### PR TITLE
docs(cli): document local-testing duplicate-module gotcha for plugins

### DIFF
--- a/.changeset/plugin-authoring-local-test-gotcha.md
+++ b/.changeset/plugin-authoring-local-test-gotcha.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': patch
+---
+
+Document a local-testing gotcha in the `plugin-authoring` agent skill (`agent:init`/`agent:sync`) and the plugin authoring guide: linking a plugin into a test app via `bun add file:`/`link:`/`workspace:` symlinks back to the plugin's source directory, so a plugin that still has its own `@guren/core` devDependency installed can end up loaded as two separate module copies alongside the app's — surfacing as duplicate-module runtime warnings or a `Property 'bindings' is protected...` TypeScript error. The fix (delete `node_modules` in the plugin package directory before linking) is now documented; published plugins never ship `node_modules`, so this only affects local testing before publishing.

--- a/docs/en/guides/plugins.md
+++ b/docs/en/guides/plugins.md
@@ -217,7 +217,21 @@ Add a build script using `tsup`:
 }
 ```
 
-## Step 7: Publish
+## Step 7: Test Locally Before Publishing
+
+Link the plugin into a real Guren app to verify it end to end before publishing:
+
+```bash
+# from your app's directory
+bun add file:../guren-plugin-analytics
+bunx guren plugin guren-plugin-analytics
+```
+
+`bun add file:` (and the `link:`/`workspace:` protocols) install the package as symlinks back to your plugin's source directory instead of copying it. If your plugin's `package.json` still has its own `node_modules` installed — from adding `@guren/core` as a `devDependency` in Step 1 — the app can end up loading two separate copies of `@guren/core`: one from its own install, one through the plugin's. This shows up as duplicate-module warnings at runtime, or a TypeScript error like `Property 'bindings' is protected but type 'Container' is not a class derived from 'Container'` at compile time.
+
+If you hit this, delete `node_modules` inside your plugin's package directory before linking it into the app — the app's own `@guren/core` install then satisfies the plugin's `peerDependencies` with nothing left to shadow it. A published plugin never ships its `node_modules`, so this only affects local testing before publishing.
+
+## Step 8: Publish
 
 ```bash
 bun run build

--- a/docs/ja/guides/plugins.md
+++ b/docs/ja/guides/plugins.md
@@ -217,7 +217,21 @@ bun test src/plugin.test.ts
 }
 ```
 
-## ステップ7: 公開する
+## ステップ7: 公開前にローカルで動作確認する
+
+公開する前に、実際のGurenアプリにプラグインをリンクしてエンドツーエンドで検証しましょう:
+
+```bash
+# アプリのディレクトリで実行
+bun add file:../guren-plugin-analytics
+bunx guren plugin guren-plugin-analytics
+```
+
+`bun add file:`(および`link:`・`workspace:`プロトコル)は、パッケージをコピーするのではなく、プラグインのソースディレクトリへのシンボリックリンクとしてインストールします。プラグインの`package.json`に、ステップ1で`@guren/core`を`devDependencies`として追加した際の`node_modules`がまだ残っている場合、アプリは`@guren/core`を2つの別々のコピーとして読み込んでしまうことがあります — 1つはアプリ自身のインストール、もう1つはプラグイン経由です。これはランタイムでの重複モジュール警告や、コンパイル時の`Property 'bindings' is protected but type 'Container' is not a class derived from 'Container'`のようなTypeScriptエラーとして現れます。
+
+この問題が発生した場合は、アプリにリンクする前にプラグインのパッケージディレクトリ内の`node_modules`を削除してください。プラグイン側に隠蔽するコピーがなくなれば、アプリ自身の`@guren/core`インストールがプラグインの`peerDependencies`を満たすようになります。公開済みのプラグインは`node_modules`を同梱しないため、これは公開前のローカル検証にのみ影響します。
+
+## ステップ8: 公開する
 
 ```bash
 bun run build

--- a/packages/cli/templates/agent/.claude/skills/plugin-authoring/SKILL.md
+++ b/packages/cli/templates/agent/.claude/skills/plugin-authoring/SKILL.md
@@ -139,7 +139,17 @@ test('registers the service', async () => {
 })
 ```
 
-### 6. Build and publish
+### 6. Test locally before publishing
+
+```bash
+# from the app you're testing against
+bun add file:../guren-plugin-<name>
+bunx guren plugin guren-plugin-<name>
+```
+
+`bun add file:` (and `link:`/`workspace:`) symlink back to the plugin's source instead of copying it. If the plugin still has its own `node_modules` (from its `@guren/core` devDependency in step 1), the app can load two separate `@guren/core` copies — surfacing as duplicate-module runtime warnings or a `Property 'bindings' is protected...` TypeScript error. Fix: delete `node_modules` inside the plugin package directory before linking it — the app's own `@guren/core` then satisfies the plugin's `peerDependencies` with nothing left to shadow it. Published plugins never ship `node_modules`, so this is a local-testing-only gotcha.
+
+### 7. Build and publish
 
 ```json
 { "scripts": { "build": "tsup src/index.ts --format esm --dts" } }


### PR DESCRIPTION
## Summary

Follow-up to #121 (plugin local-install symlink fix). While re-verifying that fix end-to-end with a real plugin (`definePlugin()` + full manifest) linked into a fresh scaffolded app via `bun add file:../my-plugin`, hit a related but distinct issue: TypeScript error `Property 'bindings' is protected but type 'Container' is not a class derived from 'Container'`, plus the `@guren/orm` "2 copies loaded" runtime warning.

**Root cause:** `bun add file:`/`link:`/`workspace:` symlink individual files back to the plugin's source directory. The plugin-authoring skill's documented `package.json` template lists `@guren/core` as a `devDependency` (for building/testing the plugin in isolation) — if that install is still present when the plugin is later locally linked into a test app, the app loads two separate `@guren/core` module instances (its own, and one through the plugin), which TypeScript sees as structurally incompatible and Bun/Node treat as duplicate class instances at runtime.

This isn't the `resolveInside` escape-guard bug from #121 (verified fixed) — it's a separate module-resolution gotcha specific to the "link your plugin locally before publishing" step, which wasn't documented anywhere. Confirmed the fix empirically: deleting `node_modules` inside the plugin package directory makes the TypeScript error disappear.

## Changes
- `docs/en/guides/plugins.md` / `docs/ja/guides/plugins.md`: new "Test Locally Before Publishing" step (renumbers Publish to the next step)
- `packages/cli/templates/agent/.claude/skills/plugin-authoring/SKILL.md`: matching condensed guidance for the AI agent skill
- Changeset (`@guren/cli` patch) — this only touches the shipped agent-skill template, not the docs site

Doesn't affect real end users: a published plugin never ships `node_modules`, so this only bites during local pre-publish testing.

## Test plan
- [x] `bun run audit:docs` — passes
- [x] `bun run audit:core-first` — passes
- [x] Empirically verified the documented remedy (delete plugin's `node_modules`) resolves the TypeScript error