### PR TITLE
fix(server): wire the SSE subscription flow end to end

### DIFF
--- a/.changeset/sse-subscription-flow.md
+++ b/.changeset/sse-subscription-flow.md
@@ -1,0 +1,17 @@
+---
+"@guren/server": minor
+"@guren/core": patch
+"@guren/orm": patch
+"@guren/cli": patch
+"@guren/testing": patch
+"@guren/openapi": patch
+"@guren/inertia-client": patch
+"create-guren-app": patch
+---
+
+Make SSE broadcasting actually reachable from clients:
+
+- **The SSE stream announces the connection** with a `connected` event carrying the `clientId` and any already-subscribed channels. Previously clients had no way to learn their id, and no HTTP path ever subscribed a client to a channel — SSE connections received pings but never a single broadcast event.
+- **`?channels=a,b` query subscriptions** on the SSE endpoint: requested channels are authorized against the connecting user (`sseMiddleware({ getUser })`) and subscribed before the stream starts, so a bare `EventSource` works for public channels.
+- **`POST /broadcasting/auth` subscribes as well as authorizes** when the payload includes the `clientId`, returning `{ authorized, subscribed }` per channel.
+- **Unregistered `private-`/`presence-` channels now default to deny** instead of public access — a missing channel registration no longer silently exposes a private channel.

