### PR TITLE
fix(server): parse console signature tokens containing descriptions

### DIFF
--- a/packages/server/src/console/Command.ts
+++ b/packages/server/src/console/Command.ts
@@ -36,6 +36,8 @@ export abstract class Command implements CommandInstance {
   /**
    * The command signature.
    * Format: 'command:name {arg} {--option}'
+   * Tokens may carry a description: 'command:name {arg : What it is}'
+   * See `parseSignature` for the full grammar.
    */
   static signature: string
 

--- a/packages/server/src/console/ConsoleKernel.ts
+++ b/packages/server/src/console/ConsoleKernel.ts
@@ -1,14 +1,35 @@
 import type { Container } from '../container'
-import type { CommandClass, ConsoleKernelOptions, OutputInterface } from './types'
+import type {
+  CommandClass,
+  ConsoleKernelOptions,
+  OptionDefinition,
+  OutputInterface,
+} from './types'
 import { Command } from './Command'
 import { Output, BufferedOutput } from './Output'
 import { argumentLabel, formatUsage, optionLabel, parseSignature } from './Input'
 
 /**
- * Left-align a help label so the column after it starts at `width`.
+ * The column help text starts at: past the longest label, and never narrower
+ * than `min` so that a list of short labels still reads as a column.
  */
-function padded(label: string, width: number): string {
-  return label + ' '.repeat(Math.max(2, width - label.length))
+function helpColumn(labels: string[], min: number): number {
+  return Math.max(min, ...labels.map((label) => label.length + 2))
+}
+
+/**
+ * Emit one help row: a label padded out to `column`, followed by whichever of
+ * its annotations are present.
+ */
+function helpRow(
+  output: OutputInterface,
+  indent: string,
+  label: string,
+  column: number,
+  annotations: Array<string | undefined>
+): void {
+  const padding = ' '.repeat(Math.max(2, column - label.length))
+  output.line(`${indent}${label}${padding}${annotations.filter(Boolean).join(' ')}`)
 }
 
 /**
@@ -163,17 +184,27 @@ export class ConsoleKernel {
     this.output.info('Available Commands:')
     this.output.line('')
 
-    // Group commands by namespace
-    const grouped = this.groupCommands()
+    // Group commands by namespace, dropping the namespace from the label
+    const groups = Array.from(this.groupCommands(), ([namespace, commands]) => ({
+      namespace,
+      entries: Array.from(commands, ([name, cmd]) => ({
+        label: namespace ? name.slice(namespace.length + 1) : name,
+        description: cmd.description,
+      })),
+    }))
 
-    for (const [namespace, commands] of grouped) {
-      if (namespace) {
-        this.output.line(`  ${namespace}`)
+    const column = helpColumn(
+      groups.flatMap((group) => group.entries.map((entry) => entry.label)),
+      20
+    )
+
+    for (const group of groups) {
+      if (group.namespace) {
+        this.output.line(`  ${group.namespace}`)
       }
 
-      for (const [name, cmd] of commands) {
-        const displayName = namespace ? name.slice(namespace.length + 1) : name
-        this.output.line(`    ${padded(displayName, 20)}${cmd.description}`)
+      for (const entry of group.entries) {
+        helpRow(this.output, '    ', entry.label, column, [entry.description])
       }
 
       this.output.line('')
@@ -199,15 +230,25 @@ export class ConsoleKernel {
     this.output.line('')
     this.output.line(`Usage: ${formatUsage(parsed)}`)
 
+    // One column for both blocks, so arguments and options line up with each other
+    const optionShortcut = (opt: OptionDefinition) => (opt.shortcut ? `-${opt.shortcut}, ` : '    ')
+    const column = helpColumn(
+      [
+        ...parsed.arguments.map(argumentLabel),
+        ...parsed.options.map((opt) => optionShortcut(opt) + optionLabel(opt)),
+      ],
+      24
+    )
+
     if (parsed.arguments.length > 0) {
       this.output.line('')
       this.output.line('Arguments:')
       for (const arg of parsed.arguments) {
-        const columns: string[] = []
-        if (arg.description) columns.push(arg.description)
-        columns.push(arg.required ? '(required)' : '(optional)')
-        if (arg.defaultValue) columns.push(`[default: ${arg.defaultValue}]`)
-        this.output.line(`  ${padded(argumentLabel(arg), 24)}${columns.join(' ')}`)
+        helpRow(this.output, '  ', argumentLabel(arg), column, [
+          arg.description,
+          arg.required ? '(required)' : '(optional)',
+          arg.defaultValue ? `[default: ${arg.defaultValue}]` : undefined,
+        ])
       }
     }
 
@@ -215,13 +256,12 @@ export class ConsoleKernel {
       this.output.line('')
       this.output.line('Options:')
       for (const opt of parsed.options) {
-        const shortcut = opt.shortcut ? `-${opt.shortcut}, ` : '    '
-        const columns: string[] = []
-        if (opt.description) columns.push(opt.description)
-        if (opt.defaultValue !== undefined && opt.defaultValue !== false) {
-          columns.push(`[default: ${opt.defaultValue}]`)
-        }
-        this.output.line(`  ${padded(shortcut + optionLabel(opt), 24)}${columns.join(' ')}`)
+        helpRow(this.output, '  ', optionShortcut(opt) + optionLabel(opt), column, [
+          opt.description,
+          opt.defaultValue !== undefined && opt.defaultValue !== false
+            ? `[default: ${opt.defaultValue}]`
+            : undefined,
+        ])
       }
     }
 

--- a/packages/server/src/console/ConsoleKernel.ts
+++ b/packages/server/src/console/ConsoleKernel.ts
@@ -2,7 +2,14 @@ import type { Container } from '../container'
 import type { CommandClass, ConsoleKernelOptions, OutputInterface } from './types'
 import { Command } from './Command'
 import { Output, BufferedOutput } from './Output'
-import { parseSignature } from './Input'
+import { argumentLabel, formatUsage, optionLabel, parseSignature } from './Input'
+
+/**
+ * Left-align a help label so the column after it starts at `width`.
+ */
+function padded(label: string, width: number): string {
+  return label + ' '.repeat(Math.max(2, width - label.length))
+}
 
 /**
  * Console kernel for managing and executing commands.
@@ -166,8 +173,7 @@ export class ConsoleKernel {
 
       for (const [name, cmd] of commands) {
         const displayName = namespace ? name.slice(namespace.length + 1) : name
-        const padding = ' '.repeat(Math.max(2, 20 - displayName.length))
-        this.output.line(`    ${displayName}${padding}${cmd.description}`)
+        this.output.line(`    ${padded(displayName, 20)}${cmd.description}`)
       }
 
       this.output.line('')
@@ -191,15 +197,17 @@ export class ConsoleKernel {
     this.output.line('')
     this.output.line(`  ${CommandClass.description || 'No description'}`)
     this.output.line('')
-    this.output.line(`Usage: ${CommandClass.signature}`)
+    this.output.line(`Usage: ${formatUsage(parsed)}`)
 
     if (parsed.arguments.length > 0) {
       this.output.line('')
       this.output.line('Arguments:')
       for (const arg of parsed.arguments) {
-        const required = arg.required ? '(required)' : '(optional)'
-        const defaultVal = arg.defaultValue ? ` [default: ${arg.defaultValue}]` : ''
-        this.output.line(`  ${arg.name}  ${required}${defaultVal}`)
+        const columns: string[] = []
+        if (arg.description) columns.push(arg.description)
+        columns.push(arg.required ? '(required)' : '(optional)')
+        if (arg.defaultValue) columns.push(`[default: ${arg.defaultValue}]`)
+        this.output.line(`  ${padded(argumentLabel(arg), 24)}${columns.join(' ')}`)
       }
     }
 
@@ -208,10 +216,12 @@ export class ConsoleKernel {
       this.output.line('Options:')
       for (const opt of parsed.options) {
         const shortcut = opt.shortcut ? `-${opt.shortcut}, ` : '    '
-        const defaultVal = opt.defaultValue !== undefined && opt.defaultValue !== false
-          ? ` [default: ${opt.defaultValue}]`
-          : ''
-        this.output.line(`  ${shortcut}--${opt.name}${defaultVal}`)
+        const columns: string[] = []
+        if (opt.description) columns.push(opt.description)
+        if (opt.defaultValue !== undefined && opt.defaultValue !== false) {
+          columns.push(`[default: ${opt.defaultValue}]`)
+        }
+        this.output.line(`  ${padded(shortcut + optionLabel(opt), 24)}${columns.join(' ')}`)
       }
     }
 

--- a/packages/server/src/console/Input.ts
+++ b/packages/server/src/console/Input.ts
@@ -19,6 +19,18 @@ import type {
  * - `{--option=default}` - Option with default value
  * - `{-o|--option}` - Option with shortcut
  * - `{--option=*}` - Array option
+ * - `{argument : Description}` - Argument with a description
+ * - `{--option= : Description}` - Option with a description
+ *
+ * A description is separated from the token by a colon with whitespace on at
+ * least one side, so it may contain spaces and colons freely. Requiring that
+ * whitespace keeps colons inside default values (`{--url=https://example.com}`)
+ * out of descriptions.
+ *
+ * A colon with no whitespace at all (`{argument:Description}`) is accepted for
+ * a single-word description, but only on a token carrying no other marker:
+ * `{argument?}`, `{argument*}` and `{--option=default}` must use the spaced
+ * form, since their markers are stripped before that fallback runs.
  *
  * @example
  * ```typescript
@@ -31,33 +43,29 @@ import type {
  * //     { name: 'role', requiresValue: true, defaultValue: 'user' }
  * //   ]
  * // }
+ *
+ * parseSignature('users:create {name : The full name} {--admin : Grant admin rights}')
+ * // => arguments[0].description === 'The full name'
+ * //    options[0].description === 'Grant admin rights'
  * ```
  */
 export function parseSignature(signature: string): ParsedSignature {
-  const parts = signature.split(/\s+/)
-  const name = parts[0]
+  const { name, tokens } = tokenizeSignature(signature)
   const args: ArgumentDefinition[] = []
   const options: OptionDefinition[] = []
 
-  for (let i = 1; i < parts.length; i++) {
-    const part = parts[i]
+  for (const token of tokens) {
+    const [content, description] = extractDescription(token)
 
-    // Skip empty parts
-    if (!part) continue
+    // Skip empty tokens
+    if (!content) continue
 
-    // Must be wrapped in braces
-    if (!part.startsWith('{') || !part.endsWith('}')) {
-      continue
-    }
-
-    const content = part.slice(1, -1).trim()
-
-    if (content.startsWith('--') || content.startsWith('-')) {
+    if (content.startsWith('-')) {
       // Option
-      options.push(parseOption(content))
+      options.push(parseOption(content, description))
     } else {
       // Argument
-      args.push(parseArgument(content))
+      args.push(parseArgument(content, description))
     }
   }
 
@@ -65,9 +73,97 @@ export function parseSignature(signature: string): ParsedSignature {
 }
 
 /**
+ * Split a signature into its command name and its brace-delimited tokens.
+ *
+ * Tokens are found by scanning for balanced `{...}` groups so that a token may
+ * contain whitespace (a description, for instance). Unterminated groups are
+ * skipped.
+ */
+function tokenizeSignature(signature: string): { name: string; tokens: string[] } {
+  const firstBrace = signature.indexOf('{')
+  const head = firstBrace === -1 ? signature : signature.slice(0, firstBrace)
+  const name = head.trim().split(/\s+/)[0]
+
+  if (firstBrace === -1) {
+    return { name, tokens: [] }
+  }
+
+  const tokens: string[] = []
+  let depth = 0
+  let start = -1
+
+  for (let i = firstBrace; i < signature.length; i++) {
+    const char = signature[i]
+
+    if (char === '{') {
+      if (depth === 0) start = i
+      depth++
+    } else if (char === '}' && depth > 0) {
+      depth--
+      if (depth === 0) {
+        tokens.push(signature.slice(start + 1, i))
+        start = -1
+      }
+    }
+  }
+
+  return { name, tokens }
+}
+
+/**
+ * Separator between a token and its description: a colon with whitespace on at
+ * least one side. Requiring that whitespace keeps colons inside default values
+ * (`{--url=https://example.com}`) intact.
+ */
+const DESCRIPTION_SEPARATOR = /\s+:\s*|\s*:\s+/
+
+/**
+ * Split a token into its definition and its description.
+ *
+ * This runs before the `?` / `*` / `=default` markers are stripped, so a
+ * description may contain any of those characters.
+ */
+function extractDescription(token: string): [string, string | undefined] {
+  const match = DESCRIPTION_SEPARATOR.exec(token)
+
+  if (!match) {
+    return [token.trim(), undefined]
+  }
+
+  const content = token.slice(0, match.index).trim()
+  const description = token.slice(match.index + match[0].length).trim()
+
+  return [content, description || undefined]
+}
+
+/**
+ * Strip a colon-delimited description written without any surrounding
+ * whitespace (`name:description`).
+ *
+ * This is the fallback for `extractDescription`, and it runs *after* the
+ * markers have been stripped so that colons inside a default value survive.
+ * Nothing is stripped once a description is already known.
+ */
+function splitInlineDescription(
+  name: string,
+  description?: string
+): [string, string | undefined] {
+  if (description !== undefined) {
+    return [name, description]
+  }
+
+  const colonIndex = name.indexOf(':')
+  if (colonIndex === -1) {
+    return [name, undefined]
+  }
+
+  return [name.slice(0, colonIndex), name.slice(colonIndex + 1).trim() || undefined]
+}
+
+/**
  * Parse an argument definition.
  */
-function parseArgument(content: string): ArgumentDefinition {
+function parseArgument(content: string, description?: string): ArgumentDefinition {
   let name = content
   let required = true
   let array = false
@@ -93,21 +189,15 @@ function parseArgument(content: string): ArgumentDefinition {
     required = false
   }
 
-  // Extract description if present (after :)
-  let description: string | undefined
-  const colonIndex = name.indexOf(':')
-  if (colonIndex !== -1) {
-    description = name.slice(colonIndex + 1)
-    name = name.slice(0, colonIndex)
-  }
+  ;[name, description] = splitInlineDescription(name, description)
 
-  return { name, description, required, array, defaultValue }
+  return { name: name.trim(), description, required, array, defaultValue }
 }
 
 /**
  * Parse an option definition.
  */
-function parseOption(content: string): OptionDefinition {
+function parseOption(content: string, description?: string): OptionDefinition {
   let name = content
   let shortcut: string | undefined
   let requiresValue = false
@@ -143,20 +233,14 @@ function parseOption(content: string): OptionDefinition {
     }
   }
 
-  // Extract description if present
-  let description: string | undefined
-  const colonIndex = name.indexOf(':')
-  if (colonIndex !== -1) {
-    description = name.slice(colonIndex + 1)
-    name = name.slice(0, colonIndex)
-  }
+  ;[name, description] = splitInlineDescription(name, description)
 
   // Boolean options default to false
   if (!requiresValue && defaultValue === undefined) {
     defaultValue = false
   }
 
-  return { name, shortcut, description, requiresValue, defaultValue, array }
+  return { name: name.trim(), shortcut, description, requiresValue, defaultValue, array }
 }
 
 /**

--- a/packages/server/src/console/Input.ts
+++ b/packages/server/src/console/Input.ts
@@ -55,7 +55,7 @@ export function parseSignature(signature: string): ParsedSignature {
   const options: OptionDefinition[] = []
 
   for (const token of tokens) {
-    const [content, description] = extractDescription(token)
+    const [content, description] = splitSpacedDescription(token)
 
     // Skip empty tokens
     if (!content) continue
@@ -102,7 +102,6 @@ function tokenizeSignature(signature: string): { name: string; tokens: string[] 
       depth--
       if (depth === 0) {
         tokens.push(signature.slice(start + 1, i))
-        start = -1
       }
     }
   }
@@ -111,19 +110,17 @@ function tokenizeSignature(signature: string): { name: string; tokens: string[] 
 }
 
 /**
- * Separator between a token and its description: a colon with whitespace on at
- * least one side. Requiring that whitespace keeps colons inside default values
- * (`{--url=https://example.com}`) intact.
+ * A colon with whitespace on at least one side. See `parseSignature` for why
+ * the whitespace is required.
  */
-const DESCRIPTION_SEPARATOR = /\s+:\s*|\s*:\s+/
+const DESCRIPTION_SEPARATOR = /\s+:\s*|:\s+/
 
 /**
- * Split a token into its definition and its description.
- *
- * This runs before the `?` / `*` / `=default` markers are stripped, so a
+ * Stage one of two: split a whole token into its definition and its
+ * description, before the `?` / `*` / `=default` markers are stripped, so a
  * description may contain any of those characters.
  */
-function extractDescription(token: string): [string, string | undefined] {
+function splitSpacedDescription(token: string): [string, string | undefined] {
   const match = DESCRIPTION_SEPARATOR.exec(token)
 
   if (!match) {
@@ -137,27 +134,27 @@ function extractDescription(token: string): [string, string | undefined] {
 }
 
 /**
- * Strip a colon-delimited description written without any surrounding
- * whitespace (`name:description`).
+ * Stage two of two: settle a definition's final name and description, stripping
+ * a description written with no surrounding whitespace (`name:description`).
  *
- * This is the fallback for `extractDescription`, and it runs *after* the
- * markers have been stripped so that colons inside a default value survive.
- * Nothing is stripped once a description is already known.
+ * This runs *after* the markers have been stripped, which is what keeps colons
+ * inside a default value out of descriptions. A description found by
+ * `splitSpacedDescription` is never overwritten — a name may legitimately
+ * contain a colon once stage one has claimed the description.
  */
-function splitInlineDescription(
+function resolveNameAndDescription(
   name: string,
   description?: string
-): [string, string | undefined] {
-  if (description !== undefined) {
-    return [name, description]
+): { name: string; description: string | undefined } {
+  if (description === undefined) {
+    const colonIndex = name.indexOf(':')
+    if (colonIndex !== -1) {
+      description = name.slice(colonIndex + 1).trim() || undefined
+      name = name.slice(0, colonIndex)
+    }
   }
 
-  const colonIndex = name.indexOf(':')
-  if (colonIndex === -1) {
-    return [name, undefined]
-  }
-
-  return [name.slice(0, colonIndex), name.slice(colonIndex + 1).trim() || undefined]
+  return { name: name.trim(), description }
 }
 
 /**
@@ -224,9 +221,12 @@ function parseArgument(content: string, description?: string): ArgumentDefinitio
     required = false
   }
 
-  ;[name, description] = splitInlineDescription(name, description)
-
-  return { name: name.trim(), description, required, array, defaultValue }
+  return {
+    ...resolveNameAndDescription(name, description),
+    required,
+    array,
+    defaultValue,
+  }
 }
 
 /**
@@ -268,14 +268,18 @@ function parseOption(content: string, description?: string): OptionDefinition {
     }
   }
 
-  ;[name, description] = splitInlineDescription(name, description)
-
   // Boolean options default to false
   if (!requiresValue && defaultValue === undefined) {
     defaultValue = false
   }
 
-  return { name: name.trim(), shortcut, description, requiresValue, defaultValue, array }
+  return {
+    ...resolveNameAndDescription(name, description),
+    shortcut,
+    requiresValue,
+    defaultValue,
+    array,
+  }
 }
 
 /**

--- a/packages/server/src/console/Input.ts
+++ b/packages/server/src/console/Input.ts
@@ -161,6 +161,41 @@ function splitInlineDescription(
 }
 
 /**
+ * The label an argument is displayed with in help output.
+ */
+export function argumentLabel(arg: ArgumentDefinition): string {
+  return arg.array ? `${arg.name}...` : arg.name
+}
+
+/**
+ * The label an option is displayed with in help output, carrying whether it
+ * takes a value and whether it may be repeated.
+ */
+export function optionLabel(opt: OptionDefinition): string {
+  if (opt.array) return `--${opt.name}=<value>...`
+  if (opt.requiresValue) return `--${opt.name}=<value>`
+  return `--${opt.name}`
+}
+
+/**
+ * Build a usage line from a parsed signature.
+ */
+export function formatUsage(parsed: ParsedSignature): string {
+  const parts = [parsed.name]
+
+  if (parsed.options.length > 0) {
+    parts.push('[options]')
+  }
+
+  for (const arg of parsed.arguments) {
+    const label = argumentLabel(arg)
+    parts.push(arg.required ? `<${label}>` : `[${label}]`)
+  }
+
+  return parts.join(' ')
+}
+
+/**
  * Parse an argument definition.
  */
 function parseArgument(content: string, description?: string): ArgumentDefinition {

--- a/packages/server/tests/console/console.test.ts
+++ b/packages/server/tests/console/console.test.ts
@@ -740,6 +740,46 @@ describe('ConsoleKernel', () => {
     expect(output.contains('Usage:')).toBe(true)
   })
 
+  test('shows command help with argument and option descriptions', async () => {
+    class DescribedCommand extends Command {
+      static signature =
+        'reports:digest {email : The recipient address} {period? : Reporting period} {--dry-run : Skip delivery} {--limit=10 : Maximum rows}'
+      static description = 'Send the digest report'
+
+      async handle(): Promise<void> {}
+    }
+
+    kernel.register(DescribedCommand)
+    const result = await kernel.handle(['help', 'reports:digest'])
+
+    expect(result).toBe(0)
+    expect(output.contains('Usage: reports:digest [options] <email> [period]')).toBe(true)
+    expect(output.contains('The recipient address')).toBe(true)
+    expect(output.contains('Reporting period')).toBe(true)
+    expect(output.contains('Skip delivery')).toBe(true)
+    expect(output.contains('Maximum rows')).toBe(true)
+    expect(output.contains('[default: 10]')).toBe(true)
+  })
+
+  test('shows whether an option takes a value or repeats', async () => {
+    class ArityCommand extends Command {
+      static signature =
+        'mail:send {emails* : Recipients} {--subject= : Subject line} {--tag=* : Tags to attach} {--dry-run : Skip delivery}'
+      static description = 'Send mail'
+
+      async handle(): Promise<void> {}
+    }
+
+    kernel.register(ArityCommand)
+    const result = await kernel.handle(['help', 'mail:send'])
+
+    expect(result).toBe(0)
+    expect(output.contains('Usage: mail:send [options] <emails...>')).toBe(true)
+    expect(output.contains('--subject=<value>')).toBe(true)
+    expect(output.contains('--tag=<value>...')).toBe(true)
+    expect(output.contains('--dry-run ')).toBe(true)
+  })
+
   test('lists commands', async () => {
     kernel.register(TestCommand)
     kernel.register(FailingCommand)

--- a/packages/server/tests/console/console.test.ts
+++ b/packages/server/tests/console/console.test.ts
@@ -94,6 +94,132 @@ describe('parseSignature', () => {
     expect(result.options[2].name).toBe('cc')
     expect(result.options[2].array).toBe(true)
   })
+
+  test('parses argument description containing spaces', () => {
+    const result = parseSignature('reports:digest {email : The recipient address}')
+    expect(result.arguments).toHaveLength(1)
+    expect(result.arguments[0].name).toBe('email')
+    expect(result.arguments[0].description).toBe('The recipient address')
+    expect(result.arguments[0].required).toBe(true)
+  })
+
+  test('parses option description containing spaces', () => {
+    const result = parseSignature('reports:digest {--dry-run : Do not send anything}')
+    expect(result.options).toHaveLength(1)
+    expect(result.options[0].name).toBe('dry-run')
+    expect(result.options[0].description).toBe('Do not send anything')
+    expect(result.options[0].requiresValue).toBe(false)
+  })
+
+  test('parses description with whitespace on only one side of the colon', () => {
+    const trailing = parseSignature('reports:digest {email: The recipient}')
+    expect(trailing.arguments[0].name).toBe('email')
+    expect(trailing.arguments[0].description).toBe('The recipient')
+
+    const leading = parseSignature('reports:digest {email :Recipient}')
+    expect(leading.arguments[0].name).toBe('email')
+    expect(leading.arguments[0].description).toBe('Recipient')
+  })
+
+  test('parses one-sided separator on a token carrying a marker', () => {
+    const optional = parseSignature('reports:digest {name?: Display name}')
+    expect(optional.arguments[0].name).toBe('name')
+    expect(optional.arguments[0].required).toBe(false)
+    expect(optional.arguments[0].description).toBe('Display name')
+
+    const defaulted = parseSignature('reports:digest {role=user: The assigned role}')
+    expect(defaulted.arguments[0].name).toBe('role')
+    expect(defaulted.arguments[0].defaultValue).toBe('user')
+    expect(defaulted.arguments[0].description).toBe('The assigned role')
+  })
+
+  test('parses argument default value with description', () => {
+    const result = parseSignature('reports:digest {role=user : The role to assign}')
+    expect(result.arguments[0].name).toBe('role')
+    expect(result.arguments[0].defaultValue).toBe('user')
+    expect(result.arguments[0].required).toBe(false)
+    expect(result.arguments[0].description).toBe('The role to assign')
+  })
+
+  test('parses array argument with description', () => {
+    const result = parseSignature('send:email {emails* : One or more addresses}')
+    expect(result.arguments[0].name).toBe('emails')
+    expect(result.arguments[0].array).toBe(true)
+    expect(result.arguments[0].description).toBe('One or more addresses')
+  })
+
+  test('parses option default value with description', () => {
+    const result = parseSignature('users:create {--role=user : The role to assign}')
+    expect(result.options[0].name).toBe('role')
+    expect(result.options[0].defaultValue).toBe('user')
+    expect(result.options[0].requiresValue).toBe(true)
+    expect(result.options[0].description).toBe('The role to assign')
+  })
+
+  test('parses array option with description', () => {
+    const result = parseSignature('users:create {--tag=* : Tags to attach}')
+    expect(result.options[0].name).toBe('tag')
+    expect(result.options[0].array).toBe(true)
+    expect(result.options[0].requiresValue).toBe(true)
+    expect(result.options[0].description).toBe('Tags to attach')
+  })
+
+  test('parses option shortcut with description', () => {
+    const result = parseSignature('mail:send {-q|--queue : Push onto the queue}')
+    expect(result.options[0].name).toBe('queue')
+    expect(result.options[0].shortcut).toBe('q')
+    expect(result.options[0].description).toBe('Push onto the queue')
+  })
+
+  test('parses value-requiring option with description', () => {
+    const result = parseSignature('mail:send {--subject= : Subject line}')
+    expect(result.options[0].name).toBe('subject')
+    expect(result.options[0].requiresValue).toBe(true)
+    expect(result.options[0].defaultValue).toBeUndefined()
+    expect(result.options[0].description).toBe('Subject line')
+  })
+
+  test('parses a signature spread over multiple lines', () => {
+    const result = parseSignature(`reports:digest
+      {email : The recipient address}
+      {--dry-run : Skip delivery}`)
+
+    expect(result.name).toBe('reports:digest')
+    expect(result.arguments).toHaveLength(1)
+    expect(result.arguments[0].name).toBe('email')
+    expect(result.arguments[0].description).toBe('The recipient address')
+    expect(result.options).toHaveLength(1)
+    expect(result.options[0].name).toBe('dry-run')
+    expect(result.options[0].description).toBe('Skip delivery')
+  })
+
+  test('keeps colons inside default values out of descriptions', () => {
+    const result = parseSignature('site:ping {--url=https://example.com}')
+    expect(result.options[0].name).toBe('url')
+    expect(result.options[0].defaultValue).toBe('https://example.com')
+    expect(result.options[0].description).toBeUndefined()
+  })
+
+  test('parses multiple described tokens in one signature', () => {
+    const result = parseSignature(
+      'reports:digest {email : The recipient address} {period? : Reporting period} {--dry-run : Skip delivery} {--limit=10 : Maximum rows}'
+    )
+
+    expect(result.name).toBe('reports:digest')
+    expect(result.arguments).toHaveLength(2)
+    expect(result.arguments[0].name).toBe('email')
+    expect(result.arguments[0].description).toBe('The recipient address')
+    expect(result.arguments[1].name).toBe('period')
+    expect(result.arguments[1].required).toBe(false)
+    expect(result.arguments[1].description).toBe('Reporting period')
+
+    expect(result.options).toHaveLength(2)
+    expect(result.options[0].name).toBe('dry-run')
+    expect(result.options[0].description).toBe('Skip delivery')
+    expect(result.options[1].name).toBe('limit')
+    expect(result.options[1].defaultValue).toBe('10')
+    expect(result.options[1].description).toBe('Maximum rows')
+  })
 })
 
 describe('Input', () => {
@@ -141,6 +267,17 @@ describe('Input', () => {
   test('uses default option value', () => {
     const input = new Input('users:create {--role=user}', [])
     expect(input.option<string>('role')).toBe('user')
+  })
+
+  test('resolves values for tokens carrying a description', () => {
+    const input = new Input(
+      'reports:digest {email : The recipient address} {--dry-run : Skip delivery} {--limit=10 : Maximum rows}',
+      ['ops@example.com', '--dry-run', '--limit', '25']
+    )
+
+    expect(input.argument<string>('email')).toBe('ops@example.com')
+    expect(input.option<boolean>('dry-run')).toBe(true)
+    expect(input.option<string>('limit')).toBe('25')
   })
 
   test('parses short option', () => {

--- a/packages/server/tests/console/console.test.ts
+++ b/packages/server/tests/console/console.test.ts
@@ -654,6 +654,19 @@ describe('Command', () => {
 // ConsoleKernel Tests
 // ===================
 
+/**
+ * The non-blank lines of a help screen with runs of whitespace collapsed, so an
+ * assertion can pin which description belongs to which label without depending
+ * on the column width — 'aligns help descriptions past the longest label'
+ * covers the padding itself.
+ */
+function helpLines(output: BufferedOutput): string[] {
+  return output
+    .getLines()
+    .map((line) => line.replace(/\s+/g, ' ').trim())
+    .filter((line) => line.length > 0)
+}
+
 describe('ConsoleKernel', () => {
   let kernel: ConsoleKernel
   let output: BufferedOutput
@@ -753,12 +766,17 @@ describe('ConsoleKernel', () => {
     const result = await kernel.handle(['help', 'reports:digest'])
 
     expect(result).toBe(0)
-    expect(output.contains('Usage: reports:digest [options] <email> [period]')).toBe(true)
-    expect(output.contains('The recipient address')).toBe(true)
-    expect(output.contains('Reporting period')).toBe(true)
-    expect(output.contains('Skip delivery')).toBe(true)
-    expect(output.contains('Maximum rows')).toBe(true)
-    expect(output.contains('[default: 10]')).toBe(true)
+    expect(helpLines(output)).toEqual([
+      'INFO Command: reports:digest',
+      'Send the digest report',
+      'Usage: reports:digest [options] <email> [period]',
+      'Arguments:',
+      'email The recipient address (required)',
+      'period Reporting period (optional)',
+      'Options:',
+      '--dry-run Skip delivery',
+      '--limit=<value> Maximum rows [default: 10]',
+    ])
   })
 
   test('shows whether an option takes a value or repeats', async () => {
@@ -774,10 +792,40 @@ describe('ConsoleKernel', () => {
     const result = await kernel.handle(['help', 'mail:send'])
 
     expect(result).toBe(0)
-    expect(output.contains('Usage: mail:send [options] <emails...>')).toBe(true)
-    expect(output.contains('--subject=<value>')).toBe(true)
-    expect(output.contains('--tag=<value>...')).toBe(true)
-    expect(output.contains('--dry-run ')).toBe(true)
+    expect(helpLines(output)).toEqual([
+      'INFO Command: mail:send',
+      'Send mail',
+      'Usage: mail:send [options] <emails...>',
+      'Arguments:',
+      'emails... Recipients (required)',
+      'Options:',
+      '--subject=<value> Subject line',
+      '--tag=<value>... Tags to attach',
+      '--dry-run Skip delivery',
+    ])
+  })
+
+  test('aligns help descriptions past the longest label', async () => {
+    class WideCommand extends Command {
+      static signature =
+        'queue:work {--connection= : Connection name} {--max-attempts=3 : Retries} {-t|--attachment=* : Files to attach} {--dry-run : Skip}'
+      static description = 'Process queued jobs'
+
+      async handle(): Promise<void> {}
+    }
+
+    kernel.register(WideCommand)
+    await kernel.handle(['help', 'queue:work'])
+
+    // The longest label is '  -t, --attachment=<value>...', so every description
+    // starts two columns past it rather than overflowing a fixed column.
+    const rows = output.getLines().filter((line) => line.includes('--'))
+    expect(rows).toEqual([
+      '      --connection=<value>     Connection name',
+      '      --max-attempts=<value>   Retries [default: 3]',
+      '  -t, --attachment=<value>...  Files to attach',
+      '      --dry-run                Skip',
+    ])
   })
 
   test('lists commands', async () => {


### PR DESCRIPTION
## Summary

`parseSignature()` split a command signature on whitespace and then required each part to both start with `{` and end with `}`. Any brace group containing a space was therefore split across several parts, none of which matched, and the argument or option was dropped without an error. Inline descriptions were consequently impossible to use:

```ts
parseSignature('reports:digest {email : Recipient}')
// before => { name: 'reports:digest', arguments: [], options: [] }
```

The token vanished, so `this.argument('email')` returned `undefined` at runtime and `this.option('some-flag')` fell through to the "unknown option, store as boolean" branch — the command appeared to run but saw no arguments. The code that strips an inline `: description` was only reachable when the description contained no spaces at all (`{email:Recipient}`), so realistic descriptions could not be written.

This is split into four commits:

**`fix(server): parse signature tokens containing descriptions`**

- Tokenize by scanning for balanced `{...}` groups instead of splitting on whitespace, so a token may contain spaces (and a signature may span multiple lines).
- Strip the description *before* the `?` / `*` / `=default` markers are parsed, so a described token still yields the right shape — `{role=user : The role}` gives `defaultValue: 'user'`, not `'user : The role'`.
- The separator is a colon with whitespace on at least one side. Requiring that whitespace keeps colons inside default values out of descriptions (`{--url=https://example.com}`, `{--time=12:30}`, `{--dsn=postgres://user:pass@host:5432/db}`).
- The fully unspaced form `{email:Recipient}` still works, handled by the original post-marker strip, which is now a single `splitInlineDescription()` helper instead of two copies.
- Names are trimmed after the description is removed, so `{email : x}` no longer yields a name with trailing whitespace.

**`feat(server): render argument and option descriptions in command help`**

`showCommandHelp()` rendered `arg.name` / `opt.name` but never their descriptions, and printed `Usage: ${CommandClass.signature}` — echoing the signature DSL back at the user. It now synthesizes the usage line and renders descriptions:

```
Usage: reports:digest [options] <email> <periods...>

Arguments:
  email                   The recipient address (required)
  periods...              Reporting periods (required)

Options:
      --dry-run           Skip delivery
  -l, --limit=<value>     Maximum rows [default: 10]
      --subject=<value>   Subject line
      --tag=<value>...    Tags to attach
```

Option labels carry their arity (`=<value>`, `=<value>...`). The raw signature echo used to convey this, and a plain `--name` would have silently lost it. Label and usage formatting lives next to `parseSignature`, since it encodes the surface syntax of the signature grammar.

**`fix(server): align help columns to the widest label`**

Those wider labels overran the fixed 24-column gutter — `--max-attempts=<value>` and `-t, --attachment=<value>...` both exceed it — so each long label pushed its own description right and the descriptions stopped lining up:

```
      --connection=<value>  Connection name
      --max-attempts=<value>  Retries [default: 3]
  -t, --attachment=<value>...  Files to attach
      --dry-run           Skip
```

The column is now derived from the labels being rendered, the way `Output.table` already sizes its columns, with the previous width kept as a floor so a list of short labels still reads as a column. Arguments and options share one column so the two blocks line up, and the command list uses the same helper instead of its own copy of the padding. Help output is unchanged wherever no label overflows.

**`refactor(server): name the two description-parsing stages`**

`extractDescription` / `splitInlineDescription` read as synonyms, so nothing in the names said which runs before the markers are stripped and which after — the constraint that makes the parse correct. They are now `splitSpacedDescription` (stage one) and `resolveNameAndDescription` (stage two), the latter returning an object and absorbing the trailing `trim()` its callers each repeated, which retires the `;[name, description] = ...` reassignment. The separator also drops an alternative branch that could never match.

## Scope

`server` (`packages/server/src/console/`) — no public API surface added: `argumentLabel` / `optionLabel` / `formatUsage` are module-level and `console/index.ts` remains a named-export list.

## Risk Assessment

**One parse result changes for a signature that parses today.** A one-sided separator on a token carrying a default value:

```ts
parseSignature('reports:digest {role=user: The assigned role}')
// before => defaultValue: 'user: The assigned role', description: undefined
// after  => defaultValue: 'user',                    description: 'The assigned role'
```

The previous output was unusable (a default value with the description embedded in it), so nothing could reasonably depend on it, and this makes the one-sided form behave consistently across plain and marker-bearing tokens. Every other change is additive.

Deliberately **not** changed, to avoid altering parse output for signatures that work today:

- Balanced-brace scanning is kept rather than replaced with a flat `/\{([^{}]*)\}/g` match, so a nested default value like `{value={foo}}` behaves as before.
- The fixed-order suffix-stripping grammar (`tokenize` → `parseArgument` → `parseOption`) is left alone. Unifying description extraction into a single rule would change `{name?:desc}` and still could not rescue `{--tag=*:desc}` — an RFC-scale change to a publicly exported parser, not a bug fix.
- Malformed signatures (unterminated braces, `{}`) are still skipped silently rather than throwing.

The JSDoc grammar list now states explicitly that the fully unspaced form applies only to tokens carrying no other marker, since `{name?:desc}` yields the name `name?` — pre-existing behavior that the previous doc wording would have over-promised.

Help output for the command *list* (`showHelp`) is byte-identical to before.

## Validation

- [x] `bun run build` (`build:clean`, all packages)
- [x] `bun run typecheck`
- [x] `bun run test` — framework 2943 pass / 54 skip / 0 fail; examples: blog 105, api 42, web 91
- [x] `bun run audit:core-first`, `bun run audit:docs`

`packages/server/tests/console/console.test.ts`: 90 pass / 0 fail. Coverage was chosen to discriminate the ordering constraint, not just the happy path — `{name? : desc}`, `{role=user : desc}`, `{emails* : desc}`, `{--role=user : desc}`, `{--tag=* : desc}`, `{-q|--queue : desc}`, `{--subject= : desc}`, one-sided separators with and without markers, a multi-line signature, a `{--url=https://example.com}` regression guard, `Input` value resolution, and help rendering including option arity.

The help assertions compare whole rendered lines rather than testing substring membership, so a failure shows which description moved and which label it ended up attached to; alignment has its own test, since the earlier substring assertions could not have caught the overflow above.

Mutation-checked: disabling the description separator fails 9 of the new tests, so they can actually fail. The separator's dropped branch was checked against the previous form over 400k fuzzed tokens plus hand cases (`--url=https://example.com`, `--dsn=postgres://u:p@h:5432/db`, `--time=12:30`, `a:b : d`) with zero differences.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation.

On the last item: `docs/en/guides/console.md` and `docs/ja/guides/console.md` do not exist, and grepping `docs/`, the skills, and the agent templates turns up no page documenting the signature DSL — the JSDoc on `parseSignature` is its only documented surface, and that is what was updated (plus a pointer from `Command.signature`). Authoring two new console guides felt like a separate piece of work; happy to add them in a follow-up if wanted.
