### PR TITLE
fix(orm): createMySqlDatabase() fails on every query under drizzle-orm rc.4

### DIFF
--- a/.changeset/mysql-driver-pool.md
+++ b/.changeset/mysql-driver-pool.md
@@ -13,8 +13,3 @@ whose wrapper exposes no `config` object for the driver to write that flag onto.
 The ORM now creates the pool itself with `mysql2`'s callback API and hands
 drizzle a client, matching how the PostgreSQL helper already works, and closes
 that pool directly instead of reaching for drizzle's `$client`.
-
-The existing tests could not catch this: they mock `drizzle-orm/mysql2` away, so
-the real adapter was never exercised. A MySQL integration test now runs against
-a live server (`MYSQL_URL`, backed by a `mysql` service in CI and
-`bun run db:up:mysql` locally).

--- a/.changeset/mysql-driver-pool.md
+++ b/.changeset/mysql-driver-pool.md
@@ -1,0 +1,20 @@
+---
+'@guren/orm': patch
+---
+
+Fix `createMySqlDatabase()`, which failed on every query
+
+Any statement against a MySQL app — including the first one `db:migrate` runs —
+threw `undefined is not an object (evaluating
+'client.config.supportBigNumbers = !0')` before touching a socket, so MySQL was
+unusable even though `create-guren-app --db mysql` offers it. Passing a
+connection to `drizzle()` makes it build the pool through `mysql2/promise`,
+whose wrapper exposes no `config` object for the driver to write that flag onto.
+The ORM now creates the pool itself with `mysql2`'s callback API and hands
+drizzle a client, matching how the PostgreSQL helper already works, and closes
+that pool directly instead of reaching for drizzle's `$client`.
+
+The existing tests could not catch this: they mock `drizzle-orm/mysql2` away, so
+the real adapter was never exercised. A MySQL integration test now runs against
+a live server (`MYSQL_URL`, backed by a `mysql` service in CI and
+`bun run db:up:mysql` locally).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,15 +53,13 @@ jobs:
           - 33306:3306
         options: >-
           --health-cmd "mysqladmin ping -h127.0.0.1 -uguren -pguren"
-          --health-interval 10s
+          --health-interval 5s
           --health-timeout 5s
-          --health-retries 10
+          --health-retries 20
     env:
       REDIS_URL: redis://localhost:6379
-      # Drives the ORM's MySQL integration test, which is the only coverage of
-      # the real drizzle-orm/mysql2 adapter (the unit tests mock it out). It gets
-      # its own database because it drops every table in the one it points at.
-      MYSQL_URL: mysql://root:guren@localhost:33306/guren_orm_test
+      # Drives the ORM's MySQL integration test, which creates its own database.
+      MYSQL_URL: mysql://root:guren@localhost:33306/guren
       APP_KEY: base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,26 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: guren
+          MYSQL_USER: guren
+          MYSQL_PASSWORD: guren
+          MYSQL_DATABASE: guren
+        ports:
+          - 33306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h127.0.0.1 -uguren -pguren"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
     env:
       REDIS_URL: redis://localhost:6379
+      # Drives the ORM's MySQL integration test, which is the only coverage of
+      # the real drizzle-orm/mysql2 adapter (the unit tests mock it out). It gets
+      # its own database because it drops every table in the one it points at.
+      MYSQL_URL: mysql://root:guren@localhost:33306/guren_orm_test
       APP_KEY: base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,8 @@ bun run dev
 
 # Database
 bun run db:up         # Start PostgreSQL container
-bun run db:up:mysql   # Start MySQL container. The ORM's MySQL integration test
-                      # skips unless MYSQL_URL is set; it drops every table in
-                      # that database, so give it a dedicated one:
-                      # MYSQL_URL=mysql://root:guren@localhost:33306/guren_orm_test
+bun run db:up:mysql   # Start MySQL container (the ORM's MySQL integration test
+                      # skips unless MYSQL_URL is set)
 bun run db:down       # Stop containers
 bun run db:migrate    # Run migrations
 bun run db:seed       # Run seeders

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,11 @@ bun run dev
 
 # Database
 bun run db:up         # Start PostgreSQL container
