### PR TITLE
refactor(orm): remove the `{} as X` type-marker cast pattern

### DIFF
--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -160,6 +160,8 @@ For User models, also define `guarded` to explicitly protect sensitive fields:
 
 ```typescript
 export class User extends AuthenticatableModel<UserRecord> {
+  static override table = users
+  declare static readonly recordType: UserRecord
   static fillable = ['name', 'email', 'password']
   static guarded = ['id', 'passwordHash', 'rememberToken']
 }

--- a/.claude/skills/guren-api/SKILL.md
+++ b/.claude/skills/guren-api/SKILL.md
@@ -61,12 +61,10 @@ All throw `ValidationException` (HTTP 422) on failure.
 Source: `packages/orm/src/Model.ts`
 
 ```typescript
-import { Model } from '@guren/orm'
+import { defineModel } from '@guren/orm'
 import { posts } from '@/db/schema'
 
-export class Post extends Model<typeof posts.$inferSelect> {
-  static table = posts
-}
+export class Post extends defineModel(posts) {}
 
 // Usage
 await Post.find(1)                              // returns null if not found
@@ -87,6 +85,7 @@ export class Post extends defineModel(posts) {
 
 export class User extends AuthenticatableModel<UserRecord> {
   static override table = users
+  declare static readonly recordType: UserRecord
   // Whitelist for mass assignment
   static fillable = ['name', 'email', 'password']
   // Blacklist: these fields are always stripped (ignored when fillable is set)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,12 +211,10 @@ export class PostController extends Controller {
 
 ### Models
 ```typescript
-import { Model } from '@guren/orm'
+import { defineModel } from '@guren/orm'
 import { posts } from '@/db/schema'
 
-export class Post extends Model<typeof posts> {
-  static table = posts
-
+export class Post extends defineModel(posts) {
   // Relationships, scopes, etc.
 }
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,10 @@ export function registerWebRoutes(router: Router): void {
 ### Model
 
 ```typescript
-import { Model } from '@guren/orm'
+import { defineModel } from '@guren/orm'
 import { posts } from '@/db/schema'
 
-export class Post extends Model<typeof posts> {
-  static table = posts
-}
+export class Post extends defineModel(posts) {}
 
 const post = await Post.findOrFail(1)
 ```

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -288,7 +288,7 @@ export type UserRecord = typeof users.$inferSelect
 
 export class User extends AuthenticatableModel<UserRecord> {
   static override table = users
-  static override readonly recordType = {} as UserRecord
+  declare static readonly recordType: UserRecord
   // Optional:
   // static override passwordField = 'plainPassword'
   // static override passwordHashField = 'password_digest'
@@ -387,7 +387,7 @@ export function registerWebRoutes(router: Router): void {
 ```ts
 export class User extends AuthenticatableModel<UserRecord> {
   static override table = users
-  static override readonly recordType = {} as UserRecord
+  declare static readonly recordType: UserRecord
   static override hidden = ['passwordHash', 'rememberToken']
 }
 ```

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -295,6 +295,8 @@ export class User extends AuthenticatableModel<UserRecord> {
 }
 ```
 
+Auth models extend `AuthenticatableModel` directly instead of using `defineModel()`: the inferred `createType` would require the `passwordHash` column on `create()`, while the auth flow supplies a plain `password` that is hashed automatically. The `declare` line redeclares the compile-time type marker and emits no JavaScript.
+
 The default `AuthServiceProvider` automatically registers a `web` guard that uses the `users` provider. If you need additional guards (e.g. token-based APIs), call `auth.registerGuard('api', factory)` inside the provider and set it as default via `auth.setDefaultGuard('api')` when appropriate.
 
 ## Controllers & Routes

--- a/docs/en/guides/database.md
+++ b/docs/en/guides/database.md
@@ -538,6 +538,7 @@ Instead of permanently removing records, soft deletes set a `deletedAt` timestam
 
 ```ts
 import { SoftDeletes, defineModel } from '@guren/orm'
+import { posts } from '@/db/schema'
 
 export class Post extends SoftDeletes(defineModel(posts)) {}
 ```

--- a/docs/en/guides/database.md
+++ b/docs/en/guides/database.md
@@ -216,10 +216,7 @@ await Post.transaction(async (_trx, txPost) => {
 Control which fields can be set through `create()` and `update()`:
 
 ```ts
-export class Post extends Model<PostRecord> {
-  static override table = posts
-  static override readonly recordType = {} as PostRecord
-
+export class Post extends defineModel(posts) {
   // Allowlist — only these fields are assignable
   static fillable = ['title', 'body', 'status']
 }
@@ -417,10 +414,7 @@ Supported for `hasMany`, `hasOne`, `morphMany` (children per record) and
 Scopes encapsulate common filters so you can reuse them by name:
 
 ```ts
-export class Post extends Model<PostRecord> {
-  static override table = posts
-  static override readonly recordType = {} as PostRecord
-
+export class Post extends defineModel(posts) {
   static scopes = {
     published: (q: QueryBuilder<PostRecord>) => q.where('status', 'published'),
     popular: (q: QueryBuilder<PostRecord>) => q.where('views', '>', 1000),
@@ -481,9 +475,7 @@ Hooks run logic at specific points in a record's lifecycle. Use them for auto-ge
 ```ts
 import { slugify } from '@/app/utils/string'
 
-export class Post extends Model<PostRecord> {
-  static override table = posts
-
+export class Post extends defineModel(posts) {
   static hooks = {
     creating: async (data) => {
       data.slug = slugify(data.title)
@@ -545,12 +537,9 @@ Observers and inline hooks coexist — hooks fire first, then observers.
 Instead of permanently removing records, soft deletes set a `deletedAt` timestamp. Users can recover deleted content, and queries automatically exclude trashed records.
 
 ```ts
-import { Model, SoftDeletes } from '@guren/orm'
+import { SoftDeletes, defineModel } from '@guren/orm'
 
-export class Post extends SoftDeletes(Model)<PostRecord> {
-  static override table = posts
-  static override readonly recordType = {} as PostRecord
-}
+export class Post extends SoftDeletes(defineModel(posts)) {}
 ```
 
 ```ts
@@ -570,10 +559,7 @@ await Post.forceDelete({ id: 1 })           // Permanent removal
 Automatically convert column values when reading from the database:
 
 ```ts
-export class Post extends Model<PostRecord> {
-  static override table = posts
-  static override readonly recordType = {} as PostRecord
-
+export class Post extends defineModel(posts) {
   static casts = {
     metadata: 'json',       // JSON string -> object
     publishedAt: 'date',    // string -> Date

--- a/docs/en/guides/first-steps.md
+++ b/docs/en/guides/first-steps.md
@@ -70,12 +70,10 @@ export const ListPostsQuerySchema = z.object({
 `app/Models/Post.ts` binds a class to a Drizzle table from `db/schema.ts`:
 
 ```ts
-import { Model } from '@guren/orm'
+import { defineModel } from '@guren/orm'
 import { posts } from '@/db/schema'
 
-export class Post extends Model<typeof posts> {
-  static table = posts
-}
+export class Post extends defineModel(posts) {}
 ```
 
 Queries read like Laravel: `Post.find(1)`, `Post.findOrFail(1)` (throws a 404), `Post.where('published', true).get()`. Column types flow from the schema into every result. See the [Database Guide](./database.md).

--- a/docs/en/guides/ship-api.md
+++ b/docs/en/guides/ship-api.md
@@ -57,12 +57,10 @@ bunx guren make:model Task
 Then wire it to your schema:
 
 ```typescript
-import { Model } from '@guren/core'
+import { defineModel } from '@guren/core'
 import { tasks } from '@/db/schema'
 
-export class Task extends Model<typeof tasks> {
-  static table = tasks
-}
+export class Task extends defineModel(tasks) {}
 ```
 
 ## 5. Create the Controller

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -293,6 +293,8 @@ export class User extends AuthenticatableModel<UserRecord> {
 }
 ```
 
+認証モデルは `defineModel()` ではなく `AuthenticatableModel` を直接継承します。`defineModel` が推論する `createType` は `passwordHash` カラムを `create()` で必須にしてしまいますが、認証フローでは平文の `password` を渡して自動ハッシュ化させるためです。`declare` の行はコンパイル時の型マーカーを再宣言するだけで、JavaScript には出力されません。
+
 既定の `AuthServiceProvider` は `users` プロバイダーを使う `web` ガードを自動登録します。追加のガード（例: トークンベース API）が必要なら、`context.auth.registerGuard('api', factory)` を呼び、必要に応じて `context.auth.setDefaultGuard('api')` で既定を差し替えます。
 
 ## コントローラーとルート

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -286,7 +286,7 @@ export type UserRecord = typeof users.$inferSelect
 
 export class User extends AuthenticatableModel<UserRecord> {
   static override table = users
-  static override readonly recordType = {} as UserRecord
+  declare static readonly recordType: UserRecord
   // 任意で上書き可能:
   // static override passwordField = 'plainPassword'
   // static override passwordHashField = 'password_digest'
@@ -384,7 +384,7 @@ export function registerWebRoutes(router: Router): void {
 ```ts
 export class User extends AuthenticatableModel<UserRecord> {
   static override table = users
-  static override readonly recordType = {} as UserRecord
+  declare static readonly recordType: UserRecord
   static override hidden = ['passwordHash', 'rememberToken']
 }
 ```

--- a/docs/ja/guides/database.md
+++ b/docs/ja/guides/database.md
@@ -327,15 +327,12 @@ const recentViaModel = await Post.query(db)
 再利用可能なクエリ制約を、モデル上の名前付きスコープとして定義できます。スコープを使えば、よく使うフィルタを見つけやすく、組み合わせやすくなります。
 
 ```ts
-import { Model, type QueryBuilder } from '@guren/orm'
+import { defineModel, type QueryBuilder } from '@guren/orm'
 import { posts } from '@/db/schema'
 
 export type PostRecord = typeof posts.$inferSelect
 
-export class Post extends Model<PostRecord> {
-  static override table = posts
-  static override readonly recordType = {} as PostRecord
-
+export class Post extends defineModel(posts) {
   static scopes = {
     published: (q: QueryBuilder<PostRecord>) => q.where('status', 'published'),
     popular: (q: QueryBuilder<PostRecord>) => q.where('views', '>', 1000),
@@ -402,13 +399,11 @@ User.removeGlobalScope('active')
 フックを使うと、モデルのライフサイクルの特定のポイントでロジックを実行できます。静的な `hooks` オブジェクトとして定義します。
 
 ```ts
-import { Model } from '@guren/orm'
+import { defineModel } from '@guren/orm'
 import { posts } from '@/db/schema'
 import { slugify } from '@/app/utils/string'
 
-export class Post extends Model<typeof posts.$inferSelect> {
-  static override table = posts
-
+export class Post extends defineModel(posts) {
   static hooks = {
     creating: async (data) => {
       // 新しいレコードが挿入される前に実行
@@ -483,15 +478,12 @@ before イベント（`creating`、`updating`、`deleting`、`saving`）で `fal
 ソフトデリートは、レコードを実際に削除する代わりに `deletedAt` タイムスタンプを設定して削除済みとしてマークします。`SoftDeletes` をミックスインして有効にします。
 
 ```ts
-import { Model, SoftDeletes } from '@guren/orm'
+import { SoftDeletes, defineModel } from '@guren/orm'
 import { posts } from '@/db/schema'
 
 export type PostRecord = typeof posts.$inferSelect
 
-export class Post extends SoftDeletes(Model)<PostRecord> {
-  static override table = posts
-  static override readonly recordType = {} as PostRecord
-}
+export class Post extends SoftDeletes(defineModel(posts)) {}
 ```
 
 スキーマに `deletedAt`（または同等の）タイムスタンプカラムが必要です。
@@ -523,10 +515,7 @@ await Post.forceDelete({ id: 1 })
 `static casts` を定義すると、データベースから読み取ったカラムの値を自動的に変換できます。
 
 ```ts
-export class Post extends Model<PostRecord> {
-  static override table = posts
-  static override readonly recordType = {} as PostRecord
-
+export class Post extends defineModel(posts) {
   static casts = {
     metadata: 'json',       // JSON 文字列をオブジェクトにパース
     publishedAt: 'date',    // Date インスタンスに変換
@@ -659,10 +648,7 @@ const json = User.serializeMany(users)
 `fillable` または `guarded` で、`create()` や `update()` で設定可能なフィールドを制御できます。
 
 ```ts
-export class Post extends Model<PostRecord> {
-  static override table = posts
-  static override readonly recordType = {} as PostRecord
-
+export class Post extends defineModel(posts) {
   // これらのフィールドのみ一括代入可能
   static fillable = ['title', 'body', 'status']
 }
@@ -700,10 +686,7 @@ await User.forceUpdate({ id: user.id }, { emailVerifiedAt: new Date() })
 あるいは、`guarded` で特定のフィールドをブロックし、それ以外をすべて許可することもできます。
 
 ```ts
-export class Post extends Model<PostRecord> {
-  static override table = posts
-  static override readonly recordType = {} as PostRecord
-
+export class Post extends defineModel(posts) {
   // これらのフィールドは一括代入から保護される
   static guarded = ['id', 'createdAt', 'updatedAt']
 }
@@ -721,15 +704,13 @@ ORM には、一般的な Eloquent スタイルのリレーション層が組み
 
 ```ts
 // app/Models/User.ts
-import { Model, type HasManyRecord } from '@guren/orm'
+import { defineModel, type HasManyRecord } from '@guren/orm'
 import { users } from '@/db/schema'
 import type { PostRecord } from '@/app/Models/Post'
 
 export type UserRecord = typeof users.$inferSelect
 
-export class User extends Model<UserRecord> {
-  static override table = users
-  static override readonly recordType = {} as UserRecord
+export class User extends defineModel(users) {
   static override relationTypes: { posts: HasManyRecord<PostRecord> } = {
     posts: [],
   }

--- a/docs/ja/guides/database.md
+++ b/docs/ja/guides/database.md
@@ -481,8 +481,6 @@ before イベント（`creating`、`updating`、`deleting`、`saving`）で `fal
 import { SoftDeletes, defineModel } from '@guren/orm'
 import { posts } from '@/db/schema'
 
-export type PostRecord = typeof posts.$inferSelect
-
 export class Post extends SoftDeletes(defineModel(posts)) {}
 ```
 

--- a/docs/ja/guides/first-steps.md
+++ b/docs/ja/guides/first-steps.md
@@ -70,12 +70,10 @@ export const ListPostsQuerySchema = z.object({
 `app/Models/Post.ts` は、クラスを `db/schema.ts` の Drizzle テーブルに結びつけます。
 
 ```ts
-import { Model } from '@guren/orm'
+import { defineModel } from '@guren/orm'
 import { posts } from '@/db/schema'
 
-export class Post extends Model<typeof posts> {
-  static table = posts
-}
+export class Post extends defineModel(posts) {}
 ```
 
 クエリは Laravel のように読めます: `Post.find(1)`、`Post.findOrFail(1)`（404 を投げます）、`Post.where('published', true).get()`。カラムの型はスキーマからすべての結果へと流れます。詳しくは [データベースガイド](./database.md) を参照してください。

--- a/docs/ja/guides/ship-api.md
+++ b/docs/ja/guides/ship-api.md
@@ -57,12 +57,10 @@ bunx guren make:model Task
 スキーマと関連付けます:
 
 ```typescript
-import { Model } from '@guren/core'
+import { defineModel } from '@guren/core'
 import { tasks } from '@/db/schema'
 
-export class Task extends Model<typeof tasks> {
-  static table = tasks
-}
+export class Task extends defineModel(tasks) {}
 ```
 
 ## 5. コントローラーを作成する

--- a/examples/api/app/Models/User.ts
+++ b/examples/api/app/Models/User.ts
@@ -9,8 +9,8 @@ export class User extends AuthenticatableModel<UserRecord> {
   static override table = users
   static fillable = ['name', 'email', 'password']
   static guarded = ['id', 'passwordHash', 'createdAt', 'updatedAt']
-  static override readonly recordType = {} as UserRecord
-  static override readonly createType = {} as Omit<NewUserRecord, 'passwordHash'> & {
+  declare static readonly recordType: UserRecord
+  declare static readonly createType: Omit<NewUserRecord, 'passwordHash'> & {
     password: string
   }
   static override relationTypes: { tasks: HasManyRecord<TaskRecord> } = {

--- a/examples/blog/app/Models/User.ts
+++ b/examples/blog/app/Models/User.ts
@@ -10,8 +10,8 @@ export class User extends AuthenticatableModel<UserRecord> {
   static fillable = ['name', 'email', 'password', 'emailVerifiedAt', 'githubId', 'googleId']
   static guarded = ['id', 'passwordHash', 'rememberToken']
   static override hidden = ['passwordHash', 'rememberToken']
-  static override readonly recordType = {} as UserRecord
-  static override readonly createType = {} as Omit<NewUserRecord, 'passwordHash'> & {
+  declare static readonly recordType: UserRecord
+  declare static readonly createType: Omit<NewUserRecord, 'passwordHash'> & {
     password: string
   }
   static override relationTypes: { posts: HasManyRecord<PostRecord> } = {

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -582,7 +582,7 @@ export type UserRecord = typeof users.$inferSelect
 
 export class User extends AuthenticatableModel<UserRecord> {
   static override table = users
-  static override readonly recordType = {} as UserRecord
+  declare static readonly recordType: UserRecord
 
   // Never serialized by Model.serialize() and stripped from auth.user()
   static override hidden = ['passwordHash', 'rememberToken']

--- a/packages/cli/templates/agent/.claude/rules/orm-models.md
+++ b/packages/cli/templates/agent/.claude/rules/orm-models.md
@@ -22,8 +22,11 @@ export class Post extends defineModel(posts) {
 Post.belongsTo('author', () => import('./User.js').then((m) => m.User), 'authorId', 'id')
 ```
 
-`class Post extends Model<typeof posts> { static table = posts }` also works.
-Auth user models: `defineModel(users, { base: AuthenticatableModel })`.
+Auth user models extend `AuthenticatableModel<UserRecord>` directly: set `static override table = users`
+and redeclare the type markers with `declare static readonly recordType: UserRecord` (plus `createType`
+when the create payload differs, e.g. `Omit<NewUserRecord, 'passwordHash'> & { password: string }`).
+Do **not** use `defineModel(users, { base: AuthenticatableModel })` — the inferred createType requires
+every non-defaulted column, so `create({ name, email, password })` would demand `passwordHash`.
 
 ## Statics
 

--- a/packages/cli/templates/agent/.claude/skills/feature/SKILL.md
+++ b/packages/cli/templates/agent/.claude/skills/feature/SKILL.md
@@ -156,6 +156,8 @@ For User models, also define `guarded` to explicitly protect sensitive fields:
 
 ```typescript
 export class User extends AuthenticatableModel<UserRecord> {
+  static override table = users
+  declare static readonly recordType: UserRecord
   static fillable = ['name', 'email', 'password']
   static guarded = ['id', 'passwordHash', 'rememberToken']
 }

--- a/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
+++ b/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
@@ -61,12 +61,10 @@ All throw `ValidationException` (HTTP 422) on failure.
 Source: `packages/orm/src/Model.ts`
 
 ```typescript
-import { Model } from '@guren/orm'
+import { defineModel } from '@guren/orm'
 import { posts } from '@/db/schema'
 
-export class Post extends Model<typeof posts.$inferSelect> {
-  static table = posts
-}
+export class Post extends defineModel(posts) {}
 
 // Usage
 await Post.find(1)                              // returns null if not found
@@ -87,6 +85,7 @@ export class Post extends defineModel(posts) {
 
 export class User extends AuthenticatableModel<UserRecord> {
   static override table = users
+  declare static readonly recordType: UserRecord
   // Whitelist for mass assignment
   static fillable = ['name', 'email', 'password']
   // Blacklist: these fields are always stripped (ignored when fillable is set)

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -217,6 +217,7 @@ type SelectFrom<TDatabase> = TDatabase extends { select: (...args: any[]) => inf
  * class LegacyUser extends Model<UserRecord> {
  *   static override table = users  // Drizzle table
  *   declare static readonly recordType: UserRecord
+ *   declare static readonly createType: NewUserRecord
  * }
  *
  * // Query records
@@ -2538,9 +2539,14 @@ type ModelClassWithTable<
 /**
  * Create a table-backed model base class from a Drizzle table.
  *
+ * `recordType` and `createType` are inferred from the table. The inferred
+ * createType requires every non-defaulted column — AuthenticatableModel user
+ * models typically want a looser payload (plain `password` instead of
+ * `passwordHash`), so extend that base directly and redeclare the markers
+ * with `declare static readonly` instead of passing it as `base`.
+ *
  * @example
  * export class Post extends defineModel(posts) {}
- * export class User extends defineModel(users, { base: AuthenticatableModel }) {}
  */
 export function defineModel<
   TTable extends TableShape,

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -210,10 +210,13 @@ type SelectFrom<TDatabase> = TDatabase extends { select: (...args: any[]) => inf
  * CRUD, querying, pagination, and eager-loading of relationships.
  *
  * @example
- * // Define a model
- * class User extends Model<UserRecord> {
+ * // Define a model — recordType/createType are inferred from the Drizzle table
+ * class User extends defineModel(users) {}
+ *
+ * // Or, when extending Model directly, redeclare the type markers
+ * class LegacyUser extends Model<UserRecord> {
  *   static override table = users  // Drizzle table
- *   static override readonly recordType = {} as UserRecord
+ *   declare static readonly recordType: UserRecord
  * }
  *
  * // Query records
@@ -236,9 +239,9 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
   protected static ormAdapter: ORMAdapter = DrizzleAdapter
   /** The database table (e.g., Drizzle table schema). */
   protected static table: unknown
-  /** Type marker for TypeScript inference. Define as `{} as YourRecordType`. */
+  /** Type marker for TypeScript inference. Set by `defineModel()`; when extending `Model` directly, redeclare as `declare static readonly recordType: YourRecordType`. */
   static readonly recordType: unknown = undefined as unknown
-  /** Type marker for insert/update payload inference. Define as `{} as typeof table.$inferInsert`. */
+  /** Type marker for insert/update payload inference. Set by `defineModel()`; when extending `Model` directly, redeclare as `declare static readonly createType: YourCreateType`. */
   static readonly createType: unknown = undefined as unknown
   protected static relationDefinitions?: Map<string, RelationDefinition>
   /** Type marker for relation types. Define relation types here for type inference. */

--- a/packages/orm/src/SoftDeletes.ts
+++ b/packages/orm/src/SoftDeletes.ts
@@ -27,9 +27,7 @@ export interface SoftDeletesStatic {
  * records via a global scope named 'softDelete'.
  *
  * @example
- * class Post extends SoftDeletes(Model)<PostRecord> {
- *   static table = posts
- * }
+ * class Post extends SoftDeletes(defineModel(posts)) {}
  *
  * // Soft delete a record (sets deletedAt)
  * await Post.delete({ id: 1 })

--- a/packages/orm/tests/model.query.types.ts
+++ b/packages/orm/tests/model.query.types.ts
@@ -17,7 +17,7 @@ export type UserRecord = typeof users.$inferSelect
 
 class User extends Model<UserRecord> {
   static override table = users
-  static override readonly recordType = {} as UserRecord
+  declare static readonly recordType: UserRecord
 }
 
 class FactoryUser extends defineModel(users) {}

--- a/web/app/Services/home-code-examples.ts
+++ b/web/app/Services/home-code-examples.ts
@@ -28,9 +28,7 @@ export function routes(router: Router) {
     return this.redirect('/posts')
   }
 }`,
-  Model: `export class Post extends Model {
-  static table = posts
-}
+  Model: `export class Post extends defineModel(posts) {}
 
 const post = await Post.findOrFail(1)
 const all = await Post

--- a/web/modules/blog/app/Models/User.ts
+++ b/web/modules/blog/app/Models/User.ts
@@ -11,6 +11,6 @@ export class User extends AuthenticatableModel<UserRecord> {
   static fillable = ['name', 'email', 'githubId']
   static guarded = ['id', 'passwordHash', 'rememberToken']
   static override hidden = ['passwordHash', 'rememberToken']
-  static override readonly recordType = {} as UserRecord
-  static override readonly createType = {} as Omit<NewUserRecord, 'passwordHash'>
+  declare static readonly recordType: UserRecord
+  declare static readonly createType: Omit<NewUserRecord, 'passwordHash'>
 }


### PR DESCRIPTION
## Summary

- Replace the documented `static override readonly recordType = {} as UserRecord` pattern everywhere it appears. Plain table-backed models now extend `defineModel(table)`, which infers `recordType`/`createType` from the Drizzle table with no cast. `AuthenticatableModel` subclasses (which need a looser `createType` than the table's insert shape — a plain `password` instead of `passwordHash`) redeclare the markers with `declare static readonly recordType/createType`, which emits no JavaScript (`declare` cannot combine with `override`).
- Updated: `packages/orm/src/Model.ts` + `SoftDeletes.ts` (JSDoc/comments), `packages/orm/tests/model.query.types.ts`, `packages/cli/src/make-auth.ts` (generated template), `examples/blog` + `examples/api` + `web/modules/blog` User models, docs (`en`/`ja` guides: database, authentication, first-steps, ship-api), `README.md`, `CLAUDE.md`, the agent-harness `.claude/rules/orm-models.md` and `guren-api`/`feature` skill docs (both the shipped template and this repo's own copy), and the guren.dev homepage code sample.
- `recordType`/`createType` are compile-time-only markers — no framework code reads their runtime values — so generated apps behave identically.

## Why the two patterns

`defineModel(users, { base: AuthenticatableModel })` looked like it should collapse auth models onto the same single pattern, but its inferred `createType` (`InferModelInsert<table> & TCreateFor<base>`) requires every non-defaulted column, including `passwordHash` (`notNull` in the shipped schemas) — which breaks the scaffolded `User.create({ name, email, password })` flow that relies on `AuthenticatableModel`'s auto-hashing. Auth models extend `AuthenticatableModel` directly and redeclare markers instead; `docs/{en,ja}/guides/authentication.md` now explain why.

## Review

Ran a Codex review plus a 4-angle `/simplify` pass (reuse, simplification, efficiency, altitude) against the diff. Findings applied:
- Fixed a `defineModel(users, { base: AuthenticatableModel })` recommendation left in `Model.ts` JSDoc and the harness's `orm-models.md` rule that doesn't actually type-check for the scaffolded create flow (see above).
- Dropped a dead `PostRecord` alias from the ja soft-delete snippet; added a missing `posts` import to its en twin.
- Converted the remaining legacy `Model<typeof posts.$inferSelect>` examples (guren-api/feature skills, guren.dev homepage) to `defineModel`, and completed partial `User` snippets with `table`/`recordType` so static queries stay typed.

Efficiency and reuse passes were clean — `defineModel`'s cost is one class + three static assignments at module load, and the `declare` conversions are a net reduction in emitted JS versus the old `{} as {}` cast.

## Test plan

- [x] `bun run build`
- [x] `bun run typecheck` (root + `examples/blog` + `examples/api` + `web`)
- [x] `bun run test:bun` (3090+ pass)
- [x] `bun run test:examples` (91 pass)
- [x] `bun run audit:core-first`
- [x] `bun run audit:docs`
- [x] Mutation check: broke a `declare static readonly recordType` type on purpose and confirmed `tsc` catches the resulting misuse, proving inference still flows through `declare`