### PR TITLE
chore: version packages to 1.0.0-rc.23

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -35,6 +35,7 @@
     "ninety-dragons-wonder",
     "openapi-major",
     "proud-snakes-brush",
+    "quality-hardening",
     "ready-numbers-rescue",
     "release-prep",
     "runtime-gate-migrations-relations",

--- a/examples/api/CHANGELOG.md
+++ b/examples/api/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @guren/example-api
 
+## 0.1.1-rc.14
+
+### Patch Changes
+
+- Updated dependencies [8ee89bb]
+  - @guren/orm@1.0.0-rc.17
+  - @guren/cli@1.0.0-rc.19
+  - @guren/core@1.0.0-rc.17
+  - @guren/testing@1.0.0-rc.17
+  - @guren/openapi@1.0.0-rc.17
+
 ## 0.1.1-rc.13
 
 ### Patch Changes

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/example-api",
-  "version": "0.1.1-rc.13",
+  "version": "0.1.1-rc.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @guren/cli
 
+## 1.0.0-rc.19
+
+### Minor Changes
+
+- 8ee89bb: Quality hardening: database-matrix runtime gates, upgrade-path protection, and add-on runtime smokes:
+
+  - **PostgreSQL golden-path gate**: the scaffold→auth→CRUD runtime smoke now also runs against PostgreSQL in CI and the release workflow (dedicated `guren_smoke` database locally so developer data is never touched), verifying dialect-aware scaffolds, `resetDatabase()`, and `migrationStatus()` on pg for every release.
+  - **`guren upgrade` works for the rc channel**: previously only `--canary` was supported, leaving rc users with no tool-assisted upgrade. `guren upgrade` now aligns every `@guren/*` package to a resolved dist-tag version (default `rc`, override with `--tag`), and warns when nested duplicate `@guren` copies survive in node_modules with the exact dedupe command.
+  - **Duplicate-copy runtime guard**: loading two copies of `@guren/orm` (mixed versions) now prints a loud diagnostic explaining why database access fails and how to fix it, instead of failing silently with "database has not been configured".
+  - **`Mail#build()` runs automatically**: scaffolded mailables previously threw "Email must have a subject" because `send()`/`queue()` never invoked `build()` — every user following the `add mail` scaffold hit this. Found by the new add-on runtime smoke, which now dispatches the scaffolded queue job and sends the scaffolded mailable on every release.
+
+### Patch Changes
+
+- Updated dependencies [8ee89bb]
+  - @guren/orm@1.0.0-rc.17
+  - @guren/core@1.0.0-rc.17
+
 ## 1.0.0-rc.18
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/cli",
-  "version": "1.0.0-rc.18",
+  "version": "1.0.0-rc.19",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -44,8 +44,8 @@
   },
   "dependencies": {
     "@babel/parser": "^7.24.7",
-    "@guren/core": "^1.0.0-rc.16",
-    "@guren/orm": "^1.0.0-rc.15",
+    "@guren/core": "^1.0.0-rc.17",
+    "@guren/orm": "^1.0.0-rc.17",
     "citty": "^0.1.6",
     "consola": "^3.4.2"
   },

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @guren/core
 
