### PR TITLE
Classify audit findings against OWASP Top 10 and CWE

### DIFF
--- a/packages/cli/src/audit-taxonomy.ts
+++ b/packages/cli/src/audit-taxonomy.ts
@@ -1,0 +1,80 @@
+/**
+ * Standard security classifications for audit findings (RFC 0007).
+ *
+ * Classifications are versioned: OWASP Top 10 2021 and 2025 number their
+ * categories differently, so a bare "A03" is ambiguous without one.
+ */
+
+export interface AuditClassification {
+  standard: 'OWASP Top 10' | 'OWASP API Security' | 'CWE'
+  /** Standard edition ('2021', '2023'); absent for CWE ids. */
+  version?: string
+  id: string
+  name?: string
+}
+
+function owasp(id: string, name: string): AuditClassification {
+  return { standard: 'OWASP Top 10', version: '2021', id, name }
+}
+
+function owaspApi(id: string, name: string): AuditClassification {
+  return { standard: 'OWASP API Security', version: '2023', id, name }
+}
+
+function cwe(id: string, name: string): AuditClassification {
+  return { standard: 'CWE', id, name }
+}
+
+export const OWASP_A06_VULNERABLE_COMPONENTS = owasp('A06', 'Vulnerable and Outdated Components')
+
+/**
+ * Rule classifications, keyed by finding-key prefix (`authz:`, `secret:`, …).
+ * Infrastructure findings (routes:load, audit-config:*) carry none.
+ *
+ * CWE pairings follow the official OWASP Top 10 2021 CWE mapping where one
+ * exists (e.g. CWE-798 hardcoded credentials sits under A07, not A02).
+ */
+const RULE_CLASSIFICATIONS: Record<string, AuditClassification[]> = {
+  validation: [owasp('A03', 'Injection'), cwe('CWE-20', 'Improper Input Validation')],
+  authz: [
+    owasp('A01', 'Broken Access Control'),
+    cwe('CWE-306', 'Missing Authentication for Critical Function'),
+  ],
+  secret: [
+    owasp('A07', 'Identification and Authentication Failures'),
+    cwe('CWE-798', 'Use of Hard-coded Credentials'),
+  ],
+  'raw-sql': [owasp('A03', 'Injection'), cwe('CWE-89', 'SQL Injection')],
+  'security-toggle': [
+    owasp('A05', 'Security Misconfiguration'),
+    cwe('CWE-693', 'Protection Mechanism Failure'),
+  ],
+  'mass-assignment': [
+    owaspApi('API3', 'Broken Object Property Level Authorization'),
+    cwe('CWE-915', 'Improperly Controlled Modification of Dynamically-Determined Object Attributes'),
+  ],
+  'force-write-request-data': [
+    owaspApi('API3', 'Broken Object Property Level Authorization'),
+    cwe('CWE-915', 'Improperly Controlled Modification of Dynamically-Determined Object Attributes'),
+  ],
+  'hidden-columns': [
+    owaspApi('API3', 'Broken Object Property Level Authorization'),
+    cwe('CWE-200', 'Exposure of Sensitive Information to an Unauthorized Actor'),
+  ],
+  deps: [OWASP_A06_VULNERABLE_COMPONENTS, cwe('CWE-1395', 'Dependency on Vulnerable Third-Party Component')],
+}
+
+export function classifyFindingKey(key: string): AuditClassification[] | undefined {
+  const prefix = key.slice(0, key.indexOf(':'))
+  return RULE_CLASSIFICATIONS[prefix]
+}
+
+/**
+ * The id shown in console output — the first non-CWE classification, since
+ * `[A01]` reads better than a CWE number in a terminal line.
+ */
+export function primaryClassificationId(
+  classifications: AuditClassification[] | undefined,
+): string | undefined {
+  return classifications?.find((c) => c.standard !== 'CWE')?.id
+}

--- a/packages/cli/src/audit-taxonomy.ts
+++ b/packages/cli/src/audit-taxonomy.ts
@@ -25,8 +25,6 @@ function cwe(id: string, name: string): AuditClassification {
   return { standard: 'CWE', id, name }
 }
 
-export const OWASP_A06_VULNERABLE_COMPONENTS = owasp('A06', 'Vulnerable and Outdated Components')
-
 /**
  * Rule classifications, keyed by finding-key prefix (`authz:`, `secret:`, …).
  * Infrastructure findings (routes:load, audit-config:*) carry none.
@@ -61,7 +59,10 @@ const RULE_CLASSIFICATIONS: Record<string, AuditClassification[]> = {
     owaspApi('API3', 'Broken Object Property Level Authorization'),
     cwe('CWE-200', 'Exposure of Sensitive Information to an Unauthorized Actor'),
   ],
-  deps: [OWASP_A06_VULNERABLE_COMPONENTS, cwe('CWE-1395', 'Dependency on Vulnerable Third-Party Component')],
+  deps: [
+    owasp('A06', 'Vulnerable and Outdated Components'),
+    cwe('CWE-1395', 'Dependency on Vulnerable Third-Party Component'),
+  ],
 }
 
 export function classifyFindingKey(key: string): AuditClassification[] | undefined {

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -10,6 +10,11 @@ import {
 } from './discovery'
 import { loadRouteDefinitions } from './load-routes'
 import {
+  classifyFindingKey,
+  primaryClassificationId,
+  type AuditClassification,
+} from './audit-taxonomy'
+import {
   classUsesAuthenticatableBase,
   extractClassDeclaration,
   extractTableIdentifier,
@@ -31,6 +36,8 @@ export interface AuditFinding {
   line?: number
   /** Set when `status` is 'ignored' — the reason from config/audit.ts. */
   ignoreReason?: string
