### PR TITLE
chore: release v1.3.0

### DIFF
--- a/.changeset/audit-hidden-columns.md
+++ b/.changeset/audit-hidden-columns.md
@@ -1,5 +1,0 @@
----
-'@guren/cli': minor
----
-
-`guren audit` now warns when a model's schema table has sensitive-looking columns (password, secret, token, salt, hash) that are not excluded from serialization via `static hidden` or a `static visible` allowlist. Records passed to `serialize()`/`toJSON()` or Inertia props would otherwise expose those values. Models whose sensitive columns are all covered get a pass finding; models without sensitive columns produce no output.

--- a/.changeset/database-api-token-store.md
+++ b/.changeset/database-api-token-store.md
@@ -1,5 +1,0 @@
----
-'@guren/core': minor
----
-
-Add `DatabaseApiTokenStore`, a database-backed `ApiTokenStore` built on the Guren ORM. Pass the Drizzle table for your `api_tokens` schema and it plugs into `createApiToken`/`verifyApiToken` and the bearer-token middleware with no custom store code, using the app's configured ORM connection. Includes `deleteExpired()` for scheduled pruning and an `abilitiesMode: 'text'` option for plain-text JSON ability columns (JSON-capable columns are the default). The API tokens guide previously told users to hand-roll this class — it now documents the built-in store and the recommended schema.

--- a/.changeset/define-plugin.md
+++ b/.changeset/define-plugin.md
@@ -1,7 +1,0 @@
----
-'@guren/server': minor
----
-
-Add `definePlugin()` helper for authoring configurable plugins without ServiceProvider boilerplate. Each factory call returns an independent provider class with the configuration captured in a closure, so the same plugin can be registered multiple times with different configurations — replacing the unsafe static-config pattern previously shown in the plugin authoring guide. Supports `deferred`/`provides` for lazy loading. Exported from `@guren/core` alongside `PluginDefinition` and `PluginFactory` types. (RFC 0001, Part A)
-
-`ProviderManager.register()` now throws when a deferred provider declares no `provides` services — previously such a provider was silently dropped and could never load.

--- a/.changeset/detect-locale-middleware.md
+++ b/.changeset/detect-locale-middleware.md
@@ -1,5 +1,0 @@
----
-'@guren/server': minor
----
-
-Add `detectLocaleMiddleware`: resolves the request locale from the `?locale=` query parameter, a `locale` cookie, or the `Accept-Language` header (region subtags and q-values understood), restricted to a supported-locales allowlist. Sets the `locale` context variable — feeding the `<html lang>` attribute of Inertia responses — and binds request-scoped `t`/`tc` translator helpers when an i18n manager is available (the `setI18n()` global, or one passed via the `i18n` option). Also fixes the `<html lang>` i18n fallback in `Controller.inertia` to read the router-injected container (the previous context-variable lookup never fired in real apps).

--- a/.changeset/oauth-redirect-safety.md
+++ b/.changeset/oauth-redirect-safety.md
@@ -1,6 +1,0 @@
----
-'@guren/server': minor
-'@guren/cli': minor
----
-
-Guard OAuth `redirectTo` against open redirects. State creation and verification both sanitize the value: app-relative paths always pass, absolute URLs only when their host is in the new `stateConfig.allowedRedirectHosts` allowlist (wildcards supported); protocol-relative URLs, backslash variants, and non-http schemes are dropped. New `OAuthManager.handleCallback()` returns the profile together with the sanitized `redirectTo`, and `sanitizeOAuthRedirect()` is exported for custom flows. The `guren add oauth` scaffold now demonstrates the safe round-trip (`?redirectTo=` → `handleCallback`).

--- a/.changeset/plugin-authoring-skill.md
+++ b/.changeset/plugin-authoring-skill.md
@@ -1,5 +1,0 @@
----
-'@guren/cli': minor
----
-
-Add a `plugin-authoring` skill to the AI agent harness (`bunx guren agent:init` / `agent:sync`). Covers both installing an existing Guren plugin (`bunx guren plugin <pkg>`, including the manifest-driven provider/env/publishes flow and the no-`provider` manual-registration case) and authoring a new plugin package (`definePlugin()`, the `gurenPlugin` manifest fields, contributing CLI commands, and testing with `@guren/testing`).

--- a/.changeset/plugin-cli-commands.md
+++ b/.changeset/plugin-cli-commands.md
@@ -1,5 +1,0 @@
----
-'@guren/cli': minor
----
-
-Plugins can now contribute CLI commands via the `gurenPlugin.commands` manifest field (RFC 0001, Part C): `{ "entry": "./dist/commands.js", "names": ["myplugin:sync"] }`. Discovery reads only package.json files — the entry module (a default-exported record of citty command definitions) is imported lazily when one of the declared commands is invoked, never for `--help` listing. Command names must be `:`-namespaced, built-in command names always win, and a name declared by two plugins is dropped for both with a warning naming the packages.

