### PR TITLE
feat(core): add database-backed DatabaseApiTokenStore

### DIFF
--- a/.changeset/database-api-token-store.md
+++ b/.changeset/database-api-token-store.md
@@ -1,0 +1,5 @@
+---
+'@guren/core': minor
+---
+
+Add `DatabaseApiTokenStore`, a database-backed `ApiTokenStore` built on the Guren ORM. Pass the Drizzle table for your `api_tokens` schema and it plugs into `createApiToken`/`verifyApiToken` and the bearer-token middleware with no custom store code, using the app's configured ORM connection. Includes `deleteExpired()` for scheduled pruning and an `abilitiesMode: 'text'` option for plain-text JSON ability columns (JSON-capable columns are the default). The API tokens guide previously told users to hand-roll this class — it now documents the built-in store and the recommended schema.

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "examples/api": {
       "name": "@guren/example-api",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -67,14 +67,14 @@
     },
     "packages/cli": {
       "name": "@guren/cli",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "bin": {
         "guren": "./dist/bin.js",
       },
       "dependencies": {
         "@babel/parser": "^7.24.7",
         "@guren/core": "^1.0.0",
-        "@guren/orm": "^1.0.0",
+        "@guren/orm": "^1.0.1",
         "citty": "^0.1.6",
         "consola": "^3.4.2",
       },
@@ -102,13 +102,14 @@
       },
       "devDependencies": {
         "@types/node": "^20.14.10",
+        "drizzle-orm": "1.0.0-rc.4",
         "tsup": "^8.5.0",
         "typescript": "^5.4.0",
       },
     },
     "packages/create-app": {
       "name": "create-guren-app",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "bin": {
         "create-guren-app": "./dist/cli.js",
       },
@@ -124,7 +125,7 @@
     },
     "packages/inertia-client": {
       "name": "@guren/inertia-client",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@inertiajs/core": "^3.6.1",
         "@inertiajs/react": "^3.6.1",
@@ -154,7 +155,7 @@
     },
     "packages/orm": {
       "name": "@guren/orm",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "drizzle-orm": "1.0.0-rc.4",
       },
@@ -176,7 +177,7 @@
     },
     "packages/plugin-vercel": {
       "name": "@guren/plugin-vercel",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@guren/core": "^1.0.0-rc.12",
       },
