### PR TITLE
docs: replace deprecated z.string().email() with z.email()

### DIFF
--- a/docs/en/guides/build-auth-app.md
+++ b/docs/en/guides/build-auth-app.md
@@ -75,7 +75,7 @@ import { z } from 'zod'
 import { pages } from '@/.guren/pages.gen'
 
 const LoginSchema = z.object({
-  email: z.string().email(),
+  email: z.email(),
   password: z.string().min(1),
   remember: z.boolean().optional(),
 })

--- a/docs/en/guides/email-verification.md
+++ b/docs/en/guides/email-verification.md
@@ -416,7 +416,7 @@ describe('Email Verification', () => {
 async register() {
   const { name, email, password } = await this.validate({
     name: z.string().min(2),
-    email: z.string().email(),
+    email: z.email(),
     password: z.string().min(8),
   })
 

--- a/docs/en/guides/error-handling.md
+++ b/docs/en/guides/error-handling.md
@@ -235,7 +235,7 @@ import { formatValidationErrors } from '@guren/core'
 import { z } from 'zod'
 
 const schema = z.object({
-  email: z.string().email(),
+  email: z.email(),
   password: z.string().min(8),
 })
 

--- a/docs/en/guides/password-reset.md
+++ b/docs/en/guides/password-reset.md
@@ -98,7 +98,7 @@ import { User } from '@/app/Models/User'
 import { pages } from '@/.guren/pages.gen'
 
 const ForgotPasswordSchema = z.object({
-  email: z.string().email(),
+  email: z.email(),
 })
 
 const ResetPasswordSchema = z.object({

--- a/docs/en/guides/validation.md
+++ b/docs/en/guides/validation.md
@@ -121,7 +121,7 @@ import { Router, validateRequest } from '@guren/core'
 import { z } from 'zod'
 
 const schema = z.object({
-  email: z.string().email(),
+  email: z.email(),
   password: z.string().min(8),
 })
 
@@ -146,7 +146,7 @@ router.put('/users/:id', [UserController, 'update'], validateRequestWith((ctx) =
 
   return z.object({
     name: z.string().min(1),
-    email: z.string().email(),
+    email: z.email(),
     // Only admins can change roles
     role: isAdmin ? z.enum(['user', 'admin']) : z.never().optional(),
   })
@@ -285,7 +285,7 @@ const schema = z.object({
 
 ```ts
 const schema = z.object({
-  email: z.string().email().toLowerCase(),
+  email: z.email().toLowerCase(),
   tags: z.string().transform(s => s.split(',').map(t => t.trim())),
   date: z.string().transform(s => new Date(s)),
 })

--- a/docs/ja/guides/build-auth-app.md
+++ b/docs/ja/guides/build-auth-app.md
@@ -75,7 +75,7 @@ import { z } from 'zod'
 import { pages } from '@/.guren/pages.gen'
 
 const LoginSchema = z.object({
-  email: z.string().email(),
+  email: z.email(),
   password: z.string().min(1),
   remember: z.boolean().optional(),
 })

--- a/docs/ja/guides/email-verification.md
+++ b/docs/ja/guides/email-verification.md
@@ -416,7 +416,7 @@ describe('メール確認', () => {
 async register() {
   const { name, email, password } = await this.validate({
     name: z.string().min(2),
-    email: z.string().email(),
+    email: z.email(),
     password: z.string().min(8),
   })
 

--- a/docs/ja/guides/error-handling.md
+++ b/docs/ja/guides/error-handling.md
@@ -137,7 +137,7 @@ import { formatValidationErrors } from '@guren/core'
 import { z } from 'zod'
 
 const schema = z.object({
-  email: z.string().email(),
+  email: z.email(),
   password: z.string().min(8),
 })
 

--- a/docs/ja/guides/password-reset.md
+++ b/docs/ja/guides/password-reset.md
@@ -98,7 +98,7 @@ import { User } from '@/app/Models/User'
 import { pages } from '@/.guren/pages.gen'
 
 const ForgotPasswordSchema = z.object({
-  email: z.string().email(),
+  email: z.email(),
 })
 
 const ResetPasswordSchema = z.object({

--- a/docs/ja/guides/validation.md
+++ b/docs/ja/guides/validation.md
@@ -56,7 +56,7 @@ import { Router, validateRequest } from '@guren/core'
 import { z } from 'zod'
 
 const schema = z.object({
-  email: z.string().email(),
+  email: z.email(),
   password: z.string().min(8),
 })
 
@@ -81,7 +81,7 @@ router.put('/users/:id', [UserController, 'update'], validateRequestWith((ctx) =
 
   return z.object({
     name: z.string().min(1),
-    email: z.string().email(),
+    email: z.email(),
     // 管理者のみロール変更可能
     role: isAdmin ? z.enum(['user', 'admin']) : z.never().optional(),
   })
@@ -220,7 +220,7 @@ const schema = z.object({
 
 ```ts
 const schema = z.object({
-  email: z.string().email().toLowerCase(),
+  email: z.email().toLowerCase(),
   tags: z.string().transform(s => s.split(',').map(t => t.trim())),
   date: z.string().transform(s => new Date(s)),
 })

--- a/examples/api/app/Http/Validators/AuthValidator.ts
+++ b/examples/api/app/Http/Validators/AuthValidator.ts
@@ -2,12 +2,12 @@ import { z } from 'zod'
 
 export const RegisterSchema = z.object({
   name: z.string().min(1, 'Name is required').max(255),
-  email: z.string().email('Invalid email format'),
+  email: z.email('Invalid email format'),
   password: z.string().min(8, 'Password must be at least 8 characters'),
 })
 
 export const LoginSchema = z.object({
-  email: z.string().email('Invalid email format'),
+  email: z.email('Invalid email format'),
   password: z.string().min(1, 'Password is required'),
 })
 

--- a/examples/api/app/Http/Validators/OpenApiSchema.ts
+++ b/examples/api/app/Http/Validators/OpenApiSchema.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 export const UserResourceSchema = z.object({
   id: z.number(),
   name: z.string(),
-  email: z.string().email(),
+  email: z.email(),
   createdAt: z.string(),
 })
 

--- a/packages/server/src/http/middleware/validation.ts
+++ b/packages/server/src/http/middleware/validation.ts
@@ -46,7 +46,7 @@ export function getValidatedData<T = Record<string, unknown>>(ctx: Context): T |
  *
  * const CreateUserSchema = z.object({
  *   name: z.string().min(1),
- *   email: z.string().email(),
+ *   email: z.email(),
  * })
  *
  * app.post('/users', validateRequest(CreateUserSchema), (c) => {

--- a/packages/server/tests/mvc/Controller.test.ts
+++ b/packages/server/tests/mvc/Controller.test.ts
@@ -6,7 +6,7 @@ import { Controller } from '../../src/mvc/Controller'
 // ─── Test Schemas ────────────────────────────────────────────
 
 const BodySchema = z.object({
-  email: z.string().email(),
+  email: z.email(),
   name: z.string().min(1),
 })
 


### PR DESCRIPTION
## Summary

Zod v4 deprecates the chained `z.string().email()` check in favor of the top-level `z.email()` type. Update all guides (en/ja), the `examples/api` validator, and the `packages/server` test fixtures/comments to the recommended form. No runtime changes, so no changeset.

## Verification

- `bun run audit:docs` — pass
- `bun test packages/server/tests/mvc/Controller.test.ts` — 8 pass