### PR TITLE
refactor(core): share Zod v3/v4 compat primitives between the CLI and OpenAPI walkers

### DIFF
--- a/.changeset/shared-zod-compat.md
+++ b/.changeset/shared-zod-compat.md
@@ -1,0 +1,31 @@
+---
+"@guren/core": patch
+"@guren/openapi": patch
+"@guren/cli": patch
+---
+
+refactor: share the Zod v3/v4 compatibility primitives between the two schema walkers
+
+`@guren/cli`'s TypeScript-type renderer and `@guren/openapi`'s schema-object
+renderer each carried their own copy of the knowledge needed to read a Zod
+schema without caring which major produced it: type-name lookup, the `Zod`
+prefix normalization, wrapper unwrapping, pipe-side selection, object-shape
+reading, and enum/literal value extraction. Knowledge added to one never
+reached the other — a Zod 4 array keeps its element in `_def.element` while
+`_def.type` holds the string `'array'`, and reading them in the wrong order
+silently dropped the element type. That single bug had to be found and fixed
+twice, months apart, once per package.
+
+Those primitives now live in `@guren/core/internal/zod-compat`, a deep-import
+internal module in the same vein as `internal/deploy-build`. Both walkers read
+from it, so a version quirk learned once is known in both places.
+
+The type switches stay where they are — one produces TypeScript type strings,
+the other OpenAPI schema objects, and they are not the same walk. `isOptional`
+also stays split on purpose: the CLI reads only the side of a `.pipe()` it is
+rendering, while the OpenAPI walker requires both sides to permit omission.
+
+Two incidental hardenings come along for the ride. The CLI's inner-schema
+lookup now skips non-object candidates instead of taking the first non-nullish
+one, and a nested node with no readable type name renders as `unknown` rather
+than throwing.

--- a/.changeset/shared-zod-compat.md
+++ b/.changeset/shared-zod-compat.md
@@ -20,17 +20,29 @@ Those primitives now live in `@guren/core/internal/zod-compat`, a deep-import
 internal module in the same vein as `internal/deploy-build`. Both walkers read
 from it, so a version quirk learned once is known in both places.
 
-The type switches stay where they are — one produces TypeScript type strings,
-the other OpenAPI schema objects, and they are not the same walk. `isOptional`
-also stays split on purpose: the CLI reads only the side of a `.pipe()` it is
-rendering, while the OpenAPI walker requires both sides to permit omission.
+The set of type names that carry exactly one nested schema moves too, as
+`SINGLE_CHILD_WRAPPERS` plus the two partitions each walker needs. The walkers
+had looked like they disagreed here — one held a five-name set, the other a
+twelve-name one — but the CLI simply handled the other seven as explicit
+`switch` cases. They differ in how they partition the vocabulary, not in what
+is in it, so the membership is now stated once.
 
-Two incidental hardenings come along for the ride. The CLI's inner-schema
+The type switches themselves stay where they are: one produces TypeScript type
+strings, the other OpenAPI schema objects. Their leaf vocabularies have
+legitimately diverged (the CLI renders `void`/`any`/`never`, which OpenAPI
+cannot express), and that is a rendering decision rather than version
+knowledge.
+
+Both `isOptional`s also stay with their callers, but not because each is right
+for its own purpose — the CLI reads one side of a `.pipe()` and the OpenAPI
+walker requires both, and each can be fooled by a pipeline the other handles.
+Deciding omissibility correctly means simulating a parse, which is a separate
+piece of work; the two approximations are now labelled as such where they live.
+
+Three incidental hardenings come along for the ride. The CLI's inner-schema
 lookup now skips non-object candidates instead of taking the first non-nullish
-one, and a nested node with no readable type name renders as `unknown` rather
-than throwing.
-
-One drift surface stays open on purpose: the Zod type-name vocabulary itself
-(`prefault` and `nonoptional` from v4, `effects` from v3) is still spelled out
-in both switches and both wrapper sets, because the two sets genuinely differ
-in membership.
+one; a nested node with no readable type name renders as `unknown` rather than
+throwing; and two degenerate schemas that used to emit invalid TypeScript now
+render correctly — an empty `z.enum([])` as `never` instead of an empty string,
+and `z.literal(undefined)` as `undefined` rather than being dropped by
+`JSON.stringify`.

--- a/.changeset/shared-zod-compat.md
+++ b/.changeset/shared-zod-compat.md
@@ -29,3 +29,8 @@ Two incidental hardenings come along for the ride. The CLI's inner-schema
 lookup now skips non-object candidates instead of taking the first non-nullish
 one, and a nested node with no readable type name renders as `unknown` rather
 than throwing.
+
+One drift surface stays open on purpose: the Zod type-name vocabulary itself
+(`prefault` and `nonoptional` from v4, `effects` from v3) is still spelled out
+in both switches and both wrapper sets, because the two sets genuinely differ
+in membership.

--- a/packages/cli/src/schema-type-extractor.ts
+++ b/packages/cli/src/schema-type-extractor.ts
@@ -1,24 +1,23 @@
 /**
  * Extracts TypeScript type literals from Zod schema objects at runtime.
- * Supports both Zod v3 (`_def.typeName`) and Zod v4 (`_def.type` / `.type`).
+ * Every read of a Zod-version-specific `_def` shape goes through
+ * `@guren/core/internal/zod-compat`; only rendering decisions live here.
  */
 
 import {
   arrayElement,
-  enumValues as sharedEnumValues,
+  enumValues,
   getTypeName,
   innerSchema,
   literalValues,
   objectShape,
   pipeSide,
+  schemaAt,
   type SchemaIo,
+  TRANSPARENT_WRAPPERS,
   typeOf,
   type ZodSchemaLike,
 } from '@guren/core/internal/zod-compat'
