### PR TITLE
fix(cli): report a failing command's error once

### DIFF
--- a/.changeset/cli-single-error-output.md
+++ b/.changeset/cli-single-error-output.md
@@ -9,3 +9,7 @@ bare message — and then exits the process itself, so the CLI's own error
 handler never ran. The root command is now wired through a local wrapper that
 keeps `--help`, `-h`, `--version`, unknown-command usage, and plugin
 subcommand proxying intact while owning the error path.
+
+A command name inherited from `Object.prototype` is also rejected properly
+now. `guren valueOf` used to fail with a raw internal `TypeError`, and
+`guren toString` took a different path than any other unknown name.

--- a/.changeset/cli-single-error-output.md
+++ b/.changeset/cli-single-error-output.md
@@ -1,0 +1,11 @@
+---
+'@guren/cli': patch
+---
+
+A failing `guren` command now reports its error once instead of twice.
+
+citty's `runMain()` logs a thrown error twice — once with its stack, once as a
+bare message — and then exits the process itself, so the CLI's own error
+handler never ran. The root command is now wired through a local wrapper that
+keeps `--help`, `-h`, `--version`, unknown-command usage, and plugin
+subcommand proxying intact while owning the error path.

--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -16,7 +16,7 @@ Ships the Citty-based CLI (`guren` bin) with generators and database helpers. Ge
 - Ensure new commands reuse `toWriterOptions` and shared logging via `consola`
 - Keep `runtime.ts` as the single entry for boot helpers; extend `MaybeApplication` instead of reaching into app internals from commands
 - When touching route type output, regenerate `examples/blog/types/generated/routes.d.ts` to verify compatibility
-- Prefer defining subcommands with `defineCommand()` and wiring the root command via `runMain()`
+- Prefer defining subcommands with `defineCommand()` and wiring the root command via `runCli()` from `run-cli.ts` (citty's own `runMain()` reports each failure twice and exits the process itself)
 - Reuse shared option helpers (such as the `force` writer option) instead of ad-hoc flag parsing
 
 ## Build & Distribution

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -2,8 +2,9 @@
 import { spawn } from 'node:child_process'
 import { pathToFileURL } from 'node:url'
 import { consola } from 'consola'
-import { defineCommand, runMain, showUsage } from 'citty'
+import { defineCommand, showUsage } from 'citty'
 import type { CommandDef } from 'citty'
+import { runCli } from './run-cli'
 import { listBlueprints, runBlueprint } from './blueprints'
 import { runDoctor } from './doctor'
 import { makeAuth } from './make-auth'
@@ -2510,11 +2511,7 @@ const main = defineCommand({
   },
 })
 
-runMain(main).catch((error) => {
-  if (error instanceof Error) {
-    consola.error(error.message)
-  } else {
-    consola.error(String(error))
-  }
-  process.exit(1)
-})
+const exitCode = await runCli(main, process.argv.slice(2))
+if (exitCode !== 0) {
+  process.exit(exitCode)
+}

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -2490,7 +2490,10 @@ const main = defineCommand({
       description: 'Show this help message',
     },
   },
