### PR TITLE
fix(cli): close two naming-derivation gaps in factory/seeder discovery and column naming

### DIFF
--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -718,6 +718,17 @@ function buildColumn(mapping: ColumnMapping, field: FieldDefinition): ColumnCode
   return mapping[field.type](snakeCase(field.name), field.nullable ? '' : '.notNull()')
 }
 
+/**
+ * Column name for a field. Deliberately separate from `tableNameFor()`, which
+ * derives the *table* name in the same emitted statement.
+ *
+ * A field name is a validated JavaScript identifier taken verbatim from the
+ * user, and its underscore runs carry meaning: `__dunder__` must stay
+ * `__dunder__`. `tableNameFor()` goes through `kebabCase()`, which collapses
+ * `[_\s]+` to one separator — fine for a name that has to round-trip through a
+ * slug, wrong for one that has to survive intact. Unifying the two would trade
+ * a column the user asked for against a coupling nobody wants.
+ */
 function snakeCase(value: string): string {
   return value.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase()
 }

--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -1,5 +1,7 @@
 import { readdir, access, readFile, stat } from 'node:fs/promises'
 import { resolve, join, extname, relative, sep, posix } from 'node:path'
+import { collectionName } from './inflect'
+import { escapeRegExp } from './utils'
 
 const SOURCE_EXTENSIONS = new Set(['.ts', '.mts', '.js', '.mjs'])
 const TEST_FILE_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.js', '.jsx', '.mjs'])
@@ -297,6 +299,34 @@ export async function hasControllerTest(cwd: string, controllerPath: string): Pr
     if (await fileExists(cwd, candidate)) return true
   }
   return false
+}
+
+/** Where `make:factory` and `make:seeder` write, keyed by the suffix they append. */
+export const DB_ARTIFACT_DIRS = {
+  Factory: 'db/factories',
+  Seeder: 'db/seeders',
+} as const
+
+export type DbArtifactKind = keyof typeof DB_ARTIFACT_DIRS
+
+/**
+ * Matches the factory or seeder file names that belong to an entity.
+ *
+ * Tolerance, not derivation. `make:factory` and `make:seeder` append their
+ * suffix to whatever the user typed without inflecting it, so the file name is
+ * the user's choice and every plausible spelling of it has to be accepted: the
+ * singular, the inflected plural (`Category` → `CategoriesFactory`), and the
+ * naive `+s` plural a user may well have typed. `(?:^|_)` lets a numbered
+ * seeder such as `002_PostsSeeder` match.
+ *
+ * The cost of over-tolerance is a stray file listed against an entity; the cost
+ * of under-tolerance is an existing one silently missing. Prefer the former.
+ * Contrast {@link controllerTestCandidates}, which probes exact paths, and
+ * `inflect.ts`, which must produce exactly one name and so declines to guess.
+ */
+export function dbArtifactPattern(entity: string, kind: DbArtifactKind): RegExp {
+  const forms = [...new Set([entity, `${entity}s`, collectionName(entity)])]
+  return new RegExp(`(?:^|_)(?:${forms.map(escapeRegExp).join('|')})${kind}\\.`, 'i')
 }
 
 /**

--- a/packages/cli/src/entity-context.ts
+++ b/packages/cli/src/entity-context.ts
@@ -12,6 +12,9 @@ import {
   collectFiles,
   toPosixRelative,
   moduleNameFromRelPath,
+  dbArtifactPattern,
+  DB_ARTIFACT_DIRS,
+  type DbArtifactKind,
 } from './discovery'
 import {
   extractClassDeclaration,
@@ -215,11 +218,14 @@ export async function generateEntityContext(
     return file ? toPosixRelative(cwd, file) : undefined
   }
 
-  const findDbArtifacts = async (subDir: string, filePattern: RegExp): Promise<string[]> => {
+  const findDbArtifacts = async (kind: DbArtifactKind): Promise<string[]> => {
     let roots = await listAppRoots(cwd)
     if (duplicated) roots = roots.filter((root) => root.module === match.module)
 
-    const groups = await Promise.all(roots.map((root) => collectFiles(resolve(root.dir, subDir))))
+    const filePattern = dbArtifactPattern(entity, kind)
+    const groups = await Promise.all(
+      roots.map((root) => collectFiles(resolve(root.dir, DB_ARTIFACT_DIRS[kind]))),
+    )
     return groups
       .flat()
       .filter((file) => filePattern.test(basename(file)))
@@ -291,8 +297,8 @@ export async function generateEntityContext(
       loadControllerBundle(),
       findComponent(discoverResourceFiles, `${entity}Resource`),
       findComponent(discoverPolicyFiles, `${entity}Policy`),
-      findDbArtifacts('db/factories', new RegExp(`(?:^|_)${entity}s?Factory\\.`, 'i')),
-      findDbArtifacts('db/seeders', new RegExp(`(?:^|_)${entity}s?Seeder\\.`, 'i')),
+      findDbArtifacts('Factory'),
+      findDbArtifacts('Seeder'),
       discoverTestFiles(cwd),
       scanDocs(cwd),
     ])

--- a/packages/cli/src/inflect.ts
+++ b/packages/cli/src/inflect.ts
@@ -25,6 +25,10 @@ export function singularize(name: string): string {
  * `Status` are structurally identical — which is why only the names inside the
  * triangle route through here. Route slugs and generated type names in
  * `make:feature` pluralize directly, so `Status` still yields `/statuses`.
+ *
+ * The one caller outside the triangle is `dbArtifactPattern()`, which does not
+ * derive a name from this: it accepts the result as one spelling among several
+ * when matching user-chosen file names, so a wrong plural costs it nothing.
  */
 export function collectionName(name: string): string {
   return pluralize(singularize(name))

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -150,6 +150,19 @@ describe('blueprints', () => {
     expect(schemaCheck?.message).toContain("No table 'user_profiles' found")
   })
 
+  // Guards the split between snakeCase() and tableNameFor() — see blueprints.ts.
+  // `publishedAt` is the contrast: the rule still splits camel humps, it just
+  // does not collapse underscore runs the way the kebab-based rule would.
+  it('preserves underscore runs in column names', async () => {
+    await seedResourceWorkspace(PG_SCHEMA_FIXTURE)
+
+    await runBlueprint('resource', { name: 'Post', fields: '__dunder__:string,publishedAt:date' })
+
+    const schema = await readFile('db/schema.ts', 'utf8')
+    expect(schema).toContain("__dunder__: text('__dunder__')")
+    expect(schema).toContain("publishedAt: timestamp('published_at', { withTimezone: true })")
+  })
+
   it('rejects unknown blueprints', async () => {
     await expect(runBlueprint('unknown')).rejects.toThrow('Unknown blueprint')
   })

--- a/packages/cli/tests/entity-context.test.ts
+++ b/packages/cli/tests/entity-context.test.ts
@@ -420,3 +420,82 @@ describe('entity context (duplicated entity across locations)', () => {
     expect(ctx.seeders).toEqual(['db/seeders/001_PostsSeeder.ts'])
   })
 })
