### PR TITLE
fix(docs): correct CSRF form field name and Inertia guidance

### DIFF
--- a/docs/en/guides/csrf.md
+++ b/docs/en/guides/csrf.md
@@ -12,17 +12,21 @@ import { createApp, createSessionMiddleware, createCsrfMiddleware } from '@guren
 
 const app = createApp()
 
-// Session middleware is required for CSRF
+// Optional — the token binds to a persisted session
 app.use('*', createSessionMiddleware())
 app.use('*', createCsrfMiddleware())
 ```
 
 The middleware automatically:
-- Generates a unique token per session
+- Generates a token per session, or a stateless double-submit token for guests
 - Validates tokens on state-changing requests (POST, PUT, PATCH, DELETE)
 - Allows safe methods (GET, HEAD, OPTIONS) without validation
 
 ## Including the Token in Forms
+
+A native `<form method="post">` must carry the token as a `_token` field, or Guren
+rejects it with a 403. In an Inertia app, `useForm()` and `<Link method="post">`
+send it for you — see [Inertia.js Integration](#inertiajs-integration).
 
 Use the `csrfField()` helper to generate a hidden input field:
 
@@ -46,7 +50,7 @@ In your frontend form (React example):
 function CreateForm({ csrfToken }: { csrfToken: string }) {
   return (
     <form method="POST" action="/posts">
-      <input type="hidden" name="_csrf" value={csrfToken} />
+      <input type="hidden" name="_token" value={csrfToken} />
       {/* form fields */}
       <button type="submit">Create</button>
     </form>
@@ -58,7 +62,7 @@ Or generate the hidden field directly:
 
 ```ts
 const hiddenField = csrfField(ctx)
-// Returns: <input type="hidden" name="_csrf" value="..." />
+// Returns: <input type="hidden" name="_token" value="..." />
 ```
 
 ## AJAX Requests
@@ -66,31 +70,39 @@ const hiddenField = csrfField(ctx)
 For JavaScript/AJAX requests, include the token in a header:
 
 ```ts
