### PR TITLE
perf(cli): share one project walk across arch check evaluators

### DIFF
--- a/packages/cli/src/arch-check.ts
+++ b/packages/cli/src/arch-check.ts
@@ -44,8 +44,18 @@ export async function runArchCheck(options: RunArchCheckOptions): Promise<CheckR
     ]
   }
 
-  const derivedResults = await evaluateDerivedModuleRules(cwd, cache, changedFiles)
-  const explicitResults = loaded.config ? await evaluateArchRules(cwd, cache, loaded.config, changedFiles) : []
+  // Both evaluators scan the same set — every importable file in the project —
+  // so the walk is shared. Lazy because a project with neither `modules/` nor
+  // a guren.arch.ts reaches neither scan, and must not pay for a walk nothing
+  // reads. `readonly` because the two now share one array instance.
+  let importableFilesPromise: Promise<readonly string[]> | null = null
+  const importableFiles = (): Promise<readonly string[]> =>
+    (importableFilesPromise ??= collectFiles(cwd, IMPORTABLE_EXTENSIONS, NON_SOURCE_DIR_NAMES))
+
+  const derivedResults = await evaluateDerivedModuleRules(cwd, cache, changedFiles, importableFiles)
+  const explicitResults = loaded.config
+    ? await evaluateArchRules(cwd, cache, loaded.config, changedFiles, importableFiles)
+    : []
 
   return [...derivedResults, ...explicitResults]
 }
