### PR TITLE
fix(cli): accept per-file symlinked local installs in plugin path guard

### DIFF
--- a/.changeset/plugin-local-install-symlinks.md
+++ b/.changeset/plugin-local-install-symlinks.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': patch
+---
+
+Fix `guren plugin` publishes and plugin CLI command discovery for locally installed plugins. Bun materializes `file:`, `link:`, and `workspace:` dependencies as per-file symlinks into the source directory, so the path-escape guard — which canonicalized paths against the node_modules entry only — misclassified every file in such packages as escaping the package directory: `publishes` aborted the install with an error and declared commands were silently dropped from `guren --help`. The guard now also accepts the package's content root (the realpath parent of its `package.json`), which is the node_modules entry itself for regular installs and the source directory for per-file-symlink installs. Malicious symlinks pointing outside both roots are still rejected.

--- a/packages/cli/src/plugin-commands.ts
+++ b/packages/cli/src/plugin-commands.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path'
 import { consola } from 'consola'
 import { defineCommand, runCommand as runCittyCommand } from 'citty'
 import type { ArgsDef, CommandDef } from 'citty'
-import { readInstalledPluginManifests, resolveInside } from './plugin-manifest'
+import { packageContentRoot, readInstalledPluginManifests, resolveInside } from './plugin-manifest'
 
 /**
  * A CLI command contributed by an installed plugin, discovered from its
@@ -42,7 +42,9 @@ export async function discoverPluginCommands(
       continue
     }
 
-    const entryPath = await resolveInside(resolve(cwd, 'node_modules', packageName), commands.entry)
+    const packageDir = resolve(cwd, 'node_modules', packageName)
+    const contentRoot = await packageContentRoot(packageDir)
+    const entryPath = await resolveInside(packageDir, commands.entry, contentRoot ? [contentRoot] : [])
     if (entryPath === null) {
       consola.warn(`Ignoring commands from "${packageName}": entry "${commands.entry}" escapes the package directory.`)
       continue

--- a/packages/cli/src/plugin-manifest.ts
+++ b/packages/cli/src/plugin-manifest.ts
@@ -134,8 +134,19 @@ async function realpathNearestExisting(candidate: string): Promise<string> {
  * (or a symlinked `node_modules` entry) can't be used to read or write
  * outside the intended directory. The candidate path (not its realpath) is
  * returned so callers keep operating on the logical location.
+ *
+ * `extraRealRoots` are additional canonical directories the resolved path
+ * may live in. Local installs (`bun add file:`, `link:`, `workspace:*`)
+ * materialize a package as per-file symlinks into the source directory, so
+ * every file's realpath escapes the node_modules entry while the entry
+ * itself does not — package-side callers pass the package's content root
+ * (see packageContentRoot) to accept that layout.
  */
