### PR TITLE
fix(plugin-cloudflare): close the gaps a real app hits on Workers

### DIFF
--- a/.changeset/cloudflare-build-migrations.md
+++ b/.changeset/cloudflare-build-migrations.md
@@ -1,0 +1,12 @@
+---
+'@guren/plugin-cloudflare': minor
+---
+
+`cloudflare:build` now bridges two real-world gaps found while migrating guren.dev to Workers:
+
+- **drizzle-kit ↔ wrangler migration layout**: drizzle-kit 1.x emits one `<timestamp>_<name>/migration.sql` folder per migration, but wrangler's `migrations_dir` only discovers flat `*.sql` files. The build flattens each folder into `<folder-name>.sql` under `.cloudflare/d1-migrations/` (plain `*.sql` files pass through, `meta/` is skipped), and the `wrangler.jsonc` scaffold points `migrations_dir` there. `flattenD1Migrations()` is exported for scripts. The opt-in wrangler contract test now uses the real nested layout.
+- **`public/index.html` no longer shadows the root route**: Workers Static Assets serves `index.html` for `/` before the worker runs; Guren apps only carry it as the dev-mode Vite shell, so the build drops it from the assets output.
+- **Dev-only modules no longer bloat (or break) the bundle**: `bun:sqlite`, `vite`, and the opt-in MCP endpoint's SDK and CLI generators sit in every app's graph behind dev-time branches, and bundlers follow them regardless. The build emits throwing stubs and aliases them, cutting the guren.dev worker from 4,282 KB to 1,899 KB gzipped against the 3 MB limit.
+- **The worker starts**: `NODE_ENV` and `import.meta.url` are substituted at build time. workerd leaves `import.meta.url` undefined, which breaks both Vite's `createRequire(import.meta.url)` in the SSR bundle and scaffolded `new URL(..., import.meta.url)` config — both at module scope, before anything is served. Substituting a literal is safe because Workers has no filesystem, so those paths are already meaningless there.
+
+**Upgrading an existing Cloudflare app:** the scaffold never overwrites your `wrangler.jsonc`, so the build now warns with the exact `alias`, `define`, and `migrations_dir` entries to add — without them the worker fails to start or silently skips migrations.

--- a/packages/plugin-cloudflare/src/build.test.ts
+++ b/packages/plugin-cloudflare/src/build.test.ts
@@ -67,6 +67,16 @@ describe('buildCloudflareOutput', () => {
     expect(existsSync(join(root, '.cloudflare/assets/assets/app-Abc123.js'))).toBe(true)
   })
 
