### PR TITLE
feat: db-matrix runtime gates, upgrade-path protection, add-on smokes

### DIFF
--- a/.changeset/quality-hardening.md
+++ b/.changeset/quality-hardening.md
@@ -1,0 +1,17 @@
+---
+"@guren/orm": minor
+"@guren/cli": minor
+"@guren/server": patch
+"@guren/core": patch
+"@guren/testing": patch
+"@guren/openapi": patch
+"@guren/inertia-client": patch
+"create-guren-app": patch
+---
+
+Quality hardening: database-matrix runtime gates, upgrade-path protection, and add-on runtime smokes:
+
+- **PostgreSQL golden-path gate**: the scaffold→auth→CRUD runtime smoke now also runs against PostgreSQL in CI and the release workflow (dedicated `guren_smoke` database locally so developer data is never touched), verifying dialect-aware scaffolds, `resetDatabase()`, and `migrationStatus()` on pg for every release.
+- **`guren upgrade` works for the rc channel**: previously only `--canary` was supported, leaving rc users with no tool-assisted upgrade. `guren upgrade` now aligns every `@guren/*` package to a resolved dist-tag version (default `rc`, override with `--tag`), and warns when nested duplicate `@guren` copies survive in node_modules with the exact dedupe command.
+- **Duplicate-copy runtime guard**: loading two copies of `@guren/orm` (mixed versions) now prints a loud diagnostic explaining why database access fails and how to fix it, instead of failing silently with "database has not been configured".
+- **`Mail#build()` runs automatically**: scaffolded mailables previously threw "Email must have a subject" because `send()`/`queue()` never invoked `build()` — every user following the `add mail` scaffold hit this. Found by the new add-on runtime smoke, which now dispatches the scaffolded queue job and sends the scaffolded mailable on every release.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,19 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: guren
+          POSTGRES_PASSWORD: guren
+          POSTGRES_DB: guren
+        ports:
+          - 54322:5432
+        options: >-
+          --health-cmd "pg_isready -U guren"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
       REDIS_URL: redis://localhost:6379
       APP_KEY: base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
@@ -98,6 +111,9 @@ jobs:
 
       - name: Golden path smoke test
         run: bun run smoke:golden-path
+
+      - name: Golden path smoke test (postgres)
+        run: bun run smoke:golden-path:postgres
 
       - name: Run tests
         run: bun run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,19 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: guren
+          POSTGRES_PASSWORD: guren
+          POSTGRES_DB: guren
+        ports:
+          - 54322:5432
+        options: >-
+          --health-cmd "pg_isready -U guren"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
       REDIS_URL: redis://localhost:6379
     permissions:
@@ -90,6 +103,9 @@ jobs:
       # export map entries, unregistered routes).
       - name: Golden path runtime smoke
         run: bun run smoke:golden-path
+
+      - name: Golden path runtime smoke (postgres)
+        run: bun run smoke:golden-path:postgres
 
       # upgrade-existing-app smoke skipped in release workflow: it tries to
       # resolve the new version from npm before publish, causing a chicken-and-egg

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "smoke:starter:packed": "GUREN_SMOKE_INSTALL_MODE=packed bun run ./scripts/smoke/fresh-app.ts",
     "smoke:upgrade-existing-app": "bun run ./scripts/smoke/upgrade-existing-app.ts",
     "smoke:golden-path": "bash ./scripts/smoke-golden-path.sh",