-export async function resolveInside(baseDir: string, relPath: string): Promise<string | null> {
+export async function resolveInside(
+  baseDir: string,
+  relPath: string,
+  extraRealRoots: string[] = [],
+): Promise<string | null> {
   if (isAbsolute(relPath)) return null
 
   const candidate = resolve(baseDir, relPath)
@@ -149,10 +160,28 @@ export async function resolveInside(baseDir: string, relPath: string): Promise<s
   }
 
   const realCandidate = await realpathNearestExisting(candidate)
-  const realRelative = relative(realBase, realCandidate)
-  if (realRelative.startsWith('..') || isAbsolute(realRelative)) return null
+  const containedIn = (root: string): boolean => {
+    const realRelative = relative(root, realCandidate)
+    return !realRelative.startsWith('..') && !isAbsolute(realRelative)
+  }
+  if (![realBase, ...extraRealRoots].some(containedIn)) return null
 
   return candidate
+}
+
+/**
+ * Canonical directory holding a package's actual content: the realpath
+ * parent of its package.json. For a regular npm install this equals the
+ * package directory itself; for per-file-symlink local installs it is the
+ * source directory every file link points into. Returns null when
+ * package.json cannot be resolved.
+ */
+export async function packageContentRoot(packageDir: string): Promise<string | null> {
+  try {
+    return dirname(await realpath(join(packageDir, 'package.json')))
+  } catch {
+    return null
+  }
 }
 
 /**
@@ -247,6 +276,8 @@ export async function applyPublishes(
 ): Promise<PublishResult> {
   const cwd = options.cwd ?? process.cwd()
   const packageDir = resolve(cwd, 'node_modules', packageName)
+  const contentRoot = await packageContentRoot(packageDir)
+  const packageRoots = contentRoot ? [contentRoot] : []
   const invalid = (detail: string): Error => new Error(`Invalid publish entry in "${packageName}": ${detail}`)
 
   // Validate sequentially so the first invalid entry is always the one
@@ -262,7 +293,7 @@ export async function applyPublishes(
       throw invalid('absolute paths are not allowed.')
     }
 
-    const fromPath = await resolveInside(packageDir, entry.from)
+    const fromPath = await resolveInside(packageDir, entry.from, packageRoots)
     if (fromPath === null) {
       throw invalid(`source "${entry.from}" escapes the package directory.`)
     }

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -26,6 +26,37 @@ export async function writeInstalledPackage(
     const filePath = join(packageDir, relativePath)
     await mkdir(dirname(filePath), { recursive: true })
     await writeFile(filePath, content)
+  }
+}
+
+/**
+ * Write a fake locally-installed package the way Bun materializes `file:`,
+ * `link:`, and `workspace:` dependencies: node_modules/<name> is a real
+ * directory tree whose files are individual symlinks into the source
+ * directory.
+ */
+export async function linkInstalledPackage(
+  name: string,
+  packageJson: Record<string, unknown>,
+  files: Record<string, string> = {},
+  baseDir: string = process.cwd(),
+): Promise<void> {
+  const sourceDir = join(baseDir, 'local-packages', name)
+  const packageDir = join(baseDir, 'node_modules', name)
+
+  const contents: Record<string, string> = {
+    'package.json': JSON.stringify({ name, ...packageJson }, null, 2),
+    ...files,
+  }
+
+  for (const [relativePath, content] of Object.entries(contents)) {
+    const sourcePath = join(sourceDir, relativePath)
+    await mkdir(dirname(sourcePath), { recursive: true })
+    await writeFile(sourcePath, content)
+
+    const linkPath = join(packageDir, relativePath)
+    await mkdir(dirname(linkPath), { recursive: true })
+    await symlink(sourcePath, linkPath)
   }
 }
 

--- a/packages/cli/tests/plugin-commands.test.ts
+++ b/packages/cli/tests/plugin-commands.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, afterEach, describe, expect, it } from 'bun:test'
 import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { runCommand } from 'citty'
-import { createTempWorkspace, writeInstalledPackage, type TempWorkspace } from './helpers'
+import { createTempWorkspace, linkInstalledPackage, writeInstalledPackage, type TempWorkspace } from './helpers'
 import { discoverPluginCommands, createPluginCommandProxy } from '../src/plugin-commands'
 
 const PLUGIN_NAME = '@acme/guren-plugin-audit'
