### PR TITLE
feat(server): add definePlugin helper for plugin authoring

### DIFF
--- a/.changeset/define-plugin.md
+++ b/.changeset/define-plugin.md
@@ -1,0 +1,7 @@
+---
+'@guren/server': minor
+---
+
+Add `definePlugin()` helper for authoring configurable plugins without ServiceProvider boilerplate. Each factory call returns an independent provider class with the configuration captured in a closure, so the same plugin can be registered multiple times with different configurations — replacing the unsafe static-config pattern previously shown in the plugin authoring guide. Supports `deferred`/`provides` for lazy loading. Exported from `@guren/core` alongside `PluginDefinition` and `PluginFactory` types. (RFC 0001, Part A)
+
+`ProviderManager.register()` now throws when a deferred provider declares no `provides` services — previously such a provider was silently dropped and could never load.

--- a/contributing/plugin-contract.md
+++ b/contributing/plugin-contract.md
@@ -58,43 +58,54 @@ export class HeavyServiceProvider extends ServiceProvider {
 | Official (Guren team) | `@guren/plugin-{name}` | `@guren/plugin-vercel`, `@guren/plugin-sentry` |
 | Community | `guren-plugin-{name}` | `guren-plugin-stripe` |
 
-The class itself should follow the `{Name}ServiceProvider` pattern (e.g., `SentryServiceProvider`, `StripeServiceProvider`).
+The primary export should follow the `{name}Plugin` pattern for `definePlugin()` factories (e.g., `sentryPlugin`, `stripePlugin`), or the `{Name}ServiceProvider` pattern for class-based providers (e.g., `SentryServiceProvider`, `StripeServiceProvider`).
 
 ## Required Exports
 
-Every plugin package must export:
+Every plugin package must export one primary entry consumers pass to `createApp({ providers })` — either:
 
-1. **Default ServiceProvider class** -- the primary export consumers pass to `createApp({ providers })`.
+1. **A `definePlugin()` factory** (recommended for configurable plugins; see below), or
+2. **A ServiceProvider class** for plugins that need no configuration or full lifecycle control.
 
 ```typescript
 // src/index.ts
+export { analyticsPlugin } from './plugin'
+// or
 export { AnalyticsServiceProvider } from './AnalyticsServiceProvider'
 ```
 
-### Optional: `definePlugin()` Helper
+> **Note:** The `guren plugin <pkg>` install command currently auto-registers only class exports matching the `{Name}Provider` heuristic. Factory-based plugins must be registered manually in `createApp({ providers })` until manifest-driven installation (RFC 0001, Part B) ships.
 
-For plugins that accept configuration, expose a factory function:
+### Recommended: the `definePlugin()` Helper
+
+For plugins that accept configuration, use the framework-provided `definePlugin()` helper from `@guren/core` instead of hand-rolling a factory. Each factory call produces an independent provider class with the configuration captured in a closure — never store configuration on a static class property, since statics are shared across registrations:
 
 ```typescript
+import { definePlugin } from '@guren/core'
 import type { AnalyticsConfig } from './types'
 
-export function definePlugin(config: AnalyticsConfig) {
-  return class ConfiguredAnalyticsProvider extends AnalyticsServiceProvider {
-    register(): void {
-      this.container.singleton('analytics', () => new AnalyticsClient(config))
-    }
-  }
-}
+export const analyticsPlugin = definePlugin<AnalyticsConfig>({
+  name: 'analytics',
+  register(container, config) {
+    container.singleton('analytics', () => new AnalyticsClient(config))
+  },
+  boot(container, config) {
+    // Optional: post-registration setup
+  },
+  // Optional: deferred loading, same semantics as ServiceProvider statics
+  // deferred: true,
+  // provides: ['analytics'],
+})
 ```
 
 Users can then use:
 
 ```typescript
-import { definePlugin } from 'guren-plugin-analytics'
+import { analyticsPlugin } from 'guren-plugin-analytics'
 
 createApp({
   providers: [
-    definePlugin({ apiKey: 'sk_...' }),
+    analyticsPlugin({ apiKey: 'sk_...' }),
   ],
 })
 ```

--- a/docs/en/guides/plugins.md
+++ b/docs/en/guides/plugins.md
@@ -44,11 +44,13 @@ Key points:
 - `@guren/core` and `@guren/testing` are **dev dependencies** for building and testing.
 - The `gurenPlugin.compatibility` field declares which Guren versions your plugin supports.
 
-## Step 2: Create the ServiceProvider
+## Step 2: Define the Plugin
+
+Use the `definePlugin()` helper from `@guren/core`. It captures your configuration in a closure and returns a factory that produces an independent provider class per call, so the same plugin can be registered twice with different configurations:
 
 ```typescript
-// src/AnalyticsServiceProvider.ts
-import { ServiceProvider } from '@guren/core'
+// src/plugin.ts
+import { definePlugin } from '@guren/core'
 
 export interface AnalyticsConfig {
   apiKey: string
@@ -65,61 +67,36 @@ export class AnalyticsClient {
   }
 }
 
-export class AnalyticsServiceProvider extends ServiceProvider {
-  static config: AnalyticsConfig = { apiKey: '' }
+export const analyticsPlugin = definePlugin<AnalyticsConfig>({
+  name: 'analytics',
 
-  register(): void {
-    this.container.singleton('analytics', () => {
-      return new AnalyticsClient(AnalyticsServiceProvider.config)
-    })
-  }
+  register(container, config) {
+    container.singleton('analytics', () => new AnalyticsClient(config))
+  },
 
-  boot(): void {
+  boot(container) {
     // Subscribe to framework events after all providers are registered
-    if (this.container.has('events')) {
-      const events = this.container.make('events')
-      const analytics = this.container.make<AnalyticsClient>('analytics')
+    if (container.has('events')) {
+      const events = container.make('events')
+      const analytics = container.make<AnalyticsClient>('analytics')
       events.on('request.completed', (data: Record<string, unknown>) => {
         analytics.track('page_view', data)
       })
     }
-  }
-}
+  },
+})
 ```
 
-## Step 3: Export the Provider
+Plugins that are expensive to initialize can pass `deferred: true` together with `provides: ['analytics']` so the provider only loads when one of its services is first resolved.
+
+If you need lifecycle behavior beyond what `definePlugin()` covers, you can still export a `ServiceProvider` subclass directly — the class-based contract is unchanged. Avoid storing configuration on a static class property, though: statics are shared, so registering the plugin twice would silently overwrite the first configuration.
+
+## Step 3: Export the Plugin
 
 ```typescript
 // src/index.ts
-export { AnalyticsServiceProvider, AnalyticsClient } from './AnalyticsServiceProvider'
-export type { AnalyticsConfig } from './AnalyticsServiceProvider'
-
-/**
- * Factory helper for configuring the plugin.
- */
-export function defineAnalyticsPlugin(config: import('./AnalyticsServiceProvider').AnalyticsConfig) {
-  return class ConfiguredAnalyticsProvider extends (
-    require('./AnalyticsServiceProvider').AnalyticsServiceProvider
-  ) {
-    static config = config
-  } as typeof import('./AnalyticsServiceProvider').AnalyticsServiceProvider
-}
-```
-
-A cleaner ESM-only approach:
-
-```typescript
-// src/index.ts
-import { AnalyticsServiceProvider } from './AnalyticsServiceProvider'
-import type { AnalyticsConfig } from './AnalyticsServiceProvider'
-
-export { AnalyticsServiceProvider }
-export type { AnalyticsConfig }
-
-export function defineAnalyticsPlugin(config: AnalyticsConfig) {
-  AnalyticsServiceProvider.config = config
-  return AnalyticsServiceProvider
-}
+export { analyticsPlugin, AnalyticsClient } from './plugin'
+export type { AnalyticsConfig } from './plugin'
 ```
 
 ## Step 4: Add Plugin Metadata
@@ -141,34 +118,28 @@ This tells Guren (and other tooling) which framework versions your plugin is des
 Use `createPluginTestApp` and `assertPluginRegisters` from `@guren/testing`:
 
 ```typescript
-// src/AnalyticsServiceProvider.test.ts
+// src/plugin.test.ts
 import { describe, test, expect } from 'bun:test'
 import { createPluginTestApp, assertPluginRegisters } from '@guren/testing'
-import { AnalyticsServiceProvider, AnalyticsClient } from './AnalyticsServiceProvider'
+import { analyticsPlugin, AnalyticsClient } from './plugin'
 
-describe('AnalyticsServiceProvider', () => {
+describe('analyticsPlugin', () => {
   test('should register the analytics service', async () => {
-    AnalyticsServiceProvider.config = { apiKey: 'test-key' }
-
-    const app = await createPluginTestApp([AnalyticsServiceProvider])
+    const app = await createPluginTestApp([analyticsPlugin({ apiKey: 'test-key' })])
 
     // Verify the service is bound
     assertPluginRegisters(app, ['analytics'])
   })
 
   test('should resolve an AnalyticsClient instance', async () => {
-    AnalyticsServiceProvider.config = { apiKey: 'test-key' }
-
-    const app = await createPluginTestApp([AnalyticsServiceProvider])
+    const app = await createPluginTestApp([analyticsPlugin({ apiKey: 'test-key' })])
 
     const client = app.container.make<AnalyticsClient>('analytics')
     expect(client).toBeInstanceOf(AnalyticsClient)
   })
 
   test('should register as a singleton', async () => {
-    AnalyticsServiceProvider.config = { apiKey: 'test-key' }
-
-    const app = await createPluginTestApp([AnalyticsServiceProvider])
+    const app = await createPluginTestApp([analyticsPlugin({ apiKey: 'test-key' })])
 
     const first = app.container.make<AnalyticsClient>('analytics')
     const second = app.container.make<AnalyticsClient>('analytics')
@@ -180,7 +151,7 @@ describe('AnalyticsServiceProvider', () => {
 Run the tests:
 
 ```bash
-bun test src/AnalyticsServiceProvider.test.ts
+bun test src/plugin.test.ts
 ```
 
 ## Step 6: Build
@@ -217,6 +188,8 @@ bun add @guren/plugin-vercel
 
 The `plugin` command adds the provider import and registers it in `createApp({ providers })` for you.
 
+> **Note:** Automatic registration currently supports class-based provider exports only. Plugins built with `definePlugin()` export a factory that must be called with its configuration, so register them manually in `createApp({ providers })` as shown below.
+
 ## Usage in a Guren Application
 
 Once published, users install and register the plugin:
@@ -228,13 +201,13 @@ bun add guren-plugin-analytics
 ```typescript
 // src/app.ts
 import { createApp } from '@guren/core'
-import { defineAnalyticsPlugin } from 'guren-plugin-analytics'
+import { analyticsPlugin } from 'guren-plugin-analytics'
 import { registerWebRoutes } from '@/routes/web'
 
 export const app = createApp({
   routes: registerWebRoutes,
   providers: [
-    defineAnalyticsPlugin({
+    analyticsPlugin({
       apiKey: process.env.ANALYTICS_API_KEY!,
       endpoint: 'https://analytics.example.com',
     }),

--- a/docs/ja/guides/plugins.md
+++ b/docs/ja/guides/plugins.md
@@ -44,11 +44,13 @@ bun init
 - `@guren/core`と`@guren/testing`はビルドとテスト用の**devDependencies**です。
 - `gurenPlugin.compatibility`フィールドでサポートするGurenバージョンを宣言します。
 
-## ステップ2: ServiceProviderを作成する
+## ステップ2: プラグインを定義する
+
+`@guren/core`の`definePlugin()`ヘルパーを使用します。設定はクロージャに捕捉され、呼び出しごとに独立したプロバイダークラスを生成するため、同じプラグインを異なる設定で複数回登録できます:
 
 ```typescript
-// src/AnalyticsServiceProvider.ts
-import { ServiceProvider } from '@guren/core'
+// src/plugin.ts
+import { definePlugin } from '@guren/core'
 
 export interface AnalyticsConfig {
   apiKey: string
@@ -65,42 +67,36 @@ export class AnalyticsClient {
   }
 }
 
-export class AnalyticsServiceProvider extends ServiceProvider {
-  static config: AnalyticsConfig = { apiKey: '' }
+export const analyticsPlugin = definePlugin<AnalyticsConfig>({
+  name: 'analytics',
 
-  register(): void {
-    this.container.singleton('analytics', () => {
-      return new AnalyticsClient(AnalyticsServiceProvider.config)
-    })
-  }
+  register(container, config) {
+    container.singleton('analytics', () => new AnalyticsClient(config))
+  },
 
-  boot(): void {
+  boot(container) {
     // 全プロバイダーの登録後にフレームワークイベントをサブスクライブ
-    if (this.container.has('events')) {
-      const events = this.container.make('events')
-      const analytics = this.container.make<AnalyticsClient>('analytics')
+    if (container.has('events')) {
+      const events = container.make('events')
+      const analytics = container.make<AnalyticsClient>('analytics')
       events.on('request.completed', (data: Record<string, unknown>) => {
         analytics.track('page_view', data)
       })
     }
-  }
-}
+  },
+})
 ```
 
-## ステップ3: プロバイダーをエクスポートする
+初期化コストの高いプラグインは`deferred: true`と`provides: ['analytics']`を併せて指定すると、提供するサービスが最初に解決されるまでプロバイダーの読み込みを遅延できます。
+
+`definePlugin()`でカバーできないライフサイクル制御が必要な場合は、従来通り`ServiceProvider`のサブクラスを直接エクスポートすることもできます。ただし設定をstaticプロパティに保存するのは避けてください。staticは共有されるため、プラグインを2回登録すると最初の設定が上書きされます。
+
+## ステップ3: プラグインをエクスポートする
 
 ```typescript
 // src/index.ts
-import { AnalyticsServiceProvider } from './AnalyticsServiceProvider'
-import type { AnalyticsConfig } from './AnalyticsServiceProvider'
-
-export { AnalyticsServiceProvider }
-export type { AnalyticsConfig }
-
-export function defineAnalyticsPlugin(config: AnalyticsConfig) {
-  AnalyticsServiceProvider.config = config
-  return AnalyticsServiceProvider
-}
+export { analyticsPlugin, AnalyticsClient } from './plugin'
+export type { AnalyticsConfig } from './plugin'
 ```
 
 ## ステップ4: プラグインメタデータを追加する
@@ -122,34 +118,28 @@ export function defineAnalyticsPlugin(config: AnalyticsConfig) {
 `@guren/testing`の`createPluginTestApp`と`assertPluginRegisters`を使用します:
 
 ```typescript
-// src/AnalyticsServiceProvider.test.ts
+// src/plugin.test.ts
 import { describe, test, expect } from 'bun:test'
 import { createPluginTestApp, assertPluginRegisters } from '@guren/testing'
-import { AnalyticsServiceProvider, AnalyticsClient } from './AnalyticsServiceProvider'
+import { analyticsPlugin, AnalyticsClient } from './plugin'
 
-describe('AnalyticsServiceProvider', () => {
+describe('analyticsPlugin', () => {
   test('analyticsサービスが登録されること', async () => {
-    AnalyticsServiceProvider.config = { apiKey: 'test-key' }
-
-    const app = await createPluginTestApp([AnalyticsServiceProvider])
+    const app = await createPluginTestApp([analyticsPlugin({ apiKey: 'test-key' })])
 
     // サービスがバインドされていることを確認
     assertPluginRegisters(app, ['analytics'])
   })
 
   test('AnalyticsClientインスタンスが解決されること', async () => {
-    AnalyticsServiceProvider.config = { apiKey: 'test-key' }
-
-    const app = await createPluginTestApp([AnalyticsServiceProvider])
+    const app = await createPluginTestApp([analyticsPlugin({ apiKey: 'test-key' })])
 
     const client = app.container.make<AnalyticsClient>('analytics')
     expect(client).toBeInstanceOf(AnalyticsClient)
   })
 
   test('シングルトンとして登録されること', async () => {
-    AnalyticsServiceProvider.config = { apiKey: 'test-key' }
-
-    const app = await createPluginTestApp([AnalyticsServiceProvider])
+    const app = await createPluginTestApp([analyticsPlugin({ apiKey: 'test-key' })])
 
     const first = app.container.make<AnalyticsClient>('analytics')
     const second = app.container.make<AnalyticsClient>('analytics')
@@ -161,7 +151,7 @@ describe('AnalyticsServiceProvider', () => {
 テストを実行:
 
 ```bash
-bun test src/AnalyticsServiceProvider.test.ts
+bun test src/plugin.test.ts
 ```
 
 ## ステップ6: ビルドする
@@ -198,6 +188,8 @@ bun add @guren/plugin-vercel
 
 `plugin`コマンドがプロバイダーのimportを追加し、`createApp({ providers })`への登録を自動で行います。
 
+> **注意:** 自動登録が現在対応しているのはクラスベースのプロバイダーエクスポートのみです。`definePlugin()`で作成したプラグインは設定を渡してファクトリを呼び出す必要があるため、下記のように`createApp({ providers })`へ手動で登録してください。
+
 ## Gurenアプリケーションでの使用方法
 
 公開後、ユーザーはプラグインをインストールして登録します:
@@ -209,13 +201,13 @@ bun add guren-plugin-analytics
 ```typescript
 // src/app.ts
 import { createApp } from '@guren/core'
-import { defineAnalyticsPlugin } from 'guren-plugin-analytics'
+import { analyticsPlugin } from 'guren-plugin-analytics'
 import { registerWebRoutes } from '@/routes/web'
 
 export const app = createApp({
   routes: registerWebRoutes,
   providers: [
-    defineAnalyticsPlugin({
+    analyticsPlugin({
       apiKey: process.env.ANALYTICS_API_KEY!,
       endpoint: 'https://analytics.example.com',
     }),

--- a/packages/server/src/container/ServiceProvider.ts
+++ b/packages/server/src/container/ServiceProvider.ts
@@ -2,6 +2,11 @@ import type { Container } from './Container'
 import type { Provider } from './types'
 
 /**
+ * Constructor shape accepted wherever a provider class can be registered.
+ */
+export type ServiceProviderConstructor = new (container: Container) => ServiceProvider
+
+/**
  * Base service provider class.
  *
  * Service providers are the central place of all application bootstrapping.
@@ -79,9 +84,7 @@ export class ProviderManager {
   /**
    * Register a provider.
    */
-  register(
-    providerOrClass: ServiceProvider | (new (container: Container) => ServiceProvider)
-  ): this {
+  register(providerOrClass: ServiceProvider | ServiceProviderConstructor): this {
     if (this.allBooted) {
       const name =
         providerOrClass instanceof ServiceProvider
@@ -98,6 +101,13 @@ export class ProviderManager {
         ? providerOrClass
         : new providerOrClass(this.container)
 
+    if (provider.isDeferred() && provider.provides().length === 0) {
+      throw new Error(
+        `Deferred provider "${provider.constructor.name}" must declare at least one service in "provides", ` +
+        'otherwise it can never be loaded.',
+      )
+    }
+
     // Deferred providers are loaded on-demand when Container.make() is called
     if (provider.isDeferred()) {
       for (const service of provider.provides()) {
@@ -113,9 +123,7 @@ export class ProviderManager {
   /**
    * Register multiple providers.
    */
-  registerMany(
-    providers: Array<ServiceProvider | (new (container: Container) => ServiceProvider)>
-  ): this {
+  registerMany(providers: Array<ServiceProvider | ServiceProviderConstructor>): this {
     for (const provider of providers) {
       this.register(provider)
     }

--- a/packages/server/src/container/definePlugin.test.ts
+++ b/packages/server/src/container/definePlugin.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect } from 'bun:test'
+import { Container } from './Container'
+import { ProviderManager, type ServiceProviderConstructor } from './ServiceProvider'
+import { definePlugin } from './definePlugin'
+
+interface FakeClientConfig {
+  apiKey: string
+}
+
+class FakeClient {
+  constructor(public config: FakeClientConfig) {}
+}
+
+const fakePlugin = definePlugin<FakeClientConfig>({
+  name: 'fake-analytics',
+  register(container, config) {
+    container.singleton('fake-analytics', () => new FakeClient(config))
+  },
+})
+
+async function bootWith(providers: ServiceProviderConstructor[]) {
+  const container = new Container()
+  const manager = new ProviderManager(container)
+  manager.registerMany(providers)
+  await manager.registerAll()
+  await manager.bootAll()
+  return { container, manager }
+}
+
+describe('definePlugin', () => {
+  test('should register services with the captured config', async () => {
+    const { container } = await bootWith([fakePlugin({ apiKey: 'key-1' })])
+
+    const client = container.make<FakeClient>('fake-analytics')
+    expect(client).toBeInstanceOf(FakeClient)
+    expect(client.config.apiKey).toBe('key-1')
+  })
+
+  test('should isolate config between factory calls', async () => {
+    const first = fakePlugin({ apiKey: 'first' })
+    const second = fakePlugin({ apiKey: 'second' })
+
+    const { container: containerA } = await bootWith([first])
+    const { container: containerB } = await bootWith([second])
+
+    expect(containerA.make<FakeClient>('fake-analytics').config.apiKey).toBe('first')
+    expect(containerB.make<FakeClient>('fake-analytics').config.apiKey).toBe('second')
+  })
+
+  test('should run boot after register', async () => {
+    const order: string[] = []
+    const plugin = definePlugin({
+      name: 'ordered',
+      register() {
+        order.push('register')
+      },
+      boot() {
+        order.push('boot')
+      },
+    })
+
+    await bootWith([plugin()])
+    expect(order).toEqual(['register', 'boot'])
+  })
+
+  test('should pass the container to boot', async () => {
+    const plugin = definePlugin<{ label: string }>({
+      name: 'boot-access',
+      register(container, config) {
+        container.instance('label', config.label)
+      },
+      boot(container, config) {
+        container.instance('booted-label', `${container.make<string>('label')}:${config.label}`)
+      },
+    })
+
+    const { container } = await bootWith([plugin({ label: 'x' })])
+    expect(container.make<string>('booted-label')).toBe('x:x')
+  })
+
+  test('should support deferred providers', async () => {
+    let registered = false
+    const plugin = definePlugin({
+      name: 'lazy',
+      deferred: true,
+      provides: ['lazy-service'],
+      register(container) {
+        registered = true
+        container.singleton('lazy-service', () => 'ready')
+      },
+    })
+
+    const { container, manager } = await bootWith([plugin()])
+
+    expect(registered).toBe(false)
+    await manager.loadDeferredProvider('lazy-service')
+    expect(registered).toBe(true)
+    expect(container.make<string>('lazy-service')).toBe('ready')
+  })
+
+  test('should derive the provider class name from the plugin name', () => {
+    const provider = fakePlugin({ apiKey: 'x' })
+    expect(provider.name).toBe('fake-analyticsPluginProvider')
+  })
+})

--- a/packages/server/src/container/definePlugin.ts
+++ b/packages/server/src/container/definePlugin.ts
@@ -1,0 +1,91 @@
+import type { Container } from './Container'
+import { ServiceProvider, type ServiceProviderConstructor } from './ServiceProvider'
+
+/**
+ * Declarative definition of a plugin's lifecycle hooks.
+ *
+ * `register` and `boot` mirror the ServiceProvider hooks and receive the
+ * container plus the configuration captured by the plugin factory.
+ */
+export interface PluginDefinition<TConfig = void> {
+  /**
+   * Diagnostic name for the plugin (e.g. 'analytics').
+   * Used to derive the generated provider class name.
+   */
+  name: string
+
+  /**
+   * Register services into the container.
+   * Called before any provider has booted.
+   */
+  register(container: Container, config: TConfig): void | Promise<void>
+
+  /**
+   * Bootstrap after all providers have registered.
+   */
+  boot?(container: Container, config: TConfig): void | Promise<void>
+
+  /**
+   * Defer instantiation until one of the `provides` services is resolved.
+   * Maps to `ServiceProvider.deferred`.
+   */
+  deferred?: boolean
+
+  /**
+   * Services bound by this plugin (required when `deferred` is true).
+   * Maps to `ServiceProvider.provides`.
+   */
+  provides?: string[]
+}
+
+/**
+ * A factory returned by `definePlugin()`. Each call produces an independent
+ * ServiceProvider subclass with the given configuration captured in a closure.
+ */
+export type PluginFactory<TConfig = void> = (config: TConfig) => ServiceProviderConstructor
+
+/**
+ * Define a configurable Guren plugin without ServiceProvider boilerplate.
+ *
+ * Unlike storing configuration on a static class property, each factory call
+ * returns a fresh provider class, so the same plugin can be registered twice
+ * with different configurations.
+ *
+ * @example
+ * ```typescript
+ * export const analyticsPlugin = definePlugin<AnalyticsConfig>({
+ *   name: 'analytics',
+ *   register(container, config) {
+ *     container.singleton('analytics', () => new AnalyticsClient(config))
+ *   },
+ * })
+ *
+ * // In the application:
+ * createApp({
+ *   providers: [analyticsPlugin({ apiKey: process.env.ANALYTICS_API_KEY! })],
+ * })
+ * ```
+ */
+export function definePlugin<TConfig = void>(
+  definition: PluginDefinition<TConfig>,
+): PluginFactory<TConfig> {
+  const className = `${definition.name}PluginProvider`
+
+  return (config: TConfig) => {
+    class ConfiguredPluginProvider extends ServiceProvider {
+      static override deferred = definition.deferred ?? false
+      static override provides = definition.provides ?? []
+
+      register(): void | Promise<void> {
+        return definition.register(this.container, config)
+      }
+
+      override boot(): void | Promise<void> {
+        return definition.boot?.(this.container, config)
+      }
+    }
+
+    Object.defineProperty(ConfiguredPluginProvider, 'name', { value: className })
+    return ConfiguredPluginProvider
+  }
+}

--- a/packages/server/src/container/index.ts
+++ b/packages/server/src/container/index.ts
@@ -21,3 +21,6 @@ export {
 } from './Container'
 
 export { ServiceProvider, ProviderManager } from './ServiceProvider'
+
+export { definePlugin } from './definePlugin'
+export type { PluginDefinition, PluginFactory } from './definePlugin'

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import type { MiddlewareHandler, ExecutionContext } from 'hono'
 import { Router } from '../mvc/Router'
 import { Container, type ServiceProvider } from '../container'
-import { ProviderManager } from '../container/ServiceProvider'
+import { ProviderManager, type ServiceProviderConstructor } from '../container/ServiceProvider'
 import { AuthManager } from '../auth/AuthManager'
 import { AuthServiceProvider } from '../providers/AuthServiceProvider'
 import { AuthorizationServiceProvider } from '../providers/AuthorizationServiceProvider'
@@ -122,7 +122,7 @@ export type BootCallback = (app: Hono) => void | Promise<void>
 /**
  * Service provider class constructor type.
  */
-export type ServiceProviderConstructor = new (container: Container) => ServiceProvider
+export type { ServiceProviderConstructor } from '../container/ServiceProvider'
 export type RouteRegistration = (router: Router) => void | Promise<void>
 export type ApplicationFeatures = Record<string, unknown>
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -633,8 +633,11 @@ export {
   resolve,
   ServiceProvider,
   ProviderManager,
+  definePlugin,
 } from './container'
 export type {
+  PluginDefinition,
+  PluginFactory,
   ServiceFactory,
   ServiceClass,
   ServiceBinding,

--- a/packages/server/tests/container/container.test.ts
+++ b/packages/server/tests/container/container.test.ts
@@ -409,6 +409,18 @@ describe('ProviderManager', () => {
     expect(manager.getProviders()).toHaveLength(1)
   })
 
+  it('should throw when a deferred provider declares no provided services', () => {
+    class BrokenDeferredProvider extends ServiceProvider {
+      static deferred = true
+
+      register(): void {}
+    }
+
+    expect(() => manager.register(BrokenDeferredProvider)).toThrow(
+      'must declare at least one service in "provides"',
+    )
+  })
+
   it('should register all providers', async () => {
     class Provider1 extends ServiceProvider {
       register(): void {

--- a/rfcs/0001-plugin-system.md
+++ b/rfcs/0001-plugin-system.md
@@ -1,0 +1,254 @@
+# RFC: First-class Plugin System
+
+**Author:** Urata Daiki
+**Date:** 2026-07-20
+**Status:** Accepted
+
+## Problem
+
+Guren already has the runtime foundation of a plugin system: `ServiceProvider`
+(register/boot lifecycle, deferred providers), `createApp({ providers })`,
+`@guren/plugin-vercel` as the first official plugin, a plugin authoring guide
+(`docs/*/guides/plugins.md`), a plugin contract (`contributing/plugin-contract.md`),
+test helpers (`createPluginTestApp`, `assertPluginRegisters`), and a
+`guren plugin <pkg>` CLI command that patches `src/app.ts`.
+
+However, several promises in the documentation are not backed by code, and the
+tooling around the contract is incomplete:
+
+1. **`gurenPlugin.compatibility` is never read.** The contract says "the
+   framework may read this field at boot time to warn about incompatible
+   plugins", but no code anywhere reads the `gurenPlugin` field. Users get no
+   warning when installing a plugin built for an incompatible Guren version.
+2. **"Plugins can add CLI commands" has no mechanism.** The contract lists
+   "Add CLI commands by registering them through the container" under what
+   plugins CAN do, but `packages/cli/src/bin.ts` is a static citty command tree
+   with no extension point. The claim is currently false.
+3. **The documented configuration pattern is unsafe.** The authoring guide's
+   "cleaner ESM-only approach" mutates a static `config` property on the shared
+   provider class. Two `defineAnalyticsPlugin()` calls with different configs
+   silently share the last config. There is no framework-provided helper, so
+   every plugin author hand-rolls this (and can get it wrong the same way).
+4. **`guren plugin` is minimal and partially hardcoded.** It patches
+   `src/app.ts` but does not install the dependency (prints "Run: bun add ..."),
+   does not check compatibility, and the extra scaffolding for official plugins
+   is hardcoded per package (`plugin-vercel.ts`). Community plugins cannot ship
+   config stubs, env keys, or migrations that install cleanly.
+
+## Proposed Solution
+
+Three deliverables, shippable as three independent PRs. All are additive
+(minor-release safe).
+
+### Part A: `definePlugin()` helper
+
+A framework-provided factory in `@guren/server` (auto-exported via
+`@guren/core`) that replaces the hand-rolled configured-provider pattern:
+
+```typescript
+// packages/server/src/container/definePlugin.ts
+import { ServiceProvider } from './ServiceProvider'
+import type { Container } from './Container'
+import type { ServiceProviderConstructor } from '../http/Application'
+
+export interface PluginDefinition<TConfig = void> {
+  /** Diagnostic name, e.g. 'analytics'. Used in error messages and doctor output. */
+  name: string
+  register(container: Container, config: TConfig): void | Promise<void>
+  boot?(container: Container, config: TConfig): void | Promise<void>
+  /** Maps to ServiceProvider.deferred / .provides */
+  deferred?: boolean
+  provides?: string[]
+}
+
+export function definePlugin<TConfig = void>(
+  definition: PluginDefinition<TConfig>,
+): (config: TConfig) => ServiceProviderConstructor
+```
+
+The returned factory captures `config` in a closure and produces a fresh
+`ServiceProvider` subclass per call — no shared static state:
+
+```typescript
+// Plugin side
+export const analyticsPlugin = definePlugin<AnalyticsConfig>({
+  name: 'analytics',
+  register(container, config) {
+    container.singleton('analytics', () => new AnalyticsClient(config))
+  },
+  boot(container) {
+    const events = container.make('events')
+    events.on('request.completed', (data) =>
+      container.make<AnalyticsClient>('analytics').track('page_view', data))
+  },
+})
+
+// App side
+createApp({
+  providers: [analyticsPlugin({ apiKey: process.env.ANALYTICS_API_KEY! })],
+})
+```
+
+Class-based `ServiceProvider` plugins remain fully supported; `definePlugin`
+is sugar, not a new contract. The authoring guide's static-mutation example is
+replaced with this helper, and the contract's "Optional: definePlugin()"
+section now points at the framework helper instead of a per-plugin recipe.
+
+**Middleware/container rule (documented, not new API):** plugins that add
+middleware must capture the services they need in a closure during `boot()`.
+The Hono context does not carry the container, and this RFC does not change
+that.
+
+### Part B: `guren add` and the `gurenPlugin` manifest
+
+#### Manifest schema (declarative only)
+
+Extend the existing `gurenPlugin` package.json field:
+
+```jsonc
+{
+  "gurenPlugin": {
+    // Existing, now actually enforced
+    "compatibility": ">=1.0.0",
+    // Named export to register in createApp({ providers }).
+    // Optional; falls back to the current name heuristic (e.g.
+    // @guren/plugin-vercel -> GurenPluginVercelProvider).
+    "provider": "AnalyticsServiceProvider",
+    // Keys appended to .env.example (and .env if present) when missing
+    "env": [
+      { "key": "ANALYTICS_API_KEY", "value": "", "comment": "Analytics API key" }
+    ],
+    // Files copied from the package into the app (skip if target exists,
+    // unless --force)
+    "publishes": [
+      { "from": "stubs/config.ts", "to": "config/analytics.ts" }
+    ],
+    // Part C (CLI commands), see below
+    "commands": { "entry": "./dist/commands.js", "names": ["analytics:flush"] }
+  }
+}
+```
+
+Security constraints, aligned with Guren's secure-by-default stance:
+
+- `guren add` **never imports or executes plugin code**. The manifest is pure
+  JSON data; there is no Adonis-style executable `configure` script.
+- `publishes.to` is restricted to an allowlist of app directories
+  (`config/`, `db/migrations/`, `resources/`); paths are normalized and
+  path-traversal (`..`, absolute paths, symlink escapes) is rejected on both
+  `from` and `to`.
+- Existing files are never overwritten without `--force`.
+
+#### Command behavior
+
+`guren add <pkg>` (new primary name; `guren plugin` stays as a hidden alias
+for backward compatibility):
+
+1. If `<pkg>` is not in the app's dependencies, run `bun add <pkg>`
+   (`--no-install` opts out and prints the command instead).
+2. Read `node_modules/<pkg>/package.json` → `gurenPlugin` manifest.
+3. Check `compatibility` against the installed `@guren/core` version using
+   `Bun.semver.satisfies` (no new dependency; the CLI is Bun-only). Warn and
+   require `--force` to proceed on mismatch.
+4. Patch `src/app.ts` via the existing `addImport`/`addProvider` helpers,
+   using `gurenPlugin.provider` when present.
+5. Apply `publishes` and `env` entries.
+6. Print a summary of every file touched and remaining manual steps.
+
+`@guren/plugin-vercel`'s hardcoded installer (`cli/src/plugin-vercel.ts`)
+migrates to this manifest; the hardcoded path is kept for one minor release,
+then deleted.
+
+`guren doctor` gains a check: for every direct dependency with a `gurenPlugin`
+field, verify `compatibility` against the installed core version and flag
+mismatches. This makes the contract's "the framework may warn about
+incompatible plugins" true — at install time and diagnosis time, with zero
+boot-time cost.
+
+### Part C: CLI command extension point
+
+Plugins declare commands statically in the manifest (`commands.names`) and
+implement them in a module (`commands.entry`) that default-exports a record of
+citty commands:
+
+```typescript
+// plugin: src/commands.ts
+import { defineCommand } from 'citty'
+
+export default {
+  'analytics:flush': defineCommand({
+    meta: { name: 'analytics:flush', description: 'Flush queued events' },
+    async run() { /* ... */ },
+  }),
+}
+```
+
+Resolution in `bin.ts`:
+
+- Discovery reads the **app's** package.json direct dependencies (and
+  devDependencies), then reads each dependency's package.json looking for
+  `gurenPlugin.commands`. This is a handful of `readFile` calls at CLI
+  startup; no plugin code runs.
+- `guren --help` lists plugin command names from `commands.names` without
+  importing anything.
+- Invoking a plugin command dynamically imports `commands.entry` and runs the
+  matching command. Executing plugin code here requires the same trust the
+  user already extended by installing the package and registering its
+  provider — and only happens on explicit invocation.
+- Plugin command names **must** contain a `:` namespace; un-namespaced names
+  are rejected at discovery with a warning.
+- Conflicts: built-in commands always win. Two plugins declaring the same
+  name is an error naming both packages.
+
+## Alternatives Considered
+
+- **Laravel-style auto-discovery** (register providers automatically from
+  node_modules): rejected. Code executing because a package landed in
+  node_modules contradicts Guren's opt-in security posture (`GUREN_MCP=1`,
+  `GUREN_TESTING`, explicit provider lists). Explicit registration stays;
+  `guren add` automates the writing, not the deciding.
+- **Adonis-style executable configure script** (`node ace add` runs the
+  package's `configure.ts`): rejected in favor of the declarative manifest.
+  Arbitrary install-time code execution is a supply-chain foothold; the
+  manifest covers the common cases (provider, config stub, env, migrations)
+  without it. If a plugin genuinely needs imperative setup, it documents
+  manual steps.
+- **Boot-time compatibility checking**: rejected. It taxes every cold start
+  (relevant for Lambda/Vercel) to catch a problem that is knowable at install
+  time. `guren add` + `guren doctor` cover it.
+- **Container-registered CLI commands** (what the contract currently claims):
+  rejected. It would require booting the full application to enumerate
+  commands, making `--help` slow and coupling the CLI to app boot success.
+  The static manifest keeps listing free and execution lazy.
+
+## Migration Path
+
+No breaking changes.
+
+- `definePlugin` is additive; existing class-based plugins keep working.
+- `guren plugin` remains as an alias of `guren add`.
+- Plugins without a `gurenPlugin` manifest still install via the name
+  heuristic exactly as today; the manifest only unlocks the extra steps.
+- Docs changes: replace the static-config pattern in the authoring guide
+  (en/ja), update the contract's CLI-commands claim to describe the real
+  mechanism, and change "may read this field at boot" to "checked by
+  `guren add` and `guren doctor`".
+
+## Implementation Order
+
+1. **PR 1 (server, docs):** `definePlugin` + tests + guide/contract updates.
+2. **PR 2 (cli):** `guren add` (manifest, compat check, publishes/env,
+   `bun add`), doctor check, plugin-vercel manifest migration.
+3. **PR 3 (cli):** command extension point + `make:*` template for plugin
+   commands modules.
+
+## Open Questions
+
+- Should `publishes` support a `migrations` shorthand that timestamps files
+  into `db/migrations/` on copy (so repeated `guren add` runs don't duplicate
+  them), or is plain file copy with skip-if-exists enough for v1?
+- Should `guren add` run `bun add` by default, or print the command and
+  require `--install`? (This RFC proposes install-by-default with
+  `--no-install`, matching Adonis DX.)
+- Do we want a `guren remove <pkg>` inverse (unregister provider, leave
+  published files)? Deferred unless demand appears.


### PR DESCRIPTION
## Summary

Implements Part A of RFC 0001 (added in this PR as `rfcs/0001-plugin-system.md`): a first-class `definePlugin()` helper for authoring configurable Guren plugins without ServiceProvider boilerplate.

Each factory call returns an independent provider class with the configuration captured in a closure, so the same plugin can be registered multiple times with different configurations. This replaces the static-config pattern previously shown in the plugin authoring guide, which silently shared the last configuration across all registrations.

## Changes

- **`@guren/server`**: new `definePlugin()` in `src/container/definePlugin.ts`, exported with `PluginDefinition`/`PluginFactory` types (auto-available from `@guren/core`). Supports `deferred`/`provides` for lazy loading.
- **Layering**: `ServiceProviderConstructor` moved to `container/ServiceProvider.ts` (its natural home) and re-exported from `Application.ts` for compatibility, removing three inline copies of the constructor shape.
- **Fail-fast**: `ProviderManager.register()` now throws when a deferred provider declares no `provides` services — previously such a provider was silently dropped and could never load. Guarded at the manager level so class-based providers benefit too.
- **Docs**: plugin authoring guides (en/ja) and `contributing/plugin-contract.md` rewritten to teach `definePlugin()` as the recommended path, keep class-based providers as the documented escape hatch, and note that `guren plugin <pkg>` currently auto-registers class exports only (manifest-driven install lands with RFC 0001 Part B).
- **RFC 0001** (accepted): plugin system design — `definePlugin`, `gurenPlugin` manifest + `guren add`, CLI command extension point.

## Test plan

- New unit tests for `definePlugin` (config capture, isolation between factory calls, register/boot order, deferred loading, generated class name)
- New test for the deferred-without-provides guard in `ProviderManager`
- `bun run build:clean`, `bun run typecheck`, `bun run test:bun` (2198 pass), `bun run test:examples` (12 pass), `bun run audit:core-first`, `bun run audit:docs` — all green