### PR TITLE
feat(orm): add createAwsDataApiDatabase for Aurora Serverless

### DIFF
--- a/.changeset/aws-data-api-database.md
+++ b/.changeset/aws-data-api-database.md
@@ -1,0 +1,18 @@
+---
+'@guren/orm': minor
+'@guren/core': minor
+'@guren/cli': patch
+---
+
+Add `createAwsDataApiDatabase()` for Aurora Serverless v2 via the RDS Data API.
+
+The factory mirrors the other database factories (`getDatabase`, `migrateDatabase`,
+`configureOrm`, `seedDatabase`, `resetDatabase`, `migrationStatus`) on top of
+`drizzle-orm/aws-data-api/pg`. The Data API is HTTP-based, so Lambda apps get a
+Postgres-compatible connection without a connection pool, RDS Proxy, or VPC
+placement. Connection settings resolve from options or the `DATABASE_NAME`,
+`DATABASE_RESOURCE_ARN`, and `DATABASE_SECRET_ARN` environment variables;
+`@aws-sdk/client-rds-data` is an optional peer dependency. Unlike the other
+factories, `getDatabase()` does not run pending migrations automatically —
+on Lambda that check costs serialized Data API round trips on every cold
+start. Run migrations out of band, or opt back in with `migrateOnStart: true`.

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "examples/api": {
       "name": "@guren/example-api",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -67,7 +67,7 @@
     },
     "packages/cli": {
       "name": "@guren/cli",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "bin": {
         "guren": "./dist/bin.js",
       },
@@ -91,7 +91,7 @@
     },
     "packages/core": {
       "name": "@guren/core",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "bin": {
         "guren": "./dist/bin.js",
       },
@@ -109,7 +109,7 @@
     },
     "packages/create-app": {
       "name": "create-guren-app",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "bin": {
         "create-guren-app": "./dist/cli.js",
       },
@@ -155,11 +155,12 @@
     },
     "packages/orm": {
       "name": "@guren/orm",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "drizzle-orm": "1.0.0-rc.4",
       },
       "devDependencies": {
+        "@aws-sdk/client-rds-data": "^3.0.0",
         "@types/node": "^20.14.10",
         "mysql2": "^3.11.3",
         "postgres": "^3.4.3",
@@ -167,17 +168,19 @@
         "typescript": "^5.4.0",
       },
       "peerDependencies": {
+        "@aws-sdk/client-rds-data": "^3.0.0",
         "mysql2": "^3.11.3",
         "postgres": "^3.4.3",
       },
       "optionalPeers": [
+        "@aws-sdk/client-rds-data",
         "mysql2",
         "postgres",
       ],
     },
     "packages/plugin-cloudflare": {
       "name": "@guren/plugin-cloudflare",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@guren/core": "^1.1.0",
         "citty": "^0.1.6",
@@ -191,7 +194,7 @@
     },
     "packages/plugin-vercel": {
       "name": "@guren/plugin-vercel",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "dependencies": {
         "@guren/core": "^1.1.0",
       },
@@ -203,7 +206,7 @@
     },
     "packages/server": {
       "name": "@guren/server",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@guren/orm": "^1.0.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -238,7 +241,7 @@
     },
     "packages/testing": {
       "name": "@guren/testing",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "devDependencies": {
         "@types/react": "^19.0.0",
         "tsup": "^8.5.0",
@@ -262,7 +265,7 @@
     },
     "web": {
       "name": "web",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -310,6 +313,38 @@
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
+
+    "@aws-sdk/client-rds-data": ["@aws-sdk/client-rds-data@3.1095.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.0", "@aws-sdk/credential-provider-node": "^3.972.72", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-PnTyGwG/I6TCmIvArMH22bzJ6cDt4Een3U/6+9i3N03iANGZHGxhPvLhaTEUbzq1FsKmIHqzP+XQ/LE57l9ymQ=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.977.1", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@aws-sdk/xml-builder": "^3.972.37", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.8", "@smithy/signature-v4": "^5.6.9", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.61", "", { "dependencies": { "@aws-sdk/core": "^3.977.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.63", "", { "dependencies": { "@aws-sdk/core": "^3.977.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-yfozsS8wkWZEi/n6IsrodcFKBWZ0iNAezhJbTReMNc0z1Px17qdeAeuL1/wziCAmCZyXiW7QzP75ggJkBQv8jQ=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.6", "", { "dependencies": { "@aws-sdk/core": "^3.977.0", "@aws-sdk/credential-provider-env": "^3.972.61", "@aws-sdk/credential-provider-http": "^3.972.63", "@aws-sdk/credential-provider-login": "^3.972.68", "@aws-sdk/credential-provider-process": "^3.972.61", "@aws-sdk/credential-provider-sso": "^3.973.5", "@aws-sdk/credential-provider-web-identity": "^3.972.67", "@aws-sdk/nested-clients": "^3.997.35", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/credential-provider-imds": "^4.4.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-jGLTW1bj148GL/6/IMlfY2fMYS9FtHOG+NahkFD4y0qkzYudNUahelxryY68/HGMslYuHClk1XaS/3b3eJzEkg=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.68", "", { "dependencies": { "@aws-sdk/core": "^3.977.0", "@aws-sdk/nested-clients": "^3.997.35", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-w6tNci6g7RqFpLhj1f5xseBvaNojb4Pkgp5Jp5apl9hrJtaf2AA+rX9+qlhlWUK6kcyAFYPA7emO+55zj+S98Q=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.72", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.61", "@aws-sdk/credential-provider-http": "^3.972.63", "@aws-sdk/credential-provider-ini": "^3.973.6", "@aws-sdk/credential-provider-process": "^3.972.61", "@aws-sdk/credential-provider-sso": "^3.973.5", "@aws-sdk/credential-provider-web-identity": "^3.972.67", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/credential-provider-imds": "^4.4.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-blQ7F5QGzylnzeh5549zQLoCAiMHkXFLjFovEMaVy4b2X8JhUu+u9NXro1hyK95YHdVFNmBHKs2hIHtZchxKlQ=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.61", "", { "dependencies": { "@aws-sdk/core": "^3.977.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-xzRuj+fUVO4nkafKQJVKAF97kGpeQbfjuwmRrtGZNf42/1dkmcz6o7dswBy7alY0htQn5sCL1GWQYEykviWZkA=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.5", "", { "dependencies": { "@aws-sdk/core": "^3.977.0", "@aws-sdk/nested-clients": "^3.997.35", "@aws-sdk/token-providers": "3.1095.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-fZRjjWhLFelsDoOYjqShQTrIGYC3Pf9Mx9Czf+1ikfQDgktxjze33dVo1q1/ZQ+T0qbtejVoHNHrfD5aJVpv/w=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.67", "", { "dependencies": { "@aws-sdk/core": "^3.977.0", "@aws-sdk/nested-clients": "^3.997.35", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.35", "", { "dependencies": { "@aws-sdk/core": "^3.977.0", "@aws-sdk/signature-v4-multi-region": "^3.996.42", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.42", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1095.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.0", "@aws-sdk/nested-clients": "^3.997.35", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-65SudS6y4nzaYHybtqcpm3sHe5jLhdMn68HRKS1nUx690BtQeaAQOoujQ+dpOjBATIVGVgKKjEP8tR+U06QJQA=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.37", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -587,6 +622,18 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
+    "@smithy/core": ["@smithy/core@3.30.0", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.14", "", { "dependencies": { "@smithy/core": "^3.30.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-QgbuahIb2qxQeZQvNK0sw3aF3JH5zwH8j2lLp5DUasVXexGGMWULAR+7z0omPXFolCP/m5wN9M5lm9EGdSviTQ=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.11", "", { "dependencies": { "@smithy/core": "^3.30.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-o0Zkj1nKqJAoq+a+BrkhU39tRftMNjLwpc/z06Frfl43wpbHrJMaSAVZE4vTqlxtVkNaGaT0bIDxOp7tkFTuQQ=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.11", "", { "dependencies": { "@smithy/core": "^3.30.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-slbzbz8taEOzoXv/9y34YNBoE+ZHmddLykCgjDAjvMAsu2nM5s2Gzwa5OGF721tD8s+CKeFUBds5lSj9lcbuDg=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.6.10", "", { "dependencies": { "@smithy/core": "^3.30.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-EXhWePm3SXJAX38npIy4TXL2Aex/OVgCClTjelN2QHw/U+8CQUH8C7AaxsVzQcYieYPseywn48s89DmvuGjiAg=="],
+
+    "@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.2.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.2" } }, "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.2", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.2", "@tailwindcss/oxide-darwin-arm64": "4.2.2", "@tailwindcss/oxide-darwin-x64": "4.2.2", "@tailwindcss/oxide-freebsd-x64": "4.2.2", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2", "@tailwindcss/oxide-linux-arm64-musl": "4.2.2", "@tailwindcss/oxide-linux-x64-gnu": "4.2.2", "@tailwindcss/oxide-linux-x64-musl": "4.2.2", "@tailwindcss/oxide-wasm32-wasi": "4.2.2", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2", "@tailwindcss/oxide-win32-x64-msvc": "4.2.2" } }, "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg=="],
@@ -702,6 +749,8 @@
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 

--- a/contributing/api-stability.md
+++ b/contributing/api-stability.md
@@ -22,7 +22,7 @@ Stable APIs include all exports from the `@guren/core` package index:
 
 **From `@guren/orm` (re-exported via `@guren/core`):**
 - `Model`, `defineModel`
-- `DrizzleAdapter`, `createPostgresDatabase`, `createSqliteDatabase`
+- `DrizzleAdapter`, `createPostgresDatabase`, `createSqliteDatabase`, `createMySqlDatabase`, `createAwsDataApiDatabase`
 - `runSeeders`, `defineSeeder`, `loadSeeders`
 - All exported types: `InferModelRecord`, `InferModelInsert`, `PlainObject`, `WhereClause`, `FindManyOptions`, `PaginateOptions`, `PaginatedResult`, etc.
 

--- a/docs/en/guides/database.md
+++ b/docs/en/guides/database.md
@@ -1,6 +1,6 @@
 # Database
 
-Guren uses Drizzle ORM and supports PostgreSQL, SQLite, and MySQL. You define your schema in TypeScript, derive models from those tables, and get a fluent query API that feels like Laravel Eloquent while staying fully type-safe.
+Guren uses Drizzle ORM and supports PostgreSQL, SQLite, MySQL, and Aurora Serverless (AWS Data API). You define your schema in TypeScript, derive models from those tables, and get a fluent query API that feels like Laravel Eloquent while staying fully type-safe.
 
 ## Connecting to the Database
 
@@ -49,6 +49,38 @@ Like the PostgreSQL and SQLite adapters, the MySQL adapter exposes the same runt
 
 > [!TIP]
 > If you want to use Drizzle's relational queries (`db.query.<table>.findMany(...)`), pass a `relations` option built with `defineRelations(schema, ...)` from `drizzle-orm` (RQB v2). The `Model` API in Guren does not require this.
+
+## Aurora Serverless (AWS Data API)
+
+Use `createAwsDataApiDatabase` when your app runs on AWS Lambda against Aurora Serverless v2 with the RDS Data API enabled. The Data API is HTTP-based, so there is no connection pool to manage and the Lambda function does not need to run inside a VPC.
+
+```ts
+// config/database.ts
+import { createAwsDataApiDatabase } from '@guren/orm'
+
+const database = createAwsDataApiDatabase({
+  migrationsFolder: new URL('../db/migrations', import.meta.url),
+  seedersFolder: new URL('../db/seeders', import.meta.url),
+  // Each setting also falls back to an environment variable:
+  // DATABASE_NAME, DATABASE_RESOURCE_ARN, DATABASE_SECRET_ARN
+  database: () => process.env.DATABASE_NAME,
+  resourceArn: () => process.env.DATABASE_RESOURCE_ARN,
+  secretArn: () => process.env.DATABASE_SECRET_ARN,
+})
+
+export const { getDatabase, migrateDatabase, closeDatabase, configureOrm, seedDatabase } = database
+```
+
+Install the driver package alongside it:
+
+```bash
+bun add @aws-sdk/client-rds-data
+```
+
+The adapter exposes the same runtime API as the other drivers, and migrations use the standard drizzle-kit folders. One deliberate difference: `getDatabase()` does **not** run pending migrations automatically — on Lambda that check would cost several serialized Data API round trips on every cold start. Run migrations out of band (`bun run db:migrate`, or the console handler once deployed), or opt back in with `migrateOnStart: true`. For `drizzle-kit generate`/`push` against the Data API, set `driver: 'aws-data-api'` in `drizzle.config.ts` with the same `database`/`resourceArn`/`secretArn` credentials.
+
+> [!NOTE]
+> Authentication uses the standard AWS SDK credential chain (IAM role on Lambda, `AWS_PROFILE` locally). Pass `clientOptions` to override the region or credentials explicitly.
 
 ## Defining Models
 

--- a/docs/en/guides/support-matrix.md
+++ b/docs/en/guides/support-matrix.md
@@ -15,6 +15,7 @@
 | PostgreSQL | 14+      | Supported (primary) |
 | SQLite     | 3.x      | Supported (via Bun native) |
 | MySQL      | 8.x      | Supported (via `createMySqlDatabase`) |
+| Aurora Serverless v2 (Data API) | PostgreSQL 14+ | Supported (via `createAwsDataApiDatabase`) |
 
 ## Optional Services
 

--- a/docs/ja/guides/database.md
+++ b/docs/ja/guides/database.md
@@ -2,7 +2,7 @@
 
 Guren は Drizzle ORM と PostgreSQL を組み合わせて使います。このガイドでは、スキーマ定義、マイグレーション、シーダー、アプリケーションコードからの日常的な利用方法を説明します。
 
-現在は PostgreSQL / SQLite / MySQL をサポートしています。
+現在は PostgreSQL / SQLite / MySQL / Aurora Serverless（AWS Data API）をサポートしています。
 
 ## 設定の概要
 - `config/database.ts`: データベース接続を生成し、フレームワークに公開します。
@@ -89,6 +89,38 @@ MySQL アダプタも PostgreSQL / SQLite と同じランタイム API（`getDat
 
 > [!TIP]
 > Drizzle のリレーショナルクエリ (`db.query.<table>.findMany(...)`) を使いたい場合は、`drizzle-orm` の `defineRelations(schema, ...)` で生成した値を `relations` オプションに渡してください (RQB v2)。Guren の `Model` API ではこの設定は不要です。
+
+## Aurora Serverless（AWS Data API）サポート
+
+AWS Lambda 上で RDS Data API を有効にした Aurora Serverless v2 に接続する場合は `createAwsDataApiDatabase` を使います。Data API は HTTP ベースのため、接続プールの管理が不要で、Lambda 関数を VPC 内に配置する必要もありません。
+
+```ts
+// config/database.ts
+import { createAwsDataApiDatabase } from '@guren/orm'
+
+const database = createAwsDataApiDatabase({
+  migrationsFolder: new URL('../db/migrations', import.meta.url),
+  seedersFolder: new URL('../db/seeders', import.meta.url),
+  // 各設定は環境変数へのフォールバックもあります:
+  // DATABASE_NAME, DATABASE_RESOURCE_ARN, DATABASE_SECRET_ARN
+  database: () => process.env.DATABASE_NAME,
+  resourceArn: () => process.env.DATABASE_RESOURCE_ARN,
+  secretArn: () => process.env.DATABASE_SECRET_ARN,
+})
+
+export const { getDatabase, migrateDatabase, closeDatabase, configureOrm, seedDatabase } = database
+```
+
+ドライバパッケージも合わせてインストールしてください:
+
+```bash
+bun add @aws-sdk/client-rds-data
+```
+
+このアダプタも他のドライバと同じランタイム API を提供し、マイグレーションは標準の drizzle-kit フォルダを使用します。意図的な違いが 1 つあります: `getDatabase()` は保留中のマイグレーションを自動実行**しません** — Lambda ではこのチェックがコールドスタートのたびに直列の Data API 往復を数回消費するためです。マイグレーションは帯域外で実行するか（ローカルでは `bun run db:migrate`、デプロイ後はコンソールハンドラ）、`migrateOnStart: true` で従来の挙動に戻せます。Data API に対して `drizzle-kit generate`/`push` を実行する場合は、`drizzle.config.ts` に `driver: 'aws-data-api'` と同じ `database`/`resourceArn`/`secretArn` を設定してください。
+
+> [!NOTE]
+> 認証は AWS SDK の標準クレデンシャルチェーン（Lambda 上では IAM ロール、ローカルでは `AWS_PROFILE`）を使用します。リージョンやクレデンシャルを明示的に指定する場合は `clientOptions` を渡してください。
 
 ## マイグレーションの生成
 Guren CLI は drizzle-kit をラップしており、Drizzle スキーマから SQL ファイルを直接生成できます。

--- a/docs/ja/guides/support-matrix.md
+++ b/docs/ja/guides/support-matrix.md
@@ -15,6 +15,7 @@
 | PostgreSQL | 14+       | サポート（プライマリ） |
 | SQLite     | 3.x       | サポート（Bun ネイティブ経由） |
 | MySQL      | 8.x       | サポート（`createMySqlDatabase` 経由） |
+| Aurora Serverless v2（Data API） | PostgreSQL 14+ | サポート（`createAwsDataApiDatabase` 経由） |
 
 ## オプションサービス
 

--- a/packages/cli/src/db-status.ts
+++ b/packages/cli/src/db-status.ts
@@ -35,7 +35,7 @@ export async function getMigrationStatus(): Promise<MigrationStatusRow[]> {
   if (!status) {
     throw new Error(
       'config/database.ts must export migrationStatus(). It is returned by ' +
-        'createSqliteDatabase()/createPostgresDatabase()/createMySqlDatabase() — ' +
+        'createSqliteDatabase()/createPostgresDatabase()/createMySqlDatabase()/createAwsDataApiDatabase() — ' +
         'add it to the export list in config/database.ts.',
     )
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export {
   createMySqlDatabase,
   createSqliteDatabase,
   createD1Database,
+  createAwsDataApiDatabase,
   runSeeders,
   defineSeeder,
 } from '@guren/orm'
@@ -55,6 +56,8 @@ export type {
   SqliteDatabaseOptions,
   D1DatabaseHandle,
   D1DatabaseOptions,
+  AwsDataApiDatabase,
+  AwsDataApiDatabaseOptions,
   SeederContext,
   SeederHandler,
   SoftDeletesStatic,

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -40,10 +40,14 @@
     "drizzle-orm": "1.0.0-rc.4"
   },
   "peerDependencies": {
+    "@aws-sdk/client-rds-data": "^3.0.0",
     "mysql2": "^3.11.3",
     "postgres": "^3.4.3"
   },
   "peerDependenciesMeta": {
+    "@aws-sdk/client-rds-data": {
+      "optional": true
+    },
     "mysql2": {
       "optional": true
     },
@@ -52,6 +56,7 @@
     }
   },
   "devDependencies": {
+    "@aws-sdk/client-rds-data": "^3.0.0",
     "@types/node": "^20.14.10",
     "mysql2": "^3.11.3",
     "postgres": "^3.4.3",

--- a/packages/orm/src/aws-data-api.ts
+++ b/packages/orm/src/aws-data-api.ts
@@ -1,0 +1,291 @@
+import type { RDSDataClientConfig } from '@aws-sdk/client-rds-data'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { hotReloadKey, releaseActiveConnection, replaceActiveConnection } from './active-connections'
+import { DrizzleAdapter } from './adapters/drizzle-adapter'
+import { buildMigrationStatus, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
+import { runSeeders } from './seeder'
+
+type ConnectionResolver = string | (() => string | undefined)
+type AwsDataApiDrizzle = typeof import('drizzle-orm/aws-data-api/pg')
+type AwsDataApiPgDatabase = import('drizzle-orm/aws-data-api/pg').AwsDataApiPgDatabase
+type DrizzleConfig = Parameters<AwsDataApiDrizzle['drizzle']>[0]
+
+// The AWS driver packages are loaded lazily so importing @guren/orm does not
+// require `@aws-sdk/client-rds-data` to be installed (e.g. SQLite-only apps).
+// The drizzle driver itself imports the SDK at module scope, so a missing SDK
+// surfaces here as an import failure of the driver module.
+async function loadAwsDataApiModules(): Promise<{
+  drizzle: AwsDataApiDrizzle['drizzle']
+  migrate: typeof import('drizzle-orm/aws-data-api/pg/migrator')['migrate']
+}> {
+  try {
+    const [{ drizzle }, { migrate }] = await Promise.all([
+      import('drizzle-orm/aws-data-api/pg'),
+      import('drizzle-orm/aws-data-api/pg/migrator'),
+    ])
+    return { drizzle, migrate }
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `createAwsDataApiDatabase() requires the "@aws-sdk/client-rds-data" package. Install it with \`bun add @aws-sdk/client-rds-data\`. (${reason})`,
+    )
+  }
+}
+
+export interface AwsDataApiDatabaseOptions {
+  migrationsFolder: string | URL
+  /** Database name. Falls back to the DATABASE_NAME environment variable. */
+  database?: ConnectionResolver
+  /** Aurora cluster ARN. Falls back to the DATABASE_RESOURCE_ARN environment variable. */
+  resourceArn?: ConnectionResolver
+  /** Secrets Manager secret ARN holding the credentials. Falls back to the DATABASE_SECRET_ARN environment variable. */
+  secretArn?: ConnectionResolver
+  /** Extra RDSDataClient configuration (region, credentials, ...). */
+  clientOptions?: RDSDataClientConfig
+  /**
+   * Run pending migrations on the first `getDatabase()` call, like the other
+   * database factories do. Off by default: on Lambda that check runs on every
+   * cold start and costs several serialized Data API round trips before the
+   * first query. Run migrations out of band instead — `db:migrate` locally,
+   * or the console handler (`{"command": "db:migrate"}`) once deployed.
+   */
+  migrateOnStart?: boolean
+  seedersFolder?: string | URL
+  /**
+   * Drizzle relations for RQB v2 (`db.query.*`).
+   * Build with `defineRelations(schema, ...)` from `drizzle-orm`,
+   * or with `relations()` from `drizzle-orm/_relations` for the RQB v1 partial-upgrade path.
+   */
+  relations?: Record<string, unknown>
+}
+
+export interface AwsDataApiDatabase {
+  getDatabase(): Promise<AwsDataApiPgDatabase>
+  migrateDatabase(): Promise<void>
+  closeDatabase(): Promise<void>
+  configureOrm(): Promise<void>
+  seedDatabase(): Promise<void>
+  /** Drops the public schema (and the drizzle tracker schema) so migrations can be re-applied from scratch. */
+  resetDatabase(): Promise<void>
+  /** Per-migration applied state derived from the drizzle-kit journal and drizzle.__drizzle_migrations. */
+  migrationStatus(): Promise<MigrationStatusEntry[]>
+}
+
+interface ResolvedConnection {
+  database: string
+  resourceArn: string
+  secretArn: string
+}
+
+export function createAwsDataApiDatabase(options: AwsDataApiDatabaseOptions): AwsDataApiDatabase {
+  const { migrationsFolder, database, resourceArn, secretArn, clientOptions, migrateOnStart, seedersFolder, relations } = options
+
+  const resolvedMigrationsFolder =
+    migrationsFolder instanceof URL ? fileURLToPath(migrationsFolder) : resolve(String(migrationsFolder))
+  const resolvedSeedersFolder =
+    seedersFolder == null ? undefined : seedersFolder instanceof URL ? fileURLToPath(seedersFolder) : resolve(String(seedersFolder))
+
+  let migrationsPromise: Promise<void> | undefined
+  let databasePromise: Promise<AwsDataApiPgDatabase> | undefined
+  let client: { destroy?: () => void } | undefined
+  let activeKey: string | undefined
+  // Captured here, not in getDatabase(), so the caller of this factory is the
+  // frame that identifies the handle across hot reloads.
+  const callSite = new Error().stack
+
+  function resolveConnection(): ResolvedConnection {
+    const resolveValue = (value: ConnectionResolver | undefined, envKey: string): string | undefined => {
+      const resolved = typeof value === 'function' ? value() : value
+      return resolved ?? process.env[envKey]
+    }
+
+    const resolvedDatabase = resolveValue(database, 'DATABASE_NAME')
+    const resolvedResourceArn = resolveValue(resourceArn, 'DATABASE_RESOURCE_ARN')
+    const resolvedSecretArn = resolveValue(secretArn, 'DATABASE_SECRET_ARN')
+
+    const missing = [
+      resolvedDatabase ? null : 'database (DATABASE_NAME)',
+      resolvedResourceArn ? null : 'resourceArn (DATABASE_RESOURCE_ARN)',
+      resolvedSecretArn ? null : 'secretArn (DATABASE_SECRET_ARN)',
+    ].filter((entry): entry is string => entry !== null)
+
+    if (missing.length > 0) {
+      throw new Error(`Missing AWS Data API connection settings: ${missing.join(', ')}.`)
+    }
+
+    return { database: resolvedDatabase!, resourceArn: resolvedResourceArn!, secretArn: resolvedSecretArn! }
+  }
+
+  function buildDrizzleConfig(connection: ResolvedConnection): DrizzleConfig {
+    return {
+      connection: {
+        ...clientOptions,
+        ...connection,
+      },
+      ...(relations ? { relations } : {}),
+    } as DrizzleConfig
+  }
+
+  async function migrateOnce(): Promise<void> {
+    if (migrationsPromise) {
+      return migrationsPromise
+    }
+
+    const promise = (async (): Promise<void> => {
+      if (!hasDrizzleMigrations(resolvedMigrationsFolder)) {
+        warnIgnoredFlatSqlMigrations(resolvedMigrationsFolder)
+        return
+      }
+
+      const { migrate } = await loadAwsDataApiModules()
+      await withAdminDb((db) => migrate(db, { migrationsFolder: resolvedMigrationsFolder }))
+    })()
+
+    migrationsPromise = promise.catch((error) => {
+      migrationsPromise = undefined
+      const reason = error instanceof Error ? error.message : String(error)
+      throw new Error(`Failed to run database migrations: ${reason}`)
+    })
+
+    await migrationsPromise
+  }
+
+  async function getDatabase(): Promise<AwsDataApiPgDatabase> {
+    if (databasePromise) {
+      return databasePromise
+    }
+
+    const promise = (async (): Promise<AwsDataApiPgDatabase> => {
+      if (migrateOnStart) {
+        await migrateOnce()
+      }
+      const { drizzle } = await loadAwsDataApiModules()
+      const connection = resolveConnection()
+      const db = drizzle(buildDrizzleConfig(connection)) as unknown as AwsDataApiPgDatabase
+      client = (db as { $client?: { destroy?: () => void } }).$client
+
+      activeKey = hotReloadKey('aws-data-api', callSite, `${connection.resourceArn}/${connection.database}`)
+      if (activeKey) {
+        await replaceActiveConnection(activeKey, closeDatabase)
+      }
+
+      return db
+    })()
+
+    databasePromise = promise.catch((error) => {
+      databasePromise = undefined
+      throw error
+    })
+
+    return databasePromise
+  }
+
+  async function closeDatabase(): Promise<void> {
+    if (!client) {
+      return
+    }
+
+    const key = activeKey
+    activeKey = undefined
+
+    try {
+      client.destroy?.()
+    } finally {
+      client = undefined
+      databasePromise = undefined
+      if (key) {
+        releaseActiveConnection(key, closeDatabase)
+      }
+    }
+  }
+
+  async function configureOrm(): Promise<void> {
+    const db = await getDatabase()
+    DrizzleAdapter.configure(db as unknown as Parameters<typeof DrizzleAdapter.configure>[0])
+  }
+
+  async function seedDatabase(): Promise<void> {
+    if (!resolvedSeedersFolder) {
+      throw new Error('No seeders folder configured. Provide "seedersFolder" when calling createAwsDataApiDatabase().')
+    }
+
+    const db = await getDatabase()
+    await runSeeders(db as unknown as Parameters<typeof runSeeders>[0], resolvedSeedersFolder)
+  }
+
+  async function withAdminDb<T>(callback: (db: AwsDataApiPgDatabase) => Promise<T>): Promise<T> {
+    const { drizzle } = await loadAwsDataApiModules()
+    const adminDb = drizzle(buildDrizzleConfig(resolveConnection())) as unknown as AwsDataApiPgDatabase & {
+      $client?: { destroy?: () => void }
+    }
+
+    try {
+      return await callback(adminDb)
+    } finally {
+      // The Data API client is a stateless HTTP client; destroy() only
+      // releases the SDK's socket pool, so there is nothing to await.
+      adminDb.$client?.destroy?.()
+    }
+  }
+
+  async function resetDatabase(): Promise<void> {
+    const { sql } = await import('drizzle-orm')
+
+    await withAdminDb(async (adminDb) => {
+      await adminDb.execute(sql.raw('DROP SCHEMA IF EXISTS public CASCADE'))
+      await adminDb.execute(sql.raw('CREATE SCHEMA public'))
+      await adminDb.execute(sql.raw('DROP SCHEMA IF EXISTS drizzle CASCADE'))
+    })
+
+    // Allow migrateDatabase() to re-apply everything from scratch.
+    migrationsPromise = undefined
+  }
+
+  async function migrationStatus(): Promise<MigrationStatusEntry[]> {
+    const localMigrations = listLocalMigrations(resolvedMigrationsFolder)
+    if (localMigrations.length === 0) return []
+
+    const { sql } = await import('drizzle-orm')
+    const appliedRows = await withAdminDb(async (adminDb) => {
+      try {
+        const result = (await adminDb.execute(
+          sql.raw('SELECT name FROM drizzle.__drizzle_migrations'),
+        )) as unknown as { rows?: Array<{ name: string | null }> } | Array<{ name: string | null }>
+        const rows = Array.isArray(result) ? result : (result.rows ?? [])
+        return rows.map((row) => ({ name: row.name, appliedAt: null }))
+      } catch (error) {
+        // Only a missing tracker table means "nothing applied". Anything else
+        // (IAM denial, missing cluster, network) must surface — reporting it
+        // as all-pending could prompt a re-run of applied migrations.
+        if (isMissingTrackerTableError(error)) {
+          return []
+        }
+        throw error
+      }
+    })
+
+    return buildMigrationStatus(localMigrations, appliedRows)
+  }
+
+  return {
+    getDatabase,
+    migrateDatabase: migrateOnce,
+    closeDatabase,
+    configureOrm,
+    seedDatabase,
+    resetDatabase,
+    migrationStatus,
+  }
+}
+
+/**
+ * Whether a query failure means the drizzle tracker table (or its schema) has
+ * not been created yet. The Data API surfaces Postgres errors as message text
+ * (e.g. `relation "drizzle.__drizzle_migrations" does not exist`), so the
+ * undefined-table condition is matched there.
+ */
+function isMissingTrackerTableError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return /does not exist/i.test(message) && /drizzle|__drizzle_migrations|schema/i.test(message)
+}

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -60,6 +60,8 @@ export type { MigrationStatusEntry } from './migration-utils'
 export type { SqliteDatabase, SqliteDatabaseOptions } from './sqlite'
 export { createD1Database } from './d1'
 export type { D1DatabaseHandle, D1DatabaseOptions } from './d1'
+export { createAwsDataApiDatabase } from './aws-data-api'
+export type { AwsDataApiDatabase, AwsDataApiDatabaseOptions } from './aws-data-api'
 export { runSeeders, defineSeeder, loadSeeders } from './seeder'
 export type { SeederContext, SeederHandler } from './seeder'
 

--- a/packages/orm/tests/aws-data-api.test.ts
+++ b/packages/orm/tests/aws-data-api.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, mock, beforeEach } from 'bun:test'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { DrizzleAdapter } from '../src/adapters/drizzle-adapter'
+
+const destroyMock = mock(() => {})
+const executeMock = mock(async (_query: unknown) => ({ rows: [] as Array<{ name: string | null }> }))
+const drizzleMock = mock((config: Record<string, unknown>) => ({
+  config,
+  $client: { destroy: destroyMock },
+  execute: executeMock,
+}))
+const migrateMock = mock(async () => {})
+
+await mock.module('drizzle-orm/aws-data-api/pg', () => ({
+  drizzle: drizzleMock,
+}))
+
+await mock.module('drizzle-orm/aws-data-api/pg/migrator', () => ({
+  migrate: migrateMock,
+}))
+
+const { createAwsDataApiDatabase } = await import('../src/aws-data-api')
+
+const CONNECTION = {
+  database: () => 'appdb',
+  resourceArn: () => 'arn:aws:rds:ap-northeast-1:123456789012:cluster:example',
+  secretArn: () => 'arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:example',
+}
+
+function createMigrationsFolder(withMigrations: boolean): string {
+  const migrationsFolder = mkdtempSync(join(tmpdir(), 'guren-orm-migrations-'))
+
+  if (withMigrations) {
+    const migrationDir = join(migrationsFolder, '20240101000000_init')
+    mkdirSync(migrationDir, { recursive: true })
+    writeFileSync(join(migrationDir, 'migration.sql'), '')
+  }
+
+  return migrationsFolder
+}
+
+describe('createAwsDataApiDatabase', () => {
+  beforeEach(() => {
+    delete process.env.DATABASE_NAME
+    delete process.env.DATABASE_RESOURCE_ARN
+    delete process.env.DATABASE_SECRET_ARN
+  })
+
+  it('runs migrations and returns a configured database', async () => {
+    const database = createAwsDataApiDatabase({
+      migrationsFolder: createMigrationsFolder(true),
+      ...CONNECTION,
+    })
+
+    await database.migrateDatabase()
+    expect(migrateMock).toHaveBeenCalled()
+
+    const db = await database.getDatabase()
+    expect(db).toMatchObject({
+      config: {
+        connection: {
+          database: 'appdb',
+          resourceArn: CONNECTION.resourceArn(),
+          secretArn: CONNECTION.secretArn(),
+        },
+      },
+    })
+  })
+
+  it('configures the Drizzle adapter', async () => {
+    const database = createAwsDataApiDatabase({
+      migrationsFolder: createMigrationsFolder(true),
+      ...CONNECTION,
+    })
+
+    const originalConfigure = DrizzleAdapter.configure
+    const configureSpy = mock(() => {})
+    DrizzleAdapter.configure = configureSpy as typeof DrizzleAdapter.configure
+
+    await database.configureOrm()
+    expect(configureSpy).toHaveBeenCalled()
+
+    DrizzleAdapter.configure = originalConfigure
+  })
+
+  it('does not migrate on getDatabase() by default', async () => {
+    const database = createAwsDataApiDatabase({
+      migrationsFolder: createMigrationsFolder(true),
+      ...CONNECTION,
+    })
+
+    migrateMock.mockClear()
+    await database.getDatabase()
+
+    expect(migrateMock).not.toHaveBeenCalled()
+  })
+
+  it('migrates on getDatabase() when migrateOnStart is enabled', async () => {
+    const database = createAwsDataApiDatabase({
+      migrationsFolder: createMigrationsFolder(true),
+      ...CONNECTION,
+      migrateOnStart: true,
+    })
+
+    migrateMock.mockClear()
+    await database.getDatabase()
+
+    expect(migrateMock).toHaveBeenCalled()
+  })
+
+  it('skips migrations when drizzle metadata is missing', async () => {
+    const database = createAwsDataApiDatabase({
+      migrationsFolder: createMigrationsFolder(false),
+      ...CONNECTION,
+    })
+
+    migrateMock.mockClear()
+    await database.migrateDatabase()
+
+    expect(migrateMock).not.toHaveBeenCalled()
+  })
+
+  it('throws when connection settings are missing', async () => {
+    const database = createAwsDataApiDatabase({
+      migrationsFolder: createMigrationsFolder(true),
+    })
+
+    await expect(database.getDatabase()).rejects.toThrow(
+      'Missing AWS Data API connection settings: database (DATABASE_NAME), resourceArn (DATABASE_RESOURCE_ARN), secretArn (DATABASE_SECRET_ARN).',
+    )
+  })
+
+  it('resolves connection settings from environment variables', async () => {
+    process.env.DATABASE_NAME = 'envdb'
+    process.env.DATABASE_RESOURCE_ARN = 'arn:aws:rds:env'
+    process.env.DATABASE_SECRET_ARN = 'arn:aws:secretsmanager:env'
+
+    const database = createAwsDataApiDatabase({
+      migrationsFolder: createMigrationsFolder(false),
+    })
+
+    const db = await database.getDatabase()
+    expect(db).toMatchObject({
+      config: {
+        connection: {
+          database: 'envdb',
+          resourceArn: 'arn:aws:rds:env',
+          secretArn: 'arn:aws:secretsmanager:env',
+        },
+      },
+    })
+  })
+
+  it('passes extra client options through to the driver', async () => {
+    const database = createAwsDataApiDatabase({
+      migrationsFolder: createMigrationsFolder(false),
+      ...CONNECTION,
+      clientOptions: { region: 'ap-northeast-1' },
+    })
+
+    const db = await database.getDatabase()
+    expect(db).toMatchObject({
+      config: { connection: { region: 'ap-northeast-1', database: 'appdb' } },
+    })
+  })
+
+  it('throws when seeders folder is missing', async () => {
+    const database = createAwsDataApiDatabase({
+      migrationsFolder: createMigrationsFolder(true),
+      ...CONNECTION,
+    })
+
+    await expect(database.seedDatabase()).rejects.toThrow('No seeders folder configured')
+  })
+
+  it('destroys the client on close', async () => {
+    const database = createAwsDataApiDatabase({
+      migrationsFolder: createMigrationsFolder(false),
+      ...CONNECTION,
+    })
+
+    await database.getDatabase()
+    destroyMock.mockClear()
+    await database.closeDatabase()
+
+    expect(destroyMock).toHaveBeenCalled()
+  })
+
+  it('reports per-migration applied state', async () => {
+    const database = createAwsDataApiDatabase({
+      migrationsFolder: createMigrationsFolder(true),
+      ...CONNECTION,
+    })
+
+    executeMock.mockResolvedValueOnce({ rows: [{ name: '20240101000000_init' }] })
+    const status = await database.migrationStatus()
+
+    expect(status).toEqual([{ name: '20240101000000_init', applied: true, appliedAt: null }])
+  })
+
+  it('treats a missing tracker table as nothing applied', async () => {
+    const database = createAwsDataApiDatabase({
+      migrationsFolder: createMigrationsFolder(true),
+      ...CONNECTION,
+    })
+
+    executeMock.mockRejectedValueOnce(new Error('relation "drizzle.__drizzle_migrations" does not exist'))
+    const status = await database.migrationStatus()
+
+    expect(status).toEqual([{ name: '20240101000000_init', applied: false, appliedAt: null }])
+  })
+
+  it('surfaces non-schema failures from migrationStatus', async () => {
+    const database = createAwsDataApiDatabase({
+      migrationsFolder: createMigrationsFolder(true),
+      ...CONNECTION,
+    })
+
+    executeMock.mockRejectedValueOnce(new Error('AccessDeniedException: not authorized to perform rds-data:ExecuteStatement'))
+
+    await expect(database.migrationStatus()).rejects.toThrow('AccessDeniedException')
+  })
+})


### PR DESCRIPTION
## Summary

- Add `createAwsDataApiDatabase()` to `@guren/orm`, a database factory for Aurora Serverless v2 through the RDS Data API, built on `drizzle-orm/aws-data-api/pg`. The Data API is HTTP-based, so Lambda deployments get a Postgres-compatible connection without a connection pool, RDS Proxy, or VPC placement.
- The factory mirrors the other drivers' runtime contract (`getDatabase`, `migrateDatabase`, `configureOrm`, `seedDatabase`, `resetDatabase`, `migrationStatus`) and reuses the shared `migration-utils` / `active-connections` / `seeder` infrastructure.
- `@aws-sdk/client-rds-data` is an optional peer dependency, loaded lazily with an install-guidance error (same pattern as `postgres`/`mysql2`).
- Connection settings resolve from options or `DATABASE_NAME` / `DATABASE_RESOURCE_ARN` / `DATABASE_SECRET_ARN`.
- One deliberate difference from the other factories: `getDatabase()` does **not** run pending migrations automatically — on Lambda that check costs several serialized Data API round trips on every cold start. Migrations run out of band (`db:migrate`, or the console handler once deployed), or opt back in with `migrateOnStart: true`.
- Re-exported through `@guren/core`; docs (database guide + support matrix, en/ja), `guren db:status` guidance, and the API stability list updated.

First of three stacked PRs adding first-class AWS Lambda support (ORM → plugin → CDK/docs).

## Test plan

- `packages/orm/tests/aws-data-api.test.ts` (12 tests): migration gating incl. `migrateOnStart`, adapter wiring, env fallbacks, missing-setting errors, `migrationStatus`, client teardown
- `bun run build` / `bun run typecheck` / `bun run test:bun` (2828 tests) / `bun run audit:core-first` / `bun run audit:docs` all green