### PR TITLE
chore: add Claude Code launch config for docs site preview

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "web-docs",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "cd web && exec bun bin/serve.ts"],
+      "port": 3333
+    }
+  ]
+}


### PR DESCRIPTION
Adds `.claude/launch.json` so Claude Code's browser preview can start the docs site (`web/`) with one click.

The config deliberately runs `bun bin/serve.ts` directly rather than `bun run dev`: the dev script's `--watch` restarts on the `.guren/*.gen.ts` files that codegen rewrites at boot, so the watch variant restart-loops and never binds the port. The Vite plugin still regenerates route/page types at boot, so nothing is lost.

Discovered while verifying #94 in the browser.