### PR TITLE
feat(cli): expose the docs relation graph to agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Commands designed for AI coding agents to understand, validate, and generate cod
 bunx guren context              # Project context map (markdown)
 bunx guren context --json       # Project context map (JSON)
 bunx guren context User         # Entity-centric bundle: model, routes, pages, resource, policy, linked docs (--module to disambiguate, "app" = root)
+bunx guren docs:graph           # OKF docs relation graph (--entity/--path narrows; --json for agents)
 bunx guren model:list           # List models with relationships
 bunx guren model:list --format json  # Models as JSON
 

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -82,6 +82,7 @@ Validate your app before shipping — these commands are also designed for AI co
 | `audit` | Security audit: missing input validation or authentication on mutating routes, raw SQL with interpolation, hardcoded credentials, disabled security defaults, mass-assignment configuration, sensitive columns not listed in `static hidden` | `bunx guren audit --json` |
 | `doctor` | Project health report (env, config, generated files) with actionable next steps | `bunx guren doctor --next` |
 | `context [Entity]` | Project context map — or, with an entity name, everything about one model: table, relationships, routes with schemas, pages with Props, resource, policy, linked docs (`--module` disambiguates, `"app"` = project root) | `bunx guren context User --json` |
+| `docs:graph` | The OKF docs relation graph: documents, entities, and code paths as nodes, verified relations as edges. `--entity <Model>` or `--path <file>` narrows to a neighborhood — ask "what governs this?" before renaming | `bunx guren docs:graph --path app/Http/Controllers/PostController.ts` |
 | `spec:generate` | Regenerates the derived spec views in `docs/spec/` (ER diagram, domain model, screens, module map) — see [Spec-Anchored Development](./spec-anchored.md) | `bunx guren spec:generate` |
 
 `audit` exits with a non-zero status when it finds failures. Plain

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -80,6 +80,7 @@ bunx guren plugin @acme/guren-plugin-audit
 | `audit` | セキュリティ監査: 変更系ルートのバリデーション/認証の欠如、文字列補間付き生SQL、ハードコードされた認証情報、無効化されたセキュリティ既定値、mass assignment 設定、`static hidden` 未登録の機微カラムを検査 | `bunx guren audit --json` |
 | `doctor` | プロジェクトの健全性レポート(環境変数・設定・生成ファイル)と次のアクション | `bunx guren doctor --next` |
 | `context [Entity]` | プロジェクトコンテキストマップ。エンティティ名を渡すと1モデルのすべて — テーブル・リレーション・スキーマ付きルート・Props付きページ・Resource・Policy・紐付きdocs — を出力(同名モデルは `--module` で解決、`"app"` はプロジェクトルート) | `bunx guren context User --json` |
+| `docs:graph` | OKF docsのリレーショングラフ。文書・エンティティ・コードパスがノード、検証済みリレーションがエッジ。`--entity <Model>` / `--path <file>` で近傍に絞り、リネーム前に「これを統べるdocsはどれか」を照会 | `bunx guren docs:graph --path app/Http/Controllers/PostController.ts` |
 | `spec:generate` | `docs/spec/` の導出スペックビュー(ER図・ドメインモデル・画面一覧・モジュールマップ)を再生成 — 詳細は[スペックアンカード開発](./spec-anchored.md) | `bunx guren spec:generate` |
 
 `audit` は失敗(fail)を検出すると非ゼロの終了コードを返します。

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -26,6 +26,7 @@ import { makeNotification } from './make-notification'
 import { makeProvider } from './make-provider'
 import { makeAdr } from './make-adr'
 import { writeSpecArtifacts } from './spec-generate'
+import { buildDocsGraphReport, renderDocsGraphMarkdown } from './docs-graph'
 import { makeResource } from './make-resource'
 import { makeRoute } from './make-route'
 import { makeSeeder } from './make-seeder'
@@ -139,6 +140,40 @@ const specGenerateCommand = defineCommand({
   },
   async run({ args }) {
     await writeSpecArtifacts({ cwd: args.app, routesFile: args.routes })
+  },
+})
+
+const docsGraphCommand = defineCommand({
+  meta: {
+    name: 'docs:graph',
+    description:
+      'Show the OKF docs relation graph: documents, entities, code paths, and verified edges. Narrow with --entity or --path to answer "what governs this?" before renaming or editing.',
+  },
+  args: {
+    entity: {
+      type: 'string',
+      description: 'Narrow to the neighborhood of one model entity (case-insensitive).',
+    },
+    path: {
+      type: 'string',
+      description: 'Narrow to the neighborhood of one app-root-relative path.',
+    },
+    app: {
+      type: 'string',
+      description: 'Application root directory.',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON.',
+    },
+  },
+  async run({ args }) {
+    const report = await buildDocsGraphReport({
+      cwd: args.app,
+      entity: args.entity,
+      path: args.path,
+    })
+    console.log(args.json ? JSON.stringify(report, null, 2) : renderDocsGraphMarkdown(report))
   },
 })
 
