### PR TITLE
feat(cli): add password reset flow to make:auth

### DIFF
--- a/.changeset/make-auth-password-reset.md
+++ b/.changeset/make-auth-password-reset.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': minor
+---
+
+`guren make:auth` now scaffolds a password reset flow (`ForgotPasswordController`, `ResetPasswordController`, a `config/mail.ts` defaulting to the `log` driver, and an in-memory `PasswordResetStore`) by default, alongside a fix for `addImport` corrupting multi-line leading import statements when wiring providers into `src/app.ts`. Pass `--minimal` to skip registration and password reset scaffolding.

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -18,9 +18,9 @@ For new applications, run the bundled scaffolder with automatic installation (th
 bunx guren make:auth --install
 ```
 
-This command generates login and registration controllers, Inertia pages, a layout, `AuthProvider`, user model, SQL migration, and a demo seeder. The `--install` flag automatically:
+This command generates login, registration, and password reset controllers, Inertia pages, a layout, `AuthProvider`, `MailProvider`, user model, SQL migration, and a demo seeder. The `--install` flag automatically:
 
-1. Registers `AuthProvider` in your `Application` providers array
+1. Registers `AuthProvider` and `MailProvider` in your `Application` providers array
 2. Adds `createSessionMiddleware` with development-friendly defaults (uses `cookieSecure: true` in production)
 3. Wires `registerAuthRoutes(router)` into `routes/web.ts`
 4. Updates `db/schema.ts` to include password and remember-token columns
@@ -35,11 +35,15 @@ bun run dev
 
 Visit `http://localhost:3000/login` and sign in with `demo@example.com` / `secret`, or visit `/register` to create a new account.
 
-Pass `--minimal` to skip the registration scaffold and generate the login-only experience instead:
+Pass `--minimal` to skip the registration and password reset scaffold and generate the login-only experience instead:
 
 ```bash
 bunx guren make:auth --install --minimal
 ```
+
+### Password reset
+
+Clicking "Forgot your password?" on the login page walks through `ForgotPasswordController` and `ResetPasswordController`, which use the framework's `createPasswordResetToken` / `verifyPasswordResetToken` primitives under the hood. The reset token is stored with the generated `app/Auth/PasswordResetStore.ts` (an in-memory store — swap it for a Redis-backed store in production or any multi-instance deployment) and emailed via the generated `config/mail.ts`, which defaults to the `log` driver: reset links print straight to the console, so the flow works with zero setup in development. Set `MAIL_DRIVER=smtp` (and the `SMTP_*` environment variables) once you're ready to send real email.
 
 ## OAuth / Social login
 

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -58,7 +58,7 @@ These commands patch `src/app.ts`, create the matching provider/runtime files, a
 | `make:controller <Name>` | Generates a controller in `app/Http/Controllers` | `bunx guren make:controller PostController` |
 | `make:model <Name>` | Generates a minimal model class and type definition in `app/Models` (imports `camelCase(Name)s` from `db/schema`) | `bunx guren make:model Post` |
 | `make:view <path>` | Generates a React component in `resources/js/pages` | `bunx guren make:view posts/Index` |
-| `make:auth` | Scaffolds login/logout and registration controllers, provider, views, migration, seeder, and routes (`--minimal` skips registration) | `bunx guren make:auth` |
+| `make:auth` | Scaffolds login/logout, registration, and password reset controllers, providers, views, migration, seeder, and routes (`--minimal` skips registration and password reset) | `bunx guren make:auth` |
 | `make:middleware <Name>` | Generates a middleware file in `app/Http/Middleware` | `bunx guren make:middleware Auth` |
 | `make:policy <Name>` | Generates an authorization policy in `app/Policies` with owner-based defaults | `bunx guren make:policy Post` |
 | `make:seeder <Name>` | Generates a database seeder file | `bunx guren make:seeder UserSeeder` |

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -18,9 +18,9 @@ Guren には Laravel 由来の認証スタックが同梱され、セッショ�
 bunx guren make:auth --install
 ```
 
-このコマンドはログイン・登録コントローラー、Inertia ページ、レイアウト、`AuthProvider`、ユーザーモデル、SQL マイグレーション、デモシーダーを生成します。`--install` フラグにより自動的に:
+このコマンドはログイン・登録・パスワードリセットのコントローラー、Inertia ページ、レイアウト、`AuthProvider`、`MailProvider`、ユーザーモデル、SQL マイグレーション、デモシーダーを生成します。`--install` フラグにより自動的に:
 
-1. `Application` の providers 配列に `AuthProvider` を登録
+1. `Application` の providers 配列に `AuthProvider` と `MailProvider` を登録
 2. 開発環境用の設定で `createSessionMiddleware` を追加（本番では `cookieSecure: true`）
 3. `routes/web.ts` で `registerAuthRoutes(router)` を接続
 4. `db/schema.ts` にパスワードや remember トークンのカラムを追加
@@ -35,11 +35,15 @@ bun run dev
 
 `http://localhost:3000/login` にアクセスし、`demo@example.com` / `secret` でログインできます。新規アカウントの作成は `/register` から行えます。
 
-登録機能を省略してログインのみを生成したい場合は `--minimal` を付けます。
+登録・パスワードリセット機能を省略してログインのみを生成したい場合は `--minimal` を付けます。
 
 ```bash
 bunx guren make:auth --install --minimal
 ```
+
+### パスワードリセット
+
+ログインページの「Forgot your password?」から `ForgotPasswordController` と `ResetPasswordController` によるフローに入ります。内部ではフレームワークの `createPasswordResetToken` / `verifyPasswordResetToken` を使用しています。リセットトークンは生成される `app/Auth/PasswordResetStore.ts`（インメモリストア。本番や複数インスタンス構成では Redis ベースのストアに差し替えてください）に保存され、生成される `config/mail.ts` 経由でメール送信されます。`config/mail.ts` はデフォルトで `log` ドライバを使うため、リセットリンクはコンソールにそのまま出力され、開発環境では設定なしで動作確認できます。実際にメールを送るには `MAIL_DRIVER=smtp`（および `SMTP_*` の環境変数）を設定してください。
 
 ## OAuth / ソーシャルログイン
 

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -56,7 +56,7 @@ bunx guren plugin @acme/guren-plugin-audit
 | `make:controller <Name>` | `app/Http/Controllers` にコントローラーを生成 | `bunx guren make:controller PostController` |
 | `make:model <Name>` | 最小のモデルクラスと型定義を `app/Models` に生成（`db/schema` から `camelCase(Name)s` を import） | `bunx guren make:model Post` |
 | `make:view <path>` | `resources/js/pages` に React コンポーネントを生成 | `bunx guren make:view posts/Index` |
-| `make:auth` | ログイン/ログアウトと新規登録のコントローラー、プロバイダー、ビュー、マイグレーション、シーダー、ルートをスキャフォールド（`--minimal` で登録機能を省略） | `bunx guren make:auth` |
+| `make:auth` | ログイン/ログアウト・新規登録・パスワードリセットのコントローラー、プロバイダー、ビュー、マイグレーション、シーダー、ルートをスキャフォールド（`--minimal` で登録・パスワードリセットを省略） | `bunx guren make:auth` |
 | `make:middleware <Name>` | `app/Http/Middleware` にミドルウェアを生成 | `bunx guren make:middleware Auth` |
 | `make:seeder <Name>` | データベースシーダーファイルを生成 | `bunx guren make:seeder UserSeeder` |
 | `make:job <Name>` | キュー可能なジョブクラスを生成 | `bunx guren make:job SendEmail` |

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -1335,6 +1335,22 @@ async function installAuth(migrationGenerated = true, includeExtras = true): Pro
   await wireProvider(appPath, 'AuthProvider', 'app/Providers/AuthProvider.js')
 
   if (includeExtras) {
+    // Wire CoreMailServiceProvider before our own MailProvider — matching
+    // the `guren add mail` blueprint's convention — so `container.singleton(
+    // 'mail', ...)` resolves to our configured manager rather than Core's
+    // empty-config default, regardless of whether `add mail` also runs
+    // (before or after this) against the same app.
+    const coreMailImportResult = await addImport(appPath, "import { MailServiceProvider as CoreMailServiceProvider } from '@guren/core'")
+    if (coreMailImportResult.modified) {
+      consola.success(`Added CoreMailServiceProvider import to ${appPath}`)
+    }
+    const coreMailProviderResult = await addProvider(appPath, 'CoreMailServiceProvider')
+    if (coreMailProviderResult.modified) {
+      consola.success(`Added CoreMailServiceProvider to providers array in ${appPath}`)
+    } else if (coreMailProviderResult.reason !== 'Provider already registered') {
+      consola.warn(`Could not add CoreMailServiceProvider: ${coreMailProviderResult.reason}`)
+    }
+
     await wireProvider(appPath, 'MailProvider', 'app/Providers/MailProvider.js')
   }
 

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -74,6 +74,81 @@ export default class RegisterController extends Controller {
 }
 `
 
+const forgotPasswordControllerTemplate = `import { Controller, createPasswordResetToken, buildPasswordResetUrl } from '@guren/core'
+import { ForgotPasswordSchema } from '../../Validators/ForgotPasswordValidator.js'
+import { User } from '../../../Models/User.js'
+import { passwordResetStore } from '../../../Auth/PasswordResetStore.js'
+import { sendPasswordResetMail } from '../../../Mail/PasswordResetMail.js'
+import { pages } from '@/.guren/pages.gen'
+
+const STATUS_MESSAGE = "If an account exists for that email, we've sent a password reset link."
+
+export default class ForgotPasswordController extends Controller {
+  async show(): Promise<Response> {
+    return this.inertia(pages.auth.ForgotPassword, {}, { url: this.request.path, title: 'Forgot password' })
+  }
+
+  async store(): Promise<Response> {
+    const { email } = await this.validateBody(ForgotPasswordSchema)
+
+    // Always respond with the same status message whether or not the
+    // account exists, to avoid leaking which emails are registered.
+    const [user] = await User.where({ email })
+    if (user) {
+      const { token } = await createPasswordResetToken(email, passwordResetStore)
+      const resetUrl = buildPasswordResetUrl(\`\${new URL(this.request.url).origin}/reset-password\`, token, email)
+      await sendPasswordResetMail(this.make('mail'), email, resetUrl)
+    }
+
+    return this.inertia(pages.auth.ForgotPassword, { status: STATUS_MESSAGE }, {
+      url: this.request.path,
+      title: 'Forgot password',
+    })
+  }
+}
+`
+
+const resetPasswordControllerTemplate = `import { Controller, ValidationException, verifyPasswordResetToken } from '@guren/core'
+import { ResetPasswordSchema } from '../../Validators/ResetPasswordValidator.js'
+import { User } from '../../../Models/User.js'
+import { passwordResetStore } from '../../../Auth/PasswordResetStore.js'
+import { pages } from '@/.guren/pages.gen'
+
+const INVALID_TOKEN_MESSAGE = 'This password reset link is invalid or has expired.'
+
+export default class ResetPasswordController extends Controller {
+  async show(): Promise<Response> {
+    const token = this.request.query('token') ?? ''
+    const email = this.request.query('email') ?? ''
+    return this.inertia(pages.auth.ResetPassword, { token, email }, {
+      url: this.request.path,
+      title: 'Reset password',
+    })
+  }
+
+  async store(): Promise<Response> {
+    const { token, password } = await this.validateBody(ResetPasswordSchema)
+
+    const email = await verifyPasswordResetToken(token, passwordResetStore)
+    if (!email) {
+      throw ValidationException.withMessages({ token: INVALID_TOKEN_MESSAGE })
+    }
+
+    const [user] = await User.where({ email })
+    if (!user) {
+      throw ValidationException.withMessages({ token: INVALID_TOKEN_MESSAGE })
+    }
+
+    // AuthenticatableModel hashes the virtual \`password\` field into
+    // \`passwordHash\` before persisting — see app/Models/User.ts.
+    await User.update({ id: user.id }, { password })
+    await passwordResetStore.deleteForEmail(email)
+
+    return this.redirect('/login')
+  }
+}
+`
+
 const dashboardControllerTemplate = `import { Controller } from '@guren/core'
 import type { UserRecord } from '../../Models/User.js'
 import { pages } from '@/.guren/pages.gen'
@@ -179,6 +254,76 @@ export default class AuthProvider extends ServiceProvider {
 }
 `
 
+const mailConfigTemplate = `import type { MailConfig } from '@guren/core'
+
+// Defaults to the \`log\` driver, which prints outgoing emails to the
+// console instead of sending them — nothing to configure for local
+// development. Set MAIL_DRIVER=smtp (and the SMTP_* variables below)
+// once you're ready to send real email.
+export const mailConfig: MailConfig = {
+  default: process.env.MAIL_DRIVER ?? 'log',
+  from: {
+    email: process.env.MAIL_FROM_ADDRESS ?? 'noreply@example.com',
+    name: process.env.MAIL_FROM_NAME ?? 'Guren',
+  },
+  transports: {
+    log: { driver: 'log' },
+    smtp: {
+      driver: 'smtp',
+      host: process.env.SMTP_HOST ?? 'localhost',
+      port: Number(process.env.SMTP_PORT ?? 587),
+      auth: {
+        user: process.env.SMTP_USER ?? '',
+        pass: process.env.SMTP_PASS ?? '',
+      },
+    },
+  },
+}
+`
+
+const mailProviderTemplate = `import { ServiceProvider, createMailManager } from '@guren/core'
+import { mailConfig } from '../../config/mail.js'
+
+export default class MailProvider extends ServiceProvider {
+  register(): void {
+    this.container.singleton('mail', () => createMailManager(mailConfig))
+  }
+}
+`
+
+const passwordResetStoreTemplate = `import { MemoryPasswordResetStore } from '@guren/core'
+
+// Swap for a Redis-backed store (see @guren/server/redis) in production
+// or any multi-instance deployment — this in-memory store does not
+// survive restarts and is not shared across processes.
+export const passwordResetStore = new MemoryPasswordResetStore()
+`
+
+const passwordResetMailTemplate = `import { mail, type MailManager } from '@guren/core'
+
+export async function sendPasswordResetMail(manager: MailManager, email: string, resetUrl: string): Promise<void> {
+  await mail(manager)
+    .to(email)
+    .subject('Reset your password')
+    .html(\`
+      <h1>Reset your password</h1>
+      <p>Click the link below to choose a new password. This link expires in 1 hour.</p>
+      <p><a href="\${resetUrl}">\${resetUrl}</a></p>
+      <p>If you didn't request this, you can safely ignore this email.</p>
+    \`)
+    .text(\`
+Reset your password
+
+Click the link below to choose a new password. This link expires in 1 hour.
+
+\${resetUrl}
+
+If you didn't request this, you can safely ignore this email.
+    \`)
+    .send()
+}
+`
+
 const loginValidatorTemplate = `import { z } from 'zod'
 
 export const LoginSchema = z.object({
@@ -232,6 +377,39 @@ export const RegisterSchema = z
   })
 
 export type RegisterInput = z.infer<typeof RegisterSchema>
+`
+
+const forgotPasswordValidatorTemplate = `import { z } from 'zod'
+
+export const ForgotPasswordSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .min(1, 'Email is required.')
+    .email('The email address is badly formatted.'),
+})
+
+export type ForgotPasswordInput = z.infer<typeof ForgotPasswordSchema>
+`
+
+const resetPasswordValidatorTemplate = `import { z } from 'zod'
+
+export const ResetPasswordSchema = z
+  .object({
+    token: z.string().min(1, 'Reset token is required.'),
+    password: z
+      .string()
+      .min(8, 'Password must be at least 8 characters.'),
+    passwordConfirmation: z
+      .string()
+      .min(1, 'Please confirm your password.'),
+  })
+  .refine((data) => data.password === data.passwordConfirmation, {
+    message: 'Passwords do not match.',
+    path: ['passwordConfirmation'],
+  })
+
+export type ResetPasswordInput = z.infer<typeof ResetPasswordSchema>
 `
 
 const profileValidatorTemplate = `import { z } from 'zod'
@@ -307,7 +485,7 @@ export default function Layout({ children }: PropsWithChildren) {
 }
 `
 
-function buildLoginViewTemplate(includeRegister: boolean): string {
+function buildLoginViewTemplate(includeRegister: boolean, includeReset: boolean): string {
   const signUpLink = includeRegister
     ? `
         <p className="mt-2 text-center text-sm text-slate-400">
@@ -317,6 +495,18 @@ function buildLoginViewTemplate(includeRegister: boolean): string {
           </Link>
         </p>`
     : ''
+
+  const forgotPasswordText = includeReset
+    ? `
+        <p className="mt-6 text-center text-sm text-slate-400">
+          <Link href="/forgot-password" className="text-emerald-300 transition hover:text-emerald-200">
+            Forgot your password?
+          </Link>
+        </p>`
+    : `
+        <p className="mt-6 text-center text-sm text-slate-400">
+          Forgot your password? Contact your administrator.
+        </p>`
 
   return `import { Head, Link, useForm } from '@inertiajs/react'
 import { useId } from 'react'
@@ -415,9 +605,7 @@ export default function Login({ email = '', errors = {} }: Props) {
           </button>
         </form>
 
-        <p className="mt-6 text-center text-sm text-slate-400">
-          Forgot your password? Contact your administrator.
-        </p>${signUpLink}
+${forgotPasswordText}${signUpLink}
       </section>
     </Layout>
   )
@@ -559,6 +747,179 @@ export default function Register({ errors = {} }: Props) {
 }
 `
 
+const forgotPasswordViewTemplate = `import { Head, useForm } from '@inertiajs/react'
+import { useId } from 'react'
+import Layout from '../../components/Layout.js'
+import type { ValidationErrors } from '@guren/core'
+
+interface Props {
+  errors?: ValidationErrors<'email'>
+  status?: string
+}
+
+type ForgotPasswordFormData = {
+  email: string
+}
+
+export default function ForgotPassword({ errors = {}, status }: Props) {
+  const form = useForm<ForgotPasswordFormData>({ email: '' })
+
+  const emailId = useId()
+
+  return (
+    <Layout>
+      <Head title="Forgot password" />
+      <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-8 shadow-xl shadow-emerald-500/5">
+        <h1 className="text-2xl font-semibold text-emerald-300">Forgot your password?</h1>
+        <p className="mt-2 text-sm text-slate-400">
+          Enter your email and we&apos;ll send you a link to reset your password.
+        </p>
+
+        {status ? (
+          <p className="mt-4 rounded border border-emerald-500/40 bg-emerald-500/10 px-4 py-2 text-sm text-emerald-200">
+            {status}
+          </p>
+        ) : null}
+
+        {errors.message && (
+          <p className="mt-4 rounded border border-rose-500/60 bg-rose-500/10 px-4 py-2 text-sm text-rose-200">
+            {errors.message}
+          </p>
+        )}
+
+        <form
+          className="mt-6 space-y-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            form.post('/forgot-password')
+          }}
+        >
+          <div>
+            <label htmlFor={emailId} className="block text-sm font-medium text-slate-200">
+              Email
+            </label>
+            <input
+              id={emailId}
+              type="email"
+              value={form.data.email}
+              onChange={(event) => form.setData('email', event.target.value)}
+              required
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+            />
+            {errors.email && <p className="mt-1 text-sm text-rose-300">{errors.email}</p>}
+          </div>
+
+          <button
+            type="submit"
+            disabled={form.processing}
+            className="w-full rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+          >
+            Send reset link
+          </button>
+        </form>
+      </section>
+    </Layout>
+  )
+}
+`
+
+const resetPasswordViewTemplate = `import { Head, useForm } from '@inertiajs/react'
+import { useId } from 'react'
+import Layout from '../../components/Layout.js'
+import type { ValidationErrors } from '@guren/core'
+
+interface Props {
+  token: string
+  email: string
+  errors?: ValidationErrors<'token' | 'password' | 'passwordConfirmation'>
+}
+
+type ResetPasswordFormData = {
+  token: string
+  password: string
+  passwordConfirmation: string
+}
+
+export default function ResetPassword({ token, email, errors = {} }: Props) {
+  const form = useForm<ResetPasswordFormData>({
+    token,
+    password: '',
+    passwordConfirmation: '',
+  })
+
+  const passwordId = useId()
+  const passwordConfirmationId = useId()
+
+  return (
+    <Layout>
+      <Head title="Reset password" />
+      <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-8 shadow-xl shadow-emerald-500/5">
+        <h1 className="text-2xl font-semibold text-emerald-300">Reset your password</h1>
+        {email ? (
+          <p className="mt-2 text-sm text-slate-400">
+            Choose a new password for {email}.
+          </p>
+        ) : null}
+
+        {errors.token && (
+          <p className="mt-4 rounded border border-rose-500/60 bg-rose-500/10 px-4 py-2 text-sm text-rose-200">
+            {errors.token}
+          </p>
+        )}
+
+        <form
+          className="mt-6 space-y-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            form.post('/reset-password')
+          }}
+        >
+          <div>
+            <label htmlFor={passwordId} className="block text-sm font-medium text-slate-200">
+              New password
+            </label>
+            <input
+              id={passwordId}
+              type="password"
+              value={form.data.password}
+              onChange={(event) => form.setData('password', event.target.value)}
+              required
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+            />
+            {errors.password && <p className="mt-1 text-sm text-rose-300">{errors.password}</p>}
+          </div>
+
+          <div>
+            <label htmlFor={passwordConfirmationId} className="block text-sm font-medium text-slate-200">
+              Confirm new password
+            </label>
+            <input
+              id={passwordConfirmationId}
+              type="password"
+              value={form.data.passwordConfirmation}
+              onChange={(event) => form.setData('passwordConfirmation', event.target.value)}
+              required
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+            />
+            {errors.passwordConfirmation && (
+              <p className="mt-1 text-sm text-rose-300">{errors.passwordConfirmation}</p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={form.processing}
+            className="w-full rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+          >
+            Reset password
+          </button>
+        </form>
+      </section>
+    </Layout>
+  )
+}
+`
+
 const dashboardViewTemplate = `import Layout from '../../components/Layout.js'
 
 interface Props {
@@ -682,7 +1043,7 @@ export default function ProfileEdit({ profile, status }: Props) {
 }
 `
 
-function buildRoutesTemplate(includeRegister: boolean): string {
+function buildRoutesTemplate(includeRegister: boolean, includeReset: boolean): string {
   const registerImport = includeRegister
     ? `\nimport RegisterController from '../app/Http/Controllers/Auth/RegisterController.js'`
     : ''
@@ -693,8 +1054,20 @@ function buildRoutesTemplate(includeRegister: boolean): string {
 `
     : ''
 
+  const resetImport = includeReset
+    ? `\nimport ForgotPasswordController from '../app/Http/Controllers/Auth/ForgotPasswordController.js'\nimport ResetPasswordController from '../app/Http/Controllers/Auth/ResetPasswordController.js'`
+    : ''
+  const resetRoutes = includeReset
+    ? `
+  router.get('/forgot-password', [ForgotPasswordController, 'show'], requireGuest({ redirectTo: '/dashboard' })).name('forgot-password')
+  router.post('/forgot-password', [ForgotPasswordController, 'store'], requireGuest({ redirectTo: '/dashboard' })).name('forgot-password.store')
+  router.get('/reset-password', [ResetPasswordController, 'show'], requireGuest({ redirectTo: '/dashboard' })).name('reset-password')
+  router.post('/reset-password', [ResetPasswordController, 'store'], requireGuest({ redirectTo: '/dashboard' })).name('reset-password.store')
+`
+    : ''
+
   return `import { Router, requireAuthenticated, requireGuest } from '@guren/core'
-import LoginController from '../app/Http/Controllers/Auth/LoginController.js'${registerImport}
+import LoginController from '../app/Http/Controllers/Auth/LoginController.js'${registerImport}${resetImport}
 import DashboardController from '../app/Http/Controllers/DashboardController.js'
 import ProfileController from '../app/Http/Controllers/ProfileController.js'
 
@@ -702,7 +1075,7 @@ export function registerAuthRoutes(router: Router): void {
   router.get('/login', [LoginController, 'show'], requireGuest({ redirectTo: '/dashboard' })).name('login')
   router.post('/login', [LoginController, 'store'], requireGuest({ redirectTo: '/dashboard' })).name('login.store')
   router.post('/logout', [LoginController, 'destroy'], requireAuthenticated({ redirectTo: '/login' })).name('logout')
-${registerRoutes}
+${registerRoutes}${resetRoutes}
   router.get('/dashboard', [DashboardController, 'index'], requireAuthenticated({ redirectTo: '/login' })).name('dashboard')
   router.get('/profile', [ProfileController, 'edit'], requireAuthenticated({ redirectTo: '/login' })).name('profile.edit')
   router.put('/profile', [ProfileController, 'update'], requireAuthenticated({ redirectTo: '/login' })).name('profile.update')
@@ -849,7 +1222,7 @@ export interface MakeAuthOptions extends WriterOptions {
 }
 
 export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]> {
-  const includeRegister = !options.minimal
+  const includeExtras = !options.minimal
 
   const files = [
     { path: 'app/Http/Controllers/Auth/LoginController.ts', contents: loginControllerTemplate },
@@ -860,18 +1233,28 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
     { path: 'app/Http/Validators/LoginValidator.ts', contents: loginValidatorTemplate },
     { path: 'app/Http/Validators/ProfileValidator.ts', contents: profileValidatorTemplate },
     { path: 'resources/js/components/Layout.tsx', contents: layoutTemplate },
-    { path: 'resources/js/pages/auth/Login.tsx', contents: buildLoginViewTemplate(includeRegister) },
+    { path: 'resources/js/pages/auth/Login.tsx', contents: buildLoginViewTemplate(includeExtras, includeExtras) },
     { path: 'resources/js/pages/dashboard/Index.tsx', contents: dashboardViewTemplate },
     { path: 'resources/js/pages/profile/Edit.tsx', contents: profileViewTemplate },
-    { path: 'routes/auth.ts', contents: buildRoutesTemplate(includeRegister) },
+    { path: 'routes/auth.ts', contents: buildRoutesTemplate(includeExtras, includeExtras) },
     { path: 'db/seeders/UsersSeeder.ts', contents: seederTemplate },
   ]
 
-  if (includeRegister) {
+  if (includeExtras) {
     files.push(
       { path: 'app/Http/Controllers/Auth/RegisterController.ts', contents: registerControllerTemplate },
       { path: 'app/Http/Validators/RegisterValidator.ts', contents: registerValidatorTemplate },
       { path: 'resources/js/pages/auth/Register.tsx', contents: registerViewTemplate },
+      { path: 'app/Http/Controllers/Auth/ForgotPasswordController.ts', contents: forgotPasswordControllerTemplate },
+      { path: 'app/Http/Controllers/Auth/ResetPasswordController.ts', contents: resetPasswordControllerTemplate },
+      { path: 'app/Http/Validators/ForgotPasswordValidator.ts', contents: forgotPasswordValidatorTemplate },
+      { path: 'app/Http/Validators/ResetPasswordValidator.ts', contents: resetPasswordValidatorTemplate },
+      { path: 'resources/js/pages/auth/ForgotPassword.tsx', contents: forgotPasswordViewTemplate },
+      { path: 'resources/js/pages/auth/ResetPassword.tsx', contents: resetPasswordViewTemplate },
+      { path: 'app/Auth/PasswordResetStore.ts', contents: passwordResetStoreTemplate },
+      { path: 'app/Mail/PasswordResetMail.ts', contents: passwordResetMailTemplate },
+      { path: 'app/Providers/MailProvider.ts', contents: mailProviderTemplate },
+      { path: 'config/mail.ts', contents: mailConfigTemplate },
     )
   }
 
@@ -882,12 +1265,15 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
   const migrationGenerated = await generateUsersMigration()
 
   if (options.install) {
-    await installAuth(migrationGenerated)
+    await installAuth(migrationGenerated, includeExtras)
   } else {
     consola.info('Next steps:')
     consola.info('  • Register AuthProvider in src/app.ts providers array')
     consola.info('  • Enable sessions and CSRF by adding `auth: {}` to your createApp() options')
     consola.info('  • Import registerAuthRoutes from routes/auth.ts and call it from your routes/web.ts registrar')
+    if (includeExtras) {
+      consola.info('  • Register MailProvider in src/app.ts providers array (used to send password reset emails)')
+    }
     if (!migrationGenerated) {
       consola.info('  • Run `bun run db:make` to generate the users migration')
     }
@@ -898,7 +1284,32 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
   return created
 }
 
-async function installAuth(migrationGenerated = true): Promise<void> {
+async function wireProvider(appPath: string, providerName: string, providerRelativePath: string): Promise<void> {
+  const importPath = (() => {
+    const base = dirname(appPath)
+    const rel = relative(base, providerRelativePath) || providerRelativePath
+    const normalized = rel.split(pathSep).join('/').replace(/^\.$/, providerRelativePath)
+    return normalized.startsWith('.') ? normalized : `./${normalized}`
+  })()
+
+  const importResult = await addImport(appPath, `import ${providerName} from '${importPath}'`)
+  if (importResult.modified) {
+    consola.success(`Added ${providerName} import to ${appPath}`)
+  } else if (importResult.reason === 'Import already exists') {
+    consola.info(`${providerName} import already exists in ${appPath}`)
+  }
+
+  const providerResult = await addProvider(appPath, providerName)
+  if (providerResult.modified) {
+    consola.success(`Added ${providerName} to providers array in ${appPath}`)
+  } else if (providerResult.reason === 'Provider already registered') {
+    consola.info(`${providerName} already registered in ${appPath}`)
+  } else {
+    consola.warn(`Could not add ${providerName}: ${providerResult.reason}`)
+  }
+}
+
+async function installAuth(migrationGenerated = true, includeExtras = true): Promise<void> {
   consola.info('Installing authentication configuration...')
 
   // Determine app file location (try src/app.ts first, then app.ts)
@@ -921,30 +1332,10 @@ async function installAuth(migrationGenerated = true): Promise<void> {
     return
   }
 
-  // Add AuthProvider import
-  const authProviderImportPath = (() => {
-    const base = dirname(appPath)
-    const rel = relative(base, 'app/Providers/AuthProvider.js') || 'app/Providers/AuthProvider.js'
-    const normalized = rel.split(pathSep).join('/').replace(/^\.$/, 'app/Providers/AuthProvider.js')
-    return normalized.startsWith('.') ? normalized : `./${normalized}`
-  })()
-  const authProviderImport = `import AuthProvider from '${authProviderImportPath}'`
+  await wireProvider(appPath, 'AuthProvider', 'app/Providers/AuthProvider.js')
 
-  const authImportResult = await addImport(appPath, authProviderImport)
-  if (authImportResult.modified) {
-    consola.success(`Added AuthProvider import to ${appPath}`)
-  } else if (authImportResult.reason === 'Import already exists') {
-    consola.info(`AuthProvider import already exists in ${appPath}`)
-  }
-
-  // Add AuthProvider to providers array
-  const providerResult = await addProvider(appPath, 'AuthProvider')
-  if (providerResult.modified) {
-    consola.success(`Added AuthProvider to providers array in ${appPath}`)
-  } else if (providerResult.reason === 'Provider already registered') {
-    consola.info(`AuthProvider already registered in ${appPath}`)
-  } else {
-    consola.warn(`Could not add AuthProvider: ${providerResult.reason}`)
+  if (includeExtras) {
+    await wireProvider(appPath, 'MailProvider', 'app/Providers/MailProvider.js')
   }
 
   // Enable session + CSRF middleware: AuthServiceProvider is only registered

--- a/packages/cli/src/patch-helpers.ts
+++ b/packages/cli/src/patch-helpers.ts
@@ -37,11 +37,27 @@ export async function addImport(
   const lines = content.split('\n')
   let insertIndex = 0
   let lastImportIndex = -1
+  let inMultilineImport = false
+  // Matches the line that closes an import statement, e.g. `} from '@guren/core'`,
+  // `import { x } from 'y';`, or a bare side-effect import `import '../config/x.js'`.
+  const importCloses = /(^import\s+['"][^'"]*['"]|from\s+['"][^'"]*['"])\s*;?\s*$/
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i].trim()
-    if (line.startsWith('import ')) {
+
+    if (inMultilineImport) {
       lastImportIndex = i
+      if (importCloses.test(line)) {
+        inMultilineImport = false
+      }
+      continue
+    }
+
+    if (line.startsWith('import ') || line.startsWith("import'") || line.startsWith('import"')) {
+      lastImportIndex = i
+      if (!importCloses.test(line)) {
+        inMultilineImport = true
+      }
     } else if (lastImportIndex >= 0 && line.length > 0 && !line.startsWith('//')) {
       break
     }

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -55,7 +55,7 @@ export function registerWebRoutes(router: Router): void {
 
       const created = await makeAuth({ install: true, force: true })
 
-      expect(created).toHaveLength(16)
+      expect(created).toHaveLength(26)
       expect(created).toEqual(expect.arrayContaining([
         expect.stringContaining('LoginController.ts'),
         expect.stringContaining('routes/auth.ts'),
@@ -64,6 +64,16 @@ export function registerWebRoutes(router: Router): void {
         expect.stringContaining('RegisterController.ts'),
         expect.stringContaining('RegisterValidator.ts'),
         expect.stringContaining('Register.tsx'),
+        expect.stringContaining('ForgotPasswordController.ts'),
+        expect.stringContaining('ResetPasswordController.ts'),
+        expect.stringContaining('ForgotPasswordValidator.ts'),
+        expect.stringContaining('ResetPasswordValidator.ts'),
+        expect.stringContaining('ForgotPassword.tsx'),
+        expect.stringContaining('ResetPassword.tsx'),
+        expect.stringContaining('PasswordResetStore.ts'),
+        expect.stringContaining('PasswordResetMail.ts'),
+        expect.stringContaining('MailProvider.ts'),
+        expect.stringContaining('config/mail.ts'),
       ]))
 
       const schema = await readFile(join(workspace.dir, 'db/schema.ts'), 'utf8')
@@ -71,7 +81,8 @@ export function registerWebRoutes(router: Router): void {
 
       const appContent = await readFile(join(workspace.dir, 'src/app.ts'), 'utf8')
       expect(appContent).toContain('AuthProvider')
-      expect(appContent).toContain('providers: [DatabaseProvider, AuthProvider]')
+      expect(appContent).toContain('MailProvider')
+      expect(appContent).toContain('providers: [DatabaseProvider, AuthProvider, MailProvider]')
       expect(appContent).toContain('auth: {}')
 
       const routesContent = await readFile(join(workspace.dir, 'routes/web.ts'), 'utf8')
@@ -82,10 +93,16 @@ export function registerWebRoutes(router: Router): void {
       expect(authRoutes).toContain("import RegisterController from '../app/Http/Controllers/Auth/RegisterController.js'")
       expect(authRoutes).toContain("router.get('/register'")
       expect(authRoutes).toContain("router.post('/register'")
+      expect(authRoutes).toContain("router.get('/forgot-password'")
+      expect(authRoutes).toContain("router.post('/forgot-password'")
+      expect(authRoutes).toContain("router.get('/reset-password'")
+      expect(authRoutes).toContain("router.post('/reset-password'")
 
       const loginPage = await readFile(join(workspace.dir, 'resources/js/pages/auth/Login.tsx'), 'utf8')
       expect(loginPage).toContain('interface Props')
       expect(loginPage).toContain('href="/register"')
+      expect(loginPage).toContain('href="/forgot-password"')
+      expect(loginPage).not.toContain('Contact your administrator.')
 
       const loginController = await readFile(join(workspace.dir, 'app/Http/Controllers/Auth/LoginController.ts'), 'utf8')
       expect(loginController).toContain('validateBody(LoginSchema)')
@@ -110,6 +127,28 @@ export function registerWebRoutes(router: Router): void {
       const registerPage = await readFile(join(workspace.dir, 'resources/js/pages/auth/Register.tsx'), 'utf8')
       expect(registerPage).toContain('interface Props')
       expect(registerPage).toContain("form.post('/register')")
+
+      const forgotController = await readFile(
+        join(workspace.dir, 'app/Http/Controllers/Auth/ForgotPasswordController.ts'),
+        'utf8',
+      )
+      expect(forgotController).toContain('validateBody(ForgotPasswordSchema)')
+      expect(forgotController).toContain('createPasswordResetToken(')
+      expect(forgotController).toContain('sendPasswordResetMail(')
+
+      const resetController = await readFile(
+        join(workspace.dir, 'app/Http/Controllers/Auth/ResetPasswordController.ts'),
+        'utf8',
+      )
+      expect(resetController).toContain('validateBody(ResetPasswordSchema)')
+      expect(resetController).toContain('verifyPasswordResetToken(')
+      expect(resetController).toContain('User.update(')
+
+      const mailConfig = await readFile(join(workspace.dir, 'config/mail.ts'), 'utf8')
+      expect(mailConfig).toContain("process.env.MAIL_DRIVER ?? 'log'")
+
+      const mailProvider = await readFile(join(workspace.dir, 'app/Providers/MailProvider.ts'), 'utf8')
+      expect(mailProvider).toContain("this.container.singleton('mail'")
     } finally {
       await workspace.cleanup()
     }
@@ -128,14 +167,23 @@ export function registerWebRoutes(router: Router): void {
         expect.stringContaining('RegisterController.ts'),
         expect.stringContaining('RegisterValidator.ts'),
         expect.stringContaining('Register.tsx'),
+        expect.stringContaining('ForgotPasswordController.ts'),
+        expect.stringContaining('ResetPasswordController.ts'),
+        expect.stringContaining('PasswordResetStore.ts'),
+        expect.stringContaining('MailProvider.ts'),
+        expect.stringContaining('config/mail.ts'),
       ]))
 
       const authRoutes = await readFile(join(workspace.dir, 'routes/auth.ts'), 'utf8')
       expect(authRoutes).not.toContain('RegisterController')
+      expect(authRoutes).not.toContain('ForgotPasswordController')
       expect(authRoutes).not.toContain("router.get('/register'")
+      expect(authRoutes).not.toContain("router.get('/forgot-password'")
 
       const loginPage = await readFile(join(workspace.dir, 'resources/js/pages/auth/Login.tsx'), 'utf8')
       expect(loginPage).not.toContain('href="/register"')
+      expect(loginPage).not.toContain('href="/forgot-password"')
+      expect(loginPage).toContain('Contact your administrator.')
     } finally {
       await workspace.cleanup()
     }

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -82,7 +82,13 @@ export function registerWebRoutes(router: Router): void {
       const appContent = await readFile(join(workspace.dir, 'src/app.ts'), 'utf8')
       expect(appContent).toContain('AuthProvider')
       expect(appContent).toContain('MailProvider')
-      expect(appContent).toContain('providers: [DatabaseProvider, AuthProvider, MailProvider]')
+      // CoreMailServiceProvider must be wired before our own MailProvider so
+      // that container.singleton('mail', ...) resolves to our configured
+      // manager instead of Core's empty-config default — matching the same
+      // Core-then-app convention `guren add mail` uses, so the two stay
+      // compatible if a user layers both onto the same app.
+      expect(appContent).toContain("import { MailServiceProvider as CoreMailServiceProvider } from '@guren/core'")
+      expect(appContent).toContain('providers: [DatabaseProvider, AuthProvider, CoreMailServiceProvider, MailProvider]')
       expect(appContent).toContain('auth: {}')
 
       const routesContent = await readFile(join(workspace.dir, 'routes/web.ts'), 'utf8')

--- a/packages/cli/tests/patch-helpers.test.ts
+++ b/packages/cli/tests/patch-helpers.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'bun:test'
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { createTempWorkspace } from './helpers'
+import { addImport } from '../src/patch-helpers'
+
+describe('addImport', () => {
+  it('inserts after a single-line leading import', async () => {
+    const workspace = await createTempWorkspace('guren-cli-add-import-')
+    try {
+      const target = join(workspace.dir, 'app.ts')
+      await writeFile(
+        target,
+        `import { createApp } from '@guren/core'
+import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
+
+const app = createApp({})
+`,
+        'utf8',
+      )
+
+      const result = await addImport('app.ts', "import MailProvider from '../app/Providers/MailProvider.js'")
+      expect(result.modified).toBe(true)
+
+      const content = await readFile(target, 'utf8')
+      expect(content).toContain(
+        "import DatabaseProvider from '../app/Providers/DatabaseProvider.js'\nimport MailProvider from '../app/Providers/MailProvider.js'\n\nconst app",
+      )
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('does not insert inside a multi-line leading import', async () => {
+    const workspace = await createTempWorkspace('guren-cli-add-import-multiline-')
+    try {
+      const target = join(workspace.dir, 'app.ts')
+      await writeFile(
+        target,
+        `import {
+  createApp,
+  ErrorServiceProvider,
+  InertiaServiceProvider,
+} from '@guren/core'
+import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
+import AuthProvider from '../app/Providers/AuthProvider.js'
+
+const app = createApp({})
+`,
+        'utf8',
+      )
+
+      const result = await addImport('app.ts', "import MailProvider from '../app/Providers/MailProvider.js'")
+      expect(result.modified).toBe(true)
+
+      const content = await readFile(target, 'utf8')
+
+      // The multi-line import block must stay intact.
+      expect(content).toContain(`import {
+  createApp,
+  ErrorServiceProvider,
+  InertiaServiceProvider,
+} from '@guren/core'`)
+
+      // The new import lands after the last import, not inside the block.
+      expect(content).toContain(
+        "import AuthProvider from '../app/Providers/AuthProvider.js'\nimport MailProvider from '../app/Providers/MailProvider.js'\n\nconst app",
+      )
+
+      // Sanity check: every line inside the multi-line block is still
+      // valid — no import statement got spliced between `{` and `}`.
+      const lines = content.split('\n')
+      const openIndex = lines.indexOf('import {')
+      const closeIndex = lines.findIndex((line) => line.startsWith('} from'))
+      for (let i = openIndex + 1; i < closeIndex; i++) {
+        expect(lines[i].trim().startsWith('import ')).toBe(false)
+      }
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('inserts after a trailing multi-line import that is not first', async () => {
+    const workspace = await createTempWorkspace('guren-cli-add-import-trailing-multiline-')
+    try {
+      const target = join(workspace.dir, 'app.ts')
+      await writeFile(
+        target,
+        `import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
+import {
+  createApp,
+  ErrorServiceProvider,
+} from '@guren/core'
+
+const app = createApp({})
+`,
+        'utf8',
+      )
+
+      const result = await addImport('app.ts', "import MailProvider from '../app/Providers/MailProvider.js'")
+      expect(result.modified).toBe(true)
+
+      const content = await readFile(target, 'utf8')
+      expect(content).toContain(`} from '@guren/core'\nimport MailProvider from '../app/Providers/MailProvider.js'\n\nconst app`)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('treats a side-effect import as a complete single line', async () => {
+    const workspace = await createTempWorkspace('guren-cli-add-import-side-effect-')
+    try {
+      const target = join(workspace.dir, 'app.ts')
+      await writeFile(
+        target,
+        `import '../config/inertia.js'
+
+const app = {}
+`,
+        'utf8',
+      )
+
+      const result = await addImport('app.ts', "import MailProvider from '../app/Providers/MailProvider.js'")
+      expect(result.modified).toBe(true)
+
+      const content = await readFile(target, 'utf8')
+      expect(content).toContain("import '../config/inertia.js'\nimport MailProvider from '../app/Providers/MailProvider.js'\n\nconst app")
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('is a no-op when the import already exists', async () => {
+    const workspace = await createTempWorkspace('guren-cli-add-import-existing-')
+    try {
+      const target = join(workspace.dir, 'app.ts')
+      await writeFile(target, "import AuthProvider from '../app/Providers/AuthProvider.js'\n", 'utf8')
+
+      const result = await addImport('app.ts', "import AuthProvider from '../app/Providers/AuthProvider.js'")
+      expect(result.modified).toBe(false)
+      expect(result.reason).toBe('Import already exists')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})

--- a/scripts/smoke-golden-path.sh
+++ b/scripts/smoke-golden-path.sh
@@ -209,7 +209,10 @@ step 10 "Add infrastructure add-on (queue)"
 # ---------------------------------------------------------------------------
 step 11 "Add infrastructure add-on (mail)"
 
-(cd "$APP_DIR" && bun "$CLI_BIN" add mail)
+# --force: `add auth` (step above) already scaffolds app/Providers/MailProvider.ts
+# for password reset — the mail blueprint's own, more complete MailProvider
+# (memory transport, setMailManager wiring) intentionally supersedes it.
+(cd "$APP_DIR" && bun "$CLI_BIN" add mail --force)
 
 # ---------------------------------------------------------------------------
 # Step 12: Add infrastructure add-on — events

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -454,7 +454,12 @@ async function main(): Promise<void> {
       await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'auth'], appDir, runtimeEnv)
       await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'resource', 'posts'], appDir, runtimeEnv)
       await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'queue'], appDir, runtimeEnv)
-      await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'mail'], appDir, runtimeEnv)
+      // --force: `add auth` now also scaffolds app/Providers/MailProvider.ts
+      // (password reset needs a mail manager) — the mail blueprint's own,
+      // more complete MailProvider (memory transport, setMailManager wiring)
+      // intentionally supersedes it here so the assertions below can verify
+      // its shape.
+      await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'mail', '--force'], appDir, runtimeEnv)
       await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'events'], appDir, runtimeEnv)
       await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'cache'], appDir, runtimeEnv)
       await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'notifications'], appDir, runtimeEnv)


### PR DESCRIPTION
Stacked on #141 — base branch is `feat/make-auth-register`, not `main`. Diff will shrink once that merges.

## Summary
- Adds `ForgotPasswordController` / `ResetPasswordController` to `make:auth`, built on the framework's `createPasswordResetToken`/`verifyPasswordResetToken` primitives
- Adds `config/mail.ts` (defaults to the `log` driver — reset links print to the console with zero setup in dev) and `app/Providers/MailProvider.ts`
- Adds an in-memory `app/Auth/PasswordResetStore.ts` (documented as swappable for a Redis-backed store in production/multi-instance deployments) and `app/Mail/PasswordResetMail.ts`
- Wires `/forgot-password` and `/reset-password` (`GET`/`POST`) into `routes/auth.ts`, linked from the login page
- Bundled under the same `--minimal` flag as registration (both are part of the default "full" experience)
- **Fix**: `addImport()` (used by `--install` to wire providers into `src/app.ts`) corrupted files whose leading import statement spans multiple lines — it spliced the new import between `{` and the first member instead of after the closing `}`. Found while verifying this PR's `MailProvider` wiring against `examples/blog`'s multi-line `@guren/core` import. Fixed with a dedicated test file (`patch-helpers.test.ts`).

## Test plan
- [x] `bun test packages/cli/tests/make-auth.test.ts` and `packages/cli/tests/patch-helpers.test.ts`
- [x] `bun run build:clean`
- [x] `bun run typecheck`
- [x] `bun run test:bun` (2275 pass)
- [x] `bun run test:examples`
- [x] `bun run audit:core-first`
- [x] `bun run audit:docs`
- [x] Regenerated into `examples/blog` (`--force --install` + `codegen` + `tsc`) to compile all new templates as real TS/TSX against real types and verify the `--install` provider wiring end-to-end, then discarded the changes (examples/blog itself is untouched — full adoption is a later PR)