### PR TITLE
feat(server): stop persisting sessions on every request (RFC 0003 Part 3b)

### DIFF
--- a/.changeset/session-write-reduction.md
+++ b/.changeset/session-write-reduction.md
@@ -1,0 +1,10 @@
+---
+'@guren/server': minor
+'@guren/core': minor
+---
+
+Reduced session write volume (RFC 0003 Part 3): the session middleware no longer persists on every request, which matters anywhere writes are metered (Cloudflare D1's free tier allows 100k row writes/day — previously every page view consumed one).
+
+- **Empty new sessions are not persisted and issue no cookie.** An anonymous request that never stores anything now costs zero store operations. Sessions (and their cookie) appear the moment anything is stored. Apps that relied on every visitor receiving a session cookie unconditionally will see it appear on first actual session use instead. (With the default auth stack this happens on the first CSRF-protected page, unchanged for now.)
+- **Flash aging only dirties sessions that carried flash data**, instead of marking every loaded session dirty on every request.
+- **New optional `SessionStore.touch(id, ttlSeconds)`** — rolling expiry for unchanged sessions becomes a TTL refresh instead of a full data rewrite. Implemented in `MemorySessionStore`, `RedisSessionStore` (EXPIRE), and `DatabaseSessionStore` (single UPDATE). Stores without `touch` keep the previous full-write fallback, and touching a missing session is a no-op — an expired session is no longer resurrected as an empty row by its stale cookie.

--- a/packages/core/src/session-store.ts
+++ b/packages/core/src/session-store.ts
@@ -109,6 +109,15 @@ export class DatabaseSessionStore implements SessionStore {
   }
 
   /**
+   * Refresh an existing session's TTL with a single UPDATE — no data
+   * rewrite, no existence check. Updating a missing row is a no-op, never a
+   * resurrection.
+   */
+  async touch(id: string, ttlSeconds: number): Promise<void> {
+    await this.model.forceUpdate({ id }, { expiresAt: new Date(Date.now() + ttlSeconds * 1000) })
+  }
+
+  /**
    * Delete sessions whose expiration time has passed. Expired rows are
    * already treated as missing (and removed) by `read`; call this from a
    * scheduled job to keep the table small.

--- a/packages/core/src/session-store.ts
+++ b/packages/core/src/session-store.ts
@@ -80,7 +80,7 @@ export class DatabaseSessionStore implements SessionStore {
   async write(id: string, data: SessionData, ttlSeconds: number): Promise<void> {
     const payload = {
       data: this.dataMode === 'text' ? JSON.stringify(data) : data,
-      expiresAt: new Date(Date.now() + ttlSeconds * 1000),
+      expiresAt: this.expiryDate(ttlSeconds),
     }
 
     const existing = await this.model.where({ id }).first()
@@ -109,12 +109,17 @@ export class DatabaseSessionStore implements SessionStore {
   }
 
   /**
-   * Refresh an existing session's TTL with a single UPDATE — no data
-   * rewrite, no existence check. Updating a missing row is a no-op, never a
-   * resurrection.
+   * Refresh an existing session's TTL with a single conditional UPDATE — no
+   * data rewrite, no existence check. Missing rows and rows that have
+   * already expired (but not yet been swept) are left untouched, never
+   * resurrected — matching the `SessionStore.touch` contract and the memory
+   * store's behavior.
    */
   async touch(id: string, ttlSeconds: number): Promise<void> {
-    await this.model.forceUpdate({ id }, { expiresAt: new Date(Date.now() + ttlSeconds * 1000) })
+    await this.model
+      .where({ id })
+      .where('expiresAt', '>', new Date())
+      .forceUpdate({ expiresAt: this.expiryDate(ttlSeconds) })
   }
 
   /**
@@ -128,5 +133,9 @@ export class DatabaseSessionStore implements SessionStore {
 
   private deserialize(record: PlainObject): SessionData {
     return decodeJsonColumn<SessionData>(record.data, {})
+  }
+
+  private expiryDate(ttlSeconds: number): Date {
+    return new Date(Date.now() + ttlSeconds * 1000)
   }
 }

--- a/packages/core/tests/session-store.test.ts
+++ b/packages/core/tests/session-store.test.ts
@@ -107,6 +107,19 @@ describe('DatabaseSessionStore', () => {
     expect(rows.count).toBe(0)
   })
 
+  test('should never refresh an expired-but-unswept row via touch', async () => {
+    const expired = Date.now() - 60_000
+    sqlite.exec(`INSERT INTO sessions (id, data, expires_at) VALUES ('stale', '{}', ${expired})`)
+
+    await store.touch('stale', 3600)
+
+    const row = sqlite.query("SELECT expires_at FROM sessions WHERE id = 'stale'").get() as {
+      expires_at: number
+    }
+    expect(row.expires_at).toBe(expired)
+    expect(await store.read('stale')).toBeUndefined()
+  })
+
   test('should delete only expired rows in deleteExpired', async () => {
     await store.write('live', { userId: 1 }, 3600)
     await store.write('dead', { userId: 2 }, -10)

--- a/packages/core/tests/session-store.test.ts
+++ b/packages/core/tests/session-store.test.ts
@@ -87,6 +87,26 @@ describe('DatabaseSessionStore', () => {
     await store.destroy('abc')
   })
 
+  test('should refresh the TTL via touch without rewriting data', async () => {
+    await store.write('abc', { userId: 7 }, 1)
+
+    await store.touch('abc', 3600)
+
+    const row = sqlite.query("SELECT expires_at FROM sessions WHERE id = 'abc'").get() as {
+      expires_at: number
+    }
+    expect(row.expires_at).toBeGreaterThan(Date.now() + 3000_000)
+    expect(await store.read('abc')).toEqual({ userId: 7 })
+  })
+
+  test('should never resurrect a missing session via touch', async () => {
+    await store.touch('ghost', 3600)
+
+    expect(await store.read('ghost')).toBeUndefined()
+    const rows = sqlite.query('SELECT COUNT(*) as count FROM sessions').get() as { count: number }
+    expect(rows.count).toBe(0)
+  })
+
   test('should delete only expired rows in deleteExpired', async () => {
     await store.write('live', { userId: 1 }, 3600)
     await store.write('dead', { userId: 2 }, -10)

--- a/packages/server/src/http/middleware/session.ts
+++ b/packages/server/src/http/middleware/session.ts
@@ -23,7 +23,8 @@ export interface SessionStore {
    * Optional: refresh an existing session's TTL without rewriting its data.
    * The middleware uses this for unchanged sessions (rolling expiry); stores
    * that omit it fall back to a full `write`. Refreshing a session that no
-   * longer exists must be a no-op, not a resurrection.
+   * longer exists — including one that has expired but not yet been swept
+   * from storage — must be a no-op, not a resurrection.
    */
   touch?(id: string, ttlSeconds: number): Promise<void>
 }
