### PR TITLE
fix(plugin-vercel): stop the function bundle from mangling class names

### DIFF
--- a/.changeset/vercel-preserve-class-names.md
+++ b/.changeset/vercel-preserve-class-names.md
@@ -1,0 +1,26 @@
+---
+"@guren/plugin-vercel": patch
+---
+
+fix: stop the Vercel function bundle from mangling class names
+
+The serverless function was bundled with a bare `--minify`, which enables
+identifier mangling and renames every class in the graph. Guren treats class
+names as durable identity, so the rename reaches data that outlives a single
+deploy:
+
+- the queue registry keys jobs on `JobClass.name` and serializes that name into
+  every queued message, so a job dispatched by one build resolves to nothing
+  after the next — and a message injected by name from outside the bundle never
+  resolves at all
+- notifications persist `notifiable.constructor.name` as their `type`, and
+  `Notification.type()` returns `this.constructor.name`
+- `HttpException` reports `this.constructor.name` as its `name`
+
+The build now passes `--minify-whitespace --minify-syntax` instead, dropping
+only identifier mangling. `--keep-names` is not an alternative: as of Bun
+1.3.14 it is accepted and silently leaves class names mangled.
+
+The bundle grows as a result. The ratio depends on the dependency graph —
+measured at ~35% on a framework-linked entrypoint (3.33 MB → 4.51 MB), and
+higher on smaller graphs. That is the cost of names that survive a redeploy.

--- a/.claude/rules/common-pitfalls.md
+++ b/.claude/rules/common-pitfalls.md
@@ -51,7 +51,8 @@ Lessons learned from code review cycles. Check these before submitting changes.
 
 ## Serverless Bundling (Vercel / Lambda)
 
-- **`bun build` inlines `process.env.NODE_ENV` at bundle time** (defaults to `"development"`, even with `--minify`). Runtime `NODE_ENV=production` cannot override it. Always pass `--define 'process.env.NODE_ENV="production"'` when bundling server entrypoints for deployment (`@guren/plugin-vercel` does this).
+- **`bun build` inlines `process.env.NODE_ENV` at bundle time** (defaults to `"development"`, regardless of minification). Runtime `NODE_ENV=production` cannot override it. Always pass `--define 'process.env.NODE_ENV="production"'` when bundling server entrypoints for deployment (`@guren/plugin-vercel` does this).
+- **Never bundle app code with identifier mangling** — no bare `--minify`, no esbuild/oxc `minify: true`. Guren keys durable records on class names: the queue registry stores `JobClass.name` in every queued message, notifications persist `constructor.name` as their `type`, and `HttpException` reports `this.constructor.name`. Mangled, records written by one deploy stop resolving after the next. Use `--minify-whitespace --minify-syntax` (or `minify: { whitespace: true, syntax: true, identifiers: false }`). `--keep-names`/`keepNames` is **not** a substitute: as of Bun 1.3.14 it is accepted and silently leaves class names mangled.
 - **SSR bundles must be self-contained on serverless.** Function directories ship without `node_modules`, so externalized `react`/`@inertiajs/react` imports fail at runtime and Inertia silently falls back to CSR. The Guren Vite plugin defaults `ssr.noExternal: true` for SSR builds — don't re-externalize deps in `.guren/ssr` unless the deploy target has them installed.
 
 ## ESM Compatibility

