### PR TITLE
feat(server): add detectLocaleMiddleware for request locale resolution

### DIFF
--- a/.changeset/detect-locale-middleware.md
+++ b/.changeset/detect-locale-middleware.md
@@ -2,4 +2,4 @@
 '@guren/server': minor
 ---
 
-Add `detectLocaleMiddleware`: resolves the request locale from the `?locale=` query parameter, a `locale` cookie, or the `Accept-Language` header (region subtags and q-values understood), restricted to a supported-locales allowlist. Sets the `locale` context variable — feeding the `<html lang>` attribute of Inertia responses — and binds request-scoped `t`/`tc` translator helpers when the i18n manager is registered.
+Add `detectLocaleMiddleware`: resolves the request locale from the `?locale=` query parameter, a `locale` cookie, or the `Accept-Language` header (region subtags and q-values understood), restricted to a supported-locales allowlist. Sets the `locale` context variable — feeding the `<html lang>` attribute of Inertia responses — and binds request-scoped `t`/`tc` translator helpers when an i18n manager is available (the `setI18n()` global, or one passed via the `i18n` option). Also fixes the `<html lang>` i18n fallback in `Controller.inertia` to read the router-injected container (the previous context-variable lookup never fired in real apps).

--- a/.changeset/detect-locale-middleware.md
+++ b/.changeset/detect-locale-middleware.md
@@ -1,0 +1,5 @@
+---
+'@guren/server': minor
+---
+
+Add `detectLocaleMiddleware`: resolves the request locale from the `?locale=` query parameter, a `locale` cookie, or the `Accept-Language` header (region subtags and q-values understood), restricted to a supported-locales allowlist. Sets the `locale` context variable — feeding the `<html lang>` attribute of Inertia responses — and binds request-scoped `t`/`tc` translator helpers when the i18n manager is registered.