@@ -2336,6 +2371,7 @@ const builtinSubCommands = {
   ...makeCommands,
   'make:adr': makeAdrCommand,
   'spec:generate': specGenerateCommand,
+  'docs:graph': docsGraphCommand,
   'make:auth': makeAuthCommand,
   'make:module': makeModuleCommand,
   'make:channel': makeChannelCommand,

--- a/packages/cli/src/docs-check.ts
+++ b/packages/cli/src/docs-check.ts
@@ -20,6 +20,8 @@ export interface DocsCheckOptions {
   changedFiles?: Set<string> | null
   /** Reuses sources already read by the surrounding `runCheck`, when present. */
   cache?: ParseCache
+  /** Reuses an existing `scanDocs` result instead of re-scanning the bundle. */
+  refs?: DocRef[]
 }
 
 function hasGlobChars(entry: string): boolean {
@@ -127,7 +129,7 @@ export async function runDocsCheck(options: DocsCheckOptions): Promise<CheckResu
   const { cwd, changedFiles, cache } = options
 
   const [refs, modelFiles, controllerFiles] = await Promise.all([
-    scanDocs(cwd),
+    options.refs ?? scanDocs(cwd),
     discoverModelFiles(cwd),
     discoverControllerFiles(cwd),
   ])

--- a/packages/cli/src/docs-graph.ts
+++ b/packages/cli/src/docs-graph.ts
@@ -5,12 +5,15 @@
  * nodes, their declared relations (`entities`, `related`, body markdown
  * links) become verdict-colored edges, and generated spec views gain
  * derivation edges from the code sources they regenerate from
- * (`SPEC_VIEWS[].sources` — the same descriptor the drift gate
- * uses). Consumed by the docs viewer endpoint; no filesystem access.
+ * (`SPEC_VIEWS[].sources` — the same descriptor the drift gate uses).
+ * `buildDocsGraph` itself does no filesystem access; `loadDocsGraph`
+ * is the one filesystem pass shared by every consumer (the docs viewer
+ * endpoint, `guren docs:graph`, and the MCP tool).
  */
 import { posix } from 'node:path'
 import { scanDocs, type DocRef } from './docs-index'
 import { resolveDocLink, runDocsCheck } from './docs-check'
+import { matchesGlob } from './glob-match'
 import type { CheckResult, CheckStatus } from './check-result'
 import { SPEC_VIEWS } from './spec-generate'
 import { SPEC_DIR } from './spec-artifact'
@@ -132,6 +135,21 @@ export function buildDocsGraph(refs: DocRef[], checks: CheckResult[]): DocsGraph
   return { nodes, edges }
 }
 
+export interface LoadedDocsGraph {
+  refs: DocRef[]
+  checks: CheckResult[]
+  graph: DocsGraph
+}
+
+/**
+ * One filesystem pass behind every graph consumer: scan the bundle
+ * once, feed the same refs to the checker, join.
+ */
+export async function loadDocsGraph(cwd: string): Promise<LoadedDocsGraph> {
+  const refs = await scanDocs(cwd)
+  const checks = await runDocsCheck({ cwd, refs })
+  return { refs, checks, graph: buildDocsGraph(refs, checks) }
+}
 
 export interface DocsGraphReportOptions {
   cwd?: string
@@ -141,18 +159,37 @@ export interface DocsGraphReportOptions {
   path?: string
 }
 
+export interface DocsGraphQuery {
+  entity?: string
+  path?: string
+}
+
 export interface DocsGraphReport extends DocsGraph {
-  /** The node ids the report was narrowed to, empty for the whole graph. */
+  /** Echo of the narrowing request; absent when the whole graph was asked for. */
+  query?: DocsGraphQuery
+  /** The node ids the query matched, empty when nothing did (or no query). */
   focus: string[]
 }
 
 /**
- * Whether a focus path names this node: exactly, or by falling under a
- * directory node (`app/Models/` covers `app/Models/Post.ts`).
+ * Whether a query path names this node. Exact ids and directory nodes
+ * match literally; glob nodes (`related` entries like `modules/billing/**`)
+ * go through the same matcher `check --docs` resolves them with; and
+ * derivation-source nodes match when any `SPEC_VIEWS` pattern that
+ * carries the node's label accepts the path — the label alone can't say
+ * which files feed a view (module schemas collapse to `db/schema.ts`,
+ * and the module map's `(all source files)` is not a path at all), so
+ * the patterns the drift gate matches changed files against decide.
  */
-function nodeMatchesPath(node: DocsGraphNode, path: string): boolean {
-  if (node.id === path) return true
-  return node.id.endsWith('/') && path.startsWith(node.id)
+function nodeMatchesPath(
+  node: DocsGraphNode,
+  path: string,
+  derivedLabels: ReadonlySet<string>,
+): boolean {
+  if (node.id === path || node.id === `${path}/`) return true
+  if (derivedLabels.has(node.id)) return true
+  if (node.id.includes('*')) return matchesGlob(path, node.id)
+  return path.startsWith(node.id.endsWith('/') ? node.id : `${node.id}/`)
 }
 
 /**
@@ -166,30 +203,41 @@ export async function buildDocsGraphReport(
   options: DocsGraphReportOptions = {},
 ): Promise<DocsGraphReport> {
   const cwd = options.cwd ?? process.cwd()
-  const refs = await scanDocs(cwd)
-  const checks = await runDocsCheck({ cwd })
-  const { nodes, edges } = buildDocsGraph(refs, checks)
+  const entity = options.entity?.trim() || undefined
+  const path = options.path?.trim() || undefined
+  if (entity !== undefined && path !== undefined) {
+    throw new Error('Narrow by either entity or path, not both.')
+  }
 
-  const focus = nodes.filter((node) => {
-    if (options.entity !== undefined && node.kind === 'entity') {
-      return node.label.toLowerCase() === options.entity.toLowerCase()
-    }
-    if (options.path !== undefined && node.kind !== 'entity') {
-      return nodeMatchesPath(node, options.path)
-    }
-    return false
-  })
-
-  if (options.entity === undefined && options.path === undefined) {
+  const { graph } = await loadDocsGraph(cwd)
+  const { nodes, edges } = graph
+  if (entity === undefined && path === undefined) {
     return { focus: [], nodes, edges }
   }
 
-  const focusIds = new Set(focus.map((node) => node.id))
+  const focusIds = new Set<string>()
+  if (entity !== undefined) {
+    const wanted = entity.toLowerCase()
+    for (const node of nodes) {
+      if (node.kind === 'entity' && node.label.toLowerCase() === wanted) focusIds.add(node.id)
+    }
+  } else if (path !== undefined) {
+    const target = posix.normalize(path.replace(/\\/g, '/'))
+    const derivedLabels = new Set(
+      SPEC_VIEWS.flatMap((view) => view.sources)
+        .filter((source) => source.pattern.test(target))
+        .map((source) => source.label),
+    )
+    for (const node of nodes) {
+      if (node.kind !== 'entity' && nodeMatchesPath(node, target, derivedLabels)) {
+        focusIds.add(node.id)
+      }
+    }
+  }
+
+  const query = entity !== undefined ? { entity } : { path }
   if (focusIds.size === 0) {
-    // Narrowing was requested but nothing matched: echo the request so
-    // the caller (and the renderer) can tell this apart from an
-    // un-narrowed report of an empty bundle.
-    return { focus: [options.entity ?? options.path ?? ''], nodes: [], edges: [] }
+    return { query, focus: [], nodes: [], edges: [] }
   }
   const keptEdges = edges.filter((edge) => focusIds.has(edge.from) || focusIds.has(edge.to))
   const keptIds = new Set(focusIds)
@@ -199,45 +247,42 @@ export async function buildDocsGraphReport(
   }
 
   return {
+    query,
     focus: [...focusIds],
     nodes: nodes.filter((node) => keptIds.has(node.id)),
     edges: keptEdges,
   }
 }
 
-const VERDICT_GLYPH: Record<CheckStatus, string> = { pass: 'ok', warn: 'warn', fail: 'FAIL' }
+const VERDICT_GLYPH: Record<Exclude<CheckStatus, 'pass'>, string> = { warn: 'warn', fail: 'FAIL' }
+
+const KIND_TITLES: Array<[DocsGraphNode['kind'], string]> = [
+  ['doc', 'Documents'],
+  ['entity', 'Entities'],
+  ['code', 'Code'],
+]
 
 /** Human-readable rendering, mirroring `guren context`'s markdown style. */
 export function renderDocsGraphMarkdown(report: DocsGraphReport): string {
   const lines: string[] = ['# Docs Graph', '']
+  const requested = report.query?.entity ?? report.query?.path
 
   if (report.focus.length > 0) {
     lines.push(`Neighborhood of: ${report.focus.join(', ')}`, '')
   }
   if (report.nodes.length === 0) {
     lines.push(
-      report.focus.length === 0
+      requested === undefined
         ? 'No OKF documents found under docs/.'
-        : 'Nothing in the docs graph references this target.',
+        : `Nothing in the docs graph references "${requested}".`,
       '',
     )
     return lines.join('\n')
   }
 
-  const byKind = new Map<string, DocsGraphNode[]>()
-  for (const node of report.nodes) {
-    const list = byKind.get(node.kind) ?? []
-    list.push(node)
-    byKind.set(node.kind, list)
-  }
-  const KIND_TITLES: Array<[DocsGraphNode['kind'], string]> = [
-    ['doc', 'Documents'],
-    ['entity', 'Entities'],
-    ['code', 'Code'],
-  ]
   for (const [kind, title] of KIND_TITLES) {
-    const nodes = byKind.get(kind)
-    if (!nodes) continue
+    const nodes = report.nodes.filter((node) => node.kind === kind)
+    if (nodes.length === 0) continue
     lines.push(`## ${title} (${nodes.length})`)
     for (const node of nodes) {
       const type = node.docType ? ` (${node.docType})` : ''

--- a/packages/cli/src/docs-graph.ts
+++ b/packages/cli/src/docs-graph.ts
@@ -9,8 +9,8 @@
  * uses). Consumed by the docs viewer endpoint; no filesystem access.
  */
 import { posix } from 'node:path'
-import type { DocRef } from './docs-index'
-import { resolveDocLink } from './docs-check'
+import { scanDocs, type DocRef } from './docs-index'
+import { resolveDocLink, runDocsCheck } from './docs-check'
 import type { CheckResult, CheckStatus } from './check-result'
 import { SPEC_VIEWS } from './spec-generate'
 import { SPEC_DIR } from './spec-artifact'
@@ -130,4 +130,128 @@ export function buildDocsGraph(refs: DocRef[], checks: CheckResult[]): DocsGraph
   }
 
   return { nodes, edges }
+}
+
+
+export interface DocsGraphReportOptions {
+  cwd?: string
+  /** Narrow to the neighborhood of one model entity (case-insensitive). */
+  entity?: string
+  /** Narrow to the neighborhood of one app-root-relative path. */
+  path?: string
+}
+
+export interface DocsGraphReport extends DocsGraph {
+  /** The node ids the report was narrowed to, empty for the whole graph. */
+  focus: string[]
+}
+
+/**
+ * Whether a focus path names this node: exactly, or by falling under a
+ * directory node (`app/Models/` covers `app/Models/Post.ts`).
+ */
+function nodeMatchesPath(node: DocsGraphNode, path: string): boolean {
+  if (node.id === path) return true
+  return node.id.endsWith('/') && path.startsWith(node.id)
+}
+
+/**
+ * The docs relation graph, optionally narrowed to one node's
+ * neighborhood — the agent-facing entry behind `guren docs:graph` and
+ * the MCP tool. Narrowing answers the impact question directly: which
+ * documents govern this path or entity, and which spec views regenerate
+ * from it, before a rename or edit rather than after `check` fails.
+ */
+export async function buildDocsGraphReport(
+  options: DocsGraphReportOptions = {},
+): Promise<DocsGraphReport> {
+  const cwd = options.cwd ?? process.cwd()
+  const refs = await scanDocs(cwd)
+  const checks = await runDocsCheck({ cwd })
+  const { nodes, edges } = buildDocsGraph(refs, checks)
+
+  const focus = nodes.filter((node) => {
+    if (options.entity !== undefined && node.kind === 'entity') {
+      return node.label.toLowerCase() === options.entity.toLowerCase()
+    }
+    if (options.path !== undefined && node.kind !== 'entity') {
+      return nodeMatchesPath(node, options.path)
+    }
+    return false
+  })
+
+  if (options.entity === undefined && options.path === undefined) {
+    return { focus: [], nodes, edges }
+  }
+
+  const focusIds = new Set(focus.map((node) => node.id))
+  if (focusIds.size === 0) {
+    // Narrowing was requested but nothing matched: echo the request so
+    // the caller (and the renderer) can tell this apart from an
+    // un-narrowed report of an empty bundle.
+    return { focus: [options.entity ?? options.path ?? ''], nodes: [], edges: [] }
+  }
+  const keptEdges = edges.filter((edge) => focusIds.has(edge.from) || focusIds.has(edge.to))
+  const keptIds = new Set(focusIds)
+  for (const edge of keptEdges) {
+    keptIds.add(edge.from)
+    keptIds.add(edge.to)
+  }
+
+  return {
+    focus: [...focusIds],
+    nodes: nodes.filter((node) => keptIds.has(node.id)),
+    edges: keptEdges,
+  }
+}
+
+const VERDICT_GLYPH: Record<CheckStatus, string> = { pass: 'ok', warn: 'warn', fail: 'FAIL' }
+
+/** Human-readable rendering, mirroring `guren context`'s markdown style. */
+export function renderDocsGraphMarkdown(report: DocsGraphReport): string {
+  const lines: string[] = ['# Docs Graph', '']
+
+  if (report.focus.length > 0) {
+    lines.push(`Neighborhood of: ${report.focus.join(', ')}`, '')
+  }
+  if (report.nodes.length === 0) {
+    lines.push(
+      report.focus.length === 0
+        ? 'No OKF documents found under docs/.'
+        : 'Nothing in the docs graph references this target.',
+      '',
+    )
+    return lines.join('\n')
+  }
+
+  const byKind = new Map<string, DocsGraphNode[]>()
+  for (const node of report.nodes) {
+    const list = byKind.get(node.kind) ?? []
+    list.push(node)
+    byKind.set(node.kind, list)
+  }
+  const KIND_TITLES: Array<[DocsGraphNode['kind'], string]> = [
+    ['doc', 'Documents'],
+    ['entity', 'Entities'],
+    ['code', 'Code'],
+  ]
+  for (const [kind, title] of KIND_TITLES) {
+    const nodes = byKind.get(kind)
+    if (!nodes) continue
+    lines.push(`## ${title} (${nodes.length})`)
+    for (const node of nodes) {
+      const type = node.docType ? ` (${node.docType})` : ''
+      lines.push(`- ${node.id}${node.kind === 'doc' && node.label !== node.id ? ` — ${node.label}` : ''}${type}`)
+    }
+    lines.push('')
+  }
+
+  lines.push(`## Relations (${report.edges.length})`)
+  for (const edge of report.edges) {
+    const verdict = edge.verdict === 'pass' ? '' : ` [${VERDICT_GLYPH[edge.verdict]}]`
+    lines.push(`- ${edge.from} —${edge.relation}→ ${edge.to}${verdict}`)
+  }
+  lines.push('')
+
+  return lines.join('\n')
 }

--- a/packages/cli/src/docs-viewer.ts
+++ b/packages/cli/src/docs-viewer.ts
@@ -12,9 +12,9 @@ import { fileURLToPath } from 'node:url'
 import { resolve } from 'node:path'
 import { parseDocFrontmatter } from './docs-frontmatter'
 import { localLinkTarget } from './docs-links'
-import { scanDocs, type DocActorEvent, type DocRef } from './docs-index'
-import { runDocsCheck, resolveDocLink } from './docs-check'
-import { buildDocsGraph, type DocsGraphEdge, type DocsGraphNode } from './docs-graph'
+import type { DocActorEvent, DocRef } from './docs-index'
+import { resolveDocLink } from './docs-check'
+import { loadDocsGraph, type DocsGraphEdge, type DocsGraphNode } from './docs-graph'
 import { renderDocHtml } from './docs-render'
 
 export type DocTrustTier = 'unverified' | 'machine-confirmed' | 'human-reviewed'
@@ -72,9 +72,11 @@ function resolveViewerLink(docPath: string, target: string): string {
 }
 
 export async function buildDocsViewerData(cwd: string): Promise<DocsViewerData> {
-  const refs = await scanDocs(cwd)
-  const checks = await runDocsCheck({ cwd })
-  const { nodes, edges } = buildDocsGraph(refs, checks)
+  const {
+    refs,
+    checks,
+    graph: { nodes, edges },
+  } = await loadDocsGraph(cwd)
   const staleDocs = new Set(
     checks.filter((check) => check.key.startsWith('docs-stale:')).map((check) => check.filePath),
   )

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -53,6 +53,17 @@ export {
   type DocActorEvent,
 } from './docs-index'
 export { runDocsCheck } from './docs-check'
+// The docs relation graph, exposed for `guren docs:graph` and the MCP
+// tool of the same shape.
+export {
+  buildDocsGraphReport,
+  renderDocsGraphMarkdown,
+  type DocsGraphReport,
+  type DocsGraphReportOptions,
+  type DocsGraph,
+  type DocsGraphNode,
+  type DocsGraphEdge,
+} from './docs-graph'
 // The docs viewer's server-side half calls exactly these two (see
 // DocsViewerCliApi); the graph builder and renderer behind them stay
 // package-internal.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -60,6 +60,7 @@ export {
   renderDocsGraphMarkdown,
   type DocsGraphReport,
   type DocsGraphReportOptions,
+  type DocsGraphQuery,
   type DocsGraph,
   type DocsGraphNode,
   type DocsGraphEdge,

--- a/packages/cli/templates/agent/.claude/rules/docs-and-spec.md
+++ b/packages/cli/templates/agent/.claude/rules/docs-and-spec.md
@@ -74,6 +74,12 @@ failures; broken body links and passed `stale_after` dates warn).
 `entities:` list.** After renaming or moving files a doc references,
 update the doc's frontmatter in the same change.
 
+Ask before you break: `bunx guren docs:graph --path <file>` (or the
+`guren_docs_graph` MCP tool) shows which documents govern a file and
+which spec views regenerate from it — the neighborhood of one node in
+the relation graph. Query it *before* renaming or moving something a
+doc might reference; `guren check` only reports the breakage after.
+
 ## Browsing the bundle: the docs viewer
 
 `bun run dev` mounts a read-only viewer at

--- a/packages/cli/templates/agent/CLAUDE.md
+++ b/packages/cli/templates/agent/CLAUDE.md
@@ -12,6 +12,7 @@ Before exploring `node_modules`, use the built-in introspection commands:
 bunx guren context         # project map: models, routes, controllers, pages (add --json for JSON)
 bunx guren context User    # everything about one entity: model, routes, pages, linked docs — start entity work here
 bunx guren check           # validate route ↔ controller ↔ page consistency, doc links, and spec freshness — run after changes
+bunx guren docs:graph --path <file>  # which docs govern this file, which spec views derive from it — ask BEFORE renaming/moving
 bunx guren codegen         # regenerate .guren/*.gen.ts typed manifests (also runs via `bun run dev`)
 bunx guren spec:generate   # regenerate docs/spec/ views (ER, domain, screens, modules) after schema/model/route changes
 bunx guren make:adr "..."  # record an architecture decision under docs/adr/ (--entity <Model> links it)
@@ -123,6 +124,7 @@ http://localhost:3333/_guren/mcp
 | `guren_get_context` | プロジェクト構造マップ（models, routes, pages, controllers等） |
 | `guren_entity_context` | エンティティ単位のコンテキストバンドル（model, routes, pages, linked docs） |
 | `guren_check` | route↔controller↔page の整合性・docリンク・spec鮮度の検証 |
+| `guren_docs_graph` | OKF docsリレーショングラフ(entity/pathで近傍に絞り込み)— リネーム前の影響照会 |
 | `guren_list_models` | モデル一覧（リレーション、soft deletes、auth trait含む） |
 | `guren_generate_guidelines` | プロジェクト固有コーディング規約の自動生成 |
 | `guren_doctor` | プロジェクト健全性チェック + 次のアクション提案 |

--- a/packages/cli/tests/docs-graph.test.ts
+++ b/packages/cli/tests/docs-graph.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test'
-import { buildDocsGraph } from '../src/docs-graph'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { buildDocsGraph, buildDocsGraphReport, renderDocsGraphMarkdown } from '../src/docs-graph'
+import { createTempWorkspace } from './helpers'
 import type { DocRef } from '../src/docs-index'
 import type { CheckResult } from '../src/check-result'
 
@@ -115,5 +118,144 @@ describe('buildDocsGraph', () => {
 
     expect(nodes.filter((n) => n.id === 'app/Models/Post.ts')).toHaveLength(1)
     expect(edges.filter((e) => e.to === 'app/Models/Post.ts')).toHaveLength(2)
+  })
+})
+
+describe('buildDocsGraphReport', () => {
+  async function writeFixture(dir: string): Promise<void> {
+    await mkdir(join(dir, 'docs/adr'), { recursive: true })
+    await mkdir(join(dir, 'app/Models'), { recursive: true })
+    await mkdir(join(dir, 'app/Http/Controllers'), { recursive: true })
+    await writeFile(join(dir, 'package.json'), '{}', 'utf8')
+    await writeFile(join(dir, 'app/Models/Post.ts'), 'export class Post {}\n', 'utf8')
+    await writeFile(
+      join(dir, 'app/Http/Controllers/PostController.ts'),
+      'export class PostController {}\n',
+      'utf8',
+    )
+    await writeFile(
+      join(dir, 'docs/adr/0001-posts.md'),
+      `---
+type: adr
+entities: [Post]
+related: [app/Http/Controllers/PostController.ts]
+---
+# Posts are public
+`,
+      'utf8',
+    )
+    await writeFile(
+      join(dir, 'docs/adr/0002-other.md'),
+      '---\ntype: adr\n---\n# Unrelated decision\n',
+      'utf8',
+    )
+  }
+
+  it('returns the whole graph when no focus is given', async () => {
+    const workspace = await createTempWorkspace('guren-cli-docs-graph-report-')
+    try {
+      await writeFixture(workspace.dir)
+
+      const report = await buildDocsGraphReport({ cwd: workspace.dir })
+
+      expect(report.focus).toEqual([])
+      expect(report.nodes.some((n) => n.id === 'docs/adr/0002-other.md')).toBe(true)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('narrows to a path neighborhood — the pre-rename impact question', async () => {
+    const workspace = await createTempWorkspace('guren-cli-docs-graph-path-')
+    try {
+      await writeFixture(workspace.dir)
+
+      const report = await buildDocsGraphReport({
+        cwd: workspace.dir,
+        path: 'app/Http/Controllers/PostController.ts',
+      })
+
+      expect(report.focus).toEqual(['app/Http/Controllers/PostController.ts'])
+      // The governing doc is pulled in; the unrelated doc is not.
+      expect(report.nodes.some((n) => n.id === 'docs/adr/0001-posts.md')).toBe(true)
+      expect(report.nodes.some((n) => n.id === 'docs/adr/0002-other.md')).toBe(false)
+      expect(report.edges).toHaveLength(1)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('narrows to an entity neighborhood, case-insensitively', async () => {
+    const workspace = await createTempWorkspace('guren-cli-docs-graph-entity-')
+    try {
+      await writeFixture(workspace.dir)
+
+      const report = await buildDocsGraphReport({ cwd: workspace.dir, entity: 'post' })
+
+      expect(report.focus).toEqual(['entity:Post'])
+      expect(report.nodes.some((n) => n.id === 'docs/adr/0001-posts.md')).toBe(true)
+      expect(report.nodes.some((n) => n.id === 'docs/adr/0002-other.md')).toBe(false)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('matches a file under a directory node', async () => {
+    const workspace = await createTempWorkspace('guren-cli-docs-graph-dir-')
+    try {
+      const dir = workspace.dir
+      await mkdir(join(dir, 'docs/spec'), { recursive: true })
+      await writeFile(join(dir, 'package.json'), '{}', 'utf8')
+      await writeFile(
+        join(dir, 'docs/spec/domain.md'),
+        '---\ntype: spec\n---\n# Domain Model\n',
+        'utf8',
+      )
+
+      // app/Models/ is a derivation source label; a concrete file under
+      // it should reach the spec views it feeds.
+      const report = await buildDocsGraphReport({ cwd: dir, path: 'app/Models/Post.ts' })
+
+      expect(report.focus).toContain('app/Models/')
+      expect(report.nodes.some((n) => n.id === 'docs/spec/domain.md')).toBe(true)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('renders an empty-neighborhood message rather than an empty document', async () => {
+    const workspace = await createTempWorkspace('guren-cli-docs-graph-empty-')
+    try {
+      await writeFixture(workspace.dir)
+
+      const report = await buildDocsGraphReport({ cwd: workspace.dir, path: 'config/nope.ts' })
+      const markdown = renderDocsGraphMarkdown(report)
+
+      expect(report.nodes).toHaveLength(0)
+      expect(markdown).toContain('Nothing in the docs graph references this target.')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('renders verdict markers on broken relations', async () => {
+    const workspace = await createTempWorkspace('guren-cli-docs-graph-verdict-')
+    try {
+      const dir = workspace.dir
+      await mkdir(join(dir, 'docs'), { recursive: true })
+      await writeFile(join(dir, 'package.json'), '{}', 'utf8')
+      await writeFile(
+        join(dir, 'docs/broken.md'),
+        '---\ntype: context\nrelated: [app/Services/Gone.ts]\n---\n# Broken\n',
+        'utf8',
+      )
+
+      const report = await buildDocsGraphReport({ cwd: dir })
+      const markdown = renderDocsGraphMarkdown(report)
+
+      expect(markdown).toContain('[FAIL]')
+    } finally {
+      await workspace.cleanup()
+    }
   })
 })

--- a/packages/cli/tests/docs-graph.test.ts
+++ b/packages/cli/tests/docs-graph.test.ts
@@ -159,6 +159,7 @@ related: [app/Http/Controllers/PostController.ts]
       const report = await buildDocsGraphReport({ cwd: workspace.dir })
 
       expect(report.focus).toEqual([])
+      expect(report.query).toBeUndefined()
       expect(report.nodes.some((n) => n.id === 'docs/adr/0002-other.md')).toBe(true)
     } finally {
       await workspace.cleanup()
@@ -176,6 +177,7 @@ related: [app/Http/Controllers/PostController.ts]
       })
 
       expect(report.focus).toEqual(['app/Http/Controllers/PostController.ts'])
+      expect(report.query).toEqual({ path: 'app/Http/Controllers/PostController.ts' })
       // The governing doc is pulled in; the unrelated doc is not.
       expect(report.nodes.some((n) => n.id === 'docs/adr/0001-posts.md')).toBe(true)
       expect(report.nodes.some((n) => n.id === 'docs/adr/0002-other.md')).toBe(false)
@@ -228,11 +230,68 @@ related: [app/Http/Controllers/PostController.ts]
     try {
       await writeFixture(workspace.dir)
 
-      const report = await buildDocsGraphReport({ cwd: workspace.dir, path: 'config/nope.ts' })
+      const report = await buildDocsGraphReport({ cwd: workspace.dir, path: 'config/nope.md' })
       const markdown = renderDocsGraphMarkdown(report)
 
       expect(report.nodes).toHaveLength(0)
-      expect(markdown).toContain('Nothing in the docs graph references this target.')
+      expect(report.focus).toEqual([])
+      expect(report.query).toEqual({ path: 'config/nope.md' })
+      expect(markdown).toContain('Nothing in the docs graph references "config/nope.md".')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reaches spec views from module paths via the drift-gate patterns', async () => {
+    const workspace = await createTempWorkspace('guren-cli-docs-graph-module-')
+    try {
+      const dir = workspace.dir
+      await mkdir(join(dir, 'docs/spec'), { recursive: true })
+      await writeFile(join(dir, 'package.json'), '{}', 'utf8')
+      await writeFile(join(dir, 'docs/spec/er.md'), '---\ntype: spec\n---\n# ER Diagram\n', 'utf8')
+
+      // The node label collapses module schemas to `db/schema.ts`; the
+      // SPEC_VIEWS pattern is what says this module file feeds the view.
+      const report = await buildDocsGraphReport({ cwd: dir, path: 'modules/billing/db/schema.ts' })
+
+      expect(report.focus).toContain('db/schema.ts')
+      expect(report.nodes.some((n) => n.id === 'docs/spec/er.md')).toBe(true)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('matches glob-form related entries and normalizes the query path', async () => {
+    const workspace = await createTempWorkspace('guren-cli-docs-graph-glob-')
+    try {
+      const dir = workspace.dir
+      await mkdir(join(dir, 'docs'), { recursive: true })
+      await mkdir(join(dir, 'modules/billing'), { recursive: true })
+      await writeFile(join(dir, 'package.json'), '{}', 'utf8')
+      await writeFile(join(dir, 'modules/billing/routes.ts'), 'export {}\n', 'utf8')
+      await writeFile(
+        join(dir, 'docs/billing.md'),
+        '---\ntype: context\nrelated: ["modules/billing/**"]\n---\n# Billing\n',
+        'utf8',
+      )
+
+      const report = await buildDocsGraphReport({ cwd: dir, path: './modules/billing/routes.ts' })
+
+      expect(report.focus).toContain('modules/billing/**')
+      expect(report.nodes.some((n) => n.id === 'docs/billing.md')).toBe(true)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('rejects narrowing by entity and path at once', async () => {
+    const workspace = await createTempWorkspace('guren-cli-docs-graph-both-')
+    try {
+      await writeFixture(workspace.dir)
+
+      await expect(
+        buildDocsGraphReport({ cwd: workspace.dir, entity: 'Post', path: 'app/Models/Post.ts' }),
+      ).rejects.toThrow('either entity or path')
     } finally {
       await workspace.cleanup()
     }

--- a/packages/server/src/mcp/create-mcp-server.ts
+++ b/packages/server/src/mcp/create-mcp-server.ts
@@ -96,6 +96,16 @@ export interface GurenCliApi {
    * runtime and may predate it — see `McpServiceProvider`.
    */
   createFreshContextApi?: () => Pick<GurenCliApi, 'generateContext' | 'generateEntityContext'>
+  /**
+   * The OKF docs relation graph (RFC 0005). Optional for the same
+   * runtime-resolution reason as above.
+   */
+  buildDocsGraphReport?(options: {
+    cwd?: string
+    entity?: string
+    path?: string
+  }): Promise<{ focus: string[]; nodes: unknown[]; edges: unknown[] }>
+  renderDocsGraphMarkdown?(report: unknown): string
 }
 
 export interface CreateMcpServerOptions {
@@ -157,6 +167,42 @@ export function createMcpServer(options: CreateMcpServerOptions): McpServer {
       }
     },
   )
+
+  if (cli.buildDocsGraphReport && cli.renderDocsGraphMarkdown) {
+    const { buildDocsGraphReport, renderDocsGraphMarkdown } = cli
+    server.tool(
+      'guren_docs_graph',
+      'The OKF docs relation graph: documents, entities, and code paths as nodes, verified relations (governs, body links, spec-view derivation) as edges. Narrow with entity or path to answer "which docs govern this, and which spec views regenerate from it?" BEFORE renaming or editing a file — guren_check only reports the breakage afterwards.',
+      {
+        entity: z
+          .string()
+          .optional()
+          .describe('Narrow to the neighborhood of one model entity (case-insensitive).'),
+        path: z
+          .string()
+          .optional()
+          .describe('Narrow to the neighborhood of one app-root-relative path (e.g. "app/Http/Controllers/PostController.ts").'),
+        format: z.enum(['json', 'markdown']).default('markdown').describe('Output format'),
+      },
+      async ({ entity, path, format }) => {
+        try {
+          const report = await buildDocsGraphReport({ cwd, entity, path })
+          const text =
+            format === 'markdown'
+              ? renderDocsGraphMarkdown(report)
+              : JSON.stringify(report, null, 2)
+          return { content: [{ type: 'text', text }] }
+        } catch (error) {
+          return {
+            content: [
+              { type: 'text' as const, text: error instanceof Error ? error.message : String(error) },
+            ],
+            isError: true,
+          }
+        }
+      },
+    )
+  }
 
   server.tool(
     'guren_check',

--- a/packages/server/src/mcp/create-mcp-server.ts
+++ b/packages/server/src/mcp/create-mcp-server.ts
@@ -100,11 +100,7 @@ export interface GurenCliApi {
    * The OKF docs relation graph (RFC 0005). Optional for the same
    * runtime-resolution reason as above.
    */
-  buildDocsGraphReport?(options: {
-    cwd?: string
-    entity?: string
-    path?: string
-  }): Promise<{ focus: string[]; nodes: unknown[]; edges: unknown[] }>
+  buildDocsGraphReport?(options: { cwd?: string; entity?: string; path?: string }): Promise<unknown>
   renderDocsGraphMarkdown?(report: unknown): string
 }
 
@@ -185,21 +181,12 @@ export function createMcpServer(options: CreateMcpServerOptions): McpServer {
         format: z.enum(['json', 'markdown']).default('markdown').describe('Output format'),
       },
       async ({ entity, path, format }) => {
-        try {
-          const report = await buildDocsGraphReport({ cwd, entity, path })
-          const text =
-            format === 'markdown'
-              ? renderDocsGraphMarkdown(report)
-              : JSON.stringify(report, null, 2)
-          return { content: [{ type: 'text', text }] }
-        } catch (error) {
-          return {
-            content: [
-              { type: 'text' as const, text: error instanceof Error ? error.message : String(error) },
-            ],
-            isError: true,
-          }
-        }
+        // Thrown errors (e.g. entity and path passed together) become
+        // isError results in the MCP SDK's tool dispatch — no local catch.
+        const report = await buildDocsGraphReport({ cwd, entity, path })
+        const text =
+          format === 'markdown' ? renderDocsGraphMarkdown(report) : JSON.stringify(report, null, 2)
+        return { content: [{ type: 'text', text }] }
       },
     )
   }

--- a/packages/server/tests/mcp/mcp-server.test.ts
+++ b/packages/server/tests/mcp/mcp-server.test.ts
@@ -147,6 +147,51 @@ describe('Guren MCP Server', () => {
     expect(tools).toHaveLength(9)
   })
 
+  test('guren_docs_graph registers only when the CLI provides it', async () => {
+    const bare = await createTestClient()
+    const bareNames = (await bare.listTools()).tools.map((tool) => tool.name)
+    expect(bareNames).not.toContain('guren_docs_graph')
+
+    const withGraph = await createTestClient({
+      buildDocsGraphReport: async () => ({ focus: [], nodes: [], edges: [] }),
+      renderDocsGraphMarkdown: () => '# Docs Graph',
+    })
+    const names = (await withGraph.listTools()).tools.map((tool) => tool.name)
+    expect(names).toContain('guren_docs_graph')
+  })
+
+  test('guren_docs_graph narrows by path and returns markdown by default', async () => {
+    const seen: Array<Record<string, unknown>> = []
+    const client = await createTestClient({
+      buildDocsGraphReport: async (options) => {
+        seen.push(options)
+        return {
+          focus: ['app/Http/Controllers/PostController.ts'],
+          nodes: [{ id: 'docs/adr/0001-posts.md', kind: 'doc', label: 'Posts are public' }],
+          edges: [
+            {
+              from: 'docs/adr/0001-posts.md',
+              to: 'app/Http/Controllers/PostController.ts',
+              relation: 'governs',
+              verdict: 'pass',
+            },
+          ],
+        }
+      },
+      renderDocsGraphMarkdown: (report) =>
+        `# Docs Graph\nNeighborhood of: ${(report as { focus: string[] }).focus.join(', ')}`,
+    })
+
+    const result = await client.callTool({
+      name: 'guren_docs_graph',
+      arguments: { path: 'app/Http/Controllers/PostController.ts' },
+    })
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text
+
+    expect(seen[0]).toMatchObject({ path: 'app/Http/Controllers/PostController.ts' })
+    expect(text).toContain('Neighborhood of: app/Http/Controllers/PostController.ts')
+  })
+
   test('guren_entity_context returns markdown by default', async () => {
     const client = await createTestClient()
     const result = await client.callTool({


### PR DESCRIPTION
## Summary

The OKF docs relation graph (RFC 0005) was reachable only through the browser viewer. This exposes the same graph to agents through the two surfaces they already use.

## What's new

**`guren docs:graph`** — the graph as markdown (`--json` for agents). `--entity <Model>` / `--path <file>` narrow to that node's neighborhood, which answers the impact question directly:

```
$ guren docs:graph --path app/Http/Controllers/PostController.ts

Neighborhood of: app/Http/Controllers/PostController.ts, app/Http/Controllers/, (all source files)

## Documents (3)
- docs/adr/0001-posts-are-public-by-default.md — Posts are public by default (adr)
- docs/spec/modules.md — Modules (spec)
- docs/spec/screens.md — Screens (spec)

## Relations (3)
- docs/adr/0001-posts-are-public-by-default.md —governs→ app/Http/Controllers/PostController.ts
- app/Http/Controllers/ —derives→ docs/spec/screens.md
- (all source files) —derives→ docs/spec/modules.md
```

Path narrowing resolves through every relation form the graph carries: literal ids, directory nodes, glob-form `related` entries (via the same matcher `check --docs` uses), and spec derivation sources via the `SPEC_VIEWS` patterns the drift gate matches changed files against — so `modules/billing/db/schema.ts` reaches the ER view even though the graph collapses its label to `db/schema.ts`. Query paths are POSIX-normalized. Broken relations carry their `check --docs` verdict markers.

JSON reports echo the narrowing request as a `query` field (`focus` stays node ids); `entity` and `path` together is an error rather than a silent union.

**MCP tool `guren_docs_graph`** — same report, same arguments, registered only when the runtime-resolved `@guren/cli` provides it (the established optional-member pattern, so older CLIs degrade to no tool rather than a broken one).

**Agent harness** — the `docs-and-spec` rule, the template's Start-Here command block, and the MCP tool table now teach the ask-before-you-break move: query the neighborhood *before* renaming or moving a file a doc might reference; `guren check` only reports the breakage after. CLI guides (en/ja) gain the command row.

## Design

Both surfaces and the docs viewer now share one `loadDocsGraph()` pass (scan once, feed the same refs to the checker, join) — humans and agents read the same verified graph, the narrowing logic exists once, and the docs bundle is no longer scanned twice per request. Payloads exclude rendered HTML (nodes/edges/verdicts only), keeping the JSON a few KB at realistic bundle sizes.

## Verification

- 9 CLI tests (whole graph, path/entity neighborhoods, directory-source and module-pattern matching, glob `related` + path normalization, empty-neighborhood rendering, entity+path rejection, verdict markers) and 2 MCP tests (conditional registration, narrowed call)
- Full suite green: 3243 tests, `test:examples` (91), `typecheck`, `audit:docs`, `audit:core-first`, `audit:starter-template`
- Exercised live on `examples/blog` (output above)