+  test('should drop public/index.html so it cannot shadow the root route', async () => {
+    scaffoldApp(root)
+    writeFileSync(join(root, 'public/index.html'), '<div id="app"></div>')
+
+    await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
+
+    expect(existsSync(join(root, '.cloudflare/assets/index.html'))).toBe(false)
+    expect(existsSync(join(root, '.cloudflare/assets/robots.txt'))).toBe(true)
+  })
+
   test('should mirror built assets under the /public/assets base URL path', async () => {
     scaffoldApp(root)
 
@@ -109,7 +119,7 @@ describe('buildCloudflareOutput', () => {
     expect(config.main).toBe('.cloudflare/worker.js')
     expect(config.compatibility_flags).toEqual(['nodejs_compat'])
     expect(config.assets.directory).toBe('.cloudflare/assets')
-    expect(config.d1_databases[0].migrations_dir).toBe('db/migrations')
+    expect(config.d1_databases[0].migrations_dir).toBe('.cloudflare/d1-migrations')
 
     writeFileSync(configPath, '{ "name": "user-edited" }\n')
     await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
@@ -149,6 +159,124 @@ describe('buildCloudflareOutput', () => {
 
     await expect(buildCloudflareOutput({ rootDir: root, skipAppBuild: true })).rejects.toThrow(
       /app entry not found/,
+    )
+  })
+})
+
+describe('flattenD1Migrations', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'guren-cf-migrations-'))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  test('should flatten drizzle-kit folder migrations into wrangler-visible sql files', async () => {
+    scaffoldApp(root)
+    mkdirSync(join(root, 'db/migrations/20260725064448_third_storm'), { recursive: true })
+    writeFileSync(
+      join(root, 'db/migrations/20260725064448_third_storm/migration.sql'),
+      'CREATE TABLE `posts` (`id` integer PRIMARY KEY);\n',
+    )
+    mkdirSync(join(root, 'db/migrations/meta'), { recursive: true })
+    writeFileSync(join(root, 'db/migrations/meta/_journal.json'), '{}')
+    writeFileSync(join(root, 'db/migrations/0000_flat_legacy.sql'), 'SELECT 1;\n')
+
+    await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
+
+    const flattened = join(root, '.cloudflare/d1-migrations')
+    expect(readFileSync(join(flattened, '20260725064448_third_storm.sql'), 'utf8')).toContain('CREATE TABLE')
+    expect(readFileSync(join(flattened, '0000_flat_legacy.sql'), 'utf8')).toContain('SELECT 1')
+    expect(existsSync(join(flattened, 'meta'))).toBe(false)
+
+    const wrangler = JSON.parse(readFileSync(join(root, 'wrangler.jsonc'), 'utf8'))
+    expect(wrangler.d1_databases[0].migrations_dir).toBe('.cloudflare/d1-migrations')
+  })
+
+  test('should emit no directory when there are no migrations', async () => {
+    scaffoldApp(root)
+
+    await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
+
+    expect(existsSync(join(root, '.cloudflare/d1-migrations'))).toBe(false)
+  })
+})
+
+describe('workers runtime configuration', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'guren-cf-config-'))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  test('should alias dev-only modules to generated stubs and define NODE_ENV', async () => {
+    scaffoldApp(root)
+
+    await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
+
+    const config = JSON.parse(readFileSync(join(root, 'wrangler.jsonc'), 'utf8'))
+    expect(config.alias['bun:sqlite']).toBe('./.cloudflare/stub-bun-sqlite.js')
+    expect(config.alias.vite).toBe('./.cloudflare/stub-vite.js')
+    expect(config.alias['@guren/cli']).toBe('./.cloudflare/stub-guren-cli.js')
+    // The SDK is only ever imported through subpaths, which a package-name
+    // alias does not cover.
+    expect(config.alias['@modelcontextprotocol/sdk/server/mcp.js']).toBeDefined()
+    expect(config.define['process.env.NODE_ENV']).toBe('"production"')
+
+    expect(readFileSync(join(root, '.cloudflare/stub-bun-sqlite.js'), 'utf8')).toContain('throw new Error')
+    expect(existsSync(join(root, '.cloudflare/stub-vite.js'))).toBe(true)
+  })
+
+  test('should define import.meta.url so module-scope URL resolution survives', async () => {
+    scaffoldApp(root)
+
+    await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
+
+    // Both Vite's createRequire(import.meta.url) and scaffolded
+    // new URL(..., import.meta.url) run at module scope; workerd leaves the
+    // value undefined and the worker never starts without this.
+    const config = JSON.parse(readFileSync(join(root, 'wrangler.jsonc'), 'utf8'))
+    expect(config.define['import.meta.url']).toBe('"file:///worker.js"')
+  })
+
+  test('should warn when an existing wrangler config lacks build-owned keys', async () => {
+    scaffoldApp(root)
+    writeJson(join(root, 'wrangler.jsonc'), {
+      name: 'legacy',
+      main: '.cloudflare/worker.js',
+      d1_databases: [{ binding: 'DB', migrations_dir: 'db/migrations' }],
+    })
+    const warnings: string[] = []
+    const original = console.warn
+    console.warn = (message: string) => warnings.push(message)
+
+    try {
+      await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
+    } finally {
+      console.warn = original
+    }
+
+    const warning = warnings.join('\n')
+    expect(warning).toContain('alias')
+    expect(warning).toContain('process.env.NODE_ENV')
+    expect(warning).toContain('.cloudflare/d1-migrations')
+  })
+
+  test('should reject migrations that flatten to the same filename', async () => {
+    scaffoldApp(root)
+    mkdirSync(join(root, 'db/migrations/0000_clash'), { recursive: true })
+    writeFileSync(join(root, 'db/migrations/0000_clash/migration.sql'), 'SELECT 1;')
+    writeFileSync(join(root, 'db/migrations/0000_clash.sql'), 'SELECT 2;')
+
+    await expect(buildCloudflareOutput({ rootDir: root, skipAppBuild: true })).rejects.toThrow(
+      /both flatten to/,
     )
   })
 })

