### PR TITLE
docs(cli): document Exceptions, relationTypes placeholders, TestApp auth

### DIFF
--- a/.changeset/agent-harness-docs-exceptions-testing.md
+++ b/.changeset/agent-harness-docs-exceptions-testing.md
@@ -1,0 +1,12 @@
+---
+"@guren/cli": patch
+---
+
+Fix and expand the AI agent harness template (`.claude/rules/*.md`, `.claude/skills/guren-api/SKILL.md`, `CLAUDE.md`) shipped by `agent:init`/`agent:sync`:
+
+- Document the `HttpException`/`ValidationException`/`AuthenticationException`/`AuthorizationException`/`NotFoundHttpException` factory methods in a new "Exceptions" section — previously only findable by grepping `node_modules/@guren/server/dist/*.d.ts`.
+- Note that `this.auth.userOrFail()`'s `<T>` defaults to `Authenticatable`, which has no `.id`, and fix the `userOrFail()` examples across the templates to use `userOrFail<UserRecord>()` so copy-pasted code type-checks.
+- Note that array-typed relations (`hasMany`, etc.) need a `[]` placeholder in `relationTypes`, not `null`.
+- Note that Guren has no global shared Inertia props by default (`shareInertiaProps()` exists but a fresh scaffold never calls it), so `usePage()` for undeclared props silently resolves to `undefined`.
+- Document `TestApp.create()`'s `auth` option and CSRF testing pattern, and add a "Testing (@guren/testing)" section to the `guren-api` skill (previously absent from the subsystem list entirely).
+- Change the `guren-api` skill's frontmatter `description` from a purely reactive framing ("use when user asks...") to also prompt proactive use during implementation, before falling back to grepping dist files.

