### PR TITLE
fix: repair scaffold-to-runtime golden path found by npm dogfooding

### DIFF
--- a/.changeset/dogfood-dx-fixes.md
+++ b/.changeset/dogfood-dx-fixes.md
@@ -1,0 +1,21 @@
+---
+"@guren/server": patch
+"@guren/orm": patch
+"@guren/cli": minor
+"@guren/inertia-client": patch
+"create-guren-app": patch
+"@guren/core": patch
+"@guren/testing": patch
+"@guren/openapi": patch
+---
+
+Fix critical scaffold-to-runtime breakages found by dogfooding the published packages:
+
+- **@guren/server**: stop bundling `@guren/orm` (now a real dependency). The bundled copy created a second `Model`/`DrizzleAdapter` instance, so `configureOrm()` never reached `AuthenticatableModel` and every auth query failed with "database has not been configured" in published apps.
+- **@guren/cli `add auth`**: schema updates and the users migration now respect the app's database dialect (sqlite/postgres/mysql) instead of always emitting Postgres SQL; the migration is generated via drizzle-kit instead of a loose `.sql` file that `db:migrate` never executed; `createApp()` is patched with `auth: {}` so sessions and CSRF actually mount.
+- **@guren/cli `add resource`**: honors `--fields` (previously silently ignored) and adds `--public`; delegates file generation to the `make:feature` templates; registers the route group with typed body contracts — the previous insertion regex never matched the starter template, so routes were silently never registered.
+- **@guren/cli `codegen`**: generates route/data/channel/API-client artifacts by default (previously skipped silently unless `--routes` was passed, leaving `routes.gen.ts` empty).
+- **@guren/orm**: warn when the migrations folder contains loose `.sql` files that the drizzle migrator will not execute; export `jsonb` from `@guren/orm/drizzle`.
+- **@guren/inertia-client**: add missing `./typed-forms` and `./components` export map entries (imports failed to resolve in published apps).
+- **create-guren-app**: `--auth` now runs after dependency installation using the app-local CLI and reports failures honestly (previously it always failed silently when run via bunx, yet printed a success message).
+- Docs: quick start now pins `create-guren-app@rc` (npm `latest` still points at the old 0.2.0 alpha) and reflects the SQLite default.

--- a/README.md
+++ b/README.md
@@ -15,13 +15,11 @@ Routing, controllers, ORM, authentication, and Inertia.js + React frontend integ
 ## Quick Start
 
 ```bash
-# 1. Scaffold a new app
-bunx create-guren-app my-app
+# 1. Scaffold a new app with authentication (dependencies install automatically)
+bunx create-guren-app@rc my-app --auth
 cd my-app
-bun install
 
-# 2. Start the database and run migrations
-bun run db:up
+# 2. Run migrations and seed the demo user (SQLite by default — no server needed)
 bun run db:migrate
 bun run db:seed
 
@@ -29,7 +27,9 @@ bun run db:seed
 bun run dev
 ```
 
