### PR TITLE
feat!: strict mass assignment and sanitized auth user records

### DIFF
--- a/.changeset/one-zero-defaults.md
+++ b/.changeset/one-zero-defaults.md
@@ -1,0 +1,15 @@
+---
+"@guren/orm": minor
+"@guren/server": minor
+"@guren/cli": minor
+"@guren/core": patch
+"@guren/testing": patch
+"@guren/openapi": patch
+"@guren/inertia-client": patch
+"create-guren-app": patch
+---
+
+Two security defaults locked in ahead of 1.0:
+
+- **Strict mass assignment.** When a model defines `fillable`, `create()`/`update()` now throw a `MassAssignmentException` naming any field outside the allowlist instead of silently discarding it (silent drops surfaced as NOT NULL violations far from the cause, and masked injection attempts). Use the new `forceCreate()` / `forceUpdate()` for trusted server-side data, or set `static strictFillable = false` per model to restore the old behavior. The `guarded` path is unchanged.
+- **`auth.user()` never exposes credentials.** The session guard sanitizes user records before caching or returning them: the password column, remember-token column, and the model's `static hidden` fields are stripped. Credential checks still run on the raw record internally, so login and remember-me behave exactly as before — but sharing `auth.user` into Inertia props no longer leaks `passwordHash` to the browser. Custom user providers can opt in via the new optional `UserProvider.sanitize()`. `guren add auth` now generates the User model with `static hidden = ['passwordHash', 'rememberToken']`.

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -249,6 +249,8 @@ setInertiaSharedProps(async (ctx) => {
 })
 ```
 
+Sharing `auth.user()` this way is safe by default: the record is sanitized before it leaves the auth layer, so the password hash never reaches the browser (see [Sanitized User Records](#sanitized-user-records)).
+
 Augment `InertiaSharedProps` (see the Controllers guide) to type this `auth` payload for React pages.
 
 > `setInertiaSharedProps` replaces the whole resolver. When several parts of
@@ -288,11 +290,36 @@ export function registerWebRoutes(router: Router): void {
 ## Session Guard Helpers
 
 - `auth.check()` – resolves to `true` when a user is authenticated.
-- `auth.user()` – returns the current user record (or `null`).
+- `auth.user()` – returns the current user record (or `null`), sanitized: the password hash, remember token, and the model's `hidden` fields are stripped.
 - `auth.userOrFail()` – returns the current user or throws `AuthenticationException` (401). Useful when you know the route is protected and want to avoid null checks.
 - `auth.login(user, remember?)` – logs in the given user and optionally issues a remember token.
 - `auth.attempt(credentials, remember?)` – validates credentials using the active guard and logs in on success.
 - `auth.logout()` – clears the session and remember token.
+
+## Sanitized User Records
+
+`auth.user()` — and the cached user available right after `login()` or `attempt()` — never exposes credential material. `ModelUserProvider` strips the password column, the remember-token column, and any fields listed in the model's `static hidden` before the record leaves the auth layer:
+
+```ts
+export class User extends AuthenticatableModel<UserRecord> {
+  static override table = users
+  static override readonly recordType = {} as UserRecord
+  static override hidden = ['passwordHash', 'rememberToken']
+}
+```
+
+The `make:auth` scaffolder generates the user model with this `hidden` declaration out of the box.
+
+Credential validation still runs on the raw database record internally, so login and remember-me tokens are unaffected — sanitization only changes what `auth.user()` exposes to application code.
+
+Custom user providers can opt in by implementing the optional `sanitize(user)` method on the `UserProvider` interface. `SessionGuard` calls it before caching or returning the user:
+
+```ts
+sanitize(user: AuthUser): AuthUser {
+  const { passwordHash, ...safe } = user
+  return safe as AuthUser
+}
+```
 
 ## Remember Tokens
 

--- a/docs/en/guides/database.md
+++ b/docs/en/guides/database.md
@@ -193,12 +193,43 @@ export class Post extends Model<PostRecord> {
 }
 ```
 
