### PR TITLE
fix(cli): guren doctor no longer warns about pages.gen.ts for API-only apps

### DIFF
--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -15,6 +15,7 @@ import {
 } from './discovery'
 import { checkPluginCompatibility, readCoreVersion, readInstalledPluginManifests } from './plugin-manifest'
 import { compareVersions } from './codemods'
+import { appEmitsPageManifest } from './pages-types'
 import { extractClassDeclaration } from './model-parser'
 import { parseSourceFile } from './parse-cache'
 import {
@@ -104,6 +105,10 @@ export interface DoctorJsonOutput {
 
 interface DoctorRuleContext {
   cwd: string
+  // Shared so every rule that checks for Inertia pages sees the same
+  // snapshot of the filesystem — computing it per-rule would let concurrent
+  // rules disagree if a page file were added or removed mid-run.
+  pagesExpected: Promise<boolean>
 }
 
 interface DoctorRule {
@@ -292,35 +297,58 @@ async function detectRoutes(context: DoctorRuleContext): Promise<DoctorCheck> {
 
 async function detectPageContracts(context: DoctorRuleContext): Promise<DoctorCheck> {
   const pageContracts = await findFirstExisting(context.cwd, PAGE_CONTRACT_CANDIDATES)
-  if (!pageContracts) {
+  if (pageContracts) {
+    return createCheck('page-contracts', 'Page Types', 'pass', `Found ${pageContracts}.`)
+  }
+
+  // An API-only app never gets a manifest out of codegen, so warning there is a false positive.
+  if (!(await context.pagesExpected)) {
     return createCheck(
       'page-contracts',
       'Page Types',
-      'warn',
-      'No .guren/pages.gen.ts file was found.',
-      {
-        fix: 'Run `bunx guren codegen --force` to generate page type definitions.',
-        manualFix: 'Run `bunx guren codegen --force` to regenerate .guren/pages.gen.ts.',
-      },
+      'pass',
+      'No Inertia pages detected; page type generation is not applicable.',
     )
   }
 
-  return createCheck('page-contracts', 'Page Types', 'pass', `Found ${pageContracts}.`)
+  return createCheck(
+    'page-contracts',
+    'Page Types',
+    'warn',
+    'No .guren/pages.gen.ts file was found.',
+    {
+      fix: 'Run `bunx guren codegen --force` to generate page type definitions.',
+      manualFix: 'Run `bunx guren codegen --force` to regenerate .guren/pages.gen.ts.',
+    },
+  )
 }
 
 function createGeneratedManifestRule(generatedFile: string): DoctorRule {
+  const key = `generated:${generatedFile}`
+
   return {
-    key: `generated:${generatedFile}`,
+    key,
     title: generatedFile,
     async detect(context) {
-      const present = await fileExists(context.cwd, generatedFile)
+      if (await fileExists(context.cwd, generatedFile)) {
+        return createCheck(key, generatedFile, 'pass', `Generated manifest present at ${generatedFile}.`)
+      }
+
+      // An API-only app never gets a pages manifest out of codegen, so warning there is a false positive.
+      if (generatedFile === '.guren/pages.gen.ts' && !(await context.pagesExpected)) {
+        return createCheck(
+          key,
+          generatedFile,
+          'pass',
+          `No Inertia pages detected; ${generatedFile} is not applicable.`,
+        )
+      }
+
       return createCheck(
-        `generated:${generatedFile}`,
+        key,
         generatedFile,
-        present ? 'pass' : 'warn',
-        present
-          ? `Generated manifest present at ${generatedFile}.`
-          : `Missing generated manifest ${generatedFile}.`,
+        'warn',
+        `Missing generated manifest ${generatedFile}.`,
         {
           fix: `Run \`guren codegen --force\` to regenerate ${generatedFile}.`,
           manualFix: `Run \`guren codegen --force\` to regenerate ${generatedFile}.`,
@@ -1194,7 +1222,7 @@ export async function getDoctorRuleEvaluations(options: { cwd?: string } = {}): 
   evaluations: DoctorRuleEvaluation[]
 }> {
   const cwd = resolve(options.cwd ?? process.cwd())
-  const context: DoctorRuleContext = { cwd }
+  const context: DoctorRuleContext = { cwd, pagesExpected: appEmitsPageManifest(cwd) }
 
   // The deploy-runtime checks share one filesystem scan, computed once here
   // rather than through the DoctorRule interface (they need no autofix and no
@@ -1383,8 +1411,15 @@ export async function suggestNextSteps(options: { cwd?: string } = {}): Promise<
     // Ignore
   }
 
+  const hasPages = await appEmitsPageManifest(cwd)
+  const requiredManifests = [
+    '.guren/routes.gen.ts',
+    ...(hasPages ? ['.guren/pages.gen.ts'] : []),
+    '.guren/data.gen.ts',
+    '.guren/api-client.gen.ts',
+  ]
   let missingManifests = false
-  for (const manifest of ['.guren/routes.gen.ts', '.guren/pages.gen.ts', '.guren/data.gen.ts', '.guren/api-client.gen.ts']) {
+  for (const manifest of requiredManifests) {
     if (!(await fileExists(cwd, manifest))) {
       missingManifests = true
       break

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -525,6 +525,52 @@ describe('runDoctor', () => {
     }
   })
 
+  it('does not warn about pages.gen.ts for an API-only app with no Inertia pages', async () => {
+    const workspace = await createTempWorkspace('guren-cli-doctor-api-only-pages-')
+
+    try {
+      await mkdir(join(workspace.dir, '.guren'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'package.json'),
+        JSON.stringify({ name: 'doctor-api-only-pages' }, null, 2),
+        'utf8',
+      )
+
+      const report = await runDoctor({ cwd: workspace.dir, json: true })
+      const pageContractsCheck = report.checks.find((check) => check.key === 'page-contracts')
+      const pagesManifestCheck = report.checks.find((check) => check.key === 'generated:.guren/pages.gen.ts')
+
+      expect(pageContractsCheck?.status).toBe('pass')
+      expect(pagesManifestCheck?.status).toBe('pass')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('still warns about pages.gen.ts when Inertia pages exist but the manifest is missing', async () => {
+    const workspace = await createTempWorkspace('guren-cli-doctor-pages-warn-')
+
+    try {
+      await mkdir(join(workspace.dir, '.guren'), { recursive: true })
+      await mkdir(join(workspace.dir, 'resources/js/pages'), { recursive: true })
+      await writeFile(join(workspace.dir, 'resources/js/pages/Home.tsx'), 'export default function Home() { return null }\n', 'utf8')
+      await writeFile(
+        join(workspace.dir, 'package.json'),
+        JSON.stringify({ name: 'doctor-pages-warn' }, null, 2),
+        'utf8',
+      )
+
+      const report = await runDoctor({ cwd: workspace.dir, json: true })
+      const pageContractsCheck = report.checks.find((check) => check.key === 'page-contracts')
+      const pagesManifestCheck = report.checks.find((check) => check.key === 'generated:.guren/pages.gen.ts')
+
+      expect(pageContractsCheck?.status).toBe('warn')
+      expect(pagesManifestCheck?.status).toBe('warn')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('warns when the @/* alias maps to the app directory instead of the project root', async () => {
     const workspace = await createTempWorkspace('guren-cli-doctor-alias-')
 
@@ -1160,6 +1206,42 @@ describe('suggestNextSteps', () => {
       // half free to drift away from `guren check`.
       expect(oauthStep!.description).toContain('filename-only detection')
       expect(oauthStep!.description).toContain('already covered under another name')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('does not suggest codegen for a missing pages.gen.ts in an API-only app', async () => {
+    const workspace = await createTempWorkspace('guren-cli-doctor-next-steps-api-only-')
+
+    try {
+      await mkdir(join(workspace.dir, '.guren'), { recursive: true })
+      await writeFile(join(workspace.dir, '.guren/routes.gen.ts'), 'export const routeManifest = {} as const\n', 'utf8')
+      await writeFile(join(workspace.dir, '.guren/data.gen.ts'), 'export namespace Data {}\n', 'utf8')
+      await writeFile(join(workspace.dir, '.guren/api-client.gen.ts'), 'export type ApiRoutes = {}\n', 'utf8')
+
+      const steps = await suggestNextSteps({ cwd: workspace.dir })
+
+      expect(steps.some((step) => step.title === 'Run codegen')).toBe(false)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('suggests codegen for a missing pages.gen.ts when Inertia pages exist', async () => {
+    const workspace = await createTempWorkspace('guren-cli-doctor-next-steps-pages-')
+
+    try {
+      await mkdir(join(workspace.dir, '.guren'), { recursive: true })
+      await mkdir(join(workspace.dir, 'resources/js/pages'), { recursive: true })
+      await writeFile(join(workspace.dir, 'resources/js/pages/Home.tsx'), 'export default function Home() { return null }\n', 'utf8')
+      await writeFile(join(workspace.dir, '.guren/routes.gen.ts'), 'export const routeManifest = {} as const\n', 'utf8')
+      await writeFile(join(workspace.dir, '.guren/data.gen.ts'), 'export namespace Data {}\n', 'utf8')
+      await writeFile(join(workspace.dir, '.guren/api-client.gen.ts'), 'export type ApiRoutes = {}\n', 'utf8')
+
+      const steps = await suggestNextSteps({ cwd: workspace.dir })
+
+      expect(steps.some((step) => step.title === 'Run codegen')).toBe(true)
     } finally {
       await workspace.cleanup()
     }


### PR DESCRIPTION
## Summary
- `bunx guren doctor` unconditionally warned "No .guren/pages.gen.ts file was found", even for API-only apps where codegen never emits that file (no Inertia page components exist).
- Gates the three affected call sites in `doctor.ts` (`detectPageContracts`, the `.guren/pages.gen.ts` case in `createGeneratedManifestRule`, and the manifest list in `suggestNextSteps`) behind `appEmitsPageManifest()` from `pages-types.ts` — the same predicate `guren check` already uses for this (introduced in #255).
- The predicate is computed once per doctor run and shared via `DoctorRuleContext.pagesExpected` so the two page-related rules can't observe different filesystem snapshots of each other (each previously ran its own independent scan under `Promise.all`).

## Test plan
- [x] `bun test packages/cli/tests/doctor.test.ts` — 46 pass, including new cases for both directions (API-only app with no pages doesn't warn; app with Inertia pages but a missing manifest still warns), covering both `runDoctor` and `suggestNextSteps`.
- [x] `bun run test:bun cli` — 974 pass, 0 fail.
- [x] `bun run build:clean cli` and `bun run typecheck` — clean.
- [x] Real scaffold verification: `create-app --blueprint api --db sqlite` → after codegen, `page-contracts` / `generated:.guren/pages.gen.ts` both pass ("not applicable"). Default (Inertia) scaffold with `.guren/pages.gen.ts` deleted after codegen → both checks still warn as expected.