@@ -188,9 +189,9 @@
     },
     "packages/server": {
       "name": "@guren/server",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "dependencies": {
-        "@guren/orm": "^1.0.0",
+        "@guren/orm": "^1.0.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "chalk": "^5.3.0",
         "consola": "^3.4.2",
@@ -247,7 +248,7 @@
     },
     "web": {
       "name": "web",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",

--- a/docs/en/guides/api-tokens.md
+++ b/docs/en/guides/api-tokens.md
@@ -220,83 +220,66 @@ router.post('/api/tokens/revoke-all', async (ctx) => {
 
 ## Database Storage
 
-### Implementing ApiTokenStore
+### Built-in DatabaseApiTokenStore
+
+For production, use the built-in `DatabaseApiTokenStore`. Pass it the Drizzle table for your `api_tokens` schema — no custom store code needed:
 
 ```ts
-import type { ApiTokenStore, ApiToken } from '@guren/core'
+import { DatabaseApiTokenStore } from '@guren/core'
 import { apiTokens } from '@/db/schema'
 
-export class DatabaseApiTokenStore implements ApiTokenStore {
-  async store(token: ApiToken): Promise<void> {
-    await db.insert(apiTokens).values({
-      id: token.id,
-      name: token.name,
-      hashedToken: token.hashedToken,
-      userId: token.userId,
-      abilities: JSON.stringify(token.abilities),
-      lastUsedAt: token.lastUsedAt,
-      expiresAt: token.expiresAt,
-      createdAt: token.createdAt,
-    })
-  }
+const store = new DatabaseApiTokenStore(apiTokens)
 
-  async findByHashedToken(hashedToken: string): Promise<ApiToken | null> {
-    const result = await db.select()
-      .from(apiTokens)
-      .where(eq(apiTokens.hashedToken, hashedToken))
-      .limit(1)
-
-    if (!result[0]) return null
-
-    return {
-      ...result[0],
-      abilities: JSON.parse(result[0].abilities),
-    }
-  }
-
-  async findByUserId(userId: string | number): Promise<ApiToken[]> {
-    const results = await db.select()
-      .from(apiTokens)
-      .where(eq(apiTokens.userId, String(userId)))
-
-    return results.map(r => ({
-      ...r,
-      abilities: JSON.parse(r.abilities),
-    }))
-  }
-
-  async delete(id: string): Promise<void> {
-    await db.delete(apiTokens).where(eq(apiTokens.id, id))
-  }
-
-  async deleteForUser(userId: string | number): Promise<void> {
-    await db.delete(apiTokens).where(eq(apiTokens.userId, String(userId)))
-  }
-
-  async updateLastUsed(id: string, timestamp: Date): Promise<void> {
-    await db.update(apiTokens)
-      .set({ lastUsedAt: timestamp })
-      .where(eq(apiTokens.id, id))
-  }
-}
+// Works with every token helper
+const { plainTextToken } = await createApiToken(store, {
+  name: 'Mobile App Token',
+  userId: user.id,
+})
 ```
+
+The store uses the app's configured ORM connection (the standard `DatabaseProvider` setup), so it needs no extra wiring. Expired tokens are already rejected by `verifyApiToken`; call `store.deleteExpired()` from a scheduled job to prune them from the table.
 
 ### Database Schema
 
+Column property names must match the `ApiToken` fields:
+
 ```ts
 // db/schema.ts
-import { pgTable, text, timestamp, json } from 'drizzle-orm/pg-core'
+import { pgTable, text, timestamp, jsonb } from 'drizzle-orm/pg-core'
 
 export const apiTokens = pgTable('api_tokens', {
   id: text('id').primaryKey(),
   name: text('name').notNull(),
   hashedToken: text('hashed_token').notNull().unique(),
   userId: text('user_id').notNull(),
-  abilities: text('abilities').notNull(), // JSON string
+  abilities: jsonb('abilities').$type<string[]>().notNull(),
   lastUsedAt: timestamp('last_used_at'),
   expiresAt: timestamp('expires_at'),
   createdAt: timestamp('created_at').notNull().defaultNow(),
 })
+```
+
+If your `abilities` column is a plain text column holding a JSON string instead of `jsonb`, pass `{ abilitiesMode: 'text' }`:
+
+```ts
+const store = new DatabaseApiTokenStore(apiTokens, { abilitiesMode: 'text' })
+```
+
+### Custom Stores
+
+Any object implementing the `ApiTokenStore` interface works — implement it yourself when tokens live in an external system:
+
+```ts
+import type { ApiTokenStore, ApiToken } from '@guren/core'
+
+export class ExternalApiTokenStore implements ApiTokenStore {
+  async store(token: ApiToken): Promise<void> { /* ... */ }
+  async findByHashedToken(hashedToken: string): Promise<ApiToken | null> { /* ... */ }
+  async findByUserId(userId: string | number): Promise<ApiToken[]> { /* ... */ }
+  async delete(id: string): Promise<void> { /* ... */ }
+  async deleteForUser(userId: string | number): Promise<void> { /* ... */ }
+  async updateLastUsed(id: string, timestamp: Date): Promise<void> { /* ... */ }
+}
 ```
 
 ## Configuration Options

--- a/docs/ja/guides/api-tokens.md
+++ b/docs/ja/guides/api-tokens.md
@@ -220,83 +220,66 @@ router.post('/api/tokens/revoke-all', async (ctx) => {
 
 ## データベースストレージ
 
-### ApiTokenStoreの実装
+### 組み込みの DatabaseApiTokenStore
+
+本番環境では組み込みの `DatabaseApiTokenStore` を使います。`api_tokens` スキーマの Drizzle テーブルを渡すだけで、カスタムストアの実装は不要です。
 
 ```ts
-import type { ApiTokenStore, ApiToken } from '@guren/core'
+import { DatabaseApiTokenStore } from '@guren/core'
 import { apiTokens } from '@/db/schema'
 
-export class DatabaseApiTokenStore implements ApiTokenStore {
-  async store(token: ApiToken): Promise<void> {
-    await db.insert(apiTokens).values({
-      id: token.id,
-      name: token.name,
-      hashedToken: token.hashedToken,
-      userId: token.userId,
-      abilities: JSON.stringify(token.abilities),
-      lastUsedAt: token.lastUsedAt,
-      expiresAt: token.expiresAt,
-      createdAt: token.createdAt,
-    })
-  }
+const store = new DatabaseApiTokenStore(apiTokens)
 
-  async findByHashedToken(hashedToken: string): Promise<ApiToken | null> {
-    const result = await db.select()
-      .from(apiTokens)
-      .where(eq(apiTokens.hashedToken, hashedToken))
-      .limit(1)
-
-    if (!result[0]) return null
-
-    return {
-      ...result[0],
-      abilities: JSON.parse(result[0].abilities),
-    }
-  }
-
-  async findByUserId(userId: string | number): Promise<ApiToken[]> {
-    const results = await db.select()
-      .from(apiTokens)
-      .where(eq(apiTokens.userId, String(userId)))
-
-    return results.map(r => ({
-      ...r,
-      abilities: JSON.parse(r.abilities),
-    }))
-  }
-
-  async delete(id: string): Promise<void> {
-    await db.delete(apiTokens).where(eq(apiTokens.id, id))
-  }
-
-  async deleteForUser(userId: string | number): Promise<void> {
-    await db.delete(apiTokens).where(eq(apiTokens.userId, String(userId)))
-  }
-
-  async updateLastUsed(id: string, timestamp: Date): Promise<void> {
-    await db.update(apiTokens)
-      .set({ lastUsedAt: timestamp })
-      .where(eq(apiTokens.id, id))
-  }
-}
+// すべてのトークンヘルパーで利用可能
+const { plainTextToken } = await createApiToken(store, {
+  name: 'Mobile App Token',
+  userId: user.id,
+})
 ```
+
+ストアはアプリで設定済みの ORM 接続（標準の `DatabaseProvider` セットアップ）を利用するため、追加の配線は不要です。期限切れトークンは `verifyApiToken` が拒否します。テーブルから削除するには、スケジュールジョブから `store.deleteExpired()` を呼んでください。
 
 ### データベーススキーマ
 
+カラムのプロパティ名は `ApiToken` のフィールドと一致させます。
+
 ```ts
 // db/schema.ts
-import { pgTable, text, timestamp, json } from 'drizzle-orm/pg-core'
+import { pgTable, text, timestamp, jsonb } from 'drizzle-orm/pg-core'
 
 export const apiTokens = pgTable('api_tokens', {
   id: text('id').primaryKey(),
   name: text('name').notNull(),
   hashedToken: text('hashed_token').notNull().unique(),
   userId: text('user_id').notNull(),
-  abilities: text('abilities').notNull(), // JSON文字列
+  abilities: jsonb('abilities').$type<string[]>().notNull(),
   lastUsedAt: timestamp('last_used_at'),
   expiresAt: timestamp('expires_at'),
   createdAt: timestamp('created_at').notNull().defaultNow(),
 })
+```
+
+`abilities` カラムが `jsonb` ではなく JSON 文字列を保持する text カラムの場合は、`{ abilitiesMode: 'text' }` を渡します。
+
+```ts
+const store = new DatabaseApiTokenStore(apiTokens, { abilitiesMode: 'text' })
+```
+
+### カスタムストア
+
+`ApiTokenStore` インターフェースを実装したオブジェクトであれば何でも利用できます。トークンを外部システムに保存する場合は自前で実装してください。
+
+```ts
+import type { ApiTokenStore, ApiToken } from '@guren/core'
+
+export class ExternalApiTokenStore implements ApiTokenStore {
+  async store(token: ApiToken): Promise<void> { /* ... */ }
+  async findByHashedToken(hashedToken: string): Promise<ApiToken | null> { /* ... */ }
+  async findByUserId(userId: string | number): Promise<ApiToken[]> { /* ... */ }
+  async delete(id: string): Promise<void> { /* ... */ }
+  async deleteForUser(userId: string | number): Promise<void> { /* ... */ }
+  async updateLastUsed(id: string, timestamp: Date): Promise<void> { /* ... */ }
+}
 ```
 
 ## 設定オプション

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.14.10",
+    "drizzle-orm": "1.0.0-rc.4",
     "tsup": "^8.5.0",
     "typescript": "^5.4.0"
   }

--- a/packages/core/src/api-token-store.ts
+++ b/packages/core/src/api-token-store.ts
@@ -1,0 +1,114 @@
+import { Model, type PlainObject } from '@guren/orm'
+import type { ApiToken, ApiTokenStore } from '@guren/server'
+
+/**
+ * Options for DatabaseApiTokenStore.
+ */
+export interface DatabaseApiTokenStoreOptions {
+  /**
+   * How the `abilities` column stores the ability list.
+   *
+   * - `'json'` (default) passes the array straight through — use with a
+   *   JSON-capable column (pg `jsonb`/`json`, sqlite `text(..., { mode: 'json' })`).
+   * - `'text'` serializes to a JSON string for plain text columns.
+   *
+   * Reads always accept both representations.
+   * @default 'json'
+   */
+  abilitiesMode?: 'json' | 'text'
+}
+
+/**
+ * Database-backed API token store built on the Guren ORM.
+ *
+ * Pass the Drizzle table for your `api_tokens` schema. Column property
+ * names must match the {@link ApiToken} fields (`id`, `name`,
+ * `hashedToken`, `userId`, `abilities`, `lastUsedAt`, `expiresAt`,
+ * `createdAt`). The ORM must be configured (the standard
+ * `DatabaseProvider` setup) before the store is used.
+ *
+ * @example
+ * ```ts
+ * import { DatabaseApiTokenStore, createApiToken } from '@guren/core'
+ * import { apiTokens } from '@/db/schema'
+ *
+ * const store = new DatabaseApiTokenStore(apiTokens)
+ *
+ * const { plainTextToken } = await createApiToken(store, {
+ *   name: 'Mobile App Token',
+ *   userId: user.id,
+ * })
+ * ```
+ */
+export class DatabaseApiTokenStore implements ApiTokenStore {
+  private readonly model: typeof Model
+  private readonly abilitiesMode: 'json' | 'text'
+
+  constructor(table: unknown, options: DatabaseApiTokenStoreOptions = {}) {
+    this.abilitiesMode = options.abilitiesMode ?? 'json'
+    this.model = class ApiTokenModel extends Model {
+      static override table = table
+    }
+  }
+
+  async store(token: ApiToken): Promise<void> {
+    await this.model.forceCreate({
+      ...token,
+      abilities:
+        this.abilitiesMode === 'text' ? JSON.stringify(token.abilities) : token.abilities,
+    })
+  }
+
+  async findByHashedToken(hashedToken: string): Promise<ApiToken | null> {
+    const record = await this.model.where({ hashedToken }).first()
+    return record ? this.deserialize(record) : null
+  }
+
+  async findByUserId(userId: string | number): Promise<ApiToken[]> {
+    const records = await this.model.where({ userId }).get()
+    return records.map((record) => this.deserialize(record))
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.model.where({ id }).delete()
+  }
+
+  async deleteForUser(userId: string | number): Promise<void> {
+    await this.model.where({ userId }).delete()
+  }
+
+  async updateLastUsed(id: string, timestamp: Date): Promise<void> {
+    await this.model.forceUpdate({ id }, { lastUsedAt: timestamp })
+  }
+
+  /**
+   * Delete tokens whose expiration time has passed. Expired tokens are
+   * already rejected by `verifyApiToken`; call this from a scheduled
+   * job to keep the table small.
+   */
+  async deleteExpired(now: Date = new Date()): Promise<void> {
+    await this.model.where('expiresAt', '<', now).delete()
+  }
+
+  private deserialize(record: PlainObject): ApiToken {
+    const abilities = record.abilities
+    return {
+      id: String(record.id),
+      name: String(record.name),
+      hashedToken: String(record.hashedToken),
+      userId: record.userId as string | number,
+      abilities:
+        typeof abilities === 'string' ? (JSON.parse(abilities) as string[]) : (abilities as string[]),
+      lastUsedAt: toDate(record.lastUsedAt),
+      expiresAt: toDate(record.expiresAt),
+      createdAt: toDate(record.createdAt) ?? new Date(0),
+    }
+  }
+}
+
+function toDate(value: unknown): Date | null {
+  if (value == null) return null
+  if (value instanceof Date) return value
+  if (typeof value === 'string' || typeof value === 'number') return new Date(value)
+  return null
+}

--- a/packages/core/src/api-token-store.ts
+++ b/packages/core/src/api-token-store.ts
@@ -99,7 +99,8 @@ export class DatabaseApiTokenStore implements ApiTokenStore {
       id: String(record.id),
       name: String(record.name),
       hashedToken: String(record.hashedToken),
-      userId: record.userId as string | number,
+      userId:
+        typeof record.userId === 'bigint' ? record.userId.toString() : (record.userId as string | number),
       abilities:
         typeof abilities === 'string' ? (JSON.parse(abilities) as string[]) : (abilities as string[]),
       lastUsedAt: toDate(record.lastUsedAt),

--- a/packages/core/src/api-token-store.ts
+++ b/packages/core/src/api-token-store.ts
@@ -90,6 +90,9 @@ export class DatabaseApiTokenStore implements ApiTokenStore {
     await this.model.where('expiresAt', '<', now).delete()
   }
 
+  // Not replaceable with `static casts`: QueryBuilder reads (`where().first()/.get()`)
+  // bypass model casts, and cast-based writes would fight drizzle column modes
+  // (Date → ISO string breaks timestamp columns; json-stringify double-encodes jsonb).
   private deserialize(record: PlainObject): ApiToken {
     const abilities = record.abilities
     return {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,5 +72,5 @@ export type {
   ScopeFunction,
 } from '@guren/orm'
 // Cross-package glue (server + orm)
-export { DatabaseApiTokenStore } from './api-token-store'
-export type { DatabaseApiTokenStoreOptions } from './api-token-store'
+export { DatabaseApiTokenStore } from './api-token-store.js'
+export type { DatabaseApiTokenStoreOptions } from './api-token-store.js'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,3 +71,6 @@ export type {
   ModelObserverConstructor,
   ScopeFunction,
 } from '@guren/orm'
+// Cross-package glue (server + orm)
+export { DatabaseApiTokenStore } from './api-token-store'
+export type { DatabaseApiTokenStoreOptions } from './api-token-store'

--- a/packages/core/tests/api-token-store.test.ts
+++ b/packages/core/tests/api-token-store.test.ts
@@ -9,27 +9,25 @@ import {
   verifyApiToken,
 } from '../src/index'
 
-const apiTokens = sqliteTable('api_tokens', {
+const baseColumns = {
   id: text('id').primaryKey(),
   name: text('name').notNull(),
   hashedToken: text('hashed_token').notNull().unique(),
   userId: text('user_id').notNull(),
-  abilities: text('abilities', { mode: 'json' }).$type<string[]>().notNull(),
   lastUsedAt: integer('last_used_at', { mode: 'timestamp_ms' }),
   expiresAt: integer('expires_at', { mode: 'timestamp_ms' }),
   createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+}
+
+const apiTokens = sqliteTable('api_tokens', {
+  ...baseColumns,
+  abilities: text('abilities', { mode: 'json' }).$type<string[]>().notNull(),
 })
 
 // Same shape but with a plain text abilities column (no drizzle json mode).
 const apiTokensText = sqliteTable('api_tokens_text', {
-  id: text('id').primaryKey(),
-  name: text('name').notNull(),
-  hashedToken: text('hashed_token').notNull().unique(),
-  userId: text('user_id').notNull(),
+  ...baseColumns,
   abilities: text('abilities').notNull(),
-  lastUsedAt: integer('last_used_at', { mode: 'timestamp_ms' }),
-  expiresAt: integer('expires_at', { mode: 'timestamp_ms' }),
-  createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
 })
 
 describe('DatabaseApiTokenStore', () => {
@@ -38,28 +36,20 @@ describe('DatabaseApiTokenStore', () => {
 
   beforeEach(() => {
     sqlite = new Database(':memory:')
-    sqlite.exec(`
-      CREATE TABLE api_tokens (
-        id text primary key,
-        name text not null,
-        hashed_token text not null unique,
-        user_id text not null,
-        abilities text not null,
-        last_used_at integer,
-        expires_at integer,
-        created_at integer not null
-      );
-      CREATE TABLE api_tokens_text (
-        id text primary key,
-        name text not null,
-        hashed_token text not null unique,
-        user_id text not null,
-        abilities text not null,
-        last_used_at integer,
-        expires_at integer,
-        created_at integer not null
-      );
-    `)
+    for (const tableName of ['api_tokens', 'api_tokens_text']) {
+      sqlite.exec(`
+        CREATE TABLE ${tableName} (
+          id text primary key,
+          name text not null,
+          hashed_token text not null unique,
+          user_id text not null,
+          abilities text not null,
+          last_used_at integer,
+          expires_at integer,
+          created_at integer not null
+        );
+      `)
+    }
     DrizzleAdapter.configure(drizzle({ client: sqlite }) as never)
     store = new DatabaseApiTokenStore(apiTokens)
   })
@@ -96,7 +86,7 @@ describe('DatabaseApiTokenStore', () => {
   })
 
   test('rejects expired tokens and deleteExpired removes them', async () => {
-    const { plainTextToken, token } = await createApiToken(store, {
+    const { plainTextToken } = await createApiToken(store, {
       name: 'Short-lived',
       userId: 'user-1',
       expiresIn: -1000, // already expired
@@ -106,7 +96,6 @@ describe('DatabaseApiTokenStore', () => {
 
     await store.deleteExpired()
     expect(await store.findByUserId('user-1')).toHaveLength(0)
-    void token
   })
 
   test('updates lastUsedAt on verification', async () => {

--- a/packages/core/tests/api-token-store.test.ts
+++ b/packages/core/tests/api-token-store.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { drizzle } from 'drizzle-orm/bun-sqlite'
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import {
+  DatabaseApiTokenStore,
+  DrizzleAdapter,
+  createApiToken,
+  verifyApiToken,
+} from '../src/index'
+
+const apiTokens = sqliteTable('api_tokens', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  hashedToken: text('hashed_token').notNull().unique(),
+  userId: text('user_id').notNull(),
+  abilities: text('abilities', { mode: 'json' }).$type<string[]>().notNull(),
+  lastUsedAt: integer('last_used_at', { mode: 'timestamp_ms' }),
+  expiresAt: integer('expires_at', { mode: 'timestamp_ms' }),
+  createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+})
+
+// Same shape but with a plain text abilities column (no drizzle json mode).
+const apiTokensText = sqliteTable('api_tokens_text', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  hashedToken: text('hashed_token').notNull().unique(),
+  userId: text('user_id').notNull(),
+  abilities: text('abilities').notNull(),
+  lastUsedAt: integer('last_used_at', { mode: 'timestamp_ms' }),
+  expiresAt: integer('expires_at', { mode: 'timestamp_ms' }),
+  createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+})
+
+describe('DatabaseApiTokenStore', () => {
+  let sqlite: Database
+  let store: DatabaseApiTokenStore
+
+  beforeEach(() => {
+    sqlite = new Database(':memory:')
+    sqlite.exec(`
+      CREATE TABLE api_tokens (
+        id text primary key,
+        name text not null,
+        hashed_token text not null unique,
+        user_id text not null,
+        abilities text not null,
+        last_used_at integer,
+        expires_at integer,
+        created_at integer not null
+      );
+      CREATE TABLE api_tokens_text (
+        id text primary key,
+        name text not null,
+        hashed_token text not null unique,
+        user_id text not null,
+        abilities text not null,
+        last_used_at integer,
+        expires_at integer,
+        created_at integer not null
+      );
+    `)
+    DrizzleAdapter.configure(drizzle({ client: sqlite }) as never)
+    store = new DatabaseApiTokenStore(apiTokens)
+  })
+
+  afterEach(() => {
+    sqlite.close()
+  })
+
+  test('round-trips a created token through verifyApiToken', async () => {
+    const { plainTextToken, token } = await createApiToken(store, {
+      name: 'Mobile App',
+      userId: 'user-1',
+      abilities: ['posts:read', 'posts:write'],
+    })
+
+    const result = await verifyApiToken(plainTextToken, store)
+
+    expect(result).not.toBeNull()
+    expect(result!.userId).toBe('user-1')
+    expect(result!.abilities).toEqual(['posts:read', 'posts:write'])
+    expect(result!.token.id).toBe(token.id)
+    expect(result!.token.name).toBe('Mobile App')
+    expect(result!.token.createdAt).toBeInstanceOf(Date)
+  })
+
+  test('rejects tampered and unknown tokens', async () => {
+    const { plainTextToken } = await createApiToken(store, {
+      name: 'App',
+      userId: 'user-1',
+    })
+
+    expect(await verifyApiToken(`${plainTextToken}x`, store)).toBeNull()
+    expect(await verifyApiToken('missing|deadbeef', store)).toBeNull()
+  })
+
+  test('rejects expired tokens and deleteExpired removes them', async () => {
+    const { plainTextToken, token } = await createApiToken(store, {
+      name: 'Short-lived',
+      userId: 'user-1',
+      expiresIn: -1000, // already expired
+    })
+
+    expect(await verifyApiToken(plainTextToken, store)).toBeNull()
+
+    await store.deleteExpired()
+    expect(await store.findByUserId('user-1')).toHaveLength(0)
+    void token
+  })
+
+  test('updates lastUsedAt on verification', async () => {
+    const { plainTextToken, token } = await createApiToken(store, {
+      name: 'App',
+      userId: 'user-1',
+    })
+    expect(token.lastUsedAt).toBeNull()
+
+    await verifyApiToken(plainTextToken, store)
+
+    const [stored] = await store.findByUserId('user-1')
+    expect(stored!.lastUsedAt).toBeInstanceOf(Date)
+  })
+
+  test('findByUserId, delete, and deleteForUser manage token lifecycles', async () => {
+    const a = await createApiToken(store, { name: 'A', userId: 'user-1' })
+    await createApiToken(store, { name: 'B', userId: 'user-1' })
+    await createApiToken(store, { name: 'C', userId: 'user-2' })
+
+    expect(await store.findByUserId('user-1')).toHaveLength(2)
+
+    await store.delete(a.token.id)
+    expect(await store.findByUserId('user-1')).toHaveLength(1)
+
+    await store.deleteForUser('user-1')
+    expect(await store.findByUserId('user-1')).toHaveLength(0)
+    expect(await store.findByUserId('user-2')).toHaveLength(1)
+  })
+
+  test('supports plain text abilities columns via abilitiesMode', async () => {
+    const textStore = new DatabaseApiTokenStore(apiTokensText, { abilitiesMode: 'text' })
+
+    const { plainTextToken } = await createApiToken(textStore, {
+      name: 'Text Mode',
+      userId: 'user-1',
+      abilities: ['read'],
+    })
+
+    const result = await verifyApiToken(plainTextToken, textStore)
+    expect(result).not.toBeNull()
+    expect(result!.abilities).toEqual(['read'])
+  })
+})


### PR DESCRIPTION
## Summary

The API tokens guide told users to hand-roll a database store; ship it instead.

- New `DatabaseApiTokenStore` in `@guren/core` (cross-package glue over `@guren/server` + `@guren/orm`, per the core-first convention). Internally wraps the given Drizzle table in a private ORM `Model` subclass.
- Pass your `api_tokens` table and it plugs into `createApiToken` / `verifyApiToken` / the bearer-token middleware, reusing the app's configured ORM connection (standard `DatabaseProvider` setup) — no extra wiring.
- `deleteExpired()` for scheduled pruning; `abilitiesMode: 'text'` for plain-text JSON ability columns (JSON-capable columns are the default; reads always accept both representations).
- API tokens guide (en/ja): the hand-rolled example is replaced by the built-in store plus a recommended `jsonb` schema; a custom-store escape hatch remains for external systems.
- `drizzle-orm` added to core devDependencies (tests only, aligned with the ORM peer range); `@guren/core` minor changeset included.

## Verification

- New `packages/core/tests/api-token-store.test.ts` against real `bun:sqlite`: round-trip, tampered/unknown token rejection, expiry + `deleteExpired`, `lastUsedAt` updates, per-user listing/deletion, `abilitiesMode: 'text'` — 6 pass
- `packages/core` typecheck + build (DTS) pass
- Full monorepo `bun run typecheck` pass; `bun run audit:docs` / `bun run audit:core-first` pass