### PR TITLE
feat(docs): position Guren as Bun-first, deploy anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Run `bun run codegen` after adding features to regenerate types. When you are re
 - **Drizzle ORM** — swap database backends through an adapter (PostgreSQL / SQLite)
 - **End-to-end type safety** — `bunx guren codegen` generates types from schema to frontend props
 - **Batteries included** — auth, queues, mail, cache, notifications, storage, broadcasting, scheduling
-- **AWS Lambda ready** — deploy serverless via `@guren/core/lambda`
+- **Bun-first, deploy anywhere** — develop on the Bun toolchain, then self-host on a Bun server or ship to AWS Lambda, Vercel, or Cloudflare Workers with first-party plugins
 
 ---
 

--- a/docs/en/guides/why-guren.md
+++ b/docs/en/guides/why-guren.md
@@ -43,7 +43,7 @@ Next.js remains the better fit when server-rendered React itself is the product 
 
 AdonisJS is the other batteries-included MVC framework in the TypeScript world, and it is excellent — if you want Laravel's architecture on Node.js, it is the established choice. Guren makes two different bets:
 
-- **Bun instead of Node.** Benchmarking the same app (the two Inertia-SSR implementations in our [framework comparison](https://github.com/gurenjs/framework-comparison)) measures Guren at **2.3× the throughput on full SSR pages, 3.5× on the JSON path, and 1.8× faster cold starts** — [methodology and one-click reproduction here](https://github.com/gurenjs/framework-comparison/blob/main/BENCHMARK.md). The app code is held constant, so the gap is the runtime. That is the point: keep the architecture, change the engine.
+- **Bun instead of Node.** Benchmarking the same app (the two Inertia-SSR implementations in our [framework comparison](https://github.com/gurenjs/framework-comparison)) measures Guren at **2.3× the throughput on full SSR pages, 3.5× on the JSON path, and 1.8× faster cold starts** — [methodology and one-click reproduction here](https://github.com/gurenjs/framework-comparison/blob/main/BENCHMARK.md). The app code is held constant, so the gap is the runtime. That is the point: keep the architecture, change the engine. And betting on Bun does not lock your deployment in — first-party plugins target AWS Lambda, Vercel, and Cloudflare Workers, and [guren.dev](https://guren.dev/) itself is a Guren app running on Workers.
 - **The TypeScript ecosystem's defaults, not first-party rewrites.** AdonisJS ships its own ORM (Lucid), validator (VineJS), and tooling. Guren assembles what the ecosystem already standardized on — Drizzle, Zod, Vite, Inertia — and adds the conventions. Reaching the same spec app left 991 lines across 38 files to maintain on Guren versus 2,438 across 68 on AdonisJS, with 17 direct dependencies versus 43.
 
 Typing effort is nearly identical — both scaffold well, at roughly 570 versus 600 handwritten lines for the same app — so the choice comes down to the runtime and whose data layer you want to live with.
@@ -86,7 +86,7 @@ No framework is the right answer everywhere. Reach for something else when:
 
 - **Your product is rendering-centric.** Granular streaming SSR, per-component caching, and the RSC ecosystem are Next.js's home turf.
 - **You want a micro-footprint service.** A webhook receiver or an edge function does not need MVC — plain Hono is lighter.
-- **Your team is committed to another runtime.** Guren is Bun-native by design. Serverless deployment on Node.js runtimes is supported, but the primary development experience assumes Bun.
+- **Your team cannot develop on Bun.** Guren is Bun-first by design: the dev server, test runner, and CLI all assume Bun. Deployment is portable — first-party plugins ship for AWS Lambda, Vercel, and Cloudflare Workers — but if Bun is off the table on developer machines, another framework will fit better.
 
 ## Next Steps
 

--- a/docs/ja/guides/why-guren.md
+++ b/docs/ja/guides/why-guren.md
@@ -43,7 +43,7 @@ Next.js と Guren は答えている問いが違います。Next.js は React �
 
 AdonisJS は TypeScript 世界のもう一つのバッテリー同梱 MVC フレームワークで、素晴らしい選択肢です — Laravel のアーキテクチャを Node.js で使いたいなら定番です。Guren は 2 つ、異なる賭けをしています:
 
-- **Node ではなく Bun。** 同一仕様アプリ同士のベンチマーク（[フレームワーク比較リポジトリ](https://github.com/gurenjs/framework-comparison)の Inertia SSR 実装 2 つ）で、Guren は **SSR ページで 2.3 倍、JSON 経路で 3.5 倍のスループット、コールドスタートは 1.8 倍高速**という結果です — [手法とワンクリック追試はこちら](https://github.com/gurenjs/framework-comparison/blob/main/BENCHMARK.md)。アプリのコードは同一なので、この差はランタイムの差です。それこそが要点で、アーキテクチャはそのまま、エンジンだけ替わります。
+- **Node ではなく Bun。** 同一仕様アプリ同士のベンチマーク（[フレームワーク比較リポジトリ](https://github.com/gurenjs/framework-comparison)の Inertia SSR 実装 2 つ）で、Guren は **SSR ページで 2.3 倍、JSON 経路で 3.5 倍のスループット、コールドスタートは 1.8 倍高速**という結果です — [手法とワンクリック追試はこちら](https://github.com/gurenjs/framework-comparison/blob/main/BENCHMARK.md)。アプリのコードは同一なので、この差はランタイムの差です。それこそが要点で、アーキテクチャはそのまま、エンジンだけ替わります。そして Bun に賭けてもデプロイ先が縛られるわけではありません — AWS Lambda・Vercel・Cloudflare Workers 向けの公式プラグインがあり、[guren.dev](https://guren.dev/) 自身も Workers 上で動く Guren アプリです。
 - **独自実装ではなく TypeScript エコシステムの定番を採用。** AdonisJS は独自の ORM（Lucid）やバリデータ（VineJS）を持ちます。Guren はエコシステムで既に標準となった部品 — Drizzle、Zod、Vite、Inertia — を組み立て、そこに規約を載せます。同一仕様アプリの実装で、保守対象のコードは Guren 991 行 / 38 ファイルに対して AdonisJS 2,438 行 / 68 ファイル、直接依存は 17 対 43 でした。
 
 タイプ量はほぼ互角です（どちらもスキャフォールドが優秀で、手書きは約 570 行対 600 行）。選択はランタイムと、どのデータ層と付き合いたいかで決まります。
@@ -86,7 +86,7 @@ bun run typecheck   # 型付き page props とルート契約のズレはビル�
 
 - **プロダクトがレンダリング中心。** コンポーネント単位のストリーミング SSR、細粒度のキャッシュ、RSC エコシステムは Next.js のホームグラウンドです。
 - **極小フットプリントのサービスが欲しい。** Webhook レシーバーやエッジファンクションに MVC は不要です — 素の Hono の方が軽量です。
-- **チームが別のランタイムにコミットしている。** Guren は設計上 Bun ネイティブです。Node.js ランタイムでのサーバーレスデプロイはサポートしていますが、主たる開発体験は Bun を前提としています。
+- **チームが Bun で開発できない。** Guren は設計上 Bun ファーストです: 開発サーバー・テストランナー・CLI は Bun を前提としています。デプロイはポータブルで、AWS Lambda・Vercel・Cloudflare Workers 向けの公式プラグインがありますが、開発マシンで Bun を使えないなら別のフレームワークの方が適しています。
 
 ## 次のステップ
 

--- a/web/resources/js/pages/Home.tsx
+++ b/web/resources/js/pages/Home.tsx
@@ -98,6 +98,29 @@ const benchmarks: Benchmark[] = [
   },
 ]
 
+const deployTargets = [
+  {
+    name: 'Bun server',
+    detail: 'Self-host on any VPS or container. The runtime you develop on is the one that serves production.',
+    href: '/docs/guides/deployment',
+  },
+  {
+    name: 'Cloudflare Workers',
+    detail: 'Workers + D1 at the edge, on the free plan if you like. This site is a Guren app running there.',
+    href: '/docs/guides/cloudflare',
+  },
+  {
+    name: 'Vercel',
+    detail: "One plugin scaffolds the build — and it runs on Vercel's Bun runtime, so the engine travels with you.",
+    href: '/docs/guides/deployment',
+  },
+  {
+    name: 'AWS Lambda',
+    detail: 'A handler adapter and Node-compatible defaults take the same app serverless.',
+    href: '/docs/guides/serverless',
+  },
+]
+
 const agentCostSteps = [
   { name: 'Bare repo', cost: 5.54, display: '$5.54', accent: false },
   { name: 'Big CLAUDE.md', cost: 4.51, display: '$4.51', accent: false },
@@ -342,8 +365,8 @@ export default function Home({ codeExamples }: Props) {
                 Fast where it counts
               </h2>
               <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-white/60">
-                The same spec app on Guren and on the equivalent Node.js MVC stack, benchmarked
-                under identical conditions. The app code is held constant, so the gap is Bun itself —
+                The same spec app on Guren and on the equivalent Node.js MVC stack, self-hosted and
+                benchmarked under identical conditions. The app code is held constant, so the gap is Bun itself —
                 and that is the point: keep the Laravel-style architecture, change the engine.
                 Every number is reproducible with one command.
               </p>
@@ -398,6 +421,39 @@ export default function Home({ codeExamples }: Props) {
                 Read the full comparison
                 <ArrowRightIcon className="size-3.5" />
               </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* Deploy targets */}
+        <section className="border-t border-white/10 px-6 py-20">
+          <div className="mx-auto max-w-5xl">
+            <div className="mb-12 text-center">
+              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-crimson-400">Bun-first, deploy anywhere</p>
+              <h2 className="mt-3 text-3xl font-bold text-white md:text-4xl">
+                Develop on Bun. Ship where you want.
+              </h2>
+              <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-white/60">
+                Bun is the development experience — one toolchain for the dev server, tests, and
+                codegen. Deployment is an adapter: pick a target, install the plugin, ship the
+                same app.
+              </p>
+            </div>
+            <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+              {deployTargets.map((t) => (
+                <Link
+                  key={t.name}
+                  href={t.href}
+                  className="group rounded-xl border border-white/10 bg-white/[0.03] p-6 transition hover:border-crimson-400/40 hover:bg-white/[0.05]"
+                >
+                  <p className="font-semibold text-white">{t.name}</p>
+                  <p className="mt-2 text-sm leading-relaxed text-white/55">{t.detail}</p>
+                  <span className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-crimson-300 transition group-hover:text-crimson-200">
+                    Deployment guide
+                    <ArrowRightIcon className="size-3.5" />
+                  </span>
+                </Link>
+              ))}
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary

With first-party plugins now covering AWS Lambda, Vercel, and Cloudflare Workers, deployment portability deserves to be part of the positioning rather than a footnote. This PR keeps the Bun-first identity ("The Laravel feeling, at Bun speed.") and makes the message explicit: **develop on Bun, deploy anywhere**.

- **README** — replace the Lambda-only bullet with a "Bun-first, deploy anywhere" bullet listing all first-party deploy targets.
- **Home page** — new "Bun-first, deploy anywhere" section with four target cards (Bun server, Cloudflare Workers, Vercel, AWS Lambda), each linking to the relevant guide. The Cloudflare card notes that guren.dev itself is a Guren app running on Workers. The benchmark intro is scoped to self-hosted deployments, where the Bun runtime is what serves production, so the claim stays honest for Workers deploys.
- **Why Guren (en/ja)** — the AdonisJS comparison now notes that betting on Bun does not lock deployment in, and the "when not to choose Guren" caveat is reframed around the development toolchain (dev server, tests, CLI assume Bun) rather than the deploy target.

## Verification

- `bun run typecheck` (web) passes
- `bun run test` (web) — 91 tests pass
- `bun run audit:docs` and `bun run audit:core-first` pass
- Rendered the home page locally: the new section renders with all four cards, and every linked guide (`/docs/guides/deployment`, `/docs/guides/cloudflare`, `/docs/guides/serverless`) returns 200; no console errors