### PR TITLE
fix(testing): export ServiceProvider and defineModule from the controller mock

### DIFF
--- a/.changeset/controller-mock-module-exports.md
+++ b/.changeset/controller-mock-module-exports.md
@@ -1,0 +1,11 @@
+---
+'@guren/testing': patch
+---
+
+`createControllerModuleMock()` now exports `ServiceProvider` and `defineModule`.
+
+A module's `index.ts` calls `defineModule()` and lists providers that extend
+`ServiceProvider`, and both run at import time. A controller test whose subject
+reached a module's public surface therefore failed to load with
+`No "ServiceProvider" export is defined on the "@guren/core" mock`, unless the
+test spread its own stand-ins over the mock.

--- a/packages/testing/src/controller.ts
+++ b/packages/testing/src/controller.ts
@@ -693,6 +693,37 @@ export function createControllerModuleMock() {
   const getApiToken = (): { userId: number | string; abilities: string[] } | null => {
     return null
   }
+  /**
+   * A module's `index.ts` calls `defineModule()` at import time and lists
+   * providers that `extend ServiceProvider`, so both are evaluated as soon as
+   * a controller reaches the module's public surface. Without them here, such
+   * a controller cannot be loaded under this mock at all.
+   *
+   * `defineModule` mirrors the real one in
+   * `packages/server/src/container/defineModule.ts` — same four fields, same
+   * `providers` normalization — spelled out by hand because this file imports
+   * nothing, so the mock never depends on a fresh framework build.
+   */
+  class ServiceProvider {
+    constructor(public container: unknown) {}
+
+    register(): void {}
+
+    boot(): void {}
+  }
+
+  const defineModule = (definition: {
+    name: string
+    prefix?: string
+    routes?: unknown
+    providers?: unknown[]
+  }) => ({
+    name: definition.name,
+    prefix: definition.prefix,
+    routes: definition.routes,
+    providers: definition.providers ?? [],
+  })
+
   const createEventManager = () => ({
     on: () => {},
     emit: async () => {},
@@ -723,6 +754,8 @@ export function createControllerModuleMock() {
     collect,
     ValidationException,
     AuthenticationException,
+    ServiceProvider,
+    defineModule,
     MemoryApiTokenStore,
     createApiToken,
     revokeApiToken,

--- a/packages/testing/tests/__fixtures__/app/Http/Controllers/CatalogController.ts
+++ b/packages/testing/tests/__fixtures__/app/Http/Controllers/CatalogController.ts
@@ -1,0 +1,9 @@
+import { Controller } from '@guren/server'
+import { listWidgets } from '../../../widgets/index.js'
+
+// A controller outside the module that reaches the module's public surface.
+export default class CatalogController extends Controller {
+  index(): Response {
+    return this.text(listWidgets().map((widget) => widget.slug).join(','))
+  }
+}

--- a/packages/testing/tests/__fixtures__/widgets/app/Http/Controllers/WidgetController.ts
+++ b/packages/testing/tests/__fixtures__/widgets/app/Http/Controllers/WidgetController.ts
@@ -1,0 +1,8 @@
+import { Controller } from '@guren/server'
+import { listWidgets } from '../../Services/widgets.js'
+
+export default class WidgetController extends Controller {
+  index(): Response {
+    return this.text(listWidgets().map((widget) => widget.title).join(','))
+  }
+}

--- a/packages/testing/tests/__fixtures__/widgets/app/Providers/WidgetProvider.ts
+++ b/packages/testing/tests/__fixtures__/widgets/app/Providers/WidgetProvider.ts
@@ -1,0 +1,7 @@
+import { ServiceProvider } from '@guren/server'
+
+export default class WidgetProvider extends ServiceProvider {
+  register(): void {
+    this.container.singleton('widgets', () => ({ enabled: true }))
+  }
+}

--- a/packages/testing/tests/__fixtures__/widgets/app/Services/widgets.ts
+++ b/packages/testing/tests/__fixtures__/widgets/app/Services/widgets.ts
@@ -1,0 +1,8 @@
+export interface Widget {
+  slug: string
+  title: string
+}
+
+export function listWidgets(): Widget[] {
+  return [{ slug: 'gauge', title: 'Gauge' }]
+}

--- a/packages/testing/tests/__fixtures__/widgets/index.ts
+++ b/packages/testing/tests/__fixtures__/widgets/index.ts
@@ -1,0 +1,12 @@
+import { defineModule } from '@guren/server'
+import WidgetProvider from './app/Providers/WidgetProvider.js'
+import { registerWidgetRoutes } from './routes.js'
+
+// The module's public surface — the only import path an app's arch rules allow.
+export { listWidgets, type Widget } from './app/Services/widgets.js'
+
+export const widgetModule = defineModule({
+  name: 'widgets',
+  routes: registerWidgetRoutes,
+  providers: [WidgetProvider],
+})

--- a/packages/testing/tests/__fixtures__/widgets/routes.ts
+++ b/packages/testing/tests/__fixtures__/widgets/routes.ts
@@ -1,0 +1,11 @@
+import { type Router, requireAuthenticated } from '@guren/server'
+import WidgetController from './app/Http/Controllers/WidgetController.js'
+
+export function registerWidgetRoutes(baseRouter: Router): void {
+  const router = baseRouter.aliasMiddleware(
+    'widgets.auth',
+    requireAuthenticated({ redirectTo: '/login' }),
+  )
+
+  router.get('/widgets', [WidgetController, 'index']).name('widgets.index')
+}

--- a/packages/testing/tests/controller-module-mock.test.ts
+++ b/packages/testing/tests/controller-module-mock.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Context } from '@guren/server'
+import { createControllerContext, createControllerModuleMock } from '../src/controller'
+
+// Apps mock `@guren/core`, which re-exports `@guren/server` plus an ORM
+// allowlist; mocking server here covers everything but that allowlist.
+vi.mock('@guren/server', () => createControllerModuleMock())
+
+// Loading this controller loads a module's `index.ts`, which calls
+// `defineModule()` and evaluates its providers.
+import CatalogController from './__fixtures__/app/Http/Controllers/CatalogController.js'
+import { widgetModule } from './__fixtures__/widgets/index.js'
+
+describe('createControllerModuleMock with an application module', () => {
+  it('loads a controller that imports a module index', async () => {
+    const controller = new CatalogController()
+    controller.setContext(createControllerContext('http://example.com/catalog') as unknown as Context)
+
+    const response = controller.index()
+
+    expect(await response.text()).toBe('gauge')
+  })
+
+  it('leaves a route registrar importable without mocking its call-time deps', () => {
+    // The registrar reaches `requireAuthenticated`, which the mock does not
+    // carry — harmless, because only what a module index touches at import
+    // time has to be mocked. Registering routes needs a real router.
+    expect(() => widgetModule.routes?.({} as never)).toThrow(/requireAuthenticated/)
+  })
+})

--- a/packages/testing/tests/controller.test.ts
+++ b/packages/testing/tests/controller.test.ts
@@ -283,6 +283,26 @@ describe('createControllerModuleMock', () => {
     expect(controller.request.path).toBe('/users/1')
     expect(controller.request.method).toBe('GET')
   })
+
+  it('defines application modules and their providers', () => {
+    const { ServiceProvider, defineModule } = createControllerModuleMock()
+
+    class WidgetProvider extends ServiceProvider {
+      register(): void {}
+    }
+
+    const widgets = defineModule({ name: 'widgets', providers: [WidgetProvider] })
+    const bare = defineModule({ name: 'bare' })
+
+    expect(widgets.providers).toEqual([WidgetProvider])
+    expect(bare.providers).toEqual([])
+
+    const provider = new WidgetProvider('container')
+    provider.register()
+    provider.boot()
+
+    expect(provider.container).toBe('container')
+  })
 })
 
 describe('readInertiaResponse', () => {


### PR DESCRIPTION
## Problem

`createControllerModuleMock()` builds a synthetic `@guren/core` stand-in, and its export surface is a hand-maintained allowlist. It carried no `ServiceProvider` and no `defineModule`.

An application module's `index.ts` calls `defineModule()` and lists providers that `extend ServiceProvider`. Both run while the module is *evaluated*, not when an export is read — so any controller test whose subject reached a module's public surface could not load at all:

```
No "ServiceProvider" export is defined on the "@guren/core" mock. Did you forget to return it from "vi.mock"?
```

Since the module index is the only import path the derived architecture rules allow, there was no way around it except spreading a private stand-in over the mock in each app test.

## Change

- `createControllerModuleMock()` now returns `ServiceProvider` (a no-op class exposing `container`) and `defineModule`.
- `defineModule` mirrors the real one in `packages/server/src/container/defineModule.ts` field for field, including the `providers ?? []` normalization. It is spelled out by hand rather than delegated: `controller.ts` imports nothing, so the mock never depends on a fresh framework build (importing the real package would resolve through `dist/`, which fails silently when stale).
- Regression test loads a controller that imports a fixture module index. `expect(ServiceProvider).toBeDefined()` would not cover this — the failure happens at module-evaluation time, so the test has to actually traverse the import chain.
- The fixture also carries a route registrar reaching `requireAuthenticated`, which the mock does *not* export. A test pins that boundary: a module index stays importable even when its route file references call-time-only symbols, because only what runs at import time has to be mocked.

## Verification

- `bun run test:testing` — 11 files / 161 tests
- `bun run test:examples` (blog + api + web) — 236 tests
- `bunx tsc --noEmit` — clean (root tsconfig covers the new fixtures)
- Mutation-checked in both directions: removing either export from the mock makes the new test fail with the exact error above.