### PR TITLE
feat(server): add OAuth --oauth-only scaffold and email verification signal

### DIFF
--- a/.changeset/oauth-profile-email-verified.md
+++ b/.changeset/oauth-profile-email-verified.md
@@ -1,0 +1,10 @@
+---
+'@guren/server': minor
+'@guren/cli': patch
+---
+
+Add `emailVerified` to `OAuthUserProfile`. Providers report whether they actually verified an address separately from the address itself — Google sends OIDC's `email_verified`, Discord sends `verified` — and until now that signal was only reachable through the untyped `profile.raw` bag. The field is tri-state on purpose: `true` (the provider asserts verified), `false` (it asserts not verified), `undefined` (no signal, so the app decides its own policy).
+
+Provider configs declare where to read it via `emailVerifiedKey`, so the shared mapper knows only OIDC's standard `email_verified` claim; the Google and Discord presets each declare their own key, and only boolean values are read. GitHub's `/user` carries no such field, so `emailVerified` stays `undefined` there — except when the private-email fallback runs, which reports `true` because `/user/emails` only yields verified primary addresses. `mapProfile` still owns the whole mapping when set.
+
+`make:auth --oauth`'s scaffolded `OAuthController` now checks `profile.emailVerified === false` instead of matching provider-specific keys on `profile.raw`. Same behavior, no provider names in generated application code.

--- a/.changeset/oauth-profile-email-verified.md
+++ b/.changeset/oauth-profile-email-verified.md
@@ -7,4 +7,6 @@ Add `emailVerified` to `OAuthUserProfile`. Providers report whether they actuall
 
 Provider configs declare where to read it via `emailVerifiedKey`, so the shared mapper knows only OIDC's standard `email_verified` claim; the Google and Discord presets each declare their own key, and only boolean values are read. GitHub's `/user` carries no such field, so `emailVerified` stays `undefined` there — except when the private-email fallback runs, which reports `true` because `/user/emails` only yields verified primary addresses. `mapProfile` still owns the whole mapping when set.
 
+`fetchFallbackEmail` may now also return `{ email, emailVerified }` instead of a bare string, since the signal read from the userinfo response cannot vouch for an address that response did not contain. This is additive: implementations written against the original signature keep compiling, and a bare string deliberately claims nothing, leaving `emailVerified` undefined rather than asserting `true` on their behalf.
+
 `make:auth --oauth`'s scaffolded `OAuthController` now checks `profile.emailVerified === false` instead of matching provider-specific keys on `profile.raw`. Same behavior, no provider names in generated application code.

