### PR TITLE
fix(cli): make the generated API client CSRF-safe by default

### DIFF
--- a/.changeset/api-client-csrf-token.md
+++ b/.changeset/api-client-csrf-token.md
@@ -1,0 +1,20 @@
+---
+"@guren/cli": patch
+"create-guren-app": patch
+---
+
+Make the generated API client CSRF-safe by default. `createApiClient()` now
+copies the `XSRF-TOKEN` cookie into the `X-XSRF-TOKEN` header on
+state-changing requests, so `client.request('posts.store', { body })` no
+longer gets a 403 from the CSRF middleware that ships enabled by default.
+
+The copy happens only when the request targets the page's own origin — the
+cookie belongs to that origin, and sending it to a third-party `baseUrl`
+would disclose the page's CSRF token. A cross-origin client, or one talking
+to a server configured with `csrf({ cookie: false })`, supplies its own
+`X-XSRF-TOKEN` header; caller-supplied `X-XSRF-TOKEN` / `X-CSRF-TOKEN`
+headers are left untouched whatever their casing. The cookie is read through
+`globalThis`, so the generated module stays import-safe during SSR.
+
+Requests also carry an explicit `credentials: 'same-origin'` — the fetch
+default, now overridable through the new `credentials` option.

--- a/packages/cli/src/api-client-types.ts
+++ b/packages/cli/src/api-client-types.ts
@@ -98,8 +98,64 @@ export type ApiRequestOptions<T extends ApiRouteName> =
     ? { params: ApiRouteParams<T>; body?: unknown; query?: Record<string, unknown> }
     : { params?: never; body?: unknown; query?: Record<string, unknown> }
 