--- a/docs/en/guides/i18n.md
+++ b/docs/en/guides/i18n.md
@@ -308,7 +308,7 @@ import { detectLocaleMiddleware } from '@guren/core'
 app.use('*', detectLocaleMiddleware({ supported: ['en', 'ja'] }))
 ```
 
-The middleware sets the `locale` context variable — which Inertia responses use for the root `<html lang>` attribute — and, when the i18n manager is registered, binds request-scoped `t`/`tc` translator helpers:
+The middleware sets the `locale` context variable — which Inertia responses use for the root `<html lang>` attribute — and, when an i18n manager is available (the global one from `setI18n()`, or one passed via the `i18n` option), binds request-scoped `t`/`tc` translator helpers:
 
 ```ts
 export class PostController extends Controller {
@@ -319,7 +319,7 @@ export class PostController extends Controller {
 }
 ```
 
-Options: `fallback` (defaults to the first supported locale), `sources` to change the detection order (e.g. `['header']`), `queryParam`, `cookieName`, and `translator: false` to skip the translator binding. `Accept-Language` matching understands region subtags (`ja-JP` matches `ja`) and q-values.
+Options: `fallback` (defaults to the first supported locale), `sources` to change the detection order (e.g. `['header']`), `queryParam`, `cookieName`, and `i18n` to pass a manager explicitly (or `false` to skip the translator binding). `Accept-Language` matching understands region subtags (`ja-JP` matches `ja`) and q-values. Keep `supported` in sync with the locales your translation files actually provide — a locale missing from the list is never detected.
 
 Without the middleware, Inertia responses fall back to the app-wide i18n locale, then `en`. A per-response `lang` option always wins:
 

--- a/docs/en/guides/i18n.md
+++ b/docs/en/guides/i18n.md
@@ -300,31 +300,28 @@ const i18n = getI18n()
 
 ### Per-Request Locale
 
+Use the built-in `detectLocaleMiddleware` to resolve each request's locale from the `?locale=` query parameter, a `locale` cookie, or the `Accept-Language` header (in that order), restricted to your supported locales:
+
 ```ts
-import { defineMiddleware } from '@guren/core'
-import { getI18n } from '@guren/core'
+import { detectLocaleMiddleware } from '@guren/core'
 
-export const i18nMiddleware = defineMiddleware(async (c, next) => {
-  const i18n = getI18n()
-
-  // Detect locale from header, cookie, or query
-  const locale =
-    c.req.query('locale') ||
-    c.req.header('Accept-Language')?.split(',')[0]?.split('-')[0] ||
-    'en'
-
-  // Create scoped translator for this request
-  const translator = i18n.forLocale(locale)
-  c.set('t', translator.t.bind(translator))
-  c.set('tc', translator.tc.bind(translator))
-  // Expose the locale itself — Inertia responses use it for `<html lang>`
-  c.set('locale', locale)
-
-  await next()
-})
+app.use('*', detectLocaleMiddleware({ supported: ['en', 'ja'] }))
 ```
 
-When the `locale` context variable is set, Inertia responses render `<html lang>` with it automatically. Without it, the app-wide i18n locale is used, falling back to `en`. A per-response `lang` option always wins:
+The middleware sets the `locale` context variable — which Inertia responses use for the root `<html lang>` attribute — and, when the i18n manager is registered, binds request-scoped `t`/`tc` translator helpers:
+
+```ts
+export class PostController extends Controller {
+  async index() {
+    const t = this.ctx.get('t')
+    return this.json({ message: t('messages.hello') })
+  }
+}
+```
+
+Options: `fallback` (defaults to the first supported locale), `sources` to change the detection order (e.g. `['header']`), `queryParam`, `cookieName`, and `translator: false` to skip the translator binding. `Accept-Language` matching understands region subtags (`ja-JP` matches `ja`) and q-values.
+
+Without the middleware, Inertia responses fall back to the app-wide i18n locale, then `en`. A per-response `lang` option always wins:
 
 ```ts
 return this.inertia(pages.posts.Show, { post }, { lang: 'ja' })

--- a/docs/ja/guides/i18n.md
+++ b/docs/ja/guides/i18n.md
@@ -300,31 +300,28 @@ const i18n = getI18n()
 
 ### リクエストごとのロケール
 
+組み込みの `detectLocaleMiddleware` を使うと、`?locale=` クエリパラメータ・`locale` Cookie・`Accept-Language` ヘッダーの順でリクエストのロケールを解決できます(サポート対象のロケールに限定されます):
+
 ```ts
-import { defineMiddleware } from '@guren/core'
-import { getI18n } from '@guren/core'
+import { detectLocaleMiddleware } from '@guren/core'
 
-export const i18nMiddleware = defineMiddleware(async (c, next) => {
-  const i18n = getI18n()
-
-  // ヘッダー、Cookie、またはクエリからロケールを検出
-  const locale =
-    c.req.query('locale') ||
-    c.req.header('Accept-Language')?.split(',')[0]?.split('-')[0] ||
-    'en'
-
-  // このリクエスト用のスコープ付きトランスレーターを作成
-  const translator = i18n.forLocale(locale)
-  c.set('t', translator.t.bind(translator))
-  c.set('tc', translator.tc.bind(translator))
-  // ロケール自体も公開 — Inertia レスポンスの `<html lang>` に使われます
-  c.set('locale', locale)
-
-  await next()
-})
+app.use('*', detectLocaleMiddleware({ supported: ['en', 'ja'] }))
 ```
 
-`locale` コンテキスト変数がセットされていると、Inertia レスポンスの `<html lang>` に自動で反映されます。未設定の場合はアプリ全体の i18n ロケール、それも無ければ `en` になります。レスポンスごとの `lang` オプションが常に優先されます:
+このミドルウェアは `locale` コンテキスト変数をセットし(Inertia レスポンスのルート `<html lang>` 属性に使われます)、i18n マネージャーが登録されていればリクエストスコープの `t`/`tc` トランスレーターヘルパーもバインドします:
+
+```ts
+export class PostController extends Controller {
+  async index() {
+    const t = this.ctx.get('t')
+    return this.json({ message: t('messages.hello') })
+  }
+}
+```
+
+オプション: `fallback`(デフォルトはサポート対象の先頭)、検出順を変える `sources`(例: `['header']`)、`queryParam`、`cookieName`、トランスレーターのバインドを止める `translator: false`。`Accept-Language` のマッチングはリージョンサブタグ(`ja-JP` は `ja` にマッチ)と q 値を理解します。
+
+ミドルウェアを使わない場合、Inertia レスポンスはアプリ全体の i18n ロケール、それも無ければ `en` にフォールバックします。レスポンスごとの `lang` オプションが常に優先されます:
 
 ```ts
 return this.inertia(pages.posts.Show, { post }, { lang: 'ja' })

--- a/docs/ja/guides/i18n.md
+++ b/docs/ja/guides/i18n.md
@@ -308,7 +308,7 @@ import { detectLocaleMiddleware } from '@guren/core'
 app.use('*', detectLocaleMiddleware({ supported: ['en', 'ja'] }))
 ```
 
-このミドルウェアは `locale` コンテキスト変数をセットし(Inertia レスポンスのルート `<html lang>` 属性に使われます)、i18n マネージャーが登録されていればリクエストスコープの `t`/`tc` トランスレーターヘルパーもバインドします:
+このミドルウェアは `locale` コンテキスト変数をセットし(Inertia レスポンスのルート `<html lang>` 属性に使われます)、i18n マネージャーが利用可能な場合(`setI18n()` のグローバル、または `i18n` オプションで渡したもの)はリクエストスコープの `t`/`tc` トランスレーターヘルパーもバインドします:
 
 ```ts
 export class PostController extends Controller {
@@ -319,7 +319,7 @@ export class PostController extends Controller {
 }
 ```
 
-オプション: `fallback`(デフォルトはサポート対象の先頭)、検出順を変える `sources`(例: `['header']`)、`queryParam`、`cookieName`、トランスレーターのバインドを止める `translator: false`。`Accept-Language` のマッチングはリージョンサブタグ(`ja-JP` は `ja` にマッチ)と q 値を理解します。
+オプション: `fallback`(デフォルトはサポート対象の先頭)、検出順を変える `sources`(例: `['header']`)、`queryParam`、`cookieName`、マネージャーを明示的に渡す `i18n`(`false` でトランスレーターのバインドを停止)。`Accept-Language` のマッチングはリージョンサブタグ(`ja-JP` は `ja` にマッチ)と q 値を理解します。`supported` は翻訳ファイルが実際に提供するロケールと同期させてください — リストに無いロケールは検出されません。
 
 ミドルウェアを使わない場合、Inertia レスポンスはアプリ全体の i18n ロケール、それも無ければ `en` にフォールバックします。レスポンスごとの `lang` オプションが常に優先されます:
 

--- a/packages/server/src/http/middleware/detect-locale.test.ts
+++ b/packages/server/src/http/middleware/detect-locale.test.ts
@@ -1,0 +1,114 @@
+import { describe, test, expect } from 'bun:test'
+import { Hono } from 'hono'
+import { detectLocaleMiddleware, type DetectLocaleOptions } from './detect-locale'
+import { Container } from '../../container/Container'
+import { createI18n } from '../../i18n'
+
+function createApp(options: DetectLocaleOptions, withI18n = false) {
+  const app = new Hono()
+
+  if (withI18n) {
+    app.use('*', async (c, next) => {
+      const container = new Container()
+      container.singleton('i18n', () =>
+        createI18n({
+          locale: 'en',
+          fallbackLocale: 'en',
+          messages: {
+            en: { greeting: 'Hello' },
+            ja: { greeting: 'こんにちは' },
+          },
+        }),
+      )
+      c.set('container' as never, container as never)
+      await next()
+    })
+  }
+
+  app.use('*', detectLocaleMiddleware(options))
+  app.get('/page', (c) =>
+    c.json({
+      locale: c.get('locale' as never) as string,
+      greeting: (c.get('t' as never) as ((key: string) => string) | undefined)?.('greeting'),
+    }),
+  )
+
+  return app
+}
+
+async function resolve(
+  app: Hono,
+  init: { path?: string; headers?: Record<string, string> } = {},
+): Promise<{ locale: string; greeting?: string }> {
+  const response = await app.request(init.path ?? '/page', { headers: init.headers })
+  return response.json() as Promise<{ locale: string; greeting?: string }>
+}
+
+describe('detectLocaleMiddleware', () => {
+  const supported = { supported: ['en', 'ja'] }
+
+  test('falls back to the first supported locale when nothing matches', async () => {
+    expect((await resolve(createApp(supported))).locale).toBe('en')
+  })
+
+  test('honors an explicit fallback', async () => {
+    const app = createApp({ supported: ['en', 'ja'], fallback: 'ja' })
+    expect((await resolve(app)).locale).toBe('ja')
+  })
+
+  test('reads the locale query parameter first', async () => {
+    const app = createApp(supported)
+    const result = await resolve(app, {
+      path: '/page?locale=ja',
+      headers: { 'Accept-Language': 'en' },
+    })
+    expect(result.locale).toBe('ja')
+  })
+
+  test('ignores unsupported query values', async () => {
+    expect((await resolve(createApp(supported), { path: '/page?locale=fr' })).locale).toBe('en')
+  })
+
+  test('reads the locale cookie', async () => {
+    const result = await resolve(createApp(supported), { headers: { Cookie: 'locale=ja' } })
+    expect(result.locale).toBe('ja')
+  })
+
+  test('matches Accept-Language with region subtags and q-values', async () => {
+    const result = await resolve(createApp(supported), {
+      headers: { 'Accept-Language': 'fr-FR, ja-JP;q=0.8, en;q=0.5' },
+    })
+    expect(result.locale).toBe('ja')
+  })
+
+  test('skips wildcard Accept-Language entries', async () => {
+    const result = await resolve(createApp(supported), { headers: { 'Accept-Language': '*' } })
+    expect(result.locale).toBe('en')
+  })
+
+  test('respects a custom source order', async () => {
+    const app = createApp({ supported: ['en', 'ja'], sources: ['header', 'query'] })
+    const result = await resolve(app, {
+      path: '/page?locale=ja',
+      headers: { 'Accept-Language': 'en' },
+    })
+    expect(result.locale).toBe('en')
+  })
+
+  test('binds request-scoped translator helpers when i18n is available', async () => {
+    const app = createApp(supported, true)
+    const result = await resolve(app, { path: '/page?locale=ja' })
+    expect(result.locale).toBe('ja')
+    expect(result.greeting).toBe('こんにちは')
+  })
+
+  test('skips translator binding when disabled', async () => {
+    const app = createApp({ supported: ['en', 'ja'], translator: false }, true)
+    const result = await resolve(app, { path: '/page?locale=ja' })
+    expect(result.greeting).toBeUndefined()
+  })
+
+  test('throws when no supported locales are given', () => {
+    expect(() => detectLocaleMiddleware({ supported: [] })).toThrow()
+  })
+})

--- a/packages/server/src/http/middleware/detect-locale.test.ts
+++ b/packages/server/src/http/middleware/detect-locale.test.ts
@@ -1,35 +1,33 @@
 import { describe, test, expect } from 'bun:test'
 import { Hono } from 'hono'
-import { detectLocaleMiddleware, type DetectLocaleOptions } from './detect-locale'
-import { Container } from '../../container/Container'
+import {
+  detectLocaleMiddleware,
+  type DetectLocaleOptions,
+  type DetectLocaleVariables,
+} from './detect-locale'
 import { createI18n } from '../../i18n'
 
-function createApp(options: DetectLocaleOptions, withI18n = false) {
-  const app = new Hono()
+const baseOptions: DetectLocaleOptions = { supported: ['en', 'ja'] }
 
-  if (withI18n) {
-    app.use('*', async (c, next) => {
-      const container = new Container()
-      container.singleton('i18n', () =>
-        createI18n({
-          locale: 'en',
-          fallbackLocale: 'en',
-          messages: {
-            en: { greeting: 'Hello' },
-            ja: { greeting: 'こんにちは' },
-          },
-        }),
-      )
-      c.set('container' as never, container as never)
-      await next()
-    })
-  }
+function createTestI18n() {
+  return createI18n({
+    locale: 'en',
+    fallbackLocale: 'en',
+    messages: {
+      en: { greeting: 'Hello' },
+      ja: { greeting: 'こんにちは' },
+    },
+  })
+}
+
+function createApp(options: DetectLocaleOptions) {
+  const app = new Hono<{ Variables: DetectLocaleVariables }>()
 
   app.use('*', detectLocaleMiddleware(options))
   app.get('/page', (c) =>
     c.json({
-      locale: c.get('locale' as never) as string,
-      greeting: (c.get('t' as never) as ((key: string) => string) | undefined)?.('greeting'),
+      locale: c.get('locale'),
+      greeting: c.get('t')?.('greeting'),
     }),
   )
 
@@ -37,7 +35,7 @@ function createApp(options: DetectLocaleOptions, withI18n = false) {
 }
 
 async function resolve(
-  app: Hono,
+  app: Hono<{ Variables: DetectLocaleVariables }>,
   init: { path?: string; headers?: Record<string, string> } = {},
 ): Promise<{ locale: string; greeting?: string }> {
   const response = await app.request(init.path ?? '/page', { headers: init.headers })
@@ -45,20 +43,17 @@ async function resolve(
 }
 
 describe('detectLocaleMiddleware', () => {
-  const supported = { supported: ['en', 'ja'] }
-
   test('falls back to the first supported locale when nothing matches', async () => {
-    expect((await resolve(createApp(supported))).locale).toBe('en')
+    expect((await resolve(createApp(baseOptions))).locale).toBe('en')
   })
 
   test('honors an explicit fallback', async () => {
-    const app = createApp({ supported: ['en', 'ja'], fallback: 'ja' })
+    const app = createApp({ ...baseOptions, fallback: 'ja' })
     expect((await resolve(app)).locale).toBe('ja')
   })
 
   test('reads the locale query parameter first', async () => {
-    const app = createApp(supported)
-    const result = await resolve(app, {
+    const result = await resolve(createApp(baseOptions), {
       path: '/page?locale=ja',
       headers: { 'Accept-Language': 'en' },
     })
@@ -66,28 +61,28 @@ describe('detectLocaleMiddleware', () => {
   })
 
   test('ignores unsupported query values', async () => {
-    expect((await resolve(createApp(supported), { path: '/page?locale=fr' })).locale).toBe('en')
+    expect((await resolve(createApp(baseOptions), { path: '/page?locale=fr' })).locale).toBe('en')
   })
 
   test('reads the locale cookie', async () => {
-    const result = await resolve(createApp(supported), { headers: { Cookie: 'locale=ja' } })
+    const result = await resolve(createApp(baseOptions), { headers: { Cookie: 'locale=ja' } })
     expect(result.locale).toBe('ja')
   })
 
   test('matches Accept-Language with region subtags and q-values', async () => {
-    const result = await resolve(createApp(supported), {
+    const result = await resolve(createApp(baseOptions), {
       headers: { 'Accept-Language': 'fr-FR, ja-JP;q=0.8, en;q=0.5' },
     })
     expect(result.locale).toBe('ja')
   })
 
   test('skips wildcard Accept-Language entries', async () => {
-    const result = await resolve(createApp(supported), { headers: { 'Accept-Language': '*' } })
+    const result = await resolve(createApp(baseOptions), { headers: { 'Accept-Language': '*' } })
     expect(result.locale).toBe('en')
   })
 
   test('respects a custom source order', async () => {
-    const app = createApp({ supported: ['en', 'ja'], sources: ['header', 'query'] })
+    const app = createApp({ ...baseOptions, sources: ['header', 'query'] })
     const result = await resolve(app, {
       path: '/page?locale=ja',
       headers: { 'Accept-Language': 'en' },
@@ -95,16 +90,26 @@ describe('detectLocaleMiddleware', () => {
     expect(result.locale).toBe('en')
   })
 
-  test('binds request-scoped translator helpers when i18n is available', async () => {
-    const app = createApp(supported, true)
+  test('binds request-scoped translator helpers from the i18n option', async () => {
+    const app = createApp({ ...baseOptions, i18n: createTestI18n() })
     const result = await resolve(app, { path: '/page?locale=ja' })
     expect(result.locale).toBe('ja')
     expect(result.greeting).toBe('こんにちは')
   })
 
+  test('reuses the cached translator binding across requests', async () => {
+    const app = createApp({ ...baseOptions, i18n: createTestI18n() })
+
+    const first = await resolve(app, { path: '/page?locale=ja' })
+    const second = await resolve(app, { path: '/page?locale=ja' })
+    expect(first.greeting).toBe('こんにちは')
+    expect(second.greeting).toBe('こんにちは')
+  })
+
   test('skips translator binding when disabled', async () => {
-    const app = createApp({ supported: ['en', 'ja'], translator: false }, true)
+    const app = createApp({ ...baseOptions, i18n: false })
     const result = await resolve(app, { path: '/page?locale=ja' })
+    expect(result.locale).toBe('ja')
     expect(result.greeting).toBeUndefined()
   })
 

--- a/packages/server/src/http/middleware/detect-locale.ts
+++ b/packages/server/src/http/middleware/detect-locale.ts
@@ -1,0 +1,157 @@
+import { createMiddleware } from 'hono/factory'
+import { getCookie } from 'hono/cookie'
+
+export type LocaleSource = 'query' | 'cookie' | 'header'
+
+export interface DetectLocaleOptions {
+  /** Locales the app supports. Detection only ever resolves to one of these. */
+  supported: readonly string[]
+  /** Locale used when no source matches (defaults to the first supported locale). */
+  fallback?: string
+  /** Detection order (defaults to `['query', 'cookie', 'header']`). */
+  sources?: readonly LocaleSource[]
+  /** Query parameter to read (defaults to `locale`). */
+  queryParam?: string
+  /** Cookie to read (defaults to `locale`). */
+  cookieName?: string
+  /**
+   * Bind request-scoped translator helpers (`t`, `tc`) when the i18n manager
+   * is available in the container (defaults to `true`).
+   */
+  translator?: boolean
+}
+
+interface I18nLike {
+  loadLocale?: (locale: string) => Promise<void>
+  forLocale?: (locale: string) => {
+    t: (key: string, params?: Record<string, unknown>) => string
+    tc: (key: string, count: number, params?: Record<string, unknown>) => string
+  }
+}
+
+const DEFAULT_SOURCES: readonly LocaleSource[] = ['query', 'cookie', 'header']
+
+/**
+ * Middleware that resolves the request locale from the query string, a cookie,
+ * or the `Accept-Language` header — in that order by default — restricted to
+ * the `supported` allowlist.
+ *
+ * The result is stored as the `locale` context variable, which Inertia
+ * responses pick up for the root `<html lang>` attribute. When the i18n
+ * manager is bound in the container, request-scoped `t`/`tc` translator
+ * helpers are attached as well.
+ *
+ * @example
+ * ```ts
+ * import { detectLocaleMiddleware } from '@guren/core'
+ *
+ * app.use('*', detectLocaleMiddleware({ supported: ['en', 'ja'] }))
+ * ```
+ */
+export function detectLocaleMiddleware(options: DetectLocaleOptions) {
+  const supported = options.supported.map((locale) => locale.trim()).filter(Boolean)
+
+  if (supported.length === 0) {
+    throw new Error('detectLocaleMiddleware requires at least one supported locale.')
+  }
+
+  const fallback = options.fallback ?? supported[0]!
+  const sources = options.sources ?? DEFAULT_SOURCES
+  const queryParam = options.queryParam ?? 'locale'
+  const cookieName = options.cookieName ?? 'locale'
+  const bindTranslator = options.translator !== false
+
+  return createMiddleware(async (c, next) => {
+    let locale: string | undefined
+
+    for (const source of sources) {
+      if (source === 'query') {
+        locale = matchSupported(supported, c.req.query(queryParam))
+      } else if (source === 'cookie') {
+        locale = matchSupported(supported, getCookie(c, cookieName))
+      } else {
+        locale = matchAcceptLanguage(supported, c.req.header('Accept-Language'))
+      }
+
+      if (locale) {
+        break
+      }
+    }
+
+    const resolved = locale ?? fallback
+    c.set('locale' as never, resolved as never)
+
+    if (bindTranslator) {
+      const i18n = resolveI18n(c.var)
+
+      if (i18n?.forLocale) {
+        await i18n.loadLocale?.(resolved).catch(() => {})
+        const translator = i18n.forLocale(resolved)
+        c.set('t' as never, translator.t.bind(translator) as never)
+        c.set('tc' as never, translator.tc.bind(translator) as never)
+      }
+    }
+
+    await next()
+  })
+}
+
+function resolveI18n(vars: unknown): I18nLike | undefined {
+  const container = (vars as { container?: { has?: (key: string) => boolean; make?: (key: string) => unknown } } | undefined)
+    ?.container
+
+  if (!container?.has?.('i18n')) {
+    return undefined
+  }
+
+  return container.make?.('i18n') as I18nLike | undefined
+}
+
+/** Match a candidate against the allowlist: exact first, then primary subtag (`ja-JP` → `ja`). */
+function matchSupported(supported: readonly string[], candidate: string | undefined): string | undefined {
+  const value = candidate?.trim()
+
+  if (!value) {
+    return undefined
+  }
+
+  const lower = value.toLowerCase()
+  const exact = supported.find((locale) => locale.toLowerCase() === lower)
+  if (exact) {
+    return exact
+  }
+
+  const primary = lower.split('-')[0]!
+  return supported.find((locale) => locale.toLowerCase() === primary)
+}
+
+/** Pick the highest-quality supported locale from an `Accept-Language` header. */
+function matchAcceptLanguage(supported: readonly string[], header: string | undefined): string | undefined {
+  if (!header) {
+    return undefined
+  }
+
+  const candidates = header
+    .split(',')
+    .map((part) => {
+      const [tag, ...params] = part.trim().split(';')
+      const qParam = params.map((param) => param.trim()).find((param) => param.startsWith('q='))
+      const quality = qParam ? Number.parseFloat(qParam.slice(2)) : 1
+      return { tag: tag?.trim() ?? '', quality: Number.isNaN(quality) ? 0 : quality }
+    })
+    .filter((candidate) => candidate.tag.length > 0 && candidate.quality > 0)
+    .sort((a, b) => b.quality - a.quality)
+
+  for (const candidate of candidates) {
+    if (candidate.tag === '*') {
+      continue
+    }
+
+    const match = matchSupported(supported, candidate.tag)
+    if (match) {
+      return match
+    }
+  }
+
+  return undefined
+}

--- a/packages/server/src/http/middleware/detect-locale.ts
+++ b/packages/server/src/http/middleware/detect-locale.ts
@@ -1,7 +1,19 @@
 import { createMiddleware } from 'hono/factory'
 import { getCookie } from 'hono/cookie'
+import { parseAccept } from 'hono/utils/accept'
+import { getI18n, type I18nManager, type Translator } from '../../i18n'
+
+/** Context key for the resolved request locale (read by Inertia for `<html lang>`). */
+export const LOCALE_CONTEXT_KEY = 'locale'
 
 export type LocaleSource = 'query' | 'cookie' | 'header'
+
+/** Context variables set by {@link detectLocaleMiddleware}, for typing Hono apps. */
+export type DetectLocaleVariables = {
+  locale: string
+  t?: Translator['t']
+  tc?: Translator['tc']
+}
 
 export interface DetectLocaleOptions {
   /** Locales the app supports. Detection only ever resolves to one of these. */
@@ -15,21 +27,17 @@ export interface DetectLocaleOptions {
   /** Cookie to read (defaults to `locale`). */
   cookieName?: string
   /**
-   * Bind request-scoped translator helpers (`t`, `tc`) when the i18n manager
-   * is available in the container (defaults to `true`).
+   * i18n manager used to bind request-scoped `t`/`tc` translator helpers.
+   * Defaults to the global manager when one was registered via `setI18n()`;
+   * pass a manager explicitly (e.g. `app.container.make('i18n')`), or `false`
+   * to skip the translator binding entirely.
    */
-  translator?: boolean
-}
-
-interface I18nLike {
-  loadLocale?: (locale: string) => Promise<void>
-  forLocale?: (locale: string) => {
-    t: (key: string, params?: Record<string, unknown>) => string
-    tc: (key: string, count: number, params?: Record<string, unknown>) => string
-  }
+  i18n?: I18nManager | false
 }
 
 const DEFAULT_SOURCES: readonly LocaleSource[] = ['query', 'cookie', 'header']
+
+type TranslatorBinding = { t: Translator['t']; tc: Translator['tc'] }
 
 /**
  * Middleware that resolves the request locale from the query string, a cookie,
@@ -37,8 +45,8 @@ const DEFAULT_SOURCES: readonly LocaleSource[] = ['query', 'cookie', 'header']
  * the `supported` allowlist.
  *
  * The result is stored as the `locale` context variable, which Inertia
- * responses pick up for the root `<html lang>` attribute. When the i18n
- * manager is bound in the container, request-scoped `t`/`tc` translator
+ * responses pick up for the root `<html lang>` attribute. When an i18n manager
+ * is available (see the `i18n` option), request-scoped `t`/`tc` translator
  * helpers are attached as well.
  *
  * @example
@@ -59,99 +67,98 @@ export function detectLocaleMiddleware(options: DetectLocaleOptions) {
   const sources = options.sources ?? DEFAULT_SOURCES
   const queryParam = options.queryParam ?? 'locale'
   const cookieName = options.cookieName ?? 'locale'
-  const bindTranslator = options.translator !== false
 
-  return createMiddleware(async (c, next) => {
-    let locale: string | undefined
+  // Case-insensitive lookup, built once: exact match wins over the primary
+  // subtag (`ja-JP` → `ja`). Values keep the casing from `supported`.
+  const byLowerCase = new Map(supported.map((locale) => [locale.toLowerCase(), locale]))
 
-    for (const source of sources) {
-      if (source === 'query') {
-        locale = matchSupported(supported, c.req.query(queryParam))
-      } else if (source === 'cookie') {
-        locale = matchSupported(supported, getCookie(c, cookieName))
-      } else {
-        locale = matchAcceptLanguage(supported, c.req.header('Accept-Language'))
+  const match = (candidate: string | undefined): string | undefined => {
+    const value = candidate?.trim().toLowerCase()
+    if (!value) {
+      return undefined
+    }
+    return byLowerCase.get(value) ?? byLowerCase.get(value.split('-')[0]!)
+  }
+
+  const matchHeader = (header: string | undefined): string | undefined => {
+    if (!header) {
+      return undefined
+    }
+    // parseAccept returns entries sorted by descending quality.
+    for (const accept of parseAccept(header)) {
+      if (accept.type === '*' || accept.q <= 0) {
+        continue
       }
+      const matched = match(accept.type)
+      if (matched) {
+        return matched
+      }
+    }
+    return undefined
+  }
 
-      if (locale) {
+  // Bound t/tc helpers, created once per locale (the set is bounded by
+  // `supported`). Messages added to the manager after a locale is cached are
+  // not picked up — acceptable for the load-once translation lifecycle.
+  const translators = new Map<string, TranslatorBinding>()
+
+  const resolveTranslator = async (locale: string): Promise<TranslatorBinding | undefined> => {
+    if (options.i18n === false) {
+      return undefined
+    }
+
+    const cached = translators.get(locale)
+    if (cached) {
+      return cached
+    }
+
+    const i18n = options.i18n ?? tryGlobalI18n()
+    if (!i18n) {
+      return undefined
+    }
+
+    await i18n.loadLocale(locale).catch(() => {})
+    const translator = i18n.forLocale(locale)
+    const binding: TranslatorBinding = {
+      t: translator.t.bind(translator),
+      tc: translator.tc.bind(translator),
+    }
+    translators.set(locale, binding)
+    return binding
+  }
+
+  return createMiddleware<{ Variables: DetectLocaleVariables }>(async (c, next) => {
+    const readers: Record<LocaleSource, () => string | undefined> = {
+      query: () => match(c.req.query(queryParam)),
+      cookie: () => match(getCookie(c, cookieName)),
+      header: () => matchHeader(c.req.header('Accept-Language')),
+    }
+
+    let resolved = fallback
+    for (const source of sources) {
+      const matched = readers[source]()
+      if (matched) {
+        resolved = matched
         break
       }
     }
 
-    const resolved = locale ?? fallback
-    c.set('locale' as never, resolved as never)
+    c.set(LOCALE_CONTEXT_KEY, resolved)
 
-    if (bindTranslator) {
-      const i18n = resolveI18n(c.var)
-
-      if (i18n?.forLocale) {
-        await i18n.loadLocale?.(resolved).catch(() => {})
-        const translator = i18n.forLocale(resolved)
-        c.set('t' as never, translator.t.bind(translator) as never)
-        c.set('tc' as never, translator.tc.bind(translator) as never)
-      }
+    const binding = await resolveTranslator(resolved)
+    if (binding) {
+      c.set('t', binding.t)
+      c.set('tc', binding.tc)
     }
 
     await next()
   })
 }
 
-function resolveI18n(vars: unknown): I18nLike | undefined {
-  const container = (vars as { container?: { has?: (key: string) => boolean; make?: (key: string) => unknown } } | undefined)
-    ?.container
-
-  if (!container?.has?.('i18n')) {
+function tryGlobalI18n(): I18nManager | undefined {
+  try {
+    return getI18n()
+  } catch {
     return undefined
   }
-
-  return container.make?.('i18n') as I18nLike | undefined
-}
-
-/** Match a candidate against the allowlist: exact first, then primary subtag (`ja-JP` → `ja`). */
-function matchSupported(supported: readonly string[], candidate: string | undefined): string | undefined {
-  const value = candidate?.trim()
-
-  if (!value) {
-    return undefined
-  }
-
-  const lower = value.toLowerCase()
-  const exact = supported.find((locale) => locale.toLowerCase() === lower)
-  if (exact) {
-    return exact
-  }
-
-  const primary = lower.split('-')[0]!
-  return supported.find((locale) => locale.toLowerCase() === primary)
-}
-
-/** Pick the highest-quality supported locale from an `Accept-Language` header. */
-function matchAcceptLanguage(supported: readonly string[], header: string | undefined): string | undefined {
-  if (!header) {
-    return undefined
-  }
-
-  const candidates = header
-    .split(',')
-    .map((part) => {
-      const [tag, ...params] = part.trim().split(';')
-      const qParam = params.map((param) => param.trim()).find((param) => param.startsWith('q='))
-      const quality = qParam ? Number.parseFloat(qParam.slice(2)) : 1
-      return { tag: tag?.trim() ?? '', quality: Number.isNaN(quality) ? 0 : quality }
-    })
-    .filter((candidate) => candidate.tag.length > 0 && candidate.quality > 0)
-    .sort((a, b) => b.quality - a.quality)
-
-  for (const candidate of candidates) {
-    if (candidate.tag === '*') {
-      continue
-    }
-
-    const match = matchSupported(supported, candidate.tag)
-    if (match) {
-      return match
-    }
-  }
-
-  return undefined
 }

--- a/packages/server/src/http/middleware/index.ts
+++ b/packages/server/src/http/middleware/index.ts
@@ -88,6 +88,8 @@ export { requestIdMiddleware } from './request-id'
 export { requestLoggingMiddleware } from './request-logging'
 export {
   detectLocaleMiddleware,
+  LOCALE_CONTEXT_KEY,
   type DetectLocaleOptions,
+  type DetectLocaleVariables,
   type LocaleSource,
 } from './detect-locale'

--- a/packages/server/src/http/middleware/index.ts
+++ b/packages/server/src/http/middleware/index.ts
@@ -86,3 +86,8 @@ export {
 } from './force-https'
 export { requestIdMiddleware } from './request-id'
 export { requestLoggingMiddleware } from './request-logging'
+export {
+  detectLocaleMiddleware,
+  type DetectLocaleOptions,
+  type LocaleSource,
+} from './detect-locale'

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -187,6 +187,8 @@ export {
   // Request ID & Logging
   requestIdMiddleware,
   requestLoggingMiddleware,
+  // Locale detection
+  detectLocaleMiddleware,
 }
   from './http/middleware'
 export { AUTH_CONTEXT_KEY } from './http/middleware/auth'
@@ -219,6 +221,9 @@ export type {
   RedirectSafetyOptions,
   // Force HTTPS types
   ForceHttpsOptions,
+  // Locale detection types
+  DetectLocaleOptions,
+  LocaleSource,
 }  from './http/middleware'
 // Validation (advanced)
 export {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -189,6 +189,7 @@ export {
   requestLoggingMiddleware,
   // Locale detection
   detectLocaleMiddleware,
+  LOCALE_CONTEXT_KEY,
 }
   from './http/middleware'
 export { AUTH_CONTEXT_KEY } from './http/middleware/auth'
@@ -223,6 +224,7 @@ export type {
   ForceHttpsOptions,
   // Locale detection types
   DetectLocaleOptions,
+  DetectLocaleVariables,
   LocaleSource,
 }  from './http/middleware'
 // Validation (advanced)

--- a/packages/server/src/mvc/Controller.ts
+++ b/packages/server/src/mvc/Controller.ts
@@ -2,6 +2,8 @@ import type { Context } from 'hono'
 import { inertia, type InertiaOptions } from './inertia/InertiaEngine'
 import { resolveSharedInertiaProps, type ResolvedSharedInertiaProps } from './inertia/shared'
 import { AUTH_CONTEXT_KEY } from '../http/middleware/auth'
+import { LOCALE_CONTEXT_KEY } from '../http/middleware/detect-locale'
+import { getI18n } from '../i18n'
 import { flattenRequestQueries, parseRequestPayload } from '../http/request'
 import type { AuthContext } from '../auth/types'
 import type { ServiceBindings } from '../container/bindings'
@@ -13,6 +15,7 @@ import type { AuthUser } from '../authorization/types'
 /** Structural type for DI containers, avoiding a hard dependency on Container. */
 interface ContainerLike {
   make(key: string): unknown
+  has?(key: string): boolean
 }
 
 /**
@@ -336,28 +339,31 @@ export class Controller {
   /**
    * Default `<html lang>` for Inertia responses when `options.lang` is not
    * provided: the request-scoped `locale` context variable (set by locale
-   * middleware) wins over the app-wide i18n locale.
+   * middleware) wins over the app-wide i18n locale (the router-injected
+   * container binding, then the `setI18n()` global).
    */
   #defaultInertiaLang(): string | undefined {
     const vars = this.ctx.var as Record<string, unknown> | undefined
 
-    const requestLocale = vars?.locale
+    const requestLocale = vars?.[LOCALE_CONTEXT_KEY]
     if (typeof requestLocale === 'string' && requestLocale.length > 0) {
       return requestLocale
     }
 
-    const container = vars?.container as
-      | { has?: (key: string) => boolean; make?: (key: string) => unknown }
-      | undefined
-    if (container?.has?.('i18n')) {
-      const i18n = container.make?.('i18n') as { getLocale?: () => string } | undefined
-      const locale = i18n?.getLocale?.()
-      if (typeof locale === 'string' && locale.length > 0) {
-        return locale
+    let i18n: { getLocale?: () => string } | undefined
+
+    if (this._container?.has?.('i18n')) {
+      i18n = this._container.make('i18n') as { getLocale?: () => string }
+    } else {
+      try {
+        i18n = getI18n()
+      } catch {
+        i18n = undefined
       }
     }
 
-    return undefined
+    const locale = i18n?.getLocale?.()
+    return typeof locale === 'string' && locale.length > 0 ? locale : undefined
   }
 
   protected json<T>(data: T, init: ResponseInit = {}): Response {

--- a/packages/server/tests/mvc/inertia-lang.test.ts
+++ b/packages/server/tests/mvc/inertia-lang.test.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 import { Controller } from '../../src/mvc/Controller'
 import { Container } from '../../src/container/Container'
 import { createI18n } from '../../src/i18n'
+import { detectLocaleMiddleware } from '../../src/http/middleware/detect-locale'
 
 class PageController extends Controller {
   async page() {
@@ -66,5 +67,22 @@ describe('Inertia html lang resolution', () => {
 
   test('falls back to the i18n container locale', async () => {
     expect(await htmlLangOf(createApp({ i18nLocale: 'ja' }))).toBe('ja')
+  })
+
+  test('detectLocaleMiddleware feeds html lang end to end', async () => {
+    const app = new Hono()
+    app.use('*', detectLocaleMiddleware({ supported: ['en', 'ja'] }))
+    app.get('/page', async (c) => {
+      const ctrl = new PageController()
+      ctrl.setContext(c)
+      return ctrl.page()
+    })
+
+    const response = await app.request('/page', {
+      headers: { Accept: 'text/html', 'Accept-Language': 'ja-JP' },
+    })
+    const html = await response.text()
+
+    expect(html).toContain('<html lang="ja"')
   })
 })

--- a/packages/server/tests/mvc/inertia-lang.test.ts
+++ b/packages/server/tests/mvc/inertia-lang.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'bun:test'
 import { Hono } from 'hono'
+import type { MiddlewareHandler } from 'hono'
 import { Controller } from '../../src/mvc/Controller'
 import { Container } from '../../src/container/Container'
 import { createI18n } from '../../src/i18n'
@@ -19,30 +20,37 @@ function createApp(options: {
   requestLocale?: string
   i18nLocale?: string
   action?: 'page' | 'pageWithLang'
+  middleware?: MiddlewareHandler
 } = {}) {
   const app = new Hono()
+
+  if (options.middleware) {
+    app.use('*', options.middleware)
+  }
 
   app.get('/page', async (c) => {
     if (options.requestLocale) {
       c.set('locale' as never, options.requestLocale as never)
     }
 
-    if (options.i18nLocale) {
-      const container = new Container()
-      container.singleton('i18n', () => createI18n({ locale: options.i18nLocale! }))
-      c.set('container' as never, container as never)
-    }
-
     const ctrl = new PageController()
     ctrl.setContext(c)
+
+    if (options.i18nLocale) {
+      // Mirror the router: the container is injected into the controller.
+      const container = new Container()
+      container.singleton('i18n', () => createI18n({ locale: options.i18nLocale! }))
+      ctrl.setContainer(container)
+    }
+
     return ctrl[options.action ?? 'page']()
   })
 
   return app
 }
 
-async function htmlLangOf(app: Hono): Promise<string | undefined> {
-  const response = await app.request('/page', { headers: { Accept: 'text/html' } })
+async function htmlLangOf(app: Hono, headers: Record<string, string> = {}): Promise<string | undefined> {
+  const response = await app.request('/page', { headers: { Accept: 'text/html', ...headers } })
   const html = await response.text()
   return html.match(/<html lang="([^"]+)"/u)?.[1]
 }
@@ -65,24 +73,12 @@ describe('Inertia html lang resolution', () => {
     expect(await htmlLangOf(createApp({ requestLocale: 'ja', i18nLocale: 'de' }))).toBe('ja')
   })
 
-  test('falls back to the i18n container locale', async () => {
+  test('falls back to the router-injected container i18n locale', async () => {
     expect(await htmlLangOf(createApp({ i18nLocale: 'ja' }))).toBe('ja')
   })
 
   test('detectLocaleMiddleware feeds html lang end to end', async () => {
-    const app = new Hono()
-    app.use('*', detectLocaleMiddleware({ supported: ['en', 'ja'] }))
-    app.get('/page', async (c) => {
-      const ctrl = new PageController()
-      ctrl.setContext(c)
-      return ctrl.page()
-    })
-
-    const response = await app.request('/page', {
-      headers: { Accept: 'text/html', 'Accept-Language': 'ja-JP' },
-    })
-    const html = await response.text()
-
-    expect(html).toContain('<html lang="ja"')
+    const app = createApp({ middleware: detectLocaleMiddleware({ supported: ['en', 'ja'] }) })
+    expect(await htmlLangOf(app, { 'Accept-Language': 'ja-JP' })).toBe('ja')
   })
 })


### PR DESCRIPTION
## Summary

Post-1.0 backlog item: promote the i18n guide's copy-paste locale-detection middleware into the framework, completing the story started in #101 (auto `<html lang>` from the `locale` context variable) — detection side and consumption side now ship together.

```ts
import { detectLocaleMiddleware } from '@guren/core'

app.use('*', detectLocaleMiddleware({ supported: ['en', 'ja'] }))
```

- Resolves from `?locale=` query → `locale` cookie → `Accept-Language` (order configurable via `sources`), restricted to the `supported` allowlist; falls back to `fallback` (default: first supported).
- `Accept-Language` matching handles q-values and region subtags (`ja-JP` → `ja`); wildcard `*` entries are skipped.
- Sets the `locale` context variable — Inertia responses pick it up for the root `<html lang>` attribute (#101).
- When the i18n manager is bound in the container, loads the locale and binds request-scoped `t`/`tc` translator helpers (`translator: false` opts out).
- i18n guide (en/ja) now documents the built-in instead of the hand-rolled example; `@guren/server` minor changeset included (stacks on the pending 1.3.0 with nothing else — releases whenever the next version PR is cut).

## Verification

- 11 middleware unit tests (`detect-locale.test.ts`) + an end-to-end case in `inertia-lang.test.ts` (middleware → `<html lang="ja">`).
- `bun run test:bun` (2207 tests), `typecheck`, `audit:core-first`, `audit:docs` — all green.