### PR TITLE
fix(create-app): keep --db mysql scaffolds on the MySQL dialect

### DIFF
--- a/.changeset/mysql-scaffold-dialect.md
+++ b/.changeset/mysql-scaffold-dialect.md
@@ -1,0 +1,24 @@
+---
+"create-guren-app": patch
+"@guren/cli": patch
+---
+
+Keep `--db mysql` scaffolds on the MySQL dialect end to end
+
+`create-guren-app --db mysql` generated a `db/schema.ts` that imported
+`mysqlTable, int, varchar, timestamp` from `@guren/orm/drizzle`. That subpath
+re-exports the PostgreSQL column builders under the unqualified names, so the
+MySQL `users` table was built out of a pg `timestamp`. Nothing reported it:
+drizzle-kit still emitted the same MySQL DDL and the app still typechecked.
+
+It did leak further, though. `guren add auth` and `add resource` merge new
+columns into the schema's `drizzle-orm/mysql-core` import and skip any name
+already visible in some import line — so with a pg `timestamp` in scope, every
+later date column silently stayed on the wrong dialect too. The scaffold now
+imports from `drizzle-orm/mysql-core`, matching what the patchers emit and what
+the SQLite scaffold already did.
+
+The demo-user seeder `guren add auth` writes is now dialect-aware. It used
+`.onConflictDoNothing()` unconditionally, which does not exist on MySQL's query
+builder — `db:seed` threw `onConflictDoNothing is not a function` on every MySQL
+app. MySQL now gets the equivalent `.onDuplicateKeyUpdate()` form.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,10 @@ jobs:
       - name: Golden path smoke test (postgres)
         run: bun run smoke:golden-path:postgres
 
+      # The only place a --db mysql scaffold is typechecked and migrated.
+      - name: Golden path smoke test (mysql)
+        run: bun run smoke:golden-path:mysql
+
       - name: Run tests
         run: bun run test
 

--- a/contributing/release-checklist.md
+++ b/contributing/release-checklist.md
@@ -8,8 +8,13 @@
 - [ ] `bun run test` succeeds (all packages + examples)
 - [ ] All audit scripts pass (`audit:core-first`, `audit:contracts`, `audit:feature-runtime`, `audit:starter-template`, `audit:docs`, `audit:bundle-budgets`)
 - [ ] Smoke tests pass (`smoke:starter`, `smoke:starter:packed`, `smoke:upgrade-existing-app`, `smoke:golden-path`)
+- [ ] Per-driver golden paths pass (`smoke:golden-path:postgres`, `smoke:golden-path:mysql`)
 - [ ] E2E tests pass
 - [ ] Nightly canary has been green for 3+ days
+
+The release workflow has no MySQL service, so `smoke:golden-path:mysql` runs
+only on the PR's CI and here. Start the databases first: `bun run db:up` and
+`bun run db:up:mysql`.
 
 ## Version Bump
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "smoke:upgrade-existing-app": "bun run ./scripts/smoke/upgrade-existing-app.ts",
     "smoke:golden-path": "bash ./scripts/smoke-golden-path.sh",
     "smoke:golden-path:postgres": "GUREN_SMOKE_DB=postgres bash ./scripts/smoke-golden-path.sh",
+    "smoke:golden-path:mysql": "GUREN_SMOKE_DB=mysql bash ./scripts/smoke-golden-path.sh",
     "changeset": "changeset",
     "version-packages": "changeset version && bun install",
     "release": "bun run build && changeset publish",

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -10,7 +10,7 @@ import { makeModel } from './make-model'
 import { makeNotification } from './make-notification'
 import { makeRoute } from './make-route'
 import { makeView } from './make-view'
-import { addImport, addProvider, ensureDrizzleImports, ensureMysqlImports, ensureSqliteImports, findClosingDelimiter } from './patch-helpers'
+import { addImport, addProvider, detectSchemaDialect, ensureDrizzleImports, ensureMysqlImports, ensureSqliteImports, findClosingDelimiter } from './patch-helpers'
 import { camelCase, kebabCase, pascalCase, writeFilesSafe, type WriterOptions } from './utils'
 import { readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
@@ -689,16 +689,6 @@ export default scheduleTasksKernel
   },
 }
 
