### PR TITLE
fix(server): let apps configure the Inertia document instead of hardcoding a Docs/ prefix

### DIFF
--- a/.changeset/inertia-document-options.md
+++ b/.changeset/inertia-document-options.md
@@ -1,0 +1,17 @@
+---
+'@guren/server': minor
+---
+
+Let apps configure the server-rendered Inertia document through `setInertiaDocument()`.
+
+The `<body>` class and the critical CSS inlined into `<head>` were hardcoded to page components named `Docs/*`. Any other page whose theme is applied by a client effect painted the stylesheet's default surface color first and only corrected itself once React hydrated — a visible flash on the very first frame.
+
+`setInertiaDocument({ bodyClass, criticalCss, prepaintScript })` moves that decision to the app. Each field takes a string or a function of the page component, so a docs section can claim a light surface while marketing pages keep a dark one. The same three fields exist on `InertiaOptions` for per-response overrides. Call it at module scope in the app entry so every runtime — the Bun server, serverless handlers, generated worker bundles — picks it up.
+
+The old `Docs/*` special case is gone, but no scaffold or template ever emitted a page component under that name, so nothing needs migrating:
+
+```typescript
+setInertiaDocument({
+  bodyClass: ({ component }) => (component.startsWith('Docs/') ? 'docs-theme' : undefined),
+})
+```

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -17,9 +17,11 @@ export type {
   ResourceRouteOptions,
 } from './mvc/Router'
 export { ViewEngine } from './mvc/ViewEngine'
