### PR TITLE
fix(cli): make codegen overwrite generated artifacts by default

### DIFF
--- a/.changeset/codegen-default-overwrite.md
+++ b/.changeset/codegen-default-overwrite.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': patch
+---
+
+Make `guren codegen` overwrite existing `.guren/*.gen.ts` artifacts by default. Previously, plain `bunx guren codegen` failed with "already exists. Use --force to overwrite." on any run after the first, even though create-app template scripts always pass `--force` and the generated CLAUDE.md documents plain `bunx guren codegen` as the way to regenerate manifests. `--force` is still accepted for backward compatibility but is now a no-op for this command.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -702,7 +702,10 @@ const codegenCommand = defineCommand({
   },
   args: routeTypesCommand.args,
   async run({ args }) {
-    const writerOptions = toWriterOptions(args)
+    // Unlike make:* and routes:types, codegen's outputs are entirely
+    // generated artifacts under .guren/ — safe to overwrite by default.
+    // --force is still accepted for backward compatibility but is a no-op.
+    const writerOptions: WriterOptions = { ...toWriterOptions(args), force: true }
     const { outputPath: pagesOutputPath } = await generatePageTypes({
       appRoot: args.app,
       pagesDir: args.pages,

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -703,8 +703,11 @@ const codegenCommand = defineCommand({
   args: routeTypesCommand.args,
   async run({ args }) {
     // Unlike make:* and routes:types, codegen's outputs are entirely
-    // generated artifacts under .guren/ — safe to overwrite by default.
-    // --force is still accepted for backward compatibility but is a no-op.
+    // generated artifacts under .guren/ and types/generated/ — safe to
+    // overwrite by default, including custom --out/--pages-out destinations
+    // (those flags exist to redirect where a generated artifact lands, not
+    // to protect hand-maintained files). --force is still accepted for
+    // backward compatibility but is a no-op.
     const writerOptions: WriterOptions = { ...toWriterOptions(args), force: true }
     const { outputPath: pagesOutputPath } = await generatePageTypes({
       appRoot: args.app,

--- a/packages/cli/tests/pages-types.test.ts
+++ b/packages/cli/tests/pages-types.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'bun:test'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { createTempWorkspace } from './helpers'
 import { buildPageModuleContent, generatePageTypes, type PageDefinition } from '../src/pages-types'
+
+const CLI_BIN_PATH = resolve(import.meta.dir, '../src/bin.ts')
 
 describe('buildPageModuleContent', () => {
   it('generates a runtime manifest and nested page contracts', () => {
@@ -76,4 +78,47 @@ describe('generatePageTypes overwrite behavior', () => {
       await workspace.cleanup()
     }
   })
+
+  // Regression test for `codegenCommand` itself (packages/cli/src/bin.ts),
+  // not just the generator it calls — this is what actually reproduces the
+  // original bug report ("already exists. Use --force to overwrite." on a
+  // plain second `bunx guren codegen` run). The tests above exercise
+  // generatePageTypes() directly with force passed explicitly either way,
+  // so they'd pass unchanged even if codegenCommand stopped forcing it.
+  it('codegen CLI command overwrites existing artifacts on a second run without --force', async () => {
+    const workspace = await createTempWorkspace('guren-cli-codegen-command-')
+    try {
+      await mkdir(join(workspace.dir, 'resources/js/pages'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'resources/js/pages/Home.tsx'),
+        'export default function Home() { return null }\n',
+        'utf8',
+      )
+
+      const runCodegen = () =>
+        Bun.spawn(['bun', CLI_BIN_PATH, 'codegen', '--app', workspace.dir], {
+          stdout: 'pipe',
+          stderr: 'pipe',
+        })
+
+      const first = runCodegen()
+      expect(await first.exited).toBe(0)
+
+      // No routes/web.ts exists in this fixture, so the command generates
+      // pages.gen.ts, warns that routes/data/channel/API-client generation
+      // was skipped, and exits 0 — exercising the exact write path the
+      // original bug hit without needing a full routes/schema fixture.
+      const second = runCodegen()
+      const secondExitCode = await second.exited
+      const secondStderr = await new Response(second.stderr).text()
+
+      expect(secondExitCode).toBe(0)
+      expect(secondStderr).not.toContain('already exists')
+
+      const content = await readFile(join(workspace.dir, '.guren/pages.gen.ts'), 'utf8')
+      expect(content).toContain("'Home': './pages/Home.tsx'")
+    } finally {
+      await workspace.cleanup()
+    }
+  }, 20000)
 })

--- a/packages/cli/tests/pages-types.test.ts
+++ b/packages/cli/tests/pages-types.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test'
-import { buildPageModuleContent, type PageDefinition } from '../src/pages-types'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { createTempWorkspace } from './helpers'
+import { buildPageModuleContent, generatePageTypes, type PageDefinition } from '../src/pages-types'
 
 describe('buildPageModuleContent', () => {
   it('generates a runtime manifest and nested page contracts', () => {
@@ -17,5 +20,60 @@ describe('buildPageModuleContent', () => {
     expect(content).toContain("Home: defineGeneratedPage('Home', pageManifest['Home'])")
     expect(content).toContain("Login: defineGeneratedPage('auth/Login', pageManifest['auth/Login'])")
     expect(content).toContain("Index: defineGeneratedPage('posts/Index', pageManifest['posts/Index'])")
+  })
+})
+
+describe('generatePageTypes overwrite behavior', () => {
+  // `bunx guren codegen` regenerates .guren/*.gen.ts on every run. These
+  // files are generated artifacts, not user source, so codegen defaults
+  // `force: true` when calling the generators (see codegenCommand in
+  // packages/cli/src/bin.ts). Without this, plain `bunx guren codegen`
+  // fails on the second run with "already exists. Use --force to overwrite."
+  // even though create-app templates and the agent-harness docs assume a
+  // plain re-run just works.
+  it('fails without force when the output file already exists (safety net preserved)', async () => {
+    const workspace = await createTempWorkspace('guren-cli-pages-types-noforce-')
+    try {
+      await mkdir(join(workspace.dir, 'resources/js/pages'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'resources/js/pages/Home.tsx'),
+        'export default function Home() { return null }\n',
+        'utf8',
+      )
+      await mkdir(join(workspace.dir, '.guren'), { recursive: true })
+      await writeFile(join(workspace.dir, '.guren/pages.gen.ts'), '// stale generated content\n', 'utf8')
+
+      await expect(
+        generatePageTypes({ appRoot: workspace.dir, extractProps: false }),
+      ).rejects.toThrow(/already exists/)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('overwrites an existing generated file when force is true, as codegen defaults', async () => {
+    const workspace = await createTempWorkspace('guren-cli-pages-types-force-')
+    try {
+      await mkdir(join(workspace.dir, 'resources/js/pages'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'resources/js/pages/Home.tsx'),
+        'export default function Home() { return null }\n',
+        'utf8',
+      )
+      await mkdir(join(workspace.dir, '.guren'), { recursive: true })
+      await writeFile(join(workspace.dir, '.guren/pages.gen.ts'), '// stale generated content\n', 'utf8')
+
+      const { outputPath } = await generatePageTypes({
+        appRoot: workspace.dir,
+        extractProps: false,
+        force: true,
+      })
+
+      const content = await readFile(outputPath, 'utf8')
+      expect(content).not.toContain('stale generated content')
+      expect(content).toContain("'Home': './pages/Home.tsx'")
+    } finally {
+      await workspace.cleanup()
+    }
   })
 })


### PR DESCRIPTION
## Motivation

Running plain `bunx guren codegen` in a scaffolded app failed on any run after the first, with:

```
ERROR .guren/pages.gen.ts already exists. Use --force to overwrite.
```

This came from `writeFileSafe` (`packages/cli/src/utils.ts`), which throws unless `force` is set. `codegenCommand` (in `packages/cli/src/bin.ts`) was passing `args.force` straight through, defaulting to `false`.

This was inconsistent with the rest of the toolchain:
- create-app template `package.json` scripts always call codegen with `--force` (`packages/create-app/templates/default/package.json`, `.../api-only/package.json`)
- the agent-harness template's generated `CLAUDE.md` documents plain `bunx guren codegen` as the way to "regenerate `.guren/*.gen.ts` typed manifests" — with no mention of `--force`

This mismatch was reported via dogfooding feedback: an agent following the documented workflow hit the overwrite error on a second run.

## Change

`.guren/*.gen.ts` and `types/generated/routes.d.ts` are entirely generated artifacts, not user source — they're safe to overwrite unconditionally. `codegenCommand`'s `run()` now builds its writer options as `{ ...toWriterOptions(args), force: true }`, so codegen always overwrites regardless of the `--force` flag. `--force` is still accepted for backward compatibility but is now a no-op for this command.

`routes:types` and all `make:*` commands are unaffected: they use the same shared `toWriterOptions` helper and (for `routes:types`) the same `args` definition, but neither was touched — both keep their existing "refuse to overwrite without `--force`" guard, which is the correct behavior for files that may contain user edits.

## Test plan

- [x] Added `packages/cli/tests/pages-types.test.ts` regression tests: `generatePageTypes` still throws `already exists` without `force` (safety net preserved for direct callers), and overwrites cleanly with `force: true` (the new codegen default)
- [x] Verified all 5 codegen generators (`pages-types`, `routes-types`, `data-types`, `channel-types`, `api-client-types`) thread their `force` option into `writeFileSafe`
- [x] `bun install && bun run build:clean` — clean build succeeds
- [x] `bun test packages/cli` — 405 pass, 0 fail
- [x] `bun run typecheck` — passes (root, `examples/blog`, `examples/api`)
- [x] End-to-end repro against `examples/blog` (whose `.guren/` is gitignored and absent in a fresh checkout): ran `bun packages/cli/src/bin.ts codegen` twice — before the fix, the second run fails with the reported error; after the fix, it exits 0 both times
- [x] Added a changeset (`@guren/cli` patch)