### PR TITLE
chore: version packages for the 1.4.0 release wave

### DIFF
--- a/.changeset/codegen-default-overwrite.md
+++ b/.changeset/codegen-default-overwrite.md
@@ -1,5 +1,0 @@
----
-'@guren/cli': patch
----
-
-Make `guren codegen` overwrite existing `.guren/*.gen.ts` artifacts by default. Previously, plain `bunx guren codegen` failed with "already exists. Use --force to overwrite." on any run after the first, even though create-app template scripts always pass `--force` and the generated CLAUDE.md documents plain `bunx guren codegen` as the way to regenerate manifests. `--force` is still accepted for backward compatibility but is now a no-op for this command.

--- a/.changeset/doctor-testing-infra-check.md
+++ b/.changeset/doctor-testing-infra-check.md
@@ -1,5 +1,0 @@
----
-'@guren/cli': minor
----
-
-Add a `guren doctor` check that detects missing test infrastructure. When a project's `package.json` has no `@guren/testing` in `dependencies`/`devDependencies` and no `*.test.ts`-style files exist under `tests/`, doctor now emits a warning recommending `bun add -d @guren/testing`, and the same signal appears as an actionable step in `guren doctor --next`. This closes a gap where apps scaffolded with older `create-guren-app` versions (or hand-rolled projects) had zero test infrastructure and no doctor signal about it.

--- a/.changeset/orm-nested-relation-types.md
+++ b/.changeset/orm-nested-relation-types.md
@@ -1,7 +1,0 @@
----
-'@guren/orm': minor
-'@guren/core': minor
-'@guren/cli': patch
----
-
-Accept dot-notation nested relation paths (`with('comments.author')`) in the type signatures of `with()`, `findWith()`, `findWithOrFail()`, and `withPaginate()` — the runtime already supported them. Add `BelongsToRequiredRecord<T>` for belongsTo relations backed by a NOT NULL foreign key, so `relationTypes` can declare the parent as non-nullable (use the `declare` modifier to skip the runtime placeholder).

--- a/.changeset/plugin-authoring-local-test-gotcha.md
+++ b/.changeset/plugin-authoring-local-test-gotcha.md
@@ -1,5 +1,0 @@
----
-'@guren/cli': patch
----
-
-Document a local-testing gotcha in the `plugin-authoring` agent skill (`agent:init`/`agent:sync`) and the plugin authoring guide: linking a plugin into a test app via `bun add file:`/`link:`/`workspace:` symlinks back to the plugin's source directory, so a plugin that still has its own `@guren/core` devDependency installed can end up loaded as two separate module copies alongside the app's — surfacing as duplicate-module runtime warnings or a `Property 'bindings' is protected...` TypeScript error. The fix (delete `node_modules` in the plugin package directory before linking) is now documented; published plugins never ship `node_modules`, so this only affects local testing before publishing.

--- a/.changeset/testing-db-isolation-docs.md
+++ b/.changeset/testing-db-isolation-docs.md
@@ -1,5 +1,0 @@
----
-'@guren/cli': patch
----
-
-Document SQLite test-database isolation and DB cleanup helpers in the AI agent harness template (`.claude/rules/testing.md`, shipped by `agent:init`/`agent:sync`): the scaffolded `NODE_ENV=test` branch in `config/database.ts` (default `./data/guren.test.db`, `TEST_DATABASE_URL` override, and the retrofit fix for older scaffolds that still write to the dev DB), plus guidance on `resetDatabase()`/`migrateDatabase()` vs. `useTruncateTables()`/`useDatabaseTransactions()` for cleaning up data between tests — including the explicit `DatabaseConnection` requirement and connection-identity caveat for the latter two, since Guren's SQLite adapter doesn't ship a ready-made adapter for them.

--- a/examples/api/CHANGELOG.md
+++ b/examples/api/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @guren/example-api
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies [20e7aa4]
+- Updated dependencies [60e2859]
+- Updated dependencies [0c01602]
+- Updated dependencies [df571cf]
+- Updated dependencies [a10aa54]
+  - @guren/cli@1.4.0
+  - @guren/orm@1.1.0
+  - @guren/core@1.2.0
+
 ## 0.1.5
 
 ### Patch Changes

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/example-api",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @guren/cli
 
