### PR TITLE
chore: add changesets for RFC 0002 (arch boundary checking + modules)

### DIFF
--- a/.changeset/application-modules.md
+++ b/.changeset/application-modules.md
@@ -1,0 +1,8 @@
+---
+'@guren/server': minor
+'@guren/cli': minor
+---
+
+Added application modules — a `modules/<name>/` directory convention for composing self-contained slices of an app instead of piling everything into one flat `app/`, `routes/`, and `db/schema.ts`. `defineModule()` (new in `@guren/server`, re-exported from `@guren/core`) declares a module's routes and providers; `Application` folds them into its provider list and route mounting at boot via the new `mountModuleRoutes()`.
+
+On the CLI side: `guren make:module <name>` scaffolds and auto-wires a module (`index.ts`, `routes.ts`, `db/schema.ts`, plus `src/app.ts`/`db/schema.ts` patching). Most `make:*` generators accept `--module <name>` to scaffold inside a module instead of the project root. `guren check`, `guren audit`, `guren context`, `model:list`, and `doctor` are all module-aware automatically, and once any `modules/` directory exists, `guren check` derives zero-config boundary rules that flag cross-module imports reaching past a module's public surface (`index.ts` or `db/schema.ts`) — no `guren.arch.ts` authoring required. `guren codegen`, `guren audit`, `openapi:generate`, and `guren route:list` all see routes registered inside a module's own `routes.ts`, not just the top-level `routes/web.ts`.

--- a/.changeset/arch-boundary-checking.md
+++ b/.changeset/arch-boundary-checking.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': minor
+---
+
+`guren check` now enforces architecture boundaries. Drop a `guren.arch.ts` file at the project root to define layers and disallowed cross-layer imports (or disallowed packages), and violations are reported alongside the existing route/controller/page checks. Two new flags support this for AI coding agents and large apps: `guren check --arch` runs only the architecture checks (a fast path for an edit hook), and `guren check --changed` restricts any check to files changed versus the merge base with `main`.


### PR DESCRIPTION
## Summary

#140 and #144 (RFC 0002's two parts) shipped without changesets — every other recent feature PR in this repo includes one, and the next release wave won't pick up a version bump or CHANGELOG entry for either without it.

- `.changeset/arch-boundary-checking.md`: `@guren/cli` minor — `guren check --arch`, `guren.arch.ts`, `--changed`.
- `.changeset/application-modules.md`: `@guren/server` + `@guren/cli` minor — `defineModule()`, `mountModuleRoutes()`, `make:module`, `--module`, module-aware `check`/`audit`/`codegen`/`route:list`.

No code changes — release metadata only.

## Test plan

- [x] `bunx changeset status` confirms both packages bump at minor, no unexpected packages included.