-
-type ZodAnyLike = ZodSchemaLike
-
-export type { SchemaIo }
 
 interface SchemaTypeOptions {
   /**
@@ -42,24 +41,17 @@ const COERCED_INPUT_TYPES: Record<string, string> = {
 }
 
 /**
- * Wrappers that neither add to a type nor decide presence — whatever they wrap
- * answers both questions. `zodToType` and `isOptional` walk separately, so this
- * is the one list keeping them from disagreeing about what to look through.
- */
-const TRANSPARENT_WRAPPERS = new Set(['catch', 'readonly', 'branded', 'lazy', 'effects'])
-
-/**
  * Convert a Zod schema object to a TypeScript type string.
  * Returns `undefined` if the schema structure is unrecognizable.
  */
 export function schemaToTypeString(schema: unknown, options: SchemaTypeOptions): string | undefined {
   if (!schema || typeof schema !== 'object') return undefined
-  const z = schema as ZodAnyLike
+  const z = schema as ZodSchemaLike
   if (!getTypeName(z)) return undefined
   return zodToType(z, options.io)
 }
 
-function zodToType(z: ZodAnyLike, io: SchemaIo): string {
+function zodToType(z: ZodSchemaLike, io: SchemaIo): string {
   const def = z._def ?? {}
   const t = typeOf(z)
 
@@ -89,7 +81,7 @@ function zodToType(z: ZodAnyLike, io: SchemaIo): string {
 
     case 'literal': {
       const vals = literalValues(def)
-      if (vals.length > 0) return vals.map((v) => JSON.stringify(v)).join(' | ')
+      if (vals.length > 0) return vals.map(literalType).join(' | ')
       return 'unknown'
     }
 
@@ -138,25 +130,28 @@ function zodToType(z: ZodAnyLike, io: SchemaIo): string {
 
     case 'union':
     case 'discriminatedunion': {
-      const opts = def.options as ZodAnyLike[] | undefined
+      const opts = def.options as ZodSchemaLike[] | undefined
       if (opts) return opts.map((o) => zodToType(o, io)).join(' | ')
       return 'unknown'
     }
 
     case 'intersection': {
-      const l = def.left as ZodAnyLike | undefined
-      const r = def.right as ZodAnyLike | undefined
+      const l = def.left as ZodSchemaLike | undefined
+      const r = def.right as ZodSchemaLike | undefined
       return `${l ? zodToType(l, io) : 'unknown'} & ${r ? zodToType(r, io) : 'unknown'}`
     }
 
     case 'record': {
-      const vt = (def.valueType ?? def.type) as ZodAnyLike | undefined
+      const vt = schemaAt(def, 'valueType')
       return vt ? `Record<string, ${zodToType(vt, io)}>` : 'Record<string, unknown>'
     }
 
     case 'enum': {
-      const vals = sharedEnumValues(def)
-      return vals.length > 0 ? vals.map((v) => JSON.stringify(v)).join(' | ') : 'string'
+      // An enum with no members accepts nothing, so `never` is its type. The
+      // empty-array case used to fall through to `[].join()` and emit an empty
+      // string, which is not valid TypeScript in the position this lands in.
+      const vals = enumValues(def)
+      return vals.length > 0 ? vals.map(literalType).join(' | ') : 'never'
     }
 
     case 'nativeenum':
@@ -179,10 +174,10 @@ function zodToType(z: ZodAnyLike, io: SchemaIo): string {
  * Whether a field may be omitted — the presence half of the input/output split
  * that `zodToType` handles for types.
  */
-function isOptional(z: ZodAnyLike, io: SchemaIo): boolean {
+function isOptional(z: ZodSchemaLike, io: SchemaIo): boolean {
   const t = typeOf(z)
   const def = z._def ?? {}
-  const look = (s: unknown): boolean => (s ? isOptional(s as ZodAnyLike, io) : false)
+  const look = (s: unknown): boolean => (s ? isOptional(s as ZodSchemaLike, io) : false)
 
   if (TRANSPARENT_WRAPPERS.has(t)) {
     // `.catch()` swallows any failure, so an omitted key is never rejected;
@@ -203,8 +198,11 @@ function isOptional(z: ZodAnyLike, io: SchemaIo): boolean {
       return false
     case 'nullable':
       return look(innerSchema(def))
-    // Read the side being rendered — matching what `zodToType` reports for
-    // this node — rather than requiring both sides of the pipeline to agree.
+    // Read the side being rendered, so presence matches the type `zodToType`
+    // reports for this node. An approximation: a pipeline runs both stages, so
+    // `z.string().optional().pipe(z.string())` is reported omissible even
+    // though the second stage rejects a missing value. Deciding that properly
+    // means simulating a parse, not reading a `_def`.
     case 'pipe':
     case 'pipeline':
       return look(pipeSide(def, io))
@@ -215,4 +213,13 @@ function isOptional(z: ZodAnyLike, io: SchemaIo): boolean {
 
 function wrapComplex(type: string): string {
   return type.includes('|') || type.includes('&') ? `(${type})` : type
+}
+
+/**
+ * A single literal value as a TypeScript type. `JSON.stringify` cannot render
+ * `undefined` — it returns `undefined` rather than a string — so a
+ * `z.literal(undefined)` would otherwise reach the output as an empty string.
+ */
+function literalType(value: unknown): string {
+  return value === undefined ? 'undefined' : JSON.stringify(value)
 }

--- a/packages/cli/src/schema-type-extractor.ts
+++ b/packages/cli/src/schema-type-extractor.ts
@@ -9,10 +9,10 @@ import {
   getTypeName,
   innerSchema,
   literalValues,
-  normalizeTypeName,
   objectShape,
   pipeSide,
   type SchemaIo,
+  typeOf,
   type ZodSchemaLike,
 } from '@guren/core/internal/zod-compat'
 
@@ -60,10 +60,8 @@ export function schemaToTypeString(schema: unknown, options: SchemaTypeOptions):
 }
 
 function zodToType(z: ZodAnyLike, io: SchemaIo): string {
-  const tn = getTypeName(z)!
   const def = z._def ?? {}
-
-  const t = normalizeTypeName(tn)
+  const t = typeOf(z)
 
   // `.coerce` is recorded on the schema itself in both v3 and v4, so this has
   // to be checked before the plain type mapping below claims the parsed type.
@@ -182,9 +180,7 @@ function zodToType(z: ZodAnyLike, io: SchemaIo): string {
  * that `zodToType` handles for types.
  */
 function isOptional(z: ZodAnyLike, io: SchemaIo): boolean {
-  const tn = getTypeName(z)
-  if (!tn) return false
-  const t = normalizeTypeName(tn)
+  const t = typeOf(z)
   const def = z._def ?? {}
   const look = (s: unknown): boolean => (s ? isOptional(s as ZodAnyLike, io) : false)
 

--- a/packages/cli/src/schema-type-extractor.ts
+++ b/packages/cli/src/schema-type-extractor.ts
@@ -3,22 +3,22 @@
  * Supports both Zod v3 (`_def.typeName`) and Zod v4 (`_def.type` / `.type`).
  */
 
-interface ZodAnyLike {
-  _def?: Record<string, unknown>
-  type?: string
-  shape?: Record<string, ZodAnyLike>
-}
+import {
+  arrayElement,
+  enumValues as sharedEnumValues,
+  getTypeName,
+  innerSchema,
+  literalValues,
+  normalizeTypeName,
+  objectShape,
+  pipeSide,
+  type SchemaIo,
+  type ZodSchemaLike,
+} from '@guren/core/internal/zod-compat'
 
-/**
- * Which side of a schema to render.
- *
- * - `output` — the parsed value, i.e. what a controller receives after
- *   validation. This is what a response body looks like.
- * - `input` — the value a client has to send over the wire. Coercing schemas
- *   differ here: `z.coerce.date()` parses to a `Date`, but JSON carries it as
- *   an ISO string, so only `string` is actually sendable.
- */
-export type SchemaIo = 'input' | 'output'
+type ZodAnyLike = ZodSchemaLike
+
+export type { SchemaIo }
 
 interface SchemaTypeOptions {
   /**
@@ -48,26 +48,6 @@ const COERCED_INPUT_TYPES: Record<string, string> = {
  */
 const TRANSPARENT_WRAPPERS = new Set(['catch', 'readonly', 'branded', 'lazy', 'effects'])
 
-function getTypeName(z: ZodAnyLike): string | undefined {
-  // v3: _def.typeName = "ZodString" etc.
-  // v4: _def.type = "string" etc. or top-level .type
-  return (z._def?.typeName as string) ?? (z._def?.type as string) ?? z.type
-}
-
-/** Normalize v3's `"ZodString"` and v4's `"string"` to one lowercase name. */
-function normalizeTypeName(typeName: string): string {
-  return typeName.startsWith('Zod') ? typeName.slice(3).toLowerCase() : typeName.toLowerCase()
-}
-
-/**
- * Whether this node is a `.transform()`'s output half — a wrapped function with
- * no type to read, as opposed to a schema that genuinely parses to `unknown`.
- */
-function isTransform(z: ZodAnyLike): boolean {
-  const tn = getTypeName(z)
-  return tn ? normalizeTypeName(tn) === 'transform' : false
-}
-
 /**
  * Convert a Zod schema object to a TypeScript type string.
  * Returns `undefined` if the schema structure is unrecognizable.
@@ -92,7 +72,8 @@ function zodToType(z: ZodAnyLike, io: SchemaIo): string {
   }
 
   if (TRANSPARENT_WRAPPERS.has(t)) {
-    return inner(def) ? zodToType(inner(def)!, io) : 'unknown'
+    const wrapped = innerSchema(def)
+    return wrapped ? zodToType(wrapped, io) : 'unknown'
   }
 
   switch (t) {
@@ -109,27 +90,19 @@ function zodToType(z: ZodAnyLike, io: SchemaIo): string {
     case 'never': return 'never'
 
     case 'literal': {
-      // v3: _def.value, v4: _def.values[]
-      if ('value' in def) return JSON.stringify(def.value)
-      const vals = def.values as unknown[]
-      if (vals) return vals.map((v) => JSON.stringify(v)).join(' | ')
+      const vals = literalValues(def)
+      if (vals.length > 0) return vals.map((v) => JSON.stringify(v)).join(' | ')
       return 'unknown'
     }
 
     case 'array': {
-      // v4 holds the element in `_def.element` and puts the literal string
-      // `'array'` in `_def.type` — so `element` has to be tried first, or v4
-      // arrays hand that string back to `zodToType`. v3 has only `_def.type`.
-      const el = (def.element ?? def.type) as ZodAnyLike | undefined
+      const el = arrayElement(def)
       if (el) return `${wrapComplex(zodToType(el, io))}[]`
       return 'unknown[]'
     }
 
     case 'object': {
-      // v3: _def.shape() is a function, v4: _def.shape is an object
-      const shape = typeof def.shape === 'function'
-        ? (def.shape as () => Record<string, ZodAnyLike>)()
-        : (def.shape ?? z.shape) as Record<string, ZodAnyLike> | undefined
+      const shape = objectShape(z)
       if (!shape) return 'Record<string, unknown>'
       const entries = Object.entries(shape)
       if (entries.length === 0) return '{}'
@@ -141,7 +114,7 @@ function zodToType(z: ZodAnyLike, io: SchemaIo): string {
     }
 
     case 'nullable': {
-      const i = inner(def)
+      const i = innerSchema(def)
       return i ? `${zodToType(i, io)} | null` : 'unknown | null'
     }
 
@@ -151,19 +124,15 @@ function zodToType(z: ZodAnyLike, io: SchemaIo): string {
     case 'optional':
     case 'default':
     case 'prefault':
-    case 'nonoptional':
-      return inner(def) ? zodToType(inner(def)!, io) : 'unknown'
+    case 'nonoptional': {
+      const wrapped = innerSchema(def)
+      return wrapped ? zodToType(wrapped, io) : 'unknown'
+    }
 
     case 'pipe':
     case 'pipeline': {
-      // v3 names this `ZodPipeline`; v4 uses one pipe for both `.pipe()` and
-      // `.transform()`. `_def.in` is what a client sends, `_def.out` what the
-      // controller receives — except for a transform, whose out side is the
-      // function itself, leaving the in side as the best available answer.
-      const from = def.in as ZodAnyLike | undefined
-      const to = def.out as ZodAnyLike | undefined
-      if (io === 'output' && to && !isTransform(to)) return zodToType(to, io)
-      return from ? zodToType(from, io) : 'unknown'
+      const side = pipeSide(def, io)
+      return side ? zodToType(side, io) : 'unknown'
     }
 
     case 'transform':
@@ -188,12 +157,8 @@ function zodToType(z: ZodAnyLike, io: SchemaIo): string {
     }
 
     case 'enum': {
-      // v3: _def.values[], v4: _def.entries {}
-      const vals = def.values as string[] | undefined
-      if (vals) return vals.map((v) => JSON.stringify(v)).join(' | ')
-      const entries = def.entries as Record<string, string> | undefined
-      if (entries) return Object.values(entries).map((v) => JSON.stringify(v)).join(' | ')
-      return 'string'
+      const vals = sharedEnumValues(def)
+      return vals.length > 0 ? vals.map((v) => JSON.stringify(v)).join(' | ') : 'string'
     }
 
     case 'nativeenum':
@@ -203,20 +168,13 @@ function zodToType(z: ZodAnyLike, io: SchemaIo): string {
       return 'unknown[]'
 
     case 'promise': {
-      const i = inner(def) ?? (def.type as ZodAnyLike | undefined)
+      const i = innerSchema(def)
       return i ? `Promise<${zodToType(i, io)}>` : 'Promise<unknown>'
     }
 
     default:
       return 'unknown'
   }
-}
-
-function inner(def: Record<string, unknown>): ZodAnyLike | undefined {
-  // v3: innerType or schema; v3's `.brand()` uses `type`, which in v4 holds the
-  // type *name* instead — so it only counts when it is actually a schema.
-  const candidate = def.innerType ?? def.schema ?? def.type
-  return candidate && typeof candidate === 'object' ? (candidate as ZodAnyLike) : undefined
 }
 
 /**
@@ -234,7 +192,7 @@ function isOptional(z: ZodAnyLike, io: SchemaIo): boolean {
     // `.catch()` swallows any failure, so an omitted key is never rejected;
     // on the way out it is absent only if what it wraps could be.
     if (t === 'catch' && io === 'input') return true
-    return look(inner(def))
+    return look(innerSchema(def))
   }
 
   switch (t) {
@@ -248,15 +206,12 @@ function isOptional(z: ZodAnyLike, io: SchemaIo): boolean {
     case 'nonoptional':
       return false
     case 'nullable':
-      return look(inner(def))
+      return look(innerSchema(def))
+    // Read the side being rendered — matching what `zodToType` reports for
+    // this node — rather than requiring both sides of the pipeline to agree.
     case 'pipe':
-    case 'pipeline': {
-      // Read the side being rendered — and when the out side is a transform,
-      // read the in side, matching what `zodToType` reports for that node.
-      const to = def.out as ZodAnyLike | undefined
-      if (io === 'output' && to && !isTransform(to)) return look(to)
-      return look(def.in)
-    }
+    case 'pipeline':
+      return look(pipeSide(def, io))
     default:
       return false
   }

--- a/packages/cli/tests/schema-type-extractor.test.ts
+++ b/packages/cli/tests/schema-type-extractor.test.ts
@@ -167,3 +167,25 @@ describe('schemaToTypeString', () => {
     })
   })
 })
+
+describe('degenerate schemas', () => {
+  // An enum with no members accepts nothing. This used to render as an empty
+  // string, which is not valid TypeScript wherever the result is spliced in.
+  it('renders an empty enum as never', () => {
+    expect(schemaToTypeString(z.enum([]), { io: 'output' })).toBe('never')
+    expect(schemaToTypeString(z3.enum([] as unknown as [string]), { io: 'output' })).toBe('never')
+  })
+
+  // `JSON.stringify(undefined)` returns undefined rather than a string, so
+  // rendering literal values through it alone dropped this to an empty string.
+  it('renders a literal undefined as the undefined type', () => {
+    expect(schemaToTypeString(z3.literal(undefined), { io: 'output' })).toBe('undefined')
+  })
+
+  it('still renders a record value type on both majors', () => {
+    expect(schemaToTypeString(z.record(z.string(), z.number()), { io: 'output' }))
+      .toBe('Record<string, number>')
+    expect(schemaToTypeString(z3.record(z3.number()), { io: 'output' }))
+      .toBe('Record<string, number>')
+  })
+})

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,6 +44,10 @@
     "./internal/deploy-build": {
       "types": "./dist/internal/deploy-build.d.ts",
       "default": "./dist/internal/deploy-build.js"
+    },
+    "./internal/zod-compat": {
+      "types": "./dist/internal/zod-compat.d.ts",
+      "default": "./dist/internal/zod-compat.js"
     }
   },
   "bin": {

--- a/packages/core/src/internal/zod-compat.test.ts
+++ b/packages/core/src/internal/zod-compat.test.ts
@@ -9,9 +9,17 @@ import {
   normalizeTypeName,
   objectShape,
   pipeSide,
+  pipeSides,
+  PRESENCE_WRAPPERS,
   schemaAt,
+  SINGLE_CHILD_WRAPPERS,
+  TRANSPARENT_WRAPPERS,
   typeOf,
 } from './zod-compat'
+
+/** Reach into a schema's `_def`, which is exactly what these helpers exist to read. */
+const defOf = (schema: unknown): Record<string, unknown> =>
+  (schema as { _def: Record<string, unknown> })._def
 
 describe('typeOf', () => {
   test('normalizes a Zod v4 type name', () => {
@@ -47,7 +55,7 @@ describe('arrayElement', () => {
   // then renders as an empty/unknown element — the bug fixed once per package.
   test('reads the element off a Zod v4 array, not the type-name string in _def.type', () => {
     const arraySchema = z.array(z.string())
-    const def = (arraySchema as never as { _def: Record<string, unknown> })._def
+    const def = defOf(arraySchema)
     expect(def.type).toBe('array')
     const element = arrayElement(def)
     expect(element).toBeDefined()
@@ -56,7 +64,7 @@ describe('arrayElement', () => {
 
   test('reads the element off a Zod v3 array', () => {
     const arraySchema = z3.array(z3.number())
-    const def = (arraySchema as never as { _def: Record<string, unknown> })._def
+    const def = defOf(arraySchema)
     const element = arrayElement(def)
     expect(element).toBeDefined()
     expect(typeOf(element!)).toBe('number')
@@ -80,22 +88,55 @@ describe('objectShape', () => {
 describe('pipeSide', () => {
   test('reads the coerced-from side for input, the parsed side for output', () => {
     const schema = z.string().pipe(z.coerce.number())
-    const def = (schema as never as { _def: Record<string, unknown> })._def
+    const def = defOf(schema)
     expect(typeOf(pipeSide(def, 'input')!)).toBe('string')
     expect(typeOf(pipeSide(def, 'output')!)).toBe('number')
   })
 
   test('falls back to the input side when the output side is a transform', () => {
     const schema = z.string().transform((value) => value.length)
-    const def = (schema as never as { _def: Record<string, unknown> })._def
+    const def = defOf(schema)
     expect(typeOf(pipeSide(def, 'output')!)).toBe('string')
+  })
+
+  test('pipeSides omits a transform out side so callers cannot read a function as a schema', () => {
+    const transformed = pipeSides(defOf(z.string().transform((value) => value.length)))
+    expect(transformed.to).toBeUndefined()
+    expect(typeOf(transformed.from!)).toBe('string')
+
+    const piped = pipeSides(defOf(z.string().pipe(z.coerce.number())))
+    expect(typeOf(piped.to!)).toBe('number')
+  })
+})
+
+describe('wrapper vocabulary', () => {
+  // The two walkers partition these differently — the CLI splits transparent
+  // from presence-deciding because it walks types and presence separately,
+  // while the OpenAPI walker looks through all of them uniformly. What they
+  // must never do is disagree about membership, so the partitions are pinned
+  // here rather than restated in each package.
+  test('SINGLE_CHILD_WRAPPERS is the union of both partitions plus the specially-rendered three', () => {
+    expect([...SINGLE_CHILD_WRAPPERS].sort()).toEqual([
+      'branded', 'catch', 'default', 'effects', 'lazy', 'nonoptional',
+      'nullable', 'optional', 'pipe', 'pipeline', 'prefault', 'readonly',
+    ])
+  })
+
+  test('the partitions are disjoint and both contained in the whole', () => {
+    for (const name of TRANSPARENT_WRAPPERS) {
+      expect(PRESENCE_WRAPPERS.has(name)).toBe(false)
+      expect(SINGLE_CHILD_WRAPPERS.has(name)).toBe(true)
+    }
+    for (const name of PRESENCE_WRAPPERS) {
+      expect(SINGLE_CHILD_WRAPPERS.has(name)).toBe(true)
+    }
   })
 })
 
 describe('isTransform', () => {
   test('identifies a transform node', () => {
     const schema = z.string().transform((value) => value.length)
-    const def = (schema as never as { _def: Record<string, unknown> })._def
+    const def = defOf(schema)
     const out = schemaAt(def, 'out')!
     expect(isTransform(out)).toBe(true)
   })
@@ -108,13 +149,13 @@ describe('isTransform', () => {
 describe('enumValues', () => {
   test('reads a Zod v4 enum (entries object)', () => {
     const schema = z.enum(['a', 'b'])
-    const def = (schema as never as { _def: Record<string, unknown> })._def
+    const def = defOf(schema)
     expect(enumValues(def)).toEqual(['a', 'b'])
   })
 
   test('reads a Zod v3 enum (values array)', () => {
     const schema = z3.enum(['a', 'b'])
-    const def = (schema as never as { _def: Record<string, unknown> })._def
+    const def = defOf(schema)
     expect(enumValues(def)).toEqual(['a', 'b'])
   })
 })
@@ -122,13 +163,13 @@ describe('enumValues', () => {
 describe('literalValues', () => {
   test('reads a Zod v3 single literal value', () => {
     const schema = z3.literal('a')
-    const def = (schema as never as { _def: Record<string, unknown> })._def
+    const def = defOf(schema)
     expect(literalValues(def)).toEqual(['a'])
   })
 
   test('reads Zod v4 literal values', () => {
     const schema = z.literal('a')
-    const def = (schema as never as { _def: Record<string, unknown> })._def
+    const def = defOf(schema)
     expect(literalValues(def)).toEqual(['a'])
   })
 })

--- a/packages/core/src/internal/zod-compat.test.ts
+++ b/packages/core/src/internal/zod-compat.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from 'bun:test'
+import { z } from 'zod'
+import * as z3 from 'zod/v3'
+import {
+  arrayElement,
+  enumValues,
+  getTypeName,
+  isTransform,
+  literalValues,
+  normalizeTypeName,
+  objectShape,
+  pipeSide,
+  schemaAt,
+  typeOf,
+} from './zod-compat'
+
+describe('typeOf', () => {
+  test('normalizes a Zod v4 type name', () => {
+    expect(typeOf(z.string() as never)).toBe('string')
+  })
+
+  test('normalizes a Zod v3 type name', () => {
+    expect(typeOf(z3.string() as never)).toBe('string')
+  })
+
+  test('returns "unknown" for a node with no readable type name', () => {
+    expect(typeOf({} as never)).toBe('unknown')
+  })
+})
+
+describe('normalizeTypeName', () => {
+  test('strips the "Zod" prefix and lowercases', () => {
+    expect(normalizeTypeName('ZodString')).toBe('string')
+  })
+
+  test('lowercases a v4 bare type name', () => {
+    expect(normalizeTypeName('string')).toBe('string')
+  })
+
+  test('returns "unknown" for undefined', () => {
+    expect(normalizeTypeName(undefined)).toBe('unknown')
+  })
+})
+
+describe('arrayElement', () => {
+  test('reads the element off a Zod v4 array (regression: _def.element before _def.type)', () => {
+    const arraySchema = z.array(z.string())
+    const def = (arraySchema as never as { _def: Record<string, unknown> })._def
+    const element = arrayElement(def)
+    expect(element).toBeDefined()
+    expect(getTypeName(element!)).toBeDefined()
+  })
+
+  test('reads the element off a Zod v3 array', () => {
+    const arraySchema = z3.array(z3.number())
+    const def = (arraySchema as never as { _def: Record<string, unknown> })._def
+    const element = arrayElement(def)
+    expect(element).toBeDefined()
+    expect(typeOf(element!)).toBe('number')
+  })
+})
+
+describe('objectShape', () => {
+  test('reads a Zod v4 object shape', () => {
+    const schema = z.object({ name: z.string() })
+    const shape = objectShape(schema as never)
+    expect(shape && Object.keys(shape)).toEqual(['name'])
+  })
+
+  test('reads a Zod v3 object shape (shape is a function)', () => {
+    const schema = z3.object({ name: z3.string() })
+    const shape = objectShape(schema as never)
+    expect(shape && Object.keys(shape)).toEqual(['name'])
+  })
+})
+
+describe('pipeSide', () => {
+  test('reads the coerced-from side for input, the parsed side for output', () => {
+    const schema = z.string().pipe(z.coerce.number())
+    const def = (schema as never as { _def: Record<string, unknown> })._def
+    expect(typeOf(pipeSide(def, 'input')!)).toBe('string')
+    expect(typeOf(pipeSide(def, 'output')!)).toBe('number')
+  })
+
+  test('falls back to the input side when the output side is a transform', () => {
+    const schema = z.string().transform((value) => value.length)
+    const def = (schema as never as { _def: Record<string, unknown> })._def
+    expect(typeOf(pipeSide(def, 'output')!)).toBe('string')
+  })
+})
+
+describe('isTransform', () => {
+  test('identifies a transform node', () => {
+    const schema = z.string().transform((value) => value.length)
+    const def = (schema as never as { _def: Record<string, unknown> })._def
+    const out = schemaAt(def, 'out')!
+    expect(isTransform(out)).toBe(true)
+  })
+
+  test('a plain schema is not a transform', () => {
+    expect(isTransform(z.string() as never)).toBe(false)
+  })
+})
+
+describe('enumValues', () => {
+  test('reads a Zod v4 enum (entries object)', () => {
+    const schema = z.enum(['a', 'b'])
+    const def = (schema as never as { _def: Record<string, unknown> })._def
+    expect(enumValues(def)).toEqual(['a', 'b'])
+  })
+
+  test('reads a Zod v3 enum (values array)', () => {
+    const schema = z3.enum(['a', 'b'])
+    const def = (schema as never as { _def: Record<string, unknown> })._def
+    expect(enumValues(def)).toEqual(['a', 'b'])
+  })
+})
+
+describe('literalValues', () => {
+  test('reads a Zod v3 single literal value', () => {
+    const schema = z3.literal('a')
+    const def = (schema as never as { _def: Record<string, unknown> })._def
+    expect(literalValues(def)).toEqual(['a'])
+  })
+
+  test('reads Zod v4 literal values', () => {
+    const schema = z.literal('a')
+    const def = (schema as never as { _def: Record<string, unknown> })._def
+    expect(literalValues(def)).toEqual(['a'])
+  })
+})

--- a/packages/core/src/internal/zod-compat.test.ts
+++ b/packages/core/src/internal/zod-compat.test.ts
@@ -4,7 +4,6 @@ import * as z3 from 'zod/v3'
 import {
   arrayElement,
   enumValues,
-  getTypeName,
   isTransform,
   literalValues,
   normalizeTypeName,
@@ -43,12 +42,16 @@ describe('normalizeTypeName', () => {
 })
 
 describe('arrayElement', () => {
-  test('reads the element off a Zod v4 array (regression: _def.element before _def.type)', () => {
+  // v4 puts the string 'array' in `_def.type` alongside the real element in
+  // `_def.element`. Taking `_def.type` yields that string, which every caller
+  // then renders as an empty/unknown element — the bug fixed once per package.
+  test('reads the element off a Zod v4 array, not the type-name string in _def.type', () => {
     const arraySchema = z.array(z.string())
     const def = (arraySchema as never as { _def: Record<string, unknown> })._def
+    expect(def.type).toBe('array')
     const element = arrayElement(def)
     expect(element).toBeDefined()
-    expect(getTypeName(element!)).toBeDefined()
+    expect(typeOf(element!)).toBe('string')
   })
 
   test('reads the element off a Zod v3 array', () => {

--- a/packages/core/src/internal/zod-compat.ts
+++ b/packages/core/src/internal/zod-compat.ts
@@ -1,6 +1,6 @@
 /**
- * Zod v3/v4 compatibility primitives shared by the CLI's TypeScript-type
- * renderer (`@guren/cli/schema-type-extractor`) and the OpenAPI schema-object
+ * Zod v3/v4 compatibility primitives shared by `@guren/cli`'s TypeScript-type
+ * renderer (`src/schema-type-extractor.ts`) and the OpenAPI schema-object
  * renderer (`@guren/openapi`).
  *
  * Internal by the rules in `contributing/api-stability.md`: reachable only
@@ -9,16 +9,20 @@
  *
  * Zod v3 tags every node with `_def.typeName` (`"ZodString"`); v4 uses
  * `_def.type` (`"string"`) or a top-level `.type`. Everything here exists to
- * read a node's shape without caring which major produced it. What does NOT
- * belong here: the two type switches that turn a node into an output
- * (a TypeScript type string vs. an OpenAPI schema object) — those produce
- * genuinely different results and stay in their own packages. `isOptional`
- * also stays out: the CLI reads only the rendered side of a `.pipe()` (input
- * or output, matching what `zodToType` returns for that side), while the
- * OpenAPI walker requires *both* sides to allow omission, since a pipeline
- * runs both stages against a real request. That is a real behavioral
- * difference, not incidental drift — merging it would change one of the two
- * outputs.
+ * read a node's shape without caring which major produced it.
+ *
+ * What does NOT belong here: the two type switches that turn a node into an
+ * output (a TypeScript type string vs. an OpenAPI schema object). Their leaf
+ * vocabularies have legitimately diverged — the CLI renders `void`/`any`/
+ * `never`, which OpenAPI has no way to express — and that is a rendering
+ * decision, not version knowledge.
+ *
+ * Neither walker's `isOptional` belongs here either, but for a weaker reason
+ * than "they are both right": the CLI reads only the side of a `.pipe()` it
+ * renders, the OpenAPI walker requires both sides to permit omission, and
+ * *both* are approximations that a sufficiently odd pipeline can fool. Fixing
+ * them properly means simulating a parse, which is well beyond reading a
+ * `_def`. They stay with their callers until someone does that.
  */
 
 export interface ZodSchemaLike {
@@ -82,14 +86,46 @@ export function innerSchema(def: Record<string, unknown>): ZodSchemaLike | undef
 
 /**
  * An array's element schema. v4 holds it in `_def.element` and puts the string
- * `'array'` in `_def.type`; v3 has no `element` and holds the schema in
- * `_def.type`. This is the read that broke twice, once per package, and it is
- * `schemaAt`'s object check rather than the key order that fixes it — the
- * order here is the redundant second guard, not the load-bearing one.
+ * `'array'` in `_def.type`; v3 has no `element` at all. `schemaAt`'s object
+ * check is what makes this safe — the key order is a redundant second guard.
  */
 export function arrayElement(def: Record<string, unknown>): ZodSchemaLike | undefined {
   return schemaAt(def, 'element', 'type')
 }
+
+/**
+ * Wrappers that neither add to a rendered type nor decide whether a field may
+ * be omitted — whatever they wrap answers both questions.
+ */
+export const TRANSPARENT_WRAPPERS: ReadonlySet<string> = new Set([
+  'catch', 'readonly', 'branded', 'lazy', 'effects',
+])
+
+/**
+ * Wrappers that pass their type through but *do* decide presence: each makes a
+ * field omissible, or (in `nonoptional`'s case) re-requires one.
+ */
+export const PRESENCE_WRAPPERS: ReadonlySet<string> = new Set([
+  'optional', 'default', 'prefault', 'nonoptional',
+])
+
+/**
+ * Every type name that carries exactly one nested schema and no shape of its
+ * own — the union of the two sets above plus the three that render specially
+ * (`nullable` becomes a union with null; a pipe holds one schema per side).
+ *
+ * This is the vocabulary, not a policy: callers partition it however their
+ * rendering needs (the CLI splits transparent from presence-deciding because
+ * it walks types and presence separately; the OpenAPI walker looks through all
+ * of them uniformly). What none of them may do is disagree about *membership*
+ * — a name known to one walker and not the other silently changes an output,
+ * which is why the list lives here rather than once per package.
+ */
+export const SINGLE_CHILD_WRAPPERS: ReadonlySet<string> = new Set([
+  ...TRANSPARENT_WRAPPERS,
+  ...PRESENCE_WRAPPERS,
+  'nullable', 'pipe', 'pipeline',
+])
 
 /**
  * Whether this node is a `.transform()`'s output half — a wrapped function
@@ -101,18 +137,26 @@ export function isTransform(schema: ZodSchemaLike): boolean {
 }
 
 /**
- * Which side of a `.pipe()`/`.pipeline()` to read for a given `io` direction.
+ * Both halves of a `.pipe()`/`.pipeline()`.
  *
  * v3 names this node `ZodPipeline`; v4 uses one `pipe` for both `.pipe()` and
  * `.transform()`. `_def.in` is what a caller sends, `_def.out` what a
  * controller receives — except for a transform, whose out side is the
- * transform function itself, leaving the in side as the best available
- * answer.
+ * transform function itself and so has no type to read. `to` is therefore
+ * absent for a transform, leaving `from` as the only readable answer.
  */
-export function pipeSide(def: Record<string, unknown>, io: SchemaIo): ZodSchemaLike | undefined {
+export function pipeSides(def: Record<string, unknown>): {
+  from: ZodSchemaLike | undefined
+  to: ZodSchemaLike | undefined
+} {
   const to = schemaAt(def, 'out')
-  if (io === 'output' && to && !isTransform(to)) return to
-  return schemaAt(def, 'in')
+  return { from: schemaAt(def, 'in'), to: to && !isTransform(to) ? to : undefined }
+}
+
+/** The one side of a `.pipe()` that describes the `io` direction being rendered. */
+export function pipeSide(def: Record<string, unknown>, io: SchemaIo): ZodSchemaLike | undefined {
+  const { from, to } = pipeSides(def)
+  return io === 'output' && to ? to : from
 }
 
 /** v3: `_def.shape()` is a function. v4: `_def.shape` (or the schema's own `.shape`) is a plain object. */

--- a/packages/core/src/internal/zod-compat.ts
+++ b/packages/core/src/internal/zod-compat.ts
@@ -135,6 +135,5 @@ export function enumValues(def: Record<string, unknown>): string[] {
 /** v3: `_def.value` holds a literal's single value. v4: `_def.values` is an array (Zod 4 literals can hold more than one). */
 export function literalValues(def: Record<string, unknown>): unknown[] {
   if ('value' in def) return [def.value]
-  const values = def.values as unknown[] | undefined
-  return values ?? []
+  return Array.isArray(def.values) ? def.values : []
 }

--- a/packages/core/src/internal/zod-compat.ts
+++ b/packages/core/src/internal/zod-compat.ts
@@ -1,0 +1,140 @@
+/**
+ * Zod v3/v4 compatibility primitives shared by the CLI's TypeScript-type
+ * renderer (`@guren/cli/schema-type-extractor`) and the OpenAPI schema-object
+ * renderer (`@guren/openapi`).
+ *
+ * Internal by the rules in `contributing/api-stability.md`: reachable only
+ * through a deep import under `internal/`, never re-exported from
+ * `@guren/core`'s index.
+ *
+ * Zod v3 tags every node with `_def.typeName` (`"ZodString"`); v4 uses
+ * `_def.type` (`"string"`) or a top-level `.type`. Everything here exists to
+ * read a node's shape without caring which major produced it. What does NOT
+ * belong here: the two type switches that turn a node into an output
+ * (a TypeScript type string vs. an OpenAPI schema object) — those produce
+ * genuinely different results and stay in their own packages. `isOptional`
+ * also stays out: the CLI reads only the rendered side of a `.pipe()` (input
+ * or output, matching what `zodToType` returns for that side), while the
+ * OpenAPI walker requires *both* sides to allow omission, since a pipeline
+ * runs both stages against a real request. That is a real behavioral
+ * difference, not incidental drift — merging it would change one of the two
+ * outputs.
+ */
+
+export interface ZodSchemaLike {
+  _def?: Record<string, unknown>
+  type?: string
+  shape?: Record<string, ZodSchemaLike>
+}
+
+/**
+ * Which side of a schema is being read.
+ *
+ * - `output` — the parsed value, i.e. what a controller receives after
+ *   validation, or what a response body looks like.
+ * - `input` — the value a client has to send over the wire. Coercing and
+ *   piped schemas can differ here from their output side.
+ */
+export type SchemaIo = 'input' | 'output'
+
+/** v3: `_def.typeName` (`"ZodString"`). v4: `_def.type` (`"string"`) or `.type`. */
+export function getTypeName(schema: ZodSchemaLike): string | undefined {
+  return (schema._def?.typeName as string | undefined)
+    ?? (schema._def?.type as string | undefined)
+    ?? schema.type
+}
+
+/** Normalize v3's `"ZodString"` and v4's `"string"` to one lowercase name. */
+export function normalizeTypeName(typeName: string | undefined): string {
+  if (!typeName) return 'unknown'
+  return typeName.startsWith('Zod') ? typeName.slice(3).toLowerCase() : typeName.toLowerCase()
+}
+
+/** `getTypeName` + `normalizeTypeName` combined, the pair almost every call site wants. */
+export function typeOf(schema: ZodSchemaLike): string {
+  return normalizeTypeName(getTypeName(schema))
+}
+
+/**
+ * The first of `keys` that actually holds a nested schema object.
+ *
+ * `_def.type` is the one key whose meaning differs between the majors: v3
+ * stores a schema there (an array's element, a `.brand()`'s inner type), v4
+ * the type *name* instead. So a key only counts once it is known to be an
+ * object — reading it by precedence alone is what let a v4 array document
+ * its element as `{}` (or a TypeScript type collapse to `unknown[]`), the
+ * same bug fixed independently in both callers before this module existed.
+ */
+export function schemaAt(def: Record<string, unknown>, ...keys: string[]): ZodSchemaLike | undefined {
+  for (const key of keys) {
+    const candidate = def[key]
+    if (candidate && typeof candidate === 'object') {
+      return candidate as ZodSchemaLike
+    }
+  }
+  return undefined
+}
+
+/** The schema wrapped by a transparent single-child wrapper (`.readonly()`, `.brand()`, `.lazy()`, v3's `.transform()`/`.refine()`, etc). */
+export function innerSchema(def: Record<string, unknown>): ZodSchemaLike | undefined {
+  return schemaAt(def, 'innerType', 'schema', 'type')
+}
+
+/**
+ * An array's element schema. v4 holds it in `_def.element` and puts the string
+ * `'array'` in `_def.type`; v3 has no `element` and holds the schema in
+ * `_def.type`. This is the read that broke twice, once per package, and it is
+ * `schemaAt`'s object check rather than the key order that fixes it — the
+ * order here is the redundant second guard, not the load-bearing one.
+ */
+export function arrayElement(def: Record<string, unknown>): ZodSchemaLike | undefined {
+  return schemaAt(def, 'element', 'type')
+}
+
+/**
+ * Whether this node is a `.transform()`'s output half — a wrapped function
+ * with no type to read, as opposed to a schema that genuinely parses to
+ * `unknown`.
+ */
+export function isTransform(schema: ZodSchemaLike): boolean {
+  return typeOf(schema) === 'transform'
+}
+
+/**
+ * Which side of a `.pipe()`/`.pipeline()` to read for a given `io` direction.
+ *
+ * v3 names this node `ZodPipeline`; v4 uses one `pipe` for both `.pipe()` and
+ * `.transform()`. `_def.in` is what a caller sends, `_def.out` what a
+ * controller receives — except for a transform, whose out side is the
+ * transform function itself, leaving the in side as the best available
+ * answer.
+ */
+export function pipeSide(def: Record<string, unknown>, io: SchemaIo): ZodSchemaLike | undefined {
+  const to = schemaAt(def, 'out')
+  if (io === 'output' && to && !isTransform(to)) return to
+  return schemaAt(def, 'in')
+}
+
+/** v3: `_def.shape()` is a function. v4: `_def.shape` (or the schema's own `.shape`) is a plain object. */
+export function objectShape(schema: ZodSchemaLike): Record<string, ZodSchemaLike> | undefined {
+  const def = schema._def ?? {}
+  if (typeof def.shape === 'function') {
+    return (def.shape as () => Record<string, ZodSchemaLike>)()
+  }
+  return (def.shape ?? schema.shape) as Record<string, ZodSchemaLike> | undefined
+}
+
+/** v3: `_def.values` is an array of raw values. v4 enums: `_def.entries` is a `{ key: value }` object instead. */
+export function enumValues(def: Record<string, unknown>): string[] {
+  const values = def.values as string[] | undefined
+  if (values) return values
+  const entries = def.entries as Record<string, string> | undefined
+  return entries ? Object.values(entries) : []
+}
+
+/** v3: `_def.value` holds a literal's single value. v4: `_def.values` is an array (Zod 4 literals can hold more than one). */
+export function literalValues(def: Record<string, unknown>): unknown[] {
+  if ('value' in def) return [def.value]
+  const values = def.values as unknown[] | undefined
+  return values ?? []
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     'src/lambda.ts',
     'src/redis.ts',
     'src/internal/deploy-build.ts',
+    'src/internal/zod-compat.ts',
   ],
   format: ['esm'],
   dts: true,

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -1,15 +1,25 @@
 import { access, mkdir, writeFile } from 'node:fs/promises'
 import { dirname, relative, resolve } from 'node:path'
 import type { Application, RouteDefinition } from '@guren/core'
+import {
+  arrayElement,
+  enumValues as sharedEnumValues,
+  getTypeName,
+  isTransform,
+  literalValues,
+  objectShape,
+  pipeSide,
+  schemaAt,
+  type SchemaIo,
+  typeOf,
+  type ZodSchemaLike,
+} from '@guren/core/internal/zod-compat'
 
 type WriterOptions = {
   force?: boolean
 }
 
-type ZodLike = {
-  _def?: Record<string, unknown>
-  type?: string
-  shape?: Record<string, ZodLike>
+type ZodLike = ZodSchemaLike & {
   safeParse?: (data: unknown) => { success: boolean }
 }
 
@@ -204,19 +214,6 @@ type ObjectSchemaDetails = {
   required: Set<string>
 }
 
-/**
- * Which side of a schema a document is describing.
- *
- * - `input` — what a caller has to send: request bodies and parameters.
- * - `output` — what a caller receives: response bodies.
- *
- * Most schemas render identically both ways, since OpenAPI describes JSON in
- * either direction. Pipes and defaults do not: a pipe holds a separate type per
- * side, and a defaulted field may be omitted from a request but is always
- * present in a response.
- */
-type SchemaIo = 'input' | 'output'
-
 function isApplicationLike(target: Application | HonoLike): target is Application & { hono: HonoLike; router: { definitions(): RouteDefinition[] } } {
   return typeof target === 'object'
     && target !== null
@@ -359,7 +356,7 @@ function readObjectSchemaDetails(schema: ZodLike, warnings: string[], label: str
     return nested ? readObjectSchemaDetails(nested, warnings, label, io) : undefined
   }
 
-  const shape = getObjectShape(schema)
+  const shape = objectShape(schema)
   if (!shape) {
     warnings.push(`${label}: object schema shape could not be read.`)
     return undefined
@@ -426,8 +423,7 @@ function toOpenApiSchema(schema: unknown, warnings: string[], label: string, io:
     case 'literal':
       return literalSchema(def)
     case 'array': {
-      // v4 holds the element in `_def.element`, v3 in `_def.type`.
-      const item = schemaAt(def, 'element', 'type')
+      const item = arrayElement(def)
       return { type: 'array', items: toOpenApiSchema(item, warnings, `${label}[]`, io) ?? {} }
     }
     case 'object': {
@@ -471,7 +467,7 @@ function toOpenApiSchema(schema: unknown, warnings: string[], label: string, io:
       }
     }
     case 'enum': {
-      const values = enumValues(def)
+      const values = sharedEnumValues(def)
       return values.length > 0 ? { type: 'string', enum: values } : { type: 'string' }
     }
     case 'nativeenum': {
@@ -588,42 +584,6 @@ function isZodSchema(schema: unknown): schema is ZodLike {
   return Boolean(getTypeName(schema as ZodLike))
 }
 
-function getTypeName(schema: ZodLike): string | undefined {
-  return (schema._def?.typeName as string | undefined)
-    ?? (schema._def?.type as string | undefined)
-    ?? schema.type
-}
-
-function normalizeTypeName(typeName: string | undefined): string {
-  if (!typeName) {
-    return 'unknown'
-  }
-
-  return typeName.startsWith('Zod') ? typeName.slice(3).toLowerCase() : typeName.toLowerCase()
-}
-
-function typeOf(schema: ZodLike): string {
-  return normalizeTypeName(getTypeName(schema))
-}
-
-/**
- * The first of `keys` that actually holds a schema. `_def.type` is the one key
- * whose meaning differs between the majors — v3 stores a schema there (an
- * array's element, a `.brand()`'s inner type), v4 the type *name* — so a key
- * can only be taken once it is known to be an object. Reading it by
- * precedence alone is what let a v4 array document its element as `{}`.
- */
-function schemaAt(def: Record<string, unknown>, ...keys: string[]): ZodLike | undefined {
-  for (const key of keys) {
-    const candidate = def[key]
-    if (candidate && typeof candidate === 'object') {
-      return candidate as ZodLike
-    }
-  }
-
-  return undefined
-}
-
 /**
  * Type names that carry exactly one nested schema and no shape of their own.
  *
@@ -651,8 +611,7 @@ function unwrap(schema: ZodLike, io: SchemaIo): ZodLike | undefined {
   const typeName = typeOf(schema)
 
   if (typeName === 'pipe' || typeName === 'pipeline') {
-    const to = schemaAt(def, 'out')
-    return io === 'output' && to && typeOf(to) !== 'transform' ? to : schemaAt(def, 'in')
+    return pipeSide(def, io)
   }
 
   if (!WRAPPER_TYPES.has(typeName)) {
@@ -660,15 +619,6 @@ function unwrap(schema: ZodLike, io: SchemaIo): ZodLike | undefined {
   }
 
   return schemaAt(def, 'innerType', 'schema', 'type')
-}
-
-function getObjectShape(schema: ZodLike): Record<string, ZodLike> | undefined {
-  const def = schema._def ?? {}
-  if (typeof def.shape === 'function') {
-    return (def.shape as () => Record<string, ZodLike>)()
-  }
-
-  return (def.shape ?? schema.shape) as Record<string, ZodLike> | undefined
 }
 
 function isOptional(schema: ZodLike, io: SchemaIo): boolean {
@@ -700,7 +650,7 @@ function isOptional(schema: ZodLike, io: SchemaIo): boolean {
       if (!from) {
         return false
       }
-      return to && typeOf(to) !== 'transform'
+      return to && !isTransform(to)
         ? isOptional(from, io) && isOptional(to, io)
         : isOptional(from, io)
     }
@@ -711,18 +661,10 @@ function isOptional(schema: ZodLike, io: SchemaIo): boolean {
   }
 }
 
-function enumValues(def: Record<string, unknown>): string[] {
-  const values = def.values as string[] | undefined
-  if (values) {
-    return values
-  }
-
-  const entries = def.entries as Record<string, string> | undefined
-  return entries ? Object.values(entries) : []
-}
-
 function literalSchema(def: Record<string, unknown>): OpenApiSchemaObject {
-  const value = 'value' in def ? def.value : Array.isArray(def.values) ? def.values[0] : undefined
+  // v4 literals can hold more than one value; only the first is documented
+  // here (unlike the CLI's type renderer, which unions all of them).
+  const value = literalValues(def)[0]
 
   if (typeof value === 'string') {
     return { type: 'string', const: value }

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -3,14 +3,16 @@ import { dirname, relative, resolve } from 'node:path'
 import type { Application, RouteDefinition } from '@guren/core'
 import {
   arrayElement,
-  enumValues as sharedEnumValues,
+  enumValues,
   getTypeName,
-  isTransform,
+  innerSchema,
   literalValues,
   objectShape,
   pipeSide,
+  pipeSides,
   schemaAt,
   type SchemaIo,
+  SINGLE_CHILD_WRAPPERS,
   typeOf,
   type ZodSchemaLike,
 } from '@guren/core/internal/zod-compat'
@@ -392,7 +394,7 @@ function toOpenApiSchema(schema: unknown, warnings: string[], label: string, io:
   // Wrappers add nothing to the rendered type, so they are looked through
   // uniformly. `nullable` is the exception — it renders as a union with null —
   // and so keeps its own case below.
-  if (typeName !== 'nullable' && WRAPPER_TYPES.has(typeName)) {
+  if (typeName !== 'nullable' && SINGLE_CHILD_WRAPPERS.has(typeName)) {
     const nested = unwrap(schema, io)
     if (!nested) {
       // Reaching a wrapper whose contents cannot be read drops the property,
@@ -467,7 +469,7 @@ function toOpenApiSchema(schema: unknown, warnings: string[], label: string, io:
       }
     }
     case 'enum': {
-      const values = sharedEnumValues(def)
+      const values = enumValues(def)
       return values.length > 0 ? { type: 'string', enum: values } : { type: 'string' }
     }
     case 'nativeenum': {
@@ -488,7 +490,7 @@ function toOpenApiSchema(schema: unknown, warnings: string[], label: string, io:
       }
     }
     case 'promise': {
-      const nested = schemaAt(def, 'innerType', 'schema', 'type')
+      const nested = innerSchema(def)
       return nested ? toOpenApiSchema(nested, warnings, label, io) : undefined
     }
     default:
@@ -585,26 +587,14 @@ function isZodSchema(schema: unknown): schema is ZodLike {
 }
 
 /**
- * Type names that carry exactly one nested schema and no shape of their own.
- *
- * Three walks look through them for different reasons — finding the object
- * behind a parameter schema, rendering a type, deciding whether a property may
- * be omitted — so the set is stated once here. Each walk layers its own
- * handling on top (`nullable` renders as a union; `optional` and friends decide
- * presence), but none of them may disagree about what is a wrapper: a name
- * reaching one walk and not another silently changes the document.
- */
-const WRAPPER_TYPES = new Set([
-  'optional', 'default', 'prefault', 'nonoptional', 'catch', 'nullable',
-  'readonly', 'branded', 'lazy', 'effects', 'pipe', 'pipeline',
-])
-
-/**
- * The schema a wrapper wraps, in the direction being documented. A pipe (v3
- * names it `ZodPipeline`) holds one per side: `_def.in` is what a caller sends,
- * `_def.out` what a controller returns. A `.transform()`'s out side is the
- * transform function rather than a schema, so there is no parsed type to read
- * and the in side remains the best available answer.
+ * The schema a wrapper wraps, in the direction being documented. Three walks
+ * look through wrappers for different reasons — finding the object behind a
+ * parameter schema, rendering a type, deciding whether a property may be
+ * omitted — and each layers its own handling on top (`nullable` renders as a
+ * union; `optional` and friends decide presence). What none of them may do is
+ * disagree about which names *are* wrappers, which is why the membership comes
+ * from `SINGLE_CHILD_WRAPPERS` rather than a local list. See `pipeSides` for
+ * why a pipe resolves per direction.
  */
 function unwrap(schema: ZodLike, io: SchemaIo): ZodLike | undefined {
   const def = schema._def ?? {}
@@ -614,11 +604,7 @@ function unwrap(schema: ZodLike, io: SchemaIo): ZodLike | undefined {
     return pipeSide(def, io)
   }
 
-  if (!WRAPPER_TYPES.has(typeName)) {
-    return undefined
-  }
-
-  return schemaAt(def, 'innerType', 'schema', 'type')
+  return SINGLE_CHILD_WRAPPERS.has(typeName) ? innerSchema(def) : undefined
 }
 
 function isOptional(schema: ZodLike, io: SchemaIo): boolean {
@@ -641,18 +627,16 @@ function isOptional(schema: ZodLike, io: SchemaIo): boolean {
       return false
     // A pipeline runs both stages, so a field may be omitted only if neither
     // stage rejects a missing value. Reading just the side being rendered
-    // would document an omission the other stage refuses.
+    // would document an omission the other stage refuses. Still an
+    // approximation in the other direction: a transforming stage can supply a
+    // value the next stage accepts, which this reports as required.
     case 'pipe':
     case 'pipeline': {
-      const def = schema._def ?? {}
-      const from = schemaAt(def, 'in')
-      const to = schemaAt(def, 'out')
+      const { from, to } = pipeSides(schema._def ?? {})
       if (!from) {
         return false
       }
-      return to && !isTransform(to)
-        ? isOptional(from, io) && isOptional(to, io)
-        : isOptional(from, io)
+      return to ? isOptional(from, io) && isOptional(to, io) : isOptional(from, io)
     }
     default: {
       const nested = unwrap(schema, io)

--- a/packages/openapi/tests/openapi.test.ts
+++ b/packages/openapi/tests/openapi.test.ts
@@ -228,6 +228,23 @@ describe('@guren/openapi', () => {
       expect(responseDocument(schema()).schema?.required).toEqual(['body'])
     })
 
+    // `nullable` is the one single-child wrapper the type walk must NOT look
+    // through: it renders as a union with null rather than passing its inner
+    // schema out unchanged. It shares a membership list with the wrappers that
+    // are looked through, so the exception has to be asserted separately —
+    // otherwise dropping it just silently emits the unwrapped schema.
+    it('renders a nullable property as a union with null rather than unwrapping it', () => {
+      for (const schema of [
+        z.object({ a: z.string().nullable() }),
+        z3.object({ a: z3.string().nullable() }),
+      ]) {
+        const { schema: document, warnings } = bodyDocument(schema)
+
+        expect(document?.properties?.a).toEqual({ anyOf: [{ type: 'string' }, { type: 'null' }] })
+        expect(warnings).toEqual([])
+      }
+    })
+
     // The type and the presence of a property are read by separate walks over
     // separate wrapper lists, so a wrapper added to one and not the other
     // quietly makes an optional property required.


### PR DESCRIPTION
## Summary

`@guren/cli`'s TypeScript-type renderer (`schema-type-extractor.ts`) and `@guren/openapi`'s schema-object renderer each carried their own copy of the logic needed to read a Zod schema without caring which major produced it: type-name lookup, wrapper unwrapping, pipe-side selection, object-shape reading, enum/literal extraction. Knowledge added to one never reached the other — a Zod 4 array keeps its element in `_def.element` while `_def.type` holds the literal string `'array'`, and reading them in the wrong order silently drops the element type. That exact bug was found and fixed twice, months apart, once per package (9987e1f, faf358a).

Those primitives, plus the wrapper-vocabulary sets each walker partitions differently, now live in `packages/core/src/internal/zod-compat.ts`, exposed as `@guren/core/internal/zod-compat` — the same deep-import pattern as the existing `internal/deploy-build`. Both walkers import from it, so a version quirk learned once is known in both places. Verified by mutation: dropping `'catch'` from the shared wrapper set makes tests fail in **both** packages.

What stays split, and why:
- The two type switches (TypeScript type strings vs. OpenAPI schema objects) — their leaf vocabularies have legitimately diverged (the CLI renders `void`/`any`/`never`, which OpenAPI can't express).
- Both `isOptional` implementations — not because each is correct for its purpose, but because both are approximations that a sufficiently odd `.pipe()` can fool in different ways. Deciding it properly means simulating a parse, which is separate work. The changeset and code comments say this plainly rather than implying the difference is intentional-and-correct.

## Scope

- `core` (new internal module + package.json/tsup wiring)
- `cli` (schema-type-extractor.ts consumes the shared module)
- `openapi` (index.ts consumes the shared module)
- Test-only additions in both consumer packages

## Risk Assessment

No public API changes — everything moved is either newly-internal or already-internal to its package. Two incidental behavior fixes, both toward correctness:
- An empty `z.enum([])` now renders as `never` instead of an empty string (which was not valid TypeScript wherever it was spliced in).
- `z.literal(undefined)` now renders as `undefined` instead of being silently dropped by `JSON.stringify`.

One test gap found and closed along the way (not introduced by this PR, but this PR is what makes it visible): OpenAPI's `nullable` rendering — the one wrapper type that must NOT be unwrapped like the others — had no test asserting it actually renders as `anyOf: [..., {type: 'null'}]`. Deleting the guard left all tests green. Added a mutation-verified test for it.

The `@guren/openapi` → `@guren/core` dependency range (`^1.0.0`) was checked against a real `changeset version` dry run rather than hand-bumped: `updateInternalDependencies: "patch"` correctly rewrites it to `^1.5.0` alongside the core version bump, since it's a `dependencies` entry (not a peerDep). No manual manifest edit needed or made.

## Validation

- `bun run build:clean` — clean
- `bun run typecheck` — clean (root + examples/blog + examples/api)
- `bun run test:bun` — 3377 pass, 55 skip, 0 fail
- `bun run test:examples` — 240 pass across blog/api/web
- `bun run audit:core-first` — passed
- `bun run audit:docs` — passed
- Mutation-tested the two most load-bearing invariants directly: reversing `arrayElement`'s key order does *not* reproduce the historical bug (the object-type guard in `schemaAt` is what actually prevents it, not key order — comments corrected accordingly); removing `'catch'` from the shared wrapper set fails tests in both consumer packages, confirming the shared module is actually load-bearing for both.
- Reviewed with a Codex pass plus a 4-agent simplify pass (reuse/simplification/efficiency/altitude); findings were verified against real Zod internals before applying — see commit messages for what was fixed and what was knowingly left as pre-existing/out-of-scope (e.g. two pre-existing `isOptional` approximation bugs, unrelated to this extraction).

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation (changeset).