### PR TITLE
feat(examples): adopt full make:auth stack in blog example

### DIFF
--- a/.changeset/blog-full-auth-adoption.md
+++ b/.changeset/blog-full-auth-adoption.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': patch
+---
+
+Fix a stray `@guren/server/redis` reference in `make:auth`'s password-reset/email-verification store comments — it should point at `@guren/core/redis`, the public subpath. Also fully adopt `make:auth`'s auth stack (registration, password reset, email verification, GitHub/Google OAuth) into `examples/blog`, replacing the login-only reference implementation.

--- a/.changeset/make-auth-template-hardening.md
+++ b/.changeset/make-auth-template-hardening.md
@@ -1,0 +1,11 @@
+---
+'@guren/cli': patch
+---
+
+Harden `make:auth` templates with fixes discovered while adopting the full auth stack in a real app:
+
+- Validators lowercase the email field, so mixed-case input round-trips correctly through login, password-reset, and email-verification lookups (the token helpers normalize to lowercase internally).
+- `/verify-email/confirm` is scaffolded as a public route — it validates the signed token itself, and gating it behind auth stranded users who opened the emailed link from another device or after their session expired.
+- `ProfileController.update()` clears `emailVerifiedAt` and re-sends the verification email when the address changes (with `--verify`), instead of letting an unproven replacement address inherit verified status.
+- `ForgotPasswordController` no longer awaits the reset-email send inline; the transport round-trip only happened for known accounts, so response timing could reveal which emails are registered.
+- `OAuthController` lowercases the provider email before matching and creating accounts.

--- a/.changeset/oauth-controller-email-verified.md
+++ b/.changeset/oauth-controller-email-verified.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': patch
+---
+
+Fix `make:auth --verify --oauth <providers>`: newly created OAuth accounts are now marked email-verified at creation. Previously they were left unverified, and since `OAuthController` never sends a verification email, `requireVerifiedEmail` would strand every OAuth signup at `/verify-email` with no way to get past it. The OAuth provider already vouches for the address, so there's nothing to re-verify.

--- a/.changeset/oauth-github-email-fallback.md
+++ b/.changeset/oauth-github-email-fallback.md
@@ -1,0 +1,5 @@
+---
+'@guren/server': minor
+---
+
+Add `fetchFallbackEmail` to `OAuthProviderConfig`: an optional async hook consulted when the userinfo response carries no email. `createGitHubOAuthProviderConfig` now supplies a default implementation that fetches the primary verified address from GitHub's `/user/emails` endpoint — GitHub returns `email: null` for accounts with a private email even when the `user:email` scope was granted, which previously made OAuth sign-in fail for those accounts.

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
       "runtimeExecutable": "bash",
       "runtimeArgs": ["-c", "cd web && exec bun bin/serve.ts"],
       "port": 3333
+    },
+    {
+      "name": "blog",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "cd examples/blog && exec bun run dev"],
+      "port": 3333
     }
   ]
 }

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -415,11 +415,12 @@ The runtime strips exactly the columns your provider is configured with plus the
 
 ## Example Application
 
-The blog example now includes:
+The blog example includes the full authentication stack:
 
-- `AuthProvider` for guard/provider setup
-- `LoginController` & `DashboardController`
-- Inertia pages at `resources/js/pages/auth/Login.tsx` and `resources/js/pages/dashboard/Index.tsx`
+- `AuthProvider` and `OAuthProvider` for guard/provider setup
+- Login, registration, password reset, and email verification controllers, plus `DashboardController`
+- Inertia pages under `resources/js/pages/auth/` (`Login`, `Register`, `ForgotPassword`, `ResetPassword`, `VerifyEmail`) and `resources/js/pages/dashboard/Index.tsx`
+- OAuth login buttons for GitHub and Google
 - Database schema, migration, and seeder for `users`
 
 Run the demo with:
@@ -428,4 +429,4 @@ Run the demo with:
 bun run dev
 ```
 
-Visit `http://localhost:3000/login` and sign in using the seeded credentials `demo@example.com` / `secret`.
+Visit `http://localhost:3333/login` and sign in using the seeded credentials `demo@guren.dev` / `secret`, or visit `/register` to create a new account.

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -412,11 +412,12 @@ type SafeUser = Sanitized<UserRecord, 'twoFactorSecret' | 'credentialDigest'>
 
 ## 実例アプリ
 
-ブログの例には以下が含まれます:
+ブログの例には認証機能一式が含まれます:
 
-- ガード/プロバイダー設定用の `AuthProvider`
-- `LoginController` と `DashboardController`
-- `resources/js/pages/auth/Login.tsx` と `resources/js/pages/dashboard/Index.tsx` の Inertia ページ
+- ガード/プロバイダー設定用の `AuthProvider` と `OAuthProvider`
+- ログイン・登録・パスワードリセット・メール確認の各コントローラー、および `DashboardController`
+- `resources/js/pages/auth/` 配下の Inertia ページ(`Login`・`Register`・`ForgotPassword`・`ResetPassword`・`VerifyEmail`)と `resources/js/pages/dashboard/Index.tsx`
+- GitHub・Google 向けの OAuth ログインボタン
 - `users` 用のスキーマ、マイグレーション、シーダー
 
 デモを実行します。
@@ -425,4 +426,4 @@ type SafeUser = Sanitized<UserRecord, 'twoFactorSecret' | 'credentialDigest'>
 bun run dev
 ```
 
-`http://localhost:3000/login` にアクセスし、シード済みの `demo@example.com` / `secret` でログインできます。
+`http://localhost:3333/login` にアクセスし、シード済みの `demo@guren.dev` / `secret` でログインするか、`/register` から新規アカウントを作成できます。

--- a/examples/blog/.env.example
+++ b/examples/blog/.env.example
@@ -26,4 +26,15 @@ RESEND_API_KEY=
 MAIL_FROM_ADDRESS=hello@example.com
 MAIL_FROM_NAME="${APP_NAME}"
 
+# OAuth login buttons render on /login and /register regardless, but a
+# provider only actually works once all three of its vars are set — see
+# app/Providers/OAuthProvider.ts
+# OAUTH_GITHUB_CLIENT_ID=
+# OAUTH_GITHUB_CLIENT_SECRET=
+# OAUTH_GITHUB_REDIRECT_URI=http://localhost:3333/auth/github/callback
+
+# OAUTH_GOOGLE_CLIENT_ID=
+# OAUTH_GOOGLE_CLIENT_SECRET=
+# OAUTH_GOOGLE_REDIRECT_URI=http://localhost:3333/auth/google/callback
+
 VITE_DEV_SERVER_URL=http://localhost:5173

--- a/examples/blog/.gitignore
+++ b/examples/blog/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 test-results/
 playwright-report/
 e2e/.auth/
+storage/app/public/

--- a/examples/blog/app/Auth/EmailVerificationStore.ts
+++ b/examples/blog/app/Auth/EmailVerificationStore.ts
@@ -1,0 +1,6 @@
+import { MemoryEmailVerificationStore } from '@guren/core'
+
+// Swap for a Redis-backed store (see @guren/core/redis) in production
+// or any multi-instance deployment — this in-memory store does not
+// survive restarts and is not shared across processes.
+export const emailVerificationStore = new MemoryEmailVerificationStore()

--- a/examples/blog/app/Auth/PasswordResetStore.ts
+++ b/examples/blog/app/Auth/PasswordResetStore.ts
@@ -1,0 +1,6 @@
+import { MemoryPasswordResetStore } from '@guren/core'
+
+// Swap for a Redis-backed store (see @guren/core/redis) in production
+// or any multi-instance deployment — this in-memory store does not
+// survive restarts and is not shared across processes.
+export const passwordResetStore = new MemoryPasswordResetStore()

--- a/examples/blog/app/Http/Controllers/Auth/ForgotPasswordController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/ForgotPasswordController.ts
@@ -1,0 +1,32 @@
+import { Controller, createPasswordResetToken, buildPasswordResetUrl } from '@guren/core'
+import { ForgotPasswordSchema } from '../../Validators/ForgotPasswordValidator.js'
+import { User } from '../../../Models/User.js'
+import { passwordResetStore } from '../../../Auth/PasswordResetStore.js'
+import { sendPasswordResetMail } from '../../../Mail/PasswordResetMail.js'
+import { pages } from '@/.guren/pages.gen'
+
+const STATUS_MESSAGE = "If an account exists for that email, we've sent a password reset link."
+
+export default class ForgotPasswordController extends Controller {
+  async show(): Promise<Response> {
+    return this.inertia(pages.auth.ForgotPassword, {}, { url: this.request.path, title: 'Forgot password | Guren Blog' })
+  }
+
+  async store(): Promise<Response> {
+    const { email } = await this.validateBody(ForgotPasswordSchema)
+
+    // Always respond with the same status message whether or not the
+    // account exists, to avoid leaking which emails are registered.
+    const [user] = await User.where({ email })
+    if (user) {
+      const { token } = await createPasswordResetToken(email, passwordResetStore)
+      const resetUrl = buildPasswordResetUrl(`${new URL(this.request.url).origin}/reset-password`, token, email)
+      await sendPasswordResetMail(this.make('mail'), email, resetUrl)
+    }
+
+    return this.inertia(pages.auth.ForgotPassword, { status: STATUS_MESSAGE }, {
+      url: this.request.path,
+      title: 'Forgot password | Guren Blog',
+    })
+  }
+}

--- a/examples/blog/app/Http/Controllers/Auth/ForgotPasswordController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/ForgotPasswordController.ts
@@ -2,7 +2,7 @@ import { Controller, createPasswordResetToken, buildPasswordResetUrl } from '@gu
 import { ForgotPasswordSchema } from '../../Validators/ForgotPasswordValidator.js'
 import { User } from '../../../Models/User.js'
 import { passwordResetStore } from '../../../Auth/PasswordResetStore.js'
-import { sendPasswordResetMail } from '../../../Mail/PasswordResetMail.js'
+import { SendPasswordResetEmailJob } from '../../../Jobs/SendPasswordResetEmailJob.js'
 import { pages } from '@/.guren/pages.gen'
 
 const STATUS_MESSAGE = "If an account exists for that email, we've sent a password reset link."
@@ -16,12 +16,15 @@ export default class ForgotPasswordController extends Controller {
     const { email } = await this.validateBody(ForgotPasswordSchema)
 
     // Always respond with the same status message whether or not the
-    // account exists, to avoid leaking which emails are registered.
+    // account exists, to avoid leaking which emails are registered. The
+    // email itself is dispatched to a queue rather than awaited inline, so
+    // the (comparatively slow) mail-transport round-trip can't be used as a
+    // timing side-channel to tell known accounts apart from unknown ones.
     const [user] = await User.where({ email })
     if (user) {
       const { token } = await createPasswordResetToken(email, passwordResetStore)
       const resetUrl = buildPasswordResetUrl(`${new URL(this.request.url).origin}/reset-password`, token, email)
-      await sendPasswordResetMail(this.make('mail'), email, resetUrl)
+      await SendPasswordResetEmailJob.dispatch({ email, resetUrl })
     }
 
     return this.inertia(pages.auth.ForgotPassword, { status: STATUS_MESSAGE }, {

--- a/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
@@ -96,6 +96,12 @@ export default class OAuthController extends Controller {
         name: profile.name ?? resolvedEmail,
         email: resolvedEmail,
         password: randomUUID(),
+        // The provider already vouches for this address (GitHub's fallback
+        // above only accepts primary+verified emails; Google's userinfo
+        // email comes from a verified account) — making the user click a
+        // verification link we never send would just strand them at
+        // /verify-email.
+        emailVerifiedAt: new Date(),
         ...identityWhere(provider, profile.id),
       })
     }

--- a/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
@@ -22,6 +22,32 @@ function identityWhere(provider: OAuthProvider, profileId: string): Partial<User
   return identities[provider]
 }
 
