### PR TITLE
fix(server): deliver schema-parsed output on Response-returning routes

### DIFF
--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -759,34 +759,57 @@ function createContractHandler<
       return result as RouteResult
     }
 
-    // If the handler returned a Response, validate the JSON body — not the Response object
+    // A Response result carries its value as a JSON body; validate that, not the Response object.
+    let outputValue: unknown = result
+    let sourceBody: string | undefined
     if (result instanceof Response) {
       try {
-        const cloned = result.clone()
-        const body = await cloned.json()
-        const output = options.output.safeParse(body)
-        if (!output.success) {
-          throw new Error(
-            `Route output validation failed for ${options.name ?? path}: ${JSON.stringify(formatValidationErrors(output.error))}`,
-          )
-        }
-      } catch (err) {
-        if (err instanceof Error && err.message.includes('output validation failed')) throw err
+        sourceBody = await result.clone().text()
+        outputValue = JSON.parse(sourceBody)
+      } catch {
         // Non-JSON response — skip output validation
+        return result as RouteResult
       }
-      return result as RouteResult
     }
 
-    // Plain object return — validate directly
-    const output = options.output.safeParse(result)
-    if (output.success) {
+    const output = options.output.safeParse(outputValue)
+    if (!output.success) {
+      throw new Error(
+        `Route output validation failed for ${options.name ?? path}: ${JSON.stringify(formatValidationErrors(output.error))}`,
+      )
+    }
+
+    // Return the parsed data so schema defaults/transforms/coercions reach the client.
+    if (!(result instanceof Response)) {
       return output.data as RouteResult
     }
 
-    throw new Error(
-      `Route output validation failed for ${options.name ?? path}: ${JSON.stringify(formatValidationErrors(output.error))}`,
-    )
+    return (rebuildJsonResponse(result, sourceBody as string, output.data) ?? result) as RouteResult
   }
+}
+
+/**
+ * Re-serialize a JSON response from schema-parsed data, or `null` when parsing was a
+ * no-op and the original response can be sent untouched.
+ *
+ * Headers describing the *previous* body are dropped: the parsed payload may differ
+ * in byte length (schema defaults) and in content (transforms), so a copied
+ * `Content-Length` or `ETag` would misdescribe what is actually sent.
+ */
+function rebuildJsonResponse(source: Response, sourceBody: string, data: unknown): Response | null {
+  const body = JSON.stringify(data)
+  if (body === sourceBody) {
+    return null
+  }
+
+  const headers = new Headers(source.headers)
+  dropStaleBodyHeaders(headers)
+  return new Response(body, { status: source.status, headers })
+}
+
+function dropStaleBodyHeaders(headers: Headers): void {
+  headers.delete('content-length')
+  headers.delete('etag')
 }
 
 function parseRouteSegment<T>(
@@ -850,18 +873,33 @@ function createContractValidationMiddleware(route: RegisteredRoute): MiddlewareH
 
     // Validate output schema against the response body
     if (schemas.output && c.res) {
+      let sourceBody: string
+      let parsedBody: unknown
       try {
-        const cloned = c.res.clone()
-        const body = await cloned.json()
-        const parsed = schemas.output.safeParse(body)
-        if (!parsed.success) {
-          const errors = 'flatten' in parsed.error && typeof (parsed.error as any).flatten === 'function'
-            ? (parsed.error as any).flatten()
-            : parsed.error
-          c.res = c.json({ message: 'Response validation failed', errors }, 500)
-        }
+        sourceBody = await c.res.clone().text()
+        parsedBody = JSON.parse(sourceBody)
       } catch {
         // Non-JSON response or parse error — skip output validation
+        return
+      }
+
+      const parsed = schemas.output.safeParse(parsedBody)
+      if (!parsed.success) {
+        const errors = 'flatten' in parsed.error && typeof (parsed.error as any).flatten === 'function'
+          ? (parsed.error as any).flatten()
+          : parsed.error
+        c.res = c.json({ message: 'Response validation failed', errors }, 500)
+        return
+      }
+
+      // Rebuild the response from the parsed data so defaults/transforms/coercions
+      // applied by the schema reach the client.
+      const rebuilt = rebuildJsonResponse(c.res, sourceBody, parsed.data)
+      if (rebuilt) {
+        c.res = rebuilt
+        // Hono's `c.res` setter copies every header off the replaced response, which
+        // restores the ones rebuildJsonResponse just dropped — drop them again.
+        dropStaleBodyHeaders(c.res.headers)
       }
     }
   }

