### PR TITLE
fix(server): wire X-Testing-Session header to session hydration

### DIFF
--- a/.changeset/testing-session-hydration.md
+++ b/.changeset/testing-session-hydration.md
@@ -1,0 +1,5 @@
+---
+'@guren/server': minor
+---
+
+Wire `TestRequestBuilder.withSession()` to server-side session hydration: the session middleware now reads the `X-Testing-Session` header — only when `GUREN_TESTING` is set, same gate as `X-Testing-User` — parses the JSON payload, and merges it over the stored session data for the request. Tests using `createTestClient(...).get(...).withSession({ ... })` now observe the injected session state instead of an empty session. Malformed or non-object payloads are ignored.

--- a/packages/server/src/http/middleware/session.ts
+++ b/packages/server/src/http/middleware/session.ts
@@ -231,6 +231,31 @@ class SessionImpl implements Session {
 
 export interface CreateSessionMiddlewareOptions extends SessionOptions {}
 
+const TESTING_SESSION_HEADER = 'x-testing-session'
+
+function resolveTestingSession(ctx: { req: { header: (name: string) => string | undefined } }): SessionData | null {
+  // Only allow testing session injection when GUREN_TESTING is explicitly set.
+  // This prevents external callers from forging session state in production/staging.
+  if (!process.env.GUREN_TESTING) {
+    return null
+  }
+
+  const rawSession = ctx.req.header(TESTING_SESSION_HEADER)
+  if (!rawSession) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(rawSession) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null
+    }
+    return parsed as SessionData
+  } catch {
+    return null
+  }
+}
+
 interface SessionCookieSigner {
   sign(sessionId: string): string
   verify(cookieValue: string | undefined): string | null
@@ -312,7 +337,9 @@ export function createSessionMiddleware(options: CreateSessionMiddlewareOptions 
     const existingId = signer.verify(getCookie(ctx, cookieName))
     const sessionId = existingId ?? globalThis.crypto.randomUUID()
     const isNew = !existingId
-    const initialData = existingId ? (await store.read(existingId)) ?? {} : {}
+    const storedData = existingId ? (await store.read(existingId)) ?? {} : {}
+    const testingData = resolveTestingSession(ctx)
+    const initialData = testingData ? { ...storedData, ...testingData } : storedData
     const session = new SessionImpl(sessionId, initialData, isNew)
     session.ageFlashData()
 

--- a/packages/server/tests/http/middleware/session.test.ts
+++ b/packages/server/tests/http/middleware/session.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test'
+import { afterEach, describe, expect, it } from 'bun:test'
 import { Hono } from 'hono'
 import {
   createSessionMiddleware,
@@ -374,6 +374,84 @@ describe('createSessionMiddleware', () => {
     expect(setCookie).toContain('Path=/api')
     expect(setCookie).toContain('SameSite=Strict')
     expect(setCookie).toContain('HttpOnly')
+  })
+})
+
+describe('X-Testing-Session hydration', () => {
+  const originalTesting = process.env.GUREN_TESTING
+
+  afterEach(() => {
+    if (originalTesting === undefined) {
+      delete process.env.GUREN_TESTING
+    } else {
+      process.env.GUREN_TESTING = originalTesting
+    }
+  })
+
+  function createTestApp(options?: Parameters<typeof createSessionMiddleware>[0]) {
+    const app = new Hono()
+    app.use(createSessionMiddleware(options))
+    app.get('/session', (c) => c.json(getSessionFromContext(c)?.all() ?? {}))
+    return app
+  }
+
+  it('hydrates session from header when GUREN_TESTING is set', async () => {
+    process.env.GUREN_TESTING = '1'
+    const app = createTestApp()
+
+    const res = await app.request('/session', {
+      headers: { 'X-Testing-Session': JSON.stringify({ step: 2, cart: ['a'] }) },
+    })
+
+    expect(await res.json()).toEqual({ step: 2, cart: ['a'] })
+  })
+
+  it('ignores header when GUREN_TESTING is not set', async () => {
+    delete process.env.GUREN_TESTING
+    const app = createTestApp()
+
+    const res = await app.request('/session', {
+      headers: { 'X-Testing-Session': JSON.stringify({ forged: true }) },
+    })
+
+    expect(await res.json()).toEqual({})
+  })
+
+  it('ignores malformed or non-object header payloads', async () => {
+    process.env.GUREN_TESTING = '1'
+    const app = createTestApp()
+
+    for (const payload of ['not-json', '"string"', '[1,2]', 'null']) {
+      const res = await app.request('/session', {
+        headers: { 'X-Testing-Session': payload },
+      })
+      expect(await res.json()).toEqual({})
+    }
+  })
+
+  it('merges testing data over stored session data', async () => {
+    process.env.GUREN_TESTING = '1'
+    const store = new MemorySessionStore()
+    const app = createTestApp({ store })
+
+    app.get('/set', (c) => {
+      const session = getSessionFromContext(c)
+      session?.set('kept', 'stored')
+      session?.set('overridden', 'stored')
+      return c.text('ok')
+    })
+
+    const res1 = await app.request('/set')
+    const cookie = res1.headers.get('set-cookie')?.split(';')[0] ?? ''
+
+    const res2 = await app.request('/session', {
+      headers: {
+        Cookie: cookie,
+        'X-Testing-Session': JSON.stringify({ overridden: 'testing', added: true }),
+      },
+    })
+
+    expect(await res2.json()).toEqual({ kept: 'stored', overridden: 'testing', added: true })
   })
 })
 

--- a/packages/testing/tests/testing.test.ts
+++ b/packages/testing/tests/testing.test.ts
@@ -15,7 +15,14 @@ import {
   createDatabaseAssertions,
   setTestDatabase,
 } from '../src'
-import { Event, Job, attachAuthContext, requireAuthenticated } from '@guren/server'
+import {
+  Event,
+  Job,
+  attachAuthContext,
+  requireAuthenticated,
+  createSessionMiddleware,
+  getSessionFromContext,
+} from '@guren/server'
 import { Hono } from 'hono'
 
 describe('TestResponse', () => {
@@ -387,6 +394,22 @@ describe('TestApp', () => {
     await localized.get('/echo').assertJson({ lang: 'en', cookie: 'locale=en' })
     // The original instance is unchanged
     await testApp.get('/echo').assertJson({ lang: null, cookie: null })
+  })
+
+  it('withSession hydrates the server-side session through session middleware', async () => {
+    process.env.APP_KEY = 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+    process.env.GUREN_TESTING = '1'
+    const app = new Hono()
+    app.use('*', createSessionMiddleware({ cookieSecure: false }))
+    app.get('/session', (c) => c.json(getSessionFromContext(c)?.all() ?? {}))
+
+    const client = createTestClient((request) => Promise.resolve(app.fetch(request)))
+    const response = await client
+      .get('/session')
+      .withSession({ step: 2, wizard: 'shipping' })
+      .send()
+
+    expect(await response.json()).toEqual({ step: 2, wizard: 'shipping' })
   })
 
   it('withHeader composes with actingAs', async () => {


### PR DESCRIPTION
## Summary

Fixes #16.

`TestRequestBuilder.withSession()` serializes session data into an `X-Testing-Session` header, but nothing on the server side ever read it — tests using `createTestClient(...).get(...).withSession({ ... })` silently observed an empty session.

This PR wires the header into `createSessionMiddleware`:

- When `GUREN_TESTING` is set (same gate as `X-Testing-User`), the middleware parses the `X-Testing-Session` header as JSON and merges it over the stored session data for the request.
- Malformed JSON and non-object payloads (arrays, strings, `null`) are ignored.
- Without `GUREN_TESTING`, the header is ignored entirely, so session state cannot be forged in production/staging.

## Changes

- `packages/server/src/http/middleware/session.ts`: add `resolveTestingSession()` and merge its result into the session's initial data
- `packages/server/tests/http/middleware/session.test.ts`: unit tests for hydration, env gating, malformed payloads, and merge-over-stored-data behavior
- `packages/testing/tests/testing.test.ts`: integration test exercising `withSession()` end-to-end through the real session middleware
- Changeset: `@guren/server` minor

## Testing

- `bun run build` — all packages compile
- `bun run typecheck` — clean
- `bun run test:bun` — 2191 pass / 0 fail
- `packages/testing` vitest suite — the new integration test passes; it fails without the middleware change (verified against baseline). The 4 remaining failures in that suite are pre-existing on `main` and unrelated (FakeQueue `assertPushedOn`, two 204-status environment issues, route registrar 404)
- `bun run audit:core-first` / `bun run audit:docs` — pass