### PR TITLE
feat(docs): add a blog RSS feed and list posts in sitemap/llms.txt

### DIFF
--- a/web/app/Http/Controllers/MetaController.ts
+++ b/web/app/Http/Controllers/MetaController.ts
@@ -7,15 +7,18 @@ import {
   absoluteUrl,
   docPaths,
 } from '../../../config/site.js'
+import { xmlEscape } from '../../../config/xml.js'
 import { docsService, type DocCategoryGroup } from '../../Services/DocsService.js'
 import { listPublishedPosts, type PublishedPost } from '../../../modules/blog/index.js'
 
-function xmlEscape(value: string): string {
-  return value
-    .replace(/&/gu, '&amp;')
-    .replace(/</gu, '&lt;')
-    .replace(/>/gu, '&gt;')
-    .replace(/"/gu, '&quot;')
+/**
+ * Post titles and descriptions are author-written free text, so they are
+ * flattened before going into llms.txt: a newline or a bracket would otherwise
+ * split one entry into several, or break the link, in a document whose whole
+ * value is being machine-parseable.
+ */
+function mdInline(value: string): string {
+  return value.replace(/\s+/gu, ' ').replace(/([\[\]])/gu, '\\$1').trim()
 }
 
 function sitemapEntry(path: string, alternates?: { en: string; ja: string }): string {
@@ -68,7 +71,7 @@ export default class MetaController extends Controller {
       cachedBody('sitemap:docs', buildDocsSitemapEntries),
       listPublishedPosts(),
     ])
-    const xml = wrapSitemap(docsEntries, posts)
+    const xml = renderSitemap(docsEntries, posts)
 
     return this.text(xml, {
       headers: {
@@ -83,7 +86,7 @@ export default class MetaController extends Controller {
       cachedBody('llms:docs', buildLlmsDocsSections),
       listPublishedPosts(),
     ])
-    const body = wrapLlms(docsSections, posts)
+    const body = renderLlms(docsSections, posts)
 
     return this.text(body, { headers: { 'Cache-Control': DOCS_CACHE_CONTROL } })
   }
@@ -115,7 +118,7 @@ async function buildDocsSitemapEntries(): Promise<string> {
   return entries.join('\n')
 }
 
-function wrapSitemap(docsEntries: string, posts: PublishedPost[]): string {
+function renderSitemap(docsEntries: string, posts: PublishedPost[]): string {
   const blogEntries = [
     sitemapEntry('/blog'),
     ...posts.map((post) => sitemapEntry(`/blog/${post.slug}`)),
@@ -150,7 +153,7 @@ async function buildLlmsDocsSections(): Promise<string> {
   return lines.join('\n')
 }
 
-function wrapLlms(docsSections: string, posts: PublishedPost[]): string {
+function renderLlms(docsSections: string, posts: PublishedPost[]): string {
   const lines: string[] = [
     `# ${SITE_NAME}`,
     '',
@@ -168,7 +171,8 @@ function wrapLlms(docsSections: string, posts: PublishedPost[]): string {
     lines.push('')
     for (const post of posts) {
       const url = absoluteUrl(`/blog/${post.slug}`)
-      lines.push(`- [${post.title}](${url})${post.description ? `: ${post.description}` : ''}`)
+      const description = post.description ? `: ${mdInline(post.description)}` : ''
+      lines.push(`- [${mdInline(post.title)}](${url})${description}`)
     }
     lines.push('')
   }

--- a/web/app/Http/Controllers/MetaController.ts
+++ b/web/app/Http/Controllers/MetaController.ts
@@ -8,6 +8,7 @@ import {
   docPaths,
 } from '../../../config/site.js'
 import { docsService, type DocCategoryGroup } from '../../Services/DocsService.js'
+import { listPublishedPosts, type PublishedPost } from '../../../modules/blog/index.js'
 
 function xmlEscape(value: string): string {
   return value
@@ -33,6 +34,9 @@ function sitemapEntry(path: string, alternates?: { en: string; ja: string }): st
 
 // Docs content is immutable per deploy, so each body is built once per process
 // (Cache-Control alone does not spare the origin — max-age has no CDN guarantee).
+// Blog posts are deliberately outside this cache: they are rows the admin UI
+// mutates at runtime, and memoizing them per isolate would leave a published
+// post visible from some isolates and missing from others until the next deploy.
 const bodyCache = new Map<string, Promise<string>>()
 
 function cachedBody(key: string, build: () => Promise<string>): Promise<string> {
@@ -60,7 +64,11 @@ export function resetMetaBodyCache(): void {
  */
 export default class MetaController extends Controller {
   async sitemap(): Promise<Response> {
-    const xml = await cachedBody('sitemap', buildSitemap)
+    const [docsEntries, posts] = await Promise.all([
+      cachedBody('sitemap:docs', buildDocsSitemapEntries),
+      listPublishedPosts(),
+    ])
+    const xml = wrapSitemap(docsEntries, posts)
 
     return this.text(xml, {
       headers: {
@@ -71,7 +79,11 @@ export default class MetaController extends Controller {
   }
 
   async llms(): Promise<Response> {
-    const body = await cachedBody('llms', buildLlms)
+    const [docsSections, posts] = await Promise.all([
+      cachedBody('llms:docs', buildLlmsDocsSections),
+      listPublishedPosts(),
+    ])
+    const body = wrapLlms(docsSections, posts)
 
     return this.text(body, { headers: { 'Cache-Control': DOCS_CACHE_CONTROL } })
   }
@@ -83,7 +95,7 @@ export default class MetaController extends Controller {
   }
 }
 
-async function buildSitemap(): Promise<string> {
+async function buildDocsSitemapEntries(): Promise<string> {
   const categories = await docsService.listDocs('en')
 
   const entries: string[] = [
@@ -100,28 +112,28 @@ async function buildSitemap(): Promise<string> {
     }
   }
 
+  return entries.join('\n')
+}
+
+function wrapSitemap(docsEntries: string, posts: PublishedPost[]): string {
+  const blogEntries = [
+    sitemapEntry('/blog'),
+    ...posts.map((post) => sitemapEntry(`/blog/${post.slug}`)),
+  ]
+
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
-    ...entries,
+    docsEntries,
+    ...blogEntries,
     '</urlset>',
     '',
   ].join('\n')
 }
 
-async function buildLlms(): Promise<string> {
+async function buildLlmsDocsSections(): Promise<string> {
   const categories = await docsService.listDocs('en')
-
-  const lines: string[] = [
-    `# ${SITE_NAME}`,
-    '',
-    `> ${SITE_DESCRIPTION.en}`,
-    '',
-    'Guren pairs Laravel-style conventions (controllers, models, middleware, validation) with the TypeScript ecosystem: Bun runtime, Hono HTTP, Drizzle ORM, and Inertia.js + React. Codegen keeps routes, page props, and API clients typed end to end.',
-    '',
-    'Every documentation page is also available as raw Markdown: append `.md` to its URL.',
-    '',
-  ]
+  const lines: string[] = []
 
   for (const group of categories) {
     lines.push(`## ${group.title}`)
@@ -135,11 +147,38 @@ async function buildLlms(): Promise<string> {
     lines.push('')
   }
 
+  return lines.join('\n')
+}
+
+function wrapLlms(docsSections: string, posts: PublishedPost[]): string {
+  const lines: string[] = [
+    `# ${SITE_NAME}`,
+    '',
+    `> ${SITE_DESCRIPTION.en}`,
+    '',
+    'Guren pairs Laravel-style conventions (controllers, models, middleware, validation) with the TypeScript ecosystem: Bun runtime, Hono HTTP, Drizzle ORM, and Inertia.js + React. Codegen keeps routes, page props, and API clients typed end to end.',
+    '',
+    'Every documentation page is also available as raw Markdown: append `.md` to its URL.',
+    '',
+    docsSections,
+  ]
+
+  if (posts.length > 0) {
+    lines.push('## Blog')
+    lines.push('')
+    for (const post of posts) {
+      const url = absoluteUrl(`/blog/${post.slug}`)
+      lines.push(`- [${post.title}](${url})${post.description ? `: ${post.description}` : ''}`)
+    }
+    lines.push('')
+  }
+
   lines.push('## Optional')
   lines.push('')
   lines.push(`- [Full documentation as one file](${absoluteUrl('/llms-full.txt')})`)
   lines.push(`- [GitHub repository](${GITHUB_URL})`)
   lines.push(`- [Japanese documentation](${absoluteUrl('/docs/ja')})`)
+  lines.push(`- [Blog RSS feed](${absoluteUrl('/blog/rss.xml')})`)
   lines.push('')
 
   return lines.join('\n')

--- a/web/config/site.ts
+++ b/web/config/site.ts
@@ -14,7 +14,7 @@ export const SITE_DESCRIPTION = {
   ja: 'Guren は Bun ネイティブのフルスタック TypeScript フレームワーク。Laravel 流の MVC コントローラ、Drizzle ORM モデル、Inertia + React ページ、ルートからコンポーネントまでの型安全性を備えています。',
 } as const
 
-/** Cache policy for machine-facing endpoints (sitemap, llms.txt, raw Markdown). */
+/** Cache policy for machine-facing endpoints (sitemap, llms.txt, RSS, raw Markdown). */
 export const DOCS_CACHE_CONTROL = 'public, max-age=3600'
 
 export function absoluteUrl(path: string): string {

--- a/web/config/xml.ts
+++ b/web/config/xml.ts
@@ -1,0 +1,18 @@
+// Shared XML escaping for the machine-facing endpoints (sitemap.xml, RSS).
+// Kept beside site.ts rather than inside either producer: both emit XML built
+// from the same post titles, and a fix applied to only one of them would leave
+// the sitemap and the feed disagreeing about what is safe to emit.
+
+// XML 1.0 forbids most C0 controls outright — a single stray one makes the
+// whole document unparseable, so they are dropped rather than escaped. Tab,
+// newline and carriage return are the legal exceptions.
+const INVALID_XML_CHARS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\uFFFE\uFFFF]/gu
+
+export function xmlEscape(value: string): string {
+  return value
+    .replace(INVALID_XML_CHARS, '')
+    .replace(/&/gu, '&amp;')
+    .replace(/</gu, '&lt;')
+    .replace(/>/gu, '&gt;')
+    .replace(/"/gu, '&quot;')
+}

--- a/web/modules/blog/app/Http/Controllers/BlogController.ts
+++ b/web/modules/blog/app/Http/Controllers/BlogController.ts
@@ -2,6 +2,7 @@ import { Controller } from '@guren/core'
 import { z } from 'zod'
 import { pageTitle } from '../../../../../config/site.js'
 import { Post, type PostRecord } from '../../Models/Post.js'
+import { isPublished, listPublishedPosts } from '../../Services/published-posts.js'
 import { pages } from '@/.guren/pages.gen.js'
 
 const SlugParamSchema = z.object({
@@ -10,10 +11,6 @@ const SlugParamSchema = z.object({
 
 /** The summary columns the list view needs — see index(). */
 type PostSummarySource = Pick<PostRecord, 'slug' | 'title' | 'description' | 'publishedAt'>
-
-export function isPublished(post: Pick<PostRecord, 'publishedAt'>, now: Date = new Date()): boolean {
-  return post.publishedAt !== null && post.publishedAt.getTime() <= now.getTime()
-}
 
 function toSummary(post: PostSummarySource) {
   return {
@@ -26,13 +23,7 @@ function toSummary(post: PostSummarySource) {
 
 export default class BlogController extends Controller {
   async index(): Promise<Response> {
-    // Only the summary columns: bodyMarkdown/bodyHtml are the two large
-    // columns on the table and none of them reach the list view.
-    const records = await Post.select('slug', 'title', 'description', 'publishedAt')
-      .whereNotNull('publishedAt')
-      .orderBy('publishedAt', 'desc')
-      .get()
-    const posts = records.filter((post) => isPublished(post)).map(toSummary)
+    const posts = (await listPublishedPosts()).map(toSummary)
 
     return this.inertia(
       pages.blog.Index,

--- a/web/modules/blog/app/Http/Controllers/FeedController.ts
+++ b/web/modules/blog/app/Http/Controllers/FeedController.ts
@@ -1,0 +1,20 @@
+import { Controller } from '@guren/core'
+import { DOCS_CACHE_CONTROL } from '../../../../../config/site.js'
+import { listPublishedPosts } from '../../Services/published-posts.js'
+import { buildRssFeed } from '../../Services/rss.js'
+
+export default class FeedController extends Controller {
+  async rss(): Promise<Response> {
+    // Built per request rather than memoized: posts are rows the admin UI
+    // mutates at runtime, and a module-scope cache would strand a published
+    // post outside whichever isolates had already answered a request.
+    const xml = buildRssFeed(await listPublishedPosts())
+
+    return this.text(xml, {
+      headers: {
+        'Content-Type': 'application/rss+xml; charset=utf-8',
+        'Cache-Control': DOCS_CACHE_CONTROL,
+      },
+    })
+  }
+}

--- a/web/modules/blog/app/Services/published-posts.ts
+++ b/web/modules/blog/app/Services/published-posts.ts
@@ -1,0 +1,39 @@
+import { Post, type PostRecord } from '../Models/Post.js'
+
+/**
+ * A post goes live once its publish date has arrived: a future `publishedAt`
+ * is scheduled, not published, so it stays out of the list, the feed, and the
+ * sitemap until then.
+ */
+export function isPublished(post: Pick<PostRecord, 'publishedAt'>, now: Date = new Date()): boolean {
+  return post.publishedAt !== null && post.publishedAt.getTime() <= now.getTime()
+}
+
+export interface PublishedPost {
+  slug: string
+  title: string
+  description: string | null
+  publishedAt: Date
+}
+
+/**
+ * Published posts, newest first — the one query behind the blog index, the RSS
+ * feed, and the sitemap. Only the summary columns: bodyMarkdown and bodyHtml
+ * are the two large columns on the table and no caller here needs them.
+ */
+export async function listPublishedPosts(now: Date = new Date()): Promise<PublishedPost[]> {
+  const records = await Post.select('slug', 'title', 'description', 'publishedAt')
+    .whereNotNull('publishedAt')
+    .orderBy('publishedAt', 'desc')
+    .get()
+
+  return records
+    .filter((record) => isPublished(record, now))
+    .map((record) => ({
+      slug: record.slug,
+      title: record.title,
+      description: record.description,
+      // Non-null by the isPublished filter above.
+      publishedAt: record.publishedAt as Date,
+    }))
+}

--- a/web/modules/blog/app/Services/rss.test.ts
+++ b/web/modules/blog/app/Services/rss.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest'
+import { buildRssFeed, toRfc822 } from './rss.js'
+import type { PublishedPost } from './published-posts.js'
+
+function post(overrides: Partial<PublishedPost> = {}): PublishedPost {
+  return {
+    slug: 'starting-a-blog',
+    title: 'Starting a blog',
+    description: 'Why the Guren blog is built with Guren.',
+    publishedAt: new Date('2026-07-26T09:05:00Z'),
+    ...overrides,
+  }
+}
+
+describe('toRfc822', () => {
+  // RSS 2.0 mandates RFC-822 dates; an ISO-8601 string is the classic bug
+  // here and readers that parse strictly drop the item.
+  test('formats a date as RFC-822 in GMT', () => {
+    expect(toRfc822(new Date('2026-07-26T09:05:00Z'))).toBe('Sun, 26 Jul 2026 09:05:00 GMT')
+  })
+
+  test('zero-pads single-digit day and time components', () => {
+    expect(toRfc822(new Date('2026-01-05T03:07:09Z'))).toBe('Mon, 05 Jan 2026 03:07:09 GMT')
+  })
+
+  test('converts a non-UTC instant to GMT rather than shifting the label', () => {
+    expect(toRfc822(new Date('2026-07-26T23:30:00+09:00'))).toBe('Sun, 26 Jul 2026 14:30:00 GMT')
+  })
+})
+
+describe('buildRssFeed', () => {
+  test('emits channel metadata and a self link', () => {
+    const xml = buildRssFeed([post()])
+
+    expect(xml).toContain('<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">')
+    expect(xml).toContain('<title>Guren Blog</title>')
+    expect(xml).toContain('<link>https://guren.dev/blog</link>')
+    expect(xml).toContain(
+      '<atom:link href="https://guren.dev/blog/rss.xml" rel="self" type="application/rss+xml" />',
+    )
+  })
+
+  test('emits an item with an absolute permalink guid and RFC-822 pubDate', () => {
+    const xml = buildRssFeed([post()])
+
+    expect(xml).toContain('<link>https://guren.dev/blog/starting-a-blog</link>')
+    expect(xml).toContain(
+      '<guid isPermaLink="true">https://guren.dev/blog/starting-a-blog</guid>',
+    )
+    expect(xml).toContain('<pubDate>Sun, 26 Jul 2026 09:05:00 GMT</pubDate>')
+    expect(xml).toContain('<description>Why the Guren blog is built with Guren.</description>')
+  })
+
+  test('derives lastBuildDate from the newest post, not the current time', () => {
+    const xml = buildRssFeed([
+      post({ slug: 'newer', publishedAt: new Date('2026-07-26T09:05:00Z') }),
+      post({ slug: 'older', publishedAt: new Date('2026-07-01T00:00:00Z') }),
+    ])
+
+    expect(xml).toContain('<lastBuildDate>Sun, 26 Jul 2026 09:05:00 GMT</lastBuildDate>')
+  })
+
+  test('escapes XML metacharacters in titles and descriptions', () => {
+    const xml = buildRssFeed([
+      post({ title: 'Types & <generics>', description: 'Use "strict" mode' }),
+    ])
+
+    expect(xml).toContain('<title>Types &amp; &lt;generics&gt;</title>')
+    expect(xml).toContain('<description>Use &quot;strict&quot; mode</description>')
+    expect(xml).not.toContain('<generics>')
+  })
+
+  test('omits the description element when a post has none', () => {
+    const xml = buildRssFeed([post({ description: null })])
+
+    expect(xml).not.toContain('<description></description>')
+  })
+
+  test('is well-formed with no posts', () => {
+    const xml = buildRssFeed([])
+
+    expect(xml).toContain('<channel>')
+    expect(xml).not.toContain('<item>')
+    expect(xml).not.toContain('<lastBuildDate>')
+  })
+})

--- a/web/modules/blog/app/Services/rss.test.ts
+++ b/web/modules/blog/app/Services/rss.test.ts
@@ -70,6 +70,15 @@ describe('buildRssFeed', () => {
     expect(xml).not.toContain('<generics>')
   })
 
+  // A single stray control character makes the whole document unparseable,
+  // so one bad post must not take the entire feed down with it.
+  test('drops control characters XML 1.0 forbids', () => {
+    const xml = buildRssFeed([post({ title: 'Bad\u0000title\u0008here' })])
+
+    expect(xml).toContain('<title>Badtitlehere</title>')
+    expect(xml).not.toMatch(/[\u0000-\u0008]/u)
+  })
+
   test('omits the description element when a post has none', () => {
     const xml = buildRssFeed([post({ description: null })])
 

--- a/web/modules/blog/app/Services/rss.ts
+++ b/web/modules/blog/app/Services/rss.ts
@@ -1,44 +1,14 @@
 import { SITE_NAME, absoluteUrl } from '../../../../config/site.js'
+import { xmlEscape } from '../../../../config/xml.js'
 import type { PublishedPost } from './published-posts.js'
-
-const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
-const MONTHS = [
-  'Jan',
-  'Feb',
-  'Mar',
-  'Apr',
-  'May',
-  'Jun',
-  'Jul',
-  'Aug',
-  'Sep',
-  'Oct',
-  'Nov',
-  'Dec',
-]
-
-function pad(value: number): string {
-  return String(value).padStart(2, '0')
-}
 
 /**
  * RSS 2.0 requires RFC-822 dates, not ISO-8601 — readers that parse strictly
- * drop items with an ISO timestamp. Always UTC, so no zone table is needed.
+ * drop items with an ISO timestamp. ES2018 fixed toUTCString() at exactly that
+ * form ("Www, DD Mmm YYYY HH:MM:SS GMT"), locale-independent.
  */
 export function toRfc822(date: Date): string {
-  const day = DAYS[date.getUTCDay()]
-  const month = MONTHS[date.getUTCMonth()]
-  const time = `${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}`
-
-  return `${day}, ${pad(date.getUTCDate())} ${month} ${date.getUTCFullYear()} ${time} GMT`
-}
-
-function xmlEscape(value: string): string {
-  return value
-    .replace(/&/gu, '&amp;')
-    .replace(/</gu, '&lt;')
-    .replace(/>/gu, '&gt;')
-    .replace(/"/gu, '&quot;')
+  return date.toUTCString()
 }
 
 function item(post: PublishedPost): string {

--- a/web/modules/blog/app/Services/rss.ts
+++ b/web/modules/blog/app/Services/rss.ts
@@ -1,0 +1,90 @@
+import { SITE_NAME, absoluteUrl } from '../../../../config/site.js'
+import type { PublishedPost } from './published-posts.js'
+
+const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+const MONTHS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+]
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0')
+}
+
+/**
+ * RSS 2.0 requires RFC-822 dates, not ISO-8601 — readers that parse strictly
+ * drop items with an ISO timestamp. Always UTC, so no zone table is needed.
+ */
+export function toRfc822(date: Date): string {
+  const day = DAYS[date.getUTCDay()]
+  const month = MONTHS[date.getUTCMonth()]
+  const time = `${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}`
+
+  return `${day}, ${pad(date.getUTCDate())} ${month} ${date.getUTCFullYear()} ${time} GMT`
+}
+
+function xmlEscape(value: string): string {
+  return value
+    .replace(/&/gu, '&amp;')
+    .replace(/</gu, '&lt;')
+    .replace(/>/gu, '&gt;')
+    .replace(/"/gu, '&quot;')
+}
+
+function item(post: PublishedPost): string {
+  const url = absoluteUrl(`/blog/${post.slug}`)
+
+  return [
+    '    <item>',
+    `      <title>${xmlEscape(post.title)}</title>`,
+    `      <link>${xmlEscape(url)}</link>`,
+    `      <guid isPermaLink="true">${xmlEscape(url)}</guid>`,
+    `      <pubDate>${toRfc822(post.publishedAt)}</pubDate>`,
+    post.description ? `      <description>${xmlEscape(post.description)}</description>` : '',
+    '    </item>',
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+/**
+ * RSS 2.0 for the blog. Posts arrive newest-first, so the head of the list is
+ * also the feed's last build date — deriving it from the content rather than
+ * from `now` keeps the body byte-identical between requests.
+ */
+export function buildRssFeed(posts: PublishedPost[]): string {
+  const feedUrl = absoluteUrl('/blog/rss.xml')
+  const channel: string[] = [
+    `    <title>${SITE_NAME} Blog</title>`,
+    `    <link>${absoluteUrl('/blog')}</link>`,
+    '    <description>Release notes, design decisions, and field notes from building Guren.</description>',
+    '    <language>en</language>',
+    `    <atom:link href="${xmlEscape(feedUrl)}" rel="self" type="application/rss+xml" />`,
+  ]
+
+  const newest = posts[0]
+  if (newest) {
+    channel.push(`    <lastBuildDate>${toRfc822(newest.publishedAt)}</lastBuildDate>`)
+  }
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+    '  <channel>',
+    ...channel,
+    ...posts.map(item),
+    '  </channel>',
+    '</rss>',
+    '',
+  ].join('\n')
+}

--- a/web/modules/blog/index.ts
+++ b/web/modules/blog/index.ts
@@ -3,6 +3,10 @@ import AuthProvider from './app/Providers/AuthProvider.js'
 import OAuthProvider from './app/Providers/OAuthProvider.js'
 import { registerBlogRoutes } from './routes.js'
 
+// The module's public surface: what the site's sitemap and llms.txt need to
+// list posts, without reaching into the module's internals.
+export { listPublishedPosts, type PublishedPost } from './app/Services/published-posts.js'
+
 // No `prefix`: the module spans several URL surfaces (/blog, /admin,
 // /auth/github, /logout), so routes.ts declares full paths itself.
 export const blogModule = defineModule({

--- a/web/modules/blog/routes.ts
+++ b/web/modules/blog/routes.ts
@@ -1,5 +1,6 @@
 import { Router, requireAuthenticated } from '@guren/core'
 import BlogController from './app/Http/Controllers/BlogController.js'
+import FeedController from './app/Http/Controllers/FeedController.js'
 import PostsController from './app/Http/Controllers/Admin/PostsController.js'
 import OAuthController from './app/Http/Controllers/Auth/OAuthController.js'
 
@@ -10,6 +11,8 @@ export function registerBlogRoutes(baseRouter: Router): void {
   )
 
   router.get('/blog', [BlogController, 'index']).name('blog.index')
+  // Ahead of /blog/:slug, which would otherwise claim "rss.xml" as a slug.
+  router.get('/blog/rss.xml', [FeedController, 'rss']).name('blog.rss')
   router.get('/blog/:slug', [BlogController, 'show']).name('blog.show')
 
   router.get('/auth/github', [OAuthController, 'redirectToProvider']).name('auth.github')

--- a/web/resources/js/components/Seo.tsx
+++ b/web/resources/js/components/Seo.tsx
@@ -41,6 +41,13 @@ export function Seo({
       <title>{title}</title>
       <meta name="description" content={description} />
       <link rel="canonical" href={canonical} />
+      {/* Site-wide so a reader pointed at any page discovers the one feed. */}
+      <link
+        rel="alternate"
+        type="application/rss+xml"
+        title={`${SITE_NAME} Blog`}
+        href={absoluteUrl('/blog/rss.xml')}
+      />
       {alternates.map((alt) => (
         <link key={alt.hrefLang} rel="alternate" hrefLang={alt.hrefLang} href={absoluteUrl(alt.href)} />
       ))}

--- a/web/tests/controllers/MetaController.test.ts
+++ b/web/tests/controllers/MetaController.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createControllerContext,
   createControllerModuleMock,
@@ -6,10 +6,23 @@ import {
 import type { Context } from '@guren/core'
 import type { DocCategoryGroup } from '../../app/Services/DocsService.js'
 
-vi.mock('@guren/core', () => createControllerModuleMock())
+// The sitemap and llms.txt list blog posts, so this controller reaches the blog
+// module's public surface — which loads its service providers. The shared
+// controller mock does not carry ServiceProvider/defineModule, so they are
+// spread over rather than replacing it.
+vi.mock('@guren/core', () => ({
+  ...createControllerModuleMock(),
+  ServiceProvider: class {
+    constructor(public container: unknown) {}
+    register(): void {}
+    boot(): void {}
+  },
+  defineModule: <T,>(definition: T): T => definition,
+}))
 
 import MetaController, { resetMetaBodyCache } from '../../app/Http/Controllers/MetaController.js'
 import { docsService } from '../../app/Services/DocsService.js'
+import * as blogModule from '../../modules/blog/index.js'
 
 const routingDoc = { slug: 'routing', title: 'Routing', description: 'Define routes' }
 const categories: DocCategoryGroup[] = [
@@ -27,7 +40,19 @@ function createController(url: string): MetaController {
   return controller
 }
 
+const post = {
+  slug: 'starting-a-blog',
+  title: 'Starting a blog',
+  description: 'Why the Guren blog is built with Guren.',
+  publishedAt: new Date('2026-07-26T09:05:00Z'),
+}
+
 describe('MetaController', () => {
+  beforeEach(() => {
+    // Default to an empty blog so docs-focused cases do not reach the database.
+    vi.spyOn(blogModule, 'listPublishedPosts').mockResolvedValue([])
+  })
+
   afterEach(() => {
     vi.restoreAllMocks()
     resetMetaBodyCache()
@@ -70,5 +95,54 @@ describe('MetaController', () => {
     expect(body).toContain('# Guren — Full Documentation')
     expect(body).toContain('<!-- https://guren.dev/docs/guides/routing -->')
     expect(body).toContain('# Routing')
+  })
+
+  it('lists the blog index and published posts in the sitemap', async () => {
+    vi.spyOn(docsService, 'listDocs').mockResolvedValue(categories)
+    vi.spyOn(blogModule, 'listPublishedPosts').mockResolvedValue([post])
+
+    const response = await createController('http://guren.dev/sitemap.xml').sitemap()
+    const body = await response.text()
+
+    expect(body).toContain('<loc>https://guren.dev/blog</loc>')
+    expect(body).toContain('<loc>https://guren.dev/blog/starting-a-blog</loc>')
+  })
+
+  it('lists published posts and the feed in llms.txt', async () => {
+    vi.spyOn(docsService, 'listDocs').mockResolvedValue(categories)
+    vi.spyOn(blogModule, 'listPublishedPosts').mockResolvedValue([post])
+
+    const response = await createController('http://guren.dev/llms.txt').llms()
+    const body = await response.text()
+
+    expect(body).toContain('## Blog')
+    expect(body).toContain(
+      '- [Starting a blog](https://guren.dev/blog/starting-a-blog): Why the Guren blog is built with Guren.',
+    )
+    expect(body).toContain('https://guren.dev/blog/rss.xml')
+  })
+
+  it('omits the blog section from llms.txt when nothing is published', async () => {
+    vi.spyOn(docsService, 'listDocs').mockResolvedValue(categories)
+
+    const response = await createController('http://guren.dev/llms.txt').llms()
+    const body = await response.text()
+
+    expect(body).not.toContain('## Blog')
+  })
+
+  // The docs half is memoized per process; posts are rows the admin UI mutates,
+  // so a post published after the first request has to still show up.
+  it('re-reads posts on every request instead of serving a memoized list', async () => {
+    vi.spyOn(docsService, 'listDocs').mockResolvedValue(categories)
+    const listPosts = vi.spyOn(blogModule, 'listPublishedPosts').mockResolvedValue([])
+
+    const first = await (await createController('http://guren.dev/sitemap.xml').sitemap()).text()
+    expect(first).not.toContain('/blog/starting-a-blog')
+
+    listPosts.mockResolvedValue([post])
+    const second = await (await createController('http://guren.dev/sitemap.xml').sitemap()).text()
+
+    expect(second).toContain('<loc>https://guren.dev/blog/starting-a-blog</loc>')
   })
 })

--- a/web/tests/controllers/MetaController.test.ts
+++ b/web/tests/controllers/MetaController.test.ts
@@ -6,23 +6,18 @@ import {
 import type { Context } from '@guren/core'
 import type { DocCategoryGroup } from '../../app/Services/DocsService.js'
 
-// The sitemap and llms.txt list blog posts, so this controller reaches the blog
-// module's public surface — which loads its service providers. The shared
-// controller mock does not carry ServiceProvider/defineModule, so they are
-// spread over rather than replacing it.
-vi.mock('@guren/core', () => ({
-  ...createControllerModuleMock(),
-  ServiceProvider: class {
-    constructor(public container: unknown) {}
-    register(): void {}
-    boot(): void {}
-  },
-  defineModule: <T,>(definition: T): T => definition,
+vi.mock('@guren/core', () => createControllerModuleMock())
+
+// Mocked at the boundary this controller actually depends on. Loading the real
+// blog module here would drag its providers, routes and controllers into a
+// docs-endpoint unit test for the sake of one query function.
+vi.mock('../../modules/blog/index.js', () => ({
+  listPublishedPosts: vi.fn(),
 }))
 
 import MetaController, { resetMetaBodyCache } from '../../app/Http/Controllers/MetaController.js'
 import { docsService } from '../../app/Services/DocsService.js'
-import * as blogModule from '../../modules/blog/index.js'
+import { listPublishedPosts } from '../../modules/blog/index.js'
 
 const routingDoc = { slug: 'routing', title: 'Routing', description: 'Define routes' }
 const categories: DocCategoryGroup[] = [
@@ -49,8 +44,8 @@ const post = {
 
 describe('MetaController', () => {
   beforeEach(() => {
-    // Default to an empty blog so docs-focused cases do not reach the database.
-    vi.spyOn(blogModule, 'listPublishedPosts').mockResolvedValue([])
+    // Default to an empty blog so docs-focused cases stay about docs.
+    vi.mocked(listPublishedPosts).mockReset().mockResolvedValue([])
   })
 
   afterEach(() => {
@@ -99,7 +94,7 @@ describe('MetaController', () => {
 
   it('lists the blog index and published posts in the sitemap', async () => {
     vi.spyOn(docsService, 'listDocs').mockResolvedValue(categories)
-    vi.spyOn(blogModule, 'listPublishedPosts').mockResolvedValue([post])
+    vi.mocked(listPublishedPosts).mockResolvedValue([post])
 
     const response = await createController('http://guren.dev/sitemap.xml').sitemap()
     const body = await response.text()
@@ -110,7 +105,7 @@ describe('MetaController', () => {
 
   it('lists published posts and the feed in llms.txt', async () => {
     vi.spyOn(docsService, 'listDocs').mockResolvedValue(categories)
-    vi.spyOn(blogModule, 'listPublishedPosts').mockResolvedValue([post])
+    vi.mocked(listPublishedPosts).mockResolvedValue([post])
 
     const response = await createController('http://guren.dev/llms.txt').llms()
     const body = await response.text()
@@ -120,6 +115,22 @@ describe('MetaController', () => {
       '- [Starting a blog](https://guren.dev/blog/starting-a-blog): Why the Guren blog is built with Guren.',
     )
     expect(body).toContain('https://guren.dev/blog/rss.xml')
+  })
+
+  // llms.txt is a machine-parsed list, so a title carrying a newline or a
+  // bracket must not split one entry into several or break the link.
+  it('flattens author-written text in llms.txt entries', async () => {
+    vi.spyOn(docsService, 'listDocs').mockResolvedValue(categories)
+    vi.mocked(listPublishedPosts).mockResolvedValue([
+      { ...post, title: 'Multi\nline [bracketed]', description: 'a\n\nb' },
+    ])
+
+    const response = await createController('http://guren.dev/llms.txt').llms()
+    const body = await response.text()
+
+    expect(body).toContain(
+      '- [Multi line \\[bracketed\\]](https://guren.dev/blog/starting-a-blog): a b',
+    )
   })
 
   it('omits the blog section from llms.txt when nothing is published', async () => {
@@ -135,7 +146,7 @@ describe('MetaController', () => {
   // so a post published after the first request has to still show up.
   it('re-reads posts on every request instead of serving a memoized list', async () => {
     vi.spyOn(docsService, 'listDocs').mockResolvedValue(categories)
-    const listPosts = vi.spyOn(blogModule, 'listPublishedPosts').mockResolvedValue([])
+    const listPosts = vi.mocked(listPublishedPosts).mockResolvedValue([])
 
     const first = await (await createController('http://guren.dev/sitemap.xml').sitemap()).text()
     expect(first).not.toContain('/blog/starting-a-blog')


### PR DESCRIPTION
## Why

The blog shipped without any machine-facing surface:

- no feed, so there was no way to subscribe (and nothing for aggregators to pick up)
- `sitemap.xml` listed 109 docs URLs and zero blog URLs, so posts were not discoverable by search
- `llms.txt` likewise covered only docs

## What

- **`/blog/rss.xml`** — RSS 2.0 from a new `FeedController` in the blog module. RFC-822 `pubDate`, `atom:link rel=self`, permalink `guid`, and `lastBuildDate` derived from the newest post rather than `now` (so the body is byte-identical between requests).
- **sitemap + llms.txt** now include the blog index and every published post; `llms.txt` also links the feed.
- **`Seo`** emits a site-wide `<link rel="alternate" type="application/rss+xml">` so readers discover the feed from any page.
- **`listPublishedPosts()`** extracted to the blog module's public surface and shared by the index, the feed, and the sitemap.

## Two things worth reviewing

**Posts bypass the body cache.** `MetaController` memoizes bodies at module scope, justified by docs being immutable per deploy. Blog posts are rows the admin UI mutates at runtime, and on Workers that cache is per-isolate — memoizing them would leave a newly published post visible from some isolates and missing from others until the next deploy. The docs half stays memoized; posts are queried per request (small table, indexed `publishedAt`). A test covers this and fails if the blog is folded back into the cache.

**Scheduled posts stay hidden consistently.** `BlogController.index` filtered `whereNotNull('publishedAt')` *and then* `isPublished`, the second step excluding future-dated posts. Reusing only the query would have leaked scheduled posts to crawlers and feed readers. All three callers now share one function.

## Verification

- `bunx vitest run` — 89 pass (15 files), including 9 new RSS tests asserting exact RFC-822 output against fixed dates
- `bunx tsc --noEmit` — clean
- `guren check --arch` — no module boundary violations
- Ran the server against a local DB seeded with one published and one future-dated post: feed/sitemap/llms.txt all list the published post and omit the scheduled one; RSS and sitemap validate as well-formed XML; `Content-Type: application/rss+xml; charset=utf-8`; autodiscovery link present in the HTML

## Note

`MetaController.test.ts` had to spread `ServiceProvider`/`defineModule` over `createControllerModuleMock()`: reaching the blog module's public surface loads its service providers, and the shared controller mock does not carry those exports. That is a gap in `@guren/testing` worth closing separately — any scaffolded app with modules hits it.