--- a/packages/server/tests/mvc/router.test.ts
+++ b/packages/server/tests/mvc/router.test.ts
@@ -324,3 +324,164 @@ describe('route contract array query params (#12)', () => {
     expect(bad.status).toBe(422)
   })
 })
+
+describe('route contract output validation for Response-returning handlers', () => {
+  /** Emits `{"id":1}` with a Content-Length and ETag that describe exactly those bytes. */
+  const staleHeaderController = () => class StaleHeaderController extends Controller {
+    async index() {
+      const body = JSON.stringify({ id: 1 })
+      return new Response(body, {
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': String(body.length),
+          ETag: 'W/"original"',
+        },
+      })
+    }
+  }
+
+  it('applies schema defaults to the body of a controller action response', async () => {
+    class EchoController extends Controller {
+      async index() {
+        return new Response(JSON.stringify({}), { headers: { 'Content-Type': 'application/json' } })
+      }
+    }
+
+    const router = new Router()
+    router.get('/echo', {
+      output: z.object({ body: z.string().default('') }),
+    }, [EchoController, 'index'])
+
+    const app = new Hono()
+    router.mount(app)
+
+    const response = await app.request('/echo')
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ body: '' })
+  })
+
+  it('preserves status and custom headers when rebuilding a controller action response', async () => {
+    class CreatedController extends Controller {
+      async store() {
+        return new Response(JSON.stringify({ id: 1 }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json', 'X-Custom': 'value' },
+        })
+      }
+    }
+
+    const router = new Router()
+    router.post('/created', {
+      output: z.object({ id: z.number() }),
+    }, [CreatedController, 'store'])
+
+    const app = new Hono()
+    router.mount(app)
+
+    const response = await app.request('/created', { method: 'POST' })
+
+    expect(response.status).toBe(201)
+    expect(response.headers.get('X-Custom')).toBe('value')
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+  })
+
+  // Headers describing the replaced body must not survive the rebuild. Hono's `c.res`
+  // setter re-copies headers off the response it replaces, so dropping them before
+  // the assignment is not enough.
+  it('drops Content-Length and ETag that no longer describe the rebuilt body', async () => {
+    const router = new Router()
+    router.get('/stale', {
+      output: z.object({ id: z.number(), padding: z.string().default('xxxxxxxxxxxxxxxxxxxx') }),
+    }, [staleHeaderController(), 'index'])
+
+    const app = new Hono()
+    router.mount(app)
+
+    const response = await app.request('/stale')
+    const text = await response.text()
+
+    expect(text).toBe(JSON.stringify({ id: 1, padding: 'xxxxxxxxxxxxxxxxxxxx' }))
+    expect(response.headers.get('Content-Length')).toBeNull()
+    expect(response.headers.get('ETag')).toBeNull()
+  })
+
+  it('passes the response through untouched when parsing changes nothing', async () => {
+    const router = new Router()
+    router.get('/stale', {
+      output: z.object({ id: z.number() }),
+    }, [staleHeaderController(), 'index'])
+
+    const app = new Hono()
+    router.mount(app)
+
+    const response = await app.request('/stale')
+
+    // No rebuild, so the handler's own Content-Length and ETag still describe the body.
+    expect(await response.text()).toBe(JSON.stringify({ id: 1 }))
+    expect(response.headers.get('Content-Length')).toBe('8')
+    expect(response.headers.get('ETag')).toBe('W/"original"')
+  })
+
+  it('skips validation for non-JSON controller action responses', async () => {
+    class PlainController extends Controller {
+      async index() {
+        return new Response('plain text')
+      }
+    }
+
+    const router = new Router()
+    router.get('/plain', {
+      output: z.object({ body: z.string() }),
+    }, [PlainController, 'index'])
+
+    const app = new Hono()
+    router.mount(app)
+
+    const response = await app.request('/plain')
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('plain text')
+  })
+
+  it('rejects a controller action response that fails output validation', async () => {
+    class InvalidController extends Controller {
+      async index() {
+        return new Response(JSON.stringify({ id: 'not-a-number' }), {
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+    }
+
+    const router = new Router()
+    router.get('/invalid', {
+      output: z.object({ id: z.number() }),
+    }, [InvalidController, 'index'])
+
+    const app = new Hono()
+    router.mount(app)
+
+    const response = await app.request('/invalid')
+
+    expect(response.status).toBe(500)
+    const json = await response.json() as { message: string }
+    expect(json.message).toBe('Response validation failed')
+  })
+
+  // The typed handler signature forbids returning a Response when `output` is set,
+  // so this branch is only reachable from untyped (JS) callers.
+  it('applies schema defaults when an untyped inline handler returns a Response', async () => {
+    const router = new Router()
+    router.get('/inline', {
+      output: z.object({ body: z.string().default('') }),
+    }, (async () => new Response(JSON.stringify({}))) as never)
+
+    const app = new Hono()
+    router.mount(app)
+
+    const response = await app.request('/inline')
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ body: '' })
+  })
+})


