### PR TITLE
refactor!: expose vercelPlugin() via definePlugin instead of a class provider

### DIFF
--- a/.changeset/plugin-vercel-defineplugin.md
+++ b/.changeset/plugin-vercel-defineplugin.md
@@ -1,0 +1,8 @@
+---
+'@guren/plugin-vercel': minor
+'@guren/cli': minor
+---
+
+BREAKING (`@guren/plugin-vercel`): the provider export changed from the `GurenPluginVercelProvider` class to a `vercelPlugin(config?)` factory built on `definePlugin()`, aligning with `@guren/plugin-cloudflare` and the plugin contract's recommended shape. The config object is empty today and reserved so future fields never force another registration-shape change. Update registrations from `providers: [GurenPluginVercelProvider]` to `providers: [vercelPlugin()]`; `createVercelHandler` and `buildVercelOutput` are unchanged. The `gurenPlugin.provider` manifest field is dropped accordingly.
+
+`@guren/cli`: `guren plugin` now knows the official factory-shaped plugins (`@guren/plugin-vercel`, `@guren/plugin-cloudflare`) and auto-registers them as `providers: [vercelPlugin()]`-style call expressions in `src/app.ts` — previously factory plugins could only print a "register manually" hint.

--- a/contributing/plugin-contract.md
+++ b/contributing/plugin-contract.md
@@ -75,6 +75,8 @@ export { AnalyticsServiceProvider } from './AnalyticsServiceProvider'
 ```
 
 > **Note:** `bunx guren plugin <pkg>` registers the class export named by `gurenPlugin.provider`. The `{PascalPkg}Provider` name heuristic is only used as a fallback for packages with **no `gurenPlugin` manifest at all** (legacy plugins predating the manifest). If a manifest exists but omits `provider` — the case for `definePlugin()` factories, which must be called with their configuration — the CLI does **not** guess a name; it skips automatic registration and prints a reminder to register the export manually in `createApp({ providers })`.
+>
+> **Official-plugin exception:** the CLI ships a table of official plugins whose primary export is a *zero-config* `definePlugin()` factory (`@guren/plugin-vercel` → `vercelPlugin()`, `@guren/plugin-cloudflare` → `cloudflarePlugin()`) and auto-registers those as call expressions, e.g. `providers: [vercelPlugin()]`. The table exists because the documented flow runs `guren plugin <pkg>` *before* `bun add <pkg>`, when no manifest is readable yet; it is not open to third-party packages. Precedence: an installed manifest that declares `provider` (a stale class-shaped release) always wins over the table, and an existing configured call (e.g. `vercelPlugin({ ... })`) counts as already registered.
 
 ### Recommended: the `definePlugin()` Helper
 

--- a/docs/en/guides/plugins.md
+++ b/docs/en/guides/plugins.md
@@ -248,7 +248,7 @@ bunx guren plugin @guren/plugin-vercel
 
 The `plugin` command installs the package with `bun add` when missing (pass `--no-install` to skip), verifies the plugin's declared Guren compatibility (`--ignore-compatibility` to register anyway), adds the provider import, registers it in `createApp({ providers })`, and applies any `env` and `publishes` entries from the plugin's `gurenPlugin` manifest. `--force` overwrites already-published files.
 
-> **Note:** Automatic registration currently supports class-based provider exports only. Plugins built with `definePlugin()` export a factory that must be called with its configuration, so register them manually in `createApp({ providers })` as shown below.
+> **Note:** Automatic registration covers class-based provider exports and the official zero-config factory plugins (`@guren/plugin-vercel`, `@guren/plugin-cloudflare`), which are registered as `providers: [vercelPlugin()]`-style calls. Third-party plugins built with `definePlugin()` export a factory that must be called with its configuration, so register them manually in `createApp({ providers })` as shown below.
 
 ## Usage in a Guren Application
 

--- a/docs/ja/guides/plugins.md
+++ b/docs/ja/guides/plugins.md
@@ -248,7 +248,7 @@ bunx guren plugin @guren/plugin-vercel
 
 `plugin`コマンドは、依存が未インストールなら`bun add`でインストールし（`--no-install`でスキップ可能）、プラグインが宣言するGuren互換性を検証した上で（`--ignore-compatibility`で無視して登録可能）、プロバイダーのimport追加と`createApp({ providers })`への登録、マニフェストの`env`・`publishes`エントリの適用を行います。`--force`は公開済みファイルの上書きに使います。
 
-> **注意:** 自動登録が現在対応しているのはクラスベースのプロバイダーエクスポートのみです。`definePlugin()`で作成したプラグインは設定を渡してファクトリを呼び出す必要があるため、下記のように`createApp({ providers })`へ手動で登録してください。
+> **注意:** 自動登録が対応しているのは、クラスベースのプロバイダーエクスポートと、公式のゼロ設定ファクトリプラグイン(`@guren/plugin-vercel`・`@guren/plugin-cloudflare`。`providers: [vercelPlugin()]`形式の呼び出しで登録されます)です。サードパーティの`definePlugin()`プラグインは設定を渡してファクトリを呼び出す必要があるため、下記のように`createApp({ providers })`へ手動で登録してください。
 
 ## Gurenアプリケーションでの使用方法
 

--- a/packages/cli/src/patch-helpers.ts
+++ b/packages/cli/src/patch-helpers.ts
@@ -80,6 +80,13 @@ export async function addImport(
 export async function addProvider(
   filePath: string,
   providerName: string,
+  /**
+   * Custom "already registered" check over the existing array entries.
+   * Defaults to exact-match against `providerName`; factory registrations
+   * pass a prefix check so a configured call like `vercelPlugin({ ... })`
+   * counts as registered.
+   */
+  isRegistered?: (entries: string[]) => boolean,
 ): Promise<PatchResult> {
   const absolutePath = resolve(process.cwd(), filePath)
   let content: string
@@ -107,7 +114,10 @@ export async function addProvider(
     .map(p => p.trim())
     .filter(p => p.length > 0)
 
-  if (providers.some(p => p === providerName)) {
+  const alreadyRegistered = isRegistered
+    ? isRegistered(providers)
+    : providers.some(p => p === providerName)
+  if (alreadyRegistered) {
     return { modified: false, reason: 'Provider already registered' }
   }
 

--- a/packages/cli/src/plugin-vercel.ts
+++ b/packages/cli/src/plugin-vercel.ts
@@ -2,7 +2,7 @@ import { access, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import type { WriterOptions } from './utils'
 
-const VERCEL_PLUGIN_PACKAGE = '@guren/plugin-vercel'
+export const VERCEL_PLUGIN_PACKAGE = '@guren/plugin-vercel'
 
 export async function installOfficialVercelPlugin(options: WriterOptions = {}): Promise<string[]> {
   await assertSupportedSsrApp()

--- a/packages/cli/src/plugin.ts
+++ b/packages/cli/src/plugin.ts
@@ -38,6 +38,17 @@ function toMessages(kind: PluginInstallMessageKind, texts: string[]): PluginInst
   return texts.map((text) => ({ kind, text }))
 }
 
+/**
+ * Official plugins whose primary export is a zero-config `definePlugin()`
+ * factory rather than a provider class. Their manifests omit
+ * `gurenPlugin.provider` (a factory cannot be named there), but the CLI can
+ * still auto-register them because the call expression is known.
+ */
+const OFFICIAL_FACTORY_PLUGINS: Record<string, { importName: string; expression: string }> = {
+  '@guren/plugin-vercel': { importName: 'vercelPlugin', expression: 'vercelPlugin()' },
+  '@guren/plugin-cloudflare': { importName: 'cloudflarePlugin', expression: 'cloudflarePlugin()' },
+}
+
 function providerIdentifierForPackage(packageName: string): string {
   const normalized = packageName.replace(/^@/u, '').replace(/[^a-zA-Z0-9]+/gu, ' ')
   const parts = normalized.split(/\s+/u).filter(Boolean)
@@ -103,7 +114,9 @@ export async function installPlugin(options: InstallPluginOptions): Promise<Plug
     }
   }
 
-  if (manifest && !manifest.provider) {
+  const factoryPlugin = OFFICIAL_FACTORY_PLUGINS[packageName]
+
+  if (manifest && !manifest.provider && !factoryPlugin) {
     // A manifest exists but intentionally omits `provider` -- e.g. a
     // command-only plugin, or a definePlugin() factory that must be called
     // with configuration. Fabricating a name here would write an import
@@ -113,12 +126,18 @@ export async function installPlugin(options: InstallPluginOptions): Promise<Plug
       text: `${packageName} does not declare a gurenPlugin.provider; register its export manually in createApp({ providers }).`,
     })
   } else {
-    const providerName = manifest?.provider ?? providerIdentifierForPackage(packageName)
+    // Official plugins expose a zero-config definePlugin() factory; the
+    // generic manifest path can only register named provider classes, so
+    // their factory-call expression is known here instead.
+    const providerName = factoryPlugin?.importName
+      ?? manifest?.provider
+      ?? providerIdentifierForPackage(packageName)
+    const providerExpression = factoryPlugin?.expression ?? providerName
     const providerImport = `import { ${providerName} } from '${packageName}'`
 
     const appPath = 'src/app.ts'
     const imported = await addImport(appPath, providerImport)
-    const registered = await addProvider(appPath, providerName)
+    const registered = await addProvider(appPath, providerExpression)
 
     if (imported.reason === 'File not found' || registered.reason === 'File not found') {
       throw new Error('src/app.ts was not found. Run this command inside a Guren app.')

--- a/packages/cli/src/plugin.ts
+++ b/packages/cli/src/plugin.ts
@@ -11,7 +11,7 @@ import {
   readPluginManifest,
   type PublishResult,
 } from './plugin-manifest'
-import { assertSupportedOfficialVercelPlugin, installOfficialVercelPlugin } from './plugin-vercel'
+import { assertSupportedOfficialVercelPlugin, installOfficialVercelPlugin, VERCEL_PLUGIN_PACKAGE } from './plugin-vercel'
 
 export interface InstallPluginOptions extends WriterOptions {
   packageName: string
@@ -40,13 +40,16 @@ function toMessages(kind: PluginInstallMessageKind, texts: string[]): PluginInst
 
 /**
  * Official plugins whose primary export is a zero-config `definePlugin()`
- * factory rather than a provider class. Their manifests omit
- * `gurenPlugin.provider` (a factory cannot be named there), but the CLI can
- * still auto-register them because the call expression is known.
+ * factory rather than a provider class, mapped to the factory's export name.
+ *
+ * This table cannot become a manifest field: the documented flow runs
+ * `guren plugin <pkg>` before `bun add <pkg>`, so no manifest is readable at
+ * registration time. An installed manifest that declares `provider` (a stale
+ * class-shaped release) always wins over this table.
  */
-const OFFICIAL_FACTORY_PLUGINS: Record<string, { importName: string; expression: string }> = {
-  '@guren/plugin-vercel': { importName: 'vercelPlugin', expression: 'vercelPlugin()' },
-  '@guren/plugin-cloudflare': { importName: 'cloudflarePlugin', expression: 'cloudflarePlugin()' },
+const OFFICIAL_FACTORY_PLUGINS: Record<string, string> = {
+  [VERCEL_PLUGIN_PACKAGE]: 'vercelPlugin',
+  '@guren/plugin-cloudflare': 'cloudflarePlugin',
 }
 
 function providerIdentifierForPackage(packageName: string): string {
@@ -86,7 +89,7 @@ export async function installPlugin(options: InstallPluginOptions): Promise<Plug
     throw new Error('Plugin package name is required.')
   }
 
-  if (packageName === '@guren/plugin-vercel') {
+  if (packageName === VERCEL_PLUGIN_PACKAGE) {
     await assertSupportedOfficialVercelPlugin()
   }
 
@@ -114,9 +117,12 @@ export async function installPlugin(options: InstallPluginOptions): Promise<Plug
     }
   }
 
-  const factoryPlugin = OFFICIAL_FACTORY_PLUGINS[packageName]
+  // An installed manifest that names a provider class describes the actual
+  // installed version and takes precedence over the official-factory table
+  // (which describes the latest release, for the register-before-install flow).
+  const factoryName = manifest?.provider ? undefined : OFFICIAL_FACTORY_PLUGINS[packageName]
 
-  if (manifest && !manifest.provider && !factoryPlugin) {
+  if (manifest && !manifest.provider && !factoryName) {
     // A manifest exists but intentionally omits `provider` -- e.g. a
     // command-only plugin, or a definePlugin() factory that must be called
     // with configuration. Fabricating a name here would write an import
@@ -129,15 +135,21 @@ export async function installPlugin(options: InstallPluginOptions): Promise<Plug
     // Official plugins expose a zero-config definePlugin() factory; the
     // generic manifest path can only register named provider classes, so
     // their factory-call expression is known here instead.
-    const providerName = factoryPlugin?.importName
+    const providerName = factoryName
       ?? manifest?.provider
       ?? providerIdentifierForPackage(packageName)
-    const providerExpression = factoryPlugin?.expression ?? providerName
+    const providerExpression = factoryName ? `${factoryName}()` : providerName
     const providerImport = `import { ${providerName} } from '${packageName}'`
 
     const appPath = 'src/app.ts'
     const imported = await addImport(appPath, providerImport)
-    const registered = await addProvider(appPath, providerExpression)
+    // A user may already have a configured call (e.g. `vercelPlugin({ ... })`)
+    // registered; any entry invoking the factory counts as registered.
+    const registered = await addProvider(
+      appPath,
+      providerExpression,
+      factoryName ? (entries) => entries.some((entry) => entry.startsWith(`${factoryName}(`)) : undefined,
+    )
 
     if (imported.reason === 'File not found' || registered.reason === 'File not found') {
       throw new Error('src/app.ts was not found. Run this command inside a Guren app.')
@@ -154,7 +166,7 @@ export async function installPlugin(options: InstallPluginOptions): Promise<Plug
     }
   }
 
-  if (packageName === '@guren/plugin-vercel') {
+  if (packageName === VERCEL_PLUGIN_PACKAGE) {
     const pluginFiles = await installOfficialVercelPlugin(options)
     messages.push(...toMessages('updated', pluginFiles))
   }

--- a/packages/cli/tests/plugin.test.ts
+++ b/packages/cli/tests/plugin.test.ts
@@ -116,6 +116,58 @@ export default app
     expect(gitignore.match(/\.vercel/g)?.length ?? 0).toBe(1)
   })
 
+  it('honors a stale installed manifest that still declares a class provider', async () => {
+    await writeInstalledPackage('@guren/plugin-vercel', {
+      version: '0.1.2',
+      gurenPlugin: { provider: 'GurenPluginVercelProvider' },
+    })
+    await writeInstalledPackage('@guren/core', { version: '1.2.0' })
+
+    await installPlugin({ packageName: '@guren/plugin-vercel' })
+
+    const app = await readFile('src/app.ts', 'utf8')
+    expect(app).toContain("import { GurenPluginVercelProvider } from '@guren/plugin-vercel'")
+    expect(app).toContain('providers: [GurenPluginVercelProvider]')
+    expect(app).not.toContain('vercelPlugin')
+  })
+
+  it('registers the factory when the installed manifest omits provider', async () => {
+    await writeInstalledPackage('@guren/plugin-vercel', {
+      version: '0.2.0',
+      gurenPlugin: { compatibility: '>=1.0.0 <2.0.0' },
+    })
+    await writeInstalledPackage('@guren/core', { version: '1.2.0' })
+
+    await installPlugin({ packageName: '@guren/plugin-vercel' })
+
+    const app = await readFile('src/app.ts', 'utf8')
+    expect(app).toContain("import { vercelPlugin } from '@guren/plugin-vercel'")
+    expect(app).toContain('providers: [vercelPlugin()]')
+  })
+
+  it('treats an existing configured factory call as already registered', async () => {
+    await installPlugin({ packageName: '@guren/plugin-vercel' })
+    const original = await readFile('src/app.ts', 'utf8')
+    await writeFile('src/app.ts', original.replace('vercelPlugin()', 'vercelPlugin({ future: true })'))
+
+    const second = await installPlugin({ packageName: '@guren/plugin-vercel' })
+
+    expect(textsOf(second, 'checked')).toContain('src/app.ts (already registered)')
+    const app = await readFile('src/app.ts', 'utf8')
+    expect(app).toContain('vercelPlugin({ future: true })')
+    expect(app).not.toContain('vercelPlugin()')
+  })
+
+  it('auto-registers the official Cloudflare factory plugin', async () => {
+    const messages = await installPlugin({ packageName: '@guren/plugin-cloudflare' })
+
+    expect(textsOf(messages, 'updated')).toContain('src/app.ts')
+
+    const app = await readFile('src/app.ts', 'utf8')
+    expect(app).toContain("import { cloudflarePlugin } from '@guren/plugin-cloudflare'")
+    expect(app).toContain('providers: [cloudflarePlugin()]')
+  })
+
   describe('gurenPlugin manifest', () => {
     async function writeManifestPackage(manifest: Record<string, unknown>): Promise<void> {
       await writeInstalledPackage('@acme/guren-plugin-audit', {

--- a/packages/cli/tests/plugin.test.ts
+++ b/packages/cli/tests/plugin.test.ts
@@ -90,8 +90,8 @@ export default app
     expect(textsOf(messages, 'hint')).toContain('Run: bun add @guren/plugin-vercel')
 
     const app = await readFile('src/app.ts', 'utf8')
-    expect(app).toContain("import { GurenPluginVercelProvider } from '@guren/plugin-vercel'")
-    expect(app).toContain('providers: [GurenPluginVercelProvider]')
+    expect(app).toContain("import { vercelPlugin } from '@guren/plugin-vercel'")
+    expect(app).toContain('providers: [vercelPlugin()]')
 
     const packageJson = JSON.parse(await readFile('package.json', 'utf8')) as { scripts?: Record<string, string> }
     expect(packageJson.scripts?.['vercel:build']).toBe('bun scripts/vercel-build.ts')
@@ -109,7 +109,7 @@ export default app
     expect(textsOf(second, 'checked')).toContain('src/app.ts (already registered)')
 
     const app = await readFile('src/app.ts', 'utf8')
-    const occurrences = app.match(/GurenPluginVercelProvider/g)?.length ?? 0
+    const occurrences = app.match(/vercelPlugin/g)?.length ?? 0
     expect(occurrences).toBe(2)
 
     const gitignore = await readFile('.gitignore', 'utf8')
@@ -217,6 +217,6 @@ export default app
     await expect(installPlugin({ packageName: '@guren/plugin-vercel' })).rejects.toThrow('SSR web apps only')
 
     const app = await readFile('src/app.ts', 'utf8')
-    expect(app).not.toContain('GurenPluginVercelProvider')
+    expect(app).not.toContain('vercelPlugin')
   })
 })

--- a/packages/plugin-vercel/package.json
+++ b/packages/plugin-vercel/package.json
@@ -16,8 +16,7 @@
     "access": "public"
   },
   "gurenPlugin": {
-    "compatibility": ">=1.0.0 <2.0.0",
-    "provider": "GurenPluginVercelProvider"
+    "compatibility": ">=1.0.0 <2.0.0"
   },
   "files": [
     "dist"

--- a/packages/plugin-vercel/src/index.ts
+++ b/packages/plugin-vercel/src/index.ts
@@ -1,7 +1,7 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { basename, extname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { ServiceProvider } from '@guren/core'
+import { definePlugin, type ServiceProviderConstructor } from '@guren/core'
 
 type PathLike = string | URL
 
@@ -31,8 +31,27 @@ export interface BuildVercelOutputOptions {
   migrationsDir?: PathLike
 }
 
-export class GurenPluginVercelProvider extends ServiceProvider {
-  register(): void {}
+/**
+ * Configuration for the Vercel plugin. Currently empty — reserved so future
+ * fields never force another registration-shape change.
+ */
+export interface VercelPluginConfig {}
+
+const factory = definePlugin<VercelPluginConfig>({
+  name: 'vercel',
+  register() {},
+})
+
+/**
+ * Register the Vercel plugin.
+ *
+ * @example
+ * ```typescript
+ * createApp({ providers: [vercelPlugin()] })
+ * ```
+ */
+export function vercelPlugin(config: VercelPluginConfig = {}): ServiceProviderConstructor {
+  return factory(config)
 }
 
 export async function createVercelHandler(app: VercelAppLike): Promise<VercelHandler> {

--- a/packages/plugin-vercel/tests/index.test.ts
+++ b/packages/plugin-vercel/tests/index.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it } from 'bun:test'
-import { buildVercelOutput, createVercelHandler, GurenPluginVercelProvider } from '../src/index'
+import { buildVercelOutput, createVercelHandler, vercelPlugin } from '../src/index'
 
 const tempDirs: string[] = []
 
@@ -31,8 +31,13 @@ describe('@guren/plugin-vercel', () => {
     expect(await response.text()).toBe('ok:/hello')
   })
 
-  it('exports the official provider class', () => {
-    expect(typeof GurenPluginVercelProvider).toBe('function')
+  it('returns an independent provider class per factory call', () => {
+    const first = vercelPlugin()
+    const second = vercelPlugin({})
+
+    expect(typeof first).toBe('function')
+    expect(first).not.toBe(second)
+    expect(first.name).toBe('vercelPluginProvider')
   })
 
   it('matches the configured handler filename to the bundled entrypoint', () => {


### PR DESCRIPTION
## Summary

Aligns `@guren/plugin-vercel` with `@guren/plugin-cloudflare` (#151) and the plugin contract's recommended `definePlugin()` factory shape, while the user base is still small enough to absorb the breaking export change.

### Changes

- **`@guren/plugin-vercel`**: `GurenPluginVercelProvider` (empty class provider) is replaced by a `vercelPlugin(config?)` factory built on `definePlugin()`. The config object is empty today and reserved, so future fields never force another registration-shape change (`vercelPlugin()` keeps working). `createVercelHandler` / `buildVercelOutput` are unchanged. `gurenPlugin.provider` is dropped from the manifest (factories cannot be named there).
- **`@guren/cli`**: `guren plugin` gains a known-plugins table for official factory-shaped plugins and auto-registers them as call expressions — `providers: [vercelPlugin()]` — instead of degrading to the "register manually" hint that manifest-without-provider packages normally get. `@guren/plugin-cloudflare` is pre-listed so it picks up the same UX once #151 lands.
- Docs need no changes: all guides reference `bunx guren plugin @guren/plugin-vercel`, and the CLI now writes the new registration form.

### Breaking change

```diff
-import { GurenPluginVercelProvider } from '@guren/plugin-vercel'
+import { vercelPlugin } from '@guren/plugin-vercel'

-createApp({ providers: [GurenPluginVercelProvider] })
+createApp({ providers: [vercelPlugin()] })
```

Apps scaffolded via `bunx guren plugin @guren/plugin-vercel` get the new form automatically; existing apps update one import and one array entry.

## Testing

- `packages/plugin-vercel`: 5 tests + typecheck clean
- `packages/cli` plugin tests: 12 tests pass (scaffold + idempotency + non-SSR rejection updated to the factory form)
- Root: `test:bun` 2,441 tests 0 fail; `typecheck` clean; `audit:core-first` / `audit:contracts` / `audit:docs` pass