### PR TITLE
docs(create-app): agent-guidance overhaul from eval stumble analysis

### DIFF
--- a/packages/create-app/templates/default/.claude/rules/controllers-http.md
+++ b/packages/create-app/templates/default/.claude/rules/controllers-http.md
@@ -1,0 +1,95 @@
+---
+description: Guren controllers — validation signatures, 422 shape, Inertia pages, auth helpers, resources
+globs:
+  - "app/Http/**"
+---
+
+# Controllers & HTTP (@guren/core)
+
+Controllers extend `Controller` and expose one async method per route action.
+
+## Validation — exact signatures
+
+Any Zod-like schema (anything with `safeParse`) is accepted:
+
+```typescript
+protected async validateBody<T>(schema: ZodLikeSchema<T>): Promise<T>   // request body
+protected validateQuery<T>(schema: ZodLikeSchema<T>): T                 // query string
+protected validateParams<T>(schema: ZodLikeSchema<T>): T                // route params
+```
+
+All throw `ValidationException` on failure, rendered as **HTTP 422** with body:
+
+```json
+{ "message": "The given data was invalid.", "errors": { "field": ["msg1", "msg2"] } }
+```
+
+Non-throwing variants return a discriminated union — note errors flatten to
+**one string per field** here (`Record<string, string>`, not `string[]`):
+
+```typescript
+protected async validateBodySafe<T>(schema): Promise<SafeValidationResult<T>>
+protected validateQuerySafe<T>(schema): SafeValidationResult<T>
+protected validateParamsSafe<T>(schema): SafeValidationResult<T>
+// SafeValidationResult<T> = { success: true; data: T } | { success: false; errors: Record<string, string> }
+```
+
+Business-logic errors: `throw ValidationException.withMessages({ email: 'Already registered' })`
+(values may be `string` or `string[]`).
+
+## Inertia responses
+
+```typescript
+import { pages } from '@/.guren/pages.gen'
+return this.inertia(pages.posts.Show, { post })   // props compile-checked via PagePropsMap
+return this.inertia('posts/Show', { post })       // string overload, untyped props
+```
+
+Page prop types come from each page component's `interface Props`, extracted by
+`bunx guren codegen` into `PagePropsMap`. If props don't type-check, re-run codegen.
+Optional third arg: `InertiaResponseOptions` (e.g. `{ status: 422 }`).
+
+## Route model binding
+
+```typescript
+// routes: router.get('/posts/:id', { bind: { id: Post }, name: 'posts.show' }, [PostController, 'show'])
+async show() {
+  const post = this.model(Post)   // typed record, already resolved via findOrFail (404 on miss)
+}
+```
+
+## Auth helpers
+
+`this.auth` (requires `AuthServiceProvider`) exposes:
+`check(): Promise<boolean>` · `guest(): Promise<boolean>` · `user<T>(): Promise<T | null>` ·
+`userOrFail<T>(): Promise<T>` (throws → 401) · `id(): Promise<unknown>` ·
+`login(user, remember?)` · `attempt(credentials, remember?): Promise<boolean>` · `logout()`
+
+Authorization (policies/gates):
+`await this.authorize('update', [Post, post])` (throws 403) ·
+`await this.can('update', [Post, post]): Promise<boolean>` ·
+API tokens: `this.apiToken()` → `{ userId, abilities }` or throws 401.
+
+## Response helpers
+
+- `this.json(data, init?)` / `this.text(body, init?)`
+- `this.redirect(url, { status?, headers? })` — defaults 302 for GET, **303 for non-GET** (correct for Inertia form posts)
+- `await this.files('avatar')` → `File[]` (uploaded files, empties filtered)
+
+## API Resources (app/Http/Resources)
+
+```typescript
+import { Resource } from '@guren/core'
+
+export class PostResource extends Resource<PostRecord> {
+  toArray() {                       // abstract — must implement; typed toArray is exported as Data.Post by codegen
+    return { id: this.resource.id, title: this.resource.title }
+  }
+}
+new PostResource(post).toJSON()          // toArray() + additional() data
+PostResource.collection(posts)           // ResourceData[]
+new PostResource(post).additional({ meta: 1 })
+this.when(cond, value)                   // conditional field inside toArray()
+```
+
+`JsonResource<T>` is a no-transform passthrough (`toArray()` returns `{ ...resource }`).

