### PR TITLE
chore: version packages to 1.0.0-rc.21

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -36,6 +36,7 @@
     "proud-snakes-brush",
     "ready-numbers-rescue",
     "release-prep",
+    "runtime-gate-migrations-relations",
     "secure-defaults-release",
     "strict-shoes-crash",
     "thick-bottles-search",

--- a/examples/api/CHANGELOG.md
+++ b/examples/api/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @guren/example-api
 
+## 0.1.1-rc.12
+
+### Patch Changes
+
+- Updated dependencies [bba40d6]
+  - @guren/orm@1.0.0-rc.15
+  - @guren/cli@1.0.0-rc.18
+  - @guren/testing@1.0.0-rc.16
+  - @guren/core@1.0.0-rc.16
+  - @guren/openapi@1.0.0-rc.16
+
 ## 0.1.1-rc.11
 
 ### Patch Changes

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/example-api",
-  "version": "0.1.1-rc.11",
+  "version": "0.1.1-rc.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @guren/cli
 
+## 1.0.0-rc.18
+
+### Minor Changes
+
+- bba40d6: Runtime release gate, unified drizzle-kit migrations, and richer relations:
+
+  - **Golden-path runtime smoke**: the release workflow now boots a scaffolded app and drives login, CRUD, CSRF, and auth rejection over HTTP before publishing — the class of published-artifact-only breakage fixed in rc.20 can no longer ship.
+  - **Migrations unified on drizzle-kit**: `createSqliteDatabase`/`createPostgresDatabase`/`createMySqlDatabase` now expose `resetDatabase()` and `migrationStatus()`, making `guren db:reset`, `db:fresh`, and `db:status` work out of the box (all three previously failed on scaffolded apps). `db:rollback` now explains that drizzle-kit migrations are forward-only and points to `db:reset` or a compensating forward migration; the dead flat-SQL rollback tracker was removed.
+  - **Relations**: nested eager loading with dot notation (`User.with('posts.comments')` — previously documented but not implemented) and `withCount()` (`users[0].postsCount`) for hasMany/hasOne/belongsTo/morphMany. Relation declarations no longer need `typeof` guards or `as any` casts; the testing mocks now include relation registrars so model modules load cleanly under Vitest.
+  - Templates export `resetDatabase`/`migrationStatus` from config/database.ts and ship `db:reset`/`db:status` scripts; relationship docs updated (EN/JA) with the clean declaration pattern and `withCount`.
+
+### Patch Changes
+
+- Updated dependencies [bba40d6]
+  - @guren/orm@1.0.0-rc.15
+  - @guren/core@1.0.0-rc.16
+
 ## 1.0.0-rc.17
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/cli",
-  "version": "1.0.0-rc.17",
+  "version": "1.0.0-rc.18",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -44,8 +44,8 @@
   },
   "dependencies": {
     "@babel/parser": "^7.24.7",
-    "@guren/core": "^1.0.0-rc.15",
-    "@guren/orm": "^1.0.0-rc.14",
+    "@guren/core": "^1.0.0-rc.16",
+    "@guren/orm": "^1.0.0-rc.15",
     "citty": "^0.1.6",
     "consola": "^3.4.2"
   },

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @guren/core
 
