### PR TITLE
fix(cli): scaffold postgres timestamp columns as timestamptz

### DIFF
--- a/.changeset/scaffold-timestamptz-columns.md
+++ b/.changeset/scaffold-timestamptz-columns.md
@@ -1,0 +1,45 @@
+---
+"create-guren-app": minor
+"@guren/cli": minor
+---
+
+Scaffold Postgres timestamp columns as `timestamptz`
+
+Every timestamp a Guren scaffold emitted for Postgres was `timestamp without
+time zone`: `add resource`'s `date` fields, the `createdAt` it appends, the
+`createdAt`/`updatedAt`/`emailVerifiedAt` on `make:auth`'s users table, and the
+`users` table `create-guren-app --db postgres` writes. All of them hold an
+instant, so all of them are now `timestamp(name, { withTimezone: true })`.
+
+A column without a time zone stores a bare wall clock, and who reads it decides
+what that clock meant:
+
+- `defaultNow()` records the wall clock of the **database session's** time zone,
+  while the app reads the column back as if it were UTC. Whenever the database
+  session is not on UTC, a `createdAt` is silently off by that offset — the
+  wrong instant is written, not merely displayed.
+- Values the app writes itself are UTC wall clock, so anything that is not
+  Drizzle — `psql`, a raw `postgres` query, a report, another service — reads
+  them as local time and sees a different instant.
+
+Drizzle parses the offset-less column as UTC, so an app that only ever reads
+through its own models stays self-consistent; `timestamptz` is what makes the
+column mean the same instant to everyone else.
+
+This changes generated code only — existing schemas are untouched. To adopt it
+in an app that has already migrated, change the column in `db/schema.ts` and
+generate a migration, then fix up the `USING` clause. Drizzle emits a bare
+`::timestamp with time zone` cast, which reinterprets stored values against
+whatever the session's time zone happens to be; name the zone the values were
+actually written in instead:
+
+```sql
+ALTER TABLE "posts"
+  ALTER COLUMN "published_at" SET DATA TYPE timestamp with time zone
+  USING "published_at" AT TIME ZONE 'UTC';
+```
+
+`'UTC'` is right for values the app wrote. If the column also carries
+`defaultNow()` rows, they were written in the database session's zone — check
+it with `SHOW TimeZone` before converting, and split the conversion if the two
+sets of rows disagree.

