### PR TITLE
feat(create-app): isolate test-run SQLite DB, bundle @guren/testing

### DIFF
--- a/.changeset/create-app-test-db-isolation.md
+++ b/.changeset/create-app-test-db-isolation.md
@@ -1,0 +1,7 @@
+---
+"@guren/create-app": minor
+---
+
+Scaffolded apps (`default` and `api-only` blueprints) no longer route test runs into the development SQLite database. `config/database.ts`'s filename resolver now checks `NODE_ENV === 'test'` (which `bun test` sets automatically) and points at `./data/guren.test.db` instead of `./data/guren.db`, unless `DATABASE_URL` is explicitly set — which still wins.
+
+Also add `@guren/testing` to both templates' `devDependencies`, matching the version format already used for other `@guren/*` packages — previously a fresh scaffold had no path to `TestApp`/controller testing without a manual `bun add -d @guren/testing` first.

--- a/packages/create-app/src/blueprints.ts
+++ b/packages/create-app/src/blueprints.ts
@@ -312,13 +312,15 @@ export const { getDatabase, migrateDatabase, closeDatabase, configureOrm, seedDa
   return `import { createSqliteDatabase } from '@guren/orm'
 
 // \`bun test\` sets NODE_ENV=test automatically, so the test suite reads and
-// writes a separate SQLite file and never touches the development database.
-// DATABASE_URL always wins when set (e.g. in CI or production).
+// writes a separate SQLite file and never touches the development database —
+// this takes priority over DATABASE_URL, which .env sets unconditionally.
+// Override the test DB path itself with TEST_DATABASE_URL if needed (e.g. to
+// shard parallel CI runs); DATABASE_URL is still authoritative outside tests.
 function resolveDatabaseFilename(): string {
-  if (process.env.DATABASE_URL) {
-    return process.env.DATABASE_URL
+  if (process.env.NODE_ENV === 'test') {
+    return process.env.TEST_DATABASE_URL ?? './data/guren.test.db'
   }
-  return process.env.NODE_ENV === 'test' ? './data/guren.test.db' : '${url}'
+  return process.env.DATABASE_URL ?? '${url}'
 }
 
 const database = createSqliteDatabase({

--- a/packages/create-app/src/blueprints.ts
+++ b/packages/create-app/src/blueprints.ts
@@ -311,10 +311,20 @@ export const { getDatabase, migrateDatabase, closeDatabase, configureOrm, seedDa
 
   return `import { createSqliteDatabase } from '@guren/orm'
 
+// \`bun test\` sets NODE_ENV=test automatically, so the test suite reads and
+// writes a separate SQLite file and never touches the development database.
+// DATABASE_URL always wins when set (e.g. in CI or production).
+function resolveDatabaseFilename(): string {
+  if (process.env.DATABASE_URL) {
+    return process.env.DATABASE_URL
+  }
+  return process.env.NODE_ENV === 'test' ? './data/guren.test.db' : '${url}'
+}
+
 const database = createSqliteDatabase({
   migrationsFolder: new URL('../db/migrations', import.meta.url),
   seedersFolder: new URL('../db/seeders', import.meta.url),
-  filename: () => process.env.DATABASE_URL ?? '${url}',
+  filename: resolveDatabaseFilename,
 })
 
 export const { getDatabase, migrateDatabase, closeDatabase, configureOrm, seedDatabase, resetDatabase, migrationStatus } = database

--- a/packages/create-app/templates/api-only/.env.example
+++ b/packages/create-app/templates/api-only/.env.example
@@ -9,6 +9,7 @@ HOST=0.0.0.0
 
 # bun test automatically sets NODE_ENV=test, which points the app at
 # ./data/guren.test.db instead — this line is only used outside tests.
+# Override the test DB path itself with TEST_DATABASE_URL if you need to.
 DATABASE_URL=./data/guren.db
 
 REDIS_URL=

--- a/packages/create-app/templates/api-only/.env.example
+++ b/packages/create-app/templates/api-only/.env.example
@@ -7,6 +7,8 @@ APP_URL=http://localhost:3333
 PORT=3333
 HOST=0.0.0.0
 
+# bun test automatically sets NODE_ENV=test, which points the app at
+# ./data/guren.test.db instead — this line is only used outside tests.
 DATABASE_URL=./data/guren.db
 
 REDIS_URL=

--- a/packages/create-app/templates/api-only/config/database.ts
+++ b/packages/create-app/templates/api-only/config/database.ts
@@ -1,9 +1,19 @@
 import { createSqliteDatabase } from '@guren/orm'
 
+// `bun test` sets NODE_ENV=test automatically, so the test suite reads and
+// writes a separate SQLite file and never touches the development database.
+// DATABASE_URL always wins when set (e.g. in CI or production).
+function resolveDatabaseFilename(): string {
+  if (process.env.DATABASE_URL) {
+    return process.env.DATABASE_URL
+  }
+  return process.env.NODE_ENV === 'test' ? './data/guren.test.db' : './data/guren.db'
+}
+
 const database = createSqliteDatabase({
   migrationsFolder: new URL('../db/migrations', import.meta.url),
   seedersFolder: new URL('../db/seeders', import.meta.url),
-  filename: () => process.env.DATABASE_URL ?? './data/guren.db',
+  filename: resolveDatabaseFilename,
 })
 
 export const { getDatabase, migrateDatabase, closeDatabase, configureOrm, seedDatabase, resetDatabase, migrationStatus } = database

--- a/packages/create-app/templates/api-only/config/database.ts
+++ b/packages/create-app/templates/api-only/config/database.ts
@@ -1,13 +1,15 @@
 import { createSqliteDatabase } from '@guren/orm'
 
 // `bun test` sets NODE_ENV=test automatically, so the test suite reads and
-// writes a separate SQLite file and never touches the development database.
-// DATABASE_URL always wins when set (e.g. in CI or production).
+// writes a separate SQLite file and never touches the development database —
+// this takes priority over DATABASE_URL, which .env sets unconditionally.
+// Override the test DB path itself with TEST_DATABASE_URL if needed (e.g. to
+// shard parallel CI runs); DATABASE_URL is still authoritative outside tests.
 function resolveDatabaseFilename(): string {
-  if (process.env.DATABASE_URL) {
-    return process.env.DATABASE_URL
+  if (process.env.NODE_ENV === 'test') {
+    return process.env.TEST_DATABASE_URL ?? './data/guren.test.db'
   }
-  return process.env.NODE_ENV === 'test' ? './data/guren.test.db' : './data/guren.db'
+  return process.env.DATABASE_URL ?? './data/guren.db'
 }
 
 const database = createSqliteDatabase({

--- a/packages/create-app/templates/api-only/package.json
+++ b/packages/create-app/templates/api-only/package.json
@@ -23,6 +23,7 @@
     "drizzle-orm": "1.0.0-rc.4"
   },
   "devDependencies": {
+    "@guren/testing": "^1.0.0",
     "bun-types": "^1.3.1",
     "drizzle-kit": "1.0.0-rc.4",
     "mysql2": "^3.11.3",

--- a/packages/create-app/templates/default/.env.example
+++ b/packages/create-app/templates/default/.env.example
@@ -9,6 +9,7 @@ HOST=0.0.0.0
 
 # bun test automatically sets NODE_ENV=test, which points the app at
 # ./data/guren.test.db instead — this line is only used outside tests.
+# Override the test DB path itself with TEST_DATABASE_URL if you need to.
 DATABASE_URL=./data/guren.db
 
 REDIS_URL=

--- a/packages/create-app/templates/default/.env.example
+++ b/packages/create-app/templates/default/.env.example
@@ -7,6 +7,8 @@ APP_URL=http://localhost:3333
 PORT=3333
 HOST=0.0.0.0
 
+# bun test automatically sets NODE_ENV=test, which points the app at
+# ./data/guren.test.db instead — this line is only used outside tests.
 DATABASE_URL=./data/guren.db
 
 REDIS_URL=

--- a/packages/create-app/templates/default/config/database.ts
+++ b/packages/create-app/templates/default/config/database.ts
@@ -1,9 +1,19 @@
 import { createSqliteDatabase } from '@guren/orm'
 
+// `bun test` sets NODE_ENV=test automatically, so the test suite reads and
+// writes a separate SQLite file and never touches the development database.
+// DATABASE_URL always wins when set (e.g. in CI or production).
+function resolveDatabaseFilename(): string {
+  if (process.env.DATABASE_URL) {
+    return process.env.DATABASE_URL
+  }
+  return process.env.NODE_ENV === 'test' ? './data/guren.test.db' : './data/guren.db'
+}
+
 const database = createSqliteDatabase({
   migrationsFolder: new URL('../db/migrations', import.meta.url),
   seedersFolder: new URL('../db/seeders', import.meta.url),
-  filename: () => process.env.DATABASE_URL ?? './data/guren.db',
+  filename: resolveDatabaseFilename,
 })
 
 export const { getDatabase, migrateDatabase, closeDatabase, configureOrm, seedDatabase, resetDatabase, migrationStatus } = database

--- a/packages/create-app/templates/default/config/database.ts
+++ b/packages/create-app/templates/default/config/database.ts
@@ -1,13 +1,15 @@
 import { createSqliteDatabase } from '@guren/orm'
 
 // `bun test` sets NODE_ENV=test automatically, so the test suite reads and
-// writes a separate SQLite file and never touches the development database.
-// DATABASE_URL always wins when set (e.g. in CI or production).
+// writes a separate SQLite file and never touches the development database —
+// this takes priority over DATABASE_URL, which .env sets unconditionally.
+// Override the test DB path itself with TEST_DATABASE_URL if needed (e.g. to
+// shard parallel CI runs); DATABASE_URL is still authoritative outside tests.
 function resolveDatabaseFilename(): string {
-  if (process.env.DATABASE_URL) {
-    return process.env.DATABASE_URL
+  if (process.env.NODE_ENV === 'test') {
+    return process.env.TEST_DATABASE_URL ?? './data/guren.test.db'
   }
-  return process.env.NODE_ENV === 'test' ? './data/guren.test.db' : './data/guren.db'
+  return process.env.DATABASE_URL ?? './data/guren.db'
 }
 
 const database = createSqliteDatabase({

--- a/packages/create-app/templates/default/package.json
+++ b/packages/create-app/templates/default/package.json
@@ -28,6 +28,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@guren/testing": "^1.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "bun-types": "^1.3.1",

--- a/packages/create-app/tests/sqlite-smoke.test.ts
+++ b/packages/create-app/tests/sqlite-smoke.test.ts
@@ -15,6 +15,11 @@ describe('SQLite default template', () => {
       const dbConfig = await readFile(join(dest, 'config/database.ts'), 'utf8')
       expect(dbConfig).toContain('createSqliteDatabase')
       expect(dbConfig).not.toContain('createPostgresDatabase')
+      // Test DB separation: DATABASE_URL wins, otherwise NODE_ENV=test (set
+      // automatically by `bun test`) routes to a dedicated SQLite file so the
+      // test suite never touches the development database.
+      expect(dbConfig).toContain('guren.test.db')
+      expect(dbConfig).toContain("process.env.NODE_ENV === 'test'")
 
       const schema = await readFile(join(dest, 'db/schema.ts'), 'utf8')
       expect(schema).toContain('sqliteTable')
@@ -23,8 +28,12 @@ describe('SQLite default template', () => {
       const drizzleConfig = await readFile(join(dest, 'drizzle.config.ts'), 'utf8')
       expect(drizzleConfig).toContain("dialect: 'sqlite'")
 
-      const pkg = JSON.parse(await readFile(join(dest, 'package.json'), 'utf8')) as { dependencies?: Record<string, string> }
+      const pkg = JSON.parse(await readFile(join(dest, 'package.json'), 'utf8')) as {
+        dependencies?: Record<string, string>
+        devDependencies?: Record<string, string>
+      }
       expect(pkg.dependencies?.postgres).toBeUndefined()
+      expect(pkg.devDependencies?.['@guren/testing']).toBeDefined()
 
       const env = await readFile(join(dest, '.env.example'), 'utf8')
       expect(env).toContain('guren.db')

--- a/packages/create-app/tests/sqlite-smoke.test.ts
+++ b/packages/create-app/tests/sqlite-smoke.test.ts
@@ -4,6 +4,48 @@ import { join } from 'node:path'
 import { scaffoldAppBlueprint } from '../src/blueprints'
 import { createTempWorkspace } from './helpers'
 
+/**
+ * Extracts and evaluates the generated `resolveDatabaseFilename()` from a
+ * scaffolded config/database.ts so its priority order can be exercised
+ * directly against controlled process.env values, instead of trusting that
+ * matching source substrings implies correct runtime behavior.
+ */
+function extractDatabaseFilenameResolver(source: string): () => string {
+  const match = source.match(/function resolveDatabaseFilename\(\): string \{[\s\S]*?\n\}/)
+  if (!match) {
+    throw new Error('resolveDatabaseFilename() not found in generated config/database.ts')
+  }
+  // Strip the TypeScript return-type annotation — new Function() only parses plain JS.
+  const plainJs = match[0].replace('(): string {', '() {')
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  return new Function(`${plainJs}\nreturn resolveDatabaseFilename;`)() as () => string
+}
+
+function withEnv(vars: Record<string, string | undefined>, run: () => void): void {
+  const original: Record<string, string | undefined> = {}
+  for (const key of Object.keys(vars)) {
+    original[key] = process.env[key]
+  }
+  try {
+    for (const [key, value] of Object.entries(vars)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+    run()
+  } finally {
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
+}
+
 describe('SQLite default template', () => {
   it('scaffolds a project with SQLite instead of PostgreSQL', async () => {
     const workspace = await createTempWorkspace('sqlite-test-')
@@ -15,11 +57,41 @@ describe('SQLite default template', () => {
       const dbConfig = await readFile(join(dest, 'config/database.ts'), 'utf8')
       expect(dbConfig).toContain('createSqliteDatabase')
       expect(dbConfig).not.toContain('createPostgresDatabase')
-      // Test DB separation: DATABASE_URL wins, otherwise NODE_ENV=test (set
-      // automatically by `bun test`) routes to a dedicated SQLite file so the
-      // test suite never touches the development database.
+      // Test DB separation: NODE_ENV=test (set automatically by `bun test`)
+      // routes to a dedicated SQLite file and takes priority over
+      // DATABASE_URL, which .env sets unconditionally — see the runtime
+      // priority assertions below.
       expect(dbConfig).toContain('guren.test.db')
       expect(dbConfig).toContain("process.env.NODE_ENV === 'test'")
+
+      const resolveDatabaseFilename = extractDatabaseFilenameResolver(dbConfig)
+
+      // A freshly scaffolded .env always sets DATABASE_URL=./data/guren.db
+      // (see the .env.example assertion below) and Bun loads .env even when
+      // running tests — so NODE_ENV=test must win over an inherited
+      // DATABASE_URL for isolation to actually happen, not just look right
+      // in the source text.
+      withEnv(
+        { NODE_ENV: 'test', DATABASE_URL: './data/guren.db', TEST_DATABASE_URL: undefined },
+        () => {
+          expect(resolveDatabaseFilename()).toBe('./data/guren.test.db')
+        },
+      )
+
+      withEnv(
+        { NODE_ENV: 'test', DATABASE_URL: './data/guren.db', TEST_DATABASE_URL: './data/shard-3.db' },
+        () => {
+          expect(resolveDatabaseFilename()).toBe('./data/shard-3.db')
+        },
+      )
+
+      withEnv({ NODE_ENV: 'production', DATABASE_URL: undefined }, () => {
+        expect(resolveDatabaseFilename()).toBe('./data/guren.db')
+      })
+
+      withEnv({ NODE_ENV: 'production', DATABASE_URL: 'postgres://example' }, () => {
+        expect(resolveDatabaseFilename()).toBe('postgres://example')
+      })
 
       const schema = await readFile(join(dest, 'db/schema.ts'), 'utf8')
       expect(schema).toContain('sqliteTable')
@@ -43,6 +115,40 @@ describe('SQLite default template', () => {
 
       const readme = await readFile(join(dest, 'README.md'), 'utf8')
       expect(readme).toContain('No Docker')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})
+
+describe('API-only SQLite template', () => {
+  it('routes bun test to a dedicated DB even with DATABASE_URL set via .env', async () => {
+    const workspace = await createTempWorkspace('sqlite-api-test-')
+
+    try {
+      const dest = join(workspace.dir, 'test-app')
+      await scaffoldAppBlueprint({
+        destination: dest,
+        renderingMode: 'spa',
+        database: 'sqlite',
+        blueprint: 'api',
+      })
+
+      const dbConfig = await readFile(join(dest, 'config/database.ts'), 'utf8')
+      expect(dbConfig).toContain('guren.test.db')
+
+      const resolveDatabaseFilename = extractDatabaseFilenameResolver(dbConfig)
+      withEnv(
+        { NODE_ENV: 'test', DATABASE_URL: './data/guren.db', TEST_DATABASE_URL: undefined },
+        () => {
+          expect(resolveDatabaseFilename()).toBe('./data/guren.test.db')
+        },
+      )
+
+      const pkg = JSON.parse(await readFile(join(dest, 'package.json'), 'utf8')) as {
+        devDependencies?: Record<string, string>
+      }
+      expect(pkg.devDependencies?.['@guren/testing']).toBeDefined()
     } finally {
       await workspace.cleanup()
     }


### PR DESCRIPTION
## Summary
- `config/database.ts` in both the `default` and `api-only` scaffold blueprints had no `NODE_ENV` branch — `bun test` (which sets `NODE_ENV=test` automatically) wrote straight into the development database (`./data/guren.db`). Test runs left dummy rows in the dev DB requiring manual cleanup.
- Neither template's `devDependencies` included `@guren/testing`, so writing a controller test against a fresh scaffold required a manual `bun add -d @guren/testing` first, with no signal that the package existed.

## Approach
`filename` resolution: `DATABASE_URL` still wins if set; otherwise `NODE_ENV === 'test'` routes to `./data/guren.test.db`, else the existing `./data/guren.db` default.

**Note:** the static template files under `templates/*/config/database.ts` aren't actually what ships — `scaffoldAppBlueprint()` (`blueprints.ts`) always regenerates `config/database.ts` via `generateDatabaseConfig(driver)`, overwriting whatever's in the template. Both the generator function and the static template file were updated to keep the source tree honest, but the generator is what matters for actual scaffold output — verified via an end-to-end scaffold run in testing.

`@guren/testing` added to both templates' `devDependencies` as `^1.0.0`, matching the version format already used for `@guren/core`/`@guren/orm`/`@guren/cli`/`@guren/inertia-client` in these same templates. No vitest added (see the companion `@guren/testing` PR — vitest is optional there too).

`.gitignore` already covers `data/` in both templates, so `guren.test.db` won't get committed; added a short comment above `DATABASE_URL=` in both `.env.example` files noting the test-DB routing.

## Test plan
- [x] `bun test packages/create-app/tests` — 9 pass (extended `sqlite-smoke.test.ts` to assert the generated `config/database.ts` contains the `NODE_ENV === 'test'` branch and `guren.test.db`, and that `package.json` lists `@guren/testing`)
- [x] `tsc --noEmit -p packages/create-app` — clean
- [x] `bun run --cwd packages/create-app build` — clean
- [x] Changeset added (`minor`)

## Context
Part of a 4-PR split from the same investigation as the `@guren/testing`, `@guren/cli`, and agent-harness docs PRs.