### PR TITLE
feat(cli): warn about Bun-only defaults on Cloudflare/Vercel/Lambda deploys

### DIFF
--- a/packages/cli/src/deploy-runtime.ts
+++ b/packages/cli/src/deploy-runtime.ts
@@ -1,5 +1,6 @@
 import { readFile, readdir } from 'node:fs/promises'
 import { extname, join, resolve } from 'node:path'
+import { parse, type ParserPlugin } from '@babel/parser'
 import {
   collectFiles,
   toPosixRelative,
@@ -69,12 +70,6 @@ const DEPLOY_PLUGIN_PACKAGES: Record<string, DeployTargetId> = {
   '@guren/plugin-vercel': 'vercel',
 }
 
-/**
- * The Lambda adapter ships inside `@guren/core`/`@guren/server` rather than a
- * plugin package, so it is detected from source imports instead.
- */
-const LAMBDA_SOURCE_PATTERN = /@guren\/(?:core|server)\/lambda|\bcreateLambdaHandler\b/
-
 export interface DeployTargetDetection {
   profile: DeployTargetProfile
   /** Human-readable evidence, e.g. `@guren/plugin-cloudflare in package.json`. */
@@ -93,7 +88,7 @@ export interface DeployRuntimeAnalysis {
   targets: DeployTargetDetection[]
   /** Evidence that the app authenticates with passwords at all. */
   passwordAuthSignals: SourceSignal[]
-  /** `NodeHasher` references — the remediation for a Bun-less runtime. */
+  /** `NodeHasher` constructions — the remediation for a Bun-less runtime. */
   nodeHasherSignals: SourceSignal[]
   /** Evidence that sessions are enabled. */
   sessionSignals: SourceSignal[]
@@ -117,123 +112,286 @@ const DEPLOY_SCAN_DIRS = ['src', 'app', 'config', 'db', 'routes', 'modules', 'bi
 /** Test files are excluded from the scan — see readAppSources. */
 const TEST_FILE_PATTERN = /\.(test|spec)\.[cm]?[jt]sx?$/
 
-type SymbolPatterns = ReadonlyArray<readonly [symbol: string, pattern: RegExp]>
+// --- AST signal extraction -------------------------------------------------
+//
+// Signals are read from a Babel AST (the same parser audit.ts and
+// model-parser.ts already use), not from per-line regexes. That buys, in one
+// mechanism, everything the regex generation of this file had to carve out
+// case by case: aliased imports resolve to their canonical names, values
+// split across lines match, and text inside comments, string literals, and
+// TypeScript type positions can no longer trip a check. Files that fail to
+// parse contribute no signals rather than failing the doctor run.
+
+type SignalKind =
+  | 'passwordAuth'
+  | 'nodeHasher'
+  | 'session'
+  | 'sessionDisabled'
+  | 'oauth'
+  | 'backedSession'
+  | 'backedOAuth'
+  | 'memoryStore'
+  | 'discovery'
+  | 'lambda'
+
+interface ExtractedSignal {
+  kind: SignalKind
+  symbol: string
+  line: number
+}
 
 /**
- * Signals that the password hasher is actually reached: `auth.attempt()` is
- * the entry point app code calls to verify a password (`guard.attempt()` sits
- * underneath it but is never called directly outside the framework's own
- * tests), and an explicitly constructed `ScryptHasher` hashes one (seeders do
- * this).
+ * Classes whose construction is a signal. Construction — not a bare import —
+ * is what counts throughout: a leftover import survives long after the app
+ * stops using the thing it names, and must neither satisfy a remediation
+ * (NodeHasher, the backed stores) nor raise a warning (AutoDiscovery).
  *
- * Deliberately excludes `AuthenticatableModel`, `passwordColumn`, and a
- * `passwordHash` column. OAuth-only apps keep all three — the guard needs
- * `passwordColumn` to reject password logins for hash-less accounts — while
- * never invoking a hasher, so matching them reports a break that cannot happen.
- *
- * Known gap: a registration-only app that creates password-hashing records
- * (`User.create({ password })`) without ever calling `auth.attempt()` would
- * pass undetected. `make:auth` always scaffolds login alongside registration,
- * so this shape doesn't occur in generated apps; a hand-rolled register-only
- * flow is the one case this misses.
+ * ScryptHasher counts as password authentication because constructing one is
+ * only ever done to hash a password (seeders do this). AutoDiscovery maps to
+ * `discovery`; `ApplicationOptions.discover` is deliberately not a signal —
+ * it is declared but never read anywhere in @guren/server, so warning about
+ * it would flag a config key that has no effect.
  */
-const PASSWORD_AUTH_PATTERNS: SymbolPatterns = [
-  ['auth.attempt', /\bauth\s*\.\s*attempt\s*\(/],
-  ['ScryptHasher', /\bnew\s+ScryptHasher\s*\(/],
-]
+const CONSTRUCTED_SIGNALS: Record<string, SignalKind> = {
+  ScryptHasher: 'passwordAuth',
+  NodeHasher: 'nodeHasher',
+  DatabaseSessionStore: 'backedSession',
+  RedisSessionStore: 'backedSession',
+  DatabaseOAuthStateStore: 'backedOAuth',
+  RedisOAuthStateStore: 'backedOAuth',
+  MemorySessionStore: 'memoryStore',
+  MemoryOAuthStateStore: 'memoryStore',
+  MemoryApiTokenStore: 'memoryStore',
+  MemoryPasswordResetStore: 'memoryStore',
+  MemoryEmailVerificationStore: 'memoryStore',
+  MemoryRateLimitStore: 'memoryStore',
+  MemoryStore: 'memoryStore',
+  MemoryDriver: 'memoryStore',
+  AutoDiscovery: 'discovery',
+}
+
+/** Framework functions whose call is a signal. */
+const CALLED_SIGNALS: Record<string, SignalKind> = {
+  createSessionMiddleware: 'session',
+  createOAuthManager: 'oauth',
+  createLambdaHandler: 'lambda',
+}
 
 /**
- * Only a constructed hasher counts — a bare import survives long after the
- * app stops using it. Known gap: `import { NodeHasher as X }; new X()` isn't
- * recognized, since matching an aliased import would need to correlate two
- * separate lines rather than test each line independently. Line-scanning for
- * a literal name is the established pattern throughout this file.
+ * Identifiers whose mere reference (outside an import declaration) is a
+ * signal — OAuthServiceProvider is listed in `createApp({ providers })`
+ * rather than constructed or called.
  */
-const NODE_HASHER_PATTERNS: SymbolPatterns = [['NodeHasher', /\bnew\s+NodeHasher\s*\(/]]
+const REFERENCED_SIGNALS: Record<string, SignalKind> = {
+  OAuthServiceProvider: 'oauth',
+}
 
 /**
- * `AuthServiceProvider` attaches session middleware whenever `options.auth`
- * is present at all and `autoSession` isn't explicitly `false` — `make:auth`
- * itself instructs users to add exactly `auth: {}` to enable sessions and
- * CSRF, so a bare `auth: {}` is the single most common real-world shape and
- * must be caught, not just an explicit `autoSession`/`sessionOptions` key.
- * Requiring the `{` after `auth:` keeps this from matching the unrelated
- * `'auth:user_id'`-style session-key string literals used elsewhere.
- *
- * The explicit opt-out (`autoSession: false`) is intentionally NOT excluded
- * here: `auth: {` alone can't see what the object it opens contains, and
- * `autoSession: false` may sit on a different line or in a different file
- * from the `auth: {` that matched. It is tracked separately in
- * SESSION_DISABLED_PATTERNS and suppresses the warning at the analysis level
- * instead, where it can be checked app-wide rather than line-by-line.
+ * The Lambda adapter ships inside `@guren/core`/`@guren/server` rather than a
+ * plugin package, so it is detected from these import sources (plus bare
+ * `createLambdaHandler` calls via CALLED_SIGNALS).
  */
-const SESSION_PATTERNS: SymbolPatterns = [
-  ['auth', /\bauth\s*:\s*\{/],
-  ['autoSession', /\bautoSession\b/],
-  ['sessionOptions', /\bsessionOptions\b/],
-  ['createSessionMiddleware', /\bcreateSessionMiddleware\b/],
-]
+const LAMBDA_IMPORT_SOURCES = new Set(['@guren/core/lambda', '@guren/server/lambda'])
+
+interface BabelNode {
+  type: string
+  loc?: { start: { line: number } }
+  [key: string]: unknown
+}
 
 /**
- * Known gap: `autoSession:` and `false` split across two lines (e.g. a
- * multi-line-formatted value) won't match, since each pattern is tested
- * against one line at a time. Prettier never breaks a boolean property value
- * onto its own line, so this doesn't occur in formatted code.
+ * Minimal generic AST walker. Recurses into every node-shaped child unless
+ * the visitor returns `false` for the current node.
  */
-const SESSION_DISABLED_PATTERNS: SymbolPatterns = [
-  ['autoSession: false', /\bautoSession\s*:\s*false\b/],
-]
+function walk(value: unknown, visit: (node: BabelNode) => boolean | void): void {
+  if (Array.isArray(value)) {
+    for (const item of value) walk(item, visit)
+    return
+  }
+  if (value === null || typeof value !== 'object') return
+  const node = value as BabelNode
+  if (typeof node.type !== 'string') return
 
-const OAUTH_PATTERNS: SymbolPatterns = [
-  ['createOAuthManager', /\bcreateOAuthManager\b/],
-  ['OAuthServiceProvider', /\bOAuthServiceProvider\b/],
-]
+  if (visit(node) === false) return
+
+  for (const [key, child] of Object.entries(node)) {
+    if (key === 'loc' || key === 'leadingComments' || key === 'trailingComments' || key === 'innerComments') {
+      continue
+    }
+    walk(child, visit)
+  }
+}
+
+function propertyKeyName(property: BabelNode): string | null {
+  if (property.computed) return null
+  const key = property.key as BabelNode | undefined
+  if (key?.type === 'Identifier') return key.name as string
+  if (key?.type === 'StringLiteral') return key.value as string
+  return null
+}
+
+function lineOf(node: BabelNode): number {
+  return node.loc?.start.line ?? 1
+}
 
 /**
- * Backed stores count as remediation only where they are constructed, not
- * merely imported — a leftover import would otherwise silence the warning for
- * an app that no longer wires the store up. Stores built in one module and
- * passed in from another still match, because the whole app tree is scanned.
+ * Extract every deploy-runtime signal from one source file. Returns null when
+ * the file does not parse — the caller skips it.
  */
-const BACKED_SESSION_PATTERNS: SymbolPatterns = [
-  ['DatabaseSessionStore', /\bnew\s+DatabaseSessionStore\s*\(/],
-  ['RedisSessionStore', /\bnew\s+RedisSessionStore\s*\(/],
-]
+function extractSignals(source: string, plugins: ParserPlugin[]): ExtractedSignal[] | null {
+  let ast
+  try {
+    ast = parse(source, { sourceType: 'module', plugins, allowAwaitOutsideFunction: true })
+  } catch {
+    return null
+  }
 
-const BACKED_OAUTH_PATTERNS: SymbolPatterns = [
-  ['DatabaseOAuthStateStore', /\bnew\s+DatabaseOAuthStateStore\s*\(/],
-  ['RedisOAuthStateStore', /\bnew\s+RedisOAuthStateStore\s*\(/],
-]
+  // Named-import aliases (`import { NodeHasher as X }`) resolve to their
+  // canonical exported names, so every table below matches aliased use too.
+  const aliases = new Map<string, string>()
+  for (const statement of ast.program.body) {
+    if (statement.type !== 'ImportDeclaration') continue
+    for (const specifier of statement.specifiers) {
+      if (specifier.type === 'ImportSpecifier') {
+        const imported = specifier.imported
+        aliases.set(specifier.local.name, imported.type === 'Identifier' ? imported.name : imported.value)
+      }
+    }
+  }
+  const canonical = (name: string): string => aliases.get(name) ?? name
 
-/**
- * In-memory stores instantiated explicitly. Unlike the implicit defaults these
- * need no gating signal — constructing one is unambiguous.
- */
-const MEMORY_STORE_PATTERNS: SymbolPatterns = [
-  ['MemorySessionStore', /\bnew\s+MemorySessionStore\s*\(/],
-  ['MemoryOAuthStateStore', /\bnew\s+MemoryOAuthStateStore\s*\(/],
-  ['MemoryApiTokenStore', /\bnew\s+MemoryApiTokenStore\s*\(/],
-  ['MemoryPasswordResetStore', /\bnew\s+MemoryPasswordResetStore\s*\(/],
-  ['MemoryEmailVerificationStore', /\bnew\s+MemoryEmailVerificationStore\s*\(/],
-  ['MemoryRateLimitStore', /\bnew\s+MemoryRateLimitStore\s*\(/],
-  ['MemoryStore', /\bnew\s+MemoryStore\s*\(/],
-  ['MemoryDriver', /\bnew\s+MemoryDriver\s*\(/],
-]
+  const signals: ExtractedSignal[] = []
+  const seen = new Set<string>()
+  const emit = (kind: SignalKind, symbol: string, line: number): void => {
+    const key = `${kind} ${symbol}`
+    if (seen.has(key)) return
+    seen.add(key)
+    signals.push({ kind, symbol, line })
+  }
 
-/**
- * Only a constructed AutoDiscovery counts — a bare import isn't active use.
- * `ApplicationOptions.discover` is deliberately not matched here: it is
- * declared but never read anywhere in @guren/server, so it has no effect —
- * warning about it would flag a config key that doesn't actually do anything.
- */
-const DISCOVERY_PATTERNS: SymbolPatterns = [
-  ['AutoDiscovery', /\bnew\s+AutoDiscovery\s*\(/],
-]
+  walk(ast.program, (node) => {
+    switch (node.type) {
+      case 'ImportDeclaration': {
+        const source = node.source as BabelNode
+        if (LAMBDA_IMPORT_SOURCES.has(source.value as string)) {
+          emit('lambda', source.value as string, lineOf(node))
+        }
+        // Import specifiers are declarations, not usage — never signals.
+        return false
+      }
+
+      case 'ExportNamedDeclaration':
+      case 'ExportAllDeclaration': {
+        const source = node.source as BabelNode | null
+        if (source && LAMBDA_IMPORT_SOURCES.has(source.value as string)) {
+          emit('lambda', source.value as string, lineOf(node))
+        }
+        return
+      }
+
+      case 'NewExpression': {
+        const callee = node.callee as BabelNode
+        if (callee?.type === 'Identifier') {
+          const name = canonical(callee.name as string)
+          const kind = CONSTRUCTED_SIGNALS[name]
+          if (kind) emit(kind, name, lineOf(node))
+        }
+        return
+      }
+
+      case 'CallExpression': {
+        const callee = node.callee as BabelNode
+        if (callee?.type === 'Identifier') {
+          const name = canonical(callee.name as string)
+          const kind = CALLED_SIGNALS[name]
+          if (kind) emit(kind, name, lineOf(node))
+
+          // An `auth` key in createApp's options object enables sessions:
+          // AuthServiceProvider attaches session middleware whenever
+          // `options.auth` is present and autoSession isn't explicitly false.
+          // `make:auth` itself tells users to add exactly `auth: {}`, so the
+          // bare key with no session-specific fields is the most common
+          // real-world shape. Scoping to createApp (rather than any `auth:`
+          // object) keeps SMTP-style `auth: { user, pass }` mailer config
+          // from reading as a session.
+          if (name === 'createApp') {
+            const first = (node.arguments as BabelNode[])[0]
+            if (first?.type === 'ObjectExpression') {
+              for (const property of first.properties as BabelNode[]) {
+                if (property.type === 'ObjectProperty' && propertyKeyName(property) === 'auth') {
+                  emit('session', 'auth', lineOf(property))
+                }
+              }
+            }
+          }
+        } else if (callee?.type === 'MemberExpression') {
+          // `auth.attempt(...)` / `this.auth.attempt(...)` is the entry point
+          // app code calls to verify a password (`guard.attempt()` sits
+          // underneath it but is never called directly outside the
+          // framework's own tests). Known gap: a registration-only app that
+          // creates password-hashing records without ever calling attempt()
+          // passes undetected — `make:auth` always scaffolds login alongside
+          // registration, so that shape doesn't occur in generated apps.
+          const property = callee.property as BabelNode
+          const object = callee.object as BabelNode
+          const isAttempt = property?.type === 'Identifier' && property.name === 'attempt'
+          const onAuth =
+            (object?.type === 'Identifier' && object.name === 'auth') ||
+            (object?.type === 'MemberExpression' &&
+              (object.property as BabelNode)?.type === 'Identifier' &&
+              (object.property as BabelNode).name === 'auth')
+          if (isAttempt && onAuth) emit('passwordAuth', 'auth.attempt', lineOf(node))
+        } else if (callee?.type === 'Import') {
+          const first = (node.arguments as BabelNode[])[0]
+          if (first?.type === 'StringLiteral' && LAMBDA_IMPORT_SOURCES.has(first.value as string)) {
+            emit('lambda', first.value as string, lineOf(node))
+          }
+        }
+        return
+      }
+
+      case 'ObjectProperty': {
+        // autoSession/sessionOptions count wherever they appear — session
+        // config objects are routinely built outside the createApp call and
+        // passed in. `autoSession: false` additionally raises the disabled
+        // signal, which suppresses the session warning at the analysis level:
+        // the opt-out may live in a different object or file than the
+        // `auth` key that raised the signal.
+        const keyName = propertyKeyName(node)
+        if (keyName === 'autoSession') {
+          emit('session', 'autoSession', lineOf(node))
+          const value = node.value as BabelNode
+          if (value?.type === 'BooleanLiteral' && value.value === false) {
+            emit('sessionDisabled', 'autoSession: false', lineOf(node))
+          }
+        } else if (keyName === 'sessionOptions') {
+          emit('session', 'sessionOptions', lineOf(node))
+        }
+        return
+      }
+
+      case 'Identifier': {
+        const name = canonical(node.name as string)
+        const kind = REFERENCED_SIGNALS[name]
+        if (kind) emit(kind, name, lineOf(node))
+        return
+      }
+    }
+  })
+
+  return signals
+}
 
 interface ScannedFile {
   filePath: string
-  /** Split once per file and reused across every pattern pass in findSignals. */
-  lines: string[]
+  signals: ExtractedSignal[]
+}
+
+function parserPluginsFor(path: string): ParserPlugin[] {
+  // JSX is off for .ts/.mts so angle-bracket type assertions still parse;
+  // everywhere else it is harmless and lets .tsx/.jsx through.
+  const ext = extname(path)
+  return ext === '.ts' || ext === '.mts' ? ['typescript'] : ['typescript', 'jsx']
 }
 
 /**
@@ -255,8 +413,9 @@ async function readRootSourceFiles(cwd: string): Promise<string[]> {
 }
 
 /**
- * Read the app's own source files from a bounded set of roots: the directories
- * in DEPLOY_SCAN_DIRS plus any source file in the project root.
+ * Read and signal-scan the app's own source files from a bounded set of
+ * roots: the directories in DEPLOY_SCAN_DIRS plus any source file in the
+ * project root.
  *
  * Test files are excluded. A fixture that constructs a backed store or a
  * NodeHasher would otherwise satisfy the remediation check on behalf of an
@@ -279,26 +438,13 @@ async function readAppSources(cwd: string): Promise<ScannedFile[]> {
     paths.map(async (path) => {
       const content = await readFile(path, 'utf8').catch(() => null)
       if (content === null) return null
-      return { filePath: toPosixRelative(cwd, path), lines: content.split('\n') }
+      const signals = extractSignals(content, parserPluginsFor(path))
+      if (signals === null) return null
+      return { filePath: toPosixRelative(cwd, path), signals }
     }),
   )
 
   return scanned.filter((file): file is ScannedFile => file !== null)
-}
-
-function findSignals(files: ScannedFile[], patterns: SymbolPatterns): SourceSignal[] {
-  const signals: SourceSignal[] = []
-
-  for (const file of files) {
-    for (const [symbol, pattern] of patterns) {
-      const index = file.lines.findIndex((line) => pattern.test(line))
-      if (index !== -1) {
-        signals.push({ symbol, filePath: file.filePath, line: index + 1 })
-      }
-    }
-  }
-
-  return signals
 }
 
 /**
@@ -318,7 +464,7 @@ async function detectDeployTargets(cwd: string, files: ScannedFile[]): Promise<D
     }
   }
 
-  const lambdaFile = files.find((file) => file.lines.some((line) => LAMBDA_SOURCE_PATTERN.test(line)))
+  const lambdaFile = files.find((file) => file.signals.some((signal) => signal.kind === 'lambda'))
   if (lambdaFile) {
     detections.push({
       profile: DEPLOY_TARGET_PROFILES.lambda,
@@ -338,17 +484,24 @@ export async function analyzeDeployRuntime(cwd: string): Promise<DeployRuntimeAn
   const files = await readAppSources(cwd)
   const targets = await detectDeployTargets(cwd, files)
 
+  const collect = (kind: SignalKind): SourceSignal[] =>
+    files.flatMap((file) =>
+      file.signals
+        .filter((signal) => signal.kind === kind)
+        .map((signal) => ({ symbol: signal.symbol, filePath: file.filePath, line: signal.line })),
+    )
+
   return {
     targets,
-    passwordAuthSignals: findSignals(files, PASSWORD_AUTH_PATTERNS),
-    nodeHasherSignals: findSignals(files, NODE_HASHER_PATTERNS),
-    sessionSignals: findSignals(files, SESSION_PATTERNS),
-    sessionDisabledSignals: findSignals(files, SESSION_DISABLED_PATTERNS),
-    oauthSignals: findSignals(files, OAUTH_PATTERNS),
-    backedSessionSignals: findSignals(files, BACKED_SESSION_PATTERNS),
-    backedOAuthSignals: findSignals(files, BACKED_OAUTH_PATTERNS),
-    memoryStoreSignals: findSignals(files, MEMORY_STORE_PATTERNS),
-    discoverySignals: findSignals(files, DISCOVERY_PATTERNS),
+    passwordAuthSignals: collect('passwordAuth'),
+    nodeHasherSignals: collect('nodeHasher'),
+    sessionSignals: collect('session'),
+    sessionDisabledSignals: collect('sessionDisabled'),
+    oauthSignals: collect('oauth'),
+    backedSessionSignals: collect('backedSession'),
+    backedOAuthSignals: collect('backedOAuth'),
+    memoryStoreSignals: collect('memoryStore'),
+    discoverySignals: collect('discovery'),
   }
 }
 

--- a/packages/cli/src/deploy-runtime.ts
+++ b/packages/cli/src/deploy-runtime.ts
@@ -19,7 +19,6 @@ import { readDeclaredDependencyNames } from './plugin-manifest'
 type DeployTargetId = 'cloudflare' | 'vercel' | 'lambda'
 
 export interface DeployTargetProfile {
-  id: DeployTargetId
   label: string
   /**
    * Whether `Bun.password` — the backend behind the default `ScryptHasher` —
@@ -34,13 +33,11 @@ export interface DeployTargetProfile {
 
 const DEPLOY_TARGET_PROFILES: Record<DeployTargetId, DeployTargetProfile> = {
   cloudflare: {
-    id: 'cloudflare',
     label: 'Cloudflare Workers',
     hasBunRuntime: false,
     discoveryBlocker: 'Workers has no filesystem and no Bun runtime, so `Bun.Glob` scanning finds nothing.',
   },
   vercel: {
-    id: 'vercel',
     label: 'Vercel',
     // The function is a `bun build` bundle; buildVercelOutput copies
     // .guren/ssr, db/migrations, docs and public into it, never `app/`.
@@ -48,7 +45,6 @@ const DEPLOY_TARGET_PROFILES: Record<DeployTargetId, DeployTargetProfile> = {
     discoveryBlocker: 'The Vercel function is a `bun build` bundle that ships no `app/` directory to scan.',
   },
   lambda: {
-    id: 'lambda',
     label: 'AWS Lambda',
     hasBunRuntime: false,
     discoveryBlocker: 'Lambda runs Node.js, where `Bun.Glob` is unavailable.',
@@ -105,15 +101,17 @@ export interface DeployRuntimeAnalysis {
   /** Explicit use of filesystem-scanning provider discovery. */
   discoverySignals: SourceSignal[]
   /**
-   * Files that failed to parse and therefore contributed no signals. Surfaced
-   * in the check messages so a missed hazard or remediation is a visible
-   * caveat, not a silent false negative — the same stance ESLint (parse
-   * errors are errors) and semgrep (skipped files are counted) take.
+   * Files that could not be read or parsed and therefore contributed no
+   * signals. Surfaced in every deploy check message so a missed hazard or
+   * remediation is a visible caveat, not a silent false negative — the same
+   * stance ESLint (parse errors are errors) and semgrep (skipped files are
+   * counted) take. Note this also covers *target* detection: the Lambda
+   * adapter is found in source, so a skipped file can hide a target too.
    */
   unparsedFiles: string[]
 }
 
-/** Directories scanned for the symbols above. */
+/** Directories scanned for signal symbols. */
 const DEPLOY_SCAN_DIRS = ['src', 'app', 'config', 'db', 'routes', 'modules', 'bin', 'functions', 'api'] as const
 
 /** Test files are excluded from the scan — see readAppSources. */
@@ -233,6 +231,9 @@ const TYPE_ONLY_NODES = new Set([
   'TSConstructSignatureDeclaration',
   'TSTypeLiteral',
   'TSQualifiedName',
+  // `class X implements Y` / `interface A extends B`. A class's `extends`
+  // clause is a plain expression on `superClass`, so it stays walkable.
+  'TSExpressionWithTypeArguments',
 ])
 
 /**
@@ -263,11 +264,13 @@ function walk(value: unknown, visit: (node: BabelNode) => boolean | void): void 
 
   if (visit(node) === false) return
 
-  for (const [key, child] of Object.entries(node)) {
+  // for...in rather than Object.entries: the latter allocates an entry array
+  // per node, which measurably dominates traversal on a large AST.
+  for (const key in node) {
     if (key === 'loc' || key === 'leadingComments' || key === 'trailingComments' || key === 'innerComments') {
       continue
     }
-    walk(child, visit)
+    walk(node[key], visit)
   }
 }
 
@@ -301,10 +304,17 @@ function extractSignals(source: string, plugins: ParserPlugin[]): ExtractedSigna
   // export from another package never resolves to a signal.
   const gurenNames = new Map<string, string>()
   const gurenNamespaces = new Set<string>()
+  // Whether the file imports from Guren at all, type-only imports included.
+  // The two signals resolved structurally rather than through a binding —
+  // `auth.attempt()` (a controller property) and the session option keys —
+  // use this to stay inside Guren code: without it any library's
+  // `auth.attempt()` or `sessionOptions` key raised a Guren signal.
+  let importsGuren = false
   for (const statement of ast.program.body) {
     if (statement.type !== 'ImportDeclaration') continue
-    if (statement.importKind === 'type') continue
     if (!statement.source.value.startsWith(GUREN_PACKAGE_PREFIX)) continue
+    importsGuren = true
+    if (statement.importKind === 'type') continue
     for (const specifier of statement.specifiers) {
       if (specifier.type === 'ImportSpecifier') {
         if (specifier.importKind === 'type') continue
@@ -372,8 +382,10 @@ function extractSignals(source: string, plugins: ParserPlugin[]): ExtractedSigna
 
       case 'NewExpression': {
         const name = resolve(node.callee as BabelNode)
-        const kind = name ? CONSTRUCTED_SIGNALS[name] : undefined
-        if (name && kind) emit(kind, name, lineOf(node))
+        if (name) {
+          const kind = CONSTRUCTED_SIGNALS[name]
+          if (kind) emit(kind, name, lineOf(node))
+        }
         return
       }
 
@@ -423,7 +435,7 @@ function extractSignals(source: string, plugins: ParserPlugin[]): ExtractedSigna
             (object?.type === 'MemberExpression' &&
               (object.property as BabelNode)?.type === 'Identifier' &&
               (object.property as BabelNode).name === 'auth')
-          if (isAttempt && onAuth) emit('passwordAuth', 'auth.attempt', lineOf(node))
+          if (isAttempt && onAuth && importsGuren) emit('passwordAuth', 'auth.attempt', lineOf(node))
         } else if (callee?.type === 'Import') {
           const first = (node.arguments as BabelNode[])[0]
           if (first?.type === 'StringLiteral' && LAMBDA_IMPORT_SOURCES.has(first.value as string)) {
@@ -436,18 +448,22 @@ function extractSignals(source: string, plugins: ParserPlugin[]): ExtractedSigna
       case 'ObjectProperty': {
         // autoSession/sessionOptions count wherever they appear — session
         // config objects are routinely built outside the createApp call and
-        // passed in. `autoSession: false` additionally raises the disabled
-        // signal, which suppresses the session warning at the analysis level:
-        // the opt-out may live in a different object or file than the
-        // `auth` key that raised the signal.
+        // passed in — but only inside a file that imports from Guren, since
+        // neither key is distinctive enough to claim on its own.
+        //
+        // `autoSession: false` is the deliberate exception: it *suppresses*
+        // the warning, so it is read everywhere, gate or no gate. Missing an
+        // opt-out warns a correctly-configured app, which is the failure
+        // direction this check exists to avoid; missing an opt-in only costs
+        // a warning the `auth` key already raises in the common shape.
         const keyName = propertyKeyName(node)
         if (keyName === 'autoSession') {
-          emit('session', 'autoSession', lineOf(node))
+          if (importsGuren) emit('session', 'autoSession', lineOf(node))
           const value = node.value as BabelNode
           if (value?.type === 'BooleanLiteral' && value.value === false) {
             emit('sessionDisabled', 'autoSession: false', lineOf(node))
           }
-        } else if (keyName === 'sessionOptions') {
+        } else if (keyName === 'sessionOptions' && importsGuren) {
           emit('session', 'sessionOptions', lineOf(node))
         }
         return
@@ -455,8 +471,10 @@ function extractSignals(source: string, plugins: ParserPlugin[]): ExtractedSigna
 
       case 'Identifier': {
         const name = resolve(node)
-        const kind = name ? REFERENCED_SIGNALS[name] : undefined
-        if (name && kind) emit(kind, name, lineOf(node))
+        if (name) {
+          const kind = REFERENCED_SIGNALS[name]
+          if (kind) emit(kind, name, lineOf(node))
+        }
         return
       }
     }
@@ -485,8 +503,9 @@ function parserPluginsFor(path: string): ParserPlugin[] {
 
 /**
  * Source files sitting directly in the project root. Deploy entrypoints
- * (`lambda.ts`, `worker.ts`) conventionally live there, and collectFiles only
- * recurses, so the root's own files need their own non-recursive pass.
+ * (`lambda.ts`, `worker.ts`) conventionally live there, and no DEPLOY_SCAN_DIRS
+ * entry covers the root itself — pointing collectFiles at it would walk the
+ * whole tree, so the root gets its own non-recursive pass.
  */
 async function readRootSourceFiles(cwd: string): Promise<string[]> {
   try {
@@ -527,7 +546,10 @@ async function readAppSources(cwd: string): Promise<{ files: ScannedFile[]; unpa
     paths.map(async (path) => {
       const filePath = toPosixRelative(cwd, path)
       const content = await readFile(path, 'utf8').catch(() => null)
-      if (content === null) return null
+      // An unreadable file is reported alongside an unparseable one: both
+      // contribute no signals, and silently dropping either is the hole the
+      // caveat exists to close.
+      if (content === null) return { filePath, signals: null }
       return { filePath, signals: extractSignals(content, parserPluginsFor(path)) }
     }),
   )
@@ -612,7 +634,7 @@ export function formatParseCaveat(analysis: DeployRuntimeAnalysis): string {
 
   const shown = unparsedFiles.slice(0, 3).join(', ')
   const more = unparsedFiles.length > 3 ? ` and ${unparsedFiles.length - 3} more` : ''
-  return ` Note: ${unparsedFiles.length} file(s) could not be parsed and were not scanned: ${shown}${more}.`
+  return ` Note: ${unparsedFiles.length} file(s) could not be read or parsed and were not scanned: ${shown}${more}.`
 }
 
 /** Targets that lack `Bun.password`, so the default `ScryptHasher` breaks. */

--- a/packages/cli/src/deploy-runtime.ts
+++ b/packages/cli/src/deploy-runtime.ts
@@ -1,0 +1,357 @@
+import { readFile, readdir } from 'node:fs/promises'
+import { extname, join, resolve } from 'node:path'
+import {
+  collectFiles,
+  toPosixRelative,
+  IMPORTABLE_EXTENSIONS,
+  NON_SOURCE_DIR_NAMES,
+} from './discovery'
+import { readDeclaredDependencyNames } from './plugin-manifest'
+
+/**
+ * Deploy targets whose runtime invalidates one or more of Guren's Bun-first
+ * defaults. The prose versions of these warnings live in
+ * packages/plugin-cloudflare/README.md ("Things Workers changes") and
+ * docs/{en,ja}/guides/serverless.md; the checks below are their mechanical
+ * counterpart.
+ */
+export type DeployTargetId = 'cloudflare' | 'vercel' | 'lambda'
+
+export interface DeployTargetProfile {
+  id: DeployTargetId
+  label: string
+  /**
+   * Whether `Bun.password` — the backend behind the default `ScryptHasher` —
+   * exists at runtime. Vercel functions are built by `@guren/plugin-vercel`
+   * with `runtime: 'bun1.x'`, so Bun's password APIs are present there; only
+   * Workers (workerd) and Lambda (Node.js) lose them.
+   */
+  hasBunRuntime: boolean
+  /** Why filesystem-scanning provider discovery cannot work on this target. */
+  discoveryBlocker: string
+}
+
+const DEPLOY_TARGET_PROFILES: Record<DeployTargetId, DeployTargetProfile> = {
+  cloudflare: {
+    id: 'cloudflare',
+    label: 'Cloudflare Workers',
+    hasBunRuntime: false,
+    discoveryBlocker: 'Workers has no filesystem and no Bun runtime, so `Bun.Glob` scanning finds nothing.',
+  },
+  vercel: {
+    id: 'vercel',
+    label: 'Vercel',
+    // The function is a `bun build` bundle; buildVercelOutput copies
+    // .guren/ssr, db/migrations, docs and public into it, never `app/`.
+    hasBunRuntime: true,
+    discoveryBlocker: 'The Vercel function is a `bun build` bundle that ships no `app/` directory to scan.',
+  },
+  lambda: {
+    id: 'lambda',
+    label: 'AWS Lambda',
+    hasBunRuntime: false,
+    discoveryBlocker: 'Lambda runs Node.js, where `Bun.Glob` is unavailable.',
+  },
+}
+
+/** Deploy plugin package names, matched against the app's own package.json. */
+const DEPLOY_PLUGIN_PACKAGES: Record<string, DeployTargetId> = {
+  '@guren/plugin-cloudflare': 'cloudflare',
+  '@guren/plugin-vercel': 'vercel',
+}
+
+/**
+ * The Lambda adapter ships inside `@guren/core`/`@guren/server` rather than a
+ * plugin package, so it is detected from source imports instead.
+ */
+const LAMBDA_SOURCE_PATTERN = /@guren\/(?:core|server)\/lambda|\bcreateLambdaHandler\b/
+
+export interface DeployTargetDetection {
+  profile: DeployTargetProfile
+  /** Human-readable evidence, e.g. `@guren/plugin-cloudflare in package.json`. */
+  detectedVia: string
+}
+
+/** A symbol match found while scanning app sources, with its location. */
+export interface SourceSignal {
+  symbol: string
+  /** POSIX-relative path from the project root. */
+  filePath: string
+  line: number
+}
+
+export interface DeployRuntimeAnalysis {
+  targets: DeployTargetDetection[]
+  /** Targets that lack `Bun.password`, so the default `ScryptHasher` breaks. */
+  bunlessTargets: DeployTargetDetection[]
+  /** Evidence that the app authenticates with passwords at all. */
+  passwordAuthSignals: SourceSignal[]
+  /** `NodeHasher` references — the remediation for a Bun-less runtime. */
+  nodeHasherSignals: SourceSignal[]
+  /** Evidence that sessions are enabled. */
+  sessionSignals: SourceSignal[]
+  /** `autoSession: false` anywhere in the app — an explicit opt-out. */
+  sessionDisabledSignals: SourceSignal[]
+  /** Evidence that OAuth is used, which brings the OAuth state store with it. */
+  oauthSignals: SourceSignal[]
+  /** Database- or Redis-backed session stores — remediation for sessions. */
+  backedSessionSignals: SourceSignal[]
+  /** Database- or Redis-backed OAuth state stores. */
+  backedOAuthSignals: SourceSignal[]
+  /** Explicit `new Memory*Store()` / `new MemoryDriver()` constructions. */
+  memoryStoreSignals: SourceSignal[]
+  /** Explicit use of filesystem-scanning provider discovery. */
+  discoverySignals: SourceSignal[]
+}
+
+/** Directories scanned for the symbols above. */
+const DEPLOY_SCAN_DIRS = ['src', 'app', 'config', 'db', 'routes', 'modules', 'bin', 'functions', 'api'] as const
+
+type SymbolPatterns = ReadonlyArray<readonly [symbol: string, pattern: RegExp]>
+
+/**
+ * Signals that the password hasher is actually reached: `auth.attempt()` is
+ * the entry point app code calls to verify a password (`guard.attempt()` sits
+ * underneath it but is never called directly outside the framework's own
+ * tests), and an explicitly constructed `ScryptHasher` hashes one (seeders do
+ * this).
+ *
+ * Deliberately excludes `AuthenticatableModel`, `passwordColumn`, and a
+ * `passwordHash` column. OAuth-only apps keep all three — the guard needs
+ * `passwordColumn` to reject password logins for hash-less accounts — while
+ * never invoking a hasher, so matching them reports a break that cannot happen.
+ *
+ * Known gap: a registration-only app that creates password-hashing records
+ * (`User.create({ password })`) without ever calling `auth.attempt()` would
+ * pass undetected. `make:auth` always scaffolds login alongside registration,
+ * so this shape doesn't occur in generated apps; a hand-rolled register-only
+ * flow is the one case this misses.
+ */
+const PASSWORD_AUTH_PATTERNS: SymbolPatterns = [
+  ['auth.attempt', /\bauth\s*\.\s*attempt\s*\(/],
+  ['ScryptHasher', /\bnew\s+ScryptHasher\s*\(/],
+]
+
+/**
+ * Only a constructed hasher counts — a bare import survives long after the
+ * app stops using it. Known gap: `import { NodeHasher as X }; new X()` isn't
+ * recognized, since matching an aliased import would need to correlate two
+ * separate lines rather than test each line independently. Line-scanning for
+ * a literal name is the established pattern throughout this file.
+ */
+const NODE_HASHER_PATTERNS: SymbolPatterns = [['NodeHasher', /\bnew\s+NodeHasher\s*\(/]]
+
+/**
+ * `AuthServiceProvider` attaches session middleware whenever `options.auth`
+ * is present at all and `autoSession` isn't explicitly `false` — `make:auth`
+ * itself instructs users to add exactly `auth: {}` to enable sessions and
+ * CSRF, so a bare `auth: {}` is the single most common real-world shape and
+ * must be caught, not just an explicit `autoSession`/`sessionOptions` key.
+ * Requiring the `{` after `auth:` keeps this from matching the unrelated
+ * `'auth:user_id'`-style session-key string literals used elsewhere.
+ *
+ * The explicit opt-out (`autoSession: false`) is intentionally NOT excluded
+ * here: `auth: {` alone can't see what the object it opens contains, and
+ * `autoSession: false` may sit on a different line or in a different file
+ * from the `auth: {` that matched. It is tracked separately in
+ * SESSION_DISABLED_PATTERNS and suppresses the warning at the analysis level
+ * instead, where it can be checked app-wide rather than line-by-line.
+ */
+const SESSION_PATTERNS: SymbolPatterns = [
+  ['auth', /\bauth\s*:\s*\{/],
+  ['autoSession', /\bautoSession\b/],
+  ['sessionOptions', /\bsessionOptions\b/],
+  ['createSessionMiddleware', /\bcreateSessionMiddleware\b/],
+]
+
+/**
+ * Known gap: `autoSession:` and `false` split across two lines (e.g. a
+ * multi-line-formatted value) won't match, since each pattern is tested
+ * against one line at a time. Prettier never breaks a boolean property value
+ * onto its own line, so this doesn't occur in formatted code.
+ */
+const SESSION_DISABLED_PATTERNS: SymbolPatterns = [
+  ['autoSession: false', /\bautoSession\s*:\s*false\b/],
+]
+
+const OAUTH_PATTERNS: SymbolPatterns = [
+  ['createOAuthManager', /\bcreateOAuthManager\b/],
+  ['OAuthServiceProvider', /\bOAuthServiceProvider\b/],
+]
+
+/**
+ * Backed stores count as remediation only where they are constructed, not
+ * merely imported — a leftover import would otherwise silence the warning for
+ * an app that no longer wires the store up. Stores built in one module and
+ * passed in from another still match, because the whole app tree is scanned.
+ */
+const BACKED_SESSION_PATTERNS: SymbolPatterns = [
+  ['DatabaseSessionStore', /\bnew\s+DatabaseSessionStore\s*\(/],
+  ['RedisSessionStore', /\bnew\s+RedisSessionStore\s*\(/],
+]
+
+const BACKED_OAUTH_PATTERNS: SymbolPatterns = [
+  ['DatabaseOAuthStateStore', /\bnew\s+DatabaseOAuthStateStore\s*\(/],
+  ['RedisOAuthStateStore', /\bnew\s+RedisOAuthStateStore\s*\(/],
+]
+
+/**
+ * In-memory stores instantiated explicitly. Unlike the implicit defaults these
+ * need no gating signal — constructing one is unambiguous.
+ */
+const MEMORY_STORE_PATTERNS: SymbolPatterns = [
+  ['MemorySessionStore', /\bnew\s+MemorySessionStore\s*\(/],
+  ['MemoryOAuthStateStore', /\bnew\s+MemoryOAuthStateStore\s*\(/],
+  ['MemoryApiTokenStore', /\bnew\s+MemoryApiTokenStore\s*\(/],
+  ['MemoryPasswordResetStore', /\bnew\s+MemoryPasswordResetStore\s*\(/],
+  ['MemoryEmailVerificationStore', /\bnew\s+MemoryEmailVerificationStore\s*\(/],
+  ['MemoryRateLimitStore', /\bnew\s+MemoryRateLimitStore\s*\(/],
+  ['MemoryStore', /\bnew\s+MemoryStore\s*\(/],
+  ['MemoryDriver', /\bnew\s+MemoryDriver\s*\(/],
+]
+
+/**
+ * Only a constructed AutoDiscovery counts — a bare import isn't active use.
+ * `ApplicationOptions.discover` is deliberately not matched here: it is
+ * declared but never read anywhere in @guren/server, so it has no effect —
+ * warning about it would flag a config key that doesn't actually do anything.
+ *
+ * Known gap: `import { AutoDiscovery as X }; new X()` isn't recognized, the
+ * same aliased-import limitation as NODE_HASHER_PATTERNS above.
+ */
+const DISCOVERY_PATTERNS: SymbolPatterns = [
+  ['AutoDiscovery', /\bnew\s+AutoDiscovery\s*\(/],
+]
+
+interface ScannedFile {
+  filePath: string
+  content: string
+  /** Split once per file and reused across every pattern pass in findSignals. */
+  lines: string[]
+}
+
+/**
+ * Read the app's own source files from a bounded set of roots: the directories
+ * in DEPLOY_SCAN_DIRS plus any source file sitting directly in the project root
+ * (deploy entrypoints like `lambda.ts` or `worker.ts` conventionally live there).
+ */
+async function readAppSources(cwd: string): Promise<ScannedFile[]> {
+  const directoryFiles = await Promise.all(
+    DEPLOY_SCAN_DIRS.map((dir) =>
+      collectFiles(resolve(cwd, dir), IMPORTABLE_EXTENSIONS, NON_SOURCE_DIR_NAMES),
+    ),
+  )
+
+  const rootFiles: string[] = []
+  try {
+    for (const entry of await readdir(cwd, { withFileTypes: true })) {
+      if (!entry.isFile() || entry.name.startsWith('.')) continue
+      if (entry.name.endsWith('.d.ts')) continue
+      if (IMPORTABLE_EXTENSIONS.has(extname(entry.name))) {
+        rootFiles.push(join(cwd, entry.name))
+      }
+    }
+  } catch {
+    // An unreadable project root leaves the directory scans as the only input.
+  }
+
+  const paths = [...rootFiles, ...directoryFiles.flat()]
+
+  const scanned = await Promise.all(
+    paths.map(async (path) => {
+      const content = await readFile(path, 'utf8').catch(() => null)
+      if (content === null) return null
+      return { filePath: toPosixRelative(cwd, path), content, lines: content.split('\n') }
+    }),
+  )
+
+  return scanned.filter((file): file is ScannedFile => file !== null)
+}
+
+function findSignals(files: ScannedFile[], patterns: SymbolPatterns): SourceSignal[] {
+  const signals: SourceSignal[] = []
+
+  for (const file of files) {
+    for (const [symbol, pattern] of patterns) {
+      const index = file.lines.findIndex((line) => pattern.test(line))
+      if (index !== -1) {
+        signals.push({ symbol, filePath: file.filePath, line: index + 1 })
+      }
+    }
+  }
+
+  return signals
+}
+
+/**
+ * Deploy targets declared by the app: plugin packages from its package.json
+ * dependencies, plus the Lambda adapter detected from source imports.
+ */
+export async function detectDeployTargets(cwd: string): Promise<DeployTargetDetection[]> {
+  return detectTargetsIn(cwd, await readAppSources(cwd))
+}
+
+async function detectTargetsIn(cwd: string, files: ScannedFile[]): Promise<DeployTargetDetection[]> {
+  const detections: DeployTargetDetection[] = []
+
+  const declared = new Set(await readDeclaredDependencyNames(cwd))
+  for (const [packageName, targetId] of Object.entries(DEPLOY_PLUGIN_PACKAGES)) {
+    if (declared.has(packageName)) {
+      detections.push({
+        profile: DEPLOY_TARGET_PROFILES[targetId],
+        detectedVia: `${packageName} in package.json`,
+      })
+    }
+  }
+
+  const lambdaFile = files.find((file) => LAMBDA_SOURCE_PATTERN.test(file.content))
+  if (lambdaFile) {
+    detections.push({
+      profile: DEPLOY_TARGET_PROFILES.lambda,
+      detectedVia: `Lambda adapter imported in ${lambdaFile.filePath}`,
+    })
+  }
+
+  return detections
+}
+
+/**
+ * Scan the app once and collect everything the deploy-runtime doctor checks
+ * need: which deploy targets are declared, and which Bun-only defaults are
+ * still in force.
+ */
+export async function analyzeDeployRuntime(cwd: string): Promise<DeployRuntimeAnalysis> {
+  const files = await readAppSources(cwd)
+  const targets = await detectTargetsIn(cwd, files)
+
+  return {
+    targets,
+    bunlessTargets: targets.filter((target) => !target.profile.hasBunRuntime),
+    passwordAuthSignals: findSignals(files, PASSWORD_AUTH_PATTERNS),
+    nodeHasherSignals: findSignals(files, NODE_HASHER_PATTERNS),
+    sessionSignals: findSignals(files, SESSION_PATTERNS),
+    sessionDisabledSignals: findSignals(files, SESSION_DISABLED_PATTERNS),
+    oauthSignals: findSignals(files, OAUTH_PATTERNS),
+    backedSessionSignals: findSignals(files, BACKED_SESSION_PATTERNS),
+    backedOAuthSignals: findSignals(files, BACKED_OAUTH_PATTERNS),
+    memoryStoreSignals: findSignals(files, MEMORY_STORE_PATTERNS),
+    discoverySignals: findSignals(files, DISCOVERY_PATTERNS),
+  }
+}
+
+export function formatTargetLabels(targets: DeployTargetDetection[]): string {
+  return targets.map((target) => target.profile.label).join(', ')
+}
+
+export function formatSignals(signals: SourceSignal[]): string {
+  const unique = new Map<string, SourceSignal>()
+  for (const signal of signals) {
+    if (!unique.has(signal.symbol)) {
+      unique.set(signal.symbol, signal)
+    }
+  }
+
+  return [...unique.values()]
+    .map((signal) => `${signal.symbol} (${signal.filePath}:${signal.line})`)
+    .join(', ')
+}

--- a/packages/cli/src/deploy-runtime.ts
+++ b/packages/cli/src/deploy-runtime.ts
@@ -15,7 +15,7 @@ import { readDeclaredDependencyNames } from './plugin-manifest'
  * docs/{en,ja}/guides/serverless.md; the checks below are their mechanical
  * counterpart.
  */
-export type DeployTargetId = 'cloudflare' | 'vercel' | 'lambda'
+type DeployTargetId = 'cloudflare' | 'vercel' | 'lambda'
 
 export interface DeployTargetProfile {
   id: DeployTargetId
@@ -54,7 +54,16 @@ const DEPLOY_TARGET_PROFILES: Record<DeployTargetId, DeployTargetProfile> = {
   },
 }
 
-/** Deploy plugin package names, matched against the app's own package.json. */
+/**
+ * Deploy plugin package names, matched against the app's own package.json.
+ *
+ * Matched by name rather than driven off the `gurenPlugin` manifest for two
+ * reasons: the manifest lives in `node_modules/<pkg>/package.json`, so reading
+ * it would stop detection working before `bun install`, and the Lambda target
+ * ships inside `@guren/core` with no plugin package for a manifest to live in.
+ * A manifest field would therefore cover two of three targets and leave the
+ * third here anyway — two sources of truth instead of one.
+ */
 const DEPLOY_PLUGIN_PACKAGES: Record<string, DeployTargetId> = {
   '@guren/plugin-cloudflare': 'cloudflare',
   '@guren/plugin-vercel': 'vercel',
@@ -82,8 +91,6 @@ export interface SourceSignal {
 
 export interface DeployRuntimeAnalysis {
   targets: DeployTargetDetection[]
-  /** Targets that lack `Bun.password`, so the default `ScryptHasher` breaks. */
-  bunlessTargets: DeployTargetDetection[]
   /** Evidence that the app authenticates with passwords at all. */
   passwordAuthSignals: SourceSignal[]
   /** `NodeHasher` references — the remediation for a Bun-less runtime. */
@@ -106,6 +113,9 @@ export interface DeployRuntimeAnalysis {
 
 /** Directories scanned for the symbols above. */
 const DEPLOY_SCAN_DIRS = ['src', 'app', 'config', 'db', 'routes', 'modules', 'bin', 'functions', 'api'] as const
+
+/** Test files are excluded from the scan — see readAppSources. */
+const TEST_FILE_PATTERN = /\.(test|spec)\.[cm]?[jt]sx?$/
 
 type SymbolPatterns = ReadonlyArray<readonly [symbol: string, pattern: RegExp]>
 
@@ -215,9 +225,6 @@ const MEMORY_STORE_PATTERNS: SymbolPatterns = [
  * `ApplicationOptions.discover` is deliberately not matched here: it is
  * declared but never read anywhere in @guren/server, so it has no effect —
  * warning about it would flag a config key that doesn't actually do anything.
- *
- * Known gap: `import { AutoDiscovery as X }; new X()` isn't recognized, the
- * same aliased-import limitation as NODE_HASHER_PATTERNS above.
  */
 const DISCOVERY_PATTERNS: SymbolPatterns = [
   ['AutoDiscovery', /\bnew\s+AutoDiscovery\s*\(/],
@@ -225,43 +232,54 @@ const DISCOVERY_PATTERNS: SymbolPatterns = [
 
 interface ScannedFile {
   filePath: string
-  content: string
   /** Split once per file and reused across every pattern pass in findSignals. */
   lines: string[]
 }
 
 /**
- * Read the app's own source files from a bounded set of roots: the directories
- * in DEPLOY_SCAN_DIRS plus any source file sitting directly in the project root
- * (deploy entrypoints like `lambda.ts` or `worker.ts` conventionally live there).
+ * Source files sitting directly in the project root. Deploy entrypoints
+ * (`lambda.ts`, `worker.ts`) conventionally live there, and collectFiles only
+ * recurses, so the root's own files need their own non-recursive pass.
  */
-async function readAppSources(cwd: string): Promise<ScannedFile[]> {
-  const directoryFiles = await Promise.all(
-    DEPLOY_SCAN_DIRS.map((dir) =>
-      collectFiles(resolve(cwd, dir), IMPORTABLE_EXTENSIONS, NON_SOURCE_DIR_NAMES),
-    ),
-  )
-
-  const rootFiles: string[] = []
+async function readRootSourceFiles(cwd: string): Promise<string[]> {
   try {
-    for (const entry of await readdir(cwd, { withFileTypes: true })) {
-      if (!entry.isFile() || entry.name.startsWith('.')) continue
-      if (entry.name.endsWith('.d.ts')) continue
-      if (IMPORTABLE_EXTENSIONS.has(extname(entry.name))) {
-        rootFiles.push(join(cwd, entry.name))
-      }
-    }
+    const entries = await readdir(cwd, { withFileTypes: true })
+    return entries
+      .filter((entry) => entry.isFile() && !entry.name.startsWith('.') && !entry.name.endsWith('.d.ts'))
+      .filter((entry) => IMPORTABLE_EXTENSIONS.has(extname(entry.name)))
+      .map((entry) => join(cwd, entry.name))
   } catch {
     // An unreadable project root leaves the directory scans as the only input.
+    return []
   }
+}
 
-  const paths = [...rootFiles, ...directoryFiles.flat()]
+/**
+ * Read the app's own source files from a bounded set of roots: the directories
+ * in DEPLOY_SCAN_DIRS plus any source file in the project root.
+ *
+ * Test files are excluded. A fixture that constructs a backed store or a
+ * NodeHasher would otherwise satisfy the remediation check on behalf of an
+ * application that never wires one up, hiding a real production gap — and a
+ * fixture enabling sessions would report sessions the app itself never enables.
+ */
+async function readAppSources(cwd: string): Promise<ScannedFile[]> {
+  const [directoryFiles, rootFiles] = await Promise.all([
+    Promise.all(
+      DEPLOY_SCAN_DIRS.map((dir) =>
+        collectFiles(resolve(cwd, dir), IMPORTABLE_EXTENSIONS, NON_SOURCE_DIR_NAMES),
+      ),
+    ),
+    readRootSourceFiles(cwd),
+  ])
+
+  const paths = [...rootFiles, ...directoryFiles.flat()].filter((path) => !TEST_FILE_PATTERN.test(path))
 
   const scanned = await Promise.all(
     paths.map(async (path) => {
       const content = await readFile(path, 'utf8').catch(() => null)
       if (content === null) return null
-      return { filePath: toPosixRelative(cwd, path), content, lines: content.split('\n') }
+      return { filePath: toPosixRelative(cwd, path), lines: content.split('\n') }
     }),
   )
 
@@ -287,11 +305,7 @@ function findSignals(files: ScannedFile[], patterns: SymbolPatterns): SourceSign
  * Deploy targets declared by the app: plugin packages from its package.json
  * dependencies, plus the Lambda adapter detected from source imports.
  */
-export async function detectDeployTargets(cwd: string): Promise<DeployTargetDetection[]> {
-  return detectTargetsIn(cwd, await readAppSources(cwd))
-}
-
-async function detectTargetsIn(cwd: string, files: ScannedFile[]): Promise<DeployTargetDetection[]> {
+async function detectDeployTargets(cwd: string, files: ScannedFile[]): Promise<DeployTargetDetection[]> {
   const detections: DeployTargetDetection[] = []
 
   const declared = new Set(await readDeclaredDependencyNames(cwd))
@@ -304,7 +318,7 @@ async function detectTargetsIn(cwd: string, files: ScannedFile[]): Promise<Deplo
     }
   }
 
-  const lambdaFile = files.find((file) => LAMBDA_SOURCE_PATTERN.test(file.content))
+  const lambdaFile = files.find((file) => file.lines.some((line) => LAMBDA_SOURCE_PATTERN.test(line)))
   if (lambdaFile) {
     detections.push({
       profile: DEPLOY_TARGET_PROFILES.lambda,
@@ -322,11 +336,10 @@ async function detectTargetsIn(cwd: string, files: ScannedFile[]): Promise<Deplo
  */
 export async function analyzeDeployRuntime(cwd: string): Promise<DeployRuntimeAnalysis> {
   const files = await readAppSources(cwd)
-  const targets = await detectTargetsIn(cwd, files)
+  const targets = await detectDeployTargets(cwd, files)
 
   return {
     targets,
-    bunlessTargets: targets.filter((target) => !target.profile.hasBunRuntime),
     passwordAuthSignals: findSignals(files, PASSWORD_AUTH_PATTERNS),
     nodeHasherSignals: findSignals(files, NODE_HASHER_PATTERNS),
     sessionSignals: findSignals(files, SESSION_PATTERNS),
@@ -337,6 +350,11 @@ export async function analyzeDeployRuntime(cwd: string): Promise<DeployRuntimeAn
     memoryStoreSignals: findSignals(files, MEMORY_STORE_PATTERNS),
     discoverySignals: findSignals(files, DISCOVERY_PATTERNS),
   }
+}
+
+/** Targets that lack `Bun.password`, so the default `ScryptHasher` breaks. */
+export function bunlessTargets(analysis: DeployRuntimeAnalysis): DeployTargetDetection[] {
+  return analysis.targets.filter((target) => !target.profile.hasBunRuntime)
 }
 
 export function formatTargetLabels(targets: DeployTargetDetection[]): string {

--- a/packages/cli/src/deploy-runtime.ts
+++ b/packages/cli/src/deploy-runtime.ts
@@ -117,10 +117,22 @@ const TEST_FILE_PATTERN = /\.(test|spec)\.[cm]?[jt]sx?$/
 // Signals are read from a Babel AST (the same parser audit.ts and
 // model-parser.ts already use), not from per-line regexes. That buys, in one
 // mechanism, everything the regex generation of this file had to carve out
-// case by case: aliased imports resolve to their canonical names, values
-// split across lines match, and text inside comments, string literals, and
-// TypeScript type positions can no longer trip a check. Files that fail to
-// parse contribute no signals rather than failing the doctor run.
+// case by case: values split across lines match, and text inside comments,
+// string literals, and TypeScript type positions cannot trip a check.
+//
+// Every signal name is resolved through the file's own `@guren/*` value
+// imports rather than matched bare. A name only means the Guren API of that
+// name when it was imported from Guren, so `import { NodeHasher } from
+// './my-own'` no longer satisfies a remediation and an unrelated
+// `DatabaseSessionStore` no longer hides a real gap. Aliases and namespace
+// imports resolve to their canonical exported names, so `NodeHasher as X`
+// and `g.NodeHasher` both count.
+//
+// Known limitations, both needing scope/dataflow analysis this deliberately
+// stops short of: a local binding that shadows an imported signal name still
+// counts, and an options object built elsewhere and passed into createApp
+// (`const o = { auth: {} }; createApp(o)`) is not seen — though any
+// `autoSession`/`sessionOptions` key inside it is, wherever it lives.
 
 type SignalKind =
   | 'passwordAuth'
@@ -186,6 +198,36 @@ const REFERENCED_SIGNALS: Record<string, SignalKind> = {
   OAuthServiceProvider: 'oauth',
 }
 
+/** Only names imported from a Guren package resolve to a signal. */
+const GUREN_PACKAGE_PREFIX = '@guren/'
+
+/**
+ * Type-only syntax. Skipped wholesale so an identifier in a type annotation,
+ * generic constraint, type query, or interface body never reads as usage.
+ * Nodes that merely *carry* a type while wrapping a real expression
+ * (TSAsExpression, TSNonNullExpression, TSSatisfiesExpression) are absent
+ * here on purpose — their expression still has to be walked.
+ */
+const TYPE_ONLY_NODES = new Set([
+  'TSTypeAnnotation',
+  'TSTypeReference',
+  'TSTypeQuery',
+  'TSTypeParameterDeclaration',
+  'TSTypeParameterInstantiation',
+  'TSInterfaceDeclaration',
+  'TSTypeAliasDeclaration',
+  'TSDeclareFunction',
+  'TSDeclareMethod',
+  'TSModuleDeclaration',
+  'TSIndexSignature',
+  'TSPropertySignature',
+  'TSMethodSignature',
+  'TSCallSignatureDeclaration',
+  'TSConstructSignatureDeclaration',
+  'TSTypeLiteral',
+  'TSQualifiedName',
+])
+
 /**
  * The Lambda adapter ships inside `@guren/core`/`@guren/server` rather than a
  * plugin package, so it is detected from these import sources (plus bare
@@ -246,19 +288,48 @@ function extractSignals(source: string, plugins: ParserPlugin[]): ExtractedSigna
     return null
   }
 
-  // Named-import aliases (`import { NodeHasher as X }`) resolve to their
-  // canonical exported names, so every table below matches aliased use too.
-  const aliases = new Map<string, string>()
+  // Value imports from `@guren/*`, mapping the file's local name to the
+  // canonical exported name. Type-only imports are excluded — they cannot be
+  // constructed or called — and so is every non-Guren source, so a same-named
+  // export from another package never resolves to a signal.
+  const gurenNames = new Map<string, string>()
+  const gurenNamespaces = new Set<string>()
   for (const statement of ast.program.body) {
     if (statement.type !== 'ImportDeclaration') continue
+    if (statement.importKind === 'type') continue
+    if (!statement.source.value.startsWith(GUREN_PACKAGE_PREFIX)) continue
     for (const specifier of statement.specifiers) {
       if (specifier.type === 'ImportSpecifier') {
+        if (specifier.importKind === 'type') continue
         const imported = specifier.imported
-        aliases.set(specifier.local.name, imported.type === 'Identifier' ? imported.name : imported.value)
+        gurenNames.set(specifier.local.name, imported.type === 'Identifier' ? imported.name : imported.value)
+      } else if (specifier.type === 'ImportNamespaceSpecifier') {
+        gurenNamespaces.add(specifier.local.name)
       }
     }
   }
-  const canonical = (name: string): string => aliases.get(name) ?? name
+
+  /**
+   * Canonical Guren export name for a callee/identifier, or null when it does
+   * not resolve to one. Covers plain and aliased named imports plus
+   * `ns.Member` access through a namespace import.
+   */
+  const resolve = (node: BabelNode | undefined): string | null => {
+    if (!node) return null
+    if (node.type === 'Identifier') return gurenNames.get(node.name as string) ?? null
+    if (node.type === 'MemberExpression' && !node.computed) {
+      const object = node.object as BabelNode
+      const property = node.property as BabelNode
+      if (
+        object?.type === 'Identifier' &&
+        property?.type === 'Identifier' &&
+        gurenNamespaces.has(object.name as string)
+      ) {
+        return property.name as string
+      }
+    }
+    return null
+  }
 
   const signals: ExtractedSignal[] = []
   const seen = new Set<string>()
@@ -270,6 +341,8 @@ function extractSignals(source: string, plugins: ParserPlugin[]): ExtractedSigna
   }
 
   walk(ast.program, (node) => {
+    if (TYPE_ONLY_NODES.has(node.type)) return false
+
     switch (node.type) {
       case 'ImportDeclaration': {
         const source = node.source as BabelNode
@@ -282,6 +355,7 @@ function extractSignals(source: string, plugins: ParserPlugin[]): ExtractedSigna
 
       case 'ExportNamedDeclaration':
       case 'ExportAllDeclaration': {
+        if (node.exportKind === 'type') return false
         const source = node.source as BabelNode | null
         if (source && LAMBDA_IMPORT_SOURCES.has(source.value as string)) {
           emit('lambda', source.value as string, lineOf(node))
@@ -290,19 +364,17 @@ function extractSignals(source: string, plugins: ParserPlugin[]): ExtractedSigna
       }
 
       case 'NewExpression': {
-        const callee = node.callee as BabelNode
-        if (callee?.type === 'Identifier') {
-          const name = canonical(callee.name as string)
-          const kind = CONSTRUCTED_SIGNALS[name]
-          if (kind) emit(kind, name, lineOf(node))
-        }
+        const name = resolve(node.callee as BabelNode)
+        const kind = name ? CONSTRUCTED_SIGNALS[name] : undefined
+        if (name && kind) emit(kind, name, lineOf(node))
         return
       }
 
       case 'CallExpression': {
         const callee = node.callee as BabelNode
-        if (callee?.type === 'Identifier') {
-          const name = canonical(callee.name as string)
+        const name = resolve(callee)
+
+        if (name) {
           const kind = CALLED_SIGNALS[name]
           if (kind) emit(kind, name, lineOf(node))
 
@@ -324,13 +396,17 @@ function extractSignals(source: string, plugins: ParserPlugin[]): ExtractedSigna
               }
             }
           }
-        } else if (callee?.type === 'MemberExpression') {
+        }
+
+        if (callee?.type === 'MemberExpression') {
           // `auth.attempt(...)` / `this.auth.attempt(...)` is the entry point
           // app code calls to verify a password (`guard.attempt()` sits
           // underneath it but is never called directly outside the
-          // framework's own tests). Known gap: a registration-only app that
-          // creates password-hashing records without ever calling attempt()
-          // passes undetected — `make:auth` always scaffolds login alongside
+          // framework's own tests). Resolved structurally rather than through
+          // the import map: `auth` here is a controller property, not an
+          // import. Known gap: a registration-only app that creates
+          // password-hashing records without ever calling attempt() passes
+          // undetected — `make:auth` always scaffolds login alongside
           // registration, so that shape doesn't occur in generated apps.
           const property = callee.property as BabelNode
           const object = callee.object as BabelNode
@@ -371,9 +447,9 @@ function extractSignals(source: string, plugins: ParserPlugin[]): ExtractedSigna
       }
 
       case 'Identifier': {
-        const name = canonical(node.name as string)
-        const kind = REFERENCED_SIGNALS[name]
-        if (kind) emit(kind, name, lineOf(node))
+        const name = resolve(node)
+        const kind = name ? REFERENCED_SIGNALS[name] : undefined
+        if (name && kind) emit(kind, name, lineOf(node))
         return
       }
     }
@@ -387,11 +463,17 @@ interface ScannedFile {
   signals: ExtractedSignal[]
 }
 
+/**
+ * Decorators and auto-accessors are enabled everywhere: without them a single
+ * `@Injectable`-style class makes the whole file unparseable, and an
+ * unparseable file contributes no signals at all — silently hiding every
+ * hazard and remediation it contains. JSX is off for .ts/.mts so
+ * angle-bracket type assertions still parse; elsewhere it lets .tsx through.
+ */
 function parserPluginsFor(path: string): ParserPlugin[] {
-  // JSX is off for .ts/.mts so angle-bracket type assertions still parse;
-  // everywhere else it is harmless and lets .tsx/.jsx through.
+  const base: ParserPlugin[] = ['typescript', 'decorators', 'decoratorAutoAccessors']
   const ext = extname(path)
-  return ext === '.ts' || ext === '.mts' ? ['typescript'] : ['typescript', 'jsx']
+  return ext === '.ts' || ext === '.mts' ? base : [...base, 'jsx']
 }
 
 /**

--- a/packages/cli/src/deploy-runtime.ts
+++ b/packages/cli/src/deploy-runtime.ts
@@ -104,6 +104,13 @@ export interface DeployRuntimeAnalysis {
   memoryStoreSignals: SourceSignal[]
   /** Explicit use of filesystem-scanning provider discovery. */
   discoverySignals: SourceSignal[]
+  /**
+   * Files that failed to parse and therefore contributed no signals. Surfaced
+   * in the check messages so a missed hazard or remediation is a visible
+   * caveat, not a silent false negative — the same stance ESLint (parse
+   * errors are errors) and semgrep (skipped files are counted) take.
+   */
+  unparsedFiles: string[]
 }
 
 /** Directories scanned for the symbols above. */
@@ -504,7 +511,7 @@ async function readRootSourceFiles(cwd: string): Promise<string[]> {
  * application that never wires one up, hiding a real production gap — and a
  * fixture enabling sessions would report sessions the app itself never enables.
  */
-async function readAppSources(cwd: string): Promise<ScannedFile[]> {
+async function readAppSources(cwd: string): Promise<{ files: ScannedFile[]; unparsed: string[] }> {
   const [directoryFiles, rootFiles] = await Promise.all([
     Promise.all(
       DEPLOY_SCAN_DIRS.map((dir) =>
@@ -518,15 +525,22 @@ async function readAppSources(cwd: string): Promise<ScannedFile[]> {
 
   const scanned = await Promise.all(
     paths.map(async (path) => {
+      const filePath = toPosixRelative(cwd, path)
       const content = await readFile(path, 'utf8').catch(() => null)
       if (content === null) return null
-      const signals = extractSignals(content, parserPluginsFor(path))
-      if (signals === null) return null
-      return { filePath: toPosixRelative(cwd, path), signals }
+      return { filePath, signals: extractSignals(content, parserPluginsFor(path)) }
     }),
   )
 
-  return scanned.filter((file): file is ScannedFile => file !== null)
+  const files: ScannedFile[] = []
+  const unparsed: string[] = []
+  for (const entry of scanned) {
+    if (entry === null) continue
+    if (entry.signals === null) unparsed.push(entry.filePath)
+    else files.push({ filePath: entry.filePath, signals: entry.signals })
+  }
+
+  return { files, unparsed }
 }
 
 /**
@@ -563,7 +577,7 @@ async function detectDeployTargets(cwd: string, files: ScannedFile[]): Promise<D
  * still in force.
  */
 export async function analyzeDeployRuntime(cwd: string): Promise<DeployRuntimeAnalysis> {
-  const files = await readAppSources(cwd)
+  const { files, unparsed } = await readAppSources(cwd)
   const targets = await detectDeployTargets(cwd, files)
 
   const collect = (kind: SignalKind): SourceSignal[] =>
@@ -584,7 +598,21 @@ export async function analyzeDeployRuntime(cwd: string): Promise<DeployRuntimeAn
     backedOAuthSignals: collect('backedOAuth'),
     memoryStoreSignals: collect('memoryStore'),
     discoverySignals: collect('discovery'),
+    unparsedFiles: unparsed,
   }
+}
+
+/**
+ * Caveat appended to signal-dependent check messages when files were skipped:
+ * a verdict computed over an incomplete scan should say so.
+ */
+export function formatParseCaveat(analysis: DeployRuntimeAnalysis): string {
+  const { unparsedFiles } = analysis
+  if (unparsedFiles.length === 0) return ''
+
+  const shown = unparsedFiles.slice(0, 3).join(', ')
+  const more = unparsedFiles.length > 3 ? ` and ${unparsedFiles.length - 3} more` : ''
+  return ` Note: ${unparsedFiles.length} file(s) could not be parsed and were not scanned: ${shown}${more}.`
 }
 
 /** Targets that lack `Bun.password`, so the default `ScryptHasher` breaks. */

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -1045,6 +1045,10 @@ function detectDeployPasswordHashing(analysis: DeployRuntimeAnalysis): DoctorChe
   const title = 'Deploy Password Hashing'
 
   const bunless = bunlessTargets(analysis)
+  // Every verdict carries the parse caveat, target-only ones included: the
+  // Lambda adapter is detected from source, so a skipped file can hide a
+  // target and turn a real warning into "no deploy target detected".
+  const caveat = formatParseCaveat(analysis)
 
   if (bunless.length === 0) {
     return createCheck(
@@ -1052,16 +1056,12 @@ function detectDeployPasswordHashing(analysis: DeployRuntimeAnalysis): DoctorChe
       title,
       'pass',
       analysis.targets.length > 0
-        ? `${formatTargetLabels(analysis.targets)} runs on Bun, so the default ScryptHasher applies.`
-        : 'No deploy plugin or Lambda adapter detected.',
+        ? `${formatTargetLabels(analysis.targets)} runs on Bun, so the default ScryptHasher applies.${caveat}`
+        : `No deploy plugin or Lambda adapter detected.${caveat}`,
     )
   }
 
   const labels = formatTargetLabels(bunless)
-  // Signal-dependent verdicts carry the parse caveat: a pass computed over an
-  // incomplete scan should say so. The target-only verdicts above don't — a
-  // parse failure can't change which deploy targets are declared.
-  const caveat = formatParseCaveat(analysis)
 
   if (analysis.passwordAuthSignals.length === 0) {
     return createCheck(key, title, 'pass', `${labels} detected, and no password authentication was found.${caveat}`)
@@ -1075,7 +1075,7 @@ function detectDeployPasswordHashing(analysis: DeployRuntimeAnalysis): DoctorChe
     key,
     title,
     'warn',
-    `${labels} detected with password authentication (${formatSignals(analysis.passwordAuthSignals)}), but NodeHasher is never referenced. The default ScryptHasher uses Bun.password, which is unavailable on this runtime.${caveat}`,
+    `${labels} detected with password authentication (${formatSignals(analysis.passwordAuthSignals)}), but NodeHasher is never constructed. The default ScryptHasher uses Bun.password, which is unavailable on this runtime.${caveat}`,
     { fix: NODE_HASHER_FIX, manualFix: NODE_HASHER_FIX },
   )
 }
@@ -1091,8 +1091,10 @@ function detectDeployRuntimeStores(analysis: DeployRuntimeAnalysis): DoctorCheck
   const key = 'deploy-runtime-stores'
   const title = 'Deploy Runtime Stores'
 
+  const caveat = formatParseCaveat(analysis)
+
   if (analysis.targets.length === 0) {
-    return createCheck(key, title, 'pass', 'No deploy plugin or Lambda adapter detected.')
+    return createCheck(key, title, 'pass', `No deploy plugin or Lambda adapter detected.${caveat}`)
   }
 
   const labels = formatTargetLabels(analysis.targets)
@@ -1118,8 +1120,6 @@ function detectDeployRuntimeStores(analysis: DeployRuntimeAnalysis): DoctorCheck
     )
   }
 
-  const caveat = formatParseCaveat(analysis)
-
   if (issues.length === 0) {
     return createCheck(key, title, 'pass', `${labels} detected, and no in-memory store defaults were found.${caveat}`)
   }
@@ -1144,12 +1144,13 @@ function detectDeployProviderDiscovery(analysis: DeployRuntimeAnalysis): DoctorC
   const key = 'deploy-provider-discovery'
   const title = 'Deploy Provider Discovery'
 
+  const caveat = formatParseCaveat(analysis)
+
   if (analysis.targets.length === 0) {
-    return createCheck(key, title, 'pass', 'No deploy plugin or Lambda adapter detected.')
+    return createCheck(key, title, 'pass', `No deploy plugin or Lambda adapter detected.${caveat}`)
   }
 
   const labels = formatTargetLabels(analysis.targets)
-  const caveat = formatParseCaveat(analysis)
 
   if (analysis.discoverySignals.length === 0) {
     return createCheck(key, title, 'pass', `${labels} detected, and provider discovery is not used.${caveat}`)

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -17,6 +17,7 @@ import { checkPluginCompatibility, readCoreVersion, readInstalledPluginManifests
 import { compareVersions } from './codemods'
 import {
   analyzeDeployRuntime,
+  bunlessTargets,
   formatSignals,
   formatTargetLabels,
   type DeployRuntimeAnalysis,
@@ -1042,7 +1043,9 @@ function detectDeployPasswordHashing(analysis: DeployRuntimeAnalysis): DoctorChe
   const key = 'deploy-password-hashing'
   const title = 'Deploy Password Hashing'
 
-  if (analysis.bunlessTargets.length === 0) {
+  const bunless = bunlessTargets(analysis)
+
+  if (bunless.length === 0) {
     return createCheck(
       key,
       title,
@@ -1053,7 +1056,7 @@ function detectDeployPasswordHashing(analysis: DeployRuntimeAnalysis): DoctorChe
     )
   }
 
-  const labels = formatTargetLabels(analysis.bunlessTargets)
+  const labels = formatTargetLabels(bunless)
 
   if (analysis.passwordAuthSignals.length === 0) {
     return createCheck(key, title, 'pass', `${labels} detected, and no password authentication was found.`)

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -18,6 +18,7 @@ import { compareVersions } from './codemods'
 import {
   analyzeDeployRuntime,
   bunlessTargets,
+  formatParseCaveat,
   formatSignals,
   formatTargetLabels,
   type DeployRuntimeAnalysis,
@@ -1057,20 +1058,24 @@ function detectDeployPasswordHashing(analysis: DeployRuntimeAnalysis): DoctorChe
   }
 
   const labels = formatTargetLabels(bunless)
+  // Signal-dependent verdicts carry the parse caveat: a pass computed over an
+  // incomplete scan should say so. The target-only verdicts above don't — a
+  // parse failure can't change which deploy targets are declared.
+  const caveat = formatParseCaveat(analysis)
 
   if (analysis.passwordAuthSignals.length === 0) {
-    return createCheck(key, title, 'pass', `${labels} detected, and no password authentication was found.`)
+    return createCheck(key, title, 'pass', `${labels} detected, and no password authentication was found.${caveat}`)
   }
 
   if (analysis.nodeHasherSignals.length > 0) {
-    return createCheck(key, title, 'pass', `${labels} detected, and NodeHasher is configured.`)
+    return createCheck(key, title, 'pass', `${labels} detected, and NodeHasher is configured.${caveat}`)
   }
 
   return createCheck(
     key,
     title,
     'warn',
-    `${labels} detected with password authentication (${formatSignals(analysis.passwordAuthSignals)}), but NodeHasher is never referenced. The default ScryptHasher uses Bun.password, which is unavailable on this runtime.`,
+    `${labels} detected with password authentication (${formatSignals(analysis.passwordAuthSignals)}), but NodeHasher is never referenced. The default ScryptHasher uses Bun.password, which is unavailable on this runtime.${caveat}`,
     { fix: NODE_HASHER_FIX, manualFix: NODE_HASHER_FIX },
   )
 }
@@ -1113,15 +1118,17 @@ function detectDeployRuntimeStores(analysis: DeployRuntimeAnalysis): DoctorCheck
     )
   }
 
+  const caveat = formatParseCaveat(analysis)
+
   if (issues.length === 0) {
-    return createCheck(key, title, 'pass', `${labels} detected, and no in-memory store defaults were found.`)
+    return createCheck(key, title, 'pass', `${labels} detected, and no in-memory store defaults were found.${caveat}`)
   }
 
   return createCheck(
     key,
     title,
     'warn',
-    `${labels} shares no memory between requests, but ${issues.join('; ')}.`,
+    `${labels} shares no memory between requests, but ${issues.join('; ')}.${caveat}`,
     { fix: BACKED_STORE_FIX, manualFix: BACKED_STORE_FIX },
   )
 }
@@ -1142,9 +1149,10 @@ function detectDeployProviderDiscovery(analysis: DeployRuntimeAnalysis): DoctorC
   }
 
   const labels = formatTargetLabels(analysis.targets)
+  const caveat = formatParseCaveat(analysis)
 
   if (analysis.discoverySignals.length === 0) {
-    return createCheck(key, title, 'pass', `${labels} detected, and provider discovery is not used.`)
+    return createCheck(key, title, 'pass', `${labels} detected, and provider discovery is not used.${caveat}`)
   }
 
   const blockers = analysis.targets.map((target) => `${target.profile.label}: ${target.profile.discoveryBlocker}`)
@@ -1153,7 +1161,7 @@ function detectDeployProviderDiscovery(analysis: DeployRuntimeAnalysis): DoctorC
     key,
     title,
     'warn',
-    `${labels} detected, but the app uses filesystem provider discovery (${formatSignals(analysis.discoverySignals)}). ${blockers.join(' ')}`,
+    `${labels} detected, but the app uses filesystem provider discovery (${formatSignals(analysis.discoverySignals)}). ${blockers.join(' ')}${caveat}`,
     { fix: EXPLICIT_PROVIDERS_FIX, manualFix: EXPLICIT_PROVIDERS_FIX },
   )
 }

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -15,6 +15,12 @@ import {
 } from './discovery'
 import { checkPluginCompatibility, readCoreVersion, readInstalledPluginManifests } from './plugin-manifest'
 import { compareVersions } from './codemods'
+import {
+  analyzeDeployRuntime,
+  formatSignals,
+  formatTargetLabels,
+  type DeployRuntimeAnalysis,
+} from './deploy-runtime'
 
 export type DoctorStatus = 'pass' | 'warn' | 'fail'
 
@@ -1024,6 +1030,131 @@ async function detectPluginCompatibility(context: DoctorRuleContext): Promise<Do
   )
 }
 
+const NODE_HASHER_FIX = 'Set `static passwordHasher = new NodeHasher()` on the AuthenticatableModel subclass and pass `hasher: new NodeHasher()` to `auth.useModel()`. ScryptHasher and NodeHasher produce incompatible hash formats, so existing passwords must be rehashed.'
+
+/**
+ * `ScryptHasher` — the default for both password hashing and verification —
+ * runs on `Bun.password`, which does not exist on Workers or Lambda. Only
+ * warns for apps that actually authenticate with passwords; OAuth-only apps
+ * never reach the hasher.
+ */
+function detectDeployPasswordHashing(analysis: DeployRuntimeAnalysis): DoctorCheck {
+  const key = 'deploy-password-hashing'
+  const title = 'Deploy Password Hashing'
+
+  if (analysis.bunlessTargets.length === 0) {
+    return createCheck(
+      key,
+      title,
+      'pass',
+      analysis.targets.length > 0
+        ? `${formatTargetLabels(analysis.targets)} runs on Bun, so the default ScryptHasher applies.`
+        : 'No deploy plugin or Lambda adapter detected.',
+    )
+  }
+
+  const labels = formatTargetLabels(analysis.bunlessTargets)
+
+  if (analysis.passwordAuthSignals.length === 0) {
+    return createCheck(key, title, 'pass', `${labels} detected, and no password authentication was found.`)
+  }
+
+  if (analysis.nodeHasherSignals.length > 0) {
+    return createCheck(key, title, 'pass', `${labels} detected, and NodeHasher is configured.`)
+  }
+
+  return createCheck(
+    key,
+    title,
+    'warn',
+    `${labels} detected with password authentication (${formatSignals(analysis.passwordAuthSignals)}), but NodeHasher is never referenced. The default ScryptHasher uses Bun.password, which is unavailable on this runtime.`,
+    { fix: NODE_HASHER_FIX, manualFix: NODE_HASHER_FIX },
+  )
+}
+
+const BACKED_STORE_FIX = 'Use DatabaseSessionStore and DatabaseOAuthStateStore from `@guren/core`, or the Redis equivalents from `@guren/core/redis`, and a Redis-backed cache/queue driver.'
+
+/**
+ * Serverless targets share no memory between invocations, so in-memory stores
+ * drop every session, cache entry, queued job, and OAuth state in production
+ * while working perfectly in local development.
+ */
+function detectDeployRuntimeStores(analysis: DeployRuntimeAnalysis): DoctorCheck {
+  const key = 'deploy-runtime-stores'
+  const title = 'Deploy Runtime Stores'
+
+  if (analysis.targets.length === 0) {
+    return createCheck(key, title, 'pass', 'No deploy plugin or Lambda adapter detected.')
+  }
+
+  const labels = formatTargetLabels(analysis.targets)
+  const issues: string[] = []
+
+  if (analysis.memoryStoreSignals.length > 0) {
+    issues.push(`in-memory stores are constructed explicitly (${formatSignals(analysis.memoryStoreSignals)})`)
+  }
+
+  if (
+    analysis.sessionSignals.length > 0 &&
+    analysis.backedSessionSignals.length === 0 &&
+    analysis.sessionDisabledSignals.length === 0
+  ) {
+    issues.push(
+      `sessions are enabled (${formatSignals(analysis.sessionSignals)}) with no DatabaseSessionStore or RedisSessionStore`,
+    )
+  }
+
+  if (analysis.oauthSignals.length > 0 && analysis.backedOAuthSignals.length === 0) {
+    issues.push(
+      `OAuth is configured (${formatSignals(analysis.oauthSignals)}) with no DatabaseOAuthStateStore or RedisOAuthStateStore`,
+    )
+  }
+
+  if (issues.length === 0) {
+    return createCheck(key, title, 'pass', `${labels} detected, and no in-memory store defaults were found.`)
+  }
+
+  return createCheck(
+    key,
+    title,
+    'warn',
+    `${labels} shares no memory between requests, but ${issues.join('; ')}.`,
+    { fix: BACKED_STORE_FIX, manualFix: BACKED_STORE_FIX },
+  )
+}
+
+const EXPLICIT_PROVIDERS_FIX = 'List providers explicitly in `createApp({ providers: [...] })` instead of discovering them from the filesystem.'
+
+/**
+ * `AutoDiscovery` scans directories with `Bun.Glob` and imports what it finds.
+ * Every deploy target breaks that, either by having no Bun runtime or by
+ * shipping a bundle with no source tree to scan.
+ */
+function detectDeployProviderDiscovery(analysis: DeployRuntimeAnalysis): DoctorCheck {
+  const key = 'deploy-provider-discovery'
+  const title = 'Deploy Provider Discovery'
+
+  if (analysis.targets.length === 0) {
+    return createCheck(key, title, 'pass', 'No deploy plugin or Lambda adapter detected.')
+  }
+
+  const labels = formatTargetLabels(analysis.targets)
+
+  if (analysis.discoverySignals.length === 0) {
+    return createCheck(key, title, 'pass', `${labels} detected, and provider discovery is not used.`)
+  }
+
+  const blockers = analysis.targets.map((target) => `${target.profile.label}: ${target.profile.discoveryBlocker}`)
+
+  return createCheck(
+    key,
+    title,
+    'warn',
+    `${labels} detected, but the app uses filesystem provider discovery (${formatSignals(analysis.discoverySignals)}). ${blockers.join(' ')}`,
+    { fix: EXPLICIT_PROVIDERS_FIX, manualFix: EXPLICIT_PROVIDERS_FIX },
+  )
+}
+
 const doctorRules: DoctorRule[] = [
   { key: 'runtime', title: 'Runtime Environment', detect: detectRuntime },
   { key: 'bun-version', title: 'Bun Version', detect: detectBunVersion },
@@ -1051,17 +1182,30 @@ export async function getDoctorRuleEvaluations(options: { cwd?: string } = {}): 
   const cwd = resolve(options.cwd ?? process.cwd())
   const context: DoctorRuleContext = { cwd }
 
-  const evaluations = await Promise.all(
-    doctorRules.map(async (rule) => {
-      const check = await rule.detect(context)
-      const autofix = rule.autofix && check.status !== 'pass'
-        ? await rule.autofix(context, check)
-        : null
-      return { check, autofix } as DoctorRuleEvaluation
-    }),
-  )
+  // The deploy-runtime checks share one filesystem scan, computed once here
+  // rather than through the DoctorRule interface (they need no autofix and no
+  // per-rule context beyond cwd, so a plain analysis object is simpler than
+  // wrapping each in its own `detect` closure).
+  const [ruleEvaluations, deployAnalysis] = await Promise.all([
+    Promise.all(
+      doctorRules.map(async (rule) => {
+        const check = await rule.detect(context)
+        const autofix = rule.autofix && check.status !== 'pass'
+          ? await rule.autofix(context, check)
+          : null
+        return { check, autofix } as DoctorRuleEvaluation
+      }),
+    ),
+    analyzeDeployRuntime(cwd),
+  ])
 
-  return { cwd, evaluations }
+  const deployEvaluations: DoctorRuleEvaluation[] = [
+    { check: detectDeployPasswordHashing(deployAnalysis), autofix: null },
+    { check: detectDeployRuntimeStores(deployAnalysis), autofix: null },
+    { check: detectDeployProviderDiscovery(deployAnalysis), autofix: null },
+  ]
+
+  return { cwd, evaluations: [...ruleEvaluations, ...deployEvaluations] }
 }
 
 export async function runDoctor(options: RunDoctorOptions = {}): Promise<DoctorReport> {

--- a/packages/cli/src/plugin-manifest.ts
+++ b/packages/cli/src/plugin-manifest.ts
@@ -67,28 +67,37 @@ export async function readPluginManifest(
 }
 
 /**
- * Enumerate installed packages (dependencies and devDependencies of the
- * app's package.json) that declare a `gurenPlugin` manifest.
+ * Package names declared in the app's own package.json `dependencies` and
+ * `devDependencies` — no node_modules lookup, so this resolves even for a
+ * package that has never been installed. Returns `[]` when package.json is
+ * missing or fails to parse.
  */
-export async function readInstalledPluginManifests(
-  cwd: string = process.cwd(),
-): Promise<Array<{ packageName: string; manifest: GurenPluginManifest }>> {
+export async function readDeclaredDependencyNames(cwd: string = process.cwd()): Promise<string[]> {
   const packageJsonRaw = await readIfExists(cwd, 'package.json')
   if (packageJsonRaw === null) return []
 
-  let dependencies: string[]
   try {
     const parsed = JSON.parse(packageJsonRaw) as {
       dependencies?: Record<string, string>
       devDependencies?: Record<string, string>
     }
-    dependencies = [
+    return [
       ...Object.keys(parsed.dependencies ?? {}),
       ...Object.keys(parsed.devDependencies ?? {}),
     ]
   } catch {
     return []
   }
+}
+
+/**
+ * Enumerate installed packages (dependencies and devDependencies of the
+ * app's package.json) that declare a `gurenPlugin` manifest.
+ */
+export async function readInstalledPluginManifests(
+  cwd: string = process.cwd(),
+): Promise<Array<{ packageName: string; manifest: GurenPluginManifest }>> {
+  const dependencies = await readDeclaredDependencyNames(cwd)
 
   const entries = await Promise.all(
     dependencies.map(async (packageName) => ({

--- a/packages/cli/tests/deploy-runtime.test.ts
+++ b/packages/cli/tests/deploy-runtime.test.ts
@@ -163,6 +163,18 @@ describe('deploy target detection', () => {
     })
   })
 
+  // LAMBDA_SOURCE_PATTERN is an alternation; this covers the createLambdaHandler
+  // half on its own, which every other Lambda fixture pairs with an import path.
+  it('detects the Lambda adapter from a bare createLambdaHandler call', async () => {
+    const files = { 'src/handler.ts': `export const handler = createLambdaHandler(app)\n` }
+
+    await withApp('guren-deploy-lambda-bare-', files, {}, async (dir) => {
+      const { targets } = await analyzeDeployRuntime(dir)
+
+      expect(targets.map((target) => target.profile.id)).toEqual(['lambda'])
+    })
+  })
+
   it('detects several targets at once', async () => {
     const files = { 'lambda.ts': `import { createLambdaHandler } from '@guren/core/lambda'\n` }
     const deps = { '@guren/plugin-cloudflare': '^0.2.0' }
@@ -430,6 +442,63 @@ export const oauth = createOAuthManager({})
     })
   })
 
+  // Without these the whole BACKED_OAUTH_PATTERNS table could be broken and
+  // every other test would still pass — a correctly-configured OAuth app would
+  // then be warned at, the exact false positive this check exists to avoid.
+  for (const store of ['DatabaseOAuthStateStore', 'RedisOAuthStateStore'] as const) {
+    it(`passes once ${store} is constructed`, async () => {
+      const files = {
+        'app/Providers/OAuthProvider.ts': `import { createOAuthManager } from '@guren/core'
+export const oauth = createOAuthManager({ stateStore: new ${store}(oauthStates) })
+`,
+      }
+
+      await withApp(`guren-stores-oauth-ok-${store}-`, files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+        expect((await deployChecks(dir))['deploy-runtime-stores'].status).toBe('pass')
+      })
+    })
+  }
+
+  it('still warns when a backed OAuth store is imported but never constructed', async () => {
+    const files = {
+      'app/Providers/OAuthProvider.ts': `import { createOAuthManager, DatabaseOAuthStateStore } from '@guren/core'
+export const oauth = createOAuthManager({})
+`,
+    }
+
+    await withApp('guren-stores-oauth-import-only-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await deployChecks(dir))['deploy-runtime-stores'].status).toBe('warn')
+    })
+  })
+
+  it('treats OAuthServiceProvider as an OAuth signal', async () => {
+    const files = {
+      'src/app.ts': `import { createApp, OAuthServiceProvider } from '@guren/core'
+export const app = createApp({ providers: [OAuthServiceProvider] })
+`,
+    }
+
+    await withApp('guren-stores-oauth-provider-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-runtime-stores']
+
+      expect(check.status).toBe('warn')
+      expect(check.message).toContain('OAuth is configured')
+    })
+  })
+
+  it('treats createSessionMiddleware as a session signal', async () => {
+    const files = {
+      'src/app.ts': `import { createSessionMiddleware } from '@guren/core'\napp.use('*', createSessionMiddleware({}))\n`,
+    }
+
+    await withApp('guren-stores-session-mw-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-runtime-stores']
+
+      expect(check.status).toBe('warn')
+      expect(check.message).toContain('sessions are enabled')
+    })
+  })
+
   it('warns about explicitly constructed in-memory cache and queue stores', async () => {
     const files = {
       'config/cache.ts': `import { MemoryStore } from '@guren/core'\nexport const store = new MemoryStore()\n`,
@@ -445,6 +514,34 @@ export const oauth = createOAuthManager({})
       expect(check.message).toContain('MemoryDriver (config/queue.ts:2)')
     })
   })
+
+  // Every entry in MEMORY_STORE_PATTERNS, so a typo in any one of them can't
+  // hide behind the two that the cache/queue case above happens to cover.
+  const MEMORY_STORES = [
+    'MemorySessionStore',
+    'MemoryOAuthStateStore',
+    'MemoryApiTokenStore',
+    'MemoryPasswordResetStore',
+    'MemoryEmailVerificationStore',
+    'MemoryRateLimitStore',
+    'MemoryStore',
+    'MemoryDriver',
+  ] as const
+
+  for (const store of MEMORY_STORES) {
+    it(`warns about an explicitly constructed ${store}`, async () => {
+      const files = {
+        'config/stores.ts': `import { ${store} } from '@guren/core'\nexport const s = new ${store}()\n`,
+      }
+
+      await withApp(`guren-stores-mem-${store}-`, files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+        const check = (await deployChecks(dir))['deploy-runtime-stores']
+
+        expect(check.status).toBe('warn')
+        expect(check.message).toContain(`${store} (config/stores.ts:2)`)
+      })
+    })
+  }
 
   it('passes for an app with no session, OAuth, or in-memory store signals', async () => {
     const files = { 'src/app.ts': `import { createApp } from '@guren/core'\nexport const app = createApp({})\n` }
@@ -618,6 +715,18 @@ const store = new DatabaseSessionStore(sessions)
     })
   })
 
+  for (const name of ['app.spec.ts', 'app.test.tsx', 'app.spec.js'] as const) {
+    it(`excludes ${name}`, async () => {
+      const files = {
+        [`src/${name}`]: `import { MemoryStore } from '@guren/core'\nexport const s = new MemoryStore()\n`,
+      }
+
+      await withApp(`guren-scan-excl-${name}-`, files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+        expect((await analyzeDeployRuntime(dir)).memoryStoreSignals).toEqual([])
+      })
+    })
+  }
+
   it('does not raise a session signal from a test fixture alone', async () => {
     const files = {
       'src/routes.test.ts': `const app = createApp({ auth: { autoSession: true } })\n`,
@@ -632,6 +741,33 @@ const store = new DatabaseSessionStore(sessions)
 })
 
 describe('analyzeDeployRuntime', () => {
+  // Every entry in DEPLOY_SCAN_DIRS. Without this, dropping a directory from
+  // that list — including `functions`/`api`, added for serverless entrypoint
+  // layouts — would silently stop the whole scan there with no test failing.
+  for (const dir of ['src', 'app', 'config', 'db', 'routes', 'modules', 'bin', 'functions', 'api'] as const) {
+    it(`scans the ${dir}/ directory`, async () => {
+      const files = {
+        [`${dir}/probe.ts`]: `import { MemoryStore } from '@guren/core'\nexport const s = new MemoryStore()\n`,
+      }
+
+      await withApp(`guren-deploy-scan-${dir}-`, files, {}, async (workspace) => {
+        const analysis = await analyzeDeployRuntime(workspace)
+
+        expect(analysis.memoryStoreSignals.map((signal) => signal.filePath)).toContain(`${dir}/probe.ts`)
+      })
+    })
+  }
+
+  it('scans source files sitting directly in the project root', async () => {
+    const files = { 'worker.ts': `import { MemoryStore } from '@guren/core'\nexport const s = new MemoryStore()\n` }
+
+    await withApp('guren-deploy-scan-root-', files, {}, async (dir) => {
+      const analysis = await analyzeDeployRuntime(dir)
+
+      expect(analysis.memoryStoreSignals.map((signal) => signal.filePath)).toContain('worker.ts')
+    })
+  })
+
   it('scans modules/ trees as well as the project root', async () => {
     const files = {
       'modules/billing/index.ts': `import { MemoryStore } from '@guren/core'\nexport const store = new MemoryStore()\n`,

--- a/packages/cli/tests/deploy-runtime.test.ts
+++ b/packages/cli/tests/deploy-runtime.test.ts
@@ -163,12 +163,17 @@ describe('deploy target detection', () => {
     })
   })
 
-  // LAMBDA_SOURCE_PATTERN is an alternation; this covers the createLambdaHandler
-  // half on its own, which every other Lambda fixture pairs with an import path.
-  it('detects the Lambda adapter from a bare createLambdaHandler call', async () => {
-    const files = { 'src/handler.ts': `export const handler = createLambdaHandler(app)\n` }
+  // The adapter is also detected from the call itself, not only from the
+  // `@guren/*/lambda` import path — this fixture imports it from `@guren/core`,
+  // which is not one of LAMBDA_IMPORT_SOURCES.
+  it('detects the Lambda adapter from a createLambdaHandler call', async () => {
+    const files = {
+      'src/handler.ts': `import { createLambdaHandler } from '@guren/core'
+export const handler = createLambdaHandler(app)
+`,
+    }
 
-    await withApp('guren-deploy-lambda-bare-', files, {}, async (dir) => {
+    await withApp('guren-deploy-lambda-call-', files, {}, async (dir) => {
       const { targets } = await analyzeDeployRuntime(dir)
 
       expect(targets.map((target) => target.profile.id)).toEqual(['lambda'])
@@ -448,7 +453,7 @@ export const oauth = createOAuthManager({})
   for (const store of ['DatabaseOAuthStateStore', 'RedisOAuthStateStore'] as const) {
     it(`passes once ${store} is constructed`, async () => {
       const files = {
-        'app/Providers/OAuthProvider.ts': `import { createOAuthManager } from '@guren/core'
+        'app/Providers/OAuthProvider.ts': `import { createOAuthManager, ${store} } from '@guren/core'
 export const oauth = createOAuthManager({ stateStore: new ${store}(oauthStates) })
 `,
       }
@@ -814,6 +819,88 @@ export const app = createApp({ auth })
 
       expect(check.status).toBe('warn')
       expect(check.message).toContain('sessions are enabled')
+    })
+  })
+
+  // Resolving names bare made any same-named export satisfy a remediation.
+  // An unrelated `NodeHasher` silently marked a Workers app as fixed, which is
+  // the worst direction for this check: it hides a real production break.
+  it('does not let a same-named import from another package satisfy the hasher remediation', async () => {
+    const files = {
+      'app/Http/Controllers/LoginController.ts': PASSWORD_LOGIN_CONTROLLER,
+      'app/lib/hash.ts': `import { NodeHasher } from 'some-other-package'\nexport const h = new NodeHasher()\n`,
+    }
+
+    await withApp('guren-ast-foreign-hasher-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await deployChecks(dir))['deploy-password-hashing'].status).toBe('warn')
+    })
+  })
+
+  it('does not let a same-named import from another package satisfy the store remediation', async () => {
+    const files = {
+      'src/app.ts': SESSION_APP,
+      'src/stores.ts': `import { DatabaseSessionStore } from './my-own'\nexport const s = new DatabaseSessionStore(x)\n`,
+    }
+
+    await withApp('guren-ast-foreign-store-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await deployChecks(dir))['deploy-runtime-stores'].status).toBe('warn')
+    })
+  })
+
+  // A decorator anywhere in the file used to make it unparseable, and an
+  // unparseable file contributes nothing — hiding every signal it holds.
+  it('still sees signals in a file that uses decorators', async () => {
+    const files = {
+      'src/app.ts': `import { AutoDiscovery } from '@guren/core'
+
+@sealed
+class Registry {
+  @log accessor entries = []
+}
+
+const discovery = new AutoDiscovery({ basePath: 'app' })
+`,
+    }
+
+    await withApp('guren-ast-decorators-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await deployChecks(dir))['deploy-provider-discovery'].status).toBe('warn')
+    })
+  })
+
+  // Deliberately a *value* import: a `import type` one is filtered out of the
+  // binding map before the walker runs, so it would pass without exercising
+  // the type-node skip at all.
+  it('ignores a value-imported signal name used only as a type', async () => {
+    const files = {
+      'src/types.ts': `import { OAuthServiceProvider } from '@guren/core'
+export let provider: OAuthServiceProvider
+export type Alias = OAuthServiceProvider
+export function build(p: OAuthServiceProvider): typeof OAuthServiceProvider | null {
+  return null
+}
+`,
+    }
+
+    await withApp('guren-ast-type-ref-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await analyzeDeployRuntime(dir)).oauthSignals).toEqual([])
+    })
+  })
+
+  it('resolves namespace imports for constructions and calls', async () => {
+    const files = {
+      'src/app.ts': `import * as guren from '@guren/core'
+export const app = guren.createApp({ auth: {} })
+export const oauth = guren.createOAuthManager({})
+export const store = new guren.DatabaseSessionStore(sessions)
+`,
+    }
+
+    await withApp('guren-ast-namespace-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const analysis = await analyzeDeployRuntime(dir)
+
+      expect(analysis.sessionSignals.map((s) => s.symbol)).toContain('auth')
+      expect(analysis.oauthSignals.map((s) => s.symbol)).toContain('createOAuthManager')
+      expect(analysis.backedSessionSignals.map((s) => s.symbol)).toContain('DatabaseSessionStore')
     })
   })
 

--- a/packages/cli/tests/deploy-runtime.test.ts
+++ b/packages/cli/tests/deploy-runtime.test.ts
@@ -695,6 +695,144 @@ describe('runDoctor integration', () => {
   })
 })
 
+describe('AST-based matching', () => {
+  // The regex generation of this scanner documented aliased imports as a
+  // known gap in both directions. The AST resolves them, so an aliased
+  // remediation must count and an aliased hazard must still warn.
+  it('recognizes an aliased NodeHasher construction as remediation', async () => {
+    const files = {
+      'app/Http/Controllers/LoginController.ts': PASSWORD_LOGIN_CONTROLLER,
+      'app/Models/User.ts': `import { AuthenticatableModel, NodeHasher as RuntimeHasher } from '@guren/core'
+export class User extends AuthenticatableModel {
+  protected static passwordHasher = new RuntimeHasher()
+}
+`,
+    }
+
+    await withApp('guren-ast-alias-hasher-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await deployChecks(dir))['deploy-password-hashing'].status).toBe('pass')
+    })
+  })
+
+  it('still warns on an aliased AutoDiscovery construction', async () => {
+    const files = {
+      'src/app.ts': `import { AutoDiscovery as Discovery } from '@guren/core'
+const discovery = new Discovery({ basePath: 'app' })
+`,
+    }
+
+    await withApp('guren-ast-alias-discovery-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await deployChecks(dir))['deploy-provider-discovery'].status).toBe('warn')
+    })
+  })
+
+  it('recognizes an aliased backed session store', async () => {
+    const files = {
+      'src/app.ts': `import { createApp, DatabaseSessionStore as SessionStore } from '@guren/core'
+export const app = createApp({ auth: { sessionOptions: { store: new SessionStore(sessions) } } })
+`,
+    }
+
+    await withApp('guren-ast-alias-store-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await deployChecks(dir))['deploy-runtime-stores'].status).toBe('pass')
+    })
+  })
+
+  // Line-scanning could not see a value split from its key; the AST can.
+  it('suppresses the session warning when autoSession: false spans multiple lines', async () => {
+    const files = {
+      'src/app.ts': `import { createApp } from '@guren/core'
+export const app = createApp({
+  auth: {
+    autoSession:
+      false,
+  },
+})
+`,
+    }
+
+    await withApp('guren-ast-multiline-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await deployChecks(dir))['deploy-runtime-stores'].status).toBe('pass')
+    })
+  })
+
+  it('ignores constructions inside comments and string literals', async () => {
+    const files = {
+      'src/notes.ts': `// migration note: replace new MemoryStore() before deploying
+export const doc = 'call new MemoryDriver() to enqueue locally'
+`,
+    }
+
+    await withApp('guren-ast-comments-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await analyzeDeployRuntime(dir)).memoryStoreSignals).toEqual([])
+    })
+  })
+
+  it('ignores an auth key in a TypeScript type position', async () => {
+    const files = {
+      'src/types.ts': `export interface AppOptions {
+  auth: { autoSession?: boolean }
+}
+`,
+    }
+
+    await withApp('guren-ast-type-pos-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await analyzeDeployRuntime(dir)).sessionSignals).toEqual([])
+    })
+  })
+
+  // Regex-era false positive: the make:auth mail config contains
+  // `auth: { user, pass }` for SMTP credentials, which has nothing to do
+  // with sessions. Scoping the auth-key signal to createApp options fixes it.
+  it('does not read SMTP mailer auth config as a session', async () => {
+    const files = {
+      'config/mail.ts': `export const mail = {
+  transport: 'smtp',
+  auth: {
+    user: process.env.SMTP_USER ?? '',
+    pass: process.env.SMTP_PASS ?? '',
+  },
+}
+`,
+    }
+
+    await withApp('guren-ast-smtp-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await deployChecks(dir))['deploy-runtime-stores'].status).toBe('pass')
+    })
+  })
+
+  it('counts a shorthand auth property in createApp options', async () => {
+    const files = {
+      'src/app.ts': `import { createApp } from '@guren/core'
+const auth = {}
+export const app = createApp({ auth })
+`,
+    }
+
+    await withApp('guren-ast-shorthand-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-runtime-stores']
+
+      expect(check.status).toBe('warn')
+      expect(check.message).toContain('sessions are enabled')
+    })
+  })
+
+  it('skips a file that fails to parse without failing the run', async () => {
+    const files = {
+      'src/broken.ts': `export const = this is not valid typescript {{{`,
+      'src/app.ts': SESSION_APP,
+    }
+
+    await withApp('guren-ast-broken-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      // The broken file contributes nothing; the valid one still signals.
+      const check = (await deployChecks(dir))['deploy-runtime-stores']
+
+      expect(check.status).toBe('warn')
+      expect(check.message).toContain('sessions are enabled')
+    })
+  })
+})
+
 describe('test files are excluded from the scan', () => {
   // A test fixture constructing a backed store would otherwise satisfy the
   // remediation check on behalf of an app that never wires one up, hiding a

--- a/packages/cli/tests/deploy-runtime.test.ts
+++ b/packages/cli/tests/deploy-runtime.test.ts
@@ -1,0 +1,628 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
+import { analyzeDeployRuntime, detectDeployTargets } from '../src/deploy-runtime'
+import { buildJsonOutput, getDoctorRuleEvaluations, runDoctor } from '../src/doctor'
+import type { DoctorCheck, DoctorStatus } from '../src/doctor'
+import { createTempWorkspace } from './helpers'
+
+let consoleLogSpy: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  // runDoctor({ json: true }) writes the report to stdout.
+  consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  consoleLogSpy.mockRestore()
+})
+
+const DEPLOY_CHECK_KEYS = [
+  'deploy-password-hashing',
+  'deploy-runtime-stores',
+  'deploy-provider-discovery',
+] as const
+
+type DeployCheckKey = (typeof DEPLOY_CHECK_KEYS)[number]
+
+/**
+ * Write a throwaway app tree. `files` keys are project-relative paths;
+ * `dependencies` is merged into the generated package.json.
+ */
+async function writeApp(
+  dir: string,
+  files: Record<string, string>,
+  dependencies: Record<string, string> = {},
+): Promise<void> {
+  await writeFile(
+    join(dir, 'package.json'),
+    JSON.stringify({ name: 'deploy-runtime-fixture', dependencies }, null, 2),
+    'utf8',
+  )
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = join(dir, relativePath)
+    await mkdir(dirname(filePath), { recursive: true })
+    await writeFile(filePath, content, 'utf8')
+  }
+}
+
+async function withApp<T>(
+  prefix: string,
+  files: Record<string, string>,
+  dependencies: Record<string, string>,
+  run: (dir: string) => Promise<T>,
+): Promise<T> {
+  const workspace = await createTempWorkspace(prefix)
+  try {
+    await writeApp(workspace.dir, files, dependencies)
+    return await run(workspace.dir)
+  } finally {
+    await workspace.cleanup()
+  }
+}
+
+/** The three deploy checks, keyed for direct assertion. */
+async function deployChecks(cwd: string): Promise<Record<DeployCheckKey, DoctorCheck>> {
+  const { evaluations } = await getDoctorRuleEvaluations({ cwd })
+  const found = {} as Record<DeployCheckKey, DoctorCheck>
+
+  for (const key of DEPLOY_CHECK_KEYS) {
+    const check = evaluations.find((evaluation) => evaluation.check.key === key)?.check
+    if (!check) {
+      throw new Error(`doctor did not emit a "${key}" check`)
+    }
+    found[key] = check
+  }
+
+  return found
+}
+
+function statuses(checks: Record<DeployCheckKey, DoctorCheck>): Record<DeployCheckKey, DoctorStatus> {
+  return {
+    'deploy-password-hashing': checks['deploy-password-hashing'].status,
+    'deploy-runtime-stores': checks['deploy-runtime-stores'].status,
+    'deploy-provider-discovery': checks['deploy-provider-discovery'].status,
+  }
+}
+
+const PASSWORD_LOGIN_CONTROLLER = `import { Controller } from '@guren/core'
+export default class LoginController extends Controller {
+  async store() {
+    return this.auth.attempt({ email, password }, remember)
+  }
+}
+`
+
+/**
+ * An OAuth-only app: it subclasses AuthenticatableModel and configures
+ * passwordColumn, but never verifies or hashes a password.
+ */
+const OAUTH_ONLY_AUTH = `import { AuthenticatableModel, ServiceProvider } from '@guren/core'
+export class User extends AuthenticatableModel {
+  static guarded = ['id', 'passwordHash', 'rememberToken']
+}
+export default class AuthProvider extends ServiceProvider {
+  register() {
+    // passwordColumn stays configured so the guard rejects password logins
+    // for hash-less OAuth accounts.
+    auth.useModel(User, { usernameColumn: 'email', passwordColumn: 'passwordHash' })
+  }
+}
+`
+
+const SESSION_APP = `import { createApp } from '@guren/core'
+export const app = createApp({ auth: { autoSession: true } })
+`
+
+describe('detectDeployTargets', () => {
+  it('detects the Cloudflare plugin from package.json dependencies', async () => {
+    await withApp('guren-deploy-cf-', {}, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const targets = await detectDeployTargets(dir)
+
+      expect(targets).toHaveLength(1)
+      expect(targets[0].profile.id).toBe('cloudflare')
+      expect(targets[0].detectedVia).toContain('@guren/plugin-cloudflare')
+    })
+  })
+
+  it('detects the Vercel plugin and marks it as a Bun runtime', async () => {
+    await withApp('guren-deploy-vercel-', {}, { '@guren/plugin-vercel': '^0.2.0' }, async (dir) => {
+      const targets = await detectDeployTargets(dir)
+
+      expect(targets).toHaveLength(1)
+      expect(targets[0].profile.id).toBe('vercel')
+      // buildVercelOutput emits `runtime: 'bun1.x'`, so Bun.password exists.
+      expect(targets[0].profile.hasBunRuntime).toBe(true)
+    })
+  })
+
+  it('detects the Lambda adapter from a @guren/core/lambda import', async () => {
+    const files = {
+      'lambda.ts': `import { createLambdaHandler } from '@guren/core/lambda'\nexport const handler = createLambdaHandler(app)\n`,
+    }
+
+    await withApp('guren-deploy-lambda-', files, {}, async (dir) => {
+      const targets = await detectDeployTargets(dir)
+
+      expect(targets).toHaveLength(1)
+      expect(targets[0].profile.id).toBe('lambda')
+      expect(targets[0].detectedVia).toContain('lambda.ts')
+    })
+  })
+
+  it('detects the Lambda adapter from the @guren/server/lambda path too', async () => {
+    const files = {
+      'src/lambda.ts': `import { createLambdaHandler } from '@guren/server/lambda'\n`,
+    }
+
+    await withApp('guren-deploy-lambda-server-', files, {}, async (dir) => {
+      const targets = await detectDeployTargets(dir)
+
+      expect(targets.map((target) => target.profile.id)).toEqual(['lambda'])
+    })
+  })
+
+  it('detects several targets at once', async () => {
+    const files = { 'lambda.ts': `import { createLambdaHandler } from '@guren/core/lambda'\n` }
+    const deps = { '@guren/plugin-cloudflare': '^0.2.0' }
+
+    await withApp('guren-deploy-multi-', files, deps, async (dir) => {
+      const targets = await detectDeployTargets(dir)
+
+      expect(targets.map((target) => target.profile.id).sort()).toEqual(['cloudflare', 'lambda'])
+    })
+  })
+
+  it('reports no target for a plain Bun app', async () => {
+    await withApp('guren-deploy-none-', { 'src/app.ts': SESSION_APP }, {}, async (dir) => {
+      expect(await detectDeployTargets(dir)).toEqual([])
+    })
+  })
+})
+
+describe('deploy-password-hashing check', () => {
+  it('warns when a Workers app verifies passwords without NodeHasher', async () => {
+    const files = { 'app/Http/Controllers/LoginController.ts': PASSWORD_LOGIN_CONTROLLER }
+
+    await withApp('guren-hash-cf-warn-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-password-hashing']
+
+      expect(check.status).toBe('warn')
+      expect(check.message).toContain('Cloudflare Workers')
+      expect(check.message).toContain('auth.attempt (app/Http/Controllers/LoginController.ts:4)')
+      expect(check.fix).toContain('NodeHasher')
+    })
+  })
+
+  it('warns for Lambda as well', async () => {
+    const files = {
+      'lambda.ts': `import { createLambdaHandler } from '@guren/core/lambda'\n`,
+      'db/seeders/001_UsersSeeder.ts': `import { ScryptHasher } from '@guren/core'\nconst hasher = new ScryptHasher()\n`,
+    }
+
+    await withApp('guren-hash-lambda-warn-', files, {}, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-password-hashing']
+
+      expect(check.status).toBe('warn')
+      expect(check.message).toContain('AWS Lambda')
+      expect(check.message).toContain('ScryptHasher')
+    })
+  })
+
+  // A bare import is not remediation: the check must see the hasher actually
+  // constructed, or a leftover `import { NodeHasher }` would silence a real gap.
+  it('still warns when NodeHasher is imported but never constructed', async () => {
+    const files = {
+      'app/Http/Controllers/LoginController.ts': PASSWORD_LOGIN_CONTROLLER,
+      'app/Models/User.ts': `import { AuthenticatableModel, NodeHasher } from '@guren/core'
+export class User extends AuthenticatableModel {}
+`,
+    }
+
+    await withApp('guren-hash-import-only-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-password-hashing']
+
+      expect(check.status).toBe('warn')
+    })
+  })
+
+  it('passes once NodeHasher is configured', async () => {
+    const files = {
+      'app/Http/Controllers/LoginController.ts': PASSWORD_LOGIN_CONTROLLER,
+      'app/Models/User.ts': `import { AuthenticatableModel, NodeHasher } from '@guren/core'
+export class User extends AuthenticatableModel {
+  protected static passwordHasher = new NodeHasher()
+}
+`,
+    }
+
+    await withApp('guren-hash-cf-pass-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-password-hashing']
+
+      expect(check.status).toBe('pass')
+      expect(check.message).toContain('NodeHasher is configured')
+    })
+  })
+
+  it('passes for an OAuth-only app with no password authentication', async () => {
+    const files = { 'src/app.ts': SESSION_APP }
+
+    await withApp('guren-hash-oauth-only-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-password-hashing']
+
+      expect(check.status).toBe('pass')
+      expect(check.message).toContain('no password authentication')
+    })
+  })
+
+  // Regression: guren.dev is an OAuth-only Workers app that keeps
+  // AuthenticatableModel and passwordColumn so the guard can reject password
+  // logins for hash-less accounts. Treating those as password auth reported a
+  // break that cannot happen.
+  it('does not warn for a passwordless app that still configures passwordColumn', async () => {
+    const files = { 'app/Providers/AuthProvider.ts': OAUTH_ONLY_AUTH }
+
+    await withApp('guren-hash-passwordless-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-password-hashing']
+
+      expect(check.status).toBe('pass')
+      expect(check.message).toContain('no password authentication')
+    })
+  })
+
+  it('does not warn on Vercel, whose functions run on Bun', async () => {
+    const files = { 'app/Http/Controllers/LoginController.ts': PASSWORD_LOGIN_CONTROLLER }
+
+    await withApp('guren-hash-vercel-', files, { '@guren/plugin-vercel': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-password-hashing']
+
+      expect(check.status).toBe('pass')
+      expect(check.message).toContain('runs on Bun')
+    })
+  })
+})
+
+describe('deploy-runtime-stores check', () => {
+  it('warns when sessions are enabled with no backed store', async () => {
+    await withApp(
+      'guren-stores-session-',
+      { 'src/app.ts': SESSION_APP },
+      { '@guren/plugin-cloudflare': '^0.2.0' },
+      async (dir) => {
+        const check = (await deployChecks(dir))['deploy-runtime-stores']
+
+        expect(check.status).toBe('warn')
+        expect(check.message).toContain('sessions are enabled')
+        expect(check.message).toContain('DatabaseSessionStore')
+        expect(check.fix).toContain('DatabaseSessionStore')
+      },
+    )
+  })
+
+  // autoSession defaults to true (AuthServiceProvider attaches session
+  // middleware unless explicitly `false`), so an app that opts out entirely
+  // must not be flagged for lacking a backed session store.
+  it('does not warn when autoSession is explicitly false', async () => {
+    const files = {
+      'src/app.ts': `import { createApp } from '@guren/core'
+export const app = createApp({ auth: { autoSession: false } })
+`,
+    }
+
+    await withApp('guren-stores-no-session-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-runtime-stores']
+
+      expect(check.status).toBe('pass')
+    })
+  })
+
+  // make:auth's own scaffolding advice is literally "add auth: {} to your
+  // createApp() options to enable sessions and CSRF" — this bare-object shape
+  // must be caught even though it names neither autoSession nor sessionOptions.
+  it('warns on a bare auth: {} with no backed store, the make:auth-recommended shape', async () => {
+    const files = {
+      'src/app.ts': `import { createApp } from '@guren/core'\nexport const app = createApp({ auth: {} })\n`,
+    }
+
+    await withApp('guren-stores-bare-auth-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-runtime-stores']
+
+      expect(check.status).toBe('warn')
+      expect(check.message).toContain('sessions are enabled')
+    })
+  })
+
+  // The `auth: {` match alone can't see what's inside the object it opens, so
+  // suppression must come from a whole-app check for `autoSession: false`,
+  // not from excluding it within the same regex pass (that reintroduces the
+  // exact backtracking bug fixed above).
+  it('does not warn when autoSession: false sits inside the same auth: { line', async () => {
+    const files = {
+      'src/app.ts': `import { createApp } from '@guren/core'
+export const app = createApp({ auth: { autoSession: false } })
+`,
+    }
+
+    await withApp('guren-stores-bare-auth-disabled-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await deployChecks(dir))['deploy-runtime-stores'].status).toBe('pass')
+    })
+  })
+
+  it('passes once a DatabaseSessionStore is wired in', async () => {
+    const files = {
+      'src/app.ts': `import { createApp, DatabaseSessionStore } from '@guren/core'
+import { sessions } from '@/db/schema'
+export const app = createApp({
+  auth: { autoSession: true, sessionOptions: { store: new DatabaseSessionStore(sessions) } },
+})
+`,
+    }
+
+    await withApp('guren-stores-session-ok-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-runtime-stores']
+
+      expect(check.status).toBe('pass')
+    })
+  })
+
+  // A store that is imported but never constructed is not remediation: the
+  // import survives refactors that drop the actual wiring.
+  it('still warns when a backed store is imported but never constructed', async () => {
+    const files = {
+      'src/app.ts': `import { createApp, DatabaseSessionStore } from '@guren/core'
+export const app = createApp({ auth: { autoSession: true, sessionOptions: {} } })
+`,
+    }
+
+    await withApp('guren-stores-import-only-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-runtime-stores']
+
+      expect(check.status).toBe('warn')
+      expect(check.message).toContain('sessions are enabled')
+    })
+  })
+
+  it('accepts a store constructed in a different module than it is used', async () => {
+    const files = {
+      'src/app.ts': `import { createApp } from '@guren/core'
+import { sessionStore } from './stores'
+export const app = createApp({ auth: { autoSession: true, sessionOptions: { store: sessionStore } } })
+`,
+      'src/stores.ts': `import { DatabaseSessionStore } from '@guren/core'
+export const sessionStore = new DatabaseSessionStore(sessions)
+`,
+    }
+
+    await withApp('guren-stores-split-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await deployChecks(dir))['deploy-runtime-stores'].status).toBe('pass')
+    })
+  })
+
+  it('accepts a Redis-backed session store as remediation', async () => {
+    const files = {
+      'src/app.ts': `import { createApp } from '@guren/core'
+import { RedisSessionStore } from '@guren/core/redis'
+export const app = createApp({
+  auth: { autoSession: true, sessionOptions: { store: new RedisSessionStore(redis) } },
+})
+`,
+    }
+
+    await withApp('guren-stores-redis-', files, { '@guren/plugin-vercel': '^0.2.0' }, async (dir) => {
+      expect((await deployChecks(dir))['deploy-runtime-stores'].status).toBe('pass')
+    })
+  })
+
+  it('warns when OAuth is configured with no backed state store', async () => {
+    const files = {
+      'app/Providers/OAuthProvider.ts': `import { createOAuthManager } from '@guren/core'
+export const oauth = createOAuthManager({})
+`,
+    }
+
+    await withApp('guren-stores-oauth-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-runtime-stores']
+
+      expect(check.status).toBe('warn')
+      expect(check.message).toContain('OAuth is configured')
+      expect(check.message).toContain('DatabaseOAuthStateStore')
+    })
+  })
+
+  it('warns about explicitly constructed in-memory cache and queue stores', async () => {
+    const files = {
+      'config/cache.ts': `import { MemoryStore } from '@guren/core'\nexport const store = new MemoryStore()\n`,
+      'config/queue.ts': `import { MemoryDriver } from '@guren/core'\nexport const driver = new MemoryDriver()\n`,
+    }
+
+    await withApp('guren-stores-explicit-', files, { '@guren/plugin-vercel': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-runtime-stores']
+
+      expect(check.status).toBe('warn')
+      expect(check.message).toContain('constructed explicitly')
+      expect(check.message).toContain('MemoryStore (config/cache.ts:2)')
+      expect(check.message).toContain('MemoryDriver (config/queue.ts:2)')
+    })
+  })
+
+  it('passes for an app with no session, OAuth, or in-memory store signals', async () => {
+    const files = { 'src/app.ts': `import { createApp } from '@guren/core'\nexport const app = createApp({})\n` }
+
+    await withApp('guren-stores-api-only-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-runtime-stores']
+
+      expect(check.status).toBe('pass')
+      expect(check.message).toContain('no in-memory store defaults')
+    })
+  })
+})
+
+describe('deploy-provider-discovery check', () => {
+  it('warns when a Workers app uses AutoDiscovery', async () => {
+    const files = {
+      'src/app.ts': `import { AutoDiscovery, createApp } from '@guren/core'
+const discovery = new AutoDiscovery({ basePath: 'app' })
+const result = await discovery.discover()
+export const app = createApp({ providers: result.providers })
+`,
+    }
+
+    await withApp('guren-discovery-cf-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-provider-discovery']
+
+      expect(check.status).toBe('warn')
+      expect(check.message).toContain('AutoDiscovery')
+      expect(check.message).toContain('Bun.Glob')
+      expect(check.fix).toContain('providers')
+    })
+  })
+
+  it('warns on Vercel because the bundle ships no app directory', async () => {
+    const files = {
+      'src/app.ts': `import { AutoDiscovery } from '@guren/core'
+const discovery = new AutoDiscovery({ basePath: 'app' })
+`,
+    }
+
+    await withApp('guren-discovery-vercel-', files, { '@guren/plugin-vercel': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-provider-discovery']
+
+      expect(check.status).toBe('warn')
+      expect(check.message).toContain('bun build` bundle')
+    })
+  })
+
+  // A bare import is not active use — it survives refactors that drop the
+  // actual discovery call, the same false positive fixed for NodeHasher.
+  it('does not warn on an AutoDiscovery import that is never constructed', async () => {
+    const files = { 'src/app.ts': `import { AutoDiscovery } from '@guren/core'\n` }
+
+    await withApp('guren-discovery-import-only-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await deployChecks(dir))['deploy-provider-discovery'].status).toBe('pass')
+    })
+  })
+
+  // ApplicationOptions.discover is declared but never read anywhere in
+  // @guren/server, so it has no runtime effect — writing `discover: true`
+  // does not activate filesystem provider discovery and must not warn.
+  it('does not warn on the inert discover: true option', async () => {
+    const files = {
+      'src/app.ts': `import { createApp } from '@guren/core'\nexport const app = createApp({ discover: true })\n`,
+    }
+
+    await withApp('guren-discovery-option-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await deployChecks(dir))['deploy-provider-discovery'].status).toBe('pass')
+    })
+  })
+
+  it('passes when providers are listed explicitly', async () => {
+    const files = {
+      'src/app.ts': `import { createApp, DatabaseProvider } from '@guren/core'
+export const app = createApp({ providers: [DatabaseProvider] })
+`,
+    }
+
+    await withApp('guren-discovery-explicit-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-provider-discovery']
+
+      expect(check.status).toBe('pass')
+      expect(check.message).toContain('provider discovery is not used')
+    })
+  })
+})
+
+describe('deploy-runtime checks without a deploy target', () => {
+  it('all pass when no deploy plugin or Lambda adapter is present', async () => {
+    const files = {
+      // Every pattern the checks look for, none of which matters off-serverless.
+      'src/app.ts': SESSION_APP,
+      'app/Http/Controllers/LoginController.ts': PASSWORD_LOGIN_CONTROLLER,
+      'config/cache.ts': `import { MemoryStore } from '@guren/core'\nexport const store = new MemoryStore()\n`,
+      'config/discovery.ts': `import { AutoDiscovery } from '@guren/core'\n`,
+    }
+
+    await withApp('guren-deploy-no-target-', files, {}, async (dir) => {
+      expect(statuses(await deployChecks(dir))).toEqual({
+        'deploy-password-hashing': 'pass',
+        'deploy-runtime-stores': 'pass',
+        'deploy-provider-discovery': 'pass',
+      })
+    })
+  })
+
+  it('leaves the checks non-autofixable so `doctor --fix` never touches deploy config', async () => {
+    const files = { 'src/app.ts': SESSION_APP }
+
+    await withApp('guren-deploy-no-autofix-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const { evaluations } = await getDoctorRuleEvaluations({ cwd: dir })
+      const deployEvaluations = evaluations.filter((evaluation) =>
+        (DEPLOY_CHECK_KEYS as readonly string[]).includes(evaluation.check.key),
+      )
+
+      expect(deployEvaluations).toHaveLength(3)
+      for (const evaluation of deployEvaluations) {
+        expect(evaluation.check.canAutofix).toBeFalsy()
+        expect(evaluation.autofix).toBeNull()
+      }
+    })
+  })
+})
+
+describe('runDoctor integration', () => {
+  it('surfaces the deploy checks through --json and --next without throwing', async () => {
+    const files = { 'src/app.ts': SESSION_APP }
+
+    await withApp('guren-deploy-report-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const report = await runDoctor({ cwd: dir, json: true, next: true })
+      const json = buildJsonOutput(report)
+      const byKey = new Map(json.checks.map((check) => [check.key, check]))
+
+      for (const key of DEPLOY_CHECK_KEYS) {
+        expect(byKey.has(key)).toBe(true)
+      }
+
+      // The session default is unaddressed here, so it must reach the operator
+      // as a warning with manual remediation and no autofix offer.
+      const stores = byKey.get('deploy-runtime-stores')
+      expect(stores?.status).toBe('warn')
+      expect(stores?.canAutofix).toBe(false)
+      expect(stores?.manualFix).toContain('DatabaseSessionStore')
+
+      expect(report.hasWarnings).toBe(true)
+      expect(report.manualChecks.map((check) => check.key)).toContain('deploy-runtime-stores')
+      expect(report.fixableChecks.map((check) => check.key)).not.toContain('deploy-runtime-stores')
+      expect(json.summary.total).toBe(json.checks.length)
+      expect(Array.isArray(json.nextSteps)).toBe(true)
+    })
+  })
+})
+
+describe('analyzeDeployRuntime', () => {
+  it('scans modules/ trees as well as the project root', async () => {
+    const files = {
+      'modules/billing/index.ts': `import { MemoryStore } from '@guren/core'\nexport const store = new MemoryStore()\n`,
+    }
+
+    await withApp('guren-deploy-modules-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const analysis = await analyzeDeployRuntime(dir)
+
+      expect(analysis.memoryStoreSignals.map((signal) => signal.filePath)).toContain(
+        'modules/billing/index.ts',
+      )
+    })
+  })
+
+  it('ignores node_modules so a dependency\'s own sources never trip a check', async () => {
+    const files = {
+      'node_modules/@guren/core/dist/index.ts': `export class MemoryStore {}\nconst s = new MemoryStore()\n`,
+      'src/app.ts': `import { createApp } from '@guren/core'\nexport const app = createApp({})\n`,
+    }
+
+    await withApp('guren-deploy-node-modules-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const analysis = await analyzeDeployRuntime(dir)
+
+      expect(analysis.memoryStoreSignals).toEqual([])
+    })
+  })
+})

--- a/packages/cli/tests/deploy-runtime.test.ts
+++ b/packages/cli/tests/deploy-runtime.test.ts
@@ -904,18 +904,36 @@ export const store = new guren.DatabaseSessionStore(sessions)
     })
   })
 
-  it('skips a file that fails to parse without failing the run', async () => {
+  it('skips a file that fails to parse, and says so in the check message', async () => {
     const files = {
       'src/broken.ts': `export const = this is not valid typescript {{{`,
       'src/app.ts': SESSION_APP,
     }
 
     await withApp('guren-ast-broken-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
-      // The broken file contributes nothing; the valid one still signals.
+      const analysis = await analyzeDeployRuntime(dir)
+      expect(analysis.unparsedFiles).toEqual(['src/broken.ts'])
+
+      // The broken file contributes nothing; the valid one still signals —
+      // and the verdict discloses that the scan was incomplete, so a skipped
+      // file is a visible caveat rather than a silent false negative.
       const check = (await deployChecks(dir))['deploy-runtime-stores']
 
       expect(check.status).toBe('warn')
       expect(check.message).toContain('sessions are enabled')
+      expect(check.message).toContain('could not be parsed and were not scanned: src/broken.ts')
+    })
+  })
+
+  it('adds no parse caveat when every file parses', async () => {
+    const files = { 'src/app.ts': SESSION_APP }
+
+    await withApp('guren-ast-clean-scan-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const analysis = await analyzeDeployRuntime(dir)
+      expect(analysis.unparsedFiles).toEqual([])
+
+      const check = (await deployChecks(dir))['deploy-runtime-stores']
+      expect(check.message).not.toContain('could not be parsed')
     })
   })
 })

--- a/packages/cli/tests/deploy-runtime.test.ts
+++ b/packages/cli/tests/deploy-runtime.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
-import { analyzeDeployRuntime, detectDeployTargets } from '../src/deploy-runtime'
+import { analyzeDeployRuntime } from '../src/deploy-runtime'
 import { buildJsonOutput, getDoctorRuleEvaluations, runDoctor } from '../src/doctor'
 import type { DoctorCheck, DoctorStatus } from '../src/doctor'
 import { createTempWorkspace } from './helpers'
@@ -115,10 +115,10 @@ const SESSION_APP = `import { createApp } from '@guren/core'
 export const app = createApp({ auth: { autoSession: true } })
 `
 
-describe('detectDeployTargets', () => {
+describe('deploy target detection', () => {
   it('detects the Cloudflare plugin from package.json dependencies', async () => {
     await withApp('guren-deploy-cf-', {}, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
-      const targets = await detectDeployTargets(dir)
+      const { targets } = await analyzeDeployRuntime(dir)
 
       expect(targets).toHaveLength(1)
       expect(targets[0].profile.id).toBe('cloudflare')
@@ -128,7 +128,7 @@ describe('detectDeployTargets', () => {
 
   it('detects the Vercel plugin and marks it as a Bun runtime', async () => {
     await withApp('guren-deploy-vercel-', {}, { '@guren/plugin-vercel': '^0.2.0' }, async (dir) => {
-      const targets = await detectDeployTargets(dir)
+      const { targets } = await analyzeDeployRuntime(dir)
 
       expect(targets).toHaveLength(1)
       expect(targets[0].profile.id).toBe('vercel')
@@ -143,7 +143,7 @@ describe('detectDeployTargets', () => {
     }
 
     await withApp('guren-deploy-lambda-', files, {}, async (dir) => {
-      const targets = await detectDeployTargets(dir)
+      const { targets } = await analyzeDeployRuntime(dir)
 
       expect(targets).toHaveLength(1)
       expect(targets[0].profile.id).toBe('lambda')
@@ -157,7 +157,7 @@ describe('detectDeployTargets', () => {
     }
 
     await withApp('guren-deploy-lambda-server-', files, {}, async (dir) => {
-      const targets = await detectDeployTargets(dir)
+      const { targets } = await analyzeDeployRuntime(dir)
 
       expect(targets.map((target) => target.profile.id)).toEqual(['lambda'])
     })
@@ -168,7 +168,7 @@ describe('detectDeployTargets', () => {
     const deps = { '@guren/plugin-cloudflare': '^0.2.0' }
 
     await withApp('guren-deploy-multi-', files, deps, async (dir) => {
-      const targets = await detectDeployTargets(dir)
+      const { targets } = await analyzeDeployRuntime(dir)
 
       expect(targets.map((target) => target.profile.id).sort()).toEqual(['cloudflare', 'lambda'])
     })
@@ -176,7 +176,7 @@ describe('detectDeployTargets', () => {
 
   it('reports no target for a plain Bun app', async () => {
     await withApp('guren-deploy-none-', { 'src/app.ts': SESSION_APP }, {}, async (dir) => {
-      expect(await detectDeployTargets(dir)).toEqual([])
+      expect((await analyzeDeployRuntime(dir)).targets).toEqual([])
     })
   })
 })
@@ -594,6 +594,39 @@ describe('runDoctor integration', () => {
       expect(report.fixableChecks.map((check) => check.key)).not.toContain('deploy-runtime-stores')
       expect(json.summary.total).toBe(json.checks.length)
       expect(Array.isArray(json.nextSteps)).toBe(true)
+    })
+  })
+})
+
+describe('test files are excluded from the scan', () => {
+  // A test fixture constructing a backed store would otherwise satisfy the
+  // remediation check on behalf of an app that never wires one up, hiding a
+  // real production gap.
+  it('does not let a store constructed in a test file mask a production gap', async () => {
+    const files = {
+      'src/app.ts': SESSION_APP,
+      'src/app.test.ts': `import { DatabaseSessionStore } from '@guren/core'
+const store = new DatabaseSessionStore(sessions)
+`,
+    }
+
+    await withApp('guren-scan-test-mask-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const check = (await deployChecks(dir))['deploy-runtime-stores']
+
+      expect(check.status).toBe('warn')
+      expect(check.message).toContain('sessions are enabled')
+    })
+  })
+
+  it('does not raise a session signal from a test fixture alone', async () => {
+    const files = {
+      'src/routes.test.ts': `const app = createApp({ auth: { autoSession: true } })\n`,
+    }
+
+    await withApp('guren-scan-test-signal-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      const analysis = await analyzeDeployRuntime(dir)
+
+      expect(analysis.sessionSignals).toEqual([])
     })
   })
 })

--- a/packages/cli/tests/deploy-runtime.test.ts
+++ b/packages/cli/tests/deploy-runtime.test.ts
@@ -121,7 +121,7 @@ describe('deploy target detection', () => {
       const { targets } = await analyzeDeployRuntime(dir)
 
       expect(targets).toHaveLength(1)
-      expect(targets[0].profile.id).toBe('cloudflare')
+      expect(targets[0].profile.label).toBe('Cloudflare Workers')
       expect(targets[0].detectedVia).toContain('@guren/plugin-cloudflare')
     })
   })
@@ -131,7 +131,7 @@ describe('deploy target detection', () => {
       const { targets } = await analyzeDeployRuntime(dir)
 
       expect(targets).toHaveLength(1)
-      expect(targets[0].profile.id).toBe('vercel')
+      expect(targets[0].profile.label).toBe('Vercel')
       // buildVercelOutput emits `runtime: 'bun1.x'`, so Bun.password exists.
       expect(targets[0].profile.hasBunRuntime).toBe(true)
     })
@@ -146,7 +146,7 @@ describe('deploy target detection', () => {
       const { targets } = await analyzeDeployRuntime(dir)
 
       expect(targets).toHaveLength(1)
-      expect(targets[0].profile.id).toBe('lambda')
+      expect(targets[0].profile.label).toBe('AWS Lambda')
       expect(targets[0].detectedVia).toContain('lambda.ts')
     })
   })
@@ -159,7 +159,7 @@ describe('deploy target detection', () => {
     await withApp('guren-deploy-lambda-server-', files, {}, async (dir) => {
       const { targets } = await analyzeDeployRuntime(dir)
 
-      expect(targets.map((target) => target.profile.id)).toEqual(['lambda'])
+      expect(targets.map((target) => target.profile.label)).toEqual(['AWS Lambda'])
     })
   })
 
@@ -176,7 +176,7 @@ export const handler = createLambdaHandler(app)
     await withApp('guren-deploy-lambda-call-', files, {}, async (dir) => {
       const { targets } = await analyzeDeployRuntime(dir)
 
-      expect(targets.map((target) => target.profile.id)).toEqual(['lambda'])
+      expect(targets.map((target) => target.profile.label)).toEqual(['AWS Lambda'])
     })
   })
 
@@ -187,7 +187,7 @@ export const handler = createLambdaHandler(app)
     await withApp('guren-deploy-multi-', files, deps, async (dir) => {
       const { targets } = await analyzeDeployRuntime(dir)
 
-      expect(targets.map((target) => target.profile.id).sort()).toEqual(['cloudflare', 'lambda'])
+      expect(targets.map((target) => target.profile.label).sort()).toEqual(['AWS Lambda', 'Cloudflare Workers'])
     })
   })
 
@@ -761,15 +761,66 @@ export const app = createApp({
     })
   })
 
+  // The file imports the very symbols it names in prose, so source-aware name
+  // filtering alone cannot carry this test — only comment/string handling can.
   it('ignores constructions inside comments and string literals', async () => {
     const files = {
-      'src/notes.ts': `// migration note: replace new MemoryStore() before deploying
+      'src/notes.ts': `import { MemoryStore, MemoryDriver } from '@guren/core'
+
+// migration note: replace new MemoryStore() before deploying
 export const doc = 'call new MemoryDriver() to enqueue locally'
 `,
     }
 
     await withApp('guren-ast-comments-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
       expect((await analyzeDeployRuntime(dir)).memoryStoreSignals).toEqual([])
+    })
+  })
+
+  // Both keys are generic enough that another library's config would claim
+  // them; they only count inside a file that imports from Guren.
+  it('ignores session option keys in a file with no Guren import', async () => {
+    const files = {
+      'config/other.ts': `export const cfg = { sessionOptions: { maxAge: 1 }, autoSession: true }\n`,
+    }
+
+    await withApp('guren-ast-foreign-session-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await analyzeDeployRuntime(dir)).sessionSignals).toEqual([])
+    })
+  })
+
+  it('ignores an unrelated auth.attempt() in a file with no Guren import', async () => {
+    const files = {
+      'src/other.ts': `import { auth } from 'some-auth-sdk'\nexport const ok = await auth.attempt({})\n`,
+    }
+
+    await withApp('guren-ast-foreign-attempt-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await analyzeDeployRuntime(dir)).passwordAuthSignals).toEqual([])
+    })
+  })
+
+  // Suppression stays ungated on purpose: missing an opt-out would warn a
+  // correctly-configured app, the failure direction this check avoids.
+  it('still reads autoSession: false from a file with no Guren import', async () => {
+    const files = {
+      'config/session.ts': `export const session = { autoSession: false }\n`,
+      'src/app.ts': `import { createApp } from '@guren/core'\nexport const app = createApp({ auth: {} })\n`,
+    }
+
+    await withApp('guren-ast-ungated-optout-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await deployChecks(dir))['deploy-runtime-stores'].status).toBe('pass')
+    })
+  })
+
+  it('ignores a signal name used only in an implements clause', async () => {
+    const files = {
+      'src/provider.ts': `import { OAuthServiceProvider } from '@guren/core'
+export class Custom implements OAuthServiceProvider {}
+`,
+    }
+
+    await withApp('guren-ast-implements-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+      expect((await analyzeDeployRuntime(dir)).oauthSignals).toEqual([])
     })
   })
 
@@ -921,7 +972,26 @@ export const store = new guren.DatabaseSessionStore(sessions)
 
       expect(check.status).toBe('warn')
       expect(check.message).toContain('sessions are enabled')
-      expect(check.message).toContain('could not be parsed and were not scanned: src/broken.ts')
+      expect(check.message).toContain('could not be read or parsed and were not scanned: src/broken.ts')
+    })
+  })
+
+  // The Lambda target is detected from source, so a skipped file can hide a
+  // target entirely. "No deploy plugin detected" computed over an incomplete
+  // scan has to disclose that, or the caveat has a hole exactly where the
+  // scan was least complete.
+  it('carries the caveat on the no-target verdict, since a skipped file can hide a Lambda target', async () => {
+    const files = { 'lambda.ts': `import { createLambdaHandler } from '@guren/core/lambda'\nexport const = broken {{{` }
+
+    await withApp('guren-caveat-no-target-', files, {}, async (dir) => {
+      const analysis = await analyzeDeployRuntime(dir)
+      expect(analysis.targets).toEqual([])
+      expect(analysis.unparsedFiles).toEqual(['lambda.ts'])
+
+      for (const check of Object.values(await deployChecks(dir))) {
+        expect(check.message).toContain('No deploy plugin or Lambda adapter detected.')
+        expect(check.message).toContain('could not be read or parsed')
+      }
     })
   })
 


### PR DESCRIPTION
## Summary

Extends `bunx guren doctor` with three new checks that fire when a deploy plugin (`@guren/plugin-cloudflare`, `@guren/plugin-vercel`) or the Lambda adapter is detected in the app:

- **`deploy-password-hashing`** — warns when `ScryptHasher` (the default, built on `Bun.password`) is reachable via password verification/hashing but `NodeHasher` is never constructed, on runtimes without Bun (Cloudflare Workers, Lambda). Vercel is excluded since its functions run on Bun (`runtime: 'bun1.x'` per `@guren/plugin-vercel`).
- **`deploy-runtime-stores`** — warns when sessions or OAuth are enabled with no database/Redis-backed store, or when an in-memory store is constructed explicitly, on targets that share no memory between requests.
- **`deploy-provider-discovery`** — warns when the app constructs `AutoDiscovery` (filesystem-scanning via `Bun.Glob`), which breaks on every one of the three targets for different reasons (no Bun runtime, no filesystem, or a bundle that ships no `app/` directory).

These mirror the prose warnings already documented in `packages/plugin-cloudflare/README.md` ("Things Workers changes") and `docs/{en,ja}/guides/serverless.md`, turned into mechanical checks per the existing `doctor`/`audit` patterns.

Also extracts a small shared helper, `readDeclaredDependencyNames()`, from `plugin-manifest.ts` so both the pre-existing plugin-manifest reader and the new deploy-target detection share one package.json-parsing implementation instead of two.

## Scope

- `cli` — new file `packages/cli/src/deploy-runtime.ts`, changes to `packages/cli/src/doctor.ts` and `packages/cli/src/plugin-manifest.ts`
- `cli` tests — new file `packages/cli/tests/deploy-runtime.test.ts`

## Risk Assessment

- All three checks are `warn`-only and non-autofixable; `doctor --fix` never touches deploy config.
- No behavior change to existing doctor checks or `readInstalledPluginManifests()` (verified via `plugin-manifest.test.ts`).
- Signals are extracted from a Babel AST (`@babel/parser`, the same parser `audit.ts` and `model-parser.ts` already use), not per-line regexes. Aliased imports resolve to canonical names, multi-line values match, and comments/string literals/TypeScript type positions cannot trip a check. Only *constructions* (`new X(`) count — a leftover import neither satisfies a remediation nor raises a warning. Files that fail to parse contribute no signals rather than failing the run.
- Test files (`*.test.*` / `*.spec.*`) are excluded from the scan, so a fixture constructing a backed store cannot mask a production gap.
- The session signal for an `auth:` key is scoped to `createApp()` options, so SMTP-style `auth: { user, pass }` mailer config does not read as an enabled session.
- Known, documented limitation: a registration-only app that hashes passwords without ever calling `auth.attempt()` passes undetected — `make:auth` always scaffolds login alongside registration, so this shape doesn't occur in generated apps.

## Validation

- [x] `bun run build` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test` — `bun run test:bun`: 2868 pass, 0 fail, 49 skip
- [x] `bun run audit:core-first` / `bun run audit:docs` — both pass

Additional verification beyond the checklist:
- Ran the actual CLI against `web/` (guren.dev, the real Cloudflare Workers app in this repo) in both directions: all three checks report clean against its real session/OAuth/hasher setup, and correctly warn once the store wiring is deliberately removed in a local probe (reverted afterward). Also ran against `examples/blog` to confirm parse robustness on a larger tree.
- Mutation-tested throughout: every signal table, every scan directory, the test-file exclusion, alias resolution, and the createApp scoping were each broken deliberately to confirm the corresponding tests fail. Earlier rounds caught a regex backtracking bug and an OAuth-remediation table with zero coverage this way.
- Two rounds of independent Codex review plus a 4-angle simplify pass, all findings either applied or explicitly declined with reasons in the commit history.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks. (None — additive only.)
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation. (N/A — this mirrors existing prose docs rather than changing them.)