### PR TITLE
feat(cli): warn about sensitive columns missing from static hidden in audit

### DIFF
--- a/.changeset/audit-hidden-columns.md
+++ b/.changeset/audit-hidden-columns.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': minor
+---
+
+`guren audit` now warns when a model's schema table has sensitive-looking columns (password, secret, token, salt, hash) that are not excluded from serialization via `static hidden` or a `static visible` allowlist. Records passed to `serialize()`/`toJSON()` or Inertia props would otherwise expose those values. Models whose sensitive columns are all covered get a pass finding; models without sensitive columns produce no output.

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -77,7 +77,7 @@ Validate your app before shipping — these commands are also designed for AI co
 | Command | Description | Example |
 |---------|-------------|---------|
 | `check` | Validate integrity across routes, controllers, pages, and models | `bunx guren check --json` |
-| `audit` | Security audit: missing input validation or authentication on mutating routes, raw SQL with interpolation, hardcoded credentials, disabled security defaults, mass-assignment configuration | `bunx guren audit --json` |
+| `audit` | Security audit: missing input validation or authentication on mutating routes, raw SQL with interpolation, hardcoded credentials, disabled security defaults, mass-assignment configuration, sensitive columns not listed in `static hidden` | `bunx guren audit --json` |
 | `doctor` | Project health report (env, config, generated files) with actionable next steps | `bunx guren doctor --next` |
 
 `audit` exits with a non-zero status when it finds failures, so you can run it in CI:

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -75,7 +75,7 @@ bunx guren add plugin @acme/guren-plugin-audit
 | コマンド | 説明 | 例 |
 |---------|------|-----|
 | `check` | ルート・コントローラ・ページ・モデル間の整合性を検証 | `bunx guren check --json` |
-| `audit` | セキュリティ監査: 変更系ルートのバリデーション/認証の欠如、文字列補間付き生SQL、ハードコードされた認証情報、無効化されたセキュリティ既定値、mass assignment 設定を検査 | `bunx guren audit --json` |
+| `audit` | セキュリティ監査: 変更系ルートのバリデーション/認証の欠如、文字列補間付き生SQL、ハードコードされた認証情報、無効化されたセキュリティ既定値、mass assignment 設定、`static hidden` 未登録の機微カラムを検査 | `bunx guren audit --json` |
 | `doctor` | プロジェクトの健全性レポート(環境変数・設定・生成ファイル)と次のアクション | `bunx guren doctor --next` |
 
 `audit` は失敗(fail)を検出すると非ゼロの終了コードを返すため、CI に組み込めます。

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -458,19 +458,57 @@ async function parseSchemaTableColumns(cwd: string): Promise<Map<string, string[
   return tables
 }
 
