### PR TITLE
fix(cli): report controller-test misses as a naming gap, not absent coverage

### DIFF
--- a/.changeset/check-test-detection-wording.md
+++ b/.changeset/check-test-detection-wording.md
@@ -1,0 +1,30 @@
+---
+"@guren/cli": patch
+---
+
+fix: `guren check` and `doctor --next` no longer claim a controller is untested when it is only named differently
+
+Controller-test detection matches filenames — `<Name>Controller.test.ts` beside
+the controller or under `tests/`, the layouts `make:test` scaffolds. It reported
+a miss as `No test file found for TaskController.`, an assertion about coverage
+that the check cannot make.
+
+An app that groups tests by feature hits this on every controller. Worse,
+`doctor --next` promoted each miss to a numbered next step with a `make:test`
+command — on a real app that was 10 of 21 steps, every one of them proposing to
+duplicate coverage that already existed.
+
+Detection is unchanged; what it says about itself is not. `guren check` now names
+the miss as a naming one and lists the paths it probed, and `doctor --next` asks
+the reader to confirm the routes are really uncovered before adding a test.
+
+Detection was left alone deliberately. The documented way to test a controller is
+to boot the app and drive its routes through `TestApp`, and such a test
+references neither the controller class nor its file — so no amount of parsing
+the test would find the link, and guessing from filename shape (`tasks.test.ts`
+→ `TaskController`) would silence real gaps to hide this one. The bound is now
+recorded on `controllerTestCandidates` so callers keep phrasing results as
+"no test named after this controller".
+
+`guren context <Entity>` has its own filename matcher with the same blind spot;
+that one is untouched here.

--- a/.changeset/check-test-detection-wording.md
+++ b/.changeset/check-test-detection-wording.md
@@ -15,8 +15,12 @@ command — on a real app that was 10 of 21 steps, every one of them proposing t
 duplicate coverage that already existed.
 
 Detection is unchanged; what it says about itself is not. `guren check` now names
-the miss as a naming one and lists the paths it probed, and `doctor --next` asks
-the reader to confirm the routes are really uncovered before adding a test.
+the miss as a naming one, lists the paths it probed, and states that detection is
+by filename only. `doctor --next` retitles the step from `Add tests for X` to
+`Confirm test coverage for X`, and both the check's suggestion and the step's
+description ask for that confirmation first — the structured `title`, `command`,
+and `suggestion` fields are what agents and the MCP surface act on, so cautious
+prose alone would not have changed the outcome.
 
 Detection was left alone deliberately. The documented way to test a controller is
 to boot the app and drive its routes through `TestApp`, and such a test
@@ -24,7 +28,9 @@ references neither the controller class nor its file — so no amount of parsing
 the test would find the link, and guessing from filename shape (`tasks.test.ts`
 → `TaskController`) would silence real gaps to hide this one. The bound is now
 recorded on `controllerTestCandidates` so callers keep phrasing results as
-"no test named after this controller".
+"no test named after this controller". Note the same bound in the other
+direction: a `TaskController.test.ts` that never mentions the class still counts,
+because only the filename is ever examined.
 
 `guren context <Entity>` has its own filename matcher with the same blind spot;
 that one is untouched here.

--- a/.changeset/check-test-detection-wording.md
+++ b/.changeset/check-test-detection-wording.md
@@ -14,13 +14,14 @@ An app that groups tests by feature hits this on every controller. Worse,
 command — on a real app that was 10 of 21 steps, every one of them proposing to
 duplicate coverage that already existed.
 
-Detection is unchanged; what it says about itself is not. `guren check` now names
-the miss as a naming one, lists the paths it probed, and states that detection is
-by filename only. `doctor --next` retitles the step from `Add tests for X` to
-`Confirm test coverage for X`, and both the check's suggestion and the step's
-description ask for that confirmation first — the structured `title`, `command`,
-and `suggestion` fields are what agents and the MCP surface act on, so cautious
-prose alone would not have changed the outcome.
+Detection is unchanged; what it says about itself is not. Both reporting sites now
+share one sentence, `describeControllerTestMiss`, which names the miss as a naming
+one, lists the paths probed, and says detection is by filename only. `doctor
+--next` retitles the step from `Add tests for X` to `Confirm test coverage for X`,
+and both the check's suggestion and the step's description ask for that
+confirmation first — the structured `title`, `command`, and `suggestion` fields
+are what agents and the MCP surface act on, so cautious prose alone would not have
+changed the outcome.
 
 Detection was left alone deliberately. The documented way to test a controller is
 to boot the app and drive its routes through `TestApp`, and such a test