+## 1.0.0-rc.17
+
+### Patch Changes
+
+- 8ee89bb: Quality hardening: database-matrix runtime gates, upgrade-path protection, and add-on runtime smokes:
+
+  - **PostgreSQL golden-path gate**: the scaffold→auth→CRUD runtime smoke now also runs against PostgreSQL in CI and the release workflow (dedicated `guren_smoke` database locally so developer data is never touched), verifying dialect-aware scaffolds, `resetDatabase()`, and `migrationStatus()` on pg for every release.
+  - **`guren upgrade` works for the rc channel**: previously only `--canary` was supported, leaving rc users with no tool-assisted upgrade. `guren upgrade` now aligns every `@guren/*` package to a resolved dist-tag version (default `rc`, override with `--tag`), and warns when nested duplicate `@guren` copies survive in node_modules with the exact dedupe command.
+  - **Duplicate-copy runtime guard**: loading two copies of `@guren/orm` (mixed versions) now prints a loud diagnostic explaining why database access fails and how to fix it, instead of failing silently with "database has not been configured".
+  - **`Mail#build()` runs automatically**: scaffolded mailables previously threw "Email must have a subject" because `send()`/`queue()` never invoked `build()` — every user following the `add mail` scaffold hit this. Found by the new add-on runtime smoke, which now dispatches the scaffolded queue job and sends the scaffolded mailable on every release.
+
+- Updated dependencies [8ee89bb]
+  - @guren/orm@1.0.0-rc.17
+  - @guren/cli@1.0.0-rc.19
+  - @guren/server@1.0.0-rc.17
+
 ## 1.0.0-rc.16
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/core",
-  "version": "1.0.0-rc.16",
+  "version": "1.0.0-rc.17",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -48,9 +48,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@guren/cli": "^1.0.0-rc.18",
-    "@guren/orm": "^1.0.0-rc.15",
-    "@guren/server": "^1.0.0-rc.16"
+    "@guren/cli": "^1.0.0-rc.19",
+    "@guren/orm": "^1.0.0-rc.17",
+    "@guren/server": "^1.0.0-rc.17"
   },
   "devDependencies": {
     "@types/node": "^20.14.10",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,16 @@
 # create-guren-app
 
+## 1.0.0-rc.21
+
+### Patch Changes
+
+- 8ee89bb: Quality hardening: database-matrix runtime gates, upgrade-path protection, and add-on runtime smokes:
+
+  - **PostgreSQL golden-path gate**: the scaffold→auth→CRUD runtime smoke now also runs against PostgreSQL in CI and the release workflow (dedicated `guren_smoke` database locally so developer data is never touched), verifying dialect-aware scaffolds, `resetDatabase()`, and `migrationStatus()` on pg for every release.
+  - **`guren upgrade` works for the rc channel**: previously only `--canary` was supported, leaving rc users with no tool-assisted upgrade. `guren upgrade` now aligns every `@guren/*` package to a resolved dist-tag version (default `rc`, override with `--tag`), and warns when nested duplicate `@guren` copies survive in node_modules with the exact dedupe command.
+  - **Duplicate-copy runtime guard**: loading two copies of `@guren/orm` (mixed versions) now prints a loud diagnostic explaining why database access fails and how to fix it, instead of failing silently with "database has not been configured".
+  - **`Mail#build()` runs automatically**: scaffolded mailables previously threw "Email must have a subject" because `send()`/`queue()` never invoked `build()` — every user following the `add mail` scaffold hit this. Found by the new add-on runtime smoke, which now dispatches the scaffolded queue job and sends the scaffolded mailable on every release.
+
 ## 1.0.0-rc.20
 
 ### Patch Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-guren-app",
-  "version": "1.0.0-rc.20",
+  "version": "1.0.0-rc.21",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/inertia-client/CHANGELOG.md
+++ b/packages/inertia-client/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @guren/inertia-client
 
+## 1.0.0-rc.16
+
+### Patch Changes
+
+- 8ee89bb: Quality hardening: database-matrix runtime gates, upgrade-path protection, and add-on runtime smokes:
+
+  - **PostgreSQL golden-path gate**: the scaffold→auth→CRUD runtime smoke now also runs against PostgreSQL in CI and the release workflow (dedicated `guren_smoke` database locally so developer data is never touched), verifying dialect-aware scaffolds, `resetDatabase()`, and `migrationStatus()` on pg for every release.
+  - **`guren upgrade` works for the rc channel**: previously only `--canary` was supported, leaving rc users with no tool-assisted upgrade. `guren upgrade` now aligns every `@guren/*` package to a resolved dist-tag version (default `rc`, override with `--tag`), and warns when nested duplicate `@guren` copies survive in node_modules with the exact dedupe command.
+  - **Duplicate-copy runtime guard**: loading two copies of `@guren/orm` (mixed versions) now prints a loud diagnostic explaining why database access fails and how to fix it, instead of failing silently with "database has not been configured".
+  - **`Mail#build()` runs automatically**: scaffolded mailables previously threw "Email must have a subject" because `send()`/`queue()` never invoked `build()` — every user following the `add mail` scaffold hit this. Found by the new add-on runtime smoke, which now dispatches the scaffolded queue job and sends the scaffolded mailable on every release.
+
 ## 1.0.0-rc.15
 
 ### Patch Changes

--- a/packages/inertia-client/package.json
+++ b/packages/inertia-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/inertia-client",
-  "version": "1.0.0-rc.15",
+  "version": "1.0.0-rc.16",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/openapi/CHANGELOG.md
+++ b/packages/openapi/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @guren/openapi
 
+## 1.0.0-rc.17
+
+### Patch Changes
+
+- 8ee89bb: Quality hardening: database-matrix runtime gates, upgrade-path protection, and add-on runtime smokes:
+
+  - **PostgreSQL golden-path gate**: the scaffold→auth→CRUD runtime smoke now also runs against PostgreSQL in CI and the release workflow (dedicated `guren_smoke` database locally so developer data is never touched), verifying dialect-aware scaffolds, `resetDatabase()`, and `migrationStatus()` on pg for every release.
+  - **`guren upgrade` works for the rc channel**: previously only `--canary` was supported, leaving rc users with no tool-assisted upgrade. `guren upgrade` now aligns every `@guren/*` package to a resolved dist-tag version (default `rc`, override with `--tag`), and warns when nested duplicate `@guren` copies survive in node_modules with the exact dedupe command.
+  - **Duplicate-copy runtime guard**: loading two copies of `@guren/orm` (mixed versions) now prints a loud diagnostic explaining why database access fails and how to fix it, instead of failing silently with "database has not been configured".
+  - **`Mail#build()` runs automatically**: scaffolded mailables previously threw "Email must have a subject" because `send()`/`queue()` never invoked `build()` — every user following the `add mail` scaffold hit this. Found by the new add-on runtime smoke, which now dispatches the scaffolded queue job and sends the scaffolded mailable on every release.
+
+- Updated dependencies [8ee89bb]
+  - @guren/core@1.0.0-rc.17
+
 ## 1.0.0-rc.16
 
 ### Patch Changes

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/openapi",
-  "version": "1.0.0-rc.16",
+  "version": "1.0.0-rc.17",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@guren/core": "^1.0.0-rc.16"
+    "@guren/core": "^1.0.0-rc.17"
   },
   "devDependencies": {
     "@types/node": "^20.14.10",

--- a/packages/orm/CHANGELOG.md
+++ b/packages/orm/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @guren/orm
 
+## 1.0.0-rc.17
+
+### Minor Changes
+
+- 8ee89bb: Quality hardening: database-matrix runtime gates, upgrade-path protection, and add-on runtime smokes:
+
+  - **PostgreSQL golden-path gate**: the scaffold→auth→CRUD runtime smoke now also runs against PostgreSQL in CI and the release workflow (dedicated `guren_smoke` database locally so developer data is never touched), verifying dialect-aware scaffolds, `resetDatabase()`, and `migrationStatus()` on pg for every release.
+  - **`guren upgrade` works for the rc channel**: previously only `--canary` was supported, leaving rc users with no tool-assisted upgrade. `guren upgrade` now aligns every `@guren/*` package to a resolved dist-tag version (default `rc`, override with `--tag`), and warns when nested duplicate `@guren` copies survive in node_modules with the exact dedupe command.
+  - **Duplicate-copy runtime guard**: loading two copies of `@guren/orm` (mixed versions) now prints a loud diagnostic explaining why database access fails and how to fix it, instead of failing silently with "database has not been configured".
+  - **`Mail#build()` runs automatically**: scaffolded mailables previously threw "Email must have a subject" because `send()`/`queue()` never invoked `build()` — every user following the `add mail` scaffold hit this. Found by the new add-on runtime smoke, which now dispatches the scaffolded queue job and sends the scaffolded mailable on every release.
+
 ## 1.0.0-rc.16
 
 ### Patch Changes

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/orm",
-  "version": "1.0.0-rc.16",
+  "version": "1.0.0-rc.17",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @guren/server
 
+## 1.0.0-rc.17
+
+### Patch Changes
+
+- 8ee89bb: Quality hardening: database-matrix runtime gates, upgrade-path protection, and add-on runtime smokes:
+
+  - **PostgreSQL golden-path gate**: the scaffold→auth→CRUD runtime smoke now also runs against PostgreSQL in CI and the release workflow (dedicated `guren_smoke` database locally so developer data is never touched), verifying dialect-aware scaffolds, `resetDatabase()`, and `migrationStatus()` on pg for every release.
+  - **`guren upgrade` works for the rc channel**: previously only `--canary` was supported, leaving rc users with no tool-assisted upgrade. `guren upgrade` now aligns every `@guren/*` package to a resolved dist-tag version (default `rc`, override with `--tag`), and warns when nested duplicate `@guren` copies survive in node_modules with the exact dedupe command.
+  - **Duplicate-copy runtime guard**: loading two copies of `@guren/orm` (mixed versions) now prints a loud diagnostic explaining why database access fails and how to fix it, instead of failing silently with "database has not been configured".
+  - **`Mail#build()` runs automatically**: scaffolded mailables previously threw "Email must have a subject" because `send()`/`queue()` never invoked `build()` — every user following the `add mail` scaffold hit this. Found by the new add-on runtime smoke, which now dispatches the scaffolded queue job and sends the scaffolded mailable on every release.
+
+- Updated dependencies [8ee89bb]
+  - @guren/orm@1.0.0-rc.17
+  - @guren/inertia-client@1.0.0-rc.16
+
 ## 1.0.0-rc.16
 
 ### Patch Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/server",
-  "version": "1.0.0-rc.16",
+  "version": "1.0.0-rc.17",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -105,8 +105,8 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@guren/inertia-client": "^1.0.0-rc.15",
-    "@guren/orm": "^1.0.0-rc.15",
+    "@guren/inertia-client": "^1.0.0-rc.16",
+    "@guren/orm": "^1.0.0-rc.17",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "chalk": "^5.3.0",
     "consola": "^3.4.2",

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @guren/testing
 
+## 1.0.0-rc.17
+
+### Patch Changes
+
+- 8ee89bb: Quality hardening: database-matrix runtime gates, upgrade-path protection, and add-on runtime smokes:
+
+  - **PostgreSQL golden-path gate**: the scaffold→auth→CRUD runtime smoke now also runs against PostgreSQL in CI and the release workflow (dedicated `guren_smoke` database locally so developer data is never touched), verifying dialect-aware scaffolds, `resetDatabase()`, and `migrationStatus()` on pg for every release.
+  - **`guren upgrade` works for the rc channel**: previously only `--canary` was supported, leaving rc users with no tool-assisted upgrade. `guren upgrade` now aligns every `@guren/*` package to a resolved dist-tag version (default `rc`, override with `--tag`), and warns when nested duplicate `@guren` copies survive in node_modules with the exact dedupe command.
+  - **Duplicate-copy runtime guard**: loading two copies of `@guren/orm` (mixed versions) now prints a loud diagnostic explaining why database access fails and how to fix it, instead of failing silently with "database has not been configured".
+  - **`Mail#build()` runs automatically**: scaffolded mailables previously threw "Email must have a subject" because `send()`/`queue()` never invoked `build()` — every user following the `add mail` scaffold hit this. Found by the new add-on runtime smoke, which now dispatches the scaffolded queue job and sends the scaffolded mailable on every release.
+
+- Updated dependencies [8ee89bb]
+  - @guren/server@1.0.0-rc.17
+
 ## 1.0.0-rc.16
 
 ### Patch Changes

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/testing",
-  "version": "1.0.0-rc.16",
+  "version": "1.0.0-rc.17",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -35,7 +35,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@guren/server": ">=1.0.0-rc.16",
+    "@guren/server": ">=1.0.0-rc.17",
     "@inertiajs/react": "^2.3.18",
     "@testing-library/react": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "hono": "^4.12.18",

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,16 @@
 # web
 
+## 0.1.1-rc.13
+
+### Patch Changes
+
+- Updated dependencies [8ee89bb]
+  - @guren/orm@1.0.0-rc.17
+  - @guren/cli@1.0.0-rc.19
+  - @guren/core@1.0.0-rc.17
+  - @guren/testing@1.0.0-rc.17
+  - @guren/inertia-client@1.0.0-rc.16
+
 ## 0.1.1-rc.12
 
 ### Patch Changes

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.1-rc.12",
+  "version": "0.1.1-rc.13",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump for quality-hardening (PR #58). @guren/orm 1.0.0-rc.17, @guren/cli 1.0.0-rc.19, @guren/server 1.0.0-rc.17 + dependents.