### PR TITLE
fix(cli): correct make:resource types, align make:test runner/controller with check

### DIFF
--- a/.changeset/cli-make-resource-and-make-test-fixes.md
+++ b/.changeset/cli-make-resource-and-make-test-fixes.md
@@ -1,0 +1,9 @@
+---
+"@guren/cli": minor
+---
+
+Fix `make:resource --model` generating code that doesn't type-check: it referenced the model's class name (`Resource<Comment>`) instead of its inferred record type, and unconditionally called `.toISOString()` on `createdAt`/`updatedAt` even when the Drizzle schema stores them as `text()` (ISO strings), which throws at runtime. The generated resource now imports and extends `Resource<XRecord>` and leaves timestamp mapping to the developer instead of guessing the column type.
+
+Fix `make:test` defaulting to a `vitest` import even in projects with no vitest installed (scaffolded apps ship `bun test`, not vitest) — the runner is now auto-detected from `vitest.config.*` / a `vitest` dependency in `package.json`, falling back to `bun:test`; `--runner` still overrides detection when passed explicitly.
+
+Add the `--controller` flag to `make:test`, which `guren check`'s remediation message already referenced but which didn't exist — it now suffixes the class name with `Controller` and writes to `tests/controllers/${ClassName}.test.ts`, matching `guren check`'s first lookup candidate.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -176,8 +176,12 @@ const makeTestCommand = defineCommand({
     },
     runner: {
       type: 'string',
-      description: 'Test runner to scaffold for (bun or vitest)',
+      description: 'Test runner to scaffold for (bun or vitest). Defaults to auto-detecting the target project.',
       valueHint: 'bun|vitest',
+    },
+    controller: {
+      type: 'boolean',
+      description: 'Scaffold a controller test in tests/controllers/ with a Controller suffix',
     },
     force: {
       type: 'boolean',
@@ -200,7 +204,11 @@ const makeTestCommand = defineCommand({
     }
 
     const writerOptions = toWriterOptions(args)
-    const file = await makeTest(args.name, runner ? { ...writerOptions, runner } : writerOptions)
+    const file = await makeTest(args.name, {
+      ...writerOptions,
+      ...(runner ? { runner } : {}),
+      controller: Boolean(args.controller),
+    })
     consola.success(`Test created at ${file}`)
   },
 })

