### PR TITLE
fix(orm): accept nested relation paths in eager-load types

### DIFF
--- a/.changeset/orm-nested-relation-types.md
+++ b/.changeset/orm-nested-relation-types.md
@@ -1,0 +1,7 @@
+---
+'@guren/orm': minor
+'@guren/core': minor
+'@guren/cli': patch
+---
+
+Accept dot-notation nested relation paths (`with('comments.author')`) in the type signatures of `with()`, `findWith()`, `findWithOrFail()`, and `withPaginate()` — the runtime already supported them. Add `BelongsToRequiredRecord<T>` for belongsTo relations backed by a NOT NULL foreign key, so `relationTypes` can declare the parent as non-nullable (use the `declare` modifier to skip the runtime placeholder).

--- a/docs/en/guides/database.md
+++ b/docs/en/guides/database.md
@@ -334,6 +334,36 @@ Nested relations use dot notation:
 const users = await User.with('posts.comments')
 ```
 
+Nested paths type only the head segment from `relationTypes`. To get typed
+children, declare the nested shape inside the head relation's record type:
+
+```ts
+export class User extends defineModel(users) {
+  declare static relationTypes: {
+    posts: HasManyRecord<PostRecord & { comments: CommentRecord[] }>
+  }
+}
+
+const loaded = await User.with('posts.comments')
+loaded[0].posts[0].comments // CommentRecord[] — typed end to end
+```
+
+`BelongsToRecord<T>` is always `T | null` — the loader cannot know the row
+exists. When the foreign key is `NOT NULL` and the parent is guaranteed,
+declare the relation with `BelongsToRequiredRecord<T>` instead. Using the
+`declare` modifier skips the runtime placeholder value:
+
+```ts
+export class Comment extends defineModel(comments) {
+  declare static relationTypes: {
+    author: BelongsToRequiredRecord<UserRecord>
+  }
+}
+
+const comments = await Comment.with('author')
+comments[0].author.name // no null check required
+```
+
 ### Relation Counts
 
 `withCount()` attaches a `${name}Count` field without loading the related rows —

--- a/docs/en/guides/database.md
+++ b/docs/en/guides/database.md
@@ -348,6 +348,9 @@ const loaded = await User.with('posts.comments')
 loaded[0].posts[0].comments // CommentRecord[] — typed end to end
 ```
 
+> [!NOTE]
+> Only the head segment (`posts` above) is checked against `relationTypes` — anything after the first dot is an unvalidated string, so a typo'd or malformed tail (`'posts.'`, `'posts..comments'`, `'posts.typo'`) still compiles. At runtime, an unknown tail relation throws — but only once the loader actually has a loaded row to recurse into. If every record's head relation loads zero rows, the tail is never inspected and the call quietly no-ops instead of throwing. Nesting through a `morphTo` relation always throws at runtime regardless — that constraint isn't enforced at the type level either.
+
 `BelongsToRecord<T>` is always `T | null` — the loader cannot know the row
 exists. When the foreign key is `NOT NULL` and the parent is guaranteed,
 declare the relation with `BelongsToRequiredRecord<T>` instead. Using the