+When `fillable` is set, passing any field outside the allowlist to `create()` or `update()` throws a `MassAssignmentException` (exported from `@guren/core`). The message names the blocked fields, so a typo or an injection attempt fails loudly at the call site instead of being silently discarded and resurfacing later as a confusing NOT NULL violation:
+
+```ts
+await Post.create({ title: 'Hello', body: '...', status: 'draft', authorId: 1 })
+// MassAssignmentException: Post: mass assignment blocked for field(s) "authorId"
+```
+
+For trusted, server-side-assembled data — OAuth account linking, seeders, system records — bypass the allowlist with `forceCreate()` / `forceUpdate()`:
+
+```ts
+const user = await User.forceCreate({
+  name: profile.name,
+  email: profile.email,
+  passwordHash: `oauth:${provider}:${profile.id}`,
+})
+
+await User.forceUpdate({ id: user.id }, { emailVerifiedAt: new Date() })
+```
+
+> [!WARNING]
+> `forceCreate()` / `forceUpdate()` skip mass-assignment protection entirely. Never pass raw request input to them.
+
+To restore the previous behavior of silently dropping non-fillable fields, opt out per model:
+
+```ts
+  static fillable = ['title', 'body', 'status']
+  static strictFillable = false
+```
+
 Or use `guarded` to block specific fields:
 
 ```ts
   // Denylist — everything except these is assignable
   static guarded = ['id', 'createdAt', 'updatedAt']
 ```
+
+Guarded fields are always silently stripped — the strict throwing behavior applies only to models that declare `fillable`.
 
 > [!NOTE]
 > Use `fillable` or `guarded`, not both. If neither is set, all fields are assignable.
@@ -552,6 +583,8 @@ const json = User.serialize(user)
 // { id: 1, name: "John", email: "john@example.com" }
 // passwordHash and rememberToken are excluded
 ```
+
+Fields listed in `hidden` are also stripped from the record returned by `auth.user()`, so they never leak into Inertia shared props or API responses that expose the authenticated user. See the [Authentication guide](./authentication.md) for details.
 
 ### Visible Fields
 

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -247,6 +247,8 @@ setInertiaSharedProps(async (ctx) => {
 })
 ```
 
+このように `auth.user()` を共有する方法はデフォルトで安全です。レコードは認証レイヤーを出る前にサニタイズされるため、パスワードハッシュがブラウザに届くことはありません（後述の「サニタイズされたユーザーレコード」を参照）。
+
 `InertiaSharedProps` を拡張し、React 側でも型付けしてください（詳細はコントローラーガイドを参照）。
 
 > `setInertiaSharedProps` はリゾルバー全体を置き換えます。auth・i18n・flash
