### PR TITLE
feat(create-app): re-add the blog blueprint as a shipped template

### DIFF
--- a/.changeset/blog-blueprint-shipped-template.md
+++ b/.changeset/blog-blueprint-shipped-template.md
@@ -1,0 +1,44 @@
+---
+"create-guren-app": minor
+---
+
+Re-add the `blog` blueprint as a template that ships
+
+`--blueprint blog` is back, this time as a curated template under `templates/`
+instead of an overlay of the `examples/blog` workspace, which no published
+tarball contains. It layers posts CRUD, session authentication, an ownership
+policy, and a seeded demo account over the default template, and it applies
+`default-ssr` in SSR mode — the blueprint it replaces skipped that layer and
+scaffolded an SSR app with no `ssr.tsx` entry.
+
+The schema comes from the template rather than a generator in `blueprints.ts`.
+A template can now ship `db/schema.<driver>.ts` per driver; the scaffolder keeps
+the one matching the selected database, renames it to `db/schema.ts`, and
+deletes the rest. A template that ships some drivers but not the selected one is
+reported as an incomplete build instead of silently falling back to the generic
+single-table schema, which would scaffold models pointing at tables that do not
+exist. This is what the old blueprint's hand-maintained schema copy existed to
+work around, and what let it drift from the columns its own controllers read.
+
+`--auth` is ignored for blueprints that already ship authentication, with a note
+saying so: it runs `guren add auth --force`, which would overwrite the
+template's own controllers, routes, and `User` model with the generic ones. The
+"add features" next steps no longer suggest adding auth to an app that has it.
+
+Two things the template does that `guren add auth`'s output does not, both
+found by driving the scaffolded app in a browser: it shares the signed-in user
+with Inertia from `AuthProvider.boot()`, without which every page renders as a
+guest and the authenticated nav never appears, and it logs out through an
+Inertia `Link` rather than a native `<form method="post">`, which carries no
+CSRF token and is rejected with a 403.
+
+`smoke:starter:blog` scaffolds, typechecks, and builds the blueprint in CI
+alongside the existing `api` and `worker` smokes. Like every other starter
+smoke it covers SQLite only; the PostgreSQL and MySQL schemas this blueprint
+ships were typechecked and run through `drizzle-kit generate` by hand.
+
+The `User` model follows RFC 0006's structural mass-assignment model
+(`defineModel(users, { base: AuthenticatableModel, ... })`, no `guarded`) —
+`passwordHash` and `rememberToken` are denied by `AuthenticatableModel` itself,
+and `Post.fillable` never lists `authorId`, which is set from the session via
+`forceCreate()` in `PostController.store()`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
       - name: Fresh app smoke (api)
         run: bun run smoke:starter:api
 
+      - name: Fresh app smoke (blog)
+        run: bun run smoke:starter:blog
+
       - name: Fresh app smoke (worker)
         run: bun run smoke:starter:worker
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "audit:docs": "bun run ./scripts/smoke/docs-audit.ts",
     "smoke:starter": "bun run ./scripts/smoke/fresh-app.ts",
     "smoke:starter:api": "GUREN_SMOKE_BLUEPRINT=api bun run ./scripts/smoke/fresh-app.ts",
+    "smoke:starter:blog": "GUREN_SMOKE_BLUEPRINT=blog bun run ./scripts/smoke/fresh-app.ts",
     "smoke:starter:worker": "GUREN_SMOKE_BLUEPRINT=worker bun run ./scripts/smoke/fresh-app.ts",
     "smoke:starter:packed": "GUREN_SMOKE_INSTALL_MODE=packed bun run ./scripts/smoke/fresh-app.ts",
     "smoke:upgrade-existing-app": "bun run ./scripts/smoke/upgrade-existing-app.ts",

--- a/packages/create-app/CLAUDE.md
+++ b/packages/create-app/CLAUDE.md
@@ -5,14 +5,35 @@ Scaffolding CLI that copies templates from `templates/default` and replaces toke
 
 ## Key Files
 - `src/cli.ts`: Citty command definition
+- `src/blueprints.ts`: blueprint registry, template layering, database-variant files
 - `src/utils.ts`: filesystem helpers (`directoryExists`, `isDirectoryEmpty`, etc.)
 - `templates/default`: Bun project template; token map lives in `cli.ts`
+- `templates/blog`: curated blog starter, overlaid on `templates/default`
 
 ## Conventions
 - **Never put a file literally named `.gitignore` in `templates/`.** npm strips those from published tarballs, so it works from the monorepo and ships nothing to real users. Name it `_gitignore`; `copyLayer` restores the dot after each layer copies. `tests/templates.test.ts` guards this.
 - Keep template imports aligned with the latest package split (use scoped packages, not legacy `guren`)
 - When adding templates, register them via the token replacement list and ensure README next-steps stay accurate
 - Utilities should remain Node-compatible (no Bun-specific APIs here)
+
+## Templates
+- **Every layer must live under `templates/`** — it is the only source tree in
+  the `files` field, so a layer outside it works from the monorepo and ENOENTs
+  from npm. `TemplateName` makes that a type error; `tests/packaging.test.ts`
+  and `auditBlueprintTemplates` check the published tarball.
+- **`transformFiles` paths are read unconditionally.** A listed file that the
+  blueprint does not ship makes scaffolding throw.
+- **`applyDatabaseConfig` overwrites `db/schema.ts`.** A template needing more
+  than the generic `users` table ships `db/schema.<driver>.ts` per driver
+  instead; the scaffolder selects one and deletes the others.
+- **Advertise nothing without a smoke.** Each blueprint gets a
+  `smoke:starter:<name>` script and a CI step — `bun run typecheck` and
+  `bun run build` inside a real scaffold are the only things that catch a
+  template drifting from the framework.
+- **`templates/blog` was authored from canonical generator output** (`guren add
+  auth` + `guren add resource posts` on the default template) and then curated.
+  Regenerating that output is the cheapest way to see what the framework now
+  considers idiomatic when the template needs updating.
 
 ## Build
 - Build with `bun run --cwd packages/create-app build`

--- a/packages/create-app/src/blueprints.ts
+++ b/packages/create-app/src/blueprints.ts
@@ -1,11 +1,11 @@
 import { randomBytes } from 'node:crypto'