--- a/docs/ja/guides/database.md
+++ b/docs/ja/guides/database.md
@@ -813,6 +813,32 @@ const user = await User.newQuery().with('posts').first()
 const users = await User.with('posts.comments')
 ```
 
+ネストパスの型は `relationTypes` の先頭セグメントのみが反映されます。ネスト先まで型を効かせたい場合は、先頭リレーションのレコード型の中にネストした形を宣言してください。
+
+```ts
+export class User extends defineModel(users) {
+  declare static relationTypes: {
+    posts: HasManyRecord<PostRecord & { comments: CommentRecord[] }>
+  }
+}
+
+const loaded = await User.with('posts.comments')
+loaded[0].posts[0].comments // CommentRecord[] — 末端まで型付き
+```
+
+`BelongsToRecord<T>` は常に `T | null` です。外部キーが `NOT NULL` で親レコードの存在が保証される場合は、代わりに `BelongsToRequiredRecord<T>` で宣言できます。`declare` 修飾子を使えばランタイム用のプレースホルダ値も不要です。
+
+```ts
+export class Comment extends defineModel(comments) {
+  declare static relationTypes: {
+    author: BelongsToRequiredRecord<UserRecord>
+  }
+}
+
+const comments = await Comment.with('author')
+comments[0].author.name // null チェック不要
+```
+
 `hasMany` リレーションは配列として展開されます（マッチするものがない場合は `[]`）。`belongsTo` は単一の関連レコードまたは外部キーが存在しない場合は `null` を返します。複数のリレーションを配列で渡すこともできます: `await User.with(['posts'])`。
 
 ### リレーション件数の取得

--- a/docs/ja/guides/database.md
+++ b/docs/ja/guides/database.md
@@ -826,6 +826,9 @@ const loaded = await User.with('posts.comments')
 loaded[0].posts[0].comments // CommentRecord[] — 末端まで型付き
 ```
 
+> [!NOTE]
+> `relationTypes` と照合されるのは先頭セグメント(上記の `posts`)だけです。最初のドット以降は検証されない文字列なので、タイプミスや不正な末尾(`'posts.'`・`'posts..comments'`・`'posts.typo'`)もコンパイルは通ります。ランタイムでは末尾が未知のリレーション名であればエラーになりますが、それはローダーが実際にロード済みの子レコードへ再帰した場合に限られます。すべてのレコードで先頭リレーションが 0 件しかロードされなければ、末尾は一切検査されず静かに何もせず終わります。`morphTo` リレーションを経由したネストは常にランタイムでエラーになりますが、この制約も型レベルでは表現されていません。
+
 `BelongsToRecord<T>` は常に `T | null` です。外部キーが `NOT NULL` で親レコードの存在が保証される場合は、代わりに `BelongsToRequiredRecord<T>` で宣言できます。`declare` 修飾子を使えばランタイム用のプレースホルダ値も不要です。
 
 ```ts

--- a/packages/cli/templates/agent/.claude/rules/orm-models.md
+++ b/packages/cli/templates/agent/.claude/rules/orm-models.md
@@ -78,24 +78,40 @@ For Inertia/HTTP pagination links wrap it with `paginate` from `@guren/core`:
 
 Typed relation results — declare `static relationTypes` using these exported types:
 `HasManyRecord<T>` = `T[]` · `HasOneRecord<T>` = `T | null` · `BelongsToRecord<T>` = `T | null` ·
-`BelongsToManyRecord<T>` = `T[]` · `HasManyThroughRecord<T>` = `T[]`
+`BelongsToRequiredRecord<T>` = `T` (NOT NULL FK) · `BelongsToManyRecord<T>` = `T[]` · `HasManyThroughRecord<T>` = `T[]`
 
-**Placeholder value must match the alias's shape**, not always `null`: array-typed relations (`hasMany`/`belongsToMany`/`hasManyThrough`) need `[]`, single-record relations (`hasOne`/`belongsTo`) need `null` — mixing them up is a TS error.
+**Placeholder value must match the alias's shape**, not always `null`: array-typed relations (`hasMany`/`belongsToMany`/`hasManyThrough`) need `[]`, single-record relations (`hasOne`/`belongsTo`) need `null` — mixing them up is a TS error. With the `declare` modifier no placeholder is needed at all (type-only, no runtime value).
 
 ```typescript
 static override relationTypes: { comments: HasManyRecord<CommentRecord> } = { comments: [] }  // hasMany → []
 static override relationTypes: { author: BelongsToRecord<UserRecord> } = { author: null }     // belongsTo → null
