### PR TITLE
fix(cli): detect plural-named factories in doctor --next

### DIFF
--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -11,6 +11,7 @@ import {
   classNameFromPath,
   toPosixRelative,
   listModuleNames,
+  moduleFlagFor,
   moduleNameFor,
   formatTruncatedList,
 } from './discovery'
@@ -163,9 +164,8 @@ export async function runCheck(options: RunCheckOptions = {}): Promise<CheckRepo
     // 4. Check missing test files for controllers
     for (const filePath of controllerFiles) {
       const name = classNameFromPath(filePath)
-      const moduleName = moduleNameFor(cwd, filePath)
       const hasTest = await hasControllerTest(cwd, filePath)
-      const moduleFlag = moduleName ? ` --module ${moduleName}` : ''
+      const moduleFlag = moduleFlagFor(cwd, filePath)
       const message = hasTest
         ? `Test file found for ${name}.`
         : describeControllerTestMiss(cwd, filePath)

--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -137,9 +137,12 @@ export async function listModuleNames(appRoot: string): Promise<string[]> {
  * the `discover*Files` functions below, `scanDocs`, and the entity
  * context's db-artifact scans.
  */
-export async function listAppRoots(
-  appRoot: string,
-): Promise<Array<{ module: string | null; dir: string }>> {
+export interface AppRoot {
+  module: string | null
+  dir: string
+}
+
+export async function listAppRoots(appRoot: string): Promise<AppRoot[]> {
   const names = await listModuleNames(appRoot)
   return [
     { module: null, dir: appRoot },
@@ -156,10 +159,13 @@ export async function listAppRoots(
  * Test files are excluded: components are frequently tested by a co-located
  * `<Name>.test.ts` sibling, and those files are tests, not components of the
  * kind each `discover*Files` function reports.
+ *
+ * `roots` overrides the fan-out for callers that have already narrowed it to
+ * one app root.
  */
-async function discoverDir(appRoot: string, subDir: string): Promise<string[]> {
-  const roots = await listAppRoots(appRoot)
-  const groups = await Promise.all(roots.map((root) => collectFiles(resolve(root.dir, subDir))))
+async function discoverDir(appRoot: string, subDir: string, roots?: AppRoot[]): Promise<string[]> {
+  const scanned = roots ?? (await listAppRoots(appRoot))
+  const groups = await Promise.all(scanned.map((root) => collectFiles(resolve(root.dir, subDir))))
   return groups.flat().filter((file) => !TEST_FILE_PATTERN.test(file))
 }
 
@@ -327,6 +333,34 @@ export type DbArtifactKind = keyof typeof DB_ARTIFACT_DIRS
 export function dbArtifactPattern(entity: string, kind: DbArtifactKind): RegExp {
   const forms = [...new Set([entity, `${entity}s`, collectionName(entity)])]
   return new RegExp(`(?:^|_)(?:${forms.map(escapeRegExp).join('|')})${kind}\\.`, 'i')
+}
+
+/**
+ * Every factory (or seeder) file in the project, from the app root and each
+ * module — the listing half of "which artifacts belong to this entity?",
+ * with {@link dbArtifactPattern} as the matching half. Shared so that
+ * `guren context <Entity>` and `guren doctor --next` cannot drift into
+ * disagreeing about whether an entity already has one.
+ *
+ * `roots` narrows the fan-out for a caller that has already picked one.
+ */
+export function discoverDbArtifactFiles(
+  appRoot: string,
+  kind: DbArtifactKind,
+  roots?: AppRoot[],
+): Promise<string[]> {
+  return discoverDir(appRoot, DB_ARTIFACT_DIRS[kind], roots)
+}
+
+/**
+ * The ` --module <name>` suffix a suggested `make:*` command needs so that it
+ * scaffolds beside `filePath` rather than at the project root — empty for a
+ * root-level file. One home for the leading space, which is load-bearing at
+ * every call site and invisible at all of them.
+ */
+export function moduleFlagFor(cwd: string, filePath: string): string {
+  const moduleName = moduleNameFor(cwd, filePath)
+  return moduleName ? ` --module ${moduleName}` : ''
 }
 
 /**

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -1,13 +1,17 @@
 import { copyFile, readFile, writeFile } from 'node:fs/promises'
-import { resolve, relative } from 'node:path'
+import { resolve, relative, basename } from 'node:path'
 import { consola } from 'consola'
 import {
+  collectFiles,
+  dbArtifactPattern,
+  DB_ARTIFACT_DIRS,
   discoverControllerFiles,
   discoverModelFiles,
   discoverTestFiles,
   fileExists,
   hasControllerTest,
   describeControllerTestMiss,
+  listAppRoots,
   readIfExists,
   classNameFromPath,
   toPosixRelative,
@@ -1385,25 +1389,30 @@ export async function suggestNextSteps(options: { cwd?: string } = {}): Promise<
 
   try {
     const modelFiles = await discoverModelFiles(cwd)
+    // Listed once for every model rather than probed per model: the factory
+    // file name is the user's choice (`make:factory` suffixes whatever they
+    // typed), so recognising it takes `dbArtifactPattern` over the directory's
+    // real contents — the same rule `guren context <Entity>` reports factories
+    // by. Probing exact singular paths here is what let doctor tell a user with
+    // `CategoriesFactory.ts` to scaffold a second one.
+    const roots = await listAppRoots(cwd)
+    const factoryGroups = await Promise.all(
+      roots.map((root) => collectFiles(resolve(root.dir, DB_ARTIFACT_DIRS.Factory))),
+    )
+    const factoryNames = factoryGroups.flat().map((file) => basename(file))
+
     for (const filePath of modelFiles) {
       const name = classNameFromPath(filePath)
-      const factoryCandidates = [
-        `database/factories/${name}Factory.ts`,
-        `db/factories/${name}Factory.ts`,
-      ]
-      let hasFactory = false
-      for (const candidate of factoryCandidates) {
-        if (await fileExists(cwd, candidate)) {
-          hasFactory = true
-          break
-        }
-      }
+      const factoryPattern = dbArtifactPattern(name, 'Factory')
+      const hasFactory = factoryNames.some((factoryName) => factoryPattern.test(factoryName))
       if (!hasFactory) {
+        const moduleName = moduleNameFromRelPath(toPosixRelative(cwd, filePath))
+        const moduleFlag = moduleName ? ` --module ${moduleName}` : ''
         steps.push({
           priority: priority++,
           title: `Add factory for ${name}`,
           description: 'No factory file found for testing and seeding.',
-          command: `bunx guren make:factory ${name}`,
+          command: `bunx guren make:factory ${name}${moduleFlag}`,
         })
       }
     }

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -2,20 +2,18 @@ import { copyFile, readFile, writeFile } from 'node:fs/promises'
 import { resolve, relative, basename } from 'node:path'
 import { consola } from 'consola'
 import {
-  collectFiles,
   dbArtifactPattern,
-  DB_ARTIFACT_DIRS,
   discoverControllerFiles,
+  discoverDbArtifactFiles,
   discoverModelFiles,
   discoverTestFiles,
   fileExists,
   hasControllerTest,
   describeControllerTestMiss,
-  listAppRoots,
+  moduleFlagFor,
+  moduleNameFor,
   readIfExists,
   classNameFromPath,
-  toPosixRelative,
-  moduleNameFromRelPath,
 } from './discovery'
 import { checkPluginCompatibility, readCoreVersion, readInstalledPluginManifests } from './plugin-manifest'
 import { compareVersions } from './codemods'
@@ -1370,8 +1368,7 @@ export async function suggestNextSteps(options: { cwd?: string } = {}): Promise<
     for (const filePath of controllerFiles) {
       const name = classNameFromPath(filePath)
       if (!(await hasControllerTest(cwd, filePath))) {
-        const moduleName = moduleNameFromRelPath(toPosixRelative(cwd, filePath))
-        const moduleFlag = moduleName ? ` --module ${moduleName}` : ''
+        const moduleFlag = moduleFlagFor(cwd, filePath)
         steps.push({
           priority: priority++,
           // Titled as a question, not an action: detection is by filename, so a
@@ -1389,30 +1386,29 @@ export async function suggestNextSteps(options: { cwd?: string } = {}): Promise<
 
   try {
     const modelFiles = await discoverModelFiles(cwd)
-    // Listed once for every model rather than probed per model: the factory
-    // file name is the user's choice (`make:factory` suffixes whatever they
-    // typed), so recognising it takes `dbArtifactPattern` over the directory's
-    // real contents — the same rule `guren context <Entity>` reports factories
-    // by. Probing exact singular paths here is what let doctor tell a user with
-    // `CategoriesFactory.ts` to scaffold a second one.
-    const roots = await listAppRoots(cwd)
-    const factoryGroups = await Promise.all(
-      roots.map((root) => collectFiles(resolve(root.dir, DB_ARTIFACT_DIRS.Factory))),
-    )
-    const factoryNames = factoryGroups.flat().map((file) => basename(file))
+    // Listed once up front rather than probed per model, and matched by
+    // `dbArtifactPattern` rather than by an exact path: `make:factory` appends
+    // its suffix to whatever the user typed, so probing `<Name>Factory.ts` is
+    // what let doctor tell a user who already had `CategoriesFactory.ts` to
+    // scaffold a second one. Grouped by app root because a module's models are
+    // paired with that module's factories — the same scoping `guren context
+    // <Entity>` applies.
+    const factoryNamesByModule = new Map<string | null, string[]>()
+    for (const file of await discoverDbArtifactFiles(cwd, 'Factory')) {
+      const key = moduleNameFor(cwd, file)
+      factoryNamesByModule.set(key, [...(factoryNamesByModule.get(key) ?? []), basename(file)])
+    }
 
     for (const filePath of modelFiles) {
       const name = classNameFromPath(filePath)
       const factoryPattern = dbArtifactPattern(name, 'Factory')
-      const hasFactory = factoryNames.some((factoryName) => factoryPattern.test(factoryName))
-      if (!hasFactory) {
-        const moduleName = moduleNameFromRelPath(toPosixRelative(cwd, filePath))
-        const moduleFlag = moduleName ? ` --module ${moduleName}` : ''
+      const factoryNames = factoryNamesByModule.get(moduleNameFor(cwd, filePath)) ?? []
+      if (!factoryNames.some((factoryName) => factoryPattern.test(factoryName))) {
         steps.push({
           priority: priority++,
           title: `Add factory for ${name}`,
           description: 'No factory file found for testing and seeding.',
-          command: `bunx guren make:factory ${name}${moduleFlag}`,
+          command: `bunx guren make:factory ${name}${moduleFlagFor(cwd, filePath)}`,
         })
       }
     }

--- a/packages/cli/src/entity-context.ts
+++ b/packages/cli/src/entity-context.ts
@@ -9,11 +9,10 @@ import {
   discoverTestFiles,
   listAppRoots,
   classNameFromPath,
-  collectFiles,
+  discoverDbArtifactFiles,
   toPosixRelative,
   moduleNameFromRelPath,
   dbArtifactPattern,
-  DB_ARTIFACT_DIRS,
   type DbArtifactKind,
 } from './discovery'
 import {
@@ -223,11 +222,7 @@ export async function generateEntityContext(
     if (duplicated) roots = roots.filter((root) => root.module === match.module)
 
     const filePattern = dbArtifactPattern(entity, kind)
-    const groups = await Promise.all(
-      roots.map((root) => collectFiles(resolve(root.dir, DB_ARTIFACT_DIRS[kind]))),
-    )
-    return groups
-      .flat()
+    return (await discoverDbArtifactFiles(cwd, kind, roots))
       .filter((file) => filePattern.test(basename(file)))
       .map((file) => toPosixRelative(cwd, file))
       .sort()

--- a/packages/cli/tests/check.test.ts
+++ b/packages/cli/tests/check.test.ts
@@ -1,8 +1,8 @@
 import { mkdir, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
 import { runCheck, type CheckReport, type RunCheckOptions } from '../src/check'
-import { createTempWorkspace, MYSQL_SCHEMA_FIXTURE, PG_SCHEMA_FIXTURE } from './helpers'
+import { createTempWorkspace, writeWorkspaceFiles, MYSQL_SCHEMA_FIXTURE, PG_SCHEMA_FIXTURE } from './helpers'
 
 /** Run a check over a throwaway workspace built from path → content. */
 async function withWorkspace(
@@ -11,10 +11,7 @@ async function withWorkspace(
 ): Promise<CheckReport> {
   const workspace = await createTempWorkspace('guren-cli-check-')
   try {
-    for (const [relPath, content] of Object.entries(files)) {
-      await mkdir(join(workspace.dir, dirname(relPath)), { recursive: true })
-      await writeFile(join(workspace.dir, relPath), content, 'utf8')
-    }
+    await writeWorkspaceFiles(workspace.dir, files)
     return await runCheck({ cwd: workspace.dir, ...options })
   } finally {
     await workspace.cleanup()

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -1,5 +1,5 @@
 import { mkdir, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
 import { consola } from 'consola'
 import { getDoctorRuleEvaluations, runDoctor, buildJsonOutput, suggestNextSteps, renderDoctorReport } from '../src/doctor'
@@ -1245,6 +1245,77 @@ describe('suggestNextSteps', () => {
     } finally {
       await workspace.cleanup()
     }
+  })
+
+  // `make:factory` appends its suffix to whatever the user typed, so the
+  // factory of a `Category` model is just as likely to be named
+  // `CategoriesFactory`. Doctor used to probe the singular path only and told
+  // the user to scaffold a duplicate of a factory `guren context Category`
+  // was already listing.
+  async function factoryWorkspaceSteps(
+    prefix: string,
+    files: Record<string, string>,
+  ): Promise<Awaited<ReturnType<typeof suggestNextSteps>>> {
+    const workspace = await createTempWorkspace(prefix)
+
+    try {
+      for (const [relPath, contents] of Object.entries(files)) {
+        await mkdir(join(workspace.dir, dirname(relPath)), { recursive: true })
+        await writeFile(join(workspace.dir, relPath), contents, 'utf8')
+      }
+
+      return await suggestNextSteps({ cwd: workspace.dir })
+    } finally {
+      await workspace.cleanup()
+    }
+  }
+
+  const MODEL_SOURCE = (name: string) => `export class ${name} {}\n`
+  const FACTORY_SOURCE = (name: string) => `export default class ${name} {}\n`
+
+  it('does not suggest a factory for a model whose factory is named in the plural', async () => {
+    const steps = await factoryWorkspaceSteps('guren-cli-doctor-factory-plural-', {
+      'app/Models/Category.ts': MODEL_SOURCE('Category'),
+      'db/factories/CategoriesFactory.ts': FACTORY_SOURCE('CategoriesFactory'),
+    })
+
+    expect(steps.some((step) => step.title === 'Add factory for Category')).toBe(false)
+  })
+
+  it('does not suggest a factory for a model whose factory is named in the singular', async () => {
+    const steps = await factoryWorkspaceSteps('guren-cli-doctor-factory-singular-', {
+      'app/Models/Post.ts': MODEL_SOURCE('Post'),
+      'db/factories/PostFactory.ts': FACTORY_SOURCE('PostFactory'),
+    })
+
+    expect(steps.some((step) => step.title === 'Add factory for Post')).toBe(false)
+  })
+
+  // Without this the check could be stuck-on-true and both suppression tests
+  // above would still pass.
+  it('suggests a factory for a model that has none', async () => {
+    const steps = await factoryWorkspaceSteps('guren-cli-doctor-factory-missing-', {
+      'app/Models/Category.ts': MODEL_SOURCE('Category'),
+      'db/factories/PostFactory.ts': FACTORY_SOURCE('PostFactory'),
+    })
+
+    const step = steps.find((s) => s.title === 'Add factory for Category')
+    expect(step).toBeDefined()
+    expect(step!.command).toBe('bunx guren make:factory Category')
+  })
+
+  it('matches a module model against its own module factories', async () => {
+    const steps = await factoryWorkspaceSteps('guren-cli-doctor-factory-module-', {
+      'modules/billing/app/Models/Invoice.ts': MODEL_SOURCE('Invoice'),
+      'modules/billing/db/factories/InvoicesFactory.ts': FACTORY_SOURCE('InvoicesFactory'),
+      'modules/billing/app/Models/Plan.ts': MODEL_SOURCE('Plan'),
+    })
+
+    expect(steps.some((step) => step.title === 'Add factory for Invoice')).toBe(false)
+
+    const planStep = steps.find((step) => step.title === 'Add factory for Plan')
+    expect(planStep).toBeDefined()
+    expect(planStep!.command).toBe('bunx guren make:factory Plan --module billing')
   })
 })
 

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -1,10 +1,10 @@
 import { mkdir, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
 import { consola } from 'consola'
 import { getDoctorRuleEvaluations, runDoctor, buildJsonOutput, suggestNextSteps, renderDoctorReport } from '../src/doctor'
 import type { DoctorCheck, DoctorJsonOutput } from '../src/doctor'
-import { createTempWorkspace, writeInstalledPackage } from './helpers'
+import { createTempWorkspace, writeInstalledPackage, writeWorkspaceFiles } from './helpers'
 
 let consoleLogSpy: ReturnType<typeof spyOn>
 const VALID_APP_KEY = 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
@@ -1247,45 +1247,38 @@ describe('suggestNextSteps', () => {
     }
   })
 
-  // `make:factory` appends its suffix to whatever the user typed, so the
-  // factory of a `Category` model is just as likely to be named
-  // `CategoriesFactory`. Doctor used to probe the singular path only and told
-  // the user to scaffold a duplicate of a factory `guren context Category`
-  // was already listing.
-  async function factoryWorkspaceSteps(
-    prefix: string,
+  /** Run `suggestNextSteps` over a throwaway workspace built from path → content. */
+  async function stepsFor(
     files: Record<string, string>,
   ): Promise<Awaited<ReturnType<typeof suggestNextSteps>>> {
-    const workspace = await createTempWorkspace(prefix)
+    const workspace = await createTempWorkspace('guren-cli-doctor-factory-')
 
     try {
-      for (const [relPath, contents] of Object.entries(files)) {
-        await mkdir(join(workspace.dir, dirname(relPath)), { recursive: true })
-        await writeFile(join(workspace.dir, relPath), contents, 'utf8')
-      }
-
+      await writeWorkspaceFiles(workspace.dir, files)
       return await suggestNextSteps({ cwd: workspace.dir })
     } finally {
       await workspace.cleanup()
     }
   }
 
-  const MODEL_SOURCE = (name: string) => `export class ${name} {}\n`
-  const FACTORY_SOURCE = (name: string) => `export default class ${name} {}\n`
+  // Neither file's contents reach an assertion — models are discovered by
+  // path and factories are matched by basename — so one fixture body serves
+  // both.
+  const SOURCE = 'export default class Fixture {}\n'
 
   it('does not suggest a factory for a model whose factory is named in the plural', async () => {
-    const steps = await factoryWorkspaceSteps('guren-cli-doctor-factory-plural-', {
-      'app/Models/Category.ts': MODEL_SOURCE('Category'),
-      'db/factories/CategoriesFactory.ts': FACTORY_SOURCE('CategoriesFactory'),
+    const steps = await stepsFor({
+      'app/Models/Category.ts': SOURCE,
+      'db/factories/CategoriesFactory.ts': SOURCE,
     })
 
     expect(steps.some((step) => step.title === 'Add factory for Category')).toBe(false)
   })
 
   it('does not suggest a factory for a model whose factory is named in the singular', async () => {
-    const steps = await factoryWorkspaceSteps('guren-cli-doctor-factory-singular-', {
-      'app/Models/Post.ts': MODEL_SOURCE('Post'),
-      'db/factories/PostFactory.ts': FACTORY_SOURCE('PostFactory'),
+    const steps = await stepsFor({
+      'app/Models/Post.ts': SOURCE,
+      'db/factories/PostFactory.ts': SOURCE,
     })
 
     expect(steps.some((step) => step.title === 'Add factory for Post')).toBe(false)
@@ -1294,9 +1287,9 @@ describe('suggestNextSteps', () => {
   // Without this the check could be stuck-on-true and both suppression tests
   // above would still pass.
   it('suggests a factory for a model that has none', async () => {
-    const steps = await factoryWorkspaceSteps('guren-cli-doctor-factory-missing-', {
-      'app/Models/Category.ts': MODEL_SOURCE('Category'),
-      'db/factories/PostFactory.ts': FACTORY_SOURCE('PostFactory'),
+    const steps = await stepsFor({
+      'app/Models/Category.ts': SOURCE,
+      'db/factories/PostFactory.ts': SOURCE,
     })
 
     const step = steps.find((s) => s.title === 'Add factory for Category')
@@ -1304,11 +1297,23 @@ describe('suggestNextSteps', () => {
     expect(step!.command).toBe('bunx guren make:factory Category')
   })
 
+  // A factory's own test is not a factory. Matching basenames rather than
+  // exact paths puts `PostFactory.test.ts` within reach of the pattern, and
+  // suppressing the step on it would hide a genuinely missing factory.
+  it('does not treat a factory test file as the factory itself', async () => {
+    const steps = await stepsFor({
+      'app/Models/Post.ts': SOURCE,
+      'db/factories/PostFactory.test.ts': SOURCE,
+    })
+
+    expect(steps.some((step) => step.title === 'Add factory for Post')).toBe(true)
+  })
+
   it('matches a module model against its own module factories', async () => {
-    const steps = await factoryWorkspaceSteps('guren-cli-doctor-factory-module-', {
-      'modules/billing/app/Models/Invoice.ts': MODEL_SOURCE('Invoice'),
-      'modules/billing/db/factories/InvoicesFactory.ts': FACTORY_SOURCE('InvoicesFactory'),
-      'modules/billing/app/Models/Plan.ts': MODEL_SOURCE('Plan'),
+    const steps = await stepsFor({
+      'modules/billing/app/Models/Invoice.ts': SOURCE,
+      'modules/billing/db/factories/InvoicesFactory.ts': SOURCE,
+      'modules/billing/app/Models/Plan.ts': SOURCE,
     })
 
     expect(steps.some((step) => step.title === 'Add factory for Invoice')).toBe(false)
@@ -1316,6 +1321,21 @@ describe('suggestNextSteps', () => {
     const planStep = steps.find((step) => step.title === 'Add factory for Plan')
     expect(planStep).toBeDefined()
     expect(planStep!.command).toBe('bunx guren make:factory Plan --module billing')
+  })
+
+  // Same class name in two app roots: the root factory belongs to the root
+  // model only. Pooling every root's factories together would leave the
+  // module's own missing factory unreported.
+  it('does not let a root factory satisfy a same-named model in a module', async () => {
+    const steps = await stepsFor({
+      'app/Models/Post.ts': SOURCE,
+      'db/factories/PostFactory.ts': SOURCE,
+      'modules/blog/app/Models/Post.ts': SOURCE,
+    })
+
+    const postSteps = steps.filter((step) => step.title === 'Add factory for Post')
+    expect(postSteps).toHaveLength(1)
+    expect(postSteps[0]!.command).toBe('bunx guren make:factory Post --module blog')
   })
 })
 

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -99,6 +99,18 @@ export const users = sqliteTable('users', {
 })
 `
 
+/** Materialize a fixture tree from `relative path → contents` under `dir`. */
+export async function writeWorkspaceFiles(
+  dir: string,
+  files: Record<string, string>,
+): Promise<void> {
+  for (const [relPath, contents] of Object.entries(files)) {
+    const filePath = join(dir, relPath)
+    await mkdir(dirname(filePath), { recursive: true })
+    await writeFile(filePath, contents, 'utf8')
+  }
+}
+
 export async function createTempWorkspace(prefix: string): Promise<TempWorkspace> {
   const dir = await mkdtemp(join(tmpdir(), prefix))
   const originalCwd = process.cwd()


### PR DESCRIPTION
## Problem

`suggestNextSteps` in `packages/cli/src/doctor.ts` decided whether a model had a factory with its own hand-written rule — two exact, singular paths:

```ts
const factoryCandidates = [
  `database/factories/${name}Factory.ts`,
  `db/factories/${name}Factory.ts`,
]
```

`make:factory` appends its suffix to whatever the user typed without inflecting it, so the file name is the user's choice. A `Category` model is just as likely to own `CategoriesFactory.ts`, which this rule cannot see.

The symptom: on a project with `db/factories/CategoriesFactory.ts`, `guren context Category` lists the factory while `guren doctor --next` still emits **"Add factory for Category"** and tells the user to run `bunx guren make:factory Category` — instructing them (or an agent) to create a duplicate.

## Change

Move the check onto the shared tolerant rule already used by `entity-context.ts`'s `findDbArtifacts`: `dbArtifactPattern(entity, kind)` and `DB_ARTIFACT_DIRS` from `discovery.ts`.

That rule matches basenames rather than probing exact paths, so the listing is hoisted out of the per-model loop — one directory walk instead of two `access()` probes per model.

Doctor and entity-context had each grown an inline copy of the same `listAppRoots` + `collectFiles` fan-out over `DB_ARTIFACT_DIRS[kind]`. Both now call `discoverDbArtifactFiles(appRoot, kind, roots?)`, which sits in `discovery.ts` next to the two constants it joins; `discoverDir`'s new `roots` parameter is what lets entity-context keep narrowing to a single app root. Three copies of the ` --module <name>` flag construction (two in doctor, one in check) collapse onto `moduleFlagFor()`.

## Behavior changes

1. **Plural-named factories now suppress the step.** `CategoriesFactory.ts`, `PostsFactory.ts`, and numbered files all count for their entity. This is the fix.

2. **`database/factories/` is no longer recognized.** No Guren command writes there — `make:factory` writes `db/factories` and the scaffold docs say the same; the only reference to that path anywhere in the repo was doctor's own line. It could have been preserved by widening `DB_ARTIFACT_DIRS`, but that would make `guren context` list files from a directory Guren never creates, and keeping the extra path in doctor alone would rebuild the exact doctor-vs-context divergence this PR removes. If a real user reports it, adding it back to the shared constant is one line.

3. **The check is module-aware, and scoped per app root.** `discoverModelFiles` already scans `modules/*/app/Models/`, so doctor was iterating module models while probing only the project root's `db/factories/` — a false positive independent of pluralization. Factories are now grouped by app root and a model is matched against its own, so a root `PostFactory.ts` does not satisfy `modules/blog/app/Models/Post.ts`; that is the scoping `guren context <Entity>` already applies. The suggested command carries `--module <name>` for a module-scoped model.

4. **A factory's own test no longer counts as the factory.** Matching basenames puts `PostFactory.test.ts` within reach of the pattern, which would suppress the step for a model that genuinely has none. The listing routes through `discoverDir`, which excludes test files the same way every other `discover*Files` does — so `guren context <Entity>` also stops listing `*.test.ts` under Factories.

Seeders are untouched: `DB_ARTIFACT_DIRS` has a `Seeder` kind, but doctor never checked seeders, so there is nothing to migrate.

## Known limits, not addressed here

- `dbArtifactPattern` accepts `entity`, `entity + "s"`, and `collectionName(entity)`. `collectionName` is a simple rule (`Bus` → `Bus`, `Child` → `Childs`), so `BusesFactory.ts` still goes undetected — no worse than the old exact-path behavior. `inflect.ts` is the single pluralization rule shared with table names and route slugs; changing it belongs in its own change.
- `collectFiles` skips symlinked entries (`isFile()` is false for a symlink), where the old `access()` followed them. This is a property of every `discover*Files` in the CLI, not of this check.

## Tests

Six cases in `describe('suggestNextSteps')`, all driving `suggestNextSteps({ cwd })` against a temp workspace:

- plural `CategoriesFactory.ts` suppresses the step (the pinning test)
- singular `PostFactory.ts` still suppresses it (no regression)
- a model with no factory **still gets the step**, so a stuck-on-true check cannot pass the cases above
- `db/factories/PostFactory.test.ts` does **not** suppress the step
- a module model matches its own module's factories, and one without gets `--module billing`
- a root `PostFactory.ts` does not satisfy a same-named model in a module

Each fix was mutation-checked: restoring the old exact-singular rule fails the plural and module tests; pooling factories across roots fails the cross-root test; dropping the test-file exclusion fails the `PostFactory.test.ts` test. None of them fail anything else.

The temp-workspace file-map loop existed in four private copies across the test suite; it is now `writeWorkspaceFiles()` in `tests/helpers.ts`, with `check.test.ts` converted alongside the new tests.

## Verification

- `bun run build` — clean
- `bun run test:bun` — 3370 pass, 0 fail
- `bun run typecheck` (root) — clean
- `bun run audit:core-first`, `bun run audit:docs` — clean

Templates are untouched, so the starter-template audits and smokes do not apply.