### PR TITLE
fix(cli,create-app): fix add resource generating pgTable in SQLite projects

### DIFF
--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -9,7 +9,7 @@ import { makeModel } from './make-model'
 import { makeNotification } from './make-notification'
 import { makeRoute } from './make-route'
 import { makeView } from './make-view'
-import { addImport, addProvider, ensureDrizzleImports } from './patch-helpers'
+import { addImport, addProvider, ensureDrizzleImports, ensureSqliteImports } from './patch-helpers'
 import { camelCase, kebabCase, pascalCase, writeFilesSafe, type WriterOptions } from './utils'
 import { readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
@@ -872,21 +872,43 @@ export default scheduleTasksKernel
   },
 }
 
+async function detectSchemaDialect(content: string): Promise<'sqlite' | 'pg'> {
+  if (content.includes('sqliteTable') || content.includes('drizzle-orm/sqlite-core')) {
+    return 'sqlite'
+  }
+  return 'pg'
+}
+
 async function updateResourceSchema(collection: string, routeName: string): Promise<void> {
   const schemaPath = resolve(process.cwd(), 'db/schema.ts')
   let content = await readFile(schemaPath, 'utf8')
   const schemaIdentifier = camelCase(collection)
   const tableName = routeName.replaceAll('-', '_')
 
-  if (content.includes(`export const ${schemaIdentifier} = pgTable(`)) {
-    return
+  const dialect = await detectSchemaDialect(content)
+
+  if (dialect === 'sqlite') {
+    if (content.includes(`export const ${schemaIdentifier} = sqliteTable(`)) {
+      return
+    }
+
+    content = ensureSqliteImports(content, ['sqliteTable', 'integer', 'text'])
+
+    const schemaBlock = `\nexport const ${schemaIdentifier} = sqliteTable('${tableName}', {\n  id: integer('id').primaryKey({ autoIncrement: true }),\n  title: text('title').notNull(),\n  body: text('body'),\n  createdAt: text('created_at').notNull().$defaultFn(() => new Date().toISOString()),\n})\n`
+
+    content = `${content.trimEnd()}\n${schemaBlock}`
+  } else {
+    if (content.includes(`export const ${schemaIdentifier} = pgTable(`)) {
+      return
+    }
+
+    content = ensureDrizzleImports(content, ['pgTable', 'serial', 'text', 'timestamp'])
+
+    const schemaBlock = `\nexport const ${schemaIdentifier} = pgTable('${tableName}', {\n  id: serial('id').primaryKey(),\n  title: text('title').notNull(),\n  body: text('body'),\n  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),\n})\n`
+
+    content = `${content.trimEnd()}\n${schemaBlock}`
   }
 
-  content = ensureDrizzleImports(content, ['pgTable', 'serial', 'text', 'timestamp'])
-
-  const schemaBlock = `\nexport const ${schemaIdentifier} = pgTable('${tableName}', {\n  id: serial('id').primaryKey(),\n  title: text('title').notNull(),\n  body: text('body'),\n  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),\n})\n`
-
-  content = `${content.trimEnd()}\n${schemaBlock}`
   await writeFile(schemaPath, content, 'utf8')
 }
 

--- a/packages/cli/src/patch-helpers.test.ts
+++ b/packages/cli/src/patch-helpers.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { addImport, addProvider, hasImport, hasAuthProvider, ensureDrizzleImports } from './patch-helpers'
+import { addImport, addProvider, hasImport, hasAuthProvider, ensureDrizzleImports, ensureSqliteImports } from './patch-helpers'
 
 describe('patch-helpers', () => {
   let tempDir: string
@@ -210,6 +210,38 @@ const app = new Application()`
     it('should return content unchanged when needed list is empty', () => {
       const content = `const x = 1\n`
       const result = ensureDrizzleImports(content, [])
+
+      expect(result).toBe(content)
+    })
+  })
+
+  describe('ensureSqliteImports', () => {
+    it('should add missing imports when no SQLite import exists', () => {
+      const content = `const x = 1\n`
+      const result = ensureSqliteImports(content, ['sqliteTable', 'integer', 'text'])
+
+      expect(result).toContain("import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'")
+      expect(result).toContain('const x = 1')
+    })
+
+    it('should merge into existing SQLite import', () => {
+      const content = `import { sqliteTable, integer } from 'drizzle-orm/sqlite-core'\n\nexport const users = sqliteTable('users', {})\n`
+      const result = ensureSqliteImports(content, ['sqliteTable', 'integer', 'text'])
+
+      expect(result).toContain("import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'")
+      expect(result).not.toContain("import { sqliteTable, integer }")
+    })
+
+    it('should not modify content when all imports already present', () => {
+      const content = `import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'\n\nexport const users = sqliteTable('users', {})\n`
+      const result = ensureSqliteImports(content, ['sqliteTable', 'integer', 'text'])
+
+      expect(result).toBe(content)
+    })
+
+    it('should return content unchanged when needed list is empty', () => {
+      const content = `const x = 1\n`
+      const result = ensureSqliteImports(content, [])
 
       expect(result).toBe(content)
     })

--- a/packages/cli/src/patch-helpers.ts
+++ b/packages/cli/src/patch-helpers.ts
@@ -165,3 +165,27 @@ export function ensureDrizzleImports(content: string, needed: string[]): string 
 
   return `import { ${missing.sort().join(', ')} } from '@guren/orm/drizzle'\n${content}`
 }
