### PR TITLE
fix(server): deliver queued notifications through their channels

### DIFF
--- a/.changeset/queued-notification-delivery.md
+++ b/.changeset/queued-notification-delivery.md
@@ -1,0 +1,49 @@
+---
+'@guren/server': patch
+---
+
+Fix queued notifications delivering nothing
+
+A notification with `static shouldQueue = true` was queued and picked up by the
+worker, but no channel was ever invoked. Serialization spread the notification
+into a plain payload (`{ ...notification }`), which copies only own enumerable
+properties — `via`, `toMail`, `toDatabase` and `toSlack` all live on the
+prototype and were dropped. The job handler then rebuilt a shim that read the
+delivery channels from a `_viaChannels` field nothing ever wrote, so `via()`
+returned an empty list and the send loop had nothing to iterate. The
+synchronous path was unaffected.
+
+Queued notifications are now rebuilt as real instances. Notification classes
+are recorded in a registry keyed on `notification.type` and restored with
+`Object.create(prototype)`, which brings back every prototype method without
+re-running the constructor (constructor arguments are not recoverable from a
+payload). Registration happens automatically when a notification is queued,
+which covers a worker sharing the dispatching process; a worker in a separate
+process should call the newly exported `registerNotification()` at boot, and an
+unregistered type now throws instead of failing silently.
+
+Routing survives the queue too. The worker used to guess a notifiable's routes
+from a `${channel}Route` property convention that the documented `Notifiable`
+does not follow, so a queued notification to a user routing Slack via
+`this.slackId` silently fell back to the org-wide webhook. `routeNotificationFor()`
+is arbitrary user code — frequently a closure on an object literal — and cannot
+be rebuilt from a payload, so it is now called at dispatch and the resolved
+routes travel with the job. Payloads written before this release still fall
+back to the old convention.
+
+The job itself was also unreachable from a dedicated worker. It was registered
+only as a side effect of dispatching, under the name of an internal per-manager
+subclass, so `guren queue:work` running as its own process failed every
+notification with `Job class not found`. That subclass is gone — since the
+queue registry keys on the class name, every manager overwrote the same entry
+anyway — leaving one `SendNotificationJob` that `NotificationServiceProvider`
+registers on boot via the new `NotificationManager#registerQueueJob()`.
+
+Also: `createdAt` is serialized explicitly and revived as a `Date`, so drivers
+that persist JSON (Redis, SQS) no longer hand channels a string. `Notifiable`
+gained an optional `notifiableType`, honored by `DatabaseChannel` through the
+newly exported `resolveNotifiableType()`, so a notifiable rebuilt from a
+payload keeps its original type name instead of recording `Object`.
+
+Because rebuilt notifications are real instances, a user-defined `shouldSend()`
+is now honored on the queued path; the previous shim hardcoded it to `true`.

--- a/docs/en/guides/notifications.md
+++ b/docs/en/guides/notifications.md
@@ -305,6 +305,39 @@ await notifications.send(user, new WelcomeNotification())
 // bunx guren queue:work --queue=notifications
 ```
 
+### Workers in a Separate Process
+
+A queued notification is stored as data, so the worker rebuilds the class to
+deliver it. When the worker shares the process that sent the notification, this
+happens automatically. When you run `queue:work` as its own process, register
+the notification classes it needs from a provider:
+
+```ts
+import { ServiceProvider, registerNotification } from '@guren/core'
+import { WelcomeNotification } from '@/app/Notifications/WelcomeNotification'
+
+export class NotificationServiceProvider extends ServiceProvider {
+  register(): void {
+    registerNotification(WelcomeNotification)
+  }
+}
+```
+
+An unregistered notification fails loudly rather than silently delivering
+nothing.
+
+Two things do not survive the queue, because only a notification's own
+properties are stored:
+
+- **Constructor arguments.** Keep anything a channel needs in a property, as
+  `WelcomeNotification` does above — the constructor is not re-run.
+- **Values JSON cannot represent**, such as `Map`, `Set`, or `#private` fields.
+  Prefer plain values.
+
+Routing is unaffected: `routeNotificationFor()` is called when the notification
+is queued and the resulting routes travel with it, so per-recipient addresses
+and webhooks arrive intact.
+
 ## Conditional Notifications
 
 ### shouldSend Method

