### PR TITLE
Add CodeQL scanning for framework code

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # Weekly full scan: query packs update independently of our commits,
+    # so a quiet week can still surface new findings.
+    - cron: '0 3 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          # security-extended trades some noise for coverage of the
+          # injection/path-traversal classes a web framework must care about.
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'


### PR DESCRIPTION
## Summary

`guren audit` covers application code, but nothing statically analyzes the framework's own source — parsers, template string assembly, path handling. This adds GitHub CodeQL (free for public repos) over `javascript-typescript` with the `security-extended` query pack, which covers the injection and path-traversal classes a web framework must care about.

Triggers: pushes and PRs to `main`, plus a weekly scheduled scan — query packs update independently of our commits, so a quiet week can still surface new findings.

## Verification

- YAML parses cleanly; the `pull_request` trigger means this PR's own checks run the first analysis. Findings (if any) will appear in the Security → Code scanning tab and as PR annotations.