-  subCommands: { ...builtinSubCommands, ...pluginSubCommands },
+  // Null-prototype so a name like `valueOf` or `constructor` can never
+  // resolve to an inherited Object member. citty's own dispatch indexes this
+  // map unguarded and would otherwise invoke the inherited value as a command.
+  subCommands: Object.assign(Object.create(null), builtinSubCommands, pluginSubCommands),
   async run(ctx) {
     if (ctx.args.help || ctx.rawArgs.length === 0) {
       await showUsage(ctx.cmd)

--- a/packages/cli/src/run-cli.ts
+++ b/packages/cli/src/run-cli.ts
@@ -1,0 +1,69 @@
+import { consola } from 'consola'
+import { runCommand, showUsage } from 'citty'
+import type { CommandDef } from 'citty'
+
+type AnyCommandDef = CommandDef<any>
+
+async function resolveValue<T>(input: T | (() => T | Promise<T>)): Promise<T> {
+  return typeof input === 'function' ? await (input as () => T | Promise<T>)() : await input
+}
+
+async function resolveSubCommand(
+  cmd: AnyCommandDef,
+  rawArgs: string[],
+  parent?: AnyCommandDef,
+): Promise<[AnyCommandDef, AnyCommandDef | undefined]> {
+  const subCommands = await resolveValue(cmd.subCommands)
+  if (subCommands && Object.keys(subCommands).length > 0) {
+    const index = rawArgs.findIndex((arg) => !arg.startsWith('-'))
+    const name = rawArgs[index]
+    const subCommand = name ? await resolveValue(subCommands[name]) : undefined
+    if (subCommand) {
+      return resolveSubCommand(subCommand, rawArgs.slice(index + 1), cmd)
+    }
+  }
+  return [cmd, parent]
+}
+
+function isUsageError(error: unknown): error is Error {
+  return error instanceof Error && error.name === 'CLIError'
+}
+
+/**
+ * Stands in for citty's `runMain`, which reports a thrown error twice — once
+ * with its stack and once as a bare message — before exiting the process
+ * itself, leaving callers no way to intervene. Returns the exit code instead
+ * of exiting so the caller decides how the process ends.
+ */
+export async function runCli(cmd: AnyCommandDef, rawArgs: string[]): Promise<number> {
+  try {
+    if (rawArgs.includes('--help') || rawArgs.includes('-h')) {
+      await showUsage(...(await resolveSubCommand(cmd, rawArgs)))
+      return 0
+    }
+
+    if (rawArgs.length === 1 && rawArgs[0] === '--version') {
+      const meta = await resolveValue(cmd.meta)
+      if (!meta?.version) {
+        await showUsage(...(await resolveSubCommand(cmd, rawArgs)))
+        consola.error('No version specified')
+        return 1
+      }
+      consola.log(meta.version)
+      return 0
+    }
+
+    await runCommand(cmd, { rawArgs })
+    return 0
+  } catch (error) {
+    if (isUsageError(error)) {
+      await showUsage(...(await resolveSubCommand(cmd, rawArgs)))
+      consola.error(error.message)
+    } else {
+      // Non-Error throwables (Bun's ResolveMessage, for one) render as an
+      // empty object when handed to consola directly, hiding the message.
+      consola.error(error instanceof Error ? error : String(error))
+    }
+    return 1
+  }
+}

--- a/packages/cli/src/run-cli.ts
+++ b/packages/cli/src/run-cli.ts
@@ -35,20 +35,38 @@ function isUsageError(error: unknown): error is Error {
  * with its stack and once as a bare message — before exiting the process
  * itself, leaving callers no way to intervene. Returns the exit code instead
  * of exiting so the caller decides how the process ends.
+ *
+ * Upgrading citty does not remove the need for this wrapper: 0.2.x prints the
+ * error once but still calls `process.exit()` from inside `runMain`, and it
+ * reports through `console.error` rather than `consola`, which would bypass
+ * the log level the rest of the CLI honours. A citty major bump is also a
+ * breaking change for plugin authors, who write `CommandDef`s against it.
+ *
+ * `resolveValue` and `resolveSubCommand` mirror internals citty 0.1.6 does not
+ * export; `tests/bin-error-output.test.ts` covers them end to end so drift on
+ * an upgrade surfaces there.
  */
 export async function runCli(cmd: AnyCommandDef, rawArgs: string[]): Promise<number> {
+  const usage = async (): Promise<void> => {
+    await showUsage(...(await resolveSubCommand(cmd, rawArgs)))
+  }
+
+  const failWithUsage = async (message: string): Promise<number> => {
+    await usage()
+    consola.error(message)
+    return 1
+  }
+
   try {
     if (rawArgs.includes('--help') || rawArgs.includes('-h')) {
-      await showUsage(...(await resolveSubCommand(cmd, rawArgs)))
+      await usage()
       return 0
     }
 
     if (rawArgs.length === 1 && rawArgs[0] === '--version') {
       const meta = await resolveValue(cmd.meta)
       if (!meta?.version) {
-        await showUsage(...(await resolveSubCommand(cmd, rawArgs)))
-        consola.error('No version specified')
-        return 1
+        return failWithUsage('No version specified')
       }
       consola.log(meta.version)
       return 0
@@ -58,13 +76,11 @@ export async function runCli(cmd: AnyCommandDef, rawArgs: string[]): Promise<num
     return 0
   } catch (error) {
     if (isUsageError(error)) {
-      await showUsage(...(await resolveSubCommand(cmd, rawArgs)))
-      consola.error(error.message)
-    } else {
-      // Non-Error throwables (Bun's ResolveMessage, for one) render as an
-      // empty object when handed to consola directly, hiding the message.
-      consola.error(error instanceof Error ? error : String(error))
+      return failWithUsage(error.message)
     }
+    // Non-Error throwables (Bun's ResolveMessage, for one) render as an
+    // empty object when handed to consola directly, hiding the message.
+    consola.error(error instanceof Error ? error : String(error))
     return 1
   }
 }

--- a/packages/cli/src/run-cli.ts
+++ b/packages/cli/src/run-cli.ts
@@ -17,7 +17,8 @@ async function resolveSubCommand(
   if (subCommands && Object.keys(subCommands).length > 0) {
     const index = rawArgs.findIndex((arg) => !arg.startsWith('-'))
     const name = rawArgs[index]
-    const subCommand = name ? await resolveValue(subCommands[name]) : undefined
+    const declared = name !== undefined && Object.prototype.hasOwnProperty.call(subCommands, name)
+    const subCommand = declared ? await resolveValue(subCommands[name]) : undefined
     if (subCommand) {
       return resolveSubCommand(subCommand, rawArgs.slice(index + 1), cmd)
     }

--- a/packages/cli/tests/bin-error-output.test.ts
+++ b/packages/cli/tests/bin-error-output.test.ts
@@ -1,0 +1,95 @@
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'bun:test'
+import { createTempWorkspace } from './helpers'
+
+const CLI_BIN_PATH = resolve(import.meta.dir, '../src/bin.ts')
+
+async function runBin(args: string[], cwd: string): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  // `bun test` sets NODE_ENV=test, which drops consola to the warn level and
+  // hides the usage output these assertions inspect. Real invocations do not.
+  const { NODE_ENV: _testEnv, ...env } = process.env
+  const proc = Bun.spawn(['bun', CLI_BIN_PATH, ...args], {
+    cwd,
+    env,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { exitCode, stdout, stderr }
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1
+}
+
+describe('guren CLI error reporting', () => {
+  it('reports a failing command once and exits 1', async () => {
+    const workspace = await createTempWorkspace('guren-cli-bin-error-')
+    try {
+      const { exitCode, stderr } = await runBin(['db:migrate'], workspace.dir)
+
+      expect(exitCode).toBe(1)
+      expect(countOccurrences(stderr, 'Could not find config/database')).toBe(1)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reports an unknown command once, with usage, and exits 1', async () => {
+    const workspace = await createTempWorkspace('guren-cli-bin-unknown-')
+    try {
+      const { exitCode, stdout, stderr } = await runBin(['definitely-not-a-command'], workspace.dir)
+
+      expect(exitCode).toBe(1)
+      expect(countOccurrences(stderr, 'Unknown command')).toBe(1)
+      expect(stdout).toContain('USAGE guren')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reports a missing required argument once, with subcommand usage, and exits 1', async () => {
+    const workspace = await createTempWorkspace('guren-cli-bin-missing-arg-')
+    try {
+      const { exitCode, stdout, stderr } = await runBin(['make:controller'], workspace.dir)
+
+      expect(exitCode).toBe(1)
+      expect(countOccurrences(stderr, 'Missing required positional argument')).toBe(1)
+      expect(stdout).toContain('USAGE guren make:controller')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('renders subcommand usage for `<command> --help` and exits 0', async () => {
+    const workspace = await createTempWorkspace('guren-cli-bin-subhelp-')
+    try {
+      const { exitCode, stdout } = await runBin(['make:controller', '--help'], workspace.dir)
+
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('USAGE guren make:controller')
+      expect(stdout).toContain('Controller class name')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('renders root usage for `--help` and for no arguments, exiting 0', async () => {
+    const workspace = await createTempWorkspace('guren-cli-bin-help-')
+    try {
+      const withFlag = await runBin(['--help'], workspace.dir)
+      expect(withFlag.exitCode).toBe(0)
+      expect(withFlag.stdout).toContain('Guren framework CLI utilities.')
+
+      const withoutArgs = await runBin([], workspace.dir)
+      expect(withoutArgs.exitCode).toBe(0)
+      expect(withoutArgs.stdout).toContain('Guren framework CLI utilities.')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})

--- a/packages/cli/tests/bin-error-output.test.ts
+++ b/packages/cli/tests/bin-error-output.test.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'bun:test'
+import { stripAnsi } from 'consola/utils'
 import { createTempWorkspace } from './helpers'
 
 const CLI_BIN_PATH = resolve(import.meta.dir, '../src/bin.ts')
@@ -26,14 +27,12 @@ function countOccurrences(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1
 }
 
-const ANSI_PATTERN = /\x1b\[[0-9;]*m/g
-
 // consola renders `showUsage`'s markdown-style code spans as ANSI styling on
 // a TTY, but leaves the literal backticks in place on CI's non-TTY stdout
 // (e.g. "USAGE `guren [OPTIONS] ...`"). Strip both so assertions work in
 // either environment.
 function plainText(text: string): string {
-  return text.replace(ANSI_PATTERN, '').replace(/`/g, '')
+  return stripAnsi(text).replace(/`/g, '')
 }
 
 describe('guren CLI error reporting', () => {
@@ -57,6 +56,22 @@ describe('guren CLI error reporting', () => {
       expect(exitCode).toBe(1)
       expect(countOccurrences(stderr, 'Unknown command')).toBe(1)
       expect(plainText(stdout)).toContain('USAGE guren')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('treats a name inherited from Object.prototype as an unknown command', async () => {
+    const workspace = await createTempWorkspace('guren-cli-bin-proto-')
+    try {
+      const results = await Promise.all(
+        ['valueOf', 'toString', 'constructor'].map((name) => runBin([name], workspace.dir)),
+      )
+
+      for (const { exitCode, stderr } of results) {
+        expect(exitCode).toBe(1)
+        expect(countOccurrences(stderr, 'Unknown command')).toBe(1)
+      }
     } finally {
       await workspace.cleanup()
     }
@@ -92,13 +107,16 @@ describe('guren CLI error reporting', () => {
   it('renders root usage for `--help` and for no arguments, exiting 0', async () => {
     const workspace = await createTempWorkspace('guren-cli-bin-help-')
     try {
-      const withFlag = await runBin(['--help'], workspace.dir)
-      expect(withFlag.exitCode).toBe(0)
-      expect(withFlag.stdout).toContain('Guren framework CLI utilities.')
+      const [withFlag, withoutArgs] = await Promise.all([
+        runBin(['--help'], workspace.dir),
+        runBin([], workspace.dir),
+      ])
 
-      const withoutArgs = await runBin([], workspace.dir)
+      expect(withFlag.exitCode).toBe(0)
+      expect(plainText(withFlag.stdout)).toContain('Guren framework CLI utilities.')
+
       expect(withoutArgs.exitCode).toBe(0)
-      expect(withoutArgs.stdout).toContain('Guren framework CLI utilities.')
+      expect(plainText(withoutArgs.stdout)).toContain('Guren framework CLI utilities.')
     } finally {
       await workspace.cleanup()
     }

--- a/packages/cli/tests/bin-error-output.test.ts
+++ b/packages/cli/tests/bin-error-output.test.ts
@@ -26,6 +26,16 @@ function countOccurrences(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1
 }
 
+const ANSI_PATTERN = /\x1b\[[0-9;]*m/g
+
+// consola renders `showUsage`'s markdown-style code spans as ANSI styling on
+// a TTY, but leaves the literal backticks in place on CI's non-TTY stdout
+// (e.g. "USAGE `guren [OPTIONS] ...`"). Strip both so assertions work in
+// either environment.
+function plainText(text: string): string {
+  return text.replace(ANSI_PATTERN, '').replace(/`/g, '')
+}
+
 describe('guren CLI error reporting', () => {
   it('reports a failing command once and exits 1', async () => {
     const workspace = await createTempWorkspace('guren-cli-bin-error-')
@@ -46,7 +56,7 @@ describe('guren CLI error reporting', () => {
 
       expect(exitCode).toBe(1)
       expect(countOccurrences(stderr, 'Unknown command')).toBe(1)
-      expect(stdout).toContain('USAGE guren')
+      expect(plainText(stdout)).toContain('USAGE guren')
     } finally {
       await workspace.cleanup()
     }
@@ -59,7 +69,7 @@ describe('guren CLI error reporting', () => {
 
       expect(exitCode).toBe(1)
       expect(countOccurrences(stderr, 'Missing required positional argument')).toBe(1)
-      expect(stdout).toContain('USAGE guren make:controller')
+      expect(plainText(stdout)).toContain('USAGE guren make:controller')
     } finally {
       await workspace.cleanup()
     }
@@ -71,8 +81,9 @@ describe('guren CLI error reporting', () => {
       const { exitCode, stdout } = await runBin(['make:controller', '--help'], workspace.dir)
 
       expect(exitCode).toBe(0)
-      expect(stdout).toContain('USAGE guren make:controller')
-      expect(stdout).toContain('Controller class name')
+      const normalized = plainText(stdout)
+      expect(normalized).toContain('USAGE guren make:controller')
+      expect(normalized).toContain('Controller class name')
     } finally {
       await workspace.cleanup()
     }


### PR DESCRIPTION
## Summary

- Every failing `guren` CLI command printed its error twice (once with a stack trace, once without). Root cause: citty 0.1.6's `runMain()` calls `consola.error(error, "\n")` then `consola.error(error.message)` in its own catch block, then calls `process.exit(1)` itself — so `runMain(main).catch(...)` in `bin.ts` never ran.
- Added `packages/cli/src/run-cli.ts`, a thin local wrapper around citty's `runCommand`/`showUsage`/`resolveSubCommand` that reproduces `runMain`'s `--help`/`-h`/`--version`/usage behavior but returns an exit code instead of exiting the process, so the CLI owns the error path and prints once.
- `resolveSubCommand` uses `hasOwnProperty` when looking up subcommand names, matching the guard `bin.ts` already applies to the root command (citty 0.1.6's own `resolveSubCommand` doesn't guard this, so e.g. `guren constructor --help` would otherwise resolve `Object.prototype.constructor`).
- Non-`Error` throwables (e.g. Bun's `ResolveMessage`) are stringified before logging — `consola.error()` renders those as an empty object otherwise, silently dropping the message that citty's second print used to carry.

## Known limitations (unchanged by this PR)

- `guren --version` still errors with "No version specified" — the root command's `meta` has no `version` field. Pre-existing, orthogonal to this fix.
- `packages/create-app/src/cli.ts` has the identical double-print bug via its own `runMain(command).catch(...)`. Left out of scope here because its test (`packages/create-app/tests/cli.test.ts`) mocks `runMain` directly; fixing it needs a small test rewrite. Filing as a follow-up.

## Test plan

- [x] `bun run build cli`
- [x] `bun run typecheck` (pre-existing unrelated failures in `examples/blog` from missing `.guren/*.gen` codegen artifacts, confirmed present on `main` too)
- [x] `bun run test:bun cli` — 678 pass
- [x] `bun run test:bun` (full framework suite) — 2777 pass
- [x] `bun run audit:core-first`, `bun run audit:docs`
- [x] New test `packages/cli/tests/bin-error-output.test.ts` spawns the real bin for: failing command (single error, exit 1), unknown command (single error + usage, exit 1), missing required arg (single error + subcommand usage, exit 1), subcommand `--help` (exit 0), root `--help`/no-args (exit 0). Verified this test fails against the pre-fix `bin.ts` (received 2 error occurrences).
- [x] Manual before/after diff of a built-bin matrix (no-args, `--help`, `-h`, `make:controller --help`, unknown command, `--version`, missing required arg, failing `db:migrate`) — only the failing-command case changed, and only by removing the duplicate error block.
- [x] Manual verification with a synthetic plugin package (`gurenPlugin.commands` manifest): plugin subcommand run, its own `--help`, missing required arg, and a thrown error inside a plugin command all behave correctly (single error, correct usage, exit codes).
- [ ] `bun run test:examples` — not run (needs `bun run db:up` / Docker Postgres); the CLI logic itself isn't exercised by that suite beyond spawning `bin.ts`, which is covered above.