--- a/packages/create-app/templates/default/.claude/rules/orm-models.md
+++ b/packages/create-app/templates/default/.claude/rules/orm-models.md
@@ -1,0 +1,118 @@
+---
+description: Guren ORM (@guren/orm) — model definition, queries, relations, pagination, mass assignment
+globs:
+  - "app/Models/**"
+  - "db/**"
+---
+
+# ORM Models (@guren/orm)
+
+## Defining a model
+
+```typescript
+import { defineModel, type BelongsToRecord } from '@guren/orm'
+import { posts } from '../../db/schema.js'
+
+export type PostRecord = typeof posts.$inferSelect
+
+export class Post extends defineModel(posts) {
+  static fillable = ['title', 'body', 'authorId']
+  static override relationTypes: { author: BelongsToRecord<UserRecord> } = { author: null }
+}
+Post.belongsTo('author', () => import('./User.js').then((m) => m.User), 'authorId', 'id')
+```
+
+`class Post extends Model<typeof posts> { static table = posts }` also works.
+Auth user models: `defineModel(users, { base: AuthenticatableModel })`.
+
+## Statics
+
+`find(id)` → record | null · `findOrFail(id)` throws `ModelNotFoundException` (renders 404) ·
+`first(where?)` → record | null · `all()` · `create(data)` · `forceCreate(data)` ·
+`update(where, data)` · `forceUpdate(where, data)` · `delete(where)` ·
+`paginate(options?)` · `transaction(async (trx) => ...)`
+
+## Where clauses
+
+```typescript
+await Post.where({ status: 'active', authorId: 1 }).get()  // object form = AND
+await Post.where({ id: [1, 2, 3] }).get()                  // array value = IN
+await Post.where('views', '>', 100).orWhere('featured', true).get()
+```
+
+Operators (exact set): `=` `!=` `>` `<` `>=` `<=` `like` `in` `not in` `is null` `is not null`
+
+## QueryBuilder chain
+
+`Post.where(...)` returns a `QueryBuilder`. Chainable:
+`where` / `orWhere` / `whereNull(field)` / `whereNotNull(field)` /
+`whereIn(field, values)` / `whereNotIn(field, values)` /
+`orderBy(field, 'asc' | 'desc')` (repeatable) / `limit(n)` / `offset(n)` /
+`with(...relations)` / `scope(name)`
+
+Terminate with: `get()` / `first()` / `firstOrFail()` / `count()` /
+`paginate(page?, perPage?)` or `paginate({ page, perPage })` /
+`update(data)` / `forceUpdate(data)` / `delete()`
+
+## Pagination
+
+```typescript
+const result = await Post.paginate({ page: 1, perPage: 15, where: {...}, orderBy: 'createdAt' })
+// PaginateOptions: { page? (1-based, default 1), perPage? (default 15), where?, orderBy? }
+// PaginatedResult: { data: TRecord[], meta: { total, perPage, currentPage, totalPages, hasMore, from, to } }
+```
+
+For Inertia/HTTP pagination links wrap it with `paginate` from `@guren/core`:
+`paginate(result, { path, query?, fragment? })` — those three fields are `PaginatorOptions`.
+
+## Relations — declaration signatures
+
+- `hasOne(name, related, foreignKey, localKey)`
+- `hasMany(name, related, foreignKey, localKey)`
+- `belongsTo(name, related, foreignKey, ownerKey)`
+- `belongsToMany(name, related, pivotTable, foreignPivotKey, relatedPivotKey, parentKey = 'id', relatedKey = 'id')` — 7 args; `pivotTable` is the Drizzle table
+- `hasManyThrough(name, related, through, firstKey, secondKey, localKey = 'id', secondLocalKey = 'id')`
+- `morphMany` / `morphTo` also exist
+
+`related` is a model class or lazy loader: `() => import('./Tag.js').then((m) => m.Tag)`.
+
+Typed relation results — declare `static relationTypes` using these exported types:
+`HasManyRecord<T>` = `T[]` · `HasOneRecord<T>` = `T | null` · `BelongsToRecord<T>` = `T | null` ·
+`BelongsToManyRecord<T>` = `T[]` · `HasManyThroughRecord<T>` = `T[]`
+
+## Eager loading
+
+```typescript
+await Post.with('tags')                    // Array<record & { tags: TagRecord[] }>; nested: with('author.posts')
+await Post.with(['author', 'tags'], { published: true })  // optional where filter
+await Post.findWith(1, 'tags')             // single record + relations, or null
+await Post.findWithOrFail(1, ['author'])   // throws ModelNotFoundException
+await Post.withCount('tags')               // adds tagsCount: number (no nested names)
+await Post.withPaginate('tags', { page: 1 })  // PaginatedResult with relations
+```
+
+## No attach/detach/sync — use a pivot model
+
+```typescript
+export class PostTag extends defineModel(postTags) {}
+await PostTag.create({ postId, tagId })   // attach
+await PostTag.delete({ postId, tagId })   // detach
+// sync: PostTag.delete({ postId }) then re-create the desired set
+```
+
+## No firstOrCreate / updateOrCreate — hand-roll it
+
+```typescript
+const existing = await Tag.first({ name })
+const tag = existing ?? await Tag.create({ name })
+```
+
+For concurrency safety add a unique index and catch the constraint error, or wrap in
+`Tag.transaction(async (trx) => ...)`.
+
+## Mass assignment
+
+- With `static fillable = [...]` set, `create()`/`update()` **throw `MassAssignmentException`**
+  on any unlisted input key (`static strictFillable = false` restores silent discarding)
+- Without `fillable`, keys in `static guarded` (default `['id']`) are silently stripped
+- `forceCreate()` / `forceUpdate()` bypass filtering — trusted server-side data only