-bun run db:down       # Stop container
+bun run db:up:mysql   # Start MySQL container. The ORM's MySQL integration test
+                      # skips unless MYSQL_URL is set; it drops every table in
+                      # that database, so give it a dedicated one:
+                      # MYSQL_URL=mysql://root:guren@localhost:33306/guren_orm_test
+bun run db:down       # Stop containers
 bun run db:migrate    # Run migrations
 bun run db:seed       # Run seeders
 ```

--- a/compose.yml
+++ b/compose.yml
@@ -18,5 +18,28 @@ services:
       start_period: 5s
       timeout: 3s
 
+  # Port and credentials match what `create-guren-app --db mysql` scaffolds, so
+  # MYSQL_URL is the same string in a fresh app and in the ORM integration test.
+  mysql:
+    image: mysql:8.4
+    container_name: guren-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: guren
+      MYSQL_USER: guren
+      MYSQL_PASSWORD: guren
+      MYSQL_DATABASE: guren
+    ports:
+      - "33306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h127.0.0.1 -uguren -pguren"]
+      interval: 5s
+      retries: 20
+      start_period: 20s
+      timeout: 3s
+
 volumes:
   postgres_data:
+  mysql_data:

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "db:migrate": "GUREN_QUIET_DUPLICATE_ORM=1 bun run --cwd examples/blog db:migrate",
     "db:seed": "GUREN_QUIET_DUPLICATE_ORM=1 bun run --cwd examples/blog db:seed",
     "db:up": "docker compose up -d postgres",
+    "db:up:mysql": "docker compose up -d mysql",
     "db:down": "docker compose down",
     "db:logs": "docker compose logs -f postgres",
     "bench": "bun run ./scripts/benchmarks/run-benchmarks.ts",

--- a/packages/orm/CLAUDE.md
+++ b/packages/orm/CLAUDE.md
@@ -11,6 +11,7 @@ Houses the ORM-facing surface (Model base class, Drizzle adapter, Postgres helpe
 - PascalCase for files that export classes (`Model.ts`); helper modules stay kebab-case (`postgres.ts`, `seeder.ts`)
 - Keep adapters self-contained; avoid importing from `@guren/server` to prevent cycles
 - Treat `drizzle-orm` and `postgres` as peer deps — type-safe but optional
+- Every driver constructs its own client and passes `drizzle({ client })`; never `connection:`. Drizzle builds the client itself for `connection:`, and for mysql2 it picks the promise-API pool, which has no `.config` for the driver to write to — so every query throws before reaching a socket. Mocked unit tests cannot catch that; each driver needs live-server coverage (see `tests/mysql-integration.test.ts`)
 
 ## Build & Tests
 - Build with `bun run --cwd packages/orm build`

--- a/packages/orm/src/mysql.ts
+++ b/packages/orm/src/mysql.ts
@@ -9,6 +9,10 @@ import { runSeeders } from './seeder'
 type ConnectionResolver = string | (() => string | undefined)
 type MySqlConnectionOptions = Record<string, unknown>
 type MySql2Drizzle = typeof import('drizzle-orm/mysql2')
+type MySql2Module = typeof import('mysql2')
+type CreatePool = MySql2Module['createPool']
+type MySqlPool = ReturnType<CreatePool>
+type MySqlPoolOptions = Parameters<CreatePool>[0]
 type DrizzleConfig = Exclude<Parameters<MySql2Drizzle['drizzle']>[0], string>
 
 // The mysql driver packages are loaded lazily so importing @guren/orm
@@ -16,13 +20,15 @@ type DrizzleConfig = Exclude<Parameters<MySql2Drizzle['drizzle']>[0], string>
 async function loadMySqlModules(): Promise<{
   drizzle: MySql2Drizzle['drizzle']
   migrate: typeof import('drizzle-orm/mysql2/migrator')['migrate']
+  createPool: CreatePool
 }> {
   try {
-    const [{ drizzle }, { migrate }] = await Promise.all([
+    const [{ drizzle }, { migrate }, { createPool }] = await Promise.all([
       import('drizzle-orm/mysql2'),
       import('drizzle-orm/mysql2/migrator'),
+      import('mysql2'),
     ])
-    return { drizzle, migrate }
+    return { drizzle, migrate, createPool }
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error)
     throw new Error(
@@ -66,7 +72,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
 
   let migrationsPromise: Promise<void> | undefined
   let databasePromise: Promise<MySql2Database> | undefined
-  let database: MySql2Database | undefined
+  let client: MySqlPool | undefined
   let activeKey: string | undefined
   // Captured here, not in getDatabase(), so the caller of this factory is the
   // frame that identifies the handle across hot reloads.
@@ -81,6 +87,15 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
     }
 
     return resolved
+  }
+
+  // The pool is built here rather than handed to drizzle as `connection`:
+  // drizzle's own wiring builds it through `mysql2/promise`, whose wrapper
+  // exposes no `.config` for the driver to write `supportBigNumbers` onto, so
+  // every query throws before reaching a socket. The callback-API pool it
+  // accepts as `client` does expose one.
+  function createClient(createPool: CreatePool, url: string): MySqlPool {
+    return createPool({ uri: url, ...clientOptions } as MySqlPoolOptions)
   }
 
   async function migrateOnce(): Promise<void> {
@@ -99,22 +114,19 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
         return
       }
 
-      const { drizzle, migrate } = await loadMySqlModules()
+      const { drizzle, migrate, createPool } = await loadMySqlModules()
       const url = resolveConnectionString()
       endpoint = describeConnectionEndpoint(url)
-      const migrationDb = drizzle({
-        connection: {
-          uri: url,
-          ...clientOptions,
-        },
-        mode: 'default',
-        ...(relations ? { relations } : {}),
-      } as DrizzleConfig)
+      const migrationClient = createClient(createPool, url)
 
       try {
+        const migrationDb = drizzle({
+          client: migrationClient,
+          ...(relations ? { relations } : {}),
+        } as DrizzleConfig)
         await migrate(migrationDb, { migrationsFolder: resolvedMigrationsFolder })
       } finally {
-        await closeClient(migrationDb)
+        await closePool(migrationClient)
       }
     })()
 
@@ -133,24 +145,22 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
 
     const promise = (async (): Promise<MySql2Database> => {
       await migrateOnce()
-      const { drizzle } = await loadMySqlModules()
+      const { drizzle, createPool } = await loadMySqlModules()
       const url = resolveConnectionString()
-      const db = drizzle({
-        connection: {
-          uri: url,
-          ...clientOptions,
-        },
-        mode: 'default',
-        ...(relations ? { relations } : {}),
-      } as DrizzleConfig) as unknown as MySql2Database
-      database = db
+      // Held locally as well as in closure state: a newer evaluation may close
+      // this client while the await below is suspended, which clears `client`.
+      const activeClient = createClient(createPool, url)
+      client = activeClient
 
       activeKey = hotReloadKey('mysql', callSite, url)
       if (activeKey) {
         await replaceActiveConnection(activeKey, closeDatabase)
       }
 
-      return db
+      return drizzle({
+        client: activeClient,
+        ...(relations ? { relations } : {}),
+      } as DrizzleConfig) as unknown as MySql2Database
     })()
 
     databasePromise = promise.catch((error) => {
@@ -162,7 +172,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
   }
 
   async function closeDatabase(): Promise<void> {
-    if (!database) {
+    if (!client) {
       return
     }
 
@@ -170,9 +180,9 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
     activeKey = undefined
 
     try {
-      await closeClient(database)
+      await closePool(client)
     } finally {
-      database = undefined
+      client = undefined
       databasePromise = undefined
       if (key) {
         releaseActiveConnection(key, closeDatabase)
@@ -199,15 +209,10 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
   }
 
   async function withAdminDb<T>(callback: (db: MySql2Database) => Promise<T>): Promise<T> {
-    const { drizzle } = await loadMySqlModules()
+    const { drizzle, createPool } = await loadMySqlModules()
     const url = resolveConnectionString()
-    const adminDb = drizzle({
-      connection: {
-        uri: url,
-        ...clientOptions,
-      },
-      mode: 'default',
-    } as DrizzleConfig) as unknown as MySql2Database
+    const adminClient = createClient(createPool, url)
+    const adminDb = drizzle({ client: adminClient } as DrizzleConfig) as unknown as MySql2Database
 
     try {
       return await callback(adminDb)
@@ -215,7 +220,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
       // Rethrowing raw would surface the driver's bare code with no message.
       throw new Error(describeDatabaseFailure(error, describeConnectionEndpoint(url)))
     } finally {
-      await closeClient(adminDb)
+      await closePool(adminClient)
     }
   }
 
@@ -276,26 +281,9 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
   }
 }
 
-async function closeClient(db: unknown): Promise<void> {
-  if (typeof db !== 'object' || db === null) {
-    return
-  }
-
-  const maybeClient = (db as { $client?: unknown }).$client as { end?: (...args: unknown[]) => unknown } | undefined
-  if (!maybeClient || typeof maybeClient.end !== 'function') {
-    return
-  }
-
-  if (maybeClient.end.length === 0) {
-    const maybePromise = maybeClient.end()
-    if (isPromiseLike(maybePromise)) {
-      await maybePromise
-    }
-    return
-  }
-
+async function closePool(pool: MySqlPool): Promise<void> {
   await new Promise<void>((resolveClose, rejectClose) => {
-    maybeClient.end?.((error?: unknown) => {
+    pool.end((error) => {
       if (error) {
         rejectClose(error)
         return
@@ -303,9 +291,5 @@ async function closeClient(db: unknown): Promise<void> {
       resolveClose()
     })
   })
-}
-
-function isPromiseLike(value: unknown): value is Promise<unknown> {
-  return typeof value === 'object' && value !== null && 'then' in value && typeof (value as { then: unknown }).then === 'function'
 }
 

--- a/packages/orm/src/mysql.ts
+++ b/packages/orm/src/mysql.ts
@@ -9,14 +9,18 @@ import { runSeeders } from './seeder'
 type ConnectionResolver = string | (() => string | undefined)
 type MySqlConnectionOptions = Record<string, unknown>
 type MySql2Drizzle = typeof import('drizzle-orm/mysql2')
-type MySql2Module = typeof import('mysql2')
-type CreatePool = MySql2Module['createPool']
+type CreatePool = typeof import('mysql2')['createPool']
 type MySqlPool = ReturnType<CreatePool>
-type MySqlPoolOptions = Parameters<CreatePool>[0]
 type DrizzleConfig = Exclude<Parameters<MySql2Drizzle['drizzle']>[0], string>
 
 // The mysql driver packages are loaded lazily so importing @guren/orm
 // does not require `mysql2` to be installed (e.g. SQLite-only apps).
+//
+// `createPool` comes from mysql2's callback API on purpose: drizzle builds its
+// own pool through `mysql2/promise` when handed a `connection:`, and that
+// wrapper exposes no `.config` for the driver to write `supportBigNumbers`
+// onto, so every query throws before reaching a socket. Pools built here are
+// passed to `drizzle({ client })` instead.
 async function loadMySqlModules(): Promise<{
   drizzle: MySql2Drizzle['drizzle']
   migrate: typeof import('drizzle-orm/mysql2/migrator')['migrate']
@@ -89,15 +93,6 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
     return resolved
   }
 
-  // The pool is built here rather than handed to drizzle as `connection`:
-  // drizzle's own wiring builds it through `mysql2/promise`, whose wrapper
-  // exposes no `.config` for the driver to write `supportBigNumbers` onto, so
-  // every query throws before reaching a socket. The callback-API pool it
-  // accepts as `client` does expose one.
-  function createClient(createPool: CreatePool, url: string): MySqlPool {
-    return createPool({ uri: url, ...clientOptions } as MySqlPoolOptions)
-  }
-
   async function migrateOnce(): Promise<void> {
     if (migrationsPromise) {
       return migrationsPromise
@@ -117,7 +112,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
       const { drizzle, migrate, createPool } = await loadMySqlModules()
       const url = resolveConnectionString()
       endpoint = describeConnectionEndpoint(url)
-      const migrationClient = createClient(createPool, url)
+      const migrationClient = createPool({ uri: url, ...clientOptions })
 
       try {
         const migrationDb = drizzle({
@@ -149,7 +144,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
       const url = resolveConnectionString()
       // Held locally as well as in closure state: a newer evaluation may close
       // this client while the await below is suspended, which clears `client`.
-      const activeClient = createClient(createPool, url)
+      const activeClient = createPool({ uri: url, ...clientOptions })
       client = activeClient
 
       activeKey = hotReloadKey('mysql', callSite, url)
@@ -211,7 +206,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
   async function withAdminDb<T>(callback: (db: MySql2Database) => Promise<T>): Promise<T> {
     const { drizzle, createPool } = await loadMySqlModules()
     const url = resolveConnectionString()
-    const adminClient = createClient(createPool, url)
+    const adminClient = createPool({ uri: url, ...clientOptions })
     const adminDb = drizzle({ client: adminClient } as DrizzleConfig) as unknown as MySql2Database
 
     try {
@@ -283,13 +278,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
 
 async function closePool(pool: MySqlPool): Promise<void> {
   await new Promise<void>((resolveClose, rejectClose) => {
-    pool.end((error) => {
-      if (error) {
-        rejectClose(error)
-        return
-      }
-      resolveClose()
-    })
+    pool.end((error) => (error ? rejectClose(error) : resolveClose()))
   })
 }
 

--- a/packages/orm/tests/mysql-integration.test.ts
+++ b/packages/orm/tests/mysql-integration.test.ts
@@ -8,23 +8,27 @@ import { createMySqlDatabase, type MySqlDatabase } from '../src/mysql'
 // The unit tests mock `drizzle-orm/mysql2` away, so they cannot see driver-level
 // breakage (a wiring shape the adapter rejects, a migrator that never runs).
 // CI supplies MYSQL_URL from a mysql service container; locally, start one with
-// `bun run db:up:mysql`.
-//
-// MYSQL_URL must name a database dedicated to this test — the reset below drops
-// every table in it — and a user allowed to create that database, since the
-// compose service only grants the app user rights on its own.
+// `bun run db:up:mysql`. MYSQL_URL needs a user allowed to create a database,
+// since the compose service only grants the app user rights on its own.
 const MYSQL_URL = process.env.MYSQL_URL
 const describeMySql = MYSQL_URL ? describe : describe.skip
 
-async function ensureDatabase(url: string): Promise<void> {
-  const { createPool } = await import('mysql2/promise')
-  const target = new URL(url)
-  const name = decodeURIComponent(target.pathname.slice(1))
-  target.pathname = '/mysql'
+// Derived rather than taken from MYSQL_URL: the reset below drops every table
+// in the database it runs against, and MYSQL_URL is the same string a
+// scaffolded app puts in DATABASE_URL.
+const TEST_DATABASE = 'guren_orm_test'
 
-  const pool = createPool({ uri: target.toString() })
+function databaseUrl(url: string, database: string): string {
+  const target = new URL(url)
+  target.pathname = `/${database}`
+  return target.toString()
+}
+
+async function ensureTestDatabase(url: string): Promise<void> {
+  const { createPool } = await import('mysql2/promise')
+  const pool = createPool({ uri: databaseUrl(url, 'mysql') })
   try {
-    await pool.query(`CREATE DATABASE IF NOT EXISTS \`${name.replaceAll('`', '``')}\``)
+    await pool.query(`CREATE DATABASE IF NOT EXISTS \`${TEST_DATABASE}\``)
   } finally {
     await pool.end()
   }