-import { cp, readFile, rename, writeFile } from 'node:fs/promises'
+import { cp, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { basename, dirname, join, relative } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
-import { directoryExists, toPackageName, toTitleCase } from './utils'
+import { directoryExists, fileExists, toPackageName, toTitleCase } from './utils'
 
-export const APP_BLUEPRINTS = ['default', 'api', 'worker'] as const
+export const APP_BLUEPRINTS = ['default', 'api', 'blog', 'worker'] as const
 export type AppBlueprintName = (typeof APP_BLUEPRINTS)[number]
 export type RenderingMode = 'spa' | 'ssr'
 
@@ -24,7 +24,7 @@ export type DatabaseDriver = (typeof DATABASE_DRIVERS)[number]
  */
 export const TEMPLATES_ROOT = fileURLToPath(new URL('../templates', import.meta.url))
 
-type TemplateName = 'default' | 'default-ssr' | 'api-only'
+type TemplateName = 'default' | 'default-ssr' | 'api-only' | 'blog'
 
 export function templateDir(name: TemplateName): string {
   return join(TEMPLATES_ROOT, name)
@@ -45,6 +45,12 @@ export interface AppBlueprint {
   baseTemplate: TemplateName
   overlayTemplates: Partial<Record<RenderingMode, TemplateName[]>>
   transformFiles: string[]
+  /**
+   * Set when the template already ships the authentication stack. `--auth` runs
+   * `guren add auth --force` afterwards, which would overwrite the template's
+   * own controllers, routes, and User model with the generic ones.
+   */
+  includesAuth?: boolean
   postScaffold?: (context: BlueprintContext) => Promise<void>
 }
 
@@ -70,6 +76,15 @@ const API_TRANSFORM_FILES = [
   'bin/serve.ts',
 ]
 
+// Transforms run once, after every layer has landed, and each path is read
+// unconditionally — so this lists every tokenised file in the scaffolded tree,
+// base template and overlay alike, not just what the overlay ships.
+const BLOG_TRANSFORM_FILES = [
+  ...DEFAULT_TRANSFORM_FILES,
+  'resources/js/components/Layout.tsx',
+  'db/seeders/001_users.ts',
+]
+
 const blueprintRegistry: Record<AppBlueprintName, AppBlueprint> = {
   default: {
     name: 'default',
@@ -86,6 +101,20 @@ const blueprintRegistry: Record<AppBlueprintName, AppBlueprint> = {
     baseTemplate: 'api-only',
     overlayTemplates: {},
     transformFiles: API_TRANSFORM_FILES,
+  },
+  blog: {
+    name: 'blog',
+    description: 'Blog starter — posts CRUD, session auth, and a seeded demo account.',
+    baseTemplate: 'default',
+    // The overlay lands last in both modes so its pages and controllers win, and
+    // SSR still gets `default-ssr` — the blueprint this replaces overlaid only
+    // itself in SSR mode and shipped an app with no ssr.tsx entry.
+    overlayTemplates: {
+      spa: ['blog'],
+      ssr: ['default-ssr', 'blog'],
+    },
+    transformFiles: BLOG_TRANSFORM_FILES,
+    includesAuth: true,
   },
   worker: {
     name: 'worker',
@@ -282,6 +311,45 @@ export const users = sqliteTable('users', {
 `
 }
 
+/**
+ * Templates whose app code needs more than the single `users` table above ship
+ * their own schema, one file per driver, as `db/schema.<driver>.ts`. The variant
+ * for the selected driver becomes `db/schema.ts` and the rest are deleted.
+ *
+ * The indirection exists because `applyDatabaseConfig` has to overwrite
+ * `db/schema.ts` — a template carrying a plain `db/schema.ts` written for one
+ * driver would otherwise be handed to users who picked another. The blueprint
+ * this replaced worked around that by regenerating its schema from a copy kept
+ * in this file, which then drifted from the columns its own controllers read.
+ *
+ * A template that ships some variants but not the selected one is a packaging
+ * bug, not a reason to fall back to the generic schema: the fallback would
+ * scaffold an app whose models reference tables that do not exist.
+ */
+function schemaVariantPath(destination: string, driver: DatabaseDriver): string {
+  return join(destination, `db/schema.${driver}.ts`)
+}
+
+async function resolveSchema(destination: string, driver: DatabaseDriver): Promise<string> {
+  const shipped = (await Promise.all(
+    DATABASE_DRIVERS.map(async (name) => (await fileExists(schemaVariantPath(destination, name)) ? name : null)),
+  )).filter((name) => name !== null)
+
+  if (shipped.length === 0) {
+    return generateSchema(driver)
+  }
+
+  if (!shipped.includes(driver)) {
+    throw new Error(
+      `This template ships a database schema for ${shipped.join(', ')} but not for ${driver}. ` +
+      'This build of create-guren-app is incomplete — please report it at ' +
+      'https://github.com/gurenjs/guren/issues.',
+    )
+  }
+
+  return readFile(schemaVariantPath(destination, driver), 'utf8')
+}
+
 function generateDrizzleConfig(driver: DatabaseDriver): string {
   const { url, dialect } = DATABASE_DEFAULTS[driver]
 
@@ -352,12 +420,19 @@ async function applyDatabaseConfig(destination: string, driver: DatabaseDriver):
   const { url, dep } = DATABASE_DEFAULTS[driver]
   const dockerCompose = generateDockerCompose(driver)
 
+  // Resolved before the writes below so a template missing the selected driver's
+  // schema fails while `db/schema.ts` still holds whatever the copy left there.
+  const schema = await resolveSchema(destination, driver)
+
   // Write all DB-variant files in parallel — including SQLite, since an overlay
   // template may ship a schema written for one driver that has to be replaced
   // with the driver the user actually selected.
   await Promise.all([
     writeFile(join(destination, 'config/database.ts'), generateDatabaseConfig(driver), 'utf8'),
-    writeFile(join(destination, 'db/schema.ts'), generateSchema(driver), 'utf8'),
+    writeFile(join(destination, 'db/schema.ts'), schema, 'utf8'),
+    // Independent of the write above: the selected variant's contents are
+    // already in `schema`, and no variant shares a path with db/schema.ts.
+    ...DATABASE_DRIVERS.map((name) => rm(schemaVariantPath(destination, name), { force: true })),
     writeFile(join(destination, 'drizzle.config.ts'), generateDrizzleConfig(driver), 'utf8'),
     dockerCompose ? writeFile(join(destination, 'docker-compose.yml'), dockerCompose, 'utf8') : Promise.resolve(),
     // Update .env and .env.example with the correct DATABASE_URL

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -280,7 +280,10 @@ const command = defineCommand({
       await updateSsrPackageJson(targetDir)
     }
 
-    const includeAuth = Boolean(args.auth)
+    if (args.auth && blueprint.includesAuth) {
+      consola.info(`The ${blueprint.name} blueprint already ships authentication — ignoring --auth.`)
+    }
+    const includeAuth = Boolean(args.auth) && !blueprint.includesAuth
 
     const shouldInstall = args.install !== false
     let installed = false
@@ -334,7 +337,9 @@ const command = defineCommand({
     }
     consola.log('')
     consola.info('Add features:')
-    consola.log('  bunx guren add auth')
+    if (!blueprint.includesAuth) {
+      consola.log('  bunx guren add auth')
+    }
     consola.log('  bunx guren add resource posts --fields "title:string,body:text"')
     consola.log('')
     consola.info('Generate types and set up database:')

--- a/packages/create-app/src/utils.ts
+++ b/packages/create-app/src/utils.ts
@@ -13,6 +13,19 @@ export async function directoryExists(path: string): Promise<boolean> {
   }
 }
 
+export async function fileExists(path: string): Promise<boolean> {
+  try {
+    const stats = await stat(path)
+    return stats.isFile()
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false
+    }
+
+    throw error
+  }
+}
+
 export async function isDirectoryEmpty(path: string): Promise<boolean> {
   try {
     const entries = await readdir(path)

--- a/packages/create-app/templates/blog/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/blog/.guren/api-client.gen.ts
@@ -1,0 +1,180 @@
+// Generated — DO NOT EDIT
+// Run `guren codegen` to regenerate.
+
+/**
+ * Typed API route registry.
+ * Use with `createApiClient<ApiRoutes>()` for end-to-end type safety.
+ */
+export interface ApiRoutes {
+  'dashboard': {
+    method: 'GET'
+    path: '/dashboard'
+    params: Record<string, never>
+  }
+  'home': {
+    method: 'GET'
+    path: '/'
+    params: Record<string, never>
+  }
+  'login': {
+    method: 'GET'
+    path: '/login'
+    params: Record<string, never>
+  }
+  'login.store': {
+    method: 'POST'
+    path: '/login'
+    params: Record<string, never>
+  }
+  'logout': {
+    method: 'POST'
+    path: '/logout'
+    params: Record<string, never>
+  }
+  'posts.create': {
+    method: 'GET'
+    path: '/posts/create'
+    params: Record<string, never>
+  }
+  'posts.destroy': {
+    method: 'DELETE'
+    path: '/posts/:id'
+    params: { id: string | number }
+  }
+  'posts.edit': {
+    method: 'GET'
+    path: '/posts/:id/edit'
+    params: { id: string | number }
+  }
+  'posts.index': {
+    method: 'GET'
+    path: '/posts'
+    params: Record<string, never>
+  }
+  'posts.show': {
+    method: 'GET'
+    path: '/posts/:id'
+    params: { id: string | number }
+  }
+  'posts.store': {
+    method: 'POST'
+    path: '/posts'
+    params: Record<string, never>
+    body: { title: string; excerpt: string; body: string }
+  }
+  'posts.update': {
+    method: 'PUT'
+    path: '/posts/:id'
+    params: { id: string | number }
+    body: { title: string; excerpt: string; body: string }
+  }
+  'profile.edit': {
+    method: 'GET'
+    path: '/profile'
+    params: Record<string, never>
+  }
+  'profile.update': {
+    method: 'PUT'
+    path: '/profile'
+    params: Record<string, never>
+  }
+  'register': {
+    method: 'GET'
+    path: '/register'
+    params: Record<string, never>
+  }
+  'register.store': {
+    method: 'POST'
+    path: '/register'
+    params: Record<string, never>
+  }
+}
+
+export type ApiRouteName = keyof ApiRoutes
+
+export type ApiRouteMethod<T extends ApiRouteName> = ApiRoutes[T]['method']
+export type ApiRoutePath<T extends ApiRouteName> = ApiRoutes[T]['path']
+export type ApiRouteParams<T extends ApiRouteName> = ApiRoutes[T]['params']
+
+type HasParams<T extends ApiRouteName> =
+  [keyof ApiRoutes[T]['params']] extends [never] ? false : true
+
+export type ApiRequestOptions<T extends ApiRouteName> =
+  HasParams<T> extends true
+    ? { params: ApiRouteParams<T>; body?: unknown; query?: Record<string, unknown> }
+    : { params?: never; body?: unknown; query?: Record<string, unknown> }
+
+/**
+ * Create a typed API client for consuming Guren routes.
+ *
+ * @example
+ * ```typescript
+ * import type { ApiRoutes } from '@/.guren/api-client.gen'
+ *
+ * const client = createApiClient<ApiRoutes>({ baseUrl: 'http://localhost:3000' })
+ * const posts = await client.request('posts.index')
+ * const post = await client.request('posts.show', { params: { id: 1 } })
+ * ```
+ */
+export function createApiClient<TRoutes extends Record<string, { method: string; path: string; params: unknown }>>(
+  config: { baseUrl: string; headers?: Record<string, string> },
+) {
+  return {
+    async request<TName extends keyof TRoutes & string>(
+      name: TName,
+      ...args: [keyof TRoutes[TName]['params']] extends [never]
+        ? [options?: { body?: unknown; query?: Record<string, unknown> }]
+        : [options: { params: TRoutes[TName]['params']; body?: unknown; query?: Record<string, unknown> }]
+    ): Promise<Response> {
+      const route = (routes as Record<string, { method: string; path: string }>)[name]
+      if (!route) throw new Error(`Route [${name}] not defined.`)
+
+      const opts = (args as unknown[])[0] as { params?: Record<string, unknown>; body?: unknown; query?: Record<string, unknown> } | undefined
+      let path = route.path
+      if (opts?.params) {
+        for (const [key, value] of Object.entries(opts.params)) {
+          path = path.replace(`:${key}`, encodeURIComponent(String(value)))
+        }
+      }
+
+      let url = `${config.baseUrl}${path}`
+      if (opts?.query) {
+        const search = new URLSearchParams()
+        for (const [k, v] of Object.entries(opts.query)) {
+          if (v != null) search.set(k, String(v))
+        }
+        const qs = search.toString()
+        if (qs) url += `?${qs}`
+      }
+
+      const init: RequestInit = {
+        method: route.method,
+        headers: { 'Content-Type': 'application/json', ...config.headers },
+      }
+      if (opts?.body && route.method !== 'GET') {
+        init.body = JSON.stringify(opts.body)
+      }
+
+      return fetch(url, init)
+    },
+  }
+}
+
+const routes: Record<string, { method: string; path: string }> = {
+  'dashboard': { method: 'GET', path: '/dashboard' },
+  'home': { method: 'GET', path: '/' },
+  'login': { method: 'GET', path: '/login' },
+  'login.store': { method: 'POST', path: '/login' },
+  'logout': { method: 'POST', path: '/logout' },
+  'posts.create': { method: 'GET', path: '/posts/create' },
+  'posts.destroy': { method: 'DELETE', path: '/posts/:id' },
+  'posts.edit': { method: 'GET', path: '/posts/:id/edit' },
+  'posts.index': { method: 'GET', path: '/posts' },
+  'posts.show': { method: 'GET', path: '/posts/:id' },
+  'posts.store': { method: 'POST', path: '/posts' },
+  'posts.update': { method: 'PUT', path: '/posts/:id' },
+  'profile.edit': { method: 'GET', path: '/profile' },
+  'profile.update': { method: 'PUT', path: '/profile' },
+  'register': { method: 'GET', path: '/register' },
+  'register.store': { method: 'POST', path: '/register' },
+}

--- a/packages/create-app/templates/blog/.guren/data.gen.ts
+++ b/packages/create-app/templates/blog/.guren/data.gen.ts
@@ -1,0 +1,23 @@
+// Generated from app/Http/Resources — DO NOT EDIT
+// Run `guren codegen` to regenerate.
+
+import type { PostRecord, PostAuthorSummary } from '../app/Models/Post.js'
+import type { WithRelations } from '@guren/core'
+
+/**
+ * Auto-extracted data types from Resource classes.
+ * Import these in your frontend to get typed API responses.
+ */
+export namespace Data {
+  export type Post = {
+  id: number
+  title: string
+  excerpt: string
+  body: string
+  authorId: number
+  // Serialized here because `created_at` is a string on SQLite and a Date on
+  // PostgreSQL and MySQL — pages should not have to know which.
+  createdAt: string
+  author?: PostAuthorSummary
+}
+}

--- a/packages/create-app/templates/blog/.guren/pages.gen.ts
+++ b/packages/create-app/templates/blog/.guren/pages.gen.ts
@@ -1,0 +1,99 @@
+// Generated from resources/js/pages — DO NOT EDIT
+// Run `guren codegen` to regenerate.
+
+import type { PageContract, PagePropsRecord } from '@guren/inertia-client'
+import type { ApiRoutes } from '@/.guren/api-client.gen'
+import type { PostResourceData } from '@/app/Http/Resources/PostResource'
+import type { PaginatedPageProps, ValidationErrors } from '@guren/core'
+
+
+export const pageManifest = {
+  'auth/Login': './pages/auth/Login.tsx',
+  'auth/Register': './pages/auth/Register.tsx',
+  'dashboard/Index': './pages/dashboard/Index.tsx',
+  'Home': './pages/Home.tsx',
+  'posts/Edit': './pages/posts/Edit.tsx',
+  'posts/Index': './pages/posts/Index.tsx',
+  'posts/New': './pages/posts/New.tsx',
+  'posts/Show': './pages/posts/Show.tsx',
+  'profile/Edit': './pages/profile/Edit.tsx',
+} as const
+
+export type PageManifest = typeof pageManifest
+export type PageId = keyof PageManifest
+export type PagePath<TPage extends PageId = PageId> = PageManifest[TPage]
+
+export const pageIds = Object.keys(pageManifest) as PageId[]
+
+export function isPageId(value: string): value is PageId {
+  return Object.prototype.hasOwnProperty.call(pageManifest, value)
+}
+
+type PostFormData = ApiRoutes['posts.store']['body']
+/**
+ * Auto-extracted Props types from page components.
+ */
+export interface PagePropsMap {
+  'auth/Login': {
+  email?: string
+  errors?: ValidationErrors<'email' | 'password'>
+}
+  'auth/Register': {
+  errors?: ValidationErrors<'name' | 'email' | 'password' | 'passwordConfirmation'>
+}
+  'dashboard/Index': {
+  user?: { id: number; name: string; email: string } | null
+}
+  'Home': {
+  latest: PostResourceData[]
+}
+  'posts/Edit': {
+  post: PostFormData & { id: number }
+}
+  'posts/Index': PaginatedPageProps<PostResourceData> & {}
+  'posts/Show': {
+  post: PostResourceData
+}
+  'profile/Edit': {
+  profile: { name: string; email: string }
+  errors?: ValidationErrors<'name' | 'email' | 'password'>
+  status?: string
+}
+}
+
+export type InferPageProps<TId extends PageId> =
+  TId extends keyof PagePropsMap ? PagePropsMap[TId] : Record<string, never>
+
+function defineGeneratedPage<TId extends string, TProps extends PagePropsRecord = Record<string, never>>(
+  id: TId,
+  path: string,
+): PageContract<TId, TProps> {
+  return {
+    id,
+    component: id,
+    path,
+    props<TNextProps extends PagePropsRecord>() {
+      return defineGeneratedPage(id, path) as PageContract<TId, TNextProps>
+    },
+  } as PageContract<TId, TProps>
+}
+
+export const pages = {
+  auth: {
+    Login: defineGeneratedPage<'auth/Login', PagePropsMap['auth/Login']>('auth/Login', pageManifest['auth/Login']),
+    Register: defineGeneratedPage<'auth/Register', PagePropsMap['auth/Register']>('auth/Register', pageManifest['auth/Register'])
+  },
+  dashboard: {
+    Index: defineGeneratedPage<'dashboard/Index', PagePropsMap['dashboard/Index']>('dashboard/Index', pageManifest['dashboard/Index'])
+  },
+  Home: defineGeneratedPage<'Home', PagePropsMap['Home']>('Home', pageManifest['Home']),
+  posts: {
+    Edit: defineGeneratedPage<'posts/Edit', PagePropsMap['posts/Edit']>('posts/Edit', pageManifest['posts/Edit']),
+    Index: defineGeneratedPage<'posts/Index', PagePropsMap['posts/Index']>('posts/Index', pageManifest['posts/Index']),
+    New: defineGeneratedPage('posts/New', pageManifest['posts/New']),
+    Show: defineGeneratedPage<'posts/Show', PagePropsMap['posts/Show']>('posts/Show', pageManifest['posts/Show'])
+  },
+  profile: {
+    Edit: defineGeneratedPage<'profile/Edit', PagePropsMap['profile/Edit']>('profile/Edit', pageManifest['profile/Edit'])
+  }
+} as const

--- a/packages/create-app/templates/blog/.guren/routes.gen.ts
+++ b/packages/create-app/templates/blog/.guren/routes.gen.ts
@@ -1,0 +1,138 @@
+// Generated from routes/web.ts — DO NOT EDIT
+// Run `guren codegen` to regenerate.
+
+export const routeManifest = {
+  'dashboard': { method: 'GET', path: '/dashboard' },
+  'home': { method: 'GET', path: '/' },
+  'login': { method: 'GET', path: '/login' },
+  'login.store': { method: 'POST', path: '/login' },
+  'logout': { method: 'POST', path: '/logout' },
+  'posts.create': { method: 'GET', path: '/posts/create' },
+  'posts.destroy': { method: 'DELETE', path: '/posts/:id' },
+  'posts.edit': { method: 'GET', path: '/posts/:id/edit' },
+  'posts.index': { method: 'GET', path: '/posts' },
+  'posts.show': { method: 'GET', path: '/posts/:id' },
+  'posts.store': { method: 'POST', path: '/posts' },
+  'posts.update': { method: 'PUT', path: '/posts/:id' },
+  'profile.edit': { method: 'GET', path: '/profile' },
+  'profile.update': { method: 'PUT', path: '/profile' },
+  'register': { method: 'GET', path: '/register' },
+  'register.store': { method: 'POST', path: '/register' },
+} as const
+
+export type RouteManifest = typeof routeManifest
+export type RouteName = keyof RouteManifest
+export type RouteMethod = [RouteName] extends [never] ? string : RouteManifest[RouteName]['method']
+export type RoutePath = [RouteName] extends [never] ? string : RouteManifest[RouteName]['path']
+
+type PrimitiveQueryValue = string | number | boolean | null | undefined
+type QueryValue = PrimitiveQueryValue | readonly PrimitiveQueryValue[]
+export type RouteQuery = Record<string, QueryValue>
+
+type NormalizeParamKey<TValue extends string> = TValue extends `${infer Key}?` ? Key : TValue
+type PathParamKeys<TPath extends string> =
+  TPath extends `${string}:${infer Param}/${infer Rest}`
+    ? NormalizeParamKey<Param> | PathParamKeys<`/${Rest}`>
+    : TPath extends `${string}:${infer Param}`
+      ? NormalizeParamKey<Param>
+      : never
+
+export type RouteParams<TName extends RouteName> =
+  [PathParamKeys<RouteManifest[TName]['path']>] extends [never]
+    ? Record<string, never>
+    : { [TKey in PathParamKeys<RouteManifest[TName]['path']>]: string | number }
+
+type RouteArgs<TName extends RouteName> =
+  [PathParamKeys<RouteManifest[TName]['path']>] extends [never]
+    ? [query?: RouteQuery]
+    : [params: RouteParams<TName>, query?: RouteQuery]
+
+export function route<TName extends RouteName>(name: TName, ...args: RouteArgs<TName>): string {
+  const definition = routeManifest[name]
+  if (!definition) {
+    throw new Error(`Route [${String(name)}] not defined.`)
+  }
+
+  const [firstArg, secondArg] = args as [RouteQuery | RouteParams<TName> | undefined, RouteQuery | undefined]
+  const params = (args.length > 1 ? firstArg : hasPathParams(definition.path) ? firstArg : undefined) as RouteParams<TName> | undefined
+  const query = (args.length > 1 ? secondArg : hasPathParams(definition.path) ? undefined : firstArg) as RouteQuery | undefined
+  const path = substituteParams(definition.path, params as Record<string, string | number> | undefined)
+  return appendQueryString(path, query)
+}
+
+export const routes = {
+  dashboard: (query?: RouteQuery) => route('dashboard', query),
+  home: (query?: RouteQuery) => route('home', query),
+  login: Object.assign(
+    (query?: RouteQuery) => route('login', query),
+    {
+    store: (query?: RouteQuery) => route('login.store', query)
+  }
+  ),
+  logout: (query?: RouteQuery) => route('logout', query),
+  posts: {
+    create: (query?: RouteQuery) => route('posts.create', query),
+    destroy: (params: RouteParams<'posts.destroy'>, query?: RouteQuery) => route('posts.destroy', params, query),
+    edit: (params: RouteParams<'posts.edit'>, query?: RouteQuery) => route('posts.edit', params, query),
+    index: (query?: RouteQuery) => route('posts.index', query),
+    show: (params: RouteParams<'posts.show'>, query?: RouteQuery) => route('posts.show', params, query),
+    store: (query?: RouteQuery) => route('posts.store', query),
+    update: (params: RouteParams<'posts.update'>, query?: RouteQuery) => route('posts.update', params, query)
+  },
+  profile: {
+    edit: (query?: RouteQuery) => route('profile.edit', query),
+    update: (query?: RouteQuery) => route('profile.update', query)
+  },
+  register: Object.assign(
+    (query?: RouteQuery) => route('register', query),
+    {
+    store: (query?: RouteQuery) => route('register.store', query)
+  }
+  )
+} as const
+
+function hasPathParams(path: string): boolean {
+  return /:[A-Za-z0-9_-]+/u.test(path)
+}
+
+function substituteParams(path: string, params?: Record<string, string | number>): string {
+  if (!params) {
+    return path
+  }
+
+  return path.replace(/:([A-Za-z0-9_-]+)/gu, (match, key) => {
+    if (!Object.prototype.hasOwnProperty.call(params, key)) {
+      return match
+    }
+
+    return encodeURIComponent(String(params[key]))
+  })
+}
+
+function appendQueryString(path: string, query?: RouteQuery): string {
+  if (!query) {
+    return path
+  }
+
+  const search = new URLSearchParams()
+
+  for (const [key, value] of Object.entries(query)) {
+    if (value == null) {
+      continue
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item != null) {
+          search.append(key, String(item))
+        }
+      }
+      continue
+    }
+
+    search.set(key, String(value))
+  }
+
+  const serialized = search.toString()
+  return serialized ? `${path}?${serialized}` : path
+}

--- a/packages/create-app/templates/blog/README.md
+++ b/packages/create-app/templates/blog/README.md
@@ -1,0 +1,85 @@
+# __APP_TITLE__
+
+A blog built with [Guren](https://guren.dev) — posts CRUD, session authentication,
+and a seeded demo account, ready to run.
+
+## Quick Start
+
+```bash
+bun install
+bun run db:make      # generate the first migration from db/schema.ts
+bun run db:migrate
+bun run db:seed      # demo@example.com / secret, plus two sample posts
+bun run dev
+```
+
+Visit `http://localhost:3333`, then sign in as `demo@example.com` with the
+password `secret` and publish a post from `/posts/create`.
+
+If you scaffolded with PostgreSQL or MySQL, run `bun run db:up` first to start
+the database container.
+
+## What's Included
+
+- `/` — landing page with the latest posts
+- `/posts` — paginated post list, `/posts/:id` — a single post
+- `/posts/create`, `/posts/:id/edit` — write and edit, signed in only
+- `/login`, `/register`, `/dashboard`, `/profile` — session authentication
+
+Posts belong to their author. `app/Providers/AuthorizationProvider.ts` binds
+`app/Policies/PostPolicy.ts` to the `Post` model, and `PostController` calls
+`this.authorize()` in every mutating action, so nobody can edit someone else's
+post. `app/Providers/AuthProvider.ts` shares the signed-in user with every page,
+which is what `resources/js/components/Layout.tsx` reads to show the
+Write/Dashboard/Log out controls.
+
+## Project Structure
+
+- `routes/web.ts`, `routes/auth.ts` — route definitions
+- `app/Http/Controllers/` — request handlers
+- `app/Http/Validators/` — Zod schemas, bound to routes and reused by the pages
+- `app/Http/Resources/` — the shapes controllers hand to pages
+- `app/Models/` — ORM models (`Post` belongs to `User`)
+- `app/Policies/` — authorization rules
+- `app/Providers/` — the auth model binding, shared page props, and the policy binding
+- `resources/js/pages/` — React pages (rendered via Inertia.js)
+- `db/schema.ts` — Drizzle table definitions
+- `db/seeders/` — the demo user and sample posts
+
+## Adding Features
+
+```bash
+bunx guren add queue          # background job processing
+bunx guren add mail           # email sending
+bunx guren add events         # event system
+bunx guren add cache          # caching layer
+bunx guren add notifications  # notification channels
+bunx guren add storage        # local/public disks
+bunx guren add broadcasting   # realtime channels
+bunx guren add schedule       # task scheduling
+```
+
+## Favicon
+
+`public/favicon.svg` ships as a placeholder and is linked from `src/app.ts` via
+`setInertiaDocument({ head })`, which is the only path that reaches the
+production document — `public/index.html` is not read by the server. Replace the
+file to change the icon, or edit the `head` markup to add more tags.
+
+Files at the root of `public/` are served by the Bun runtime. On Node-based
+deployments (AWS Lambda, for example) serve them from a CDN instead.
+
+## Scripts
+
+| Command | Description |
+|---------|-------------|
+| `bun run dev` | Start dev server (Bun + Vite) |
+| `bun run build` | Build for production |
+| `bun run preview` | Start the built app with the Bun production server |
+| `bun run db:make` | Generate a migration from `db/schema.ts` |
+| `bun run db:migrate` | Run database migrations |
+| `bun run db:seed` | Seed the database |
+| `bun run codegen` | Regenerate route/page types |
+
+Run `bun run build` before `bun run preview` so the production server can read
+the generated manifests from `public/assets`.

--- a/packages/create-app/templates/blog/app/Http/Controllers/Auth/LoginController.ts
+++ b/packages/create-app/templates/blog/app/Http/Controllers/Auth/LoginController.ts
@@ -1,0 +1,30 @@
+import { Controller, ValidationException } from '@guren/core'
+import { LoginSchema } from '../../Validators/LoginValidator.js'
+import { pages } from '@/.guren/pages.gen'
+
+export default class LoginController extends Controller {
+  async show(): Promise<Response> {
+    const email = this.request.query('email') ?? ''
+    return this.inertia(pages.auth.Login, { email }, { url: this.request.path, title: 'Login' })
+  }
+
+  async store(): Promise<Response> {
+    const { email, password, remember } = await this.validateBody(LoginSchema)
+
+    this.auth.session()?.regenerate()
+
+    const authenticated = await this.auth.attempt({ email, password }, remember)
+
+    if (!authenticated) {
+      throw ValidationException.withMessages({ message: 'Invalid credentials.' })
+    }
+
+    return this.redirect('/dashboard')
+  }
+
+  async destroy(): Promise<Response> {
+    await this.auth.logout()
+    this.auth.session()?.invalidate()
+    return this.redirect('/')
+  }
+}

--- a/packages/create-app/templates/blog/app/Http/Controllers/Auth/RegisterController.ts
+++ b/packages/create-app/templates/blog/app/Http/Controllers/Auth/RegisterController.ts
@@ -1,0 +1,28 @@
+import { Controller, ValidationException } from '@guren/core'
+import { RegisterSchema } from '../../Validators/RegisterValidator.js'
+import { User } from '../../../Models/User.js'
+import { pages } from '@/.guren/pages.gen'
+
+export default class RegisterController extends Controller {
+  async show(): Promise<Response> {
+    return this.inertia(pages.auth.Register, {}, { url: this.request.path, title: 'Register' })
+  }
+
+  async store(): Promise<Response> {
+    const { name, email, password } = await this.validateBody(RegisterSchema)
+
+    const existing = await User.where({ email })
+    if (existing.length > 0) {
+      throw ValidationException.withMessages({ email: 'An account with this email already exists.' })
+    }
+
+    // AuthenticatableModel hashes the virtual `password` field into
+    // `passwordHash` before persisting — see app/Models/User.ts.
+    const user = await User.create({ name, email, password })
+
+    this.auth.session()?.regenerate()
+    await this.auth.login(user)
+
+    return this.redirect('/dashboard')
+  }
+}

--- a/packages/create-app/templates/blog/app/Http/Controllers/DashboardController.ts
+++ b/packages/create-app/templates/blog/app/Http/Controllers/DashboardController.ts
@@ -1,0 +1,17 @@
+import { Controller } from '@guren/core'
+import type { UserRecord } from '../../Models/User.js'
+import { pages } from '@/.guren/pages.gen'
+
+export default class DashboardController extends Controller {
+  async index(): Promise<Response> {
+    const currentUser = await this.auth.user<UserRecord | null>()
+    const user = currentUser
+      ? {
+          id: currentUser.id,
+          name: currentUser.name,
+          email: currentUser.email,
+        }
+      : null
+    return this.inertia(pages.dashboard.Index, { user }, { url: this.request.path, title: 'Dashboard' })
+  }
+}

--- a/packages/create-app/templates/blog/app/Http/Controllers/HomeController.ts
+++ b/packages/create-app/templates/blog/app/Http/Controllers/HomeController.ts
@@ -1,0 +1,22 @@
+import { Controller } from '@guren/core'
+import { pages } from '@/.guren/pages.gen'
+import { Post } from '../../Models/Post.js'
+import { PostResource } from '../Resources/PostResource.js'
+
+const LATEST_POST_COUNT = 3
+
+export default class HomeController extends Controller {
+  async index(): Promise<Response> {
+    const latest = await Post.newQuery()
+      .with('author')
+      .orderBy('id', 'desc')
+      .limit(LATEST_POST_COUNT)
+      .get()
+
+    return this.inertia(
+      pages.Home,
+      { latest: latest.map((post) => new PostResource(post).toJSON()) },
+      { url: this.request.path, title: '__APP_TITLE__' },
+    )
+  }
+}

--- a/packages/create-app/templates/blog/app/Http/Controllers/PostController.ts
+++ b/packages/create-app/templates/blog/app/Http/Controllers/PostController.ts
@@ -1,0 +1,83 @@
+import { Controller, paginate, type PaginatedPageProps } from '@guren/core'
+import { pages } from '@/.guren/pages.gen'
+import { Post } from '../../Models/Post.js'
+import type { UserRecord } from '../../Models/User.js'
+import { PostResource, type PostResourceData } from '../Resources/PostResource.js'
+import { PostIdParamSchema, PostPayloadSchema, ListPostsQuerySchema } from '../Validators/PostValidator.js'
+
+type PostsIndexProps = PaginatedPageProps<PostResourceData>
+
+export default class PostController extends Controller {
+  async index(): Promise<Response> {
+    const { page } = this.validateQuery(ListPostsQuerySchema)
+    const result = await Post.newQuery()
+      .with('author')
+      .orderBy('id', 'desc')
+      .paginate({ page, perPage: 10 })
+    const paginator = paginate(result, { path: this.request.path ?? '/posts' })
+
+    return this.inertia(pages.posts.Index, {
+      data: result.data.map((post) => new PostResource(post).toJSON()),
+      pagination: {
+        meta: paginator.meta(),
+        links: paginator.links(),
+      },
+    } satisfies PostsIndexProps)
+  }
+
+  async show(): Promise<Response> {
+    const { id } = this.validateParams(PostIdParamSchema)
+    const post = await Post.findWithOrFail(id, 'author')
+
+    return this.inertia(pages.posts.Show, {
+      post: new PostResource(post).toJSON(),
+    })
+  }
+
+  async create(): Promise<Response> {
+    await this.authorize('create', Post)
+    return this.inertia(pages.posts.New, {})
+  }
+
+  async store(): Promise<Response> {
+    await this.authorize('create', Post)
+    const author = await this.auth.userOrFail<UserRecord>()
+    const data = await this.validateBody(PostPayloadSchema)
+    // forceCreate, because `authorId` is deliberately absent from Post.fillable:
+    // it comes from the session, and a request must never be able to set it.
+    const post = await Post.forceCreate({ ...data, authorId: author.id })
+
+    return this.redirect(post?.id ? `/posts/${post.id}` : '/posts')
+  }
+
+  async edit(): Promise<Response> {
+    const { id } = this.validateParams(PostIdParamSchema)
+    const post = await Post.findOrFail(id)
+    await this.authorize('update', [Post, post])
+
+    return this.inertia(pages.posts.Edit, {
+      post: new PostResource(post).toJSON(),
+    })
+  }
+
+  async update(): Promise<Response> {
+    const { id } = this.validateParams(PostIdParamSchema)
+    const post = await Post.findOrFail(id)
+    await this.authorize('update', [Post, post])
+
+    const data = await this.validateBody(PostPayloadSchema)
+    await Post.update({ id: post.id }, data)
+
+    return this.redirect(`/posts/${post.id}`)
+  }
+
+  async destroy(): Promise<Response> {
+    const { id } = this.validateParams(PostIdParamSchema)
+    const post = await Post.findOrFail(id)
+    await this.authorize('delete', [Post, post])
+
+    await Post.delete({ id: post.id })
+
+    return this.redirect('/posts')
+  }
+}

--- a/packages/create-app/templates/blog/app/Http/Controllers/ProfileController.ts
+++ b/packages/create-app/templates/blog/app/Http/Controllers/ProfileController.ts
@@ -1,0 +1,54 @@
+import { Controller, ValidationException } from '@guren/core'
+import { User, type UserRecord } from '../../Models/User.js'
+import { ProfileUpdateSchema } from '../Validators/ProfileValidator.js'
+import { pages } from '@/.guren/pages.gen'
+
+export default class ProfileController extends Controller {
+  async edit(): Promise<Response> {
+    const user = await this.auth.user<UserRecord | null>()
+    if (!user) {
+      return this.redirect('/login')
+    }
+
+    return this.inertia(pages.profile.Edit, {
+      profile: {
+        name: user.name,
+        email: user.email,
+      },
+    }, { url: this.request.path, title: 'Profile' })
+  }
+
+  async update(): Promise<Response> {
+    const user = await this.auth.user<UserRecord | null>()
+    if (!user) {
+      return this.redirect('/login')
+    }
+
+    const { name, email, password } = await this.validateBody(ProfileUpdateSchema)
+    const emailChanged = email !== user.email
+
+    if (emailChanged) {
+      const existing = await User.where({ email })
+      const conflict = existing.find((candidate) => candidate.id !== user.id)
+      if (conflict) {
+        throw ValidationException.withMessages({ email: 'Email is already in use.' })
+      }
+    }
+
+    await User.update({ id: user.id }, {
+      name,
+      email,
+      ...(password ? { password } : {}),
+    })
+
+    const refreshed = await User.find(user.id)
+    if (refreshed) {
+      await this.auth.login(refreshed)
+    }
+
+    return this.inertia(pages.profile.Edit, {
+      profile: { name, email },
+      status: 'Profile updated successfully.',
+    }, { url: this.request.path, title: 'Profile' })
+  }
+}

--- a/packages/create-app/templates/blog/app/Http/Resources/PostResource.ts
+++ b/packages/create-app/templates/blog/app/Http/Resources/PostResource.ts
@@ -1,0 +1,40 @@
+import { Resource, type WithRelations } from '@guren/core'
+import { Post } from '../../Models/Post.js'
+import type { PostRecord, PostAuthorSummary } from '../../Models/Post.js'
+
+type PostWithAuthor = WithRelations<typeof Post, 'author'>
+
+export interface PostResourceData extends Record<string, unknown> {
+  id: number
+  title: string
+  excerpt: string
+  body: string
+  authorId: number
+  // Serialized here because `created_at` is a string on SQLite and a Date on
+  // PostgreSQL and MySQL — pages should not have to know which.
+  createdAt: string
+  author?: PostAuthorSummary
+}
+
+export class PostResource extends Resource<PostRecord | PostWithAuthor> {
+  toArray(): PostResourceData {
+    const post = this.resource
+
+    return {
+      id: post.id as number,
+      title: post.title as string,
+      excerpt: post.excerpt as string,
+      body: post.body as string,
+      authorId: post.authorId as number,
+      createdAt: new Date(post.createdAt as string | Date).toISOString(),
+      author: this.whenLoaded('author', () => ({
+        id: (post as PostWithAuthor).author?.id,
+        name: (post as PostWithAuthor).author?.name,
+      })) as PostAuthorSummary | undefined,
+    }
+  }
+
+  override toJSON(): PostResourceData {
+    return super.toJSON() as PostResourceData
+  }
+}

--- a/packages/create-app/templates/blog/app/Http/Validators/LoginValidator.ts
+++ b/packages/create-app/templates/blog/app/Http/Validators/LoginValidator.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+export const LoginSchema = z.object({
+  // Lowercased to match how registration stores emails — a case-sensitive
+  // lookup would otherwise reject the same address typed with different casing.
+  email: z
+    .string()
+    .trim()
+    .min(1, 'Email is required.')
+    .email('The email address is badly formatted.')
+    .toLowerCase(),
+  password: z
+    .string()
+    .min(1, 'Password is required.'),
+  remember: z
+    .union([
+      z.boolean(),
+      z
+        .string()
+        .transform((value) => ['true', 'on', '1'].includes(value.toLowerCase())),
+    ])
+    .optional()
+    .transform((value) => Boolean(value))
+    .default(false),
+})
+
+export type LoginInput = z.infer<typeof LoginSchema>

--- a/packages/create-app/templates/blog/app/Http/Validators/PostValidator.ts
+++ b/packages/create-app/templates/blog/app/Http/Validators/PostValidator.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+export const PostIdParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+})
+
+export const ListPostsQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+})
+
+export const PostPayloadSchema = z.object({
+  title: z.string().trim().min(1, 'Title is required.').max(255, 'Title must be 255 characters or fewer.'),
+  excerpt: z.string().trim().min(1, 'Excerpt is required.').max(500, 'Excerpt must be 500 characters or fewer.'),
+  body: z.string().trim().min(1, 'Body is required.'),
+})
+
+export type PostPayload = z.infer<typeof PostPayloadSchema>

--- a/packages/create-app/templates/blog/app/Http/Validators/ProfileValidator.ts
+++ b/packages/create-app/templates/blog/app/Http/Validators/ProfileValidator.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod'
+
+export const ProfileUpdateSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, 'Name is required.')
+    .max(120, 'Name must be 120 characters or fewer.'),
+  email: z
+    .string()
+    .trim()
+    .min(1, 'Email is required.')
+    .email('Enter a valid email address.')
+    .toLowerCase(),
+  password: z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => value ?? '')
+    .refine((value) => value === '' || value.length >= 8, 'Password must be at least 8 characters.'),
+})
+
+export type ProfileUpdateInput = z.infer<typeof ProfileUpdateSchema>

