### PR TITLE
fix(orm): report the connection failure behind a failed database command

### DIFF
--- a/.changeset/migrate-connection-errors.md
+++ b/.changeset/migrate-connection-errors.md
@@ -1,9 +1,10 @@
 ---
 'create-guren-app': minor
+'@guren/cli': patch
 '@guren/orm': patch
 ---
 
-Name the real cause when migrations fail, and give container-backed apps `db:up`/`db:down`
+Name the real cause when a database command fails, and give container-backed apps `db:up`/`db:down`
 
 `db:migrate` against a database that is not reachable used to report `Failed to
 run database migrations: Failed query: CREATE SCHEMA IF NOT EXISTS "drizzle"` —
@@ -13,6 +14,13 @@ reports `cannot connect to the database at localhost:54322 (ECONNREFUSED). Is it
 running and accepting connections?`, with the host and port only so the
 connection string's credentials stay out of the log. Genuine SQL failures now
 carry the driver's message alongside the query instead of the query alone.
+
+Two sibling commands had the same blind spot. `db:status` caught an unreachable
+server in the branch written for "the tracker table does not exist yet", so it
+reported every migration as pending and exited 0 — indistinguishable from a
+healthy database with nothing applied; it now fails with the connection error.
+`db:reset` rethrew the driver error untouched, and a message-less
+`AggregateError` printed as a bare `ERROR` line with nothing after it.
 
 Scaffolding with PostgreSQL or MySQL also writes `db:up` and `db:down` scripts
 next to the generated `docker-compose.yml`, so starting the database is

--- a/.changeset/migrate-connection-errors.md
+++ b/.changeset/migrate-connection-errors.md
@@ -1,5 +1,5 @@
 ---
-'create-guren-app': patch
+'create-guren-app': minor
 '@guren/orm': patch
 ---
 

--- a/.changeset/migrate-connection-errors.md
+++ b/.changeset/migrate-connection-errors.md
@@ -15,15 +15,20 @@ running and accepting connections?`, with the host and port only so the
 connection string's credentials stay out of the log. Genuine SQL failures now
 carry the driver's message alongside the query instead of the query alone.
 
-Two sibling commands had the same blind spot. `db:status` caught an unreachable
+Three sibling commands had the same blind spot. `db:status` caught an unreachable
 server in the branch written for "the tracker table does not exist yet", so it
 reported every migration as pending and exited 0 — indistinguishable from a
 healthy database with nothing applied; it now fails with the connection error.
 `db:reset` rethrew the driver error untouched, and a message-less
-`AggregateError` printed as a bare `ERROR` line with nothing after it.
+`AggregateError` printed as a bare `ERROR` line with nothing after it. `db:seed`
+reported the failing statement without the driver's explanation of why it failed.
 
 Scaffolding with PostgreSQL or MySQL also writes `db:up` and `db:down` scripts
 next to the generated `docker-compose.yml`, so starting the database is
 discoverable from `package.json`. The selected driver is no longer listed in both
 `dependencies` and `devDependencies`, which made `bun install` warn about a
 duplicate dependency on the first command a new project runs.
+
+The AI agent harness that `agent:init` installs is updated to match: its database
+skill pointed agents at a `db:logs` script that nothing scaffolds, and handed
+container commands to SQLite projects, which have no container.

--- a/.changeset/migrate-connection-errors.md
+++ b/.changeset/migrate-connection-errors.md
@@ -1,0 +1,21 @@
+---
+'create-guren-app': patch
+'@guren/orm': patch
+---
+
+Name the real cause when migrations fail, and give container-backed apps `db:up`/`db:down`
+
+`db:migrate` against a database that is not reachable used to report `Failed to
+run database migrations: Failed query: CREATE SCHEMA IF NOT EXISTS "drizzle"` —
+the migrator's own bookkeeping statement, not anything the user wrote. The
+driver's `ECONNREFUSED` lived on the error's `cause`, which was discarded. It now
+reports `cannot connect to the database at localhost:54322 (ECONNREFUSED). Is it
+running and accepting connections?`, with the host and port only so the
+connection string's credentials stay out of the log. Genuine SQL failures now
+carry the driver's message alongside the query instead of the query alone.
+
+Scaffolding with PostgreSQL or MySQL also writes `db:up` and `db:down` scripts
+next to the generated `docker-compose.yml`, so starting the database is
+discoverable from `package.json`. The selected driver is no longer listed in both
+`dependencies` and `devDependencies`, which made `bun install` warn about a
+duplicate dependency on the first command a new project runs.

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -21,7 +21,7 @@
 - Surface the most relevant next steps at the end of each document
 
 ## Maintenance Checklist
-- After editing, run `rg` on `docs/` for disallowed terms (`packages/core`, `citty`, `consola`, `bun run db:up`, etc.)
+- After editing, run `rg` on `docs/` for disallowed terms (`packages/core`, `citty`, `consola`, etc.)
 - Keep Quick Start and Getting Started aligned whenever the scaffold workflow changes
 - Update examples promptly if `create-guren-app` template changes
 - Keep `testing.md` synchronized with `@guren/testing` helpers and CLI commands

--- a/docs/en/guides/build-auth-app.md
+++ b/docs/en/guides/build-auth-app.md
@@ -38,7 +38,7 @@ This scaffolds:
 ## 3. Start the Database
 
 ```bash
-docker compose up -d
+bun run db:up
 ```
 
 Then run the generated migration to create the `users` table:

--- a/docs/en/guides/build-auth-app.md
+++ b/docs/en/guides/build-auth-app.md
@@ -13,7 +13,7 @@ This guide walks you through building an application with user registration, log
 ## 1. Scaffold the Project
 
 ```bash
-bunx create-guren-app my-auth-app --mode ssr
+bunx create-guren-app my-auth-app --mode ssr --db postgres
 cd my-auth-app
 bun install
 ```

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -67,7 +67,7 @@ Default connection strings:
 - PostgreSQL: `postgres://guren:guren@localhost:54322/guren`
 - MySQL: `mysql://guren:guren@localhost:33306/guren`
 
-Stop the container with `docker compose down` when you are done.
+Stop the container with `bun run db:down` when you are done.
 
 > [!TIP]
 > Already running Postgres locally or in the cloud? Skip Docker entirely and point `DATABASE_URL` at that instance — the rest of the guide works unchanged. An existing SQLite app can switch later by updating `config/database.ts`; see the [Database Guide](./database.md).

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -59,7 +59,7 @@ Everything below is optional for your first session, but you will want it as you
 Pass `--db postgres` (or `--db mysql`) when scaffolding, or pick it at the prompt. The scaffolder then writes a `docker-compose.yml` for the matching database and points `DATABASE_URL` at it. With **Docker Desktop (Compose v2)** installed, start the database with:
 
 ```bash
-docker compose up -d
+bun run db:up
 ```
 
 Default connection strings:

--- a/docs/en/guides/ship-api.md
+++ b/docs/en/guides/ship-api.md
@@ -15,7 +15,7 @@ This guide walks you through building and shipping a JSON API with Guren. You wi
 The `api` blueprint skips Inertia and frontend tooling, giving you a lean JSON API starter:
 
 ```bash
-bunx create-guren-app my-api --blueprint api
+bunx create-guren-app my-api --blueprint api --db postgres
 cd my-api
 bun install
 ```

--- a/docs/en/guides/ship-api.md
+++ b/docs/en/guides/ship-api.md
@@ -23,7 +23,7 @@ bun install
 ## 2. Start the Database
 
 ```bash
-docker compose up -d
+bun run db:up
 ```
 
 ## 3. Define Your Schema

--- a/docs/en/guides/troubleshoot.md
+++ b/docs/en/guides/troubleshoot.md
@@ -68,14 +68,16 @@ The `--force` flag bypasses the cache and regenerates all manifests from scratch
 
 ### "Connection refused" when accessing the database
 
-**Cause:** The Postgres container is not running, or `DATABASE_URL` points to the wrong host or port.
+`bun run db:migrate` fails with `cannot connect to the database at localhost:54322 (ECONNREFUSED)`.
+
+**Cause:** The Postgres container is not running, its port is not published to the host, or `DATABASE_URL` points to the wrong host or port.
 
 **Fix:**
 
 1. Start the database container:
 
    ```bash
-   docker compose up -d
+   bun run db:up
    ```
 
 2. Verify the connection string in `.env`:
@@ -86,10 +88,16 @@ The `--force` flag bypasses the cache and regenerates all manifests from scratch
 
    The default port is `54322` (not the standard `5432`) to avoid conflicts with system Postgres.
 
-3. Confirm the container is healthy:
+3. Confirm the container **publishes its port to the host**:
 
    ```bash
-   docker compose ps
+   docker compose port postgres 5432
+   ```
+
+   You should see `0.0.0.0:54322`. If `docker compose ps` reports `Up` but this command prints nothing, publishing failed (this happens after a Docker Desktop restart). Recreate the container — the named volume survives, so no data is lost:
+
+   ```bash
+   bun run db:down && bun run db:up
    ```
 
 ---

--- a/docs/en/guides/troubleshoot.md
+++ b/docs/en/guides/troubleshoot.md
@@ -80,6 +80,8 @@ The `--force` flag bypasses the cache and regenerates all manifests from scratch
    bun run db:up
    ```
 
+   Projects scaffolded before `db:up` existed do not have that script — run `docker compose up -d` instead, or add it to `package.json`.
+
 2. Verify the connection string in `.env`:
 
    ```dotenv
@@ -97,7 +99,7 @@ The `--force` flag bypasses the cache and regenerates all manifests from scratch
    You should see `0.0.0.0:54322`. If `docker compose ps` reports `Up` but this command prints nothing, publishing failed (this happens after a Docker Desktop restart). Recreate the container — the named volume survives, so no data is lost:
 
    ```bash
-   bun run db:down && bun run db:up
+   docker compose down && docker compose up -d
    ```
 
 ---

--- a/docs/en/tutorials/create-blog-post-app.md
+++ b/docs/en/tutorials/create-blog-post-app.md
@@ -402,6 +402,9 @@ Codegen hasn't run since you added the pages. Run `bun run codegen` (or restart 
 **`no such table: posts` when opening `/posts`.**
 The migration was never generated or applied. Run `bun run db:make create_posts_table` and then `bun run db:migrate`.
 
+**`bun run db:migrate` fails with "cannot connect to the database".**
+You picked PostgreSQL or MySQL instead of SQLite when scaffolding. Start the container first with `bun run db:up`. See [Troubleshooting](../guides/troubleshoot.md) for the details.
+
 **Submitting the form does nothing.**
 It almost certainly returned a 422. Check that your page renders `form.errors.title` and `form.errors.body` — the messages are there, you're just not showing them. The network tab (an `X-Inertia` POST to `/posts`) confirms it.
 

