### PR TITLE
feat(cli): scaffold and harness support for docs/spec conventions (RFC 0004 Part 4)

### DIFF
--- a/.changeset/harness-docs-spec.md
+++ b/.changeset/harness-docs-spec.md
@@ -12,7 +12,9 @@ feat: teach scaffolds and the agent harness the docs/spec conventions
   to docs, schema, models, controllers, routes, and pages): start
   entity work with `guren context <Entity>`, keep doc frontmatter
   current when moving files, regenerate `docs/spec/` views after
-  structural changes. The harness `CLAUDE.md` and MCP tool table now
-  cover `guren context <Entity>`, `spec:generate`, `make:adr`, and
-  `guren_entity_context`. Existing apps pick this up via
-  `bunx guren agent:sync`.
+  structural changes. Existing apps receive the rule via
+  `bunx guren agent:sync`. The harness `CLAUDE.md` (start-here block
+  and MCP tool table, now covering `guren context <Entity>`,
+  `spec:generate`, `make:adr`, and `guren_entity_context`) applies to
+  new `agent:init` installs — `CLAUDE.md` is user-owned and never
+  overwritten by sync.

--- a/.changeset/harness-docs-spec.md
+++ b/.changeset/harness-docs-spec.md
@@ -1,0 +1,18 @@
+---
+'@guren/cli': minor
+'@guren/create-app': minor
+---
+
+feat: teach scaffolds and the agent harness the docs/spec conventions
+
+- New apps ship with `docs/adr/0001-record-architecture-decisions.md`,
+  a seed ADR explaining the frontmatter convention, `make:adr`, and the
+  link checking `guren check` performs.
+- The agent harness gains `.claude/rules/docs-and-spec.md` (glob-scoped
+  to docs, schema, models, controllers, routes, and pages): start
+  entity work with `guren context <Entity>`, keep doc frontmatter
+  current when moving files, regenerate `docs/spec/` views after
+  structural changes. The harness `CLAUDE.md` and MCP tool table now
+  cover `guren context <Entity>`, `spec:generate`, `make:adr`, and
+  `guren_entity_context`. Existing apps pick this up via
+  `bunx guren agent:sync`.

--- a/packages/cli/templates/agent/.claude/rules/docs-and-spec.md
+++ b/packages/cli/templates/agent/.claude/rules/docs-and-spec.md
@@ -1,0 +1,72 @@
+---
+description: Linked docs (ADRs, business context) and generated spec views — how they connect to code and stay verified
+globs:
+  - "docs/**"
+  - "db/schema.ts"
+  - "app/Models/**"
+  - "app/Http/Controllers/**"
+  - "routes/**"
+  - "resources/js/pages/**"
+  - "modules/**"
+---
+
+# Docs & Spec Views
+
+## Start entity work with the context bundle
+
+Before touching a model or its surroundings, pull everything the project
+knows about it in one shot:
+
+```bash
+bunx guren context User          # model, routes, controller, pages, resource, policy, linked docs
+bunx guren context User --json   # machine-readable
+```
+
+Same-named models across modules: add `--module <name>` (`--module app`
+selects the application root). The **Linked docs** section lists the ADRs
+and context documents that govern the entity — read them before changing
+behavior they describe.
+
+## Linking docs to code
+
+Markdown under `docs/` (and `modules/<name>/docs/`) declares what it
+governs via frontmatter:
+
+```yaml
+---
+kind: adr                # adr | context | guide
+status: accepted         # adr only: draft | accepted | superseded
+entities: [User, Invoice]
+related:
+  - app/Http/Controllers/InvoiceController.ts
+  - modules/billing/**
+last_reviewed: 2026-07-25
+---
+```
+
+- `entities` links by model class name (survives file moves) — this is
+  what `guren context <Entity>` traverses.
+- Code can link back with a JSDoc tag: `/** @docs docs/adr/0007-billing.md */`.
+- Record decisions with `bunx guren make:adr "Title"` — numbered file
+  under `docs/adr/` with prefilled frontmatter. `--entity <Model>` fills
+  `entities:`/`related:` automatically.
+
+`guren check` validates these links: a renamed `related` path, an unknown
+entity, or a broken `@docs` tag fails. **After implementing a decision,
+add the entity to its ADR's `entities:` list.** After renaming or moving
+files a doc references, update the doc's frontmatter in the same change.
+
+## Generated spec views (docs/spec/)
+
+If `docs/spec/` exists, it holds four generated views (ER diagram, domain
+model, screens, module map). They are derived from code and drift-gated:
+
+```bash
+bunx guren spec:generate     # regenerate after schema/model/route/page changes
+bunx guren check --spec      # verify (CI gate; exits non-zero on drift)
+```
+
+When `guren check` reports `docs/spec/*.md is out of date`, run
+`bunx guren spec:generate` and include the regenerated files in the same
+commit as the code change — the diff shows reviewers exactly what your
+change did to the spec. Never edit `docs/spec/` files by hand.

