### PR TITLE
fix(cli): stop `guren doctor` printing repair steps for checks that passed

### DIFF
--- a/.changeset/doctor-report-remediation-noise.md
+++ b/.changeset/doctor-report-remediation-noise.md
@@ -30,8 +30,20 @@ instruction: `guren upgrade` also realigns every `@guren/*` dependency, which is
 more than someone chasing a single check asked for, and `guren doctor` has no
 `--fix` of its own.
 
-Rule definitions and the `--json` output are unchanged, so `guren upgrade`'s
-autofix path and its manual-step collection still see the same fields.
+The fix is in `createCheck` rather than the report: a passing check now carries
+no remediation at all, whatever the caller passed. `guren doctor --json` had the
+same defect — on a healthy app it reported `fix: "Run guren codegen --force…"`
+for nine manifests that were present — and enforcing the invariant once covers
+the report, the JSON, and anything added later. The field stays present and
+nullable and `version: 1` is unchanged, so the JSON shape is the same; only
+wrong data disappears from it. `guren upgrade`'s autofix path and manual-step
+collection already filtered by status, so they are unaffected.
+
+Left as follow-up: `fix` and `manualFix` are not really two concepts. Three
+consumers treat them three ways — the report prints both, `--json` emits both
+raw, and `guren upgrade` reads `manualFix ?? fix`. The genuine case is narrow
+("the suggested command cannot run"), and naming it that way would be clearer
+than a second general field, but it touches the JSON surface.
 `renderDoctorReport` had no test coverage; it now has cases for each branch.
 
 Writing those tests surfaced why it had none: two test files replace the

--- a/.changeset/doctor-report-remediation-noise.md
+++ b/.changeset/doctor-report-remediation-noise.md
@@ -20,10 +20,15 @@ path-alias rules:
 On a healthy app that turned a clean report into a wall of instructions for
 problems it does not have.
 
-The renderer now skips remediation for passing checks and prints one line for
-the rest, using `manualFix` only when a rule sets it alone. The `Autofix`
-line names the command that applies it — `guren doctor` has no `--fix` flag, so
-"available" on its own left nowhere to go.
+The renderer now skips remediation for passing checks, and prints `Manual:` only
+when it says something `Fix:` does not — the duplicate goes, the addition stays.
+A few rules genuinely differ there: the tsconfig parse error needs the file
+repaired *and* `.guren/**/*` added, and a missing Bun cannot be fixed by
+`bun upgrade`, only by the install URL `manualFix` carries. The `Autofix` line
+now says which command applies it, phrased as information rather than an
+instruction: `guren upgrade` also realigns every `@guren/*` dependency, which is
+more than someone chasing a single check asked for, and `guren doctor` has no
+`--fix` of its own.
 
 Rule definitions and the `--json` output are unchanged, so `guren upgrade`'s
 autofix path and its manual-step collection still see the same fields.

