### PR TITLE
fix(cli): make add resource typecheck for date/boolean/json fields

### DIFF
--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -1,6 +1,6 @@
 import { makeAuth } from './make-auth'
 import { makeChannel } from './make-channel'
-import { makeFeature, parseFieldsString, type FieldDefinition } from './make-feature'
+import { makeFeature, parseFieldsString, type FieldDefinition, type FieldType } from './make-feature'
 import { makeController } from './make-controller'
 import { makeEvent } from './make-event'
 import { makeJob } from './make-job'
@@ -699,50 +699,51 @@ async function detectSchemaDialect(content: string): Promise<'sqlite' | 'pg' | '
   return 'pg'
 }
 
-function sqliteColumn(field: FieldDefinition): { code: string; imports: string[] } {
-  const notNull = field.nullable ? '' : '.notNull()'
-  switch (field.type) {
-    case 'number':
-      return { code: `integer('${snakeCase(field.name)}')${notNull}`, imports: ['integer'] }
-    case 'boolean':
-      return { code: `integer('${snakeCase(field.name)}', { mode: 'boolean' })${notNull}`, imports: ['integer'] }
-    case 'json':
-      return { code: `text('${snakeCase(field.name)}', { mode: 'json' })${notNull}`, imports: ['text'] }
-    default:
-      return { code: `text('${snakeCase(field.name)}')${notNull}`, imports: ['text'] }
-  }
+interface ColumnCode {
+  code: string
+  imports: string[]
 }
 
-function pgColumn(field: FieldDefinition): { code: string; imports: string[] } {
-  const notNull = field.nullable ? '' : '.notNull()'
-  switch (field.type) {
-    case 'number':
-      return { code: `integer('${snakeCase(field.name)}')${notNull}`, imports: ['integer'] }
-    case 'boolean':
-      return { code: `boolean('${snakeCase(field.name)}')${notNull}`, imports: ['boolean'] }
-    case 'date':
-      return { code: `timestamp('${snakeCase(field.name)}', { withTimezone: false })${notNull}`, imports: ['timestamp'] }
-    case 'json':
-      return { code: `jsonb('${snakeCase(field.name)}')${notNull}`, imports: ['jsonb'] }
-    default:
-      return { code: `text('${snakeCase(field.name)}')${notNull}`, imports: ['text'] }
-  }
+/**
+ * Per-dialect column builders, keyed by field type.
+ *
+ * The `Record<FieldType, …>` is load-bearing: these used to be switches with a
+ * `default:` arm, which is how sqlite shipped without a `date` case and quietly
+ * emitted a text column for it. A missing key now fails to compile.
+ */
+type ColumnMapping = Record<FieldType, (name: string, notNull: string) => ColumnCode>
+
+const SQLITE_COLUMNS: ColumnMapping = {
+  string: (name, notNull) => ({ code: `text('${name}')${notNull}`, imports: ['text'] }),
+  text: (name, notNull) => ({ code: `text('${name}')${notNull}`, imports: ['text'] }),
+  number: (name, notNull) => ({ code: `integer('${name}')${notNull}`, imports: ['integer'] }),
+  boolean: (name, notNull) => ({ code: `integer('${name}', { mode: 'boolean' })${notNull}`, imports: ['integer'] }),
+  // Timestamp mode keeps the record type a `Date`, matching pg/mysql — a bare
+  // text column would reject the `Date` that `z.coerce.date()` produces.
+  date: (name, notNull) => ({ code: `integer('${name}', { mode: 'timestamp' })${notNull}`, imports: ['integer'] }),
+  json: (name, notNull) => ({ code: `text('${name}', { mode: 'json' })${notNull}`, imports: ['text'] }),
 }
 
-function mysqlColumn(field: FieldDefinition): { code: string; imports: string[] } {
-  const notNull = field.nullable ? '' : '.notNull()'
-  switch (field.type) {
-    case 'number':
-      return { code: `int('${snakeCase(field.name)}')${notNull}`, imports: ['int'] }
-    case 'boolean':
-      return { code: `boolean('${snakeCase(field.name)}')${notNull}`, imports: ['boolean'] }
-    case 'date':
-      return { code: `timestamp('${snakeCase(field.name)}')${notNull}`, imports: ['timestamp'] }
-    case 'json':
-      return { code: `json('${snakeCase(field.name)}')${notNull}`, imports: ['json'] }
-    default:
-      return { code: `varchar('${snakeCase(field.name)}', { length: 255 })${notNull}`, imports: ['varchar'] }
-  }
+const PG_COLUMNS: ColumnMapping = {
+  string: (name, notNull) => ({ code: `text('${name}')${notNull}`, imports: ['text'] }),
+  text: (name, notNull) => ({ code: `text('${name}')${notNull}`, imports: ['text'] }),
+  number: (name, notNull) => ({ code: `integer('${name}')${notNull}`, imports: ['integer'] }),
+  boolean: (name, notNull) => ({ code: `boolean('${name}')${notNull}`, imports: ['boolean'] }),
+  date: (name, notNull) => ({ code: `timestamp('${name}', { withTimezone: false })${notNull}`, imports: ['timestamp'] }),
+  json: (name, notNull) => ({ code: `jsonb('${name}')${notNull}`, imports: ['jsonb'] }),
+}
+
+const MYSQL_COLUMNS: ColumnMapping = {
+  string: (name, notNull) => ({ code: `varchar('${name}', { length: 255 })${notNull}`, imports: ['varchar'] }),
+  text: (name, notNull) => ({ code: `varchar('${name}', { length: 255 })${notNull}`, imports: ['varchar'] }),
+  number: (name, notNull) => ({ code: `int('${name}')${notNull}`, imports: ['int'] }),
+  boolean: (name, notNull) => ({ code: `boolean('${name}')${notNull}`, imports: ['boolean'] }),
+  date: (name, notNull) => ({ code: `timestamp('${name}')${notNull}`, imports: ['timestamp'] }),
+  json: (name, notNull) => ({ code: `json('${name}')${notNull}`, imports: ['json'] }),
+}
+
+function buildColumn(mapping: ColumnMapping, field: FieldDefinition): ColumnCode {
+  return mapping[field.type](snakeCase(field.name), field.nullable ? '' : '.notNull()')
 }
 
 function snakeCase(value: string): string {
@@ -762,7 +763,7 @@ async function updateResourceSchema(collection: string, routeName: string, field
       return
     }
 
-    const columns = fields.map((field) => sqliteColumn(field))
+    const columns = fields.map((field) => buildColumn(SQLITE_COLUMNS, field))
     const imports = [...new Set(['sqliteTable', 'integer', 'text', ...columns.flatMap((c) => c.imports)])]
     content = ensureSqliteImports(content, imports)
 
@@ -775,7 +776,7 @@ async function updateResourceSchema(collection: string, routeName: string, field
       return
     }
 
-    const columns = fields.map((field) => mysqlColumn(field))
+    const columns = fields.map((field) => buildColumn(MYSQL_COLUMNS, field))
     const imports = [...new Set(['mysqlTable', 'int', 'timestamp', ...columns.flatMap((c) => c.imports)])]
     content = ensureMysqlImports(content, imports)
 
@@ -788,7 +789,7 @@ async function updateResourceSchema(collection: string, routeName: string, field
       return
     }
 
-    const columns = fields.map((field) => pgColumn(field))
+    const columns = fields.map((field) => buildColumn(PG_COLUMNS, field))
     const imports = [...new Set(['pgTable', 'serial', 'text', 'timestamp', ...columns.flatMap((c) => c.imports)])]
     content = ensureDrizzleImports(content, imports)
 

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { dirname, relative, resolve, sep as pathSep } from 'node:path'
 import { consola } from 'consola'
 import { writeFilesSafe, type WriterOptions } from './utils'
+import { readIfExists } from './discovery'
 import {
   addImport,
   addProvider,
@@ -1713,7 +1714,15 @@ ${registerRoutes}${resetRoutes}${verifyRoutes}${oauthRoutes}
 `
 }
 
-const seederTemplate = `import { defineSeeder, ScryptHasher } from '@guren/core'
+// Re-running the seeder must not fail on the unique email. MySQL has no
+// `onConflictDoNothing` — INSERT IGNORE is its equivalent, and it is a
+// builder method that has to come before values().
+function buildSeederTemplate(dialect: SchemaDialect): string {
+  const isMysql = dialect === 'mysql'
+  const ignore = isMysql ? '\n    .ignore()' : ''
+  const onConflict = isMysql ? '' : '\n    .onConflictDoNothing({ target: users.email })'
+
+  return `import { defineSeeder, ScryptHasher } from '@guren/core'
 import { users } from '../schema.js'
 
 export default defineSeeder(async ({ db }) => {
@@ -1721,19 +1730,25 @@ export default defineSeeder(async ({ db }) => {
   const passwordHash = await hasher.hash('secret')
 
   await db
-    .insert(users)
+    .insert(users)${ignore}
     .values([
       {
         name: 'Demo User',
         email: 'demo@example.com',
         passwordHash,
       },
-    ])
-    .onConflictDoNothing({ target: users.email })
+    ])${onConflict}
 })
 `
+}
 
 type SchemaDialect = 'sqlite' | 'pg' | 'mysql'
+
+/** Dialect of the project's db/schema.ts, defaulting to pg when there is none yet. */
+async function detectProjectDialect(): Promise<SchemaDialect> {
+  const content = await readIfExists(process.cwd(), 'db/schema.ts')
+  return content === null ? 'pg' : detectSchemaDialect(content)
+}
 
 function detectSchemaDialect(content: string): SchemaDialect {
   if (content.includes('sqliteTable') || content.includes('drizzle-orm/sqlite-core')) {
@@ -2170,8 +2185,9 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
       { path: 'app/Http/Validators/LoginValidator.ts', contents: loginValidatorTemplate },
       // The demo user only exists to be signed in as with a password. Without
       // password login it is an unreachable row — and seeding it would hash a
-      // password with scrypt, the exact cost --oauth-only avoids.
-      { path: 'db/seeders/UsersSeeder.ts', contents: seederTemplate },
+      // password with scrypt, the exact cost --oauth-only avoids. The seeder is
+      // the only dialect-sensitive file here, so the schema is read only now.
+      { path: 'db/seeders/UsersSeeder.ts', contents: buildSeederTemplate(await detectProjectDialect()) },
     )
   }
 

--- a/packages/cli/src/make-feature.ts
+++ b/packages/cli/src/make-feature.ts
@@ -4,9 +4,13 @@ import { makeModel } from './make-model'
 import { makePolicy } from './make-policy'
 import { makeTest } from './make-test'
 
+export const FIELD_TYPES = ['string', 'number', 'boolean', 'text', 'date', 'json'] as const
+
+export type FieldType = (typeof FIELD_TYPES)[number]
+
 export interface FieldDefinition {
   name: string
-  type: 'string' | 'number' | 'boolean' | 'text' | 'date' | 'json'
+  type: FieldType
   nullable?: boolean
 }
 
@@ -39,12 +43,18 @@ export function parseFieldsString(fieldsStr: string): FieldDefinition[] {
 
     if (!name) throw new Error(`Invalid field definition: "${field}"`)
 
-    const validTypes = ['string', 'number', 'boolean', 'text', 'date', 'json']
-    if (!validTypes.includes(type)) {
-      throw new Error(`Invalid field type "${type}" for field "${name}". Valid: ${validTypes.join(', ')}`)
+    // The name is interpolated raw into interfaces, object literals, and
+    // property access, so anything that is not an identifier would emit
+    // generated code that does not parse.
+    if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/u.test(name)) {
+      throw new Error(`Invalid field name "${name}". Field names must be valid JavaScript identifiers.`)
     }
 
-    return { name, type: type as FieldDefinition['type'], nullable }
+    if (!(FIELD_TYPES as readonly string[]).includes(type)) {
+      throw new Error(`Invalid field type "${type}" for field "${name}". Valid: ${FIELD_TYPES.join(', ')}`)
+    }
+
+    return { name, type: type as FieldType, nullable }
   })
 }
 
@@ -95,7 +105,7 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
     },
     {
       path: `resources/js/pages/${pagePrefix}${routeName}/Edit.tsx`,
-      contents: generateEditPage(singular, routeName, variableName, fields),
+      contents: generateEditPage(singular, routeName, variableName, fields, appPrefix),
     },
   ], writerOptions)
 