@@ -73,12 +83,13 @@ async function evaluateDerivedModuleRules(
   cwd: string,
   cache: ParseCache,
   changedFiles: Set<string> | null | undefined,
+  importableFiles: () => Promise<readonly string[]>,
 ): Promise<CheckResult[]> {
   const moduleNames = await listModuleNames(cwd)
   if (moduleNames.length === 0) return []
 
   const results: CheckResult[] = []
-  const files = await collectFiles(cwd, IMPORTABLE_EXTENSIONS, NON_SOURCE_DIR_NAMES)
+  const files = await importableFiles()
   let filesChecked = 0
 
   for (const absPath of files) {
@@ -140,12 +151,13 @@ async function evaluateArchRules(
   cache: ParseCache,
   config: ArchRuleSet,
   changedFiles: Set<string> | null | undefined,
+  importableFiles: () => Promise<readonly string[]>,
 ): Promise<CheckResult[]> {
   const layers = config.layers ?? {}
   const rules = config.rules
   const results: CheckResult[] = []
 
-  const files = await collectFiles(cwd, IMPORTABLE_EXTENSIONS, NON_SOURCE_DIR_NAMES)
+  const files = await importableFiles()
   let filesChecked = 0
 
   for (const absPath of files) {

--- a/packages/cli/tests/arch-check.test.ts
+++ b/packages/cli/tests/arch-check.test.ts
@@ -510,4 +510,64 @@ describe('runArchCheck derived module rules (RFC 0002, zero-config)', () => {
       await workspace.cleanup()
     }
   })
+
+  // Pins that both evaluators agree on which files they scan. It deliberately
+  // does NOT claim to prove the project is walked only once: two identical
+  // walks yield identical lists, so reverting to a walk per evaluator still
+  // passes here. What it catches is one evaluator being narrowed to a subtree
+  // — scanning only `modules/` for the derived rules, say — which is the
+  // plausible way the shared walk gets undone.
+  //
+  // The counts are files *checked*, not files walked: `filesChecked` only
+  // counts files with at least one import specifier, past each evaluator's own
+  // filtering. So the fixture's guren.arch.ts has to stay import-free, or the
+  // derived count moves for a reason unrelated to what is under test.
+  it('scans the same file set in both evaluators', async () => {
+    const workspace = await createTempWorkspace('guren-cli-arch-shared-walk-')
+    try {
+      await writeFile(
+        join(workspace.dir, 'guren.arch.ts'),
+        `export default {
+  layers: { domain: 'app/Domain/**' },
+  rules: [{ from: 'domain', disallow: ['app/Forbidden/**'] }],
+}
+`,
+        'utf8',
+      )
+
+      // Two importing files at the project root, one inside a module. No
+      // violations anywhere, so both evaluators fall through to their summary.
+      await mkdir(join(workspace.dir, 'app/Domain'), { recursive: true })
+      await writeFile(join(workspace.dir, 'app/Domain/Helper.ts'), 'export const helper = 1', 'utf8')
+      await writeFile(
+        join(workspace.dir, 'app/Domain/OrderService.ts'),
+        `import { helper } from './Helper'\nexport class OrderService {}`,
+        'utf8',
+      )
+      await mkdir(join(workspace.dir, 'modules/billing'), { recursive: true })
+      await writeFile(join(workspace.dir, 'modules/billing/index.ts'), 'export const billing = 1', 'utf8')
+      await mkdir(join(workspace.dir, 'modules/inventory'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'modules/inventory/index.ts'),
+        `import { billing } from '../billing'\nexport const inventory = {}`,
+        'utf8',
+      )
+
+      const results = await runArchCheck({ cwd: workspace.dir, cache: new ParseCache() })
+
+      // Derived rules reach both importers — the project-root one and the one
+      // inside a module — which is what a modules-only walk would miss.
+      const moduleSummary = results.find((r) => r.key === 'arch:module-summary')
+      expect(moduleSummary?.status).toBe('pass')
+      expect(moduleSummary?.message).toContain('Checked 2 file(s)')
+
+      // Explicit rules start from that same list and narrow to the `domain`
+      // layer: Helper.ts is in the layer but imports nothing, so it drops out.
+      const archSummary = results.find((r) => r.key === 'arch:summary')
+      expect(archSummary?.status).toBe('pass')
+      expect(archSummary?.message).toContain('Checked 1 file(s)')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
 })


### PR DESCRIPTION
## Summary

`runArchCheck()` performed two identical full-tree `collectFiles()` walks — one inside `evaluateDerivedModuleRules`, one inside `evaluateArchRules` — despite both scanning the exact same file set (every importable file in the project). This hoists the walk into a lazily-memoized thunk shared by both evaluators, so it runs at most once per invocation, and not at all when neither evaluator is active (no `modules/` directory and no `guren.arch.ts`).

This originated from investigating a different perf ticket (`packages/cli/src/discovery.ts`'s `listAppRoots` memoization and `discoverTestFiles`/`discoverDir` walk sharing). Both of those turned out to be non-issues on measurement:
- `listAppRoots` costs ~0.14ms across all 9 call sites on a 25.9k-file tree, and `generateEntityContext` runs it out-of-process (`createFreshContextApi`) anyway, so a cache wouldn't survive to matter — and a module-level cache would be a correctness regression on the in-process `runCheck` MCP path.
- The narrow `discoverDir` walks touch only 12 of 242 directories a full `discoverTestFiles` walk visits (~5%), so sharing that walk saves ~0.5ms of 8.9ms.

The actual duplicate walk was in `arch-check.ts` instead, fixed here.

## Measurements

Interleaved A/B (source swapped between rounds, same machine state, 4 rounds) on synthetic trees:

| tree size | before | after | delta |
|---|---|---|---|
| 6,468 files | 26.5 ms | 15.3 ms | **-42%** |
| 25,863 files | 89.7 ms | 52.5 ms | **-41%** |

Verified byte-identical `runArchCheck` output before/after on a fixture with 4 real violations (arch rule + module boundary), in both full-scan and `--changed` modes.

## Reviewed

Passed through both a Codex correctness review and a 4-angle `/simplify` pass (reuse, simplification, efficiency, altitude) run in parallel. No correctness issues found. One test-comment overclaim was caught and fixed: the new test pins that both evaluators agree on the scanned file set, not that the walk happens exactly once (two identical walks would still pass it — it catches a narrower re-split instead). Follow-ups identified but out of scope for this PR: `spec-modules.ts` runs a third identical full-tree walk plus an uncached full re-read of every file, and doesn't narrow under `--changed`; `discoverModelFiles` runs 5x per `guren check` with 3x redundant re-parsing.

## Test plan

- [x] `bun run test:bun cli` — 1052 pass / 0 fail
- [x] `bunx tsc --noEmit -p packages/cli/tsconfig.json` — clean
- [x] Root `bun run typecheck` — pre-existing, unrelated failures only (missing `.guren/*.gen` codegen artifacts in `examples/blog`, gitignored and never generated in this worktree; zero errors in `packages/cli`)
- [x] New regression test mutation-tested: fails when one evaluator is re-split onto a narrower walk