### PR TITLE
feat(cli): manifest-driven plugin install and doctor compatibility check

### DIFF
--- a/.changeset/plugin-manifest-install.md
+++ b/.changeset/plugin-manifest-install.md
@@ -1,0 +1,6 @@
+---
+'@guren/cli': minor
+'@guren/plugin-vercel': patch
+---
+
+Turn `guren plugin <pkg>` into a full plugin installer driven by the declarative `gurenPlugin` package.json manifest (RFC 0001, Part B). The command now installs the dependency with `bun add` when missing (`--no-install` to skip), verifies the plugin's declared Guren `compatibility` range against the installed `@guren/core` (`--ignore-compatibility` to override), registers the manifest-declared `provider` export (falling back to the name heuristic), copies declared `publishes` files into `config/`, `db/migrations/`, or `resources/` (path-traversal guarded, never overwriting without `--force`), and appends declared `env` keys to `.env.example`/`.env`. The manifest is pure data — no plugin code is executed during installation. The command is now also registered at the top level (`bunx guren plugin ...` previously only worked as `guren add plugin ...` despite being documented). `bunx guren doctor` gains a Plugin Compatibility check that flags installed plugins whose `compatibility` range excludes the installed core version. `@guren/plugin-vercel` now declares its `gurenPlugin` manifest.

--- a/contributing/plugin-contract.md
+++ b/contributing/plugin-contract.md
@@ -74,7 +74,7 @@ export { analyticsPlugin } from './plugin'
 export { AnalyticsServiceProvider } from './AnalyticsServiceProvider'
 ```
 
-> **Note:** The `guren plugin <pkg>` install command currently auto-registers only class exports matching the `{Name}Provider` heuristic. Factory-based plugins must be registered manually in `createApp({ providers })` until manifest-driven installation (RFC 0001, Part B) ships.
+> **Note:** `bunx guren plugin <pkg>` registers the class export named by `gurenPlugin.provider`, falling back to the `{PascalPkg}Provider` name heuristic when the field is absent. `definePlugin()` factories must be called with their configuration, so register them manually in `createApp({ providers })`.
 
 ### Recommended: the `definePlugin()` Helper
 
@@ -119,10 +119,13 @@ Every plugin must declare a `gurenPlugin` field in its `package.json`:
   "name": "guren-plugin-analytics",
   "version": "1.0.0",
   "gurenPlugin": {
-    "compatibility": ">=0.2.0"
+    "compatibility": ">=1.0.0",
+    "provider": "AnalyticsServiceProvider",
+    "env": [{ "key": "ANALYTICS_API_KEY", "comment": "Analytics API key" }],
+    "publishes": [{ "from": "stubs/analytics.ts", "to": "config/analytics.ts" }]
   },
   "peerDependencies": {
-    "@guren/core": ">=0.2.0"
+    "@guren/core": ">=1.0.0"
   }
 }
 ```
@@ -130,8 +133,11 @@ Every plugin must declare a `gurenPlugin` field in its `package.json`:
 | Field | Type | Description |
 |-------|------|-------------|
 | `gurenPlugin.compatibility` | semver range | Guren versions this plugin supports |
+| `gurenPlugin.provider` | string | Named class export registered by `bunx guren plugin`; omit for `definePlugin()` factories |
+| `gurenPlugin.env` | array | Env keys appended to the app's `.env.example` (and `.env` when present) at install time |
+| `gurenPlugin.publishes` | array | Files copied into the app at install time (`config/`, `db/migrations/`, `resources/` targets only) |
 
-The framework may read this field at boot time to warn about incompatible plugins.
+The manifest is declarative data only — the CLI never imports or executes plugin code during installation. `compatibility` is verified by `bunx guren plugin` at install time and by `bunx guren doctor`; there is no boot-time cost.
 
 ## What Plugins CAN Do
 

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -35,10 +35,10 @@ bunx guren add schedule
 > **Golden path:** Start with `bunx guren add auth` and `bunx guren add resource`, then add more features as your app grows.
 
 ```bash
-bunx guren add plugin @acme/guren-plugin-audit
+bunx guren plugin @acme/guren-plugin-audit
 ```
 
-`add plugin` wires the plugin provider into `src/app.ts` and prints a `bun add <package>` hint when the dependency is not installed yet.
+`plugin` (also available as `add plugin`) installs the package with `bun add` when missing (pass `--no-install` to skip), verifies the plugin's declared Guren compatibility (`--ignore-compatibility` to override), wires the provider into `src/app.ts`, and applies any config stubs and env keys the plugin declares in its `gurenPlugin` manifest. `--force` overwrites already-published files.
 
 
 These commands patch `src/app.ts`, create the matching provider/runtime files, and keep the generated app aligned with the reference starter.

--- a/docs/en/guides/plugins.md
+++ b/docs/en/guides/plugins.md
@@ -106,12 +106,26 @@ Your `package.json` must include the `gurenPlugin` field:
 ```json
 {
   "gurenPlugin": {
-    "compatibility": ">=1.0.0"
+    "compatibility": ">=1.0.0",
+    "provider": "AnalyticsServiceProvider",
+    "env": [
+      { "key": "ANALYTICS_API_KEY", "comment": "Analytics service API key" }
+    ],
+    "publishes": [
+      { "from": "stubs/analytics.ts", "to": "config/analytics.ts" }
+    ]
   }
 }
 ```
 
-This tells Guren (and other tooling) which framework versions your plugin is designed for.
+| Field | Purpose |
+|-------|---------|
+| `compatibility` | Semver range of Guren versions your plugin supports. Verified by `bunx guren plugin` at install time and by `bunx guren doctor`. |
+| `provider` | Named class export for `bunx guren plugin` to register in `createApp({ providers })`. Omit for `definePlugin()` factories (registered manually). |
+| `env` | Env keys appended to the app's `.env.example` (and `.env` when present) at install time. |
+| `publishes` | Files copied from your package into the app (`config/`, `db/migrations/`, or `resources/` only). Existing files are never overwritten without `--force`. |
+
+The manifest is pure data — the CLI never executes plugin code during installation.
 
 ## Step 5: Write Tests
 
@@ -177,16 +191,15 @@ bun run build
 npm publish
 ```
 
-## Installing Official Plugins
+## Installing Plugins
 
-Official plugins (`@guren/plugin-*`) can be installed via the CLI, which patches `src/app.ts` and scaffolds any extra files automatically:
+Any plugin — official (`@guren/plugin-*`) or community (`guren-plugin-*`) — can be installed via the CLI:
 
 ```bash
 bunx guren plugin @guren/plugin-vercel
-bun add @guren/plugin-vercel
 ```
 
-The `plugin` command adds the provider import and registers it in `createApp({ providers })` for you.
+The `plugin` command installs the package with `bun add` when missing (pass `--no-install` to skip), verifies the plugin's declared Guren compatibility (`--ignore-compatibility` to register anyway), adds the provider import, registers it in `createApp({ providers })`, and applies any `env` and `publishes` entries from the plugin's `gurenPlugin` manifest. `--force` overwrites already-published files.
 
 > **Note:** Automatic registration currently supports class-based provider exports only. Plugins built with `definePlugin()` export a factory that must be called with its configuration, so register them manually in `createApp({ providers })` as shown below.
 

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -34,10 +34,10 @@ bunx guren add schedule
 > **Golden path:** まず `bunx guren add auth` と `bunx guren add resource` から始め、アプリの成長に応じて他の機能を追加してください。
 
 ```bash
