### PR TITLE
feat: controller file helpers and multipart TestApp bodies

### DIFF
--- a/.changeset/file-helpers-multipart.md
+++ b/.changeset/file-helpers-multipart.md
@@ -1,0 +1,15 @@
+---
+"@guren/server": minor
+"@guren/testing": minor
+"@guren/core": patch
+"@guren/orm": patch
+"@guren/cli": patch
+"@guren/openapi": patch
+"@guren/inertia-client": patch
+"create-guren-app": patch
+---
+
+First-class file uploads:
+
+- **`this.file(name)` / `this.files(name)` controller helpers** — read uploaded files from multipart requests (null/empty-safe, composes with other body reads via Hono's cached parseBody). Previously controllers had to call `this.request.parseBody()` and duck-type the result.
+- **`TestApp` accepts `FormData` bodies** — `csrf.post('/tasks/1/attachments', formData)` sends real multipart requests, so upload endpoints are finally testable.

--- a/packages/server/src/mvc/Controller.ts
+++ b/packages/server/src/mvc/Controller.ts
@@ -172,6 +172,40 @@ export class Controller {
     return this.ctx.req
   }
 
+  /**
+   * Get an uploaded file from a multipart request.
+   *
+   * Returns null when the field is missing, is not a file, or the upload is
+   * empty. Hono caches the parsed body, so this composes with other body
+   * reads in the same request.
+   *
+   * @example
+   * ```typescript
+   * const avatar = await this.file('avatar')
+   * if (!avatar) {
+   *   throw ValidationException.withMessages({ avatar: 'Choose a file.' })
+   * }
+   * await storage.disk().put(`avatars/${avatar.name}`, Buffer.from(await avatar.arrayBuffer()))
+   * ```
+   */
+  protected async file(name: string): Promise<File | null> {
+    const body = await this.ctx.req.parseBody({ all: true })
+    const value = body[name]
+    const candidate = Array.isArray(value) ? value[0] : value
+    return candidate instanceof File && candidate.size > 0 ? candidate : null
+  }
+
+  /**
+   * Get all uploaded files for a multipart field (e.g. `<input multiple>`).
+   * Returns an empty array when none were uploaded.
+   */
+  protected async files(name: string): Promise<File[]> {
+    const body = await this.ctx.req.parseBody({ all: true })
+    const value = body[name]
+    const values = Array.isArray(value) ? value : value !== undefined ? [value] : []
+    return values.filter((item): item is File => item instanceof File && item.size > 0)
+  }
+
   protected get auth(): AuthContext {
     const auth = this.ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
     if (!auth) {

--- a/packages/server/tests/mvc/ControllerFiles.test.ts
+++ b/packages/server/tests/mvc/ControllerFiles.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect } from 'bun:test'
+import { Hono } from 'hono'
+import { Controller } from '../../src/mvc/Controller'
+
+class UploadController extends Controller {
+  async single() {
+    const file = await this.file('document')
+    if (!file) {
+      return this.json({ file: null })
+    }
+    return this.json({ file: { name: file.name, size: file.size, content: await file.text() } })
+  }
+
+  async multiple() {
+    const files = await this.files('documents')
+    return this.json({ count: files.length, names: files.map((file) => file.name) })
+  }
+
+  async mixed() {
+    const file = await this.file('document')
+    const body = await this.ctx.req.parseBody()
+    return this.json({ hasFile: file !== null, title: body.title ?? null })
+  }
+}
+
+function createApp() {
+  const app = new Hono()
+  for (const [path, action] of [
+    ['/single', 'single'],
+    ['/multiple', 'multiple'],
+    ['/mixed', 'mixed'],
+  ] as const) {
+    app.post(path, async (c) => {
+      const ctrl = new UploadController()
+      ctrl.setContext(c)
+      return ctrl[action]()
+    })
+  }
+  return app
+}
+
+describe('Controller file helpers', () => {
+  test('file() returns the uploaded file with its contents', async () => {
+    const app = createApp()
+    const form = new FormData()
+    form.append('document', new File(['hello world'], 'notes.txt', { type: 'text/plain' }))
+
+    const res = await app.request('/single', { method: 'POST', body: form })
+    const json = (await res.json()) as { file: { name: string; size: number; content: string } }
+    expect(json.file.name).toBe('notes.txt')
+    expect(json.file.content).toBe('hello world')
+  })
+
+  test('file() returns null for a missing or non-file field', async () => {
+    const app = createApp()
+    const form = new FormData()
+    form.append('document', 'just a string')
+
+    const res = await app.request('/single', { method: 'POST', body: form })
+    expect(((await res.json()) as { file: unknown }).file).toBeNull()
+  })
+
+  test('file() returns null for empty uploads', async () => {
+    const app = createApp()
+    const form = new FormData()
+    form.append('document', new File([], 'empty.txt'))
+
+    const res = await app.request('/single', { method: 'POST', body: form })
+    expect(((await res.json()) as { file: unknown }).file).toBeNull()
+  })
+
+  test('files() returns every uploaded file for a multi field', async () => {
+    const app = createApp()
+    const form = new FormData()
+    form.append('documents', new File(['a'], 'a.txt'))
+    form.append('documents', new File(['b'], 'b.txt'))
+
+    const res = await app.request('/multiple', { method: 'POST', body: form })
+    const json = (await res.json()) as { count: number; names: string[] }
+    expect(json.count).toBe(2)
+    expect(json.names).toEqual(['a.txt', 'b.txt'])
+  })
+
+  test('file() composes with other parseBody reads in the same request', async () => {
+    const app = createApp()
+    const form = new FormData()
+    form.append('document', new File(['x'], 'x.txt'))
+    form.append('title', 'My upload')
+
+    const res = await app.request('/mixed', { method: 'POST', body: form })
+    const json = (await res.json()) as { hasFile: boolean; title: string }
+    expect(json.hasFile).toBe(true)
+    expect(json.title).toBe('My upload')
+  })
+})

--- a/packages/testing/src/test-app.ts
+++ b/packages/testing/src/test-app.ts
@@ -499,7 +499,8 @@ export class TestApp {
 
     const headers: Record<string, string> = { ...this.defaultHeaders }
 
-    if (body !== undefined && body !== null) {
+    // FormData bodies get their multipart boundary from fetch itself.
+    if (body !== undefined && body !== null && !(body instanceof FormData)) {
       headers['Content-Type'] = 'application/json'
     }
 
@@ -521,7 +522,7 @@ export class TestApp {
     }
 
     if (body !== undefined && body !== null) {
-      init.body = JSON.stringify(body)
+      init.body = body instanceof FormData ? body : JSON.stringify(body)
     }
 
     const promise = (async () => {


### PR DESCRIPTION
Kadai phase IV surfaced two gaps: no first-class file API on controllers (raw `parseBody()` + duck typing) and no way to send multipart bodies through TestApp. Adds `this.file()`/`this.files()` (5 tests incl. cached-parseBody composition) and FormData body support in TestApp. Framework tests, typecheck green.