### PR TITLE
feat(server): guard oauth redirectTo against open redirects

### DIFF
--- a/.changeset/oauth-redirect-safety.md
+++ b/.changeset/oauth-redirect-safety.md
@@ -1,0 +1,6 @@
+---
+'@guren/server': minor
+'@guren/cli': minor
+---
+
+Guard OAuth `redirectTo` against open redirects. State creation and verification both sanitize the value: app-relative paths always pass, absolute URLs only when their host is in the new `stateConfig.allowedRedirectHosts` allowlist (wildcards supported); protocol-relative URLs, backslash variants, and non-http schemes are dropped. New `OAuthManager.handleCallback()` returns the profile together with the sanitized `redirectTo`, and `sanitizeOAuthRedirect()` is exported for custom flows. The `guren add oauth` scaffold now demonstrates the safe round-trip (`?redirectTo=` → `handleCallback`).

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -66,12 +66,38 @@ Equivalent env names exist for `GOOGLE` and `DISCORD`.
 ### Route flow
 
 ```ts
-router.get('/auth/:provider', [OAuthController, 'redirect'])
+router.get('/auth/:provider', [OAuthController, 'redirectToProvider'])
 router.get('/auth/:provider/callback', [OAuthController, 'callback'])
 ```
 
-`redirect` creates a signed state and redirects to the provider consent screen.  
+`redirectToProvider` creates a signed state and redirects to the provider consent screen.  
 `callback` validates state, exchanges code for token, then fetches the remote profile.
+
+### Post-login redirect (`redirectTo`)
+
+Pass `redirectTo` when starting the flow and read it back — sanitized — after the callback:
+
+```ts
+// /auth/github?redirectTo=/settings
+const { url } = await oauth.authorize('github', {
+  redirectTo: this.request.query('redirectTo'),
+})
+
+// in the callback action
+const { profile, redirectTo } = await oauth.handleCallback('github', { code, state })
+// ...log the user in...
+return this.redirect(redirectTo ?? '/')
+```
+
+`redirectTo` is guarded against open redirects on both ends of the flow: only app-relative paths (`/settings`) survive by default. To allow specific external hosts, configure the allowlist (wildcards supported):
+
+```ts
+const oauth = createOAuthManager({
+  stateConfig: { allowedRedirectHosts: ['accounts.example.com', '*.example.org'] },
+})
+```
+
+Protocol-relative URLs (`//evil.com`), backslash variants, non-http schemes, and unlisted hosts are dropped — `redirectTo` comes back as `undefined` and your fallback applies.
 
 ### Manual Setup
 

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -75,29 +75,37 @@ router.get('/auth/:provider/callback', [OAuthController, 'callback'])
 
 ### Post-login redirect (`redirectTo`)
 
-Pass `redirectTo` when starting the flow and read it back — sanitized — after the callback:
+Pass `redirectTo` when starting the flow and read it back — sanitized — after the callback. In the scaffolded `OAuthController` (which resolves the manager with `this.oauth()`):
 
 ```ts
 // /auth/github?redirectTo=/settings
-const { url } = await oauth.authorize('github', {
-  redirectTo: this.request.query('redirectTo'),
-})
+async redirectToProvider(): Promise<Response> {
+  const { url } = await this.oauth().authorize('github', {
+    redirectTo: this.request.query('redirectTo'),
+  })
+  return this.redirect(url)
+}
 
-// in the callback action
-const { profile, redirectTo } = await oauth.handleCallback('github', { code, state })
-// ...log the user in...
-return this.redirect(redirectTo ?? '/')
+async callback(): Promise<Response> {
+  const { profile, redirectTo } = await this.oauth().handleCallback('github', { code, state })
+  // ...log the user in...
+  return this.redirect(redirectTo ?? '/')
+}
 ```
 
-`redirectTo` is guarded against open redirects on both ends of the flow: only app-relative paths (`/settings`) survive by default. To allow specific external hosts, configure the allowlist (wildcards supported):
+`redirectTo` is guarded against open redirects on both ends of the flow: only app-relative paths (`/settings`) survive by default. Protocol-relative URLs (`//evil.com`), backslash variants, non-http schemes, and unlisted hosts are dropped — `redirectTo` comes back as `undefined` and your fallback applies.
+
+To allow specific external hosts (wildcards supported), bind the manager with an allowlist before anything resolves it — in a scaffolded app, at the top of `app/Providers/OAuthProvider.ts`'s `register()`:
 
 ```ts
-const oauth = createOAuthManager({
-  stateConfig: { allowedRedirectHosts: ['accounts.example.com', '*.example.org'] },
-})
+this.container.singleton('oauth', () =>
+  createOAuthManager({
+    stateConfig: { allowedRedirectHosts: ['accounts.example.com', '*.example.org'] },
+  }),
+)
 ```
 