-export { inertia, setInertiaSsrRenderer } from './mvc/inertia/InertiaEngine'
+export { inertia, setInertiaSsrRenderer, setInertiaDocument } from './mvc/inertia/InertiaEngine'
 export { setInertiaSharedProps, getInertiaSharedPropsResolver, shareInertiaProps } from './mvc/inertia/shared'
 export type {
+  InertiaDocumentContext,
+  InertiaDocumentOptions,
   InertiaOptions,
   InertiaPagePayload,
   InertiaSsrContext,

--- a/packages/server/src/mvc/inertia/InertiaEngine.ts
+++ b/packages/server/src/mvc/inertia/InertiaEngine.ts
@@ -5,7 +5,16 @@ import { parseImportMap } from "../../support/import-map";
 
 ensureErrorStackTracePolyfill();
 
-export interface InertiaOptions {
+/**
+ * Per-response form of {@link InertiaDocumentOptions}: the same fields, already
+ * resolved to strings. Each one overrides the app-wide default registered
+ * through {@link setInertiaDocument}.
+ */
+type InertiaDocumentOverrides = {
+  readonly [K in keyof InertiaDocumentOptions]?: string;
+};
+
+export interface InertiaOptions extends InertiaDocumentOverrides {
   readonly url?: string;
   readonly version?: string;
   readonly status?: number;
@@ -47,6 +56,68 @@ export interface InertiaSsrOptions {
   entry?: string;
   manifest?: string;
   render?: InertiaSsrRenderer;
+}
+
+export interface InertiaDocumentContext {
+  /** Page component being rendered, e.g. `"Docs/Show"`. */
+  readonly component: string;
+}
+
+type InertiaDocumentValue =
+  | string
+  | ((context: InertiaDocumentContext) => string | undefined);
+
+export interface InertiaDocumentOptions {
+  /**
+   * Class attribute for the root `<body>` element. Pass a function to vary it
+   * per page component — a docs section that needs a light surface while the
+   * marketing pages keep a dark one, for instance.
+   */
+  readonly bodyClass?: InertiaDocumentValue;
+  /**
+   * CSS inlined into `<head>` ahead of the stylesheet links. Keep it to the
+   * few declarations that decide the first paint (surface and text colors);
+   * the main stylesheet still wins for everything it defines later.
+   */
+  readonly criticalCss?: InertiaDocumentValue;
+  /**
+   * Body of a blocking inline `<script>` executed before the first paint.
+   * Use it for theme prepaint logic that has to read `localStorage` or
+   * `matchMedia` before React hydrates.
+   */
+  readonly prepaintScript?: InertiaDocumentValue;
+}
+
+let documentOptions: InertiaDocumentOptions | undefined;
+
+/**
+ * Register app-wide document defaults for server-rendered Inertia responses.
+ *
+ * Without this, the `<body>` ships without a class and nothing is inlined into
+ * `<head>`, so a page whose theme is applied by a client effect flashes the
+ * stylesheet's default surface color until React hydrates. Call it at module
+ * scope in the app entry so every runtime (Bun, serverless handlers, generated
+ * worker bundles) picks it up.
+ *
+ * Registration is process-wide and not request-scoped: calling this while
+ * requests are in flight leaks the new policy into them. Use the matching
+ * {@link InertiaOptions} fields for a single response instead.
+ *
+ * The values are emitted verbatim inside `<style>` / `<script>` elements —
+ * they are developer-authored assets, never user input.
+ *
+ * ```typescript
+ * setInertiaDocument({
+ *   bodyClass: ({ component }) => (component.startsWith('Docs/') ? 'docs-theme' : undefined),
+ * })
+ * ```
+ *
+ * Pass `undefined` to clear (test isolation).
+ */
+export function setInertiaDocument(
+  options: InertiaDocumentOptions | undefined
+): void {
+  documentOptions = options;
 }
 
 let defaultSsrRenderer: InertiaSsrRenderer | undefined;
@@ -168,7 +239,16 @@ async function renderDocument(
   const importMap = JSON.stringify({ imports: importMapEntries }, null, 2);
   const serializedPage = serializePage(page);
   const stylesheetLinks = renderStyles(styles);
-  const docsHeadBootstrap = renderDocsHeadBootstrap(page.component);
+  const criticalCss = resolveDocumentValue(
+    "criticalCss",
+    options,
+    page.component
+  );
+  const prepaintScript = resolveDocumentValue(
+    "prepaintScript",
+    options,
+    page.component
+  );
   const ssrResult = await tryRenderSsr(page, options);
   const headElements = (ssrResult?.head ?? []).map(normalizeHeadElement);
   const hasCustomTitle = headElements.some((element) =>
@@ -178,7 +258,10 @@ async function renderDocument(
     '<meta charset="utf-8" />',
     '<meta name="viewport" content="width=device-width, initial-scale=1" />',
     hasCustomTitle ? "" : `<title>${title}</title>`,
-    docsHeadBootstrap,
+    // Both must precede the stylesheet links: they exist to settle the first
+    // paint before the app's own CSS arrives.
+    criticalCss ? `<style id="guren-critical">${criticalCss}</style>` : "",
+    prepaintScript ? `<script>${prepaintScript}</script>` : "",
     stylesheetLinks,
     ...headElements,
     Object.keys(importMapEntries).length > 0
@@ -192,7 +275,7 @@ async function renderDocument(
   const appMarkup =
     ssrResult?.body ??
     `<script data-page="app" type="application/json">${serializedPage}</script><div id="app"></div>`;
-  const bodyClass = resolveBodyClass(page.component);
+  const bodyClass = resolveDocumentValue("bodyClass", options, page.component);
   const bodyAttributes = bodyClass ? ` class="${escapeAttribute(bodyClass)}"` : "";
   const lang = escapeAttribute(options.lang ?? "en");
 
@@ -345,40 +428,27 @@ function normalizeHeadElement(element: unknown): string {
   );
 }
 
-function resolveBodyClass(componentName: string): string {
-  return componentName.startsWith("Docs/") ? "docs-theme" : "";
-}
+/**
+ * Resolves one document field: the per-response override wins, then the
+ * app-wide default, then the empty string (meaning "emit nothing").
+ */
+function resolveDocumentValue(
+  key: keyof InertiaDocumentOptions,
+  options: InertiaOptions,
+  componentName: string
+): string {
+  const override = options[key];
 
-function renderDocsHeadBootstrap(componentName: string): string {
-  if (!componentName.startsWith("Docs/")) {
-    return "";
+  if (override !== undefined) {
+    return override;
   }
 
-  const criticalStyles = [
-    "html,body{background:#ffffff;color:#1f2937;}",
-    "body.docs-theme{background:#ffffff;color:#1f2937;}",
-    "html.dark,html.dark body,html.dark body.docs-theme{background:#1a1a2e;color:#e0def4;}",
-    ".size-4{width:1rem;height:1rem;}",
-    ".size-5{width:1.25rem;height:1.25rem;}",
-    ".size-6{width:1.5rem;height:1.5rem;}",
-    ".size-8{width:2rem;height:2rem;}",
-    ".size-9{width:2.25rem;height:2.25rem;}",
-  ].join("");
+  const value = documentOptions?.[key];
 
-  const prepaintScript = [
-    "(function(){",
-    "try{",
-    "var mode=localStorage.getItem('guren-color-mode')||'system';",
-    "var dark=mode==='dark'||(mode!=='light'&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches);",
-    "var root=document.documentElement;",
-    "root.classList.toggle('dark',dark);",
-    "root.style.colorScheme=dark?'dark':'light';",
-    "}catch(_){",
-    "}",
-    "})();",
-  ].join("");
-
-  return `<style id="guren-docs-critical">${criticalStyles}</style><script>${prepaintScript}</script>`;
+  return (
+    (typeof value === "function" ? value({ component: componentName }) : value) ??
+    ""
+  );
 }
 
 function serializePage(page: InertiaPagePayload): string {

--- a/packages/server/tests/mvc/InertiaEngine.test.ts
+++ b/packages/server/tests/mvc/InertiaEngine.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'bun:test'
-import { inertia, setInertiaSsrRenderer } from '../../src'
+import { afterEach, describe, expect, it } from 'bun:test'
+import { inertia, setInertiaDocument, setInertiaSsrRenderer } from '../../src'
 
 describe('InertiaEngine SSR integration', () => {
+  afterEach(() => {
+    setInertiaDocument(undefined)
+  })
+
   it('renders client-side shell when no SSR renderer is configured', async () => {
     const response = await inertia('Dashboard', { stats: { users: 2 } }, { url: '/dashboard' })
     const body = await response.text()
@@ -12,21 +16,91 @@ describe('InertiaEngine SSR integration', () => {
   })
 
 
-  it('adds docs body class for docs pages', async () => {
+  it('ships a bare body and head when no document options are registered', async () => {
     const response = await inertia('Docs/Show', { categories: [] }, { url: '/docs/guides/overview' })
     const body = await response.text()
 
-    expect(body).toContain('<body class="docs-theme">')
+    expect(body).toContain('<body>')
+    expect(body).not.toContain('id="guren-critical"')
   })
 
+  it('applies the app-wide body class to every page component', async () => {
+    setInertiaDocument({ bodyClass: 'app-theme' })
 
-  it('injects docs prepaint critical style and script', async () => {
+    const response = await inertia('Dashboard', {}, { url: '/dashboard' })
+    const body = await response.text()
+
+    expect(body).toContain('<body class="app-theme">')
+  })
+
+  it('resolves document options per page component', async () => {
+    setInertiaDocument({
+      bodyClass: ({ component }) => (component.startsWith('Docs/') ? 'docs-theme' : undefined),
+    })
+
+    const docs = await inertia('Docs/Show', { categories: [] }, { url: '/docs/guides/overview' })
+    const home = await inertia('Home', {}, { url: '/' })
+
+    expect(await docs.text()).toContain('<body class="docs-theme">')
+    expect(await home.text()).toContain('<body>')
+  })
+
+  it('inlines critical CSS and the prepaint script into the head', async () => {
+    setInertiaDocument({
+      criticalCss: 'body{background:#ffffff;}',
+      prepaintScript: "document.documentElement.classList.add('dark');",
+    })
+
     const response = await inertia('Docs/Show', { categories: [] }, { url: '/docs/guides/overview' })
     const body = await response.text()
 
-    expect(body).toContain('id="guren-docs-critical"')
-    expect(body).toContain("localStorage.getItem('guren-color-mode')")
-    expect(body).toContain("prefers-color-scheme: dark")
+    expect(body).toContain('<style id="guren-critical">body{background:#ffffff;}</style>')
+    expect(body).toContain("<script>document.documentElement.classList.add('dark');</script>")
+  })
+
+  it('places the critical CSS and prepaint script ahead of the stylesheet links', async () => {
+    setInertiaDocument({
+      criticalCss: 'body{background:#ffffff;}',
+      prepaintScript: "document.documentElement.classList.add('dark');",
+    })
+
+    const response = await inertia(
+      'Docs/Show',
+      {},
+      { url: '/docs/guides/overview', styles: ['/assets/app.css'] },
+    )
+    const body = await response.text()
+
+    expect(body.indexOf('id="guren-critical"')).toBeLessThan(body.indexOf('/assets/app.css'))
+    expect(body.indexOf('classList.add')).toBeLessThan(body.indexOf('/assets/app.css'))
+  })
+
+  it('treats an empty per-call override as a suppression of the app-wide default', async () => {
+    setInertiaDocument({ bodyClass: 'docs-theme', criticalCss: 'body{background:#ffffff;}' })
+
+    const response = await inertia(
+      'Docs/Show',
+      {},
+      { url: '/docs/guides/overview', bodyClass: '', criticalCss: '' },
+    )
+    const body = await response.text()
+
+    expect(body).toContain('<body>')
+    expect(body).not.toContain('id="guren-critical"')
+  })
+
+  it('lets per-call options override the app-wide document defaults', async () => {
+    setInertiaDocument({ bodyClass: 'docs-theme', criticalCss: 'body{background:#ffffff;}' })
+
+    const response = await inertia(
+      'Docs/Show',
+      { categories: [] },
+      { url: '/docs/guides/overview', bodyClass: 'print-theme', criticalCss: 'body{background:#000000;}' },
+    )
+    const body = await response.text()
+
+    expect(body).toContain('<body class="print-theme">')
+    expect(body).toContain('<style id="guren-critical">body{background:#000000;}</style>')
   })
 
   it('utilizes provided SSR renderer when available', async () => {

--- a/web/config/document-theme.ts
+++ b/web/config/document-theme.ts
@@ -1,0 +1,44 @@
+// Markup inlined into the server-rendered document `<head>`. Imported only by
+// `src/app.ts` — keeping these strings out of `theme.ts` keeps them out of the
+// client bundle, where they would ship on every page and never be read.
+
+import { COLOR_MODE_STORAGE_KEY, LIGHT_SURFACE_BODY_CLASS } from './theme.js'
+
+/**
+ * Surface and text colors for the first paint, inlined ahead of the stylesheet
+ * links. Duplicates the `--docs-surface-page` / `--docs-text-primary` values
+ * from `resources/css/app.css` — CSS custom properties cannot be read from TS,
+ * so retheming the docs surface means editing both files.
+ */
+const SURFACE_CSS = `
+html,body{background:#ffffff;color:#1f2937;}
+body.${LIGHT_SURFACE_BODY_CLASS}{background:#ffffff;color:#1f2937;}
+html.dark,html.dark body,html.dark body.${LIGHT_SURFACE_BODY_CLASS}{background:#1a1a2e;color:#e0def4;}
+`
+
+/** Tailwind `size-*` utilities the generated stylesheet does not always emit. */
+const SIZE_UTILITIES = `
+.size-4{width:1rem;height:1rem;}
+.size-5{width:1.25rem;height:1.25rem;}
+.size-6{width:1.5rem;height:1.5rem;}
+.size-8{width:2rem;height:2rem;}
+.size-9{width:2.25rem;height:2.25rem;}
+`
+
+export const LIGHT_SURFACE_CRITICAL_CSS = `${SURFACE_CSS}${SIZE_UTILITIES}`
+
+/**
+ * Resolves the color mode before the first paint, so a dark-mode reader never
+ * sees a light flash. Mirrors `applyMode()` in
+ * `resources/js/pages/Docs/theme.ts` — the two must agree, and nothing but this
+ * comment enforces that.
+ */
+export const COLOR_MODE_PREPAINT_SCRIPT = `(function(){
+  try{
+    var mode = localStorage.getItem('${COLOR_MODE_STORAGE_KEY}') || 'system';
+    var dark = mode === 'dark' || (mode !== 'light' && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    var root = document.documentElement;
+    root.classList.toggle('dark', dark);
+    root.style.colorScheme = dark ? 'dark' : 'light';
+  }catch(_){}
+})();`

--- a/web/config/theme.ts
+++ b/web/config/theme.ts
@@ -1,0 +1,22 @@
+// Shared theme constants. Imported by both the server document config and the
+// React pages, so keep this module dependency-free and side-effect-free.
+//
+// Anything only the server needs belongs in `document-theme.ts` instead — this
+// module is reachable from the client bundle.
+
+/** localStorage key holding the user's light / dark / system preference. */
+export const COLOR_MODE_STORAGE_KEY = 'guren-color-mode'
+
+/**
+ * `<body>` class that swaps the default crimson marketing surface for the
+ * light documentation surface. Mirrors the `body.docs-theme` rule in
+ * `resources/css/app.css`.
+ */
+export const LIGHT_SURFACE_BODY_CLASS = 'docs-theme'
+
+/** Page components rendered on the light documentation surface. */
+const LIGHT_SURFACE_PREFIXES = ['Docs/', 'blog/', 'admin/']
+
+export function usesLightSurface(component: string): boolean {
+  return LIGHT_SURFACE_PREFIXES.some((prefix) => component.startsWith(prefix))
+}

--- a/web/resources/js/app.tsx
+++ b/web/resources/js/app.tsx
@@ -1,4 +1,17 @@
+import { router } from '@inertiajs/react'
 import '../css/app.css'
+import { LIGHT_SURFACE_BODY_CLASS, usesLightSurface } from '../../config/theme.js'
+
+// The server puts this class on <body> for the initial document; client-side
+// visits never re-render it, so mirror the same rule here. Driving it from
+// `usesLightSurface` — the predicate the server uses too — keeps one list of
+// light-surface pages instead of a hook call each page has to remember.
+router.on('navigate', (event: { detail: { page: { component: string } } }) => {
+  document.body.classList.toggle(
+    LIGHT_SURFACE_BODY_CLASS,
+    usesLightSurface(event.detail.page.component),
+  )
+})
 
 let pages: Record<string, () => Promise<unknown>> | undefined
 

--- a/web/resources/js/pages/Docs/Index.tsx
+++ b/web/resources/js/pages/Docs/Index.tsx
@@ -36,7 +36,6 @@ import { Footer } from '../../components/Footer.js'
 import { Header } from '../../components/Header.js'
 import { Seo } from '../../components/Seo.js'
 import { BookOpenIcon, TerminalIcon } from '../../components/icons.js'
-import { useDocsPageTheme } from './theme.js'
 
 const HERO_COPY = {
   en: {
@@ -56,8 +55,6 @@ const HERO_COPY = {
 } as const
 
 export default function DocsIndex({ categories, locale, locales = [], basePath }: Props) {
-  useDocsPageTheme()
-
   const copy = HERO_COPY[locale]
 
   return (

--- a/web/resources/js/pages/Docs/Show.tsx
+++ b/web/resources/js/pages/Docs/Show.tsx
@@ -5,7 +5,7 @@ import { Footer } from '../../components/Footer.js'
 import { Header } from '../../components/Header.js'
 import { Seo } from '../../components/Seo.js'
 import { breadcrumbJsonLd, techArticleJsonLd } from '../../lib/structured-data.js'
-import { docsTheme, useDocsPageTheme } from './theme.js'
+import { docsTheme } from './theme.js'
 
 type DocSummary = {
   slug: string
@@ -156,8 +156,6 @@ function useTableOfContents(doc: DocPage | null) {
 }
 
 export default function DocsShow({ categories, doc, active, locale, locales = [], basePath }: Props) {
-  useDocsPageTheme()
-
   const docLabel = doc?.category === 'tutorials' ? 'Tutorial' : 'Guide'
   const docPath = doc ? `${basePath}/${doc.category}/${doc.slug}` : basePath
   const nav = buildPrevNext(categories, active, basePath)

--- a/web/resources/js/pages/Docs/theme.ts
+++ b/web/resources/js/pages/Docs/theme.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState, useSyncExternalStore } from 'react'
+import { COLOR_MODE_STORAGE_KEY as STORAGE_KEY } from '../../../../config/theme.js'
 
 export const docsTheme = {
   fontFamily: 'system-ui, sans-serif',
@@ -30,20 +31,9 @@ export const docsTheme = {
 
 export type DocsTheme = typeof docsTheme
 
-export function useDocsPageTheme() {
-  useEffect(() => {
-    document.body.classList.add('docs-theme')
-    return () => {
-      document.body.classList.remove('docs-theme')
-    }
-  }, [])
-}
-
 // ─── Color mode (light / dark / system) ───
 
 export type ColorMode = 'light' | 'dark' | 'system'
-
-const STORAGE_KEY = 'guren-color-mode'
 
 function getStoredMode(): ColorMode {
   if (typeof window === 'undefined') return 'system'

--- a/web/resources/js/pages/admin/PostForm.tsx
+++ b/web/resources/js/pages/admin/PostForm.tsx
@@ -1,7 +1,6 @@
 import { Head, Link, useForm } from '@inertiajs/react'
 import type { FormEvent } from 'react'
 import { pageTitle } from '../../../../config/site.js'
-import { useDocsPageTheme } from '../Docs/theme.js'
 
 type EditablePost = {
   id: number
@@ -16,8 +15,6 @@ interface Props {
 }
 
 export default function AdminPostForm({ post }: Props) {
-  useDocsPageTheme()
-
   const form = useForm({
     title: post?.title ?? '',
     description: post?.description ?? '',

--- a/web/resources/js/pages/admin/Posts.tsx
+++ b/web/resources/js/pages/admin/Posts.tsx
@@ -1,6 +1,5 @@
 import { Head, Link, router } from '@inertiajs/react'
 import { pageTitle } from '../../../../config/site.js'
-import { useDocsPageTheme } from '../Docs/theme.js'
 
 type AdminPostSummary = {
   id: number
@@ -23,8 +22,6 @@ function formatDate(iso: string): string {
 }
 
 export default function AdminPosts({ posts }: Props) {
-  useDocsPageTheme()
-
   const togglePublish = (post: AdminPostSummary) => {
     router.post(`/admin/posts/${post.id}/publish`, { published: !post.publishedAt })
   }

--- a/web/resources/js/pages/blog/Index.tsx
+++ b/web/resources/js/pages/blog/Index.tsx
@@ -3,7 +3,6 @@ import { SITE_DESCRIPTION, pageTitle } from '../../../../config/site.js'
 import { Footer } from '../../components/Footer.js'
 import { Header } from '../../components/Header.js'
 import { Seo } from '../../components/Seo.js'
-import { useDocsPageTheme } from '../Docs/theme.js'
 
 type BlogPostSummary = {
   slug: string
@@ -26,8 +25,6 @@ function formatDate(iso: string | null): string {
 }
 
 export default function BlogIndex({ posts }: Props) {
-  useDocsPageTheme()
-
   return (
     <>
       <Seo

--- a/web/resources/js/pages/blog/Show.tsx
+++ b/web/resources/js/pages/blog/Show.tsx
@@ -3,7 +3,6 @@ import { SITE_DESCRIPTION, pageTitle } from '../../../../config/site.js'
 import { Footer } from '../../components/Footer.js'
 import { Header } from '../../components/Header.js'
 import { Seo } from '../../components/Seo.js'
-import { useDocsPageTheme } from '../Docs/theme.js'
 
 type BlogPost = {
   slug: string
@@ -27,8 +26,6 @@ function formatDate(iso: string | null): string {
 }
 
 export default function BlogShow({ post }: Props) {
-  useDocsPageTheme()
-
   return (
     <>
       {post ? (

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -2,13 +2,28 @@ import {
   createApp,
   AuthServiceProvider as CoreAuthServiceProvider,
   DatabaseSessionStore,
+  setInertiaDocument,
 } from '@guren/core'
 import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
+import {
+  COLOR_MODE_PREPAINT_SCRIPT,
+  LIGHT_SURFACE_CRITICAL_CSS,
+} from '../config/document-theme.js'
+import { LIGHT_SURFACE_BODY_CLASS, usesLightSurface } from '../config/theme.js'
 import { sessions } from '../db/schema.js'
 import { blogModule } from '../modules/blog/index.js'
 import registerWebRoutes from '../routes/web.js'
 
 const secureCookies = process.env.NODE_ENV === 'production' && !process.env.CI
+
+// Registered at module scope so every entrypoint picks it up — the Bun server,
+// the Vercel handler, and the generated Workers bundle all import this module.
+setInertiaDocument({
+  bodyClass: ({ component }) => (usesLightSurface(component) ? LIGHT_SURFACE_BODY_CLASS : undefined),
+  criticalCss: ({ component }) => (usesLightSurface(component) ? LIGHT_SURFACE_CRITICAL_CSS : undefined),
+  prepaintScript: ({ component }) =>
+    usesLightSurface(component) ? COLOR_MODE_PREPAINT_SCRIPT : undefined,
+})
 
 const app = createApp({
   routes: registerWebRoutes,


### PR DESCRIPTION
## Summary

`/blog` painted a dark red background (`#450a0a`) on its first frame and turned white a moment later.

`web/resources/css/app.css` defaults `body` to the crimson marketing surface, and only `body.docs-theme` is light. That class was applied server-side by `InertiaEngine`, but only for page components whose name started with `Docs/` — a hardcoded prefix in `@guren/server`. Blog and admin pages are named `blog/*` and `admin/*`, so they got the class only from a client `useEffect`, i.e. after hydration.

Two changes:

**`@guren/server`** — replace the hardcoded `Docs/` special case with `setInertiaDocument({ bodyClass, criticalCss, prepaintScript })`. Each field takes a string or a function of the page component. The same three fields exist on `InertiaOptions` for per-response overrides, derived from the registry type via a mapped type so the two lists cannot drift. Follows the existing `setInertiaSsrRenderer` / `setInertiaSharedProps` module-scope pattern in the same package.

**`web`** — register the site's own surface policy at module scope in `src/app.ts`, which all three entrypoints import (Bun `src/main.ts`, Vercel `src/index.ts`, and the generated `.cloudflare/worker.js`).

Two follow-on cleanups that fell out of review:

- Client-side visits never re-render `<body>`, so the class still needs maintaining on navigation. That was six per-page `useDocsPageTheme()` calls, kept in sync with the server's list by nothing at all — exactly the split that produced this bug. Both halves now read one predicate, driven from a single `navigate` listener in the client entry.
- The inlined `<head>` markup lives in a server-only module. Routing it through the shared theme module pulled ~3KB of never-read strings into the client bundle of every page, including the landing page.

## Scope

`server`, `docs` (the guren.dev site under `web/`).

## Risk Assessment

- **New public API**, no removal from a shipped surface: `setInertiaDocument` plus three `InertiaOptions` fields. Changeset is `minor` for `@guren/server`.
- **The `Docs/*` special case is gone.** No template under `packages/cli/templates` or `packages/create-app` emits a page component under that name, so no published app can be relying on it — guren.dev was the only consumer.
- **`/docs` output is unchanged** except for one intentional rename: the inlined `<style>` id `guren-docs-critical` became `guren-critical`, since the element is no longer docs-specific. Nothing references that id. The CSS and script bodies diff byte-identical against production `https://guren.dev/docs`.
- `Home` is untouched — no body class, no inlined markup, still `#450a0a`.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck` (monorepo + `web`)
- [x] `bun run test` — `test:bun` 2745 pass / 0 fail, `test:examples` 71 pass
- [x] `bun run audit:core-first`, `bun run audit:docs`
- [x] `web` client + SSR + Cloudflare bundles build

Server HTML, against a local production build:

| route | `<body>` |
|---|---|
| `/` | `<body>` |
| `/docs`, `/blog`, `/blog/:slug` | `<body class="docs-theme">` |

All seven page components checked directly through the engine: the six that need the light surface resolve it (`Docs/Index`, `Docs/Show`, `blog/Index`, `blog/Show`, `admin/Posts`, `admin/PostForm`); `Home` stays bare.

Client-side navigation in a real browser: `/blog` (white) → `Home` (`rgb(69, 10, 10)`) → back (white), and `/blog` → `/docs` stays white. No console errors.

Bundle check: the server-only strings are absent from every emitted client chunk after `vite build`.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
