### PR TITLE
feat(orm): add createD1Database for Cloudflare D1 (RFC 0003 Part 2)

### DIFF
--- a/.changeset/orm-d1-factory.md
+++ b/.changeset/orm-d1-factory.md
@@ -3,6 +3,6 @@
 '@guren/core': minor
 ---
 
-Added `createD1Database` — the Cloudflare D1 factory (RFC 0003 Part 2), alongside the postgres/mysql/sqlite factories and re-exported from `@guren/core`. It takes a deferred `binding` resolver (`binding: () => getWorkersEnv<Env>().DB` — D1 bindings only exist per-request on Workers) and wires `drizzle-orm/d1` into the ORM adapter. D1 speaks the SQLite dialect, so schemas written for `createSqliteDatabase` port unchanged.
+Added `createD1Database` — the Cloudflare D1 factory (RFC 0003 Part 2), alongside the postgres/mysql/sqlite factories and re-exported from `@guren/core`. It takes a deferred `binding` resolver (`binding: () => getWorkersEnv<Env>().DB` — bindings reach runtime-portable app code via the plugin's write-once holder, populated on the first request) and wires `drizzle-orm/d1` into the ORM adapter. D1 speaks the SQLite dialect, so schemas written for `createSqliteDatabase` port unchanged.
 
 The operational surface is deliberately different from the other factories: `migrateDatabase()`, `seedDatabase()`, `resetDatabase()`, and `migrationStatus()` throw with guidance instead of executing — wrangler owns the D1 migration lifecycle (`wrangler d1 migrations apply` over the same drizzle-kit-generated SQL files, `migrations_dir` pointing at `db/migrations`). The drizzle-kit SQL format contract (statement-breakpoint separators, filename ordering, idempotent re-apply) is covered by an opt-in end-to-end test against wrangler's local D1 (`GUREN_TEST_WRANGLER=1`).

--- a/.changeset/orm-d1-factory.md
+++ b/.changeset/orm-d1-factory.md
@@ -1,0 +1,8 @@
+---
+'@guren/orm': minor
+'@guren/core': minor
+---
+
+Added `createD1Database` — the Cloudflare D1 factory (RFC 0003 Part 2), alongside the postgres/mysql/sqlite factories and re-exported from `@guren/core`. It takes a deferred `binding` resolver (`binding: () => getWorkersEnv<Env>().DB` — D1 bindings only exist per-request on Workers) and wires `drizzle-orm/d1` into the ORM adapter. D1 speaks the SQLite dialect, so schemas written for `createSqliteDatabase` port unchanged.
+
+The operational surface is deliberately different from the other factories: `migrateDatabase()`, `seedDatabase()`, `resetDatabase()`, and `migrationStatus()` throw with guidance instead of executing — wrangler owns the D1 migration lifecycle (`wrangler d1 migrations apply` over the same drizzle-kit-generated SQL files, `migrations_dir` pointing at `db/migrations`). The drizzle-kit SQL format contract (statement-breakpoint separators, filename ordering, idempotent re-apply) is covered by an opt-in end-to-end test against wrangler's local D1 (`GUREN_TEST_WRANGLER=1`).

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export {
   createPostgresDatabase,
   createMySqlDatabase,
   createSqliteDatabase,
+  createD1Database,
   runSeeders,
   defineSeeder,
 } from '@guren/orm'
@@ -52,6 +53,8 @@ export type {
   MySqlDatabaseOptions,
   SqliteDatabase,
   SqliteDatabaseOptions,
+  D1DatabaseHandle,
+  D1DatabaseOptions,
   SeederContext,
   SeederHandler,
   SoftDeletesStatic,

--- a/packages/orm/src/d1.test.ts
+++ b/packages/orm/src/d1.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect } from 'bun:test'
+import { createD1Database } from './d1'
+
+function createStubBinding() {
+  return {
+    prepare() {
+      throw new Error('not executed in tests')
+    },
+  }
+}
+
+describe('createD1Database', () => {
+  test('should not call the binding resolver until getDatabase is used', () => {
+    let calls = 0
+    createD1Database({
+      binding: () => {
+        calls += 1
+        return createStubBinding()
+      },
+    })
+
+    expect(calls).toBe(0)
+  })
+
+  test('should build a drizzle instance from the binding and cache it', async () => {
+    let calls = 0
+    const database = createD1Database({
+      binding: () => {
+        calls += 1
+        return createStubBinding()
+      },
+    })
+
+    const first = await database.getDatabase()
+    const second = await database.getDatabase()
+
+    expect(first).toBeDefined()
+    expect(second).toBe(first)
+    expect(calls).toBe(1)
+  })
+
+  test('should throw a deferral hint when the binding resolves to nothing', async () => {
+    const database = createD1Database({ binding: () => undefined })
+
+    await expect(database.getDatabase()).rejects.toThrow(/before the first request/)
+  })
+
+  test('should drop the cached instance on closeDatabase', async () => {
+    const database = createD1Database({ binding: createStubBinding })
+
+    const first = await database.getDatabase()
+    await database.closeDatabase()
+    const second = await database.getDatabase()
+
+    expect(second).not.toBe(first)
+  })
+
+  test('should reject runtime migrations with wrangler guidance', async () => {
+    const database = createD1Database({
+      binding: createStubBinding,
+      migrationsFolder: new URL('./migrations', import.meta.url),
+    })
+
+    await expect(database.migrateDatabase()).rejects.toThrow(/wrangler d1 migrations apply/)
+    await expect(database.migrateDatabase()).rejects.toThrow(/migrations/)
+  })
+
+  test('should reject runtime seeding with wrangler guidance', async () => {
+    const database = createD1Database({ binding: createStubBinding })
+
+    await expect(database.seedDatabase()).rejects.toThrow(/wrangler d1 execute/)
+  })
+
+  test('should reject runtime resets with wrangler guidance', async () => {
+    const database = createD1Database({ binding: createStubBinding })
+
+    await expect(database.resetDatabase()).rejects.toThrow(/wrangler d1 delete/)
+  })
+
+  test('should defer migration status to the wrangler tracker', async () => {
+    const database = createD1Database({ binding: createStubBinding })
+
+    await expect(database.migrationStatus()).rejects.toThrow(/wrangler d1 migrations list/)
+  })
+
+  test('should configure the ORM adapter without touching the binding client', async () => {
+    const database = createD1Database({ binding: createStubBinding })
+
+    await database.configureOrm()
+
+    expect(await database.getDatabase()).toBeDefined()
+  })
+})

--- a/packages/orm/src/d1.test.ts
+++ b/packages/orm/src/d1.test.ts
@@ -1,10 +1,13 @@
 import { describe, test, expect } from 'bun:test'
+import { sql } from 'drizzle-orm'
 import { createD1Database } from './d1'
 
 function createStubBinding() {
   return {
-    prepare() {
-      throw new Error('not executed in tests')
+    prepare(query: string) {
+      // Sentinel proving a query actually reached the D1 client boundary —
+      // guards the drizzle(client, config) positional invocation shape.
+      throw new Error(`stub-prepare:${query}`)
     },
   }
 }
@@ -39,6 +42,45 @@ describe('createD1Database', () => {
     expect(calls).toBe(1)
   })
 
+  test('should route queries through the binding client (positional drizzle invocation)', async () => {
+    const database = createD1Database({ binding: createStubBinding })
+    const db = (await database.getDatabase()) as { run(query: unknown): Promise<unknown> }
+
+    // Statement preparation happens synchronously inside run(); drizzle wraps
+    // the stub sentinel in a DrizzleQueryError carrying the SQL text — enough
+    // to prove the query reached client.prepare through the positional form.
+    expect(() => db.run(sql`select 1`)).toThrow(/Failed query: select 1/)
+  })
+
+  test('should share one in-flight initialization across concurrent getDatabase calls', async () => {
+    let calls = 0
+    const database = createD1Database({
+      binding: () => {
+        calls += 1
+        return createStubBinding()
+      },
+    })
+
+    const [first, second] = await Promise.all([database.getDatabase(), database.getDatabase()])
+
+    expect(first).toBe(second)
+    expect(calls).toBe(1)
+  })
+
+  test('should retry initialization after a failed binding resolution', async () => {
+    let calls = 0
+    const database = createD1Database({
+      binding: () => {
+        calls += 1
+        return calls === 1 ? undefined : createStubBinding()
+      },
+    })
+
+    await expect(database.getDatabase()).rejects.toThrow(/before the first request/)
+    expect(await database.getDatabase()).toBeDefined()
+    expect(calls).toBe(2)
+  })
+
   test('should throw a deferral hint when the binding resolves to nothing', async () => {
     const database = createD1Database({ binding: () => undefined })
 
@@ -62,7 +104,20 @@ describe('createD1Database', () => {
     })
 
     await expect(database.migrateDatabase()).rejects.toThrow(/wrangler d1 migrations apply/)
-    await expect(database.migrateDatabase()).rejects.toThrow(/migrations/)
+  })
+
+  test('should never leak an absolute path into the migrations guidance', async () => {
+    const absoluteDir = new URL('.', import.meta.url).pathname
+    const database = createD1Database({
+      binding: createStubBinding,
+      migrationsFolder: new URL('./migrations', import.meta.url),
+    })
+
+    const error = await database.migrateDatabase().catch((caught: Error) => caught)
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toContain('migrations')
+    expect((error as Error).message).not.toContain(absoluteDir)
   })
 
   test('should reject runtime seeding with wrangler guidance', async () => {

--- a/packages/orm/src/d1.ts
+++ b/packages/orm/src/d1.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'node:path'
+import { relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
 
@@ -45,37 +45,54 @@ export interface D1DatabaseHandle {
 export function createD1Database(options: D1DatabaseOptions): D1DatabaseHandle {
   const { binding, migrationsFolder, relations } = options
 
+  // Display-only (wrangler owns the folder): keep strings as the caller wrote
+  // them and relativize URLs, so error guidance never leaks a machine-specific
+  // absolute path into a copy-pasteable wrangler.jsonc value.
   const migrationsHint =
     migrationsFolder == null
       ? 'db/migrations'
       : migrationsFolder instanceof URL
-        ? fileURLToPath(migrationsFolder)
-        : resolve(String(migrationsFolder))
+        ? relative(process.cwd(), fileURLToPath(migrationsFolder))
+        : migrationsFolder
 
-  let db: unknown
+  let databasePromise: Promise<unknown> | undefined
 
-  async function ensureDatabase(): Promise<unknown> {
-    if (db) return db
+  function ensureDatabase(): Promise<unknown> {
+    if (databasePromise) return databasePromise
 
-    const client = binding()
-    if (client == null) {
-      throw new Error(
-        'createD1Database: the "binding" resolver returned no D1 binding. ' +
-          'On Workers this usually means it ran before the first request — defer access ' +
-          '(e.g. binding: () => getWorkersEnv<Env>().DB) and check the d1_databases entry in wrangler.jsonc.',
-      )
-    }
+    const promise = (async () => {
+      const client = binding()
+      if (client == null) {
+        throw new Error(
+          'createD1Database: the "binding" resolver returned no D1 binding. ' +
+            'On Workers this usually means it ran before the first request — defer access ' +
+            '(e.g. binding: () => getWorkersEnv<Env>().DB) and check the d1_databases entry in wrangler.jsonc.',
+        )
+      }
 
-    const { drizzle } = await import('drizzle-orm/d1')
-    type DrizzleConfig = NonNullable<Exclude<Parameters<typeof drizzle>[0], string>>
-    db = drizzle({ client, ...(relations ? { relations } : {}) } as DrizzleConfig)
-    return db
+      // drizzle-orm/d1 only accepts the positional (client, config) form —
+      // unlike bun-sqlite there is no `{ client }` object overload.
+      const { drizzle } = await import('drizzle-orm/d1')
+      type D1Client = Parameters<typeof drizzle>[0]
+      type D1Config = NonNullable<Parameters<typeof drizzle>[1]>
+      return drizzle(client as D1Client, relations ? ({ relations } as D1Config) : undefined)
+    })()
+
+    databasePromise = promise.catch((error) => {
+      databasePromise = undefined
+      throw error
+    })
+    return databasePromise
   }
 
   return {
     getDatabase: ensureDatabase,
 
     async migrateDatabase() {
+      // The drizzle-kit SQL ↔ wrangler format contract is covered by the
+      // opt-in e2e test in packages/plugin-cloudflare/src/wrangler-migrations.test.ts
+      // (GUREN_TEST_WRANGLER=1); keep its hand-written fixtures in sync with
+      // drizzle-kit output when migration generation changes.
       throw new Error(
         'D1 migrations are not applied at runtime. Run `wrangler d1 migrations apply <database>` ' +
           `(local: add --local) with d1_databases[].migrations_dir pointing at ${migrationsHint}.`,
@@ -83,8 +100,9 @@ export function createD1Database(options: D1DatabaseOptions): D1DatabaseHandle {
     },
 
     async closeDatabase() {
-      // D1 sessions have no connection to close; just drop the cached instance.
-      db = undefined
+      // D1 sessions have no connection to close; just drop the cached instance
+      // (mirrors the sqlite factory).
+      databasePromise = undefined
     },
 
     async configureOrm() {

--- a/packages/orm/src/d1.ts
+++ b/packages/orm/src/d1.ts
@@ -1,0 +1,115 @@
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { DrizzleAdapter } from './adapters/drizzle-adapter'
+
+export interface D1DatabaseOptions {
+  /**
+   * Resolver returning the Cloudflare D1 binding. Bindings arrive with the
+   * first request on Workers, so this must be a deferred closure, e.g.
+   * `binding: () => getWorkersEnv<Env>().DB`.
+   */
+  binding: () => unknown
+  /**
+   * Drizzle-kit migrations folder. D1 migrations are applied out-of-band via
+   * `wrangler d1 migrations apply` (point `d1_databases[].migrations_dir` at
+   * this folder); the factory only references it in error guidance.
+   */
+  migrationsFolder?: string | URL
+  /**
+   * Drizzle relations for RQB v2 (`db.query.*`).
+   * Build with `defineRelations(schema, ...)` from `drizzle-orm`,
+   * or with `relations()` from `drizzle-orm/_relations` for the RQB v1 partial-upgrade path.
+   */
+  relations?: Record<string, unknown>
+}
+
+export interface D1DatabaseHandle {
+  getDatabase(): Promise<unknown>
+  /** Always throws: D1 migrations are applied with `wrangler d1 migrations apply`, never at runtime. */
+  migrateDatabase(): Promise<void>
+  closeDatabase(): Promise<void>
+  configureOrm(): Promise<void>
+  /** Always throws: seed with SQL through `wrangler d1 execute`. */
+  seedDatabase(): Promise<void>
+  /** Always throws: recreate the database with wrangler instead. */
+  resetDatabase(): Promise<void>
+  /** Always throws: wrangler's tracker is authoritative — use `wrangler d1 migrations list`. */
+  migrationStatus(): Promise<never>
+}
+
+/**
+ * Cloudflare D1 database factory. D1 speaks the SQLite dialect, so schemas
+ * written for `createSqliteDatabase` port unchanged; only the connection and
+ * the migration workflow differ (wrangler owns migrations, see RFC 0003).
+ */
+export function createD1Database(options: D1DatabaseOptions): D1DatabaseHandle {
+  const { binding, migrationsFolder, relations } = options
+
+  const migrationsHint =
+    migrationsFolder == null
+      ? 'db/migrations'
+      : migrationsFolder instanceof URL
+        ? fileURLToPath(migrationsFolder)
+        : resolve(String(migrationsFolder))
+
+  let db: unknown
+
+  async function ensureDatabase(): Promise<unknown> {
+    if (db) return db
+
+    const client = binding()
+    if (client == null) {
+      throw new Error(
+        'createD1Database: the "binding" resolver returned no D1 binding. ' +
+          'On Workers this usually means it ran before the first request — defer access ' +
+          '(e.g. binding: () => getWorkersEnv<Env>().DB) and check the d1_databases entry in wrangler.jsonc.',
+      )
+    }
+
+    const { drizzle } = await import('drizzle-orm/d1')
+    type DrizzleConfig = NonNullable<Exclude<Parameters<typeof drizzle>[0], string>>
+    db = drizzle({ client, ...(relations ? { relations } : {}) } as DrizzleConfig)
+    return db
+  }
+
+  return {
+    getDatabase: ensureDatabase,
+
+    async migrateDatabase() {
+      throw new Error(
+        'D1 migrations are not applied at runtime. Run `wrangler d1 migrations apply <database>` ' +
+          `(local: add --local) with d1_databases[].migrations_dir pointing at ${migrationsHint}.`,
+      )
+    },
+
+    async closeDatabase() {
+      // D1 sessions have no connection to close; just drop the cached instance.
+      db = undefined
+    },
+
+    async configureOrm() {
+      const database = await ensureDatabase()
+      DrizzleAdapter.configure(database as Parameters<typeof DrizzleAdapter.configure>[0])
+    },
+
+    async seedDatabase() {
+      throw new Error(
+        'D1 seeding runs outside the Worker: generate SQL and apply it with ' +
+          '`wrangler d1 execute <database> --file <seed.sql>` (local: add --local).',
+      )
+    },
+
+    async resetDatabase() {
+      throw new Error(
+        'D1 databases are reset with wrangler, not at runtime: delete and recreate the database ' +
+          '(`wrangler d1 delete` / `wrangler d1 create`), then re-apply migrations with `wrangler d1 migrations apply`.',
+      )
+    },
+
+    async migrationStatus() {
+      throw new Error(
+        "Wrangler's migration tracker is authoritative for D1. Use `wrangler d1 migrations list <database>` instead.",
+      )
+    },
+  }
+}

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -58,6 +58,8 @@ export type { MySqlDatabase, MySqlDatabaseOptions } from './mysql'
 export { createSqliteDatabase } from './sqlite'
 export type { MigrationStatusEntry } from './migration-utils'
 export type { SqliteDatabase, SqliteDatabaseOptions } from './sqlite'
+export { createD1Database } from './d1'
+export type { D1DatabaseHandle, D1DatabaseOptions } from './d1'
 export { runSeeders, defineSeeder, loadSeeders } from './seeder'
 export type { SeederContext, SeederHandler } from './seeder'
 

--- a/packages/plugin-cloudflare/src/wrangler-migrations.test.ts
+++ b/packages/plugin-cloudflare/src/wrangler-migrations.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// Opt-in end-to-end contract test: verifies wrangler applies drizzle-kit
+// generated SQL (tab indentation, backtick quoting, `--> statement-breakpoint`
+// separators, 0000_-prefixed filename ordering) against a local D1 database.
+// Requires network on first run (bunx downloads wrangler + workerd), so it is
+// gated behind GUREN_TEST_WRANGLER=1 and skipped in CI.
+const enabled = process.env.GUREN_TEST_WRANGLER === '1'
+
+function wrangler(cwd: string, args: string[]): { exitCode: number; output: string } {
+  const result = Bun.spawnSync({
+    cmd: ['bunx', 'wrangler', ...args],
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  return {
+    exitCode: result.exitCode,
+    output: `${result.stdout.toString()}${result.stderr.toString()}`,
+  }
+}
+
+describe.skipIf(!enabled)('wrangler d1 migrations (drizzle-kit SQL contract)', () => {
+  let root: string
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'guren-wrangler-d1-'))
+    mkdirSync(join(root, 'db/migrations/meta'), { recursive: true })
+
+    writeFileSync(
+      join(root, 'wrangler.jsonc'),
+      JSON.stringify({
+        name: 'guren-fmt-test',
+        main: 'worker.js',
+        compatibility_date: '2026-07-01',
+        d1_databases: [
+          {
+            binding: 'DB',
+            database_name: 'guren-fmt-test',
+            database_id: '00000000-0000-0000-0000-000000000000',
+            migrations_dir: 'db/migrations',
+          },
+        ],
+      }),
+    )
+    writeFileSync(join(root, 'worker.js'), 'export default { fetch() { return new Response("ok") } }\n')
+
+    writeFileSync(
+      join(root, 'db/migrations/0000_bright_dawn.sql'),
+      'CREATE TABLE `posts` (\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\n\t`title` text NOT NULL\n);\n--> statement-breakpoint\nCREATE INDEX `posts_title_idx` ON `posts` (`title`);\n',
+    )
+    writeFileSync(
+      join(root, 'db/migrations/0001_calm_night.sql'),
+      'ALTER TABLE `posts` ADD `slug` text;\n--> statement-breakpoint\nCREATE UNIQUE INDEX `posts_slug_unique` ON `posts` (`slug`);\n',
+    )
+    writeFileSync(join(root, 'db/migrations/meta/_journal.json'), '{"version":"7","dialect":"sqlite","entries":[]}\n')
+  })
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  test(
+    'should apply drizzle-kit SQL files in filename order and stay idempotent',
+    () => {
+      const apply = wrangler(root, ['d1', 'migrations', 'apply', 'DB', '--local'])
+      expect(apply.exitCode).toBe(0)
+      expect(apply.output).toContain('0000_bright_dawn.sql')
+      expect(apply.output).toContain('0001_calm_night.sql')
+
+      const reapply = wrangler(root, ['d1', 'migrations', 'apply', 'DB', '--local'])
+      expect(reapply.exitCode).toBe(0)
+      expect(reapply.output).toContain('No migrations to apply')
+    },
+    240_000,
+  )
+
+  test(
+    'should produce a queryable schema including post-ALTER columns',
+    () => {
+      const query = wrangler(root, [
+        'd1',
+        'execute',
+        'DB',
+        '--local',
+        '--json',
+        '--command',
+        "INSERT INTO posts (title, slug) VALUES ('hello', 'hello-slug'); SELECT title, slug FROM posts",
+      ])
+      expect(query.exitCode).toBe(0)
+      expect(query.output).toContain('"hello-slug"')
+    },
+    240_000,
+  )
+})

--- a/rfcs/0003-cloudflare-workers-plugin.md
+++ b/rfcs/0003-cloudflare-workers-plugin.md
@@ -155,7 +155,9 @@ Differences from the other factories:
   slow and unsafe under concurrent isolates. `migrateDatabase()` throws with
   a message pointing at the wrangler command. (See Open Questions for the
   runtime-migrator alternative.)
-- **`closeDatabase()` is a no-op** — D1 sessions have no connection to close.
+- **`closeDatabase()`** ~~is a no-op~~ **Amended in implementation:** drops
+  the cached drizzle instance (mirroring the sqlite factory) rather than
+  doing strictly nothing — D1 still has no connection to close.
 - **`seedDatabase()` throws.** The existing seeder machinery reads seeder
   files from disk (`orm/src/seeder.ts`), and a Worker has no filesystem —
   `wrangler dev` storing local D1 data in SQLite does not give the Worker


### PR DESCRIPTION
## Summary

Implements **RFC 0003 Part 2**: the Cloudflare D1 database factory.

- **`createD1Database`** in `@guren/orm` — fourth factory alongside postgres/mysql/sqlite, re-exported through `@guren/core`'s explicit allowlist. Takes a deferred `binding` resolver (`binding: () => getWorkersEnv<Env>().DB` — D1 bindings only exist per-request on Workers, pairing with `@guren/plugin-cloudflare`'s lazy-boot handler from #151) and wires `drizzle-orm/d1` into the `DrizzleAdapter`. D1 speaks the SQLite dialect, so schemas written for `createSqliteDatabase` port unchanged.
- **Wrangler owns the migration lifecycle** (per the RFC): `migrateDatabase()`, `seedDatabase()`, `resetDatabase()`, and `migrationStatus()` throw with actionable guidance pointing at their `wrangler d1` equivalents instead of executing at runtime. Cold-start migrations under concurrent isolates are unsafe, and wrangler's applied-migrations tracker is authoritative for D1.
- **drizzle-kit ↔ wrangler format contract verified end-to-end**: an opt-in test (`GUREN_TEST_WRANGLER=1`, skipped in CI — first run downloads wrangler/workerd) applies drizzle-kit-style SQL (tab indentation, backtick quoting, `--> statement-breakpoint` separators, `0000_`-prefixed ordering) against wrangler's local D1 and asserts idempotent re-apply plus a queryable post-`ALTER` schema. Run green locally, including a manual pass covering defaults, indexes, and inserts.

Docs note: the full Cloudflare deploy guide (migration/seed workflow walkthrough) lands with Part 4's dogfooding so it can be written against the real `web/` setup.

## Testing

- 9 new unit tests for the factory (lazy binding resolution, instance caching, close/recreate, guidance errors)
- 2 opt-in wrangler end-to-end tests (run green locally)
- `bun run test:bun`: 2,478 tests, 0 fail; root `typecheck` clean; orm package suite 185 tests, 0 fail

Refs: RFC 0003