### PR TITLE
fix(server): make csrf and InertiaValidation tests self-contained for APP_KEY

### DIFF
--- a/packages/server/tests/http/middleware/csrf.test.ts
+++ b/packages/server/tests/http/middleware/csrf.test.ts
@@ -1,3 +1,5 @@
+process.env.APP_KEY = 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+
 import { describe, expect, it } from 'bun:test'
 import { Hono } from 'hono'
 import {

--- a/packages/server/tests/providers/InertiaValidation.test.ts
+++ b/packages/server/tests/providers/InertiaValidation.test.ts
@@ -1,3 +1,5 @@
+process.env.APP_KEY = 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+
 import { describe, expect, it, beforeEach } from 'bun:test'
 import { Hono } from 'hono'
 import { Container } from '../../src/container'


### PR DESCRIPTION
## Summary
- `packages/server/tests/http/middleware/csrf.test.ts` and `packages/server/tests/providers/InertiaValidation.test.ts` both exercise `createSessionMiddleware()`, which requires `APP_KEY` to be set to sign session cookies.
- Unlike sibling test files (`session.test.ts`, `flash-session.test.ts`) that set a test `process.env.APP_KEY` at the top of the file, these two relied on the environment already having it set — so running `bun test` locally without `APP_KEY` exported fails all tests in both files with `APP_KEY is required and must be a base64-encoded 32-byte key.`
- CI never caught this because `.github/workflows/ci.yml` sets `APP_KEY` at the job level, which happens to satisfy the missing per-file setup.
- Fix: set `process.env.APP_KEY` at the top of both files, matching the pattern already used elsewhere.

## Test plan
- [x] `env -u APP_KEY bun test packages/server/tests/http/middleware/csrf.test.ts packages/server/tests/providers/InertiaValidation.test.ts` → 25 pass / 0 fail (previously 1 pass / 24 fail without `APP_KEY` in the shell)
- [x] `env -u APP_KEY bun test packages/server` → 1629 pass / 45 skip / 0 fail (no regressions)