### PR TITLE
fix(server): accept Hono middleware as terminal route handler

### DIFF
--- a/.changeset/middleware-as-route-handler.md
+++ b/.changeset/middleware-as-route-handler.md
@@ -1,0 +1,15 @@
+---
+"@guren/server": minor
+"@guren/core": patch
+"@guren/orm": patch
+"@guren/cli": patch
+"@guren/testing": patch
+"@guren/openapi": patch
+"@guren/inertia-client": patch
+"create-guren-app": patch
+---
+
+Accept Hono middleware as a terminal route handler:
+
+- **`RouteHandler` now includes `(c, next)` signatures**, so any Hono `MiddlewareHandler` — including `broadcast.sseMiddleware()` and `broadcast.authMiddleware()` — can be passed directly to `router.get()` / `router.post()` as the docs show, without wrapper closures or `as Promise<Response>` casts.
+- **Responses set via `c.res` are honored**: a middleware mounted as a handler that finalizes the response through `next()` or `c.res =` no longer gets clobbered by a synthesized `204 No Content`. Plain handlers returning `undefined` still produce `204`.

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -1,4 +1,4 @@
-import type { Context, MiddlewareHandler, Hono } from 'hono'
+import type { Context, MiddlewareHandler, Hono, Next } from 'hono'
 import { Controller } from './Controller'
 import type { Container } from '../container/Container'
 import { mountRoute } from './mount-route'
@@ -36,12 +36,14 @@ export type RouteResult =
 
 /**
  * Handler for a route - either an inline function or a controller action tuple.
+ * Inline handlers receive `next`, so any Hono middleware (e.g.
+ * `broadcast.sseMiddleware()`) can be mounted directly as a terminal handler.
  */
 export type RouteHandler<C extends ControllerConstructor = ControllerConstructor> =
-  | ((c: Context) => RouteResult | Promise<RouteResult>)
+  | ((c: Context, next: Next) => RouteResult | Promise<RouteResult>)
   | ControllerAction<C>
 
-type AnyRouteHandler = ((c: Context) => RouteResult | Promise<RouteResult>) | AnyControllerAction
+type AnyRouteHandler = ((c: Context, next: Next) => RouteResult | Promise<RouteResult>) | AnyControllerAction
 
 /**
  * Model binding resolver function.
@@ -907,8 +909,14 @@ function resolveHandler(
     }
   }
 
-  return async (c) => {
-    const result = await action(c)
+  return async (c, next) => {
+    const result = await action(c, next)
+    // Middleware mounted as a handler may set the response via c.res
+    // (directly or through next()) and return nothing — honor it instead
+    // of synthesizing a 204.
+    if (result === undefined && c.finalized) {
+      return c.res
+    }
     return ensureResponse(result)
   }
 }

--- a/packages/server/tests/mvc/router.test.ts
+++ b/packages/server/tests/mvc/router.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import { Hono, type MiddlewareHandler } from 'hono'
 import { z } from 'zod'
 import { Router } from '../../src/mvc/Router'
 import { Controller } from '../../src/mvc/Controller'
@@ -165,5 +166,51 @@ describe('Router definition introspection', () => {
 
     const [def] = router.definitions()
     expect(def!.hasInlineMiddleware).toBe(true)
+  })
+})
+
+describe('Router middleware as terminal handler', () => {
+  it('accepts a Hono MiddlewareHandler as the route handler', async () => {
+    const middleware: MiddlewareHandler = async (c) => {
+      return c.text('from middleware')
+    }
+
+    const router = new Router()
+    router.get('/events', middleware)
+
+    const app = new Hono()
+    router.mount(app)
+
+    const response = await app.request('/events')
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('from middleware')
+  })
+
+  it('honors a response set via c.res instead of synthesizing a 204', async () => {
+    const middleware: MiddlewareHandler = async (c, next) => {
+      await next()
+      c.res = new Response('finalized', { status: 201 })
+    }
+
+    const router = new Router()
+    router.get('/finalized', middleware)
+
+    const app = new Hono()
+    router.mount(app)
+
+    const response = await app.request('/finalized')
+    expect(response.status).toBe(201)
+    expect(await response.text()).toBe('finalized')
+  })
+
+  it('still converts undefined returns from plain handlers into 204', async () => {
+    const router = new Router()
+    router.get('/empty', () => undefined)
+
+    const app = new Hono()
+    router.mount(app)
+
+    const response = await app.request('/empty')
+    expect(response.status).toBe(204)
   })
 })


### PR DESCRIPTION
## Summary

Kadai dogfooding (rc.29) surfaced a docs/type mismatch: the broadcasting guide shows passing `broadcast.sseMiddleware()` directly to `router.get()`, but `RouteHandler`'s inline form only accepted `(c: Context) => RouteResult`. Hono's `MiddlewareHandler` takes `(c, next)`, which is not assignable to a one-parameter function type, so following the docs failed to compile — forcing this workaround in app code:

```ts
// TODO(guren): docs show passing sseMiddleware() directly to router.get,
const sseHandler = broadcastManager.sseMiddleware({ ... })
router.get('/broadcasting/events', (c) => sseHandler(c, async () => {}) as Promise<Response>)
```

## Changes

- Widen `RouteHandler`'s inline signature to `(c: Context, next: Next) => RouteResult | Promise<RouteResult>` so any Hono `MiddlewareHandler` can be mounted as a terminal handler. Plain `(c) => ...` handlers remain assignable.
- `resolveHandler` passes `next` through, and honors a response finalized via `c.res` (directly or through `next()`) instead of synthesizing a `204`. Plain handlers returning `undefined` still produce `204`.

After the next release, Kadai's wrapper (and cast) collapses to:

```ts
router.get('/broadcasting/events', broadcastManager.sseMiddleware({ ... }))
router.post('/broadcasting/auth', broadcastManager.authMiddleware({ ... }))
```

## Testing

- New tests in `packages/server/tests/mvc/router.test.ts`: MiddlewareHandler as route handler, `c.res` finalization not clobbered by 204, and the existing undefined→204 behavior preserved
- `bun run build` / `bun run typecheck` / `bun run test:bun` (2097 pass, 0 fail)