### PR TITLE
fix(cli): align drizzle pins with what @guren/orm depends on

### DIFF
--- a/.changeset/upgrade-aligns-drizzle-pins.md
+++ b/.changeset/upgrade-aligns-drizzle-pins.md
@@ -21,11 +21,24 @@ for apps.
 
 The command now reads the `drizzle-orm` version the target `@guren/orm` depends
 on straight from its registry metadata and writes that, exactly, to both
-`drizzle-orm` and `drizzle-kit`. It only acts on apps that declare `@guren/orm`
-and already have a drizzle entry, never adds one, and leaves both alone when the
-pin cannot be read.
+`drizzle-orm` and `drizzle-kit`. It only rewrites entries that already exist,
+never adds one, and stands down rather than guessing when:
 
-`drizzle-kit` is matched to `drizzle-orm` by convention rather than from
-metadata: it is not a dependency of `@guren/orm`, so the registry has nothing to
-say about it — the two simply ship as a pair, which is what the templates and
-`packages/orm` already assume.
+- the entry names a location instead of a release (`workspace:`, `file:`,
+  `catalog:`, a git URL) — usually a local drizzle build being developed
+  against, which a registry release would silently replace;
+- the field is `peerDependencies` or `optionalDependencies` — a peer range is a
+  compatibility window a library publishes, not an installed copy to dedupe, and
+  narrowing it to one exact version shrinks what that library claims to support;
+- `@guren/orm` depends on a range rather than one exact version — deduping only
+  works when there is a single version to converge on;
+- the version was never published for `drizzle-kit`.
+
+That last one matters because `drizzle-kit` is matched by convention, not from
+metadata: it is not a dependency of `@guren/orm`, so the registry says nothing
+about it, and the two packages have not always shared a release line. Writing a
+`drizzle-kit` version that does not exist would break the next install, so its
+existence is checked first and the entry is left alone with a warning otherwise.
+
+Registry documents are fetched once per package for the whole command, so adding
+these lookups does not add requests.

--- a/.changeset/upgrade-aligns-drizzle-pins.md
+++ b/.changeset/upgrade-aligns-drizzle-pins.md
@@ -40,5 +40,12 @@ about it, and the two packages have not always shared a release line. Writing a
 `drizzle-kit` version that does not exist would break the next install, so its
 existence is checked first and the entry is left alone with a warning otherwise.
 
-Registry documents are fetched once per package for the whole command, so adding
-these lookups does not add requests.
+The lookups read one published version's manifest
+(`registry.npmjs.org/<name>/<version-or-tag>`) rather than the package's full
+document: `@guren/orm/latest` is 2 KB and carries the version *and* its
+dependencies in a single request, where the abbreviated packument is 28 KB — and
+`drizzle-kit`'s is 1.2 MB, which is what checking one version used to cost. That
+adds one request when the pins already agree and two when they have drifted; a
+package appearing in both `dependencies` and `devDependencies` is still asked
+about once. `--tag canary` returns before any of it, so that mode stays
+offline.

--- a/.changeset/upgrade-aligns-drizzle-pins.md
+++ b/.changeset/upgrade-aligns-drizzle-pins.md
@@ -1,0 +1,31 @@
+---
+"@guren/cli": patch
+---
+
+fix: `guren upgrade` aligns `drizzle-orm` and `drizzle-kit` with what `@guren/orm` depends on
+
+`@guren/orm` names an exact `drizzle-orm` version under `dependencies`, not a
+range. Upgrading only the `@guren/*` entries therefore left apps pinning a
+different one with two copies installed:
+
+```
+node_modules/drizzle-orm                         -> 1.0.0-rc.1   (the app's pin)
+node_modules/@guren/orm/node_modules/drizzle-orm -> 1.0.0-rc.4   (what the ORM brings)
+```
+
+The app builds its table descriptors against one copy while the adapter runs on
+the other — the same split-state hazard the duplicate-`@guren/orm` warning
+exists for, and `guren upgrade` was the step that introduced it. `CLAUDE.md`
+already tells contributors to keep these versions aligned; nothing enforced it
+for apps.
+
+The command now reads the `drizzle-orm` version the target `@guren/orm` depends
+on straight from its registry metadata and writes that, exactly, to both
+`drizzle-orm` and `drizzle-kit`. It only acts on apps that declare `@guren/orm`
+and already have a drizzle entry, never adds one, and leaves both alone when the
+pin cannot be read.
+
+`drizzle-kit` is matched to `drizzle-orm` by convention rather than from
+metadata: it is not a dependency of `@guren/orm`, so the registry has nothing to
+say about it — the two simply ship as a pair, which is what the templates and
+`packages/orm` already assume.

--- a/.claude/rules/common-pitfalls.md
+++ b/.claude/rules/common-pitfalls.md
@@ -39,7 +39,7 @@ Lessons learned from code review cycles. Check these before submitting changes.
 
 ## Template Dependencies
 
-- **Keep `drizzle-orm` and `drizzle-kit` versions aligned** across `packages/orm/package.json` (peerDeps), `templates/default/package.json`, and `templates/api-only/package.json`.
+- **Keep `drizzle-orm` and `drizzle-kit` versions aligned** across `packages/orm/package.json` (an exact pin under `dependencies`, not peerDeps) and both `packages/create-app/templates/*/package.json`. `guren upgrade` propagates the ORM's pin into apps, and checks the companion version exists before writing it — the two packages have never shared numbers on their stable lines.
 - **API-only template has no Vite, React, or Inertia.** Force SPA mode in CLI (`blueprint === 'api'` → skip SSR).
 - **Default template always calls `configureOrm()`** even without migrations (models need a DB connection).
 

--- a/packages/cli/src/codemods.ts
+++ b/packages/cli/src/codemods.ts
@@ -107,6 +107,17 @@ export function isExactVersion(specifier: string): boolean {
 }
 
 /**
+ * A specifier pointing at a place rather than the registry. Unlike a range,
+ * which can be converged onto a published version, this cannot — rewriting it
+ * would change what the app actually runs.
+ */
+const LOCATION_SPECIFIER = /^(?:workspace|catalog|link|file|npm|git|github|portal|patch):|^[./]/u
+
+export function isLocationSpecifier(specifier: string): boolean {
+  return LOCATION_SPECIFIER.test(specifier)
+}
+
+/**
  * Order two versions, prereleases included. Returns NaN when either side is not
  * an exact version — including a partial pin like `1.3`, which `Bun.semver`
  * ranks *above* `1.3.0` rather than equal to it.

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -9,11 +9,13 @@ import {
 } from './doctor'
 import { checkDeprecations, type DeprecationWarning } from './deprecations'
 import { runCommand } from './utils'
-import { compareVersions, isExactVersion, runCodemods, type CodemodResult } from './codemods'
+import { compareVersions, isExactVersion, isLocationSpecifier, runCodemods, type CodemodResult } from './codemods'
 
 const PACKAGE_JSON = 'package.json'
 const GUREN_PACKAGE = /^(?:@guren\/|create-guren-app$)/u
 const MANIFEST_FIELDS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'] as const
+/** The subset that installs a copy, so a duplicate of it is possible. */
+const INSTALLED_FIELDS = ['dependencies', 'devDependencies'] as const
 
 /** `latest`, not `rc` — the `rc` tag still points at Guren's pre-1.0 candidates. */
 export const DEFAULT_UPGRADE_TAG = 'latest'
