### PR TITLE
Scan application dependencies in guren audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,11 @@ jobs:
       - name: Dependency audit
         run: bun run audit:deps
 
+      # --no-deps: the app-level scan would resolve the monorepo's root
+      # lockfile and hit the registry on every PR; the root dependency gate
+      # (audit:deps) already covers exactly that surface hermetically.
       - name: Security audit (blog example)
-        run: cd examples/blog && bun ../../packages/cli/src/bin.ts audit
+        run: cd examples/blog && bun ../../packages/cli/src/bin.ts audit --no-deps
 
       # Also the only cross-machine exercise of the spec views' determinism
       # contract: committed-on-macOS vs regenerated-on-ubuntu.

--- a/packages/cli/src/audit-deps.ts
+++ b/packages/cli/src/audit-deps.ts
@@ -1,0 +1,130 @@
+import type { AuditFinding } from './audit'
+
+/**
+ * Dependency vulnerability scan for `guren audit` (RFC 0007): runs
+ * `bun audit --json` in the app and converts advisories into findings.
+ *
+ * Parsing rules: `bun audit` exits 0 (clean) or 1 (advisories found) with
+ * valid JSON either way; any other exit code is an execution/registry
+ * failure. A proxy can also answer with JSON that merely *parses* — an
+ * error object instead of the package→advisories map — so the shape is
+ * validated, not assumed. "Could not scan" is reported as its own finding
+ * and status, never as a pass: an offline machine must not look identical
+ * to a clean one.
+ */
+
+export interface DependencyScan {
+  status: 'complete' | 'unavailable' | 'skipped'
+  tool: 'bun audit'
+}
+
+interface BunAuditAdvisory {
+  url: string
+  title: string
+  severity: string
+  vulnerable_versions: string
+}
+
+const GHSA_PATTERN = /GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}/i
+
+function scanFailure(findings: AuditFinding[], why: string, detail?: string): DependencyScan {
+  findings.push({
+    key: 'deps:scan',
+    title: 'Dependency scan',
+    status: 'warn',
+    message: `Dependencies could not be scanned (${why}).${detail ? ` ${detail}` : ''}`,
+    suggestion:
+      'Run `bun audit` manually to diagnose (registry access is required), or pass --no-deps to skip the scan intentionally.',
+  })
+  return { status: 'unavailable', tool: 'bun audit' }
+}
+
+/**
+ * Pure conversion from a finished `bun audit --json` invocation. Exported
+ * for tests; `auditDependencies` supplies the real subprocess output.
+ */
+export function dependencyFindingsFromScan(
+  stdout: string,
+  exitCode: number,
+  findings: AuditFinding[],
+): DependencyScan {
+  if (exitCode > 1) {
+    return scanFailure(findings, `bun audit exited with code ${exitCode}`)
+  }
+
+  let report: unknown
+  try {
+    report = JSON.parse(stdout)
+  } catch {
+    return scanFailure(findings, 'bun audit produced no JSON')
+  }
+  if (typeof report !== 'object' || report === null || Array.isArray(report)) {
+    return scanFailure(findings, 'unrecognized bun audit output shape')
+  }
+
+  // Collected locally and committed only on success: a shape failure halfway
+  // through must not leave a half-parsed advisory list next to an
+  // "unavailable" status.
+  const parsed: AuditFinding[] = []
+  const seen = new Set<string>()
+
+  for (const [pkg, advisories] of Object.entries(report as Record<string, unknown>)) {
+    if (!Array.isArray(advisories)) {
+      return scanFailure(findings, 'unrecognized bun audit output shape')
+    }
+    for (const advisory of advisories as BunAuditAdvisory[]) {
+      if (typeof advisory?.url !== 'string' || typeof advisory?.severity !== 'string') {
+        return scanFailure(findings, 'unrecognized bun audit output shape')
+      }
+
+      // The same advisory appears once per affected version range; one
+      // finding per package+advisory is what a human (or CI) acts on.
+      const ghsa = advisory.url.match(GHSA_PATTERN)?.[0].toUpperCase() ?? advisory.url
+      const key = `deps:${pkg}:${ghsa}`
+      if (seen.has(key)) continue
+      seen.add(key)
+
+      const severity = advisory.severity.toLowerCase()
+      parsed.push({
+        key,
+        title: `${pkg} dependency`,
+        status: severity === 'critical' || severity === 'high' ? 'fail' : 'warn',
+        message: `${severity} advisory (${advisory.vulnerable_versions}): ${advisory.title}`,
+        suggestion: `Update ${pkg} to a patched release (see ${advisory.url}), or record an ignore with a reason in config/audit.ts.`,
+      })
+    }
+  }
+
+  if (parsed.length === 0) {
+    parsed.push({
+      key: 'deps:none',
+      title: 'Dependency scan',
+      status: 'pass',
+      message: 'No known vulnerabilities in installed dependencies.',
+    })
+  }
+
+  findings.push(...parsed)
+  return { status: 'complete', tool: 'bun audit' }
+}
+
+export async function auditDependencies(cwd: string, findings: AuditFinding[]): Promise<DependencyScan> {
+  let proc: ReturnType<typeof Bun.spawn>
+  try {
+    proc = Bun.spawn([process.execPath, 'audit', '--json'], {
+      cwd,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      timeout: 60_000,
+    })
+  } catch (error) {
+    return scanFailure(findings, 'bun audit could not be started', error instanceof Error ? error.message : undefined)
+  }
+
+  const [stdout, exitCode] = await Promise.all([
+    new Response(proc.stdout as ReadableStream).text(),
+    proc.exited,
+  ])
+
+  return dependencyFindingsFromScan(stdout, exitCode, findings)
+}