+
+export function ensureSqliteImports(content: string, needed: string[]): string {
+  const importLines = content.split('\n').filter((line) => line.trimStart().startsWith('import '))
+  const importContent = importLines.join('\n')
+
+  const missing = needed.filter(
+    (name) => !new RegExp(`\\b${name}\\b`).test(importContent),
+  )
+
+  if (missing.length === 0) {
+    return content
+  }
+
+  const existingSqliteImport = /import\s*\{([^}]+)\}\s*from\s*['"]drizzle-orm\/sqlite-core['"]/
+  const match = content.match(existingSqliteImport)
+
+  if (match) {
+    const existingNames = match[1].split(',').map((s) => s.trim()).filter(Boolean)
+    const allNames = [...new Set([...existingNames, ...missing])].sort()
+    return content.replace(existingSqliteImport, `import { ${allNames.join(', ')} } from 'drizzle-orm/sqlite-core'`)
+  }
+
+  return `import { ${missing.sort().join(', ')} } from 'drizzle-orm/sqlite-core'\n${content}`
+}

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -231,6 +231,7 @@ const command = defineCommand({
     consola.log('')
     consola.info('Generate types and set up database:')
     consola.log('  bun run codegen')
+    consola.log('  bun run db:make')
     consola.log('  bun run db:migrate')
     consola.log('  bun run db:seed')
     consola.log('')


### PR DESCRIPTION
## Summary

- `bunx guren add resource` always inserted `pgTable` (PostgreSQL) schema into `db/schema.ts`, even when the project uses SQLite. This caused `buildExtraConfigColumn` errors at migration time.
- Added schema dialect detection (`sqliteTable` vs `pgTable`) so the correct table builder and column types are used.
- Added `ensureSqliteImports` helper in `patch-helpers.ts` for managing `drizzle-orm/sqlite-core` imports.
- Added missing `bun run db:make` step to `create-guren-app` post-scaffold instructions — without it, `db:migrate` runs with no migration files.

## Test plan

- [x] `ensureSqliteImports` unit tests added (4 cases) — all pass
- [ ] Run `create-guren-app`, then `bunx guren add resource posts`, verify `db/schema.ts` uses `sqliteTable`
- [ ] Run `bun run db:make && bun run db:migrate` — no errors
- [ ] Verify `GET /posts` returns 200