### PR TITLE
fix(cli): forward rawArgs from guren new to create-guren-app

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env bun
-import { spawn } from 'node:child_process'
 import { pathToFileURL } from 'node:url'
 import { consola } from 'consola'
 import { defineCommand, showUsage } from 'citty'
 import type { CommandDef } from 'citty'
 import { runCli, UsageError } from './run-cli'
+import { newCommand } from './new-command'
 import { listBlueprints, runBlueprint } from './blueprints'
 import { runDoctor } from './doctor'
 import { makeAuth } from './make-auth'
@@ -195,27 +195,6 @@ function reportSuccess(action: string, message: string, json: boolean, extra?: R
   } else {
     consola.success(message)
   }
-}
-
-async function runBunCommand(args: string[]): Promise<void> {
-  await new Promise<void>((resolvePromise, rejectPromise) => {
-    const child = spawn(process.execPath || 'bun', args, {
-      stdio: 'inherit',
-      env: process.env,
-    })
-
-    child.on('error', (error) => {
-      rejectPromise(error)
-    })
-
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolvePromise()
-      } else {
-        rejectPromise(new Error(`bun ${args.join(' ')} exited with code ${code}`))
-      }
-    })
-  })
 }
 
 const makeTestCommand = defineCommand({
@@ -1958,62 +1937,6 @@ const makeFeatureCommand = defineCommand({
       publicAccess: Boolean(args.public),
       withPolicy: Boolean(args.policy),
     })
-  },
-})
-
-const newCommand = defineCommand({
-  meta: {
-    name: 'new',
-    description: 'Scaffold a new Guren application via create-guren-app.',
-  },
-  args: {
-    target: {
-      type: 'positional',
-      description: 'Directory to create the application in',
-      default: '.',
-    },
-    force: {
-      type: 'boolean',
-      alias: 'f',
-      description: 'Overwrite existing files in the target directory',
-    },
-    mode: {
-      type: 'string',
-      description: 'Rendering mode to scaffold (spa or ssr)',
-    },
-    auth: {
-      type: 'boolean',
-      description: 'Include authentication scaffolding',
-    },
-    blueprint: {
-      type: 'string',
-      description: 'Application blueprint to scaffold (default or blog).',
-    },
-  },
-  async run({ args }) {
-    const commandArgs = ['x', 'create-guren-app']
-
-    if (args.target) {
-      commandArgs.push(String(args.target))
-    }
-
-    if (args.force) {
-      commandArgs.push('--force')
-    }
-
-    if (args.mode) {
-      commandArgs.push('--mode', String(args.mode))
-    }
-
-    if (args.auth) {
-      commandArgs.push('--auth')
-    }
-
-    if (args.blueprint) {
-      commandArgs.push('--blueprint', String(args.blueprint))
-    }
-
-    await runBunCommand(commandArgs)
   },
 })
 

--- a/packages/cli/src/new-command.ts
+++ b/packages/cli/src/new-command.ts
@@ -1,0 +1,87 @@
+import { spawn } from 'node:child_process'
+import { defineCommand } from 'citty'
+
+export type CommandRunner = (args: string[]) => Promise<void>
+
+async function runBunCommand(args: string[]): Promise<void> {
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const child = spawn(process.execPath || 'bun', args, {
+      stdio: 'inherit',
+      env: process.env,
+    })
+
+    child.on('error', (error) => {
+      rejectPromise(error)
+    })
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolvePromise()
+      } else {
+        rejectPromise(new Error(`bun ${args.join(' ')} exited with code ${code}`))
+      }
+    })
+  })
+}
+
+/**
+ * `guren new` is a thin forwarder to `create-guren-app`, so the transport is
+ * `ctx.rawArgs` — citty hands over exactly the argv that followed the
+ * subcommand name, which the child then parses with its own declarations.
+ *
+ * The `args` block below exists **only** so `guren new --help` stays useful
+ * (`runCli` intercepts `--help` before `run()` is ever reached). citty still
+ * parses it on the way in; `run()` just ignores the result. Do not reintroduce
+ * a parsed-arg translation table: an undeclared string flag does not merely get
+ * dropped by citty, it parses as boolean `true` and leaks its value into
+ * `args._` — which is how `guren new app --db postgres` silently scaffolded a
+ * SQLite app.
+ *
+ * Keep these declarations in sync with `packages/create-app/src/cli.ts` by
+ * hand; they are documentation, and only the child enforces them.
+ */
+export function createNewCommand(runCreateApp: CommandRunner = runBunCommand) {
+  return defineCommand({
+    meta: {
+      name: 'new',
+      description: 'Scaffold a new Guren application via create-guren-app.',
+    },
+    args: {
+      target: {
+        type: 'positional',
+        description: 'Directory to create the application in',
+        default: '.',
+      },
+      force: {
+        type: 'boolean',
+        alias: 'f',
+        description: 'Overwrite existing files in the target directory',
+      },
+      mode: {
+        type: 'string',
+        description: 'Rendering mode to scaffold (spa or ssr)',
+      },
+      auth: {
+        type: 'boolean',
+        description: 'Include authentication scaffolding',
+      },
+      blueprint: {
+        type: 'string',
+        description: 'Starter blueprint to scaffold (default, api, blog, worker)',
+      },
+      db: {
+        type: 'string',
+        description: 'Database driver (sqlite, postgres, mysql)',
+      },
+      install: {
+        type: 'boolean',
+        description: 'Install dependencies after scaffolding (default: true)',
+      },
+    },
+    async run(ctx) {
+      await runCreateApp(['x', 'create-guren-app', ...ctx.rawArgs])
+    },
+  })
+}
+
+export const newCommand = createNewCommand()

