### PR TITLE
chore: version packages to 1.0.0-rc.18

### DIFF
--- a/.changeset/fix-sqlite-add-resource.md
+++ b/.changeset/fix-sqlite-add-resource.md
@@ -1,0 +1,6 @@
+---
+"@guren/cli": patch
+"create-guren-app": patch
+---
+
+fix(cli,create-app): fix `add resource` generating pgTable in SQLite projects

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -28,6 +28,7 @@
     "busy-bobcats-smell",
     "dull-tips-go",
     "fix-orm-drizzle",
+    "fix-sqlite-add-resource",
     "hot-parents-know",
     "ninety-dragons-wonder",
     "openapi-major",

--- a/examples/api/CHANGELOG.md
+++ b/examples/api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @guren/example-api
 
+## 0.1.1-rc.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @guren/cli@1.0.0-rc.15
+
 ## 0.1.1-rc.8
 
 ### Patch Changes

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/example-api",
-  "version": "0.1.1-rc.8",
+  "version": "0.1.1-rc.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guren/cli
 
+## 1.0.0-rc.15
+
+### Patch Changes
+
+- fix(cli,create-app): fix `add resource` generating pgTable in SQLite projects
+
 ## 1.0.0-rc.14
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/cli",
-  "version": "1.0.0-rc.14",
+  "version": "1.0.0-rc.15",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-guren-app
 
+## 1.0.0-rc.17
+
+### Patch Changes
+
+- fix(cli,create-app): fix `add resource` generating pgTable in SQLite projects
+
 ## 1.0.0-rc.16
 
 ### Patch Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-guren-app",
-  "version": "1.0.0-rc.16",
+  "version": "1.0.0-rc.17",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,12 @@
 # web
 
+## 0.1.1-rc.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @guren/cli@1.0.0-rc.15
+
 ## 0.1.1-rc.7
 
 ### Patch Changes

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.1-rc.7",
+  "version": "0.1.1-rc.8",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump `@guren/cli` to `1.0.0-rc.15`
- Bump `create-guren-app` to `1.0.0-rc.17`
- Changeset for fix(cli,create-app): fix `add resource` generating pgTable in SQLite projects