-// Get token from meta tag or cookie
-const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
+// The middleware sets a JavaScript-readable XSRF-TOKEN cookie
+const csrfToken = decodeURIComponent(
+  document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]*)/)?.[1] ?? '',
+)
 
 fetch('/api/posts', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    'X-CSRF-Token': csrfToken,
+    'X-XSRF-TOKEN': csrfToken,
   },
   body: JSON.stringify({ title: 'Hello' }),
 })
 ```
 
-The middleware checks both the `_csrf` form field and `X-CSRF-Token` header.
+Axios — and therefore Inertia.js — does this for you, so you only need the code
+above for plain `fetch`.
+
+The middleware accepts the token from three places, in this order:
+
+1. The `X-CSRF-TOKEN` header
+2. The `X-XSRF-TOKEN` header, read from the `XSRF-TOKEN` cookie
+3. The `_token` field in an urlencoded, multipart, or JSON request body
+
+These names are not configurable. If you turn the cookie off (`cookie: false`
+below), pass the token to the page yourself with `getCsrfToken(ctx)` and send it
+as `X-CSRF-TOKEN` — do this only for session-authenticated flows, because guest
+tokens verify against the cookie and cannot work without it.
 
 ## Configuration Options
 
 ```ts
 createCsrfMiddleware({
-  // Custom form field name (default: '_csrf')
-  fieldName: '_token',
-
-  // Custom header name (default: 'X-CSRF-Token')
-  headerName: 'X-XSRF-Token',
-
   // Routes to exclude from CSRF validation
   exclude: ['/api/webhooks/*', '/api/public/*'],
 
@@ -100,6 +112,14 @@ createCsrfMiddleware({
   },
 })
 ```
+
+The remaining options rarely need changing:
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| `methods` | `['POST', 'PUT', 'PATCH', 'DELETE']` | Which HTTP methods require a token |
+| `cookie` | `true` | Issue the `XSRF-TOKEN` cookie on safe requests and successful mutations |
+| `cookieOptions` | `{ path: '/', sameSite: 'Lax' }` | Cookie attributes; `secure` is on when `NODE_ENV` is `production`, and in runtimes without `process` |
 
 ## Excluding Routes
 
@@ -138,9 +158,11 @@ export function registerWebRoutes(router: Router): void {
 
 ## Token Regeneration
 
-Tokens are tied to the session and regenerate when:
-- A new session is created
+A session-bound token follows the session id, so it changes when:
+- The session is first persisted (a brand-new session does not yet anchor a token)
 - `session.regenerate()` is called (recommended after login)
+
+Guest tokens carry no session id and are reused until a session exists.
 
 ```ts
 // After successful login
@@ -154,7 +176,7 @@ await session.regenerate()
 1. **Always use HTTPS** - Tokens can be intercepted over HTTP
 2. **Regenerate after login** - Prevents session fixation attacks
 3. **Don't expose tokens in URLs** - Use POST bodies or headers
-4. **Set secure cookie flags** - The session middleware handles this automatically
+4. **Set secure cookie flags** - The session middleware handles the session cookie; the `XSRF-TOKEN` cookie follows `cookieOptions`
 
 ## Inertia.js Integration
 
@@ -166,3 +188,29 @@ axios.defaults.withCredentials = true
 ```
 
 Inertia automatically reads the `XSRF-TOKEN` cookie and includes it in requests.
+
+### Submit through Inertia, not a native form
+
+That only covers requests Inertia sends through Axios. A native
+`<form method="post">` submits as a full browser navigation, which carries no
+`X-XSRF-TOKEN` header — so Guren rejects it with a 403 unless the form itself
+carries a `_token` hidden field.
+
+In an Inertia page, prefer `useForm()`:
+
+```tsx
+import { useForm } from '@inertiajs/react'
+
+function LogoutButton() {
+  const { post, processing } = useForm()
+
+  return (
+    <button type="button" onClick={() => post('/logout')} disabled={processing}>
+      Log out
+    </button>
+  )
+}
+```
+
+`<Link href="/logout" method="post" as="button">` works too, for a plain action
+link. Reach for a native form only when you deliberately want a full page submit.

--- a/docs/ja/guides/csrf.md
+++ b/docs/ja/guides/csrf.md
@@ -12,17 +12,21 @@ import { createApp, createSessionMiddleware, createCsrfMiddleware } from '@guren
 
 const app = createApp()
 
-// CSRF にはセッションミドルウェアが必要
+// 任意 — トークンは永続化済みのセッションに紐づきます
 app.use('*', createSessionMiddleware())
 app.use('*', createCsrfMiddleware())
 ```
 
 ミドルウェアは自動的に以下を行います。
-- セッションごとに一意のトークンを生成
+- セッションごとにトークンを生成（ゲストにはステートレスな double-submit トークン）
 - 状態を変更するリクエスト（POST、PUT、PATCH、DELETE）でトークンを検証
 - 安全なメソッド（GET、HEAD、OPTIONS）は検証なしで許可
 
 ## フォームにトークンを含める
+
+ネイティブの `<form method="post">` はトークンを `_token` フィールドとして含める必要が
+あります。含めないと Guren が 403 で拒否します。Inertia アプリなら `useForm()` と
+`<Link method="post">` が自動で送信します（[Inertia.js との統合](#inertiajs-との統合)を参照）。
 
 `csrfField()` ヘルパーを使用して hidden input フィールドを生成します。
 
@@ -46,7 +50,7 @@ export default class FormController extends Controller {
 function CreateForm({ csrfToken }: { csrfToken: string }) {
   return (
     <form method="POST" action="/posts">
-      <input type="hidden" name="_csrf" value={csrfToken} />
+      <input type="hidden" name="_token" value={csrfToken} />
       {/* フォームフィールド */}
       <button type="submit">作成</button>
     </form>
@@ -58,7 +62,7 @@ function CreateForm({ csrfToken }: { csrfToken: string }) {
 
 ```ts
 const hiddenField = csrfField(ctx)
-// 出力: <input type="hidden" name="_csrf" value="..." />
+// 出力: <input type="hidden" name="_token" value="..." />
 ```
 
 ## AJAX リクエスト
@@ -66,31 +70,39 @@ const hiddenField = csrfField(ctx)
 JavaScript/AJAX リクエストの場合、ヘッダーにトークンを含めます。
 
 ```ts
-// meta タグまたは cookie からトークンを取得
-const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
+// ミドルウェアが JavaScript から読める XSRF-TOKEN Cookie を設定します
+const csrfToken = decodeURIComponent(
+  document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]*)/)?.[1] ?? '',
+)
 
 fetch('/api/posts', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    'X-CSRF-Token': csrfToken,
+    'X-XSRF-TOKEN': csrfToken,
   },
   body: JSON.stringify({ title: 'Hello' }),
 })
 ```
 
-ミドルウェアは `_csrf` フォームフィールドと `X-CSRF-Token` ヘッダーの両方をチェックします。
+Axios（つまり Inertia.js）はこれを自動で行うため、上記のコードが必要なのは素の
+`fetch` を使う場合だけです。
+
+ミドルウェアは次の 3 か所からこの順にトークンを受け取ります。
+
+1. `X-CSRF-TOKEN` ヘッダー
+2. `XSRF-TOKEN` Cookie から読み取られた `X-XSRF-TOKEN` ヘッダー
+3. urlencoded・multipart・JSON いずれかのリクエストボディの `_token` フィールド
+
+これらの名前は変更できません。Cookie を無効化する場合（後述の `cookie: false`）は、
+`getCsrfToken(ctx)` でトークンをページへ渡し、`X-CSRF-TOKEN` ヘッダーで送信してください。
+ただしこれはセッション認証済みのフローに限ります。ゲストのトークンは Cookie と照合して
+検証されるため、Cookie なしでは成立しません。
 
 ## 設定オプション
 
 ```ts
 createCsrfMiddleware({
-  // カスタムフォームフィールド名（デフォルト: '_csrf'）
-  fieldName: '_token',
-
-  // カスタムヘッダー名（デフォルト: 'X-CSRF-Token'）
-  headerName: 'X-XSRF-Token',
-
   // CSRF 検証から除外するルート
   exclude: ['/api/webhooks/*', '/api/public/*'],
 
@@ -100,6 +112,14 @@ createCsrfMiddleware({
   },
 })
 ```
+
+残りのオプションは通常変更する必要がありません。
+
+| オプション | デフォルト | 用途 |
+|--------|---------|------|
+| `methods` | `['POST', 'PUT', 'PATCH', 'DELETE']` | トークンを要求する HTTP メソッド |
+| `cookie` | `true` | 安全なリクエストと成功した更新系リクエストで `XSRF-TOKEN` Cookie を発行する |
+| `cookieOptions` | `{ path: '/', sameSite: 'Lax' }` | Cookie 属性。`secure` は `NODE_ENV` が `production` のとき、および `process` が無いランタイムで有効 |
 
 ## ルートの除外
 
@@ -138,9 +158,11 @@ export function registerWebRoutes(router: Router): void {
 
 ## トークンの再生成
 
-トークンはセッションに紐づいており、以下の場合に再生成されます。
-- 新しいセッションが作成されたとき
+セッションに紐づくトークンはセッション ID に追随するため、以下の場合に変わります。
+- セッションが最初に永続化されたとき（作成直後のセッションはまだトークンの拠り所になりません）
 - `session.regenerate()` が呼び出されたとき（ログイン後に推奨）
+
+ゲストのトークンはセッション ID を持たず、セッションが生まれるまで再利用されます。
 
 ```ts
 // ログイン成功後
@@ -154,7 +176,7 @@ await session.regenerate()
 1. **常に HTTPS を使用** - HTTP ではトークンが傍受される可能性あり
 2. **ログイン後に再生成** - セッション固定攻撃を防止
 3. **URL にトークンを公開しない** - POST ボディまたはヘッダーを使用
-4. **セキュアな Cookie フラグを設定** - セッションミドルウェアが自動的に処理
+4. **セキュアな Cookie フラグを設定** - セッション Cookie はセッションミドルウェアが処理し、`XSRF-TOKEN` Cookie は `cookieOptions` に従います
 
 ## Inertia.js との統合
 
@@ -166,3 +188,29 @@ axios.defaults.withCredentials = true
 ```
 
 Inertia は自動的に `XSRF-TOKEN` Cookie を読み取り、リクエストに含めます。
+
+### ネイティブフォームではなく Inertia 経由で送信する
+
+対象となるのは、Inertia が Axios 経由で送るリクエストだけです。ネイティブの
+`<form method="post">` は通常のブラウザ遷移として送信され、`X-XSRF-TOKEN` ヘッダーが
+付きません。そのため、フォーム自身が `_token` hidden フィールドを持っていない限り
+Guren は 403 で拒否します。
+
+Inertia のページでは `useForm()` を使ってください。
+
+```tsx
+import { useForm } from '@inertiajs/react'
+
+function LogoutButton() {
+  const { post, processing } = useForm()
+
+  return (
+    <button type="button" onClick={() => post('/logout')} disabled={processing}>
+      ログアウト
+    </button>
+  )
+}
+```
+
+単純なアクションリンクなら `<Link href="/logout" method="post" as="button">` でも構い
+ません。ネイティブフォームは、意図的にフルページ遷移をさせたい場合にだけ使ってください。


### PR DESCRIPTION
## Summary

- Both CSRF guides (`docs/en/guides/csrf.md`, `docs/ja/guides/csrf.md`) documented the wrong form field name (`_csrf` instead of the real `CSRF_FORM_FIELD = '_token'`), two `createCsrfMiddleware` options that don't exist in `CsrfOptions` (`fieldName`, `headerName`), and an AJAX example that read a `meta[name="csrf-token"]` tag nothing in the framework emits — any hand-written form or fetch call following the guide got rejected with a 403.
- Corrected the accepted-token list to match `getTokenFromRequest()`'s actual precedence (`X-CSRF-TOKEN` header → `X-XSRF-TOKEN` header → `_token` body field), replaced the fictional config options with the real ones (`methods`, `cookie`, `cookieOptions`) and their verified defaults, and rewrote the AJAX snippet to read the `XSRF-TOKEN` cookie directly.
- Added guidance that a native `<form method="post">` must carry the `_token` field explicitly, since only Axios/Inertia forward the `XSRF-TOKEN` cookie as the `X-XSRF-TOKEN` header automatically — with `useForm()` / `<Link method="post">` as the Inertia-native alternative.
- Fixed several adjacent claims that were already stale or became inconsistent once the primary fix landed: session middleware is optional (guests get a stateless double-submit token), the Token Regeneration section's session-binding description, and the Security Best Practices bullet about secure cookie flags.
- English and Japanese guides were kept in lockstep (identical heading structure/line counts).

## Verification

- `bun run audit:docs` — passed
- Manual grep sweep for stale `_csrf`/`fieldName`/`headerName`/`csrf-token` references and disallowed doc terms — none found
- All factual claims cross-checked against `packages/server/src/http/middleware/csrf.ts`
- Two independent review passes (Codex + a 4-angle simplify pass: reuse/simplification/efficiency/altitude) applied; findings verified against source before being incorporated

## Known follow-ups (out of scope for this PR)

- `docs/{en,ja}/guides/troubleshoot.md`'s "CSRF token mismatch" entry has the same class of staleness (wrong `getCsrfToken()` call signature, outdated cause description) but wasn't touched here.
- `packages/cli/src/make-auth.ts`'s generated `Layout.tsx` still emits a native `<form method="post" action="/logout">` without a `_token` field — the exact pattern this PR's new guidance warns against. `examples/blog`'s `Layout.tsx` already uses `<Link method="post">` as the fix pattern.
- `scripts/smoke/docs-audit.ts` could gain two cheap negative assertions (`!includes('_csrf')`, `!includes('fieldName:')`) per locale to pin this regression class going forward.