### PR TITLE
feat(server): add Sanitized type helper for auth user records

### DIFF
--- a/.changeset/sanitized-type-helper.md
+++ b/.changeset/sanitized-type-helper.md
@@ -1,0 +1,5 @@
+---
+'@guren/server': minor
+---
+
+Add the `Sanitized<T, Hidden>` type helper (and `DefaultSanitizedKeys`). `auth.user()` sanitizes records at runtime — the password column, remember-token column, and the model's `static hidden` fields are stripped — but the type previously still claimed those fields were present. `auth.userOrFail<Sanitized<UserRecord>>()` now lets the compile-time type match the runtime shape; extra hidden fields go in the second type parameter (`Sanitized<UserRecord, 'twoFactorSecret'>`).

--- a/.changeset/sanitized-type-helper.md
+++ b/.changeset/sanitized-type-helper.md
@@ -2,4 +2,4 @@
 '@guren/server': minor
 ---
 
-Add the `Sanitized<T, Hidden>` type helper (and `DefaultSanitizedKeys`). `auth.user()` sanitizes records at runtime — the password column, remember-token column, and the model's `static hidden` fields are stripped — but the type previously still claimed those fields were present. `auth.userOrFail<Sanitized<UserRecord>>()` now lets the compile-time type match the runtime shape; extra hidden fields go in the second type parameter (`Sanitized<UserRecord, 'twoFactorSecret'>`).
+Add the `Sanitized<T, Hidden>` type helper (and `DefaultSanitizedKeys`). `auth.user()` sanitizes records at runtime — the password column, remember-token column, and the model's `static hidden` fields are stripped — but the type previously still claimed those fields were present. `auth.userOrFail<Sanitized<UserRecord>>()` strips the conventional credential keys from the compile-time type (distributing over union records); columns with non-conventional names and extra hidden fields go in the second type parameter (`Sanitized<UserRecord, 'twoFactorSecret'>`).

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -355,6 +355,26 @@ sanitize(user: AuthUser): AuthUser {
 }
 ```
 
+### Typing Sanitized Users
+
+Sanitization happens at runtime, so a plain `auth.user<UserRecord>()` would still *type* the record as if the credential fields were present. Use the `Sanitized<T>` helper to make the type match reality:
+
+```ts
+import type { Sanitized } from '@guren/core'
+
+// Strips password/passwordHash/rememberToken-style keys from the type
+const user = await this.auth.userOrFail<Sanitized<UserRecord>>()
+
+user.email        // ✅ string
+user.passwordHash // ❌ compile error — stripped at runtime
+```
+
+If your model hides additional fields via `static hidden`, list them in the second type parameter:
+
+```ts
+type SafeUser = Sanitized<UserRecord, 'twoFactorSecret'>
+```
+
 ## Remember Tokens
 
 `SessionGuard` manages remember tokens automatically when your user provider implements `setRememberToken` / `getRememberToken`. `ModelUserProvider` handles this when the `rememberTokenColumn` option is supplied.

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -357,7 +357,7 @@ sanitize(user: AuthUser): AuthUser {
 
 ### Typing Sanitized Users
 
-Sanitization happens at runtime, so a plain `auth.user<UserRecord>()` would still *type* the record as if the credential fields were present. Use the `Sanitized<T>` helper to make the type match reality:
+Sanitization happens at runtime, so a plain `auth.user<UserRecord>()` would still *type* the record as if the credential fields were present. Use the `Sanitized<T>` helper to strip the conventional credential keys from the type:
 
 ```ts
 import type { Sanitized } from '@guren/core'
@@ -369,11 +369,13 @@ user.email        // ✅ string
 user.passwordHash // ❌ compile error — stripped at runtime
 ```
 
-If your model hides additional fields via `static hidden`, list them in the second type parameter:
+If your model hides additional fields via `static hidden`, or your credential columns use names outside the conventions (`password`, `passwordHash`, `password_hash`, `rememberToken`, `remember_token`), list them in the second type parameter:
 
 ```ts