@@ -21,18 +23,11 @@ export const DEFAULT_UPGRADE_TAG = 'latest'
 /** The one tag pinned literally, so installs keep following it. */
 export const CANARY_TAG = 'canary'
 
+/** The dependency whose version is read from `@guren/orm`'s own manifest. */
+const PIN_SOURCE = 'drizzle-orm'
+
 /** Kept in step with what `@guren/orm` depends on, not with each other. */
-const DRIZZLE_PACKAGES = ['drizzle-orm', 'drizzle-kit'] as const
-
-/**
- * A specifier pointing at a place rather than the registry. Unlike a range,
- * which can be converged onto a published version, this cannot — rewriting it
- * would change what the app actually runs.
- */
-const LOCATION_SPECIFIER = /^(?:workspace|catalog|link|file|npm|git|github|portal|patch):|^[.~/]/u
-
-/** Fields that describe what gets installed, so a duplicate copy is possible. */
-const DRIZZLE_ALIGNED_FIELDS = ['dependencies', 'devDependencies'] as const
+const DRIZZLE_PACKAGES = [PIN_SOURCE, 'drizzle-kit'] as const
 
 type ManifestField = (typeof MANIFEST_FIELDS)[number]
 
@@ -51,14 +46,11 @@ export interface UpgradeCanaryOptions {
   tag?: string
   /** Override registry version lookups (used in tests). */
   versionResolver?: (packageName: string, tag: string) => Promise<string | null>
-  /** Override registry dependency-pin lookups (used in tests). */
-  dependencyPinResolver?: (
+  /** Override published-manifest lookups (used in tests). */
+  manifestResolver?: (
     packageName: string,
-    version: string,
-    dependency: string,
-  ) => Promise<string | null>
-  /** Override registry version-existence lookups (used in tests). */
-  versionExistsResolver?: (packageName: string, version: string) => Promise<boolean>
+    versionOrTag: string,
+  ) => Promise<{ version: string; dependencies?: Record<string, string> } | null>
 }
 
 export interface UpgradedDependency {
@@ -142,56 +134,29 @@ async function resolveDistTagVersion(packageName: string, tag: string): Promise<
   return tags[tag] ?? null
 }
 
