### PR TITLE
fix(cli): make generated-file writes idempotent

### DIFF
--- a/.changeset/codegen-idempotent-writes.md
+++ b/.changeset/codegen-idempotent-writes.md
@@ -1,0 +1,20 @@
+---
+'@guren/cli': patch
+---
+
+fix: skip rewriting generated artifacts whose content is unchanged
+
+`guren codegen` wrote `.guren/pages.gen.ts`, `.guren/routes.gen.ts`,
+`.guren/data.gen.ts`, `.guren/channels.gen.ts`, `.guren/api-client.gen.ts`,
+and `types/generated/routes.d.ts` unconditionally, so every run bumped
+their mtimes even when the output was byte-identical. Since the Vite plugin
+regenerates on each save under `resources/js/pages/`,
+`app/Http/Resources/`, and `routes/web.ts`, a frontend-only edit churned
+files that backend code imports. The generators now compare the existing
+file first and skip the write when nothing changed; content that differs
+still goes through the usual `--force` guard.
+
+As a consequence, `guren routes:types` without `--force` no longer errors
+with "already exists. Use --force to overwrite." when the existing file is
+already byte-identical to what it would generate — identical content is not
+a clobber. Output that differs is still refused without `--force`.

--- a/packages/cli/src/api-client-types.ts
+++ b/packages/cli/src/api-client-types.ts
@@ -6,7 +6,7 @@
  * separate frontend applications.
  */
 import { relative, resolve } from 'node:path'
-import { writeFileSafe, type WriterOptions } from './utils'
+import { writeGeneratedFile, type WriterOptions } from './utils'
 import { schemaToTypeString } from './schema-type-extractor'
 
 export interface RouteDefinitionLike {
@@ -44,7 +44,7 @@ export async function generateApiClientTypes(
   const module = buildApiClientContent(definitions)
 
   const relativeTarget = relative(process.cwd(), outputFile) || outputFile
-  const outputPath = await writeFileSafe(relativeTarget, module, { force: options.force })
+  const outputPath = await writeGeneratedFile(relativeTarget, module, { force: options.force })
 
   return { outputPath }
 }

--- a/packages/cli/src/channel-types.ts
+++ b/packages/cli/src/channel-types.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile } from 'node:fs/promises'
 import { relative, resolve } from 'node:path'
 import { parse } from '@babel/parser'
-import { writeFileSafe, type WriterOptions } from './utils'
+import { writeGeneratedFile, type WriterOptions } from './utils'
 
 export interface GenerateChannelTypesOptions extends WriterOptions {
   appRoot?: string
@@ -41,7 +41,7 @@ export async function generateChannelTypes(
   })
 
   const relativeTarget = relative(process.cwd(), outputFile) || outputFile
-  const outputPath = await writeFileSafe(relativeTarget, module, { force: options.force })
+  const outputPath = await writeGeneratedFile(relativeTarget, module, { force: options.force })
 
   return { outputPath, channels }
 }

--- a/packages/cli/src/data-types.ts
+++ b/packages/cli/src/data-types.ts
@@ -8,7 +8,7 @@
 import { readdir, readFile } from 'node:fs/promises'
 import { dirname, extname, relative, resolve } from 'node:path'
 import { parse } from '@babel/parser'
-import { writeFileSafe, type WriterOptions } from './utils'
+import { writeGeneratedFile, type WriterOptions } from './utils'
 
 export interface ResourceDefinition {
   /** Class name (e.g. 'PostResource') */
@@ -50,7 +50,7 @@ export async function generateDataTypes(
   })
 
   const relativeTarget = relative(process.cwd(), outputFile) || outputFile
-  const outputPath = await writeFileSafe(relativeTarget, module, { force: options.force })
+  const outputPath = await writeGeneratedFile(relativeTarget, module, { force: options.force })
 
   return { outputPath, definitions }
 }

--- a/packages/cli/src/pages-types.ts
+++ b/packages/cli/src/pages-types.ts
@@ -1,6 +1,6 @@
 import { readdir } from 'node:fs/promises'
 import { dirname, extname, relative, resolve } from 'node:path'
