### PR TITLE
perf: replace remaining backtracking regexes with linear scans

### DIFF
--- a/packages/cli/src/docs-viewer.ts
+++ b/packages/cli/src/docs-viewer.ts
@@ -68,16 +68,30 @@ function skipWhitespace(body: string, from: number): number {
   return cursor
 }
 
-/** Where the `#` heading starting at `at` ends, or -1 when there is none. */
+/** Whether a `#` heading opens at `at`: a `#` with whitespace behind it. */
+function opensHeading(body: string, at: number): boolean {
+  return body[at] === '#' && at + 1 < body.length && WHITESPACE.test(body[at + 1])
+}
+
+/** Where the heading opening at `at` ends. Only meaningful once it opens one. */
 function headingEnd(body: string, at: number): number {
-  if (body[at] !== '#') return -1
-
-  const text = skipWhitespace(body, at + 1)
-  if (text === at + 1) return -1
-
-  let cursor = text
+  let cursor = skipWhitespace(body, at + 1)
   while (cursor < body.length && !LINE_TERMINATOR.test(body[cursor])) cursor += 1
   return cursor
+}
+
+/**
+ * Where the first heading standing behind a comment closed at or after `from`
+ * ends, or -1 when no `-->` from there on has one behind it. Which `<!--`
+ * opened the comment never changes the answer, so the search need not know.
+ */
+function headingBehindComment(body: string, from: number): number {
+  for (let closer = body.indexOf('-->', from); closer !== -1; closer = body.indexOf('-->', closer + 3)) {
+    const heading = skipWhitespace(body, closer + 3)
+    if (opensHeading(body, heading)) return headingEnd(body, heading)
+  }
+
+  return -1
 }
 
 /**
@@ -89,29 +103,38 @@ function headingEnd(body: string, at: number): number {
  * many `<!--` took time quadratic in its length. Every `-->` is classified once
  * here instead, which is enough, because whether a heading may follow a comment
  * turns only on where that comment ends and never on where it opened.
+ *
+ * Two things keep this to a bounded number of visits per character, and both
+ * are easy to lose:
+ *
+ *  - `headingBehindComment` asks where the heading *ends* only for the closer
+ *    it settles on. Resolving that for every `-->` up front re-walked the rest
+ *    of the line once each, so one long line of them cost quadratic time —
+ *    worse than the pattern this replaced. It also runs at most twice: once
+ *    that finds a heading and returns, or once that finds none, after which no
+ *    later `<!--` can reach what this search has already ruled out.
+ *  - the line loop resumes at `from` rather than at `lineStart`. Every line
+ *    start between the two sits inside the whitespace just skipped and lands
+ *    on the same `from`, so re-testing them repeats a failure already known,
+ *    once per blank line.
  */
 function stripLeadingH1(body: string): string {
-  const closers: Array<{ at: number; end: number }> = []
-  for (let found = body.indexOf('-->'); found !== -1; found = body.indexOf('-->', found + 3)) {
-    const end = headingEnd(body, skipWhitespace(body, found + 3))
-    if (end !== -1) closers.push({ at: found, end })
-  }
-
-  let next = 0
+  let noHeadingBehindComments = false
   let lineStart = 0
+
   for (;;) {
     const from = skipWhitespace(body, lineStart)
 
-    if (body.startsWith('<!--', from)) {
-      while (next < closers.length && closers[next].at < from + 4) next += 1
-      if (next < closers.length) return body.slice(0, lineStart) + body.slice(closers[next].end)
+    if (!noHeadingBehindComments && body.startsWith('<!--', from)) {
+      const end = headingBehindComment(body, from + 4)
+      if (end !== -1) return body.slice(0, lineStart) + body.slice(end)
+      noHeadingBehindComments = true
     }
 
-    const end = headingEnd(body, from)
-    if (end !== -1) return body.slice(0, lineStart) + body.slice(end)
+    if (opensHeading(body, from)) return body.slice(0, lineStart) + body.slice(headingEnd(body, from))
 
     // A multiline `^` anchors after every line terminator, `\r` included.
-    let cursor = lineStart
+    let cursor = from
     while (cursor < body.length && !LINE_TERMINATOR.test(body[cursor])) cursor += 1
     if (cursor === body.length) return body
     lineStart = cursor + 1

--- a/packages/cli/src/docs-viewer.ts
+++ b/packages/cli/src/docs-viewer.ts
@@ -58,7 +58,66 @@ export interface DocsViewerData {
   docs: DocsViewerDoc[]
 }
 
-const LEADING_H1 = /^\s*(?:<!--[\s\S]*?-->\s*)?#\s+.*$/m
+/** Both match one character, so neither can backtrack the way a quantifier can. */
+const WHITESPACE = /\s/
+const LINE_TERMINATOR = /[\n\r\u2028\u2029]/
+
+function skipWhitespace(body: string, from: number): number {
+  let cursor = from
+  while (cursor < body.length && WHITESPACE.test(body[cursor])) cursor += 1
+  return cursor
+}
+
+/** Where the `#` heading starting at `at` ends, or -1 when there is none. */
+function headingEnd(body: string, at: number): number {
+  if (body[at] !== '#') return -1
+
+  const text = skipWhitespace(body, at + 1)
+  if (text === at + 1) return -1
+
+  let cursor = text
+  while (cursor < body.length && !LINE_TERMINATOR.test(body[cursor])) cursor += 1
+  return cursor
+}
+
+/**
+ * The body without its first H1, and without the HTML comment that may precede
+ * it — the panel header carries the title, so the body H1 would repeat it.
+ *
+ * Scanned rather than matched with `/^\s*(?:<!--[\s\S]*?-->\s*)?#\s+.*$/m`,
+ * whose lazy comment body was re-scanned from every line start: a doc holding
+ * many `<!--` took time quadratic in its length. Every `-->` is classified once
+ * here instead, which is enough, because whether a heading may follow a comment
+ * turns only on where that comment ends and never on where it opened.
+ */
+function stripLeadingH1(body: string): string {
+  const closers: Array<{ at: number; end: number }> = []
+  for (let found = body.indexOf('-->'); found !== -1; found = body.indexOf('-->', found + 3)) {
+    const end = headingEnd(body, skipWhitespace(body, found + 3))
+    if (end !== -1) closers.push({ at: found, end })
+  }
+
+  let next = 0
+  let lineStart = 0
+  for (;;) {
+    const from = skipWhitespace(body, lineStart)
+
+    if (body.startsWith('<!--', from)) {
+      while (next < closers.length && closers[next].at < from + 4) next += 1
+      if (next < closers.length) return body.slice(0, lineStart) + body.slice(closers[next].end)
+    }
+
+    const end = headingEnd(body, from)
+    if (end !== -1) return body.slice(0, lineStart) + body.slice(end)
+
+    // A multiline `^` anchors after every line terminator, `\r` included.
+    let cursor = lineStart
+    while (cursor < body.length && !LINE_TERMINATOR.test(body[cursor])) cursor += 1
+    if (cursor === body.length) return body
+    lineStart = cursor + 1
+  }
+}
+
 /**
  * The graph node id a body link points at. `localLinkTarget` is the
  * same filter `scanDocs` ran to derive the edge, so the rendered target
@@ -84,8 +143,7 @@ export async function buildDocsViewerData(cwd: string): Promise<DocsViewerData> 
   const docs = await Promise.all(
     refs.map(async (ref): Promise<DocsViewerDoc> => {
       const source = await readFile(resolve(cwd, ref.path), 'utf-8').catch(() => '')
-      // The panel header carries the title, so the body H1 would repeat it.
-      const body = (parseDocFrontmatter(source)?.body ?? source).replace(LEADING_H1, '')
+      const body = stripLeadingH1(parseDocFrontmatter(source)?.body ?? source)
       return {
         path: ref.path,
         module: ref.module,

--- a/packages/cli/tests/docs-viewer.test.ts
+++ b/packages/cli/tests/docs-viewer.test.ts
@@ -71,6 +71,56 @@ Everyone can read.
       await workspace.cleanup()
     }
   })
+
+  it('drops an HTML comment standing in front of the H1, however many precede it', async () => {
+    const workspace = await createTempWorkspace('guren-cli-docs-viewer-comment-')
+    try {
+      const dir = workspace.dir
+      await mkdir(join(dir, 'docs/adr'), { recursive: true })
+      await writeFile(join(dir, 'package.json'), '{}', 'utf8')
+      await writeFile(
+        join(dir, 'docs/adr/0001-posts.md'),
+        `---\ntype: adr\nstatus: stable\n---\n\n<!-- one --> <!-- two -->\n# Posts are public\n\nEveryone can read.\n`,
+        'utf8',
+      )
+
+      const data = await buildDocsViewerData(dir)
+
+      // The H1 stands behind two comments, so it is reachable only through the
+      // optional comment prefix — and only by looking past the first `-->`,
+      // which is the step that decides where the dropped span ends.
+      const [doc] = data.docs
+      expect(doc.html).not.toContain('Posts are public')
+      expect(doc.html).toContain('Everyone can read.')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('leaves a body that opens comments it never closes untouched', async () => {
+    const workspace = await createTempWorkspace('guren-cli-docs-viewer-unclosed-')
+    try {
+      const dir = workspace.dir
+      await mkdir(join(dir, 'docs/adr'), { recursive: true })
+      await writeFile(join(dir, 'package.json'), '{}', 'utf8')
+      // Every one of these line starts used to re-scan the rest of the file
+      // looking for a `-->` that is not there, which is the quadratic case.
+      const noise = '<!-- generated, do not edit\n'.repeat(4_000)
+      await writeFile(
+        join(dir, 'docs/adr/0001-posts.md'),
+        `---\ntype: adr\nstatus: stable\n---\n\n${noise}\nEveryone can read.\n`,
+        'utf8',
+      )
+
+      const data = await buildDocsViewerData(dir)
+
+      // Nothing to drop: no heading is reachable behind those openers, so the
+      // prose after them has to survive rather than be swallowed as a heading.
+      expect(data.docs[0].html).toContain('Everyone can read.')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
 })
 
 describe('buildDocsViewerData link resolution', () => {

--- a/packages/cli/tests/docs-viewer.test.ts
+++ b/packages/cli/tests/docs-viewer.test.ts
@@ -97,6 +97,32 @@ Everyone can read.
     }
   })
 
+  it('stays linear on a body that is one long line of comment closers', async () => {
+    const workspace = await createTempWorkspace('guren-cli-docs-viewer-closers-')
+    try {
+      const dir = workspace.dir
+      await mkdir(join(dir, 'docs/adr'), { recursive: true })
+      await writeFile(join(dir, 'package.json'), '{}', 'utf8')
+      // Every `-->` here has a `#` behind it, and none of them ends a line.
+      // Resolving where each one's heading ends re-walks the rest of the line,
+      // so doing that per closer is quadratic — 13 seconds at this size, well
+      // past the pattern this replaced. The heading is on the same line as the
+      // closers, so nothing is dropped and only the cost is under test.
+      await writeFile(
+        join(dir, 'docs/adr/0001-posts.md'),
+        `---\ntype: adr\nstatus: stable\n---\n\n${'--> # '.repeat(16_000)}\n`,
+        'utf8',
+      )
+
+      const started = performance.now()
+      await buildDocsViewerData(dir)
+
+      expect(performance.now() - started).toBeLessThan(2_000)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('leaves a body that opens comments it never closes untouched', async () => {
     const workspace = await createTempWorkspace('guren-cli-docs-viewer-unclosed-')
     try {

--- a/packages/orm/src/active-connections.test.ts
+++ b/packages/orm/src/active-connections.test.ts
@@ -102,6 +102,22 @@ describe('describeCallerFile', () => {
     expect(frame('    at factory (/app/v2:1:2)')).toBe('/app/v2')
   })
 
+  test('should read a malformed frame exactly as the engine-driven parse did', () => {
+    // These are degenerate frames no runtime emits, pinned because the parse is
+    // deliberately bug-for-bug with the pattern it replaced and nothing else
+    // holds it there: each of these is the only witness that separates the
+    // real rule from a plausible simplification of it. Their values are not
+    // interesting in themselves — that they do not drift is.
+    const frame = (last: string) => describeCallerFile(`Error\n    at factory (/app/dist/index.js:1:1)\n${last}`)
+
+    // A path may be the whitespace the run after `at` gives back...
+    expect(frame('at  :1')).toBe(' ')
+    // ...but only where there is a spare character to give.
+    expect(frame('at :1')).toBeUndefined()
+    // Line and column are split off together, leaving `:1` as the path.
+    expect(frame('at   :1:1')).toBe(':1')
+  })
+
   test('should not take time superlinear in the length of a frame', () => {
     // Both shapes previously backtracked polynomially, so a frame padded with
     // whitespace or opening parens cost quadratic time. Nothing here is

--- a/packages/orm/src/active-connections.test.ts
+++ b/packages/orm/src/active-connections.test.ts
@@ -91,6 +91,30 @@ describe('describeCallerFile', () => {
     expect(describeCallerFile('Error\n    at createPostgresDatabase (/app/dist/index.js:120:15)')).toBeUndefined()
   })
 
+  test('should split a path that itself ends in numbers at the leftmost location', () => {
+    // `/app/v2:9` is a legal path followed by a line number, so `:1:2` has to
+    // be read as line and column rather than the path keeping `:1` and the
+    // column standing alone. Anything else keys two reloads of one file apart.
+    const frame = (last: string) => describeCallerFile(`Error\n    at factory (/app/dist/index.js:1:1)\n${last}`)
+
+    expect(frame('    at /app/v2:1:2')).toBe('/app/v2')
+    expect(frame('    at a:1:2:3')).toBe('a:1')
+    expect(frame('    at factory (/app/v2:1:2)')).toBe('/app/v2')
+  })
+
+  test('should not take time superlinear in the length of a frame', () => {
+    // Both shapes previously backtracked polynomially, so a frame padded with
+    // whitespace or opening parens cost quadratic time. Nothing here is
+    // request-derived, but a stack embeds whatever a message put in it.
+    const padded = (last: string) => describeCallerFile(`Error\n    at factory (/app/dist/index.js:1:1)\n${last}`)
+    const started = performance.now()
+
+    expect(padded(`    at ${' '.repeat(100_000)}x`)).toBeUndefined()
+    expect(padded(`    ${'('.repeat(100_000)}x`)).toBeUndefined()
+
+    expect(performance.now() - started).toBeLessThan(1_000)
+  })
+
   test('should stay identical when the call moves to another line', () => {
     // The whole point of dropping line and column: adding an import above the
     // factory must not orphan the entry holding the previous connection.

--- a/packages/orm/src/active-connections.ts
+++ b/packages/orm/src/active-connections.ts
@@ -87,12 +87,6 @@ function isDigitAt(text: string, index: number): boolean {
   return code >= 48 && code <= 57
 }
 
-function trimmedEnd(text: string): number {
-  let cursor = text.length
-  while (cursor > 0 && WHITESPACE.test(text[cursor - 1])) cursor -= 1
-  return cursor
-}
-
 /**
  * Where a frame's trailing `:line[:column]` may begin, in the order the lazy
  * `(.+?):\d+(?::\d+)?` these replace settled on them: the `:line:column` split
@@ -156,7 +150,9 @@ function afterLastTerminator(frame: string, before: number): number {
 function parseFrameLocation(frame: string | undefined): string | undefined {
   if (frame === undefined) return undefined
 
-  const end = trimmedEnd(frame)
+  // `trimEnd` drops exactly the characters `\s` matches, so this is where the
+  // patterns' trailing `\s*$` would have started.
+  const end = frame.trimEnd().length
 
   // `at fn (/path/file.ts:1:2)`. The opening paren is the frame's *leftmost*
   // usable one, not the one nearest the location: `(` is ordinary in a
@@ -164,16 +160,15 @@ function parseFrameLocation(frame: string | undefined): string | undefined {
   // whole. Usable means the path it opens reaches the location without
   // crossing a line break, which is why a split can fall to a later paren.
   if (end > 0 && frame[end - 1] === ')') {
-    let best: { open: number; split: number } | undefined
+    const splits = locationSplits(frame, end - 1)
 
-    for (const split of locationSplits(frame, end - 1)) {
-      const open = frame.indexOf('(', Math.max(afterLastTerminator(frame, split) - 1, 0))
-      if (open !== -1 && open + 1 < split && (best === undefined || open < best.open)) {
-        best = { open, split }
-      }
-    }
+    // Both splits sit inside one `:line:column` run, which is colons and
+    // digits, so no line break can fall between them — the earliest paren a
+    // path may open at is therefore the same whichever split is taken.
+    const open = splits.length === 0 ? -1 : frame.indexOf('(', afterLastTerminator(frame, splits[0]))
+    const path = open === -1 ? undefined : pathBefore(frame, open + 1, splits)
 
-    if (best !== undefined) return frame.slice(best.open + 1, best.split)
+    if (path !== undefined) return path
   }
 
   // `at /path/file.ts:1:2`, where only the trailing location bounds the path.

--- a/packages/orm/src/active-connections.ts
+++ b/packages/orm/src/active-connections.ts
@@ -78,26 +78,128 @@ function isHotReloadRuntime(): boolean {
   return typeof process !== 'undefined' && Array.isArray(process.execArgv) && process.execArgv.includes('--hot')
 }
 
+/** Both match one character, so neither can backtrack the way `\s*` in a pattern can. */
+const WHITESPACE = /\s/
+const LINE_TERMINATOR = /[\n\r\u2028\u2029]/
+
+function isDigitAt(text: string, index: number): boolean {
+  const code = text.charCodeAt(index)
+  return code >= 48 && code <= 57
+}
+
+function trimmedEnd(text: string): number {
+  let cursor = text.length
+  while (cursor > 0 && WHITESPACE.test(text[cursor - 1])) cursor -= 1
+  return cursor
+}
+
+/**
+ * Where a frame's trailing `:line[:column]` may begin, in the order the lazy
+ * `(.+?):\d+(?::\d+)?` these replace settled on them: the `:line:column` split
+ * first, because a lazy path stops at the earliest suffix that satisfies the
+ * rest, then the `:column`-only split it backtracked to when the shorter path
+ * came out empty.
+ *
+ * Walking the digits back from `end` finds both in one pass. The pattern
+ * instead re-tested the suffix at every prefix length, which is what made it
+ * quadratic in the length of a frame.
+ */
+function locationSplits(frame: string, end: number): number[] {
+  let cursor = end
+  while (cursor > 0 && isDigitAt(frame, cursor - 1)) cursor -= 1
+  if (cursor === end || cursor === 0 || frame[cursor - 1] !== ':') return []
+
+  const lastColon = cursor - 1
+  cursor = lastColon
+  while (cursor > 0 && isDigitAt(frame, cursor - 1)) cursor -= 1
+
+  return cursor < lastColon && cursor > 0 && frame[cursor - 1] === ':' ? [cursor - 1, lastColon] : [lastColon]
+}
+
+/** The path a split leaves in front of it, or undefined when it leaves none. */
+function pathBefore(frame: string, from: number, splits: number[]): string | undefined {
+  for (const split of splits) {
+    if (split > from) return frame.slice(from, split)
+  }
+  return undefined
+}
+
+/**
+ * Where the last line terminator before `before` ends, or 0 when there is none.
+ *
+ * A path could never span one — the patterns spelled it `.`, which stops at
+ * every line break — so this is the earliest a path ending at `before` may
+ * start.
+ */
+function afterLastTerminator(frame: string, before: number): number {
+  let cursor = before
+  while (cursor > 0 && !LINE_TERMINATOR.test(frame[cursor - 1])) cursor -= 1
+  return cursor
+}
+
 /**
  * The path a single stack frame points at, without its line and column.
  *
- * The two shapes a frame comes in are matched separately rather than by one
- * pattern loose enough to cover both. `at fn (/path/file.ts:1:2)` is tried
- * first, because its parentheses bound the path; a pattern that also had to
- * accept the bare `at /path/file.ts:1:2` could only bound it by whitespace, and
- * would truncate `/Users/me/My Projects/app/config` to `Projects/app/config`.
+ * The two shapes a frame comes in are read separately rather than by one rule
+ * loose enough to cover both. `at fn (/path/file.ts:1:2)` is tried first,
+ * because its parentheses bound the path; a rule that also had to accept the
+ * bare `at /path/file.ts:1:2` could only bound it by whitespace, and would
+ * truncate `/Users/me/My Projects/app/config` to `Projects/app/config`.
  * Nothing constrains what the path itself may contain — spaces and parentheses
  * are both ordinary in a macOS directory name, and excluding either is how the
  * truncation happened in the first place.
  *
  * Both shapes require a trailing `:line`, so frames that name no location at
  * all — `at native`, `at <anonymous>` — are rejected instead of being read as a
- * path. Both path groups are lazy for the same reason both are anchored: a
- * greedy one would swallow the line number and leave the column to satisfy
- * `:\d+`, returning `/path/file.ts:1`.
+ * path.
  */
 function parseFrameLocation(frame: string | undefined): string | undefined {
-  return frame?.match(/\((.+?):\d+(?::\d+)?\)\s*$/)?.[1] ?? frame?.match(/^\s*at\s+(.+?):\d+(?::\d+)?\s*$/)?.[1]
+  if (frame === undefined) return undefined
+
+  const end = trimmedEnd(frame)
+
+  // `at fn (/path/file.ts:1:2)`. The opening paren is the frame's *leftmost*
+  // usable one, not the one nearest the location: `(` is ordinary in a
+  // directory name, and matching leftmost is what keeps `/app (old)/config`
+  // whole. Usable means the path it opens reaches the location without
+  // crossing a line break, which is why a split can fall to a later paren.
+  if (end > 0 && frame[end - 1] === ')') {
+    let best: { open: number; split: number } | undefined
+
+    for (const split of locationSplits(frame, end - 1)) {
+      const open = frame.indexOf('(', Math.max(afterLastTerminator(frame, split) - 1, 0))
+      if (open !== -1 && open + 1 < split && (best === undefined || open < best.open)) {
+        best = { open, split }
+      }
+    }
+
+    if (best !== undefined) return frame.slice(best.open + 1, best.split)
+  }
+
+  // `at /path/file.ts:1:2`, where only the trailing location bounds the path.
+  let cursor = 0
+  while (cursor < end && WHITESPACE.test(frame[cursor])) cursor += 1
+  if (!frame.startsWith('at', cursor)) return undefined
+
+  const afterAt = cursor + 2
+  let pathStart = afterAt
+  while (pathStart < end && WHITESPACE.test(frame[pathStart])) pathStart += 1
+  if (pathStart === afterAt) return undefined
+
+  const splits = locationSplits(frame, end)
+  if (splits.length === 0) return undefined
+
+  // `at` is followed by a greedy run of whitespace, so the path starts as late
+  // as that run allows while still leaving itself a character to match.
+  pathStart = Math.min(pathStart, splits[splits.length - 1] - 1)
+  if (pathStart <= afterAt) return undefined
+
+  // Nothing here can start the path any later, so a line break inside it means
+  // there was never a match — unlike the parenthesized shape, whose opening
+  // paren can move.
+  const path = pathBefore(frame, pathStart, splits)
+
+  return path !== undefined && !LINE_TERMINATOR.test(path) ? path : undefined
 }
 
 /**

--- a/packages/server/src/hot-reload/hot-disposables.test.ts
+++ b/packages/server/src/hot-reload/hot-disposables.test.ts
@@ -85,6 +85,20 @@ describe('describeCallerFile', () => {
     expect(describeCallerFile('Error\n    at new BaseMemoryStore (/app/dist/index.js:120:15)')).toBeUndefined()
   })
 
+  test('should not take time superlinear in the length of a frame', () => {
+    // The bare shape previously let a lazy body and a greedy whitespace tail
+    // claim the same spaces. A run of them followed by anything that is not a
+    // location made the two re-divide the run at every offset, so the cost grew
+    // quadratically before the frame was finally rejected. The padding sits
+    // *after* a non-space character on purpose: a frame that is only `at` plus
+    // spaces matches on the first try and never reaches the slow path.
+    const stack = `Error\n    at new Base (/app/dist/index.js:1:1)\n    at a${' '.repeat(100_000)}a`
+    const started = performance.now()
+
+    expect(describeCallerFile(stack)).toBeUndefined()
+    expect(performance.now() - started).toBeLessThan(1_000)
+  })
+
   test('should parse a stack this runtime actually produced', () => {
     // The fixtures above are hand-written, so they would keep passing if the
     // engine changed its stack format and every real key silently became

--- a/packages/server/src/hot-reload/hot-disposables.ts
+++ b/packages/server/src/hot-reload/hot-disposables.ts
@@ -81,6 +81,42 @@ const SYNTHETIC_FRAME_PATHS = new Set(['unknown', 'native', '<anonymous>'])
 
 const LOCATION_SUFFIX = /:\d+(?::\d+)?$/
 
+/** Both match one character, so neither can backtrack the way `\s*` in a pattern can. */
+const WHITESPACE = /\s/
+const LINE_TERMINATOR = /[\n\r\u2028\u2029]/
+
+/**
+ * What a bare `at …` frame carries, with surrounding whitespace dropped.
+ *
+ * Scanned rather than captured with `/^\s*at\s+(.+?)\s*$/`, whose lazy body and
+ * greedy tail both laid claim to the same spaces: a frame padded with a run of
+ * them took time cubic in the run's length before concluding it did not match.
+ */
+function parseBareFrame(frame: string): string | undefined {
+  let end = frame.length
+  while (end > 0 && WHITESPACE.test(frame[end - 1])) end -= 1
+
+  let cursor = 0
+  while (cursor < end && WHITESPACE.test(frame[cursor])) cursor += 1
+  if (!frame.startsWith('at', cursor)) return undefined
+
+  const afterAt = cursor + 2
+  let start = afterAt
+  while (start < end && WHITESPACE.test(frame[start])) start += 1
+  if (start === afterAt) return undefined
+
+  // `at` is followed by a greedy run of whitespace, which gives back the one
+  // character the frame body needs of its own.
+  start = Math.min(start, end - 1)
+  if (start <= afterAt) return undefined
+
+  // A frame body never matched across a line break, so one spanning it is no
+  // body at all. Nothing can start it later, so there is no second chance.
+  const body = frame.slice(start, end)
+
+  return LINE_TERMINATOR.test(body) ? undefined : body
+}
+
 /**
  * The `file:line:column` a single stack frame points at, minus line and column.
  *
@@ -93,7 +129,7 @@ const LOCATION_SUFFIX = /:\d+(?::\d+)?$/
  * function name, so a frame without one yields nothing.
  */
 function parseFrameLocation(frame: string): string | undefined {
-  const location = frame.match(/\(([^()]*)\)\s*$/)?.[1] ?? frame.match(/^\s*at\s+(.+?)\s*$/)?.[1]
+  const location = frame.match(/\(([^()]*)\)\s*$/)?.[1] ?? parseBareFrame(frame)
 
   if (!location || !LOCATION_SUFFIX.test(location)) {
     return undefined

--- a/packages/server/src/hot-reload/hot-disposables.ts
+++ b/packages/server/src/hot-reload/hot-disposables.ts
@@ -91,10 +91,16 @@ const LINE_TERMINATOR = /[\n\r\u2028\u2029]/
  * Scanned rather than captured with `/^\s*at\s+(.+?)\s*$/`, whose lazy body and
  * greedy tail both laid claim to the same spaces: a frame padded with a run of
  * them took time cubic in the run's length before concluding it did not match.
+ *
+ * One case is read differently on purpose. Where the frame is `at` and nothing
+ * but whitespace, the pattern handed back a single space as the body; this
+ * rejects it. The two agree at the only boundary that matters, because a body
+ * carrying no `:line` is discarded by the caller either way.
  */
 function parseBareFrame(frame: string): string | undefined {
-  let end = frame.length
-  while (end > 0 && WHITESPACE.test(frame[end - 1])) end -= 1
+  // `trimEnd` drops exactly the characters `\s` matches, so this is where the
+  // pattern's trailing `\s*$` would have started.
+  const end = frame.trimEnd().length
 
   let cursor = 0
   while (cursor < end && WHITESPACE.test(frame[cursor])) cursor += 1
@@ -104,11 +110,6 @@ function parseBareFrame(frame: string): string | undefined {
   let start = afterAt
   while (start < end && WHITESPACE.test(frame[start])) start += 1
   if (start === afterAt) return undefined
-
-  // `at` is followed by a greedy run of whitespace, which gives back the one
-  // character the frame body needs of its own.
-  start = Math.min(start, end - 1)
-  if (start <= afterAt) return undefined
 
   // A frame body never matched across a line break, so one spanning it is no
   // body at all. Nothing can start it later, so there is no second chance.


### PR DESCRIPTION
## Summary

Follow-up sweep to #265, which rewrote the request-reachable polynomial regexes flagged by CodeQL. This PR handles three more sites with the same shapes, found by review rather than by an open alert (the repo currently has zero open CodeQL alerts — this is hygiene, not alert-clearing).

Measured before changing anything:

- `packages/orm/src/active-connections.ts` — both frame-parsing shapes quadratic (~4.9s at 100k padding characters)
- `packages/server/src/hot-reload/hot-disposables.ts` — the bare `at …` shape quadratic (~5.7s at 100k)
- `packages/cli/src/docs-viewer.ts` — the leading-H1 stripper quadratic in a body holding many `<!--` (~1s at 16k lines)

All three now scan in one pass.

Three further sites from the sweep were measured and deliberately left alone (linear under both JSC and V8, so rewriting them would add risk for no gain):

- `hot-disposables.ts`'s parenthesized shape — `[^()]*` cannot cross a `(`, so the scan across all start positions sums to O(n)
- `docs-config.ts`'s title extraction — the `m` flag anchors `$` at every line end, bounding the backtrack to one line's length
- `docs-links.ts`'s link-definition pattern — `[^\]]+` stops at the first `]` and cannot extend past it

`debug-page.ts`'s `splitLocation` helper was **not** reused for sites 1–2 despite the similar shape: it takes the frame's *last* `(`, while these two need the *leftmost* one to keep a path like `/app (old)/config` whole. Reusing it turns that path into `old)/config` — a regression the existing `active-connections.test.ts` fixture already pins.

### Second commit: review fixes

A Codex review plus a 4-angle simplify pass (reuse / simplification / efficiency / altitude) surfaced that the first commit's `docs-viewer.ts` rewrite was itself still quadratic on two input families — one of them **~2000x slower** than the pattern it replaced (13.8s vs 0.5ms at 64k chars for a single long line of `--> #`). Fixed by resolving a comment's heading end only for the closer actually taken (was resolved eagerly per `-->`), and resuming the line scan at the post-whitespace position instead of the line start.

Also applied several no-behavior-change simplifications surfaced by the same pass: collapsed a redundant accumulator in `active-connections.ts` (both location-split candidates always yield the same leftmost `(`, so tracking a "best" was unnecessary), removed dead clamp/guard lines in `hot-disposables.ts` (0 hits across 500k generated frames), and replaced hand-rolled trailing-whitespace loops with `trimEnd()`.

## Verification

- Differential fuzzing: old regex vs. new scanner, 1.6M+ generated cases across multiple seeds, zero divergence (an earlier round of this did catch 13 real divergences from a `.` vs newline edge case — since fixed)
- All 181 markdown files in the repo, LF and CRLF, byte-identical output for the H1 stripper
- Real `Error().stack` values captured from **built dist bundles** (not just src) — covers implicit-constructor frames (`unknown:1:28`, `native:7:39`) that only appear post-build
- Perf regression tests added for all three sites, each verified to actually fail against the pre-fix code (not just pass trivially)
- `bun run build`, `bun run typecheck`, `bun run test` (3378 tests), `audit:core-first`, `audit:docs` — all green

## Follow-up (not in this PR)

Filed separately: `active-connections.ts` and `hot-disposables.ts` are documented as "twins" but disagree on paths containing parentheses — the ORM side keeps such a path whole, the server side rejects the frame outright. Pre-existing divergence, deliberately left alone here since fixing it is a behavior change outside this PR's scope (exact-equivalence preservation).

## Test plan

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` (3378 pass, 0 fail)
- [x] `bun run audit:core-first`
- [x] `bun run audit:docs`
- [x] Differential fuzz harness (old regex vs. new scanner)
- [x] Dist-boundary check against real built-bundle stack traces