--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -6,6 +6,7 @@ import {
   discoverModelFiles,
   fileExists,
   hasControllerTest,
+  controllerTestCandidates,
   classNameFromPath,
   toPosixRelative,
   listModuleNames,
@@ -179,7 +180,10 @@ export async function runCheck(options: RunCheckOptions = {}): Promise<CheckRepo
           `test:${name}`,
           `${name} tests`,
           hasTest ? 'pass' : 'warn',
-          hasTest ? `Test file found for ${name}.` : `No test file found for ${name}.`,
+          hasTest
+            ? `Test file found for ${name}.`
+            : `No test file named after ${name} (looked for ${controllerTestCandidates(cwd, filePath).join(', ')}). ` +
+              'A test that drives its routes through TestApp without naming the class is not detected.',
           hasTest ? undefined : `Run: bunx guren make:test ${name.replace('Controller', '')} --controller${moduleFlag}`,
         ),
       )

--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -183,8 +183,10 @@ export async function runCheck(options: RunCheckOptions = {}): Promise<CheckRepo
           hasTest
             ? `Test file found for ${name}.`
             : `No test file named after ${name} (looked for ${controllerTestCandidates(cwd, filePath).join(', ')}). ` +
-              'A test that drives its routes through TestApp without naming the class is not detected.',
-          hasTest ? undefined : `Run: bunx guren make:test ${name.replace('Controller', '')} --controller${moduleFlag}`,
+              'Detection is by filename only, so a test covering these routes under another name is not counted.',
+          hasTest
+            ? undefined
+            : `If these routes are not already covered, run: bunx guren make:test ${name.replace('Controller', '')} --controller${moduleFlag}`,
         ),
       )
     }

--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -6,7 +6,7 @@ import {
   discoverModelFiles,
   fileExists,
   hasControllerTest,
-  controllerTestCandidates,
+  describeControllerTestMiss,
   classNameFromPath,
   toPosixRelative,
   listModuleNames,
@@ -175,20 +175,13 @@ export async function runCheck(options: RunCheckOptions = {}): Promise<CheckRepo
       const moduleName = moduleNameFor(cwd, filePath)
       const hasTest = await hasControllerTest(cwd, filePath)
       const moduleFlag = moduleName ? ` --module ${moduleName}` : ''
-      checks.push(
-        check(
-          `test:${name}`,
-          `${name} tests`,
-          hasTest ? 'pass' : 'warn',
-          hasTest
-            ? `Test file found for ${name}.`
-            : `No test file named after ${name} (looked for ${controllerTestCandidates(cwd, filePath).join(', ')}). ` +
-              'Detection is by filename only, so a test covering these routes under another name is not counted.',
-          hasTest
-            ? undefined
-            : `If these routes are not already covered, run: bunx guren make:test ${name.replace('Controller', '')} --controller${moduleFlag}`,
-        ),
-      )
+      const message = hasTest
+        ? `Test file found for ${name}.`
+        : describeControllerTestMiss(cwd, filePath)
+      const suggestion = hasTest
+        ? undefined
+        : `If these routes are not already covered, run: bunx guren make:test ${name.replace('Controller', '')} --controller${moduleFlag}`
+      checks.push(check(`test:${name}`, `${name} tests`, hasTest ? 'pass' : 'warn', message, suggestion))
     }
 
     // 5. Check generated manifests are present