--- a/packages/plugin-vercel/src/index.ts
+++ b/packages/plugin-vercel/src/index.ts
@@ -126,6 +126,15 @@ export function buildVercelOutput(options: BuildVercelOutputOptions = {}): void 
   const result = Bun.spawnSync({
     // `bun build` inlines `process.env.NODE_ENV` at bundle time (defaulting to
     // "development"), so pin it to "production" for the deployed function.
+    //
+    // Whitespace and syntax only — never plain `--minify`, which also mangles
+    // identifiers. Guren keys durable records on class names: the queue
+    // registry stores `JobClass.name` in every queued message, and
+    // notifications persist `constructor.name` as their `type`. Mangled, a job
+    // dispatched by one deploy resolves to nothing after the next.
+    //
+    // Not `--keep-names`: as of Bun 1.3.14 it is accepted and silently leaves
+    // class names mangled, so it cannot replace this.
     cmd: [
       'bun',
       'build',
@@ -134,7 +143,8 @@ export function buildVercelOutput(options: BuildVercelOutputOptions = {}): void 
       funcDir,
       '--target',
       'bun',
-      '--minify',
+      '--minify-whitespace',
+      '--minify-syntax',
       '--define',
       'process.env.NODE_ENV="production"',
     ],

--- a/packages/plugin-vercel/tests/index.test.ts
+++ b/packages/plugin-vercel/tests/index.test.ts
@@ -109,6 +109,35 @@ describe('@guren/plugin-vercel', () => {
     expect(copied).toContain('Hello docs.')
   })
 
+  it('preserves class names through the bundler', async () => {
+    // Regression guard for the bundler flags in src/index.ts — see the comment
+    // on that argv for why mangled class names outlive a deploy.
+    const rootDir = mkdtempSync(join(tmpdir(), 'guren-plugin-vercel-'))
+    tempDirs.push(rootDir)
+
+    const entrypoint = join(rootDir, 'src/index.ts')
+    mkdirSync(join(rootDir, 'src'), { recursive: true })
+    writeFileSync(
+      entrypoint,
+      'class GurenJobProbe {}\nexport default { fetch() { return new Response(GurenJobProbe.name) } }\n',
+      'utf8',
+    )
+
+    buildVercelOutput({
+      rootDir,
+      entrypoint,
+      outputDir: join(rootDir, '.vercel/output'),
+    })
+
+    // Asserting on the runtime name rather than the bundle text: `.name` is
+    // what the queue registry and notification types actually read, and it
+    // survives any reformatting the bundler may do.
+    const bundled = await import(join(rootDir, '.vercel/output/functions/index.func/index.js'))
+    const response = await bundled.default.fetch(new Request('http://example.com/'))
+
+    expect(await response.text()).toBe('GurenJobProbe')
+  })
+
   it('finds docs in a parent directory when the app root is nested', () => {
     const workspaceDir = mkdtempSync(join(tmpdir(), 'guren-plugin-vercel-'))
     tempDirs.push(workspaceDir)


### PR DESCRIPTION
## Summary

- The Vercel serverless function was bundled with a bare `--minify`, which enables identifier mangling and renames every class in the graph.
- Guren keys durable records on class names: the queue registry stores `JobClass.name` in every queued message (`SqsDriver`/`RedisDriver`), `NotificationManager` persists `constructor.name` as a notification's `type`, `Notification.type()` returns `this.constructor.name`, and `HttpException` reports `this.constructor.name` as its `name`. Mangled, a job dispatched by one deploy resolves to nothing after the next.
- Switched the `bun build` argv to `--minify-whitespace --minify-syntax`, which drops whitespace/syntax minification but keeps identifiers intact. `--keep-names` is not a substitute: on Bun 1.3.14 it is accepted and silently leaves class names mangled.
- Added a regression test that bundles a class referenced only by name and asserts the runtime `.name` survives — verified red under the old `--minify` flag before the fix, and confirmed the assertion mutation-tests correctly (reverting the flag reintroduces the failure).
- Documented the invariant in `.claude/rules/common-pitfalls.md` under "Serverless Bundling" so the next bundler added to the repo doesn't reintroduce it.
- Added a changeset for `@guren/plugin-vercel` (patch), with the bundle-size tradeoff measured directly (~35% growth on a framework-linked entrypoint).

Same defect class as the one already fixed for `@guren/plugin-lambda`.

## Test plan

- [x] `bun run test:bun plugin-vercel` — 7 pass
- [x] `bunx tsc --noEmit -p packages/plugin-vercel/tsconfig.json` — clean
- [x] `bun run audit:core-first` — passed
- [x] `bun run audit:docs` — passed
- [x] Mutation check: reverted the flag to `--minify`, confirmed the new test goes red (1 fail), restored and confirmed green (7 pass)