### PR TITLE
fix(cli): dispatch the app's own kernel from the Lambda console handler

### DIFF
--- a/.changeset/lambda-console-app-kernel.md
+++ b/.changeset/lambda-console-app-kernel.md
@@ -1,0 +1,16 @@
+---
+'@guren/cli': patch
+---
+
+The Lambda console handler now dispatches the app's own console kernel.
+
+The scaffolded `src/lambda.ts` built a second `ConsoleKernel` inline and
+registered a single `db:migrate` command on it. An app therefore had two
+kernels with different command sets: register five commands in `src/console.ts`,
+uncomment the Lambda console export, and the deployed function still knew only
+`db:migrate` — with nothing to warn you.
+
+The scaffold now imports `kernel` from `src/console.ts`, so every command
+reachable through `bun run console` is reachable on Lambda under the same name.
+The `db:migrate` recipe moved to the serverless guide, since needing it at all
+is specific to deploying where no CLI exists.

--- a/docs/en/guides/serverless.md
+++ b/docs/en/guides/serverless.md
@@ -84,11 +84,15 @@ Runs due tasks when invoked by EventBridge. Configure an EventBridge rule with `
 
 Executes the commands registered on your app's `ConsoleKernel` — the one `src/console.ts` exports as `kernel`. See the [console commands guide](./console.md) for defining commands and registering them.
 
-Uncomment the `console` export in the scaffolded `src/lambda.ts` to enable the handler. Because it dispatches the app's own kernel, every command you register in `src/console.ts` is reachable on Lambda under the same name you use locally.
+Uncomment the `console` export in the scaffolded `src/lambda.ts` to enable the handler.
 
-The kernel has no built-in commands, so applying migrations needs one of your own. `lambda:build` copies `db/migrations/` next to the bundle, so it can run in place:
+The kernel has no built-in commands. You need a migration command only on the Data API adapter, whose `getDatabase()` deliberately skips pending migrations — the other adapters apply them on first use. See [the Aurora Serverless notes](./database.md#aurora-serverless-aws-data-api) for that tradeoff and the `migrateOnStart` alternative. Running them out of band keeps the latency off the request path either way:
 
-```ts
+```bash
+bunx guren make:command Migrate --command db:migrate
+```
+
+```typescript
 // app/Console/Commands/MigrateCommand.ts
 import { Command } from '@guren/core'
 import { migrateDatabase } from '../../../config/database.js'
@@ -103,7 +107,7 @@ export default class MigrateCommand extends Command {
 }
 ```
 
-Register it in `src/console.ts`, then invoke via AWS CLI:
+`make:command` prints the line that registers it in `src/console.ts`. Then invoke via AWS CLI:
 
 ```bash
 aws lambda invoke --function-name my-app-console \

--- a/docs/en/guides/serverless.md
+++ b/docs/en/guides/serverless.md
@@ -84,9 +84,26 @@ Runs due tasks when invoked by EventBridge. Configure an EventBridge rule with `
 
 Executes the commands registered on your app's `ConsoleKernel` — the one `src/console.ts` exports as `kernel`. See the [console commands guide](./console.md) for defining commands and registering them.
 
-The kernel has no built-in commands. The scaffolded `src/lambda.ts` ships a commented-out `db:migrate` example; uncomment it and the `console` export to enable the handler.
+Uncomment the `console` export in the scaffolded `src/lambda.ts` to enable the handler. Because it dispatches the app's own kernel, every command you register in `src/console.ts` is reachable on Lambda under the same name you use locally.
 
