### PR TITLE
feat(server): merge prepared headers into route responses + DX helpers

### DIFF
--- a/.changeset/dx-friction-lap3.md
+++ b/.changeset/dx-friction-lap3.md
@@ -1,0 +1,17 @@
+---
+"@guren/server": minor
+"@guren/testing": minor
+"@guren/core": patch
+"@guren/orm": patch
+"@guren/cli": patch
+"@guren/openapi": patch
+"@guren/inertia-client": patch
+"create-guren-app": patch
+---
+
+DX fixes from the i18n dogfooding lap:
+
+- **Middleware `c.header()` now reaches controller responses.** Handlers and controllers return raw `Response` objects, which bypassed Hono's response construction — headers staged via `c.header()` in upstream middleware (e.g. a locale cookie) were silently dropped. Route responses are now rebuilt through `c.newResponse()`, merging prepared headers (`Set-Cookie` appended, the handler's own headers winning otherwise).
+- **`TestApp.withHeaders()` / `withHeader()`**: send custom request headers on every request (Accept-Language, bearer tokens, …). Like `actingAs()` and `json()`, they return a new `TestApp` and compose freely.
+- **`shareInertiaProps()`** merges shared props over previously registered resolvers, so multiple providers can each contribute (auth, i18n, flash, …) without clobbering one another. `getInertiaSharedPropsResolver()` is now exported for manual composition.
+- **Docs**: global middleware must be attached in a provider's `register()` — routes mount before `boot()`, so `app.use()` from `boot()` never applies. Documented in the architecture guide (en/ja).

