### PR TITLE
fix(orm): compile array where values to IN instead of eq

### DIFF
--- a/.changeset/array-where-in.md
+++ b/.changeset/array-where-in.md
@@ -1,0 +1,5 @@
+---
+"@guren/orm": patch
+---
+
+Fix array values in object-form `where()` producing `eq(column, array)` instead of an IN clause. On bun:sqlite this threw "SQLite query expected 1 values, received N" whenever an eager load (`Model.with(...)`) ran against two or more parent records; with a single value it silently used wrong equality semantics. `where({ id: [1, 2] })`, `where('id', [1, 2])`, and the `orWhere` equivalents now compile to `IN`, matching `whereIn()`. Adds a real bun:sqlite integration test suite for relations, which fake-adapter tests could not cover.

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -104,7 +104,8 @@ export class QueryBuilder<
     if (typeof fieldOrConditions === 'object' && fieldOrConditions !== null) {
       for (const [key, val] of Object.entries(fieldOrConditions)) {
         if (val !== undefined) {
-          this.addSimpleCondition(key, '=', val)
+          // Array values mean IN — mirrors the adapter's object-where contract
+          this.addSimpleCondition(key, Array.isArray(val) ? 'in' : '=', val)
         }
       }
       return this
@@ -113,7 +114,7 @@ export class QueryBuilder<
     const field = fieldOrConditions as string
 
     if (arguments.length === 2) {
-      this.addSimpleCondition(field, '=', operatorOrValue)
+      this.addSimpleCondition(field, Array.isArray(operatorOrValue) ? 'in' : '=', operatorOrValue)
     } else {
       this.addSimpleCondition(field, operatorOrValue as WhereOperator, value)
     }
@@ -140,14 +141,14 @@ export class QueryBuilder<
     if (typeof fieldOrConditions === 'object' && fieldOrConditions !== null) {
       for (const [key, val] of Object.entries(fieldOrConditions)) {
         if (val !== undefined) {
-          orConditions.push({ type: 'simple', field: key, operator: '=', value: val })
+          orConditions.push({ type: 'simple', field: key, operator: Array.isArray(val) ? 'in' : '=', value: val })
         }
       }
     } else {
       const field = fieldOrConditions as string
 
       if (arguments.length === 2) {
-        orConditions.push({ type: 'simple', field, operator: '=', value: operatorOrValue })
+        orConditions.push({ type: 'simple', field, operator: Array.isArray(operatorOrValue) ? 'in' : '=', value: operatorOrValue })
       } else {
         orConditions.push({ type: 'simple', field, operator: operatorOrValue as WhereOperator, value })
       }

--- a/packages/orm/tests/model-relations-sqlite.test.ts
+++ b/packages/orm/tests/model-relations-sqlite.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { drizzle } from 'drizzle-orm/bun-sqlite'
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { Model } from '../src/Model'
+import { DrizzleAdapter } from '../src/adapters/drizzle-adapter'
+
+// Integration test against the real bun:sqlite driver. The fake-adapter
+// tests cannot catch SQL placeholder bugs (e.g. eq(column, array) binding
+// one placeholder to N values), which broke eager loading for 2+ parents.
+
+const usersTable = sqliteTable('users', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  name: text('name').notNull(),
+})
+
+const postsTable = sqliteTable('posts', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  title: text('title').notNull(),
+  authorId: integer('author_id').notNull(),
+})
+
+type UserRecord = typeof usersTable.$inferSelect
+type PostRecord = typeof postsTable.$inferSelect
+
+describe('relations on real bun:sqlite driver', () => {
+  let sqlite: Database
+
+  class User extends Model<UserRecord> {
+    static override table = usersTable
+  }
+
+  class Post extends Model<PostRecord> {
+    static override table = postsTable
+  }
+
+  User.hasMany('posts', Post, 'authorId', 'id')
+  Post.belongsTo('author', User, 'authorId', 'id')
+
+  beforeEach(() => {
+    sqlite = new Database(':memory:')
+    sqlite.exec(`
+      CREATE TABLE users (id integer primary key autoincrement, name text not null);
+      CREATE TABLE posts (id integer primary key autoincrement, title text not null, author_id integer not null);
+      INSERT INTO users (name) VALUES ('Alice'), ('Bob'), ('Carol');
+      INSERT INTO posts (title, author_id) VALUES
+        ('A1', 1), ('A2', 1), ('B1', 2);
+    `)
+    DrizzleAdapter.configure(drizzle({ client: sqlite }) as never)
+  })
+
+  afterEach(() => {
+    sqlite.close()
+  })
+
+  it('should filter with array where (IN) across multiple values', async () => {
+    const posts = await Post.where({ authorId: [1, 2] })
+    expect(posts).toHaveLength(3)
+
+    const single = await Post.where({ authorId: [2] })
+    expect(single).toHaveLength(1)
+    expect(single[0].title).toBe('B1')
+  })
+
+  it('should eager load hasMany for more than one parent record', async () => {
+    const users = (await User.with('posts')) as Array<UserRecord & { posts: PostRecord[] }>
+
+    expect(users).toHaveLength(3)
+    expect(users.find((u) => u.name === 'Alice')?.posts.map((p) => p.title).sort()).toEqual(['A1', 'A2'])
+    expect(users.find((u) => u.name === 'Bob')?.posts).toHaveLength(1)
+    expect(users.find((u) => u.name === 'Carol')?.posts).toEqual([])
+  })
+
+  it('should eager load belongsTo across multiple children', async () => {
+    const posts = (await Post.with('author')) as Array<PostRecord & { author: UserRecord | null }>
+
+    expect(posts).toHaveLength(3)
+    expect(posts.find((p) => p.title === 'A1')?.author?.name).toBe('Alice')
+    expect(posts.find((p) => p.title === 'B1')?.author?.name).toBe('Bob')
+  })
+
+  it('should attach counts via withCount', async () => {
+    const users = (await User.withCount('posts')) as Array<UserRecord & { postsCount: number }>
+
+    expect(users.find((u) => u.name === 'Alice')?.postsCount).toBe(2)
+    expect(users.find((u) => u.name === 'Bob')?.postsCount).toBe(1)
+    expect(users.find((u) => u.name === 'Carol')?.postsCount).toBe(0)
+  })
+
+  it('should support orWhere with array values', async () => {
+    const posts = await Post.where({ authorId: 1 }).orWhere({ authorId: [2] }).get()
+    expect(posts).toHaveLength(3)
+  })
+})


### PR DESCRIPTION
Object-form `where()` mapped arrays to `'='` → `eq(column, array)` → one placeholder bound to N values. Every `Model.with(...)` eager load with 2+ parent records threw on bun:sqlite ("expected 1 values, received N"); single-element arrays silently used wrong semantics. Found by runtime-testing relations against the npm-published rc.21 packages. Fix: arrays compile to `IN` in `where()`/`orWhere()`, matching `whereIn()`. Adds a real bun:sqlite integration suite for relations (fake adapters cannot catch placeholder bugs).