### PR TITLE
fix(orm): load postgres and mysql2 drivers lazily

### DIFF
--- a/.changeset/lazy-db-drivers.md
+++ b/.changeset/lazy-db-drivers.md
@@ -1,0 +1,5 @@
+---
+"@guren/orm": patch
+---
+
+Load the `postgres` and `mysql2` driver packages lazily. Importing `@guren/orm` previously executed `import postgres from 'postgres'` at module load, so any environment without the optional peer installed (SQLite-only apps that prune unused drivers, or the CLI resolved outside an app) crashed with "Cannot find package 'postgres'" before any code ran. Drivers now load on first use of `createPostgresDatabase()` / `createMySqlDatabase()`, with a clear install hint when missing.

--- a/packages/orm/src/mysql.ts
+++ b/packages/orm/src/mysql.ts
@@ -1,5 +1,4 @@
-import { drizzle, type MySql2Database } from 'drizzle-orm/mysql2'
-import { migrate } from 'drizzle-orm/mysql2/migrator'
+import type { MySql2Database } from 'drizzle-orm/mysql2'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
@@ -8,7 +7,28 @@ import { runSeeders } from './seeder'
 
 type ConnectionResolver = string | (() => string | undefined)
 type MySqlConnectionOptions = Record<string, unknown>
-type DrizzleConfig = Exclude<Parameters<typeof drizzle>[0], string>
+type MySql2Drizzle = typeof import('drizzle-orm/mysql2')
+type DrizzleConfig = Exclude<Parameters<MySql2Drizzle['drizzle']>[0], string>
+
+// The mysql driver packages are loaded lazily so importing @guren/orm
+// does not require `mysql2` to be installed (e.g. SQLite-only apps).
+async function loadMySqlModules(): Promise<{
+  drizzle: MySql2Drizzle['drizzle']
+  migrate: typeof import('drizzle-orm/mysql2/migrator')['migrate']
+}> {
+  try {
+    const [{ drizzle }, { migrate }] = await Promise.all([
+      import('drizzle-orm/mysql2'),
+      import('drizzle-orm/mysql2/migrator'),
+    ])
+    return { drizzle, migrate }
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `createMySqlDatabase() requires the "mysql2" package. Install it with \`bun add mysql2\`. (${reason})`,
+    )
+  }
+}
 
 export interface MySqlDatabaseOptions {
   migrationsFolder: string | URL
@@ -69,6 +89,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
         return
       }
 
+      const { drizzle, migrate } = await loadMySqlModules()
       const url = resolveConnectionString()
       const migrationDb = drizzle({
         connection: {
@@ -102,6 +123,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
 
     const promise = (async (): Promise<MySql2Database> => {
       await migrateOnce()
+      const { drizzle } = await loadMySqlModules()
       const url = resolveConnectionString()
       const db = drizzle({
         connection: {
@@ -148,6 +170,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
   }
 
   async function withAdminDb<T>(callback: (db: MySql2Database) => Promise<T>): Promise<T> {
+    const { drizzle } = await loadMySqlModules()
     const adminDb = drizzle({
       connection: {
         uri: resolveConnectionString(),

--- a/packages/orm/src/postgres.ts
+++ b/packages/orm/src/postgres.ts
@@ -1,14 +1,36 @@
-import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js'
-import { migrate } from 'drizzle-orm/postgres-js/migrator'
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import postgres from 'postgres'
+import type postgres from 'postgres'
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
 import { buildMigrationStatus, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
 import { runSeeders } from './seeder'
 
 type ConnectionResolver = string | (() => string | undefined)
-type DrizzleConfig = Exclude<Parameters<typeof drizzle>[0], string>
+type PostgresJsDrizzle = typeof import('drizzle-orm/postgres-js')
+type DrizzleConfig = Exclude<Parameters<PostgresJsDrizzle['drizzle']>[0], string>
+
+// The postgres driver packages are loaded lazily so importing @guren/orm
+// does not require `postgres` to be installed (e.g. SQLite-only apps).
+async function loadPostgresModules(): Promise<{
+  drizzle: PostgresJsDrizzle['drizzle']
+  migrate: typeof import('drizzle-orm/postgres-js/migrator')['migrate']
+  postgres: typeof postgres
+}> {
+  try {
+    const [{ drizzle }, { migrate }, postgresModule] = await Promise.all([
+      import('drizzle-orm/postgres-js'),
+      import('drizzle-orm/postgres-js/migrator'),
+      import('postgres'),
+    ])
+    return { drizzle, migrate, postgres: postgresModule.default }
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `createPostgresDatabase() requires the "postgres" package. Install it with \`bun add postgres\`. (${reason})`,
+    )
+  }
+}
 
 export interface PostgresDatabaseOptions {
   migrationsFolder: string | URL
@@ -69,8 +91,9 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
         return
       }
 
+      const { drizzle, migrate, postgres: postgresFactory } = await loadPostgresModules()
       const url = resolveConnectionString()
-      const migrationClient = postgres(url, {
+      const migrationClient = postgresFactory(url, {
         max: 1,
         ...clientOptions,
       })
@@ -99,8 +122,9 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
 
     const promise = (async (): Promise<PostgresJsDatabase> => {
       await migrateOnce()
+      const { drizzle, postgres: postgresFactory } = await loadPostgresModules()
       const url = resolveConnectionString()
-      client = postgres(url, {
+      client = postgresFactory(url, {
         max: 1,
         ...clientOptions,
       })
@@ -141,7 +165,8 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
   }
 
   async function withAdminClient<T>(callback: (client: ReturnType<typeof postgres>) => Promise<T>): Promise<T> {
-    const adminClient = postgres(resolveConnectionString(), {
+    const { postgres: postgresFactory } = await loadPostgresModules()
+    const adminClient = postgresFactory(resolveConnectionString(), {
       max: 1,
       ...clientOptions,
     })


### PR DESCRIPTION
Importing @guren/orm crashed with "Cannot find package 'postgres'" in any environment without the optional peers installed (SQLite-only apps pruning unused drivers; CLI resolved outside an app via bunx). Static driver imports are now dynamic, loaded on first use of `createPostgresDatabase()`/`createMySqlDatabase()` with a clear install hint. Verified: bare install without drivers imports cleanly; postgres golden-path smoke passes with the lazy path.