@@ -94,6 +95,14 @@ export interface Session {
   forget(key: string): void
   flush(): void
   all(): SessionData
+  /**
+   * Rotate the session id (call after login to mitigate session fixation).
+   * The new id is persisted and the old one destroyed at request end. Known
+   * limitation shared by every multi-process store: a concurrent request
+   * still carrying the old cookie can re-persist the old id afterwards; the
+   * resurrected row holds only pre-rotation data (no auth state), so
+   * fixation does not escalate, but the row can linger until it expires.
+   */
   regenerate(): void
   invalidate(): void
   flash(key: string, value: unknown): void
@@ -210,9 +219,7 @@ class SessionImpl implements Session {
    * every request carrying a session would persist unconditionally.
    */
   ageFlashData(): void {
-    const hadFlash =
-      Object.keys(this._flash.new).length > 0 ||
-      Object.keys(this._flash.old).length > 0
+    const hadFlash = this.hasFlash()
     this._flash.old = { ...this._flash.new }
     this._flash.new = {}
     if (hadFlash) {
@@ -239,17 +246,18 @@ class SessionImpl implements Session {
   }
 
   private hasContent(): boolean {
+    return Object.keys(this.data).length > 0 || this.hasFlash()
+  }
+
+  private hasFlash(): boolean {
     return (
-      Object.keys(this.data).length > 0 ||
       Object.keys(this._flash.new).length > 0 ||
       Object.keys(this._flash.old).length > 0
     )
   }
 
   snapshot(): SessionData {
-    const hasFlash =
-      Object.keys(this._flash.new).length > 0 ||
-      Object.keys(this._flash.old).length > 0
+    const hasFlash = this.hasFlash()
     return {
       ...this.data,
       ...(hasFlash ? { _flash: { new: { ...this._flash.new }, old: { ...this._flash.old } } } : {}),

--- a/packages/server/src/http/middleware/session.ts
+++ b/packages/server/src/http/middleware/session.ts
@@ -19,6 +19,13 @@ export interface SessionStore {
    * Destroy a session. Implementations must treat repeated calls as safe.
    */
   destroy(id: string): Promise<void>
+  /**
+   * Optional: refresh an existing session's TTL without rewriting its data.
+   * The middleware uses this for unchanged sessions (rolling expiry); stores
+   * that omit it fall back to a full `write`. Refreshing a session that no
+   * longer exists must be a no-op, not a resurrection.
+   */
+  touch?(id: string, ttlSeconds: number): Promise<void>
 }
 
 export class MemorySessionStore implements SessionStore {
@@ -47,6 +54,14 @@ export class MemorySessionStore implements SessionStore {
 
   async destroy(id: string): Promise<void> {
     this.store.delete(id)
+  }
+
+  async touch(id: string, ttlSeconds: number): Promise<void> {
+    const entry = this.store.get(id)
+    if (!entry || entry.expiresAt <= this.now()) {
+      return
+    }
+    entry.expiresAt = this.now() + ttlSeconds * 1000
   }
 }
 
@@ -191,11 +206,18 @@ class SessionImpl implements Session {
   /**
    * Age flash data: move `new` → `old`, clear previous `old`.
    * Called at the start of each request by the session middleware.
+   * Only dirties the session when there was flash data to age — otherwise
+   * every request carrying a session would persist unconditionally.
    */
   ageFlashData(): void {
+    const hadFlash =
+      Object.keys(this._flash.new).length > 0 ||
+      Object.keys(this._flash.old).length > 0
     this._flash.old = { ...this._flash.new }
     this._flash.new = {}
-    this.dirty = true
+    if (hadFlash) {
+      this.dirty = true
+    }
   }
 
   markTouched(): void {
@@ -211,7 +233,17 @@ class SessionImpl implements Session {
   }
 
   shouldPersist(): boolean {
-    return this.dirty || this.isNew
+    // Empty brand-new sessions are not persisted: an anonymous request that
+    // never stores anything must not cost a database write (or a cookie).
+    return this.dirty || (this.isNew && this.hasContent())
+  }
+
+  private hasContent(): boolean {
+    return (
+      Object.keys(this.data).length > 0 ||
+      Object.keys(this._flash.new).length > 0 ||
+      Object.keys(this._flash.old).length > 0
+    )
   }
 
   snapshot(): SessionData {
@@ -362,7 +394,13 @@ export function createSessionMiddleware(options: CreateSessionMiddlewareOptions 
 
       if (!session.shouldPersist()) {
         if (existingId) {
-          await store.write(existingId, session.snapshot(), ttlSeconds)
+          // Rolling expiry for an unchanged session: a TTL refresh, not a
+          // full rewrite, when the store supports it.
+          if (store.touch) {
+            await store.touch(existingId, ttlSeconds)
+          } else {
+            await store.write(existingId, session.snapshot(), ttlSeconds)
+          }
 
           setCookie(ctx, cookieName, signer.sign(existingId), {
             path: cookiePath,
@@ -378,6 +416,11 @@ export function createSessionMiddleware(options: CreateSessionMiddlewareOptions 
 
       const nextId = session.id
       await store.write(nextId, session.snapshot(), ttlSeconds)
+      // Known limitation shared by every multi-process store: a concurrent
+      // request still carrying the old cookie can re-persist the old id
+      // after this destroy. The resurrected session holds only pre-rotation
+      // data (no auth state), so fixation does not escalate, but the row can
+      // reappear until it expires.
       if (session.wasRegenerated() && session.originalSessionId() !== nextId) {
         await store.destroy(session.originalSessionId())
       }

--- a/packages/server/src/redis/RedisSessionStore.ts
+++ b/packages/server/src/redis/RedisSessionStore.ts
@@ -72,6 +72,15 @@ export class RedisSessionStore implements SessionStore {
   }
 
   /**
+   * Refresh an existing session's TTL without rewriting its data.
+   * EXPIRE on a missing key is a no-op, never a resurrection.
+   */
+  async touch(id: string, ttlSeconds: number): Promise<void> {
+    const key = this.prefix + id
+    await this.redis.expire(key, ttlSeconds)
+  }
+
+  /**
    * Get all session keys (for debugging/admin purposes).
    * Note: This uses SCAN to avoid blocking Redis.
    */

--- a/packages/server/tests/http/middleware/session.test.ts
+++ b/packages/server/tests/http/middleware/session.test.ts
@@ -4,6 +4,7 @@ import {
   createSessionMiddleware,
   getSessionFromContext,
   MemorySessionStore,
+  type SessionStore,
 } from '../../../src/http/middleware/session'
 
 const APP_KEY = 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
@@ -93,8 +94,21 @@ describe('createSessionMiddleware', () => {
     expect(sessionId).toBeDefined()
     expect(isNew).toBe(true)
 
-    const setCookie = res.headers.get('set-cookie')
-    expect(setCookie).toContain('guren.session=')
+    // An untouched new session is not persisted and issues no cookie.
+    expect(res.headers.get('set-cookie')).toBeNull()
+  })
+
+  it('issues a cookie once a new session stores data', async () => {
+    const app = createTestApp()
+
+    app.get('/test', (c) => {
+      getSessionFromContext(c)?.set('visited', true)
+      return c.text('ok')
+    })
+
+    const res = await app.request('/test')
+
+    expect(res.headers.get('set-cookie')).toContain('guren.session=')
   })
 
   it('reuses existing session when cookie is present', async () => {
@@ -350,7 +364,10 @@ describe('createSessionMiddleware', () => {
   it('respects custom cookie name', async () => {
     const app = createTestApp({ cookieName: 'my_session' })
 
-    app.get('/test', (c) => c.text('ok'))
+    app.get('/test', (c) => {
+      getSessionFromContext(c)?.set('visited', true)
+      return c.text('ok')
+    })
 
     const res = await app.request('/test')
     const setCookie = res.headers.get('set-cookie')
@@ -366,7 +383,10 @@ describe('createSessionMiddleware', () => {
       cookieHttpOnly: true,
     })
 
-    app.get('/test', (c) => c.text('ok'))
+    app.get('/test', (c) => {
+      getSessionFromContext(c)?.set('visited', true)
+      return c.text('ok')
+    })
 
     const res = await app.request('/test')
     const setCookie = res.headers.get('set-cookie')
@@ -374,6 +394,160 @@ describe('createSessionMiddleware', () => {
     expect(setCookie).toContain('Path=/api')
     expect(setCookie).toContain('SameSite=Strict')
     expect(setCookie).toContain('HttpOnly')
+  })
+})
+
+describe('session write volume', () => {
+  class CountingStore extends MemorySessionStore {
+    writes = 0
+    touches = 0
+    destroys = 0
+
+    override async write(id: string, data: Record<string, unknown>, ttlSeconds: number): Promise<void> {
+      this.writes += 1
+      await super.write(id, data, ttlSeconds)
+    }
+
+    override async touch(id: string, ttlSeconds: number): Promise<void> {
+      this.touches += 1
+      await super.touch(id, ttlSeconds)
+    }
+
+    override async destroy(id: string): Promise<void> {
+      this.destroys += 1
+      await super.destroy(id)
+    }
+  }
+
+  // A store without touch support exercises the full-write fallback.
+  class NoTouchStore implements SessionStore {
+    writes = 0
+    private readonly inner = new MemorySessionStore()
+
+    async read(id: string) {
+      return this.inner.read(id)
+    }
+
+    async write(id: string, data: Record<string, unknown>, ttlSeconds: number): Promise<void> {
+      this.writes += 1
+      await this.inner.write(id, data, ttlSeconds)
+    }
+
+    async destroy(id: string): Promise<void> {
+      await this.inner.destroy(id)
+    }
+  }
+
+  // Hono forbids adding routes once a request has been handled, so every
+  // route is registered up front and /login establishes the session.
+  function createCountingApp(store: SessionStore) {
+    const app = new Hono()
+    app.use('*', createSessionMiddleware({ store }))
+    app.get('/login', (c) => {
+      getSessionFromContext(c)?.set('userId', 7)
+      return c.text('ok')
+    })
+    app.get('/page', (c) => c.text('ok'))
+    app.get('/update', (c) => {
+      getSessionFromContext(c)?.set('theme', 'dark')
+      return c.text('ok')
+    })
+    app.get('/flash', (c) => {
+      getSessionFromContext(c)?.flash('status', 'saved')
+      return c.text('ok')
+    })
+    app.get('/rotate', (c) => {
+      getSessionFromContext(c)?.regenerate()
+      return c.text('ok')
+    })
+    return app
+  }
+
+  async function establishSession(app: Hono, store: CountingStore | NoTouchStore): Promise<string> {
+    const res = await app.request('/login')
+    const cookie = res.headers.get('set-cookie')?.split(';')[0]
+    if (!cookie) throw new Error('expected session cookie')
+    store.writes = 0
+    return cookie
+  }
+
+  it('performs zero store operations for an anonymous GET that never touches the session', async () => {
+    const store = new CountingStore()
+    const app = createCountingApp(store)
+
+    await app.request('/page')
+    await app.request('/page')
+
+    expect(store.writes).toBe(0)
+    expect(store.touches).toBe(0)
+    expect(store.destroys).toBe(0)
+  })
+
+  it('refreshes an unchanged session with touch instead of a full write', async () => {
+    const store = new CountingStore()
+    const app = createCountingApp(store)
+    const cookie = await establishSession(app, store)
+
+    const res = await app.request('/page', { headers: { Cookie: cookie } })
+
+    expect(store.writes).toBe(0)
+    expect(store.touches).toBe(1)
+    // The rolling cookie is still refreshed.
+    expect(res.headers.get('set-cookie')).toContain('guren.session=')
+  })
+
+  it('falls back to a full write for stores without touch support', async () => {
+    const store = new NoTouchStore()
+    const app = createCountingApp(store)
+    const cookie = await establishSession(app, store)
+
+    await app.request('/page', { headers: { Cookie: cookie } })
+
+    expect(store.writes).toBe(1)
+  })
+
+  it('writes once when session data changes', async () => {
+    const store = new CountingStore()
+    const app = createCountingApp(store)
+    const cookie = await establishSession(app, store)
+
+    await app.request('/update', { headers: { Cookie: cookie } })
+
+    expect(store.writes).toBe(1)
+    expect(store.touches).toBe(0)
+  })
+
+  it('writes while flash data ages out, then returns to touch-only', async () => {
+    const store = new CountingStore()
+    const app = createCountingApp(store)
+    const cookie = await establishSession(app, store)
+
+    await app.request('/flash', { headers: { Cookie: cookie } })
+    expect(store.writes).toBe(1)
+
+    // Aging moves new → old: write.
+    await app.request('/page', { headers: { Cookie: cookie } })
+    expect(store.writes).toBe(2)
+
+    // Aging clears the consumed old bag: final write.
+    await app.request('/page', { headers: { Cookie: cookie } })
+    expect(store.writes).toBe(3)
+
+    // Flash fully drained: back to touch-only.
+    await app.request('/page', { headers: { Cookie: cookie } })
+    expect(store.writes).toBe(3)
+    expect(store.touches).toBe(1)
+  })
+
+  it('writes the new id and destroys the old one on regeneration', async () => {
+    const store = new CountingStore()
+    const app = createCountingApp(store)
+    const cookie = await establishSession(app, store)
+
+    await app.request('/rotate', { headers: { Cookie: cookie } })
+
+    expect(store.writes).toBe(1)
+    expect(store.destroys).toBe(1)
   })
 })
 

--- a/packages/server/tests/http/middleware/session.test.ts
+++ b/packages/server/tests/http/middleware/session.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'bun:test'
+import { afterEach, describe, expect, it, spyOn, type Mock } from 'bun:test'
 import { Hono } from 'hono'
 import {
   createSessionMiddleware,
@@ -52,6 +52,30 @@ describe('MemorySessionStore', () => {
 
     // After expiry
     currentTime = 1000 + 61 * 1000
+    expect(await store.read('session-1')).toBeUndefined()
+  })
+
+  it('refreshes the TTL of a live entry via touch', async () => {
+    let currentTime = 1000
+    const store = new MemorySessionStore(() => currentTime)
+
+    await store.write('session-1', { user: 'Alice' }, 60)
+    currentTime = 1000 + 50 * 1000
+    await store.touch('session-1', 60)
+
+    // Past the original expiry, still alive thanks to the refresh.
+    currentTime = 1000 + 90 * 1000
+    expect(await store.read('session-1')).toEqual({ user: 'Alice' })
+  })
+
+  it('never revives an expired entry via touch', async () => {
+    let currentTime = 1000
+    const store = new MemorySessionStore(() => currentTime)
+
+    await store.write('session-1', { user: 'Alice' }, 60)
+    currentTime = 1000 + 61 * 1000
+    await store.touch('session-1', 3600)
+
     expect(await store.read('session-1')).toBeUndefined()
   })
 
@@ -398,44 +422,25 @@ describe('createSessionMiddleware', () => {
 })
 
 describe('session write volume', () => {
-  class CountingStore extends MemorySessionStore {
-    writes = 0
-    touches = 0
-    destroys = 0
-
-    override async write(id: string, data: Record<string, unknown>, ttlSeconds: number): Promise<void> {
-      this.writes += 1
-      await super.write(id, data, ttlSeconds)
-    }
-
-    override async touch(id: string, ttlSeconds: number): Promise<void> {
-      this.touches += 1
-      await super.touch(id, ttlSeconds)
-    }
-
-    override async destroy(id: string): Promise<void> {
-      this.destroys += 1
-      await super.destroy(id)
+  function createSpiedStore() {
+    const store = new MemorySessionStore()
+    return {
+      store,
+      writes: spyOn(store, 'write'),
+      touches: spyOn(store, 'touch'),
+      destroys: spyOn(store, 'destroy'),
     }
   }
 
   // A store without touch support exercises the full-write fallback.
-  class NoTouchStore implements SessionStore {
-    writes = 0
-    private readonly inner = new MemorySessionStore()
-
-    async read(id: string) {
-      return this.inner.read(id)
+  function createNoTouchStore() {
+    const inner = new MemorySessionStore()
+    const store: SessionStore = {
+      read: (id) => inner.read(id),
+      write: (id, data, ttlSeconds) => inner.write(id, data, ttlSeconds),
+      destroy: (id) => inner.destroy(id),
     }
-
-    async write(id: string, data: Record<string, unknown>, ttlSeconds: number): Promise<void> {
-      this.writes += 1
-      await this.inner.write(id, data, ttlSeconds)
-    }
-
-    async destroy(id: string): Promise<void> {
-      await this.inner.destroy(id)
-    }
+    return { store, writes: spyOn(store, 'write') }
   }
 
   // Hono forbids adding routes once a request has been handled, so every
@@ -463,91 +468,91 @@ describe('session write volume', () => {
     return app
   }
 
-  async function establishSession(app: Hono, store: CountingStore | NoTouchStore): Promise<string> {
+  async function establishSession(app: Hono, writes: Mock<SessionStore['write']>): Promise<string> {
     const res = await app.request('/login')
     const cookie = res.headers.get('set-cookie')?.split(';')[0]
     if (!cookie) throw new Error('expected session cookie')
-    store.writes = 0
+    writes.mockClear()
     return cookie
   }
 
   it('performs zero store operations for an anonymous GET that never touches the session', async () => {
-    const store = new CountingStore()
+    const { store, writes, touches, destroys } = createSpiedStore()
     const app = createCountingApp(store)
 
     await app.request('/page')
     await app.request('/page')
 
-    expect(store.writes).toBe(0)
-    expect(store.touches).toBe(0)
-    expect(store.destroys).toBe(0)
+    expect(writes).toHaveBeenCalledTimes(0)
+    expect(touches).toHaveBeenCalledTimes(0)
+    expect(destroys).toHaveBeenCalledTimes(0)
   })
 
   it('refreshes an unchanged session with touch instead of a full write', async () => {
-    const store = new CountingStore()
+    const { store, writes, touches } = createSpiedStore()
     const app = createCountingApp(store)
-    const cookie = await establishSession(app, store)
+    const cookie = await establishSession(app, writes)
 
     const res = await app.request('/page', { headers: { Cookie: cookie } })
 
-    expect(store.writes).toBe(0)
-    expect(store.touches).toBe(1)
+    expect(writes).toHaveBeenCalledTimes(0)
+    expect(touches).toHaveBeenCalledTimes(1)
     // The rolling cookie is still refreshed.
     expect(res.headers.get('set-cookie')).toContain('guren.session=')
   })
 
   it('falls back to a full write for stores without touch support', async () => {
-    const store = new NoTouchStore()
+    const { store, writes } = createNoTouchStore()
     const app = createCountingApp(store)
-    const cookie = await establishSession(app, store)
+    const cookie = await establishSession(app, writes)
 
     await app.request('/page', { headers: { Cookie: cookie } })
 
-    expect(store.writes).toBe(1)
+    expect(writes).toHaveBeenCalledTimes(1)
   })
 
   it('writes once when session data changes', async () => {
-    const store = new CountingStore()
+    const { store, writes, touches } = createSpiedStore()
     const app = createCountingApp(store)
-    const cookie = await establishSession(app, store)
+    const cookie = await establishSession(app, writes)
 
     await app.request('/update', { headers: { Cookie: cookie } })
 
-    expect(store.writes).toBe(1)
-    expect(store.touches).toBe(0)
+    expect(writes).toHaveBeenCalledTimes(1)
+    expect(touches).toHaveBeenCalledTimes(0)
   })
 
   it('writes while flash data ages out, then returns to touch-only', async () => {
-    const store = new CountingStore()
+    const { store, writes, touches } = createSpiedStore()
     const app = createCountingApp(store)
-    const cookie = await establishSession(app, store)
+    const cookie = await establishSession(app, writes)
 
     await app.request('/flash', { headers: { Cookie: cookie } })
-    expect(store.writes).toBe(1)
+    expect(writes).toHaveBeenCalledTimes(1)
 
-    // Aging moves new → old: write.
+    // Aging moves new -> old: write.
     await app.request('/page', { headers: { Cookie: cookie } })
-    expect(store.writes).toBe(2)
+    expect(writes).toHaveBeenCalledTimes(2)
 
     // Aging clears the consumed old bag: final write.
     await app.request('/page', { headers: { Cookie: cookie } })
-    expect(store.writes).toBe(3)
+    expect(writes).toHaveBeenCalledTimes(3)
 
     // Flash fully drained: back to touch-only.
     await app.request('/page', { headers: { Cookie: cookie } })
-    expect(store.writes).toBe(3)
-    expect(store.touches).toBe(1)
+    expect(writes).toHaveBeenCalledTimes(3)
+    expect(touches).toHaveBeenCalledTimes(1)
   })
 
   it('writes the new id and destroys the old one on regeneration', async () => {
-    const store = new CountingStore()
+    const { store, writes, destroys } = createSpiedStore()
     const app = createCountingApp(store)
-    const cookie = await establishSession(app, store)
+    const cookie = await establishSession(app, writes)
 
     await app.request('/rotate', { headers: { Cookie: cookie } })
 
-    expect(store.writes).toBe(1)
-    expect(store.destroys).toBe(1)
+    expect(writes).toHaveBeenCalledTimes(1)
+    expect(destroys).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -568,6 +573,23 @@ describe('X-Testing-Session hydration', () => {
     app.get('/session', (c) => c.json(getSessionFromContext(c)?.all() ?? {}))
     return app
   }
+
+  it('persists a new session hydrated with testing data', async () => {
+    process.env.GUREN_TESTING = '1'
+    const store = new MemorySessionStore()
+    const app = createTestApp({ store })
+    const writes = spyOn(store, 'write')
+
+    const res = await app.request('/session', {
+      headers: { 'X-Testing-Session': JSON.stringify({ userId: 7 }) },
+    })
+
+    // Hydrated content counts as content: the empty-new-session rule must
+    // not drop testing sessions.
+    expect(await res.json()).toEqual({ userId: 7 })
+    expect(writes).toHaveBeenCalledTimes(1)
+    expect(res.headers.get('set-cookie')).toContain('guren.session=')
+  })
 
   it('hydrates session from header when GUREN_TESTING is set', async () => {
     process.env.GUREN_TESTING = '1'


### PR DESCRIPTION
## Summary

Second slice of **RFC 0003 Part 3** — the session write-volume fixes. Verified during the Part 3a review: the middleware wrote to the store on essentially every request (`shouldPersist()` returned true for every new session, `ageFlashData()` unconditionally dirtied every loaded session, and the unchanged-session branch rewrote the full snapshot for rolling expiry). On metered stores — Cloudflare D1's free tier allows 100k row writes/day — that turned every page view into a database write.

### Behavior changes

- **Empty new sessions are not persisted and issue no cookie.** An anonymous request that never stores anything costs zero store operations. The session (and cookie) appears the moment anything is stored. With the default auth stack, CSRF token generation on GETs still creates sessions — making that lazy/stateless is the next slice (Part 3c), kept separate because it is security-sensitive.
- **Flash aging only dirties sessions that carried flash data.**
- **Rolling expiry uses the new optional `SessionStore.touch(id, ttlSeconds)`** instead of rewriting the full snapshot: implemented in `MemorySessionStore`, `RedisSessionStore` (EXPIRE), and `DatabaseSessionStore` (single UPDATE, no data rewrite, no existence check). Stores without `touch` keep the previous full-write fallback. Touching a missing session is a no-op, so an expired session is no longer resurrected as an empty row by its stale cookie.
- The regeneration ordering limitation (a concurrent request with the old cookie can re-persist the old id after rotation; the resurrected row carries only pre-rotation data) is now documented at the destroy site — shared by every multi-process store, not introduced here.

### Write-count regression tests

A counting store wrapper asserts the contract end-to-end through the middleware: anonymous GET = zero store operations; unchanged session = one `touch` (or one write with a non-touch store); data change = one write; flash = writes only until the bag drains, then back to touch-only; regeneration = one write + one destroy.

Three pre-existing tests asserting the old "cookie on every empty new session" behavior were updated to the new contract (cookie-attribute assertions now exercise sessions that store data).

## Testing

- Session middleware suite: 30 tests, 0 fail (6 new write-volume tests + 1 new cookie-issuance test)
- `bun run test:bun`: 2,518 tests, 0 fail; `test:examples` (blog/api/web) green; root `typecheck` clean
- `DatabaseSessionStore.touch` covered in core (TTL refresh without data rewrite; no resurrection of missing sessions)

Refs: RFC 0003