@@ -285,11 +287,36 @@ export function registerWebRoutes(router: Router): void {
 ## セッションガードのヘルパー
 
 - `auth.check()` — 認証済みなら `true`。
-- `auth.user()` — 現在のユーザーレコード（または `null`）。
+- `auth.user()` — 現在のユーザーレコード（または `null`）。パスワードハッシュ・remember トークン・モデルの `hidden` フィールドは除去されたサニタイズ済みレコードを返します。
 - `auth.userOrFail()` — 現在のユーザーを返すか、未認証なら `AuthenticationException`（401）をスロー。ルートが保護されていると分かっている場合に、null チェックを省略できます。
 - `auth.login(user, remember?)` — 指定ユーザーでログインし、任意で remember トークンを発行。
 - `auth.attempt(credentials, remember?)` — 資格情報を検証し、成功時にログイン。
 - `auth.logout()` — セッションと remember トークンをクリア。
+
+## サニタイズされたユーザーレコード
+
+`auth.user()`（および `login()` / `attempt()` 直後にキャッシュされるユーザー）が資格情報を露出することはありません。`ModelUserProvider` は、レコードが認証レイヤーを出る前に、パスワードカラム・remember トークンカラム・モデルの `static hidden` に列挙されたフィールドを除去します。
+
+```ts
+export class User extends AuthenticatableModel<UserRecord> {
+  static override table = users
+  static override readonly recordType = {} as UserRecord
+  static override hidden = ['passwordHash', 'rememberToken']
+}
+```
+
+`make:auth` スキャフォルダーは、この `hidden` 宣言を含むユーザーモデルを最初から生成します。
+
+資格情報の検証は内部で生のデータベースレコードに対して行われるため、ログインや remember me の動作には影響しません。サニタイズが変えるのは、`auth.user()` がアプリケーションコードに公開する内容だけです。
+
+カスタムのユーザープロバイダーは、`UserProvider` インターフェースのオプションメソッド `sanitize(user)` を実装することでオプトインできます。`SessionGuard` はユーザーをキャッシュ・返却する前にこのメソッドを呼び出します。
+
+```ts
+sanitize(user: AuthUser): AuthUser {
+  const { passwordHash, ...safe } = user
+  return safe as AuthUser
+}
+```
 
 ## Remember トークン
 

--- a/docs/ja/guides/database.md
+++ b/docs/ja/guides/database.md
@@ -579,6 +579,8 @@ const json = User.serialize(user)
 // passwordHash と rememberToken は除外される
 ```
 
+`hidden` に列挙したフィールドは `auth.user()` が返すレコードからも除去されるため、認証済みユーザーを公開する Inertia 共有 props や API レスポンスに漏れることはありません。詳細は[認証ガイド](./authentication.md)を参照してください。
+
 ### 表示フィールドのホワイトリスト
 
 ブラックリストの代わりにホワイトリストを使用することもできます。
@@ -630,8 +632,37 @@ export class Post extends Model<PostRecord> {
   static override readonly recordType = {} as PostRecord
 
   // これらのフィールドのみ一括代入可能
-  static fillable = ['title', 'content', 'status', 'authorId']
+  static fillable = ['title', 'body', 'status']
 }
+```
+
+`fillable` を設定すると、許可リスト外のフィールドを `create()` や `update()` に渡した場合、`MassAssignmentException`（`@guren/core` からエクスポート）がスローされます。エラーメッセージにはブロックされたフィールド名が含まれるため、タイプミスやインジェクションの試みが黙って破棄されて後から NOT NULL 違反として現れるのではなく、呼び出し箇所でその場で検出できます。
+
+```ts
+await Post.create({ title: 'Hello', body: '...', status: 'draft', authorId: 1 })
+// MassAssignmentException: Post: mass assignment blocked for field(s) "authorId"
+```
+
+OAuth アカウント連携やシーダー、システムレコードなど、サーバーサイドで組み立てた信頼できるデータには、許可リストをバイパスする `forceCreate()` / `forceUpdate()` を使います。
+
+```ts
+const user = await User.forceCreate({
+  name: profile.name,
+  email: profile.email,
+  passwordHash: `oauth:${provider}:${profile.id}`,
+})
+
+await User.forceUpdate({ id: user.id }, { emailVerifiedAt: new Date() })
+```
+
+> [!WARNING]
+> `forceCreate()` / `forceUpdate()` はマスアサインメント保護を完全にスキップします。リクエスト入力をそのまま渡さないでください。
+
+以前の「許可リスト外のフィールドを黙って破棄する」挙動に戻したい場合は、モデルごとにオプトアウトできます。
+
+```ts
+  static fillable = ['title', 'body', 'status']
+  static strictFillable = false
 ```
 
 あるいは、`guarded` で特定のフィールドをブロックし、それ以外をすべて許可することもできます。
@@ -645,6 +676,8 @@ export class Post extends Model<PostRecord> {
   static guarded = ['id', 'createdAt', 'updatedAt']
 }
 ```
+
+`guarded` のフィールドは従来どおり黙って除外されます。例外をスローする厳格な挙動は、`fillable` を宣言したモデルにのみ適用されます。
 
 `fillable` と `guarded` はどちらか一方を使ってください。`fillable` は許可リスト、`guarded` は拒否リストです。どちらも設定されていない場合は、すべてのフィールドが代入可能になります。
 

--- a/examples/blog/app/Models/User.ts
+++ b/examples/blog/app/Models/User.ts
@@ -9,6 +9,7 @@ export class User extends AuthenticatableModel<UserRecord> {
   static override table = users
   static fillable = ['name', 'email', 'password']
   static guarded = ['id', 'passwordHash', 'rememberToken']
+  static override hidden = ['passwordHash', 'rememberToken']
   static override readonly recordType = {} as UserRecord
   static override readonly createType = {} as Omit<NewUserRecord, 'passwordHash'> & {
     password: string

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -126,6 +126,9 @@ export type UserRecord = typeof users.$inferSelect
 export class User extends AuthenticatableModel<UserRecord> {
   static override table = users
   static override readonly recordType = {} as UserRecord
+
+  // Never serialized by Model.serialize() and stripped from auth.user()
+  static override hidden = ['passwordHash', 'rememberToken']
 }
 `
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export {
   type InferModelRecord,
   type InferModelInsert,
   ModelNotFoundException,
+  MassAssignmentException,
   QueryBuilder,
   SoftDeletes,
   DrizzleAdapter,

--- a/packages/orm/src/MassAssignmentException.ts
+++ b/packages/orm/src/MassAssignmentException.ts
@@ -1,0 +1,22 @@
+/**
+ * Thrown when mass assignment receives fields outside the model's
+ * `fillable` allowlist. Silently discarding them hides bugs (a typo'd
+ * fillable entry surfaces as a NOT NULL violation much later) and can
+ * mask injection attempts, so strict models fail loudly instead.
+ */
+export class MassAssignmentException extends Error {
+  readonly model: string
+  readonly fields: string[]
+
+  constructor(model: string, fields: string[]) {
+    const list = fields.map((field) => `"${field}"`).join(', ')
+    super(
+      `${model}: mass assignment blocked for field(s) ${list} — not listed in ${model}.fillable. ` +
+        `Add them to fillable, use ${model}.forceCreate()/forceUpdate() for trusted server-side data, ` +
+        `or set \`static strictFillable = false\` to restore silent discarding.`,
+    )
+    this.name = 'MassAssignmentException'
+    this.model = model
+    this.fields = fields
+  }
+}

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -11,6 +11,7 @@ import { ModelNotFoundException } from './ModelNotFoundException'
 import { QueryBuilder } from './QueryBuilder'
 import type { WhereOperator } from './QueryBuilder'
 import { serializeRecord, serializeRecords } from './serialization'
+import { MassAssignmentException } from './MassAssignmentException'
 
 /** Generic plain object type used throughout the ORM. */
 export type PlainObject = Record<string, unknown>
@@ -299,7 +300,12 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
 
   /**
    * Whitelist of fields allowed for mass assignment.
-   * If set, only these fields will be accepted in `create()` and `update()`.
+   * If set, `create()` and `update()` accept only these fields — input
+   * containing any other key throws a MassAssignmentException so bugs
+   * (and injection attempts) surface immediately instead of being
+   * silently discarded. Use `forceCreate()` / `forceUpdate()` for
+   * trusted server-side data, or set `strictFillable = false` to
+   * restore silent discarding.
    *
    * @example
    * class User extends Model<UserRecord> {
@@ -307,6 +313,13 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
    * }
    */
   static fillable?: string[]
+
+  /**
+   * When `fillable` is set, controls what happens to input fields outside
+   * the allowlist: `true` (default) throws a MassAssignmentException,
+   * `false` silently discards them (pre-1.0 behavior).
+   */
+  static strictFillable?: boolean
 
   /**
    * Blacklist of fields excluded from mass assignment.
@@ -654,6 +667,13 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
   static filterFillable(data: PlainObject): PlainObject {
     const fillableFields = this.fillable
     if (fillableFields) {
+      if (this.strictFillable !== false) {
+        const blocked = Object.keys(data).filter((key) => !fillableFields.includes(key))
+        if (blocked.length > 0) {
+          throw new MassAssignmentException(this.name, blocked)
+        }
+      }
+
       const filtered: PlainObject = {}
       for (const key of fillableFields) {
         if (key in data) {
@@ -1534,8 +1554,37 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     data: TCreateFor<T>,
     writeOptions?: ModelWriteOptions,
   ): Promise<TRecordFor<T>> {
+    return this.runCreate(data, writeOptions, true)
+  }
+
+  /**
+   * Create a record bypassing mass-assignment protection. Use for trusted,
+   * server-side-assembled data (OAuth account linking, seeders, system
+   * records) — never for raw request input.
+   *
+   * @example
+   * const user = await User.forceCreate({
+   *   name: profile.name,
+   *   email: profile.email,
+   *   passwordHash: `oauth:${provider}:${profile.id}`,
+   * })
+   */
+  static async forceCreate<T extends typeof Model>(
+    this: T,
+    data: TCreateFor<T>,
+    writeOptions?: ModelWriteOptions,
+  ): Promise<TRecordFor<T>> {
+    return this.runCreate(data, writeOptions, false)
+  }
+
+  protected static async runCreate<T extends typeof Model>(
+    this: T,
+    data: TCreateFor<T>,
+    writeOptions: ModelWriteOptions | undefined,
+    applyFillable: boolean,
+  ): Promise<TRecordFor<T>> {
     const table = this.resolveTable()
-    const filtered = this.filterFillable(data)
+    const filtered = applyFillable ? this.filterFillable(data) : { ...(data as PlainObject) }
     const payload = await this.preparePersistencePayload(filtered)
 
     const hooks = this.hooks
@@ -1593,13 +1642,36 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     data: Partial<TCreateFor<T>>,
     writeOptions?: ModelWriteOptions,
   ): Promise<TRecordFor<T>> {
+    return this.runUpdate(where, data, writeOptions, true)
+  }
+
+  /**
+   * Update records bypassing mass-assignment protection. Use for trusted,
+   * server-side-assembled data — never for raw request input.
+   */
+  static async forceUpdate<T extends typeof Model>(
+    this: T,
+    where: WhereClauseFor<T>,
+    data: Partial<TCreateFor<T>>,
+    writeOptions?: ModelWriteOptions,
+  ): Promise<TRecordFor<T>> {
+    return this.runUpdate(where, data, writeOptions, false)
+  }
+
+  protected static async runUpdate<T extends typeof Model>(
+    this: T,
+    where: WhereClauseFor<T>,
+    data: Partial<TCreateFor<T>>,
+    writeOptions: ModelWriteOptions | undefined,
+    applyFillable: boolean,
+  ): Promise<TRecordFor<T>> {
     const table = this.resolveTable()
     const adapter = this.getAdapter()
     if (!adapter.update) {
       throw new Error('Configured adapter does not support update operations.')
     }
 
-    const filtered = this.filterFillable(data)
+    const filtered = applyFillable ? this.filterFillable(data) : { ...(data as PlainObject) }
     const payload = await this.preparePersistencePayload(filtered)
 
     const hooks = this.hooks

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -1,6 +1,7 @@
 import './instance-guard'
 export { Model, defineModel } from './Model'
 export { ModelNotFoundException } from './ModelNotFoundException'
+export { MassAssignmentException } from './MassAssignmentException'
 export type {
   PlainObject,
   InferModelRecord,

--- a/packages/orm/tests/fillable.test.ts
+++ b/packages/orm/tests/fillable.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'bun:test'
 import { Model, type PlainObject } from '../src/Model'
+import { MassAssignmentException } from '../src/MassAssignmentException'
 
 // Minimal concrete subclasses for testing filterFillable
 
@@ -37,14 +38,28 @@ describe('Model.filterFillable', () => {
     })
   })
 
-  describe('with fillable', () => {
-    it('should only keep fillable fields', () => {
-      const result = FillableModel.filterFillable({
-        title: 'Hello',
-        body: 'World',
-        isAdmin: true,
-        authorId: 99,
-      })
+  describe('with fillable (strict by default)', () => {
+    it('should throw MassAssignmentException for fields outside the allowlist', () => {
+      expect(() =>
+        FillableModel.filterFillable({
+          title: 'Hello',
+          body: 'World',
+          isAdmin: true,
+          authorId: 99,
+        }),
+      ).toThrow(MassAssignmentException)
+
+      try {
+        FillableModel.filterFillable({ title: 'Hello', isAdmin: true })
+      } catch (error) {
+        expect(error).toBeInstanceOf(MassAssignmentException)
+        expect((error as MassAssignmentException).fields).toEqual(['isAdmin'])
+        expect((error as MassAssignmentException).message).toContain('forceCreate')
+      }
+    })
+
+    it('should pass through data made only of fillable fields', () => {
+      const result = FillableModel.filterFillable({ title: 'Hello', body: 'World' })
       expect(result).toEqual({ title: 'Hello', body: 'World' })
     })
 
@@ -52,9 +67,26 @@ describe('Model.filterFillable', () => {
       const result = FillableModel.filterFillable({ title: 'Hello' })
       expect(result).toEqual({ title: 'Hello' })
     })
+  })
+
+  describe('with fillable and strictFillable = false', () => {
+    class LenientModel extends Model<PlainObject> {
+      static override table = {} as unknown
+      static fillable = ['title', 'body']
+      static strictFillable = false
+    }
+
+    it('should silently discard fields outside the allowlist', () => {
+      const result = LenientModel.filterFillable({
+        title: 'Hello',
+        body: 'World',
+        isAdmin: true,
+      })
+      expect(result).toEqual({ title: 'Hello', body: 'World' })
+    })
 
     it('should return empty object when no fillable fields match', () => {
-      const result = FillableModel.filterFillable({ isAdmin: true, role: 'superuser' })
+      const result = LenientModel.filterFillable({ isAdmin: true, role: 'superuser' })
       expect(result).toEqual({})
     })
   })
@@ -77,14 +109,71 @@ describe('Model.filterFillable', () => {
   })
 
   describe('fillable takes precedence over guarded', () => {
-    it('should use fillable whitelist and ignore guarded', () => {
+    it('should use the fillable allowlist and ignore guarded', () => {
+      expect(() =>
+        FillableAndGuardedModel.filterFillable({
+          id: 1,
+          name: 'Alice',
+          email: 'alice@test.com',
+          isAdmin: true,
+        }),
+      ).toThrow(MassAssignmentException)
+
       const result = FillableAndGuardedModel.filterFillable({
-        id: 1,
         name: 'Alice',
         email: 'alice@test.com',
-        isAdmin: true,
       })
       expect(result).toEqual({ name: 'Alice', email: 'alice@test.com' })
+    })
+  })
+
+  describe('forceCreate / forceUpdate', () => {
+    function createRecordingAdapter() {
+      const calls: { create: PlainObject[]; update: PlainObject[] } = { create: [], update: [] }
+      const adapter = {
+        async findMany<T extends PlainObject>(): Promise<T[]> { return [] },
+        async findUnique<T extends PlainObject>(): Promise<T | null> { return null },
+        async create<T extends PlainObject>(_table: unknown, data: PlainObject): Promise<T> {
+          calls.create.push(data)
+          return data as unknown as T
+        },
+        async update<T extends PlainObject>(_table: unknown, _where: unknown, data: PlainObject): Promise<T> {
+          calls.update.push(data)
+          return data as unknown as T
+        },
+      }
+      return { adapter, calls }
+    }
+
+    it('create() throws for unfillable fields, forceCreate() writes them', async () => {
+      class StrictUser extends Model<PlainObject> {
+        static override table = 'users'
+        static fillable = ['name', 'email']
+      }
+      const { adapter, calls } = createRecordingAdapter()
+      StrictUser.useAdapter(adapter)
+
+      await expect(
+        StrictUser.create({ name: 'A', email: 'a@x.com', passwordHash: 'oauth:x' }),
+      ).rejects.toThrow(MassAssignmentException)
+
+      const record = await StrictUser.forceCreate({ name: 'A', email: 'a@x.com', passwordHash: 'oauth:x' })
+      expect(record).toEqual({ name: 'A', email: 'a@x.com', passwordHash: 'oauth:x' })
+      expect(calls.create).toHaveLength(1)
+    })
+
+    it('forceUpdate() bypasses the allowlist', async () => {
+      class StrictUser extends Model<PlainObject> {
+        static override table = 'users'
+        static fillable = ['name']
+      }
+      const { adapter, calls } = createRecordingAdapter()
+      StrictUser.useAdapter(adapter)
+
+      await expect(StrictUser.update({ id: 1 }, { role: 'admin' })).rejects.toThrow(MassAssignmentException)
+
+      await StrictUser.forceUpdate({ id: 1 }, { role: 'admin' })
+      expect(calls.update).toEqual([{ role: 'admin' }])
     })
   })
 })

--- a/packages/server/src/auth/SessionGuard.ts
+++ b/packages/server/src/auth/SessionGuard.ts
@@ -55,9 +55,15 @@ export class SessionGuard<User extends Authenticatable = Authenticatable> implem
       return null
     }
 
-    this.cachedUser = user
     await this.provider.setRememberToken?.(user, rememberToken)
-    return user
+    const sanitized = this.sanitizeUser(user)
+    this.cachedUser = sanitized
+    return sanitized
+  }
+
+  /** Strip auth-internal fields before a record is cached or exposed. */
+  private sanitizeUser(user: User): User {
+    return this.provider.sanitize ? this.provider.sanitize(user) : user
   }
 
   private async resolveUser(): Promise<User | null> {
@@ -86,8 +92,9 @@ export class SessionGuard<User extends Authenticatable = Authenticatable> implem
       return null
     }
 
-    this.cachedUser = user
-    return user
+    const sanitized = this.sanitizeUser(user)
+    this.cachedUser = sanitized
+    return sanitized
   }
 
   async check(): Promise<boolean> {
@@ -134,7 +141,7 @@ export class SessionGuard<User extends Authenticatable = Authenticatable> implem
 
     const identifier = this.provider.getId(castUser)
     session.set(this.sessionKey(), identifier)
-    this.cachedUser = castUser
+    this.cachedUser = this.sanitizeUser(castUser)
 
     if (remember) {
       await this.remember(castUser)

--- a/packages/server/src/auth/providers/ModelUserProvider.ts
+++ b/packages/server/src/auth/providers/ModelUserProvider.ts
@@ -85,10 +85,35 @@ export class ModelUserProvider<User extends Authenticatable = Authenticatable> e
     return (user as PlainObject)[this.idColumn]
   }
 
+  /**
+   * Strip the password hash, remember token, and the model's `hidden`
+   * fields before the record leaves the auth layer. Credential
+   * validation happens on the raw record before sanitizing, so this
+   * never affects login — only what `auth.user()` exposes.
+   */
+  sanitize(user: User): User {
+    const blocked = new Set<string>([
+      this.passwordColumn,
+      this.rememberTokenColumn,
+      ...(((this.model as typeof Model).hidden as string[] | undefined) ?? []),
+    ])
+
+    const clean: PlainObject = {}
+    for (const [key, value] of Object.entries(user as PlainObject)) {
+      if (!blocked.has(key)) {
+        clean[key] = value
+      }
+    }
+
+    return clean as User
+  }
+
   override async setRememberToken(user: User, token: string | null): Promise<void> {
     if (typeof (user as PlainObject)[this.rememberTokenColumn] !== 'undefined') {
       ;(user as PlainObject)[this.rememberTokenColumn] = token
-      await (this.model as typeof Model).update({ [this.idColumn]: this.getId(user) }, { [this.rememberTokenColumn]: token })
+      // forceUpdate: the remember-token column is a trusted server-side
+      // write and is typically not in the model's fillable allowlist.
+      await (this.model as typeof Model).forceUpdate({ [this.idColumn]: this.getId(user) }, { [this.rememberTokenColumn]: token })
     }
   }
 

--- a/packages/server/src/auth/types.ts
+++ b/packages/server/src/auth/types.ts
@@ -29,6 +29,12 @@ export interface UserProvider<User = Authenticatable> {
   getId(user: User): unknown
   setRememberToken?(user: User, token: string | null): Promise<void> | void
   getRememberToken?(user: User): Promise<string | null> | string | null
+  /**
+   * Strip fields that must never leave the auth layer (password hashes,
+   * remember tokens, model `hidden` fields) from a user record before it
+   * is cached or handed to application code via guard.user().
+   */
+  sanitize?(user: User): User
 }
 
 export interface GuardContext {

--- a/packages/server/tests/auth/auth-manager.test.ts
+++ b/packages/server/tests/auth/auth-manager.test.ts
@@ -115,3 +115,29 @@ describe('AuthManager', () => {
     })
   })
 })
+
+describe('ModelUserProvider.sanitize', () => {
+  test('strips the password column, remember token, and model hidden fields', async () => {
+    const { ModelUserProvider } = await import('../../src/auth/providers/ModelUserProvider')
+
+    class FakeUserModel {
+      static hidden = ['apiSecret']
+    }
+
+    const provider = new ModelUserProvider(FakeUserModel as never, {
+      passwordColumn: 'passwordHash',
+      rememberTokenColumn: 'rememberToken',
+    })
+
+    const clean = provider.sanitize({
+      id: 1,
+      email: 'a@x.com',
+      passwordHash: 'scrypt:...',
+      rememberToken: 'tok',
+      apiSecret: 's3cret',
+      name: 'A',
+    } as never) as unknown as Record<string, unknown>
+
+    expect(clean).toEqual({ id: 1, email: 'a@x.com', name: 'A' })
+  })
+})

--- a/packages/server/tests/auth/session-guard.test.ts
+++ b/packages/server/tests/auth/session-guard.test.ts
@@ -361,3 +361,52 @@ describe('SessionGuard', () => {
     })
   })
 })