-bunx guren add plugin @acme/guren-plugin-audit
+bunx guren plugin @acme/guren-plugin-audit
 ```
 
-`add plugin` は `src/app.ts` にプラグイン Provider を自動登録し、依存が未インストールの場合は `bun add <package>` の案内を表示します。
+`plugin`（`add plugin` としても利用可能）は、依存が未インストールの場合に `bun add` でインストールし（`--no-install` でスキップ可能）、プラグインが宣言するGurenバージョン互換性を検証した上で（`--ignore-compatibility` で無視可能）、Providerを `src/app.ts` に自動登録します。プラグインが `gurenPlugin` マニフェストで宣言した設定スタブや環境変数キーも適用されます。`--force` は公開済みファイルの上書きに使います。
 
 これらのコマンドは `src/app.ts` を更新し、対応する provider/runtime ファイルを生成します。
 

--- a/docs/ja/guides/plugins.md
+++ b/docs/ja/guides/plugins.md
@@ -106,12 +106,26 @@ export type { AnalyticsConfig } from './plugin'
 ```json
 {
   "gurenPlugin": {
-    "compatibility": ">=1.0.0"
+    "compatibility": ">=1.0.0",
+    "provider": "AnalyticsServiceProvider",
+    "env": [
+      { "key": "ANALYTICS_API_KEY", "comment": "Analytics service API key" }
+    ],
+    "publishes": [
+      { "from": "stubs/analytics.ts", "to": "config/analytics.ts" }
+    ]
   }
 }
 ```
 
-これにより、Guren（および他のツール）がプラグインがどのフレームワークバージョンに対応しているかを把握できます。
+| フィールド | 用途 |
+|-----------|------|
+| `compatibility` | サポートするGurenバージョンのsemver範囲。`bunx guren plugin`のインストール時と`bunx guren doctor`で検証されます。 |
+| `provider` | `bunx guren plugin`が`createApp({ providers })`に登録する名前付きクラスエクスポート。`definePlugin()`ファクトリの場合は省略します（手動登録）。 |
+| `env` | インストール時にアプリの`.env.example`（`.env`が存在すればそちらにも）へ追記される環境変数キー。 |
+| `publishes` | パッケージからアプリへコピーされるファイル（`config/`、`db/migrations/`、`resources/`のみ）。既存ファイルは`--force`なしでは上書きされません。 |
+
+マニフェストは純粋なデータです — CLIはインストール中にプラグインのコードを一切実行しません。
 
 ## ステップ5: テストを書く
 
@@ -177,16 +191,15 @@ bun run build
 npm publish
 ```
 
-## 公式プラグインのインストール
+## プラグインのインストール
 
-公式プラグイン（`@guren/plugin-*`）はCLI経由でインストールでき、`src/app.ts`のパッチと必要なファイルの自動生成を行います:
+公式（`@guren/plugin-*`）・コミュニティ（`guren-plugin-*`）を問わず、プラグインはCLI経由でインストールできます:
 
 ```bash
 bunx guren plugin @guren/plugin-vercel
-bun add @guren/plugin-vercel
 ```
 