--- a/packages/create-app/templates/default/.claude/rules/routes-codegen.md
+++ b/packages/create-app/templates/default/.claude/rules/routes-codegen.md
@@ -1,0 +1,96 @@
+---
+description: Guren routing & codegen — RouteContractOptions, schema binding, the Zod→ApiRoutes matrix, middleware
+globs:
+  - "routes/**"
+  - "app/Http/Validators/**"
+---
+
+# Routes & Codegen
+
+## Registering routes
+
+```typescript
+import { Router, requireAuthenticated } from '@guren/core'
+
+export function registerWebRoutes(router: Router): void {
+  router.get('/posts', [PostController, 'index']).name('posts.index')
+  router.post('/posts', { name: 'posts.store', body: CreatePostSchema }, [PostController, 'store'])
+
+  router.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
+  router.middleware('auth').group((group) => {
+    group.get('/dashboard', [DashboardController, 'index'])
+  })
+  router.group('/admin', (admin) => { /* path-prefixed */ })
+}
+```
+
+Options object (second arg) is `RouteContractOptions`:
+`name?` · `middlewares?: MiddlewareHandler[]` · `params?` / `query?` / `body?` / `output?`
+(Zod schemas) · `bind?: Record<string, BindableModel>` · plus OpenAPI metadata
+(`summary?`, `description?`, `tags?`, `operationId?`, `deprecated?`).
+
+Schemas attached here do double duty: requests are **validated automatically**
+(422 before the controller runs) and `bunx guren codegen` extracts them into typed manifests.
+
+`router.resource('/posts', PostController, { name?, param?, only?, except? })` registers
+index/create/store/show/edit/update/destroy (GET/POST/PUT/DELETE, `:id` param) named `posts.index` etc.
+Model binding: `bind: { id: Post }` + `this.model(Post)` in the controller.
+
+## Route Schema Binding: concrete input → output
+
+```typescript
+const CreatePostSchema = z.object({
+  title: z.string().trim().min(1),
+  body: z.string(),
+  published: z.boolean().optional().default(false),
+  tagIds: z.array(z.coerce.number().int()).optional(),
+})
+router.post('/posts', { name: 'posts.store', body: CreatePostSchema }, [PostController, 'store'])
+```
+
+generates this entry in `.guren/api-client.gen.ts`:
+
+```typescript
+export interface ApiRoutes {
+  'posts.store': {
+    method: 'POST'
+    path: '/posts'
+    params: Record<string, never>          // path params come from ':id' segments, typed string | number
+    body: { title: string; body: string; published?: boolean; tagIds?: number[] }
+  }
+}
+```
+
+Only **named** routes are emitted. `output:` schemas add a `response:` field.
+Consume with `createApiClient<ApiRoutes>({ baseUrl })` → `client.request('posts.store', { body })`.
+
+## Which Zod constructs survive type extraction
+
+Codegen walks schemas at runtime (Zod v3 and v4):
+
+- **Typed**: primitives (`string`/`number`/`boolean`/`bigint`/`date`), `literal`, `enum`,
+  `array`, nested `object`, `union` / `discriminatedUnion`, `intersection`, `record`,
+  `nullable` (`| null`)
+- **Unwrapped transparently**: `.optional()` and `.default()` (field becomes `key?:`),
+  `.catch()`, `.readonly()`, `.brand()`, `.lazy()`
+- **Validation checks don't change the type**: `.min()`, `.max()`, `.trim()`, `.email()`,
+  regex etc. stay `string`; `z.coerce.number()` is `number`
+- **Input side only**: `.transform()` / `.refine()` chains extract the schema's *input*
+  type — transform output types are NOT reflected
+- **Degrades**: `tuple` → `unknown[]`, `z.nativeEnum()` → `string | number`,
+  unrecognized constructs → `unknown`
+
+So `z.string().trim().min(1).optional().default('x')` survives as `key?: string`.
+If a generated type comes out as `unknown`, simplify the construct instead of reading `node_modules`.
+
+## When to re-run codegen
+
+`bunx guren codegen` (or `bun run codegen`) regenerates `.guren/pages.gen.ts`,
+`routes.gen.ts`, `data.gen.ts`, `api-client.gen.ts`. Re-run after changing:
+
+- `routes/web.ts` (route names, paths, schemas)
+- page components' `interface Props` in `resources/js/pages/`
+- Resource classes in `app/Http/Resources/`
+
+`bun run dev` runs codegen on start, and the Vite plugin watches those paths and
+regenerates on change. In tests/CI, run it explicitly if generated types are stale.

--- a/packages/create-app/templates/default/.claude/rules/testing.md
+++ b/packages/create-app/templates/default/.claude/rules/testing.md
@@ -1,0 +1,93 @@
+---
+description: Guren testing (@guren/testing) — TestApp client methods and the full assertion surface
+globs:
+  - "tests/**"
+---
+
+# Testing (@guren/testing + bun:test)
+
+Requests run in-process through `app.fetch()` — no server, no port.
+
+## Creating a TestApp
+
+```typescript
+import { TestApp } from '@guren/testing'
+
+const app = await TestApp.create()             // boots the real Application
+const app = await TestApp.create({ boot, providers, routes })  // all optional
+const app = TestApp.fromFetch(app.fetch)       // wrap an existing fetch fn (not async)
+```
+
+Both set `GUREN_TESTING=1` so `actingAs()` header auth is accepted.
+
+## Client methods
+
+```typescript
+app.get(path)                 // → PendingTestResponse (awaitable AND chainable)
+app.post(path, body?)         // body auto-JSON-encoded unless FormData
+app.put(path, body?) / app.patch(path, body?) / app.delete(path, body?)
+
+app.actingAs(user)            // returns a NEW TestApp with the user injected
+app.json()                    // returns a NEW TestApp with Accept: application/json
+app.withHeader(name, value) / app.withHeaders(record)   // also return new TestApp
+const csrf = await app.withCsrf()   // primes session + XSRF cookies; use for mutating requests hitting CSRF
+```
+
+## Chainable assertions (on PendingTestResponse)
+
+```typescript
+await app.get('/posts').assertOk().assertJsonCount(3, 'data')
+```
+
+Exact list:
+`assertStatus(code: number)` · `assertOk()` (200) · `assertCreated()` (201) ·
+`assertNoContent()` (204) · `assertRedirect(url?: string)` (3xx, optional Location match) ·
+`assertNotFound()` (404) · `assertForbidden()` (403) · `assertUnauthorized()` (401) ·
+`assertUnprocessable()` (422) ·
+`assertJson(expected: Record<string, unknown>)` (exact deep match) ·
+`assertJsonCount(count: number, key?: string)` ·
+`assertJsonStructure(keys: string[])` (top-level keys exist) ·
+`assertJsonPath(path: string, value: unknown)` (dot-path, deep equal) ·
+`assertInertia(component: string, props?: Record<string, unknown>)` ·
+`assertCookie(name: string, value?: string)` · `assertCookieMissing(name: string)` ·
+`assertHeader(name: string, value?: string)` · `assertHeaderMissing(name: string)`
+
+## Awaited response (TestResponse)
+
+Awaiting yields a `TestResponse` with extras not available on the chain:
+
+```typescript
+const res = await app.get('/posts')
+res.status                          // number
+res.headers                         // Headers
+await res.text()                    // body string
+await res.json<T>()                 // parsed body
+res.assertBadRequest()              // 400
+res.assertServerError()             // 500
+res.assertSuccessful()              // any 2xx
+await res.assertJsonContains({ k: v })   // partial top-level match
+await res.assertBodyContains('text')
+```
+
+## Patterns
+
+```typescript
+import { describe, test, expect, beforeAll } from 'bun:test'
+
+describe('PostController', () => {
+  let app: TestApp
+  beforeAll(async () => { app = await TestApp.create() })
+
+  test('store validates input', async () => {
+    await app.json().post('/posts', {}).assertUnprocessable()
+  })
+
+  test('store creates post for authed user', async () => {
+    const csrf = await app.actingAs(user).withCsrf()
+    await csrf.post('/posts', { title: 'Hi', body: '...' }).assertRedirect('/posts')
+  })
+})
+```
+
+Validation failures return 422 with `{ message, errors: Record<string, string[]> }` —
+assert with `assertJsonPath('errors.title.0', 'Title is required')`.