--- a/docs/ja/guides/build-auth-app.md
+++ b/docs/ja/guides/build-auth-app.md
@@ -38,7 +38,7 @@ bunx guren add auth
 ## 3. データベースを起動する
 
 ```bash
-docker compose up -d
+bun run db:up
 ```
 
 マイグレーションを実行して `users` テーブルを作成します:

--- a/docs/ja/guides/build-auth-app.md
+++ b/docs/ja/guides/build-auth-app.md
@@ -13,7 +13,7 @@
 ## 1. プロジェクトを作成する
 
 ```bash
-bunx create-guren-app my-auth-app --mode ssr
+bunx create-guren-app my-auth-app --mode ssr --db postgres
 cd my-auth-app
 bun install
 ```

--- a/docs/ja/guides/getting-started.md
+++ b/docs/ja/guides/getting-started.md
@@ -67,7 +67,7 @@ bun run db:up
 - PostgreSQL: `postgres://guren:guren@localhost:54322/guren`
 - MySQL: `mysql://guren:guren@localhost:33306/guren`
 
-使い終わったら `docker compose down` でコンテナを停止します。
+使い終わったら `bun run db:down` でコンテナを停止します。
 
 > [!TIP]
 > すでにローカルやクラウドで Postgres が動いていますか？ その場合は Docker を使わず、`DATABASE_URL` をそのインスタンスに向けるだけで構いません — このガイドの残りはそのまま通用します。SQLite で作ったアプリも、あとから `config/database.ts` を更新すれば切り替えられます。詳しくは [データベースガイド](./database.md) を参照してください。

--- a/docs/ja/guides/getting-started.md
+++ b/docs/ja/guides/getting-started.md
@@ -59,7 +59,7 @@ bun run dev
 雛形生成時に `--db postgres`（または `--db mysql`）を渡すか、プロンプトで選択します。スキャフォールダーが対応するデータベースの `docker-compose.yml` を書き出し、`DATABASE_URL` をそこに向けてくれます。**Docker Desktop（Compose v2）** がインストールされていれば、次のコマンドでデータベースを起動できます。
 
 ```bash
-docker compose up -d
+bun run db:up
 ```
 
 デフォルトの接続文字列:

--- a/docs/ja/guides/ship-api.md
+++ b/docs/ja/guides/ship-api.md
@@ -23,7 +23,7 @@ bun install
 ## 2. データベースを起動する
 
 ```bash
-docker compose up -d
+bun run db:up
 ```
 
 ## 3. スキーマを定義する

--- a/docs/ja/guides/ship-api.md
+++ b/docs/ja/guides/ship-api.md
@@ -15,7 +15,7 @@
 `api` ブループリントを指定すると、Inertia やフロントエンドツールを省いた軽量な API スターターが生成されます:
 
 ```bash
-bunx create-guren-app my-api --blueprint api
+bunx create-guren-app my-api --blueprint api --db postgres
 cd my-api
 bun install
 ```

--- a/docs/ja/guides/troubleshoot.md
+++ b/docs/ja/guides/troubleshoot.md
@@ -80,6 +80,8 @@ bun run codegen --force
    bun run db:up
    ```
 
+   `db:up` が追加される前に生成したプロジェクトにはこのスクリプトがありません。その場合は `docker compose up -d` を実行するか、`package.json` に追加してください。
+
 2. `.env` の接続文字列を確認する:
 
    ```dotenv
@@ -97,7 +99,7 @@ bun run codegen --force
    `0.0.0.0:54322` が表示されれば正常です。`docker compose ps` が `Up` と表示していても、このコマンドが何も返さない場合はポートの公開に失敗しています(Docker Desktop の再起動後などに起こります)。コンテナを作り直してください — 名前付きボリュームは残るのでデータは失われません:
 
    ```bash
-   bun run db:down && bun run db:up
+   docker compose down && docker compose up -d
    ```
 
 ---

--- a/docs/ja/guides/troubleshoot.md
+++ b/docs/ja/guides/troubleshoot.md
@@ -68,14 +68,16 @@ bun run codegen --force
 
 ### データベースへの "Connection refused"
 
-**原因:** Postgres コンテナが起動していないか、`DATABASE_URL` のホストまたはポートが間違っている。
+`bun run db:migrate` が `cannot connect to the database at localhost:54322 (ECONNREFUSED)` で失敗します。
+
+**原因:** Postgres コンテナが起動していない、ポートがホストに公開されていない、または `DATABASE_URL` のホストかポートが間違っている。
 
 **解決方法:**
 
 1. データベースコンテナを起動する:
 
    ```bash
-   docker compose up -d
+   bun run db:up
    ```
 
 2. `.env` の接続文字列を確認する:
@@ -86,10 +88,16 @@ bun run codegen --force
 
    デフォルトポートはシステムの Postgres との競合を避けるため `54322`(標準の `5432` ではない)です。
 
-3. コンテナが正常に起動しているか確認する:
+3. コンテナがポートを**ホストに公開している**か確認する:
 
    ```bash
-   docker compose ps
+   docker compose port postgres 5432
+   ```
+
+   `0.0.0.0:54322` が表示されれば正常です。`docker compose ps` が `Up` と表示していても、このコマンドが何も返さない場合はポートの公開に失敗しています(Docker Desktop の再起動後などに起こります)。コンテナを作り直してください — 名前付きボリュームは残るのでデータは失われません:
+
+   ```bash
+   bun run db:down && bun run db:up
    ```
 
 ---

--- a/docs/ja/tutorials/create-blog-post-app.md
+++ b/docs/ja/tutorials/create-blog-post-app.md
@@ -402,6 +402,9 @@ bun run codegen
 **`/posts` を開くと `no such table: posts`。**
 マイグレーションが生成されていないか、適用されていません。`bun run db:make create_posts_table` に続けて `bun run db:migrate` を実行してください。
 
+**`bun run db:migrate` が "cannot connect to the database" で失敗する。**
+スキャフォールド時に SQLite ではなく PostgreSQL / MySQL を選んでいます。先に `bun run db:up` でコンテナを起動してください。詳しくは[トラブルシューティング](../guides/troubleshoot.md)を参照してください。
+
 **フォームを送信しても何も起きない。**
 ほぼ間違いなく 422 が返っています。ページが `form.errors.title` と `form.errors.body` を描画しているか確認してください — メッセージは届いているのに、表示していないだけです。ネットワークタブ（`/posts` への `X-Inertia` POST）で確認できます。
 

--- a/packages/cli/templates/agent/.claude/skills/db-manage/SKILL.md
+++ b/packages/cli/templates/agent/.claude/skills/db-manage/SKILL.md
@@ -54,10 +54,17 @@ bun run db:seed
 
 ### Reset
 
-Full reset: stop container, start fresh, migrate, and seed.
+Full reset. On a container-backed project, stop the container, start it fresh,
+then migrate and seed:
 
 ```bash
 bun run db:down && bun run db:up && sleep 3 && bun run db:migrate && bun run db:seed
+```
+
+On SQLite there is no container — `db:reset` drops every table in place:
+
+```bash
+bun run db:reset && bun run db:migrate && bun run db:seed
 ```
 
 - This destroys all existing data in the development database
@@ -75,10 +82,14 @@ bunx guren make:migration <name>
 Then provide schema template.
 
 ### Container Management
+
+Only projects scaffolded with PostgreSQL or MySQL have a `docker-compose.yml`
+and these scripts. SQLite projects have neither — the database is a file.
+
 ```bash
-bun run db:up    # Start PostgreSQL
-bun run db:down  # Stop
-bun run db:logs  # View logs
+bun run db:up    # Start the database container
+bun run db:down  # Stop it
+docker compose logs -f   # Follow its logs
 ```
 
 ## Safety Rules
@@ -89,7 +100,7 @@ bun run db:logs  # View logs
    - Warn about data loss
 
 2. **Error handling:**
-   - DB not running → suggest `bun run db:up`
+   - DB not running → suggest `bun run db:up` (container-backed projects only)
    - Migration failed → show error, suggest rollback
 
 3. **Production:**

--- a/packages/cli/templates/agent/.claude/skills/dev-workflow/SKILL.md
+++ b/packages/cli/templates/agent/.claude/skills/dev-workflow/SKILL.md
@@ -22,7 +22,7 @@ bun run dev
 ```
 
 **Prerequisites check before starting:**
-1. Database running? If not: `bun run db:up`
+1. Database running? Container-backed projects start it with `bun run db:up`; SQLite needs nothing.
 2. Migrations applied? If not: `bun run db:migrate`
 
 **After startup:**

--- a/packages/create-app/src/blueprints.ts
+++ b/packages/create-app/src/blueprints.ts
@@ -470,6 +470,15 @@ export default defineConfig({
 `
 }
 
+/**
+ * True when the driver runs in a container the scaffolder provisions — the one
+ * fact that decides docker-compose.yml, the db:up/db:down scripts, and whether
+ * the next-steps output mentions starting a database.
+ */
+export function usesDatabaseContainer(driver: DatabaseDriver): boolean {
+  return generateDockerCompose(driver) !== null
+}
+
 function generateDockerCompose(driver: DatabaseDriver): string | null {
   if (driver === 'postgres') {
     return `services:
@@ -551,8 +560,8 @@ async function applyDatabaseConfig(destination: string, driver: DatabaseDriver):
     // migration failure.
     if (dockerCompose) {
       pkg.scripts ??= {}
-      pkg.scripts['db:up'] ??= 'docker compose up -d'
-      pkg.scripts['db:down'] ??= 'docker compose down'
+      pkg.scripts['db:up'] = 'docker compose up -d'
+      pkg.scripts['db:down'] = 'docker compose down'
     }
 
     await writeFile(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`, 'utf8')

--- a/packages/create-app/src/blueprints.ts
+++ b/packages/create-app/src/blueprints.ts
@@ -535,13 +535,26 @@ async function applyDatabaseConfig(destination: string, driver: DatabaseDriver):
     }),
   ])
 
