### PR TITLE
feat(docs): surface the blog and its feed in the site navigation

### DIFF
--- a/web/resources/js/components/Footer.tsx
+++ b/web/resources/js/components/Footer.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@inertiajs/react'
 import { GITHUB_URL } from '../../../config/site.js'
-import { GithubIcon } from './icons.js'
+import { GithubIcon, RssIcon } from './icons.js'
 
 interface FooterProps {
   variant: 'home' | 'docs'
@@ -19,6 +19,14 @@ export function Footer({ variant }: FooterProps) {
           </div>
           <div className="flex items-center gap-4">
             <Link href="/docs" className="no-underline transition hover:text-docs-accent">Docs</Link>
+            <Link href="/blog" className="no-underline transition hover:text-docs-accent">Blog</Link>
+            <a
+              href="/blog/rss.xml"
+              className="flex items-center gap-1.5 no-underline transition hover:text-docs-accent"
+            >
+              <RssIcon className="size-4" />
+              RSS
+            </a>
             <a
               href="https://github.com/gurenjs/guren"
               target="_blank"
@@ -52,6 +60,8 @@ export function Footer({ variant }: FooterProps) {
             <Link href="/docs" className="no-underline transition hover:text-white">Documentation</Link>
             <Link href="/docs/guides/getting-started" className="no-underline transition hover:text-white">Getting Started</Link>
             <Link href="/docs/tutorials/overview" className="no-underline transition hover:text-white">Tutorials</Link>
+            <Link href="/blog" className="no-underline transition hover:text-white">Blog</Link>
+            <a href="/blog/rss.xml" className="no-underline transition hover:text-white">RSS</a>
             <a href="/llms.txt" className="no-underline transition hover:text-white">llms.txt</a>
           </nav>
         </div>

--- a/web/resources/js/components/icons.tsx
+++ b/web/resources/js/components/icons.tsx
@@ -114,3 +114,11 @@ export function RocketIcon(props: IconProps) {
     </svg>
   )
 }
+
+export function RssIcon(props: IconProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" {...props}>
+      <path fillRule="evenodd" d="M3.75 3a.75.75 0 0 0-.75.75v.75c0 .414.336.75.75.75 8.284 0 15 6.716 15 15 0 .414.336.75.75.75h.75a.75.75 0 0 0 .75-.75C21 11.42 13.58 4 4.5 4a.75.75 0 0 0-.75-.75Zm0 5.25a.75.75 0 0 0-.75.75v.75c0 .414.336.75.75.75a9 9 0 0 1 9 9c0 .414.336.75.75.75h.75a.75.75 0 0 0 .75-.75c0-6.213-5.037-11.25-11.25-11.25Zm1.5 7.5a2.25 2.25 0 1 0 0 4.5 2.25 2.25 0 0 0 0-4.5Z" clipRule="evenodd" />
+    </svg>
+  )
+}

--- a/web/resources/js/pages/blog/Index.tsx
+++ b/web/resources/js/pages/blog/Index.tsx
@@ -3,6 +3,7 @@ import { SITE_DESCRIPTION, pageTitle } from '../../../../config/site.js'
 import { Footer } from '../../components/Footer.js'
 import { Header } from '../../components/Header.js'
 import { Seo } from '../../components/Seo.js'
+import { RssIcon } from '../../components/icons.js'
 
 type BlogPostSummary = {
   slug: string
@@ -37,9 +38,21 @@ export default function BlogIndex({ posts }: Props) {
 
       <main className="mx-auto w-full max-w-[760px] px-6 py-16">
         <header className="mb-12">
-          <h1 className="mb-3 text-[2.75rem] font-extrabold leading-[1.1] tracking-tight text-docs-heading">
-            Blog
-          </h1>
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-4">
+            <h1 className="text-[2.75rem] font-extrabold leading-[1.1] tracking-tight text-docs-heading">
+              Blog
+            </h1>
+            {/* Browsers dropped their feed indicators, so the visible link is
+                the only way a reader finds the feed. */}
+            <a
+              href="/blog/rss.xml"
+              title="Subscribe via RSS"
+              className="flex items-center gap-1.5 rounded-full border border-docs-border px-3.5 py-1.5 text-sm font-medium text-docs-text-secondary no-underline transition hover:border-docs-accent hover:text-docs-accent"
+            >
+              <RssIcon className="size-4" />
+              RSS
+            </a>
+          </div>
           <p className="text-lg leading-relaxed text-docs-text-secondary">
             News, releases, and notes from the Guren team.
           </p>


### PR DESCRIPTION
## Why

Two discoverability gaps found while verifying the RSS feed from #191:

- **The blog had no inbound link anywhere on the site.** Neither footer variant nor the header linked `/blog`, so it was reachable only by typing the URL.
- **The feed was discoverable only via the autodiscovery `<link>`.** Chrome and Firefox both removed their feed indicators years ago, so that tag is how a reader resolves a site URL you paste into it — it is not how a human finds the feed. Without a visible link there is effectively no subscribe path.

## What

- Footer (both `docs` and `home` variants): **Blog** and **RSS** entries. In the home variant they join the existing `Resources` column next to `llms.txt`, keeping the machine-facing links together.
- Blog index: an **RSS** pill button beside the heading — where someone looking to subscribe actually looks.
- New `RssIcon` in `icons.tsx`, matching the existing 24×24 `fill="currentColor"` convention.

The header is deliberately left alone so the primary docs path stays uncluttered.

## Verification

- `bunx vitest run` — 91 pass, `bunx tsc --noEmit` clean, `guren check --arch` clean
- Rendered locally against a seeded post: RSS pill and footer links present, correct in both light and dark (the button reuses the same `docs-*` tokens as its neighbours), no console errors
- Footer hrefs asserted from the DOM: `Blog -> /blog`, `RSS -> /blog/rss.xml`