--- a/packages/cli/templates/agent/.claude/rules/docs-and-spec.md
+++ b/packages/cli/templates/agent/.claude/rules/docs-and-spec.md
@@ -51,14 +51,16 @@ last_reviewed: 2026-07-25
   under `docs/adr/` with prefilled frontmatter. `--entity <Model>` fills
   `entities:`/`related:` automatically.
 
-`guren check` validates these links: a renamed `related` path, an unknown
-entity, or a broken `@docs` tag fails. **After implementing a decision,
-add the entity to its ADR's `entities:` list.** After renaming or moving
-files a doc references, update the doc's frontmatter in the same change.
+`guren check` reports broken links — a renamed `related` path, an
+unknown entity, a dangling `@docs` tag — as failures in its output;
+`guren check --docs` is the CI gate (exits non-zero on them). **After
+implementing a decision, add the entity to its ADR's `entities:`
+list.** After renaming or moving files a doc references, update the
+doc's frontmatter in the same change.
 
 ## Generated spec views (docs/spec/)
 
-If `docs/spec/` exists, it holds four generated views (ER diagram, domain
+If `docs/spec/` exists, it holds generated views (ER diagram, domain
 model, screens, module map). They are derived from code and drift-gated:
 
 ```bash

--- a/packages/cli/templates/agent/CLAUDE.md
+++ b/packages/cli/templates/agent/CLAUDE.md
@@ -9,9 +9,12 @@ A fullstack TypeScript application built with the Guren framework (Laravel-inspi
 Before exploring `node_modules`, use the built-in introspection commands:
 
 ```bash
-bunx guren context     # project map: models, routes, controllers, pages (add --json for JSON)
-bunx guren check       # validate route ↔ controller ↔ page consistency — run after changes
-bunx guren codegen     # regenerate .guren/*.gen.ts typed manifests (also runs via `bun run dev`)
+bunx guren context         # project map: models, routes, controllers, pages (add --json for JSON)
+bunx guren context User    # everything about one entity: model, routes, pages, linked docs — start entity work here
+bunx guren check           # validate route ↔ controller ↔ page consistency, doc links, and spec freshness — run after changes
+bunx guren codegen         # regenerate .guren/*.gen.ts typed manifests (also runs via `bun run dev`)
+bunx guren spec:generate   # regenerate docs/spec/ views (ER, domain, screens, modules) after schema/model/route changes
+bunx guren make:adr "..."  # record an architecture decision under docs/adr/ (--entity <Model> links it)
 ```
 
 This project ships with an agent harness wired into `.claude/settings.json`:
@@ -24,7 +27,8 @@ failures back immediately. Framework-managed files (`.claude/rules`, `skills`,
 Detailed, verified API rules live in `.claude/rules/*.md` and load automatically
 based on the files you are editing (glob-scoped): `orm-models.md` (models, queries,
 relations), `controllers-http.md` (validation, Inertia, auth), `routes-codegen.md`
-(route options, schema binding, codegen), `testing.md` (TestApp assertions).
+(route options, schema binding, codegen), `testing.md` (TestApp assertions),
+`docs-and-spec.md` (linked ADRs/docs, generated spec views).
 Read the matching rule file before reading `node_modules/@guren/*` — it covers the
 exact signatures.
 
@@ -115,7 +119,8 @@ http://localhost:3333/_guren/mcp
 | Tool | 説明 |
 |------|------|
 | `guren_get_context` | プロジェクト構造マップ（models, routes, pages, controllers等） |
-| `guren_check` | route↔controller↔page の整合性検証 |
+| `guren_entity_context` | エンティティ単位のコンテキストバンドル（model, routes, pages, linked docs） |
+| `guren_check` | route↔controller↔page の整合性・docリンク・spec鮮度の検証 |
 | `guren_list_models` | モデル一覧（リレーション、soft deletes、auth trait含む） |
 | `guren_generate_guidelines` | プロジェクト固有コーディング規約の自動生成 |
 | `guren_doctor` | プロジェクト健全性チェック + 次のアクション提案 |

--- a/packages/cli/tests/agent-harness.test.ts
+++ b/packages/cli/tests/agent-harness.test.ts
@@ -25,6 +25,7 @@ describe('installAgentHarness', () => {
     expect(result.written).toContain('.claude/settings.json')
     expect(result.written).toContain('.claude/hooks/check-after-edit.ts')
     expect(result.written).toContain('.claude/rules/orm-models.md')
+    expect(result.written).toContain('.claude/rules/docs-and-spec.md')
     expect(result.written).toContain('.claude/skills/dev-workflow/SKILL.md')
     expect(result.written).toContain('.claude/agents/code-review.md')
 

--- a/packages/create-app/templates/api-only/docs/adr/0001-record-architecture-decisions.md
+++ b/packages/create-app/templates/api-only/docs/adr/0001-record-architecture-decisions.md
@@ -34,13 +34,14 @@ Each ADR declares what it governs in its frontmatter:
 - `status:` — `draft` → `accepted`; mark `superseded` when replaced
   (and write the replacement).
 
-`bunx guren check` verifies these links: renaming a file a doc points
-at, or removing a model a doc names, fails the check until the doc is
-updated. Keep frontmatter current in the same change that moves the
-code.
+Once declared, the links are verified: `bunx guren check` reports a
+renamed file a doc points at, or a removed model a doc names, as a
+failure, and `bunx guren check --docs` gates CI on it (non-zero exit).
+Keep frontmatter current in the same change that moves the code.
 
 ## Consequences
 
 Decisions stay discoverable from the code they govern, at the cost of
-writing them down and keeping links fresh — which the checker enforces,
-so the links can be trusted.
+writing them down and keeping links fresh — declared links are checked,
+so they can be trusted. (An ADR with no links, like this one, is valid;
+it simply isn't surfaced by `guren context`.)

--- a/packages/create-app/templates/api-only/docs/adr/0001-record-architecture-decisions.md
+++ b/packages/create-app/templates/api-only/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,46 @@
+---
+kind: adr
+status: accepted
+entities: []
+related: []
+---
+
+# Record architecture decisions
+
+## Context
+
+Code shows *what* the system does; it cannot show *why*. Decisions —
+business rules, trade-offs, rejected alternatives — live in people's
+heads and get lost. AI coding agents working on this codebase have the
+same problem: without recorded decisions they can only infer intent.
+
+## Decision
+
+We record significant decisions as numbered ADRs in this directory,
+created with:
+
+```bash
+bunx guren make:adr "Title of the decision"
+bunx guren make:adr "Title" --entity Invoice   # prefills the links below
+```
+
+Each ADR declares what it governs in its frontmatter:
+
+- `entities: [Invoice]` — model class names the decision affects.
+  `bunx guren context Invoice` then surfaces this ADR to anyone (human
+  or agent) working on that model.
+- `related: [app/Http/Controllers/InvoiceController.ts]` — files or
+  globs the decision touches.
+- `status:` — `draft` → `accepted`; mark `superseded` when replaced
+  (and write the replacement).
+
+`bunx guren check` verifies these links: renaming a file a doc points
+at, or removing a model a doc names, fails the check until the doc is
+updated. Keep frontmatter current in the same change that moves the
+code.
+
+## Consequences
+
+Decisions stay discoverable from the code they govern, at the cost of
+writing them down and keeping links fresh — which the checker enforces,
+so the links can be trusted.

--- a/packages/create-app/templates/default/docs/adr/0001-record-architecture-decisions.md
+++ b/packages/create-app/templates/default/docs/adr/0001-record-architecture-decisions.md
@@ -34,13 +34,14 @@ Each ADR declares what it governs in its frontmatter:
 - `status:` — `draft` → `accepted`; mark `superseded` when replaced
   (and write the replacement).
 
-`bunx guren check` verifies these links: renaming a file a doc points
-at, or removing a model a doc names, fails the check until the doc is
-updated. Keep frontmatter current in the same change that moves the
-code.
+Once declared, the links are verified: `bunx guren check` reports a
+renamed file a doc points at, or a removed model a doc names, as a
+failure, and `bunx guren check --docs` gates CI on it (non-zero exit).
+Keep frontmatter current in the same change that moves the code.
 
 ## Consequences
 
 Decisions stay discoverable from the code they govern, at the cost of
-writing them down and keeping links fresh — which the checker enforces,
-so the links can be trusted.
+writing them down and keeping links fresh — declared links are checked,
+so they can be trusted. (An ADR with no links, like this one, is valid;
+it simply isn't surfaced by `guren context`.)

--- a/packages/create-app/templates/default/docs/adr/0001-record-architecture-decisions.md
+++ b/packages/create-app/templates/default/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,46 @@
+---
+kind: adr
+status: accepted
+entities: []
+related: []
+---
+
+# Record architecture decisions
+
+## Context
+
+Code shows *what* the system does; it cannot show *why*. Decisions —
+business rules, trade-offs, rejected alternatives — live in people's
+heads and get lost. AI coding agents working on this codebase have the
+same problem: without recorded decisions they can only infer intent.
+
+## Decision
+
+We record significant decisions as numbered ADRs in this directory,
+created with:
+
+```bash
+bunx guren make:adr "Title of the decision"
+bunx guren make:adr "Title" --entity Invoice   # prefills the links below
+```
+
+Each ADR declares what it governs in its frontmatter:
+
+- `entities: [Invoice]` — model class names the decision affects.
+  `bunx guren context Invoice` then surfaces this ADR to anyone (human
+  or agent) working on that model.
+- `related: [app/Http/Controllers/InvoiceController.ts]` — files or
+  globs the decision touches.
+- `status:` — `draft` → `accepted`; mark `superseded` when replaced
+  (and write the replacement).
+
+`bunx guren check` verifies these links: renaming a file a doc points
+at, or removing a model a doc names, fails the check until the doc is
+updated. Keep frontmatter current in the same change that moves the
+code.
+
+## Consequences
+
+Decisions stay discoverable from the code they govern, at the cost of
+writing them down and keeping links fresh — which the checker enforces,
+so the links can be trusted.

--- a/packages/create-app/tests/cli.test.ts
+++ b/packages/create-app/tests/cli.test.ts
@@ -79,6 +79,13 @@ describe('create-guren-app CLI', () => {
       const readme = await readFile(join(appRoot, 'README.md'), 'utf8')
       expect(readme).toContain('# My App')
 
+      const seedAdr = await readFile(
+        join(appRoot, 'docs/adr/0001-record-architecture-decisions.md'),
+        'utf8',
+      )
+      expect(seedAdr).toContain('kind: adr')
+      expect(seedAdr).toContain('make:adr')
+
       // Harness install requires dependencies; without install we point at agent:init
       await expect(access(join(appRoot, 'CLAUDE.md'))).rejects.toThrow()
       expect(warnMock.mock.calls.some((call) => call.join(' ').includes('bunx guren agent:init'))).toBe(true)


### PR DESCRIPTION
## Summary

Completes the **RFC 0004 rollout** (`rfcs/0004-spec-anchored-development.md`, final step): new apps and the agent harness now teach the doc-linking and spec-view conventions instead of leaving them opt-in-and-undiscovered.

- **Seed ADR in scaffolds** — `create-app` templates (default + api-only; the SSR blueprint overlays default) ship `docs/adr/0001-record-architecture-decisions.md`: a working example of the frontmatter convention that explains `make:adr`, `entities:`/`related:` links, and the validation `guren check` performs. Because it ships with empty links, it activates the docs check suite without failing it.
- **New harness rule** — `.claude/rules/docs-and-spec.md`, glob-scoped to `docs/`, schema, models, controllers, routes, and pages. Teaches the three habits the RFC's rollout step calls for: `guren context <Entity>` before entity work, frontmatter updates in the same change that moves linked files, and `spec:generate` + commit after structural changes.
- **Harness CLAUDE.md refresh** — the start-here command block and MCP tool table now cover `guren context <Entity>`, `spec:generate`, `make:adr`, and `guren_entity_context`. Existing apps pick everything up via `bunx guren agent:sync` (the rule lands under the framework-managed prefix).

## Verification

- `bun run test:bun` (2715 pass / 0 fail), `audit:core-first`, `audit:docs` all green; harness and create-app tests assert the new files.
- Dogfooded: `agent:init` into a scratch directory ships `docs-and-spec.md` alongside the existing rules, and `guren check --docs` on a fresh scaffold stays green (seed ADR activates the suite without tripping it).

Refs: RFC 0004