### PR TITLE
fix(cli): dispatch the root command on the argument citty actually reads

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -4,7 +4,7 @@ import { pathToFileURL } from 'node:url'
 import { consola } from 'consola'
 import { defineCommand, showUsage } from 'citty'
 import type { CommandDef } from 'citty'
-import { runCli } from './run-cli'
+import { runCli, UsageError } from './run-cli'
 import { listBlueprints, runBlueprint } from './blueprints'
 import { runDoctor } from './doctor'
 import { makeAuth } from './make-auth'
@@ -2500,17 +2500,19 @@ const main = defineCommand({
       return
     }
 
-    const [commandName] = ctx.rawArgs
+    // citty dispatches on the first non-flag argument, not on rawArgs[0], and
+    // calls this handler again once that subcommand returns. Read the name the
+    // same way so a flag in front of it (`guren --zzz model:list`) does not
+    // look like a command of its own. A name citty does not have never reaches
+    // here — it throws `Unknown command` before running anything — so the only
+    // state left to report is flags with no command at all.
+    const commandName = ctx.rawArgs.find((arg) => !arg.startsWith('-'))
     const subCommands = ctx.cmd.subCommands ?? {}
     if (commandName && Object.prototype.hasOwnProperty.call(subCommands, commandName)) {
       return
     }
 
-    if (commandName) {
-      consola.error(`Unknown command: ${commandName}`)
-      await showUsage(ctx.cmd)
-      process.exit(1)
-    }
+    throw new UsageError('No command specified.')
   },
 })
 

--- a/packages/cli/src/run-cli.ts
+++ b/packages/cli/src/run-cli.ts
@@ -26,8 +26,22 @@ async function resolveSubCommand(
   return [cmd, parent]
 }
 
