### PR TITLE
fix(openapi): keep array element types and zod 3 pipelines in the document

### DIFF
--- a/.changeset/openapi-zod-walker.md
+++ b/.changeset/openapi-zod-walker.md
@@ -1,0 +1,51 @@
+---
+"@guren/openapi": patch
+---
+
+Keep array element types, Zod 3 pipelines, and response-side types in the
+generated OpenAPI document.
+
+Every array rendered as `items: {}`. Zod 4 keeps an array's element in
+`_def.element` and puts the literal string `'array'` in `_def.type`, and the
+walker read `_def.type` first — so it handed that string back to itself,
+failed to recognize it as a schema, and fell back to an empty item schema.
+Zod 3 stores the element in `_def.type`, so both orderings have to be tried,
+with `element` first.
+
+Zod 3 names a pipe `ZodPipeline`, which the walker did not recognize at all:
+a `.pipe()`ed property was dropped from the document rather than mis-typed.
+Zod 4's `prefault()` and `nonoptional()` were dropped the same way, as was a
+Zod 3 `.brand()`, which keeps its inner schema under a key the walker read as
+a type name.
+
+Request and response schemas are now walked in their own direction. A pipe
+carries a separate type per side, so a `z.string().pipe(z.coerce.number())`
+response documented the string a caller sends instead of the number it
+receives; a `.transform()` has no readable output type, so its input side
+stays the answer for both. A `.default()`ed field is likewise omittable from
+a request but always present in a response, and now appears in the response's
+`required` list.
+
+A `query` or `params` schema wrapped in `.default()`, `.optional()`,
+`.catch()` or `.nullable()` lost every one of its parameters, because the walk
+that finds the object behind a parameter schema looked through a shorter list
+of wrappers than the two walks that render types and decide presence. All
+three now read one shared set, so a wrapper cannot reach one walk and miss
+another.
+
+Two more properties were described as required when they are not, and one
+the reverse. A `.catch()`ed field substitutes its fallback for any failure, a
+missing value included, so a request never has to carry it. A `.pipe()`d field
+runs both stages, so it may be omitted only when neither stage rejects a
+missing value — reading just the side being documented promised an omission
+the other stage refuses.
+
+A `z.lazy()` schema keeps its contents behind a getter this walker does not
+call, so the property cannot be documented. It is now reported as a warning
+instead of vanishing, along with any other wrapper whose contents cannot be
+read — a silently missing property reads as a schema that never declared one.
+
+Coercion is deliberately not widened: OpenAPI describes JSON in both
+directions, so `z.coerce.date()` already documents as the ISO string a caller
+sends, and widening `z.coerce.number()` to accept a string would cost callers
+precision in exchange for nothing the schema requires.

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -204,6 +204,19 @@ type ObjectSchemaDetails = {
   required: Set<string>
 }
 