--- a/packages/cli/src/make-resource.ts
+++ b/packages/cli/src/make-resource.ts
@@ -5,14 +5,23 @@ const RESOURCES_DIR = 'app/Http/Resources'
 
 function resourceTemplate(className: string, modelName: string): string {
   return `import { Resource } from '@guren/core'
+import type { ${modelName}Record } from '../../Models/${modelName}.js'
 
-export class ${className} extends Resource<${modelName}> {
-  toArray() {
+export interface ${className}Data extends Record<string, unknown> {
+  id: number
+}
+
+export class ${className} extends Resource<${modelName}Record> {
+  toArray(): ${className}Data {
     return {
-      id: this.resource.id,
-      createdAt: this.resource.createdAt?.toISOString(),
-      updatedAt: this.resource.updatedAt?.toISOString(),
+      id: this.resource.id as number,
+      // Map the remaining ${modelName}Record columns here. Only call
+      // .toISOString() on Date columns — text timestamps are already strings.
     }
+  }
+
+  override toJSON(): ${className}Data {
+    return super.toJSON() as ${className}Data
   }
 }
 `

--- a/packages/cli/src/make-resource.ts
+++ b/packages/cli/src/make-resource.ts
@@ -8,13 +8,13 @@ function resourceTemplate(className: string, modelName: string): string {
 import type { ${modelName}Record } from '../../Models/${modelName}.js'
 
 export interface ${className}Data extends Record<string, unknown> {
-  id: number
+  id: ${modelName}Record['id']
 }
 
 export class ${className} extends Resource<${modelName}Record> {
   toArray(): ${className}Data {
     return {
-      id: this.resource.id as number,
+      id: this.resource.id,
       // Map the remaining ${modelName}Record columns here. Only call
       // .toISOString() on Date columns — text timestamps are already strings.
     }

--- a/packages/cli/src/make-test.ts
+++ b/packages/cli/src/make-test.ts
@@ -1,11 +1,57 @@
+import { resourceName, writeFileSafe, ensureSuffix } from './utils'
 import type { WriterOptions } from './utils'
-import { resourceName, writeFileSafe } from './utils'
+import { fileExists, readIfExists } from './discovery'
 
 const TEST_ROOT = 'tests'
+const CONTROLLER_TEST_DIR = `${TEST_ROOT}/controllers`
 
 export type TestRunner = 'bun' | 'vitest'
 
-const DEFAULT_RUNNER: TestRunner = 'vitest'
+// Scaffolded apps run their test script via `bun test` and don't ship
+// vitest by default, so `bun:test` is the safe default. `detectRunner`
+// switches to vitest when the target project has opted into it.
+const FALLBACK_RUNNER: TestRunner = 'bun'
+
+const VITEST_CONFIG_CANDIDATES = [
+  'vitest.config.ts',
+  'vitest.config.js',
+  'vitest.config.mts',
+  'vitest.config.mjs',
+  'vitest.config.cts',
+  'vitest.config.cjs',
+]
+
+interface PackageJsonShape {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+/**
+ * Detect which test runner the target project (cwd) is set up for.
+ * Looks for a vitest config file, then for a `vitest` dependency in
+ * package.json. Falls back to `bun` when neither is found.
+ */
+export async function detectRunner(cwd: string = process.cwd()): Promise<TestRunner> {
+  for (const candidate of VITEST_CONFIG_CANDIDATES) {
+    if (await fileExists(cwd, candidate)) {
+      return 'vitest'
+    }
+  }
+
+  const pkgRaw = await readIfExists(cwd, 'package.json')
+  if (pkgRaw) {
+    try {
+      const pkg = JSON.parse(pkgRaw) as PackageJsonShape
+      if (pkg.dependencies?.vitest || pkg.devDependencies?.vitest) {
+        return 'vitest'
+      }
+    } catch {
+      // Malformed package.json — fall through to the default runner.
+    }
+  }
+
+  return FALLBACK_RUNNER
+}
 
 function testTemplate(suiteName: string, runner: TestRunner): string {
   const importPath = runner === 'bun' ? 'bun:test' : 'vitest'
@@ -22,6 +68,7 @@ describe('${suiteName}', () => {
 
 export interface MakeTestOptions extends WriterOptions {
   runner?: TestRunner
+  controller?: boolean
 }
 
 export async function makeTest(name: string, options: MakeTestOptions = {}): Promise<string> {
@@ -30,7 +77,7 @@ export async function makeTest(name: string, options: MakeTestOptions = {}): Pro
     throw new Error('Test name is required.')
   }
 
-  const runner = options.runner ?? DEFAULT_RUNNER
+  const runner = options.runner ?? (await detectRunner())
 
   const normalizedPath = trimmed.replace(/^\/+/gu, '').replace(/\/+$/gu, '')
   if (!normalizedPath) {
@@ -40,10 +87,13 @@ export async function makeTest(name: string, options: MakeTestOptions = {}): Pro
   const segments = normalizedPath.split('/').filter(Boolean)
   const baseSegment = segments.pop() ?? 'Example'
   const baseName = baseSegment.replace(/\.(test\.)?(t|j)sx?$/giu, '')
-  const { className } = resourceName(baseName)
+  const { className: baseClassName } = resourceName(baseName)
+  const className = options.controller ? ensureSuffix(baseClassName, 'Controller') : baseClassName
   const fileName = `${className}.test.ts`
-  const filePath = `${TEST_ROOT}/${[...segments, fileName].join('/')}`
+  const filePath = options.controller
+    ? `${CONTROLLER_TEST_DIR}/${fileName}`
+    : `${TEST_ROOT}/${[...segments, fileName].join('/')}`
 
-  const { runner: _runner, ...writer } = options
+  const { runner: _runner, controller: _controller, ...writer } = options
   return writeFileSafe(filePath, testTemplate(className, runner), writer)
 }

--- a/packages/cli/tests/make-commands.test.ts
+++ b/packages/cli/tests/make-commands.test.ts
@@ -233,7 +233,8 @@ describe('CLI make:* commands', () => {
     it('uses custom model name', async () => {
       const result = await makeResource('UserProfile', { model: 'Profile' })
       const content = fs.readFileSync(result, 'utf-8')
-      expect(content).toContain('Resource<Profile>')
+      expect(content).toContain('Resource<ProfileRecord>')
+      expect(content).toContain("import type { ProfileRecord } from '../../Models/Profile.js'")
     })
 
     it('preserves Resource suffix if already present', async () => {

--- a/packages/cli/tests/make-resource.test.ts
+++ b/packages/cli/tests/make-resource.test.ts
@@ -16,6 +16,11 @@ describe('makeResource', () => {
       )
       expect(content).toContain('export class CommentResource extends Resource<CommentRecord>')
       expect(content).toContain('export interface CommentResourceData extends Record<string, unknown>')
+      // id type is derived from the record, not hardcoded — a UUID/text primary
+      // key must not be forced through an incorrect `number` cast.
+      expect(content).toContain("id: CommentRecord['id']")
+      expect(content).toContain('id: this.resource.id,')
+      expect(content).not.toContain('as number')
       expect(content).not.toContain('this.resource.createdAt?.toISOString()')
     } finally {
       await workspace.cleanup()

--- a/packages/cli/tests/make-resource.test.ts
+++ b/packages/cli/tests/make-resource.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { createTempWorkspace } from './helpers'
+import { makeResource } from '../src/make-resource'
+
+describe('makeResource', () => {
+  it('generates a resource typed against the model record', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-resource-')
+    try {
+      const result = await makeResource('Comment', { model: 'Comment' })
+
+      expect(result).toContain('app/Http/Resources/CommentResource.ts')
+      const content = await readFile(result, 'utf8')
+      expect(content).toContain(
+        "import type { CommentRecord } from '../../Models/Comment.js'",
+      )
+      expect(content).toContain('export class CommentResource extends Resource<CommentRecord>')
+      expect(content).toContain('export interface CommentResourceData extends Record<string, unknown>')
+      expect(content).not.toContain('this.resource.createdAt?.toISOString()')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('derives the model name from the resource name when --model is omitted', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-resource-derived-')
+    try {
+      const result = await makeResource('PostResource')
+
+      const content = await readFile(result, 'utf8')
+      expect(content).toContain("import type { PostRecord } from '../../Models/Post.js'")
+      expect(content).toContain('extends Resource<PostRecord>')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})

--- a/packages/cli/tests/make-test.test.ts
+++ b/packages/cli/tests/make-test.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'bun:test'
-import { readFile } from 'node:fs/promises'
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
 import { createTempWorkspace } from './helpers'
-import { makeTest } from '../src/make-test'
+import { detectRunner, makeTest } from '../src/make-test'
 
 describe('makeTest', () => {
   it('creates a test file using the provided runner', async () => {
@@ -22,6 +23,131 @@ describe('makeTest', () => {
     const workspace = await createTempWorkspace('guren-cli-make-test-empty-')
     try {
       await expect(makeTest('   ')).rejects.toThrow('Test name is required')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('defaults to bun:test when the project has no vitest dependency or config', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-test-default-')
+    try {
+      await writeFile(join(workspace.dir, 'package.json'), JSON.stringify({ name: 'app', devDependencies: {} }))
+
+      const result = await makeTest('widget')
+
+      const content = await readFile(result, 'utf8')
+      expect(content).toContain("from 'bun:test'")
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('detects vitest when it is listed in package.json', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-test-vitest-pkg-')
+    try {
+      await writeFile(
+        join(workspace.dir, 'package.json'),
+        JSON.stringify({ name: 'app', devDependencies: { vitest: '^2.0.0' } }),
+      )
+
+      const result = await makeTest('widget')
+
+      const content = await readFile(result, 'utf8')
+      expect(content).toContain("from 'vitest'")
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('detects vitest when a vitest config file is present', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-test-vitest-config-')
+    try {
+      await writeFile(join(workspace.dir, 'vitest.config.ts'), 'export default {}\n')
+
+      const result = await makeTest('widget')
+
+      const content = await readFile(result, 'utf8')
+      expect(content).toContain("from 'vitest'")
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('prefers an explicit --runner over auto-detection', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-test-explicit-runner-')
+    try {
+      await writeFile(
+        join(workspace.dir, 'package.json'),
+        JSON.stringify({ name: 'app', devDependencies: { vitest: '^2.0.0' } }),
+      )
+
+      const result = await makeTest('widget', { runner: 'bun' })
+
+      const content = await readFile(result, 'utf8')
+      expect(content).toContain("from 'bun:test'")
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('scaffolds a controller test into tests/controllers with a Controller suffix', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-test-controller-')
+    try {
+      const result = await makeTest('Post', { runner: 'bun', controller: true })
+
+      expect(result).toContain('tests/controllers/PostController.test.ts')
+      const content = await readFile(result, 'utf8')
+      expect(content).toContain("describe('PostController'")
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('does not double-append Controller when the name already has the suffix', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-test-controller-suffix-')
+    try {
+      const result = await makeTest('PostController', { runner: 'bun', controller: true })
+
+      expect(result).toContain('tests/controllers/PostController.test.ts')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})
+
+describe('detectRunner', () => {
+  it('returns bun when no vitest signal is present', async () => {
+    const workspace = await createTempWorkspace('guren-cli-detect-runner-bun-')
+    try {
+      const runner = await detectRunner(workspace.dir)
+      expect(runner).toBe('bun')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('returns vitest when package.json lists it as a dependency', async () => {
+    const workspace = await createTempWorkspace('guren-cli-detect-runner-dep-')
+    try {
+      await writeFile(
+        join(workspace.dir, 'package.json'),
+        JSON.stringify({ name: 'app', dependencies: { vitest: '^2.0.0' } }),
+      )
+
+      const runner = await detectRunner(workspace.dir)
+      expect(runner).toBe('vitest')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('returns bun when package.json is malformed', async () => {
+    const workspace = await createTempWorkspace('guren-cli-detect-runner-malformed-')
+    try {
+      await writeFile(join(workspace.dir, 'package.json'), '{ not valid json')
+
+      const runner = await detectRunner(workspace.dir)
+      expect(runner).toBe('bun')
     } finally {
       await workspace.cleanup()
     }


### PR DESCRIPTION
## Summary

Two independent `@guren/cli` generator bugs found while auditing a downstream retrospective doc against this repo's actual generator output.

### `make:resource --model`
Generated code that doesn't type-check or run correctly:
- `Resource<${modelName}>` embedded the model **class name** (e.g. `Resource<Comment>`) as the type argument instead of its Drizzle-inferred record type (`CommentRecord`).
- `createdAt`/`updatedAt` always got `.toISOString()` calls, which throws at runtime whenever the schema stores them via `text()` (ISO string) rather than a `Date`-typed column — the generator never looked at the schema to decide.

Now generates `export class CommentResource extends Resource<CommentRecord>` with the matching `import type { CommentRecord } from '../../Models/Comment.js'`, and leaves timestamp field mapping to the developer instead of guessing.

### `make:test`
- Defaulted to generating a `vitest` import (`DEFAULT_RUNNER = 'vitest'`) regardless of the target project — but scaffolded apps ship `bun test`, not vitest, so this produced code that fails to import out of the box. Runner is now auto-detected (`detectRunner()`): explicit `--runner` wins, otherwise checks for `vitest.config.{ts,js,mts,mjs,cts,cjs}` or a `vitest` entry in `package.json`, falling back to `bun:test`.
- `guren check`'s remediation message (`check.ts`) already told users to run `make:test ${name} --controller`, but that flag didn't exist — bin.ts only wired `name`/`runner`/`force`. Now implemented: it suffixes the class name with `Controller` (no double-suffixing) and writes to `tests/controllers/${ClassName}.test.ts`, matching `check`'s first lookup candidate so the generated file is actually found.

## Test plan
- [x] `bun test packages/cli/tests/make-commands.test.ts packages/cli/tests/make-test.test.ts packages/cli/tests/make-resource.test.ts` — 62 pass (added `make-resource.test.ts`; extended `make-test.test.ts` with runner-detection and `--controller` cases)
- [x] `tsc --noEmit -p packages/cli` — clean
- [x] Changeset added (`minor`)

## Context
Part of a 4-PR split from the same investigation as the `@guren/testing`, `@guren/create-app`, and agent-harness docs PRs.