--- a/packages/create-app/templates/blog/app/Http/Validators/RegisterValidator.ts
+++ b/packages/create-app/templates/blog/app/Http/Validators/RegisterValidator.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+
+export const RegisterSchema = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(1, 'Name is required.')
+      .max(120, 'Name must be 120 characters or fewer.'),
+    // Lowercased so it round-trips correctly through the password-reset and
+    // email-verification token helpers, which normalize emails to lowercase
+    // internally before matching against stored records.
+    email: z
+      .string()
+      .trim()
+      .min(1, 'Email is required.')
+      .email('The email address is badly formatted.')
+      .toLowerCase(),
+    password: z
+      .string()
+      .min(8, 'Password must be at least 8 characters.'),
+    passwordConfirmation: z
+      .string()
+      .min(1, 'Please confirm your password.'),
+  })
+  .refine((data) => data.password === data.passwordConfirmation, {
+    message: 'Passwords do not match.',
+    path: ['passwordConfirmation'],
+  })
+
+export type RegisterInput = z.infer<typeof RegisterSchema>

--- a/packages/create-app/templates/blog/app/Models/Post.ts
+++ b/packages/create-app/templates/blog/app/Models/Post.ts
@@ -1,0 +1,18 @@
+import { defineModel, type BelongsToRecord } from '@guren/core'
+import { posts } from '../../db/schema.js'
+import type { UserRecord } from './User.js'
+
+export type PostRecord = typeof posts.$inferSelect
+export type NewPostRecord = typeof posts.$inferInsert
+export type PostAuthorSummary = Pick<UserRecord, 'id' | 'name'>
+
+export class Post extends defineModel(posts) {
+  // `authorId` is set from the signed-in user, never from request input.
+  static fillable = ['title', 'excerpt', 'body']
+
+  static override relationTypes: { author: BelongsToRecord<PostAuthorSummary> } = {
+    author: null,
+  }
+}
+
+Post.belongsTo('author', () => import('./User.js').then((module) => module.User), 'authorId', 'id')

