### PR TITLE
chore: backfill changesets for #88/#89/#90

### DIFF
--- a/.changeset/auto-register-inertia-provider.md
+++ b/.changeset/auto-register-inertia-provider.md
@@ -1,0 +1,5 @@
+---
+'@guren/server': patch
+---
+
+Auto-register `InertiaServiceProvider` after user providers. Validation errors on Inertia requests are now redirected with the error bag as expected instead of returning a raw JSON 422 that triggered the Inertia error modal. Apps that registered the provider explicitly keep working unchanged.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,5 +13,8 @@
   "privatePackages": {
     "version": true,
     "tag": false
+  },
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
   }
 }

--- a/.changeset/orm-first-or-fail-404.md
+++ b/.changeset/orm-first-or-fail-404.md
@@ -1,0 +1,5 @@
+---
+'@guren/orm': patch
+---
+
+`QueryBuilder.firstOrFail()` now throws `ModelNotFoundException` (rendered as HTTP 404) instead of a plain `Error` (which rendered as 500), matching `Model.findOrFail()`.

--- a/.changeset/project-root-alias.md
+++ b/.changeset/project-root-alias.md
@@ -1,0 +1,7 @@
+---
+'@guren/server': minor
+'@guren/cli': minor
+'@guren/inertia-client': patch
+---
+
+Resolve the `@/` alias from the project root instead of `app/`. The Vite plugin alias, scaffolded imports (`make:*`, `add resource`), and docs now use root-relative paths like `@/.guren/pages.gen` and `@/app/Http/Resources/PostResource`, removing deep `../../..` relative imports. `guren doctor` gains a `tsconfig-alias` check with autofix. Apps created before this release should update `tsconfig.json` paths to `"@/*": ["./*"]` so newly scaffolded code resolves.


### PR DESCRIPTION
## Summary

- Add the changesets that PRs #88, #89, and #90 were merged without, so the next release bumps every affected package:
  - `@guren/orm` **patch** — `QueryBuilder.firstOrFail()` throws `ModelNotFoundException` (404) instead of a plain Error (#88)
  - `@guren/server` **patch** — auto-register `InertiaServiceProvider` after user providers (#90)
  - `@guren/server` + `@guren/cli` **minor**, `@guren/inertia-client` **patch** — `@/` alias resolves from the project root (#89)
- Set `onlyUpdatePeerDependentsWhenOutOfRange` in `.changeset/config.json`: without it, the `@guren/server` minor bump forces `@guren/testing` to a spurious **2.0.0** major (its peer range `>=1.0.0` is not left by the bump).

## Resulting bump plan (`changeset status`, together with #91's changeset)

- patch: `@guren/orm`, `@guren/inertia-client`
- minor: `@guren/cli`, `create-guren-app`, `@guren/server`
- major: none

https://claude.ai/code/session_017LebZkEGJtZ9GFCxV9fVqk