--- a/docs/en/guides/api-tokens.md
+++ b/docs/en/guides/api-tokens.md
@@ -253,9 +253,9 @@ export const apiTokens = pgTable('api_tokens', {
   hashedToken: text('hashed_token').notNull().unique(),
   userId: text('user_id').notNull(),
   abilities: jsonb('abilities').$type<string[]>().notNull(),
-  lastUsedAt: timestamp('last_used_at'),
-  expiresAt: timestamp('expires_at'),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
+  lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
+  expiresAt: timestamp('expires_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 })
 ```
 

--- a/docs/en/guides/database.md
+++ b/docs/en/guides/database.md
@@ -15,11 +15,16 @@ export const posts = pgTable('posts', {
   title: text('title').notNull(),
   body: text('body').notNull(),
   status: text('status').notNull().default('draft'),
-  publishedAt: timestamp('published_at'),
-  createdAt: timestamp('created_at').defaultNow(),
-  updatedAt: timestamp('updated_at').defaultNow(),
+  publishedAt: timestamp('published_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
 })
 ```
+
+On PostgreSQL, give every timestamp column `{ withTimezone: true }`. A
+`timestamp without time zone` stores a bare wall clock with no offset, so
+`defaultNow()` records it in the database session's zone while your app reads
+it back as UTC, and any client other than your app sees a different instant.
 
 ```ts
 // config/database.ts

--- a/docs/en/guides/email-verification.md
+++ b/docs/en/guides/email-verification.md
@@ -308,15 +308,15 @@ import { pgTable, text, timestamp } from 'drizzle-orm/pg-core'
 export const emailVerifications = pgTable('email_verifications', {
   hashedToken: text('hashed_token').primaryKey(),
   email: text('email').notNull(),
-  expiresAt: timestamp('expires_at').notNull(),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
+  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 })
 
 // User table should include emailVerifiedAt
 export const users = pgTable('users', {
   id: serial('id').primaryKey(),
   email: text('email').notNull().unique(),
-  emailVerifiedAt: timestamp('email_verified_at'),
+  emailVerifiedAt: timestamp('email_verified_at', { withTimezone: true }),
   // ... other fields
 })
 ```

--- a/docs/en/guides/password-reset.md
+++ b/docs/en/guides/password-reset.md
@@ -284,8 +284,8 @@ import { pgTable, text, timestamp } from 'drizzle-orm/pg-core'
 export const passwordResets = pgTable('password_resets', {
   tokenHash: text('token_hash').primaryKey(),
   email: text('email').notNull(),
-  expiresAt: timestamp('expires_at').notNull(),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
+  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 })
 ```
 

--- a/docs/en/guides/ship-api.md
+++ b/docs/en/guides/ship-api.md
@@ -37,7 +37,7 @@ export const tasks = pgTable('tasks', {
   id: serial('id').primaryKey(),
   title: text('title').notNull(),
   completed: boolean('completed').notNull().default(false),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 })
 ```
 

--- a/docs/ja/guides/api-tokens.md
+++ b/docs/ja/guides/api-tokens.md
@@ -253,9 +253,9 @@ export const apiTokens = pgTable('api_tokens', {
   hashedToken: text('hashed_token').notNull().unique(),
   userId: text('user_id').notNull(),
   abilities: jsonb('abilities').$type<string[]>().notNull(),
-  lastUsedAt: timestamp('last_used_at'),
-  expiresAt: timestamp('expires_at'),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
+  lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
+  expiresAt: timestamp('expires_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 })
 ```
 

--- a/docs/ja/guides/database.md
+++ b/docs/ja/guides/database.md
@@ -25,12 +25,17 @@ export const posts = pgTable('posts', {
   body: text('body').notNull(),
   status: text('status').notNull().default('draft'),
   metadata: jsonb('metadata'),
-  publishedAt: timestamp('published_at'),
-  deletedAt: timestamp('deleted_at'),
-  createdAt: timestamp('created_at').defaultNow(),
-  updatedAt: timestamp('updated_at').defaultNow(),
+  publishedAt: timestamp('published_at', { withTimezone: true }),
+  deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
 })
 ```
+
+PostgreSQL では、タイムスタンプ列に必ず `{ withTimezone: true }` を付けてください。
+`timestamp without time zone` はオフセットを持たない壁時計を保存するため、
+`defaultNow()` はデータベースセッションのタイムゾーンで書き込む一方でアプリは
+UTC として読み戻し、アプリ以外のクライアントは異なる instant を見ることになります。
 
 テーブルは `defineModel()` でモデルに公開するのが推奨です。
 

--- a/docs/ja/guides/email-verification.md
+++ b/docs/ja/guides/email-verification.md
@@ -308,15 +308,15 @@ import { pgTable, text, timestamp } from 'drizzle-orm/pg-core'
 export const emailVerifications = pgTable('email_verifications', {
   hashedToken: text('hashed_token').primaryKey(),
   email: text('email').notNull(),
-  expiresAt: timestamp('expires_at').notNull(),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
+  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 })
 
 // usersテーブルにはemailVerifiedAtを含める
 export const users = pgTable('users', {
   id: serial('id').primaryKey(),
   email: text('email').notNull().unique(),
-  emailVerifiedAt: timestamp('email_verified_at'),
+  emailVerifiedAt: timestamp('email_verified_at', { withTimezone: true }),
   // ... その他のフィールド
 })
 ```

--- a/docs/ja/guides/password-reset.md
+++ b/docs/ja/guides/password-reset.md
@@ -284,8 +284,8 @@ import { pgTable, text, timestamp } from 'drizzle-orm/pg-core'
 export const passwordResets = pgTable('password_resets', {
   tokenHash: text('token_hash').primaryKey(),
   email: text('email').notNull(),
-  expiresAt: timestamp('expires_at').notNull(),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
+  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 })
 ```
 

--- a/docs/ja/guides/ship-api.md
+++ b/docs/ja/guides/ship-api.md
@@ -37,7 +37,7 @@ export const tasks = pgTable('tasks', {
   id: serial('id').primaryKey(),
   title: text('title').notNull(),
   completed: boolean('completed').notNull().default(false),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 })
 ```
 

--- a/examples/api/db/schema.ts
+++ b/examples/api/db/schema.ts
@@ -7,8 +7,8 @@ export const users = pgTable(
     name: text('name').notNull(),
     email: text('email').notNull(),
     passwordHash: text('password_hash').notNull(),
-    createdAt: timestamp('created_at').defaultNow().notNull(),
-    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [uniqueIndex('users_email_unique').on(table.email)],
 )
@@ -21,8 +21,8 @@ export const tasks = pgTable('tasks', {
   userId: integer('user_id')
     .notNull()
     .references(() => users.id, { onDelete: 'cascade' }),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
-  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 })
 
 export const schema = { users, tasks }

--- a/examples/blog/db/migrations/20260731154538_slimy_joshua_kane/migration.sql
+++ b/examples/blog/db/migrations/20260731154538_slimy_joshua_kane/migration.sql
@@ -1,0 +1,6 @@
+-- Existing rows hold a bare wall clock that was written as UTC: drizzle sends
+-- `Date.toISOString()` and `timestamp without time zone` drops the offset. The
+-- generated cast (`::timestamp with time zone`) would reinterpret that wall
+-- clock against the session's TimeZone instead, so the USING clause names UTC
+-- explicitly and the conversion no longer depends on who runs the migration.
+ALTER TABLE "users" ALTER COLUMN "email_verified_at" SET DATA TYPE timestamp with time zone USING "email_verified_at" AT TIME ZONE 'UTC';

--- a/examples/blog/db/migrations/20260731154538_slimy_joshua_kane/snapshot.json
+++ b/examples/blog/db/migrations/20260731154538_slimy_joshua_kane/snapshot.json
@@ -1,0 +1,272 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "11138176-12ed-44a5-ad69-114b04cf6a31",
+  "prevIds": [
+    "94447d97-45fd-4df6-a568-4f8c86b4b7c8"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "posts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "excerpt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "body",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "remember_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email_verified_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "github_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "google_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "users_email_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "author_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "posts_author_id_users_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "posts_pkey",
+      "schema": "public",
+      "table": "posts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "github_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_github_id_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "google_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_google_id_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    }
+  ],
+  "renames": []
+}

--- a/examples/blog/db/schema.ts
+++ b/examples/blog/db/schema.ts
@@ -8,7 +8,7 @@ export const users = pgTable(
     email: text('email').notNull(),
     passwordHash: text('password_hash').notNull(),
     rememberToken: text('remember_token'),
-    emailVerifiedAt: timestamp('email_verified_at', { withTimezone: false }),
+    emailVerifiedAt: timestamp('email_verified_at', { withTimezone: true }),
     githubId: text('github_id').unique(),
     googleId: text('google_id').unique(),
   },

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -719,7 +719,14 @@ const PG_COLUMNS: ColumnMapping = {
   text: (name, notNull) => ({ code: `text('${name}')${notNull}`, imports: ['text'] }),
   number: (name, notNull) => ({ code: `integer('${name}')${notNull}`, imports: ['integer'] }),
   boolean: (name, notNull) => ({ code: `boolean('${name}')${notNull}`, imports: ['boolean'] }),
-  date: (name, notNull) => ({ code: `timestamp('${name}', { withTimezone: false })${notNull}`, imports: ['timestamp'] }),
+  // `timestamptz`, not `timestamp`. A `date` field holds an instant: drizzle
+  // writes `Date.toISOString()`, so `timestamp without time zone` keeps the UTC
+  // wall clock but drops the offset, and what that wall clock means is then up
+  // to the reader. Drizzle parses it back as UTC, so the app stays
+  // self-consistent — but a raw `postgres` query, psql, or any other client
+  // reads it as local time and sees a different instant. `timestamptz` stores
+  // the instant itself, so every reader agrees.
+  date: (name, notNull) => ({ code: `timestamp('${name}', { withTimezone: true })${notNull}`, imports: ['timestamp'] }),
   json: (name, notNull) => ({ code: `jsonb('${name}')${notNull}`, imports: ['jsonb'] }),
 }
 
@@ -728,6 +735,9 @@ const MYSQL_COLUMNS: ColumnMapping = {
   text: (name, notNull) => ({ code: `varchar('${name}', { length: 255 })${notNull}`, imports: ['varchar'] }),
   number: (name, notNull) => ({ code: `int('${name}')${notNull}`, imports: ['int'] }),
   boolean: (name, notNull) => ({ code: `boolean('${name}')${notNull}`, imports: ['boolean'] }),
+  // Bare `timestamp` on purpose — MySQL has no `timestamptz`, and its TIMESTAMP
+  // is already stored as UTC and converted per session, so it round-trips the
+  // instant. `datetime` is the one that would drop the offset here.
   date: (name, notNull) => ({ code: `timestamp('${name}')${notNull}`, imports: ['timestamp'] }),
   json: (name, notNull) => ({ code: `json('${name}')${notNull}`, imports: ['json'] }),
 }
@@ -784,7 +794,7 @@ async function updateResourceSchema(collection: string, routeName: string, field
     content = ensureDrizzleImports(content, imports)
 
     const fieldLines = fields.map((field, index) => `  ${field.name}: ${columns[index].code},`).join('\n')
-    const schemaBlock = `\nexport const ${schemaIdentifier} = pgTable('${tableName}', {\n  id: serial('id').primaryKey(),\n${fieldLines}\n  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),\n})\n`
+    const schemaBlock = `\nexport const ${schemaIdentifier} = pgTable('${tableName}', {\n  id: serial('id').primaryKey(),\n${fieldLines}\n  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),\n})\n`
 
     content = `${content.trimEnd()}\n${schemaBlock}`
   }

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -1747,6 +1747,10 @@ export default defineSeeder(async ({ db }) => {
 `
 }
 
+// The timestamps in these blocks — and in `emailVerifiedAtField` below — all
+// hold instants, so pg gets `timestamptz`. An offset-less column stores a bare
+// wall clock whose meaning is left to the reader, and `defaultNow()` writes it
+// in the database session's zone while the app reads it back as UTC.
 const usersTableBlocks: Record<SchemaDialect, string> = {
   sqlite: `export const users = sqliteTable('users', {
   id: integer('id').primaryKey({ autoIncrement: true }),
@@ -1764,8 +1768,8 @@ const usersTableBlocks: Record<SchemaDialect, string> = {
   email: text('email').notNull().unique(),
   passwordHash: text('password_hash').notNull(),
   rememberToken: text('remember_token'),
-  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: false }).defaultNow().notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 })
 `,
   mysql: `export const users = mysqlTable('users', {
@@ -1782,7 +1786,7 @@ const usersTableBlocks: Record<SchemaDialect, string> = {
 
 const emailVerifiedAtField: Record<SchemaDialect, string> = {
   sqlite: `emailVerifiedAt: integer('email_verified_at', { mode: 'timestamp' }),`,
-  pg: `emailVerifiedAt: timestamp('email_verified_at', { withTimezone: false }),`,
+  pg: `emailVerifiedAt: timestamp('email_verified_at', { withTimezone: true }),`,
   mysql: `emailVerifiedAt: timestamp('email_verified_at'),`,
 }
 

--- a/packages/cli/templates/agent/.claude/skills/feature/SKILL.md
+++ b/packages/cli/templates/agent/.claude/skills/feature/SKILL.md
@@ -195,7 +195,12 @@ export const posts = pgTable('posts', {
   id: serial('id').primaryKey(),
   title: varchar('title', { length: 255 }).notNull(),
   content: text('content'),
-  createdAt: timestamp('created_at').defaultNow(),
-  updatedAt: timestamp('updated_at').defaultNow(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
 })
 ```
+
+On PostgreSQL, always give timestamp columns `{ withTimezone: true }`. A
+`timestamp without time zone` stores a bare wall clock, so `defaultNow()`
+records it in the database session's zone while the app reads it back as UTC,
+and any client other than the app sees a different instant.

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -167,7 +167,7 @@ export const users = pgTable('users', {
         "body: text('body').notNull()",
         "count: integer('count').notNull()",
         "active: boolean('active').notNull()",
-        "publishedAt: timestamp('published_at', { withTimezone: false }).notNull()",
+        "publishedAt: timestamp('published_at', { withTimezone: true }).notNull()",
         "meta: jsonb('meta').notNull()",
       ],
     },

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -75,7 +75,7 @@ export const users = pgTable('users', {
   id: serial('id').primaryKey(),
   name: text('name').notNull(),
   email: text('email').notNull(),
-  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 })
 `
 

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -322,7 +322,7 @@ export const users = pgTable(
 
       const schema = await readFile(join(workspace.dir, 'db/schema.ts'), 'utf8')
       expect(schema.match(/export const users = pgTable\(/g)).toHaveLength(1)
-      expect(schema).toContain("emailVerifiedAt: timestamp('email_verified_at', { withTimezone: false }),")
+      expect(schema).toContain("emailVerifiedAt: timestamp('email_verified_at', { withTimezone: true }),")
       expect(schema).toContain('uniqueIndex')
       expect(schema).toContain("(table) => [uniqueIndex('users_email_unique').on(table.email)]")
     } finally {
@@ -450,8 +450,8 @@ export const users = pgTable('users', {
   email: text('email').notNull().unique(),
   passwordHash: text('password_hash').notNull(),
   rememberToken: text('remember_token'),
-  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: false }).defaultNow().notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 })
 `,
         'utf8',
@@ -560,8 +560,8 @@ export const users = pgTable('users', {
   email: text('email').notNull().unique(),
   passwordHash: text('password_hash').notNull(),
   rememberToken: text('remember_token'),
-  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: false }).defaultNow().notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 })
 `,
         'utf8',

--- a/packages/create-app/src/blueprints.ts
+++ b/packages/create-app/src/blueprints.ts
@@ -282,7 +282,7 @@ export const users = pgTable('users', {
   id: serial('id').primaryKey(),
   name: text('name').notNull(),
   email: text('email').notNull(),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 })
 `
   }

--- a/packages/create-app/templates/blog/db/schema.postgres.ts
+++ b/packages/create-app/templates/blog/db/schema.postgres.ts
@@ -6,8 +6,8 @@ export const users = pgTable('users', {
   email: text('email').notNull().unique(),
   passwordHash: text('password_hash').notNull(),
   rememberToken: text('remember_token'),
-  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: false }).defaultNow().notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 })
 
 export const posts = pgTable('posts', {
@@ -18,5 +18,5 @@ export const posts = pgTable('posts', {
   authorId: integer('author_id')
     .notNull()
     .references(() => users.id),
-  createdAt: timestamp('created_at', { withTimezone: false }).defaultNow().notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 })

--- a/scripts/smoke-golden-path.sh
+++ b/scripts/smoke-golden-path.sh
@@ -365,8 +365,28 @@ if (Number(tracker[0].c) < 1) {
   console.error('drizzle.__drizzle_migrations is empty after db:migrate')
   process.exit(1)
 }
+
+// Every timestamp a scaffold emits must carry a time zone. An offset-less
+// column stores a bare wall clock and leaves its meaning to the reader: the
+// app itself stays self-consistent (drizzle parses the column as UTC), which
+// is why no HTTP round trip below can catch this, but every other reader sees
+// a different instant and a `defaultNow()` column records the DB session's
+// local wall clock. Asked as "which columns are wrong" rather than against a
+// list of names, so a scaffold that grows a new timestamp is covered too.
+const offsetlessColumns = await sql`
+  SELECT table_name, column_name, data_type FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND data_type LIKE 'timestamp%'
+    AND data_type <> 'timestamp with time zone'
+`
+if (offsetlessColumns.length > 0) {
+  const named = offsetlessColumns.map((c) => c.table_name + '.' + c.column_name + ' (' + c.data_type + ')')
+  console.error('Expected every timestamp column to be timestamptz, but found: ' + named.join(', '))
+  process.exit(1)
+}
+
 await sql.end()
-console.log('DB tables OK (postgres): ' + tables.join(', '))
+console.log('DB tables OK (postgres): ' + tables.join(', ') + ' — timestamp columns are timestamptz')
 DBCHECK
   (cd "$APP_DIR" && bun "$TEMP_DIR/dbcheck.ts")
 elif [ "$SMOKE_DB" = "mysql" ]; then
@@ -506,12 +526,12 @@ if ! printf '%s' "$COMMENTS_BODY" | grep -q "golden-path-json"; then
   printf '%s\n' "$COMMENTS_BODY" | head -40
   exit 1
 fi
-# The resource serializes date columns as ISO strings. sqlite's timestamp-mode
-# integer round-trips the instant exactly, but postgres `timestamp without time
-# zone` and MySQL `timestamp` both shift it by the server/session's UTC
-# offset, so the day is asserted loosely — what this checks is that a Date
-# went in and a Date came back, not that every dialect agrees on the instant.
-if ! printf '%s' "$COMMENTS_BODY" | grep -qE '2026-02-0[23]T[0-9]{2}:[0-9]{2}:[0-9]{2}'; then
+# The resource serializes date columns as ISO strings. This checks that a
+# `Date` went in and a `Date` came back — it deliberately does not police the
+# time zone, because the app's own reads round-trip on either column type
+# (drizzle parses an offset-less postgres timestamp as UTC). The column type
+# itself is asserted in the db check above, which is what catches a regression.
+if ! printf '%s' "$COMMENTS_BODY" | grep -qF '2026-02-03T00:00:00.000Z'; then
   echo "ERROR: GET /comments did not round-trip the date column"
   printf '%s\n' "$COMMENTS_BODY" | head -40
   exit 1


### PR DESCRIPTION
Rebased onto `main` now that #250 has merged; base retargeted to `main`.

## The problem

Every Postgres timestamp a Guren scaffold emitted was `timestamp without time zone`:

- `add resource`'s `date` fields, and the `createdAt` it appends (`packages/cli/src/blueprints.ts`)
- `make:auth`'s users table — `createdAt`, `updatedAt`, `emailVerifiedAt`
- the `users` table `create-guren-app --db postgres` writes (`packages/create-app/src/blueprints.ts`)
- the blog template's schema (`packages/create-app/templates/blog/db/schema.postgres.ts`)

All of them hold an instant, so all of them are now `timestamp(name, { withTimezone: true })`.

A column without a time zone stores a bare wall clock, and the reader decides what that clock meant. Two consequences, measured against the compose Postgres with the process on `TZ=Asia/Tokyo`:

| reader | `timestamp` | `timestamptz` |
| --- | --- | --- |
| the app (drizzle + postgres-js) | exact | exact |
| a raw `postgres` query | **−9h** | exact |
| `defaultNow()`, DB session zone ≠ UTC | **−9h off reality** | exact |

The second row is the one that costs data: `defaultNow()` records the wall clock of the *database session's* zone while the app reads the column back as UTC, so a `createdAt` on a non-UTC session is written as the wrong instant. The first row means anything that is not Drizzle — `psql`, a report, another service — reads a different instant than the app does.

## Why the smoke assertion moved

The original report described a 9-hour shift through the app, and the smoke's date assertion was left loose (`2026-02-0[23]T…`) because of it. That turns out not to be reproducible over HTTP: drizzle overrides the oid-1114 parser and reads the column as UTC, so the app is self-consistent on **either** column type. Tightening that assertion to an exact instant and re-running the Postgres smoke against the old column confirmed it — the smoke passed unchanged, so the assertion could never have guarded the fix.

The guard is now a question rather than a checklist — "which columns in the public schema are offset-less?" — so a scaffold that grows a new timestamp is covered without being enumerated. Run against a database holding a single reverted column it reports:

```
Expected every timestamp column to be timestamptz, but found: posts.created_at (timestamp without time zone)
```

`posts.created_at` is worth noting: an earlier version of this guard listed three columns by name, and that one was not among them. The HTTP assertion stays as the "a Date went in, a Date came back" check it always was.

## Docs and the agent harness

The generators were only half the surface. `packages/cli/templates/agent/.claude/skills/feature/SKILL.md` — installed into apps by `agent:init` — and the pg schema snippets in `docs/{en,ja}/guides/` all taught bare `timestamp('created_at')`, which no generator-side fix can reach; an agent following the harness would keep writing offset-less columns. Both now teach `withTimezone: true`, and `examples/api` moves with them. (`api-tokens` and `password-reset` are the pointed ones — an `expiresAt` compared against `now()` in an offset-less column is a correctness bug in a security-relevant path.)

## `date` stays an instant

Not a calendar day. sqlite already binds `date` as an instant (`integer(name, { mode: 'timestamp' })`), the DSL has exactly one temporal type, and `z.coerce.date()` produces a `Date` — mapping Postgres to a calendar day would make the two dialects disagree on the type rather than just the offset. The generated `<input type="date">` stays self-consistent under this: `new Date("2026-02-03")` parses as UTC midnight, timestamptz stores that instant, and the form renders `2026-02-03` back.

## MySQL is deliberately unchanged

It has no `timestamptz`, and its `TIMESTAMP` is already stored as UTC and converted per session. The `mysql` golden-path variant passes the same exact-instant assertion, so the instant round-trips; the mapping now says why, so the next sweep for offset-less columns doesn't "fix" it.

## Existing apps

Generated code only — no schema is rewritten. The changeset carries the adoption snippet, including the part drizzle gets wrong: its generated `::timestamp with time zone` cast reinterprets stored values against whatever zone the session running the migration is in, so the `USING` clause should name the zone the values were written in (`AT TIME ZONE 'UTC'` for app-written rows; check `SHOW TimeZone` for `defaultNow()` rows). `examples/blog`'s `email_verified_at` migration is written that way.

## Verification

- `bun run typecheck`, `bun run test` — clean
- `smoke:golden-path` on **sqlite, postgres, and mysql** — all pass
- the guard confirmed to fail on a reverted column, naming it
- `audit:starter-template`, `audit:core-first`, `audit:docs`, `smoke:starter` — pass

## Scoped out

A `guren check` rule that would catch offset-less timestamps in hand-written and agent-written schemas — the plumbing exists (`schema-parser.ts`), but `SchemaColumn.type` records the builder name without its options, so it needs a parser extension plus both-direction validation against `web/` and `examples/blog`. Its own PR.