--- a/packages/create-app/templates/blog/app/Models/User.ts
+++ b/packages/create-app/templates/blog/app/Models/User.ts
@@ -1,0 +1,27 @@
+import { AuthenticatableModel, defineModel, type HasManyRecord } from '@guren/core'
+import { users } from '../../db/schema.js'
+import type { PostRecord } from './Post.js'
+
+export type UserRecord = typeof users.$inferSelect
+
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  // Derived from the plain `password`, so callers never set it directly
+  optionalOnCreate: ['passwordHash'],
+  requireOnCreate: ['password'],
+}) {
+  // passwordHash and rememberToken are denied from mass assignment by
+  // AuthenticatableModel itself. `name` and `email` are the only remaining
+  // columns, so this fillable list matches what would be mass-assignable
+  // anyway — it stays explicit so a later column addition needs an opt-in.
+  static fillable = ['name', 'email', 'password']
+
+  // Never serialized by Model.serialize() and stripped from auth.user()
+  static override hidden = ['passwordHash', 'rememberToken']
+
+  static override relationTypes: { posts: HasManyRecord<PostRecord> } = {
+    posts: [],
+  }
+}
+
+User.hasMany('posts', () => import('./Post.js').then((module) => module.Post), 'authorId', 'id')

--- a/packages/create-app/templates/blog/app/Policies/PostPolicy.ts
+++ b/packages/create-app/templates/blog/app/Policies/PostPolicy.ts
@@ -1,0 +1,32 @@
+import { Policy, type AuthUser } from '@guren/core'
+
+interface PostLike {
+  authorId: number
+}
+
+/**
+ * Bound to the Post model in app/Providers/AuthorizationProvider.ts.
+ * PostController calls `this.authorize()` for every mutating action, so a
+ * signed-in user can only edit or delete their own posts.
+ */
+export class PostPolicy extends Policy {
+  viewAny(_user: AuthUser | null): boolean {
+    return true
+  }
+
+  view(_user: AuthUser | null, _post: PostLike): boolean {
+    return true
+  }
+
+  create(user: AuthUser | null): boolean {
+    return user !== null
+  }
+
+  update(user: AuthUser | null, post: PostLike): boolean {
+    return user !== null && Number(user.id) === post.authorId
+  }
+
+  delete(user: AuthUser | null, post: PostLike): boolean {
+    return user !== null && Number(user.id) === post.authorId
+  }
+}

