### PR TITLE
chore: version packages for 1.2.0 release

### DIFF
--- a/.changeset/inertia-lang-option.md
+++ b/.changeset/inertia-lang-option.md
@@ -1,5 +1,0 @@
----
-'@guren/server': minor
----
-
-Localize the root `<html lang>` attribute of Inertia responses. Controllers can set it per response with `this.inertia(page, props, { lang: 'ja' })`, and when the option is omitted it is derived automatically: a request-scoped `locale` context variable (set by locale-detection middleware via `c.set('locale', ...)`) wins over the app-wide i18n locale (`I18nServiceProvider`), falling back to `"en"`.

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guren/server
 
+## 1.2.0
+
+### Minor Changes
+
+- 7a30cb5: Localize the root `<html lang>` attribute of Inertia responses. Controllers can set it per response with `this.inertia(page, props, { lang: 'ja' })`, and when the option is omitted it is derived automatically: a request-scoped `locale` context variable (set by locale-detection middleware via `c.set('locale', ...)`) wins over the app-wide i18n locale (`I18nServiceProvider`), falling back to `"en"`.
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Version PR for the 1.2.0 release, consuming the pending changeset:

- **@guren/server 1.2.0** (minor): localized `<html lang>` for Inertia responses — per-response `lang` option (#99) plus automatic derivation from the request-scoped `locale` context variable or the app-wide i18n locale (#101).

Dependents (`@guren/core` etc.) stay at their current versions — the new server version is within their dependency ranges (`onlyUpdatePeerDependentsWhenOutOfRange`, #97).

## Release steps after merge

1. Merge this PR.
2. Publish GitHub Release `v1.2.0` (`--latest`) — that triggers the npm publish workflow.