### PR TITLE
feat: secure-by-default authorization and AI-agent security harness

### DIFF
--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -23,11 +23,19 @@ When given a feature name (e.g., "Post", "Product"):
 bunx guren make:feature <Name> --fields "title:string,body:text,published:boolean"
 ```
 
+Useful flags:
+- `--policy` — also generate an authorization policy and enforce it in `store`/`update`
+- `--public` — skip authentication checks in mutating actions (auth is required by default)
+- `--test` — also generate a test file
+
 This generates Validator, Resource, Controller, Views (Index/Show/New/Edit), and Model in one step with:
 - Typed page props (no `any`)
 - `route()` helper for all URLs
 - `ApiRoutes` for form data types
 - `RouteErrors` for validation error types
+- `this.auth.userOrFail()` in `store`/`update` (secure by default)
+
+After wiring routes and codegen, run `bunx guren audit` to verify validation/authentication coverage.
 
 **Or generate individually:**
 

--- a/.claude/skills/guren-api/SKILL.md
+++ b/.claude/skills/guren-api/SKILL.md
@@ -205,9 +205,16 @@ Additional auth features:
 ### Authorization (Gate & Policy)
 Source: `packages/server/src/authorization/`
 
-- `Gate.ts` — Define abilities and policies
-- `Policy.ts` — Resource-based authorization
+- `Gate.ts` — Define abilities and policies. The global gate is auto-wired at boot; access via `getGate()`
+- `Policy.ts` — Resource-based authorization. Scaffold with `bunx guren make:policy <Model>`
 - `middleware.ts` — Route-level authorization middleware
+
+Key patterns:
+- Register: `getGate().policy(Post, PostPolicy)` in `src/app.ts` boot callback
+- ORM records are plain objects — pass the model class as a tuple: `await this.authorize('update', [Post, post])`
+- Record-less abilities take the bare class: `await this.authorize('create', Post)`
+- Controllers have `this.authorize(ability, subject)` (throws 403) and `this.can(ability, subject)` (boolean)
+- Full guide: `docs/en/guides/authorization.md`
 
 ### Events & Listeners
 Source: `packages/server/src/events/`

--- a/.claude/skills/scaffold/SKILL.md
+++ b/.claude/skills/scaffold/SKILL.md
@@ -18,6 +18,7 @@ bunx guren make:controller <Name>
 bunx guren make:model <Name>
 bunx guren make:view <path>
 bunx guren make:middleware <Name>
+bunx guren make:policy <Name>
 bunx guren make:job <Name>
 bunx guren make:event <Name>
 bunx guren make:listener <Name> --event=<EventName>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Docs audit
         run: bun run audit:docs
 
+      - name: Security audit (blog example)
+        run: cd examples/blog && bun ../../packages/cli/src/bin.ts audit
+
       - name: Build example apps
         run: |
           bun run --cwd examples/blog build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,13 +85,18 @@ bunx guren model:list --format json  # Models as JSON
 # Integrity checking
 bunx guren check                # Validate route↔controller↔page consistency
 bunx guren check --json         # Check results as JSON
+bunx guren audit                # Security audit: validation/auth on mutating routes, raw SQL, secrets, mass assignment
+bunx guren audit --json         # Audit results as JSON (exits non-zero on failures)
 bunx guren doctor --next        # Doctor report + actionable next steps
 
 # Code generation
 bunx guren guidelines           # Auto-generate project-specific coding guidelines
 bunx guren guidelines -o .claude/rules/project-guidelines.md  # Write to file
-bunx guren make:feature Post --fields "title:string,body:text,published:boolean"  # CRUD scaffold
+bunx guren make:feature Post --fields "title:string,body:text,published:boolean"  # CRUD scaffold (store/update require auth by default)
 bunx guren make:feature Post --fields "title:string,body:text" --test  # With test file
+bunx guren make:feature Post --fields "title:string" --public  # Skip auth checks in mutating actions
+bunx guren make:feature Post --fields "title:string" --policy  # Also generate a policy and enforce it in store/update
+bunx guren make:policy Post     # Authorization policy scaffold (app/Policies)
 ```
 
 ## Coding Conventions
@@ -323,6 +328,7 @@ export const handler = createLambdaHandler(app)
 | `packages/cli/src/bin.ts` | CLI entry point |
 | `packages/cli/src/context.ts` | AI agent: project context map generation |
 | `packages/cli/src/check.ts` | AI agent: integrity checking |
+| `packages/cli/src/audit.ts` | AI agent: security audit (validation, auth, raw SQL, secrets) |
 | `packages/cli/src/guidelines.ts` | AI agent: dynamic guidelines generation |
 | `packages/cli/src/model-list.ts` | AI agent: model introspection |
 | `packages/cli/src/model-parser.ts` | AI agent: Babel AST model parsing |

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ bunx guren add broadcasting    # Real-time (SSE)
 bunx guren add schedule        # Cron scheduling
 ```
 
-Run `bun run codegen` after adding features to regenerate types.
+Run `bun run codegen` after adding features to regenerate types. When you are ready to ship, `bun run build` creates the production build.
 
 ---
 
@@ -57,7 +57,7 @@ Run `bun run codegen` after adding features to regenerate types.
 - **Drizzle ORM** — swap database backends through an adapter (PostgreSQL / SQLite)
 - **End-to-end type safety** — `bunx guren codegen` generates types from schema to frontend props
 - **Batteries included** — auth, queues, mail, cache, notifications, storage, broadcasting, scheduling
-- **AWS Lambda ready** — deploy serverless via `@guren/server/lambda`
+- **AWS Lambda ready** — deploy serverless via `@guren/core/lambda`
 
 ---
 

--- a/docs/en/guides/authorization.md
+++ b/docs/en/guides/authorization.md
@@ -1,6 +1,8 @@
 # Authorization
 
-Authorization determines what an authenticated user is allowed to do. Guren provides a powerful policy-based authorization system inspired by Laravel.
+Authorization determines what an authenticated user is allowed to do. Guren provides a policy-based authorization system inspired by Laravel.
+
+The authorization gate is created automatically when your app boots — call `getGate()` anywhere after boot to define abilities and register policies. No manual setup is required.
 
 ## Gates
 
@@ -8,47 +10,51 @@ Gates are simple closures that determine if a user is authorized to perform a gi
 
 ### Defining Gates
 
-Define gates using the `Gate` class:
+Define gates in `src/app.ts` (inside the boot callback) or a service provider:
 
 ```typescript
-import { Gate } from '@guren/core'
+import { getGate } from '@guren/core'
+
+const gate = getGate()
 
 // Simple gate
