### PR TITLE
feat(cli): add email verification to make:auth --verify

### DIFF
--- a/.changeset/make-auth-email-verification.md
+++ b/.changeset/make-auth-email-verification.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': minor
+---
+
+`guren make:auth --verify` now scaffolds an email verification flow (`VerifyEmailController`, a `VerifyEmail` page, an `emailVerifiedAt` users column, and an in-memory `EmailVerificationStore`). Registration sends a verification email and redirects to `/verify-email` instead of `/dashboard`, and the generated `/dashboard` route is guarded with `requireVerifiedEmail`. Also fixes `updateSchema()` corrupting a `users` table defined with Drizzle's three-argument form (e.g. `pgTable('users', {...}, (table) => [...])`) by inserting the new column next to the `rememberToken` field instead of attempting a whole-block replace.

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -45,6 +45,16 @@ bunx guren make:auth --install --minimal
 
 Clicking "Forgot your password?" on the login page walks through `ForgotPasswordController` and `ResetPasswordController`, which use the framework's `createPasswordResetToken` / `verifyPasswordResetToken` primitives under the hood. The reset token is stored with the generated `app/Auth/PasswordResetStore.ts` (an in-memory store — swap it for a Redis-backed store in production or any multi-instance deployment) and emailed via the generated `config/mail.ts`, which defaults to the `log` driver: reset links print straight to the console, so the flow works with zero setup in development. Set `MAIL_DRIVER=smtp` (and the `SMTP_*` environment variables) once you're ready to send real email.
 
+### Email verification
+
+Pass `--verify` to also scaffold an email verification flow:
+
+```bash
+bunx guren make:auth --install --verify
+```
+
+This adds an `emailVerifiedAt` column to the `users` table, a `VerifyEmailController` (shows a "check your email" notice, resends the verification link, and confirms the token), and a `VerifyEmail` page. Registering now sends a verification email and redirects to `/verify-email` instead of `/dashboard`, and the generated `/dashboard` route is guarded with `requireVerifiedEmail` — unverified users are redirected back to `/verify-email` until they confirm. Verification links use the same in-memory store and `log`-driver mail setup as password reset, so this also works with zero setup in development. `--verify` requires the default (non-minimal) experience, since it builds on the registration flow.
+
 ## OAuth / Social login
 
 Wave 4 adds first-party OAuth primitives plus provider presets for GitHub / Google / Discord.

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -58,7 +58,7 @@ These commands patch `src/app.ts`, create the matching provider/runtime files, a
 | `make:controller <Name>` | Generates a controller in `app/Http/Controllers` | `bunx guren make:controller PostController` |
 | `make:model <Name>` | Generates a minimal model class and type definition in `app/Models` (imports `camelCase(Name)s` from `db/schema`) | `bunx guren make:model Post` |
 | `make:view <path>` | Generates a React component in `resources/js/pages` | `bunx guren make:view posts/Index` |
-| `make:auth` | Scaffolds login/logout, registration, and password reset controllers, providers, views, migration, seeder, and routes (`--minimal` skips registration and password reset) | `bunx guren make:auth` |
+| `make:auth` | Scaffolds login/logout, registration, and password reset controllers, providers, views, migration, seeder, and routes (`--minimal` skips registration and password reset, `--verify` also scaffolds email verification) | `bunx guren make:auth` |
 | `make:middleware <Name>` | Generates a middleware file in `app/Http/Middleware` | `bunx guren make:middleware Auth` |
 | `make:policy <Name>` | Generates an authorization policy in `app/Policies` with owner-based defaults | `bunx guren make:policy Post` |
 | `make:seeder <Name>` | Generates a database seeder file | `bunx guren make:seeder UserSeeder` |

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -45,6 +45,16 @@ bunx guren make:auth --install --minimal
 
 ログインページの「Forgot your password?」から `ForgotPasswordController` と `ResetPasswordController` によるフローに入ります。内部ではフレームワークの `createPasswordResetToken` / `verifyPasswordResetToken` を使用しています。リセットトークンは生成される `app/Auth/PasswordResetStore.ts`（インメモリストア。本番や複数インスタンス構成では Redis ベースのストアに差し替えてください）に保存され、生成される `config/mail.ts` 経由でメール送信されます。`config/mail.ts` はデフォルトで `log` ドライバを使うため、リセットリンクはコンソールにそのまま出力され、開発環境では設定なしで動作確認できます。実際にメールを送るには `MAIL_DRIVER=smtp`（および `SMTP_*` の環境変数）を設定してください。
 
