### PR TITLE
Verify route authentication via middleware capability stamps

### DIFF
--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -70,6 +70,34 @@ const WEBHOOK_PATH_PATTERN = /(webhook|callback)/i
 
 const AUTH_MIDDLEWARE_PATTERN = /auth/i
 
+export type AuthMiddlewareVerdict =
+  /** A middleware in the chain carries the framework's authentication capability. */
+  | 'verified'
+  /** Old server without capability support; a middleware *name* matched /auth/i. */
+  | 'legacy-name-match'
+  /** Capabilities are supported, no guard found, but a name looks auth-like. */
+  | 'unverified-auth-name'
+  /** No authentication middleware detected by any signal. */
+  | 'none'
+
+/**
+ * Exported for tests. `route` is the shape `Router.definitions()` returns:
+ * `capabilities` is always present (possibly empty) on servers with
+ * capability support, and absent entirely on older servers.
+ */
+export function authMiddlewareVerdict(route: {
+  middlewareNames?: string[]
+  capabilities?: { authentication?: { mode: string } }
+}): AuthMiddlewareVerdict {
+  if (route.capabilities?.authentication?.mode === 'required') return 'verified'
+
+  const nameMatches = (route.middlewareNames ?? []).some((name) => AUTH_MIDDLEWARE_PATTERN.test(name))
+  if (route.capabilities === undefined) {
+    return nameMatches ? 'legacy-name-match' : 'none'
+  }
+  return nameMatches ? 'unverified-auth-name' : 'none'
+}
+
 /**
  * Calls that actually reject unauthenticated requests. Optional reads like
  * `auth.user()`, `auth.id()`, or `auth.check()` do not enforce anything on
@@ -464,7 +492,13 @@ async function auditRoutes(
     if (GUEST_PATH_PATTERN.test(route.path)) continue
 
     const middlewareNames = route.middlewareNames ?? []
-    const hasAuthMiddleware = middlewareNames.some((name) => AUTH_MIDDLEWARE_PATTERN.test(name))
+    // Capability verdict (RFC 0007): the server stamps its auth guards
+    // (requireAuthenticated/requireGuest) and definitions() aggregates the
+    // stamps across aliases, groups, and inline handlers. An older server
+    // emits no `capabilities` field at all — only then fall back to the
+    // pre-capability name heuristic so mixed-version apps don't regress.
+    const verdict = authMiddlewareVerdict(route)
+    const hasAuthMiddleware = verdict === 'verified' || verdict === 'legacy-name-match'
     const hasControllerAuth = methodInfo ? AUTH_CALL_PATTERN.test(methodInfo.body) : false
 
     if (hasAuthMiddleware || hasControllerAuth) {
@@ -473,9 +507,21 @@ async function auditRoutes(
           `authz:${routeLabel}`,
           routeLabel,
           'pass',
-          hasAuthMiddleware
-            ? `Protected by middleware: ${middlewareNames.join(', ')}.`
-            : `Controller checks authentication in ${controllerKey}.`,
+          verdict === 'verified'
+            ? 'Protected by an authentication guard (verified via middleware capabilities).'
+            : verdict === 'legacy-name-match'
+              ? `Protected by middleware: ${middlewareNames.join(', ')}.`
+              : `Controller checks authentication in ${controllerKey}.`,
+        ),
+      )
+    } else if (verdict === 'unverified-auth-name') {
+      findings.push(
+        finding(
+          `authz:${routeLabel}`,
+          routeLabel,
+          'warn',
+          `Middleware (${middlewareNames.join(', ')}) is named like an auth guard but is not one the framework recognizes.`,
+          'Use requireAuthenticated() from @guren/core (recognized inline or aliased), or suppress via config/audit.ts if this middleware really enforces authentication.',
         ),
       )
     } else if (route.hasInlineMiddleware) {
@@ -484,8 +530,8 @@ async function auditRoutes(
           `authz:${routeLabel}`,
           routeLabel,
           'warn',
-          'Inline middleware is attached but cannot be inspected — verify it enforces authentication.',
-          'Prefer named middleware via router.aliasMiddleware() so audits can verify protection.',
+          'Inline middleware is attached but is not a recognized authentication guard.',
+          'Use requireAuthenticated() from @guren/core (recognized inline or aliased), or suppress via config/audit.ts if this middleware really enforces authentication.',
         ),
       )
     } else if (WEBHOOK_PATH_PATTERN.test(route.path)) {

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -9,6 +9,7 @@ import {
   listModuleNames,
 } from './discovery'
 import { loadRouteDefinitions } from './load-routes'
+import type { RouteDefinition } from '@guren/core'
 import {
   classifyFindingKey,
   primaryClassificationId,
@@ -70,6 +71,9 @@ const WEBHOOK_PATH_PATTERN = /(webhook|callback)/i
 
 const AUTH_MIDDLEWARE_PATTERN = /auth/i
 
+const UNRECOGNIZED_GUARD_SUGGESTION =
+  'Use requireAuthenticated() from @guren/core (recognized inline or aliased), or suppress via config/audit.ts if this middleware really enforces authentication.'
+
 export type AuthMiddlewareVerdict =
   /** A middleware in the chain carries the framework's authentication capability. */
   | 'verified'