+// The wire contract these mirror is owned by Guren's CSRF middleware: it
+// writes the XSRF-TOKEN cookie and reads either header name. Change them
+// together.
+const XSRF_COOKIE_NAME = 'XSRF-TOKEN'
+const XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+const CSRF_SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS']
+const CSRF_HEADER_NAMES = [XSRF_HEADER_NAME.toLowerCase(), 'x-csrf-token']
+
+/**
+ * Read the \`XSRF-TOKEN\` cookie issued by Guren's CSRF middleware.
+ *
+ * Reached through \`globalThis\` so this module stays importable — and
+ * type-checkable — outside the browser, where \`document\` does not exist.
+ */
+function readXsrfToken(): string | undefined {
+  const cookies = (globalThis as { document?: { cookie?: string } }).document?.cookie
+  if (!cookies) return undefined
+  for (const part of cookies.split(';')) {
+    const entry = part.trim()
+    if (!entry.startsWith(\`$\{XSRF_COOKIE_NAME}=\`)) continue
+    const value = entry.slice(XSRF_COOKIE_NAME.length + 1)
+    try {
+      return decodeURIComponent(value)
+    } catch {
+      return value
+    }
+  }
+  return undefined
+}
+
+/**
+ * Whether \`url\` targets the page's own origin.
+ *
+ * The \`XSRF-TOKEN\` cookie belongs to that origin, so it must never ride along
+ * to a third-party \`baseUrl\`: that would hand this page's CSRF token to
+ * another server, which a permissive CORS policy there is enough to accept.
+ * Outside the browser there is no origin — and no cookie — so nothing is sent.
+ */
+function isSameOrigin(url: string): boolean {
+  const location = (globalThis as { location?: { href?: string; origin?: string } }).location
+  if (!location?.href || !location.origin) return false
+  try {
+    return new URL(url, location.href).origin === location.origin
+  } catch {
+    return false
+  }
+}
+
 /**
  * Create a typed API client for consuming Guren routes.
+ *
+ * Same-origin state-changing requests automatically copy the \`XSRF-TOKEN\`
+ * cookie into the \`X-XSRF-TOKEN\` header, which is what Guren's CSRF
+ * middleware expects. Pass your own \`X-XSRF-TOKEN\` / \`X-CSRF-TOKEN\` header
+ * to opt out — you have to, for a \`baseUrl\` on another origin (the cookie is
+ * never sent there) or for a server configured with \`csrf({ cookie: false })\`.
+ * Cookies follow the \`credentials\` option (\`'same-origin'\` by default; use
+ * \`'include'\` cross-origin, with a CORS setup that allows it).
  *
  * @example
  * \`\`\`typescript
@@ -111,7 +167,7 @@ export type ApiRequestOptions<T extends ApiRouteName> =
  * \`\`\`
  */
 export function createApiClient<TRoutes extends Record<string, { method: string; path: string; params: unknown }>>(
-  config: { baseUrl: string; headers?: Record<string, string> },
+  config: { baseUrl: string; headers?: Record<string, string>; credentials?: RequestInit['credentials'] },
 ) {
   return {
     async request<TName extends keyof TRoutes & string>(
@@ -141,11 +197,23 @@ export function createApiClient<TRoutes extends Record<string, { method: string;
         if (qs) url += \`?$\{qs}\`
       }
 
-      const init: RequestInit = {
-        method: route.method,
-        headers: { 'Content-Type': 'application/json', ...config.headers },
+      const method = route.method.toUpperCase()
+      const headers: Record<string, string> = { 'Content-Type': 'application/json', ...config.headers }
+      if (
+        !CSRF_SAFE_METHODS.includes(method) &&
+        !Object.keys(headers).some((key) => CSRF_HEADER_NAMES.includes(key.toLowerCase())) &&
+        isSameOrigin(url)
+      ) {
+        const token = readXsrfToken()
+        if (token) headers[XSRF_HEADER_NAME] = token
       }
-      if (opts?.body && route.method !== 'GET') {
+
+      const init: RequestInit = {
+        method,
+        headers,
+        credentials: config.credentials ?? 'same-origin',
+      }
+      if (opts?.body && method !== 'GET') {
         init.body = JSON.stringify(opts.body)
       }
 

--- a/packages/cli/templates/agent/.claude/rules/routes-codegen.md
+++ b/packages/cli/templates/agent/.claude/rules/routes-codegen.md
@@ -63,6 +63,10 @@ export interface ApiRoutes {
 
 Only **named** routes are emitted. `output:` schemas add a `response:` field.
 Consume with `createApiClient<ApiRoutes>({ baseUrl })` → `client.request('posts.store', { body })`.
+Mutating requests copy the `XSRF-TOKEN` cookie into the `X-XSRF-TOKEN` header, so a
+same-origin client passes CSRF protection without extra wiring. The token is never
+copied to a `baseUrl` on another origin — that client passes its own `X-XSRF-TOKEN`
+header (and `credentials: 'include'` plus CORS if it needs the session cookie sent).
 
 ## Which Zod constructs survive type extraction
 

--- a/packages/cli/tests/api-client-types.test.ts
+++ b/packages/cli/tests/api-client-types.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, afterAll, afterEach, beforeAll } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { buildApiClientContent, type RouteDefinitionLike } from '../src/api-client-types'
+
+const definitions: RouteDefinitionLike[] = [
+  { method: 'GET', path: '/posts', name: 'posts.index' },
+  { method: 'POST', path: '/posts', name: 'posts.store' },
+]
+
+describe('buildApiClientContent', () => {
+  it('emits the cookie-to-header names the CSRF middleware expects', () => {
+    const content = buildApiClientContent(definitions)
+
+    expect(content).toContain("const XSRF_COOKIE_NAME = 'XSRF-TOKEN'")
+    expect(content).toContain("const XSRF_HEADER_NAME = 'X-XSRF-TOKEN'")
+    // A bare `document.cookie` would need the DOM lib to type-check and would
+    // throw on the server, so the lookup has to go through globalThis. Nothing
+    // else in this file type-checks the emitted source: the create-app
+    // template it lands in is excluded from every tsconfig.
+    expect(content).toContain('(globalThis as { document?: { cookie?: string } }).document?.cookie')
+  })
+})
+
+/**
+ * The generated file is app-facing code, so the assertions above only prove it
+ * mentions the right names. These run it: transpile the emitted TypeScript,
+ * import it, and drive `request()` against a stubbed `document`/`fetch`.
+ */
+describe('generated createApiClient', () => {
+  type CreateApiClient = (config: {
+    baseUrl: string
+    headers?: Record<string, string>
+    credentials?: RequestCredentials
+  }) => { request: (name: string, options?: { body?: unknown }) => Promise<Response> }
+
+  const PAGE_ORIGIN = 'http://localhost:3000'
+  const originalFetch = globalThis.fetch
+  const originalGlobals = globalThis as { document?: unknown; location?: unknown }
+  const restore = { document: originalGlobals.document, location: originalGlobals.location }
+
+  let dir: string
+  let createApiClient: CreateApiClient
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'guren-cli-api-client-'))
+    const source = buildApiClientContent(definitions)
+    const modulePath = join(dir, 'api-client.gen.mjs')
+    await writeFile(modulePath, new Bun.Transpiler({ loader: 'ts' }).transformSync(source), 'utf8')
+    createApiClient = (await import(pathToFileURL(modulePath).href)).createApiClient
+  })
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    for (const key of ['document', 'location'] as const) {
+      if (restore[key] === undefined) delete originalGlobals[key]
+      else originalGlobals[key] = restore[key]
+    }
+  })
+
+  function stubFetch(): { calls: Array<{ url: string; init: RequestInit }> } {
+    const calls: Array<{ url: string; init: RequestInit }> = []
+    globalThis.fetch = ((url: string, init: RequestInit) => {
+      calls.push({ url, init })
+      return Promise.resolve(new Response(null, { status: 204 }))
+    }) as typeof fetch
+    return { calls }
+  }
+
+  /** Bun defines neither global, so a browser has to be stubbed in whole. */
+  function browsingAt(origin: string, cookie: string): void {
+    originalGlobals.document = { cookie }
+    originalGlobals.location = { href: `${origin}/current-page`, origin }
+  }
+
+  function headersOf(init: RequestInit): Record<string, string> {
+    return init.headers as Record<string, string>
+  }
+
+  it('sends the decoded cookie value as X-XSRF-TOKEN on mutating requests', async () => {
+    const { calls } = stubFetch()
+    browsingAt(PAGE_ORIGIN, 'other=1; XSRF-TOKEN=token%2Fwith%2Fslashes; another=2')
+
+    await createApiClient({ baseUrl: PAGE_ORIGIN }).request('posts.store', { body: { title: 'hi' } })
+
+    expect(headersOf(calls[0]!.init)['X-XSRF-TOKEN']).toBe('token/with/slashes')
+    expect(calls[0]!.init.credentials).toBe('same-origin')
+  })
+
+  it('resolves a relative baseUrl against the page', async () => {
+    const { calls } = stubFetch()
+    browsingAt(PAGE_ORIGIN, 'XSRF-TOKEN=abc')
+
+    await createApiClient({ baseUrl: '' }).request('posts.store', { body: {} })
+
+    expect(headersOf(calls[0]!.init)['X-XSRF-TOKEN']).toBe('abc')
+  })
+
+  it('matches the cookie name exactly, not by prefix', async () => {
+    const { calls } = stubFetch()
+    browsingAt(PAGE_ORIGIN, 'NOT-XSRF-TOKEN=wrong; XSRF-TOKEN-OLD=stale; XSRF-TOKEN=right')
+
+    await createApiClient({ baseUrl: PAGE_ORIGIN }).request('posts.store', { body: {} })
+
+    expect(headersOf(calls[0]!.init)['X-XSRF-TOKEN']).toBe('right')
+  })
+
+  it('omits the header on safe methods', async () => {
+    const { calls } = stubFetch()
+    browsingAt(PAGE_ORIGIN, 'XSRF-TOKEN=abc')
+
+    await createApiClient({ baseUrl: PAGE_ORIGIN }).request('posts.index')
+
+    expect(headersOf(calls[0]!.init)['X-XSRF-TOKEN']).toBeUndefined()
+  })
+
+  // The cookie belongs to the page's origin. Attaching it to a caller-supplied
+  // cross-origin baseUrl would disclose this page's CSRF token to that server,
+  // which only needs a permissive CORS policy to collect it.
+  it('never sends the page token to another origin', async () => {
+    const { calls } = stubFetch()
+    browsingAt(PAGE_ORIGIN, 'XSRF-TOKEN=secret')
+
+    await createApiClient({ baseUrl: 'https://third-party.example' }).request('posts.store', { body: {} })
+
+    expect(headersOf(calls[0]!.init)['X-XSRF-TOKEN']).toBeUndefined()
+  })
+
+  // Header names are case-insensitive over the wire, so the caller's spelling
+  // must not decide whether their token survives: matching case-sensitively
+  // either overwrites an explicit token or leaves two conflicting keys behind.
+  for (const headerName of ['X-XSRF-TOKEN', 'x-xsrf-token', 'X-CSRF-TOKEN', 'x-csrf-token']) {
+    it(`keeps a caller-supplied ${headerName} header`, async () => {
+      const { calls } = stubFetch()
+      browsingAt(PAGE_ORIGIN, 'XSRF-TOKEN=from-cookie')
+
+      const client = createApiClient({
+        baseUrl: PAGE_ORIGIN,
+        headers: { [headerName]: 'explicit' },
+      })
+      await client.request('posts.store', { body: {} })
+
+      const headers = headersOf(calls[0]!.init)
+      const tokenHeaders = Object.entries(headers).filter(([key]) => key.toLowerCase().endsWith('srf-token'))
+      expect(tokenHeaders).toEqual([[headerName, 'explicit']])
+    })
+  }
+
+  it('makes no request-time assumptions about document outside the browser', async () => {
+    const { calls } = stubFetch()
+    delete originalGlobals.document
+    delete originalGlobals.location
+
+    await createApiClient({ baseUrl: PAGE_ORIGIN }).request('posts.store', { body: {} })
+
+    expect(headersOf(calls[0]!.init)['X-XSRF-TOKEN']).toBeUndefined()
+  })
+
+  it('honours an explicit credentials mode for cross-origin clients', async () => {
+    const { calls } = stubFetch()
+    browsingAt(PAGE_ORIGIN, 'XSRF-TOKEN=abc')
+
+    const client = createApiClient({ baseUrl: 'https://api.example.com', credentials: 'include' })
+    await client.request('posts.store', { body: {} })
+
+    expect(calls[0]!.init.credentials).toBe('include')
+  })
+})

--- a/packages/create-app/templates/default/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/default/.guren/api-client.gen.ts
@@ -23,8 +23,64 @@ export type ApiRequestOptions<T extends ApiRouteName> =
     ? { params: ApiRouteParams<T>; body?: unknown; query?: Record<string, unknown> }
     : { params?: never; body?: unknown; query?: Record<string, unknown> }
 
+// The wire contract these mirror is owned by Guren's CSRF middleware: it
+// writes the XSRF-TOKEN cookie and reads either header name. Change them
+// together.
+const XSRF_COOKIE_NAME = 'XSRF-TOKEN'
+const XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+const CSRF_SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS']
+const CSRF_HEADER_NAMES = [XSRF_HEADER_NAME.toLowerCase(), 'x-csrf-token']
+
+/**
+ * Read the `XSRF-TOKEN` cookie issued by Guren's CSRF middleware.
+ *
+ * Reached through `globalThis` so this module stays importable — and
+ * type-checkable — outside the browser, where `document` does not exist.
+ */
+function readXsrfToken(): string | undefined {
+  const cookies = (globalThis as { document?: { cookie?: string } }).document?.cookie
+  if (!cookies) return undefined
+  for (const part of cookies.split(';')) {
+    const entry = part.trim()
+    if (!entry.startsWith(`${XSRF_COOKIE_NAME}=`)) continue
+    const value = entry.slice(XSRF_COOKIE_NAME.length + 1)
+    try {
+      return decodeURIComponent(value)
+    } catch {
+      return value
+    }
+  }
+  return undefined
+}
+
+/**
+ * Whether `url` targets the page's own origin.
+ *
+ * The `XSRF-TOKEN` cookie belongs to that origin, so it must never ride along
+ * to a third-party `baseUrl`: that would hand this page's CSRF token to
+ * another server, which a permissive CORS policy there is enough to accept.
+ * Outside the browser there is no origin — and no cookie — so nothing is sent.
+ */
+function isSameOrigin(url: string): boolean {
+  const location = (globalThis as { location?: { href?: string; origin?: string } }).location
+  if (!location?.href || !location.origin) return false
+  try {
+    return new URL(url, location.href).origin === location.origin
+  } catch {
+    return false
+  }
+}
+
 /**
  * Create a typed API client for consuming Guren routes.
+ *
+ * Same-origin state-changing requests automatically copy the `XSRF-TOKEN`
+ * cookie into the `X-XSRF-TOKEN` header, which is what Guren's CSRF
+ * middleware expects. Pass your own `X-XSRF-TOKEN` / `X-CSRF-TOKEN` header
+ * to opt out — you have to, for a `baseUrl` on another origin (the cookie is
+ * never sent there) or for a server configured with `csrf({ cookie: false })`.
+ * Cookies follow the `credentials` option (`'same-origin'` by default; use
+ * `'include'` cross-origin, with a CORS setup that allows it).
  *
  * @example
  * ```typescript
@@ -36,7 +92,7 @@ export type ApiRequestOptions<T extends ApiRouteName> =
  * ```
  */
 export function createApiClient<TRoutes extends Record<string, { method: string; path: string; params: unknown }>>(
-  config: { baseUrl: string; headers?: Record<string, string> },
+  config: { baseUrl: string; headers?: Record<string, string>; credentials?: RequestInit['credentials'] },
 ) {
   return {
     async request<TName extends keyof TRoutes & string>(
@@ -66,11 +122,23 @@ export function createApiClient<TRoutes extends Record<string, { method: string;
         if (qs) url += `?${qs}`
       }
 
-      const init: RequestInit = {
-        method: route.method,
-        headers: { 'Content-Type': 'application/json', ...config.headers },
+      const method = route.method.toUpperCase()
+      const headers: Record<string, string> = { 'Content-Type': 'application/json', ...config.headers }
+      if (
+        !CSRF_SAFE_METHODS.includes(method) &&
+        !Object.keys(headers).some((key) => CSRF_HEADER_NAMES.includes(key.toLowerCase())) &&
+        isSameOrigin(url)
+      ) {
+        const token = readXsrfToken()
+        if (token) headers[XSRF_HEADER_NAME] = token
       }
-      if (opts?.body && route.method !== 'GET') {
+
+      const init: RequestInit = {
+        method,
+        headers,
+        credentials: config.credentials ?? 'same-origin',
+      }
+      if (opts?.body && method !== 'GET') {
         init.body = JSON.stringify(opts.body)
       }
 


### PR DESCRIPTION
## Summary

`bunx guren codegen` emits `.guren/api-client.gen.ts` from the template string in `packages/cli/src/api-client-types.ts`. Its `createApiClient().request()` sent a raw `fetch` with no CSRF token, so any state-changing request (`posts.store`, etc.) issued from a browser hit the 403 that Guren's CSRF middleware returns by default — the client had no way to pass.

- `createApiClient()` now copies the `XSRF-TOKEN` cookie into the `X-XSRF-TOKEN` header on non-safe-method requests, matching what `packages/server/src/http/middleware/csrf.ts` reads.
- The copy only happens when the request targets the **same origin** as the page. The cookie belongs to that origin; attaching it to a caller-supplied cross-origin `baseUrl` would disclose the page's CSRF token to that server (a permissive CORS policy there is all it takes to collect it). A cross-origin client, or one talking to a server configured with `csrf({ cookie: false })`, supplies its own `X-XSRF-TOKEN` header instead.
- A caller-supplied `X-XSRF-TOKEN` / `X-CSRF-TOKEN` header (any casing) is left untouched rather than overwritten or duplicated.
- Cookie and `location` reads go through `globalThis`, so the generated module stays import-safe (and type-checkable without the DOM lib) during SSR.
- Requests now carry an explicit `credentials: 'same-origin'` (the existing fetch default, now overridable via a new `credentials` config option — e.g. `'include'` for a cross-origin client with matching CORS).

The regenerated `packages/create-app/templates/default/.guren/api-client.gen.ts` is a byte-identical copy of `buildApiClientContent([])`'s output, not a hand-edit.

## Review notes

This went through a Codex review pass and a 4-agent simplify pass (reuse / simplification / efficiency / altitude). Codex caught a real cross-origin token-leak bug in the first draft (now fixed with the same-origin gate above); simplify tightened the cookie parsing to `startsWith`, derived `CSRF_HEADER_NAMES` from `XSRF_HEADER_NAME` instead of a second literal, and removed a couple of test assertions that were redundant with the runtime behavioral tests.

## Test plan

- [x] `packages/cli/tests/api-client-types.test.ts` (12 tests): source-string assertions plus runtime tests that transpile the emitted TS, import it, and drive `request()` against a stubbed `document`/`location`/`fetch` — covers cookie decoding, exact-name matching (no prefix-collision false positives), safe-method exclusion, caller header preservation (all 4 casings), same-origin gating, cross-origin token suppression, SSR (`document`/`location` absent), and `credentials` override.
- [x] Mutation-tested: reverting the same-origin gate or the exact cookie-name match each break a test.
- [x] `bun run build:clean`, `bun run typecheck` (clean, including `examples/blog` after running `guren codegen` against the new template), `bun run test:bun cli` (957 pass)
- [x] `bun run audit:core-first`, `bun run audit:docs`, `bun run audit:starter-template`, `bun run smoke:starter` all green