### PR TITLE
fix(plugin-vercel): route the asset base onto the output root

### DIFF
--- a/.changeset/vercel-public-route.md
+++ b/.changeset/vercel-public-route.md
@@ -1,0 +1,9 @@
+---
+'@guren/plugin-vercel': patch
+---
+
+Route the asset base back onto the output root in the emitted deployment config.
+
+Built assets self-reference `/public/assets/`, the base the Guren Vite plugin derives, while the files themselves are copied to the output root. The emitted `config.json` carried no mapping between the two, so on a `--prebuilt` upload — routed by that file alone, and the flow the deployment guide documents — every chunk the entry script imports missed the filesystem handler, fell through to the function, and came back as HTML. The page loaded and the app never started.
+
+Deployments built by Vercel itself were unaffected, since `vercel.json`'s `rewrites` are compiled into routing on that path. That is why the failure stayed hidden.

--- a/examples/deploy/vercel/README.md
+++ b/examples/deploy/vercel/README.md
@@ -76,8 +76,7 @@ Built assets carry the Guren Vite plugin's derived base, `/public/assets/` — c
 
 Without it the page's entry script still loads — the plugin injects that path directly — but the chunks it imports 404, so the app never starts.
 
-> [!NOTE]
-> This entry is compiled into the deployment's routing when **Vercel** runs the build. A `--prebuilt` upload is routed by the `config.json` the plugin emits, which does not carry it — so prefer the git integration, or add the route to the emitted config yourself.
+The plugin emits the same mapping into `.vercel/output/config.json`, so a `--prebuilt` upload — routed by that file alone — behaves the same way. Keeping it in `vercel.json` covers builds Vercel runs itself.
 
 ## Notes
 

--- a/packages/plugin-vercel/src/index.ts
+++ b/packages/plugin-vercel/src/index.ts
@@ -89,6 +89,16 @@ export function buildVercelOutput(options: BuildVercelOutputOptions = {}): void 
       {
         version: 3,
         routes: [
+          // Built assets self-reference the Vite plugin's derived base,
+          // `/public/assets/`, while the files themselves are copied to the
+          // output root. Without this the entry script still loads — its path
+          // is injected directly — but every chunk it imports falls through
+          // to the function and comes back as HTML.
+          //
+          // A `rewrites` entry in vercel.json only covers builds Vercel runs
+          // itself; a `--prebuilt` upload is routed by this file alone, which
+          // is the flow the deployment guide documents.
+          { src: '/public/(.*)', dest: '/$1' },
           { handle: 'filesystem' },
           { src: '/(.*)', dest: '/index' },
         ],

--- a/packages/plugin-vercel/tests/index.test.ts
+++ b/packages/plugin-vercel/tests/index.test.ts
@@ -61,6 +61,30 @@ describe('@guren/plugin-vercel', () => {
     expect(config.handler).toBe('vercel.js')
   })
 
+  it('routes the asset base back onto the output root', () => {
+    // Built assets self-reference `/public/assets/` while the files land at
+    // the output root, so a deployment routed only by this file — which is
+    // what `--prebuilt` does — needs the mapping here rather than in
+    // vercel.json.
+    const rootDir = mkdtempSync(join(tmpdir(), 'guren-plugin-vercel-'))
+    const outputDir = join(rootDir, '.vercel/output')
+    const entrypoint = join(rootDir, 'src/vercel.ts')
+    mkdirSync(join(rootDir, 'src'), { recursive: true })
+    writeFileSync(entrypoint, "export default { fetch() { return new Response('ok') } }\n", 'utf8')
+
+    buildVercelOutput({ rootDir, outputDir, entrypoint })
+
+    const config = JSON.parse(readFileSync(join(outputDir, 'config.json'), 'utf8'))
+    const routes = config.routes as Array<Record<string, string>>
+
+    expect(routes[0]).toEqual({ src: '/public/(.*)', dest: '/$1' })
+    // It has to win before the filesystem handler, which would otherwise
+    // miss and fall through to the function.
+    expect(routes.findIndex((route) => route.handle === 'filesystem')).toBeGreaterThan(0)
+
+    rmSync(rootDir, { recursive: true, force: true })
+  })
+
   it('copies the docs directory into the function bundle', () => {
     const rootDir = mkdtempSync(join(tmpdir(), 'guren-plugin-vercel-'))
     tempDirs.push(rootDir)

--- a/scripts/smoke/vercel-build-audit.ts
+++ b/scripts/smoke/vercel-build-audit.ts
@@ -22,6 +22,10 @@ interface FunctionConfig {
   environment?: Record<string, string>
 }
 
+interface OutputConfig {
+  routes?: Array<{ src?: string; dest?: string; handle?: string }>
+}
+
 const appDir = resolve(process.argv[2] ?? 'examples/blog')
 const clientManifest = resolve(appDir, 'public/assets/.vite/manifest.json')
 
@@ -85,6 +89,18 @@ try {
 
   if (!config.handler) {
     failures.push('The function config has no handler.')
+  }
+
+  // A --prebuilt upload is routed by this file alone, so the asset base has
+  // to be mapped here rather than in vercel.json.
+  const routes = (JSON.parse(readFileSync(resolve(outputDir, 'config.json'), 'utf8')) as OutputConfig)
+    .routes ?? []
+  const assetRoute = routes.findIndex((route) => route.src === '/public/(.*)')
+  const filesystem = routes.findIndex((route) => route.handle === 'filesystem')
+  if (assetRoute < 0) {
+    failures.push('The output config has no /public/(.*) route, so chunk imports would 404 on a prebuilt deploy.')
+  } else if (filesystem >= 0 && assetRoute > filesystem) {
+    failures.push('The /public/(.*) route must come before the filesystem handler.')
   }
 
   summary = {


### PR DESCRIPTION
## Summary

Built assets self-reference `/public/assets/` — the base the Guren Vite plugin derives — while the files themselves are copied to the output root. The emitted `config.json` carried no mapping between the two:

```json
[{ "handle": "filesystem" }, { "src": "/(.*)", "dest": "/index" }]
```

On a `--prebuilt` upload, routed by that file alone, the entry script still loaded — the plugin injects its path directly — but every chunk it imported missed the filesystem handler, fell through to the function, and came back as HTML. **The page rendered and the app never started.**

That is the flow [the deployment guide documents](../blob/main/docs/en/guides/deployment.md), so it is the path a reader following the docs would take.

## Why it stayed hidden

Deployments built by Vercel itself were unaffected: `vercel.json`'s `rewrites` are compiled into routing on that path. guren.dev deployed that way for months, which is exactly why nobody hit it.

## What changed

One route, ahead of the filesystem handler:

```json
{ "src": "/public/(.*)", "dest": "/" }
```

Ordering matters — behind the filesystem handler it would never be reached — so the test pins the position, not just the presence. The build audit added in #187 now checks the same thing against a real build, so a regression fails CI rather than a deploy.

## Testing

- plugin-vercel: 6 tests (was 5); **mutation-checked** — removing the route fails the new test
- Reproduced the gap first: the emitted config had no mapping, and `static/` contains `assets/` but no `public/assets/`
- `audit:docs` passes, `typecheck` clean

The recipe added in #187 is corrected too: its note said a prebuilt upload would need the route added by hand, which is no longer true.