### PR TITLE
Scaffold CI workflows into new apps and add check --ci

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1769,6 +1769,10 @@ const checkCommand = defineCommand({
       type: 'boolean',
       description: 'Restrict file-scanning checks to files changed vs. the merge base with main.',
     },
+    ci: {
+      type: 'boolean',
+      description: 'Exit non-zero when any check fails or warns (runs the full suite; for CI gates).',
+    },
   },
   async run({ args }) {
     const report = await runCheck({
@@ -1787,13 +1791,24 @@ const checkCommand = defineCommand({
       renderCheckReport(report)
     }
 
-    // Only the suite flags (`--arch`/`--docs`/`--spec`) gate on exit code.
-    // Plain `guren check` has never set one (it's a v1.0-stable command;
-    // changing that default is a breaking change reserved for a major
-    // release). The fast-path flags are new, with no prior contract to
-    // preserve, so they can gate CI from day one — that's the intended way
-    // to enforce boundaries, doc links, and spec freshness in CI.
+    // Only the suite flags (`--arch`/`--docs`/`--spec`) and the opt-in
+    // `--ci` gate on exit code. Plain `guren check` has never set one (it's
+    // a v1.0-stable command; changing that default is a breaking change
+    // reserved for a major release). These flags are newer, with no prior
+    // contract to preserve, so they can gate CI from day one — that's the
+    // intended way to enforce checks in CI without breaking the default.
     if ((args.arch || args.docs || args.spec) && report.failCount > 0) {
+      process.exitCode = 1
+    }
+    // --ci also gates on warns: most integrity problems (a missing codegen
+    // manifest, an unregistered console command) report as 'warn', so a
+    // fail-only gate would wave nearly everything through. Test-coverage
+    // nudges (`test:*`) are advice rather than integrity and are exempt —
+    // scaffolding a controller must not turn CI red until a test exists.
+    const gating = report.checks.filter(
+      (c) => c.status === 'fail' || (c.status === 'warn' && !c.key.startsWith('test:')),
+    )
+    if (args.ci && gating.length > 0) {
       process.exitCode = 1
     }
   },

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1775,6 +1775,14 @@ const checkCommand = defineCommand({
     },
   },
   async run({ args }) {
+    // --ci promises a full-suite gate; letting a suite flag narrow the run
+    // underneath it would report success while docs/spec/core went unchecked.
+    if (args.ci && (args.arch || args.docs || args.spec)) {
+      consola.error('check --ci runs the full suite — drop --arch/--docs/--spec (they gate on their own).')
+      process.exitCode = 1
+      return
+    }
+
     const report = await runCheck({
       cwd: args.app,
       json: Boolean(args.json),
@@ -1802,13 +1810,10 @@ const checkCommand = defineCommand({
     }
     // --ci also gates on warns: most integrity problems (a missing codegen
     // manifest, an unregistered console command) report as 'warn', so a
-    // fail-only gate would wave nearly everything through. Test-coverage
-    // nudges (`test:*`) are advice rather than integrity and are exempt —
-    // scaffolding a controller must not turn CI red until a test exists.
-    const gating = report.checks.filter(
-      (c) => c.status === 'fail' || (c.status === 'warn' && !c.key.startsWith('test:')),
-    )
-    if (args.ci && gating.length > 0) {
+    // fail-only gate would wave nearly everything through. Advisory checks
+    // (test-coverage nudges) are exempt — the flag lives on the result, so
+    // JSON consumers see the same rule this gate applies.
+    if (args.ci && report.checks.some((c) => !c.advisory && c.status !== 'pass')) {
       process.exitCode = 1
     }
   },

--- a/packages/cli/src/check-result.ts
+++ b/packages/cli/src/check-result.ts
@@ -7,6 +7,12 @@ export interface CheckResult {
   message: string
   suggestion?: string
   filePath?: string
+  /**
+   * Advice rather than integrity (e.g. test-coverage nudges): exit-code
+   * gates such as `check --ci` skip advisory warns, and JSON consumers can
+   * predict the exit code without re-deriving the rule from finding keys.
+   */
+  advisory?: boolean
 }
 
 export interface CheckReport {

--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -184,8 +184,15 @@ export async function runCheck(options: RunCheckOptions = {}): Promise<CheckRepo
       checks.push(check(`test:${name}`, `${name} tests`, hasTest ? 'pass' : 'warn', message, suggestion))
     }
 
-    // 5. Check generated manifests are present
-    const manifests = ['.guren/routes.gen.ts', '.guren/pages.gen.ts', '.guren/data.gen.ts']
+    // 5. Check generated manifests are present. The pages manifest only
+    // exists for apps with Inertia pages — codegen never emits it in an
+    // API-only app, so demanding it there is a false positive.
+    const hasPages = await fileExists(cwd, 'resources/js/pages')
+    const manifests = [
+      '.guren/routes.gen.ts',
+      ...(hasPages ? ['.guren/pages.gen.ts'] : []),
+      '.guren/data.gen.ts',
+    ]
     for (const manifest of manifests) {
       const exists = await fileExists(cwd, manifest)
       checks.push(

--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -25,6 +25,7 @@ import { checkSchemaTimestamps } from './schema-check'
 import { schemaPathFor } from './schema-parser'
 import { ParseCache } from './parse-cache'
 import { extractInertiaPageRefs, resolveInertiaPageFile, expectedInertiaPagePath } from './inertia-pages'
+import { appEmitsPageManifest } from './pages-types'
 import { runArchCheck } from './arch-check'
 import { runDocsCheck } from './docs-check'
 import { runSpecCheck } from './spec-check'
@@ -181,13 +182,15 @@ export async function runCheck(options: RunCheckOptions = {}): Promise<CheckRepo
       const suggestion = hasTest
         ? undefined
         : `If these routes are not already covered, run: bunx guren make:test ${name.replace('Controller', '')} --controller${moduleFlag}`
-      checks.push(check(`test:${name}`, `${name} tests`, hasTest ? 'pass' : 'warn', message, suggestion))
+      // Advisory: a missing test is advice, not an integrity failure, so
+      // exit-code gates (check --ci) must not fail on it.
+      checks.push({ ...check(`test:${name}`, `${name} tests`, hasTest ? 'pass' : 'warn', message, suggestion), advisory: true })
     }
 
     // 5. Check generated manifests are present. The pages manifest only
     // exists for apps with Inertia pages — codegen never emits it in an
     // API-only app, so demanding it there is a false positive.
-    const hasPages = await fileExists(cwd, 'resources/js/pages')
+    const hasPages = await appEmitsPageManifest(cwd)
     const manifests = [
       '.guren/routes.gen.ts',
       ...(hasPages ? ['.guren/pages.gen.ts'] : []),

--- a/packages/cli/src/pages-types.ts
+++ b/packages/cli/src/pages-types.ts
@@ -20,6 +20,18 @@ const DEFAULT_PAGES_DIR = 'resources/js/pages'
 const DEFAULT_OUTPUT_FILE = '.guren/pages.gen.ts'
 const PAGE_COMPONENT_EXTENSIONS = new Set(['.tsx', '.jsx'])
 
+/**
+ * Whether codegen would emit a pages manifest for this app: true only when
+ * the pages directory contains page components — `generatePageTypes` writes
+ * nothing otherwise. check (and eventually doctor) share this predicate so
+ * "is .guren/pages.gen.ts expected?" cannot drift from codegen's actual rule
+ * (an API-only app must not be told to generate one).
+ */
+export async function appEmitsPageManifest(appRoot: string, pagesDir?: string): Promise<boolean> {
+  const definitions = await collectPageDefinitions(resolve(appRoot, pagesDir ?? DEFAULT_PAGES_DIR))
+  return definitions.length > 0
+}
+
 export async function generatePageTypes(
   options: GeneratePageTypesOptions = {},
 ): Promise<{ outputPath: string; definitions: PageDefinition[] }> {

--- a/packages/cli/tests/check-ci-flag.test.ts
+++ b/packages/cli/tests/check-ci-flag.test.ts
@@ -1,0 +1,104 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'bun:test'
+import { createTempWorkspace } from './helpers'
+
+const CLI_BIN_PATH = resolve(import.meta.dir, '../src/bin.ts')
+
+async function runBin(args: string[], cwd: string): Promise<number> {
+  const proc = Bun.spawn(['bun', CLI_BIN_PATH, ...args], {
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
+  return proc.exited
+}
+
+/**
+ * In a real app `guren codegen` runs before `check --ci` (that is the
+ * scaffolded workflow order); stub its manifests so fixtures match that
+ * state instead of warning about missing generated files.
+ */
+async function writeCodegenManifests(dir: string): Promise<void> {
+  await mkdir(join(dir, '.guren'), { recursive: true })
+  for (const manifest of ['routes.gen.ts', 'pages.gen.ts', 'data.gen.ts']) {
+    await writeFile(join(dir, '.guren', manifest), 'export {}\n', 'utf8')
+  }
+}
+
+/** A controller with no matching test file: `check` reports it as a warn. */
+async function writeUntestedController(dir: string): Promise<void> {
+  await mkdir(join(dir, 'app/Http/Controllers'), { recursive: true })
+  await writeFile(
+    join(dir, 'app/Http/Controllers/WidgetController.ts'),
+    `export default class WidgetController {
+  async index() {
+    return { widgets: [] }
+  }
+}`,
+    'utf8',
+  )
+}
+
+describe('check --ci exit gating', () => {
+  it('plain check never sets an exit code; --ci gates on integrity warns', async () => {
+    const workspace = await createTempWorkspace('guren-cli-check-ci-')
+
+    try {
+      // Routes exist but no codegen manifests: an integrity warn.
+      await mkdir(join(workspace.dir, 'routes'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'routes/web.ts'),
+        `export default function registerRoutes(router: any) {
+  router.get('/health', (c: any) => c.json({ status: 'ok' }))
+}`,
+        'utf8',
+      )
+
+      // The stable v1.0 contract: findings alone never fail a plain check.
+      expect(await runBin(['check'], workspace.dir)).toBe(0)
+      // The opt-in gate fails on integrity warns — most integrity problems
+      // report as 'warn', so a fail-only gate would wave nearly everything
+      // through.
+      expect(await runBin(['check', '--ci'], workspace.dir)).toBe(1)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('--ci does not gate on test-coverage nudges', async () => {
+    const workspace = await createTempWorkspace('guren-cli-check-ci-coverage-')
+
+    try {
+      await writeUntestedController(workspace.dir)
+      await writeCodegenManifests(workspace.dir)
+
+      // The missing-test warn is advice, not an integrity failure —
+      // scaffolding a controller must not turn CI red until a test exists.
+      expect(await runBin(['check', '--ci'], workspace.dir)).toBe(0)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('--ci passes on a clean workspace', async () => {
+    const workspace = await createTempWorkspace('guren-cli-check-ci-clean-')
+
+    try {
+      await mkdir(join(workspace.dir, 'routes'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'routes/web.ts'),
+        `export default function registerRoutes(router: any) {
+  router.get('/health', (c: any) => c.json({ status: 'ok' }))
+}`,
+        'utf8',
+      )
+      await writeCodegenManifests(workspace.dir)
+
+      expect(await runBin(['check', '--ci'], workspace.dir)).toBe(0)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})

--- a/packages/cli/tests/check-ci-flag.test.ts
+++ b/packages/cli/tests/check-ci-flag.test.ts
@@ -102,3 +102,19 @@ describe('check --ci exit gating', () => {
     }
   })
 })
+
+describe('check --ci flag combinations', () => {
+  it('refuses suite flags so a narrowed run cannot pose as the full gate', async () => {
+    const workspace = await createTempWorkspace('guren-cli-check-ci-suite-')
+
+    try {
+      await writeCodegenManifests(workspace.dir)
+
+      // Even a workspace with nothing to report exits 1 — the failure is
+      // the flag combination itself, not a finding.
+      expect(await runBin(['check', '--ci', '--docs'], workspace.dir)).toBe(1)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})

--- a/packages/create-app/bunfig.toml
+++ b/packages/create-app/bunfig.toml
@@ -1,0 +1,6 @@
+# Templates now ship *.test.ts files for scaffolded apps; without a test
+# root, `bun test` discovers and runs them here, where their imports
+# (@guren/testing, ../app/...) cannot resolve. The package's own tests all
+# live under tests/.
+[test]
+root = "tests"

--- a/packages/create-app/templates/api-only/.github/workflows/ci.yml
+++ b/packages/create-app/templates/api-only/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate types
+        run: bun run codegen
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Integrity check
+        run: bunx guren check --ci --routes routes/api.ts
+
+      # Exits non-zero on failing findings. Scans dependencies too; pass
+      # --no-deps if this runner cannot reach the npm registry.
+      - name: Security audit
+        run: bunx guren audit --json --routes routes/api.ts
+
+      - name: Tests
+        run: bun test

--- a/packages/create-app/templates/api-only/tests/app.test.ts
+++ b/packages/create-app/templates/api-only/tests/app.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from 'bun:test'
+import { TestApp } from '@guren/testing'
+import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
+import { registerApiRoutes } from '../routes/api.js'
+
+describe('api', () => {
+  it('answers the health check', async () => {
+    const app = await TestApp.create({
+      routes: registerApiRoutes,
+      providers: [DatabaseProvider],
+    })
+
+    await app.get('/health').assertOk()
+  })
+
+  it('serves the API root', async () => {
+    const app = await TestApp.create({
+      routes: registerApiRoutes,
+      providers: [DatabaseProvider],
+    })
+
+    await app.get('/api/v1').assertOk()
+  })
+})

--- a/packages/create-app/templates/blog/tests/HomeController.test.ts
+++ b/packages/create-app/templates/blog/tests/HomeController.test.ts
@@ -1,0 +1,19 @@
+import { describe, it } from 'bun:test'
+import { TestApp } from '@guren/testing'
+import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
+import { registerWebRoutes } from '../routes/web.js'
+
+// The blog home page reads posts from the database, so exercising it here
+// would need migrations and fixtures — the golden-path flow already covers
+// it end to end. This starter test keeps `bun test` green out of the box;
+// replace it with real feature tests as you build.
+describe('app', () => {
+  it('answers the health check', async () => {
+    const app = await TestApp.create({
+      routes: registerWebRoutes,
+      providers: [DatabaseProvider],
+    })
+
+    await app.get('/health').assertOk()
+  })
+})

--- a/packages/create-app/templates/default/.github/workflows/ci.yml
+++ b/packages/create-app/templates/default/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate types
+        run: bun run codegen
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Integrity check
+        run: bunx guren check --ci
+
+      # Exits non-zero on failing findings. Scans dependencies too; pass
+      # --no-deps if this runner cannot reach the npm registry.
+      - name: Security audit
+        run: bunx guren audit --json
+
+      - name: Tests
+        run: bun test

--- a/packages/create-app/templates/default/package.json
+++ b/packages/create-app/templates/default/package.json
@@ -9,6 +9,7 @@
     "dev:server": "bun --hot bin/serve.ts",
     "console": "bun bin/console.ts",
     "typecheck": "tsc --noEmit",
+    "test": "bun test",
     "build": "bun run codegen && bunx vite build",
     "preview": "NODE_ENV=production bun bin/serve.ts",
     "db:make": "bunx guren make:migration",

--- a/packages/create-app/templates/default/tests/HomeController.test.ts
+++ b/packages/create-app/templates/default/tests/HomeController.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from 'bun:test'
+import { TestApp } from '@guren/testing'
+import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
+import { registerWebRoutes } from '../routes/web.js'
+
+describe('app', () => {
+  it('serves the home page', async () => {
+    const app = await TestApp.create({
+      routes: registerWebRoutes,
+      providers: [DatabaseProvider],
+    })
+
+    await app.get('/').assertOk()
+  })
+
+  it('answers the health check', async () => {
+    const app = await TestApp.create({
+      routes: registerWebRoutes,
+      providers: [DatabaseProvider],
+    })
+
+    await app.get('/health').assertOk()
+  })
+})

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -601,6 +601,23 @@ async function main(): Promise<void> {
       await run(['bun', resolve(repoRoot, 'scripts/smoke/build-budget.ts'), '--max-kb', '600', appDir], repoRoot, runtimeEnv)
     }
 
+    // Templates advertise a starter test suite and a CI workflow gating on
+    // `check --ci` and `guren audit`; exercise all three here so they cannot
+    // drift from the framework. Worker is excluded like typecheck above
+    // (same export mismatch). The api blueprint needs its codegen manifests
+    // first — the generated workflow runs codegen before the gates too.
+    // --no-deps keeps the audit off the network; releases of the CLI without
+    // the flag ignore it harmlessly.
+    if (blueprint !== 'worker') {
+      if (blueprint === 'api') {
+        await run(['bun', 'run', 'codegen'], appDir, runtimeEnv)
+      }
+      const routesArgs = blueprint === 'api' ? ['--routes', 'routes/api.ts'] : []
+      await run(['bun', 'test'], appDir, runtimeEnv)
+      await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'check', '--ci', ...routesArgs], appDir, runtimeEnv)
+      await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'audit', '--no-deps', ...routesArgs], appDir, runtimeEnv)
+    }
+
     console.log(`\nFresh app smoke passed (${blueprint}, ${installMode}): ${appDir}`)
   } finally {
     if (keepTemp) {

--- a/scripts/smoke/starter-template-audit.ts
+++ b/scripts/smoke/starter-template-audit.ts
@@ -46,6 +46,24 @@ export async function auditBlueprintTemplates(root: string): Promise<void> {
       )
     }
   }
+
+  // npm keeps dot-directories under `files` entries (unlike files literally
+  // named `.gitignore`, which it strips — hence the `_gitignore` convention).
+  // Assert the scaffolded CI workflow survives packing so an npm behavior
+  // change can never silently ship templates without their workflow.
+  for (const template of ['default', 'api-only']) {
+    const workflow = join(root, 'templates', template, '.github/workflows/ci.yml')
+    let contents = ''
+    try {
+      contents = await readFile(workflow, 'utf8')
+    } catch {
+      // fall through to the assert below with the empty string
+    }
+    assert(
+      contents.includes('guren check --ci'),
+      `templates/${template}/.github/workflows/ci.yml is missing from the create-guren-app tarball (or lost its check gate).`,
+    )
+  }
 }
 
 /**

--- a/scripts/smoke/starter-template-audit.ts
+++ b/scripts/smoke/starter-template-audit.ts
@@ -52,13 +52,7 @@ export async function auditBlueprintTemplates(root: string): Promise<void> {
   // Assert the scaffolded CI workflow survives packing so an npm behavior
   // change can never silently ship templates without their workflow.
   for (const template of ['default', 'api-only']) {
-    const workflow = join(root, 'templates', template, '.github/workflows/ci.yml')
-    let contents = ''
-    try {
-      contents = await readFile(workflow, 'utf8')
-    } catch {
-      // fall through to the assert below with the empty string
-    }
+    const contents = await read(root, `templates/${template}/.github/workflows/ci.yml`).catch(() => '')
     assert(
       contents.includes('guren check --ci'),
       `templates/${template}/.github/workflows/ci.yml is missing from the create-guren-app tarball (or lost its check gate).`,

--- a/scripts/test-packages.ts
+++ b/scripts/test-packages.ts
@@ -44,21 +44,36 @@ if (targets.length === 0) {
   process.exit(1)
 }
 
-console.log(`[test] ${targets.map((pkg) => pkg.name).join(', ')}`)
-
-// One `bun test` per package, from the package's own directory: a single
-// root-cwd run ignores per-package bunfig.toml, and create-app relies on
-// its `[test] root` to keep the *.test.ts files its templates ship for
-// scaffolded apps out of the monorepo's own suite.
-let failed = false
-for (const pkg of targets) {
-  console.log(`\n[test] ${pkg.name}`)
-  const proc = Bun.spawn([process.execPath, 'test', '--isolate', ...forwarded], {
-    cwd: pkg.dir,
-    stdout: 'inherit',
-    stderr: 'inherit',
-  })
-  if ((await proc.exited) !== 0) failed = true
+// A single root-cwd run ignores per-package bunfig.toml, so each package's
+// `[test] root` (create-app uses it to keep the *.test.ts files its
+// templates ship for scaffolded apps out of the monorepo suite) is resolved
+// here and passed as the package's path filter instead. One invocation, so
+// forwarded flags like `-t <pattern>` keep matching across packages rather
+// than failing in every package the pattern misses.
+async function testPathFor(pkg: { dir: string; relativeDir: string }): Promise<string> {
+  try {
+    const bunfig = await Bun.file(`${pkg.dir}/bunfig.toml`).text()
+    const root = bunfig.match(/^\s*root\s*=\s*"([^"]+)"/m)?.[1]
+    if (root) return `${pkg.relativeDir}/${root}`
+  } catch {
+    // no bunfig — the package directory itself is the test root
+  }
+  return pkg.relativeDir
 }
 
-process.exit(failed ? 1 : 0)
+const testArgs = [
+  'test',
+  '--isolate',
+  ...forwarded,
+  ...(await Promise.all(targets.map(testPathFor))),
+]
+
+console.log(`[test] ${targets.map((pkg) => pkg.name).join(', ')}`)
+
+const proc = Bun.spawn([process.execPath, ...testArgs], {
+  cwd: repoRoot,
+  stdout: 'inherit',
+  stderr: 'inherit',
+})
+
+process.exit(await proc.exited)

--- a/scripts/test-packages.ts
+++ b/scripts/test-packages.ts
@@ -44,19 +44,21 @@ if (targets.length === 0) {
   process.exit(1)
 }
 
-const testArgs = [
-  'test',
-  '--isolate',
-  ...forwarded,
-  ...targets.map((pkg) => pkg.relativeDir),
-]
-
 console.log(`[test] ${targets.map((pkg) => pkg.name).join(', ')}`)
 
-const proc = Bun.spawn([process.execPath, ...testArgs], {
-  cwd: repoRoot,
-  stdout: 'inherit',
-  stderr: 'inherit',
-})
+// One `bun test` per package, from the package's own directory: a single
+// root-cwd run ignores per-package bunfig.toml, and create-app relies on
+// its `[test] root` to keep the *.test.ts files its templates ship for
+// scaffolded apps out of the monorepo's own suite.
+let failed = false
+for (const pkg of targets) {
+  console.log(`\n[test] ${pkg.name}`)
+  const proc = Bun.spawn([process.execPath, 'test', '--isolate', ...forwarded], {
+    cwd: pkg.dir,
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  if ((await proc.exited) !== 0) failed = true
+}
 
-process.exit(await proc.exited)
+process.exit(failed ? 1 : 0)


### PR DESCRIPTION
## Summary

Fourth implementation slice of RFC 0007 (#249), following Rails 7.2's lead of shipping every new app with CI: scaffolded apps now include `.github/workflows/ci.yml` (install → codegen → typecheck → `guren check --ci` → `guren audit` → `bun test`) plus a starter test built on `@guren/testing`, so the suite is green — and exemplified — from the first commit.

### `check --ci`

Opt-in exit-code gate for the full check suite. Two deliberate calls:

- It gates on **integrity warns** too: most integrity problems (missing codegen manifest, unregistered command) report as `warn`, so a fail-only gate would wave nearly everything through.
- It **exempts test-coverage nudges** (`test:*`): scaffolding a controller must not turn CI red until a test exists.

The stable plain-`check` exit contract is unchanged.

### Template details

- Default and api-only ship the workflow + starter test directly; blog and worker inherit via layering. Blog overlays its own starter test (its home page reads the database — the golden-path smoke covers that flow end to end).
- `check` no longer demands `.guren/pages.gen.ts` in apps without Inertia pages — codegen never emits it for the api blueprint, so the unconditional check was a false positive there.
- npm keeps dot-directories under `files` entries, so `.github` ships as-is — no `_gitignore`-style rename mechanism needed. The packed-artifact audit now asserts the workflow survives `npm pack`, so an npm behavior change cannot slip through silently. (RFC amended accordingly.)

### Infrastructure fallout

Templates shipping `*.test.ts` meant `bun test` in the monorepo discovered them: `create-app` gains a bunfig `[test] root`, and `test-packages.ts` now runs each package's suite from the package directory (a single root-cwd run ignores per-package bunfig). Failure propagation mutation-verified.

## Verification

- All five smokes pass **with new steps added**: the fresh-app smoke now runs `bun test`, `check --ci`, and `guren audit` inside every scaffold (default / api / blog / worker / packed) — templates advertise nothing without a smoke.
- `check --ci` gating: 3 bin-level tests (integrity warn gates, coverage nudge doesn't, clean passes); live mutations on a real scaffold (coverage warn pre-exemption exited 1; removing a pages manifest exits 1; plain `check` stays 0 throughout).
- `audit:starter-template`, `audit:core-first`, `audit:docs`, root `typecheck`, full `test:bun` (10 packages, 0 fail, per-package runner mutation-verified) all green.

Refs: RFC 0007