### PR TITLE
feat(orm): reshape defineModel's inferred create payload without casts

### DIFF
--- a/.changeset/define-model-create-shape.md
+++ b/.changeset/define-model-create-shape.md
@@ -1,0 +1,48 @@
+---
+"@guren/orm": minor
+"@guren/cli": minor
+---
+
+Let `defineModel()` reshape the inferred create payload without a cast.
+
+`defineModel(table)` infers `createType` from the table, which requires every
+non-defaulted column — the wrong shape for a model that fills a column in
+itself. `AuthenticatableModel` is the standing example: it hashes a plain
+`password` into `passwordHash`, so callers pass the former and not the latter,
+and until now the only way to say so was to skip `defineModel()` entirely and
+redeclare the type markers by hand.
+
+Two type-level options replace that:
+
+```ts
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  optionalOnCreate: ['passwordHash'],
+  requireOnCreate: ['password'],
+}) {
+  static guarded = ['id', 'passwordHash', 'rememberToken']
+  static override hidden = ['passwordHash', 'rememberToken']
+}
+```
+
+`optionalOnCreate` makes columns optional — they keep their type, callers just
+need not supply them. `requireOnCreate` goes the other way, accepting both
+table columns (Drizzle marks defaulted ones optional) and named fields
+contributed by `base`. Both are checked against the real keys, so a typo fails
+to compile, and neither has a runtime effect. Neither closes the payload
+either: a create type always admits unknown keys as `unknown`, so
+`fillable`/`guarded` remain what reject an unwanted field at runtime.
+
+`make:auth` now generates this shape — with `requireOnCreate` only when
+password sign-up is the sole way in, since OAuth accounts are created without
+one — and guards `passwordHash` against mass assignment, which the scaffolded
+model previously left on its default.
+
+The `createType` option is deprecated in favour of these: it needs a value to
+infer from, which is exactly the cast this removes. It still works, and
+`defineModel<TTable, TBase, TCreate>()` still means what it did — the two new
+type parameters go after `TCreate`, not before it.
+
+Also fixes `guren audit`: its sensitive-column check resolved a model's table
+only from `static table = users`, so it silently skipped any model written as
+`defineModel(users, …)` — including every model this release migrates.