--- a/packages/server/src/broadcasting/BroadcastManager.ts
+++ b/packages/server/src/broadcasting/BroadcastManager.ts
@@ -211,8 +211,10 @@ export class BroadcastManager {
     const registration = this.findChannelRegistration(channelName)
 
     if (!registration) {
-      // No registration means public access
-      return true
+      // Unregistered channels are treated as public, but names using the
+      // private-/presence- prefixes default to deny — otherwise a typo in
+      // channel registration would silently expose a private channel.
+      return !(channelName.startsWith('private-') || channelName.startsWith('presence-'))
     }
 
     if (registration.type === 'presence') {
@@ -264,6 +266,22 @@ export class BroadcastManager {
       const encoder = new TextEncoder()
       const manager = this
 
+      // Channels requested up front (?channels=a,b) are authorized against
+      // the connecting user and subscribed before the stream starts, so a
+      // plain EventSource works for public channels with zero extra calls.
+      const requestedChannels = (ctx.req.query('channels') ?? '')
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean)
+      const user = options.getUser ? await options.getUser(ctx) : undefined
+      const authorizedChannels: string[] = []
+      for (const channelName of requestedChannels) {
+        const authResult = await this.authorize(channelName, user)
+        if (authResult !== false && authResult !== null) {
+          authorizedChannels.push(channelName)
+        }
+      }
+
       let controller: ReadableStreamDefaultController<Uint8Array> | null = null
       let client: SSEClient | null = null
       let pingTimer: ReturnType<typeof setInterval> | null = null
@@ -313,6 +331,14 @@ export class BroadcastManager {
 
           // Send initial retry configuration
           sendRaw(`retry: ${retry}\n\n`)
+
+          // Tell the client its id so it can authorize private channels
+          // via POST /broadcasting/auth { clientId, channel }.
+          client.send('connected', { clientId, channels: authorizedChannels })
+
+          for (const channelName of authorizedChannels) {
+            manager.subscribeClient(clientId, channelName)
+          }
 
           // Setup ping interval
           pingTimer = setInterval(() => {
@@ -365,7 +391,10 @@ export class BroadcastManager {
         return ctx.json({ error: 'No channel specified' }, 400)
       }
 
-      // Authorize each channel
+      // Authorize each channel; when the payload carries the SSE clientId
+      // (sent to the client in the `connected` event), also subscribe the
+      // client so authorized events actually flow.
+      const clientId = typeof payload.clientId === 'string' ? payload.clientId : undefined
       const results: Record<string, unknown> = {}
 
       for (const ch of channels) {
@@ -373,12 +402,17 @@ export class BroadcastManager {
 
         if (authResult === false || authResult === null) {
           results[ch] = { authorized: false }
-        } else if (authResult === true) {
-          results[ch] = { authorized: true }
+          continue
+        }
+
+        const subscribed = clientId ? this.subscribeClient(clientId, ch) : false
+        if (authResult === true) {
+          results[ch] = { authorized: true, subscribed }
         } else {
           // Presence channel - return member info
           results[ch] = {
             authorized: true,
+            subscribed,
             member: authResult,
           }
         }

--- a/packages/server/src/broadcasting/types.ts
+++ b/packages/server/src/broadcasting/types.ts
@@ -144,6 +144,12 @@ export interface SSEMiddlewareOptions {
    * Retry delay for SSE reconnection.
    */
   retry?: number
+
+  /**
+   * Function to get the user from the request context, used to authorize
+   * channels requested via the `?channels=` query parameter.
+   */
+  getUser?: (ctx: unknown) => unknown | Promise<unknown>
 }
 
 /**

--- a/packages/server/tests/broadcasting/sse-flow.test.ts
+++ b/packages/server/tests/broadcasting/sse-flow.test.ts
@@ -1,0 +1,134 @@
+import { describe, test, expect } from 'bun:test'
+import { Hono } from 'hono'
+import { createBroadcastManager } from '../../src/broadcasting'
+import { MemoryDriver } from '../../src/broadcasting/drivers'
+
+function createManager() {
+  return createBroadcastManager({
+    default: 'memory',
+    drivers: { memory: () => new MemoryDriver() },
+  })
+}
+
+async function readEvents(
+  body: ReadableStream<Uint8Array>,
+  until: (events: Array<{ event: string; data: unknown }>) => boolean,
+  timeoutMs = 2000,
+): Promise<Array<{ event: string; data: unknown }>> {
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  const events: Array<{ event: string; data: unknown }> = []
+  let buffer = ''
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline && !until(events)) {
+    const { value, done } = await Promise.race([
+      reader.read(),
+      new Promise<{ value: undefined; done: true }>((resolve) =>
+        setTimeout(() => resolve({ value: undefined, done: true }), deadline - Date.now()),
+      ),
+    ])
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+
+    let index: number
+    while ((index = buffer.indexOf('\n\n')) !== -1) {
+      const chunk = buffer.slice(0, index)
+      buffer = buffer.slice(index + 2)
+      const eventMatch = chunk.match(/^event: (.+)$/m)
+      const dataMatch = chunk.match(/^data: (.+)$/m)
+      if (eventMatch && dataMatch) {
+        events.push({ event: eventMatch[1], data: JSON.parse(dataMatch[1]) })
+      }
+    }
+  }
+
+  await reader.cancel().catch(() => {})
+  return events
+}
+
+describe('SSE subscription flow', () => {
+  test('should announce the client id and deliver events for query-subscribed public channels', async () => {
+    const manager = createManager()
+    manager.channel('announcements', () => true)
+
+    const app = new Hono()
+    app.get('/events', manager.sseMiddleware({ pingInterval: 60000 }) as never)
+
+    const response = await app.request('/events?channels=announcements')
+    expect(response.status).toBe(200)
+
+    const eventsPromise = readEvents(response.body!, (events) =>
+      events.some((entry) => entry.event === 'BoardUpdated'),
+    )
+
+    // Give the stream a beat to register its subscription, then publish.
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    await manager.broadcast('announcements', 'BoardUpdated', { taskId: 7 })
+
+    const events = await eventsPromise
+    const connected = events.find((entry) => entry.event === 'connected')
+    expect(connected).toBeDefined()
+    expect((connected!.data as { clientId: string }).clientId).toMatch(/.+/)
+    expect((connected!.data as { channels: string[] }).channels).toEqual(['announcements'])
+
+    const update = events.find((entry) => entry.event === 'BoardUpdated')
+    expect(update).toBeDefined()
+    expect((update!.data as { data: { taskId: number } }).data?.taskId ?? (update!.data as { taskId: number }).taskId).toBe(7)
+  })
+
+  test('should not subscribe unauthorized channels from the query', async () => {
+    const manager = createManager()
+    manager.privateChannel('secret', () => false)
+
+    const app = new Hono()
+    app.get('/events', manager.sseMiddleware({ pingInterval: 60000 }) as never)
+
+    const response = await app.request('/events?channels=private-secret,private-unregistered')
+    const events = await readEvents(response.body!, (entries) =>
+      entries.some((entry) => entry.event === 'connected'),
+    )
+
+    const connected = events.find((entry) => entry.event === 'connected')
+    expect((connected!.data as { channels: string[] }).channels).toEqual([])
+  })
+
+  test('should subscribe an existing client through the auth endpoint', async () => {
+    const manager = createManager()
+    manager.privateChannel('users.1.notifications', (_channel, user) => (user as { id: number } | null)?.id === 1)
+
+    const app = new Hono()
+    app.get('/events', manager.sseMiddleware({ pingInterval: 60000 }) as never)
+    app.post(
+      '/auth',
+      manager.authMiddleware({ getUser: () => ({ id: 1 }) }) as never,
+    )
+
+    const response = await app.request('/events')
+    const reader = response.body!.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+    let clientId = ''
+    while (!clientId) {
+      const { value, done } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      const match = buffer.match(/event: connected\ndata: (.+)\n/)
+      if (match) {
+        clientId = (JSON.parse(match[1]) as { clientId: string }).clientId
+      }
+    }
+    expect(clientId).toMatch(/.+/)
+
+    const authResponse = await app.request('/auth', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ clientId, channel: 'private-users.1.notifications' }),
+    })
+    const authJson = (await authResponse.json()) as Record<string, { authorized: boolean; subscribed: boolean }>
+    expect(authJson['private-users.1.notifications'].authorized).toBe(true)
+    expect(authJson['private-users.1.notifications'].subscribed).toBe(true)
+
+    await reader.cancel().catch(() => {})
+  })
+})


### PR DESCRIPTION
Kadai phase V surfaced that SSE broadcasting was end-to-end non-functional: clients never learned their clientId and nothing ever called subscribeClient(), so EventSource connections only received pings. Adds the connected handshake, ?channels= query subscription (authorized via getUser), auth-endpoint subscription, and default-deny for unregistered private-/presence- channels (security hardening: a missing registration no longer exposes a private channel). New SSE flow test suite; framework tests green.