### PR TITLE
docs: record that guren docs:graph shipped (RFC 0005)

### DIFF
--- a/rfcs/0005-docs-viewer.md
+++ b/rfcs/0005-docs-viewer.md
@@ -176,8 +176,14 @@ without its label), so the pairing is enforced by the type instead of by
 adjacency — which is the property this sentence wanted: the graph and
 the drift gate share one
 list and cannot drift apart. Living in `@guren/cli`, the builder is also
-trivially exposable as `guren docs:graph --json` for agents and CI later,
-though that command is not part of this RFC.
+trivially exposable as ~~`guren docs:graph --json` for agents and CI
+later, though that command is not part of this RFC~~ **Amended in
+implementation:** shipped separately as `guren docs:graph` plus a
+`guren_docs_graph` MCP tool (#238), narrowed to one node's neighborhood
+via `--entity`/`--path` — path narrowing resolves through the same
+`SPEC_VIEWS` patterns and reuses the `matchesGlob()` helper `check
+--docs` validates `related` globs with, so the CLI/MCP surface and the
+viewer's graph cannot disagree about what a path reaches.
 
 ### Markdown rendering
 


### PR DESCRIPTION
## Summary

RFC 0005 speculated the graph builder would be "trivially exposable... later" as a CLI command, explicitly out of the RFC's scope. #238 shipped that command (`guren docs:graph` + the `guren_docs_graph` MCP tool). Amending the RFC in place per the project's deviation-recording convention, rather than leaving a fulfilled prediction dangling with no link to the PR that fulfilled it.

## Test plan

Docs-only change; no code touched.