### PR TITLE
fix(orm): keep spaces and parentheses in the hot-reload caller path

### DIFF
--- a/.changeset/orm-hot-reload-key-caller-path.md
+++ b/.changeset/orm-hot-reload-key-caller-path.md
@@ -1,0 +1,7 @@
+---
+'@guren/orm': patch
+---
+
+Fixed the `bun --hot` connection registry truncating call-site paths that contain a space or parentheses. The stack frame naming the caller was parsed with a pattern that excluded both characters from the path, so a project under `/Users/me/My Projects` was recorded as `Projects/app/config/database.ts`.
+
+The truncation was deterministic, so the key stayed stable across reloads and connection replacement kept working. What it cost was identity: a registry slot is keyed by driver, caller file, and connection target, so two call sites that truncate to the same path — two apps in one monorepo booted by a single dev process, pointed at one database — would share a slot, and the second would close the first's live connection. Frames are now matched by shape (`at fn (/path/file.ts:1:2)` and the bare `at /path/file.ts:1:2`) with nothing excluded from the path itself.

--- a/packages/orm/src/active-connections.test.ts
+++ b/packages/orm/src/active-connections.test.ts
@@ -38,6 +38,53 @@ describe('describeCallerFile', () => {
     )
   })
 
+  test('should keep a path that contains spaces intact', () => {
+    // "My Projects", iCloud's "Mobile Documents" — ordinary on macOS. A
+    // truncated path no longer identifies the caller: two call sites that
+    // truncate alike land on one registry slot, and under `--hot` the second
+    // would close the first's live connection.
+    const bare = [
+      'Error',
+      '    at createPostgresDatabase (/app/dist/index.js:1:1)',
+      '    at /Users/me/My Projects/app/config/database.ts:3:18',
+    ].join('\n')
+    const named = [
+      'Error',
+      '    at createPostgresDatabase (/app/dist/index.js:1:1)',
+      '    at makeDatabase (/Users/me/My Projects/app/config/database.ts:3:18)',
+    ].join('\n')
+
+    expect(describeCallerFile(bare)).toBe('/Users/me/My Projects/app/config/database.ts')
+    expect(describeCallerFile(named)).toBe('/Users/me/My Projects/app/config/database.ts')
+  })
+
+  test('should keep a path that contains parentheses intact', () => {
+    // Same failure as the spaces above: the path is whatever the frame says it
+    // is, so nothing about it may be excluded — a named frame is bounded by its
+    // own trailing `)`, not by the first one it happens to contain.
+    const bare = ['Error', '    at factory (/app/dist/index.js:1:1)', '    at /app (old)/config/database.ts:3:18'].join(
+      '\n',
+    )
+    const named = [
+      'Error',
+      '    at factory (/app/dist/index.js:1:1)',
+      '    at makeDatabase (/app (old)/config/database.ts:3:18)',
+    ].join('\n')
+
+    expect(describeCallerFile(bare)).toBe('/app (old)/config/database.ts')
+    expect(describeCallerFile(named)).toBe('/app (old)/config/database.ts')
+  })
+
+  test('should reject a frame that names no location', () => {
+    // Rejecting is the safe failure: no key means the handle is left alone, and
+    // a leaked connection beats closing a live one that belongs to someone else.
+    const frame = (last: string) => describeCallerFile(`Error\n    at factory (/app/dist/index.js:1:1)\n${last}`)
+
+    expect(frame('    at native')).toBeUndefined()
+    expect(frame('    at <anonymous>')).toBeUndefined()
+    expect(frame('    at makeDatabase (native)')).toBeUndefined()
+  })
+
   test('should return undefined when there is no caller frame', () => {
     expect(describeCallerFile(undefined)).toBeUndefined()
     expect(describeCallerFile('Error')).toBeUndefined()

--- a/packages/orm/src/active-connections.ts
+++ b/packages/orm/src/active-connections.ts
@@ -79,6 +79,28 @@ function isHotReloadRuntime(): boolean {
 }
 
 /**
+ * The path a single stack frame points at, without its line and column.
+ *
+ * The two shapes a frame comes in are matched separately rather than by one
+ * pattern loose enough to cover both. `at fn (/path/file.ts:1:2)` is tried
+ * first, because its parentheses bound the path; a pattern that also had to
+ * accept the bare `at /path/file.ts:1:2` could only bound it by whitespace, and
+ * would truncate `/Users/me/My Projects/app/config` to `Projects/app/config`.
+ * Nothing constrains what the path itself may contain — spaces and parentheses
+ * are both ordinary in a macOS directory name, and excluding either is how the
+ * truncation happened in the first place.
+ *
+ * Both shapes require a trailing `:line`, so frames that name no location at
+ * all — `at native`, `at <anonymous>` — are rejected instead of being read as a
+ * path. Both path groups are lazy for the same reason both are anchored: a
+ * greedy one would swallow the line number and leave the column to satisfy
+ * `:\d+`, returning `/path/file.ts:1`.
+ */
+function parseFrameLocation(frame: string | undefined): string | undefined {
+  return frame?.match(/\((.+?):\d+(?::\d+)?\)\s*$/)?.[1] ?? frame?.match(/^\s*at\s+(.+?):\d+(?::\d+)?\s*$/)?.[1]
+}
+
+/**
  * The file that called a `create*Database()` factory.
  *
  * `stack` must come from an `Error` constructed inside the factory itself, so
@@ -87,12 +109,7 @@ function isHotReloadRuntime(): boolean {
  * same line.
  */
 export function describeCallerFile(stack: string | undefined): string | undefined {
-  const caller = stack?.split('\n')[2]
-  // Matched as one `file:line:column` run, then trimmed: letting the group stop
-  // at the first `:` would leave the line number attached, since a greedy path
-  // match backtracks no further than it has to.
-  const location = caller?.match(/\(?([^()\s]+:\d+(?::\d+)?)\)?\s*$/)?.[1]
-  return location?.replace(/:\d+(?::\d+)?$/, '') || undefined
+  return parseFrameLocation(stack?.split('\n')[2])
 }
 
 /**


### PR DESCRIPTION
## Summary

The registry that replaces a live database connection across `bun --hot` reloads identifies a handle by the file that built it, read out of an `Error` stack frame. That frame was parsed with `/\(?([^()\s]+:\d+(?::\d+)?)\)?\s*$/`, which excludes both whitespace and parentheses from the path — so it captured only the run after the last space. A project under `/Users/me/My Projects` was recorded as `Projects/app/config/database.ts`. Spaces are ordinary on macOS ("My Projects", iCloud's "Mobile Documents"), and so are parentheses ("app (old)").

The truncation was deterministic, so the key stayed stable across reloads and connection replacement kept working. What it cost was identity: a slot is keyed by `driver|callerFile|target`, so two call sites that truncate to the same path — two apps in one monorepo booted by a single dev process, pointed at one database — would share a slot, and the second would close the first's live connection.

Frames are now matched by shape instead. The parenthesized `at fn (/path/file.ts:1:2)` is tried first, since its own trailing `)` bounds the path, then the bare `at /path/file.ts:1:2`. Nothing is excluded from the path itself. Both shapes require a trailing `:line`, so a frame that names no location (`at native`, `at <anonymous>`) is rejected rather than read as a path — leaving the handle alone beats closing a connection that belongs somewhere else.

Behavior across the three variants, on the frames that distinguish them:

| frame | before | after |
|---|---|---|
| `at /Users/me/My Projects/app/config/database.ts:3:18` | `Projects/app/config/database.ts` | `/Users/me/My Projects/app/config/database.ts` |
| `at fn (/a/My (Projects)/app.ts:3:18)` | `/app.ts` | `/a/My (Projects)/app.ts` |
| `at file:///abs/My Path/mod.ts:1:2` | `Path/mod.ts` | `file:///abs/My Path/mod.ts` |
| `at C:\Users\me\My Docs\app.ts:3:18` | `Docs\app.ts` | `C:\Users\me\My Docs\app.ts` |
| `at native` / `at <anonymous>` | `undefined` | `undefined` |

## Scope

- `orm` — `packages/orm/src/active-connections.ts` (fix), `active-connections.test.ts` (regression tests)
- changeset: `@guren/orm` patch

## Risk Assessment

Low, and confined to `bun --hot`. `hotReloadKey()` returns `undefined` before reaching this code path unless `process.execArgv` contains `--hot`, so nothing here executes in production, tests, CLI commands, or serverless.

Two behavior changes a reviewer should weigh:

1. **The parentheses case was not the reported bug.** The report covered spaces only; the parentheses failure shares the same root cause (ordinary path characters excluded from a character class) and is fixed in the same change. Worth noting because the old result for such a path was `/app.ts` — a far more collision-prone key than either the space case or `undefined`. Happy to split this out if it should stay scoped to spaces.
2. **Eval pseudo-frames now yield a key instead of `undefined`.** `at eval (eval at <anonymous> (/a/b.ts:1:1), <anonymous>:1:1)` previously produced `<anonymous>` (pre-fix) and now produces a longer string embedding the real inner path. Distinct eval sites still get distinct keys, so this does not introduce a collision — and frame 2 of a `create*Database()` call is a config module, never an eval frame. Called out only because it runs slightly against the "reject rather than guess" principle the new test asserts.

No public API change: `parseFrameLocation` is module-private, and `describeCallerFile`'s signature is unchanged.

Backtracking was checked, since the bare-form pattern pairs `\s+` with a lazy `.+?`. It is quadratic in the length of the whitespace run after `at`, not in the path length — a 20k-space synthetic frame costs ~180ms, a realistic 621-char spaced path costs ~0.4us. The input is the library's own `new Error().stack`, so there is no external input path, and the profile is unchanged from the previous pattern.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck` — clean (root, blog, api)
- [x] `bun run test` — `test:bun` 2696 pass / 49 skip / 0 fail (181 files); `test:examples` 71 pass / 0 fail (13 files)
- [x] `bun run audit:core-first` — passed
- [x] `bun run audit:docs` — passed

Note: `web/` tests initially failed on a missing `sanitize-html`. It is declared in `web/package.json` but was absent from this checkout; `bun install` fixed it without touching `bun.lock`. Reproduced with this branch's changes stashed, so it is unrelated to this PR.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation — no user-facing docs describe this internal key derivation; the changeset covers the user-visible effect.