--- a/packages/cli/src/audit-deps.ts
+++ b/packages/cli/src/audit-deps.ts
@@ -11,6 +11,11 @@ import type { AuditFinding } from './audit'
  * validated, not assumed. "Could not scan" is reported as its own finding
  * and status, never as a pass: an offline machine must not look identical
  * to a clean one.
+ *
+ * The monorepo's own supply-chain gate (scripts/smoke/dependency-audit.ts)
+ * implements the same contract with its own policy (reasoned ignore list,
+ * stale detection); a change to `bun audit`'s output shape needs both
+ * updated.
  */
 
 export interface DependencyScan {
@@ -26,6 +31,7 @@ interface BunAuditAdvisory {
 }
 
 const GHSA_PATTERN = /GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}/i
+const BAD_SHAPE = 'unrecognized bun audit output shape'
 
 function scanFailure(findings: AuditFinding[], why: string, detail?: string): DependencyScan {
   findings.push({
@@ -41,25 +47,28 @@ function scanFailure(findings: AuditFinding[], why: string, detail?: string): De
 
 /**
  * Pure conversion from a finished `bun audit --json` invocation. Exported
- * for tests; `auditDependencies` supplies the real subprocess output.
+ * for tests; `startDependencyScan` supplies the real subprocess output.
  */
 export function dependencyFindingsFromScan(
   stdout: string,
   exitCode: number,
   findings: AuditFinding[],
+  stderr = '',
 ): DependencyScan {
+  const detail = stderr.trim() || undefined
+
   if (exitCode > 1) {
-    return scanFailure(findings, `bun audit exited with code ${exitCode}`)
+    return scanFailure(findings, `bun audit exited with code ${exitCode}`, detail)
   }
 
   let report: unknown
   try {
     report = JSON.parse(stdout)
   } catch {
-    return scanFailure(findings, 'bun audit produced no JSON')
+    return scanFailure(findings, 'bun audit produced no JSON', detail)
   }
   if (typeof report !== 'object' || report === null || Array.isArray(report)) {
-    return scanFailure(findings, 'unrecognized bun audit output shape')
+    return scanFailure(findings, BAD_SHAPE, detail)
   }
 
   // Collected locally and committed only on success: a shape failure halfway
@@ -70,11 +79,11 @@ export function dependencyFindingsFromScan(
 
   for (const [pkg, advisories] of Object.entries(report as Record<string, unknown>)) {
     if (!Array.isArray(advisories)) {
-      return scanFailure(findings, 'unrecognized bun audit output shape')
+      return scanFailure(findings, BAD_SHAPE, detail)
     }
     for (const advisory of advisories as BunAuditAdvisory[]) {
       if (typeof advisory?.url !== 'string' || typeof advisory?.severity !== 'string') {
-        return scanFailure(findings, 'unrecognized bun audit output shape')
+        return scanFailure(findings, BAD_SHAPE, detail)
       }
 
       // The same advisory appears once per affected version range; one
@@ -95,6 +104,13 @@ export function dependencyFindingsFromScan(
     }
   }
 
+  // Exit 1 is bun audit's "vulnerabilities found" contract: an exit-1 run
+  // whose report contains none is contradicting itself (truncated output,
+  // a broken wrapper), and must not read as a clean pass.
+  if (exitCode === 1 && parsed.length === 0) {
+    return scanFailure(findings, 'bun audit exited 1 but reported no advisories', detail)
+  }
+
   if (parsed.length === 0) {
     parsed.push({
       key: 'deps:none',
@@ -108,7 +124,18 @@ export function dependencyFindingsFromScan(
   return { status: 'complete', tool: 'bun audit' }
 }
 
-export async function auditDependencies(cwd: string, findings: AuditFinding[]): Promise<DependencyScan> {
+export interface DependencyScanOutput {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+/**
+ * Kick off `bun audit --json` without awaiting it, so the registry
+ * round-trip can overlap the local file scanning. `null` means the process
+ * could not even start.
+ */
+export function startDependencyScan(cwd: string): Promise<DependencyScanOutput | null> {
   let proc: ReturnType<typeof Bun.spawn>
   try {
     proc = Bun.spawn([process.execPath, 'audit', '--json'], {
@@ -117,14 +144,23 @@ export async function auditDependencies(cwd: string, findings: AuditFinding[]): 
       stderr: 'pipe',
       timeout: 60_000,
     })
-  } catch (error) {
-    return scanFailure(findings, 'bun audit could not be started', error instanceof Error ? error.message : undefined)
+  } catch {
+    return Promise.resolve(null)
   }
 
-  const [stdout, exitCode] = await Promise.all([
+  return Promise.all([
     new Response(proc.stdout as ReadableStream).text(),
+    new Response(proc.stderr as ReadableStream).text(),
     proc.exited,
-  ])
+  ]).then(([stdout, stderr, exitCode]) => ({ stdout, stderr, exitCode }))
+}
 
-  return dependencyFindingsFromScan(stdout, exitCode, findings)
+export function dependencyFindingsFromOutput(
+  output: DependencyScanOutput | null,
+  findings: AuditFinding[],
+): DependencyScan {
+  if (output === null) {
+    return scanFailure(findings, 'bun audit could not be started')
+  }
+  return dependencyFindingsFromScan(output.stdout, output.exitCode, findings, output.stderr)
 }

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -15,6 +15,7 @@ import {
   primaryClassificationId,
   type AuditClassification,
 } from './audit-taxonomy'
+import { auditDependencies, type DependencyScan } from './audit-deps'
 import {
   classUsesAuthenticatableBase,
   extractClassDeclaration,
@@ -49,6 +50,8 @@ export interface AuditReport {
   failCount: number
   ignoredCount: number
   routesAnalyzed: boolean
+  /** Present when the dependency scan ran (or was skipped via options). */
+  dependencyScan?: DependencyScan
 }
 
 export interface RunAuditOptions {
@@ -56,6 +59,12 @@ export interface RunAuditOptions {
   routesFile?: string
   /** Explicit path to the ignore config (relative to cwd). Defaults to config/audit.{ts,js,mjs}. */
   auditConfigFile?: string
+  /**
+   * Scan installed dependencies via `bun audit` (requires registry access).
+   * Defaults to false here so embedded callers stay hermetic; the `guren
+   * audit` command enables it unless invoked with --no-deps.
+   */
+  deps?: boolean
 }
 
 const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
@@ -135,6 +144,10 @@ export async function runAudit(options: RunAuditOptions = {}): Promise<AuditRepo
   await auditSourceFiles(cwd, findings)
   await auditModels(cwd, findings)
 
+  const dependencyScan: DependencyScan = options.deps
+    ? await auditDependencies(cwd, findings)
+    : { status: 'skipped', tool: 'bun audit' }
+
   for (const entry of findings) {
     entry.classifications ??= classifyFindingKey(entry.key)
   }
@@ -149,6 +162,7 @@ export async function runAudit(options: RunAuditOptions = {}): Promise<AuditRepo
     failCount: findings.filter((f) => f.status === 'fail').length,
     ignoredCount: findings.filter((f) => f.status === 'ignored').length,
     routesAnalyzed,
+    dependencyScan,
   }
 }
 
@@ -810,6 +824,9 @@ export function renderAuditReport(report: AuditReport): void {
 
   if (!report.routesAnalyzed) {
     consola.warn('Route-level checks were skipped (routes could not be loaded).')
+  }
+  if (report.dependencyScan?.status === 'skipped') {
+    consola.info('Dependency scan skipped (--no-deps).')
   }
 
   for (const f of report.findings) {

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -15,7 +15,7 @@ import {
   primaryClassificationId,
   type AuditClassification,
 } from './audit-taxonomy'
-import { auditDependencies, type DependencyScan } from './audit-deps'
+import { dependencyFindingsFromOutput, startDependencyScan, type DependencyScan } from './audit-deps'
 import {
   classUsesAuthenticatableBase,
   extractClassDeclaration,
@@ -137,6 +137,11 @@ export async function runAudit(options: RunAuditOptions = {}): Promise<AuditRepo
   const cwd = resolve(options.cwd ?? process.cwd())
   const findings: AuditFinding[] = []
 
+  // Kicked off first so the registry round-trip overlaps the local
+  // parsing below; the result is folded in (in stable finding order)
+  // once the local scans are done.
+  const dependencyScanOutput = options.deps ? startDependencyScan(cwd) : null
+
   const controllerMethods = await parseControllerMethods(cwd, findings)
 
   const routesAnalyzed = await auditRoutes(cwd, options.routesFile, controllerMethods, findings)
@@ -144,8 +149,8 @@ export async function runAudit(options: RunAuditOptions = {}): Promise<AuditRepo
   await auditSourceFiles(cwd, findings)
   await auditModels(cwd, findings)
 
-  const dependencyScan: DependencyScan = options.deps
-    ? await auditDependencies(cwd, findings)
+  const dependencyScan: DependencyScan = dependencyScanOutput
+    ? dependencyFindingsFromOutput(await dependencyScanOutput, findings)
     : { status: 'skipped', tool: 'bun audit' }
 
   for (const entry of findings) {

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1802,7 +1802,7 @@ const checkCommand = defineCommand({
 const auditCommand = defineCommand({
   meta: {
     name: 'audit',
-    description: 'Run a security audit: validation, authentication, raw SQL, secrets, mass assignment.',
+    description: 'Run a security audit: validation, authentication, raw SQL, secrets, mass assignment, dependency vulnerabilities.',
   },
   args: {
     json: {
@@ -1821,12 +1821,18 @@ const auditCommand = defineCommand({
       type: 'string',
       description: 'Path to the ignore config (defaults to config/audit.{ts,js,mjs}).',
     },
+    deps: {
+      type: 'boolean',
+      default: true,
+      description: 'Scan dependencies via bun audit (requires registry access). Disable with --no-deps.',
+    },
   },
   async run({ args }) {
     const report = await runAudit({
       cwd: args.app,
       routesFile: args.routes,
       auditConfigFile: args.auditConfig,
+      deps: args.deps,
     })
 
     if (args.json) {

--- a/packages/cli/tests/audit-deps.test.ts
+++ b/packages/cli/tests/audit-deps.test.ts
@@ -110,3 +110,23 @@ describe('dependencyFindingsFromScan partial failures', () => {
     expect(findings.map((f) => f.key)).toEqual(['deps:scan'])
   })
 })
+
+describe('dependencyFindingsFromScan exit-code contract', () => {
+  it('treats exit 1 with an empty report as scan-unavailable, not a clean pass', () => {
+    // Exit 1 is bun audit's "vulnerabilities found" contract — an exit-1
+    // run reporting none is contradicting itself (truncated output, a
+    // broken wrapper) and must not produce deps:none.
+    const findings: AuditFinding[] = []
+    const scan = dependencyFindingsFromScan('{}', 1, findings)
+
+    expect(scan.status).toBe('unavailable')
+    expect(findings.map((f) => f.key)).toEqual(['deps:scan'])
+  })
+
+  it('surfaces stderr detail on scan failures', () => {
+    const findings: AuditFinding[] = []
+    dependencyFindingsFromScan('', 7, findings, 'error: registry unreachable\n')
+
+    expect(findings[0]!.message).toContain('registry unreachable')
+  })
+})

--- a/packages/cli/tests/audit-deps.test.ts
+++ b/packages/cli/tests/audit-deps.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'bun:test'
+import type { AuditFinding } from '../src/audit'
+import { dependencyFindingsFromScan } from '../src/audit-deps'
+
+// Captured from a real `bun audit --json` run (bun 1.3.14) and trimmed:
+// values are a map of package name → advisory list, advisories repeat per
+// affected version range, and carry fields (id, cwe, cvss) beyond what the
+// scan consumes — the parser must tolerate them.
+const REAL_SHAPE = JSON.stringify({
+  'js-yaml': [
+    {
+      id: 1123911,
+      url: 'https://github.com/advisories/GHSA-52cp-r559-cp3m',
+      title: 'js-yaml: YAML merge-key chains can force quadratic CPU consumption',
+      severity: 'high',
+      vulnerable_versions: '>=4.0.0 <4.3.0',
+      cwe: ['CWE-400', 'CWE-407'],
+      cvss: { score: 7.5, vectorString: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H' },
+    },
+    {
+      id: 1123912,
+      url: 'https://github.com/advisories/GHSA-52cp-r559-cp3m',
+      title: 'js-yaml: YAML merge-key chains can force quadratic CPU consumption',
+      severity: 'high',
+      vulnerable_versions: '>=3.0.0 <3.15.0',
+      cwe: ['CWE-400', 'CWE-407'],
+      cvss: { score: 7.5, vectorString: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H' },
+    },
+  ],
+  esbuild: [
+    {
+      id: 1102341,
+      url: 'https://github.com/advisories/GHSA-67mh-4wv8-2f99',
+      title: 'esbuild enables any website to send requests to the development server',
+      severity: 'moderate',
+      vulnerable_versions: '<=0.24.2',
+      cwe: ['CWE-346'],
+      cvss: { score: 5.3, vectorString: 'CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:N/A:N' },
+    },
+  ],
+})
+
+describe('dependencyFindingsFromScan', () => {
+  it('converts advisories to findings, one per package+advisory', () => {
+    const findings: AuditFinding[] = []
+    const scan = dependencyFindingsFromScan(REAL_SHAPE, 1, findings)
+
+    expect(scan.status).toBe('complete')
+    // Two js-yaml version ranges collapse into one finding.
+    expect(findings.map((f) => f.key)).toEqual([
+      'deps:js-yaml:GHSA-52CP-R559-CP3M',
+      'deps:esbuild:GHSA-67MH-4WV8-2F99',
+    ])
+    expect(findings[0]!.status).toBe('fail') // high
+    expect(findings[1]!.status).toBe('warn') // moderate
+    expect(findings[0]!.message).toContain('quadratic CPU')
+    expect(findings[1]!.suggestion).toContain('config/audit.ts')
+  })
+
+  it('reports a clean scan as a pass finding', () => {
+    const findings: AuditFinding[] = []
+    const scan = dependencyFindingsFromScan('{}', 0, findings)
+
+    expect(scan.status).toBe('complete')
+    expect(findings).toHaveLength(1)
+    expect(findings[0]!.key).toBe('deps:none')
+    expect(findings[0]!.status).toBe('pass')
+  })
+
+  it('treats exit codes above 1 as scan-unavailable, never a pass', () => {
+    const findings: AuditFinding[] = []
+    const scan = dependencyFindingsFromScan('', 7, findings)
+
+    expect(scan.status).toBe('unavailable')
+    expect(findings[0]!.key).toBe('deps:scan')
+    expect(findings[0]!.status).toBe('warn')
+  })
+
+  it('treats non-JSON and non-map JSON as scan-unavailable', () => {
+    for (const stdout of ['registry timeout', '{"error":"blocked by proxy"}', '[]']) {
+      const findings: AuditFinding[] = []
+      const scan = dependencyFindingsFromScan(stdout, 1, findings)
+
+      expect(scan.status).toBe('unavailable')
+      expect(findings[0]!.key).toBe('deps:scan')
+    }
+  })
+})
+
+describe('dependencyFindingsFromScan partial failures', () => {
+  it('does not leak half-parsed findings when a later entry is malformed', () => {
+    const findings: AuditFinding[] = []
+    const scan = dependencyFindingsFromScan(
+      JSON.stringify({
+        'ok-package': [
+          {
+            url: 'https://github.com/advisories/GHSA-aaaa-bbbb-cccc',
+            title: 'valid advisory',
+            severity: 'high',
+            vulnerable_versions: '<1.0.0',
+          },
+        ],
+        'broken-package': 'not-an-array',
+      }),
+      1,
+      findings,
+    )
+
+    expect(scan.status).toBe('unavailable')
+    expect(findings.map((f) => f.key)).toEqual(['deps:scan'])
+  })
+})

--- a/scripts/smoke/dependency-audit.ts
+++ b/scripts/smoke/dependency-audit.ts
@@ -10,6 +10,10 @@
  * ignores, or an invalid ignore list, 2 scan unavailable (registry
  * failure or unrecognized `bun audit` output) — CI treats an unavailable
  * scan as a failure rather than a silent pass.
+ *
+ * `guren audit`'s app-facing scan (packages/cli/src/audit-deps.ts)
+ * implements the same `bun audit` contract with its own policy; a change
+ * to the output shape needs both updated.
  */
 
 interface Advisory {


### PR DESCRIPTION
> Stacked on #253 (capability verdict), which stacks on #251 (taxonomy). Merge order: #251 → #253 → this, retargeting each time.

## Summary

Third implementation slice of RFC 0007 (#249): `guren audit` gains dependency vulnerability scanning — the missing SCA leg next to its existing static checks.

- Runs `bun audit --json` in the app; advisories become findings keyed `deps:<pkg>:<GHSA>` (one per package+advisory — repeated version ranges collapse), classified **A06:2021** via the taxonomy table, with critical/high → `fail` (gating the existing exit code) and moderate/low → `warn`.
- Parsing reuses the rules proven by the monorepo's own supply-chain gate: exit codes 0/1 carry valid JSON, anything else is a scan failure; the report shape is validated before iterating; a mid-parse shape failure never leaves half-parsed findings next to an `unavailable` status.
- **"Could not scan" is never a pass**: it is its own `warn` finding plus a `dependencyScan.status` field in the JSON report (`complete` / `unavailable` / `skipped`), so CI can require a completed scan.
- Default **on** for the CLI command; `--no-deps` opts out and the skip is printed. `runAudit()` defaults it **off** so embedded callers (tests, MCP, check tooling) stay hermetic.
- The monorepo's blog-example CI step now passes `--no-deps`: the app-level scan would resolve the workspace root lockfile and hit the registry on every PR, a surface the root `audit:deps` gate already covers hermetically.

One flag-parsing find along the way: a `noDeps` citty arg only matches `--noDeps`, silently ignoring `--no-deps` — the flag is instead declared as `deps` with `default: true`, which citty negates properly.

## Verification

- 5 fixture tests over captured real `bun audit --json` output (bun 1.3.14): conversion/dedupe/severity mapping, clean-scan pass, exit>1, non-JSON / error-JSON / array shapes, and the partial-failure no-leak case. `packages/cli`: 977 pass / 0 fail, `tsc --noEmit` clean.
- Live E2E on `examples/blog`: default run reports the workspace's one known advisory as `[warn] [A06] esbuild dependency ...` with `dependencyScan: {"status":"complete"}`; `--no-deps` prints the skip note and emits no deps findings.

Refs: RFC 0007