### PR TITLE
fix(server): stop interval timers leaked across hot reloads

### DIFF
--- a/.changeset/server-hot-reload-timer-leak.md
+++ b/.changeset/server-hot-reload-timer-leak.md
@@ -1,0 +1,11 @@
+---
+'@guren/server': patch
+---
+
+Fixed leaked interval timers under `bun --hot`. Each hot reload re-runs the module graph in the same process, and a `setInterval` callback keeps its owner reachable — so the cache sweep, rate-limit cleanup, SSE ping, and scheduler timers built by the previous evaluation went on firing against objects nothing referenced any more, one extra timer per reload. The rate-limit and SSE timers are not `unref()`ed, so those also duplicated work and held the process open on their own; a duplicated scheduler would have run every scheduled task twice per reload. Each owner now parks its teardown on a `globalThis` registry — the same approach `Application.listen()` already uses for the Bun and Vite dev servers — and stops its predecessor before taking over.
+
+This only applies under `bun --hot`. An owner is identified by the file that built it plus a discriminator (the cache store's name, the rate-limit store's class, the scheduler's timezone), so it is replaced only by a later evaluation of that same file. Nothing is ever torn down automatically in production, tests, CLI commands, or serverless.
+
+Three things to know. Cache stores are tracked from the cache configuration, so a store built by calling `new MemoryStore()` directly in application code is not covered — every path the templates and examples take goes through cache config. Broadcast managers are tracked from `createBroadcastManager()`, so a bare `new BroadcastManager()` is likewise left alone. And because every manager built through `createCacheManager()` reports that factory as its call site, the store name is the whole of a cache store's identity: two cache managers in one process would share a slot per store name, so the second store under a given name stops the first one's sweep. Apps have one cache manager.
+
+As part of this, `BroadcastManager` gained a public `disconnectAll()` that closes every SSE connection it is holding, which is what stops those connections' ping timers.

--- a/packages/server/src/broadcasting/BroadcastManager.ts
+++ b/packages/server/src/broadcasting/BroadcastManager.ts
@@ -13,6 +13,7 @@ import type {
 } from './types'
 import { Channel, PrivateChannel, PresenceChannel } from './channels'
 import { MemoryDriver } from './drivers'
+import { claimHotDisposable, isHotReloadRuntime } from '../hot-reload/hot-disposables'
 import type { Context } from '../http/Application'
 import type { Middleware } from '../http/middleware'
 import { parseRequestPayload } from '../http/request'
@@ -540,6 +541,30 @@ export class BroadcastManager {
   }
 
   /**
+   * Close every SSE connection this manager is holding.
+   *
+   * Each connection owns a ping timer that is only cleared when the stream is
+   * cancelled or the request aborts. `Bun.serve().stop()` without forcing waits
+   * for in-flight requests instead of cutting them, and an SSE response never
+   * finishes — so on a hot reload those connections outlive the manager, and
+   * their timers go on pinging a stream nobody reads.
+   *
+   * `getClients()` returns a snapshot. A `Map` iterator does tolerate an entry
+   * deleting itself, which is all `cleanup()` does today — but not a `close()`
+   * that reaches another client, which would drop that one from the iteration
+   * unvisited and leave its timer running.
+   */
+  disconnectAll(): void {
+    for (const client of this.getClients()) {
+      try {
+        client.close()
+      } catch {
+        // A stream torn down from the other end is already what we wanted.
+      }
+    }
+  }
+
+  /**
    * Generate a unique client ID.
    */
   protected generateClientId(prefix: 'sse' | 'ws' = 'sse'): string {
@@ -571,9 +596,24 @@ export function getBroadcastManager(): BroadcastManager {
 
 /**
  * Create a broadcast manager.
+ *
+ * Under `bun --hot`, the manager this one replaces has its SSE connections
+ * closed first, so their ping timers stop with it. Registered from the factory
+ * rather than the constructor because the factory is what application code
+ * calls: frame 2 of the stack is the provider that built the manager, not this
+ * file. A bare `new BroadcastManager()` is left alone.
  */
 export function createBroadcastManager(
   options?: BroadcastManagerOptions
 ): BroadcastManager {
-  return new BroadcastManager(options)
+  const manager = new BroadcastManager(options)
+
+  claimHotDisposable(
+    'broadcast-manager',
+    isHotReloadRuntime() ? new Error().stack : undefined,
+    options?.default ?? 'memory',
+    () => manager.disconnectAll(),
+  )
+
+  return manager
 }

--- a/packages/server/src/cache/CacheManager.ts
+++ b/packages/server/src/cache/CacheManager.ts
@@ -13,6 +13,7 @@ import { MemoryStore } from './stores/MemoryStore'
 import { RedisStore } from './stores/RedisStore'
 import { FileStore } from './stores/FileStore'
 import { TaggedCache } from './TaggedCache'
+import { claimHotDisposable, isHotReloadRuntime } from '../hot-reload/hot-disposables'
 
 /**
  * Taggable wrapper that adds tag support to any cache store.
@@ -106,8 +107,18 @@ export class CacheManager {
   private readonly defaultStoreName: string
   private readonly storeFactories: Map<string, CacheStoreFactory> = new Map()
   private readonly resolvedStores: Map<string, TaggableCacheStore> = new Map()
+  /**
+   * Where this manager was built, for identifying its stores across hot reloads.
+   *
+   * Captured here rather than in `store()` because stores resolve lazily, from
+   * whichever request first asks for one — a call site that says nothing about
+   * which manager owns the result. Skipped outside `--hot`, where it would be a
+   * formatted stack string held for the manager's lifetime and never read.
+   */
+  private readonly builtAt: string | undefined
 
   constructor(config: CacheConfig = {}) {
+    this.builtAt = isHotReloadRuntime() ? new Error().stack : undefined
     this.defaultStoreName = config.default ?? 'memory'
 
     // Register built-in drivers
@@ -184,9 +195,27 @@ export class CacheManager {
       throw new Error(`Cache store not found: ${storeName}`)
     }
 
-    const store = new TaggableCacheStoreWrapper(factory())
+    const raw = factory()
+    this.stopPreviousStore(storeName, raw)
+
+    const store = new TaggableCacheStoreWrapper(raw)
     this.resolvedStores.set(storeName, store)
     return store
+  }
+
+  /**
+   * Under `bun --hot`, stops the sweep timer held by the store this one replaces.
+   *
+   * Registered from here rather than from `MemoryStore` itself because this is
+   * where the store's name is known, and the name is what keeps two memory
+   * stores in one config from sharing a slot and cancelling each other's sweep.
+   */
+  private stopPreviousStore(storeName: string, store: CacheStore): void {
+    const disposable = store as CacheStore & { destroy?: () => void }
+
+    if (typeof disposable.destroy === 'function') {
+      claimHotDisposable('cache-store', this.builtAt, storeName, () => disposable.destroy?.())
+    }
   }
 
   /**

--- a/packages/server/src/hot-reload/hot-disposables.test.ts
+++ b/packages/server/src/hot-reload/hot-disposables.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, test } from 'bun:test'
+import { claimHotDisposable, describeCallerFile, hotReloadKey } from './hot-disposables'
+import { withHotRuntime } from './testing'
+
+/** A stack shaped like the ones the four owners hand `claimHotDisposable`. */
+function stackFrom(file: string, line = 31): string {
+  return ['Error', '    at factory (/app/dist/index.js:1:1)', `    at ${file}:${line}:26`].join('\n')
+}
+
+describe('describeCallerFile', () => {
+  test('should return the file that built the owner', () => {
+    const stack = [
+      'Error',
+      '    at new BaseMemoryStore (/app/node_modules/@guren/server/dist/index.js:120:15)',
+      '    at /app/routes/api.ts:31:26',
+      '    at /app/src/app.ts:9:1',
+    ].join('\n')
+
+    expect(describeCallerFile(stack)).toBe('/app/routes/api.ts')
+  })
+
+  test('should read a frame that carries a function name', () => {
+    const stack = [
+      'Error',
+      '    at createBroadcastManager (/app/dist/index.js:120:15)',
+      '    at register (/app/app/Providers/BroadcastProvider.ts:10:29)',
+    ].join('\n')
+
+    expect(describeCallerFile(stack)).toBe('/app/app/Providers/BroadcastProvider.ts')
+  })
+
+  test('should read a frame that carries no column', () => {
+    expect(describeCallerFile('Error\n    at factory (/app/dist/index.js:1:1)\n    at /app/routes/api.ts:31')).toBe(
+      '/app/routes/api.ts',
+    )
+  })
+
+  test('should keep a path that contains spaces intact', () => {
+    // Ordinary on macOS. Splitting the frame on whitespace truncates this to
+    // `Projects/app/routes/api.ts`, which collides with any other project whose
+    // path ends the same way.
+    const parenthesized = 'Error\n    at f (/app/dist/index.js:1:1)\n    at g (/Users/me/My Projects/app/api.ts:31:26)'
+    const bare = 'Error\n    at f (/app/dist/index.js:1:1)\n    at /Users/me/My Projects/app/api.ts:31:26'
+
+    expect(describeCallerFile(parenthesized)).toBe('/Users/me/My Projects/app/api.ts')
+    expect(describeCallerFile(bare)).toBe('/Users/me/My Projects/app/api.ts')
+  })
+
+  test('should step over the synthetic frame of an implicit constructor', () => {
+    // A subclass with no constructor of its own gets an implicit one, which JSC
+    // reports with no source location. Taking that frame keys every such owner
+    // to the literal string `unknown`, so stores built in unrelated files share
+    // a slot and stop each other.
+    const stack = [
+      'Error',
+      '    at new BaseMemoryStore (/app/dist/index.js:120:15)',
+      '    at new MemoryRateLimitStore (unknown:1:28)',
+      '    at /app/routes/api.ts:31:26',
+    ].join('\n')
+
+    expect(describeCallerFile(stack)).toBe('/app/routes/api.ts')
+  })
+
+  test('should step over a run of frames with no source location', () => {
+    const stack = [
+      'Error',
+      '    at new Base (/app/dist/index.js:120:15)',
+      '    at new Middle (unknown:1:28)',
+      '    at map (native:1:11)',
+      '    at /app/routes/api.ts:31:26',
+    ].join('\n')
+
+    expect(describeCallerFile(stack)).toBe('/app/routes/api.ts')
+  })
+
+  test('should ignore a frame that names a function but no location', () => {
+    const stack = ['Error', '    at new Base (/app/dist/index.js:120:15)', '    at Object.<anonymous>'].join('\n')
+
+    expect(describeCallerFile(stack)).toBeUndefined()
+  })
+
+  test('should return undefined when there is no caller frame', () => {
+    expect(describeCallerFile(undefined)).toBeUndefined()
+    expect(describeCallerFile('Error')).toBeUndefined()
+    expect(describeCallerFile('Error\n    at new BaseMemoryStore (/app/dist/index.js:120:15)')).toBeUndefined()
+  })
+
+  test('should parse a stack this runtime actually produced', () => {
+    // The fixtures above are hand-written, so they would keep passing if the
+    // engine changed its stack format and every real key silently became
+    // undefined — leaking again, quietly. This asserts against the real thing,
+    // through an implicit constructor, which is the shape that broke first.
+    class Base {
+      readonly builtBy = describeCallerFile(new Error().stack)
+    }
+    class Derived extends Base {}
+
+    const here = new Derived().builtBy
+    expect(here).toEndWith('hot-disposables.test.ts')
+    // A call from a different line of this same file must produce the same key.
+    expect(new Derived().builtBy).toBe(here)
+  })
+})
+
+describe('hotReloadKey', () => {
+  const stack = stackFrom('/app/routes/api.ts')
+
+  test('should return undefined outside a hot-reloading runtime', () => {
+    expect(hotReloadKey('rate-limit-store', stack, 'MemoryRateLimitStore')).toBeUndefined()
+  })
+
+  test('should key by call site under --hot', () => {
+    withHotRuntime(() => {
+      expect(hotReloadKey('rate-limit-store', stack, 'MemoryRateLimitStore')).toBe(
+        'rate-limit-store|/app/routes/api.ts|MemoryRateLimitStore',
+      )
+    })
+  })
+
+  test('should return undefined when the call site cannot be determined', () => {
+    withHotRuntime(() => {
+      expect(hotReloadKey('rate-limit-store', undefined, 'MemoryRateLimitStore')).toBeUndefined()
+    })
+  })
+
+  test('should survive the call moving to another line', () => {
+    // The whole point of dropping line and column: adding an import above the
+    // call must not orphan the entry holding the previous timer.
+    withHotRuntime(() => {
+      expect(hotReloadKey('rate-limit-store', stack, 'X')).toBe(
+        hotReloadKey('rate-limit-store', stackFrom('/app/routes/api.ts', 48), 'X'),
+      )
+    })
+  })
+
+  test('should separate owners built in different modules', () => {
+    withHotRuntime(() => {
+      expect(hotReloadKey('rate-limit-store', stack, 'X')).not.toBe(
+        hotReloadKey('rate-limit-store', stackFrom('/app/routes/web.ts'), 'X'),
+      )
+    })
+  })
+
+  test('should separate one call site that builds several owners', () => {
+    withHotRuntime(() => {
+      expect(hotReloadKey('cache-store', stack, 'default')).not.toBe(hotReloadKey('cache-store', stack, 'sessions'))
+    })
+  })
+
+  test('should separate scopes sharing a call site and target', () => {
+    withHotRuntime(() => {
+      expect(hotReloadKey('cache-store', stack, 'x')).not.toBe(hotReloadKey('scheduler', stack, 'x'))
+    })
+  })
+})
+
+describe('claimHotDisposable', () => {
+  /** Claims `target` from a fixed synthetic call site, recording teardowns. */
+  function claim(target: string, dispose: () => void, file = '/app/config/cache.ts') {
+    return claimHotDisposable('cache-store', stackFrom(file), target, dispose)
+  }
+
+  test('should not claim anything outside a hot-reloading runtime', () => {
+    const stopped: string[] = []
+
+    expect(claim('inert', () => stopped.push('first'))).toBeUndefined()
+    expect(claim('inert', () => stopped.push('second'))).toBeUndefined()
+    expect(stopped).toEqual([])
+  })
+
+  test('should not claim anything when the call site cannot be determined', () => {
+    withHotRuntime(() => {
+      expect(claimHotDisposable('cache-store', 'Error', 'unparseable', () => {})).toBeUndefined()
+    })
+  })
+
+  test('should stop the previous owner when an identity is claimed again', () => {
+    withHotRuntime(() => {
+      const stopped: string[] = []
+
+      claim('replace', () => stopped.push('first'))
+      claim('replace', () => stopped.push('second'))
+
+      expect(stopped).toEqual(['first'])
+    })
+  })
+
+  test('should not stop anything for an identity claimed the first time', () => {
+    withHotRuntime(() => {
+      const stopped: string[] = []
+
+      claim('fresh', () => stopped.push('first'))
+
+      expect(stopped).toEqual([])
+    })
+  })
+
+  test('should leave owners under other identities running', () => {
+    withHotRuntime(() => {
+      const stopped: string[] = []
+
+      claim('kept', () => stopped.push('kept'))
+      claim('replaced', () => stopped.push('replaced'))
+      claim('replaced', () => stopped.push('replacement'))
+
+      expect(stopped).toEqual(['replaced'])
+    })
+  })
+
+  test('should not stop an owner that re-registers itself', () => {
+    withHotRuntime(() => {
+      const stopped: string[] = []
+      const dispose = () => stopped.push('only')
+
+      claim('idempotent', dispose)
+      claim('idempotent', dispose)
+
+      expect(stopped).toEqual([])
+    })
+  })
+
+  test('should keep the new owner registered when the previous teardown throws', () => {
+    withHotRuntime(() => {
+      const stopped: string[] = []
+
+      claim('throwing', () => {
+        throw new Error('already gone')
+      })
+      claim('throwing', () => stopped.push('second'))
+      claim('throwing', () => stopped.push('third'))
+
+      expect(stopped).toEqual(['second'])
+    })
+  })
+
+  test('should not let a teardown that re-claims the slot stop the new owner', () => {
+    withHotRuntime(() => {
+      const stopped: string[] = []
+
+      // A store's own destroy() runs as the teardown here, and an application
+      // can put anything in one — including something that resolves the store
+      // again. The owner this call is installing must survive that.
+      claim('reentrant', () => {
+        stopped.push('first')
+        claim('reentrant', () => stopped.push('nested'))
+      })
+      claim('reentrant', () => stopped.push('second'))
+
+      expect(stopped).toEqual(['first'])
+
+      claim('reentrant', () => stopped.push('third'))
+      expect(stopped).toEqual(['first', 'second'])
+    })
+  })
+})
+
+describe('HotDisposableClaim.release', () => {
+  test('should free the slot so the next claim stops nothing', () => {
+    withHotRuntime(() => {
+      const stopped: string[] = []
+      const claim = claimHotDisposable('scheduler', stackFrom('/app/src/app.ts'), 'release', () =>
+        stopped.push('first'),
+      )
+
+      claim?.release()
+      claimHotDisposable('scheduler', stackFrom('/app/src/app.ts'), 'release', () => stopped.push('second'))
+
+      expect(stopped).toEqual([])
+    })
+  })
+
+  test('should ignore a release from an owner that no longer holds the slot', () => {
+    withHotRuntime(() => {
+      const stopped: string[] = []
+      const stack = stackFrom('/app/src/app.ts')
+
+      const stale = claimHotDisposable('scheduler', stack, 'stale', () => stopped.push('stale'))
+      claimHotDisposable('scheduler', stack, 'stale', () => stopped.push('current'))
+      // The replaced owner deregisters itself while stopping; the newer owner
+      // must keep the slot.
+      stale?.release()
+
+      claimHotDisposable('scheduler', stack, 'stale', () => stopped.push('next'))
+
+      expect(stopped).toEqual(['stale', 'current'])
+    })
+  })
+})

--- a/packages/server/src/hot-reload/hot-disposables.ts
+++ b/packages/server/src/hot-reload/hot-disposables.ts
@@ -1,0 +1,196 @@
+/**
+ * Stops the timers a previous module evaluation left running.
+ *
+ * `bun --hot` re-runs the module graph inside the same process. Anything the
+ * previous evaluation built is dropped on the floor — but a `setInterval`
+ * callback keeps its owner reachable, so a store, manager, or scheduler that
+ * nothing references any more goes on firing forever. One extra timer per
+ * reload, each one retaining the dead object graph behind it.
+ *
+ * `globalThis` survives re-evaluation, so it is where the previous owner's
+ * teardown is parked — the same storage `Application.listen()` uses for the Bun
+ * and Vite dev servers, and the same approach `@guren/orm` uses for database
+ * connections. Bun does not expose `import.meta.hot` to `bun --hot` (checked on
+ * 1.3.14), so there is no reload hook to register with instead.
+ *
+ * This is deliberately not the ORM's registry with the names changed. Closing a
+ * connection is an async operation that can hang on a wedged socket, which is
+ * what forces that module's serialized claims and teardown timeout. Every
+ * teardown here is synchronous — `clearInterval`, and the `destroy()`/`stop()`
+ * methods wrapping it — so a claim can simply run the previous teardown inline
+ * and be done. Sharing a helper across the two packages would mean either a new
+ * package for ~60 lines or a dependency `@guren/orm` is not allowed to take, and
+ * would buy machinery neither side needs in the same shape.
+ *
+ * Its twin is `packages/orm/src/active-connections.ts`. The two derive an
+ * owner's identity the same way, so a fix to the stack parsing in one is worth
+ * carrying to the other.
+ *
+ * An owner is identified by the file that built it plus a discriminator, so it
+ * is replaced only by a later evaluation of that same file. Keying on the exact
+ * line would be more precise, but a line number changes the moment anything
+ * above it does — adding an import would orphan the previous entry and leak the
+ * timer it was holding, during the very workflow this exists to fix. The file is
+ * stable across every edit that isn't a rename.
+ */
+
+type Dispose = () => void
+
+/** Frees the slot an owner claimed, unless a newer owner has since taken it. */
+export interface HotDisposableClaim {
+  release(): void
+}
+
+const REGISTRY_KEY = Symbol.for('guren.server.hotDisposables')
+
+type GlobalWithRegistry = typeof globalThis & {
+  [REGISTRY_KEY]?: Map<string, Dispose>
+}
+
+function getRegistry(): Map<string, Dispose> {
+  const scope = globalThis as GlobalWithRegistry
+  return (scope[REGISTRY_KEY] ??= new Map<string, Dispose>())
+}
+
+/**
+ * Whether modules can be re-evaluated in this process.
+ *
+ * `bun --watch` restarts the process instead, which drops every timer with it,
+ * so `--hot` is the only mode that leaks. Everywhere else — production, tests,
+ * CLI commands, serverless — nothing is ever torn down automatically.
+ *
+ * Exported so callers can skip building the `Error` whose stack identifies them:
+ * capturing one formats the whole stack into a string, and outside `--hot` it
+ * would only be thrown away.
+ */
+export function isHotReloadRuntime(): boolean {
+  return typeof process !== 'undefined' && Array.isArray(process.execArgv) && process.execArgv.includes('--hot')
+}
+
+/**
+ * Paths the engine reports for code that has no source location.
+ *
+ * A class that extends another without declaring a constructor gets an implicit
+ * one, and JSC reports it as `at new Subclass (unknown:1:28)` — a frame sitting
+ * between the base constructor and the code that actually wrote `new`. Taking it
+ * would key every such owner in the process to the string `unknown`, collapsing
+ * owners built in different files into one slot where each new one stops the
+ * last. `native` shows up the same way for built-ins (`at map (native:1:11)`).
+ */
+const SYNTHETIC_FRAME_PATHS = new Set(['unknown', 'native', '<anonymous>'])
+
+const LOCATION_SUFFIX = /:\d+(?::\d+)?$/
+
+/**
+ * The `file:line:column` a single stack frame points at, minus line and column.
+ *
+ * Frames come in two shapes — `at fn (/path/file.ts:1:2)` and a bare
+ * `at /path/file.ts:1:2` — and the parenthesized form is checked first because a
+ * path may contain spaces, which is ordinary on macOS. Splitting on whitespace
+ * instead would silently truncate `/Users/me/My Projects/app.ts` to `Projects/app.ts`.
+ *
+ * The line number is what proves this is a location at all rather than a bare
+ * function name, so a frame without one yields nothing.
+ */
+function parseFrameLocation(frame: string): string | undefined {
+  const location = frame.match(/\(([^()]*)\)\s*$/)?.[1] ?? frame.match(/^\s*at\s+(.+?)\s*$/)?.[1]
+
+  if (!location || !LOCATION_SUFFIX.test(location)) {
+    return undefined
+  }
+
+  return location.replace(LOCATION_SUFFIX, '')
+}
+
+/**
+ * The file that built the timer owner.
+ *
+ * `stack` must come from an `Error` constructed inside the constructor or
+ * factory itself, so frame 0 is `Error`, frame 1 is that function, and frame 2
+ * is the caller — or the first frame after it that names a real file, since the
+ * engine may have synthesized the frames in between. Only the path is kept: a
+ * reload re-runs the same file, but not necessarily at the same line.
+ */
+export function describeCallerFile(stack: string | undefined): string | undefined {
+  for (const frame of stack?.split('\n').slice(2) ?? []) {
+    const path = parseFrameLocation(frame)
+
+    if (path && !SYNTHETIC_FRAME_PATHS.has(path)) {
+      return path
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Identity for a timer owner across hot reloads, or `undefined` when the owner
+ * must be left alone.
+ *
+ * `target` separates owners that share a call site — the name of a cache store,
+ * say — so one module building several does not collapse them into a slot where
+ * each new one stops the last.
+ */
+export function hotReloadKey(scope: string, stack: string | undefined, target: string): string | undefined {
+  if (!isHotReloadRuntime()) {
+    return undefined
+  }
+
+  const callerFile = describeCallerFile(stack)
+
+  return callerFile ? `${scope}|${callerFile}|${target}` : undefined
+}
+
+/**
+ * Records `dispose` as the live owner for this identity, stops whichever owner
+ * held it before, and hands back the claim so the new owner can give it up.
+ *
+ * Returns `undefined` outside `--hot`, or when the stack does not name a caller
+ * — the owner is then simply left alone, which is how things behaved before this
+ * registry existed.
+ *
+ * A teardown that throws is reported and swallowed: the replacement has already
+ * been built by the time this runs, and refusing to register it would leak the
+ * very timer this is here to stop.
+ */
+export function claimHotDisposable(
+  scope: string,
+  stack: string | undefined,
+  target: string,
+  dispose: Dispose,
+): HotDisposableClaim | undefined {
+  const key = hotReloadKey(scope, stack, target)
+  if (!key) {
+    return undefined
+  }
+
+  const registry = getRegistry()
+  const previous = registry.get(key)
+
+  // The slot is vacated before the old teardown runs, not after. A teardown is
+  // free to claim this identity again on its way out — the cache path runs a
+  // store's own `destroy()`, and an application can put anything in one — and if
+  // the new owner were already installed, that nested claim would read it as the
+  // predecessor and stop a timer that had just been created. Leaving the slot
+  // empty means the worst a nested claim can do is register something this call
+  // then overwrites, which strands a timer rather than stopping a live one.
+  registry.delete(key)
+
+  if (previous && previous !== dispose) {
+    try {
+      previous()
+    } catch (error) {
+      console.warn('[guren] Failed to stop the previous hot-reload disposable:', error)
+    }
+  }
+
+  registry.set(key, dispose)
+
+  return {
+    release() {
+      if (registry.get(key) === dispose) {
+        registry.delete(key)
+      }
+    },
+  }
+}

--- a/packages/server/src/hot-reload/hot-reload-wiring.test.ts
+++ b/packages/server/src/hot-reload/hot-reload-wiring.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Proves the four interval owners actually register with the hot-reload
+ * registry. `hot-disposables.test.ts` covers the registry itself, which it
+ * would keep doing perfectly while nothing on the boot path ever called it.
+ *
+ * Every teardown here is synchronous, so a reload can be simulated by building
+ * the owner twice from this file and asserting against the first one right
+ * after — no waiting on a real interval to fire, and no shortened periods to
+ * make the wait bearable.
+ */
+import { afterEach, describe, expect, test } from 'bun:test'
+import { CacheManager } from '../cache/CacheManager'
+import { MemoryRateLimitStore, SlidingWindowRateLimitStore } from '../http/middleware/rate-limit'
+import { BroadcastManager, createBroadcastManager } from '../broadcasting/BroadcastManager'
+import { Scheduler } from '../scheduling/Scheduler'
+import type { SSEClient } from '../broadcasting/types'
+import type { TaggableCacheStore } from '../cache/types'
+import { withHotRuntime } from './testing'
+
+interface Destroyable {
+  destroy?: () => void
+}
+
+/** The store a `CacheManager` wrapped, reached past its taggable wrapper. */
+function rawStoreOf(store: TaggableCacheStore): Destroyable & { checkInterval?: unknown } {
+  return (store as unknown as { store: Destroyable & { checkInterval?: unknown } }).store
+}
+
+function sweepTimerOf(store: TaggableCacheStore): unknown {
+  return rawStoreOf(store).checkInterval
+}
+
+function cleanupTimerOf(store: MemoryRateLimitStore | SlidingWindowRateLimitStore): unknown {
+  return (store as unknown as { cleanupInterval?: unknown }).cleanupInterval
+}
+
+function sseClientsOf(manager: BroadcastManager): Map<string, SSEClient> {
+  return (manager as unknown as { sseClients: Map<string, SSEClient> }).sseClients
+}
+
+function addFakeClient(manager: BroadcastManager, id: string, close: () => void): void {
+  sseClientsOf(manager).set(id, { id, userId: undefined, channels: new Set(), send: () => {}, close })
+}
+
+/** A client whose close() removes it from the map, as the real cleanup() does. */
+function addRecordingClient(manager: BroadcastManager, id: string, closed: string[]): void {
+  addFakeClient(manager, id, () => {
+    sseClientsOf(manager).delete(id)
+    closed.push(id)
+  })
+}
+
+function registeredSlots(scope: string, target: string): string[] {
+  const registry = (globalThis as Record<symbol, unknown>)[
+    Symbol.for('guren.server.hotDisposables')
+  ] as Map<string, unknown> | undefined
+
+  return [...(registry?.keys() ?? [])].filter((key) => key.startsWith(`${scope}|`) && key.endsWith(`|${target}`))
+}
+
+function hasRegisteredSlot(scope: string, target: string): boolean {
+  return registeredSlots(scope, target).length > 0
+}
+
+/**
+ * The call site recorded in the slot an owner claimed.
+ *
+ * Asserting on this rather than just on the slot existing: a frame offset that
+ * lands on a synthetic stack entry still produces a stable key, so every owner
+ * would keep replacing itself correctly while owners built in *different* files
+ * silently collapsed into one slot and stopped each other.
+ */
+function callSiteOf(scope: string, target: string): string | undefined {
+  return registeredSlots(scope, target)[0]?.split('|')[1]
+}
+
+describe('CacheManager hot-reload wiring', () => {
+  const survivors: Destroyable[] = []
+
+  afterEach(() => {
+    // The sweep timer is unref()ed, so a survivor cannot hang the test run — but
+    // leaving one running would let it sweep during a later test.
+    for (const store of survivors.splice(0)) {
+      store.destroy?.()
+    }
+  })
+
+  /** Builds a manager the way a reload would: same file, same config. */
+  function memoryStore(name: string): TaggableCacheStore {
+    return new CacheManager({ stores: { [name]: { driver: 'memory' } } }).store(name)
+  }
+
+  test('should stop the sweep timer of the store it replaces', () => {
+    withHotRuntime(() => {
+      const previous = memoryStore('sweep')
+      expect(sweepTimerOf(previous)).not.toBeNull()
+
+      const current = memoryStore('sweep')
+
+      expect(sweepTimerOf(previous)).toBeNull()
+      expect(sweepTimerOf(current)).not.toBeNull()
+      survivors.push(rawStoreOf(current))
+    })
+  })
+
+  test('should keep stores under other names sweeping', () => {
+    withHotRuntime(() => {
+      const kept = memoryStore('kept')
+      const replaced = memoryStore('replaced')
+      const current = memoryStore('replaced')
+
+      expect(sweepTimerOf(replaced)).toBeNull()
+      expect(sweepTimerOf(kept)).not.toBeNull()
+      survivors.push(rawStoreOf(kept), rawStoreOf(current))
+    })
+  })
+
+  test('should leave stores alone outside a hot-reloading runtime', () => {
+    const previous = memoryStore('prod')
+    const current = memoryStore('prod')
+
+    expect(sweepTimerOf(previous)).not.toBeNull()
+    survivors.push(rawStoreOf(previous), rawStoreOf(current))
+  })
+
+  test('should not capture a stack outside a hot-reloading runtime', () => {
+    // The stack would be held for the manager's lifetime and never read.
+    const manager = new CacheManager()
+
+    expect((manager as unknown as { builtAt?: string }).builtAt).toBeUndefined()
+  })
+})
+
+describe('rate limit store hot-reload wiring', () => {
+  const survivors: Array<MemoryRateLimitStore | SlidingWindowRateLimitStore> = []
+
+  afterEach(() => {
+    // This interval is NOT unref()ed: a survivor would hold the test process
+    // open for its full 60s period.
+    for (const store of survivors.splice(0)) {
+      store.destroy()
+    }
+  })
+
+  test('should stop the cleanup timer of the store it replaces', () => {
+    withHotRuntime(() => {
+      const previous = new MemoryRateLimitStore()
+      expect(cleanupTimerOf(previous)).toBeDefined()
+
+      const current = new MemoryRateLimitStore()
+
+      expect(cleanupTimerOf(previous)).toBeUndefined()
+      expect(cleanupTimerOf(current)).toBeDefined()
+      survivors.push(current)
+    })
+  })
+
+  test('should not let one store flavour stop the other', () => {
+    withHotRuntime(() => {
+      const fixedWindow = new MemoryRateLimitStore()
+      const slidingWindow = new SlidingWindowRateLimitStore()
+
+      expect(cleanupTimerOf(fixedWindow)).toBeDefined()
+      expect(cleanupTimerOf(slidingWindow)).toBeDefined()
+      survivors.push(fixedWindow, slidingWindow)
+    })
+  })
+
+  test('should not claim a slot when cleanup is disabled', () => {
+    withHotRuntime(() => {
+      const running = new MemoryRateLimitStore()
+      // A store built with cleanup off owns no timer, so it has nothing to hand
+      // the registry — and must not displace the store that does.
+      new MemoryRateLimitStore(0)
+
+      expect(cleanupTimerOf(running)).toBeDefined()
+      survivors.push(running)
+    })
+  })
+
+  test('should key on the file that built the store, not the implicit constructor', () => {
+    withHotRuntime(() => {
+      const store = new MemoryRateLimitStore()
+
+      // These subclasses declare no constructor, so the frame between
+      // BaseMemoryStore and this file has no source location.
+      expect(callSiteOf('rate-limit-store', 'MemoryRateLimitStore')).toEndWith('hot-reload-wiring.test.ts')
+      store.destroy()
+    })
+  })
+
+  test('should give up its slot when destroyed', () => {
+    withHotRuntime(() => {
+      const store = new SlidingWindowRateLimitStore()
+      expect(hasRegisteredSlot('rate-limit-store', 'SlidingWindowRateLimitStore')).toBe(true)
+
+      store.destroy()
+
+      expect(hasRegisteredSlot('rate-limit-store', 'SlidingWindowRateLimitStore')).toBe(false)
+    })
+  })
+
+  test('should leave stores alone outside a hot-reloading runtime', () => {
+    const previous = new MemoryRateLimitStore()
+    const current = new MemoryRateLimitStore()
+
+    expect(cleanupTimerOf(previous)).toBeDefined()
+    survivors.push(previous, current)
+  })
+})
+
+describe('BroadcastManager hot-reload wiring', () => {
+  test('should close the SSE connections of the manager it replaces', () => {
+    withHotRuntime(() => {
+      const closed: string[] = []
+      const previous = createBroadcastManager({ default: 'replaced' })
+      addRecordingClient(previous, 'sse_1', closed)
+
+      createBroadcastManager({ default: 'replaced' })
+
+      expect(closed).toEqual(['sse_1'])
+    })
+  })
+
+  test('should close every connection, not just the first', () => {
+    withHotRuntime(() => {
+      const closed: string[] = []
+      const previous = createBroadcastManager({ default: 'iterated' })
+      addRecordingClient(previous, 'sse_1', closed)
+      addRecordingClient(previous, 'sse_2', closed)
+      addRecordingClient(previous, 'sse_3', closed)
+
+      createBroadcastManager({ default: 'iterated' })
+
+      expect(closed).toEqual(['sse_1', 'sse_2', 'sse_3'])
+      expect(sseClientsOf(previous).size).toBe(0)
+    })
+  })
+
+  test('should survive a connection that throws while closing', () => {
+    withHotRuntime(() => {
+      const closed: string[] = []
+      const previous = createBroadcastManager({ default: 'throwing' })
+      addFakeClient(previous, 'sse_bad', () => {
+        throw new Error('stream already torn down')
+      })
+      addRecordingClient(previous, 'sse_good', closed)
+
+      createBroadcastManager({ default: 'throwing' })
+
+      expect(closed).toEqual(['sse_good'])
+    })
+  })
+
+  test('should leave managers alone outside a hot-reloading runtime', () => {
+    const closed: string[] = []
+    const previous = createBroadcastManager({ default: 'prod' })
+    addRecordingClient(previous, 'sse_1', closed)
+
+    createBroadcastManager({ default: 'prod' })
+
+    expect(closed).toEqual([])
+  })
+})
+
+describe('Scheduler hot-reload wiring', () => {
+  const survivors: Scheduler[] = []
+
+  afterEach(() => {
+    for (const scheduler of survivors.splice(0)) {
+      scheduler.stop()
+    }
+  })
+
+  test('should stop the scheduler it replaces', () => {
+    withHotRuntime(() => {
+      const previous = new Scheduler({ timezone: 'UTC' })
+      previous.start()
+
+      const current = new Scheduler({ timezone: 'UTC' })
+      current.start()
+
+      expect(previous.getIsRunning()).toBe(false)
+      expect(current.getIsRunning()).toBe(true)
+      survivors.push(current)
+    })
+  })
+
+  test('should keep running after a stop and start within one evaluation', () => {
+    withHotRuntime(() => {
+      const scheduler = new Scheduler({ timezone: 'Asia/Tokyo' })
+
+      scheduler.start()
+      scheduler.stop()
+      scheduler.start()
+
+      // Restarting re-claims the same identity, so the claim must not run the
+      // teardown left behind by the first start() against the interval the
+      // second one just created.
+      expect(scheduler.getIsRunning()).toBe(true)
+      survivors.push(scheduler)
+    })
+  })
+
+  test('should give up its slot when stopped', () => {
+    withHotRuntime(() => {
+      const scheduler = new Scheduler({ timezone: 'Pacific/Auckland' })
+
+      scheduler.start()
+      expect(hasRegisteredSlot('scheduler', 'Pacific/Auckland')).toBe(true)
+
+      scheduler.stop()
+
+      // Otherwise the registry holds this scheduler — and every task closed over
+      // by its teardown — for the rest of the process.
+      expect(hasRegisteredSlot('scheduler', 'Pacific/Auckland')).toBe(false)
+    })
+  })
+
+  test('should leave schedulers alone outside a hot-reloading runtime', () => {
+    const previous = new Scheduler({ timezone: 'Europe/Berlin' })
+    previous.start()
+
+    const current = new Scheduler({ timezone: 'Europe/Berlin' })
+    current.start()
+
+    expect(previous.getIsRunning()).toBe(true)
+    survivors.push(previous, current)
+  })
+})

--- a/packages/server/src/hot-reload/testing.ts
+++ b/packages/server/src/hot-reload/testing.ts
@@ -1,0 +1,22 @@
+/**
+ * Test-only helpers for the hot-reload registry.
+ *
+ * Not reachable from any tsup entry point, so it never ships — it lives beside
+ * the code it exercises because both test files in this directory need it and
+ * `@guren/server` has no shared test-support module.
+ */
+
+/**
+ * Runs `callback` with the registry's `--hot` guard satisfied.
+ *
+ * The guard reads `process.execArgv`, which is also how the real thing detects
+ * `bun --hot`; there is no flag or injection seam to prefer over it.
+ */
+export function withHotRuntime<T>(callback: () => T): T {
+  process.execArgv.push('--hot')
+  try {
+    return callback()
+  } finally {
+    process.execArgv.splice(process.execArgv.indexOf('--hot'), 1)
+  }
+}

--- a/packages/server/src/http/middleware/rate-limit.ts
+++ b/packages/server/src/http/middleware/rate-limit.ts
@@ -1,4 +1,5 @@
 import type { MiddlewareHandler, Context } from 'hono'
+import { claimHotDisposable, isHotReloadRuntime, type HotDisposableClaim } from '../../hot-reload/hot-disposables'
 
 /**
  * Rate limit entry stored in the backing store.
@@ -35,11 +36,32 @@ export interface RateLimitStore {
  */
 abstract class BaseMemoryStore implements RateLimitStore {
   protected cleanupInterval?: ReturnType<typeof setInterval>
+  /**
+   * This store's claim on its hot-reload slot, if it holds one.
+   *
+   * Unlike the cache sweep, this interval is not `unref()`ed, so a leaked one
+   * both duplicates work and keeps the process alive on its own.
+   */
+  private readonly hotReloadClaim: HotDisposableClaim | undefined
 
   constructor(cleanupIntervalMs = 60000) {
-    if (cleanupIntervalMs > 0) {
-      this.cleanupInterval = setInterval(() => this.cleanup(), cleanupIntervalMs)
+    if (cleanupIntervalMs <= 0) {
+      return
     }
+
+    this.cleanupInterval = setInterval(() => this.cleanup(), cleanupIntervalMs)
+
+    // Resolves to whoever wrote `new MemoryRateLimitStore()`. The subclasses
+    // declare no constructor, so the engine puts a synthetic frame for the
+    // implicit one between here and that caller — `describeCallerFile()` steps
+    // over it. The class name keeps the two store flavours apart when one module
+    // builds both.
+    this.hotReloadClaim = claimHotDisposable(
+      'rate-limit-store',
+      isHotReloadRuntime() ? new Error().stack : undefined,
+      this.constructor.name,
+      () => this.destroy(),
+    )
   }
 
   abstract get(key: string): Promise<RateLimitEntry | null>
@@ -54,6 +76,10 @@ abstract class BaseMemoryStore implements RateLimitStore {
       clearInterval(this.cleanupInterval)
       this.cleanupInterval = undefined
     }
+
+    // Also reached as the registry's teardown for this store, in which case the
+    // slot already belongs to the replacement and this release is a no-op.
+    this.hotReloadClaim?.release()
   }
 }
 

--- a/packages/server/src/scheduling/Scheduler.ts
+++ b/packages/server/src/scheduling/Scheduler.ts
@@ -1,6 +1,7 @@
 import type { SchedulerOptions } from './types'
 import { Schedule } from './Schedule'
 import { ScheduledTask } from './ScheduledTask'
+import { claimHotDisposable, isHotReloadRuntime, type HotDisposableClaim } from '../hot-reload/hot-disposables'
 
 /**
  * Task scheduler for running periodic tasks.
@@ -30,6 +31,8 @@ export class Scheduler {
   private interval: ReturnType<typeof setInterval> | null = null
   private isRunning = false
   private lastCheck: Date | null = null
+  /** This scheduler's claim on its hot-reload slot while it is running. */
+  private hotReloadClaim: HotDisposableClaim | undefined
 
   constructor(options: SchedulerOptions = {}) {
     this.options = {
@@ -99,6 +102,16 @@ export class Scheduler {
     this.isRunning = true
     this.options.logger('Scheduler started')
 
+    // Under `bun --hot`, stop the scheduler the previous evaluation started —
+    // otherwise both tick, and every scheduled task runs twice per reload.
+    // Keyed on frame 2 of this stack: whoever called `start()`.
+    this.hotReloadClaim = claimHotDisposable(
+      'scheduler',
+      isHotReloadRuntime() ? new Error().stack : undefined,
+      this.options.timezone,
+      () => this.stop(),
+    )
+
     // Run immediately
     this.tick()
 
@@ -125,6 +138,14 @@ export class Scheduler {
       clearInterval(this.interval)
       this.interval = null
     }
+
+    // Give the slot up: a stopped scheduler left holding one keeps itself, and
+    // every task it has been given, reachable from `globalThis` for the rest of
+    // the process — the same leak this registry exists to close. Also reached as
+    // the registry's own teardown, where the slot already belongs to the
+    // replacement and this is a no-op.
+    this.hotReloadClaim?.release()
+    this.hotReloadClaim = undefined
 
     this.isRunning = false
     this.options.logger('Scheduler stopped')


### PR DESCRIPTION
## Summary

`bun --hot` re-runs the module graph inside the same process but does **not** clear timers. A `setInterval` callback keeps its owner reachable, so four timer owners in `@guren/server` kept firing against objects nothing referenced any more — one extra timer per reload, each retaining the dead object graph behind it:

| Owner | Timer | `unref()`ed? | Consequence of the leak |
|---|---|---|---|
| `MemoryStore` (cache) | expiry sweep | yes | retains the dead `Application` graph |
| `BaseMemoryStore` (rate limit) | cleanup | **no** | duplicates work, holds the process open |
| `BroadcastManager` | SSE ping, per connection | **no** | pings a stream nobody reads, holds the process open |
| `Scheduler` | tick | yes | would run every scheduled task twice per reload |

Each owner now parks its teardown on a `globalThis` registry and stops its predecessor before taking over. This is the same approach `Application.listen()` already uses for the Bun and Vite dev servers, and the one `@guren/orm` uses for database connections (`packages/orm/src/active-connections.ts`, #173).

### Why a sibling registry rather than a shared one

Closing a database connection is asynchronous and can hang on a wedged socket, which is what forces the ORM module's serialized claims and teardown timeout. Every teardown here is synchronous — `clearInterval` and the `destroy()`/`stop()` methods wrapping it — so a claim runs the previous teardown inline and is done, in about 60 lines.

Sharing one helper would mean either a new package for that, or a dependency `@guren/orm` is not allowed to take (`packages/orm/CLAUDE.md`) in one direction and `@guren/server` avoids in the other (`packages/server/CLAUDE.md`). About 15 lines of stack parsing are duplicated instead; both files now name their twin in a header comment.

`BroadcastManager` gains a public `disconnectAll()`, since closing its SSE connections is what stops their ping timers. `Bun.serve().stop()` without forcing waits for in-flight requests, and an SSE response never finishes, so those connections otherwise outlive the manager.

## Scope

`server` — cache, rate-limit middleware, broadcasting, scheduling, plus the new `src/hot-reload/` module. Changeset included (`@guren/server`, patch).

## Risk Assessment

**Inert outside `bun --hot`.** The whole mechanism is guarded by `process.execArgv.includes('--hot')`; production, tests, CLI commands, and serverless never register anything and never tear anything down. Outside `--hot` no stack is even captured, so nothing is retained.

**Documented identity limits.** An owner is identified by the file that built it plus a discriminator (cache store name, rate-limit store class, broadcast driver, scheduler timezone), deliberately dropping line and column so that adding an import above the call does not orphan the previous entry. Consequences, all dev-only and all in the changeset:

- Two owners sharing a call site and discriminator share a slot, so the second stops the first. Same class of accepted cost as the ORM registry's.
- Because every manager built through `createCacheManager()` reports that factory as its call site, the store name is the whole of a cache store's identity.
- A bare `new MemoryStore()` or `new BroadcastManager()` in application code is not covered — every path the templates and examples take goes through cache config and `createBroadcastManager()`.

**A deeper alternative exists and was not taken.** Registration could instead hang off the `Application`/provider boundary (`app.onDispose()`), which would remove stack parsing and the collisions above structurally. It would change `Application`'s public surface and every provider, well outside this change, and would still not cover the rate-limit default store or a hand-written store in application code, neither of which passes through the container. Worth considering separately.

**This is live, not dormant.** #180 switched `dev:server` in the templates and `examples/blog` to `bun --hot bin/serve.ts`, so every reload on the default dev path leaks these timers today. Rebased onto that change and re-verified against it.

## Validation

- [x] `bun run build` — `build:clean`, all packages including DTS
- [x] `bun run typecheck` — clean (root, blog, api)
- [x] `bun run test` — `test:bun` **2732 pass / 0 fail**; `test:examples` blog 28/28 and api 15/15 pass. The 3 failing `web/` files are pre-existing and unrelated (`sanitize-html` declared in `web/package.json` but not installed in this worktree) — verified identical on a clean tree via `git stash`.
- [x] `bun run audit:core-first` / `bun run audit:docs` — both pass

Beyond the standard checks:

- **Mutation-tested.** Nine independent breakages — each of the four registration sites, both release paths, the reentrancy ordering, the space-in-path parsing, and the synthetic-frame skip — were each applied in turn and confirmed to make a specific test fail. No wiring point is covered only vacuously.
- **Verified across the `dist` boundary**, not just from `src`. This caught a real bug: a subclass with no constructor of its own gets an implicit one, which JSC reports as `at new MemoryRateLimitStore (unknown:1:28)` — a frame with no source location sitting where the caller was expected. Taking it keyed every rate-limit store in the process to the string `unknown`, collapsing stores built in unrelated files into one slot. `describeCallerFile()` now steps over synthetic frames, and the tests assert the resolved path rather than just the presence of a key.
- **Paths containing spaces** (ordinary on macOS) were being truncated — `/Users/me/My Projects/app.ts` became `Projects/app.ts`. Frame parsing now prefers the parenthesized form and requires a trailing line number. The twin in `@guren/orm` has the same defect in already-merged code; tracked separately, not fixed here.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks. No breaking change; `disconnectAll()` is additive.
- [x] I added/updated tests for behavior changes. 44 tests across a unit suite for the registry and a wiring suite proving each owner registers.
- [x] I updated relevant documentation. Changeset covers the user-facing behavior and its documented limits; the mechanism is dev-only and internal, so no docs page applies.
