### PR TITLE
feat(server): derive inertia html lang from request locale or i18n

### DIFF
--- a/.changeset/inertia-lang-option.md
+++ b/.changeset/inertia-lang-option.md
@@ -2,4 +2,4 @@
 '@guren/server': minor
 ---
 
-Add `InertiaOptions.lang` so controllers can localize the root `<html lang>` attribute, e.g. `this.inertia(page, props, { lang: 'ja' })` for Japanese pages. Defaults to `"en"`.
+Localize the root `<html lang>` attribute of Inertia responses. Controllers can set it per response with `this.inertia(page, props, { lang: 'ja' })`, and when the option is omitted it is derived automatically: a request-scoped `locale` context variable (set by locale-detection middleware via `c.set('locale', ...)`) wins over the app-wide i18n locale (`I18nServiceProvider`), falling back to `"en"`.

--- a/docs/en/guides/i18n.md
+++ b/docs/en/guides/i18n.md
@@ -317,9 +317,17 @@ export const i18nMiddleware = defineMiddleware(async (c, next) => {
   const translator = i18n.forLocale(locale)
   c.set('t', translator.t.bind(translator))
   c.set('tc', translator.tc.bind(translator))
+  // Expose the locale itself — Inertia responses use it for `<html lang>`
+  c.set('locale', locale)
 
   await next()
 })
+```
+
+When the `locale` context variable is set, Inertia responses render `<html lang>` with it automatically. Without it, the app-wide i18n locale is used, falling back to `en`. A per-response `lang` option always wins:
+
+```ts
+return this.inertia(pages.posts.Show, { post }, { lang: 'ja' })
 ```
 
 ### Using in Controllers

--- a/docs/ja/guides/i18n.md
+++ b/docs/ja/guides/i18n.md
@@ -317,9 +317,17 @@ export const i18nMiddleware = defineMiddleware(async (c, next) => {
   const translator = i18n.forLocale(locale)
   c.set('t', translator.t.bind(translator))
   c.set('tc', translator.tc.bind(translator))
+  // ロケール自体も公開 — Inertia レスポンスの `<html lang>` に使われます
+  c.set('locale', locale)
 
   await next()
 })
+```
+
+`locale` コンテキスト変数がセットされていると、Inertia レスポンスの `<html lang>` に自動で反映されます。未設定の場合はアプリ全体の i18n ロケール、それも無ければ `en` になります。レスポンスごとの `lang` オプションが常に優先されます:
+
+```ts
+return this.inertia(pages.posts.Show, { post }, { lang: 'ja' })
 ```
 
 ### コントローラーでの使用

