### PR TITLE
chore: version packages to 1.0.0-rc.19

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -35,6 +35,7 @@
     "proud-snakes-brush",
     "ready-numbers-rescue",
     "release-prep",
+    "secure-defaults-release",
     "strict-shoes-crash",
     "thick-bottles-search",
     "v1-rc-release"

--- a/.changeset/secure-defaults-release.md
+++ b/.changeset/secure-defaults-release.md
@@ -1,0 +1,19 @@
+---
+"@guren/server": minor
+"@guren/cli": minor
+"@guren/core": patch
+"@guren/orm": patch
+"@guren/testing": patch
+"@guren/openapi": patch
+"@guren/inertia-client": patch
+"create-guren-app": patch
+---
+
+Secure-by-default hardening and AI-agent tooling:
+
+- `guren audit` command: validates auth/validation coverage on mutating routes, detects raw SQL, secrets, and mass assignment risks
+- `make:feature` now scaffolds auth checks by default (`--public` to opt out) and supports `--policy`
+- Authorization gate wiring, hardened auth/storage/mail/error rendering
+- Inertia asset version mismatch handling
+- drizzle-orm / drizzle-kit upgraded to 1.0.0-rc.1
+- Migration tracker SQL escaping fix and dependency vulnerability patches

--- a/examples/api/CHANGELOG.md
+++ b/examples/api/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @guren/example-api
 
+## 0.1.1-rc.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @guren/cli@1.0.0-rc.16
+  - @guren/core@1.0.0-rc.14
+  - @guren/orm@1.0.0-rc.13
+  - @guren/testing@1.0.0-rc.14
+  - @guren/openapi@1.0.0-rc.14
+
 ## 0.1.1-rc.9
 
 ### Patch Changes

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/example-api",
-  "version": "0.1.1-rc.9",
+  "version": "0.1.1-rc.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @guren/cli
 
+## 1.0.0-rc.16
+
+### Minor Changes
+
+- Secure-by-default hardening and AI-agent tooling:
+
+  - `guren audit` command: validates auth/validation coverage on mutating routes, detects raw SQL, secrets, and mass assignment risks
+  - `make:feature` now scaffolds auth checks by default (`--public` to opt out) and supports `--policy`
+  - Authorization gate wiring, hardened auth/storage/mail/error rendering
+  - Inertia asset version mismatch handling
+  - drizzle-orm / drizzle-kit upgraded to 1.0.0-rc.1
+  - Migration tracker SQL escaping fix and dependency vulnerability patches
+
+### Patch Changes
+
+- Updated dependencies
+  - @guren/core@1.0.0-rc.14
+  - @guren/orm@1.0.0-rc.13
+
 ## 1.0.0-rc.15
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/cli",
-  "version": "1.0.0-rc.15",
+  "version": "1.0.0-rc.16",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -44,8 +44,8 @@
   },
   "dependencies": {
     "@babel/parser": "^7.24.7",
-    "@guren/core": "^1.0.0-rc.13",
-    "@guren/orm": "^1.0.0-rc.12",
+    "@guren/core": "^1.0.0-rc.14",
+    "@guren/orm": "^1.0.0-rc.13",
     "citty": "^0.1.6",
     "consola": "^3.4.2"
   },

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @guren/core
 