--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -159,9 +159,11 @@ export class <Name> extends defineModel(<names>) {
 For User models, also define `guarded` to explicitly protect sensitive fields:
 
 ```typescript
-export class User extends AuthenticatableModel<UserRecord> {
-  static override table = users
-  declare static readonly recordType: UserRecord
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  optionalOnCreate: ['passwordHash'],
+  requireOnCreate: ['password'],
+}) {
   static fillable = ['name', 'email', 'password']
   static guarded = ['id', 'passwordHash', 'rememberToken']
 }

--- a/.claude/skills/guren-api/SKILL.md
+++ b/.claude/skills/guren-api/SKILL.md
@@ -83,9 +83,12 @@ export class Post extends defineModel(posts) {
   static fillable = ['title', 'excerpt', 'body', 'authorId']
 }
 
-export class User extends AuthenticatableModel<UserRecord> {
-  static override table = users
-  declare static readonly recordType: UserRecord
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  // The model hashes a plain `password` into `passwordHash`
+  optionalOnCreate: ['passwordHash'],
+  requireOnCreate: ['password'],
+}) {
   // Whitelist for mass assignment
   static fillable = ['name', 'email', 'password']
   // Blacklist: these fields are always stripped (ignored when fillable is set)
@@ -102,7 +105,7 @@ export class User extends AuthenticatableModel<UserRecord> {
 
 ```typescript
 // app/Models/User.ts
-export class User extends AuthenticatableModel<UserRecord> {
+export class User extends defineModel(users, { base: AuthenticatableModel, optionalOnCreate: ['passwordHash'] }) {
   static override relationTypes: { posts: HasManyRecord<PostRecord> } = { posts: [] }
 }
 User.hasMany('posts', () => import('./Post.js').then((m) => m.Post), 'authorId', 'id')

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -281,21 +281,27 @@ Pair this with the `AuthenticatableModel` base class (see below) to get automati
 Models that extend `AuthenticatableModel` receive first-class password handling. Providing a plain `password` property when calling `create` or `update` automatically hashes and stores it in the `passwordHash` column (configurable via static properties). The framework never persists the plain text password, and authentication continues to rely on the same hashing algorithm as the providers.
 
 ```ts
-import { AuthenticatableModel } from '@guren/core'
+import { AuthenticatableModel, defineModel } from '@guren/core'
 import { users } from '@/db/schema.js'
 
 export type UserRecord = typeof users.$inferSelect
 
-export class User extends AuthenticatableModel<UserRecord> {
-  static override table = users
-  declare static readonly recordType: UserRecord
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  optionalOnCreate: ['passwordHash'],
+  requireOnCreate: ['password'],
+}) {
   // Optional:
   // static override passwordField = 'plainPassword'
   // static override passwordHashField = 'password_digest'
 }
 ```
 
-Auth models extend `AuthenticatableModel` directly instead of using `defineModel()`: the inferred `createType` would require the `passwordHash` column on `create()`, while the auth flow supplies a plain `password` that is hashed automatically. The `declare` line redeclares the compile-time type marker and emits no JavaScript.
+Pass `AuthenticatableModel` as the `base` and reshape the create payload in the same call. The type `defineModel()` infers from the table requires every non-defaulted column, which is the wrong shape here: callers pass a plain `password` the model hashes for them, not a `passwordHash`. `optionalOnCreate` makes the column optional and `requireOnCreate` makes the virtual field required, both at the type level with no cast and no redeclared markers.
+
+Optional means optional: a caller may still pass `passwordHash` and it will type-check. Mass assignment is what keeps a request body from setting its own hash — leave the column out of `fillable`, or list it in `guarded` on models that set no `fillable`.
+
+Leave `requireOnCreate` off when accounts can also arrive without a password — an OAuth-only sign-up, for instance — so `password` stays optional.
 
 The default `AuthServiceProvider` automatically registers a `web` guard that uses the `users` provider. If you need additional guards (e.g. token-based APIs), call `auth.registerGuard('api', factory)` inside the provider and set it as default via `auth.setDefaultGuard('api')` when appropriate.
 
@@ -387,9 +393,11 @@ export function registerWebRoutes(router: Router): void {
 `auth.user()` — and the cached user available right after `login()` or `attempt()` — never exposes credential material. `ModelUserProvider` strips the password column, the remember-token column, and any fields listed in the model's `static hidden` before the record leaves the auth layer:
 
 ```ts
-export class User extends AuthenticatableModel<UserRecord> {
-  static override table = users
-  declare static readonly recordType: UserRecord
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  optionalOnCreate: ['passwordHash'],
+  requireOnCreate: ['password'],
+}) {
   static override hidden = ['passwordHash', 'rememberToken']
 }
 ```

--- a/docs/en/guides/database.md
+++ b/docs/en/guides/database.md
@@ -99,6 +99,22 @@ export class Post extends defineModel(posts) {}
 
 That is all you need. `Post` now has `find`, `create`, `where`, `paginate`, and dozens more methods.
 
+### Reshaping the create payload
+
+The type `defineModel()` infers for `create()` requires every column without a database default. When the model derives a column itself, say so in the same call rather than hand-writing a type:
+
+```ts
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  optionalOnCreate: ['passwordHash'],  // derived from `password`, so callers need not pass it
+  requireOnCreate: ['password'],     // demand the virtual field instead
+}) {}
+```
+
+`optionalOnCreate` makes columns optional — they keep their type, callers just need not supply them. `requireOnCreate` goes the other way, and accepts both table columns (Drizzle marks defaulted ones optional) and fields contributed by `base`. Both are type-level only and are checked against the real keys, so a typo fails to compile.
+
+Neither closes the payload: a create type always admits unknown keys as `unknown`, so `fillable`/`guarded` remain what reject an unwanted field at runtime.
+
 ## Querying Data
 
 Start simple, then build up:

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -279,21 +279,27 @@ export default class AuthProvider extends ServiceProvider {
 `AuthenticatableModel` を継承したモデルはパスワード処理が組み込まれます。`create` や `update` に平文 `password` を渡すと自動でハッシュ化し、`passwordHash` カラム（静的プロパティで変更可）に保存します。平文は保持せず、プロバイダーと同じアルゴリズムで認証を行います。
 
 ```ts
-import { AuthenticatableModel } from '@guren/core'
+import { AuthenticatableModel, defineModel } from '@guren/core'
 import { users } from '@/db/schema.js'
 
 export type UserRecord = typeof users.$inferSelect
 
-export class User extends AuthenticatableModel<UserRecord> {
-  static override table = users
-  declare static readonly recordType: UserRecord
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  optionalOnCreate: ['passwordHash'],
+  requireOnCreate: ['password'],
+}) {
   // 任意で上書き可能:
   // static override passwordField = 'plainPassword'
   // static override passwordHashField = 'password_digest'
 }
 ```
 
-認証モデルは `defineModel()` ではなく `AuthenticatableModel` を直接継承します。`defineModel` が推論する `createType` は `passwordHash` カラムを `create()` で必須にしてしまいますが、認証フローでは平文の `password` を渡して自動ハッシュ化させるためです。`declare` の行はコンパイル時の型マーカーを再宣言するだけで、JavaScript には出力されません。
+`AuthenticatableModel` を `base` に渡し、同じ呼び出しで create のペイロードを整えます。`defineModel()` がテーブルから推論する型はデフォルト値のない全カラムを必須にしますが、ここではそれが正しい形ではありません。呼び出し側が渡すのは平文の `password` であって `passwordHash` ではないからです。`optionalOnCreate` がカラムを任意にし、`requireOnCreate` が仮想フィールドを必須にします。どちらも型レベルの指定で、キャストも型マーカーの再宣言も不要です。
+
+任意にするだけなので、呼び出し側が `passwordHash` を渡しても型としては通ります。リクエストボディが自前のハッシュを設定するのを防ぐのはマスアサインメント側です。`fillable` にこのカラムを入れない、あるいは `fillable` を設定しないモデルでは `guarded` に列挙してください。
+
+OAuth 専用のサインアップなどパスワードなしでアカウントが作られる場合は `requireOnCreate` を付けず、`password` を任意のままにします。
 
 既定の `AuthServiceProvider` は `users` プロバイダーを使う `web` ガードを自動登録します。追加のガード（例: トークンベース API）が必要なら、`context.auth.registerGuard('api', factory)` を呼び、必要に応じて `context.auth.setDefaultGuard('api')` で既定を差し替えます。
 
@@ -384,9 +390,11 @@ export function registerWebRoutes(router: Router): void {
 `auth.user()`（および `login()` / `attempt()` 直後にキャッシュされるユーザー）が資格情報を露出することはありません。`ModelUserProvider` は、レコードが認証レイヤーを出る前に、パスワードカラム・remember トークンカラム・モデルの `static hidden` に列挙されたフィールドを除去します。
 
 ```ts
-export class User extends AuthenticatableModel<UserRecord> {
-  static override table = users
-  declare static readonly recordType: UserRecord
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  optionalOnCreate: ['passwordHash'],
+  requireOnCreate: ['password'],
+}) {
   static override hidden = ['passwordHash', 'rememberToken']
 }
 ```

--- a/docs/ja/guides/database.md
+++ b/docs/ja/guides/database.md
@@ -46,6 +46,22 @@ export class Post extends defineModel(posts) {}
 // Drizzle の推論型がそのまま Post.find() などの静的ヘルパーに流れます。
 ```
 
+### create のペイロードを整える
+
+`defineModel()` が `create()` 用に推論する型は、データベース側のデフォルト値を持たない全カラムを必須にします。モデル自身が値を導出するカラムがある場合は、型を手書きせず同じ呼び出しで指定します。
+
+```ts
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  optionalOnCreate: ['passwordHash'],  // password から生成するので渡さなくてよい
+  requireOnCreate: ['password'],     // 代わりに仮想フィールドを必須にする
+}) {}
+```
+
+`optionalOnCreate` はカラムを任意にします（型はそのままで、渡さなくてよくなります）。`requireOnCreate` は逆にフィールドを必須にし、テーブルのカラム（Drizzle はデフォルト値付きを任意にします）と `base` が提供するフィールドの両方を受け付けます。どちらも型レベルのみの指定で、実際のキーと照合されるためタイポはコンパイルエラーになります。
+
+どちらもペイロードを閉じるわけではありません。create の型は未知のキーを `unknown` として受け入れるため、意図しないフィールドを実行時に弾くのは引き続き `fillable` / `guarded` です。
+
 ## SQLite サポート
 
 Guren は Bun 組み込みの SQLite ドライバを使って、SQLite をそのままサポートします。新規プロジェクトはデフォルトで SQLite を使用するため、Docker や外部データベースのセットアップは不要です。

--- a/examples/api/app/Models/User.ts
+++ b/examples/api/app/Models/User.ts
@@ -1,18 +1,18 @@
-import { AuthenticatableModel, type HasManyRecord } from '@guren/core'
+import { AuthenticatableModel, defineModel, type HasManyRecord } from '@guren/core'
 import { users } from '../../db/schema.js'
 import type { TaskRecord } from './Task.js'
 
 export type UserRecord = typeof users.$inferSelect
 export type NewUserRecord = typeof users.$inferInsert
 
-export class User extends AuthenticatableModel<UserRecord> {
-  static override table = users
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  optionalOnCreate: ['passwordHash'],
+  requireOnCreate: ['password'],
+}) {
   static fillable = ['name', 'email', 'password']
   static guarded = ['id', 'passwordHash', 'createdAt', 'updatedAt']
-  declare static readonly recordType: UserRecord
-  declare static readonly createType: Omit<NewUserRecord, 'passwordHash'> & {
-    password: string
-  }
+  static override hidden = ['passwordHash']
   static override relationTypes: { tasks: HasManyRecord<TaskRecord> } = {
     tasks: [],
   }

--- a/examples/blog/app/Models/User.ts
+++ b/examples/blog/app/Models/User.ts
@@ -1,19 +1,18 @@
-import { AuthenticatableModel, type HasManyRecord } from '@guren/core'
+import { AuthenticatableModel, defineModel, type HasManyRecord } from '@guren/core'
 import { users } from '../../db/schema.js'
 import type { PostRecord } from './Post.js'
 
 export type UserRecord = typeof users.$inferSelect
 export type NewUserRecord = typeof users.$inferInsert
 
-export class User extends AuthenticatableModel<UserRecord> {
-  static override table = users
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  optionalOnCreate: ['passwordHash'],
+  requireOnCreate: ['password'],
+}) {
   static fillable = ['name', 'email', 'password', 'emailVerifiedAt', 'githubId', 'googleId']
   static guarded = ['id', 'passwordHash', 'rememberToken']
   static override hidden = ['passwordHash', 'rememberToken']
-  declare static readonly recordType: UserRecord
-  declare static readonly createType: Omit<NewUserRecord, 'passwordHash'> & {
-    password: string
-  }
   static override relationTypes: { posts: HasManyRecord<PostRecord> } = {
     posts: [],
   }

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -9,7 +9,7 @@ import {
   listModuleNames,
 } from './discovery'
 import { loadRouteDefinitions } from './load-routes'
-import { extractClassDeclaration } from './model-parser'
+import { extractClassDeclaration, extractTableIdentifier } from './model-parser'
 import { parseSourceFile } from './parse-cache'
 import { parseSchemaTableColumns } from './schema-parser'
 import { loadAuditConfig, type AuditIgnoreEntry } from './audit-config'
@@ -587,8 +587,10 @@ interface ModelSerializationInfo {
 }
 
 /**
- * Extract `static table`, `static hidden`, and `static visible` from a model
- * source via AST (regexes would count string literals inside comments).
+ * Extract the model's table plus `static hidden`/`static visible` from a model
+ * source via AST (regexes would count string literals inside comments). The
+ * table is resolved through `extractTableIdentifier`, so models that bind it
+ * via `defineModel(users, …)` are covered as well as `static table = users`.
  */
 function parseModelSerializationInfo(source: string, filePath: string): ModelSerializationInfo {
   const info: ModelSerializationInfo = {}
@@ -602,12 +604,12 @@ function parseModelSerializationInfo(source: string, filePath: string): ModelSer
     const classDecl = extractClassDeclaration(node)
     if (!classDecl) continue
 
+    info.tableIdentifier = extractTableIdentifier(classDecl) ?? info.tableIdentifier
+
     for (const member of classDecl.body.body) {
       if (member.type !== 'ClassProperty' || !member.static || member.key.type !== 'Identifier') continue
 
-      if (member.key.name === 'table' && member.value?.type === 'Identifier') {
-        info.tableIdentifier = member.value.name
-      } else if (
+      if (
         (member.key.name === 'hidden' || member.key.name === 'visible') &&
         member.value?.type === 'ArrayExpression'
       ) {

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -575,19 +575,32 @@ ${verifyResend}
 `
 }
 
-const userModelTemplate = `import { AuthenticatableModel } from '@guren/core'
+/**
+ * OAuth accounts are created without a password, so `password` can only be
+ * required on the create payload when password sign-up is the sole way in.
+ */
+function buildUserModelTemplate(requirePassword: boolean): string {
+  const requireOnCreate = requirePassword ? "\n  requireOnCreate: ['password']," : ''
+
+  return `import { AuthenticatableModel, defineModel } from '@guren/core'
 import { users } from '../../db/schema.js'
 
 export type UserRecord = typeof users.$inferSelect
 
-export class User extends AuthenticatableModel<UserRecord> {
-  static override table = users
-  declare static readonly recordType: UserRecord
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  // Derived from the plain \`password\`, so callers never set it directly
+  optionalOnCreate: ['passwordHash'],${requireOnCreate}
+}) {
+  // Stripped from create()/update() payloads — this is what stops a request
+  // body from setting its own hash
+  static guarded = ['id', 'passwordHash', 'rememberToken']
 
   // Never serialized by Model.serialize() and stripped from auth.user()
   static override hidden = ['passwordHash', 'rememberToken']
 }
 `
+}
 
 const authProviderTemplate = `import { ServiceProvider } from '@guren/core'
 import type { AuthManager } from '@guren/core'
@@ -2076,6 +2089,8 @@ interface AuthFeatures {
   includePassword: boolean
   /** The email comes from the OAuth provider and must not be locally editable. */
   providerOwnedEmail: boolean
+  /** Every account is created with a password, so the user model can require one. */
+  passwordOnlySignUp: boolean
   /** Providers to scaffold buttons, a callback, and id columns for. */
   oauthProviders: string[]
 }
@@ -2113,25 +2128,30 @@ function resolveAuthFeatures(options: MakeAuthOptions): AuthFeatures {
   // --verify) as well as plain --oauth without --verify.
   const providerOwnedEmail = oauthProviders.length > 0 && !includeVerify
 
+  // OAuth accounts are created passwordless, so the user model can only
+  // require a password when no provider can produce an account without one.
+  const passwordOnlySignUp = !oauthOnly && oauthProviders.length === 0
+
   return {
     includeExtras,
     includeVerify,
     includePassword: !oauthOnly,
     providerOwnedEmail,
+    passwordOnlySignUp,
     oauthProviders,
   }
 }
 
 export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]> {
   const features = resolveAuthFeatures(options)
-  const { includeExtras, includeVerify, includePassword, oauthProviders } = features
+  const { includeExtras, includeVerify, includePassword, passwordOnlySignUp, oauthProviders } = features
   const includeOAuth = oauthProviders.length > 0
 
   const files = [
     { path: 'app/Http/Controllers/Auth/LoginController.ts', contents: buildLoginControllerTemplate(includePassword) },
     { path: 'app/Http/Controllers/DashboardController.ts', contents: dashboardControllerTemplate },
     { path: 'app/Http/Controllers/ProfileController.ts', contents: buildProfileControllerTemplate(features) },
-    { path: 'app/Models/User.ts', contents: userModelTemplate },
+    { path: 'app/Models/User.ts', contents: buildUserModelTemplate(passwordOnlySignUp) },
     { path: 'app/Providers/AuthProvider.ts', contents: authProviderTemplate },
     { path: 'app/Http/Validators/ProfileValidator.ts', contents: buildProfileValidatorTemplate(features) },
     { path: 'resources/js/components/Layout.tsx', contents: layoutTemplate },

--- a/packages/cli/src/model-parser.ts
+++ b/packages/cli/src/model-parser.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises'
-import type { Statement, Expression, ClassDeclaration, ClassBody } from '@babel/types'
+import type { Statement, Expression, ClassDeclaration, ClassBody, Node, ObjectProperty } from '@babel/types'
 import { extractDocsTags } from './docs-index'
 import { discoverModelFiles, toPosixRelative, moduleNameFromRelPath } from './discovery'
 import { parseSourceFile } from './parse-cache'
@@ -97,36 +97,47 @@ export function extractClassDeclaration(node: Statement): ClassDeclaration | nul
   return null
 }
 
-function analyzeClassHeader(
-  classDecl: ClassDeclaration,
-  source: string,
-): { tableName?: string; usesAuth: boolean; hasSoftDeletes: boolean } {
+/**
+ * Whether an expression names `AuthenticatableModel`, as a bare identifier or
+ * with type arguments (`AuthenticatableModel<UserRecord>`). Both the superclass
+ * and `defineModel`'s `base` option accept either spelling, so both go through
+ * here. Matching is by name only — an aliased import is not resolved.
+ */
+function isAuthenticatableBase(node: Node): boolean {
+  const target = node.type === 'TSInstantiationExpression' ? node.expression : node
+  return target.type === 'Identifier' && target.name === 'AuthenticatableModel'
+}
+
+/** The name of an object property key, for both `{ base: X }` and `{ 'base': X }`. */
+function propertyKeyName(property: ObjectProperty): string | undefined {
+  if (property.computed) return undefined
+  if (property.key.type === 'Identifier') return property.key.name
+  if (property.key.type === 'StringLiteral') return property.key.value
+  return undefined
+}
+
+/**
+ * The identifier a model binds its table to, from either supported spelling:
+ * `defineModel(users, …)` or `static table = users`. Callers that only look
+ * for the latter silently stop covering every model written the modern way,
+ * so anything resolving a model's table goes through here.
+ */
+export function extractTableIdentifier(classDecl: ClassDeclaration): string | undefined {
   let tableName: string | undefined
-  let usesAuth = false
-  const hasSoftDeletes = source.includes('SoftDeletes')
 
   const superClass = classDecl.superClass
-  if (superClass) {
-    // defineModel(posts) pattern
-    if (superClass.type === 'CallExpression') {
-      const callee = superClass.callee
-      if (callee.type === 'Identifier' && callee.name === 'defineModel') {
-        const firstArg = superClass.arguments[0]
-        if (firstArg?.type === 'Identifier') {
-          tableName = firstArg.name
-        }
+  if (superClass?.type === 'CallExpression') {
+    const callee = superClass.callee
+    if (callee.type === 'Identifier' && callee.name === 'defineModel') {
+      const firstArg = superClass.arguments[0]
+      if (firstArg?.type === 'Identifier') {
+        tableName = firstArg.name
       }
-    }
-    // AuthenticatableModel pattern
-    if (superClass.type === 'Identifier' && superClass.name === 'AuthenticatableModel') {
-      usesAuth = true
-    }
-    if (superClass.type === 'TSInstantiationExpression' && superClass.expression.type === 'Identifier' && superClass.expression.name === 'AuthenticatableModel') {
-      usesAuth = true
     }
   }
 
-  // Check for static table = xxx
+  // An explicit `static table` wins: a class may extend defineModel(x) and
+  // still repoint the table.
   for (const member of classDecl.body.body) {
     if (
       member.type === 'ClassProperty' &&
@@ -139,7 +150,39 @@ function analyzeClassHeader(
     }
   }
 
-  return { tableName, usesAuth, hasSoftDeletes }
+  return tableName
+}
+
+function analyzeClassHeader(
+  classDecl: ClassDeclaration,
+  source: string,
+): { tableName?: string; usesAuth: boolean; hasSoftDeletes: boolean } {
+  let usesAuth = false
+  const hasSoftDeletes = source.includes('SoftDeletes')
+
+  const superClass = classDecl.superClass
+  if (superClass) {
+    // defineModel(users, { base: AuthenticatableModel }) — the auth base
+    // arrives as an option rather than as the superclass itself.
+    if (superClass.type === 'CallExpression') {
+      const callee = superClass.callee
+      if (callee.type === 'Identifier' && callee.name === 'defineModel') {
+        const options = superClass.arguments[1]
+        if (options?.type === 'ObjectExpression') {
+          usesAuth ||= options.properties.some(
+            (property) =>
+              property.type === 'ObjectProperty' &&
+              propertyKeyName(property) === 'base' &&
+              isAuthenticatableBase(property.value),
+          )
+        }
+      }
+    }
+    // AuthenticatableModel pattern
+    usesAuth ||= isAuthenticatableBase(superClass)
+  }
+
+  return { tableName: extractTableIdentifier(classDecl), usesAuth, hasSoftDeletes }
 }
 
 /**

--- a/packages/cli/templates/agent/.claude/rules/orm-models.md
+++ b/packages/cli/templates/agent/.claude/rules/orm-models.md
@@ -22,11 +22,24 @@ export class Post extends defineModel(posts) {
 Post.belongsTo('author', () => import('./User.js').then((m) => m.User), 'authorId', 'id')
 ```
 
-Auth user models extend `AuthenticatableModel<UserRecord>` directly: set `static override table = users`
-and redeclare the type markers with `declare static readonly recordType: UserRecord` (plus `createType`
-when the create payload differs, e.g. `Omit<NewUserRecord, 'passwordHash'> & { password: string }`).
-Do **not** use `defineModel(users, { base: AuthenticatableModel })` — the inferred createType requires
-every non-defaulted column, so `create({ name, email, password })` would demand `passwordHash`.
+Auth user models use the same `defineModel()` call with `AuthenticatableModel` as the base, plus the
+options that reshape the create payload — the model hashes a plain `password` into `passwordHash`, so
+the column becomes optional and the virtual field becomes required:
+
+```typescript
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  optionalOnCreate: ['passwordHash'],
+  requireOnCreate: ['password'],
+}) {
+  static guarded = ['id', 'passwordHash', 'rememberToken']
+  static override hidden = ['passwordHash', 'rememberToken']
+}
+```
+
+Drop `requireOnCreate` when accounts can also be created without a password (OAuth-only sign-up).
+Optional means optional — passing `passwordHash` still type-checks. Mass assignment is the guard:
+keep it out of `fillable`, or in `guarded` on models that set no `fillable`.
 
 ## Statics
 

--- a/packages/cli/templates/agent/.claude/skills/feature/SKILL.md
+++ b/packages/cli/templates/agent/.claude/skills/feature/SKILL.md
@@ -155,9 +155,11 @@ export class <Name> extends defineModel(<names>) {
 For User models, also define `guarded` to explicitly protect sensitive fields:
 
 ```typescript
-export class User extends AuthenticatableModel<UserRecord> {
-  static override table = users
-  declare static readonly recordType: UserRecord
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  optionalOnCreate: ['passwordHash'],
+  requireOnCreate: ['password'],
+}) {
   static fillable = ['name', 'email', 'password']
   static guarded = ['id', 'passwordHash', 'rememberToken']
 }

--- a/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
+++ b/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
@@ -83,9 +83,12 @@ export class Post extends defineModel(posts) {
   static fillable = ['title', 'excerpt', 'body', 'authorId']
 }
 
-export class User extends AuthenticatableModel<UserRecord> {
-  static override table = users
-  declare static readonly recordType: UserRecord
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  // The model hashes a plain `password` into `passwordHash`
+  optionalOnCreate: ['passwordHash'],
+  requireOnCreate: ['password'],
+}) {
   // Whitelist for mass assignment
   static fillable = ['name', 'email', 'password']
   // Blacklist: these fields are always stripped (ignored when fillable is set)
@@ -102,7 +105,7 @@ export class User extends AuthenticatableModel<UserRecord> {
 
 ```typescript
 // app/Models/User.ts
-export class User extends AuthenticatableModel<UserRecord> {
+export class User extends defineModel(users, { base: AuthenticatableModel, optionalOnCreate: ['passwordHash'] }) {
   static override relationTypes: { posts: HasManyRecord<PostRecord> } = { posts: [] }
 }
 User.hasMany('posts', () => import('./Post.js').then((m) => m.Post), 'authorId', 'id')

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -530,6 +530,50 @@ export default function registerRoutes(router: any) {
     }
   })
 
+  it('resolves the table from defineModel, not just from `static table`', async () => {
+    // A model that binds its table through defineModel() used to fall out of
+    // this check entirely — the table never resolved, so no column was ever
+    // compared against `hidden`.
+    const workspace = await createTempWorkspace('guren-cli-audit-hidden-define-model-')
+
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'db/schema.ts'),
+        `import { pgTable, text } from 'drizzle-orm/pg-core'
+export const users = pgTable('users', {
+  id: text('id').primaryKey(),
+  email: text('email').notNull(),
+  passwordHash: text('password_hash').notNull(),
+})`,
+        'utf8',
+      )
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Models/User.ts'),
+        `import { AuthenticatableModel, defineModel } from '@guren/core'
+import { users } from '../../db/schema.js'
+
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  optionalOnCreate: ['passwordHash'],
+}) {
+  static guarded = ['id', 'passwordHash']
+}`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const hidden = report.findings.find(f => f.key === 'hidden-columns:User')
+      expect(hidden).toBeDefined()
+      expect(hidden!.status).toBe('warn')
+      expect(hidden!.message).toContain('passwordHash')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('warns when a sensitive schema column is not hidden', async () => {
     const workspace = await createTempWorkspace('guren-cli-audit-hidden-warn-')
 

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -544,6 +544,38 @@ export const posts = pgTable('posts', {
     }
   })
 
+  it('requires a password on create only when password sign-up is the sole way in', async () => {
+    const passwordOnly = await createTempWorkspace('guren-cli-make-auth-user-model-')
+    try {
+      await mkdir(join(passwordOnly.dir, 'db'), { recursive: true })
+      await makeAuth({ force: true })
+
+      const model = await readFile(join(passwordOnly.dir, 'app/Models/User.ts'), 'utf8')
+      expect(model).toContain('base: AuthenticatableModel')
+      expect(model).toContain("optionalOnCreate: ['passwordHash']")
+      expect(model).toContain("requireOnCreate: ['password']")
+      // The create type still admits passwordHash, so the guard against a
+      // request body setting its own hash has to be a runtime one.
+      expect(model).toContain("static guarded = ['id', 'passwordHash', 'rememberToken']")
+    } finally {
+      await passwordOnly.cleanup()
+    }
+
+    // OAuth accounts arrive without a password, so requiring one would make
+    // the generated OAuth controller's User.create() fail to compile.
+    const withOAuth = await createTempWorkspace('guren-cli-make-auth-user-model-oauth-')
+    try {
+      await mkdir(join(withOAuth.dir, 'db'), { recursive: true })
+      await makeAuth({ force: true, oauth: 'github' })
+
+      const model = await readFile(join(withOAuth.dir, 'app/Models/User.ts'), 'utf8')
+      expect(model).toContain("optionalOnCreate: ['passwordHash']")
+      expect(model).not.toContain('requireOnCreate')
+    } finally {
+      await withOAuth.cleanup()
+    }
+  })
+
   it('scaffolds OAuth buttons on the login page even with --minimal', async () => {
     const workspace = await createTempWorkspace('guren-cli-make-auth-oauth-minimal-')
     try {

--- a/packages/cli/tests/model-parser.test.ts
+++ b/packages/cli/tests/model-parser.test.ts
@@ -60,6 +60,50 @@ if (typeof User.hasMany === 'function') {
     expect(result!.relationships[0].type).toBe('hasMany')
   })
 
+  it('parses AuthenticatableModel passed as a defineModel base', () => {
+    const source = `
+import { AuthenticatableModel, defineModel, type HasManyRecord } from '@guren/core'
+import { users } from '../../db/schema.js'
+import type { PostRecord } from './Post.js'
+
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  optionalOnCreate: ['passwordHash'],
+  requireOnCreate: ['password'],
+}) {
+  static override relationTypes: { posts: HasManyRecord<PostRecord> } = {
+    posts: [],
+  }
+}
+
+if (typeof User.hasMany === 'function') {
+  User.hasMany('posts', (() => import('./Post.js').then((module) => module.Post)) as any, 'authorId', 'id')
+}
+`
+    const result = parseModelSource(source, '/app/Models/User.ts')
+
+    expect(result).not.toBeNull()
+    expect(result!.className).toBe('User')
+    expect(result!.tableName).toBe('users')
+    expect(result!.usesAuth).toBe(true)
+    expect(result!.relationships).toHaveLength(1)
+    expect(result!.relationships[0].name).toBe('posts')
+  })
+
+  it('does not flag a plain defineModel model as authenticatable', () => {
+    const source = `
+import { defineModel } from '@guren/orm'
+import { posts } from '../../db/schema.js'
+
+export class Post extends defineModel(posts, { optionalOnCreate: ['slug'] }) {}
+`
+    const result = parseModelSource(source, '/app/Models/Post.ts')
+
+    expect(result).not.toBeNull()
+    expect(result!.tableName).toBe('posts')
+    expect(result!.usesAuth).toBe(false)
+  })
+
   it('detects SoftDeletes', () => {
     const source = `
 import { defineModel, SoftDeletes } from '@guren/orm'

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -2526,39 +2526,91 @@ export type WithRelations<
   K extends RelationPath<T> | readonly RelationPath<T>[],
 > = TRecordFor<T> & RelationTypePick<T, K>
 
-type ModelClassWithTable<
-  TTable extends TableShape,
-  TBase extends typeof Model = typeof Model,
-  TCreate extends PlainObject = InferModelInsert<TTable> & TCreateFor<TBase>,
-> = TBase & {
+type ModelClassWithTable<TTable extends TableShape, TBase extends typeof Model, TCreate extends PlainObject> = TBase & {
   readonly table: TTable
   readonly recordType: InferModelRecord<TTable>
   readonly createType: TCreate
 }
 
 /**
+ * Keys of `T` excluding its string/number index signature, so that a base
+ * class whose `createType` widens to `PlainObject` still contributes its
+ * named fields (and only those) to `requireOnCreate`.
+ */
+type NamedKeys<T> = keyof {
+  [K in keyof T as string extends K ? never : number extends K ? never : K]: never
+}
+
+/** A key that can appear in a model's create payload: a table column, or a named field its base contributes. */
+type CreateKey<TTable extends TableShape, TBase extends typeof Model> =
+  | keyof InferModelInsert<TTable>
+  | NamedKeys<TCreateFor<TBase>>
+
+type CreateShape<
+  TTable extends TableShape,
+  TBase extends typeof Model,
+  TOptional extends keyof InferModelInsert<TTable>,
+  TRequire extends CreateKey<TTable, TBase>,
+> = Partial<Pick<InferModelInsert<TTable>, TOptional>> &
+  Omit<InferModelInsert<TTable>, TOptional> &
+  TCreateFor<TBase> &
+  Required<Pick<InferModelInsert<TTable> & TCreateFor<TBase>, TRequire & keyof (InferModelInsert<TTable> & TCreateFor<TBase>)>>
+
+/**
  * Create a table-backed model base class from a Drizzle table.
  *
  * `recordType` and `createType` are inferred from the table. The inferred
- * createType requires every non-defaulted column — AuthenticatableModel user
- * models typically want a looser payload (plain `password` instead of
- * `passwordHash`), so extend that base directly and redeclare the markers
- * with `declare static readonly` instead of passing it as `base`.
+ * createType requires every non-defaulted column, which is not always the
+ * payload a model accepts: `AuthenticatableModel` hashes a plain `password`
+ * into `passwordHash`, so a user model wants the column optional and the
+ * virtual field required. `optionalOnCreate` and `requireOnCreate` reshape the
+ * inferred type without any cast.
  *
  * @example
  * export class Post extends defineModel(posts) {}
+ *
+ * export class User extends defineModel(users, {
+ *   base: AuthenticatableModel,
+ *   optionalOnCreate: ['passwordHash'],
+ *   requireOnCreate: ['password'],
+ * }) {}
  */
 export function defineModel<
   TTable extends TableShape,
   TBase extends typeof Model = typeof Model,
-  TCreate extends PlainObject = InferModelInsert<TTable> & TCreateFor<TBase>,
+  // Stays third so the pre-existing `defineModel<TTable, TBase, TCreate>()`
+  // spelling keeps working; the two option-driven parameters go after it and
+  // the create shape is resolved in the return type instead of as a default,
+  // which may only reference parameters declared before it.
+  TCreate extends PlainObject | undefined = undefined,
+  const TOptional extends keyof InferModelInsert<TTable> = never,
+  const TRequire extends CreateKey<TTable, TBase> = never,
 >(
   table: TTable,
   options: {
     base?: TBase
+    /**
+     * Columns the model fills in itself, so callers need not pass them.
+     * Type-level only.
+     */
+    optionalOnCreate?: readonly TOptional[]
+    /**
+     * Fields to make required on the create payload. Accepts table columns
+     * (Drizzle marks defaulted ones optional) and named fields contributed by
+     * `base`, such as `AuthenticatableModel`'s virtual `password`.
+     * Type-level only.
+     */
+    requireOnCreate?: readonly TRequire[]
+    /** @deprecated Prefer `optionalOnCreate`/`requireOnCreate`, which need no value to infer from. */
     createType?: TCreate
   } = {},
-): ModelClassWithTable<TTable, TBase, TCreate> {
+): ModelClassWithTable<
+  TTable,
+  TBase,
+  TCreate extends PlainObject ? TCreate : CreateShape<TTable, TBase, TOptional, TRequire>
+> {
+  type ResolvedCreate = TCreate extends PlainObject ? TCreate : CreateShape<TTable, TBase, TOptional, TRequire>
+
   const BaseClass = (options.base ?? Model) as typeof Model
 
   abstract class DefinedModel extends BaseClass {}
@@ -2566,10 +2618,10 @@ export function defineModel<
   ;(DefinedModel as typeof Model & { table: TTable }).table = table
   ;(DefinedModel as typeof Model & { recordType: InferModelRecord<TTable> }).recordType =
     {} as InferModelRecord<TTable>
-  ;(DefinedModel as typeof Model & { createType: TCreate }).createType =
-    (options.createType ?? ({} as InferModelInsert<TTable> & TCreateFor<TBase>)) as TCreate
+  ;(DefinedModel as typeof Model & { createType: ResolvedCreate }).createType =
+    (options.createType ?? {}) as ResolvedCreate
 
-  return DefinedModel as ModelClassWithTable<TTable, TBase, TCreate>
+  return DefinedModel as ModelClassWithTable<TTable, TBase, ResolvedCreate>
 }
 
 function normalizeOrderBy<TRecord extends PlainObject>(order: OrderByInput<TRecord>): OrderByClause<TRecord> {

--- a/packages/orm/tests/model.query.types.ts
+++ b/packages/orm/tests/model.query.types.ts
@@ -4,13 +4,23 @@ import {
   Model,
   defineModel,
   type BelongsToRequiredRecord,
+  type PlainObject,
   type TransactionHandle,
   type TransactionModelScope,
 } from '../src/Model'
+import { SoftDeletes } from '../src/SoftDeletes'
 
 const users = pgTable('users', {
   id: serial('id').primaryKey(),
   name: text('name').notNull(),
+})
+
+const accounts = pgTable('accounts', {
+  id: serial('id').primaryKey(),
+  name: text('name').notNull(),
+  email: text('email').notNull(),
+  passwordHash: text('password_hash').notNull(),
+  githubId: text('github_id'),
 })
 
 export type UserRecord = typeof users.$inferSelect
@@ -170,3 +180,120 @@ async function _requiredBelongsTo() {
   }
 }
 void _requiredBelongsTo
+
+// defineModel's create payload can be reshaped at the type level. The base
+// below mirrors @guren/server's AuthenticatableModel, which the ORM cannot
+// import (that would invert the package dependency) — examples/blog and
+// examples/api typecheck the same options against the real class.
+abstract class PasswordHashingModel<TRecord extends PlainObject = PlainObject> extends Model<TRecord> {
+  declare static readonly createType: PlainObject & {
+    password?: string
+    plainPassword?: string
+  }
+}
+
+class Account extends defineModel(accounts, {
+  base: PasswordHashingModel,
+  optionalOnCreate: ['passwordHash'],
+  requireOnCreate: ['password'],
+}) {}
+
+// Making the column optional alone leaves the base's `password` optional too —
+// what a model backed solely by OAuth wants, since it never supplies one.
+class OAuthAccount extends defineModel(accounts, {
+  base: PasswordHashingModel,
+  optionalOnCreate: ['passwordHash'],
+}) {}
+
+async function _reshapedCreatePayload() {
+  await Account.update({ id: 1 }, { password: 'rotated' })
+
+  await OAuthAccount.create({ name: 'Ada', email: 'ada@example.com' })
+
+  const created = await Account.create({ name: 'Ada', email: 'ada@example.com', password: 'secret' })
+  const _hash: string = created.passwordHash // the record type keeps every column
+  void _hash
+}
+void _reshapedCreatePayload
+
+// requireOnCreate in isolation: no column is made optional here, so the only
+// thing missing from the call below is the base's virtual `password`.
+class RequirePasswordAccount extends defineModel(accounts, {
+  base: PasswordHashingModel,
+  requireOnCreate: ['password'],
+}) {}
+async function _requireOnCreateAddsTheNamedField() {
+  await RequirePasswordAccount.create({
+    name: 'Ada',
+    email: 'ada@example.com',
+    passwordHash: 'precomputed',
+    password: 'secret',
+  })
+
+  // @ts-expect-error requireOnCreate put `password` on the required list
+  await RequirePasswordAccount.create({ name: 'Ada', email: 'ada@example.com', passwordHash: 'precomputed' })
+}
+void _requireOnCreateAddsTheNamedField
+
+// optionalOnCreate in isolation: the named column stops being required and
+// keeps its own type, and nothing else moves. The last two calls are what fail
+// if the option's keys ever widen from literals to `string`, which would make
+// every column optional.
+class DerivedHashAccount extends defineModel(accounts, { optionalOnCreate: ['passwordHash'] }) {}
+async function _optionalOnCreateDropsOnlyTheNamedRequirement() {
+  await DerivedHashAccount.create({ name: 'Ada', email: 'ada@example.com' })
+  await DerivedHashAccount.create({ name: 'Ada', email: 'ada@example.com', passwordHash: 'precomputed' })
+
+  // @ts-expect-error the column stays typed even though it is now optional
+  await DerivedHashAccount.create({ name: 'Ada', email: 'ada@example.com', passwordHash: 42 })
+
+  // @ts-expect-error the other columns are still required
+  await DerivedHashAccount.create({ name: 'Ada' })
+}
+void _optionalOnCreateDropsOnlyTheNamedRequirement
+
+// Both options are checked against the table columns and the base's own
+// named create fields, so typos fail to compile.
+// @ts-expect-error 'passwordHassh' is not a column of the table
+class _BadOptional extends defineModel(accounts, { optionalOnCreate: ['passwordHassh'] }) {}
+void _BadOptional
+class _BadRequire extends defineModel(accounts, {
+  base: PasswordHashingModel,
+  // @ts-expect-error 'passwrod' is neither a column nor a field of the base
+  requireOnCreate: ['passwrod'],
+}) {}
+void _BadRequire
+
+// The pre-existing explicit-type-argument spelling still resolves to the type
+// it names, so adding the two option parameters after TCreate is not a break.
+type LegacyCreate = { name: string; email: string; password: string }
+class LegacyAccount extends defineModel<typeof accounts, typeof PasswordHashingModel, LegacyCreate>(accounts, {
+  base: PasswordHashingModel,
+  createType: {} as LegacyCreate,
+}) {}
+async function _explicitTypeArgumentsStillGovern() {
+  await LegacyAccount.create({ name: 'Ada', email: 'ada@example.com', password: 'secret' })
+
+  // @ts-expect-error the explicitly named create type still applies
+  await LegacyAccount.create({ name: 'Ada' })
+}
+void _explicitTypeArgumentsStillGovern
+
+// Without options the create payload still requires every non-defaulted column.
+class PlainAccount extends defineModel(accounts) {}
+async function _inferredCreatePayload() {
+  // @ts-expect-error passwordHash is not defaulted, so it stays required
+  await PlainAccount.create({ name: 'Ada', email: 'ada@example.com' })
+}
+void _inferredCreatePayload
+
+// The SoftDeletes mixin must preserve the inferred markers.
+class SoftAccount extends SoftDeletes(defineModel(accounts)) {}
+async function _softDeletesPreservesInference() {
+  const found = await SoftAccount.find(1)
+  if (found) {
+    const _email: string = found.email
+    void _email
+  }
+}
+void _softDeletesPreservesInference

--- a/packages/server/tests/auth/AuthenticatableModel.test.ts
+++ b/packages/server/tests/auth/AuthenticatableModel.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import { defineModel } from '@guren/orm'
 import type { FindManyOptions, ORMAdapter, PlainObject, WhereClause } from '@guren/orm'
 import { AuthenticatableModel } from '../../src/auth/AuthenticatableModel'
 
@@ -74,6 +75,36 @@ describe('AuthenticatableModel', () => {
     const persisted = captured[0]
     expect(persisted.passwordDigest).toBeDefined()
     expect('plainPassword' in persisted).toBe(false)
+  })
+})
+
+describe('as a defineModel base', () => {
+  // The user models in scaffolded apps reach the hashing pipeline through the
+  // subclass defineModel() synthesizes, not by extending this class directly.
+  // Every other check on that path is a type check, so this is what would fail
+  // if the base ever stopped composing and signups started storing plaintext.
+  const usersTable = {
+    $inferSelect: {} as { id: number; email: string; passwordHash: string },
+    $inferInsert: {} as { id?: number; email: string; passwordHash: string },
+  }
+
+  it('hashes the password field for a model built with defineModel', async () => {
+    class User extends defineModel(usersTable, {
+      base: AuthenticatableModel,
+      optionalOnCreate: ['passwordHash'],
+      requireOnCreate: ['password'],
+    }) {}
+
+    const captured: PlainObject[] = []
+    User.useAdapter(createAdapter(captured))
+
+    const created = await User.create({ email: 'demo@guren.dev', password: 'secret' })
+
+    expect(created.passwordHash).toBeDefined()
+    expect(created.passwordHash).not.toBe('secret')
+    expect('password' in created).toBe(false)
+    expect(captured[0]).toHaveProperty('passwordHash')
+    expect(captured[0]).not.toHaveProperty('password')
   })
 })
 

--- a/web/modules/blog/app/Models/User.ts
+++ b/web/modules/blog/app/Models/User.ts
@@ -1,16 +1,17 @@
-import { AuthenticatableModel } from '@guren/core'
+import { AuthenticatableModel, defineModel } from '@guren/core'
 import { users } from '../../../../db/schema.js'
 
 export type UserRecord = typeof users.$inferSelect
 export type NewUserRecord = typeof users.$inferInsert
 
 // Accounts are created exclusively through GitHub OAuth (passwordless), so
-// createType omits passwordHash and no password field exists at all.
-export class User extends AuthenticatableModel<UserRecord> {
-  static override table = users
+// passwordHash is never supplied and no password is ever required — unlike a
+// model that also offers password sign-up.
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  optionalOnCreate: ['passwordHash'],
+}) {
   static fillable = ['name', 'email', 'githubId']
   static guarded = ['id', 'passwordHash', 'rememberToken']
   static override hidden = ['passwordHash', 'rememberToken']
-  declare static readonly recordType: UserRecord
-  declare static readonly createType: Omit<NewUserRecord, 'passwordHash'>
 }


### PR DESCRIPTION
## Summary

`defineModel(table)` infers `createType` from the Drizzle table, which requires every non-defaulted column. That is the wrong shape whenever the model fills a column in itself. `AuthenticatableModel` is the standing example: it hashes a plain `password` into `passwordHash`, so callers pass the former and not the latter. Saying so meant skipping `defineModel()` altogether and redeclaring both type markers by hand — the `createType` option is value-based, so using it reintroduces the `{} as X` cast that #231 just removed.

Two type-level options replace that, and auth user models collapse onto the same single pattern every other model uses:

```ts
export class User extends defineModel(users, {
  base: AuthenticatableModel,
  optionalOnCreate: ['passwordHash'],
  requireOnCreate: ['password'],
}) {
  static guarded = ['id', 'passwordHash', 'rememberToken']
  static override hidden = ['passwordHash', 'rememberToken']
}
```

`optionalOnCreate` makes columns optional — they keep their type, callers just need not supply them. `requireOnCreate` goes the other way and accepts both table columns (Drizzle marks defaulted ones optional) and named fields contributed by `base`, which is what lets it require a virtual `password` that no column backs. Both are checked against the real create keys, so a typo fails to compile. Neither has a runtime effect.

Neither closes the payload either: a create type always admits unknown keys as `unknown`, so `fillable`/`guarded` remain what reject an unwanted field at runtime. The docs say so, and the type tests pin both halves.

### Two things reviewers should look at

**The option is named `optionalOnCreate`, not `omitFromCreate`.** The first draft used the latter and it needed the same "it un-requires, it does not forbid" caveat repeated in seven places — the change telling us the name was wrong. Renaming also let the implementation say it: `Partial<Pick<…>>` keeps the column present and typed instead of deleting it and letting the base marker's index signature re-admit it as `unknown`. `create({ passwordHash: 42 })` is now a type error where it used to compile.

**This uncovered a pre-existing hole in `guren audit`.** Its sensitive-column check resolved a model's table only from `static table = users`, so any model written as `defineModel(users, …)` fell out of the scan entirely — not just the ones migrated here. `examples/api` had a live "passwordHash is serialized" warning that simply stopped being reported once its model moved. Table resolution now goes through a shared `extractTableIdentifier` covering both spellings, with a regression test, and `examples/api` gets the `hidden` list the warning was asking for. `guren context` / `model:list` likewise learned to recognise an auth model whose base arrives as a `defineModel` option rather than a superclass.

## Scope

orm, cli, server, docs, examples, web

- `packages/orm` — `optionalOnCreate` / `requireOnCreate` on `defineModel()`, plus type tests
- `packages/cli` — `make:auth` user-model template, `model-parser` auth-base and table detection, `audit` table resolution, agent harness rules and skills
- `packages/server` — runtime test that hashing still composes through `defineModel`
- `docs/en` + `docs/ja` — authentication and database guides
- `examples/blog`, `examples/api`, `web/modules/blog` — User models migrated

## Risk Assessment

**No breaking changes.** The two new type parameters go after `TCreate`, so `defineModel<TTable, TBase, TCreate>()` keeps meaning what it did; the create shape resolves in the return type rather than as a parameter default (which may only reference earlier parameters). A type test pins that spelling. The `createType` option still works and is marked deprecated.

**Scaffold output changes.** `make:auth` now emits `optionalOnCreate` (and `requireOnCreate` only when password sign-up is the sole way in — OAuth accounts are created without a password, so requiring one would make the generated OAuth controller fail to compile). It also emits `static guarded = ['id', 'passwordHash', 'rememberToken']`, which the scaffolded model previously left on its `['id']` default — a request body could set its own hash. Remember-me is unaffected: the token is persisted via `forceUpdate`, which bypasses mass-assignment filtering.

**`guren audit` will report more.** Projects whose models use `defineModel` were silently skipping the sensitive-column check and will now see its findings. That is the point of the fix, but it means an audit that passed before may warn after upgrading.

Changeset: `@guren/orm` minor, `@guren/cli` minor.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` — 3096 framework + 91 example tests, 0 failures

Also run:

- `bun run audit:docs`, `bun run audit:core-first` — pass
- `examples/blog`, `examples/api`, `web` typechecks — pass (these are what exercise the options against the real `AuthenticatableModel`; the ORM's own type test uses a local stand-in, since importing `@guren/server` would invert the package dependency)
- `guren audit` on `examples/blog` — 22 passed, 0 warnings (21 while the check was silently skipping)
- `scripts/smoke-golden-path.sh` — fresh app, auth scaffold, codegen, typecheck, build, migrations, live login/CRUD/CSRF over HTTP
- The same golden path against `make:auth --install --oauth github` — covers the OAuth template variant, whose model omits `requireOnCreate`

Behavioural coverage worth calling out: the runtime test in `packages/server/tests/auth/AuthenticatableModel.test.ts` asserts that a model built with `defineModel(table, { base: AuthenticatableModel })` still hashes `password` into `passwordHash` and drops the plain value. Verified it can fail — breaking the base composition in `defineModel` makes it fail.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
