### PR TITLE
fix(ci): exit benchmark process to prevent nightly canary hang

### DIFF
--- a/scripts/benchmarks/run-benchmarks.ts
+++ b/scripts/benchmarks/run-benchmarks.ts
@@ -152,6 +152,7 @@ async function main() {
   }
 
   console.log('All benchmarks within thresholds.')
+  process.exit(0)
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

- The nightly canary `canary-validate` job takes ~43 minutes, but the actual work finishes in ~3 minutes
- The benchmark script (`bun run bench`) boots the blog app to measure startup/latency, which opens a DB connection pool
- Without an explicit `process.exit(0)`, the open handles keep the Bun process alive indefinitely
- The PostgreSQL service container logs `FATAL: role "root" does not exist` every 10 seconds until the job eventually times out
- Adding `process.exit(0)` after benchmarks complete fixes the hang, reducing total job time from ~43min to ~3min

## Test plan

- [ ] Trigger nightly canary via `workflow_dispatch` and verify `canary-validate` completes in ~3-5 minutes
- [ ] Verify benchmark results are still written to `benchmarks.json` before exit