+interface GitHubEmail {
+  email: string
+  primary: boolean
+  verified: boolean
+}
+
+// GitHub's /user endpoint returns `email: null` whenever the account's email
+// is set to private, even with the `user:email` scope granted — the primary
+// verified address is only available from this separate endpoint.
+async function fetchGitHubPrimaryEmail(accessToken: string): Promise<string | undefined> {
+  const response = await fetch('https://api.github.com/user/emails', {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'guren-blog',
+    },
+  })
+
+  if (!response.ok) {
+    return undefined
+  }
+
+  const emails = (await response.json()) as GitHubEmail[]
+  return emails.find((entry) => entry.primary && entry.verified)?.email
+}
+
 export default class OAuthController extends Controller {
   private oauth(): OAuthManager {
     return this.make<OAuthManager>('oauth')
@@ -45,14 +71,18 @@ export default class OAuthController extends Controller {
 
     const { profile, redirectTo } = await this.oauth().handleCallback(provider, { code, state })
 
-    if (!profile.email) {
+    const resolvedEmail = (
+      profile.email ?? (provider === 'github' ? await fetchGitHubPrimaryEmail(profile.token.accessToken) : undefined)
+    )?.toLowerCase()
+
+    if (!resolvedEmail) {
       throw ValidationException.withMessages({ message: 'This provider did not return an email address.' })
     }
 
     let [user] = await User.where(identityWhere(provider, profile.id))
 
     if (!user) {
-      const [existingByEmail] = await User.where({ email: profile.email })
+      const [existingByEmail] = await User.where({ email: resolvedEmail })
       if (existingByEmail) {
         throw ValidationException.withMessages({
           message: 'An account with this email already exists. Sign in with your password instead.',
@@ -63,8 +93,8 @@ export default class OAuthController extends Controller {
       // account still satisfies AuthenticatableModel's hashing pipeline.
       // It's never surfaced to the user and can't realistically be guessed.
       user = await User.create({
-        name: profile.name ?? profile.email,
-        email: profile.email,
+        name: profile.name ?? resolvedEmail,
+        email: resolvedEmail,
         password: randomUUID(),
         ...identityWhere(provider, profile.id),
       })

--- a/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
@@ -1,0 +1,78 @@
+import { Controller, ValidationException, type OAuthManager } from '@guren/core'
+import { randomUUID } from 'node:crypto'
+import { z } from 'zod'
+import { User, type UserRecord } from '../../../Models/User.js'
+
+const ProviderParamSchema = z.object({
+  provider: z.enum(['github', 'google']),
+})
+
+const CallbackQuerySchema = z.object({
+  code: z.string(),
+  state: z.string(),
+})
+
+type OAuthProvider = z.infer<typeof ProviderParamSchema>['provider']
+
+function identityWhere(provider: OAuthProvider, profileId: string): Partial<UserRecord> {
+  const identities: Record<OAuthProvider, Partial<UserRecord>> = {
+    github: { githubId: profileId },
+    google: { googleId: profileId },
+  }
+  return identities[provider]
+}
+
+export default class OAuthController extends Controller {
+  private oauth(): OAuthManager {
+    return this.make<OAuthManager>('oauth')
+  }
+
+  // Note: not named `redirect` — that would shadow the base
+  // Controller.redirect() helper used below.
+  async redirectToProvider(): Promise<Response> {
+    const { provider } = this.validateParams(ProviderParamSchema)
+
+    const { url } = await this.oauth().authorize(provider, {
+      redirectTo: this.request.query('redirectTo') ?? undefined,
+    })
+
+    return this.redirect(url)
+  }
+
+  async callback(): Promise<Response> {
+    const { provider } = this.validateParams(ProviderParamSchema)
+    const { code, state } = this.validateQuery(CallbackQuerySchema)
+
+    const { profile, redirectTo } = await this.oauth().handleCallback(provider, { code, state })
+
+    if (!profile.email) {
+      throw ValidationException.withMessages({ message: 'This provider did not return an email address.' })
+    }
+
+    let [user] = await User.where(identityWhere(provider, profile.id))
+
+    if (!user) {
+      const [existingByEmail] = await User.where({ email: profile.email })
+      if (existingByEmail) {
+        throw ValidationException.withMessages({
+          message: 'An account with this email already exists. Sign in with your password instead.',
+        })
+      }
+
+      // No password was supplied by the user — generate a random one so the
+      // account still satisfies AuthenticatableModel's hashing pipeline.
+      // It's never surfaced to the user and can't realistically be guessed.
+      user = await User.create({
+        name: profile.name ?? profile.email,
+        email: profile.email,
+        password: randomUUID(),
+        ...identityWhere(provider, profile.id),
+      })
+    }
+
+    this.auth.session()?.regenerate()
+    await this.auth.login(user)
+
+    return this.redirect(redirectTo ?? '/dashboard')
+  }
+}

--- a/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
@@ -22,32 +22,6 @@ function identityWhere(provider: OAuthProvider, profileId: string): Partial<User
   return identities[provider]
 }
 
-interface GitHubEmail {
-  email: string
-  primary: boolean
-  verified: boolean
-}
-
-// GitHub's /user endpoint returns `email: null` whenever the account's email
-// is set to private, even with the `user:email` scope granted — the primary
-// verified address is only available from this separate endpoint.
-async function fetchGitHubPrimaryEmail(accessToken: string): Promise<string | undefined> {
-  const response = await fetch('https://api.github.com/user/emails', {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      Accept: 'application/vnd.github+json',
-      'User-Agent': 'guren-blog',
-    },
-  })
-
-  if (!response.ok) {
-    return undefined
-  }
-
-  const emails = (await response.json()) as GitHubEmail[]
-  return emails.find((entry) => entry.primary && entry.verified)?.email
-}
-
 export default class OAuthController extends Controller {
   private oauth(): OAuthManager {
     return this.make<OAuthManager>('oauth')
@@ -71,9 +45,10 @@ export default class OAuthController extends Controller {
 
     const { profile, redirectTo } = await this.oauth().handleCallback(provider, { code, state })
 
-    const resolvedEmail = (
-      profile.email ?? (provider === 'github' ? await fetchGitHubPrimaryEmail(profile.token.accessToken) : undefined)
-    )?.toLowerCase()
+    // GitHub accounts with a private email are handled upstream:
+    // createGitHubOAuthProviderConfig falls back to /user/emails, so
+    // profile.email is already populated whenever one is obtainable.
+    const resolvedEmail = profile.email?.toLowerCase()
 
     if (!resolvedEmail) {
       throw ValidationException.withMessages({ message: 'This provider did not return an email address.' })

--- a/examples/blog/app/Http/Controllers/Auth/RegisterController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/RegisterController.ts
@@ -1,0 +1,37 @@
+import { Controller, ValidationException, createEmailVerificationToken, buildVerificationUrl } from '@guren/core'
+import { RegisterSchema } from '../../Validators/RegisterValidator.js'
+import { User } from '../../../Models/User.js'
+import { emailVerificationStore } from '../../../Auth/EmailVerificationStore.js'
+import { sendEmailVerificationMail } from '../../../Mail/EmailVerificationMail.js'
+import { SendWelcomeEmailJob } from '../../../Jobs/SendWelcomeEmailJob.js'
+import { pages } from '@/.guren/pages.gen'
+
+export default class RegisterController extends Controller {
+  async show(): Promise<Response> {
+    return this.inertia(pages.auth.Register, {}, { url: this.request.path, title: 'Register | Guren Blog' })
+  }
+
+  async store(): Promise<Response> {
+    const { name, email, password } = await this.validateBody(RegisterSchema)
+
+    const existing = await User.where({ email })
+    if (existing.length > 0) {
+      throw ValidationException.withMessages({ email: 'An account with this email already exists.' })
+    }
+
+    // AuthenticatableModel hashes the virtual `password` field into
+    // `passwordHash` before persisting — see app/Models/User.ts.
+    const user = await User.create({ name, email, password })
+
+    await SendWelcomeEmailJob.dispatch({ userId: user.id })
+
+    const { token } = await createEmailVerificationToken(user.email, emailVerificationStore)
+    const verifyUrl = buildVerificationUrl(`${new URL(this.request.url).origin}/verify-email/confirm`, token, user.email)
+    await sendEmailVerificationMail(this.make('mail'), user.email, verifyUrl)
+
+    this.auth.session()?.regenerate()
+    await this.auth.login(user)
+
+    return this.redirect('/verify-email')
+  }
+}

--- a/examples/blog/app/Http/Controllers/Auth/ResetPasswordController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/ResetPasswordController.ts
@@ -1,0 +1,39 @@
+import { Controller, ValidationException, verifyPasswordResetToken } from '@guren/core'
+import { ResetPasswordSchema } from '../../Validators/ResetPasswordValidator.js'
+import { User } from '../../../Models/User.js'
+import { passwordResetStore } from '../../../Auth/PasswordResetStore.js'
+import { pages } from '@/.guren/pages.gen'
+
+const INVALID_TOKEN_MESSAGE = 'This password reset link is invalid or has expired.'
+
+export default class ResetPasswordController extends Controller {
+  async show(): Promise<Response> {
+    const token = this.request.query('token') ?? ''
+    const email = this.request.query('email') ?? ''
+    return this.inertia(pages.auth.ResetPassword, { token, email }, {
+      url: this.request.path,
+      title: 'Reset password | Guren Blog',
+    })
+  }
+
+  async store(): Promise<Response> {
+    const { token, password } = await this.validateBody(ResetPasswordSchema)
+
+    const email = await verifyPasswordResetToken(token, passwordResetStore)
+    if (!email) {
+      throw ValidationException.withMessages({ token: INVALID_TOKEN_MESSAGE })
+    }
+
+    const [user] = await User.where({ email })
+    if (!user) {
+      throw ValidationException.withMessages({ token: INVALID_TOKEN_MESSAGE })
+    }
+
+    // AuthenticatableModel hashes the virtual `password` field into
+    // `passwordHash` before persisting — see app/Models/User.ts.
+    await User.update({ id: user.id }, { password })
+    await passwordResetStore.deleteForEmail(email)
+
+    return this.redirect('/login')
+  }
+}

--- a/examples/blog/app/Http/Controllers/Auth/VerifyEmailController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/VerifyEmailController.ts
@@ -1,0 +1,50 @@
+import { Controller, createEmailVerificationToken, completeEmailVerification, buildVerificationUrl } from '@guren/core'
+import { User, type UserRecord } from '../../../Models/User.js'
+import { emailVerificationStore } from '../../../Auth/EmailVerificationStore.js'
+import { sendEmailVerificationMail } from '../../../Mail/EmailVerificationMail.js'
+import { pages } from '@/.guren/pages.gen'
+
+const EXPIRED_MESSAGE = 'This verification link is invalid or has expired. Request a new one below.'
+
+export default class VerifyEmailController extends Controller {
+  async notice(): Promise<Response> {
+    const user = await this.auth.userOrFail<UserRecord>()
+    if (user.emailVerifiedAt) {
+      return this.redirect('/dashboard')
+    }
+
+    return this.inertia(pages.auth.VerifyEmail, {}, { url: this.request.path, title: 'Verify email | Guren Blog' })
+  }
+
+  async resend(): Promise<Response> {
+    const user = await this.auth.userOrFail<UserRecord>()
+
+    if (!user.emailVerifiedAt) {
+      const { token } = await createEmailVerificationToken(user.email, emailVerificationStore)
+      const verifyUrl = buildVerificationUrl(`${new URL(this.request.url).origin}/verify-email/confirm`, token, user.email)
+      await sendEmailVerificationMail(this.make('mail'), user.email, verifyUrl)
+    }
+
+    return this.inertia(pages.auth.VerifyEmail, {
+      status: 'A new verification link has been sent to your email address.',
+    }, { url: this.request.path, title: 'Verify email | Guren Blog' })
+  }
+
+  async confirm(): Promise<Response> {
+    const token = this.request.query('token') ?? ''
+
+    const verifiedEmail = await completeEmailVerification(token, emailVerificationStore, async (email) => {
+      await User.update({ email }, { emailVerifiedAt: new Date() })
+      return email
+    })
+
+    if (!verifiedEmail) {
+      return this.inertia(pages.auth.VerifyEmail, { status: EXPIRED_MESSAGE }, {
+        url: this.request.path,
+        title: 'Verify email | Guren Blog',
+      })
+    }
+
+    return this.redirect('/dashboard')
+  }
+}

--- a/examples/blog/app/Http/Controllers/ProfileController.ts
+++ b/examples/blog/app/Http/Controllers/ProfileController.ts
@@ -1,6 +1,8 @@
-import { Controller, ValidationException } from '@guren/core'
+import { Controller, ValidationException, createEmailVerificationToken, buildVerificationUrl } from '@guren/core'
 import { ProfileUpdateSchema } from '../Validators/ProfileValidator.js'
 import { User, type UserRecord } from '../../Models/User.js'
+import { emailVerificationStore } from '../../Auth/EmailVerificationStore.js'
+import { sendEmailVerificationMail } from '../../Mail/EmailVerificationMail.js'
 import { pages } from '@/.guren/pages.gen'
 
 export default class ProfileController extends Controller {
@@ -27,7 +29,9 @@ export default class ProfileController extends Controller {
     const { name, email, password: rawPassword } = await this.validateBody(ProfileUpdateSchema)
     const password = rawPassword ?? ''
 
-    if (email !== authed.email) {
+    const emailChanged = email !== authed.email
+
+    if (emailChanged) {
       const existing = await User.where({ email })
       const conflict = existing.find((user) => user.id !== authed.id)
       if (conflict) {
@@ -44,6 +48,13 @@ export default class ProfileController extends Controller {
       updates.password = password
     }
 
+    if (emailChanged) {
+      // The new address hasn't been proven to belong to this user yet — an
+      // arbitrary replacement email must not inherit the old address's
+      // verified status.
+      updates.emailVerifiedAt = null
+    }
+
     await User.update({ id: authed.id }, updates)
 
     const refreshedUser = await User.find(authed.id)
@@ -53,9 +64,17 @@ export default class ProfileController extends Controller {
 
     await this.auth.login(refreshedUser)
 
+    if (emailChanged) {
+      const { token } = await createEmailVerificationToken(email, emailVerificationStore)
+      const verifyUrl = buildVerificationUrl(`${new URL(this.request.url).origin}/verify-email/confirm`, token, email)
+      await sendEmailVerificationMail(this.make('mail'), email, verifyUrl)
+    }
+
     return this.inertia(pages.profile.Edit, {
       profile: { name, email },
-      status: 'Profile updated successfully.',
+      status: emailChanged
+        ? 'Profile updated. Check your new email address for a verification link.'
+        : 'Profile updated successfully.',
     }, { url: this.request.path, title: 'Edit Profile | Guren Blog' })
   }
 }

--- a/examples/blog/app/Http/Validators/ForgotPasswordValidator.ts
+++ b/examples/blog/app/Http/Validators/ForgotPasswordValidator.ts
@@ -5,7 +5,10 @@ export const ForgotPasswordSchema = z.object({
     .string({ error: 'Email is required.' })
     .trim()
     .min(1, 'Email is required.')
-    .email('The email address is badly formatted.'),
+    .email('The email address is badly formatted.')
+    // Lowercased to match how registration stores emails and how the
+    // password-reset token helpers normalize emails internally.
+    .toLowerCase(),
 })
 
 export type ForgotPasswordInput = z.infer<typeof ForgotPasswordSchema>

--- a/examples/blog/app/Http/Validators/ForgotPasswordValidator.ts
+++ b/examples/blog/app/Http/Validators/ForgotPasswordValidator.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+export const ForgotPasswordSchema = z.object({
+  email: z
+    .string({ error: 'Email is required.' })
+    .trim()
+    .min(1, 'Email is required.')
+    .email('The email address is badly formatted.'),
+})
+
+export type ForgotPasswordInput = z.infer<typeof ForgotPasswordSchema>

--- a/examples/blog/app/Http/Validators/LoginValidator.ts
+++ b/examples/blog/app/Http/Validators/LoginValidator.ts
@@ -5,7 +5,12 @@ export const LoginSchema = z.object({
     .string({ error: 'Email is required.' })
     .trim()
     .min(1, 'Email is required.')
-    .email('The email address is badly formatted.'),
+    .email('The email address is badly formatted.')
+    // Registration stores emails lowercased, so normalize here too —
+    // otherwise a user who registered as Ada@Example.com and logs in with
+    // the same casing gets "Invalid credentials" from a case-sensitive
+    // database lookup.
+    .toLowerCase(),
   password: z
     .string({ error: 'Password is required.' })
     .min(1, 'Password is required.'),

--- a/examples/blog/app/Http/Validators/ProfileValidator.ts
+++ b/examples/blog/app/Http/Validators/ProfileValidator.ts
@@ -18,7 +18,8 @@ export const ProfileUpdateSchema = z
       .string({ error: 'Email is required.' })
       .trim()
       .min(1, 'Email is required.')
-      .email('Please provide a valid email address.'),
+      .email('Please provide a valid email address.')
+      .toLowerCase(),
     password: optionalPasswordField,
     passwordConfirmation: optionalPasswordField,
   })

--- a/examples/blog/app/Http/Validators/RegisterValidator.ts
+++ b/examples/blog/app/Http/Validators/RegisterValidator.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+export const RegisterSchema = z
+  .object({
+    name: z
+      .string({ error: 'Name is required.' })
+      .trim()
+      .min(1, 'Name is required.')
+      .max(120, 'Name must be 120 characters or fewer.'),
+    email: z
+      .string({ error: 'Email is required.' })
+      .trim()
+      .min(1, 'Email is required.')
+      .email('The email address is badly formatted.'),
+    password: z
+      .string({ error: 'Password is required.' })
+      .min(8, 'Password must be at least 8 characters.'),
+    passwordConfirmation: z
+      .string({ error: 'Please confirm your password.' })
+      .min(1, 'Please confirm your password.'),
+  })
+  .refine((data) => data.password === data.passwordConfirmation, {
+    message: 'Passwords do not match.',
+    path: ['passwordConfirmation'],
+  })
+
+export type RegisterInput = z.infer<typeof RegisterSchema>

--- a/examples/blog/app/Http/Validators/RegisterValidator.ts
+++ b/examples/blog/app/Http/Validators/RegisterValidator.ts
@@ -13,9 +13,9 @@ export const RegisterSchema = z
       .min(1, 'Email is required.')
       .email('The email address is badly formatted.')
       // Lowercased so it round-trips correctly through the password-reset
-      // and email-verification token helpers, which both normalize emails
-      // to lowercase internally (@guren/server's email-verification.ts /
-      // password-reset.ts) before matching against stored records.
+      // and email-verification token helpers (@guren/core), which both
+      // normalize emails to lowercase internally before matching against
+      // stored records.
       .toLowerCase(),
     password: z
       .string({ error: 'Password is required.' })

--- a/examples/blog/app/Http/Validators/RegisterValidator.ts
+++ b/examples/blog/app/Http/Validators/RegisterValidator.ts
@@ -11,7 +11,12 @@ export const RegisterSchema = z
       .string({ error: 'Email is required.' })
       .trim()
       .min(1, 'Email is required.')
-      .email('The email address is badly formatted.'),
+      .email('The email address is badly formatted.')
+      // Lowercased so it round-trips correctly through the password-reset
+      // and email-verification token helpers, which both normalize emails
+      // to lowercase internally (@guren/server's email-verification.ts /
+      // password-reset.ts) before matching against stored records.
+      .toLowerCase(),
     password: z
       .string({ error: 'Password is required.' })
       .min(8, 'Password must be at least 8 characters.'),

--- a/examples/blog/app/Http/Validators/ResetPasswordValidator.ts
+++ b/examples/blog/app/Http/Validators/ResetPasswordValidator.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+
+export const ResetPasswordSchema = z
+  .object({
+    token: z.string({ error: 'Reset token is required.' }).min(1, 'Reset token is required.'),
+    password: z
+      .string({ error: 'Password is required.' })
+      .min(8, 'Password must be at least 8 characters.'),
+    passwordConfirmation: z
+      .string({ error: 'Please confirm your password.' })
+      .min(1, 'Please confirm your password.'),
+  })
+  .refine((data) => data.password === data.passwordConfirmation, {
+    message: 'Passwords do not match.',
+    path: ['passwordConfirmation'],
+  })
+
+export type ResetPasswordInput = z.infer<typeof ResetPasswordSchema>

--- a/examples/blog/app/Jobs/SendPasswordResetEmailJob.ts
+++ b/examples/blog/app/Jobs/SendPasswordResetEmailJob.ts
@@ -1,0 +1,30 @@
+import { Job } from '@guren/core'
+import { sendPasswordResetMail } from '../Mail/PasswordResetMail.js'
+
+interface SendPasswordResetEmailPayload {
+  email: string
+  resetUrl: string
+}
+
+/**
+ * Job that sends the password-reset email. Dispatched (never awaited)
+ * regardless of whether the account exists, so ForgotPasswordController's
+ * response time doesn't leak which emails are registered.
+ */
+export class SendPasswordResetEmailJob extends Job<SendPasswordResetEmailPayload> {
+  static override queue = 'emails'
+  static override maxAttempts = 3
+  static override backoff: 'exponential' = 'exponential'
+
+  async handle(payload: SendPasswordResetEmailPayload): Promise<void> {
+    await sendPasswordResetMail(this.make('mail'), payload.email, payload.resetUrl)
+    console.log(`[Job] Password reset email sent to ${payload.email}`)
+  }
+
+  async failed(payload: SendPasswordResetEmailPayload, error: Error): Promise<void> {
+    console.error(
+      `[Job] Failed to send password reset email to ${payload.email}:`,
+      error.message
+    )
+  }
+}

--- a/examples/blog/app/Jobs/index.ts
+++ b/examples/blog/app/Jobs/index.ts
@@ -1,2 +1,3 @@
 export { SendWelcomeEmailJob } from './SendWelcomeEmailJob.js'
 export { ProcessNewPostJob } from './ProcessNewPostJob.js'
+export { SendPasswordResetEmailJob } from './SendPasswordResetEmailJob.js'

--- a/examples/blog/app/Mail/EmailVerificationMail.ts
+++ b/examples/blog/app/Mail/EmailVerificationMail.ts
@@ -1,0 +1,23 @@
+import { mail, type MailManager } from '@guren/core'
+
+export async function sendEmailVerificationMail(manager: MailManager, email: string, verifyUrl: string): Promise<void> {
+  await mail(manager)
+    .to(email)
+    .subject('Verify your email address')
+    .html(`
+      <h1>Verify your email address</h1>
+      <p>Click the link below to verify your email address.</p>
+      <p><a href="${verifyUrl}">${verifyUrl}</a></p>
+      <p>If you didn't create an account, you can safely ignore this email.</p>
+    `)
+    .text(`
+Verify your email address
+
+Click the link below to verify your email address.
+
+${verifyUrl}
+
+If you didn't create an account, you can safely ignore this email.
+    `)
+    .send()
+}

--- a/examples/blog/app/Mail/PasswordResetMail.ts
+++ b/examples/blog/app/Mail/PasswordResetMail.ts
@@ -1,0 +1,23 @@
+import { mail, type MailManager } from '@guren/core'
+
+export async function sendPasswordResetMail(manager: MailManager, email: string, resetUrl: string): Promise<void> {
+  await mail(manager)
+    .to(email)
+    .subject('Reset your password')
+    .html(`
+      <h1>Reset your password</h1>
+      <p>Click the link below to choose a new password. This link expires in 1 hour.</p>
+      <p><a href="${resetUrl}">${resetUrl}</a></p>
+      <p>If you didn't request this, you can safely ignore this email.</p>
+    `)
+    .text(`
+Reset your password
+
+Click the link below to choose a new password. This link expires in 1 hour.
+
+${resetUrl}
+
+If you didn't request this, you can safely ignore this email.
+    `)
+    .send()
+}

--- a/examples/blog/app/Mail/index.ts
+++ b/examples/blog/app/Mail/index.ts
@@ -1,2 +1,4 @@
 export { sendWelcomeMail } from './WelcomeMail.js'
 export { sendNewPostMail } from './NewPostMail.js'
+export { sendPasswordResetMail } from './PasswordResetMail.js'
+export { sendEmailVerificationMail } from './EmailVerificationMail.js'

--- a/examples/blog/app/Models/User.ts
+++ b/examples/blog/app/Models/User.ts
@@ -7,7 +7,7 @@ export type NewUserRecord = typeof users.$inferInsert
 
 export class User extends AuthenticatableModel<UserRecord> {
   static override table = users
-  static fillable = ['name', 'email', 'password']
+  static fillable = ['name', 'email', 'password', 'emailVerifiedAt', 'githubId', 'googleId']
   static guarded = ['id', 'passwordHash', 'rememberToken']
   static override hidden = ['passwordHash', 'rememberToken']
   static override readonly recordType = {} as UserRecord

--- a/examples/blog/app/Providers/EventServiceProvider.ts
+++ b/examples/blog/app/Providers/EventServiceProvider.ts
@@ -37,10 +37,18 @@ export function initializeEventSystem(): EventManager {
   eventManager = eventManager ?? createEventManager()
 
   mailManager = mailManager ?? createMailManager({
-    default: 'memory',
-    from: { email: 'noreply@blog.example.com', name: 'Guren Blog' },
+    // Defaults to the `log` driver (prints to the console) so verification
+    // and password-reset links are actually visible in development — the
+    // `memory` driver silently discards them, which broke both flows.
+    default: process.env.MAIL_MAILER ?? 'log',
+    from: {
+      email: process.env.MAIL_FROM_ADDRESS ?? 'noreply@blog.example.com',
+      name: process.env.MAIL_FROM_NAME ?? 'Guren Blog',
+    },
     transports: {
+      log: { driver: 'log' },
       memory: { driver: 'memory' },
+      resend: { driver: 'resend', apiKey: process.env.RESEND_API_KEY ?? '' },
     },
   })
   setMailManager(mailManager)

--- a/examples/blog/app/Providers/EventServiceProvider.ts
+++ b/examples/blog/app/Providers/EventServiceProvider.ts
@@ -19,6 +19,7 @@ import { UserLoggedIn } from '../Events/UserLoggedIn.js'
 import { PostCreated } from '../Events/PostCreated.js'
 import { SendWelcomeEmailJob } from '../Jobs/SendWelcomeEmailJob.js'
 import { ProcessNewPostJob } from '../Jobs/ProcessNewPostJob.js'
+import { SendPasswordResetEmailJob } from '../Jobs/SendPasswordResetEmailJob.js'
 
 let eventManager: EventManager | null = null
 let mailManager: MailManager | null = null
@@ -63,6 +64,7 @@ export function initializeEventSystem(): EventManager {
 
   registerJob(SendWelcomeEmailJob)
   registerJob(ProcessNewPostJob)
+  registerJob(SendPasswordResetEmailJob)
   registerListeners(eventManager)
 
   initialized = true

--- a/examples/blog/app/Providers/OAuthProvider.ts
+++ b/examples/blog/app/Providers/OAuthProvider.ts
@@ -1,0 +1,29 @@
+import { ServiceProvider, type OAuthManager, createGitHubOAuthProviderConfig, createGoogleOAuthProviderConfig } from '@guren/core'
+
+export default class OAuthProvider extends ServiceProvider {
+  register(): void {
+    const oauth = this.container.make<OAuthManager>('oauth')
+
+    const githubClientId = process.env.OAUTH_GITHUB_CLIENT_ID
+    const githubClientSecret = process.env.OAUTH_GITHUB_CLIENT_SECRET
+    const githubRedirectUri = process.env.OAUTH_GITHUB_REDIRECT_URI
+    if (githubClientId && githubClientSecret && githubRedirectUri) {
+      oauth.registerProvider('github', createGitHubOAuthProviderConfig({
+        clientId: githubClientId,
+        clientSecret: githubClientSecret,
+        redirectUri: githubRedirectUri,
+      }))
+    }
+
+    const googleClientId = process.env.OAUTH_GOOGLE_CLIENT_ID
+    const googleClientSecret = process.env.OAUTH_GOOGLE_CLIENT_SECRET
+    const googleRedirectUri = process.env.OAUTH_GOOGLE_REDIRECT_URI
+    if (googleClientId && googleClientSecret && googleRedirectUri) {
+      oauth.registerProvider('google', createGoogleOAuthProviderConfig({
+        clientId: googleClientId,
+        clientSecret: googleClientSecret,
+        redirectUri: googleRedirectUri,
+      }))
+    }
+  }
+}

--- a/examples/blog/db/migrations/20260724131638_tearful_misty_knight/migration.sql
+++ b/examples/blog/db/migrations/20260724131638_tearful_misty_knight/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "users" ADD COLUMN "email_verified_at" timestamp;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "github_id" text;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "google_id" text;--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_github_id_key" UNIQUE("github_id");--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_google_id_key" UNIQUE("google_id");

--- a/examples/blog/db/migrations/20260724131638_tearful_misty_knight/snapshot.json
+++ b/examples/blog/db/migrations/20260724131638_tearful_misty_knight/snapshot.json
@@ -1,0 +1,272 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "94447d97-45fd-4df6-a568-4f8c86b4b7c8",
+  "prevIds": [
+    "2d963231-2d88-49c8-80f1-eb7a20508b19"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "posts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "excerpt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "body",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "remember_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email_verified_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "github_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "google_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "users_email_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "author_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "posts_author_id_users_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "posts_pkey",
+      "schema": "public",
+      "table": "posts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "github_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_github_id_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "google_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_google_id_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    }
+  ],
+  "renames": []
+}

--- a/examples/blog/db/schema.ts
+++ b/examples/blog/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, text, uniqueIndex, integer } from '@guren/orm/drizzle'
+import { pgTable, serial, text, timestamp, uniqueIndex, integer } from '@guren/orm/drizzle'
 
 export const users = pgTable(
   'users',
@@ -8,6 +8,9 @@ export const users = pgTable(
     email: text('email').notNull(),
     passwordHash: text('password_hash').notNull(),
     rememberToken: text('remember_token'),
+    emailVerifiedAt: timestamp('email_verified_at', { withTimezone: false }),
+    githubId: text('github_id').unique(),
+    googleId: text('google_id').unique(),
   },
   (table) => [uniqueIndex('users_email_unique').on(table.email)],
 )

--- a/examples/blog/db/seeders/001_UsersSeeder.ts
+++ b/examples/blog/db/seeders/001_UsersSeeder.ts
@@ -13,6 +13,9 @@ export default defineSeeder(async ({ db }) => {
         name: 'Demo User',
         email: 'demo@guren.dev',
         passwordHash,
+        // Pre-verified so the seeded demo account can reach /dashboard
+        // immediately — matches the account's role as a login E2E fixture.
+        emailVerifiedAt: new Date(),
       },
     ])
     .onConflictDoNothing({ target: users.email })

--- a/examples/blog/e2e/helpers.ts
+++ b/examples/blog/e2e/helpers.ts
@@ -1,0 +1,9 @@
+import type { Page } from '@playwright/test'
+
+// Auth pages use plain controlled inputs (no useForm()), so filling a field
+// before Inertia's client hydration completes can get clobbered by React's
+// hydration reconciliation. Layout.tsx exposes data-hydrated for this.
+export async function gotoHydrated(page: Page, path: string) {
+  await page.goto(path)
+  await page.waitForSelector('main[data-hydrated="true"]')
+}

--- a/examples/blog/e2e/password-reset.spec.ts
+++ b/examples/blog/e2e/password-reset.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test'
+import { gotoHydrated } from './helpers.js'
+
+const STATUS_MESSAGE = "If an account exists for that email, we've sent a password reset link."
+
+test.describe('Password reset', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  test('forgot-password page renders the request form', async ({ page }) => {
+    await gotoHydrated(page, '/forgot-password')
+
+    await expect(page.getByRole('heading', { name: 'Forgot your password?' })).toBeVisible()
+    await expect(page.getByLabel('Email address')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Send reset link' })).toBeVisible()
+  })
+
+  test('shows the same status message for a known account', async ({ page }) => {
+    await gotoHydrated(page, '/forgot-password')
+    await page.getByLabel('Email address').fill('demo@guren.dev')
+    await page.getByRole('button', { name: 'Send reset link' }).click()
+
+    await expect(page.getByText(STATUS_MESSAGE)).toBeVisible()
+  })
+
+  test('shows the same status message for an unknown account (no enumeration)', async ({ page }) => {
+    await gotoHydrated(page, '/forgot-password')
+    await page.getByLabel('Email address').fill('nobody-at-all@example.com')
+    await page.getByRole('button', { name: 'Send reset link' }).click()
+
+    await expect(page.getByText(STATUS_MESSAGE)).toBeVisible()
+  })
+
+  test('login page links to the forgot-password page', async ({ page }) => {
+    await gotoHydrated(page, '/login')
+    await page.getByRole('link', { name: 'Forgot password?' }).click()
+    await expect(page).toHaveURL(/\/forgot-password/)
+  })
+
+  test('reset-password page renders with the token and email from the link', async ({ page }) => {
+    await gotoHydrated(page, '/reset-password?token=e2e-fake-token&email=demo@guren.dev')
+
+    await expect(page.getByRole('heading', { name: 'Reset your password' })).toBeVisible()
+    await expect(page.getByText('Choose a new password for demo@guren.dev.')).toBeVisible()
+  })
+
+  test('submitting an invalid or expired token shows an error', async ({ page }) => {
+    await gotoHydrated(page, '/reset-password?token=e2e-fake-token&email=demo@guren.dev')
+    await page.getByLabel('New password', { exact: true }).fill('newpassword123')
+    await page.getByLabel('Confirm new password').fill('newpassword123')
+    await page.getByRole('button', { name: 'Reset password' }).click()
+
+    await expect(page).toHaveURL(/\/reset-password/)
+    await expect(page.getByText('This password reset link is invalid or has expired.')).toBeVisible()
+  })
+})

--- a/examples/blog/e2e/registration.spec.ts
+++ b/examples/blog/e2e/registration.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test'
+import { gotoHydrated } from './helpers.js'
+
+test.describe('Registration', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  test('register page renders the sign-up form', async ({ page }) => {
+    await gotoHydrated(page, '/register')
+
+    await expect(page.getByRole('heading', { name: 'Create an account' })).toBeVisible()
+    await expect(page.getByLabel('Name')).toBeVisible()
+    await expect(page.getByLabel('Email address')).toBeVisible()
+    await expect(page.getByLabel('Password', { exact: true })).toBeVisible()
+    await expect(page.getByLabel('Confirm password')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Create account' })).toBeVisible()
+  })
+
+  test('registering with valid details redirects to email verification', async ({ page }) => {
+    const email = `register-${Date.now()}@example.com`
+
+    await gotoHydrated(page, '/register')
+    await page.getByLabel('Name').fill('New Author')
+    await page.getByLabel('Email address').fill(email)
+    await page.getByLabel('Password', { exact: true }).fill('password123')
+    await page.getByLabel('Confirm password').fill('password123')
+    await page.getByRole('button', { name: 'Create account' }).click()
+
+    await expect(page).toHaveURL(/\/verify-email$/)
+    await expect(page.getByRole('heading', { name: 'Verify your email' })).toBeVisible()
+  })
+
+  test('an unverified account is redirected away from /dashboard', async ({ page }) => {
+    const email = `register-gate-${Date.now()}@example.com`
+
+    await gotoHydrated(page, '/register')
+    await page.getByLabel('Name').fill('Gate Check')
+    await page.getByLabel('Email address').fill(email)
+    await page.getByLabel('Password', { exact: true }).fill('password123')
+    await page.getByLabel('Confirm password').fill('password123')
+    await page.getByRole('button', { name: 'Create account' }).click()
+    await expect(page).toHaveURL(/\/verify-email$/)
+
+    await page.goto('/dashboard')
+    await expect(page).toHaveURL(/\/verify-email$/)
+  })
+
+  test('registering with an already-used email shows a validation error', async ({ page }) => {
+    await gotoHydrated(page, '/register')
+    await page.getByLabel('Name').fill('Duplicate Demo')
+    await page.getByLabel('Email address').fill('demo@guren.dev')
+    await page.getByLabel('Password', { exact: true }).fill('password123')
+    await page.getByLabel('Confirm password').fill('password123')
+    await page.getByRole('button', { name: 'Create account' }).click()
+
+    await expect(page).toHaveURL(/\/register/)
+    await expect(page.getByText('An account with this email already exists.')).toBeVisible()
+  })
+
+  test('mismatched password confirmation shows a validation error', async ({ page }) => {
+    await gotoHydrated(page, '/register')
+    await page.getByLabel('Name').fill('Mismatch Case')
+    await page.getByLabel('Email address').fill(`mismatch-${Date.now()}@example.com`)
+    await page.getByLabel('Password', { exact: true }).fill('password123')
+    await page.getByLabel('Confirm password').fill('different456')
+    await page.getByRole('button', { name: 'Create account' }).click()
+
+    await expect(page).toHaveURL(/\/register/)
+    await expect(page.getByText('Passwords do not match.')).toBeVisible()
+  })
+
+  test('login page links to the registration page', async ({ page }) => {
+    await gotoHydrated(page, '/login')
+    await page.getByRole('link', { name: 'Sign up' }).click()
+    await expect(page).toHaveURL(/\/register/)
+  })
+})

--- a/examples/blog/playwright.config.ts
+++ b/examples/blog/playwright.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
     // Auth + route protection tests run without saved session
     {
       name: 'unauthenticated',
-      testMatch: /auth\.spec\.ts/,
+      testMatch: /(auth|registration|password-reset)\.spec\.ts/,
       use: { ...devices['Desktop Chrome'] },
     },
     // Tests that need an authenticated session

--- a/examples/blog/resources/js/components/AuthCard.tsx
+++ b/examples/blog/resources/js/components/AuthCard.tsx
@@ -1,0 +1,18 @@
+import type { PropsWithChildren, ReactNode } from 'react'
+
+interface AuthCardProps {
+  title: string
+  subtitle?: ReactNode
+}
+
+export default function AuthCard({ title, subtitle, children }: PropsWithChildren<AuthCardProps>) {
+  return (
+    <div className="w-full max-w-md space-y-8">
+      <div className="text-center">
+        <h2 className="mt-2 text-2xl font-semibold tracking-tight text-stone-900">{title}</h2>
+        {subtitle ? <p className="mt-2 text-sm text-stone-400">{subtitle}</p> : null}
+      </div>
+      <div className="rounded-lg bg-white px-6 py-8 shadow-sm sm:px-10">{children}</div>
+    </div>
+  )
+}

--- a/examples/blog/resources/js/components/AuthFormField.tsx
+++ b/examples/blog/resources/js/components/AuthFormField.tsx
@@ -1,0 +1,37 @@
+import { useId } from 'react'
+
+interface AuthFormFieldProps {
+  label: string
+  name: string
+  type?: string
+  autoComplete?: string
+  value: string
+  onChange: (value: string) => void
+  error?: string | string[]
+}
+
+export default function AuthFormField({ label, name, type = 'text', autoComplete, value, onChange, error }: AuthFormFieldProps) {
+  const id = useId()
+  const message = Array.isArray(error) ? error[0] : error
+
+  return (
+    <div>
+      <label htmlFor={id} className="block text-sm font-medium text-stone-700">
+        {label}
+      </label>
+      <div className="mt-2">
+        <input
+          id={id}
+          name={name}
+          type={type}
+          autoComplete={autoComplete}
+          required
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="block w-full rounded-md border-0 py-2.5 px-3 text-stone-900 shadow-sm ring-1 ring-inset ring-stone-200 placeholder:text-stone-300 focus:ring-2 focus:ring-inset focus:ring-stone-900 sm:text-sm sm:leading-6"
+        />
+      </div>
+      {message && <p className="mt-2 text-sm text-red-600">{message}</p>}
+    </div>
+  )
+}

--- a/examples/blog/resources/js/components/OAuthButtons.tsx
+++ b/examples/blog/resources/js/components/OAuthButtons.tsx
@@ -1,0 +1,27 @@
+const PROVIDERS = [
+  { id: 'github', label: 'GitHub' },
+  { id: 'google', label: 'Google' },
+] as const
+
+export default function OAuthButtons() {
+  return (
+    <div className="mt-6">
+      <div className="flex items-center gap-3 text-xs uppercase tracking-wide text-stone-400">
+        <span className="h-px flex-1 bg-stone-200" />
+        Or continue with
+        <span className="h-px flex-1 bg-stone-200" />
+      </div>
+      <div className="mt-4 space-y-3">
+        {PROVIDERS.map((provider) => (
+          <a
+            key={provider.id}
+            href={`/auth/${provider.id}`}
+            className="flex w-full items-center justify-center rounded-md border border-stone-200 bg-white px-4 py-2.5 text-sm font-medium text-stone-700 transition-colors hover:bg-stone-50"
+          >
+            Continue with {provider.label}
+          </a>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/examples/blog/resources/js/pages/auth/ForgotPassword.tsx
+++ b/examples/blog/resources/js/pages/auth/ForgotPassword.tsx
@@ -1,0 +1,75 @@
+import { Head, usePage } from '@inertiajs/react'
+import { useState } from 'react'
+import Layout from '../../components/Layout.js'
+import AuthCard from '../../components/AuthCard.js'
+import AuthFormField from '../../components/AuthFormField.js'
+import { Loader2 } from 'lucide-react'
+import type { RouteErrors } from '@guren/inertia-client/typed-forms'
+import type { ApiRoutes } from '@/.guren/api-client.gen'
+import { route } from '@/.guren/routes.gen'
+
+type ForgotPasswordBody = ApiRoutes['forgot-password.store']['body']
+
+interface Props {
+  errors?: RouteErrors<ForgotPasswordBody> & { message?: string }
+  status?: string
+}
+
+export default function ForgotPassword({ errors = {}, status }: Props) {
+  const { props } = usePage<{ csrfToken?: string }>()
+  const [email, setEmail] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleSubmit = () => {
+    setIsLoading(true)
+  }
+
+  return (
+    <Layout
+      wrapperClassName="flex flex-col"
+      mainClassName="flex-1 flex items-center justify-center w-full max-w-none px-4 sm:px-6 lg:px-8 pt-10 pb-16"
+    >
+      <Head title="Forgot password" />
+
+      <AuthCard title="Forgot your password?" subtitle="Enter your email and we'll send you a link to reset it.">
+        {status && (
+          <div className="mb-6 rounded-md bg-stone-50 border border-stone-200 p-4 text-sm text-stone-600">
+            {status}
+          </div>
+        )}
+
+        {errors.message && (
+          <div className="mb-6 rounded-md bg-red-50 border border-red-200 p-4 text-sm text-red-700">
+            {errors.message}
+          </div>
+        )}
+
+        <form method="post" action={route('forgot-password.store')} className="space-y-6" onSubmit={handleSubmit}>
+          {props.csrfToken && <input type="hidden" name="_token" value={props.csrfToken} />}
+          <AuthFormField
+            label="Email address"
+            name="email"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={setEmail}
+            error={errors.email}
+          />
+
+          <div>
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="flex w-full justify-center rounded-md bg-guren-600 px-3 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-guren-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-guren-600 disabled:opacity-70 disabled:cursor-not-allowed"
+            >
+              {isLoading ? (
+                <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+              ) : null}
+              Send reset link
+            </button>
+          </div>
+        </form>
+      </AuthCard>
+    </Layout>
+  )
+}

--- a/examples/blog/resources/js/pages/auth/Login.tsx
+++ b/examples/blog/resources/js/pages/auth/Login.tsx
@@ -5,6 +5,7 @@ import { Loader2 } from 'lucide-react'
 import type { RouteErrors } from '@guren/inertia-client/typed-forms'
 import type { ApiRoutes } from '@/.guren/api-client.gen'
 import { route } from '@/.guren/routes.gen'
+import OAuthButtons from '../../components/OAuthButtons.js'
 
 type LoginBody = ApiRoutes['login.store']['body']
 
@@ -49,9 +50,9 @@ export default function Login({ email: initialEmail = '', errors = {} }: Props) 
             Sign in to your account
           </h2>
           <p className="mt-2 text-sm text-stone-400">
-            Or{' '}
-            <Link href="/register" className="font-medium text-stone-600 hover:text-stone-900">
-              contact your administrator
+            Don&apos;t have an account?{' '}
+            <Link href={route('register')} className="font-medium text-stone-600 hover:text-stone-900">
+              Sign up
             </Link>
           </p>
         </div>
@@ -124,9 +125,9 @@ export default function Login({ email: initialEmail = '', errors = {} }: Props) 
               </div>
 
               <div className="text-sm">
-                <a href="#" className="font-medium text-stone-500 hover:text-stone-700">
+                <Link href={route('forgot-password')} className="font-medium text-stone-500 hover:text-stone-700">
                   Forgot password?
-                </a>
+                </Link>
               </div>
             </div>
 
@@ -143,6 +144,8 @@ export default function Login({ email: initialEmail = '', errors = {} }: Props) 
               </button>
             </div>
           </form>
+
+          <OAuthButtons />
         </div>
       </div>
     </Layout>

--- a/examples/blog/resources/js/pages/auth/Register.tsx
+++ b/examples/blog/resources/js/pages/auth/Register.tsx
@@ -1,0 +1,103 @@
+import { Head, Link, usePage } from '@inertiajs/react'
+import { useState } from 'react'
+import Layout from '../../components/Layout.js'
+import AuthCard from '../../components/AuthCard.js'
+import AuthFormField from '../../components/AuthFormField.js'
+import { Loader2 } from 'lucide-react'
+import type { RouteErrors } from '@guren/inertia-client/typed-forms'
+import type { ApiRoutes } from '@/.guren/api-client.gen'
+import { route } from '@/.guren/routes.gen'
+import OAuthButtons from '../../components/OAuthButtons.js'
+
+type RegisterBody = ApiRoutes['register.store']['body']
+
+interface Props {
+  errors?: RouteErrors<RegisterBody> & { message?: string }
+}
+
+export default function Register({ errors = {} }: Props) {
+  const { props } = usePage<{ csrfToken?: string }>()
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [passwordConfirmation, setPasswordConfirmation] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleSubmit = () => {
+    setIsLoading(true)
+  }
+
+  return (
+    <Layout
+      wrapperClassName="flex flex-col"
+      mainClassName="flex-1 flex items-center justify-center w-full max-w-none px-4 sm:px-6 lg:px-8 pt-10 pb-16"
+    >
+      <Head title="Sign up" />
+
+      <AuthCard
+        title="Create an account"
+        subtitle={
+          <>
+            Already have an account?{' '}
+            <Link href={route('login')} className="font-medium text-stone-600 hover:text-stone-900">
+              Sign in
+            </Link>
+          </>
+        }
+      >
+        {errors.message && (
+          <div className="mb-6 rounded-md bg-red-50 border border-red-200 p-4 text-sm text-red-700">
+            {errors.message}
+          </div>
+        )}
+
+        <form method="post" action={route('register.store')} className="space-y-6" onSubmit={handleSubmit}>
+          {props.csrfToken && <input type="hidden" name="_token" value={props.csrfToken} />}
+          <AuthFormField label="Name" name="name" autoComplete="name" value={name} onChange={setName} error={errors.name} />
+          <AuthFormField
+            label="Email address"
+            name="email"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={setEmail}
+            error={errors.email}
+          />
+          <AuthFormField
+            label="Password"
+            name="password"
+            type="password"
+            autoComplete="new-password"
+            value={password}
+            onChange={setPassword}
+            error={errors.password}
+          />
+          <AuthFormField
+            label="Confirm password"
+            name="passwordConfirmation"
+            type="password"
+            autoComplete="new-password"
+            value={passwordConfirmation}
+            onChange={setPasswordConfirmation}
+            error={errors.passwordConfirmation}
+          />
+
+          <div>
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="flex w-full justify-center rounded-md bg-guren-600 px-3 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-guren-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-guren-600 disabled:opacity-70 disabled:cursor-not-allowed"
+            >
+              {isLoading ? (
+                <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+              ) : null}
+              Create account
+            </button>
+          </div>
+        </form>
+
+        <OAuthButtons />
+      </AuthCard>
+    </Layout>
+  )
+}

--- a/examples/blog/resources/js/pages/auth/ResetPassword.tsx
+++ b/examples/blog/resources/js/pages/auth/ResetPassword.tsx
@@ -1,0 +1,81 @@
+import { Head, usePage } from '@inertiajs/react'
+import { useState } from 'react'
+import Layout from '../../components/Layout.js'
+import AuthCard from '../../components/AuthCard.js'
+import AuthFormField from '../../components/AuthFormField.js'
+import { Loader2 } from 'lucide-react'
+import type { RouteErrors } from '@guren/inertia-client/typed-forms'
+import type { ApiRoutes } from '@/.guren/api-client.gen'
+import { route } from '@/.guren/routes.gen'
+
+type ResetPasswordBody = ApiRoutes['reset-password.store']['body']
+
+interface Props {
+  token: string
+  email: string
+  errors?: RouteErrors<ResetPasswordBody> & { message?: string }
+}
+
+export default function ResetPassword({ token, email, errors = {} }: Props) {
+  const { props } = usePage<{ csrfToken?: string }>()
+  const [password, setPassword] = useState('')
+  const [passwordConfirmation, setPasswordConfirmation] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleSubmit = () => {
+    setIsLoading(true)
+  }
+
+  return (
+    <Layout
+      wrapperClassName="flex flex-col"
+      mainClassName="flex-1 flex items-center justify-center w-full max-w-none px-4 sm:px-6 lg:px-8 pt-10 pb-16"
+    >
+      <Head title="Reset password" />
+
+      <AuthCard title="Reset your password" subtitle={email ? `Choose a new password for ${email}.` : undefined}>
+        {(errors.token || errors.message) && (
+          <div className="mb-6 rounded-md bg-red-50 border border-red-200 p-4 text-sm text-red-700">
+            {errors.token ?? errors.message}
+          </div>
+        )}
+
+        <form method="post" action={route('reset-password.store')} className="space-y-6" onSubmit={handleSubmit}>
+          {props.csrfToken && <input type="hidden" name="_token" value={props.csrfToken} />}
+          <input type="hidden" name="token" value={token} />
+          <AuthFormField
+            label="New password"
+            name="password"
+            type="password"
+            autoComplete="new-password"
+            value={password}
+            onChange={setPassword}
+            error={errors.password}
+          />
+          <AuthFormField
+            label="Confirm new password"
+            name="passwordConfirmation"
+            type="password"
+            autoComplete="new-password"
+            value={passwordConfirmation}
+            onChange={setPasswordConfirmation}
+            error={errors.passwordConfirmation}
+          />
+
+          <div>
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="flex w-full justify-center rounded-md bg-guren-600 px-3 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-guren-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-guren-600 disabled:opacity-70 disabled:cursor-not-allowed"
+            >
+              {isLoading ? (
+                <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+              ) : null}
+              Reset password
+            </button>
+          </div>
+        </form>
+      </AuthCard>
+    </Layout>
+  )
+}

--- a/examples/blog/resources/js/pages/auth/VerifyEmail.tsx
+++ b/examples/blog/resources/js/pages/auth/VerifyEmail.tsx
@@ -1,0 +1,53 @@
+import { Head, usePage } from '@inertiajs/react'
+import { useState } from 'react'
+import Layout from '../../components/Layout.js'
+import AuthCard from '../../components/AuthCard.js'
+import { Loader2 } from 'lucide-react'
+import { route } from '@/.guren/routes.gen'
+
+interface Props {
+  status?: string
+}
+
+export default function VerifyEmail({ status }: Props) {
+  const { props } = usePage<{ csrfToken?: string }>()
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleSubmit = () => {
+    setIsLoading(true)
+  }
+
+  return (
+    <Layout
+      wrapperClassName="flex flex-col"
+      mainClassName="flex-1 flex items-center justify-center w-full max-w-none px-4 sm:px-6 lg:px-8 pt-10 pb-16"
+    >
+      <Head title="Verify email" />
+
+      <AuthCard
+        title="Verify your email"
+        subtitle="We sent a verification link to your email address. Click it to activate your account."
+      >
+        {status && (
+          <div className="mb-6 rounded-md bg-stone-50 border border-stone-200 p-4 text-sm text-stone-600">
+            {status}
+          </div>
+        )}
+
+        <form method="post" action={route('verify-email.resend')} onSubmit={handleSubmit}>
+          {props.csrfToken && <input type="hidden" name="_token" value={props.csrfToken} />}
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="flex w-full justify-center rounded-md bg-guren-600 px-3 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-guren-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-guren-600 disabled:opacity-70 disabled:cursor-not-allowed"
+          >
+            {isLoading ? (
+              <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+            ) : null}
+            Resend verification email
+          </button>
+        </form>
+      </AuthCard>
+    </Layout>
+  )
+}

--- a/examples/blog/routes/auth.ts
+++ b/examples/blog/routes/auth.ts
@@ -1,0 +1,56 @@
+import { Router, requireVerifiedEmail } from '@guren/core'
+import LoginController from '../app/Http/Controllers/Auth/LoginController.js'
+import RegisterController from '../app/Http/Controllers/Auth/RegisterController.js'
+import ForgotPasswordController from '../app/Http/Controllers/Auth/ForgotPasswordController.js'
+import ResetPasswordController from '../app/Http/Controllers/Auth/ResetPasswordController.js'
+import VerifyEmailController from '../app/Http/Controllers/Auth/VerifyEmailController.js'
+import OAuthController from '../app/Http/Controllers/Auth/OAuthController.js'
+import DashboardController from '../app/Http/Controllers/DashboardController.js'
+import ProfileController from '../app/Http/Controllers/ProfileController.js'
+import { LoginSchema } from '../app/Http/Validators/LoginValidator.js'
+import { RegisterSchema } from '../app/Http/Validators/RegisterValidator.js'
+import { ForgotPasswordSchema } from '../app/Http/Validators/ForgotPasswordValidator.js'
+import { ResetPasswordSchema } from '../app/Http/Validators/ResetPasswordValidator.js'
+import { ProfileUpdateSchema } from '../app/Http/Validators/ProfileValidator.js'
+
+// Relies on the 'auth'/'guest' aliases the caller (routes/web.ts) has
+// already registered on this router via aliasMiddleware() — reusing them
+// (via .group(), not direct .middleware(name).post() chaining, since the
+// latter's RouterMiddlewareGroupBuilder doesn't support the
+// [Controller, 'method'] tuple + typed body-schema combination) keeps this
+// middleware visible to `guren audit`'s static route inspection, unlike
+// passing requireAuthenticated()/requireGuest() call results inline.
+export function registerAuthRoutes(router: Router<'auth' | 'guest'>): void {
+  router.middleware('guest').group((guest) => {
+    guest.get('/login', { name: 'login' }, [LoginController, 'show'])
+    guest.post('/login', { name: 'login.store', body: LoginSchema }, [LoginController, 'store'])
+
+    guest.get('/register', { name: 'register' }, [RegisterController, 'show'])
+    guest.post('/register', { name: 'register.store', body: RegisterSchema }, [RegisterController, 'store'])
+
+    guest.get('/forgot-password', { name: 'forgot-password' }, [ForgotPasswordController, 'show'])
+    guest.post('/forgot-password', { name: 'forgot-password.store', body: ForgotPasswordSchema }, [ForgotPasswordController, 'store'])
+    guest.get('/reset-password', { name: 'reset-password' }, [ResetPasswordController, 'show'])
+    guest.post('/reset-password', { name: 'reset-password.store', body: ResetPasswordSchema }, [ResetPasswordController, 'store'])
+
+    guest.get('/auth/:provider', { name: 'oauth.redirect' }, [OAuthController, 'redirectToProvider'])
+  })
+
+  router.middleware('auth').group((authed) => {
+    authed.post('/logout', { name: 'logout' }, [LoginController, 'destroy'])
+
+    authed.get('/verify-email', { name: 'verify-email' }, [VerifyEmailController, 'notice'])
+    authed.post('/verify-email', { name: 'verify-email.resend' }, [VerifyEmailController, 'resend'])
+    authed.get('/verify-email/confirm', { name: 'verify-email.confirm' }, [VerifyEmailController, 'confirm'])
+
+    authed
+      .get('/dashboard', [DashboardController, 'index'], requireVerifiedEmail({ redirectTo: '/verify-email' }))
+      .name('dashboard')
+    authed.get('/profile', { name: 'profile.edit' }, [ProfileController, 'edit'])
+    authed.put('/profile', { name: 'profile.update', body: ProfileUpdateSchema }, [ProfileController, 'update'])
+    authed.patch('/profile', { name: 'profile.patch', body: ProfileUpdateSchema }, [ProfileController, 'update'])
+  })
+
+  // Public: the OAuth provider redirects here directly, before any session exists.
+  router.get('/auth/:provider/callback', { name: 'oauth.callback' }, [OAuthController, 'callback'])
+}

--- a/examples/blog/routes/auth.ts
+++ b/examples/blog/routes/auth.ts
@@ -41,7 +41,6 @@ export function registerAuthRoutes(router: Router<'auth' | 'guest'>): void {
 
     authed.get('/verify-email', { name: 'verify-email' }, [VerifyEmailController, 'notice'])
     authed.post('/verify-email', { name: 'verify-email.resend' }, [VerifyEmailController, 'resend'])
-    authed.get('/verify-email/confirm', { name: 'verify-email.confirm' }, [VerifyEmailController, 'confirm'])
 
     authed
       .get('/dashboard', [DashboardController, 'index'], requireVerifiedEmail({ redirectTo: '/verify-email' }))
@@ -53,4 +52,9 @@ export function registerAuthRoutes(router: Router<'auth' | 'guest'>): void {
 
   // Public: the OAuth provider redirects here directly, before any session exists.
   router.get('/auth/:provider/callback', { name: 'oauth.callback' }, [OAuthController, 'callback'])
+
+  // Public: confirm() validates the signed token itself and doesn't use the
+  // session — gating it behind auth would strand a user who opens the email
+  // link from a different device or after their session expired.
+  router.get('/verify-email/confirm', { name: 'verify-email.confirm' }, [VerifyEmailController, 'confirm'])
 }

--- a/examples/blog/routes/web.ts
+++ b/examples/blog/routes/web.ts
@@ -1,12 +1,8 @@
 import { Router, requireAuthenticated, requireGuest } from '@guren/core'
 import PostController from '../app/Http/Controllers/PostController.js'
-import LoginController from '../app/Http/Controllers/Auth/LoginController.js'
-import DashboardController from '../app/Http/Controllers/DashboardController.js'
-import ProfileController from '../app/Http/Controllers/ProfileController.js'
 import { Post } from '../app/Models/Post.js'
 import { PostPayloadSchema } from '../app/Http/Validators/PostValidator.js'
-import { LoginSchema } from '../app/Http/Validators/LoginValidator.js'
-import { ProfileUpdateSchema } from '../app/Http/Validators/ProfileValidator.js'
+import { registerAuthRoutes } from './auth.js'
 
 export function registerWebRoutes(baseRouter: Router): void {
   const router = baseRouter
@@ -15,9 +11,7 @@ export function registerWebRoutes(baseRouter: Router): void {
 
   router.get('/', [PostController, 'index']).name('home')
 
-  router.middleware('guest').get('/login', [LoginController, 'show']).name('login')
-  router.post('/login', { name: 'login.store', body: LoginSchema }, [LoginController, 'store'])
-  router.middleware('auth').post('/logout', [LoginController, 'destroy']).name('logout')
+  registerAuthRoutes(router)
 
   router.group('/posts', (posts) => {
     posts.get('/', [PostController, 'index']).name('posts.index')
@@ -29,12 +23,5 @@ export function registerWebRoutes(baseRouter: Router): void {
       authed.put('/:id', { bind: { id: Post }, name: 'posts.update', body: PostPayloadSchema }, [PostController, 'update'])
       authed.patch('/:id', { bind: { id: Post }, name: 'posts.patch', body: PostPayloadSchema }, [PostController, 'update'])
     })
-  })
-
-  router.middleware('auth').group((authed) => {
-    authed.get('/dashboard', [DashboardController, 'index']).name('dashboard')
-    authed.get('/profile', [ProfileController, 'edit']).name('profile.edit')
-    authed.put('/profile', { name: 'profile.update', body: ProfileUpdateSchema }, [ProfileController, 'update'])
-    authed.patch('/profile', { name: 'profile.patch', body: ProfileUpdateSchema }, [ProfileController, 'update'])
   })
 }

--- a/examples/blog/src/app.ts
+++ b/examples/blog/src/app.ts
@@ -3,12 +3,14 @@ import {
   ErrorServiceProvider,
   InertiaServiceProvider,
   AuthServiceProvider as CoreAuthServiceProvider,
+  OAuthServiceProvider as CoreOAuthServiceProvider,
   NotificationServiceProvider as CoreNotificationServiceProvider,
   StorageServiceProvider as CoreStorageServiceProvider,
   BroadcastServiceProvider as CoreBroadcastServiceProvider,
 } from '@guren/core'
 import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
 import AuthProvider from '../app/Providers/AuthProvider.js'
+import OAuthProvider from '../app/Providers/OAuthProvider.js'
 import CacheProvider from '../app/Providers/CacheProvider.js'
 import requestLogger from '../app/Http/middleware/requestLogger.js'
 import EventServiceProvider from '../app/Providers/EventServiceProvider.js'
@@ -29,6 +31,8 @@ const app = createApp({
     CoreAuthServiceProvider,
     DatabaseProvider,
     AuthProvider,
+    CoreOAuthServiceProvider,
+    OAuthProvider,
     CacheProvider,
     CoreNotificationServiceProvider,
     NotificationProvider,

--- a/examples/blog/tests/controllers/ForgotPasswordController.test.ts
+++ b/examples/blog/tests/controllers/ForgotPasswordController.test.ts
@@ -6,17 +6,17 @@ import {
 } from '@guren/testing'
 import type { Context } from '@guren/core'
 
-const { mockUserWhere, mockSendPasswordResetMail } = vi.hoisted(() => ({
+const { mockUserWhere, mockDispatch } = vi.hoisted(() => ({
   mockUserWhere: vi.fn(),
-  mockSendPasswordResetMail: vi.fn(),
+  mockDispatch: vi.fn(),
 }))
 
 vi.mock('../../app/Models/User.js', () => ({
   User: { where: mockUserWhere },
 }))
 
-vi.mock('../../app/Mail/PasswordResetMail.js', () => ({
-  sendPasswordResetMail: mockSendPasswordResetMail,
+vi.mock('../../app/Jobs/SendPasswordResetEmailJob.js', () => ({
+  SendPasswordResetEmailJob: { dispatch: mockDispatch },
 }))
 
 vi.mock('guren', () => createControllerModuleMock())
@@ -50,7 +50,7 @@ describe('ForgotPasswordController', () => {
 
   it('sends a reset email when the account exists', async () => {
     mockUserWhere.mockResolvedValue([{ id: 1, email: 'ada@example.com' }])
-    mockSendPasswordResetMail.mockResolvedValue(undefined)
+    mockDispatch.mockResolvedValue('job-id')
 
     const controller = new ForgotPasswordController()
     const ctx = createControllerContext('http://blog.test/forgot-password', {
@@ -63,7 +63,7 @@ describe('ForgotPasswordController', () => {
     const response = await controller.store()
     const { payload } = await readInertiaResponse(response)
 
-    expect(mockSendPasswordResetMail).toHaveBeenCalled()
+    expect(mockDispatch).toHaveBeenCalledWith(expect.objectContaining({ email: 'ada@example.com' }))
     expect(payload.props.status).toBe(STATUS_MESSAGE)
   })
 
@@ -81,7 +81,7 @@ describe('ForgotPasswordController', () => {
     const response = await controller.store()
     const { payload } = await readInertiaResponse(response)
 
-    expect(mockSendPasswordResetMail).not.toHaveBeenCalled()
+    expect(mockDispatch).not.toHaveBeenCalled()
     expect(payload.props.status).toBe(STATUS_MESSAGE)
   })
 })

--- a/examples/blog/tests/controllers/ForgotPasswordController.test.ts
+++ b/examples/blog/tests/controllers/ForgotPasswordController.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createControllerContext,
+  createControllerModuleMock,
+  readInertiaResponse,
+} from '@guren/testing'
+import type { Context } from '@guren/core'
+
+const { mockUserWhere, mockSendPasswordResetMail } = vi.hoisted(() => ({
+  mockUserWhere: vi.fn(),
+  mockSendPasswordResetMail: vi.fn(),
+}))
+
+vi.mock('../../app/Models/User.js', () => ({
+  User: { where: mockUserWhere },
+}))
+
+vi.mock('../../app/Mail/PasswordResetMail.js', () => ({
+  sendPasswordResetMail: mockSendPasswordResetMail,
+}))
+
+vi.mock('guren', () => createControllerModuleMock())
+vi.mock('@guren/core', async () => {
+  const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
+  return {
+    ...actual,
+    ...createControllerModuleMock(),
+    ServiceProvider: actual.ServiceProvider,
+  }
+})
+
+import ForgotPasswordController from '../../app/Http/Controllers/Auth/ForgotPasswordController.js'
+
+const STATUS_MESSAGE = "If an account exists for that email, we've sent a password reset link."
+
+describe('ForgotPasswordController', () => {
+  it('renders the forgot-password form', async () => {
+    const controller = new ForgotPasswordController()
+    const ctx = createControllerContext('http://blog.test/forgot-password', {
+      headers: { 'X-Inertia': 'true' },
+    }) as unknown as Context
+    controller.setContext(ctx)
+
+    const response = await controller.show()
+    const { payload } = await readInertiaResponse(response)
+
+    expect(response.status).toBe(200)
+    expect(payload.component).toBe('auth/ForgotPassword')
+  })
+
+  it('sends a reset email when the account exists', async () => {
+    mockUserWhere.mockResolvedValue([{ id: 1, email: 'ada@example.com' }])
+    mockSendPasswordResetMail.mockResolvedValue(undefined)
+
+    const controller = new ForgotPasswordController()
+    const ctx = createControllerContext('http://blog.test/forgot-password', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'ada@example.com' }),
+      headers: { 'Content-Type': 'application/json' },
+    }) as unknown as Context
+    controller.setContext(ctx)
+
+    const response = await controller.store()
+    const { payload } = await readInertiaResponse(response)
+
+    expect(mockSendPasswordResetMail).toHaveBeenCalled()
+    expect(payload.props.status).toBe(STATUS_MESSAGE)
+  })
+
+  it('returns the same status message when the account does not exist, without sending mail', async () => {
+    mockUserWhere.mockResolvedValue([])
+
+    const controller = new ForgotPasswordController()
+    const ctx = createControllerContext('http://blog.test/forgot-password', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'nobody@example.com' }),
+      headers: { 'Content-Type': 'application/json' },
+    }) as unknown as Context
+    controller.setContext(ctx)
+
+    const response = await controller.store()
+    const { payload } = await readInertiaResponse(response)
+
+    expect(mockSendPasswordResetMail).not.toHaveBeenCalled()
+    expect(payload.props.status).toBe(STATUS_MESSAGE)
+  })
+})

--- a/examples/blog/tests/controllers/OAuthController.test.ts
+++ b/examples/blog/tests/controllers/OAuthController.test.ts
@@ -104,7 +104,12 @@ describe('OAuthController', () => {
       const response = await controller.callback()
 
       expect(mockUserCreate).toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'New Person', email: 'new@example.com', githubId: 'gh-2' }),
+        expect.objectContaining({
+          name: 'New Person',
+          email: 'new@example.com',
+          githubId: 'gh-2',
+          emailVerifiedAt: expect.any(Date),
+        }),
       )
       expect(response.status).toBe(302)
       expect(response.headers.get('Location')).toBe('/dashboard')

--- a/examples/blog/tests/controllers/OAuthController.test.ts
+++ b/examples/blog/tests/controllers/OAuthController.test.ts
@@ -134,22 +134,14 @@ describe('OAuthController', () => {
       expect(mockUserCreate).not.toHaveBeenCalled()
     })
 
-    it('falls back to the GitHub /user/emails endpoint when the profile email is private', async () => {
+    it('lowercases the provider email before matching and creating accounts', async () => {
       const oauth = createOAuthStub()
       oauth.handleCallback.mockResolvedValue({
-        profile: { id: 'gh-5', email: undefined, name: 'Private Email', token: { accessToken: 'gh-token-abc' } },
+        profile: { id: 'gh-5', email: 'Mixed@Example.com', name: 'Mixed Case' },
         redirectTo: null,
       })
       mockUserWhere.mockResolvedValue([])
-      mockUserCreate.mockResolvedValue({ id: 3, email: 'private@example.com', githubId: 'gh-5' })
-      const fetchMock = vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => [
-          { email: 'secondary@example.com', primary: false, verified: true },
-          { email: 'Private@Example.com', primary: true, verified: true },
-        ],
-      })
-      vi.stubGlobal('fetch', fetchMock)
+      mockUserCreate.mockResolvedValue({ id: 3, email: 'mixed@example.com', githubId: 'gh-5' })
 
       const controller = createController()
       const ctx = createControllerContext('http://blog.test/auth/github/callback?code=abc&state=xyz', {}, { oauth }) as unknown as Context
@@ -158,23 +150,16 @@ describe('OAuthController', () => {
 
       const response = await controller.callback()
 
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://api.github.com/user/emails',
-        expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer gh-token-abc' }) }),
-      )
-      expect(mockUserCreate).toHaveBeenCalledWith(expect.objectContaining({ email: 'private@example.com' }))
+      expect(mockUserCreate).toHaveBeenCalledWith(expect.objectContaining({ email: 'mixed@example.com' }))
       expect(response.status).toBe(302)
-
-      vi.unstubAllGlobals()
     })
 
     it('rejects when the provider does not return an email address', async () => {
       const oauth = createOAuthStub()
       oauth.handleCallback.mockResolvedValue({
-        profile: { id: 'gh-4', email: undefined, name: 'No Email', token: { accessToken: 'gh-token-abc' } },
+        profile: { id: 'gh-4', email: undefined, name: 'No Email' },
         redirectTo: null,
       })
-      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => [] }))
 
       const controller = createController()
       const ctx = createControllerContext('http://blog.test/auth/github/callback?code=abc&state=xyz', {}, { oauth }) as unknown as Context
@@ -182,8 +167,6 @@ describe('OAuthController', () => {
       ;(ctx as unknown as { req: { param: () => Record<string, string> } }).req.param = () => ({ provider: 'github' })
 
       await expect(controller.callback()).rejects.toThrow()
-
-      vi.unstubAllGlobals()
     })
   })
 })

--- a/examples/blog/tests/controllers/OAuthController.test.ts
+++ b/examples/blog/tests/controllers/OAuthController.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createControllerContext,
+  createControllerModuleMock,
+  readInertiaResponse,
+} from '@guren/testing'
+import type { Context } from '@guren/core'
+
+const { mockUserWhere, mockUserCreate } = vi.hoisted(() => ({
+  mockUserWhere: vi.fn(),
+  mockUserCreate: vi.fn(),
+}))
+
+vi.mock('../../app/Models/User.js', () => ({
+  User: {
+    where: mockUserWhere,
+    create: mockUserCreate,
+  },
+}))
+
+vi.mock('guren', () => createControllerModuleMock())
+vi.mock('@guren/core', async () => {
+  const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
+  return {
+    ...actual,
+    ...createControllerModuleMock(),
+    ServiceProvider: actual.ServiceProvider,
+  }
+})
+
+import OAuthController from '../../app/Http/Controllers/Auth/OAuthController.js'
+
+function createOAuthStub() {
+  return {
+    authorize: vi.fn().mockResolvedValue({ url: 'https://github.com/login/oauth/authorize?client_id=abc' }),
+    handleCallback: vi.fn(),
+  }
+}
+
+function createController() {
+  const controller = new OAuthController()
+  Object.defineProperty(controller, 'auth', {
+    value: {
+      session: vi.fn().mockReturnValue({ regenerate: vi.fn() }),
+      login: vi.fn().mockResolvedValue(undefined),
+    },
+    configurable: true,
+  })
+  return controller
+}
+
+describe('OAuthController', () => {
+  describe('redirectToProvider()', () => {
+    it('redirects to the provider authorization URL', async () => {
+      const oauth = createOAuthStub()
+      const controller = createController()
+      const ctx = createControllerContext('http://blog.test/auth/github', {}, { oauth }) as unknown as Context
+      controller.setContext(ctx)
+      ;(ctx as unknown as { req: { param: () => Record<string, string> } }).req.param = () => ({ provider: 'github' })
+
+      const response = await controller.redirectToProvider()
+
+      expect(oauth.authorize).toHaveBeenCalledWith('github', { redirectTo: undefined })
+      expect(response.status).toBe(302)
+      expect(response.headers.get('Location')).toBe('https://github.com/login/oauth/authorize?client_id=abc')
+    })
+  })
+
+  describe('callback()', () => {
+    it('logs in an existing user matched by provider identity', async () => {
+      const oauth = createOAuthStub()
+      oauth.handleCallback.mockResolvedValue({
+        profile: { id: 'gh-1', email: 'ada@example.com', name: 'Ada' },
+        redirectTo: null,
+      })
+      mockUserWhere.mockResolvedValue([{ id: 1, email: 'ada@example.com', githubId: 'gh-1' }])
+
+      const controller = createController()
+      const ctx = createControllerContext('http://blog.test/auth/github/callback?code=abc&state=xyz', {}, { oauth }) as unknown as Context
+      controller.setContext(ctx)
+      ;(ctx as unknown as { req: { param: () => Record<string, string> } }).req.param = () => ({ provider: 'github' })
+
+      const response = await controller.callback()
+
+      expect(mockUserCreate).not.toHaveBeenCalled()
+      expect(response.status).toBe(302)
+      expect(response.headers.get('Location')).toBe('/dashboard')
+    })
+
+    it('creates a new account when no existing user matches', async () => {
+      const oauth = createOAuthStub()
+      oauth.handleCallback.mockResolvedValue({
+        profile: { id: 'gh-2', email: 'new@example.com', name: 'New Person' },
+        redirectTo: null,
+      })
+      mockUserWhere.mockResolvedValue([])
+      mockUserCreate.mockResolvedValue({ id: 2, email: 'new@example.com', githubId: 'gh-2' })
+
+      const controller = createController()
+      const ctx = createControllerContext('http://blog.test/auth/github/callback?code=abc&state=xyz', {}, { oauth }) as unknown as Context
+      controller.setContext(ctx)
+      ;(ctx as unknown as { req: { param: () => Record<string, string> } }).req.param = () => ({ provider: 'github' })
+
+      const response = await controller.callback()
+
+      expect(mockUserCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'New Person', email: 'new@example.com', githubId: 'gh-2' }),
+      )
+      expect(response.status).toBe(302)
+      expect(response.headers.get('Location')).toBe('/dashboard')
+    })
+
+    it('rejects when an account with the same email already exists under a different identity', async () => {
+      const oauth = createOAuthStub()
+      oauth.handleCallback.mockResolvedValue({
+        profile: { id: 'gh-3', email: 'existing@example.com', name: 'Existing' },
+        redirectTo: null,
+      })
+      mockUserWhere
+        .mockResolvedValueOnce([]) // no match by githubId
+        .mockResolvedValueOnce([{ id: 9, email: 'existing@example.com' }]) // match by email
+
+      const controller = createController()
+      const ctx = createControllerContext('http://blog.test/auth/github/callback?code=abc&state=xyz', {}, { oauth }) as unknown as Context
+      controller.setContext(ctx)
+      ;(ctx as unknown as { req: { param: () => Record<string, string> } }).req.param = () => ({ provider: 'github' })
+
+      await expect(controller.callback()).rejects.toThrow()
+      expect(mockUserCreate).not.toHaveBeenCalled()
+    })
+
+    it('rejects when the provider does not return an email address', async () => {
+      const oauth = createOAuthStub()
+      oauth.handleCallback.mockResolvedValue({
+        profile: { id: 'gh-4', email: undefined, name: 'No Email' },
+        redirectTo: null,
+      })
+
+      const controller = createController()
+      const ctx = createControllerContext('http://blog.test/auth/github/callback?code=abc&state=xyz', {}, { oauth }) as unknown as Context
+      controller.setContext(ctx)
+      ;(ctx as unknown as { req: { param: () => Record<string, string> } }).req.param = () => ({ provider: 'github' })
+
+      await expect(controller.callback()).rejects.toThrow()
+    })
+  })
+})

--- a/examples/blog/tests/controllers/OAuthController.test.ts
+++ b/examples/blog/tests/controllers/OAuthController.test.ts
@@ -129,12 +129,47 @@ describe('OAuthController', () => {
       expect(mockUserCreate).not.toHaveBeenCalled()
     })
 
+    it('falls back to the GitHub /user/emails endpoint when the profile email is private', async () => {
+      const oauth = createOAuthStub()
+      oauth.handleCallback.mockResolvedValue({
+        profile: { id: 'gh-5', email: undefined, name: 'Private Email', token: { accessToken: 'gh-token-abc' } },
+        redirectTo: null,
+      })
+      mockUserWhere.mockResolvedValue([])
+      mockUserCreate.mockResolvedValue({ id: 3, email: 'private@example.com', githubId: 'gh-5' })
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { email: 'secondary@example.com', primary: false, verified: true },
+          { email: 'Private@Example.com', primary: true, verified: true },
+        ],
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const controller = createController()
+      const ctx = createControllerContext('http://blog.test/auth/github/callback?code=abc&state=xyz', {}, { oauth }) as unknown as Context
+      controller.setContext(ctx)
+      ;(ctx as unknown as { req: { param: () => Record<string, string> } }).req.param = () => ({ provider: 'github' })
+
+      const response = await controller.callback()
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.github.com/user/emails',
+        expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer gh-token-abc' }) }),
+      )
+      expect(mockUserCreate).toHaveBeenCalledWith(expect.objectContaining({ email: 'private@example.com' }))
+      expect(response.status).toBe(302)
+
+      vi.unstubAllGlobals()
+    })
+
     it('rejects when the provider does not return an email address', async () => {
       const oauth = createOAuthStub()
       oauth.handleCallback.mockResolvedValue({
-        profile: { id: 'gh-4', email: undefined, name: 'No Email' },
+        profile: { id: 'gh-4', email: undefined, name: 'No Email', token: { accessToken: 'gh-token-abc' } },
         redirectTo: null,
       })
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => [] }))
 
       const controller = createController()
       const ctx = createControllerContext('http://blog.test/auth/github/callback?code=abc&state=xyz', {}, { oauth }) as unknown as Context
@@ -142,6 +177,8 @@ describe('OAuthController', () => {
       ;(ctx as unknown as { req: { param: () => Record<string, string> } }).req.param = () => ({ provider: 'github' })
 
       await expect(controller.callback()).rejects.toThrow()
+
+      vi.unstubAllGlobals()
     })
   })
 })

--- a/examples/blog/tests/controllers/ProfileController.test.ts
+++ b/examples/blog/tests/controllers/ProfileController.test.ts
@@ -6,10 +6,11 @@ import {
 } from '@guren/testing'
 import type { Context } from '@guren/core'
 
-const { mockUserWhere, mockUserUpdate, mockUserFind } = vi.hoisted(() => ({
+const { mockUserWhere, mockUserUpdate, mockUserFind, mockSendEmailVerificationMail } = vi.hoisted(() => ({
   mockUserWhere: vi.fn(),
   mockUserUpdate: vi.fn(),
   mockUserFind: vi.fn(),
+  mockSendEmailVerificationMail: vi.fn(),
 }))
 
 vi.mock('../../app/Models/User.js', () => ({
@@ -18,6 +19,10 @@ vi.mock('../../app/Models/User.js', () => ({
     update: mockUserUpdate,
     find: mockUserFind,
   },
+}))
+
+vi.mock('../../app/Mail/EmailVerificationMail.js', () => ({
+  sendEmailVerificationMail: mockSendEmailVerificationMail,
 }))
 
 vi.mock('guren', () => createControllerModuleMock())
@@ -83,5 +88,41 @@ describe('ProfileController', () => {
 
     expect(payload.component).toBe('profile/Edit')
     expect(payload.props.status).toBe('Profile updated successfully.')
+  })
+
+  it('clears emailVerifiedAt and sends a new verification email when the email changes', async () => {
+    const controller = new ProfileController()
+    Object.defineProperty(controller, 'auth', {
+      value: createAuthStub({ id: 1, name: 'Ada', email: 'ada@example.com', emailVerifiedAt: new Date() }),
+      configurable: true,
+    })
+
+    mockUserWhere.mockResolvedValue([])
+    mockUserUpdate.mockResolvedValue(undefined)
+    mockUserFind.mockResolvedValue({ id: 1, name: 'Ada', email: 'new@example.com', emailVerifiedAt: null })
+    mockSendEmailVerificationMail.mockResolvedValue(undefined)
+
+    const ctx = createControllerContext('http://blog.test/profile', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: 'Ada',
+        email: 'new@example.com',
+        password: '',
+        passwordConfirmation: '',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    }, { mail: {} }) as unknown as Context
+
+    controller.setContext(ctx)
+
+    const response = await controller.update()
+    const { payload } = await readInertiaResponse(response)
+
+    expect(mockUserUpdate).toHaveBeenCalledWith(
+      { id: 1 },
+      expect.objectContaining({ email: 'new@example.com', emailVerifiedAt: null }),
+    )
+    expect(mockSendEmailVerificationMail).toHaveBeenCalled()
+    expect(payload.props.status).toBe('Profile updated. Check your new email address for a verification link.')
   })
 })

--- a/examples/blog/tests/controllers/RegisterController.test.ts
+++ b/examples/blog/tests/controllers/RegisterController.test.ts
@@ -103,6 +103,30 @@ describe('RegisterController', () => {
     expect(response.headers.get('Location')).toBe('/verify-email')
   })
 
+  it('lowercases the email before storing it, so it round-trips through the verification token', async () => {
+    mockUserWhere.mockResolvedValue([])
+    mockUserCreate.mockResolvedValue({ id: 2, name: 'Ada Lovelace', email: 'ada@example.com' })
+    mockDispatch.mockResolvedValue('job-id')
+    mockSendEmailVerificationMail.mockResolvedValue(undefined)
+
+    const controller = createController()
+    const ctx = createControllerContext('http://blog.test/register', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: 'Ada Lovelace',
+        email: 'Ada@Example.com',
+        password: 'password123',
+        passwordConfirmation: 'password123',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    }, { mail: {} }) as unknown as Context
+    controller.setContext(ctx)
+
+    await controller.store()
+
+    expect(mockUserCreate).toHaveBeenCalledWith(expect.objectContaining({ email: 'ada@example.com' }))
+  })
+
   it('rejects registration when the email is already taken', async () => {
     mockUserWhere.mockResolvedValue([{ id: 5, email: 'ada@example.com' }])
 

--- a/examples/blog/tests/controllers/RegisterController.test.ts
+++ b/examples/blog/tests/controllers/RegisterController.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createControllerContext,
+  createControllerModuleMock,
+  readInertiaResponse,
+} from '@guren/testing'
+import type { Context } from '@guren/core'
+
+const { mockUserWhere, mockUserCreate, mockDispatch, mockSendEmailVerificationMail } = vi.hoisted(() => ({
+  mockUserWhere: vi.fn(),
+  mockUserCreate: vi.fn(),
+  mockDispatch: vi.fn(),
+  mockSendEmailVerificationMail: vi.fn(),
+}))
+
+vi.mock('../../app/Models/User.js', () => ({
+  User: {
+    where: mockUserWhere,
+    create: mockUserCreate,
+  },
+}))
+
+vi.mock('../../app/Jobs/SendWelcomeEmailJob.js', () => ({
+  SendWelcomeEmailJob: { dispatch: mockDispatch },
+}))
+
+vi.mock('../../app/Mail/EmailVerificationMail.js', () => ({
+  sendEmailVerificationMail: mockSendEmailVerificationMail,
+}))
+
+vi.mock('guren', () => createControllerModuleMock())
+vi.mock('@guren/core', async () => {
+  const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
+  return {
+    ...actual,
+    ...createControllerModuleMock(),
+    ServiceProvider: actual.ServiceProvider,
+  }
+})
+
+import RegisterController from '../../app/Http/Controllers/Auth/RegisterController.js'
+
+function createAuthStub() {
+  return {
+    session: vi.fn().mockReturnValue({ regenerate: vi.fn() }),
+    login: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function createController() {
+  const controller = new RegisterController()
+  Object.defineProperty(controller, 'auth', {
+    value: createAuthStub(),
+    configurable: true,
+  })
+  return controller
+}
+
+describe('RegisterController', () => {
+  it('renders the registration form', async () => {
+    const controller = createController()
+    const ctx = createControllerContext('http://blog.test/register', {
+      headers: { 'X-Inertia': 'true' },
+    }) as unknown as Context
+    controller.setContext(ctx)
+
+    const response = await controller.show()
+    const { payload } = await readInertiaResponse(response)
+
+    expect(response.status).toBe(200)
+    expect(payload.component).toBe('auth/Register')
+  })
+
+  it('creates a user, dispatches the welcome email job, sends a verification email, and redirects to /verify-email', async () => {
+    mockUserWhere.mockResolvedValue([])
+    mockUserCreate.mockResolvedValue({ id: 1, name: 'Ada Lovelace', email: 'ada@example.com' })
+    mockDispatch.mockResolvedValue('job-id')
+    mockSendEmailVerificationMail.mockResolvedValue(undefined)
+
+    const controller = createController()
+    const ctx = createControllerContext('http://blog.test/register', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: 'Ada Lovelace',
+        email: 'ada@example.com',
+        password: 'password123',
+        passwordConfirmation: 'password123',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    }, { mail: {} }) as unknown as Context
+    controller.setContext(ctx)
+
+    const response = await controller.store()
+
+    expect(mockUserCreate).toHaveBeenCalledWith({
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      password: 'password123',
+    })
+    expect(mockDispatch).toHaveBeenCalledWith({ userId: 1 })
+    expect(mockSendEmailVerificationMail).toHaveBeenCalled()
+    expect(response.status).toBe(303)
+    expect(response.headers.get('Location')).toBe('/verify-email')
+  })
+
+  it('rejects registration when the email is already taken', async () => {
+    mockUserWhere.mockResolvedValue([{ id: 5, email: 'ada@example.com' }])
+
+    const controller = createController()
+    const ctx = createControllerContext('http://blog.test/register', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: 'Ada Lovelace',
+        email: 'ada@example.com',
+        password: 'password123',
+        passwordConfirmation: 'password123',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    }) as unknown as Context
+    controller.setContext(ctx)
+
+    await expect(controller.store()).rejects.toThrow()
+    expect(mockUserCreate).not.toHaveBeenCalled()
+  })
+
+  it('rejects registration when passwords do not match', async () => {
+    const controller = createController()
+    const ctx = createControllerContext('http://blog.test/register', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: 'Ada Lovelace',
+        email: 'ada@example.com',
+        password: 'password123',
+        passwordConfirmation: 'different',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    }) as unknown as Context
+    controller.setContext(ctx)
+
+    await expect(controller.store()).rejects.toThrow()
+  })
+})

--- a/examples/blog/tests/controllers/ResetPasswordController.test.ts
+++ b/examples/blog/tests/controllers/ResetPasswordController.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createControllerContext,
+  createControllerModuleMock,
+  readInertiaResponse,
+} from '@guren/testing'
+import type { Context } from '@guren/core'
+
+const { mockUserWhere, mockUserUpdate } = vi.hoisted(() => ({
+  mockUserWhere: vi.fn(),
+  mockUserUpdate: vi.fn(),
+}))
+
+vi.mock('../../app/Models/User.js', () => ({
+  User: {
+    where: mockUserWhere,
+    update: mockUserUpdate,
+  },
+}))
+
+vi.mock('guren', () => createControllerModuleMock())
+vi.mock('@guren/core', async () => {
+  const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
+  return {
+    ...actual,
+    ...createControllerModuleMock(),
+    ServiceProvider: actual.ServiceProvider,
+  }
+})
+
+import ResetPasswordController from '../../app/Http/Controllers/Auth/ResetPasswordController.js'
+import { passwordResetStore } from '../../app/Auth/PasswordResetStore.js'
+import { createPasswordResetToken } from '@guren/core'
+
+describe('ResetPasswordController', () => {
+  it('renders the reset form with the token and email from the query string', async () => {
+    const controller = new ResetPasswordController()
+    const ctx = createControllerContext('http://blog.test/reset-password?token=abc&email=ada@example.com', {
+      headers: { 'X-Inertia': 'true' },
+    }) as unknown as Context
+    controller.setContext(ctx)
+
+    const response = await controller.show()
+    const { payload } = await readInertiaResponse(response)
+
+    expect(payload.component).toBe('auth/ResetPassword')
+    expect(payload.props.token).toBe('abc')
+    expect(payload.props.email).toBe('ada@example.com')
+  })
+
+  it('resets the password and redirects to /login for a valid token', async () => {
+    mockUserWhere.mockResolvedValue([{ id: 1, email: 'ada@example.com' }])
+    mockUserUpdate.mockResolvedValue(undefined)
+
+    const { token } = await createPasswordResetToken('ada@example.com', passwordResetStore)
+
+    const controller = new ResetPasswordController()
+    const ctx = createControllerContext('http://blog.test/reset-password', {
+      method: 'POST',
+      body: JSON.stringify({
+        token,
+        password: 'newpassword123',
+        passwordConfirmation: 'newpassword123',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    }) as unknown as Context
+    controller.setContext(ctx)
+
+    const response = await controller.store()
+
+    expect(mockUserUpdate).toHaveBeenCalledWith({ id: 1 }, { password: 'newpassword123' })
+    expect(response.status).toBe(303)
+    expect(response.headers.get('Location')).toBe('/login')
+  })
+
+  it('rejects an invalid or expired token', async () => {
+    const controller = new ResetPasswordController()
+    const ctx = createControllerContext('http://blog.test/reset-password', {
+      method: 'POST',
+      body: JSON.stringify({
+        token: 'not-a-real-token',
+        password: 'newpassword123',
+        passwordConfirmation: 'newpassword123',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    }) as unknown as Context
+    controller.setContext(ctx)
+
+    await expect(controller.store()).rejects.toThrow()
+    expect(mockUserUpdate).not.toHaveBeenCalled()
+  })
+
+  it('rejects mismatched password confirmation', async () => {
+    const controller = new ResetPasswordController()
+    const ctx = createControllerContext('http://blog.test/reset-password', {
+      method: 'POST',
+      body: JSON.stringify({
+        token: 'irrelevant',
+        password: 'newpassword123',
+        passwordConfirmation: 'different',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    }) as unknown as Context
+    controller.setContext(ctx)
+
+    await expect(controller.store()).rejects.toThrow()
+  })
+})

--- a/examples/blog/tests/controllers/VerifyEmailController.test.ts
+++ b/examples/blog/tests/controllers/VerifyEmailController.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createControllerContext,
+  createControllerModuleMock,
+  readInertiaResponse,
+} from '@guren/testing'
+import type { Context } from '@guren/core'
+
+const { mockUserUpdate, mockSendEmailVerificationMail } = vi.hoisted(() => ({
+  mockUserUpdate: vi.fn(),
+  mockSendEmailVerificationMail: vi.fn(),
+}))
+
+vi.mock('../../app/Models/User.js', () => ({
+  User: { update: mockUserUpdate },
+}))
+
+vi.mock('../../app/Mail/EmailVerificationMail.js', () => ({
+  sendEmailVerificationMail: mockSendEmailVerificationMail,
+}))
+
+vi.mock('guren', () => createControllerModuleMock())
+vi.mock('@guren/core', async () => {
+  const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
+  return {
+    ...actual,
+    ...createControllerModuleMock(),
+    ServiceProvider: actual.ServiceProvider,
+  }
+})
+
+import VerifyEmailController from '../../app/Http/Controllers/Auth/VerifyEmailController.js'
+import { emailVerificationStore } from '../../app/Auth/EmailVerificationStore.js'
+import { createEmailVerificationToken } from '@guren/core'
+
+function createController(user: unknown) {
+  const controller = new VerifyEmailController()
+  Object.defineProperty(controller, 'auth', {
+    value: { userOrFail: vi.fn().mockResolvedValue(user) },
+    configurable: true,
+  })
+  return controller
+}
+
+describe('VerifyEmailController', () => {
+  describe('notice()', () => {
+    it('redirects to /dashboard when the email is already verified', async () => {
+      const controller = createController({ id: 1, email: 'ada@example.com', emailVerifiedAt: new Date() })
+      const ctx = createControllerContext('http://blog.test/verify-email') as unknown as Context
+      controller.setContext(ctx)
+
+      const response = await controller.notice()
+
+      expect(response.status).toBe(302)
+      expect(response.headers.get('Location')).toBe('/dashboard')
+    })
+
+    it('renders the notice page when the email is not verified', async () => {
+      const controller = createController({ id: 1, email: 'ada@example.com', emailVerifiedAt: null })
+      const ctx = createControllerContext('http://blog.test/verify-email', {
+        headers: { 'X-Inertia': 'true' },
+      }) as unknown as Context
+      controller.setContext(ctx)
+
+      const response = await controller.notice()
+      const { payload } = await readInertiaResponse(response)
+
+      expect(payload.component).toBe('auth/VerifyEmail')
+    })
+  })
+
+  describe('resend()', () => {
+    it('sends a new verification email when unverified', async () => {
+      mockSendEmailVerificationMail.mockResolvedValue(undefined)
+      const controller = createController({ id: 1, email: 'ada@example.com', emailVerifiedAt: null })
+      const ctx = createControllerContext('http://blog.test/verify-email', {
+        method: 'POST',
+        headers: { 'X-Inertia': 'true' },
+      }) as unknown as Context
+      controller.setContext(ctx)
+
+      const response = await controller.resend()
+      const { payload } = await readInertiaResponse(response)
+
+      expect(mockSendEmailVerificationMail).toHaveBeenCalled()
+      expect(payload.props.status).toBe('A new verification link has been sent to your email address.')
+    })
+
+    it('does not send mail when already verified', async () => {
+      const controller = createController({ id: 1, email: 'ada@example.com', emailVerifiedAt: new Date() })
+      const ctx = createControllerContext('http://blog.test/verify-email', {
+        method: 'POST',
+        headers: { 'X-Inertia': 'true' },
+      }) as unknown as Context
+      controller.setContext(ctx)
+
+      await controller.resend()
+
+      expect(mockSendEmailVerificationMail).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('confirm()', () => {
+    it('verifies the email and redirects to /dashboard for a valid token', async () => {
+      mockUserUpdate.mockResolvedValue(undefined)
+      const { token } = await createEmailVerificationToken('ada@example.com', emailVerificationStore)
+
+      const controller = createController({ id: 1, email: 'ada@example.com', emailVerifiedAt: null })
+      const ctx = createControllerContext(`http://blog.test/verify-email/confirm?token=${token}`) as unknown as Context
+      controller.setContext(ctx)
+
+      const response = await controller.confirm()
+
+      expect(mockUserUpdate).toHaveBeenCalledWith({ email: 'ada@example.com' }, { emailVerifiedAt: expect.any(Date) })
+      expect(response.status).toBe(302)
+      expect(response.headers.get('Location')).toBe('/dashboard')
+    })
+
+    it('shows an expired message for an invalid token', async () => {
+      const controller = createController({ id: 1, email: 'ada@example.com', emailVerifiedAt: null })
+      const ctx = createControllerContext('http://blog.test/verify-email/confirm?token=not-real', {
+        headers: { 'X-Inertia': 'true' },
+      }) as unknown as Context
+      controller.setContext(ctx)
+
+      const response = await controller.confirm()
+      const { payload } = await readInertiaResponse(response)
+
+      expect(mockUserUpdate).not.toHaveBeenCalled()
+      expect(payload.props.status).toBe('This verification link is invalid or has expired. Request a new one below.')
+    })
+  })
+})

--- a/examples/blog/tests/jobs/SendPasswordResetEmailJob.test.ts
+++ b/examples/blog/tests/jobs/SendPasswordResetEmailJob.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@guren/core', () => ({
+  Job: class {
+    protected make() {
+      return { id: 'mailer' }
+    }
+  },
+}))
+
+const { sendPasswordResetMailMock } = vi.hoisted(() => ({
+  sendPasswordResetMailMock: vi.fn(),
+}))
+
+vi.mock('../../app/Mail/PasswordResetMail.js', () => ({
+  sendPasswordResetMail: sendPasswordResetMailMock,
+}))
+
+import { SendPasswordResetEmailJob } from '../../app/Jobs/SendPasswordResetEmailJob.js'
+
+describe('SendPasswordResetEmailJob', () => {
+  it('sends the password reset email', async () => {
+    const job = new SendPasswordResetEmailJob()
+    await job.handle({ email: 'ada@example.com', resetUrl: 'https://blog.test/reset-password?token=abc' })
+
+    expect(sendPasswordResetMailMock).toHaveBeenCalledWith(
+      { id: 'mailer' },
+      'ada@example.com',
+      'https://blog.test/reset-password?token=abc',
+    )
+  })
+})

--- a/examples/blog/tests/setup.ts
+++ b/examples/blog/tests/setup.ts
@@ -1,4 +1,9 @@
 import '@testing-library/jest-dom'
 import { configureInertiaVitest } from '@guren/testing/vitest'
 
+// Fixed test-only key so password-reset/email-verification token signing
+// (createPasswordResetToken, createEmailVerificationToken) works under test
+// without depending on a real .env file. Never used outside this suite.
+process.env.APP_KEY ??= 'base64:DmubbpobAdBxPuaD0Qn1eUz5RwJeaMnVurIY6AzU5S8='
+
 configureInertiaVitest()

--- a/examples/blog/types/generated/routes.d.ts
+++ b/examples/blog/types/generated/routes.d.ts
@@ -10,7 +10,10 @@ declare namespace Guren {
 
   export type RoutePath =
     '/'
+    | `/auth/${string}`
+    | `/auth/${string}/callback`
     | '/dashboard'
+    | '/forgot-password'
     | '/login'
     | '/logout'
     | '/posts'
@@ -18,6 +21,10 @@ declare namespace Guren {
     | `/posts/${string}/edit`
     | '/posts/new'
     | '/profile'
+    | '/register'
+    | '/reset-password'
+    | '/verify-email'
+    | '/verify-email/confirm'
 
   export type RouteUrl = RoutePath | `${RoutePath}?${string}`
 

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -114,12 +114,17 @@ export default class ForgotPasswordController extends Controller {
     const { email } = await this.validateBody(ForgotPasswordSchema)
 
     // Always respond with the same status message whether or not the
-    // account exists, to avoid leaking which emails are registered.
+    // account exists, to avoid leaking which emails are registered. The
+    // mail send is deliberately not awaited: the transport round-trip only
+    // happens for known accounts, so awaiting it would let response timing
+    // (or a transport failure) reveal which emails exist.
     const [user] = await User.where({ email })
     if (user) {
       const { token } = await createPasswordResetToken(email, passwordResetStore)
       const resetUrl = buildPasswordResetUrl(\`\${new URL(this.request.url).origin}/reset-password\`, token, email)
-      await sendPasswordResetMail(this.make('mail'), email, resetUrl)
+      void sendPasswordResetMail(this.make('mail'), email, resetUrl).catch((error) => {
+        console.error('Failed to send password reset email:', error)
+      })
     }
 
     return this.inertia(pages.auth.ForgotPassword, { status: STATUS_MESSAGE }, {
@@ -324,14 +329,17 @@ export default class OAuthController extends Controller {
 
     const { profile, redirectTo } = await this.oauth().handleCallback(provider, { code, state })
 
-    if (!profile.email) {
+    // Lowercased to match how registration stores emails; provider casing
+    // isn't guaranteed to be stable across logins.
+    const email = profile.email?.toLowerCase()
+    if (!email) {
       throw ValidationException.withMessages({ message: 'This provider did not return an email address.' })
     }
 
     let [user] = await User.where(identityWhere(provider, profile.id))
 
     if (!user) {
-      const [existingByEmail] = await User.where({ email: profile.email })
+      const [existingByEmail] = await User.where({ email })
       if (existingByEmail) {
         throw ValidationException.withMessages({
           message: 'An account with this email already exists. Sign in with your password instead.',
@@ -342,8 +350,8 @@ export default class OAuthController extends Controller {
       // account still satisfies AuthenticatableModel's hashing pipeline.
       // It's never surfaced to the user and can't realistically be guessed.
       user = await User.create({
-        name: profile.name ?? profile.email,
-        email: profile.email,
+        name: profile.name ?? email,
+        email,
         password: randomUUID(),${emailVerifiedAtField}
         ...identityWhere(provider, profile.id),
       })
@@ -377,9 +385,44 @@ export default class DashboardController extends Controller {
 }
 `
 
-const profileControllerTemplate = `import { Controller, ValidationException } from '@guren/core'
+function buildProfileControllerTemplate(includeVerify: boolean): string {
+  const coreImports = includeVerify
+    ? 'Controller, ValidationException, createEmailVerificationToken, buildVerificationUrl'
+    : 'Controller, ValidationException'
+
+  const verifyImports = includeVerify
+    ? `
+import { emailVerificationStore } from '../../Auth/EmailVerificationStore.js'
+import { sendEmailVerificationMail } from '../../Mail/EmailVerificationMail.js'`
+    : ''
+
+  const verifyResetField = includeVerify
+    ? `
+      // The new address hasn't been proven to belong to this user yet — an
+      // arbitrary replacement email must not inherit the old address's
+      // verified status.
+      ...(emailChanged ? { emailVerifiedAt: null } : {}),`
+    : ''
+
+  const verifyResend = includeVerify
+    ? `
+    if (emailChanged) {
+      const { token } = await createEmailVerificationToken(email, emailVerificationStore)
+      const verifyUrl = buildVerificationUrl(\`\${new URL(this.request.url).origin}/verify-email/confirm\`, token, email)
+      await sendEmailVerificationMail(this.make('mail'), email, verifyUrl)
+    }
+`
+    : ''
+
+  const statusMessage = includeVerify
+    ? `emailChanged
+        ? 'Profile updated. Check your new email address for a verification link.'
+        : 'Profile updated successfully.'`
+    : `'Profile updated successfully.'`
+
+  return `import { ${coreImports} } from '@guren/core'
 import { User, type UserRecord } from '../../Models/User.js'
-import { ProfileUpdateSchema } from '../Validators/ProfileValidator.js'
+import { ProfileUpdateSchema } from '../Validators/ProfileValidator.js'${verifyImports}
 import { pages } from '@/.guren/pages.gen'
 
 export default class ProfileController extends Controller {
@@ -404,8 +447,9 @@ export default class ProfileController extends Controller {
     }
 
     const { name, email, password } = await this.validateBody(ProfileUpdateSchema)
+    const emailChanged = email !== user.email
 
-    if (email !== user.email) {
+    if (emailChanged) {
       const existing = await User.where({ email })
       const conflict = existing.find((candidate) => candidate.id !== user.id)
       if (conflict) {
@@ -415,7 +459,7 @@ export default class ProfileController extends Controller {
 
     await User.update({ id: user.id }, {
       name,
-      email,
+      email,${verifyResetField}
       ...(password ? { password } : {}),
     })
 
@@ -423,14 +467,15 @@ export default class ProfileController extends Controller {
     if (refreshed) {
       await this.auth.login(refreshed)
     }
-
+${verifyResend}
     return this.inertia(pages.profile.Edit, {
       profile: { name, email },
-      status: 'Profile updated successfully.',
+      status: ${statusMessage},
     }, { url: this.request.path, title: 'Profile' })
   }
 }
 `
+}
 
 const userModelTemplate = `import { AuthenticatableModel } from '@guren/core'
 import { users } from '../../db/schema.js'
@@ -569,11 +614,14 @@ If you didn't create an account, you can safely ignore this email.
 const loginValidatorTemplate = `import { z } from 'zod'
 
 export const LoginSchema = z.object({
+  // Lowercased to match how registration stores emails — a case-sensitive
+  // lookup would otherwise reject the same address typed with different casing.
   email: z
     .string()
     .trim()
     .min(1, 'Email is required.')
-    .email('The email address is badly formatted.'),
+    .email('The email address is badly formatted.')
+    .toLowerCase(),
   password: z
     .string()
     .min(1, 'Password is required.'),
@@ -601,11 +649,15 @@ export const RegisterSchema = z
       .trim()
       .min(1, 'Name is required.')
       .max(120, 'Name must be 120 characters or fewer.'),
+    // Lowercased so it round-trips correctly through the password-reset and
+    // email-verification token helpers, which normalize emails to lowercase
+    // internally before matching against stored records.
     email: z
       .string()
       .trim()
       .min(1, 'Email is required.')
-      .email('The email address is badly formatted.'),
+      .email('The email address is badly formatted.')
+      .toLowerCase(),
     password: z
       .string()
       .min(8, 'Password must be at least 8 characters.'),
@@ -624,11 +676,14 @@ export type RegisterInput = z.infer<typeof RegisterSchema>
 const forgotPasswordValidatorTemplate = `import { z } from 'zod'
 
 export const ForgotPasswordSchema = z.object({
+  // Lowercased to match how registration stores emails and how the
+  // password-reset token helpers normalize emails internally.
   email: z
     .string()
     .trim()
     .min(1, 'Email is required.')
-    .email('The email address is badly formatted.'),
+    .email('The email address is badly formatted.')
+    .toLowerCase(),
 })
 
 export type ForgotPasswordInput = z.infer<typeof ForgotPasswordSchema>
@@ -666,7 +721,8 @@ export const ProfileUpdateSchema = z.object({
     .string()
     .trim()
     .min(1, 'Email is required.')
-    .email('Enter a valid email address.'),
+    .email('Enter a valid email address.')
+    .toLowerCase(),
   password: z
     .string()
     .trim()
@@ -1402,7 +1458,10 @@ function buildRoutesTemplate(
     ? `
   router.get('/verify-email', [VerifyEmailController, 'notice'], requireAuthenticated({ redirectTo: '/login' })).name('verify-email')
   router.post('/verify-email', [VerifyEmailController, 'resend'], requireAuthenticated({ redirectTo: '/login' })).name('verify-email.resend')
-  router.get('/verify-email/confirm', [VerifyEmailController, 'confirm'], requireAuthenticated({ redirectTo: '/login' })).name('verify-email.confirm')
+  // Public: confirm() validates the signed token itself and doesn't use the
+  // session — gating it behind auth would strand a user who opens the email
+  // link from a different device or after their session expired.
+  router.get('/verify-email/confirm', [VerifyEmailController, 'confirm']).name('verify-email.confirm')
 `
     : ''
   const requireVerifiedImport = includeVerify ? ', requireVerifiedEmail' : ''
@@ -1703,7 +1762,7 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
   const files = [
     { path: 'app/Http/Controllers/Auth/LoginController.ts', contents: loginControllerTemplate },
     { path: 'app/Http/Controllers/DashboardController.ts', contents: dashboardControllerTemplate },
-    { path: 'app/Http/Controllers/ProfileController.ts', contents: profileControllerTemplate },
+    { path: 'app/Http/Controllers/ProfileController.ts', contents: buildProfileControllerTemplate(includeVerify) },
     { path: 'app/Models/User.ts', contents: userModelTemplate },
     { path: 'app/Providers/AuthProvider.ts', contents: authProviderTemplate },
     { path: 'app/Http/Validators/LoginValidator.ts', contents: loginValidatorTemplate },

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -496,7 +496,7 @@ export default class MailProvider extends ServiceProvider {
 
 const passwordResetStoreTemplate = `import { MemoryPasswordResetStore } from '@guren/core'
 
-// Swap for a Redis-backed store (see @guren/server/redis) in production
+// Swap for a Redis-backed store (see @guren/core/redis) in production
 // or any multi-instance deployment — this in-memory store does not
 // survive restarts and is not shared across processes.
 export const passwordResetStore = new MemoryPasswordResetStore()
@@ -529,7 +529,7 @@ If you didn't request this, you can safely ignore this email.
 
 const emailVerificationStoreTemplate = `import { MemoryEmailVerificationStore } from '@guren/core'
 
-// Swap for a Redis-backed store (see @guren/server/redis) in production
+// Swap for a Redis-backed store (see @guren/core/redis) in production
 // or any multi-instance deployment — this in-memory store does not
 // survive restarts and is not shared across processes.
 export const emailVerificationStore = new MemoryEmailVerificationStore()

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -266,11 +266,17 @@ ${registrations}
 `
 }
 
-function buildOAuthControllerTemplate(providers: string[]): string {
+function buildOAuthControllerTemplate(providers: string[], includeVerify: boolean): string {
   const providerLiterals = providers.map((provider) => `'${provider}'`).join(', ')
   const identityEntries = providers
     .map((provider) => `    ${provider}: { ${provider}Id: profileId },`)
     .join('\n')
+
+  // The provider already vouches for this address, so an OAuth-created
+  // account is verified on arrival — without this, requireVerifiedEmail
+  // would strand OAuth users at /verify-email forever, since this
+  // controller never sends a verification email for them to click.
+  const emailVerifiedAtField = includeVerify ? '\n        emailVerifiedAt: new Date(),' : ''
 
   return `import { Controller, ValidationException, type OAuthManager } from '@guren/core'
 import { randomUUID } from 'node:crypto'
@@ -338,7 +344,7 @@ export default class OAuthController extends Controller {
       user = await User.create({
         name: profile.name ?? profile.email,
         email: profile.email,
-        password: randomUUID(),
+        password: randomUUID(),${emailVerifiedAtField}
         ...identityWhere(provider, profile.id),
       })
     }
@@ -1740,7 +1746,7 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
   if (includeOAuth) {
     files.push(
       { path: 'app/Providers/OAuthProvider.ts', contents: buildOAuthProviderTemplate(oauthProviders) },
-      { path: 'app/Http/Controllers/Auth/OAuthController.ts', contents: buildOAuthControllerTemplate(oauthProviders) },
+      { path: 'app/Http/Controllers/Auth/OAuthController.ts', contents: buildOAuthControllerTemplate(oauthProviders, includeVerify) },
     )
   }
 

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -129,6 +129,7 @@ export function registerWebRoutes(router: Router): void {
       )
       expect(registerValidator).toContain('passwordConfirmation')
       expect(registerValidator).toContain('Passwords do not match.')
+      expect(registerValidator).toContain('.toLowerCase()')
 
       const registerPage = await readFile(join(workspace.dir, 'resources/js/pages/auth/Register.tsx'), 'utf8')
       expect(registerPage).toContain('interface Props')
@@ -140,7 +141,16 @@ export function registerWebRoutes(router: Router): void {
       )
       expect(forgotController).toContain('validateBody(ForgotPasswordSchema)')
       expect(forgotController).toContain('createPasswordResetToken(')
-      expect(forgotController).toContain('sendPasswordResetMail(')
+      // Not awaited: the transport round-trip only happens for known
+      // accounts, so awaiting it would leak account existence via timing.
+      expect(forgotController).toContain('void sendPasswordResetMail(')
+      expect(forgotController).not.toContain('await sendPasswordResetMail(')
+
+      const profileController = await readFile(
+        join(workspace.dir, 'app/Http/Controllers/ProfileController.ts'),
+        'utf8',
+      )
+      expect(profileController).not.toContain('emailVerifiedAt')
 
       const resetController = await readFile(
         join(workspace.dir, 'app/Http/Controllers/Auth/ResetPasswordController.ts'),
@@ -244,6 +254,18 @@ export const posts = pgTable('posts', {
       )
       expect(verifyController).toContain('completeEmailVerification(')
       expect(verifyController).toContain('emailVerifiedAt: new Date()')
+
+      // Public — the emailed link must work from any device or expired session.
+      expect(authRoutes).toContain("router.get('/verify-email/confirm', [VerifyEmailController, 'confirm']).name('verify-email.confirm')")
+      expect(authRoutes).not.toContain("router.get('/verify-email/confirm', [VerifyEmailController, 'confirm'], requireAuthenticated")
+
+      // Changing the profile email must reset verification and re-send the link.
+      const profileController = await readFile(
+        join(workspace.dir, 'app/Http/Controllers/ProfileController.ts'),
+        'utf8',
+      )
+      expect(profileController).toContain('emailVerifiedAt: null')
+      expect(profileController).toContain('sendEmailVerificationMail(')
     } finally {
       await workspace.cleanup()
     }

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -451,6 +451,27 @@ export const posts = pgTable('posts', {
       expect(schema).toContain("githubId: text('github_id').unique()")
       expect(schema).toContain("googleId: text('google_id').unique()")
       expect(schema.match(/export const users = /g)).toHaveLength(1)
+
+      // Without this, requireVerifiedEmail would strand every OAuth signup
+      // at /verify-email forever — OAuthController never sends a
+      // verification email, so there'd be nothing for them to click.
+      const controller = await readFile(join(workspace.dir, 'app/Http/Controllers/Auth/OAuthController.ts'), 'utf8')
+      expect(controller).toContain('emailVerifiedAt: new Date()')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('omits emailVerifiedAt from OAuthController when --verify is not enabled', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-auth-oauth-no-verify-')
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(join(workspace.dir, 'db/schema.ts'), `export const posts = 'posts'\n`, 'utf8')
+
+      await makeAuth({ force: true, oauth: 'github' })
+
+      const controller = await readFile(join(workspace.dir, 'app/Http/Controllers/Auth/OAuthController.ts'), 'utf8')
+      expect(controller).not.toContain('emailVerifiedAt')
     } finally {
       await workspace.cleanup()
     }

--- a/packages/server/src/auth/oauth/index.ts
+++ b/packages/server/src/auth/oauth/index.ts
@@ -17,6 +17,13 @@ export interface OAuthProviderConfig {
   tokenAuthMethod?: 'client_secret_post' | 'client_secret_basic'
   userInfoMethod?: 'GET' | 'POST'
   mapProfile?: (raw: Record<string, unknown>, token: OAuthTokenResult) => OAuthUserProfile
+  /**
+   * Fallback used when the userinfo response carries no email — e.g. GitHub
+   * returns `email: null` for accounts with a private email even when the
+   * `user:email` scope was granted. Returns the email to use, or undefined
+   * to leave the profile without one.
+   */
+  fetchFallbackEmail?: (token: OAuthTokenResult) => Promise<string | undefined>
 }
 
 export interface OAuthTokenResult {
@@ -372,10 +379,24 @@ export async function fetchOAuthUserProfile(
   }
 
   const raw = await response.json() as Record<string, unknown>
-  if (provider.mapProfile) {
-    return provider.mapProfile(raw, token)
+  const profile = provider.mapProfile
+    ? provider.mapProfile(raw, token)
+    : defaultProfileFromUserInfo(raw, token)
+
+  if (!profile.email && provider.fetchFallbackEmail) {
+    const email = await provider.fetchFallbackEmail(token)
+    if (email) {
+      return { ...profile, email }
+    }
   }
 
+  return profile
+}
+
+function defaultProfileFromUserInfo(
+  raw: Record<string, unknown>,
+  token: OAuthTokenResult,
+): OAuthUserProfile {
   const idCandidate = raw.id ?? raw.sub
   const id = typeof idCandidate === 'string' || typeof idCandidate === 'number'
     ? String(idCandidate)
@@ -405,6 +426,37 @@ export interface OAuthProviderFactoryInput {
   scopes?: string[]
 }
 
+// GitHub's /user endpoint returns `email: null` whenever the account's email
+// is set to private, even with the `user:email` scope granted — the primary
+// verified address is only available from this separate endpoint.
+async function fetchGitHubPrimaryEmail(token: OAuthTokenResult): Promise<string | undefined> {
+  const response = await fetch('https://api.github.com/user/emails', {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token.accessToken}`,
+      'User-Agent': 'guren-oauth',
+    },
+  })
+
+  if (!response.ok) {
+    return undefined
+  }
+
+  const emails = await response.json() as unknown
+  if (!Array.isArray(emails)) {
+    return undefined
+  }
+
+  const primary = emails.find(
+    (entry): entry is { email: string } =>
+      typeof entry === 'object' && entry !== null &&
+      (entry as { primary?: unknown }).primary === true &&
+      (entry as { verified?: unknown }).verified === true &&
+      typeof (entry as { email?: unknown }).email === 'string',
+  )
+  return primary?.email
+}
+
 export function createGitHubOAuthProviderConfig(input: OAuthProviderFactoryInput): OAuthProviderConfig {
   return {
     ...input,
@@ -412,6 +464,7 @@ export function createGitHubOAuthProviderConfig(input: OAuthProviderFactoryInput
     tokenUrl: 'https://github.com/login/oauth/access_token',
     userInfoUrl: 'https://api.github.com/user',
     scopes: input.scopes ?? ['read:user', 'user:email'],
+    fetchFallbackEmail: fetchGitHubPrimaryEmail,
   }
 }
 

--- a/packages/server/tests/auth/oauth.test.ts
+++ b/packages/server/tests/auth/oauth.test.ts
@@ -162,6 +162,50 @@ describe('OAuthManager', () => {
     expect(profile.token.accessToken).toBe('token-123')
   })
 
+  it('falls back to /user/emails when the GitHub profile email is private', async () => {
+    const manager = new OAuthManager({
+      stateStore: new MemoryOAuthStateStore(),
+    })
+    manager.registerProvider('github', githubConfig)
+
+    const fetchMock = mock(async (input: string) => {
+      const body = input.includes('/access_token')
+        ? { access_token: 'token-123' }
+        : input.includes('/user/emails')
+          ? [
+              { email: 'secondary@example.com', primary: false, verified: true },
+              { email: 'unverified@example.com', primary: true, verified: false },
+              { email: 'primary@example.com', primary: true, verified: true },
+            ]
+          : { id: 42, email: null, name: 'Private Octo' }
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+    ;(globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch
+
+    const { state } = await manager.authorize('github')
+    const profile = await manager.user('github', { code: 'auth-code', state })
+
+    expect(profile.email).toBe('primary@example.com')
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/user/emails'))).toBe(true)
+  })
+
+  it('leaves the profile email undefined when the fallback finds nothing', async () => {
+    const manager = new OAuthManager({
+      stateStore: new MemoryOAuthStateStore(),
+    })
+    manager.registerProvider('github', githubConfig)
+
+    installOAuthFetchMock({ access_token: 'token-123' }, { id: 42 })
+
+    const { state } = await manager.authorize('github')
+    const profile = await manager.user('github', { code: 'auth-code', state })
+
+    expect(profile.email).toBeUndefined()
+  })
+
   it('round-trips sanitized redirectTo through authorize and handleCallback', async () => {
     const manager = new OAuthManager({
       stateStore: new MemoryOAuthStateStore(),


### PR DESCRIPTION
## Summary

Replaces the blog example's hand-rolled, login-only auth with the full `make:auth` feature set: registration, password reset, email verification, and GitHub/Google OAuth login. This is the final item of the original `make:auth` roadmap (PRs A-D added the CLI features; this PR dogfoods them into the reference app).

- New controllers/validators/pages for registration, forgot/reset password, email verification, and OAuth callback, following the existing conventions established by `LoginController`/`Login.tsx` rather than overwriting them
- `users` table gains `emailVerifiedAt`/`githubId`/`googleId` (migration included); `/dashboard` now requires a verified email
- `routes/auth.ts` centralizes auth route registration, reusing the `auth`/`guest` router aliases `routes/web.ts` already registers, so `guren audit`'s route-protection check still passes
- The `SendWelcomeEmailJob` that was registered but never dispatched anywhere is now wired into registration
- Shared `AuthCard`/`AuthFormField`/`OAuthButtons` components factor out markup that would otherwise repeat across five auth pages
- Controller tests for every new controller (99 total in `examples/blog`); new `registration.spec.ts` and `password-reset.spec.ts` E2E specs

**Scope note on OAuth E2E:** the live provider handshake (redirecting to GitHub/Google and completing their consent screen) isn't covered by E2E — there's no test credential and driving a third-party consent screen in Playwright isn't practical. OAuth is fully wired and the buttons render; the callback logic is covered by `OAuthController.test.ts` with a mocked `OAuthManager`.

Also fixes a stray `@guren/server/redis` reference in `make:auth`'s own generated comment (should be the public `@guren/core/redis` subpath) — caught by running `guren audit:core-first` against the regenerated app, which hadn't been exercised for this template before.

## Test plan

- [x] `bun run build` (full monorepo)
- [x] `bun run typecheck` (full monorepo, including `examples/blog` and `examples/api`)
- [x] `bun run test` (2396 + 99 + 42 + 12 tests pass across the monorepo)
- [x] `bun run audit:core-first`
- [x] `bun run audit:docs`
- [x] `guren check` / `guren audit` against the regenerated `examples/blog` (0 warnings, 0 failures)
- [x] Full E2E suite (`bun run e2e`) — all auth-related specs green; one pre-existing, unrelated flaky test (`posts-crud.spec.ts: edit an existing post`) passes in isolation and is untouched by this diff
- [x] Manual verification in-browser: register → verify-email gate → login → dashboard → logout
- [x] `/simplify` pass (4 parallel review agents); applied: shared E2E hydration helper, shared `AuthCard`/`AuthFormField` components; documented what was intentionally left as-is (matches upstream `make:auth` template patterns)