### PR TITLE
fix: keep a single ORM copy in the Workers bundle

### DIFF
--- a/.changeset/exception-console-fallback.md
+++ b/.changeset/exception-console-fallback.md
@@ -1,0 +1,7 @@
+---
+'@guren/server': patch
+---
+
+Report unhandled exceptions to the console when no reporter is registered.
+
+An app that never called `reporter()` turned a 500 into a rendered error page and nothing else. On a hosted runtime, where stdout is the only channel back to the operator, that left production failures with no trace to follow — the cause could only be found by bisecting the code. Anything that registers a reporter still owns reporting entirely; this only fills the empty case.

--- a/.changeset/testing-model-mock.md
+++ b/.changeset/testing-model-mock.md
@@ -1,0 +1,7 @@
+---
+'@guren/testing': patch
+---
+
+Cover model declarations in the controller module mock.
+
+`createControllerModuleMock()` stubbed `AuthenticatableModel` but not `defineModel`, so a controller test failed to even load when a model it imported used the function form — which `@guren/core` exports right alongside the class form. The stub also lacked the read/write entry points controllers reach for (`all`, `create`, `findOrFail`, `first`, `select`, `delete`); tests drive model behaviour by spying on those, and a spy cannot replace a method that was never defined.

--- a/docs/en/guides/cloudflare.md
+++ b/docs/en/guides/cloudflare.md
@@ -1,0 +1,201 @@
+# Cloudflare Workers Deployment
+
+Guren runs on Cloudflare Workers via `@guren/plugin-cloudflare`, with D1 as the database. This guide covers the full path from an empty account to a deployed app.
+
+Workers is a different shape of runtime from a long-lived server: there is no filesystem, no shared memory between requests, and a CPU budget measured in milliseconds. Most of this guide is about the handful of places where that changes how an app is configured.
+
+## Install
+
+```bash
+bunx guren plugin @guren/plugin-cloudflare
+bun add @guren/plugin-cloudflare
+```
+
+The plugin registers a `cloudflare:build` command and scaffolds `wrangler.jsonc` on the first build.
+
+## Build and Deploy
+
+```bash
+bunx guren cloudflare:build
+bunx wrangler deploy
+```
+
+`cloudflare:build` runs your app's `build` script, then assembles a `.cloudflare/` directory containing the worker entry, static assets, and flattened database migrations. Wire both steps into one script so nobody deploys a stale worker:
+
+```json
+{
+  "scripts": {
+    "cloudflare:build": "bun run build && bunx guren cloudflare:build --skip-app-build",
+    "deploy:cloudflare": "bun run cloudflare:build && bunx wrangler deploy"
+  }
+}
+```
+
+> [!IMPORTANT]
+> `.cloudflare/` is generated output — add it to `.gitignore` and rebuild before every deploy. Nothing else reads from it, so a stale directory silently ships old code.
+
+## Database (D1)
+
+Create the database and record its id in `wrangler.jsonc`:
+
+```bash
+bunx wrangler d1 create my-app
+```
+
+```jsonc
+{
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "my-app",
+      "database_id": "<the id wrangler printed>",
+      "migrations_dir": ".cloudflare/d1-migrations"
+    }
+  ]
+}
+```
+
+Select the driver by runtime in `config/database.ts`. D1 speaks SQLite, so write your schema in the SQLite dialect and keep a local SQLite file for development:
+
+```typescript
+import { createD1Database, createSqliteDatabase } from '@guren/core'
+import { getWorkersEnv } from '@guren/plugin-cloudflare'
+
+interface WorkersEnv {
+  DB: unknown
+}
+
+function isWorkersRuntime(): boolean {
+  return typeof navigator !== 'undefined' && navigator.userAgent === 'Cloudflare-Workers'
+}
+
+const database = isWorkersRuntime()
+  ? createD1Database({ binding: () => getWorkersEnv<WorkersEnv>().DB })
+  : createSqliteDatabase({
+      migrationsFolder: new URL('../db/migrations', import.meta.url),
+      filename: () => process.env.SQLITE_DATABASE_PATH ?? './data/guren.db',
+    })
+
+export const { getDatabase, configureOrm, seedDatabase } = database
+```
+
+The binding is a resolver, not a value: bindings only exist once a request arrives, so it must be read lazily.
+
+### Applying migrations
+
+Migrations are applied out of band — the app never migrates itself on Workers:
+
+```bash
+bunx guren cloudflare:build          # regenerates .cloudflare/d1-migrations
+bunx wrangler d1 migrations apply my-app --remote
+```
+
+> [!WARNING]
+> Build first. `migrations_dir` points inside the generated directory, and `wrangler` reports "no migrations to apply" — successfully, with no error — when it finds an empty folder. Applying before building is the one failure here that looks like success.
+
+Skip the filesystem probe when bootstrapping models, since there is no filesystem to probe:
+
+```typescript
+export async function bootModels(): Promise<void> {
+  await configureOrm()
+  if (!isWorkersRuntime()) {
+    await seedDatabase()
+  }
+}
+```
+
+## Sessions and OAuth State Must Be Database-Backed
+
+This is not a preference. Each request may land on a different isolate, and isolates share nothing but the database. The in-memory defaults will appear to work locally and then drop every session in production.
+
+```typescript
+import { createApp, AuthServiceProvider, DatabaseSessionStore } from '@guren/core'
+import { sessions } from '../db/schema.js'
+
+const app = createApp({
+  providers: [AuthServiceProvider],
+  auth: {
+    autoSession: true,
+    sessionOptions: {
+      store: new DatabaseSessionStore(sessions),
+      cookieSecure: true,
+    },
+  },
+})
+```
+
+The same applies to OAuth: the authorize redirect and the callback that follows it routinely land on different isolates, so the state that ties them together has to be shared.
+
+```typescript
+import { createOAuthManager, DatabaseOAuthStateStore } from '@guren/core'
+import { oauthStates } from '../db/schema.js'
+
+const oauth = createOAuthManager({
+  stateStore: new DatabaseOAuthStateStore(oauthStates),
+})
+```
+
+Both stores need tables. See [Authentication](./authentication.md) for the schema.
+
+## Secrets
+
+`APP_KEY` is required — sessions and CSRF are signed with it, and the worker throws during startup without it, before serving a single request.
+
+```bash
+bun -e "console.log('base64:'+Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString('base64'))" | bunx wrangler secret put APP_KEY
+```
+
+Add any others your app reads (OAuth credentials, API keys) the same way. Secrets set through `wrangler secret put` are available as `process.env.*` at runtime; only non-sensitive values belong in the `vars` block of `wrangler.jsonc`.
+
+## Free Plan Limits
+
+Two limits shape what an app can do:
+
+| Limit | Value | What it means |
+|---|---|---|
+| Worker size | 3 MB gzipped | Large generated content must be weighed against the budget |
+| CPU per request | 10 ms | Anything expensive belongs at build time or save time |
+
+The CPU budget rules out password hashing entirely — a deliberately slow operation cannot fit in 10 ms. Apps on the free plan should authenticate through OAuth rather than passwords. See [Authentication](./authentication.md) for the OAuth flow.
+
+The same budget rewards moving work off the request path: render Markdown when content is saved rather than when it is read, and prerender static content at build time. The paid plan lifts the CPU limit if your workload genuinely needs it.
+
+## Observability
+
+Workers keeps no logs by default, which makes a production failure very hard to trace:
+
+```jsonc
+{
+  "observability": {
+    "enabled": true
+  }
+}
+```
+
+Pair it with `bunx wrangler tail` for live output while reproducing an issue.
+
+## Local Development
+
+`wrangler dev` runs the real runtime against a local D1 database — worth using before deploying, since it catches runtime differences that a Bun dev server cannot:
+
+```bash
+bunx wrangler d1 migrations apply my-app --local
+bunx wrangler dev
+```
+
+Put local secrets in `.dev.vars` (and add it to `.gitignore`):
+
+```
+APP_KEY=base64:...
+```
+
+Your normal `bun run dev` server is still the faster loop for day-to-day work. Reach for `wrangler dev` when you are about to deploy, or when something behaves differently in production.
+
+## Upgrading an Existing App
+
+`wrangler.jsonc` is scaffolded once and never overwritten, so an app created before a plugin update keeps its original config. The build prints exactly which entries are missing when it finds an outdated one — add them and rebuild.
+
+## Post-Deployment
+
+- Point a custom domain at the worker in the Cloudflare dashboard, then update any OAuth callback URLs to match.
+- Follow the [Production Operations Runbook](./operations.md) for monitoring and incident response.

