### PR TITLE
docs: warn about identifier mangling in serverless bundling

### DIFF
--- a/docs/en/guides/serverless.md
+++ b/docs/en/guides/serverless.md
@@ -286,3 +286,6 @@ const consoleFn = new lambda.Function(this, 'Console', {
 
 > [!NOTE]
 > Bundle your application with `esbuild` or `tsup` before deploying. Ensure all dependencies are included in the deployment package.
+
+> [!WARNING]
+> Disable identifier mangling in your bundler. Guren stores class names inside durable records — queued jobs carry the job's class name, persisted notifications carry their notification type, and HTTP exceptions report their own name — so a mangled build cannot resolve records written by the previous deploy. With `bun build`, use `--minify-whitespace --minify-syntax` instead of `--minify`. With `esbuild`, set `minifyIdentifiers: false`. With `tsup`, use `minifyWhitespace` and `minifySyntax` instead of `minify`. `--keep-names` / `keepNames` is not a substitute on Bun: as of Bun 1.3.14 the flag is accepted and class names stay mangled.

--- a/docs/ja/guides/serverless.md
+++ b/docs/ja/guides/serverless.md
@@ -286,3 +286,6 @@ const consoleFn = new lambda.Function(this, 'Console', {
 
 > [!NOTE]
 > Lambda にデプロイする前に、`esbuild` や `tsup` でアプリをバンドルしてください。すべての依存がデプロイパッケージに含まれていることを確認してください。
+
+> [!WARNING]
+> バンドラーの識別子マングリングは無効にしてください。Guren はキュー投入されたジョブ、永続化された通知の種別、HTTP 例外の名前といった永続レコードにクラス名を保存するため、マングルすると前回のデプロイが書き込んだレコードを解決できなくなります。`bun build` では `--minify` ではなく `--minify-whitespace --minify-syntax` を、`esbuild` では `minifyIdentifiers: false` を、`tsup` では `minify` ではなく `minifyWhitespace` と `minifySyntax` を指定します。Bun では `--keep-names` / `keepNames` は代替になりません。Bun 1.3.14 時点でフラグは受け付けられますが、クラス名はマングルされたままです。


### PR DESCRIPTION
## Summary
- Both `docs/en/guides/serverless.md` and `docs/ja/guides/serverless.md` told users to bundle with esbuild/tsup before deploying, with no warning about identifier mangling.
- Guren stores class names inside durable records (queued job class names, persisted notification types, HTTP exception names), so a mangled bundle can't resolve records written by the previous deploy.
- Added a `[!WARNING]` callout right after the existing bundling note in both locales, with concrete flags to avoid mangling for `bun build`, `esbuild`, and `tsup`, and a note that `--keep-names`/`keepNames` is not a substitute on Bun (verified against Bun 1.3.14: accepted, but class names stay mangled).

## Test plan
- [x] `bun run audit:docs` passes
- [x] `bun run audit:core-first` passes
- [x] Line counts match between EN/JA (291 lines each) and no internal jargon (`packages/*`, plugin names, RFC/PR numbers) was introduced