@@ -100,6 +100,20 @@ describe('plugin-commands', () => {
       const discovered = await discoverPluginCommands()
 
       expect(discovered.map((command) => command.name)).toEqual(['other:sync'])
+    })
+
+    it('should discover commands from a per-file symlinked local install', async () => {
+      await writeAppPackageJson({ [PLUGIN_NAME]: 'file:../guren-plugin-audit' })
+      await linkInstalledPackage(PLUGIN_NAME, {
+        gurenPlugin: { commands: { entry: 'dist/commands.mjs', names: ['audit:report'] } },
+      }, {
+        'dist/commands.mjs': 'export default {}\n',
+      })
+
+      const discovered = await discoverPluginCommands()
+
+      expect(discovered).toHaveLength(1)
+      expect(discovered[0].name).toBe('audit:report')
     })
 
     it('should reject entries escaping the package directory', async () => {

--- a/packages/cli/tests/plugin-manifest.test.ts
+++ b/packages/cli/tests/plugin-manifest.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, afterEach, describe, expect, it } from 'bun:test'
 import { mkdir, readFile, symlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { createTempWorkspace, writeInstalledPackage, type TempWorkspace } from './helpers'
+import { createTempWorkspace, linkInstalledPackage, writeInstalledPackage, type TempWorkspace } from './helpers'
 import {
   applyEnvEntries,
   applyPublishes,
@@ -175,6 +175,32 @@ describe('plugin-manifest', () => {
       await expect(applyPublishes(PLUGIN_NAME, [
         { from: '/etc/passwd', to: 'config/passwd.ts' },
       ])).rejects.toThrow('absolute paths are not allowed')
+    })
+
+    it('should copy files from a per-file symlinked local install', async () => {
+      await linkInstalledPackage('@acme/guren-plugin-local', {}, {
+        'stubs/hello.ts': 'export const hello = true\n',
+      })
+
+      const result = await applyPublishes('@acme/guren-plugin-local', [
+        { from: 'stubs/hello.ts', to: 'config/hello.ts' },
+      ])
+
+      expect(result.written).toEqual(['config/hello.ts'])
+      expect(await readFile('config/hello.ts', 'utf8')).toBe('export const hello = true\n')
+    })
+
+    it('should still reject escaping sources in a per-file symlinked local install', async () => {
+      await linkInstalledPackage('@acme/guren-plugin-local', {}, {
+        'stubs/hello.ts': 'export const hello = true\n',
+      })
+      const secretPath = join(workspace.dir, 'secret.ts')
+      await writeFile(secretPath, 'export const secret = true\n')
+      await symlink(secretPath, join(workspace.dir, 'node_modules', '@acme/guren-plugin-local', 'stubs', 'escape-link.ts'))
+
+      await expect(applyPublishes('@acme/guren-plugin-local', [
+        { from: 'stubs/escape-link.ts', to: 'config/hello.ts' },
+      ])).rejects.toThrow('escapes the package directory')
     })
 
     it('should reject a source that is a symlink escaping the package directory', async () => {


### PR DESCRIPTION
## Summary

Dogfooding the v1.3.0 plugin system end-to-end (authoring a plugin with `definePlugin()`, a full `gurenPlugin` manifest, and a contributed CLI command, then installing it into a fresh `create-guren-app` app) surfaced a real-world break: **locally installed plugins fail the path-escape guard**.

Bun materializes `file:`, `link:`, and `workspace:` dependencies as **per-file symlinks** into the source directory — `package.json`, `dist/*`, `publish/*` are each individual symlinks while the `node_modules/<pkg>` directory itself is real. `resolveInside()` canonicalizes candidates against the realpath of the node_modules entry only, so every file in such a package resolves "outside" it:

- `publishes` → `guren plugin <pkg>` aborts with `Invalid publish entry … escapes the package directory`
- `commands` → declared commands are silently dropped from `guren --help` and invocation, on every CLI start

This breaks the standard author workflow documented in the `plugin-authoring` skill (test locally before publishing), and would also bite `@guren/plugin-vercel` itself once its hardcoded installer moves to manifest `publishes` (the monorepo uses `workspace:*`).

## Fix

`resolveInside()` now accepts additional allowed real roots, and package-side callers (`applyPublishes` source paths, `discoverPluginCommands` entry) pass the package's **content root** — the realpath parent of its `package.json`:

- Regular npm install: content root == the package directory → behavior unchanged
- Per-file-symlink local install: content root == the source directory every file link points into → legitimate files pass
- Malicious symlinks pointing outside **both** roots are still rejected (existing escape tests unchanged and passing, plus a new escape test under the symlinked layout)

The app-side target guard (`to` paths) stays strict — no extra roots.

## Test plan
- [x] New `linkInstalledPackage` test helper mirrors Bun's per-file symlink layout
- [x] New tests: publishes copy + command discovery under symlinked installs; escape rejection still enforced under the same layout
- [x] `bun test --isolate packages/cli` — 392 pass, 0 fail
- [x] Real-world verification: `bun add file:../guren-plugin-hello` into a fresh scaffolded app, then `guren plugin` (publishes + env applied) and `guren hello:greet` (discovered and runs) using the patched CLI
- [x] `bun run build:cli`, `bun run typecheck`