### PR TITLE
feat(cli): doc-code linking (RFC 0004 Part 2)

### DIFF
--- a/.changeset/docs-linking.md
+++ b/.changeset/docs-linking.md
@@ -14,6 +14,10 @@ feat: doc–code linking (RFC 0004 Part 2)
   `related` paths/globs and unknown `entities` fail; entities whose
   only docs are superseded warn; `--docs-ttl <days>` warns on stale
   `last_reviewed`. Content-activated — apps without the convention see
-  zero results — and participates in `check --changed`.
+  zero results — and participates in `check --changed`. Doc-link
+  results also appear in plain `guren check`, so agent-harness edit
+  hooks surface dangling links when the files they govern change —
+  intentional: that is exactly when the link should be fixed.
+  `--arch --docs` together runs the union of both suites.
 - `make:adr "Title"` scaffolds numbered ADRs under `docs/adr/` with
   prefilled, linkable frontmatter (`--module` targets a module's docs).

--- a/.changeset/docs-linking.md
+++ b/.changeset/docs-linking.md
@@ -21,3 +21,8 @@ feat: doc–code linking (RFC 0004 Part 2)
   `--arch --docs` together runs the union of both suites.
 - `make:adr "Title"` scaffolds numbered ADRs under `docs/adr/` with
   prefilled, linkable frontmatter (`--module` targets a module's docs).
+  `--entity <Model>` prefills `entities:` with the canonical class name
+  and `related:` with the entity's controller/resource/policy files; an
+  entity that doesn't exist yet is prefilled as given, so ADR-first
+  flows get a failing `check --docs` as the "implementation missing"
+  signal.

--- a/.changeset/docs-linking.md
+++ b/.changeset/docs-linking.md
@@ -1,0 +1,19 @@
+---
+'@guren/cli': minor
+---
+
+feat: doc–code linking (RFC 0004 Part 2)
+
+- `docs/` frontmatter convention: markdown under `docs/` (and
+  `modules/*/docs/`) can declare `kind`, `status`, `entities`,
+  `related` (paths or globs), and `last_reviewed`.
+- `guren context <Entity>` gains a **Linked docs** section, resolved
+  from frontmatter `entities:` and code-side `@docs <path>` JSDoc tags
+  on models and controllers.
+- `guren check --docs` validates the links deterministically: dangling
+  `related` paths/globs and unknown `entities` fail; entities whose
+  only docs are superseded warn; `--docs-ttl <days>` warns on stale
+  `last_reviewed`. Content-activated — apps without the convention see
+  zero results — and participates in `check --changed`.
+- `make:adr "Title"` scaffolds numbered ADRs under `docs/adr/` with
+  prefilled, linkable frontmatter (`--module` targets a module's docs).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ bunx guren model:list           # List models with relationships
 bunx guren model:list --format json  # Models as JSON
 
 # Integrity checking
-bunx guren check                # Validate route↔controller↔page consistency + architecture boundaries (exits non-zero on failures)
+bunx guren check                # Validate route↔controller↔page consistency, architecture boundaries, and doc links (informational; only --arch/--docs set the exit code)
 bunx guren check --json         # Check results as JSON
 bunx guren check --arch         # Architecture boundary checks only (guren.arch.ts) — fast path for edit hooks
 bunx guren check --docs         # Doc-link checks only: docs/ frontmatter (entities/related) + @docs tags (exits non-zero on failures)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ Commands designed for AI coding agents to understand, validate, and generate cod
 # Project introspection
 bunx guren context              # Project context map (markdown)
 bunx guren context --json       # Project context map (JSON)
+bunx guren context User         # Entity-centric bundle: model, routes, pages, resource, policy, linked docs (--module to disambiguate, "app" = root)
 bunx guren model:list           # List models with relationships
 bunx guren model:list --format json  # Models as JSON
 
@@ -86,6 +87,7 @@ bunx guren model:list --format json  # Models as JSON
 bunx guren check                # Validate route↔controller↔page consistency + architecture boundaries (exits non-zero on failures)
 bunx guren check --json         # Check results as JSON
 bunx guren check --arch         # Architecture boundary checks only (guren.arch.ts) — fast path for edit hooks
+bunx guren check --docs         # Doc-link checks only: docs/ frontmatter (entities/related) + @docs tags (exits non-zero on failures)
 bunx guren check --changed      # Restrict file-scanning checks to files changed vs. the merge base with main
 bunx guren audit                # Security audit: validation/auth on mutating routes, raw SQL, secrets, mass assignment
 bunx guren audit --json         # Audit results as JSON (exits non-zero on failures)
@@ -103,6 +105,7 @@ bunx guren make:feature Post --fields "title:string,body:text" --test  # With te
 bunx guren make:feature Post --fields "title:string" --public  # Skip auth checks in mutating actions
 bunx guren make:feature Post --fields "title:string" --policy  # Also generate a policy and enforce it in store/update
 bunx guren make:policy Post     # Authorization policy scaffold (app/Policies)
+bunx guren make:adr "Billing cycle is end-of-month"  # Numbered ADR under docs/adr with linkable frontmatter (entities/related)
 
 # Application modules (RFC 0002) — self-contained modules/<name>/ directories
 bunx guren make:module Billing              # Scaffold modules/billing/{index.ts,routes.ts,db/schema.ts}, wire into src/app.ts
@@ -341,6 +344,10 @@ export const handler = createLambdaHandler(app)
 | `packages/server/src/auth/password/NodeHasher.ts` | Node.js-compatible password hasher |
 | `packages/cli/src/bin.ts` | CLI entry point |
 | `packages/cli/src/context.ts` | AI agent: project context map generation |
+| `packages/cli/src/entity-context.ts` | AI agent: entity-centric context bundles (`guren context <Entity>`, RFC 0004) |
+| `packages/cli/src/docs-index.ts` | AI agent: docs/ frontmatter scanning + `@docs` tag extraction |
+| `packages/cli/src/docs-check.ts` | AI agent: doc-link validation (`guren check --docs`) |
+| `packages/cli/src/make-adr.ts` | AI agent: numbered ADR scaffolding (`make:adr`) |
 | `packages/cli/src/check.ts` | AI agent: integrity checking |
 | `packages/cli/src/arch-check.ts` | AI agent: architecture boundary checking (`guren.arch.ts`, see RFC 0002) |
 | `packages/cli/src/arch/index.ts` | `defineArchRules()` + types, published as the `@guren/cli/arch` subpath |

--- a/examples/blog/docs/adr/0001-posts-are-public-by-default.md
+++ b/examples/blog/docs/adr/0001-posts-are-public-by-default.md
@@ -1,0 +1,25 @@
+---
+kind: adr
+status: accepted
+entities: [Post]
+related:
+  - app/Http/Controllers/PostController.ts
+  - app/Http/Resources/PostResource.ts
+last_reviewed: 2026-07-25
+---
+
+# Posts are public by default
+
+## Context
+
+The blog is a public reading experience; only authoring is gated.
+
+## Decision
+
+Index and Show render without authentication. Store, update, and
+destroy require an authenticated author (see PostController).
+
+## Consequences
+
+Public caching of post pages stays trivial; any future private-post
+feature must introduce its own visibility model.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -23,6 +23,7 @@ import { makeModel } from './make-model'
 import { makeModule } from './make-module'
 import { makeNotification } from './make-notification'
 import { makeProvider } from './make-provider'
+import { makeAdr } from './make-adr'
 import { makeResource } from './make-resource'
 import { makeRoute } from './make-route'
 import { makeSeeder } from './make-seeder'
@@ -117,6 +118,7 @@ const makeCommandSpecs: MakeCommandSpec[] = [
   { name: 'make:seeder', description: 'Generate a new database seeder.', argDescription: 'Seeder class name', makeFn: makeSeeder, resourceName: 'Seeder' },
   { name: 'make:notification', description: 'Generate a new notification class.', argDescription: 'Notification class name', makeFn: makeNotification, resourceName: 'Notification' },
   { name: 'make:provider', description: 'Generate a new service provider.', argDescription: 'Provider class name', makeFn: makeProvider, resourceName: 'Provider' },
+  { name: 'make:adr', description: 'Generate a numbered ADR under docs/adr with linkable frontmatter.', argDescription: 'Decision title (quoted prose)', makeFn: makeAdr, resourceName: 'ADR' },
 ]
 
 const makeCommands = Object.fromEntries(
@@ -1682,6 +1684,14 @@ const checkCommand = defineCommand({
       type: 'boolean',
       description: 'Run only architecture boundary checks (guren.arch.ts). Fast path for edit hooks.',
     },
+    docs: {
+      type: 'boolean',
+      description: 'Run only doc-link checks (docs/ frontmatter + @docs tags).',
+    },
+    'docs-ttl': {
+      type: 'string',
+      description: 'Warn when a doc\'s last_reviewed is older than N days.',
+    },
     changed: {
       type: 'boolean',
       description: 'Restrict file-scanning checks to files changed vs. the merge base with main.',
@@ -1693,6 +1703,8 @@ const checkCommand = defineCommand({
       json: Boolean(args.json),
       routesFile: args.routes,
       arch: Boolean(args.arch),
+      docs: Boolean(args.docs),
+      docsTtlDays: args['docs-ttl'] ? Number(args['docs-ttl']) : undefined,
       changed: Boolean(args.changed),
     })
 
@@ -1702,12 +1714,13 @@ const checkCommand = defineCommand({
       renderCheckReport(report)
     }
 
-    // Only `--arch` gates on exit code. Plain `guren check` has never set
-    // one (it's a v1.0-stable command; changing that default is a breaking
-    // change reserved for a major release). `--arch` is a brand-new flag
-    // with no prior contract to preserve, so it can gate CI from day one —
-    // that's the intended way to enforce guren.arch.ts boundaries in CI.
-    if (args.arch && report.failCount > 0) {
+    // Only `--arch` and `--docs` gate on exit code. Plain `guren check` has
+    // never set one (it's a v1.0-stable command; changing that default is a
+    // breaking change reserved for a major release). The fast-path flags
+    // are new, with no prior contract to preserve, so they can gate CI from
+    // day one — that's the intended way to enforce boundaries and doc
+    // links in CI.
+    if ((args.arch || args.docs) && report.failCount > 0) {
       process.exitCode = 1
     }
   },

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -118,8 +118,29 @@ const makeCommandSpecs: MakeCommandSpec[] = [
   { name: 'make:seeder', description: 'Generate a new database seeder.', argDescription: 'Seeder class name', makeFn: makeSeeder, resourceName: 'Seeder' },
   { name: 'make:notification', description: 'Generate a new notification class.', argDescription: 'Notification class name', makeFn: makeNotification, resourceName: 'Notification' },
   { name: 'make:provider', description: 'Generate a new service provider.', argDescription: 'Provider class name', makeFn: makeProvider, resourceName: 'Provider' },
-  { name: 'make:adr', description: 'Generate a numbered ADR under docs/adr with linkable frontmatter.', argDescription: 'Decision title (quoted prose)', makeFn: makeAdr, resourceName: 'ADR' },
 ]
+
+// make:adr takes an extra --entity flag beyond the shared writer options,
+// so it gets its own command instead of a makeCommandSpecs entry.
+const makeAdrCommand = defineCommand({
+  meta: {
+    name: 'make:adr',
+    description: 'Generate a numbered ADR under docs/adr with linkable frontmatter.',
+  },
+  args: {
+    name: { type: 'positional', required: true, description: 'Decision title (quoted prose)' },
+    entity: {
+      type: 'string',
+      description: 'Model class name to prefill entities:/related: with (case-insensitive).',
+    },
+    force: { type: 'boolean', description: 'Overwrite existing files', alias: 'f' },
+    module: MODULE_ARG,
+  },
+  async run({ args }) {
+    const file = await makeAdr(args.name, { ...toWriterOptions(args), entity: args.entity })
+    consola.success(`ADR created at ${file}`)
+  },
+})
 
 const makeCommands = Object.fromEntries(
   makeCommandSpecs.map((spec) => [
@@ -2346,6 +2367,7 @@ const deployCommand = defineCommand({
 
 const builtinSubCommands = {
   ...makeCommands,
+  'make:adr': makeAdrCommand,
   'make:auth': makeAuthCommand,
   'make:module': makeModuleCommand,
   'make:channel': makeChannelCommand,

--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -113,7 +113,16 @@ export async function runCheck(options: RunCheckOptions = {}): Promise<CheckRepo
   const filterChanged = (files: string[]): string[] =>
     changedFiles ? files.filter((f) => changedFiles.has(toPosixRelative(cwd, f))) : files
 
-  if (!options.arch && !options.docs) {
+  // `--arch` / `--docs` select suites; combining them runs the union (never
+  // silently nothing). No flag = every suite.
+  const selected = new Set<'arch' | 'docs'>([
+    ...(options.arch ? (['arch'] as const) : []),
+    ...(options.docs ? (['docs'] as const) : []),
+  ])
+  const runs = (suite: 'core' | 'arch' | 'docs'): boolean =>
+    selected.size === 0 || (suite !== 'core' && selected.has(suite))
+
+  if (runs('core')) {
     // 1. Check controllers for empty methods
     const controllerFiles = filterChanged(await discoverControllerFiles(cwd))
     for (const filePath of controllerFiles) {
@@ -210,13 +219,13 @@ export async function runCheck(options: RunCheckOptions = {}): Promise<CheckRepo
   // 7. Doc-link checks (docs/ frontmatter + @docs tags, RFC 0004). Runs in
   // plain mode and under --docs; content-activated, so apps without the
   // docs convention contribute zero results here.
-  if (!options.arch) {
-    const docsResults = await runDocsCheck({ cwd, changedFiles, ttlDays: options.docsTtlDays })
+  if (runs('docs')) {
+    const docsResults = await runDocsCheck({ cwd, changedFiles, ttlDays: options.docsTtlDays, cache })
     checks.push(...docsResults)
   }
 
   // 8. Check architecture boundaries (guren.arch.ts + derived module rules)
-  if (!options.docs) {
+  if (runs('arch')) {
     const archResults = await runArchCheck({ cwd, cache, changedFiles })
     checks.push(...archResults)
   }

--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -13,6 +13,7 @@ import {
 import { ParseCache } from './parse-cache'
 import { extractInertiaPageRefs, resolveInertiaPageFile, expectedInertiaPagePath } from './inertia-pages'
 import { runArchCheck } from './arch-check'
+import { runDocsCheck } from './docs-check'
 import { getChangedFiles } from './changed-files'
 import { check, type CheckResult, type CheckReport, type CheckStatus } from './check-result'
 
@@ -34,6 +35,14 @@ export interface RunCheckOptions {
    * Falls back to checking everything when not in a git repo.
    */
   changed?: boolean
+  /**
+   * Run doc-link checks only (docs/ frontmatter + @docs tags), skipping
+   * everything else. Like `--arch`, a brand-new fast path that gates on
+   * exit code from day one.
+   */
+  docs?: boolean
+  /** Warn when a doc's `last_reviewed` is older than this many days. Off when unset. */
+  docsTtlDays?: number
 }
 
 /**
@@ -104,7 +113,7 @@ export async function runCheck(options: RunCheckOptions = {}): Promise<CheckRepo
   const filterChanged = (files: string[]): string[] =>
     changedFiles ? files.filter((f) => changedFiles.has(toPosixRelative(cwd, f))) : files
 
-  if (!options.arch) {
+  if (!options.arch && !options.docs) {
     // 1. Check controllers for empty methods
     const controllerFiles = filterChanged(await discoverControllerFiles(cwd))
     for (const filePath of controllerFiles) {
@@ -198,9 +207,19 @@ export async function runCheck(options: RunCheckOptions = {}): Promise<CheckRepo
     checks.push(...schemaAggregationResults)
   }
 
-  // 7. Check architecture boundaries (guren.arch.ts + derived module rules)
-  const archResults = await runArchCheck({ cwd, cache, changedFiles })
-  checks.push(...archResults)
+  // 7. Doc-link checks (docs/ frontmatter + @docs tags, RFC 0004). Runs in
+  // plain mode and under --docs; content-activated, so apps without the
+  // docs convention contribute zero results here.
+  if (!options.arch) {
+    const docsResults = await runDocsCheck({ cwd, changedFiles, ttlDays: options.docsTtlDays })
+    checks.push(...docsResults)
+  }
+
+  // 8. Check architecture boundaries (guren.arch.ts + derived module rules)
+  if (!options.docs) {
+    const archResults = await runArchCheck({ cwd, cache, changedFiles })
+    checks.push(...archResults)
+  }
 
   const report: CheckReport = {
     cwd,

--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -120,26 +120,60 @@ export async function listModuleNames(appRoot: string): Promise<string[]> {
 }
 
 /**
- * Absolute paths of directories directly under `modules/` — each is
- * expected to mirror the top-level app layout, so `modules/<name>/<subDir>`
- * is scanned alongside `<appRoot>/<subDir>` for every `discover*Files`
- * function below.
+ * The app root plus every `modules/<name>/` directory, each tagged with
+ * its module name — the single "root + modules" fan-out point shared by
+ * the `discover*Files` functions below, `scanDocs`, and the entity
+ * context's db-artifact scans.
  */
-async function listModuleDirs(appRoot: string): Promise<string[]> {
+export async function listAppRoots(
+  appRoot: string,
+): Promise<Array<{ module: string | null; dir: string }>> {
   const names = await listModuleNames(appRoot)
-  return names.map((name) => resolve(appRoot, 'modules', name))
+  return [
+    { module: null, dir: appRoot },
+    ...names.map((name) => ({ module: name, dir: resolve(appRoot, 'modules', name) })),
+  ]
 }
 
 /**
- * Scans `<appRoot>/<subDir>` plus `<subDir>` under every module directory
- * discovered by `listModuleDirs` — the single fan-out point that makes
- * every `discover*Files` function below (and everything built on them:
- * `check`, `audit`, `context`, `model:list`, `doctor`) module-aware for free.
+ * Scans `<appRoot>/<subDir>` plus `<subDir>` under every module directory —
+ * what makes every `discover*Files` function below (and everything built
+ * on them: `check`, `audit`, `context`, `model:list`, `doctor`)
+ * module-aware for free.
  */
 async function discoverDir(appRoot: string, subDir: string): Promise<string[]> {
-  const roots = [appRoot, ...(await listModuleDirs(appRoot))]
-  const groups = await Promise.all(roots.map((root) => collectFiles(resolve(root, subDir))))
+  const roots = await listAppRoots(appRoot)
+  const groups = await Promise.all(roots.map((root) => collectFiles(resolve(root.dir, subDir))))
   return groups.flat()
+}
+
+/**
+ * Recursively collect every file under `directory`, skipping only
+ * dependency/build directories and `.git`. Unlike `collectFiles`, dotfiles
+ * and all extensions are included — docs `related:` globs may target
+ * markdown, JSON, workflows, or migrations, not just source files.
+ */
+export async function collectAllFiles(directory: string): Promise<string[]> {
+  const results: string[] = []
+
+  let entries
+  try {
+    entries = await readdir(directory, { withFileTypes: true })
+  } catch {
+    return results
+  }
+
+  for (const entry of entries) {
+    const fullPath = join(directory, entry.name)
+    if (entry.isDirectory()) {
+      if (NON_SOURCE_DIR_NAMES.has(entry.name) || entry.name === '.git') continue
+      results.push(...(await collectAllFiles(fullPath)))
+    } else if (entry.isFile()) {
+      results.push(fullPath)
+    }
+  }
+
+  return results
 }
 
 export function discoverModelFiles(appRoot: string): Promise<string[]> {

--- a/packages/cli/src/docs-check.ts
+++ b/packages/cli/src/docs-check.ts
@@ -1,0 +1,203 @@
+import { resolve } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import {
+  discoverModelFiles,
+  discoverControllerFiles,
+  fileExists,
+  directoryExists,
+  collectFiles,
+  toPosixRelative,
+  classNameFromPath,
+  IMPORTABLE_EXTENSIONS,
+  NON_SOURCE_DIR_NAMES,
+} from './discovery'
+import { matchesGlob } from './glob-match'
+import { scanDocs, extractDocsTags, type DocRef } from './docs-index'
+import { check, type CheckResult } from './check-result'
+
+export interface DocsCheckOptions {
+  cwd: string
+  /** Restrict validation to changed docs and tags in changed source files. */
+  changedFiles?: Set<string> | null
+  /** Warn when `last_reviewed` is older than this many days. Off when unset. */
+  ttlDays?: number
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+function hasGlobChars(entry: string): boolean {
+  return entry.includes('*')
+}
+
+/**
+ * Doc-link validation (RFC 0004): frontmatter `related` paths/globs must
+ * resolve, `entities` must name real models, `@docs` tags in model and
+ * controller sources must point at existing files, and entities whose only
+ * linked docs are superseded ADRs get flagged. Activates on content — an
+ * app with no docs and no tags produces zero results, so nothing goes red
+ * on projects that haven't adopted the convention.
+ */
+export async function runDocsCheck(options: DocsCheckOptions): Promise<CheckResult[]> {
+  const { cwd, changedFiles, ttlDays } = options
+  const results: CheckResult[] = []
+
+  const [refs, modelFiles, controllerFiles] = await Promise.all([
+    scanDocs(cwd),
+    discoverModelFiles(cwd),
+    discoverControllerFiles(cwd),
+  ])
+
+  const modelNames = new Set(modelFiles.map((file) => classNameFromPath(file).toLowerCase()))
+
+  // Lazily built once, only when some doc uses a glob: POSIX-relative
+  // source-file list to match `related` globs against.
+  let projectFiles: string[] | null = null
+  const globMatchesSomething = async (glob: string): Promise<boolean> => {
+    projectFiles ??= (await collectFiles(cwd, IMPORTABLE_EXTENSIONS, NON_SOURCE_DIR_NAMES)).map(
+      (file) => toPosixRelative(cwd, file),
+    )
+    return projectFiles.some((file) => matchesGlob(file, glob))
+  }
+
+  const changedModelNames = changedFiles
+    ? new Set(
+        modelFiles
+          .filter((file) => changedFiles.has(toPosixRelative(cwd, file)))
+          .map((file) => classNameFromPath(file).toLowerCase()),
+      )
+    : null
+
+  const docInChangedScope = (ref: DocRef): boolean => {
+    if (!changedFiles) return true
+    if (changedFiles.has(ref.path)) return true
+    if (ref.entities.some((entity) => changedModelNames?.has(entity.toLowerCase()))) return true
+    return ref.related.some((entry) =>
+      hasGlobChars(entry)
+        ? [...changedFiles].some((file) => matchesGlob(file, entry))
+        : changedFiles.has(entry.replace(/\/$/, '')),
+    )
+  }
+
+  const linkedDocs = refs.filter((ref) => ref.hasFrontmatter)
+
+  for (const ref of linkedDocs) {
+    if (!docInChangedScope(ref)) continue
+
+    let broken = 0
+
+    for (const entry of ref.related) {
+      const resolves = hasGlobChars(entry)
+        ? await globMatchesSomething(entry)
+        : (await fileExists(cwd, entry)) || (await directoryExists(resolve(cwd, entry)))
+      if (!resolves) {
+        broken += 1
+        results.push(
+          check(
+            `docs-related:${ref.path}:${entry}`,
+            `${ref.path} → ${entry}`,
+            'fail',
+            `Doc references '${entry}' but nothing matches it (renamed or deleted?).`,
+            `Update the 'related' entry in ${ref.path} or restore the path.`,
+            ref.path,
+          ),
+        )
+      }
+    }
+
+    for (const entity of ref.entities) {
+      if (!modelNames.has(entity.toLowerCase())) {
+        broken += 1
+        results.push(
+          check(
+            `docs-entity:${ref.path}:${entity}`,
+            `${ref.path} → ${entity}`,
+            'fail',
+            `Doc lists entity '${entity}' but no such model exists.`,
+            `Fix the 'entities' entry in ${ref.path} or add the model.`,
+            ref.path,
+          ),
+        )
+      }
+    }
+
+    if (ttlDays && ttlDays > 0 && ref.lastReviewed) {
+      const reviewedAt = Date.parse(ref.lastReviewed)
+      if (!Number.isNaN(reviewedAt) && Date.now() - reviewedAt > ttlDays * MS_PER_DAY) {
+        results.push(
+          check(
+            `docs-stale:${ref.path}`,
+            `${ref.path} freshness`,
+            'warn',
+            `last_reviewed (${ref.lastReviewed}) is older than ${ttlDays} days.`,
+            `Re-read ${ref.path}, update it if needed, and bump last_reviewed.`,
+            ref.path,
+          ),
+        )
+      }
+    }
+
+    if (broken === 0 && (ref.related.length > 0 || ref.entities.length > 0)) {
+      results.push(
+        check(
+          `docs-links:${ref.path}`,
+          `${ref.path} links`,
+          'pass',
+          `All ${ref.related.length + ref.entities.length} link(s) resolve.`,
+          undefined,
+          ref.path,
+        ),
+      )
+    }
+  }
+
+  // Entities whose only frontmatter-linked docs are superseded ADRs: the
+  // entity still "has documentation", but nothing current governs it.
+  const byEntity = new Map<string, DocRef[]>()
+  for (const ref of linkedDocs) {
+    for (const entity of ref.entities) {
+      const key = entity.toLowerCase()
+      if (!modelNames.has(key)) continue
+      const list = byEntity.get(key) ?? []
+      list.push(ref)
+      byEntity.set(key, list)
+    }
+  }
+  for (const [entityKey, docs] of byEntity) {
+    const allSuperseded = docs.every((ref) => ref.status === 'superseded')
+    if (allSuperseded && (!changedFiles || docs.some(docInChangedScope))) {
+      results.push(
+        check(
+          `docs-superseded:${entityKey}`,
+          `${docs[0].entities.find((e) => e.toLowerCase() === entityKey) ?? entityKey} docs`,
+          'warn',
+          `Every doc linked to this entity is superseded (${docs.map((d) => d.path).join(', ')}).`,
+          `Write or link a current doc for the entity, or remove it from the superseded doc's 'entities'.`,
+        ),
+      )
+    }
+  }
+
+  // Code-side @docs tags must point at existing files.
+  const sourceFiles = [...modelFiles, ...controllerFiles].filter(
+    (file) => !changedFiles || changedFiles.has(toPosixRelative(cwd, file)),
+  )
+  for (const file of sourceFiles) {
+    const relPath = toPosixRelative(cwd, file)
+    const source = await readFile(file, 'utf-8')
+    for (const tag of extractDocsTags(source)) {
+      const exists = await fileExists(cwd, tag)
+      results.push(
+        check(
+          `docs-tag:${relPath}:${tag}`,
+          `${relPath} @docs`,
+          exists ? 'pass' : 'fail',
+          exists ? `@docs ${tag} resolves.` : `@docs tag points at '${tag}' but the file does not exist.`,
+          exists ? undefined : `Fix the @docs path in ${relPath} or restore ${tag}.`,
+          relPath,
+        ),
+      )
+    }
+  }
+
+  return results
+}

--- a/packages/cli/src/docs-check.ts
+++ b/packages/cli/src/docs-check.ts
@@ -1,18 +1,16 @@
-import { resolve } from 'node:path'
 import { readFile } from 'node:fs/promises'
 import {
   discoverModelFiles,
   discoverControllerFiles,
   fileExists,
-  directoryExists,
-  collectFiles,
+  collectAllFiles,
   toPosixRelative,
   classNameFromPath,
-  IMPORTABLE_EXTENSIONS,
-  NON_SOURCE_DIR_NAMES,
 } from './discovery'
 import { matchesGlob } from './glob-match'
-import { scanDocs, extractDocsTags, type DocRef } from './docs-index'
+import { parseModelFile } from './model-parser'
+import { scanDocs, extractDocsTags, buildEntityDocIndex, type DocRef } from './docs-index'
+import type { ParseCache } from './parse-cache'
 import { check, type CheckResult } from './check-result'
 
 export interface DocsCheckOptions {
@@ -21,6 +19,8 @@ export interface DocsCheckOptions {
   changedFiles?: Set<string> | null
   /** Warn when `last_reviewed` is older than this many days. Off when unset. */
   ttlDays?: number
+  /** Reuses sources already read by the surrounding `runCheck`, when present. */
+  cache?: ParseCache
 }
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000
@@ -30,15 +30,34 @@ function hasGlobChars(entry: string): boolean {
 }
 
 /**
+ * Doc links are app-root-relative by convention; absolute paths and `..`
+ * segments would validate files outside the project.
+ */
+function isAppRootRelative(entry: string): boolean {
+  return !entry.startsWith('/') && !/^[A-Za-z]:/.test(entry) && !entry.split('/').includes('..')
+}
+
+/** Calendar-day difference, treating both sides as dates (not instants). */
+function daysSince(isoDate: string): number | null {
+  const reviewedAt = Date.parse(isoDate)
+  if (Number.isNaN(reviewedAt)) return null
+  const now = new Date()
+  const todayUtc = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())
+  return Math.floor((todayUtc - reviewedAt) / MS_PER_DAY)
+}
+
+const MODEL_FILE_PATTERN = /(?:^|\/)app\/Models\/[^/]+\.(?:ts|mts|js|mjs)$/
+
+/**
  * Doc-link validation (RFC 0004): frontmatter `related` paths/globs must
  * resolve, `entities` must name real models, `@docs` tags in model and
  * controller sources must point at existing files, and entities whose only
- * linked docs are superseded ADRs get flagged. Activates on content — an
- * app with no docs and no tags produces zero results, so nothing goes red
- * on projects that haven't adopted the convention.
+ * linked docs are superseded get flagged. Activates on content — an app
+ * with no docs and no tags produces zero results, so nothing goes red on
+ * projects that haven't adopted the convention.
  */
 export async function runDocsCheck(options: DocsCheckOptions): Promise<CheckResult[]> {
-  const { cwd, changedFiles, ttlDays } = options
+  const { cwd, changedFiles, ttlDays, cache } = options
   const results: CheckResult[] = []
 
   const [refs, modelFiles, controllerFiles] = await Promise.all([
@@ -47,82 +66,101 @@ export async function runDocsCheck(options: DocsCheckOptions): Promise<CheckResu
     discoverControllerFiles(cwd),
   ])
 
-  const modelNames = new Set(modelFiles.map((file) => classNameFromPath(file).toLowerCase()))
+  // Lowercased name → canonical class name, parsed from model sources (the
+  // same identity `guren context <Entity>` resolves against); filename is
+  // the fallback for unparsable files.
+  const parsedModels = await Promise.all(modelFiles.map((file) => parseModelFile(file)))
+  const modelNames = new Map(
+    parsedModels.map((info, index) => {
+      const className = info?.className ?? classNameFromPath(modelFiles[index])
+      return [className.toLowerCase(), className] as const
+    }),
+  )
 
-  // Lazily built once, only when some doc uses a glob: POSIX-relative
-  // source-file list to match `related` globs against.
-  let projectFiles: string[] | null = null
+  // Lazily built once, only when some doc uses a glob. Holds the promise so
+  // concurrent glob entries share one scan.
+  let projectFilesPromise: Promise<string[]> | null = null
   const globMatchesSomething = async (glob: string): Promise<boolean> => {
-    projectFiles ??= (await collectFiles(cwd, IMPORTABLE_EXTENSIONS, NON_SOURCE_DIR_NAMES)).map(
-      (file) => toPosixRelative(cwd, file),
+    projectFilesPromise ??= collectAllFiles(cwd).then((files) =>
+      files.map((file) => toPosixRelative(cwd, file)),
     )
-    return projectFiles.some((file) => matchesGlob(file, glob))
+    return (await projectFilesPromise).some((file) => matchesGlob(file, glob))
   }
 
-  const changedModelNames = changedFiles
+  const entryResolves = async (entry: string): Promise<boolean> => {
+    if (!isAppRootRelative(entry)) return false
+    // `fileExists` is access()-based, so it accepts directories too.
+    return hasGlobChars(entry) ? globMatchesSomething(entry) : fileExists(cwd, entry)
+  }
+
+  // --changed scoping. Entity names are derived from changed *paths* (not
+  // the discovered file list) so a deleted model still pulls the docs that
+  // referenced it into scope and fails their dangling `entities:` links.
+  const changedList = changedFiles ? [...changedFiles] : null
+  const changedModelNames = changedList
     ? new Set(
-        modelFiles
-          .filter((file) => changedFiles.has(toPosixRelative(cwd, file)))
-          .map((file) => classNameFromPath(file).toLowerCase()),
+        changedList
+          .filter((path) => MODEL_FILE_PATTERN.test(path))
+          .map((path) => classNameFromPath(path).toLowerCase()),
       )
     : null
 
   const docInChangedScope = (ref: DocRef): boolean => {
-    if (!changedFiles) return true
-    if (changedFiles.has(ref.path)) return true
-    if (ref.entities.some((entity) => changedModelNames?.has(entity.toLowerCase()))) return true
-    return ref.related.some((entry) =>
-      hasGlobChars(entry)
-        ? [...changedFiles].some((file) => matchesGlob(file, entry))
-        : changedFiles.has(entry.replace(/\/$/, '')),
-    )
+    if (!changedList) return true
+    if (changedFiles!.has(ref.path)) return true
+    if (ref.entities.some((entity) => changedModelNames!.has(entity.toLowerCase()))) return true
+    return ref.related.some((entry) => {
+      if (hasGlobChars(entry)) return changedList.some((file) => matchesGlob(file, entry))
+      const normalized = entry.replace(/\/$/, '')
+      // A directory target is in scope when anything beneath it changed.
+      return changedList.some((file) => file === normalized || file.startsWith(`${normalized}/`))
+    })
   }
 
-  const linkedDocs = refs.filter((ref) => ref.hasFrontmatter)
+  const docsWithFrontmatter = refs.filter((ref) => ref.hasFrontmatter)
+  const inScope = new Set(docsWithFrontmatter.filter(docInChangedScope).map((ref) => ref.path))
 
-  for (const ref of linkedDocs) {
-    if (!docInChangedScope(ref)) continue
+  for (const ref of docsWithFrontmatter) {
+    if (!inScope.has(ref.path)) continue
 
-    let broken = 0
+    const relatedChecks = await Promise.all(
+      ref.related.map(async (entry) => ({ entry, ok: await entryResolves(entry) })),
+    )
+    const brokenRelated = relatedChecks.filter((result) => !result.ok).map((result) => result.entry)
+    const brokenEntities = ref.entities.filter((entity) => !modelNames.has(entity.toLowerCase()))
 
-    for (const entry of ref.related) {
-      const resolves = hasGlobChars(entry)
-        ? await globMatchesSomething(entry)
-        : (await fileExists(cwd, entry)) || (await directoryExists(resolve(cwd, entry)))
-      if (!resolves) {
-        broken += 1
-        results.push(
-          check(
-            `docs-related:${ref.path}:${entry}`,
-            `${ref.path} → ${entry}`,
-            'fail',
-            `Doc references '${entry}' but nothing matches it (renamed or deleted?).`,
-            `Update the 'related' entry in ${ref.path} or restore the path.`,
-            ref.path,
-          ),
-        )
-      }
+    for (const entry of brokenRelated) {
+      const escapes = !isAppRootRelative(entry)
+      results.push(
+        check(
+          `docs-related:${ref.path}:${entry}`,
+          `${ref.path} → ${entry}`,
+          'fail',
+          escapes
+            ? `Doc references '${entry}', which is not app-root-relative.`
+            : `Doc references '${entry}' but nothing matches it (renamed or deleted?).`,
+          `Update the 'related' entry in ${ref.path}${escapes ? ' to an app-root-relative path' : ' or restore the path'}.`,
+          ref.path,
+        ),
+      )
     }
 
-    for (const entity of ref.entities) {
-      if (!modelNames.has(entity.toLowerCase())) {
-        broken += 1
-        results.push(
-          check(
-            `docs-entity:${ref.path}:${entity}`,
-            `${ref.path} → ${entity}`,
-            'fail',
-            `Doc lists entity '${entity}' but no such model exists.`,
-            `Fix the 'entities' entry in ${ref.path} or add the model.`,
-            ref.path,
-          ),
-        )
-      }
+    for (const entity of brokenEntities) {
+      results.push(
+        check(
+          `docs-entity:${ref.path}:${entity}`,
+          `${ref.path} → ${entity}`,
+          'fail',
+          `Doc lists entity '${entity}' but no such model exists.`,
+          `Fix the 'entities' entry in ${ref.path} or add the model.`,
+          ref.path,
+        ),
+      )
     }
 
     if (ttlDays && ttlDays > 0 && ref.lastReviewed) {
-      const reviewedAt = Date.parse(ref.lastReviewed)
-      if (!Number.isNaN(reviewedAt) && Date.now() - reviewedAt > ttlDays * MS_PER_DAY) {
+      const age = daysSince(ref.lastReviewed)
+      if (age !== null && age > ttlDays) {
         results.push(
           check(
             `docs-stale:${ref.path}`,
@@ -136,13 +174,14 @@ export async function runDocsCheck(options: DocsCheckOptions): Promise<CheckResu
       }
     }
 
-    if (broken === 0 && (ref.related.length > 0 || ref.entities.length > 0)) {
+    const totalLinks = ref.related.length + ref.entities.length
+    if (totalLinks > 0 && brokenRelated.length === 0 && brokenEntities.length === 0) {
       results.push(
         check(
           `docs-links:${ref.path}`,
           `${ref.path} links`,
           'pass',
-          `All ${ref.related.length + ref.entities.length} link(s) resolve.`,
+          `All ${totalLinks} link(s) resolve.`,
           undefined,
           ref.path,
         ),
@@ -150,25 +189,17 @@ export async function runDocsCheck(options: DocsCheckOptions): Promise<CheckResu
     }
   }
 
-  // Entities whose only frontmatter-linked docs are superseded ADRs: the
-  // entity still "has documentation", but nothing current governs it.
-  const byEntity = new Map<string, DocRef[]>()
-  for (const ref of linkedDocs) {
-    for (const entity of ref.entities) {
-      const key = entity.toLowerCase()
-      if (!modelNames.has(key)) continue
-      const list = byEntity.get(key) ?? []
-      list.push(ref)
-      byEntity.set(key, list)
-    }
-  }
-  for (const [entityKey, docs] of byEntity) {
+  // Entities whose only frontmatter-linked docs are superseded: the entity
+  // still "has documentation", but nothing current governs it.
+  for (const [entityKey, docs] of buildEntityDocIndex(docsWithFrontmatter)) {
+    const canonicalName = modelNames.get(entityKey)
+    if (!canonicalName) continue
     const allSuperseded = docs.every((ref) => ref.status === 'superseded')
-    if (allSuperseded && (!changedFiles || docs.some(docInChangedScope))) {
+    if (allSuperseded && docs.some((ref) => inScope.has(ref.path))) {
       results.push(
         check(
-          `docs-superseded:${entityKey}`,
-          `${docs[0].entities.find((e) => e.toLowerCase() === entityKey) ?? entityKey} docs`,
+          `docs-superseded:${canonicalName}`,
+          `${canonicalName} docs`,
           'warn',
           `Every doc linked to this entity is superseded (${docs.map((d) => d.path).join(', ')}).`,
           `Write or link a current doc for the entity, or remove it from the superseded doc's 'entities'.`,
@@ -177,25 +208,34 @@ export async function runDocsCheck(options: DocsCheckOptions): Promise<CheckResu
     }
   }
 
-  // Code-side @docs tags must point at existing files.
+  // Code-side @docs tags must point at existing files inside the app root.
   const sourceFiles = [...modelFiles, ...controllerFiles].filter(
     (file) => !changedFiles || changedFiles.has(toPosixRelative(cwd, file)),
   )
-  for (const file of sourceFiles) {
-    const relPath = toPosixRelative(cwd, file)
-    const source = await readFile(file, 'utf-8')
+  const sources = await Promise.all(
+    sourceFiles.map(async (file) => ({
+      relPath: toPosixRelative(cwd, file),
+      source: (await cache?.get(file))?.source ?? (await readFile(file, 'utf-8')),
+    })),
+  )
+  for (const { relPath, source } of sources) {
     for (const tag of extractDocsTags(source)) {
-      const exists = await fileExists(cwd, tag)
-      results.push(
-        check(
-          `docs-tag:${relPath}:${tag}`,
-          `${relPath} @docs`,
-          exists ? 'pass' : 'fail',
-          exists ? `@docs ${tag} resolves.` : `@docs tag points at '${tag}' but the file does not exist.`,
-          exists ? undefined : `Fix the @docs path in ${relPath} or restore ${tag}.`,
-          relPath,
-        ),
-      )
+      const key = `docs-tag:${relPath}:${tag}`
+      const title = `${relPath} @docs`
+      if (isAppRootRelative(tag) && (await fileExists(cwd, tag))) {
+        results.push(check(key, title, 'pass', `@docs ${tag} resolves.`, undefined, relPath))
+      } else {
+        results.push(
+          check(
+            key,
+            title,
+            'fail',
+            `@docs tag points at '${tag}' but no such file exists inside the app root.`,
+            `Fix the @docs path in ${relPath} or restore ${tag}.`,
+            relPath,
+          ),
+        )
+      }
     }
   }
 

--- a/packages/cli/src/docs-index.ts
+++ b/packages/cli/src/docs-index.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path'
 import { readFile } from 'node:fs/promises'
 import {
   collectFiles,
-  listModuleNames,
+  listAppRoots,
   toPosixRelative,
 } from './discovery'
 
@@ -42,6 +42,40 @@ function unquote(value: string): string {
 }
 
 /**
+ * Strip a trailing YAML comment (` # …`) from an unquoted value. Quoted
+ * values keep their content verbatim — `unquote` handles them afterwards.
+ */
+function stripInlineComment(value: string): string {
+  if (value.startsWith("'") || value.startsWith('"')) return value
+  return value.replace(/\s+#.*$/, '').trim()
+}
+
+/** Split an inline array body on commas that are not inside quotes. */
+function splitInlineArray(inner: string): string[] {
+  const parts: string[] = []
+  let current = ''
+  let quote: string | null = null
+
+  for (const char of inner) {
+    if (quote) {
+      current += char
+      if (char === quote) quote = null
+    } else if (char === "'" || char === '"') {
+      current += char
+      quote = char
+    } else if (char === ',') {
+      parts.push(current)
+      current = ''
+    } else {
+      current += char
+    }
+  }
+  parts.push(current)
+
+  return parts.map((part) => unquote(part.trim())).filter((part) => part !== '')
+}
+
+/**
  * Parse a leading `---` frontmatter block. Deliberately a minimal YAML
  * subset — scalars, inline arrays (`[a, b]`), and block lists (`- item`) —
  * the frozen vocabulary the docs convention needs, same philosophy as
@@ -54,36 +88,36 @@ export function parseDocFrontmatter(
   if (!match) return null
 
   const data: Record<string, string | string[]> = {}
-  let currentListKey: string | null = null
+  let currentList: string[] | null = null
 
   for (const line of match[1].split(/\r?\n/)) {
     if (!line.trim()) continue
 
     const item = /^\s*-\s+(.+)$/.exec(line)
-    if (item && currentListKey) {
-      ;(data[currentListKey] as string[]).push(unquote(item[1].trim()))
+    if (item && currentList) {
+      const entry = stripInlineComment(item[1].trim())
+      if (entry) currentList.push(unquote(entry))
       continue
     }
 
     const kv = /^([A-Za-z_][\w-]*):\s*(.*)$/.exec(line)
     if (!kv) {
-      currentListKey = null
+      currentList = null
       continue
     }
 
     const key = kv[1]
-    const value = kv[2].trim()
+    const value = stripInlineComment(kv[2].trim())
+    currentList = null
 
     if (value === '') {
-      data[key] = []
-      currentListKey = key
+      const list: string[] = []
+      data[key] = list
+      currentList = list
     } else if (value.startsWith('[') && value.endsWith(']')) {
-      const inner = value.slice(1, -1).trim()
-      data[key] = inner === '' ? [] : inner.split(',').map((part) => unquote(part.trim()))
-      currentListKey = null
+      data[key] = splitInlineArray(value.slice(1, -1))
     } else {
       data[key] = unquote(value)
-      currentListKey = null
     }
   }
 
@@ -105,17 +139,11 @@ function toScalar(value: string | string[] | undefined): string | undefined {
  * without a docs convention see zero refs, never an error.
  */
 export async function scanDocs(cwd: string): Promise<DocRef[]> {
-  const roots = [
-    { module: null as string | null, dir: resolve(cwd, 'docs') },
-    ...(await listModuleNames(cwd)).map((name) => ({
-      module: name as string | null,
-      dir: resolve(cwd, 'modules', name, 'docs'),
-    })),
-  ]
+  const roots = await listAppRoots(cwd)
 
   const groups = await Promise.all(
     roots.map(async (root) => {
-      const files = await collectFiles(root.dir, MARKDOWN_EXTENSIONS)
+      const files = await collectFiles(resolve(root.dir, 'docs'), MARKDOWN_EXTENSIONS)
       return Promise.all(
         files.map(async (file): Promise<DocRef> => {
           const source = await readFile(file, 'utf-8')

--- a/packages/cli/src/docs-index.ts
+++ b/packages/cli/src/docs-index.ts
@@ -1,0 +1,176 @@
+import { resolve } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import {
+  collectFiles,
+  listModuleNames,
+  toPosixRelative,
+} from './discovery'
+
+const MARKDOWN_EXTENSIONS = new Set(['.md'])
+
+/**
+ * A markdown document under `docs/` (or `modules/<name>/docs/`) with its
+ * parsed frontmatter. Documents without frontmatter are still listed
+ * (`hasFrontmatter: false`) but never linked or validated.
+ */
+export interface DocRef {
+  /** Path relative to the app root (POSIX separators). */
+  path: string
+  /** Module whose `docs/` directory contains the file, or null for the root `docs/`. */
+  module: string | null
+  /** First `# heading` in the body, if any. */
+  title?: string
+  kind?: string
+  status?: string
+  /** Model class names this document governs (frontmatter `entities`). */
+  entities: string[]
+  /** Paths or globs this document governs (frontmatter `related`). */
+  related: string[]
+  /** Frontmatter `last_reviewed` (YYYY-MM-DD), verbatim. */
+  lastReviewed?: string
+  hasFrontmatter: boolean
+}
+
+function unquote(value: string): string {
+  if (
+    (value.startsWith("'") && value.endsWith("'"))
+    || (value.startsWith('"') && value.endsWith('"'))
+  ) {
+    return value.slice(1, -1)
+  }
+  return value
+}
+
+/**
+ * Parse a leading `---` frontmatter block. Deliberately a minimal YAML
+ * subset — scalars, inline arrays (`[a, b]`), and block lists (`- item`) —
+ * the frozen vocabulary the docs convention needs, same philosophy as
+ * `glob-match.ts`. Anything else is ignored, never an error.
+ */
+export function parseDocFrontmatter(
+  source: string,
+): { data: Record<string, string | string[]>; body: string } | null {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(source)
+  if (!match) return null
+
+  const data: Record<string, string | string[]> = {}
+  let currentListKey: string | null = null
+
+  for (const line of match[1].split(/\r?\n/)) {
+    if (!line.trim()) continue
+
+    const item = /^\s*-\s+(.+)$/.exec(line)
+    if (item && currentListKey) {
+      ;(data[currentListKey] as string[]).push(unquote(item[1].trim()))
+      continue
+    }
+
+    const kv = /^([A-Za-z_][\w-]*):\s*(.*)$/.exec(line)
+    if (!kv) {
+      currentListKey = null
+      continue
+    }
+
+    const key = kv[1]
+    const value = kv[2].trim()
+
+    if (value === '') {
+      data[key] = []
+      currentListKey = key
+    } else if (value.startsWith('[') && value.endsWith(']')) {
+      const inner = value.slice(1, -1).trim()
+      data[key] = inner === '' ? [] : inner.split(',').map((part) => unquote(part.trim()))
+      currentListKey = null
+    } else {
+      data[key] = unquote(value)
+      currentListKey = null
+    }
+  }
+
+  return { data, body: source.slice(match[0].length) }
+}
+
+function toStringList(value: string | string[] | undefined): string[] {
+  if (value === undefined) return []
+  return Array.isArray(value) ? value : [value]
+}
+
+function toScalar(value: string | string[] | undefined): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+/**
+ * Every markdown file under the root `docs/` plus each module's `docs/`,
+ * with parsed frontmatter. Missing directories resolve to nothing — apps
+ * without a docs convention see zero refs, never an error.
+ */
+export async function scanDocs(cwd: string): Promise<DocRef[]> {
+  const roots = [
+    { module: null as string | null, dir: resolve(cwd, 'docs') },
+    ...(await listModuleNames(cwd)).map((name) => ({
+      module: name as string | null,
+      dir: resolve(cwd, 'modules', name, 'docs'),
+    })),
+  ]
+
+  const groups = await Promise.all(
+    roots.map(async (root) => {
+      const files = await collectFiles(root.dir, MARKDOWN_EXTENSIONS)
+      return Promise.all(
+        files.map(async (file): Promise<DocRef> => {
+          const source = await readFile(file, 'utf-8')
+          const parsed = parseDocFrontmatter(source)
+          const body = parsed?.body ?? source
+          const data = parsed?.data ?? {}
+          return {
+            path: toPosixRelative(cwd, file),
+            module: root.module,
+            title: /^#\s+(.+)$/m.exec(body)?.[1].trim(),
+            kind: toScalar(data.kind),
+            status: toScalar(data.status),
+            entities: toStringList(data.entities),
+            related: toStringList(data.related),
+            lastReviewed: toScalar(data.last_reviewed),
+            hasFrontmatter: parsed !== null,
+          }
+        }),
+      )
+    }),
+  )
+
+  return groups.flat().sort((a, b) => a.path.localeCompare(b.path))
+}
+
+/**
+ * Reverse index: lowercased entity class name → documents whose
+ * frontmatter `entities` list names it.
+ */
+export function buildEntityDocIndex(refs: DocRef[]): Map<string, DocRef[]> {
+  const index = new Map<string, DocRef[]>()
+  for (const ref of refs) {
+    for (const entity of ref.entities) {
+      const key = entity.toLowerCase()
+      const list = index.get(key) ?? []
+      list.push(ref)
+      index.set(key, list)
+    }
+  }
+  return index
+}
+
+const DOCS_TAG_REGEX = /@docs\s+([^\s*'"`)]+)/g
+
+/**
+ * `@docs <path>` tags in a source file — the code-side half of the doc
+ * link. Regex-based like the inertia page scan (a tag in a string literal
+ * is a false positive we accept); paths are app-root-relative by
+ * convention.
+ */
+export function extractDocsTags(source: string): string[] {
+  const tags = new Set<string>()
+  let match: RegExpExecArray | null
+  while ((match = DOCS_TAG_REGEX.exec(source)) !== null) {
+    tags.add(match[1])
+  }
+  return [...tags]
+}

--- a/packages/cli/src/entity-context.ts
+++ b/packages/cli/src/entity-context.ts
@@ -28,6 +28,7 @@ import {
   type ContextRoute,
 } from './context-route'
 import { extractInertiaPageRefs, resolveInertiaPageFile } from './inertia-pages'
+import { scanDocs, extractDocsTags, type DocRef } from './docs-index'
 import { extractPageProps } from './page-props-extractor'
 import { parseSchemaTableColumns } from './audit'
 
@@ -36,6 +37,14 @@ export interface EntityPage {
   /** Component file relative to the app root; absent when the referenced page has no file. */
   filePath?: string
   props?: string
+}
+
+export interface EntityDoc {
+  path: string
+  title?: string
+  kind?: string
+  status?: string
+  lastReviewed?: string
 }
 
 export interface EntityContext {
@@ -60,6 +69,8 @@ export interface EntityContext {
   factories: string[]
   seeders: string[]
   tests: string[]
+  /** Docs linked via frontmatter `entities:` or code-side `@docs` tags. */
+  docs: EntityDoc[]
 }
 
 export interface EntityContextOptions {
@@ -259,13 +270,14 @@ export async function generateEntityContext(
   const loadControllerBundle = async (): Promise<{
     controller?: EntityContext['controller']
     pages: EntityPage[]
+    docsTags: string[]
   }> => {
     let files = (await discoverControllerFiles(cwd)).filter(
       (file) => classNameFromPath(file) === controllerName,
     )
     if (duplicated) files = files.filter(inLocation)
     const controllerFile = files.find(inLocation) ?? files[0]
-    if (!controllerFile) return { pages: [] }
+    if (!controllerFile) return { pages: [], docsTags: [] }
 
     const source = await readFile(controllerFile, 'utf-8')
     return {
@@ -278,6 +290,7 @@ export async function generateEntityContext(
         cwd,
         extractInertiaPageRefs(source).map((ref) => ref.id),
       ),
+      docsTags: extractDocsTags(source),
     }
   }
 
@@ -287,7 +300,7 @@ export async function generateEntityContext(
     return tables?.get(match.info.tableName)
   }
 
-  const [columns, routes, controllerBundle, resource, policy, factories, seeders, testFiles] =
+  const [columns, routes, controllerBundle, resource, policy, factories, seeders, testFiles, allDocRefs] =
     await Promise.all([
       loadColumns(),
       loadEntityRoutes(),
@@ -297,6 +310,7 @@ export async function generateEntityContext(
       findDbArtifacts('db/factories', new RegExp(`(?:^|_)${entity}s?Factory\\.`, 'i')),
       findDbArtifacts('db/seeders', new RegExp(`(?:^|_)${entity}s?Seeder\\.`, 'i')),
       discoverTestFiles(cwd),
+      scanDocs(cwd),
     ])
 
   const referencedBy = models
@@ -313,6 +327,30 @@ export async function generateEntityContext(
     .filter((file) => !duplicated || inLocation(file))
     .map((file) => toPosixRelative(cwd, file))
     .sort()
+
+  // Linked docs: frontmatter `entities:` (location-scoped when duplicated)
+  // merged with explicit @docs tags from the model and controller sources
+  // (tags cross scope on purpose — they are declared, not inferred).
+  const toEntityDoc = (ref: DocRef): EntityDoc => ({
+    path: ref.path,
+    title: ref.title,
+    kind: ref.kind,
+    status: ref.status,
+    lastReviewed: ref.lastReviewed,
+  })
+  const linkedDocs = new Map<string, EntityDoc>()
+  const scopedDocRefs = duplicated ? allDocRefs.filter((ref) => ref.module === match.module) : allDocRefs
+  for (const ref of scopedDocRefs) {
+    if (ref.entities.some((name) => name.toLowerCase() === lower)) {
+      linkedDocs.set(ref.path, toEntityDoc(ref))
+    }
+  }
+  for (const tag of [...match.info.docsTags, ...controllerBundle.docsTags]) {
+    if (linkedDocs.has(tag)) continue
+    const ref = allDocRefs.find((candidate) => candidate.path === tag)
+    linkedDocs.set(tag, ref ? toEntityDoc(ref) : { path: tag })
+  }
+  const docs = [...linkedDocs.values()].sort((a, b) => a.path.localeCompare(b.path))
 
   return {
     entity,
@@ -334,6 +372,7 @@ export async function generateEntityContext(
     factories,
     seeders,
     tests,
+    docs,
   }
 }
 
@@ -418,6 +457,17 @@ export function renderEntityContextMarkdown(ctx: EntityContext): string {
   pushList('Factories', ctx.factories)
   pushList('Seeders', ctx.seeders)
   pushList('Tests', ctx.tests)
+
+  if (ctx.docs.length > 0) {
+    lines.push(`## Linked docs (${ctx.docs.length})`)
+    for (const doc of ctx.docs) {
+      const meta = [doc.kind, doc.status, doc.lastReviewed ? `reviewed ${doc.lastReviewed}` : undefined]
+        .filter(Boolean)
+        .join(', ')
+      lines.push(`- ${doc.path}${doc.title ? ` — ${doc.title}` : ''}${meta ? ` (${meta})` : ''}`)
+    }
+    lines.push('')
+  }
 
   return lines.join('\n')
 }

--- a/packages/cli/src/entity-context.ts
+++ b/packages/cli/src/entity-context.ts
@@ -9,7 +9,7 @@ import {
   discoverResourceFiles,
   discoverPolicyFiles,
   discoverTestFiles,
-  listModuleNames,
+  listAppRoots,
   classNameFromPath,
   collectFiles,
   toPosixRelative,
@@ -28,7 +28,7 @@ import {
   type ContextRoute,
 } from './context-route'
 import { extractInertiaPageRefs, resolveInertiaPageFile } from './inertia-pages'
-import { scanDocs, extractDocsTags, type DocRef } from './docs-index'
+import { scanDocs, extractDocsTags, buildEntityDocIndex } from './docs-index'
 import { extractPageProps } from './page-props-extractor'
 import { parseSchemaTableColumns } from './audit'
 
@@ -228,11 +228,7 @@ export async function generateEntityContext(
   }
 
   const findDbArtifacts = async (subDir: string, filePattern: RegExp): Promise<string[]> => {
-    const moduleNames = await listModuleNames(cwd)
-    let roots: Array<{ module: string | null; dir: string }> = [
-      { module: null, dir: cwd },
-      ...moduleNames.map((name) => ({ module: name, dir: resolve(cwd, 'modules', name) })),
-    ]
+    let roots = await listAppRoots(cwd)
     if (duplicated) roots = roots.filter((root) => root.module === match.module)
 
     const groups = await Promise.all(roots.map((root) => collectFiles(resolve(root.dir, subDir))))
@@ -331,26 +327,21 @@ export async function generateEntityContext(
   // Linked docs: frontmatter `entities:` (location-scoped when duplicated)
   // merged with explicit @docs tags from the model and controller sources
   // (tags cross scope on purpose — they are declared, not inferred).
-  const toEntityDoc = (ref: DocRef): EntityDoc => ({
-    path: ref.path,
-    title: ref.title,
-    kind: ref.kind,
-    status: ref.status,
-    lastReviewed: ref.lastReviewed,
-  })
-  const linkedDocs = new Map<string, EntityDoc>()
   const scopedDocRefs = duplicated ? allDocRefs.filter((ref) => ref.module === match.module) : allDocRefs
-  for (const ref of scopedDocRefs) {
-    if (ref.entities.some((name) => name.toLowerCase() === lower)) {
-      linkedDocs.set(ref.path, toEntityDoc(ref))
-    }
-  }
-  for (const tag of [...match.info.docsTags, ...controllerBundle.docsTags]) {
-    if (linkedDocs.has(tag)) continue
-    const ref = allDocRefs.find((candidate) => candidate.path === tag)
-    linkedDocs.set(tag, ref ? toEntityDoc(ref) : { path: tag })
-  }
-  const docs = [...linkedDocs.values()].sort((a, b) => a.path.localeCompare(b.path))
+  const docRefByPath = new Map(allDocRefs.map((ref) => [ref.path, ref] as const))
+  const linkedPaths = new Set([
+    ...(buildEntityDocIndex(scopedDocRefs).get(lower) ?? []).map((ref) => ref.path),
+    ...match.info.docsTags,
+    ...controllerBundle.docsTags,
+  ])
+  const docs = [...linkedPaths]
+    .sort((a, b) => a.localeCompare(b))
+    .map((path): EntityDoc => {
+      const ref = docRefByPath.get(path)
+      return ref
+        ? { path, title: ref.title, kind: ref.kind, status: ref.status, lastReviewed: ref.lastReviewed }
+        : { path }
+    })
 
   return {
     entity,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -43,6 +43,8 @@ export {
   type EntityContextOptions,
 } from './entity-context'
 export { routeDefinitionToContextRoute, loadContextRoutes, type ContextRoute } from './context-route'
+export { scanDocs, parseDocFrontmatter, extractDocsTags, type DocRef } from './docs-index'
+export { runDocsCheck } from './docs-check'
 export { runCheck, renderCheckReport } from './check'
 export { generateGuidelines } from './guidelines'
 export { listModels, displayModels } from './model-list'

--- a/packages/cli/src/make-adr.ts
+++ b/packages/cli/src/make-adr.ts
@@ -12,6 +12,7 @@ import {
   discoverPolicyFiles,
   classNameFromPath,
   toPosixRelative,
+  moduleNameFromRelPath,
 } from './discovery'
 import { parseModelFile } from './model-parser'
 
@@ -42,45 +43,77 @@ interface AdrPrefill {
 const EMPTY_PREFILL: AdrPrefill = { entities: [], related: [] }
 
 /**
+ * Entity names are class identifiers, and they are interpolated into the
+ * frontmatter unquoted — anything beyond identifier characters could
+ * inject frontmatter keys (`]`, newlines, `#`, quotes), so it is rejected
+ * outright rather than escaped.
+ */
+const ENTITY_NAME_RE = /^[A-Za-z][A-Za-z0-9_]*$/
+
+/**
  * Prefill for `--entity`: the canonical class name plus the entity's
- * companion files as `related:` entries. A model that doesn't exist yet is
- * prefilled as given — ADR-first flows write the decision before the code,
- * and `guren check --docs` failing until the model lands is the intended
+ * companion files (from the same location as the resolved model) as
+ * `related:` entries. A model that doesn't exist yet is prefilled as
+ * given — ADR-first flows write the decision before the code, and
+ * `guren check --docs` failing until the model lands is the intended
  * "implementation missing" signal.
  */
 async function resolveAdrPrefill(entity: string, moduleName?: string): Promise<AdrPrefill> {
+  if (!ENTITY_NAME_RE.test(entity)) {
+    throw new Error(
+      `Invalid entity name "${entity}" — it is written into YAML frontmatter, so it must be a plain class identifier (letters, digits, underscores).`,
+    )
+  }
+
   const cwd = process.cwd()
   const modelFiles = await discoverModelFiles(cwd)
   const parsed = await Promise.all(modelFiles.map((file) => parseModelFile(file)))
   const lower = entity.toLowerCase()
-  const matches = parsed.flatMap((info, index) =>
-    info && info.className.toLowerCase() === lower
-      ? [{ className: info.className, file: modelFiles[index] }]
-      : [],
-  )
-  // When scaffolding into a module, that module's model wins a name tie.
+  const matches = parsed.flatMap((info, index) => {
+    if (!info || info.className.toLowerCase() !== lower) return []
+    const relPath = toPosixRelative(cwd, modelFiles[index])
+    return [{ className: info.className, module: moduleNameFromRelPath(relPath) }]
+  })
+
+  // A module ADR prefers that module's model; a root ADR prefers the root
+  // model. Only when neither preference resolves a name tie is it ambiguous.
+  const preferredModule = moduleName ?? null
   const match =
-    matches.find(
-      (m) => moduleName && toPosixRelative(cwd, m.file).startsWith(`modules/${moduleName}/`),
-    ) ?? matches[0]
+    matches.find((m) => m.module === preferredModule)
+    ?? (matches.length === 1 ? matches[0] : undefined)
 
   if (!match) {
+    if (matches.length > 1) {
+      const locations = matches.map((m) => m.module ?? 'app').sort()
+      throw new Error(
+        `Model "${entity}" exists in multiple locations: ${locations.join(', ')}. Pass --module <name> to target that module's model (and docs/adr).`,
+      )
+    }
     consola.warn(
       `Model "${entity}" not found — prefilled entities anyway; \`guren check --docs\` will fail until the model exists.`,
     )
     return { entities: [entity], related: [] }
   }
 
-  const related: string[] = []
+  // Companions come from the resolved model's own location, so a module
+  // entity never links a same-named root controller (and vice versa).
   const companions: Array<[(root: string) => Promise<string[]>, string]> = [
     [discoverControllerFiles, `${match.className}Controller`],
     [discoverResourceFiles, `${match.className}Resource`],
     [discoverPolicyFiles, `${match.className}Policy`],
   ]
-  for (const [discover, companionName] of companions) {
-    const file = (await discover(cwd)).find((f) => classNameFromPath(f) === companionName)
-    if (file) related.push(toPosixRelative(cwd, file))
-  }
+  const related = (
+    await Promise.all(
+      companions.map(async ([discover, companionName]) => {
+        const files = (await discover(cwd)).map((file) => toPosixRelative(cwd, file))
+        return files.find(
+          (file) =>
+            classNameFromPath(file) === companionName
+            && moduleNameFromRelPath(file) === match.module,
+        )
+      }),
+    )
+  ).filter((file): file is string => file !== undefined)
 
   return { entities: [match.className], related }
 }

--- a/packages/cli/src/make-adr.ts
+++ b/packages/cli/src/make-adr.ts
@@ -1,0 +1,104 @@
+import { readdir } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+import type { WriterOptions } from './utils'
+import { safeModuleName, writeFileSafe } from './utils'
+
+const ADR_DIR = 'docs/adr'
+
+/**
+ * Matches the `NNNN-slug.md` files `make:adr` produces; anything else in the
+ * directory is ignored when numbering. The extension match is case-insensitive
+ * on purpose: on a case-insensitive filesystem (APFS, NTFS) a `0001-x.MD` that
+ * numbering skipped would still collide with the `0001-x.md` we then try to
+ * write, so such a file has to participate in the sequence.
+ */
+const ADR_FILE_RE = /^(\d{4})-.*\.md$/iu
+
+/**
+ * `make:adr` takes no extra options beyond the shared writer ones: `force`
+ * overwrites, and `root` (wired from `--module <name>` by `toWriterOptions`
+ * in bin.ts) targets `modules/<name>/docs/adr/` instead of `docs/adr/`.
+ */
+export type MakeAdrOptions = WriterOptions
+
+function adrTemplate(title: string, lastReviewed: string): string {
+  return `---
+kind: adr
+status: draft
+entities: []
+related: []
+last_reviewed: ${lastReviewed}
+---
+
+# ${title}
+
+## Context
+
+<!-- What is the issue we're seeing that motivates this decision? -->
+
+## Decision
+
+<!-- What is the change we're making? -->
+
+## Consequences
+
+<!-- What becomes easier or harder because of this change? -->
+`
+}
+
+/**
+ * kebab-cases an ADR title for its filename. Unlike `kebabCase()` in utils,
+ * this drops punctuation instead of preserving it (titles are prose, not
+ * identifiers), so `"Use HTTP/2 — why?"` becomes `use-http-2-why`. A title
+ * with no ASCII alphanumerics at all (e.g. a fully Japanese title) would
+ * otherwise slug to the empty string and produce `0001-.md`, so it falls
+ * back to `adr` and leaves the number as the distinguishing part.
+ */
+export function adrSlug(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, '-')
+    .replace(/^-+|-+$/gu, '')
+
+  return slug || 'adr'
+}
+
+/** Highest existing `NNNN-` prefix in `dir`, plus one, zero-padded to four digits. */
+async function nextSequenceNumber(dir: string): Promise<string> {
+  let entries: string[] = []
+
+  try {
+    entries = await readdir(resolve(process.cwd(), dir))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
+  }
+
+  const highest = entries.reduce((max, entry) => {
+    const match = ADR_FILE_RE.exec(entry)
+    return match ? Math.max(max, Number(match[1])) : max
+  }, 0)
+
+  return String(highest + 1).padStart(4, '0')
+}
+
+/** Local-calendar `YYYY-MM-DD` (not UTC, so the stamp matches the author's day). */
+function today(): string {
+  const now = new Date()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+  return `${now.getFullYear()}-${month}-${day}`
+}
+
+export async function makeAdr(title: string, options: MakeAdrOptions = {}): Promise<string> {
+  const dir = options.root ? `modules/${safeModuleName(options.root)}/${ADR_DIR}` : ADR_DIR
+  const sequence = await nextSequenceNumber(dir)
+
+  return writeFileSafe(
+    `${dir}/${sequence}-${adrSlug(title)}.md`,
+    adrTemplate(title.trim(), today()),
+    options,
+  )
+}

--- a/packages/cli/src/make-adr.ts
+++ b/packages/cli/src/make-adr.ts
@@ -1,8 +1,19 @@
 import { readdir } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
+import { consola } from 'consola'
+
 import type { WriterOptions } from './utils'
 import { safeModuleName, slugifyProse, writeFileSafe } from './utils'
+import {
+  discoverModelFiles,
+  discoverControllerFiles,
+  discoverResourceFiles,
+  discoverPolicyFiles,
+  classNameFromPath,
+  toPosixRelative,
+} from './discovery'
+import { parseModelFile } from './model-parser'
 
 const ADR_DIR = 'docs/adr'
 
@@ -15,19 +26,78 @@ const ADR_DIR = 'docs/adr'
  */
 const ADR_FILE_RE = /^(\d{4})-.*\.md$/iu
 
-/**
- * `make:adr` takes no extra options beyond the shared writer ones: `force`
- * overwrites, and `root` (wired from `--module <name>` by `toWriterOptions`
- * in bin.ts) targets `modules/<name>/docs/adr/` instead of `docs/adr/`.
- */
-export type MakeAdrOptions = WriterOptions
+export interface MakeAdrOptions extends WriterOptions {
+  /**
+   * Model class name (case-insensitive) to prefill `entities:` with; its
+   * companion controller/resource/policy files prefill `related:`.
+   */
+  entity?: string
+}
 
-function adrTemplate(title: string, lastReviewed: string): string {
+interface AdrPrefill {
+  entities: string[]
+  related: string[]
+}
+
+const EMPTY_PREFILL: AdrPrefill = { entities: [], related: [] }
+
+/**
+ * Prefill for `--entity`: the canonical class name plus the entity's
+ * companion files as `related:` entries. A model that doesn't exist yet is
+ * prefilled as given — ADR-first flows write the decision before the code,
+ * and `guren check --docs` failing until the model lands is the intended
+ * "implementation missing" signal.
+ */
+async function resolveAdrPrefill(entity: string, moduleName?: string): Promise<AdrPrefill> {
+  const cwd = process.cwd()
+  const modelFiles = await discoverModelFiles(cwd)
+  const parsed = await Promise.all(modelFiles.map((file) => parseModelFile(file)))
+  const lower = entity.toLowerCase()
+  const matches = parsed.flatMap((info, index) =>
+    info && info.className.toLowerCase() === lower
+      ? [{ className: info.className, file: modelFiles[index] }]
+      : [],
+  )
+  // When scaffolding into a module, that module's model wins a name tie.
+  const match =
+    matches.find(
+      (m) => moduleName && toPosixRelative(cwd, m.file).startsWith(`modules/${moduleName}/`),
+    ) ?? matches[0]
+
+  if (!match) {
+    consola.warn(
+      `Model "${entity}" not found — prefilled entities anyway; \`guren check --docs\` will fail until the model exists.`,
+    )
+    return { entities: [entity], related: [] }
+  }
+
+  const related: string[] = []
+  const companions: Array<[(root: string) => Promise<string[]>, string]> = [
+    [discoverControllerFiles, `${match.className}Controller`],
+    [discoverResourceFiles, `${match.className}Resource`],
+    [discoverPolicyFiles, `${match.className}Policy`],
+  ]
+  for (const [discover, companionName] of companions) {
+    const file = (await discover(cwd)).find((f) => classNameFromPath(f) === companionName)
+    if (file) related.push(toPosixRelative(cwd, file))
+  }
+
+  return { entities: [match.className], related }
+}
+
+function adrTemplate(title: string, lastReviewed: string, prefill: AdrPrefill): string {
+  const entities =
+    prefill.entities.length > 0 ? `entities: [${prefill.entities.join(', ')}]` : 'entities: []'
+  const related =
+    prefill.related.length > 0
+      ? `related:\n${prefill.related.map((path) => `  - ${path}`).join('\n')}`
+      : 'related: []'
+
   return `---
 kind: adr
 status: draft
-entities: []
-related: []
+${entities}
+${related}
 last_reviewed: ${lastReviewed}
 ---
 
@@ -81,12 +151,14 @@ function today(): string {
 }
 
 export async function makeAdr(title: string, options: MakeAdrOptions = {}): Promise<string> {
-  const dir = options.root ? `modules/${safeModuleName(options.root)}/${ADR_DIR}` : ADR_DIR
+  const moduleName = options.root ? safeModuleName(options.root) : undefined
+  const dir = moduleName ? `modules/${moduleName}/${ADR_DIR}` : ADR_DIR
+  const prefill = options.entity ? await resolveAdrPrefill(options.entity, moduleName) : EMPTY_PREFILL
   const sequence = await nextSequenceNumber(dir)
 
   return writeFileSafe(
     `${dir}/${sequence}-${adrSlug(title)}.md`,
-    adrTemplate(title.trim(), today()),
+    adrTemplate(title.trim(), today(), prefill),
     options,
   )
 }

--- a/packages/cli/src/make-adr.ts
+++ b/packages/cli/src/make-adr.ts
@@ -2,7 +2,7 @@ import { readdir } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
 import type { WriterOptions } from './utils'
-import { safeModuleName, writeFileSafe } from './utils'
+import { safeModuleName, slugifyProse, writeFileSafe } from './utils'
 
 const ADR_DIR = 'docs/adr'
 
@@ -47,21 +47,9 @@ last_reviewed: ${lastReviewed}
 `
 }
 
-/**
- * kebab-cases an ADR title for its filename. Unlike `kebabCase()` in utils,
- * this drops punctuation instead of preserving it (titles are prose, not
- * identifiers), so `"Use HTTP/2 — why?"` becomes `use-http-2-why`. A title
- * with no ASCII alphanumerics at all (e.g. a fully Japanese title) would
- * otherwise slug to the empty string and produce `0001-.md`, so it falls
- * back to `adr` and leaves the number as the distinguishing part.
- */
+/** kebab-case slug for a prose ADR title, e.g. `"Use HTTP/2 — why?"` → `use-http-2-why`. */
 export function adrSlug(title: string): string {
-  const slug = title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/gu, '-')
-    .replace(/^-+|-+$/gu, '')
-
-  return slug || 'adr'
+  return slugifyProse(title, '-', 'adr')
 }
 
 /** Highest existing `NNNN-` prefix in `dir`, plus one, zero-padded to four digits. */

--- a/packages/cli/src/make-migration.ts
+++ b/packages/cli/src/make-migration.ts
@@ -1,6 +1,6 @@
 import { access } from 'node:fs/promises'
 import { resolve } from 'node:path'
-import { runCommand } from './utils'
+import { runCommand, slugifyProse } from './utils'
 
 const DEFAULT_SCHEMA = 'db/schema.ts'
 const DEFAULT_OUTPUT = 'db/migrations'
@@ -18,12 +18,7 @@ export interface MakeMigrationOptions {
 }
 
 function toSlug(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-    || 'migration'
+  return slugifyProse(value, '_', 'migration')
 }
 
 async function resolveDrizzleConfig(): Promise<string | undefined> {

--- a/packages/cli/src/model-parser.ts
+++ b/packages/cli/src/model-parser.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import { parse } from '@babel/parser'
 import type { Statement, Expression, ClassDeclaration, ClassBody } from '@babel/types'
+import { extractDocsTags } from './docs-index'
 
 export interface ModelRelationship {
   name: string
@@ -15,6 +16,8 @@ export interface ModelInfo {
   relationships: ModelRelationship[]
   usesAuth: boolean
   hasSoftDeletes: boolean
+  /** `@docs <path>` tags in the model source (code-side doc links). */
+  docsTags: string[]
 }
 
 export async function parseModelFile(filePath: string): Promise<ModelInfo | null> {
@@ -56,6 +59,7 @@ export function parseModelSource(source: string, filePath: string): ModelInfo | 
     relationships,
     usesAuth,
     hasSoftDeletes,
+    docsTags: extractDocsTags(source),
   }
 }
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -113,6 +113,22 @@ export function camelCase(value: string): string {
   return pascal.charAt(0).toLowerCase() + pascal.slice(1)
 }
 
+/**
+ * Slug for prose input (ADR titles, migration names): lowercase,
+ * non-alphanumeric runs collapse to `separator`, edges trimmed. Unlike
+ * `kebabCase()`, punctuation is dropped rather than preserved. Input with
+ * no ASCII alphanumerics at all (e.g. a fully Japanese title) falls back
+ * to `fallback` so the sequence number stays the distinguishing part.
+ */
+export function slugifyProse(value: string, separator: string, fallback: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, separator)
+    .replace(new RegExp(`^[${separator}]+|[${separator}]+$`, 'gu'), '')
+
+  return slug || fallback
+}
+
 export function kebabCase(value: string): string {
   return value
     .replace(/([a-z0-9])([A-Z])/gu, '$1-$2')

--- a/packages/cli/tests/context.test.ts
+++ b/packages/cli/tests/context.test.ts
@@ -90,6 +90,7 @@ describe('renderContextMarkdown', () => {
         relationships: [{ name: 'author', type: 'belongsTo', relatedModel: 'User' }],
         usesAuth: false,
         hasSoftDeletes: false,
+        docsTags: [],
       }],
       routes: [
         {

--- a/packages/cli/tests/docs-check.test.ts
+++ b/packages/cli/tests/docs-check.test.ts
@@ -1,0 +1,177 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { runDocsCheck } from '../src/docs-check'
+import { createTempWorkspace, type TempWorkspace } from './helpers'
+
+describe('runDocsCheck', () => {
+  let workspace: TempWorkspace
+
+  beforeAll(async () => {
+    workspace = await createTempWorkspace('guren-cli-docs-check-')
+    const dir = workspace.dir
+
+    await mkdir(join(dir, 'app/Models'), { recursive: true })
+    await mkdir(join(dir, 'app/Http/Controllers'), { recursive: true })
+    await mkdir(join(dir, 'docs/adr'), { recursive: true })
+    await writeFile(join(dir, 'package.json'), '{}', 'utf8')
+
+    await writeFile(
+      join(dir, 'app/Models/Post.ts'),
+      `/**
+ * @docs docs/adr/0001-valid.md
+ */
+export class Post {}
+`,
+      'utf8',
+    )
+    await writeFile(
+      join(dir, 'app/Models/Legacy.ts'),
+      `/** @docs docs/adr/missing-target.md */
+export class Legacy {}
+`,
+      'utf8',
+    )
+
+    // Valid doc: resolvable related paths + real entity
+    await writeFile(
+      join(dir, 'docs/adr/0001-valid.md'),
+      `---
+kind: adr
+status: accepted
+entities: [Post]
+related:
+  - app/Models/Post.ts
+  - app/Models/*.ts
+---
+
+# Valid decision
+`,
+      'utf8',
+    )
+
+    // Broken doc: dangling related path + unknown entity
+    await writeFile(
+      join(dir, 'docs/adr/0002-broken.md'),
+      `---
+kind: adr
+status: draft
+entities: [Ghost]
+related: [app/Services/Deleted.ts]
+---
+
+# Broken decision
+`,
+      'utf8',
+    )
+
+    // Superseded-only entity link
+    await writeFile(
+      join(dir, 'docs/adr/0003-superseded.md'),
+      `---
+kind: adr
+status: superseded
+entities: [Legacy]
+last_reviewed: 2020-01-01
+---
+
+# Old decision
+`,
+      'utf8',
+    )
+
+    // No frontmatter: never validated
+    await writeFile(join(dir, 'docs/notes.md'), '# Free-form notes\n', 'utf8')
+  })
+
+  afterAll(async () => {
+    await workspace.cleanup()
+  })
+
+  it('passes docs whose related paths, globs, and entities all resolve', async () => {
+    const results = await runDocsCheck({ cwd: workspace.dir })
+
+    const pass = results.find((r) => r.key === 'docs-links:docs/adr/0001-valid.md')
+    expect(pass?.status).toBe('pass')
+  })
+
+  it('fails dangling related paths and unknown entities', async () => {
+    const results = await runDocsCheck({ cwd: workspace.dir })
+
+    const related = results.find(
+      (r) => r.key === 'docs-related:docs/adr/0002-broken.md:app/Services/Deleted.ts',
+    )
+    expect(related?.status).toBe('fail')
+
+    const entity = results.find((r) => r.key === 'docs-entity:docs/adr/0002-broken.md:Ghost')
+    expect(entity?.status).toBe('fail')
+  })
+
+  it('warns when every doc linked to an entity is superseded', async () => {
+    const results = await runDocsCheck({ cwd: workspace.dir })
+
+    const superseded = results.find((r) => r.key === 'docs-superseded:legacy')
+    expect(superseded?.status).toBe('warn')
+    expect(superseded?.message).toContain('docs/adr/0003-superseded.md')
+  })
+
+  it('does not flag entities that also have a current doc', async () => {
+    const results = await runDocsCheck({ cwd: workspace.dir })
+
+    expect(results.find((r) => r.key === 'docs-superseded:post')).toBeUndefined()
+  })
+
+  it('validates @docs tags in model sources', async () => {
+    const results = await runDocsCheck({ cwd: workspace.dir })
+
+    const valid = results.find(
+      (r) => r.key === 'docs-tag:app/Models/Post.ts:docs/adr/0001-valid.md',
+    )
+    expect(valid?.status).toBe('pass')
+
+    const broken = results.find(
+      (r) => r.key === 'docs-tag:app/Models/Legacy.ts:docs/adr/missing-target.md',
+    )
+    expect(broken?.status).toBe('fail')
+  })
+
+  it('warns on stale last_reviewed only when a TTL is configured', async () => {
+    const without = await runDocsCheck({ cwd: workspace.dir })
+    expect(without.find((r) => r.key === 'docs-stale:docs/adr/0003-superseded.md')).toBeUndefined()
+
+    const withTtl = await runDocsCheck({ cwd: workspace.dir, ttlDays: 180 })
+    const stale = withTtl.find((r) => r.key === 'docs-stale:docs/adr/0003-superseded.md')
+    expect(stale?.status).toBe('warn')
+  })
+
+  it('never validates docs without frontmatter', async () => {
+    const results = await runDocsCheck({ cwd: workspace.dir })
+
+    expect(results.some((r) => r.key.includes('docs/notes.md'))).toBe(false)
+  })
+
+  it('restricts validation to the changed scope', async () => {
+    const results = await runDocsCheck({
+      cwd: workspace.dir,
+      changedFiles: new Set(['docs/adr/0002-broken.md']),
+    })
+
+    expect(results.some((r) => r.key.startsWith('docs-related:docs/adr/0002-broken.md'))).toBe(true)
+    expect(results.some((r) => r.key === 'docs-links:docs/adr/0001-valid.md')).toBe(false)
+    // Tag validation follows changed source files, none of which changed here
+    expect(results.some((r) => r.key.startsWith('docs-tag:'))).toBe(false)
+  })
+
+  it('produces zero results for apps without docs or tags', async () => {
+    const empty = await createTempWorkspace('guren-cli-docs-none-')
+    try {
+      await mkdir(join(empty.dir, 'app/Models'), { recursive: true })
+      await writeFile(join(empty.dir, 'app/Models/Post.ts'), 'export class Post {}\n', 'utf8')
+      await writeFile(join(empty.dir, 'package.json'), '{}', 'utf8')
+
+      expect(await runDocsCheck({ cwd: empty.dir })).toEqual([])
+    } finally {
+      await empty.cleanup()
+    }
+  })
+})

--- a/packages/cli/tests/docs-check.test.ts
+++ b/packages/cli/tests/docs-check.test.ts
@@ -2,6 +2,7 @@ import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
 import { runDocsCheck } from '../src/docs-check'
+import { runCheck } from '../src/check'
 import { createTempWorkspace, type TempWorkspace } from './helpers'
 
 describe('runDocsCheck', () => {
@@ -110,7 +111,7 @@ last_reviewed: 2020-01-01
   it('warns when every doc linked to an entity is superseded', async () => {
     const results = await runDocsCheck({ cwd: workspace.dir })
 
-    const superseded = results.find((r) => r.key === 'docs-superseded:legacy')
+    const superseded = results.find((r) => r.key === 'docs-superseded:Legacy')
     expect(superseded?.status).toBe('warn')
     expect(superseded?.message).toContain('docs/adr/0003-superseded.md')
   })
@@ -118,7 +119,7 @@ last_reviewed: 2020-01-01
   it('does not flag entities that also have a current doc', async () => {
     const results = await runDocsCheck({ cwd: workspace.dir })
 
-    expect(results.find((r) => r.key === 'docs-superseded:post')).toBeUndefined()
+    expect(results.find((r) => r.key === 'docs-superseded:Post')).toBeUndefined()
   })
 
   it('validates @docs tags in model sources', async () => {
@@ -160,6 +161,84 @@ last_reviewed: 2020-01-01
     expect(results.some((r) => r.key === 'docs-links:docs/adr/0001-valid.md')).toBe(false)
     // Tag validation follows changed source files, none of which changed here
     expect(results.some((r) => r.key.startsWith('docs-tag:'))).toBe(false)
+  })
+
+  it('pulls docs into --changed scope when their model was deleted', async () => {
+    // app/Models/Ghost.ts never existed on disk, mirroring a deletion whose
+    // path is still present in the changed-files set.
+    const results = await runDocsCheck({
+      cwd: workspace.dir,
+      changedFiles: new Set(['app/Models/Ghost.ts']),
+    })
+
+    const entity = results.find((r) => r.key === 'docs-entity:docs/adr/0002-broken.md:Ghost')
+    expect(entity?.status).toBe('fail')
+  })
+
+  it('matches globs against non-source files', async () => {
+    const scoped = await createTempWorkspace('guren-cli-docs-glob-')
+    try {
+      await mkdir(join(scoped.dir, 'docs'), { recursive: true })
+      await mkdir(join(scoped.dir, 'db/migrations'), { recursive: true })
+      await writeFile(join(scoped.dir, 'package.json'), '{}', 'utf8')
+      await writeFile(join(scoped.dir, 'db/migrations/0001_init.sql'), 'select 1;', 'utf8')
+      await writeFile(
+        join(scoped.dir, 'docs/migrations.md'),
+        `---
+related: [db/migrations/*.sql]
+---
+# Migrations
+`,
+        'utf8',
+      )
+
+      const results = await runDocsCheck({ cwd: scoped.dir })
+      expect(results.find((r) => r.key === 'docs-links:docs/migrations.md')?.status).toBe('pass')
+    } finally {
+      await scoped.cleanup()
+    }
+  })
+
+  it('rejects related entries and @docs tags that escape the app root', async () => {
+    const scoped = await createTempWorkspace('guren-cli-docs-escape-')
+    try {
+      await mkdir(join(scoped.dir, 'docs'), { recursive: true })
+      await mkdir(join(scoped.dir, 'app/Models'), { recursive: true })
+      await writeFile(join(scoped.dir, 'package.json'), '{}', 'utf8')
+      await writeFile(
+        join(scoped.dir, 'app/Models/Post.ts'),
+        '/** @docs ../outside.md */\nexport class Post {}\n',
+        'utf8',
+      )
+      await writeFile(
+        join(scoped.dir, 'docs/escape.md'),
+        `---
+related: [../outside.md]
+---
+# Escape
+`,
+        'utf8',
+      )
+
+      const results = await runDocsCheck({ cwd: scoped.dir })
+      expect(
+        results.find((r) => r.key === 'docs-related:docs/escape.md:../outside.md')?.status,
+      ).toBe('fail')
+      expect(
+        results.find((r) => r.key === 'docs-tag:app/Models/Post.ts:../outside.md')?.status,
+      ).toBe('fail')
+    } finally {
+      await scoped.cleanup()
+    }
+  })
+
+  it('runs the union when --arch and --docs are combined', async () => {
+    const report = await runCheck({ cwd: workspace.dir, arch: true, docs: true })
+
+    // Docs suite ran (broken doc fails), arch suite ran, core suite did not
+    expect(report.checks.some((c) => c.key.startsWith('docs-related:'))).toBe(true)
+    expect(report.checks.some((c) => c.key.startsWith('manifest:'))).toBe(false)
+    expect(report.failCount).toBeGreaterThan(0)
   })
 
   it('produces zero results for apps without docs or tags', async () => {

--- a/packages/cli/tests/docs-index.test.ts
+++ b/packages/cli/tests/docs-index.test.ts
@@ -1,0 +1,164 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { describe, expect, it } from 'bun:test'
+import { parseDocFrontmatter, scanDocs, extractDocsTags, buildEntityDocIndex } from '../src/docs-index'
+import { createTempWorkspace } from './helpers'
+
+describe('parseDocFrontmatter', () => {
+  it('parses scalars, inline arrays, and block lists', () => {
+    const parsed = parseDocFrontmatter(`---
+kind: adr
+status: accepted
+entities: [User, Invoice]
+related:
+  - app/Models/Invoice.ts
+  - modules/billing/**
+last_reviewed: 2026-07-25
+---
+
+# Billing cycle
+`)
+
+    expect(parsed).not.toBeNull()
+    expect(parsed!.data.kind).toBe('adr')
+    expect(parsed!.data.status).toBe('accepted')
+    expect(parsed!.data.entities).toEqual(['User', 'Invoice'])
+    expect(parsed!.data.related).toEqual(['app/Models/Invoice.ts', 'modules/billing/**'])
+    expect(parsed!.data.last_reviewed).toBe('2026-07-25')
+    expect(parsed!.body).toContain('# Billing cycle')
+  })
+
+  it('strips quotes from values', () => {
+    const parsed = parseDocFrontmatter(`---
+kind: "adr"
+entities: ['User']
+---
+body`)
+
+    expect(parsed!.data.kind).toBe('adr')
+    expect(parsed!.data.entities).toEqual(['User'])
+  })
+
+  it('returns null when there is no frontmatter', () => {
+    expect(parseDocFrontmatter('# Just a heading\n')).toBeNull()
+  })
+
+  it('ignores unknown keys and malformed lines without failing', () => {
+    const parsed = parseDocFrontmatter(`---
+custom_field: hello
+:::garbage:::
+entities: []
+---
+`)
+
+    expect(parsed!.data.custom_field).toBe('hello')
+    expect(parsed!.data.entities).toEqual([])
+  })
+})
+
+describe('scanDocs', () => {
+  it('scans root docs/ and module docs/, extracting titles', async () => {
+    const workspace = await createTempWorkspace('guren-cli-docs-scan-')
+
+    try {
+      const dir = workspace.dir
+      await mkdir(join(dir, 'docs/adr'), { recursive: true })
+      await mkdir(join(dir, 'modules/billing/docs'), { recursive: true })
+      await writeFile(
+        join(dir, 'docs/adr/0001-billing-cycle.md'),
+        `---
+kind: adr
+status: accepted
+entities: [Post]
+---
+
+# Billing cycle is end-of-month
+`,
+        'utf8',
+      )
+      await writeFile(
+        join(dir, 'modules/billing/docs/context.md'),
+        '# Billing context\n\nNo frontmatter here.\n',
+        'utf8',
+      )
+
+      const refs = await scanDocs(dir)
+
+      expect(refs).toHaveLength(2)
+      const adr = refs.find((r) => r.path === 'docs/adr/0001-billing-cycle.md')
+      expect(adr?.module).toBeNull()
+      expect(adr?.title).toBe('Billing cycle is end-of-month')
+      expect(adr?.kind).toBe('adr')
+      expect(adr?.entities).toEqual(['Post'])
+      expect(adr?.hasFrontmatter).toBe(true)
+
+      const moduleDoc = refs.find((r) => r.path === 'modules/billing/docs/context.md')
+      expect(moduleDoc?.module).toBe('billing')
+      expect(moduleDoc?.hasFrontmatter).toBe(false)
+      expect(moduleDoc?.title).toBe('Billing context')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('resolves to an empty list when no docs directories exist', async () => {
+    const workspace = await createTempWorkspace('guren-cli-docs-empty-')
+
+    try {
+      await writeFile(join(workspace.dir, 'package.json'), '{}', 'utf8')
+      expect(await scanDocs(workspace.dir)).toEqual([])
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})
+
+describe('extractDocsTags', () => {
+  it('extracts @docs tags from JSDoc comments', () => {
+    const tags = extractDocsTags(`/**
+ * @docs docs/adr/0007-billing-cycle.md
+ */
+export class Invoice {}
+`)
+
+    expect(tags).toEqual(['docs/adr/0007-billing-cycle.md'])
+  })
+
+  it('deduplicates and handles multiple tags', () => {
+    const tags = extractDocsTags(`
+/** @docs docs/a.md */
+/** @docs docs/b.md */
+/** @docs docs/a.md */
+`)
+
+    expect(tags).toEqual(['docs/a.md', 'docs/b.md'])
+  })
+
+  it('returns an empty list when no tags exist', () => {
+    expect(extractDocsTags('export class Post {}')).toEqual([])
+  })
+})
+
+describe('buildEntityDocIndex', () => {
+  it('indexes docs by lowercased entity name', () => {
+    const index = buildEntityDocIndex([
+      {
+        path: 'docs/a.md',
+        module: null,
+        entities: ['Post', 'User'],
+        related: [],
+        hasFrontmatter: true,
+      },
+      {
+        path: 'docs/b.md',
+        module: null,
+        entities: ['Post'],
+        related: [],
+        hasFrontmatter: true,
+      },
+    ])
+
+    expect(index.get('post')?.map((r) => r.path)).toEqual(['docs/a.md', 'docs/b.md'])
+    expect(index.get('user')?.map((r) => r.path)).toEqual(['docs/a.md'])
+  })
+})

--- a/packages/cli/tests/docs-index.test.ts
+++ b/packages/cli/tests/docs-index.test.ts
@@ -39,6 +39,29 @@ body`)
     expect(parsed!.data.entities).toEqual(['User'])
   })
 
+  it('strips inline YAML comments from unquoted values', () => {
+    const parsed = parseDocFrontmatter(`---
+status: superseded # replaced by 0009
+entities: [Post] # main entity
+related:
+  - app/Models/Post.ts # the model
+---
+`)
+
+    expect(parsed!.data.status).toBe('superseded')
+    expect(parsed!.data.entities).toEqual(['Post'])
+    expect(parsed!.data.related).toEqual(['app/Models/Post.ts'])
+  })
+
+  it('respects quoted commas inside inline arrays', () => {
+    const parsed = parseDocFrontmatter(`---
+related: ["config/foo,bar.json", app/Models/Post.ts]
+---
+`)
+
+    expect(parsed!.data.related).toEqual(['config/foo,bar.json', 'app/Models/Post.ts'])
+  })
+
   it('returns null when there is no frontmatter', () => {
     expect(parseDocFrontmatter('# Just a heading\n')).toBeNull()
   })

--- a/packages/cli/tests/entity-context.test.ts
+++ b/packages/cli/tests/entity-context.test.ts
@@ -60,6 +60,9 @@ export class Post extends defineModel(posts) {
 import { users } from '../../db/schema.js'
 import type { PostRecord } from './Post.js'
 
+/**
+ * @docs docs/context/users.md
+ */
 export class User extends defineModel(users) {
   static override relationTypes: { posts: HasManyRecord<PostRecord> } = {
     posts: [],
@@ -161,6 +164,23 @@ export default function Index({ posts }: Props) {
     'import { test } from "bun:test"\ntest("noop", () => {})\n',
     'utf8',
   )
+
+  await mkdir(join(dir, 'docs/adr'), { recursive: true })
+  await mkdir(join(dir, 'docs/context'), { recursive: true })
+  await writeFile(
+    join(dir, 'docs/adr/0001-posts-are-public.md'),
+    `---
+kind: adr
+status: accepted
+entities: [Post]
+last_reviewed: 2026-07-25
+---
+
+# Posts are public by default
+`,
+    'utf8',
+  )
+  await writeFile(join(dir, 'docs/context/users.md'), '# User lifecycle\n', 'utf8')
 }
 
 // The blog fixture is read-only for every test in this file, so one shared
@@ -210,6 +230,40 @@ describe('entity context (blog fixture)', () => {
     expect(ctx.factories).toEqual(['db/factories/PostFactory.ts'])
     expect(ctx.seeders).toEqual(['db/seeders/002_PostsSeeder.ts'])
     expect(ctx.tests).toContain('tests/controllers/PostController.test.ts')
+  })
+
+  it('links docs via frontmatter entities and code-side @docs tags', async () => {
+    const post = await generateEntityContext('Post', { cwd: workspace.dir })
+    expect(post.docs).toEqual([
+      {
+        path: 'docs/adr/0001-posts-are-public.md',
+        title: 'Posts are public by default',
+        kind: 'adr',
+        status: 'accepted',
+        lastReviewed: '2026-07-25',
+      },
+    ])
+
+    const user = await generateEntityContext('User', { cwd: workspace.dir })
+    expect(user.docs).toEqual([
+      {
+        path: 'docs/context/users.md',
+        title: 'User lifecycle',
+        kind: undefined,
+        status: undefined,
+        lastReviewed: undefined,
+      },
+    ])
+  })
+
+  it('renders the Linked docs section', async () => {
+    const ctx = await generateEntityContext('Post', { cwd: workspace.dir })
+    const md = renderEntityContextMarkdown(ctx)
+
+    expect(md).toContain('## Linked docs (1)')
+    expect(md).toContain(
+      '- docs/adr/0001-posts-are-public.md — Posts are public by default (adr, accepted, reviewed 2026-07-25)',
+    )
   })
 
   it('resolves entity names case-insensitively', async () => {

--- a/packages/cli/tests/make-adr.test.ts
+++ b/packages/cli/tests/make-adr.test.ts
@@ -177,4 +177,46 @@ describe('makeAdr', () => {
       await workspace.cleanup()
     }
   })
+
+  it('prefills entities and related from a resolved --entity', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-adr-entity-')
+    try {
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      await mkdir(join(workspace.dir, 'app/Http/Controllers'), { recursive: true })
+      await mkdir(join(workspace.dir, 'app/Http/Resources'), { recursive: true })
+      await writeFile(join(workspace.dir, 'app/Models/Post.ts'), 'export class Post {}\n', 'utf8')
+      await writeFile(
+        join(workspace.dir, 'app/Http/Controllers/PostController.ts'),
+        'export class PostController {}\n',
+        'utf8',
+      )
+      await writeFile(
+        join(workspace.dir, 'app/Http/Resources/PostResource.ts'),
+        'export class PostResource {}\n',
+        'utf8',
+      )
+
+      // Case-insensitive input canonicalizes to the parsed class name
+      const result = await makeAdr('Posts are public', { entity: 'post' })
+      const content = readFileSync(result, 'utf8')
+
+      expect(content).toContain('entities: [Post]')
+      expect(content).toContain('related:\n  - app/Http/Controllers/PostController.ts\n  - app/Http/Resources/PostResource.ts')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('prefills an unknown --entity as given, with empty related', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-adr-ghost-')
+    try {
+      const result = await makeAdr('Future decision', { entity: 'Ghost' })
+      const content = readFileSync(result, 'utf8')
+
+      expect(content).toContain('entities: [Ghost]')
+      expect(content).toContain('related: []')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
 })

--- a/packages/cli/tests/make-adr.test.ts
+++ b/packages/cli/tests/make-adr.test.ts
@@ -219,4 +219,84 @@ describe('makeAdr', () => {
       await workspace.cleanup()
     }
   })
+
+  it('rejects --entity values that are not plain identifiers', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-adr-inject-')
+    try {
+      expect(
+        makeAdr('Injection attempt', { entity: 'Ghost]\nstatus: accepted\nentities: [Post' }),
+      ).rejects.toThrow('Invalid entity name')
+      expect(makeAdr('Injection attempt', { entity: 'Post # comment' })).rejects.toThrow(
+        'Invalid entity name',
+      )
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('resolves name ties by ADR location and scopes companions to it', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-adr-dup-')
+    try {
+      const dir = workspace.dir
+      await mkdir(join(dir, 'app/Models'), { recursive: true })
+      await mkdir(join(dir, 'app/Http/Controllers'), { recursive: true })
+      await mkdir(join(dir, 'modules/billing/app/Models'), { recursive: true })
+      await mkdir(join(dir, 'modules/billing/app/Http/Controllers'), { recursive: true })
+      await writeFile(join(dir, 'app/Models/Post.ts'), 'export class Post {}\n', 'utf8')
+      await writeFile(
+        join(dir, 'app/Http/Controllers/PostController.ts'),
+        'export class PostController {}\n',
+        'utf8',
+      )
+      await writeFile(
+        join(dir, 'modules/billing/app/Models/Post.ts'),
+        'export class Post {}\n',
+        'utf8',
+      )
+      await writeFile(
+        join(dir, 'modules/billing/app/Http/Controllers/PostController.ts'),
+        'export class PostController {}\n',
+        'utf8',
+      )
+
+      // Root ADR prefers the root model and links only root companions
+      const rootAdr = await makeAdr('Root decision', { entity: 'Post' })
+      const rootContent = readFileSync(rootAdr, 'utf8')
+      expect(rootContent).toContain('- app/Http/Controllers/PostController.ts')
+      expect(rootContent).not.toContain('modules/billing')
+
+      // Module ADR prefers the module model and links only its companions
+      const moduleAdr = await makeAdr('Billing decision', { entity: 'Post', root: 'billing' })
+      const moduleContent = readFileSync(moduleAdr, 'utf8')
+      expect(moduleContent).toContain('- modules/billing/app/Http/Controllers/PostController.ts')
+      expect(moduleContent).not.toContain('- app/Http/Controllers/PostController.ts')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('errors on a name tie that no location preference resolves', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-adr-ambiguous-')
+    try {
+      const dir = workspace.dir
+      await mkdir(join(dir, 'modules/billing/app/Models'), { recursive: true })
+      await mkdir(join(dir, 'modules/sales/app/Models'), { recursive: true })
+      await writeFile(
+        join(dir, 'modules/billing/app/Models/Post.ts'),
+        'export class Post {}\n',
+        'utf8',
+      )
+      await writeFile(
+        join(dir, 'modules/sales/app/Models/Post.ts'),
+        'export class Post {}\n',
+        'utf8',
+      )
+
+      expect(makeAdr('Ambiguous decision', { entity: 'Post' })).rejects.toThrow(
+        'multiple locations: billing, sales',
+      )
+    } finally {
+      await workspace.cleanup()
+    }
+  })
 })

--- a/packages/cli/tests/make-adr.test.ts
+++ b/packages/cli/tests/make-adr.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'bun:test'
+import { existsSync, readFileSync } from 'node:fs'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { createTempWorkspace } from './helpers'
+import { makeAdr } from '../src/make-adr'
+
+async function seedAdrFiles(dir: string, names: string[]): Promise<void> {
+  await mkdir(dir, { recursive: true })
+  for (const name of names) {
+    await writeFile(join(dir, name), '# seeded\n', 'utf8')
+  }
+}
+
+describe('makeAdr', () => {
+  it('creates the first ADR at 0001 when docs/adr does not exist', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-adr-first-')
+    try {
+      const result = await makeAdr('Billing cycle is end-of-month')
+
+      expect(result).toContain('docs/adr/0001-billing-cycle-is-end-of-month.md')
+      expect(existsSync(result)).toBe(true)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('fills in the frontmatter and section skeleton', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-adr-template-')
+    try {
+      const result = await makeAdr('Billing cycle is end-of-month')
+      const content = readFileSync(result, 'utf8')
+
+      expect(content.startsWith('---\n')).toBe(true)
+      expect(content).toContain('kind: adr')
+      expect(content).toContain('status: draft')
+      expect(content).toContain('entities: []')
+      expect(content).toContain('related: []')
+      expect(content).toMatch(/^last_reviewed: \d{4}-\d{2}-\d{2}$/m)
+      expect(content).toContain('# Billing cycle is end-of-month')
+      expect(content).toContain('## Context')
+      expect(content).toContain('## Decision')
+      expect(content).toContain('## Consequences')
+      expect(content.endsWith('\n')).toBe(true)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('continues the sequence after existing ADRs', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-adr-sequence-')
+    try {
+      await seedAdrFiles(join(workspace.dir, 'docs/adr'), [
+        '0001-first-decision.md',
+        '0002-second-decision.md',
+      ])
+
+      const result = await makeAdr('Third decision')
+
+      expect(result).toContain('docs/adr/0003-third-decision.md')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('uses the highest existing number, not the file count, and ignores non-ADR files', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-adr-gap-')
+    try {
+      await seedAdrFiles(join(workspace.dir, 'docs/adr'), [
+        '0001-first-decision.md',
+        '0007-seventh-decision.md',
+        'README.md',
+        'notes.txt',
+        '12-not-four-digits.md',
+      ])
+
+      const result = await makeAdr('Next decision')
+
+      expect(result).toContain('docs/adr/0008-next-decision.md')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('slugifies punctuation, casing, and whitespace runs', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-adr-slug-')
+    try {
+      const result = await makeAdr('  Use HTTP/2 — Why?  ')
+
+      expect(result).toContain('docs/adr/0001-use-http-2-why.md')
+      const content = readFileSync(result, 'utf8')
+      expect(content).toContain('# Use HTTP/2 — Why?')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('falls back to an "adr" slug when the title has no ASCII alphanumerics', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-adr-slug-fallback-')
+    try {
+      const result = await makeAdr('請求サイクル')
+
+      expect(result).toContain('docs/adr/0001-adr.md')
+      expect(existsSync(result)).toBe(true)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('writes into modules/<name>/docs/adr when a module root is given', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-adr-module-')
+    try {
+      const result = await makeAdr('Invoice numbering', { root: 'Billing' })
+
+      expect(result).toContain('modules/billing/docs/adr/0001-invoice-numbering.md')
+      expect(existsSync(result)).toBe(true)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('numbers module ADRs independently of the project-root docs/adr', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-adr-module-sequence-')
+    try {
+      await seedAdrFiles(join(workspace.dir, 'docs/adr'), ['0001-root-decision.md'])
+
+      const result = await makeAdr('Module decision', { root: 'billing' })
+
+      expect(result).toContain('modules/billing/docs/adr/0001-module-decision.md')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('counts uppercase .MD files so numbering cannot collide on a case-insensitive filesystem', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-adr-case-')
+    try {
+      await seedAdrFiles(join(workspace.dir, 'docs/adr'), ['0001-Billing-Cycle.MD'])
+
+      const result = await makeAdr('Billing cycle')
+
+      expect(result).toContain('docs/adr/0002-billing-cycle.md')
+      expect(existsSync(result)).toBe(true)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  // `writeFileSafe` refuses to overwrite without `--force`. Because the sequence
+  // is always `max(existing) + 1` (counting `.MD` too), a repeated title is
+  // additive rather than an error, so `--force` has nothing to overwrite here.
+  it('never overwrites an existing ADR: a repeated title takes the next number', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-adr-repeat-')
+    try {
+      const first = await makeAdr('Billing cycle')
+      const second = await makeAdr('Billing cycle')
+
+      expect(first).toContain('docs/adr/0001-billing-cycle.md')
+      expect(second).toContain('docs/adr/0002-billing-cycle.md')
+      expect(existsSync(first)).toBe(true)
+      expect(readFileSync(first, 'utf8')).toContain('kind: adr')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('accepts the shared force writer option without altering numbering', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-adr-force-')
+    try {
+      await seedAdrFiles(join(workspace.dir, 'docs/adr'), ['0001-billing-cycle.md'])
+
+      const result = await makeAdr('Billing cycle', { force: true })
+
+      expect(result).toContain('docs/adr/0002-billing-cycle.md')
+      expect(readFileSync(join(workspace.dir, 'docs/adr/0001-billing-cycle.md'), 'utf8')).toBe('# seeded\n')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Implements **RFC 0004 Part 2** (`rfcs/0004-spec-anchored-development.md`): deterministic doc–code linking.

- **`docs/` frontmatter convention** — markdown under `docs/` and `modules/*/docs/` declares `kind`, `status`, `entities`, `related` (paths or globs, Cursor/Kiro-convergent idiom), `last_reviewed`. Parsed by a minimal YAML-subset parser (`docs-index.ts`) — no new dependency, same frozen-vocabulary philosophy as `glob-match.ts`.
- **`guren context <Entity>` → Linked docs** — the reverse index (frontmatter `entities:`) merges with code-side `@docs <path>` JSDoc tags on models and controllers. Location-scoped when the entity name exists in multiple modules; explicit tags cross scope by design.
- **`guren check --docs`** — dangling `related` paths/globs, unknown `entities`, and broken `@docs` tags **fail**; entities whose only linked docs are superseded **warn**; `--docs-ttl <days>` warns on stale `last_reviewed` (off by default). Content-activated so no existing CI goes red; participates in `--changed` for the edit-hook path; like `--arch`, the new flag gates on exit code from day one.
- **`make:adr "Title"`** — numbered ADRs (`docs/adr/NNNN-slug.md`, max+1 numbering) with prefilled linkable frontmatter; `--module` targets `modules/<m>/docs/adr/`.
- **Living example** — `examples/blog/docs/adr/0001-posts-are-public-by-default.md` links the Post entity and both its controller/resource files.

## Verification

- `bun run build` / `bun run typecheck` / `bun run test:bun` (2550 pass / 0 fail) / `audit:core-first` / `audit:docs` all green.
- New tests: frontmatter parser variants, `scanDocs` (root + module docs), `@docs` extraction, full `runDocsCheck` matrix (pass/fail/warn/TTL/changed-scope/zero-activation), `make:adr` (11 cases incl. numbering gaps and non-ASCII titles), entity-context linked-docs joins and rendering.
- Dogfooded on `examples/blog`: `make:adr` → filled frontmatter → `guren context Post` shows the Linked docs section; `guren check --docs` passes clean, fails (exit 1) on a renamed `related` target, and returns to green on restore.

Refs: RFC 0004