-import { writeFileSafe, type WriterOptions } from './utils'
+import { writeGeneratedFile, type WriterOptions } from './utils'
 import { extractPageProps, type ExtractedPageProps } from './page-props-extractor'
 
 export type PageDefinition = {
@@ -57,7 +57,7 @@ export async function generatePageTypes(
   })
 
   const relativeTarget = relative(process.cwd(), outputFile) || outputFile
-  const outputPath = await writeFileSafe(relativeTarget, module, { force: options.force })
+  const outputPath = await writeGeneratedFile(relativeTarget, module, { force: options.force })
 
   return { outputPath, definitions }
 }

--- a/packages/cli/src/routes-types.ts
+++ b/packages/cli/src/routes-types.ts
@@ -1,5 +1,5 @@
 import { relative, resolve } from 'node:path'
-import { writeFileSafe, type WriterOptions } from './utils'
+import { writeGeneratedFile, type WriterOptions } from './utils'
 import { loadRouteDefinitions } from './load-routes'
 import {
   DECLARATION_MODULE_AUGMENTATION,
@@ -47,8 +47,8 @@ export async function generateRouteTypes(
 
   const relativeTarget = relative(process.cwd(), outputFile) || outputFile
   const relativeRuntimeTarget = relative(process.cwd(), runtimeOutputFile) || runtimeOutputFile
-  const outputPath = await writeFileSafe(relativeTarget, declaration, { force: options.force })
-  const runtimeOutputPath = await writeFileSafe(relativeRuntimeTarget, runtimeModule, { force: options.force })
+  const outputPath = await writeGeneratedFile(relativeTarget, declaration, { force: options.force })
+  const runtimeOutputPath = await writeGeneratedFile(relativeRuntimeTarget, runtimeModule, { force: options.force })
 
   return {
     outputPath,

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process'
-import { access, mkdir, writeFile } from 'node:fs/promises'
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 
 export interface WriterOptions {
@@ -76,6 +76,40 @@ export async function writeFileSafe(relativePath: string, contents: string, opti
   await mkdir(dirname(fullPath), { recursive: true })
   await writeFile(fullPath, contents, 'utf8')
   return fullPath
+}
+
+/**
+ * Writes a generated artifact, skipping the write entirely when the file
+ * already holds byte-identical content.
+ *
+ * Codegen re-runs on every save under `resources/js/pages/`,
+ * `app/Http/Resources/`, and `routes/web.ts` (see `vite/route-types.ts`), and
+ * controllers import the results (`@/.guren/pages.gen`). Rewriting unchanged
+ * output bumps those files' mtimes, which wakes up anything watching backend
+ * sources for no reason. Comparing first keeps a no-op run a real no-op.
+ *
+ * Differing content still goes through `writeFileSafe`, so the
+ * "already exists. Use --force to overwrite." guard is untouched — identical
+ * content is simply not a clobber worth guarding against.
+ */
+export async function writeGeneratedFile(
+  relativePath: string,
+  contents: string,
+  options: WriterOptions = {},
+): Promise<string> {
+  const fullPath = resolve(process.cwd(), relativePath)
+
+  try {
+    if ((await readFile(fullPath, 'utf8')) === contents) {
+      return fullPath
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
+  }
+
+  return writeFileSafe(relativePath, contents, options)
 }
 
 export async function writeFilesSafe(

--- a/packages/cli/tests/codegen-idempotency.test.ts
+++ b/packages/cli/tests/codegen-idempotency.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdir, stat, utimes, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { createTempWorkspace } from './helpers'
+import { generatePageTypes } from '../src/pages-types'
+import { generateRouteTypes } from '../src/routes-types'
+import { writeGeneratedFile } from '../src/utils'
+
+// Codegen re-runs on every save under resources/js/pages/,
+// app/Http/Resources/, and routes/web.ts (the Vite plugin's
+// handleHotUpdate). Controllers import the results, so rewriting
+// byte-identical output bumps the mtime of files a backend watcher is
+// watching — a frontend-only edit would restart the server (and with it the
+// in-process Vite dev server, killing the browser's HMR connection).
+//
+// Comparing timestamps across two writes is not enough on its own: both can
+// land inside one filesystem timestamp tick and compare equal even when the
+// write really happened. Each test below back-dates the artifact to a known
+// mtime first, so an unchanged timestamp proves no write occurred, and every
+// no-op case is paired with a control asserting the mtime does move when the
+// output would actually change.
+
+const BACKDATED_SECONDS = 1000
+const BACKDATED_MS = BACKDATED_SECONDS * 1000
+
+async function backdate(path: string): Promise<void> {
+  await utimes(path, BACKDATED_SECONDS, BACKDATED_SECONDS)
+}
+
+async function mtimeMs(path: string): Promise<number> {
+  return (await stat(path)).mtimeMs
+}
+
+async function writePage(dir: string, name: string, body: string): Promise<void> {
+  await mkdir(join(dir, 'resources/js/pages'), { recursive: true })
+  await writeFile(join(dir, `resources/js/pages/${name}`), body, 'utf8')
+}
+
+const ROUTES_FILE = `import type { Router } from '@guren/core'
+
+export function registerWebRoutes(router: Router): void {
+  router.get('/posts', () => new Response('ok')).name('posts.index')
+}
+`
+
+describe('codegen write idempotency', () => {
+  it('leaves pages.gen.ts untouched when the regenerated content is identical', async () => {
+    const workspace = await createTempWorkspace('guren-cli-idempotent-pages-')
+    try {
+      await writePage(workspace.dir, 'Home.tsx', 'export default function Home() { return null }\n')
+
+      const { outputPath } = await generatePageTypes({
+        appRoot: workspace.dir,
+        extractProps: false,
+        force: true,
+      })
+      await backdate(outputPath)
+
+      await generatePageTypes({ appRoot: workspace.dir, extractProps: false, force: true })
+
+      expect(await mtimeMs(outputPath)).toBe(BACKDATED_MS)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('rewrites pages.gen.ts when a page is added', async () => {
+    const workspace = await createTempWorkspace('guren-cli-idempotent-pages-changed-')
+    try {
+      await writePage(workspace.dir, 'Home.tsx', 'export default function Home() { return null }\n')
+
+      const { outputPath } = await generatePageTypes({
+        appRoot: workspace.dir,
+        extractProps: false,
+        force: true,
+      })
+      await backdate(outputPath)
+
+      await writePage(workspace.dir, 'About.tsx', 'export default function About() { return null }\n')
+      await generatePageTypes({ appRoot: workspace.dir, extractProps: false, force: true })
+
+      expect(await mtimeMs(outputPath)).toBeGreaterThan(BACKDATED_MS)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('leaves routes.gen.ts and routes.d.ts untouched when the regenerated content is identical', async () => {
+    const workspace = await createTempWorkspace('guren-cli-idempotent-routes-')
+    try {
+      await mkdir(join(workspace.dir, 'routes'), { recursive: true })
+      await writeFile(join(workspace.dir, 'routes/web.ts'), ROUTES_FILE, 'utf8')
+
+      const { outputPath, runtimeOutputPath } = await generateRouteTypes({
+        appRoot: workspace.dir,
+        force: true,
+      })
+      await backdate(outputPath)
+      await backdate(runtimeOutputPath)
+
+      await generateRouteTypes({ appRoot: workspace.dir, force: true })
+
+      expect(await mtimeMs(outputPath)).toBe(BACKDATED_MS)
+      expect(await mtimeMs(runtimeOutputPath)).toBe(BACKDATED_MS)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  // The route fixture can't be edited between two runs the way the pages
+  // fixture can: `loadRouteDefinitions` imports routes/web.ts, and the module
+  // cache hands back the first version for the rest of the process (the
+  // cache-busting query it appends is inert on Bun). Staling the *output*
+  // exercises the same branch — regeneration must still overwrite content
+  // that differs from what it produces.
+  it('rewrites route artifacts whose content differs from the regenerated output', async () => {
+    const workspace = await createTempWorkspace('guren-cli-idempotent-routes-changed-')
+    try {
+      await mkdir(join(workspace.dir, 'routes'), { recursive: true })
+      await writeFile(join(workspace.dir, 'routes/web.ts'), ROUTES_FILE, 'utf8')
+
+      const { outputPath, runtimeOutputPath } = await generateRouteTypes({
+        appRoot: workspace.dir,
+        force: true,
+      })
+
+      for (const path of [outputPath, runtimeOutputPath]) {
+        await writeFile(path, '// stale generated content\n', 'utf8')
+        await backdate(path)
+      }
+
+      await generateRouteTypes({ appRoot: workspace.dir, force: true })
+
+      for (const path of [outputPath, runtimeOutputPath]) {
+        expect(await mtimeMs(path)).toBeGreaterThan(BACKDATED_MS)
+        expect(await Bun.file(path).text()).not.toContain('stale generated content')
+      }
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})
+
+describe('writeGeneratedFile', () => {
+  it('creates the file (and its directory) when it does not exist', async () => {
+    const workspace = await createTempWorkspace('guren-cli-write-generated-new-')
+    try {
+      const path = await writeGeneratedFile('.guren/example.gen.ts', 'export const a = 1\n')
+
+      expect(await Bun.file(path).text()).toBe('export const a = 1\n')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('still refuses to overwrite differing content without force', async () => {
+    const workspace = await createTempWorkspace('guren-cli-write-generated-guard-')
+    try {
+      await mkdir(join(workspace.dir, '.guren'), { recursive: true })
+      await writeFile(join(workspace.dir, '.guren/example.gen.ts'), '// stale\n', 'utf8')
+
+      await expect(
+        writeGeneratedFile('.guren/example.gen.ts', 'export const a = 1\n'),
+      ).rejects.toThrow(/already exists/)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('accepts identical content without force, since that is not a clobber', async () => {
+    const workspace = await createTempWorkspace('guren-cli-write-generated-identical-')
+    try {
+      const contents = 'export const a = 1\n'
+      await mkdir(join(workspace.dir, '.guren'), { recursive: true })
+      await writeFile(join(workspace.dir, '.guren/example.gen.ts'), contents, 'utf8')
+      await backdate(join(workspace.dir, '.guren/example.gen.ts'))
+
+      const path = await writeGeneratedFile('.guren/example.gen.ts', contents)
+
+      expect(await Bun.file(path).text()).toBe(contents)
+      expect(await mtimeMs(path)).toBe(BACKDATED_MS)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- `writeFileSafe` wrote generated artifacts unconditionally, so `guren codegen` bumped the mtime of `.guren/pages.gen.ts`, `.guren/routes.gen.ts`, `.guren/data.gen.ts`, `.guren/channels.gen.ts`, `.guren/api-client.gen.ts`, and `types/generated/routes.d.ts` even when the regenerated content was byte-identical.
- The Vite route-types plugin re-runs codegen on every save under `resources/js/pages/`, `app/Http/Resources/`, and `routes/web.ts`, so a frontend-only edit churned files that controllers import (`@/.guren/pages.gen`) for no reason.
- Adds `writeGeneratedFile()` in `packages/cli/src/utils.ts` — reads the existing file first and skips the write when content is identical, otherwise delegates to `writeFileSafe()` (so the `--force` overwrite guard is unchanged for differing content). Kept separate from `writeFileSafe` itself to preserve the "already exists, use `--force`" semantics the `make:*` scaffolders depend on.
- Swaps all five codegen generators (`routes-types.ts`, `pages-types.ts`, `data-types.ts`, `channel-types.ts`, `api-client-types.ts`) to use the new helper. `make:*` scaffolders and `openapi`'s private copy are untouched.

**Semantic delta:** `guren routes:types` (and the other codegen commands) without `--force` no longer errors on an existing file whose content is already identical to what would be generated — identical content isn't a clobber. Output that differs is still refused without `--force`.

## Why

This is the blocking prerequisite for adding `--watch` to `dev:server` so backend hot-reload can be real: without idempotent writes, every frontend edit restarts the backend process, which also restarts the in-process Vite dev server and kills the browser's HMR connection.

## Test plan

- [x] `bun test packages/cli/tests` — 554 pass, including new `packages/cli/tests/codegen-idempotency.test.ts` (mtime-based idempotency + control cases proving regeneration still happens when content changes)
- [x] `bun run test:bun` — 2529 pass
- [x] `bun run test:examples` (blog, api, web) — all pass
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run audit:core-first` / `bun run audit:docs`
- [x] Manual end-to-end in `examples/blog`: ran `guren codegen` twice, confirmed all six generated files' mtimes were unchanged on the second run (back-dated to a known timestamp first, to rule out filesystem timestamp-resolution false positives)
- [x] Confirmed no code reads the mtime of these generated artifacts (checked `check.ts`, `doctor.ts`, the Vite plugin) — nothing depends on mtime changing on every regenerate