### PR TITLE
fix(ci): add missing APP_KEY and .env setup to nightly canary

### DIFF
--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -20,6 +20,7 @@ jobs:
           --health-retries 5
     env:
       REDIS_URL: redis://localhost:6379
+      APP_KEY: base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 
     steps:
       # ----------------------------------------------------------------
@@ -123,6 +124,7 @@ jobs:
           --health-retries 5
     env:
       DATABASE_URL: postgres://guren:guren@localhost:54322/guren
+      APP_KEY: base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 
     steps:
       - uses: actions/checkout@v6
@@ -139,8 +141,17 @@ jobs:
       - name: Generate route types
         run: bun run build:routes
 
+      - name: Build blog frontend
+        run: bun run --cwd examples/blog build
+
       - name: Install Playwright browsers
         run: cd examples/blog && bunx playwright install --with-deps chromium
+
+      - name: Set up blog .env
+        run: |
+          cp examples/blog/.env.example examples/blog/.env
+          sed -i "s/^APP_KEY=$/APP_KEY=$APP_KEY/" examples/blog/.env
+          sed -i "/^VITE_DEV_SERVER_URL=/d" examples/blog/.env
 
       - name: Run migrations and seed
         working-directory: examples/blog
@@ -149,6 +160,8 @@ jobs:
           bun ../../packages/cli/src/bin.ts db:seed --force
 
       - name: Run E2E tests
+        env:
+          NODE_ENV: production
         run: bun run --cwd examples/blog e2e
 
   web-app:


### PR DESCRIPTION
## Summary

- Add `APP_KEY` env var to `canary-validate` and `e2e` jobs — the nightly workflow was not synced with `ci.yml` after the APP_KEY infrastructure was introduced (`ea8dcac`), causing `app.boot()` to throw `APP_KEY is required and must be a base64-encoded 32-byte key` on every run
- Add blog frontend build, `.env` setup step, and `NODE_ENV=production` to the `e2e` job, mirroring the existing `ci.yml` E2E configuration

Both the benchmark and E2E jobs have been failing for 3 consecutive nights (April 2–4).

## Test plan

- [ ] Trigger the nightly canary workflow via `workflow_dispatch` and verify both `canary-validate` (benchmarks) and `e2e` jobs pass
- [ ] Confirm the workflow stays in sync with `ci.yml` E2E job steps