### PR TITLE
refactor(cli): fold dialect import patchers into ensureNamedImports

### DIFF
--- a/packages/cli/src/patch-helpers.test.ts
+++ b/packages/cli/src/patch-helpers.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { addImport, addProvider, hasImport, hasAuthProvider, ensureDrizzleImports, ensureMysqlImports, ensureSqliteImports } from './patch-helpers'
+import { addImport, addProvider, hasImport, hasAuthProvider, ensureDrizzleImports, ensureMysqlImports, ensureNamedImports, ensureSqliteImports } from './patch-helpers'
 
 describe('patch-helpers', () => {
   let tempDir: string
@@ -349,6 +349,18 @@ const app = new Application()`
       const result = ensureMysqlImports(mixed, ['mysqlTable', 'int', 'varchar', 'timestamp'])
 
       expect(result).toBe(mixed)
+    })
+  })
+
+  describe('ensureNamedImports', () => {
+    // The three dialect wrappers pass fixed, `$`-free specifiers, so only a
+    // direct caller can hit this. `$&` is special inside a replacement
+    // string — merging must insert the specifier literally instead.
+    it('should insert a specifier containing replacement patterns literally', () => {
+      const content = `import { a } from '$&/pkg'\n\nconst x = 1\n`
+      const result = ensureNamedImports(content, '$&/pkg', ['a', 'b'])
+
+      expect(result).toBe(`import { a, b } from '$&/pkg'\n\nconst x = 1\n`)
     })
   })
 })

--- a/packages/cli/src/patch-helpers.ts
+++ b/packages/cli/src/patch-helpers.ts
@@ -443,81 +443,59 @@ export async function readSchemaDialect(cwd: string = process.cwd()): Promise<Sc
 }
 
 /**
- * Ensures that a set of named Drizzle imports are present in file content.
- * Merges into an existing `@guren/orm/drizzle` import or prepends a new one.
- * Returns the (possibly updated) content string.
+ * Ensures that a set of named imports from `specifier` are present in file
+ * content. Merges into the first `import { ... } from '<specifier>'` or
+ * prepends a new one. Returns the (possibly updated) content string.
+ *
+ * Three limits are inherited from the dialect-specific patchers this
+ * generalizes, and callers have to know them:
+ *
+ * - The "already imported?" check is **not** module-scoped. A name in scope
+ *   from any module counts as present, so nothing is added — see the mixed
+ *   dialect case in `patch-helpers.test.ts`.
+ * - Only the plain named form is merged. `import type`, default, and
+ *   namespace imports of the same specifier do not match, so a second import
+ *   line gets prepended alongside them.
+ * - `needed` must be plain identifiers; they go into a `\b...\b` pattern
+ *   unescaped.
  */
-export function ensureDrizzleImports(content: string, needed: string[]): string {
+export function ensureNamedImports(content: string, specifier: string, needed: string[]): string {
   // Check only import lines for existing identifiers, not the entire file content
-  const importLines = content.split('\n').filter((line) => line.trimStart().startsWith('import '))
-  const importContent = importLines.join('\n')
+  const importContent = content
+    .split('\n')
+    .filter((line) => line.trimStart().startsWith('import '))
+    .join('\n')
 
-  const missing = needed.filter(
-    (name) => !new RegExp(`\\b${name}\\b`).test(importContent),
-  )
+  const missing = needed.filter((name) => !new RegExp(`\\b${name}\\b`).test(importContent))
 
   if (missing.length === 0) {
     return content
   }
 
-  const existingDrizzleImport = /import\s*\{([^}]+)\}\s*from\s*['"]@guren\/orm\/drizzle['"]/
-  const match = content.match(existingDrizzleImport)
+  const existingImport = new RegExp(
+    `import\\s*\\{([^}]+)\\}\\s*from\\s*['"]${escapeRegExp(specifier)}['"]`,
+  )
+  const match = content.match(existingImport)
+  const existingNames = match ? match[1].split(',').map((s) => s.trim()).filter(Boolean) : []
+  const names = [...new Set([...existingNames, ...missing])].sort()
+  const importLine = `import { ${names.join(', ')} } from '${specifier}'`
 
-  if (match) {
-    const existingNames = match[1].split(',').map((s) => s.trim()).filter(Boolean)
-    const allNames = [...new Set([...existingNames, ...missing])].sort()
-    return content.replace(existingDrizzleImport, `import { ${allNames.join(', ')} } from '@guren/orm/drizzle'`)
-  }
+  // A function replacer, not a replacement string: `specifier` and the merged
+  // names are parameters now, and `$&`/`$1` in a replacement string would be
+  // expanded instead of inserted literally.
+  return match ? content.replace(existingImport, () => importLine) : `${importLine}\n${content}`
+}
 