--- a/docs/en/guides/deployment.md
+++ b/docs/en/guides/deployment.md
@@ -145,6 +145,22 @@ vercel deploy --prebuilt
 > [!NOTE]
 > The plugin targets SSR apps only. It reads Vite manifests to inject the correct `GUREN_INERTIA_*` environment variables into the serverless function. API-only apps should use Docker or Lambda instead.
 
+## Cloudflare Workers
+
+Apps can run on Cloudflare Workers with D1 as the database, via the official plugin.
+
+```bash
+bunx guren plugin @guren/plugin-cloudflare
+bun add @guren/plugin-cloudflare
+```
+
+```bash
+bunx guren cloudflare:build
+bunx wrangler deploy
+```
+
+Workers has no filesystem and shares no memory between requests, so sessions and OAuth state must be database-backed, and migrations are applied out of band. See the **[Cloudflare Workers Deployment Guide](./cloudflare.md)** for the full setup including D1, secrets, free-plan limits, and local development.
+
 ## Post-Deployment Tasks
 - Follow the [Production Operations Runbook](./operations.md) for SLO, incident response, and backup/restore drill policy.
 - Set up HTTPS (e.g. via a reverse proxy such as Nginx, Caddy, or your cloud platform).

--- a/docs/ja/guides/cloudflare.md
+++ b/docs/ja/guides/cloudflare.md
@@ -1,0 +1,201 @@
+# Cloudflare Workers へのデプロイ
+
+Guren は `@guren/plugin-cloudflare` を通じて Cloudflare Workers 上で動作し、データベースには D1 を使います。このガイドでは、まっさらなアカウントからデプロイ完了までを一通り扱います。
+
+Workers は常駐サーバーとは形の違うランタイムです。ファイルシステムがなく、リクエスト間でメモリを共有せず、CPU 時間はミリ秒単位で区切られています。このガイドの大部分は、その違いがアプリの設定に影響する数か所についての説明です。
+
+## インストール
+
+```bash
+bunx guren plugin @guren/plugin-cloudflare
+bun add @guren/plugin-cloudflare
+```
+
+プラグインは `cloudflare:build` コマンドを登録し、初回ビルド時に `wrangler.jsonc` を生成します。
+
+## ビルドとデプロイ
+
+```bash
+bunx guren cloudflare:build
+bunx wrangler deploy
+```
+
+`cloudflare:build` はアプリの `build` スクリプトを実行したあと、ワーカーのエントリポイント・静的アセット・平坦化したマイグレーションを含む `.cloudflare/` ディレクトリを組み立てます。古いワーカーをデプロイしてしまわないよう、両方を 1 つのスクリプトにまとめておきましょう。
+
+```json
+{
+  "scripts": {
+    "cloudflare:build": "bun run build && bunx guren cloudflare:build --skip-app-build",
+    "deploy:cloudflare": "bun run cloudflare:build && bunx wrangler deploy"
+  }
+}
+```
+
+> [!IMPORTANT]
+> `.cloudflare/` は生成物です。`.gitignore` に追加し、デプロイのたびに作り直してください。他のどこからも参照されないため、古いままだと気づかずに古いコードがデプロイされます。
+
+## データベース（D1）
+
+データベースを作成し、その ID を `wrangler.jsonc` に記録します。
+
+```bash
+bunx wrangler d1 create my-app
+```
+
+```jsonc
+{
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "my-app",
+      "database_id": "<wrangler が出力した ID>",
+      "migrations_dir": ".cloudflare/d1-migrations"
+    }
+  ]
+}
+```
+
+ドライバはランタイムによって `config/database.ts` で切り替えます。D1 は SQLite 互換なので、スキーマは SQLite のダイアレクトで書き、開発時はローカルの SQLite ファイルを使います。
+
+```typescript
+import { createD1Database, createSqliteDatabase } from '@guren/core'
+import { getWorkersEnv } from '@guren/plugin-cloudflare'
+
+interface WorkersEnv {
+  DB: unknown
+}
+
+function isWorkersRuntime(): boolean {
+  return typeof navigator !== 'undefined' && navigator.userAgent === 'Cloudflare-Workers'
+}
+
+const database = isWorkersRuntime()
+  ? createD1Database({ binding: () => getWorkersEnv<WorkersEnv>().DB })
+  : createSqliteDatabase({
+      migrationsFolder: new URL('../db/migrations', import.meta.url),
+      filename: () => process.env.SQLITE_DATABASE_PATH ?? './data/guren.db',
+    })
+
+export const { getDatabase, configureOrm, seedDatabase } = database
+```
+
+バインディングは値ではなく解決関数として渡します。バインディングはリクエストが届いて初めて存在するため、遅延して読み取る必要があります。
+
+### マイグレーションの適用
+
+マイグレーションはアプリの外側で適用します。Workers 上でアプリが自分でマイグレートすることはありません。
+
+```bash
+bunx guren cloudflare:build          # .cloudflare/d1-migrations を再生成
+bunx wrangler d1 migrations apply my-app --remote
+```
+
+> [!WARNING]
+> 先にビルドしてください。`migrations_dir` は生成ディレクトリの中を指しているため、空のフォルダを見つけた `wrangler` は「適用するマイグレーションはありません」と**エラーではなく正常終了で**報告します。ビルド前に適用してしまうと、失敗が成功のように見えます。
+
+モデルの初期化では、ファイルシステムの確認を Workers 上では飛ばします（確認する対象が存在しないため）。
+
+```typescript
+export async function bootModels(): Promise<void> {
+  await configureOrm()
+  if (!isWorkersRuntime()) {
+    await seedDatabase()
+  }
+}
+```
+
+## セッションと OAuth state はデータベースに保存する
+
+これは好みの問題ではありません。各リクエストは別々の isolate に到達しうるうえ、isolate 同士はデータベース以外に何も共有しません。メモリ実装のままでもローカルでは動いているように見え、本番でセッションが毎回消えます。
+
+```typescript
+import { createApp, AuthServiceProvider, DatabaseSessionStore } from '@guren/core'
+import { sessions } from '../db/schema.js'
+
+const app = createApp({
+  providers: [AuthServiceProvider],
+  auth: {
+    autoSession: true,
+    sessionOptions: {
+      store: new DatabaseSessionStore(sessions),
+      cookieSecure: true,
+    },
+  },
+})
+```
+
+OAuth も同様です。認可へのリダイレクトと、そこから戻ってくるコールバックは別の isolate に届くのが普通なので、両者を結びつける state は共有された場所に置く必要があります。
+
+```typescript
+import { createOAuthManager, DatabaseOAuthStateStore } from '@guren/core'
+import { oauthStates } from '../db/schema.js'
+
+const oauth = createOAuthManager({
+  stateStore: new DatabaseOAuthStateStore(oauthStates),
+})
+```
+
+どちらのストアもテーブルを必要とします。スキーマは[認証ガイド](./authentication.md)を参照してください。
+
+## シークレット
+
+`APP_KEY` は必須です。セッションと CSRF の署名に使われ、これが無いとワーカーは起動時に例外を投げます。リクエストを 1 件も処理しないまま落ちます。
+
+```bash
+bun -e "console.log('base64:'+Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString('base64'))" | bunx wrangler secret put APP_KEY
+```
+
+アプリが読む他の値（OAuth の認証情報、API キーなど）も同じ方法で設定します。`wrangler secret put` で設定した値は実行時に `process.env.*` から参照できます。`wrangler.jsonc` の `vars` に書いてよいのは、秘密でない値だけです。
+
+## 無料プランの制限
+
+アプリの設計に影響する制限が 2 つあります。
+
+| 制限 | 値 | 意味 |
+|---|---|---|
+| ワーカーサイズ | 3 MB（gzip 後） | 生成コンテンツが大きい場合は予算との兼ね合いを検討する |
+| リクエストあたり CPU | 10 ミリ秒 | 重い処理はビルド時か保存時に寄せる |
+
+この CPU 制限により、パスワードハッシュは事実上不可能です。意図的に遅くしてある処理を 10 ミリ秒に収めることはできません。無料プランでは、パスワードではなく OAuth による認証を選んでください。フローは[認証ガイド](./authentication.md)を参照してください。
+
+同じ制約は「リクエスト時の仕事を減らす」設計を後押しします。Markdown の変換は読み取り時ではなく保存時に行い、静的なコンテンツはビルド時にレンダリングしておきます。処理内容がどうしても必要とする場合は、有料プランで CPU 制限が緩和されます。
+
+## 可観測性
+
+Workers は既定ではログを保持しません。本番で問題が起きたときの追跡が非常に困難になります。
+
+```jsonc
+{
+  "observability": {
+    "enabled": true
+  }
+}
+```
+
+再現しながらリアルタイムで見たい場合は `bunx wrangler tail` と併用してください。
+
+## ローカル開発
+
+`wrangler dev` はローカルの D1 を相手に実際のランタイムを動かします。Bun の開発サーバーでは検出できないランタイム差異を拾えるため、デプロイ前に一度通しておく価値があります。
+
+```bash
+bunx wrangler d1 migrations apply my-app --local
+bunx wrangler dev
+```
+
+ローカル用のシークレットは `.dev.vars` に置きます（`.gitignore` への追加も忘れずに）。
+
+```
+APP_KEY=base64:...
+```
+
+日々の開発では通常の `bun run dev` の方が速く回せます。`wrangler dev` は、デプロイ直前や、本番でだけ挙動が違うときに使ってください。
+
+## 既存アプリの更新
+
+`wrangler.jsonc` は初回のみ生成され、その後は上書きされません。そのため、プラグイン更新前に作られたアプリは元の設定を保ち続けます。古い設定を検出すると、ビルドが不足している項目を具体的に出力するので、それを追記して再ビルドしてください。
+
+## デプロイ後
+
+- Cloudflare のダッシュボードでワーカーに独自ドメインを割り当て、OAuth のコールバック URL も併せて更新します。
+- 監視とインシデント対応については[本番運用ランブック](./operations.md)を参照してください。

