### PR TITLE
chore(web): serve the site at guren.dev

### DIFF
--- a/web/app/Http/Middleware/canonical-host.ts
+++ b/web/app/Http/Middleware/canonical-host.ts
@@ -1,0 +1,23 @@
+import { defineMiddleware } from '@guren/core'
+
+/**
+ * Redirect a `www.` request to the bare host, permanently.
+ *
+ * Both hostnames resolve to this worker, so without it the site would answer
+ * on two origins — splitting sessions (cookies are host-scoped) and search
+ * ranking, and letting the same page be indexed twice.
+ *
+ * Only the leading `www.` is stripped: any other host reaching the worker is
+ * left alone, so preview and local hostnames keep working.
+ */
+export const redirectToCanonicalHost = defineMiddleware(async (c, next) => {
+  const url = new URL(c.req.url)
+
+  if (!url.hostname.startsWith('www.')) {
+    return next()
+  }
+
+  url.hostname = url.hostname.slice('www.'.length)
+
+  return c.redirect(url.toString(), 301)
+})

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -3,6 +3,7 @@ import {
   AuthServiceProvider as CoreAuthServiceProvider,
   DatabaseSessionStore,
 } from '@guren/core'
+import { redirectToCanonicalHost } from '../app/Http/Middleware/canonical-host.js'
 import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
 import { sessions } from '../db/schema.js'
 import { blogModule } from '../modules/blog/index.js'
@@ -29,5 +30,9 @@ const app = createApp({
     },
   },
 })
+
+// Both hostnames are routed to this worker, so the redirect lives here
+// rather than in DNS.
+app.use('*', redirectToCanonicalHost)
 
 export default app

--- a/web/tests/middleware/canonical-host.test.ts
+++ b/web/tests/middleware/canonical-host.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { redirectToCanonicalHost } from '../../app/Http/Middleware/canonical-host.js'
+
+type MiddlewareContext = Parameters<typeof redirectToCanonicalHost>[0]
+
+function contextFor(url: string) {
+  let redirectedTo: string | undefined
+  let redirectStatus: number | undefined
+
+  const ctx = {
+    req: { url },
+    redirect: (target: string, status: number) => {
+      redirectedTo = target
+      redirectStatus = status
+      return new Response(null, { status, headers: { location: target } })
+    },
+  } as unknown as MiddlewareContext
+
+  return {
+    ctx,
+    get redirectedTo() {
+      return redirectedTo
+    },
+    get redirectStatus() {
+      return redirectStatus
+    },
+  }
+}
+
+async function run(url: string) {
+  const probe = contextFor(url)
+  let reachedApp = false
+
+  await redirectToCanonicalHost(probe.ctx, async () => {
+    reachedApp = true
+  })
+
+  return { ...probe, reachedApp }
+}
+
+describe('redirectToCanonicalHost', () => {
+  it('should send www to the bare host permanently', async () => {
+    const result = await run('https://www.guren.dev/docs/guides/routing')
+
+    expect(result.redirectStatus).toBe(301)
+    expect(result.redirectedTo).toBe('https://guren.dev/docs/guides/routing')
+    expect(result.reachedApp).toBe(false)
+  })
+
+  it('should preserve the query string', async () => {
+    const result = await run('https://www.guren.dev/search?q=inertia&page=2')
+
+    expect(result.redirectedTo).toBe('https://guren.dev/search?q=inertia&page=2')
+  })
+
+  it('should leave the bare host alone', async () => {
+    const result = await run('https://guren.dev/blog')
+
+    expect(result.reachedApp).toBe(true)
+    expect(result.redirectedTo).toBeUndefined()
+  })
+
+  it('should not touch hosts that merely contain www', async () => {
+    // Only a leading `www.` is a hostname to redirect away from — stripping
+    // it anywhere else would send visitors to a host that does not exist.
+    const result = await run('https://wwwguren.dev/blog')
+
+    expect(result.reachedApp).toBe(true)
+  })
+
+  it('should leave local and preview hosts alone', async () => {
+    for (const url of ['http://localhost:3333/', 'https://guren-web.workers.dev/docs']) {
+      expect((await run(url)).reachedApp).toBe(true)
+    }
+  })
+})

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -9,6 +9,10 @@
     {
       "pattern": "guren.dev",
       "custom_domain": true
+    },
+    {
+      "pattern": "www.guren.dev",
+      "custom_domain": true
     }
   ],
   "compatibility_date": "2026-07-25",

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -1,6 +1,16 @@
 {
   "name": "guren-web",
   "main": ".cloudflare/worker.js",
+  // Serves the site at its own domain. Cloudflare is already authoritative
+  // for the zone, so deploying this claims the hostname and issues the
+  // certificate; the apex A records pointing elsewhere have to be removed
+  // first or the record conflicts.
+  "routes": [
+    {
+      "pattern": "guren.dev",
+      "custom_domain": true
+    }
+  ],
   "compatibility_date": "2026-07-25",
   "compatibility_flags": [
     "nodejs_compat"


### PR DESCRIPTION
Claims the apex as a custom domain for the worker, so the site is served from Workers rather than the previous host.

Cloudflare is already authoritative for the zone, so deploying this creates the DNS record and issues the certificate. The apex `A` records pointing at the previous host have to be removed first or the record conflicts — that removal is the actual cutover moment.

Keeping the domain in the config rather than the dashboard means a later deploy cannot silently drop it.

**Not part of this PR**, and needed at cutover: the GitHub OAuth app's callback URL and the `OAUTH_GITHUB_REDIRECT_URI` secret both move to `https://guren.dev/auth/github/callback`. Until both change, admin sign-in is unavailable; public pages are unaffected.

Refs: RFC 0003