-`plugin`コマンドがプロバイダーのimportを追加し、`createApp({ providers })`への登録を自動で行います。
+`plugin`コマンドは、依存が未インストールなら`bun add`でインストールし（`--no-install`でスキップ可能）、プラグインが宣言するGuren互換性を検証した上で（`--ignore-compatibility`で無視して登録可能）、プロバイダーのimport追加と`createApp({ providers })`への登録、マニフェストの`env`・`publishes`エントリの適用を行います。`--force`は公開済みファイルの上書きに使います。
 
 > **注意:** 自動登録が現在対応しているのはクラスベースのプロバイダーエクスポートのみです。`definePlugin()`で作成したプラグインは設定を渡してファクトリを呼び出す必要があるため、下記のように`createApp({ providers })`へ手動で登録してください。
 

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1928,7 +1928,7 @@ function createAddBlueprintCommand(
 const addPluginCommand = defineCommand({
   meta: {
     name: 'plugin',
-    description: 'Register a third-party plugin provider in src/app.ts.',
+    description: 'Install a plugin package and register its provider in src/app.ts.',
   },
   args: {
     package: {
@@ -1938,23 +1938,47 @@ const addPluginCommand = defineCommand({
     },
     force: {
       type: 'boolean',
-      description: 'Overwrite existing plugin registration',
+      description: 'Overwrite existing plugin registration and published files',
       alias: 'f',
+    },
+    install: {
+      type: 'boolean',
+      default: true,
+      description: 'Install the package with bun add when missing (--no-install to skip)',
+    },
+    'ignore-compatibility': {
+      type: 'boolean',
+      description: 'Register the plugin even when it declares an incompatible Guren version range',
     },
   },
   async run({ args }) {
     const result = await installPlugin({
       packageName: String(args.package),
       force: Boolean(args.force),
+      install: args.install !== false,
+      ignoreCompatibility: Boolean(args['ignore-compatibility']),
     })
 
-    for (const item of result) {
-      if (item.startsWith('Run:')) {
-        consola.info(item)
-      } else if (item.includes('(already registered)')) {
-        consola.info(`Checked ${item}`)
-      } else {
-        consola.success(`Updated ${item}`)
+    for (const message of result) {
+      switch (message.kind) {
+        case 'installed':
+          consola.success(`Installed ${message.text}`)
+          break
+        case 'updated':
+          consola.success(`Updated ${message.text}`)
+          break
+        case 'checked':
+          consola.info(`Checked ${message.text}`)
+          break
+        case 'skipped':
+          consola.info(`Skipped ${message.text}`)
+          break
+        case 'warning':
+          consola.warn(message.text)
+          break
+        case 'hint':
+          consola.info(message.text)
+          break
       }
     }
   },
@@ -2227,6 +2251,7 @@ const main = defineCommand({
     'lang:list': langListCommand,
     'make:lang': makeLangCommand,
     add: addCommand,
+    plugin: addPluginCommand,
     doctor: doctorCommand,
     'key:generate': keyGenerateCommand,
     new: newCommand,

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -2,6 +2,7 @@ import { copyFile, readFile, writeFile } from 'node:fs/promises'
 import { resolve, relative } from 'node:path'
 import { consola } from 'consola'
 import { discoverControllerFiles, discoverModelFiles, fileExists, readIfExists, classNameFromPath } from './discovery'
+import { checkPluginCompatibility, readCoreVersion, readPluginManifest } from './plugin-manifest'
 
 export type DoctorStatus = 'pass' | 'warn' | 'fail'
 
@@ -903,6 +904,85 @@ async function detectDatabaseConfig(context: DoctorRuleContext): Promise<DoctorC
   )
 }
 
+async function detectPluginCompatibility(context: DoctorRuleContext): Promise<DoctorCheck> {
+  const packageJsonRaw = await readIfExists(context.cwd, 'package.json')
+  if (packageJsonRaw === null) {
+    return createCheck('plugin-compatibility', 'Plugin Compatibility', 'pass', 'No package.json found; skipping plugin checks.')
+  }
+
+  let dependencies: string[] = []
+  try {
+    const parsed = JSON.parse(packageJsonRaw) as {
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+    }
+    dependencies = [
+      ...Object.keys(parsed.dependencies ?? {}),
+      ...Object.keys(parsed.devDependencies ?? {}),
+    ]
+  } catch {
+    return createCheck('plugin-compatibility', 'Plugin Compatibility', 'pass', 'package.json could not be parsed; skipping plugin checks.')
+  }
+
+  const manifests = await Promise.all(
+    dependencies.map(async (dependency) => ({
+      dependency,
+      manifest: await readPluginManifest(dependency, context.cwd).catch(() => null),
+    })),
+  )
+  const plugins = manifests.flatMap((entry) =>
+    entry.manifest ? [{ dependency: entry.dependency, manifest: entry.manifest }] : [],
+  )
+
+  const coreVersion = await readCoreVersion(context.cwd)
+  const incompatible: string[] = []
+  const unverified: string[] = []
+
+  for (const { dependency, manifest } of plugins) {
+    const compatibility = checkPluginCompatibility(manifest, coreVersion)
+    if (compatibility === null && manifest.compatibility) {
+      unverified.push(dependency)
+    } else if (compatibility && !compatibility.compatible) {
+      incompatible.push(
+        `${dependency} (declares "${compatibility.range}", installed @guren/core is ${compatibility.coreVersion})`,
+      )
+    }
+  }
+
+  if (incompatible.length > 0) {
+    return createCheck(
+      'plugin-compatibility',
+      'Plugin Compatibility',
+      'warn',
+      `Incompatible plugins: ${incompatible.join('; ')}.`,
+      {
+        manualFix: 'Upgrade the plugin(s) to a version that supports the installed Guren release, or upgrade @guren/core.',
+      },
+    )
+  }
+
+  if (unverified.length > 0) {
+    return createCheck(
+      'plugin-compatibility',
+      'Plugin Compatibility',
+      'warn',
+      `Could not verify compatibility for: ${unverified.join(', ')} (@guren/core version unresolved).`,
+      {
+        manualFix: 'Install dependencies so node_modules/@guren/core/package.json is available.',
+      },
+    )
+  }
+
+  return createCheck(
+    'plugin-compatibility',
+    'Plugin Compatibility',
+    'pass',
+    plugins.length > 0
+      ? `${plugins.length} plugin(s) compatible with the installed Guren version.`
+      : 'No Guren plugins detected.',
+  )
+}
+
 const doctorRules: DoctorRule[] = [
   { key: 'runtime', title: 'Runtime Environment', detect: detectRuntime },
   { key: 'bun-version', title: 'Bun Version', detect: detectBunVersion },
@@ -919,6 +999,7 @@ const doctorRules: DoctorRule[] = [
   { key: 'config-drift', title: 'App Wiring', detect: detectConfigDrift },
   { key: 'scripts', title: 'App Scripts', detect: detectScripts, autofix: createScriptsAutofix },
   { key: 'database-config', title: 'Database Configuration', detect: detectDatabaseConfig },
+  { key: 'plugin-compatibility', title: 'Plugin Compatibility', detect: detectPluginCompatibility },
 ]
 
 export async function getDoctorRuleEvaluations(options: { cwd?: string } = {}): Promise<{

--- a/packages/cli/src/make-migration.ts
+++ b/packages/cli/src/make-migration.ts
@@ -1,6 +1,6 @@
 import { access } from 'node:fs/promises'
 import { resolve } from 'node:path'
-import { spawn } from 'node:child_process'
+import { runCommand } from './utils'
 
 const DEFAULT_SCHEMA = 'db/schema.ts'
 const DEFAULT_OUTPUT = 'db/migrations'
@@ -44,27 +44,6 @@ async function resolveDrizzleConfig(): Promise<string | undefined> {
   }
 
   return undefined
-}
-
-async function runCommand(command: string, args: string[]): Promise<void> {
-  await new Promise<void>((resolvePromise, rejectPromise) => {
-    const child = spawn(command, args, {
-      stdio: 'inherit',
-      env: process.env,
-    })
-
-    child.on('error', (error) => {
-      rejectPromise(error)
-    })
-
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolvePromise()
-      } else {
-        rejectPromise(new Error(`drizzle-kit exited with code ${code}`))
-      }
-    })
-  })
 }
 
 export async function makeMigration(options: MakeMigrationOptions = {}): Promise<void> {

--- a/packages/cli/src/plugin-manifest.ts
+++ b/packages/cli/src/plugin-manifest.ts
@@ -1,0 +1,203 @@
+import { copyFile, mkdir, writeFile } from 'node:fs/promises'
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { fileExists, readIfExists } from './discovery'
+
+/**
+ * Declarative `gurenPlugin` manifest read from a plugin package's
+ * package.json. The manifest is pure data — `guren plugin` never imports or
+ * executes plugin code.
+ */
+export interface GurenPluginManifest {
+  /** Semver range of Guren versions this plugin supports. */
+  compatibility?: string
+  /** Named provider export to register in createApp({ providers }). */
+  provider?: string
+  /** Env keys appended to .env.example (and .env when present). */
+  env?: GurenPluginEnvEntry[]
+  /** Files copied from the package into the application. */
+  publishes?: GurenPluginPublishEntry[]
+  /** CLI commands contributed by the plugin (RFC 0001, Part C). */
+  commands?: GurenPluginCommands
+}
+
+export interface GurenPluginEnvEntry {
+  key: string
+  value?: string
+  comment?: string
+}
+
+export interface GurenPluginPublishEntry {
+  from: string
+  to: string
+}
+
+export interface GurenPluginCommands {
+  entry: string
+  names: string[]
+}
+
+/** Application directories a plugin is allowed to publish files into. */
+export const PUBLISH_TARGET_ROOTS = ['config/', 'db/migrations/', 'resources/'] as const
+
+const ENV_KEY_PATTERN = /^[A-Z][A-Z0-9_]*$/u
+
+// Bun is only available at runtime. The declaration keeps TypeScript happy
+// while allowing the compatibility check to no-op on other runtimes.
+declare const Bun:
+  | { semver: { satisfies(version: string, range: string): boolean } }
+  | undefined
+
+/**
+ * Read the `gurenPlugin` manifest from an installed package.
+ * Returns null when the package or the field is absent.
+ */
+export async function readPluginManifest(
+  packageName: string,
+  cwd: string = process.cwd(),
+): Promise<GurenPluginManifest | null> {
+  const raw = await readIfExists(cwd, join('node_modules', packageName, 'package.json'))
+  if (raw === null) return null
+
+  const parsed = JSON.parse(raw) as { gurenPlugin?: unknown }
+  if (!parsed.gurenPlugin || typeof parsed.gurenPlugin !== 'object') {
+    return null
+  }
+
+  return parsed.gurenPlugin as GurenPluginManifest
+}
+
+/**
+ * Read the installed `@guren/core` version, or null when not installed.
+ */
+export async function readCoreVersion(cwd: string = process.cwd()): Promise<string | null> {
+  const raw = await readIfExists(cwd, join('node_modules', '@guren/core', 'package.json'))
+  if (raw === null) return null
+
+  return (JSON.parse(raw) as { version?: string }).version ?? null
+}
+
+export interface CompatibilityResult {
+  compatible: boolean
+  coreVersion: string
+  range: string
+}
+
+/**
+ * Check a manifest's `compatibility` range against a core version.
+ * Returns null when either side is unknown (no range declared, core version
+ * unresolved, or a runtime without Bun.semver).
+ */
+export function checkPluginCompatibility(
+  manifest: GurenPluginManifest,
+  coreVersion: string | null,
+): CompatibilityResult | null {
+  const range = manifest.compatibility
+  if (!range || !coreVersion || typeof Bun === 'undefined') return null
+
+  return {
+    compatible: Bun.semver.satisfies(coreVersion, range),
+    coreVersion,
+    range,
+  }
+}
+
+/**
+ * Append missing env keys to .env.example (created when absent) and .env
+ * (only when it already exists). Returns the files that were modified.
+ */
+export async function applyEnvEntries(
+  entries: GurenPluginEnvEntry[],
+  cwd: string = process.cwd(),
+): Promise<string[]> {
+  const validEntries = entries.filter((entry) => ENV_KEY_PATTERN.test(entry.key ?? ''))
+  if (validEntries.length === 0) return []
+
+  const modified: string[] = []
+
+  for (const file of ['.env.example', '.env']) {
+    const existing = await readIfExists(cwd, file)
+
+    // .env is only updated when it already exists
+    if (existing === null && file === '.env') continue
+    const content = existing ?? ''
+
+    const missing = validEntries.filter(
+      (entry) => !new RegExp(`^${entry.key}=`, 'm').test(content),
+    )
+    if (missing.length === 0) continue
+
+    const blocks = missing.map((entry) => {
+      const comment = entry.comment ? `# ${entry.comment}\n` : ''
+      return `${comment}${entry.key}=${entry.value ?? ''}\n`
+    })
+
+    const separator = content.length > 0 && !content.endsWith('\n') ? '\n' : ''
+    await writeFile(resolve(cwd, file), `${content}${separator}${blocks.join('')}`, 'utf8')
+    modified.push(file)
+  }
+
+  return modified
+}
+
+export interface PublishResult {
+  written: string[]
+  skipped: string[]
+}
+
+/**
+ * Copy declared files from the installed package into the application.
+ *
+ * Targets are restricted to PUBLISH_TARGET_ROOTS, sources must stay inside
+ * the package directory, and existing files are never overwritten unless
+ * `force` is set.
+ */
+export async function applyPublishes(
+  packageName: string,
+  entries: GurenPluginPublishEntry[],
+  options: { cwd?: string; force?: boolean } = {},
+): Promise<PublishResult> {
+  const cwd = options.cwd ?? process.cwd()
+  const packageDir = resolve(cwd, 'node_modules', packageName)
+  const written: string[] = []
+  const skipped: string[] = []
+
+  for (const entry of entries) {
+    if (!entry.from || !entry.to) {
+      throw new Error(`Invalid publish entry in "${packageName}": both "from" and "to" are required.`)
+    }
+    if (isAbsolute(entry.from) || isAbsolute(entry.to)) {
+      throw new Error(`Invalid publish entry in "${packageName}": absolute paths are not allowed.`)
+    }
+
+    const fromPath = resolve(packageDir, entry.from)
+    if (relative(packageDir, fromPath).startsWith('..')) {
+      throw new Error(
+        `Invalid publish entry in "${packageName}": source "${entry.from}" escapes the package directory.`,
+      )
+    }
+
+    const toPath = resolve(cwd, entry.to)
+    const toRelative = relative(cwd, toPath)
+    if (toRelative.startsWith('..')) {
+      throw new Error(
+        `Invalid publish entry in "${packageName}": target "${entry.to}" escapes the project directory.`,
+      )
+    }
+    if (!PUBLISH_TARGET_ROOTS.some((root) => toRelative.startsWith(root))) {
+      throw new Error(
+        `Invalid publish entry in "${packageName}": target "${entry.to}" must be inside ${PUBLISH_TARGET_ROOTS.join(', ')}.`,
+      )
+    }
+
+    if (!options.force && await fileExists(cwd, toRelative)) {
+      skipped.push(entry.to)
+      continue
+    }
+
+    await mkdir(dirname(toPath), { recursive: true })
+    await copyFile(fromPath, toPath)
+    written.push(entry.to)
+  }
+
+  return { written, skipped }
+}

--- a/packages/cli/src/plugin.ts
+++ b/packages/cli/src/plugin.ts
@@ -1,11 +1,36 @@
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import type { WriterOptions } from './utils'
+import { runCommand } from './utils'
 import { addImport, addProvider } from './patch-helpers'
+import {
+  applyEnvEntries,
+  applyPublishes,
+  checkPluginCompatibility,
+  readCoreVersion,
+  readPluginManifest,
+} from './plugin-manifest'
 import { assertSupportedOfficialVercelPlugin, installOfficialVercelPlugin } from './plugin-vercel'
 
 export interface InstallPluginOptions extends WriterOptions {
   packageName: string
+  /** Run `bun add <pkg>` when the dependency is missing. Off by default. */
+  install?: boolean
+  /** Register the plugin even when its declared compatibility range excludes the installed core. */
+  ignoreCompatibility?: boolean
+}
+
+export type PluginInstallMessageKind =
+  | 'installed'
+  | 'updated'
+  | 'checked'
+  | 'skipped'
+  | 'warning'
+  | 'hint'
+
+export interface PluginInstallMessage {
+  kind: PluginInstallMessageKind
+  text: string
 }
 
 function providerIdentifierForPackage(packageName: string): string {
@@ -39,7 +64,7 @@ async function hasDependency(packageName: string): Promise<boolean> {
   return Boolean(packageJson.dependencies?.[packageName] ?? packageJson.devDependencies?.[packageName])
 }
 
-export async function installPlugin(options: InstallPluginOptions): Promise<string[]> {
+export async function installPlugin(options: InstallPluginOptions): Promise<PluginInstallMessage[]> {
   const packageName = options.packageName.trim()
   if (!packageName) {
     throw new Error('Plugin package name is required.')
@@ -49,19 +74,38 @@ export async function installPlugin(options: InstallPluginOptions): Promise<stri
     await assertSupportedOfficialVercelPlugin()
   }
 
-  const providerName = providerIdentifierForPackage(packageName)
+  const messages: PluginInstallMessage[] = []
+
+  let present = await hasDependency(packageName)
+  if (options.install && !present) {
+    await runCommand('bun', ['add', packageName])
+    present = true
+    messages.push({ kind: 'installed', text: packageName })
+  }
+
+  const manifest = await readPluginManifest(packageName)
+
+  if (manifest) {
+    const compatibility = checkPluginCompatibility(manifest, await readCoreVersion())
+    if (compatibility && !compatibility.compatible) {
+      const summary =
+        `${packageName} declares compatibility "${compatibility.range}" but @guren/core ` +
+        `${compatibility.coreVersion} is installed.`
+      if (!options.ignoreCompatibility) {
+        throw new Error(`${summary} Pass --ignore-compatibility to register it anyway.`)
+      }
+      messages.push({ kind: 'warning', text: summary })
+    }
+  }
+
+  const providerName = manifest?.provider ?? providerIdentifierForPackage(packageName)
   const providerImport = `import { ${providerName} } from '${packageName}'`
 
   const appPath = 'src/app.ts'
   const imported = await addImport(appPath, providerImport)
   const registered = await addProvider(appPath, providerName)
 
-  if (!imported.modified && imported.reason === 'File not found') {
-    throw new Error('src/app.ts was not found. Run this command inside a Guren app.')
-  }
-
-
-  if (!registered.modified && registered.reason === 'File not found') {
+  if (imported.reason === 'File not found' || registered.reason === 'File not found') {
     throw new Error('src/app.ts was not found. Run this command inside a Guren app.')
   }
 
@@ -69,23 +113,34 @@ export async function installPlugin(options: InstallPluginOptions): Promise<stri
     throw new Error('Could not find providers array in src/app.ts. Please register the provider manually.')
   }
 
-  const messages: string[] = []
-
   if (imported.modified || registered.modified) {
-    messages.push(appPath)
-  }
-
-  if (!imported.modified && imported.reason === 'Import already exists' && !registered.modified && registered.reason === 'Provider already registered') {
-    messages.push(`${appPath} (already registered)`)
+    messages.push({ kind: 'updated', text: appPath })
+  } else if (imported.reason === 'Import already exists' && registered.reason === 'Provider already registered') {
+    messages.push({ kind: 'checked', text: `${appPath} (already registered)` })
   }
 
   if (packageName === '@guren/plugin-vercel') {
     const pluginFiles = await installOfficialVercelPlugin(options)
-    messages.push(...pluginFiles)
+    messages.push(...pluginFiles.map((text): PluginInstallMessage => ({ kind: 'updated', text })))
   }
 
-  if (!await hasDependency(packageName)) {
-    messages.push(`Run: bun add ${packageName}`)
+  if (manifest?.publishes?.length) {
+    const published = await applyPublishes(packageName, manifest.publishes, {
+      force: options.force,
+    })
+    messages.push(...published.written.map((text): PluginInstallMessage => ({ kind: 'updated', text })))
+    messages.push(...published.skipped.map((text): PluginInstallMessage => ({
+      kind: 'skipped',
+      text: `${text} (already exists, use --force to overwrite)`,
+    })))
+  }
+
+  if (manifest?.env?.length) {
+    messages.push(...(await applyEnvEntries(manifest.env)).map((text): PluginInstallMessage => ({ kind: 'updated', text })))
+  }
+
+  if (!present) {
+    messages.push({ kind: 'hint', text: `Run: bun add ${packageName}` })
   }
 
   return messages

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -1,6 +1,5 @@
 import { readFile, writeFile, readdir } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
-import { spawn } from 'node:child_process'
 import { join, resolve } from 'node:path'
 import {
   DOCTOR_RECOMMENDED_COMMANDS,
@@ -9,6 +8,7 @@ import {
   type DoctorCheck,
 } from './doctor'
 import { checkDeprecations, type DeprecationWarning } from './deprecations'
+import { runCommand } from './utils'
 import { compareVersions, runCodemods, type CodemodResult } from './codemods'
 
 const PACKAGE_JSON = 'package.json'
@@ -95,25 +95,7 @@ async function findNestedGurenCopies(cwd: string): Promise<string[]> {
 }
 
 async function runBunInstall(cwd: string): Promise<void> {
-  await new Promise<void>((resolvePromise, rejectPromise) => {
-    const child = spawn(process.execPath || 'bun', ['install'], {
-      cwd,
-      stdio: 'inherit',
-      env: process.env,
-    })
-
-    child.on('error', (error) => {
-      rejectPromise(error)
-    })
-
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolvePromise()
-      } else {
-        rejectPromise(new Error(`bun install exited with code ${code}`))
-      }
-    })
-  })
+  await runCommand(process.execPath || 'bun', ['install'], { cwd })
 }
 
 async function resolveDistTagVersion(packageName: string, tag: string): Promise<string | null> {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process'
 import { access, mkdir, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 
@@ -18,6 +19,35 @@ export interface ScaffoldConfig {
   extension?: string
   fileName?: (names: ScaffoldNames) => string
   template: (names: ScaffoldNames) => string
+}
+
+/**
+ * Spawn a command with inherited stdio and resolve when it exits cleanly.
+ */
+export async function runCommand(
+  command: string,
+  args: string[],
+  options: { cwd?: string } = {},
+): Promise<void> {
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      stdio: 'inherit',
+      env: process.env,
+    })
+
+    child.on('error', (error) => {
+      rejectPromise(error)
+    })
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolvePromise()
+      } else {
+        rejectPromise(new Error(`${command} ${args.join(' ')} exited with code ${code}`))
+      }
+    })
+  })
 }
 
 export async function writeFileSafe(relativePath: string, contents: string, options: WriterOptions = {}): Promise<string> {

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
 import { getDoctorRuleEvaluations, runDoctor, buildJsonOutput } from '../src/doctor'
 import type { DoctorJsonOutput } from '../src/doctor'
-import { createTempWorkspace } from './helpers'
+import { createTempWorkspace, writeInstalledPackage } from './helpers'
 
 let consoleLogSpy: ReturnType<typeof spyOn>
 const VALID_APP_KEY = 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
@@ -841,6 +841,39 @@ describe('runDoctor', () => {
       expect(driftCheck).toBeDefined()
       expect(driftCheck?.status).toBe('warn')
       expect(driftCheck?.message).toContain('DatabaseProvider')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('warns when an installed plugin is incompatible with the installed core', async () => {
+    const workspace = await createTempWorkspace('guren-cli-doctor-plugin-compat-')
+
+    try {
+      await writeFile(
+        join(workspace.dir, 'package.json'),
+        JSON.stringify({
+          name: 'doctor-plugin-compat',
+          dependencies: {
+            '@guren/core': '^1.0.0',
+            '@acme/guren-plugin-audit': '^1.0.0',
+          },
+        }, null, 2),
+        'utf8',
+      )
+      await writeInstalledPackage('@guren/core', { version: '1.2.0' }, {}, workspace.dir)
+      await writeInstalledPackage('@acme/guren-plugin-audit', {
+        version: '1.0.0',
+        gurenPlugin: { compatibility: '>=2.0.0' },
+      }, {}, workspace.dir)
+
+      const report = await runDoctor({ cwd: workspace.dir, json: true })
+      const pluginCheck = report.checks.find((check) => check.key === 'plugin-compatibility')
+
+      expect(pluginCheck).toBeDefined()
+      expect(pluginCheck?.status).toBe('warn')
+      expect(pluginCheck?.message).toContain('@acme/guren-plugin-audit')
+      expect(pluginCheck?.message).toContain('>=2.0.0')
     } finally {
       await workspace.cleanup()
     }

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -1,11 +1,32 @@
-import { mkdtemp, rm } from 'node:fs/promises'
-import { join } from 'node:path'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 
 export interface TempWorkspace {
   dir: string
   originalCwd: string
   cleanup: () => Promise<void>
+}
+
+/**
+ * Write a fake installed package into node_modules, with optional extra
+ * files relative to the package directory.
+ */
+export async function writeInstalledPackage(
+  name: string,
+  packageJson: Record<string, unknown>,
+  files: Record<string, string> = {},
+  baseDir: string = process.cwd(),
+): Promise<void> {
+  const packageDir = join(baseDir, 'node_modules', name)
+  await mkdir(packageDir, { recursive: true })
+  await writeFile(join(packageDir, 'package.json'), JSON.stringify({ name, ...packageJson }, null, 2))
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = join(packageDir, relativePath)
+    await mkdir(dirname(filePath), { recursive: true })
+    await writeFile(filePath, content)
+  }
 }
 
 export async function createTempWorkspace(prefix: string): Promise<TempWorkspace> {

--- a/packages/cli/tests/plugin-manifest.test.ts
+++ b/packages/cli/tests/plugin-manifest.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, afterEach, describe, expect, it } from 'bun:test'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { createTempWorkspace, writeInstalledPackage, type TempWorkspace } from './helpers'
+import {
+  applyEnvEntries,
+  applyPublishes,
+  checkPluginCompatibility,
+  readCoreVersion,
+  readPluginManifest,
+} from '../src/plugin-manifest'
+
+const PLUGIN_NAME = '@acme/guren-plugin-audit'
+
+describe('plugin-manifest', () => {
+  let workspace: TempWorkspace
+
+  beforeEach(async () => {
+    workspace = await createTempWorkspace('guren-cli-plugin-manifest-')
+  })
+
+  afterEach(async () => {
+    await workspace.cleanup()
+  })
+
+  describe('readPluginManifest', () => {
+    it('should return the gurenPlugin field of an installed package', async () => {
+      await writeInstalledPackage(PLUGIN_NAME, {
+        gurenPlugin: { compatibility: '>=1.0.0', provider: 'AuditProvider' },
+      })
+
+      const manifest = await readPluginManifest(PLUGIN_NAME)
+
+      expect(manifest?.compatibility).toBe('>=1.0.0')
+      expect(manifest?.provider).toBe('AuditProvider')
+    })
+
+    it('should return null when the package is not installed', async () => {
+      expect(await readPluginManifest('@acme/missing')).toBeNull()
+    })
+
+    it('should return null when the package declares no gurenPlugin field', async () => {
+      await writeInstalledPackage(PLUGIN_NAME, {})
+
+      expect(await readPluginManifest(PLUGIN_NAME)).toBeNull()
+    })
+  })
+
+  describe('readCoreVersion', () => {
+    it('should return the installed core version', async () => {
+      await writeInstalledPackage('@guren/core', { version: '1.2.0' })
+
+      expect(await readCoreVersion()).toBe('1.2.0')
+    })
+
+    it('should return null when core is not installed', async () => {
+      expect(await readCoreVersion()).toBeNull()
+    })
+  })
+
+  describe('checkPluginCompatibility', () => {
+    it('should pass when the core version satisfies the range', () => {
+      const result = checkPluginCompatibility({ compatibility: '>=1.0.0' }, '1.2.0')
+
+      expect(result).toEqual({ compatible: true, coreVersion: '1.2.0', range: '>=1.0.0' })
+    })
+
+    it('should fail when the core version is outside the range', () => {
+      const result = checkPluginCompatibility({ compatibility: '>=2.0.0' }, '1.2.0')
+
+      expect(result?.compatible).toBe(false)
+    })
+
+    it('should return null when no range is declared', () => {
+      expect(checkPluginCompatibility({}, '1.2.0')).toBeNull()
+    })
+
+    it('should return null when the core version is unknown', () => {
+      expect(checkPluginCompatibility({ compatibility: '>=1.0.0' }, null)).toBeNull()
+    })
+  })
+
+  describe('applyEnvEntries', () => {
+    it('should create .env.example and append missing keys', async () => {
+      const modified = await applyEnvEntries([
+        { key: 'AUDIT_API_KEY', comment: 'Audit service API key' },
+        { key: 'AUDIT_ENDPOINT', value: 'https://audit.example.com' },
+      ])
+
+      expect(modified).toEqual(['.env.example'])
+      const content = await readFile('.env.example', 'utf8')
+      expect(content).toContain('# Audit service API key\nAUDIT_API_KEY=\n')
+      expect(content).toContain('AUDIT_ENDPOINT=https://audit.example.com\n')
+    })
+
+    it('should append to an existing .env but not create one', async () => {
+      await writeFile('.env', 'EXISTING=1\n')
+
+      const modified = await applyEnvEntries([{ key: 'AUDIT_API_KEY' }])
+
+      expect(modified).toEqual(['.env.example', '.env'])
+      expect(await readFile('.env', 'utf8')).toBe('EXISTING=1\nAUDIT_API_KEY=\n')
+    })
+
+    it('should be idempotent for keys that already exist', async () => {
+      await writeFile('.env.example', 'AUDIT_API_KEY=set\n')
+
+      const modified = await applyEnvEntries([{ key: 'AUDIT_API_KEY' }])
+
+      expect(modified).toEqual([])
+      expect(await readFile('.env.example', 'utf8')).toBe('AUDIT_API_KEY=set\n')
+    })
+
+    it('should ignore entries with invalid keys', async () => {
+      const modified = await applyEnvEntries([{ key: 'not-a-key' }, { key: 'lower' }])
+
+      expect(modified).toEqual([])
+    })
+  })
+
+  describe('applyPublishes', () => {
+    beforeEach(async () => {
+      await writeInstalledPackage(PLUGIN_NAME, {}, {
+        'stubs/audit.ts': 'export const audit = true\n',
+      })
+    })
+
+    it('should copy declared files into allowed directories', async () => {
+      const result = await applyPublishes(PLUGIN_NAME, [
+        { from: 'stubs/audit.ts', to: 'config/audit.ts' },
+      ])
+
+      expect(result.written).toEqual(['config/audit.ts'])
+      expect(await readFile('config/audit.ts', 'utf8')).toBe('export const audit = true\n')
+    })
+
+    it('should skip existing files unless force is set', async () => {
+      await mkdir('config', { recursive: true })
+      await writeFile('config/audit.ts', 'export const custom = true\n')
+
+      const result = await applyPublishes(PLUGIN_NAME, [
+        { from: 'stubs/audit.ts', to: 'config/audit.ts' },
+      ])
+
+      expect(result.skipped).toEqual(['config/audit.ts'])
+      expect(await readFile('config/audit.ts', 'utf8')).toBe('export const custom = true\n')
+
+      const forced = await applyPublishes(PLUGIN_NAME, [
+        { from: 'stubs/audit.ts', to: 'config/audit.ts' },
+      ], { force: true })
+
+      expect(forced.written).toEqual(['config/audit.ts'])
+      expect(await readFile('config/audit.ts', 'utf8')).toBe('export const audit = true\n')
+    })
+
+    it('should reject targets outside the allowed directories', async () => {
+      await expect(applyPublishes(PLUGIN_NAME, [
+        { from: 'stubs/audit.ts', to: 'src/audit.ts' },
+      ])).rejects.toThrow('must be inside')
+    })
+
+    it('should reject path traversal in targets', async () => {
+      await expect(applyPublishes(PLUGIN_NAME, [
+        { from: 'stubs/audit.ts', to: 'config/../../evil.ts' },
+      ])).rejects.toThrow('escapes the project directory')
+    })
+
+    it('should reject sources escaping the package directory', async () => {
+      await expect(applyPublishes(PLUGIN_NAME, [
+        { from: '../../../etc/passwd', to: 'config/passwd.ts' },
+      ])).rejects.toThrow('escapes the package directory')
+    })
+
+    it('should reject absolute paths', async () => {
+      await expect(applyPublishes(PLUGIN_NAME, [
+        { from: '/etc/passwd', to: 'config/passwd.ts' },
+      ])).rejects.toThrow('absolute paths are not allowed')
+    })
+  })
+})

--- a/packages/cli/tests/plugin.test.ts
+++ b/packages/cli/tests/plugin.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, afterEach, describe, expect, it } from 'bun:test'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { createTempWorkspace, type TempWorkspace } from './helpers'
-import { installPlugin } from '../src/plugin'
+import { createTempWorkspace, writeInstalledPackage, type TempWorkspace } from './helpers'
+import { installPlugin, type PluginInstallMessage } from '../src/plugin'
+
+function textsOf(messages: PluginInstallMessage[], kind: PluginInstallMessage['kind']): string[] {
+  return messages.filter((message) => message.kind === kind).map((message) => message.text)
+}
 
 describe('installPlugin', () => {
   let workspace: TempWorkspace
@@ -38,10 +42,10 @@ export default app
   })
 
   it('registers provider import and provider entry', async () => {
-    const updated = await installPlugin({ packageName: '@acme/guren-plugin-audit' })
+    const messages = await installPlugin({ packageName: '@acme/guren-plugin-audit' })
 
-    expect(updated).toContain('src/app.ts')
-    expect(updated).toContain('Run: bun add @acme/guren-plugin-audit')
+    expect(textsOf(messages, 'updated')).toContain('src/app.ts')
+    expect(textsOf(messages, 'hint')).toContain('Run: bun add @acme/guren-plugin-audit')
 
     const app = await readFile('src/app.ts', 'utf8')
     expect(app).toContain("import { AcmeGurenPluginAuditProvider } from '@acme/guren-plugin-audit'")
@@ -52,7 +56,7 @@ export default app
     await installPlugin({ packageName: '@acme/guren-plugin-audit' })
     const second = await installPlugin({ packageName: '@acme/guren-plugin-audit' })
 
-    expect(second).toContain('src/app.ts (already registered)')
+    expect(textsOf(second, 'checked')).toContain('src/app.ts (already registered)')
 
     const app = await readFile('src/app.ts', 'utf8')
     const occurrences = app.match(/AcmeGurenPluginAuditProvider/g)?.length ?? 0
@@ -69,20 +73,21 @@ export default app
       },
     }, null, 2))
 
-    const result = await installPlugin({ packageName: '@acme/guren-plugin-audit' })
-    expect(result.some(item => item.startsWith('Run: bun add'))).toBe(false)
+    const messages = await installPlugin({ packageName: '@acme/guren-plugin-audit' })
+    expect(textsOf(messages, 'hint')).toHaveLength(0)
   })
 
   it('scaffolds official Vercel plugin files for SSR apps', async () => {
-    const result = await installPlugin({ packageName: '@guren/plugin-vercel' })
+    const messages = await installPlugin({ packageName: '@guren/plugin-vercel' })
+    const updated = textsOf(messages, 'updated')
 
-    expect(result).toContain('src/app.ts')
-    expect(result).toContain('package.json')
-    expect(result).toContain('.gitignore')
-    expect(result).toContain('src/vercel.ts')
-    expect(result).toContain('scripts/vercel-build.ts')
-    expect(result).toContain('vercel.json')
-    expect(result).toContain('Run: bun add @guren/plugin-vercel')
+    expect(updated).toContain('src/app.ts')
+    expect(updated).toContain('package.json')
+    expect(updated).toContain('.gitignore')
+    expect(updated).toContain('src/vercel.ts')
+    expect(updated).toContain('scripts/vercel-build.ts')
+    expect(updated).toContain('vercel.json')
+    expect(textsOf(messages, 'hint')).toContain('Run: bun add @guren/plugin-vercel')
 
     const app = await readFile('src/app.ts', 'utf8')
     expect(app).toContain("import { GurenPluginVercelProvider } from '@guren/plugin-vercel'")
@@ -101,7 +106,7 @@ export default app
     await installPlugin({ packageName: '@guren/plugin-vercel' })
     const second = await installPlugin({ packageName: '@guren/plugin-vercel' })
 
-    expect(second).toContain('src/app.ts (already registered)')
+    expect(textsOf(second, 'checked')).toContain('src/app.ts (already registered)')
 
     const app = await readFile('src/app.ts', 'utf8')
     const occurrences = app.match(/GurenPluginVercelProvider/g)?.length ?? 0
@@ -109,6 +114,79 @@ export default app
 
     const gitignore = await readFile('.gitignore', 'utf8')
     expect(gitignore.match(/\.vercel/g)?.length ?? 0).toBe(1)
+  })
+
+  describe('gurenPlugin manifest', () => {
+    async function writeManifestPackage(manifest: Record<string, unknown>): Promise<void> {
+      await writeInstalledPackage('@acme/guren-plugin-audit', {
+        version: '1.0.0',
+        gurenPlugin: manifest,
+      }, {
+        'stubs/audit.ts': 'export const audit = true\n',
+      })
+      await writeInstalledPackage('@guren/core', { version: '1.2.0' })
+    }
+
+    it('uses the provider export declared in the manifest', async () => {
+      await writeManifestPackage({ provider: 'AuditProvider' })
+
+      await installPlugin({ packageName: '@acme/guren-plugin-audit' })
+
+      const app = await readFile('src/app.ts', 'utf8')
+      expect(app).toContain("import { AuditProvider } from '@acme/guren-plugin-audit'")
+      expect(app).toContain('providers: [AuditProvider]')
+    })
+
+    it('throws when the plugin is incompatible with the installed core', async () => {
+      await writeManifestPackage({ compatibility: '>=2.0.0' })
+
+      await expect(installPlugin({ packageName: '@acme/guren-plugin-audit' }))
+        .rejects.toThrow('declares compatibility ">=2.0.0"')
+
+      const app = await readFile('src/app.ts', 'utf8')
+      expect(app).not.toContain('guren-plugin-audit')
+    })
+
+    it('registers an incompatible plugin with a warning when ignoreCompatibility is set', async () => {
+      await writeManifestPackage({ compatibility: '>=2.0.0' })
+
+      const messages = await installPlugin({
+        packageName: '@acme/guren-plugin-audit',
+        ignoreCompatibility: true,
+      })
+
+      expect(textsOf(messages, 'warning')).toHaveLength(1)
+      const app = await readFile('src/app.ts', 'utf8')
+      expect(app).toContain('providers: [AcmeGurenPluginAuditProvider]')
+    })
+
+    it('publishes declared files and appends env keys', async () => {
+      await writeManifestPackage({
+        publishes: [{ from: 'stubs/audit.ts', to: 'config/audit.ts' }],
+        env: [{ key: 'AUDIT_API_KEY', comment: 'Audit API key' }],
+      })
+
+      const messages = await installPlugin({ packageName: '@acme/guren-plugin-audit' })
+      const updated = textsOf(messages, 'updated')
+
+      expect(updated).toContain('config/audit.ts')
+      expect(updated).toContain('.env.example')
+      expect(await readFile('config/audit.ts', 'utf8')).toBe('export const audit = true\n')
+      expect(await readFile('.env.example', 'utf8')).toContain('AUDIT_API_KEY=')
+    })
+
+    it('skips existing published files without force', async () => {
+      await writeManifestPackage({
+        publishes: [{ from: 'stubs/audit.ts', to: 'config/audit.ts' }],
+      })
+      await mkdir('config', { recursive: true })
+      await writeFile('config/audit.ts', 'export const custom = true\n')
+
+      const messages = await installPlugin({ packageName: '@acme/guren-plugin-audit' })
+
+      expect(textsOf(messages, 'skipped')).toContain('config/audit.ts (already exists, use --force to overwrite)')
+      expect(await readFile('config/audit.ts', 'utf8')).toBe('export const custom = true\n')
+    })
   })
 
   it('rejects the official Vercel plugin for non-SSR apps', async () => {

--- a/packages/plugin-vercel/package.json
+++ b/packages/plugin-vercel/package.json
@@ -15,6 +15,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "gurenPlugin": {
+    "compatibility": ">=1.0.0",
+    "provider": "GurenPluginVercelProvider"
+  },
   "files": [
     "dist"
   ],

--- a/rfcs/0001-plugin-system.md
+++ b/rfcs/0001-plugin-system.md
@@ -99,7 +99,7 @@ middleware must capture the services they need in a closure during `boot()`.
 The Hono context does not carry the container, and this RFC does not change
 that.
 
-### Part B: `guren add` and the `gurenPlugin` manifest
+### Part B: `guren plugin` and the `gurenPlugin` manifest
 
 #### Manifest schema (declarative only)
 
@@ -131,7 +131,7 @@ Extend the existing `gurenPlugin` package.json field:
 
 Security constraints, aligned with Guren's secure-by-default stance:
 
-- `guren add` **never imports or executes plugin code**. The manifest is pure
+- `guren plugin` **never imports or executes plugin code**. The manifest is pure
   JSON data; there is no Adonis-style executable `configure` script.
 - `publishes.to` is restricted to an allowlist of app directories
   (`config/`, `db/migrations/`, `resources/`); paths are normalized and
@@ -141,15 +141,21 @@ Security constraints, aligned with Guren's secure-by-default stance:
 
 #### Command behavior
 
-`guren add <pkg>` (new primary name; `guren plugin` stays as a hidden alias
-for backward compatibility):
+> **Amendment (implementation):** `guren add` already exists as the blueprint
+> namespace (`guren add auth`, `guren add plugin <pkg>`, ...), so the bare
+> `guren add <pkg>` form proposed here would collide with blueprint names.
+> The implemented primary name is `guren plugin <pkg>` (top-level, previously
+> documented but unwired), with `guren add plugin <pkg>` unchanged.
+
+`guren plugin <pkg>`:
 
 1. If `<pkg>` is not in the app's dependencies, run `bun add <pkg>`
    (`--no-install` opts out and prints the command instead).
 2. Read `node_modules/<pkg>/package.json` → `gurenPlugin` manifest.
 3. Check `compatibility` against the installed `@guren/core` version using
    `Bun.semver.satisfies` (no new dependency; the CLI is Bun-only). Warn and
-   require `--force` to proceed on mismatch.
+   require `--ignore-compatibility` to proceed on mismatch (`--force` stays
+   scoped to file overwrites).
 4. Patch `src/app.ts` via the existing `addImport`/`addProvider` helpers,
    using `gurenPlugin.provider` when present.
 5. Apply `publishes` and `env` entries.
@@ -206,7 +212,7 @@ Resolution in `bin.ts`:
   node_modules): rejected. Code executing because a package landed in
   node_modules contradicts Guren's opt-in security posture (`GUREN_MCP=1`,
   `GUREN_TESTING`, explicit provider lists). Explicit registration stays;
-  `guren add` automates the writing, not the deciding.
+  `guren plugin` automates the writing, not the deciding.
 - **Adonis-style executable configure script** (`node ace add` runs the
   package's `configure.ts`): rejected in favor of the declarative manifest.
   Arbitrary install-time code execution is a supply-chain foothold; the
@@ -215,7 +221,7 @@ Resolution in `bin.ts`:
   manual steps.
 - **Boot-time compatibility checking**: rejected. It taxes every cold start
   (relevant for Lambda/Vercel) to catch a problem that is knowable at install
-  time. `guren add` + `guren doctor` cover it.
+  time. `guren plugin` + `guren doctor` cover it.
 - **Container-registered CLI commands** (what the contract currently claims):
   rejected. It would require booting the full application to enumerate
   commands, making `--help` slow and coupling the CLI to app boot success.
@@ -226,18 +232,19 @@ Resolution in `bin.ts`:
 No breaking changes.
 
 - `definePlugin` is additive; existing class-based plugins keep working.
-- `guren plugin` remains as an alias of `guren add`.
+- `guren plugin <pkg>` is the primary top-level form (see the Part B
+  amendment); `guren add plugin <pkg>` remains available unchanged.
 - Plugins without a `gurenPlugin` manifest still install via the name
   heuristic exactly as today; the manifest only unlocks the extra steps.
 - Docs changes: replace the static-config pattern in the authoring guide
   (en/ja), update the contract's CLI-commands claim to describe the real
   mechanism, and change "may read this field at boot" to "checked by
-  `guren add` and `guren doctor`".
+  `guren plugin` and `guren doctor`".
 
 ## Implementation Order
 
 1. **PR 1 (server, docs):** `definePlugin` + tests + guide/contract updates.
-2. **PR 2 (cli):** `guren add` (manifest, compat check, publishes/env,
+2. **PR 2 (cli):** `guren plugin` (manifest, compat check, publishes/env,
    `bun add`), doctor check, plugin-vercel manifest migration.
 3. **PR 3 (cli):** command extension point + `make:*` template for plugin
    commands modules.
@@ -245,10 +252,12 @@ No breaking changes.
 ## Open Questions
 
 - Should `publishes` support a `migrations` shorthand that timestamps files
-  into `db/migrations/` on copy (so repeated `guren add` runs don't duplicate
+  into `db/migrations/` on copy (so repeated `guren plugin` runs don't duplicate
   them), or is plain file copy with skip-if-exists enough for v1?
-- Should `guren add` run `bun add` by default, or print the command and
-  require `--install`? (This RFC proposes install-by-default with
-  `--no-install`, matching Adonis DX.)
+- ~~Should the install command run `bun add` by default, or print the
+  command and require `--install`?~~ **Resolved:** implemented as
+  install-by-default with `--no-install`. The compatibility gate got its own
+  escape hatch, `--ignore-compatibility`, so `--force` stays scoped to file
+  overwrites.
 - Do we want a `guren remove <pkg>` inverse (unregister provider, leave
   published files)? Deferred unless demand appears.


### PR DESCRIPTION
## Summary

Implements Part B of RFC 0001: `bunx guren plugin <pkg>` becomes a full plugin installer driven by the declarative `gurenPlugin` package.json manifest. **Stacked on #111** — merge that first; this PR's base is `feat/define-plugin`.

> **Naming amendment:** the RFC proposed `guren add <pkg>`, but `guren add` is already the blueprint namespace (`guren add auth`, ...). The implemented primary form is top-level `guren plugin <pkg>` — which was already documented in the guides but never actually wired at the top level (only `guren add plugin` worked). The RFC has been amended in place.

## Changes

- **`guren plugin <pkg>`** now: installs the dependency with `bun add` when missing (`--no-install` to skip) → reads the package's `gurenPlugin` manifest → verifies its `compatibility` semver range against the installed `@guren/core` via `Bun.semver` (`--ignore-compatibility` to register anyway; `--force` stays scoped to file overwrites) → registers the manifest-declared `provider` export (name-heuristic fallback) → copies `publishes` files (targets restricted to `config/`, `db/migrations/`, `resources/`; path-traversal rejected on both ends; skip-if-exists without `--force`) → appends `env` keys to `.env.example`/`.env`.
- **Security stance:** the manifest is pure JSON data — the CLI never imports or executes plugin code during installation (no Adonis-style executable configure script).
- **`guren doctor`**: new Plugin Compatibility check — flags installed plugins whose declared range excludes the installed core version, and distinguishes "could not verify" from a real pass.
- **Structured messages:** `installPlugin` returns `{kind, text}[]` instead of prefix-sniffed strings; bin.ts maps kinds to consola levels once.
- **Shared `runCommand`** hoisted into `utils.ts`, replacing three near-identical private spawn wrappers (`make-migration.ts`, `upgrade.ts`, and the new call site).
- **`@guren/plugin-vercel`** declares its `gurenPlugin` manifest (`compatibility`, `provider`); its extra scaffolding stays on the existing hardcoded path for one more minor release per the RFC.
- Docs (en/ja plugin guide, CLI guide, plugin contract) updated to match; test fixture helper `writeInstalledPackage` added to the CLI test helpers.

## Test plan

- New `plugin-manifest.test.ts` (manifest read, compat check, env append idempotency, publish allowlist/traversal/absolute-path rejection, force overwrite)
- New `installPlugin` integration tests (manifest provider override, incompatible → throw / `ignoreCompatibility` → warn, publishes + env application, skip-if-exists)
- New doctor test (incompatible plugin → warn)
- `bun run build:clean`, `bun run typecheck`, `bun run test:bun` (2268 pass), `bun run test:examples`, `bun run audit:core-first`, `bun run audit:docs` — all green