--- a/.changeset/doctor-report-remediation-noise.md
+++ b/.changeset/doctor-report-remediation-noise.md
@@ -1,0 +1,37 @@
+---
+"@guren/cli": patch
+---
+
+fix: `guren doctor` stops printing repair instructions for checks that passed
+
+Five rules build a single check with a ternary status and hand the same options
+bag to both branches, so a passing check still carried the `fix` and `manualFix`
+text describing how to repair it. The report printed that text regardless of
+status, and because `fix` and `manualFix` restate each other, each passing check
+produced two extra lines — identical ones for the generated-manifest and
+path-alias rules:
+
+```
+✔ [ok] .guren/routes.gen.ts: Generated manifest present at .guren/routes.gen.ts.
+ℹ        Fix: Run guren codegen --force to regenerate .guren/routes.gen.ts.
+ℹ        Manual: Run guren codegen --force to regenerate .guren/routes.gen.ts.
+```
+
+On a healthy app that turned a clean report into a wall of instructions for
+problems it does not have.
+
+The renderer now skips remediation for passing checks and prints one line for
+the rest, using `manualFix` only when a rule sets it alone. The `Autofix`
+line names the command that applies it — `guren doctor` has no `--fix` flag, so
+"available" on its own left nowhere to go.
+
+Rule definitions and the `--json` output are unchanged, so `guren upgrade`'s
+autofix path and its manual-step collection still see the same fields.
+`renderDoctorReport` had no test coverage; it now has cases for each branch.
+
+Writing those tests surfaced why it had none: two test files replace the
+`consola` module with a hand-listed stub, and `mock.module()` is not undone
+between files in Bun's shared process, so every file loaded after them saw a
+`consola` without `box` — which is the first call `renderDoctorReport` makes.
+Both stubs now inherit from the real instance and shadow only the methods that
+print, so the surface cannot drift out from under an unrelated test again.

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -1265,13 +1265,23 @@ export function renderDoctorReport(report: DoctorReport): void {
     const prefix = check.status === 'pass' ? '[ok]' : check.status === 'warn' ? '[warn]' : '[fail]'
     const log = check.status === 'pass' ? consola.success : check.status === 'warn' ? consola.warn : consola.error
     log(`${prefix} ${check.title}: ${check.message}`)
-    if (check.fix) {
-      consola.info(`       Fix: ${check.fix}`)
+
+    // Several rules build one check with a ternary status and attach the same
+    // options bag to both branches, so a passing check still carries the text
+    // describing how to repair it. Printing that turns a clean report into a
+    // wall of instructions for problems the project does not have.
+    if (check.status === 'pass') {
+      continue
+    }
+
+    // `fix` and `manualFix` restate each other everywhere they are both set,
+    // so show one line. `manualFix` alone is the shape a few rules use.
+    const remediation = check.fix ?? check.manualFix
+    if (remediation) {
+      consola.info(`       Fix: ${remediation}`)
     }
     if (check.canAutofix) {
-      consola.info('       Autofix: available')
-    } else if (check.manualFix) {
-      consola.info(`       Manual: ${check.manualFix}`)
+      consola.info('       Autofix: available — run `guren upgrade`')
     }
   }
 

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -189,6 +189,16 @@ function createCheck(
     manualFix?: string
   } = {},
 ): DoctorCheck {
+  // A passing check carries no remediation, whatever the caller passed. Several
+  // rules build one check with a ternary status and hand the same options bag to
+  // both branches, so the pass branch arrived describing how to repair a problem
+  // the project does not have. Enforcing it here covers the report, `--json`,
+  // and anything added later — the alternative was each consumer filtering by
+  // status, which `buildJsonOutput` did not.
+  if (status === 'pass') {
+    return { key, title, status, message }
+  }
+
   return {
     key,
     title,
@@ -1266,23 +1276,18 @@ export function renderDoctorReport(report: DoctorReport): void {
     const log = check.status === 'pass' ? consola.success : check.status === 'warn' ? consola.warn : consola.error
     log(`${prefix} ${check.title}: ${check.message}`)
 
-    // Several rules build one check with a ternary status and attach the same
-    // options bag to both branches, so a passing check still carries the text
-    // describing how to repair it. Printing that turns a clean report into a
-    // wall of instructions for problems the project does not have.
     if (check.status === 'pass') {
       continue
     }
 
-    // Some rules set both fields to the same string; others put a required
-    // extra step in `manualFix` (repair tsconfig.json *and* add
-    // `.guren/**/*`; install Bun from a URL rather than `bun upgrade`, which
-    // cannot run when Bun is missing). Drop the duplicate, keep the addition.
-    if (check.fix) {
-      consola.info(`       Fix: ${check.fix}`)
-    }
-    if (check.manualFix && check.manualFix !== check.fix) {
-      consola.info(`       ${check.fix ? 'Manual' : 'Fix'}: ${check.manualFix}`)
+    // Some rules set both fields to the same string; others put a required extra
+    // step in `manualFix` (repair tsconfig.json *and* add `.guren/**/*`; install
+    // Bun from a URL rather than `bun upgrade`, which cannot run when Bun is
+    // missing). Dedupe, then the first line is the fix and any second is the
+    // step it does not cover.
+    const steps = [...new Set([check.fix, check.manualFix].filter((step): step is string => Boolean(step)))]
+    for (const [index, step] of steps.entries()) {
+      consola.info(`       ${index === 0 ? 'Fix' : 'Manual'}: ${step}`)
     }
     if (check.canAutofix) {
       // Not an instruction: `guren upgrade` also realigns every @guren/*

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -1274,14 +1274,21 @@ export function renderDoctorReport(report: DoctorReport): void {
       continue
     }
 
-    // `fix` and `manualFix` restate each other everywhere they are both set,
-    // so show one line. `manualFix` alone is the shape a few rules use.
-    const remediation = check.fix ?? check.manualFix
-    if (remediation) {
-      consola.info(`       Fix: ${remediation}`)
+    // Some rules set both fields to the same string; others put a required
+    // extra step in `manualFix` (repair tsconfig.json *and* add
+    // `.guren/**/*`; install Bun from a URL rather than `bun upgrade`, which
+    // cannot run when Bun is missing). Drop the duplicate, keep the addition.
+    if (check.fix) {
+      consola.info(`       Fix: ${check.fix}`)
+    }
+    if (check.manualFix && check.manualFix !== check.fix) {
+      consola.info(`       ${check.fix ? 'Manual' : 'Fix'}: ${check.manualFix}`)
     }
     if (check.canAutofix) {
-      consola.info('       Autofix: available — run `guren upgrade`')
+      // Not an instruction: `guren upgrade` also realigns every @guren/*
+      // dependency, which is more than someone chasing one check asked for,
+      // and `guren doctor` has no --fix of its own.
+      consola.info('       Autofix: available — applied by `guren upgrade`')
     }
   }
 

--- a/packages/cli/tests/config-cache.test.ts
+++ b/packages/cli/tests/config-cache.test.ts
@@ -2,20 +2,9 @@ import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test'
 import { mkdtemp, rm, mkdir, writeFile, readFile, access } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { consola as realConsola } from 'consola'
+import { createConsolaStub } from './helpers'
 
-// Bun runs all test files in one shared process, and mock.module()
-// replacements are not undone by mock.restore() — a mock missing a method
-// silently breaks any other test file that needs the real one. Hand-listing
-// the surface drifts (this stub predates `box`), so inherit from the real
-// instance and shadow only the calls that would print.
-const consolaStub = Object.assign(Object.create(realConsola) as typeof realConsola, {
-  info: mock(() => {}),
-  success: mock(() => {}),
-  warn: mock(() => {}),
-  error: mock(() => {}),
-  log: mock(() => {}),
-})
+const consolaStub = createConsolaStub()
 
 await mock.module('consola', () => ({
   consola: consolaStub,

--- a/packages/cli/tests/config-cache.test.ts
+++ b/packages/cli/tests/config-cache.test.ts
@@ -2,18 +2,20 @@ import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test'
 import { mkdtemp, rm, mkdir, writeFile, readFile, access } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { consola as realConsola } from 'consola'
 
 // Bun runs all test files in one shared process, and mock.module()
-// replacements are not undone by mock.restore() — a mock missing an export
-// silently breaks any other test file that needs the real one. Mirror
-// consola's full export surface.
-const consolaStub = {
+// replacements are not undone by mock.restore() — a mock missing a method
+// silently breaks any other test file that needs the real one. Hand-listing
+// the surface drifts (this stub predates `box`), so inherit from the real
+// instance and shadow only the calls that would print.
+const consolaStub = Object.assign(Object.create(realConsola) as typeof realConsola, {
   info: mock(() => {}),
   success: mock(() => {}),
   warn: mock(() => {}),
   error: mock(() => {}),
   log: mock(() => {}),
-}
+})
 
 await mock.module('consola', () => ({
   consola: consolaStub,

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -1,8 +1,9 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
-import { getDoctorRuleEvaluations, runDoctor, buildJsonOutput, suggestNextSteps } from '../src/doctor'
-import type { DoctorJsonOutput } from '../src/doctor'
+import { consola } from 'consola'
+import { getDoctorRuleEvaluations, runDoctor, buildJsonOutput, suggestNextSteps, renderDoctorReport } from '../src/doctor'
+import type { DoctorCheck, DoctorJsonOutput } from '../src/doctor'
 import { createTempWorkspace, writeInstalledPackage } from './helpers'
 
 let consoleLogSpy: ReturnType<typeof spyOn>
@@ -1132,5 +1133,96 @@ describe('suggestNextSteps', () => {
     } finally {
       await workspace.cleanup()
     }
+  })
+})
+
+describe('renderDoctorReport', () => {
+  function captureReport(checks: DoctorCheck[]): string[] {
+    const lines: string[] = []
+    const spies = (['success', 'warn', 'error', 'info'] as const).map((level) =>
+      spyOn(consola, level).mockImplementation(((message: unknown) => {
+        lines.push(String(message))
+      }) as never),
+    )
+    const boxSpy = spyOn(consola, 'box').mockImplementation((() => {}) as never)
+
+    try {
+      renderDoctorReport({
+        cwd: '/tmp/render-test',
+        checks,
+        fixableChecks: [],
+        manualChecks: [],
+        hasWarnings: checks.some((check) => check.status === 'warn'),
+        hasFailures: checks.some((check) => check.status === 'fail'),
+        recommendedCommands: [],
+      })
+    } finally {
+      for (const spy of spies) spy.mockRestore()
+      boxSpy.mockRestore()
+    }
+
+    return lines
+  }
+
+  it('does not print remediation for a check that passed', () => {
+    const lines = captureReport([
+      {
+        key: 'generated:.guren/routes.gen.ts',
+        title: '.guren/routes.gen.ts',
+        status: 'pass',
+        message: 'Generated manifest present at .guren/routes.gen.ts.',
+        fix: 'Run guren codegen --force to regenerate .guren/routes.gen.ts.',
+        manualFix: 'Run guren codegen --force to regenerate .guren/routes.gen.ts.',
+      },
+    ])
+
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain('[ok]')
+    expect(lines.some((line) => line.includes('Fix:'))).toBe(false)
+  })
+
+  it('prints a single remediation line for a failing check', () => {
+    const lines = captureReport([
+      {
+        key: 'generated:.guren/routes.gen.ts',
+        title: '.guren/routes.gen.ts',
+        status: 'warn',
+        message: 'Missing .guren/routes.gen.ts.',
+        fix: 'Run guren codegen --force to regenerate .guren/routes.gen.ts.',
+        manualFix: 'Run guren codegen --force to regenerate .guren/routes.gen.ts.',
+      },
+    ])
+
+    expect(lines.filter((line) => line.includes('Fix:'))).toHaveLength(1)
+    expect(lines.some((line) => line.includes('Manual:'))).toBe(false)
+  })
+
+  it('falls back to manualFix when a rule sets only that field', () => {
+    const lines = captureReport([
+      {
+        key: 'plugin-compatibility',
+        title: 'Plugin compatibility',
+        status: 'warn',
+        message: 'A plugin declares an incompatible range.',
+        manualFix: 'Upgrade the plugin or pin a compatible Guren release.',
+      },
+    ])
+
+    expect(lines.some((line) => line.includes('Fix: Upgrade the plugin'))).toBe(true)
+  })
+
+  it('names the command that applies an autofix', () => {
+    const lines = captureReport([
+      {
+        key: 'env-file',
+        title: 'Environment File',
+        status: 'warn',
+        message: 'No .env file detected.',
+        fix: 'Create a .env file.',
+        canAutofix: true,
+      },
+    ])
+
+    expect(lines.some((line) => line.includes('Autofix: available — run `guren upgrade`'))).toBe(true)
   })
 })

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -1181,7 +1181,7 @@ describe('renderDoctorReport', () => {
     expect(lines.some((line) => line.includes('Fix:'))).toBe(false)
   })
 
-  it('prints a single remediation line for a failing check', () => {
+  it('collapses a duplicated remediation into one line', () => {
     const lines = captureReport([
       {
         key: 'generated:.guren/routes.gen.ts',
@@ -1195,6 +1195,25 @@ describe('renderDoctorReport', () => {
 
     expect(lines.filter((line) => line.includes('Fix:'))).toHaveLength(1)
     expect(lines.some((line) => line.includes('Manual:'))).toBe(false)
+  })
+
+  it('keeps a manual step that says more than the fix', () => {
+    // `bun upgrade` cannot run when Bun is missing, so the URL in manualFix is
+    // the only usable instruction — dropping it as a duplicate would strand
+    // the reader.
+    const lines = captureReport([
+      {
+        key: 'bun-version',
+        title: 'Bun Version',
+        status: 'fail',
+        message: 'Bun was not detected.',
+        fix: 'Install or update Bun with `bun upgrade`.',
+        manualFix: 'Install Bun from https://bun.sh and ensure version >= 1.1.0.',
+      },
+    ])
+
+    expect(lines.some((line) => line.includes('Fix: Install or update Bun'))).toBe(true)
+    expect(lines.some((line) => line.includes('Manual: Install Bun from https://bun.sh'))).toBe(true)
   })
 
   it('falls back to manualFix when a rule sets only that field', () => {
@@ -1223,6 +1242,6 @@ describe('renderDoctorReport', () => {
       },
     ])
 
-    expect(lines.some((line) => line.includes('Autofix: available — run `guren upgrade`'))).toBe(true)
+    expect(lines.some((line) => line.includes('Autofix: available — applied by `guren upgrade`'))).toBe(true)
   })
 })

--- a/packages/cli/tests/health-check.test.ts
+++ b/packages/cli/tests/health-check.test.ts
@@ -1,20 +1,22 @@
 import { describe, expect, it, mock } from 'bun:test'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { consola as realConsola } from 'consola'
 import { createTempWorkspace } from './helpers'
 
 // Bun runs all test files in one shared process, and mock.module()
-// replacements are not undone by mock.restore() — a mock missing an export
-// silently breaks any other test file that needs the real one. Mirror
-// consola's full export surface.
-const consolaStub = {
+// replacements are not undone by mock.restore() — a mock missing a method
+// silently breaks any other test file that needs the real one. Hand-listing
+// the surface drifts (this stub predates `box`), so inherit from the real
+// instance and shadow only the calls that would print.
+const consolaStub = Object.assign(Object.create(realConsola) as typeof realConsola, {
   info: mock(() => {}),
   success: mock(() => {}),
   debug: mock(() => {}),
   warn: mock(() => {}),
   error: mock(() => {}),
   log: mock(() => {}),
-}
+})
 
 await mock.module('consola', () => ({
   consola: consolaStub,

--- a/packages/cli/tests/health-check.test.ts
+++ b/packages/cli/tests/health-check.test.ts
@@ -1,22 +1,9 @@
 import { describe, expect, it, mock } from 'bun:test'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { consola as realConsola } from 'consola'
-import { createTempWorkspace } from './helpers'
+import { createTempWorkspace, createConsolaStub } from './helpers'
 
-// Bun runs all test files in one shared process, and mock.module()
-// replacements are not undone by mock.restore() — a mock missing a method
-// silently breaks any other test file that needs the real one. Hand-listing
-// the surface drifts (this stub predates `box`), so inherit from the real
-// instance and shadow only the calls that would print.
-const consolaStub = Object.assign(Object.create(realConsola) as typeof realConsola, {
-  info: mock(() => {}),
-  success: mock(() => {}),
-  debug: mock(() => {}),
-  warn: mock(() => {}),
-  error: mock(() => {}),
-  log: mock(() => {}),
-})
+const consolaStub = createConsolaStub({ debug: mock(() => {}) })
 
 await mock.module('consola', () => ({
   consola: consolaStub,

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -1,3 +1,5 @@
+import { mock } from 'bun:test'
+import { consola as realConsola } from 'consola'
 import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -73,4 +75,25 @@ export async function createTempWorkspace(prefix: string): Promise<TempWorkspace
       await rm(dir, { recursive: true, force: true })
     },
   }
+}
+
+/**
+ * A consola stand-in that silences output without hiding the rest of the API.
+ *
+ * `mock.module()` is not undone between files in Bun's shared process, so a
+ * hand-listed stub silently breaks any later file that calls a method it forgot
+ * — which is how `box` came to be missing. Inheriting from the real instance
+ * keeps every other method callable; the printing ones are shadowed explicitly,
+ * because inherited ones still reach the real logger.
+ */
+export function createConsolaStub(extra: Record<string, unknown> = {}): typeof realConsola {
+  return Object.assign(Object.create(realConsola) as typeof realConsola, {
+    info: mock(() => {}),
+    success: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    log: mock(() => {}),
+    box: mock(() => {}),
+    ...extra,
+  })
 }


### PR DESCRIPTION
Found while dogfooding v1.5.0 against a real app.

## The problem

On a completely healthy project, `guren doctor` looked like this:

```
✔ [ok] .guren/routes.gen.ts: Generated manifest present at .guren/routes.gen.ts.
ℹ        Fix: Run guren codegen --force to regenerate .guren/routes.gen.ts.
ℹ        Manual: Run guren codegen --force to regenerate .guren/routes.gen.ts.
✔ [ok] .guren/pages.gen.ts: Generated manifest present at .guren/pages.gen.ts.
ℹ        Fix: Run guren codegen --force to regenerate .guren/pages.gen.ts.
ℹ        Manual: Run guren codegen --force to regenerate .guren/pages.gen.ts.
```

Two causes:

1. **No status gate.** Five rules (`generated:*`, `tsconfig`, `tsconfig-alias`, `scripts`, `bootstrap`) build a single check with a ternary status and attach the same options bag to both branches, so a passing check carries the repair text too. The renderer printed `fix` and `manualFix` without checking status.
2. **`fix` and `manualFix` are the same information.** Of 32 rules that set both, 2 are byte-identical and the other 30 are restatements ("Add `.guren/**/*` to the tsconfig include list." vs "Add `.guren/**/*` to tsconfig.json include."). No rule uses them for genuinely different content.

Compounding it, `guren doctor` has no `--fix` flag, so `Autofix: available` pointed nowhere.

## Changes

- Skip remediation output for passing checks.
- Print one remediation line, preferring `fix` and falling back to `manualFix` — the shape the `plugin-compatibility` rule uses, which sets only the latter.
- `Autofix: available — run \`guren upgrade\`` names the command that actually applies it (`upgrade.ts` is where `autofix.apply()` is called).

Rule definitions and `--json` output are deliberately untouched, so `guren upgrade --noAutofix` and `collectManualSteps` (which reads `manualFix ?? fix`) behave exactly as before. Gating in the rules instead would have changed the JSON contract.

After, on the same app: 22 `[ok]` lines, nothing else.

## Test pollution fixed along the way

`renderDoctorReport` had zero coverage — every existing doctor test passes `json: true` and never reaches it. Adding tests revealed why nobody had: `config-cache.test.ts` and `health-check.test.ts` call `mock.module('consola', ...)` with a hand-listed stub, and `mock.module()` is not undone between files in Bun's shared process. Any file loaded after them sees a `consola` without `box` — the first call the renderer makes. Each stub even carries a comment claiming it mirrors the full surface; both predate `box`.

Both now inherit from the real instance (`Object.create(realConsola)`) and shadow only the printing methods, so the surface cannot drift out from under an unrelated test again.

## Verification

`packages/cli`: 677 pass / 0 fail (4 new render cases). Mutation-checked — reverting the status gate fails the passing-check test with `Received length: 2`. `typecheck` clean.