### PR TITLE
fix(testing): repair 4 vitest suite failures in packages/testing

### DIFF
--- a/packages/testing/src/queue.test.ts
+++ b/packages/testing/src/queue.test.ts
@@ -24,6 +24,7 @@ describe('FakeQueue', () => {
 
     expect(() => queue.assertPushed(TestJob)).not.toThrow()
     expect(() => queue.assertPushedTimes(TestJob, 1)).not.toThrow()
-    expect(() => queue.assertPushedOn('default', TestJob)).toThrow()
+    expect(() => queue.assertPushedOn('default', TestJob)).not.toThrow()
+    expect(() => queue.assertPushedOn('critical', TestJob)).toThrow()
   })
 })

--- a/packages/testing/src/test-app.ts
+++ b/packages/testing/src/test-app.ts
@@ -352,15 +352,21 @@ export class TestApp {
     try {
       ;({ Application } = await import('@guren/core') as { Application: ApplicationConstructor })
     } catch {
-      // Fallback: use a plain Hono app when @guren/server is not available.
-      const { Hono } = await import('hono')
-      const hono = new Hono()
-      if (options.boot) {
-        await options.boot(hono)
-      }
+      try {
+        // @guren/core is not always installed (it aggregates @guren/server);
+        // fall back to the peer dependency, which exports the same Application.
+        ;({ Application } = await import('@guren/server') as { Application: ApplicationConstructor })
+      } catch {
+        // Fallback: use a plain Hono app when @guren/server is not available.
+        const { Hono } = await import('hono')
+        const hono = new Hono()
+        if (options.boot) {
+          await options.boot(hono)
+        }
 
-      const fetchFn = (request: Request) => Promise.resolve(hono.fetch(request))
-      return new TestApp(fetchFn)
+        const fetchFn = (request: Request) => Promise.resolve(hono.fetch(request))
+        return new TestApp(fetchFn)
+      }
     }
 
     const application = new Application({

--- a/packages/testing/tests/testing.test.ts
+++ b/packages/testing/tests/testing.test.ts
@@ -20,7 +20,10 @@ import { Hono } from 'hono'
 
 describe('TestResponse', () => {
   function createResponse(body: string, init: ResponseInit = {}): TestResponse {
-    return new TestResponse(new Response(body, init))
+    // Null-body statuses reject any body (even '') in Node's Response.
+    const nullBodyStatuses = [101, 204, 205, 304]
+    const content = nullBodyStatuses.includes(init.status ?? 200) ? null : body
+    return new TestResponse(new Response(content, init))
   }
 
   function createJsonResponse(data: unknown, init: ResponseInit = {}): TestResponse {


### PR DESCRIPTION
## Summary

The packages/testing vitest suite (`cd packages/testing && bun run test`) had 4 failing tests. This suite is the only path that exercises these tests — root `test:bun` excludes packages/testing (its tests are vitest-based), and CI has no step for it — so the failures went unnoticed.

- **`TestApp.create` silently dropped the `routes` registrar under Node** (implementation bug): it dynamically imports `@guren/core`, which is not a dependency of this package, so the import always failed under vitest/Node and fell back to a plain Hono app that ignores `options.routes`. Added a fallback to the `@guren/server` peer dependency, which exports the same `Application`. Apps that have `@guren/core` installed still use it first.
- **Inverted `assertPushedOn` assertion in `src/queue.test.ts`** (test bug): `queue.record(TestJob, { id: 2 })` pushes to the job class default queue (`'default'`), mirroring real dispatch (`options.queue ?? this.queue` in `Job.dispatch`). The test asserted that `assertPushedOn('default', ...)` throws. Now asserts it passes for `'default'` and throws for a non-matching queue.
- **204 Response construction in `tests/testing.test.ts`** (test bug, 2 failures): Node's undici `Response` rejects any body — even `''` — for null-body statuses (101/204/205/304), while Bun tolerates it. The `createResponse` helper now passes `null` for those statuses.

## Scope

testing (packages/testing only; one runtime fix in `TestApp.create`, two test-only fixes)

## Risk Assessment

- `TestApp.create` behavior is unchanged when `@guren/core` is installed (the common case in scaffolded apps). The new `@guren/server` fallback only activates where the old code degraded to a routes-less Hono app, so it strictly fixes previously broken behavior.
- No public API changes.

## Validation

- [x] `bun run build` (packages/testing — tsup + DTS pass)
- [x] `bun run typecheck` (packages/testing)
- [x] `bun run test` in packages/testing — **147 passed (147)**, previously 4 failed
- [x] `bun run test:bun` — 2187 pass, 0 fail

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation. (N/A — no user-facing API change)

## Note for reviewers

CI never runs this vitest suite; adding a `bun run --cwd packages/testing test` step to ci.yml would prevent regressions like these. Left out of this PR to keep it scoped to the fixes.