### PR TITLE
docs: record stale dist as a silent test-failure mode

### DIFF
--- a/.claude/rules/common-pitfalls.md
+++ b/.claude/rules/common-pitfalls.md
@@ -9,6 +9,12 @@ Lessons learned from code review cycles. Check these before submitting changes.
 - **When adding ORM exports**, they must be explicitly listed in `packages/core/src/index.ts` (allowlist, not `export *`).
 - **Don't reference non-existent symbols in docs.** Verify imports compile before documenting them.
 
+## Stale Build Artifacts
+
+- **A stale `dist/` can fail tests silently, not just loudly.** The documented symptom is a DTS build error (`could not find declaration file`), but a stale artifact can also load fine and merely *lack a field added since it was built* — which surfaces as a confusing `toEqual` mismatch in an unrelated package's unit test.
+- **`packages/cli` tests reach `@guren/server` through `dist/`, not `src/`.** `@guren/core` resolves to `packages/core/src/index.ts`, but its `export * from '@guren/server'` follows the workspace symlink to `packages/server`'s `exports`, which points at `dist/index.js`. So anything a CLI test loads via `@guren/core` (routers, route definitions) is the *built* server, however fresh the source is.
+- **`git stash` does not make a checkout clean.** `dist/` is untracked, so stashing leaves stale artifacts in place. When a test fails only on one machine, rebuild before bisecting: `bun run build:clean` (or `bun run build:<pkg>` for a targeted check).
+
 ## CI Environment
 
 - **Never use `bunx guren` in CI.** The `guren` package is not on npm. Use `bun packages/cli/src/bin.ts` directly.


### PR DESCRIPTION
## Summary

Adds a **Stale Build Artifacts** section to `.claude/rules/common-pitfalls.md`.

The existing stale-artifact guidance (in `CLAUDE.md`) only describes the loud symptom — a DTS build failing with `could not find declaration file`. A stale `dist/` can also import perfectly well and simply lack a field added after it was built, which shows up as an unexplained assertion mismatch in a unit test that never mentions the built package.

This came out of a real debugging session. `packages/cli/tests/entity-context.test.ts` failed with:

```
- { "id": "Post" }   (expected)
+ undefined          (received)
```

on `expect(show?.bindings).toEqual({ id: 'Post' })`, while the other ten tests in the file passed and `packages/server/src/mvc/Router.ts` was byte-identical to a checkout where all eleven passed.

The cause is a resolution path that is easy to miss:

```
packages/cli/src/load-routes.ts
  → @guren/core   → packages/core/src/index.ts        (source)
  → export * from '@guren/server'
      → packages/core/node_modules/@guren/server      (workspace symlink)
      → packages/server/package.json exports
      → packages/server/dist/index.js                 (built artifact)
```

So a CLI unit test loading `Router` via `@guren/core` exercises the *built* server no matter how fresh the source is. The local `dist` predated `serializeBindings()`, so `Router.prototype.definitions()` dropped `bindings` from its destructuring — confirmed by printing `Router.prototype.definitions.toString()` from the loaded module. `bun run build:server` fixed it; no source was at fault.

The third bullet records a related trap: `git stash` does not make a checkout clean, because `dist/` is untracked and survives the stash.

## Scope

- `.claude/rules/common-pitfalls.md` — documentation only. No shipped code touched, so no changeset.

## Risk Assessment

None. Markdown-only change to repo-internal agent rules; nothing is published or executed from this file.

## Validation

Not run — the change is a markdown-only edit to `.claude/rules/`, outside every build, typecheck, and test input.

- [ ] `bun run build`
- [ ] `bun run typecheck`
- [ ] `bun run test`

For context, the failure this documents was verified end to end: `bun test --isolate packages/cli/tests/entity-context.test.ts` went from 10 pass / 1 fail to 11 pass after `bun run build:server` alone, with no source change.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [ ] I added/updated tests for behavior changes. — N/A, no behavior change.
- [x] I updated relevant documentation.