### PR TITLE
refactor(core): share the deploy plugins' build-time helpers

### DIFF
--- a/.changeset/shared-deploy-build-helpers.md
+++ b/.changeset/shared-deploy-build-helpers.md
@@ -32,7 +32,9 @@ Four behaviour fixes fall out of the plugins now sharing one implementation:
 on disk, or one that escapes the SSR output directory. It previously wrote the
 entry into the function environment unchecked, so a stale or partial SSR build
 deployed and fell back to client-side rendering at request time. Cloudflare and
-Lambda already treated this as fatal.
+Lambda already treated this as fatal. It also checks the entrypoint exists
+before deleting the previous output — the spawned `bun build` caught a missing
+`src/vercel.ts` too, but only after the last deployable artifact was gone.
 
 Stubs for the dev-only modules are emitted as throwing functions rather than
 classes. The stubbed names mix constructors (`new Database()`) with plain calls

--- a/.changeset/shared-deploy-build-helpers.md
+++ b/.changeset/shared-deploy-build-helpers.md
@@ -28,6 +28,12 @@ Four behaviour fixes fall out of the plugins now sharing one implementation:
   `.vite/manifest.json` when the SSR build emitted the flat `manifest.json`
   layout instead.
 
+`buildVercelOutput` now fails when the SSR manifest names a chunk that is not
+on disk, or one that escapes the SSR output directory. It previously wrote the
+entry into the function environment unchecked, so a stale or partial SSR build
+deployed and fell back to client-side rendering at request time. Cloudflare and
+Lambda already treated this as fatal.
+
 Stubs for the dev-only modules are emitted as throwing functions rather than
 classes. The stubbed names mix constructors (`new Database()`) with plain calls
 (`createServer()`), and only a function reports the intended message under

--- a/.changeset/shared-deploy-build-helpers.md
+++ b/.changeset/shared-deploy-build-helpers.md
@@ -8,25 +8,28 @@
 Share the deploy plugins' build-time helpers through `@guren/core/internal/deploy-build`
 
 The Cloudflare, Lambda, and Vercel plugins each carried their own copy of the
-manifest and path helpers, and Cloudflare and Lambda separately listed the
-dev-only modules a deployed bundle has to stub. That list describes the
-framework's own module graph, so keeping it in two places had already let the
-copies drift.
+manifest and path helpers, the static-asset staging step, and the SSR manifest
+lookup. Cloudflare and Lambda separately listed the dev-only modules a deployed
+bundle has to stub. That list describes the module graph of any app importing
+`@guren/core`, so keeping it in two places had already let the copies drift.
 
-Three behaviour fixes fall out of the plugins now sharing one implementation:
+Four behaviour fixes fall out of the plugins now sharing one implementation:
 
 - `buildVercelOutput` gained the output-directory guard it never had. It
   deletes `outputDir` before writing, so pointing it at the project previously
   deleted the source tree.
-- `buildCloudflareOutput` and `buildVercelOutput` no longer accept the
-  filesystem root as `outputDir`. The old check compared strings, and `out + sep`
-  is `//` at the root, which no absolute path is prefixed by.
-- `buildCloudflareOutput` now honours a custom `publicDir` when reading the
-  client manifest instead of always looking under `<root>/public`.
+- No plugin accepts the filesystem root as `outputDir`. The old check compared
+  strings, and `out + sep` is `//` at the root, which no absolute path is
+  prefixed by.
+- `buildCloudflareOutput` and `buildVercelOutput` now honour a custom
+  `publicDir` when reading the client manifest instead of always looking under
+  `<root>/public`. Vercel likewise honours `ssrDir`.
+- `buildVercelOutput` no longer reports `GUREN_INERTIA_SSR_MANIFEST` as
+  `.vite/manifest.json` when the SSR build emitted the flat `manifest.json`
+  layout instead.
 
-Cloudflare's generated stub filenames are now derived from the module
-specifier, so `stub-mcp-server.js` and `stub-mcp-transport.js` are written
-under their full specifier-derived names. An existing `wrangler.jsonc` keeps
-its old `alias` values, which now point at files the build no longer writes —
-the build warns and prints the map to paste in. The other three stub filenames
-are unchanged.
+Stubs for the dev-only modules are emitted as throwing functions rather than
+classes. The stubbed names mix constructors (`new Database()`) with plain calls
+(`createServer()`), and only a function reports the intended message under
+both — a class invoked without `new` reports "Class constructor cannot be
+invoked without 'new'" instead.

--- a/.changeset/shared-deploy-build-helpers.md
+++ b/.changeset/shared-deploy-build-helpers.md
@@ -1,0 +1,32 @@
+---
+'@guren/plugin-cloudflare': patch
+'@guren/plugin-lambda': patch
+'@guren/plugin-vercel': patch
+'@guren/core': minor
+---
+
+Share the deploy plugins' build-time helpers through `@guren/core/internal/deploy-build`
+
+The Cloudflare, Lambda, and Vercel plugins each carried their own copy of the
+manifest and path helpers, and Cloudflare and Lambda separately listed the
+dev-only modules a deployed bundle has to stub. That list describes the
+framework's own module graph, so keeping it in two places had already let the
+copies drift.
+
+Three behaviour fixes fall out of the plugins now sharing one implementation:
+
+- `buildVercelOutput` gained the output-directory guard it never had. It
+  deletes `outputDir` before writing, so pointing it at the project previously
+  deleted the source tree.
+- `buildCloudflareOutput` and `buildVercelOutput` no longer accept the
+  filesystem root as `outputDir`. The old check compared strings, and `out + sep`
+  is `//` at the root, which no absolute path is prefixed by.
+- `buildCloudflareOutput` now honours a custom `publicDir` when reading the
+  client manifest instead of always looking under `<root>/public`.
+
+Cloudflare's generated stub filenames are now derived from the module
+specifier, so `stub-mcp-server.js` and `stub-mcp-transport.js` are written
+under their full specifier-derived names. An existing `wrangler.jsonc` keeps
+its old `alias` values, which now point at files the build no longer writes —
+the build warns and prints the map to paste in. The other three stub filenames
+are unchanged.

--- a/contributing/api-stability.md
+++ b/contributing/api-stability.md
@@ -46,6 +46,9 @@ Internal APIs carry no stability guarantee. They may change or disappear in any 
 - Being accessible only via deep imports (e.g., `@guren/server/internal`, `@guren/orm/src/utils`)
 - Residing in files prefixed with `_` or directories named `internal`
 
+Current internal subpaths:
+- `@guren/core/internal/deploy-build` -- build-time helpers the official deploy plugins share (manifest and path resolution, the output-directory guard, and the list of dev-only modules a deployed bundle must stub). Exists to keep one copy of knowledge about the framework's own module graph, not as an extension point.
+
 ## How to Determine Stability
 
 Use this decision tree:

--- a/contributing/api-stability.md
+++ b/contributing/api-stability.md
@@ -46,9 +46,6 @@ Internal APIs carry no stability guarantee. They may change or disappear in any 
 - Being accessible only via deep imports (e.g., `@guren/server/internal`, `@guren/orm/src/utils`)
 - Residing in files prefixed with `_` or directories named `internal`
 
-Current internal subpaths:
-- `@guren/core/internal/deploy-build` -- build-time helpers the official deploy plugins share (manifest and path resolution, the output-directory guard, and the list of dev-only modules a deployed bundle must stub). Exists to keep one copy of knowledge about the framework's own module graph, not as an extension point.
-
 ## How to Determine Stability
 
 Use this decision tree:

--- a/packages/cli/src/plugin-manifest.ts
+++ b/packages/cli/src/plugin-manifest.ts
@@ -116,6 +116,10 @@ export async function readInstalledPluginManifests(
  * canonical (symlink-resolved) path, plus the non-existent tail rejoined
  * onto it. Lets callers realpath-validate a path that doesn't exist yet
  * (e.g. a publish target about to be created).
+ *
+ * A sibling of `realpathOfNearestExisting` in `@guren/core`'s internal
+ * deploy-build module, kept as a copy because that module cannot import cli.
+ * Keep the two in step, especially the ENOENT-only walk-up.
  */
 async function realpathNearestExisting(candidate: string): Promise<string> {
   const tail: string[] = []

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,10 @@
     "./redis": {
       "types": "./dist/redis.d.ts",
       "default": "./dist/redis.js"
+    },
+    "./internal/deploy-build": {
+      "types": "./dist/internal/deploy-build.d.ts",
+      "default": "./dist/internal/deploy-build.js"
     }
   },
   "bin": {

--- a/packages/core/src/internal/deploy-build.test.ts
+++ b/packages/core/src/internal/deploy-build.test.ts
@@ -7,10 +7,10 @@ import {
   assertOutputDirOutsideRoot,
   DEV_ONLY_MODULES,
   importSpecifier,
-  loadManifest,
   MCP_SDK_SUBPATH_PREFIX,
+  readManifest,
   resolvePathLike,
-  ssrManifestRelativePath,
+  ssrRuntimePaths,
 } from './deploy-build'
 
 describe('assertOutputDirOutsideRoot', () => {
@@ -99,7 +99,7 @@ describe('importSpecifier', () => {
   })
 })
 
-describe('loadManifest', () => {
+describe('readManifest', () => {
   let dir: string
 
   beforeEach(() => {
@@ -110,11 +110,12 @@ describe('loadManifest', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  test('should return the first manifest that exists', () => {
+  test('should return the first manifest that exists, and its path', () => {
     writeFileSync(join(dir, 'second.json'), JSON.stringify({ 'a.tsx': { file: 'a.js' } }))
 
-    expect(loadManifest(join(dir, 'missing.json'), join(dir, 'second.json'))).toEqual({
-      'a.tsx': { file: 'a.js' },
+    expect(readManifest(join(dir, 'missing.json'), join(dir, 'second.json'))).toEqual({
+      manifest: { 'a.tsx': { file: 'a.js' } },
+      path: join(dir, 'second.json'),
     })
   })
 
@@ -122,12 +123,41 @@ describe('loadManifest', () => {
     writeFileSync(join(dir, 'broken.json'), '{ not json')
     writeFileSync(join(dir, 'good.json'), JSON.stringify({ 'b.tsx': { file: 'b.js' } }))
 
-    expect(loadManifest(join(dir, 'broken.json'), join(dir, 'good.json'))).toEqual({
-      'b.tsx': { file: 'b.js' },
+    expect(readManifest(join(dir, 'broken.json'), join(dir, 'good.json'))?.path).toBe(
+      join(dir, 'good.json'),
+    )
+  })
+
+  test('should return undefined when nothing is found', () => {
+    expect(readManifest(join(dir, 'a.json'), join(dir, 'b.json'))).toBeUndefined()
+  })
+})
+
+describe('ssrRuntimePaths', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'guren-ssr-paths-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  test('should place the entry and manifest under the caller prefix', () => {
+    mkdirSync(join(dir, '.vite'), { recursive: true })
+    writeFileSync(
+      join(dir, '.vite/manifest.json'),
+      JSON.stringify({ 'resources/js/ssr.tsx': { file: 'ssr.js' } }),
+    )
+
+    expect(ssrRuntimePaths(dir, join(dir, 'ssr.js'), './.guren/ssr')).toEqual({
+      entry: './.guren/ssr/ssr.js',
+      manifest: './.guren/ssr/.vite/manifest.json',
     })
   })
 
-  test('should report the path it actually parsed, not the first that exists', () => {
+  test('should name the manifest it actually parsed, not the first that exists', () => {
     // A malformed .vite/manifest.json alongside a valid flat one: naming the
     // file that merely exists publishes the path to the one that was skipped.
     mkdirSync(join(dir, '.vite'), { recursive: true })
@@ -137,15 +167,20 @@ describe('loadManifest', () => {
       JSON.stringify({ 'resources/js/ssr.tsx': { file: 'ssr.js' } }),
     )
 
-    expect(ssrManifestRelativePath(dir, './.guren/ssr')).toBe('./.guren/ssr/manifest.json')
+    expect(ssrRuntimePaths(dir, join(dir, 'ssr.js'), './.guren/ssr').manifest).toBe(
+      './.guren/ssr/manifest.json',
+    )
   })
 
-  test('should return undefined when no manifest parses', () => {
-    expect(ssrManifestRelativePath(dir, './.guren/ssr')).toBeUndefined()
-  })
+  test('should omit the manifest when none parses', () => {
+    mkdirSync(join(dir, '.vite'), { recursive: true })
+    writeFileSync(join(dir, '.vite/manifest.json'), '{ not json')
+    writeFileSync(join(dir, 'manifest.json'), 'also { not json')
 
-  test('should return undefined when nothing is found', () => {
-    expect(loadManifest(join(dir, 'a.json'), join(dir, 'b.json'))).toBeUndefined()
+    expect(ssrRuntimePaths(dir, join(dir, 'ssr.js'), './.guren/ssr')).toEqual({
+      entry: './.guren/ssr/ssr.js',
+      manifest: undefined,
+    })
   })
 })
 

--- a/packages/core/src/internal/deploy-build.test.ts
+++ b/packages/core/src/internal/deploy-build.test.ts
@@ -1,0 +1,168 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  assertOutputDirOutsideRoot,
+  DEV_ONLY_MODULES,
+  importSpecifier,
+  loadManifest,
+  MCP_SDK_SUBPATH_PREFIX,
+  resolvePathLike,
+} from './deploy-build'
+
+describe('assertOutputDirOutsideRoot', () => {
+  test('should accept an output directory below the app root', () => {
+    expect(() => assertOutputDirOutsideRoot('/app/.lambda', '/app', 'Test build')).not.toThrow()
+  })
+
+  test('should accept an output directory beside the app root', () => {
+    expect(() => assertOutputDirOutsideRoot('/tmp/out', '/app', 'Test build')).not.toThrow()
+  })
+
+  test('should reject the app root itself', () => {
+    expect(() => assertOutputDirOutsideRoot('/app', '/app', 'Test build')).toThrow(
+      /never the root itself or a parent of it/,
+    )
+  })
+
+  test('should reject a parent of the app root', () => {
+    expect(() => assertOutputDirOutsideRoot('/app', '/app/nested', 'Test build')).toThrow(
+      /never the root itself or a parent of it/,
+    )
+  })
+
+  test('should reject the filesystem root', () => {
+    // The reason this helper compares with `relative`: `out + sep` is "//"
+    // here, so a string-prefix containment test would accept it.
+    expect(() => assertOutputDirOutsideRoot('/', '/app', 'Test build')).toThrow(
+      /never the root itself or a parent of it/,
+    )
+  })
+
+  test('should name the calling platform in the message', () => {
+    expect(() => assertOutputDirOutsideRoot('/', '/app', 'Cloudflare build')).toThrow(
+      /^Cloudflare build:/,
+    )
+  })
+})
+
+describe('importSpecifier', () => {
+  test('should produce an explicitly relative POSIX specifier', () => {
+    expect(importSpecifier('/app/.lambda', '/app/src/lambda.ts', 'Test build')).toBe(
+      '../src/lambda.ts',
+    )
+  })
+
+  test('should prefix a same-directory target with ./', () => {
+    expect(importSpecifier('/app/out', '/app/out/handler.js', 'Test build')).toBe('./handler.js')
+  })
+})
+
+describe('loadManifest', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'guren-deploy-build-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  test('should return the first manifest that exists', () => {
+    writeFileSync(join(dir, 'second.json'), JSON.stringify({ 'a.tsx': { file: 'a.js' } }))
+
+    expect(loadManifest(join(dir, 'missing.json'), join(dir, 'second.json'))).toEqual({
+      'a.tsx': { file: 'a.js' },
+    })
+  })
+
+  test('should skip a malformed manifest rather than throw', () => {
+    writeFileSync(join(dir, 'broken.json'), '{ not json')
+    writeFileSync(join(dir, 'good.json'), JSON.stringify({ 'b.tsx': { file: 'b.js' } }))
+
+    expect(loadManifest(join(dir, 'broken.json'), join(dir, 'good.json'))).toEqual({
+      'b.tsx': { file: 'b.js' },
+    })
+  })
+
+  test('should return undefined when nothing is found', () => {
+    expect(loadManifest(join(dir, 'a.json'), join(dir, 'b.json'))).toBeUndefined()
+  })
+})
+
+describe('resolvePathLike', () => {
+  test('should accept a file URL', () => {
+    expect(resolvePathLike(new URL('file:///app/src'))).toBe('/app/src')
+  })
+
+  test('should resolve a relative string against the cwd', () => {
+    expect(resolvePathLike('src')).toBe(join(process.cwd(), 'src'))
+  })
+})
+
+describe('DEV_ONLY_MODULES', () => {
+  test('should list every MCP SDK entry under the documented subpath prefix', () => {
+    const sdkEntries = DEV_ONLY_MODULES.filter((module) =>
+      module.specifier.startsWith('@modelcontextprotocol/'),
+    )
+
+    expect(sdkEntries.length).toBeGreaterThan(0)
+    for (const entry of sdkEntries) {
+      expect(entry.specifier.startsWith(MCP_SDK_SUBPATH_PREFIX)).toBe(true)
+      // A package-name alias does not cover subpaths, so a bare package entry
+      // would silently leave the real SDK in a Workers bundle.
+      expect(entry.specifier).not.toBe(MCP_SDK_SUBPATH_PREFIX.replace(/\/$/, ''))
+    }
+  })
+
+  test('should not list the same specifier twice', () => {
+    const specifiers = DEV_ONLY_MODULES.map((module) => module.specifier)
+    expect(new Set(specifiers).size).toBe(specifiers.length)
+  })
+
+  test('should give every destructured module its export names', () => {
+    // `@guren/cli` is read only through namespace property access, so an empty
+    // module suffices; everything else is destructured and needs its names, or
+    // the bundle fails with "no matching export".
+    for (const module of DEV_ONLY_MODULES) {
+      if (module.specifier === '@guren/cli') {
+        expect(module.exportNames).toEqual([])
+      } else {
+        expect(module.exportNames.length).toBeGreaterThan(0)
+      }
+    }
+  })
+})
+
+describe('the module graph this list describes', () => {
+  const repoRoot = join(import.meta.dir, '../../../..')
+
+  function importersOf(specifier: string): string {
+    const { stdout } = Bun.spawnSync({
+      cmd: ['git', 'grep', '-l', '--fixed-strings', specifier, '--', 'packages/server/src', 'packages/orm/src'],
+      cwd: repoRoot,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    return stdout.toString().trim()
+  }
+
+  // Checked per entry, not as one alternation: the point of the list is to
+  // track @guren/core's own dev-only imports, and a single matching entry
+  // would otherwise mask every stale one. A framework change that drops an
+  // import should surface here rather than as dead weight in every plugin.
+  test.each(DEV_ONLY_MODULES.map((module) => module.specifier))(
+    'should still be imported by the framework: %s',
+    (specifier) => {
+      expect(importersOf(specifier)).not.toBe('')
+    },
+  )
+
+  test('should detect a specifier the framework does not import', () => {
+    // Guards the check above: without this, a `git grep` that silently stopped
+    // working would let every case pass.
+    expect(importersOf('@guren/not-a-real-dev-only-module')).toBe('')
+  })
+})

--- a/packages/core/src/internal/deploy-build.test.ts
+++ b/packages/core/src/internal/deploy-build.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { isBuiltin } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -28,6 +29,15 @@ describe('assertOutputDirOutsideRoot', () => {
 
   test('should reject a parent of the app root', () => {
     expect(() => assertOutputDirOutsideRoot('/app', '/app/nested', 'Test build')).toThrow(
+      /never the root itself or a parent of it/,
+    )
+  })
+
+  test('should reject a root inside out whose name begins with ..', () => {
+    // `relative` returns "..-source" here. Testing `startsWith('..')` reads
+    // that as an escape and lets the delete run over a directory that really
+    // is inside the output directory.
+    expect(() => assertOutputDirOutsideRoot('/tmp/app', '/tmp/app/..-source', 'Test build')).toThrow(
       /never the root itself or a parent of it/,
     )
   })
@@ -108,30 +118,34 @@ describe('DEV_ONLY_MODULES', () => {
       module.specifier.startsWith('@modelcontextprotocol/'),
     )
 
+    // A package-name alias does not cover subpaths, so a bare package entry
+    // would silently leave the real SDK in a Workers bundle.
     expect(sdkEntries.length).toBeGreaterThan(0)
     for (const entry of sdkEntries) {
       expect(entry.specifier.startsWith(MCP_SDK_SUBPATH_PREFIX)).toBe(true)
-      // A package-name alias does not cover subpaths, so a bare package entry
-      // would silently leave the real SDK in a Workers bundle.
-      expect(entry.specifier).not.toBe(MCP_SDK_SUBPATH_PREFIX.replace(/\/$/, ''))
     }
   })
+})
 
-  test('should not list the same specifier twice', () => {
-    const specifiers = DEV_ONLY_MODULES.map((module) => module.specifier)
-    expect(new Set(specifiers).size).toBe(specifiers.length)
-  })
+describe('the built artifact', () => {
+  test('should import nothing but node builtins', () => {
+    // The module documents this, and the plugins rely on it: importing it must
+    // not drag the framework runtime into a developer's build. It holds today
+    // only because this tsup entry happens to share no code with core's
+    // others — the day one does, ESM splitting emits a chunk and the property
+    // disappears with nothing else to notice.
+    const built = join(import.meta.dir, '../../dist/internal/deploy-build.js')
+    if (!existsSync(built)) {
+      throw new Error(`Expected ${built}; run \`bun run build core\` before this test.`)
+    }
 
-  test('should give every destructured module its export names', () => {
-    // `@guren/cli` is read only through namespace property access, so an empty
-    // module suffices; everything else is destructured and needs its names, or
-    // the bundle fails with "no matching export".
-    for (const module of DEV_ONLY_MODULES) {
-      if (module.specifier === '@guren/cli') {
-        expect(module.exportNames).toEqual([])
-      } else {
-        expect(module.exportNames.length).toBeGreaterThan(0)
-      }
+    const specifiers = [...readFileSync(built, 'utf8').matchAll(/from\s*["']([^"']+)["']/g)].map(
+      ([, specifier]) => specifier,
+    )
+
+    expect(specifiers.length).toBeGreaterThan(0)
+    for (const specifier of specifiers) {
+      expect(isBuiltin(specifier)).toBe(true)
     }
   })
 })
@@ -139,9 +153,24 @@ describe('DEV_ONLY_MODULES', () => {
 describe('the module graph this list describes', () => {
   const repoRoot = join(import.meta.dir, '../../../..')
 
+  /**
+   * Files that actually import `specifier`, matched on the import form rather
+   * than the bare string: `vite` alone also hits a `@vite-ignore` comment and
+   * an identifier, which would leave this green after the real import was
+   * deleted — the exact drift the check exists to catch.
+   */
   function importersOf(specifier: string): string {
+    const escaped = specifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     const { stdout } = Bun.spawnSync({
-      cmd: ['git', 'grep', '-l', '--fixed-strings', specifier, '--', 'packages/server/src', 'packages/orm/src'],
+      cmd: [
+        'git',
+        'grep',
+        '-lE',
+        `(from|import\\(|require\\()[[:space:]]*['"]${escaped}['"]`,
+        '--',
+        'packages/server/src',
+        'packages/orm/src',
+      ],
       cwd: repoRoot,
       stdout: 'pipe',
       stderr: 'pipe',
@@ -149,10 +178,9 @@ describe('the module graph this list describes', () => {
     return stdout.toString().trim()
   }
 
-  // Checked per entry, not as one alternation: the point of the list is to
-  // track @guren/core's own dev-only imports, and a single matching entry
-  // would otherwise mask every stale one. A framework change that drops an
-  // import should surface here rather than as dead weight in every plugin.
+  // Checked per entry, not as one alternation: a single matching entry would
+  // otherwise mask every stale one. A framework change that drops one of these
+  // imports should surface here rather than as dead weight in every plugin.
   test.each(DEV_ONLY_MODULES.map((module) => module.specifier))(
     'should still be imported by the framework: %s',
     (specifier) => {
@@ -160,9 +188,30 @@ describe('the module graph this list describes', () => {
     },
   )
 
-  test('should detect a specifier the framework does not import', () => {
-    // Guards the check above: without this, a `git grep` that silently stopped
-    // working would let every case pass.
+  test('should not match a specifier that is merely mentioned', () => {
+    // Guards the check above two ways: a grep that silently stopped working
+    // would let every case pass, and a substring match would accept a module
+    // the framework only names in a comment.
     expect(importersOf('@guren/not-a-real-dev-only-module')).toBe('')
+    expect(importersOf('vit')).toBe('')
+  })
+
+  test.each(
+    DEV_ONLY_MODULES.filter((module) => module.exportNames.length > 0).map((module) => [
+      module.specifier,
+      module.exportNames,
+    ] as const),
+  )('should name exports the importer actually destructures: %s', (specifier, exportNames) => {
+    // A wrong name here still renders a stub, and only fails at bundle time
+    // with "no matching export" — so check the names against the real importer.
+    const found = importersOf(specifier)
+    expect(found).not.toBe('')
+
+    const files = found.split('\n')
+    const source = files.map((file) => readFileSync(join(repoRoot, file), 'utf8')).join('\n')
+
+    for (const name of exportNames) {
+      expect(source).toContain(name)
+    }
   })
 })

--- a/packages/core/src/internal/deploy-build.test.ts
+++ b/packages/core/src/internal/deploy-build.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { isBuiltin } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -10,6 +10,7 @@ import {
   loadManifest,
   MCP_SDK_SUBPATH_PREFIX,
   resolvePathLike,
+  ssrManifestRelativePath,
 } from './deploy-build'
 
 describe('assertOutputDirOutsideRoot', () => {
@@ -48,6 +49,35 @@ describe('assertOutputDirOutsideRoot', () => {
     expect(() => assertOutputDirOutsideRoot('/', '/app', 'Test build')).toThrow(
       /never the root itself or a parent of it/,
     )
+  })
+
+  test('should reject an outputDir that reaches the app root through a symlink', () => {
+    // The delete follows symlinks, so a lexical comparison is not enough. On
+    // macOS /tmp is itself a symlink to /private/tmp, so this is ordinary.
+    const base = realpathSync(mkdtempSync(join(tmpdir(), 'guren-symlink-')))
+    try {
+      mkdirSync(join(base, 'real/app'), { recursive: true })
+      symlinkSync(join(base, 'real'), join(base, 'link'))
+
+      expect(() =>
+        assertOutputDirOutsideRoot(join(base, 'link/app'), join(base, 'real/app'), 'Test build'),
+      ).toThrow(/never the root itself or a parent of it/)
+    } finally {
+      rmSync(base, { recursive: true, force: true })
+    }
+  })
+
+  test('should still accept an output directory that does not exist yet', () => {
+    const base = realpathSync(mkdtempSync(join(tmpdir(), 'guren-symlink-')))
+    try {
+      mkdirSync(join(base, 'app'), { recursive: true })
+
+      expect(() =>
+        assertOutputDirOutsideRoot(join(base, 'app/.out'), join(base, 'app'), 'Test build'),
+      ).not.toThrow()
+    } finally {
+      rmSync(base, { recursive: true, force: true })
+    }
   })
 
   test('should name the calling platform in the message', () => {
@@ -97,6 +127,23 @@ describe('loadManifest', () => {
     })
   })
 
+  test('should report the path it actually parsed, not the first that exists', () => {
+    // A malformed .vite/manifest.json alongside a valid flat one: naming the
+    // file that merely exists publishes the path to the one that was skipped.
+    mkdirSync(join(dir, '.vite'), { recursive: true })
+    writeFileSync(join(dir, '.vite/manifest.json'), '{ not json')
+    writeFileSync(
+      join(dir, 'manifest.json'),
+      JSON.stringify({ 'resources/js/ssr.tsx': { file: 'ssr.js' } }),
+    )
+
+    expect(ssrManifestRelativePath(dir, './.guren/ssr')).toBe('./.guren/ssr/manifest.json')
+  })
+
+  test('should return undefined when no manifest parses', () => {
+    expect(ssrManifestRelativePath(dir, './.guren/ssr')).toBeUndefined()
+  })
+
   test('should return undefined when nothing is found', () => {
     expect(loadManifest(join(dir, 'a.json'), join(dir, 'b.json'))).toBeUndefined()
   })
@@ -139,9 +186,16 @@ describe('the built artifact', () => {
       throw new Error(`Expected ${built}; run \`bun run build core\` before this test.`)
     }
 
-    const specifiers = [...readFileSync(built, 'utf8').matchAll(/from\s*["']([^"']+)["']/g)].map(
-      ([, specifier]) => specifier,
-    )
+    // Every import form, not just `from "..."`: a side-effect import or a
+    // dynamic `import()` of a bundled chunk would otherwise slip past while the
+    // builtin `from` imports kept the assertion green.
+    const source = readFileSync(built, 'utf8')
+    const specifiers = [
+      ...source.matchAll(/from\s*["']([^"']+)["']/g),
+      ...source.matchAll(/(?:^|[^.\w])import\s*["']([^"']+)["']/g),
+      ...source.matchAll(/\bimport\s*\(\s*["']([^"']+)["']/g),
+      ...source.matchAll(/\brequire\s*\(\s*["']([^"']+)["']/g),
+    ].map(([, specifier]) => specifier)
 
     expect(specifiers.length).toBeGreaterThan(0)
     for (const specifier of specifiers) {

--- a/packages/core/src/internal/deploy-build.ts
+++ b/packages/core/src/internal/deploy-build.ts
@@ -21,8 +21,8 @@
  * is fatal, and how an SSR bundle's renderer export is verified are all
  * per-plugin by design.
  */
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs'
-import { isAbsolute, relative, resolve, sep } from 'node:path'
+import { cpSync, existsSync, mkdirSync, readFileSync, realpathSync, rmSync } from 'node:fs'
+import { basename, dirname, isAbsolute, relative, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 export type PathLike = string | URL
@@ -45,13 +45,25 @@ export function resolvePathLike(value: PathLike): string {
  * missing manifest means for its platform.
  */
 export function loadManifest(...paths: string[]): Manifest | undefined {
+  return readManifest(...paths)?.manifest
+}
+
+/**
+ * As `loadManifest`, but also reports which path was read. A caller that
+ * publishes the manifest location to the runtime has to name the file that was
+ * actually parsed: testing which one *exists* picks the malformed one that
+ * `loadManifest` just skipped.
+ */
+export function readManifest(
+  ...paths: string[]
+): { manifest: Manifest; path: string } | undefined {
   for (const path of paths) {
     if (!existsSync(path)) {
       continue
     }
 
     try {
-      return JSON.parse(readFileSync(path, 'utf8')) as Manifest
+      return { manifest: JSON.parse(readFileSync(path, 'utf8')) as Manifest, path }
     } catch {
       continue
     }
@@ -66,26 +78,50 @@ export function manifestPaths(dir: string): [string, string] {
 }
 
 /**
+ * Resolve symlinks in the parts of `path` that exist, keeping the trailing
+ * components that do not. `realpathSync` throws on a path that is not there
+ * yet, and an output directory usually is not on a first build.
+ */
+function realpathOfNearestExisting(path: string): string {
+  let existing = path
+  const missing: string[] = []
+
+  while (!existsSync(existing)) {
+    const parent = dirname(existing)
+    if (parent === existing) {
+      return path
+    }
+    missing.unshift(basename(existing))
+    existing = parent
+  }
+
+  return resolve(realpathSync(existing), ...missing)
+}
+
+/**
  * Throw unless `out` is safe to delete: it must be neither the app root nor a
  * directory containing it.
  *
- * Containment is decided with `relative` rather than a string prefix because
- * `out + sep` is `//` at the filesystem root, which no absolute path is
- * prefixed by — a prefix test lets `outputDir: '/'` through.
+ * Both paths are resolved through their symlinks first, because the delete
+ * that follows does too. Comparing lexically accepts `outputDir` values that
+ * reach the app root the long way — on macOS `/tmp` is itself a symlink to
+ * `/private/tmp`, so this is not a contrived case.
  *
- * The escape test is `'..'` exactly or a `'../'` prefix, not `startsWith('..')`:
- * a directory legitimately named `..-source` inside `out` yields the relative
- * path `..-source`, which the looser test would read as an escape and wave
- * through.
+ * Containment is then decided with `relative` rather than a string prefix
+ * because `out + sep` is `//` at the filesystem root, which no absolute path
+ * is prefixed by — a prefix test lets `outputDir: '/'` through. The escape
+ * test is `'..'` exactly or a `'../'` prefix, not `startsWith('..')`: a
+ * directory legitimately named `..-source` inside `out` yields the relative
+ * path `..-source`, which the looser test would read as an escape.
  *
- * Exported separately from `resetOutputDir` so it can be exercised without a
- * filesystem, but plugins should call `resetOutputDir` — it is what keeps the
- * delete from being reachable on its own.
+ * Exported separately from `resetOutputDir` so a caller can validate the
+ * option early and delete later, but the delete itself should always go
+ * through `resetOutputDir`.
  *
  * @param label Platform name for the error message, e.g. `'Lambda build'`.
  */
 export function assertOutputDirOutsideRoot(out: string, root: string, label: string): void {
-  const outToRoot = relative(out, root)
+  const outToRoot = relative(realpathOfNearestExisting(out), realpathOfNearestExisting(root))
   const rootIsInsideOut =
     outToRoot !== '..' && !outToRoot.startsWith(`..${sep}`) && !isAbsolute(outToRoot)
 
@@ -200,13 +236,20 @@ export function resolveSsrEntryFile(
 
 /**
  * Path of the SSR manifest that `resolveSsrEntryFile` actually read, relative
- * to the function root, for platforms that pass it to the runtime. Both Vite
- * layouts occur in the wild, so this must follow the fallback rather than
- * assume `.vite/`.
+ * to the function root, for platforms that pass it to the runtime.
+ *
+ * Derived from the file that parsed rather than the first one that exists:
+ * both Vite layouts occur in the wild, and a malformed `.vite/manifest.json`
+ * alongside a valid flat one would otherwise publish the path to the file that
+ * was skipped.
  */
-export function ssrManifestRelativePath(ssrDir: string, prefix: string): string {
-  const [nested] = manifestPaths(ssrDir)
-  return existsSync(nested) ? `${prefix}/.vite/manifest.json` : `${prefix}/manifest.json`
+export function ssrManifestRelativePath(ssrDir: string, prefix: string): string | undefined {
+  const read = readManifest(...manifestPaths(ssrDir))
+  if (!read) {
+    return undefined
+  }
+
+  return `${prefix}/${relative(ssrDir, read.path).split(sep).join('/')}`
 }
 
 /**

--- a/packages/core/src/internal/deploy-build.ts
+++ b/packages/core/src/internal/deploy-build.ts
@@ -1,0 +1,190 @@
+/**
+ * Build-time helpers shared by the deploy plugins (`@guren/plugin-cloudflare`,
+ * `@guren/plugin-lambda`, `@guren/plugin-vercel`).
+ *
+ * Internal by the rules in `contributing/api-stability.md`: reachable only
+ * through a deep import under `internal/`, never re-exported from
+ * `@guren/core`'s index. No stability guarantee — it exists so the three
+ * plugins stop carrying three copies of the same knowledge, not as a public
+ * extension point.
+ *
+ * Deliberately imports nothing from the framework itself: a plugin's build
+ * step should not drag the runtime into a developer's build process. Only
+ * `node:` builtins belong here.
+ *
+ * What does *not* belong here: anything a platform legitimately decides for
+ * itself. The stub *rendering* (Workers needs a file per alias, Lambda needs
+ * inline source for its bundler plugin), the message text naming a platform
+ * and its replacement API, whether a missing `build` script is fatal, and how
+ * an SSR bundle's renderer export is verified are all per-plugin by design.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import { isAbsolute, relative, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export type PathLike = string | URL
+
+export type ManifestEntry = {
+  file?: string
+  css?: string[]
+}
+
+export type Manifest = Record<string, ManifestEntry>
+
+/** Accept both the `new URL('...', import.meta.url)` and plain-string forms. */
+export function resolvePathLike(value: PathLike): string {
+  return value instanceof URL ? fileURLToPath(value) : resolve(String(value))
+}
+
+/**
+ * Read the first manifest that exists, tolerating both Vite layouts
+ * (`.vite/manifest.json` and the flat `manifest.json` older configs emit).
+ * A malformed file is skipped rather than fatal — the caller decides what a
+ * missing manifest means for its platform.
+ */
+export function loadManifest(...paths: string[]): Manifest | undefined {
+  for (const path of paths) {
+    if (!existsSync(path)) {
+      continue
+    }
+
+    try {
+      return JSON.parse(readFileSync(path, 'utf8')) as Manifest
+    } catch {
+      continue
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Reject an output directory that is the app root or contains it. Every plugin
+ * deletes its output directory on each build, so this is the guard between a
+ * mistyped option and `rm -rf` over a project.
+ *
+ * Compared with `relative` rather than a string prefix: `out + sep` is `//` at
+ * the filesystem root, which no absolute path is prefixed by, so a prefix test
+ * lets `outputDir: '/'` through.
+ *
+ * @param label Platform name for the error message, e.g. `'Lambda build'`.
+ */
+export function assertOutputDirOutsideRoot(out: string, root: string, label: string): void {
+  const outToRoot = relative(out, root)
+  if (outToRoot === '' || (!outToRoot.startsWith('..') && !isAbsolute(outToRoot))) {
+    throw new Error(
+      `${label}: outputDir (${out}) must be a directory outside or below the app root, never the root itself or a parent of it — it is deleted on every build.`,
+    )
+  }
+}
+
+/**
+ * Relative specifier for importing `target` from a module written into
+ * `fromDir`, in POSIX form so the emitted source is platform-agnostic.
+ *
+ * @param label Platform name for the error message, e.g. `'Lambda build'`.
+ */
+export function importSpecifier(fromDir: string, target: string, label: string): string {
+  const rel = relative(fromDir, target)
+  if (isAbsolute(rel)) {
+    throw new Error(
+      `${label}: ${target} cannot be imported relative to ${fromDir} (different drive or root?). Keep the app, SSR output, and outputDir on the same volume.`,
+    )
+  }
+
+  const specifier = rel.split(sep).join('/')
+  return specifier.startsWith('.') ? specifier : `./${specifier}`
+}
+
+export interface ClientAssetEnv {
+  entry?: string
+  styles?: string
+}
+
+/**
+ * Locate the built client entry and its CSS in the Vite client manifest, as
+ * the `/assets/`-prefixed URLs the Inertia head expects.
+ *
+ * Takes the public directory rather than the app root so a caller passing a
+ * custom `publicDir` is honoured.
+ *
+ * @param label Platform name for the warning message, e.g. `'Lambda build'`.
+ */
+export function resolveClientAssetEnv(
+  publicDir: string,
+  clientEntryKey: string,
+  label: string,
+): ClientAssetEnv {
+  const manifest = loadManifest(
+    resolve(publicDir, 'assets/.vite/manifest.json'),
+    resolve(publicDir, 'assets/manifest.json'),
+  )
+
+  const entry = manifest?.[clientEntryKey]
+  if (!entry?.file) {
+    console.warn(
+      `${label}: no client manifest entry for "${clientEntryKey}"; GUREN_INERTIA_ENTRY will not be set.`,
+    )
+    return {}
+  }
+
+  return {
+    entry: `/assets/${entry.file}`,
+    styles: entry.css?.length ? entry.css.map((file) => `/assets/${file}`).join(',') : undefined,
+  }
+}
+
+/** What a dev-only module is needed for, so a plugin can word its own message. */
+export type DevOnlyModuleKind = 'sqlite' | 'vite' | 'mcp'
+
+export interface DevOnlyModule {
+  readonly specifier: string
+  readonly kind: DevOnlyModuleKind
+  /**
+   * Names the importing code destructures. A stub must declare every one of
+   * them: an empty module fails the bundle with "no matching export" rather
+   * than at runtime. Empty means the module is only ever read through
+   * namespace property access, so an empty module suffices.
+   */
+  readonly exportNames: readonly string[]
+}
+
+/**
+ * Modules in every Guren app's graph that cannot run off Bun, reached only
+ * through dev-time branches. This list describes `@guren/core`'s own imports,
+ * which is why it lives here: it changes when the framework's module graph
+ * changes, and a deploy plugin that misses an entry ships a broken bundle.
+ *
+ * Bundlers follow these imports even when they are dynamic, so without stubs
+ * the build either fails to resolve them or ships megabytes of dev tooling.
+ *
+ * - `sqlite` — the local sqlite ORM factory, opposite the platform's own
+ *   database branch in `config/database.ts`.
+ * - `vite` — the dev asset server `Application` starts when serving locally.
+ * - `mcp` — the opt-in MCP endpoint's lazy imports, which drag the CLI
+ *   generators (and Babel) plus the MCP SDK in behind them.
+ */
+export const DEV_ONLY_MODULES: readonly DevOnlyModule[] = [
+  { specifier: 'bun:sqlite', kind: 'sqlite', exportNames: ['Database'] },
+  { specifier: 'vite', kind: 'vite', exportNames: ['createServer'] },
+  { specifier: '@guren/cli', kind: 'mcp', exportNames: [] },
+  {
+    specifier: '@modelcontextprotocol/sdk/server/mcp.js',
+    kind: 'mcp',
+    exportNames: ['McpServer', 'ResourceTemplate'],
+  },
+  {
+    specifier: '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js',
+    kind: 'mcp',
+    exportNames: ['WebStandardStreamableHTTPServerTransport'],
+  },
+]
+
+/**
+ * The MCP SDK is only ever reached through subpaths, and a bundler alias on a
+ * package name does not cover them — which is why `DEV_ONLY_MODULES` lists
+ * each one. A platform whose aliasing supports prefixes should also route
+ * unlisted subpaths under this prefix to a stub, so a new subpath added
+ * upstream cannot pull the real SDK into a deployed bundle.
+ */
+export const MCP_SDK_SUBPATH_PREFIX = '@modelcontextprotocol/sdk/'

--- a/packages/core/src/internal/deploy-build.ts
+++ b/packages/core/src/internal/deploy-build.ts
@@ -10,15 +10,18 @@
  *
  * Deliberately imports nothing from the framework itself: a plugin's build
  * step should not drag the runtime into a developer's build process. Only
- * `node:` builtins belong here.
+ * `node:` builtins belong here, and `deploy-build.test.ts` asserts it of the
+ * built artifact — the property would otherwise break silently the day tsup
+ * splits a shared chunk out of this entry.
  *
  * What does *not* belong here: anything a platform legitimately decides for
- * itself. The stub *rendering* (Workers needs a file per alias, Lambda needs
- * inline source for its bundler plugin), the message text naming a platform
- * and its replacement API, whether a missing `build` script is fatal, and how
- * an SSR bundle's renderer export is verified are all per-plugin by design.
+ * itself. The message naming a platform and its replacement API, where a
+ * rendered stub is delivered (Workers resolves an alias to a file on disk,
+ * Lambda hands source to its bundler plugin), whether a missing `build` script
+ * is fatal, and how an SSR bundle's renderer export is verified are all
+ * per-plugin by design.
  */
-import { existsSync, readFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs'
 import { isAbsolute, relative, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -31,7 +34,6 @@ export type ManifestEntry = {
 
 export type Manifest = Record<string, ManifestEntry>
 
-/** Accept both the `new URL('...', import.meta.url)` and plain-string forms. */
 export function resolvePathLike(value: PathLike): string {
   return value instanceof URL ? fileURLToPath(value) : resolve(String(value))
 }
@@ -58,23 +60,57 @@ export function loadManifest(...paths: string[]): Manifest | undefined {
   return undefined
 }
 
+/** The two layouts `loadManifest` accepts, in preference order. */
+export function manifestPaths(dir: string): [string, string] {
+  return [resolve(dir, '.vite/manifest.json'), resolve(dir, 'manifest.json')]
+}
+
 /**
- * Reject an output directory that is the app root or contains it. Every plugin
- * deletes its output directory on each build, so this is the guard between a
- * mistyped option and `rm -rf` over a project.
+ * Throw unless `out` is safe to delete: it must be neither the app root nor a
+ * directory containing it.
  *
- * Compared with `relative` rather than a string prefix: `out + sep` is `//` at
- * the filesystem root, which no absolute path is prefixed by, so a prefix test
- * lets `outputDir: '/'` through.
+ * Containment is decided with `relative` rather than a string prefix because
+ * `out + sep` is `//` at the filesystem root, which no absolute path is
+ * prefixed by — a prefix test lets `outputDir: '/'` through.
+ *
+ * The escape test is `'..'` exactly or a `'../'` prefix, not `startsWith('..')`:
+ * a directory legitimately named `..-source` inside `out` yields the relative
+ * path `..-source`, which the looser test would read as an escape and wave
+ * through.
+ *
+ * Exported separately from `resetOutputDir` so it can be exercised without a
+ * filesystem, but plugins should call `resetOutputDir` — it is what keeps the
+ * delete from being reachable on its own.
  *
  * @param label Platform name for the error message, e.g. `'Lambda build'`.
  */
 export function assertOutputDirOutsideRoot(out: string, root: string, label: string): void {
   const outToRoot = relative(out, root)
-  if (outToRoot === '' || (!outToRoot.startsWith('..') && !isAbsolute(outToRoot))) {
+  const rootIsInsideOut =
+    outToRoot !== '..' && !outToRoot.startsWith(`..${sep}`) && !isAbsolute(outToRoot)
+
+  if (outToRoot === '' || rootIsInsideOut) {
     throw new Error(
       `${label}: outputDir (${out}) must be a directory outside or below the app root, never the root itself or a parent of it — it is deleted on every build.`,
     )
+  }
+}
+
+/**
+ * Delete the output directory so the build starts from a clean slate, after
+ * checking it is safe to delete.
+ *
+ * The check and the delete are one call on purpose: they were separate
+ * statements in each plugin, and a plugin that had only the delete has already
+ * shipped.
+ *
+ * @param label Platform name for the error message, e.g. `'Lambda build'`.
+ */
+export function resetOutputDir(out: string, root: string, label: string): void {
+  assertOutputDirOutsideRoot(out, root, label)
+
+  if (existsSync(out)) {
+    rmSync(out, { recursive: true, force: true })
   }
 }
 
@@ -115,10 +151,7 @@ export function resolveClientAssetEnv(
   clientEntryKey: string,
   label: string,
 ): ClientAssetEnv {
-  const manifest = loadManifest(
-    resolve(publicDir, 'assets/.vite/manifest.json'),
-    resolve(publicDir, 'assets/manifest.json'),
-  )
+  const manifest = loadManifest(...manifestPaths(resolve(publicDir, 'assets')))
 
   const entry = manifest?.[clientEntryKey]
   if (!entry?.file) {
@@ -131,6 +164,78 @@ export function resolveClientAssetEnv(
   return {
     entry: `/assets/${entry.file}`,
     styles: entry.css?.length ? entry.css.map((file) => `/assets/${file}`).join(',') : undefined,
+  }
+}
+
+/**
+ * Absolute path of the built SSR entry chunk, or undefined when the app has no
+ * SSR build. Verifying that the chunk actually exports a renderer is left to
+ * the caller: the platforms disagree on whether importing it during a build is
+ * acceptable.
+ *
+ * @param label Platform name for the error messages, e.g. `'Lambda build'`.
+ */
+export function resolveSsrEntryFile(
+  ssrDir: string,
+  ssrEntryKey: string,
+  label: string,
+): string | undefined {
+  const manifest = loadManifest(...manifestPaths(ssrDir))
+
+  const entryFile = manifest?.[ssrEntryKey]?.file
+  if (!entryFile) {
+    return undefined
+  }
+
+  const file = resolve(ssrDir, entryFile)
+  if (!file.startsWith(ssrDir + sep)) {
+    throw new Error(`${label}: SSR manifest entry "${entryFile}" escapes the SSR output directory ${ssrDir}.`)
+  }
+  if (!existsSync(file)) {
+    throw new Error(`${label}: SSR manifest points at ${file}, but the file does not exist.`)
+  }
+
+  return file
+}
+
+/**
+ * Path of the SSR manifest that `resolveSsrEntryFile` actually read, relative
+ * to the function root, for platforms that pass it to the runtime. Both Vite
+ * layouts occur in the wild, so this must follow the fallback rather than
+ * assume `.vite/`.
+ */
+export function ssrManifestRelativePath(ssrDir: string, prefix: string): string {
+  const [nested] = manifestPaths(ssrDir)
+  return existsSync(nested) ? `${prefix}/.vite/manifest.json` : `${prefix}/manifest.json`
+}
+
+/**
+ * Copy `public/` into a platform's static-asset staging directory.
+ *
+ * Two pieces of Guren-specific knowledge, not platform policy, which is why
+ * this is shared: the dev-mode `index.html` shell must never ship (it would
+ * shadow the app's root route on any host that serves static files first), and
+ * built assets self-reference the Vite plugin's derived base `/public/assets/`
+ * while HTML references use `/assets/` — so on a host without rewrites the
+ * built-assets directory has to appear under both prefixes.
+ */
+export function stageStaticAssets(publicDir: string, assetsOut: string): void {
+  mkdirSync(assetsOut, { recursive: true })
+
+  if (!existsSync(publicDir)) {
+    return
+  }
+
+  cpSync(publicDir, assetsOut, { recursive: true })
+
+  const shadowingIndex = resolve(assetsOut, 'index.html')
+  if (existsSync(shadowingIndex)) {
+    rmSync(shadowingIndex)
+  }
+
+  const clientAssetsDir = resolve(publicDir, 'assets')
+  if (existsSync(clientAssetsDir)) {
+    cpSync(clientAssetsDir, resolve(assetsOut, 'public/assets'), { recursive: true })
   }
 }
 
@@ -150,10 +255,11 @@ export interface DevOnlyModule {
 }
 
 /**
- * Modules in every Guren app's graph that cannot run off Bun, reached only
- * through dev-time branches. This list describes `@guren/core`'s own imports,
- * which is why it lives here: it changes when the framework's module graph
- * changes, and a deploy plugin that misses an entry ships a broken bundle.
+ * Modules that cannot run off Bun but sit in the graph of any app importing
+ * `@guren/core`, reached only through dev-time branches. Core aggregates
+ * `@guren/server` and `@guren/orm`, where these imports actually live, so it
+ * is the one package that sees the whole set — which is why the list lives
+ * here rather than in each plugin, where two copies had already drifted apart.
  *
  * Bundlers follow these imports even when they are dynamic, so without stubs
  * the build either fails to resolve them or ships megabytes of dev tooling.
@@ -163,8 +269,11 @@ export interface DevOnlyModule {
  * - `vite` — the dev asset server `Application` starts when serving locally.
  * - `mcp` — the opt-in MCP endpoint's lazy imports, which drag the CLI
  *   generators (and Babel) plus the MCP SDK in behind them.
+ *
+ * `as const` so a consumer can key an exhaustive table on the specifiers and
+ * have a new entry here surface as a compile error there.
  */
-export const DEV_ONLY_MODULES: readonly DevOnlyModule[] = [
+export const DEV_ONLY_MODULES = [
   { specifier: 'bun:sqlite', kind: 'sqlite', exportNames: ['Database'] },
   { specifier: 'vite', kind: 'vite', exportNames: ['createServer'] },
   { specifier: '@guren/cli', kind: 'mcp', exportNames: [] },
@@ -178,7 +287,31 @@ export const DEV_ONLY_MODULES: readonly DevOnlyModule[] = [
     kind: 'mcp',
     exportNames: ['WebStandardStreamableHTTPServerTransport'],
   },
-]
+] as const satisfies readonly DevOnlyModule[]
+
+export type DevOnlySpecifier = (typeof DEV_ONLY_MODULES)[number]['specifier']
+
+/**
+ * Source for a stub replacing one dev-only module. Shared because what it
+ * encodes is a bundler constraint, not a platform choice: every name the
+ * importer destructures must be present or the bundle fails with "no matching
+ * export", and each is emitted as a throwing *function* because the stubbed
+ * names mix constructors (`new Database()`) with plain calls
+ * (`createServer()`) — a class invoked without `new` reports "Class
+ * constructor cannot be invoked without 'new'" instead of the real reason.
+ *
+ * @param message Platform-specific explanation, including the replacement API.
+ */
+export function renderDevOnlyStub(module: DevOnlyModule, message: string): string {
+  if (module.exportNames.length === 0) {
+    return `// ${message}\nexport {}\n`
+  }
+
+  const throwing = module.exportNames
+    .map((name) => `export function ${name}() { throw new Error(${JSON.stringify(message)}) }`)
+    .join('\n')
+  return `${throwing}\nexport default { ${module.exportNames.join(', ')} }\n`
+}
 
 /**
  * The MCP SDK is only ever reached through subpaths, and a bundler alias on a

--- a/packages/core/src/internal/deploy-build.ts
+++ b/packages/core/src/internal/deploy-build.ts
@@ -39,20 +39,13 @@ export function resolvePathLike(value: PathLike): string {
 }
 
 /**
- * Read the first manifest that exists, tolerating both Vite layouts
- * (`.vite/manifest.json` and the flat `manifest.json` older configs emit).
- * A malformed file is skipped rather than fatal — the caller decides what a
- * missing manifest means for its platform.
- */
-export function loadManifest(...paths: string[]): Manifest | undefined {
-  return readManifest(...paths)?.manifest
-}
-
-/**
- * As `loadManifest`, but also reports which path was read. A caller that
- * publishes the manifest location to the runtime has to name the file that was
- * actually parsed: testing which one *exists* picks the malformed one that
- * `loadManifest` just skipped.
+ * Read the first manifest that parses, tolerating both Vite layouts
+ * (`.vite/manifest.json` and the flat `manifest.json` older configs emit), and
+ * report which path it was. A malformed file is skipped rather than fatal —
+ * the caller decides what a missing manifest means for its platform. The path
+ * is part of the result because a caller publishing the manifest location to
+ * the runtime has to name the file that was actually parsed: testing which one
+ * *exists* picks the malformed one that was just skipped.
  */
 export function readManifest(
   ...paths: string[]
@@ -72,8 +65,8 @@ export function readManifest(
   return undefined
 }
 
-/** The two layouts `loadManifest` accepts, in preference order. */
-export function manifestPaths(dir: string): [string, string] {
+/** The two layouts `readManifest` accepts, in preference order. */
+function manifestPaths(dir: string): [string, string] {
   return [resolve(dir, '.vite/manifest.json'), resolve(dir, 'manifest.json')]
 }
 
@@ -81,21 +74,29 @@ export function manifestPaths(dir: string): [string, string] {
  * Resolve symlinks in the parts of `path` that exist, keeping the trailing
  * components that do not. `realpathSync` throws on a path that is not there
  * yet, and an output directory usually is not on a first build.
+ *
+ * A sibling of `realpathNearestExisting` in `@guren/cli`'s plugin-manifest.ts,
+ * kept as a copy because this module must not import beyond node builtins and
+ * cli cannot be imported from core. Only ENOENT walks up, matching the twin:
+ * any other failure (an unreadable or non-directory ancestor) is surfaced
+ * rather than silently treated as nonexistent — this feeds a deletion guard,
+ * which must not compare a path it could not actually resolve.
  */
 function realpathOfNearestExisting(path: string): string {
-  let existing = path
-  const missing: string[] = []
-
-  while (!existsSync(existing)) {
-    const parent = dirname(existing)
-    if (parent === existing) {
-      return path
+  try {
+    return realpathSync(path)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
     }
-    missing.unshift(basename(existing))
-    existing = parent
   }
 
-  return resolve(realpathSync(existing), ...missing)
+  const parent = dirname(path)
+  if (parent === path) {
+    return path
+  }
+
+  return resolve(realpathOfNearestExisting(parent), basename(path))
 }
 
 /**
@@ -187,7 +188,7 @@ export function resolveClientAssetEnv(
   clientEntryKey: string,
   label: string,
 ): ClientAssetEnv {
-  const manifest = loadManifest(...manifestPaths(resolve(publicDir, 'assets')))
+  const manifest = readManifest(...manifestPaths(resolve(publicDir, 'assets')))?.manifest
 
   const entry = manifest?.[clientEntryKey]
   if (!entry?.file) {
@@ -216,7 +217,7 @@ export function resolveSsrEntryFile(
   ssrEntryKey: string,
   label: string,
 ): string | undefined {
-  const manifest = loadManifest(...manifestPaths(ssrDir))
+  const manifest = readManifest(...manifestPaths(ssrDir))?.manifest
 
   const entryFile = manifest?.[ssrEntryKey]?.file
   if (!entryFile) {
@@ -235,21 +236,31 @@ export function resolveSsrEntryFile(
 }
 
 /**
- * Path of the SSR manifest that `resolveSsrEntryFile` actually read, relative
- * to the function root, for platforms that pass it to the runtime.
+ * Runtime locations of a staged SSR bundle, for platforms that copy `ssrDir`
+ * under the function root and hand the layout to the server through
+ * environment variables. `prefix` is where the caller stages the directory —
+ * it cannot be derived here because staging happens later in the caller's own
+ * flow.
  *
- * Derived from the file that parsed rather than the first one that exists:
- * both Vite layouts occur in the wild, and a malformed `.vite/manifest.json`
- * alongside a valid flat one would otherwise publish the path to the file that
- * was skipped.
+ * The manifest path is derived from the file that parsed rather than the
+ * first one that exists: both Vite layouts occur in the wild, and a malformed
+ * `.vite/manifest.json` alongside a valid flat one would otherwise publish the
+ * path to the file that was skipped. It is optional only for the mid-build
+ * race where the manifest vanishes between `resolveSsrEntryFile` and this
+ * call — callers already hold a chunk path that manifest produced.
  */
-export function ssrManifestRelativePath(ssrDir: string, prefix: string): string | undefined {
+export function ssrRuntimePaths(
+  ssrDir: string,
+  ssrFile: string,
+  prefix: string,
+): { entry: string; manifest?: string } {
+  const under = (target: string) => `${prefix}/${relative(ssrDir, target).split(sep).join('/')}`
   const read = readManifest(...manifestPaths(ssrDir))
-  if (!read) {
-    return undefined
-  }
 
-  return `${prefix}/${relative(ssrDir, read.path).split(sep).join('/')}`
+  return {
+    entry: under(ssrFile),
+    manifest: read ? under(read.path) : undefined,
+  }
 }
 
 /**

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/bin.ts', 'src/runtime.ts', 'src/vite.ts', 'src/lambda.ts', 'src/redis.ts'],
+  entry: [
+    'src/index.ts',
+    'src/bin.ts',
+    'src/runtime.ts',
+    'src/vite.ts',
+    'src/lambda.ts',
+    'src/redis.ts',
+    'src/internal/deploy-build.ts',
+  ],
   format: ['esm'],
   dts: true,
   outDir: 'dist',

--- a/packages/plugin-cloudflare/src/build.test.ts
+++ b/packages/plugin-cloudflare/src/build.test.ts
@@ -108,6 +108,19 @@ describe('buildCloudflareOutput', () => {
     expect(existsSync(join(root, 'src/app.ts'))).toBe(true)
   })
 
+  test('should keep the previous output when the build fails', async () => {
+    scaffoldApp(root)
+    mkdirSync(join(root, '.cloudflare'), { recursive: true })
+    writeFileSync(join(root, '.cloudflare/worker.js'), '// previous deploy\n')
+    rmSync(join(root, 'src/app.ts'))
+
+    await expect(buildCloudflareOutput({ rootDir: root, skipAppBuild: true })).rejects.toThrow(
+      /app entry not found/,
+    )
+
+    expect(readFileSync(join(root, '.cloudflare/worker.js'), 'utf8')).toBe('// previous deploy\n')
+  })
+
   test('should refuse the filesystem root as outputDir', async () => {
     scaffoldApp(root)
 

--- a/packages/plugin-cloudflare/src/build.test.ts
+++ b/packages/plugin-cloudflare/src/build.test.ts
@@ -108,6 +108,38 @@ describe('buildCloudflareOutput', () => {
     expect(existsSync(join(root, 'src/app.ts'))).toBe(true)
   })
 
+  test('should refuse the filesystem root as outputDir', async () => {
+    scaffoldApp(root)
+
+    // `out + sep` is "//" here, which no absolute path is prefixed by — a
+    // string-prefix containment test lets this through to the rmSync.
+    await expect(
+      buildCloudflareOutput({ rootDir: root, outputDir: '/', skipAppBuild: true }),
+    ).rejects.toThrow(/never the root itself or a parent of it/)
+    expect(existsSync(join(root, 'src/app.ts'))).toBe(true)
+  })
+
+  test('should read the client manifest from a custom publicDir', async () => {
+    scaffoldApp(root)
+
+    // Move the built client somewhere other than <root>/public: the manifest
+    // lookup has to follow `publicDir`, not assume the default location.
+    mkdirSync(join(root, 'web-root/assets/.vite'), { recursive: true })
+    writeJson(join(root, 'web-root/assets/.vite/manifest.json'), {
+      'resources/js/app.tsx': { file: 'app-Custom999.js', css: ['app-Custom999.css'] },
+    })
+
+    await buildCloudflareOutput({
+      rootDir: root,
+      publicDir: join(root, 'web-root'),
+      skipAppBuild: true,
+    })
+
+    const worker = readFileSync(join(root, '.cloudflare/worker.js'), 'utf8')
+    expect(worker).toContain('process.env.GUREN_INERTIA_ENTRY = "/assets/app-Custom999.js"')
+    expect(worker).toContain('process.env.GUREN_INERTIA_STYLES = "/assets/app-Custom999.css"')
+  })
+
   test('should scaffold wrangler.jsonc once and never overwrite it', async () => {
     scaffoldApp(root)
 
@@ -281,6 +313,42 @@ describe('workers runtime configuration', () => {
     expect(warning).toContain('alias')
     expect(warning).toContain('process.env.NODE_ENV')
     expect(warning).toContain('.cloudflare/d1-migrations')
+  })
+
+  test('should warn when an existing wrangler config aliases stale stub filenames', async () => {
+    scaffoldApp(root)
+    // Every key is present, so a keys-only check passes this config — but the
+    // MCP values name files a specifier-derived build no longer writes, and
+    // wrangler would resolve the alias to nothing.
+    writeJson(join(root, 'wrangler.jsonc'), {
+      name: 'legacy',
+      main: '.cloudflare/worker.js',
+      alias: {
+        'bun:sqlite': './.cloudflare/stub-bun-sqlite.js',
+        vite: './.cloudflare/stub-vite.js',
+        '@guren/cli': './.cloudflare/stub-guren-cli.js',
+        '@modelcontextprotocol/sdk/server/mcp.js': './.cloudflare/stub-mcp-server.js',
+        '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js':
+          './.cloudflare/stub-mcp-transport.js',
+      },
+      define: { 'process.env.NODE_ENV': '"production"' },
+    })
+    const warnings: string[] = []
+    const original = console.warn
+    console.warn = (message: string) => warnings.push(message)
+
+    try {
+      await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
+    } finally {
+      console.warn = original
+    }
+
+    const warning = warnings.join('\n')
+    expect(warning).toContain('predates this plugin version')
+    // The replacement map is printed so it can be pasted in.
+    expect(warning).toContain('stub-modelcontextprotocol-sdk-server-mcp-js.js')
+    // The stub files it names are the ones this build actually wrote.
+    expect(existsSync(join(root, '.cloudflare/stub-modelcontextprotocol-sdk-server-mcp-js.js'))).toBe(true)
   })
 
   test('should reject migrations that flatten to the same filename', async () => {

--- a/packages/plugin-cloudflare/src/build.test.ts
+++ b/packages/plugin-cloudflare/src/build.test.ts
@@ -315,40 +315,20 @@ describe('workers runtime configuration', () => {
     expect(warning).toContain('.cloudflare/d1-migrations')
   })
 
-  test('should warn when an existing wrangler config aliases stale stub filenames', async () => {
+  test('should write a stub file for every aliased specifier', async () => {
     scaffoldApp(root)
-    // Every key is present, so a keys-only check passes this config — but the
-    // MCP values name files a specifier-derived build no longer writes, and
-    // wrangler would resolve the alias to nothing.
-    writeJson(join(root, 'wrangler.jsonc'), {
-      name: 'legacy',
-      main: '.cloudflare/worker.js',
-      alias: {
-        'bun:sqlite': './.cloudflare/stub-bun-sqlite.js',
-        vite: './.cloudflare/stub-vite.js',
-        '@guren/cli': './.cloudflare/stub-guren-cli.js',
-        '@modelcontextprotocol/sdk/server/mcp.js': './.cloudflare/stub-mcp-server.js',
-        '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js':
-          './.cloudflare/stub-mcp-transport.js',
-      },
-      define: { 'process.env.NODE_ENV': '"production"' },
-    })
-    const warnings: string[] = []
-    const original = console.warn
-    console.warn = (message: string) => warnings.push(message)
 
-    try {
-      await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
-    } finally {
-      console.warn = original
+    await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
+
+    // The alias map and the files on disk are derived from one list but through
+    // two code paths; a stub the config points at but the build never writes
+    // fails only at `wrangler deploy`.
+    const config = JSON.parse(readFileSync(join(root, 'wrangler.jsonc'), 'utf8'))
+    const aliases = Object.values(config.alias) as string[]
+    expect(aliases.length).toBeGreaterThan(0)
+    for (const target of aliases) {
+      expect(existsSync(join(root, target.replace(/^\.\//, '')))).toBe(true)
     }
-
-    const warning = warnings.join('\n')
-    expect(warning).toContain('predates this plugin version')
-    // The replacement map is printed so it can be pasted in.
-    expect(warning).toContain('stub-modelcontextprotocol-sdk-server-mcp-js.js')
-    // The stub files it names are the ones this build actually wrote.
-    expect(existsSync(join(root, '.cloudflare/stub-modelcontextprotocol-sdk-server-mcp-js.js'))).toBe(true)
   })
 
   test('should reject migrations that flatten to the same filename', async () => {

--- a/packages/plugin-cloudflare/src/build.ts
+++ b/packages/plugin-cloudflare/src/build.ts
@@ -1,15 +1,20 @@
 import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { isAbsolute, relative, resolve, sep } from 'node:path'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+import { relative, resolve, sep } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import {
+  assertOutputDirOutsideRoot,
+  DEV_ONLY_MODULES,
+  importSpecifier,
+  loadManifest,
+  resolveClientAssetEnv,
+  resolvePathLike,
+  type ClientAssetEnv,
+  type DevOnlyModule,
+  type PathLike,
+} from '@guren/core/internal/deploy-build'
 
-type PathLike = string | URL
-
-type ManifestEntry = {
-  file?: string
-  css?: string[]
-}
-
-type Manifest = Record<string, ManifestEntry>
+/** Prefixes every diagnostic this build emits. */
+const LABEL = 'Cloudflare build'
 
 interface PackageJsonLike {
   name?: string
@@ -50,11 +55,7 @@ export async function buildCloudflareOutput(options: BuildCloudflareOutputOption
   const clientEntryKey = options.clientEntryKey ?? 'resources/js/app.tsx'
   const ssrEntryKey = options.ssrEntryKey ?? 'resources/js/ssr.tsx'
 
-  if (out === root || root.startsWith(out + sep)) {
-    throw new Error(
-      `Cloudflare build: outputDir (${out}) must be a directory outside or below the app root, never the root itself — it is deleted on every build.`,
-    )
-  }
+  assertOutputDirOutsideRoot(out, root, LABEL)
 
   const packageJson = readPackageJson(root)
 
@@ -67,7 +68,7 @@ export async function buildCloudflareOutput(options: BuildCloudflareOutputOption
   }
 
   const ssrImport = await resolveSsrImport(ssrDir, ssrEntryKey)
-  const assetEnv = resolveClientAssetEnv(root, clientEntryKey)
+  const assetEnv = resolveClientAssetEnv(publicDir, clientEntryKey, LABEL)
 
   if (existsSync(out)) {
     rmSync(out, { recursive: true, force: true })
@@ -106,72 +107,63 @@ export async function buildCloudflareOutput(options: BuildCloudflareOutputOption
   scaffoldWranglerConfig(root, out, packageJson.name)
 }
 
-/**
- * Modules that exist in every Guren app's graph but can never run on
- * Workers, reached only through dev-time branches: `bun:sqlite` (the local
- * sqlite ORM factory, opposite the D1 branch of `config/database.ts`) and
- * `vite` (the dev asset server `Application` starts when serving locally).
- * Bundlers follow those imports anyway — even dynamic ones — so without
- * stubs the build either fails to resolve or ships megabytes of dev
- * tooling. Each stub throws if a code path ever really reaches it.
- */
 const MCP_UNAVAILABLE = 'The MCP endpoint is unavailable on Cloudflare Workers — it generates files on disk.'
 
 /**
- * Stubs must carry the exact names their importers destructure: an empty
- * module fails the bundle with "no matching export", not at runtime.
+ * Why the dev-only modules in `DEV_ONLY_MODULES` cannot run here, worded for
+ * this platform: each names the Workers-appropriate replacement.
  */
-function mcpStub(exportNames: string[]): string {
-  const throwing = exportNames
-    .map((name) => `export class ${name} { constructor() { throw new Error(${JSON.stringify(MCP_UNAVAILABLE)}) } }`)
-    .join('\n')
-  return `${throwing}\nexport default {}\n`
+const UNAVAILABLE_ON_WORKERS: Record<DevOnlyModule['kind'], string> = {
+  sqlite: 'bun:sqlite is unavailable on Cloudflare Workers — use createD1Database().',
+  vite: 'The Vite dev server is unavailable on Cloudflare Workers — assets are served by Workers Static Assets.',
+  mcp: MCP_UNAVAILABLE,
 }
 
-const DEV_ONLY_STUBS: Record<string, { file: string; source: string }> = {
-  'bun:sqlite': {
-    file: 'stub-bun-sqlite.js',
-    source:
-      'export const Database = class { constructor() { throw new Error("bun:sqlite is unavailable on Cloudflare Workers — use createD1Database().") } }\nexport default { Database }\n',
-  },
-  vite: {
-    file: 'stub-vite.js',
-    source:
-      'export function createServer() { throw new Error("The Vite dev server is unavailable on Cloudflare Workers — assets are served by Workers Static Assets.") }\nexport default { createServer }\n',
-  },
-  // The opt-in MCP endpoint's lazy imports still drag the CLI generators
-  // (and Babel) plus the MCP SDK into the bundle. `@guren/cli` is imported
-  // bare, but the SDK is only ever reached through subpaths — and an alias
-  // on a package name does not cover them, so each subpath is listed.
-  // `@guren/cli` is imported bare and only read through namespace property
-  // access, so an empty module suffices; the SDK subpaths are destructured
-  // and need their names present. A package-name alias does not cover
-  // subpaths, so each is listed.
-  '@guren/cli': {
-    file: 'stub-guren-cli.js',
-    source: `// ${MCP_UNAVAILABLE}\nexport {}\n`,
-  },
-  '@modelcontextprotocol/sdk/server/mcp.js': {
-    file: 'stub-mcp-server.js',
-    source: mcpStub(['McpServer', 'ResourceTemplate']),
-  },
-  '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js': {
-    file: 'stub-mcp-transport.js',
-    source: mcpStub(['WebStandardStreamableHTTPServerTransport']),
-  },
+/**
+ * Stubs must carry the exact names their importers destructure: an empty
+ * module fails the bundle with "no matching export", not at runtime. Emitted
+ * as functions rather than classes because the stubbed names mix constructors
+ * (`new Database()`) with plain calls (`createServer()`), and only a function
+ * throws the intended message under both.
+ */
+function renderStub({ kind, exportNames }: DevOnlyModule): string {
+  const message = UNAVAILABLE_ON_WORKERS[kind]
+  if (exportNames.length === 0) {
+    return `// ${message}\nexport {}\n`
+  }
+
+  const throwing = exportNames
+    .map((name) => `export function ${name}() { throw new Error(${JSON.stringify(message)}) }`)
+    .join('\n')
+  return `${throwing}\nexport default { ${exportNames.join(', ')} }\n`
+}
+
+/**
+ * Wrangler resolves an `alias` to a path on disk, so unlike a bundler plugin
+ * each stub needs a file of its own. Derived from the specifier rather than
+ * hand-named so `DEV_ONLY_MODULES` stays the only place a module is listed.
+ */
+function stubFileName(specifier: string): string {
+  return `stub-${specifier.replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-|-$/g, '')}.js`
 }
 
 function writeDevOnlyStubs(out: string): void {
-  for (const stub of Object.values(DEV_ONLY_STUBS)) {
-    writeFileSync(resolve(out, stub.file), stub.source)
+  for (const module of DEV_ONLY_MODULES) {
+    writeFileSync(resolve(out, stubFileName(module.specifier)), renderStub(module))
   }
 }
 
+/**
+ * A package-name alias does not cover subpaths, so every stubbed specifier —
+ * including each MCP SDK subpath — needs its own entry. Unlike the Lambda
+ * plugin's bundler hook, wrangler cannot match a prefix, so an SDK subpath
+ * added upstream needs a new `DEV_ONLY_MODULES` entry to stay stubbed here.
+ */
 function devOnlyAliases(outRelative: string): Record<string, string> {
   return Object.fromEntries(
-    Object.entries(DEV_ONLY_STUBS).map(([specifier, stub]) => [
-      specifier,
-      `./${outRelative}/${stub.file}`,
+    DEV_ONLY_MODULES.map((module) => [
+      module.specifier,
+      `./${outRelative}/${stubFileName(module.specifier)}`,
     ]),
   )
 }
@@ -312,31 +304,6 @@ async function resolveSsrImport(ssrDir: string, ssrEntryKey: string): Promise<Ss
   return { file, rendererExport }
 }
 
-interface ClientAssetEnv {
-  entry?: string
-  styles?: string
-}
-
-function resolveClientAssetEnv(root: string, clientEntryKey: string): ClientAssetEnv {
-  const manifest = loadManifest(
-    resolve(root, 'public/assets/.vite/manifest.json'),
-    resolve(root, 'public/assets/manifest.json'),
-  )
-
-  const entry = manifest?.[clientEntryKey]
-  if (!entry?.file) {
-    console.warn(
-      `Cloudflare build: no client manifest entry for "${clientEntryKey}"; GUREN_INERTIA_ENTRY will not be set.`,
-    )
-    return {}
-  }
-
-  return {
-    entry: `/assets/${entry.file}`,
-    styles: entry.css?.length ? entry.css.map((file) => `/assets/${file}`).join(',') : undefined,
-  }
-}
-
 function renderWorkerModule(input: {
   out: string
   appEntry: string
@@ -351,11 +318,11 @@ function renderWorkerModule(input: {
   if (input.ssrImport) {
     lines.push(
       "import { setInertiaSsrRenderer } from '@guren/core'",
-      `import * as ssrModule from ${JSON.stringify(importSpecifier(input.out, input.ssrImport.file))}`,
+      `import * as ssrModule from ${JSON.stringify(importSpecifier(input.out, input.ssrImport.file, LABEL))}`,
     )
   }
 
-  lines.push(`import app from ${JSON.stringify(importSpecifier(input.out, input.appEntry))}`, '')
+  lines.push(`import app from ${JSON.stringify(importSpecifier(input.out, input.appEntry, LABEL))}`, '')
 
   if (input.assetEnv.entry) {
     lines.push(`process.env.GUREN_INERTIA_ENTRY = ${JSON.stringify(input.assetEnv.entry)}`)
@@ -374,18 +341,6 @@ function renderWorkerModule(input: {
   lines.push('export default createWorkersHandler(app)', '')
 
   return lines.join('\n')
-}
-
-function importSpecifier(fromDir: string, target: string): string {
-  const rel = relative(fromDir, target)
-  if (isAbsolute(rel)) {
-    throw new Error(
-      `Cloudflare build: ${target} cannot be imported relative to ${fromDir} (different drive or root?). Keep the app, SSR output, and outputDir on the same volume.`,
-    )
-  }
-
-  const specifier = rel.split(sep).join('/')
-  return specifier.startsWith('.') ? specifier : `./${specifier}`
 }
 
 function scaffoldWranglerConfig(root: string, out: string, packageName: string | undefined): void {
@@ -453,8 +408,12 @@ function warnMissingBuildOwnedKeys(configPath: string, outRelative: string): voi
 
   const missing: string[] = []
   const alias = config.alias as Record<string, string> | undefined
-  if (!alias || Object.keys(devOnlyAliases(outRelative)).some((key) => !(key in alias))) {
-    missing.push(`"alias": ${JSON.stringify(devOnlyAliases(outRelative))}`)
+  const expectedAliases = devOnlyAliases(outRelative)
+  // Values as well as keys: the stub filenames are derived from the specifier,
+  // so a config written by a version that hand-named them still has every key
+  // while pointing at files this build no longer writes.
+  if (!alias || Object.entries(expectedAliases).some(([key, value]) => alias[key] !== value)) {
+    missing.push(`"alias": ${JSON.stringify(expectedAliases)}`)
   }
   const define = config.define as Record<string, string> | undefined
   if (!define?.['process.env.NODE_ENV']) {
@@ -472,22 +431,3 @@ function warnMissingBuildOwnedKeys(configPath: string, outRelative: string): voi
   }
 }
 
-function resolvePathLike(value: PathLike): string {
-  return value instanceof URL ? fileURLToPath(value) : resolve(String(value))
-}
-
-function loadManifest(...paths: string[]): Manifest | undefined {
-  for (const path of paths) {
-    if (!existsSync(path)) {
-      continue
-    }
-
-    try {
-      return JSON.parse(readFileSync(path, 'utf8')) as Manifest
-    } catch {
-      continue
-    }
-  }
-
-  return undefined
-}

--- a/packages/plugin-cloudflare/src/build.ts
+++ b/packages/plugin-cloudflare/src/build.ts
@@ -2,19 +2,19 @@ import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, write
 import { relative, resolve, sep } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import {
-  assertOutputDirOutsideRoot,
   DEV_ONLY_MODULES,
   importSpecifier,
-  loadManifest,
+  renderDevOnlyStub,
+  resetOutputDir,
   resolveClientAssetEnv,
   resolvePathLike,
+  resolveSsrEntryFile,
+  stageStaticAssets,
   type ClientAssetEnv,
   type DevOnlyModule,
+  type DevOnlySpecifier,
   type PathLike,
 } from '@guren/core/internal/deploy-build'
-
-/** Prefixes every diagnostic this build emits. */
-const LABEL = 'Cloudflare build'
 
 interface PackageJsonLike {
   name?: string
@@ -55,7 +55,7 @@ export async function buildCloudflareOutput(options: BuildCloudflareOutputOption
   const clientEntryKey = options.clientEntryKey ?? 'resources/js/app.tsx'
   const ssrEntryKey = options.ssrEntryKey ?? 'resources/js/ssr.tsx'
 
-  assertOutputDirOutsideRoot(out, root, LABEL)
+  resetOutputDir(out, root, 'Cloudflare build')
 
   const packageJson = readPackageJson(root)
 
@@ -68,35 +68,12 @@ export async function buildCloudflareOutput(options: BuildCloudflareOutputOption
   }
 
   const ssrImport = await resolveSsrImport(ssrDir, ssrEntryKey)
-  const assetEnv = resolveClientAssetEnv(publicDir, clientEntryKey, LABEL)
+  const assetEnv = resolveClientAssetEnv(publicDir, clientEntryKey, 'Cloudflare build')
 
-  if (existsSync(out)) {
-    rmSync(out, { recursive: true, force: true })
-  }
-  mkdirSync(resolve(out, 'assets'), { recursive: true })
-
-  if (existsSync(publicDir)) {
-    cpSync(publicDir, resolve(out, 'assets'), { recursive: true })
-  }
-
-  // Workers Static Assets serves index.html for `/` BEFORE the worker runs,
-  // which would shadow the app's root route. public/index.html is the
-  // dev-mode Vite shell in Guren apps — never a production page.
-  const shadowingIndex = resolve(out, 'assets/index.html')
-  if (existsSync(shadowingIndex)) {
-    rmSync(shadowingIndex)
-  }
-
-  // Built assets are emitted with the Guren Vite plugin's derived base
-  // `/public/assets/` (chunk imports, CSS urls, preloads self-reference that
-  // prefix). Vercel resolves it with a `/public/(.*) -> /$1` rewrite; Workers
-  // Static Assets has no rewrites, so mirror the built-assets directory under
-  // the base URL path as well: the root copy serves `/assets/*`, this copy
-  // serves `/public/assets/*`.
-  const clientAssetsDir = resolve(publicDir, 'assets')
-  if (existsSync(clientAssetsDir)) {
-    cpSync(clientAssetsDir, resolve(out, 'assets/public/assets'), { recursive: true })
-  }
+  // Workers Static Assets serves `/` from index.html BEFORE the worker runs,
+  // and has no rewrites for the built assets' `/public/assets/` base — both
+  // handled by the shared staging step.
+  stageStaticAssets(publicDir, resolve(out, 'assets'))
 
   writeFileSync(resolve(out, 'worker.js'), renderWorkerModule({ out, appEntry, ssrImport, assetEnv }))
 
@@ -120,36 +97,30 @@ const UNAVAILABLE_ON_WORKERS: Record<DevOnlyModule['kind'], string> = {
 }
 
 /**
- * Stubs must carry the exact names their importers destructure: an empty
- * module fails the bundle with "no matching export", not at runtime. Emitted
- * as functions rather than classes because the stubbed names mix constructors
- * (`new Database()`) with plain calls (`createServer()`), and only a function
- * throws the intended message under both.
- */
-function renderStub({ kind, exportNames }: DevOnlyModule): string {
-  const message = UNAVAILABLE_ON_WORKERS[kind]
-  if (exportNames.length === 0) {
-    return `// ${message}\nexport {}\n`
-  }
-
-  const throwing = exportNames
-    .map((name) => `export function ${name}() { throw new Error(${JSON.stringify(message)}) }`)
-    .join('\n')
-  return `${throwing}\nexport default { ${exportNames.join(', ')} }\n`
-}
-
-/**
  * Wrangler resolves an `alias` to a path on disk, so unlike a bundler plugin
- * each stub needs a file of its own. Derived from the specifier rather than
- * hand-named so `DEV_ONLY_MODULES` stays the only place a module is listed.
+ * each stub needs a file of its own. The names are deliberately hand-written
+ * rather than derived: they are baked into every app's committed
+ * `wrangler.jsonc`, which the scaffold never overwrites, so deriving them
+ * would rename files out from under existing apps for no benefit.
+ *
+ * Keyed on `DevOnlySpecifier`, so adding an entry to `DEV_ONLY_MODULES` is a
+ * compile error here until it gets a filename — the drift a derived name would
+ * have prevented, caught by the type system instead.
  */
-function stubFileName(specifier: string): string {
-  return `stub-${specifier.replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-|-$/g, '')}.js`
+const STUB_FILES: Record<DevOnlySpecifier, string> = {
+  'bun:sqlite': 'stub-bun-sqlite.js',
+  vite: 'stub-vite.js',
+  '@guren/cli': 'stub-guren-cli.js',
+  '@modelcontextprotocol/sdk/server/mcp.js': 'stub-mcp-server.js',
+  '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js': 'stub-mcp-transport.js',
 }
 
 function writeDevOnlyStubs(out: string): void {
   for (const module of DEV_ONLY_MODULES) {
-    writeFileSync(resolve(out, stubFileName(module.specifier)), renderStub(module))
+    writeFileSync(
+      resolve(out, STUB_FILES[module.specifier]),
+      renderDevOnlyStub(module, UNAVAILABLE_ON_WORKERS[module.kind]),
+    )
   }
 }
 
@@ -163,7 +134,7 @@ function devOnlyAliases(outRelative: string): Record<string, string> {
   return Object.fromEntries(
     DEV_ONLY_MODULES.map((module) => [
       module.specifier,
-      `./${outRelative}/${stubFileName(module.specifier)}`,
+      `./${outRelative}/${STUB_FILES[module.specifier]}`,
     ]),
   )
 }
@@ -264,27 +235,12 @@ interface SsrImport {
 }
 
 async function resolveSsrImport(ssrDir: string, ssrEntryKey: string): Promise<SsrImport | undefined> {
-  const manifest = loadManifest(
-    resolve(ssrDir, '.vite/manifest.json'),
-    resolve(ssrDir, 'manifest.json'),
-  )
-
-  const entryFile = manifest?.[ssrEntryKey]?.file
-  if (!entryFile) {
+  const file = resolveSsrEntryFile(ssrDir, ssrEntryKey, 'Cloudflare build')
+  if (!file) {
     console.warn(
       `Cloudflare build: no SSR manifest entry for "${ssrEntryKey}" under ${ssrDir}; generating a CSR-only worker.`,
     )
     return undefined
-  }
-
-  const file = resolve(ssrDir, entryFile)
-  if (!file.startsWith(ssrDir + sep)) {
-    throw new Error(
-      `Cloudflare build: SSR manifest entry "${entryFile}" escapes the SSR output directory ${ssrDir}.`,
-    )
-  }
-  if (!existsSync(file)) {
-    throw new Error(`Cloudflare build: SSR manifest points at ${file}, but the file does not exist.`)
   }
 
   const module = (await import(pathToFileURL(file).href)) as Record<string, unknown>
@@ -318,11 +274,11 @@ function renderWorkerModule(input: {
   if (input.ssrImport) {
     lines.push(
       "import { setInertiaSsrRenderer } from '@guren/core'",
-      `import * as ssrModule from ${JSON.stringify(importSpecifier(input.out, input.ssrImport.file, LABEL))}`,
+      `import * as ssrModule from ${JSON.stringify(importSpecifier(input.out, input.ssrImport.file, 'Cloudflare build'))}`,
     )
   }
 
-  lines.push(`import app from ${JSON.stringify(importSpecifier(input.out, input.appEntry, LABEL))}`, '')
+  lines.push(`import app from ${JSON.stringify(importSpecifier(input.out, input.appEntry, 'Cloudflare build'))}`, '')
 
   if (input.assetEnv.entry) {
     lines.push(`process.env.GUREN_INERTIA_ENTRY = ${JSON.stringify(input.assetEnv.entry)}`)
@@ -409,10 +365,7 @@ function warnMissingBuildOwnedKeys(configPath: string, outRelative: string): voi
   const missing: string[] = []
   const alias = config.alias as Record<string, string> | undefined
   const expectedAliases = devOnlyAliases(outRelative)
-  // Values as well as keys: the stub filenames are derived from the specifier,
-  // so a config written by a version that hand-named them still has every key
-  // while pointing at files this build no longer writes.
-  if (!alias || Object.entries(expectedAliases).some(([key, value]) => alias[key] !== value)) {
+  if (!alias || Object.keys(expectedAliases).some((key) => !(key in alias))) {
     missing.push(`"alias": ${JSON.stringify(expectedAliases)}`)
   }
   const define = config.define as Record<string, string> | undefined

--- a/packages/plugin-cloudflare/src/build.ts
+++ b/packages/plugin-cloudflare/src/build.ts
@@ -5,6 +5,7 @@ import {
   DEV_ONLY_MODULES,
   importSpecifier,
   renderDevOnlyStub,
+  assertOutputDirOutsideRoot,
   resetOutputDir,
   resolveClientAssetEnv,
   resolvePathLike,
@@ -55,7 +56,10 @@ export async function buildCloudflareOutput(options: BuildCloudflareOutputOption
   const clientEntryKey = options.clientEntryKey ?? 'resources/js/app.tsx'
   const ssrEntryKey = options.ssrEntryKey ?? 'resources/js/ssr.tsx'
 
-  resetOutputDir(out, root, 'Cloudflare build')
+  // Validated up front so a bad option fails before running the app build,
+  // but the delete waits until every check below has passed — a failed build
+  // must not take the previous deploy output with it.
+  assertOutputDirOutsideRoot(out, root, 'Cloudflare build')
 
   const packageJson = readPackageJson(root)
 
@@ -69,6 +73,8 @@ export async function buildCloudflareOutput(options: BuildCloudflareOutputOption
 
   const ssrImport = await resolveSsrImport(ssrDir, ssrEntryKey)
   const assetEnv = resolveClientAssetEnv(publicDir, clientEntryKey, 'Cloudflare build')
+
+  resetOutputDir(out, root, 'Cloudflare build')
 
   // Workers Static Assets serves `/` from index.html BEFORE the worker runs,
   // and has no rewrites for the built assets' `/public/assets/` base — both

--- a/packages/plugin-lambda/src/build.test.ts
+++ b/packages/plugin-lambda/src/build.test.ts
@@ -312,6 +312,22 @@ describe('buildLambdaOutput', () => {
     expect(existsSync(join(root, 'src/lambda.ts'))).toBe(true)
   })
 
+  test('should keep the previous output when the build fails', async () => {
+    scaffoldApp(root)
+    // A previous successful deploy, and an entrypoint that has gone missing.
+    mkdirSync(join(root, '.lambda/function'), { recursive: true })
+    writeFileSync(join(root, '.lambda/function/handler.js'), 'export const http = () => "old"\n')
+    rmSync(join(root, 'src/lambda.ts'))
+
+    await expect(buildLambdaOutput({ rootDir: root, skipAppBuild: true })).rejects.toThrow(
+      /entrypoint not found/,
+    )
+
+    // Deleting up front would take the last deployable artifact with it,
+    // leaving nothing to roll back to or inspect.
+    expect(existsSync(join(root, '.lambda/function/handler.js'))).toBe(true)
+  })
+
   test('should refuse the filesystem root as outputDir', async () => {
     scaffoldApp(root)
 

--- a/packages/plugin-lambda/src/build.ts
+++ b/packages/plugin-lambda/src/build.ts
@@ -1,10 +1,11 @@
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { relative, resolve, sep } from 'node:path'
 import {
   DEV_ONLY_MODULES,
   importSpecifier,
   MCP_SDK_SUBPATH_PREFIX,
   renderDevOnlyStub,
+  assertOutputDirOutsideRoot,
   resetOutputDir,
   resolveClientAssetEnv,
   resolvePathLike,
@@ -104,7 +105,10 @@ export async function buildLambdaOutput(options: BuildLambdaOutputOptions = {}):
   const clientEntryKey = options.clientEntryKey ?? 'resources/js/app.tsx'
   const ssrEntryKey = options.ssrEntryKey ?? 'resources/js/ssr.tsx'
 
-  resetOutputDir(out, root, 'Lambda build')
+  // Validated up front so a bad option fails before running the app build,
+  // but the delete waits until every check below has passed — a failed build
+  // must not take the previous deploy output with it.
+  assertOutputDirOutsideRoot(out, root, 'Lambda build')
 
   if (!options.skipAppBuild) {
     runAppBuild(root)
@@ -118,6 +122,8 @@ export async function buildLambdaOutput(options: BuildLambdaOutputOptions = {}):
 
   const ssrFile = resolveSsrEntry(ssrDir, ssrEntryKey)
   const assetEnv = resolveClientAssetEnv(publicDir, clientEntryKey, 'Lambda build')
+
+  resetOutputDir(out, root, 'Lambda build')
 
   const funcDir = resolve(out, 'function')
   mkdirSync(funcDir, { recursive: true })
@@ -170,7 +176,10 @@ function buildLambdaEnvironment(
     // Relative specifiers resolve from process.cwd(), which is the function
     // root (/var/task) on Lambda — where the SSR bundle is copied.
     env.GUREN_INERTIA_SSR_ENTRY = `./.guren/ssr/${relative(ssrDir, ssrFile).split(sep).join('/')}`
-    env.GUREN_INERTIA_SSR_MANIFEST = ssrManifestRelativePath(ssrDir, './.guren/ssr')
+    const manifestPath = ssrManifestRelativePath(ssrDir, './.guren/ssr')
+    if (manifestPath) {
+      env.GUREN_INERTIA_SSR_MANIFEST = manifestPath
+    }
   }
 
   return env

--- a/packages/plugin-lambda/src/build.ts
+++ b/packages/plugin-lambda/src/build.ts
@@ -1,5 +1,5 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { relative, resolve, sep } from 'node:path'
+import { resolve } from 'node:path'
 import {
   DEV_ONLY_MODULES,
   importSpecifier,
@@ -10,7 +10,7 @@ import {
   resolveClientAssetEnv,
   resolvePathLike,
   resolveSsrEntryFile,
-  ssrManifestRelativePath,
+  ssrRuntimePaths,
   stageStaticAssets,
   type ClientAssetEnv,
   type DevOnlyModule,
@@ -175,10 +175,10 @@ function buildLambdaEnvironment(
   if (ssrFile) {
     // Relative specifiers resolve from process.cwd(), which is the function
     // root (/var/task) on Lambda — where the SSR bundle is copied.
-    env.GUREN_INERTIA_SSR_ENTRY = `./.guren/ssr/${relative(ssrDir, ssrFile).split(sep).join('/')}`
-    const manifestPath = ssrManifestRelativePath(ssrDir, './.guren/ssr')
-    if (manifestPath) {
-      env.GUREN_INERTIA_SSR_MANIFEST = manifestPath
+    const ssrPaths = ssrRuntimePaths(ssrDir, ssrFile, './.guren/ssr')
+    env.GUREN_INERTIA_SSR_ENTRY = ssrPaths.entry
+    if (ssrPaths.manifest) {
+      env.GUREN_INERTIA_SSR_MANIFEST = ssrPaths.manifest
     }
   }
 

--- a/packages/plugin-lambda/src/build.ts
+++ b/packages/plugin-lambda/src/build.ts
@@ -1,21 +1,21 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { relative, resolve, sep } from 'node:path'
 import {
-  assertOutputDirOutsideRoot,
   DEV_ONLY_MODULES,
   importSpecifier,
-  loadManifest,
   MCP_SDK_SUBPATH_PREFIX,
+  renderDevOnlyStub,
+  resetOutputDir,
   resolveClientAssetEnv,
   resolvePathLike,
+  resolveSsrEntryFile,
+  ssrManifestRelativePath,
+  stageStaticAssets,
   type ClientAssetEnv,
   type DevOnlyModule,
   type PathLike,
 } from '@guren/core/internal/deploy-build'
 import { LAMBDA_HANDLER_EXPORTS, LAMBDA_HANDLER_MODULE } from './handlers'
-
-/** Prefixes every diagnostic this build emits. */
-const LABEL = 'Lambda build'
 
 export interface BuildLambdaOutputOptions {
   /** App root directory. Defaults to the current working directory. */
@@ -53,30 +53,6 @@ const UNAVAILABLE_ON_LAMBDA: Record<DevOnlyModule['kind'], string> = {
 }
 
 /**
- * Render a dev-only module as inline source for the bundler plugin below.
- *
- * Every name the importer destructures has to be present or the bundle fails
- * with "no matching export", so each is emitted as a throwing function. A
- * function rather than a class deliberately: the stubbed names are a mix of
- * constructors (`new Database()`) and plain calls (`createServer()`), and only
- * a function throws the intended message under both — invoking a class without
- * `new` reports "Class constructor cannot be invoked without 'new'" instead. A
- * module read only through namespace property access needs no names, and gets
- * a bare comment.
- */
-function renderStub({ kind, exportNames }: DevOnlyModule): string {
-  const message = UNAVAILABLE_ON_LAMBDA[kind]
-  if (exportNames.length === 0) {
-    return `// ${message}\nexport {}\n`
-  }
-
-  const throwing = exportNames
-    .map((name) => `export function ${name}() { throw new Error(${JSON.stringify(message)}) }`)
-    .join('\n')
-  return `${throwing}\nexport default { ${exportNames.join(', ')} }\n`
-}
-
-/**
  * Dev-only modules replaced with throwing stubs rather than left external.
  * Inlining a lazily-imported module hoists that module's own static imports to
  * the bundle top level, so an external module reached this way (the MCP SDK)
@@ -84,7 +60,10 @@ function renderStub({ kind, exportNames }: DevOnlyModule): string {
  * Stubbing also keeps megabytes of dev tooling out of the bundle.
  */
 const DEV_ONLY_STUBS: Record<string, string> = Object.fromEntries(
-  DEV_ONLY_MODULES.map((module) => [module.specifier, renderStub(module)]),
+  DEV_ONLY_MODULES.map((module) => [
+    module.specifier,
+    renderDevOnlyStub(module, UNAVAILABLE_ON_LAMBDA[module.kind]),
+  ]),
 )
 
 /**
@@ -125,7 +104,7 @@ export async function buildLambdaOutput(options: BuildLambdaOutputOptions = {}):
   const clientEntryKey = options.clientEntryKey ?? 'resources/js/app.tsx'
   const ssrEntryKey = options.ssrEntryKey ?? 'resources/js/ssr.tsx'
 
-  assertOutputDirOutsideRoot(out, root, LABEL)
+  resetOutputDir(out, root, 'Lambda build')
 
   if (!options.skipAppBuild) {
     runAppBuild(root)
@@ -138,11 +117,8 @@ export async function buildLambdaOutput(options: BuildLambdaOutputOptions = {}):
   }
 
   const ssrFile = resolveSsrEntry(ssrDir, ssrEntryKey)
-  const assetEnv = resolveClientAssetEnv(publicDir, clientEntryKey, LABEL)
+  const assetEnv = resolveClientAssetEnv(publicDir, clientEntryKey, 'Lambda build')
 
-  if (existsSync(out)) {
-    rmSync(out, { recursive: true, force: true })
-  }
   const funcDir = resolve(out, 'function')
   mkdirSync(funcDir, { recursive: true })
 
@@ -177,33 +153,6 @@ export async function buildLambdaOutput(options: BuildLambdaOutputOptions = {}):
   }
 }
 
-/**
- * Copy `public/` into the S3 staging directory. Vite emits built assets that
- * self-reference the derived base `/public/assets/`, while HTML references use
- * `/assets/`; S3 has no rewrites, so the built-assets directory is mirrored
- * under both prefixes. The dev-mode `index.html` shell is dropped — it must
- * never shadow the app's root route.
- */
-function stageStaticAssets(publicDir: string, assetsOut: string): void {
-  mkdirSync(assetsOut, { recursive: true })
-
-  if (!existsSync(publicDir)) {
-    return
-  }
-
-  cpSync(publicDir, assetsOut, { recursive: true })
-
-  const shadowingIndex = resolve(assetsOut, 'index.html')
-  if (existsSync(shadowingIndex)) {
-    rmSync(shadowingIndex)
-  }
-
-  const clientAssetsDir = resolve(publicDir, 'assets')
-  if (existsSync(clientAssetsDir)) {
-    cpSync(clientAssetsDir, resolve(assetsOut, 'public/assets'), { recursive: true })
-  }
-}
-
 function buildLambdaEnvironment(
   assetEnv: ClientAssetEnv,
   ssrFile: string | undefined,
@@ -221,11 +170,7 @@ function buildLambdaEnvironment(
     // Relative specifiers resolve from process.cwd(), which is the function
     // root (/var/task) on Lambda — where the SSR bundle is copied.
     env.GUREN_INERTIA_SSR_ENTRY = `./.guren/ssr/${relative(ssrDir, ssrFile).split(sep).join('/')}`
-    // Point at whichever manifest layout the SSR build actually produced —
-    // resolveSsrEntry accepts the root-level fallback too.
-    env.GUREN_INERTIA_SSR_MANIFEST = existsSync(resolve(ssrDir, '.vite/manifest.json'))
-      ? './.guren/ssr/.vite/manifest.json'
-      : './.guren/ssr/manifest.json'
+    env.GUREN_INERTIA_SSR_MANIFEST = ssrManifestRelativePath(ssrDir, './.guren/ssr')
   }
 
   return env
@@ -254,7 +199,7 @@ function renderHandlerModule(input: {
   lines.push(
     '// Imported dynamically so the assignments above run before the app module',
     '// graph evaluates — static imports are hoisted past them.',
-    `const module = await import(${JSON.stringify(importSpecifier(input.out, input.entrypoint, LABEL))})`,
+    `const module = await import(${JSON.stringify(importSpecifier(input.out, input.entrypoint, 'Lambda build'))})`,
     '',
   )
 
@@ -373,24 +318,9 @@ function runAppBuild(root: string): void {
 
 /** Absolute path of the built SSR entry chunk, or undefined for CSR-only apps. */
 function resolveSsrEntry(ssrDir: string, ssrEntryKey: string): string | undefined {
-  const manifest = loadManifest(
-    resolve(ssrDir, '.vite/manifest.json'),
-    resolve(ssrDir, 'manifest.json'),
-  )
-
-  const entryFile = manifest?.[ssrEntryKey]?.file
-  if (!entryFile) {
+  const file = resolveSsrEntryFile(ssrDir, ssrEntryKey, 'Lambda build')
+  if (!file) {
     return undefined
-  }
-
-  const file = resolve(ssrDir, entryFile)
-  if (!file.startsWith(ssrDir + sep)) {
-    throw new Error(
-      `Lambda build: SSR manifest entry "${entryFile}" escapes the SSR output directory ${ssrDir}.`,
-    )
-  }
-  if (!existsSync(file)) {
-    throw new Error(`Lambda build: SSR manifest points at ${file}, but the file does not exist.`)
   }
 
   // Checked statically rather than by importing the chunk: executing the SSR

--- a/packages/plugin-lambda/src/build.ts
+++ b/packages/plugin-lambda/src/build.ts
@@ -1,16 +1,21 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { isAbsolute, relative, resolve, sep } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { relative, resolve, sep } from 'node:path'
+import {
+  assertOutputDirOutsideRoot,
+  DEV_ONLY_MODULES,
+  importSpecifier,
+  loadManifest,
+  MCP_SDK_SUBPATH_PREFIX,
+  resolveClientAssetEnv,
+  resolvePathLike,
+  type ClientAssetEnv,
+  type DevOnlyModule,
+  type PathLike,
+} from '@guren/core/internal/deploy-build'
 import { LAMBDA_HANDLER_EXPORTS, LAMBDA_HANDLER_MODULE } from './handlers'
 
-type PathLike = string | URL
-
-type ManifestEntry = {
-  file?: string
-  css?: string[]
-}
-
-type Manifest = Record<string, ManifestEntry>
+/** Prefixes every diagnostic this build emits. */
+const LABEL = 'Lambda build'
 
 export interface BuildLambdaOutputOptions {
   /** App root directory. Defaults to the current working directory. */
@@ -37,44 +42,56 @@ export interface BuildLambdaOutputOptions {
 
 const MCP_UNAVAILABLE = 'The MCP endpoint is unavailable on AWS Lambda — it generates files on disk.'
 
-function mcpStub(exportNames: string[]): string {
-  const throwing = exportNames
-    .map((name) => `export class ${name} { constructor() { throw new Error(${JSON.stringify(MCP_UNAVAILABLE)}) } }`)
-    .join('\n')
-  return `${throwing}\nexport default {}\n`
-}
-
 /**
- * Modules that exist in every Guren app's graph but can never run on the
- * Lambda Node.js runtime, reached only through dev-time branches: `bun:sqlite`
- * (the local sqlite ORM factory), `vite` (the dev asset server), and the
- * opt-in MCP endpoint's generators. They are replaced with throwing stubs
- * rather than left external — inlining a lazily-imported module hoists that
- * module's own static imports to the bundle top level, so an external module
- * reached this way (the MCP SDK) would fail at import time on Lambda even
- * though no code path ever runs it. Stubbing also keeps megabytes of dev
- * tooling out of the bundle.
+ * Why the dev-only modules in `DEV_ONLY_MODULES` cannot run here, worded for
+ * this platform: each names the Lambda-appropriate replacement.
  */
-const DEV_ONLY_STUBS: Record<string, string> = {
-  'bun:sqlite':
-    'export const Database = class { constructor() { throw new Error("bun:sqlite is unavailable on AWS Lambda — use createAwsDataApiDatabase() or createPostgresDatabase().") } }\nexport default { Database }\n',
-  vite:
-    'export function createServer() { throw new Error("The Vite dev server is unavailable on AWS Lambda — serve assets from S3/CloudFront.") }\nexport default { createServer }\n',
-  '@guren/cli': `// ${MCP_UNAVAILABLE}\nexport {}\n`,
-  '@modelcontextprotocol/sdk/server/mcp.js': mcpStub(['McpServer', 'ResourceTemplate']),
-  '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js': mcpStub(['WebStandardStreamableHTTPServerTransport']),
+const UNAVAILABLE_ON_LAMBDA: Record<DevOnlyModule['kind'], string> = {
+  sqlite: 'bun:sqlite is unavailable on AWS Lambda — use createAwsDataApiDatabase() or createPostgresDatabase().',
+  vite: 'The Vite dev server is unavailable on AWS Lambda — serve assets from S3/CloudFront.',
+  mcp: MCP_UNAVAILABLE,
 }
 
-// The MCP SDK is only ever reached through subpaths, so any of them — not
-// just the two listed above — must resolve to a stub rather than the real
-// package. Unlisted subpaths get `unlistedMcpStub` in onLoad.
-const MCP_SDK_PREFIX = '@modelcontextprotocol/sdk/'
+/**
+ * Render a dev-only module as inline source for the bundler plugin below.
+ *
+ * Every name the importer destructures has to be present or the bundle fails
+ * with "no matching export", so each is emitted as a throwing function. A
+ * function rather than a class deliberately: the stubbed names are a mix of
+ * constructors (`new Database()`) and plain calls (`createServer()`), and only
+ * a function throws the intended message under both — invoking a class without
+ * `new` reports "Class constructor cannot be invoked without 'new'" instead. A
+ * module read only through namespace property access needs no names, and gets
+ * a bare comment.
+ */
+function renderStub({ kind, exportNames }: DevOnlyModule): string {
+  const message = UNAVAILABLE_ON_LAMBDA[kind]
+  if (exportNames.length === 0) {
+    return `// ${message}\nexport {}\n`
+  }
+
+  const throwing = exportNames
+    .map((name) => `export function ${name}() { throw new Error(${JSON.stringify(message)}) }`)
+    .join('\n')
+  return `${throwing}\nexport default { ${exportNames.join(', ')} }\n`
+}
 
 /**
- * Fallback for an MCP SDK subpath the table does not name. It cannot know
- * which names the importer destructures, so it throws on evaluation rather
- * than resolving to an empty module: a subpath reached from app code (not
- * Guren's disabled MCP endpoint) must fail loudly at build or cold start,
+ * Dev-only modules replaced with throwing stubs rather than left external.
+ * Inlining a lazily-imported module hoists that module's own static imports to
+ * the bundle top level, so an external module reached this way (the MCP SDK)
+ * would fail at import time on Lambda even though no code path ever runs it.
+ * Stubbing also keeps megabytes of dev tooling out of the bundle.
+ */
+const DEV_ONLY_STUBS: Record<string, string> = Object.fromEntries(
+  DEV_ONLY_MODULES.map((module) => [module.specifier, renderStub(module)]),
+)
+
+/**
+ * Fallback for an MCP SDK subpath `DEV_ONLY_MODULES` does not name. It cannot
+ * know which names the importer destructures, so it throws on evaluation
+ * rather than resolving to an empty module: a subpath reached from app code
+ * (not Guren's disabled MCP endpoint) must fail loudly at build or cold start,
  * never silently hand back missing exports.
  */
 const unlistedMcpStub = `throw new Error(${JSON.stringify(MCP_UNAVAILABLE)})\n`
@@ -83,10 +100,13 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
-// Derived from DEV_ONLY_STUBS so the record stays the only list of stubbed
+// Derived from the shared list so it stays the only enumeration of stubbed
 // specifiers — a hand-maintained regex could silently fall out of sync.
 const STUB_FILTER = new RegExp(
-  `^(?:${[...Object.keys(DEV_ONLY_STUBS).map(escapeRegExp), `${escapeRegExp(MCP_SDK_PREFIX)}.+`].join('|')})$`,
+  `^(?:${[
+    ...DEV_ONLY_MODULES.map((module) => escapeRegExp(module.specifier)),
+    `${escapeRegExp(MCP_SDK_SUBPATH_PREFIX)}.+`,
+  ].join('|')})$`,
 )
 
 /**
@@ -105,15 +125,7 @@ export async function buildLambdaOutput(options: BuildLambdaOutputOptions = {}):
   const clientEntryKey = options.clientEntryKey ?? 'resources/js/app.tsx'
   const ssrEntryKey = options.ssrEntryKey ?? 'resources/js/ssr.tsx'
 
-  // Compared with `relative` rather than a string prefix: `out + sep` is `//`
-  // at the filesystem root, which no absolute path starts with, so a prefix
-  // test would wave `outputDir: '/'` straight through to the rmSync below.
-  const outToRoot = relative(out, root)
-  if (outToRoot === '' || (!outToRoot.startsWith('..') && !isAbsolute(outToRoot))) {
-    throw new Error(
-      `Lambda build: outputDir (${out}) must be a directory outside or below the app root, never the root itself or a parent of it — it is deleted on every build.`,
-    )
-  }
+  assertOutputDirOutsideRoot(out, root, LABEL)
 
   if (!options.skipAppBuild) {
     runAppBuild(root)
@@ -126,7 +138,7 @@ export async function buildLambdaOutput(options: BuildLambdaOutputOptions = {}):
   }
 
   const ssrFile = resolveSsrEntry(ssrDir, ssrEntryKey)
-  const assetEnv = resolveClientAssetEnv(publicDir, clientEntryKey)
+  const assetEnv = resolveClientAssetEnv(publicDir, clientEntryKey, LABEL)
 
   if (existsSync(out)) {
     rmSync(out, { recursive: true, force: true })
@@ -242,7 +254,7 @@ function renderHandlerModule(input: {
   lines.push(
     '// Imported dynamically so the assignments above run before the app module',
     '// graph evaluates — static imports are hoisted past them.',
-    `const module = await import(${JSON.stringify(importSpecifier(input.out, input.entrypoint))})`,
+    `const module = await import(${JSON.stringify(importSpecifier(input.out, input.entrypoint, LABEL))})`,
     '',
   )
 
@@ -407,59 +419,3 @@ function hasRendererExport(source: string): boolean {
   )
 }
 
-interface ClientAssetEnv {
-  entry?: string
-  styles?: string
-}
-
-function resolveClientAssetEnv(publicDir: string, clientEntryKey: string): ClientAssetEnv {
-  const manifest = loadManifest(
-    resolve(publicDir, 'assets/.vite/manifest.json'),
-    resolve(publicDir, 'assets/manifest.json'),
-  )
-
-  const entry = manifest?.[clientEntryKey]
-  if (!entry?.file) {
-    console.warn(
-      `Lambda build: no client manifest entry for "${clientEntryKey}"; GUREN_INERTIA_ENTRY will not be set.`,
-    )
-    return {}
-  }
-
-  return {
-    entry: `/assets/${entry.file}`,
-    styles: entry.css?.length ? entry.css.map((file) => `/assets/${file}`).join(',') : undefined,
-  }
-}
-
-function importSpecifier(fromDir: string, target: string): string {
-  const rel = relative(fromDir, target)
-  if (isAbsolute(rel)) {
-    throw new Error(
-      `Lambda build: ${target} cannot be imported relative to ${fromDir} (different drive or root?). Keep the app, SSR output, and outputDir on the same volume.`,
-    )
-  }
-
-  const specifier = rel.split(sep).join('/')
-  return specifier.startsWith('.') ? specifier : `./${specifier}`
-}
-
-function resolvePathLike(value: PathLike): string {
-  return value instanceof URL ? fileURLToPath(value) : resolve(String(value))
-}
-
-function loadManifest(...paths: string[]): Manifest | undefined {
-  for (const path of paths) {
-    if (!existsSync(path)) {
-      continue
-    }
-
-    try {
-      return JSON.parse(readFileSync(path, 'utf8')) as Manifest
-    } catch {
-      continue
-    }
-  }
-
-  return undefined
-}

--- a/packages/plugin-vercel/src/index.ts
+++ b/packages/plugin-vercel/src/index.ts
@@ -1,16 +1,15 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { basename, extname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { definePlugin, type ServiceProviderConstructor } from '@guren/core'
+import {
+  assertOutputDirOutsideRoot,
+  loadManifest,
+  resolvePathLike,
+  type PathLike,
+} from '@guren/core/internal/deploy-build'
 
-type PathLike = string | URL
-
-type ManifestEntry = {
-  file?: string
-  css?: string[]
-}
-
-type Manifest = Record<string, ManifestEntry>
+/** Prefixes every diagnostic this build emits. */
+const LABEL = 'Vercel build'
 
 export interface VercelAppLike {
   boot(): Promise<void>
@@ -73,6 +72,8 @@ export function buildVercelOutput(options: BuildVercelOutputOptions = {}): void 
   const docsDir = resolvePathLike(options.docsDir ?? resolveNearestDocsDir(root) ?? resolve(root, 'docs'))
   const ssrDir = resolvePathLike(options.ssrDir ?? resolve(root, '.guren/ssr'))
   const migrationsDir = resolvePathLike(options.migrationsDir ?? resolve(root, 'db/migrations'))
+
+  assertOutputDirOutsideRoot(out, root, LABEL)
 
   if (existsSync(out)) {
     rmSync(out, { recursive: true, force: true })
@@ -218,10 +219,6 @@ function buildVercelEnvironment(root: string): Record<string, string> {
   return env
 }
 
-function resolvePathLike(value: PathLike): string {
-  return value instanceof URL ? fileURLToPath(value) : resolve(String(value))
-}
-
 function resolveNearestDocsDir(startDir: string, maxDepth = 6): string | undefined {
   let currentDir = startDir
 
@@ -241,18 +238,3 @@ function resolveNearestDocsDir(startDir: string, maxDepth = 6): string | undefin
   return undefined
 }
 
-function loadManifest(...paths: string[]): Manifest | undefined {
-  for (const path of paths) {
-    if (!existsSync(path)) {
-      continue
-    }
-
-    try {
-      return JSON.parse(readFileSync(path, 'utf8')) as Manifest
-    } catch {
-      continue
-    }
-  }
-
-  return undefined
-}

--- a/packages/plugin-vercel/src/index.ts
+++ b/packages/plugin-vercel/src/index.ts
@@ -1,10 +1,12 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { basename, extname, resolve } from 'node:path'
+import { basename, extname, relative, resolve, sep } from 'node:path'
 import { definePlugin, type ServiceProviderConstructor } from '@guren/core'
 import {
-  assertOutputDirOutsideRoot,
-  loadManifest,
+  resetOutputDir,
+  resolveClientAssetEnv,
   resolvePathLike,
+  resolveSsrEntryFile,
+  ssrManifestRelativePath,
   type PathLike,
 } from '@guren/core/internal/deploy-build'
 
@@ -73,16 +75,12 @@ export function buildVercelOutput(options: BuildVercelOutputOptions = {}): void 
   const ssrDir = resolvePathLike(options.ssrDir ?? resolve(root, '.guren/ssr'))
   const migrationsDir = resolvePathLike(options.migrationsDir ?? resolve(root, 'db/migrations'))
 
-  assertOutputDirOutsideRoot(out, root, LABEL)
-
-  if (existsSync(out)) {
-    rmSync(out, { recursive: true, force: true })
-  }
+  resetOutputDir(out, root, LABEL)
 
   mkdirSync(funcDir, { recursive: true })
   mkdirSync(resolve(out, 'static'), { recursive: true })
 
-  const env = buildVercelEnvironment(root)
+  const env = buildVercelEnvironment(publicDir, ssrDir)
 
   writeFileSync(
     resolve(out, 'config.json'),
@@ -176,7 +174,7 @@ export function buildVercelOutput(options: BuildVercelOutputOptions = {}): void 
   }
 }
 
-function buildVercelEnvironment(root: string): Record<string, string> {
+function buildVercelEnvironment(publicDir: string, ssrDir: string): Record<string, string> {
   const env: Record<string, string> = {
     NODE_ENV: 'production',
     BUN_RUNTIME_TRANSPILER_CACHE_PATH: '/tmp/.bun-cache',
@@ -184,32 +182,20 @@ function buildVercelEnvironment(root: string): Record<string, string> {
     TMPDIR: '/tmp',
   }
 
-  const clientManifest = loadManifest(
-    resolve(root, 'public/assets/.vite/manifest.json'),
-    resolve(root, 'public/assets/manifest.json'),
-  )
-
-  if (clientManifest) {
-    const entry = clientManifest['resources/js/app.tsx']
-    if (entry?.file) {
-      env.GUREN_INERTIA_ENTRY = `/assets/${entry.file}`
-    }
-    if (entry?.css?.length) {
-      env.GUREN_INERTIA_STYLES = entry.css.map((file) => `/assets/${file}`).join(',')
-    }
+  const assetEnv = resolveClientAssetEnv(publicDir, 'resources/js/app.tsx', LABEL)
+  if (assetEnv.entry) {
+    env.GUREN_INERTIA_ENTRY = assetEnv.entry
+  }
+  if (assetEnv.styles) {
+    env.GUREN_INERTIA_STYLES = assetEnv.styles
   }
 
-  const ssrManifest = loadManifest(
-    resolve(root, '.guren/ssr/.vite/manifest.json'),
-    resolve(root, '.guren/ssr/manifest.json'),
-  )
-
-  if (ssrManifest) {
-    const ssrEntry = ssrManifest['resources/js/ssr.tsx']
-    if (ssrEntry?.file) {
-      env.GUREN_INERTIA_SSR_ENTRY = `./.guren/ssr/${ssrEntry.file}`
-    }
-    env.GUREN_INERTIA_SSR_MANIFEST = './.guren/ssr/.vite/manifest.json'
+  const ssrFile = resolveSsrEntryFile(ssrDir, 'resources/js/ssr.tsx', LABEL)
+  if (ssrFile) {
+    // Relative specifiers resolve from the function root, where the SSR bundle
+    // is copied.
+    env.GUREN_INERTIA_SSR_ENTRY = `./.guren/ssr/${relative(ssrDir, ssrFile).split(sep).join('/')}`
+    env.GUREN_INERTIA_SSR_MANIFEST = ssrManifestRelativePath(ssrDir, './.guren/ssr')
   }
 
   env.GUREN_INERTIA_IMPORT_MAP = JSON.stringify({

--- a/packages/plugin-vercel/src/index.ts
+++ b/packages/plugin-vercel/src/index.ts
@@ -1,5 +1,5 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { basename, extname, relative, resolve, sep } from 'node:path'
+import { basename, extname, resolve } from 'node:path'
 import { definePlugin, type ServiceProviderConstructor } from '@guren/core'
 import {
   assertOutputDirOutsideRoot,
@@ -7,7 +7,7 @@ import {
   resolveClientAssetEnv,
   resolvePathLike,
   resolveSsrEntryFile,
-  ssrManifestRelativePath,
+  ssrRuntimePaths,
   type PathLike,
 } from '@guren/core/internal/deploy-build'
 
@@ -80,6 +80,14 @@ export function buildVercelOutput(options: BuildVercelOutputOptions = {}): void 
   // delete waits until the environment resolves — a stale or partial SSR build
   // must not take the previous deploy output with it.
   assertOutputDirOutsideRoot(out, root, LABEL)
+
+  // Checked here rather than left to the spawned `bun build`, which only
+  // fails after the previous output is gone.
+  if (!existsSync(entrypoint)) {
+    throw new Error(
+      `${LABEL}: entrypoint not found at ${entrypoint}. Run \`bunx guren plugin @guren/plugin-vercel\` to scaffold src/vercel.ts, or pass "entrypoint".`,
+    )
+  }
 
   const env = buildVercelEnvironment(publicDir, ssrDir)
 
@@ -200,10 +208,10 @@ function buildVercelEnvironment(publicDir: string, ssrDir: string): Record<strin
   if (ssrFile) {
     // Relative specifiers resolve from the function root, where the SSR bundle
     // is copied.
-    env.GUREN_INERTIA_SSR_ENTRY = `./.guren/ssr/${relative(ssrDir, ssrFile).split(sep).join('/')}`
-    const manifestPath = ssrManifestRelativePath(ssrDir, './.guren/ssr')
-    if (manifestPath) {
-      env.GUREN_INERTIA_SSR_MANIFEST = manifestPath
+    const ssrPaths = ssrRuntimePaths(ssrDir, ssrFile, './.guren/ssr')
+    env.GUREN_INERTIA_SSR_ENTRY = ssrPaths.entry
+    if (ssrPaths.manifest) {
+      env.GUREN_INERTIA_SSR_MANIFEST = ssrPaths.manifest
     }
   }
 

--- a/packages/plugin-vercel/src/index.ts
+++ b/packages/plugin-vercel/src/index.ts
@@ -1,7 +1,8 @@
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { basename, extname, relative, resolve, sep } from 'node:path'
 import { definePlugin, type ServiceProviderConstructor } from '@guren/core'
 import {
+  assertOutputDirOutsideRoot,
   resetOutputDir,
   resolveClientAssetEnv,
   resolvePathLike,
@@ -75,12 +76,17 @@ export function buildVercelOutput(options: BuildVercelOutputOptions = {}): void 
   const ssrDir = resolvePathLike(options.ssrDir ?? resolve(root, '.guren/ssr'))
   const migrationsDir = resolvePathLike(options.migrationsDir ?? resolve(root, 'db/migrations'))
 
+  // Validated up front so a bad option fails before anything else, but the
+  // delete waits until the environment resolves — a stale or partial SSR build
+  // must not take the previous deploy output with it.
+  assertOutputDirOutsideRoot(out, root, LABEL)
+
+  const env = buildVercelEnvironment(publicDir, ssrDir)
+
   resetOutputDir(out, root, LABEL)
 
   mkdirSync(funcDir, { recursive: true })
   mkdirSync(resolve(out, 'static'), { recursive: true })
-
-  const env = buildVercelEnvironment(publicDir, ssrDir)
 
   writeFileSync(
     resolve(out, 'config.json'),
@@ -195,7 +201,10 @@ function buildVercelEnvironment(publicDir: string, ssrDir: string): Record<strin
     // Relative specifiers resolve from the function root, where the SSR bundle
     // is copied.
     env.GUREN_INERTIA_SSR_ENTRY = `./.guren/ssr/${relative(ssrDir, ssrFile).split(sep).join('/')}`
-    env.GUREN_INERTIA_SSR_MANIFEST = ssrManifestRelativePath(ssrDir, './.guren/ssr')
+    const manifestPath = ssrManifestRelativePath(ssrDir, './.guren/ssr')
+    if (manifestPath) {
+      env.GUREN_INERTIA_SSR_MANIFEST = manifestPath
+    }
   }
 
   env.GUREN_INERTIA_IMPORT_MAP = JSON.stringify({

--- a/packages/plugin-vercel/tests/index.test.ts
+++ b/packages/plugin-vercel/tests/index.test.ts
@@ -62,6 +62,19 @@ describe('@guren/plugin-vercel', () => {
       rmSync(root, { recursive: true, force: true })
     })
 
+    it('refuses an outputDir that is, contains, or is the root of the app', () => {
+      // The build deletes outputDir before writing it, so a caller that points
+      // it at the project (or at `/`) would lose the source tree.
+      const app = scaffoldApp(root, { entrypoint: 'src/vercel.ts' })
+
+      for (const outputDir of [root, join(root, '..'), '/']) {
+        expect(() => buildVercelOutput({ ...app, outputDir })).toThrow(
+          /never the root itself or a parent of it/,
+        )
+      }
+      expect(readFileSync(app.entrypoint, 'utf8')).toBe(DEFAULT_ENTRYPOINT_SOURCE)
+    })
+
     it('matches the configured handler filename to the bundled entrypoint', () => {
       const app = scaffoldApp(root, { entrypoint: 'src/vercel.ts' })
 

--- a/packages/plugin-vercel/tests/index.test.ts
+++ b/packages/plugin-vercel/tests/index.test.ts
@@ -116,11 +116,13 @@ describe('@guren/plugin-vercel', () => {
       expect(config.environment.GUREN_INERTIA_SSR_MANIFEST).toBe('./.guren/ssr/manifest.json')
     })
 
-    it('fails when the SSR manifest names a chunk that is not on disk', () => {
+    it('fails when the SSR manifest names a chunk that is not on disk, keeping the previous output', () => {
       // Previously written into the function environment unchecked, so a stale
       // or partial SSR build deployed and fell back to CSR at request time.
       // Cloudflare and Lambda already treated this as fatal.
       const app = scaffoldApp(root, { entrypoint: 'src/vercel.ts' })
+      mkdirSync(join(app.outputDir, 'functions'), { recursive: true })
+      writeFileSync(join(app.outputDir, 'config.json'), '{ "previous": true }')
       mkdirSync(join(root, '.guren/ssr/.vite'), { recursive: true })
       writeFileSync(
         join(root, '.guren/ssr/.vite/manifest.json'),
@@ -128,6 +130,21 @@ describe('@guren/plugin-vercel', () => {
       )
 
       expect(() => buildVercelOutput(app)).toThrow(/but the file does not exist/)
+      // Deleting before validation would take the last deployable artifact
+      // with it, leaving nothing to roll back to.
+      expect(readFileSync(join(app.outputDir, 'config.json'), 'utf8')).toBe('{ "previous": true }')
+    })
+
+    it('fails on a missing entrypoint before touching the previous output', () => {
+      // The spawned `bun build` would also fail on this, but only after the
+      // previous output was deleted.
+      const app = scaffoldApp(root, { entrypoint: 'src/vercel.ts' })
+      rmSync(app.entrypoint)
+      mkdirSync(join(app.outputDir, 'functions'), { recursive: true })
+      writeFileSync(join(app.outputDir, 'config.json'), '{ "previous": true }')
+
+      expect(() => buildVercelOutput(app)).toThrow(/entrypoint not found/)
+      expect(readFileSync(join(app.outputDir, 'config.json'), 'utf8')).toBe('{ "previous": true }')
     })
 
     it('matches the configured handler filename to the bundled entrypoint', () => {

--- a/packages/plugin-vercel/tests/index.test.ts
+++ b/packages/plugin-vercel/tests/index.test.ts
@@ -75,6 +75,47 @@ describe('@guren/plugin-vercel', () => {
       expect(readFileSync(app.entrypoint, 'utf8')).toBe(DEFAULT_ENTRYPOINT_SOURCE)
     })
 
+    it('reads the client manifest from a custom publicDir', () => {
+      const app = scaffoldApp(root, { entrypoint: 'src/vercel.ts' })
+      mkdirSync(join(root, 'web-root/assets/.vite'), { recursive: true })
+      writeFileSync(
+        join(root, 'web-root/assets/.vite/manifest.json'),
+        JSON.stringify({
+          'resources/js/app.tsx': { file: 'app-Custom999.js', css: ['app-Custom999.css'] },
+        }),
+      )
+
+      buildVercelOutput({ ...app, publicDir: join(root, 'web-root') })
+
+      const config = JSON.parse(
+        readFileSync(join(app.outputDir, 'functions/index.func/.vc-config.json'), 'utf8'),
+      ) as { environment: Record<string, string> }
+
+      expect(config.environment.GUREN_INERTIA_ENTRY).toBe('/assets/app-Custom999.js')
+      expect(config.environment.GUREN_INERTIA_STYLES).toBe('/assets/app-Custom999.css')
+    })
+
+    it('points GUREN_INERTIA_SSR_MANIFEST at the layout the SSR build produced', () => {
+      // Older Vite configs emit a flat manifest.json; naming the .vite path
+      // unconditionally leaves the runtime loading a file that is not there.
+      const app = scaffoldApp(root, { entrypoint: 'src/vercel.ts' })
+      mkdirSync(join(root, '.guren/ssr'), { recursive: true })
+      writeFileSync(join(root, '.guren/ssr/ssr-Xyz789.js'), 'export const render = () => ({})\n')
+      writeFileSync(
+        join(root, '.guren/ssr/manifest.json'),
+        JSON.stringify({ 'resources/js/ssr.tsx': { file: 'ssr-Xyz789.js' } }),
+      )
+
+      buildVercelOutput(app)
+
+      const config = JSON.parse(
+        readFileSync(join(app.outputDir, 'functions/index.func/.vc-config.json'), 'utf8'),
+      ) as { environment: Record<string, string> }
+
+      expect(config.environment.GUREN_INERTIA_SSR_ENTRY).toBe('./.guren/ssr/ssr-Xyz789.js')
+      expect(config.environment.GUREN_INERTIA_SSR_MANIFEST).toBe('./.guren/ssr/manifest.json')
+    })
+
     it('matches the configured handler filename to the bundled entrypoint', () => {
       const app = scaffoldApp(root, { entrypoint: 'src/vercel.ts' })
 

--- a/packages/plugin-vercel/tests/index.test.ts
+++ b/packages/plugin-vercel/tests/index.test.ts
@@ -116,6 +116,20 @@ describe('@guren/plugin-vercel', () => {
       expect(config.environment.GUREN_INERTIA_SSR_MANIFEST).toBe('./.guren/ssr/manifest.json')
     })
 
+    it('fails when the SSR manifest names a chunk that is not on disk', () => {
+      // Previously written into the function environment unchecked, so a stale
+      // or partial SSR build deployed and fell back to CSR at request time.
+      // Cloudflare and Lambda already treated this as fatal.
+      const app = scaffoldApp(root, { entrypoint: 'src/vercel.ts' })
+      mkdirSync(join(root, '.guren/ssr/.vite'), { recursive: true })
+      writeFileSync(
+        join(root, '.guren/ssr/.vite/manifest.json'),
+        JSON.stringify({ 'resources/js/ssr.tsx': { file: 'ssr-Gone.js' } }),
+      )
+
+      expect(() => buildVercelOutput(app)).toThrow(/but the file does not exist/)
+    })
+
     it('matches the configured handler filename to the bundled entrypoint', () => {
       const app = scaffoldApp(root, { entrypoint: 'src/vercel.ts' })
 


### PR DESCRIPTION
## Why

The three deploy plugins each carried their own copy of the same build-time code. `resolvePathLike` and `loadManifest` were byte-identical in all three; `importSpecifier` and `resolveClientAssetEnv` in two.

The part that actually motivates sharing is the dev-only module list. `bun:sqlite`, `vite`, `@guren/cli`, and the MCP SDK subpaths have to be stubbed out of any deployed bundle, and that list describes **`@guren/core`'s own module graph** — it changes when the framework changes, and a plugin that misses an entry ships a broken deploy. Keeping it in two places had already let them drift: Lambda routes any unlisted `@modelcontextprotocol/sdk/*` subpath to a stub, Cloudflare only ever aliased the two it named by hand.

## What is shared, and what deliberately is not

`@guren/core/internal/deploy-build` exports the mechanical helpers plus `DEV_ONLY_MODULES`, a list of `{ specifier, kind, exportNames }`. It imports only `node:` builtins, so a plugin's build step does not pull the framework runtime in behind it.

Rendering stays per plugin, because the platforms genuinely differ — wrangler resolves an `alias` to a path on disk so Cloudflare writes a file per stub, while Lambda inlines source into its `Bun.build` plugin, and each names its own replacement API in the message. Also left alone for the same reason:

| Kept per plugin | Why |
|---|---|
| `runAppBuild` | Fatal on Cloudflare, a warning on Lambda (API-only apps have no frontend build) |
| SSR renderer verification | Cloudflare imports the built chunk; Lambda greps its source, deliberately, to avoid running the app's module-scope side effects inside a build |
| `readPackageJson` | Only one consumer left after this change |

Internal per `contributing/api-stability.md`: reachable only through a deep import under `internal/`, never re-exported from core's index. Added to that document's Internal section.

## Behaviour changes

Three fall out of one implementation replacing three. All are fixes, and each is called out rather than left to hide inside a refactor:

- **`buildVercelOutput` gained the output-directory guard it never had.** It `rmSync`s `outputDir` before writing, so pointing it at the project deleted the source tree. Cloudflare and Lambda both guarded; Vercel did not.
- **Cloudflare and Vercel no longer accept `/` as `outputDir`.** The old check was `root.startsWith(out + sep)`, and `out + sep` is `//` at the filesystem root, which no absolute path is prefixed by. (Lambda's copy was fixed in #219; this brings the other two along and removes the follow-up task that tracked it.)
- **Cloudflare and Vercel honour a custom `publicDir`** when reading the client manifest, instead of always looking under `<root>/public` while the same option was respected everywhere else. Vercel likewise honours `ssrDir`.
- **Vercel no longer reports `GUREN_INERTIA_SSR_MANIFEST` as `.vite/manifest.json`** when the SSR build emitted the flat `manifest.json` layout. Lambda already branched on this; Vercel's copy had drifted.

## No migration for existing apps

An earlier revision of this branch derived Cloudflare's stub filenames from the module specifier, which renamed two files out from under every app's committed `wrangler.jsonc`. That churn was invented by the refactor, so it is gone: the filenames are hand-written again, and the map is keyed on `DevOnlySpecifier` so adding an entry to `DEV_ONLY_MODULES` is a compile error until it gets a filename. Same no-drift guarantee, no app-facing change, and no collision risk from a non-injective derivation.

## Verification

- `bun run build:clean`, `bun run typecheck` — clean
- `bun run test:bun` — 3017 pass, 54 skip, 0 fail
- `bun run test:examples` — 91 pass, 0 fail
- `bun run audit:core-first`, `bun run audit:docs` — passed
- New: 26 unit tests for the shared module. The per-specifier checks that the framework still imports each `DEV_ONLY_MODULES` entry match the **import form** rather than the bare string (matching `vite` alone also hits a `@vite-ignore` comment, which would have left them green after the real import was deleted), assert the declared export names appear in the importing file, and carry negative controls so a broken grep cannot make them pass vacuously. The "imports only node builtins" property the module documents is asserted against the built artifact.
- Every behaviour change above has a test **verified to fail without its fix**

## Review pass

A Codex review plus four cleanup passes ran against the first commit; `035bbfe` applies what they found. Two were substantive: the new output-directory guard fixed `outputDir: '/'` but regressed a case the old string-prefix check got right (a directory named `..-source` inside `out` reads as an escape under `startsWith('..')`), and Vercel had never adopted the shared helper, so it still had the exact `publicDir` bug this PR claimed to fix. The extraction also went further — `renderDevOnlyStub`, `stageStaticAssets`, and `resolveSsrEntryFile` were byte-identical across plugins and are now shared, and the guard is paired with the delete it protects as `resetOutputDir`.