+// NOT NULL FK: parent always exists once loaded — declare it non-nullable (no placeholder with `declare`)
+declare static relationTypes: { author: BelongsToRequiredRecord<UserRecord> }
 ```
 
 ## Eager loading
 
 ```typescript
-await Post.with('tags')                    // Array<record & { tags: TagRecord[] }>; nested: with('author.posts')
+await Post.with('tags')                    // Array<record & { tags: TagRecord[] }>
 await Post.with(['author', 'tags'], { published: true })  // optional where filter
+await Post.with('comments.author')         // nested via dot notation (see below)
 await Post.findWith(1, 'tags')             // single record + relations, or null
 await Post.findWithOrFail(1, ['author'])   // throws ModelNotFoundException
 await Post.withCount('tags')               // adds tagsCount: number (no nested names)
 await Post.withPaginate('tags', { page: 1 })  // PaginatedResult with relations
+```
+
+**Nested paths type only the head segment** from `relationTypes`. To get typed
+children, declare the nested shape inside the head relation's record type:
+
+```typescript
+export class Post extends defineModel(posts) {
+  declare static relationTypes: {
+    comments: HasManyRecord<CommentRecord & { author: BelongsToRecord<UserRecord> }>
+  }
+}
+const post = await Post.findWithOrFail(id, 'comments.author')
+post.comments[0].author   // UserRecord | null — typed end to end
 ```
 
 ## No attach/detach/sync — use a pivot model

--- a/packages/cli/templates/agent/.claude/rules/orm-models.md
+++ b/packages/cli/templates/agent/.claude/rules/orm-models.md
@@ -114,6 +114,8 @@ const post = await Post.findWithOrFail(id, 'comments.author')
 post.comments[0].author   // UserRecord | null — typed end to end
 ```
 