-Open `http://localhost:3000` and sign in at `/login` with `demo@example.com` / `secret`.
+Open `http://localhost:3333` and sign in at `/login` with `demo@example.com` / `secret`.
+
+> Guren is on the `rc` npm dist-tag while 1.0 stabilizes — always include `@rc` when running `bunx create-guren-app`.
 
 ### Add features as you go
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "examples/api": {
       "name": "@guren/example-api",
-      "version": "0.1.1-rc.9",
+      "version": "0.1.1-rc.10",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -67,7 +67,7 @@
     },
     "packages/cli": {
       "name": "@guren/cli",
-      "version": "1.0.0-rc.15",
+      "version": "1.0.0-rc.16",
       "bin": {
         "guren": "./dist/bin.js",
       },
@@ -91,7 +91,7 @@
     },
     "packages/core": {
       "name": "@guren/core",
-      "version": "1.0.0-rc.13",
+      "version": "1.0.0-rc.14",
       "bin": {
         "guren": "./dist/bin.js",
       },
@@ -108,7 +108,7 @@
     },
     "packages/create-app": {
       "name": "create-guren-app",
-      "version": "1.0.0-rc.17",
+      "version": "1.0.0-rc.18",
       "bin": {
         "create-guren-app": "./dist/cli.js",
       },
@@ -124,7 +124,7 @@
     },
     "packages/inertia-client": {
       "name": "@guren/inertia-client",
-      "version": "1.0.0-rc.12",
+      "version": "1.0.0-rc.13",
       "dependencies": {
         "@inertiajs/core": "^2.3.18",
         "@inertiajs/react": "^2.3.18",
@@ -140,7 +140,7 @@
     },
     "packages/openapi": {
       "name": "@guren/openapi",
-      "version": "1.0.0-rc.13",
+      "version": "1.0.0-rc.14",
       "dependencies": {
         "@guren/core": "^1.0.0-rc.13",
       },
@@ -152,7 +152,7 @@
     },
     "packages/orm": {
       "name": "@guren/orm",
-      "version": "1.0.0-rc.12",
+      "version": "1.0.0-rc.13",
       "dependencies": {
         "drizzle-orm": "1.0.0-rc.1",
       },
@@ -186,9 +186,10 @@
     },
     "packages/server": {
       "name": "@guren/server",
-      "version": "1.0.0-rc.13",
+      "version": "1.0.0-rc.14",
       "dependencies": {
-        "@guren/inertia-client": "^1.0.0-rc.12",
+        "@guren/inertia-client": "^1.0.0-rc.13",
+        "@guren/orm": "^1.0.0-rc.13",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "chalk": "^5.3.0",
         "consola": "^3.4.2",
@@ -219,7 +220,7 @@
     },
     "packages/testing": {
       "name": "@guren/testing",
-      "version": "1.0.0-rc.13",
+      "version": "1.0.0-rc.14",
       "devDependencies": {
         "@types/react": "^19.0.0",
         "tsup": "^8.5.0",
@@ -237,7 +238,7 @@
     },
     "web": {
       "name": "web",
-      "version": "0.1.1-rc.8",
+      "version": "0.1.1-rc.9",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -701,12 +701,18 @@ const codegenCommand = defineCommand({
     })
     if (pagesOutputPath) consola.success(`Page helpers generated at ${pagesOutputPath}`)
 
-    if (!args.routes) {
+    // Route/API artifacts default to routes/web.ts; skip only when no routes file exists.
+    const { existsSync } = await import('node:fs')
+    const { resolve: resolvePath } = await import('node:path')
+    const routesFile = args.routes ?? 'routes/web.ts'
+    const appRoot = args.app ?? process.cwd()
+    if (!existsSync(resolvePath(appRoot, routesFile))) {
+      consola.warn(`Routes file ${routesFile} not found — skipped route, data, channel, and API client generation.`)
       process.exit(0)
     }
 
     const { outputPath, runtimeOutputPath, definitions } = await generateRouteTypes({
-      routesFile: args.routes,
+      routesFile,
       outputFile: args.out,
       appRoot: args.app,
       ...writerOptions,
@@ -1806,6 +1812,14 @@ const addResourceCommand = defineCommand({
       required: true,
       description: 'Resource name (singular)',
     },
+    fields: {
+      type: 'string',
+      description: 'Comma-separated fields, e.g. "title:string,body:text,published:boolean" (append ? for nullable)',
+    },
+    public: {
+      type: 'boolean',
+      description: 'Skip authentication checks in store/update actions',
+    },
     force: {
       type: 'boolean',
       description: 'Overwrite existing files',
@@ -1815,11 +1829,22 @@ const addResourceCommand = defineCommand({
   async run({ args }) {
     const createdFiles = await runBlueprint('resource', {
       name: String(args.name),
+      fields: typeof args.fields === 'string' ? args.fields : undefined,
+      publicAccess: Boolean(args.public),
       force: Boolean(args.force),
     })
 
     for (const file of createdFiles) {
       consola.success(`Created ${file}`)
+    }
+
+    consola.info('')
+    consola.info('Schema and routes were updated automatically. Next steps:')
+    consola.info('  • Run `bun run db:make` to generate the migration')
+    consola.info('  • Run `bun run db:migrate` to apply it')
+    consola.info('  • Run `bun run codegen` (or `bun run dev`) to refresh generated types')
+    if (!args.public) {
+      consola.info('  • store/update require a signed-in user — pass --public to opt out')
     }
   },
 })

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -1,5 +1,6 @@
 import { makeAuth } from './make-auth'
 import { makeChannel } from './make-channel'
+import { makeFeature, parseFieldsString, type FieldDefinition } from './make-feature'
 import { makeController } from './make-controller'
 import { makeEvent } from './make-event'
 import { makeJob } from './make-job'
@@ -9,13 +10,17 @@ import { makeModel } from './make-model'
 import { makeNotification } from './make-notification'
 import { makeRoute } from './make-route'
 import { makeView } from './make-view'
-import { addImport, addProvider, ensureDrizzleImports, ensureSqliteImports } from './patch-helpers'
+import { addImport, addProvider, ensureDrizzleImports, ensureMysqlImports, ensureSqliteImports } from './patch-helpers'
 import { camelCase, kebabCase, pascalCase, writeFilesSafe, type WriterOptions } from './utils'
 import { readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
 export interface RunBlueprintOptions extends WriterOptions {
   name?: string
+  /** Comma-separated field definitions for the resource blueprint, e.g. "title:string,body:text?". */
+  fields?: string
+  /** Skip authentication checks in mutating actions (resource blueprint). */
+  publicAccess?: boolean
 }
 
 export interface BlueprintDefinition {
@@ -613,226 +618,19 @@ export default class BroadcastProvider extends ServiceProvider {
       const collection = pluralizeResourceName(singular)
       const routeName = kebabCase(collection)
       const routeVar = routeName.replace(/-([a-z])/g, (_, char: string) => char.toUpperCase())
-      const variableName = singular.charAt(0).toLowerCase() + singular.slice(1)
-      const writerOptions: WriterOptions = { force: Boolean(options.force) }
+      const fields = parseFieldsString(options.fields ?? '')
 
-      const created = await writeFilesSafe([
-        {
-          path: `app/Http/Validators/${singular}Validator.ts`,
-          contents: `import { z } from 'zod'
+      const created = await makeFeature(singular, {
+        force: Boolean(options.force),
+        fields: options.fields,
+        publicAccess: options.publicAccess,
+        announce: false,
+      })
 
-export const ${singular}IdParamSchema = z.object({
-  id: z.coerce.number().int().positive(),
-})
-
-export const List${collection}QuerySchema = z.object({
-  page: z.coerce.number().int().min(1).default(1),
-})
-
-export const ${singular}PayloadSchema = z.object({
-  title: z.string().trim().min(1, 'Title is required.'),
-  body: z.string().trim().min(1, 'Body is required.'),
-})
-
-export type ${singular}Payload = z.infer<typeof ${singular}PayloadSchema>
-`,
-        },
-        {
-          path: `app/Http/Resources/${singular}Resource.ts`,
-          contents: `import { Resource } from '@guren/core'
-import type { ${singular}Record } from '../../Models/${singular}.js'
-
-export interface ${singular}ResourceData extends Record<string, unknown> {
-  id: number
-  title: string
-  body: string | null
-}
-
-export class ${singular}Resource extends Resource<${singular}Record> {
-  toArray(): ${singular}ResourceData {
-    return {
-      id: this.resource.id as number,
-      title: this.resource.title as string,
-      body: (this.resource.body as string | null) ?? null,
-    }
-  }
-
-  override toJSON(): ${singular}ResourceData {
-    return super.toJSON() as ${singular}ResourceData
-  }
-}
-`,
-        },
-        {
-          path: `app/Http/Controllers/${singular}Controller.ts`,
-          contents: `import { Controller, paginate, type PaginatedPageProps, type ValidationErrors } from '@guren/core'
-import { ${singular} } from '../../Models/${singular}.js'
-import { ${singular}Resource, type ${singular}ResourceData } from '../Resources/${singular}Resource.js'
-import { ${singular}IdParamSchema, ${singular}PayloadSchema, List${collection}QuerySchema } from '../Validators/${singular}Validator.js'
-import { pages } from '../../../.guren/pages.gen.js'
-
-type ${collection}IndexProps = PaginatedPageProps<${singular}ResourceData>
-type ${singular}FormErrors = ValidationErrors<'title' | 'body'>
-
-export default class ${singular}Controller extends Controller {
-  async index(): Promise<Response> {
-    const { page } = this.validateQuery(List${collection}QuerySchema)
-    const result = await ${singular}.paginate({ page, perPage: 10, orderBy: ['id', 'desc'] })
-    const paginator = paginate(result, { path: this.request.path ?? '/${routeName}' })
-
-    return this.inertia(pages.${routeVar}.Index, {
-      data: result.data.map((${variableName}) => new ${singular}Resource(${variableName}).toJSON()),
-      pagination: {
-        meta: paginator.meta(),
-        links: paginator.links(),
-      },
-    } satisfies ${collection}IndexProps, { url: this.request.url ?? this.request.path, title: '${collection}' })
-  }
-
-  async show(): Promise<Response> {
-    const { id } = this.validateParams(${singular}IdParamSchema)
-    const ${variableName} = await ${singular}.findOrFail(id)
-
-    return this.inertia(pages.${routeVar}.Show, {
-      ${variableName}: new ${singular}Resource(${variableName}).toJSON(),
-    }, { url: this.request.path, title: '${singular}' })
-  }
-
-  async create(): Promise<Response> {
-    return this.inertia(pages.${routeVar}.New, {}, { url: this.request.path, title: 'New ${singular}' })
-  }
-
-  async store(): Promise<Response> {
-    const data = await this.validateBody(${singular}PayloadSchema)
-    const ${variableName} = await ${singular}.create(data)
-    return this.redirect('/${routeName}/' + ${variableName}?.id)
-  }
-
-  async edit(): Promise<Response> {
-    const { id } = this.validateParams(${singular}IdParamSchema)
-    const ${variableName} = await ${singular}.findOrFail(id)
-    return this.inertia(pages.${routeVar}.Edit, {
-      ${variableName}: new ${singular}Resource(${variableName}).toJSON(),
-      errors: {} as ${singular}FormErrors,
-    }, { url: this.request.path, title: 'Edit ${singular}' })
-  }
-
-  async update(): Promise<Response> {
-    const { id } = this.validateParams(${singular}IdParamSchema)
-    const data = await this.validateBody(${singular}PayloadSchema)
-    await ${singular}.update({ id }, data)
-    return this.redirect('/${routeName}/' + id)
-  }
-}
-`,
-        },
-        {
-          path: `resources/js/pages/${routeName}/Index.tsx`,
-          contents: `import { Link } from '@inertiajs/react'
-import type { PaginatedPageProps } from '@guren/core'
-import type { ${singular}ResourceData } from '../../../../app/Http/Resources/${singular}Resource.js'
-
-interface Props extends PaginatedPageProps<${singular}ResourceData> {}
-
-export default function ${collection}Index({ data, pagination }: Props) {
-  return (
-    <main className="mx-auto max-w-3xl space-y-6 px-6 py-12">
-      <div className="flex items-center justify-between">
-        <h1 className="text-3xl font-semibold">${collection}</h1>
-        <Link href="/${routeName}/create" className="rounded bg-black px-4 py-2 text-white">New ${singular}</Link>
-      </div>
-      <div className="space-y-4">
-        {data.map((${variableName}) => (
-          <article key={${variableName}.id} className="rounded border p-4">
-            <Link href={'/${routeName}/' + ${variableName}.id} className="text-xl font-medium">${'${'}${variableName}.title}</Link>
-            <p className="mt-2 text-sm text-zinc-600">${'${'}${variableName}.body ?? ''}</p>
-          </article>
-        ))}
-      </div>
-      <nav className="flex gap-2">
-        {pagination.links.pages.map((page) => (
-          <Link key={page.page} href={page.url ?? '#'} className="rounded border px-3 py-1">
-            {page.page}
-          </Link>
-        ))}
-      </nav>
-    </main>
-  )
-}
-`,
-        },
-        {
-          path: `resources/js/pages/${routeName}/Show.tsx`,
-          contents: `import { Link } from '@inertiajs/react'
-import type { ${singular}ResourceData } from '../../../../app/Http/Resources/${singular}Resource.js'
-
-interface Props {
-  ${variableName}: ${singular}ResourceData
-}
-
-export default function ${singular}Show({ ${variableName} }: Props) {
-  return (
-    <main className="mx-auto max-w-3xl space-y-6 px-6 py-12">
-      <Link href="/${routeName}">Back</Link>
-      <h1 className="text-3xl font-semibold">{${variableName}.title}</h1>
-      <p>{${variableName}.body ?? ''}</p>
-      <Link href={'/${routeName}/' + ${variableName}.id + '/edit'}>Edit</Link>
-    </main>
-  )
-}
-`,
-        },
-        {
-          path: `resources/js/pages/${routeName}/New.tsx`,
-          contents: `import { useForm } from '@inertiajs/react'
-
-export default function New${singular}() {
-  const form = useForm({ title: '', body: '' })
-  return (
-    <main className="mx-auto max-w-3xl px-6 py-12">
-      <form className="space-y-4" onSubmit={(event) => { event.preventDefault(); form.post('/${routeName}') }}>
-        <input value={form.data.title} onChange={(event) => form.setData('title', event.target.value)} placeholder="Title" className="w-full rounded border px-3 py-2" />
-        <textarea value={form.data.body} onChange={(event) => form.setData('body', event.target.value)} placeholder="Body" className="w-full rounded border px-3 py-2" />
-        <button type="submit" className="rounded bg-black px-4 py-2 text-white">Create</button>
-      </form>
-    </main>
-  )
-}
-`,
-        },
-        {
-          path: `resources/js/pages/${routeName}/Edit.tsx`,
-          contents: `import { useForm } from '@inertiajs/react'
-import type { ${singular}ResourceData } from '../../../../app/Http/Resources/${singular}Resource.js'
-import type { ValidationErrors } from '@guren/core'
-
-interface Props {
-  ${variableName}: ${singular}ResourceData
-  errors?: ValidationErrors<'title' | 'body'>
-}
-
-export default function Edit${singular}({ ${variableName} }: Props) {
-  const form = useForm({ title: ${variableName}.title, body: ${variableName}.body ?? '' })
-  return (
-    <main className="mx-auto max-w-3xl px-6 py-12">
-      <form className="space-y-4" onSubmit={(event) => { event.preventDefault(); form.put('/${routeName}/' + ${variableName}.id) }}>
-        <input value={form.data.title} onChange={(event) => form.setData('title', event.target.value)} className="w-full rounded border px-3 py-2" />
-        <textarea value={form.data.body} onChange={(event) => form.setData('body', event.target.value)} className="w-full rounded border px-3 py-2" />
-        <button type="submit" className="rounded bg-black px-4 py-2 text-white">Save</button>
-      </form>
-    </main>
-  )
-}
-`,
-        },
-      ], writerOptions)
-
-      await updateResourceSchema(collection, routeName)
-      const modelPath = await makeModel(singular, writerOptions)
-      await updateResourceContracts(singular, collection, routeName, routeVar, variableName)
+      await updateResourceSchema(collection, routeName, fields)
       await updateResourceRoutes(singular, routeName, routeVar)
 
-      return [...created, modelPath]
+      return created
     },
   },
   schedule: {
@@ -872,14 +670,67 @@ export default scheduleTasksKernel
   },
 }
 
-async function detectSchemaDialect(content: string): Promise<'sqlite' | 'pg'> {
+async function detectSchemaDialect(content: string): Promise<'sqlite' | 'pg' | 'mysql'> {
   if (content.includes('sqliteTable') || content.includes('drizzle-orm/sqlite-core')) {
     return 'sqlite'
+  }
+  if (content.includes('mysqlTable') || content.includes('drizzle-orm/mysql-core')) {
+    return 'mysql'
   }
   return 'pg'
 }
 
-async function updateResourceSchema(collection: string, routeName: string): Promise<void> {
+function sqliteColumn(field: FieldDefinition): { code: string; imports: string[] } {
+  const notNull = field.nullable ? '' : '.notNull()'
+  switch (field.type) {
+    case 'number':
+      return { code: `integer('${snakeCase(field.name)}')${notNull}`, imports: ['integer'] }
+    case 'boolean':
+      return { code: `integer('${snakeCase(field.name)}', { mode: 'boolean' })${notNull}`, imports: ['integer'] }
+    case 'json':
+      return { code: `text('${snakeCase(field.name)}', { mode: 'json' })${notNull}`, imports: ['text'] }
+    default:
+      return { code: `text('${snakeCase(field.name)}')${notNull}`, imports: ['text'] }
+  }
+}
+
+function pgColumn(field: FieldDefinition): { code: string; imports: string[] } {
+  const notNull = field.nullable ? '' : '.notNull()'
+  switch (field.type) {
+    case 'number':
+      return { code: `integer('${snakeCase(field.name)}')${notNull}`, imports: ['integer'] }
+    case 'boolean':
+      return { code: `boolean('${snakeCase(field.name)}')${notNull}`, imports: ['boolean'] }
+    case 'date':
+      return { code: `timestamp('${snakeCase(field.name)}', { withTimezone: false })${notNull}`, imports: ['timestamp'] }
+    case 'json':
+      return { code: `jsonb('${snakeCase(field.name)}')${notNull}`, imports: ['jsonb'] }
+    default:
+      return { code: `text('${snakeCase(field.name)}')${notNull}`, imports: ['text'] }
+  }
+}
+
+function mysqlColumn(field: FieldDefinition): { code: string; imports: string[] } {
+  const notNull = field.nullable ? '' : '.notNull()'
+  switch (field.type) {
+    case 'number':
+      return { code: `int('${snakeCase(field.name)}')${notNull}`, imports: ['int'] }
+    case 'boolean':
+      return { code: `boolean('${snakeCase(field.name)}')${notNull}`, imports: ['boolean'] }
+    case 'date':
+      return { code: `timestamp('${snakeCase(field.name)}')${notNull}`, imports: ['timestamp'] }
+    case 'json':
+      return { code: `json('${snakeCase(field.name)}')${notNull}`, imports: ['json'] }
+    default:
+      return { code: `varchar('${snakeCase(field.name)}', { length: 255 })${notNull}`, imports: ['varchar'] }
+  }
+}
+
+function snakeCase(value: string): string {
+  return value.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase()
+}
+
+async function updateResourceSchema(collection: string, routeName: string, fields: FieldDefinition[]): Promise<void> {
   const schemaPath = resolve(process.cwd(), 'db/schema.ts')
   let content = await readFile(schemaPath, 'utf8')
   const schemaIdentifier = camelCase(collection)
@@ -892,9 +743,25 @@ async function updateResourceSchema(collection: string, routeName: string): Prom
       return
     }
 
-    content = ensureSqliteImports(content, ['sqliteTable', 'integer', 'text'])
+    const columns = fields.map((field) => sqliteColumn(field))
+    const imports = [...new Set(['sqliteTable', 'integer', 'text', ...columns.flatMap((c) => c.imports)])]
+    content = ensureSqliteImports(content, imports)
 
-    const schemaBlock = `\nexport const ${schemaIdentifier} = sqliteTable('${tableName}', {\n  id: integer('id').primaryKey({ autoIncrement: true }),\n  title: text('title').notNull(),\n  body: text('body'),\n  createdAt: text('created_at').notNull().$defaultFn(() => new Date().toISOString()),\n})\n`
+    const fieldLines = fields.map((field, index) => `  ${field.name}: ${columns[index].code},`).join('\n')
+    const schemaBlock = `\nexport const ${schemaIdentifier} = sqliteTable('${tableName}', {\n  id: integer('id').primaryKey({ autoIncrement: true }),\n${fieldLines}\n  createdAt: text('created_at').notNull().$defaultFn(() => new Date().toISOString()),\n})\n`
+
+    content = `${content.trimEnd()}\n${schemaBlock}`
+  } else if (dialect === 'mysql') {
+    if (content.includes(`export const ${schemaIdentifier} = mysqlTable(`)) {
+      return
+    }
+
+    const columns = fields.map((field) => mysqlColumn(field))
+    const imports = [...new Set(['mysqlTable', 'int', 'timestamp', ...columns.flatMap((c) => c.imports)])]
+    content = ensureMysqlImports(content, imports)
+
+    const fieldLines = fields.map((field, index) => `  ${field.name}: ${columns[index].code},`).join('\n')
+    const schemaBlock = `\nexport const ${schemaIdentifier} = mysqlTable('${tableName}', {\n  id: int('id').primaryKey().autoincrement(),\n${fieldLines}\n  createdAt: timestamp('created_at').defaultNow().notNull(),\n})\n`
 
     content = `${content.trimEnd()}\n${schemaBlock}`
   } else {
@@ -902,9 +769,12 @@ async function updateResourceSchema(collection: string, routeName: string): Prom
       return
     }
 
-    content = ensureDrizzleImports(content, ['pgTable', 'serial', 'text', 'timestamp'])
+    const columns = fields.map((field) => pgColumn(field))
+    const imports = [...new Set(['pgTable', 'serial', 'text', 'timestamp', ...columns.flatMap((c) => c.imports)])]
+    content = ensureDrizzleImports(content, imports)
 
-    const schemaBlock = `\nexport const ${schemaIdentifier} = pgTable('${tableName}', {\n  id: serial('id').primaryKey(),\n  title: text('title').notNull(),\n  body: text('body'),\n  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),\n})\n`
+    const fieldLines = fields.map((field, index) => `  ${field.name}: ${columns[index].code},`).join('\n')
+    const schemaBlock = `\nexport const ${schemaIdentifier} = pgTable('${tableName}', {\n  id: serial('id').primaryKey(),\n${fieldLines}\n  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),\n})\n`
 
     content = `${content.trimEnd()}\n${schemaBlock}`
   }
@@ -912,20 +782,12 @@ async function updateResourceSchema(collection: string, routeName: string): Prom
   await writeFile(schemaPath, content, 'utf8')
 }
 
-async function updateResourceContracts(
-  _singular: string,
-  _collection: string,
-  _routeName: string,
-  _routeVar: string,
-  _variableName: string,
-): Promise<void> {
-}
-
 async function updateResourceRoutes(singular: string, routeName: string, routeVar: string): Promise<void> {
   const controllerName = `${singular}Controller`
   const routesPath = resolve(process.cwd(), 'routes/web.ts')
   let content = await readFile(routesPath, 'utf8')
   const controllerImport = `import ${controllerName} from '../app/Http/Controllers/${controllerName}.js'`
+  const validatorImport = `import { ${singular}PayloadSchema } from '../app/Http/Validators/${singular}Validator.js'`
 
   if (!content.includes(controllerImport)) {
     content = content.replace(
@@ -934,11 +796,48 @@ async function updateResourceRoutes(singular: string, routeName: string, routeVa
     )
   }
 
-  if (!content.includes(`'${routeName}.index'`) && !content.includes(`/${routeName}`)) {
-    const groupBlock = `  router.group('/${routeName}', (${routeVar}) => {\n    ${routeVar}.get('/', [${controllerName}, 'index']).name('${routeName}.index')\n    ${routeVar}.get('/create', [${controllerName}, 'create']).name('${routeName}.create')\n    ${routeVar}.get('/:id', [${controllerName}, 'show']).name('${routeName}.show')\n    ${routeVar}.get('/:id/edit', [${controllerName}, 'edit']).name('${routeName}.edit')\n    ${routeVar}.post('/', [${controllerName}, 'store']).name('${routeName}.store')\n    ${routeVar}.put('/:id', [${controllerName}, 'update']).name('${routeName}.update')\n  })\n`
-    content = content.replace(/\n\}\n(?:\n)?export default/u, `\n${groupBlock}}\n\nexport default`)
-    await writeFile(routesPath, content, 'utf8')
+  if (!content.includes(validatorImport)) {
+    content = content.replace(
+      /(import[^\n]+\n)(\n)?export function/u,
+      `$1${validatorImport}\n\nexport function`,
+    )
   }
+
+  if (!content.includes(`'${routeName}.index'`) && !content.includes(`/${routeName}'`)) {
+    const groupBlock = `\n  router.group('/${routeName}', (${routeVar}) => {\n    ${routeVar}.get('/', [${controllerName}, 'index']).name('${routeName}.index')\n    ${routeVar}.get('/create', [${controllerName}, 'create']).name('${routeName}.create')\n    ${routeVar}.get('/:id', [${controllerName}, 'show']).name('${routeName}.show')\n    ${routeVar}.get('/:id/edit', [${controllerName}, 'edit']).name('${routeName}.edit')\n    ${routeVar}.post('/', { name: '${routeName}.store', body: ${singular}PayloadSchema }, [${controllerName}, 'store'])\n    ${routeVar}.put('/:id', { name: '${routeName}.update', body: ${singular}PayloadSchema }, [${controllerName}, 'update'])\n  })\n`
+
+    // Insert before the closing brace of the route registrar function.
+    const registrarMatch = content.match(/export function [^(]*\(\s*router\s*:\s*Router\s*\)[^{]*\{/u)
+    let inserted = false
+    if (registrarMatch && registrarMatch.index !== undefined) {
+      const openIndex = registrarMatch.index + registrarMatch[0].length - 1
+      let depth = 0
+      let closeIndex = -1
+      for (let i = openIndex; i < content.length; i++) {
+        const char = content[i]
+        if (char === '{') depth++
+        else if (char === '}') {
+          depth--
+          if (depth === 0) {
+            closeIndex = i
+            break
+          }
+        }
+      }
+      if (closeIndex !== -1) {
+        content = content.slice(0, closeIndex) + groupBlock + content.slice(closeIndex)
+        inserted = true
+      }
+    }
+
+    if (!inserted) {
+      throw new Error(
+        `Could not find a route registrar in routes/web.ts. Register the /${routeName} routes manually.`,
+      )
+    }
+  }
+
+  await writeFile(routesPath, content, 'utf8')
 }
 
 export function listBlueprints(): string[] {

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -2,20 +2,15 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { dirname, relative, resolve, sep as pathSep } from 'node:path'
 import { consola } from 'consola'
 import { writeFilesSafe, type WriterOptions } from './utils'
-import { addImport, addProvider, ensureDrizzleImports } from './patch-helpers'
-
-function timestamp(): string {
-  const now = new Date()
-  const pad = (value: number, size = 2) => value.toString().padStart(size, '0')
-  return [
-    now.getUTCFullYear(),
-    pad(now.getUTCMonth() + 1),
-    pad(now.getUTCDate()),
-    pad(now.getUTCHours()),
-    pad(now.getUTCMinutes()),
-    pad(now.getUTCSeconds()),
-  ].join('')
-}
+import {
+  addImport,
+  addProvider,
+  addCreateAppOption,
+  ensureDrizzleImports,
+  ensureMysqlImports,
+  ensureSqliteImports,
+} from './patch-helpers'
+import { makeMigration } from './make-migration'
 
 const loginControllerTemplate = `import { Controller, ValidationException } from '@guren/core'
 import { LoginSchema } from '@/Http/Validators/LoginValidator'
@@ -515,18 +510,50 @@ export default defineSeeder(async ({ db }) => {
 })
 `
 
-const migrationTemplate = `CREATE TABLE IF NOT EXISTS users (
-  id SERIAL PRIMARY KEY,
-  name TEXT NOT NULL,
-  email TEXT NOT NULL UNIQUE,
-  password_hash TEXT NOT NULL,
-  remember_token TEXT,
-  created_at TIMESTAMP DEFAULT NOW() NOT NULL,
-  updated_at TIMESTAMP DEFAULT NOW() NOT NULL
-);
+type SchemaDialect = 'sqlite' | 'pg' | 'mysql'
 
-CREATE UNIQUE INDEX IF NOT EXISTS users_email_unique ON users (email);
-`
+function detectSchemaDialect(content: string): SchemaDialect {
+  if (content.includes('sqliteTable') || content.includes('drizzle-orm/sqlite-core')) {
+    return 'sqlite'
+  }
+  if (content.includes('mysqlTable') || content.includes('drizzle-orm/mysql-core')) {
+    return 'mysql'
+  }
+  return 'pg'
+}
+
+const usersTableBlocks: Record<SchemaDialect, string> = {
+  sqlite: `export const users = sqliteTable('users', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  name: text('name').notNull(),
+  email: text('email').notNull().unique(),
+  passwordHash: text('password_hash').notNull(),
+  rememberToken: text('remember_token'),
+  createdAt: text('created_at').notNull().$defaultFn(() => new Date().toISOString()),
+  updatedAt: text('updated_at').notNull().$defaultFn(() => new Date().toISOString()),
+})
+`,
+  pg: `export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  name: text('name').notNull(),
+  email: text('email').notNull().unique(),
+  passwordHash: text('password_hash').notNull(),
+  rememberToken: text('remember_token'),
+  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: false }).defaultNow().notNull(),
+})
+`,
+  mysql: `export const users = mysqlTable('users', {
+  id: int('id').primaryKey().autoincrement(),
+  name: varchar('name', { length: 255 }).notNull(),
+  email: varchar('email', { length: 255 }).notNull().unique(),
+  passwordHash: varchar('password_hash', { length: 255 }).notNull(),
+  rememberToken: varchar('remember_token', { length: 255 }),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+})
+`,
+}
 
 async function updateSchema(): Promise<void> {
   const schemaPath = resolve(process.cwd(), 'db/schema.ts')
@@ -546,29 +573,22 @@ async function updateSchema(): Promise<void> {
     return
   }
 
-  // Replace SQLite-specific imports with Postgres imports when switching adapters
-  content = content.replace(
-    /import\s*\{[^}]*\}\s*from\s*['"]drizzle-orm\/sqlite-core['"]\s*\n?/,
-    '',
-  )
+  // Keep the schema in the dialect the app was scaffolded with
+  const dialect = detectSchemaDialect(content)
 
-  // Ensure required Drizzle imports are present
-  content = ensureDrizzleImports(content, ['pgTable', 'serial', 'text', 'timestamp'])
+  if (dialect === 'sqlite') {
+    content = ensureSqliteImports(content, ['sqliteTable', 'integer', 'text'])
+  } else if (dialect === 'mysql') {
+    content = ensureMysqlImports(content, ['mysqlTable', 'int', 'varchar', 'timestamp'])
+  } else {
+    content = ensureDrizzleImports(content, ['pgTable', 'serial', 'text', 'timestamp'])
+  }
 
   // Replace an existing users table that lacks auth columns, or append if absent
-  // Match both pgTable and sqliteTable variants — use `})` on its own line as the end anchor
-  // to avoid premature matching inside nested function calls like `$defaultFn(() => ...)`
-  const usersTablePattern = /export const users = (?:pgTable|sqliteTable)\('users',\s*\{[\s\S]*?\n\}\)\s*\n?/
-  const usersTableBlock = `export const users = pgTable('users', {
-  id: serial('id').primaryKey(),
-  name: text('name').notNull(),
-  email: text('email').notNull(),
-  passwordHash: text('password_hash').notNull(),
-  rememberToken: text('remember_token'),
-  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: false }).defaultNow().notNull(),
-})
-`
+  // Use `})` on its own line as the end anchor to avoid premature matching
+  // inside nested function calls like `$defaultFn(() => ...)`
+  const usersTablePattern = /export const users = (?:pgTable|sqliteTable|mysqlTable)\('users',\s*\{[\s\S]*?\n\}\)\s*\n?/
+  const usersTableBlock = usersTableBlocks[dialect]
 
   if (usersTablePattern.test(content)) {
     content = content.replace(usersTablePattern, usersTableBlock)
@@ -577,7 +597,26 @@ async function updateSchema(): Promise<void> {
   }
 
   await writeFile(schemaPath, content, 'utf8')
-  consola.info('Updated db/schema.ts with authentication columns.')
+  consola.info(`Updated db/schema.ts with authentication columns (${dialect}).`)
+}
+
+async function generateUsersMigration(): Promise<boolean> {
+  const { existsSync } = await import('node:fs')
+  if (!existsSync(resolve(process.cwd(), 'node_modules', 'drizzle-kit'))) {
+    consola.info('drizzle-kit is not installed — run `bun run db:make` after `bun install` to generate the users migration.')
+    return false
+  }
+
+  try {
+    await makeMigration({ name: 'create_users_table' })
+    consola.success('Generated users table migration via drizzle-kit.')
+    return true
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    consola.warn(`Could not generate the users migration automatically (${reason}).`)
+    consola.info('Run `bun run db:make` (drizzle-kit generate) to create it from db/schema.ts.')
+    return false
+  }
 }
 
 async function updatePageContracts(): Promise<void> {
@@ -588,7 +627,6 @@ export interface MakeAuthOptions extends WriterOptions {
 }
 
 export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]> {
-  const migrationPath = `db/migrations/${timestamp()}_create_users_table.sql`
   const created = await writeFilesSafe([
     { path: 'app/Http/Controllers/Auth/LoginController.ts', contents: loginControllerTemplate },
     { path: 'app/Http/Controllers/DashboardController.ts', contents: dashboardControllerTemplate },
@@ -602,29 +640,31 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
     { path: 'resources/js/pages/dashboard/Index.tsx', contents: dashboardViewTemplate },
     { path: 'resources/js/pages/profile/Edit.tsx', contents: profileViewTemplate },
     { path: 'routes/auth.ts', contents: routesTemplate },
-    { path: migrationPath, contents: migrationTemplate },
     { path: 'db/seeders/UsersSeeder.ts', contents: seederTemplate },
   ], options)
 
   await updateSchema()
   await updatePageContracts()
+  const migrationGenerated = await generateUsersMigration()
 
   if (options.install) {
-    await installAuth()
+    await installAuth(migrationGenerated)
   } else {
     consola.info('Next steps:')
     consola.info('  • Register AuthProvider in src/app.ts providers array')
+    consola.info('  • Enable sessions and CSRF by adding `auth: {}` to your createApp() options')
     consola.info('  • Import registerAuthRoutes from routes/auth.ts and call it from your routes/web.ts registrar')
+    if (!migrationGenerated) {
+      consola.info('  • Run `bun run db:make` to generate the users migration')
+    }
     consola.info('  • Run `bun run db:migrate` and `bun run db:seed`')
     consola.info('  • Install zod if not already installed: `bun add zod`')
-    consola.info('')
-    consola.info('Session middleware is auto-configured when AuthProvider is registered.')
   }
 
   return created
 }
 
-async function installAuth(): Promise<void> {
+async function installAuth(migrationGenerated = true): Promise<void> {
   consola.info('Installing authentication configuration...')
 
   // Determine app file location (try src/app.ts first, then app.ts)
@@ -673,6 +713,18 @@ async function installAuth(): Promise<void> {
     consola.warn(`Could not add AuthProvider: ${providerResult.reason}`)
   }
 
+  // Enable session + CSRF middleware: AuthServiceProvider is only registered
+  // when createApp() receives an `auth` option.
+  const authOptionResult = await addCreateAppOption(appPath, 'auth', '{}')
+  if (authOptionResult.modified) {
+    consola.success(`Enabled sessions and CSRF via auth option in ${appPath}`)
+  } else if (authOptionResult.reason === 'Option already set') {
+    consola.info(`auth option already set in ${appPath}`)
+  } else {
+    consola.warn(`Could not set the auth option automatically: ${authOptionResult.reason}`)
+    consola.info('Add `auth: {}` to your createApp() options to enable sessions and CSRF.')
+  }
+
   // Add auth routes import to routes/web.ts
   const webRoutesPath = 'routes/web.ts'
   try {
@@ -706,7 +758,10 @@ async function installAuth(): Promise<void> {
   consola.success('Authentication configuration installed!')
   consola.info('Session middleware is auto-configured via AuthServiceProvider (autoSession: true)')
   consola.info('Next steps:')
+  if (!migrationGenerated) {
+    consola.info('  • Run `bun run db:make` to generate the users migration')
+  }
   consola.info('  • Run `bun run db:migrate` to create the users table')
   consola.info('  • Run `bun run db:seed` to create demo user')
-  consola.info('  • Start the dev server and visit /login')
+  consola.info('  • Start the dev server and visit /login (demo@example.com / secret)')
 }

--- a/packages/cli/src/make-feature.ts
+++ b/packages/cli/src/make-feature.ts
@@ -18,6 +18,8 @@ export interface MakeFeatureOptions extends WriterOptions {
   publicAccess?: boolean
   /** Also generate an authorization policy and enforce it in mutating actions. */
   withPolicy?: boolean
+  /** Print created files and next steps (default: true). Callers that wire routes/schema themselves pass false. */
+  announce?: boolean
 }
 
 const DEFAULT_FIELDS: FieldDefinition[] = [
@@ -106,6 +108,10 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
     } catch {
       // Ignore if test creation fails
     }
+  }
+
+  if (options.announce === false) {
+    return created
   }
 
   for (const file of created) {
@@ -476,22 +482,26 @@ ${formFields}
 }
 
 function generateFormField(field: FieldDefinition, formVar: string): string {
+  // Nullable fields are typed `T | null | undefined` — coalesce for controlled inputs.
+  const stringValue = field.nullable ? `${formVar}.data.${field.name} ?? ''` : `${formVar}.data.${field.name}`
   if (field.type === 'boolean') {
+    const checkedValue = field.nullable ? `${formVar}.data.${field.name} ?? false` : `${formVar}.data.${field.name}`
     return `        <label className="flex items-center gap-2">
-          <input type="checkbox" checked={${formVar}.data.${field.name}} onChange={(event) => ${formVar}.setData('${field.name}', event.target.checked)} />
+          <input type="checkbox" checked={${checkedValue}} onChange={(event) => ${formVar}.setData('${field.name}', event.target.checked)} />
           ${field.name}
         </label>`
   }
   if (field.type === 'text') {
-    return `        <textarea value={${formVar}.data.${field.name}} onChange={(event) => ${formVar}.setData('${field.name}', event.target.value)} placeholder="${field.name}" className="w-full rounded border px-3 py-2" />`
+    return `        <textarea value={${stringValue}} onChange={(event) => ${formVar}.setData('${field.name}', event.target.value)} placeholder="${field.name}" className="w-full rounded border px-3 py-2" />`
   }
   if (field.type === 'number') {
-    return `        <input type="number" value={${formVar}.data.${field.name}} onChange={(event) => ${formVar}.setData('${field.name}', Number(event.target.value))} placeholder="${field.name}" className="w-full rounded border px-3 py-2" />`
+    const numberValue = field.nullable ? `${formVar}.data.${field.name} ?? 0` : `${formVar}.data.${field.name}`
+    return `        <input type="number" value={${numberValue}} onChange={(event) => ${formVar}.setData('${field.name}', Number(event.target.value))} placeholder="${field.name}" className="w-full rounded border px-3 py-2" />`
   }
   if (field.type === 'date') {
-    return `        <input type="date" value={${formVar}.data.${field.name}} onChange={(event) => ${formVar}.setData('${field.name}', event.target.value)} className="w-full rounded border px-3 py-2" />`
+    return `        <input type="date" value={${stringValue}} onChange={(event) => ${formVar}.setData('${field.name}', event.target.value)} className="w-full rounded border px-3 py-2" />`
   }
-  return `        <input value={${formVar}.data.${field.name}} onChange={(event) => ${formVar}.setData('${field.name}', event.target.value)} placeholder="${field.name}" className="w-full rounded border px-3 py-2" />`
+  return `        <input value={${stringValue}} onChange={(event) => ${formVar}.setData('${field.name}', event.target.value)} placeholder="${field.name}" className="w-full rounded border px-3 py-2" />`
 }
 
 function pluralize(name: string): string {

--- a/packages/cli/src/patch-helpers.ts
+++ b/packages/cli/src/patch-helpers.ts
@@ -189,3 +189,89 @@ export function ensureSqliteImports(content: string, needed: string[]): string {
 
   return `import { ${missing.sort().join(', ')} } from 'drizzle-orm/sqlite-core'\n${content}`
 }
+
+export function ensureMysqlImports(content: string, needed: string[]): string {
+  const importLines = content.split('\n').filter((line) => line.trimStart().startsWith('import '))
+  const importContent = importLines.join('\n')
+
+  const missing = needed.filter(
+    (name) => !new RegExp(`\\b${name}\\b`).test(importContent),
+  )
+
+  if (missing.length === 0) {
+    return content
+  }
+
+  const existingMysqlImport = /import\s*\{([^}]+)\}\s*from\s*['"]drizzle-orm\/mysql-core['"]/
+  const match = content.match(existingMysqlImport)
+
+  if (match) {
+    const existingNames = match[1].split(',').map((s) => s.trim()).filter(Boolean)
+    const allNames = [...new Set([...existingNames, ...missing])].sort()
+    return content.replace(existingMysqlImport, `import { ${allNames.join(', ')} } from 'drizzle-orm/mysql-core'`)
+  }
+
+  return `import { ${missing.sort().join(', ')} } from 'drizzle-orm/mysql-core'\n${content}`
+}
+
+/**
+ * Adds a top-level option to the createApp({ ... }) call in a file.
+ * The value is inserted verbatim, e.g. addCreateAppOption(path, 'auth', '{}').
+ */
+export async function addCreateAppOption(
+  filePath: string,
+  key: string,
+  valueSource: string,
+): Promise<PatchResult> {
+  const absolutePath = resolve(process.cwd(), filePath)
+  let content: string
+
+  try {
+    content = await readFile(absolutePath, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { modified: false, reason: 'File not found' }
+    }
+    throw error
+  }
+
+  const createAppPattern = /createApp\(\s*\{/
+  const match = content.match(createAppPattern)
+
+  if (!match || match.index === undefined) {
+    return { modified: false, reason: 'Could not find a createApp({ ... }) call' }
+  }
+
+  // Scan the createApp options object for an existing top-level `key:`
+  const openBraceIndex = match.index + match[0].length - 1
+  let depth = 0
+  let closeBraceIndex = -1
+  for (let i = openBraceIndex; i < content.length; i++) {
+    const char = content[i]
+    if (char === '{') depth++
+    else if (char === '}') {
+      depth--
+      if (depth === 0) {
+        closeBraceIndex = i
+        break
+      }
+    }
+  }
+
+  if (closeBraceIndex === -1) {
+    return { modified: false, reason: 'Could not parse createApp options object' }
+  }
+
+  const optionsSource = content.slice(openBraceIndex, closeBraceIndex + 1)
+  const keyPattern = new RegExp(`(^|[{,]\\s*)${key}\\s*:`, 'm')
+  if (keyPattern.test(optionsSource)) {
+    return { modified: false, reason: 'Option already set' }
+  }
+
+  const insertion = `\n  ${key}: ${valueSource},`
+  const updated =
+    content.slice(0, openBraceIndex + 1) + insertion + content.slice(openBraceIndex + 1)
+
+  await writeFile(absolutePath, updated, 'utf8')
+  return { modified: true }
+}

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { createTempWorkspace } from './helpers'
 import { makeAuth } from '../src/make-auth'
@@ -55,7 +55,7 @@ export function registerWebRoutes(router: Router): void {
 
       const created = await makeAuth({ install: true, force: true })
 
-      expect(created).toHaveLength(14)
+      expect(created).toHaveLength(13)
       expect(created).toEqual(expect.arrayContaining([
         expect.stringContaining('LoginController.ts'),
         expect.stringContaining('routes/auth.ts'),
@@ -63,15 +63,13 @@ export function registerWebRoutes(router: Router): void {
         expect.stringContaining('ProfileValidator.ts'),
       ]))
 
-      const migrations = await readdir(join(workspace.dir, 'db/migrations'))
-      expect(migrations.some((name) => name.endsWith('_create_users_table.sql'))).toBe(true)
-
       const schema = await readFile(join(workspace.dir, 'db/schema.ts'), 'utf8')
       expect(schema).toContain('passwordHash')
 
       const appContent = await readFile(join(workspace.dir, 'src/app.ts'), 'utf8')
       expect(appContent).toContain('AuthProvider')
       expect(appContent).toContain('providers: [DatabaseProvider, AuthProvider]')
+      expect(appContent).toContain('auth: {}')
 
       const routesContent = await readFile(join(workspace.dir, 'routes/web.ts'), 'utf8')
       expect(routesContent).toContain("import { registerAuthRoutes } from './auth.js'")

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -3,7 +3,7 @@
 `create-guren-app` scaffolds a new Guren project with a sensible default directory layout.
 
 ```bash
-npx create-guren-app my-app
+npx create-guren-app@rc my-app
 ```
 
 Use `--force` to allow scaffolding into a non-empty directory.

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -40,9 +40,17 @@ async function updateSsrPackageJson(destination: string): Promise<void> {
   await writeFile(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`, 'utf8')
 }
 
-async function installAuthBlueprint(): Promise<void> {
-  const { runBlueprint } = await import('@guren/cli')
-  await runBlueprint('auth', { force: true })
+async function installAuthBlueprint(targetDir: string): Promise<boolean> {
+  // Run the CLI installed in the scaffolded app so the blueprint sees the
+  // app's own dependencies. A bare import of '@guren/cli' from create-guren-app
+  // would fail: it is not a dependency of this package.
+  const { spawnSync } = await import('node:child_process')
+  const cliBin = resolve(targetDir, 'node_modules/@guren/cli/dist/bin.js')
+  const result = spawnSync('bun', [cliBin, 'add', 'auth', '--force'], {
+    cwd: targetDir,
+    stdio: 'inherit',
+  })
+  return result.status === 0
 }
 
 async function resolveRenderingMode(flagValue: unknown): Promise<RenderingMode> {
@@ -192,23 +200,24 @@ const command = defineCommand({
 
     const includeAuth = Boolean(args.auth)
 
-    if (includeAuth) {
-      const originalCwd = process.cwd()
-      try {
-        process.chdir(targetDir)
-        await installAuthBlueprint()
-      } catch (error) {
-        consola.warn('Failed to scaffold authentication automatically. You can run it manually after install with `bunx guren add auth`.')
-        consola.debug(error)
-      } finally {
-        process.chdir(originalCwd)
-      }
-    }
-
     const shouldInstall = args.install !== false
     let installed = false
     if (shouldInstall) {
       installed = await installDependencies(targetDir)
+    }
+
+    let authInstalled = false
+    if (includeAuth) {
+      if (installed) {
+        consola.start('Adding authentication scaffolding...')
+        authInstalled = await installAuthBlueprint(targetDir)
+        if (authInstalled) {
+          consola.success('Authentication scaffolding added')
+        }
+      }
+      if (!authInstalled) {
+        consola.warn('Authentication was not scaffolded automatically. Run `bunx guren add auth` inside the app after installing dependencies.')
+      }
     }
 
     const relativeTarget = relative(process.cwd(), targetDir) || '.'
@@ -240,9 +249,10 @@ const command = defineCommand({
     consola.log('  bun run test')
     consola.log('  bun run dev')
 
-    if (includeAuth) {
+    if (authInstalled) {
       consola.log('')
       consola.info('Auth scaffolding was included automatically.')
+      consola.info('Set up the users table with: bun run db:migrate && bun run db:seed')
     }
 
     if (renderingMode === 'ssr') {

--- a/packages/inertia-client/package.json
+++ b/packages/inertia-client/package.json
@@ -43,6 +43,16 @@
       "import": "./dist/channel.js",
       "default": "./dist/channel.js"
     },
+    "./typed-forms": {
+      "types": "./dist/typed-forms.d.ts",
+      "import": "./dist/typed-forms.js",
+      "default": "./dist/typed-forms.js"
+    },
+    "./components": {
+      "types": "./dist/components.d.ts",
+      "import": "./dist/components.js",
+      "default": "./dist/components.js"
+    },
     "./dist/*": {
       "default": "./dist/*"
     },

--- a/packages/orm/src/drizzle.ts
+++ b/packages/orm/src/drizzle.ts
@@ -9,6 +9,7 @@ export {
   bigint,
   timestamp,
   boolean,
+  jsonb,
   uniqueIndex,
 } from 'drizzle-orm/pg-core'
 

--- a/packages/orm/src/migration-utils.ts
+++ b/packages/orm/src/migration-utils.ts
@@ -1,0 +1,39 @@
+import { existsSync, readdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+/**
+ * Returns true when the folder contains drizzle-kit generated migrations
+ * (subdirectories with a migration.sql file).
+ */
+export function hasDrizzleMigrations(migrationsFolder: string): boolean {
+  if (!existsSync(migrationsFolder)) {
+    return false
+  }
+
+  const entries = readdirSync(migrationsFolder, { withFileTypes: true })
+  return entries.some(
+    (entry) => entry.isDirectory() && existsSync(resolve(migrationsFolder, entry.name, 'migration.sql')),
+  )
+}
+
+/**
+ * Warns when the migrations folder contains loose .sql files, which the
+ * drizzle migrator does not execute. Without this, `db:migrate` reports
+ * success while silently skipping them.
+ */
+export function warnIgnoredFlatSqlMigrations(migrationsFolder: string): void {
+  if (!existsSync(migrationsFolder)) {
+    return
+  }
+
+  const flatSqlFiles = readdirSync(migrationsFolder, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.sql'))
+    .map((entry) => entry.name)
+
+  if (flatSqlFiles.length > 0) {
+    console.warn(
+      `[guren/orm] Ignoring ${flatSqlFiles.length} loose .sql file(s) in ${migrationsFolder}: ${flatSqlFiles.join(', ')}.\n` +
+      '[guren/orm] Migrations must be generated with drizzle-kit (`bun run db:make`), which creates one folder per migration.',
+    )
+  }
+}

--- a/packages/orm/src/mysql.ts
+++ b/packages/orm/src/mysql.ts
@@ -1,9 +1,9 @@
 import { drizzle, type MySql2Database } from 'drizzle-orm/mysql2'
 import { migrate } from 'drizzle-orm/mysql2/migrator'
-import { existsSync, readdirSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
+import { hasDrizzleMigrations, warnIgnoredFlatSqlMigrations } from './migration-utils'
 import { runSeeders } from './seeder'
 
 type ConnectionResolver = string | (() => string | undefined)
@@ -61,6 +61,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
 
     const promise = (async (): Promise<void> => {
       if (!hasDrizzleMigrations(resolvedMigrationsFolder)) {
+        warnIgnoredFlatSqlMigrations(resolvedMigrationsFolder)
         return
       }
 
@@ -184,13 +185,3 @@ function isPromiseLike(value: unknown): value is Promise<unknown> {
   return typeof value === 'object' && value !== null && 'then' in value && typeof (value as { then: unknown }).then === 'function'
 }
 
-function hasDrizzleMigrations(migrationsFolder: string): boolean {
-  if (!existsSync(migrationsFolder)) {
-    return false
-  }
-
-  const entries = readdirSync(migrationsFolder, { withFileTypes: true })
-  return entries.some(
-    (entry) => entry.isDirectory() && existsSync(resolve(migrationsFolder, entry.name, 'migration.sql')),
-  )
-}

--- a/packages/orm/src/postgres.ts
+++ b/packages/orm/src/postgres.ts
@@ -1,10 +1,10 @@
 import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js'
 import { migrate } from 'drizzle-orm/postgres-js/migrator'
-import { existsSync, readdirSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import postgres from 'postgres'
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
+import { hasDrizzleMigrations, warnIgnoredFlatSqlMigrations } from './migration-utils'
 import { runSeeders } from './seeder'
 
 type ConnectionResolver = string | (() => string | undefined)
@@ -61,6 +61,7 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
 
     const promise = (async (): Promise<void> => {
       if (!hasDrizzleMigrations(resolvedMigrationsFolder)) {
+        warnIgnoredFlatSqlMigrations(resolvedMigrationsFolder)
         return
       }
 
@@ -144,13 +145,3 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
   }
 }
 
-function hasDrizzleMigrations(migrationsFolder: string): boolean {
-  if (!existsSync(migrationsFolder)) {
-    return false
-  }
-
-  const entries = readdirSync(migrationsFolder, { withFileTypes: true })
-  return entries.some(
-    (entry) => entry.isDirectory() && existsSync(resolve(migrationsFolder, entry.name, 'migration.sql')),
-  )
-}

--- a/packages/orm/src/sqlite.ts
+++ b/packages/orm/src/sqlite.ts
@@ -1,7 +1,7 @@
-import { existsSync, readdirSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
+import { hasDrizzleMigrations, warnIgnoredFlatSqlMigrations } from './migration-utils'
 import { runSeeders } from './seeder'
 
 type ConnectionResolver = string | (() => string | undefined)
@@ -76,6 +76,7 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
 
     migrationsPromise = (async () => {
       if (!hasDrizzleMigrations(resolvedMigrationsFolder)) {
+        warnIgnoredFlatSqlMigrations(resolvedMigrationsFolder)
         return
       }
 
@@ -126,13 +127,3 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
   }
 }
 
-function hasDrizzleMigrations(migrationsFolder: string): boolean {
-  if (!existsSync(migrationsFolder)) {
-    return false
-  }
-
-  const entries = readdirSync(migrationsFolder, { withFileTypes: true })
-  return entries.some(
-    (entry) => entry.isDirectory() && existsSync(resolve(migrationsFolder, entry.name, 'migration.sql')),
-  )
-}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -106,6 +106,7 @@
   },
   "dependencies": {
     "@guren/inertia-client": "^1.0.0-rc.13",
+    "@guren/orm": "^1.0.0-rc.13",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "chalk": "^5.3.0",
     "consola": "^3.4.2",

--- a/packages/server/tsup.config.ts
+++ b/packages/server/tsup.config.ts
@@ -7,6 +7,7 @@ const sharedExternal = [
   '@aws-sdk/client-sqs',
   '@modelcontextprotocol/sdk',
   '@guren/cli',
+  '@guren/orm',
   'zod',
 ]
 

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -303,7 +303,7 @@ async function assertCanonicalScaffolds(appDir: string): Promise<void> {
 
   const postController = await readFile(join(appDir, 'app/Http/Controllers/PostController.ts'), 'utf8')
   assert(postController.includes('type PostsIndexProps = PaginatedPageProps<PostResourceData>'), 'Resource scaffold must use PaginatedPageProps in index controller.')
-  assert(postController.includes('type PostFormErrors = ValidationErrors'), 'Resource scaffold must expose ValidationErrors in edit flow.')
+  assert(postController.includes('await this.auth.userOrFail()'), 'Resource scaffold must require auth in mutating actions by default.')
   assert(postController.includes('const paginator = paginate(result,'), 'Resource scaffold must use paginate(result, ...) as the canonical paginator path.')
   assert(!postController.includes('.safeParse('), 'Resource scaffold must not use manual safeParse() in PostController.')
   assert(!postController.includes('getEventManager'), 'Resource scaffold must not use event helper singletons in PostController.')

--- a/web/resources/js/pages/Home.tsx
+++ b/web/resources/js/pages/Home.tsx
@@ -125,7 +125,7 @@ export default function Home({ message, codeExamples }: Props) {
               </p>
               <CodeBlock
                 lines={[
-                  '$ bunx create-guren-app my-app',
+                  '$ bunx create-guren-app@rc my-app',
                   '$ cd my-app',
                   '$ bun run dev',
                 ]}


### PR DESCRIPTION
## Summary

Dogfooded the published rc packages end-to-end (`create-guren-app@rc` → `guren add auth` → `guren add resource` → migrate/seed → login + CRUD over HTTP) and fixed everything that broke. Several of these only reproduce **outside the monorepo** because example apps resolve `@guren/*` to `src/` via tsconfig paths, masking published-artifact bugs.

## Critical fixes

1. **Auth was broken in every published app** — `@guren/server` bundled `@guren/orm`, creating a second `Model`/`DrizzleAdapter` instance. `configureOrm()` configured the app's copy while `AuthenticatableModel` used the bundled one → `DrizzleAdapter: database has not been configured` (500) on any auth query. Now a real dependency + tsup external.
2. **`add auth` generated Postgres artifacts in SQLite apps** (default DB!) — pgTable schema rewrite + `SERIAL`/`NOW()` SQL. Now dialect-aware (sqlite/pg/mysql) and generates the migration via drizzle-kit.
3. **`db:migrate` silently ignored the generated migration** — loose `.sql` files aren't drizzle-kit format; migrate reported success while creating zero tables. `add auth` now emits drizzle-kit migrations, and the ORM warns about ignored loose `.sql` files.
4. **Sessions/CSRF never mounted in scaffolded apps** — `AuthServiceProvider` requires `createApp({ auth: ... })`, which nothing set. `add auth` now patches `auth: {}` into `createApp()`.
5. **`add resource` never registered routes** — insertion regex required `export default`, absent from the starter template. Now brace-matched insertion, with typed body contracts.
6. **`add resource --fields` was silently ignored** (create-app's own next-steps hint and smoke-golden-path both use it). Now honored via delegation to the `make:feature` templates, plus `--public`.
7. **`codegen` skipped route/API generation without `--routes`** — the template's `bun run codegen` never passed it, so `routes.gen.ts` stayed empty. Now defaults to `routes/web.ts`.
8. **`@guren/inertia-client/typed-forms` didn't resolve** — missing from the exports map (also added `./components`).
9. **`create-guren-app --auth` always failed silently via bunx** (dynamic import of `@guren/cli`, not a dependency) yet printed success. Now runs the app-local CLI after `bun install` and reports honestly.

## Docs

- README quick start pins `create-guren-app@rc` (npm `latest` still points at 0.2.0-alpha.7), documents the SQLite default and correct port (3333).

## Verified

- `bun run test:bun`, `typecheck`, `audit:core-first/docs/contracts/feature-runtime/starter-template`, `smoke:starter`, `smoke:starter:packed`, `smoke:golden-path` all pass
- Runtime E2E with vendored dists: login (303→/dashboard), authed post create (303→/posts/1), list/show 200, CSRF-less POST → 403, guest POST → 401