+/**
+ * Raised by a command whose arguments cannot be dispatched, so `runCli` reports
+ * it the way it reports citty's own dispatch failures: usage, then the message,
+ * exit code 1.
+ */
+export class UsageError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'UsageError'
+  }
+}
+
 function isUsageError(error: unknown): error is Error {
-  return error instanceof Error && error.name === 'CLIError'
+  // citty raises `CLIError` for its own dispatch failures but does not export
+  // the class; commands raise `UsageError` for the same class of failure.
+  return error instanceof UsageError || (error instanceof Error && error.name === 'CLIError')
 }
 
 /**

--- a/packages/cli/tests/bin-error-output.test.ts
+++ b/packages/cli/tests/bin-error-output.test.ts
@@ -77,6 +77,33 @@ describe('guren CLI error reporting', () => {
     }
   })
 
+  it('runs the command a stray flag precedes without reporting it as unknown', async () => {
+    const workspace = await createTempWorkspace('guren-cli-bin-leading-flag-')
+    try {
+      const { exitCode, stderr } = await runBin(['--zzz', 'model:list'], workspace.dir)
+
+      // citty dispatches on the first non-flag argument, so `model:list` runs.
+      expect(stderr).toContain('No models found')
+      expect(countOccurrences(stderr, 'Unknown command')).toBe(0)
+      expect(exitCode).toBe(0)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reports flags without a command once, with usage, and exits 1', async () => {
+    const workspace = await createTempWorkspace('guren-cli-bin-no-command-')
+    try {
+      const { exitCode, stdout, stderr } = await runBin(['--zzz'], workspace.dir)
+
+      expect(exitCode).toBe(1)
+      expect(countOccurrences(stderr, 'No command specified')).toBe(1)
+      expect(plainText(stdout)).toContain('USAGE guren')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('reports a missing required argument once, with subcommand usage, and exits 1', async () => {
     const workspace = await createTempWorkspace('guren-cli-bin-missing-arg-')
     try {

--- a/packages/cli/tests/bin-error-output.test.ts
+++ b/packages/cli/tests/bin-error-output.test.ts
@@ -91,6 +91,19 @@ describe('guren CLI error reporting', () => {
     }
   })
 
+  it('reports an unknown command a stray flag precedes, naming the command', async () => {
+    const workspace = await createTempWorkspace('guren-cli-bin-leading-flag-unknown-')
+    try {
+      const { exitCode, stderr } = await runBin(['--zzz', 'definitely-not-a-command'], workspace.dir)
+
+      expect(exitCode).toBe(1)
+      expect(countOccurrences(stderr, 'Unknown command')).toBe(1)
+      expect(stderr).toContain('definitely-not-a-command')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('reports flags without a command once, with usage, and exits 1', async () => {
     const workspace = await createTempWorkspace('guren-cli-bin-no-command-')
     try {


### PR DESCRIPTION
## Summary

The root command's `run(ctx)` handler in `packages/cli/src/bin.ts` read
`rawArgs[0]` to decide the dispatched command name, but citty dispatches
subcommands on the first *non-flag* argument
(`rawArgs.findIndex(arg => !arg.startsWith('-'))`) and calls the root
handler again once that subcommand returns. A flag preceding the command
name therefore ran the command to completion and only then reported the
flag itself as an unknown command:

```
$ guren --zzz model:list
 WARN  No models found in app/Models/.
 ERROR  Unknown command: --zzz
```

- `packages/cli/src/bin.ts` — read the dispatch name the way citty does
  (`ctx.rawArgs.find(arg => !arg.startsWith('-'))`). The handler's own
  "Unknown command" branch turned out to be unreachable: citty itself
  throws `Unknown command` for any non-flag name it doesn't recognize,
  before running anything, so the only state left for the root handler to
  report is flags with no command at all — replaced with a thrown
  `UsageError('No command specified.')`.
- `packages/cli/src/run-cli.ts` — added an exported `UsageError` class and
  widened `isUsageError` to recognize it alongside citty's unexported
  `CLIError`, so `runCli` renders it the same way (usage, then the
  message, exit 1) instead of the handler calling `process.exit(1)`
  directly and bypassing `runCli`'s contract that the entry point returns
  an exit code.
- `packages/cli/tests/bin-error-output.test.ts` — three new cases,
  written red-first against the old handler:
  - a leading flag no longer prevents the command from running
    (`guren --zzz model:list` now runs `model:list`)
  - a leading flag still lets citty's own dispatch error through
    (`guren --zzz definitely-not-a-command` still reports the unknown
    command, not the flag)
  - flags with no command at all report `No command specified.` once,
    with usage, exit 1

## Design notes

- **Ignore vs. reject unknown flags**: chose to ignore. No subcommand in
  this CLI validates unrecognized flags today, so making the root
  command strict about them would be inconsistent with the rest of the
  CLI.
- **Observable behavior change**: `guren --zzz` (flags, no command) now
  prints `No command specified.` instead of `Unknown command: --zzz`,
  and usage renders before the error line (`runCli`'s `failWithUsage`
  order) instead of after. Exit code is unchanged at 1.
- **Left `add`'s equivalent branch alone** — `guren add --zzz` still
  silently exits 0 on flags-only input. Same shape of gap as this fix
  addressed at the root, but out of scope here; noting it as a possible
  follow-up.
- **Separated flag values** (`guren --tag latest model:list`) are still
  read by citty as the dispatch name itself (`latest`), which throws
  `Unknown command latest` — unchanged before/after this fix, and out of
  scope since root doesn't declare a `--tag` flag.
- Reviewed with a Codex pass (no code changes needed); its main finding
  was a pre-existing, unrelated gap where `guren --version` prints usage
  and errors because the root command has no `meta.version` set.

## Test plan

- [x] `bun run test:bun cli` — 705 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run build cli` and reproduced the reported repro against
      `dist/bin.js`:
      `bun packages/cli/dist/bin.js --zzz model:list` → runs `model:list`,
      exit 0, no `Unknown command`
- [x] `bun run audit:core-first` / `bun run audit:docs` — pass