+## 1.0.0-rc.14
+
+### Patch Changes
+
+- Secure-by-default hardening and AI-agent tooling:
+
+  - `guren audit` command: validates auth/validation coverage on mutating routes, detects raw SQL, secrets, and mass assignment risks
+  - `make:feature` now scaffolds auth checks by default (`--public` to opt out) and supports `--policy`
+  - Authorization gate wiring, hardened auth/storage/mail/error rendering
+  - Inertia asset version mismatch handling
+  - drizzle-orm / drizzle-kit upgraded to 1.0.0-rc.1
+  - Migration tracker SQL escaping fix and dependency vulnerability patches
+
+- Updated dependencies
+  - @guren/server@1.0.0-rc.14
+  - @guren/cli@1.0.0-rc.16
+  - @guren/orm@1.0.0-rc.13
+
 ## 1.0.0-rc.13
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/core",
-  "version": "1.0.0-rc.13",
+  "version": "1.0.0-rc.14",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -48,9 +48,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@guren/cli": "^1.0.0-rc.14",
-    "@guren/orm": "^1.0.0-rc.12",
-    "@guren/server": "^1.0.0-rc.13"
+    "@guren/cli": "^1.0.0-rc.16",
+    "@guren/orm": "^1.0.0-rc.13",
+    "@guren/server": "^1.0.0-rc.14"
   },
   "devDependencies": {
     "@types/node": "^20.14.10",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,18 @@
 # create-guren-app
 
+## 1.0.0-rc.18
+
+### Patch Changes
+
+- Secure-by-default hardening and AI-agent tooling:
+
+  - `guren audit` command: validates auth/validation coverage on mutating routes, detects raw SQL, secrets, and mass assignment risks
+  - `make:feature` now scaffolds auth checks by default (`--public` to opt out) and supports `--policy`
+  - Authorization gate wiring, hardened auth/storage/mail/error rendering
+  - Inertia asset version mismatch handling
+  - drizzle-orm / drizzle-kit upgraded to 1.0.0-rc.1
+  - Migration tracker SQL escaping fix and dependency vulnerability patches
+
 ## 1.0.0-rc.17
 
 ### Patch Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-guren-app",
-  "version": "1.0.0-rc.17",
+  "version": "1.0.0-rc.18",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/inertia-client/CHANGELOG.md
+++ b/packages/inertia-client/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @guren/inertia-client
 
+## 1.0.0-rc.13
+
+### Patch Changes
+
+- Secure-by-default hardening and AI-agent tooling:
+
+  - `guren audit` command: validates auth/validation coverage on mutating routes, detects raw SQL, secrets, and mass assignment risks
+  - `make:feature` now scaffolds auth checks by default (`--public` to opt out) and supports `--policy`
+  - Authorization gate wiring, hardened auth/storage/mail/error rendering
+  - Inertia asset version mismatch handling
+  - drizzle-orm / drizzle-kit upgraded to 1.0.0-rc.1
+  - Migration tracker SQL escaping fix and dependency vulnerability patches
+
 ## 1.0.0-rc.12
 
 ### Patch Changes

--- a/packages/inertia-client/package.json
+++ b/packages/inertia-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/inertia-client",
-  "version": "1.0.0-rc.12",
+  "version": "1.0.0-rc.13",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/openapi/CHANGELOG.md
+++ b/packages/openapi/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @guren/openapi
 
+## 1.0.0-rc.14
+
+### Patch Changes
+
+- Secure-by-default hardening and AI-agent tooling:
+
+  - `guren audit` command: validates auth/validation coverage on mutating routes, detects raw SQL, secrets, and mass assignment risks
+  - `make:feature` now scaffolds auth checks by default (`--public` to opt out) and supports `--policy`
+  - Authorization gate wiring, hardened auth/storage/mail/error rendering
+  - Inertia asset version mismatch handling
+  - drizzle-orm / drizzle-kit upgraded to 1.0.0-rc.1
+  - Migration tracker SQL escaping fix and dependency vulnerability patches
+
+- Updated dependencies
+  - @guren/core@1.0.0-rc.14
+
 ## 1.0.0-rc.13
 
 ### Patch Changes

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/openapi",
-  "version": "1.0.0-rc.13",
+  "version": "1.0.0-rc.14",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@guren/core": "^1.0.0-rc.13"
+    "@guren/core": "^1.0.0-rc.14"
   },
   "devDependencies": {
     "@types/node": "^20.14.10",

--- a/packages/orm/CHANGELOG.md
+++ b/packages/orm/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @guren/orm
 
+## 1.0.0-rc.13
+
+### Patch Changes
+
+- Secure-by-default hardening and AI-agent tooling:
+
+  - `guren audit` command: validates auth/validation coverage on mutating routes, detects raw SQL, secrets, and mass assignment risks
+  - `make:feature` now scaffolds auth checks by default (`--public` to opt out) and supports `--policy`
+  - Authorization gate wiring, hardened auth/storage/mail/error rendering
+  - Inertia asset version mismatch handling
+  - drizzle-orm / drizzle-kit upgraded to 1.0.0-rc.1
+  - Migration tracker SQL escaping fix and dependency vulnerability patches
+
 ## 1.0.0-rc.12
 
 ### Patch Changes

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/orm",
-  "version": "1.0.0-rc.12",
+  "version": "1.0.0-rc.13",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @guren/server
 
+## 1.0.0-rc.14
+
+### Minor Changes
+
+- Secure-by-default hardening and AI-agent tooling:
+
+  - `guren audit` command: validates auth/validation coverage on mutating routes, detects raw SQL, secrets, and mass assignment risks
+  - `make:feature` now scaffolds auth checks by default (`--public` to opt out) and supports `--policy`
+  - Authorization gate wiring, hardened auth/storage/mail/error rendering
+  - Inertia asset version mismatch handling
+  - drizzle-orm / drizzle-kit upgraded to 1.0.0-rc.1
+  - Migration tracker SQL escaping fix and dependency vulnerability patches
+
+### Patch Changes
+
+- Updated dependencies
+  - @guren/inertia-client@1.0.0-rc.13
+
 ## 1.0.0-rc.13
 
 ### Patch Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/server",
-  "version": "1.0.0-rc.13",
+  "version": "1.0.0-rc.14",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -105,7 +105,7 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@guren/inertia-client": "^1.0.0-rc.12",
+    "@guren/inertia-client": "^1.0.0-rc.13",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "chalk": "^5.3.0",
     "consola": "^3.4.2",

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @guren/testing
 
+## 1.0.0-rc.14
+
+### Patch Changes
+
+- Secure-by-default hardening and AI-agent tooling:
+
+  - `guren audit` command: validates auth/validation coverage on mutating routes, detects raw SQL, secrets, and mass assignment risks
+  - `make:feature` now scaffolds auth checks by default (`--public` to opt out) and supports `--policy`
+  - Authorization gate wiring, hardened auth/storage/mail/error rendering
+  - Inertia asset version mismatch handling
+  - drizzle-orm / drizzle-kit upgraded to 1.0.0-rc.1
+  - Migration tracker SQL escaping fix and dependency vulnerability patches
+
+- Updated dependencies
+  - @guren/server@1.0.0-rc.14
+
 ## 1.0.0-rc.13
 
 ### Patch Changes

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/testing",
-  "version": "1.0.0-rc.13",
+  "version": "1.0.0-rc.14",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -35,7 +35,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@guren/server": ">=1.0.0-rc.13",
+    "@guren/server": ">=1.0.0-rc.14",
     "@inertiajs/react": "^2.3.18",
     "@testing-library/react": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "hono": "^4.12.18",

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,16 @@
 # web
 
+## 0.1.1-rc.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @guren/cli@1.0.0-rc.16
+  - @guren/core@1.0.0-rc.14
+  - @guren/orm@1.0.0-rc.13
+  - @guren/testing@1.0.0-rc.14
+  - @guren/inertia-client@1.0.0-rc.13
+
 ## 0.1.1-rc.8
 
 ### Patch Changes

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.1-rc.8",
+  "version": "0.1.1-rc.9",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Add changeset covering unreleased work since v1.0.0-rc.18 (secure-by-default hardening, `guren audit`, policy-aware scaffolding, Inertia asset version handling, drizzle 1.0.0-rc.1, dependency patches)
- `changeset version` output: @guren/server 1.0.0-rc.14, @guren/cli 1.0.0-rc.16, @guren/core 1.0.0-rc.14, create-guren-app 1.0.0-rc.18, etc.

## Release plan
After merge, publish GitHub Release `v1.0.0-rc.19` to trigger the npm publish workflow.