### PR TITLE
feat(server): handle Inertia asset version mismatch

### DIFF
--- a/packages/server/src/http/inertia-assets.ts
+++ b/packages/server/src/http/inertia-assets.ts
@@ -6,6 +6,7 @@ import type { Application } from './Application'
 import { createStaticRewrite, registerDevAssets, type DevAssetsOptions } from './dev-assets'
 import { registerRootPublicAssets } from './public-assets'
 import { parseImportMap } from '../support/import-map'
+import { hash } from '../encryption/Hash'
 
 export interface InertiaAssetsOptions extends DevAssetsOptions {
   /** Default stylesheet entry embedded into Inertia responses. */
@@ -212,6 +213,13 @@ export function autoConfigureInertiaAssets(app: Application, options: AutoConfig
   const clientEntryFile = getManifestFile(clientEntry)
   const clientCssFiles = getManifestCss(clientEntry)
 
+  if (clientManifest?.__raw__) {
+    setEnvIfUserDidNotProvide(
+      'GUREN_INERTIA_VERSION',
+      hash(clientManifest.__raw__, 'sha1').slice(0, 12),
+    )
+  }
+
   if (clientEntryFile) {
     setEnvIfUserDidNotProvide('GUREN_INERTIA_ENTRY', `/public/assets/${clientEntryFile.replace(/^\//u, '')}`)
   }
@@ -276,6 +284,7 @@ type InertiaEnvKey =
   | 'GUREN_INERTIA_STYLES'
   | 'GUREN_INERTIA_SSR_ENTRY'
   | 'GUREN_INERTIA_SSR_MANIFEST'
+  | 'GUREN_INERTIA_VERSION'
 
 function captureInertiaEnvFlags(): Record<InertiaEnvKey, boolean> {
   return {
@@ -283,6 +292,7 @@ function captureInertiaEnvFlags(): Record<InertiaEnvKey, boolean> {
     GUREN_INERTIA_STYLES: process.env.GUREN_INERTIA_STYLES !== undefined,
     GUREN_INERTIA_SSR_ENTRY: process.env.GUREN_INERTIA_SSR_ENTRY !== undefined,
     GUREN_INERTIA_SSR_MANIFEST: process.env.GUREN_INERTIA_SSR_MANIFEST !== undefined,
+    GUREN_INERTIA_VERSION: process.env.GUREN_INERTIA_VERSION !== undefined,
   }
 }
 
@@ -331,7 +341,7 @@ type ViteManifestEntryObject = {
 
 type ViteManifestValue = ViteManifestEntryObject | string[]
 
-type ViteManifest = Record<string, ViteManifestValue> & { __path__?: string }
+type ViteManifest = Record<string, ViteManifestValue> & { __path__?: string; __raw__?: string }
 
 function loadViteManifest(candidatePaths: string[], label: 'client' | 'SSR'): ViteManifest | undefined {
   const command = label === 'SSR' ? 'bunx vite build --ssr' : 'bunx vite build'
@@ -342,6 +352,10 @@ function loadViteManifest(candidatePaths: string[], label: 'client' | 'SSR'): Vi
       const manifest = JSON.parse(raw) as ViteManifest
       Object.defineProperty(manifest, '__path__', {
         value: manifestPath,
+        enumerable: false,
+      })
+      Object.defineProperty(manifest, '__raw__', {
+        value: raw,
         enumerable: false,
       })
       return manifest

--- a/packages/server/src/mvc/inertia/InertiaEngine.ts
+++ b/packages/server/src/mvc/inertia/InertiaEngine.ts
@@ -63,16 +63,40 @@ export async function inertia(
   props: Record<string, unknown>,
   options: InertiaOptions = {}
 ): Promise<Response> {
+  const resolvedVersion =
+    options.version ?? process.env.GUREN_INERTIA_VERSION ?? undefined;
+
   const page: InertiaPagePayload = {
     component,
     props,
     url: options.url ?? "",
-    version: options.version,
+    version: resolvedVersion,
   };
 
   const request = options.request;
   const isInertiaVisit = Boolean(request?.headers.get("X-Inertia"));
   const prefersJson = request ? acceptsJson(request) : false;
+  const versionHeader: Record<string, string> = resolvedVersion
+    ? { "X-Inertia-Version": resolvedVersion }
+    : {};
+
+  if (
+    request &&
+    resolvedVersion &&
+    isInertiaVisit &&
+    request.method === "GET"
+  ) {
+    const clientVersion = request.headers.get("X-Inertia-Version");
+    if (clientVersion !== resolvedVersion) {
+      return new Response(null, {
+        status: 409,
+        headers: {
+          "X-Inertia-Location": options.url ?? request.url,
+          Vary: "Accept",
+        },
+      });
+    }
+  }
 
   if (isInertiaVisit || prefersJson) {
     return new Response(serializePage(page), {
@@ -81,7 +105,7 @@ export async function inertia(
         "Content-Type": "application/json; charset=utf-8",
         "X-Inertia": "true",
         Vary: "Accept",
-        ...(options.version ? { "X-Inertia-Version": options.version } : {}),
+        ...versionHeader,
         ...options.headers,
       },
     });
@@ -95,7 +119,7 @@ export async function inertia(
       "Content-Type": "text/html; charset=utf-8",
       "X-Inertia": "true",
       Vary: "Accept",
-      ...(options.version ? { "X-Inertia-Version": options.version } : {}),
+      ...versionHeader,
       ...options.headers,
     },
   });

--- a/packages/server/tests/mvc/InertiaEngine.test.ts
+++ b/packages/server/tests/mvc/InertiaEngine.test.ts
@@ -51,3 +51,124 @@ describe('InertiaEngine SSR integration', () => {
     expect(body).toContain('SSR')
   })
 })
+
+describe('Inertia asset version mismatch', () => {
+  const buildInertiaRequest = (
+    overrides: { method?: string; version?: string | null } = {},
+  ): Request =>
+    new Request('http://localhost/dashboard', {
+      method: overrides.method ?? 'GET',
+      headers: {
+        'X-Inertia': 'true',
+        ...(overrides.version === null
+          ? {}
+          : { 'X-Inertia-Version': overrides.version ?? 'v1' }),
+      },
+    })
+
+  it('returns 200 when client version matches', async () => {
+    const response = await inertia(
+      'Dashboard',
+      {},
+      {
+        url: '/dashboard',
+        version: 'v1',
+        request: buildInertiaRequest({ version: 'v1' }),
+      },
+    )
+    expect(response.status).toBe(200)
+    expect(response.headers.get('X-Inertia-Version')).toBe('v1')
+  })
+
+  it('returns 409 with X-Inertia-Location when GET version mismatches', async () => {
+    const response = await inertia(
+      'Dashboard',
+      {},
+      {
+        url: '/dashboard',
+        version: 'v1',
+        request: buildInertiaRequest({ version: 'v0' }),
+      },
+    )
+    expect(response.status).toBe(409)
+    expect(response.headers.get('X-Inertia-Location')).toBe('/dashboard')
+  })
+
+  it('falls back to request.url for X-Inertia-Location when options.url is absent', async () => {
+    const response = await inertia(
+      'Dashboard',
+      {},
+      {
+        version: 'v1',
+        request: buildInertiaRequest({ version: 'v0' }),
+      },
+    )
+    expect(response.status).toBe(409)
+    expect(response.headers.get('X-Inertia-Location')).toBe('http://localhost/dashboard')
+  })
+
+  it('returns 409 when client omits X-Inertia-Version', async () => {
+    const response = await inertia(
+      'Dashboard',
+      {},
+      {
+        version: 'v1',
+        request: buildInertiaRequest({ version: null }),
+      },
+    )
+    expect(response.status).toBe(409)
+  })
+
+  it('does not return 409 for non-GET requests', async () => {
+    const response = await inertia(
+      'Dashboard',
+      {},
+      {
+        version: 'v1',
+        request: buildInertiaRequest({ method: 'POST', version: 'v0' }),
+      },
+    )
+    expect(response.status).not.toBe(409)
+  })
+
+  it('does not return 409 for non-Inertia requests', async () => {
+    const request = new Request('http://localhost/dashboard', {
+      method: 'GET',
+      headers: { 'X-Inertia-Version': 'v0' },
+    })
+    const response = await inertia('Dashboard', {}, { version: 'v1', request })
+    expect(response.status).not.toBe(409)
+  })
+
+  it('skips version check when no version is configured', async () => {
+    const response = await inertia(
+      'Dashboard',
+      {},
+      {
+        request: buildInertiaRequest({ version: 'v0' }),
+      },
+    )
+    expect(response.status).toBe(200)
+  })
+
+  it('reads GUREN_INERTIA_VERSION as fallback', async () => {
+    const original = process.env.GUREN_INERTIA_VERSION
+    process.env.GUREN_INERTIA_VERSION = 'env-v1'
+    try {
+      const response = await inertia(
+        'Dashboard',
+        {},
+        {
+          request: buildInertiaRequest({ version: 'env-v0' }),
+        },
+      )
+      expect(response.status).toBe(409)
+    } finally {
+      if (original === undefined) {
+        delete process.env.GUREN_INERTIA_VERSION
+      } else {
+        process.env.GUREN_INERTIA_VERSION = original
+      }
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Implement the Inertia.js protocol requirement to return **409 Conflict + `X-Inertia-Location`** when a GET visit's `X-Inertia-Version` does not match the server's configured version — previously the engine only set the outbound version header and never validated the inbound one, so stale clients would silently continue against new bundles.
- Auto-derive the version in production from a sha1 of the Vite client manifest (12-char hex via the existing `hash()` helper) and expose it as `GUREN_INERTIA_VERSION`. The engine reads `options.version` first with the env var as fallback. Dev mode is skipped to avoid spurious 409s during HMR.
- Prefer `options.url` over `request.url` for `X-Inertia-Location` so reverse-proxied deployments don't redirect clients to internal origins.

## Files
- `packages/server/src/mvc/inertia/InertiaEngine.ts` — 409 early-return for Inertia GET version mismatch; outbound `X-Inertia-Version` header derived once from `resolvedVersion`.
- `packages/server/src/http/inertia-assets.ts` — `loadViteManifest` stashes the raw text on the manifest as `__raw__`; `autoConfigureInertiaAssets` hashes that to set `GUREN_INERTIA_VERSION` (no duplicate read). Adds the env key to `InertiaEnvKey` / `captureInertiaEnvFlags`.
- `packages/server/tests/mvc/InertiaEngine.test.ts` — 8 cases covering match / mismatch / missing client header / non-GET / non-Inertia / unconfigured / env fallback / `options.url` vs `request.url` for the location header.

## Test plan
- [x] `cd packages/server && bun test tests/mvc/InertiaEngine.test.ts` — 12 pass / 0 fail
- [x] `cd packages/server && bun test` — 1524 pass / 45 skip / 0 fail
- [x] `bun run typecheck` — clean
- [ ] Manual smoke (optional): production-build `examples/blog`, send Inertia visit with stale `X-Inertia-Version` and confirm 409 + `X-Inertia-Location`.