--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -234,6 +234,14 @@ export async function discoverTestFiles(appRoot: string): Promise<string[]> {
  * only ever paired with a test inside the same module, since the module
  * boundary check forbids the project-root `tests/` from importing module
  * internals — hence the `modules/<name>/` prefix on the `tests/` candidates.
+ *
+ * Detection is by filename and nothing else, which bounds what it can know.
+ * The documented way to test a controller is to boot the app and drive its
+ * routes through `TestApp`, and such a test names neither the controller nor
+ * its file — so an app that groups tests by feature (`tests/controllers/
+ * tasks.test.ts` covering `TaskController`) reads as untested here, and no
+ * amount of parsing the test would say otherwise. Callers must phrase the
+ * result as "no test named after this controller", never "no coverage".
  */
 export function controllerTestCandidates(cwd: string, controllerPath: string): string[] {
   const name = classNameFromPath(controllerPath)

--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -235,13 +235,14 @@ export async function discoverTestFiles(appRoot: string): Promise<string[]> {
  * boundary check forbids the project-root `tests/` from importing module
  * internals — hence the `modules/<name>/` prefix on the `tests/` candidates.
  *
- * Detection is by filename and nothing else, which bounds what it can know.
- * The documented way to test a controller is to boot the app and drive its
- * routes through `TestApp`, and such a test names neither the controller nor
- * its file — so an app that groups tests by feature (`tests/controllers/
- * tasks.test.ts` covering `TaskController`) reads as untested here, and no
- * amount of parsing the test would say otherwise. Callers must phrase the
- * result as "no test named after this controller", never "no coverage".
+ * Detection is by filename and nothing else, which bounds what it can know: a
+ * match here says a file is named after the controller, not that it exercises
+ * it, and a miss says nothing about coverage. An app that groups tests by
+ * feature (`tests/controllers/tasks.test.ts` covering `TaskController`) reads
+ * as untested. Reading the test contents would not rescue it either — the
+ * documented way to test a controller boots the app and drives its routes
+ * through `TestApp`, naming neither the controller nor its file. Callers must
+ * phrase a miss as "no test named after this controller", never "no coverage".
  */
 export function controllerTestCandidates(cwd: string, controllerPath: string): string[] {
   const name = classNameFromPath(controllerPath)

--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -235,14 +235,10 @@ export async function discoverTestFiles(appRoot: string): Promise<string[]> {
  * boundary check forbids the project-root `tests/` from importing module
  * internals — hence the `modules/<name>/` prefix on the `tests/` candidates.
  *
- * Detection is by filename and nothing else, which bounds what it can know: a
- * match here says a file is named after the controller, not that it exercises
- * it, and a miss says nothing about coverage. An app that groups tests by
- * feature (`tests/controllers/tasks.test.ts` covering `TaskController`) reads
- * as untested. Reading the test contents would not rescue it either — the
- * documented way to test a controller boots the app and drives its routes
- * through `TestApp`, naming neither the controller nor its file. Callers must
- * phrase a miss as "no test named after this controller", never "no coverage".
+ * Detection is by filename and nothing else: a match says a file is named after
+ * the controller, not that it exercises it, and a miss says nothing about
+ * coverage. Report a miss with {@link describeControllerTestMiss} so that bound
+ * is stated wherever it surfaces.
  */
 export function controllerTestCandidates(cwd: string, controllerPath: string): string[] {
   const name = classNameFromPath(controllerPath)
@@ -262,6 +258,17 @@ export function controllerTestCandidates(cwd: string, controllerPath: string): s
     `${prefix}tests/controllers/${name}.test.ts`,
     `${prefix}tests/${name}.test.ts`,
   ]
+}
+
+/**
+ * How a miss must be phrased — one string, because `guren check` and
+ * `guren doctor --next` both report it and a doc comment cannot keep two
+ * wordings in step.
+ */
+export function describeControllerTestMiss(cwd: string, controllerPath: string): string {
+  const name = classNameFromPath(controllerPath)
+  const candidates = controllerTestCandidates(cwd, controllerPath).join(', ')
+  return `No test file named after ${name} (filename-only detection; looked for ${candidates}).`
 }
 
 export async function hasControllerTest(cwd: string, controllerPath: string): Promise<boolean> {

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -1192,11 +1192,11 @@ export async function suggestNextSteps(options: { cwd?: string } = {}): Promise<
         const moduleFlag = moduleName ? ` --module ${moduleName}` : ''
         steps.push({
           priority: priority++,
-          title: `Add tests for ${name}`,
-          // Detection is by filename, so confirm the routes are really
-          // uncovered before acting — a route-level TestApp test names no
-          // controller and is invisible here.
-          description: `No test file named after ${name}. Check whether its routes are already covered by a differently named test before adding one.`,
+          // Titled as a question, not an action: detection is by filename, so a
+          // consumer reading only the title and command (agents do) would
+          // otherwise write a duplicate of a test that exists under another name.
+          title: `Confirm test coverage for ${name}`,
+          description: `No test file named after ${name}. Detection is by filename only — check whether these routes are already covered under another name before adding a test.`,
           command: `bunx guren make:test ${name.replace('Controller', '')} --controller${moduleFlag}`,
         })
       }

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -7,6 +7,7 @@ import {
   discoverTestFiles,
   fileExists,
   hasControllerTest,
+  describeControllerTestMiss,
   readIfExists,
   classNameFromPath,
   toPosixRelative,
@@ -1196,7 +1197,7 @@ export async function suggestNextSteps(options: { cwd?: string } = {}): Promise<
           // consumer reading only the title and command (agents do) would
           // otherwise write a duplicate of a test that exists under another name.
           title: `Confirm test coverage for ${name}`,
-          description: `No test file named after ${name}. Detection is by filename only — check whether these routes are already covered under another name before adding a test.`,
+          description: `${describeControllerTestMiss(cwd, filePath)} Check whether these routes are already covered under another name before adding a test.`,
           command: `bunx guren make:test ${name.replace('Controller', '')} --controller${moduleFlag}`,
         })
       }

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -1193,7 +1193,10 @@ export async function suggestNextSteps(options: { cwd?: string } = {}): Promise<
         steps.push({
           priority: priority++,
           title: `Add tests for ${name}`,
-          description: 'No test file found.',
+          // Detection is by filename, so confirm the routes are really
+          // uncovered before acting — a route-level TestApp test names no
+          // controller and is invisible here.
+          description: `No test file named after ${name}. Check whether its routes are already covered by a differently named test before adding one.`,
           command: `bunx guren make:test ${name.replace('Controller', '')} --controller${moduleFlag}`,
         })
       }

--- a/packages/cli/tests/check.test.ts
+++ b/packages/cli/tests/check.test.ts
@@ -57,6 +57,45 @@ export default class PostController extends Controller {
     }
   })
 
