### PR TITLE
fix: server-render Inertia pages on serverless deployments

### DIFF
--- a/.changeset/vercel-ssr-production.md
+++ b/.changeset/vercel-ssr-production.md
@@ -1,0 +1,10 @@
+---
+'@guren/server': patch
+'@guren/plugin-vercel': patch
+---
+
+Fix Inertia SSR on serverless deployments and stop shipping dev import maps in production.
+
+- The Guren Vite plugin now defaults `ssr.noExternal` to `true` for SSR builds so `.guren/ssr` bundles are self-contained and importable on runtimes without `node_modules` (Vercel, Lambda).
+- `@guren/plugin-vercel` pins `process.env.NODE_ENV` to `"production"` when bundling the function entrypoint; `bun build` otherwise inlines it as `"development"`, disabling every production code path at runtime.
+- The Inertia HTML document no longer emits the esm.sh dev React import map when `NODE_ENV` is `production`.

--- a/.claude/rules/common-pitfalls.md
+++ b/.claude/rules/common-pitfalls.md
@@ -42,6 +42,11 @@ Lessons learned from code review cycles. Check these before submitting changes.
 - **Entrypoint is `bun bin/serve.ts`**, not `bun run start` (no `start` script exists in templates).
 - **Copy runtime dirs explicitly**: `bin/`, `src/`, `app/`, `config/`, `routes/`, `public/`, `db/`, `.guren/`.
 
+## Serverless Bundling (Vercel / Lambda)
+
+- **`bun build` inlines `process.env.NODE_ENV` at bundle time** (defaults to `"development"`, even with `--minify`). Runtime `NODE_ENV=production` cannot override it. Always pass `--define 'process.env.NODE_ENV="production"'` when bundling server entrypoints for deployment (`@guren/plugin-vercel` does this).
+- **SSR bundles must be self-contained on serverless.** Function directories ship without `node_modules`, so externalized `react`/`@inertiajs/react` imports fail at runtime and Inertia silently falls back to CSR. The Guren Vite plugin defaults `ssr.noExternal: true` for SSR builds — don't re-externalize deps in `.guren/ssr` unless the deploy target has them installed.
+
 ## ESM Compatibility
 
 - **No `require()` in ESM packages.** Use top-level `import` or dynamic `import()`. Bun tolerates `require()` but Node ESM does not.

