### PR TITLE
fix(orm): run bulk updates through persistence payload preparation

### DIFF
--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -745,6 +745,11 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     return result
   }
 
+  /** @internal Lets QueryBuilder bulk updates run the same payload preparation as `Model.update()`. */
+  static async prepareBulkPersistencePayload(data: PlainObject): Promise<PlainObject> {
+    return this.preparePersistencePayload(data)
+  }
+
   protected static getRelationDefinitions(): Map<string, RelationDefinition> {
     if (!Object.prototype.hasOwnProperty.call(this, 'relationDefinitions') || !this.relationDefinitions) {
       this.relationDefinitions = new Map()

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -417,8 +417,11 @@ export class QueryBuilder<
    *
    * Mass-assignment protection applies exactly as in `Model.update()`:
    * with a `fillable` allowlist, out-of-allowlist keys throw a
-   * MassAssignmentException. Note that bulk updates skip model hooks,
-   * observers, mutators, and casts by design.
+   * MassAssignmentException. The payload also runs through the same
+   * persistence preparation as `Model.update()` — mutators, casts, and
+   * `preparePersistencePayload` overrides (e.g. password hashing on
+   * authenticatable models). Per-record hooks and observers are still
+   * skipped by design.
    *
    * @param data - Data to set on matching records
    * @returns The updated record (adapter-dependent)
@@ -441,7 +444,8 @@ export class QueryBuilder<
     }
 
     const model = this.modelClass as typeof Model
-    const payload = applyFillable ? model.filterFillable(data) : { ...data }
+    const filtered = applyFillable ? model.filterFillable(data) : { ...data }
+    const payload = await model.prepareBulkPersistencePayload(filtered)
 
     const advancedAdapter = this.adapter as ORMAdapterAdvanced
     if (typeof advancedAdapter.updateAdvanced === 'function') {

--- a/packages/orm/tests/query-builder.test.ts
+++ b/packages/orm/tests/query-builder.test.ts
@@ -352,6 +352,59 @@ describe('QueryBuilder', () => {
       const results = await qb().where('name', 'Alice').get()
       expect(results[0].score).toBe(100)
     })
+
+    it('should run payloads through preparePersistencePayload overrides', async () => {
+      const PreparedModel = class extends Model<TestRecord> {
+        static table = 'tests' as any
+        static getAdapter() { return adapter as ORMAdapter }
+        static resolveTable() { return 'tests' }
+
+        protected static override async preparePersistencePayload(data: PlainObject): Promise<PlainObject> {
+          const payload = await super.preparePersistencePayload(data)
+          if (typeof payload.name === 'string') {
+            payload.name = payload.name.toUpperCase()
+          }
+          return payload
+        }
+      }
+
+      await new QueryBuilder<TestRecord>(PreparedModel).where('id', 1).update({ name: 'renamed' })
+      const results = await qb().where('id', 1).get()
+      expect(results[0].name).toBe('RENAMED')
+    })
+
+    it('should run forceUpdate payloads through preparePersistencePayload overrides', async () => {
+      const PreparedModel = class extends Model<TestRecord> {
+        static table = 'tests' as any
+        static getAdapter() { return adapter as ORMAdapter }
+        static resolveTable() { return 'tests' }
+
+        protected static override async preparePersistencePayload(data: PlainObject): Promise<PlainObject> {
+          const payload = await super.preparePersistencePayload(data)
+          if (typeof payload.name === 'string') {
+            payload.name = payload.name.toUpperCase()
+          }
+          return payload
+        }
+      }
+
+      await new QueryBuilder<TestRecord>(PreparedModel).where('id', 2).forceUpdate({ name: 'renamed' })
+      const results = await qb().where('id', 2).get()
+      expect(results[0].name).toBe('RENAMED')
+    })
+
+    it('should apply casts to bulk update payloads', async () => {
+      const CastModel = class extends Model<TestRecord> {
+        static table = 'tests' as any
+        static override casts = { score: 'number' } as const
+        static getAdapter() { return adapter as ORMAdapter }
+        static resolveTable() { return 'tests' }
+      }
+
+      await new QueryBuilder<TestRecord>(CastModel).where('id', 3).update({ score: '42' })
+      const results = await qb().where('id', 3).get()
+      expect(results[0].score).toBe(42)
+    })
   })
 
   describe('delete', () => {

--- a/packages/server/tests/auth/AuthenticatableModel.test.ts
+++ b/packages/server/tests/auth/AuthenticatableModel.test.ts
@@ -55,6 +55,25 @@ describe('AuthenticatableModel', () => {
     expect('password' in persisted).toBe(false)
   })
 
+  it('hashes the password on query-builder bulk updates', async () => {
+    type UserRecord = { id?: number; email: string; passwordHash?: string }
+
+    class User extends AuthenticatableModel<UserRecord> {
+      static override table = 'users'
+      static override guarded = ['id']
+    }
+
+    const captured: PlainObject[] = []
+    User.useAdapter(createAdapter(captured))
+
+    await User.where('email', 'demo@guren.dev').update({ password: 'secret' })
+
+    const persisted = captured[0]
+    expect(persisted.passwordHash).toBeDefined()
+    expect(persisted.passwordHash).not.toBe('secret')
+    expect('password' in persisted).toBe(false)
+  })
+
   it('supports custom password and hash column names', async () => {
     type MemberRecord = { id?: number; passwordDigest?: string }
 


### PR DESCRIPTION
## Summary

- `QueryBuilder.update()` / `forceUpdate()` (bulk updates via `Model.where(...).update(...)`) sent the filtered payload straight to the adapter, skipping `preparePersistencePayload`.
- On `AuthenticatableModel` subclasses this meant a bulk update with `{ password: 'secret' }` persisted a literal plaintext `password` column instead of hashing it into `passwordHash` — silently, with no error.
- `Model.create()` / `Model.update()` (single-record path) were unaffected; they already route through `preparePersistencePayload`.

## Fix

- Added an `@internal` public bridge `Model.prepareBulkPersistencePayload()` (the underlying `preparePersistencePayload` stays `protected` so existing overrides like `AuthenticatableModel` keep compiling).
- `QueryBuilder.runBulkUpdate` now awaits this bridge after `filterFillable`, applying the same mutators/casts/`preparePersistencePayload` overrides as the single-record path.
- Per-record hooks and observers remain skipped by design (documented in the updated JSDoc) — only payload-level preparation is now shared.

## Test plan

- [x] New regression test: bulk `update()` on an `AuthenticatableModel` hashes the password and drops the plaintext field.
- [x] New `QueryBuilder` tests: `preparePersistencePayload` overrides run for both `update()` and `forceUpdate()`; casts apply to bulk update payloads.
- [x] Verified the fix is load-bearing by reverting it locally and confirming the new tests fail (4/4), then restoring.
- [x] `bun run build`, `bun run typecheck`, `bun run test:bun`, `bun run test:examples` all pass.