-Gate.define('view-dashboard', (user) => {
-  return user.isAdmin
+gate.define('view-dashboard', (user) => {
+  return user?.isAdmin === true
 })
 
 // Gate with a resource
-Gate.define('update-post', (user, post) => {
-  return user.id === post.userId
+gate.define('update-post', (user, post) => {
+  return user?.id === post.userId
 })
 
 // Async gate with database check
-Gate.define('delete-comment', async (user, comment) => {
+gate.define('delete-comment', async (user, comment) => {
   const post = await Post.find(comment.postId)
-  return user.id === post?.userId
+  return user?.id === post?.userId
 })
 ```
 
 ### Using Gates
 
-Check authorization using gate methods:
+Check authorization with a user bound via `forUser()`:
 
 ```typescript
-import { Gate } from '@guren/core'
+import { getGate } from '@guren/core'
+
+const gate = getGate().forUser(user)
 
 // Check if allowed
-const canView = await Gate.allows('view-dashboard', user)
+const canView = await gate.allows('view-dashboard')
 
 // Check if denied
-const cannotView = await Gate.denies('view-dashboard', user)
+const cannotView = await gate.denies('view-dashboard')
 
 // With a resource
-const canUpdate = await Gate.allows('update-post', user, post)
+const canUpdate = await gate.allows('update-post', post)
 
 // Authorize or throw
-await Gate.authorize('update-post', user, post)
-// Throws AuthorizationException if denied
+await gate.authorize('update-post', post)
+// Throws AuthorizationException (403) if denied
 ```
 
 ### Before Callbacks
@@ -56,9 +62,9 @@ await Gate.authorize('update-post', user, post)
 Register a callback that runs before all gate checks:
 
 ```typescript
-Gate.before((user, ability) => {
+getGate().before((user, ability) => {
   // Super admins can do everything
-  if (user.isSuperAdmin) {
+  if (user?.isSuperAdmin) {
     return true
   }
   // Return undefined to continue to the gate
@@ -70,9 +76,9 @@ Gate.before((user, ability) => {
 Register a callback that runs after all gate checks:
 
 ```typescript
-Gate.after((user, ability, result) => {
+getGate().after((user, ability, result) => {
   // Log authorization attempts
-  logger.info(`User ${user.id} ${result ? 'allowed' : 'denied'} for ${ability}`)
+  logger.info(`User ${user?.id} ${result ? 'allowed' : 'denied'} for ${ability}`)
 })
 ```
 
@@ -82,90 +88,99 @@ Policies organize authorization logic around a particular model or resource.
 
 ### Creating Policies
 
-```typescript
-import { Policy } from '@guren/core'
-import type { User } from '../Models/User'
-import type { Post } from '../Models/Post'
+Scaffold a policy with the CLI:
 
-export class PostPolicy extends Policy<User, Post> {
+```bash
+bunx guren make:policy Post
+```
+
+Or write one by hand:
+
+```typescript
+import { Policy, type AuthUser } from '@guren/core'
+import type { PostRecord } from '../Models/Post'
+
+export class PostPolicy extends Policy {
   /**
    * Determine if the user can view any posts.
    */
-  viewAny(user: User): boolean {
+  viewAny(user: AuthUser | null): boolean {
     return true
   }
 
   /**
    * Determine if the user can view the post.
    */
-  view(user: User, post: Post): boolean {
-    return post.published || user.id === post.userId
+  view(user: AuthUser | null, post: PostRecord): boolean {
+    return post.published || user?.id === post.userId
   }
 
   /**
    * Determine if the user can create posts.
    */
-  create(user: User): boolean {
-    return user.verified
+  create(user: AuthUser | null): boolean {
+    return user !== null
   }
 
   /**
    * Determine if the user can update the post.
    */
-  update(user: User, post: Post): boolean {
-    return user.id === post.userId
+  update(user: AuthUser | null, post: PostRecord): boolean {
+    return user?.id === post.userId
   }
 
   /**
    * Determine if the user can delete the post.
    */
-  delete(user: User, post: Post): boolean {
-    return user.id === post.userId
-  }
-
-  /**
-   * Determine if the user can restore the post.
-   */
-  restore(user: User, post: Post): boolean {
-    return user.id === post.userId
-  }
-
-  /**
-   * Determine if the user can permanently delete the post.
-   */
-  forceDelete(user: User, post: Post): boolean {
-    return user.isAdmin
+  delete(user: AuthUser | null, post: PostRecord): boolean {
+    return user?.id === post.userId
   }
 }
 ```
 
 ### Registering Policies
 
-Register policies with the Gate class:
+Register policies on the gate in `src/app.ts` (inside the boot callback) or a service provider:
 
 ```typescript
-import { Gate } from '@guren/core'
-import { PostPolicy } from './Policies/PostPolicy'
-import { Post } from './Models/Post'
+import { getGate } from '@guren/core'
+import { PostPolicy } from '../app/Policies/PostPolicy'
+import { Post } from '../app/Models/Post'
 
 // Register by model class
-Gate.policy(Post, new PostPolicy())
+getGate().policy(Post, PostPolicy)
 
 // Or by string key
-Gate.policy('post', new PostPolicy())
+getGate().policy('post', PostPolicy)
 ```
 
 ### Using Policies
 
+ORM queries return plain records without constructor information, so pass the model class alongside the record to resolve the policy:
+
 ```typescript
-// Check policy via Gate
-const canUpdate = await Gate.allows('update', user, post)
+import { getGate } from '@guren/core'
 
-// Or use forUser for chainable checks
-const canDelete = await Gate.forUser(user).allows('delete', post)
+const gate = getGate().forUser(user)
+const post = await Post.findOrFail(id)
 
-// Authorize with exception
-await Gate.forUser(user).authorize('update', post)
+// Pass [ModelClass, record] for ORM records
+const canUpdate = await gate.allows('update', [Post, post])
+
+// Abilities without a record take the bare class
+const canCreate = await gate.allows('create', Post)
+
+// String keys work the same way
+const canDelete = await gate.allows('delete', ['post', post])
+
+// Authorize with exception (throws AuthorizationException, 403)
+await gate.authorize('update', [Post, post])
+```
+
+Class instances (objects created with `new`) resolve their policy automatically without the tuple:
+
+```typescript
+const canView = await gate.allows('view', somePostInstance)
 ```
 
 ### Policy Methods
@@ -187,10 +202,10 @@ Policies support these standard methods:
 Add a `before` method to intercept all policy checks:
 
 ```typescript
-export class PostPolicy extends Policy<User, Post> {
-  before(user: User, ability: string): boolean | undefined {
+export class PostPolicy extends Policy {
+  before(user: AuthUser | null, ability: string): boolean | undefined {
     // Admins can do anything with posts
-    if (user.isAdmin) {
+    if (user !== null && (user as { isAdmin?: boolean }).isAdmin) {
       return true
     }
     // Return undefined to continue to specific method
@@ -200,28 +215,31 @@ export class PostPolicy extends Policy<User, Post> {
 
 ## Controller Integration
 
-Use authorization in controllers:
+Controllers ship with `authorize()` and `can()` helpers. They resolve the current user from the auth context automatically (guests are `null`):
 
 ```typescript
-import { Controller, Gate } from '@guren/core'
-import { PostResource } from '@/app/Http/Resources/PostResource'
+import { Controller } from '@guren/core'
 import { pages } from '@/.guren/pages.gen'
+import { Post } from '@/app/Models/Post'
+import { PostResource } from '@/app/Http/Resources/PostResource'
 
 export default class PostController extends Controller {
-  async show(id: number) {
-    const post = await Post.find(id)
+  async show() {
+    const { id } = this.validateParams(PostIdParamSchema)
+    const post = await Post.findOrFail(id)
 
-    // Authorize using Gate
-    await Gate.authorize('view', this.user(), post)
+    // Throws AuthorizationException (403) when denied
+    await this.authorize('view', [Post, post])
 
     return this.inertia(pages.posts.Show, { post: new PostResource(post).toJSON() })
   }
 
-  async update(id: number) {
-    const post = await Post.find(id)
+  async update() {
+    const { id } = this.validateParams(PostIdParamSchema)
+    const post = await Post.findOrFail(id)
 
-    // Check permission manually
-    if (await Gate.denies('update', this.user(), post)) {
+    // Check without throwing
+    if (!(await this.can('update', [Post, post]))) {
       return this.json({ error: 'Unauthorized' }, 403)
     }
 
@@ -230,28 +248,30 @@ export default class PostController extends Controller {
 }
 ```
 
+> **Tip:** `bunx guren make:feature Post --policy` scaffolds the policy and wires `authorize()` calls into `store`/`update` for you.
+
 ## Middleware
 
 Create authorization middleware for route-level checks:
 
 ```typescript
-import { Router, Gate, AuthorizationException } from '@guren/core'
+import { type Router, getGate, AuthorizationException, defineMiddleware } from '@guren/core'
 
-export function authorize(ability: string) {
-  return async (ctx, next) => {
-    const user = ctx.get('user')
+export function authorizeAbility(ability: string) {
+  return defineMiddleware(async (ctx, next) => {
+    const user = ctx.get('user') ?? null
 
-    if (!user || await Gate.denies(ability, user)) {
+    if (await getGate().forUser(user).denies(ability)) {
       throw new AuthorizationException()
     }
 
-    return next()
-  }
+    await next()
+  })
 }
 
 // Usage in routes
 export function registerWebRoutes(router: Router): void {
-  router.get('/admin', [AdminController, 'index']).middleware(authorize('access-admin'))
+  router.get('/admin', [AdminController, 'index'], authorizeAbility('access-admin'))
 }
 ```
 
@@ -265,28 +285,33 @@ export function registerWebRoutes(router: Router): void {
 
 ## Testing Authorization
 
+Instantiate a fresh `Gate` per test instead of relying on the global instance:
+
 ```typescript
 import { describe, it, expect, beforeEach } from 'bun:test'
 import { Gate } from '@guren/core'
+import { PostPolicy } from '../app/Policies/PostPolicy'
 
 describe('PostPolicy', () => {
+  let gate: Gate
+
   beforeEach(() => {
-    Gate.clear()
-    Gate.policy('post', new PostPolicy())
+    gate = new Gate()
+    gate.policy('post', PostPolicy)
   })
 
   it('allows owner to update post', async () => {
     const user = { id: 1 }
     const post = { id: 1, userId: 1 }
 
-    expect(await Gate.allows('update', user, post)).toBe(true)
+    expect(await gate.forUser(user).allows('update', ['post', post])).toBe(true)
   })
 
   it('denies non-owner from updating post', async () => {
     const user = { id: 2 }
     const post = { id: 1, userId: 1 }
 
-    expect(await Gate.denies('update', user, post)).toBe(true)
+    expect(await gate.forUser(user).denies('update', ['post', post])).toBe(true)
   })
 })
 ```

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -60,6 +60,7 @@ These commands patch `src/app.ts`, create the matching provider/runtime files, a
 | `make:view <path>` | Generates a React component in `resources/js/pages` | `bunx guren make:view posts/Index` |
 | `make:auth` | Scaffolds login/logout controllers, provider, views, migration, seeder, and routes | `bunx guren make:auth` |
 | `make:middleware <Name>` | Generates a middleware file in `app/Http/Middleware` | `bunx guren make:middleware Auth` |
+| `make:policy <Name>` | Generates an authorization policy in `app/Policies` with owner-based defaults | `bunx guren make:policy Post` |
 | `make:seeder <Name>` | Generates a database seeder file | `bunx guren make:seeder UserSeeder` |
 | `make:job <Name>` | Generates a queueable job class | `bunx guren make:job SendEmail` |
 | `make:event <Name>` | Generates an event class | `bunx guren make:event UserRegistered` |
@@ -68,6 +69,31 @@ These commands patch `src/app.ts`, create the matching provider/runtime files, a
 | `make:mail <Name>` | Generates a mailable class | `bunx guren make:mail WelcomeEmail` |
 
 > **Note:** `make:*` commands avoid overwriting existing files. Use `--force` if you need to replace them.
+
+## Inspection & Audit Commands
+
+Validate your app before shipping — these commands are also designed for AI coding agents (add `--json` for machine-readable output):
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `check` | Validate integrity across routes, controllers, pages, and models | `bunx guren check --json` |
+| `audit` | Security audit: missing input validation or authentication on mutating routes, raw SQL with interpolation, hardcoded credentials, disabled security defaults, mass-assignment configuration | `bunx guren audit --json` |
+| `doctor` | Project health report (env, config, generated files) with actionable next steps | `bunx guren doctor --next` |
+
+`audit` exits with a non-zero status when it finds failures, so you can run it in CI:
+
+```bash
+bunx guren audit
+```
+
+Routes wrapped in named middleware (for example `router.middleware('auth').group(...)`) are recognized as protected. Guest flows such as `/login` and `/register` are excluded from authentication checks.
+
+Suppress a false positive by placing `// guren-audit-ignore` on the flagged line or the line above it:
+
+```ts
+// guren-audit-ignore -- documented example value
+const apiKey = 'example-not-a-real-key'
+```
 
 ## Deployment Recipes
 

--- a/docs/en/guides/deploy-production.md
+++ b/docs/en/guides/deploy-production.md
@@ -183,6 +183,7 @@ docker compose -f docker-compose.production.yml logs app --tail 50
 Once your app is deployed and running, consider these additional steps:
 
 - **Reverse proxy** — place Nginx or Caddy in front of Bun for TLS termination and static asset serving
+- **HSTS** — `Strict-Transport-Security: max-age=31536000` is sent automatically when `NODE_ENV=production`. Add `includeSubDomains`/`preload` via `securityHeaders: { hsts: { ... } }` in `createApp`, or disable with `hsts: false` if you serve plain HTTP internally
 - **Process monitoring** — use `restart: unless-stopped` in Docker or a process manager like systemd
 - **Logging** — configure structured logging and ship logs to a centralized service
 - **Backups** — schedule regular Postgres backups with `pg_dump` or a managed database service

--- a/docs/en/guides/rate-limiting.md
+++ b/docs/en/guides/rate-limiting.md
@@ -83,8 +83,24 @@ interface RateLimitOptions {
 
   /** Prefix for rate limit keys (default: 'rl:') */
   keyPrefix?: string
+
+  /** Trust proxy headers (CF-Connecting-IP, True-Client-IP, X-Real-IP, X-Forwarded-For) for client IPs (default: false) */
+  trustProxy?: boolean
 }
 ```
+
+### Deployments Behind a Proxy
+
+When your app always sits behind a reverse proxy or CDN (Cloudflare, ALB, Nginx), enable `trustProxy` for per-client limiting without writing a custom `keyGenerator`:
+
+```ts
+createRateLimitMiddleware({
+  limit: 100,
+  trustProxy: true, // resolves CF-Connecting-IP → True-Client-IP → X-Real-IP → X-Forwarded-For[0]
+})
+```
+
+> **Warning:** Enable `trustProxy` only when every request passes through your proxy. On direct deployments clients can spoof these headers to bypass per-client limits — that is why it defaults to `false`.
 
 ### Full Configuration Example
 

--- a/docs/ja/guides/authorization.md
+++ b/docs/ja/guides/authorization.md
@@ -2,291 +2,316 @@
 
 認可は、認証済みユーザーが実行できる操作を制御する仕組みです。Guren は Laravel に着想を得たポリシーベースの認可システムを提供しています。
 
+認可ゲートはアプリの起動時に自動的に作成されます。起動後はどこからでも `getGate()` を呼び出してアビリティの定義やポリシーの登録ができます。手動のセットアップは不要です。
+
 ## ゲート
 
 ゲートは、ユーザーが特定のアクションを実行することを許可されているかどうかを判断するシンプルなクロージャです。
 
 ### ゲートの定義
 
-`Gate`クラスを使用してゲートを定義します。
+`src/app.ts`(boot コールバック内)またはサービスプロバイダでゲートを定義します:
 
 ```typescript
-import { Gate } from '@guren/core'
+import { getGate } from '@guren/core'
+
+const gate = getGate()
 
 // シンプルなゲート
-Gate.define('view-dashboard', (user) => {
-  return user.isAdmin
+gate.define('view-dashboard', (user) => {
+  return user?.isAdmin === true
 })
 
-// リソース付きゲート
-Gate.define('update-post', (user, post) => {
-  return user.id === post.userId
+// リソースを伴うゲート
+gate.define('update-post', (user, post) => {
+  return user?.id === post.userId
 })
 
-// データベースチェック付き非同期ゲート
-Gate.define('delete-comment', async (user, comment) => {
+// データベースチェックを伴う非同期ゲート
+gate.define('delete-comment', async (user, comment) => {
   const post = await Post.find(comment.postId)
-  return user.id === post?.userId
+  return user?.id === post?.userId
 })
 ```
 
 ### ゲートの使用
 
-ゲートメソッドを使用して認可をチェックします。
+`forUser()` でユーザーを束縛してから認可をチェックします:
 
 ```typescript
-import { Gate } from '@guren/core'
+import { getGate } from '@guren/core'
 
-// 許可されているかチェック
-const canView = await Gate.allows('view-dashboard', user)
+const gate = getGate().forUser(user)
 
-// 拒否されているかチェック
-const cannotView = await Gate.denies('view-dashboard', user)
+// 許可されているか
+const canView = await gate.allows('view-dashboard')
 
-// リソース付き
-const canUpdate = await Gate.allows('update-post', user, post)
+// 拒否されているか
+const cannotView = await gate.denies('view-dashboard')
 
-// 認可を確認し、拒否された場合は例外をスロー
-await Gate.authorize('update-post', user, post)
-// 拒否された場合 AuthorizationException をスロー
+// リソースを伴うチェック
+const canUpdate = await gate.allows('update-post', post)
+
+// 認可するか例外を投げる
+await gate.authorize('update-post', post)
+// 拒否時は AuthorizationException (403) をスロー
 ```
 
 ### Beforeコールバック
 
-すべてのゲートチェックの前に実行されるコールバックを登録します。
+すべてのゲートチェックの前に実行されるコールバックを登録します:
 
 ```typescript
-Gate.before((user, ability) => {
-  // スーパー管理者は全て実行可能
-  if (user.isSuperAdmin) {
+getGate().before((user, ability) => {
+  // スーパー管理者はすべての操作が可能
+  if (user?.isSuperAdmin) {
     return true
   }
-  // undefined を返すと通常のゲート判定に進みます
+  // undefined を返すとゲートのチェックに進む
 })
 ```
 
 ### Afterコールバック
 
-すべてのゲートチェックの後に実行されるコールバックを登録します。
+すべてのゲートチェックの後に実行されるコールバックを登録します:
 
 ```typescript
-Gate.after((user, ability, result) => {
+getGate().after((user, ability, result) => {
   // 認可の試行をログに記録
-  logger.info(`ユーザー ${user.id} は ${ability} を ${result ? '許可' : '拒否'} されました`)
+  logger.info(`User ${user?.id} ${result ? 'allowed' : 'denied'} for ${ability}`)
 })
 ```
 
 ## ポリシー
 
-ポリシーは特定のモデルまたはリソースに関する認可ロジックを整理します。
+ポリシーは、特定のモデルやリソースを軸に認可ロジックを整理する仕組みです。
 
 ### ポリシーの作成
 
-```typescript
-import { Policy } from '@guren/core'
-import type { User } from '../Models/User'
-import type { Post } from '../Models/Post'
+CLI でポリシーをスキャフォールドできます:
 
-export class PostPolicy extends Policy<User, Post> {
+```bash
+bunx guren make:policy Post
+```
+
+手書きする場合:
+
+```typescript
+import { Policy, type AuthUser } from '@guren/core'
+import type { PostRecord } from '../Models/Post'
+
+export class PostPolicy extends Policy {
   /**
-   * ユーザーが投稿を閲覧できるかどうかを判断します。
+   * すべての投稿を閲覧できるか
    */
-  viewAny(user: User): boolean {
+  viewAny(user: AuthUser | null): boolean {
     return true
   }
 
   /**
-   * ユーザーが投稿を閲覧できるかどうかを判断します。
+   * この投稿を閲覧できるか
    */
-  view(user: User, post: Post): boolean {
-    return post.published || user.id === post.userId
+  view(user: AuthUser | null, post: PostRecord): boolean {
+    return post.published || user?.id === post.userId
   }
 
   /**
-   * ユーザーが投稿を作成できるかどうかを判断します。
+   * 投稿を作成できるか
    */
-  create(user: User): boolean {
-    return user.verified
+  create(user: AuthUser | null): boolean {
+    return user !== null
   }
 
   /**
-   * ユーザーが投稿を更新できるかどうかを判断します。
+   * この投稿を更新できるか
    */
-  update(user: User, post: Post): boolean {
-    return user.id === post.userId
+  update(user: AuthUser | null, post: PostRecord): boolean {
+    return user?.id === post.userId
   }
 
   /**
-   * ユーザーが投稿を削除できるかどうかを判断します。
+   * この投稿を削除できるか
    */
-  delete(user: User, post: Post): boolean {
-    return user.id === post.userId
-  }
-
-  /**
-   * ユーザーが投稿を復元できるかどうかを判断します。
-   */
-  restore(user: User, post: Post): boolean {
-    return user.id === post.userId
-  }
-
-  /**
-   * ユーザーが投稿を完全に削除できるかどうかを判断します。
-   */
-  forceDelete(user: User, post: Post): boolean {
-    return user.isAdmin
+  delete(user: AuthUser | null, post: PostRecord): boolean {
+    return user?.id === post.userId
   }
 }
 ```
 
 ### ポリシーの登録
 
-Gateクラスにポリシーを登録します。
+`src/app.ts`(boot コールバック内)またはサービスプロバイダでゲートにポリシーを登録します:
 
 ```typescript
-import { Gate } from '@guren/core'
-import { PostPolicy } from './Policies/PostPolicy'
-import { Post } from './Models/Post'
+import { getGate } from '@guren/core'
+import { PostPolicy } from '../app/Policies/PostPolicy'
+import { Post } from '../app/Models/Post'
 
 // モデルクラスで登録
-Gate.policy(Post, new PostPolicy())
+getGate().policy(Post, PostPolicy)
 
-// または文字列キーで登録
-Gate.policy('post', new PostPolicy())
+// 文字列キーでも登録可能
+getGate().policy('post', PostPolicy)
 ```
 
 ### ポリシーの使用
 
+ORM のクエリはコンストラクタ情報を持たない平オブジェクトを返すため、ポリシーを解決するにはモデルクラスをレコードと一緒に渡します:
+
 ```typescript
-// Gate経由でポリシーをチェック
-const canUpdate = await Gate.allows('update', user, post)
+import { getGate } from '@guren/core'
 
-// またはforUserでチェーン可能なチェック
-const canDelete = await Gate.forUser(user).allows('delete', post)
+const gate = getGate().forUser(user)
+const post = await Post.findOrFail(id)
 
-// 例外付き認可
-await Gate.forUser(user).authorize('update', post)
+// ORM レコードには [モデルクラス, レコード] を渡す
+const canUpdate = await gate.allows('update', [Post, post])
+
+// レコードを伴わないアビリティはクラス単体を渡す
+const canCreate = await gate.allows('create', Post)
+
+// 文字列キーも同様に使える
+const canDelete = await gate.allows('delete', ['post', post])
+
+// 認可するか例外を投げる(AuthorizationException, 403)
+await gate.authorize('update', [Post, post])
+```
+
+クラスインスタンス(`new` で生成したオブジェクト)はタプルなしで自動的にポリシーが解決されます:
+
+```typescript
+const canView = await gate.allows('view', somePostInstance)
 ```
 
 ### ポリシーメソッド
 
-ポリシーは以下の標準メソッドをサポートしています。
+ポリシーは以下の標準メソッドをサポートします:
 
 | メソッド | 説明 |
-|--------|-------------|
-| `viewAny` | すべてのリソースを閲覧可能か |
-| `view` | 特定のリソースを閲覧可能か |
-| `create` | 新しいリソースを作成可能か |
-| `update` | リソースを更新可能か |
-| `delete` | リソースを削除可能か |
-| `restore` | ソフト削除されたリソースを復元可能か |
-| `forceDelete` | リソースを完全に削除可能か |
+|---------|------|
+| `viewAny` | すべてのリソースを閲覧できるか |
+| `view` | 特定のリソースを閲覧できるか |
+| `create` | 新しいリソースを作成できるか |
+| `update` | リソースを更新できるか |
+| `delete` | リソースを削除できるか |
+| `restore` | ソフトデリートされたリソースを復元できるか |
+| `forceDelete` | リソースを完全に削除できるか |
 
 ### Beforeメソッド
 
-すべてのポリシーチェックをインターセプトする`before`メソッドを追加します。
+`before` メソッドを追加すると、すべてのポリシーチェックの前に割り込めます:
 
 ```typescript
-export class PostPolicy extends Policy<User, Post> {
-  before(user: User, ability: string): boolean | undefined {
-    // 管理者は投稿に対して何でもできる
-    if (user.isAdmin) {
+export class PostPolicy extends Policy {
+  before(user: AuthUser | null, ability: string): boolean | undefined {
+    // 管理者は投稿に対してあらゆる操作が可能
+    if (user !== null && (user as { isAdmin?: boolean }).isAdmin) {
       return true
     }
-    // undefined を返すと個別のポリシーメソッドで判定します
+    // undefined を返すと個別メソッドのチェックに進む
   }
 }
 ```
 
 ## コントローラー統合
 
-コントローラーで認可を使用します。
+コントローラーには `authorize()` と `can()` ヘルパーが組み込まれています。現在のユーザーは認証コンテキストから自動的に解決されます(ゲストは `null`):
 
 ```typescript
-import { Controller, Gate } from '@guren/core'
-import { PostResource } from '@/app/Http/Resources/PostResource'
+import { Controller } from '@guren/core'
 import { pages } from '@/.guren/pages.gen'
+import { Post } from '@/app/Models/Post'
+import { PostResource } from '@/app/Http/Resources/PostResource'
 
 export default class PostController extends Controller {
-  async show(id: number) {
-    const post = await Post.find(id)
+  async show() {
+    const { id } = this.validateParams(PostIdParamSchema)
+    const post = await Post.findOrFail(id)
 
-    // Gateを使用して認可
-    await Gate.authorize('view', this.user(), post)
+    // 拒否時は AuthorizationException (403) をスロー
+    await this.authorize('view', [Post, post])
 
     return this.inertia(pages.posts.Show, { post: new PostResource(post).toJSON() })
   }
 
-  async update(id: number) {
-    const post = await Post.find(id)
+  async update() {
+    const { id } = this.validateParams(PostIdParamSchema)
+    const post = await Post.findOrFail(id)
 
-    // 手動で権限をチェック
-    if (await Gate.denies('update', this.user(), post)) {
+    // 例外を投げずにチェック
+    if (!(await this.can('update', [Post, post]))) {
       return this.json({ error: 'Unauthorized' }, 403)
     }
 
-    // 更新ロジック...
+    // 更新処理...
   }
 }
 ```
 
+> **Tip:** `bunx guren make:feature Post --policy` を使うと、ポリシーの生成と `store`/`update` への `authorize()` 呼び出しの組み込みまで自動で行われます。
+
 ## ミドルウェア
 
-ルートレベルのチェック用認可ミドルウェアを作成します。
+ルートレベルのチェック用に認可ミドルウェアを作成できます:
 
 ```typescript
-import { Router, Gate, AuthorizationException } from '@guren/core'
+import { type Router, getGate, AuthorizationException, defineMiddleware } from '@guren/core'
 
-export function authorize(ability: string) {
-  return async (ctx, next) => {
-    const user = ctx.get('user')
+export function authorizeAbility(ability: string) {
+  return defineMiddleware(async (ctx, next) => {
+    const user = ctx.get('user') ?? null
 
-    if (!user || await Gate.denies(ability, user)) {
+    if (await getGate().forUser(user).denies(ability)) {
       throw new AuthorizationException()
     }
 
-    return next()
-  }
+    await next()
+  })
 }
 
 // ルートでの使用
 export function registerWebRoutes(router: Router): void {
-  router.get('/admin', [AdminController, 'index']).middleware(authorize('access-admin'))
+  router.get('/admin', [AdminController, 'index'], authorizeAbility('access-admin'))
 }
 ```
 
 ## ベストプラクティス
 
-1. **モデル固有のロジックにはポリシーを使用** - モデルごとに認可を整理します。
-2. **ゲートはシンプルに** - 特定のモデルに紐付かない能力にはゲートを使用します。
-3. **高コストなチェックはキャッシュ** - 認可にデータベースクエリが必要な場合、キャッシュを検討します。
-4. **beforeコールバックは控えめに** - 使いすぎるとデバッグが難しくなります。
-5. **認可をテスト** - ゲートとポリシーのテストを書きます。
+1. **モデル固有のロジックにはポリシーを使う** - 認可をモデル単位で整理する。
+2. **ゲートはシンプルに保つ** - 特定のモデルに紐づかないアビリティに使う。
+3. **高コストなチェックはキャッシュする** - 認可にデータベースクエリが必要な場合はキャッシュを検討する。
+4. **before コールバックは控えめに** - 多用するとデバッグが難しくなる。
+5. **認可をテストする** - ゲートとポリシーのテストを書く。
 
 ## 認可のテスト
+
+グローバルインスタンスに依存せず、テストごとに新しい `Gate` を生成します:
 
 ```typescript
 import { describe, it, expect, beforeEach } from 'bun:test'
 import { Gate } from '@guren/core'
+import { PostPolicy } from '../app/Policies/PostPolicy'
 
 describe('PostPolicy', () => {
+  let gate: Gate
+
   beforeEach(() => {
-    Gate.clear()
-    Gate.policy('post', new PostPolicy())
+    gate = new Gate()
+    gate.policy('post', PostPolicy)
   })
 
-  it('所有者は投稿を更新できる', async () => {
+  it('allows owner to update post', async () => {
     const user = { id: 1 }
     const post = { id: 1, userId: 1 }
 
-    expect(await Gate.allows('update', user, post)).toBe(true)
+    expect(await gate.forUser(user).allows('update', ['post', post])).toBe(true)
   })
 
-  it('非所有者は投稿を更新できない', async () => {
+  it('denies non-owner from updating post', async () => {
     const user = { id: 2 }
     const post = { id: 1, userId: 1 }
 
-    expect(await Gate.denies('update', user, post)).toBe(true)
+    expect(await gate.forUser(user).denies('update', ['post', post])).toBe(true)
   })
 })
 ```

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -64,8 +64,34 @@ bunx guren add plugin @acme/guren-plugin-audit
 | `make:listener <Name>` | イベントリスナークラスを生成 | `bunx guren make:listener SendWelcomeEmail` |
 | `make:notification <Name>` | 通知クラスを生成 | `bunx guren make:notification InvoicePaid` |
 | `make:mail <Name>` | メールクラスを生成 | `bunx guren make:mail WelcomeEmail` |
+| `make:policy <Name>` | 所有者ベースのデフォルトを備えた認可ポリシーを `app/Policies` に生成 | `bunx guren make:policy Post` |
 
 > **Note:** `make:*` は既存ファイルを上書きしません。必要なら `--force` を付けてください。
+
+## 検査・監査コマンド
+
+リリース前のアプリ検証に使えるコマンドです。AIコーディングエージェント向けにも設計されています(`--json` で機械可読な出力になります)。
+
+| コマンド | 説明 | 例 |
+|---------|------|-----|
+| `check` | ルート・コントローラ・ページ・モデル間の整合性を検証 | `bunx guren check --json` |
+| `audit` | セキュリティ監査: 変更系ルートのバリデーション/認証の欠如、文字列補間付き生SQL、ハードコードされた認証情報、無効化されたセキュリティ既定値、mass assignment 設定を検査 | `bunx guren audit --json` |
+| `doctor` | プロジェクトの健全性レポート(環境変数・設定・生成ファイル)と次のアクション | `bunx guren doctor --next` |
+
+`audit` は失敗(fail)を検出すると非ゼロの終了コードを返すため、CI に組み込めます。
+
+```bash
+bunx guren audit
+```
+
+名前付きミドルウェアで保護されたルート(例: `router.middleware('auth').group(...)`)は保護済みと認識されます。`/login` や `/register` などのゲストフローは認証チェックの対象外です。
+
+誤検出は、対象行またはその直前の行に `// guren-audit-ignore` を置くことで抑制できます:
+
+```ts
+// guren-audit-ignore -- ドキュメント用のサンプル値
+const apiKey = 'example-not-a-real-key'
+```
 
 ## デプロイレシピ生成
 

--- a/docs/ja/guides/deploy-production.md
+++ b/docs/ja/guides/deploy-production.md
@@ -183,6 +183,7 @@ docker compose -f docker-compose.production.yml logs app --tail 50
 アプリがデプロイされて稼働したら、以下の追加対策を検討してください:
 
 - **リバースプロキシ** — Nginx や Caddy を Bun の前に配置して TLS 終端と静的アセット配信を担当させる
+- **HSTS** — `NODE_ENV=production` では `Strict-Transport-Security: max-age=31536000` が自動送信されます。`createApp` の `securityHeaders: { hsts: { ... } }` で `includeSubDomains`/`preload` を追加、内部で平文 HTTP を配信する場合は `hsts: false` で無効化できます
 - **プロセス監視** — Docker の `restart: unless-stopped` や systemd などのプロセスマネージャーを使用する
 - **ロギング** — 構造化ログを設定し、集約サービスに転送する
 - **バックアップ** — `pg_dump` やマネージドデータベースサービスで定期的な Postgres バックアップをスケジュールする

--- a/docs/ja/guides/rate-limiting.md
+++ b/docs/ja/guides/rate-limiting.md
@@ -83,8 +83,24 @@ interface RateLimitOptions {
 
   /** レート制限キーのプレフィックス（デフォルト: 'rl:'） */
   keyPrefix?: string
+
+  /** プロキシヘッダー (CF-Connecting-IP, True-Client-IP, X-Real-IP, X-Forwarded-For) からクライアントIPを解決（デフォルト: false） */
+  trustProxy?: boolean
 }
 ```
+
+### プロキシ配下でのデプロイ
+
+アプリが常にリバースプロキシや CDN(Cloudflare、ALB、Nginx)の背後にある場合は、`trustProxy` を有効にすると独自の `keyGenerator` を書かずにクライアント単位の制限ができます:
+
+```ts
+createRateLimitMiddleware({
+  limit: 100,
+  trustProxy: true, // CF-Connecting-IP → True-Client-IP → X-Real-IP → X-Forwarded-For[0] の順で解決
+})
+```
+
+> **警告:** `trustProxy` はすべてのリクエストがプロキシを経由する場合のみ有効にしてください。直接公開されたデプロイではクライアントがヘッダーを偽装してクライアント単位の制限を回避できます。そのためデフォルトは `false` です。
 
 ### 完全な設定例
 

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -1,0 +1,451 @@
+import { resolve, relative } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import { parse } from '@babel/parser'
+import { consola } from 'consola'
+import {
+  collectFiles,
+  discoverControllerFiles,
+  discoverModelFiles,
+  classNameFromPath,
+} from './discovery'
+import { loadRouteDefinitions } from './load-routes'
+
+export type AuditStatus = 'pass' | 'warn' | 'fail'
+
+export interface AuditFinding {
+  key: string
+  title: string
+  status: AuditStatus
+  message: string
+  suggestion?: string
+  filePath?: string
+  line?: number
+}
+
+export interface AuditReport {
+  cwd: string
+  findings: AuditFinding[]
+  passCount: number
+  warnCount: number
+  failCount: number
+  routesAnalyzed: boolean
+}
+
+export interface RunAuditOptions {
+  cwd?: string
+  routesFile?: string
+}
+
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
+const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH'])
+
+/**
+ * Paths that are expected to be reachable without authentication
+ * (guest flows like login/registration).
+ */
+const GUEST_PATH_PATTERN = /(login|logout|register|signup|sign-up|password|forgot|reset|verification|verify-email)/i
+
+const WEBHOOK_PATH_PATTERN = /(webhook|callback)/i
+
+const AUTH_MIDDLEWARE_PATTERN = /auth/i
+
+/**
+ * Calls that actually reject unauthenticated requests. Optional reads like
+ * `auth.user()`, `auth.id()`, or `auth.check()` do not enforce anything on
+ * their own, so they intentionally do not count as protection.
+ */
+const AUTH_CALL_PATTERN = /\bauth\s*\.\s*userOrFail\s*\(|\bthis\s*\.\s*apiToken(?:UserId)?\s*\(/
+const VALIDATE_BODY_PATTERN = /\bvalidateBody(Safe)?\s*\(/
+const BODY_ACCESS_PATTERN = /\b(req|request)\s*\.\s*(json|formData|parseBody|text|body|raw)\b|\bparseRequestPayload\s*\(/
+
+function finding(
+  key: string,
+  title: string,
+  status: AuditStatus,
+  message: string,
+  suggestion?: string,
+  filePath?: string,
+  line?: number,
+): AuditFinding {
+  return { key, title, status, message, suggestion, filePath, line }
+}
+
+export async function runAudit(options: RunAuditOptions = {}): Promise<AuditReport> {
+  const cwd = resolve(options.cwd ?? process.cwd())
+  const findings: AuditFinding[] = []
+
+  const controllerMethods = await parseControllerMethods(cwd)
+
+  const routesAnalyzed = await auditRoutes(cwd, options.routesFile, controllerMethods, findings)
+  await auditSourceFiles(cwd, findings)
+  await auditModels(cwd, findings)
+
+  return {
+    cwd,
+    findings,
+    passCount: findings.filter((f) => f.status === 'pass').length,
+    warnCount: findings.filter((f) => f.status === 'warn').length,
+    failCount: findings.filter((f) => f.status === 'fail').length,
+    routesAnalyzed,
+  }
+}
+
+// --- Route-level checks ---
+
+interface ControllerMethodInfo {
+  body: string
+  filePath: string
+}
+
+/**
+ * Map of `ClassName.method` → method body source, for every controller in app/Http/Controllers.
+ */
+async function parseControllerMethods(cwd: string): Promise<Map<string, ControllerMethodInfo>> {
+  const methods = new Map<string, ControllerMethodInfo>()
+  const controllerFiles = await discoverControllerFiles(cwd)
+
+  for (const filePath of controllerFiles) {
+    const source = await readFile(filePath, 'utf-8')
+    const relPath = relative(cwd, filePath)
+
+    let ast: ReturnType<typeof parse>
+    try {
+      ast = parse(source, { sourceType: 'module', plugins: ['typescript'] })
+    } catch {
+      continue
+    }
+
+    for (const node of ast.program.body) {
+      let classDecl = null
+      if (node.type === 'ExportNamedDeclaration' && node.declaration?.type === 'ClassDeclaration') {
+        classDecl = node.declaration
+      } else if (node.type === 'ExportDefaultDeclaration' && node.declaration?.type === 'ClassDeclaration') {
+        classDecl = node.declaration
+      } else if (node.type === 'ClassDeclaration') {
+        classDecl = node
+      }
+
+      if (!classDecl) continue
+      const className = classDecl.id?.name ?? classNameFromPath(filePath)
+
+      for (const member of classDecl.body.body) {
+        if (member.type === 'ClassMethod' && member.key.type === 'Identifier') {
+          const start = member.body.start ?? 0
+          const end = member.body.end ?? 0
+          methods.set(`${className}.${member.key.name}`, {
+            body: source.slice(start, end),
+            filePath: relPath,
+          })
+        }
+      }
+    }
+  }
+
+  return methods
+}
+
+async function auditRoutes(
+  cwd: string,
+  routesFile: string | undefined,
+  controllerMethods: Map<string, ControllerMethodInfo>,
+  findings: AuditFinding[],
+): Promise<boolean> {
+  const resolvedRoutesFile = resolve(cwd, routesFile ?? 'routes/web.ts')
+
+  let definitions
+  try {
+    definitions = await loadRouteDefinitions(resolvedRoutesFile)
+  } catch (error) {
+    findings.push(
+      finding(
+        'routes:load',
+        'Route analysis',
+        'warn',
+        `Could not load routes (${error instanceof Error ? error.message : String(error)}). Route-level checks skipped.`,
+        'Ensure routes/web.ts is importable, or pass --routes <file>.',
+      ),
+    )
+    return false
+  }
+
+  for (const route of definitions) {
+    const method = route.method.toUpperCase()
+    if (!MUTATING_METHODS.has(method)) continue
+
+    const routeLabel = `${method} ${route.path}`
+    const controllerKey = route.controller
+      ? `${route.controller.name}.${route.controller.action}`
+      : undefined
+    const methodInfo = controllerKey ? controllerMethods.get(controllerKey) : undefined
+
+    // 1. Input validation on body-carrying routes
+    if (BODY_METHODS.has(method)) {
+      const hasRouteSchema = Boolean(route.schemas?.body)
+      // Route-level body schemas are runtime-enforced only for inline handlers.
+      // For controller actions the router intentionally leaves body validation
+      // to this.validateBody() (the schema is type-information only).
+      const routeSchemaEnforced = hasRouteSchema && !route.controller
+      const hasControllerValidation = methodInfo ? VALIDATE_BODY_PATTERN.test(methodInfo.body) : false
+      const readsBody = methodInfo ? BODY_ACCESS_PATTERN.test(methodInfo.body) : false
+
+      if (routeSchemaEnforced || hasControllerValidation) {
+        findings.push(
+          finding(
+            `validation:${routeLabel}`,
+            routeLabel,
+            'pass',
+            hasControllerValidation
+              ? `Controller validates body in ${controllerKey}.`
+              : 'Body schema validated at route level.',
+          ),
+        )
+      } else if (methodInfo && !readsBody) {
+        findings.push(
+          finding(
+            `validation:${routeLabel}`,
+            routeLabel,
+            'pass',
+            `${controllerKey} does not consume the request body.`,
+          ),
+        )
+      } else if (methodInfo) {
+        findings.push(
+          finding(
+            `validation:${routeLabel}`,
+            routeLabel,
+            'fail',
+            hasRouteSchema
+              ? `Route body schema is type-only for controller actions — ${controllerKey} reads the body without calling validateBody().`
+              : `Request body is read without validation in ${controllerKey}.`,
+            `Call this.validateBody(schema) in ${controllerKey}.`,
+            methodInfo.filePath,
+          ),
+        )
+      } else {
+        findings.push(
+          finding(
+            `validation:${routeLabel}`,
+            routeLabel,
+            'warn',
+            route.controller
+              ? `Controller source for ${controllerKey} could not be analyzed — route body schemas are type-only for controller actions.`
+              : 'Handler source could not be analyzed and no body schema is attached.',
+            route.controller
+              ? `Ensure ${controllerKey} calls this.validateBody(schema).`
+              : 'Attach a body schema to the route, or validate the payload inside the handler.',
+          ),
+        )
+      }
+    }
+
+    // 2. Authentication on mutating routes
+    if (GUEST_PATH_PATTERN.test(route.path)) continue
+
+    const middlewareNames = route.middlewareNames ?? []
+    const hasAuthMiddleware = middlewareNames.some((name) => AUTH_MIDDLEWARE_PATTERN.test(name))
+    const hasControllerAuth = methodInfo ? AUTH_CALL_PATTERN.test(methodInfo.body) : false
+
+    if (hasAuthMiddleware || hasControllerAuth) {
+      findings.push(
+        finding(
+          `authz:${routeLabel}`,
+          routeLabel,
+          'pass',
+          hasAuthMiddleware
+            ? `Protected by middleware: ${middlewareNames.join(', ')}.`
+            : `Controller checks authentication in ${controllerKey}.`,
+        ),
+      )
+    } else if (route.hasInlineMiddleware) {
+      findings.push(
+        finding(
+          `authz:${routeLabel}`,
+          routeLabel,
+          'warn',
+          'Inline middleware is attached but cannot be inspected — verify it enforces authentication.',
+          'Prefer named middleware via router.aliasMiddleware() so audits can verify protection.',
+        ),
+      )
+    } else if (WEBHOOK_PATH_PATTERN.test(route.path)) {
+      findings.push(
+        finding(
+          `authz:${routeLabel}`,
+          routeLabel,
+          'warn',
+          `Webhook-style route has no authentication check${controllerKey ? ` (${controllerKey})` : ''}.`,
+          'Webhooks cannot use session auth — verify the provider signature (e.g. HMAC header) before processing the payload.',
+          methodInfo?.filePath,
+        ),
+      )
+    } else {
+      findings.push(
+        finding(
+          `authz:${routeLabel}`,
+          routeLabel,
+          'warn',
+          `Mutating route has no authentication check${controllerKey ? ` (${controllerKey})` : ''}.`,
+          "Wrap the route in router.middleware('auth').group(...) or call this.auth.userOrFail() in the controller.",
+          methodInfo?.filePath,
+        ),
+      )
+    }
+  }
+
+  return true
+}
+
+// --- File-level checks ---
+
+const SCAN_DIRECTORIES = ['app', 'src', 'routes', 'config']
+
+const SECRET_PATTERN = /\b(secret|password|passwd|api[_-]?key|token|private[_-]?key)\b\s*[:=]\s*['"`]([^'"`]{8,})['"`]/i
+const SECRET_ALLOWLIST = /(process\.env|import\.meta\.env|\bz\.|example|placeholder|change[-_ ]?me|your[-_]|dummy|<[^>]*>|\$\{)/i
+
+const RAW_SQL_PATTERN = /\bsql\.raw\s*\(\s*`[^`]*\$\{/
+const UNSAFE_SQL_PATTERN = /\.unsafe\s*\(\s*`[^`]*\$\{/
+
+async function auditSourceFiles(cwd: string, findings: AuditFinding[]): Promise<void> {
+  const files: string[] = []
+  for (const dir of SCAN_DIRECTORIES) {
+    files.push(...(await collectFiles(resolve(cwd, dir))))
+  }
+
+  let secretCount = 0
+  let rawSqlCount = 0
+  let toggleCount = 0
+
+  for (const filePath of files) {
+    if (filePath.endsWith('.test.ts') || filePath.endsWith('.test.js')) continue
+
+    const relPath = relative(cwd, filePath)
+    const source = await readFile(filePath, 'utf-8')
+    const lines = source.split('\n')
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!
+      const lineNumber = i + 1
+
+      // `// guren-audit-ignore` on the same or preceding line suppresses findings
+      if (line.includes('guren-audit-ignore') || lines[i - 1]?.includes('guren-audit-ignore')) {
+        continue
+      }
+
+      // Hardcoded secrets
+      const secretMatch = SECRET_PATTERN.exec(line)
+      if (secretMatch && !SECRET_ALLOWLIST.test(line)) {
+        secretCount++
+        findings.push(
+          finding(
+            `secret:${relPath}:${lineNumber}`,
+            `${relPath}:${lineNumber}`,
+            'fail',
+            `Possible hardcoded credential ('${secretMatch[1]}').`,
+            'Move the value to an environment variable and read it via process.env.',
+            relPath,
+            lineNumber,
+          ),
+        )
+      }
+
+      // Raw SQL with interpolation
+      if (RAW_SQL_PATTERN.test(line) || UNSAFE_SQL_PATTERN.test(line)) {
+        rawSqlCount++
+        findings.push(
+          finding(
+            `raw-sql:${relPath}:${lineNumber}`,
+            `${relPath}:${lineNumber}`,
+            'fail',
+            'Raw SQL with string interpolation — potential SQL injection.',
+            'Use parameterized queries (drizzle sql`` template binds values safely) instead of sql.raw()/unsafe() with interpolation.',
+            relPath,
+            lineNumber,
+          ),
+        )
+      }
+
+      // Disabled security defaults
+      const toggleMatch = /\b(autoCsrf|securityHeaders|csrf)\s*:\s*false\b/.exec(line)
+      if (toggleMatch) {
+        toggleCount++
+        findings.push(
+          finding(
+            `security-toggle:${relPath}:${lineNumber}`,
+            `${relPath}:${lineNumber}`,
+            'warn',
+            `Security default '${toggleMatch[1]}' is disabled.`,
+            `Re-enable ${toggleMatch[1]} unless you have a compensating control.`,
+            relPath,
+            lineNumber,
+          ),
+        )
+      }
+    }
+  }
+
+  if (secretCount === 0) {
+    findings.push(finding('secret:none', 'Hardcoded credentials', 'pass', 'No hardcoded credentials detected.'))
+  }
+  if (rawSqlCount === 0) {
+    findings.push(finding('raw-sql:none', 'Raw SQL usage', 'pass', 'No raw SQL with interpolation detected.'))
+  }
+  if (toggleCount === 0) {
+    findings.push(finding('security-toggle:none', 'Security defaults', 'pass', 'No disabled security defaults detected.'))
+  }
+}
+
+// --- Model checks ---
+
+async function auditModels(cwd: string, findings: AuditFinding[]): Promise<void> {
+  const modelFiles = await discoverModelFiles(cwd)
+
+  for (const filePath of modelFiles) {
+    const relPath = relative(cwd, filePath)
+    const name = classNameFromPath(filePath)
+    const source = await readFile(filePath, 'utf-8')
+
+    const hasMassAssignmentConfig = /\bstatic\s+(override\s+)?(fillable|guarded)\b/.test(source)
+
+    findings.push(
+      finding(
+        `mass-assignment:${name}`,
+        `${name} mass assignment`,
+        hasMassAssignmentConfig ? 'pass' : 'warn',
+        hasMassAssignmentConfig
+          ? `${name} declares fillable/guarded.`
+          : `${name} declares neither fillable nor guarded — all columns except 'id' are mass-assignable.`,
+        hasMassAssignmentConfig
+          ? undefined
+          : `Add 'static fillable = [...]' to ${relPath} to whitelist assignable columns.`,
+        relPath,
+      ),
+    )
+  }
+}
+
+// --- Rendering ---
+
+export function renderAuditReport(report: AuditReport): void {
+  consola.box(`Guren security audit for ${report.cwd}`)
+
+  if (!report.routesAnalyzed) {
+    consola.warn('Route-level checks were skipped (routes could not be loaded).')
+  }
+
+  for (const f of report.findings) {
+    if (f.status === 'pass') continue
+    const log = f.status === 'warn' ? consola.warn : consola.error
+    log(`[${f.status}] ${f.title}: ${f.message}`)
+    if (f.suggestion) {
+      consola.info(`       → ${f.suggestion}`)
+    }
+  }
+
+  console.log('')
+  console.log(
+    `Results: ${report.passCount} passed, ${report.warnCount} warnings, ${report.failCount} failures`,
+  )
+
+  if (report.failCount === 0 && report.warnCount === 0) {
+    consola.success('No security findings.')
+  }
+}

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -16,6 +16,7 @@ import { makeJob } from './make-job'
 import { makeListener } from './make-listener'
 import { makeMail } from './make-mail'
 import { makeMiddleware } from './make-middleware'
+import { makePolicy } from './make-policy'
 import { makeMigration } from './make-migration'
 import { makeModel } from './make-model'
 import { makeNotification } from './make-notification'
@@ -49,6 +50,7 @@ import { installPlugin } from './plugin'
 import { displayModels } from './model-list'
 import { displayContext } from './context'
 import { runCheck, renderCheckReport } from './check'
+import { runAudit, renderAuditReport } from './audit'
 import { generateGuidelines } from './guidelines'
 import { makeFeature, parseFieldsString } from './make-feature'
 import { generateKeyValue, writeKeyToEnv } from './key-generate'
@@ -98,6 +100,7 @@ const makeCommandSpecs: MakeCommandSpec[] = [
   { name: 'make:event', description: 'Generate a new event class.', argDescription: 'Event class name', makeFn: makeEvent, resourceName: 'Event' },
   { name: 'make:mail', description: 'Generate a new mailable class.', argDescription: 'Mail class name', makeFn: makeMail, resourceName: 'Mail' },
   { name: 'make:middleware', description: 'Generate a new middleware.', argDescription: 'Middleware name', makeFn: makeMiddleware, resourceName: 'Middleware' },
+  { name: 'make:policy', description: 'Generate a new authorization policy.', argDescription: 'Policy class name', makeFn: makePolicy, resourceName: 'Policy' },
   { name: 'make:seeder', description: 'Generate a new database seeder.', argDescription: 'Seeder class name', makeFn: makeSeeder, resourceName: 'Seeder' },
   { name: 'make:notification', description: 'Generate a new notification class.', argDescription: 'Notification class name', makeFn: makeNotification, resourceName: 'Notification' },
   { name: 'make:provider', description: 'Generate a new service provider.', argDescription: 'Provider class name', makeFn: makeProvider, resourceName: 'Provider' },
@@ -1603,6 +1606,43 @@ const checkCommand = defineCommand({
   },
 })
 
+const auditCommand = defineCommand({
+  meta: {
+    name: 'audit',
+    description: 'Run a security audit: validation, authentication, raw SQL, secrets, mass assignment.',
+  },
+  args: {
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON.',
+    },
+    routes: {
+      type: 'string',
+      description: 'Path to routes entry file.',
+    },
+    app: {
+      type: 'string',
+      description: 'Application root directory.',
+    },
+  },
+  async run({ args }) {
+    const report = await runAudit({
+      cwd: args.app,
+      routesFile: args.routes,
+    })
+
+    if (args.json) {
+      console.log(JSON.stringify(report, null, 2))
+    } else {
+      renderAuditReport(report)
+    }
+
+    if (report.failCount > 0) {
+      process.exitCode = 1
+    }
+  },
+})
+
 const guidelinesCommand = defineCommand({
   meta: {
     name: 'guidelines',
@@ -1656,12 +1696,22 @@ const makeFeatureCommand = defineCommand({
       type: 'boolean',
       description: 'Also generate a test file.',
     },
+    public: {
+      type: 'boolean',
+      description: 'Skip authentication checks in mutating actions (default: auth required).',
+    },
+    policy: {
+      type: 'boolean',
+      description: 'Also generate an authorization policy and enforce it in store/update.',
+    },
   },
   async run({ args }) {
     await makeFeature(args.name as string, {
       fields: args.fields,
       force: Boolean(args.force),
       withTest: Boolean(args.test),
+      publicAccess: Boolean(args.public),
+      withPolicy: Boolean(args.policy),
     })
   },
 })
@@ -2123,6 +2173,7 @@ const main = defineCommand({
     'model:list': modelListCommand,
     context: contextCommand,
     check: checkCommand,
+    audit: auditCommand,
     guidelines: guidelinesCommand,
     'make:feature': makeFeatureCommand,
   },

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -10,6 +10,7 @@ import {
   discoverMiddlewareFiles,
   discoverListenerFiles,
   discoverValidatorFiles,
+  discoverPolicyFiles,
   classNameFromPath,
   readIfExists,
   collectFiles,
@@ -30,6 +31,7 @@ export interface ProjectContext {
   middleware: string[]
   listeners: string[]
   validators: string[]
+  policies: string[]
 }
 
 export interface ContextOptions {
@@ -91,6 +93,7 @@ export async function generateContext(options: ContextOptions = {}): Promise<Pro
   const middleware = await toNames(discoverMiddlewareFiles)
   const listeners = await toNames(discoverListenerFiles)
   const validators = await toNames(discoverValidatorFiles)
+  const policies = await toNames(discoverPolicyFiles)
 
   return {
     framework: { name: 'Guren', version },
@@ -104,6 +107,7 @@ export async function generateContext(options: ContextOptions = {}): Promise<Pro
     middleware,
     listeners,
     validators,
+    policies,
   }
 }
 
@@ -169,6 +173,7 @@ export function renderContextMarkdown(ctx: ProjectContext): string {
     ['Middleware', ctx.middleware],
     ['Listeners', ctx.listeners],
     ['Validators', ctx.validators],
+    ['Policies', ctx.policies],
   ]
 
   for (const [title, items] of sections) {

--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -104,6 +104,10 @@ export function discoverValidatorFiles(appRoot: string): Promise<string[]> {
   return discoverDir(appRoot, 'app/Http/Validators')
 }
 
+export function discoverPolicyFiles(appRoot: string): Promise<string[]> {
+  return discoverDir(appRoot, 'app/Policies')
+}
+
 /**
  * Extract a class name from a file path.
  * e.g., '/app/Models/Post.ts' → 'Post'

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -1056,6 +1056,15 @@ export async function suggestNextSteps(options: { cwd?: string } = {}): Promise<
     })
   }
 
+  if (controllerFiles.length > 0) {
+    steps.push({
+      priority: priority++,
+      title: 'Run the security audit',
+      description: 'Verify validation/authentication coverage on mutating routes and scan for raw SQL and hardcoded credentials.',
+      command: 'bunx guren audit',
+    })
+  }
+
   return steps
 }
 

--- a/packages/cli/src/guidelines.ts
+++ b/packages/cli/src/guidelines.ts
@@ -7,6 +7,7 @@ import {
   discoverJobFiles,
   discoverMiddlewareFiles,
   discoverValidatorFiles,
+  discoverPolicyFiles,
   classNameFromPath,
   fileExists,
   directoryExists,
@@ -87,6 +88,26 @@ export async function generateGuidelines(options: GuidelinesOptions = {}): Promi
   }
   lines.push('')
 
+  // Authorization
+  lines.push('## Authorization')
+  const policies = excludeBarrelFiles(await discoverPolicyFiles(cwd)).map(classNameFromPath)
+  if (policies.length > 0) {
+    lines.push('- Policies in app/Policies/ — enforce with `await this.authorize(ability, [Model, record])` in controllers')
+    lines.push(`- Available: ${policies.join(', ')}`)
+  } else {
+    lines.push('- No policies found. Scaffold with `bunx guren make:policy <Model>` and register via `getGate().policy(Model, ModelPolicy)`')
+  }
+  lines.push('')
+
+  // Security rules
+  lines.push('## Security Rules (checked by `bunx guren audit`)')
+  lines.push('- Validate every mutating route: call `this.validateBody(schema)` in controller actions (route `body` schemas are type-only for controllers; they are runtime-enforced only for inline handlers)')
+  lines.push("- Protect mutating routes: wrap in `router.middleware('auth').group(...)` or call `this.auth.userOrFail()` (optional reads like `auth.user()` do not enforce)")
+  lines.push('- Never interpolate values into raw SQL (`sql.raw`) — drizzle `sql` templates bind values safely')
+  lines.push('- Never hardcode credentials — read secrets via `process.env`')
+  lines.push('- Declare `static fillable` on models to whitelist mass-assignable columns')
+  lines.push('')
+
   // Resources
   const resources = excludeBarrelFiles(await discoverResourceFiles(cwd)).map(classNameFromPath)
   if (resources.length > 0) {
@@ -123,6 +144,7 @@ export async function generateGuidelines(options: GuidelinesOptions = {}): Promi
   lines.push('5. Create resource in `app/Http/Resources/`')
   lines.push('6. Register routes in `routes/web.ts`')
   lines.push('7. Run `bunx guren codegen` after adding routes')
+  lines.push('8. Run `bunx guren audit` and fix any findings before opening a PR')
   lines.push('')
 
   const output = lines.join('\n')

--- a/packages/cli/src/make-feature.ts
+++ b/packages/cli/src/make-feature.ts
@@ -1,6 +1,7 @@
 import { consola } from 'consola'
 import { writeFilesSafe, type WriterOptions, pascalCase, kebabCase } from './utils'
 import { makeModel } from './make-model'
+import { makePolicy } from './make-policy'
 import { makeTest } from './make-test'
 
 export interface FieldDefinition {
@@ -13,6 +14,10 @@ export interface MakeFeatureOptions extends WriterOptions {
   fields?: string
   withTest?: boolean
   withFactory?: boolean
+  /** Skip authentication checks in mutating actions. Defaults to false (auth required). */
+  publicAccess?: boolean
+  /** Also generate an authorization policy and enforce it in mutating actions. */
+  withPolicy?: boolean
 }
 
 const DEFAULT_FIELDS: FieldDefinition[] = [
@@ -48,6 +53,8 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
   const routeName = kebabCase(collection)
   const routeVar = routeName.replace(/-([a-z])/g, (_, char: string) => char.toUpperCase())
   const variableName = singular.charAt(0).toLowerCase() + singular.slice(1)
+  const withAuth = !options.publicAccess
+  const withPolicy = Boolean(options.withPolicy)
   const writerOptions: WriterOptions = { force: Boolean(options.force) }
 
   const created = await writeFilesSafe([
@@ -61,7 +68,7 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
     },
     {
       path: `app/Http/Controllers/${singular}Controller.ts`,
-      contents: generateController(singular, collection, routeName, routeVar, variableName, fields),
+      contents: generateController(singular, collection, routeName, routeVar, variableName, fields, withAuth, withPolicy),
     },
     {
       path: `resources/js/pages/${routeName}/Index.tsx`,
@@ -85,6 +92,12 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
   const modelPath = await makeModel(singular, writerOptions)
   created.push(modelPath)
 
+  // Optionally create policy
+  if (withPolicy) {
+    const policyPath = await makePolicy(singular, writerOptions)
+    created.push(policyPath)
+  }
+
   // Optionally create test
   if (options.withTest) {
     try {
@@ -99,22 +112,38 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
     consola.success(`Created ${file}`)
   }
 
+  const authSuffix = withAuth ? `.middleware('auth')` : ''
   consola.info('')
   consola.info('Next steps:')
   consola.info(`  1. Add table definition to db/schema.ts`)
   consola.info(`  2. Register routes in routes/web.ts with body schemas:`)
   consola.info(`     import ${singular}Controller from '../app/Http/Controllers/${singular}Controller.js'`)
   consola.info(`     import { ${singular}PayloadSchema } from '../app/Http/Validators/${singular}Validator.js'`)
+  if (withAuth) {
+    consola.info(`     router.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))`)
+  }
   consola.info(`     router.group('/${routeName}', (${routeVar}) => {`)
   consola.info(`       ${routeVar}.get('/', [${singular}Controller, 'index']).name('${routeName}.index')`)
   consola.info(`       ${routeVar}.get('/create', [${singular}Controller, 'create']).name('${routeName}.create')`)
   consola.info(`       ${routeVar}.get('/:id', [${singular}Controller, 'show']).name('${routeName}.show')`)
   consola.info(`       ${routeVar}.get('/:id/edit', [${singular}Controller, 'edit']).name('${routeName}.edit')`)
-  consola.info(`       ${routeVar}.post('/', { name: '${routeName}.store', body: ${singular}PayloadSchema }, [${singular}Controller, 'store'])`)
-  consola.info(`       ${routeVar}.put('/:id', { name: '${routeName}.update', body: ${singular}PayloadSchema }, [${singular}Controller, 'update'])`)
+  consola.info(`       ${routeVar}.post('/', { name: '${routeName}.store', body: ${singular}PayloadSchema }, [${singular}Controller, 'store'])${authSuffix}`)
+  consola.info(`       ${routeVar}.put('/:id', { name: '${routeName}.update', body: ${singular}PayloadSchema }, [${singular}Controller, 'update'])${authSuffix}`)
   consola.info(`     })`)
   consola.info(`  3. Run: bunx guren db:migrate`)
   consola.info(`  4. Run: bunx guren codegen`)
+  if (withPolicy) {
+    consola.info(`  5. Register the policy in src/app.ts (inside the boot callback):`)
+    consola.info(`     import { getGate } from '@guren/core'`)
+    consola.info(`     import { ${singular} } from '../app/Models/${singular}.js'`)
+    consola.info(`     import { ${singular}Policy } from '../app/Policies/${singular}Policy.js'`)
+    consola.info(`     getGate().policy(${singular}, ${singular}Policy)`)
+  }
+  if (withAuth) {
+    consola.info('')
+    consola.info(`  Note: store/update call this.auth.userOrFail() — unauthenticated requests get 401.`)
+    consola.info(`  Use --public to scaffold without authentication checks.`)
+  }
 
   return created
 }
@@ -226,7 +255,14 @@ function generateController(
   routeVar: string,
   variableName: string,
   fields: FieldDefinition[],
+  withAuth: boolean,
+  withPolicy: boolean,
 ): string {
+  const authGuard = withAuth ? '    await this.auth.userOrFail()\n' : ''
+  const createGuard = withPolicy ? `    await this.authorize('create', ${singular})\n` : ''
+  const updateGuard = withPolicy
+    ? `    await this.authorize('update', [${singular}, await ${singular}.findOrFail(id)])\n`
+    : ''
   return `import { Controller, paginate, type PaginatedPageProps } from '@guren/core'
 import { pages } from '../../../.guren/pages.gen.js'
 import { ${singular} } from '../../Models/${singular}.js'
@@ -264,7 +300,7 @@ export default class ${singular}Controller extends Controller {
   }
 
   async store(): Promise<Response> {
-    const data = await this.validateBody(${singular}PayloadSchema)
+${authGuard}${createGuard}    const data = await this.validateBody(${singular}PayloadSchema)
     const ${variableName} = await ${singular}.create(data)
     return this.redirect('/${routeName}/' + ${variableName}?.id)
   }
@@ -279,8 +315,8 @@ export default class ${singular}Controller extends Controller {
   }
 
   async update(): Promise<Response> {
-    const { id } = this.validateParams(${singular}IdParamSchema)
-    const data = await this.validateBody(${singular}PayloadSchema)
+${authGuard}    const { id } = this.validateParams(${singular}IdParamSchema)
+${updateGuard}    const data = await this.validateBody(${singular}PayloadSchema)
     await ${singular}.update({ id }, data)
     return this.redirect('/${routeName}/' + id)
   }

--- a/packages/cli/src/make-policy.ts
+++ b/packages/cli/src/make-policy.ts
@@ -1,0 +1,46 @@
+import type { WriterOptions } from './utils'
+import { scaffoldFile } from './utils'
+
+const POLICY_DIR = 'app/Policies'
+
+function policyTemplate(className: string): string {
+  const modelName = className.replace(/Policy$/, '')
+  const variableName = modelName.charAt(0).toLowerCase() + modelName.slice(1)
+
+  return `import { Policy, type AuthUser } from '@guren/core'
+
+interface ${modelName}Like {
+  userId?: string | number
+}
+
+export class ${className} extends Policy {
+  viewAny(_user: AuthUser | null): boolean {
+    return true
+  }
+
+  view(_user: AuthUser | null, _${variableName}: ${modelName}Like): boolean {
+    return true
+  }
+
+  create(user: AuthUser | null): boolean {
+    return user !== null
+  }
+
+  update(user: AuthUser | null, ${variableName}: ${modelName}Like): boolean {
+    return user !== null && user.id === ${variableName}.userId
+  }
+
+  delete(user: AuthUser | null, ${variableName}: ${modelName}Like): boolean {
+    return user !== null && user.id === ${variableName}.userId
+  }
+}
+`
+}
+
+export async function makePolicy(name: string, options: WriterOptions = {}): Promise<string> {
+  return scaffoldFile(name, {
+    dir: POLICY_DIR,
+    suffix: 'Policy',
+    template: ({ normalizedName }) => policyTemplate(normalizedName),
+  }, options)
+}

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -1,0 +1,526 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { describe, expect, it } from 'bun:test'
+import { runAudit } from '../src/audit'
+import { createTempWorkspace } from './helpers'
+
+async function writeRoutes(dir: string, contents: string): Promise<void> {
+  await mkdir(join(dir, 'routes'), { recursive: true })
+  await writeFile(join(dir, 'routes/web.ts'), contents, 'utf8')
+}
+
+async function writeController(dir: string, name: string, contents: string): Promise<void> {
+  await mkdir(join(dir, 'app/Http/Controllers'), { recursive: true })
+  await writeFile(join(dir, `app/Http/Controllers/${name}.ts`), contents, 'utf8')
+}
+
+describe('runAudit', () => {
+  it('fails when the request body is read without validation', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-validation-')
+
+    try {
+      await writeController(
+        workspace.dir,
+        'PostController',
+        `export default class PostController {
+  async store() {
+    const data = await this.request.json()
+    return null
+  }
+}`,
+      )
+      await writeRoutes(
+        workspace.dir,
+        `class PostController {
+  async store() { return null }
+}
+export default function registerRoutes(router: any) {
+  router.post('/posts', [PostController, 'store'])
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      expect(report.routesAnalyzed).toBe(true)
+      const validation = report.findings.find(f => f.key === 'validation:POST /posts')
+      expect(validation).toBeDefined()
+      expect(validation!.status).toBe('fail')
+      expect(validation!.suggestion).toContain('validateBody')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('passes validation when the controller does not consume the body', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-nobody-')
+
+    try {
+      await writeController(
+        workspace.dir,
+        'SessionController',
+        `export default class SessionController {
+  async destroy() {
+    await this.auth.logout()
+    return this.redirect('/')
+  }
+}`,
+      )
+      await writeRoutes(
+        workspace.dir,
+        `class SessionController {
+  async destroy() { return null }
+}
+export default function registerRoutes(router: any) {
+  router.post('/sessions/end', [SessionController, 'destroy'])
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const validation = report.findings.find(f => f.key === 'validation:POST /sessions/end')
+      expect(validation).toBeDefined()
+      expect(validation!.status).toBe('pass')
+      expect(validation!.message).toContain('does not consume')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('warns when an inline handler has no schema and cannot be analyzed', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-inline-')
+
+    try {
+      await writeRoutes(
+        workspace.dir,
+        `export default function registerRoutes(router: any) {
+  router.post('/items', (c: any) => null)
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const validation = report.findings.find(f => f.key === 'validation:POST /items')
+      expect(validation).toBeDefined()
+      expect(validation!.status).toBe('warn')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('passes validation when controller calls validateBody', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-validatebody-')
+
+    try {
+      await writeController(
+        workspace.dir,
+        'PostController',
+        `export default class PostController {
+  async store() {
+    const data = await this.validateBody(schema)
+    return null
+  }
+}`,
+      )
+      await writeRoutes(
+        workspace.dir,
+        `class PostController {
+  async store() { return null }
+}
+export default function registerRoutes(router: any) {
+  router.post('/posts', [PostController, 'store'])
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const validation = report.findings.find(f => f.key === 'validation:POST /posts')
+      expect(validation).toBeDefined()
+      expect(validation!.status).toBe('pass')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('fails controller routes that rely on a type-only route body schema', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-typeonly-schema-')
+
+    try {
+      await writeController(
+        workspace.dir,
+        'PostController',
+        `export default class PostController {
+  async store() {
+    const data = await this.request.json()
+    return null
+  }
+}`,
+      )
+      await writeRoutes(
+        workspace.dir,
+        `class PostController {
+  async store() { return null }
+}
+const schema = { safeParse: (value: unknown) => ({ success: true, data: value }) }
+export default function registerRoutes(router: any) {
+  router.post('/posts', { name: 'posts.store', body: schema }, [PostController, 'store'])
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const validation = report.findings.find(f => f.key === 'validation:POST /posts')
+      expect(validation).toBeDefined()
+      expect(validation!.status).toBe('fail')
+      expect(validation!.message).toContain('type-only')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('does not count optional auth reads as protection', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-optional-auth-')
+
+    try {
+      await writeController(
+        workspace.dir,
+        'PostController',
+        `export default class PostController {
+  async destroy() {
+    const user = await this.auth.user()
+    return null
+  }
+}`,
+      )
+      await writeRoutes(
+        workspace.dir,
+        `class PostController {
+  async destroy() { return null }
+}
+export default function registerRoutes(router: any) {
+  router.delete('/posts/:id', [PostController, 'destroy'])
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const authz = report.findings.find(f => f.key === 'authz:DELETE /posts/:id')
+      expect(authz).toBeDefined()
+      expect(authz!.status).toBe('warn')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('passes validation when route attaches a body schema', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-schema-')
+
+    try {
+      await writeRoutes(
+        workspace.dir,
+        `const schema = { safeParse: (value: unknown) => ({ success: true, data: value }) }
+export default function registerRoutes(router: any) {
+  router.post('/posts', { name: 'posts.store', body: schema }, (c: any) => null)
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const validation = report.findings.find(f => f.key === 'validation:POST /posts')
+      expect(validation).toBeDefined()
+      expect(validation!.status).toBe('pass')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('warns about mutating routes without authentication', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-authz-')
+
+    try {
+      await writeController(
+        workspace.dir,
+        'PostController',
+        `export default class PostController {
+  async destroy() {
+    return null
+  }
+}`,
+      )
+      await writeRoutes(
+        workspace.dir,
+        `class PostController {
+  async destroy() { return null }
+}
+export default function registerRoutes(router: any) {
+  router.delete('/posts/:id', [PostController, 'destroy'])
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const authz = report.findings.find(f => f.key === 'authz:DELETE /posts/:id')
+      expect(authz).toBeDefined()
+      expect(authz!.status).toBe('warn')
+      expect(authz!.suggestion).toContain('auth')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('passes authz when auth middleware protects the route', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-authz-mw-')
+
+    try {
+      await writeRoutes(
+        workspace.dir,
+        `export default function registerRoutes(router: any) {
+  router.delete('/posts/:id', (c: any) => null).middleware('auth')
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const authz = report.findings.find(f => f.key === 'authz:DELETE /posts/:id')
+      expect(authz).toBeDefined()
+      expect(authz!.status).toBe('pass')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('passes authz when controller calls auth.userOrFail', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-authz-controller-')
+
+    try {
+      await writeController(
+        workspace.dir,
+        'PostController',
+        `export default class PostController {
+  async store() {
+    const user = await this.auth.userOrFail()
+    const data = await this.validateBody(schema)
+    return null
+  }
+}`,
+      )
+      await writeRoutes(
+        workspace.dir,
+        `class PostController {
+  async store() { return null }
+}
+export default function registerRoutes(router: any) {
+  router.post('/posts', [PostController, 'store'])
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const authz = report.findings.find(f => f.key === 'authz:POST /posts')
+      expect(authz).toBeDefined()
+      expect(authz!.status).toBe('pass')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('suggests signature verification for unprotected webhook routes', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-webhook-')
+
+    try {
+      await writeRoutes(
+        workspace.dir,
+        `export default function registerRoutes(router: any) {
+  router.post('/webhooks/stripe', (c: any) => null)
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const authz = report.findings.find(f => f.key === 'authz:POST /webhooks/stripe')
+      expect(authz).toBeDefined()
+      expect(authz!.status).toBe('warn')
+      expect(authz!.suggestion).toContain('signature')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('skips authz for guest paths like /login', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-guest-')
+
+    try {
+      await writeRoutes(
+        workspace.dir,
+        `export default function registerRoutes(router: any) {
+  router.post('/login', (c: any) => null)
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const authz = report.findings.find(f => f.key === 'authz:POST /login')
+      expect(authz).toBeUndefined()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('detects hardcoded credentials', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-secret-')
+
+    try {
+      await mkdir(join(workspace.dir, 'src'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'src/config.ts'),
+        `export const apiKey = 'sk-live-1234567890abcdef'\n`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const secret = report.findings.find(f => f.key.startsWith('secret:src/config.ts'))
+      expect(secret).toBeDefined()
+      expect(secret!.status).toBe('fail')
+      expect(secret!.line).toBe(1)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('suppresses findings marked with guren-audit-ignore', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-ignore-')
+
+    try {
+      await mkdir(join(workspace.dir, 'src'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'src/config.ts'),
+        [
+          `// guren-audit-ignore -- documented example value`,
+          `export const apiKey = 'sk-live-1234567890abcdef'`,
+          `export const otherKey = 'sk-live-fedcba0987654321' // guren-audit-ignore`,
+        ].join('\n') + '\n',
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const secret = report.findings.find(f => f.key.startsWith('secret:src/config.ts'))
+      expect(secret).toBeUndefined()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('ignores credentials read from process.env', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-env-')
+
+    try {
+      await mkdir(join(workspace.dir, 'src'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'src/config.ts'),
+        `export const apiKey = process.env.API_KEY ?? ''\n`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const secret = report.findings.find(f => f.key.startsWith('secret:src/'))
+      expect(secret).toBeUndefined()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('detects raw SQL with interpolation', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-rawsql-')
+
+    try {
+      await mkdir(join(workspace.dir, 'app/Services'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Services/ReportService.ts'),
+        'const rows = await db.execute(sql.raw(`SELECT * FROM users WHERE id = ${userId}`))\n',
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const rawSql = report.findings.find(f => f.key.startsWith('raw-sql:app/Services/ReportService.ts'))
+      expect(rawSql).toBeDefined()
+      expect(rawSql!.status).toBe('fail')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('warns when security defaults are disabled', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-toggle-')
+
+    try {
+      await mkdir(join(workspace.dir, 'src'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'src/app.ts'),
+        `export const app = createApp({ autoCsrf: false })\n`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const toggle = report.findings.find(f => f.key.startsWith('security-toggle:src/app.ts'))
+      expect(toggle).toBeDefined()
+      expect(toggle!.status).toBe('warn')
+      expect(toggle!.message).toContain('autoCsrf')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('warns about models without fillable or guarded', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-mass-')
+
+    try {
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Models/Post.ts'),
+        `export class Post {
+  static table = posts
+}`,
+        'utf8',
+      )
+      await writeFile(
+        join(workspace.dir, 'app/Models/User.ts'),
+        `export class User {
+  static table = users
+  static fillable = ['name', 'email']
+}`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const post = report.findings.find(f => f.key === 'mass-assignment:Post')
+      expect(post).toBeDefined()
+      expect(post!.status).toBe('warn')
+
+      const user = report.findings.find(f => f.key === 'mass-assignment:User')
+      expect(user).toBeDefined()
+      expect(user!.status).toBe('pass')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('degrades gracefully when routes cannot be loaded', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-noroutes-')
+
+    try {
+      const report = await runAudit({ cwd: workspace.dir })
+
+      expect(report.routesAnalyzed).toBe(false)
+      const loadWarning = report.findings.find(f => f.key === 'routes:load')
+      expect(loadWarning).toBeDefined()
+      expect(loadWarning!.status).toBe('warn')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})

--- a/packages/cli/tests/context.test.ts
+++ b/packages/cli/tests/context.test.ts
@@ -100,6 +100,7 @@ describe('renderContextMarkdown', () => {
       middleware: [],
       listeners: [],
       validators: [],
+      policies: [],
     })
 
     expect(md).toContain('# Project Context')

--- a/packages/cli/tests/guidelines.test.ts
+++ b/packages/cli/tests/guidelines.test.ts
@@ -13,7 +13,30 @@ describe('generateGuidelines', () => {
 
       expect(output).toContain('# Project Guidelines')
       expect(output).toContain('## Naming Conventions')
+      expect(output).toContain('## Security Rules (checked by `bunx guren audit`)')
       expect(output).toContain('## When Creating New Features')
+      expect(output).toContain('bunx guren make:policy')
+      expect(output).toContain('Run `bunx guren audit`')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('lists policies when present', async () => {
+    const workspace = await createTempWorkspace('guren-cli-guidelines-policy-')
+
+    try {
+      await mkdir(join(workspace.dir, 'app/Policies'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Policies/PostPolicy.ts'),
+        `export class PostPolicy {}`,
+        'utf8',
+      )
+
+      const output = await generateGuidelines({ cwd: workspace.dir })
+
+      expect(output).toContain('PostPolicy')
+      expect(output).toContain('this.authorize')
     } finally {
       await workspace.cleanup()
     }

--- a/packages/cli/tests/make-commands.test.ts
+++ b/packages/cli/tests/make-commands.test.ts
@@ -11,6 +11,7 @@ import { makeListener } from '../src/make-listener'
 import { makeMail } from '../src/make-mail'
 import { makeMiddleware } from '../src/make-middleware'
 import { makeNotification } from '../src/make-notification'
+import { makePolicy } from '../src/make-policy'
 import { makeProvider } from '../src/make-provider'
 import { makeResource } from '../src/make-resource'
 import { makeSeeder } from '../src/make-seeder'
@@ -152,6 +153,31 @@ describe('CLI make:* commands', () => {
       expect(content).toContain('LogRequestMiddleware')
       expect(content).toContain('ctx: Context')
       expect(content).toContain('await next()')
+    })
+  })
+
+  describe('makePolicy', () => {
+    it('creates a policy file', async () => {
+      const result = await makePolicy('Post')
+      expect(result).toContain('app/Policies/PostPolicy.ts')
+      expect(fs.existsSync(result)).toBe(true)
+    })
+
+    it('generates correct policy template', async () => {
+      const result = await makePolicy('Post')
+      const content = fs.readFileSync(result, 'utf-8')
+      expect(content).toContain('export class PostPolicy extends Policy')
+      expect(content).toContain('viewAny')
+      expect(content).toContain('update(user: AuthUser | null, post: PostLike)')
+      expect(content).toContain('user.id === post.userId')
+    })
+
+    it('does not duplicate the Policy suffix', async () => {
+      const result = await makePolicy('CommentPolicy')
+      expect(result).toContain('app/Policies/CommentPolicy.ts')
+      const content = fs.readFileSync(result, 'utf-8')
+      expect(content).toContain('class CommentPolicy extends Policy')
+      expect(content).toContain('comment: CommentLike')
     })
   })
 

--- a/packages/cli/tests/make-feature.test.ts
+++ b/packages/cli/tests/make-feature.test.ts
@@ -1,5 +1,8 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
-import { parseFieldsString } from '../src/make-feature'
+import { makeFeature, parseFieldsString } from '../src/make-feature'
+import { createTempWorkspace } from './helpers'
 
 describe('parseFieldsString', () => {
   it('parses simple fields', () => {
@@ -46,5 +49,68 @@ describe('parseFieldsString', () => {
   it('defaults type to string when omitted', () => {
     const fields = parseFieldsString('title')
     expect(fields[0].type).toBe('string')
+  })
+})
+
+describe('makeFeature', () => {
+  it('includes auth checks in mutating actions by default', async () => {
+    const workspace = await createTempWorkspace('guren-cli-feature-auth-')
+
+    try {
+      await makeFeature('Post', { fields: 'title:string' })
+
+      const controller = await readFile(
+        join(workspace.dir, 'app/Http/Controllers/PostController.ts'),
+        'utf8',
+      )
+
+      const storeBody = controller.slice(controller.indexOf('async store'))
+      expect(storeBody).toContain('await this.auth.userOrFail()')
+      const updateBody = controller.slice(controller.indexOf('async update'))
+      expect(updateBody).toContain('await this.auth.userOrFail()')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('generates a policy and authorize calls with withPolicy', async () => {
+    const workspace = await createTempWorkspace('guren-cli-feature-policy-')
+
+    try {
+      await makeFeature('Post', { fields: 'title:string', withPolicy: true })
+
+      const controller = await readFile(
+        join(workspace.dir, 'app/Http/Controllers/PostController.ts'),
+        'utf8',
+      )
+      expect(controller).toContain("await this.authorize('create', Post)")
+      expect(controller).toContain("await this.authorize('update', [Post, await Post.findOrFail(id)])")
+
+      const policy = await readFile(
+        join(workspace.dir, 'app/Policies/PostPolicy.ts'),
+        'utf8',
+      )
+      expect(policy).toContain('export class PostPolicy extends Policy')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('skips auth checks with publicAccess', async () => {
+    const workspace = await createTempWorkspace('guren-cli-feature-public-')
+
+    try {
+      await makeFeature('Post', { fields: 'title:string', publicAccess: true })
+
+      const controller = await readFile(
+        join(workspace.dir, 'app/Http/Controllers/PostController.ts'),
+        'utf8',
+      )
+
+      expect(controller).not.toContain('auth.userOrFail')
+      expect(controller).toContain('validateBody')
+    } finally {
+      await workspace.cleanup()
+    }
   })
 })

--- a/packages/server/src/authorization/Gate.ts
+++ b/packages/server/src/authorization/Gate.ts
@@ -261,6 +261,11 @@ export class Gate {
 
   /**
    * Check a policy for the given ability.
+   *
+   * The subject may be a class instance (policy resolved via its constructor)
+   * or a `[ModelClass, record]` / `['key', record]` tuple. The tuple form is
+   * required for plain records returned by the ORM, which carry no constructor
+   * information.
    */
   protected async checkPolicy(
     ability: string,
@@ -268,12 +273,30 @@ export class Gate {
     model: unknown,
     additionalArgs: unknown[]
   ): Promise<boolean | undefined> {
-    const modelConstructor = model?.constructor
-    if (!modelConstructor) {
+    let policyKey: unknown
+    let subject: unknown = model
+    let hasSubject = true
+
+    if (
+      Array.isArray(model)
+      && model.length === 2
+      && (typeof model[0] === 'function' || typeof model[0] === 'string')
+    ) {
+      policyKey = model[0]
+      subject = model[1]
+    } else if (typeof model === 'function') {
+      // Bare model class — abilities without a record, e.g. can('create', Post)
+      policyKey = model
+      hasSubject = false
+    } else {
+      policyKey = model?.constructor
+    }
+
+    if (!policyKey) {
       return undefined
     }
 
-    const policyClass = this.policies.get(modelConstructor)
+    const policyClass = this.policies.get(policyKey)
     if (!policyClass) {
       return undefined
     }
@@ -291,7 +314,9 @@ export class Gate {
     // Check ability method
     const method = (policy as Record<string, unknown>)[ability]
     if (typeof method === 'function') {
-      return method.call(policy, user, model, ...additionalArgs)
+      return hasSubject
+        ? method.call(policy, user, subject, ...additionalArgs)
+        : method.call(policy, user, ...additionalArgs)
     }
 
     return undefined

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -5,6 +5,8 @@ import { Container, type ServiceProvider } from '../container'
 import { ProviderManager } from '../container/ServiceProvider'
 import { AuthManager } from '../auth/AuthManager'
 import { AuthServiceProvider } from '../providers/AuthServiceProvider'
+import { AuthorizationServiceProvider } from '../providers/AuthorizationServiceProvider'
+import { ErrorServiceProvider } from '../providers/ErrorServiceProvider'
 import { attachAuthContext } from './middleware/auth'
 import { SessionGuard } from '../auth/SessionGuard'
 import type { CreateSessionMiddlewareOptions } from './middleware/session'
@@ -220,9 +222,26 @@ export class Application {
       this.providerManager.register(AuthServiceProvider)
     }
 
+    // Authorization gate is always available; user providers registered
+    // below can resolve 'gate' from the container or use getGate().
+    this.providerManager.register(AuthorizationServiceProvider)
+
+    const userProviders = Array.isArray(this.options.providers) ? this.options.providers : []
+
+    // Exception rendering is on by default so HttpExceptions map to their
+    // status codes (404/422/403) instead of opaque 500s. Registered before
+    // user providers so a custom ErrorServiceProvider subclass wins via
+    // its later hono.onError() call.
+    const hasUserErrorProvider = userProviders.some(
+      (provider) => provider === ErrorServiceProvider || provider.prototype instanceof ErrorServiceProvider,
+    )
+    if (!hasUserErrorProvider) {
+      this.providerManager.register(ErrorServiceProvider)
+    }
+
     // Register user providers
-    if (Array.isArray(this.options.providers)) {
-      this.providerManager.registerMany(this.options.providers)
+    if (userProviders.length > 0) {
+      this.providerManager.registerMany(userProviders)
     }
   }
 

--- a/packages/server/src/http/middleware/rate-limit.ts
+++ b/packages/server/src/http/middleware/rate-limit.ts
@@ -171,6 +171,18 @@ export interface RateLimitOptions {
    * @default 'rl:'
    */
   keyPrefix?: string
+
+  /**
+   * Trust reverse-proxy headers for client IP resolution, checked in order:
+   * `CF-Connecting-IP`, `True-Client-IP`, `X-Real-IP`, then the first entry
+   * of `X-Forwarded-For`. Falls back to `server.requestIP()` when none are set.
+   *
+   * Enable ONLY when every request passes through a proxy that sets or strips
+   * these headers — on direct deployments clients can spoof them to bypass
+   * per-client limits. Ignored when a custom `keyGenerator` is supplied.
+   * @default false
+   */
+  trustProxy?: boolean
 }
 
 let defaultKeyGeneratorWarned = false
@@ -194,6 +206,31 @@ let defaultKeyGeneratorWarned = false
  * Does NOT trust proxy headers by default to prevent rate-limit bypass via
  * header spoofing on direct deployments.
  */
+const PROXY_IP_HEADERS = ['cf-connecting-ip', 'true-client-ip', 'x-real-ip'] as const
+
+/**
+ * Resolve the client IP from trusted reverse-proxy headers.
+ * Returns null when no proxy header is present.
+ */
+function clientIpFromProxyHeaders(ctx: Context): string | null {
+  for (const header of PROXY_IP_HEADERS) {
+    const value = ctx.req.header(header)?.trim()
+    if (value) return value
+  }
+
+  const forwardedFor = ctx.req.header('x-forwarded-for')
+  if (forwardedFor) {
+    const first = forwardedFor.split(',')[0]?.trim()
+    if (first) return first
+  }
+
+  return null
+}
+
+function proxyAwareKeyGenerator(ctx: Context): string {
+  return clientIpFromProxyHeaders(ctx) ?? defaultKeyGenerator(ctx)
+}
+
 function defaultKeyGenerator(ctx: Context): string {
   // Bun.serve passes { server } in env — use server.requestIP() for true client IP
   const env = ctx.env as Record<string, unknown> | undefined
@@ -275,7 +312,8 @@ export function createRateLimitMiddleware(options: RateLimitOptions = {}): Middl
   const {
     limit = 100,
     windowMs = 60000,
-    keyGenerator = defaultKeyGenerator,
+    trustProxy = false,
+    keyGenerator = trustProxy ? proxyAwareKeyGenerator : defaultKeyGenerator,
     store = getDefaultStore(),
     skip,
     onRateLimited,

--- a/packages/server/src/http/middleware/security-headers.test.ts
+++ b/packages/server/src/http/middleware/security-headers.test.ts
@@ -64,4 +64,30 @@ describe('createSecurityHeaders', () => {
       'max-age=31536000; includeSubDomains; preload',
     )
   })
+
+  test('should enable HSTS by default in production', async () => {
+    const originalEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    try {
+      const app = createApp()
+      const res = await app.request('/')
+
+      expect(res.headers.get('Strict-Transport-Security')).toBe('max-age=31536000')
+    } finally {
+      process.env.NODE_ENV = originalEnv
+    }
+  })
+
+  test('should allow disabling HSTS in production with false', async () => {
+    const originalEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    try {
+      const app = createApp({ hsts: false })
+      const res = await app.request('/')
+
+      expect(res.headers.get('Strict-Transport-Security')).toBeNull()
+    } finally {
+      process.env.NODE_ENV = originalEnv
+    }
+  })
 })

--- a/packages/server/src/http/middleware/security-headers.ts
+++ b/packages/server/src/http/middleware/security-headers.ts
@@ -20,7 +20,11 @@ export interface SecurityHeadersOptions {
   referrerPolicy?: string | false
   /** X-Permitted-Cross-Domain-Policies header. Set to false to disable. Default: 'none' */
   crossDomainPolicies?: string | false
-  /** Strict-Transport-Security header. Default: false (disabled) */
+  /**
+   * Strict-Transport-Security header.
+   * Default: `{ maxAge: 31536000 }` (1 year) when NODE_ENV is 'production', false otherwise.
+   * Browsers ignore HSTS on plain-HTTP responses, so the production default is safe behind TLS terminators.
+   */
   hsts?: HstsOptions | false
 }
 
@@ -52,7 +56,7 @@ export function createSecurityHeaders(options: SecurityHeadersOptions = {}): Mid
     xssProtection = '0',
     referrerPolicy = 'strict-origin-when-cross-origin',
     crossDomainPolicies = 'none',
-    hsts = false,
+    hsts = process.env.NODE_ENV === 'production' ? { maxAge: 31536000 } : false,
   } = options
 
   const hstsValue = hsts !== false ? buildHstsValue(hsts) : null

--- a/packages/server/src/mvc/Controller.ts
+++ b/packages/server/src/mvc/Controller.ts
@@ -7,6 +7,8 @@ import type { AuthContext } from '../auth/types'
 import type { ServiceBindings } from '../container/bindings'
 import { ValidationException } from '../errors/exceptions/ValidationException'
 import { getApiTokenOrFail } from '../auth/api-token'
+import { getGate } from '../authorization/Gate'
+import type { AuthUser } from '../authorization/types'
 
 /** Structural type for DI containers, avoiding a hard dependency on Container. */
 interface ContainerLike {
@@ -212,6 +214,46 @@ export class Controller {
    */
   protected apiTokenUserId(): string | number {
     return this.apiToken().userId
+  }
+
+  // ─── Authorization Helpers ──────────────────────────────────────
+
+  /**
+   * Authorize the current user (or guest) for an ability.
+   * Throws AuthorizationException (403) when denied.
+   *
+   * ORM records are plain objects with no constructor information, so pass
+   * the model class alongside the record to resolve the policy:
+   *
+   * @example
+   * ```typescript
+   * const post = await Post.findOrFail(id)
+   * await this.authorize('update', [Post, post])
+   * await this.authorize('create', Post)
+   * ```
+   */
+  protected async authorize(ability: string, ...args: unknown[]): Promise<void> {
+    await getGate().forUser(await this.gateUser()).authorize(ability, ...args)
+  }
+
+  /**
+   * Check whether the current user (or guest) can perform an ability.
+   *
+   * @example
+   * ```typescript
+   * if (await this.can('update', [Post, post])) { ... }
+   * ```
+   */
+  protected async can(ability: string, ...args: unknown[]): Promise<boolean> {
+    return getGate().forUser(await this.gateUser()).allows(ability, ...args)
+  }
+
+  private async gateUser(): Promise<AuthUser | null> {
+    const auth = this.ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
+    if (!auth) {
+      return null
+    }
+    return (await auth.user()) as AuthUser | null
   }
 
   // ─── Response Helpers ───────────────────────────────────────────

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -143,6 +143,15 @@ export interface RouteDefinition {
     body?: SchemaLike<unknown>
     output?: SchemaLike<unknown>
   }
+  /** Named middleware (aliases or groups) applied to this route */
+  middlewareNames?: string[]
+  /** Whether inline (unnamed) middleware handlers are attached */
+  hasInlineMiddleware?: boolean
+  /** Controller binding when the handler is a [Controller, 'method'] tuple */
+  controller?: {
+    name: string
+    action: string
+  }
   summary?: string
   description?: string
   tags?: string[]
@@ -466,11 +475,16 @@ export class Router<M extends string = never> {
   }
 
   definitions(): RouteDefinition[] {
-    return this.registry.map(({ method, path, name, schemas, openapi }) => ({
+    return this.registry.map(({ method, path, name, schemas, openapi, routeMiddlewareNames, middlewares, handler }) => ({
       method,
       path,
       name,
       schemas,
+      middlewareNames: [...routeMiddlewareNames],
+      hasInlineMiddleware: middlewares.length > 0,
+      controller: isControllerAction(handler)
+        ? { name: handler[0].name, action: String(handler[1]) }
+        : undefined,
       ...openapi,
     }))
   }

--- a/packages/server/src/providers/AuthorizationServiceProvider.ts
+++ b/packages/server/src/providers/AuthorizationServiceProvider.ts
@@ -1,11 +1,15 @@
 import { ServiceProvider } from '../container/ServiceProvider'
-import { createGate } from '../authorization'
+import { createGate, setGate } from '../authorization'
 
 /**
- * Binds the Gate as a singleton in the container.
+ * Binds the Gate as a singleton in the container and exposes it as the
+ * global gate so `getGate()`, `can()`, and controller authorization helpers
+ * work without manual wiring.
  */
 export class AuthorizationServiceProvider extends ServiceProvider {
   register(): void {
-    this.container.singleton('gate', () => createGate())
+    const gate = createGate()
+    setGate(gate)
+    this.container.singleton('gate', () => gate)
   }
 }

--- a/packages/server/tests/application.test.ts
+++ b/packages/server/tests/application.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { Application, Controller, createApp } from '../src'
+import { Application, Controller, createApp, getGate, Policy, ErrorServiceProvider } from '../src'
 import { z } from 'zod'
 
 class GreetingController extends Controller {
@@ -173,5 +173,116 @@ describe('Application routing integration', () => {
     expect(failure.status).toBe(400)
     const failureBody = await failure.json() as { errors?: Record<string, string> }
     expect(failureBody.errors?.id).toContain('number')
+  })
+})
+
+describe('Application authorization wiring', () => {
+  class Doc {
+    constructor(public id: number, public ownerId: number) {}
+  }
+
+  it('makes the global gate available after boot without manual wiring', async () => {
+    const app = createApp({
+      routes: (router) => {
+        router.get('/ping', () => 'pong')
+      },
+    })
+    await app.boot()
+
+    const gate = getGate()
+    expect(gate).toBeDefined()
+    gate.define('always', () => true)
+    expect(await gate.allows('always')).toBe(true)
+  })
+
+  it('denies controller authorize() for guests via registered policy (403)', async () => {
+    class DocPolicy extends Policy {
+      update(user: { id: string | number } | null, doc: { ownerId?: unknown }) {
+        return user !== null && user.id === doc.ownerId
+      }
+    }
+
+    class DocController extends Controller {
+      async update() {
+        await this.authorize('update', [Doc, { id: 1, ownerId: 5 }])
+        return this.json({ ok: true })
+      }
+    }
+
+    const app = createApp({
+      routes: (router) => {
+        router.put('/docs/:id', [DocController, 'update'])
+      },
+    })
+    await app.boot()
+    getGate().policy(Doc, DocPolicy)
+
+    const response = await app.fetch(new Request('http://example.com/docs/1', { method: 'PUT' }))
+
+    expect(response.status).toBe(403)
+  })
+
+  it('maps duck-typed statusCode exceptions without manual ErrorServiceProvider', async () => {
+    class NotFoundish extends Error {
+      readonly statusCode = 404
+    }
+
+    const app = createApp({
+      routes: (router) => {
+        router.get('/missing', () => {
+          throw new NotFoundish('Nope')
+        })
+      },
+    })
+    await app.boot()
+
+    const response = await app.fetch(new Request('http://example.com/missing'))
+
+    expect(response.status).toBe(404)
+  })
+
+  it('lets a user-supplied ErrorServiceProvider take precedence', async () => {
+    class CustomErrorProvider extends ErrorServiceProvider {
+      boot(): void {
+        const hono = this.container.make<import('hono').Hono>('hono')
+        hono.onError(() => new Response('custom', { status: 418 }))
+      }
+    }
+
+    const app = createApp({
+      routes: (router) => {
+        router.get('/boom', () => {
+          throw new Error('boom')
+        })
+      },
+      providers: [CustomErrorProvider],
+    })
+    await app.boot()
+
+    const response = await app.fetch(new Request('http://example.com/boom'))
+
+    expect(response.status).toBe(418)
+    expect(await response.text()).toBe('custom')
+  })
+
+  it('controller can() reflects gate definitions', async () => {
+    class StatusController extends Controller {
+      async index() {
+        return this.json({ allowed: await this.can('view-dashboard') })
+      }
+    }
+
+    const app = createApp({
+      routes: (router) => {
+        router.get('/status', [StatusController, 'index'])
+      },
+    })
+    await app.boot()
+    getGate().define('view-dashboard', () => true)
+
+    const response = await app.fetch(new Request('http://example.com/status'))
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ allowed: true })
   })
 })

--- a/packages/server/tests/authorization/authorization.test.ts
+++ b/packages/server/tests/authorization/authorization.test.ts
@@ -339,6 +339,40 @@ describe('Policy', () => {
     expect(await guestGate.allows('create', dummyPost)).toBe(false)
   })
 
+  test('resolves policy via [ModelClass, record] tuple for plain records', async () => {
+    // ORM queries return plain objects with no constructor information
+    const plainRecord = { id: 1, authorId: 5, published: true }
+
+    const authorGate = gate.forUser({ id: 5, role: 'user' } as TestUser)
+    const otherGate = gate.forUser({ id: 10, role: 'user' } as TestUser)
+
+    expect(await authorGate.allows('update', [Post, plainRecord])).toBe(true)
+    expect(await otherGate.allows('update', [Post, plainRecord])).toBe(false)
+  })
+
+  test('plain record without tuple cannot resolve a policy (denied)', async () => {
+    const plainRecord = { id: 1, authorId: 5, published: true }
+    const authorGate = gate.forUser({ id: 5, role: 'user' } as TestUser)
+
+    expect(await authorGate.allows('update', plainRecord)).toBe(false)
+  })
+
+  test('resolves policy via bare model class for record-less abilities', async () => {
+    const userGate = gate.forUser({ id: 1, role: 'user' } as TestUser)
+    const guestGate = gate.forUser(null)
+
+    expect(await userGate.allows('create', Post)).toBe(true)
+    expect(await guestGate.allows('create', Post)).toBe(false)
+  })
+
+  test('resolves policy via [stringKey, record] tuple', async () => {
+    gate.policy('post', PostPolicy)
+    const plainRecord = { id: 1, authorId: 5, published: true }
+    const authorGate = gate.forUser({ id: 5, role: 'user' } as TestUser)
+
+    expect(await authorGate.allows('update', ['post', plainRecord])).toBe(true)
+  })
+
   test('unpublished post only visible to author', async () => {
     const unpublishedPost = new Post(1, 5, false)
 

--- a/packages/server/tests/http/middleware/rate-limit.test.ts
+++ b/packages/server/tests/http/middleware/rate-limit.test.ts
@@ -158,6 +158,44 @@ describe('createRateLimitMiddleware', () => {
     }
   })
 
+  it('separates clients by proxy IP headers when trustProxy is enabled', async () => {
+    app.use('*', createRateLimitMiddleware({ limit: 1, store, trustProxy: true }))
+    app.get('/', (c) => c.text('OK'))
+
+    const clientA1 = await app.request('/', { headers: { 'cf-connecting-ip': '1.1.1.1' } })
+    const clientA2 = await app.request('/', { headers: { 'cf-connecting-ip': '1.1.1.1' } })
+    const clientB1 = await app.request('/', { headers: { 'cf-connecting-ip': '2.2.2.2' } })
+
+    expect(clientA1.status).toBe(200)
+    expect(clientA2.status).toBe(429)
+    expect(clientB1.status).toBe(200)
+  })
+
+  it('uses the first X-Forwarded-For entry when trustProxy is enabled', async () => {
+    app.use('*', createRateLimitMiddleware({ limit: 1, store, trustProxy: true }))
+    app.get('/', (c) => c.text('OK'))
+
+    const first = await app.request('/', { headers: { 'x-forwarded-for': '3.3.3.3, 10.0.0.1' } })
+    const second = await app.request('/', { headers: { 'x-forwarded-for': '3.3.3.3, 10.0.0.2' } })
+    const other = await app.request('/', { headers: { 'x-forwarded-for': '4.4.4.4, 10.0.0.1' } })
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(429)
+    expect(other.status).toBe(200)
+  })
+
+  it('ignores proxy headers by default (spoofing cannot bypass limits)', async () => {
+    app.use('*', createRateLimitMiddleware({ limit: 1, store }))
+    app.get('/', (c) => c.text('OK'))
+
+    const first = await app.request('/', { headers: { 'x-forwarded-for': '5.5.5.5' } })
+    const spoofed = await app.request('/', { headers: { 'x-forwarded-for': '6.6.6.6' } })
+
+    expect(first.status).toBe(200)
+    // Different spoofed header still hits the same shared fallback bucket
+    expect(spoofed.status).toBe(429)
+  })
+
   it('blocks requests over the limit', async () => {
     app.use('*', createRateLimitMiddleware({ limit: 3, store }))
     app.get('/', (c) => c.text('OK'))

--- a/packages/server/tests/mvc/router.test.ts
+++ b/packages/server/tests/mvc/router.test.ts
@@ -86,6 +86,9 @@ describe('Router route contract metadata', () => {
           params: undefined,
           query: undefined,
         },
+        middlewareNames: [],
+        hasInlineMiddleware: false,
+        controller: undefined,
         summary: 'Create post',
         description: 'Creates a post resource.',
         tags: ['Posts'],
@@ -113,6 +116,9 @@ describe('Router route contract metadata', () => {
           params: undefined,
           query: undefined,
         },
+        middlewareNames: [],
+        hasInlineMiddleware: false,
+        controller: undefined,
         summary: 'Health check',
         description: undefined,
         tags: undefined,
@@ -120,5 +126,44 @@ describe('Router route contract metadata', () => {
         deprecated: undefined,
       },
     ])
+  })
+})
+
+describe('Router definition introspection', () => {
+  it('exposes controller binding for controller action routes', () => {
+    const router = new Router()
+    router.post('/posts', [StubController, 'store'])
+
+    const [def] = router.definitions()
+    expect(def!.controller).toEqual({ name: 'StubController', action: 'store' })
+    expect(def!.hasInlineMiddleware).toBe(false)
+  })
+
+  it('exposes named middleware applied via middleware groups', () => {
+    const router = new Router<'auth'>()
+    router.aliasMiddleware('auth', async (_c, next) => { await next() })
+    router.middleware('auth').group((auth) => {
+      auth.delete('/posts/:id', [StubController, 'destroy'])
+    })
+
+    const [def] = router.definitions()
+    expect(def!.middlewareNames).toEqual(['auth'])
+  })
+
+  it('exposes named middleware applied via the route builder', () => {
+    const router = new Router<'auth'>()
+    router.aliasMiddleware('auth', async (_c, next) => { await next() })
+    router.delete('/posts/:id', [StubController, 'destroy']).middleware('auth')
+
+    const [def] = router.definitions()
+    expect(def!.middlewareNames).toEqual(['auth'])
+  })
+
+  it('reports inline middleware presence', () => {
+    const router = new Router()
+    router.post('/posts', async (_c) => null, async (_c, next) => { await next() })
+
+    const [def] = router.definitions()
+    expect(def!.hasInlineMiddleware).toBe(true)
   })
 })

--- a/scripts/smoke/core-first-audit.ts
+++ b/scripts/smoke/core-first-audit.ts
@@ -26,6 +26,7 @@ const ignoredDirNames = new Set([
   '.next',
   '.turbo',
   '.guren',
+  '.vercel',
   'coverage',
 ])
 


### PR DESCRIPTION
## Summary

Makes Guren secure by default and gives AI coding agents a built-in security harness: a generate → check → fix loop that works out of the box.

### Secure by default (`@guren/server`)
- **Authorization gate is auto-wired at boot** — `AuthorizationServiceProvider` is always registered (`setGate()` + `'gate'` container singleton); no manual setup needed
- **Gate works with ORM records** — `Gate.checkPolicy` now resolves policies from `[ModelClass, record]` tuples and bare classes. Previously, policy resolution relied on `model.constructor`, which never matches the plain records returned by the ORM, so policy checks silently denied everything
- **`Controller.authorize()` / `can()` helpers** (Laravel parity) — resolve the current user from the auth context (guests are `null`), throw `AuthorizationException` (403) on denial
- **`ErrorServiceProvider` registered by default** — `findOrFail`/`validateBody`/`authorize` now map to 404/422/403 instead of opaque 500s; a user-supplied subclass still takes precedence
- **HSTS on by default in production** (`max-age=31536000`)
- **Rate-limit `trustProxy` option** — resolves `CF-Connecting-IP` → `True-Client-IP` → `X-Real-IP` → `X-Forwarded-For[0]`; off by default so spoofed headers can't bypass per-client limits

### Harness by default (`@guren/cli`)
- **`guren audit`** — static security audit designed for AI agents: missing body validation on mutating routes (route body schemas count only for inline handlers — they are type-only for controller actions), unauthenticated mutating routes (only enforcing calls like `auth.userOrFail()` count), `sql.raw` interpolation, hardcoded credentials, disabled security toggles, missing `fillable`/`guarded`. Supports `--json`, non-zero exit for CI, `// guren-audit-ignore`, and webhook signature guidance
- **`make:policy`** — policy scaffold with owner-based defaults
- **`make:feature`** — `store`/`update` now require auth by default (`--public` opts out); `--policy` also generates and enforces a policy
- **`guren guidelines` / `context` / `doctor --next`** — surface security rules, the policies inventory, and the audit loop to agents
- `Router.definitions()` exposes `middlewareNames` / `hasInlineMiddleware` / `controller` for static analysis

### Docs & CI
- Authorization guide (en/ja) rewritten to the real `getGate()` API (the previous version documented a non-existent static `Gate` API)
- CI now dogfoods `guren audit` against `examples/blog`
- Restored `bun run build` to the README and fixed the stale `@guren/server/lambda` reference (repairs the previously failing `audit:docs` / `audit:core-first` gates)

## Breaking changes (pre-1.0)
- Exceptions are now rendered by the default `ErrorServiceProvider` (correct status codes instead of 500). Apps registering their own provider are unaffected
- `Strict-Transport-Security` is sent automatically when `NODE_ENV=production` (disable with `securityHeaders: { hsts: false }`)
- `make:feature` scaffolds now call `this.auth.userOrFail()` in mutating actions by default

## Test plan
- ~70 new tests (audit, Gate tuple resolution, Application wiring/403 integration, HSTS, trustProxy, scaffolds, guidelines)
- `bun run build` / `bun run typecheck` / `bun run test` — 2114 pass, 0 fail
- `bun run audit:core-first` / `audit:docs` / `audit:contracts` / `audit:feature-runtime` / `audit:starter-template` — all pass
- `examples/blog` security audit: 17 passed, 0 findings; `make:feature --policy` output typechecks in the blog app
- Codex review findings (false negatives for optional auth reads and type-only route body schemas) fixed with regression tests