### PR TITLE
docs(plugins): add READMEs for the Cloudflare and Vercel plugins

### DIFF
--- a/.changeset/plugin-readmes.md
+++ b/.changeset/plugin-readmes.md
@@ -1,0 +1,6 @@
+---
+'@guren/plugin-cloudflare': patch
+'@guren/plugin-vercel': patch
+---
+
+Add a README to both deploy plugins. Neither package shipped one, so their npm pages were blank — the first thing anyone sees when evaluating the plugin said nothing about what it does. Each README covers install, build and deploy, the exported API, and the runtime constraints that change how an app is configured, then links to the full guide.

--- a/packages/plugin-cloudflare/README.md
+++ b/packages/plugin-cloudflare/README.md
@@ -1,0 +1,51 @@
+# @guren/plugin-cloudflare
+
+Deploy a [Guren](https://guren.dev/) application to Cloudflare Workers, with D1 as the database.
+
+```bash
+bunx guren plugin @guren/plugin-cloudflare
+bun add @guren/plugin-cloudflare
+```
+
+Installing registers a `cloudflare:build` command and scaffolds `wrangler.jsonc` on the first build.
+
+## Build and deploy
+
+```bash
+bunx guren cloudflare:build
+bunx wrangler deploy
+```
+
+`cloudflare:build` runs your app's `build` script, then assembles a `.cloudflare/` directory containing the worker entry, static assets for Workers Static Assets, and flattened D1 migrations. It is generated output — add it to `.gitignore` and rebuild before every deploy.
+
+## API
+
+- **`createWorkersHandler(app)`** — wraps a Guren `Application` in a Workers module handler. Boot is lazy and deduplicated on the first request, because bindings only arrive with `fetch` and cannot be read at module scope.
+- **`getWorkersEnv<Env>()`** — exposes the first request's bindings to boot-time config through a write-once holder. Use it to hand a D1 binding to the ORM:
+
+  ```typescript
+  import { createD1Database } from '@guren/core'
+  import { getWorkersEnv } from '@guren/plugin-cloudflare'
+
+  const database = createD1Database({
+    binding: () => getWorkersEnv<{ DB: unknown }>().DB,
+  })
+  ```
+
+  The binding is a resolver, not a value — it must be read lazily.
+
+- **`cloudflarePlugin()`** — the service provider factory, registered automatically by `guren plugin`.
+
+## Things Workers changes
+
+Workers has no filesystem and shares no memory between requests, so a few defaults do not apply:
+
+- **Sessions and OAuth state must be database-backed.** Each request may land on a different isolate. The in-memory defaults work locally and then drop every session in production. Use `DatabaseSessionStore` and `DatabaseOAuthStateStore`.
+- **Migrations are applied out of band.** `wrangler d1 migrations apply` owns the lifecycle; the app never migrates itself.
+- **`APP_KEY` is required.** Sessions and CSRF are signed with it, and the worker throws at startup without it.
+
+See the [Cloudflare Workers deployment guide](https://guren.dev/docs/guides/cloudflare) for the full path from an empty account to a deployed app, including D1 setup, secrets, free-plan limits, and local development.
+
+## License
+
+MIT

--- a/packages/plugin-vercel/README.md
+++ b/packages/plugin-vercel/README.md
@@ -1,0 +1,44 @@
+# @guren/plugin-vercel
+
+Deploy a [Guren](https://guren.dev/) SSR application to Vercel. The plugin assembles a [Build Output API v3](https://vercel.com/docs/build-output-api/v3) directory that runs on Vercel's Bun runtime.
+
+```bash
+bunx guren plugin @guren/plugin-vercel
+bun add @guren/plugin-vercel
+```
+
+Installing scaffolds `src/vercel.ts`, `scripts/vercel-build.ts`, and `vercel.json`.
+
+## Build and deploy
+
+```bash
+bun run vercel:build
+vercel deploy --prebuilt
+```
+
+## API
+
+- **`createVercelHandler(app)`** — boots a Guren `Application` and returns a `fetch` handler for the serverless function.
+
+  ```typescript
+  // src/vercel.ts
+  import app from './app.js'
+  import { createVercelHandler } from '@guren/plugin-vercel'
+
+  export default await createVercelHandler(app)
+  ```
+
+- **`buildVercelOutput(options)`** — assembles `.vercel/output`: the bundled function, static assets, and the routing config. Reads the Vite manifests to inject the correct `GUREN_INERTIA_*` environment variables into the function.
+- **`vercelPlugin()`** — the service provider factory, registered automatically by `guren plugin`.
+
+## Notes
+
+- **SSR apps only.** The plugin reads Vite manifests to wire the Inertia SSR bundle. API-only apps should use Docker or Lambda instead.
+- **SSR bundles must be self-contained.** Function directories ship without `node_modules`, so externalized `react`/`@inertiajs/react` imports fail at runtime and Inertia silently falls back to client-side rendering. The Guren Vite plugin defaults `ssr.noExternal: true` for SSR builds — leave it alone unless you know the target has those packages installed.
+- **`NODE_ENV` is inlined at bundle time.** `bun build` bakes in `"development"` unless told otherwise, and a runtime `NODE_ENV=production` cannot override it. This plugin passes the right `--define` for you.
+
+See the [deployment guide](https://guren.dev/docs/guides/deployment) for the full setup.
+
+## License
+
+MIT


### PR DESCRIPTION
Neither deploy plugin shipped a README, so both npm pages are blank — the first thing anyone sees when evaluating the plugin says nothing about what it does. `@guren/plugin-cloudflare` just had its first release, which makes this the moment it matters most.

Each README covers install, build and deploy, the exported API, and the runtime constraints that change how an app is configured, then links to the full guide rather than restating it.

The Cloudflare README calls out the three defaults Workers invalidates (database-backed sessions and OAuth state, out-of-band migrations, required `APP_KEY`). The Vercel one calls out SSR-only support and the two bundling traps already recorded in the repo's pitfalls — self-contained SSR bundles, and `NODE_ENV` being inlined at bundle time.

Code samples were checked against the actual scaffold templates in `packages/cli/src/plugin-vercel.ts` rather than written from memory, and all three documentation links were verified to return 200.

Both packages are `patch` — the tarball gains a file, no code changes.