### PR TITLE
chore: version packages to 1.0.0-rc.33

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -40,6 +40,7 @@
     "middleware-as-route-handler",
     "ninety-dragons-wonder",
     "one-zero-blockers",
+    "one-zero-defaults",
     "openapi-major",
     "props-heritage-csrf-testing",
     "proud-snakes-brush",

--- a/examples/api/CHANGELOG.md
+++ b/examples/api/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @guren/example-api
 
+## 0.1.1-rc.24
+
+### Patch Changes
+
+- Updated dependencies [a1fc6ec]
+  - @guren/orm@1.0.0-rc.26
+  - @guren/cli@1.0.0-rc.28
+  - @guren/core@1.0.0-rc.25
+  - @guren/testing@1.0.0-rc.25
+  - @guren/openapi@1.0.0-rc.25
+
 ## 0.1.1-rc.23
 
 ### Patch Changes

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/example-api",
-  "version": "0.1.1-rc.23",
+  "version": "0.1.1-rc.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @guren/cli
 
+## 1.0.0-rc.28
+
+### Minor Changes
+
+- a1fc6ec: Two security defaults locked in ahead of 1.0:
+
+  - **Strict mass assignment.** When a model defines `fillable`, `create()`/`update()` now throw a `MassAssignmentException` naming any field outside the allowlist instead of silently discarding it (silent drops surfaced as NOT NULL violations far from the cause, and masked injection attempts). Use the new `forceCreate()` / `forceUpdate()` for trusted server-side data, or set `static strictFillable = false` per model to restore the old behavior. The `guarded` path is unchanged.
+  - **`auth.user()` never exposes credentials.** The session guard sanitizes user records before caching or returning them: the password column, remember-token column, and the model's `static hidden` fields are stripped. Credential checks still run on the raw record internally, so login and remember-me behave exactly as before — but sharing `auth.user` into Inertia props no longer leaks `passwordHash` to the browser. Custom user providers can opt in via the new optional `UserProvider.sanitize()`. `guren add auth` now generates the User model with `static hidden = ['passwordHash', 'rememberToken']`.
+
+### Patch Changes
+
+- Updated dependencies [a1fc6ec]
+  - @guren/orm@1.0.0-rc.26
+  - @guren/core@1.0.0-rc.25
+
 ## 1.0.0-rc.27
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/cli",
-  "version": "1.0.0-rc.27",
+  "version": "1.0.0-rc.28",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -44,8 +44,8 @@
   },
   "dependencies": {
     "@babel/parser": "^7.24.7",
-    "@guren/core": "^1.0.0-rc.24",
-    "@guren/orm": "^1.0.0-rc.25",
+    "@guren/core": "^1.0.0-rc.25",
+    "@guren/orm": "^1.0.0-rc.26",
     "citty": "^0.1.6",
     "consola": "^3.4.2"
   },

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @guren/core
 