--- a/docs/ja/guides/deployment.md
+++ b/docs/ja/guides/deployment.md
@@ -143,6 +143,22 @@ vercel deploy --prebuilt
 > [!NOTE]
 > このプラグインは SSR アプリ専用です。Vite マニフェストを読み取り、サーバーレス関数に正しい `GUREN_INERTIA_*` 環境変数を注入します。API-only アプリは Docker や Lambda を使ってください。
 
+## Cloudflare Workers
+
+公式プラグインを使うと、データベースに D1 を用いて Cloudflare Workers 上でアプリを動かせます。
+
+```bash
+bunx guren plugin @guren/plugin-cloudflare
+bun add @guren/plugin-cloudflare
+```
+
+```bash
+bunx guren cloudflare:build
+bunx wrangler deploy
+```
+
+Workers にはファイルシステムがなく、リクエスト間でメモリを共有しません。そのためセッションと OAuth state はデータベースに保存する必要があり、マイグレーションはアプリの外側で適用します。D1・シークレット・無料プランの制限・ローカル開発を含む詳細は **[Cloudflare Workers へのデプロイ](./cloudflare.md)** を参照してください。
+
 ## デプロイ後の作業
 - HTTPS を設定（Nginx/Caddy などのリバースプロキシやクラウド機能）。
 - ログ・モニタリングを構成（Bun は stdout/stderr に出力するので、集約先へ転送）。

