### PR TITLE
docs: remove dead ROADMAP.md link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ const post = await Post.findOrFail(1)
 
 - [Official docs](https://gurenjs.vercel.app/) — tutorials, API reference, guides
 - [examples/blog](./examples/blog) — reference implementation
-- [ROADMAP.md](./ROADMAP.md) — development plans
 
 ---
 


### PR DESCRIPTION
## Summary
- `README.md` linked to `./ROADMAP.md`, but that file was deleted in the v1.0-alpha commit (4518155) and never restored — the link 404s.
- Remove the dead link from the Documentation section.

## Test plan
- N/A (docs only)