### PR TITLE
chore: switch site URL to guren.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ const post = await Post.findOrFail(1)
 
 ## Documentation
 
-- [Official docs](https://gurenjs.vercel.app/) — tutorials, API reference, guides
+- [Official docs](https://guren.dev/) — tutorials, API reference, guides
 - [examples/blog](./examples/blog) — reference implementation
 
 ---

--- a/web/config/site.ts
+++ b/web/config/site.ts
@@ -1,7 +1,7 @@
 // Shared site metadata. Imported by both server controllers and React pages,
 // so keep this module dependency-free and side-effect-free.
 
-export const SITE_URL = 'https://gurenjs.vercel.app'
+export const SITE_URL = 'https://guren.dev'
 export const SITE_NAME = 'Guren'
 export const GITHUB_URL = 'https://github.com/gurenjs/guren'
 export const OG_IMAGE_PATH = '/og.png'

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://gurenjs.vercel.app/sitemap.xml
+Sitemap: https://guren.dev/sitemap.xml

--- a/web/tests/controllers/MetaController.test.ts
+++ b/web/tests/controllers/MetaController.test.ts
@@ -40,9 +40,9 @@ describe('MetaController', () => {
     const body = await response.text()
 
     expect(response.headers.get('Content-Type')).toContain('application/xml')
-    expect(body).toContain('<loc>https://gurenjs.vercel.app/docs/guides/routing</loc>')
-    expect(body).toContain('<loc>https://gurenjs.vercel.app/docs/ja/guides/routing</loc>')
-    expect(body).toContain('hreflang="ja" href="https://gurenjs.vercel.app/docs/ja/guides/routing"')
+    expect(body).toContain('<loc>https://guren.dev/docs/guides/routing</loc>')
+    expect(body).toContain('<loc>https://guren.dev/docs/ja/guides/routing</loc>')
+    expect(body).toContain('hreflang="ja" href="https://guren.dev/docs/ja/guides/routing"')
     expect(body).toContain('hreflang="x-default"')
   })
 
@@ -55,7 +55,7 @@ describe('MetaController', () => {
     expect(response.headers.get('Content-Type')).toContain('text/plain')
     expect(body).toContain('# Guren')
     expect(body).toContain('## Guides')
-    expect(body).toContain('- [Routing](https://gurenjs.vercel.app/docs/guides/routing.md): Define routes')
+    expect(body).toContain('- [Routing](https://guren.dev/docs/guides/routing.md): Define routes')
     expect(body).toContain('/llms-full.txt')
   })
 
@@ -68,7 +68,7 @@ describe('MetaController', () => {
 
     expect(docsService.getRawMarkdown).toHaveBeenCalledWith('guides', 'routing', 'en')
     expect(body).toContain('# Guren — Full Documentation')
-    expect(body).toContain('<!-- https://gurenjs.vercel.app/docs/guides/routing -->')
+    expect(body).toContain('<!-- https://guren.dev/docs/guides/routing -->')
     expect(body).toContain('# Routing')
   })
 })


### PR DESCRIPTION
## Summary

- Switch the canonical site URL from `gurenjs.vercel.app` to the new custom domain `https://guren.dev`
- `SITE_URL` in `web/config/site.ts` drives canonical/OG/Twitter tags, JSON-LD, `sitemap.xml`, and `/llms.txt`, so most of the change is that single constant
- Also updated: `robots.txt` sitemap pointer, README docs link, and `MetaController` test expectations

## Verification

- `bun test tests/controllers/MetaController.test.ts` — 3 pass
- `https://guren.dev/llms.txt` already returns 200 on the new domain

## Notes

- `gurenjs.vercel.app` will be configured to 308-redirect to `guren.dev` in the Vercel dashboard, so existing links keep working