+    "smoke:golden-path:postgres": "GUREN_SMOKE_DB=postgres bash ./scripts/smoke-golden-path.sh",
     "changeset": "changeset",
     "version-packages": "changeset version && bun install",
     "release": "bun run build && changeset publish",

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1947,6 +1947,10 @@ const upgradeCommand = defineCommand({
       type: 'boolean',
       description: 'Pin @guren/* dependencies to the canary release tag.',
     },
+    tag: {
+      type: 'string',
+      description: 'npm dist-tag to upgrade to (default: rc). All @guren/* packages are aligned to it.',
+    },
     install: {
       type: 'boolean',
       description: 'Run bun install after package.json is updated.',
@@ -1969,15 +1973,14 @@ const upgradeCommand = defineCommand({
     },
   },
   async run({ args }) {
-    if (!args.canary && !args.checkOnly) {
-      throw new Error('Only `guren upgrade --canary` is currently supported.')
-    }
+    const tag = args.canary ? 'canary' : typeof args.tag === 'string' && args.tag ? args.tag : 'rc'
 
     const result = await upgradeCanary({
       install: Boolean(args.install),
       dryRun: Boolean(args.dryRun),
       noAutofix: Boolean(args.noAutofix),
       checkOnly: Boolean(args.checkOnly),
+      tag,
     })
 
     if (args.json) {

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -1,4 +1,5 @@
-import { readFile, writeFile } from 'node:fs/promises'
+import { readFile, writeFile, readdir } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
 import { spawn } from 'node:child_process'
 import { join, resolve } from 'node:path'
 import {
@@ -23,6 +24,14 @@ export interface UpgradeCanaryOptions {
   noAutofix?: boolean
   checkOnly?: boolean
   installRunner?: (cwd: string) => Promise<void>
+  /**
+   * npm dist-tag to upgrade to (default: 'rc'). 'canary' pins the literal
+   * tag so installs keep floating; any other tag is resolved to a concrete
+   * version and written as ^version.
+   */
+  tag?: string
+  /** Override registry version lookups (used in tests). */
+  versionResolver?: (packageName: string, tag: string) => Promise<string | null>
 }
 
 export interface UpgradedDependency {
@@ -63,6 +72,28 @@ type PackageManifest = Partial<Record<ManifestField, Record<string, string>>> & 
   version?: string
 }
 
+async function findNestedGurenCopies(cwd: string): Promise<string[]> {
+  const gurenRoot = resolve(cwd, 'node_modules', '@guren')
+  if (!existsSync(gurenRoot)) {
+    return []
+  }
+
+  const nested: string[] = []
+  const entries = await readdir(gurenRoot, { withFileTypes: true }).catch(() => [])
+  for (const entry of entries) {
+    const nestedGuren = resolve(gurenRoot, entry.name, 'node_modules', '@guren')
+    if (!existsSync(nestedGuren)) {
+      continue
+    }
+    const inner = await readdir(nestedGuren).catch(() => [])
+    for (const innerName of inner) {
+      nested.push(`@guren/${entry.name} -> @guren/${innerName}`)
+    }
+  }
+
+  return nested
+}
+
 async function runBunInstall(cwd: string): Promise<void> {
   await new Promise<void>((resolvePromise, rejectPromise) => {
     const child = spawn(process.execPath || 'bun', ['install'], {
@@ -85,7 +116,23 @@ async function runBunInstall(cwd: string): Promise<void> {
   })
 }
 
-async function updateManifestDependencies(cwd: string, dryRun = false): Promise<{
+async function resolveDistTagVersion(packageName: string, tag: string): Promise<string | null> {
+  const response = await fetch(`https://registry.npmjs.org/${packageName}`, {
+    headers: { accept: 'application/vnd.npm.install-v1+json' },
+  })
+  if (!response.ok) {
+    return null
+  }
+  const payload = (await response.json()) as { 'dist-tags'?: Record<string, string> }
+  return payload['dist-tags']?.[tag] ?? null
+}
+
+async function updateManifestDependencies(
+  cwd: string,
+  dryRun = false,
+  tag = 'rc',
+  versionResolver: (packageName: string, tag: string) => Promise<string | null> = resolveDistTagVersion,
+): Promise<{
   packageJsonPath: string
   updatedDependencies: UpgradedDependency[]
 }> {
@@ -94,6 +141,16 @@ async function updateManifestDependencies(cwd: string, dryRun = false): Promise<
   const manifest = JSON.parse(raw) as PackageManifest
   const updatedDependencies: UpgradedDependency[] = []
 
+  // 'canary' keeps the floating dist-tag pin; other tags resolve to ^version
+  // so every @guren/* package lands on one coherent release.
+  const resolveTarget = async (name: string): Promise<string | null> => {
+    if (tag === 'canary') {
+      return 'canary'
+    }
+    const version = await versionResolver(name, tag)
+    return version ? `^${version}` : null
+  }
+
   for (const field of MANIFEST_FIELDS) {
     const dependencies = manifest[field]
     if (!dependencies) {
@@ -101,16 +158,26 @@ async function updateManifestDependencies(cwd: string, dryRun = false): Promise<
     }
 
     for (const [name, version] of Object.entries(dependencies)) {
-      if (!GUREN_PACKAGE.test(name) || version === 'canary') {
+      if (!GUREN_PACKAGE.test(name)) {
         continue
       }
 
-      dependencies[name] = 'canary'
+      const nextVersion = await resolveTarget(name)
+      if (nextVersion === null) {
+        console.warn(`[guren upgrade] Could not resolve ${name}@${tag} from the npm registry — leaving it at ${version}.`)
+        continue
+      }
+
+      if (version === nextVersion) {
+        continue
+      }
+
+      dependencies[name] = nextVersion
       updatedDependencies.push({
         field,
         name,
         previousVersion: version,
-        nextVersion: 'canary',
+        nextVersion,
       })
     }
   }
@@ -157,9 +224,11 @@ function collectManualSteps(checks: DoctorCheck[]): string[] {
 
 export async function upgradeCanary(options: UpgradeCanaryOptions = {}): Promise<UpgradeCanaryResult> {
   const cwd = resolve(options.cwd ?? process.cwd())
+  const tag = options.tag ?? 'rc'
+  const manualStepsExtra: string[] = []
 
   // Run version compatibility and deprecation checks
-  const versionCompatibility = await checkVersionCompatibility(cwd, 'canary')
+  const versionCompatibility = await checkVersionCompatibility(cwd, tag)
   const deprecationWarnings = await checkDeprecations(cwd)
 
   // If check-only mode, return early with just the checks
@@ -178,7 +247,7 @@ export async function upgradeCanary(options: UpgradeCanaryOptions = {}): Promise
     }
   }
 
-  const { packageJsonPath, updatedDependencies } = await updateManifestDependencies(cwd, Boolean(options.dryRun))
+  const { packageJsonPath, updatedDependencies } = await updateManifestDependencies(cwd, Boolean(options.dryRun), tag, options.versionResolver)
   const { evaluations } = await getDoctorRuleEvaluations({ cwd })
 
   const candidateAutofixes = evaluations
@@ -218,7 +287,7 @@ export async function upgradeCanary(options: UpgradeCanaryOptions = {}): Promise
   const codemodResults = await runCodemods(
     cwd,
     versionCompatibility.currentVersion,
-    'canary',
+    tag,
     { dryRun: options.dryRun },
   )
 
@@ -227,12 +296,23 @@ export async function upgradeCanary(options: UpgradeCanaryOptions = {}): Promise
     await installRunner(cwd)
   }
 
+  // Nested @guren copies survive plain `bun install` because the lockfile
+  // keeps the old resolution. Two loaded copies of @guren/orm means adapter
+  // state is split and database access fails, so surface it loudly.
+  const nestedCopies = await findNestedGurenCopies(cwd)
+  if (nestedCopies.length > 0) {
+    manualStepsExtra.push(
+      `Duplicate @guren copies detected (${nestedCopies.join(', ')}). ` +
+        'Run `rm -rf node_modules bun.lock && bun install` to dedupe them.',
+    )
+  }
+
   return {
     packageJsonPath,
     updatedDependencies,
     autofixes,
     warnings: warningChecks,
-    manualSteps: collectManualSteps(warningChecks),
+    manualSteps: [...collectManualSteps(warningChecks), ...manualStepsExtra],
     recommendedCommands: [...DOCTOR_RECOMMENDED_COMMANDS],
     versionCompatibility,
     deprecationWarnings,

--- a/packages/cli/tests/upgrade.test.ts
+++ b/packages/cli/tests/upgrade.test.ts
@@ -42,7 +42,7 @@ describe('upgradeCanary', () => {
   })
 
   it('updates Guren packages to canary', async () => {
-    const result = await upgradeCanary({ cwd: workspace.dir })
+    const result = await upgradeCanary({ cwd: workspace.dir, tag: 'canary' })
     const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
       dependencies: Record<string, string>
       devDependencies: Record<string, string>
@@ -57,8 +57,39 @@ describe('upgradeCanary', () => {
     expect(packageJson.dependencies.react).toBe('^19.0.0')
   })
 
+
+  it('aligns Guren packages to a resolved rc version by default', async () => {
+    const result = await upgradeCanary({
+      cwd: workspace.dir,
+      versionResolver: async (name) => (name.startsWith('@guren/') ? '1.0.0-rc.99' : null),
+    })
+    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
+      dependencies: Record<string, string>
+      devDependencies: Record<string, string>
+    }
+
+    expect(result.versionCompatibility?.targetVersion).toBe('rc')
+    expect(packageJson.dependencies['@guren/core']).toBe('^1.0.0-rc.99')
+    expect(packageJson.dependencies['@guren/server']).toBe('^1.0.0-rc.99')
+    expect(packageJson.devDependencies['@guren/testing']).toBe('^1.0.0-rc.99')
+    expect(packageJson.dependencies.react).toBe('^19.0.0')
+  })
+
+  it('leaves packages untouched when the registry lookup fails', async () => {
+    const result = await upgradeCanary({
+      cwd: workspace.dir,
+      versionResolver: async () => null,
+    })
+    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
+      dependencies: Record<string, string>
+    }
+
+    expect(result.updatedDependencies).toHaveLength(0)
+    expect(packageJson.dependencies['@guren/core']).not.toBe('^null')
+  })
+
   it('supports dry runs', async () => {
-    const result = await upgradeCanary({ cwd: workspace.dir, dryRun: true })
+    const result = await upgradeCanary({ cwd: workspace.dir, dryRun: true , versionResolver: async () => '1.0.0-rc.99' })
     const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
       dependencies: Record<string, string>
       scripts?: Record<string, string>
@@ -75,7 +106,7 @@ describe('upgradeCanary', () => {
   })
 
   it('supports disabling autofix', async () => {
-    const result = await upgradeCanary({ cwd: workspace.dir, noAutofix: true })
+    const result = await upgradeCanary({ cwd: workspace.dir, noAutofix: true, tag: 'canary' })
     const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
       dependencies: Record<string, string>
       scripts?: Record<string, string>
@@ -94,7 +125,7 @@ describe('upgradeCanary', () => {
   })
 
   it('returns a stable json-shaped report', async () => {
-    const result = await upgradeCanary({ cwd: workspace.dir, dryRun: true })
+    const result = await upgradeCanary({ cwd: workspace.dir, dryRun: true , versionResolver: async () => '1.0.0-rc.99' })
 
     expect(result).toHaveProperty('packageJsonPath')
     expect(result).toHaveProperty('updatedDependencies')
@@ -109,15 +140,15 @@ describe('upgradeCanary', () => {
   it('runs install only when dependencies were updated', async () => {
     const installRunner = mock(async () => {})
 
-    await upgradeCanary({ cwd: workspace.dir, install: true, installRunner })
+    await upgradeCanary({ cwd: workspace.dir, install: true, installRunner , versionResolver: async () => '1.0.0-rc.99' })
     expect(installRunner).toHaveBeenCalledTimes(1)
 
-    await upgradeCanary({ cwd: workspace.dir, install: true, installRunner })
+    await upgradeCanary({ cwd: workspace.dir, install: true, installRunner , versionResolver: async () => '1.0.0-rc.99' })
     expect(installRunner).toHaveBeenCalledTimes(1)
   })
 
   it('includes deprecation and codemod results in output', async () => {
-    const result = await upgradeCanary({ cwd: workspace.dir, dryRun: true })
+    const result = await upgradeCanary({ cwd: workspace.dir, dryRun: true , versionResolver: async () => '1.0.0-rc.99' })
 
     expect(result).toHaveProperty('deprecationWarnings')
     expect(result).toHaveProperty('codemodResults')

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -1,3 +1,4 @@
+import './instance-guard'
 export { Model, defineModel } from './Model'
 export { ModelNotFoundException } from './ModelNotFoundException'
 export type {

--- a/packages/orm/src/instance-guard.ts
+++ b/packages/orm/src/instance-guard.ts
@@ -1,0 +1,41 @@
+/**
+ * Detects multiple loaded copies of @guren/orm in one process.
+ *
+ * Model and DrizzleAdapter keep module-level state (the configured database,
+ * relation registries). When two copies of the package are loaded — usually
+ * because mixed @guren/* versions made the package manager nest a second
+ * copy under another @guren package — `configureOrm()` configures one copy
+ * while models imported through the other copy stay unconfigured, and every
+ * query fails with "database has not been configured".
+ *
+ * The runtime cannot merge the copies, but it can make the failure mode
+ * obvious instead of silent.
+ */
+const INSTANCE_KEY = Symbol.for('guren.orm.loaded')
+
+type GlobalWithMarker = typeof globalThis & {
+  [INSTANCE_KEY]?: { count: number; warned: boolean }
+}
+
+const globalScope = globalThis as GlobalWithMarker
+
+const marker = globalScope[INSTANCE_KEY]
+
+if (!marker) {
+  globalScope[INSTANCE_KEY] = { count: 1, warned: false }
+} else {
+  marker.count += 1
+  if (!marker.warned) {
+    marker.warned = true
+    console.warn(
+      `[guren/orm] ${marker.count} copies of @guren/orm are loaded in this process. ` +
+        'Adapter configuration and model state are NOT shared between copies, so database access will fail ' +
+        'with "database has not been configured" for models imported through the extra copy.\n' +
+        '[guren/orm] This usually means mixed @guren/* versions (check `bun pm ls | grep @guren`). ' +
+        'Fix it by aligning all @guren/* packages to the same release, e.g. `bunx guren upgrade` or ' +
+        'updating every @guren/* entry in package.json together, then reinstalling.',
+    )
+  }
+}
+
+export {}

--- a/packages/server/src/mail/Mail.ts
+++ b/packages/server/src/mail/Mail.ts
@@ -208,7 +208,26 @@ export class Mail {
   /**
    * Build the final message.
    */
+  /**
+   * Mailable subclasses define their content in build() (subject, body, ...).
+   * It runs automatically before sending, so `new WelcomeMail(manager).to(x).send()`
+   * works without a manual build() call.
+   */
+  protected build?(): this
+
+  private hasRunBuild = false
+
+  private runBuildOnce(): void {
+    if (this.hasRunBuild) {
+      return
+    }
+    this.hasRunBuild = true
+    this.build?.()
+  }
+
   buildMessage(): MailMessage {
+    this.runBuildOnce()
+
     if (!this.message.to || this.message.to.length === 0) {
       throw new Error('Email must have at least one recipient')
     }

--- a/scripts/smoke-golden-path.sh
+++ b/scripts/smoke-golden-path.sh
@@ -28,6 +28,17 @@ step() {
 CLI_BIN="$REPO_ROOT/packages/cli/src/bin.ts"
 CREATE_APP_BIN="$REPO_ROOT/packages/create-app/src/cli.ts"
 
+# Database driver for the scaffolded app. "postgres" expects a reachable
+# server (default: the repo docker-compose instance on port 54322 — run
+# `bun run db:up` locally; CI maps its service container to the same port).
+SMOKE_DB="${GUREN_SMOKE_DB:-sqlite}"
+
+if [ "$SMOKE_DB" = "postgres" ]; then
+  # Use a dedicated database so db:reset never touches a developer's data
+  # on the shared compose instance. CI maps its service to the same port.
+  export DATABASE_URL="${GUREN_SMOKE_DATABASE_URL:-postgres://guren:guren@localhost:54322/guren_smoke}"
+fi
+
 PACKAGES="cli core inertia-client orm server"
 
 # ---------------------------------------------------------------------------
@@ -55,7 +66,7 @@ APP_DIR="$TEMP_DIR/golden-path-app"
 echo "Temp directory: $TEMP_DIR"
 echo "App directory:  $APP_DIR"
 
-bun "$CREATE_APP_BIN" "$APP_DIR" --mode ssr
+bun "$CREATE_APP_BIN" "$APP_DIR" --mode ssr --db "$SMOKE_DB"
 
 # ---------------------------------------------------------------------------
 # Step 2: Vendor local packages and install dependencies
@@ -256,12 +267,74 @@ cleanup() {
 }
 
 (cd "$APP_DIR" && bun run db:make)
-(cd "$APP_DIR" && bun run db:migrate)
+
+if [ "$SMOKE_DB" = "postgres" ]; then
+  # Create the smoke database if missing (CREATE DATABASE has no IF NOT EXISTS).
+  cat > "$TEMP_DIR/ensure-db.ts" <<'ENSUREDB'
+import postgres from 'postgres'
+
+const target = new URL(process.env.DATABASE_URL ?? '')
+const dbName = target.pathname.slice(1)
+const admin = new URL(target.toString())
+admin.pathname = '/postgres'
+
+const sql = postgres(admin.toString(), { max: 1 })
+const exists = await sql`SELECT 1 FROM pg_database WHERE datname = ${dbName}`
+if (exists.length === 0) {
+  await sql.unsafe(`CREATE DATABASE "${dbName.replaceAll('"', '""')}"`)
+  console.log(`Created database ${dbName}`)
+} else {
+  console.log(`Database ${dbName} already exists`)
+}
+await sql.end()
+ENSUREDB
+  (cd "$APP_DIR" && bun "$TEMP_DIR/ensure-db.ts")
+
+  # Drop leftovers from previous runs and exercise resetDatabase() on pg.
+  (cd "$APP_DIR" && bun "$CLI_BIN" db:reset --force)
+else
+  (cd "$APP_DIR" && bun run db:migrate)
+fi
 (cd "$APP_DIR" && bun run db:seed)
+
+# db:status must see every migration as applied on both drivers.
+STATUS_OUTPUT=$(cd "$APP_DIR" && bun "$CLI_BIN" db:status 2>&1)
+printf '%s\n' "$STATUS_OUTPUT"
+if printf '%s' "$STATUS_OUTPUT" | grep -q "pending"; then
+  echo "ERROR: db:status reports pending migrations after db:migrate"
+  exit 1
+fi
+if ! printf '%s' "$STATUS_OUTPUT" | grep -q "applied"; then
+  echo "ERROR: db:status did not report any applied migrations"
+  exit 1
+fi
 
 # Assert migrations actually created tables — db:migrate used to report
 # success while silently executing nothing.
-(cd "$APP_DIR" && bun -e "
+if [ "$SMOKE_DB" = "postgres" ]; then
+  cat > "$TEMP_DIR/dbcheck.ts" <<'DBCHECK'
+import postgres from 'postgres'
+
+const sql = postgres(process.env.DATABASE_URL ?? 'postgres://guren:guren@localhost:54322/guren', { max: 1 })
+const rows = await sql`SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`
+const tables = rows.map((row) => row.table_name as string)
+for (const required of ['users', 'posts', 'comments']) {
+  if (!tables.includes(required)) {
+    console.error('Missing table after db:migrate: ' + required + ' (found: ' + tables.join(', ') + ')')
+    process.exit(1)
+  }
+}
+const tracker = await sql`SELECT count(*)::int AS c FROM drizzle.__drizzle_migrations`
+if (Number(tracker[0].c) < 1) {
+  console.error('drizzle.__drizzle_migrations is empty after db:migrate')
+  process.exit(1)
+}
+await sql.end()
+console.log('DB tables OK (postgres): ' + tables.join(', '))
+DBCHECK
+  (cd "$APP_DIR" && bun "$TEMP_DIR/dbcheck.ts")
+else
+  (cd "$APP_DIR" && bun -e "
 import { Database } from 'bun:sqlite'
 const db = new Database('./data/guren.db')
 const tables = db.query(\"SELECT name FROM sqlite_master WHERE type='table'\").all().map((r) => r.name)
@@ -273,6 +346,7 @@ for (const required of ['users', 'posts', 'comments', '__drizzle_migrations']) {
 }
 console.log('DB tables OK: ' + tables.join(', '))
 ")
+fi
 
 RUNTIME_PORT="${GUREN_SMOKE_PORT:-3799}"
 RUNTIME_URL="http://localhost:$RUNTIME_PORT"
@@ -360,6 +434,64 @@ http_expect "POST /posts (guest with valid CSRF)" 401 \
   -d '{"title":"guest","body":"blocked"}'
 
 stop_server
+
+# ---------------------------------------------------------------------------
+# Step 17: Add-on runtime smoke — boot the app once more and exercise the
+# queue (dispatch + pop on the memory driver) and mail (memory transport)
+# wiring that the add-on blueprints installed. Compile-time checks cannot
+# tell whether the providers actually register working managers.
+# ---------------------------------------------------------------------------
+step 17 "Add-on runtime smoke (queue dispatch + mail send)"
+
+cat > "$APP_DIR/addons-check.ts" <<'ADDONS'
+import app, { ready } from './src/main.js'
+
+await ready
+
+// Queue: dispatch the scaffolded job and confirm it lands on the driver.
+const queue = app.container.make('queue') as {
+  driver(): {
+    size(queue: string): Promise<number>
+    pop(queue: string): Promise<{ name: string } | null>
+  }
+}
+const { ProcessWelcomeSequenceJob } = await import('./app/Jobs/ProcessWelcomeSequenceJob.js')
+const jobId = await ProcessWelcomeSequenceJob.dispatch({ source: 'smoke' })
+if (typeof jobId !== 'string' || jobId.length === 0) {
+  console.error('Job dispatch did not return a job id')
+  process.exit(1)
+}
+const queued = await queue.driver().size('default')
+if (queued < 1) {
+  console.error(`Expected at least 1 queued job, found ${queued}`)
+  process.exit(1)
+}
+const job = await queue.driver().pop('default')
+if (!job || job.name !== 'ProcessWelcomeSequenceJob') {
+  console.error('Queued job missing or wrong name: ' + JSON.stringify(job))
+  process.exit(1)
+}
+console.log('Queue OK: dispatched and popped ' + job.name)
+
+// Mail: send the scaffolded mailable through the memory transport.
+const mailManager = app.container.make('mail') as never
+const { WelcomeEmailMail } = await import('./app/Mail/WelcomeEmailMail.js')
+const result = (await new WelcomeEmailMail(mailManager).to('smoke@example.com').send()) as {
+  success: boolean
+  response?: string
+  error?: string
+}
+if (!result.success) {
+  console.error('Mail send failed: ' + JSON.stringify(result))
+  process.exit(1)
+}
+console.log('Mail OK: ' + (result.response ?? 'sent'))
+
+process.exit(0)
+ADDONS
+
+(cd "$APP_DIR" && bun addons-check.ts)
+rm -f "$APP_DIR/addons-check.ts"
 
 # ---------------------------------------------------------------------------
 # Done


### PR DESCRIPTION
## Summary

Third round of quality hardening, closing the gaps called out after rc.22:

1. **PostgreSQL runtime gate** — `smoke:golden-path:postgres` runs the full scaffold→auth→CRUD→CSRF flow against pg in CI and releases. Verified locally against the compose instance (uses a dedicated `guren_smoke` database + `db:reset` so reruns are idempotent and developer data is untouched). Also asserts `db:status` output on both drivers.
2. **Upgrade path** — `guren upgrade` was canary-only; rc users had no repair tool for mixed versions. Now aligns all `@guren/*` to a resolved dist-tag (default `rc`, `--tag` to override), and detects nested duplicate `@guren` copies after install with the exact dedupe command. Verified end-to-end on an intentionally broken mixed-version app.
3. **Dual-copy diagnostic** — two loaded `@guren/orm` copies now warn loudly with cause + fix instead of opaque "database has not been configured" failures.
4. **Mail scaffold bug (found by the new add-on smoke)** — `Mail#build()` was never invoked by `send()`/`queue()`, so every scaffolded mailable threw "Email must have a subject". Now runs automatically (idempotent). The golden path now dispatches the scaffolded queue job and sends the scaffolded mailable at runtime.

## Validation
- `bun run test` / `bun run typecheck` green
- `bun run smoke:golden-path` (sqlite) and `smoke:golden-path:postgres` both PASS locally including the new step 17
- upgrade repair flow verified on a real mixed-version app (detect → align → dedupe → create works)