--- a/packages/plugin-vercel/src/index.ts
+++ b/packages/plugin-vercel/src/index.ts
@@ -95,7 +95,20 @@ export function buildVercelOutput(options: BuildVercelOutputOptions = {}): void 
   )
 
   const result = Bun.spawnSync({
-    cmd: ['bun', 'build', entrypoint, '--outdir', funcDir, '--target', 'bun', '--minify'],
+    // `bun build` inlines `process.env.NODE_ENV` at bundle time (defaulting to
+    // "development"), so pin it to "production" for the deployed function.
+    cmd: [
+      'bun',
+      'build',
+      entrypoint,
+      '--outdir',
+      funcDir,
+      '--target',
+      'bun',
+      '--minify',
+      '--define',
+      'process.env.NODE_ENV="production"',
+    ],
     cwd: root,
     stdout: 'inherit',
     stderr: 'inherit',

--- a/packages/server/src/mvc/inertia/InertiaEngine.ts
+++ b/packages/server/src/mvc/inertia/InertiaEngine.ts
@@ -48,7 +48,9 @@ export interface InertiaSsrOptions {
 }
 
 const DEFAULT_TITLE = "Guren";
-const DEFAULT_IMPORT_MAP: Record<string, string> = {
+// Dev-only fallback used when serving unbundled sources; production builds
+// bundle React into the Vite assets and must not pull esm.sh dev builds.
+const DEV_FALLBACK_IMPORT_MAP: Record<string, string> = {
   react: "https://esm.sh/react@19.0.0?dev",
   "react/jsx-runtime": "https://esm.sh/react@19.0.0/jsx-runtime?dev",
   "react/jsx-dev-runtime": "https://esm.sh/react@19.0.0/jsx-dev-runtime?dev",
@@ -138,17 +140,13 @@ async function renderDocument(
   const envImportMap = parseImportMap(process.env.GUREN_INERTIA_IMPORT_MAP, {
     context: "GUREN_INERTIA_IMPORT_MAP",
   });
-  const importMap = JSON.stringify(
-    {
-      imports: {
-        ...DEFAULT_IMPORT_MAP,
-        ...envImportMap,
-        ...(options.importMap ?? {}),
-      },
-    },
-    null,
-    2
-  );
+  const isProduction = process.env.NODE_ENV === "production";
+  const importMapEntries = {
+    ...(isProduction ? {} : DEV_FALLBACK_IMPORT_MAP),
+    ...envImportMap,
+    ...(options.importMap ?? {}),
+  };
+  const importMap = JSON.stringify({ imports: importMapEntries }, null, 2);
   const serializedPage = serializePage(page);
   const stylesheetLinks = renderStyles(styles);
   const docsHeadBootstrap = renderDocsHeadBootstrap(page.component);
@@ -164,7 +162,9 @@ async function renderDocument(
     docsHeadBootstrap,
     stylesheetLinks,
     ...headElements,
-    `<script type="importmap">${importMap}</script>`,
+    Object.keys(importMapEntries).length > 0
+      ? `<script type="importmap">${importMap}</script>`
+      : "",
     `<script>window.__INERTIA_PAGE__ = ${serializedPage};</script>`,
   ].filter((segment) => segment && segment.length > 0);
   // Inertia v3 contract: the initial page ships in a JSON script element

--- a/packages/server/src/vite/plugin.ts
+++ b/packages/server/src/vite/plugin.ts
@@ -117,6 +117,13 @@ function ensureBuild(
   }
 
   if (isSsrBuild) {
+    // Bundle all dependencies into the SSR output so `.guren/ssr` stays
+    // importable on serverless runtimes that ship without node_modules.
+    config.ssr ??= {}
+    if (config.ssr.noExternal === undefined) {
+      config.ssr.noExternal = true
+    }
+
     if (config.build.outDir === undefined) {
       config.build.outDir = options.ssrOutDir
     }

--- a/packages/server/tests/mvc/InertiaEngine.test.ts
+++ b/packages/server/tests/mvc/InertiaEngine.test.ts
@@ -52,6 +52,45 @@ describe('InertiaEngine SSR integration', () => {
   })
 })
 
+describe('Inertia import map', () => {
+  it('includes the esm.sh dev fallback outside production', async () => {
+    const previous = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+
+    try {
+      const response = await inertia('Dashboard', {}, { url: '/dashboard' })
+      const body = await response.text()
+
+      expect(body).toContain('type="importmap"')
+      expect(body).toContain('esm.sh/react')
+    } finally {
+      if (previous === undefined) {
+        delete process.env.NODE_ENV
+      } else {
+        process.env.NODE_ENV = previous
+      }
+    }
+  })
+
+  it('omits the esm.sh dev fallback in production', async () => {
+    const previous = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+
+    try {
+      const response = await inertia('Dashboard', {}, { url: '/dashboard' })
+      const body = await response.text()
+
+      expect(body).not.toContain('esm.sh')
+    } finally {
+      if (previous === undefined) {
+        delete process.env.NODE_ENV
+      } else {
+        process.env.NODE_ENV = previous
+      }
+    }
+  })
+})
+
 describe('Inertia asset version mismatch', () => {
   const buildInertiaRequest = (
     overrides: { method?: string; version?: string | null } = {},

--- a/packages/server/tests/vite/plugin.test.ts
+++ b/packages/server/tests/vite/plugin.test.ts
@@ -35,5 +35,24 @@ describe('gurenVitePlugin', () => {
     expect(config.build.outDir).toBe('.guren/ssr')
     expect(config.build.manifest).toBe(true)
     expect(config.build.ssr).toContain('resources/js/ssr.tsx')
+    expect(config.ssr.noExternal).toBe(true)
+  })
+
+  it('respects user-provided ssr.noExternal', () => {
+    const plugin = gurenVitePlugin()
+    const config: Record<string, any> = { ssr: { noExternal: ['react'] } }
+
+    plugin.config?.(config, { ssrBuild: true })
+
+    expect(config.ssr.noExternal).toEqual(['react'])
+  })
+
+  it('does not touch ssr config for client builds', () => {
+    const plugin = gurenVitePlugin()
+    const config: Record<string, any> = {}
+
+    plugin.config?.(config, { command: 'build' })
+
+    expect(config.ssr).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

The production docs site (https://gurenjs.vercel.app) served the homepage as a client-rendered SPA shell instead of SSR HTML, and its import map referenced esm.sh **dev** builds of React. Two compounding bugs:

1. **`bun build` inlines `process.env.NODE_ENV` at bundle time** (defaulting to `"development"`, even with `--minify`). The `.vc-config.json` runtime `NODE_ENV=production` could never take effect — the deployed function ran every dev code path, which is why the esm.sh `?dev` React import map appeared in production HTML.
2. **Vite SSR builds externalized `react` / `react-dom/server` / `@inertiajs/react`.** The Vercel function directory ships without `node_modules`, so the dynamic import of the SSR entry failed at runtime and `InertiaEngine` silently fell back to client rendering. Local `NODE_ENV=production bun bin/serve.ts` worked because `node_modules` is present there.

## Changes

- **`@guren/plugin-vercel`**: pass `--define 'process.env.NODE_ENV="production"'` to `bun build` when bundling the function entrypoint.
- **`@guren/server` (Vite plugin)**: default `ssr.noExternal: true` for SSR builds so `.guren/ssr` bundles are self-contained and importable on runtimes without `node_modules` (Vercel, Lambda). User-provided `ssr.noExternal` still wins.
- **`@guren/server` (InertiaEngine)**: the esm.sh dev React import map is now a dev-only fallback — omitted when `NODE_ENV=production`; the importmap tag is skipped entirely when empty.
- Tests for all three behaviors, changeset (both packages patch), and a `common-pitfalls.md` entry for the `bun build` NODE_ENV inlining gotcha.

No `web/vercel.json` change is needed — its buildCommand rebuilds the monorepo, so a redeploy after merge picks this up.

## Verification

Simulated the Vercel runtime by copying `.vercel/output/functions/index.func` into an isolated directory (no `node_modules` anywhere up the tree) and invoking the handler with only the `.vc-config.json` environment:

- Before: CSR shell + esm.sh `?dev` import map (reproduces the production symptom)
- After: full SSR HTML including the "Built for AI coding agents" and "Fast where it counts" sections, zero esm.sh references

Also green: `bun run test:bun` (2139 tests), `bun run test:examples`, web vitest suite, `bun run typecheck`, `audit:core-first`, `audit:docs`, and a clean `examples/blog` client+SSR build.