--- a/packages/create-app/templates/default/.claude/skills/feature/SKILL.md
+++ b/packages/create-app/templates/default/.claude/skills/feature/SKILL.md
@@ -7,6 +7,8 @@ description: Generate a complete CRUD feature with all related components in one
 
 You are a full-feature scaffolding assistant for the Guren framework.
 
+> When filling in generated code, follow the API rules in `.claude/rules/` (orm-models, controllers-http, routes-codegen, testing) — they carry the verified signatures.
+
 ## Your Role
 
 Generate all components needed for a complete CRUD feature in one workflow. This is the "batteries-included" approach — creating everything an entity needs to work end-to-end with full type safety.

--- a/packages/create-app/templates/default/.claude/skills/guren-api/SKILL.md
+++ b/packages/create-app/templates/default/.claude/skills/guren-api/SKILL.md
@@ -7,6 +7,8 @@ description: Guren framework API documentation, code patterns, and examples. Cov
 
 You are a documentation assistant for the Guren framework.
 
+> The authoritative signature-level API reference lives in `.claude/rules/*.md` (auto-loaded per edited path); this skill is a subsystem tour for interactive Q&A.
+
 ## Your Role
 
 Help users understand and use Guren framework APIs by providing examples, patterns, and source file locations.
@@ -118,7 +120,7 @@ await User.with('posts.comments')              // nested, dot notation
 await User.where('active', true).with('posts').get()  // QueryBuilder
 await User.findWith(1, 'posts')                // single record + relations
 await User.withCount('posts')                  // users[0].postsCount: number (no rows loaded)
-await Post.withPaginate({ page: 1 }, 'author') // paginated + relations
+await Post.withPaginate('author', { page: 1 }) // paginated + relations
 ```
 
 Also available: `hasOne`, `belongsToMany(name, related, pivotTable, foreignPivotKey, relatedPivotKey, parentKey?, relatedKey?)`, `hasManyThrough`, `morphMany`/`morphTo`. There are **no `attach`/`detach`/`sync` pivot helpers and no `firstOrCreate`/`updateOrCreate`** — manage pivot rows via a model on the pivot table (`PivotModel.create(...)` / `PivotModel.delete(...)`), and hand-roll find-or-create with `Model.first(where)` + `Model.create(...)`. Full guide: `docs/en/guides/database.md` (Relationships section).

--- a/packages/create-app/templates/default/.claude/skills/guren-api/SKILL.md
+++ b/packages/create-app/templates/default/.claude/skills/guren-api/SKILL.md
@@ -92,8 +92,8 @@ export class User extends AuthenticatableModel<UserRecord> {
 }
 ```
 
-- `fillable` (whitelist) — only listed fields pass through to `create()` / `update()`
-- `guarded` (blacklist, default: `['id']`) — listed fields are stripped; ignored when `fillable` is set
+- `fillable` (whitelist) — only listed fields pass through to `create()` / `update()`; unlisted input keys **throw `MassAssignmentException`** (set `static strictFillable = false` for silent discarding). Use `forceCreate()` / `forceUpdate()` for trusted server-side data.
+- `guarded` (blacklist, default: `['id']`) — listed fields are silently stripped; ignored when `fillable` is set
 - Both are enforced by `Model.filterFillable()`, called automatically before persistence
 - Always define `fillable` on models that accept user input — this is the second defense layer after Zod validation
 
