### PR TITLE
docs: add agent evaluation and benchmark sections to homepage

### DIFF
--- a/web/resources/js/pages/Home.tsx
+++ b/web/resources/js/pages/Home.tsx
@@ -52,6 +52,56 @@ const features = [
   },
 ]
 
+interface BenchmarkBar {
+  name: string
+  ratio: number
+  display: string
+  accent: boolean
+}
+
+interface Benchmark {
+  value: string
+  label: string
+  detail: string
+  bars: BenchmarkBar[]
+}
+
+const benchmarks: Benchmark[] = [
+  {
+    value: '2.3×',
+    label: 'SSR throughput',
+    detail: 'Full Inertia SSR pages, same app on a Node.js MVC framework',
+    bars: [
+      { name: 'Guren', ratio: 2.3, display: '2.3×', accent: true },
+      { name: 'Node', ratio: 1, display: '1×', accent: false },
+    ],
+  },
+  {
+    value: '3.5×',
+    label: 'JSON API throughput',
+    detail: 'The plain JSON path, same-app comparison',
+    bars: [
+      { name: 'Guren', ratio: 3.5, display: '3.5×', accent: true },
+      { name: 'Node', ratio: 1, display: '1×', accent: false },
+    ],
+  },
+  {
+    value: '1.8×',
+    label: 'Faster cold starts',
+    detail: 'Process start to first response',
+    bars: [
+      { name: 'Guren', ratio: 1.8, display: '1.8×', accent: true },
+      { name: 'Node', ratio: 1, display: '1×', accent: false },
+    ],
+  },
+]
+
+const agentCostSteps = [
+  { name: 'Bare repo', cost: 5.54, display: '$5.54', accent: false },
+  { name: 'Big CLAUDE.md', cost: 4.51, display: '$4.51', accent: false },
+  { name: 'Shipped guidance', cost: 3.35, display: '$3.35', accent: true },
+]
+
 const TAB_KEYS = ['Routes', 'Controller', 'Model'] as const
 type TabKey = (typeof TAB_KEYS)[number]
 