--- a/docs/ja/guides/notifications.md
+++ b/docs/ja/guides/notifications.md
@@ -294,6 +294,30 @@ await notifications.send(user, new WelcomeNotification())
 // bunx guren queue:work --queue=notifications
 ```
 
+### 別プロセスで動かすワーカー
+
+キューに入った通知はデータとして保存されるため、ワーカーは配信時にクラスを復元します。通知を送ったプロセスとワーカーが同じ場合、この登録は自動で行われます。`queue:work` を独立したプロセスとして動かす場合は、必要な通知クラスをプロバイダから登録してください。
+
+```ts
+import { ServiceProvider, registerNotification } from '@guren/core'
+import { WelcomeNotification } from '@/app/Notifications/WelcomeNotification'
+
+export class NotificationServiceProvider extends ServiceProvider {
+  register(): void {
+    registerNotification(WelcomeNotification)
+  }
+}
+```
+
+未登録の通知は、何も配信されないまま黙って終わるのではなくエラーになります。
+
+保存されるのは通知の自前のプロパティだけなので、次の2つはキューを越えられません。
+
+- **コンストラクタ引数**。コンストラクタは再実行されないため、チャンネルが必要とする値は上記の `WelcomeNotification` のようにプロパティとして保持してください。
+- **JSONで表現できない値**（`Map`・`Set`・`#private` フィールドなど）。素の値を使ってください。
+
+ルーティングは影響を受けません。`routeNotificationFor()` はキュー投入時に呼ばれ、解決されたルートが通知と一緒に運ばれるため、受信者ごとのアドレスやWebhookはそのまま届きます。
+
 ## 条件付き通知
 
 ### shouldSendメソッド

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -579,8 +579,13 @@ export {
   DatabaseChannel,
   SlackChannel,
   MemoryChannel,
+  registerNotification,
+  getNotification,
+  clearNotificationRegistry,
+  resolveNotifiableType,
 } from './notifications'
 export type {
+  NotificationConstructor,
   NotificationChannel,
   Notifiable,
   DatabaseNotification,

--- a/packages/server/src/notifications/NotificationManager.ts
+++ b/packages/server/src/notifications/NotificationManager.ts
@@ -6,7 +6,13 @@ import type {
   NotificationClass,
 } from './types'
 import type { Notification } from './Notification'
-import { Job, registerJob, getQueueDriver } from '../queue'
+import {
+  registerNotification,
+  getNotification,
+  type NotificationConstructor,
+} from './registry'
+import { resolveNotifiableType } from './notifiable-type'
+import { Job, registerJob } from '../queue'
 
 /**
  * Notification manager for sending notifications through multiple channels.
@@ -177,12 +183,21 @@ export class NotificationManager {
     notification: Notification,
     queueConfig: { queue?: string; delay?: number }
   ): Promise<void> {
-    // Create and register the job
-    const job = this.createNotificationJob()
-    registerJob(job)
+    const job = this.registerQueueJob()
+
+    // Register the notification class so the worker can rebuild a real
+    // instance. Explicit registerNotification() is only needed when the worker
+    // runs in a separate process from the dispatch.
+    registerNotification(
+      notification.constructor as NotificationConstructor,
+      notification.type
+    )
 
     const payload: SendNotificationPayload = {
-      notifiableData: this.serializeNotifiable(notifiable),
+      notifiableData: this.serializeNotifiable(
+        notifiable,
+        notification.via(notifiable)
+      ),
       notificationData: this.serializeNotification(notification),
       notificationType: notification.type,
     }
@@ -223,40 +238,56 @@ export class NotificationManager {
 
   /**
    * Serialize notifiable for queue storage.
+   *
+   * Routing is resolved here rather than in the worker: `routeNotificationFor`
+   * is arbitrary user code — often a closure on an object literal — and cannot
+   * be reconstructed from a payload.
+   *
+   * @param channels - Channels to resolve routes for
    */
-  protected serializeNotifiable(notifiable: Notifiable): SerializedNotifiable {
+  protected serializeNotifiable(
+    notifiable: Notifiable,
+    channels: string[] = []
+  ): SerializedNotifiable {
+    const routes: Record<string, string | null> = {}
+    for (const channel of channels) {
+      routes[channel] = notifiable.routeNotificationFor(channel)
+    }
+
     // Basic serialization - can be overridden for custom behavior
     return {
-      type: notifiable.constructor?.name ?? 'Unknown',
+      type: resolveNotifiableType(notifiable),
+      routes,
       data: { ...notifiable } as Record<string, unknown>,
     }
   }
 
   /**
    * Serialize notification for queue storage.
+   *
+   * Only own enumerable properties are captured. Behaviour is restored by
+   * rebuilding the registered class in the job handler, not by serializing it.
    */
   protected serializeNotification(
     notification: Notification
   ): SerializedNotification {
     return {
-      type: notification.type,
       id: notification.id,
+      createdAt: notification.createdAt.toISOString(),
       data: { ...notification } as Record<string, unknown>,
     }
   }
 
   /**
-   * Create the notification job class.
+   * Bind this manager to the queued-notification job and register it.
+   *
+   * Call this during boot in a process that runs a worker but may never send
+   * a notification itself: without it, the worker cannot resolve the job.
    */
-  protected createNotificationJob(): typeof SendNotificationJob {
-    // Bind manager reference for job handler
-    const manager = this
-
-    class BoundSendNotificationJob extends SendNotificationJob {
-      static notificationManager = manager
-    }
-
-    return BoundSendNotificationJob
+  registerQueueJob(): typeof SendNotificationJob {
+    SendNotificationJob.notificationManager = this
+    registerJob(SendNotificationJob)
+    return SendNotificationJob
   }
 }
 
@@ -271,12 +302,14 @@ interface SendNotificationPayload {
 
 interface SerializedNotifiable {
   type: string
+  /** Channel routes resolved at dispatch time. Absent on legacy payloads. */
+  routes?: Record<string, string | null>
   data: Record<string, unknown>
 }
 
 interface SerializedNotification {
-  type: string
   id: string
+  createdAt: string
   data: Record<string, unknown>
 }
 
@@ -284,7 +317,6 @@ interface SerializedNotification {
  * Job for sending queued notifications.
  */
 class SendNotificationJob extends Job<SendNotificationPayload> {
-  static jobName = 'SendNotificationJob'
   static queue = 'notifications'
   static maxAttempts = 3
 
@@ -297,39 +329,69 @@ class SendNotificationJob extends Job<SendNotificationPayload> {
       throw new Error('NotificationManager not set on SendNotificationJob')
     }
 
-    // Reconstruct notifiable (basic)
-    const notifiable: Notifiable = {
-      ...payload.notifiableData.data,
+    const notifiable = this.rebuildNotifiable(payload.notifiableData)
+    const notification = this.rebuildNotification(
+      payload.notificationType,
+      payload.notificationData
+    )
+
+    await manager.sendNow(notifiable, notification)
+  }
+
+  /**
+   * Rebuild the notifiable from its serialized data.
+   */
+  protected rebuildNotifiable(serialized: SerializedNotifiable): Notifiable {
+    const { data, routes } = serialized
+
+    return {
+      ...data,
+      notifiableType: serialized.type,
       routeNotificationFor(channel: string): string | null {
-        const key = `${channel}Route` as keyof typeof payload.notifiableData.data
-        const value = payload.notifiableData.data[key]
+        if (routes && channel in routes) {
+          return routes[channel] ?? null
+        }
+
+        // Legacy payloads carry no routes: fall back to the conventions the
+        // previous implementation guessed at.
+        const value = data[`${channel}Route`]
         if (typeof value === 'string') return value
 
-        // Fallback to common fields
         if (channel === 'mail') {
-          const email = payload.notifiableData.data['email']
+          const email = data['email']
           return typeof email === 'string' ? email : null
         }
         return null
       },
     }
+  }
 
-    // Reconstruct notification (basic)
-    const notification = {
-      ...payload.notificationData.data,
-      id: payload.notificationData.id,
-      type: payload.notificationType,
-      via: () => {
-        const viaChannels = (payload.notificationData.data as { _viaChannels?: string[] })._viaChannels
-        return viaChannels ?? []
-      },
-      shouldSend: () => true,
-      toMail: (payload.notificationData.data as { toMail?: unknown }).toMail,
-      toDatabase: (payload.notificationData.data as { toDatabase?: unknown }).toDatabase,
-      toSlack: (payload.notificationData.data as { toSlack?: unknown }).toSlack,
-    } as unknown as import('./Notification').Notification
+  /**
+   * Rebuild a real notification instance from its serialized data.
+   *
+   * The class is looked up in the notification registry and instantiated via
+   * its prototype, so prototype methods (`via`, `toMail`, `toDatabase`,
+   * `toSlack`, `shouldSend`) are restored without running the constructor.
+   */
+  protected rebuildNotification(
+    type: string,
+    serialized: SerializedNotification
+  ): Notification {
+    const NotificationClass = getNotification(type)
+    if (!NotificationClass) {
+      throw new Error(
+        `Notification type "${type}" is not registered. ` +
+          `Call registerNotification(${type}) before running the queue worker.`
+      )
+    }
 
-    await manager.sendNow(notifiable, notification)
+    // createdAt is revived explicitly: queue drivers that persist JSON turn
+    // Dates into strings.
+    return Object.assign(
+      Object.create(NotificationClass.prototype) as Notification,
+      serialized.data,
+      { id: serialized.id, createdAt: new Date(serialized.createdAt) }
+    )
   }
 }
 

--- a/packages/server/src/notifications/channels/DatabaseChannel.ts
+++ b/packages/server/src/notifications/channels/DatabaseChannel.ts
@@ -5,6 +5,7 @@ import type {
   DatabaseChannelOptions,
 } from '../types'
 import type { Notification } from '../Notification'
+import { resolveNotifiableType } from '../notifiable-type'
 
 /**
  * Database notification channel.
@@ -86,7 +87,7 @@ export class DatabaseChannel implements NotificationChannel {
    * Get the notifiable type.
    */
   protected getNotifiableType(notifiable: Notifiable): string {
-    return notifiable.constructor?.name ?? 'Unknown'
+    return resolveNotifiableType(notifiable)
   }
 
   /**

--- a/packages/server/src/notifications/index.ts
+++ b/packages/server/src/notifications/index.ts
@@ -24,6 +24,15 @@ export {
 } from './NotificationManager'
 
 export {
+  registerNotification,
+  getNotification,
+  clearNotificationRegistry,
+  type NotificationConstructor,
+} from './registry'
+
+export { resolveNotifiableType } from './notifiable-type'
+
+export {
   MailChannel,
   type MailChannelOptions,
   DatabaseChannel,

--- a/packages/server/src/notifications/notifiable-type.ts
+++ b/packages/server/src/notifications/notifiable-type.ts
@@ -1,0 +1,13 @@
+import type { Notifiable } from './types'
+
+/**
+ * Resolve the stable type name of a notifiable.
+ *
+ * Channels that record which entity a notification belongs to should use this
+ * rather than reading `constructor.name` directly: a notifiable rebuilt from a
+ * queue payload carries its original name in `notifiableType`, and its
+ * constructor is a plain object.
+ */
+export function resolveNotifiableType(notifiable: Notifiable): string {
+  return notifiable.notifiableType ?? notifiable.constructor?.name ?? 'Unknown'
+}

--- a/packages/server/src/notifications/registry.ts
+++ b/packages/server/src/notifications/registry.ts
@@ -1,0 +1,78 @@
+import type { Notification } from './Notification'
+
+/**
+ * A notification class usable for queue reconstruction.
+ *
+ * Only the prototype and name are required: queued notifications are rebuilt
+ * with `Object.create(prototype)` and never constructed, so classes with
+ * required constructor arguments are supported.
+ */
+export interface NotificationConstructor {
+  readonly name: string
+  readonly prototype: Notification
+}
+
+const notificationRegistry = new Map<string, NotificationConstructor>()
+
+/**
+ * Resolve the registry key for a class without constructing it.
+ *
+ * Reads the `type` getter off the prototype so a class overriding it registers
+ * under the same key the dispatched payload carries.
+ */
+function resolveRegistryKey(notificationClass: NotificationConstructor): string {
+  try {
+    const { type } = Object.create(notificationClass.prototype) as Notification
+    if (typeof type === 'string' && type.length > 0) {
+      return type
+    }
+  } catch {
+    // A `type` getter depending on instance state cannot be resolved here;
+    // fall back to the class name.
+  }
+  return notificationClass.name
+}
+
+/**
+ * Register a notification class so queued instances can be rebuilt.
+ *
+ * Notifications are registered automatically when they are queued, which
+ * covers delivery by a worker running in the same process. A worker running
+ * in a separate process must register them explicitly at boot.
+ *
+ * Type names must be unique within an application: as with the job registry,
+ * registering a second class under an existing type replaces the first.
+ *
+ * @param notificationClass - The notification class to register
+ * @param type - Registry key, defaulting to the class's own `type` value
+ *
+ * @example
+ * ```typescript
+ * registerNotification(OrderShipped)
+ * ```
+ */
+export function registerNotification(
+  notificationClass: NotificationConstructor,
+  type?: string
+): void {
+  notificationRegistry.set(
+    type ?? resolveRegistryKey(notificationClass),
+    notificationClass
+  )
+}
+
+/**
+ * Get a registered notification class by type.
+ */
+export function getNotification(
+  type: string
+): NotificationConstructor | undefined {
+  return notificationRegistry.get(type)
+}
+
+/**
+ * Clear all registered notifications (for testing).
+ */
+export function clearNotificationRegistry(): void {
+  notificationRegistry.clear()
+}

--- a/packages/server/src/notifications/types.ts
+++ b/packages/server/src/notifications/types.ts
@@ -18,6 +18,15 @@ export interface Notifiable {
   routeNotificationFor(channel: string): string | null
 
   /**
+   * Stable type name for this notifiable (optional).
+   *
+   * Defaults to the constructor name. Set this when the notifiable is rebuilt
+   * from a queue payload, or when the class name is not durable (bundlers that
+   * mangle identifiers).
+   */
+  notifiableType?: string
+
+  /**
    * Database notifications (optional).
    */
   notifications?: DatabaseNotification[]

--- a/packages/server/src/providers/NotificationServiceProvider.ts
+++ b/packages/server/src/providers/NotificationServiceProvider.ts
@@ -1,5 +1,5 @@
 import { ServiceProvider } from '../container/ServiceProvider'
-import { createNotificationManager } from '../notifications'
+import { createNotificationManager, type NotificationManager } from '../notifications'
 
 /**
  * Binds the NotificationManager as a singleton in the container.
@@ -7,5 +7,13 @@ import { createNotificationManager } from '../notifications'
 export class NotificationServiceProvider extends ServiceProvider {
   register(): void {
     this.container.singleton('notifications', () => createNotificationManager())
+  }
+
+  boot(): void {
+    // Register the queued-notification job in every booted process, including
+    // a worker that never sends a notification itself.
+    this.container
+      .make<NotificationManager>('notifications')
+      .registerQueueJob()
   }
 }

--- a/packages/server/tests/notifications/notifications.test.ts
+++ b/packages/server/tests/notifications/notifications.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, mock } from 'bun:test'
+import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test'
 import {
   Notification,
   NotificationManager,
@@ -9,11 +9,19 @@ import {
   createNotificationManager,
   setNotificationManager,
   getNotificationManager,
+  registerNotification,
+  clearNotificationRegistry,
   type Notifiable,
   type NotificationMailMessage,
   type SlackMessage,
   type NotificationChannel,
 } from '../../src/notifications'
+import {
+  MemoryDriver,
+  setQueueDriver,
+  getJob,
+  clearJobRegistry,
+} from '../../src/queue'
 
 // Test notification classes
 class TestNotification extends Notification {
@@ -855,6 +863,282 @@ describe('MailChannel', () => {
         })
       )
     })
+  })
+})
+
+describe('Queued notifications', () => {
+  // Routing shaped like the documented Notifiable: the channel name has no
+  // relationship to the property holding the route, so it can only survive the
+  // queue if routeNotificationFor() is actually consulted at dispatch.
+  class QueuedUser implements Notifiable {
+    constructor(
+      public id: number,
+      public email: string,
+      public slackId?: string
+    ) {}
+
+    routeNotificationFor(channel: string): string | null {
+      switch (channel) {
+        case 'mail':
+          return this.email
+        case 'slack':
+          return this.slackId ?? null
+        default:
+          return null
+      }
+    }
+  }
+
+  class QueuedMultiChannel extends Notification {
+    static shouldQueue = true
+
+    // Constructor argument, kept as an own property. The argument is not
+    // recoverable from the payload, so re-running the constructor during
+    // rebuild would throw on the undefined order.
+    orderId: number
+
+    constructor(order: { id: number }) {
+      super()
+      this.orderId = order.id
+    }
+
+    via(_notifiable: Notifiable): string[] {
+      return ['mail', 'database', 'slack']
+    }
+
+    toMail(_notifiable: Notifiable): NotificationMailMessage {
+      return { subject: `Order #${this.orderId}`, html: '<p>Shipped</p>' }
+    }
+
+    toDatabase(_notifiable: Notifiable): Record<string, unknown> {
+      return { orderId: this.orderId }
+    }
+
+    toSlack(_notifiable: Notifiable): SlackMessage {
+      return { text: `Order #${this.orderId} shipped` }
+    }
+  }
+
+  class QueuedConditional extends Notification {
+    static shouldQueue = true
+
+    constructor(private shouldSendFlag: boolean = true) {
+      super()
+    }
+
+    via(_notifiable: Notifiable): string[] {
+      return ['database']
+    }
+
+    toDatabase(_notifiable: Notifiable): Record<string, unknown> {
+      return { key: 'value' }
+    }
+
+    shouldSend(_notifiable: Notifiable): boolean {
+      return this.shouldSendFlag
+    }
+  }
+
+  let driver: MemoryDriver
+  let manager: NotificationManager
+  let user: QueuedUser
+  let dbChannel: DatabaseChannel
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    driver = new MemoryDriver()
+    setQueueDriver(driver)
+    manager = new NotificationManager()
+    dbChannel = new DatabaseChannel()
+    user = new QueuedUser(1, 'test@example.com', 'https://hooks.slack.com/user')
+
+    // QueuedMultiChannel sends through all three; each test overrides the one
+    // it asserts on.
+    manager.registerChannel('database', dbChannel)
+    manager.registerChannel('mail', { name: 'mail', send: async () => {} })
+    manager.registerChannel('slack', { name: 'slack', send: async () => {} })
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  /**
+   * Pop the queued job and hand back what a worker would run, forcing the
+   * payload through JSON so drivers that persist (Redis/SQS) are represented.
+   */
+  async function takeQueuedJob() {
+    const queued = await driver.pop('notifications')
+    if (!queued) {
+      throw new Error('Expected a job to be queued')
+    }
+    const JobClass = getJob(queued.name)
+    if (!JobClass) {
+      throw new Error(`Job "${queued.name}" is not registered`)
+    }
+    return {
+      JobClass,
+      payload: JSON.parse(JSON.stringify(queued.payload)),
+    }
+  }
+
+  async function processQueue(): Promise<void> {
+    const { JobClass, payload } = await takeQueuedJob()
+    await new JobClass().handle(payload as never)
+  }
+
+  it('should queue instead of sending immediately', async () => {
+    await manager.send(user, new QueuedConditional())
+
+    expect(dbChannel.getStored()).toHaveLength(0)
+  })
+
+  it('should register the job without any dispatch', () => {
+    clearJobRegistry()
+    expect(getJob('SendNotificationJob')).toBeUndefined()
+
+    // What a worker process does at boot: it may never send a notification.
+    new NotificationManager().registerQueueJob()
+
+    expect(getJob('SendNotificationJob')).toBeDefined()
+  })
+
+  it('should persist the job under a stable name', async () => {
+    await manager.send(user, new QueuedConditional())
+
+    const queued = await driver.pop('notifications')
+    expect(queued?.name).toBe('SendNotificationJob')
+  })
+
+  it('should deliver through the database channel', async () => {
+    const notification = new QueuedMultiChannel({ id: 42 })
+    await manager.send(user, notification)
+    await processQueue()
+
+    const stored = dbChannel.getStored()
+    expect(stored).toHaveLength(1)
+    expect(stored[0].type).toBe('QueuedMultiChannel')
+    expect(stored[0].data).toEqual({ orderId: 42 })
+    expect(stored[0].id).toBe(notification.id)
+    expect(stored[0].notifiableId).toBe(1)
+    expect(stored[0].notifiableType).toBe('QueuedUser')
+  })
+
+  it('should revive createdAt as a Date', async () => {
+    const notification = new QueuedMultiChannel({ id: 1 })
+    await manager.send(user, notification)
+    await processQueue()
+
+    const stored = dbChannel.getStored()[0]
+    expect(stored.createdAt).toBeInstanceOf(Date)
+    expect(stored.createdAt.getTime()).toBe(notification.createdAt.getTime())
+  })
+
+  it('should deliver through the mail channel', async () => {
+    const sendMock = mock(() => Promise.resolve({ success: true }))
+    const mailChannel = new MailChannel({
+      transport: () => ({ send: sendMock }),
+    } as any)
+    manager.registerChannel('mail', mailChannel)
+
+    await manager.send(user, new QueuedMultiChannel({ id: 7 }))
+    await processQueue()
+
+    expect(sendMock).toHaveBeenCalledTimes(1)
+    expect(sendMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: [{ email: 'test@example.com' }],
+        subject: 'Order #7',
+      })
+    )
+  })
+
+  it('should deliver through the slack channel', async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(new Response('ok', { status: 200 }))
+    )
+    // @ts-ignore
+    global.fetch = fetchMock
+
+    manager.registerChannel(
+      'slack',
+      new SlackChannel('https://hooks.slack.com/default')
+    )
+
+    await manager.send(user, new QueuedMultiChannel({ id: 9 }))
+    await processQueue()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ]
+    expect(url).toBe('https://hooks.slack.com/user')
+    expect(JSON.parse(init.body as string).text).toBe('Order #9 shipped')
+  })
+
+  it('should honor user-defined shouldSend after rebuild', async () => {
+    await manager.send(user, new QueuedConditional(false))
+    await processQueue()
+
+    expect(dbChannel.getStored()).toHaveLength(0)
+  })
+
+  it('should throw for an unregistered notification type', async () => {
+    await manager.send(user, new QueuedConditional())
+
+    const { JobClass, payload } = await takeQueuedJob()
+
+    clearNotificationRegistry()
+
+    await expect(new JobClass().handle(payload as never)).rejects.toThrow(
+      'Notification type "QueuedConditional" is not registered'
+    )
+
+    // Explicit registration makes the same payload deliverable again.
+    registerNotification(QueuedConditional)
+    await expect(new JobClass().handle(payload as never)).resolves.toBeUndefined()
+  })
+
+  it('should register a custom type getter under the key the payload uses', async () => {
+    class Renamed extends QueuedConditional {
+      override get type(): string {
+        return 'order.shipped'
+      }
+    }
+
+    await manager.send(user, new Renamed())
+    const { JobClass, payload } = await takeQueuedJob()
+    expect(payload.notificationType).toBe('order.shipped')
+
+    // A separate worker process registers the class, not an instance: the
+    // default key must still match what the payload carries.
+    clearNotificationRegistry()
+    registerNotification(Renamed)
+
+    await expect(new JobClass().handle(payload as never)).resolves.toBeUndefined()
+    expect(dbChannel.getStored()).toHaveLength(1)
+  })
+
+  it('should preserve routes that the channel name does not imply', async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(new Response('ok', { status: 200 }))
+    )
+    // @ts-ignore
+    global.fetch = fetchMock
+
+    // The route lives on `slackId`, so nothing about the payload shape reveals
+    // it. Only routeNotificationFor() knows, and it cannot survive the queue.
+    manager.registerChannel(
+      'slack',
+      new SlackChannel('https://hooks.slack.com/org-wide-default')
+    )
+
+    await manager.send(user, new QueuedMultiChannel({ id: 3 }))
+    await processQueue()
+
+    const [url] = fetchMock.mock.calls[0] as unknown as [string]
+    expect(url).toBe('https://hooks.slack.com/user')
   })
 })
 


