### PR TITLE
ci: run packages/testing vitest suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Run tests
         run: bun run test
 
+      - name: Testing package tests (vitest)
+        run: bun run test:testing
+
   sqlite-smoke:
     runs-on: ubuntu-latest
     # No redis service — verifies all tests gracefully skip when Redis is unavailable

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "version-packages": "changeset version && bun install",
     "release": "bun run build && changeset publish",
     "test:bun": "bun test packages/server packages/orm packages/core packages/inertia-client packages/create-app packages/cli packages/openapi packages/plugin-vercel",
+    "test:testing": "bun run --cwd packages/testing test",
     "test:examples": "bun run --cwd examples/blog test && bun run --cwd examples/api test && bun run --cwd web test",
     "test": "bun run test:bun && bun run test:examples",
     "typecheck": "tsc --noEmit && bun run typecheck:blog && bun run typecheck:api",


### PR DESCRIPTION
## Summary

The vitest suite in `packages/testing` (148 tests) was never executed in CI: the root `test:bun` script cannot include it (`bun test` does not run vitest files) and `ci.yml` had no vitest step. This PR wires the suite into the `build-and-test` job.

Note: while preparing this PR, 4 pre-existing failures in the suite were found (root-caused to an unreachable `@guren/core` import in `TestApp.create`, an inverted assertion in `queue.test.ts`, and a null-body `Response` bug in a test helper). Those fixes landed separately in #110 and this branch has been rebased on top of them, so this PR now contains only the CI wiring.

**CI wiring**
- Add root script `test:testing` (`bun run --cwd packages/testing test`) and run it in the `build-and-test` job after `bun run build` (the suite resolves `@guren/server` from `dist`).

## Scope

- ci (`.github/workflows/ci.yml`), root `package.json`

## Risk Assessment

- CI gains one step in `build-and-test`; suite runtime is under a second.
- No public API changes.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` (`test:bun`: 2191 pass / 0 fail; `test:examples`: all green)
- [x] `bun run test:testing` — 148/148 passed

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes. (n/a — CI-only change; tests already fixed in #110)
- [ ] I updated relevant documentation. (n/a)