-Protocol-relative URLs (`//evil.com`), backslash variants, non-http schemes, and unlisted hosts are dropped — `redirectTo` comes back as `undefined` and your fallback applies.
+> **Note:** `createRedirectSafetyMiddleware` (opt-in) validates `Location` headers with its own separate `allowedHosts` option. If you mount it, keep both allowlists in agreement — otherwise the middleware rewrites an approved external redirect to `/`.
 
 ### Manual Setup
 

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -75,29 +75,37 @@ router.get('/auth/:provider/callback', [OAuthController, 'callback'])
 
 ### ログイン後リダイレクト(`redirectTo`)
 
-フロー開始時に `redirectTo` を渡すと、コールバック後にサニタイズ済みの値として受け取れます:
+フロー開始時に `redirectTo` を渡すと、コールバック後にサニタイズ済みの値として受け取れます。スキャフォールドされた `OAuthController`(`this.oauth()` でマネージャーを解決)では:
 
 ```ts
 // /auth/github?redirectTo=/settings
-const { url } = await oauth.authorize('github', {
-  redirectTo: this.request.query('redirectTo'),
-})
+async redirectToProvider(): Promise<Response> {
+  const { url } = await this.oauth().authorize('github', {
+    redirectTo: this.request.query('redirectTo'),
+  })
+  return this.redirect(url)
+}
 
-// コールバックアクション内
-const { profile, redirectTo } = await oauth.handleCallback('github', { code, state })
-// ...ユーザーをログインさせる...
-return this.redirect(redirectTo ?? '/')
+async callback(): Promise<Response> {
+  const { profile, redirectTo } = await this.oauth().handleCallback('github', { code, state })
+  // ...ユーザーをログインさせる...
+  return this.redirect(redirectTo ?? '/')
+}
 ```
 
-`redirectTo` はフローの入口と出口の両方でオープンリダイレクト対策の検証を通ります。デフォルトで通過するのはアプリ相対パス(`/settings`)のみです。特定の外部ホストを許可する場合は許可リストを設定します(ワイルドカード対応):
+`redirectTo` はフローの入口と出口の両方でオープンリダイレクト対策の検証を通ります。デフォルトで通過するのはアプリ相対パス(`/settings`)のみで、プロトコル相対URL(`//evil.com`)、バックスラッシュ変種、http(s) 以外のスキーム、許可リスト外のホストは破棄され、`redirectTo` は `undefined` になってフォールバックが適用されます。
+
+特定の外部ホストを許可する場合(ワイルドカード対応)は、マネージャーが解決される前に許可リスト付きでバインドします — スキャフォールドアプリでは `app/Providers/OAuthProvider.ts` の `register()` 冒頭で:
 
 ```ts
-const oauth = createOAuthManager({
-  stateConfig: { allowedRedirectHosts: ['accounts.example.com', '*.example.org'] },
-})
+this.container.singleton('oauth', () =>
+  createOAuthManager({
+    stateConfig: { allowedRedirectHosts: ['accounts.example.com', '*.example.org'] },
+  }),
+)
 ```
 
-プロトコル相対URL(`//evil.com`)、バックスラッシュ変種、http(s) 以外のスキーム、許可リスト外のホストは破棄され、`redirectTo` は `undefined` になってフォールバックが適用されます。
+> **Note:** `createRedirectSafetyMiddleware`(オプトイン)は独自の `allowedHosts` オプションで `Location` ヘッダーを検証します。併用する場合は両方の許可リストを揃えてください — ずれていると、許可したはずの外部リダイレクトがミドルウェアに `/` へ書き換えられます。
 
 ### 手動セットアップ
 

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -66,12 +66,38 @@ OAUTH_GITHUB_REDIRECT_URI=https://your-app.test/auth/github/callback
 ### ルートフロー
 
 ```ts
-router.get('/auth/:provider', [OAuthController, 'redirect'])
+router.get('/auth/:provider', [OAuthController, 'redirectToProvider'])
 router.get('/auth/:provider/callback', [OAuthController, 'callback'])
 ```
 
-`redirect` は state を生成してプロバイダー同意画面へリダイレクトします。  
+`redirectToProvider` は state を生成してプロバイダー同意画面へリダイレクトします。  
 `callback` は state を検証し、authorization code を token に交換してプロフィールを取得します。
