### PR TITLE
chore: release v1.2.1

### DIFF
--- a/.changeset/plugin-local-install-symlinks.md
+++ b/.changeset/plugin-local-install-symlinks.md
@@ -1,5 +1,0 @@
----
-'@guren/cli': patch
----
-
-Fix `guren plugin` publishes and plugin CLI command discovery for locally installed plugins. Bun materializes `file:`, `link:`, and `workspace:` dependencies as per-file symlinks into the source directory, so the path-escape guard — which canonicalized paths against the node_modules entry only — misclassified every file in such packages as escaping the package directory: `publishes` aborted the install with an error and declared commands were silently dropped from `guren --help`. The guard now also accepts the package's content root (the realpath parent of its `package.json`), which is the node_modules entry itself for regular installs and the source directory for per-file-symlink installs. Malicious symlinks pointing outside both roots are still rejected.

--- a/examples/api/CHANGELOG.md
+++ b/examples/api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @guren/example-api
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies [368df85]
+  - @guren/cli@1.2.1
+
 ## 0.1.3
 
 ### Patch Changes

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/example-api",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guren/cli
 
+## 1.2.1
+
+### Patch Changes
+
+- 368df85: Fix `guren plugin` publishes and plugin CLI command discovery for locally installed plugins. Bun materializes `file:`, `link:`, and `workspace:` dependencies as per-file symlinks into the source directory, so the path-escape guard — which canonicalized paths against the node_modules entry only — misclassified every file in such packages as escaping the package directory: `publishes` aborted the install with an error and declared commands were silently dropped from `guren --help`. The guard now also accepts the package's content root (the realpath parent of its `package.json`), which is the node_modules entry itself for regular installs and the source directory for per-file-symlink installs. Malicious symlinks pointing outside both roots are still rejected.
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,12 @@
 # web
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies [368df85]
+  - @guren/cli@1.2.1
+
 ## 0.1.3
 
 ### Patch Changes

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Patch release: `@guren/cli` → 1.2.1.

Fixes `guren plugin` publishes and plugin CLI command discovery for locally installed plugins (`file:`, `link:`, `workspace:` protocols). Bun materializes these as per-file symlinks into the source directory, which the path-escape guard misclassified as escaping the package — blocking `publishes` entirely and silently dropping contributed CLI commands. Discovered while dogfooding the v1.3.0 plugin system end-to-end; see #121 for the fix and verification detail.

## Test plan
- [x] `bun run build:clean` — all packages build
- [x] `bun run typecheck` — no errors
- [x] `bun run test:bun` — 2239 pass, 0 fail (45 skipped)
- [ ] After merge: `gh release create v1.2.1 --latest` to trigger npm publish