--- a/packages/server/src/errors/ExceptionHandler.ts
+++ b/packages/server/src/errors/ExceptionHandler.ts
@@ -125,6 +125,14 @@ export class ExceptionHandler {
       return
     }
 
+    // An app with no reporter configured would otherwise turn a 500 into a
+    // rendered page and nothing else — on a hosted runtime, where stdout is
+    // the only channel back to the operator, that leaves the failure
+    // undiagnosable. Anything registering a reporter owns the reporting.
+    if (this.reporters.length === 0) {
+      console.error('Unhandled exception:', error)
+    }
+
     // Call all reporters
     for (const reporter of this.reporters) {
       try {

--- a/packages/testing/src/controller.ts
+++ b/packages/testing/src/controller.ts
@@ -466,7 +466,54 @@ export function createControllerModuleMock() {
     static async findWith(): Promise<unknown> {
       return null
     }
+
+    // Read/write entry points a controller commonly reaches for. They are
+    // inert, but they have to exist: tests drive model behaviour by spying
+    // on them, and a spy cannot replace a method that was never defined.
+    static async all(): Promise<unknown[]> {
+      return []
+    }
+
+    static async create(): Promise<unknown> {
+      return {}
+    }
+
+    static async findOrFail(): Promise<unknown> {
+      return {}
+    }
+
+    static async first(): Promise<unknown> {
+      return null
+    }
+
+    static async delete(): Promise<void> {}
+
+    /** Chainable like the real query builder, and awaitable at any point. */
+    static select(): Record<string, unknown> {
+      const query: Record<string, unknown> = {
+        get: async () => [],
+        first: async () => null,
+        then: (resolve: (value: unknown[]) => unknown) => resolve([]),
+      }
+      for (const method of ['where', 'whereNotNull', 'whereNull', 'orderBy', 'limit', 'offset']) {
+        query[method] = () => query
+      }
+      return query
+    }
   }
+  /**
+   * `defineModel()` is the function form of a model declaration, and
+   * `@guren/core` exports it alongside the class form — so a controller
+   * under test can reach it through any model module it imports. It returns
+   * the same inert stub, named after the table it was given.
+   */
+  function defineModel(table: unknown, config: Record<string, unknown> = {}) {
+    return class DefinedModel extends AuthenticatableModel {
+      static override table = table
+      static config = config
+    }
+  }
+
   class Resource<T = Record<string, unknown>> {
     public resource: T
     public additionalData: Record<string, unknown> = {}
@@ -670,6 +717,7 @@ export function createControllerModuleMock() {
     Listener,
     Job,
     AuthenticatableModel,
+    defineModel,
     Resource,
     JsonResource,
     collect,

--- a/web/app/Services/docs-config.ts
+++ b/web/app/Services/docs-config.ts
@@ -70,7 +70,7 @@ const GUIDE_SECTIONS: readonly DocSectionConfig[] = [
   },
   {
     title: { en: 'Testing & Deployment', ja: 'テストとデプロイ' },
-    slugs: ['testing', 'deployment', 'serverless', 'operations'],
+    slugs: ['testing', 'deployment', 'serverless', 'cloudflare', 'operations'],
   },
   {
     title: { en: 'AI-Native Development', ja: 'AIネイティブ開発' },

--- a/web/modules/blog/app/Models/Post.ts
+++ b/web/modules/blog/app/Models/Post.ts
@@ -1,4 +1,4 @@
-import { defineModel } from '@guren/orm'
+import { defineModel } from '@guren/core'
 import { posts } from '../../../../db/schema.js'
 
 export type PostRecord = typeof posts.$inferSelect

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -1,5 +1,5 @@
 {
-  "name": "web",
+  "name": "guren-web",
   "main": ".cloudflare/worker.js",
   "compatibility_date": "2026-07-25",
   "compatibility_flags": [
@@ -23,12 +23,30 @@
   "d1_databases": [
     {
       "binding": "DB",
-      "database_name": "web",
-      "database_id": "TODO: run wrangler d1 create guren-web",
+      "database_name": "guren-web",
+      "database_id": "9cb55bab-b69d-4bab-b074-fdd65f468541",
       "migrations_dir": ".cloudflare/d1-migrations"
     }
   ],
   "vars": {
     "NODE_ENV": "production"
-  }
+  },
+  // This worker name previously hosted an abandoned Containers experiment.
+  // Its Durable Object class blocks any deploy that stops exporting it, and
+  // the remote is already at v1 — so v1 is restated as history (wrangler
+  // skips what is applied) and v2 drops the class. Nothing used it.
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": [
+        "GurenContainer"
+      ]
+    },
+    {
+      "tag": "v2",
+      "deleted_classes": [
+        "GurenContainer"
+      ]
+    }
+  ]
 }

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -11,7 +11,13 @@
     "@guren/cli": "./.cloudflare/stub-guren-cli.js",
     "@modelcontextprotocol/sdk/server/mcp.js": "./.cloudflare/stub-mcp-server.js",
     "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js": "./.cloudflare/stub-mcp-transport.js",
-    "shiki": "./stubs/shiki.js"
+    "shiki": "./stubs/shiki.js",
+    // Monorepo-only: app code resolves @guren/core through tsconfig paths to
+    // source while prebuilt dist files resolve @guren/orm through
+    // node_modules, so the bundle ends up with two ORM copies — and the
+    // adapter each model uses is configured on only one of them. Pinning the
+    // specifier keeps a single copy, and with it a single configured adapter.
+    "@guren/orm": "../packages/orm/dist/index.js"
   },
   "define": {
     "process.env.NODE_ENV": "\"production\"",
@@ -28,6 +34,11 @@
       "migrations_dir": ".cloudflare/d1-migrations"
     }
   ],
