### PR TITLE
chore: version packages to 1.0.0-rc.22

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -25,6 +25,7 @@
     "align-rc16",
     "align-rc17",
     "align-rc9",
+    "array-where-in",
     "busy-bobcats-smell",
     "dogfood-dx-fixes",
     "dull-tips-go",

--- a/examples/api/CHANGELOG.md
+++ b/examples/api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @guren/example-api
 
+## 0.1.1-rc.13
+
+### Patch Changes
+
+- Updated dependencies [7687a0f]
+  - @guren/orm@1.0.0-rc.16
+
 ## 0.1.1-rc.12
 
 ### Patch Changes

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/example-api",
-  "version": "0.1.1-rc.12",
+  "version": "0.1.1-rc.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/orm/CHANGELOG.md
+++ b/packages/orm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guren/orm
 
+## 1.0.0-rc.16
+
+### Patch Changes
+
+- 7687a0f: Fix array values in object-form `where()` producing `eq(column, array)` instead of an IN clause. On bun:sqlite this threw "SQLite query expected 1 values, received N" whenever an eager load (`Model.with(...)`) ran against two or more parent records; with a single value it silently used wrong equality semantics. `where({ id: [1, 2] })`, `where('id', [1, 2])`, and the `orWhere` equivalents now compile to `IN`, matching `whereIn()`. Adds a real bun:sqlite integration test suite for relations, which fake-adapter tests could not cover.
+
 ## 1.0.0-rc.15
 
 ### Minor Changes

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/orm",
-  "version": "1.0.0-rc.15",
+  "version": "1.0.0-rc.16",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,12 @@
 # web
 
+## 0.1.1-rc.12
+
+### Patch Changes
+
+- Updated dependencies [7687a0f]
+  - @guren/orm@1.0.0-rc.16
+
 ## 0.1.1-rc.11
 
 ### Patch Changes

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.1-rc.11",
+  "version": "0.1.1-rc.12",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump for the array-where IN fix (PR #56). @guren/orm 1.0.0-rc.16 + dependents.