@@ -42,13 +46,14 @@ function createMigrationsFolder(): string {
 }
 
 describeMySql('createMySqlDatabase against a real MySQL server (requires MYSQL_URL)', () => {
-  let database: MySqlDatabase | undefined
+  let database: MySqlDatabase
 
   beforeAll(async () => {
-    await ensureDatabase(MYSQL_URL as string)
+    const url = MYSQL_URL as string
+    await ensureTestDatabase(url)
     database = createMySqlDatabase({
       migrationsFolder: createMigrationsFolder(),
-      connectionString: () => MYSQL_URL,
+      connectionString: () => databaseUrl(url, TEST_DATABASE),
     })
     await database.resetDatabase()
   })
@@ -59,15 +64,7 @@ describeMySql('createMySqlDatabase against a real MySQL server (requires MYSQL_U
     await database?.closeDatabase()
   })
 
-  function getDatabaseHandle(): MySqlDatabase {
-    if (!database) {
-      throw new Error('beforeAll did not set up the database handle')
-    }
-    return database
-  }
-
   it('runs migrations and queries through the real driver', async () => {
-    const database = getDatabaseHandle()
     const db = await database.getDatabase()
 
     const [rows] = (await db.execute(sql`SELECT 1 AS one`)) as unknown as [Array<{ one: number }>]
@@ -81,7 +78,6 @@ describeMySql('createMySqlDatabase against a real MySQL server (requires MYSQL_U
   })
 
   it('reports the applied migration', async () => {
-    const database = getDatabaseHandle()
     await database.migrateDatabase()
 
     const status = await database.migrationStatus()
@@ -90,7 +86,6 @@ describeMySql('createMySqlDatabase against a real MySQL server (requires MYSQL_U
   })
 
   it('drops every table on reset', async () => {
-    const database = getDatabaseHandle()
     await database.migrateDatabase()
     await database.resetDatabase()
 

--- a/packages/orm/tests/mysql-integration.test.ts
+++ b/packages/orm/tests/mysql-integration.test.ts
@@ -42,7 +42,7 @@ function createMigrationsFolder(): string {
 }
 
 describeMySql('createMySqlDatabase against a real MySQL server (requires MYSQL_URL)', () => {
-  let database: MySqlDatabase
+  let database: MySqlDatabase | undefined
 
   beforeAll(async () => {
     await ensureDatabase(MYSQL_URL as string)
@@ -54,10 +54,20 @@ describeMySql('createMySqlDatabase against a real MySQL server (requires MYSQL_U
   })
 
   afterAll(async () => {
-    await database.closeDatabase()
+    // beforeAll may have thrown before `database` was assigned — don't mask
+    // that failure with a "Cannot read properties of undefined" here.
+    await database?.closeDatabase()
   })
 
+  function getDatabaseHandle(): MySqlDatabase {
+    if (!database) {
+      throw new Error('beforeAll did not set up the database handle')
+    }
+    return database
+  }
+
   it('runs migrations and queries through the real driver', async () => {
+    const database = getDatabaseHandle()
     const db = await database.getDatabase()
 
     const [rows] = (await db.execute(sql`SELECT 1 AS one`)) as unknown as [Array<{ one: number }>]
@@ -71,6 +81,7 @@ describeMySql('createMySqlDatabase against a real MySQL server (requires MYSQL_U
   })
 
   it('reports the applied migration', async () => {
+    const database = getDatabaseHandle()
     await database.migrateDatabase()
 
     const status = await database.migrationStatus()
@@ -79,6 +90,7 @@ describeMySql('createMySqlDatabase against a real MySQL server (requires MYSQL_U
   })
 
   it('drops every table on reset', async () => {
+    const database = getDatabaseHandle()
     await database.migrateDatabase()
     await database.resetDatabase()
 

--- a/packages/orm/tests/mysql-integration.test.ts
+++ b/packages/orm/tests/mysql-integration.test.ts
@@ -1,0 +1,88 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { sql } from 'drizzle-orm'
+import { createMySqlDatabase, type MySqlDatabase } from '../src/mysql'
+
+// The unit tests mock `drizzle-orm/mysql2` away, so they cannot see driver-level
+// breakage (a wiring shape the adapter rejects, a migrator that never runs).
+// CI supplies MYSQL_URL from a mysql service container; locally, start one with
+// `bun run db:up:mysql`.
+//
+// MYSQL_URL must name a database dedicated to this test — the reset below drops
+// every table in it — and a user allowed to create that database, since the
+// compose service only grants the app user rights on its own.
+const MYSQL_URL = process.env.MYSQL_URL
+const describeMySql = MYSQL_URL ? describe : describe.skip
+
+async function ensureDatabase(url: string): Promise<void> {
+  const { createPool } = await import('mysql2/promise')
+  const target = new URL(url)
+  const name = decodeURIComponent(target.pathname.slice(1))
+  target.pathname = '/mysql'
+
+  const pool = createPool({ uri: target.toString() })
+  try {
+    await pool.query(`CREATE DATABASE IF NOT EXISTS \`${name.replaceAll('`', '``')}\``)
+  } finally {
+    await pool.end()
+  }
+}
+
+function createMigrationsFolder(): string {
+  const migrationsFolder = mkdtempSync(join(tmpdir(), 'guren-orm-mysql-integration-'))
+  const migrationDir = join(migrationsFolder, '20240101000000_init')
+  mkdirSync(migrationDir, { recursive: true })
+  writeFileSync(
+    join(migrationDir, 'migration.sql'),
+    'CREATE TABLE `widgets` (`id` int AUTO_INCREMENT PRIMARY KEY NOT NULL, `name` varchar(255) NOT NULL);',
+  )
+  return migrationsFolder
+}
+
+describeMySql('createMySqlDatabase against a real MySQL server (requires MYSQL_URL)', () => {
+  let database: MySqlDatabase
+
+  beforeAll(async () => {
+    await ensureDatabase(MYSQL_URL as string)
+    database = createMySqlDatabase({
+      migrationsFolder: createMigrationsFolder(),
+      connectionString: () => MYSQL_URL,
+    })
+    await database.resetDatabase()
+  })
+
+  afterAll(async () => {
+    await database.closeDatabase()
+  })
+
+  it('runs migrations and queries through the real driver', async () => {
+    const db = await database.getDatabase()
+
+    const [rows] = (await db.execute(sql`SELECT 1 AS one`)) as unknown as [Array<{ one: number }>]
+    expect(rows[0]?.one).toBe(1)
+
+    await db.execute(sql`INSERT INTO \`widgets\` (\`name\`) VALUES ('gear')`)
+    const [widgets] = (await db.execute(sql`SELECT \`name\` FROM \`widgets\``)) as unknown as [
+      Array<{ name: string }>,
+    ]
+    expect(widgets.map((widget) => widget.name)).toEqual(['gear'])
+  })
+
+  it('reports the applied migration', async () => {
+    await database.migrateDatabase()
+
+    const status = await database.migrationStatus()
+    expect(status).toHaveLength(1)
+    expect(status[0]).toMatchObject({ name: '20240101000000_init', applied: true })
+  })
+
+  it('drops every table on reset', async () => {
+    await database.migrateDatabase()
+    await database.resetDatabase()
+
+    const status = await database.migrationStatus()
+    expect(status[0]).toMatchObject({ applied: false })
+  })
+})

--- a/packages/orm/tests/mysql.test.ts
+++ b/packages/orm/tests/mysql.test.ts
@@ -4,22 +4,17 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { DrizzleAdapter } from '../src/adapters/drizzle-adapter'
 
+// Annotated because `end` reads `pool` from its own initializer.
 interface FakePool {
-  options: unknown
   ended: boolean
-  config: Record<string, unknown>
   end(callback?: (error?: unknown) => void): void
 }
 
 let executeImpl: () => Promise<unknown> = async () => [[]]
 const createdPools: FakePool[] = []
-const createPoolMock = mock((options: unknown) => {
+const createPoolMock = mock(() => {
   const pool: FakePool = {
-    options,
     ended: false,
-    // The callback-API pool exposes `config`; drizzle's own promise-API pool
-    // does not, which is why the adapter builds the pool itself.
-    config: {},
     end(callback) {
       pool.ended = true
       callback?.()
@@ -75,15 +70,18 @@ describe('createMySqlDatabase', () => {
 
     await database.migrateDatabase()
     expect(migrateMock).toHaveBeenCalled()
-    // The migration pool is short-lived and must not outlive the migration.
-    expect(createdPools.at(0)?.ended).toBe(true)
 
     const db = await database.getDatabase()
     expect(createPoolMock).toHaveBeenLastCalledWith({ uri: 'mysql://example', connectTimeout: 1234 })
-    expect(db).toMatchObject({ config: { client: createdPools.at(-1) } })
+
+    const [migrationPool, activePool] = createdPools
+    // The migration pool is short-lived and must not outlive the migration.
+    expect(migrationPool?.ended).toBe(true)
+    // `client`, not `connection`: drizzle must be handed the pool we built.
+    expect((db as unknown as { config: { client: unknown } }).config.client).toBe(activePool)
 
     await database.closeDatabase()
-    expect(createdPools.at(-1)?.ended).toBe(true)
+    expect(activePool?.ended).toBe(true)
   })
 
   it('configures the Drizzle adapter', async () => {

--- a/packages/orm/tests/mysql.test.ts
+++ b/packages/orm/tests/mysql.test.ts
@@ -4,18 +4,39 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { DrizzleAdapter } from '../src/adapters/drizzle-adapter'
 
+interface FakePool {
+  options: unknown
+  ended: boolean
+  config: Record<string, unknown>
+  end(callback?: (error?: unknown) => void): void
+}
+
 let executeImpl: () => Promise<unknown> = async () => [[]]
+const createdPools: FakePool[] = []
+const createPoolMock = mock((options: unknown) => {
+  const pool: FakePool = {
+    options,
+    ended: false,
+    // The callback-API pool exposes `config`; drizzle's own promise-API pool
+    // does not, which is why the adapter builds the pool itself.
+    config: {},
+    end(callback) {
+      pool.ended = true
+      callback?.()
+    },
+  }
+  createdPools.push(pool)
+  return pool
+})
 const drizzleMock = mock((config: unknown) => ({
-  $client: {
-    end: mock((cb?: (err?: unknown) => void) => {
-      cb?.()
-      return undefined
-    }),
-  },
   execute: () => executeImpl(),
   config,
 }))
 const migrateMock = mock(async () => {})
+
+await mock.module('mysql2', () => ({
+  createPool: createPoolMock,
+}))
 
 await mock.module('drizzle-orm/mysql2', () => ({
   drizzle: drizzleMock,
@@ -42,24 +63,27 @@ function createMigrationsFolder(withMigrations: boolean): string {
 describe('createMySqlDatabase', () => {
   afterEach(() => {
     executeImpl = async () => [[]]
+    createdPools.length = 0
   })
 
-  it('runs migrations and returns a configured database', async () => {
+  it('runs migrations and hands drizzle a pool it owns', async () => {
     const database = createMySqlDatabase({
       migrationsFolder: createMigrationsFolder(true),
       connectionString: () => 'mysql://example',
+      clientOptions: { connectTimeout: 1234 },
     })
 
     await database.migrateDatabase()
     expect(migrateMock).toHaveBeenCalled()
+    // The migration pool is short-lived and must not outlive the migration.
+    expect(createdPools.at(0)?.ended).toBe(true)
 
     const db = await database.getDatabase()
-    expect(db).toMatchObject({
-      config: {
-        connection: { uri: 'mysql://example' },
-        mode: 'default',
-      },
-    })
+    expect(createPoolMock).toHaveBeenLastCalledWith({ uri: 'mysql://example', connectTimeout: 1234 })
+    expect(db).toMatchObject({ config: { client: createdPools.at(-1) } })
+
+    await database.closeDatabase()
+    expect(createdPools.at(-1)?.ended).toBe(true)
   })
 
   it('configures the Drizzle adapter', async () => {


### PR DESCRIPTION
## Summary

- `createMySqlDatabase()` was completely non-functional: every query — including `db:migrate`'s first statement — threw `undefined is not an object (evaluating 'client.config.supportBigNumbers = !0')` before touching a socket, on both a reachable and an unreachable host. Root cause: `drizzle-orm@1.0.0-rc.4`'s `mysql2` driver builds its pool through `mysql2/promise` when given `connection: {...}`, and that `PromisePool` wrapper exposes no `.config` for the driver to write `supportBigNumbers` onto. `create-guren-app --db mysql` offers MySQL, so every scaffolded MySQL app was dead on arrival.
- Fixed in `packages/orm/src/mysql.ts` by owning the pool ourselves: build it with `mysql2`'s callback `createPool` and pass it to drizzle as `client:`, mirroring how `postgres.ts` already works. The (unreleased) upstream fix checks `.config` first too, so this stays correct after the next `drizzle-orm` bump — no need to pin a dev snapshot.
- The existing unit tests (`tests/mysql.test.ts`) `mock.module()`s `drizzle-orm/mysql2` away, so the real adapter was never exercised and this shipped invisibly. Added `tests/mysql-integration.test.ts`, gated on `MYSQL_URL`, that runs migrate → query → `migrationStatus` → `resetDatabase` against a live server. Verified it fails with the original TypeError when the fix is reverted.
- Wired a `mysql:8.4` service + `MYSQL_URL` into CI (`.github/workflows/ci.yml`) so the integration test actually runs there instead of silently skipping. Added `bun run db:up:mysql` and a `mysql` service in `compose.yml` for local runs. The integration test creates its own `guren_orm_test` database (via a root connection) rather than using the URL a scaffolded app defaults to, since it drops every table in whatever database it points at.
- Updated `tests/mysql.test.ts` to mock `mysql2`'s `createPool` and assert the new `client:` wiring instead of the old `connection:` shape.
- Added a changeset for `@guren/orm`.

## Test plan

- [x] `bun run --cwd packages/orm typecheck`
- [x] `bun run typecheck` (repo-wide)
- [x] `bun run test:bun` (2775 pass) with `MYSQL_URL` pointed at a local `mysql:8.4` container
- [x] `bun run test:bun orm` — mutation check: reverting `mysql.ts` alone makes the new integration test fail with the original TypeError
- [x] Manual: scaffolded a MySQL app against the built `dist/` output and ran `db:migrate` / `db:status` / `db:reset` via the CLI end-to-end
- [x] Confirmed the integration test's `resetDatabase()` only touches its own dedicated database, leaving a pre-existing `guren` database's tables intact