+
+### ログイン後リダイレクト(`redirectTo`)
+
+フロー開始時に `redirectTo` を渡すと、コールバック後にサニタイズ済みの値として受け取れます:
+
+```ts
+// /auth/github?redirectTo=/settings
+const { url } = await oauth.authorize('github', {
+  redirectTo: this.request.query('redirectTo'),
+})
+
+// コールバックアクション内
+const { profile, redirectTo } = await oauth.handleCallback('github', { code, state })
+// ...ユーザーをログインさせる...
+return this.redirect(redirectTo ?? '/')
+```
+
+`redirectTo` はフローの入口と出口の両方でオープンリダイレクト対策の検証を通ります。デフォルトで通過するのはアプリ相対パス(`/settings`)のみです。特定の外部ホストを許可する場合は許可リストを設定します(ワイルドカード対応):
+
+```ts
+const oauth = createOAuthManager({
+  stateConfig: { allowedRedirectHosts: ['accounts.example.com', '*.example.org'] },
+})
+```
+
+プロトコル相対URL(`//evil.com`)、バックスラッシュ変種、http(s) 以外のスキーム、許可リスト外のホストは破棄され、`redirectTo` は `undefined` になってフォールバックが適用されます。
 
 ### 手動セットアップ
 

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -237,7 +237,11 @@ export default class OAuthController extends Controller {
   // Controller.redirect() helper used below.
   async redirectToProvider(): Promise<Response> {
     const provider = this.validateProvider(this.request.param('provider'))
-    const { url } = await this.oauth().authorize(provider)
+    // \`?redirectTo=\` is user input — the manager only keeps app-relative
+    // paths (or hosts allowlisted via stateConfig.allowedRedirectHosts).
+    const { url } = await this.oauth().authorize(provider, {
+      redirectTo: this.request.query('redirectTo'),
+    })
     return this.redirect(url)
   }
 
@@ -251,9 +255,11 @@ export default class OAuthController extends Controller {
     }
 
     // Replace this with your own account linking: look the user up by
-    // profile.email, create one when missing, then \`await this.auth.login(user)\`.
-    const profile = await this.oauth().user(provider, { code, state })
-    return this.json({ provider, profile }, { status: 200 })
+    // profile.email, create one when missing, then \`await this.auth.login(user)\`
+    // and finish with \`return this.redirect(redirectTo ?? '/')\` —
+    // \`redirectTo\` is already sanitized against open redirects.
+    const { profile, redirectTo } = await this.oauth().handleCallback(provider, { code, state })
+    return this.json({ provider, profile, redirectTo }, { status: 200 })
   }
 
   private validateProvider(value: string | undefined): SupportedProvider {

--- a/packages/server/src/auth/index.ts
+++ b/packages/server/src/auth/index.ts
@@ -65,6 +65,7 @@ export {
   createDiscordOAuthProviderConfig,
   buildOAuthRedirectUrl,
   parseOAuthRedirectUrl,
+  sanitizeOAuthRedirect,
 } from './oauth'
 export type {
   ApiToken,

--- a/packages/server/src/auth/oauth/index.ts
+++ b/packages/server/src/auth/oauth/index.ts
@@ -1,4 +1,9 @@
 import { AuthenticationException } from '../../errors/exceptions/AuthenticationException'
+import {
+  hostMatchesAllowlist,
+  isAppRelativePath,
+  normalizeRedirectTarget,
+} from '../../support/redirect-target'
 import { buildTokenUrl, generateToken, hashToken, parseTokenUrl } from '../utils'
 
 export interface OAuthProviderConfig {
@@ -258,10 +263,9 @@ export function sanitizeOAuthRedirect(
     return undefined
   }
 
-  // Normalize backslash tricks (e.g. /\evil.com) before classifying
-  const normalized = value.replace(/\\/g, '/')
+  const normalized = normalizeRedirectTarget(value)
 
-  if (normalized.startsWith('/') && !normalized.startsWith('//')) {
+  if (isAppRelativePath(normalized)) {
     return normalized
   }
 
@@ -272,21 +276,10 @@ export function sanitizeOAuthRedirect(
       return undefined
     }
 
-    for (const allowed of allowedHosts) {
-      if (allowed.startsWith('*.')) {
-        const suffix = allowed.slice(1).toLowerCase()
-        if (target.hostname.toLowerCase().endsWith(suffix) && target.hostname.length > suffix.length) {
-          return normalized
-        }
-      } else if (target.host.toLowerCase() === allowed.toLowerCase()) {
-        return normalized
-      }
-    }
+    return hostMatchesAllowlist(target, allowedHosts) ? normalized : undefined
   } catch {
     return undefined
   }
-
-  return undefined
 }
 
 export function buildOAuthAuthorizeUrl(

--- a/packages/server/src/auth/oauth/index.ts
+++ b/packages/server/src/auth/oauth/index.ts
@@ -48,6 +48,12 @@ export interface OAuthStateConfig {
   expiresIn?: number
   stateLength?: number
   hashAlgorithm?: 'sha256' | 'sha512'
+  /**
+   * External hosts allowed as `redirectTo` targets (supports `*.example.com`
+   * wildcards). App-relative paths (`/dashboard`) are always allowed; anything
+   * else is dropped to prevent open redirects.
+   */
+  allowedRedirectHosts?: string[]
 }
 
 export interface OAuthAuthorizeOptions {
@@ -134,6 +140,7 @@ export class OAuthManager {
       expiresIn: options.stateConfig?.expiresIn ?? DEFAULT_STATE_EXPIRES_IN,
       stateLength: options.stateConfig?.stateLength ?? DEFAULT_STATE_LENGTH,
       hashAlgorithm: options.stateConfig?.hashAlgorithm ?? DEFAULT_STATE_HASH_ALGORITHM,
+      allowedRedirectHosts: options.stateConfig?.allowedRedirectHosts ?? [],
     }
   }
 
@@ -168,6 +175,20 @@ export class OAuthManager {
   }
 
   async user(providerName: string, payload: OAuthCallbackPayload): Promise<OAuthUserProfile> {
+    const { profile } = await this.handleCallback(providerName, payload)
+    return profile
+  }
+
+  /**
+   * Verify the callback and return the user profile together with the
+   * sanitized `redirectTo` stored at authorize time. `redirectTo` is safe to
+   * pass to a redirect response: app-relative paths and allowlisted hosts
+   * only.
+   */
+  async handleCallback(
+    providerName: string,
+    payload: OAuthCallbackPayload,
+  ): Promise<{ profile: OAuthUserProfile; redirectTo?: string }> {
     const provider = this.getProvider(providerName)
     const verified = await verifyOAuthState(payload.state, providerName, this.stateStore, this.stateConfig)
     if (!verified) {
@@ -175,7 +196,8 @@ export class OAuthManager {
     }
 
     const token = await exchangeOAuthCode(provider, payload.code)
-    return fetchOAuthUserProfile(provider, token)
+    const profile = await fetchOAuthUserProfile(provider, token)
+    return { profile, redirectTo: verified.redirectTo }
   }
 }
 
@@ -194,7 +216,11 @@ export async function createOAuthState(
   const hashAlgorithm = config.hashAlgorithm ?? DEFAULT_STATE_HASH_ALGORITHM
   const expiresAt = new Date(Date.now() + (config.expiresIn ?? DEFAULT_STATE_EXPIRES_IN))
   const stateHash = hashToken(state, hashAlgorithm)
-  await store.store(stateHash, { provider, redirectTo, expiresAt })
+  await store.store(stateHash, {
+    provider,
+    redirectTo: sanitizeOAuthRedirect(redirectTo, config.allowedRedirectHosts),
+    expiresAt,
+  })
   return { state, expiresAt }
 }
 
@@ -210,7 +236,57 @@ export async function verifyOAuthState(
   if (!payload) return null
   await store.delete(stateHash)
   if (payload.provider !== provider) return null
-  return payload
+  // Re-sanitize on the way out so custom stores and states persisted before
+  // an allowlist change cannot smuggle an unsafe target through.
+  return { ...payload, redirectTo: sanitizeOAuthRedirect(payload.redirectTo, config.allowedRedirectHosts) }
+}
+
+/**
+ * Reduce a `redirectTo` value to a safe target: app-relative paths always
+ * pass; absolute http(s) URLs pass only when their host is in the allowlist
+ * (supports `*.example.com` wildcards). Everything else — protocol-relative
+ * URLs, backslash tricks, `javascript:` and other schemes — returns
+ * `undefined`.
+ */
+export function sanitizeOAuthRedirect(
+  redirectTo: string | undefined,
+  allowedHosts: string[] = [],
+): string | undefined {
+  const value = redirectTo?.trim()
+
+  if (!value) {
+    return undefined
+  }
+
+  // Normalize backslash tricks (e.g. /\evil.com) before classifying
+  const normalized = value.replace(/\\/g, '/')
+
+  if (normalized.startsWith('/') && !normalized.startsWith('//')) {
+    return normalized
+  }
+
+  try {
+    const target = new URL(normalized)
+
+    if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+      return undefined
+    }
+
+    for (const allowed of allowedHosts) {
+      if (allowed.startsWith('*.')) {
+        const suffix = allowed.slice(1).toLowerCase()
+        if (target.hostname.toLowerCase().endsWith(suffix) && target.hostname.length > suffix.length) {
+          return normalized
+        }
+      } else if (target.host.toLowerCase() === allowed.toLowerCase()) {
+        return normalized
+      }
+    }
+  } catch {
+    return undefined
+  }
+
+  return undefined
 }
 
 export function buildOAuthAuthorizeUrl(

--- a/packages/server/src/http/middleware/redirect-safety.ts
+++ b/packages/server/src/http/middleware/redirect-safety.ts
@@ -1,4 +1,9 @@
 import type { MiddlewareHandler } from 'hono'
+import {
+  hostMatchesAllowlist,
+  isAppRelativePath,
+  normalizeRedirectTarget,
+} from '../../support/redirect-target'
 
 export interface RedirectSafetyOptions {
   /** Additional external hosts allowed as redirect targets. */
@@ -56,11 +61,9 @@ export function isSafeRedirectUrl(
   requestUrl: string,
   allowedHosts: string[] = [],
 ): boolean {
-  // Normalize backslash tricks (e.g., \/evil.com)
-  const normalized = url.replace(/\\/g, '/')
+  const normalized = normalizeRedirectTarget(url)
 
-  // Relative URLs starting with a single slash are always safe
-  if (normalized.startsWith('/') && !normalized.startsWith('//')) {
+  if (isAppRelativePath(normalized)) {
     return true
   }
 
@@ -74,21 +77,9 @@ export function isSafeRedirectUrl(
       return true
     }
 
-    // Check allowed hosts
-    for (const allowed of allowedHosts) {
-      if (allowed.startsWith('*.')) {
-        const suffix = allowed.slice(1).toLowerCase()
-        if (target.hostname.toLowerCase().endsWith(suffix) && target.hostname.length > suffix.length) {
-          return true
-        }
-      } else if (target.host.toLowerCase() === allowed.toLowerCase()) {
-        return true
-      }
-    }
+    return hostMatchesAllowlist(target, allowedHosts)
   } catch {
     // Malformed URLs are not safe
     return false
   }
-
-  return false
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -96,6 +96,7 @@ export {
   createOAuthManager,
   createOAuthState,
   verifyOAuthState,
+  sanitizeOAuthRedirect,
   buildOAuthAuthorizeUrl,
   exchangeOAuthCode,
   fetchOAuthUserProfile,

--- a/packages/server/src/support/redirect-target.ts
+++ b/packages/server/src/support/redirect-target.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared open-redirect classification primitives, used by both the
+ * redirect-safety middleware and the OAuth `redirectTo` sanitizer. Keep every
+ * hardening fix here so the two layers cannot drift.
+ */
+
+/** Normalize backslash tricks (e.g. `/\evil.com`) before classifying. */
+export function normalizeRedirectTarget(value: string): string {
+  return value.replace(/\\/g, '/')
+}
+
+/** App-relative paths (`/path`, but not protocol-relative `//host`) are always safe. */
+export function isAppRelativePath(value: string): boolean {
+  return value.startsWith('/') && !value.startsWith('//')
+}
+
+/** Match a URL's host against an allowlist supporting `*.example.com` wildcards. */
+export function hostMatchesAllowlist(target: URL, allowedHosts: readonly string[]): boolean {
+  const hostname = target.hostname.toLowerCase()
+  const host = target.host.toLowerCase()
+
+  for (const allowed of allowedHosts) {
+    if (allowed.startsWith('*.')) {
+      const suffix = allowed.slice(1).toLowerCase()
+      if (hostname.endsWith(suffix) && hostname.length > suffix.length) {
+        return true
+      }
+    } else if (host === allowed.toLowerCase()) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/packages/server/tests/auth/oauth.test.ts
+++ b/packages/server/tests/auth/oauth.test.ts
@@ -8,6 +8,7 @@ import {
   createGoogleOAuthProviderConfig,
   createOAuthState,
   verifyOAuthState,
+  sanitizeOAuthRedirect,
   type OAuthProviderConfig,
 } from '../../src/auth/oauth'
 
@@ -42,6 +43,66 @@ describe('oauth helpers', () => {
 
     const secondUse = await verifyOAuthState(state, 'github', store, {})
     expect(secondUse).toBeNull()
+  })
+
+  it('drops unsafe redirectTo values when creating state', async () => {
+    const store = new MemoryOAuthStateStore()
+    const { state } = await createOAuthState('github', store, {}, 'https://evil.example.com/phish')
+
+    const payload = await verifyOAuthState(state, 'github', store, {})
+    expect(payload?.redirectTo).toBeUndefined()
+  })
+
+  it('re-sanitizes redirectTo on verify for custom stores', async () => {
+    const store = new MemoryOAuthStateStore()
+    await store.store('tampered', {
+      provider: 'github',
+      redirectTo: '//evil.example.com',
+      expiresAt: new Date(Date.now() + 60_000),
+    })
+
+    // Bypass createOAuthState entirely — the payload was written directly.
+    const payload = await store.find('tampered')
+    expect(payload?.redirectTo).toBe('//evil.example.com')
+
+    const { state } = await createOAuthState('github', store, {}, '/ok')
+    const verified = await verifyOAuthState(state, 'github', store, {})
+    expect(verified?.redirectTo).toBe('/ok')
+  })
+})
+
+describe('sanitizeOAuthRedirect', () => {
+  it('allows app-relative paths', () => {
+    expect(sanitizeOAuthRedirect('/dashboard')).toBe('/dashboard')
+    expect(sanitizeOAuthRedirect('/settings?tab=profile')).toBe('/settings?tab=profile')
+  })
+
+  it('rejects protocol-relative and backslash-crafted URLs', () => {
+    expect(sanitizeOAuthRedirect('//evil.example.com')).toBeUndefined()
+    expect(sanitizeOAuthRedirect('/\\evil.example.com')).toBeUndefined()
+    expect(sanitizeOAuthRedirect('\\/evil.example.com')).toBeUndefined()
+  })
+
+  it('rejects absolute URLs and non-http schemes by default', () => {
+    expect(sanitizeOAuthRedirect('https://evil.example.com/phish')).toBeUndefined()
+    expect(sanitizeOAuthRedirect('javascript:alert(1)')).toBeUndefined()
+    expect(sanitizeOAuthRedirect('data:text/html,x')).toBeUndefined()
+  })
+
+  it('allows allowlisted hosts including wildcards', () => {
+    expect(sanitizeOAuthRedirect('https://app.example.com/next', ['app.example.com'])).toBe(
+      'https://app.example.com/next',
+    )
+    expect(sanitizeOAuthRedirect('https://staging.example.com/next', ['*.example.com'])).toBe(
+      'https://staging.example.com/next',
+    )
+    expect(sanitizeOAuthRedirect('https://example.com.evil.net/', ['*.example.com'])).toBeUndefined()
+    expect(sanitizeOAuthRedirect('ftp://app.example.com/', ['app.example.com'])).toBeUndefined()
+  })
+
+  it('returns undefined for empty values', () => {
+    expect(sanitizeOAuthRedirect(undefined)).toBeUndefined()
+    expect(sanitizeOAuthRedirect('   ')).toBeUndefined()
   })
 })
 
@@ -99,6 +160,64 @@ describe('OAuthManager', () => {
     expect(profile.id).toBe('42')
     expect(profile.email).toBe('octo@example.com')
     expect(profile.token.accessToken).toBe('token-123')
+  })
+
+  it('returns sanitized redirectTo from handleCallback', async () => {
+    const manager = new OAuthManager({
+      stateStore: new MemoryOAuthStateStore(),
+    })
+    manager.registerProvider('github', githubConfig)
+
+    const fetchMock = mock(async (input: string) => {
+      if (input.includes('/access_token')) {
+        return new Response(JSON.stringify({ access_token: 'token-123' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return new Response(JSON.stringify({ id: 42 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+    ;(globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch
+
+    const safe = await manager.authorize('github', { redirectTo: '/dashboard' })
+    const safeResult = await manager.handleCallback('github', { code: 'auth-code', state: safe.state })
+    expect(safeResult.redirectTo).toBe('/dashboard')
+    expect(safeResult.profile.id).toBe('42')
+
+    const unsafe = await manager.authorize('github', { redirectTo: 'https://evil.example.com' })
+    const unsafeResult = await manager.handleCallback('github', { code: 'auth-code', state: unsafe.state })
+    expect(unsafeResult.redirectTo).toBeUndefined()
+  })
+
+  it('honors allowedRedirectHosts from stateConfig', async () => {
+    const manager = new OAuthManager({
+      stateStore: new MemoryOAuthStateStore(),
+      stateConfig: { allowedRedirectHosts: ['trusted.example.com'] },
+    })
+    manager.registerProvider('github', githubConfig)
+
+    const fetchMock = mock(async (input: string) => {
+      if (input.includes('/access_token')) {
+        return new Response(JSON.stringify({ access_token: 'token-123' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return new Response(JSON.stringify({ id: 42 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+    ;(globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch
+
+    const { state } = await manager.authorize('github', {
+      redirectTo: 'https://trusted.example.com/welcome',
+    })
+    const result = await manager.handleCallback('github', { code: 'auth-code', state })
+    expect(result.redirectTo).toBe('https://trusted.example.com/welcome')
   })
 
   it('exposes provider presets for google and discord', () => {

--- a/packages/server/tests/auth/oauth.test.ts
+++ b/packages/server/tests/auth/oauth.test.ts
@@ -11,6 +11,7 @@ import {
   sanitizeOAuthRedirect,
   type OAuthProviderConfig,
 } from '../../src/auth/oauth'
+import { hashToken } from '../../src/auth/utils'
 
 describe('oauth helpers', () => {
   it('builds authorize URL with required params and scopes', () => {
@@ -55,19 +56,19 @@ describe('oauth helpers', () => {
 
   it('re-sanitizes redirectTo on verify for custom stores', async () => {
     const store = new MemoryOAuthStateStore()
-    await store.store('tampered', {
+    const { state } = await createOAuthState('github', store, {}, '/ok', 'fixed-state')
+
+    // Overwrite the stored payload with an unsafe target, simulating a custom
+    // store (or a state persisted before an allowlist change).
+    await store.store(hashToken(state, 'sha256'), {
       provider: 'github',
       redirectTo: '//evil.example.com',
       expiresAt: new Date(Date.now() + 60_000),
     })
 
-    // Bypass createOAuthState entirely — the payload was written directly.
-    const payload = await store.find('tampered')
-    expect(payload?.redirectTo).toBe('//evil.example.com')
-
-    const { state } = await createOAuthState('github', store, {}, '/ok')
     const verified = await verifyOAuthState(state, 'github', store, {})
-    expect(verified?.redirectTo).toBe('/ok')
+    expect(verified?.provider).toBe('github')
+    expect(verified?.redirectTo).toBeUndefined()
   })
 })
 
@@ -113,6 +114,20 @@ describe('OAuthManager', () => {
     redirectUri: 'https://app.example.com/auth/github/callback',
   })
 
+  const installOAuthFetchMock = (
+    tokenResponse: Record<string, unknown>,
+    userResponse: Record<string, unknown>,
+  ) => {
+    const fetchMock = mock(async (input: string) => {
+      const body = input.includes('/access_token') ? tokenResponse : userResponse
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+    ;(globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch
+  }
+
   beforeEach(() => {
     mock.restore()
   })
@@ -134,25 +149,10 @@ describe('OAuthManager', () => {
     })
     manager.registerProvider('github', githubConfig)
 
-    const tokenResponse = {
-      access_token: 'token-123',
-      token_type: 'bearer',
-      scope: 'read:user',
-    }
-    const userResponse = {
-      id: 42,
-      email: 'octo@example.com',
-      name: 'Octo Cat',
-      avatar_url: 'https://example.com/avatar.png',
-    }
-
-    const fetchMock = mock(async (input: string) => {
-      if (input.includes('/access_token')) {
-        return new Response(JSON.stringify(tokenResponse), { status: 200, headers: { 'Content-Type': 'application/json' } })
-      }
-      return new Response(JSON.stringify(userResponse), { status: 200, headers: { 'Content-Type': 'application/json' } })
-    })
-    ;(globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch
+    installOAuthFetchMock(
+      { access_token: 'token-123', token_type: 'bearer', scope: 'read:user' },
+      { id: 42, email: 'octo@example.com', name: 'Octo Cat', avatar_url: 'https://example.com/avatar.png' },
+    )
 
     const { state } = await manager.authorize('github')
     const profile = await manager.user('github', { code: 'auth-code', state })
@@ -162,62 +162,28 @@ describe('OAuthManager', () => {
     expect(profile.token.accessToken).toBe('token-123')
   })
 
-  it('returns sanitized redirectTo from handleCallback', async () => {
-    const manager = new OAuthManager({
-      stateStore: new MemoryOAuthStateStore(),
-    })
-    manager.registerProvider('github', githubConfig)
-
-    const fetchMock = mock(async (input: string) => {
-      if (input.includes('/access_token')) {
-        return new Response(JSON.stringify({ access_token: 'token-123' }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
-      }
-      return new Response(JSON.stringify({ id: 42 }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    })
-    ;(globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch
-
-    const safe = await manager.authorize('github', { redirectTo: '/dashboard' })
-    const safeResult = await manager.handleCallback('github', { code: 'auth-code', state: safe.state })
-    expect(safeResult.redirectTo).toBe('/dashboard')
-    expect(safeResult.profile.id).toBe('42')
-
-    const unsafe = await manager.authorize('github', { redirectTo: 'https://evil.example.com' })
-    const unsafeResult = await manager.handleCallback('github', { code: 'auth-code', state: unsafe.state })
-    expect(unsafeResult.redirectTo).toBeUndefined()
-  })
-
-  it('honors allowedRedirectHosts from stateConfig', async () => {
+  it('round-trips sanitized redirectTo through authorize and handleCallback', async () => {
     const manager = new OAuthManager({
       stateStore: new MemoryOAuthStateStore(),
       stateConfig: { allowedRedirectHosts: ['trusted.example.com'] },
     })
     manager.registerProvider('github', githubConfig)
+    installOAuthFetchMock({ access_token: 'token-123' }, { id: 42 })
 
-    const fetchMock = mock(async (input: string) => {
-      if (input.includes('/access_token')) {
-        return new Response(JSON.stringify({ access_token: 'token-123' }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
-      }
-      return new Response(JSON.stringify({ id: 42 }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    })
-    ;(globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch
+    const roundTrip = async (redirectTo: string) => {
+      const { state } = await manager.authorize('github', { redirectTo })
+      return manager.handleCallback('github', { code: 'auth-code', state })
+    }
 
-    const { state } = await manager.authorize('github', {
-      redirectTo: 'https://trusted.example.com/welcome',
-    })
-    const result = await manager.handleCallback('github', { code: 'auth-code', state })
-    expect(result.redirectTo).toBe('https://trusted.example.com/welcome')
+    const relative = await roundTrip('/dashboard')
+    expect(relative.redirectTo).toBe('/dashboard')
+    expect(relative.profile.id).toBe('42')
+
+    const unsafe = await roundTrip('https://evil.example.com')
+    expect(unsafe.redirectTo).toBeUndefined()
+
+    const allowlisted = await roundTrip('https://trusted.example.com/welcome')
+    expect(allowlisted.redirectTo).toBe('https://trusted.example.com/welcome')
   })
 
   it('exposes provider presets for google and discord', () => {


### PR DESCRIPTION
## Summary

Post-1.0 backlog item (security): the OAuth manager stored a caller-supplied `redirectTo` in the state payload and handed it back verbatim — an app following the natural pattern (`/auth/github?redirectTo=...` → redirect after login) was an open-redirect phishing vector. It was also awkward to do correctly: `user()` never returned the stored `redirectTo` at all.

- **Sanitize at both ends**: `createOAuthState` drops unsafe values before storing; `verifyOAuthState` re-sanitizes on the way out (covers custom stores and states persisted before an allowlist change).
- **Rules**: app-relative paths (`/settings`) always pass; absolute URLs only when the host is in the new `stateConfig.allowedRedirectHosts` allowlist (`*.example.com` wildcards supported); protocol-relative (`//evil.com`), backslash variants (`/\evil.com`), `javascript:`/`data:` and other non-http schemes are dropped to `undefined`.
- **New API**: `OAuthManager.handleCallback(provider, { code, state })` returns `{ profile, redirectTo }` with the sanitized target (`user()` now delegates to it); `sanitizeOAuthRedirect()` exported for custom flows.
- **Scaffold**: `guren add oauth` controller template now demonstrates the safe round-trip (`?redirectTo=` in `redirectToProvider`, `handleCallback` + fallback in `callback`).
- **Docs (en/ja)**: new "Post-login redirect" section; also fixes the stale `redirect` action name in the route-flow example (the scaffold has used `redirectToProvider` for a while).
- `@guren/server` + `@guren/cli` minor changesets included (stacks on pending 1.3.0 items).

## Verification

- 8 new tests: `sanitizeOAuthRedirect` matrix (relative, protocol-relative, backslash, schemes, allowlist + wildcard, suffix-spoof), intake/outlet sanitization through the state store, `handleCallback` end-to-end with mocked provider, `allowedRedirectHosts` via `stateConfig`.
- `bun run test:bun` (2204 tests), `test:examples`, `typecheck`, `audit:core-first`, `audit:docs` — all green.