-Invoke via AWS CLI:
+The kernel has no built-in commands, so applying migrations needs one of your own. `lambda:build` copies `db/migrations/` next to the bundle, so it can run in place:
+
+```ts
+// app/Console/Commands/MigrateCommand.ts
+import { Command } from '@guren/core'
+import { migrateDatabase } from '../../../config/database.js'
+
+export default class MigrateCommand extends Command {
+  static signature = 'db:migrate'
+  static description = 'Apply pending database migrations'
+
+  async handle(): Promise<void> {
+    await migrateDatabase()
+  }
+}
+```
+
+Register it in `src/console.ts`, then invoke via AWS CLI:
 
 ```bash
 aws lambda invoke --function-name my-app-console \
@@ -202,7 +219,7 @@ const app = createApp({
 
 The scaffolded `config/app.ts` seeds the database on boot as a local development convenience and skips it when `NODE_ENV=production`. Keep that guard — Lambda boots the app on every cold start, so boot-time seeding would re-run against production data.
 
-**Migrations** ship with the function: `lambda:build` copies `db/migrations/` next to the bundle, so the scaffold's `db:migrate` console command can apply them in place once you uncomment it. See [Console — `createConsoleHandler(kernel)`](#console--createconsolehandlerkernel) for the command definition and how to invoke it.
+**Migrations** ship with the function: `lambda:build` copies `db/migrations/` next to the bundle, so a `db:migrate` console command can apply them in place. See [Console — `createConsoleHandler(kernel)`](#console--createconsolehandlerkernel) for the command and how to invoke it.
 
 **Seeders cannot run inside the function.** They are ordinary `.ts` modules that import your schema and `@guren/core`, and the deployed function is a self-contained bundle with no `node_modules` and no TypeScript loader — the Node.js runtime rejects them outright. Seed from somewhere that has the project source instead:
 

--- a/docs/ja/guides/serverless.md
+++ b/docs/ja/guides/serverless.md
@@ -84,11 +84,15 @@ EventBridge から呼び出されたときに実行予定のタスクを処理�
 
 アプリの `ConsoleKernel` に登録したコマンド — `src/console.ts` が `kernel` としてエクスポートするもの — を実行します。コマンドの定義と登録については [コンソールコマンドガイド](./console.md) を参照してください。
 
-スキャフォールドされた `src/lambda.ts` の `console` export のコメントを外すとハンドラが有効になります。アプリ自身のカーネルをディスパッチするため、`src/console.ts` に登録したコマンドはすべて、ローカルと同じ名前で Lambda 上でも呼び出せます。
+スキャフォールドされた `src/lambda.ts` の `console` export のコメントを外すとハンドラが有効になります。
 
-カーネルに組み込みコマンドはないので、マイグレーションの適用には自分のコマンドが必要です。`lambda:build` が `db/migrations/` をバンドルの隣にコピーするため、その場で実行できます。
+カーネルに組み込みコマンドはありません。マイグレーション用のコマンドが必要になるのは Data API アダプタだけです（`getDatabase()` が意図的に未適用のマイグレーションを実行しないため。他のアダプタは初回利用時に適用します）。このトレードオフと `migrateOnStart` については [Aurora Serverless の項](./database.md#aurora-serverlessaws-data-apiサポート) を参照してください。いずれにせよ、帯域外で実行すればリクエストパスからレイテンシを外せます。
 
-```ts
+```bash
+bunx guren make:command Migrate --command db:migrate
+```
+
+```typescript
 // app/Console/Commands/MigrateCommand.ts
 import { Command } from '@guren/core'
 import { migrateDatabase } from '../../../config/database.js'
@@ -103,7 +107,7 @@ export default class MigrateCommand extends Command {
 }
 ```
 
-これを `src/console.ts` に登録したうえで、AWS CLI から呼び出します:
+`make:command` が `src/console.ts` への登録行を出力します。そのうえで AWS CLI から呼び出します:
 
 ```bash
 aws lambda invoke --function-name my-app-console \

--- a/docs/ja/guides/serverless.md
+++ b/docs/ja/guides/serverless.md
@@ -84,9 +84,26 @@ EventBridge から呼び出されたときに実行予定のタスクを処理�
 
 アプリの `ConsoleKernel` に登録したコマンド — `src/console.ts` が `kernel` としてエクスポートするもの — を実行します。コマンドの定義と登録については [コンソールコマンドガイド](./console.md) を参照してください。
 
-カーネルに組み込みコマンドはありません。スキャフォールドされた `src/lambda.ts` に `db:migrate` のコメントアウト済みの例が同梱されているので、それと `console` export のコメントを外して有効化します。
+スキャフォールドされた `src/lambda.ts` の `console` export のコメントを外すとハンドラが有効になります。アプリ自身のカーネルをディスパッチするため、`src/console.ts` に登録したコマンドはすべて、ローカルと同じ名前で Lambda 上でも呼び出せます。
 
-AWS CLI から呼び出します:
+カーネルに組み込みコマンドはないので、マイグレーションの適用には自分のコマンドが必要です。`lambda:build` が `db/migrations/` をバンドルの隣にコピーするため、その場で実行できます。
+
+```ts
+// app/Console/Commands/MigrateCommand.ts
+import { Command } from '@guren/core'
+import { migrateDatabase } from '../../../config/database.js'
+
+export default class MigrateCommand extends Command {
+  static signature = 'db:migrate'
+  static description = 'Apply pending database migrations'
+
+  async handle(): Promise<void> {
+    await migrateDatabase()
+  }
+}
+```
+
+これを `src/console.ts` に登録したうえで、AWS CLI から呼び出します:
 
 ```bash
 aws lambda invoke --function-name my-app-console \
