### PR TITLE
feat(cli): add registration scaffold to make:auth

### DIFF
--- a/.changeset/make-auth-registration.md
+++ b/.changeset/make-auth-registration.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': minor
+---
+
+`guren make:auth` now scaffolds a registration flow (`RegisterController`, `RegisterSchema` with password confirmation, and a `Register` page) by default, wired into `routes/auth.ts` and linked from the login page. Pass `--minimal` to reproduce the previous login-only scaffold.

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -18,7 +18,7 @@ For new applications, run the bundled scaffolder with automatic installation (th
 bunx guren make:auth --install
 ```
 
-This command generates controllers, Inertia pages, a layout, `AuthProvider`, user model, SQL migration, and a demo seeder. The `--install` flag automatically:
+This command generates login and registration controllers, Inertia pages, a layout, `AuthProvider`, user model, SQL migration, and a demo seeder. The `--install` flag automatically:
 
 1. Registers `AuthProvider` in your `Application` providers array
 2. Adds `createSessionMiddleware` with development-friendly defaults (uses `cookieSecure: true` in production)
@@ -33,7 +33,13 @@ bun run db:seed
 bun run dev
 ```
 
-Visit `http://localhost:3000/login` and sign in with `demo@example.com` / `secret`.
+Visit `http://localhost:3000/login` and sign in with `demo@example.com` / `secret`, or visit `/register` to create a new account.
+
+Pass `--minimal` to skip the registration scaffold and generate the login-only experience instead:
+
+```bash
+bunx guren make:auth --install --minimal
+```
 
 ## OAuth / Social login
 

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -58,7 +58,7 @@ These commands patch `src/app.ts`, create the matching provider/runtime files, a
 | `make:controller <Name>` | Generates a controller in `app/Http/Controllers` | `bunx guren make:controller PostController` |
 | `make:model <Name>` | Generates a minimal model class and type definition in `app/Models` (imports `camelCase(Name)s` from `db/schema`) | `bunx guren make:model Post` |
 | `make:view <path>` | Generates a React component in `resources/js/pages` | `bunx guren make:view posts/Index` |
-| `make:auth` | Scaffolds login/logout controllers, provider, views, migration, seeder, and routes | `bunx guren make:auth` |
+| `make:auth` | Scaffolds login/logout and registration controllers, provider, views, migration, seeder, and routes (`--minimal` skips registration) | `bunx guren make:auth` |
 | `make:middleware <Name>` | Generates a middleware file in `app/Http/Middleware` | `bunx guren make:middleware Auth` |
 | `make:policy <Name>` | Generates an authorization policy in `app/Policies` with owner-based defaults | `bunx guren make:policy Post` |
 | `make:seeder <Name>` | Generates a database seeder file | `bunx guren make:seeder UserSeeder` |

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -18,7 +18,7 @@ Guren には Laravel 由来の認証スタックが同梱され、セッショ�
 bunx guren make:auth --install
 ```
 
-このコマンドはコントローラー、Inertia ページ、レイアウト、`AuthProvider`、ユーザーモデル、SQL マイグレーション、デモシーダーを生成します。`--install` フラグにより自動的に:
+このコマンドはログイン・登録コントローラー、Inertia ページ、レイアウト、`AuthProvider`、ユーザーモデル、SQL マイグレーション、デモシーダーを生成します。`--install` フラグにより自動的に:
 
 1. `Application` の providers 配列に `AuthProvider` を登録
 2. 開発環境用の設定で `createSessionMiddleware` を追加（本番では `cookieSecure: true`）
@@ -33,7 +33,13 @@ bun run db:seed
 bun run dev
 ```
 
-`http://localhost:3000/login` にアクセスし、`demo@example.com` / `secret` でログインできます。
+`http://localhost:3000/login` にアクセスし、`demo@example.com` / `secret` でログインできます。新規アカウントの作成は `/register` から行えます。
+
+登録機能を省略してログインのみを生成したい場合は `--minimal` を付けます。
+
+```bash
+bunx guren make:auth --install --minimal
+```
 
 ## OAuth / ソーシャルログイン
 

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -56,7 +56,7 @@ bunx guren plugin @acme/guren-plugin-audit
 | `make:controller <Name>` | `app/Http/Controllers` にコントローラーを生成 | `bunx guren make:controller PostController` |
 | `make:model <Name>` | 最小のモデルクラスと型定義を `app/Models` に生成（`db/schema` から `camelCase(Name)s` を import） | `bunx guren make:model Post` |
 | `make:view <path>` | `resources/js/pages` に React コンポーネントを生成 | `bunx guren make:view posts/Index` |
-| `make:auth` | ログイン/ログアウトのコントローラー、プロバイダー、ビュー、マイグレーション、シーダー、ルートをスキャフォールド | `bunx guren make:auth` |
+| `make:auth` | ログイン/ログアウトと新規登録のコントローラー、プロバイダー、ビュー、マイグレーション、シーダー、ルートをスキャフォールド（`--minimal` で登録機能を省略） | `bunx guren make:auth` |
 | `make:middleware <Name>` | `app/Http/Middleware` にミドルウェアを生成 | `bunx guren make:middleware Auth` |
 | `make:seeder <Name>` | データベースシーダーファイルを生成 | `bunx guren make:seeder UserSeeder` |
 | `make:job <Name>` | キュー可能なジョブクラスを生成 | `bunx guren make:job SendEmail` |

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -229,11 +229,16 @@ const makeAuthCommand = defineCommand({
       description: 'Automatically wire up auth configuration in app.ts and routes',
       alias: 'i',
     },
+    minimal: {
+      type: 'boolean',
+      description: 'Skip registration scaffolding and generate the login-only experience',
+    },
   },
   async run({ args }) {
     const files = await makeAuth({
       ...toWriterOptions(args),
       install: Boolean(args.install),
+      minimal: Boolean(args.minimal),
     })
     for (const file of files) {
       consola.success(`Created ${file}`)

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -44,6 +44,37 @@ export default class LoginController extends Controller {
 }
 `
 
+const registerControllerTemplate = `import { Controller, ScryptHasher, ValidationException } from '@guren/core'
+import { RegisterSchema } from '../../Validators/RegisterValidator.js'
+import { User } from '../../../Models/User.js'
+import { pages } from '@/.guren/pages.gen'
+
+const hasher = new ScryptHasher()
+
+export default class RegisterController extends Controller {
+  async show(): Promise<Response> {
+    return this.inertia(pages.auth.Register, {}, { url: this.request.path, title: 'Register' })
+  }
+
+  async store(): Promise<Response> {
+    const { name, email, password } = await this.validateBody(RegisterSchema)
+
+    const existing = await User.where({ email })
+    if (existing.length > 0) {
+      throw ValidationException.withMessages({ email: 'An account with this email already exists.' })
+    }
+
+    const passwordHash = await hasher.hash(password)
+    const user = await User.create({ name, email, passwordHash })
+
+    this.auth.session()?.regenerate()
+    await this.auth.login(user)
+
+    return this.redirect('/dashboard')
+  }
+}
+`
+
 const dashboardControllerTemplate = `import { Controller } from '@guren/core'
 import type { UserRecord } from '../../Models/User.js'
 import { pages } from '@/.guren/pages.gen'
@@ -175,6 +206,35 @@ export const LoginSchema = z.object({
 export type LoginInput = z.infer<typeof LoginSchema>
 `
 
+const registerValidatorTemplate = `import { z } from 'zod'
+
+export const RegisterSchema = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(1, 'Name is required.')
+      .max(120, 'Name must be 120 characters or fewer.'),
+    email: z
+      .string()
+      .trim()
+      .min(1, 'Email is required.')
+      .email('The email address is badly formatted.'),
+    password: z
+      .string()
+      .min(8, 'Password must be at least 8 characters.'),
+    passwordConfirmation: z
+      .string()
+      .min(1, 'Please confirm your password.'),
+  })
+  .refine((data) => data.password === data.passwordConfirmation, {
+    message: 'Passwords do not match.',
+    path: ['passwordConfirmation'],
+  })
+
+export type RegisterInput = z.infer<typeof RegisterSchema>
+`
+
 const profileValidatorTemplate = `import { z } from 'zod'
 
 export const ProfileUpdateSchema = z.object({
@@ -248,7 +308,18 @@ export default function Layout({ children }: PropsWithChildren) {
 }
 `
 
-const loginViewTemplate = `import { Head, Link, useForm } from '@inertiajs/react'
+function buildLoginViewTemplate(includeRegister: boolean): string {
+  const signUpLink = includeRegister
+    ? `
+        <p className="mt-2 text-center text-sm text-slate-400">
+          Don&apos;t have an account?{' '}
+          <Link href="/register" className="text-emerald-300 transition hover:text-emerald-200">
+            Sign up
+          </Link>
+        </p>`
+    : ''
+
+  return `import { Head, Link, useForm } from '@inertiajs/react'
 import { useId } from 'react'
 import Layout from '../../components/Layout.js'
 import type { ValidationErrors } from '@guren/core'
@@ -347,6 +418,141 @@ export default function Login({ email = '', errors = {} }: Props) {
 
         <p className="mt-6 text-center text-sm text-slate-400">
           Forgot your password? Contact your administrator.
+        </p>${signUpLink}
+      </section>
+    </Layout>
+  )
+}
+`
+}
+
+const registerViewTemplate = `import { Head, Link, useForm } from '@inertiajs/react'
+import { useId } from 'react'
+import Layout from '../../components/Layout.js'
+import type { ValidationErrors } from '@guren/core'
+
+interface Props {
+  errors?: ValidationErrors<'name' | 'email' | 'password' | 'passwordConfirmation'>
+}
+
+type RegisterFormData = {
+  name: string
+  email: string
+  password: string
+  passwordConfirmation: string
+}
+
+export default function Register({ errors = {} }: Props) {
+  const form = useForm<RegisterFormData>({
+    name: '',
+    email: '',
+    password: '',
+    passwordConfirmation: '',
+  })
+
+  const nameId = useId()
+  const emailId = useId()
+  const passwordId = useId()
+  const passwordConfirmationId = useId()
+
+  return (
+    <Layout>
+      <Head title="Sign up" />
+      <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-8 shadow-xl shadow-emerald-500/5">
+        <h1 className="text-2xl font-semibold text-emerald-300">Create an account</h1>
+        <p className="mt-2 text-sm text-slate-400">
+          Sign up to get started.
+        </p>
+
+        {errors.message && (
+          <p className="mt-4 rounded border border-rose-500/60 bg-rose-500/10 px-4 py-2 text-sm text-rose-200">
+            {errors.message}
+          </p>
+        )}
+
+        <form
+          className="mt-6 space-y-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            form.post('/register')
+          }}
+        >
+          <div>
+            <label htmlFor={nameId} className="block text-sm font-medium text-slate-200">
+              Name
+            </label>
+            <input
+              id={nameId}
+              type="text"
+              value={form.data.name}
+              onChange={(event) => form.setData('name', event.target.value)}
+              required
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+            />
+            {errors.name && <p className="mt-1 text-sm text-rose-300">{errors.name}</p>}
+          </div>
+
+          <div>
+            <label htmlFor={emailId} className="block text-sm font-medium text-slate-200">
+              Email
+            </label>
+            <input
+              id={emailId}
+              type="email"
+              value={form.data.email}
+              onChange={(event) => form.setData('email', event.target.value)}
+              required
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+            />
+            {errors.email && <p className="mt-1 text-sm text-rose-300">{errors.email}</p>}
+          </div>
+
+          <div>
+            <label htmlFor={passwordId} className="block text-sm font-medium text-slate-200">
+              Password
+            </label>
+            <input
+              id={passwordId}
+              type="password"
+              value={form.data.password}
+              onChange={(event) => form.setData('password', event.target.value)}
+              required
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+            />
+            {errors.password && <p className="mt-1 text-sm text-rose-300">{errors.password}</p>}
+          </div>
+
+          <div>
+            <label htmlFor={passwordConfirmationId} className="block text-sm font-medium text-slate-200">
+              Confirm password
+            </label>
+            <input
+              id={passwordConfirmationId}
+              type="password"
+              value={form.data.passwordConfirmation}
+              onChange={(event) => form.setData('passwordConfirmation', event.target.value)}
+              required
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+            />
+            {errors.passwordConfirmation && (
+              <p className="mt-1 text-sm text-rose-300">{errors.passwordConfirmation}</p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={form.processing}
+            className="w-full rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+          >
+            Create account
+          </button>
+        </form>
+
+        <p className="mt-6 text-center text-sm text-slate-400">
+          Already have an account?{' '}
+          <Link href="/login" className="text-emerald-300 transition hover:text-emerald-200">
+            Sign in
+          </Link>
         </p>
       </section>
     </Layout>
@@ -477,8 +683,19 @@ export default function ProfileEdit({ profile, status }: Props) {
 }
 `
 
-const routesTemplate = `import { Router, requireAuthenticated, requireGuest } from '@guren/core'
-import LoginController from '../app/Http/Controllers/Auth/LoginController.js'
+function buildRoutesTemplate(includeRegister: boolean): string {
+  const registerImport = includeRegister
+    ? `\nimport RegisterController from '../app/Http/Controllers/Auth/RegisterController.js'`
+    : ''
+  const registerRoutes = includeRegister
+    ? `
+  router.get('/register', [RegisterController, 'show'], requireGuest({ redirectTo: '/dashboard' })).name('register')
+  router.post('/register', [RegisterController, 'store'], requireGuest({ redirectTo: '/dashboard' })).name('register.store')
+`
+    : ''
+
+  return `import { Router, requireAuthenticated, requireGuest } from '@guren/core'
+import LoginController from '../app/Http/Controllers/Auth/LoginController.js'${registerImport}
 import DashboardController from '../app/Http/Controllers/DashboardController.js'
 import ProfileController from '../app/Http/Controllers/ProfileController.js'
 
@@ -486,12 +703,13 @@ export function registerAuthRoutes(router: Router): void {
   router.get('/login', [LoginController, 'show'], requireGuest({ redirectTo: '/dashboard' })).name('login')
   router.post('/login', [LoginController, 'store'], requireGuest({ redirectTo: '/dashboard' })).name('login.store')
   router.post('/logout', [LoginController, 'destroy'], requireAuthenticated({ redirectTo: '/login' })).name('logout')
-
+${registerRoutes}
   router.get('/dashboard', [DashboardController, 'index'], requireAuthenticated({ redirectTo: '/login' })).name('dashboard')
   router.get('/profile', [ProfileController, 'edit'], requireAuthenticated({ redirectTo: '/login' })).name('profile.edit')
   router.put('/profile', [ProfileController, 'update'], requireAuthenticated({ redirectTo: '/login' })).name('profile.update')
 }
 `
+}
 
 const seederTemplate = `import { defineSeeder, ScryptHasher } from '@guren/core'
 import { users } from '../schema.js'
@@ -627,10 +845,14 @@ async function updatePageContracts(): Promise<void> {
 
 export interface MakeAuthOptions extends WriterOptions {
   install?: boolean
+  /** Skip registration scaffolding and generate the login-only experience. */
+  minimal?: boolean
 }
 
 export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]> {
-  const created = await writeFilesSafe([
+  const includeRegister = !options.minimal
+
+  const files = [
     { path: 'app/Http/Controllers/Auth/LoginController.ts', contents: loginControllerTemplate },
     { path: 'app/Http/Controllers/DashboardController.ts', contents: dashboardControllerTemplate },
     { path: 'app/Http/Controllers/ProfileController.ts', contents: profileControllerTemplate },
@@ -639,12 +861,22 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
     { path: 'app/Http/Validators/LoginValidator.ts', contents: loginValidatorTemplate },
     { path: 'app/Http/Validators/ProfileValidator.ts', contents: profileValidatorTemplate },
     { path: 'resources/js/components/Layout.tsx', contents: layoutTemplate },
-    { path: 'resources/js/pages/auth/Login.tsx', contents: loginViewTemplate },
+    { path: 'resources/js/pages/auth/Login.tsx', contents: buildLoginViewTemplate(includeRegister) },
     { path: 'resources/js/pages/dashboard/Index.tsx', contents: dashboardViewTemplate },
     { path: 'resources/js/pages/profile/Edit.tsx', contents: profileViewTemplate },
-    { path: 'routes/auth.ts', contents: routesTemplate },
+    { path: 'routes/auth.ts', contents: buildRoutesTemplate(includeRegister) },
     { path: 'db/seeders/UsersSeeder.ts', contents: seederTemplate },
-  ], options)
+  ]
+
+  if (includeRegister) {
+    files.push(
+      { path: 'app/Http/Controllers/Auth/RegisterController.ts', contents: registerControllerTemplate },
+      { path: 'app/Http/Validators/RegisterValidator.ts', contents: registerValidatorTemplate },
+      { path: 'resources/js/pages/auth/Register.tsx', contents: registerViewTemplate },
+    )
+  }
+
+  const created = await writeFilesSafe(files, options)
 
   await updateSchema()
   await updatePageContracts()

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -44,12 +44,10 @@ export default class LoginController extends Controller {
 }
 `
 
-const registerControllerTemplate = `import { Controller, ScryptHasher, ValidationException } from '@guren/core'
+const registerControllerTemplate = `import { Controller, ValidationException } from '@guren/core'
 import { RegisterSchema } from '../../Validators/RegisterValidator.js'
 import { User } from '../../../Models/User.js'
 import { pages } from '@/.guren/pages.gen'
-
-const hasher = new ScryptHasher()
 
 export default class RegisterController extends Controller {
   async show(): Promise<Response> {
@@ -64,8 +62,9 @@ export default class RegisterController extends Controller {
       throw ValidationException.withMessages({ email: 'An account with this email already exists.' })
     }
 
-    const passwordHash = await hasher.hash(password)
-    const user = await User.create({ name, email, passwordHash })
+    // AuthenticatableModel hashes the virtual \`password\` field into
+    // \`passwordHash\` before persisting — see app/Models/User.ts.
+    const user = await User.create({ name, email, password })
 
     this.auth.session()?.regenerate()
     await this.auth.login(user)

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -55,12 +55,15 @@ export function registerWebRoutes(router: Router): void {
 
       const created = await makeAuth({ install: true, force: true })
 
-      expect(created).toHaveLength(13)
+      expect(created).toHaveLength(16)
       expect(created).toEqual(expect.arrayContaining([
         expect.stringContaining('LoginController.ts'),
         expect.stringContaining('routes/auth.ts'),
         expect.stringContaining('ProfileController.ts'),
         expect.stringContaining('ProfileValidator.ts'),
+        expect.stringContaining('RegisterController.ts'),
+        expect.stringContaining('RegisterValidator.ts'),
+        expect.stringContaining('Register.tsx'),
       ]))
 
       const schema = await readFile(join(workspace.dir, 'db/schema.ts'), 'utf8')
@@ -75,13 +78,64 @@ export function registerWebRoutes(router: Router): void {
       expect(routesContent).toContain("import { registerAuthRoutes } from './auth.js'")
       expect(routesContent).toContain('registerAuthRoutes(router)')
 
+      const authRoutes = await readFile(join(workspace.dir, 'routes/auth.ts'), 'utf8')
+      expect(authRoutes).toContain("import RegisterController from '../app/Http/Controllers/Auth/RegisterController.js'")
+      expect(authRoutes).toContain("router.get('/register'")
+      expect(authRoutes).toContain("router.post('/register'")
+
       const loginPage = await readFile(join(workspace.dir, 'resources/js/pages/auth/Login.tsx'), 'utf8')
       expect(loginPage).toContain('interface Props')
+      expect(loginPage).toContain('href="/register"')
 
       const loginController = await readFile(join(workspace.dir, 'app/Http/Controllers/Auth/LoginController.ts'), 'utf8')
       expect(loginController).toContain('validateBody(LoginSchema)')
       expect(loginController).toContain('pages.auth.Login')
       expect(loginController).not.toContain('safeParse')
+
+      const registerController = await readFile(
+        join(workspace.dir, 'app/Http/Controllers/Auth/RegisterController.ts'),
+        'utf8',
+      )
+      expect(registerController).toContain('validateBody(RegisterSchema)')
+      expect(registerController).toContain('pages.auth.Register')
+      expect(registerController).toContain('User.create(')
+
+      const registerValidator = await readFile(
+        join(workspace.dir, 'app/Http/Validators/RegisterValidator.ts'),
+        'utf8',
+      )
+      expect(registerValidator).toContain('passwordConfirmation')
+      expect(registerValidator).toContain('Passwords do not match.')
+
+      const registerPage = await readFile(join(workspace.dir, 'resources/js/pages/auth/Register.tsx'), 'utf8')
+      expect(registerPage).toContain('interface Props')
+      expect(registerPage).toContain("form.post('/register')")
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('skips registration scaffolding with --minimal', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-auth-minimal-')
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(join(workspace.dir, 'db/schema.ts'), `export const posts = 'posts'\n`, 'utf8')
+
+      const created = await makeAuth({ force: true, minimal: true })
+
+      expect(created).toHaveLength(13)
+      expect(created).not.toEqual(expect.arrayContaining([
+        expect.stringContaining('RegisterController.ts'),
+        expect.stringContaining('RegisterValidator.ts'),
+        expect.stringContaining('Register.tsx'),
+      ]))
+
+      const authRoutes = await readFile(join(workspace.dir, 'routes/auth.ts'), 'utf8')
+      expect(authRoutes).not.toContain('RegisterController')
+      expect(authRoutes).not.toContain("router.get('/register'")
+
+      const loginPage = await readFile(join(workspace.dir, 'resources/js/pages/auth/Login.tsx'), 'utf8')
+      expect(loginPage).not.toContain('href="/register"')
     } finally {
       await workspace.cleanup()
     }


### PR DESCRIPTION
## Summary
- `make:auth` now scaffolds a registration flow by default: `RegisterController` (duplicate-email check, `ScryptHasher`, `User.create()`, auto-login), `RegisterSchema` (password confirmation via `.refine()`), and a `Register` page linked from the login page
- Adds `/register` (`GET`/`POST`) to `routes/auth.ts`
- Adds `--minimal` flag to reproduce the previous login-only scaffold

## Test plan
- [x] `bun test packages/cli/tests/make-auth.test.ts` — new register/`--minimal` assertions pass
- [x] `bun run build:clean`
- [x] `bun run typecheck`
- [x] `bun run test:bun` (2270 pass)
- [x] `bun run test:examples`
- [x] `bun run audit:core-first`
- [x] `bun run audit:docs`
- [x] Manually ran `make:auth --install` in a scratch workspace and inspected generated import paths, route wiring, and schema
- [x] Regenerated into `examples/blog` (`--force` + `codegen` + `tsc`) to compile the new templates as real TSX/TS against real types, then discarded the changes (examples/blog itself is untouched by this PR — full adoption is a later PR)