@@ -177,45 +187,139 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
 
 // --- Template generators ---
 
-function drizzleColumnType(field: FieldDefinition): string {
-  const map: Record<string, string> = {
-    string: 'text',
-    text: 'text',
-    number: 'integer',
-    boolean: 'boolean',
-    date: 'timestamp',
-    json: 'jsonb',
-  }
-  const col = map[field.type] ?? 'text'
-  const nullable = field.nullable ? '' : '.notNull()'
-  return `${field.name}: ${col}('${field.name}')${nullable}`
+// Keyed by FieldType rather than string so a new field type fails to compile
+// until every mapping below covers it — a silent `?? 'string'` fallback is how
+// a type ends up generating code for the wrong column shape.
+const ZOD_SCHEMAS: Record<FieldType, string> = {
+  string: 'z.string().trim().min(1)',
+  text: 'z.string().trim().min(1)',
+  number: 'z.coerce.number()',
+  boolean: 'z.boolean()',
+  date: 'z.coerce.date()',
+  json: 'z.record(z.string(), z.unknown())',
+}
+
+const TS_TYPES: Record<FieldType, string> = {
+  string: 'string',
+  text: 'string',
+  number: 'number',
+  boolean: 'boolean',
+  date: 'string',
+  json: 'Record<string, unknown>',
 }
 
 function zodFieldType(field: FieldDefinition): string {
-  const map: Record<string, string> = {
-    string: 'z.string().trim().min(1)',
-    text: 'z.string().trim().min(1)',
-    number: 'z.coerce.number()',
-    boolean: 'z.boolean()',
-    date: 'z.coerce.date()',
-    json: 'z.record(z.unknown())',
-  }
-  let schema = map[field.type] ?? 'z.string()'
-  if (field.nullable) schema += '.nullable().optional()'
-  return schema
+  const schema = ZOD_SCHEMAS[field.type]
+  return field.nullable ? `${schema}.nullable().optional()` : schema
 }
 
 function tsFieldType(field: FieldDefinition): string {
-  const map: Record<string, string> = {
-    string: 'string',
-    text: 'string',
-    number: 'number',
-    boolean: 'boolean',
-    date: 'string',
-    json: 'Record<string, unknown>',
-  }
-  const base = map[field.type] ?? 'string'
+  const base = TS_TYPES[field.type]
   return field.nullable ? `${base} | null` : base
+}
+
+/**
+ * Expression that reads a column off the model record and returns it in the
+ * JSON-serializable shape `tsFieldType()` promises.
+ *
+ * Date columns are the only ones that need real work: the record type is a
+ * `Date` on postgres/mysql/sqlite timestamp columns, so it has to be turned
+ * into an ISO string explicitly. The `string | number | Date` cast keeps the
+ * expression valid whichever representation the column was hand-edited to.
+ */
+function resourceValueExpression(field: FieldDefinition): string {
+  const source = `this.resource.${field.name}`
+
+  if (field.type === 'date') {
+    const iso = `new Date(${source} as string | number | Date).toISOString()`
+    return field.nullable ? `${source} == null ? null : ${iso}` : iso
+  }
+
+  return field.nullable
+    ? `(${source} as ${tsFieldType(field)}) ?? null`
+    : `${source} as ${tsFieldType(field)}`
+}
+
+/**
+ * Expression that renders a `ResourceData` field as page text. Booleans read
+ * better as Yes/No, and objects are not valid `ReactNode`s.
+ */
+function resourceDisplayExpression(field: FieldDefinition, variableName: string): string {
+  const access = `${variableName}.${field.name}`
+
+  if (field.type === 'boolean') return `${access} ? 'Yes' : 'No'`
+  if (field.type === 'json') return `JSON.stringify(${access})`
+  return field.nullable ? `${access} ?? ''` : access
+}
+
+/**
+ * The form data type for the New/Edit pages.
+ *
+ * It is the route's request body type, except that `json` fields are edited as
+ * raw JSON text: an object value fails Inertia's `FormDataType` constraint
+ * (`unknown` is not `FormDataConvertible`) and cannot back a textarea, so the
+ * form holds the source text and `submitStatements()` parses it on submit.
+ */
+function formDataType(routeName: string, fields: FieldDefinition[]): string {
+  const body = `ApiRoutes['${routeName}.store']['body']`
+  const jsonFields = fields.filter((f) => f.type === 'json')
+  if (jsonFields.length === 0) return body
+
+  const omitted = jsonFields.map((f) => `'${f.name}'`).join(' | ')
+  const overrides = jsonFields.map((f) => `${f.name}: string`).join('; ')
+  return `Omit<${body}, ${omitted}> & { ${overrides} }`
+}
+
+/**
+ * The `onSubmit` attribute for the New/Edit form.
+ *
+ * With no json fields this is the one-liner it has always been. json fields
+ * hold source text that has to become an object before it is sent, and a typo
+ * in that text must surface as a form error rather than an exception thrown out
+ * of the handler — so those pages get a block body that parses first and
+ * installs the transform only once every field parsed.
+ */
+function submitHandler(fields: FieldDefinition[], submitCall: string): string {
+  const jsonFields = fields.filter((f) => f.type === 'json')
+
+  if (jsonFields.length === 0) {
+    return `onSubmit={(event) => { event.preventDefault(); ${submitCall} }}`
+  }
+
+  const parses = jsonFields.map((f) => {
+    const parse = f.nullable
+      ? `form.data.${f.name} ? JSON.parse(form.data.${f.name}) : null`
+      : `JSON.parse(form.data.${f.name})`
+    return `        let ${f.name}: unknown
+        try {
+          ${f.name} = ${parse}
+        } catch {
+          form.setError('${f.name}', 'Enter valid JSON.')
+          return
+        }`
+  }).join('\n')
+
+  const overrides = jsonFields.map((f) => f.name).join(', ')
+
+  return `onSubmit={(event) => {
+        event.preventDefault()
+${parses}
+        form.transform((data) => ({ ...data, ${overrides} }))
+        ${submitCall}
+      }}`
+}
+
+/** Module-level helpers the generated form fields call. */
+function formPageHelpers(fields: FieldDefinition[]): string {
+  if (!fields.some((f) => f.type === 'date')) return ''
+
+  return `
+function toDateInputValue(value: Date | string | null | undefined): string {
+  if (!value) return ''
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? '' : date.toISOString().slice(0, 10)
+}
+`
 }
 
 function generateValidator(singular: string, collection: string, fields: FieldDefinition[]): string {
@@ -246,12 +350,7 @@ function generateResource(singular: string, fields: FieldDefinition[]): string {
 
   const toArrayFields = [
     '      id: this.resource.id as number,',
-    ...fields.map((f) => {
-      if (f.nullable) {
-        return `      ${f.name}: (this.resource.${f.name} as ${tsFieldType(f)}) ?? null,`
-      }
-      return `      ${f.name}: this.resource.${f.name} as ${tsFieldType(f)},`
-    }),
+    ...fields.map((f) => `      ${f.name}: ${resourceValueExpression(f)},`),
   ].join('\n')
 
   return `import { Resource } from '@guren/core'
@@ -377,8 +476,8 @@ function generateIndexPage(
   fields: FieldDefinition[],
   appPrefix: string,
 ): string {
-  const titleField = fields[0]?.name ?? 'id'
-  const summaryField = fields.length > 1 ? fields[1]?.name : null
+  const titleField = fields[0] ? resourceDisplayExpression(fields[0], variableName) : `${variableName}.id`
+  const summaryField = fields[1] ? resourceDisplayExpression(fields[1], variableName) : null
 
   return `import { Link } from '@inertiajs/react'
 import type { PaginatedPageProps } from '@guren/core'
@@ -397,8 +496,8 @@ export default function ${collection}Index({ data, pagination }: Props) {
       <div className="space-y-4">
         {data.map((${variableName}) => (
           <article key={${variableName}.id} className="rounded border p-4">
-            <Link href={route('${routeName}.show', { id: ${variableName}.id })} className="text-xl font-medium">{${variableName}.${titleField}}</Link>
-${summaryField ? `            <p className="mt-2 text-sm text-zinc-600">{${variableName}.${summaryField} ?? ''}</p>` : ''}
+            <Link href={route('${routeName}.show', { id: ${variableName}.id })} className="text-xl font-medium">{${titleField}}</Link>
+${summaryField ? `            <p className="mt-2 text-sm text-zinc-600">{${summaryField}}</p>` : ''}
           </article>
         ))}
       </div>
@@ -424,12 +523,9 @@ function generateShowPage(
   fields: FieldDefinition[],
   appPrefix: string,
 ): string {
-  const fieldRenders = fields.map((f) => {
-    if (f.type === 'boolean') {
-      return `      <p><strong>${f.name}:</strong> {${variableName}.${f.name} ? 'Yes' : 'No'}</p>`
-    }
-    return `      <p><strong>${f.name}:</strong> {${variableName}.${f.name}${f.nullable ? " ?? ''" : ''}}</p>`
-  }).join('\n')
+  const fieldRenders = fields
+    .map((f) => `      <p><strong>${f.name}:</strong> {${resourceDisplayExpression(f, variableName)}}</p>`)
+    .join('\n')
 
   return `import { Link } from '@inertiajs/react'
 import type { ${singular}ResourceData } from '@/${appPrefix}app/Http/Resources/${singular}Resource'
@@ -467,24 +563,22 @@ function generateNewPage(
   routeName: string,
   fields: FieldDefinition[],
 ): string {
-  const defaults = fields.map((f) => {
-    const defaultVal = f.type === 'boolean' ? 'false' : f.type === 'number' ? '0' : "''"
-    return `${f.name}: ${defaultVal}`
-  }).join(', ')
+  const defaults = fields.map((f) => `${f.name}: ${newPageDefault(f)}`).join(', ')
 
   const formFields = fields.map((f) => generateFormField(f, 'form')).join('\n')
+  const onSubmit = submitHandler(fields, `form.post(route('${routeName}.store'))`)
 
   return `import { useForm } from '@inertiajs/react'
 import type { ApiRoutes } from '@/.guren/api-client.gen'
 import { route } from '@/.guren/routes.gen'
 
-type ${singular}FormData = ApiRoutes['${routeName}.store']['body']
-
+type ${singular}FormData = ${formDataType(routeName, fields)}
+${formPageHelpers(fields)}
 export default function New${singular}() {
   const form = useForm<${singular}FormData>({ ${defaults} })
   return (
     <main className="mx-auto max-w-3xl px-6 py-12">
-      <form className="space-y-4" onSubmit={(event) => { event.preventDefault(); form.post(route('${routeName}.store')) }}>
+      <form className="space-y-4" ${onSubmit}>
 ${formFields}
         <button type="submit" className="rounded bg-black px-4 py-2 text-white">Create</button>
       </form>
@@ -499,31 +593,31 @@ function generateEditPage(
   routeName: string,
   variableName: string,
   fields: FieldDefinition[],
+  appPrefix: string,
 ): string {
-  const defaults = fields.map((f) => {
-    const defaultVal = f.nullable ? ` ?? ${f.type === 'boolean' ? 'false' : f.type === 'number' ? '0' : "''"}` : ''
-    return `${f.name}: ${variableName}.${f.name}${defaultVal}`
-  }).join(', ')
+  const defaults = fields.map((f) => `${f.name}: ${editPageDefault(f, variableName)}`).join(', ')
 
   const formFields = fields.map((f) => generateFormField(f, 'form')).join('\n')
+  const onSubmit = submitHandler(fields, `form.put(route('${routeName}.update', { id: ${variableName}.id }))`)
 
   return `import { useForm } from '@inertiajs/react'
 import type { ApiRoutes } from '@/.guren/api-client.gen'
 import type { RouteErrors } from '@guren/inertia-client/typed-forms'
+import type { ${singular}ResourceData } from '@/${appPrefix}app/Http/Resources/${singular}Resource'
 import { route } from '@/.guren/routes.gen'
 
-type ${singular}FormData = ApiRoutes['${routeName}.store']['body']
+type ${singular}FormData = ${formDataType(routeName, fields)}
 
 interface Props {
-  ${variableName}: ${singular}FormData & { id: number }
+  ${variableName}: ${singular}ResourceData
   errors?: RouteErrors<${singular}FormData> & { message?: string }
 }
-
+${formPageHelpers(fields)}
 export default function Edit${singular}({ ${variableName} }: Props) {
   const form = useForm<${singular}FormData>({ ${defaults} })
   return (
     <main className="mx-auto max-w-3xl px-6 py-12">
-      <form className="space-y-4" onSubmit={(event) => { event.preventDefault(); form.put(route('${routeName}.update', { id: ${variableName}.id })) }}>
+      <form className="space-y-4" ${onSubmit}>
 ${formFields}
         <button type="submit" className="rounded bg-black px-4 py-2 text-white">Save</button>
       </form>
@@ -531,6 +625,43 @@ ${formFields}
   )
 }
 `
+}
+
+/** Initial form value for a field on the New page. */
+function newPageDefault(field: FieldDefinition): string {
+  switch (field.type) {
+    case 'boolean':
+      return 'false'
+    case 'number':
+      return '0'
+    case 'date':
+      // The form data type is the route body type, so this is a real `Date`
+      // — Inertia serializes it to an ISO string that `z.coerce.date()` reads.
+      return field.nullable ? 'null' : 'new Date()'
+    case 'json':
+      return field.nullable ? "''" : "'{}'"
+    default:
+      return "''"
+  }
+}
+
+/** Initial form value for a field on the Edit page, read off the resource props. */
+function editPageDefault(field: FieldDefinition, variableName: string): string {
+  const access = `${variableName}.${field.name}`
+
+  switch (field.type) {
+    case 'date':
+      // `ResourceData` carries dates as ISO strings; the form wants a `Date`.
+      return field.nullable ? `${access} ? new Date(${access}) : null` : `new Date(${access})`
+    case 'json':
+      return field.nullable ? `${access} ? JSON.stringify(${access}) : ''` : `JSON.stringify(${access})`
+    case 'boolean':
+      return field.nullable ? `${access} ?? false` : access
+    case 'number':
+      return field.nullable ? `${access} ?? 0` : access
+    default:
+      return field.nullable ? `${access} ?? ''` : access
+  }
 }
 
 function generateFormField(field: FieldDefinition, formVar: string): string {
@@ -551,7 +682,18 @@ function generateFormField(field: FieldDefinition, formVar: string): string {
     return `        <input type="number" value={${numberValue}} onChange={(event) => ${formVar}.setData('${field.name}', Number(event.target.value))} placeholder="${field.name}" className="w-full rounded border px-3 py-2" />`
   }
   if (field.type === 'date') {
-    return `        <input type="date" value={${stringValue}} onChange={(event) => ${formVar}.setData('${field.name}', event.target.value)} className="w-full rounded border px-3 py-2" />`
+    // A cleared required input would set an invalid Date, which serializes to
+    // null and which `z.coerce.date()` then reads as the epoch — `required`
+    // keeps the browser from submitting that instead of storing 1970-01-01.
+    const onChange = field.nullable
+      ? `event.target.value ? new Date(event.target.value) : null`
+      : `new Date(event.target.value)`
+    const required = field.nullable ? '' : ' required'
+    return `        <input type="date"${required} value={toDateInputValue(${formVar}.data.${field.name})} onChange={(event) => ${formVar}.setData('${field.name}', ${onChange})} className="w-full rounded border px-3 py-2" />`
+  }
+  if (field.type === 'json') {
+    // The form holds JSON source text; onSubmit parses it back into an object.
+    return `        <textarea value={${stringValue}} onChange={(event) => ${formVar}.setData('${field.name}', event.target.value)} placeholder="${field.name} (JSON)" className="w-full rounded border px-3 py-2 font-mono text-sm" />`
   }
   return `        <input value={${stringValue}} onChange={(event) => ${formVar}.setData('${field.name}', event.target.value)} placeholder="${field.name}" className="w-full rounded border px-3 py-2" />`
 }

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -3,6 +3,24 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { createTempWorkspace, type TempWorkspace } from './helpers'
 import { listBlueprints, runBlueprint } from '../src/blueprints'
 
+const ROUTES_FIXTURE = `import { Router } from '@guren/core'
+
+export function registerWebRoutes(router: Router): void {
+  router.get('/', () => 'home')
+}
+
+export default registerWebRoutes
+`
+
+/** Minimum project shape the resource blueprint patches into. */
+async function seedWorkspace(schema: string): Promise<void> {
+  await mkdir('resources/js/pages', { recursive: true })
+  await mkdir('routes', { recursive: true })
+  await mkdir('db', { recursive: true })
+  await writeFile('routes/web.ts', ROUTES_FIXTURE)
+  await writeFile('db/schema.ts', schema)
+}
+
 describe('blueprints', () => {
   let workspace: TempWorkspace
 
@@ -32,18 +50,7 @@ describe('blueprints', () => {
   })
 
   it('runs the resource blueprint', async () => {
-    await mkdir('resources/js/pages', { recursive: true })
-    await mkdir('routes', { recursive: true })
-    await mkdir('db', { recursive: true })
-    await writeFile('routes/web.ts', `import { Router } from '@guren/core'
-
-export function registerWebRoutes(router: Router): void {
-  router.get('/', () => 'home')
-}
-
-export default registerWebRoutes
-`)
-    await writeFile('db/schema.ts', `import { pgTable, serial, text, timestamp } from '@guren/orm/drizzle'
+    await seedWorkspace(`import { pgTable, serial, text, timestamp } from '@guren/orm/drizzle'
 
 export const users = pgTable('users', {
   id: serial('id').primaryKey(),
@@ -84,6 +91,86 @@ export const users = pgTable('users', {
     await expect(runBlueprint('unknown')).rejects.toThrow('Unknown blueprint')
   })
 
+  // Every field type has to map to a column in every dialect. A missing case
+  // silently falls through to the text/varchar default, which then rejects the
+  // value the generated validator produces (a `date` field is the example: a
+  // bare text column cannot take the `Date` from `z.coerce.date()`).
+  //
+  // The sqlite and postgres golden-path smokes typecheck a real app scaffolded
+  // with all of these; this covers the mysql mapper the same way at the unit
+  // level so it cannot drift while its smoke is unavailable.
+  const ALL_FIELDS = 'name:string,body:text,count:number,active:boolean,publishedAt:date,meta:json'
+
+  const COLUMN_CASES = [
+    {
+      dialect: 'sqlite',
+      schema: `import { sqliteTable, integer, text } from '@guren/orm/drizzle'
+
+export const users = sqliteTable('users', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  name: text('name').notNull(),
+})
+`,
+      columns: [
+        "name: text('name').notNull()",
+        "body: text('body').notNull()",
+        "count: integer('count').notNull()",
+        "active: integer('active', { mode: 'boolean' }).notNull()",
+        "publishedAt: integer('published_at', { mode: 'timestamp' }).notNull()",
+        "meta: text('meta', { mode: 'json' }).notNull()",
+      ],
+    },
+    {
+      dialect: 'mysql',
+      schema: `import { mysqlTable, int, varchar } from '@guren/orm/drizzle'
+
+export const users = mysqlTable('users', {
+  id: int('id').primaryKey().autoincrement(),
+  name: varchar('name', { length: 255 }).notNull(),
+})
+`,
+      columns: [
+        "name: varchar('name', { length: 255 }).notNull()",
+        "body: varchar('body', { length: 255 }).notNull()",
+        "count: int('count').notNull()",
+        "active: boolean('active').notNull()",
+        "publishedAt: timestamp('published_at').notNull()",
+        "meta: json('meta').notNull()",
+      ],
+    },
+    {
+      dialect: 'postgres',
+      schema: `import { pgTable, serial, text } from '@guren/orm/drizzle'
+
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  name: text('name').notNull(),
+})
+`,
+      columns: [
+        "name: text('name').notNull()",
+        "body: text('body').notNull()",
+        "count: integer('count').notNull()",
+        "active: boolean('active').notNull()",
+        "publishedAt: timestamp('published_at', { withTimezone: false }).notNull()",
+        "meta: jsonb('meta').notNull()",
+      ],
+    },
+  ] as const
+
+  for (const { dialect, schema: fixture, columns } of COLUMN_CASES) {
+    it(`maps every field type to a ${dialect} column`, async () => {
+      await seedWorkspace(fixture)
+
+      await runBlueprint('resource', { name: 'Entry', fields: ALL_FIELDS })
+
+      const schema = await readFile('db/schema.ts', 'utf8')
+      for (const column of columns) {
+        expect(schema).toContain(column)
+      }
+    })
+  }
+
   it('runs the infrastructure blueprints', async () => {
     await mkdir('src', { recursive: true })
     await mkdir('routes', { recursive: true })
@@ -96,14 +183,7 @@ const app = createApp({
 
 export default app
 `)
-    await writeFile('routes/web.ts', `import { Router } from '@guren/core'
-
-export function registerWebRoutes(router: Router): void {
-  router.get('/', () => 'home')
-}
-
-export default registerWebRoutes
-`)
+    await writeFile('routes/web.ts', ROUTES_FIXTURE)
 
     const adminFiles = await runBlueprint('admin')
     const queueFiles = await runBlueprint('queue')

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -1038,4 +1038,32 @@ export function registerWebRoutes(router: Router): void {
       await workspace.cleanup()
     }
   })
+
+  // The seeder has to be re-runnable, and `onConflictDoNothing` does not exist
+  // on MySQL — INSERT IGNORE is its equivalent.
+  for (const [dialect, table, expected, absent] of [
+    ['mysql', 'mysqlTable', '.ignore()', '.onConflictDoNothing'],
+    ['pg', 'pgTable', '.onConflictDoNothing({ target: users.email })', '.ignore()'],
+    ['sqlite', 'sqliteTable', '.onConflictDoNothing({ target: users.email })', '.ignore()'],
+  ] as const) {
+    it(`seeds the demo user with the ${dialect} conflict clause`, async () => {
+      const workspace = await createTempWorkspace(`guren-cli-make-auth-seeder-${dialect}-`)
+      try {
+        await mkdir(join(workspace.dir, 'db'), { recursive: true })
+        await writeFile(
+          join(workspace.dir, 'db/schema.ts'),
+          `export const users = ${table}('users', {})\n`,
+          'utf8',
+        )
+
+        await makeAuth({ force: true })
+
+        const seeder = await readFile(join(workspace.dir, 'db/seeders/UsersSeeder.ts'), 'utf8')
+        expect(seeder).toContain(expected)
+        expect(seeder).not.toContain(absent)
+      } finally {
+        await workspace.cleanup()
+      }
+    })
+  }
 })

--- a/packages/cli/tests/make-feature.test.ts
+++ b/packages/cli/tests/make-feature.test.ts
@@ -148,6 +148,55 @@ describe('makeFeature', () => {
     }
   })
 
+  // A `date` column is a `Date` on the record but an ISO string over the wire,
+  // and a `json` column cannot back a controlled input or be rendered as a
+  // ReactNode. The golden-path smokes typecheck a real app scaffolded with
+  // these; the assertions below pin the specific conversions down.
+  it('converts date and json fields at every boundary', async () => {
+    const workspace = await createTempWorkspace('guren-cli-feature-date-json-')
+
+    try {
+      await makeFeature('Entry', { fields: 'publishedAt:date,meta:json' })
+
+      const validator = await readFile(join(workspace.dir, 'app/Http/Validators/EntryValidator.ts'), 'utf8')
+      // zod v4 requires the key schema — `z.record(z.unknown())` is a type error.
+      expect(validator).toContain('meta: z.record(z.string(), z.unknown())')
+
+      const resource = await readFile(join(workspace.dir, 'app/Http/Resources/EntryResource.ts'), 'utf8')
+      expect(resource).toContain('publishedAt: string')
+      expect(resource).toContain('publishedAt: new Date(this.resource.publishedAt as string | number | Date).toISOString()')
+
+      const showPage = await readFile(join(workspace.dir, 'resources/js/pages/entries/Show.tsx'), 'utf8')
+      expect(showPage).toContain('{JSON.stringify(entry.meta)}')
+
+      for (const page of ['New', 'Edit']) {
+        const source = await readFile(join(workspace.dir, `resources/js/pages/entries/${page}.tsx`), 'utf8')
+        // json fields are edited as raw text: an object value fails Inertia's
+        // FormDataType constraint, so the form holds the source and parses on submit.
+        expect(source).toContain("type EntryFormData = Omit<ApiRoutes['entries.store']['body'], 'meta'> & { meta: string }")
+        // A typo in the JSON textarea must surface as a form error, not throw
+        // out of the submit handler.
+        expect(source).toContain('meta = JSON.parse(form.data.meta)')
+        expect(source).toContain("form.setError('meta', 'Enter valid JSON.')")
+        expect(source).toContain('form.transform((data) => ({ ...data, meta }))')
+        expect(source).toContain('value={toDateInputValue(form.data.publishedAt)}')
+        expect(source).toContain("form.setData('publishedAt', new Date(event.target.value))")
+        // Clearing a required date would otherwise submit an invalid Date,
+        // which `z.coerce.date()` reads as the epoch.
+        expect(source).toContain('<input type="date" required')
+      }
+
+      // Edit receives what the controller actually sends — the resource — not
+      // the request body type, which diverges from it for date fields.
+      const editPage = await readFile(join(workspace.dir, 'resources/js/pages/entries/Edit.tsx'), 'utf8')
+      expect(editPage).toContain('entry: EntryResourceData')
+      expect(editPage).toContain('publishedAt: new Date(entry.publishedAt)')
+      expect(editPage).toContain('meta: JSON.stringify(entry.meta)')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('scaffolds app/ files under modules/<name>/ but namespaces pages instead of colocating them (--module)', async () => {
     const workspace = await createTempWorkspace('guren-cli-feature-module-')
 

--- a/scripts/smoke-golden-path.sh
+++ b/scripts/smoke-golden-path.sh
@@ -31,6 +31,10 @@ CREATE_APP_BIN="$REPO_ROOT/packages/create-app/src/cli.ts"
 # Database driver for the scaffolded app. "postgres" expects a reachable
 # server (default: the repo docker-compose instance on port 54322 — run
 # `bun run db:up` locally; CI maps its service container to the same port).
+#
+# There is no "mysql" variant: db:reset followed by db:seed replays migrations
+# against existing tables on MySQL, so the runtime steps below cannot pass yet.
+# `mysqlColumn()` is covered by unit tests in packages/cli/tests instead.
 SMOKE_DB="${GUREN_SMOKE_DB:-sqlite}"
 
 if [ "$SMOKE_DB" = "postgres" ]; then
@@ -195,7 +199,10 @@ fi
 # ---------------------------------------------------------------------------
 step 9 "Add resource scaffold (comments)"
 
-(cd "$APP_DIR" && bun "$CLI_BIN" add resource comments --fields "body:text,postId:number")
+# The field list covers every branch of the dialect column mappers
+# (text/number/boolean/date/json) so the typecheck below is what catches
+# generated code that only compiles for the simplest column types.
+(cd "$APP_DIR" && bun "$CLI_BIN" add resource comments --fields "body:text,postId:number,published:boolean,publishedAt:date,meta:json")
 
 # ---------------------------------------------------------------------------
 # Step 10: Add infrastructure add-on — queue
@@ -422,6 +429,42 @@ if ! printf '%s' "$POSTS_BODY" | grep -q "Golden path runtime"; then
   exit 1
 fi
 echo "  OK: GET /posts contains created post"
+
+# The token rotates on each accepted request, so re-read it from the jar the
+# previous POST just rewrote.
+XSRF=$(awk '$6 == "XSRF-TOKEN" { print $7 }' "$COOKIES")
+
+# The comments resource carries every column type. Typechecking the generated
+# code does not prove a `Date` or a JSON object survives the round trip through
+# the dialect's timestamp/json columns — this write does.
+http_expect "POST /comments (date + json payload)" 303 \
+  -b "$COOKIES" -c "$COOKIES" -X POST "$RUNTIME_URL/comments" \
+  -H "Content-Type: application/json" -H "X-XSRF-TOKEN: $XSRF" \
+  -d '{"body":"typed columns","postId":1,"published":true,"publishedAt":"2026-02-03T00:00:00.000Z","meta":{"origin":"golden-path-json"}}'
+
+COMMENTS_BODY=$(curl -s -b "$COOKIES" "$RUNTIME_URL/comments")
+if ! printf '%s' "$COMMENTS_BODY" | grep -q "typed columns"; then
+  echo "ERROR: GET /comments does not contain the created comment"
+  exit 1
+fi
+# The json column must come back as an object, not as the string "[object
+# Object]" a text column would have stored.
+if ! printf '%s' "$COMMENTS_BODY" | grep -q "golden-path-json"; then
+  echo "ERROR: GET /comments did not round-trip the json column"
+  printf '%s\n' "$COMMENTS_BODY" | head -40
+  exit 1
+fi
+# The resource serializes date columns as ISO strings. sqlite's timestamp-mode
+# integer round-trips the instant exactly, but postgres `timestamp without time
+# zone` shifts it by the server's UTC offset, so the day is asserted loosely —
+# what this checks is that a Date went in and a Date came back, not that the
+# two dialects agree on the instant.
+if ! printf '%s' "$COMMENTS_BODY" | grep -qE '2026-02-0[23]T[0-9]{2}:[0-9]{2}:[0-9]{2}'; then
+  echo "ERROR: GET /comments did not round-trip the date column"
+  printf '%s\n' "$COMMENTS_BODY" | head -40
+  exit 1
+fi
+echo "  OK: GET /comments round-tripped date and json columns"
 
 # Security defaults
 http_expect "POST /posts (no CSRF token)" 403 \


### PR DESCRIPTION
## Summary

`guren add resource <name> --fields "...:date"` / `"...:json"` generated an app that failed `bun run typecheck` in every SQL dialect.

Root causes fixed:

- `sqliteColumn()` had no `date` case and fell through to `text`, so the record type (`string`) rejected the `Date` produced by `z.coerce.date()`.
- `Resource.toArray()` cast a `Date` column straight to `string` (`TS2352`).
- `z.record(z.unknown())` needs a key schema under zod v4 (`TS2554`).
- Generated New/Edit pages couldn't put an object value through Inertia's `FormDataType` constraint, and Show/Index rendered a json field as a `ReactNode`.
- The Edit page's `Props` used the request-body type instead of the `ResourceData` the controller actually sends — the two only coincided by accident for text/number fields.

## What changed

- **`packages/cli/src/blueprints.ts`**: per-dialect column mappers are now `Record<FieldType, ...>` instead of switches with a `default:` arm — the shape that let sqlite ship without a `date` case. A missing key now fails to compile (verified by mutation: adding a field type breaks the build in all five mapping sites).
- **`packages/cli/src/make-feature.ts`**: date columns round-trip as ISO strings; json fields are edited as raw text and parsed on submit, with `form.setError(...)` on invalid JSON instead of an uncaught exception; non-nullable date inputs are `required` so clearing one can't silently submit the epoch; Edit page `Props` now matches what the controller sends; field names are validated as identifiers.
- **`packages/cli/src/make-auth.ts`**: the demo-user seeder is dialect-aware — MySQL has no `onConflictDoNothing`, so it uses `.ignore()` there. Found while checking the fix against every dialect.
- **`scripts/smoke-golden-path.sh`**: both golden paths (sqlite, postgres) now scaffold a resource covering every field type and `POST` a date+json payload to prove the value actually round-trips through the database, not just that the generated code typechecks.
- Tests added/reworked in `packages/cli/tests/{blueprints,make-feature,make-auth}.test.ts`.

## Known follow-ups (not in this PR — separate background tasks)

- MySQL's `db:reset` → `db:seed` replays migrations against existing tables (pre-existing ORM bug found while checking this fix on MySQL — there is no MySQL golden path yet because of it).
- Postgres `timestamp(..., { withTimezone: false })` shifts stored instants by the server's UTC offset (measured via the new smoke round-trip). sqlite is exact.
- `ApiRoutes[...]['body']` in codegen is the Zod *output* type, not the wire/input type — the root cause of the date/json form workarounds in this PR.
- `SeederContext.db` is hard-typed to Postgres, so generated MySQL/sqlite seeders aren't independently type-correct (currently invisible because `db/` isn't in the scaffolded tsconfig `include`).

## Test plan

- [x] `bun run build`
- [x] `bun run typecheck` (root + examples/blog + examples/api)
- [x] `bun run test` (vitest) and `bun run test:bun` — 3219 pass / 0 fail
- [x] `bun run audit:core-first`, `audit:docs`, `audit:starter-template`
- [x] `bun run smoke:golden-path` (sqlite) — full field-type resource, date+json round trip, PASSED
- [x] `bun run smoke:golden-path:postgres` — same, PASSED
- [x] Manual: scaffolded sqlite and postgres apps with all 6 field types, required and nullable variants, zero type errors in both
- [x] Mutation check: adding a 7th `FieldType` fails to compile in all five per-type mapping sites