+
+// `make:factory Categories` writes `CategoriesFactory.ts` — the command
+// appends its suffix without inflecting — so discovery has to accept the
+// inflected plural, not just a trailing `s`.
+describe('entity context (irregular plural db artifacts)', () => {
+  let workspace: TempWorkspace
+
+  beforeAll(async () => {
+    workspace = await createTempWorkspace('guren-cli-entity-plural-')
+    const dir = workspace.dir
+
+    await mkdir(join(dir, 'app/Models'), { recursive: true })
+    await mkdir(join(dir, 'db/factories'), { recursive: true })
+    await mkdir(join(dir, 'db/seeders'), { recursive: true })
+    await writeFile(join(dir, 'package.json'), '{}', 'utf8')
+
+    await writeFile(join(dir, 'app/Models/Category.ts'), 'export class Category {}\n', 'utf8')
+    await writeFile(join(dir, 'app/Models/Box.ts'), 'export class Box {}\n', 'utf8')
+    // `$` is legal in an identifier and an anchor in a regex.
+    await writeFile(join(dir, 'app/Models/$Ledger.ts'), 'export class $Ledger {}\n', 'utf8')
+
+    await writeFile(
+      join(dir, 'db/factories/CategoriesFactory.ts'),
+      'export default class CategoriesFactory {}\n',
+      'utf8',
+    )
+    await writeFile(
+      join(dir, 'db/seeders/003_CategoriesSeeder.ts'),
+      'export async function seed() {}\n',
+      'utf8',
+    )
+    // The naive `+s` plural a user may have typed into `make:factory`. Matched
+    // before the inflection rule existed, so it must keep matching.
+    await writeFile(
+      join(dir, 'db/factories/CategorysFactory.ts'),
+      'export default class CategorysFactory {}\n',
+      'utf8',
+    )
+    // Singular naming must keep working alongside all of it.
+    await writeFile(
+      join(dir, 'db/factories/BoxFactory.ts'),
+      'export default class BoxFactory {}\n',
+      'utf8',
+    )
+    await writeFile(
+      join(dir, 'db/factories/$LedgerFactory.ts'),
+      'export default class $LedgerFactory {}\n',
+      'utf8',
+    )
+  })
+
+  afterAll(async () => {
+    await workspace.cleanup()
+  })
+
+  it('finds factories and seeders named with the inflected plural', async () => {
+    const ctx = await generateEntityContext('Category', { cwd: workspace.dir })
+
+    expect(ctx.factories).toEqual([
+      'db/factories/CategoriesFactory.ts',
+      'db/factories/CategorysFactory.ts',
+    ])
+    expect(ctx.seeders).toEqual(['db/seeders/003_CategoriesSeeder.ts'])
+  })
+
+  it('still finds artifacts named with the singular', async () => {
+    const ctx = await generateEntityContext('Box', { cwd: workspace.dir })
+
+    expect(ctx.factories).toEqual(['db/factories/BoxFactory.ts'])
+    // No seeder is named after Box, so another entity's must not stand in.
+    expect(ctx.seeders).toEqual([])
+  })
+
+  it('treats regex metacharacters in the entity name as literals', async () => {
+    const ctx = await generateEntityContext('$Ledger', { cwd: workspace.dir })
+
+    expect(ctx.factories).toEqual(['db/factories/$LedgerFactory.ts'])
+  })
+})


