### PR TITLE
fix(plugin-cloudflare): name the SSR export the built bundle actually has

### DIFF
--- a/.changeset/cloudflare-worker-ssr-export.md
+++ b/.changeset/cloudflare-worker-ssr-export.md
@@ -1,0 +1,30 @@
+---
+"@guren/plugin-cloudflare": patch
+---
+
+fix: the generated Workers entry names the SSR export the bundle actually has
+
+`cloudflare:build` emitted `setInertiaSsrRenderer(ssrModule.render ?? ssrModule.default)`,
+probing both renderer shapes. Since a built SSR chunk only ever has one of them,
+esbuild reported the other as missing on every `wrangler deploy`:
+
+```
+▲ [WARNING] Import "render" will always be undefined because there is no matching
+  export in ".guren/ssr/ssr-XXXX.js" [import-is-undefined]
+```
+
+The runtime fallback made it harmless, but it sat on the one line whose real
+failure mode is Inertia silently falling back to CSR — so the warning that
+means "your SSR is wired wrong" was printed on every healthy deploy too, and
+could not be told apart from the genuine one.
+
+`resolveSsrImport` already imports the built chunk to check it exposes a
+renderer, so it now records which export won and the generated entry names that
+one directly. Both shapes stay supported: a chunk built from
+`export default` gets `ssrModule.default`, one from `export function render`
+gets `ssrModule.render`.
+
+The same check now tests each candidate for being a function rather than taking
+the first non-nullish one, matching how the runtime loader picks a renderer — an
+entry exporting `const render = 42` alongside a valid default builds instead of
+failing.

--- a/packages/plugin-cloudflare/src/build.test.ts
+++ b/packages/plugin-cloudflare/src/build.test.ts
@@ -54,7 +54,7 @@ describe('buildCloudflareOutput', () => {
     expect(worker).toContain('import app from "../src/app.ts"')
     expect(worker).toContain('process.env.GUREN_INERTIA_ENTRY = "/assets/app-Abc123.js"')
     expect(worker).toContain('process.env.GUREN_INERTIA_STYLES = "/assets/app-Def456.css"')
-    expect(worker).toContain('setInertiaSsrRenderer(ssrModule.render ?? ssrModule.default)')
+    expect(worker).toContain('setInertiaSsrRenderer(ssrModule.render)')
     expect(worker).toContain('export default createWorkersHandler(app)')
   })
 
