### PR TITLE
fix(create-app): stop citty mock leaking a stubbed runCommand

### DIFF
--- a/packages/create-app/tests/cli.test.ts
+++ b/packages/create-app/tests/cli.test.ts
@@ -12,22 +12,17 @@ const debugMock = mock(() => {})
 const errorMock = mock(() => {})
 
 // Bun runs all test files in one shared process, and mock.module()
-// replacements are not undone by mock.restore() — a mock missing an export
-// silently breaks any other test file that needs the real one. Mirror
-// citty's full export surface even though this file only exercises
-// defineCommand/runMain.
+// replacements are not undone by mock.restore() — even with --isolate the
+// replacement leaks into other test files through the shared module
+// registry. Spread the real module and override only runMain (all this file
+// needs), so leaked imports still get the real defineCommand/runCommand —
+// stubbing runCommand here silently broke the plugin-commands tests.
+const realCitty = await import('citty')
 await mock.module('citty', () => ({
-  createMain: (command: any) => () => command,
-  defineCommand: (command: any) => command,
-  parseArgs: (args: unknown) => args,
-  renderUsage: async () => '',
-  runCommand: async (command: any) => {
-    capturedCommand = command
-  },
+  ...realCitty,
   runMain: async (command: any) => {
     capturedCommand = command
   },
-  showUsage: async () => {},
 }))
 
 const consolaStub = {


### PR DESCRIPTION
## Summary

The v1.3.0 release workflow failed twice at `Run tests`: two `plugin-commands` tests failed with `runCommand` resolving instead of executing/throwing (`packages/cli/tests/plugin-commands.test.ts:151`).

**Root cause:** `packages/create-app/tests/cli.test.ts` mocked every `citty` export, including a `runCommand` stub that captures the command without running it. `mock.module()` replacements leak across test files through the shared module registry even under `--isolate`. The new plugin-commands tests are the first to depend on the *real* `runCommand`, and in CI (where create-app tests run before cli tests) they deterministically got the stub.

**Fix:** spread the real `citty` module and override only `runMain`, which is all the create-app tests exercise. Leaked imports now resolve to the real implementations.

## Verification

Reproduced and verified under CI-equivalent conditions (Docker `oven/bun:1.3.11`, `--cpus=2`, container-local disk, full `test:bun` invocation):

- Before fix: **3/3 runs failed** with exactly the two CI-failing tests
- After fix: **3/3 runs passed** (2236 pass, 0 fail)
- Local macOS (Bun 1.3.14): full `test:bun` passes

## Test plan
- [x] `bun run test:bun` — 2236 pass, 0 fail
- [x] CI-equivalent Docker reproduction confirms before/after behavior