### PR DESCRIPTION
## Summary

Two small naming-derivation gaps left out of scope from the `inflect.ts` pluralization consolidation (#396194d/#0335ce5/#aceb78d, since merged into `main`):

- **`guren context <Entity>` missed inflected-plural factory/seeder files.** Discovery matched `${entity}s?Factory` — `Category` found `CategoryFactory` and `CategorysFactory` but not `CategoriesFactory`, even though `make:factory`/`make:seeder` append their suffix to the raw user argument without inflecting, so plural-named files are a real, expected shape. Fixed by matching the singular, the naive `+s` plural, and `collectionName()`'s inflected plural — landed as `dbArtifactPattern()` in `discovery.ts`, next to the existing `controllerTestCandidates()` precedent for the same kind of filename-tolerance rule.
- **A second `snakeCase()` for column names vs. `tableNameFor()` for table names.** Investigated whether these should unify. They should not: a field name is a user-written identifier where underscore runs are meaningful (`__dunder__` must survive), while `tableNameFor()` is kebab-based and would collapse them. No behavior change — added a pinning test plus an explanatory comment at the decision site.

## Review

Went through a Codex pass plus a 4-angle simplify pass (reuse/simplification/efficiency/altitude). Codex caught three real issues before this landed, all fixed:
- The original "unreachable" claim for the column/table naming split was checked against every real caller of `tableNameFor()` and was **false** — `check.ts` passes a raw file basename (not `pascalCase()`d) into it. The comment now argues from what each name has to do, not from where it came from.
- Dropping the naive `+s` plural form was a real regression (`make:factory Categorys` genuinely produces `CategorysFactory.ts`); it's kept.
- Entity names weren't regex-escaped (`$` is legal in a class name and an anchor in a regex) — now escaped via the existing `escapeRegExp()`.

## Known follow-ups (out of scope here, filed as separate tasks)

- `doctor.ts` has its own singular-only, non-module-aware rule for "does this entity have a factory?" that now disagrees with `guren context`. Should converge on the shared `dbArtifactPattern()`/`DB_ARTIFACT_DIRS`, but isn't a drop-in — doctor also scans a `database/factories/` path the shared constant doesn't know about.
- `listAppRoots()` is called 9× uncached per `generateEntityContext()`, and `discoverTestFiles()` walks the whole project tree separately from the narrower `discoverDir` walks — redundant I/O, not correctness-affecting, scales with project size.

## Test plan

- [x] `bun run build cli`
- [x] `bun run test:bun cli` — 985 pass, 0 fail
- [x] `bunx tsc --noEmit -p packages/cli/tsconfig.json` — clean
- [x] New tests verified to fail under mutation (reverting each fix independently) before being verified to pass with the fix applied