@@ -121,7 +121,7 @@ await User.withCount('posts')                  // users[0].postsCount: number (n
 await Post.withPaginate({ page: 1 }, 'author') // paginated + relations
 ```
 
-Also available: `hasOne`, `belongsToMany(pivotTable, ...)`, `hasManyThrough`, `morphMany`/`morphTo`. Full guide: `docs/en/guides/database.md` (Relationships section).
+Also available: `hasOne`, `belongsToMany(name, related, pivotTable, foreignPivotKey, relatedPivotKey, parentKey?, relatedKey?)`, `hasManyThrough`, `morphMany`/`morphTo`. There are **no `attach`/`detach`/`sync` pivot helpers and no `firstOrCreate`/`updateOrCreate`** — manage pivot rows via a model on the pivot table (`PivotModel.create(...)` / `PivotModel.delete(...)`), and hand-roll find-or-create with `Model.first(where)` + `Model.create(...)`. Full guide: `docs/en/guides/database.md` (Relationships section).
 
 ### Routes
 Source: `packages/server/src/mvc/Router.ts`

--- a/packages/create-app/templates/default/.claude/skills/scaffold/SKILL.md
+++ b/packages/create-app/templates/default/.claude/skills/scaffold/SKILL.md
@@ -7,6 +7,8 @@ description: Generate individual Guren framework components using bunx guren mak
 
 You are a component scaffolding assistant for the Guren framework.
 
+> When editing the generated files, the verified API signatures live in `.claude/rules/*.md` (auto-loaded per edited path).
+
 ## Your Role
 
 Help users generate individual framework components using the Guren CLI. Understand context and suggest related components.

--- a/packages/create-app/templates/default/CLAUDE.md
+++ b/packages/create-app/templates/default/CLAUDE.md
@@ -14,6 +14,13 @@ bunx guren check       # validate route ↔ controller ↔ page consistency — 
 bunx guren codegen     # regenerate .guren/*.gen.ts typed manifests (also runs via `bun run dev`)
 ```
 
+Detailed, verified API rules live in `.claude/rules/*.md` and load automatically
+based on the files you are editing (glob-scoped): `orm-models.md` (models, queries,
+relations), `controllers-http.md` (validation, Inertia, auth), `routes-codegen.md`
+(route options, schema binding, codegen), `testing.md` (TestApp assertions).
+Read the matching rule file before reading `node_modules/@guren/*` — it covers the
+exact signatures.
+
 ## Project Structure
 
 ```
@@ -105,183 +112,53 @@ http://localhost:3333/_guren/mcp
 | `guren_make_component` | 個別コンポーネント生成 |
 | `guren_codegen` | 型マニフェスト生成（routes.gen.ts, pages.gen.ts等） |
 
-## Architecture Patterns
+## Architecture Overview
 
-### Controllers
+The request lifecycle: `routes/web.ts` registers routes on a `Router`, each pointing
+at a `[Controller, 'method']` tuple. Controllers validate input with Zod schemas,
+query models, and render Inertia pages or JSON.
+
 ```typescript
-import { Controller } from '@guren/core'
-import { z } from 'zod'
+// routes/web.ts
+router.get('/posts', [PostController, 'index']).name('posts.index')
+router.post('/posts', { name: 'posts.store', body: CreatePostSchema }, [PostController, 'store'])
 
-const CreatePostSchema = z.object({
-  title: z.string().min(1),
-  body: z.string().min(1),
-})
-
-const PostIdParamSchema = z.object({
-  id: z.coerce.number().int().positive(),
-})
-
+// app/Http/Controllers/PostController.ts
 export class PostController extends Controller {
-  async index() {
-    const result = await Post.paginate({ page: 1, perPage: 15 })
-    const paginator = paginate(result, { path: this.request.path ?? '/posts' })
-    return this.inertia(pages.posts.Index, {
-      data: result.data.map((post) => new PostResource(post).toJSON()),
-      pagination: paginator,
-    })
-  }
-
-  async show() {
-    const { id } = this.validateParams(PostIdParamSchema)
-    const post = await Post.findOrFail(id)
-    return this.inertia(pages.posts.Show, { post: new PostResource(post).toJSON() })
-  }
-
   async store() {
-    const data = await this.validateBody(CreatePostSchema)
-    const user = await this.auth.userOrFail()
+    const data = await this.validateBody(CreatePostSchema)   // 422 on failure
+    const user = await this.auth.userOrFail()                // 401 if unauthenticated
     const post = await Post.create({ ...data, authorId: user.id })
     return this.redirect('/posts')
   }
 }
-```
 
-**Validation helpers** (accepts any Zod-like schema with `safeParse`):
-- `this.validateBody<T>(schema): Promise<T>` — parse request body
-- `this.validateQuery<T>(schema): T` — parse query parameters
-- `this.validateParams<T>(schema): T` — parse route parameters
-
-All throw `ValidationException` on failure, rendered as HTTP 422 with `{ message, errors: Record<string, string[]> }`. Non-throwing variants (`validateBodySafe` etc.) return `{ success: true, data } | { success: false, errors }`.
-
-### Models
-```typescript
-import { Model } from '@guren/orm'
-import { posts } from '@/db/schema'
-
-export class Post extends Model<typeof posts> {
-  static table = posts
-}
-
-// Usage
-const post = await Post.find(1)          // returns null if not found
-const post = await Post.findOrFail(1)    // throws ModelNotFoundException (404)
-const all = await Post.where('published', true).get()
-```
-
-**Where clauses** — object form or `(field, operator, value)` form:
-
-```typescript
-await Post.where({ status: 'active', authorId: 1 }).get()  // AND; array value = IN
-await Post.where({ id: [1, 2, 3] }).get()                  // WHERE id IN (1, 2, 3)
-await Post.where('views', '>', 100).orWhere('featured', true).get()
-```
-
-Operators: `=` `!=` `>` `<` `>=` `<=` `like` `in` `not in` `is null` `is not null`.
-Chain: `where` / `orWhere` / `whereNull` / `whereNotNull` / `orderBy(field, 'asc'|'desc')` / `limit` / `offset` / `with` — finish with `get()` / `first()` / `firstOrFail()` / `count()` / `paginate(page?, perPage?)` / `update(data)` / `delete()`.
-
-**Relationships** — declare on the class, eager-load with `with()`:
-
-```typescript
-User.hasMany('posts', () => import('./Post.js').then((m) => m.Post), 'authorId', 'id')
-Post.belongsTo('author', () => import('./User.js').then((m) => m.User), 'authorId', 'id')
-// belongsToMany(name, related, pivotTable, foreignPivotKey, relatedPivotKey, parentKey = 'id', relatedKey = 'id')
-Post.belongsToMany('tags', () => import('./Tag.js').then((m) => m.Tag), postTags, 'postId', 'tagId')
-
-await Post.with('tags')            // eager load; nested via dot: with('author.posts')
-await Post.findWith(1, 'tags')     // single record + relations
-await Post.withCount('tags')       // adds tagsCount, no rows loaded
-```
-
-Also: `hasOne`, `hasManyThrough`, `morphMany`/`morphTo`, `withPaginate`.
-
-**There are no `attach`/`detach`/`sync` pivot helpers.** Manage pivot rows with a model on the pivot table:
-
-```typescript
-export class PostTag extends Model<typeof postTags> { static table = postTags }
-await PostTag.create({ postId, tagId })   // attach
-await PostTag.delete({ postId, tagId })   // detach
-// sync: PostTag.delete({ postId }) then re-create the desired set
-```
-
-**There is no `firstOrCreate` / `updateOrCreate`.** Hand-roll the pattern:
-
-```typescript
-const existing = await Tag.first({ name })  // first(where?) → record | null
-const tag = existing ?? await Tag.create({ name })
-```
-
-For concurrency safety, add a unique index and catch the constraint error, or wrap in `Tag.transaction(async (trx) => ...)`.
-
-**Mass assignment** — `create()` / `update()` filter their input:
-
-```typescript
-export class Post extends Model<typeof posts> {
-  static table = posts
-  static fillable = ['title', 'body', 'authorId']  // whitelist — always set on user-input models
+// app/Models/Post.ts
+export class Post extends defineModel(posts) {
+  static fillable = ['title', 'body', 'authorId']
 }
 ```
 
-- With `fillable` set, unlisted input keys **throw `MassAssignmentException`** (`static strictFillable = false` restores silent discarding)
-- Without `fillable`, keys in `guarded` (default `['id']`) are silently stripped
-- `forceCreate()` / `forceUpdate()` bypass filtering — trusted server-side data only
-
-### Routes
-```typescript
-import { Router } from '@guren/core'
-
-export function registerWebRoutes(router: Router): void {
-  router.get('/posts', [PostController, 'index']).name('posts.index')
-  // Attach the Zod body schema so codegen can extract typed ApiRoutes entries
-  router.post('/posts', { name: 'posts.store', body: CreatePostSchema }, [PostController, 'store'])
-
-  router.middleware('auth').group((group) => {
-    group.get('/dashboard', [DashboardController, 'index'])
-  })
-}
-```
-
-### Codegen: which Zod constructs survive type extraction
-
-`bunx guren codegen` walks route schemas at runtime (Zod v3 and v4 both supported) and emits `body` types into `ApiRoutes` (`.guren/api-client.gen.ts`):
-
-- **Typed**: primitives (`string`/`number`/`boolean`/`bigint`/`date`), `literal`, `enum`, `array`, nested `object`, `union` / `discriminatedUnion`, `intersection`, `record`, `nullable` (`| null`)
-- **Unwrapped transparently**: `.optional()` and `.default()` (field becomes `key?:`), `.catch()`, `.readonly()`, `.brand()`, `.lazy()`
-- **Validation checks don't change the type**: `.min()`, `.max()`, `.trim()`, `.email()`, regex etc. stay `string`; `z.coerce.number()` is `number`
-- **Input side only**: `.transform()` / `.refine()` chains extract the schema's *input* type — transform output types are NOT reflected
-- **Degrades**: `tuple` → `unknown[]`, `z.nativeEnum()` → `string | number`, unrecognized constructs → `unknown`
-
-So `z.string().trim().min(1).optional().default('x')` survives as `key?: string`. If a generated type comes out as `unknown`, simplify the construct rather than reading `node_modules`.
-
-### Middleware
-```typescript
-import { defineMiddleware } from '@guren/core'
-
-export const requireAuth = defineMiddleware(async (c, next) => {
-  if (!c.get('user')) {
-    return c.redirect('/login')
-  }
-  await next()
-})
-```
+- Models: `await Post.findOrFail(id)` throws a 404; `Post.where(...)` starts a query
+  builder chain. Full API in `.claude/rules/orm-models.md`.
+- Attaching a Zod schema to a route both validates the request automatically and
+  feeds `bunx guren codegen` typed manifests. Details in `.claude/rules/routes-codegen.md`.
+- Middleware: `defineMiddleware(async (c, next) => { ... })` from `@guren/core`;
+  register aliases via `router.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))`.
 
 ## Testing
 
 Uses `bun:test` + `@guren/testing`. Requests run in-process via `app.fetch()` — no server needed.
 
 ```typescript
-import { test } from 'bun:test'
 import { TestApp } from '@guren/testing'
 
-test('posts endpoints', async () => {
-  const app = await TestApp.create()
-  await app.get('/posts').assertOk().assertJsonCount(3, 'data')
-  await app.actingAs(user).json().post('/posts', { title: 'Hi' }).assertCreated()
-  await app.get('/posts/999').assertNotFound()
-})
+const app = await TestApp.create()
+await app.get('/posts').assertOk()
+await app.actingAs(user).json().post('/posts', { title: 'Hi' }).assertCreated()
 ```
 
-- **Client**: `get(path)` / `post(path, body?)` / `put` / `patch` / `delete`, `actingAs(user)`, `json()`, `withHeader(name, value)` / `withHeaders(obj)`, `await app.withCsrf()` (primes session + XSRF cookies so mutating requests pass CSRF)
-- **Chainable assertions**: `assertStatus(code)`, `assertOk`, `assertCreated`, `assertNoContent`, `assertRedirect(url?)`, `assertNotFound`, `assertForbidden`, `assertUnauthorized`, `assertUnprocessable`, `assertJson(obj)`, `assertJsonCount(n, key?)`, `assertJsonStructure(keys)`, `assertJsonPath(path, value)`, `assertInertia(component, props?)`, `assertCookie(name, value?)`, `assertCookieMissing(name)`, `assertHeader(name, value?)`, `assertHeaderMissing(name)`
+Full client and assertion reference: `.claude/rules/testing.md`.
 
 ## Key Files
 
@@ -293,3 +170,4 @@ test('posts endpoints', async () => {
 | `routes/web.ts` | Web route definitions |
 | `app/Providers/` | Service providers |
 | `resources/js/pages/` | React page components |
+| `.claude/rules/` | Glob-scoped API rules (auto-loaded per edited path) |

--- a/packages/create-app/templates/default/CLAUDE.md
+++ b/packages/create-app/templates/default/CLAUDE.md
@@ -4,6 +4,16 @@
 
 A fullstack TypeScript application built with the Guren framework (Laravel-inspired, running on Bun).
 
+## AI Agents: Start Here
+
+Before exploring `node_modules`, use the built-in introspection commands:
+
+```bash
+bunx guren context     # project map: models, routes, controllers, pages (add --json for JSON)
+bunx guren check       # validate route ↔ controller ↔ page consistency — run after changes
+bunx guren codegen     # regenerate .guren/*.gen.ts typed manifests (also runs via `bun run dev`)
+```
+
 ## Project Structure
 
 ```
@@ -59,9 +69,12 @@ bunx guren make:listener <Name> --event=<EventName>
 bunx guren make:mail <Name>
 bunx guren make:test <Name>
 
-# Database
-bun run db:migrate
-bun run db:seed
+# Database workflow: edit db/schema.ts first, then
+bunx guren make:migration <name>   # generate SQL migration via drizzle-kit into db/migrations/
+bun run db:migrate                 # apply pending migrations
+bunx guren db:status               # show applied/pending state
+bun run db:seed                    # run seeders
+# Migrations are forward-only (no rollback). Dev reset: bunx guren db:reset --seed
 
 # Build & test
 bun run build
@@ -134,9 +147,11 @@ export class PostController extends Controller {
 ```
 
 **Validation helpers** (accepts any Zod-like schema with `safeParse`):
-- `this.validateBody(schema)` — parse request body, throw 422 on failure
-- `this.validateQuery(schema)` — parse query parameters
-- `this.validateParams(schema)` — parse route parameters
+- `this.validateBody<T>(schema): Promise<T>` — parse request body
+- `this.validateQuery<T>(schema): T` — parse query parameters
+- `this.validateParams<T>(schema): T` — parse route parameters
+
+All throw `ValidationException` on failure, rendered as HTTP 422 with `{ message, errors: Record<string, string[]> }`. Non-throwing variants (`validateBodySafe` etc.) return `{ success: true, data } | { success: false, errors }`.
 
 ### Models
 ```typescript
@@ -153,20 +168,89 @@ const post = await Post.findOrFail(1)    // throws ModelNotFoundException (404)
 const all = await Post.where('published', true).get()
 ```
 
+**Where clauses** — object form or `(field, operator, value)` form:
+
+```typescript
+await Post.where({ status: 'active', authorId: 1 }).get()  // AND; array value = IN
+await Post.where({ id: [1, 2, 3] }).get()                  // WHERE id IN (1, 2, 3)
+await Post.where('views', '>', 100).orWhere('featured', true).get()
+```
+
+Operators: `=` `!=` `>` `<` `>=` `<=` `like` `in` `not in` `is null` `is not null`.
+Chain: `where` / `orWhere` / `whereNull` / `whereNotNull` / `orderBy(field, 'asc'|'desc')` / `limit` / `offset` / `with` — finish with `get()` / `first()` / `firstOrFail()` / `count()` / `paginate(page?, perPage?)` / `update(data)` / `delete()`.
+
+**Relationships** — declare on the class, eager-load with `with()`:
+
+```typescript
+User.hasMany('posts', () => import('./Post.js').then((m) => m.Post), 'authorId', 'id')
+Post.belongsTo('author', () => import('./User.js').then((m) => m.User), 'authorId', 'id')
+// belongsToMany(name, related, pivotTable, foreignPivotKey, relatedPivotKey, parentKey = 'id', relatedKey = 'id')
+Post.belongsToMany('tags', () => import('./Tag.js').then((m) => m.Tag), postTags, 'postId', 'tagId')
+
+await Post.with('tags')            // eager load; nested via dot: with('author.posts')
+await Post.findWith(1, 'tags')     // single record + relations
+await Post.withCount('tags')       // adds tagsCount, no rows loaded
+```
+
+Also: `hasOne`, `hasManyThrough`, `morphMany`/`morphTo`, `withPaginate`.
+
+**There are no `attach`/`detach`/`sync` pivot helpers.** Manage pivot rows with a model on the pivot table:
+
+```typescript
+export class PostTag extends Model<typeof postTags> { static table = postTags }
+await PostTag.create({ postId, tagId })   // attach
+await PostTag.delete({ postId, tagId })   // detach
+// sync: PostTag.delete({ postId }) then re-create the desired set
+```
+
+**There is no `firstOrCreate` / `updateOrCreate`.** Hand-roll the pattern:
+
+```typescript
+const existing = await Tag.first({ name })  // first(where?) → record | null
+const tag = existing ?? await Tag.create({ name })
+```
+
+For concurrency safety, add a unique index and catch the constraint error, or wrap in `Tag.transaction(async (trx) => ...)`.
+
+**Mass assignment** — `create()` / `update()` filter their input:
+
+```typescript
+export class Post extends Model<typeof posts> {
+  static table = posts
+  static fillable = ['title', 'body', 'authorId']  // whitelist — always set on user-input models
+}
+```
+
+- With `fillable` set, unlisted input keys **throw `MassAssignmentException`** (`static strictFillable = false` restores silent discarding)
+- Without `fillable`, keys in `guarded` (default `['id']`) are silently stripped
+- `forceCreate()` / `forceUpdate()` bypass filtering — trusted server-side data only
+
 ### Routes
 ```typescript
 import { Router } from '@guren/core'
 
 export function registerWebRoutes(router: Router): void {
-  router.get('/posts', PostController.index)
-  router.post('/posts', PostController.store)
-  router.resource('/posts', PostController)
+  router.get('/posts', [PostController, 'index']).name('posts.index')
+  // Attach the Zod body schema so codegen can extract typed ApiRoutes entries
+  router.post('/posts', { name: 'posts.store', body: CreatePostSchema }, [PostController, 'store'])
 
   router.middleware('auth').group((group) => {
-    group.get('/dashboard', DashboardController.index)
+    group.get('/dashboard', [DashboardController, 'index'])
   })
 }
 ```
+
+### Codegen: which Zod constructs survive type extraction
+
+`bunx guren codegen` walks route schemas at runtime (Zod v3 and v4 both supported) and emits `body` types into `ApiRoutes` (`.guren/api-client.gen.ts`):
+
+- **Typed**: primitives (`string`/`number`/`boolean`/`bigint`/`date`), `literal`, `enum`, `array`, nested `object`, `union` / `discriminatedUnion`, `intersection`, `record`, `nullable` (`| null`)
+- **Unwrapped transparently**: `.optional()` and `.default()` (field becomes `key?:`), `.catch()`, `.readonly()`, `.brand()`, `.lazy()`
+- **Validation checks don't change the type**: `.min()`, `.max()`, `.trim()`, `.email()`, regex etc. stay `string`; `z.coerce.number()` is `number`
+- **Input side only**: `.transform()` / `.refine()` chains extract the schema's *input* type — transform output types are NOT reflected
+- **Degrades**: `tuple` → `unknown[]`, `z.nativeEnum()` → `string | number`, unrecognized constructs → `unknown`
+
+So `z.string().trim().min(1).optional().default('x')` survives as `key?: string`. If a generated type comes out as `unknown`, simplify the construct rather than reading `node_modules`.
 
 ### Middleware
 ```typescript
@@ -179,6 +263,25 @@ export const requireAuth = defineMiddleware(async (c, next) => {
   await next()
 })
 ```
+
+## Testing
+
+Uses `bun:test` + `@guren/testing`. Requests run in-process via `app.fetch()` — no server needed.
+
+```typescript
+import { test } from 'bun:test'
+import { TestApp } from '@guren/testing'
+
+test('posts endpoints', async () => {
+  const app = await TestApp.create()
+  await app.get('/posts').assertOk().assertJsonCount(3, 'data')
+  await app.actingAs(user).json().post('/posts', { title: 'Hi' }).assertCreated()
+  await app.get('/posts/999').assertNotFound()
+})
+```
+
+- **Client**: `get(path)` / `post(path, body?)` / `put` / `patch` / `delete`, `actingAs(user)`, `json()`, `withHeader(name, value)` / `withHeaders(obj)`, `await app.withCsrf()` (primes session + XSRF cookies so mutating requests pass CSRF)
+- **Chainable assertions**: `assertStatus(code)`, `assertOk`, `assertCreated`, `assertNoContent`, `assertRedirect(url?)`, `assertNotFound`, `assertForbidden`, `assertUnauthorized`, `assertUnprocessable`, `assertJson(obj)`, `assertJsonCount(n, key?)`, `assertJsonStructure(keys)`, `assertJsonPath(path, value)`, `assertInertia(component, props?)`, `assertCookie(name, value?)`, `assertCookieMissing(name)`, `assertHeader(name, value?)`, `assertHeaderMissing(name)`
 
 ## Key Files
 


### PR DESCRIPTION
## Summary

Round-2 agent evaluations (framework-comparison `agent-eval/STUMBLES.md`) showed coding agents spend **17–46% of all tool actions** reverse-engineering `@guren/*` internals out of `node_modules/*/dist` because the scaffold guidance didn't cover the APIs they need. Implementation itself was fast and error-free once they knew the API — the ramp is the whole gap.

This PR makes the template CLAUDE.md + guren-api skill cover the eight topics agents actually hunted for, all verified against package sources:

- **AI Agents: Start Here** section (`bunx guren context` / `guren check` / codegen)
- Database migration workflow (make:migration → db:migrate → db:status, forward-only)
- `validateBody/Query/Params` exact signatures + 422 error shape
- Where-clause operator list (incl. `in`) and QueryBuilder chain
- `belongsToMany` full 7-arg signature + eager loading
- Explicit **absence** of `attach`/`detach`/`sync` → pivot-model pattern
- Explicit **absence** of `firstOrCreate`/`updateOrCreate` → hand-rolled pattern
- Strict mass-assignment semantics — fixes stale skill text that said unlisted fields are "stripped" (they **throw** since #80)
- **Codegen zod support matrix** (verified against `schema-type-extractor.ts`): what survives type extraction, what degrades to `unknown`
- TestApp client methods + all chainable assertions

## Test plan

- [x] `bun run audit:core-first` — passed
- [x] `bun run audit:docs` — passed
- [ ] Round-3 agent eval (in progress) measures whether this guidance closes the knowledge-acquisition gap