--- a/packages/create-app/templates/blog/app/Providers/AuthProvider.ts
+++ b/packages/create-app/templates/blog/app/Providers/AuthProvider.ts
@@ -1,0 +1,28 @@
+import { ServiceProvider, shareInertiaProps, AUTH_CONTEXT_KEY } from '@guren/core'
+import type { AuthContext, AuthManager } from '@guren/core'
+import { User } from '../Models/User.js'
+
+export default class AuthProvider extends ServiceProvider {
+  register(): void {
+    const auth = this.container.make<AuthManager>('auth')
+    auth.useModel(User, {
+      usernameColumn: 'email',
+      passwordColumn: 'passwordHash',
+      rememberTokenColumn: 'rememberToken',
+      credentialsPasswordField: 'password',
+    })
+  }
+
+  boot(): void {
+    // Nothing shares the signed-in user with the frontend by default, so every
+    // page would render as a guest. Layout.tsx reads this to choose between
+    // "Sign in" and the Write/Dashboard/Log out controls.
+    //
+    // shareInertiaProps merges over resolvers registered earlier instead of
+    // replacing them, so the framework's flashed `errors` still come through.
+    shareInertiaProps(async (ctx) => {
+      const auth = ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
+      return { auth: { user: await auth?.user() } }
+    })
+  }
+}

--- a/packages/create-app/templates/blog/app/Providers/AuthorizationProvider.ts
+++ b/packages/create-app/templates/blog/app/Providers/AuthorizationProvider.ts
@@ -1,0 +1,19 @@
+import { ServiceProvider, getGate } from '@guren/core'
+import { Post } from '../Models/Post.js'
+import { PostPolicy } from '../Policies/PostPolicy.js'
+
+/**
+ * Maps models to their policies. `PostController` calls `this.authorize()` in
+ * every mutating action, and without a registered policy the gate has nothing
+ * to consult and denies them all.
+ *
+ * The framework's own provider creates the gate during registration, so this
+ * runs in boot() — getGate() throws before that.
+ */
+export default class AuthorizationProvider extends ServiceProvider {
+  register(): void {}
+
+  boot(): void {
+    getGate().policy(Post, PostPolicy)
+  }
+}

--- a/packages/create-app/templates/blog/db/schema.mysql.ts
+++ b/packages/create-app/templates/blog/db/schema.mysql.ts
@@ -1,0 +1,26 @@
+// Imported from drizzle-orm/mysql-core rather than @guren/orm/drizzle, which
+// re-exports `text` and `timestamp` from pg-core only — taking them from there
+// would build a MySQL table out of PostgreSQL column builders. Drizzle happens
+// to emit the same DDL either way today; this does not rely on that.
+import { mysqlTable, int, varchar, text, timestamp } from 'drizzle-orm/mysql-core'
+
+export const users = mysqlTable('users', {
+  id: int('id').primaryKey().autoincrement(),
+  name: varchar('name', { length: 255 }).notNull(),
+  email: varchar('email', { length: 255 }).notNull().unique(),
+  passwordHash: varchar('password_hash', { length: 255 }).notNull(),
+  rememberToken: varchar('remember_token', { length: 255 }),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+})
+
+export const posts = mysqlTable('posts', {
+  id: int('id').primaryKey().autoincrement(),
+  title: varchar('title', { length: 255 }).notNull(),
+  excerpt: varchar('excerpt', { length: 500 }).notNull(),
+  body: text('body').notNull(),
+  authorId: int('author_id')
+    .notNull()
+    .references(() => users.id),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+})

--- a/packages/create-app/templates/blog/db/schema.postgres.ts
+++ b/packages/create-app/templates/blog/db/schema.postgres.ts
@@ -1,0 +1,22 @@
+import { pgTable, serial, integer, text, timestamp } from '@guren/orm/drizzle'
+
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  name: text('name').notNull(),
+  email: text('email').notNull().unique(),
+  passwordHash: text('password_hash').notNull(),
+  rememberToken: text('remember_token'),
+  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: false }).defaultNow().notNull(),
+})
+
+export const posts = pgTable('posts', {
+  id: serial('id').primaryKey(),
+  title: text('title').notNull(),
+  excerpt: text('excerpt').notNull(),
+  body: text('body').notNull(),
+  authorId: integer('author_id')
+    .notNull()
+    .references(() => users.id),
+  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),
+})

--- a/packages/create-app/templates/blog/db/schema.sqlite.ts
+++ b/packages/create-app/templates/blog/db/schema.sqlite.ts
@@ -1,0 +1,22 @@
+import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core'
+
+export const users = sqliteTable('users', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  name: text('name').notNull(),
+  email: text('email').notNull().unique(),
+  passwordHash: text('password_hash').notNull(),
+  rememberToken: text('remember_token'),
+  createdAt: text('created_at').notNull().$defaultFn(() => new Date().toISOString()),
+  updatedAt: text('updated_at').notNull().$defaultFn(() => new Date().toISOString()),
+})
+
+export const posts = sqliteTable('posts', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  title: text('title').notNull(),
+  excerpt: text('excerpt').notNull(),
+  body: text('body').notNull(),
+  authorId: integer('author_id')
+    .notNull()
+    .references(() => users.id),
+  createdAt: text('created_at').notNull().$defaultFn(() => new Date().toISOString()),
+})

--- a/packages/create-app/templates/blog/db/seeders/001_users.ts
+++ b/packages/create-app/templates/blog/db/seeders/001_users.ts
@@ -1,0 +1,22 @@
+import { defineSeeder, ScryptHasher } from '@guren/core'
+import { eq } from 'drizzle-orm'
+import { users } from '../schema.js'
+
+export const DEMO_EMAIL = 'demo@example.com'
+
+// Existence is checked rather than upserted because the three databases this
+// template supports spell conflict handling differently.
+export default defineSeeder(async ({ db }) => {
+  const existing = await db.select().from(users).where(eq(users.email, DEMO_EMAIL)).limit(1)
+  if (existing.length > 0) {
+    return
+  }
+
+  const hasher = new ScryptHasher()
+
+  await db.insert(users).values({
+    name: '__APP_TITLE__ Demo',
+    email: DEMO_EMAIL,
+    passwordHash: await hasher.hash('secret'),
+  })
+})

--- a/packages/create-app/templates/blog/db/seeders/002_posts.ts
+++ b/packages/create-app/templates/blog/db/seeders/002_posts.ts
@@ -1,0 +1,31 @@
+import { defineSeeder } from '@guren/core'
+import { eq } from 'drizzle-orm'
+import { posts, users } from '../schema.js'
+import { DEMO_EMAIL } from './001_users.js'
+
+const SAMPLE_POSTS = [
+  {
+    title: 'Hello from Guren',
+    excerpt: 'The first post on this blog, written by the seeder.',
+    body: 'Every page you see here is server-rendered by a controller and hydrated by Inertia. Edit resources/js/pages/posts/Show.tsx to change this layout.',
+  },
+  {
+    title: 'Writing your second post',
+    excerpt: 'Sign in as the demo user and publish from the browser.',
+    body: 'Sign in with demo@example.com / secret, then open /posts/create. Posts belong to their author, and PostPolicy stops anyone else editing them.',
+  },
+]
+
+export default defineSeeder(async ({ db }) => {
+  const [author] = await db.select().from(users).where(eq(users.email, DEMO_EMAIL)).limit(1)
+  if (!author) {
+    return
+  }
+
+  const existing = await db.select().from(posts).where(eq(posts.authorId, author.id)).limit(1)
+  if (existing.length > 0) {
+    return
+  }
+
+  await db.insert(posts).values(SAMPLE_POSTS.map((post) => ({ ...post, authorId: author.id })))
+})

--- a/packages/create-app/templates/blog/resources/js/components/Layout.tsx
+++ b/packages/create-app/templates/blog/resources/js/components/Layout.tsx
@@ -1,0 +1,56 @@
+import { Link, usePage } from '@inertiajs/react'
+import type { PropsWithChildren } from 'react'
+
+export default function Layout({ children }: PropsWithChildren) {
+  const { props } = usePage<{ auth?: { user?: { name?: string } } }>()
+  const user = props.auth?.user
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <header className="border-b border-slate-800 bg-slate-900/60 backdrop-blur">
+        <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
+          <Link href="/" className="text-lg font-semibold text-emerald-300">
+            __APP_TITLE__
+          </Link>
+          <nav className="flex items-center gap-4 text-sm text-slate-300">
+            <Link href="/posts" className="transition hover:text-emerald-200">
+              Posts
+            </Link>
+            {user ? (
+              <>
+                <Link href="/posts/create" className="transition hover:text-emerald-200">
+                  Write
+                </Link>
+                <Link href="/dashboard" className="transition hover:text-emerald-200">
+                  Dashboard
+                </Link>
+                {/* Inertia's Link posts through Axios, which copies the
+                    XSRF-TOKEN cookie into the request header. A native <form>
+                    POST carries neither that header nor a _token field, so CSRF
+                    protection rejects it and the session survives the click. */}
+                <Link
+                  href="/logout"
+                  method="post"
+                  as="button"
+                  className="rounded border border-emerald-500 px-3 py-1 text-emerald-200 transition hover:bg-emerald-500 hover:text-slate-950"
+                >
+                  Log out
+                </Link>
+              </>
+            ) : (
+              <Link
+                href="/login"
+                className="rounded border border-emerald-500 px-3 py-1 text-emerald-200 transition hover:bg-emerald-500 hover:text-slate-950"
+              >
+                Sign in
+              </Link>
+            )}
+          </nav>
+        </div>
+      </header>
+      <main className="mx-auto max-w-2xl px-6 py-12">
+        {children}
+      </main>
+    </div>
+  )
+}

