### PR TITLE
chore: version packages to 1.0.0-rc.26

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -36,6 +36,7 @@
     "lazy-db-drivers",
     "ninety-dragons-wonder",
     "openapi-major",
+    "props-heritage-csrf-testing",
     "proud-snakes-brush",
     "quality-hardening",
     "ready-numbers-rescue",

--- a/examples/api/CHANGELOG.md
+++ b/examples/api/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @guren/example-api
 
+## 0.1.1-rc.17
+
+### Patch Changes
+
+- Updated dependencies [4011200]
+  - @guren/cli@1.0.0-rc.21
+  - @guren/testing@1.0.0-rc.19
+  - @guren/orm@1.0.0-rc.20
+  - @guren/core@1.0.0-rc.19
+  - @guren/openapi@1.0.0-rc.19
+
 ## 0.1.1-rc.16
 
 ### Patch Changes

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/example-api",
-  "version": "0.1.1-rc.16",
+  "version": "0.1.1-rc.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @guren/cli
 
+## 1.0.0-rc.21
+
+### Patch Changes
+
+- 4011200: Second round of real-app (Kadai) fixes:
+
+  - **@guren/cli codegen: inherited page props are no longer dropped.** `interface Props extends PaginatedPageProps<T> { ... }` now extracts as an intersection of the heritage clauses and the body. Previously only the body was captured — an empty-bodied extends silently degraded the page contract to `{}` (no type checking at all), and adding any own member made the inherited members vanish from the contract, rejecting valid controller props.
+  - **@guren/testing: `TestApp.withCsrf()`** primes CSRF like a real browser — GETs a page, captures the session and XSRF-TOKEN cookies, and sends them (plus `X-XSRF-TOKEN`) on subsequent requests, so mutating endpoints are finally testable against apps with CSRF enabled.
+  - **@guren/orm: `GUREN_QUIET_DUPLICATE_ORM=1`** silences the duplicate-copy warning for environments where two copies coexist by design (e.g. monorepo dev with src + dist).
+
+- Updated dependencies [4011200]
+  - @guren/orm@1.0.0-rc.20
+  - @guren/core@1.0.0-rc.19
+
 ## 1.0.0-rc.20
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/cli",
-  "version": "1.0.0-rc.20",
+  "version": "1.0.0-rc.21",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -44,8 +44,8 @@
   },
   "dependencies": {
     "@babel/parser": "^7.24.7",
-    "@guren/core": "^1.0.0-rc.18",
-    "@guren/orm": "^1.0.0-rc.19",
+    "@guren/core": "^1.0.0-rc.19",
+    "@guren/orm": "^1.0.0-rc.20",
     "citty": "^0.1.6",
     "consola": "^3.4.2"
   },

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @guren/core
 
