### PR TITLE
fix(server): CSRF cookie refresh wipes other cookies + i18n loader option

### DIFF
--- a/.changeset/i18n-loader-csrf-cookie-append.md
+++ b/.changeset/i18n-loader-csrf-cookie-append.md
@@ -1,0 +1,15 @@
+---
+"@guren/server": patch
+"@guren/core": patch
+"@guren/orm": patch
+"@guren/cli": patch
+"@guren/testing": patch
+"@guren/openapi": patch
+"@guren/inertia-client": patch
+"create-guren-app": patch
+---
+
+Two fixes surfaced by dogfooding i18n in a real app:
+
+- **CSRF cookie refresh no longer wipes other cookies.** `setXsrfCookie` replaced the `Set-Cookie` header on the finalized response, silently dropping any cookie appended by inner middleware or handlers (e.g. a `locale` cookie). It now appends.
+- **`I18nConfig` accepts a `loader` option** as the i18n guide documents. Previously only `path` existed, so `MemoryLoader` (or any custom `TranslationLoader`) could not be injected into `createI18n` / `new I18nManager()`. `loader` takes precedence over `path`.

--- a/packages/server/src/http/middleware/csrf.ts
+++ b/packages/server/src/http/middleware/csrf.ts
@@ -260,9 +260,12 @@ function setXsrfCookie(
   options: CsrfOptions['cookieOptions'] = {},
 ): void {
   const { path = '/', secure = DEFAULT_COOKIE_SECURE, sameSite = 'Lax' } = options
-  // httpOnly must be false so JavaScript (Axios) can read the cookie
+  // httpOnly must be false so JavaScript (Axios) can read the cookie.
+  // Must append: setting Set-Cookie wholesale on the finalized response
+  // wipes cookies added by inner middleware and handlers.
   ctx.header(
     'Set-Cookie',
     `${XSRF_COOKIE_NAME}=${encodeURIComponent(token)}; Path=${path}; SameSite=${sameSite}${secure ? '; Secure' : ''}`,
+    { append: true },
   )
 }