--- a/packages/create-app/templates/blog/resources/js/pages/Home.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/Home.tsx
@@ -1,0 +1,55 @@
+import { Head, Link } from '@inertiajs/react'
+import type { PostResourceData } from '@/app/Http/Resources/PostResource'
+import Layout from '../components/Layout.js'
+
+interface Props {
+  latest: PostResourceData[]
+}
+
+export default function Home({ latest }: Props) {
+  return (
+    <Layout>
+      <Head title="__APP_TITLE__" />
+      <section className="space-y-10">
+        <header className="space-y-3">
+          <h1 className="text-4xl font-semibold tracking-tight text-emerald-300">__APP_TITLE__</h1>
+          <p className="text-slate-400">
+            A blog built with Guren — controllers on the server, React pages over Inertia, one
+            codebase. Edit <code className="rounded bg-slate-900 px-1.5 py-0.5 text-sm text-emerald-200">resources/js/pages/Home.tsx</code>{' '}
+            to make it yours.
+          </p>
+        </header>
+
+        <div className="space-y-4">
+          <div className="flex items-baseline justify-between">
+            <h2 className="text-xl font-medium text-slate-100">Latest posts</h2>
+            <Link href="/posts" className="text-sm text-emerald-300 transition hover:text-emerald-200">
+              All posts →
+            </Link>
+          </div>
+
+          {latest.length === 0 ? (
+            <p className="rounded border border-slate-800 bg-slate-900/40 px-4 py-6 text-sm text-slate-400">
+              No posts yet. Run <code className="text-emerald-200">bun run db:seed</code> for sample content,
+              or sign in and write the first one.
+            </p>
+          ) : (
+            <ul className="space-y-4">
+              {latest.map((post) => (
+                <li key={post.id} className="rounded-lg border border-slate-800 bg-slate-900/40 p-5">
+                  <Link href={`/posts/${post.id}`} className="text-lg font-medium text-slate-100 transition hover:text-emerald-200">
+                    {post.title}
+                  </Link>
+                  <p className="mt-2 text-sm text-slate-400">{post.excerpt}</p>
+                  {post.author ? (
+                    <p className="mt-3 text-xs uppercase tracking-wide text-slate-500">by {post.author.name}</p>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
+    </Layout>
+  )
+}

--- a/packages/create-app/templates/blog/resources/js/pages/auth/Login.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/auth/Login.tsx
@@ -1,0 +1,108 @@
+import { Head, Link, useForm } from '@inertiajs/react'
+import { useId } from 'react'
+import Layout from '../../components/Layout.js'
+import type { ValidationErrors } from '@guren/core'
+
+interface Props {
+  email?: string
+  errors?: ValidationErrors<'email' | 'password'>
+}
+
+type LoginFormData = {
+  email: string
+  password: string
+  remember: boolean
+}
+
+export default function Login({ email = '', errors = {} }: Props) {
+  const form = useForm<LoginFormData>({
+    email,
+    password: '',
+    remember: false,
+  })
+
+  const emailId = useId()
+  const passwordId = useId()
+
+  return (
+    <Layout>
+      <Head title="Sign in" />
+      <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-8 shadow-xl shadow-emerald-500/5">
+        <h1 className="text-2xl font-semibold text-emerald-300">Sign in</h1>
+        <p className="mt-2 text-sm text-slate-400">
+          Use your account credentials to continue.
+        </p>
+
+        {errors.message && (
+          <p className="mt-4 rounded border border-rose-500/60 bg-rose-500/10 px-4 py-2 text-sm text-rose-200">
+            {errors.message}
+          </p>
+        )}
+
+        <form
+          className="mt-6 space-y-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            form.post('/login')
+          }}
+        >
+          <div>
+            <label htmlFor={emailId} className="block text-sm font-medium text-slate-200">
+              Email
+            </label>
+            <input
+              id={emailId}
+              type="email"
+              value={form.data.email}
+              onChange={(event) => form.setData('email', event.target.value)}
+              required
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+            />
+            {errors.email && <p className="mt-1 text-sm text-rose-300">{errors.email}</p>}
+          </div>
+
+          <div>
+            <label htmlFor={passwordId} className="block text-sm font-medium text-slate-200">
+              Password
+            </label>
+            <input
+              id={passwordId}
+              type="password"
+              value={form.data.password}
+              onChange={(event) => form.setData('password', event.target.value)}
+              required
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+            />
+            {errors.password && <p className="mt-1 text-sm text-rose-300">{errors.password}</p>}
+          </div>
+
+          <label className="flex items-center gap-2 text-sm text-slate-300">
+            <input
+              type="checkbox"
+              checked={form.data.remember}
+              onChange={(event) => form.setData('remember', event.target.checked)}
+              className="h-4 w-4 rounded border-slate-700 bg-slate-950 text-emerald-400 focus:ring-emerald-400"
+            />
+            Remember me
+          </label>
+
+            <button
+              type="submit"
+              disabled={form.processing}
+              className="w-full rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400"
+            >
+              Sign in
+          </button>
+        </form>
+
+
+        <p className="mt-6 text-center text-sm text-slate-400">
+          Don&apos;t have an account?{' '}
+          <Link href="/register" className="text-emerald-300 transition hover:text-emerald-200">
+            Sign up
+          </Link>
+        </p>
+      </section>
+    </Layout>
+  )
+}

--- a/packages/create-app/templates/blog/resources/js/pages/auth/Register.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/auth/Register.tsx
@@ -1,0 +1,132 @@
+import { Head, Link, useForm } from '@inertiajs/react'
+import { useId } from 'react'
+import Layout from '../../components/Layout.js'
+import type { ValidationErrors } from '@guren/core'
+
+interface Props {
+  errors?: ValidationErrors<'name' | 'email' | 'password' | 'passwordConfirmation'>
+}
+
+type RegisterFormData = {
+  name: string
+  email: string
+  password: string
+  passwordConfirmation: string
+}
+
+export default function Register({ errors = {} }: Props) {
+  const form = useForm<RegisterFormData>({
+    name: '',
+    email: '',
+    password: '',
+    passwordConfirmation: '',
+  })
+
+  const nameId = useId()
+  const emailId = useId()
+  const passwordId = useId()
+  const passwordConfirmationId = useId()
+
+  return (
+    <Layout>
+      <Head title="Sign up" />
+      <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-8 shadow-xl shadow-emerald-500/5">
+        <h1 className="text-2xl font-semibold text-emerald-300">Create an account</h1>
+        <p className="mt-2 text-sm text-slate-400">
+          Sign up to get started.
+        </p>
+
+        {errors.message && (
+          <p className="mt-4 rounded border border-rose-500/60 bg-rose-500/10 px-4 py-2 text-sm text-rose-200">
+            {errors.message}
+          </p>
+        )}
+
+        <form
+          className="mt-6 space-y-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            form.post('/register')
+          }}
+        >
+          <div>
+            <label htmlFor={nameId} className="block text-sm font-medium text-slate-200">
+              Name
+            </label>
+            <input
+              id={nameId}
+              type="text"
+              value={form.data.name}
+              onChange={(event) => form.setData('name', event.target.value)}
+              required
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+            />
+            {errors.name && <p className="mt-1 text-sm text-rose-300">{errors.name}</p>}
+          </div>
+
+          <div>
+            <label htmlFor={emailId} className="block text-sm font-medium text-slate-200">
+              Email
+            </label>
+            <input
+              id={emailId}
+              type="email"
+              value={form.data.email}
+              onChange={(event) => form.setData('email', event.target.value)}
+              required
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+            />
+            {errors.email && <p className="mt-1 text-sm text-rose-300">{errors.email}</p>}
+          </div>
+
+          <div>
+            <label htmlFor={passwordId} className="block text-sm font-medium text-slate-200">
+              Password
+            </label>
+            <input
+              id={passwordId}
+              type="password"
+              value={form.data.password}
+              onChange={(event) => form.setData('password', event.target.value)}
+              required
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+            />
+            {errors.password && <p className="mt-1 text-sm text-rose-300">{errors.password}</p>}
+          </div>
+
+          <div>
+            <label htmlFor={passwordConfirmationId} className="block text-sm font-medium text-slate-200">
+              Confirm password
+            </label>
+            <input
+              id={passwordConfirmationId}
+              type="password"
+              value={form.data.passwordConfirmation}
+              onChange={(event) => form.setData('passwordConfirmation', event.target.value)}
+              required
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+            />
+            {errors.passwordConfirmation && (
+              <p className="mt-1 text-sm text-rose-300">{errors.passwordConfirmation}</p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={form.processing}
+            className="w-full rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+          >
+            Create account
+          </button>
+        </form>
+
+        <p className="mt-6 text-center text-sm text-slate-400">
+          Already have an account?{' '}
+          <Link href="/login" className="text-emerald-300 transition hover:text-emerald-200">
+            Sign in
+          </Link>
+        </p>
+      </section>
+    </Layout>
+  )
+}

--- a/packages/create-app/templates/blog/resources/js/pages/dashboard/Index.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/dashboard/Index.tsx
@@ -1,0 +1,29 @@
+import Layout from '../../components/Layout.js'
+
+interface Props {
+  user?: { id: number; name: string; email: string } | null
+}
+
+export default function Dashboard({ user }: Props) {
+  return (
+    <Layout>
+      <section className="space-y-6">
+        <header>
+          <h1 className="text-3xl font-semibold text-emerald-300">Dashboard</h1>
+          <p className="mt-2 text-sm text-slate-400">This page is protected by the auth middleware.</p>
+        </header>
+
+        {user ? (
+          <div className="rounded-lg border border-slate-800 bg-slate-900/40 p-6 shadow-lg shadow-emerald-500/10">
+            <h2 className="text-xl font-medium text-slate-100">Signed in as {user.name}</h2>
+            <p className="mt-2 text-sm text-slate-300">Email: {user.email}</p>
+          </div>
+        ) : (
+          <div className="rounded border border-rose-500/60 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+            You are not signed in.
+          </div>
+        )}
+      </section>
+    </Layout>
+  )
+}

--- a/packages/create-app/templates/blog/resources/js/pages/posts/Edit.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/posts/Edit.tsx
@@ -1,0 +1,79 @@
+import { Head, useForm } from '@inertiajs/react'
+import type { ApiRoutes } from '@/.guren/api-client.gen'
+import { route } from '@/.guren/routes.gen'
+import Layout from '../../components/Layout.js'
+
+type PostFormData = ApiRoutes['posts.store']['body']
+
+interface Props {
+  post: PostFormData & { id: number }
+}
+
+const fieldClass =
+  'mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring'
+
+export default function EditPost({ post }: Props) {
+  const form = useForm<PostFormData>({
+    title: post.title,
+    excerpt: post.excerpt,
+    body: post.body,
+  })
+
+  return (
+    <Layout>
+      <Head title={`Edit ${post.title}`} />
+      <section className="space-y-6">
+        <h1 className="text-3xl font-semibold text-emerald-300">Edit post</h1>
+
+        <form
+          className="space-y-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            form.put(route('posts.update', { id: post.id }))
+          }}
+        >
+          <div>
+            <label className="block text-sm font-medium text-slate-200">Title</label>
+            <input
+              type="text"
+              value={form.data.title}
+              onChange={(event) => form.setData('title', event.target.value)}
+              className={fieldClass}
+            />
+            {form.errors.title ? <p className="mt-1 text-sm text-rose-300">{form.errors.title}</p> : null}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-200">Excerpt</label>
+            <input
+              type="text"
+              value={form.data.excerpt}
+              onChange={(event) => form.setData('excerpt', event.target.value)}
+              className={fieldClass}
+            />
+            {form.errors.excerpt ? <p className="mt-1 text-sm text-rose-300">{form.errors.excerpt}</p> : null}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-200">Body</label>
+            <textarea
+              rows={10}
+              value={form.data.body}
+              onChange={(event) => form.setData('body', event.target.value)}
+              className={fieldClass}
+            />
+            {form.errors.body ? <p className="mt-1 text-sm text-rose-300">{form.errors.body}</p> : null}
+          </div>
+
+          <button
+            type="submit"
+            disabled={form.processing}
+            className="rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+          >
+            Save changes
+          </button>
+        </form>
+      </section>
+    </Layout>
+  )
+}

--- a/packages/create-app/templates/blog/resources/js/pages/posts/Index.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/posts/Index.tsx
@@ -1,0 +1,49 @@
+import { Head, Link } from '@inertiajs/react'
+import type { PaginatedPageProps } from '@guren/core'
+import type { PostResourceData } from '@/app/Http/Resources/PostResource'
+import { route } from '@/.guren/routes.gen'
+import Layout from '../../components/Layout.js'
+
+interface Props extends PaginatedPageProps<PostResourceData> {}
+
+export default function PostsIndex({ data, pagination }: Props) {
+  return (
+    <Layout>
+      <Head title="Posts" />
+      <section className="space-y-6">
+        <h1 className="text-3xl font-semibold text-emerald-300">Posts</h1>
+
+        <div className="space-y-4">
+          {data.map((post) => (
+            <article key={post.id} className="rounded-lg border border-slate-800 bg-slate-900/40 p-5">
+              <Link
+                href={route('posts.show', { id: post.id })}
+                className="text-lg font-medium text-slate-100 transition hover:text-emerald-200"
+              >
+                {post.title}
+              </Link>
+              <p className="mt-2 text-sm text-slate-400">{post.excerpt}</p>
+              {post.author ? (
+                <p className="mt-3 text-xs uppercase tracking-wide text-slate-500">by {post.author.name}</p>
+              ) : null}
+            </article>
+          ))}
+        </div>
+
+        {pagination?.links?.pages && (
+          <nav className="flex gap-2">
+            {pagination.links.pages.map((page) => (
+              <Link
+                key={page.page}
+                href={page.url ?? '#'}
+                className="rounded border border-slate-800 px-3 py-1 text-sm text-slate-300 transition hover:border-emerald-500 hover:text-emerald-200"
+              >
+                {page.page}
+              </Link>
+            ))}
+          </nav>
+        )}
+      </section>
+    </Layout>
+  )
+}

--- a/packages/create-app/templates/blog/resources/js/pages/posts/New.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/posts/New.tsx
@@ -1,0 +1,71 @@
+import { Head, useForm } from '@inertiajs/react'
+import type { ApiRoutes } from '@/.guren/api-client.gen'
+import { route } from '@/.guren/routes.gen'
+import Layout from '../../components/Layout.js'
+
+type PostFormData = ApiRoutes['posts.store']['body']
+
+const fieldClass =
+  'mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring'
+
+export default function NewPost() {
+  const form = useForm<PostFormData>({ title: '', excerpt: '', body: '' })
+
+  return (
+    <Layout>
+      <Head title="New post" />
+      <section className="space-y-6">
+        <h1 className="text-3xl font-semibold text-emerald-300">New post</h1>
+
+        <form
+          className="space-y-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            form.post(route('posts.store'))
+          }}
+        >
+          <div>
+            <label className="block text-sm font-medium text-slate-200">Title</label>
+            <input
+              type="text"
+              value={form.data.title}
+              onChange={(event) => form.setData('title', event.target.value)}
+              className={fieldClass}
+            />
+            {form.errors.title ? <p className="mt-1 text-sm text-rose-300">{form.errors.title}</p> : null}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-200">Excerpt</label>
+            <input
+              type="text"
+              value={form.data.excerpt}
+              onChange={(event) => form.setData('excerpt', event.target.value)}
+              className={fieldClass}
+            />
+            {form.errors.excerpt ? <p className="mt-1 text-sm text-rose-300">{form.errors.excerpt}</p> : null}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-200">Body</label>
+            <textarea
+              rows={10}
+              value={form.data.body}
+              onChange={(event) => form.setData('body', event.target.value)}
+              className={fieldClass}
+            />
+            {form.errors.body ? <p className="mt-1 text-sm text-rose-300">{form.errors.body}</p> : null}
+          </div>
+
+          <button
+            type="submit"
+            disabled={form.processing}
+            className="rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+          >
+            Publish
+          </button>
+        </form>
+      </section>
+    </Layout>
+  )
+}

--- a/packages/create-app/templates/blog/resources/js/pages/posts/Show.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/posts/Show.tsx
@@ -1,0 +1,55 @@
+import { Head, Link, usePage } from '@inertiajs/react'
+import type { PostResourceData } from '@/app/Http/Resources/PostResource'
+import { route } from '@/.guren/routes.gen'
+import Layout from '../../components/Layout.js'
+
+interface Props {
+  post: PostResourceData
+}
+
+export default function PostShow({ post }: Props) {
+  const { props } = usePage<{ auth?: { user?: { id?: number } } }>()
+  // Mirrors PostPolicy — the server rejects it either way, this only keeps
+  // controls the viewer cannot use off the page.
+  const canManage = props.auth?.user?.id === post.authorId
+
+  return (
+    <Layout>
+      <Head title={post.title} />
+      <article className="space-y-6">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-semibold text-emerald-300">{post.title}</h1>
+          <p className="text-sm text-slate-500">
+            {post.author ? `by ${post.author.name} · ` : ''}
+            {new Date(post.createdAt).toLocaleDateString()}
+          </p>
+          <p className="text-slate-400">{post.excerpt}</p>
+        </header>
+
+        <div className="whitespace-pre-wrap text-slate-200">{post.body}</div>
+
+        <footer className="flex gap-4 border-t border-slate-800 pt-6 text-sm">
+          <Link href={route('posts.index')} className="text-slate-300 transition hover:text-emerald-200">
+            ← All posts
+          </Link>
+          {canManage ? (
+            <>
+              <Link href={route('posts.edit', { id: post.id })} className="text-emerald-300 transition hover:text-emerald-200">
+                Edit
+              </Link>
+              <Link
+                href={route('posts.destroy', { id: post.id })}
+                method="delete"
+                as="button"
+                onBefore={() => window.confirm('Delete this post?')}
+                className="text-rose-400 transition hover:text-rose-300"
+              >
+                Delete
+              </Link>
+            </>
+          ) : null}
+        </footer>
+      </article>
+    </Layout>
+  )
+}

--- a/packages/create-app/templates/blog/resources/js/pages/profile/Edit.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/profile/Edit.tsx
@@ -1,0 +1,90 @@
+import { Head, useForm } from '@inertiajs/react'
+import type { FormEvent } from 'react'
+import Layout from '../../components/Layout.js'
+import type { ValidationErrors } from '@guren/core'
+
+interface Props {
+  profile: { name: string; email: string }
+  errors?: ValidationErrors<'name' | 'email' | 'password'>
+  status?: string
+}
+
+type ProfileFormValues = {
+  name: string
+  email: string
+  password: string
+}
+
+export default function ProfileEdit({ profile, status }: Props) {
+  const form = useForm<ProfileFormValues>({
+    name: profile.name,
+    email: profile.email,
+    password: '',
+  })
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    form.put('/profile')
+  }
+
+  return (
+    <Layout>
+      <Head title="Profile" />
+      <section className="space-y-6 rounded-lg border border-slate-800 bg-slate-900/40 p-8 shadow-xl shadow-emerald-500/5">
+        <header>
+          <h1 className="text-2xl font-semibold text-emerald-300">Profile</h1>
+          <p className="mt-2 text-sm text-slate-400">Update your account details and password.</p>
+        </header>
+
+        {status ? (
+          <p className="rounded border border-emerald-500/40 bg-emerald-500/10 px-4 py-2 text-sm text-emerald-200">
+            {status}
+          </p>
+        ) : null}
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label className="block text-sm font-medium text-slate-200">Name</label>
+            <input
+              type="text"
+              value={form.data.name}
+              onChange={(event) => form.setData('name', event.target.value)}
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+            />
+            {form.errors.name ? <p className="mt-1 text-sm text-rose-300">{form.errors.name}</p> : null}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-200">Email</label>
+            <input
+              type="email"
+              value={form.data.email}
+              onChange={(event) => form.setData('email', event.target.value)}
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+            />
+            {form.errors.email ? <p className="mt-1 text-sm text-rose-300">{form.errors.email}</p> : null}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-200">New password</label>
+            <input
+              type="password"
+              value={form.data.password}
+              onChange={(event) => form.setData('password', event.target.value)}
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+            />
+            {form.errors.password ? <p className="mt-1 text-sm text-rose-300">{form.errors.password}</p> : null}
+          </div>
+
+          <button
+            type="submit"
+            disabled={form.processing}
+            className="w-full rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+          >
+            Save changes
+          </button>
+        </form>
+      </section>
+    </Layout>
+  )
+}