+
+describe('provider sanitize', () => {
+  function createSanitizingProvider(users: MockUser[]): UserProvider<MockUser> {
+    const base = createMockProvider(users)
+    return {
+      ...base,
+      sanitize(user: MockUser) {
+        const { password: _password, rememberToken: _token, ...clean } = user
+        return clean as unknown as MockUser
+      },
+    }
+  }
+
+  test('user() resolved from the session never exposes sanitized fields', async () => {
+    const user = createMockUser()
+    const session = createMockSession()
+    const guard = new SessionGuard({ provider: createSanitizingProvider([user]), session })
+
+    session.set('auth:user_id', 1)
+
+    const resolved = await guard.user<Record<string, unknown>>()
+    expect(resolved?.id).toBe(1)
+    expect(resolved).not.toHaveProperty('password')
+    expect(resolved).not.toHaveProperty('rememberToken')
+  })
+
+  test('user() after login() is sanitized while credentials still validate', async () => {
+    const user = createMockUser()
+    const session = createMockSession()
+    const guard = new SessionGuard({ provider: createSanitizingProvider([user]), session })
+
+    const ok = await guard.attempt({ email: 'user@test.com', password: 'hashed_password' })
+    expect(ok).toBe(true)
+
+    const resolved = await guard.user<Record<string, unknown>>()
+    expect(resolved?.email).toBe('user@test.com')
+    expect(resolved).not.toHaveProperty('password')
+  })
+
+  test('providers without sanitize keep returning the record as-is', async () => {
+    const user = createMockUser()
+    const session = createMockSession()
+    const guard = new SessionGuard({ provider: createMockProvider([user]), session })
+
+    session.set('auth:user_id', 1)
+    const resolved = await guard.user<Record<string, unknown>>()
+    expect(resolved).toHaveProperty('password')
+  })
+})