@@ -173,6 +223,140 @@ export default function Home({ message, codeExamples }: Props) {
           </div>
         </section>
 
+        {/* Agent Evaluation */}
+        <section className="border-t border-white/10 px-6 py-20">
+          <div className="mx-auto grid max-w-5xl items-start gap-12 lg:grid-cols-2">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-crimson-400">Agent-native</p>
+              <h2 className="mt-3 text-3xl font-bold text-white md:text-4xl">
+                Built for AI coding agents
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-white/60">
+                One command hands an agent your whole project map. Three mechanical gates catch its
+                mistakes before you read the diff. And every new app ships agent guidance whose
+                effect is measured in a public, reproducible evaluation — a 40% cut in agent cost
+                over an undocumented baseline.
+              </p>
+              <CodeBlock
+                lines={[
+                  '$ bunx guren context   # project map for the agent',
+                  '$ bunx guren check     # routes ↔ controllers ↔ pages',
+                  '$ bunx guren audit     # validation, auth, secrets',
+                ]}
+                title="Terminal"
+              />
+              <p className="mt-4 text-sm leading-relaxed text-white/50">
+                Every Guren trial in the evaluation shipped a working feature — scored blind by
+                typecheck, tests, and a hidden HTTP smoke the agent never saw.
+              </p>
+            </div>
+            <div className="rounded-xl border border-white/10 bg-white/[0.03] p-6">
+              <p className="text-sm font-semibold text-white">
+                Agent cost for the same feature
+              </p>
+              <p className="mt-1 text-xs text-white/50">
+                Median USD per trial — Claude Code building a full tagging feature on Guren
+              </p>
+              <div className="mt-6 space-y-4">
+                {agentCostSteps.map((step) => (
+                  <div key={step.name} title={`${step.name}: ${step.display}`}>
+                    <p className="text-[11px] font-medium text-white/60">{step.name}</p>
+                    <div className="mt-1 flex items-center gap-2">
+                      <div
+                        className={`h-3 shrink-0 rounded-r ${step.accent ? 'bg-crimson-500' : 'bg-[#6b6363]'}`}
+                        style={{ width: `calc((100% - 48px) * ${(step.cost / 5.54).toFixed(4)})` }}
+                      />
+                      <span className="shrink-0 text-[11px] text-white/70">{step.display}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <p className="mt-5 text-xs leading-relaxed text-white/50">
+                The guidance in the last bar — a lean auto-loaded CLAUDE.md plus path-scoped rules —
+                is exactly what <code className="text-white/70">create-guren-app</code> ships today.
+              </p>
+              <a
+                href="https://github.com/gurenjs/framework-comparison/tree/main/agent-eval"
+                target="_blank"
+                rel="noreferrer"
+                className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-crimson-300 transition hover:text-crimson-200"
+              >
+                Evaluation harness &amp; raw data
+                <ArrowRightIcon className="size-3.5" />
+              </a>
+            </div>
+          </div>
+        </section>
+
+        {/* Benchmarks */}
+        <section className="border-t border-white/10 px-6 py-20">
+          <div className="mx-auto max-w-5xl">
+            <div className="mb-12 text-center">
+              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-crimson-400">Measured, not promised</p>
+              <h2 className="mt-3 text-3xl font-bold text-white md:text-4xl">
+                Fast where it counts
+              </h2>
+              <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-white/60">
+                The same spec app on Guren and on the equivalent Node.js MVC stack, benchmarked
+                under identical conditions. The app code is held constant, so the gap is Bun itself —
+                and that is the point: keep the Laravel-style architecture, change the engine.
+                Every number is reproducible with one command.
+              </p>
+            </div>
+            <div className="stagger-fade-in grid gap-5 sm:grid-cols-3">
+              {benchmarks.map((b) => {
+                const maxRatio = Math.max(...b.bars.map((bar) => bar.ratio))
+                return (
+                  <div
+                    key={b.label}
+                    className="rounded-xl border border-white/10 bg-white/[0.03] p-6"
+                  >
+                    <p className="bg-gradient-to-r from-crimson-300 to-crimson-500 bg-clip-text text-center text-4xl font-extrabold text-transparent">
+                      {b.value}
+                    </p>
+                    <p className="mt-2 text-center text-sm font-semibold text-white">{b.label}</p>
+                    <div className="mt-4 space-y-1.5">
+                      {b.bars.map((bar) => (
+                        <div key={bar.name} className="flex items-center gap-2" title={`${bar.name}: ${bar.display}`}>
+                          <span className="w-11 shrink-0 text-[10px] font-medium text-white/50">
+                            {bar.name}
+                          </span>
+                          <div className="flex flex-1 items-center gap-1.5">
+                            <div
+                              className={`h-2.5 shrink-0 rounded-r ${bar.accent ? 'bg-crimson-500' : 'bg-[#6b6363]'}`}
+                              style={{ width: `calc((100% - 34px) * ${(bar.ratio / maxRatio).toFixed(4)})` }}
+                            />
+                            <span className="shrink-0 text-[10px] text-white/70">{bar.display}</span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                    <p className="mt-3 text-center text-xs leading-relaxed text-white/50">{b.detail}</p>
+                  </div>
+                )
+              })}
+            </div>
+            <div className="mt-8 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm">
+              <a
+                href="https://github.com/gurenjs/framework-comparison/blob/main/BENCHMARK.md"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1.5 font-semibold text-crimson-300 transition hover:text-crimson-200"
+              >
+                Methodology &amp; reproduction
+                <ArrowRightIcon className="size-3.5" />
+              </a>
+              <Link
+                href="/docs/guides/why-guren"
+                className="inline-flex items-center gap-1.5 font-semibold text-crimson-300 transition hover:text-crimson-200"
+              >
+                Read the full comparison
+                <ArrowRightIcon className="size-3.5" />
+              </Link>
+            </div>
+          </div>
+        </section>
+
         {/* Stats Bar */}
         <section className="border-y border-white/10 bg-white/[0.02] px-6 py-12">
           <div className="mx-auto flex max-w-4xl flex-wrap items-center justify-center gap-8 text-center md:gap-16">
@@ -180,7 +364,6 @@ export default function Home({ message, codeExamples }: Props) {
               { label: 'TypeScript-first', icon: <CodeBracketIcon className="mx-auto mb-2 size-6 text-crimson-400" /> },
               { label: 'MIT Licensed', icon: <ShieldCheckIcon className="mx-auto mb-2 size-6 text-crimson-400" /> },
               { label: 'Bun-native', icon: <RocketIcon className="mx-auto mb-2 size-6 text-crimson-400" /> },
-              { label: 'v1.0', icon: <BoltIcon className="mx-auto mb-2 size-6 text-crimson-400" /> },
             ].map((stat) => (
               <div key={stat.label}>
                 {stat.icon}
@@ -199,7 +382,7 @@ export default function Home({ message, codeExamples }: Props) {
           <div className="relative mx-auto max-w-2xl text-center">
             <h2 className="text-3xl font-bold text-white md:text-4xl">Ready to build?</h2>
             <p className="mt-4 text-lg text-white/60">
-              Get started with Guren in under a minute. No config, no boilerplate.
+              Guren is stable at v1.0 — get started in under a minute. No config, no boilerplate.
             </p>
             <div className="mt-8 flex flex-wrap justify-center gap-4">
               <Link


### PR DESCRIPTION
## Summary

The homepage previously made a "blazingly fast" claim with no receipts and said nothing about Guren's agent-native design. This PR adds two data-backed sections, ordered so Guren's own differentiator comes first and the runtime dividend second:

### Agent-native — Built for AI coding agents
- Left: the discover/verify loop (`guren context` / `check` / `audit`) and the blind-scored evaluation result (every Guren trial shipped a working feature).
- Right: a bar chart of the guidance arc from the public agent evaluation — bare repo $5.54 → big CLAUDE.md $4.51 → **shipped guidance $3.35** median per trial (−40%) — with a link to the evaluation harness and raw data.
- Deliberately **not** a six-framework cost comparison: presented honestly it is unflattering (training-data familiarity dominates), and cherry-picked it would be dishonest. The guidance arc is the finding that is ours to claim.

### Measured, not promised — Fast where it counts
- 2.3× SSR / 3.5× JSON / 1.8× cold start as stat cards with mini bar charts (Guren vs the same app on the equivalent Node.js MVC stack).
- Copy explicitly attributes the gap to Bun, per BENCHMARK.md's own framing: *the app code is held constant, so the gap is Bun itself — keep the Laravel-style architecture, change the engine.*
- Links to the benchmark methodology and the Why Guren page.

### Misc
- Folded the `v1.0` + bolt-icon stat chip into the CTA copy ("Guren is stable at v1.0") — the icon implied speed, which the perf section now carefully attributes to the runtime.

Chart colors (crimson #f23a3a vs de-emphasis gray #6b6363) were validated for CVD separation and ≥3:1 contrast against the card surface; bar widths verified to match the published ratios exactly.

## Verification
- `bun run typecheck` (web) ✅
- `bun run test` (web, 7 tests) ✅
- `bun run audit:core-first` / `audit:docs` ✅
- Full-page render verified in browser (section order, charts, links to BENCHMARK.md / agent-eval / why-guren)