### PR DESCRIPTION
## Summary

Notifications with `static shouldQueue = true` were queued, picked up by the worker, and delivered to **zero channels**. Two root causes in `NotificationManager`:

1. `serializeNotification()` did `data: { ...notification }` — a spread copies only own enumerable properties, so every prototype method (`via`, `toMail`, `toDatabase`, `toSlack`) was dropped.
2. The job handler rebuilt a shim that read delivery channels from a `_viaChannels` payload field nothing ever wrote, so `via()` returned `[]` and the send loop had nothing to iterate. The synchronous (`sendNow`) path was unaffected.

## What changed

- Added a notification registry (`registerNotification`/`getNotification`) keyed on `notification.type`. The queue worker now rebuilds a **real instance** via `Object.create(prototype)` + `Object.assign` of the serialized own properties — restoring every prototype method without re-running the constructor (constructor args aren't recoverable from a payload, so `new Klass()` would throw). Registration happens automatically on dispatch; a worker in a separate process should call the newly exported `registerNotification()` from a provider. An unregistered type now throws instead of silently delivering nothing.
- **Routing bug found during review, fixed alongside:** the worker was guessing a notifiable's routes from a `${channel}Route` property convention that the documented `Notifiable` (`docs/en/guides/notifications.md`) never uses — it routes Slack via `this.slackId`. A queued Slack notification to a documented-shape user silently fell back to the org-wide default webhook. `routeNotificationFor()` is now called at dispatch time and the resolved routes travel with the job (payloads written before this release fall back to the old guess).
- `createdAt` is serialized explicitly and revived as a `Date` — `MemoryDriver` keeps live object references so this was invisible in dev, but Redis/SQS persist JSON and would hand channels a string.
- `Notifiable` gained an optional `notifiableType`, honored by `DatabaseChannel` via the new `resolveNotifiableType()`, so a rebuilt notifiable keeps its original type name instead of recording `Object`.
- The queued job was registered only as a side effect of dispatch, under a per-manager anonymous subclass name, so a dedicated `guren queue:work` process failed every job with `Job class not found`. Since the queue registry keys on class name, every manager's subclass silently overwrote the same entry anyway — so the subclass added no real capability. Replaced with one `SendNotificationJob`, registered via `NotificationManager#registerQueueJob()` and called from `NotificationServiceProvider.boot()`.
- Docs (en/ja) updated with the separate-worker registration pattern and what does/doesn't survive the queue.

## Test plan

- [x] `bun run build` / `build:clean`
- [x] `bun run typecheck` (root + examples/blog + examples/api)
- [x] `bun run test` — 2904 pass, 0 fail
- [x] `bun run audit:core-first`, `bun run audit:docs`
- [x] New tests in `packages/server/tests/notifications/notifications.test.ts` cover the full queued round trip per channel (mail/database/slack), `createdAt` revival, custom `shouldSend` after rebuild, unregistered-type error, stable job naming/registration without dispatch, a custom `type` getter registering under the payload's key, and route preservation for a channel whose route the payload shape doesn't imply
- [x] Verified by mutation: reverting each fix (prototype reconstruction, route serialization, stable job name, registry key resolution, `registerQueueJob`) makes a distinct test fail