--- a/packages/plugin-cloudflare/src/build.ts
+++ b/packages/plugin-cloudflare/src/build.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { isAbsolute, relative, resolve, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
@@ -78,6 +78,14 @@ export async function buildCloudflareOutput(options: BuildCloudflareOutputOption
     cpSync(publicDir, resolve(out, 'assets'), { recursive: true })
   }
 
+  // Workers Static Assets serves index.html for `/` BEFORE the worker runs,
+  // which would shadow the app's root route. public/index.html is the
+  // dev-mode Vite shell in Guren apps — never a production page.
+  const shadowingIndex = resolve(out, 'assets/index.html')
+  if (existsSync(shadowingIndex)) {
+    rmSync(shadowingIndex)
+  }
+
   // Built assets are emitted with the Guren Vite plugin's derived base
   // `/public/assets/` (chunk imports, CSS urls, preloads self-reference that
   // prefix). Vercel resolves it with a `/public/(.*) -> /$1` rewrite; Workers
@@ -91,7 +99,137 @@ export async function buildCloudflareOutput(options: BuildCloudflareOutputOption
 
   writeFileSync(resolve(out, 'worker.js'), renderWorkerModule({ out, appEntry, ssrImport, assetEnv }))
 
+  flattenD1Migrations(resolve(root, 'db/migrations'), resolve(out, 'd1-migrations'))
+
+  writeDevOnlyStubs(out)
+
   scaffoldWranglerConfig(root, out, packageJson.name)
+}
+
+/**
+ * Modules that exist in every Guren app's graph but can never run on
+ * Workers, reached only through dev-time branches: `bun:sqlite` (the local
+ * sqlite ORM factory, opposite the D1 branch of `config/database.ts`) and
+ * `vite` (the dev asset server `Application` starts when serving locally).
+ * Bundlers follow those imports anyway — even dynamic ones — so without
+ * stubs the build either fails to resolve or ships megabytes of dev
+ * tooling. Each stub throws if a code path ever really reaches it.
+ */
+const MCP_UNAVAILABLE = 'The MCP endpoint is unavailable on Cloudflare Workers — it generates files on disk.'
+
+/**
+ * Stubs must carry the exact names their importers destructure: an empty
+ * module fails the bundle with "no matching export", not at runtime.
+ */
+function mcpStub(exportNames: string[]): string {
+  const throwing = exportNames
+    .map((name) => `export class ${name} { constructor() { throw new Error(${JSON.stringify(MCP_UNAVAILABLE)}) } }`)
+    .join('\n')
+  return `${throwing}\nexport default {}\n`
+}
+
+const DEV_ONLY_STUBS: Record<string, { file: string; source: string }> = {
+  'bun:sqlite': {
+    file: 'stub-bun-sqlite.js',
+    source:
+      'export const Database = class { constructor() { throw new Error("bun:sqlite is unavailable on Cloudflare Workers — use createD1Database().") } }\nexport default { Database }\n',
+  },
+  vite: {
+    file: 'stub-vite.js',
+    source:
+      'export function createServer() { throw new Error("The Vite dev server is unavailable on Cloudflare Workers — assets are served by Workers Static Assets.") }\nexport default { createServer }\n',
+  },
+  // The opt-in MCP endpoint's lazy imports still drag the CLI generators
+  // (and Babel) plus the MCP SDK into the bundle. `@guren/cli` is imported
+  // bare, but the SDK is only ever reached through subpaths — and an alias
+  // on a package name does not cover them, so each subpath is listed.
+  // `@guren/cli` is imported bare and only read through namespace property
+  // access, so an empty module suffices; the SDK subpaths are destructured
+  // and need their names present. A package-name alias does not cover
+  // subpaths, so each is listed.
+  '@guren/cli': {
+    file: 'stub-guren-cli.js',
+    source: `// ${MCP_UNAVAILABLE}\nexport {}\n`,
+  },
+  '@modelcontextprotocol/sdk/server/mcp.js': {
+    file: 'stub-mcp-server.js',
+    source: mcpStub(['McpServer', 'ResourceTemplate']),
+  },
+  '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js': {
+    file: 'stub-mcp-transport.js',
+    source: mcpStub(['WebStandardStreamableHTTPServerTransport']),
+  },
+}
+
+function writeDevOnlyStubs(out: string): void {
+  for (const stub of Object.values(DEV_ONLY_STUBS)) {
+    writeFileSync(resolve(out, stub.file), stub.source)
+  }
+}
+
+function devOnlyAliases(outRelative: string): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(DEV_ONLY_STUBS).map(([specifier, stub]) => [
+      specifier,
+      `./${outRelative}/${stub.file}`,
+    ]),
+  )
+}
+
+/**
+ * Wrangler's `migrations_dir` only discovers flat `*.sql` files, but
+ * drizzle-kit (1.x) emits one `<timestamp>_<name>/migration.sql` folder per
+ * migration. Flatten each folder into `<folder-name>.sql` (plain `*.sql`
+ * files pass through unchanged, `meta/` bookkeeping is skipped) so
+ * `wrangler d1 migrations apply` sees them in filename order. Regenerated on
+ * every build — run `cloudflare:build` after adding a migration.
+ */
+export function flattenD1Migrations(migrationsDir: string, outDir: string): void {
+  if (!existsSync(migrationsDir)) {
+    return
+  }
+
+  const entries = readdirSync(migrationsDir, { withFileTypes: true })
+  const copies: Array<{ from: string; to: string }> = []
+
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name.endsWith('.sql')) {
+      copies.push({ from: resolve(migrationsDir, entry.name), to: entry.name })
+      continue
+    }
+    if (entry.isDirectory() && entry.name !== 'meta') {
+      const nested = resolve(migrationsDir, entry.name, 'migration.sql')
+      if (existsSync(nested)) {
+        copies.push({ from: nested, to: `${entry.name}.sql` })
+      }
+    }
+  }
+
+  const seen = new Map<string, string>()
+  for (const copy of copies) {
+    const clash = seen.get(copy.to)
+    if (clash) {
+      throw new Error(
+        `Cloudflare build: migrations "${clash}" and "${copy.from}" both flatten to "${copy.to}". Rename one so wrangler sees a stable order.`,
+      )
+    }
+    seen.set(copy.to, copy.from)
+  }
+
+  // Rebuilt from scratch: a migration deleted or renamed upstream must not
+  // linger here, because wrangler would still discover and apply it.
+  if (existsSync(outDir)) {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+
+  if (copies.length === 0) {
+    return
+  }
+
+  mkdirSync(outDir, { recursive: true })
+  for (const copy of copies) {
+    cpSync(copy.from, resolve(outDir, copy.to))
+  }
 }
 
 function readPackageJson(root: string): PackageJsonLike {
@@ -245,6 +383,7 @@ function importSpecifier(fromDir: string, target: string): string {
 function scaffoldWranglerConfig(root: string, out: string, packageName: string | undefined): void {
   const configPath = resolve(root, 'wrangler.jsonc')
   if (existsSync(configPath)) {
+    warnMissingBuildOwnedKeys(configPath, relative(root, out).split(sep).join('/'))
     return
   }
 
@@ -256,13 +395,29 @@ function scaffoldWranglerConfig(root: string, out: string, packageName: string |
     main: `${outRelative}/worker.js`,
     compatibility_date: new Date().toISOString().slice(0, 10),
     compatibility_flags: ['nodejs_compat'],
+    alias: devOnlyAliases(outRelative),
+    define: {
+      // Statements in the generated worker cannot beat ESM import hoisting,
+      // and wrangler `vars` are not guaranteed to reach `process.env` before
+      // the app's module graph evaluates — framework and app code branch on
+      // NODE_ENV at module scope, so it is substituted at build time (the
+      // same approach the Vercel plugin takes).
+      'process.env.NODE_ENV': '"production"',
+      // workerd leaves `import.meta.url` undefined. Two things break on it:
+      // Vite's SSR bundle initializes `createRequire(import.meta.url)`, and
+      // scaffolded config resolves paths with `new URL(..., import.meta.url)`
+      // — both at module scope, so the worker dies before serving anything.
+      // Substituting a literal is safe precisely because Workers has no
+      // filesystem: every such path is already meaningless there.
+      'import.meta.url': '"file:///worker.js"',
+    },
     assets: { directory: `${outRelative}/assets` },
     d1_databases: [
       {
         binding: 'DB',
         database_name: appName,
         database_id: 'TODO: wrangler d1 create',
-        migrations_dir: 'db/migrations',
+        migrations_dir: `${outRelative}/d1-migrations`,
       },
     ],
     vars: { NODE_ENV: 'production' },
@@ -270,6 +425,43 @@ function scaffoldWranglerConfig(root: string, out: string, packageName: string |
 
   writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`)
   console.log(`Cloudflare build: scaffolded ${configPath} — fill in d1_databases[0].database_id before deploying.`)
+}
+
+/**
+ * The scaffold never overwrites an existing config, but `alias`, `define`,
+ * and `migrations_dir` are build-owned invariants pointing into the output
+ * directory — an app scaffolded before they existed deploys a worker that
+ * cannot resolve `bun:sqlite` or never applies its migrations. Name exactly
+ * what is missing rather than failing the build.
+ */
+function warnMissingBuildOwnedKeys(configPath: string, outRelative: string): void {
+  let config: Record<string, unknown>
+  try {
+    config = JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>
+  } catch {
+    // Comments or trailing commas — a real JSONC file we should not guess at.
+    return
+  }
+
+  const missing: string[] = []
+  const alias = config.alias as Record<string, string> | undefined
+  if (!alias || Object.keys(devOnlyAliases(outRelative)).some((key) => !(key in alias))) {
+    missing.push(`"alias": ${JSON.stringify(devOnlyAliases(outRelative))}`)
+  }
+  const define = config.define as Record<string, string> | undefined
+  if (!define?.['process.env.NODE_ENV']) {
+    missing.push('"define": { "process.env.NODE_ENV": "\\"production\\"" }')
+  }
+  const d1 = (config.d1_databases as Array<Record<string, unknown>> | undefined)?.[0]
+  if (d1 && d1.migrations_dir !== `${outRelative}/d1-migrations`) {
+    missing.push(`"migrations_dir": "${outRelative}/d1-migrations" (inside d1_databases[0])`)
+  }
+
+  if (missing.length > 0) {
+    console.warn(
+      `Cloudflare build: ${configPath} predates this plugin version. Add the following or the worker will fail to start or skip migrations:\n  ${missing.join('\n  ')}`,
+    )
+  }
 }
 
 function resolvePathLike(value: PathLike): string {

--- a/packages/plugin-cloudflare/src/index.ts
+++ b/packages/plugin-cloudflare/src/index.ts
@@ -26,5 +26,5 @@ export function cloudflarePlugin(config: CloudflarePluginConfig = {}): ServicePr
 export { captureWorkersEnv, getWorkersEnv, resetWorkersEnv } from './env'
 export { createWorkersHandler } from './handler'
 export type { WorkersAppLike, WorkersExecutionContext, WorkersHandler } from './handler'
-export { buildCloudflareOutput } from './build'
+export { buildCloudflareOutput, flattenD1Migrations } from './build'
 export type { BuildCloudflareOutputOptions } from './build'

--- a/packages/plugin-cloudflare/src/wrangler-migrations.test.ts
+++ b/packages/plugin-cloudflare/src/wrangler-migrations.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { flattenD1Migrations } from './build'
 
 // Opt-in end-to-end contract test: verifies wrangler applies drizzle-kit
 // generated SQL (tab indentation, backtick quoting, `--> statement-breakpoint`
@@ -41,22 +42,27 @@ describe.skipIf(!enabled)('wrangler d1 migrations (drizzle-kit SQL contract)', (
             binding: 'DB',
             database_name: 'guren-fmt-test',
             database_id: '00000000-0000-0000-0000-000000000000',
-            migrations_dir: 'db/migrations',
+            migrations_dir: 'd1-migrations',
           },
         ],
       }),
     )
     writeFileSync(join(root, 'worker.js'), 'export default { fetch() { return new Response("ok") } }\n')
 
+    // Real drizzle-kit 1.x layout: one folder per migration containing
+    // migration.sql — flattened for wrangler by flattenD1Migrations.
+    mkdirSync(join(root, 'db/migrations/0000_bright_dawn'), { recursive: true })
     writeFileSync(
-      join(root, 'db/migrations/0000_bright_dawn.sql'),
+      join(root, 'db/migrations/0000_bright_dawn/migration.sql'),
       'CREATE TABLE `posts` (\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\n\t`title` text NOT NULL\n);\n--> statement-breakpoint\nCREATE INDEX `posts_title_idx` ON `posts` (`title`);\n',
     )
+    mkdirSync(join(root, 'db/migrations/0001_calm_night'), { recursive: true })
     writeFileSync(
-      join(root, 'db/migrations/0001_calm_night.sql'),
+      join(root, 'db/migrations/0001_calm_night/migration.sql'),
       'ALTER TABLE `posts` ADD `slug` text;\n--> statement-breakpoint\nCREATE UNIQUE INDEX `posts_slug_unique` ON `posts` (`slug`);\n',
     )
     writeFileSync(join(root, 'db/migrations/meta/_journal.json'), '{"version":"7","dialect":"sqlite","entries":[]}\n')
+    flattenD1Migrations(join(root, 'db/migrations'), join(root, 'd1-migrations'))
   })
 
   afterAll(() => {


### PR DESCRIPTION
## Summary

Found by moving **guren.dev itself** onto Workers + D1 (the app migration follows in a separate PR). Each of these either failed the build or killed the worker at startup, and any Guren app would hit them.

### Dev-only modules were being bundled

`bun:sqlite`, `vite`, and the opt-in MCP endpoint's SDK + CLI generators all sit in every app's module graph behind dev-only branches — the sqlite half of `config/database.ts`, the dev asset server `Application` starts locally, the `GUREN_MCP` endpoint. Bundlers follow those imports regardless of the branch, so the build either couldn't resolve them (`bun:sqlite`) or shipped megabytes of dev tooling. `cloudflare:build` now emits throwing stubs and aliases them in the wrangler config.

**Measured on guren.dev: 4,282 KB → 1,899 KB gzipped**, against the 3 MB Free-plan limit.

### The worker died during module init

Vite's SSR output calls `createRequire(import.meta.url)` for CJS interop, and workerd leaves `import.meta.url` undefined — so the worker threw before serving a single request. `NODE_ENV` and `import.meta.url` are now substituted at build time via wrangler `define`:

- ESM import hoisting means the app's module graph evaluates *before* any statement the generated entry could run, so a runtime assignment can't win.
- wrangler `vars` are not guaranteed to reach `process.env` in time either — framework and app code branch on `NODE_ENV` at module scope (asset URLs, prerendered content).
- `ssr.target: 'webworker'` is not an option: Vite 8 moved it to the Environment API.

### D1 migrations silently went unapplied

drizzle-kit emits `<timestamp>_<name>/migration.sql` folders; wrangler's `migrations_dir` only discovers flat `.sql` files. Migrations are flattened into `.cloudflare/d1-migrations` and `migrations_dir` points there. **The opt-in wrangler contract test now uses the real nested layout** instead of hand-written flat fixtures — the drift an earlier review warned about turned out to be real.

### `public/index.html` shadowed the root route

It's the dev-mode Vite shell, but Workers Static Assets served it for `/` before the worker ran. Dropped from the assets output.

## Testing

- plugin-cloudflare: 28 tests (new coverage for migration flattening, the index.html exclusion, and the nested drizzle layout end-to-end against wrangler's local D1)
- `bun run test:bun`: 2,628 tests, 0 fail; `typecheck` clean
- **Verified end to end under `wrangler dev` with local D1**: home, docs, llms.txt, sitemap, blog, 404s and the admin redirect all behave, with SSR markup in the response

Refs: RFC 0003