-async function detectSchemaDialect(content: string): Promise<'sqlite' | 'pg' | 'mysql'> {
-  if (content.includes('sqliteTable') || content.includes('drizzle-orm/sqlite-core')) {
-    return 'sqlite'
-  }
-  if (content.includes('mysqlTable') || content.includes('drizzle-orm/mysql-core')) {
-    return 'mysql'
-  }
-  return 'pg'
-}
-
 function sqliteColumn(field: FieldDefinition): { code: string; imports: string[] } {
   const notNull = field.nullable ? '' : '.notNull()'
   switch (field.type) {
@@ -755,7 +745,7 @@ async function updateResourceSchema(collection: string, routeName: string, field
   const schemaIdentifier = camelCase(collection)
   const tableName = routeName.replaceAll('-', '_')
 
-  const dialect = await detectSchemaDialect(content)
+  const dialect = detectSchemaDialect(content)
 
   if (dialect === 'sqlite') {
     if (content.includes(`export const ${schemaIdentifier} = sqliteTable(`)) {

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -6,10 +6,14 @@ import {
   addImport,
   addProvider,
   addCreateAppOption,
+  detectSchemaDialect,
   ensureDrizzleImports,
   ensureMysqlImports,
   ensureSqliteImports,
+  readSchemaDialect,
+  type SchemaDialect,
 } from './patch-helpers'
+import { readIfExists } from './discovery'
 import { makeMigration } from './make-migration'
 
 // Passwordless apps keep show() (the OAuth button page) and destroy()
@@ -1714,7 +1718,19 @@ ${registerRoutes}${resetRoutes}${verifyRoutes}${oauthRoutes}
 `
 }
 
-const seederTemplate = `import { defineSeeder, ScryptHasher } from '@guren/core'
+/**
+ * Re-running the seeder must not fail on the unique email. MySQL has no
+ * ON CONFLICT clause — drizzle exposes INSERT ... ON DUPLICATE KEY UPDATE
+ * instead, and calling `.onConflictDoNothing()` on a MySQL query builder
+ * throws at runtime ("is not a function").
+ */
+function buildSeederTemplate(dialect: SchemaDialect): string {
+  const idempotentInsert =
+    dialect === 'mysql'
+      ? `.onDuplicateKeyUpdate({ set: { name: 'Demo User' } })`
+      : `.onConflictDoNothing({ target: users.email })`
+
+  return `import { defineSeeder, ScryptHasher } from '@guren/core'
 import { users } from '../schema.js'
 
 export default defineSeeder(async ({ db }) => {
@@ -1730,20 +1746,9 @@ export default defineSeeder(async ({ db }) => {
         passwordHash,
       },
     ])
-    .onConflictDoNothing({ target: users.email })
+    ${idempotentInsert}
 })
 `
-
-type SchemaDialect = 'sqlite' | 'pg' | 'mysql'
-
-function detectSchemaDialect(content: string): SchemaDialect {
-  if (content.includes('sqliteTable') || content.includes('drizzle-orm/sqlite-core')) {
-    return 'sqlite'
-  }
-  if (content.includes('mysqlTable') || content.includes('drizzle-orm/mysql-core')) {
-    return 'mysql'
-  }
-  return 'pg'
 }
 
 const usersTableBlocks: Record<SchemaDialect, string> = {
@@ -1854,18 +1859,13 @@ function relaxPasswordHashForOAuth(content: string): string {
 
 async function updateSchema({ includeVerify, includePassword, oauthProviders }: AuthFeatures): Promise<void> {
   const schemaPath = resolve(process.cwd(), 'db/schema.ts')
-  let content: string
+  const existing = await readIfExists(process.cwd(), 'db/schema.ts')
 
-  try {
-    content = await readFile(schemaPath, 'utf8')
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return
-    }
-
-    throw error
+  if (existing === null) {
+    return
   }
 
+  let content = existing
   const originalContent = content
   const hasAuthColumns = content.includes('passwordHash')
   const dialect = detectSchemaDialect(content)
@@ -2172,7 +2172,7 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
       // The demo user only exists to be signed in as with a password. Without
       // password login it is an unreachable row — and seeding it would hash a
       // password with scrypt, the exact cost --oauth-only avoids.
-      { path: 'db/seeders/UsersSeeder.ts', contents: seederTemplate },
+      { path: 'db/seeders/UsersSeeder.ts', contents: buildSeederTemplate(await readSchemaDialect()) },
     )
   }
 

--- a/packages/cli/src/patch-helpers.test.ts
+++ b/packages/cli/src/patch-helpers.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { addImport, addProvider, hasImport, hasAuthProvider, ensureDrizzleImports, ensureSqliteImports } from './patch-helpers'
+import { addImport, addProvider, hasImport, hasAuthProvider, ensureDrizzleImports, ensureMysqlImports, ensureSqliteImports } from './patch-helpers'
 
 describe('patch-helpers', () => {
   let tempDir: string
@@ -300,6 +300,55 @@ const app = new Application()`
       const result = ensureSqliteImports(content, [])
 
       expect(result).toBe(content)
+    })
+  })
+
+  describe('ensureMysqlImports', () => {
+    // The header `create-guren-app --db mysql` scaffolds.
+    const scaffoldedSchema = `import { mysqlTable, int, varchar, timestamp } from 'drizzle-orm/mysql-core'\n\nexport const users = mysqlTable('users', {})\n`
+
+    it('should add missing imports when no MySQL import exists', () => {
+      const content = `const x = 1\n`
+      const result = ensureMysqlImports(content, ['mysqlTable', 'int', 'varchar'])
+
+      expect(result).toContain("import { int, mysqlTable, varchar } from 'drizzle-orm/mysql-core'")
+      expect(result).toContain('const x = 1')
+    })
+
+    it('should merge new column builders into the scaffolded MySQL import', () => {
+      const result = ensureMysqlImports(scaffoldedSchema, ['mysqlTable', 'int', 'timestamp', 'boolean'])
+
+      expect(result).toContain(
+        "import { boolean, int, mysqlTable, timestamp, varchar } from 'drizzle-orm/mysql-core'",
+      )
+      // One import line, not a second one appended alongside it.
+      expect(result.match(/^import /gmu)).toHaveLength(1)
+    })
+
+    it('should not modify content when all imports already present', () => {
+      const result = ensureMysqlImports(scaffoldedSchema, ['mysqlTable', 'int', 'varchar', 'timestamp'])
+
+      expect(result).toBe(scaffoldedSchema)
+    })
+
+    it('should return content unchanged when needed list is empty', () => {
+      const content = `const x = 1\n`
+      const result = ensureMysqlImports(content, [])
+
+      expect(result).toBe(content)
+    })
+
+    // Documents why the mysql scaffold must not import from
+    // `@guren/orm/drizzle`: the merge is not module-scoped, so a same-named
+    // builder already in scope from another dialect satisfies the requirement
+    // and the MySQL one is never imported. Scoping the match per module would
+    // be an improvement — update this test rather than treating it as a
+    // regression.
+    it('should not re-import a name another module already brought into scope', () => {
+      const mixed = `import { mysqlTable, int, varchar, timestamp } from '@guren/orm/drizzle'\n\nexport const users = mysqlTable('users', {})\n`
+      const result = ensureMysqlImports(mixed, ['mysqlTable', 'int', 'varchar', 'timestamp'])
+
+      expect(result).toBe(mixed)
     })
   })
 })

--- a/packages/cli/src/patch-helpers.ts
+++ b/packages/cli/src/patch-helpers.ts
@@ -405,6 +405,32 @@ export async function hasAuthProvider(filePath: string): Promise<boolean> {
   }
 }
 
+export type SchemaDialect = 'sqlite' | 'pg' | 'mysql'
+
+/**
+ * The drizzle dialect an app's `db/schema.ts` is written in. Every patcher
+ * that appends columns or tables has to agree on this — `add auth` and
+ * `add resource` writing different dialects into one schema is silent, since
+ * drizzle's table builders accept a foreign dialect's column builders.
+ */
+export function detectSchemaDialect(content: string): SchemaDialect {
+  if (content.includes('sqliteTable') || content.includes('drizzle-orm/sqlite-core')) {
+    return 'sqlite'
+  }
+  if (content.includes('mysqlTable') || content.includes('drizzle-orm/mysql-core')) {
+    return 'mysql'
+  }
+  return 'pg'
+}
+
+/**
+ * The dialect of the app's `db/schema.ts`. An app that has none yet reads as
+ * PostgreSQL, the same default an empty schema yields.
+ */
+export async function readSchemaDialect(cwd: string = process.cwd()): Promise<SchemaDialect> {
+  return detectSchemaDialect((await readIfExists(cwd, 'db/schema.ts')) ?? '')
+}
+
 /**
  * Ensures that a set of named Drizzle imports are present in file content.
  * Merges into an existing `@guren/orm/drizzle` import or prepends a new one.

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -1,7 +1,23 @@
 import { beforeEach, afterEach, describe, expect, it } from 'bun:test'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { createTempWorkspace, type TempWorkspace } from './helpers'
+import { createTempWorkspace, MYSQL_SCHEMA_FIXTURE, PG_SCHEMA_FIXTURE, type TempWorkspace } from './helpers'
 import { listBlueprints, runBlueprint } from '../src/blueprints'
+
+/** The directories and route file the resource blueprint expects to patch. */
+async function seedResourceWorkspace(schema: string): Promise<void> {
+  await mkdir('resources/js/pages', { recursive: true })
+  await mkdir('routes', { recursive: true })
+  await mkdir('db', { recursive: true })
+  await writeFile('routes/web.ts', `import { Router } from '@guren/core'
+
+export function registerWebRoutes(router: Router): void {
+  router.get('/', () => 'home')
+}
+
+export default registerWebRoutes
+`)
+  await writeFile('db/schema.ts', schema)
+}
 
 describe('blueprints', () => {
   let workspace: TempWorkspace
@@ -32,26 +48,7 @@ describe('blueprints', () => {
   })
 
   it('runs the resource blueprint', async () => {
-    await mkdir('resources/js/pages', { recursive: true })
-    await mkdir('routes', { recursive: true })
-    await mkdir('db', { recursive: true })
-    await writeFile('routes/web.ts', `import { Router } from '@guren/core'
-
-export function registerWebRoutes(router: Router): void {
-  router.get('/', () => 'home')
-}
-
-export default registerWebRoutes
-`)
-    await writeFile('db/schema.ts', `import { pgTable, serial, text, timestamp } from '@guren/orm/drizzle'
-
-export const users = pgTable('users', {
-  id: serial('id').primaryKey(),
-  name: text('name').notNull(),
-  email: text('email').notNull(),
-  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),
-})
-`)
+    await seedResourceWorkspace(PG_SCHEMA_FIXTURE)
 
     const files = await runBlueprint('resource', { name: 'Post' })
 
@@ -78,6 +75,29 @@ export const users = pgTable('users', {
 
     const schema = await readFile('db/schema.ts', 'utf8')
     expect(schema).toContain("export const posts = pgTable('posts'")
+  })
+
+  it('adds resource tables to a mysql schema without borrowing another dialect', async () => {
+    await seedResourceWorkspace(MYSQL_SCHEMA_FIXTURE)
+
+    await runBlueprint('resource', {
+      name: 'Post',
+      fields: 'title:string,views:number,published:boolean,publishedAt:date,meta:json',
+    })
+
+    const schema = await readFile('db/schema.ts', 'utf8')
+
+    expect(schema).toContain("export const posts = mysqlTable('posts'")
+    expect(schema).toContain("publishedAt: timestamp('published_at').notNull()")
+    expect(schema).toContain("meta: json('meta').notNull()")
+    expect(schema).toContain("published: boolean('published').notNull()")
+    // Every builder — the scaffolded ones and the ones this run added — must
+    // come from mysql-core. `@guren/orm/drizzle` re-exports the pg builders
+    // under the same names, and mixing them is silent at build time.
+    const importedModules = [...schema.matchAll(/import\s*\{[^}]*\}\s*from\s*['"]([^'"]+)['"]/g)].map(
+      (match) => match[1],
+    )
+    expect([...new Set(importedModules)]).toEqual(['drizzle-orm/mysql-core'])
   })
 
   it('rejects unknown blueprints', async () => {

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -62,6 +62,33 @@ export async function linkInstalledPackage(
   }
 }
 
+/**
+ * The `db/schema.ts` a fresh app starts from, per dialect. Kept in the shape
+ * `create-guren-app` scaffolds so the patchers are exercised against what
+ * users actually have on disk — notably, MySQL apps import their builders
+ * from `drizzle-orm/mysql-core`, never from the PostgreSQL-first
+ * `@guren/orm/drizzle` subpath.
+ */
+export const PG_SCHEMA_FIXTURE = `import { pgTable, serial, text, timestamp } from '@guren/orm/drizzle'
+
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  name: text('name').notNull(),
+  email: text('email').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),
+})
+`
+
+export const MYSQL_SCHEMA_FIXTURE = `import { mysqlTable, int, varchar, timestamp } from 'drizzle-orm/mysql-core'
+
+export const users = mysqlTable('users', {
+  id: int('id').primaryKey().autoincrement(),
+  name: varchar('name', { length: 255 }).notNull(),
+  email: varchar('email', { length: 255 }).notNull(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+})
+`
+
 export async function createTempWorkspace(prefix: string): Promise<TempWorkspace> {
   const dir = await mkdtemp(join(tmpdir(), prefix))
   const originalCwd = process.cwd()

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { consola } from 'consola'
-import { createTempWorkspace } from './helpers'
+import { createTempWorkspace, MYSQL_SCHEMA_FIXTURE, PG_SCHEMA_FIXTURE } from './helpers'
 import { makeAuth } from '../src/make-auth'
 
 describe('makeAuth', () => {
@@ -481,6 +481,41 @@ export const users = mysqlTable('users', {
       await workspace.cleanup()
     }
   })
+
+  // MySQL has no ON CONFLICT: onConflictDoNothing() is undefined on its query
+  // builder and throws when the seeder runs.
+  const seederUpserts = [
+    {
+      dialect: 'mysql',
+      schema: MYSQL_SCHEMA_FIXTURE,
+      expected: ".onDuplicateKeyUpdate({ set: { name: 'Demo User' } })",
+      forbidden: 'onConflictDoNothing',
+    },
+    {
+      dialect: 'pg',
+      schema: PG_SCHEMA_FIXTURE,
+      expected: '.onConflictDoNothing({ target: users.email })',
+      forbidden: 'onDuplicateKeyUpdate',
+    },
+  ]
+
+  for (const { dialect, schema, expected, forbidden } of seederUpserts) {
+    it(`seeds the demo user with the ${dialect} upsert`, async () => {
+      const workspace = await createTempWorkspace(`guren-cli-make-auth-seeder-${dialect}-`)
+      try {
+        await mkdir(join(workspace.dir, 'db'), { recursive: true })
+        await writeFile(join(workspace.dir, 'db/schema.ts'), schema, 'utf8')
+
+        await makeAuth({ force: true })
+
+        const seeder = await readFile(join(workspace.dir, 'db/seeders/UsersSeeder.ts'), 'utf8')
+        expect(seeder).toContain(expected)
+        expect(seeder).not.toContain(forbidden)
+      } finally {
+        await workspace.cleanup()
+      }
+    })
+  }
 
   it('leaves a passwordHash column on another table untouched', async () => {
     const workspace = await createTempWorkspace('guren-cli-make-auth-oauth-scope-')

--- a/packages/create-app/src/blueprints.ts
+++ b/packages/create-app/src/blueprints.ts
@@ -230,7 +230,12 @@ export const users = pgTable('users', {
   }
 
   if (driver === 'mysql') {
-    return `import { mysqlTable, int, varchar, timestamp } from '@guren/orm/drizzle'
+    // MySQL uses drizzle-orm directly — @guren/orm/drizzle re-exports the
+    // PostgreSQL builders under the plain names (`timestamp`, `text`), so a
+    // MySQL table imported from there is built out of pg column builders.
+    // This is also the module `guren add auth` / `add resource` merge their
+    // new columns into.
+    return `import { mysqlTable, int, varchar, timestamp } from 'drizzle-orm/mysql-core'
 
 export const users = mysqlTable('users', {
   id: int('id').primaryKey().autoincrement(),

--- a/packages/create-app/tests/schema-dialect.test.ts
+++ b/packages/create-app/tests/schema-dialect.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { DATABASE_DRIVERS, scaffoldAppBlueprint, type DatabaseDriver } from '../src/blueprints'
+import { createTempWorkspace } from './helpers'
+
+/**
+ * Every column builder in a generated db/schema.ts must come from the module
+ * that owns the app's dialect. Drizzle's builders share names across dialects
+ * (`timestamp`, `text`, `boolean`), and mixing them is silent: drizzle-kit
+ * still emits DDL and tsc still passes, so nothing downstream reports that a
+ * MySQL table was built out of PostgreSQL columns.
+ *
+ * `@guren/orm/drizzle` re-exports the pg-core builders under those plain
+ * names, which is why only the PostgreSQL scaffold may import from it.
+ */
+const EXPECTED_SCHEMA_MODULE = {
+  postgres: '@guren/orm/drizzle',
+  mysql: 'drizzle-orm/mysql-core',
+  sqlite: 'drizzle-orm/sqlite-core',
+} as const satisfies Record<DatabaseDriver, string>
+
+function importedModules(source: string): string[] {
+  return [...source.matchAll(/import\s*(?:\{[^}]*\}|[\w*\s,]+)\s*from\s*['"]([^'"]+)['"]/g)].map(
+    (match) => match[1],
+  )
+}
+
+describe('generated db/schema.ts dialect', () => {
+  for (const driver of DATABASE_DRIVERS) {
+    it(`imports every builder from ${EXPECTED_SCHEMA_MODULE[driver]} for --db ${driver}`, async () => {
+      const workspace = await createTempWorkspace(`guren-schema-dialect-${driver}-`)
+
+      try {
+        const dest = join(workspace.dir, 'test-app')
+        await scaffoldAppBlueprint({ destination: dest, renderingMode: 'spa', database: driver })
+
+        const schema = await readFile(join(dest, 'db/schema.ts'), 'utf8')
+        const modules = importedModules(schema)
+
+        expect(modules.length).toBeGreaterThan(0)
+        expect([...new Set(modules)]).toEqual([EXPECTED_SCHEMA_MODULE[driver]])
+      } finally {
+        await workspace.cleanup()
+      }
+    })
+  }
+})

--- a/packages/orm/src/drizzle.ts
+++ b/packages/orm/src/drizzle.ts
@@ -1,3 +1,8 @@
+// PostgreSQL-first convenience re-exports: the unqualified column builders
+// below (`text`, `timestamp`, `boolean`, …) are the pg-core ones. MySQL and
+// SQLite schemas must import their builders from `drizzle-orm/mysql-core` /
+// `drizzle-orm/sqlite-core` — mixing dialects here is silent, because the
+// names collide and drizzle-kit still emits DDL for the wrong builder.
 export { sql } from 'drizzle-orm'
 export type { SQL } from 'drizzle-orm'
 

--- a/rfcs/0005-docs-viewer.md
+++ b/rfcs/0005-docs-viewer.md
@@ -176,8 +176,14 @@ without its label), so the pairing is enforced by the type instead of by
 adjacency — which is the property this sentence wanted: the graph and
 the drift gate share one
 list and cannot drift apart. Living in `@guren/cli`, the builder is also
-trivially exposable as `guren docs:graph --json` for agents and CI later,
-though that command is not part of this RFC.
+trivially exposable as ~~`guren docs:graph --json` for agents and CI
+later, though that command is not part of this RFC~~ **Amended in
+implementation:** shipped separately as `guren docs:graph` plus a
+`guren_docs_graph` MCP tool (#238), narrowed to one node's neighborhood
+via `--entity`/`--path` — path narrowing resolves through the same
+`SPEC_VIEWS` patterns and reuses the `matchesGlob()` helper `check
+--docs` validates `related` globs with, so the CLI/MCP surface and the
+viewer's graph cannot disagree about what a path reaches.
 
 ### Markdown rendering
 

--- a/scripts/smoke-golden-path.sh
+++ b/scripts/smoke-golden-path.sh
@@ -28,15 +28,21 @@ step() {
 CLI_BIN="$REPO_ROOT/packages/cli/src/bin.ts"
 CREATE_APP_BIN="$REPO_ROOT/packages/create-app/src/cli.ts"
 
-# Database driver for the scaffolded app. "postgres" expects a reachable
-# server (default: the repo docker-compose instance on port 54322 — run
-# `bun run db:up` locally; CI maps its service container to the same port).
+# Database driver for the scaffolded app. "postgres" and "mysql" expect a
+# reachable server (default: the repo compose instances on ports 54322 and
+# 33306 — run `bun run db:up` / `bun run db:up:mysql` locally; CI maps its
+# service containers to the same ports).
 SMOKE_DB="${GUREN_SMOKE_DB:-sqlite}"
 
 if [ "$SMOKE_DB" = "postgres" ]; then
   # Use a dedicated database so db:reset never touches a developer's data
   # on the shared compose instance. CI maps its service to the same port.
   export DATABASE_URL="${GUREN_SMOKE_DATABASE_URL:-postgres://guren:guren@localhost:54322/guren_smoke}"
+elif [ "$SMOKE_DB" = "mysql" ]; then
+  # Same reasoning as postgres. The unprivileged `guren` user only owns the
+  # `guren` database in both compose and CI, so creating the dedicated one
+  # needs root.
+  export DATABASE_URL="${GUREN_SMOKE_DATABASE_URL:-mysql://root:guren@localhost:33306/guren_smoke}"
 fi
 
 PACKAGES="cli core inertia-client orm server"
@@ -271,9 +277,14 @@ cleanup() {
 
 (cd "$APP_DIR" && bun run db:make)
 
-if [ "$SMOKE_DB" = "postgres" ]; then
-  # Create the smoke database if missing (CREATE DATABASE has no IF NOT EXISTS).
-  cat > "$TEMP_DIR/ensure-db.ts" <<'ENSUREDB'
+if [ "$SMOKE_DB" = "sqlite" ]; then
+  (cd "$APP_DIR" && bun run db:migrate)
+else
+  # Server-backed drivers get a dedicated database, created here if missing.
+  case "$SMOKE_DB" in
+    postgres)
+      # CREATE DATABASE has no IF NOT EXISTS on pg.
+      cat > "$TEMP_DIR/ensure-db.ts" <<'ENSUREDB'
 import postgres from 'postgres'
 
 const target = new URL(process.env.DATABASE_URL ?? '')
@@ -291,16 +302,35 @@ if (exists.length === 0) {
 }
 await sql.end()
 ENSUREDB
+      ;;
+    mysql)
+      cat > "$TEMP_DIR/ensure-db.ts" <<'ENSUREDB'
+import { createConnection } from 'mysql2/promise'
+
+const target = new URL(process.env.DATABASE_URL ?? '')
+const dbName = decodeURIComponent(target.pathname.slice(1))
+const admin = new URL(target.toString())
+admin.pathname = '/'
+
+const connection = await createConnection(admin.toString())
+await connection.query(`CREATE DATABASE IF NOT EXISTS \`${dbName.replaceAll('`', '``')}\``)
+await connection.end()
+console.log(`Database ${dbName} ready`)
+ENSUREDB
+      ;;
+    *)
+      echo "ERROR: unknown GUREN_SMOKE_DB '$SMOKE_DB' (expected sqlite, postgres, or mysql)"
+      exit 1
+      ;;
+  esac
   (cd "$APP_DIR" && bun "$TEMP_DIR/ensure-db.ts")
 
-  # Drop leftovers from previous runs and exercise resetDatabase() on pg.
+  # Drop leftovers from previous runs and exercise resetDatabase().
   (cd "$APP_DIR" && bun "$CLI_BIN" db:reset --force)
-else
-  (cd "$APP_DIR" && bun run db:migrate)
 fi
 (cd "$APP_DIR" && bun run db:seed)
 
-# db:status must see every migration as applied on both drivers.
+# db:status must see every migration as applied on every driver.
 STATUS_OUTPUT=$(cd "$APP_DIR" && bun "$CLI_BIN" db:status 2>&1)
 printf '%s\n' "$STATUS_OUTPUT"
 if printf '%s' "$STATUS_OUTPUT" | grep -q "pending"; then
@@ -334,6 +364,32 @@ if (Number(tracker[0].c) < 1) {
 }
 await sql.end()
 console.log('DB tables OK (postgres): ' + tables.join(', '))
+DBCHECK
+  (cd "$APP_DIR" && bun "$TEMP_DIR/dbcheck.ts")
+elif [ "$SMOKE_DB" = "mysql" ]; then
+  cat > "$TEMP_DIR/dbcheck.ts" <<'DBCHECK'
+import { createConnection } from 'mysql2/promise'
+
+const connection = await createConnection(process.env.DATABASE_URL ?? '')
+const [rows] = await connection.query(
+  'SELECT table_name AS name FROM information_schema.tables WHERE table_schema = DATABASE()',
+)
+const tables = (rows as Array<{ name: string }>).map((row) => row.name)
+for (const required of ['users', 'posts', 'comments']) {
+  if (!tables.includes(required)) {
+    console.error('Missing table after db:migrate: ' + required + ' (found: ' + tables.join(', ') + ')')
+    process.exit(1)
+  }
+}
+// The tracker table lives in the app database on MySQL, so the count below
+// doubles as its existence check — the query fails if it was never created.
+const [tracker] = await connection.query('SELECT count(*) AS c FROM __drizzle_migrations')
+if (Number((tracker as Array<{ c: number }>)[0].c) < 1) {
+  console.error('__drizzle_migrations is empty after db:migrate')
+  process.exit(1)
+}
+await connection.end()
+console.log('DB tables OK (mysql): ' + tables.join(', '))
 DBCHECK
   (cd "$APP_DIR" && bun "$TEMP_DIR/dbcheck.ts")
 else


### PR DESCRIPTION
## Summary

- `create-guren-app --db mysql` generated `db/schema.ts` importing `mysqlTable, int, varchar, timestamp` from `@guren/orm/drizzle` — a subpath that re-exports the **PostgreSQL** pg-core builders under those same unqualified names. The MySQL `users` table was silently built out of a pg `timestamp`. Nothing caught it: drizzle-kit still emitted correct MySQL DDL and the app still typechecked. The scaffold now imports from `drizzle-orm/mysql-core`, matching what the SQLite scaffold already did and what the CLI's own patchers emit.
- The bug leaked further: `guren add auth` / `add resource` merge new columns into whichever import already has the same name across *all* import lines in the file, so a pg `timestamp` already in scope suppressed the MySQL one for every date column added afterward.
- Fixes a live runtime bug the new MySQL golden path uncovered along the way: the demo-user seeder `guren add auth` generates called `.onConflictDoNothing()` unconditionally, which doesn't exist on MySQL's drizzle query builder — `db:seed` threw on every MySQL app. The seeder is now dialect-aware (`.onDuplicateKeyUpdate()` on MySQL).
- Consolidated `detectSchemaDialect`/`readSchemaDialect` into `patch-helpers.ts` (previously duplicated between `blueprints.ts` and `make-auth.ts`, which risked the two disagreeing about one app's dialect).
- Added `smoke:golden-path:mysql`, wired into CI — nothing previously typechecked or migrated a `--db mysql` scaffold anywhere.

## Why the smoke alone isn't the guard

Dialect mixing still typechecks and still emits valid DDL, so the runtime smoke would pass either way. The actual regression guard is the new static coverage: every generated `db/schema.ts` import must come from the dialect-correct module, both on fresh scaffold (`packages/create-app/tests/schema-dialect.test.ts`, all three drivers) and after `add auth` / `add resource` patch it further (`packages/cli/tests/blueprints.test.ts`, `packages/cli/tests/make-auth.test.ts`).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test:bun` — 3204 pass / 0 fail
- [x] `bun run smoke:golden-path` (sqlite) — full pass
- [x] `bun run smoke:golden-path:mysql` — full pass (scaffold → add auth → add resource → codegen → typecheck ×2 → build ×2 → migrate → seed → HTTP login/CRUD/CSRF → queue/mail), run twice to confirm idempotence
- [x] `bun run audit:core-first`, `audit:docs`, `audit:starter-template` — pass
- [x] Confirmed the new static test fails red against the pre-fix import (mutation-tested)
- [x] Confirmed an unknown `GUREN_SMOKE_DB` value now fails loudly instead of silently falling through

## Known follow-up (out of scope here, tracked separately)

`guren add resource --fields "x:date"` / `"x:json"` generates app code that doesn't typecheck on **any** dialect (Resource `Date`→`string` cast, Validator zod arity, New/Edit/Show passing `Date`/`Record` into inputs and `ReactNode`). This is a pre-existing, dialect-independent defect — not something this PR introduces or fixes. It's why the golden path's resource field list stays at `body:text,postId:number` rather than exercising every column type.