### PR TITLE
fix(orm): drop views in MySQL resetDatabase()

### DIFF
--- a/packages/orm/src/mysql.ts
+++ b/packages/orm/src/mysql.ts
@@ -223,14 +223,24 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
     const { sql } = await import('drizzle-orm')
 
     await withAdminDb(async (adminDb) => {
+      // table_type is selected because information_schema.tables lists views
+      // alongside base tables, and DROP TABLE on a view raises a warning
+      // rather than an error. Dropping every row as a table therefore leaves
+      // views standing while reporting a successful reset, and the replayed
+      // migration then dies on `CREATE VIEW ... Table 'x' already exists`.
       const [rows] = (await adminDb.execute(
-        sql.raw('SELECT table_name AS name FROM information_schema.tables WHERE table_schema = DATABASE()'),
-      )) as unknown as [Array<{ name: string }>]
+        sql.raw(
+          'SELECT table_name AS name, table_type AS type FROM information_schema.tables WHERE table_schema = DATABASE()',
+        ),
+      )) as unknown as [Array<{ name: string; type: string }>]
 
       await adminDb.execute(sql.raw('SET FOREIGN_KEY_CHECKS = 0'))
       try {
-        for (const { name } of rows) {
-          await adminDb.execute(sql.raw(`DROP TABLE IF EXISTS \`${name.replaceAll('`', '``')}\``))
+        for (const { name, type } of rows) {
+          const quoted = `\`${name.replaceAll('`', '``')}\``
+          await adminDb.execute(
+            sql.raw(type === 'VIEW' ? `DROP VIEW IF EXISTS ${quoted}` : `DROP TABLE IF EXISTS ${quoted}`),
+          )
         }
       } finally {
         await adminDb.execute(sql.raw('SET FOREIGN_KEY_CHECKS = 1'))

--- a/packages/orm/src/mysql.ts
+++ b/packages/orm/src/mysql.ts
@@ -60,7 +60,7 @@ export interface MySqlDatabase {
   closeDatabase(): Promise<void>
   configureOrm(): Promise<void>
   seedDatabase(): Promise<void>
-  /** Drops every table (including the drizzle migration tracker) so migrations can be re-applied from scratch. */
+  /** Drops every table and view (including the drizzle migration tracker) so migrations can be re-applied from scratch. */
   resetDatabase(): Promise<void>
   /** Per-migration applied state derived from the drizzle-kit journal and the __drizzle_migrations table. */
   migrationStatus(): Promise<MigrationStatusEntry[]>
@@ -224,10 +224,9 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
 
     await withAdminDb(async (adminDb) => {
       // table_type is selected because information_schema.tables lists views
-      // alongside base tables, and DROP TABLE on a view raises a warning
-      // rather than an error. Dropping every row as a table therefore leaves
-      // views standing while reporting a successful reset, and the replayed
-      // migration then dies on `CREATE VIEW ... Table 'x' already exists`.
+      // alongside base tables, and MySQL answers DROP TABLE on a view with a
+      // warning rather than an error — so dropping every row as a table
+      // silently leaves views standing behind a successful-looking reset.
       const [rows] = (await adminDb.execute(
         sql.raw(
           'SELECT table_name AS name, table_type AS type FROM information_schema.tables WHERE table_schema = DATABASE()',
@@ -237,9 +236,9 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
       await adminDb.execute(sql.raw('SET FOREIGN_KEY_CHECKS = 0'))
       try {
         for (const { name, type } of rows) {
-          const quoted = `\`${name.replaceAll('`', '``')}\``
+          const identifier = sql.identifier(name)
           await adminDb.execute(
-            sql.raw(type === 'VIEW' ? `DROP VIEW IF EXISTS ${quoted}` : `DROP TABLE IF EXISTS ${quoted}`),
+            type === 'VIEW' ? sql`DROP VIEW IF EXISTS ${identifier}` : sql`DROP TABLE IF EXISTS ${identifier}`,
           )
         }
       } finally {

--- a/packages/orm/tests/mysql-integration.test.ts
+++ b/packages/orm/tests/mysql-integration.test.ts
@@ -92,4 +92,22 @@ describeMySql('createMySqlDatabase against a real MySQL server (requires MYSQL_U
     const status = await database.migrationStatus()
     expect(status[0]).toMatchObject({ applied: false })
   })
+
+  // Views are listed by information_schema.tables but DROP TABLE only warns on
+  // them, so a reset that treats every row as a table leaves them behind while
+  // still reporting success. The next migration run then fails on
+  // `CREATE VIEW ... Table 'x' already exists` — a reset that did not reset.
+  it('drops views on reset, not just base tables', async () => {
+    // The preceding test leaves the database empty.
+    await database.migrateDatabase()
+    const db = await database.getDatabase()
+    await db.execute(sql`CREATE OR REPLACE VIEW \`widget_names\` AS SELECT \`name\` FROM \`widgets\``)
+
+    await database.resetDatabase()
+
+    const [remaining] = (await db.execute(
+      sql`SELECT table_name AS name FROM information_schema.tables WHERE table_schema = DATABASE()`,
+    )) as unknown as [Array<{ name: string }>]
+    expect(remaining.map((row) => row.name)).toEqual([])
+  })
 })

--- a/packages/orm/tests/mysql-integration.test.ts
+++ b/packages/orm/tests/mysql-integration.test.ts
@@ -93,12 +93,9 @@ describeMySql('createMySqlDatabase against a real MySQL server (requires MYSQL_U
     expect(status[0]).toMatchObject({ applied: false })
   })
 
-  // Views are listed by information_schema.tables but DROP TABLE only warns on
-  // them, so a reset that treats every row as a table leaves them behind while
-  // still reporting success. The next migration run then fails on
-  // `CREATE VIEW ... Table 'x' already exists` — a reset that did not reset.
   it('drops views on reset, not just base tables', async () => {
-    // The preceding test leaves the database empty.
+    // The preceding test leaves the database empty, so re-create `widgets`
+    // for the view to select from.
     await database.migrateDatabase()
     const db = await database.getDatabase()
     await db.execute(sql`CREATE OR REPLACE VIEW \`widget_names\` AS SELECT \`name\` FROM \`widgets\``)


### PR DESCRIPTION
## Summary

- `createMySqlDatabase().resetDatabase()` listed every row of `information_schema.tables` and issued `DROP TABLE IF EXISTS` for each one. MySQL answers `DROP TABLE` on a view with a warning rather than an error, so views survived a reset that still reported "Database reset successfully" — the next migration run then failed with `CREATE VIEW ... Table 'x' already exists`.
- The reset now also selects `table_type` and issues `DROP VIEW IF EXISTS` for views, `DROP TABLE IF EXISTS` otherwise (using `sql.identifier()` instead of hand-rolled backtick escaping).
- Updated the `resetDatabase()` contract doc to say it drops tables *and views*.
- Added a regression test to `packages/orm/tests/mysql-integration.test.ts` (gated on `MYSQL_URL`, which CI supplies) that creates a view, resets, and asserts nothing remains.

The postgres adapter never had this gap — `DROP SCHEMA public CASCADE` takes views with it by construction. A separate task has been spun off to check whether the SQLite adapter's reset (which filters `sqlite_master` to `type = 'table'`) has the same gap.

## Test plan

- [x] New integration test fails before the fix and passes after (mutation-checked)
- [x] Verified with backtick- and hyphen-containing table/view names against a live MySQL container
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run test` (3245 pass / 0 fail, plus vitest suites) with `MYSQL_URL` set
- [x] `bun run smoke:golden-path:mysql`