### PR TITLE
fix(cli): stop guren add auth logout from tripping CSRF

### DIFF
--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -863,6 +863,8 @@ import type { PropsWithChildren } from 'react'
 export default function Layout({ children }: PropsWithChildren) {
   const { props } = usePage<{ auth?: { user?: { name?: string } } }>()
   const user = props.auth?.user
+  const navButtonClass =
+    'rounded border border-emerald-500 px-3 py-1 text-emerald-200 transition hover:bg-emerald-500 hover:text-slate-950'
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
@@ -879,19 +881,14 @@ export default function Layout({ children }: PropsWithChildren) {
               Dashboard
             </Link>
             {user ? (
-              <form method="post" action="/logout">
-                <button
-                  type="submit"
-                  className="rounded border border-emerald-500 px-3 py-1 text-emerald-200 transition hover:bg-emerald-500 hover:text-slate-950"
-                >
-                  Log out
-                </button>
-              </form>
+              // Inertia's HTTP client copies the XSRF-TOKEN cookie into the
+              // request header. A native <form> does not, so CSRF protection
+              // would answer 403 and leave the session signed in.
+              <Link href="/logout" method="post" as="button" className={navButtonClass}>
+                Log out
+              </Link>
             ) : (
-              <Link
-                href="/login"
-                className="rounded border border-emerald-500 px-3 py-1 text-emerald-200 transition hover:bg-emerald-500 hover:text-slate-950"
-              >
+              <Link href="/login" className={navButtonClass}>
                 Sign in
               </Link>
             )}

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -206,6 +206,24 @@ export function registerWebRoutes(router: Router): void {
     }
   })
 
+  it('logs out through Inertia so the CSRF token reaches the request', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-auth-logout-')
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(join(workspace.dir, 'db/schema.ts'), `export const posts = 'posts'\n`, 'utf8')
+
+      await makeAuth({ force: true })
+
+      const layout = await readFile(join(workspace.dir, 'resources/js/components/Layout.tsx'), 'utf8')
+      expect(layout).not.toContain('action="/logout"')
+      expect(layout).toContain('href="/logout"')
+      expect(layout).toContain('method="post"')
+      expect(layout).toContain('as="button"')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('scaffolds email verification with --verify', async () => {
     const workspace = await createTempWorkspace('guren-cli-make-auth-verify-')
     try {

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -328,6 +328,12 @@ async function assertCanonicalScaffolds(appDir: string): Promise<void> {
 
   const postsIndexPage = await readFile(join(appDir, 'resources/js/pages/posts/Index.tsx'), 'utf8')
   assert(postsIndexPage.includes('interface Props') || postsIndexPage.includes('PaginatedPageProps'), 'Posts index page must define Props.')
+
+  const layout = await readFile(join(appDir, 'resources/js/components/Layout.tsx'), 'utf8')
+  assert(!layout.includes('action="/logout"'), 'Auth layout must not log out through a native form POST — CSRF rejects it.')
+  assert(layout.includes('href="/logout"'), 'Auth layout must log out through an Inertia Link.')
+  assert(layout.includes('method="post"'), 'Auth layout logout Link must POST — the default GET does not match the route.')
+  assert(layout.includes('as="button"'), 'Auth layout logout Link must render as a button.')
 }
 
 async function assertFeatureScaffolds(appDir: string): Promise<void> {


### PR DESCRIPTION
## Summary

- \`guren add auth\` scaffolds a Layout.tsx that logs out through a native `<form method="post" action="/logout">`. A native form POST carries the XSRF-TOKEN cookie but never copies it into the X-XSRF-TOKEN header (and emits no `_token` field), so the default CSRF middleware answers 403 and the session stays signed in. Not reproducible via curl-with-headers or TestApp — only a browser's native form submission hits this path.
- Replace it with an Inertia `<Link href="/logout" method="post" as="button">`, matching the pattern already used in `examples/blog/resources/js/components/Layout.tsx`. Inertia's HTTP client copies the cookie into the header.
- The swap left both nav buttons using the same 90-character Tailwind class string byte-for-byte; hoisted it into a `navButtonClass` constant in the generated Layout so a future style tweak doesn't need two edits.
- Added a regression test in `packages/cli/tests/make-auth.test.ts` that scaffolds a real app and asserts the generated Layout can't regress to the native form.
- Strengthened `assertCanonicalScaffolds()` in `scripts/smoke/fresh-app.ts` with the same checks, split into separate asserts (the original combined `&&` assert would have missed a regression to a `method`-less `Link`, which silently degrades to GET and no longer matches the POST-only `/logout` route).

## Review

Ran a Codex review pass plus a 4-agent `/simplify` sweep (reuse / simplification / efficiency / altitude) against the diff. Applied:
- smoke assert missing `method="post"` (found independently by both)
- inaccurate "Axios" wording in comments — verified `@inertiajs/core@3.6.1` has no axios dependency and uses its own XHR client
- duplicated Tailwind class string (see above)
- two comments that only restated their neighboring assert/test name

Declined a recommendation to move this into an `audit`/`check` lint rule — `resources/js` isn't in any scanner's path today, and the bug class has exactly one known instance.

Two related pre-existing issues were found and spun off separately (not in this diff): `docs/en/guides/csrf.md` documents the wrong CSRF field name (`_csrf` instead of `_token`) and a nonexistent `fieldName` option, and the codegen'd API client (`packages/cli/src/api-client-types.ts`) sends no CSRF token at all on mutating requests.

## Test plan

- [x] `bun test packages/cli/tests/make-auth.test.ts` — 26 pass, including mutation checks (reverting to the native form, or dropping `method="post"` alone, both fail the new test)
- [x] `bun run test:bun cli` — 946 pass
- [x] `bun run typecheck`
- [x] `bun run smoke:starter` — scaffolds a real app, typechecks, builds