@@ -83,12 +87,13 @@ export type AuthMiddlewareVerdict =
 /**
  * Exported for tests. `route` is the shape `Router.definitions()` returns:
  * `capabilities` is always present (possibly empty) on servers with
- * capability support, and absent entirely on older servers.
+ * capability support, and absent entirely on older servers. Typed against
+ * the server's own RouteDefinition so a capability-shape change over there
+ * breaks this compile instead of silently mis-detecting.
  */
-export function authMiddlewareVerdict(route: {
-  middlewareNames?: string[]
-  capabilities?: { authentication?: { mode: string } }
-}): AuthMiddlewareVerdict {
+export function authMiddlewareVerdict(
+  route: Pick<RouteDefinition, 'middlewareNames' | 'capabilities'>,
+): AuthMiddlewareVerdict {
   if (route.capabilities?.authentication?.mode === 'required') return 'verified'
 
   const nameMatches = (route.middlewareNames ?? []).some((name) => AUTH_MIDDLEWARE_PATTERN.test(name))
@@ -521,7 +526,7 @@ async function auditRoutes(
           routeLabel,
           'warn',
           `Middleware (${middlewareNames.join(', ')}) is named like an auth guard but is not one the framework recognizes.`,
-          'Use requireAuthenticated() from @guren/core (recognized inline or aliased), or suppress via config/audit.ts if this middleware really enforces authentication.',
+          UNRECOGNIZED_GUARD_SUGGESTION,
         ),
       )
     } else if (route.hasInlineMiddleware) {
@@ -531,7 +536,7 @@ async function auditRoutes(
           routeLabel,
           'warn',
           'Inline middleware is attached but is not a recognized authentication guard.',
-          'Use requireAuthenticated() from @guren/core (recognized inline or aliased), or suppress via config/audit.ts if this middleware really enforces authentication.',
+          UNRECOGNIZED_GUARD_SUGGESTION,
         ),
       )
     } else if (WEBHOOK_PATH_PATTERN.test(route.path)) {

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
-import { runAudit } from '../src/audit'
+import { authMiddlewareVerdict, runAudit } from '../src/audit'
 import { createTempWorkspace } from './helpers'
 
 async function writeRoutes(dir: string, contents: string): Promise<void> {
@@ -267,7 +267,10 @@ export default function registerRoutes(router: any) {
     }
   })
 
