### PR TITLE
feat(cli): detect missing test infrastructure in doctor

### DIFF
--- a/.changeset/doctor-testing-infra-check.md
+++ b/.changeset/doctor-testing-infra-check.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': minor
+---
+
+Add a `guren doctor` check that detects missing test infrastructure. When a project's `package.json` has no `@guren/testing` in `dependencies`/`devDependencies` and no `*.test.ts`-style files exist under `tests/`, doctor now emits a warning recommending `bun add -d @guren/testing`, and the same signal appears as an actionable step in `guren doctor --next`. This closes a gap where apps scaffolded with older `create-guren-app` versions (or hand-rolled projects) had zero test infrastructure and no doctor signal about it.

--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -2,6 +2,8 @@ import { readdir, access, readFile, stat } from 'node:fs/promises'
 import { resolve, join, extname } from 'node:path'
 
 const SOURCE_EXTENSIONS = new Set(['.ts', '.mts', '.js', '.mjs'])
+const TEST_FILE_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.js', '.jsx', '.mjs'])
+const TEST_FILE_PATTERN = /\.test\.(ts|tsx|mts|js|jsx|mjs)$/
 
 /**
  * Recursively collect files from a directory matching given extensions.
@@ -106,6 +108,16 @@ export function discoverValidatorFiles(appRoot: string): Promise<string[]> {
 
 export function discoverPolicyFiles(appRoot: string): Promise<string[]> {
   return discoverDir(appRoot, 'app/Policies')
+}
+
+/**
+ * Discover `*.test.{ts,tsx,mts,js,jsx,mjs}` files under the project's `tests/`
+ * directory (the convention used by scaffolded apps and the blog example).
+ */
+export async function discoverTestFiles(appRoot: string): Promise<string[]> {
+  const dir = resolve(appRoot, 'tests')
+  const files = await collectFiles(dir, TEST_FILE_EXTENSIONS)
+  return files.filter((file) => TEST_FILE_PATTERN.test(file))
 }
 
 /**

--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -5,13 +5,20 @@ const SOURCE_EXTENSIONS = new Set(['.ts', '.mts', '.js', '.mjs'])
 const TEST_FILE_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.js', '.jsx', '.mjs'])
 const TEST_FILE_PATTERN = /\.test\.(ts|tsx|mts|js|jsx|mjs)$/
 
+// Directories that never contain a project's own source/test files — skipped
+// when scanning from the project root (not needed for the scoped app/**
+// discoverers below, which never descend into these anyway).
+const NON_SOURCE_DIR_NAMES = new Set(['node_modules', 'dist', 'build', 'coverage'])
+
 /**
  * Recursively collect files from a directory matching given extensions.
- * Skips dotfiles and declaration files (.d.ts).
+ * Skips dotfiles, declaration files (.d.ts), and any directory named in
+ * `excludeDirNames`.
  */
 export async function collectFiles(
   directory: string,
   extensions: Set<string> = SOURCE_EXTENSIONS,
+  excludeDirNames: Set<string> = new Set(),
 ): Promise<string[]> {
   const results: string[] = []
 
@@ -28,7 +35,8 @@ export async function collectFiles(
     const fullPath = join(directory, entry.name)
 
     if (entry.isDirectory()) {
-      results.push(...(await collectFiles(fullPath, extensions)))
+      if (excludeDirNames.has(entry.name)) continue
+      results.push(...(await collectFiles(fullPath, extensions, excludeDirNames)))
     } else if (entry.isFile()) {
       if (entry.name.endsWith('.d.ts')) continue
       if (extensions.has(extname(entry.name))) {
@@ -111,12 +119,13 @@ export function discoverPolicyFiles(appRoot: string): Promise<string[]> {
 }
 
 /**
- * Discover `*.test.{ts,tsx,mts,js,jsx,mjs}` files under the project's `tests/`
- * directory (the convention used by scaffolded apps and the blog example).
+ * Discover `*.test.{ts,tsx,mts,js,jsx,mjs}` files anywhere in the project:
+ * under `tests/` (the convention used by scaffolded apps and the blog
+ * example) as well as colocated next to source files elsewhere (the
+ * convention this framework's own packages use — see CLAUDE.md).
  */
 export async function discoverTestFiles(appRoot: string): Promise<string[]> {
-  const dir = resolve(appRoot, 'tests')
-  const files = await collectFiles(dir, TEST_FILE_EXTENSIONS)
+  const files = await collectFiles(appRoot, TEST_FILE_EXTENSIONS, NON_SOURCE_DIR_NAMES)
   return files.filter((file) => TEST_FILE_PATTERN.test(file))
 }
 

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -1,7 +1,7 @@
 import { copyFile, readFile, writeFile } from 'node:fs/promises'
 import { resolve, relative } from 'node:path'
 import { consola } from 'consola'
-import { discoverControllerFiles, discoverModelFiles, fileExists, readIfExists, classNameFromPath } from './discovery'
+import { discoverControllerFiles, discoverModelFiles, discoverTestFiles, fileExists, readIfExists, classNameFromPath } from './discovery'
 import { checkPluginCompatibility, readCoreVersion, readInstalledPluginManifests } from './plugin-manifest'
 
 export type DoctorStatus = 'pass' | 'warn' | 'fail'
@@ -116,6 +116,11 @@ export const CANONICAL_APP_SCRIPTS = {
 
 type PackageJsonShape = {
   scripts?: Record<string, string>
+}
+
+type PackageDependenciesShape = {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
 }
 
 type TsconfigShape = {
@@ -904,6 +909,52 @@ async function detectDatabaseConfig(context: DoctorRuleContext): Promise<DoctorC
   )
 }
 
+/**
+ * Checks whether the project has any test foundation at all: either
+ * `@guren/testing` is installed, or at least one `*.test.ts`-style file
+ * already exists under `tests/`. Older `create-guren-app` scaffolds and
+ * hand-rolled projects can have neither, which leaves `guren doctor`
+ * silent even though there is no way to write a controller test.
+ */
+async function hasTestInfrastructure(cwd: string): Promise<boolean> {
+  const packageJson = await readJsonIfExists<PackageDependenciesShape>(cwd, 'package.json')
+  const hasTestingPackage = Boolean(
+    packageJson.value?.dependencies?.['@guren/testing'] ||
+    packageJson.value?.devDependencies?.['@guren/testing'],
+  )
+
+  if (hasTestingPackage) {
+    return true
+  }
+
+  const testFiles = await discoverTestFiles(cwd).catch(() => [] as string[])
+  return testFiles.length > 0
+}
+
+async function detectTestInfrastructure(context: DoctorRuleContext): Promise<DoctorCheck> {
+  const present = await hasTestInfrastructure(context.cwd)
+
+  if (present) {
+    return createCheck(
+      'test-infrastructure',
+      'Test Infrastructure',
+      'pass',
+      'Test infrastructure detected (@guren/testing dependency or test files present).',
+    )
+  }
+
+  return createCheck(
+    'test-infrastructure',
+    'Test Infrastructure',
+    'warn',
+    'No @guren/testing dependency and no test files were found; the project has no test foundation.',
+    {
+      fix: 'Run `bun add -d @guren/testing` and scaffold a first test with `bunx guren make:test`.',
+      manualFix: 'Add @guren/testing to devDependencies and create test files under tests/.',
+    },
+  )
+}
+
 async function detectPluginCompatibility(context: DoctorRuleContext): Promise<DoctorCheck> {
   const [plugins, coreVersion] = await Promise.all([
     readInstalledPluginManifests(context.cwd),
@@ -974,6 +1025,7 @@ const doctorRules: DoctorRule[] = [
   { key: 'config-drift', title: 'App Wiring', detect: detectConfigDrift },
   { key: 'scripts', title: 'App Scripts', detect: detectScripts, autofix: createScriptsAutofix },
   { key: 'database-config', title: 'Database Configuration', detect: detectDatabaseConfig },
+  { key: 'test-infrastructure', title: 'Test Infrastructure', detect: detectTestInfrastructure },
   { key: 'plugin-compatibility', title: 'Plugin Compatibility', detect: detectPluginCompatibility },
 ]
 
@@ -1065,6 +1117,16 @@ export async function suggestNextSteps(options: { cwd?: string } = {}): Promise<
   let priority = 1
 
   const controllerFiles = await discoverControllerFiles(cwd).catch(() => [] as string[])
+
+  const testInfraPresent = await hasTestInfrastructure(cwd).catch(() => true)
+  if (!testInfraPresent) {
+    steps.push({
+      priority: priority++,
+      title: 'Install test infrastructure',
+      description: 'No @guren/testing dependency and no test files were found; the project has no test foundation.',
+      command: 'bun add -d @guren/testing',
+    })
+  }
 
   try {
     for (const filePath of controllerFiles) {

--- a/packages/cli/tests/discovery.test.ts
+++ b/packages/cli/tests/discovery.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
-import { collectFiles, classNameFromPath, excludeBarrelFiles } from '../src/discovery'
+import { collectFiles, classNameFromPath, excludeBarrelFiles, discoverTestFiles } from '../src/discovery'
 import { createTempWorkspace } from './helpers'
 
 describe('collectFiles', () => {
@@ -88,5 +88,65 @@ describe('excludeBarrelFiles', () => {
     const files = ['/app/Models/Post.ts', '/app/Models/User.ts']
     const result = excludeBarrelFiles(files)
     expect(result).toHaveLength(2)
+  })
+})
+
+describe('discoverTestFiles', () => {
+  it('finds *.test.ts files under tests/', async () => {
+    const workspace = await createTempWorkspace('guren-cli-discovery-tests-')
+
+    try {
+      await mkdir(join(workspace.dir, 'tests/controllers'), { recursive: true })
+      await writeFile(join(workspace.dir, 'tests/controllers/PostController.test.ts'), '', 'utf8')
+
+      const files = await discoverTestFiles(workspace.dir)
+
+      expect(files).toHaveLength(1)
+      expect(files[0]).toMatch(/PostController\.test\.ts$/)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('finds *.test.tsx files under tests/', async () => {
+    const workspace = await createTempWorkspace('guren-cli-discovery-tests-tsx-')
+
+    try {
+      await mkdir(join(workspace.dir, 'tests/pages'), { recursive: true })
+      await writeFile(join(workspace.dir, 'tests/pages/Login.test.tsx'), '', 'utf8')
+
+      const files = await discoverTestFiles(workspace.dir)
+
+      expect(files).toHaveLength(1)
+      expect(files[0]).toMatch(/Login\.test\.tsx$/)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('ignores non-test files under tests/', async () => {
+    const workspace = await createTempWorkspace('guren-cli-discovery-tests-nontest-')
+
+    try {
+      await mkdir(join(workspace.dir, 'tests'), { recursive: true })
+      await writeFile(join(workspace.dir, 'tests/helpers.ts'), '', 'utf8')
+
+      const files = await discoverTestFiles(workspace.dir)
+
+      expect(files).toHaveLength(0)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('returns an empty array when tests/ does not exist', async () => {
+    const workspace = await createTempWorkspace('guren-cli-discovery-tests-missing-')
+
+    try {
+      const files = await discoverTestFiles(workspace.dir)
+      expect(files).toHaveLength(0)
+    } finally {
+      await workspace.cleanup()
+    }
   })
 })

--- a/packages/cli/tests/discovery.test.ts
+++ b/packages/cli/tests/discovery.test.ts
@@ -149,4 +149,42 @@ describe('discoverTestFiles', () => {
       await workspace.cleanup()
     }
   })
+
+  it('finds *.test.ts files colocated next to source, outside tests/', async () => {
+    const workspace = await createTempWorkspace('guren-cli-discovery-tests-colocated-')
+
+    try {
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      await writeFile(join(workspace.dir, 'app/Models/Post.ts'), '', 'utf8')
+      await writeFile(join(workspace.dir, 'app/Models/Post.test.ts'), '', 'utf8')
+
+      const files = await discoverTestFiles(workspace.dir)
+
+      expect(files).toHaveLength(1)
+      expect(files[0]).toMatch(/Post\.test\.ts$/)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('ignores test files under node_modules/dist/build/coverage', async () => {
+    const workspace = await createTempWorkspace('guren-cli-discovery-tests-excluded-dirs-')
+
+    try {
+      await mkdir(join(workspace.dir, 'node_modules/some-pkg'), { recursive: true })
+      await writeFile(join(workspace.dir, 'node_modules/some-pkg/index.test.ts'), '', 'utf8')
+      await mkdir(join(workspace.dir, 'dist'), { recursive: true })
+      await writeFile(join(workspace.dir, 'dist/bundle.test.js'), '', 'utf8')
+      await mkdir(join(workspace.dir, 'build'), { recursive: true })
+      await writeFile(join(workspace.dir, 'build/out.test.js'), '', 'utf8')
+      await mkdir(join(workspace.dir, 'coverage'), { recursive: true })
+      await writeFile(join(workspace.dir, 'coverage/report.test.js'), '', 'utf8')
+
+      const files = await discoverTestFiles(workspace.dir)
+
+      expect(files).toHaveLength(0)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
 })

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -38,6 +38,9 @@ describe('runDoctor', () => {
             typecheck: 'tsc --noEmit',
             codegen: 'bunx guren codegen --force',
           },
+          devDependencies: {
+            '@guren/testing': '^1.0.0',
+          },
         }, null, 2),
         'utf8',
       )
@@ -874,6 +877,167 @@ describe('runDoctor', () => {
       expect(pluginCheck?.status).toBe('warn')
       expect(pluginCheck?.message).toContain('@acme/guren-plugin-audit')
       expect(pluginCheck?.message).toContain('>=2.0.0')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('warns when @guren/testing is absent and no test files exist', async () => {
+    const workspace = await createTempWorkspace('guren-cli-doctor-test-infra-warn-')
+
+    try {
+      await writeFile(
+        join(workspace.dir, 'package.json'),
+        JSON.stringify({ name: 'doctor-test-infra-warn' }, null, 2),
+        'utf8',
+      )
+
+      const report = await runDoctor({ cwd: workspace.dir, json: true })
+      const testInfraCheck = report.checks.find((check) => check.key === 'test-infrastructure')
+
+      expect(testInfraCheck).toBeDefined()
+      expect(testInfraCheck?.status).toBe('warn')
+      expect(testInfraCheck?.message).toContain('@guren/testing')
+      expect(testInfraCheck?.fix).toContain('bun add -d @guren/testing')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('passes test-infrastructure when @guren/testing is a devDependency', async () => {
+    const workspace = await createTempWorkspace('guren-cli-doctor-test-infra-devdep-')
+
+    try {
+      await writeFile(
+        join(workspace.dir, 'package.json'),
+        JSON.stringify({
+          name: 'doctor-test-infra-devdep',
+          devDependencies: { '@guren/testing': '^1.0.0' },
+        }, null, 2),
+        'utf8',
+      )
+
+      const report = await runDoctor({ cwd: workspace.dir, json: true })
+      const testInfraCheck = report.checks.find((check) => check.key === 'test-infrastructure')
+
+      expect(testInfraCheck).toBeDefined()
+      expect(testInfraCheck?.status).toBe('pass')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('passes test-infrastructure when @guren/testing is a regular dependency', async () => {
+    const workspace = await createTempWorkspace('guren-cli-doctor-test-infra-dep-')
+
+    try {
+      await writeFile(
+        join(workspace.dir, 'package.json'),
+        JSON.stringify({
+          name: 'doctor-test-infra-dep',
+          dependencies: { '@guren/testing': '^1.0.0' },
+        }, null, 2),
+        'utf8',
+      )
+
+      const report = await runDoctor({ cwd: workspace.dir, json: true })
+      const testInfraCheck = report.checks.find((check) => check.key === 'test-infrastructure')
+
+      expect(testInfraCheck).toBeDefined()
+      expect(testInfraCheck?.status).toBe('pass')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('passes test-infrastructure when test files exist even without @guren/testing', async () => {
+    const workspace = await createTempWorkspace('guren-cli-doctor-test-infra-files-')
+
+    try {
+      await mkdir(join(workspace.dir, 'tests/controllers'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'package.json'),
+        JSON.stringify({ name: 'doctor-test-infra-files' }, null, 2),
+        'utf8',
+      )
+      await writeFile(
+        join(workspace.dir, 'tests/controllers/PostController.test.ts'),
+        "import { test, expect } from 'bun:test'\ntest('placeholder', () => { expect(true).toBe(true) })\n",
+        'utf8',
+      )
+
+      const report = await runDoctor({ cwd: workspace.dir, json: true })
+      const testInfraCheck = report.checks.find((check) => check.key === 'test-infrastructure')
+
+      expect(testInfraCheck).toBeDefined()
+      expect(testInfraCheck?.status).toBe('pass')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('does not treat non-test files under tests/ as test infrastructure', async () => {
+    const workspace = await createTempWorkspace('guren-cli-doctor-test-infra-nontest-')
+
+    try {
+      await mkdir(join(workspace.dir, 'tests'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'package.json'),
+        JSON.stringify({ name: 'doctor-test-infra-nontest' }, null, 2),
+        'utf8',
+      )
+      // A helper file, not a *.test.ts file — should not count as test infrastructure.
+      await writeFile(join(workspace.dir, 'tests/helpers.ts'), 'export const noop = () => {}\n', 'utf8')
+
+      const report = await runDoctor({ cwd: workspace.dir, json: true })
+      const testInfraCheck = report.checks.find((check) => check.key === 'test-infrastructure')
+
+      expect(testInfraCheck).toBeDefined()
+      expect(testInfraCheck?.status).toBe('warn')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('surfaces missing test infrastructure as a --next actionable step', async () => {
+    const workspace = await createTempWorkspace('guren-cli-doctor-test-infra-next-')
+
+    try {
+      await writeFile(
+        join(workspace.dir, 'package.json'),
+        JSON.stringify({ name: 'doctor-test-infra-next' }, null, 2),
+        'utf8',
+      )
+
+      const report = await runDoctor({ cwd: workspace.dir, json: true, next: true })
+
+      expect(report.nextSteps).toBeDefined()
+      expect(
+        report.nextSteps?.some((step) => step.command === 'bun add -d @guren/testing'),
+      ).toBe(true)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('does not suggest installing test infrastructure in --next when already present', async () => {
+    const workspace = await createTempWorkspace('guren-cli-doctor-test-infra-next-absent-')
+
+    try {
+      await writeFile(
+        join(workspace.dir, 'package.json'),
+        JSON.stringify({
+          name: 'doctor-test-infra-next-absent',
+          devDependencies: { '@guren/testing': '^1.0.0' },
+        }, null, 2),
+        'utf8',
+      )
+
+      const report = await runDoctor({ cwd: workspace.dir, json: true, next: true })
+
+      expect(
+        report.nextSteps?.some((step) => step.command === 'bun add -d @guren/testing'),
+      ).toBe(false)
     } finally {
       await workspace.cleanup()
     }

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -976,6 +976,32 @@ describe('runDoctor', () => {
     }
   })
 
+  it('passes test-infrastructure when tests are colocated next to source, outside tests/', async () => {
+    const workspace = await createTempWorkspace('guren-cli-doctor-test-infra-colocated-')
+
+    try {
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'package.json'),
+        JSON.stringify({ name: 'doctor-test-infra-colocated' }, null, 2),
+        'utf8',
+      )
+      await writeFile(
+        join(workspace.dir, 'app/Models/Post.test.ts'),
+        "import { test, expect } from 'bun:test'\ntest('placeholder', () => { expect(true).toBe(true) })\n",
+        'utf8',
+      )
+
+      const report = await runDoctor({ cwd: workspace.dir, json: true })
+      const testInfraCheck = report.checks.find((check) => check.key === 'test-infrastructure')
+
+      expect(testInfraCheck).toBeDefined()
+      expect(testInfraCheck?.status).toBe('pass')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('does not treat non-test files under tests/ as test infrastructure', async () => {
     const workspace = await createTempWorkspace('guren-cli-doctor-test-infra-nontest-')
 


### PR DESCRIPTION
## Summary
- `guren doctor` had no project-level signal that a project's test foundation is entirely missing. The existing "No test file found." warning only fires per-controller when a matching test file is absent, so a project with zero test files and no `@guren/testing` dependency got a clean bill of health.
- Reported via dogfooding feedback: an app scaffolded with an older `create-guren-app` had no `@guren/testing` in `devDependencies`, no test script, and zero test files, and `guren doctor` never flagged it. Current `create-guren-app` templates already bundle `@guren/testing`, so this check mainly helps older scaffolds and hand-rolled projects.

## Changes
- Add a `discoverTestFiles()` helper in `packages/cli/src/discovery.ts` that finds `*.test.{ts,tsx,mts,js,jsx,mjs}` files under a project's `tests/` directory (the convention already used by `suggestNextSteps` and the blog example).
- Add a new `test-infrastructure` doctor check in `packages/cli/src/doctor.ts`: warns when `@guren/testing` is present in neither `dependencies` nor `devDependencies` of `package.json` **and** no test files are found, recommending `bun add -d @guren/testing`. Silent (pass) when either condition is satisfied.
- Surface the same signal as an actionable step (`bun add -d @guren/testing`) in `guren doctor --next` output.
- Add a changeset (`@guren/cli`: minor).

## Test plan
- [x] Added `packages/cli/tests/discovery.test.ts` coverage for `discoverTestFiles` (finds `.test.ts`/`.test.tsx`, ignores non-test files, handles missing `tests/` dir).
- [x] Added `packages/cli/tests/doctor.test.ts` coverage: fires when both `@guren/testing` is absent and no test files exist; silent when `@guren/testing` is a `devDependency`; silent when it's a regular `dependency`; silent when test files exist without the package; appears in `--next` output when absent and does not appear when present.
- [x] Updated the existing "passes for a vNext-style workspace" doctor test fixture to include `@guren/testing` in `devDependencies` so it remains fully green.
- [x] `bun install`
- [x] `bun run build:clean`
- [x] `bun test packages/cli` — 414 pass, 0 fail
- [x] `bun run test:bun` — 2262 pass, 0 fail (45 pre-existing skips)
- [x] `bun run typecheck` — clean (after running `codegen` in `examples/blog`, required in any fresh worktree)