### PR TITLE
fix(orm): make the SQLite resetDatabase() drop everything it lists

### DIFF
--- a/packages/orm/src/mysql.ts
+++ b/packages/orm/src/mysql.ts
@@ -60,7 +60,7 @@ export interface MySqlDatabase {
   closeDatabase(): Promise<void>
   configureOrm(): Promise<void>
   seedDatabase(): Promise<void>
-  /** Drops every table (including the drizzle migration tracker) so migrations can be re-applied from scratch. */
+  /** Drops every table and view (including the drizzle migration tracker) so migrations can be re-applied from scratch. */
   resetDatabase(): Promise<void>
   /** Per-migration applied state derived from the drizzle-kit journal and the __drizzle_migrations table. */
   migrationStatus(): Promise<MigrationStatusEntry[]>

--- a/packages/orm/src/sqlite.test.ts
+++ b/packages/orm/src/sqlite.test.ts
@@ -155,6 +155,69 @@ describe('createSqliteDatabase outside a hot-reloading runtime', () => {
   })
 })
 
+describe('createSqliteDatabase resetDatabase', () => {
+  test('should drop views as well as base tables', async () => {
+    // sqlite_master lists views under their own type, so a reset that selects
+    // only `type = 'table'` leaves them standing while still reporting success.
+    // The next migration run then dies on `CREATE VIEW ... table v already
+    // exists` — a reset that did not reset.
+    const database = createSqliteDatabase({
+      migrationsFolder: join(workDir, 'migrations'),
+      filename: join(workDir, 'app.db'),
+    })
+
+    const db = (await database.getDatabase()) as RunnableDatabase & { all(query: unknown): unknown[] }
+    db.run(sql`CREATE TABLE t (id integer primary key, name text)`)
+    db.run(sql`CREATE VIEW v AS SELECT id FROM t`)
+
+    await database.resetDatabase()
+
+    const remaining = db.all(sql`SELECT name FROM sqlite_master WHERE name NOT LIKE 'sqlite_%'`) as Array<{
+      name: string
+    }>
+    expect(remaining.map((row) => row.name)).toEqual([])
+
+    await database.closeDatabase()
+  })
+
+  test('should drop a user table whose name only looks internal', async () => {
+    // `_` is a LIKE wildcard, so an unescaped `sqlite_%` filter also matches
+    // names like `sqliteXtable` and mistakes them for SQLite's own tables.
+    const database = createSqliteDatabase({
+      migrationsFolder: join(workDir, 'migrations'),
+      filename: join(workDir, 'app.db'),
+    })
+
+    const db = (await database.getDatabase()) as RunnableDatabase & { all(query: unknown): unknown[] }
+    db.run(sql`CREATE TABLE sqliteXtable (id integer primary key)`)
+
+    await database.resetDatabase()
+
+    expect(db.all(sql`SELECT name FROM main.sqlite_master`)).toEqual([])
+
+    await database.closeDatabase()
+  })
+
+  test('should drop the migrated table when a temp table shares its name', async () => {
+    // An unqualified DROP resolves against `temp` before `main`, so the temp
+    // object absorbs the drop and the table migrations own survives the reset.
+    const database = createSqliteDatabase({
+      migrationsFolder: join(workDir, 'migrations'),
+      filename: join(workDir, 'app.db'),
+    })
+
+    const db = (await database.getDatabase()) as RunnableDatabase & { all(query: unknown): unknown[] }
+    db.run(sql`CREATE TABLE t (id integer primary key)`)
+    db.run(sql`CREATE TEMP TABLE t (id integer primary key)`)
+
+    await database.resetDatabase()
+
+    expect(db.all(sql`SELECT name FROM main.sqlite_master`)).toEqual([])
+
+    await database.closeDatabase()
+  })
+})
+
 describe('createSqliteDatabase closeDatabase', () => {
   test('should close the underlying handle', async () => {
     const database = createSqliteDatabase({

--- a/packages/orm/src/sqlite.ts
+++ b/packages/orm/src/sqlite.ts
@@ -153,14 +153,23 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
       await ensureDatabase()
       if (!sqliteClient) return
 
-      const tables = sqliteClient
-        .query("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")
-        .all() as Array<{ name: string }>
+      // Anything left behind fails the next migration run, and three things
+      // stand between this loop and that: SQLite refuses DROP TABLE on a view,
+      // `_` is a LIKE wildcard so the internal-name filter needs ESCAPE, and an
+      // unqualified drop resolves against `temp` before `main`. Each has a
+      // regression test alongside. Indexes and triggers stay out of the
+      // selection; they go with their table.
+      const objects = sqliteClient
+        .query(
+          "SELECT name, type FROM main.sqlite_master WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite\\_%' ESCAPE '\\'",
+        )
+        .all() as Array<{ name: string; type: string }>
 
       sqliteClient.exec('PRAGMA foreign_keys = OFF;')
       try {
-        for (const { name } of tables) {
-          sqliteClient.exec(`DROP TABLE IF EXISTS "${name.replaceAll('"', '""')}"`)
+        for (const { name, type } of objects) {
+          const quoted = `main."${name.replaceAll('"', '""')}"`
+          sqliteClient.exec(type === 'view' ? `DROP VIEW IF EXISTS ${quoted}` : `DROP TABLE IF EXISTS ${quoted}`)
         }
       } finally {
         sqliteClient.exec('PRAGMA foreign_keys = ON;')

--- a/packages/orm/src/sqlite.ts
+++ b/packages/orm/src/sqlite.ts
@@ -26,7 +26,7 @@ export interface SqliteDatabase {
   closeDatabase(): Promise<void>
   configureOrm(): Promise<void>
   seedDatabase(): Promise<void>
-  /** Drops every table (including the drizzle migration tracker) so migrations can be re-applied from scratch. */
+  /** Drops every table and view (including the drizzle migration tracker) so migrations can be re-applied from scratch. */
   resetDatabase(): Promise<void>
   /** Per-migration applied state derived from the drizzle-kit journal and the __drizzle_migrations table. */
   migrationStatus(): Promise<MigrationStatusEntry[]>


### PR DESCRIPTION
## Summary

`resetDatabase()` in the SQLite adapter reported success while leaving objects behind, so `db:reset` was followed by a migration run that failed on a statement the user had already applied once. Three separate holes in the same statement caused it:

- **Views were never dropped.** The scan selected `type = 'table'` from `sqlite_master`, so views were not listed and never dropped. The next migration run died on `CREATE VIEW ... table v already exists`. Unlike MySQL — which answers `DROP TABLE` on a view with a warning — SQLite refuses it outright (`use DROP VIEW to delete view v`), so the type branch is required, not merely tidy.
- **`_` is a LIKE wildcard.** `name NOT LIKE 'sqlite_%'` was meant to skip SQLite's internal tables, but it also matched legal user tables such as `sqliteXtable`, which survived the reset. The filter now escapes the underscore.
- **Drops were schema-unqualified.** SQLite resolves an unqualified name against `temp` before `main`, so a same-named temp object absorbed the drop while the migrated table it was meant to remove survived. Every drop now names the `main` schema.

The same view defect exists in the MySQL adapter and is fixed on a separate branch; `postgres` and the Data API never had it (`DROP SCHEMA public CASCADE` takes views with it), and D1's `resetDatabase()` throws.

## Scope

- `orm` — `packages/orm/src/sqlite.ts` (the `resetDatabase()` drop loop) and `packages/orm/src/sqlite.test.ts` (three regression tests), plus a one-line doc comment on the `resetDatabase()` contract in `sqlite.ts` and `mysql.ts`.

## Risk Assessment

- Behavior change is confined to `resetDatabase()`, a developer-facing `db:reset` path. It now removes strictly more than before; nothing that was previously dropped is left standing.
- No migration impact, no API change, no compatibility concern.
- The `resetDatabase()` doc comment on both the SQLite and MySQL interfaces now names views. The MySQL implementation's own view fix lives on a separate branch, so until that lands, MySQL's comment describes the contract rather than the shipped behavior on this branch.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck` — clean (requires `guren codegen` in `examples/blog` first on a fresh checkout)
- [x] `bun run test` — `3257 pass / 0 fail` (bun), plus 107 / 42 / 91 across the vitest suites

Each of the three fixes was checked by mutation: all three regression tests fail against the pre-fix implementation and pass after it.

```
(fail) createSqliteDatabase resetDatabase > should drop views as well as base tables
(fail) createSqliteDatabase resetDatabase > should drop a user table whose name only looks internal
(fail) createSqliteDatabase resetDatabase > should drop the migrated table when a temp table shares its name
```

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation — the `resetDatabase()` interface doc comment now names views on both adapters. No user-facing docs describe the reset internals.