@@ -142,7 +142,10 @@ describe('buildCloudflareOutput', () => {
     await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
 
     const worker = readFileSync(join(root, '.cloudflare/worker.js'), 'utf8')
-    expect(worker).toContain('setInertiaSsrRenderer(ssrModule.render ?? ssrModule.default)')
+    // The generated entry names the export the chunk has, so esbuild has no
+    // absent binding to warn about at deploy time.
+    expect(worker).toContain('setInertiaSsrRenderer(ssrModule.default)')
+    expect(worker).not.toContain('ssrModule.render')
   })
 
   test('should throw when the SSR entry exports no renderer', async () => {

--- a/packages/plugin-cloudflare/src/build.test.ts
+++ b/packages/plugin-cloudflare/src/build.test.ts
@@ -142,10 +142,21 @@ describe('buildCloudflareOutput', () => {
     await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
 
     const worker = readFileSync(join(root, '.cloudflare/worker.js'), 'utf8')
-    // The generated entry names the export the chunk has, so esbuild has no
-    // absent binding to warn about at deploy time.
     expect(worker).toContain('setInertiaSsrRenderer(ssrModule.default)')
     expect(worker).not.toContain('ssrModule.render')
+  })
+
+  test('should prefer a callable default over a non-function render', async () => {
+    scaffoldApp(root, {
+      renderExport: 'export const render = 42\nexport default () => ({ body: "", head: [] })',
+    })
+
+    await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
+
+    // What the runtime loader would pick: each candidate is tested for being a
+    // function, so a non-callable `render` does not shadow a valid default.
+    const worker = readFileSync(join(root, '.cloudflare/worker.js'), 'utf8')
+    expect(worker).toContain('setInertiaSsrRenderer(ssrModule.default)')
   })
 
   test('should throw when the SSR entry exports no renderer', async () => {

--- a/packages/plugin-cloudflare/src/build.ts
+++ b/packages/plugin-cloudflare/src/build.ts
@@ -267,11 +267,7 @@ function runAppBuild(root: string, scripts: Record<string, string>): void {
 interface SsrImport {
   /** Absolute path of the built SSR entry chunk. */
   file: string
-  /**
-   * Export the chunk actually exposes the renderer under. Recorded here so the
-   * generated worker can name it, instead of probing both shapes and leaving a
-   * reference to whichever one is absent.
-   */
+  /** Export name the chunk exposes the renderer under; the worker names it directly. */
   rendererExport: 'render' | 'default'
 }
 
@@ -300,8 +296,10 @@ async function resolveSsrImport(ssrDir: string, ssrEntryKey: string): Promise<Ss
   }
 
   const module = (await import(pathToFileURL(file).href)) as Record<string, unknown>
-  // Same order and the same per-candidate function test the runtime loader
-  // applies, so the build accepts exactly what the server would run.
+  // Mirrors extractSsrRenderer in @guren/server (mvc/inertia/InertiaEngine.ts):
+  // same order, same per-candidate function test, so the build accepts exactly
+  // what the server would run. Kept as a copy rather than an import — build.ts
+  // otherwise depends on node builtins alone.
   const rendererExport = (['render', 'default'] as const).find(
     (name) => typeof module[name] === 'function',
   )
@@ -370,10 +368,6 @@ function renderWorkerModule(input: {
   }
 
   if (input.ssrImport) {
-    // Name the export the chunk really has. Probing both shapes made esbuild
-    // warn on every deploy that the missing one "will always be undefined" —
-    // on the exact line whose failure mode is a silent fall back to CSR, so
-    // the noise was indistinguishable from the real thing.
     lines.push(`setInertiaSsrRenderer(ssrModule.${input.ssrImport.rendererExport})`, '')
   }
 

--- a/packages/plugin-cloudflare/src/build.ts
+++ b/packages/plugin-cloudflare/src/build.ts
@@ -267,6 +267,12 @@ function runAppBuild(root: string, scripts: Record<string, string>): void {
 interface SsrImport {
   /** Absolute path of the built SSR entry chunk. */
   file: string
+  /**
+   * Export the chunk actually exposes the renderer under. Recorded here so the
+   * generated worker can name it, instead of probing both shapes and leaving a
+   * reference to whichever one is absent.
+   */
+  rendererExport: 'render' | 'default'
 }
 
 async function resolveSsrImport(ssrDir: string, ssrEntryKey: string): Promise<SsrImport | undefined> {
@@ -294,14 +300,18 @@ async function resolveSsrImport(ssrDir: string, ssrEntryKey: string): Promise<Ss
   }
 
   const module = (await import(pathToFileURL(file).href)) as Record<string, unknown>
-  const renderer = module.render ?? module.default
-  if (typeof renderer !== 'function') {
+  // Same order and the same per-candidate function test the runtime loader
+  // applies, so the build accepts exactly what the server would run.
+  const rendererExport = (['render', 'default'] as const).find(
+    (name) => typeof module[name] === 'function',
+  )
+  if (!rendererExport) {
     throw new Error(
       `Cloudflare build: SSR entry ${file} does not export a renderer (expected a named "render" or default export).`,
     )
   }
 
-  return { file }
+  return { file, rendererExport }
 }
 
 interface ClientAssetEnv {
@@ -360,7 +370,11 @@ function renderWorkerModule(input: {
   }
 
   if (input.ssrImport) {
-    lines.push('setInertiaSsrRenderer(ssrModule.render ?? ssrModule.default)', '')
+    // Name the export the chunk really has. Probing both shapes made esbuild
+    // warn on every deploy that the missing one "will always be undefined" —
+    // on the exact line whose failure mode is a silent fall back to CSR, so
+    // the noise was indistinguishable from the real thing.
+    lines.push(`setInertiaSsrRenderer(ssrModule.${input.ssrImport.rendererExport})`, '')
   }
 
   lines.push('export default createWorkersHandler(app)', '')


### PR DESCRIPTION
Found while dogfooding v1.5.0 — this reproduces on every `wrangler deploy` of guren.dev.

## The problem

`cloudflare:build` generated a worker entry that probed both renderer shapes:

```js
import * as ssrModule from "../.guren/ssr/ssr-DtLULZyT.js"
setInertiaSsrRenderer(ssrModule.render ?? ssrModule.default)
```

A built SSR chunk only ever exposes one of them, so esbuild flagged the other on every deploy:

```
▲ [WARNING] Import "render" will always be undefined because there is no matching
  export in ".guren/ssr/ssr-DtLULZyT.js" [import-is-undefined]

    .cloudflare/worker.js:10:32:
      10 │ setInertiaSsrRenderer(ssrModule.render ?? ssrModule.default)
```

The `?? default` fallback meant SSR worked — verified against production, which serves ~32 KB of real server-rendered markup. But the warning sat on the exact line whose genuine failure mode is Inertia silently falling back to CSR, a hazard this repo documents in `common-pitfalls.md`. So the message that would mean "your SSR is broken" also printed on every healthy deploy, and the two were indistinguishable.

## Changes

`resolveSsrImport` already dynamically imports the built chunk to verify it exposes a renderer — it just discarded which one it found. It now records that and the generator names it:

- chunk from `export default …` → `setInertiaSsrRenderer(ssrModule.default)`
- chunk from `export function render` → `setInertiaSsrRenderer(ssrModule.render)`

Both shapes remain supported; the runtime loader accepts either, so the build must too. `import * as ssrModule` is unchanged.

Also aligned the build-time check with the runtime one: it now tests each candidate for being a function rather than taking the first non-nullish value. Previously `export const render = 42` alongside a valid `default` failed the build even though the server would have run fine.

## Verification

Rebuilt guren.dev and ran `wrangler deploy --dry-run`:

- Generated entry: `setInertiaSsrRenderer(ssrModule.default)`
- **No esbuild warning.** Previously one every run.
- Bundle unchanged: `gzip: 1897.25 KiB` (was 1897.01 KiB).

`packages/plugin-cloudflare`: 28 pass / 0 fail. The two assertions that hardcoded the old expression now diverge by fixture — the named-`render` case asserts `ssrModule.render`, the default-export case asserts `ssrModule.default` and that `ssrModule.render` is absent. `typecheck` clean.