--- a/docs/en/guides/architecture.md
+++ b/docs/en/guides/architecture.md
@@ -105,6 +105,25 @@ export default class AppServiceProvider extends ServiceProvider {
 - **`register()`**: Bind services into the container. Do not resolve other services here—they may not be registered yet.
 - **`boot()`**: Called after every provider's `register()` has run. Safe to resolve and use other services.
 
+> **Global middleware must be attached in `register()`.** Routes are mounted
+> *between* `register()` and `boot()`, and Hono only applies middleware
+> registered ahead of the matched route — `app.use()` from `boot()` never runs
+> for your routes. Both hooks may be `async` if you need to load resources
+> (e.g. translation files) first:
+>
+> ```ts
+> export default class I18nProvider extends ServiceProvider {
+>   async register(): Promise<void> {
+>     const i18n = createI18n({ locale: 'ja', fallbackLocale: 'en', path: './lang' })
+>     await i18n.loadLocales(['en', 'ja'])
+>     setI18n(i18n)
+>
+>     const app = this.container.make<Application>('app')
+>     app.use('*', localeMiddleware) // register(), not boot()
+>   }
+> }
+> ```
+
 ## Routing
 `routes/web.ts` exports a registrar and configures an app-local router:
 

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -251,6 +251,17 @@ setInertiaSharedProps(async (ctx) => {
 
 Augment `InertiaSharedProps` (see the Controllers guide) to type this `auth` payload for React pages.
 
+> `setInertiaSharedProps` replaces the whole resolver. When several parts of
+> your app contribute shared props (auth, i18n, flash, …), use
+> `shareInertiaProps` instead — it merges its props over whatever was
+> registered before:
+>
+> ```ts
+> import { shareInertiaProps } from '@guren/core'
+>
+> shareInertiaProps((ctx) => ({ i18n: { locale: detectLocale(ctx) } }))
+> ```
+
 Route middleware makes protecting endpoints straightforward:
 
 ```ts

--- a/docs/en/guides/testing.md
+++ b/docs/en/guides/testing.md
@@ -109,6 +109,27 @@ test('API validates input', async () => {
 })
 ```
 
+## Custom Request Headers
+
+Use `withHeaders()` / `withHeader()` to send headers on every request — handy
+for locale detection, API versioning, or bearer tokens. Like `actingAs()` and
+`json()`, they return a new `TestApp`, so variants compose freely:
+
+```ts
+test('renders the English locale', async () => {
+  const en = app.withHeaders({ 'Accept-Language': 'en' })
+  await en.get('/').assertOk()
+})
+
+test('accepts an API token', async () => {
+  await app
+    .withHeader('Authorization', `Bearer ${token}`)
+    .json()
+    .get('/api/me/tasks')
+    .assertOk()
+})
+```
+
 ## Database in Tests
 
 Keep tests isolated by resetting the database between runs:

--- a/docs/ja/guides/architecture.md
+++ b/docs/ja/guides/architecture.md
@@ -108,6 +108,25 @@ export default class AppServiceProvider extends ServiceProvider {
 }
 ```
 
+> **グローバルミドルウェアは `register()` で追加してください。** ルートは
+> `register()` と `boot()` の**間**にマウントされ、Hono はマッチしたルートより
+> 前に登録されたミドルウェアしか適用しません — `boot()` からの `app.use()` は
+> ルートに対して実行されません。リソースの読み込みが必要な場合は両フックとも
+> `async` にできます:
+>
+> ```ts
+> export default class I18nProvider extends ServiceProvider {
+>   async register(): Promise<void> {
+>     const i18n = createI18n({ locale: 'ja', fallbackLocale: 'en', path: './lang' })
+>     await i18n.loadLocales(['en', 'ja'])
+>     setI18n(i18n)
+>
+>     const app = this.container.make<Application>('app')
+>     app.use('*', localeMiddleware) // boot() ではなく register() で
+>   }
+> }
+> ```
+
 ### ファサード
 
 頻繁に使うサービスにはファサードが用意されています。コンテナから遅延解決されるため、import するだけで利用可能です。

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -249,6 +249,16 @@ setInertiaSharedProps(async (ctx) => {
 
 `InertiaSharedProps` を拡張し、React 側でも型付けしてください（詳細はコントローラーガイドを参照）。
 
+> `setInertiaSharedProps` はリゾルバー全体を置き換えます。auth・i18n・flash
+> など複数箇所から共有 props を提供する場合は、既存の props にマージする
+> `shareInertiaProps` を使ってください:
+>
+> ```ts
+> import { shareInertiaProps } from '@guren/core'
+>
+> shareInertiaProps((ctx) => ({ i18n: { locale: detectLocale(ctx) } }))
+> ```
+
 ルートミドルウェアを使うと保護が簡単です。
 
 ```ts

--- a/docs/ja/guides/testing.md
+++ b/docs/ja/guides/testing.md
@@ -140,6 +140,25 @@ await app.actingAs(user).post('/posts', data).assertStatus(201)
 await app.get('/dashboard').assertUnauthorized()
 ```
 
+### カスタムリクエストヘッダー
+
+`withHeaders()` / `withHeader()` で全リクエストにヘッダーを付与できます。
+ロケール検出・API バージョニング・Bearer トークンなどに便利です。
+`actingAs()` や `json()` と同様に新しい `TestApp` を返すので、自由に合成できます。
+
+```ts
+// Accept-Language でロケールを切り替えてレンダリング
+const en = app.withHeaders({ 'Accept-Language': 'en' })
+await en.get('/').assertOk()
+
+// API トークン認証と JSON モードの合成
+await app
+  .withHeader('Authorization', `Bearer ${token}`)
+  .json()
+  .get('/api/me/tasks')
+  .assertOk()
+```
+
 ### コンテナフェイクを使ったテスト
 
 コンテナの `fake()` メソッドを使って、サービスをテストダブルに置き換えられます。

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -18,7 +18,7 @@ export type {
 } from './mvc/Router'
 export { ViewEngine } from './mvc/ViewEngine'
 export { inertia } from './mvc/inertia/InertiaEngine'
-export { setInertiaSharedProps } from './mvc/inertia/shared'
+export { setInertiaSharedProps, getInertiaSharedPropsResolver, shareInertiaProps } from './mvc/inertia/shared'
 export type {
   InertiaOptions,
   InertiaPagePayload,

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -905,7 +905,7 @@ function resolveHandler(
 
       const args: unknown[] = resolvedBindings.length > 0 ? [c, ...resolvedBindings] : [c]
       const result = await (method as (...a: unknown[]) => unknown).apply(controller, args)
-      return ensureResponse(result)
+      return ensureResponse(result, c)
     }
   }
 
@@ -917,7 +917,7 @@ function resolveHandler(
     if (result === undefined && c.finalized) {
       return c.res
     }
-    return ensureResponse(result)
+    return ensureResponse(result, c)
   }
 }
 
@@ -949,7 +949,22 @@ async function resolveModelBindings(
   return resolved
 }
 
-function ensureResponse(result: unknown): Response {
+function ensureResponse(result: unknown, c?: Context): Response {
+  const response = buildResponse(result)
+
+  // Handlers and controllers return raw Response objects, which bypass
+  // Hono's response construction — headers staged via c.header() in
+  // upstream middleware would be silently dropped. Rebuild through
+  // c.newResponse() so prepared headers are merged (Set-Cookie appended,
+  // the handler's own headers winning otherwise).
+  if (c) {
+    return c.newResponse(response.body, response) as Response
+  }
+
+  return response
+}
+
+function buildResponse(result: unknown): Response {
   if (result instanceof Response) {
     return result
   }

--- a/packages/server/src/mvc/inertia/shared.ts
+++ b/packages/server/src/mvc/inertia/shared.ts
@@ -25,6 +25,23 @@ export function getInertiaSharedPropsResolver(): SharedInertiaPropsResolver<Reso
   return resolver
 }
 
+/**
+ * Register additional shared props without replacing resolvers registered
+ * earlier — the new resolver's props are merged over the previous ones.
+ * Use this from app providers so multiple providers can each contribute
+ * shared props (setInertiaSharedProps replaces the resolver wholesale).
+ */
+export function shareInertiaProps<Props extends Record<string, unknown>>(
+  resolverFn: SharedInertiaPropsResolver<Props>,
+): void {
+  const previous = resolver
+  resolver = async (ctx) => {
+    const prev = previous ? await previous(ctx) : ({} as ResolvedSharedInertiaProps)
+    const next = await resolverFn(ctx)
+    return { ...prev, ...next } as ResolvedSharedInertiaProps
+  }
+}
+
 export async function resolveSharedInertiaProps(ctx: Context): Promise<ResolvedSharedInertiaProps> {
   if (!resolver) return {} as ResolvedSharedInertiaProps
 

--- a/packages/server/tests/mvc/inertia-shared.test.ts
+++ b/packages/server/tests/mvc/inertia-shared.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, beforeEach } from 'bun:test'
+import type { Context } from 'hono'
+import {
+  setInertiaSharedProps,
+  shareInertiaProps,
+  getInertiaSharedPropsResolver,
+  resolveSharedInertiaProps,
+} from '../../src/mvc/inertia/shared'
+
+const fakeCtx = {} as Context
+
+describe('shareInertiaProps', () => {
+  beforeEach(() => {
+    setInertiaSharedProps(null)
+  })
+
+  it('merges props over a resolver registered via setInertiaSharedProps', async () => {
+    setInertiaSharedProps(() => ({ appName: 'Test' }))
+    shareInertiaProps(() => ({ i18n: { locale: 'ja' } }))
+
+    const shared = await resolveSharedInertiaProps(fakeCtx)
+    expect(shared).toEqual({ appName: 'Test', i18n: { locale: 'ja' } })
+  })
+
+  it('composes multiple shareInertiaProps calls, later ones winning on conflicts', async () => {
+    shareInertiaProps(() => ({ a: 1, shared: 'first' }))
+    shareInertiaProps(async () => ({ b: 2, shared: 'second' }))
+
+    const shared = await resolveSharedInertiaProps(fakeCtx)
+    expect(shared).toEqual({ a: 1, b: 2, shared: 'second' })
+  })
+
+  it('works as the first registration with no prior resolver', async () => {
+    shareInertiaProps(() => ({ only: true }))
+
+    const shared = await resolveSharedInertiaProps(fakeCtx)
+    expect(shared).toEqual({ only: true })
+  })
+
+  it('getInertiaSharedPropsResolver exposes the current resolver for manual composition', async () => {
+    setInertiaSharedProps(() => ({ base: true }))
+
+    const previous = getInertiaSharedPropsResolver()
+    expect(previous).not.toBeNull()
+
+    setInertiaSharedProps(async (ctx) => ({
+      ...(previous ? await previous(ctx) : {}),
+      extra: 1,
+    }))
+
+    const shared = await resolveSharedInertiaProps(fakeCtx)
+    expect(shared).toEqual({ base: true, extra: 1 })
+  })
+})

--- a/packages/server/tests/mvc/router.test.ts
+++ b/packages/server/tests/mvc/router.test.ts
@@ -214,3 +214,58 @@ describe('Router middleware as terminal handler', () => {
     expect(response.status).toBe(204)
   })
 })
+
+describe('prepared headers on raw Response returns', () => {
+  it('merges c.header() values from middleware into controller responses', async () => {
+    const router = new Router()
+    router.get('/posts', [StubController, 'index'])
+
+    const app = new Hono()
+    app.use(async (c, next) => {
+      c.header('X-Locale', 'ja')
+      c.header('Set-Cookie', 'locale=ja; Path=/', { append: true })
+      await next()
+    })
+    router.mount(app)
+
+    const response = await app.request('/posts')
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('index')
+    expect(response.headers.get('X-Locale')).toBe('ja')
+    expect(response.headers.getSetCookie()).toContain('locale=ja; Path=/')
+  })
+
+  it('merges c.header() values into raw Response returns from inline handlers', async () => {
+    const router = new Router()
+    router.get('/raw', () => new Response('raw body', { headers: { 'X-From-Handler': 'yes' } }))
+
+    const app = new Hono()
+    app.use(async (c, next) => {
+      c.header('X-Locale', 'en')
+      await next()
+    })
+    router.mount(app)
+
+    const response = await app.request('/raw')
+
+    expect(response.headers.get('X-Locale')).toBe('en')
+    expect(response.headers.get('X-From-Handler')).toBe('yes')
+    expect(await response.text()).toBe('raw body')
+  })
+
+  it('lets the handler response win on header conflicts', async () => {
+    const router = new Router()
+    router.get('/conflict', () => new Response('ok', { headers: { 'X-Locale': 'handler' } }))
+
+    const app = new Hono()
+    app.use(async (c, next) => {
+      c.header('X-Locale', 'middleware')
+      await next()
+    })
+    router.mount(app)
+
+    const response = await app.request('/conflict')
+    expect(response.headers.get('X-Locale')).toBe('handler')
+  })
+})

--- a/packages/testing/src/test-app.ts
+++ b/packages/testing/src/test-app.ts
@@ -447,13 +447,31 @@ export class TestApp {
    * Return a new TestApp that sends `Accept: application/json` on every request.
    */
   json(): TestApp {
+    return this.withHeaders({ Accept: 'application/json' })
+  }
+
+  /**
+   * Return a new TestApp that sends the given headers on every request.
+   *
+   * @example
+   * const en = http.withHeaders({ 'Accept-Language': 'en' })
+   * await en.get('/') // rendered with the English locale
+   */
+  withHeaders(headers: Record<string, string>): TestApp {
     const copy = new TestApp(this.fetchFn, this.baseUrl)
     copy.defaultHeaders = {
       ...this.defaultHeaders,
-      Accept: 'application/json',
+      ...headers,
     }
     copy.authenticatedUser = this.authenticatedUser
     return copy
+  }
+
+  /**
+   * Return a new TestApp that sends the given header on every request.
+   */
+  withHeader(name: string, value: string): TestApp {
+    return this.withHeaders({ [name]: value })
   }
 
   /**

--- a/packages/testing/tests/testing.test.ts
+++ b/packages/testing/tests/testing.test.ts
@@ -373,6 +373,37 @@ describe('TestApp', () => {
     const response = await testApp.actingAs(user).get('/protected')
     expect(response.status).toBe(200)
   })
+
+  it('withHeaders sends custom headers on every request', async () => {
+    const app = new Hono()
+    app.get('/echo', (c) => c.json({
+      lang: c.req.header('Accept-Language') ?? null,
+      cookie: c.req.header('Cookie') ?? null,
+    }))
+
+    const testApp = TestApp.fromFetch((request) => app.fetch(request))
+    const localized = testApp.withHeaders({ 'Accept-Language': 'en', Cookie: 'locale=en' })
+
+    await localized.get('/echo').assertJson({ lang: 'en', cookie: 'locale=en' })
+    // The original instance is unchanged
+    await testApp.get('/echo').assertJson({ lang: null, cookie: null })
+  })
+
+  it('withHeader composes with actingAs', async () => {
+    const app = new Hono()
+    app.get('/echo', (c) => c.json({
+      lang: c.req.header('Accept-Language') ?? null,
+      user: c.req.header('X-Testing-User') !== undefined,
+    }))
+
+    const testApp = TestApp.fromFetch((request) => app.fetch(request))
+    const response = await testApp
+      .actingAs({ id: 1 })
+      .withHeader('Accept-Language', 'ja')
+      .get('/echo')
+
+    expect(await response.json()).toEqual({ lang: 'ja', user: true })
+  })
 })
 
 describe('FakeQueue', () => {


### PR DESCRIPTION
## Summary

Third dogfooding lap: fixes for the DX friction recorded while wiring i18n into Kadai.

### 1. Middleware `c.header()` never reached controller responses

Guren handlers and controllers return raw `Response` objects, which bypass Hono's `#newResponse` — headers staged via `c.header()` in upstream middleware were silently dropped. Concretely: a locale-persisting middleware calling `c.header('Set-Cookie', 'locale=ja', { append: true })` before `next()` worked on inline `c.json()` routes but did nothing on any controller/Inertia route.

Fix: `ensureResponse` rebuilds the route response through `c.newResponse(body, response)`, which starts from Hono's prepared headers and merges the handler's own headers on top (`Set-Cookie` appended, other headers winning on conflict). Streaming (SSE) responses pass through untouched since only the body reference is reused.

### 2. `TestApp.withHeaders()` / `withHeader()`

`TestApp` had no way to send custom request headers, while `TestRequestBuilder.withHeaders` existed — so header-driven tests (Accept-Language locale detection, bearer tokens) had to bypass `TestApp` with raw `app.fetch`. Both helpers follow the existing immutable-copy pattern and compose with `actingAs()` / `json()`.

### 3. `shareInertiaProps()` + exported `getInertiaSharedPropsResolver`

`setInertiaSharedProps` replaces the resolver wholesale and the getter wasn't exported from `@guren/core`, so app providers couldn't each contribute shared props (auth + i18n + …) — last one won. `shareInertiaProps()` merges over the previous resolver, matching how `InertiaServiceProvider` composes internally.

### 4. Docs: middleware must be attached in `register()`

Routes mount between provider `register()` and `boot()`, so `app.use()` from `boot()` silently never applies to routes. Documented in the architecture guide (en/ja), plus `shareInertiaProps` in the auth guide and `withHeaders` in the testing guide.

## Testing

- New tests: prepared-header merge on controller & inline raw-Response routes (fail without the fix), `withHeaders`/`withHeader` composition, `shareInertiaProps` composition
- `bun run build:clean` / `bun run typecheck` / `bun run test:bun` (2153 pass, 0 fail) / `audit:core-first` / `audit:docs`