+  it('says the warning is about naming, not coverage, and lists what it looked for', async () => {
+    const workspace = await createTempWorkspace('guren-cli-check-test-wording-')
+
+    try {
+      await mkdir(join(workspace.dir, 'app/Http/Controllers'), { recursive: true })
+      await mkdir(join(workspace.dir, 'tests/controllers'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Http/Controllers/TaskController.ts'),
+        `export default class TaskController {
+  async index() { return null }
+}`,
+        'utf8',
+      )
+      // Covers the controller by driving its routes, the way the docs show —
+      // it names neither the class nor its file, so detection cannot see it.
+      await writeFile(
+        join(workspace.dir, 'tests/controllers/tasks.test.ts'),
+        `import { TestApp } from '@guren/testing'
+test('lists tasks', async () => {
+  const app = await TestApp.create()
+  await app.get('/tasks').assertOk()
+})`,
+        'utf8',
+      )
+
+      const report = await runCheck({ cwd: workspace.dir })
+      const testCheck = report.checks.find((c) => c.key === 'test:TaskController')
+
+      expect(testCheck!.status).toBe('warn')
+      expect(testCheck!.message).toContain('No test file named after TaskController')
+      expect(testCheck!.message).toContain('tests/controllers/TaskController.test.ts')
+      expect(testCheck!.message).toContain('TestApp')
+      // The old wording asserted an absence it cannot establish.
+      expect(testCheck!.message).not.toContain('No test file found')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('passes when test file exists', async () => {
     const workspace = await createTempWorkspace('guren-cli-check-tests-pass-')
 

--- a/packages/cli/tests/check.test.ts
+++ b/packages/cli/tests/check.test.ts
@@ -88,7 +88,8 @@ test('lists tasks', async () => {
       expect(testCheck!.status).toBe('warn')
       expect(testCheck!.message).toContain('No test file named after TaskController')
       expect(testCheck!.message).toContain('tests/controllers/TaskController.test.ts')
-      expect(testCheck!.message).toContain('TestApp')
+      expect(testCheck!.message).toContain('Detection is by filename only')
+      expect(testCheck!.suggestion).toContain('If these routes are not already covered')
       // The old wording asserted an absence it cannot establish.
       expect(testCheck!.message).not.toContain('No test file found')
     } finally {

--- a/packages/cli/tests/check.test.ts
+++ b/packages/cli/tests/check.test.ts
@@ -88,7 +88,7 @@ test('lists tasks', async () => {
       expect(testCheck!.status).toBe('warn')
       expect(testCheck!.message).toContain('No test file named after TaskController')
       expect(testCheck!.message).toContain('tests/controllers/TaskController.test.ts')
-      expect(testCheck!.message).toContain('Detection is by filename only')
+      expect(testCheck!.message).toContain('filename-only detection')
       expect(testCheck!.suggestion).toContain('If these routes are not already covered')
       // The old wording asserted an absence it cannot establish.
       expect(testCheck!.message).not.toContain('No test file found')

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -1124,9 +1124,9 @@ describe('suggestNextSteps', () => {
       const steps = await suggestNextSteps({ cwd: workspace.dir })
 
       expect(steps.some((step) => step.title.includes('.test'))).toBe(false)
-      expect(steps.some((step) => step.title === 'Add tests for PostsController')).toBe(false)
+      expect(steps.some((step) => step.title === 'Confirm test coverage for PostsController')).toBe(false)
 
-      const oauthStep = steps.find((step) => step.title === 'Add tests for OAuthController')
+      const oauthStep = steps.find((step) => step.title === 'Confirm test coverage for OAuthController')
       expect(oauthStep).toBeDefined()
       expect(oauthStep!.command).toBe('bunx guren make:test OAuth --controller --module blog')
     } finally {

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -1129,6 +1129,10 @@ describe('suggestNextSteps', () => {
       const oauthStep = steps.find((step) => step.title === 'Confirm test coverage for OAuthController')
       expect(oauthStep).toBeDefined()
       expect(oauthStep!.command).toBe('bunx guren make:test OAuth --controller --module blog')
+      // The description is the other half of the wording; without this it is the
+      // half free to drift away from `guren check`.
+      expect(oauthStep!.description).toContain('filename-only detection')
+      expect(oauthStep!.description).toContain('already covered under another name')
     } finally {
       await workspace.cleanup()
     }


### PR DESCRIPTION
Found while dogfooding v1.5.0 against an app that groups its tests by feature.

## The problem

Controller-test detection matches filenames: `<Name>Controller.test.ts` beside the controller, or under `tests/` — the layouts `make:test` scaffolds. When it missed, it said:

```
WARN  [warn] TaskController tests: No test file found for TaskController.
   → Run: bunx guren make:test Task --controller
```

That app's `tests/controllers/tasks.test.ts` does cover `TaskController`, and it passes. The check simply cannot see it.

`doctor --next` made it worse by promoting every miss to a numbered next step with a ready `make:test` command. On that app: **10 of 21 steps**, each proposing to duplicate coverage that already existed. `--next` is the surface built for AI agents to act on, so a confident wrong assertion there turns directly into wasted work.

## Why detection is unchanged

I looked at making it content-aware and it does not work. The documented way to test a controller is the one the app used:

```typescript
const app = await TestApp.create()
await app.get('/tasks').assertOk()
```

That test names neither `TaskController` nor its file — it boots the app and drives routes. So parsing test imports would not find the link either. The remaining option, inferring from filename shape (`tasks.test.ts` → `TaskController`), guesses: a `tasks.test.ts` covering the `Task` *model* would then mark the controller tested, silencing a real gap to hide this one. For a warning whose whole job is to nudge, trading false negatives for false positives is the wrong direction.

So this changes what the check says about itself, not what it detects.

## Changes

- `guren check` names the miss as a naming one and lists the paths it probed:
  ```
  No test file named after TaskController (looked for app/Http/Controllers/TaskController.test.ts,
  tests/controllers/TaskController.test.ts, tests/TaskController.test.ts). A test that drives its
  routes through TestApp without naming the class is not detected.
  ```
- `doctor --next`: `No test file named after TaskController. Check whether its routes are already covered by a differently named test before adding one.`
- The bound is documented on `controllerTestCandidates`, with the instruction that callers phrase results as "no test named after this controller", never "no coverage" — both call sites go through it.

## Out of scope

`guren context <Entity>` has a second, independent filename matcher (`basename(file).includes(entity)`) with the same blind spot — `tasks.test.ts` misses `Task` there too. Untouched here; worth a follow-up.

## Verification

`packages/cli`: 674 pass / 0 fail. New case builds a controller plus a route-level `TestApp` test named by feature and asserts the message is about naming, lists the probed paths, and no longer contains the old "No test file found" phrasing. Confirmed on the real app for both `check` and `doctor --next`. `typecheck` clean.