### PR TITLE
fix(cli): make:factory and make:seeder read DB_ARTIFACT_DIRS

### DIFF
--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -307,7 +307,14 @@ export async function hasControllerTest(cwd: string, controllerPath: string): Pr
   return false
 }
 
-/** Where `make:factory` and `make:seeder` write, keyed by the suffix they append. */
+/**
+ * Where `make:factory` and `make:seeder` write, keyed by the suffix they
+ * append. Those two scaffolders import this rather than declaring the path
+ * themselves, which is what makes it safe for the readers below — and for
+ * `guren doctor --next`, which suggests running `make:factory` when a scan
+ * finds nothing — to treat a miss here as "no such artifact exists" rather
+ * than "it was written somewhere this constant does not know about".
+ */
 export const DB_ARTIFACT_DIRS = {
   Factory: 'db/factories',
   Seeder: 'db/seeders',

--- a/packages/cli/src/make-factory.ts
+++ b/packages/cli/src/make-factory.ts
@@ -1,7 +1,6 @@
+import { DB_ARTIFACT_DIRS } from './discovery'
 import type { WriterOptions } from './utils'
 import { scaffoldFile } from './utils'
-
-const FACTORIES_DIR = 'db/factories'
 
 function factoryTemplate(className: string, modelName: string): string {
   return `import { Factory } from '@guren/core'
@@ -20,7 +19,7 @@ export interface MakeFactoryOptions extends WriterOptions {
 
 export async function makeFactory(name: string, options: MakeFactoryOptions = {}): Promise<string> {
   return scaffoldFile(name, {
-    dir: FACTORIES_DIR,
+    dir: DB_ARTIFACT_DIRS.Factory,
     suffix: 'Factory',
     template: ({ normalizedName }) => {
       const modelName = options.model ?? normalizedName.replace(/Factory$/, '')

--- a/packages/cli/src/make-seeder.ts
+++ b/packages/cli/src/make-seeder.ts
@@ -1,8 +1,7 @@
+import { DB_ARTIFACT_DIRS } from './discovery'
 import { readSchemaDialect, seederContextTypes } from './patch-helpers'
 import type { WriterOptions } from './utils'
 import { scaffoldFile } from './utils'
-
-const SEEDERS_DIR = 'db/seeders'
 
 function seederTemplate(className: string, context: string): string {
   return `import { defineSeeder, type ${context} } from '@guren/core'
@@ -18,7 +17,7 @@ export async function makeSeeder(name: string, options: WriterOptions = {}): Pro
   const context = seederContextTypes[await readSchemaDialect()]
 
   return scaffoldFile(name, {
-    dir: SEEDERS_DIR,
+    dir: DB_ARTIFACT_DIRS.Seeder,
     suffix: 'Seeder',
     template: ({ normalizedName }) => seederTemplate(normalizedName, context),
   }, options)


### PR DESCRIPTION
## Summary

- `make-factory.ts` and `make-seeder.ts` each declared their own `db/factories` / `db/seeders` path literal instead of importing `DB_ARTIFACT_DIRS` from `discovery.ts`, even though `discovery.ts` documents that constant as "where `make:factory` and `make:seeder` write."
- `guren doctor --next` (#270) now scans `DB_ARTIFACT_DIRS.Factory`/`.Seeder` and, when it finds nothing, suggests running `make:factory <Name>`. With the reader and writer pinned to separate literals, relocating the scaffold output would make doctor keep re-suggesting the same factory forever.
- Both scaffolders now import `DB_ARTIFACT_DIRS` from `discovery.ts` instead of declaring their own path constants. Expanded the doc comment on `DB_ARTIFACT_DIRS` to state why this matters.

## Notes for reviewers

- Checked for an import cycle: `discovery.ts` → `inflect.ts` → `utils.ts` → node builtins only; nothing in that chain imports `make-factory.ts`/`make-seeder.ts`. Acyclic.
- `db-seed.ts` was left with its own `SEEDERS_DIR` literal on purpose — it's a runtime loader (`join(process.cwd(), SEEDERS_DIR)`, root-only, no module fan-out), a different concern from the scaffold/discovery pairing `DB_ARTIFACT_DIRS` documents. There's no reader/writer loop to close there.
- Left `tests/make-commands.test.ts` path assertions (`'db/seeders/UserSeeder.ts'`, `'db/factories/UserFactory.ts'`) as string literals rather than deriving them from `DB_ARTIFACT_DIRS` — deriving them would make the assertion tautological and remove the only external check that the scaffolder still writes where users/docs expect.
- Out of scope but same drift class, noted for a follow-up: `make-auth.ts` hardcodes `'db/seeders/UsersSeeder.ts'` at several call sites, and `templates/agent/.claude/skills/scaffold/SKILL.md` documents both paths as literals.

## Test plan

- [x] `bun run build:clean` (repo tests load `@guren/server` through `packages/cli`'s built `dist/`, so a stale build silently loads pre-change behavior)
- [x] `bun run test:bun cli` — 1060 pass / 0 fail
- [x] `bunx tsc --noEmit -p packages/cli/tsconfig.json` — no errors
- [x] Mutation check: temporarily changed `DB_ARTIFACT_DIRS.Factory`/`.Seeder` to bogus paths and confirmed `make-commands.test.ts` fails and the scaffolder actually writes to the new (wrong) path — proves the writer really reads the constant now, not just that types check