### PR TITLE
chore: version packages to 1.0.0-rc.24

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -32,6 +32,7 @@
     "fix-orm-drizzle",
     "fix-sqlite-add-resource",
     "hot-parents-know",
+    "lazy-db-drivers",
     "ninety-dragons-wonder",
     "openapi-major",
     "proud-snakes-brush",

--- a/examples/api/CHANGELOG.md
+++ b/examples/api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @guren/example-api
 
+## 0.1.1-rc.15
+
+### Patch Changes
+
+- Updated dependencies [77049eb]
+  - @guren/orm@1.0.0-rc.18
+
 ## 0.1.1-rc.14
 
 ### Patch Changes

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/example-api",
-  "version": "0.1.1-rc.14",
+  "version": "0.1.1-rc.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/orm/CHANGELOG.md
+++ b/packages/orm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guren/orm
 
+## 1.0.0-rc.18
+
+### Patch Changes
+
+- 77049eb: Load the `postgres` and `mysql2` driver packages lazily. Importing `@guren/orm` previously executed `import postgres from 'postgres'` at module load, so any environment without the optional peer installed (SQLite-only apps that prune unused drivers, or the CLI resolved outside an app) crashed with "Cannot find package 'postgres'" before any code ran. Drivers now load on first use of `createPostgresDatabase()` / `createMySqlDatabase()`, with a clear install hint when missing.
+
 ## 1.0.0-rc.17
 
 ### Minor Changes

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/orm",
-  "version": "1.0.0-rc.17",
+  "version": "1.0.0-rc.18",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,12 @@
 # web
 
+## 0.1.1-rc.14
+
+### Patch Changes
+
+- Updated dependencies [77049eb]
+  - @guren/orm@1.0.0-rc.18
+
 ## 0.1.1-rc.13
 
 ### Patch Changes

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.1-rc.13",
+  "version": "0.1.1-rc.14",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump for the lazy driver-loading fix (PR #60). @guren/orm 1.0.0-rc.18 + dependents.