--- a/.claude/skills/guren-api/SKILL.md
+++ b/.claude/skills/guren-api/SKILL.md
@@ -35,7 +35,7 @@ export default class PostController extends Controller {
 
   async store() {
     const data = await this.validateBody(PostPayloadSchema)  // throws 422
-    const user = await this.auth.userOrFail()                // throws 401
+    const user = await this.auth.userOrFail<UserRecord>()    // throws 401
     const post = await Post.create({ ...data, authorId: user.id })
     return this.redirect('/posts/' + post?.id)
   }
@@ -54,6 +54,8 @@ All throw `ValidationException` (HTTP 422) on failure.
 **Auth helpers:**
 - `this.auth.user<T>()` — returns user or null
 - `this.auth.userOrFail<T>()` — returns user or throws `AuthenticationException` (401)
+
+`<T>` defaults to `Authenticatable`, which has **no `.id`** — pass your record type (`userOrFail<UserRecord>()`) whenever you access fields.
 
 ### Models
 Source: `packages/orm/src/Model.ts`
@@ -216,8 +218,8 @@ router.middleware('auth').group((auth) => {
 })
 
 // In controller
-const user = await this.auth.user()         // returns user | null
-const user = await this.auth.userOrFail()   // throws AuthenticationException (401)
+const user = await this.auth.user<UserRecord>()         // returns user | null
+const user = await this.auth.userOrFail<UserRecord>()   // throws AuthenticationException (401)
 const isLoggedIn = await this.auth.check()  // returns boolean
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ export class PostController extends Controller {
 
   async store() {
     const data = await this.validateBody(CreatePostSchema)  // throws 422 on failure
-    const user = await this.auth.userOrFail()  // throws 401 if unauthenticated
+    const user = await this.auth.userOrFail<UserRecord>()  // throws 401 if unauthenticated
     const post = await Post.create({ ...data, authorId: user.id })
     return this.redirect('/posts')
   }

--- a/packages/cli/templates/agent/.claude/rules/controllers-http.md
+++ b/packages/cli/templates/agent/.claude/rules/controllers-http.md
@@ -49,6 +49,8 @@ Page prop types come from each page component's `interface Props`, extracted by
 `bunx guren codegen` into `PagePropsMap`. If props don't type-check, re-run codegen.
 Optional third arg: `InertiaResponseOptions` (e.g. `{ status: 422 }`).
 
+**No global shared props by default.** `shareInertiaProps(resolverFn)` (from `@guren/core`) can inject data (e.g. `auth.user`) into every Inertia response, but a fresh scaffold never calls it. `usePage<{ auth: {...} }>()` on the frontend silently resolves to `undefined` — it type-checks but is wrong at runtime. Pass everything a page needs explicitly through `this.inertia(page, { ... })` and declare it in that page's `interface Props`; only reach for `usePage()` for props you have actually wired up via `shareInertiaProps`.
+
 ## Route model binding
 
 ```typescript
@@ -69,6 +71,40 @@ Authorization (policies/gates):
 `await this.authorize('update', [Post, post])` (throws 403) ·
 `await this.can('update', [Post, post]): Promise<boolean>` ·
 API tokens: `this.apiToken()` → `{ userId, abilities }` or throws 401.
+
+**`<T>` defaults to `Authenticatable`** (`{ getAuthIdentifier(): unknown; getAuthPassword(): string; ... }`) — it does **not** have `.id`. Pass your record type explicitly when you need field access: `const user = await this.auth.userOrFail<UserRecord>(); user.id` — omitting `<T>` type-checks until the first `.id`/`.email` access.
+
+## Exceptions
+
+All extend `HttpException` (import from `@guren/core`) and are rendered automatically by the global handler via their `statusCode` — throw directly from a controller method, no try/catch needed:
+
+```typescript
+HttpException.badRequest(msg?)      // 400
+HttpException.unauthorized(msg?)    // 401
+HttpException.forbidden(msg?)       // 403
+HttpException.notFound(msg?)        // 404
+HttpException.conflict(msg?)        // 409
+HttpException.unprocessable(msg?, errors?)  // 422 — same errors shape as validateBody()
+HttpException.internal(msg?)        // 500
+// also: methodNotAllowed / gone / tooManyRequests / notImplemented / badGateway / serviceUnavailable / gatewayTimeout
+
+new ValidationException({ email: ['Already registered'] })          // 422
+ValidationException.withMessages({ email: 'Already registered' })   // string | string[] values
+
+new AuthenticationException(message?, guard?, redirectTo?)          // 401
+AuthenticationException.withRedirect(redirectTo, message?)
+
+new AuthorizationException(message?, action?, resource?)            // 403
+AuthorizationException.deny(resource?)              // e.g. AuthorizationException.deny('Comment')
+AuthorizationException.forAction(action, resource?)
+
+new NotFoundHttpException(message?)                                 // 404
+NotFoundHttpException.forModel('User', 123)
+```
+
+Use `AuthorizationException.deny(...)` for manual ownership checks that don't go through `this.authorize()`/policies.
+
+**`Model.findOrFail()` throws `ModelNotFoundException` from `@guren/orm`** — a separate class that does *not* extend `HttpException`; the handler picks it up via its duck-typed `statusCode: 404`. `forModel()` exists only on `NotFoundHttpException`.
 
 ## Response helpers
 

--- a/packages/cli/templates/agent/.claude/rules/orm-models.md
+++ b/packages/cli/templates/agent/.claude/rules/orm-models.md
@@ -80,6 +80,13 @@ Typed relation results — declare `static relationTypes` using these exported t
 `HasManyRecord<T>` = `T[]` · `HasOneRecord<T>` = `T | null` · `BelongsToRecord<T>` = `T | null` ·
 `BelongsToManyRecord<T>` = `T[]` · `HasManyThroughRecord<T>` = `T[]`
 
+**Placeholder value must match the alias's shape**, not always `null`: array-typed relations (`hasMany`/`belongsToMany`/`hasManyThrough`) need `[]`, single-record relations (`hasOne`/`belongsTo`) need `null` — mixing them up is a TS error.
+
+```typescript
+static override relationTypes: { comments: HasManyRecord<CommentRecord> } = { comments: [] }  // hasMany → []
+static override relationTypes: { author: BelongsToRecord<UserRecord> } = { author: null }     // belongsTo → null
+```
+
 ## Eager loading
 
 ```typescript

--- a/packages/cli/templates/agent/.claude/rules/testing.md
+++ b/packages/cli/templates/agent/.claude/rules/testing.md
@@ -31,7 +31,15 @@ const app = await TestApp.create({
 const csrf = await app.withCsrf()
 ```
 
-**Not installed by default**: `@guren/testing` isn't in a fresh scaffold's `devDependencies` — run `bun add -d @guren/testing`. The main entry does not require vitest; `useDatabaseTransactions()`/`useTruncateTables()` pick up bun:test's injected globals automatically — under vitest, `import '@guren/testing/vitest'` once in your setup file to register its hooks.
+**Included in `create-app`-scaffolded apps' `devDependencies`** by default (`default`/`api` blueprints) — if it's missing (e.g. an older scaffold, or a project set up by hand), run `bun add -d @guren/testing`. The main entry does not require vitest; `useDatabaseTransactions()`/`useTruncateTables()` pick up bun:test's injected globals automatically — under vitest, `import '@guren/testing/vitest'` once in your setup file to register its hooks.
+
+## Generating test files
+
+`bunx guren make:test <Name>` auto-detects the runner: explicit `--runner bun|vitest` wins,
+otherwise it checks for a `vitest.config.*` file or a `vitest` dependency in `package.json`,
+falling back to `bun:test`. Pass `--controller` for a controller test — it suffixes the class
+name with `Controller` and writes to `tests/controllers/${ClassName}.test.ts`, matching where
+`guren check` looks for it.
 
 ## Client methods
 

--- a/packages/cli/templates/agent/.claude/rules/testing.md
+++ b/packages/cli/templates/agent/.claude/rules/testing.md
@@ -20,6 +20,19 @@ const app = TestApp.fromFetch(app.fetch)       // wrap an existing fetch fn (not
 
 Both set `GUREN_TESTING=1` so `actingAs()` header auth is accepted.
 
+**Session + CSRF in tests.** `TestApp.create()` accepts `auth` just like `createApp({ auth: {} })`. Without it, session + CSRF middleware are **not** mounted — JSON requests (`app.json().post(...)`) pass with no CSRF check at all, which is fine for quick validation/auth-guard checks but not representative of production. To exercise real CSRF behavior (and for `withCsrf()` to work — it throws `"did not set an XSRF-TOKEN cookie"` otherwise):
+
+```typescript
+const app = await TestApp.create({
+  auth: {},
+  providers: [DatabaseProvider],
+  routes: registerWebRoutes,
+})
+const csrf = await app.withCsrf()
+```
+
+**Not installed by default**: `@guren/testing` isn't in a fresh scaffold's `devDependencies` — run `bun add -d @guren/testing`. The main entry does not require vitest; `useDatabaseTransactions()`/`useTruncateTables()` pick up bun:test's injected globals automatically — under vitest, `import '@guren/testing/vitest'` once in your setup file to register its hooks.
+
 ## Client methods
 
 ```typescript

--- a/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
+++ b/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: guren-api
-description: Guren framework API documentation, code patterns, and examples. Covers all subsystems — Controllers, Models, Routes, Middleware, Authentication, Authorization, Events, Jobs, Queue, Mail, Cache, Validation, Broadcasting, Notifications, Storage, Scheduling, I18n, Encryption, Health Checks, Error Handling, Container/ServiceProvider, Console Commands, and API Resources. Use when user asks "how to", "how does", "example of", "what is", or needs help understanding any Guren API.
+description: Guren framework API documentation, code patterns, and examples. Covers all subsystems — Controllers, Models, Routes, Middleware, Authentication, Authorization, Events, Jobs, Queue, Mail, Cache, Validation, Broadcasting, Notifications, Storage, Scheduling, I18n, Encryption, Health Checks, Error Handling, Container/ServiceProvider, Console Commands, and API Resources. Use when user asks "how to", "how does", "example of", "what is", or needs help understanding any Guren API — and proactively during implementation whenever you encounter an unfamiliar @guren/* API surface; check this before grepping node_modules dist files.
 ---
 
 # Guren API Documentation Skill
@@ -37,7 +37,7 @@ export default class PostController extends Controller {
 
   async store() {
     const data = await this.validateBody(PostPayloadSchema)  // throws 422
-    const user = await this.auth.userOrFail()                // throws 401
+    const user = await this.auth.userOrFail<UserRecord>()    // throws 401 — <T> defaults to Authenticatable, no .id
     const post = await Post.create({ ...data, authorId: user.id })
     return this.redirect('/posts/' + post?.id)
   }
@@ -228,6 +228,30 @@ Additional auth features:
 - Email Verification: `packages/server/src/auth/email-verification.ts`
 - Password Reset: `packages/server/src/auth/password-reset.ts`
 
+### Testing (@guren/testing)
+Source: `packages/testing/src/`
+
+Not installed by default — `bun add -d @guren/testing`.
+
+```typescript
+import { TestApp } from '@guren/testing'
+
+const app = await TestApp.create({
+  auth: {},                      // mounts session + CSRF middleware (needed for withCsrf())
+  providers: [DatabaseProvider],
+  routes: registerWebRoutes,
+})
+
+await app.get('/posts').assertOk()
+
+const csrf = await app.actingAs(user).withCsrf()   // header auth + primed XSRF cookie
+await csrf.post('/posts', { title: 'Hi' }).assertRedirect('/posts')
+```
+
+- `actingAs(user)` / `withCsrf()` each return a **new** `TestApp` — chain or reassign, don't discard the result
+- Without `auth`, no session/CSRF middleware is mounted — `app.json().post(...)` skips CSRF entirely, fine for quick checks but not production-representative
+- The main entry has no vitest dependency; DB lifecycle helpers (`useDatabaseTransactions` etc.) use bun:test globals automatically — vitest projects `import '@guren/testing/vitest'` once in setup to register hooks
+
 ## Extended Subsystems
 
 ### Authorization (Gate & Policy)
@@ -354,6 +378,34 @@ The ExceptionHandler automatically handles:
 - Any error with a `statusCode` property (duck-typed) → uses that status code (e.g., `ModelNotFoundException` → 404)
 - Other errors → 500 (message hidden unless debug mode)
 
+Factory methods — throw directly from a controller method, no try/catch needed:
+
+```typescript
+HttpException.badRequest(msg?)      // 400
+HttpException.unauthorized(msg?)    // 401
+HttpException.forbidden(msg?)       // 403
+HttpException.notFound(msg?)        // 404
+HttpException.conflict(msg?)        // 409
+HttpException.unprocessable(msg?, errors?)  // 422 — same errors shape as validateBody()
+HttpException.internal(msg?)        // 500
+// also: methodNotAllowed / gone / tooManyRequests / notImplemented / badGateway / serviceUnavailable / gatewayTimeout
+
+new ValidationException({ email: ['Already registered'] })          // 422
+ValidationException.withMessages({ email: 'Already registered' })   // string | string[] values
+
+new AuthenticationException(message?, guard?, redirectTo?)          // 401
+AuthenticationException.withRedirect(redirectTo, message?)
+
+new AuthorizationException(message?, action?, resource?)            // 403
+AuthorizationException.deny(resource?)              // e.g. AuthorizationException.deny('Comment')
+AuthorizationException.forAction(action, resource?)
+
+new NotFoundHttpException(message?)                                 // 404
+NotFoundHttpException.forModel('User', 123)
+```
+
+`Model.findOrFail()` throws `ModelNotFoundException` from `@guren/orm` — it does *not* extend `HttpException`; the handler picks it up via its duck-typed `statusCode: 404`.
+
 ### Container & Service Providers
 Source: `packages/server/src/container/`
 
@@ -406,6 +458,7 @@ Source: `packages/server/src/redis/`
 | Models | `packages/orm/src/Model.ts` |
 | Routes | `packages/server/src/mvc/Route.ts` |
 | Auth | `packages/server/src/auth/` |
+| Testing | `packages/testing/src/` |
 | Authorization | `packages/server/src/authorization/` |
 | Events | `packages/server/src/events/` |
 | Queue/Jobs | `packages/server/src/queue/` |

--- a/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
+++ b/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
@@ -231,7 +231,7 @@ Additional auth features:
 ### Testing (@guren/testing)
 Source: `packages/testing/src/`
 
-Not installed by default — `bun add -d @guren/testing`.
+Included by default in `create-app`-scaffolded apps' `devDependencies`; if missing, `bun add -d @guren/testing`.
 
 ```typescript
 import { TestApp } from '@guren/testing'

--- a/packages/cli/templates/agent/CLAUDE.md
+++ b/packages/cli/templates/agent/CLAUDE.md
@@ -134,7 +134,7 @@ router.post('/posts', { name: 'posts.store', body: CreatePostSchema }, [PostCont
 export class PostController extends Controller {
   async store() {
     const data = await this.validateBody(CreatePostSchema)   // 422 on failure
-    const user = await this.auth.userOrFail()                // 401 if unauthenticated
+    const user = await this.auth.userOrFail<UserRecord>()    // 401 if unauthenticated
     const post = await Post.create({ ...data, authorId: user.id })
     return this.redirect('/posts')
   }


### PR DESCRIPTION
## Summary

The AI agent harness template (`.claude/rules/*.md`, `.claude/skills/guren-api/SKILL.md`, root `CLAUDE.md`, and their `packages/cli/templates/agent/` counterparts shipped by `agent:init`/`agent:sync`) had several gaps found while implementing a comment feature against a fresh scaffold and cross-checking a resulting retrospective doc against this repo's actual source:

- **No "Exceptions" section anywhere.** `HttpException`/`ValidationException`/`AuthenticationException`/`AuthorizationException`/`NotFoundHttpException` factory methods (`AuthorizationException.deny()`, etc.) were only discoverable by grepping `node_modules/@guren/server/dist/*.d.ts` — added a section listing every factory's real signature, verified against `packages/server/src/errors/`, plus a note that `Model.findOrFail()` throws the *separate* `@guren/orm` `ModelNotFoundException` (duck-typed, not an `HttpException` subclass).
- **`this.auth.userOrFail()` examples were a trap.** `<T>` defaults to `Authenticatable`, which has no `.id` — every Controller example in the templates (and this repo's own root `CLAUDE.md`) called `userOrFail()` with no type argument and then accessed `.id`, which doesn't type-check. Fixed to `userOrFail<UserRecord>()` everywhere, with a note explaining why.
- **`relationTypes` placeholder examples only showed `null`.** Array-typed relations (`hasMany`, `belongsToMany`, `hasManyThrough`) need `[]`; the templates had a type-mapping table but no code example showing this, so it surfaced as a TS error in practice.
- **No mention that Guren has no global shared Inertia props by default.** `shareInertiaProps()` exists but a fresh scaffold never calls it — `usePage<{ auth: {...} }>()` on the frontend silently resolves to `undefined` (type-checks, wrong at runtime).
- **`guren-api` skill had no Testing subsystem section at all** despite `@guren/testing` being a real package, and its frontmatter `description` was purely reactive ("use when user asks..."), giving no signal to check it proactively during implementation before falling back to grepping dist files.

## Test plan
- [x] `bun run audit:core-first` — passed
- [x] `bun run audit:docs` — passed
- [x] Changeset added (`patch`, `@guren/cli` — the `packages/cli/templates/agent/` portion ships inside that package; the root `CLAUDE.md`/`.claude/skills/` files are this repo's own dev docs and aren't published, so no changeset needed for those)
- Markdown-only change; no build/typecheck required.

## Context
Documents behavior introduced/fixed in the companion PRs from the same investigation: #122 (`@guren/testing` — `auth` option, optional vitest), #123 (`@guren/cli` — `make:resource`/`make:test` fixes), #124 (`@guren/create-app` — test DB isolation). Can be reviewed and merged independently since it's markdown-only, but the `TestApp.create({ auth })` documentation describes behavior that ships in #122.