--- a/.changeset/plugin-manifest-install.md
+++ b/.changeset/plugin-manifest-install.md
@@ -1,6 +1,0 @@
----
-'@guren/cli': minor
-'@guren/plugin-vercel': patch
----
-
-Turn `guren plugin <pkg>` into a full plugin installer driven by the declarative `gurenPlugin` package.json manifest (RFC 0001, Part B). The command now installs the dependency with `bun add` when missing (`--no-install` to skip), verifies the plugin's declared Guren `compatibility` range against the installed `@guren/core` (`--ignore-compatibility` to override), registers the manifest-declared `provider` export (falling back to the name heuristic), copies declared `publishes` files into `config/`, `db/migrations/`, or `resources/` (path-traversal guarded, never overwriting without `--force`), and appends declared `env` keys to `.env.example`/`.env`. The manifest is pure data — no plugin code is executed during installation. The command is now also registered at the top level (`bunx guren plugin ...` previously only worked as `guren add plugin ...` despite being documented). `bunx guren doctor` gains a Plugin Compatibility check that flags installed plugins whose `compatibility` range excludes the installed core version. `@guren/plugin-vercel` now declares its `gurenPlugin` manifest.

--- a/.changeset/sanitized-type-helper.md
+++ b/.changeset/sanitized-type-helper.md
@@ -1,5 +1,0 @@
----
-'@guren/server': minor
----
-
-Add the `Sanitized<T, Hidden>` type helper (and `DefaultSanitizedKeys`). `auth.user()` sanitizes records at runtime — the password column, remember-token column, and the model's `static hidden` fields are stripped — but the type previously still claimed those fields were present. `auth.userOrFail<Sanitized<UserRecord>>()` strips the conventional credential keys from the compile-time type (distributing over union records); columns with non-conventional names and extra hidden fields go in the second type parameter (`Sanitized<UserRecord, 'twoFactorSecret'>`).

--- a/.changeset/testing-session-hydration.md
+++ b/.changeset/testing-session-hydration.md
@@ -1,5 +1,0 @@
----
-'@guren/server': minor
----
-
-Wire `TestRequestBuilder.withSession()` to server-side session hydration: the session middleware now reads the `X-Testing-Session` header — only when `GUREN_TESTING` is set, same gate as `X-Testing-User` — parses the JSON payload, and merges it over the stored session data for the request. Tests using `createTestClient(...).get(...).withSession({ ... })` now observe the injected session state instead of an empty session. Malformed or non-object payloads are ignored.

--- a/examples/api/CHANGELOG.md
+++ b/examples/api/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @guren/example-api
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies [d7be76a]
+- Updated dependencies [2bbc832]
+- Updated dependencies [6e0efe2]
+- Updated dependencies [2f7aae5]
+- Updated dependencies [2f7aae5]
+- Updated dependencies [494ac11]
+  - @guren/cli@1.2.0
+  - @guren/core@1.1.0
+
 ## 0.1.2
 
 ### Patch Changes

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/example-api",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @guren/cli
 