-interface Packument {
-  versions?: Record<string, { dependencies?: Record<string, string> }>
+interface PublishedManifest {
+  version: string
+  dependencies?: Record<string, string>
 }
 
 /**
- * The full package document, cached per package. Only worth its size for
- * reading a published version's own dependencies or checking a version exists;
- * tag lookups use the dist-tags endpoint above. `guren upgrade` is a one-shot
- * command, so nothing here outlives the process.
+ * One published version's manifest, by version or by dist-tag. 404 means that
+ * version does not exist, which is a useful answer rather than an error.
+ *
+ * This endpoint, not the packument: `@guren/orm/latest` is 2 KB and carries the
+ * version *and* its dependencies, where the abbreviated packument is 28 KB —
+ * and `drizzle-kit`'s is 1.2 MB, for one boolean.
  */
-const packumentCache = new Map<string, Promise<Packument | null>>()
-
-function fetchPackument(packageName: string): Promise<Packument | null> {
-  const cached = packumentCache.get(packageName)
-  if (cached) {
-    return cached
+async function resolveManifest(packageName: string, versionOrTag: string): Promise<PublishedManifest | null> {
+  const response = await fetch(`https://registry.npmjs.org/${packageName}/${versionOrTag}`)
+  if (!response.ok) {
+    return null
   }
-  const pending = (async (): Promise<Packument | null> => {
-    const response = await fetch(`https://registry.npmjs.org/${packageName}`, {
-      headers: { accept: 'application/vnd.npm.install-v1+json' },
-    })
-    return response.ok ? ((await response.json()) as Packument) : null
-  })().catch(() => null)
-  packumentCache.set(packageName, pending)
-  return pending
-}
-
-/** Whether a package has a given version published. */
-async function resolveVersionExists(packageName: string, version: string): Promise<boolean> {
-  const payload = await fetchPackument(packageName)
-  return Boolean(payload?.versions?.[version])
-}
-
-/** Read what a published version of a package pins one of its dependencies to. */
-async function resolveDependencyPin(
-  packageName: string,
-  version: string,
-  dependency: string,
-): Promise<string | null> {
-  const payload = await fetchPackument(packageName)
-  return payload?.versions?.[version]?.dependencies?.[dependency] ?? null
+  return (await response.json()) as PublishedManifest
 }
 
 type VersionResolver = (packageName: string, tag: string) => Promise<string | null>
-type DependencyPinResolver = (
-  packageName: string,
-  version: string,
-  dependency: string,
-) => Promise<string | null>
-type VersionExistsResolver = (packageName: string, version: string) => Promise<boolean>
+type ManifestResolver = (packageName: string, versionOrTag: string) => Promise<PublishedManifest | null>
 
 /**
  * Resolve each package once. The tag is looked up both to report the target
@@ -227,41 +192,53 @@ function memoizeResolver(resolver: VersionResolver): VersionResolver {
  * runs on the other. Aligning `@guren/*` alone is what leaves that behind.
  *
  * `drizzle-kit` has no upstream declaration to read: it is not a dependency of
- * `@guren/orm`, only of apps and templates. Matching it to `drizzle-orm` is the
- * repo's convention (the two ship as a pair), not a fact from the registry.
+ * `@guren/orm`, only of apps and templates. Keeping the pair in step is a
+ * convention this repo already states (see `.claude/rules/common-pitfalls.md`),
+ * and the two have never shared numbers on their stable lines — so the version
+ * is checked against the registry before being written.
  */
 async function alignDrizzlePins(
   manifest: PackageManifest,
   tag: string,
-  versionResolver: VersionResolver,
-  pinResolver: DependencyPinResolver,
-  versionExistsResolver: VersionExistsResolver,
-  updatedDependencies: UpgradedDependency[],
-): Promise<void> {
-  // Runtime fields only. A `peerDependencies` entry is a compatibility range a
-  // library publishes, not an installed copy to dedupe — narrowing it to one
-  // exact version would shrink what that library declares it works with.
-  const fieldsWithDrizzle = DRIZZLE_ALIGNED_FIELDS.filter((field) =>
-    DRIZZLE_PACKAGES.some((name) => manifest[field]?.[name]),
-  )
+  manifestResolver: ManifestResolver,
+): Promise<UpgradedDependency[]> {
+  // canary keeps a floating pin on purpose; writing an exact drizzle version
+  // beside it would contradict the mode, and there is nothing to converge on.
+  if (tag === CANARY_TAG) {
+    return []
+  }
+
+  const candidates = INSTALLED_FIELDS.flatMap((field) => {
+    const dependencies = manifest[field]
+    return dependencies
+      ? DRIZZLE_PACKAGES.filter((name) => dependencies[name]).map((name) => ({
+          field,
+          dependencies,
+          name,
+          current: dependencies[name] as string,
+        }))
+      : []
+  })
   // Only meaningful for an app that uses the ORM: the pin being matched is the
   // one @guren/orm brings with it.
   const usesGurenOrm = MANIFEST_FIELDS.some((field) => manifest[field]?.['@guren/orm'])
-  if (fieldsWithDrizzle.length === 0 || !usesGurenOrm) {
-    return
+  if (candidates.length === 0 || !usesGurenOrm) {
+    return []
   }
 
-  const ormVersion = await versionResolver('@guren/orm', tag)
-  if (!ormVersion) {
-    return
+  // One request for the target ORM's own manifest yields both its version and
+  // the drizzle version it depends on.
+  const orm = await manifestResolver('@guren/orm', tag)
+  if (!orm) {
+    return []
   }
 
-  const pin = await pinResolver('@guren/orm', ormVersion, 'drizzle-orm')
+  const pin = orm.dependencies?.[PIN_SOURCE]
   if (!pin) {
     console.warn(
-      `[guren upgrade] Could not read the drizzle-orm version @guren/orm@${ormVersion} depends on — leaving the drizzle pins alone.`,
+      `[guren upgrade] Could not read the ${PIN_SOURCE} version @guren/orm@${orm.version} depends on — leaving the drizzle pins alone.`,
     )
-    return
+    return []
   }
 
   // Deduping only works if the ORM names one exact version. A range would let
@@ -269,44 +246,46 @@ async function alignDrizzlePins(
   // being fixed — and copying a range into `drizzle-kit` says nothing useful.
   if (!isExactVersion(pin)) {
     console.warn(
-      `[guren upgrade] @guren/orm@${ormVersion} depends on drizzle-orm "${pin}", which is not a single exact version — leaving the drizzle pins alone.`,
+      `[guren upgrade] @guren/orm@${orm.version} depends on ${PIN_SOURCE} "${pin}", which is not a single exact version — leaving the drizzle pins alone.`,
     )
-    return
+    return []
   }
 
-  for (const field of fieldsWithDrizzle) {
-    const dependencies = manifest[field]
-    if (!dependencies) {
+  const published = new Map<string, Promise<boolean>>()
+  const isPublished = (name: string): Promise<boolean> => {
+    // The same package can appear in two fields; ask the registry once.
+    let pending = published.get(name)
+    if (!pending) {
+      pending = manifestResolver(name, pin).then((found) => found !== null)
+      published.set(name, pending)
+    }
+    return pending
+  }
+
+  const updated: UpgradedDependency[] = []
+  for (const { field, dependencies, name, current } of candidates) {
+    if (current === pin) {
       continue
     }
-    for (const name of DRIZZLE_PACKAGES) {
-      const current = dependencies[name]
-      if (!current || current === pin) {
-        continue
-      }
-      // `workspace:`, `file:`, `catalog:` and friends name a location on
-      // purpose — usually a local drizzle build being developed against.
-      // Replacing that with a registry release changes what the app runs.
-      if (LOCATION_SPECIFIER.test(current)) {
-        console.warn(
-          `[guren upgrade] ${field}.${name} is "${current}", which names a location rather than a release — leaving it alone. Align it with drizzle-orm ${pin} yourself if you want the ORM's copy deduped.`,
-        )
-        continue
-      }
-      // drizzle-kit is a separate package on its own release line; it is not a
-      // dependency of @guren/orm, so nothing guarantees the ORM's drizzle-orm
-      // version was ever published for it. Writing one that does not exist
-      // would break the next install.
-      if (name !== 'drizzle-orm' && !(await versionExistsResolver(name, pin))) {
-        console.warn(
-          `[guren upgrade] ${name}@${pin} does not exist on npm — leaving ${field}.${name} at "${current}". Pick the ${name} release matching drizzle-orm ${pin} yourself.`,
-        )
-        continue
-      }
-      dependencies[name] = pin
-      updatedDependencies.push({ field, name, previousVersion: current, nextVersion: pin })
+    if (isLocationSpecifier(current)) {
+      console.warn(
+        `[guren upgrade] ${field}.${name} is "${current}", which names a location rather than a release — leaving it alone. Align it with ${PIN_SOURCE} ${pin} yourself if you want the ORM's copy deduped.`,
+      )
+      continue
     }
+    // Only the companion needs checking: `pin` came from the ORM's own
+    // dependency on PIN_SOURCE, so that version necessarily exists.
+    if (name !== PIN_SOURCE && !(await isPublished(name))) {
+      console.warn(
+        `[guren upgrade] ${name}@${pin} does not exist on npm — leaving ${field}.${name} at "${current}". Pick the ${name} release matching ${PIN_SOURCE} ${pin} yourself.`,
+      )
+      continue
+    }
+    dependencies[name] = pin
+    updated.push({ field, name, previousVersion: current, nextVersion: pin })
   }
+
+  return updated
 }
 
 async function updateManifestDependencies(
@@ -314,8 +293,7 @@ async function updateManifestDependencies(
   dryRun = false,
   tag = DEFAULT_UPGRADE_TAG,
   versionResolver: VersionResolver = resolveDistTagVersion,
-  pinResolver: DependencyPinResolver = resolveDependencyPin,
-  versionExistsResolver: VersionExistsResolver = resolveVersionExists,
+  manifestResolver: ManifestResolver = resolveManifest,
 ): Promise<{
   packageJsonPath: string
   updatedDependencies: UpgradedDependency[]
@@ -378,7 +356,7 @@ async function updateManifestDependencies(
     }
   }
 
-  await alignDrizzlePins(manifest, tag, versionResolver, pinResolver, versionExistsResolver, updatedDependencies)
+  updatedDependencies.push(...(await alignDrizzlePins(manifest, tag, manifestResolver)))
 
   if (!dryRun && updatedDependencies.length > 0) {
     await writeFile(packageJsonPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
@@ -494,7 +472,7 @@ export async function upgradeCanary(options: UpgradeCanaryOptions = {}): Promise
     }
   }
 
-  const { packageJsonPath, updatedDependencies } = await updateManifestDependencies(cwd, Boolean(options.dryRun), tag, versionResolver, options.dependencyPinResolver, options.versionExistsResolver)
+  const { packageJsonPath, updatedDependencies } = await updateManifestDependencies(cwd, Boolean(options.dryRun), tag, versionResolver, options.manifestResolver)
   const { evaluations } = await getDoctorRuleEvaluations({ cwd })
 
   const candidateAutofixes = evaluations

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -24,6 +24,13 @@ export const CANARY_TAG = 'canary'
 /** Kept in step with what `@guren/orm` depends on, not with each other. */
 const DRIZZLE_PACKAGES = ['drizzle-orm', 'drizzle-kit'] as const
 
+/**
+ * A specifier pointing at a place rather than the registry. Unlike a range,
+ * which can be converged onto a published version, this cannot — rewriting it
+ * would change what the app actually runs.
+ */
+const LOCATION_SPECIFIER = /^(?:workspace|catalog|link|file|npm|git|github|portal|patch):|^[.~/]/u
+
 /** Fields that describe what gets installed, so a duplicate copy is possible. */
 const DRIZZLE_ALIGNED_FIELDS = ['dependencies', 'devDependencies'] as const
 
@@ -280,7 +287,7 @@ async function alignDrizzlePins(
       // `workspace:`, `file:`, `catalog:` and friends name a location on
       // purpose — usually a local drizzle build being developed against.
       // Replacing that with a registry release changes what the app runs.
-      if (NON_REGISTRY_SPECIFIER.test(current)) {
+      if (LOCATION_SPECIFIER.test(current)) {
         console.warn(
           `[guren upgrade] ${field}.${name} is "${current}", which names a location rather than a release — leaving it alone. Align it with drizzle-orm ${pin} yourself if you want the ORM's copy deduped.`,
         )

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -21,6 +21,9 @@ export const DEFAULT_UPGRADE_TAG = 'latest'
 /** The one tag pinned literally, so installs keep following it. */
 export const CANARY_TAG = 'canary'
 
+/** Kept in step with what `@guren/orm` depends on, not with each other. */
+const DRIZZLE_PACKAGES = ['drizzle-orm', 'drizzle-kit'] as const
+
 type ManifestField = (typeof MANIFEST_FIELDS)[number]
 
 export interface UpgradeCanaryOptions {
@@ -38,6 +41,12 @@ export interface UpgradeCanaryOptions {
   tag?: string
   /** Override registry version lookups (used in tests). */
   versionResolver?: (packageName: string, tag: string) => Promise<string | null>
+  /** Override registry dependency-pin lookups (used in tests). */
+  dependencyPinResolver?: (
+    packageName: string,
+    version: string,
+    dependency: string,
+  ) => Promise<string | null>
 }
 
 export interface UpgradedDependency {
@@ -121,7 +130,40 @@ async function resolveDistTagVersion(packageName: string, tag: string): Promise<
   return tags[tag] ?? null
 }
 
+interface Packument {
+  versions?: Record<string, { dependencies?: Record<string, string> }>
+}
+
+/**
+ * The full package document. Only worth its size for reading what a published
+ * version depends on; tag lookups use the dist-tags endpoint above instead.
+ */
+async function fetchPackument(packageName: string): Promise<Packument | null> {
+  const response = await fetch(`https://registry.npmjs.org/${packageName}`, {
+    headers: { accept: 'application/vnd.npm.install-v1+json' },
+  })
+  if (!response.ok) {
+    return null
+  }
+  return (await response.json()) as Packument
+}
+
+/** Read what a published version of a package pins one of its dependencies to. */
+async function resolveDependencyPin(
+  packageName: string,
+  version: string,
+  dependency: string,
+): Promise<string | null> {
+  const payload = await fetchPackument(packageName)
+  return payload?.versions?.[version]?.dependencies?.[dependency] ?? null
+}
+
 type VersionResolver = (packageName: string, tag: string) => Promise<string | null>
+type DependencyPinResolver = (
+  packageName: string,
+  version: string,
+  dependency: string,
+) => Promise<string | null>
 
 /**
  * Resolve each package once. The tag is looked up both to report the target
@@ -147,11 +189,71 @@ function memoizeResolver(resolver: VersionResolver): VersionResolver {
   }
 }
 
+/**
+ * Align the app's `drizzle-orm` and `drizzle-kit` pins with the version
+ * `@guren/orm` depends on.
+ *
+ * `@guren/orm` names an exact `drizzle-orm` version under `dependencies`, not a
+ * range, so an app pinning a different one gets a second nested copy on install
+ * — the app builds its table descriptors against one copy while the adapter
+ * runs on the other. Aligning `@guren/*` alone is what leaves that behind.
+ *
+ * `drizzle-kit` has no upstream declaration to read: it is not a dependency of
+ * `@guren/orm`, only of apps and templates. Matching it to `drizzle-orm` is the
+ * repo's convention (the two ship as a pair), not a fact from the registry.
+ */
+async function alignDrizzlePins(
+  manifest: PackageManifest,
+  tag: string,
+  versionResolver: VersionResolver,
+  pinResolver: DependencyPinResolver,
+  updatedDependencies: UpgradedDependency[],
+): Promise<void> {
+  const fieldsWithDrizzle = MANIFEST_FIELDS.filter((field) =>
+    DRIZZLE_PACKAGES.some((name) => manifest[field]?.[name]),
+  )
+  // Only meaningful for an app that uses the ORM: the pin being matched is the
+  // one @guren/orm brings with it.
+  const usesGurenOrm = MANIFEST_FIELDS.some((field) => manifest[field]?.['@guren/orm'])
+  if (fieldsWithDrizzle.length === 0 || !usesGurenOrm) {
+    return
+  }
+
+  const ormVersion = await versionResolver('@guren/orm', tag)
+  if (!ormVersion) {
+    return
+  }
+
+  const pin = await pinResolver('@guren/orm', ormVersion, 'drizzle-orm')
+  if (!pin) {
+    console.warn(
+      `[guren upgrade] Could not read the drizzle-orm version @guren/orm@${ormVersion} depends on — leaving the drizzle pins alone.`,
+    )
+    return
+  }
+
+  for (const field of fieldsWithDrizzle) {
+    const dependencies = manifest[field]
+    if (!dependencies) {
+      continue
+    }
+    for (const name of DRIZZLE_PACKAGES) {
+      const current = dependencies[name]
+      if (!current || current === pin) {
+        continue
+      }
+      dependencies[name] = pin
+      updatedDependencies.push({ field, name, previousVersion: current, nextVersion: pin })
+    }
+  }
+}
+
 async function updateManifestDependencies(
   cwd: string,
   dryRun = false,
   tag = DEFAULT_UPGRADE_TAG,
   versionResolver: VersionResolver = resolveDistTagVersion,
+  pinResolver: DependencyPinResolver = resolveDependencyPin,
 ): Promise<{
   packageJsonPath: string
   updatedDependencies: UpgradedDependency[]
@@ -213,6 +315,8 @@ async function updateManifestDependencies(
       })
     }
   }
+
+  await alignDrizzlePins(manifest, tag, versionResolver, pinResolver, updatedDependencies)
 
   if (!dryRun && updatedDependencies.length > 0) {
     await writeFile(packageJsonPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
@@ -328,7 +432,7 @@ export async function upgradeCanary(options: UpgradeCanaryOptions = {}): Promise
     }
   }
 
-  const { packageJsonPath, updatedDependencies } = await updateManifestDependencies(cwd, Boolean(options.dryRun), tag, versionResolver)
+  const { packageJsonPath, updatedDependencies } = await updateManifestDependencies(cwd, Boolean(options.dryRun), tag, versionResolver, options.dependencyPinResolver)
   const { evaluations } = await getDoctorRuleEvaluations({ cwd })
 
   const candidateAutofixes = evaluations

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -24,6 +24,9 @@ export const CANARY_TAG = 'canary'
 /** Kept in step with what `@guren/orm` depends on, not with each other. */
 const DRIZZLE_PACKAGES = ['drizzle-orm', 'drizzle-kit'] as const
 
+/** Fields that describe what gets installed, so a duplicate copy is possible. */
+const DRIZZLE_ALIGNED_FIELDS = ['dependencies', 'devDependencies'] as const
+
 type ManifestField = (typeof MANIFEST_FIELDS)[number]
 
 export interface UpgradeCanaryOptions {
@@ -47,6 +50,8 @@ export interface UpgradeCanaryOptions {
     version: string,
     dependency: string,
   ) => Promise<string | null>
+  /** Override registry version-existence lookups (used in tests). */
+  versionExistsResolver?: (packageName: string, version: string) => Promise<boolean>
 }
 
 export interface UpgradedDependency {
@@ -135,17 +140,32 @@ interface Packument {
 }
 
 /**
- * The full package document. Only worth its size for reading what a published
- * version depends on; tag lookups use the dist-tags endpoint above instead.
+ * The full package document, cached per package. Only worth its size for
+ * reading a published version's own dependencies or checking a version exists;
+ * tag lookups use the dist-tags endpoint above. `guren upgrade` is a one-shot
+ * command, so nothing here outlives the process.
  */
-async function fetchPackument(packageName: string): Promise<Packument | null> {
-  const response = await fetch(`https://registry.npmjs.org/${packageName}`, {
-    headers: { accept: 'application/vnd.npm.install-v1+json' },
-  })
-  if (!response.ok) {
-    return null
+const packumentCache = new Map<string, Promise<Packument | null>>()
+
+function fetchPackument(packageName: string): Promise<Packument | null> {
+  const cached = packumentCache.get(packageName)
+  if (cached) {
+    return cached
   }
-  return (await response.json()) as Packument
+  const pending = (async (): Promise<Packument | null> => {
+    const response = await fetch(`https://registry.npmjs.org/${packageName}`, {
+      headers: { accept: 'application/vnd.npm.install-v1+json' },
+    })
+    return response.ok ? ((await response.json()) as Packument) : null
+  })().catch(() => null)
+  packumentCache.set(packageName, pending)
+  return pending
+}
+
+/** Whether a package has a given version published. */
+async function resolveVersionExists(packageName: string, version: string): Promise<boolean> {
+  const payload = await fetchPackument(packageName)
+  return Boolean(payload?.versions?.[version])
 }
 
 /** Read what a published version of a package pins one of its dependencies to. */
@@ -164,6 +184,7 @@ type DependencyPinResolver = (
   version: string,
   dependency: string,
 ) => Promise<string | null>
+type VersionExistsResolver = (packageName: string, version: string) => Promise<boolean>
 
 /**
  * Resolve each package once. The tag is looked up both to report the target
@@ -207,9 +228,13 @@ async function alignDrizzlePins(
   tag: string,
   versionResolver: VersionResolver,
   pinResolver: DependencyPinResolver,
+  versionExistsResolver: VersionExistsResolver,
   updatedDependencies: UpgradedDependency[],
 ): Promise<void> {
-  const fieldsWithDrizzle = MANIFEST_FIELDS.filter((field) =>
+  // Runtime fields only. A `peerDependencies` entry is a compatibility range a
+  // library publishes, not an installed copy to dedupe — narrowing it to one
+  // exact version would shrink what that library declares it works with.
+  const fieldsWithDrizzle = DRIZZLE_ALIGNED_FIELDS.filter((field) =>
     DRIZZLE_PACKAGES.some((name) => manifest[field]?.[name]),
   )
   // Only meaningful for an app that uses the ORM: the pin being matched is the
@@ -232,6 +257,16 @@ async function alignDrizzlePins(
     return
   }
 
+  // Deduping only works if the ORM names one exact version. A range would let
+  // the app and the nested copy resolve differently, which is the situation
+  // being fixed — and copying a range into `drizzle-kit` says nothing useful.
+  if (!isExactVersion(pin)) {
+    console.warn(
+      `[guren upgrade] @guren/orm@${ormVersion} depends on drizzle-orm "${pin}", which is not a single exact version — leaving the drizzle pins alone.`,
+    )
+    return
+  }
+
   for (const field of fieldsWithDrizzle) {
     const dependencies = manifest[field]
     if (!dependencies) {
@@ -240,6 +275,25 @@ async function alignDrizzlePins(
     for (const name of DRIZZLE_PACKAGES) {
       const current = dependencies[name]
       if (!current || current === pin) {
+        continue
+      }
+      // `workspace:`, `file:`, `catalog:` and friends name a location on
+      // purpose — usually a local drizzle build being developed against.
+      // Replacing that with a registry release changes what the app runs.
+      if (NON_REGISTRY_SPECIFIER.test(current)) {
+        console.warn(
+          `[guren upgrade] ${field}.${name} is "${current}", which names a location rather than a release — leaving it alone. Align it with drizzle-orm ${pin} yourself if you want the ORM's copy deduped.`,
+        )
+        continue
+      }
+      // drizzle-kit is a separate package on its own release line; it is not a
+      // dependency of @guren/orm, so nothing guarantees the ORM's drizzle-orm
+      // version was ever published for it. Writing one that does not exist
+      // would break the next install.
+      if (name !== 'drizzle-orm' && !(await versionExistsResolver(name, pin))) {
+        console.warn(
+          `[guren upgrade] ${name}@${pin} does not exist on npm — leaving ${field}.${name} at "${current}". Pick the ${name} release matching drizzle-orm ${pin} yourself.`,
+        )
         continue
       }
       dependencies[name] = pin
@@ -254,6 +308,7 @@ async function updateManifestDependencies(
   tag = DEFAULT_UPGRADE_TAG,
   versionResolver: VersionResolver = resolveDistTagVersion,
   pinResolver: DependencyPinResolver = resolveDependencyPin,
+  versionExistsResolver: VersionExistsResolver = resolveVersionExists,
 ): Promise<{
   packageJsonPath: string
   updatedDependencies: UpgradedDependency[]
@@ -316,7 +371,7 @@ async function updateManifestDependencies(
     }
   }
 
-  await alignDrizzlePins(manifest, tag, versionResolver, pinResolver, updatedDependencies)
+  await alignDrizzlePins(manifest, tag, versionResolver, pinResolver, versionExistsResolver, updatedDependencies)
 
   if (!dryRun && updatedDependencies.length > 0) {
     await writeFile(packageJsonPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
@@ -432,7 +487,7 @@ export async function upgradeCanary(options: UpgradeCanaryOptions = {}): Promise
     }
   }
 
-  const { packageJsonPath, updatedDependencies } = await updateManifestDependencies(cwd, Boolean(options.dryRun), tag, versionResolver, options.dependencyPinResolver)
+  const { packageJsonPath, updatedDependencies } = await updateManifestDependencies(cwd, Boolean(options.dryRun), tag, versionResolver, options.dependencyPinResolver, options.versionExistsResolver)
   const { evaluations } = await getDoctorRuleEvaluations({ cwd })
 
   const candidateAutofixes = evaluations

--- a/packages/cli/tests/upgrade.test.ts
+++ b/packages/cli/tests/upgrade.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, afterEach, describe, expect, it, mock } from 'bun:test'
+import { beforeEach, afterEach, describe, expect, it, mock, spyOn } from 'bun:test'
 import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { createTempWorkspace, type TempWorkspace } from './helpers'
@@ -136,13 +136,8 @@ describe('upgradeCanary', () => {
       packageJsonPath,
       JSON.stringify({
         name: 'drizzle-test',
-        dependencies: {
-          '@guren/orm': '^1.0.0',
-          'drizzle-orm': '1.0.0-rc.1',
-        },
-        devDependencies: {
-          'drizzle-kit': '1.0.0-rc.1',
-        },
+        dependencies: { '@guren/orm': '^1.0.0', 'drizzle-orm': '1.0.0-rc.1' },
+        devDependencies: { 'drizzle-kit': '1.0.0-rc.1' },
       }, null, 2),
       'utf8',
     )
@@ -150,8 +145,10 @@ describe('upgradeCanary', () => {
     const result = await upgradeCanary({
       cwd: workspace.dir,
       versionResolver: async () => '1.2.0',
-      dependencyPinResolver: async () => '1.0.0-rc.4',
-      versionExistsResolver: async () => true,
+      manifestResolver: async (name) =>
+        name === '@guren/orm'
+          ? { version: '1.2.0', dependencies: { 'drizzle-orm': '1.0.0-rc.4' } }
+          : { version: '1.0.0-rc.4' },
     })
     const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
       dependencies: Record<string, string>
@@ -162,158 +159,120 @@ describe('upgradeCanary', () => {
     // app resolve a different copy than the adapter runs on.
     expect(packageJson.dependencies['drizzle-orm']).toBe('1.0.0-rc.4')
     expect(packageJson.devDependencies['drizzle-kit']).toBe('1.0.0-rc.4')
-    expect(result.updatedDependencies.some((dependency) => dependency.name === 'drizzle-orm')).toBe(true)
-    expect(result.updatedDependencies.some((dependency) => dependency.name === 'drizzle-kit')).toBe(true)
-  })
-
-  it('does not overwrite drizzle specifiers that name a location', async () => {
-    await writeFile(
-      packageJsonPath,
-      JSON.stringify({
-        name: 'drizzle-local',
-        dependencies: {
-          '@guren/orm': '^1.0.0',
-          'drizzle-orm': 'workspace:*',
-        },
-      }, null, 2),
-      'utf8',
-    )
-
-    await upgradeCanary({
-      cwd: workspace.dir,
-      versionResolver: async () => '1.2.0',
-      dependencyPinResolver: async () => '1.0.0-rc.4',
-      versionExistsResolver: async () => true,
+    expect(result.updatedDependencies).toContainEqual({
+      field: 'dependencies',
+      name: 'drizzle-orm',
+      previousVersion: '1.0.0-rc.1',
+      nextVersion: '1.0.0-rc.4',
     })
-    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
-      dependencies: Record<string, string>
-    }
-
-    expect(packageJson.dependencies['drizzle-orm']).toBe('workspace:*')
+    expect(result.updatedDependencies).toContainEqual({
+      field: 'devDependencies',
+      name: 'drizzle-kit',
+      previousVersion: '1.0.0-rc.1',
+      nextVersion: '1.0.0-rc.4',
+    })
   })
 
-  it('does not narrow a published peer range', async () => {
-    await writeFile(
-      packageJsonPath,
-      JSON.stringify({
-        name: 'drizzle-peer',
+  // Every path that declines to write, with the entry that must survive and the
+  // warning the user gets. Adding a case is a row, not another copied block.
+  const ORM_PINS_RC4 = { version: '1.2.0', dependencies: { 'drizzle-orm': '1.0.0-rc.4' } }
+  const declines = [
+    {
+      label: 'a specifier that names a location',
+      manifest: { dependencies: { '@guren/orm': '^1.0.0', 'drizzle-orm': 'workspace:*' } },
+      manifestResolver: async () => ORM_PINS_RC4,
+      survives: ['dependencies', 'drizzle-orm', 'workspace:*'],
+      warning: 'names a location rather than a release',
+    },
+    {
+      label: 'a published peer range',
+      manifest: { dependencies: { '@guren/orm': '^1.0.0' }, peerDependencies: { 'drizzle-orm': '^1' } },
+      manifestResolver: async () => ORM_PINS_RC4,
+      survives: ['peerDependencies', 'drizzle-orm', '^1'],
+      warning: null,
+    },
+    {
+      label: 'a drizzle-kit version that was never published',
+      manifest: {
         dependencies: { '@guren/orm': '^1.0.0' },
-        peerDependencies: { 'drizzle-orm': '^1' },
-      }, null, 2),
-      'utf8',
-    )
-
-    await upgradeCanary({
-      cwd: workspace.dir,
-      versionResolver: async () => '1.2.0',
-      dependencyPinResolver: async () => '1.0.0-rc.4',
-      versionExistsResolver: async () => true,
-    })
-    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
-      peerDependencies: Record<string, string>
-    }
-
-    expect(packageJson.peerDependencies['drizzle-orm']).toBe('^1')
-  })
-
-  it('skips drizzle-kit when the matching version was never published', async () => {
-    await writeFile(
-      packageJsonPath,
-      JSON.stringify({
-        name: 'drizzle-kit-missing',
-        dependencies: { '@guren/orm': '^1.0.0', 'drizzle-orm': '1.0.0-rc.1' },
         devDependencies: { 'drizzle-kit': '0.31.0' },
-      }, null, 2),
-      'utf8',
-    )
+      },
+      manifestResolver: async (name: string) => (name === '@guren/orm' ? ORM_PINS_RC4 : null),
+      survives: ['devDependencies', 'drizzle-kit', '0.31.0'],
+      warning: 'does not exist on npm',
+    },
+    {
+      label: 'an ORM that depends on a range rather than one version',
+      manifest: { dependencies: { '@guren/orm': '^1.0.0', 'drizzle-orm': '1.0.0-rc.1' } },
+      manifestResolver: async () => ({ version: '1.2.0', dependencies: { 'drizzle-orm': '^1.0.0' } }),
+      survives: ['dependencies', 'drizzle-orm', '1.0.0-rc.1'],
+      warning: 'not a single exact version',
+    },
+    {
+      label: 'an app that does not use @guren/orm',
+      manifest: { dependencies: { '@guren/core': '^1.0.0', 'drizzle-orm': '1.0.0-rc.1' } },
+      manifestResolver: async () => ORM_PINS_RC4,
+      survives: ['dependencies', 'drizzle-orm', '1.0.0-rc.1'],
+      warning: null,
+    },
+  ] as const
 
-    await upgradeCanary({
-      cwd: workspace.dir,
-      versionResolver: async () => '1.2.0',
-      dependencyPinResolver: async () => '1.0.0-rc.4',
-      // drizzle-kit rides its own release line, so the ORM's drizzle-orm
-      // version need not exist for it.
-      versionExistsResolver: async (name) => name !== 'drizzle-kit',
+  for (const { label, manifest, manifestResolver, survives, warning } of declines) {
+    it(`leaves drizzle alone for ${label}`, async () => {
+      await writeFile(packageJsonPath, JSON.stringify({ name: 'decline', ...manifest }, null, 2), 'utf8')
+      const warnings: string[] = []
+      const warnSpy = spyOn(console, 'warn').mockImplementation(((message: unknown) => {
+        warnings.push(String(message))
+      }) as never)
+
+      try {
+        await upgradeCanary({
+          cwd: workspace.dir,
+          versionResolver: async () => '1.2.0',
+          manifestResolver,
+        })
+      } finally {
+        warnSpy.mockRestore()
+      }
+
+      const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as Record<
+        string,
+        Record<string, string>
+      >
+      const [field, name, value] = survives
+      expect(packageJson[field]?.[name]).toBe(value)
+      if (warning) {
+        expect(warnings.join('\n')).toContain(warning)
+      }
     })
-    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
-      dependencies: Record<string, string>
-      devDependencies: Record<string, string>
-    }
+  }
 
-    expect(packageJson.dependencies['drizzle-orm']).toBe('1.0.0-rc.4')
-    expect(packageJson.devDependencies['drizzle-kit']).toBe('0.31.0')
-  })
-
-  it('leaves drizzle alone when the ORM depends on a range rather than one version', async () => {
+  it('makes no registry call for drizzle under the canary tag', async () => {
     await writeFile(
       packageJsonPath,
       JSON.stringify({
-        name: 'drizzle-range',
+        name: 'canary-drizzle',
         dependencies: { '@guren/orm': '^1.0.0', 'drizzle-orm': '1.0.0-rc.1' },
       }, null, 2),
       'utf8',
     )
 
+    let looked = false
     await upgradeCanary({
       cwd: workspace.dir,
-      versionResolver: async () => '1.2.0',
-      dependencyPinResolver: async () => '^1.0.0',
-      versionExistsResolver: async () => true,
+      tag: 'canary',
+      manifestResolver: async () => {
+        looked = true
+        return null
+      },
     })
     const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
       dependencies: Record<string, string>
     }
 
-    expect(packageJson.dependencies['drizzle-orm']).toBe('1.0.0-rc.1')
-  })
-
-  it('leaves drizzle alone for an app that does not use @guren/orm', async () => {
-    await writeFile(
-      packageJsonPath,
-      JSON.stringify({
-        name: 'no-orm-test',
-        dependencies: {
-          '@guren/core': '^1.0.0',
-          'drizzle-orm': '1.0.0-rc.1',
-        },
-      }, null, 2),
-      'utf8',
-    )
-
-    await upgradeCanary({
-      cwd: workspace.dir,
-      versionResolver: async () => '1.3.0',
-      dependencyPinResolver: async () => '1.0.0-rc.4',
-    })
-    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
-      dependencies: Record<string, string>
-    }
-
-    expect(packageJson.dependencies['drizzle-orm']).toBe('1.0.0-rc.1')
-  })
-
-  it('leaves drizzle alone when the pin cannot be read', async () => {
-    await writeFile(
-      packageJsonPath,
-      JSON.stringify({
-        name: 'drizzle-unreadable',
-        dependencies: {
-          '@guren/orm': '^1.0.0',
-          'drizzle-orm': '1.0.0-rc.1',
-        },
-      }, null, 2),
-      'utf8',
-    )
-
-    await upgradeCanary({
-      cwd: workspace.dir,
-      versionResolver: async () => '1.2.0',
-      dependencyPinResolver: async () => null,
-    })
-    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
-      dependencies: Record<string, string>
-    }
-
+    // canary keeps a floating pin, so there is nothing to converge on — and the
+    // mode stays offline.
+    expect(looked).toBe(false)
     expect(packageJson.dependencies['drizzle-orm']).toBe('1.0.0-rc.1')
   })
 

--- a/packages/cli/tests/upgrade.test.ts
+++ b/packages/cli/tests/upgrade.test.ts
@@ -131,6 +131,90 @@ describe('upgradeCanary', () => {
     expect(result.versionCompatibility?.warnings.join('\n')).toContain('would downgrade')
   })
 
+  it('aligns drizzle pins with the version @guren/orm depends on', async () => {
+    await writeFile(
+      packageJsonPath,
+      JSON.stringify({
+        name: 'drizzle-test',
+        dependencies: {
+          '@guren/orm': '^1.0.0',
+          'drizzle-orm': '1.0.0-rc.1',
+        },
+        devDependencies: {
+          'drizzle-kit': '1.0.0-rc.1',
+        },
+      }, null, 2),
+      'utf8',
+    )
+
+    const result = await upgradeCanary({
+      cwd: workspace.dir,
+      versionResolver: async () => '1.2.0',
+      dependencyPinResolver: async () => '1.0.0-rc.4',
+    })
+    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
+      dependencies: Record<string, string>
+      devDependencies: Record<string, string>
+    }
+
+    // Written exactly, matching how @guren/orm pins it — a caret would let the
+    // app resolve a different copy than the adapter runs on.
+    expect(packageJson.dependencies['drizzle-orm']).toBe('1.0.0-rc.4')
+    expect(packageJson.devDependencies['drizzle-kit']).toBe('1.0.0-rc.4')
+    expect(result.updatedDependencies.some((dependency) => dependency.name === 'drizzle-orm')).toBe(true)
+    expect(result.updatedDependencies.some((dependency) => dependency.name === 'drizzle-kit')).toBe(true)
+  })
+
+  it('leaves drizzle alone for an app that does not use @guren/orm', async () => {
+    await writeFile(
+      packageJsonPath,
+      JSON.stringify({
+        name: 'no-orm-test',
+        dependencies: {
+          '@guren/core': '^1.0.0',
+          'drizzle-orm': '1.0.0-rc.1',
+        },
+      }, null, 2),
+      'utf8',
+    )
+
+    await upgradeCanary({
+      cwd: workspace.dir,
+      versionResolver: async () => '1.3.0',
+      dependencyPinResolver: async () => '1.0.0-rc.4',
+    })
+    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
+      dependencies: Record<string, string>
+    }
+
+    expect(packageJson.dependencies['drizzle-orm']).toBe('1.0.0-rc.1')
+  })
+
+  it('leaves drizzle alone when the pin cannot be read', async () => {
+    await writeFile(
+      packageJsonPath,
+      JSON.stringify({
+        name: 'drizzle-unreadable',
+        dependencies: {
+          '@guren/orm': '^1.0.0',
+          'drizzle-orm': '1.0.0-rc.1',
+        },
+      }, null, 2),
+      'utf8',
+    )
+
+    await upgradeCanary({
+      cwd: workspace.dir,
+      versionResolver: async () => '1.2.0',
+      dependencyPinResolver: async () => null,
+    })
+    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
+      dependencies: Record<string, string>
+    }
+
+    expect(packageJson.dependencies['drizzle-orm']).toBe('1.0.0-rc.1')
+  })
+
   it('resolves each package once even though it appears in several lookups', async () => {
     const calls: string[] = []
     await upgradeCanary({

--- a/packages/cli/tests/upgrade.test.ts
+++ b/packages/cli/tests/upgrade.test.ts
@@ -151,6 +151,7 @@ describe('upgradeCanary', () => {
       cwd: workspace.dir,
       versionResolver: async () => '1.2.0',
       dependencyPinResolver: async () => '1.0.0-rc.4',
+      versionExistsResolver: async () => true,
     })
     const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
       dependencies: Record<string, string>
@@ -163,6 +164,107 @@ describe('upgradeCanary', () => {
     expect(packageJson.devDependencies['drizzle-kit']).toBe('1.0.0-rc.4')
     expect(result.updatedDependencies.some((dependency) => dependency.name === 'drizzle-orm')).toBe(true)
     expect(result.updatedDependencies.some((dependency) => dependency.name === 'drizzle-kit')).toBe(true)
+  })
+
+  it('does not overwrite drizzle specifiers that name a location', async () => {
+    await writeFile(
+      packageJsonPath,
+      JSON.stringify({
+        name: 'drizzle-local',
+        dependencies: {
+          '@guren/orm': '^1.0.0',
+          'drizzle-orm': 'workspace:*',
+        },
+      }, null, 2),
+      'utf8',
+    )
+
+    await upgradeCanary({
+      cwd: workspace.dir,
+      versionResolver: async () => '1.2.0',
+      dependencyPinResolver: async () => '1.0.0-rc.4',
+      versionExistsResolver: async () => true,
+    })
+    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
+      dependencies: Record<string, string>
+    }
+
+    expect(packageJson.dependencies['drizzle-orm']).toBe('workspace:*')
+  })
+
+  it('does not narrow a published peer range', async () => {
+    await writeFile(
+      packageJsonPath,
+      JSON.stringify({
+        name: 'drizzle-peer',
+        dependencies: { '@guren/orm': '^1.0.0' },
+        peerDependencies: { 'drizzle-orm': '^1' },
+      }, null, 2),
+      'utf8',
+    )
+
+    await upgradeCanary({
+      cwd: workspace.dir,
+      versionResolver: async () => '1.2.0',
+      dependencyPinResolver: async () => '1.0.0-rc.4',
+      versionExistsResolver: async () => true,
+    })
+    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
+      peerDependencies: Record<string, string>
+    }
+
+    expect(packageJson.peerDependencies['drizzle-orm']).toBe('^1')
+  })
+
+  it('skips drizzle-kit when the matching version was never published', async () => {
+    await writeFile(
+      packageJsonPath,
+      JSON.stringify({
+        name: 'drizzle-kit-missing',
+        dependencies: { '@guren/orm': '^1.0.0', 'drizzle-orm': '1.0.0-rc.1' },
+        devDependencies: { 'drizzle-kit': '0.31.0' },
+      }, null, 2),
+      'utf8',
+    )
+
+    await upgradeCanary({
+      cwd: workspace.dir,
+      versionResolver: async () => '1.2.0',
+      dependencyPinResolver: async () => '1.0.0-rc.4',
+      // drizzle-kit rides its own release line, so the ORM's drizzle-orm
+      // version need not exist for it.
+      versionExistsResolver: async (name) => name !== 'drizzle-kit',
+    })
+    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
+      dependencies: Record<string, string>
+      devDependencies: Record<string, string>
+    }
+
+    expect(packageJson.dependencies['drizzle-orm']).toBe('1.0.0-rc.4')
+    expect(packageJson.devDependencies['drizzle-kit']).toBe('0.31.0')
+  })
+
+  it('leaves drizzle alone when the ORM depends on a range rather than one version', async () => {
+    await writeFile(
+      packageJsonPath,
+      JSON.stringify({
+        name: 'drizzle-range',
+        dependencies: { '@guren/orm': '^1.0.0', 'drizzle-orm': '1.0.0-rc.1' },
+      }, null, 2),
+      'utf8',
+    )
+
+    await upgradeCanary({
+      cwd: workspace.dir,
+      versionResolver: async () => '1.2.0',
+      dependencyPinResolver: async () => '^1.0.0',
+      versionExistsResolver: async () => true,
+    })
+    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
+      dependencies: Record<string, string>
+    }
+
+    expect(packageJson.dependencies['drizzle-orm']).toBe('1.0.0-rc.1')
   })
 
   it('leaves drizzle alone for an app that does not use @guren/orm', async () => {


### PR DESCRIPTION
> **Stacked on #199.** Base is `fix/upgrade-default-latest`, not `main` — both touch `updateManifestDependencies`/`upgradeCanary`. Merge #199 first, then retarget this to `main`.

Found while dogfooding v1.5.0: this is what following `guren upgrade` exactly still leaves behind.

## The problem

`@guren/orm` declares `"drizzle-orm": "1.0.0-rc.4"` — an **exact** pin under `dependencies`, not a range. Upgrading only the `@guren/*` entries left an app whose own pin differs with two copies installed:

```
node_modules/drizzle-orm                         -> 1.0.0-rc.1   (the app's pin)
node_modules/@guren/orm/node_modules/drizzle-orm -> 1.0.0-rc.4   (what the ORM brings)
```

Observed directly on a real app after running `guren upgrade --tag latest` and `bun install`.

The app then builds its table descriptors against one copy while the adapter runs on the other — the same split-module-state failure the duplicate-`@guren/orm` runtime warning exists to catch, reached through the command that warning recommends. It did not break that app at runtime, but nothing about the arrangement guarantees that, and `CLAUDE.md` already instructs contributors to keep these versions aligned. Nothing enforced it for apps.

## Changes

Read the `drizzle-orm` version the target `@guren/orm` depends on from its registry metadata (`versions[v].dependencies`, already in the packument the tag lookup fetches) and write that value, exactly, to both `drizzle-orm` and `drizzle-kit`.

Guards:

- only for apps that declare `@guren/orm` — the pin being matched is the one the ORM brings, so it means nothing otherwise
- only rewrites drizzle entries that already exist; never adds one
- leaves both alone, with a warning, when the pin cannot be read

Written without a caret, matching how `@guren/orm` and the templates pin it. A range would reintroduce the possibility of resolving a different copy than the adapter runs on.

### On `drizzle-kit`

Matched to `drizzle-orm` **by convention, not from metadata** — `drizzle-kit` is not a dependency of `@guren/orm`, so the registry has nothing to say about it. It appears only in app and template manifests, where the two are always kept in step. That judgement is recorded in a comment on `alignDrizzlePins` so it does not read as derived.

## Verification

Against the live registry, on an app with `@guren/orm ^1.2.0` and drizzle at `rc.1`:

```
$ guren upgrade --dry-run
✔ Version compatible (1.5.0 -> 1.5.0)
✔ dependencies: drizzle-orm 1.0.0-rc.1 -> 1.0.0-rc.4
✔ devDependencies: drizzle-kit 1.0.0-rc.1 -> 1.0.0-rc.4
```

`rc.4` is read from `@guren/orm@1.2.0`'s own dependency, not hardcoded. After aligning and reinstalling, that app resolves to a single `node_modules/drizzle-orm`.

`packages/cli`: 686 pass / 0 fail (3 new cases: alignment, an app without `@guren/orm`, an unreadable pin). `typecheck` clean.