+**The tail after the first dot is unvalidated** — `'comments.'`, `'comments..author'`, `'comments.typo'` all compile. At runtime an unknown tail throws "unknown relation", but only once the loader recurses into an actual loaded child; if the head relation loads zero rows for every record, the tail is never checked and the call silently no-ops. Nesting through `morphTo` always throws at runtime — also not type-checked.
+
 ## No attach/detach/sync — use a pivot model
 
 ```typescript

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export type {
   HasManyRecord,
   HasOneRecord,
   BelongsToRecord,
+  BelongsToRequiredRecord,
   BelongsToManyRecord,
   HasManyThroughRecord,
   MorphManyRelationResult,

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -848,7 +848,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
    * const post = await Post.findWith(1, 'author')
    * const post = await Post.findWith(1, ['author', 'tags'])
    */
-  static async findWith<T extends typeof Model, K extends RelationKey<T>>(
+  static async findWith<T extends typeof Model, K extends RelationPath<T>>(
     this: T,
     id: TRecordFor<T>[keyof TRecordFor<T> & string],
     relations: K | readonly K[],
@@ -888,8 +888,9 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
    * @example
    * const post = await Post.findWithOrFail(1, 'author')
    * const post = await Post.findWithOrFail(1, ['author', 'tags'])
+   * const post = await Post.findWithOrFail(1, 'comments.author') // nested
    */
-  static async findWithOrFail<T extends typeof Model, K extends RelationKey<T>>(
+  static async findWithOrFail<T extends typeof Model, K extends RelationPath<T>>(
     this: T,
     id: TRecordFor<T>[keyof TRecordFor<T> & string],
     relations: K | readonly K[],
@@ -1507,7 +1508,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
    * // result.data - Users with their posts loaded
    * // result.meta - Pagination metadata
    */
-  static async withPaginate<T extends typeof Model, K extends RelationKey<T>>(
+  static async withPaginate<T extends typeof Model, K extends RelationPath<T>>(
     this: T,
     relations: K | readonly K[],
     options?: PaginateOptions<TRecordFor<T>>,
@@ -1815,8 +1816,11 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
    *
    * // With filtering
    * const activeUsersWithPosts = await User.with('posts', { status: 'active' })
+   *
+   * // Nested relations via dot notation
+   * const usersWithPostComments = await User.with('posts.comments')
    */
-  static async with<T extends typeof Model, K extends RelationKey<T>>(
+  static async with<T extends typeof Model, K extends RelationPath<T>>(
     this: T,
     relations: K | readonly K[],
     where?: WhereClauseFor<T>,
@@ -2346,6 +2350,13 @@ type FieldFor<T extends typeof Model> = keyof TRecordFor<T> & string
 
 type RelationNames = string | readonly string[]
 
+// A declared relation key, or a dot-notation nested path rooted at one
+// ('comments.author'). The nested tail is unvalidated — declare the nested
+// record shape inside relationTypes to type the loaded children.
+type RelationPath<T extends typeof Model> = RelationKey<T> | `${RelationKey<T>}.${string}`
+
+type RelationHead<Name> = Name extends `${infer Head}.${string}` ? Head : Name
+
 type RelationTypesFor<T extends typeof Model> = T extends { relationTypes: infer R }
   ? R extends RelationShape
     ? R
@@ -2362,7 +2373,7 @@ type RelationNameUnion<Names> = Names extends readonly (infer Items)[] ? Items :
 // would distribute over the union and turn with(['a', 'b']) results into
 // `{ a } | { b }` instead of `{ a } & { b }`.
 type RelationTypePick<T extends typeof Model, Names> = {
-  [K in RelationNameUnion<Names> & string & keyof RelationTypesFor<T>]: RelationTypesFor<T>[K]
+  [K in RelationHead<RelationNameUnion<Names>> & string & keyof RelationTypesFor<T>]: RelationTypesFor<T>[K]
 }
 
 type RelationCountPick<Names> = { [K in RelationNameUnion<Names> & string as `${K}Count`]: number }
@@ -2459,6 +2470,16 @@ export type HasManyRecord<TRecord extends PlainObject> = TRecord[]
 /** Utility type for belongsTo relation data shape. */
 export type BelongsToRecord<TRecord extends PlainObject> = TRecord | null
 
+/**
+ * Utility type for belongsTo relations backed by a NOT NULL foreign key,
+ * where the parent is guaranteed to exist once loaded. Declare with the
+ * `declare` modifier so no runtime placeholder value is needed:
+ *
+ * @example
+ * declare static relationTypes: { author: BelongsToRequiredRecord<UserRecord> }
+ */
+export type BelongsToRequiredRecord<TRecord extends PlainObject> = TRecord
+
 /** Type for hasOne relation results (single record or null). */
 export type HasOneRelationResult<T extends typeof Model> = TRecordFor<T> | null
 
@@ -2492,7 +2513,7 @@ export type MorphToRecord = PlainObject | null
 /** Utility type: model record with specified relations merged. */
 export type WithRelations<
   T extends typeof Model,
-  K extends RelationKey<T> | readonly RelationKey<T>[],
+  K extends RelationPath<T> | readonly RelationPath<T>[],
 > = TRecordFor<T> & RelationTypePick<T, K>
 
 type ModelClassWithTable<

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -2351,7 +2351,13 @@ type FieldFor<T extends typeof Model> = keyof TRecordFor<T> & string
 type RelationNames = string | readonly string[]
 
 // A declared relation key, or a dot-notation nested path rooted at one
-// ('comments.author'). The nested tail is unvalidated — declare the nested
+// ('comments.author'). Only the head segment is checked against
+// relationTypes — the tail is an unvalidated string, so a malformed path
+// ('comments.', 'comments..author') or a typo'd nested segment still
+// type-checks. loadRelationInto() throws "unknown relation" for a bad tail
+// segment at runtime, but only once it actually recurses into at least one
+// loaded child row — if every record's head relation loads zero rows, the
+// tail is never inspected and the call silently no-ops. Declare the nested
 // record shape inside relationTypes to type the loaded children.
 type RelationPath<T extends typeof Model> = RelationKey<T> | `${RelationKey<T>}.${string}`
 

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -27,6 +27,7 @@ export type {
   HasManyRecord,
   HasOneRecord,
   BelongsToRecord,
+  BelongsToRequiredRecord,
   BelongsToManyRecord,
   HasManyThroughRecord,
   MorphManyRelationResult,

--- a/packages/orm/tests/model.query.types.ts
+++ b/packages/orm/tests/model.query.types.ts
@@ -143,6 +143,11 @@ async function _nestedRelationPaths() {
   await NestedRelUser.with('posts.')
   await NestedRelUser.with('posts..comments')
   await NestedRelUser.with('posts.comments.typo')
+
+  // 3+ level paths still resolve the type from the head segment only.
+  const deep = await NestedRelUser.with('posts.comments.author')
+  const _deepPosts: PostRecordT[] = deep[0].posts
+  void _deepPosts
 }
 void _nestedRelationPaths
 

--- a/packages/orm/tests/model.query.types.ts
+++ b/packages/orm/tests/model.query.types.ts
@@ -1,6 +1,12 @@
 import { drizzle } from 'drizzle-orm/postgres-js'
 import { pgTable, serial, text } from 'drizzle-orm/pg-core'
-import { Model, defineModel, type TransactionHandle, type TransactionModelScope } from '../src/Model'
+import {
+  Model,
+  defineModel,
+  type BelongsToRequiredRecord,
+  type TransactionHandle,
+  type TransactionModelScope,
+} from '../src/Model'
 
 const users = pgTable('users', {
   id: serial('id').primaryKey(),
@@ -85,3 +91,60 @@ async function _relationIntersection() {
   void _count
 }
 void _relationIntersection
+
+// Nested eager-load paths ('posts.comments') must be accepted by with()/
+// findWith()/findWithOrFail()/withPaginate(). The head segment is typed from
+// relationTypes; declare the nested shape there to type the loaded children.
+class NestedRelUser extends Model<UserRecord> {
+  static table = users
+  declare static relationTypes: {
+    posts: Array<PostRecordT & { comments: CommentRecordT[] }>
+  }
+}
+
+async function _nestedRelationPaths() {
+  const found = await NestedRelUser.findWithOrFail(1, 'posts.comments')
+  const _foundComments: CommentRecordT[] = found.posts[0].comments
+  void _foundComments
+
+  const maybe = await NestedRelUser.findWith(1, 'posts.comments')
+  if (maybe) {
+    const _maybePosts: PostRecordT[] = maybe.posts
+    void _maybePosts
+  }
+
+  const listed = await NestedRelUser.with('posts.comments')
+  const _listedComments: CommentRecordT[] = listed[0].posts[0].comments
+  void _listedComments
+
+  const paged = await NestedRelUser.withPaginate('posts.comments')
+  const _pagedComments: CommentRecordT[] = paged.data[0].posts[0].comments
+  void _pagedComments
+
+  // @ts-expect-error nested paths must be rooted at a declared relation key
+  await NestedRelUser.with('nope.comments')
+
+  // @ts-expect-error withCount does not support nested relation paths
+  await NestedRelUser.withCount('posts.comments')
+}
+void _nestedRelationPaths
+
+// belongsTo relations backed by a NOT NULL foreign key can opt into a
+// non-nullable declaration via BelongsToRequiredRecord. Using `declare`
+// avoids the runtime placeholder value entirely.
+class RequiredAuthorUser extends Model<UserRecord> {
+  static table = users
+  declare static relationTypes: {
+    author: BelongsToRequiredRecord<UserRecord>
+  }
+}
+
+async function _requiredBelongsTo() {
+  const listed = await RequiredAuthorUser.with('author')
+  const first = listed[0]
+  if (first) {
+    const _authorName: string = first.author.name // no null check required
+    void _authorName
+  }
+}
+void _requiredBelongsTo

--- a/packages/orm/tests/model.query.types.ts
+++ b/packages/orm/tests/model.query.types.ts
@@ -126,6 +126,23 @@ async function _nestedRelationPaths() {
 
   // @ts-expect-error withCount does not support nested relation paths
   await NestedRelUser.withCount('posts.comments')
+
+  // A mixed array of a plain key and a nested path must still intersect
+  // (not distribute into a union) on the head segments.
+  const mixed = await NestedRelUser.with(['posts', 'posts.comments'] as const)
+  const _mixedPosts: PostRecordT[] = mixed[0].posts
+  void _mixedPosts
+
+  // Only the head segment is validated — everything after the first dot is
+  // an unvalidated string, so these malformed/deeper paths type-check even
+  // though the runtime would throw "unknown relation" for a bad tail (and
+  // even that only once it recurses into an actually-loaded child; see the
+  // RelationPath comment above its definition). This is documented, not a
+  // gap to close here — flagging it so a future edit doesn't "fix" it into
+  // silently narrowing what compiles.
+  await NestedRelUser.with('posts.')
+  await NestedRelUser.with('posts..comments')
+  await NestedRelUser.with('posts.comments.typo')
 }
 void _nestedRelationPaths
 


### PR DESCRIPTION
## Motivation

External dogfooding feedback: the docs and agent rules advertise dot-notation nested eager loading (`with('author.posts')`, `findWithOrFail(id, 'comments.author')`), and the runtime has supported it all along (`loadRelationInto` splits on `.` and recurses). But the public type overloads of `with()`, `findWith()`, `findWithOrFail()`, and `withPaginate()` only accepted keys declared in `relationTypes`, so following the docs produced:

```
error TS2345: Argument of type '"comments.author"' is not assignable to
parameter of type '"comments" | readonly "comments"[]'.
```

A second, related paper cut: `BelongsToRecord<T>` is fixed to `T | null`, so a `belongsTo` backed by a `NOT NULL` foreign key still forces defensive `?.`/`??` handling in resources even though the parent is guaranteed to exist.

## Changes

- **Nested relation paths in types**: the four eager-load statics now accept `RelationPath<T>` = `RelationKey<T> | ` `` `${RelationKey<T>}.${string}` ``. `RelationTypePick` normalizes dot paths to their head segment, so `with('comments.author')` types `comments` from `relationTypes`. Declaring the nested shape inside the head relation's record type (`comments: HasManyRecord<CommentRecord & { author: BelongsToRecord<UserRecord> }>`) types the loaded children end to end. `withCount()` intentionally keeps top-level keys only (the runtime rejects nested names there).
- **`BelongsToRequiredRecord<T>`** (= `T`): opt-in non-nullable declaration for NOT NULL FK relations. Combined with the `declare` modifier, no runtime placeholder value is needed: `declare static relationTypes: { author: BelongsToRequiredRecord<UserRecord> }`. Exported from `@guren/orm` and re-exported through `@guren/core`'s allowlist.
- **Docs**: updated the eager-loading sections of `docs/en|ja/guides/database.md` and the agent-harness rule template (`orm-models.md`) with the nested typing pattern and the non-nullable belongsTo declaration.
- **Type tests**: extended `packages/orm/tests/model.query.types.ts` with assertions for nested paths across all four methods, `@ts-expect-error` guards for unknown head keys and nested `withCount`, and the `BelongsToRequiredRecord` + `declare` pattern.

No runtime behavior changes — this is a type-surface fix plus docs.

## Test plan

- `bun run build:clean` — all packages compile
- `bun run typecheck` — passes (root + examples/blog + examples/api), including the new type assertions
- `bun test packages/orm` — 176 pass, 0 fail
- `bun run audit:docs` / `bun run audit:core-first` — pass