-  // Add driver dependency to package.json (SQLite has dep: null, so this is skipped)
-  if (dep) {
+  // SQLite needs neither a driver dependency nor a container, so both edits are skipped.
+  if (dep || dockerCompose) {
     const packageJsonPath = join(destination, 'package.json')
     const raw = await readFile(packageJsonPath, 'utf8')
-    const pkg = JSON.parse(raw) as { dependencies?: Record<string, string> }
-    pkg.dependencies ??= {}
-    Object.assign(pkg.dependencies, dep)
+    const pkg = JSON.parse(raw) as { scripts?: Record<string, string>; dependencies?: Record<string, string> }
+
+    if (dep) {
+      pkg.dependencies ??= {}
+      Object.assign(pkg.dependencies, dep)
+    }
+
+    // Without these, the generated docker-compose.yml is something the user has
+    // to discover on their own — and an unstarted container surfaces only as a
+    // migration failure.
+    if (dockerCompose) {
+      pkg.scripts ??= {}
+      pkg.scripts['db:up'] ??= 'docker compose up -d'
+      pkg.scripts['db:down'] ??= 'docker compose down'
+    }
+
     await writeFile(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`, 'utf8')
   }
 }

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -3,7 +3,7 @@ import { relative, resolve } from 'node:path'
 import process from 'node:process'
 import { consola } from 'consola'
 import { defineCommand, runMain } from 'citty'
-import { DATABASE_DRIVERS, getAppBlueprint, listAppBlueprints, scaffoldAppBlueprint, type DatabaseDriver, type RenderingMode } from './blueprints'
+import { DATABASE_DRIVERS, getAppBlueprint, listAppBlueprints, scaffoldAppBlueprint, usesDatabaseContainer, type DatabaseDriver, type RenderingMode } from './blueprints'
 import { directoryExists, isDirectoryEmpty } from './utils'
 
 const RENDERING_MODES = ['spa', 'ssr'] as const
@@ -242,7 +242,7 @@ const command = defineCommand({
     if (!installed) {
       consola.log('  bun install')
     }
-    if (database !== 'sqlite') {
+    if (usesDatabaseContainer(database)) {
       consola.log('  bun run db:up')
     }
     consola.log('')

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -243,7 +243,7 @@ const command = defineCommand({
       consola.log('  bun install')
     }
     if (database !== 'sqlite') {
-      consola.log('  docker compose up -d')
+      consola.log('  bun run db:up')
     }
     consola.log('')
     consola.info('Add features:')

--- a/packages/create-app/templates/api-only/README.md
+++ b/packages/create-app/templates/api-only/README.md
@@ -10,6 +10,8 @@ bun run db:migrate
 bun run dev
 ```
 
+If you scaffolded with PostgreSQL or MySQL, this project also has a `docker-compose.yml` and `bun run db:up` / `bun run db:down` to start and stop the database container. Start it before `bun run db:migrate`.
+
 ## API Endpoints
 
 - `GET /health` — Health check

--- a/packages/create-app/templates/api-only/package.json
+++ b/packages/create-app/templates/api-only/package.json
@@ -26,8 +26,6 @@
     "@guren/testing": "^1.0.0",
     "bun-types": "^1.3.1",
     "drizzle-kit": "1.0.0-rc.4",
-    "mysql2": "^3.11.3",
-    "postgres": "^3.4.3",
     "typescript": "^5.4.0"
   }
 }

--- a/packages/create-app/templates/default/README.md
+++ b/packages/create-app/templates/default/README.md
@@ -48,6 +48,8 @@ bunx guren add schedule       # task scheduling
 | `bun run db:seed` | Seed the database |
 | `bun run codegen` | Regenerate route/page types |
 
+If you scaffolded with PostgreSQL or MySQL, this project also has a `docker-compose.yml` and `bun run db:up` / `bun run db:down` to start and stop the database container. Start it before `bun run db:migrate`.
+
 Run `bun run build` before `bun run preview` so the production server can read the generated manifests from `public/assets`.
 
 ## Switching to PostgreSQL

--- a/packages/create-app/templates/default/package.json
+++ b/packages/create-app/templates/default/package.json
@@ -33,8 +33,6 @@
     "@types/react-dom": "^19.0.0",
     "bun-types": "^1.3.1",
     "drizzle-kit": "1.0.0-rc.4",
-    "mysql2": "^3.11.3",
-    "postgres": "^3.4.3",
     "typescript": "^5.4.0",
     "@vitejs/plugin-react": "^6.0.0",
     "vite": "^8.0.0",

--- a/packages/create-app/tests/cli.test.ts
+++ b/packages/create-app/tests/cli.test.ts
@@ -199,6 +199,7 @@ describe('create-guren-app CLI', () => {
       await workspace.cleanup()
     }
   })