+## 1.0.0-rc.19
+
+### Patch Changes
+
+- 4011200: Second round of real-app (Kadai) fixes:
+
+  - **@guren/cli codegen: inherited page props are no longer dropped.** `interface Props extends PaginatedPageProps<T> { ... }` now extracts as an intersection of the heritage clauses and the body. Previously only the body was captured — an empty-bodied extends silently degraded the page contract to `{}` (no type checking at all), and adding any own member made the inherited members vanish from the contract, rejecting valid controller props.
+  - **@guren/testing: `TestApp.withCsrf()`** primes CSRF like a real browser — GETs a page, captures the session and XSRF-TOKEN cookies, and sends them (plus `X-XSRF-TOKEN`) on subsequent requests, so mutating endpoints are finally testable against apps with CSRF enabled.
+  - **@guren/orm: `GUREN_QUIET_DUPLICATE_ORM=1`** silences the duplicate-copy warning for environments where two copies coexist by design (e.g. monorepo dev with src + dist).
+
+- Updated dependencies [4011200]
+  - @guren/cli@1.0.0-rc.21
+  - @guren/orm@1.0.0-rc.20
+  - @guren/server@1.0.0-rc.19
+
 ## 1.0.0-rc.18
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/core",
-  "version": "1.0.0-rc.18",
+  "version": "1.0.0-rc.19",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -48,9 +48,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@guren/cli": "^1.0.0-rc.20",
-    "@guren/orm": "^1.0.0-rc.19",
-    "@guren/server": "^1.0.0-rc.18"
+    "@guren/cli": "^1.0.0-rc.21",
+    "@guren/orm": "^1.0.0-rc.20",
+    "@guren/server": "^1.0.0-rc.19"
   },
   "devDependencies": {
     "@types/node": "^20.14.10",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,15 @@
 # create-guren-app
 
+## 1.0.0-rc.23
+
+### Patch Changes
+
+- 4011200: Second round of real-app (Kadai) fixes:
+
+  - **@guren/cli codegen: inherited page props are no longer dropped.** `interface Props extends PaginatedPageProps<T> { ... }` now extracts as an intersection of the heritage clauses and the body. Previously only the body was captured — an empty-bodied extends silently degraded the page contract to `{}` (no type checking at all), and adding any own member made the inherited members vanish from the contract, rejecting valid controller props.
+  - **@guren/testing: `TestApp.withCsrf()`** primes CSRF like a real browser — GETs a page, captures the session and XSRF-TOKEN cookies, and sends them (plus `X-XSRF-TOKEN`) on subsequent requests, so mutating endpoints are finally testable against apps with CSRF enabled.
+  - **@guren/orm: `GUREN_QUIET_DUPLICATE_ORM=1`** silences the duplicate-copy warning for environments where two copies coexist by design (e.g. monorepo dev with src + dist).
+
 ## 1.0.0-rc.22
 
 ### Patch Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-guren-app",
-  "version": "1.0.0-rc.22",
+  "version": "1.0.0-rc.23",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/inertia-client/CHANGELOG.md
+++ b/packages/inertia-client/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @guren/inertia-client
 
+## 1.0.0-rc.18
+
+### Patch Changes
+
+- 4011200: Second round of real-app (Kadai) fixes:
+
+  - **@guren/cli codegen: inherited page props are no longer dropped.** `interface Props extends PaginatedPageProps<T> { ... }` now extracts as an intersection of the heritage clauses and the body. Previously only the body was captured — an empty-bodied extends silently degraded the page contract to `{}` (no type checking at all), and adding any own member made the inherited members vanish from the contract, rejecting valid controller props.
+  - **@guren/testing: `TestApp.withCsrf()`** primes CSRF like a real browser — GETs a page, captures the session and XSRF-TOKEN cookies, and sends them (plus `X-XSRF-TOKEN`) on subsequent requests, so mutating endpoints are finally testable against apps with CSRF enabled.
+  - **@guren/orm: `GUREN_QUIET_DUPLICATE_ORM=1`** silences the duplicate-copy warning for environments where two copies coexist by design (e.g. monorepo dev with src + dist).
+
 ## 1.0.0-rc.17
 
 ### Patch Changes

--- a/packages/inertia-client/package.json
+++ b/packages/inertia-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/inertia-client",
-  "version": "1.0.0-rc.17",
+  "version": "1.0.0-rc.18",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/openapi/CHANGELOG.md
+++ b/packages/openapi/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @guren/openapi
 
+## 1.0.0-rc.19
+
+### Patch Changes
+
+- 4011200: Second round of real-app (Kadai) fixes:
+
+  - **@guren/cli codegen: inherited page props are no longer dropped.** `interface Props extends PaginatedPageProps<T> { ... }` now extracts as an intersection of the heritage clauses and the body. Previously only the body was captured — an empty-bodied extends silently degraded the page contract to `{}` (no type checking at all), and adding any own member made the inherited members vanish from the contract, rejecting valid controller props.
+  - **@guren/testing: `TestApp.withCsrf()`** primes CSRF like a real browser — GETs a page, captures the session and XSRF-TOKEN cookies, and sends them (plus `X-XSRF-TOKEN`) on subsequent requests, so mutating endpoints are finally testable against apps with CSRF enabled.
+  - **@guren/orm: `GUREN_QUIET_DUPLICATE_ORM=1`** silences the duplicate-copy warning for environments where two copies coexist by design (e.g. monorepo dev with src + dist).
+
+- Updated dependencies [4011200]
+  - @guren/core@1.0.0-rc.19
+
 ## 1.0.0-rc.18
 
 ### Patch Changes

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/openapi",
-  "version": "1.0.0-rc.18",
+  "version": "1.0.0-rc.19",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@guren/core": "^1.0.0-rc.18"
+    "@guren/core": "^1.0.0-rc.19"
   },
   "devDependencies": {
     "@types/node": "^20.14.10",

--- a/packages/orm/CHANGELOG.md
+++ b/packages/orm/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @guren/orm
 
+## 1.0.0-rc.20
+
+### Patch Changes
+
+- 4011200: Second round of real-app (Kadai) fixes:
+
+  - **@guren/cli codegen: inherited page props are no longer dropped.** `interface Props extends PaginatedPageProps<T> { ... }` now extracts as an intersection of the heritage clauses and the body. Previously only the body was captured — an empty-bodied extends silently degraded the page contract to `{}` (no type checking at all), and adding any own member made the inherited members vanish from the contract, rejecting valid controller props.
+  - **@guren/testing: `TestApp.withCsrf()`** primes CSRF like a real browser — GETs a page, captures the session and XSRF-TOKEN cookies, and sends them (plus `X-XSRF-TOKEN`) on subsequent requests, so mutating endpoints are finally testable against apps with CSRF enabled.
+  - **@guren/orm: `GUREN_QUIET_DUPLICATE_ORM=1`** silences the duplicate-copy warning for environments where two copies coexist by design (e.g. monorepo dev with src + dist).
+
 ## 1.0.0-rc.19
 
 ### Patch Changes

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/orm",
-  "version": "1.0.0-rc.19",
+  "version": "1.0.0-rc.20",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @guren/server
 
+## 1.0.0-rc.19
+
+### Patch Changes
+
+- 4011200: Second round of real-app (Kadai) fixes:
+
+  - **@guren/cli codegen: inherited page props are no longer dropped.** `interface Props extends PaginatedPageProps<T> { ... }` now extracts as an intersection of the heritage clauses and the body. Previously only the body was captured — an empty-bodied extends silently degraded the page contract to `{}` (no type checking at all), and adding any own member made the inherited members vanish from the contract, rejecting valid controller props.
+  - **@guren/testing: `TestApp.withCsrf()`** primes CSRF like a real browser — GETs a page, captures the session and XSRF-TOKEN cookies, and sends them (plus `X-XSRF-TOKEN`) on subsequent requests, so mutating endpoints are finally testable against apps with CSRF enabled.
+  - **@guren/orm: `GUREN_QUIET_DUPLICATE_ORM=1`** silences the duplicate-copy warning for environments where two copies coexist by design (e.g. monorepo dev with src + dist).
+
+- Updated dependencies [4011200]
+  - @guren/orm@1.0.0-rc.20
+  - @guren/inertia-client@1.0.0-rc.18
+
 ## 1.0.0-rc.18
 
 ### Minor Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/server",
-  "version": "1.0.0-rc.18",
+  "version": "1.0.0-rc.19",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -105,8 +105,8 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@guren/inertia-client": "^1.0.0-rc.17",
-    "@guren/orm": "^1.0.0-rc.19",
+    "@guren/inertia-client": "^1.0.0-rc.18",
+    "@guren/orm": "^1.0.0-rc.20",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "chalk": "^5.3.0",
     "consola": "^3.4.2",

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @guren/testing
 
+## 1.0.0-rc.19
+
+### Minor Changes
+
+- 4011200: Second round of real-app (Kadai) fixes:
+
+  - **@guren/cli codegen: inherited page props are no longer dropped.** `interface Props extends PaginatedPageProps<T> { ... }` now extracts as an intersection of the heritage clauses and the body. Previously only the body was captured — an empty-bodied extends silently degraded the page contract to `{}` (no type checking at all), and adding any own member made the inherited members vanish from the contract, rejecting valid controller props.
+  - **@guren/testing: `TestApp.withCsrf()`** primes CSRF like a real browser — GETs a page, captures the session and XSRF-TOKEN cookies, and sends them (plus `X-XSRF-TOKEN`) on subsequent requests, so mutating endpoints are finally testable against apps with CSRF enabled.
+  - **@guren/orm: `GUREN_QUIET_DUPLICATE_ORM=1`** silences the duplicate-copy warning for environments where two copies coexist by design (e.g. monorepo dev with src + dist).
+
+### Patch Changes
+
+- Updated dependencies [4011200]
+  - @guren/server@1.0.0-rc.19
+
 ## 1.0.0-rc.18
 
 ### Patch Changes

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/testing",
-  "version": "1.0.0-rc.18",
+  "version": "1.0.0-rc.19",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -35,7 +35,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@guren/server": ">=1.0.0-rc.18",
+    "@guren/server": ">=1.0.0-rc.19",
     "@inertiajs/react": "^2.3.18",
     "@testing-library/react": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "hono": "^4.12.18",

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,16 @@
 # web
 
+## 0.1.1-rc.16
+
+### Patch Changes
+
+- Updated dependencies [4011200]
+  - @guren/cli@1.0.0-rc.21
+  - @guren/testing@1.0.0-rc.19
+  - @guren/orm@1.0.0-rc.20
+  - @guren/core@1.0.0-rc.19
+  - @guren/inertia-client@1.0.0-rc.18
+
 ## 0.1.1-rc.15
 
 ### Patch Changes

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.1-rc.15",
+  "version": "0.1.1-rc.16",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump for props-heritage-csrf-testing (PR #64).