### PR TITLE
docs: drop @rc tag from quick start now that latest points to rc

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Routing, controllers, ORM, authentication, and Inertia.js + React frontend integ
 
 ```bash
 # 1. Scaffold a new app with authentication (dependencies install automatically)
-bunx create-guren-app@rc my-app --auth
+bunx create-guren-app my-app --auth
 cd my-app
 
 # 2. Run migrations and seed the demo user (SQLite by default — no server needed)
@@ -28,8 +28,6 @@ bun run dev
 ```
 
 Open `http://localhost:3333` and sign in at `/login` with `demo@example.com` / `secret`.
-
-> Guren is on the `rc` npm dist-tag while 1.0 stabilizes — always include `@rc` when running `bunx create-guren-app`.
 
 ### Add features as you go
 

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -3,7 +3,7 @@
 `create-guren-app` scaffolds a new Guren project with a sensible default directory layout.
 
 ```bash
-npx create-guren-app@rc my-app
+npx create-guren-app my-app
 ```
 
 Use `--force` to allow scaffolding into a non-empty directory.

--- a/web/resources/js/pages/Home.tsx
+++ b/web/resources/js/pages/Home.tsx
@@ -125,7 +125,7 @@ export default function Home({ message, codeExamples }: Props) {
               </p>
               <CodeBlock
                 lines={[
-                  '$ bunx create-guren-app@rc my-app',
+                  '$ bunx create-guren-app my-app',
                   '$ cd my-app',
                   '$ bun run dev',
                 ]}


### PR DESCRIPTION
npm's `latest` dist-tag for create-guren-app now points to 1.0.0-rc.19, so the bare `bunx create-guren-app` command works again (verified: scaffolds rc.19 and resolves all @guren/* deps to current rc versions via the template's ^ ranges). Removes the @rc workaround note from the quick start.