+## 1.2.0
+
+### Minor Changes
+
+- d7be76a: `guren audit` now warns when a model's schema table has sensitive-looking columns (password, secret, token, salt, hash) that are not excluded from serialization via `static hidden` or a `static visible` allowlist. Records passed to `serialize()`/`toJSON()` or Inertia props would otherwise expose those values. Models whose sensitive columns are all covered get a pass finding; models without sensitive columns produce no output.
+- 6e0efe2: Guard OAuth `redirectTo` against open redirects. State creation and verification both sanitize the value: app-relative paths always pass, absolute URLs only when their host is in the new `stateConfig.allowedRedirectHosts` allowlist (wildcards supported); protocol-relative URLs, backslash variants, and non-http schemes are dropped. New `OAuthManager.handleCallback()` returns the profile together with the sanitized `redirectTo`, and `sanitizeOAuthRedirect()` is exported for custom flows. The `guren add oauth` scaffold now demonstrates the safe round-trip (`?redirectTo=` → `handleCallback`).
+- 2f7aae5: Add a `plugin-authoring` skill to the AI agent harness (`bunx guren agent:init` / `agent:sync`). Covers both installing an existing Guren plugin (`bunx guren plugin <pkg>`, including the manifest-driven provider/env/publishes flow and the no-`provider` manual-registration case) and authoring a new plugin package (`definePlugin()`, the `gurenPlugin` manifest fields, contributing CLI commands, and testing with `@guren/testing`).
+- 2f7aae5: Plugins can now contribute CLI commands via the `gurenPlugin.commands` manifest field (RFC 0001, Part C): `{ "entry": "./dist/commands.js", "names": ["myplugin:sync"] }`. Discovery reads only package.json files — the entry module (a default-exported record of citty command definitions) is imported lazily when one of the declared commands is invoked, never for `--help` listing. Command names must be `:`-namespaced, built-in command names always win, and a name declared by two plugins is dropped for both with a warning naming the packages.
+- 494ac11: Turn `guren plugin <pkg>` into a full plugin installer driven by the declarative `gurenPlugin` package.json manifest (RFC 0001, Part B). The command now installs the dependency with `bun add` when missing (`--no-install` to skip), verifies the plugin's declared Guren `compatibility` range against the installed `@guren/core` (`--ignore-compatibility` to override), registers the manifest-declared `provider` export (falling back to the name heuristic), copies declared `publishes` files into `config/`, `db/migrations/`, or `resources/` (path-traversal guarded, never overwriting without `--force`), and appends declared `env` keys to `.env.example`/`.env`. The manifest is pure data — no plugin code is executed during installation. The command is now also registered at the top level (`bunx guren plugin ...` previously only worked as `guren add plugin ...` despite being documented). `bunx guren doctor` gains a Plugin Compatibility check that flags installed plugins whose `compatibility` range excludes the installed core version. `@guren/plugin-vercel` now declares its `gurenPlugin` manifest.
+
+### Patch Changes
+
+- Updated dependencies [2bbc832]
+  - @guren/core@1.1.0
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/cli",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@babel/parser": "^7.24.7",
-    "@guren/core": "^1.0.0",
+    "@guren/core": "^1.1.0",
     "@guren/orm": "^1.0.1",
     "citty": "^0.1.6",
     "consola": "^3.4.2"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @guren/core
 
+## 1.1.0
+
+### Minor Changes
+
+- 2bbc832: Add `DatabaseApiTokenStore`, a database-backed `ApiTokenStore` built on the Guren ORM. Pass the Drizzle table for your `api_tokens` schema and it plugs into `createApiToken`/`verifyApiToken` and the bearer-token middleware with no custom store code, using the app's configured ORM connection. Includes `deleteExpired()` for scheduled pruning and an `abilitiesMode: 'text'` option for plain-text JSON ability columns (JSON-capable columns are the default). The API tokens guide previously told users to hand-roll this class — it now documents the built-in store and the recommended schema.
+
+### Patch Changes
+
+- Updated dependencies [d7be76a]
+- Updated dependencies [9576668]
+- Updated dependencies [15b4be0]
+- Updated dependencies [6e0efe2]
+- Updated dependencies [2f7aae5]
+- Updated dependencies [2f7aae5]
+- Updated dependencies [494ac11]
+- Updated dependencies [7683c66]
+- Updated dependencies [b1098cf]
+  - @guren/cli@1.2.0
+  - @guren/server@1.3.0
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/core",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -52,9 +52,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@guren/cli": "^1.0.0",
+    "@guren/cli": "^1.2.0",
     "@guren/orm": "^1.0.0",
-    "@guren/server": "^1.0.0"
+    "@guren/server": "^1.3.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.10",

--- a/packages/plugin-vercel/CHANGELOG.md
+++ b/packages/plugin-vercel/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @guren/plugin-vercel
 
+## 0.1.2
+
+### Patch Changes
+
+- 494ac11: Turn `guren plugin <pkg>` into a full plugin installer driven by the declarative `gurenPlugin` package.json manifest (RFC 0001, Part B). The command now installs the dependency with `bun add` when missing (`--no-install` to skip), verifies the plugin's declared Guren `compatibility` range against the installed `@guren/core` (`--ignore-compatibility` to override), registers the manifest-declared `provider` export (falling back to the name heuristic), copies declared `publishes` files into `config/`, `db/migrations/`, or `resources/` (path-traversal guarded, never overwriting without `--force`), and appends declared `env` keys to `.env.example`/`.env`. The manifest is pure data — no plugin code is executed during installation. The command is now also registered at the top level (`bunx guren plugin ...` previously only worked as `guren add plugin ...` despite being documented). `bunx guren doctor` gains a Plugin Compatibility check that flags installed plugins whose `compatibility` range excludes the installed core version. `@guren/plugin-vercel` now declares its `gurenPlugin` manifest.
+- Updated dependencies [2bbc832]
+  - @guren/core@1.1.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/plugin-vercel/package.json
+++ b/packages/plugin-vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/plugin-vercel",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -36,7 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@guren/core": "^1.0.0-rc.12"
+    "@guren/core": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.10",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @guren/server
 