+## 1.4.0
+
+### Minor Changes
+
+- 60e2859: Add a `guren doctor` check that detects missing test infrastructure. When a project's `package.json` has no `@guren/testing` in `dependencies`/`devDependencies` and no `*.test.ts`-style files exist under `tests/`, doctor now emits a warning recommending `bun add -d @guren/testing`, and the same signal appears as an actionable step in `guren doctor --next`. This closes a gap where apps scaffolded with older `create-guren-app` versions (or hand-rolled projects) had zero test infrastructure and no doctor signal about it.
+
+### Patch Changes
+
+- 20e7aa4: Make `guren codegen` overwrite existing `.guren/*.gen.ts` artifacts by default. Previously, plain `bunx guren codegen` failed with "already exists. Use --force to overwrite." on any run after the first, even though create-app template scripts always pass `--force` and the generated CLAUDE.md documents plain `bunx guren codegen` as the way to regenerate manifests. `--force` is still accepted for backward compatibility but is now a no-op for this command.
+- 0c01602: Accept dot-notation nested relation paths (`with('comments.author')`) in the type signatures of `with()`, `findWith()`, `findWithOrFail()`, and `withPaginate()` — the runtime already supported them. Add `BelongsToRequiredRecord<T>` for belongsTo relations backed by a NOT NULL foreign key, so `relationTypes` can declare the parent as non-nullable (use the `declare` modifier to skip the runtime placeholder).
+- df571cf: Document a local-testing gotcha in the `plugin-authoring` agent skill (`agent:init`/`agent:sync`) and the plugin authoring guide: linking a plugin into a test app via `bun add file:`/`link:`/`workspace:` symlinks back to the plugin's source directory, so a plugin that still has its own `@guren/core` devDependency installed can end up loaded as two separate module copies alongside the app's — surfacing as duplicate-module runtime warnings or a `Property 'bindings' is protected...` TypeScript error. The fix (delete `node_modules` in the plugin package directory before linking) is now documented; published plugins never ship `node_modules`, so this only affects local testing before publishing.
+- a10aa54: Document SQLite test-database isolation and DB cleanup helpers in the AI agent harness template (`.claude/rules/testing.md`, shipped by `agent:init`/`agent:sync`): the scaffolded `NODE_ENV=test` branch in `config/database.ts` (default `./data/guren.test.db`, `TEST_DATABASE_URL` override, and the retrofit fix for older scaffolds that still write to the dev DB), plus guidance on `resetDatabase()`/`migrateDatabase()` vs. `useTruncateTables()`/`useDatabaseTransactions()` for cleaning up data between tests — including the explicit `DatabaseConnection` requirement and connection-identity caveat for the latter two, since Guren's SQLite adapter doesn't ship a ready-made adapter for them.
+- Updated dependencies [0c01602]
+  - @guren/orm@1.1.0
+  - @guren/core@1.2.0
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/cli",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -45,8 +45,8 @@
   },
   "dependencies": {
     "@babel/parser": "^7.24.7",
-    "@guren/core": "^1.1.0",
-    "@guren/orm": "^1.0.1",
+    "@guren/core": "^1.2.0",
+    "@guren/orm": "^1.1.0",
     "citty": "^0.1.6",
     "consola": "^3.4.2"
   },

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @guren/core
 
+## 1.2.0
+
+### Minor Changes
+
+- 0c01602: Accept dot-notation nested relation paths (`with('comments.author')`) in the type signatures of `with()`, `findWith()`, `findWithOrFail()`, and `withPaginate()` — the runtime already supported them. Add `BelongsToRequiredRecord<T>` for belongsTo relations backed by a NOT NULL foreign key, so `relationTypes` can declare the parent as non-nullable (use the `declare` modifier to skip the runtime placeholder).
+
+### Patch Changes
+
+- Updated dependencies [20e7aa4]
+- Updated dependencies [60e2859]
+- Updated dependencies [0c01602]
+- Updated dependencies [df571cf]
+- Updated dependencies [a10aa54]
+  - @guren/cli@1.4.0
+  - @guren/orm@1.1.0
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -52,8 +52,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@guren/cli": "^1.2.0",
-    "@guren/orm": "^1.0.0",
+    "@guren/cli": "^1.4.0",
+    "@guren/orm": "^1.1.0",
     "@guren/server": "^1.3.0"
   },
   "devDependencies": {

--- a/packages/orm/CHANGELOG.md
+++ b/packages/orm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guren/orm
 
+## 1.1.0
+
+### Minor Changes
+
+- 0c01602: Accept dot-notation nested relation paths (`with('comments.author')`) in the type signatures of `with()`, `findWith()`, `findWithOrFail()`, and `withPaginate()` — the runtime already supported them. Add `BelongsToRequiredRecord<T>` for belongsTo relations backed by a NOT NULL foreign key, so `relationTypes` can declare the parent as non-nullable (use the `declare` modifier to skip the runtime placeholder).
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/orm",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,18 @@
 # web
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies [20e7aa4]
+- Updated dependencies [60e2859]
+- Updated dependencies [0c01602]
+- Updated dependencies [df571cf]
+- Updated dependencies [a10aa54]
+  - @guren/cli@1.4.0
+  - @guren/orm@1.1.0
+  - @guren/core@1.2.0
+
 ## 0.1.5
 
 ### Patch Changes

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Consumes all pending changesets from the recently-merged dogfooding-feedback PRs (#131, #132, #133, #134) plus the already-merged plugin-authoring docs fix (#129):

- **@guren/cli**: 1.3.0 → **1.4.0** (minor — new `doctor` test-infrastructure check)
  - minor: `guren doctor` now warns when a project has no `@guren/testing` dependency and no test files (#134)
  - patch: `guren codegen` overwrites existing `.guren/*.gen.ts` artifacts by default (#132)
  - patch: nested relation path type support (bundled via @guren/orm dependency bump) (#133)
  - patch: plugin-authoring local-testing symlink gotcha docs (#129)
  - patch: SQLite test-database isolation docs (#131)
- **@guren/core**: 1.1.0 → **1.2.0** (minor — nested relation path types, re-exported from @guren/orm)
- **@guren/orm**: 1.0.1 → **1.1.0** (minor — nested relation path types, `BelongsToRequiredRecord`)

`@guren/server`, `@guren/testing`, `@guren/inertia-client`, `create-guren-app`, and `@guren/openapi` are untouched by this wave (no changesets touched them).

## Test plan
- [x] `bun run build:clean` — all packages compile
- [x] `bun run typecheck` — passes (root + examples/blog + examples/api)
- [x] `bun run test:bun` — 2268 pass, 45 skip (expected), 0 fail
- [x] `bun run audit:core-first` / `bun run audit:docs` — pass