-type SafeUser = Sanitized<UserRecord, 'twoFactorSecret'>
+type SafeUser = Sanitized<UserRecord, 'twoFactorSecret' | 'credentialDigest'>
 ```
+
+The runtime strips exactly the columns your provider is configured with plus the model's `static hidden` — a static type cannot see that configuration, so `Sanitized<T>` reflects the conventional names and relies on you to pass anything else. `guren audit` warns about sensitive columns missing from `static hidden`, which keeps the runtime side honest.
 
 ## Remember Tokens
 

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -352,6 +352,26 @@ sanitize(user: AuthUser): AuthUser {
 }
 ```
 
+### サニタイズ済みユーザーの型付け
+
+サニタイズはランタイムの処理なので、単に `auth.user<UserRecord>()` と書くと、実際には取り除かれている資格情報フィールドが型の上では残ったままになります。`Sanitized<T>` ヘルパーを使うと、型を実態に一致させられます。
+
+```ts
+import type { Sanitized } from '@guren/core'
+
+// password / passwordHash / rememberToken 系のキーを型から除去
+const user = await this.auth.userOrFail<Sanitized<UserRecord>>()
+
+user.email        // ✅ string
+user.passwordHash // ❌ コンパイルエラー — ランタイムで除去済み
+```
+
+モデルの `static hidden` で追加のフィールドを隠している場合は、第2型引数に列挙します。
+
+```ts
+type SafeUser = Sanitized<UserRecord, 'twoFactorSecret'>
+```
+
 ## Remember トークン
 
 `SessionGuard` は remember トークンを自動管理します。ユーザープロバイダーが `setRememberToken` / `getRememberToken` を実装していれば動作し、`ModelUserProvider` は `rememberTokenColumn` を指定すると対応します。

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -354,7 +354,7 @@ sanitize(user: AuthUser): AuthUser {
 
 ### サニタイズ済みユーザーの型付け
 
-サニタイズはランタイムの処理なので、単に `auth.user<UserRecord>()` と書くと、実際には取り除かれている資格情報フィールドが型の上では残ったままになります。`Sanitized<T>` ヘルパーを使うと、型を実態に一致させられます。
+サニタイズはランタイムの処理なので、単に `auth.user<UserRecord>()` と書くと、実際には取り除かれている資格情報フィールドが型の上では残ったままになります。`Sanitized<T>` ヘルパーを使うと、慣例的な資格情報キーを型から取り除けます。
 
 ```ts
 import type { Sanitized } from '@guren/core'
@@ -366,11 +366,13 @@ user.email        // ✅ string
 user.passwordHash // ❌ コンパイルエラー — ランタイムで除去済み
 ```
 
-モデルの `static hidden` で追加のフィールドを隠している場合は、第2型引数に列挙します。
+モデルの `static hidden` で追加のフィールドを隠している場合や、資格情報カラムが慣例名(`password`、`passwordHash`、`password_hash`、`rememberToken`、`remember_token`)以外の場合は、第2型引数に列挙します。
 
 ```ts
-type SafeUser = Sanitized<UserRecord, 'twoFactorSecret'>
+type SafeUser = Sanitized<UserRecord, 'twoFactorSecret' | 'credentialDigest'>
 ```
+
+ランタイムが除去するのは「プロバイダーに設定されたカラム + モデルの `static hidden`」そのものです。静的型はこの設定を参照できないため、`Sanitized<T>` は慣例名を反映し、それ以外は第2型引数での指定に委ねます。`static hidden` に漏れている機微カラムは `guren audit` が警告するため、ランタイム側の正しさはそちらで担保できます。
 
 ## Remember トークン
 

--- a/packages/server/src/auth/index.ts
+++ b/packages/server/src/auth/index.ts
@@ -98,6 +98,8 @@ export type {
   UserProvider,
   ProviderFactory,
   AttachContextOptions,
+  DefaultSanitizedKeys,
+  Sanitized,
 } from './types'
 export {
   hashToken,

--- a/packages/server/src/auth/types.ts
+++ b/packages/server/src/auth/types.ts
@@ -38,10 +38,11 @@ export interface UserProvider<User = Authenticatable> {
 }
 
 /**
- * Credential-material keys that `ModelUserProvider.sanitize()` strips by
- * default: the password column (`password` by default, commonly configured
- * as `passwordHash`/`password_hash`) and the remember-token column
- * (`remember_token` by default, commonly `rememberToken`).
+ * The conventional names for the credential columns that
+ * `ModelUserProvider.sanitize()` strips: the password column (`password`
+ * by default, commonly configured as `passwordHash`/`password_hash`) and
+ * the remember-token column (`remember_token` by default, commonly
+ * `rememberToken`).
  */
 export type DefaultSanitizedKeys =
   | 'password'
@@ -52,23 +53,29 @@ export type DefaultSanitizedKeys =
 
 /**
  * The shape of a user record after auth-layer sanitization — what
- * `auth.user()` actually returns at runtime. Removes the default
- * credential keys plus any extra keys listed in the model's
- * `static hidden`.
+ * `auth.user()` returns at runtime when the provider's column names
+ * follow the {@link DefaultSanitizedKeys} conventions. Removes those
+ * conventional credential keys plus any extra keys passed as `Hidden`.
+ *
+ * The runtime strips exactly the *configured* password/remember-token
+ * columns plus the model's `static hidden` — a static type cannot see
+ * that configuration. If your columns use other names, or the model
+ * hides additional fields, list them in `Hidden` explicitly. Only
+ * meaningful for concrete record types (index-signature records like
+ * `Record<string, string>` cannot have individual keys removed).
  *
  * @example
  * ```ts
  * const user = await this.auth.userOrFail<Sanitized<UserRecord>>()
  * user.passwordHash // compile error — stripped at runtime
  *
- * // With additional hidden fields:
- * type SafeUser = Sanitized<UserRecord, 'twoFactorSecret'>
+ * // With additional hidden fields or custom column names:
+ * type SafeUser = Sanitized<UserRecord, 'twoFactorSecret' | 'credentialDigest'>
  * ```
  */
-export type Sanitized<User, Hidden extends string = never> = Omit<
-  User,
-  Extract<keyof User, DefaultSanitizedKeys | Hidden>
->
+export type Sanitized<User, Hidden extends string = never> = User extends unknown
+  ? Omit<User, Extract<keyof User, DefaultSanitizedKeys | Hidden>>
+  : never
 
 export interface GuardContext {
   ctx: Context

--- a/packages/server/src/auth/types.ts
+++ b/packages/server/src/auth/types.ts
@@ -37,6 +37,39 @@ export interface UserProvider<User = Authenticatable> {
   sanitize?(user: User): User
 }
 
+/**
+ * Credential-material keys that `ModelUserProvider.sanitize()` strips by
+ * default: the password column (`password` by default, commonly configured
+ * as `passwordHash`/`password_hash`) and the remember-token column
+ * (`remember_token` by default, commonly `rememberToken`).
+ */
+export type DefaultSanitizedKeys =
+  | 'password'
+  | 'passwordHash'
+  | 'password_hash'
+  | 'rememberToken'
+  | 'remember_token'
+
+/**
+ * The shape of a user record after auth-layer sanitization — what
+ * `auth.user()` actually returns at runtime. Removes the default
+ * credential keys plus any extra keys listed in the model's
+ * `static hidden`.
+ *
+ * @example
+ * ```ts
+ * const user = await this.auth.userOrFail<Sanitized<UserRecord>>()
+ * user.passwordHash // compile error — stripped at runtime
+ *
+ * // With additional hidden fields:
+ * type SafeUser = Sanitized<UserRecord, 'twoFactorSecret'>
+ * ```
+ */
+export type Sanitized<User, Hidden extends string = never> = Omit<
+  User,
+  Extract<keyof User, DefaultSanitizedKeys | Hidden>
+>
+
 export interface GuardContext {
   ctx: Context
   session: Session | undefined

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -117,6 +117,8 @@ export type {
   GuardFactory,
   UserProvider,
   ProviderFactory,
+  DefaultSanitizedKeys,
+  Sanitized,
   PasswordResetConfig,
   PasswordResetTokenStore,
   PasswordResetTokenResult,

--- a/packages/server/tests/auth/sanitized.test.ts
+++ b/packages/server/tests/auth/sanitized.test.ts
@@ -28,6 +28,22 @@ describe('Sanitized<T>', () => {
     expect(safe.email).toBe('user@example.com')
   })
 
+  test('distributes over union record types', () => {
+    type Admin = { kind: 'admin'; email: string; password: string }
+    type Customer = { kind: 'customer'; phone: string; password: string }
+
+    const admin: Sanitized<Admin | Customer> = { kind: 'admin', email: 'a@example.com' }
+    const customer: Sanitized<Admin | Customer> = { kind: 'customer', phone: '555' }
+
+    // Member-specific safe fields survive after narrowing.
+    if (admin.kind === 'admin') {
+      expect(admin.email).toBe('a@example.com')
+    }
+    if (customer.kind === 'customer') {
+      expect(customer.phone).toBe('555')
+    }
+  })
+
   test('matches what ModelUserProvider.sanitize() strips at runtime', () => {
     class FakeUserModel {
       static hidden = ['twoFactorSecret']

--- a/packages/server/tests/auth/sanitized.test.ts
+++ b/packages/server/tests/auth/sanitized.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from 'bun:test'
+import { ModelUserProvider } from '../../src/auth/providers/ModelUserProvider'
+import type { Sanitized } from '../../src/auth/types'
+
+interface UserRecord {
+  id: number
+  email: string
+  passwordHash: string
+  rememberToken: string | null
+  twoFactorSecret: string
+}
+
+describe('Sanitized<T>', () => {
+  test('strips default credential keys and extra hidden keys at the type level', () => {
+    const safe: Sanitized<UserRecord, 'twoFactorSecret'> = {
+      id: 1,
+      email: 'user@example.com',
+    }
+
+    // @ts-expect-error passwordHash is stripped by sanitization
+    void safe.passwordHash
+    // @ts-expect-error rememberToken is stripped by sanitization
+    void safe.rememberToken
+    // @ts-expect-error twoFactorSecret is stripped via the Hidden parameter
+    void safe.twoFactorSecret
+
+    expect(safe.id).toBe(1)
+    expect(safe.email).toBe('user@example.com')
+  })
+
+  test('matches what ModelUserProvider.sanitize() strips at runtime', () => {
+    class FakeUserModel {
+      static hidden = ['twoFactorSecret']
+    }
+
+    const provider = new ModelUserProvider(FakeUserModel as never, {
+      passwordColumn: 'passwordHash',
+      rememberTokenColumn: 'rememberToken',
+    })
+
+    const sanitized = provider.sanitize({
+      id: 1,
+      email: 'user@example.com',
+      passwordHash: 'hashed',
+      rememberToken: 'token',
+      twoFactorSecret: 'otp-secret',
+    } as never) as unknown as Record<string, unknown>
+
+    // The runtime result carries exactly the keys Sanitized<UserRecord, 'twoFactorSecret'> keeps.
+    expect(Object.keys(sanitized).sort()).toEqual(['email', 'id'])
+  })
+})


### PR DESCRIPTION
## Summary

`auth.user()` sanitizes records at runtime — the password column, remember-token column, and the model's `static hidden` fields are stripped — but the type still claimed those fields were present. This adds an opt-in type helper so the compile-time shape can match the runtime record:

```ts
import type { Sanitized } from '@guren/core'

const user = await this.auth.userOrFail<Sanitized<UserRecord>>()
user.passwordHash // compile error — stripped at runtime
```

- New `Sanitized<T, Hidden>` and `DefaultSanitizedKeys` exports from `@guren/server` (available via `@guren/core`).
- Extra `static hidden` fields go in the second type parameter: `Sanitized<UserRecord, 'twoFactorSecret'>`.
- No changes to existing API signatures — purely additive.
- Authentication guide (en/ja) gains a "Typing Sanitized Users" section; `@guren/server` minor changeset included.

## Verification

- New `packages/server/tests/auth/sanitized.test.ts`: `@ts-expect-error` type assertions + a runtime check that the helper's kept keys match `ModelUserProvider.sanitize()` output exactly
- `packages/server` typecheck pass / auth tests 231 pass / `bun run audit:docs` pass