### PR DESCRIPTION
## Summary

Route `output` Zod schemas validated `Response`-returning handlers but discarded the parsed result, so `.default()`/`.transform()`/`.coerce` never reached the client even though validation passed. For example, `output: z.object({ body: z.string().default('') })` on a handler returning `new Response(JSON.stringify({}))` passed validation but shipped `{}` to the client instead of `{ body: '' }`.

Both `Response`-handling sites in `Router.ts` now rebuild the response from `safeParse(...).data`, matching the existing plain-object return path's behavior — but only when re-serializing actually changes the bytes, so a no-op schema leaves the original response untouched.

The task pointed at the inline typed-handler path in `createContractHandler` (~line 758), but `typecheck` proved that branch is unreachable from typed code: `TypedRouteHandler` types the handler's return as `InferSchema<TOutputSchema>`, so returning a `Response` there is a type error. The real-world, type-legal path is `createContractValidationMiddleware`, used by every controller-action route, which always deals in a finished `Response`. Both are fixed.

A follow-up bug surfaced mid-implementation and is fixed in the same commit: Hono's `c.res` setter copies headers from the replaced response back onto the new one, which silently undid the `Content-Length` deletion at the controller-action site — a rebuilt body could ship with a stale, mismatched `Content-Length`. Fixed by dropping the stale headers again after the `c.res` assignment, and extracted a shared `rebuildJsonResponse`/`dropStaleBodyHeaders` helper so both sites behave identically instead of drifting (this drift is exactly how the bug happened).

## Scope

- `packages/server/src/mvc/Router.ts` — `createContractHandler` (inline handlers) and `createContractValidationMiddleware` (controller actions)
- `packages/server/tests/mvc/router.test.ts` — 6 new tests

## Risk Assessment

**Wire-format change (intentional, needs a maintainer call):** since both `Response` paths now emit `safeParse(...).data` instead of the original bytes, a handler returning extra keys not declared in the `output` schema will have them stripped — e.g. `output: z.object({ id: z.number() })` on a handler returning `{ id: 1, extra: 'x' }` now sends only `{ id: 1 }`. This matches the plain-object return path's existing behavior (the two paths were inconsistent before this fix) and is a fix per the declared contract, but it changes bytes on the wire for any existing app that relied on the old passthrough. It only fires when the schema output actually differs from the original body — a no-op schema (all fields present, nothing to default/transform/strip) passes the response through byte-for-byte unchanged.

**Not in scope, flagging for awareness:** the two `Response` paths have pre-existing, divergent failure behavior that this PR intentionally leaves alone — `createContractHandler` throws (masked to `Internal Server Error` in production by `ExceptionHandler`), while `createContractValidationMiddleware` bypasses the exception handler and always ships flattened Zod error details to the client, including in production. That's an information-disclosure gap worth a separate look.

## Validation

- [x] `bun run build:clean` (server + full workspace)
- [x] `bun run typecheck` — 29 pre-existing errors, unchanged with/without this diff (confirmed via `git stash`); all in `examples/blog` due to missing `.guren/` codegen artifacts in this worktree, unrelated to this change
- [x] `bun run test:bun` — 3324 pass, 0 fail, 55 skip (209 files)
- [x] Mutation-tested all 5 new regression guards (removing each fix's core line makes its corresponding test fail)

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks (see Risk Assessment).
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation. (No public-facing docs describe this validation behavior; nothing to update.)