### PR TITLE
fix(server): make guren_codegen regenerate changed artifacts

### DIFF
--- a/.changeset/mcp-codegen-force.md
+++ b/.changeset/mcp-codegen-force.md
@@ -1,0 +1,23 @@
+---
+'@guren/server': minor
+---
+
+fix: make the `guren_codegen` MCP tool regenerate changed artifacts
+
+The tool called the CLI generators without `force`, so as soon as a route
+changed — the one case where regeneration matters — the writer refused with
+"already exists. Use --force to overwrite." A blanket `catch {}` per generator
+swallowed that, and the tool reported `{"generated": []}` as a success. It now
+passes `force: true`, the way `guren codegen` already does, since these
+outputs are generated artifacts that exist to be overwritten.
+
+Skips are no longer silent. The response carries a `skipped` array naming each
+artifact and the reason it was not produced, and a generator that throws now
+marks the whole run as an error even when other artifacts were written. A
+generator that simply found nothing to describe — an app with no page
+components, for instance — is reported as a skip rather than a failure.
+
+The tool also generates `.guren/api-client.gen.ts`, which it previously left
+out even though `guren codegen` produces it. Because the API client is built
+from the route manifest, an agent that added a route through MCP got every
+other artifact refreshed while the client silently went stale.

--- a/packages/server/src/mcp/McpServiceProvider.ts
+++ b/packages/server/src/mcp/McpServiceProvider.ts
@@ -44,9 +44,18 @@ export class McpServiceProvider extends ServiceProvider {
     // than failing outright.
     //
     // guren_codegen (generateRouteTypes et al.) has the same staleness
-    // exposure but is deliberately left in-process here: it already fails on
-    // any repeat call because it writes without `force`, so it needs that
-    // fixed before freshness would matter — tracked separately.
+    // exposure and is still left in-process here, so the route-derived
+    // artifacts it writes — routes.gen.ts, routes.d.ts, api-client.gen.ts —
+    // describe the graph as of this process's first route load. It now writes
+    // with `force`, so that snapshot overwrites what is on disk instead of
+    // failing the way it used to. Page, data, and channel manifests are
+    // unaffected: those generators re-scan the filesystem on every call.
+    //
+    // An app using the default Vite setup repairs the difference on the next
+    // save, because routeTypesPlugin's handleHotUpdate spawns `guren codegen`
+    // in a child process. A dev server running without that plugin has no
+    // such repair, and there MCP-driven codegen is the only writer. Moving
+    // codegen behind the same child process is tracked separately.
     const routeAwareCli: GurenCliApi = cli.createFreshContextApi
       ? { ...cli, ...cli.createFreshContextApi() }
       : cli

--- a/packages/server/src/mcp/create-mcp-server.ts
+++ b/packages/server/src/mcp/create-mcp-server.ts
@@ -2,6 +2,32 @@ import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mc
 import { z } from 'zod'
 
 /**
+ * Options the `.guren/*.gen.ts` generators are called with. Only `force`
+ * reaches them — they resolve every path against the process cwd, which the
+ * codegen tool sets before calling. `cwd` rides along to name the project the
+ * call is for.
+ */
+export interface CodegenOptions {
+  cwd: string
+  force?: boolean
+}
+
+/**
+ * What a generator reports back. An empty `outputPath` means the generator
+ * found nothing to describe and wrote no file (a project with no page
+ * components, for instance).
+ *
+ * `definitions` is the route manifest `generateRouteTypes` builds. It stays
+ * opaque here — this package only carries it from one CLI call to the next
+ * (`generateApiClientTypes` consumes it) and never reads inside it, so
+ * mirroring the CLI's route shape would only create something to keep in sync.
+ */
+export interface CodegenResult {
+  outputPath?: string
+  definitions?: unknown[]
+}
+
+/**
  * CLI functions that the MCP server wraps.
  * These are injected at runtime to avoid circular dependencies
  * (@guren/server cannot depend on @guren/cli directly).
@@ -52,10 +78,18 @@ export interface GurenCliApi {
   makeView(name: string, opts: { force?: boolean }): Promise<string | string[]>
   makeTest(name: string, opts: { force?: boolean }): Promise<string | string[]>
   makeRoute(name: string, opts: { force?: boolean }): Promise<string | string[]>
-  generateRouteTypes(opts: { cwd: string }): Promise<unknown>
-  generatePageTypes(opts: { cwd: string }): Promise<unknown>
-  generateDataTypes(opts: { cwd: string }): Promise<unknown>
-  generateChannelTypes(opts: { cwd: string }): Promise<unknown>
+  generateRouteTypes(opts: CodegenOptions): Promise<CodegenResult | void>
+  generatePageTypes(opts: CodegenOptions): Promise<CodegenResult | void>
+  generateDataTypes(opts: CodegenOptions): Promise<CodegenResult | void>
+  generateChannelTypes(opts: CodegenOptions): Promise<CodegenResult | void>
+  /**
+   * Takes the route manifest `generateRouteTypes` returns, so it can only run
+   * after that succeeded.
+   */
+  generateApiClientTypes(
+    definitions: unknown[],
+    opts: CodegenOptions,
+  ): Promise<CodegenResult | void>
   /**
    * Route-dependent context generation that re-runs the CLI in a fresh
    * process. Optional because `@guren/cli` is resolved from the app at
@@ -272,44 +306,74 @@ export function createMcpServer(options: CreateMcpServerOptions): McpServer {
 
   server.tool(
     'guren_codegen',
-    'Generate type-safe route, page, data, and channel type manifests (.guren/*.gen.ts files).',
+    'Generate the type-safe route, page, data, and channel manifests plus the API client (.guren/ and types/generated/).',
     {},
     async () => {
       const originalCwd = process.cwd()
       try {
         process.chdir(cwd)
+
+        // `force` matches what `guren codegen` passes: every artifact below is
+        // generated output, so overwriting it is the whole point — without it
+        // the writer rejects each one as "already exists" from the second run
+        // onwards.
+        const options: CodegenOptions = { cwd, force: true }
+
         const generated: string[] = []
+        const skipped: Array<{ artifacts: string[]; reason: string }> = []
+        let failed = false
 
-        try {
-          await cli.generateRouteTypes({ cwd })
-          generated.push('.guren/routes.gen.ts')
-        } catch {
-          /* skip if routes not configured */
+        /**
+         * Runs one generator and files its artifacts under `generated` or
+         * `skipped`. A generator that returns an empty `outputPath` had
+         * nothing to describe, which is a normal shape for a project rather
+         * than a failure; a throw is the opposite, and is what `isError`
+         * reports on.
+         */
+        const run = async (
+          artifacts: string[],
+          generate: () => Promise<CodegenResult | void>,
+        ): Promise<CodegenResult | void> => {
+          try {
+            const result = await generate()
+            if (result?.outputPath === '') {
+              skipped.push({ artifacts, reason: 'nothing to generate' })
+            } else {
+              generated.push(...artifacts)
+            }
+            return result
+          } catch (error) {
+            failed = true
+            skipped.push({
+              artifacts,
+              reason: error instanceof Error ? error.message : String(error),
+            })
+          }
         }
 
-        try {
-          await cli.generatePageTypes({ cwd })
-          generated.push('.guren/pages.gen.ts')
-        } catch {
-          /* skip if pages not configured */
-        }
-
-        try {
-          await cli.generateDataTypes({ cwd })
-          generated.push('.guren/data.gen.ts')
-        } catch {
-          /* skip if resources not configured */
-        }
-
-        try {
-          await cli.generateChannelTypes({ cwd })
-          generated.push('.guren/channels.gen.ts')
-        } catch {
-          /* skip if channels not configured */
-        }
+        // Ordered as `guren codegen` orders it, and for the same reason at the
+        // end: the API client is built from the route manifest, so it can only
+        // run once routes has produced one.
+        const routes = await run(
+          ['.guren/routes.gen.ts', 'types/generated/routes.d.ts'],
+          () => cli.generateRouteTypes(options),
+        )
+        await run(['.guren/pages.gen.ts'], () => cli.generatePageTypes(options))
+        await run(['.guren/data.gen.ts'], () => cli.generateDataTypes(options))
+        await run(['.guren/channels.gen.ts'], () => cli.generateChannelTypes(options))
+        await run(['.guren/api-client.gen.ts'], () => {
+          if (!routes?.definitions) {
+            throw new Error('route generation produced no manifest to build a client from')
+          }
+          return cli.generateApiClientTypes(routes.definitions, options)
+        })
 
         return {
-          content: [{ type: 'text', text: JSON.stringify({ generated }, null, 2) }],
+          content: [{ type: 'text', text: JSON.stringify({ generated, skipped }, null, 2) }],
+          // A generator that found nothing to describe is not a failure — an
+          // app with no page components is a normal shape — so only a thrown
+          // one makes the run an error, even when other artifacts landed.
+          isError: failed,
         }
       } finally {
         process.chdir(originalCwd)

--- a/packages/server/tests/mcp/mcp-server.test.ts
+++ b/packages/server/tests/mcp/mcp-server.test.ts
@@ -5,9 +5,19 @@ import { join } from 'node:path'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import { createMcpServer } from '../../src/mcp/create-mcp-server'
-import type { GurenCliApi } from '../../src/mcp/create-mcp-server'
+import type { CodegenOptions, CodegenResult, GurenCliApi } from '../../src/mcp/create-mcp-server'
 
-function createMockCli(): GurenCliApi {
+const ROUTE_MANIFEST = [{ method: 'GET', path: '/posts', name: 'posts.index' }]
+
+type CodegenCall = { generator: string; options: CodegenOptions; definitions?: unknown[] }
+
+function createMockCli(overrides: Partial<GurenCliApi> = {}, calls?: CodegenCall[]): GurenCliApi {
+  const record =
+    (generator: string, result?: CodegenResult) => async (options: CodegenOptions) => {
+      calls?.push({ generator, options })
+      return result
+    }
+
   return {
     generateContext: async () => ({
       framework: { name: 'guren', version: '0.2.0' },
@@ -83,19 +93,23 @@ function createMockCli(): GurenCliApi {
     makeView: async (name) => `resources/js/pages/${name}.tsx`,
     makeTest: async (name) => `tests/${name}.test.ts`,
     makeRoute: async (name) => `routes/${name}.ts`,
-    generateRouteTypes: async () => {},
-    generatePageTypes: async () => {},
-    generateDataTypes: async () => {},
-    generateChannelTypes: async () => {},
+    generateRouteTypes: record('generateRouteTypes', { definitions: ROUTE_MANIFEST }),
+    generatePageTypes: record('generatePageTypes'),
+    generateDataTypes: record('generateDataTypes'),
+    generateChannelTypes: record('generateChannelTypes'),
+    generateApiClientTypes: async (definitions: unknown[], options: CodegenOptions) => {
+      calls?.push({ generator: 'generateApiClientTypes', options, definitions })
+    },
+    ...overrides,
   }
 }
 
 let testDir: string
 
-async function createTestClient() {
+async function createTestClient(overrides: Partial<GurenCliApi> = {}, calls?: CodegenCall[]) {
   const mcpServer = createMcpServer({
     cwd: testDir,
-    cli: createMockCli(),
+    cli: createMockCli(overrides, calls),
   })
 
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
@@ -267,6 +281,94 @@ describe('Guren MCP Server', () => {
 
     expect(data.generated).toContain('.guren/routes.gen.ts')
     expect(data.generated).toContain('.guren/pages.gen.ts')
+    expect(data.generated).toContain('types/generated/routes.d.ts')
+    expect(data.generated).toContain('.guren/api-client.gen.ts')
+    expect(data.skipped).toEqual([])
+  })
+
+  test('guren_codegen forces every generator and feeds the client the route manifest', async () => {
+    const calls: CodegenCall[] = []
+    const client = await createTestClient({}, calls)
+    await client.callTool({ name: 'guren_codegen', arguments: {} })
+
+    expect(calls.map((call) => call.generator)).toEqual([
+      'generateRouteTypes',
+      'generatePageTypes',
+      'generateDataTypes',
+      'generateChannelTypes',
+      'generateApiClientTypes',
+    ])
+    for (const call of calls) {
+      expect(call.options.force).toBe(true)
+    }
+    expect(calls.at(-1)?.definitions).toEqual(ROUTE_MANIFEST)
+  })
+
+  test('guren_codegen skips the API client when route generation failed', async () => {
+    const client = await createTestClient({
+      generateRouteTypes: async () => {
+        throw new Error('routes/web.ts not found')
+      },
+    })
+    const result = await client.callTool({ name: 'guren_codegen', arguments: {} })
+    const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text)
+
+    expect(data.generated).not.toContain('.guren/api-client.gen.ts')
+    expect(data.skipped).toContainEqual({
+      artifacts: ['.guren/api-client.gen.ts'],
+      reason: 'route generation produced no manifest to build a client from',
+    })
+  })
+
+  test('guren_codegen reports a partial failure as an error, with the reason', async () => {
+    const client = await createTestClient({
+      generateDataTypes: async () => {
+        throw new Error('app/Http/Resources not found')
+      },
+    })
+    const result = await client.callTool({ name: 'guren_codegen', arguments: {} })
+    const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text)
+
+    expect(result.isError).toBe(true)
+    expect(data.generated).toContain('.guren/routes.gen.ts')
+    expect(data.skipped).toEqual([
+      { artifacts: ['.guren/data.gen.ts'], reason: 'app/Http/Resources not found' },
+    ])
+  })
+
+  test('guren_codegen skips an artifact a generator reports as empty', async () => {
+    const client = await createTestClient({
+      generatePageTypes: async () => ({ outputPath: '' }),
+    })
+    const result = await client.callTool({ name: 'guren_codegen', arguments: {} })
+    const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text)
+
+    // Nothing to describe is a shape, not a failure — an app with no page
+    // components must not make the whole run report an error.
+    expect(result.isError).toBe(false)
+    expect(data.generated).not.toContain('.guren/pages.gen.ts')
+    expect(data.skipped).toEqual([
+      { artifacts: ['.guren/pages.gen.ts'], reason: 'nothing to generate' },
+    ])
+  })
+
+  test('guren_codegen is an error when nothing could be generated', async () => {
+    const failing = async () => {
+      throw new Error('routes/web.ts not found')
+    }
+    const client = await createTestClient({
+      generateRouteTypes: failing,
+      generatePageTypes: failing,
+      generateDataTypes: failing,
+      generateChannelTypes: failing,
+    })
+    const result = await client.callTool({ name: 'guren_codegen', arguments: {} })
+    const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text)
+
+    expect(result.isError).toBe(true)
+    expect(data.generated).toEqual([])
+    // The API client makes a fifth: it has no manifest to work from either.
+    expect(data.skipped).toHaveLength(5)
   })
 
   test('lists resources', async () => {


### PR DESCRIPTION
## Summary

The `guren_codegen` MCP tool could not regenerate `.guren/*.gen.ts` or `types/generated/routes.d.ts` once their content actually changed — the one case where regeneration matters.

The handler called `cli.generateRouteTypes({ cwd })` and its three siblings without `force`. `writeGeneratedFile()` skips a write only when the new content is byte-identical; when a route was added it fell through to `writeFileSafe()`, which threw `"types/generated/routes.d.ts already exists. Use --force to overwrite."` Each call sat behind a blanket `catch {}`, so the tool discarded that error and answered `{"generated": []}` as though it had succeeded.

This passes `force: true` in each call, matching what `codegenCommand.run()` in `packages/cli/src/bin.ts` already hardcodes — these outputs are entirely generated artifacts, so overwriting them is the point.

Two related changes came out of the same handler:

- **Skips are reported, not swallowed.** The response carries a `skipped` array naming each artifact and the reason. A generator that *throws* now marks the run as an error even when other artifacts landed; a generator that found nothing to describe (an app with no page components) is reported as a skip, not a failure. The two are separated by mechanism rather than by sniffing error messages.
- **`.guren/api-client.gen.ts` is now generated.** The tool omitted it even though `guren codegen` produces it. It is built from the route manifest `generateRouteTypes` returns, so an agent that added a route through MCP had every other artifact refreshed while the API client silently went stale.

## Scope

server (`packages/server/src/mcp/`), tests, changeset. No CLI changes — the `guren codegen` command already behaved correctly.

## Risk Assessment

- **Behavior change (intended):** the tool now overwrites generated artifacts instead of failing. That is the fix.
- **Response shape:** `{ generated }` becomes `{ generated, skipped }`, and `isError` is now always present. Additive for callers that read `generated`.
- **`GurenCliApi.generateApiClientTypes` is declared required, not optional.** The MCP surface and that CLI export shipped in the same commit (`4518155`), so a `@guren/cli` old enough to lack it lacks the whole interface — an optional guard would only add a branch that cannot be reached.
- **Known limitation, unchanged by this PR:** codegen still runs in-process, so route-derived artifacts (`routes.gen.ts`, `routes.d.ts`, `api-client.gen.ts`) describe the route graph as of the process's first route load. With `force` they now overwrite rather than fail. Page/data/channel manifests are unaffected — those generators re-scan the filesystem every call. The comment in `McpServiceProvider.ts` was updated to state this accurately: an app on the default Vite setup repairs the difference on the next save via `routeTypesPlugin`'s `handleHotUpdate`, which spawns `guren codegen` in a child process; a dev server without that plugin has no such repair. Moving codegen behind the same child process used for context generation is tracked separately.

## Validation

Reproduced against `examples/blog` with a route added since the last codegen:

- Pre-fix, the exact call the handler makes threw `types/generated/routes.d.ts already exists. Use --force to overwrite.`
- Post-fix, two consecutive tool calls both succeed and the artifacts update: `.guren/routes.gen.ts` 6891 → 7024 bytes, `types/generated/routes.d.ts` 1601 → 1621, `.guren/api-client.gen.ts` 7742 → 7896, with the new route present in each.
- The `api-client.gen.ts` the MCP path produces is **byte-identical** to what `guren codegen` produces — the check that the route-manifest handoff is right rather than merely plausible.
- The `isError` semantics are covered by unit tests only; they are a response-shape rule with no disk state, so the live script does not exercise them.

- [x] `bun run build` (`build:clean`)
- [x] `bun run typecheck`
- [x] `bun run test` (2602 framework, 105 blog, 12 web/api)
- [x] `bun run audit:core-first`
- [x] `bun run audit:docs`

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.