-  return `import { ${missing.sort().join(', ')} } from '@guren/orm/drizzle'\n${content}`
+export function ensureDrizzleImports(content: string, needed: string[]): string {
+  return ensureNamedImports(content, '@guren/orm/drizzle', needed)
 }
 
 export function ensureSqliteImports(content: string, needed: string[]): string {
-  const importLines = content.split('\n').filter((line) => line.trimStart().startsWith('import '))
-  const importContent = importLines.join('\n')
-
-  const missing = needed.filter(
-    (name) => !new RegExp(`\\b${name}\\b`).test(importContent),
-  )
-
-  if (missing.length === 0) {
-    return content
-  }
-
-  const existingSqliteImport = /import\s*\{([^}]+)\}\s*from\s*['"]drizzle-orm\/sqlite-core['"]/
-  const match = content.match(existingSqliteImport)
-
-  if (match) {
-    const existingNames = match[1].split(',').map((s) => s.trim()).filter(Boolean)
-    const allNames = [...new Set([...existingNames, ...missing])].sort()
-    return content.replace(existingSqliteImport, `import { ${allNames.join(', ')} } from 'drizzle-orm/sqlite-core'`)
-  }
-
-  return `import { ${missing.sort().join(', ')} } from 'drizzle-orm/sqlite-core'\n${content}`
+  return ensureNamedImports(content, 'drizzle-orm/sqlite-core', needed)
 }
 
 export function ensureMysqlImports(content: string, needed: string[]): string {
-  const importLines = content.split('\n').filter((line) => line.trimStart().startsWith('import '))
-  const importContent = importLines.join('\n')
-
-  const missing = needed.filter(
-    (name) => !new RegExp(`\\b${name}\\b`).test(importContent),
-  )
-
-  if (missing.length === 0) {
-    return content
-  }
-
-  const existingMysqlImport = /import\s*\{([^}]+)\}\s*from\s*['"]drizzle-orm\/mysql-core['"]/
-  const match = content.match(existingMysqlImport)
-
-  if (match) {
-    const existingNames = match[1].split(',').map((s) => s.trim()).filter(Boolean)
-    const allNames = [...new Set([...existingNames, ...missing])].sort()
-    return content.replace(existingMysqlImport, `import { ${allNames.join(', ')} } from 'drizzle-orm/mysql-core'`)
-  }
-
-  return `import { ${missing.sort().join(', ')} } from 'drizzle-orm/mysql-core'\n${content}`
+  return ensureNamedImports(content, 'drizzle-orm/mysql-core', needed)
 }
 
 /**


### PR DESCRIPTION
## Summary
- `ensureDrizzleImports`, `ensureSqliteImports`, and `ensureMysqlImports` in `packages/cli/src/patch-helpers.ts` were near-verbatim copies differing only in their module specifier — fold them into a single `ensureNamedImports(content, specifier, needed)`, keeping the three names as thin wrappers so `blueprints.ts` and `make-auth.ts` callers are unchanged
- Build the specifier match regex with `escapeRegExp` instead of a hand-escaped literal
- Merge via a function replacer instead of a `String.prototype.replace` replacement string, so a specifier containing `$&`/`$1` is inserted literally instead of expanded
- Document the three inherited limits (non-module-scoped presence check, plain named imports only, unescaped identifier matching) on the new shared function
- Add a regression test for the `$&` replacement-pattern case (verified it fails without the fix)

## Test plan
- [x] `bun run test:bun cli` — 973 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] Confirmed the new `ensureNamedImports` test fails without the function-replacer fix