--- a/packages/server/src/i18n/I18nManager.ts
+++ b/packages/server/src/i18n/I18nManager.ts
@@ -18,7 +18,7 @@ export class I18nManager {
 
   constructor(config: I18nConfig) {
     this.config = config
-    this.loader = config.path ? new JsonLoader(config.path) : null
+    this.loader = config.loader ?? (config.path ? new JsonLoader(config.path) : null)
 
     this.translator = new Translator({
       locale: config.locale,

--- a/packages/server/src/i18n/types.ts
+++ b/packages/server/src/i18n/types.ts
@@ -85,9 +85,15 @@ export interface I18nConfig {
   fallbackLocale?: string
 
   /**
-   * Path to translation files.
+   * Path to translation files (constructs a JsonLoader internally).
    */
   path?: string
+
+  /**
+   * Custom translation loader (e.g. JsonLoader, MemoryLoader).
+   * Takes precedence over `path`.
+   */
+  loader?: TranslationLoader
 
   /**
    * Preloaded messages.

--- a/packages/server/tests/http/middleware/csrf.test.ts
+++ b/packages/server/tests/http/middleware/csrf.test.ts
@@ -379,3 +379,53 @@ describe('createCsrfMiddleware', () => {
     expect(token1).toBe(token2) // Same token across session
   })
 })
+
+describe('setXsrfCookie append behavior', () => {
+  it('preserves cookies set by inner middleware and handlers', async () => {
+    const app = createTestApp()
+
+    app.use(async (c, next) => {
+      c.header('Set-Cookie', 'locale=ja; Path=/; SameSite=Lax', { append: true })
+      await next()
+    })
+
+    app.get('/page', (c) => c.text('page content'))
+
+    const res = await app.request('/page')
+    const cookies = res.headers.getSetCookie()
+
+    expect(cookies.some((c) => c.startsWith('locale=ja'))).toBe(true)
+    expect(cookies.some((c) => c.startsWith('XSRF-TOKEN='))).toBe(true)
+  })
+
+  it('preserves cookies on protected methods after a successful mutation', async () => {
+    const app = createTestApp()
+    let token: string | undefined
+
+    app.get('/form', (c) => {
+      token = getCsrfToken(c)
+      return c.text('form')
+    })
+
+    app.post('/submit', (c) => {
+      c.header('Set-Cookie', 'theme=dark; Path=/; SameSite=Lax', { append: true })
+      return c.text('submitted')
+    })
+
+    const getRes = await app.request('/form')
+    const cookie = extractCookie(getRes)
+
+    const postRes = await app.request('/submit', {
+      method: 'POST',
+      headers: {
+        [CSRF_HEADER_NAME]: token!,
+        Cookie: cookie,
+      },
+    })
+
+    expect(postRes.status).toBe(200)
+    const cookies = postRes.headers.getSetCookie()
+    expect(cookies.some((c) => c.startsWith('theme=dark'))).toBe(true)
+    expect(cookies.some((c) => c.startsWith('XSRF-TOKEN='))).toBe(true)
+  })
+})

--- a/packages/server/tests/i18n/i18n.test.ts
+++ b/packages/server/tests/i18n/i18n.test.ts
@@ -498,3 +498,39 @@ describe('Global functions', () => {
     expect(i18n.getLocale()).toBe('en')
   })
 })
+
+describe('I18nConfig loader option', () => {
+  it('accepts a custom loader (MemoryLoader) as documented', async () => {
+    const loader = new MemoryLoader({
+      en: { messages: { hello: 'Hello' } },
+      ja: { messages: { hello: 'こんにちは' } },
+    })
+
+    const i18n = createI18n({
+      locale: 'en',
+      fallbackLocale: 'en',
+      loader,
+    })
+
+    await i18n.loadLocales(['en', 'ja'])
+
+    expect(i18n.t('messages.hello')).toBe('Hello')
+    expect(i18n.forLocale('ja').t('messages.hello')).toBe('こんにちは')
+  })
+
+  it('prefers the loader over path when both are given', async () => {
+    const loader = new MemoryLoader({
+      en: { messages: { source: 'memory' } },
+    })
+
+    const i18n = createI18n({
+      locale: 'en',
+      path: './definitely-missing-lang-dir',
+      loader,
+    })
+
+    await i18n.loadLocale('en')
+
+    expect(i18n.t('messages.source')).toBe('memory')
+  })
+})


### PR DESCRIPTION
## Summary

Two bugs surfaced while dogfooding the i18n subsystem in Kadai (first real-app use of i18n).

### 1. CSRF cookie refresh silently drops other cookies

`setXsrfCookie()` called `ctx.header('Set-Cookie', ...)` **without append** after `next()`. On a finalized response this replaces the entire `Set-Cookie` header, wiping any cookie appended by inner middleware or route handlers. In Kadai, a `locale` cookie set by an app middleware disappeared from every response — the session cookie only survives because the session middleware's after-`next()` phase happens to run later and re-appends.

Fix: append instead of set. Each request goes through exactly one `setXsrfCookie` call (safe-method and protected-method paths are exclusive branches), so no duplicate XSRF-TOKEN entries are introduced.

### 2. `I18nConfig` rejects the documented `loader` option

The i18n guide shows `new I18nManager({ locale, loader: new JsonLoader('./lang') })` and MemoryLoader injection, but `I18nConfig` only accepted `path` — the JsonLoader was constructed internally and custom `TranslationLoader`s could not be injected (`error TS2353: 'loader' does not exist in type 'I18nConfig'`). Add `loader?: TranslationLoader`, taking precedence over `path`.

## Testing

- New csrf tests assert cookies from inner middleware/handlers survive on both safe and protected methods (verified they fail without the fix)
- New i18n tests cover MemoryLoader injection via `createI18n` and loader-over-path precedence
- `bun run build:clean` / `bun run typecheck` / `bun run test:bun` (2098 pass, 0 fail)
- End-to-end: Kadai now serves a locale cookie alongside XSRF/session cookies and renders ja/en UI from `?locale=` / cookie / Accept-Language