--- a/docs/en/guides/oauth.md
+++ b/docs/en/guides/oauth.md
@@ -153,6 +153,37 @@ const gitlabConfig: OAuthProviderConfig = {
 oauth.registerProvider('gitlab', gitlabConfig)
 ```
 
+## Provider Email Verification
+
+A provider returning an email is not a claim that it checked the address. Most report that separately — Google sends OIDC's `email_verified`, Discord sends `verified` — and the profile exposes it as `profile.emailVerified`:
+
+| Value | Meaning |
+|-------|---------|
+| `true` | The provider says it verified the address |
+| `false` | The provider says it did **not** |
+| `undefined` | The provider sends no such signal — your app decides |
+
+Refuse to *create* an account on `false`: an unverified address lets a user claim an email they do not own, and a callback that rejects duplicate emails then locks the real owner out for good. Check it only on the create path so an already-linked account is not stranded if its status changes later:
+
+```ts
+if (!user && profile.emailVerified === false) {
+  throw ValidationException.withMessages({
+    message: 'Your provider has not verified this email address.',
+  })
+}
+```
+
+The built-in presets declare their own key. For a provider you register yourself, set `emailVerifiedKey` when it uses a non-standard name — the default reads OIDC's `email_verified`, and only boolean values count:
+
+```ts
+const discordish: OAuthProviderConfig = {
+  // ...
+  emailVerifiedKey: 'verified',
+}
+```
+
+`mapProfile` owns the whole mapping, so a provider using it sets `emailVerified` itself and `emailVerifiedKey` is ignored. GitHub's `/user` carries no verification field at all, so `emailVerified` stays `undefined` there — except when the private-email fallback runs, since `/user/emails` only yields verified primary addresses.
+
 ## State Storage
 
 The one-time `state` value that ties the callback back to the original request is stored server-side. The default `MemoryOAuthStateStore` works for single-process dev, but production deployments with more than one process (load balancers, serverless) need shared storage — otherwise the callback can land on a process that never issued the state.
@@ -205,6 +236,7 @@ interface OAuthProviderConfig {
   tokenAuthMethod?: 'client_secret_post' | 'client_secret_basic'
   userInfoMethod?: 'GET' | 'POST'
   mapProfile?: (raw: Record<string, unknown>, token: OAuthTokenResult) => OAuthUserProfile
+  emailVerifiedKey?: string      // Userinfo key holding the verification signal (default: 'email_verified')
 }
 
 interface OAuthStateConfig {

--- a/docs/en/guides/oauth.md
+++ b/docs/en/guides/oauth.md
@@ -184,6 +184,12 @@ const discordish: OAuthProviderConfig = {
 
 `mapProfile` owns the whole mapping, so a provider using it sets `emailVerified` itself and `emailVerifiedKey` is ignored. GitHub's `/user` carries no verification field at all, so `emailVerified` stays `undefined` there — except when the private-email fallback runs, since `/user/emails` only yields verified primary addresses.
 
+A `fetchFallbackEmail` hook is read against a response that had no email, so the key above cannot vouch for what it returns. Returning a bare string makes no claim and leaves the field `undefined`; return an object to state one:
+
+```ts
+fetchFallbackEmail: async (token) => ({ email: await lookupEmail(token), emailVerified: true }),
+```
+
 ## State Storage
 
 The one-time `state` value that ties the callback back to the original request is stored server-side. The default `MemoryOAuthStateStore` works for single-process dev, but production deployments with more than one process (load balancers, serverless) need shared storage — otherwise the callback can land on a process that never issued the state.

--- a/docs/ja/guides/oauth.md
+++ b/docs/ja/guides/oauth.md
@@ -184,6 +184,12 @@ const discordish: OAuthProviderConfig = {
 
 `mapProfile` はマッピング全体を担うため、それを使うプロバイダーでは `emailVerified` も自分で設定し、`emailVerifiedKey` は無視されます。GitHub の `/user` には検証状態のフィールドがないため `emailVerified` は `undefined` のままですが、メールアドレス非公開時のフォールバックが動いた場合は例外です（`/user/emails` は検証済みのプライマリアドレスしか返さないため）。
 
+`fetchFallbackEmail` はメールアドレスを含まないレスポンスに対して読んだ後に呼ばれるため、上記のキーはその戻り値を保証できません。文字列をそのまま返す場合は検証状態を主張せず `undefined` のままになります。主張する場合はオブジェクトを返してください。
+
+```ts
+fetchFallbackEmail: async (token) => ({ email: await lookupEmail(token), emailVerified: true }),
+```
+
 ## Stateストレージ
 
 コールバックを元のリクエストに結びつける一度限りの `state` 値は、サーバー側で保存されます。デフォルトの `MemoryOAuthStateStore` は単一プロセスの開発環境では動作しますが、複数プロセス（ロードバランサー、サーバーレス）構成の本番環境では共有ストレージが必要です。そうしないと、コールバックがstateを発行していないプロセスに到達してしまう可能性があります。

--- a/docs/ja/guides/oauth.md
+++ b/docs/ja/guides/oauth.md
@@ -153,6 +153,37 @@ const gitlabConfig: OAuthProviderConfig = {
 oauth.registerProvider('gitlab', gitlabConfig)
 ```
 
+## プロバイダーによるメールアドレスの検証状態
+
+プロバイダーがメールアドレスを返したことは、そのアドレスを検証したという主張ではありません。多くのプロバイダーは検証状態を別に報告しており（Google は OIDC の `email_verified`、Discord は `verified`）、プロフィールでは `profile.emailVerified` として公開されます。
+
+| 値 | 意味 |
+|----|------|
+| `true` | プロバイダーが検証済みと報告している |
+| `false` | プロバイダーが未検証と報告している |
+| `undefined` | プロバイダーがこの情報を返していない（アプリ側で方針を決める） |
+
+`false` の場合はアカウントの**新規作成**を拒否してください。未検証のアドレスをそのまま受け入れると、所有していないメールアドレスを名乗れてしまい、重複メールを弾くコールバックが本来の所有者を恒久的に締め出すことになります。既に紐付け済みのアカウントが後から状態変化で締め出されないよう、チェックは作成パスだけに置きます。
+
+```ts
+if (!user && profile.emailVerified === false) {
+  throw ValidationException.withMessages({
+    message: 'Your provider has not verified this email address.',
+  })
+}
+```
+
+組み込みプリセットは自分のキーを宣言済みです。自前で登録するプロバイダーが標準以外のキー名を使う場合は `emailVerifiedKey` を設定してください。デフォルトでは OIDC の `email_verified` を読み、boolean 値のみを有効な信号として扱います。
+
+```ts
+const discordish: OAuthProviderConfig = {
+  // ...
+  emailVerifiedKey: 'verified',
+}
+```
+
+`mapProfile` はマッピング全体を担うため、それを使うプロバイダーでは `emailVerified` も自分で設定し、`emailVerifiedKey` は無視されます。GitHub の `/user` には検証状態のフィールドがないため `emailVerified` は `undefined` のままですが、メールアドレス非公開時のフォールバックが動いた場合は例外です（`/user/emails` は検証済みのプライマリアドレスしか返さないため）。
+
 ## Stateストレージ
 
 コールバックを元のリクエストに結びつける一度限りの `state` 値は、サーバー側で保存されます。デフォルトの `MemoryOAuthStateStore` は単一プロセスの開発環境では動作しますが、複数プロセス（ロードバランサー、サーバーレス）構成の本番環境では共有ストレージが必要です。そうしないと、コールバックがstateを発行していないプロセスに到達してしまう可能性があります。
@@ -205,6 +236,7 @@ interface OAuthProviderConfig {
   tokenAuthMethod?: 'client_secret_post' | 'client_secret_basic'
   userInfoMethod?: 'GET' | 'POST'
   mapProfile?: (raw: Record<string, unknown>, token: OAuthTokenResult) => OAuthUserProfile
+  emailVerifiedKey?: string      // 検証状態を持つユーザー情報のキー（デフォルト: 'email_verified'）
 }
 
 interface OAuthStateConfig {

--- a/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
@@ -57,6 +57,21 @@ export default class OAuthController extends Controller {
     let [user] = await User.where(identityWhere(provider, profile.id))
 
     if (!user) {
+      // Returning an email is not a claim that the provider checked it — the
+      // provider reports that separately, and profile.emailVerified carries
+      // the answer. Creating an account from an address the provider says it
+      // never verified would let it claim an email it does not own, and the
+      // collision check below would then turn the real owner away for good.
+      // Only an explicit false is refused: providers that send no signal at
+      // all (GitHub's /user) leave this undefined. Checked only on the create
+      // path, so an already-linked account is not locked out if its provider
+      // status changes later.
+      if (profile.emailVerified === false) {
+        throw ValidationException.withMessages({
+          message: 'Your provider has not verified this email address. Verify it with the provider and try again.',
+        })
+      }
+
       const [existingByEmail] = await User.where({ email: resolvedEmail })
       if (existingByEmail) {
         throw ValidationException.withMessages({
@@ -71,11 +86,10 @@ export default class OAuthController extends Controller {
         name: profile.name ?? resolvedEmail,
         email: resolvedEmail,
         password: randomUUID(),
-        // The provider already vouches for this address (GitHub's fallback
-        // above only accepts primary+verified emails; Google's userinfo
-        // email comes from a verified account) — making the user click a
-        // verification link we never send would just strand them at
-        // /verify-email.
+        // The address got past the check above — either the provider vouches
+        // for it, or it came from GitHub's fallback, which only accepts
+        // primary+verified emails. Making the user click a verification link
+        // we never send would just strand them at /verify-email.
         emailVerifiedAt: new Date(),
         ...identityWhere(provider, profile.id),
       })

--- a/examples/blog/tests/controllers/OAuthController.test.ts
+++ b/examples/blog/tests/controllers/OAuthController.test.ts
@@ -134,6 +134,42 @@ describe('OAuthController', () => {
       expect(mockUserCreate).not.toHaveBeenCalled()
     })
 
+    it('refuses to create an account from an address the provider has not verified', async () => {
+      const oauth = createOAuthStub()
+      oauth.handleCallback.mockResolvedValue({
+        profile: { id: 'gh-6', email: 'unverified@example.com', name: 'Unverified', emailVerified: false },
+        redirectTo: null,
+      })
+      mockUserWhere.mockResolvedValue([])
+
+      const controller = createController()
+      const ctx = createControllerContext('http://blog.test/auth/github/callback?code=abc&state=xyz', {}, { oauth }) as unknown as Context
+      controller.setContext(ctx)
+      ;(ctx as unknown as { req: { param: () => Record<string, string> } }).req.param = () => ({ provider: 'github' })
+
+      await expect(controller.callback()).rejects.toThrow()
+      expect(mockUserCreate).not.toHaveBeenCalled()
+    })
+
+    it('signs in an already-linked account even when the provider reports it unverified', async () => {
+      const oauth = createOAuthStub()
+      oauth.handleCallback.mockResolvedValue({
+        profile: { id: 'gh-7', email: 'linked@example.com', name: 'Linked', emailVerified: false },
+        redirectTo: null,
+      })
+      mockUserWhere.mockResolvedValue([{ id: 7, email: 'linked@example.com', githubId: 'gh-7' }])
+
+      const controller = createController()
+      const ctx = createControllerContext('http://blog.test/auth/github/callback?code=abc&state=xyz', {}, { oauth }) as unknown as Context
+      controller.setContext(ctx)
+      ;(ctx as unknown as { req: { param: () => Record<string, string> } }).req.param = () => ({ provider: 'github' })
+
+      const response = await controller.callback()
+
+      expect(mockUserCreate).not.toHaveBeenCalled()
+      expect(response.status).toBe(302)
+    })
+
     it('lowercases the provider email before matching and creating accounts', async () => {
       const oauth = createOAuthStub()
       oauth.handleCallback.mockResolvedValue({

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -257,7 +257,9 @@ export default class OAuthController extends Controller {
     // Replace this with your own account linking: look the user up by
     // profile.email, create one when missing, then \`await this.auth.login(user)\`
     // and finish with \`return this.redirect(redirectTo ?? '/')\` —
-    // \`redirectTo\` is already sanitized against open redirects.
+    // \`redirectTo\` is already sanitized against open redirects. Refuse to
+    // create an account when \`profile.emailVerified === false\`: the provider
+    // is saying it never checked that the address belongs to this user.
     const { profile, redirectTo } = await this.oauth().handleCallback(provider, { code, state })
     return this.json({ provider, profile, redirectTo }, { status: 200 })
   }

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -357,13 +357,14 @@ export default class OAuthController extends Controller {
 
     if (!user) {
       // Providers report separately whether they actually verified the
-      // address (Google's \`email_verified\`, Discord's \`verified\`) — returning
-      // it in the profile is not a claim that it was checked. Creating an
-      // account from an unverified one would let it claim an email it does
-      // not own, and the collision check below would then turn the real owner
-      // away for good. Checked only on the create path: an already-linked
-      // account should not be locked out if its provider status changes later.
-      if (profile.raw.email_verified === false || profile.raw.verified === false) {
+      // address — returning it in the profile is not a claim that it was
+      // checked. Creating an account from an unverified one would let it claim
+      // an email it does not own, and the collision check below would then turn
+      // the real owner away for good. Only an explicit \`false\` is refused:
+      // providers that send no signal at all leave this undefined. Checked only
+      // on the create path, so an already-linked account is not locked out if
+      // its provider status changes later.
+      if (profile.emailVerified === false) {
         throw ValidationException.withMessages({
           message: 'Your provider has not verified this email address. Verify it with the provider and try again.',
         })

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -378,17 +378,21 @@ export const posts = pgTable('posts', {
       expect(controller).not.toContain('password:')
       expect(controller).toContain('already exists. Sign in with the method you originally used.')
 
-      // Returning an email is not a claim that the provider checked it:
-      // Google reports email_verified and Discord reports verified separately.
-      // Creating an account from an unverified address would let it claim an
-      // email it does not own, which the collision check above then makes
-      // permanent for the real owner.
-      expect(controller).toContain('profile.raw.email_verified === false || profile.raw.verified === false')
+      // Returning an email is not a claim that the provider checked it, so the
+      // scaffold reads the typed signal @guren/server maps from the provider's
+      // own key. Creating an account from an unverified address would let it
+      // claim an email it does not own, which the collision check above then
+      // makes permanent for the real owner.
+      expect(controller).toContain('profile.emailVerified === false')
       expect(controller).toContain('has not verified this email address')
+      // Providers that send no signal leave the field undefined — those users
+      // (GitHub's /user, for one) must still be able to sign up.
+      expect(controller).not.toContain('profile.emailVerified !== true')
+      expect(controller).not.toContain('profile.raw.email_verified')
       // Only on the create path — an existing link must not break if the
       // provider's verification status changes later.
       const createBranch = controller.slice(controller.indexOf('if (!user) {'))
-      expect(createBranch).toContain('profile.raw.email_verified')
+      expect(createBranch).toContain('profile.emailVerified === false')
 
       const authRoutes = await readFile(join(workspace.dir, 'routes/auth.ts'), 'utf8')
       expect(authRoutes).toContain("import OAuthController from '../app/Http/Controllers/Auth/OAuthController.js'")

--- a/packages/server/src/auth/index.ts
+++ b/packages/server/src/auth/index.ts
@@ -78,6 +78,7 @@ export type {
   OAuthProviderConfig,
   OAuthTokenResult,
   OAuthUserProfile,
+  OAuthFallbackEmail,
   OAuthStatePayload,
   OAuthStateStore,
   OAuthStateConfig,

--- a/packages/server/src/auth/oauth/index.ts
+++ b/packages/server/src/auth/oauth/index.ts
@@ -31,11 +31,22 @@ export interface OAuthProviderConfig {
    * `user:email` scope was granted. Returns the email to use, or undefined
    * to leave the profile without one.
    *
-   * Only return an address the provider has verified: the resulting profile
-   * reports `emailVerified: true`, since the returned address is a different
-   * one than `emailVerifiedKey` was read against.
+   * The signal read via `emailVerifiedKey` does not carry over to a fallback
+   * address — it was read against a response that had no email. A bare string
+   * therefore makes no verification claim and leaves `profile.emailVerified`
+   * undefined; return `{ email, emailVerified: true }` to assert one.
    */
-  fetchFallbackEmail?: (token: OAuthTokenResult) => Promise<string | undefined>
+  fetchFallbackEmail?: (token: OAuthTokenResult) => Promise<string | OAuthFallbackEmail | undefined>
+}
+
+export interface OAuthFallbackEmail {
+  email: string
+  /**
+   * Whether the provider verified this specific address. Omit it when the
+   * lookup cannot tell — the profile then reports `emailVerified: undefined`
+   * rather than an unfounded claim.
+   */
+  emailVerified?: boolean
 }
 
 export interface OAuthTokenResult {
@@ -439,12 +450,15 @@ export async function fetchOAuthUserProfile(
     : defaultProfileFromUserInfo(raw, token, provider.emailVerifiedKey)
 
   if (!profile.email && provider.fetchFallbackEmail) {
-    const email = await provider.fetchFallbackEmail(token)
+    const fallback = await provider.fetchFallbackEmail(token)
+    const email = typeof fallback === 'string' ? fallback : fallback?.email
     if (email) {
-      // A fallback address is a different one than the userinfo response was
-      // read against, and the contract is that only verified addresses are
-      // returned — so the signal read from `raw` no longer applies to it.
-      return { ...profile, email, emailVerified: true }
+      // The signal read from `raw` was read against a response with no email,
+      // so it cannot vouch for this one. Only the object form claims anything;
+      // a bare string — every implementation written against the original
+      // signature — leaves the field undefined rather than asserting `true`.
+      const emailVerified = typeof fallback === 'string' ? undefined : fallback?.emailVerified
+      return { ...profile, email, emailVerified }
     }
   }
 
@@ -501,7 +515,7 @@ export interface OAuthProviderFactoryInput {
 // GitHub's /user endpoint returns `email: null` whenever the account's email
 // is set to private, even with the `user:email` scope granted — the primary
 // verified address is only available from this separate endpoint.
-async function fetchGitHubPrimaryEmail(token: OAuthTokenResult): Promise<string | undefined> {
+async function fetchGitHubPrimaryEmail(token: OAuthTokenResult): Promise<OAuthFallbackEmail | undefined> {
   const response = await fetch('https://api.github.com/user/emails', {
     headers: {
       Accept: 'application/vnd.github+json',
@@ -526,7 +540,9 @@ async function fetchGitHubPrimaryEmail(token: OAuthTokenResult): Promise<string 
       (entry as { verified?: unknown }).verified === true &&
       typeof (entry as { email?: unknown }).email === 'string',
   )
-  return primary?.email
+  // The `verified === true` filter above is GitHub's own signal for this
+  // address, so this lookup can claim what a generic fallback cannot.
+  return primary ? { email: primary.email, emailVerified: true } : undefined
 }
 
 export function createGitHubOAuthProviderConfig(input: OAuthProviderFactoryInput): OAuthProviderConfig {

--- a/packages/server/src/auth/oauth/index.ts
+++ b/packages/server/src/auth/oauth/index.ts
@@ -18,10 +18,22 @@ export interface OAuthProviderConfig {
   userInfoMethod?: 'GET' | 'POST'
   mapProfile?: (raw: Record<string, unknown>, token: OAuthTokenResult) => OAuthUserProfile
   /**
+   * Key in the userinfo response carrying the provider's own verification
+   * signal for the email address — Discord returns `verified`, for example.
+   * Defaults to OIDC's standard `email_verified` claim. Only boolean values
+   * are read; anything else leaves `profile.emailVerified` undefined. Ignored
+   * when `mapProfile` is set, since that owns the whole mapping.
+   */
+  emailVerifiedKey?: string
+  /**
    * Fallback used when the userinfo response carries no email — e.g. GitHub
    * returns `email: null` for accounts with a private email even when the
    * `user:email` scope was granted. Returns the email to use, or undefined
    * to leave the profile without one.
+   *
+   * Only return an address the provider has verified: the resulting profile
+   * reports `emailVerified: true`, since the returned address is a different
+   * one than `emailVerifiedKey` was read against.
    */
   fetchFallbackEmail?: (token: OAuthTokenResult) => Promise<string | undefined>
 }
@@ -40,6 +52,15 @@ export interface OAuthUserProfile {
   email?: string
   name?: string
   avatar?: string
+  /**
+   * Whether the provider itself verified `email`. Tri-state on purpose:
+   * `true` — the provider asserts the address is verified; `false` — it
+   * asserts it is not; `undefined` — the provider sends no such signal
+   * (GitHub's `/user`, for instance), so the consumer decides its own policy.
+   * Returning an email is not by itself a claim that it was checked, so
+   * treating `undefined` as verified is a decision, not a default.
+   */
+  emailVerified?: boolean
   token: OAuthTokenResult
   raw: Record<string, unknown>
 }
@@ -415,21 +436,37 @@ export async function fetchOAuthUserProfile(
   const raw = await response.json() as Record<string, unknown>
   const profile = provider.mapProfile
     ? provider.mapProfile(raw, token)
-    : defaultProfileFromUserInfo(raw, token)
+    : defaultProfileFromUserInfo(raw, token, provider.emailVerifiedKey)
 
   if (!profile.email && provider.fetchFallbackEmail) {
     const email = await provider.fetchFallbackEmail(token)
     if (email) {
-      return { ...profile, email }
+      // A fallback address is a different one than the userinfo response was
+      // read against, and the contract is that only verified addresses are
+      // returned — so the signal read from `raw` no longer applies to it.
+      return { ...profile, email, emailVerified: true }
     }
   }
 
   return profile
 }
 
+// OIDC's standard claim, so hand-configured OIDC providers get it without
+// declaring anything. Provider-specific keys belong on the provider config.
+const DEFAULT_EMAIL_VERIFIED_KEY = 'email_verified'
+
+function readEmailVerified(
+  raw: Record<string, unknown>,
+  key: string = DEFAULT_EMAIL_VERIFIED_KEY,
+): boolean | undefined {
+  const value = raw[key]
+  return typeof value === 'boolean' ? value : undefined
+}
+
 function defaultProfileFromUserInfo(
   raw: Record<string, unknown>,
   token: OAuthTokenResult,
+  emailVerifiedKey?: string,
 ): OAuthUserProfile {
   const idCandidate = raw.id ?? raw.sub
   const id = typeof idCandidate === 'string' || typeof idCandidate === 'number'
@@ -442,6 +479,7 @@ function defaultProfileFromUserInfo(
   return {
     id,
     email: typeof raw.email === 'string' ? raw.email : undefined,
+    emailVerified: readEmailVerified(raw, emailVerifiedKey),
     name: typeof raw.name === 'string' ? raw.name : undefined,
     avatar:
       typeof raw.avatar_url === 'string' ? raw.avatar_url
@@ -509,6 +547,7 @@ export function createGoogleOAuthProviderConfig(input: OAuthProviderFactoryInput
     tokenUrl: 'https://oauth2.googleapis.com/token',
     userInfoUrl: 'https://openidconnect.googleapis.com/v1/userinfo',
     scopes: input.scopes ?? ['openid', 'profile', 'email'],
+    emailVerifiedKey: 'email_verified',
   }
 }
 
@@ -519,6 +558,7 @@ export function createDiscordOAuthProviderConfig(input: OAuthProviderFactoryInpu
     tokenUrl: 'https://discord.com/api/oauth2/token',
     userInfoUrl: 'https://discord.com/api/users/@me',
     scopes: input.scopes ?? ['identify', 'email'],
+    emailVerifiedKey: 'verified',
   }
 }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -136,6 +136,7 @@ export type {
   OAuthProviderConfig,
   OAuthTokenResult,
   OAuthUserProfile,
+  OAuthFallbackEmail,
   OAuthStatePayload,
   OAuthStateStore,
   OAuthStateConfig,

--- a/packages/server/tests/auth/oauth.test.ts
+++ b/packages/server/tests/auth/oauth.test.ts
@@ -396,10 +396,44 @@ describe('OAuthManager', () => {
     const { state } = await manager.authorize('github')
     const profile = await manager.user('github', { code: 'auth-code', state })
 
-    // The fallback address is a different one than the userinfo response was
-    // read against, and GitHub's lookup only returns verified primaries.
+    // GitHub's lookup filters on the address's own `verified` flag, so it
+    // returns the object form and can claim verification for it.
     expect(profile.email).toBe('primary@example.com')
     expect(profile.emailVerified).toBe(true)
+  })
+
+  it('makes no verification claim for a fallback that returns a bare string', async () => {
+    const manager = new OAuthManager({ stateStore: new MemoryOAuthStateStore() })
+    manager.registerProvider('custom', {
+      ...githubConfig,
+      // The original signature every pre-existing implementation was written
+      // against. It promises nothing about verification, so neither do we.
+      fetchFallbackEmail: async () => 'from-elsewhere@example.com',
+    })
+
+    installOAuthFetchMock({ access_token: 'token-123' }, { id: 42, email: null })
+
+    const { state } = await manager.authorize('custom')
+    const profile = await manager.user('custom', { code: 'auth-code', state })
+
+    expect(profile.email).toBe('from-elsewhere@example.com')
+    expect(profile.emailVerified).toBeUndefined()
+  })
+
+  it('honors an explicit false from a fallback', async () => {
+    const manager = new OAuthManager({ stateStore: new MemoryOAuthStateStore() })
+    manager.registerProvider('custom', {
+      ...githubConfig,
+      fetchFallbackEmail: async () => ({ email: 'unverified@example.com', emailVerified: false }),
+    })
+
+    installOAuthFetchMock({ access_token: 'token-123' }, { id: 42, email: null })
+
+    const { state } = await manager.authorize('custom')
+    const profile = await manager.user('custom', { code: 'auth-code', state })
+
+    expect(profile.email).toBe('unverified@example.com')
+    expect(profile.emailVerified).toBe(false)
   })
 
   it('does not overwrite emailVerified set by a custom mapProfile', async () => {

--- a/packages/server/tests/auth/oauth.test.ts
+++ b/packages/server/tests/auth/oauth.test.ts
@@ -297,6 +297,134 @@ describe('OAuthManager', () => {
     expect(allowlisted.redirectTo).toBe('https://trusted.example.com/welcome')
   })
 
+  it('reports the provider verification signal from the configured key', async () => {
+    // Discord names it `verified`, not OIDC's `email_verified` — the preset
+    // declares the key so the shared mapper never has to know about it.
+    const discordConfig = createDiscordOAuthProviderConfig({
+      clientId: 'd-id',
+      clientSecret: 'd-secret',
+      redirectUri: 'https://app.example.com/auth/discord/callback',
+    })
+    const manager = new OAuthManager({ stateStore: new MemoryOAuthStateStore() })
+    manager.registerProvider('discord', discordConfig)
+
+    // Discord's token endpoint is `/api/oauth2/token`, which the shared
+    // `installOAuthFetchMock` helper would misroute to the userinfo body.
+    const fetchMock = mock(async (input: string) => {
+      const body = input.includes('/oauth2/token')
+        ? { access_token: 'token-123' }
+        : { id: '99', email: 'user@example.com', verified: false }
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+    ;(globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch
+
+    const { state } = await manager.authorize('discord')
+    const profile = await manager.user('discord', { code: 'auth-code', state })
+
+    expect(profile.email).toBe('user@example.com')
+    expect(profile.emailVerified).toBe(false)
+  })
+
+  it('reads the OIDC email_verified claim by default', async () => {
+    const oidcConfig: OAuthProviderConfig = {
+      clientId: 'oidc-id',
+      clientSecret: 'oidc-secret',
+      redirectUri: 'https://app.example.com/auth/oidc/callback',
+      authorizeUrl: 'https://provider.example.com/authorize',
+      tokenUrl: 'https://provider.example.com/access_token',
+      userInfoUrl: 'https://provider.example.com/userinfo',
+    }
+    const manager = new OAuthManager({ stateStore: new MemoryOAuthStateStore() })
+    manager.registerProvider('oidc', oidcConfig)
+
+    installOAuthFetchMock(
+      { access_token: 'token-123' },
+      { sub: 'user-1', email: 'user@example.com', email_verified: true },
+    )
+
+    const { state } = await manager.authorize('oidc')
+    expect((await manager.user('oidc', { code: 'auth-code', state })).emailVerified).toBe(true)
+
+    // Non-boolean values carry no signal — the field stays undefined rather
+    // than coercing a string into a verification claim.
+    installOAuthFetchMock(
+      { access_token: 'token-123' },
+      { sub: 'user-1', email: 'user@example.com', email_verified: 'true' },
+    )
+    const { state: second } = await manager.authorize('oidc')
+    expect((await manager.user('oidc', { code: 'auth-code', state: second })).emailVerified).toBeUndefined()
+  })
+
+  it('leaves emailVerified undefined when the provider sends no signal', async () => {
+    const manager = new OAuthManager({ stateStore: new MemoryOAuthStateStore() })
+    manager.registerProvider('github', githubConfig)
+
+    // GitHub's /user carries no verification field. Consumers must be able to
+    // tell "no signal" apart from "the provider says no".
+    installOAuthFetchMock(
+      { access_token: 'token-123' },
+      { id: 42, email: 'octo@example.com', name: 'Octo Cat' },
+    )
+
+    const { state } = await manager.authorize('github')
+    const profile = await manager.user('github', { code: 'auth-code', state })
+
+    expect(profile.email).toBe('octo@example.com')
+    expect(profile.emailVerified).toBeUndefined()
+  })
+
+  it('marks a fallback email as verified', async () => {
+    const manager = new OAuthManager({ stateStore: new MemoryOAuthStateStore() })
+    manager.registerProvider('github', githubConfig)
+
+    const fetchMock = mock(async (input: string) => {
+      const body = input.includes('/access_token')
+        ? { access_token: 'token-123' }
+        : input.includes('/user/emails')
+          ? [{ email: 'primary@example.com', primary: true, verified: true }]
+          : { id: 42, email: null }
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+    ;(globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch
+
+    const { state } = await manager.authorize('github')
+    const profile = await manager.user('github', { code: 'auth-code', state })
+
+    // The fallback address is a different one than the userinfo response was
+    // read against, and GitHub's lookup only returns verified primaries.
+    expect(profile.email).toBe('primary@example.com')
+    expect(profile.emailVerified).toBe(true)
+  })
+
+  it('does not overwrite emailVerified set by a custom mapProfile', async () => {
+    const manager = new OAuthManager({ stateStore: new MemoryOAuthStateStore() })
+    manager.registerProvider('custom', {
+      ...githubConfig,
+      emailVerifiedKey: 'verified',
+      mapProfile: (raw, token) => ({
+        id: String(raw.id),
+        email: 'mapped@example.com',
+        emailVerified: true,
+        token,
+        raw,
+      }),
+    })
+
+    installOAuthFetchMock({ access_token: 'token-123' }, { id: 42, verified: false })
+
+    const { state } = await manager.authorize('custom')
+    const profile = await manager.user('custom', { code: 'auth-code', state })
+
+    expect(profile.email).toBe('mapped@example.com')
+    expect(profile.emailVerified).toBe(true)
+  })
+
   it('exposes provider presets for google and discord', () => {
     const google = createGoogleOAuthProviderConfig({
       clientId: 'g-id',
@@ -311,5 +439,8 @@ describe('OAuthManager', () => {
 
     expect(google.authorizeUrl).toContain('accounts.google.com')
     expect(discord.authorizeUrl).toContain('discord.com')
+    // Each preset declares how to read its own verification signal.
+    expect(google.emailVerifiedKey).toBe('email_verified')
+    expect(discord.emailVerifiedKey).toBe('verified')
   })
 })


### PR DESCRIPTION
## Summary

This branch combines two pieces of related OAuth work:

- **`make:auth --oauth-only`**: a new flag for scaffolding a passwordless OAuth-only auth experience — omitting the password/registration/reset artifacts entirely rather than generating and then ignoring them. Includes a stale-scaffold report when converting an existing password app.
- **Provider email verification**: `OAuthUserProfile` gains a typed, tri-state `emailVerified?: boolean` field (`true` = provider asserts verified, `false` = provider asserts not verified, `undefined` = no signal). Provider configs declare where to read it via `emailVerifiedKey` (Google's `email_verified`, Discord's `verified`, defaulting to the OIDC standard claim). The scaffolded `OAuthController` now refuses to *create* an account when `emailVerified === false`, replacing what was previously provider-specific string matching against the untyped `profile.raw` bag in generated application code.
- `fetchFallbackEmail` can now return `{ email, emailVerified }` instead of a bare string, since the signal read from the userinfo response cannot vouch for an address that response didn't contain — the built-in GitHub fallback returns `emailVerified: true` because `/user/emails` only yields verified primary addresses; a bare string (every pre-existing implementation) claims nothing and leaves the field undefined.
- The reference blog example (`examples/blog`) picked up the same guard — it had an unqualified comment asserting Google emails are always verified, which is exactly the assumption this change refutes.

## Why

Returning an email from an OAuth provider is not a claim that the provider verified it. Without this check, an attacker could sign up with an unverified address they don't own, and the existing email-collision check would then permanently lock out the real owner's first sign-in.

## Test plan

- [x] `bun run build:clean`
- [x] `bun run typecheck`
- [x] `bun run test` (2510 pass, 0 fail)
- [x] `bun run audit:core-first`
- [x] `bun run audit:docs`
- [x] New unit tests for `OAuthManager`/provider presets (Discord/Google/GitHub key handling, undefined-signal case, fallback object vs bare-string form)
- [x] New CLI scaffold tests asserting the typed field is used and the guard isn't over-tightened to `!== true` (would reject GitHub users with no signal)
- [x] New blog example controller tests (reject unverified create, allow already-linked sign-in)

## Changesets

- `@guren/server`: minor
- `@guren/cli`: patch