+## 1.0.0-rc.25
+
+### Patch Changes
+
+- a1fc6ec: Two security defaults locked in ahead of 1.0:
+
+  - **Strict mass assignment.** When a model defines `fillable`, `create()`/`update()` now throw a `MassAssignmentException` naming any field outside the allowlist instead of silently discarding it (silent drops surfaced as NOT NULL violations far from the cause, and masked injection attempts). Use the new `forceCreate()` / `forceUpdate()` for trusted server-side data, or set `static strictFillable = false` per model to restore the old behavior. The `guarded` path is unchanged.
+  - **`auth.user()` never exposes credentials.** The session guard sanitizes user records before caching or returning them: the password column, remember-token column, and the model's `static hidden` fields are stripped. Credential checks still run on the raw record internally, so login and remember-me behave exactly as before — but sharing `auth.user` into Inertia props no longer leaks `passwordHash` to the browser. Custom user providers can opt in via the new optional `UserProvider.sanitize()`. `guren add auth` now generates the User model with `static hidden = ['passwordHash', 'rememberToken']`.
+
+- Updated dependencies [a1fc6ec]
+  - @guren/orm@1.0.0-rc.26
+  - @guren/server@1.0.0-rc.25
+  - @guren/cli@1.0.0-rc.28
+
 ## 1.0.0-rc.24
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/core",
-  "version": "1.0.0-rc.24",
+  "version": "1.0.0-rc.25",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -48,9 +48,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@guren/cli": "^1.0.0-rc.27",
-    "@guren/orm": "^1.0.0-rc.25",
-    "@guren/server": "^1.0.0-rc.24"
+    "@guren/cli": "^1.0.0-rc.28",
+    "@guren/orm": "^1.0.0-rc.26",
+    "@guren/server": "^1.0.0-rc.25"
   },
   "devDependencies": {
     "@types/node": "^20.14.10",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,14 @@
 # create-guren-app
 
+## 1.0.0-rc.29
+
+### Patch Changes
+
+- a1fc6ec: Two security defaults locked in ahead of 1.0:
+
+  - **Strict mass assignment.** When a model defines `fillable`, `create()`/`update()` now throw a `MassAssignmentException` naming any field outside the allowlist instead of silently discarding it (silent drops surfaced as NOT NULL violations far from the cause, and masked injection attempts). Use the new `forceCreate()` / `forceUpdate()` for trusted server-side data, or set `static strictFillable = false` per model to restore the old behavior. The `guarded` path is unchanged.
+  - **`auth.user()` never exposes credentials.** The session guard sanitizes user records before caching or returning them: the password column, remember-token column, and the model's `static hidden` fields are stripped. Credential checks still run on the raw record internally, so login and remember-me behave exactly as before — but sharing `auth.user` into Inertia props no longer leaks `passwordHash` to the browser. Custom user providers can opt in via the new optional `UserProvider.sanitize()`. `guren add auth` now generates the User model with `static hidden = ['passwordHash', 'rememberToken']`.
+
 ## 1.0.0-rc.28
 
 ### Patch Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-guren-app",
-  "version": "1.0.0-rc.28",
+  "version": "1.0.0-rc.29",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/inertia-client/CHANGELOG.md
+++ b/packages/inertia-client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @guren/inertia-client
 
+## 1.0.0-rc.24
+
+### Patch Changes
+
+- a1fc6ec: Two security defaults locked in ahead of 1.0:
+
+  - **Strict mass assignment.** When a model defines `fillable`, `create()`/`update()` now throw a `MassAssignmentException` naming any field outside the allowlist instead of silently discarding it (silent drops surfaced as NOT NULL violations far from the cause, and masked injection attempts). Use the new `forceCreate()` / `forceUpdate()` for trusted server-side data, or set `static strictFillable = false` per model to restore the old behavior. The `guarded` path is unchanged.
+  - **`auth.user()` never exposes credentials.** The session guard sanitizes user records before caching or returning them: the password column, remember-token column, and the model's `static hidden` fields are stripped. Credential checks still run on the raw record internally, so login and remember-me behave exactly as before — but sharing `auth.user` into Inertia props no longer leaks `passwordHash` to the browser. Custom user providers can opt in via the new optional `UserProvider.sanitize()`. `guren add auth` now generates the User model with `static hidden = ['passwordHash', 'rememberToken']`.
+
 ## 1.0.0-rc.23
 
 ### Patch Changes

--- a/packages/inertia-client/package.json
+++ b/packages/inertia-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/inertia-client",
-  "version": "1.0.0-rc.23",
+  "version": "1.0.0-rc.24",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/openapi/CHANGELOG.md
+++ b/packages/openapi/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @guren/openapi
 
+## 1.0.0-rc.25
+
+### Patch Changes
+
+- a1fc6ec: Two security defaults locked in ahead of 1.0:
+
+  - **Strict mass assignment.** When a model defines `fillable`, `create()`/`update()` now throw a `MassAssignmentException` naming any field outside the allowlist instead of silently discarding it (silent drops surfaced as NOT NULL violations far from the cause, and masked injection attempts). Use the new `forceCreate()` / `forceUpdate()` for trusted server-side data, or set `static strictFillable = false` per model to restore the old behavior. The `guarded` path is unchanged.
+  - **`auth.user()` never exposes credentials.** The session guard sanitizes user records before caching or returning them: the password column, remember-token column, and the model's `static hidden` fields are stripped. Credential checks still run on the raw record internally, so login and remember-me behave exactly as before — but sharing `auth.user` into Inertia props no longer leaks `passwordHash` to the browser. Custom user providers can opt in via the new optional `UserProvider.sanitize()`. `guren add auth` now generates the User model with `static hidden = ['passwordHash', 'rememberToken']`.
+
+- Updated dependencies [a1fc6ec]
+  - @guren/core@1.0.0-rc.25
+
 ## 1.0.0-rc.24
 
 ### Patch Changes

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/openapi",
-  "version": "1.0.0-rc.24",
+  "version": "1.0.0-rc.25",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@guren/core": "^1.0.0-rc.24"
+    "@guren/core": "^1.0.0-rc.25"
   },
   "devDependencies": {
     "@types/node": "^20.14.10",

--- a/packages/orm/CHANGELOG.md
+++ b/packages/orm/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @guren/orm
 
+## 1.0.0-rc.26
+
+### Minor Changes
+
+- a1fc6ec: Two security defaults locked in ahead of 1.0:
+
+  - **Strict mass assignment.** When a model defines `fillable`, `create()`/`update()` now throw a `MassAssignmentException` naming any field outside the allowlist instead of silently discarding it (silent drops surfaced as NOT NULL violations far from the cause, and masked injection attempts). Use the new `forceCreate()` / `forceUpdate()` for trusted server-side data, or set `static strictFillable = false` per model to restore the old behavior. The `guarded` path is unchanged.
+  - **`auth.user()` never exposes credentials.** The session guard sanitizes user records before caching or returning them: the password column, remember-token column, and the model's `static hidden` fields are stripped. Credential checks still run on the raw record internally, so login and remember-me behave exactly as before — but sharing `auth.user` into Inertia props no longer leaks `passwordHash` to the browser. Custom user providers can opt in via the new optional `UserProvider.sanitize()`. `guren add auth` now generates the User model with `static hidden = ['passwordHash', 'rememberToken']`.
+
 ## 1.0.0-rc.25
 
 ### Patch Changes

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/orm",
-  "version": "1.0.0-rc.25",
+  "version": "1.0.0-rc.26",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @guren/server
 
+## 1.0.0-rc.25
+
+### Minor Changes
+
+- a1fc6ec: Two security defaults locked in ahead of 1.0:
+
+  - **Strict mass assignment.** When a model defines `fillable`, `create()`/`update()` now throw a `MassAssignmentException` naming any field outside the allowlist instead of silently discarding it (silent drops surfaced as NOT NULL violations far from the cause, and masked injection attempts). Use the new `forceCreate()` / `forceUpdate()` for trusted server-side data, or set `static strictFillable = false` per model to restore the old behavior. The `guarded` path is unchanged.
+  - **`auth.user()` never exposes credentials.** The session guard sanitizes user records before caching or returning them: the password column, remember-token column, and the model's `static hidden` fields are stripped. Credential checks still run on the raw record internally, so login and remember-me behave exactly as before — but sharing `auth.user` into Inertia props no longer leaks `passwordHash` to the browser. Custom user providers can opt in via the new optional `UserProvider.sanitize()`. `guren add auth` now generates the User model with `static hidden = ['passwordHash', 'rememberToken']`.
+
+### Patch Changes
+
+- Updated dependencies [a1fc6ec]
+  - @guren/orm@1.0.0-rc.26
+  - @guren/inertia-client@1.0.0-rc.24
+
 ## 1.0.0-rc.24
 
 ### Minor Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/server",
-  "version": "1.0.0-rc.24",
+  "version": "1.0.0-rc.25",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -105,8 +105,8 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@guren/inertia-client": "^1.0.0-rc.23",
-    "@guren/orm": "^1.0.0-rc.25",
+    "@guren/inertia-client": "^1.0.0-rc.24",
+    "@guren/orm": "^1.0.0-rc.26",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "chalk": "^5.3.0",
     "consola": "^3.4.2",

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @guren/testing
 
+## 1.0.0-rc.25
+
+### Patch Changes
+
+- a1fc6ec: Two security defaults locked in ahead of 1.0:
+
+  - **Strict mass assignment.** When a model defines `fillable`, `create()`/`update()` now throw a `MassAssignmentException` naming any field outside the allowlist instead of silently discarding it (silent drops surfaced as NOT NULL violations far from the cause, and masked injection attempts). Use the new `forceCreate()` / `forceUpdate()` for trusted server-side data, or set `static strictFillable = false` per model to restore the old behavior. The `guarded` path is unchanged.
+  - **`auth.user()` never exposes credentials.** The session guard sanitizes user records before caching or returning them: the password column, remember-token column, and the model's `static hidden` fields are stripped. Credential checks still run on the raw record internally, so login and remember-me behave exactly as before — but sharing `auth.user` into Inertia props no longer leaks `passwordHash` to the browser. Custom user providers can opt in via the new optional `UserProvider.sanitize()`. `guren add auth` now generates the User model with `static hidden = ['passwordHash', 'rememberToken']`.
+
+- Updated dependencies [a1fc6ec]
+  - @guren/server@1.0.0-rc.25
+
 ## 1.0.0-rc.24
 
 ### Patch Changes

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/testing",
-  "version": "1.0.0-rc.24",
+  "version": "1.0.0-rc.25",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -35,7 +35,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@guren/server": ">=1.0.0-rc.24",
+    "@guren/server": ">=1.0.0-rc.25",
     "@inertiajs/react": "^2.3.18",
     "@testing-library/react": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "hono": "^4.12.18",

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,16 @@
 # web
 
+## 0.1.1-rc.23
+
+### Patch Changes
+
+- Updated dependencies [a1fc6ec]
+  - @guren/orm@1.0.0-rc.26
+  - @guren/cli@1.0.0-rc.28
+  - @guren/core@1.0.0-rc.25
+  - @guren/testing@1.0.0-rc.25
+  - @guren/inertia-client@1.0.0-rc.24
+
 ## 0.1.1-rc.22
 
 ### Patch Changes

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.1-rc.22",
+  "version": "0.1.1-rc.23",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump for the v1.0.0-rc.33 release train (changesets pre mode).

Includes #80 — strict mass assignment (MassAssignmentException, forceCreate/forceUpdate) and sanitized auth.user() records (breaking changes ahead of 1.0).