--- a/packages/create-app/templates/blog/routes/auth.ts
+++ b/packages/create-app/templates/blog/routes/auth.ts
@@ -1,0 +1,22 @@
+import type { Router } from '@guren/core'
+import LoginController from '../app/Http/Controllers/Auth/LoginController.js'
+import RegisterController from '../app/Http/Controllers/Auth/RegisterController.js'
+import DashboardController from '../app/Http/Controllers/DashboardController.js'
+import ProfileController from '../app/Http/Controllers/ProfileController.js'
+
+// Uses the 'auth' and 'guest' aliases routes/web.ts registers on this router.
+export function registerAuthRoutes(router: Router<'auth' | 'guest'>): void {
+  router.middleware('guest').group((guest) => {
+    guest.get('/login', [LoginController, 'show']).name('login')
+    guest.post('/login', [LoginController, 'store']).name('login.store')
+    guest.get('/register', [RegisterController, 'show']).name('register')
+    guest.post('/register', [RegisterController, 'store']).name('register.store')
+  })
+
+  router.middleware('auth').group((authed) => {
+    authed.post('/logout', [LoginController, 'destroy']).name('logout')
+    authed.get('/dashboard', [DashboardController, 'index']).name('dashboard')
+    authed.get('/profile', [ProfileController, 'edit']).name('profile.edit')
+    authed.put('/profile', [ProfileController, 'update']).name('profile.update')
+  })
+}

--- a/packages/create-app/templates/blog/routes/web.ts
+++ b/packages/create-app/templates/blog/routes/web.ts
@@ -1,0 +1,34 @@
+import { Router, requireAuthenticated, requireGuest } from '@guren/core'
+import HomeController from '../app/Http/Controllers/HomeController.js'
+import PostController from '../app/Http/Controllers/PostController.js'
+import { PostPayloadSchema } from '../app/Http/Validators/PostValidator.js'
+import { registerAuthRoutes } from './auth.js'
+
+export function registerWebRoutes(baseRouter: Router): void {
+  // Named rather than inline so `guren audit` can see which routes are
+  // protected — it cannot inspect a middleware passed as a call result.
+  const router = baseRouter
+    .aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
+    .aliasMiddleware('guest', requireGuest({ redirectTo: '/dashboard' }))
+
+  router.get('/', [HomeController, 'index']).name('home')
+
+  // Health check endpoint for load balancers and uptime monitors
+  router.get('/health', (c) => c.json({ status: 'ok' }))
+
+  registerAuthRoutes(router)
+
+  router.group('/posts', (posts) => {
+    // Registered before '/:id', or "create" is read as a post id.
+    posts.middleware('auth').group((authed) => {
+      authed.get('/create', [PostController, 'create']).name('posts.create')
+      authed.get('/:id/edit', [PostController, 'edit']).name('posts.edit')
+      authed.post('/', { name: 'posts.store', body: PostPayloadSchema }, [PostController, 'store'])
+      authed.put('/:id', { name: 'posts.update', body: PostPayloadSchema }, [PostController, 'update'])
+      authed.delete('/:id', { name: 'posts.destroy' }, [PostController, 'destroy'])
+    })
+
+    posts.get('/', [PostController, 'index']).name('posts.index')
+    posts.get('/:id', [PostController, 'show']).name('posts.show')
+  })
+}

--- a/packages/create-app/templates/blog/src/app.ts
+++ b/packages/create-app/templates/blog/src/app.ts
@@ -1,0 +1,23 @@
+import { createApp, setInertiaDocument } from '@guren/core'
+import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
+import AuthProvider from '../app/Providers/AuthProvider.js'
+import AuthorizationProvider from '../app/Providers/AuthorizationProvider.js'
+import { registerWebRoutes } from '../routes/web.js'
+
+// Rendered into every server-rendered document. Replace public/favicon.svg
+// with your own artwork, or add more tags here (Open Graph, apple-touch-icon).
+setInertiaDocument({
+  head: '<link rel="icon" type="image/svg+xml" href="/favicon.svg" />',
+})
+
+const app = createApp({
+  auth: {},
+  routes: registerWebRoutes,
+  providers: [DatabaseProvider, AuthProvider, AuthorizationProvider],
+  hostAuthorization: process.env.NODE_ENV === 'production' ? false : {
+    allowedHosts: ['localhost:*', '127.0.0.1:*'],
+    exclude: ['/healthcheck', '/up'],
+  },
+})
+
+export default app

--- a/packages/create-app/tests/cli.test.ts
+++ b/packages/create-app/tests/cli.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, mock } from 'bun:test'
 import { readFile, access, mkdir, writeFile } from 'node:fs/promises'
 import { spawnSync } from 'node:child_process'
 import { join } from 'node:path'
+import { DATABASE_DRIVERS } from '../src/blueprints'
 import { createTempWorkspace } from './helpers'
 
 let capturedCommand: any