+  /** Standard references (OWASP Top 10 / OWASP API Security / CWE) for the rule. */
+  classifications?: AuditClassification[]
 }
 
 export interface AuditReport {
@@ -94,6 +101,10 @@ export async function runAudit(options: RunAuditOptions = {}): Promise<AuditRepo
   auditForceWrites(controllerMethods, findings)
   await auditSourceFiles(cwd, findings)
   await auditModels(cwd, findings)
+
+  for (const entry of findings) {
+    entry.classifications ??= classifyFindingKey(entry.key)
+  }
 
   await applyIgnoreConfig(cwd, options.auditConfigFile, findings)
 
@@ -757,7 +768,8 @@ export function renderAuditReport(report: AuditReport): void {
       continue
     }
     const log = f.status === 'warn' ? consola.warn : consola.error
-    log(`[${f.status}] ${f.title}: ${f.message}`)
+    const classification = primaryClassificationId(f.classifications)
+    log(`[${f.status}]${classification ? ` [${classification}]` : ''} ${f.title}: ${f.message}`)
     if (f.suggestion) {
       consola.info(`       → ${f.suggestion}`)
     }

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -1311,3 +1311,71 @@ export default class TaskController extends Controller {
     expect(/\bvalidateBody(Safe)?\s*(?:<[^>]*>)?\s*\(/.test(source)).toBe(true)
   })
 })
+
+describe('finding classifications', () => {
+  it('tags rule findings with versioned standards and leaves infra findings untagged', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-taxonomy-')
+
+    try {
+      await writeController(
+        workspace.dir,
+        'PostController',
+        `export default class PostController {
+  async store() {
+    const data = await this.request.json()
+    return null
+  }
+}`,
+      )
+      await writeRoutes(
+        workspace.dir,
+        `class PostController {
+  async store() { return null }
+}
+export default function registerRoutes(router: any) {
+  router.post('/posts', [PostController, 'store'])
+}`,
+      )
+      await mkdir(join(workspace.dir, 'src'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'src/leak.ts'),
+        `export const apiKey = 'sk-live-abcdef1234567890'\n`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const validation = report.findings.find(f => f.key === 'validation:POST /posts')
+      expect(validation!.classifications).toEqual([
+        { standard: 'OWASP Top 10', version: '2021', id: 'A03', name: 'Injection' },
+        { standard: 'CWE', id: 'CWE-20', name: 'Improper Input Validation' },
+      ])
+
+      const authz = report.findings.find(f => f.key === 'authz:POST /posts')
+      expect(authz!.classifications?.[0]).toEqual({
+        standard: 'OWASP Top 10',
+        version: '2021',
+        id: 'A01',
+        name: 'Broken Access Control',
+      })
+
+      const secret = report.findings.find(f => f.key.startsWith('secret:src/leak.ts'))
+      expect(secret).toBeDefined()
+      expect(secret!.classifications?.map(c => c.id)).toEqual(['A07', 'CWE-798'])
+
+      // Passing findings carry the rule's classification too — the taxonomy
+      // describes the check, not the failure.
+      const massAssignmentPass = report.findings.find(f => f.key === 'raw-sql:none')
+      expect(massAssignmentPass!.classifications?.[0]?.id).toBe('A03')
+
+      // Infrastructure findings (config load, module load) are not security
+      // rules and stay untagged.
+      const infra = report.findings.filter(f => f.key.startsWith('routes:') || f.key.startsWith('audit-config:'))
+      for (const entry of infra) {
+        expect(entry.classifications).toBeUndefined()
+      }
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

First implementation slice of RFC 0007 (#249). `guren audit` findings gain a `classifications` array of **versioned** standard references — versioned because OWASP Top 10 2021 and 2025 number their categories differently, so a bare `A03` is ambiguous:

```json
{ "standard": "OWASP Top 10", "version": "2021", "id": "A01", "name": "Broken Access Control" }
```

- Console warn/fail lines are prefixed with the primary id: `[fail] [A07] src/leak.ts:1: Possible hardcoded credential`.
- `--json` carries the full array. Classifications describe the *rule*, so passing findings carry them too; infrastructure findings (route load, ignore config) stay untagged.
- Mapping lives in one table (`audit-taxonomy.ts`), keyed by finding-key prefix; the dependency-scan slice (RFC 0007 §3) will reuse it for A06.
- CWE pairings follow the official OWASP Top 10 2021 CWE mapping — notably hardcoded credentials (CWE-798) sit under **A07**, not A02.

Purely additive: new optional field, no behavior change to statuses or exit codes.

## Verification

- New test asserts A03/A01/A07 tagging, rule-describing tags on passes, and untagged infra findings; full `packages/cli` suite 967 pass / 0 fail; `tsc --noEmit` clean.
- Both-direction check on real apps: `examples/blog` (22 findings) and `web` (15 findings) audit clean with all rule findings tagged in `--json`; a fixture with a hardcoded secret renders `[fail] [A07] ...` while the untagged route-load warning renders without a prefix.

Refs: RFC 0007