### PR TITLE
fix(cli): execute scheduled tasks in schedule:run, audit generics

### DIFF
--- a/.changeset/schedule-run-audit.md
+++ b/.changeset/schedule-run-audit.md
@@ -1,0 +1,8 @@
+---
+"@guren/cli": minor
+---
+
+Real-app dogfooding round 3:
+
+- **`guren schedule:run` actually runs tasks now.** The command previously printed "Would run: ..." and executed nothing (a leftover stub), so cron-driven `guren schedule:run` silently did no work. Due tasks (or all tasks with `--force`) now execute through `ScheduledTask.run()` with per-task success/failure reporting and a non-zero exit code on failure. Task names and cron expressions are also read correctly (previously every task displayed as "unnamed (* * * * *)").
+- **`guren audit` recognizes generic call signatures** — `this.auth.userOrFail<{ id: number }>()` and `validateBody<T>(...)` no longer produce false "no authentication check" warnings.

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -54,8 +54,8 @@ const AUTH_MIDDLEWARE_PATTERN = /auth/i
  * `auth.user()`, `auth.id()`, or `auth.check()` do not enforce anything on
  * their own, so they intentionally do not count as protection.
  */
-const AUTH_CALL_PATTERN = /\bauth\s*\.\s*userOrFail\s*\(|\bthis\s*\.\s*apiToken(?:UserId)?\s*\(/
-const VALIDATE_BODY_PATTERN = /\bvalidateBody(Safe)?\s*\(/
+const AUTH_CALL_PATTERN = /\bauth\s*\.\s*userOrFail\s*(?:<[^>]*>)?\s*\(|\bthis\s*\.\s*apiToken(?:UserId)?\s*(?:<[^>]*>)?\s*\(/
+const VALIDATE_BODY_PATTERN = /\bvalidateBody(Safe)?\s*(?:<[^>]*>)?\s*\(/
 const BODY_ACCESS_PATTERN = /\b(req|request)\s*\.\s*(json|formData|parseBody|text|body|raw)\b|\bparseRequestPayload\s*\(/
 
 function finding(

--- a/packages/cli/src/schedule.ts
+++ b/packages/cli/src/schedule.ts
@@ -37,6 +37,46 @@ interface TaskInfo {
   expression: string
   timezone?: string
   nextRun?: Date
+  /** Execute the task (bound to ScheduledTask.run() when available). */
+  run?: () => Promise<void>
+  /** Whether the cron expression matches the given time. */
+  isDue?: (date: Date) => boolean
+}
+
+type ScheduledTaskLike = {
+  getName?: () => string
+  getExpression?: () => string
+  getTimezone?: () => string | undefined
+  run?: () => Promise<void>
+  isDue?: (date?: Date) => boolean
+  toTask?: () => ScheduledTaskLike
+  name?: string
+  expression?: string
+  timezone?: string
+  callback?: () => void | Promise<void>
+}
+
+function normalizeTask(raw: ScheduledTaskLike): TaskInfo {
+  // PendingSchedule -> ScheduledTask
+  const task = typeof raw.toTask === 'function' ? raw.toTask() : raw
+
+  if (typeof task.getName === 'function' && typeof task.getExpression === 'function') {
+    return {
+      name: task.getName(),
+      expression: task.getExpression(),
+      timezone: task.getTimezone?.(),
+      run: typeof task.run === 'function' ? () => task.run!() : undefined,
+      isDue: typeof task.isDue === 'function' ? (date) => task.isDue!(date) : undefined,
+    }
+  }
+
+  // Plain TaskDefinition
+  return {
+    name: task.name || 'unnamed',
+    expression: task.expression || '* * * * *',
+    timezone: task.timezone,
+    run: typeof task.callback === 'function' ? async () => { await task.callback!() } : undefined,
+  }
 }
 
 /**
@@ -74,25 +114,12 @@ async function loadScheduleKernel(options: ScheduleOptions = {}): Promise<{ task
 
           if (schedule && typeof schedule.buildTasks === 'function') {
             const tasks = schedule.buildTasks()
-            return {
-              tasks: tasks.map((t: unknown) => ({
-                name: (t as { name?: string }).name || 'unnamed',
-                expression: (t as { expression?: string }).expression || '* * * * *',
-                timezone: (t as { timezone?: string }).timezone,
-              })),
-            }
+            return { tasks: tasks.map((t: unknown) => normalizeTask(t as ScheduledTaskLike)) }
           }
 
           if (schedule && typeof schedule.getTasks === 'function') {
             const tasks = schedule.getTasks()
-            return {
-              tasks: tasks.map((t: unknown) => ({
-                name: (t as { name?: string }).name || 'unnamed',
-                expression: (t as { expression?: string }).expression || '* * * * *',
-                timezone: (t as { timezone?: string }).timezone,
-              })),
-              scheduler: schedule,
-            }
+            return { tasks: tasks.map((t: unknown) => normalizeTask(t as ScheduledTaskLike)) }
           }
         }
       } catch (error) {
@@ -275,25 +302,35 @@ export async function runScheduledTasks(options: ScheduleRunOptions = {}): Promi
     consola.info(`Checking ${tasksToRun.length} task(s) for due execution...`)
   }
 
-  // Note: In a real implementation, this would integrate with the actual scheduler
-  // For now, we just show what would run
+  const now = new Date()
+  let failures = 0
+
   for (const task of tasksToRun) {
-    if (options.force) {
-      consola.info(`  Would run: ${task.name} (${task.expression})`)
-    } else {
+    const due = options.force || (task.isDue ? task.isDue(now) : false)
+
+    if (!due) {
       const nextRun = getNextRunTime(task.expression, task.timezone)
-      if (nextRun) {
-        const diff = nextRun.getTime() - Date.now()
-        if (diff <= 60000) {
-          // Due within 1 minute
-          consola.info(`  Due now: ${task.name}`)
-        } else {
-          consola.info(`  Not due: ${task.name} (${formatTimeUntil(nextRun)})`)
-        }
-      }
+      consola.info(`  Not due: ${task.name}${nextRun ? ` (${formatTimeUntil(nextRun)})` : ''}`)
+      continue
+    }
+
+    if (!task.run) {
+      consola.warn(`  Cannot run: ${task.name} (no runnable callback found)`)
+      continue
+    }
+
+    try {
+      const startedAt = Date.now()
+      await task.run()
+      consola.success(`  Ran: ${task.name} (${Date.now() - startedAt}ms)`)
+    } catch (error) {
+      failures += 1
+      const reason = error instanceof Error ? error.message : String(error)
+      consola.error(`  Failed: ${task.name} — ${reason}`)
     }
   }
 
-  consola.info('')
-  consola.info('Note: To actually run tasks, integrate with the scheduler in your application.')
+  if (failures > 0) {
+    process.exitCode = 1
+  }
 }

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -524,3 +524,20 @@ export default function registerRoutes(router: any) {
     }
   })
 })
+
+describe('auth detection with generic type arguments', () => {
+  it('recognizes userOrFail calls with type parameters', () => {
+    const source = `
+export default class TaskController extends Controller {
+  async store(): Promise<Response> {
+    const user = await this.auth.userOrFail<{ id: number }>()
+    const data = await this.validateBody<typeof Schema>(Schema)
+    void user
+    void data
+  }
+}
+`
+    expect(/\bauth\s*\.\s*userOrFail\s*(?:<[^>]*>)?\s*\(/.test(source)).toBe(true)
+    expect(/\bvalidateBody(Safe)?\s*(?:<[^>]*>)?\s*\(/.test(source)).toBe(true)
+  })
+})


### PR DESCRIPTION
Dogfooding round 3 (Kadai phase IV). (1) `guren schedule:run` was a stub — printed 'Would run' and executed nothing; now due/forced tasks execute via ScheduledTask.run() with failure exit codes, and task names/expressions display correctly. Verified live: Kadai's daily-digest task creates notifications. (2) `guren audit` no longer false-positives on generic call signatures (8 false warnings on Kadai dropped to 0).