+### メール確認
+
+`--verify` を付けるとメール確認フローも一緒にスキャフォールドします。
+
+```bash
+bunx guren make:auth --install --verify
+```
+
+`users` テーブルに `emailVerifiedAt` カラムが追加され、`VerifyEmailController`（「メールを確認してください」の通知表示・再送・トークン確認を担当）と `VerifyEmail` ページが生成されます。登録時に確認メールが送信され、`/dashboard` の代わりに `/verify-email` へリダイレクトされるようになります。また生成される `/dashboard` ルートには `requireVerifiedEmail` が適用され、未確認のユーザーは確認が完了するまで `/verify-email` に戻されます。確認リンクもパスワードリセットと同じインメモリストア・`log` ドライバのメール設定を使うため、開発環境では設定なしで動作確認できます。`--verify` は登録フローの上に構築されるため、デフォルト（非 `--minimal`）の構成が前提です。
+
 ## OAuth / ソーシャルログイン
 
 Wave 4 で、GitHub / Google / Discord 向けの OAuth プリセットを追加しました。

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -56,7 +56,7 @@ bunx guren plugin @acme/guren-plugin-audit
 | `make:controller <Name>` | `app/Http/Controllers` にコントローラーを生成 | `bunx guren make:controller PostController` |
 | `make:model <Name>` | 最小のモデルクラスと型定義を `app/Models` に生成（`db/schema` から `camelCase(Name)s` を import） | `bunx guren make:model Post` |
 | `make:view <path>` | `resources/js/pages` に React コンポーネントを生成 | `bunx guren make:view posts/Index` |