--- a/packages/server/src/mvc/Controller.ts
+++ b/packages/server/src/mvc/Controller.ts
@@ -320,6 +320,7 @@ export class Controller {
 
     const response = await inertia(component, propsWithShared as Record<string, unknown>, {
       ...rest,
+      lang: rest.lang ?? this.#defaultInertiaLang(),
       url,
       request: ctx.req.raw,
     })
@@ -330,6 +331,33 @@ export class Controller {
     }
 
     return response as InertiaResponse<Component, typeof propsWithShared>
+  }
+
+  /**
+   * Default `<html lang>` for Inertia responses when `options.lang` is not
+   * provided: the request-scoped `locale` context variable (set by locale
+   * middleware) wins over the app-wide i18n locale.
+   */
+  #defaultInertiaLang(): string | undefined {
+    const vars = this.ctx.var as Record<string, unknown> | undefined
+
+    const requestLocale = vars?.locale
+    if (typeof requestLocale === 'string' && requestLocale.length > 0) {
+      return requestLocale
+    }
+
+    const container = vars?.container as
+      | { has?: (key: string) => boolean; make?: (key: string) => unknown }
+      | undefined
+    if (container?.has?.('i18n')) {
+      const i18n = container.make?.('i18n') as { getLocale?: () => string } | undefined
+      const locale = i18n?.getLocale?.()
+      if (typeof locale === 'string' && locale.length > 0) {
+        return locale
+      }
+    }
+
+    return undefined
   }
 
   protected json<T>(data: T, init: ResponseInit = {}): Response {

--- a/packages/server/tests/mvc/inertia-lang.test.ts
+++ b/packages/server/tests/mvc/inertia-lang.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect } from 'bun:test'
+import { Hono } from 'hono'
+import { Controller } from '../../src/mvc/Controller'
+import { Container } from '../../src/container/Container'
+import { createI18n } from '../../src/i18n'
+
+class PageController extends Controller {
+  async page() {
+    return this.inertia('Docs/Show', {}, {})
+  }
+
+  async pageWithLang() {
+    return this.inertia('Docs/Show', {}, { lang: 'fr' })
+  }
+}
+
+function createApp(options: {
+  requestLocale?: string
+  i18nLocale?: string
+  action?: 'page' | 'pageWithLang'
+} = {}) {
+  const app = new Hono()
+
+  app.get('/page', async (c) => {
+    if (options.requestLocale) {
+      c.set('locale' as never, options.requestLocale as never)
+    }
+
+    if (options.i18nLocale) {
+      const container = new Container()
+      container.singleton('i18n', () => createI18n({ locale: options.i18nLocale! }))
+      c.set('container' as never, container as never)
+    }
+
+    const ctrl = new PageController()
+    ctrl.setContext(c)
+    return ctrl[options.action ?? 'page']()
+  })
+
+  return app
+}
+
+async function htmlLangOf(app: Hono): Promise<string | undefined> {
+  const response = await app.request('/page', { headers: { Accept: 'text/html' } })
+  const html = await response.text()
+  return html.match(/<html lang="([^"]+)"/u)?.[1]
+}
+
+describe('Inertia html lang resolution', () => {
+  test('defaults to en without locale context or i18n binding', async () => {
+    expect(await htmlLangOf(createApp())).toBe('en')
+  })
+
+  test('explicit options.lang wins over everything', async () => {
+    const app = createApp({ requestLocale: 'ja', i18nLocale: 'de', action: 'pageWithLang' })
+    expect(await htmlLangOf(app)).toBe('fr')
+  })
+
+  test('uses the request-scoped locale context variable', async () => {
+    expect(await htmlLangOf(createApp({ requestLocale: 'ja' }))).toBe('ja')
+  })
+
+  test('request-scoped locale wins over the app-wide i18n locale', async () => {
+    expect(await htmlLangOf(createApp({ requestLocale: 'ja', i18nLocale: 'de' }))).toBe('ja')
+  })
+
+  test('falls back to the i18n container locale', async () => {
+    expect(await htmlLangOf(createApp({ i18nLocale: 'ja' }))).toBe('ja')
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to the `InertiaOptions.lang` addition in #99 (unreleased): the option worked but had to be threaded through every `this.inertia()` call — a forgotten call site silently shipped `lang="en"` on a localized page, exactly the bug the option was meant to fix.

`Controller.inertia` now derives the lang when `options.lang` is omitted, in priority order:

1. `options.lang` (explicit, always wins)
2. request-scoped `locale` context variable (`c.set('locale', ...)` in locale-detection middleware)
3. app-wide i18n locale from the container (`I18nServiceProvider` → `getLocale()`)
4. engine default `"en"`

Apps without i18n are unaffected. The i18n guide's per-request middleware example (en/ja) now sets `c.set('locale', locale)` and documents the resolution order. The pending `@guren/server` minor changeset is updated to describe the full behavior — this ships together with #99's option in the next release (1.2.0 candidate).

## Verification

- New `packages/server/tests/mvc/inertia-lang.test.ts` covers all four resolution tiers (5 tests).
- `bun run test:bun` (2195 tests), `test:examples`, `typecheck`, `audit:core-first`, `audit:docs` — all green.