+## 1.3.0
+
+### Minor Changes
+
+- 9576668: Add `definePlugin()` helper for authoring configurable plugins without ServiceProvider boilerplate. Each factory call returns an independent provider class with the configuration captured in a closure, so the same plugin can be registered multiple times with different configurations — replacing the unsafe static-config pattern previously shown in the plugin authoring guide. Supports `deferred`/`provides` for lazy loading. Exported from `@guren/core` alongside `PluginDefinition` and `PluginFactory` types. (RFC 0001, Part A)
+
+  `ProviderManager.register()` now throws when a deferred provider declares no `provides` services — previously such a provider was silently dropped and could never load.
+
+- 15b4be0: Add `detectLocaleMiddleware`: resolves the request locale from the `?locale=` query parameter, a `locale` cookie, or the `Accept-Language` header (region subtags and q-values understood), restricted to a supported-locales allowlist. Sets the `locale` context variable — feeding the `<html lang>` attribute of Inertia responses — and binds request-scoped `t`/`tc` translator helpers when an i18n manager is available (the `setI18n()` global, or one passed via the `i18n` option). Also fixes the `<html lang>` i18n fallback in `Controller.inertia` to read the router-injected container (the previous context-variable lookup never fired in real apps).
+- 6e0efe2: Guard OAuth `redirectTo` against open redirects. State creation and verification both sanitize the value: app-relative paths always pass, absolute URLs only when their host is in the new `stateConfig.allowedRedirectHosts` allowlist (wildcards supported); protocol-relative URLs, backslash variants, and non-http schemes are dropped. New `OAuthManager.handleCallback()` returns the profile together with the sanitized `redirectTo`, and `sanitizeOAuthRedirect()` is exported for custom flows. The `guren add oauth` scaffold now demonstrates the safe round-trip (`?redirectTo=` → `handleCallback`).
+- 7683c66: Add the `Sanitized<T, Hidden>` type helper (and `DefaultSanitizedKeys`). `auth.user()` sanitizes records at runtime — the password column, remember-token column, and the model's `static hidden` fields are stripped — but the type previously still claimed those fields were present. `auth.userOrFail<Sanitized<UserRecord>>()` strips the conventional credential keys from the compile-time type (distributing over union records); columns with non-conventional names and extra hidden fields go in the second type parameter (`Sanitized<UserRecord, 'twoFactorSecret'>`).
+- b1098cf: Wire `TestRequestBuilder.withSession()` to server-side session hydration: the session middleware now reads the `X-Testing-Session` header — only when `GUREN_TESTING` is set, same gate as `X-Testing-User` — parses the JSON payload, and merges it over the stored session data for the request. Tests using `createTestClient(...).get(...).withSession({ ... })` now observe the injected session state instead of an empty session. Malformed or non-object payloads are ignored.
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/server",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,19 @@
 # web
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies [d7be76a]
+- Updated dependencies [2bbc832]
+- Updated dependencies [6e0efe2]
+- Updated dependencies [2f7aae5]
+- Updated dependencies [2f7aae5]
+- Updated dependencies [494ac11]
+  - @guren/cli@1.2.0
+  - @guren/core@1.1.0
+  - @guren/plugin-vercel@0.1.2
+
 ## 0.1.2
 
 ### Patch Changes

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Version bump via changesets for the v1.3.0 release, covering everything merged to `main` since v1.2.0:

- **`@guren/server` → 1.3.0**: `definePlugin()` helper (RFC 0001 Part A), `detectLocaleMiddleware`, OAuth `redirectTo` open-redirect guard, `Sanitized<T>` type helper, `withSession()` test hydration
- **`@guren/core` → 1.1.0**: `DatabaseApiTokenStore`
- **`@guren/cli` → 1.2.0**: manifest-driven `guren plugin` installer + doctor compatibility check (RFC 0001 Part B), plugin-contributed CLI commands (RFC 0001 Part C), `plugin-authoring` agent skill, audit hidden-columns warning, OAuth redirect guard
- **`@guren/plugin-vercel` → 0.1.2**: declares `gurenPlugin` manifest (patch, dependency bump)
- **`examples/api`, `web` → patch**: dependency bumps only

## Test plan
- [x] `bun run build:clean` — all packages build
- [x] `bun run typecheck` — no errors
- [x] `bun run test:bun` — 2236 pass, 0 fail (45 skipped)
- [ ] After merge: `gh release create v1.3.0 --latest` to trigger npm publish