+  // Retains request logs and uncaught errors so a production failure can be
+  // diagnosed after the fact rather than only while a tail happens to run.
+  "observability": {
+    "enabled": true
+  },
   "vars": {
     "NODE_ENV": "production"
   },


### PR DESCRIPTION
## Summary

Sign-in failed in production on Workers with `DrizzleAdapter: database has not been configured`, while every public page served fine. Found by deploying guren.dev to Workers + D1 and actually signing in.

### One specifier, two modules

The worker bundle carried **two copies of `@guren/orm`**: app code resolves `@guren/core` through tsconfig paths to *source*, while prebuilt `dist` files resolve `@guren/orm` through `node_modules`. `configureOrm()` configures the adapter on one copy — so models reached through the other, namely the database-backed **session and OAuth state stores**, had no database at all.

That asymmetry is exactly why the symptom looked so strange: public pages never touch those stores, so only the moment a session is written failed.

Pinning the specifier in the wrangler alias map leaves one copy, and the blog's model now imports through `@guren/core` like the rest of the app.

The `2 copies of @guren/orm` warning the build already prints was reporting precisely this. It reads as monorepo noise, which is how it went ignored through several deploys.

### A 500 with no trace

`ExceptionHandler` only notified registered reporters, so an app that never called `reporter()` rendered an error page and logged **nothing**. On a hosted runtime, where stdout is the only channel back to the operator, that left the failure above diagnosable only by bisecting code. It now writes to the console when no reporter is registered; anything that registers one still owns reporting entirely.

### Testing gap the fix uncovered

Moving the model to the documented core-first import path broke its controller tests: `createControllerModuleMock()` stubbed `AuthenticatableModel` but not `defineModel`, which `@guren/core` exports right alongside it, so the suite failed to load. The stub also had no `create`/`select`/`findOrFail`/`all`/`first`/`delete` — tests drive model behaviour by spying on those, and a spy cannot replace a method that was never defined.

## Testing

- `bun run test:bun`: 2,789 tests, 0 fail
- web suite: 71 tests; `typecheck` clean
- **Verified against the deployed worker**: sign-in now completes end to end, with the account row (passwordless, as designed) and its session present in production D1

Refs: RFC 0003