### PR TITLE
feat(cli): entity-centric context bundles (RFC 0004 Part 1)

### DIFF
--- a/.changeset/entity-context.md
+++ b/.changeset/entity-context.md
@@ -9,8 +9,10 @@ feat: entity-centric context bundles (RFC 0004 Part 1)
   into a single markdown/JSON bundle: model metadata (table, columns,
   relationships, reverse references), routes with validation schemas,
   controller actions, Inertia pages with extracted Props, resource,
-  policy, seeders, and tests. Same-named models across modules are
-  disambiguated with `--module`.
+  policy, factories, seeders, and tests. Same-named models across
+  modules are disambiguated with `--module` (`--module app` selects the
+  application root), and every join is scoped to the selected location
+  when the name is duplicated.
 - `guren context` (whole-project) now reports routes from the full
   `RouteDefinition` payload — the Routes table gains a Controller column
   and JSON output includes controller bindings and schema type strings.

--- a/.changeset/entity-context.md
+++ b/.changeset/entity-context.md
@@ -1,0 +1,20 @@
+---
+'@guren/server': minor
+'@guren/cli': minor
+---
+
+feat: entity-centric context bundles (RFC 0004 Part 1)
+
+- `guren context <Entity>` joins everything the CLI knows about one model
+  into a single markdown/JSON bundle: model metadata (table, columns,
+  relationships, reverse references), routes with validation schemas,
+  controller actions, Inertia pages with extracted Props, resource,
+  policy, seeders, and tests. Same-named models across modules are
+  disambiguated with `--module`.
+- `guren context` (whole-project) now reports routes from the full
+  `RouteDefinition` payload — the Routes table gains a Controller column
+  and JSON output includes controller bindings and schema type strings.
+- `RouteDefinition` gains `bindings` (param name → bound model class
+  name) so route model bindings are introspectable.
+- The MCP endpoint exposes the bundle as the `guren_entity_context` tool
+  and the `guren://context/{entity}` resource template.

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -656,8 +656,8 @@ async function extractTableColumns(schemaPath: string, tables: Map<string, strin
  * never appear in the root file's AST — without this, sensitive-column
  * checks on module models would silently see no columns at all and skip.
  *
- * Also consumed by entity-context.ts (RFC 0004 Part 1); slated to move
- * into the shared schema parser that RFC 0004 Part 3 introduces.
+ * Also consumed by entity-context.ts — keep behavior general, not
+ * audit-specific.
  */
 export async function parseSchemaTableColumns(cwd: string): Promise<Map<string, string[]> | null> {
   const tables = new Map<string, string[]>()

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -655,6 +655,9 @@ async function extractTableColumns(schemaPath: string, tables: Map<string, strin
  * '../modules/<name>/db/schema'`, so a module's own `pgTable(...)` calls
  * never appear in the root file's AST — without this, sensitive-column
  * checks on module models would silently see no columns at all and skip.
+ *
+ * Also consumed by entity-context.ts (RFC 0004 Part 1); slated to move
+ * into the shared schema parser that RFC 0004 Part 3 introduces.
  */
 export async function parseSchemaTableColumns(cwd: string): Promise<Map<string, string[]> | null> {
   const tables = new Map<string, string[]>()

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -656,7 +656,7 @@ async function extractTableColumns(schemaPath: string, tables: Map<string, strin
  * never appear in the root file's AST — without this, sensitive-column
  * checks on module models would silently see no columns at all and skip.
  */
-async function parseSchemaTableColumns(cwd: string): Promise<Map<string, string[]> | null> {
+export async function parseSchemaTableColumns(cwd: string): Promise<Map<string, string[]> | null> {
   const tables = new Map<string, string[]>()
   await extractTableColumns(resolve(cwd, 'db/schema.ts'), tables)
 

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1638,7 +1638,7 @@ const contextCommand = defineCommand({
     },
     module: {
       type: 'string',
-      description: 'Module name to disambiguate same-named models (entity mode only).',
+      description: 'Module name to disambiguate same-named models; "app" selects the application root (entity mode only).',
     },
   },
   async run({ args }) {

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -52,6 +52,7 @@ import { installPlugin } from './plugin'
 import { discoverPluginCommands, createPluginCommandProxy } from './plugin-commands'
 import { displayModels } from './model-list'
 import { displayContext } from './context'
+import { displayEntityContext } from './entity-context'
 import { runCheck, renderCheckReport } from './check'
 import { runAudit, renderAuditReport } from './audit'
 import { generateGuidelines } from './guidelines'
@@ -1615,9 +1616,14 @@ const modelListCommand = defineCommand({
 const contextCommand = defineCommand({
   meta: {
     name: 'context',
-    description: 'Generate a project context map for AI agents.',
+    description: 'Generate a project context map for AI agents. Pass an entity name (e.g. `guren context User`) for an entity-centric bundle.',
   },
   args: {
+    entity: {
+      type: 'positional',
+      required: false,
+      description: 'Model class name for an entity-centric context bundle (case-insensitive).',
+    },
     json: {
       type: 'boolean',
       description: 'Output as JSON.',
@@ -1630,8 +1636,22 @@ const contextCommand = defineCommand({
       type: 'string',
       description: 'Application root directory.',
     },
+    module: {
+      type: 'string',
+      description: 'Module name to disambiguate same-named models (entity mode only).',
+    },
   },
   async run({ args }) {
+    if (args.entity) {
+      await displayEntityContext(args.entity, {
+        cwd: args.app,
+        json: Boolean(args.json),
+        routesFile: args.routes,
+        module: args.module,
+      })
+      return
+    }
+
     await displayContext({
       cwd: args.app,
       json: Boolean(args.json),

--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -11,6 +11,7 @@ import {
   moduleNameFromRelPath,
 } from './discovery'
 import { ParseCache } from './parse-cache'
+import { extractInertiaPageRefs, resolveInertiaPageFile, expectedInertiaPagePath } from './inertia-pages'
 import { runArchCheck } from './arch-check'
 import { getChangedFiles } from './changed-files'
 import { check, type CheckResult, type CheckReport, type CheckStatus } from './check-result'
@@ -266,30 +267,21 @@ async function checkInertiaPages(
   const parsed = await cache.get(filePath)
   const source = parsed?.source ?? (await readFile(filePath, 'utf-8'))
 
-  // Find this.inertia('PageName', ...) calls via regex (simpler than AST for this)
-  const inertiaCallRegex = /this\.inertia\(\s*(?:pages\.[.\w]+|['"]([^'"]+)['"])/g
-  let match
-  while ((match = inertiaCallRegex.exec(source)) !== null) {
-    const pageName = match[1]
-    if (!pageName) continue // pages.xxx pattern — already type-checked
+  for (const ref of extractInertiaPageRefs(source)) {
+    if (ref.form === 'manifest') continue // pages.xxx pattern — already type-checked
 
-    const pagePath = `resources/js/pages/${pageName}.tsx`
-    const exists = await fileExists(cwd, pagePath)
-    if (!exists) {
-      const altPath = `resources/js/pages/${pageName}.jsx`
-      const altExists = await fileExists(cwd, altPath)
-      if (!altExists) {
-        results.push(
-          check(
-            `page:${pageName}`,
-            `Page ${pageName}`,
-            'fail',
-            `Controller references page '${pageName}' but no file found.`,
-            `Create: resources/js/pages/${pageName}.tsx`,
-            relPath,
-          ),
-        )
-      }
+    const pageFile = await resolveInertiaPageFile(cwd, ref.id)
+    if (!pageFile) {
+      results.push(
+        check(
+          `page:${ref.id}`,
+          `Page ${ref.id}`,
+          'fail',
+          `Controller references page '${ref.id}' but no file found.`,
+          `Create: ${expectedInertiaPagePath(ref.id)}`,
+          relPath,
+        ),
+      )
     }
   }
 

--- a/packages/cli/src/context-route.ts
+++ b/packages/cli/src/context-route.ts
@@ -1,0 +1,75 @@
+import { resolve } from 'node:path'
+import type { RouteDefinition } from '@guren/core'
+import { loadRouteDefinitions, DEFAULT_ROUTES_FILE } from './load-routes'
+import { schemaToTypeString } from './schema-type-extractor'
+
+/**
+ * Serializable route view shared by the whole-project context and the
+ * entity bundle: `RouteDefinition` with its live Zod schema objects
+ * replaced by rendered type strings, so `--json` output stays clean.
+ */
+export interface ContextRoute {
+  method: string
+  path: string
+  name?: string
+  controller?: { name: string; action: string }
+  bindings?: Record<string, string>
+  middleware?: string[]
+  hasInlineMiddleware?: boolean
+  params?: string
+  query?: string
+  body?: string
+  output?: string
+  summary?: string
+  description?: string
+  tags?: string[]
+  operationId?: string
+  deprecated?: boolean
+}
+
+export function routeDefinitionToContextRoute(def: RouteDefinition): ContextRoute {
+  return {
+    method: def.method.toUpperCase(),
+    path: def.path,
+    name: def.name,
+    controller: def.controller,
+    bindings: def.bindings,
+    middleware: def.middlewareNames?.length ? def.middlewareNames : undefined,
+    hasInlineMiddleware: def.hasInlineMiddleware || undefined,
+    params: schemaToTypeString(def.schemas?.params),
+    query: schemaToTypeString(def.schemas?.query),
+    body: schemaToTypeString(def.schemas?.body),
+    output: schemaToTypeString(def.schemas?.output),
+    summary: def.summary,
+    description: def.description,
+    tags: def.tags,
+    operationId: def.operationId,
+    deprecated: def.deprecated,
+  }
+}
+
+/**
+ * A value rendered inside a markdown pipe-table cell — schema type strings
+ * routinely contain `|` (unions) and can span lines, both of which break
+ * table structure unescaped.
+ */
+export function escapeMarkdownTableCell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\s*\r?\n\s*/g, ' ')
+}
+
+/**
+ * Every route as a `ContextRoute`, or `[]` when the routes file can't be
+ * loaded (missing deps, mid-scaffold app, etc.) — context commands degrade
+ * to a route-less view instead of failing.
+ */
+export async function loadContextRoutes(cwd: string, routesFile?: string): Promise<ContextRoute[]> {
+  try {
+    const definitions = await loadRouteDefinitions(
+      resolve(cwd, routesFile ?? DEFAULT_ROUTES_FILE),
+      cwd,
+    )
+    return definitions.map(routeDefinitionToContextRoute)
+  } catch {
+    return []
+  }
+}

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -17,8 +17,7 @@ import {
   excludeBarrelFiles,
 } from './discovery'
 import { parseModelFile, type ModelInfo } from './model-parser'
-import { loadRouteDefinitions } from './load-routes'
-import { routeDefinitionToContextRoute, type ContextRoute } from './entity-context'
+import { loadContextRoutes, escapeMarkdownTableCell, type ContextRoute } from './context-route'
 
 export interface ProjectContext {
   framework: { name: string; version: string }
@@ -52,54 +51,59 @@ export async function generateContext(options: ContextOptions = {}): Promise<Pro
     version = pkg.dependencies?.['@guren/core'] ?? pkg.devDependencies?.['@guren/core'] ?? 'unknown'
   }
 
-  // Models
-  const modelFiles = await discoverModelFiles(cwd)
-  const models: ModelInfo[] = []
-  for (const f of modelFiles) {
-    const info = await parseModelFile(f)
-    if (info) {
-      info.filePath = relative(cwd, info.filePath)
-      models.push(info)
-    }
-  }
-  models.sort((a, b) => a.className.localeCompare(b.className))
-
-  // Routes — full RouteDefinition payload (controller binding, schemas as
-  // rendered type strings), not the lossy method/path/name view.
-  let routes: ContextRoute[] = []
-  try {
-    const definitions = await loadRouteDefinitions(
-      resolve(cwd, options.routesFile ?? 'routes/web.ts'),
-      cwd,
-    )
-    routes = definitions.map(routeDefinitionToContextRoute)
-  } catch {
-    // Routes may not be loadable (missing deps, etc.)
+  const collectModels = async (): Promise<ModelInfo[]> => {
+    const modelFiles = await discoverModelFiles(cwd)
+    const parsed = await Promise.all(modelFiles.map((file) => parseModelFile(file)))
+    const models = parsed.flatMap((info, index) => {
+      if (!info) return []
+      info.filePath = relative(cwd, modelFiles[index])
+      return [info]
+    })
+    return models.sort((a, b) => a.className.localeCompare(b.className))
   }
 
-  // Pages
-  const pagesDir = resolve(cwd, 'resources/js/pages')
-  const pageExts = new Set(['.tsx', '.jsx', '.ts', '.js'])
-  const pageFiles = await collectFiles(pagesDir, pageExts)
-  const pages = pageFiles
-    .map((f) => relative(pagesDir, f).replace(/\.(tsx|jsx|ts|js)$/, ''))
-    .filter((p) => !p.startsWith('contracts'))
-    .sort()
+  const collectPages = async (): Promise<string[]> => {
+    const pagesDir = resolve(cwd, 'resources/js/pages')
+    const pageExts = new Set(['.tsx', '.jsx', '.ts', '.js'])
+    const pageFiles = await collectFiles(pagesDir, pageExts)
+    return pageFiles
+      .map((f) => relative(pagesDir, f).replace(/\.(tsx|jsx|ts|js)$/, ''))
+      .filter((p) => !p.startsWith('contracts'))
+      .sort()
+  }
 
-  // Other components
   const toNames = async (discover: (root: string) => Promise<string[]>) => {
     const files = excludeBarrelFiles(await discover(cwd))
     return files.map(classNameFromPath).sort()
   }
 
-  const controllers = await toNames(discoverControllerFiles)
-  const resources = await toNames(discoverResourceFiles)
-  const events = await toNames(discoverEventFiles)
-  const jobs = await toNames(discoverJobFiles)
-  const middleware = await toNames(discoverMiddlewareFiles)
-  const listeners = await toNames(discoverListenerFiles)
-  const validators = await toNames(discoverValidatorFiles)
-  const policies = await toNames(discoverPolicyFiles)
+  // Every source below is independent — one barrier instead of a dozen
+  // serialized directory walks (plus the route-graph import).
+  const [
+    models,
+    routes,
+    pages,
+    controllers,
+    resources,
+    events,
+    jobs,
+    middleware,
+    listeners,
+    validators,
+    policies,
+  ] = await Promise.all([
+    collectModels(),
+    loadContextRoutes(cwd, options.routesFile),
+    collectPages(),
+    toNames(discoverControllerFiles),
+    toNames(discoverResourceFiles),
+    toNames(discoverEventFiles),
+    toNames(discoverJobFiles),
+    toNames(discoverMiddlewareFiles),
+    toNames(discoverListenerFiles),
+    toNames(discoverValidatorFiles),
+    toNames(discoverPolicyFiles),
+  ])
 
   return {
     framework: { name: 'Guren', version },
@@ -159,7 +163,8 @@ export function renderContextMarkdown(ctx: ProjectContext): string {
       const controller = route.controller
         ? `${route.controller.name}.${route.controller.action}`
         : ''
-      lines.push(`| ${route.method} | ${route.path} | ${route.name ?? ''} | ${controller} |`)
+      const cells = [route.method, route.path, route.name ?? '', controller]
+      lines.push(`| ${cells.map(escapeMarkdownTableCell).join(' | ')} |`)
     }
   } else {
     lines.push('No routes loaded.')

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -17,12 +17,13 @@ import {
   excludeBarrelFiles,
 } from './discovery'
 import { parseModelFile, type ModelInfo } from './model-parser'
-import { listRoutes, type RouteInfo } from './route-list'
+import { loadRouteDefinitions } from './load-routes'
+import { routeDefinitionToContextRoute, type ContextRoute } from './entity-context'
 
 export interface ProjectContext {
   framework: { name: string; version: string }
   models: ModelInfo[]
-  routes: RouteInfo[]
+  routes: ContextRoute[]
   pages: string[]
   controllers: string[]
   resources: string[]
@@ -63,10 +64,15 @@ export async function generateContext(options: ContextOptions = {}): Promise<Pro
   }
   models.sort((a, b) => a.className.localeCompare(b.className))
 
-  // Routes
-  let routes: RouteInfo[] = []
+  // Routes — full RouteDefinition payload (controller binding, schemas as
+  // rendered type strings), not the lossy method/path/name view.
+  let routes: ContextRoute[] = []
   try {
-    routes = await listRoutes({ appRoot: cwd, routesFile: options.routesFile })
+    const definitions = await loadRouteDefinitions(
+      resolve(cwd, options.routesFile ?? 'routes/web.ts'),
+      cwd,
+    )
+    routes = definitions.map(routeDefinitionToContextRoute)
   } catch {
     // Routes may not be loadable (missing deps, etc.)
   }
@@ -147,10 +153,13 @@ export function renderContextMarkdown(ctx: ProjectContext): string {
   // Routes
   lines.push(`## Routes (${ctx.routes.length})`)
   if (ctx.routes.length > 0) {
-    lines.push('| Method | Path | Name |')
-    lines.push('|--------|------|------|')
+    lines.push('| Method | Path | Name | Controller |')
+    lines.push('|--------|------|------|------------|')
     for (const route of ctx.routes) {
-      lines.push(`| ${route.method} | ${route.path} | ${route.name ?? ''} |`)
+      const controller = route.controller
+        ? `${route.controller.name}.${route.controller.action}`
+        : ''
+      lines.push(`| ${route.method} | ${route.path} | ${route.name ?? ''} | ${controller} |`)
     }
   } else {
     lines.push('No routes loaded.')

--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -194,7 +194,7 @@ export async function discoverTestFiles(appRoot: string): Promise<string[]> {
  * e.g., '/app/Models/Post.ts' → 'Post'
  */
 export function classNameFromPath(filePath: string): string {
-  const base = filePath.split('/').pop() ?? ''
+  const base = filePath.split(/[\\/]/).pop() ?? ''
   return base.replace(/\.(ts|mts|js|mjs)$/, '')
 }
 

--- a/packages/cli/src/entity-context.ts
+++ b/packages/cli/src/entity-context.ts
@@ -1,8 +1,8 @@
-import { resolve } from 'node:path'
+import { resolve, basename } from 'node:path'
 import { readFile } from 'node:fs/promises'
 import { parse } from '@babel/parser'
+import type { ClassDeclaration } from '@babel/types'
 import { consola } from 'consola'
-import type { RouteDefinition } from '@guren/core'
 import {
   discoverModelFiles,
   discoverControllerFiles,
@@ -14,43 +14,28 @@ import {
   collectFiles,
   toPosixRelative,
   moduleNameFromRelPath,
-  fileExists,
 } from './discovery'
-import { parseModelFile, type ModelInfo, type ModelRelationship } from './model-parser'
-import { loadRouteDefinitions } from './load-routes'
-import { schemaToTypeString } from './schema-type-extractor'
+import {
+  parseModelFile,
+  extractClassDeclaration,
+  type ModelInfo,
+  type ModelRelationship,
+} from './model-parser'
+import { loadRouteDefinitions, DEFAULT_ROUTES_FILE } from './load-routes'
+import {
+  routeDefinitionToContextRoute,
+  escapeMarkdownTableCell,
+  type ContextRoute,
+} from './context-route'
+import { extractInertiaPageRefs, resolveInertiaPageFile } from './inertia-pages'
 import { extractPageProps } from './page-props-extractor'
 import { parseSchemaTableColumns } from './audit'
 
-const DEFAULT_ROUTES_FILE = 'routes/web.ts'
-
-/**
- * Serializable route view shared by the whole-project context and the
- * entity bundle: `RouteDefinition` with its live Zod schema objects
- * replaced by rendered type strings, so `--json` output stays clean.
- */
-export interface ContextRoute {
-  method: string
-  path: string
-  name?: string
-  controller?: { name: string; action: string }
-  bindings?: Record<string, string>
-  middleware?: string[]
-  params?: string
-  query?: string
-  body?: string
-  output?: string
-}
-
 export interface EntityPage {
   id: string
-  filePath: string
+  /** Component file relative to the app root; absent when the referenced page has no file. */
+  filePath?: string
   props?: string
-}
-
-export interface EntityFileRef {
-  className: string
-  filePath: string
 }
 
 export interface EntityContext {
@@ -70,8 +55,9 @@ export interface EntityContext {
   routes: ContextRoute[]
   controller?: { className: string; filePath: string; actions: string[] }
   pages: EntityPage[]
-  resource?: EntityFileRef
-  policy?: EntityFileRef
+  resource?: string
+  policy?: string
+  factories: string[]
   seeders: string[]
   tests: string[]
 }
@@ -85,31 +71,13 @@ export interface EntityContextOptions {
 
 /**
  * Thrown when the entity argument can't be resolved to exactly one model —
- * unknown name, or the same class name in more than one module. The CLI and
- * the MCP tool both surface `message` verbatim.
+ * unknown name, or the same class name in more than one location. The CLI
+ * and the MCP tool both surface `message` verbatim.
  */
 export class EntityResolutionError extends Error {
-  constructor(
-    message: string,
-    readonly candidates: string[] = [],
-  ) {
+  constructor(message: string) {
     super(message)
     this.name = 'EntityResolutionError'
-  }
-}
-
-export function routeDefinitionToContextRoute(def: RouteDefinition): ContextRoute {
-  return {
-    method: def.method.toUpperCase(),
-    path: def.path,
-    name: def.name,
-    controller: def.controller,
-    bindings: def.bindings,
-    middleware: def.middlewareNames && def.middlewareNames.length > 0 ? def.middlewareNames : undefined,
-    params: schemaToTypeString(def.schemas?.params),
-    query: schemaToTypeString(def.schemas?.query),
-    body: schemaToTypeString(def.schemas?.body),
-    output: schemaToTypeString(def.schemas?.output),
   }
 }
 
@@ -121,33 +89,31 @@ interface DiscoveredModel {
 
 async function discoverParsedModels(cwd: string): Promise<DiscoveredModel[]> {
   const files = await discoverModelFiles(cwd)
-  const models: DiscoveredModel[] = []
-  for (const file of files) {
-    const info = await parseModelFile(file)
-    if (!info) continue
-    const relPath = toPosixRelative(cwd, file)
-    models.push({ info, relPath, module: moduleNameFromRelPath(relPath) })
-  }
-  return models
+  const parsed = await Promise.all(files.map((file) => parseModelFile(file)))
+  return parsed.flatMap((info, index) => {
+    if (!info) return []
+    const relPath = toPosixRelative(cwd, files[index])
+    return [{ info, relPath, module: moduleNameFromRelPath(relPath) }]
+  })
 }
 
 function resolveEntity(
   entityName: string,
-  models: DiscoveredModel[],
+  sameName: DiscoveredModel[],
+  allModels: DiscoveredModel[],
   moduleFilter?: string,
 ): DiscoveredModel {
-  const lower = entityName.toLowerCase()
-  let matches = models.filter((m) => m.info.className.toLowerCase() === lower)
-  if (moduleFilter) {
-    matches = matches.filter((m) => m.module === moduleFilter)
-  }
+  // `--module app` selects the application root — the label the ambiguity
+  // error uses for it — since root models have no module name of their own.
+  const matches = moduleFilter
+    ? sameName.filter((m) => (m.module ?? 'app') === moduleFilter)
+    : sameName
 
   if (matches.length === 0) {
-    const available = models.map((m) => m.info.className).sort()
+    const available = allModels.map((m) => m.info.className).sort()
     throw new EntityResolutionError(
       `Model "${entityName}" not found${moduleFilter ? ` in module "${moduleFilter}"` : ''}.`
         + (available.length > 0 ? ` Available models: ${available.join(', ')}` : ' No models discovered.'),
-      available,
     )
   }
 
@@ -155,15 +121,31 @@ function resolveEntity(
     const locations = matches.map((m) => m.module ?? 'app').sort()
     throw new EntityResolutionError(
       `Model "${entityName}" exists in multiple locations: ${locations.join(', ')}. Pass --module <name> to disambiguate.`,
-      locations,
     )
   }
 
   return matches[0]
 }
 
-/** Public class method names of the first exported class in a source file. */
-function extractClassActions(source: string): string[] {
+function publicMethodNames(classDecl: ClassDeclaration): string[] {
+  const actions: string[] = []
+  for (const member of classDecl.body.body) {
+    if (member.type !== 'ClassMethod') continue
+    if (member.key.type !== 'Identifier') continue
+    if (member.key.name === 'constructor') continue
+    if (member.accessibility === 'private' || member.accessibility === 'protected') continue
+    if (member.static) continue
+    actions.push(member.key.name)
+  }
+  return actions
+}
+
+/**
+ * Public method names of the controller class in a source file. Exported
+ * classes win over unexported helpers declared alongside them; a bare
+ * class is only used when nothing is exported.
+ */
+function extractControllerActions(source: string): string[] {
   let ast: ReturnType<typeof parse>
   try {
     ast = parse(source, { sourceType: 'module', plugins: ['typescript'] })
@@ -171,95 +153,37 @@ function extractClassActions(source: string): string[] {
     return []
   }
 
+  let unexported: ClassDeclaration | null = null
   for (const node of ast.program.body) {
-    const classDecl =
-      node.type === 'ExportNamedDeclaration' && node.declaration?.type === 'ClassDeclaration'
-        ? node.declaration
-        : node.type === 'ExportDefaultDeclaration' && node.declaration?.type === 'ClassDeclaration'
-          ? node.declaration
-          : node.type === 'ClassDeclaration'
-            ? node
-            : null
+    const classDecl = extractClassDeclaration(node)
     if (!classDecl) continue
-
-    const actions: string[] = []
-    for (const member of classDecl.body.body) {
-      if (member.type !== 'ClassMethod') continue
-      if (member.key.type !== 'Identifier') continue
-      if (member.key.name === 'constructor') continue
-      if (member.accessibility === 'private' || member.accessibility === 'protected') continue
-      if (member.static) continue
-      actions.push(member.key.name)
+    if (node.type !== 'ClassDeclaration') {
+      return publicMethodNames(classDecl)
     }
-    return actions
+    unexported ??= classDecl
   }
 
-  return []
-}
-
-/**
- * Page IDs referenced from a controller source via `this.inertia(...)` —
- * both the string-literal form (`this.inertia('posts/Index')`) and the
- * typed-manifest form (`this.inertia(pages.posts.Index)`), the same two
- * shapes `guren check` recognizes.
- */
-function extractInertiaPageIds(source: string): string[] {
-  const inertiaCallRegex = /this\.inertia\(\s*(?:pages\.([\w.]+)|['"]([^'"]+)['"])/g
-  const ids = new Set<string>()
-  let match: RegExpExecArray | null
-  while ((match = inertiaCallRegex.exec(source)) !== null) {
-    const id = match[1] ? match[1].split('.').join('/') : match[2]
-    if (id) ids.add(id)
-  }
-  return [...ids]
+  return unexported ? publicMethodNames(unexported) : []
 }
 
 async function resolvePages(cwd: string, pageIds: string[]): Promise<EntityPage[]> {
-  const pages: EntityPage[] = []
-  for (const id of pageIds.sort()) {
-    let filePath: string | undefined
-    for (const ext of ['tsx', 'jsx']) {
-      const candidate = `resources/js/pages/${id}.${ext}`
-      if (await fileExists(cwd, candidate)) {
-        filePath = candidate
-        break
+  return Promise.all(
+    [...pageIds].sort().map(async (id) => {
+      const filePath = await resolveInertiaPageFile(cwd, id)
+      if (!filePath) return { id }
+
+      let props: string | undefined
+      try {
+        const extracted = await extractPageProps(resolve(cwd, filePath), id)
+        // Props types can span lines; collapse whitespace for one-line rendering.
+        props = extracted.rawType?.replace(/\s+/g, ' ').trim()
+      } catch {
+        // Unparsable page — still list it, just without props.
       }
-    }
 
-    if (!filePath) {
-      pages.push({ id, filePath: `resources/js/pages/${id}.tsx` })
-      continue
-    }
-
-    let props: string | undefined
-    try {
-      const extracted = await extractPageProps(resolve(cwd, filePath), id)
-      // Props types can span lines; collapse whitespace for one-line rendering.
-      props = extracted.rawType?.replace(/\s+/g, ' ').trim() ?? undefined
-    } catch {
-      // Unparsable page — still list it, just without props.
-    }
-
-    pages.push({ id, filePath, props })
-  }
-  return pages
-}
-
-async function findSeeders(cwd: string, entityName: string): Promise<string[]> {
-  const roots = [cwd, ...(await listModuleNames(cwd)).map((name) => resolve(cwd, 'modules', name))]
-  const seederPattern = new RegExp(`(?:^|_)${entityName}s?Seeder\\.`, 'i')
-
-  const seeders: string[] = []
-  for (const root of roots) {
-    const files = await collectFiles(resolve(root, 'db/seeders'))
-    for (const file of files) {
-      const base = file.split('/').pop() ?? ''
-      if (seederPattern.test(base)) {
-        seeders.push(toPosixRelative(cwd, file))
-      }
-    }
-  }
-  return seeders.sort()
+      return { id, filePath, props }
+    }),
+  )
 }
 
 export async function generateEntityContext(
@@ -269,17 +193,112 @@ export async function generateEntityContext(
   const cwd = resolve(options.cwd ?? process.cwd())
 
   const models = await discoverParsedModels(cwd)
-  const match = resolveEntity(entityName, models, options.module)
+  const lower = entityName.toLowerCase()
+  const sameName = models.filter((m) => m.info.className.toLowerCase() === lower)
+  const match = resolveEntity(entityName, sameName, models, options.module)
   const entity = match.info.className
+  const controllerName = `${entity}Controller`
 
-  // Schema columns (names only until the Part 3 schema parser lands)
-  let columns: string[] | undefined
-  if (match.info.tableName) {
-    const tables = await parseSchemaTableColumns(cwd)
-    columns = tables?.get(match.info.tableName)
+  // When the same class name exists in more than one location, every join
+  // below is restricted to the selected location — otherwise artifacts of
+  // the sibling entity would leak into the bundle.
+  const duplicated = sameName.length > 1
+  const locationOf = (file: string) => moduleNameFromRelPath(toPosixRelative(cwd, file))
+  const inLocation = (file: string) => locationOf(file) === match.module
+
+  const findComponent = async (
+    discover: (root: string) => Promise<string[]>,
+    className: string,
+  ): Promise<string | undefined> => {
+    let files = (await discover(cwd)).filter((file) => classNameFromPath(file) === className)
+    if (duplicated) files = files.filter(inLocation)
+    const file = files.find(inLocation) ?? files[0]
+    return file ? toPosixRelative(cwd, file) : undefined
   }
 
-  // Reverse relationship edges from every other model
+  const findDbArtifacts = async (subDir: string, filePattern: RegExp): Promise<string[]> => {
+    const moduleNames = await listModuleNames(cwd)
+    let roots: Array<{ module: string | null; dir: string }> = [
+      { module: null, dir: cwd },
+      ...moduleNames.map((name) => ({ module: name, dir: resolve(cwd, 'modules', name) })),
+    ]
+    if (duplicated) roots = roots.filter((root) => root.module === match.module)
+
+    const groups = await Promise.all(roots.map((root) => collectFiles(resolve(root.dir, subDir))))
+    return groups
+      .flat()
+      .filter((file) => filePattern.test(basename(file)))
+      .map((file) => toPosixRelative(cwd, file))
+      .sort()
+  }
+
+  const loadEntityRoutes = async (): Promise<ContextRoute[]> => {
+    try {
+      const provenance: Array<string | null> = []
+      const definitions = await loadRouteDefinitions(
+        resolve(cwd, options.routesFile ?? DEFAULT_ROUTES_FILE),
+        cwd,
+        undefined,
+        provenance,
+      )
+      return definitions
+        .filter((def, index) => {
+          const matchesEntity =
+            def.controller?.name === controllerName
+            || (def.bindings !== undefined && Object.values(def.bindings).includes(entity))
+          if (!matchesEntity) return false
+          return duplicated ? provenance[index] === match.module : true
+        })
+        .map(routeDefinitionToContextRoute)
+    } catch {
+      // Routes may not be loadable (missing deps, etc.) — degrade to a route-less bundle.
+      return []
+    }
+  }
+
+  const loadControllerBundle = async (): Promise<{
+    controller?: EntityContext['controller']
+    pages: EntityPage[]
+  }> => {
+    let files = (await discoverControllerFiles(cwd)).filter(
+      (file) => classNameFromPath(file) === controllerName,
+    )
+    if (duplicated) files = files.filter(inLocation)
+    const controllerFile = files.find(inLocation) ?? files[0]
+    if (!controllerFile) return { pages: [] }
+
+    const source = await readFile(controllerFile, 'utf-8')
+    return {
+      controller: {
+        className: controllerName,
+        filePath: toPosixRelative(cwd, controllerFile),
+        actions: extractControllerActions(source),
+      },
+      pages: await resolvePages(
+        cwd,
+        extractInertiaPageRefs(source).map((ref) => ref.id),
+      ),
+    }
+  }
+
+  const loadColumns = async (): Promise<string[] | undefined> => {
+    if (!match.info.tableName) return undefined
+    const tables = await parseSchemaTableColumns(cwd)
+    return tables?.get(match.info.tableName)
+  }
+
+  const [columns, routes, controllerBundle, resource, policy, factories, seeders, testFiles] =
+    await Promise.all([
+      loadColumns(),
+      loadEntityRoutes(),
+      loadControllerBundle(),
+      findComponent(discoverResourceFiles, `${entity}Resource`),
+      findComponent(discoverPolicyFiles, `${entity}Policy`),
+      findDbArtifacts('db/factories', new RegExp(`(?:^|_)${entity}s?Factory\\.`, 'i')),
+      findDbArtifacts('db/seeders', new RegExp(`(?:^|_)${entity}s?Seeder\\.`, 'i')),
+      discoverTestFiles(cwd),
+    ])
+
   const referencedBy = models
     .filter((m) => m !== match)
     .flatMap((m) =>
@@ -289,60 +308,9 @@ export async function generateEntityContext(
     )
     .sort((a, b) => a.model.localeCompare(b.model) || a.relationship.localeCompare(b.relationship))
 
-  // Routes: controller-name convention plus route model bindings
-  const controllerName = `${entity}Controller`
-  let routes: ContextRoute[] = []
-  try {
-    const definitions = await loadRouteDefinitions(
-      resolve(cwd, options.routesFile ?? DEFAULT_ROUTES_FILE),
-      cwd,
-    )
-    routes = definitions
-      .filter(
-        (def) =>
-          def.controller?.name === controllerName
-          || (def.bindings && Object.values(def.bindings).includes(entity)),
-      )
-      .map(routeDefinitionToContextRoute)
-  } catch {
-    // Routes may not be loadable (missing deps, etc.) — same tolerance as generateContext.
-  }
-
-  // Controller (prefer the one in the entity's own module when duplicated)
-  const controllerFiles = (await discoverControllerFiles(cwd)).filter(
-    (file) => classNameFromPath(file) === controllerName,
-  )
-  const controllerFile =
-    controllerFiles.find(
-      (file) => moduleNameFromRelPath(toPosixRelative(cwd, file)) === match.module,
-    ) ?? controllerFiles[0]
-
-  let controller: EntityContext['controller']
-  let pages: EntityPage[] = []
-  if (controllerFile) {
-    const source = await readFile(controllerFile, 'utf-8')
-    controller = {
-      className: controllerName,
-      filePath: toPosixRelative(cwd, controllerFile),
-      actions: extractClassActions(source),
-    }
-    pages = await resolvePages(cwd, extractInertiaPageIds(source))
-  }
-
-  const findByClassName = async (
-    discover: (root: string) => Promise<string[]>,
-    className: string,
-  ): Promise<EntityFileRef | undefined> => {
-    const file = (await discover(cwd)).find((f) => classNameFromPath(f) === className)
-    return file ? { className, filePath: toPosixRelative(cwd, file) } : undefined
-  }
-
-  const resource = await findByClassName(discoverResourceFiles, `${entity}Resource`)
-  const policy = await findByClassName(discoverPolicyFiles, `${entity}Policy`)
-  const seeders = await findSeeders(cwd, entity)
-
-  const tests = (await discoverTestFiles(cwd))
-    .filter((file) => (file.split('/').pop() ?? '').includes(entity))
+  const tests = testFiles
+    .filter((file) => basename(file).includes(entity))
+    .filter((file) => !duplicated || inLocation(file))
     .map((file) => toPosixRelative(cwd, file))
     .sort()
 
@@ -359,10 +327,11 @@ export async function generateEntityContext(
     },
     referencedBy,
     routes,
-    controller,
-    pages,
+    controller: controllerBundle.controller,
+    pages: controllerBundle.pages,
     resource,
     policy,
+    factories,
     seeders,
     tests,
   }
@@ -405,9 +374,8 @@ export function renderEntityContextMarkdown(ctx: EntityContext): string {
     lines.push('|--------|------|------|--------|--------|------|')
     for (const route of ctx.routes) {
       const action = route.controller ? `${route.controller.name}.${route.controller.action}` : ''
-      lines.push(
-        `| ${route.method} | ${route.path} | ${route.name ?? ''} | ${action} | ${route.params ?? ''} | ${route.body ?? ''} |`,
-      )
+      const cells = [route.method, route.path, route.name ?? '', action, route.params ?? '', route.body ?? '']
+      lines.push(`| ${cells.map(escapeMarkdownTableCell).join(' | ')} |`)
     }
   } else {
     lines.push('No routes reference this entity.')
@@ -423,36 +391,33 @@ export function renderEntityContextMarkdown(ctx: EntityContext): string {
   if (ctx.pages.length > 0) {
     lines.push(`## Pages (${ctx.pages.length})`)
     for (const page of ctx.pages) {
+      const missing = page.filePath ? '' : ' (page file missing)'
       const props = page.props ? ` — Props: \`${page.props}\`` : ''
-      lines.push(`- ${page.id}${props}`)
+      lines.push(`- ${page.id}${missing}${props}`)
     }
     lines.push('')
   }
 
-  const singleRefs: Array<[string, EntityFileRef | undefined]> = [
-    ['Resource', ctx.resource],
-    ['Policy', ctx.policy],
-  ]
-  for (const [title, ref] of singleRefs) {
-    if (ref) {
-      lines.push(`## ${title} — ${ref.filePath}`)
-      lines.push('')
-    }
+  if (ctx.resource) {
+    lines.push(`## Resource — ${ctx.resource}`)
+    lines.push('')
+  }
+  if (ctx.policy) {
+    lines.push(`## Policy — ${ctx.policy}`)
+    lines.push('')
   }
 
-  const listSections: Array<[string, string[]]> = [
-    ['Seeders', ctx.seeders],
-    ['Tests', ctx.tests],
-  ]
-  for (const [title, items] of listSections) {
-    if (items.length > 0) {
-      lines.push(`## ${title} (${items.length})`)
-      for (const item of items) {
-        lines.push(`- ${item}`)
-      }
-      lines.push('')
+  const pushList = (title: string, items: string[]): void => {
+    if (items.length === 0) return
+    lines.push(`## ${title} (${items.length})`)
+    for (const item of items) {
+      lines.push(`- ${item}`)
     }
+    lines.push('')
   }
+  pushList('Factories', ctx.factories)
+  pushList('Seeders', ctx.seeders)
+  pushList('Tests', ctx.tests)
 
   return lines.join('\n')
 }

--- a/packages/cli/src/entity-context.ts
+++ b/packages/cli/src/entity-context.ts
@@ -1,0 +1,482 @@
+import { resolve } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import { parse } from '@babel/parser'
+import { consola } from 'consola'
+import type { RouteDefinition } from '@guren/core'
+import {
+  discoverModelFiles,
+  discoverControllerFiles,
+  discoverResourceFiles,
+  discoverPolicyFiles,
+  discoverTestFiles,
+  listModuleNames,
+  classNameFromPath,
+  collectFiles,
+  toPosixRelative,
+  moduleNameFromRelPath,
+  fileExists,
+} from './discovery'
+import { parseModelFile, type ModelInfo, type ModelRelationship } from './model-parser'
+import { loadRouteDefinitions } from './load-routes'
+import { schemaToTypeString } from './schema-type-extractor'
+import { extractPageProps } from './page-props-extractor'
+import { parseSchemaTableColumns } from './audit'
+
+const DEFAULT_ROUTES_FILE = 'routes/web.ts'
+
+/**
+ * Serializable route view shared by the whole-project context and the
+ * entity bundle: `RouteDefinition` with its live Zod schema objects
+ * replaced by rendered type strings, so `--json` output stays clean.
+ */
+export interface ContextRoute {
+  method: string
+  path: string
+  name?: string
+  controller?: { name: string; action: string }
+  bindings?: Record<string, string>
+  middleware?: string[]
+  params?: string
+  query?: string
+  body?: string
+  output?: string
+}
+
+export interface EntityPage {
+  id: string
+  filePath: string
+  props?: string
+}
+
+export interface EntityFileRef {
+  className: string
+  filePath: string
+}
+
+export interface EntityContext {
+  entity: string
+  /** Module the model lives in (RFC 0002), or undefined for the app root. */
+  module?: string
+  model: {
+    filePath: string
+    tableName?: string
+    columns?: string[]
+    relationships: ModelRelationship[]
+    usesAuth: boolean
+    hasSoftDeletes: boolean
+  }
+  /** Reverse relationship edges: other models whose relationships target this entity. */
+  referencedBy: Array<{ model: string; relationship: string; type: string }>
+  routes: ContextRoute[]
+  controller?: { className: string; filePath: string; actions: string[] }
+  pages: EntityPage[]
+  resource?: EntityFileRef
+  policy?: EntityFileRef
+  seeders: string[]
+  tests: string[]
+}
+
+export interface EntityContextOptions {
+  cwd?: string
+  module?: string
+  routesFile?: string
+  json?: boolean
+}
+
+/**
+ * Thrown when the entity argument can't be resolved to exactly one model —
+ * unknown name, or the same class name in more than one module. The CLI and
+ * the MCP tool both surface `message` verbatim.
+ */
+export class EntityResolutionError extends Error {
+  constructor(
+    message: string,
+    readonly candidates: string[] = [],
+  ) {
+    super(message)
+    this.name = 'EntityResolutionError'
+  }
+}
+
+export function routeDefinitionToContextRoute(def: RouteDefinition): ContextRoute {
+  return {
+    method: def.method.toUpperCase(),
+    path: def.path,
+    name: def.name,
+    controller: def.controller,
+    bindings: def.bindings,
+    middleware: def.middlewareNames && def.middlewareNames.length > 0 ? def.middlewareNames : undefined,
+    params: schemaToTypeString(def.schemas?.params),
+    query: schemaToTypeString(def.schemas?.query),
+    body: schemaToTypeString(def.schemas?.body),
+    output: schemaToTypeString(def.schemas?.output),
+  }
+}
+
+interface DiscoveredModel {
+  info: ModelInfo
+  relPath: string
+  module: string | null
+}
+
+async function discoverParsedModels(cwd: string): Promise<DiscoveredModel[]> {
+  const files = await discoverModelFiles(cwd)
+  const models: DiscoveredModel[] = []
+  for (const file of files) {
+    const info = await parseModelFile(file)
+    if (!info) continue
+    const relPath = toPosixRelative(cwd, file)
+    models.push({ info, relPath, module: moduleNameFromRelPath(relPath) })
+  }
+  return models
+}
+
+function resolveEntity(
+  entityName: string,
+  models: DiscoveredModel[],
+  moduleFilter?: string,
+): DiscoveredModel {
+  const lower = entityName.toLowerCase()
+  let matches = models.filter((m) => m.info.className.toLowerCase() === lower)
+  if (moduleFilter) {
+    matches = matches.filter((m) => m.module === moduleFilter)
+  }
+
+  if (matches.length === 0) {
+    const available = models.map((m) => m.info.className).sort()
+    throw new EntityResolutionError(
+      `Model "${entityName}" not found${moduleFilter ? ` in module "${moduleFilter}"` : ''}.`
+        + (available.length > 0 ? ` Available models: ${available.join(', ')}` : ' No models discovered.'),
+      available,
+    )
+  }
+
+  if (matches.length > 1) {
+    const locations = matches.map((m) => m.module ?? 'app').sort()
+    throw new EntityResolutionError(
+      `Model "${entityName}" exists in multiple locations: ${locations.join(', ')}. Pass --module <name> to disambiguate.`,
+      locations,
+    )
+  }
+
+  return matches[0]
+}
+
+/** Public class method names of the first exported class in a source file. */
+function extractClassActions(source: string): string[] {
+  let ast: ReturnType<typeof parse>
+  try {
+    ast = parse(source, { sourceType: 'module', plugins: ['typescript'] })
+  } catch {
+    return []
+  }
+
+  for (const node of ast.program.body) {
+    const classDecl =
+      node.type === 'ExportNamedDeclaration' && node.declaration?.type === 'ClassDeclaration'
+        ? node.declaration
+        : node.type === 'ExportDefaultDeclaration' && node.declaration?.type === 'ClassDeclaration'
+          ? node.declaration
+          : node.type === 'ClassDeclaration'
+            ? node
+            : null
+    if (!classDecl) continue
+
+    const actions: string[] = []
+    for (const member of classDecl.body.body) {
+      if (member.type !== 'ClassMethod') continue
+      if (member.key.type !== 'Identifier') continue
+      if (member.key.name === 'constructor') continue
+      if (member.accessibility === 'private' || member.accessibility === 'protected') continue
+      if (member.static) continue
+      actions.push(member.key.name)
+    }
+    return actions
+  }
+
+  return []
+}
+
+/**
+ * Page IDs referenced from a controller source via `this.inertia(...)` —
+ * both the string-literal form (`this.inertia('posts/Index')`) and the
+ * typed-manifest form (`this.inertia(pages.posts.Index)`), the same two
+ * shapes `guren check` recognizes.
+ */
+function extractInertiaPageIds(source: string): string[] {
+  const inertiaCallRegex = /this\.inertia\(\s*(?:pages\.([\w.]+)|['"]([^'"]+)['"])/g
+  const ids = new Set<string>()
+  let match: RegExpExecArray | null
+  while ((match = inertiaCallRegex.exec(source)) !== null) {
+    const id = match[1] ? match[1].split('.').join('/') : match[2]
+    if (id) ids.add(id)
+  }
+  return [...ids]
+}
+
+async function resolvePages(cwd: string, pageIds: string[]): Promise<EntityPage[]> {
+  const pages: EntityPage[] = []
+  for (const id of pageIds.sort()) {
+    let filePath: string | undefined
+    for (const ext of ['tsx', 'jsx']) {
+      const candidate = `resources/js/pages/${id}.${ext}`
+      if (await fileExists(cwd, candidate)) {
+        filePath = candidate
+        break
+      }
+    }
+
+    if (!filePath) {
+      pages.push({ id, filePath: `resources/js/pages/${id}.tsx` })
+      continue
+    }
+
+    let props: string | undefined
+    try {
+      const extracted = await extractPageProps(resolve(cwd, filePath), id)
+      // Props types can span lines; collapse whitespace for one-line rendering.
+      props = extracted.rawType?.replace(/\s+/g, ' ').trim() ?? undefined
+    } catch {
+      // Unparsable page — still list it, just without props.
+    }
+
+    pages.push({ id, filePath, props })
+  }
+  return pages
+}
+
+async function findSeeders(cwd: string, entityName: string): Promise<string[]> {
+  const roots = [cwd, ...(await listModuleNames(cwd)).map((name) => resolve(cwd, 'modules', name))]
+  const seederPattern = new RegExp(`(?:^|_)${entityName}s?Seeder\\.`, 'i')
+
+  const seeders: string[] = []
+  for (const root of roots) {
+    const files = await collectFiles(resolve(root, 'db/seeders'))
+    for (const file of files) {
+      const base = file.split('/').pop() ?? ''
+      if (seederPattern.test(base)) {
+        seeders.push(toPosixRelative(cwd, file))
+      }
+    }
+  }
+  return seeders.sort()
+}
+
+export async function generateEntityContext(
+  entityName: string,
+  options: EntityContextOptions = {},
+): Promise<EntityContext> {
+  const cwd = resolve(options.cwd ?? process.cwd())
+
+  const models = await discoverParsedModels(cwd)
+  const match = resolveEntity(entityName, models, options.module)
+  const entity = match.info.className
+
+  // Schema columns (names only until the Part 3 schema parser lands)
+  let columns: string[] | undefined
+  if (match.info.tableName) {
+    const tables = await parseSchemaTableColumns(cwd)
+    columns = tables?.get(match.info.tableName)
+  }
+
+  // Reverse relationship edges from every other model
+  const referencedBy = models
+    .filter((m) => m !== match)
+    .flatMap((m) =>
+      m.info.relationships
+        .filter((rel) => rel.relatedModel === entity)
+        .map((rel) => ({ model: m.info.className, relationship: rel.name, type: rel.type })),
+    )
+    .sort((a, b) => a.model.localeCompare(b.model) || a.relationship.localeCompare(b.relationship))
+
+  // Routes: controller-name convention plus route model bindings
+  const controllerName = `${entity}Controller`
+  let routes: ContextRoute[] = []
+  try {
+    const definitions = await loadRouteDefinitions(
+      resolve(cwd, options.routesFile ?? DEFAULT_ROUTES_FILE),
+      cwd,
+    )
+    routes = definitions
+      .filter(
+        (def) =>
+          def.controller?.name === controllerName
+          || (def.bindings && Object.values(def.bindings).includes(entity)),
+      )
+      .map(routeDefinitionToContextRoute)
+  } catch {
+    // Routes may not be loadable (missing deps, etc.) — same tolerance as generateContext.
+  }
+
+  // Controller (prefer the one in the entity's own module when duplicated)
+  const controllerFiles = (await discoverControllerFiles(cwd)).filter(
+    (file) => classNameFromPath(file) === controllerName,
+  )
+  const controllerFile =
+    controllerFiles.find(
+      (file) => moduleNameFromRelPath(toPosixRelative(cwd, file)) === match.module,
+    ) ?? controllerFiles[0]
+
+  let controller: EntityContext['controller']
+  let pages: EntityPage[] = []
+  if (controllerFile) {
+    const source = await readFile(controllerFile, 'utf-8')
+    controller = {
+      className: controllerName,
+      filePath: toPosixRelative(cwd, controllerFile),
+      actions: extractClassActions(source),
+    }
+    pages = await resolvePages(cwd, extractInertiaPageIds(source))
+  }
+
+  const findByClassName = async (
+    discover: (root: string) => Promise<string[]>,
+    className: string,
+  ): Promise<EntityFileRef | undefined> => {
+    const file = (await discover(cwd)).find((f) => classNameFromPath(f) === className)
+    return file ? { className, filePath: toPosixRelative(cwd, file) } : undefined
+  }
+
+  const resource = await findByClassName(discoverResourceFiles, `${entity}Resource`)
+  const policy = await findByClassName(discoverPolicyFiles, `${entity}Policy`)
+  const seeders = await findSeeders(cwd, entity)
+
+  const tests = (await discoverTestFiles(cwd))
+    .filter((file) => (file.split('/').pop() ?? '').includes(entity))
+    .map((file) => toPosixRelative(cwd, file))
+    .sort()
+
+  return {
+    entity,
+    module: match.module ?? undefined,
+    model: {
+      filePath: match.relPath,
+      tableName: match.info.tableName,
+      columns,
+      relationships: match.info.relationships,
+      usesAuth: match.info.usesAuth,
+      hasSoftDeletes: match.info.hasSoftDeletes,
+    },
+    referencedBy,
+    routes,
+    controller,
+    pages,
+    resource,
+    policy,
+    seeders,
+    tests,
+  }
+}
+
+export function renderEntityContextMarkdown(ctx: EntityContext): string {
+  const lines: string[] = []
+
+  lines.push(`# ${ctx.entity}${ctx.module ? ` (module: ${ctx.module})` : ''}`)
+  lines.push('')
+
+  // Model
+  const table = ctx.model.tableName ? ` (table: \`${ctx.model.tableName}\`)` : ''
+  lines.push(`## Model — ${ctx.model.filePath}${table}`)
+  const traits: string[] = []
+  if (ctx.model.usesAuth) traits.push('Authenticatable')
+  if (ctx.model.hasSoftDeletes) traits.push('SoftDeletes')
+  if (traits.length > 0) lines.push(`- Traits: ${traits.join(', ')}`)
+  if (ctx.model.columns && ctx.model.columns.length > 0) {
+    lines.push(`- Columns: ${ctx.model.columns.join(', ')}`)
+  }
+  for (const rel of ctx.model.relationships) {
+    const target = rel.relatedModel ? ` → ${rel.relatedModel}` : ''
+    lines.push(`- ${rel.type}: \`${rel.name}\`${target}`)
+  }
+  lines.push('')
+
+  if (ctx.referencedBy.length > 0) {
+    lines.push(`## Referenced by`)
+    for (const ref of ctx.referencedBy) {
+      lines.push(`- ${ref.model} — ${ref.type} \`${ref.relationship}\``)
+    }
+    lines.push('')
+  }
+
+  // Routes
+  lines.push(`## Routes (${ctx.routes.length})`)
+  if (ctx.routes.length > 0) {
+    lines.push('| Method | Path | Name | Action | Params | Body |')
+    lines.push('|--------|------|------|--------|--------|------|')
+    for (const route of ctx.routes) {
+      const action = route.controller ? `${route.controller.name}.${route.controller.action}` : ''
+      lines.push(
+        `| ${route.method} | ${route.path} | ${route.name ?? ''} | ${action} | ${route.params ?? ''} | ${route.body ?? ''} |`,
+      )
+    }
+  } else {
+    lines.push('No routes reference this entity.')
+  }
+  lines.push('')
+
+  if (ctx.controller) {
+    lines.push(`## Controller — ${ctx.controller.filePath}`)
+    lines.push(`- Actions: ${ctx.controller.actions.join(', ') || 'none'}`)
+    lines.push('')
+  }
+
+  if (ctx.pages.length > 0) {
+    lines.push(`## Pages (${ctx.pages.length})`)
+    for (const page of ctx.pages) {
+      const props = page.props ? ` — Props: \`${page.props}\`` : ''
+      lines.push(`- ${page.id}${props}`)
+    }
+    lines.push('')
+  }
+
+  const singleRefs: Array<[string, EntityFileRef | undefined]> = [
+    ['Resource', ctx.resource],
+    ['Policy', ctx.policy],
+  ]
+  for (const [title, ref] of singleRefs) {
+    if (ref) {
+      lines.push(`## ${title} — ${ref.filePath}`)
+      lines.push('')
+    }
+  }
+
+  const listSections: Array<[string, string[]]> = [
+    ['Seeders', ctx.seeders],
+    ['Tests', ctx.tests],
+  ]
+  for (const [title, items] of listSections) {
+    if (items.length > 0) {
+      lines.push(`## ${title} (${items.length})`)
+      for (const item of items) {
+        lines.push(`- ${item}`)
+      }
+      lines.push('')
+    }
+  }
+
+  return lines.join('\n')
+}
+
+export async function displayEntityContext(
+  entityName: string,
+  options: EntityContextOptions = {},
+): Promise<void> {
+  let ctx: EntityContext
+  try {
+    ctx = await generateEntityContext(entityName, options)
+  } catch (error) {
+    if (error instanceof EntityResolutionError) {
+      consola.error(error.message)
+      process.exitCode = 1
+      return
+    }
+    throw error
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify(ctx, null, 2))
+    return
+  }
+
+  console.log(renderEntityContextMarkdown(ctx))
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -34,6 +34,16 @@ export type { DoctorCheck, DoctorReport, DoctorStatus, DoctorJsonOutput, RunDoct
 
 // AI Agent commands
 export { generateContext, renderContextMarkdown, displayContext } from './context'
+export {
+  generateEntityContext,
+  renderEntityContextMarkdown,
+  displayEntityContext,
+  routeDefinitionToContextRoute,
+  EntityResolutionError,
+  type EntityContext,
+  type EntityContextOptions,
+  type ContextRoute,
+} from './entity-context'
 export { runCheck, renderCheckReport } from './check'
 export { generateGuidelines } from './guidelines'
 export { listModels, displayModels } from './model-list'

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,12 +38,11 @@ export {
   generateEntityContext,
   renderEntityContextMarkdown,
   displayEntityContext,
-  routeDefinitionToContextRoute,
   EntityResolutionError,
   type EntityContext,
   type EntityContextOptions,
-  type ContextRoute,
 } from './entity-context'
+export { routeDefinitionToContextRoute, loadContextRoutes, type ContextRoute } from './context-route'
 export { runCheck, renderCheckReport } from './check'
 export { generateGuidelines } from './guidelines'
 export { listModels, displayModels } from './model-list'

--- a/packages/cli/src/inertia-pages.ts
+++ b/packages/cli/src/inertia-pages.ts
@@ -1,0 +1,66 @@
+import { fileExists } from './discovery'
+
+export interface InertiaPageRef {
+  /** Page ID relative to the pages directory, e.g. `posts/Index`. */
+  id: string
+  /** How the controller referenced it: a string literal or the typed `pages.*` manifest. */
+  form: 'literal' | 'manifest'
+}
+
+const INERTIA_CALL_REGEX =
+  /this\.inertia\(\s*(?:pages((?:\.\w+|\[['"][^'"]+['"]\])+)|['"]([^'"]+)['"])/g
+
+const MANIFEST_SEGMENT_REGEX = /\.\w+|\[['"][^'"]+['"]\]/g
+
+/**
+ * Page references in a controller source via `this.inertia(...)` — the
+ * string-literal form (`this.inertia('posts/Index')`) and the typed
+ * manifest form (`this.inertia(pages.posts.Index)`, including bracket
+ * segments like `pages['sales-admin'].Index`). Regex-based by design (the
+ * same trade-off `guren check` has always made), so calls inside comments
+ * can produce false positives. The single source of truth for "how a
+ * controller references a page", shared by `guren check` and the entity
+ * context.
+ */
+export function extractInertiaPageRefs(source: string): InertiaPageRef[] {
+  const seen = new Set<string>()
+  const refs: InertiaPageRef[] = []
+  let match: RegExpExecArray | null
+  while ((match = INERTIA_CALL_REGEX.exec(source)) !== null) {
+    let id: string | undefined
+    let form: InertiaPageRef['form']
+    if (match[1]) {
+      form = 'manifest'
+      const segments = match[1].match(MANIFEST_SEGMENT_REGEX) ?? []
+      id = segments
+        .map((segment) => (segment.startsWith('.') ? segment.slice(1) : segment.slice(2, -2)))
+        .join('/')
+    } else {
+      form = 'literal'
+      id = match[2]
+    }
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    refs.push({ id, form })
+  }
+  return refs
+}
+
+/**
+ * Component file for a page ID (`.tsx` then `.jsx`), relative to `cwd`, or
+ * `undefined` when no file exists.
+ */
+export async function resolveInertiaPageFile(cwd: string, id: string): Promise<string | undefined> {
+  for (const ext of ['tsx', 'jsx']) {
+    const candidate = `resources/js/pages/${id}.${ext}`
+    if (await fileExists(cwd, candidate)) {
+      return candidate
+    }
+  }
+  return undefined
+}
+
+/** The path a missing page component *should* live at — used in fix suggestions. */
+export function expectedInertiaPagePath(id: string): string {
+  return `resources/js/pages/${id}.tsx`
+}

--- a/packages/cli/src/load-routes.ts
+++ b/packages/cli/src/load-routes.ts
@@ -6,6 +6,9 @@ import { listModuleNames } from './discovery'
 
 type RouteRegistrar = (router: Router) => void | Promise<void>
 
+/** Conventional routes entry file, shared by every command that loads routes. */
+export const DEFAULT_ROUTES_FILE = 'routes/web.ts'
+
 const REGISTRAR_EXPORTS = [
   'registerRoutes',
   'registerWebRoutes',
@@ -127,11 +130,17 @@ async function loadGurenModule(appRoot: string, moduleName: string, warnings?: s
  * `moduleWarnings`, when passed, collects one message per module that was
  * skipped (import failure or no recognizable `GurenModule` export) — see
  * `loadGurenModule`.
+ *
+ * `moduleProvenance`, when passed, receives one entry per returned
+ * definition (same order): the module name that mounted the route, or
+ * `null` for routes from the top-level routes file. Lets entity-scoped
+ * consumers attribute routes to a bounded context.
  */
 export async function loadRouteDefinitions(
   routesFile: string,
   appRoot: string,
   moduleWarnings?: string[],
+  moduleProvenance?: Array<string | null>,
 ): Promise<RouteDefinition[]> {
   const moduleExports = await import(createImportUrl(routesFile)) as Record<string, unknown>
   const registrar = resolveRegistrar(moduleExports)
@@ -144,6 +153,8 @@ export async function loadRouteDefinitions(
 
   const router = new Router()
   await registrar(router)
+  let definitionCount = router.definitions().length
+  moduleProvenance?.push(...Array.from({ length: definitionCount }, () => null))
 
   const moduleNames = await listModuleNames(appRoot)
 
@@ -151,6 +162,9 @@ export async function loadRouteDefinitions(
     const gurenModule = await loadGurenModule(appRoot, moduleName, moduleWarnings)
     if (gurenModule) {
       await mountModuleRoutes(router, gurenModule)
+      const mounted = router.definitions().length
+      moduleProvenance?.push(...Array.from({ length: mounted - definitionCount }, () => moduleName))
+      definitionCount = mounted
     }
   }
 

--- a/packages/cli/src/model-parser.ts
+++ b/packages/cli/src/model-parser.ts
@@ -59,7 +59,11 @@ export function parseModelSource(source: string, filePath: string): ModelInfo | 
   }
 }
 
-function extractClassDeclaration(node: Statement): ClassDeclaration | null {
+/**
+ * The `ClassDeclaration` in a top-level statement — export named, export
+ * default, or bare. Shared AST-shape knowledge for "the class in this file".
+ */
+export function extractClassDeclaration(node: Statement): ClassDeclaration | null {
   if (node.type === 'ExportNamedDeclaration' && node.declaration?.type === 'ClassDeclaration') {
     return node.declaration
   }

--- a/packages/cli/src/route-list.ts
+++ b/packages/cli/src/route-list.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path'
 import { consola } from 'consola'
-import { loadRouteDefinitions } from './load-routes'
+import { loadRouteDefinitions, DEFAULT_ROUTES_FILE } from './load-routes'
 
 export interface RouteListOptions {
   /**
@@ -43,8 +43,6 @@ export interface RouteListOptions {
    */
   reverse?: boolean
 }
-
-const DEFAULT_ROUTES_FILE = 'routes/web.ts'
 
 export interface RouteInfo {
   method: string

--- a/packages/cli/tests/context.test.ts
+++ b/packages/cli/tests/context.test.ts
@@ -91,7 +91,14 @@ describe('renderContextMarkdown', () => {
         usesAuth: false,
         hasSoftDeletes: false,
       }],
-      routes: [{ method: 'GET', path: '/posts', name: 'posts.index' }],
+      routes: [
+        {
+          method: 'GET',
+          path: '/posts',
+          name: 'posts.index',
+          controller: { name: 'PostController', action: 'index' },
+        },
+      ],
       pages: ['posts/Index', 'posts/Show'],
       controllers: ['PostController'],
       resources: ['PostResource'],
@@ -107,7 +114,7 @@ describe('renderContextMarkdown', () => {
     expect(md).toContain('Guren 1.0.0')
     expect(md).toContain('### Post')
     expect(md).toContain('belongsTo: `author` → User')
-    expect(md).toContain('| GET | /posts | posts.index |')
+    expect(md).toContain('| GET | /posts | posts.index | PostController.index |')
     expect(md).toContain('- posts/Index')
     expect(md).toContain('- PostController')
   })

--- a/packages/cli/tests/entity-context.test.ts
+++ b/packages/cli/tests/entity-context.test.ts
@@ -1,0 +1,318 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { describe, expect, it } from 'bun:test'
+import {
+  generateEntityContext,
+  renderEntityContextMarkdown,
+  EntityResolutionError,
+} from '../src/entity-context'
+import { createTempWorkspace } from './helpers'
+
+async function writeBlogFixture(dir: string): Promise<void> {
+  await mkdir(join(dir, 'app/Models'), { recursive: true })
+  await mkdir(join(dir, 'app/Http/Controllers'), { recursive: true })
+  await mkdir(join(dir, 'app/Http/Resources'), { recursive: true })
+  await mkdir(join(dir, 'app/Policies'), { recursive: true })
+  await mkdir(join(dir, 'routes'), { recursive: true })
+  await mkdir(join(dir, 'resources/js/pages/posts'), { recursive: true })
+  await mkdir(join(dir, 'db/seeders'), { recursive: true })
+  await mkdir(join(dir, 'tests/controllers'), { recursive: true })
+
+  await writeFile(join(dir, 'package.json'), '{}', 'utf8')
+
+  await writeFile(
+    join(dir, 'db/schema.ts'),
+    `import { pgTable, serial, text } from 'drizzle-orm/pg-core'
+
+export const posts = pgTable('posts', {
+  id: serial('id'),
+  title: text('title'),
+  authorId: serial('author_id'),
+})
+
+export const users = pgTable('users', {
+  id: serial('id'),
+  email: text('email'),
+})
+`,
+    'utf8',
+  )
+
+  await writeFile(
+    join(dir, 'app/Models/Post.ts'),
+    `import { defineModel, type BelongsToRecord } from '@guren/orm'
+import { posts } from '../../db/schema.js'
+import type { UserRecord } from './User.js'
+
+export class Post extends defineModel(posts) {
+  static override relationTypes: { author: BelongsToRecord<UserRecord> } = {
+    author: null,
+  }
+}
+`,
+    'utf8',
+  )
+
+  await writeFile(
+    join(dir, 'app/Models/User.ts'),
+    `import { defineModel, type HasManyRecord } from '@guren/orm'
+import { users } from '../../db/schema.js'
+import type { PostRecord } from './Post.js'
+
+export class User extends defineModel(users) {
+  static override relationTypes: { posts: HasManyRecord<PostRecord> } = {
+    posts: [],
+  }
+}
+`,
+    'utf8',
+  )
+
+  await writeFile(
+    join(dir, 'routes/web.ts'),
+    `import type { Router } from '@guren/core'
+
+class PostController {
+  index() {}
+  show() {}
+}
+
+class Post {
+  static findOrFail(id: unknown) {
+    return Promise.resolve({ id })
+  }
+}
+
+export function registerWebRoutes(router: Router): void {
+  router.get('/posts', [PostController, 'index'] as any).name('posts.index')
+  router.get('/posts/:id', { name: 'posts.show', bind: { id: Post } } as any, [
+    PostController,
+    'show',
+  ] as any)
+  router.get('/about', () => new Response('ok')).name('about')
+}
+`,
+    'utf8',
+  )
+
+  await writeFile(
+    join(dir, 'app/Http/Controllers/PostController.ts'),
+    `export class PostController {
+  async index() {
+    return this.inertia('posts/Index', { posts: [] })
+  }
+
+  async show() {
+    return this.inertia(pages.posts.Show, { post: null })
+  }
+
+  private helper() {
+    return null
+  }
+}
+`,
+    'utf8',
+  )
+
+  await writeFile(
+    join(dir, 'resources/js/pages/posts/Index.tsx'),
+    `interface Props {
+  posts: string[]
+}
+
+export default function Index({ posts }: Props) {
+  return null
+}
+`,
+    'utf8',
+  )
+
+  await writeFile(
+    join(dir, 'resources/js/pages/posts/Show.tsx'),
+    'export default function Show() { return null }\n',
+    'utf8',
+  )
+
+  await writeFile(
+    join(dir, 'app/Http/Resources/PostResource.ts'),
+    'export class PostResource {}\n',
+    'utf8',
+  )
+  await writeFile(join(dir, 'app/Policies/PostPolicy.ts'), 'export class PostPolicy {}\n', 'utf8')
+  await writeFile(
+    join(dir, 'db/seeders/002_PostsSeeder.ts'),
+    'export async function seed() {}\n',
+    'utf8',
+  )
+  await writeFile(
+    join(dir, 'tests/controllers/PostController.test.ts'),
+    'import { test } from "bun:test"\ntest("noop", () => {})\n',
+    'utf8',
+  )
+}
+
+describe('generateEntityContext', () => {
+  it('joins model, routes, controller, pages, resource, policy, seeders, and tests', async () => {
+    const workspace = await createTempWorkspace('guren-cli-entity-context-')
+
+    try {
+      await writeBlogFixture(workspace.dir)
+
+      const ctx = await generateEntityContext('Post', { cwd: workspace.dir })
+
+      expect(ctx.entity).toBe('Post')
+      expect(ctx.module).toBeUndefined()
+
+      expect(ctx.model.filePath).toBe('app/Models/Post.ts')
+      expect(ctx.model.tableName).toBe('posts')
+      expect(ctx.model.columns).toEqual(['id', 'title', 'authorId'])
+      expect(ctx.model.relationships).toEqual([
+        { name: 'author', type: 'belongsTo', relatedModel: 'User' },
+      ])
+
+      // posts.index via controller-name convention, posts.show via bind — not /about
+      expect(ctx.routes).toHaveLength(2)
+      expect(ctx.routes.map((r) => r.name).sort()).toEqual(['posts.index', 'posts.show'])
+      const show = ctx.routes.find((r) => r.name === 'posts.show')
+      expect(show?.bindings).toEqual({ id: 'Post' })
+      expect(show?.controller).toEqual({ name: 'PostController', action: 'show' })
+
+      expect(ctx.controller?.filePath).toBe('app/Http/Controllers/PostController.ts')
+      expect(ctx.controller?.actions).toEqual(['index', 'show'])
+
+      expect(ctx.pages.map((p) => p.id)).toEqual(['posts/Index', 'posts/Show'])
+      const index = ctx.pages.find((p) => p.id === 'posts/Index')
+      expect(index?.props).toContain('posts')
+
+      expect(ctx.resource?.filePath).toBe('app/Http/Resources/PostResource.ts')
+      expect(ctx.policy?.filePath).toBe('app/Policies/PostPolicy.ts')
+      expect(ctx.seeders).toEqual(['db/seeders/002_PostsSeeder.ts'])
+      expect(ctx.tests).toContain('tests/controllers/PostController.test.ts')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('resolves entity names case-insensitively', async () => {
+    const workspace = await createTempWorkspace('guren-cli-entity-case-')
+
+    try {
+      await writeBlogFixture(workspace.dir)
+
+      const ctx = await generateEntityContext('post', { cwd: workspace.dir })
+
+      expect(ctx.entity).toBe('Post')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('collects reverse relationship edges under referencedBy', async () => {
+    const workspace = await createTempWorkspace('guren-cli-entity-reverse-')
+
+    try {
+      await writeBlogFixture(workspace.dir)
+
+      const ctx = await generateEntityContext('User', { cwd: workspace.dir })
+
+      expect(ctx.referencedBy).toEqual([
+        { model: 'Post', relationship: 'author', type: 'belongsTo' },
+      ])
+      expect(ctx.routes).toHaveLength(0)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('throws EntityResolutionError listing available models for unknown entities', async () => {
+    const workspace = await createTempWorkspace('guren-cli-entity-unknown-')
+
+    try {
+      await writeBlogFixture(workspace.dir)
+
+      expect(generateEntityContext('Ghost', { cwd: workspace.dir })).rejects.toThrow(
+        EntityResolutionError,
+      )
+      expect(generateEntityContext('Ghost', { cwd: workspace.dir })).rejects.toThrow(
+        'Available models: Post, User',
+      )
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('requires --module when the same model exists in multiple locations', async () => {
+    const workspace = await createTempWorkspace('guren-cli-entity-ambiguous-')
+
+    try {
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      await mkdir(join(workspace.dir, 'modules/crm/app/Models'), { recursive: true })
+      await writeFile(join(workspace.dir, 'package.json'), '{}', 'utf8')
+      await writeFile(
+        join(workspace.dir, 'app/Models/Post.ts'),
+        'export class Post {}\n',
+        'utf8',
+      )
+      await writeFile(
+        join(workspace.dir, 'modules/crm/app/Models/Post.ts'),
+        'export class Post {}\n',
+        'utf8',
+      )
+
+      expect(generateEntityContext('Post', { cwd: workspace.dir })).rejects.toThrow(
+        'multiple locations: app, crm',
+      )
+
+      const ctx = await generateEntityContext('Post', { cwd: workspace.dir, module: 'crm' })
+      expect(ctx.module).toBe('crm')
+      expect(ctx.model.filePath).toBe('modules/crm/app/Models/Post.ts')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})
+
+describe('renderEntityContextMarkdown', () => {
+  it('renders the entity bundle as markdown', async () => {
+    const workspace = await createTempWorkspace('guren-cli-entity-markdown-')
+
+    try {
+      await writeBlogFixture(workspace.dir)
+
+      const ctx = await generateEntityContext('Post', { cwd: workspace.dir })
+      const md = renderEntityContextMarkdown(ctx)
+
+      expect(md).toContain('# Post')
+      expect(md).toContain('## Model — app/Models/Post.ts (table: `posts`)')
+      expect(md).toContain('- Columns: id, title, authorId')
+      expect(md).toContain('- belongsTo: `author` → User')
+      expect(md).toContain('## Routes (2)')
+      expect(md).toContain('| GET | /posts | posts.index | PostController.index |')
+      expect(md).toContain('- Actions: index, show')
+      expect(md).toContain('- posts/Index — Props:')
+      expect(md).toContain('## Resource — app/Http/Resources/PostResource.ts')
+      expect(md).toContain('## Policy — app/Policies/PostPolicy.ts')
+      expect(md).toContain('## Seeders (1)')
+      expect(md).toContain('## Tests (1)')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('renders reverse references for the target entity', async () => {
+    const workspace = await createTempWorkspace('guren-cli-entity-md-reverse-')
+
+    try {
+      await writeBlogFixture(workspace.dir)
+
+      const ctx = await generateEntityContext('User', { cwd: workspace.dir })
+      const md = renderEntityContextMarkdown(ctx)
+
+      expect(md).toContain('## Referenced by')
+      expect(md).toContain('- Post — belongsTo `author`')
+      expect(md).toContain('No routes reference this entity.')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})

--- a/packages/cli/tests/entity-context.test.ts
+++ b/packages/cli/tests/entity-context.test.ts
@@ -1,12 +1,12 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { describe, expect, it } from 'bun:test'
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
 import {
   generateEntityContext,
   renderEntityContextMarkdown,
   EntityResolutionError,
 } from '../src/entity-context'
-import { createTempWorkspace } from './helpers'
+import { createTempWorkspace, type TempWorkspace } from './helpers'
 
 async function writeBlogFixture(dir: string): Promise<void> {
   await mkdir(join(dir, 'app/Models'), { recursive: true })
@@ -16,6 +16,7 @@ async function writeBlogFixture(dir: string): Promise<void> {
   await mkdir(join(dir, 'routes'), { recursive: true })
   await mkdir(join(dir, 'resources/js/pages/posts'), { recursive: true })
   await mkdir(join(dir, 'db/seeders'), { recursive: true })
+  await mkdir(join(dir, 'db/factories'), { recursive: true })
   await mkdir(join(dir, 'tests/controllers'), { recursive: true })
 
   await writeFile(join(dir, 'package.json'), '{}', 'utf8')
@@ -97,7 +98,13 @@ export function registerWebRoutes(router: Router): void {
 
   await writeFile(
     join(dir, 'app/Http/Controllers/PostController.ts'),
-    `export class PostController {
+    `class UnexportedHelper {
+  irrelevant() {
+    return null
+  }
+}
+
+export class PostController {
   async index() {
     return this.inertia('posts/Index', { posts: [] })
   }
@@ -145,174 +152,182 @@ export default function Index({ posts }: Props) {
     'utf8',
   )
   await writeFile(
+    join(dir, 'db/factories/PostFactory.ts'),
+    'export default class PostFactory {}\n',
+    'utf8',
+  )
+  await writeFile(
     join(dir, 'tests/controllers/PostController.test.ts'),
     'import { test } from "bun:test"\ntest("noop", () => {})\n',
     'utf8',
   )
 }
 
-describe('generateEntityContext', () => {
-  it('joins model, routes, controller, pages, resource, policy, seeders, and tests', async () => {
-    const workspace = await createTempWorkspace('guren-cli-entity-context-')
+// The blog fixture is read-only for every test in this file, so one shared
+// workspace serves them all (createTempWorkspace chdirs; tests run serially).
+describe('entity context (blog fixture)', () => {
+  let workspace: TempWorkspace
 
-    try {
-      await writeBlogFixture(workspace.dir)
+  beforeAll(async () => {
+    workspace = await createTempWorkspace('guren-cli-entity-context-')
+    await writeBlogFixture(workspace.dir)
+  })
 
-      const ctx = await generateEntityContext('Post', { cwd: workspace.dir })
+  afterAll(async () => {
+    await workspace.cleanup()
+  })
 
-      expect(ctx.entity).toBe('Post')
-      expect(ctx.module).toBeUndefined()
+  it('joins model, routes, controller, pages, resource, policy, factories, seeders, and tests', async () => {
+    const ctx = await generateEntityContext('Post', { cwd: workspace.dir })
 
-      expect(ctx.model.filePath).toBe('app/Models/Post.ts')
-      expect(ctx.model.tableName).toBe('posts')
-      expect(ctx.model.columns).toEqual(['id', 'title', 'authorId'])
-      expect(ctx.model.relationships).toEqual([
-        { name: 'author', type: 'belongsTo', relatedModel: 'User' },
-      ])
+    expect(ctx.entity).toBe('Post')
+    expect(ctx.module).toBeUndefined()
 
-      // posts.index via controller-name convention, posts.show via bind — not /about
-      expect(ctx.routes).toHaveLength(2)
-      expect(ctx.routes.map((r) => r.name).sort()).toEqual(['posts.index', 'posts.show'])
-      const show = ctx.routes.find((r) => r.name === 'posts.show')
-      expect(show?.bindings).toEqual({ id: 'Post' })
-      expect(show?.controller).toEqual({ name: 'PostController', action: 'show' })
+    expect(ctx.model.filePath).toBe('app/Models/Post.ts')
+    expect(ctx.model.tableName).toBe('posts')
+    expect(ctx.model.columns).toEqual(['id', 'title', 'authorId'])
+    expect(ctx.model.relationships).toEqual([
+      { name: 'author', type: 'belongsTo', relatedModel: 'User' },
+    ])
 
-      expect(ctx.controller?.filePath).toBe('app/Http/Controllers/PostController.ts')
-      expect(ctx.controller?.actions).toEqual(['index', 'show'])
+    // posts.index via controller-name convention, posts.show via bind — not /about
+    expect(ctx.routes).toHaveLength(2)
+    expect(ctx.routes.map((r) => r.name).sort()).toEqual(['posts.index', 'posts.show'])
+    const show = ctx.routes.find((r) => r.name === 'posts.show')
+    expect(show?.bindings).toEqual({ id: 'Post' })
+    expect(show?.controller).toEqual({ name: 'PostController', action: 'show' })
 
-      expect(ctx.pages.map((p) => p.id)).toEqual(['posts/Index', 'posts/Show'])
-      const index = ctx.pages.find((p) => p.id === 'posts/Index')
-      expect(index?.props).toContain('posts')
+    // Exported controller class wins over the unexported helper above it
+    expect(ctx.controller?.filePath).toBe('app/Http/Controllers/PostController.ts')
+    expect(ctx.controller?.actions).toEqual(['index', 'show'])
 
-      expect(ctx.resource?.filePath).toBe('app/Http/Resources/PostResource.ts')
-      expect(ctx.policy?.filePath).toBe('app/Policies/PostPolicy.ts')
-      expect(ctx.seeders).toEqual(['db/seeders/002_PostsSeeder.ts'])
-      expect(ctx.tests).toContain('tests/controllers/PostController.test.ts')
-    } finally {
-      await workspace.cleanup()
-    }
+    expect(ctx.pages.map((p) => p.id)).toEqual(['posts/Index', 'posts/Show'])
+    const index = ctx.pages.find((p) => p.id === 'posts/Index')
+    expect(index?.props).toContain('posts')
+
+    expect(ctx.resource).toBe('app/Http/Resources/PostResource.ts')
+    expect(ctx.policy).toBe('app/Policies/PostPolicy.ts')
+    expect(ctx.factories).toEqual(['db/factories/PostFactory.ts'])
+    expect(ctx.seeders).toEqual(['db/seeders/002_PostsSeeder.ts'])
+    expect(ctx.tests).toContain('tests/controllers/PostController.test.ts')
   })
 
   it('resolves entity names case-insensitively', async () => {
-    const workspace = await createTempWorkspace('guren-cli-entity-case-')
+    const ctx = await generateEntityContext('post', { cwd: workspace.dir })
 
-    try {
-      await writeBlogFixture(workspace.dir)
-
-      const ctx = await generateEntityContext('post', { cwd: workspace.dir })
-
-      expect(ctx.entity).toBe('Post')
-    } finally {
-      await workspace.cleanup()
-    }
+    expect(ctx.entity).toBe('Post')
   })
 
   it('collects reverse relationship edges under referencedBy', async () => {
-    const workspace = await createTempWorkspace('guren-cli-entity-reverse-')
+    const ctx = await generateEntityContext('User', { cwd: workspace.dir })
 
-    try {
-      await writeBlogFixture(workspace.dir)
-
-      const ctx = await generateEntityContext('User', { cwd: workspace.dir })
-
-      expect(ctx.referencedBy).toEqual([
-        { model: 'Post', relationship: 'author', type: 'belongsTo' },
-      ])
-      expect(ctx.routes).toHaveLength(0)
-    } finally {
-      await workspace.cleanup()
-    }
+    expect(ctx.referencedBy).toEqual([
+      { model: 'Post', relationship: 'author', type: 'belongsTo' },
+    ])
+    expect(ctx.routes).toHaveLength(0)
   })
 
   it('throws EntityResolutionError listing available models for unknown entities', async () => {
-    const workspace = await createTempWorkspace('guren-cli-entity-unknown-')
-
-    try {
-      await writeBlogFixture(workspace.dir)
-
-      expect(generateEntityContext('Ghost', { cwd: workspace.dir })).rejects.toThrow(
-        EntityResolutionError,
-      )
-      expect(generateEntityContext('Ghost', { cwd: workspace.dir })).rejects.toThrow(
-        'Available models: Post, User',
-      )
-    } finally {
-      await workspace.cleanup()
-    }
+    expect(generateEntityContext('Ghost', { cwd: workspace.dir })).rejects.toThrow(
+      EntityResolutionError,
+    )
+    expect(generateEntityContext('Ghost', { cwd: workspace.dir })).rejects.toThrow(
+      'Available models: Post, User',
+    )
   })
 
-  it('requires --module when the same model exists in multiple locations', async () => {
-    const workspace = await createTempWorkspace('guren-cli-entity-ambiguous-')
-
-    try {
-      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
-      await mkdir(join(workspace.dir, 'modules/crm/app/Models'), { recursive: true })
-      await writeFile(join(workspace.dir, 'package.json'), '{}', 'utf8')
-      await writeFile(
-        join(workspace.dir, 'app/Models/Post.ts'),
-        'export class Post {}\n',
-        'utf8',
-      )
-      await writeFile(
-        join(workspace.dir, 'modules/crm/app/Models/Post.ts'),
-        'export class Post {}\n',
-        'utf8',
-      )
-
-      expect(generateEntityContext('Post', { cwd: workspace.dir })).rejects.toThrow(
-        'multiple locations: app, crm',
-      )
-
-      const ctx = await generateEntityContext('Post', { cwd: workspace.dir, module: 'crm' })
-      expect(ctx.module).toBe('crm')
-      expect(ctx.model.filePath).toBe('modules/crm/app/Models/Post.ts')
-    } finally {
-      await workspace.cleanup()
-    }
-  })
-})
-
-describe('renderEntityContextMarkdown', () => {
   it('renders the entity bundle as markdown', async () => {
-    const workspace = await createTempWorkspace('guren-cli-entity-markdown-')
+    const ctx = await generateEntityContext('Post', { cwd: workspace.dir })
+    const md = renderEntityContextMarkdown(ctx)
 
-    try {
-      await writeBlogFixture(workspace.dir)
-
-      const ctx = await generateEntityContext('Post', { cwd: workspace.dir })
-      const md = renderEntityContextMarkdown(ctx)
-
-      expect(md).toContain('# Post')
-      expect(md).toContain('## Model — app/Models/Post.ts (table: `posts`)')
-      expect(md).toContain('- Columns: id, title, authorId')
-      expect(md).toContain('- belongsTo: `author` → User')
-      expect(md).toContain('## Routes (2)')
-      expect(md).toContain('| GET | /posts | posts.index | PostController.index |')
-      expect(md).toContain('- Actions: index, show')
-      expect(md).toContain('- posts/Index — Props:')
-      expect(md).toContain('## Resource — app/Http/Resources/PostResource.ts')
-      expect(md).toContain('## Policy — app/Policies/PostPolicy.ts')
-      expect(md).toContain('## Seeders (1)')
-      expect(md).toContain('## Tests (1)')
-    } finally {
-      await workspace.cleanup()
-    }
+    expect(md).toContain('# Post')
+    expect(md).toContain('## Model — app/Models/Post.ts (table: `posts`)')
+    expect(md).toContain('- Columns: id, title, authorId')
+    expect(md).toContain('- belongsTo: `author` → User')
+    expect(md).toContain('## Routes (2)')
+    expect(md).toContain('| GET | /posts | posts.index | PostController.index |')
+    expect(md).toContain('- Actions: index, show')
+    expect(md).toContain('- posts/Index — Props:')
+    expect(md).toContain('## Resource — app/Http/Resources/PostResource.ts')
+    expect(md).toContain('## Policy — app/Policies/PostPolicy.ts')
+    expect(md).toContain('## Factories (1)')
+    expect(md).toContain('## Seeders (1)')
+    expect(md).toContain('## Tests (1)')
   })
 
   it('renders reverse references for the target entity', async () => {
-    const workspace = await createTempWorkspace('guren-cli-entity-md-reverse-')
+    const ctx = await generateEntityContext('User', { cwd: workspace.dir })
+    const md = renderEntityContextMarkdown(ctx)
 
-    try {
-      await writeBlogFixture(workspace.dir)
+    expect(md).toContain('## Referenced by')
+    expect(md).toContain('- Post — belongsTo `author`')
+    expect(md).toContain('No routes reference this entity.')
+  })
+})
 
-      const ctx = await generateEntityContext('User', { cwd: workspace.dir })
-      const md = renderEntityContextMarkdown(ctx)
+describe('entity context (duplicated entity across locations)', () => {
+  let workspace: TempWorkspace
 
-      expect(md).toContain('## Referenced by')
-      expect(md).toContain('- Post — belongsTo `author`')
-      expect(md).toContain('No routes reference this entity.')
-    } finally {
-      await workspace.cleanup()
-    }
+  beforeAll(async () => {
+    workspace = await createTempWorkspace('guren-cli-entity-ambiguous-')
+    const dir = workspace.dir
+
+    await mkdir(join(dir, 'app/Models'), { recursive: true })
+    await mkdir(join(dir, 'app/Http/Resources'), { recursive: true })
+    await mkdir(join(dir, 'db/seeders'), { recursive: true })
+    await mkdir(join(dir, 'modules/crm/app/Models'), { recursive: true })
+    await mkdir(join(dir, 'modules/crm/app/Http/Resources'), { recursive: true })
+    await writeFile(join(dir, 'package.json'), '{}', 'utf8')
+
+    await writeFile(join(dir, 'app/Models/Post.ts'), 'export class Post {}\n', 'utf8')
+    await writeFile(
+      join(dir, 'modules/crm/app/Models/Post.ts'),
+      'export class Post {}\n',
+      'utf8',
+    )
+    await writeFile(
+      join(dir, 'app/Http/Resources/PostResource.ts'),
+      'export class PostResource {}\n',
+      'utf8',
+    )
+    await writeFile(
+      join(dir, 'modules/crm/app/Http/Resources/PostResource.ts'),
+      'export class PostResource {}\n',
+      'utf8',
+    )
+    // Root-only seeder: must not leak into the crm bundle
+    await writeFile(
+      join(dir, 'db/seeders/001_PostsSeeder.ts'),
+      'export async function seed() {}\n',
+      'utf8',
+    )
+  })
+
+  afterAll(async () => {
+    await workspace.cleanup()
+  })
+
+  it('requires --module when the same model exists in multiple locations', async () => {
+    expect(generateEntityContext('Post', { cwd: workspace.dir })).rejects.toThrow(
+      'multiple locations: app, crm',
+    )
+  })
+
+  it('scopes every join to the selected module', async () => {
+    const ctx = await generateEntityContext('Post', { cwd: workspace.dir, module: 'crm' })
+
+    expect(ctx.module).toBe('crm')
+    expect(ctx.model.filePath).toBe('modules/crm/app/Models/Post.ts')
+    expect(ctx.resource).toBe('modules/crm/app/Http/Resources/PostResource.ts')
+    expect(ctx.seeders).toEqual([])
+  })
+
+  it('selects the application root via --module app', async () => {
+    const ctx = await generateEntityContext('Post', { cwd: workspace.dir, module: 'app' })
+
+    expect(ctx.module).toBeUndefined()
+    expect(ctx.model.filePath).toBe('app/Models/Post.ts')
+    expect(ctx.resource).toBe('app/Http/Resources/PostResource.ts')
+    expect(ctx.seeders).toEqual(['db/seeders/001_PostsSeeder.ts'])
   })
 })

--- a/packages/cli/tests/inertia-pages.test.ts
+++ b/packages/cli/tests/inertia-pages.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test'
+import { extractInertiaPageRefs, expectedInertiaPagePath } from '../src/inertia-pages'
+
+describe('extractInertiaPageRefs', () => {
+  it('extracts string-literal references', () => {
+    const refs = extractInertiaPageRefs(`
+      class PostController {
+        index() { return this.inertia('posts/Index', { posts: [] }) }
+      }
+    `)
+
+    expect(refs).toEqual([{ id: 'posts/Index', form: 'literal' }])
+  })
+
+  it('extracts typed-manifest references', () => {
+    const refs = extractInertiaPageRefs(`
+      class PostController {
+        show() { return this.inertia(pages.posts.Show, { post }) }
+      }
+    `)
+
+    expect(refs).toEqual([{ id: 'posts/Show', form: 'manifest' }])
+  })
+
+  it('supports bracket segments in manifest references', () => {
+    const refs = extractInertiaPageRefs(`
+      class AdminController {
+        index() { return this.inertia(pages['sales-admin'].Index, {}) }
+      }
+    `)
+
+    expect(refs).toEqual([{ id: 'sales-admin/Index', form: 'manifest' }])
+  })
+
+  it('deduplicates repeated references', () => {
+    const refs = extractInertiaPageRefs(`
+      class PostController {
+        a() { return this.inertia('posts/Index') }
+        b() { return this.inertia('posts/Index') }
+      }
+    `)
+
+    expect(refs).toHaveLength(1)
+  })
+})
+
+describe('expectedInertiaPagePath', () => {
+  it('points at the conventional .tsx location', () => {
+    expect(expectedInertiaPagePath('posts/Index')).toBe('resources/js/pages/posts/Index.tsx')
+  })
+})

--- a/packages/server/src/mcp/create-mcp-server.ts
+++ b/packages/server/src/mcp/create-mcp-server.ts
@@ -96,7 +96,7 @@ export function createMcpServer(options: CreateMcpServerOptions): McpServer {
       module: z
         .string()
         .optional()
-        .describe('Module name to disambiguate same-named models across modules/'),
+        .describe('Module name to disambiguate same-named models across modules/; "app" selects the application root'),
       format: z.enum(['json', 'markdown']).default('markdown').describe('Output format'),
     },
     async ({ entity, module, format }) => {
@@ -338,7 +338,8 @@ export function createMcpServer(options: CreateMcpServerOptions): McpServer {
     'entity-context',
     new ResourceTemplate('guren://context/{entity}', { list: undefined }),
     {
-      description: 'Entity-centric context bundle: model, routes, controller, pages, resource, policy',
+      description:
+        'Entity-centric context bundle: model, routes, controller, pages, resource, policy. For same-named models across modules, use the guren_entity_context tool with its module argument instead.',
       mimeType: 'text/markdown',
     },
     async (uri, variables) => {

--- a/packages/server/src/mcp/create-mcp-server.ts
+++ b/packages/server/src/mcp/create-mcp-server.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 
 /**
@@ -21,6 +21,8 @@ export interface GurenCliApi {
     validators: string[]
   }>
   renderContextMarkdown(ctx: unknown): string
+  generateEntityContext(entity: string, opts: { cwd: string; module?: string }): Promise<unknown>
+  renderEntityContextMarkdown(ctx: unknown): string
   runCheck(opts: { cwd: string }): Promise<{
     cwd: string
     checks: Array<{ key: string; title: string; status: string; message: string; suggestion?: string }>
@@ -83,6 +85,36 @@ export function createMcpServer(options: CreateMcpServerOptions): McpServer {
       const text =
         format === 'markdown' ? cli.renderContextMarkdown(ctx) : JSON.stringify(ctx, null, 2)
       return { content: [{ type: 'text', text }] }
+    },
+  )
+
+  server.tool(
+    'guren_entity_context',
+    'Get everything about one entity in a single bundle: model (table, columns, relationships, reverse references), routes with validation schemas, controller actions, Inertia pages with props, resource, policy, seeders, and tests. Prefer this over guren_get_context when working on a specific model.',
+    {
+      entity: z.string().describe('Model class name (e.g., "User"). Case-insensitive.'),
+      module: z
+        .string()
+        .optional()
+        .describe('Module name to disambiguate same-named models across modules/'),
+      format: z.enum(['json', 'markdown']).default('markdown').describe('Output format'),
+    },
+    async ({ entity, module, format }) => {
+      try {
+        const ctx = await cli.generateEntityContext(entity, { cwd, module })
+        const text =
+          format === 'markdown'
+            ? cli.renderEntityContextMarkdown(ctx)
+            : JSON.stringify(ctx, null, 2)
+        return { content: [{ type: 'text', text }] }
+      } catch (error) {
+        return {
+          content: [
+            { type: 'text' as const, text: error instanceof Error ? error.message : String(error) },
+          ],
+          isError: true,
+        }
+      }
     },
   )
 
@@ -296,6 +328,27 @@ export function createMcpServer(options: CreateMcpServerOptions): McpServer {
             uri: uri.href,
             mimeType: 'application/json',
             text: JSON.stringify(ctx, null, 2),
+          },
+        ],
+      }
+    },
+  )
+
+  server.resource(
+    'entity-context',
+    new ResourceTemplate('guren://context/{entity}', { list: undefined }),
+    {
+      description: 'Entity-centric context bundle: model, routes, controller, pages, resource, policy',
+      mimeType: 'text/markdown',
+    },
+    async (uri, variables) => {
+      const ctx = await cli.generateEntityContext(String(variables.entity), { cwd })
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: 'text/markdown',
+            text: cli.renderEntityContextMarkdown(ctx),
           },
         ],
       }

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -55,6 +55,8 @@ type ModelBindingResolver = (value: string) => Promise<unknown>
  */
 interface BindableModel {
   findOrFail(id: unknown, key?: string): Promise<unknown>
+  /** Bound values are model classes at runtime; the constructor name is the introspection payload. */
+  readonly name?: string
 }
 
 type SchemaLike<T = unknown> = ValidationSchema<T> | undefined
@@ -215,6 +217,8 @@ export class Router<M extends string = never> {
   private readonly middlewareAliases: Map<string, MiddlewareHandler> = new Map()
   private readonly middlewareGroups: Map<string, string[]> = new Map()
   private readonly modelBindings: Map<string, ModelBindingResolver> = new Map()
+  /** Model class names for router-level bind(param, Model) calls — resolver-only binds carry no name. */
+  private readonly modelBindingNames: Map<string, string> = new Map()
 
   aliasMiddleware<N extends string>(name: N, handler: MiddlewareHandler): Router<M | N> {
     this.middlewareAliases.set(name, handler)
@@ -234,6 +238,7 @@ export class Router<M extends string = never> {
     if (typeof modelOrResolver === 'function' && 'findOrFail' in modelOrResolver) {
       // Model class with static findOrFail — wrap in resolver
       const model = modelOrResolver as unknown as BindableModel
+      if (model.name) this.modelBindingNames.set(param, model.name)
       this.modelBindings.set(param, async (value: string) => {
         return model.findOrFail(value)
       })
@@ -476,6 +481,7 @@ export class Router<M extends string = never> {
     this.middlewareAliases.clear()
     this.middlewareGroups.clear()
     this.modelBindings.clear()
+    this.modelBindingNames.clear()
   }
 
   definitions(): RouteDefinition[] {
@@ -489,17 +495,7 @@ export class Router<M extends string = never> {
       controller: isControllerAction(handler)
         ? { name: handler[0].name, action: String(handler[1]) }
         : undefined,
-      bindings: bindings && bindings.size > 0
-        ? Object.fromEntries(
-            [...bindings].flatMap(([param, model]) => {
-              // `bind` values are model classes at runtime; their constructor
-              // name is the introspection payload. Anonymous values carry no
-              // usable name, so they are omitted rather than emitted as ''.
-              const modelName = (model as { name?: string }).name
-              return modelName ? [[param, modelName]] : []
-            }),
-          )
-        : undefined,
+      bindings: serializeBindings(path, bindings, this.modelBindingNames),
       ...openapi,
     }))
   }
@@ -1000,6 +996,32 @@ function buildResponse(result: unknown): Response {
   }
 
   return new Response(String(result))
+}
+
+/**
+ * Introspectable model bindings for a route: per-route `bind` entries plus
+ * router-level `bind(param, Model)` calls whose param appears in the path
+ * (route-level entries win). Bindings without a usable constructor name
+ * (anonymous classes, custom resolvers) are omitted rather than emitted
+ * as an empty string.
+ */
+function serializeBindings(
+  path: string,
+  routeBindings: Map<string, BindableModel> | undefined,
+  routerBindingNames: Map<string, string>,
+): Record<string, string> | undefined {
+  const entries = new Map<string, string>()
+
+  for (const param of path.match(/:(\w+)/g) ?? []) {
+    const name = routerBindingNames.get(param.slice(1))
+    if (name) entries.set(param.slice(1), name)
+  }
+
+  for (const [param, model] of routeBindings ?? []) {
+    if (model.name) entries.set(param, model.name)
+  }
+
+  return entries.size > 0 ? Object.fromEntries(entries) : undefined
 }
 
 function isControllerAction(action: AnyRouteHandler): action is AnyControllerAction {

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -154,6 +154,8 @@ export interface RouteDefinition {
     name: string
     action: string
   }
+  /** Route model bindings: param name → bound model class name (from `bind`) */
+  bindings?: Record<string, string>
   summary?: string
   description?: string
   tags?: string[]
@@ -477,7 +479,7 @@ export class Router<M extends string = never> {
   }
 
   definitions(): RouteDefinition[] {
-    return this.registry.map(({ method, path, name, schemas, openapi, routeMiddlewareNames, middlewares, handler }) => ({
+    return this.registry.map(({ method, path, name, schemas, openapi, routeMiddlewareNames, middlewares, handler, bindings }) => ({
       method,
       path,
       name,
@@ -486,6 +488,17 @@ export class Router<M extends string = never> {
       hasInlineMiddleware: middlewares.length > 0,
       controller: isControllerAction(handler)
         ? { name: handler[0].name, action: String(handler[1]) }
+        : undefined,
+      bindings: bindings && bindings.size > 0
+        ? Object.fromEntries(
+            [...bindings].flatMap(([param, model]) => {
+              // `bind` values are model classes at runtime; their constructor
+              // name is the introspection payload. Anonymous values carry no
+              // usable name, so they are omitted rather than emitted as ''.
+              const modelName = (model as { name?: string }).name
+              return modelName ? [[param, modelName]] : []
+            }),
+          )
         : undefined,
       ...openapi,
     }))

--- a/packages/server/tests/mcp/mcp-server.test.ts
+++ b/packages/server/tests/mcp/mcp-server.test.ts
@@ -23,6 +23,18 @@ function createMockCli(): GurenCliApi {
       validators: ['CreatePostValidator'],
     }),
     renderContextMarkdown: (ctx) => `# Context\n${JSON.stringify(ctx)}`,
+    generateEntityContext: async (entity: string) => {
+      if (entity.toLowerCase() !== 'post') {
+        throw new Error(`Model "${entity}" not found. Available models: Post, User`)
+      }
+      return {
+        entity: 'Post',
+        model: { filePath: 'app/Models/Post.ts', tableName: 'posts', relationships: [] },
+        routes: [{ method: 'GET', path: '/posts', controller: { name: 'PostController', action: 'index' } }],
+        pages: [{ id: 'posts/Index', filePath: 'resources/js/pages/posts/Index.tsx' }],
+      }
+    },
+    renderEntityContextMarkdown: (ctx) => `# Post\n${JSON.stringify(ctx)}`,
     runCheck: async () => ({
       cwd: '/test',
       checks: [
@@ -110,6 +122,7 @@ describe('Guren MCP Server', () => {
     const names = tools.map((t) => t.name)
 
     expect(names).toContain('guren_get_context')
+    expect(names).toContain('guren_entity_context')
     expect(names).toContain('guren_check')
     expect(names).toContain('guren_list_models')
     expect(names).toContain('guren_generate_guidelines')
@@ -117,7 +130,44 @@ describe('Guren MCP Server', () => {
     expect(names).toContain('guren_make_feature')
     expect(names).toContain('guren_make_component')
     expect(names).toContain('guren_codegen')
-    expect(tools).toHaveLength(8)
+    expect(tools).toHaveLength(9)
+  })
+
+  test('guren_entity_context returns markdown by default', async () => {
+    const client = await createTestClient()
+    const result = await client.callTool({
+      name: 'guren_entity_context',
+      arguments: { entity: 'Post' },
+    })
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text
+
+    expect(result.isError).toBeFalsy()
+    expect(text).toStartWith('# Post')
+  })
+
+  test('guren_entity_context returns JSON when requested', async () => {
+    const client = await createTestClient()
+    const result = await client.callTool({
+      name: 'guren_entity_context',
+      arguments: { entity: 'Post', format: 'json' },
+    })
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text
+    const parsed = JSON.parse(text)
+
+    expect(parsed.entity).toBe('Post')
+    expect(parsed.routes[0].controller.name).toBe('PostController')
+  })
+
+  test('guren_entity_context surfaces resolution errors as isError', async () => {
+    const client = await createTestClient()
+    const result = await client.callTool({
+      name: 'guren_entity_context',
+      arguments: { entity: 'Ghost' },
+    })
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text
+
+    expect(result.isError).toBe(true)
+    expect(text).toContain('Model "Ghost" not found')
   })
 
   test('guren_get_context returns JSON by default', async () => {
@@ -234,6 +284,21 @@ describe('Guren MCP Server', () => {
     const parsed = JSON.parse(text)
 
     expect(parsed.framework.name).toBe('guren')
+  })
+
+  test('lists the entity context resource template', async () => {
+    const client = await createTestClient()
+    const { resourceTemplates } = await client.listResourceTemplates()
+
+    expect(resourceTemplates.map((t) => t.uriTemplate)).toContain('guren://context/{entity}')
+  })
+
+  test('reads entity context through the resource template', async () => {
+    const client = await createTestClient()
+    const result = await client.readResource({ uri: 'guren://context/Post' })
+    const text = (result.contents[0] as { text: string }).text
+
+    expect(text).toStartWith('# Post')
   })
 
   test('reads guidelines resource', async () => {

--- a/rfcs/0004-spec-anchored-development.md
+++ b/rfcs/0004-spec-anchored-development.md
@@ -371,7 +371,10 @@ Purely additive. Existing applications see no behavior change:
    provenance headers?
 3. **Reverse relationship edges.** Showing "Post belongsTo User" under
    `guren context User` requires an inverted index over all models —
-   include in Part 1, or defer?
+   ~~include in Part 1, or defer?~~
+   **Resolved in implementation:** included in Part 1 as `referencedBy`.
+   Every model is already parsed to resolve the entity argument, so the
+   inversion is a cheap in-memory pass over data the command has anyway.
 4. **`last_reviewed` TTL.** Ship disabled with config opt-in (as
    proposed), or default to a generous TTL (e.g. 180 days, warn-only)?
 5. **Richer code-side vocabulary.** `@coreConcept`/`@businessRule`


### PR DESCRIPTION
## Summary

Implements **RFC 0004 Part 1** (`rfcs/0004-spec-anchored-development.md`): entity-centric context bundles for AI agents and humans.

- **`guren context <Entity>`** — one command answers "everything about this model": table + columns, relationships **and reverse references** (`referencedBy`), routes with validation-schema type strings, controller actions, Inertia pages with extracted Props, resource, policy, seeders, and tests. Case-insensitive; `--module <name>` disambiguates same-named models across `modules/*` (RFC 0002); `--json` for machine consumption.
- **Route data upgrade** — whole-project `guren context` now consumes `loadRouteDefinitions`/`RouteDefinition` instead of the lossy `RouteInfo`: the Routes table gains a Controller column, JSON output carries controller bindings and rendered schema types.
- **`RouteDefinition.bindings`** — new introspection field (param name → bound model class name) so `bind: { id: Post }` routes are attributable to their entity.
- **MCP surface** — `guren_entity_context` tool (markdown/json, resolution errors surface as `isError`) and `guren://context/{entity}` resource template, both through the existing `GurenCliApi` seam. Endpoint remains dev-only behind `GUREN_MCP=1`.

## Verification

- `bun run build:clean`, `bun run typecheck`, `bun run test:bun` (2505 pass / 0 fail) all green; `audit:core-first` and `audit:docs` pass.
- New tests: `packages/cli/tests/entity-context.test.ts` (bundle joins, case-insensitive resolution, reverse edges, unknown-entity error, cross-module ambiguity + `--module`, markdown rendering), MCP tool/resource-template tests.
- Dogfooded against `examples/blog`: `guren context Post` renders the full bundle including schema-derived body types and Props.

## RFC notes

- Resolves RFC 0004 Open Question 3 in place (reverse edges included in Part 1 — amendment in this PR).
- The "Linked docs" section lands with Part 2 (docs frontmatter convention).

Refs: RFC 0004