-| `make:auth` | ログイン/ログアウト・新規登録・パスワードリセットのコントローラー、プロバイダー、ビュー、マイグレーション、シーダー、ルートをスキャフォールド（`--minimal` で登録・パスワードリセットを省略） | `bunx guren make:auth` |
+| `make:auth` | ログイン/ログアウト・新規登録・パスワードリセットのコントローラー、プロバイダー、ビュー、マイグレーション、シーダー、ルートをスキャフォールド（`--minimal` で登録・パスワードリセットを省略、`--verify` でメール確認も追加） | `bunx guren make:auth` |
 | `make:middleware <Name>` | `app/Http/Middleware` にミドルウェアを生成 | `bunx guren make:middleware Auth` |
 | `make:seeder <Name>` | データベースシーダーファイルを生成 | `bunx guren make:seeder UserSeeder` |
 | `make:job <Name>` | キュー可能なジョブクラスを生成 | `bunx guren make:job SendEmail` |

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -231,7 +231,11 @@ const makeAuthCommand = defineCommand({
     },
     minimal: {
       type: 'boolean',
-      description: 'Skip registration scaffolding and generate the login-only experience',
+      description: 'Skip registration and password reset scaffolding and generate the login-only experience',
+    },
+    verify: {
+      type: 'boolean',
+      description: 'Also scaffold email verification (requires the default, non-minimal experience)',
     },
   },
   async run({ args }) {
@@ -239,6 +243,7 @@ const makeAuthCommand = defineCommand({
       ...toWriterOptions(args),
       install: Boolean(args.install),
       minimal: Boolean(args.minimal),
+      verify: Boolean(args.verify),
     })
     for (const file of files) {
       consola.success(`Created ${file}`)

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -44,9 +44,30 @@ export default class LoginController extends Controller {
 }
 `
 
-const registerControllerTemplate = `import { Controller, ValidationException } from '@guren/core'
+function buildRegisterControllerTemplate(includeVerify: boolean): string {
+  const coreImports = includeVerify
+    ? 'Controller, ValidationException, createEmailVerificationToken, buildVerificationUrl'
+    : 'Controller, ValidationException'
+
+  const verifyImports = includeVerify
+    ? `
+import { emailVerificationStore } from '../../../Auth/EmailVerificationStore.js'
+import { sendEmailVerificationMail } from '../../../Mail/EmailVerificationMail.js'`
+    : ''
+
+  const sendVerification = includeVerify
+    ? `
+    const { token } = await createEmailVerificationToken(user.email, emailVerificationStore)
+    const verifyUrl = buildVerificationUrl(\`\${new URL(this.request.url).origin}/verify-email/confirm\`, token, user.email)
+    await sendEmailVerificationMail(this.make('mail'), user.email, verifyUrl)
+`
+    : ''
+
+  const redirectPath = includeVerify ? '/verify-email' : '/dashboard'
+
+  return `import { ${coreImports} } from '@guren/core'
 import { RegisterSchema } from '../../Validators/RegisterValidator.js'
-import { User } from '../../../Models/User.js'
+import { User } from '../../../Models/User.js'${verifyImports}
 import { pages } from '@/.guren/pages.gen'
 
 export default class RegisterController extends Controller {
@@ -65,14 +86,15 @@ export default class RegisterController extends Controller {
     // AuthenticatableModel hashes the virtual \`password\` field into
     // \`passwordHash\` before persisting — see app/Models/User.ts.
     const user = await User.create({ name, email, password })
-
+${sendVerification}
     this.auth.session()?.regenerate()
     await this.auth.login(user)
 
-    return this.redirect('/dashboard')
+    return this.redirect('${redirectPath}')
   }
 }
 `
+}
 
 const forgotPasswordControllerTemplate = `import { Controller, createPasswordResetToken, buildPasswordResetUrl } from '@guren/core'
 import { ForgotPasswordSchema } from '../../Validators/ForgotPasswordValidator.js'
@@ -145,6 +167,58 @@ export default class ResetPasswordController extends Controller {
     await passwordResetStore.deleteForEmail(email)
 
     return this.redirect('/login')
+  }
+}
+`
+
+const verifyEmailControllerTemplate = `import { Controller, createEmailVerificationToken, completeEmailVerification, buildVerificationUrl } from '@guren/core'
+import { User, type UserRecord } from '../../../Models/User.js'
+import { emailVerificationStore } from '../../../Auth/EmailVerificationStore.js'
+import { sendEmailVerificationMail } from '../../../Mail/EmailVerificationMail.js'
+import { pages } from '@/.guren/pages.gen'
+
+const EXPIRED_MESSAGE = 'This verification link is invalid or has expired. Request a new one below.'
+
+export default class VerifyEmailController extends Controller {
+  async notice(): Promise<Response> {
+    const user = await this.auth.userOrFail<UserRecord>()
+    if (user.emailVerifiedAt) {
+      return this.redirect('/dashboard')
+    }
+
+    return this.inertia(pages.auth.VerifyEmail, {}, { url: this.request.path, title: 'Verify email' })
+  }
+
+  async resend(): Promise<Response> {
+    const user = await this.auth.userOrFail<UserRecord>()
+
+    if (!user.emailVerifiedAt) {
+      const { token } = await createEmailVerificationToken(user.email, emailVerificationStore)
+      const verifyUrl = buildVerificationUrl(\`\${new URL(this.request.url).origin}/verify-email/confirm\`, token, user.email)
+      await sendEmailVerificationMail(this.make('mail'), user.email, verifyUrl)
+    }
+
+    return this.inertia(pages.auth.VerifyEmail, {
+      status: 'A new verification link has been sent to your email address.',
+    }, { url: this.request.path, title: 'Verify email' })
+  }
+
+  async confirm(): Promise<Response> {
+    const token = this.request.query('token') ?? ''
+
+    const verifiedEmail = await completeEmailVerification(token, emailVerificationStore, async (email) => {
+      await User.update({ email }, { emailVerifiedAt: new Date() })
+      return email
+    })
+
+    if (!verifiedEmail) {
+      return this.inertia(pages.auth.VerifyEmail, { status: EXPIRED_MESSAGE }, {
+        url: this.request.path,
+        title: 'Verify email',
+      })
+    }
+
+    return this.redirect('/dashboard')
   }
 }
 `
@@ -319,6 +393,39 @@ Click the link below to choose a new password. This link expires in 1 hour.
 \${resetUrl}
 
 If you didn't request this, you can safely ignore this email.
+    \`)
+    .send()
+}
+`
+
+const emailVerificationStoreTemplate = `import { MemoryEmailVerificationStore } from '@guren/core'
+
+// Swap for a Redis-backed store (see @guren/server/redis) in production
+// or any multi-instance deployment — this in-memory store does not
+// survive restarts and is not shared across processes.
+export const emailVerificationStore = new MemoryEmailVerificationStore()
+`
+
+const emailVerificationMailTemplate = `import { mail, type MailManager } from '@guren/core'
+
+export async function sendEmailVerificationMail(manager: MailManager, email: string, verifyUrl: string): Promise<void> {
+  await mail(manager)
+    .to(email)
+    .subject('Verify your email address')
+    .html(\`
+      <h1>Verify your email address</h1>
+      <p>Click the link below to verify your email address.</p>
+      <p><a href="\${verifyUrl}">\${verifyUrl}</a></p>
+      <p>If you didn't create an account, you can safely ignore this email.</p>
+    \`)
+    .text(\`
+Verify your email address
+
+Click the link below to verify your email address.
+
+\${verifyUrl}
+
+If you didn't create an account, you can safely ignore this email.
     \`)
     .send()
 }
@@ -920,6 +1027,52 @@ export default function ResetPassword({ token, email, errors = {} }: Props) {
 }
 `
 
+const verifyEmailViewTemplate = `import { Head, useForm } from '@inertiajs/react'
+import Layout from '../../components/Layout.js'
+
+interface Props {
+  status?: string
+}
+
+export default function VerifyEmail({ status }: Props) {
+  const form = useForm({})
+
+  return (
+    <Layout>
+      <Head title="Verify email" />
+      <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-8 shadow-xl shadow-emerald-500/5">
+        <h1 className="text-2xl font-semibold text-emerald-300">Verify your email</h1>
+        <p className="mt-2 text-sm text-slate-400">
+          We sent a verification link to your email address. Click it to activate your account.
+        </p>
+
+        {status ? (
+          <p className="mt-4 rounded border border-emerald-500/40 bg-emerald-500/10 px-4 py-2 text-sm text-emerald-200">
+            {status}
+          </p>
+        ) : null}
+
+        <form
+          className="mt-6"
+          onSubmit={(event) => {
+            event.preventDefault()
+            form.post('/verify-email')
+          }}
+        >
+          <button
+            type="submit"
+            disabled={form.processing}
+            className="w-full rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+          >
+            Resend verification email
+          </button>
+        </form>
+      </section>
+    </Layout>
+  )
+}
+`
+
 const dashboardViewTemplate = `import Layout from '../../components/Layout.js'
 
 interface Props {
@@ -1043,7 +1196,7 @@ export default function ProfileEdit({ profile, status }: Props) {
 }
 `
 
-function buildRoutesTemplate(includeRegister: boolean, includeReset: boolean): string {
+function buildRoutesTemplate(includeRegister: boolean, includeReset: boolean, includeVerify: boolean): string {
   const registerImport = includeRegister
     ? `\nimport RegisterController from '../app/Http/Controllers/Auth/RegisterController.js'`
     : ''
@@ -1066,8 +1219,23 @@ function buildRoutesTemplate(includeRegister: boolean, includeReset: boolean): s
 `
     : ''
 
-  return `import { Router, requireAuthenticated, requireGuest } from '@guren/core'
-import LoginController from '../app/Http/Controllers/Auth/LoginController.js'${registerImport}${resetImport}
+  const verifyImport = includeVerify
+    ? `\nimport VerifyEmailController from '../app/Http/Controllers/Auth/VerifyEmailController.js'`
+    : ''
+  const verifyRoutes = includeVerify
+    ? `
+  router.get('/verify-email', [VerifyEmailController, 'notice'], requireAuthenticated({ redirectTo: '/login' })).name('verify-email')
+  router.post('/verify-email', [VerifyEmailController, 'resend'], requireAuthenticated({ redirectTo: '/login' })).name('verify-email.resend')
+  router.get('/verify-email/confirm', [VerifyEmailController, 'confirm'], requireAuthenticated({ redirectTo: '/login' })).name('verify-email.confirm')
+`
+    : ''
+  const requireVerifiedImport = includeVerify ? ', requireVerifiedEmail' : ''
+  const dashboardMiddleware = includeVerify
+    ? `requireAuthenticated({ redirectTo: '/login' }), requireVerifiedEmail({ redirectTo: '/verify-email' })`
+    : `requireAuthenticated({ redirectTo: '/login' })`
+
+  return `import { Router, requireAuthenticated, requireGuest${requireVerifiedImport} } from '@guren/core'
+import LoginController from '../app/Http/Controllers/Auth/LoginController.js'${registerImport}${resetImport}${verifyImport}
 import DashboardController from '../app/Http/Controllers/DashboardController.js'
 import ProfileController from '../app/Http/Controllers/ProfileController.js'
 
@@ -1075,8 +1243,8 @@ export function registerAuthRoutes(router: Router): void {
   router.get('/login', [LoginController, 'show'], requireGuest({ redirectTo: '/dashboard' })).name('login')
   router.post('/login', [LoginController, 'store'], requireGuest({ redirectTo: '/dashboard' })).name('login.store')
   router.post('/logout', [LoginController, 'destroy'], requireAuthenticated({ redirectTo: '/login' })).name('logout')
-${registerRoutes}${resetRoutes}
-  router.get('/dashboard', [DashboardController, 'index'], requireAuthenticated({ redirectTo: '/login' })).name('dashboard')
+${registerRoutes}${resetRoutes}${verifyRoutes}
+  router.get('/dashboard', [DashboardController, 'index'], ${dashboardMiddleware}).name('dashboard')
   router.get('/profile', [ProfileController, 'edit'], requireAuthenticated({ redirectTo: '/login' })).name('profile.edit')
   router.put('/profile', [ProfileController, 'update'], requireAuthenticated({ redirectTo: '/login' })).name('profile.update')
 }
@@ -1148,7 +1316,59 @@ const usersTableBlocks: Record<SchemaDialect, string> = {
 `,
 }
 
-async function updateSchema(): Promise<void> {
+const usersTableBlocksWithVerification: Record<SchemaDialect, string> = {
+  sqlite: `export const users = sqliteTable('users', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  name: text('name').notNull(),
+  email: text('email').notNull().unique(),
+  passwordHash: text('password_hash').notNull(),
+  rememberToken: text('remember_token'),
+  emailVerifiedAt: integer('email_verified_at', { mode: 'timestamp' }),
+  createdAt: text('created_at').notNull().$defaultFn(() => new Date().toISOString()),
+  updatedAt: text('updated_at').notNull().$defaultFn(() => new Date().toISOString()),
+})
+`,
+  pg: `export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  name: text('name').notNull(),
+  email: text('email').notNull().unique(),
+  passwordHash: text('password_hash').notNull(),
+  rememberToken: text('remember_token'),
+  emailVerifiedAt: timestamp('email_verified_at', { withTimezone: false }),
+  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: false }).defaultNow().notNull(),
+})
+`,
+  mysql: `export const users = mysqlTable('users', {
+  id: int('id').primaryKey().autoincrement(),
+  name: varchar('name', { length: 255 }).notNull(),
+  email: varchar('email', { length: 255 }).notNull().unique(),
+  passwordHash: varchar('password_hash', { length: 255 }).notNull(),
+  rememberToken: varchar('remember_token', { length: 255 }),
+  emailVerifiedAt: timestamp('email_verified_at'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+})
+`,
+}
+
+const emailVerifiedAtField: Record<SchemaDialect, string> = {
+  sqlite: `emailVerifiedAt: integer('email_verified_at', { mode: 'timestamp' }),`,
+  pg: `emailVerifiedAt: timestamp('email_verified_at', { withTimezone: false }),`,
+  mysql: `emailVerifiedAt: timestamp('email_verified_at'),`,
+}
+
+function ensureVerifyImports(content: string, dialect: SchemaDialect): string {
+  if (dialect === 'sqlite') {
+    return ensureSqliteImports(content, ['sqliteTable', 'integer', 'text'])
+  }
+  if (dialect === 'mysql') {
+    return ensureMysqlImports(content, ['mysqlTable', 'int', 'varchar', 'timestamp'])
+  }
+  return ensureDrizzleImports(content, ['pgTable', 'serial', 'text', 'timestamp'])
+}
+
+async function updateSchema(includeVerify: boolean): Promise<void> {
   const schemaPath = resolve(process.cwd(), 'db/schema.ts')
   let content: string
 
@@ -1162,26 +1382,48 @@ async function updateSchema(): Promise<void> {
     throw error
   }
 
-  if (content.includes('passwordHash')) {
+  const hasAuthColumns = content.includes('passwordHash')
+  const hasVerificationColumn = content.includes('emailVerifiedAt')
+
+  if (hasAuthColumns && (!includeVerify || hasVerificationColumn)) {
     return
   }
 
-  // Keep the schema in the dialect the app was scaffolded with
   const dialect = detectSchemaDialect(content)
 
-  if (dialect === 'sqlite') {
-    content = ensureSqliteImports(content, ['sqliteTable', 'integer', 'text'])
-  } else if (dialect === 'mysql') {
-    content = ensureMysqlImports(content, ['mysqlTable', 'int', 'varchar', 'timestamp'])
-  } else {
-    content = ensureDrizzleImports(content, ['pgTable', 'serial', 'text', 'timestamp'])
+  if (hasAuthColumns) {
+    // The users table already has auth columns (from an earlier make:auth
+    // run) and may have been customized since — e.g. extra columns or a
+    // trailing index callback (`pgTable('users', {...}, (table) => [...])`).
+    // Rather than risk mangling a table shape we can't fully parse, insert
+    // just the new column next to the rememberToken column we know we
+    // generated, preserving its indentation.
+    const rememberTokenPattern = /^([ \t]*)rememberToken:[^\n]*\n/m
+    const match = content.match(rememberTokenPattern)
+
+    if (!match) {
+      consola.warn(
+        'Could not locate the rememberToken column in db/schema.ts — add `emailVerifiedAt` to your users table manually for email verification.',
+      )
+      return
+    }
+
+    content = ensureVerifyImports(content, dialect)
+    const indent = match[1]
+    content = content.replace(rememberTokenPattern, (line) => `${line}${indent}${emailVerifiedAtField[dialect]}\n`)
+
+    await writeFile(schemaPath, content, 'utf8')
+    consola.info(`Added emailVerifiedAt column to db/schema.ts (${dialect}).`)
+    return
   }
 
-  // Replace an existing users table that lacks auth columns, or append if absent
-  // Use `})` on its own line as the end anchor to avoid premature matching
-  // inside nested function calls like `$defaultFn(() => ...)`
+  content = ensureVerifyImports(content, dialect)
+
+  // Replace an existing users table that lacks auth columns, or append if
+  // absent. Use `})` on its own line as the end anchor to avoid premature
+  // matching inside nested function calls like `$defaultFn(() => ...)`.
   const usersTablePattern = /export const users = (?:pgTable|sqliteTable|mysqlTable)\('users',\s*\{[\s\S]*?\n\}\)\s*\n?/
-  const usersTableBlock = usersTableBlocks[dialect]
+  const usersTableBlock = includeVerify ? usersTableBlocksWithVerification[dialect] : usersTableBlocks[dialect]
 
   if (usersTablePattern.test(content)) {
     content = content.replace(usersTablePattern, usersTableBlock)
@@ -1217,12 +1459,19 @@ async function updatePageContracts(): Promise<void> {
 
 export interface MakeAuthOptions extends WriterOptions {
   install?: boolean
-  /** Skip registration scaffolding and generate the login-only experience. */
+  /** Skip registration and password reset scaffolding and generate the login-only experience. */
   minimal?: boolean
+  /** Also scaffold email verification. Requires the default (non-minimal) experience. */
+  verify?: boolean
 }
 
 export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]> {
   const includeExtras = !options.minimal
+  const includeVerify = includeExtras && Boolean(options.verify)
+
+  if (options.minimal && options.verify) {
+    consola.warn('--verify requires the default (non-minimal) experience — skipping email verification.')
+  }
 
   const files = [
     { path: 'app/Http/Controllers/Auth/LoginController.ts', contents: loginControllerTemplate },
@@ -1236,13 +1485,13 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
     { path: 'resources/js/pages/auth/Login.tsx', contents: buildLoginViewTemplate(includeExtras, includeExtras) },
     { path: 'resources/js/pages/dashboard/Index.tsx', contents: dashboardViewTemplate },
     { path: 'resources/js/pages/profile/Edit.tsx', contents: profileViewTemplate },
-    { path: 'routes/auth.ts', contents: buildRoutesTemplate(includeExtras, includeExtras) },
+    { path: 'routes/auth.ts', contents: buildRoutesTemplate(includeExtras, includeExtras, includeVerify) },
     { path: 'db/seeders/UsersSeeder.ts', contents: seederTemplate },
   ]
 
   if (includeExtras) {
     files.push(
-      { path: 'app/Http/Controllers/Auth/RegisterController.ts', contents: registerControllerTemplate },
+      { path: 'app/Http/Controllers/Auth/RegisterController.ts', contents: buildRegisterControllerTemplate(includeVerify) },
       { path: 'app/Http/Validators/RegisterValidator.ts', contents: registerValidatorTemplate },
       { path: 'resources/js/pages/auth/Register.tsx', contents: registerViewTemplate },
       { path: 'app/Http/Controllers/Auth/ForgotPasswordController.ts', contents: forgotPasswordControllerTemplate },
@@ -1258,9 +1507,18 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
     )
   }
 
+  if (includeVerify) {
+    files.push(
+      { path: 'app/Http/Controllers/Auth/VerifyEmailController.ts', contents: verifyEmailControllerTemplate },
+      { path: 'resources/js/pages/auth/VerifyEmail.tsx', contents: verifyEmailViewTemplate },
+      { path: 'app/Auth/EmailVerificationStore.ts', contents: emailVerificationStoreTemplate },
+      { path: 'app/Mail/EmailVerificationMail.ts', contents: emailVerificationMailTemplate },
+    )
+  }
+
   const created = await writeFilesSafe(files, options)
 
-  await updateSchema()
+  await updateSchema(includeVerify)
   await updatePageContracts()
   const migrationGenerated = await generateUsersMigration()
 

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -1316,49 +1316,13 @@ const usersTableBlocks: Record<SchemaDialect, string> = {
 `,
 }
 
-const usersTableBlocksWithVerification: Record<SchemaDialect, string> = {
-  sqlite: `export const users = sqliteTable('users', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  name: text('name').notNull(),
-  email: text('email').notNull().unique(),
-  passwordHash: text('password_hash').notNull(),
-  rememberToken: text('remember_token'),
-  emailVerifiedAt: integer('email_verified_at', { mode: 'timestamp' }),
-  createdAt: text('created_at').notNull().$defaultFn(() => new Date().toISOString()),
-  updatedAt: text('updated_at').notNull().$defaultFn(() => new Date().toISOString()),
-})
-`,
-  pg: `export const users = pgTable('users', {
-  id: serial('id').primaryKey(),
-  name: text('name').notNull(),
-  email: text('email').notNull().unique(),
-  passwordHash: text('password_hash').notNull(),
-  rememberToken: text('remember_token'),
-  emailVerifiedAt: timestamp('email_verified_at', { withTimezone: false }),
-  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: false }).defaultNow().notNull(),
-})
-`,
-  mysql: `export const users = mysqlTable('users', {
-  id: int('id').primaryKey().autoincrement(),
-  name: varchar('name', { length: 255 }).notNull(),
-  email: varchar('email', { length: 255 }).notNull().unique(),
-  passwordHash: varchar('password_hash', { length: 255 }).notNull(),
-  rememberToken: varchar('remember_token', { length: 255 }),
-  emailVerifiedAt: timestamp('email_verified_at'),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
-  updatedAt: timestamp('updated_at').defaultNow().notNull(),
-})
-`,
-}
-
 const emailVerifiedAtField: Record<SchemaDialect, string> = {
   sqlite: `emailVerifiedAt: integer('email_verified_at', { mode: 'timestamp' }),`,
   pg: `emailVerifiedAt: timestamp('email_verified_at', { withTimezone: false }),`,
   mysql: `emailVerifiedAt: timestamp('email_verified_at'),`,
 }
 
-function ensureVerifyImports(content: string, dialect: SchemaDialect): string {
+function ensureUsersTableImports(content: string, dialect: SchemaDialect): string {
   if (dialect === 'sqlite') {
     return ensureSqliteImports(content, ['sqliteTable', 'integer', 'text'])
   }
@@ -1366,6 +1330,25 @@ function ensureVerifyImports(content: string, dialect: SchemaDialect): string {
     return ensureMysqlImports(content, ['mysqlTable', 'int', 'varchar', 'timestamp'])
   }
   return ensureDrizzleImports(content, ['pgTable', 'serial', 'text', 'timestamp'])
+}
+
+/**
+ * Insert a column definition right after the `rememberToken` column of a
+ * `users` table block, preserving its indentation. Used both to build the
+ * "with verification" variant of a fresh table block and to patch an
+ * existing one — a single source of truth for the splice, instead of
+ * hand-maintaining a second full table-block template per dialect.
+ */
+function insertColumnAfterRememberToken(content: string, fieldLine: string): string | null {
+  const rememberTokenPattern = /^([ \t]*)rememberToken:[^\n]*\n/m
+  let inserted = false
+
+  const updated = content.replace(rememberTokenPattern, (line, indent: string) => {
+    inserted = true
+    return `${line}${indent}${fieldLine}\n`
+  })
+
+  return inserted ? updated : null
 }
 
 async function updateSchema(includeVerify: boolean): Promise<void> {
@@ -1398,32 +1381,31 @@ async function updateSchema(includeVerify: boolean): Promise<void> {
     // Rather than risk mangling a table shape we can't fully parse, insert
     // just the new column next to the rememberToken column we know we
     // generated, preserving its indentation.
-    const rememberTokenPattern = /^([ \t]*)rememberToken:[^\n]*\n/m
-    const match = content.match(rememberTokenPattern)
+    const updated = insertColumnAfterRememberToken(content, emailVerifiedAtField[dialect])
 
-    if (!match) {
+    if (!updated) {
       consola.warn(
         'Could not locate the rememberToken column in db/schema.ts — add `emailVerifiedAt` to your users table manually for email verification.',
       )
       return
     }
 
-    content = ensureVerifyImports(content, dialect)
-    const indent = match[1]
-    content = content.replace(rememberTokenPattern, (line) => `${line}${indent}${emailVerifiedAtField[dialect]}\n`)
+    content = ensureUsersTableImports(updated, dialect)
 
     await writeFile(schemaPath, content, 'utf8')
     consola.info(`Added emailVerifiedAt column to db/schema.ts (${dialect}).`)
     return
   }
 
-  content = ensureVerifyImports(content, dialect)
+  content = ensureUsersTableImports(content, dialect)
 
   // Replace an existing users table that lacks auth columns, or append if
   // absent. Use `})` on its own line as the end anchor to avoid premature
   // matching inside nested function calls like `$defaultFn(() => ...)`.
   const usersTablePattern = /export const users = (?:pgTable|sqliteTable|mysqlTable)\('users',\s*\{[\s\S]*?\n\}\)\s*\n?/
-  const usersTableBlock = includeVerify ? usersTableBlocksWithVerification[dialect] : usersTableBlocks[dialect]
+  const usersTableBlock = includeVerify
+    ? insertColumnAfterRememberToken(usersTableBlocks[dialect], emailVerifiedAtField[dialect])!
+    : usersTableBlocks[dialect]
 
   if (usersTablePattern.test(content)) {
     content = content.replace(usersTablePattern, usersTableBlock)

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -194,4 +194,77 @@ export function registerWebRoutes(router: Router): void {
       await workspace.cleanup()
     }
   })
+
+  it('scaffolds email verification with --verify', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-auth-verify-')
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'db/schema.ts'),
+        `import { pgTable, serial, text } from 'drizzle-orm/pg-core'
+
+export const posts = pgTable('posts', {
+  id: serial('id').primaryKey(),
+  title: text('title').notNull(),
+})
+`,
+        'utf8',
+      )
+
+      const created = await makeAuth({ force: true, verify: true })
+
+      expect(created).toEqual(expect.arrayContaining([
+        expect.stringContaining('VerifyEmailController.ts'),
+        expect.stringContaining('VerifyEmail.tsx'),
+        expect.stringContaining('EmailVerificationStore.ts'),
+        expect.stringContaining('EmailVerificationMail.ts'),
+      ]))
+
+      const schema = await readFile(join(workspace.dir, 'db/schema.ts'), 'utf8')
+      expect(schema).toContain('emailVerifiedAt: timestamp(')
+
+      const authRoutes = await readFile(join(workspace.dir, 'routes/auth.ts'), 'utf8')
+      expect(authRoutes).toContain("import VerifyEmailController from '../app/Http/Controllers/Auth/VerifyEmailController.js'")
+      expect(authRoutes).toContain("router.get('/verify-email'")
+      expect(authRoutes).toContain("router.get('/verify-email/confirm'")
+      expect(authRoutes).toContain('requireVerifiedEmail')
+      expect(authRoutes).toContain("router.get('/dashboard', [DashboardController, 'index'], requireAuthenticated({ redirectTo: '/login' }), requireVerifiedEmail({ redirectTo: '/verify-email' }))")
+
+      const registerController = await readFile(
+        join(workspace.dir, 'app/Http/Controllers/Auth/RegisterController.ts'),
+        'utf8',
+      )
+      expect(registerController).toContain('createEmailVerificationToken(')
+      expect(registerController).toContain('sendEmailVerificationMail(')
+      expect(registerController).toContain("this.redirect('/verify-email')")
+
+      const verifyController = await readFile(
+        join(workspace.dir, 'app/Http/Controllers/Auth/VerifyEmailController.ts'),
+        'utf8',
+      )
+      expect(verifyController).toContain('completeEmailVerification(')
+      expect(verifyController).toContain('emailVerifiedAt: new Date()')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('warns and skips --verify when combined with --minimal', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-auth-verify-minimal-')
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(join(workspace.dir, 'db/schema.ts'), `export const posts = 'posts'\n`, 'utf8')
+
+      const created = await makeAuth({ force: true, minimal: true, verify: true })
+
+      expect(created).not.toEqual(expect.arrayContaining([
+        expect.stringContaining('VerifyEmailController.ts'),
+      ]))
+
+      const schema = await readFile(join(workspace.dir, 'db/schema.ts'), 'utf8')
+      expect(schema).not.toContain('emailVerifiedAt')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
 })

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -249,6 +249,46 @@ export const posts = pgTable('posts', {
     }
   })
 
+  it('inserts emailVerifiedAt next to an existing three-argument pgTable users block', async () => {
+    // Regression test: a whole-block regex replace only matches Drizzle's
+    // two-argument pgTable(name, columns) form. A users table already
+    // carrying auth columns *and* a trailing index callback — the shape
+    // make:auth's own generated schema.ts uses once wired up — must get a
+    // single, in-place column insertion, not a duplicated `users` export.
+    const workspace = await createTempWorkspace('guren-cli-make-auth-verify-existing-')
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'db/schema.ts'),
+        `import { pgTable, serial, text, uniqueIndex } from 'drizzle-orm/pg-core'
+
+export const users = pgTable(
+  'users',
+  {
+    id: serial('id').primaryKey(),
+    name: text('name').notNull(),
+    email: text('email').notNull(),
+    passwordHash: text('password_hash').notNull(),
+    rememberToken: text('remember_token'),
+  },
+  (table) => [uniqueIndex('users_email_unique').on(table.email)],
+)
+`,
+        'utf8',
+      )
+
+      await makeAuth({ force: true, verify: true })
+
+      const schema = await readFile(join(workspace.dir, 'db/schema.ts'), 'utf8')
+      expect(schema.match(/export const users = pgTable\(/g)).toHaveLength(1)
+      expect(schema).toContain("emailVerifiedAt: timestamp('email_verified_at', { withTimezone: false }),")
+      expect(schema).toContain('uniqueIndex')
+      expect(schema).toContain("(table) => [uniqueIndex('users_email_unique').on(table.email)]")
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('warns and skips --verify when combined with --minimal', async () => {
     const workspace = await createTempWorkspace('guren-cli-make-auth-verify-minimal-')
     try {


### PR DESCRIPTION
## Summary
- Add `--verify` flag to `guren make:auth` that scaffolds a full email verification flow on top of the registration + password reset experience
- Generates `VerifyEmailController` (notice/resend/confirm actions), a `VerifyEmail` page, an `EmailVerificationStore` (in-memory, swappable for Redis in production), and an `EmailVerificationMail`
- Adds an `emailVerifiedAt` column to the `users` table across all three supported dialects (sqlite/pg/mysql)
- Registration now sends a verification email and redirects to `/verify-email` instead of `/dashboard` when `--verify` is used
- The generated `/dashboard` route is guarded with `requireVerifiedEmail({ redirectTo: '/verify-email' })`
- `--verify` requires the default (non-minimal) experience since it builds on the registration flow generated in #141; warns and skips if combined with `--minimal`

## Bug fix found during verification
While regenerating into `examples/blog` to verify the schema patch, found that `updateSchema()` corrupted the `users` table when it was defined with Drizzle's three-argument form (e.g. `pgTable('users', { ... }, (table) => [uniqueIndex(...)])`, which is what `examples/blog/db/schema.ts` actually uses). The old whole-block regex replace only matched the two-argument form, so it silently fell through to the "append" branch and produced a duplicate `export const users = pgTable(...)` block.

Fixed by branching `updateSchema()`: when auth columns already exist (i.e. a previous `make:auth` run already added `passwordHash` etc.), insert just the new `emailVerifiedAt` column next to the `rememberToken` line via a targeted per-line regex instead of attempting to parse/replace the whole table block. The original whole-block replace/append path is now only used for a truly fresh schema, where the exact shape we generate is guaranteed.

## Test plan
- [x] `bun test packages/cli/tests/make-auth.test.ts` — 4 tests, 61 assertions, all passing (2 new tests added: `--verify` scaffolding, `--verify` + `--minimal` warning)
- [x] `bun run build:clean`
- [x] `bun run typecheck`
- [x] `bun run test:bun` (2277 pass)
- [x] `bun run test:examples`
- [x] `bun run audit:core-first`
- [x] `bun run audit:docs`
- [x] Regenerated into `examples/blog` with `--force --verify`, ran `tsc --noEmit` against the real generated code (only pre-existing unrelated errors remained)
- [x] Verified the `updateSchema()` fix produces a correct single-line insertion into the real 3-arg `pgTable('users', ...)` block, no duplication
- [x] Ran a standalone runtime script proving token issuance → mail send → confirm → single-use invalidation all work end-to-end with a real `APP_KEY`
- [x] Traced `requireVerifiedEmail`'s default `getUser` against `AUTH_CONTEXT_KEY` (`'guren:auth'`) and `ModelUserProvider.sanitize()` to confirm `emailVerifiedAt` survives sanitization and the guard correctly resolves the authenticated user (not just compile-checked — read the actual resolution path)
- [x] Reverted all `examples/blog` changes back to a clean state after manual verification

Stacked on #142 — base branch is `feat/make-auth-password-reset`, not `main`.