### PR TITLE
fix(orm): firstOrFail throws ModelNotFoundException for consistent 404

### DIFF
--- a/packages/orm/src/ModelNotFoundException.ts
+++ b/packages/orm/src/ModelNotFoundException.ts
@@ -1,5 +1,5 @@
 /**
- * Exception thrown when a model is not found via findOrFail.
+ * Exception thrown when a model is not found via findOrFail or firstOrFail.
  *
  * Carries a `statusCode` of 404 so that framework exception handlers
  * can render it as a proper HTTP 404 without coupling to the ORM package.
@@ -9,8 +9,8 @@ export class ModelNotFoundException extends Error {
   readonly modelName: string
   readonly modelId: unknown
 
-  constructor(modelName: string, id: unknown, key = 'id') {
-    super(`${modelName} not found for ${key}=${String(id)}`)
+  constructor(modelName: string, id?: unknown, key = 'id') {
+    super(id === undefined ? `${modelName} not found` : `${modelName} not found for ${key}=${String(id)}`)
     this.name = 'ModelNotFoundException'
     this.modelName = modelName
     this.modelId = id

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_PAGINATION_SIZE } from './Model'
+import { ModelNotFoundException } from './ModelNotFoundException'
 import type {
   AdapterQueryOptions,
   FindManyOptions,
@@ -327,12 +328,12 @@ export class QueryBuilder<
   /**
    * Execute the query and return the first matching record, or throw.
    * @returns The first record
-   * @throws Error if no record matches
+   * @throws ModelNotFoundException (404) if no record matches
    */
   async firstOrFail(): Promise<TResult> {
     const record = await this.first()
     if (record === null) {
-      throw new Error(`${this.modelClass.name} not found`)
+      throw new ModelNotFoundException(this.modelClass.name)
     }
     return record
   }

--- a/packages/orm/tests/query-builder.test.ts
+++ b/packages/orm/tests/query-builder.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'bun:test'
 import { QueryBuilder, type WhereCondition, type ORMAdapterAdvanced } from '../src/QueryBuilder'
 import { Model, type ORMAdapter, type PlainObject, type WhereClause, type FindManyOptions } from '../src/Model'
+import { ModelNotFoundException } from '../src/ModelNotFoundException'
 
 type TestRecord = {
   id: number
@@ -290,8 +291,18 @@ describe('QueryBuilder', () => {
       expect(result).toBeNull()
     })
 
-    it('firstOrFail should throw when no match', async () => {
-      await expect(qb().where('name', 'Nobody').firstOrFail()).rejects.toThrow('not found')
+    it('firstOrFail should throw ModelNotFoundException when no match', async () => {
+      await expect(qb().where('name', 'Nobody').firstOrFail()).rejects.toThrow(ModelNotFoundException)
+    })
+
+    it('firstOrFail exception should carry statusCode 404', async () => {
+      try {
+        await qb().where('name', 'Nobody').firstOrFail()
+        expect.unreachable('firstOrFail should have thrown')
+      } catch (error) {
+        expect(error).toBeInstanceOf(ModelNotFoundException)
+        expect((error as ModelNotFoundException).statusCode).toBe(404)
+      }
     })
 
     it('firstOrFail should return record when match exists', async () => {


### PR DESCRIPTION
## Summary

`QueryBuilder.firstOrFail()` threw a plain `Error`, which the exception handler renders as a **500**. `Model.findOrFail()` already throws `ModelNotFoundException` (`statusCode: 404`), so the two "or fail" APIs were inconsistent.

This mattered in practice: the route model binding pattern recommended in `docs/en/guides/routing.md` —

```ts
router.bind('post', async (value) => Post.where('slug', value).firstOrFail())
```

— returned 500 instead of 404 when no record matched.

Changes:
- `firstOrFail()` now throws `ModelNotFoundException`
- `ModelNotFoundException`'s `id` parameter is now optional; without an id the message is `"User not found"` (condition-based lookup). Messages for id-based `findOrFail` lookups are unchanged (`"User not found for id=1"`)

## Scope

- orm (`QueryBuilder.ts`, `ModelNotFoundException.ts`, tests)

## Risk Assessment

- Behavior change: missing record via `firstOrFail()` now renders **404 instead of 500**. This aligns with documented expectations and `findOrFail`; treating it as a bug fix, not a breaking change.
- `ModelNotFoundException extends Error`, so existing `instanceof Error` handling keeps working.
- Constructor change is backward compatible (`id` made optional; existing call sites unaffected).

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` (`test:bun`: 2128 pass / 0 fail, `test:examples`: 7 pass)

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation. (No doc change needed — docs already describe the intended 404 behavior; this fixes the implementation to match.)