-function extractStaticStringArray(source: string, property: string): string[] | null {
-  const match = new RegExp(
-    `\\bstatic\\s+(?:override\\s+)?(?:readonly\\s+)?${property}(?:\\s*:[^=]+)?\\s*=\\s*\\[([\\s\\S]*?)\\]`,
-  ).exec(source)
-  if (!match) return null
+interface ModelSerializationInfo {
+  tableIdentifier?: string
+  hidden?: string[]
+  visible?: string[]
+}
 
-  const entries: string[] = []
-  const literal = /['"\`]([^'"\`]+)['"\`]/g
-  let m: RegExpExecArray | null
-  while ((m = literal.exec(match[1]!)) !== null) {
-    entries.push(m[1]!)
+/**
+ * Extract `static table`, `static hidden`, and `static visible` from a model
+ * source via AST (regexes would count string literals inside comments).
+ */
+function parseModelSerializationInfo(source: string): ModelSerializationInfo {
+  const info: ModelSerializationInfo = {}
+
+  let ast: ReturnType<typeof parse>
+  try {
+    // errorRecovery: `override` members parse-error without an extends clause
+    ast = parse(source, { sourceType: 'module', plugins: ['typescript'], errorRecovery: true })
+  } catch {
+    return info
   }
-  return entries
+
+  for (const node of ast.program.body) {
+    const classDecl =
+      node.type === 'ExportNamedDeclaration' && node.declaration?.type === 'ClassDeclaration'
+        ? node.declaration
+        : node.type === 'ExportDefaultDeclaration' && node.declaration?.type === 'ClassDeclaration'
+          ? node.declaration
+          : node.type === 'ClassDeclaration'
+            ? node
+            : null
+    if (!classDecl) continue
+
+    for (const member of classDecl.body.body) {
+      if (member.type !== 'ClassProperty' || !member.static || member.key.type !== 'Identifier') continue
+
+      if (member.key.name === 'table' && member.value?.type === 'Identifier') {
+        info.tableIdentifier = member.value.name
+      } else if (
+        (member.key.name === 'hidden' || member.key.name === 'visible') &&
+        member.value?.type === 'ArrayExpression'
+      ) {
+        const entries: string[] = []
+        for (const element of member.value.elements) {
+          if (element?.type === 'StringLiteral') entries.push(element.value)
+        }
+        info[member.key.name] = entries
+      }
+    }
+  }
+
+  return info
 }
 
 async function auditModels(cwd: string, findings: AuditFinding[]): Promise<void> {
@@ -500,17 +538,19 @@ async function auditModels(cwd: string, findings: AuditFinding[]): Promise<void>
     )
 
     // Sensitive columns must be excluded from serialization via hidden/visible.
-    const tableMatch = /\bstatic\s+(?:override\s+)?(?:readonly\s+)?table\s*=\s*([A-Za-z_$][\w$]*)/.exec(source)
-    const columns = tableMatch ? schemaTables?.get(tableMatch[1]!) : undefined
+    const info = parseModelSerializationInfo(source)
+    const columns = info.tableIdentifier ? schemaTables?.get(info.tableIdentifier) : undefined
     if (!columns) continue
 
     const sensitiveColumns = columns.filter((column) => SENSITIVE_COLUMN_PATTERN.test(column))
     if (sensitiveColumns.length === 0) continue
 
-    const hidden = new Set(extractStaticStringArray(source, 'hidden') ?? [])
-    const visible = extractStaticStringArray(source, 'visible')
-    const exposed = sensitiveColumns.filter(
-      (column) => !hidden.has(column) && (visible ? visible.includes(column) : true),
+    // Mirror serializeRecord: a non-empty visible allowlist wins and hidden is
+    // ignored entirely; an empty visible array is ignored at runtime.
+    const visibleActive = info.visible !== undefined && info.visible.length > 0
+    const hidden = new Set(info.hidden ?? [])
+    const exposed = sensitiveColumns.filter((column) =>
+      visibleActive ? info.visible!.includes(column) : !hidden.has(column),
     )
 
     findings.push(
@@ -523,7 +563,9 @@ async function auditModels(cwd: string, findings: AuditFinding[]): Promise<void>
           : `${name} serializes sensitive-looking column(s) ${exposed.join(', ')} — serialize()/toJSON() and Inertia props will expose them.`,
         exposed.length === 0
           ? undefined
-          : `Add ${exposed.map((c) => `'${c}'`).join(', ')} to 'static hidden = [...]' in ${relPath}.`,
+          : visibleActive
+            ? `Remove ${exposed.map((c) => `'${c}'`).join(', ')} from 'static visible' in ${relPath} (a non-empty visible allowlist overrides hidden).`
+            : `Add ${exposed.map((c) => `'${c}'`).join(', ')} to 'static hidden = [...]' in ${relPath}.`,
         relPath,
       ),
     )

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -395,8 +395,87 @@ async function auditSourceFiles(cwd: string, findings: AuditFinding[]): Promise<
 
 // --- Model checks ---
 
+/**
+ * Column names that look like credentials or secrets. Matching columns
+ * must be listed in the model's `static hidden` (or excluded via
+ * `static visible`) so serialize()/toJSON() never exposes them.
+ */
+const SENSITIVE_COLUMN_PATTERN = /(password|passwd|secret|token|salt|hash)/i
+
+/**
+ * Parse db/schema.ts and map each exported table variable to its column
+ * property names (e.g. `users` → ['id', 'email', 'passwordHash']).
+ * Returns null when the schema file is missing or unparsable.
+ */
+async function parseSchemaTableColumns(cwd: string): Promise<Map<string, string[]> | null> {
+  let source: string
+  try {
+    source = await readFile(resolve(cwd, 'db/schema.ts'), 'utf-8')
+  } catch {
+    return null
+  }
+
+  let ast: ReturnType<typeof parse>
+  try {
+    ast = parse(source, { sourceType: 'module', plugins: ['typescript'] })
+  } catch {
+    return null
+  }
+
+  const TABLE_FACTORIES = new Set(['pgTable', 'sqliteTable', 'mysqlTable'])
+  const tables = new Map<string, string[]>()
+
+  for (const node of ast.program.body) {
+    const declaration =
+      node.type === 'ExportNamedDeclaration' && node.declaration?.type === 'VariableDeclaration'
+        ? node.declaration
+        : node.type === 'VariableDeclaration'
+          ? node
+          : null
+    if (!declaration) continue
+
+    for (const declarator of declaration.declarations) {
+      if (declarator.id.type !== 'Identifier') continue
+      if (declarator.init?.type !== 'CallExpression') continue
+
+      const callee = declarator.init.callee
+      if (callee.type !== 'Identifier' || !TABLE_FACTORIES.has(callee.name)) continue
+
+      const columnsArg = declarator.init.arguments.find((arg) => arg.type === 'ObjectExpression')
+      if (!columnsArg || columnsArg.type !== 'ObjectExpression') continue
+
+      const columns: string[] = []
+      for (const prop of columnsArg.properties) {
+        if (prop.type !== 'ObjectProperty') continue
+        if (prop.key.type === 'Identifier') columns.push(prop.key.name)
+        else if (prop.key.type === 'StringLiteral') columns.push(prop.key.value)
+      }
+
+      tables.set(declarator.id.name, columns)
+    }
+  }
+
+  return tables
+}
+
+function extractStaticStringArray(source: string, property: string): string[] | null {
+  const match = new RegExp(
+    `\\bstatic\\s+(?:override\\s+)?(?:readonly\\s+)?${property}(?:\\s*:[^=]+)?\\s*=\\s*\\[([\\s\\S]*?)\\]`,
+  ).exec(source)
+  if (!match) return null
+
+  const entries: string[] = []
+  const literal = /['"\`]([^'"\`]+)['"\`]/g
+  let m: RegExpExecArray | null
+  while ((m = literal.exec(match[1]!)) !== null) {
+    entries.push(m[1]!)
+  }
+  return entries
+}
+
 async function auditModels(cwd: string, findings: AuditFinding[]): Promise<void> {
   const modelFiles = await discoverModelFiles(cwd)
+  const schemaTables = modelFiles.length > 0 ? await parseSchemaTableColumns(cwd) : null
 
   for (const filePath of modelFiles) {
     const relPath = relative(cwd, filePath)
@@ -416,6 +495,35 @@ async function auditModels(cwd: string, findings: AuditFinding[]): Promise<void>
         hasMassAssignmentConfig
           ? undefined
           : `Add 'static fillable = [...]' to ${relPath} to whitelist assignable columns.`,
+        relPath,
+      ),
+    )
+
+    // Sensitive columns must be excluded from serialization via hidden/visible.
+    const tableMatch = /\bstatic\s+(?:override\s+)?(?:readonly\s+)?table\s*=\s*([A-Za-z_$][\w$]*)/.exec(source)
+    const columns = tableMatch ? schemaTables?.get(tableMatch[1]!) : undefined
+    if (!columns) continue
+
+    const sensitiveColumns = columns.filter((column) => SENSITIVE_COLUMN_PATTERN.test(column))
+    if (sensitiveColumns.length === 0) continue
+
+    const hidden = new Set(extractStaticStringArray(source, 'hidden') ?? [])
+    const visible = extractStaticStringArray(source, 'visible')
+    const exposed = sensitiveColumns.filter(
+      (column) => !hidden.has(column) && (visible ? visible.includes(column) : true),
+    )
+
+    findings.push(
+      finding(
+        `hidden-columns:${name}`,
+        `${name} hidden columns`,
+        exposed.length === 0 ? 'pass' : 'warn',
+        exposed.length === 0
+          ? `${name} hides its sensitive column(s): ${sensitiveColumns.join(', ')}.`
+          : `${name} serializes sensitive-looking column(s) ${exposed.join(', ')} — serialize()/toJSON() and Inertia props will expose them.`,
+        exposed.length === 0
+          ? undefined
+          : `Add ${exposed.map((c) => `'${c}'`).join(', ')} to 'static hidden = [...]' in ${relPath}.`,
         relPath,
       ),
     )

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -618,6 +618,114 @@ export const users = pgTable('users', {
     }
   })
 
+  it('warns when a non-empty visible allowlist re-exposes a hidden sensitive column', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-hidden-visible-wins-')
+
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'db/schema.ts'),
+        `export const users = pgTable('users', {
+  id: text('id').primaryKey(),
+  passwordHash: text('password_hash').notNull(),
+})`,
+        'utf8',
+      )
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      // serializeRecord gives a non-empty visible list precedence over hidden.
+      await writeFile(
+        join(workspace.dir, 'app/Models/User.ts'),
+        `export class User {
+  static table = users
+  static fillable = ['email']
+  static hidden = ['passwordHash']
+  static visible = ['id', 'passwordHash']
+}`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const hidden = report.findings.find(f => f.key === 'hidden-columns:User')
+      expect(hidden).toBeDefined()
+      expect(hidden!.status).toBe('warn')
+      expect(hidden!.suggestion).toContain('static visible')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('ignores an empty visible array like the runtime serializer does', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-hidden-empty-visible-')
+
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'db/schema.ts'),
+        `export const users = pgTable('users', {
+  id: text('id').primaryKey(),
+  passwordHash: text('password_hash').notNull(),
+})`,
+        'utf8',
+      )
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Models/User.ts'),
+        `export class User {
+  static table = users
+  static fillable = ['email']
+  static visible: string[] = []
+}`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const hidden = report.findings.find(f => f.key === 'hidden-columns:User')
+      expect(hidden).toBeDefined()
+      expect(hidden!.status).toBe('warn')
+      expect(hidden!.message).toContain('passwordHash')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('does not count commented-out hidden entries', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-hidden-comment-')
+
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'db/schema.ts'),
+        `export const users = pgTable('users', {
+  id: text('id').primaryKey(),
+  passwordHash: text('password_hash').notNull(),
+})`,
+        'utf8',
+      )
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Models/User.ts'),
+        `export class User {
+  static table = users
+  static fillable = ['email']
+  static hidden = [
+    // 'passwordHash',
+  ]
+}`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const hidden = report.findings.find(f => f.key === 'hidden-columns:User')
+      expect(hidden).toBeDefined()
+      expect(hidden!.status).toBe('warn')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('emits no hidden-columns finding without sensitive columns or schema', async () => {
     const workspace = await createTempWorkspace('guren-cli-audit-hidden-none-')
 

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -509,6 +509,156 @@ export default function registerRoutes(router: any) {
     }
   })
 
+  it('warns when a sensitive schema column is not hidden', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-hidden-warn-')
+
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'db/schema.ts'),
+        `import { pgTable, text } from 'drizzle-orm/pg-core'
+export const users = pgTable('users', {
+  id: text('id').primaryKey(),
+  email: text('email').notNull(),
+  passwordHash: text('password_hash').notNull(),
+  rememberToken: text('remember_token'),
+})`,
+        'utf8',
+      )
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Models/User.ts'),
+        `export class User {
+  static table = users
+  static fillable = ['email']
+  static hidden = ['passwordHash']
+}`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const hidden = report.findings.find(f => f.key === 'hidden-columns:User')
+      expect(hidden).toBeDefined()
+      expect(hidden!.status).toBe('warn')
+      expect(hidden!.message).toContain('rememberToken')
+      expect(hidden!.message).not.toContain('passwordHash,')
+      expect(hidden!.suggestion).toContain("'rememberToken'")
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('passes when all sensitive columns are hidden', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-hidden-pass-')
+
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'db/schema.ts'),
+        `export const users = pgTable('users', {
+  id: text('id').primaryKey(),
+  passwordHash: text('password_hash').notNull(),
+})`,
+        'utf8',
+      )
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Models/User.ts'),
+        `export class User {
+  static table = users
+  static fillable = ['email']
+  static override hidden = ['passwordHash']
+}`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const hidden = report.findings.find(f => f.key === 'hidden-columns:User')
+      expect(hidden).toBeDefined()
+      expect(hidden!.status).toBe('pass')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('passes when a visible allowlist excludes sensitive columns', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-hidden-visible-')
+
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'db/schema.ts'),
+        `export const users = pgTable('users', {
+  id: text('id').primaryKey(),
+  email: text('email').notNull(),
+  apiSecret: text('api_secret').notNull(),
+})`,
+        'utf8',
+      )
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Models/User.ts'),
+        `export class User {
+  static table = users
+  static fillable = ['email']
+  static visible = ['id', 'email']
+}`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const hidden = report.findings.find(f => f.key === 'hidden-columns:User')
+      expect(hidden).toBeDefined()
+      expect(hidden!.status).toBe('pass')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('emits no hidden-columns finding without sensitive columns or schema', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-hidden-none-')
+
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'db/schema.ts'),
+        `export const posts = pgTable('posts', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+})`,
+        'utf8',
+      )
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Models/Post.ts'),
+        `export class Post {
+  static table = posts
+  static fillable = ['title']
+}`,
+        'utf8',
+      )
+      // Model whose table is not in db/schema.ts is skipped silently.
+      await writeFile(
+        join(workspace.dir, 'app/Models/Audit.ts'),
+        `export class Audit {
+  static table = audits
+  static fillable = ['action']
+}`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      expect(report.findings.find(f => f.key === 'hidden-columns:Post')).toBeUndefined()
+      expect(report.findings.find(f => f.key === 'hidden-columns:Audit')).toBeUndefined()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('degrades gracefully when routes cannot be loaded', async () => {
     const workspace = await createTempWorkspace('guren-cli-audit-noroutes-')
 


### PR DESCRIPTION
## Summary

`guren audit` now cross-references each model's schema table against its serialization config and warns when credential-looking columns would leak through `serialize()`/`toJSON()` or Inertia props.

- Parses `db/schema.ts` table definitions (`pgTable`/`sqliteTable`/`mysqlTable`) and matches them to each model's `static table = <ident>`.
- Columns matching `password|passwd|secret|token|salt|hash` that are neither listed in `static hidden` nor excluded by a `static visible` allowlist produce a **warn** finding with a concrete suggestion.
- Models whose sensitive columns are all covered get a **pass** finding; models with no sensitive columns (or an unresolvable table) emit nothing to avoid noise.
- CLI guide (en/ja) audit description updated; `@guren/cli` minor changeset included.

## Verification

- `bun test packages/cli/tests/audit.test.ts` — 24 pass (4 new cases: warn / hidden pass / visible pass / no-finding)
- `packages/cli` typecheck — pass
- Dogfooding against `examples/blog`: 18 passed, 0 warnings (its User model already declares `hidden`)
- `bun run audit:docs` — pass