### PR TITLE
fix(core): real-path import specifiers + add @guren/core README

### DIFF
--- a/.changeset/core-readme.md
+++ b/.changeset/core-readme.md
@@ -1,0 +1,8 @@
+---
+"@guren/core": patch
+---
+
+Add a README. `@guren/core` is the package every Guren app imports from, yet
+its npm page was blank. The README covers install, a minimal controller and
+route example, the package's entry points (`/runtime`, `/vite`, `/lambda`,
+`/redis`), and links to the docs site.

--- a/.changeset/deploy-build-symlink-import.md
+++ b/.changeset/deploy-build-symlink-import.md
@@ -1,0 +1,21 @@
+---
+"@guren/core": patch
+---
+
+fix: compute deploy-bundle import specifiers from real paths
+
+`buildLambdaOutput({ outputDir })` failed with `Bundle failed` whenever the
+output directory was reached through a symlink that changes path depth — on
+macOS `/tmp` is a link to `/private/tmp` and `os.tmpdir()` lives under
+`/var/folders`, a link into `/private/var`, so pointing a build script or CI
+harness at a temp directory hit this immediately.
+
+The generated `handler.ts` imports the app entrypoint through a relative
+specifier, and `importSpecifier()` computed it from the paths as given while
+the bundler resolves the emitted file from its real path. A depth-changing
+link left the specifier one `..` short. Both arguments now resolve through
+`realpathOfNearestExisting()` first — the same normalization the module's
+deletion guard already applies.
+
+The default `<root>/.lambda` output and the `lambda:build` command were never
+affected; only programmatic calls passing an explicit `outputDir` were.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,53 @@
+# @guren/core
+
+The framework entry point for [Guren](https://guren.dev/) — a Laravel-inspired fullstack TypeScript framework, built for Bun. Application code imports everything from this one package: routing, controllers, validation, authentication, the ORM surface, queues, mail, events, and the rest of the framework API.
+
+```bash
+bun add @guren/core
+```
+
+Starting a new app? Scaffold one instead — it wires all of this up for you:
+
+```bash
+bunx create-guren-app my-app --auth
+```
+
+## Usage
+
+```typescript
+import { Controller, Router, createApp } from '@guren/core'
+import { Model } from '@guren/core'
+import { z } from 'zod'
+
+class PostController extends Controller {
+  async store() {
+    const data = await this.validateBody(
+      z.object({ title: z.string().min(1), body: z.string().min(1) }),
+    )
+    const post = await Post.create(data)
+    return this.redirect(`/posts/${post.id}`)
+  }
+}
+
+export function registerWebRoutes(router: Router): void {
+  router.post('/posts', [PostController, 'store'])
+}
+```
+
+Boot the app with `createApp({ routes, providers })`, then `app.boot()` and `app.listen()`.
+
+## Entry points
+
+| Import | Contents |
+|--------|----------|
+| `@guren/core` | The framework API: controllers, routing, middleware, auth, models, queues, mail, events, notifications, cache, validation |
+| `@guren/core/runtime` | Bun server helpers used by the scaffolded `bin/serve.ts` |
+| `@guren/core/vite` | The Vite plugin: Inertia + React integration, codegen watching, SSR builds |
+| `@guren/core/lambda` | AWS Lambda adapters: `createLambdaHandler`, `createSqsHandler`, `createScheduleHandler`, `createConsoleHandler` |
+| `@guren/core/redis` | Redis-backed session, cache, and queue stores |
+
+The `guren` CLI ships with this package too — `bunx guren` inside an app gives you scaffolding (`make:*`), codegen, migrations, and the integrity checks (`check`, `audit`, `doctor`).
+
+## Documentation
+
+Guides, API reference, and deployment docs (Cloudflare Workers, AWS Lambda, Vercel, Docker) live at [guren.dev/docs](https://guren.dev/docs).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @guren/core
 
-The framework entry point for [Guren](https://guren.dev/) — a Laravel-inspired fullstack TypeScript framework, built for Bun. Application code imports everything from this one package: routing, controllers, validation, authentication, the ORM surface, queues, mail, events, and the rest of the framework API.
+The framework entry point for [Guren](https://guren.dev/) — a Laravel-inspired fullstack TypeScript framework, built for Bun. Application code imports the whole framework API from this one package.
 
 ```bash
 bun add @guren/core
@@ -15,9 +15,13 @@ bunx create-guren-app my-app --auth
 ## Usage
 
 ```typescript
-import { Controller, Router, createApp } from '@guren/core'
-import { Model } from '@guren/core'
+import { Controller, Router, defineModel } from '@guren/core'
 import { z } from 'zod'
+import { posts } from '@/db/schema'
+
+class Post extends defineModel(posts) {
+  static fillable = ['title', 'body']
+}
 
 class PostController extends Controller {
   async store() {
@@ -46,7 +50,9 @@ Boot the app with `createApp({ routes, providers })`, then `app.boot()` and `app
 | `@guren/core/lambda` | AWS Lambda adapters: `createLambdaHandler`, `createSqsHandler`, `createScheduleHandler`, `createConsoleHandler` |
 | `@guren/core/redis` | Redis-backed session, cache, and queue stores |
 
-The `guren` CLI ships with this package too — `bunx guren` inside an app gives you scaffolding (`make:*`), codegen, migrations, and the integrity checks (`check`, `audit`, `doctor`).
+## CLI
+
+The `guren` CLI ships with this package. `bunx guren` inside an app gives you scaffolding (`make:*`), codegen, migrations, and the integrity checks (`check`, `audit`, `doctor`).
 
 ## Documentation
 

--- a/packages/core/src/internal/deploy-build.test.ts
+++ b/packages/core/src/internal/deploy-build.test.ts
@@ -97,6 +97,26 @@ describe('importSpecifier', () => {
   test('should prefix a same-directory target with ./', () => {
     expect(importSpecifier('/app/out', '/app/out/handler.js', 'Test build')).toBe('./handler.js')
   })
+
+  test('should count .. segments from the real path when a symlink changes depth', () => {
+    // The bundler resolves the emitted import from the module's real path, so
+    // a specifier computed from the link path breaks whenever the link and its
+    // target sit at different depths — exactly what macOS does with /tmp ->
+    // /private/tmp and os.tmpdir() under /var -> /private/var.
+    const base = realpathSync(mkdtempSync(join(tmpdir(), 'guren-symlink-')))
+    try {
+      mkdirSync(join(base, 'deep/nested/out'), { recursive: true })
+      mkdirSync(join(base, 'app/src'), { recursive: true })
+      writeFileSync(join(base, 'app/src/lambda.ts'), '')
+      symlinkSync(join(base, 'deep/nested/out'), join(base, 'out'))
+
+      expect(importSpecifier(join(base, 'out'), join(base, 'app/src/lambda.ts'), 'Test build')).toBe(
+        '../../../app/src/lambda.ts',
+      )
+    } finally {
+      rmSync(base, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('readManifest', () => {

--- a/packages/core/src/internal/deploy-build.test.ts
+++ b/packages/core/src/internal/deploy-build.test.ts
@@ -100,18 +100,16 @@ describe('importSpecifier', () => {
 
   test('should count .. segments from the real path when a symlink changes depth', () => {
     // The bundler resolves the emitted import from the module's real path, so
-    // a specifier computed from the link path breaks whenever the link and its
-    // target sit at different depths — exactly what macOS does with /tmp ->
+    // a specifier computed from the link path is short a `..` whenever the link
+    // and its target sit at different depths — what macOS does with /tmp ->
     // /private/tmp and os.tmpdir() under /var -> /private/var.
     const base = realpathSync(mkdtempSync(join(tmpdir(), 'guren-symlink-')))
     try {
-      mkdirSync(join(base, 'deep/nested/out'), { recursive: true })
-      mkdirSync(join(base, 'app/src'), { recursive: true })
-      writeFileSync(join(base, 'app/src/lambda.ts'), '')
-      symlinkSync(join(base, 'deep/nested/out'), join(base, 'out'))
+      mkdirSync(join(base, 'nested/out'), { recursive: true })
+      symlinkSync(join(base, 'nested/out'), join(base, 'out'))
 
-      expect(importSpecifier(join(base, 'out'), join(base, 'app/src/lambda.ts'), 'Test build')).toBe(
-        '../../../app/src/lambda.ts',
+      expect(importSpecifier(join(base, 'out'), join(base, 'app/lambda.ts'), 'Test build')).toBe(
+        '../../app/lambda.ts',
       )
     } finally {
       rmSync(base, { recursive: true, force: true })

--- a/packages/core/src/internal/deploy-build.ts
+++ b/packages/core/src/internal/deploy-build.ts
@@ -155,10 +155,16 @@ export function resetOutputDir(out: string, root: string, label: string): void {
  * Relative specifier for importing `target` from a module written into
  * `fromDir`, in POSIX form so the emitted source is platform-agnostic.
  *
+ * Both paths go through their symlinks first, because the bundler resolving
+ * the emitted import does too. A link that changes path depth — on macOS
+ * `/tmp` is `/private/tmp` and `os.tmpdir()` lives under `/var`, a link to
+ * `/private/var` — otherwise yields a specifier with the wrong number of
+ * `..` segments, and the build fails on a path that plainly exists.
+ *
  * @param label Platform name for the error message, e.g. `'Lambda build'`.
  */
 export function importSpecifier(fromDir: string, target: string, label: string): string {
-  const rel = relative(fromDir, target)
+  const rel = relative(realpathOfNearestExisting(fromDir), realpathOfNearestExisting(target))
   if (isAbsolute(rel)) {
     throw new Error(
       `${label}: ${target} cannot be imported relative to ${fromDir} (different drive or root?). Keep the app, SSR output, and outputDir on the same volume.`,

--- a/packages/core/src/internal/deploy-build.ts
+++ b/packages/core/src/internal/deploy-build.ts
@@ -20,6 +20,15 @@
  * Lambda hands source to its bundler plugin), whether a missing `build` script
  * is fatal, and how an SSR bundle's renderer export is verified are all
  * per-plugin by design.
+ *
+ * One rule holds across the helpers here: a helper that *relates* two paths —
+ * a containment test, a relative specifier — canonicalizes both first, because
+ * whatever consumes the answer resolves links too. A helper that merely reads
+ * or writes one path passes it through, since the OS follows the links itself.
+ * That is why `resolveSsrEntryFile` compares raw strings (both operands derive
+ * from one `ssrDir`, so no link can come between them) and why the plugins'
+ * own `relative(root, out)` for `wrangler.jsonc` must stay lexical: that path
+ * is read by wrangler, not by a bundler resolving a module from its real path.
  */
 import { cpSync, existsSync, mkdirSync, readFileSync, realpathSync, rmSync } from 'node:fs'
 import { basename, dirname, isAbsolute, relative, resolve, sep } from 'node:path'
@@ -79,8 +88,9 @@ function manifestPaths(dir: string): [string, string] {
  * kept as a copy because this module must not import beyond node builtins and
  * cli cannot be imported from core. Only ENOENT walks up, matching the twin:
  * any other failure (an unreadable or non-directory ancestor) is surfaced
- * rather than silently treated as nonexistent — this feeds a deletion guard,
- * which must not compare a path it could not actually resolve.
+ * rather than silently treated as nonexistent — both callers relate two paths
+ * (a deletion guard, an import specifier) and neither may answer from a path
+ * it could not actually resolve.
  */
 function realpathOfNearestExisting(path: string): string {
   try {
@@ -103,10 +113,9 @@ function realpathOfNearestExisting(path: string): string {
  * Throw unless `out` is safe to delete: it must be neither the app root nor a
  * directory containing it.
  *
- * Both paths are resolved through their symlinks first, because the delete
- * that follows does too. Comparing lexically accepts `outputDir` values that
- * reach the app root the long way — on macOS `/tmp` is itself a symlink to
- * `/private/tmp`, so this is not a contrived case.
+ * Relates two paths, so it canonicalizes both: comparing lexically would
+ * accept `outputDir` values that reach the app root the long way, and the
+ * delete that follows resolves the links regardless.
  *
  * Containment is then decided with `relative` rather than a string prefix
  * because `out + sep` is `//` at the filesystem root, which no absolute path
@@ -155,11 +164,9 @@ export function resetOutputDir(out: string, root: string, label: string): void {
  * Relative specifier for importing `target` from a module written into
  * `fromDir`, in POSIX form so the emitted source is platform-agnostic.
  *
- * Both paths go through their symlinks first, because the bundler resolving
- * the emitted import does too. A link that changes path depth — on macOS
- * `/tmp` is `/private/tmp` and `os.tmpdir()` lives under `/var`, a link to
- * `/private/var` — otherwise yields a specifier with the wrong number of
- * `..` segments, and the build fails on a path that plainly exists.
+ * Relates two paths, so it canonicalizes both: the bundler resolves the
+ * emitted module from its real path, and a link that changes depth would
+ * otherwise leave the specifier short a `..` segment.
  *
  * @param label Platform name for the error message, e.g. `'Lambda build'`.
  */


### PR DESCRIPTION
## Summary

Two small follow-ups from post-release verification of v1.6.0.

### Fix: `importSpecifier()` breaks through depth-changing symlinks

`buildLambdaOutput({ outputDir })` failed with `Bundle failed` whenever the output directory was reached through a symlink that changes path depth — on macOS `/tmp` is a link to `/private/tmp` and `os.tmpdir()` lives under `/var/folders` (→ `/private/var`), so pointing a custom build script or CI harness at a temp directory hit this immediately.

The generated `handler.ts` imports the app entrypoint through a relative specifier. `importSpecifier()` computed it from the paths as given, while the bundler resolves the emitted file from its **real** path — a depth-changing link left the specifier one `..` short. Both arguments now resolve through `realpathOfNearestExisting()` first, the same normalization `assertOutputDirOutsideRoot` in the same module already applies.

Blast radius was small: the default `<root>/.lambda` output and the `lambda:build` command never pass `outputDir`, so only programmatic calls were affected. Vercel/Cloudflare builds don't emit a relative-import wrapper and were never affected.

### Docs: add `packages/core/README.md`

`@guren/core` — the package every app imports from — had no README, so its npm page was blank (v1.6.0 added READMEs to the deploy plugins but not core). Covers install, a minimal example, the entry-point table (`/runtime`, `/vite`, `/lambda`, `/redis`), and links to guren.dev. Every referenced symbol was checked against the built dist exports.

## Test plan
- [x] New regression test: symlinked dir at different depth yields the correct `../` count — fails without the fix (31 pass/1 fail), passes with it (32 pass)
- [x] E2E: `buildLambdaOutput({ outputDir: '/tmp/…' })` on macOS fails before, succeeds after rebuild
- [x] `bun run typecheck`
- [x] `bun run test:bun core` (67 pass) + plugin-lambda/cloudflare/vercel tests (74 pass)
- [x] `bun run audit:core-first`