@@ -122,6 +123,98 @@ describe('create-guren-app CLI', () => {
 
       expect(infoMock.mock.calls.some((call) => call.join(' ').includes('Optional deploy path:'))).toBe(true)
       expect(logMock.mock.calls.some((call) => call.join(' ').includes('bunx guren plugin @guren/plugin-vercel'))).toBe(true)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('scaffolds the blog blueprint on top of the default template', async () => {
+    const workspace = await createTempWorkspace('guren-create-app-cli-blog-')
+    try {
+      await capturedCommand.run({
+        args: {
+          target: 'blog-app',
+          force: false,
+          mode: 'ssr',
+          auth: false,
+          blueprint: 'blog',
+          db: 'sqlite',
+          install: false,
+        },
+      })
+
+      const appRoot = join(workspace.dir, 'blog-app')
+
+      // The overlay copies last, so its files must win over the base template's.
+      const home = await readFile(join(appRoot, 'resources/js/pages/Home.tsx'), 'utf8')
+      expect(home).toContain('Latest posts')
+
+      // Tokens are replaced in the overlay's own files, not just the base's.
+      const layout = await readFile(join(appRoot, 'resources/js/components/Layout.tsx'), 'utf8')
+      expect(layout).toContain('Blog App')
+      expect(layout).not.toContain('__APP_TITLE__')
+
+      // ...without dropping the SSR layer the base blueprint contributes.
+      await access(join(appRoot, 'resources/js/ssr.tsx'))
+
+      await access(join(appRoot, 'app/Http/Controllers/PostController.ts'))
+      await access(join(appRoot, 'app/Policies/PostPolicy.ts'))
+      await access(join(appRoot, 'db/seeders/002_posts.ts'))
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('keeps only the selected driver schema and never the generic one', async () => {
+    const workspace = await createTempWorkspace('guren-create-app-cli-blog-schema-')
+    try {
+      await capturedCommand.run({
+        args: {
+          target: 'pg-blog',
+          force: false,
+          mode: 'spa',
+          auth: false,
+          blueprint: 'blog',
+          db: 'postgres',
+          install: false,
+        },
+      })
+
+      const appRoot = join(workspace.dir, 'pg-blog')
+      const schema = await readFile(join(appRoot, 'db/schema.ts'), 'utf8')
+
+      expect(schema).toContain('pgTable')
+      // The generic schema has no posts table — writing it over a template that
+      // ships its own is what broke the blueprint this one replaces.
+      expect(schema).toContain('export const posts')
+
+      for (const driver of DATABASE_DRIVERS) {
+        await expect(access(join(appRoot, `db/schema.${driver}.ts`))).rejects.toThrow()
+      }
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('ignores --auth for a blueprint that already ships it', async () => {
+    const workspace = await createTempWorkspace('guren-create-app-cli-blog-auth-')
+    try {
+      infoMock.mockClear()
+      await capturedCommand.run({
+        args: {
+          target: 'auth-blog',
+          force: false,
+          mode: 'spa',
+          auth: true,
+          blueprint: 'blog',
+          db: 'sqlite',
+          install: false,
+        },
+      })
+
+      // `guren add auth --force` would overwrite the template's own controllers,
+      // routes, and User model with the generic ones.
+      expect(infoMock.mock.calls.some((call) => call.join(' ').includes('already ships authentication'))).toBe(true)
     } finally {
       await workspace.cleanup()
     }

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -2,6 +2,8 @@ import { cp, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/pr
 import { tmpdir } from 'node:os'
 import { dirname, join, relative, resolve } from 'node:path'
 import process from 'node:process'
+import { DATABASE_DRIVERS } from '../../packages/create-app/src/blueprints'
+import { fileExists } from '../../packages/create-app/src/utils'
 import { auditBlueprintTemplates, auditConsoleWiring, auditStarterTemplate } from './starter-template-audit'
 
 type PackageName =
@@ -330,6 +332,75 @@ async function assertCanonicalScaffolds(appDir: string): Promise<void> {
   assert(postsIndexPage.includes('interface Props') || postsIndexPage.includes('PaginatedPageProps'), 'Posts index page must define Props.')
 }
 
+/**
+ * The blog template ships its app code instead of generating it, so nothing
+ * else in CI reads these files. Typecheck and build cover whether they compile;
+ * these assertions cover the wiring that compiles either way — an unregistered
+ * policy, a mass-assignable `authorId`, or a leftover per-driver schema variant
+ * all typecheck fine and all produce a broken or unsafe app.
+ */
+async function assertBlogScaffold(appDir: string): Promise<void> {
+  for (const driver of DATABASE_DRIVERS) {
+    assert(
+      !await fileExists(join(appDir, `db/schema.${driver}.ts`)),
+      `Blog blueprint left db/schema.${driver}.ts behind in the scaffolded app.`,
+    )
+  }
+
+  const schema = await readFile(join(appDir, 'db/schema.ts'), 'utf8')
+  assert(schema.includes('export const posts'), 'Blog blueprint must ship a posts table.')
+  assert(schema.includes('author_id'), 'Blog posts must carry their author.')
+
+  const appBootstrap = await readFile(join(appDir, 'src/app.ts'), 'utf8')
+  assert(appBootstrap.includes('AuthProvider'), 'Blog blueprint must register AuthProvider.')
+  assert(appBootstrap.includes('AuthorizationProvider'), 'Blog blueprint must register AuthorizationProvider.')
+
+  // getGate() throws until the framework's own provider has registered, so the
+  // policy has to be bound from a provider's boot(), not at module scope.
+  const authorizationProvider = await readFile(join(appDir, 'app/Providers/AuthorizationProvider.ts'), 'utf8')
+  assert(
+    /boot\(\)[^{]*\{[^}]*getGate\(\)\.policy\(Post,\s*PostPolicy\)/su.test(authorizationProvider),
+    'Blog blueprint must bind PostPolicy to the Post model from boot(), not at module scope.',
+  )
+
+  // Nothing shares the signed-in user with Inertia by default, and Layout.tsx
+  // gates every authenticated control on it — without this the nav renders as a
+  // guest for a signed-in user and the Log out button is unreachable.
+  const authProvider = await readFile(join(appDir, 'app/Providers/AuthProvider.ts'), 'utf8')
+  assert(authProvider.includes('shareInertiaProps('), 'Blog blueprint must share the signed-in user with Inertia.')
+
+  // A native form POST carries neither the X-XSRF-TOKEN header nor a _token
+  // field, so CSRF protection rejects it — the click silently does nothing.
+  const layout = await readFile(join(appDir, 'resources/js/components/Layout.tsx'), 'utf8')
+  assert(!/<form[^>]*method="post"/iu.test(layout), 'Blog blueprint must not post from a native form — CSRF rejects it.')
+  assert(/<Link[^>]*method="post"/su.test(layout), 'Blog blueprint must log out through an Inertia Link.')
+
+  const post = await readFile(join(appDir, 'app/Models/Post.ts'), 'utf8')
+  assert(post.includes('static fillable'), 'Blog Post model must declare fillable fields.')
+  assert(!/fillable\s*=\s*\[[^\]]*authorId/su.test(post), 'Blog Post model must not accept authorId as mass-assignable input.')
+
+  const postController = await readFile(join(appDir, 'app/Http/Controllers/PostController.ts'), 'utf8')
+  for (const ability of ["'create'", "'update'", "'delete'"]) {
+    assert(postController.includes(`this.authorize(${ability}`), `Blog PostController must authorize ${ability}.`)
+  }
+  assert(postController.includes('authorId: author.id'), 'Blog PostController must set the author from the signed-in user.')
+
+  const webRoutes = await readFile(join(appDir, 'routes/web.ts'), 'utf8')
+  assert(webRoutes.includes('registerAuthRoutes(router)'), 'Blog blueprint must register its auth routes.')
+  // Named, because `guren audit` cannot inspect a middleware passed inline as a
+  // call result and downgrades those routes to an unverifiable warning.
+  assert(webRoutes.includes("aliasMiddleware('auth'"), 'Blog blueprint must alias its auth middleware.')
+  assert(webRoutes.includes("posts.middleware('auth').group("), 'Blog blueprint must guard mutating post routes with the named auth middleware.')
+
+  // The seeders are the only way a fresh blog app has anything to show, and
+  // nothing else in CI loads them.
+  for (const seeder of ['db/seeders/001_users.ts', 'db/seeders/002_posts.ts']) {
+    const source = await readFile(join(appDir, seeder), 'utf8')
+    assert(source.includes('defineSeeder'), `${seeder} must export a seeder.`)
+    assert(!source.includes('onConflictDoNothing'), `${seeder} must stay portable across the drivers this blueprint supports.`)
+  }
+}
+
 async function assertFeatureScaffolds(appDir: string): Promise<void> {
   const appBootstrap = await readFile(join(appDir, 'src/app.ts'), 'utf8')
   for (const providerName of [
@@ -489,6 +560,12 @@ async function main(): Promise<void> {
       assert(routesFile.includes('/health'), 'API blueprint must include a /health endpoint.')
       assert(routesFile.includes('/api/v1'), 'API blueprint must include /api/v1 prefix.')
       await assertCoreFirstStarter(appDir, { checkDependencies: false })
+    } else if (blueprint === 'blog') {
+      // No codegen before the typecheck below: the template ships .guren/*.gen.ts,
+      // and running codegen first would regenerate them, hiding stubs that have
+      // fallen behind the pages and routes the template actually ships.
+      await assertCoreFirstStarter(appDir, { checkDependencies: false })
+      await assertBlogScaffold(appDir)
     } else if (blueprint === 'worker') {
       // Worker blueprint: postScaffold adds queue/events/cache/schedule
       await assertCoreFirstStarter(appDir, { checkDependencies: false })


### PR DESCRIPTION
## Summary

- Re-adds the `blog` blueprint (`--blueprint blog`) removed in #237, this time as a curated template under `packages/create-app/templates/blog/` instead of an overlay of `examples/blog`, which no published tarball contains.
- Layers posts CRUD, session authentication, an ownership policy (`PostPolicy`, bound via `AuthorizationProvider.boot()`), and a seeded demo account over the `default` template. Applies `default-ssr` in SSR mode — the removed blueprint skipped that layer and scaffolded an SSR app with no `ssr.tsx` entry.
- Adds per-driver template schemas: a template can ship `db/schema.<driver>.ts` per database driver; `applyDatabaseConfig()` in `blueprints.ts` now selects the one matching the chosen driver, renames it to `db/schema.ts`, and deletes the rest. Shipping some drivers but not the selected one fails loudly instead of silently falling back to the generic single-table schema (which would scaffold models pointing at tables that don't exist) — this is what the previous blueprint's hand-maintained schema copy existed to work around, and what let it drift from its own controllers.
- Adds `includesAuth` on `AppBlueprint`: `--auth` is now ignored (with a note) for a blueprint that already ships authentication, since `guren add auth --force` would overwrite the template's own controllers/routes/`User` model.
- `templates/blog` was authored from `guren add auth` + `guren add resource posts` output and then curated, so it stays close to canonical generator output. `Post.fillable` deliberately excludes `authorId`, which is set from the session via `forceCreate()`. The `User` model follows RFC 0006's structural mass-assignment model (`defineModel(users, { base: AuthenticatableModel, ... })`, no `guarded`).
- Adds `smoke:starter:blog` (scaffold → typecheck → build) alongside the existing `api`/`worker` smokes, in `package.json` and CI.

## Bugs found and fixed by actually driving the scaffolded app

Static checks (typecheck, build, `guren check`/`audit`) don't catch either of these — both were found by clicking through a real running instance in a browser:

- **Logout was permanently broken.** The generated `Layout.tsx` posted to `/logout` from a native `<form>`, which carries no CSRF token (no `X-XSRF-TOKEN` header, no `_token` field) and is rejected with a 403 — the click silently did nothing. Fixed by switching to an Inertia `Link method="post"`. This same bug exists in `guren add auth`'s generator output; filed as a separate fix (#241, already open).
- **The nav never showed authenticated state.** Nothing shares the signed-in user with Inertia by default, so every page rendered as a guest even when signed in, and the Log out control was unreachable. Fixed with `shareInertiaProps()` in `AuthProvider.boot()`.

Both are now smoke-asserted (`assertBlogScaffold` in `scripts/smoke/fresh-app.ts` checks the Layout has no native logout form and that `AuthProvider` shares auth props), with mutation tests confirming the assertions actually fail on a reverted version.

## Review

Ran a Codex review pass plus a 4-agent `/simplify` sweep (reuse / simplification / efficiency / altitude) against the diff, verifying each finding against real code/behavior before applying:

- Confirmed (Codex): the native-form logout CSRF bug above.
- Applied: dropped a duplicate `.guren/channels.gen.ts` stub, replaced hardcoded driver-name arrays with the exported `DATABASE_DRIVERS`, simplified `resolveSchema()`/removed a redundant `removeSchemaVariants()` helper, made `body` `NOT NULL` (was accidentally nullable — deleted five `?? ''` workaround sites), removed dead props/prop round-trips (`Home.tsx`'s `title` prop, `posts/Edit.tsx`'s unused `errors` prop), fixed a stale docstring/README pointing at the wrong file for policy registration.
- Declined: extracting a shared `New.tsx`/`Edit.tsx` form component (a starter template favors newcomer readability over DRY here — both reviewers agreed), reusing `ProfileController`/`DashboardController`'s `userOrFail()` pattern in the auth-copied controllers (those files are intentionally byte-identical to `guren add auth`'s generator output; fixing the pattern belongs there).

## Rebase note

This branch was originally stacked on the blueprint-removal work in #237 before it merged; rebased onto current `main` (past RFC 0006 / #239) and updated the `User` model to the new structural mass-assignment API in the process. Re-verified end to end afterward: `guren check`/`audit` on the rebased scaffold, full authenticated CRUD flow (login, create, cross-user 403s, `authorId` spoof rejection, logout) against a CI-faithful vendored install, and a browser click-through confirming the nav and logout fixes still hold.

## Test plan

- [x] `bun run build`, `bun run typecheck`
- [x] `bun run test:bun` (3217 pass), `bun run test:examples` (91 pass)
- [x] `bun test packages/create-app` (32 pass)
- [x] `bun run audit:core-first`, `audit:docs`, `audit:starter-template`, `audit:contracts`, `audit:feature-runtime`
- [x] `bun run smoke:starter`, `smoke:starter:api`, `smoke:starter:worker`, `smoke:starter:blog`, `smoke:starter:packed`
- [x] Scaffolded blog apps for all three drivers (sqlite/postgres/mysql); typechecked and ran `drizzle-kit generate` for postgres/mysql (not covered by the sqlite-only CI smoke)
- [x] `guren check`/`guren audit` on a scaffolded blog app (0 failures; one expected `forceCreate` review-prompt warning matching the framework's own documented pattern)
- [x] Full authenticated flow against a real running instance: login, dashboard, create post, cross-user edit/delete → 403, `authorId` spoof → ignored, logout via native-form-shaped request → still correctly 403'd (CSRF), browser click-through of login → nav → Write → publish → logout