### PR TITLE
fix: share module state across server entries, real sync/log defaults

### DIFF
--- a/.changeset/kadai-learnings.md
+++ b/.changeset/kadai-learnings.md
@@ -1,0 +1,17 @@
+---
+"@guren/server": minor
+"@guren/orm": patch
+"@guren/cli": minor
+"@guren/core": patch
+"@guren/testing": patch
+"@guren/openapi": patch
+"@guren/inertia-client": patch
+"create-guren-app": patch
+---
+
+Fixes and features from building a real app (Kadai) on the published packages:
+
+- **@guren/server: entry bundles now share chunks** (tsup `splitting: true`). Each entry point previously bundled its own copy of module-level state, so `registerJob()` via the root entry and `Worker` via `./queue` used different job registries — jobs failed with "Job class not found". The same duplication affected the mail manager and queue driver globals.
+- **@guren/server: new `SyncDriver` (queue) and `LogTransport` (mail)** — the template `.env` defaults (`QUEUE_CONNECTION=sync`, `MAIL_MAILER=log`) previously named drivers that did not exist. Sync dispatch executes jobs inline with no worker process; the log transport writes full messages to server output. The `add queue` / `add mail` blueprints now honor these env vars and default to sync/log.
+- **@guren/orm: multi-relation type fix** — `findWith(id, ['a', 'b'])` and `with(['a', 'b'])` typed their results as a union of single-relation picks instead of an intersection, making relation properties inaccessible.
+- **@guren/orm: `QueryBuilder.paginate()` accepts an options object** (`{ page, perPage }`) in addition to positional arguments, matching `Model.paginate()`.

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -402,9 +402,12 @@ export default class EventProvider extends ServiceProvider {
 export default class MailProvider extends ServiceProvider {
   register(): void {
     const manager = createMailManager({
-      default: 'memory',
+      // MAIL_MAILER=log writes messages to the server output (default);
+      // 'memory' keeps them inspectable in tests.
+      default: process.env.MAIL_MAILER === 'memory' ? 'memory' : 'log',
       from: { email: 'noreply@example.com', name: 'Guren App' },
       transports: {
+        log: { driver: 'log' },
         memory: { driver: 'memory' },
       },
     })
@@ -439,14 +442,17 @@ export default class MailProvider extends ServiceProvider {
       const created = await scaffoldFeatureFiles([
         {
           path: 'app/Providers/QueueProvider.ts',
-          contents: `import { ServiceProvider, MemoryDriver, createQueueManager, registerJob, type QueueManager } from '@guren/core'
+          contents: `import { ServiceProvider, MemoryDriver, SyncDriver, createQueueManager, registerJob, type QueueManager } from '@guren/core'
 import { ProcessWelcomeSequenceJob } from '../Jobs/ProcessWelcomeSequenceJob.js'
 
 export default class QueueProvider extends ServiceProvider {
   register(): void {
     const queue = createQueueManager({
-      default: 'memory',
+      // QUEUE_CONNECTION=sync executes jobs inline on dispatch (default,
+      // no worker process needed); 'memory' queues them for a Worker.
+      default: process.env.QUEUE_CONNECTION === 'memory' ? 'memory' : 'sync',
       drivers: {
+        sync: () => new SyncDriver(),
         memory: () => new MemoryDriver(),
       },
     })
@@ -455,9 +461,10 @@ export default class QueueProvider extends ServiceProvider {
   }
 
   boot(): void {
+    // Register job classes before the driver so sync dispatches can resolve them.
+    registerJob(ProcessWelcomeSequenceJob)
     const queue = this.container.make<QueueManager>('queue')
     queue.driver()
-    registerJob(ProcessWelcomeSequenceJob)
   }
 }
 `,

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -2286,11 +2286,12 @@ type RelationKeyOrString<T extends typeof Model> = RelationKey<T> extends never 
 
 type RelationNameUnion<Names> = Names extends readonly (infer Items)[] ? Items : Names
 
-type RelationTypePick<T extends typeof Model, Names> = RelationNameUnion<Names> extends infer Keys
-  ? Keys extends string
-    ? { [K in Keys & keyof RelationTypesFor<T>]: RelationTypesFor<T>[K] }
-    : {}
-  : {}
+// Note: a single non-distributing mapped type — `Keys extends string ? ...`
+// would distribute over the union and turn with(['a', 'b']) results into
+// `{ a } | { b }` instead of `{ a } & { b }`.
+type RelationTypePick<T extends typeof Model, Names> = {
+  [K in RelationNameUnion<Names> & string & keyof RelationTypesFor<T>]: RelationTypesFor<T>[K]
+}
 
 type RelationCountPick<Names> = { [K in RelationNameUnion<Names> & string as `${K}Count`]: number }
 

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -359,11 +359,22 @@ export class QueryBuilder<
 
   /**
    * Paginate the query results.
-   * @param page - Page number (1-based, default: 1)
-   * @param perPage - Records per page (default: 15)
-   * @returns Paginated result with data and metadata
+   *
+   * Accepts either positional arguments or the same options object shape as
+   * `Model.paginate()` so the two APIs stay interchangeable:
+   *
+   * @example
+   * await Post.where('published', true).paginate(2, 10)
+   * await Post.where('published', true).paginate({ page: 2, perPage: 10 })
    */
-  async paginate(page = 1, perPage = DEFAULT_PAGINATION_SIZE): Promise<PaginatedResult<TResult>> {
+  async paginate(page?: number, perPage?: number): Promise<PaginatedResult<TResult>>
+  async paginate(options: { page?: number; perPage?: number }): Promise<PaginatedResult<TResult>>
+  async paginate(
+    pageOrOptions: number | { page?: number; perPage?: number } = 1,
+    perPageArg = DEFAULT_PAGINATION_SIZE,
+  ): Promise<PaginatedResult<TResult>> {
+    const page = typeof pageOrOptions === 'object' ? pageOrOptions.page ?? 1 : pageOrOptions
+    const perPage = typeof pageOrOptions === 'object' ? pageOrOptions.perPage ?? DEFAULT_PAGINATION_SIZE : perPageArg
     const sanitizedPage = Number.isFinite(page) && page >= 1 ? Math.floor(page) : 1
     const sanitizedPerPage = Number.isFinite(perPage) && perPage >= 1 ? Math.floor(perPage) : DEFAULT_PAGINATION_SIZE
 

--- a/packages/orm/tests/model.query.types.ts
+++ b/packages/orm/tests/model.query.types.ts
@@ -48,3 +48,40 @@ const txUser = User.inTransaction(trx)
 const _txScope: TransactionModelScope<typeof User> = txUser
 txUser.create({ name: 'Kaworu' })
 txUser.update({ id: 1 }, { name: 'Nagisa' })
+
+// findWith / with() with multiple relations must intersect the relation
+// picks, not distribute them into a union.
+type PostRecordT = { id: number; title: string; authorId: number }
+type CommentRecordT = { id: number; body: string; postId: number }
+
+class RelUser extends Model<UserRecord> {
+  static table = users
+  static override relationTypes: {
+    posts: PostRecordT[]
+    comments: CommentRecordT[]
+  } = { posts: [], comments: [] }
+}
+
+async function _relationIntersection() {
+  const found = await RelUser.findWith(1, ['posts', 'comments'])
+  if (found) {
+    const _posts: PostRecordT[] = found.posts
+    const _comments: CommentRecordT[] = found.comments
+    void _posts
+    void _comments
+  }
+
+  const listed = await RelUser.with(['posts', 'comments'])
+  const first = listed[0]
+  if (first) {
+    const _posts: PostRecordT[] = first.posts
+    const _comments: CommentRecordT[] = first.comments
+    void _posts
+    void _comments
+  }
+
+  const counted = await RelUser.withCount('posts')
+  const _count: number = counted[0].postsCount
+  void _count
+}
+void _relationIntersection

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -316,6 +316,7 @@ export {
   Worker,
   QueueManager,
   MemoryDriver,
+  SyncDriver,
   RedisDriver,
   setQueueDriver,
   getQueueDriver,
@@ -354,6 +355,7 @@ export {
   SmtpTransport,
   ResendTransport,
   MemoryTransport,
+  LogTransport,
 } from './mail'
 export type {
   MailAddress,

--- a/packages/server/src/mail/MailManager.ts
+++ b/packages/server/src/mail/MailManager.ts
@@ -10,6 +10,7 @@ import type {
 import { SmtpTransport } from './transports/SmtpTransport'
 import { ResendTransport } from './transports/ResendTransport'
 import { MemoryTransport } from './transports/MemoryTransport'
+import { LogTransport, type LogTransportOptions } from './transports/LogTransport'
 
 /**
  * Mail manager for handling multiple transports.
@@ -78,6 +79,11 @@ export class MailManager {
     // Memory driver factory
     this.registerDriverFactory('memory', (options?: MemoryTransportOptions) => {
       return new MemoryTransport(options)
+    })
+
+    // Log driver factory (development default)
+    this.registerDriverFactory('log', (options?: LogTransportOptions) => {
+      return new LogTransport(options)
     })
   }
 

--- a/packages/server/src/mail/index.ts
+++ b/packages/server/src/mail/index.ts
@@ -17,6 +17,7 @@ export type {
 export { SmtpTransport } from './transports/SmtpTransport'
 export { ResendTransport } from './transports/ResendTransport'
 export { MemoryTransport } from './transports/MemoryTransport'
+export { LogTransport, type LogTransportOptions } from './transports/LogTransport'
 
 // Manager
 export { MailManager, createMailManager } from './MailManager'

--- a/packages/server/src/mail/transports/LogTransport.ts
+++ b/packages/server/src/mail/transports/LogTransport.ts
@@ -1,0 +1,46 @@
+import type { MailMessage, MailTransport, SendResult } from '../types'
+
+export interface LogTransportOptions {
+  /**
+   * Log function to write to.
+   * @default console.log
+   */
+  logger?: (message: string) => void
+}
+
+/**
+ * Log mail transport: writes each email to the log instead of sending it.
+ * This is the development default (`MAIL_MAILER=log`) — every send succeeds
+ * and the full message is visible in the server output.
+ */
+export class LogTransport implements MailTransport {
+  readonly name = 'log'
+  private readonly logger: (message: string) => void
+
+  constructor(options: LogTransportOptions = {}) {
+    this.logger = options.logger ?? console.log
+  }
+
+  async send(message: MailMessage): Promise<SendResult> {
+    const to = message.to.map((address) => address.email).join(', ')
+    const from = message.from ? message.from.email : '(default sender)'
+    const body = message.text ?? message.html ?? ''
+
+    this.logger(
+      [
+        '[mail] ------------------------------------------------------------',
+        `[mail] To: ${to}`,
+        `[mail] From: ${from}`,
+        `[mail] Subject: ${message.subject}`,
+        `[mail] ${body.split('\n').join('\n[mail] ')}`,
+        '[mail] ------------------------------------------------------------',
+      ].join('\n'),
+    )
+
+    return {
+      success: true,
+      messageId: `log-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      response: 'Message written to log',
+    }
+  }
+}

--- a/packages/server/src/queue/drivers/SyncDriver.ts
+++ b/packages/server/src/queue/drivers/SyncDriver.ts
@@ -1,0 +1,86 @@
+import type { QueueDriver, QueuedJob, FailedJob } from '../types'
+import { getJob } from '../Job'
+
+/**
+ * Synchronous queue driver: jobs execute immediately in the dispatching
+ * process, no worker required. This is the development default — dispatch
+ * semantics stay identical to a real queue, but failures surface right away
+ * and nothing needs a second process.
+ *
+ * @example
+ * ```ts
+ * const queue = createQueueManager({
+ *   default: 'sync',
+ *   drivers: { sync: () => new SyncDriver() },
+ * })
+ * ```
+ */
+export class SyncDriver implements QueueDriver {
+  private failedJobs: Map<string, FailedJob> = new Map()
+
+  async push(job: QueuedJob): Promise<void> {
+    const JobClass = getJob(job.name)
+    if (!JobClass) {
+      throw new Error(
+        `SyncDriver: job class "${job.name}" is not registered. Call registerJob(${job.name}) before dispatching.`,
+      )
+    }
+
+    job.attempts += 1
+    try {
+      const instance = new JobClass()
+      await instance.handle(job.payload)
+    } catch (error) {
+      await this.fail(job, error instanceof Error ? error : new Error(String(error)))
+      throw error
+    }
+  }
+
+  async pop(): Promise<QueuedJob | null> {
+    // Jobs never wait in a sync queue.
+    return null
+  }
+
+  async release(job: QueuedJob): Promise<void> {
+    // Re-run immediately: releasing back to a sync queue means retrying now.
+    await this.push(job)
+  }
+
+  async delete(): Promise<void> {}
+
+  async fail(job: QueuedJob, error: Error): Promise<void> {
+    this.failedJobs.set(job.id, {
+      ...job,
+      failedAt: new Date(),
+      error: error.message,
+      stack: error.stack,
+    })
+  }
+
+  async size(): Promise<number> {
+    return 0
+  }
+
+  async getFailedJobs(queue?: string): Promise<FailedJob[]> {
+    const failed = [...this.failedJobs.values()]
+    return queue ? failed.filter((job) => job.queue === queue) : failed
+  }
+
+  async retryFailedJob(jobId: string): Promise<void> {
+    const failed = this.failedJobs.get(jobId)
+    if (!failed) {
+      throw new Error(`SyncDriver: failed job "${jobId}" not found.`)
+    }
+    this.failedJobs.delete(jobId)
+    const { failedAt: _failedAt, error: _error, stack: _stack, ...job } = failed
+    await this.push({ ...job, reservedAt: null })
+  }
+
+  async deleteFailedJob(jobId: string): Promise<void> {
+    this.failedJobs.delete(jobId)
+  }
+
+  async clear(): Promise<void> {
+    this.failedJobs.clear()
+  }
+}

--- a/packages/server/src/queue/index.ts
+++ b/packages/server/src/queue/index.ts
@@ -23,6 +23,7 @@ export {
 
 // Drivers
 export { MemoryDriver } from './drivers/MemoryDriver'
+export { SyncDriver } from './drivers/SyncDriver'
 export { RedisDriver, type RedisDriverOptions } from './drivers/RedisDriver'
 export { SqsDriver, createSqsAdapter, type SqsDriverOptions, type SqsAdapter } from './drivers/SqsDriver'
 

--- a/packages/server/tsup.config.ts
+++ b/packages/server/tsup.config.ts
@@ -35,7 +35,12 @@ export default defineConfig({
     'src/mcp/index.ts',
   ],
   format: ['esm'],
-  splitting: false,
+  // Multiple entry points MUST share chunks: with splitting disabled each
+  // entry bundles its own copy of module-level state (job registry, mail
+  // manager global, queue driver global), so state set through one entry
+  // is invisible through another (e.g. registerJob via the root entry +
+  // Worker via ./queue never saw each other's registry).
+  splitting: true,
   dts: { only: false },
   outDir: 'dist',
   clean: true,

--- a/scripts/smoke-golden-path.sh
+++ b/scripts/smoke-golden-path.sh
@@ -445,35 +445,36 @@ step 17 "Add-on runtime smoke (queue dispatch + mail send)"
 
 cat > "$APP_DIR/addons-check.ts" <<'ADDONS'
 import app, { ready } from './src/main.js'
+import { Job, registerJob } from '@guren/core'
 
 await ready
 
-// Queue: dispatch the scaffolded job and confirm it lands on the driver.
-const queue = app.container.make('queue') as {
-  driver(): {
-    size(queue: string): Promise<number>
-    pop(queue: string): Promise<{ name: string } | null>
+// Queue: the scaffolded default is the sync driver — dispatch must execute
+// the handler inline, in this process, with no worker.
+let probeRan = false
+class SmokeProbeJob extends Job<Record<string, never>> {
+  async handle(): Promise<void> {
+    probeRan = true
   }
 }
-const { ProcessWelcomeSequenceJob } = await import('./app/Jobs/ProcessWelcomeSequenceJob.js')
-const jobId = await ProcessWelcomeSequenceJob.dispatch({ source: 'smoke' })
+registerJob(SmokeProbeJob)
+const jobId = await SmokeProbeJob.dispatch({})
 if (typeof jobId !== 'string' || jobId.length === 0) {
   console.error('Job dispatch did not return a job id')
   process.exit(1)
 }
-const queued = await queue.driver().size('default')
-if (queued < 1) {
-  console.error(`Expected at least 1 queued job, found ${queued}`)
+if (!probeRan) {
+  console.error('SyncDriver did not execute the dispatched job inline')
   process.exit(1)
 }
-const job = await queue.driver().pop('default')
-if (!job || job.name !== 'ProcessWelcomeSequenceJob') {
-  console.error('Queued job missing or wrong name: ' + JSON.stringify(job))
-  process.exit(1)
-}
-console.log('Queue OK: dispatched and popped ' + job.name)
+console.log('Queue OK: sync dispatch executed the job inline')
 
-// Mail: send the scaffolded mailable through the memory transport.
+// The scaffolded sample job must dispatch cleanly too.
+const { ProcessWelcomeSequenceJob } = await import('./app/Jobs/ProcessWelcomeSequenceJob.js')
+await ProcessWelcomeSequenceJob.dispatch({ source: 'smoke' })
+
+// Mail: the scaffolded default is the log transport — send() must succeed
+// and report the log response.
 const mailManager = app.container.make('mail') as never
 const { WelcomeEmailMail } = await import('./app/Mail/WelcomeEmailMail.js')
 const result = (await new WelcomeEmailMail(mailManager).to('smoke@example.com').send()) as {
@@ -485,7 +486,11 @@ if (!result.success) {
   console.error('Mail send failed: ' + JSON.stringify(result))
   process.exit(1)
 }
-console.log('Mail OK: ' + (result.response ?? 'sent'))
+if (result.response !== 'Message written to log') {
+  console.error('Expected the log transport to handle the message, got: ' + JSON.stringify(result))
+  process.exit(1)
+}
+console.log('Mail OK: ' + result.response)
 
 process.exit(0)
 ADDONS


### PR DESCRIPTION
## Summary
Fixes from the first day of building a real app (Kadai) on the published npm packages:

1. **server entry-bundle state duplication (critical)** — `splitting: false` + multiple tsup entries meant each entry carried its own copy of module state. `registerJob()` (root entry) + `Worker` (`./queue` entry) → different registries → "Job class not found" at runtime. Now all entries share chunks; verified with a cross-entry probe (register via root, process via ./queue).
2. **SyncDriver + LogTransport** — template `.env` advertised `QUEUE_CONNECTION=sync` / `MAIL_MAILER=log` but neither driver existed (blueprints hardcoded memory). Sync executes jobs inline on dispatch (dev default, no worker needed); log writes the full message to server output. Blueprints honor the env vars.
3. **findWith/with multi-relation typing** — `RelationTypePick` distributed over the union (`{a} | {b}` instead of `{a} & {b}`); relation properties were inaccessible without casts. Added compile-time regression tests.
4. **`QueryBuilder.paginate({ page, perPage })`** — options-object overload matching `Model.paginate()`.

## Validation
- `bun run test` (2082+ pass, 0 fail), `bun run typecheck` green
- Golden path smoke (sqlite + postgres) PASS, including the updated add-on step: sync inline execution asserted, log transport response asserted
- Cross-entry state probe: register via root entry → Worker via ./queue processes the job