+
   it('gives container-backed drivers a single driver dependency and db:up/db:down scripts', async () => {
     const workspace = await createTempWorkspace('guren-create-app-cli-postgres-')
     try {

--- a/packages/create-app/tests/cli.test.ts
+++ b/packages/create-app/tests/cli.test.ts
@@ -199,4 +199,71 @@ describe('create-guren-app CLI', () => {
       await workspace.cleanup()
     }
   })
+  it('gives container-backed drivers a single driver dependency and db:up/db:down scripts', async () => {
+    const workspace = await createTempWorkspace('guren-create-app-cli-postgres-')
+    try {
+      await capturedCommand.run({
+        args: {
+          target: 'pg-app',
+          force: false,
+          mode: 'spa',
+          auth: false,
+          db: 'postgres',
+          install: false,
+        },
+      })
+
+      const appRoot = join(workspace.dir, 'pg-app')
+      await access(join(appRoot, 'docker-compose.yml'))
+
+      const packageJson = JSON.parse(await readFile(join(appRoot, 'package.json'), 'utf8')) as {
+        scripts?: Record<string, string>
+        dependencies?: Record<string, string>
+        devDependencies?: Record<string, string>
+      }
+
+      expect(packageJson.scripts?.['db:up']).toBe('docker compose up -d')
+      expect(packageJson.scripts?.['db:down']).toBe('docker compose down')
+
+      // Listing the driver in both trees makes `bun install` warn about a
+      // duplicate dependency on the very first command a user runs.
+      expect(packageJson.dependencies?.postgres).toBeDefined()
+      expect(packageJson.devDependencies?.postgres).toBeUndefined()
+      expect(packageJson.devDependencies?.mysql2).toBeUndefined()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('leaves SQLite projects without container scripts or driver packages', async () => {
+    const workspace = await createTempWorkspace('guren-create-app-cli-sqlite-db-')
+    try {
+      await capturedCommand.run({
+        args: {
+          target: 'lite-app',
+          force: false,
+          mode: 'spa',
+          auth: false,
+          db: 'sqlite',
+          install: false,
+        },
+      })
+
+      const appRoot = join(workspace.dir, 'lite-app')
+      await expect(access(join(appRoot, 'docker-compose.yml'))).rejects.toThrow()
+
+      const packageJson = JSON.parse(await readFile(join(appRoot, 'package.json'), 'utf8')) as {
+        scripts?: Record<string, string>
+        dependencies?: Record<string, string>
+        devDependencies?: Record<string, string>
+      }
+
+      expect(packageJson.scripts?.['db:up']).toBeUndefined()
+      expect(packageJson.dependencies?.postgres).toBeUndefined()
+      expect(packageJson.devDependencies?.postgres).toBeUndefined()
+      expect(packageJson.devDependencies?.mysql2).toBeUndefined()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
 })

--- a/packages/orm/src/migration-utils.test.ts
+++ b/packages/orm/src/migration-utils.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { buildMigrationStatus, listLocalMigrations } from './migration-utils'
+import { buildMigrationStatus, describeConnectionEndpoint, describeMigrationFailure, listLocalMigrations } from './migration-utils'
 import { createSqliteDatabase } from './sqlite'
 
 function writeDrizzleMigration(migrationsDir: string, name: string, sql: string): void {
@@ -121,5 +121,74 @@ describe('createSqliteDatabase resetDatabase/migrationStatus', () => {
     await database.migrateDatabase()
     const remigrated = await database.migrationStatus()
     expect(remigrated[0].applied).toBe(true)
+  })
+})
+
+describe('describeConnectionEndpoint', () => {
+  test('should reduce a connection string to host and port', () => {
+    expect(describeConnectionEndpoint('postgres://guren:guren@localhost:54322/guren')).toBe('localhost:54322')
+  })
+
+  test('should not leak credentials from the connection string', () => {
+    const endpoint = describeConnectionEndpoint('mysql://root:sup3rs3cret@db.internal:33306/app')
+    expect(endpoint).toBe('db.internal:33306')
+    expect(endpoint).not.toContain('sup3rs3cret')
+    expect(endpoint).not.toContain('root')
+  })
+
+  test('should omit the port when the connection string has none', () => {
+    expect(describeConnectionEndpoint('postgres://guren@example.com/guren')).toBe('example.com')
+  })
+
+  test('should return undefined for values that are not URLs', () => {
+    expect(describeConnectionEndpoint('./data/guren.db')).toBeUndefined()
+  })
+})
+
+describe('describeMigrationFailure', () => {
+  test('should report a connection failure instead of the query drizzle happened to be running', () => {
+    // Shape produced by drizzle + postgres-js when the server is unreachable:
+    // the outer message names the migrator's own bookkeeping statement and the
+    // AggregateError cause carries the code but no message at all.
+    const cause = new AggregateError([], '')
+    Object.assign(cause, { code: 'ECONNREFUSED' })
+    const error = new Error('Failed query: CREATE SCHEMA IF NOT EXISTS "drizzle"\nparams: ', { cause })
+
+    const message = describeMigrationFailure(error, 'localhost:54322')
+
+    expect(message).toContain('cannot connect to the database at localhost:54322')
+    expect(message).toContain('ECONNREFUSED')
+    expect(message).not.toContain('CREATE SCHEMA')
+  })
+
+  test('should describe a connection failure without an endpoint', () => {
+    const error = new Error('Failed query: SELECT 1', { cause: Object.assign(new Error(''), { code: 'ENOTFOUND' }) })
+    expect(describeMigrationFailure(error)).toContain('cannot connect to the database (ENOTFOUND)')
+  })
+
+  test('should keep the real SQL error when the database is reachable', () => {
+    const error = new Error('Failed query: ALTER TABLE "posts" ADD COLUMN "slug" text NOT NULL', {
+      cause: new Error('column "slug" of relation "posts" already exists'),
+    })
+
+    const message = describeMigrationFailure(error, 'localhost:54322')
+
+    expect(message).toContain('ALTER TABLE "posts"')
+    expect(message).toContain('column "slug" of relation "posts" already exists')
+  })
+
+  test('should surface a cause nested inside an AggregateError', () => {
+    const error = new Error('outer', { cause: new AggregateError([Object.assign(new Error(''), { code: 'ECONNREFUSED' })], '') })
+    expect(describeMigrationFailure(error, 'db:5432')).toContain('ECONNREFUSED')
+  })
+
+  test('should not loop forever on a self-referencing cause chain', () => {
+    const error = new Error('boom') as Error & { cause?: unknown }
+    error.cause = error
+    expect(describeMigrationFailure(error)).toBe('boom')
+  })
+
+  test('should stringify non-Error rejections', () => {
+    expect(describeMigrationFailure('plain string failure')).toBe('plain string failure')
   })
 })

--- a/packages/orm/src/migration-utils.test.ts
+++ b/packages/orm/src/migration-utils.test.ts
@@ -201,6 +201,13 @@ describe('describeMigrationFailure', () => {
     )
   })
 
+  test('should append the driver code rather than a SQLSTATE on an outer frame', () => {
+    const error = Object.assign(new Error('Failed query: SELECT 1'), { code: '42P06' })
+    error.cause = Object.assign(new Error(''), { code: 'EPIPE' })
+
+    expect(describeMigrationFailure(error)).toBe('Failed query: SELECT 1 (EPIPE)')
+  })
+
   test('should surface a cause nested inside an AggregateError', () => {
     const error = new Error('outer', { cause: new AggregateError([Object.assign(new Error(''), { code: 'ECONNREFUSED' })], '') })
     expect(describeMigrationFailure(error, 'db:5432')).toContain('ECONNREFUSED')

--- a/packages/orm/src/migration-utils.test.ts
+++ b/packages/orm/src/migration-utils.test.ts
@@ -177,6 +177,30 @@ describe('describeMigrationFailure', () => {
     expect(message).toContain('column "slug" of relation "posts" already exists')
   })
 
+  test('should keep the in-flight query when the connection drops mid-migration', () => {
+    // ECONNRESET/EPIPE can hit halfway through a run, so which migration was
+    // executing is the useful part — unlike a server that was never reached.
+    const error = new Error('Failed query: ALTER TABLE "posts" ADD COLUMN "slug" text', {
+      cause: Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }),
+    })
+
+    const message = describeMigrationFailure(error, 'localhost:54322')
+
+    expect(message).toContain('ALTER TABLE "posts"')
+    expect(message).toContain('ECONNRESET')
+    expect(message).not.toContain('cannot connect')
+  })
+
+  test('should append a bare error code when no cause carries a message', () => {
+    const error = new Error('Failed query: ALTER TABLE "posts" ADD COLUMN "slug" text', {
+      cause: Object.assign(new Error(''), { code: 'EPIPE' }),
+    })
+
+    expect(describeMigrationFailure(error, 'localhost:54322')).toBe(
+      'Failed query: ALTER TABLE "posts" ADD COLUMN "slug" text (EPIPE)',
+    )
+  })
+
   test('should surface a cause nested inside an AggregateError', () => {
     const error = new Error('outer', { cause: new AggregateError([Object.assign(new Error(''), { code: 'ECONNREFUSED' })], '') })
     expect(describeMigrationFailure(error, 'db:5432')).toContain('ECONNREFUSED')

--- a/packages/orm/src/migration-utils.test.ts
+++ b/packages/orm/src/migration-utils.test.ts
@@ -177,6 +177,29 @@ describe('describeMigrationFailure', () => {
     expect(message).toContain('column "slug" of relation "posts" already exists')
   })
 
+  test('should treat a mysql2 connect timeout as a connection failure', () => {
+    // mysql2 reports a connect timeout as ETIMEDOUT with syscall 'connect';
+    // a read that times out mid-query does not carry that syscall.
+    const cause = Object.assign(new Error('connect ETIMEDOUT'), { code: 'ETIMEDOUT', syscall: 'connect' })
+    const error = new Error('Failed query: CREATE TABLE `__drizzle_migrations`', { cause })
+
+    const message = describeMigrationFailure(error, 'db.internal:33306')
+
+    expect(message).toBe(
+      'cannot connect to the database at db.internal:33306 (ETIMEDOUT). Is it running and accepting connections?',
+    )
+  })
+
+  test('should keep the in-flight query when a read times out mid-migration', () => {
+    const cause = Object.assign(new Error('read ETIMEDOUT'), { code: 'ETIMEDOUT', syscall: 'read' })
+    const error = new Error('Failed query: ALTER TABLE `posts` ADD COLUMN `slug` text', { cause })
+
+    const message = describeMigrationFailure(error, 'db.internal:33306')
+
+    expect(message).toContain('ALTER TABLE `posts`')
+    expect(message).not.toContain('cannot connect')
+  })
+
   test('should keep the in-flight query when the connection drops mid-migration', () => {
     // ECONNRESET/EPIPE can hit halfway through a run, so which migration was
     // executing is the useful part — unlike a server that was never reached.

--- a/packages/orm/src/migration-utils.test.ts
+++ b/packages/orm/src/migration-utils.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { buildMigrationStatus, describeConnectionEndpoint, describeMigrationFailure, listLocalMigrations } from './migration-utils'
+import { buildMigrationStatus, describeConnectionEndpoint, describeDatabaseFailure, listLocalMigrations } from './migration-utils'
 import { createSqliteDatabase } from './sqlite'
 
 function writeDrizzleMigration(migrationsDir: string, name: string, sql: string): void {
@@ -145,7 +145,7 @@ describe('describeConnectionEndpoint', () => {
   })
 })
 
-describe('describeMigrationFailure', () => {
+describe('describeDatabaseFailure', () => {
   test('should report a connection failure instead of the query drizzle happened to be running', () => {
     // Shape produced by drizzle + postgres-js when the server is unreachable:
     // the outer message names the migrator's own bookkeeping statement and the
@@ -154,7 +154,7 @@ describe('describeMigrationFailure', () => {
     Object.assign(cause, { code: 'ECONNREFUSED' })
     const error = new Error('Failed query: CREATE SCHEMA IF NOT EXISTS "drizzle"\nparams: ', { cause })
 
-    const message = describeMigrationFailure(error, 'localhost:54322')
+    const message = describeDatabaseFailure(error, 'localhost:54322')
 
     expect(message).toContain('cannot connect to the database at localhost:54322')
     expect(message).toContain('ECONNREFUSED')
@@ -163,7 +163,7 @@ describe('describeMigrationFailure', () => {
 
   test('should describe a connection failure without an endpoint', () => {
     const error = new Error('Failed query: SELECT 1', { cause: Object.assign(new Error(''), { code: 'ENOTFOUND' }) })
-    expect(describeMigrationFailure(error)).toContain('cannot connect to the database (ENOTFOUND)')
+    expect(describeDatabaseFailure(error)).toContain('cannot connect to the database (ENOTFOUND)')
   })
 
   test('should keep the real SQL error when the database is reachable', () => {
@@ -171,7 +171,7 @@ describe('describeMigrationFailure', () => {
       cause: new Error('column "slug" of relation "posts" already exists'),
     })
 
-    const message = describeMigrationFailure(error, 'localhost:54322')
+    const message = describeDatabaseFailure(error, 'localhost:54322')
 
     expect(message).toContain('ALTER TABLE "posts"')
     expect(message).toContain('column "slug" of relation "posts" already exists')
@@ -183,7 +183,7 @@ describe('describeMigrationFailure', () => {
     const cause = Object.assign(new Error('connect ETIMEDOUT'), { code: 'ETIMEDOUT', syscall: 'connect' })
     const error = new Error('Failed query: CREATE TABLE `__drizzle_migrations`', { cause })
 
-    const message = describeMigrationFailure(error, 'db.internal:33306')
+    const message = describeDatabaseFailure(error, 'db.internal:33306')
 
     expect(message).toBe(
       'cannot connect to the database at db.internal:33306 (ETIMEDOUT). Is it running and accepting connections?',
@@ -194,7 +194,7 @@ describe('describeMigrationFailure', () => {
     const cause = Object.assign(new Error('read ETIMEDOUT'), { code: 'ETIMEDOUT', syscall: 'read' })
     const error = new Error('Failed query: ALTER TABLE `posts` ADD COLUMN `slug` text', { cause })
 
-    const message = describeMigrationFailure(error, 'db.internal:33306')
+    const message = describeDatabaseFailure(error, 'db.internal:33306')
 
     expect(message).toContain('ALTER TABLE `posts`')
     expect(message).not.toContain('cannot connect')
@@ -207,7 +207,7 @@ describe('describeMigrationFailure', () => {
       cause: Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }),
     })
 
-    const message = describeMigrationFailure(error, 'localhost:54322')
+    const message = describeDatabaseFailure(error, 'localhost:54322')
 
     expect(message).toContain('ALTER TABLE "posts"')
     expect(message).toContain('ECONNRESET')
@@ -219,7 +219,7 @@ describe('describeMigrationFailure', () => {
       cause: Object.assign(new Error(''), { code: 'EPIPE' }),
     })
 
-    expect(describeMigrationFailure(error, 'localhost:54322')).toBe(
+    expect(describeDatabaseFailure(error, 'localhost:54322')).toBe(
       'Failed query: ALTER TABLE "posts" ADD COLUMN "slug" text (EPIPE)',
     )
   })
@@ -228,21 +228,21 @@ describe('describeMigrationFailure', () => {
     const error = Object.assign(new Error('Failed query: SELECT 1'), { code: '42P06' })
     error.cause = Object.assign(new Error(''), { code: 'EPIPE' })
 
-    expect(describeMigrationFailure(error)).toBe('Failed query: SELECT 1 (EPIPE)')
+    expect(describeDatabaseFailure(error)).toBe('Failed query: SELECT 1 (EPIPE)')
   })
 
   test('should surface a cause nested inside an AggregateError', () => {
     const error = new Error('outer', { cause: new AggregateError([Object.assign(new Error(''), { code: 'ECONNREFUSED' })], '') })
-    expect(describeMigrationFailure(error, 'db:5432')).toContain('ECONNREFUSED')
+    expect(describeDatabaseFailure(error, 'db:5432')).toContain('ECONNREFUSED')
   })
 
   test('should not loop forever on a self-referencing cause chain', () => {
     const error = new Error('boom') as Error & { cause?: unknown }
     error.cause = error
-    expect(describeMigrationFailure(error)).toBe('boom')
+    expect(describeDatabaseFailure(error)).toBe('boom')
   })
 
   test('should stringify non-Error rejections', () => {
-    expect(describeMigrationFailure('plain string failure')).toBe('plain string failure')
+    expect(describeDatabaseFailure('plain string failure')).toBe('plain string failure')
   })
 })

--- a/packages/orm/src/migration-utils.ts
+++ b/packages/orm/src/migration-utils.ts
@@ -58,17 +58,26 @@ const PRE_CONNECTION_ERROR_CODES = new Set([
   'ENOTFOUND',
 ])
 
-/** True when this error was raised while establishing the connection. */
-function failedWhileConnecting(error: unknown): boolean {
-  const { code, syscall } = error as { code?: unknown; syscall?: unknown }
-  if (typeof code === 'string' && PRE_CONNECTION_ERROR_CODES.has(code)) {
-    return true
-  }
-  return syscall === 'connect' && typeof code === 'string' && code !== ''
+interface CauseLike {
+  code?: unknown
+  message?: unknown
+  syscall?: unknown
 }
 
-/** Walks the cause chain (and AggregateError members) collecting every nested error. */
-function collectCauses(error: unknown, seen = new Set<unknown>()): unknown[] {
+/** True when this error was raised while establishing the connection. */
+function failedWhileConnecting(error: CauseLike): error is CauseLike & { code: string } {
+  const { code, syscall } = error
+  if (typeof code !== 'string' || code === '') {
+    return false
+  }
+  return PRE_CONNECTION_ERROR_CODES.has(code) || syscall === 'connect'
+}
+
+/**
+ * Walks the cause chain (and AggregateError members) collecting every nested
+ * error, outwards-in. `seen` bounds the walk on self-referencing chains.
+ */
+function collectCauses(error: unknown, seen = new Set<unknown>()): CauseLike[] {
   if (error == null || typeof error !== 'object' || seen.has(error)) {
     return []
   }
@@ -79,11 +88,16 @@ function collectCauses(error: unknown, seen = new Set<unknown>()): unknown[] {
     ...('cause' in error ? [(error as { cause: unknown }).cause] : []),
   ]
 
-  return [error, ...nested.flatMap((child) => collectCauses(child, seen))]
+  return [error as CauseLike, ...nested.flatMap((child) => collectCauses(child, seen))]
+}
+
+/** True when the failure means the database server was never reached. */
+export function isConnectionFailure(error: unknown): boolean {
+  return collectCauses(error).some(failedWhileConnecting)
 }
 
 /**
- * Turns a migration failure into a message that names the actual problem.
+ * Turns a database failure into a message that names the actual problem.
  *
  * Drizzle wraps driver failures in a DrizzleQueryError whose message is the SQL
  * it was running — for a fresh database that is `CREATE SCHEMA IF NOT EXISTS
@@ -92,42 +106,49 @@ function collectCauses(error: unknown, seen = new Set<unknown>()): unknown[] {
  * unreachable server (postgres-js reports `ECONNREFUSED` on `cause` and leaves
  * that error's message empty) or a SQL error whose text also lives on `cause`.
  *
- * `endpoint` is included only as host:port / filename — never the connection
- * string, which carries credentials.
+ * `endpoint` is included only as host:port — never the connection string, which
+ * carries credentials.
  */
-export function describeMigrationFailure(error: unknown, endpoint?: string): string {
+export function describeDatabaseFailure(error: unknown, endpoint?: string): string {
   const causes = collectCauses(error)
-  const codes = causes
-    .map((cause) => (cause as { code?: unknown }).code)
-    .filter((code): code is string => typeof code === 'string' && code !== '')
 
-  const connectFailure = causes.find(failedWhileConnecting) as { code: string } | undefined
+  const connectFailure = causes.find(failedWhileConnecting)
   if (connectFailure) {
     const target = endpoint ? `the database at ${endpoint}` : 'the database'
     return `cannot connect to ${target} (${connectFailure.code}). Is it running and accepting connections?`
   }
 
-  const messages: string[] = []
-  for (const cause of causes) {
-    const message = (cause as { message?: unknown }).message
-    if (typeof message === 'string' && message.trim() !== '' && !messages.includes(message)) {
-      messages.push(message)
-    }
-  }
+  const messages = [
+    ...new Set(
+      causes
+        .map((cause) => cause.message)
+        .filter((message): message is string => typeof message === 'string' && message.trim() !== ''),
+    ),
+  ]
 
   if (messages.length === 0) {
     return error instanceof Error ? error.message : String(error)
   }
 
   // A driver that reports only a code (postgres-js leaves the message empty)
-  // would otherwise leave the outer query text unexplained. collectCauses walks
-  // outwards-in, so the last code is the deepest one — the driver's, not a
-  // SQLSTATE an outer frame happened to copy.
-  if (messages.length === 1 && codes.length > 0) {
-    return `${messages[0]} (${codes[codes.length - 1]})`
+  // would otherwise leave the outer query text unexplained. The deepest code is
+  // the driver's, not a SQLSTATE an outer frame happened to copy.
+  if (messages.length === 1) {
+    const deepestCode = causes.reduce<string | undefined>(
+      (found, cause) => (typeof cause.code === 'string' && cause.code !== '' ? cause.code : found),
+      undefined,
+    )
+    if (deepestCode) {
+      return `${messages[0]} (${deepestCode})`
+    }
   }
 
   return messages.join(' — ')
+}
+
+/** Wraps a migration failure in the message `db:migrate` reports. */
+export function migrationFailure(error: unknown, endpoint?: string): Error {
+  return new Error(`Failed to run database migrations: ${describeDatabaseFailure(error, endpoint)}`)
 }
 
 /**

--- a/packages/orm/src/migration-utils.ts
+++ b/packages/orm/src/migration-utils.ts
@@ -38,6 +38,88 @@ export function warnIgnoredFlatSqlMigrations(migrationsFolder: string): void {
   }
 }
 
+/** Driver error codes that mean the server was never reached. */
+const CONNECTION_ERROR_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EAI_AGAIN',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'EPIPE',
+  'ETIMEDOUT',
+  'CONNECT_TIMEOUT',
+])
+
+/** Walks the cause chain (and AggregateError members) collecting every nested error. */
+function collectCauses(error: unknown, seen = new Set<unknown>()): unknown[] {
+  if (error == null || typeof error !== 'object' || seen.has(error)) {
+    return []
+  }
+  seen.add(error)
+
+  const nested = [
+    ...(Array.isArray((error as { errors?: unknown }).errors) ? ((error as { errors: unknown[] }).errors) : []),
+    ...('cause' in error ? [(error as { cause: unknown }).cause] : []),
+  ]
+
+  return [error, ...nested.flatMap((child) => collectCauses(child, seen))]
+}
+
+/**
+ * Turns a migration failure into a message that names the actual problem.
+ *
+ * Drizzle wraps driver failures in a DrizzleQueryError whose message is the SQL
+ * it was running — for a fresh database that is `CREATE SCHEMA IF NOT EXISTS
+ * "drizzle"`, the migrator's own bookkeeping statement. Reporting only that
+ * message blames a statement the user never wrote for what is usually an
+ * unreachable server (postgres-js reports `ECONNREFUSED` on `cause` and leaves
+ * that error's message empty) or a SQL error whose text also lives on `cause`.
+ *
+ * `endpoint` is included only as host:port / filename — never the connection
+ * string, which carries credentials.
+ */
+export function describeMigrationFailure(error: unknown, endpoint?: string): string {
+  const causes = collectCauses(error)
+
+  const connectionCode = causes
+    .map((cause) => (cause as { code?: unknown }).code)
+    .find((code): code is string => typeof code === 'string' && CONNECTION_ERROR_CODES.has(code))
+
+  if (connectionCode) {
+    const target = endpoint ? `the database at ${endpoint}` : 'the database'
+    return `cannot connect to ${target} (${connectionCode}). Is it running and accepting connections?`
+  }
+
+  const messages: string[] = []
+  for (const cause of causes) {
+    const message = (cause as { message?: unknown }).message
+    if (typeof message === 'string' && message.trim() !== '' && !messages.includes(message)) {
+      messages.push(message)
+    }
+  }
+
+  if (messages.length === 0) {
+    return error instanceof Error ? error.message : String(error)
+  }
+
+  return messages.join(' — ')
+}
+
+/**
+ * Reduces a connection string to host:port for error messages, dropping the
+ * credentials it embeds. Returns undefined when the value does not parse.
+ */
+export function describeConnectionEndpoint(connectionString: string): string | undefined {
+  try {
+    const { hostname, port } = new URL(connectionString)
+    if (!hostname) return undefined
+    return port ? `${hostname}:${port}` : hostname
+  } catch {
+    return undefined
+  }
+}
+
 export interface LocalMigrationEntry {
   /** Folder name, e.g. 20260710221915_create_users_table */
   name: string

--- a/packages/orm/src/migration-utils.ts
+++ b/packages/orm/src/migration-utils.ts
@@ -106,9 +106,11 @@ export function describeMigrationFailure(error: unknown, endpoint?: string): str
   }
 
   // A driver that reports only a code (postgres-js leaves the message empty)
-  // would otherwise leave the outer query text unexplained.
+  // would otherwise leave the outer query text unexplained. collectCauses walks
+  // outwards-in, so the last code is the deepest one — the driver's, not a
+  // SQLSTATE an outer frame happened to copy.
   if (messages.length === 1 && codes.length > 0) {
-    return `${messages[0]} (${codes[0]})`
+    return `${messages[0]} (${codes[codes.length - 1]})`
   }
 
   return messages.join(' — ')

--- a/packages/orm/src/migration-utils.ts
+++ b/packages/orm/src/migration-utils.ts
@@ -151,6 +151,11 @@ export function migrationFailure(error: unknown, endpoint?: string): Error {
   return new Error(`Failed to run database migrations: ${describeDatabaseFailure(error, endpoint)}`)
 }
 
+/** Wraps a seeding failure in the message `db:seed` reports. */
+export function seedFailure(error: unknown, endpoint?: string): Error {
+  return new Error(`Failed to seed the database: ${describeDatabaseFailure(error, endpoint)}`)
+}
+
 /**
  * Reduces a connection string to host:port for error messages, dropping the
  * credentials it embeds. Returns undefined when the value does not parse.

--- a/packages/orm/src/migration-utils.ts
+++ b/packages/orm/src/migration-utils.ts
@@ -43,6 +43,11 @@ export function warnIgnoredFlatSqlMigrations(migrationsFolder: string): void {
  * drizzle happened to be sending is noise. Deliberately excludes mid-flight
  * failures like ECONNRESET and EPIPE — those can hit halfway through a
  * migration run, where the query text is the useful part.
+ *
+ * ETIMEDOUT is absent for the same reason, and is instead recognised through
+ * `syscall: 'connect'` below: mysql2 reports a connect timeout as
+ * `ETIMEDOUT`/`syscall: 'connect'`, while a read that times out mid-query does
+ * not carry that syscall.
  */
 const PRE_CONNECTION_ERROR_CODES = new Set([
   'CONNECT_TIMEOUT',
@@ -52,6 +57,15 @@ const PRE_CONNECTION_ERROR_CODES = new Set([
   'ENETUNREACH',
   'ENOTFOUND',
 ])
+
+/** True when this error was raised while establishing the connection. */
+function failedWhileConnecting(error: unknown): boolean {
+  const { code, syscall } = error as { code?: unknown; syscall?: unknown }
+  if (typeof code === 'string' && PRE_CONNECTION_ERROR_CODES.has(code)) {
+    return true
+  }
+  return syscall === 'connect' && typeof code === 'string' && code !== ''
+}
 
 /** Walks the cause chain (and AggregateError members) collecting every nested error. */
 function collectCauses(error: unknown, seen = new Set<unknown>()): unknown[] {
@@ -87,10 +101,10 @@ export function describeMigrationFailure(error: unknown, endpoint?: string): str
     .map((cause) => (cause as { code?: unknown }).code)
     .filter((code): code is string => typeof code === 'string' && code !== '')
 
-  const preConnectionCode = codes.find((code) => PRE_CONNECTION_ERROR_CODES.has(code))
-  if (preConnectionCode) {
+  const connectFailure = causes.find(failedWhileConnecting) as { code: string } | undefined
+  if (connectFailure) {
     const target = endpoint ? `the database at ${endpoint}` : 'the database'
-    return `cannot connect to ${target} (${preConnectionCode}). Is it running and accepting connections?`
+    return `cannot connect to ${target} (${connectFailure.code}). Is it running and accepting connections?`
   }
 
   const messages: string[] = []

--- a/packages/orm/src/migration-utils.ts
+++ b/packages/orm/src/migration-utils.ts
@@ -38,17 +38,19 @@ export function warnIgnoredFlatSqlMigrations(migrationsFolder: string): void {
   }
 }
 
-/** Driver error codes that mean the server was never reached. */
-const CONNECTION_ERROR_CODES = new Set([
-  'ECONNREFUSED',
-  'ECONNRESET',
+/**
+ * Driver error codes that mean the server was never reached, so the statement
+ * drizzle happened to be sending is noise. Deliberately excludes mid-flight
+ * failures like ECONNRESET and EPIPE — those can hit halfway through a
+ * migration run, where the query text is the useful part.
+ */
+const PRE_CONNECTION_ERROR_CODES = new Set([
+  'CONNECT_TIMEOUT',
   'EAI_AGAIN',
+  'ECONNREFUSED',
   'EHOSTUNREACH',
   'ENETUNREACH',
   'ENOTFOUND',
-  'EPIPE',
-  'ETIMEDOUT',
-  'CONNECT_TIMEOUT',
 ])
 
 /** Walks the cause chain (and AggregateError members) collecting every nested error. */
@@ -81,14 +83,14 @@ function collectCauses(error: unknown, seen = new Set<unknown>()): unknown[] {
  */
 export function describeMigrationFailure(error: unknown, endpoint?: string): string {
   const causes = collectCauses(error)
-
-  const connectionCode = causes
+  const codes = causes
     .map((cause) => (cause as { code?: unknown }).code)
-    .find((code): code is string => typeof code === 'string' && CONNECTION_ERROR_CODES.has(code))
+    .filter((code): code is string => typeof code === 'string' && code !== '')
 
-  if (connectionCode) {
+  const preConnectionCode = codes.find((code) => PRE_CONNECTION_ERROR_CODES.has(code))
+  if (preConnectionCode) {
     const target = endpoint ? `the database at ${endpoint}` : 'the database'
-    return `cannot connect to ${target} (${connectionCode}). Is it running and accepting connections?`
+    return `cannot connect to ${target} (${preConnectionCode}). Is it running and accepting connections?`
   }
 
   const messages: string[] = []
@@ -101,6 +103,12 @@ export function describeMigrationFailure(error: unknown, endpoint?: string): str
 
   if (messages.length === 0) {
     return error instanceof Error ? error.message : String(error)
+  }
+
+  // A driver that reports only a code (postgres-js leaves the message empty)
+  // would otherwise leave the outer query text unexplained.
+  if (messages.length === 1 && codes.length > 0) {
+    return `${messages[0]} (${codes[0]})`
   }
 
   return messages.join(' — ')

--- a/packages/orm/src/mysql.ts
+++ b/packages/orm/src/mysql.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { hotReloadKey, releaseActiveConnection, replaceActiveConnection } from './active-connections'
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
-import { buildMigrationStatus, describeConnectionEndpoint, describeMigrationFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
+import { buildMigrationStatus, describeConnectionEndpoint, describeDatabaseFailure, isConnectionFailure, migrationFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
 import { runSeeders } from './seeder'
 
 type ConnectionResolver = string | (() => string | undefined)
@@ -88,7 +88,9 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
       return migrationsPromise
     }
 
-    // Captured for the error handler below, which runs outside this closure.
+    // Resolved inside the IIFE below: resolveConnectionString() throws when no
+    // connection string is configured, so it must not run before the
+    // no-migrations early return. The catch handler needs it afterwards.
     let endpoint: string | undefined
 
     const promise = (async (): Promise<void> => {
@@ -118,7 +120,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
 
     migrationsPromise = promise.catch((error) => {
       migrationsPromise = undefined
-      throw new Error(`Failed to run database migrations: ${describeMigrationFailure(error, endpoint)}`)
+      throw migrationFailure(error, endpoint)
     })
 
     await migrationsPromise
@@ -194,9 +196,10 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
 
   async function withAdminDb<T>(callback: (db: MySql2Database) => Promise<T>): Promise<T> {
     const { drizzle } = await loadMySqlModules()
+    const url = resolveConnectionString()
     const adminDb = drizzle({
       connection: {
-        uri: resolveConnectionString(),
+        uri: url,
         ...clientOptions,
       },
       mode: 'default',
@@ -204,6 +207,9 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
 
     try {
       return await callback(adminDb)
+    } catch (error) {
+      // Rethrowing raw would surface the driver's bare code with no message.
+      throw new Error(describeDatabaseFailure(error, describeConnectionEndpoint(url)))
     } finally {
       await closeClient(adminDb)
     }
@@ -242,7 +248,11 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
           sql.raw('SELECT name, applied_at FROM __drizzle_migrations'),
         )) as unknown as [Array<{ name: string | null; applied_at: string | Date | null }>]
         return rows.map((row) => ({ name: row.name, appliedAt: row.applied_at }))
-      } catch {
+      } catch (error) {
+        // An unreachable server reaches this catch too, and reporting it as
+        // "nothing applied" makes db:status indistinguishable from a database
+        // that is up with no migrations run.
+        if (isConnectionFailure(error)) throw error
         // Tracker table does not exist yet — nothing applied.
         return []
       }

--- a/packages/orm/src/mysql.ts
+++ b/packages/orm/src/mysql.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { hotReloadKey, releaseActiveConnection, replaceActiveConnection } from './active-connections'
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
-import { buildMigrationStatus, describeConnectionEndpoint, describeDatabaseFailure, isConnectionFailure, migrationFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
+import { buildMigrationStatus, describeConnectionEndpoint, describeDatabaseFailure, isConnectionFailure, migrationFailure, seedFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
 import { runSeeders } from './seeder'
 
 type ConnectionResolver = string | (() => string | undefined)
@@ -191,7 +191,11 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
     }
 
     const db = await getDatabase()
-    await runSeeders(db as unknown as Parameters<typeof runSeeders>[0], resolvedSeedersFolder)
+    try {
+      await runSeeders(db as unknown as Parameters<typeof runSeeders>[0], resolvedSeedersFolder)
+    } catch (error) {
+      throw seedFailure(error, describeConnectionEndpoint(resolveConnectionString()))
+    }
   }
 
   async function withAdminDb<T>(callback: (db: MySql2Database) => Promise<T>): Promise<T> {

--- a/packages/orm/src/mysql.ts
+++ b/packages/orm/src/mysql.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { hotReloadKey, releaseActiveConnection, replaceActiveConnection } from './active-connections'
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
-import { buildMigrationStatus, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
+import { buildMigrationStatus, describeConnectionEndpoint, describeMigrationFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
 import { runSeeders } from './seeder'
 
 type ConnectionResolver = string | (() => string | undefined)
@@ -88,6 +88,9 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
       return migrationsPromise
     }
 
+    // Captured for the error handler below, which runs outside this closure.
+    let endpoint: string | undefined
+
     const promise = (async (): Promise<void> => {
       if (!hasDrizzleMigrations(resolvedMigrationsFolder)) {
         warnIgnoredFlatSqlMigrations(resolvedMigrationsFolder)
@@ -96,6 +99,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
 
       const { drizzle, migrate } = await loadMySqlModules()
       const url = resolveConnectionString()
+      endpoint = describeConnectionEndpoint(url)
       const migrationDb = drizzle({
         connection: {
           uri: url,
@@ -114,8 +118,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
 
     migrationsPromise = promise.catch((error) => {
       migrationsPromise = undefined
-      const reason = error instanceof Error ? error.message : String(error)
-      throw new Error(`Failed to run database migrations: ${reason}`)
+      throw new Error(`Failed to run database migrations: ${describeMigrationFailure(error, endpoint)}`)
     })
 
     await migrationsPromise

--- a/packages/orm/src/postgres.ts
+++ b/packages/orm/src/postgres.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url'
 import type postgres from 'postgres'
 import { hotReloadKey, releaseActiveConnection, replaceActiveConnection } from './active-connections'
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
-import { buildMigrationStatus, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
+import { buildMigrationStatus, describeConnectionEndpoint, describeMigrationFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
 import { runSeeders } from './seeder'
 
 type ConnectionResolver = string | (() => string | undefined)
@@ -90,6 +90,9 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
       return migrationsPromise
     }
 
+    // Captured for the error handler below, which runs outside this closure.
+    let endpoint: string | undefined
+
     const promise = (async (): Promise<void> => {
       if (!hasDrizzleMigrations(resolvedMigrationsFolder)) {
         warnIgnoredFlatSqlMigrations(resolvedMigrationsFolder)
@@ -98,6 +101,7 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
 
       const { drizzle, migrate, postgres: postgresFactory } = await loadPostgresModules()
       const url = resolveConnectionString()
+      endpoint = describeConnectionEndpoint(url)
       const migrationClient = postgresFactory(url, {
         max: 1,
         ...clientOptions,
@@ -113,8 +117,7 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
 
     migrationsPromise = promise.catch((error) => {
       migrationsPromise = undefined
-      const reason = error instanceof Error ? error.message : String(error)
-      throw new Error(`Failed to run database migrations: ${reason}`)
+      throw new Error(`Failed to run database migrations: ${describeMigrationFailure(error, endpoint)}`)
     })
 
     await migrationsPromise

--- a/packages/orm/src/postgres.ts
+++ b/packages/orm/src/postgres.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url'
 import type postgres from 'postgres'
 import { hotReloadKey, releaseActiveConnection, replaceActiveConnection } from './active-connections'
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
-import { buildMigrationStatus, describeConnectionEndpoint, describeDatabaseFailure, isConnectionFailure, migrationFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
+import { buildMigrationStatus, describeConnectionEndpoint, describeDatabaseFailure, isConnectionFailure, migrationFailure, seedFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
 import { runSeeders } from './seeder'
 
 type ConnectionResolver = string | (() => string | undefined)
@@ -191,7 +191,11 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
     }
 
     const db = await getDatabase()
-    await runSeeders(db, resolvedSeedersFolder)
+    try {
+      await runSeeders(db, resolvedSeedersFolder)
+    } catch (error) {
+      throw seedFailure(error, describeConnectionEndpoint(resolveConnectionString()))
+    }
   }
 
   async function withAdminClient<T>(callback: (client: ReturnType<typeof postgres>) => Promise<T>): Promise<T> {

--- a/packages/orm/src/postgres.ts
+++ b/packages/orm/src/postgres.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url'
 import type postgres from 'postgres'
 import { hotReloadKey, releaseActiveConnection, replaceActiveConnection } from './active-connections'
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
-import { buildMigrationStatus, describeConnectionEndpoint, describeMigrationFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
+import { buildMigrationStatus, describeConnectionEndpoint, describeDatabaseFailure, isConnectionFailure, migrationFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
 import { runSeeders } from './seeder'
 
 type ConnectionResolver = string | (() => string | undefined)
@@ -90,7 +90,9 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
       return migrationsPromise
     }
 
-    // Captured for the error handler below, which runs outside this closure.
+    // Resolved inside the IIFE below: resolveConnectionString() throws when no
+    // connection string is configured, so it must not run before the
+    // no-migrations early return. The catch handler needs it afterwards.
     let endpoint: string | undefined
 
     const promise = (async (): Promise<void> => {
@@ -117,7 +119,7 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
 
     migrationsPromise = promise.catch((error) => {
       migrationsPromise = undefined
-      throw new Error(`Failed to run database migrations: ${describeMigrationFailure(error, endpoint)}`)
+      throw migrationFailure(error, endpoint)
     })
 
     await migrationsPromise
@@ -194,12 +196,17 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
 
   async function withAdminClient<T>(callback: (client: ReturnType<typeof postgres>) => Promise<T>): Promise<T> {
     const { postgres: postgresFactory } = await loadPostgresModules()
-    const adminClient = postgresFactory(resolveConnectionString(), {
+    const url = resolveConnectionString()
+    const adminClient = postgresFactory(url, {
       max: 1,
       ...clientOptions,
     })
     try {
       return await callback(adminClient)
+    } catch (error) {
+      // postgres-js reports an unreachable server as an AggregateError whose
+      // message is empty, so rethrowing raw prints a bare "ERROR" line.
+      throw new Error(describeDatabaseFailure(error, describeConnectionEndpoint(url)))
     } finally {
       await adminClient.end({ timeout: 0 })
     }
@@ -227,7 +234,11 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
           const record = row as unknown as { name: string | null }
           return { name: record.name, appliedAt: null }
         })
-      } catch {
+      } catch (error) {
+        // An unreachable server reaches this catch too, and reporting it as
+        // "nothing applied" makes db:status indistinguishable from a database
+        // that is up with no migrations run.
+        if (isConnectionFailure(error)) throw error
         // Tracker table does not exist yet — nothing applied.
         return []
       }

--- a/packages/orm/src/sqlite.ts
+++ b/packages/orm/src/sqlite.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { hotReloadKey, releaseActiveConnection, replaceActiveConnection } from './active-connections'
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
-import { buildMigrationStatus, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
+import { buildMigrationStatus, describeMigrationFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
 import { runSeeders } from './seeder'
 
 type ConnectionResolver = string | (() => string | undefined)
@@ -132,8 +132,8 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
 
     migrationsPromise = migrationsPromise.catch((error) => {
       migrationsPromise = undefined
-      const reason = error instanceof Error ? error.message : String(error)
-      throw new Error(`Failed to run database migrations: ${reason}`)
+      // No endpoint: a SQLite file has no host, so only the cause chain adds signal.
+      throw new Error(`Failed to run database migrations: ${describeMigrationFailure(error)}`)
     })
 
     await migrationsPromise

--- a/packages/orm/src/sqlite.ts
+++ b/packages/orm/src/sqlite.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { hotReloadKey, releaseActiveConnection, replaceActiveConnection } from './active-connections'
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
-import { buildMigrationStatus, describeMigrationFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
+import { buildMigrationStatus, migrationFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
 import { runSeeders } from './seeder'
 
 type ConnectionResolver = string | (() => string | undefined)
@@ -133,7 +133,7 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
     migrationsPromise = migrationsPromise.catch((error) => {
       migrationsPromise = undefined
       // No endpoint: a SQLite file has no host, so only the cause chain adds signal.
-      throw new Error(`Failed to run database migrations: ${describeMigrationFailure(error)}`)
+      throw migrationFailure(error)
     })
 
     await migrationsPromise

--- a/packages/orm/src/sqlite.ts
+++ b/packages/orm/src/sqlite.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { hotReloadKey, releaseActiveConnection, replaceActiveConnection } from './active-connections'
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
-import { buildMigrationStatus, migrationFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
+import { buildMigrationStatus, migrationFailure, seedFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
 import { runSeeders } from './seeder'
 
 type ConnectionResolver = string | (() => string | undefined)
@@ -199,10 +199,15 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
         throw new Error('No seeders folder configured. Provide "seedersFolder" when calling createSqliteDatabase().')
       }
       const database = await ensureDatabase()
-      await runSeeders(
-        database as Parameters<typeof runSeeders>[0],
-        resolvedSeedersFolder,
-      )
+      try {
+        // No endpoint: a SQLite file has no host, so only the cause chain adds signal.
+        await runSeeders(
+          database as Parameters<typeof runSeeders>[0],
+          resolvedSeedersFolder,
+        )
+      } catch (error) {
+        throw seedFailure(error)
+      }
     },
   }
 }

--- a/packages/orm/tests/mysql.test.ts
+++ b/packages/orm/tests/mysql.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it, mock } from 'bun:test'
+import { afterEach, describe, expect, it, mock } from 'bun:test'
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { DrizzleAdapter } from '../src/adapters/drizzle-adapter'
 
+let executeImpl: () => Promise<unknown> = async () => [[]]
 const drizzleMock = mock((config: unknown) => ({
   $client: {
     end: mock((cb?: (err?: unknown) => void) => {
@@ -11,6 +12,7 @@ const drizzleMock = mock((config: unknown) => ({
       return undefined
     }),
   },
+  execute: () => executeImpl(),
   config,
 }))
 const migrateMock = mock(async () => {})
@@ -38,6 +40,10 @@ function createMigrationsFolder(withMigrations: boolean): string {
 }
 
 describe('createMySqlDatabase', () => {
+  afterEach(() => {
+    executeImpl = async () => [[]]
+  })
+
   it('runs migrations and returns a configured database', async () => {
     const database = createMySqlDatabase({
       migrationsFolder: createMigrationsFolder(true),
@@ -121,6 +127,41 @@ describe('createMySqlDatabase', () => {
     // Canary: keeps the credential check alive if the assertion above is
     // ever loosened from toBe to toContain.
     expect(error?.message).not.toContain('hunter2')
+  })
+
+  it('reports an unreachable server from db:status instead of calling every migration pending', async () => {
+    const database = createMySqlDatabase({
+      migrationsFolder: createMigrationsFolder(true),
+      connectionString: () => 'mysql://guren:hunter2@db.internal:33306/guren',
+    })
+
+    executeImpl = async () => {
+      throw Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED', syscall: 'connect' })
+    }
+
+    const error = await database.migrationStatus().then(
+      () => null,
+      (reason: unknown) => reason as Error,
+    )
+
+    expect(error?.message).toBe(
+      'cannot connect to the database at db.internal:33306 (ECONNREFUSED). Is it running and accepting connections?',
+    )
+  })
+
+  it('still reports nothing applied when only the tracker table is missing', async () => {
+    const database = createMySqlDatabase({
+      migrationsFolder: createMigrationsFolder(true),
+      connectionString: () => 'mysql://guren:hunter2@db.internal:33306/guren',
+    })
+
+    executeImpl = async () => {
+      throw Object.assign(new Error("Table 'guren.__drizzle_migrations' doesn't exist"), { code: 'ER_NO_SUCH_TABLE' })
+    }
+
+    expect(await database.migrationStatus()).toEqual([
+      { name: '20240101000000_init', applied: false, appliedAt: null },
+    ])
   })
 
   it('throws when seeders folder is missing', async () => {

--- a/packages/orm/tests/mysql.test.ts
+++ b/packages/orm/tests/mysql.test.ts
@@ -98,6 +98,30 @@ describe('createMySqlDatabase', () => {
     expect(migrateMock).toHaveBeenCalled()
   })
 
+  it('reports an unreachable server instead of the query drizzle was running', async () => {
+    const database = createMySqlDatabase({
+      migrationsFolder: createMigrationsFolder(true),
+      connectionString: () => 'mysql://guren:hunter2@db.internal:33306/guren',
+    })
+
+    migrateMock.mockImplementationOnce(async () => {
+      throw new Error('Failed query: CREATE TABLE `__drizzle_migrations`', {
+        cause: Object.assign(new Error(''), { code: 'ECONNREFUSED' }),
+      })
+    })
+
+    const error = await database.migrateDatabase().then(
+      () => null,
+      (reason: unknown) => reason as Error,
+    )
+
+    expect(error?.message).toBe(
+      'Failed to run database migrations: cannot connect to the database at db.internal:33306 (ECONNREFUSED). Is it running and accepting connections?',
+    )
+    // The connection string's password must never reach the log.
+    expect(error?.message).not.toContain('hunter2')
+  })
+
   it('throws when seeders folder is missing', async () => {
     const database = createMySqlDatabase({
       migrationsFolder: createMigrationsFolder(true),

--- a/packages/orm/tests/mysql.test.ts
+++ b/packages/orm/tests/mysql.test.ts
@@ -118,7 +118,8 @@ describe('createMySqlDatabase', () => {
     expect(error?.message).toBe(
       'Failed to run database migrations: cannot connect to the database at db.internal:33306 (ECONNREFUSED). Is it running and accepting connections?',
     )
-    // The connection string's password must never reach the log.
+    // Canary: keeps the credential check alive if the assertion above is
+    // ever loosened from toBe to toContain.
     expect(error?.message).not.toContain('hunter2')
   })
 

--- a/packages/orm/tests/postgres.test.ts
+++ b/packages/orm/tests/postgres.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock } from 'bun:test'
+import { afterEach, describe, expect, it, mock } from 'bun:test'
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -41,6 +41,10 @@ function createMigrationsFolder(withMigrations: boolean): string {
 }
 
 describe('createPostgresDatabase', () => {
+  afterEach(() => {
+    unsafeImpl = async () => []
+  })
+
   it('runs migrations and returns a configured database', async () => {
     const database = createPostgresDatabase({
       migrationsFolder: createMigrationsFolder(true),
@@ -161,7 +165,6 @@ describe('createPostgresDatabase', () => {
       () => null,
       (reason: unknown) => reason as Error,
     )
-    unsafeImpl = async () => []
 
     expect(error?.message).toBe(
       'cannot connect to the database at db.internal:54322 (ECONNREFUSED). Is it running and accepting connections?',
@@ -180,7 +183,6 @@ describe('createPostgresDatabase', () => {
     }
 
     const status = await database.migrationStatus()
-    unsafeImpl = async () => []
 
     expect(status).toEqual([{ name: '20240101000000_init', applied: false, appliedAt: null }])
   })
@@ -199,11 +201,38 @@ describe('createPostgresDatabase', () => {
       () => null,
       (reason: unknown) => reason as Error,
     )
-    unsafeImpl = async () => []
 
     expect(error?.message).toBe(
       'cannot connect to the database at db.internal:54322 (ECONNREFUSED). Is it running and accepting connections?',
     )
+  })
+
+  it('describes a seeder failure instead of leaving the driver message on the cause', async () => {
+    const seedersFolder = mkdtempSync(join(tmpdir(), 'guren-orm-seeders-'))
+    writeFileSync(
+      join(seedersFolder, 'BrokenSeeder.ts'),
+      'export default async function run() {\n' +
+        "  throw new Error('Failed query: INSERT INTO posts (title) VALUES ($1)', {\n" +
+        "    cause: new Error('null value in column \"body\" violates not-null constraint'),\n" +
+        '  })\n' +
+        '}\n',
+    )
+
+    const database = createPostgresDatabase({
+      migrationsFolder: createMigrationsFolder(true),
+      seedersFolder,
+      connectionString: () => 'postgres://guren:hunter2@db.internal:54322/guren',
+    })
+
+    const error = await database.seedDatabase().then(
+      () => null,
+      (reason: unknown) => reason as Error,
+    )
+
+    expect(error?.message).toContain('Failed to seed the database:')
+    expect(error?.message).toContain('INSERT INTO posts')
+    expect(error?.message).toContain('violates not-null constraint')
+    expect(error?.message).not.toContain('hunter2')
   })
 
   it('throws when seeders folder is missing', async () => {

--- a/packages/orm/tests/postgres.test.ts
+++ b/packages/orm/tests/postgres.test.ts
@@ -94,6 +94,53 @@ describe('createPostgresDatabase', () => {
     expect(migrateMock).toHaveBeenCalled()
   })
 
+  it('reports an unreachable server instead of the query drizzle was running', async () => {
+    const database = createPostgresDatabase({
+      migrationsFolder: createMigrationsFolder(true),
+      connectionString: () => 'postgres://guren:hunter2@db.internal:54322/guren',
+    })
+
+    // Shape drizzle + postgres-js produce when the server is not reachable: the
+    // outer message names the migrator's own bookkeeping statement, and the
+    // AggregateError cause carries the code with no message of its own.
+    const cause = Object.assign(new AggregateError([], ''), { code: 'ECONNREFUSED' })
+    migrateMock.mockImplementationOnce(async () => {
+      throw new Error('Failed query: CREATE SCHEMA IF NOT EXISTS "drizzle"\nparams: ', { cause })
+    })
+
+    const error = await database.migrateDatabase().then(
+      () => null,
+      (reason: unknown) => reason as Error,
+    )
+
+    expect(error?.message).toBe(
+      'Failed to run database migrations: cannot connect to the database at db.internal:54322 (ECONNREFUSED). Is it running and accepting connections?',
+    )
+    // The connection string's password must never reach the log.
+    expect(error?.message).not.toContain('hunter2')
+  })
+
+  it('keeps the failing statement when the server is reachable', async () => {
+    const database = createPostgresDatabase({
+      migrationsFolder: createMigrationsFolder(true),
+      connectionString: () => 'postgres://guren:hunter2@db.internal:54322/guren',
+    })
+
+    migrateMock.mockImplementationOnce(async () => {
+      throw new Error('Failed query: ALTER TABLE "posts" ADD COLUMN "slug" text', {
+        cause: new Error('column "slug" of relation "posts" already exists'),
+      })
+    })
+
+    const error = await database.migrateDatabase().then(
+      () => null,
+      (reason: unknown) => reason as Error,
+    )
+
+    expect(error?.message).toContain('ALTER TABLE "posts"')
+    expect(error?.message).toContain('column "slug" of relation "posts" already exists')
+  })
+
   it('throws when seeders folder is missing', async () => {
     const database = createPostgresDatabase({
       migrationsFolder: createMigrationsFolder(true),

--- a/packages/orm/tests/postgres.test.ts
+++ b/packages/orm/tests/postgres.test.ts
@@ -8,8 +8,10 @@ const drizzleMock = mock((config: Record<string, unknown>) => ({
   config,
 }))
 const migrateMock = mock(async () => {})
+let unsafeImpl: (query: string) => Promise<unknown[]> = async () => []
 const postgresMock = mock((_url: string, _options: Record<string, unknown>) => ({
   end: mock(async () => {}),
+  unsafe: (query: string) => unsafeImpl(query),
 }))
 
 await mock.module('drizzle-orm/postgres-js', () => ({
@@ -116,7 +118,8 @@ describe('createPostgresDatabase', () => {
     expect(error?.message).toBe(
       'Failed to run database migrations: cannot connect to the database at db.internal:54322 (ECONNREFUSED). Is it running and accepting connections?',
     )
-    // The connection string's password must never reach the log.
+    // Canary: keeps the credential check alive if the assertion above is
+    // ever loosened from toBe to toContain.
     expect(error?.message).not.toContain('hunter2')
   })
 
@@ -139,6 +142,68 @@ describe('createPostgresDatabase', () => {
 
     expect(error?.message).toContain('ALTER TABLE "posts"')
     expect(error?.message).toContain('column "slug" of relation "posts" already exists')
+  })
+
+  it('reports an unreachable server from db:status instead of calling every migration pending', async () => {
+    const migrationsFolder = createMigrationsFolder(true)
+    const database = createPostgresDatabase({
+      migrationsFolder,
+      connectionString: () => 'postgres://guren:hunter2@db.internal:54322/guren',
+    })
+
+    // postgres-js reports an unreachable server as a message-less AggregateError,
+    // which the tracker-table catch would otherwise read as "nothing applied".
+    unsafeImpl = async () => {
+      throw Object.assign(new AggregateError([], ''), { code: 'ECONNREFUSED' })
+    }
+
+    const error = await database.migrationStatus().then(
+      () => null,
+      (reason: unknown) => reason as Error,
+    )
+    unsafeImpl = async () => []
+
+    expect(error?.message).toBe(
+      'cannot connect to the database at db.internal:54322 (ECONNREFUSED). Is it running and accepting connections?',
+    )
+  })
+
+  it('still reports nothing applied when only the tracker table is missing', async () => {
+    const migrationsFolder = createMigrationsFolder(true)
+    const database = createPostgresDatabase({
+      migrationsFolder,
+      connectionString: () => 'postgres://guren:hunter2@db.internal:54322/guren',
+    })
+
+    unsafeImpl = async () => {
+      throw Object.assign(new Error('relation "drizzle.__drizzle_migrations" does not exist'), { code: '42P01' })
+    }
+
+    const status = await database.migrationStatus()
+    unsafeImpl = async () => []
+
+    expect(status).toEqual([{ name: '20240101000000_init', applied: false, appliedAt: null }])
+  })
+
+  it('describes an unreachable server when resetting rather than throwing a message-less error', async () => {
+    const database = createPostgresDatabase({
+      migrationsFolder: createMigrationsFolder(true),
+      connectionString: () => 'postgres://guren:hunter2@db.internal:54322/guren',
+    })
+
+    unsafeImpl = async () => {
+      throw Object.assign(new AggregateError([], ''), { code: 'ECONNREFUSED' })
+    }
+
+    const error = await database.resetDatabase().then(
+      () => null,
+      (reason: unknown) => reason as Error,
+    )
+    unsafeImpl = async () => []
+
+    expect(error?.message).toBe(
+      'cannot connect to the database at db.internal:54322 (ECONNREFUSED). Is it running and accepting connections?',
+    )
   })
 
   it('throws when seeders folder is missing', async () => {


### PR DESCRIPTION
## Summary

Following the blog tutorial with PostgreSQL, `bun run db:migrate` against an unreachable database failed with:

```
Failed to run database migrations: Failed query: CREATE SCHEMA IF NOT EXISTS "drizzle"
```

drizzle wraps driver failures in a `DrizzleQueryError` whose `message` is the SQL it was running — here the migrator's own bookkeeping statement. The real driver error (`ECONNREFUSED`) lives on `error.cause`, and postgres-js leaves that cause's own `message` empty, so the actual problem was silently discarded.

- **`packages/orm`**: `describeDatabaseFailure()` walks the full cause chain (including `AggregateError.errors[]`, with a cycle guard) and reports a connection failure by code + host:port when the server was never reached, or joins the nested SQL/driver messages when it was. Wired into all entry points that hit the driver — `db:migrate`, `db:status`, `db:reset`, and `db:seed` — across the Postgres, MySQL, and SQLite drivers. `db:status` previously read an unreachable server as "tracker table doesn't exist" and reported every migration pending with exit 0; `db:reset` printed a bare `ERROR` line with nothing after it.
- **`create-guren-app`**: templates listed the selected driver in both `dependencies` and `devDependencies`, so `bun install` warned about a duplicate dependency on the first command a new project runs — fixed. Scaffolding with Postgres/MySQL now also writes `db:up`/`db:down` scripts next to the generated `docker-compose.yml` (the agent harness's `db-manage` skill already told agents to run `bun run db:up`, which didn't exist).
- **Docs**: troubleshooting guides updated for the new error message and get a diagnostic step for a Docker Desktop failure mode where a container reports `Up` but never actually published its port to the host (root cause of the original report).

## Also found while verifying

MySQL is currently broken with the pinned `drizzle-orm@1.0.0-rc.4` + `mysql2@3.20.0` — any query crashes inside the mysql2 adapter (`client.config.supportBigNumbers`) before a connection is even attempted, reachable host or not. Filed separately; not fixed in this PR. The CLI also double-prints every error (upstream in citty's `runMain`); also filed separately.

## Test plan

- [x] `bun run build:clean && bun run typecheck && bun run test` — all green (2772 tests)
- [x] `bun run audit:docs` / `bun run audit:core-first` — pass
- [x] Reproduced the original failure against a real PostgreSQL instance (server down, bad SQL with server up, DNS failure, mid-migration `ECONNRESET`/`ETIMEDOUT`) and confirmed the new messages
- [x] Scaffolded fresh Postgres and SQLite apps end-to-end (`bun install`, `bun run typecheck`) to confirm no duplicate-dependency warning and correct `db:up`/`db:down` presence
- [x] Mutation-tested every new code path (removed the fix, confirmed the corresponding test fails) for the connection-endpoint wiring, the mid-flight-vs-connect classification, and the `db:status`/`db:reset`/`db:seed` reach fixes
