### PR TITLE
feat(docs): add favicon and X social link to homepage

### DIFF
--- a/web/config/site.ts
+++ b/web/config/site.ts
@@ -4,6 +4,7 @@
 export const SITE_URL = 'https://guren.dev'
 export const SITE_NAME = 'Guren'
 export const GITHUB_URL = 'https://github.com/gurenjs/guren'
+export const X_URL = 'https://x.com/gurenjs'
 export const OG_IMAGE_PATH = '/og.png'
 
 export const SITE_TITLE =

--- a/web/resources/js/components/Footer.tsx
+++ b/web/resources/js/components/Footer.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@inertiajs/react'
-import { GITHUB_URL } from '../../../config/site.js'
-import { GithubIcon } from './icons.js'
+import { GITHUB_URL, X_URL } from '../../../config/site.js'
+import { GithubIcon, XLogoIcon } from './icons.js'
 
 interface FooterProps {
   variant: 'home' | 'docs'
@@ -27,6 +27,15 @@ export function Footer({ variant }: FooterProps) {
             >
               <GithubIcon className="size-4" />
               GitHub
+            </a>
+            <a
+              href={X_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1.5 no-underline transition hover:text-docs-accent"
+              aria-label="Guren on X"
+            >
+              <XLogoIcon className="size-4" />
             </a>
           </div>
         </div>
@@ -61,6 +70,7 @@ export function Footer({ variant }: FooterProps) {
             <a href="https://github.com/gurenjs/guren" target="_blank" rel="noreferrer" className="no-underline transition hover:text-white">GitHub</a>
             <a href="https://github.com/gurenjs/guren/issues" target="_blank" rel="noreferrer" className="no-underline transition hover:text-white">Issues</a>
             <a href="https://github.com/gurenjs/guren/discussions" target="_blank" rel="noreferrer" className="no-underline transition hover:text-white">Discussions</a>
+            <a href={X_URL} target="_blank" rel="noreferrer" className="no-underline transition hover:text-white">X</a>
           </nav>
         </div>
         <div>

--- a/web/resources/js/components/Header.tsx
+++ b/web/resources/js/components/Header.tsx
@@ -1,7 +1,8 @@
 import { Link } from '@inertiajs/react'
 import { useState } from 'react'
+import { X_URL } from '../../../config/site.js'
 import { useColorMode } from '../pages/Docs/theme.js'
-import { GithubIcon, MenuIcon, MoonIcon, SunIcon } from './icons.js'
+import { GithubIcon, MenuIcon, MoonIcon, SunIcon, XLogoIcon } from './icons.js'
 import { MobileMenu } from './MobileMenu.js'
 
 interface LocaleLink {
@@ -72,6 +73,15 @@ export function Header({ variant, basePath = '/docs', locales = [] }: HeaderProp
                   <GithubIcon className="size-4" />
                   GitHub
                 </a>
+                <a
+                  href={X_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center gap-1.5 transition hover:text-white"
+                  aria-label="Guren on X"
+                >
+                  <XLogoIcon className="size-4" />
+                </a>
               </nav>
               <ColorModeButton variant="home" />
               <button
@@ -115,6 +125,15 @@ export function Header({ variant, basePath = '/docs', locales = [] }: HeaderProp
               >
                 <GithubIcon className="size-4" />
                 GitHub
+              </a>
+              <a
+                href={X_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="flex items-center gap-1.5 text-docs-text-muted no-underline transition hover:text-docs-accent"
+                aria-label="Guren on X"
+              >
+                <XLogoIcon className="size-4" />
               </a>
             </nav>
             {locales.length > 1 && (

--- a/web/resources/js/components/MobileMenu.tsx
+++ b/web/resources/js/components/MobileMenu.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@inertiajs/react'
 import { useEffect } from 'react'
-import { GithubIcon, XIcon } from './icons.js'
+import { X_URL } from '../../../config/site.js'
+import { GithubIcon, XIcon, XLogoIcon } from './icons.js'
 
 interface LocaleLink {
   code: string
@@ -79,6 +80,15 @@ export function MobileMenu({ open, onClose, basePath, locales = [] }: MobileMenu
           >
             <GithubIcon className="size-4" />
             GitHub
+          </a>
+          <a
+            href={X_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center gap-2 rounded-lg px-3 py-2.5 text-[0.95rem] font-medium text-gray-700 no-underline transition hover:bg-gray-100"
+          >
+            <XLogoIcon className="size-4" />
+            X
           </a>
         </nav>
         {locales.length > 1 && (

--- a/web/resources/js/components/Seo.tsx
+++ b/web/resources/js/components/Seo.tsx
@@ -40,6 +40,10 @@ export function Seo({
     <Head>
       <title>{title}</title>
       <meta name="description" content={description} />
+      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+      <link rel="icon" type="image/png" sizes="192x192" href="/favicon-192x192.png" />
+      <link rel="icon" type="image/png" sizes="512x512" href="/favicon-512x512.png" />
+      <link rel="apple-touch-icon" sizes="192x192" href="/favicon-192x192.png" />
       <link rel="canonical" href={canonical} />
       {alternates.map((alt) => (
         <link key={alt.hrefLang} rel="alternate" hrefLang={alt.hrefLang} href={absoluteUrl(alt.href)} />
@@ -56,6 +60,7 @@ export function Seo({
       <meta property="og:image" content={ogImage} />
       <meta property="og:locale" content={locale === 'ja' ? 'ja_JP' : 'en_US'} />
       <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:site" content="@gurenjs" />
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
       <meta name="twitter:image" content={ogImage} />

--- a/web/resources/js/components/icons.tsx
+++ b/web/resources/js/components/icons.tsx
@@ -58,6 +58,14 @@ export function XIcon(props: IconProps) {
   )
 }
 
+export function XLogoIcon(props: IconProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" {...props}>
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  )
+}
+
 export function ChevronRightIcon(props: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" {...props}>

--- a/web/resources/js/lib/structured-data.ts
+++ b/web/resources/js/lib/structured-data.ts
@@ -1,4 +1,4 @@
-import { GITHUB_URL, SITE_DESCRIPTION, SITE_NAME, SITE_URL, absoluteUrl } from '../../../config/site.js'
+import { GITHUB_URL, SITE_DESCRIPTION, SITE_NAME, SITE_URL, X_URL, absoluteUrl } from '../../../config/site.js'
 
 const WEBSITE_JSON_LD: Record<string, unknown> = {
   '@context': 'https://schema.org',
@@ -17,7 +17,7 @@ const SOFTWARE_JSON_LD: Record<string, unknown> = {
   offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
   description: SITE_DESCRIPTION.en,
   url: SITE_URL,
-  sameAs: [GITHUB_URL],
+  sameAs: [GITHUB_URL, X_URL],
   programmingLanguage: 'TypeScript',
 }
 


### PR DESCRIPTION
## Summary
- The generated Inertia document head never included a `<link rel="icon">` — `web/public/index.html` (which has the favicon links) is unused since Vite's `publicDir` is disabled for this app, so `guren.dev` served no favicon even though the PNG assets were already deployed as static files. Add favicon/apple-touch-icon links to the shared `Seo` component so every page renders them.
- Add the project's X account (https://x.com/gurenjs) next to the existing GitHub link in the header, footer, and mobile menu, plus `twitter:site` meta and JSON-LD `sameAs`.

## Test plan
- [x] Ran the `web-docs` dev server and confirmed `<head>` now includes the favicon/apple-touch-icon `<link>` tags, and that the referenced PNGs return 200
- [x] Confirmed the X link renders in the header and footer on both the home and docs page variants, with the correct `href`