### PR DESCRIPTION
## Summary

Lap B of the road to 1.0: locks in the two security defaults that must be decided before the semver commitment, both discovered through dogfooding.

### 1. Strict mass assignment

`create()`/`update()` on a model with `static fillable` now **throw `MassAssignmentException`** (exported from `@guren/core`) when input contains keys outside the allowlist, naming the blocked fields with a remediation hint. Previously they were silently discarded — in Kadai this surfaced as a `NOT NULL constraint failed` five layers away from the actual bug (a typo'd fillable entry), and silent drops also mask injection attempts.

- `Model.forceCreate(data)` / `Model.forceUpdate(where, data)` bypass the allowlist for trusted, server-side-assembled data (OAuth account linking, system records)
- `static strictFillable = false` restores silent discarding per model
- The `guarded` path (models without fillable) is unchanged — commonly-present metadata keys like `id` are still stripped silently

### 2. `auth.user()` never exposes credentials

`ModelUserProvider` gains a `sanitize()` step applied by the session guard at every point a user record is cached or returned: the password column, remember-token column, and the model's `static hidden` fields are stripped. Credential validation still runs on the raw record internally, so login/remember-me are byte-for-byte unaffected.

This closes a real leak: the documented pattern of sharing `auth.user()` into Inertia shared props previously delivered `passwordHash` to the browser on every page.

- Custom `UserProvider` implementations opt in via the new optional `sanitize(user)` method
- `make:auth` now generates the User model with `static hidden = ['passwordHash', 'rememberToken']` (blog example updated too)
- `setRememberToken` switched to `forceUpdate` so remember-me works with strict allowlists

### Docs

`database.md` (mass assignment, hiding fields) and `authentication.md` (new "Sanitized User Records" section) updated in en/ja with byte-identical code blocks.

## Testing

- New tests: strict fillable throw + field reporting, `strictFillable = false` opt-out, `forceCreate`/`forceUpdate` bypass with a recording adapter, session-guard sanitize on session-resolve/login/attempt paths, provider-without-sanitize compat, `ModelUserProvider.sanitize` unit test
- `bun run build` / `bun run typecheck` / `bun run test:bun` (2,169 pass, 0 fail) / `audit:docs` / `audit:core-first`
- **`bun run smoke:golden-path` passes** — scaffold → auth (with the new defaults) → CRUD → runtime HTTP verification end to end