### PR TITLE
fix(server): support raw head markup for site-wide favicon links

### DIFF
--- a/packages/server/src/mvc/inertia/InertiaEngine.ts
+++ b/packages/server/src/mvc/inertia/InertiaEngine.ts
@@ -86,6 +86,13 @@ export interface InertiaDocumentOptions {
    * `matchMedia` before React hydrates.
    */
   readonly prepaintScript?: InertiaDocumentValue;
+  /**
+   * Raw markup inlined into `<head>`, ahead of the critical CSS and stylesheet
+   * links. Unescaped — the app author owns this string. Use it for static,
+   * site-wide tags the framework has no way to infer on its own, such as
+   * `<link rel="icon">` favicons.
+   */
+  readonly head?: InertiaDocumentValue;
 }
 
 let documentOptions: InertiaDocumentOptions | undefined;
@@ -103,8 +110,9 @@ let documentOptions: InertiaDocumentOptions | undefined;
  * requests are in flight leaks the new policy into them. Use the matching
  * {@link InertiaOptions} fields for a single response instead.
  *
- * The values are emitted verbatim inside `<style>` / `<script>` elements —
- * they are developer-authored assets, never user input.
+ * The values are emitted verbatim — inside `<style>` / `<script>` elements,
+ * or as raw markup for `head` — they are developer-authored assets, never
+ * user input.
  *
  * ```typescript
  * setInertiaDocument({
@@ -249,6 +257,7 @@ async function renderDocument(
     options,
     page.component
   );
+  const headMarkup = resolveDocumentValue("head", options, page.component);
   const ssrResult = await tryRenderSsr(page, options);
   const headElements = (ssrResult?.head ?? []).map(normalizeHeadElement);
   const hasCustomTitle = headElements.some((element) =>
@@ -258,6 +267,7 @@ async function renderDocument(
     '<meta charset="utf-8" />',
     '<meta name="viewport" content="width=device-width, initial-scale=1" />',
     hasCustomTitle ? "" : `<title>${title}</title>`,
+    headMarkup ?? "",
     // Both must precede the stylesheet links: they exist to settle the first
     // paint before the app's own CSS arrives.
     criticalCss ? `<style id="guren-critical">${criticalCss}</style>` : "",

--- a/packages/server/tests/mvc/InertiaEngine.test.ts
+++ b/packages/server/tests/mvc/InertiaEngine.test.ts
@@ -58,6 +58,17 @@ describe('InertiaEngine SSR integration', () => {
     expect(body).toContain("<script>document.documentElement.classList.add('dark');</script>")
   })
 
+  it('inlines raw head markup such as favicon links', async () => {
+    setInertiaDocument({
+      head: '<link rel="icon" type="image/png" href="/favicon-32x32.png" />',
+    })
+
+    const response = await inertia('Docs/Show', { categories: [] }, { url: '/docs/guides/overview' })
+    const body = await response.text()
+
+    expect(body).toContain('<link rel="icon" type="image/png" href="/favicon-32x32.png" />')
+  })
+
   it('places the critical CSS and prepaint script ahead of the stylesheet links', async () => {
     setInertiaDocument({
       criticalCss: 'body{background:#ffffff;}',

--- a/web/config/document-theme.ts
+++ b/web/config/document-theme.ts
@@ -27,6 +27,14 @@ const SIZE_UTILITIES = `
 
 export const LIGHT_SURFACE_CRITICAL_CSS = `${SURFACE_CSS}${SIZE_UTILITIES}`
 
+/** Favicon links, site-wide — the framework has no default of its own. */
+export const FAVICON_HEAD = `
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+<link rel="icon" type="image/png" sizes="192x192" href="/favicon-192x192.png" />
+<link rel="icon" type="image/png" sizes="512x512" href="/favicon-512x512.png" />
+<link rel="apple-touch-icon" sizes="192x192" href="/favicon-192x192.png" />
+`.trim()
+
 /**
  * Resolves the color mode before the first paint, so a dark-mode reader never
  * sees a light flash. Mirrors `applyMode()` in

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -8,6 +8,7 @@ import { redirectToCanonicalHost } from '../app/Http/Middleware/canonical-host.j
 import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
 import {
   COLOR_MODE_PREPAINT_SCRIPT,
+  FAVICON_HEAD,
   LIGHT_SURFACE_CRITICAL_CSS,
 } from '../config/document-theme.js'
 import { LIGHT_SURFACE_BODY_CLASS, usesLightSurface } from '../config/theme.js'
@@ -24,6 +25,7 @@ setInertiaDocument({
   criticalCss: ({ component }) => (usesLightSurface(component) ? LIGHT_SURFACE_CRITICAL_CSS : undefined),
   prepaintScript: ({ component }) =>
     usesLightSurface(component) ? COLOR_MODE_PREPAINT_SCRIPT : undefined,
+  head: FAVICON_HEAD,
 })
 
 const app = createApp({


### PR DESCRIPTION
## Summary
- guren.dev shipped with no favicon: production HTML is generated entirely by `InertiaEngine.renderDocument`, which never reads `web/public/index.html`, so the `<link rel="icon">` tags there were dead code — the framework had no way to emit favicon links into the SSR'd `<head>` at all.
- Add a `head` field to `InertiaDocumentOptions` / `setInertiaDocument` for raw, site-wide markup inlined ahead of the critical CSS and stylesheet links (mirrors `bodyClass`/`criticalCss`/`prepaintScript`, but unescaped raw markup since favicon links can't be expressed as a class or script body).
- Wire it up in guren.dev's `src/app.ts` via a new `FAVICON_HEAD` constant pointing at the existing favicon PNGs in `public/`.
- This is a framework-wide gap, not guren.dev-specific — `packages/create-app`'s scaffold template has the same issue; tracked separately for a follow-up.

## Test plan
- [x] `bun run build:clean`
- [x] `bun run test:bun server` (1800 tests pass) incl. new `InertiaEngine.test.ts` case asserting the favicon link renders into `<head>`
- [x] `bun run typecheck`
- [x] `bun run audit:core-first` / `bun run audit:docs`
- [x] Manually rendered guren.dev's `app.ts` document and confirmed the favicon links appear in the shell
- [x] Deployed to production (`bun run deploy:cloudflare`) and confirmed `link[rel=icon]` now present on https://guren.dev/