--- a/packages/cli/tests/new-command.test.ts
+++ b/packages/cli/tests/new-command.test.ts
@@ -1,0 +1,129 @@
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'bun:test'
+import { runCommand } from 'citty'
+import { stripAnsi } from 'consola/utils'
+import { createNewCommand } from '../src/new-command'
+
+/**
+ * Drives the command through citty rather than asserting on a pure argv
+ * builder: the bug this covers lived in citty's *parsing*, so a test that
+ * skips the parse cannot see it.
+ */
+async function forwardedArgs(rawArgs: string[]): Promise<string[]> {
+  const calls: string[][] = []
+  const command = createNewCommand(async (args) => {
+    calls.push(args)
+  })
+
+  await runCommand(command, { rawArgs })
+
+  expect(calls).toHaveLength(1)
+  return calls[0]!
+}
+
+describe('guren new', () => {
+  it('forwards a string flag with its value instead of parsing it as a boolean', async () => {
+    // The regression: `--db` was undeclared, so citty produced `db: true` and
+    // leaked "postgres" into `args._`. Rebuilding argv from parsed args then
+    // dropped it entirely and the user silently got a SQLite app.
+    expect(await forwardedArgs(['my-app', '--db', 'postgres'])).toEqual([
+      'x',
+      'create-guren-app',
+      'my-app',
+      '--db',
+      'postgres',
+    ])
+  })
+
+  it('forwards --no-install, the only way to skip the child default of true', async () => {
+    expect(await forwardedArgs(['my-app', '--no-install'])).toEqual([
+      'x',
+      'create-guren-app',
+      'my-app',
+      '--no-install',
+    ])
+  })
+
+  it('forwards flags it declares only for --help', async () => {
+    expect(await forwardedArgs(['my-app', '--force', '--mode', 'ssr', '--auth', '--blueprint', 'blog'])).toEqual([
+      'x',
+      'create-guren-app',
+      'my-app',
+      '--force',
+      '--mode',
+      'ssr',
+      '--auth',
+      '--blueprint',
+      'blog',
+    ])
+  })
+
+  it('forwards flag order and aliases verbatim', async () => {
+    expect(await forwardedArgs(['-f', 'my-app', '--db', 'mysql'])).toEqual([
+      'x',
+      'create-guren-app',
+      '-f',
+      'my-app',
+      '--db',
+      'mysql',
+    ])
+  })
+
+  it('passes no positional through when none was given, leaving the child default to apply', async () => {
+    expect(await forwardedArgs([])).toEqual(['x', 'create-guren-app'])
+  })
+
+  it('forwards a flag this command does not declare at all', async () => {
+    // The contract is "forward everything", not "forward what we mirror". Every
+    // other case here uses a declared flag, so a translation table rebuilt to
+    // cover the current declarations would satisfy them while silently dropping
+    // the next flag `create-guren-app` grows. That is exactly how `--db` broke.
+    expect(await forwardedArgs(['my-app', '--not-a-declared-flag', 'value'])).toEqual([
+      'x',
+      'create-guren-app',
+      'my-app',
+      '--not-a-declared-flag',
+      'value',
+    ])
+  })
+
+  it('forwards the --flag=value form, which the old translation table also dropped', async () => {
+    expect(await forwardedArgs(['my-app', '--db=postgres'])).toEqual([
+      'x',
+      'create-guren-app',
+      'my-app',
+      '--db=postgres',
+    ])
+  })
+
+  it('forwards a -- separator and everything after it', async () => {
+    expect(await forwardedArgs(['my-app', '--', '--db', 'postgres'])).toEqual([
+      'x',
+      'create-guren-app',
+      'my-app',
+      '--',
+      '--db',
+      'postgres',
+    ])
+  })
+
+  // The cases above construct the command directly, so none of them would
+  // notice if it stopped being registered in `bin.ts`. `--help` is the one
+  // path that exercises the real wiring without spawning `create-guren-app`:
+  // `runCli` renders usage and returns before `run()` is reached.
+  it('is registered in the CLI, and its help lists the flags it forwards', async () => {
+    const { NODE_ENV: _testEnv, ...env } = process.env
+    const proc = Bun.spawn(['bun', resolve(import.meta.dir, '../src/bin.ts'), 'new', '--help'], {
+      env,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+    const usage = stripAnsi(stdout).replace(/`/g, '')
+
+    expect(exitCode).toBe(0)
+    expect(usage).toContain('USAGE guren new')
+    expect(usage).toContain('--db')
+    expect(usage).toContain('--install')
+  })
+})


### PR DESCRIPTION
## Summary

- `guren new` declared only a subset of `create-guren-app`'s flags (`target`, `force`, `mode`, `auth`, `blueprint`) and rebuilt argv from citty's *parsed* args in its `run()` body.
- `--db` and `--install` were never declared. With citty 0.1.6 (pinned), an undeclared string flag isn't dropped — it parses as boolean `true` and its value leaks into `args._`. So `guren new my-app --db postgres` silently produced a SQLite app, with no error or warning. Same class of bug affected `--install`/`--no-install` (the child defaults `install: true`, so there was previously no way to skip install through `guren new` at all).
- Fix: forward `ctx.rawArgs` verbatim to `create-guren-app` instead of reconstructing argv. This fixes `--db`/`--install` (and `--flag=value` / `--` forms) for any flag the child supports today or adds later, since there's no longer a translation table to keep in sync.
- `newCommand` is extracted out of `bin.ts` (which self-executes on import) into `packages/cli/src/new-command.ts` so it's directly testable. The `args` declarations are kept, but now exist only so `guren new --help` documents the flags — `runCli` intercepts `--help` before `run()` is reached, so they're otherwise unused (citty still parses them; the result is just ignored).

## Verification

- Reviewed with Codex (`mcp__codex__codex`) as a second pass; findings were checked against the actual code before being applied — one finding was accepted as stated, one was accepted in substance but its specific claim ("a complete translation table passes all 5 tests") was empirically wrong (2 of 5 still failed), so the fix was scoped to what the finding actually proved.
- Added tests in `packages/cli/tests/new-command.test.ts`, driven through citty (not a plain argv-builder unit test) since the bug lived in citty's parsing:
  - forwards a declared string flag with its value (`--db postgres`)
  - forwards `--no-install`
  - forwards flags only declared for `--help`
  - preserves flag order and aliases
  - passes no positional through when none given
  - forwards a flag the command does not declare at all (the actual shape of the original bug)
  - forwards `--flag=value` form
  - forwards a `--` separator and everything after it
  - confirms `new` is registered in the real CLI and `--help` lists `--db`/`--install`
- Mutation-tested: restoring the old translation table turns 4/5 original tests red; a translation table extended to cover every declared flag (including `db`/`install`) still turns 5/9 tests red; removing the `new: newCommand` registration from `bin.ts` turns the registration test red.
- `bun run test` (full suite): 3100 pass, 0 fail. `bun run typecheck`: clean. `packages/cli` suite: 872 pass, 0 fail.
- Manually scaffolded a real app through the fixed path with `--db=postgres --no-install` and confirmed `config/database.ts` has the postgres connection string and `node_modules/` was not created.

## Test plan

- [x] `bun run test`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run audit:core-first`
- [x] `bun run audit:docs`
- [x] `bun run audit:starter-template`
- [x] Manual scaffold via `bun packages/cli/src/bin.ts new <dir> --db=postgres --no-install`