+/**
+ * Which side of a schema a document is describing.
+ *
+ * - `input` — what a caller has to send: request bodies and parameters.
+ * - `output` — what a caller receives: response bodies.
+ *
+ * Most schemas render identically both ways, since OpenAPI describes JSON in
+ * either direction. Pipes and defaults do not: a pipe holds a separate type per
+ * side, and a defaulted field may be omitted from a request but is always
+ * present in a response.
+ */
+type SchemaIo = 'input' | 'output'
+
 function isApplicationLike(target: Application | HonoLike): target is Application & { hono: HonoLike; router: { definitions(): RouteDefinition[] } } {
   return typeof target === 'object'
     && target !== null
@@ -250,7 +263,7 @@ function buildOperation(definition: RouteDefinition, warnings: string[]): OpenAp
 function buildParameters(definition: RouteDefinition, warnings: string[]): OpenApiParameterObject[] {
   const parameters: OpenApiParameterObject[] = []
   const pathParamNames = extractPathParamNames(definition.path)
-  const paramsDetails = readObjectSchema(definition.schemas?.params, warnings, `${definition.method} ${definition.path} params`)
+  const paramsDetails = readObjectSchema(definition.schemas?.params, warnings, `${definition.method} ${definition.path} params`, 'input')
 
   for (const name of pathParamNames) {
     parameters.push({
@@ -261,7 +274,7 @@ function buildParameters(definition: RouteDefinition, warnings: string[]): OpenA
     })
   }
 
-  const queryDetails = readObjectSchema(definition.schemas?.query, warnings, `${definition.method} ${definition.path} query`)
+  const queryDetails = readObjectSchema(definition.schemas?.query, warnings, `${definition.method} ${definition.path} query`, 'input')
   if (queryDetails) {
     for (const [name, schema] of Object.entries(queryDetails.properties)) {
       parameters.push({
@@ -282,7 +295,7 @@ function buildRequestBody(definition: RouteDefinition, warnings: string[]): Open
     return undefined
   }
 
-  const bodySchema = toOpenApiSchema(schema, warnings, `${definition.method} ${definition.path} body`)
+  const bodySchema = toOpenApiSchema(schema, warnings, `${definition.method} ${definition.path} body`, 'input')
   if (!bodySchema) {
     return undefined
   }
@@ -299,7 +312,7 @@ function buildResponses(definition: RouteDefinition, warnings: string[]): Record
   const responses: Record<string, OpenApiResponseObject> = {}
   const successStatus = definition.method === 'POST' ? '201' : '200'
   const successSchema = definition.schemas?.output
-    ? toOpenApiSchema(definition.schemas.output, warnings, `${definition.method} ${definition.path} response`)
+    ? toOpenApiSchema(definition.schemas.output, warnings, `${definition.method} ${definition.path} response`, 'output')
     : undefined
 
   responses[successStatus] = {
@@ -323,7 +336,7 @@ function buildResponses(definition: RouteDefinition, warnings: string[]): Record
   return responses
 }
 
-function readObjectSchema(schema: unknown, warnings: string[], label: string): ObjectSchemaDetails | undefined {
+function readObjectSchema(schema: unknown, warnings: string[], label: string, io: SchemaIo): ObjectSchemaDetails | undefined {
   if (!schema) {
     return undefined
   }
@@ -333,21 +346,17 @@ function readObjectSchema(schema: unknown, warnings: string[], label: string): O
     return undefined
   }
 
-  const details = readObjectSchemaDetails(schema, warnings, label)
+  const details = readObjectSchemaDetails(schema, warnings, label, io)
   if (!details) {
     warnings.push(`${label}: expected an object schema for parameter expansion.`)
   }
   return details
 }
 
-function readObjectSchemaDetails(schema: ZodLike, warnings: string[], label: string): ObjectSchemaDetails | undefined {
-  const normalized = normalizeTypeName(getTypeName(schema))
-  if (normalized !== 'object') {
-    if ((normalized === 'effects' || normalized === 'pipe' || normalized === 'readonly' || normalized === 'branded' || normalized === 'lazy')
-      && inner(schema._def ?? {})) {
-      return readObjectSchemaDetails(inner(schema._def ?? {})!, warnings, label)
-    }
-    return undefined
+function readObjectSchemaDetails(schema: ZodLike, warnings: string[], label: string, io: SchemaIo): ObjectSchemaDetails | undefined {
+  if (typeOf(schema) !== 'object') {
+    const nested = unwrap(schema, io)
+    return nested ? readObjectSchemaDetails(nested, warnings, label, io) : undefined
   }
 
   const shape = getObjectShape(schema)
@@ -360,13 +369,13 @@ function readObjectSchemaDetails(schema: ZodLike, warnings: string[], label: str
   const required = new Set<string>()
 
   for (const [key, value] of Object.entries(shape)) {
-    const propertySchema = toOpenApiSchema(value, warnings, `${label}.${key}`)
+    const propertySchema = toOpenApiSchema(value, warnings, `${label}.${key}`, io)
     if (!propertySchema) {
       continue
     }
 
     properties[key] = propertySchema
-    if (!isOptional(value)) {
+    if (!isOptional(value, io)) {
       required.add(key)
     }
   }
@@ -374,14 +383,30 @@ function readObjectSchemaDetails(schema: ZodLike, warnings: string[], label: str
   return { properties, required }
 }
 
-function toOpenApiSchema(schema: unknown, warnings: string[], label: string): OpenApiSchemaObject | undefined {
+function toOpenApiSchema(schema: unknown, warnings: string[], label: string, io: SchemaIo): OpenApiSchemaObject | undefined {
   if (!isZodSchema(schema)) {
     warnings.push(`${label}: skipped because schema is not a supported Zod schema.`)
     return undefined
   }
 
-  const typeName = normalizeTypeName(getTypeName(schema))
+  const typeName = typeOf(schema)
   const def = schema._def ?? {}
+
+  // Wrappers add nothing to the rendered type, so they are looked through
+  // uniformly. `nullable` is the exception — it renders as a union with null —
+  // and so keeps its own case below.
+  if (typeName !== 'nullable' && WRAPPER_TYPES.has(typeName)) {
+    const nested = unwrap(schema, io)
+    if (!nested) {
+      // Reaching a wrapper whose contents cannot be read drops the property,
+      // so say so — `z.lazy()` hides its schema behind a getter this walker
+      // does not call, and a silently missing property reads as a schema that
+      // never declared one.
+      warnings.push(`${label}: the contents of a "${typeName}" schema could not be read, so it is omitted.`)
+      return undefined
+    }
+    return toOpenApiSchema(nested, warnings, label, io)
+  }
 
   switch (typeName) {
     case 'string':
@@ -401,11 +426,12 @@ function toOpenApiSchema(schema: unknown, warnings: string[], label: string): Op
     case 'literal':
       return literalSchema(def)
     case 'array': {
-      const item = (def.type ?? def.element) as unknown
-      return { type: 'array', items: toOpenApiSchema(item, warnings, `${label}[]`) ?? {} }
+      // v4 holds the element in `_def.element`, v3 in `_def.type`.
+      const item = schemaAt(def, 'element', 'type')
+      return { type: 'array', items: toOpenApiSchema(item, warnings, `${label}[]`, io) ?? {} }
     }
     case 'object': {
-      const details = readObjectSchemaDetails(schema, warnings, label)
+      const details = readObjectSchemaDetails(schema, warnings, label, io)
       if (!details) {
         return { type: 'object' }
       }
@@ -415,23 +441,9 @@ function toOpenApiSchema(schema: unknown, warnings: string[], label: string): Op
         required: details.required.size > 0 ? Array.from(details.required) : undefined,
       }
     }
-    case 'optional':
-    case 'default':
-    case 'catch':
-    case 'readonly':
-    case 'branded':
-    case 'lazy':
-    case 'effects': {
-      const nested = inner(def)
-      return nested ? toOpenApiSchema(nested, warnings, label) : undefined
-    }
-    case 'pipe': {
-      const nested = (def.in as unknown) ?? inner(def)
-      return nested ? toOpenApiSchema(nested, warnings, label) : undefined
-    }
     case 'nullable': {
-      const nested = inner(def)
-      const nestedSchema = nested ? toOpenApiSchema(nested, warnings, label) : undefined
+      const nested = unwrap(schema, io)
+      const nestedSchema = nested ? toOpenApiSchema(nested, warnings, label, io) : undefined
       return nestedSchema ? { anyOf: [nestedSchema, { type: 'null' }] } : { type: ['null'] }
     }
     case 'transform':
@@ -441,21 +453,21 @@ function toOpenApiSchema(schema: unknown, warnings: string[], label: string): Op
     case 'discriminatedunion': {
       const options = (def.options as unknown[]) ?? []
       const oneOf = options
-        .map((option, index) => toOpenApiSchema(option, warnings, `${label}.option${index}`))
+        .map((option, index) => toOpenApiSchema(option, warnings, `${label}.option${index}`, io))
         .filter((option): option is OpenApiSchemaObject => Boolean(option))
       return oneOf.length > 0 ? { oneOf } : undefined
     }
     case 'intersection': {
-      const left = toOpenApiSchema(def.left, warnings, `${label}.left`)
-      const right = toOpenApiSchema(def.right, warnings, `${label}.right`)
+      const left = toOpenApiSchema(def.left, warnings, `${label}.left`, io)
+      const right = toOpenApiSchema(def.right, warnings, `${label}.right`, io)
       const allOf = [left, right].filter((value): value is OpenApiSchemaObject => Boolean(value))
       return allOf.length > 0 ? { allOf } : undefined
     }
     case 'record': {
-      const valueType = (def.valueType ?? def.type) as unknown
+      const valueType = schemaAt(def, 'valueType')
       return {
         type: 'object',
-        additionalProperties: toOpenApiSchema(valueType, warnings, `${label}.value`) ?? true,
+        additionalProperties: toOpenApiSchema(valueType, warnings, `${label}.value`, io) ?? true,
       }
     }
     case 'enum': {
@@ -470,7 +482,7 @@ function toOpenApiSchema(schema: unknown, warnings: string[], label: string): Op
     }
     case 'tuple': {
       const items = ((def.items as unknown[]) ?? [])
-        .map((item, index) => toOpenApiSchema(item, warnings, `${label}[${index}]`))
+        .map((item, index) => toOpenApiSchema(item, warnings, `${label}[${index}]`, io))
         .filter((item): item is OpenApiSchemaObject => Boolean(item))
       return {
         type: 'array',
@@ -480,8 +492,8 @@ function toOpenApiSchema(schema: unknown, warnings: string[], label: string): Op
       }
     }
     case 'promise': {
-      const nested = inner(def) ?? (def.type as unknown)
-      return nested ? toOpenApiSchema(nested, warnings, label) : undefined
+      const nested = schemaAt(def, 'innerType', 'schema', 'type')
+      return nested ? toOpenApiSchema(nested, warnings, label, io) : undefined
     }
     default:
       warnings.push(`${label}: unsupported Zod type "${typeName}".`)
@@ -590,8 +602,64 @@ function normalizeTypeName(typeName: string | undefined): string {
   return typeName.startsWith('Zod') ? typeName.slice(3).toLowerCase() : typeName.toLowerCase()
 }
 
-function inner(def: Record<string, unknown>): ZodLike | undefined {
-  return (def.innerType ?? def.schema) as ZodLike | undefined
+function typeOf(schema: ZodLike): string {
+  return normalizeTypeName(getTypeName(schema))
+}
+
+/**
+ * The first of `keys` that actually holds a schema. `_def.type` is the one key
+ * whose meaning differs between the majors — v3 stores a schema there (an
+ * array's element, a `.brand()`'s inner type), v4 the type *name* — so a key
+ * can only be taken once it is known to be an object. Reading it by
+ * precedence alone is what let a v4 array document its element as `{}`.
+ */
+function schemaAt(def: Record<string, unknown>, ...keys: string[]): ZodLike | undefined {
+  for (const key of keys) {
+    const candidate = def[key]
+    if (candidate && typeof candidate === 'object') {
+      return candidate as ZodLike
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Type names that carry exactly one nested schema and no shape of their own.
+ *
+ * Three walks look through them for different reasons — finding the object
+ * behind a parameter schema, rendering a type, deciding whether a property may
+ * be omitted — so the set is stated once here. Each walk layers its own
+ * handling on top (`nullable` renders as a union; `optional` and friends decide
+ * presence), but none of them may disagree about what is a wrapper: a name
+ * reaching one walk and not another silently changes the document.
+ */
+const WRAPPER_TYPES = new Set([
+  'optional', 'default', 'prefault', 'nonoptional', 'catch', 'nullable',
+  'readonly', 'branded', 'lazy', 'effects', 'pipe', 'pipeline',
+])
+
+/**
+ * The schema a wrapper wraps, in the direction being documented. A pipe (v3
+ * names it `ZodPipeline`) holds one per side: `_def.in` is what a caller sends,
+ * `_def.out` what a controller returns. A `.transform()`'s out side is the
+ * transform function rather than a schema, so there is no parsed type to read
+ * and the in side remains the best available answer.
+ */
+function unwrap(schema: ZodLike, io: SchemaIo): ZodLike | undefined {
+  const def = schema._def ?? {}
+  const typeName = typeOf(schema)
+
+  if (typeName === 'pipe' || typeName === 'pipeline') {
+    const to = schemaAt(def, 'out')
+    return io === 'output' && to && typeOf(to) !== 'transform' ? to : schemaAt(def, 'in')
+  }
+
+  if (!WRAPPER_TYPES.has(typeName)) {
+    return undefined
+  }
+
+  return schemaAt(def, 'innerType', 'schema', 'type')
 }
 
 function getObjectShape(schema: ZodLike): Record<string, ZodLike> | undefined {
@@ -603,23 +671,44 @@ function getObjectShape(schema: ZodLike): Record<string, ZodLike> | undefined {
   return (def.shape ?? schema.shape) as Record<string, ZodLike> | undefined
 }
 
-function isOptional(schema: ZodLike): boolean {
-  const typeName = normalizeTypeName(getTypeName(schema))
-  if (typeName === 'optional' || typeName === 'default') {
-    return true
+function isOptional(schema: ZodLike, io: SchemaIo): boolean {
+  switch (typeOf(schema)) {
+    case 'optional':
+      return true
+    // Both fill a missing value in, so the field may be left out of a request
+    // but is always present in a response.
+    case 'default':
+    case 'prefault':
+      return io === 'input'
+    // Swallows any failure, a missing value included, and substitutes its
+    // fallback — so nothing is required of a caller, and a response always
+    // carries the field.
+    case 'catch':
+      return io === 'input'
+    // Re-requires a field an inner wrapper made optional, so the walk stops
+    // here rather than reading what it wraps.
+    case 'nonoptional':
+      return false
+    // A pipeline runs both stages, so a field may be omitted only if neither
+    // stage rejects a missing value. Reading just the side being rendered
+    // would document an omission the other stage refuses.
+    case 'pipe':
+    case 'pipeline': {
+      const def = schema._def ?? {}
+      const from = schemaAt(def, 'in')
+      const to = schemaAt(def, 'out')
+      if (!from) {
+        return false
+      }
+      return to && typeOf(to) !== 'transform'
+        ? isOptional(from, io) && isOptional(to, io)
+        : isOptional(from, io)
+    }
+    default: {
+      const nested = unwrap(schema, io)
+      return nested ? isOptional(nested, io) : false
+    }
   }
-
-  const def = schema._def ?? {}
-  const nested = inner(def)
-  if ((typeName === 'effects' || typeName === 'nullable' || typeName === 'readonly' || typeName === 'branded' || typeName === 'lazy') && nested) {
-    return isOptional(nested)
-  }
-
-  if (typeName === 'pipe' && def.in) {
-    return isOptional(def.in as ZodLike)
-  }
-
-  return false
 }
 
 function enumValues(def: Record<string, unknown>): string[] {

--- a/packages/openapi/tests/openapi.test.ts
+++ b/packages/openapi/tests/openapi.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { z } from 'zod'
+import * as z3 from 'zod/v3'
 import { createApp, type RouteDefinition } from '@guren/core'
 import {
   generateOpenApiDocument,
@@ -134,6 +135,174 @@ describe('@guren/openapi', () => {
     })
 
     expect(document.paths['/posts/{id}']?.patch?.requestBody?.required).toBe(false)
+  })
+
+  // Apps pin their own Zod, so both majors have to be walked. v4 keeps an
+  // array's element in `_def.element` and the literal string `'array'` in
+  // `_def.type`; v3 has only `_def.type`. Reading them in the wrong order
+  // still produces a document, just one with the element type missing.
+  describe('schema walking', () => {
+    // `.pipe()` statically requires the target to accept the source's output,
+    // but the walker reads whatever schema object it is handed at runtime.
+    const pipeTo = (from: unknown, to: unknown) => (from as { pipe(target: unknown): unknown }).pipe(to)
+
+    const operationFor = (schemas: Record<string, unknown>) => {
+      const { document, warnings } = generateOpenApiDocument(
+        [{ method: 'POST', path: '/posts', schemas }] as RouteDefinition[],
+        { title: 'Blog API', version: '1.0.0' },
+      )
+      return { operation: document.paths['/posts']?.post, warnings }
+    }
+
+    const bodyDocument = (body: unknown) => {
+      const { operation, warnings } = operationFor({ body })
+      return { schema: operation?.requestBody?.content['application/json']?.schema, warnings }
+    }
+
+    const responseDocument = (output: unknown) => {
+      const { operation, warnings } = operationFor({ output })
+      return { schema: operation?.responses['201']?.content?.['application/json']?.schema, warnings }
+    }
+
+    const queryParameters = (query: unknown) => {
+      const { operation, warnings } = operationFor({ query })
+      return { parameters: operation?.parameters, warnings }
+    }
+
+    it('keeps the element type of a zod 4 array', () => {
+      const { schema, warnings } = bodyDocument(z.object({ tags: z.array(z.string()) }))
+
+      expect(schema?.properties?.tags).toEqual({ type: 'array', items: { type: 'string' } })
+      expect(warnings).toEqual([])
+    })
+
+    it('keeps the element type of a zod 3 array', () => {
+      const { schema, warnings } = bodyDocument(z3.object({ tags: z3.array(z3.string()) }))
+
+      expect(schema?.properties?.tags).toEqual({ type: 'array', items: { type: 'string' } })
+      expect(warnings).toEqual([])
+    })
+
+    // v3 names this `ZodPipeline`, not `pipe` — unhandled, the property is
+    // dropped from the document entirely rather than merely mis-typed.
+    it('documents a zod 3 pipeline instead of dropping it', () => {
+      const { schema, warnings } = bodyDocument(z3.object({ page: z3.string().pipe(z3.number()) }))
+
+      expect(schema?.properties?.page).toEqual({ type: 'string' })
+      expect(warnings).toEqual([])
+    })
+
+    // A pipe carries two types: `_def.in` is what a caller sends, `_def.out`
+    // what the controller returns. Requests and responses need opposite sides.
+    it('reports each side of a pipe to the message that carries it', () => {
+      expect(bodyDocument(z.object({ page: z.string().pipe(z.coerce.number()) })).schema?.properties?.page)
+        .toEqual({ type: 'string' })
+      expect(responseDocument(z.object({ page: z.string().pipe(z.coerce.number()) })).schema?.properties?.page)
+        .toEqual({ type: 'number' })
+    })
+
+    // `.transform()` is a pipe whose out side is an opaque function, so there
+    // is no parsed type to recover — the in side stays the best answer.
+    it('falls back to the in side of a transform', () => {
+      const { schema } = responseDocument(z.object({ title: z.string() }).transform((value) => value.title))
+
+      expect(schema).toEqual({ type: 'object', properties: { title: { type: 'string' } }, required: ['title'] })
+    })
+
+    // A default is filled in when the field is missing, so a caller may omit
+    // it but a response always carries it. `prefault` behaves the same way.
+    it('requires a filled-in field in a response but not in a request', () => {
+      for (const schema of [
+        () => z.object({ body: z.string().default('') }),
+        () => z.object({ body: z.string().prefault('') }),
+      ]) {
+        expect(bodyDocument(schema()).schema?.required).toBeUndefined()
+        expect(responseDocument(schema()).schema?.required).toEqual(['body'])
+      }
+    })
+
+    it('requires a non-optional field in both directions', () => {
+      const schema = () => z.object({ body: z.string().optional().nonoptional() })
+
+      expect(bodyDocument(schema()).schema?.required).toEqual(['body'])
+      expect(responseDocument(schema()).schema?.required).toEqual(['body'])
+    })
+
+    // The type and the presence of a property are read by separate walks over
+    // separate wrapper lists, so a wrapper added to one and not the other
+    // quietly makes an optional property required.
+    it('looks through the same wrappers when deciding presence as when reading the type', () => {
+      for (const schema of [
+        z.object({ a: z.string().optional().readonly() }),
+        z.object({ a: z.string().optional().nullable() }),
+        z3.object({ a: z3.string().optional().brand<'Tagged'>() }),
+        z3.object({ a: z3.string().optional().refine(() => true) }),
+      ]) {
+        const { schema: document, warnings } = bodyDocument(schema)
+
+        expect(document?.properties?.a).toBeDefined()
+        expect(document?.required).toBeUndefined()
+        expect(warnings).toEqual([])
+      }
+    })
+
+    // `.catch()` substitutes its fallback for any failure, a missing value
+    // included, so an empty payload parses and the caller owes nothing.
+    it('never requires a caught field of a request', () => {
+      const schema = () => z.object({ mode: z.string().catch('safe') })
+
+      expect(schema().safeParse({}).success).toBe(true)
+      expect(bodyDocument(schema()).schema?.required).toBeUndefined()
+      expect(responseDocument(schema()).schema?.required).toEqual(['mode'])
+    })
+
+    // A pipeline runs both stages, so reading only the side being rendered
+    // documents an omission the other stage rejects.
+    it('requires a piped field unless both stages accept a missing value', () => {
+      for (const schema of [
+        z.object({ a: z.string().optional().pipe(z.string()) }),
+        z3.object({ a: z3.string().optional().pipe(z3.string()) }),
+      ]) {
+        expect(schema.safeParse({}).success).toBe(false)
+        expect(bodyDocument(schema).schema?.required).toEqual(['a'])
+      }
+
+      const output = z.object({ a: pipeTo(z.string(), z.string().optional()) })
+      expect(output.safeParse({}).success).toBe(false)
+      expect(responseDocument(output).schema?.required).toEqual(['a'])
+    })
+
+    // `z.lazy()` keeps its schema behind a getter this walker does not call.
+    // The property is unavoidably absent; what it must not be is silent.
+    it('warns rather than quietly dropping a schema it cannot read', () => {
+      for (const schema of [
+        z.object({ a: z.lazy(() => z.string()) }),
+        z3.object({ a: z3.lazy(() => z3.string()) }),
+      ]) {
+        const { schema: document, warnings } = bodyDocument(schema)
+
+        expect(document?.properties?.a).toBeUndefined()
+        expect(warnings).toEqual(['POST /posts body.a: the contents of a "lazy" schema could not be read, so it is omitted.'])
+      }
+    })
+
+    // Finding the object behind a parameter schema is a third walk over the
+    // same wrappers, and one that reports nothing when it gives up: a wrapper
+    // it fails to look through drops every parameter from the document.
+    it('expands parameters through a wrapped query schema', () => {
+      for (const query of [
+        z.object({ page: z.number() }).default({ page: 1 }),
+        z.object({ page: z.number() }).optional(),
+        z.object({ page: z.number() }).nullable(),
+        z.object({ page: z.number() }).readonly(),
+        z3.object({ page: z3.number() }).optional(),
+      ]) {
+        const { parameters, warnings } = queryParameters(query)
+
+        expect(parameters).toEqual([{ name: 'page', in: 'query', required: true, schema: { type: 'number' } }])
+        expect(warnings).toEqual([])
+      }
+    })
   })
 
   it('writes the generated document to disk', async () => {


### PR DESCRIPTION
## Summary

- Fixes `@guren/openapi`'s Zod-schema-to-OpenAPI walker, which mishandled several Zod 3/4 shapes and silently produced a wrong or incomplete document (no crash, no reliable warning).
- Every array documented as `items: {}`: the element was read as `def.type ?? def.element`, but Zod 4 puts the literal string `'array'` in `_def.type` and the real element in `_def.element`, so the wrong operand won.
- A Zod 3 `.pipe()` (`ZodPipeline`) was unhandled and silently dropped the property from the document. Zod 4's `prefault()`/`nonoptional()` and a Zod 3 `.brand()` were dropped the same way.
- Request and response schemas are now walked in their own direction (`io: 'input' | 'output'`), so a `.pipe()`'d response documents what the client receives (`_def.out`) instead of what it sends (`_def.in`), and a `.default()`'d field is required in a response but optional in a request.
- A `query`/`params` schema wrapped in `.default()`, `.optional()`, `.catch()`, or `.nullable()` lost every parameter — three separate walks over wrapper types each carried their own hand-written list, and one list was shorter than the others. They now share a single `WRAPPER_TYPES` set plus an `unwrap()`/`schemaAt()` pair, so a wrapper can't reach one walk and miss another.
- `.catch()`'d fields are no longer marked required (they substitute a fallback for any failure, missing value included); pipeline optionality now checks both stages instead of only the rendered side.
- A `z.lazy()` schema hides its contents behind a getter this walker doesn't call — it can't be documented, but it's now reported as a warning instead of silently vanishing (as is any other unreadable wrapper).
- Coercion (`z.coerce.*`) is deliberately left unwidened: OpenAPI describes JSON in both directions already, so `z.coerce.date()` correctly documents as the ISO string a caller sends, and widening `z.coerce.number()` to `number | string` would only cost precision.

This went through a Codex review + `/simplify` pass; several findings from both were verified against real Zod 3/4 internals and folded in (see changeset for the full list). Two related issues were deliberately scoped out and filed as follow-ups rather than expanded here:
- Extracting the shared Zod-introspection primitives duplicated between this file and `packages/cli/src/schema-type-extractor.ts` — deferred until an in-flight branch rewriting the CLI copy merges.
- A `Response`-returning route handler discards parsed `output` (defaults/transforms never reach the client, unlike the plain-object-return path) — a `packages/server` Router issue, not an openapi-walker issue, filed separately.

## Test plan

- [x] `bun test` in `packages/openapi` — 17 pass, including new coverage for Zod 3/4 arrays, pipes/pipelines (both directions), `.catch()`, `.default()`/`.prefault()`, `.nonoptional()`, wrapped query parameters, and `z.lazy()` warnings
- [x] `bun run typecheck` (root, including blog/api examples)
- [x] `bun run test:bun` (full framework suite) — 3279 pass, 0 fail