### PR TITLE
fix(server): make OAuth state consumption atomic

### DIFF
--- a/packages/core/src/oauth-state-store.ts
+++ b/packages/core/src/oauth-state-store.ts
@@ -53,6 +53,16 @@ export class DatabaseOAuthStateStore implements OAuthStateStore {
   }
 
   async find(stateHash: string): Promise<OAuthStatePayload | null> {
+    const record = await this.fetchLive(stateHash)
+    return record ? mapRecordToPayload(record) : null
+  }
+
+  /**
+   * Fetch the row for `stateHash`, clearing it out and returning null if
+   * expired. Shared by `find` and `consume`, which otherwise diverge only
+   * in what they do with a live row.
+   */
+  private async fetchLive(stateHash: string): Promise<Record<string, unknown> | null> {
     const record = await this.model.where({ stateHash }).first()
     if (!record) {
       return null
@@ -66,12 +76,7 @@ export class DatabaseOAuthStateStore implements OAuthStateStore {
       return null
     }
 
-    return {
-      provider: String(record.provider),
-      redirectTo: record.redirectTo == null ? undefined : String(record.redirectTo),
-      // isExpired above guarantees this parses.
-      expiresAt: toDate(record.expiresAt) as Date,
-    }
+    return record
   }
 
   async delete(stateHash: string): Promise<void> {
@@ -104,13 +109,8 @@ export class DatabaseOAuthStateStore implements OAuthStateStore {
    * matched" signal.
    */
   async consume(stateHash: string): Promise<OAuthStatePayload | null> {
-    const record = await this.model.where({ stateHash }).first()
+    const record = await this.fetchLive(stateHash)
     if (!record) {
-      return null
-    }
-
-    if (isExpired(record.expiresAt)) {
-      await this.model.where({ stateHash, expiresAt: record.expiresAt }).delete()
       return null
     }
 
@@ -118,18 +118,11 @@ export class DatabaseOAuthStateStore implements OAuthStateStore {
     // DELETE actually removes the row may return the payload. RETURNING
     // drivers (postgres, sqlite, d1) yield the deleted row or undefined;
     // MySQL yields a result carrying affectedRows — both distinguish the
-    // winner from concurrent losers.
+    // winner from concurrent losers. The pre-delete read above is what
+    // supplies the payload on MySQL, which has no RETURNING to read it
+    // back from the delete itself.
     const result = await this.model.where({ stateHash, expiresAt: record.expiresAt }).delete()
-    if (!deleteRemovedRow(result)) {
-      return null
-    }
-
-    return {
-      provider: String(record.provider),
-      redirectTo: record.redirectTo == null ? undefined : String(record.redirectTo),
-      // isExpired above guarantees this parses.
-      expiresAt: toDate(record.expiresAt) as Date,
-    }
+    return deleteRemovedRow(result) ? mapRecordToPayload(record) : null
   }
 
   /**
@@ -139,6 +132,19 @@ export class DatabaseOAuthStateStore implements OAuthStateStore {
    */
   async deleteExpired(now: Date = new Date()): Promise<void> {
     await this.model.where('expiresAt', '<=', now).delete()
+  }
+}
+
+/**
+ * Build the public payload from a live (non-expired) row. Shared by `find`
+ * and `consume` so the column-to-payload mapping only lives in one place.
+ */
+function mapRecordToPayload(record: Record<string, unknown>): OAuthStatePayload {
+  return {
+    provider: String(record.provider),
+    redirectTo: record.redirectTo == null ? undefined : String(record.redirectTo),
+    // fetchLive's isExpired check guarantees this parses.
+    expiresAt: toDate(record.expiresAt) as Date,
   }
 }
 

--- a/packages/core/src/oauth-state-store.ts
+++ b/packages/core/src/oauth-state-store.ts
@@ -79,6 +79,60 @@ export class DatabaseOAuthStateStore implements OAuthStateStore {
   }
 
   /**
+   * Atomically fetch and delete a state, guaranteeing exactly one concurrent
+   * caller for the same hash receives the payload.
+   *
+   * This guarantee depends on the configured ORM adapter's `delete()`
+   * reporting whether a row actually matched — either the deleted row
+   * (RETURNING) or an affected-row count. `DrizzleAdapter`, the framework's
+   * default and only shipped adapter, always does this: RETURNING drivers
+   * (Postgres, SQLite, D1) resolve to the deleted row or `undefined` only
+   * when zero rows matched; MySQL resolves to a result carrying
+   * `affectedRows` (verified by inspection, not a dedicated test).
+   *
+   * The `ORMAdapter.delete` contract also permits a bare `void` return.
+   * A custom adapter (via `Model.useAdapter()`) that returns `void`
+   * unconditionally — on both a successful delete and a no-op — gives
+   * `consume()` no way to tell which caller won: the value is identical for
+   * both, so no post-hoc check can attribute the deletion. Rather than
+   * silently rejecting every real login for such adapters,
+   * `deleteRemovedRow` treats an unrecognized non-null result as removed —
+   * this reopens the pre-consume find-then-delete race window (multiple
+   * concurrent callers can pass) for adapters that can't report a match,
+   * but does not break login. It is fail-closed (returns null / rejects)
+   * only for `null`/`undefined`, DrizzleAdapter's definitive "no rows
+   * matched" signal.
+   */
+  async consume(stateHash: string): Promise<OAuthStatePayload | null> {
+    const record = await this.model.where({ stateHash }).first()
+    if (!record) {
+      return null
+    }
+
+    if (isExpired(record.expiresAt)) {
+      await this.model.where({ stateHash, expiresAt: record.expiresAt }).delete()
+      return null
+    }
+
+    // Guarded delete on the observed row version: only the caller whose
+    // DELETE actually removes the row may return the payload. RETURNING
+    // drivers (postgres, sqlite, d1) yield the deleted row or undefined;
+    // MySQL yields a result carrying affectedRows — both distinguish the
+    // winner from concurrent losers.
+    const result = await this.model.where({ stateHash, expiresAt: record.expiresAt }).delete()
+    if (!deleteRemovedRow(result)) {
+      return null
+    }
+
+    return {
+      provider: String(record.provider),
+      redirectTo: record.redirectTo == null ? undefined : String(record.redirectTo),
+      // isExpired above guarantees this parses.
+      expiresAt: toDate(record.expiresAt) as Date,
+    }
+  }
+
+  /**
    * Delete OAuth states whose expiration time has passed. Expired states
    * are already rejected by `find`; call this from a scheduled job to keep
    * the table small.
@@ -86,4 +140,29 @@ export class DatabaseOAuthStateStore implements OAuthStateStore {
   async deleteExpired(now: Date = new Date()): Promise<void> {
     await this.model.where('expiresAt', '<=', now).delete()
   }
+}
+
+/**
+ * Interpret an adapter delete result as "this call removed the row". See
+ * the `consume()` JSDoc above for the full adapter-support tradeoff: this
+ * is exact for DrizzleAdapter, and best-effort (assume removed) for any
+ * other result shape, since a bare `void` return carries no information to
+ * confirm or refute a match.
+ */
+function deleteRemovedRow(result: unknown): boolean {
+  if (result == null) return false
+  if (typeof result === 'number') return result > 0
+  if (Array.isArray(result)) {
+    // mysql2 resolves to [ResultSetHeader, fields]
+    return result.length > 0 && deleteRemovedRow(result[0])
+  }
+  if (typeof result === 'object') {
+    const record = result as Record<string, unknown>
+    for (const key of ['affectedRows', 'rowsAffected', 'rowCount', 'changes'] as const) {
+      if (typeof record[key] === 'number') return (record[key] as number) > 0
+    }
+    // No count field: assume this is the deleted row itself (RETURNING).
+    return true
+  }
+  return Boolean(result)
 }

--- a/packages/core/tests/oauth-state-store.test.ts
+++ b/packages/core/tests/oauth-state-store.test.ts
@@ -90,6 +90,61 @@ describe('DatabaseOAuthStateStore', () => {
     expect(await store.find('hash-4')).toBeNull()
   })
 
+  test('consume returns the payload and removes the row', async () => {
+    const expiresAt = new Date(Date.now() + 60_000)
+    await store.store('hash-consume', {
+      provider: 'github',
+      redirectTo: '/dashboard',
+      expiresAt,
+    })
+
+    const result = await store.consume('hash-consume')
+
+    expect(result).not.toBeNull()
+    expect(result!.provider).toBe('github')
+    expect(result!.redirectTo).toBe('/dashboard')
+    expect(result!.expiresAt.getTime()).toBe(expiresAt.getTime())
+
+    expect(await store.consume('hash-consume')).toBeNull()
+    expect(await store.find('hash-consume')).toBeNull()
+  })
+
+  test('consume returns null for an unknown state hash', async () => {
+    expect(await store.consume('missing')).toBeNull()
+  })
+
+  test('consume returns null and deletes an expired state', async () => {
+    await store.store('hash-consume-expired', {
+      provider: 'github',
+      expiresAt: new Date(Date.now() - 1000),
+    })
+
+    expect(await store.consume('hash-consume-expired')).toBeNull()
+
+    const row = sqlite
+      .query('SELECT * FROM oauth_states WHERE state_hash = ?')
+      .get('hash-consume-expired')
+    expect(row).toBeNull()
+  })
+
+  test('concurrent consume hands the payload to exactly one caller', async () => {
+    await store.store('hash-race', {
+      provider: 'github',
+      redirectTo: '/dashboard',
+      expiresAt: new Date(Date.now() + 60_000),
+    })
+
+    const results = await Promise.all([
+      store.consume('hash-race'),
+      store.consume('hash-race'),
+      store.consume('hash-race'),
+    ])
+
+    const winners = results.filter((r) => r !== null)
+    expect(winners).toHaveLength(1)
+    expect(winners[0]!.provider).toBe('github')
+  })
+
   test('deleteExpired removes only expired states', async () => {
     await store.store('expired', {
       provider: 'github',

--- a/packages/server/src/auth/oauth/index.ts
+++ b/packages/server/src/auth/oauth/index.ts
@@ -54,6 +54,17 @@ export interface OAuthStateStore {
   store(stateHash: string, payload: OAuthStatePayload): Promise<void>
   find(stateHash: string): Promise<OAuthStatePayload | null>
   delete(stateHash: string): Promise<void>
+  /**
+   * Atomically fetch and delete a state in one step. Exactly one caller may
+   * receive the payload; every other concurrent caller (and any later call)
+   * must get null. Expired states must also return null, mirroring `find`.
+   *
+   * Optional for backward compatibility: `verifyOAuthState` prefers this
+   * when present. Stores that only implement find/delete keep working, but
+   * leave a window where two concurrent callbacks with the same state can
+   * both pass verification.
+   */
+  consume?(stateHash: string): Promise<OAuthStatePayload | null>
 }
 
 export interface OAuthStateConfig {
@@ -134,6 +145,16 @@ export class MemoryOAuthStateStore implements OAuthStateStore {
 
   async delete(stateHash: string): Promise<void> {
     this.states.delete(stateHash)
+  }
+
+  async consume(stateHash: string): Promise<OAuthStatePayload | null> {
+    // Map.get + Map.delete run synchronously before the first await, so
+    // within one isolate at most one caller can observe the entry.
+    const payload = this.states.get(stateHash)
+    if (!payload) return null
+    this.states.delete(stateHash)
+    if (payload.expiresAt.getTime() <= Date.now()) return null
+    return payload
   }
 
   clear(): void {
@@ -244,13 +265,26 @@ export async function verifyOAuthState(
 ): Promise<OAuthStatePayload | null> {
   const hashAlgorithm = config.hashAlgorithm ?? DEFAULT_STATE_HASH_ALGORITHM
   const stateHash = hashToken(state, hashAlgorithm)
-  const payload = await store.find(stateHash)
+  const payload = typeof store.consume === 'function'
+    ? await store.consume(stateHash)
+    : await findAndDeleteState(store, stateHash)
   if (!payload) return null
-  await store.delete(stateHash)
   if (payload.provider !== provider) return null
   // Re-sanitize on the way out so custom stores and states persisted before
   // an allowlist change cannot smuggle an unsafe target through.
   return { ...payload, redirectTo: sanitizeOAuthRedirect(payload.redirectTo, config.allowedRedirectHosts) }
+}
+
+// Fallback for stores without consume(): two concurrent callbacks can both
+// find() before either delete() lands, so one-time use is not strict here.
+async function findAndDeleteState(
+  store: OAuthStateStore,
+  stateHash: string,
+): Promise<OAuthStatePayload | null> {
+  const payload = await store.find(stateHash)
+  if (!payload) return null
+  await store.delete(stateHash)
+  return payload
 }
 
 /**

--- a/packages/server/src/redis/RedisOAuthStateStore.ts
+++ b/packages/server/src/redis/RedisOAuthStateStore.ts
@@ -30,6 +30,16 @@ export interface RedisOAuthStateStoreOptions {
  * const oauth = createOAuthManager({ stateStore: new RedisOAuthStateStore(redis) })
  * ```
  */
+// GET + DEL in one script so consumption is atomic on the Redis side.
+// GETDEL would do the same but requires Redis >= 6.2; EVAL works everywhere.
+const CONSUME_SCRIPT = `
+local value = redis.call('GET', KEYS[1])
+if value then
+  redis.call('DEL', KEYS[1])
+end
+return value
+`
+
 export class RedisOAuthStateStore implements OAuthStateStore {
   private readonly prefix: string
 
@@ -61,18 +71,42 @@ export class RedisOAuthStateStore implements OAuthStateStore {
       return null
     }
 
+    const payload = this.parsePayload(data)
+    if (!payload) {
+      return null
+    }
+    if (payload.expiresAt.getTime() <= Date.now()) {
+      await this.delete(stateHash)
+      return null
+    }
+    return payload
+  }
+
+  async consume(stateHash: string): Promise<OAuthStatePayload | null> {
+    const data = (await this.redis.eval(
+      CONSUME_SCRIPT,
+      1,
+      `${this.prefix}${stateHash}`,
+    )) as string | null
+    if (!data) {
+      return null
+    }
+
+    const payload = this.parsePayload(data)
+    if (!payload || payload.expiresAt.getTime() <= Date.now()) {
+      return null
+    }
+    return payload
+  }
+
+  private parsePayload(data: string): OAuthStatePayload | null {
     try {
       const parsed = JSON.parse(data) as { provider: string; redirectTo?: string; expiresAt: string }
-      const payload: OAuthStatePayload = {
+      return {
         provider: parsed.provider,
         redirectTo: parsed.redirectTo,
         expiresAt: new Date(parsed.expiresAt),
       }
-      if (payload.expiresAt.getTime() <= Date.now()) {
-        await this.delete(stateHash)
-        return null
-      }
-      return payload
     } catch {
       return null
     }

--- a/packages/server/tests/auth/oauth.test.ts
+++ b/packages/server/tests/auth/oauth.test.ts
@@ -54,6 +54,73 @@ describe('oauth helpers', () => {
     expect(payload?.redirectTo).toBeUndefined()
   })
 
+  it('consume returns the payload exactly once under concurrency', async () => {
+    const store = new MemoryOAuthStateStore()
+    await store.store('hash-1', {
+      provider: 'github',
+      redirectTo: '/dashboard',
+      expiresAt: new Date(Date.now() + 60_000),
+    })
+
+    const results = await Promise.all([store.consume('hash-1'), store.consume('hash-1')])
+
+    const winners = results.filter((r) => r !== null)
+    expect(winners).toHaveLength(1)
+    expect(winners[0]?.provider).toBe('github')
+    expect(await store.find('hash-1')).toBeNull()
+  })
+
+  it('consume returns null for expired state and removes it', async () => {
+    const store = new MemoryOAuthStateStore()
+    await store.store('hash-expired', {
+      provider: 'github',
+      expiresAt: new Date(Date.now() - 1000),
+    })
+
+    expect(await store.consume('hash-expired')).toBeNull()
+    expect(await store.find('hash-expired')).toBeNull()
+  })
+
+  it('only one concurrent verifyOAuthState call succeeds for the same state', async () => {
+    const store = new MemoryOAuthStateStore()
+    const { state } = await createOAuthState('github', store, { expiresIn: 60_000 }, '/dashboard')
+
+    const results = await Promise.all([
+      verifyOAuthState(state, 'github', store, {}),
+      verifyOAuthState(state, 'github', store, {}),
+    ])
+
+    expect(results.filter((r) => r !== null)).toHaveLength(1)
+  })
+
+  it('verifyOAuthState prefers consume over find/delete when available', async () => {
+    const payload = {
+      provider: 'github',
+      redirectTo: '/next',
+      expiresAt: new Date(Date.now() + 60_000),
+    }
+    const calls: string[] = []
+    const store = {
+      store: async () => {},
+      find: async () => {
+        calls.push('find')
+        return payload
+      },
+      delete: async () => {
+        calls.push('delete')
+      },
+      consume: async () => {
+        calls.push('consume')
+        return payload
+      },
+    }
+
+    const verified = await verifyOAuthState('some-state', 'github', store, {})
+
+    expect(verified?.redirectTo).toBe('/next')
+    expect(calls).toEqual(['consume'])
+  })
+
   it('re-sanitizes redirectTo on verify for custom stores', async () => {
     const store = new MemoryOAuthStateStore()
     const { state } = await createOAuthState('github', store, {}, '/ok', 'fixed-state')

--- a/packages/server/tests/redis/RedisOAuthStateStore.test.ts
+++ b/packages/server/tests/redis/RedisOAuthStateStore.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'bun:test'
+import type { Redis } from 'ioredis'
+import { RedisOAuthStateStore } from '../../src/redis/RedisOAuthStateStore'
+
+/**
+ * In-memory stand-in covering the commands RedisOAuthStateStore uses.
+ * eval mirrors the real GET+DEL script contract: the read and the delete
+ * happen in one atomic step, so only one caller can receive the value.
+ */
+class FakeRedis {
+  private readonly data = new Map<string, string>()
+
+  async psetex(key: string, _ttlMs: number, value: string): Promise<'OK'> {
+    this.data.set(key, value)
+    return 'OK'
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.data.get(key) ?? null
+  }
+
+  async del(...keys: string[]): Promise<number> {
+    let removed = 0
+    for (const key of keys) {
+      if (this.data.delete(key)) removed++
+    }
+    return removed
+  }
+
+  async eval(_script: string, _numKeys: number, key: string): Promise<string | null> {
+    const value = this.data.get(key) ?? null
+    if (value !== null) {
+      this.data.delete(key)
+    }
+    return value
+  }
+}
+
+const createStore = () => {
+  const redis = new FakeRedis()
+  return new RedisOAuthStateStore(redis as unknown as Redis, { prefix: 'test:oauthstate:' })
+}
+
+describe('RedisOAuthStateStore', () => {
+  it('consume returns the payload once and deletes the key', async () => {
+    const store = createStore()
+    const expiresAt = new Date(Date.now() + 60_000)
+    await store.store('hash-1', { provider: 'github', redirectTo: '/dashboard', expiresAt })
+
+    const first = await store.consume('hash-1')
+    expect(first).not.toBeNull()
+    expect(first!.provider).toBe('github')
+    expect(first!.redirectTo).toBe('/dashboard')
+    expect(first!.expiresAt.getTime()).toBe(expiresAt.getTime())
+
+    expect(await store.consume('hash-1')).toBeNull()
+    expect(await store.find('hash-1')).toBeNull()
+  })
+
+  it('consume returns null for an unknown state hash', async () => {
+    const store = createStore()
+    expect(await store.consume('missing')).toBeNull()
+  })
+
+  it('consume returns null for an expired payload', async () => {
+    // Write an already-expired payload directly, simulating one whose
+    // embedded expiry lapsed while the Redis TTL has not fired yet.
+    const redis = new FakeRedis()
+    const store = new RedisOAuthStateStore(redis as unknown as Redis)
+    await redis.psetex(
+      'oauthstate:hash-expired',
+      60_000,
+      JSON.stringify({
+        provider: 'github',
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+      }),
+    )
+
+    expect(await store.consume('hash-expired')).toBeNull()
+    // The key was still consumed atomically.
+    expect(await redis.get('oauthstate:hash-expired')).toBeNull()
+  })
+
+  it('concurrent consume hands the payload to exactly one caller', async () => {
+    const store = createStore()
+    await store.store('hash-race', {
+      provider: 'github',
+      expiresAt: new Date(Date.now() + 60_000),
+    })
+
+    const results = await Promise.all([
+      store.consume('hash-race'),
+      store.consume('hash-race'),
+      store.consume('hash-race'),
+    ])
+
+    expect(results.filter((r) => r !== null)).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

`verifyOAuthState` consumed one-time OAuth state non-atomically: `store.find(stateHash)` followed by `store.delete(stateHash)` as two separate steps. Two concurrent callbacks presenting the same state could both pass `find()` before either `delete()` landed, so one-time state did not strictly prevent replay.

Adds an optional `consume(stateHash): Promise<OAuthStatePayload | null>` to `OAuthStateStore` that fetches and deletes a state in one atomic step, guaranteeing at most one caller ever receives the payload. `verifyOAuthState` prefers `consume()` when present and falls back to `find`/`delete` for stores that only implement the older interface, so existing custom stores keep working unchanged.

Implemented for all three bundled stores:
- **`MemoryOAuthStateStore`** — `Map.get`+`Map.delete` run synchronously before the first `await`, so this is atomic within one isolate with no extra work.
- **`RedisOAuthStateStore`** — GET+DEL via a Lua script (`eval`), which works on Redis versions without `GETDEL` (Redis < 6.2).
- **`DatabaseOAuthStateStore`** — a guarded `DELETE` on the exact row version observed by the prior read, using `DrizzleAdapter`'s result (deleted row via RETURNING on Postgres/SQLite/D1, or an affected-row count on MySQL) to distinguish the winner from concurrent losers.

## Scope

`server` (OAuth state store interface, Memory/Redis stores), `core` (`DatabaseOAuthStateStore`)

## Risk Assessment

- Purely additive to the public `OAuthStateStore` interface — `consume` is optional, so no existing custom store implementation breaks.
- `DatabaseOAuthStateStore.consume()`'s exactly-once guarantee depends on the ORM adapter's `delete()` reporting whether a row matched. This holds for `DrizzleAdapter` (the framework's default and only shipped adapter) on every dialect it supports. A custom adapter (via `Model.useAdapter()`) whose `delete()` returns a bare `void` unconditionally — legal per the `ORMAdapter.delete` contract — cannot be distinguished from a no-op delete from the return value alone; this case is documented in the `consume()`/`deleteRemovedRow` JSDoc and falls back to "assume removed" rather than permanently rejecting logins for that adapter.
- No schema or migration changes required.

## Validation

- `bun run build:clean`
- `bun run typecheck`
- `bun run test:bun` — 2472 pass / 0 fail
- `bun run test:testing` — 158 pass
- `bun run audit:core-first` / `bun run audit:docs` — both pass
- Added targeted regression tests for all three stores plus `verifyOAuthState`, including concurrent double/triple-`consume` races asserting exactly one caller receives the payload.
- Reviewed via the built-in Codex reviewer; one finding (custom void-returning adapters silently rejecting every login) addressed by documenting the adapter requirement and the residual best-effort fallback rather than a return-value fix, since `undefined` is provably indistinguishable between a DrizzleAdapter no-match and a void-adapter success under concurrency.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks (none — additive interface change).
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation (JSDoc on the new interface method and adapter-support tradeoffs).