-  it('passes authz when auth middleware protects the route', async () => {
+  it('warns when middleware is only named like an auth guard (unverifiable)', async () => {
+    // Pre-capability audits passed any middleware whose *name* matched
+    // /auth/i. The name alone proves nothing — this alias is never even
+    // registered — so with capability-aware servers this is now a warn.
     const workspace = await createTempWorkspace('guren-cli-audit-authz-mw-')
 
     try {
@@ -282,7 +285,62 @@ export default function registerRoutes(router: any) {
 
       const authz = report.findings.find(f => f.key === 'authz:DELETE /posts/:id')
       expect(authz).toBeDefined()
-      expect(authz!.status).toBe('pass')
+      expect(authz!.status).toBe('warn')
+      expect(authz!.message).toContain('not one the framework recognizes')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('passes authz for stamped guards, inline or aliased under any name', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-authz-capability-')
+
+    try {
+      await writeRoutes(
+        workspace.dir,
+        `const guard = async (c: any, next: any) => next()
+Object.defineProperty(guard, Symbol.for('guren.capabilities'), {
+  value: { authentication: { mode: 'required' } },
+})
+export default function registerRoutes(router: any) {
+  router.aliasMiddleware('member', guard)
+  router.delete('/posts/:id', (c: any) => null, guard)
+  router.put('/posts/:id', (c: any) => null).middleware('member')
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const inline = report.findings.find(f => f.key === 'authz:DELETE /posts/:id')
+      expect(inline!.status).toBe('pass')
+      expect(inline!.message).toContain('verified via middleware capabilities')
+
+      const aliased = report.findings.find(f => f.key === 'authz:PUT /posts/:id')
+      expect(aliased!.status).toBe('pass')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('does not count guest-only guards as protection', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-authz-guest-')
+
+    try {
+      await writeRoutes(
+        workspace.dir,
+        `const guard = async (c: any, next: any) => next()
+Object.defineProperty(guard, Symbol.for('guren.capabilities'), {
+  value: { authentication: { mode: 'guest-only' } },
+})
+export default function registerRoutes(router: any) {
+  router.delete('/posts/:id', (c: any) => null, guard)
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const authz = report.findings.find(f => f.key === 'authz:DELETE /posts/:id')
+      expect(authz!.status).toBe('warn')
     } finally {
       await workspace.cleanup()
     }
@@ -1377,5 +1435,33 @@ export default function registerRoutes(router: any) {
     } finally {
       await workspace.cleanup()
     }
+  })
+})
+
+describe('authMiddlewareVerdict', () => {
+  const required = { authentication: { mode: 'required' } }
+
+  it('verifies capability-carrying routes regardless of names', () => {
+    expect(authMiddlewareVerdict({ middlewareNames: [], capabilities: required })).toBe('verified')
+    expect(authMiddlewareVerdict({ middlewareNames: ['member'], capabilities: required })).toBe('verified')
+  })
+
+  it('falls back to the name heuristic only for pre-capability servers', () => {
+    // Old server: no capabilities field at all — the name keeps counting so
+    // a newer CLI does not flood a not-yet-upgraded app with false warns.
+    expect(authMiddlewareVerdict({ middlewareNames: ['auth'] })).toBe('legacy-name-match')
+    expect(authMiddlewareVerdict({ middlewareNames: ['member'] })).toBe('none')
+    // New server: empty capabilities means "checked, nothing recognized".
+    expect(authMiddlewareVerdict({ middlewareNames: ['auth'], capabilities: {} })).toBe('unverified-auth-name')
+    expect(authMiddlewareVerdict({ middlewareNames: ['member'], capabilities: {} })).toBe('none')
+  })
+
+  it('treats guest-only as unprotected', () => {
+    expect(
+      authMiddlewareVerdict({
+        middlewareNames: [],
+        capabilities: { authentication: { mode: 'guest-only' } },
+      }),
+    ).toBe('none')
   })
 })

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -1439,7 +1439,7 @@ export default function registerRoutes(router: any) {
 })
 
 describe('authMiddlewareVerdict', () => {
-  const required = { authentication: { mode: 'required' } }
+  const required = { authentication: { mode: 'required' } } as const
 
   it('verifies capability-carrying routes regardless of names', () => {
     expect(authMiddlewareVerdict({ middlewareNames: [], capabilities: required })).toBe('verified')

--- a/packages/server/src/http/middleware/auth.ts
+++ b/packages/server/src/http/middleware/auth.ts
@@ -1,6 +1,7 @@
 import type { Context, MiddlewareHandler } from 'hono'
 import type { Authenticatable, AuthContext } from '../../auth/types'
 import { jsonResponse } from './index'
+import { stampCapabilities } from './capabilities'
 export type { AuthContext } from '../../auth/types'
 
 export interface RequireAuthOptions {
@@ -76,7 +77,7 @@ function resolveAuth(ctx: { get: (key: string) => unknown }): AuthContext | unde
 export function requireAuthenticated(options: RequireAuthOptions = {}): MiddlewareHandler {
   const { redirectTo, status = 401, responseFactory } = options
 
-  return async (ctx, next) => {
+  return stampCapabilities(async (ctx, next) => {
     const auth = resolveAuth(ctx)
 
     if (!auth) {
@@ -96,13 +97,13 @@ export function requireAuthenticated(options: RequireAuthOptions = {}): Middlewa
     }
 
     await next()
-  }
+  }, { authentication: { mode: 'required' } })
 }
 
 export function requireGuest(options: RequireAuthOptions = {}): MiddlewareHandler {
   const { redirectTo, status = 403, responseFactory } = options
 
-  return async (ctx, next) => {
+  return stampCapabilities(async (ctx, next) => {
     const auth = resolveAuth(ctx)
 
     if (!auth) {
@@ -122,7 +123,7 @@ export function requireGuest(options: RequireAuthOptions = {}): MiddlewareHandle
     }
 
     await next()
-  }
+  }, { authentication: { mode: 'guest-only' } })
 }
 
 export { AUTH_CONTEXT_KEY }

--- a/packages/server/src/http/middleware/capabilities.ts
+++ b/packages/server/src/http/middleware/capabilities.ts
@@ -1,0 +1,33 @@
+import type { MiddlewareHandler } from 'hono'
+
+/**
+ * Internal security-capability marker (RFC 0007).
+ *
+ * Built-in middleware factories stamp the handlers they return so tooling
+ * that holds the real function objects (the router registry, `guren audit`
+ * via route loading) can recognize what a handler enforces without name
+ * heuristics. `Symbol.for()` keeps the key identical across duplicated
+ * `@guren/server` copies in one process.
+ *
+ * Deliberately not part of the public API: nothing here is exported from
+ * the package root, and the shape may change in any release. A public
+ * `defineMiddleware` integration is future work in RFC 0007.
+ */
+export const CAPABILITIES = Symbol.for('guren.capabilities')
+
+export interface MiddlewareCapabilities {
+  authentication?: { mode: 'required' | 'guest-only' }
+}
+
+export function stampCapabilities(
+  handler: MiddlewareHandler,
+  capabilities: MiddlewareCapabilities,
+): MiddlewareHandler {
+  Object.defineProperty(handler, CAPABILITIES, { value: capabilities, enumerable: false })
+  return handler
+}
+
+export function capabilitiesOf(handler: unknown): MiddlewareCapabilities | undefined {
+  if (typeof handler !== 'function') return undefined
+  return (handler as { [CAPABILITIES]?: MiddlewareCapabilities })[CAPABILITIES]
+}

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -5,6 +5,7 @@ import { mountRoute } from './mount-route'
 import { flattenRequestQueries, formatValidationErrors, parseRequestPayload, type ValidationErrorLike } from '../http/request'
 import { ValidationException } from '../errors/exceptions/ValidationException'
 import type { ValidationSchema } from '../http/middleware/validation'
+import { capabilitiesOf, type MiddlewareCapabilities } from '../http/middleware/capabilities'
 
 /**
  * Constructor type for Controller classes.
@@ -151,6 +152,15 @@ export interface RouteDefinition {
   middlewareNames?: string[]
   /** Whether inline (unnamed) middleware handlers are attached */
   hasInlineMiddleware?: boolean
+  /**
+   * Security capabilities aggregated from the route's middleware chain
+   * (named aliases, groups, and inline handlers). Always present on routers
+   * from this release — an empty object means "no recognized capability" —
+   * so consumers can distinguish that from definitions produced by older
+   * servers, where the field is absent. The value shape is internal and may
+   * change (RFC 0007).
+   */
+  capabilities?: MiddlewareCapabilities
   /** Controller binding when the handler is a [Controller, 'method'] tuple */
   controller?: {
     name: string
@@ -492,6 +502,7 @@ export class Router<M extends string = never> {
       schemas,
       middlewareNames: [...routeMiddlewareNames],
       hasInlineMiddleware: middlewares.length > 0,
+      capabilities: this.aggregateCapabilities(routeMiddlewareNames, middlewares),
       controller: isControllerAction(handler)
         ? { name: handler[0].name, action: String(handler[1]) }
         : undefined,
@@ -562,6 +573,58 @@ export class Router<M extends string = never> {
 
     this.registry.push(route)
     return createRouteBuilder(route, this.namedRoutes)
+  }
+
+  /**
+   * Security capabilities present on a route's middleware chain, aggregated
+   * across named aliases (group-expanded) and inline handlers. Unlike
+   * `resolveMiddlewareNames`, unregistered names are skipped rather than
+   * thrown: `definitions()` must stay side-effect-free for introspection of
+   * routers that never mount (audit, codegen), and an unresolvable alias
+   * simply contributes no capabilities.
+   */
+  private aggregateCapabilities(
+    names: string[],
+    inline: MiddlewareHandler[],
+    seen?: Set<string>,
+  ): MiddlewareCapabilities {
+    const aggregated: MiddlewareCapabilities = {}
+    const visited = seen ?? new Set<string>()
+
+    const merge = (handler: MiddlewareHandler): void => {
+      const capabilities = capabilitiesOf(handler)
+      if (!capabilities) return
+      if (capabilities.authentication) {
+        // 'required' wins: a route that both requires auth and (oddly)
+        // requires guest is reported as requiring auth.
+        if (!aggregated.authentication || capabilities.authentication.mode === 'required') {
+          aggregated.authentication = capabilities.authentication
+        }
+      }
+    }
+
+    for (const name of names) {
+      if (visited.has(name)) continue
+      visited.add(name)
+
+      const groupNames = this.middlewareGroups.get(name)
+      if (groupNames) {
+        const nested = this.aggregateCapabilities(groupNames, [], visited)
+        if (nested.authentication) {
+          if (!aggregated.authentication || nested.authentication.mode === 'required') {
+            aggregated.authentication = nested.authentication
+          }
+        }
+        continue
+      }
+
+      const handler = this.middlewareAliases.get(name)
+      if (handler) merge(handler)
+    }
+
+    for (const handler of inline) merge(handler)
+
+    return aggregated
   }
 
   private resolveMiddlewareNames(names: string[], seen?: Set<string>): MiddlewareHandler[] {

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -591,15 +591,13 @@ export class Router<M extends string = never> {
     const aggregated: MiddlewareCapabilities = {}
     const visited = seen ?? new Set<string>()
 
-    const merge = (handler: MiddlewareHandler): void => {
-      const capabilities = capabilitiesOf(handler)
-      if (!capabilities) return
-      if (capabilities.authentication) {
-        // 'required' wins: a route that both requires auth and (oddly)
-        // requires guest is reported as requiring auth.
-        if (!aggregated.authentication || capabilities.authentication.mode === 'required') {
-          aggregated.authentication = capabilities.authentication
-        }
+    const absorb = (capabilities: MiddlewareCapabilities | undefined): void => {
+      const auth = capabilities?.authentication
+      if (!auth) return
+      // 'required' wins: a route that both requires auth and (oddly)
+      // requires guest is reported as requiring auth.
+      if (!aggregated.authentication || auth.mode === 'required') {
+        aggregated.authentication = auth
       }
     }
 
@@ -609,20 +607,14 @@ export class Router<M extends string = never> {
 
       const groupNames = this.middlewareGroups.get(name)
       if (groupNames) {
-        const nested = this.aggregateCapabilities(groupNames, [], visited)
-        if (nested.authentication) {
-          if (!aggregated.authentication || nested.authentication.mode === 'required') {
-            aggregated.authentication = nested.authentication
-          }
-        }
+        absorb(this.aggregateCapabilities(groupNames, [], visited))
         continue
       }
 
-      const handler = this.middlewareAliases.get(name)
-      if (handler) merge(handler)
+      absorb(capabilitiesOf(this.middlewareAliases.get(name)))
     }
 
-    for (const handler of inline) merge(handler)
+    for (const handler of inline) absorb(capabilitiesOf(handler))
 
     return aggregated
   }

--- a/packages/server/tests/mvc/router.test.ts
+++ b/packages/server/tests/mvc/router.test.ts
@@ -359,7 +359,7 @@ describe('Router capability aggregation', () => {
   })
 
   it('reads stamps through aliases and groups', () => {
-    const router = new Router()
+    const router = new Router<'member' | 'web'>()
     router.aliasMiddleware('member', stamped('required'))
     router.groupMiddleware('web', ['member'])
     router.post('/direct', () => 'ok').middleware('member')
@@ -371,7 +371,9 @@ describe('Router capability aggregation', () => {
   })
 
   it('skips unregistered middleware names instead of throwing', () => {
-    const router = new Router()
+    // Declared but never aliased: the name typechecks while staying
+    // unregistered at runtime, which is the case under test.
+    const router = new Router<'auth'>()
     router.post('/posts', () => 'ok').middleware('auth')
 
     expect(router.definitions()[0]!.capabilities).toEqual({})

--- a/packages/server/tests/mvc/router.test.ts
+++ b/packages/server/tests/mvc/router.test.ts
@@ -89,6 +89,7 @@ describe('Router route contract metadata', () => {
         },
         middlewareNames: [],
         hasInlineMiddleware: false,
+        capabilities: {},
         controller: undefined,
         summary: 'Create post',
         description: 'Creates a post resource.',
@@ -119,6 +120,7 @@ describe('Router route contract metadata', () => {
         },
         middlewareNames: [],
         hasInlineMiddleware: false,
+        capabilities: {},
         controller: undefined,
         summary: 'Health check',
         description: undefined,
@@ -322,5 +324,71 @@ describe('route contract array query params (#12)', () => {
 
     const bad = await app.request('/posts?tag=a')
     expect(bad.status).toBe(422)
+  })
+})
+
+describe('Router capability aggregation', () => {
+  const noop: MiddlewareHandler = async (_ctx, next) => { await next() }
+
+  function stamped(mode: 'required' | 'guest-only'): MiddlewareHandler {
+    const handler: MiddlewareHandler = async (_ctx, next) => { await next() }
+    Object.defineProperty(handler, Symbol.for('guren.capabilities'), {
+      value: { authentication: { mode } },
+      enumerable: false,
+    })
+    return handler
+  }
+
+  it('always emits capabilities, empty when nothing is recognized', () => {
+    const router = new Router()
+    router.get('/plain', () => 'ok')
+    router.post('/inline', () => 'ok', noop)
+
+    const defs = router.definitions()
+    expect(defs[0]!.capabilities).toEqual({})
+    expect(defs[1]!.capabilities).toEqual({})
+  })
+
+  it('reads stamps from inline middleware', () => {
+    const router = new Router()
+    router.post('/posts', () => 'ok', stamped('required'))
+
+    expect(router.definitions()[0]!.capabilities).toEqual({
+      authentication: { mode: 'required' },
+    })
+  })
+
+  it('reads stamps through aliases and groups', () => {
+    const router = new Router()
+    router.aliasMiddleware('member', stamped('required'))
+    router.groupMiddleware('web', ['member'])
+    router.post('/direct', () => 'ok').middleware('member')
+    router.post('/grouped', () => 'ok').middleware('web')
+
+    const defs = router.definitions()
+    expect(defs[0]!.capabilities?.authentication?.mode).toBe('required')
+    expect(defs[1]!.capabilities?.authentication?.mode).toBe('required')
+  })
+
+  it('skips unregistered middleware names instead of throwing', () => {
+    const router = new Router()
+    router.post('/posts', () => 'ok').middleware('auth')
+
+    expect(router.definitions()[0]!.capabilities).toEqual({})
+  })
+
+  it('lets required win over guest-only', () => {
+    const router = new Router()
+    router.post('/odd', () => 'ok', stamped('guest-only'), stamped('required'))
+
+    expect(router.definitions()[0]!.capabilities?.authentication?.mode).toBe('required')
+  })
+
+  it('requireAuthenticated and requireGuest carry their stamps', async () => {
+    const { requireAuthenticated, requireGuest } = await import('../../src/http/middleware/auth')
+    const { capabilitiesOf } = await import('../../src/http/middleware/capabilities')
+
+    expect(capabilitiesOf(requireAuthenticated())).toEqual({ authentication: { mode: 'required' } })
+    expect(capabilitiesOf(requireGuest())).toEqual({ authentication: { mode: 'guest-only' } })
   })
 })


### PR DESCRIPTION
> Stacked on #251 (audit taxonomy) — merge that first, then retarget this to `main`.

## Summary

Second implementation slice of RFC 0007 (#249): replaces `guren audit`'s name-based auth detection with capability verification.

**The defect**: the audit matched middleware *names* against `/auth/i`. The inline `requireAuthenticated(...)` that `guren add auth` generates was invisible (false warn on every scaffolded auth route), while any alias merely containing "auth" counted as protection.

**The mechanism**:

- `requireAuthenticated()` / `requireGuest()` stamp their returned handlers with an internal `Symbol.for('guren.capabilities')` marker — non-enumerable, process-global identity across duplicated `@guren/server` copies. Deliberately **not** public API (unexported, undocumented; `defineMiddleware` integration is Future Work in the RFC).
- `Router.definitions()` aggregates stamps across aliases, groups, and inline handlers into a new `capabilities` field. It is **always present**: an empty object means "checked, nothing recognized", absence means a pre-capability server — which is what lets the CLI keep a name-heuristic fallback for mixed-version apps instead of flooding them with false warns.
- The audit's verdict: stamped guards pass under any name and registration style; auth-*named* but unrecognized middleware now **warns** with a pointed message (intended behavior change, called out in the RFC's migration section); guest-only guards never count as protection.

## Verification

- Server: 7 new Router aggregation tests (inline/alias/group, unregistered-name leniency, required-beats-guest-only, factory stamps); full suite green.
- CLI: 3 new integration tests + a unit matrix for the verdict function including the legacy-server fallback; 49/49 in `audit.test.ts`, 967-test package suite green, `tsc --noEmit` clean, root `test:bun` 3266 pass / 0 fail.
- Both-direction real-app check: `examples/blog` — all 5 auth routes now report *"verified via middleware capabilities"*, 0 warns; `web` (module-based, OAuth admin) — 4/4 authz passes; `check --spec` in blog confirms no route-definition drift into committed spec views.

Refs: RFC 0007