+## 1.0.0-rc.16
+
+### Patch Changes
+
+- bba40d6: Runtime release gate, unified drizzle-kit migrations, and richer relations:
+
+  - **Golden-path runtime smoke**: the release workflow now boots a scaffolded app and drives login, CRUD, CSRF, and auth rejection over HTTP before publishing — the class of published-artifact-only breakage fixed in rc.20 can no longer ship.
+  - **Migrations unified on drizzle-kit**: `createSqliteDatabase`/`createPostgresDatabase`/`createMySqlDatabase` now expose `resetDatabase()` and `migrationStatus()`, making `guren db:reset`, `db:fresh`, and `db:status` work out of the box (all three previously failed on scaffolded apps). `db:rollback` now explains that drizzle-kit migrations are forward-only and points to `db:reset` or a compensating forward migration; the dead flat-SQL rollback tracker was removed.
+  - **Relations**: nested eager loading with dot notation (`User.with('posts.comments')` — previously documented but not implemented) and `withCount()` (`users[0].postsCount`) for hasMany/hasOne/belongsTo/morphMany. Relation declarations no longer need `typeof` guards or `as any` casts; the testing mocks now include relation registrars so model modules load cleanly under Vitest.
+  - Templates export `resetDatabase`/`migrationStatus` from config/database.ts and ship `db:reset`/`db:status` scripts; relationship docs updated (EN/JA) with the clean declaration pattern and `withCount`.
+
+- Updated dependencies [bba40d6]
+  - @guren/orm@1.0.0-rc.15
+  - @guren/cli@1.0.0-rc.18
+  - @guren/server@1.0.0-rc.16
+
 ## 1.0.0-rc.15
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/core",
-  "version": "1.0.0-rc.15",
+  "version": "1.0.0-rc.16",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -48,9 +48,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@guren/cli": "^1.0.0-rc.17",
-    "@guren/orm": "^1.0.0-rc.14",
-    "@guren/server": "^1.0.0-rc.15"
+    "@guren/cli": "^1.0.0-rc.18",
+    "@guren/orm": "^1.0.0-rc.15",
+    "@guren/server": "^1.0.0-rc.16"
   },
   "devDependencies": {
     "@types/node": "^20.14.10",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,16 @@
 # create-guren-app
 
+## 1.0.0-rc.20
+
+### Patch Changes
+
+- bba40d6: Runtime release gate, unified drizzle-kit migrations, and richer relations:
+
+  - **Golden-path runtime smoke**: the release workflow now boots a scaffolded app and drives login, CRUD, CSRF, and auth rejection over HTTP before publishing — the class of published-artifact-only breakage fixed in rc.20 can no longer ship.
+  - **Migrations unified on drizzle-kit**: `createSqliteDatabase`/`createPostgresDatabase`/`createMySqlDatabase` now expose `resetDatabase()` and `migrationStatus()`, making `guren db:reset`, `db:fresh`, and `db:status` work out of the box (all three previously failed on scaffolded apps). `db:rollback` now explains that drizzle-kit migrations are forward-only and points to `db:reset` or a compensating forward migration; the dead flat-SQL rollback tracker was removed.
+  - **Relations**: nested eager loading with dot notation (`User.with('posts.comments')` — previously documented but not implemented) and `withCount()` (`users[0].postsCount`) for hasMany/hasOne/belongsTo/morphMany. Relation declarations no longer need `typeof` guards or `as any` casts; the testing mocks now include relation registrars so model modules load cleanly under Vitest.
+  - Templates export `resetDatabase`/`migrationStatus` from config/database.ts and ship `db:reset`/`db:status` scripts; relationship docs updated (EN/JA) with the clean declaration pattern and `withCount`.
+
 ## 1.0.0-rc.19
 
 ### Patch Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-guren-app",
-  "version": "1.0.0-rc.19",
+  "version": "1.0.0-rc.20",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/inertia-client/CHANGELOG.md
+++ b/packages/inertia-client/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @guren/inertia-client
 
+## 1.0.0-rc.15
+
+### Patch Changes
+
+- bba40d6: Runtime release gate, unified drizzle-kit migrations, and richer relations:
+
+  - **Golden-path runtime smoke**: the release workflow now boots a scaffolded app and drives login, CRUD, CSRF, and auth rejection over HTTP before publishing — the class of published-artifact-only breakage fixed in rc.20 can no longer ship.
+  - **Migrations unified on drizzle-kit**: `createSqliteDatabase`/`createPostgresDatabase`/`createMySqlDatabase` now expose `resetDatabase()` and `migrationStatus()`, making `guren db:reset`, `db:fresh`, and `db:status` work out of the box (all three previously failed on scaffolded apps). `db:rollback` now explains that drizzle-kit migrations are forward-only and points to `db:reset` or a compensating forward migration; the dead flat-SQL rollback tracker was removed.
+  - **Relations**: nested eager loading with dot notation (`User.with('posts.comments')` — previously documented but not implemented) and `withCount()` (`users[0].postsCount`) for hasMany/hasOne/belongsTo/morphMany. Relation declarations no longer need `typeof` guards or `as any` casts; the testing mocks now include relation registrars so model modules load cleanly under Vitest.
+  - Templates export `resetDatabase`/`migrationStatus` from config/database.ts and ship `db:reset`/`db:status` scripts; relationship docs updated (EN/JA) with the clean declaration pattern and `withCount`.
+
 ## 1.0.0-rc.14
 
 ### Patch Changes

--- a/packages/inertia-client/package.json
+++ b/packages/inertia-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/inertia-client",
-  "version": "1.0.0-rc.14",
+  "version": "1.0.0-rc.15",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/openapi/CHANGELOG.md
+++ b/packages/openapi/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @guren/openapi
 
+## 1.0.0-rc.16
+
+### Patch Changes
+
+- bba40d6: Runtime release gate, unified drizzle-kit migrations, and richer relations:
+
+  - **Golden-path runtime smoke**: the release workflow now boots a scaffolded app and drives login, CRUD, CSRF, and auth rejection over HTTP before publishing — the class of published-artifact-only breakage fixed in rc.20 can no longer ship.
+  - **Migrations unified on drizzle-kit**: `createSqliteDatabase`/`createPostgresDatabase`/`createMySqlDatabase` now expose `resetDatabase()` and `migrationStatus()`, making `guren db:reset`, `db:fresh`, and `db:status` work out of the box (all three previously failed on scaffolded apps). `db:rollback` now explains that drizzle-kit migrations are forward-only and points to `db:reset` or a compensating forward migration; the dead flat-SQL rollback tracker was removed.
+  - **Relations**: nested eager loading with dot notation (`User.with('posts.comments')` — previously documented but not implemented) and `withCount()` (`users[0].postsCount`) for hasMany/hasOne/belongsTo/morphMany. Relation declarations no longer need `typeof` guards or `as any` casts; the testing mocks now include relation registrars so model modules load cleanly under Vitest.
+  - Templates export `resetDatabase`/`migrationStatus` from config/database.ts and ship `db:reset`/`db:status` scripts; relationship docs updated (EN/JA) with the clean declaration pattern and `withCount`.
+
+- Updated dependencies [bba40d6]
+  - @guren/core@1.0.0-rc.16
+
 ## 1.0.0-rc.15
 
 ### Patch Changes

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/openapi",
-  "version": "1.0.0-rc.15",
+  "version": "1.0.0-rc.16",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@guren/core": "^1.0.0-rc.15"
+    "@guren/core": "^1.0.0-rc.16"
   },
   "devDependencies": {
     "@types/node": "^20.14.10",

--- a/packages/orm/CHANGELOG.md
+++ b/packages/orm/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @guren/orm
 
+## 1.0.0-rc.15
+
+### Minor Changes
+
+- bba40d6: Runtime release gate, unified drizzle-kit migrations, and richer relations:
+
+  - **Golden-path runtime smoke**: the release workflow now boots a scaffolded app and drives login, CRUD, CSRF, and auth rejection over HTTP before publishing — the class of published-artifact-only breakage fixed in rc.20 can no longer ship.
+  - **Migrations unified on drizzle-kit**: `createSqliteDatabase`/`createPostgresDatabase`/`createMySqlDatabase` now expose `resetDatabase()` and `migrationStatus()`, making `guren db:reset`, `db:fresh`, and `db:status` work out of the box (all three previously failed on scaffolded apps). `db:rollback` now explains that drizzle-kit migrations are forward-only and points to `db:reset` or a compensating forward migration; the dead flat-SQL rollback tracker was removed.
+  - **Relations**: nested eager loading with dot notation (`User.with('posts.comments')` — previously documented but not implemented) and `withCount()` (`users[0].postsCount`) for hasMany/hasOne/belongsTo/morphMany. Relation declarations no longer need `typeof` guards or `as any` casts; the testing mocks now include relation registrars so model modules load cleanly under Vitest.
+  - Templates export `resetDatabase`/`migrationStatus` from config/database.ts and ship `db:reset`/`db:status` scripts; relationship docs updated (EN/JA) with the clean declaration pattern and `withCount`.
+
 ## 1.0.0-rc.14
 
 ### Patch Changes

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/orm",
-  "version": "1.0.0-rc.14",
+  "version": "1.0.0-rc.15",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @guren/server
 
+## 1.0.0-rc.16
+
+### Patch Changes
+
+- bba40d6: Runtime release gate, unified drizzle-kit migrations, and richer relations:
+
+  - **Golden-path runtime smoke**: the release workflow now boots a scaffolded app and drives login, CRUD, CSRF, and auth rejection over HTTP before publishing — the class of published-artifact-only breakage fixed in rc.20 can no longer ship.
+  - **Migrations unified on drizzle-kit**: `createSqliteDatabase`/`createPostgresDatabase`/`createMySqlDatabase` now expose `resetDatabase()` and `migrationStatus()`, making `guren db:reset`, `db:fresh`, and `db:status` work out of the box (all three previously failed on scaffolded apps). `db:rollback` now explains that drizzle-kit migrations are forward-only and points to `db:reset` or a compensating forward migration; the dead flat-SQL rollback tracker was removed.
+  - **Relations**: nested eager loading with dot notation (`User.with('posts.comments')` — previously documented but not implemented) and `withCount()` (`users[0].postsCount`) for hasMany/hasOne/belongsTo/morphMany. Relation declarations no longer need `typeof` guards or `as any` casts; the testing mocks now include relation registrars so model modules load cleanly under Vitest.
+  - Templates export `resetDatabase`/`migrationStatus` from config/database.ts and ship `db:reset`/`db:status` scripts; relationship docs updated (EN/JA) with the clean declaration pattern and `withCount`.
+
+- Updated dependencies [bba40d6]
+  - @guren/orm@1.0.0-rc.15
+  - @guren/inertia-client@1.0.0-rc.15
+
 ## 1.0.0-rc.15
 
 ### Patch Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/server",
-  "version": "1.0.0-rc.15",
+  "version": "1.0.0-rc.16",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -105,8 +105,8 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@guren/inertia-client": "^1.0.0-rc.14",
-    "@guren/orm": "^1.0.0-rc.14",
+    "@guren/inertia-client": "^1.0.0-rc.15",
+    "@guren/orm": "^1.0.0-rc.15",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "chalk": "^5.3.0",
     "consola": "^3.4.2",

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @guren/testing
 
+## 1.0.0-rc.16
+
+### Patch Changes
+
+- bba40d6: Runtime release gate, unified drizzle-kit migrations, and richer relations:
+
+  - **Golden-path runtime smoke**: the release workflow now boots a scaffolded app and drives login, CRUD, CSRF, and auth rejection over HTTP before publishing — the class of published-artifact-only breakage fixed in rc.20 can no longer ship.
+  - **Migrations unified on drizzle-kit**: `createSqliteDatabase`/`createPostgresDatabase`/`createMySqlDatabase` now expose `resetDatabase()` and `migrationStatus()`, making `guren db:reset`, `db:fresh`, and `db:status` work out of the box (all three previously failed on scaffolded apps). `db:rollback` now explains that drizzle-kit migrations are forward-only and points to `db:reset` or a compensating forward migration; the dead flat-SQL rollback tracker was removed.
+  - **Relations**: nested eager loading with dot notation (`User.with('posts.comments')` — previously documented but not implemented) and `withCount()` (`users[0].postsCount`) for hasMany/hasOne/belongsTo/morphMany. Relation declarations no longer need `typeof` guards or `as any` casts; the testing mocks now include relation registrars so model modules load cleanly under Vitest.
+  - Templates export `resetDatabase`/`migrationStatus` from config/database.ts and ship `db:reset`/`db:status` scripts; relationship docs updated (EN/JA) with the clean declaration pattern and `withCount`.
+
+- Updated dependencies [bba40d6]
+  - @guren/server@1.0.0-rc.16
+
 ## 1.0.0-rc.15
 
 ### Patch Changes

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/testing",
-  "version": "1.0.0-rc.15",
+  "version": "1.0.0-rc.16",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -35,7 +35,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@guren/server": ">=1.0.0-rc.15",
+    "@guren/server": ">=1.0.0-rc.16",
     "@inertiajs/react": "^2.3.18",
     "@testing-library/react": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "hono": "^4.12.18",

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,16 @@
 # web
 
+## 0.1.1-rc.11
+
+### Patch Changes
+
+- Updated dependencies [bba40d6]
+  - @guren/orm@1.0.0-rc.15
+  - @guren/cli@1.0.0-rc.18
+  - @guren/testing@1.0.0-rc.16
+  - @guren/core@1.0.0-rc.16
+  - @guren/inertia-client@1.0.0-rc.15
+
 ## 0.1.1-rc.10
 
 ### Patch Changes

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.1-rc.10",
+  "version": "0.1.1-rc.11",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump from the runtime-gate-migrations-relations changeset (PR #54). Release train v1.0.0-rc.21: @guren/server 1.0.0-rc.16, @guren/core 1.0.0-rc.16, @guren/cli 1.0.0-rc.18, @guren/orm 1.0.0-rc.15, create-guren-app 1.0.0-rc.20.