@@ -202,7 +219,7 @@ const app = createApp({
 
 スキャフォールドされた `config/app.ts` は、ローカル開発の利便性としてブート時にシードを実行し、`NODE_ENV=production` ではスキップします。このガードはそのまま残してください。Lambda はコールドスタートのたびにアプリをブートするため、ブート時シードは本番データに対して繰り返し実行されてしまいます。
 
-**マイグレーションは関数に同梱されます。** `lambda:build` が `db/migrations/` をバンドルの隣にコピーするため、スキャフォールドの `db:migrate` コンソールコマンドのコメントを外せばその場で適用できます。コマンド定義と呼び出し方は [コンソール — `createConsoleHandler(kernel)`](#コンソール--createconsolehandlerkernel) を参照してください。
+**マイグレーションは関数に同梱されます。** `lambda:build` が `db/migrations/` をバンドルの隣にコピーするため、`db:migrate` コンソールコマンドでその場で適用できます。コマンド定義と呼び出し方は [コンソール — `createConsoleHandler(kernel)`](#コンソール--createconsolehandlerkernel) を参照してください。
 
 **シーダーは関数内では実行できません。** シーダーはスキーマや `@guren/core` を import する通常の `.ts` モジュールですが、デプロイされる関数は `node_modules` も TypeScript ローダーも持たない自己完結バンドルであり、Node.js ランタイムはこれらを読み込めません。プロジェクトのソースがある環境からシードしてください:
 

--- a/examples/deploy/serverless/README.md
+++ b/examples/deploy/serverless/README.md
@@ -62,7 +62,7 @@ The stack outputs the CloudFront URL (serve traffic from here) and the raw API e
 
 ### 5. Run migrations
 
-The console function executes commands registered on your app's `ConsoleKernel`. The scaffolded `src/lambda.ts` ships a commented-out `db:migrate` command — uncomment it (and the `console` export) before building, then invoke it inside the deployed environment:
+The console function dispatches the kernel your app exports from `src/console.ts`, so any command registered there is available here. Register a `db:migrate` command (see the [serverless guide](https://guren.dev/docs/guides/serverless)), uncomment the `console` export in `src/lambda.ts` before building, then invoke it inside the deployed environment:
 
 ```bash
 aws lambda invoke --function-name <stack>-Console... \

--- a/examples/deploy/serverless/README.md
+++ b/examples/deploy/serverless/README.md
@@ -62,7 +62,7 @@ The stack outputs the CloudFront URL (serve traffic from here) and the raw API e
 
 ### 5. Run migrations
 
-The console function dispatches the kernel your app exports from `src/console.ts`, so any command registered there is available here. Register a `db:migrate` command (see the [serverless guide](https://guren.dev/docs/guides/serverless)), uncomment the `console` export in `src/lambda.ts` before building, then invoke it inside the deployed environment:
+Register a `db:migrate` command in `src/console.ts` (see the [serverless guide](../../../docs/en/guides/serverless.md)), uncomment the `console` export in `src/lambda.ts` before building, then invoke it inside the deployed environment:
 
 ```bash
 aws lambda invoke --function-name <stack>-Console... \

--- a/examples/deploy/serverless/cdk/bin/app.ts
+++ b/examples/deploy/serverless/cdk/bin/app.ts
@@ -27,10 +27,10 @@ new GurenLambdaApp(stack, 'App', {
   // Remove if the app dispatches no jobs.
   queue: {},
 
-  // Console function: run ConsoleKernel commands in the deployed environment.
-  // Requires the `console` export in src/lambda.ts — the scaffold ships a
-  // commented-out db:migrate command; uncomment it before `lambda:build`,
-  // then invoke it:
+  // Console function: run your app's console commands in the deployed
+  // environment. Requires the `console` export in src/lambda.ts, which
+  // dispatches the kernel src/console.ts exports — register a db:migrate
+  // command there, uncomment the export before `lambda:build`, then invoke:
   //   aws lambda invoke --function-name ... \
   //     --cli-binary-format raw-in-base64-out \
   //     --payload '{"command":"db:migrate"}' out.json

--- a/packages/cli/src/plugin-lambda.ts
+++ b/packages/cli/src/plugin-lambda.ts
@@ -42,24 +42,14 @@ export const queue = createSqsHandler()
 // import { scheduler } from './scheduler.js'
 // export const schedule = createScheduleHandler(scheduler)
 
-// Console commands — uncomment to run kernel commands (the kernel has no
-// built-in ones) with \`aws lambda invoke\`.
-// Writing commands: https://guren.dev/docs/guides/console
+// Console commands — uncomment to run them with \`aws lambda invoke\`. This
+// dispatches the kernel src/console.ts exports, so every command registered
+// there is reachable here too, under the same name as \`bun run console\`.
+// Writing and registering commands: https://guren.dev/docs/guides/console
 // Seeders can't run in the bundle — use \`bunx guren db:seed --force\` instead.
-// import { Command, ConsoleKernel } from '@guren/core'
 // import { createConsoleHandler } from '@guren/core/lambda'
-// import { migrateDatabase } from '../config/database.js'
+// import { kernel } from './console.js'
 //
-// class MigrateCommand extends Command {
-//   static signature = 'db:migrate'
-//   static description = 'Apply pending database migrations'
-//   async handle(): Promise<void> {
-//     await migrateDatabase()
-//   }
-// }
-//
-// const kernel = new ConsoleKernel()
-// kernel.register(MigrateCommand)
 // const consoleHandler = createConsoleHandler(kernel)
 // export { consoleHandler as console }
 `

--- a/packages/cli/src/plugin-lambda.ts
+++ b/packages/cli/src/plugin-lambda.ts
@@ -25,14 +25,18 @@ export async function installOfficialLambdaPlugin(options: WriterOptions = {}): 
   return updated
 }
 
+// Kept identical to packages/create-app/templates/{default,api-only}/src/console.ts —
+// see packages/cli/tests/plugin.test.ts, which pins this to that file so the two
+// can't drift the way they did when #223 rewrote the templates without this one.
 function consoleKernelTemplate(): string {
   return `import { ConsoleKernel } from '@guren/core'
 import app from './app.js'
 
 export const kernel = new ConsoleKernel({ container: app.container })
 
-// Register the classes \`bunx guren make:command\` writes to app/Console/Commands:
-//   import SendDigestCommand from '../app/Console/Commands/SendDigestCommand.js'
+// \`bunx guren make:command\` adds the import and the array entry for you; the
+// empty array literal is what it edits, so keep it even while unused.
+// \`bunx guren check\` warns about any command class this file never registers.
 kernel.registerMany([])
 `
 }

--- a/packages/cli/src/plugin-lambda.ts
+++ b/packages/cli/src/plugin-lambda.ts
@@ -10,11 +10,31 @@ export async function installOfficialLambdaPlugin(options: WriterOptions = {}): 
     updated.push('.gitignore')
   }
 
+  // The entrypoint's console handler imports src/console.ts, which projects
+  // created before that file existed do not have. Scaffold it here so
+  // uncommenting the console export can't fail to resolve; apps that already
+  // have one keep it untouched.
+  if (await ensureScaffoldFile('src/console.ts', consoleKernelTemplate(), options)) {
+    updated.push('src/console.ts')
+  }
+
   if (await ensureScaffoldFile('src/lambda.ts', lambdaEntrypointTemplate(), options)) {
     updated.push('src/lambda.ts')
   }
 
   return updated
+}
+
+function consoleKernelTemplate(): string {
+  return `import { ConsoleKernel } from '@guren/core'
+import app from './app.js'
+
+export const kernel = new ConsoleKernel({ container: app.container })
+
+// Register the classes \`bunx guren make:command\` writes to app/Console/Commands:
+//   import SendDigestCommand from '../app/Console/Commands/SendDigestCommand.js'
+kernel.registerMany([])
+`
 }
 
 function lambdaEntrypointTemplate(): string {
@@ -42,9 +62,8 @@ export const queue = createSqsHandler()
 // import { scheduler } from './scheduler.js'
 // export const schedule = createScheduleHandler(scheduler)
 
-// Console commands — uncomment to run them with \`aws lambda invoke\`. This
-// dispatches the kernel src/console.ts exports, so every command registered
-// there is reachable here too, under the same name as \`bun run console\`.
+// Console commands — uncomment to run them with \`aws lambda invoke\`, under
+// the same names as \`bun run console\`.
 // Writing and registering commands: https://guren.dev/docs/guides/console
 // Seeders can't run in the bundle — use \`bunx guren db:seed --force\` instead.
 // import { createConsoleHandler } from '@guren/core/lambda'

--- a/packages/cli/tests/plugin.test.ts
+++ b/packages/cli/tests/plugin.test.ts
@@ -135,6 +135,12 @@ export default app
     expect(entrypoint).toContain("from '@guren/core/lambda'")
     expect(entrypoint).toContain('export const http = createLambdaHandler(app)')
     expect(entrypoint).toContain('export const queue = createSqsHandler()')
+
+    // The console handler must dispatch the kernel src/console.ts exports.
+    // Building a second kernel here would give the deployed console function a
+    // different command set than `bun run console`.
+    expect(entrypoint).toContain("import { kernel } from './console.js'")
+    expect(entrypoint).not.toContain('new ConsoleKernel(')
   })
 
   it('is idempotent for the official Lambda plugin', async () => {

--- a/packages/cli/tests/plugin.test.ts
+++ b/packages/cli/tests/plugin.test.ts
@@ -123,6 +123,10 @@ export default app
     expect(updated).toContain('src/app.ts')
     expect(updated).toContain('.gitignore')
     expect(updated).toContain('src/lambda.ts')
+    // Projects predating src/console.ts would otherwise get an entrypoint
+    // importing a file they don't have.
+    expect(updated).toContain('src/console.ts')
+    expect(await readFile('src/console.ts', 'utf8')).toContain('export const kernel =')
     expect(textsOf(messages, 'hint')).toContain('Run: bun add @guren/plugin-lambda')
 
     const app = await readFile('src/app.ts', 'utf8')
@@ -136,9 +140,7 @@ export default app
     expect(entrypoint).toContain('export const http = createLambdaHandler(app)')
     expect(entrypoint).toContain('export const queue = createSqsHandler()')
 
-    // The console handler must dispatch the kernel src/console.ts exports.
-    // Building a second kernel here would give the deployed console function a
-    // different command set than `bun run console`.
+    // A second kernel here would diverge from `bun run console`'s command set.
     expect(entrypoint).toContain("import { kernel } from './console.js'")
     expect(entrypoint).not.toContain('new ConsoleKernel(')
   })

--- a/packages/cli/tests/plugin.test.ts
+++ b/packages/cli/tests/plugin.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, afterEach, describe, expect, it } from 'bun:test'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
 import { createTempWorkspace, writeInstalledPackage, type TempWorkspace } from './helpers'
 import { installPlugin, type PluginInstallMessage } from '../src/plugin'
 
@@ -126,7 +127,15 @@ export default app
     // Projects predating src/console.ts would otherwise get an entrypoint
     // importing a file they don't have.
     expect(updated).toContain('src/console.ts')
-    expect(await readFile('src/console.ts', 'utf8')).toContain('export const kernel =')
+    // Pinned to the create-app templates so the two can't silently drift —
+    // this is exactly what happened once, when #223 rewrote both templates'
+    // comment without touching this scaffold's copy.
+    const consoleEntry = await readFile('src/console.ts', 'utf8')
+    const canonicalConsoleEntry = await readFile(
+      resolve(import.meta.dir, '../../create-app/templates/default/src/console.ts'),
+      'utf8',
+    )
+    expect(consoleEntry).toBe(canonicalConsoleEntry)
     expect(textsOf(messages, 'hint')).toContain('Run: bun add @guren/plugin-lambda')
 
     const app = await readFile('src/app.ts', 'utf8')

--- a/packages/plugin-lambda/README.md
+++ b/packages/plugin-lambda/README.md
@@ -43,7 +43,7 @@ new GurenLambdaApp(stack, 'App', {
   functionDir: '../.lambda/function',
   assets: { dir: '../.lambda/assets' },   // S3 + CloudFront
   queue: {},                              // SQS + worker + DLQ
-  console: true,                          // aws lambda invoke '{"command":"db:migrate"}'
+  console: true,                          // aws lambda invoke, dispatching src/console.ts's kernel
   dataApi: {                              // DATABASE_* env + rds-data/secret grants
     database: 'appdb',
     resourceArn: process.env.DATABASE_RESOURCE_ARN!,


### PR DESCRIPTION
## Summary

Scaffolded apps export a `ConsoleKernel` as `kernel` from `src/console.ts`, and `bun run console <command>` dispatches through it. The Lambda scaffold did not use it — `src/lambda.ts` built a **second** kernel inline and registered a single `db:migrate` command on it:

```ts
// const kernel = new ConsoleKernel()
// kernel.register(MigrateCommand)
// const consoleHandler = createConsoleHandler(kernel)
```

So an app had two kernels with different command sets. Register five commands in `src/console.ts`, uncomment the Lambda console export, and the deployed console function still knows only `db:migrate` — with nothing warning you that the rest are unreachable. `src/lambda.ts` already imports `./app.js`, so importing `./console.js` adds no coupling it didn't already have.

The scaffold now imports the app's kernel, and the `db:migrate` recipe moves to the serverless guide — where the reason it exists belongs, since needing a command at all is specific to deploying somewhere no CLI can run, and `lambda:build` ships `db/migrations/` next to the bundle so it can apply them in place.

## Scope

cli, docs, examples

## Risk Assessment

The changed code is a commented-out block in a scaffolded file, so nothing executes differently until a user uncomments it. Existing apps that already uncommented the old block keep working — their inline kernel is still valid code; they just won't pick up commands added to `src/console.ts` until they switch to the new form.

`packages/plugin-lambda/src/build.test.ts` asserts on the `consoleHandler` export name; that shape is unchanged, and the plugin's own tests pass untouched.

Four doc sites asserted the old behavior and were updated together (all written by #219): `docs/{en,ja}/guides/serverless.md` (both the console section and the migrations note), `examples/deploy/serverless/README.md`, and `examples/deploy/serverless/cdk/bin/app.ts`.

## Validation

- [x] `bun run build:clean`
- [x] `bun run typecheck`
- [x] `bun run test:bun` — 3008 pass, 0 fail; `test:bun plugin-lambda` — 28 pass
- [x] `bun run audit:docs`, `bun run audit:core-first`
- [x] New assertion in `packages/cli/tests/plugin.test.ts` mutation-tested: reintroducing `new ConsoleKernel()` in the scaffold makes it fail (17 pass / 1 fail), restoring makes it pass (18 pass)
- [x] End-to-end against a scaffolded app: installed the plugin, uncommented the console export, added the `MigrateCommand` exactly as the serverless guide now documents it (including the `../../../config/database.js` import path), and confirmed
  - `bun run console list` shows `db:migrate` locally
  - `buildLambdaOutput()` bundles both the `console` export and `MigrateCommand`
  - the bundled `handler.js` loads and reaches app boot
  - dispatch returns `{"exitCode":0}` for `db:migrate` and `list`, and `{"exitCode":1}` for an unknown name
- [x] en/ja serverless guide parity — both 311 lines

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.