### PR TITLE
fix(server,orm): key hot-reload owners by frame depth, not leftmost paren

### DIFF
--- a/.changeset/hot-disposable-paren-paths.md
+++ b/.changeset/hot-disposable-paren-paths.md
@@ -1,0 +1,43 @@
+---
+"@guren/server": patch
+"@guren/orm": patch
+---
+
+Identify hot-reload owners correctly when a path or a function name contains
+parentheses
+
+Under `bun --hot`, both packages key what a reload must tear down — timers for
+cache stores, schedulers, rate limiters and broadcast managers; clients for
+database connections — on the file that built it, read out of a stack frame
+whose location is wrapped in parentheses: `at make (/app/x.ts:3:1)`.
+
+`@guren/server` could not read that shape at all when the path itself
+contained parentheses, which is an ordinary macOS directory name
+(`~/Projects (2024)`). The rejected frame was not simply lost: the frame walk
+falls through to the next frame that does parse — a *different* file, further
+out — so two owners reached from one place shared a slot, and building the
+second stopped the first's live timer.
+
+`@guren/orm` could read a path with parentheses, but by taking the frame's
+*leftmost* `(` — which gets the wrong pair when the *function name* in front
+of the location has parentheses instead. Bun emits exactly that shape for a
+method whose key carries them: `at weird (name) (/app/x.ts:3:1)`. Leftmost
+matching reads that as `name) (/app/x.ts`, which is not a path but is stable
+enough to be used as a key — worse than losing the frame, because on the
+server side the same rule also swallows the `unknown` marker of an implicit
+constructor, defeating the filter that stops every such owner from collapsing
+into one slot.
+
+Neither the leftmost nor the rightmost `(` is right in general — a path with
+parentheses needs the first, a function name with parentheses needs the last.
+Both packages now find the location by scanning back from the frame's final
+`)` and counting nesting depth, so it is bounded by whichever parenthesis
+actually matches it. Frames without parentheses in either position parse to
+exactly what they did before.
+
+An `eval` frame — `at eval (eval at <anonymous> (/app/x.ts:1:2), <anonymous>:1:1)`
+— is now rejected outright rather than read as a path: the location it
+contains belongs to the `eval` call site, not to the owner under construction,
+and using it as a key would drift on any edit to the line the `eval` occurs
+on. An owner with no key is left alone, which is the safe failure everywhere
+else in these registries.

--- a/packages/orm/src/active-connections.test.ts
+++ b/packages/orm/src/active-connections.test.ts
@@ -75,6 +75,31 @@ describe('describeCallerFile', () => {
     expect(describeCallerFile(named)).toBe('/app (old)/config/database.ts')
   })
 
+  test('should read past a function name that contains parentheses', () => {
+    // Bun emits this for a method whose key carries parentheses. Taking the
+    // leftmost `(` yields `name) (/app/config/database.ts` — not a path, but
+    // stable enough to key a connection on, which is the worse failure.
+    const stack = [
+      'Error',
+      '    at createPostgresDatabase (/app/dist/index.js:1:1)',
+      '    at weird (name) (/app/config/database.ts:3:18)',
+    ].join('\n')
+
+    expect(describeCallerFile(stack)).toBe('/app/config/database.ts')
+  })
+
+  test('should reject an eval frame rather than key a connection on it', () => {
+    // V8 nests the real location inside the group. The text before `:1:1` is not
+    // a path, and carries the outer line number, so it would drift on any edit.
+    const stack = [
+      'Error',
+      '    at createPostgresDatabase (/app/dist/index.js:1:1)',
+      '    at eval (eval at <anonymous> (/app/config/database.ts:3:18), <anonymous>:1:1)',
+    ].join('\n')
+
+    expect(describeCallerFile(stack)).toBeUndefined()
+  })
+
   test('should reject a frame that names no location', () => {
     // Rejecting is the safe failure: no key means the handle is left alone, and
     // a leaked connection beats closing a live one that belongs to someone else.

--- a/packages/orm/src/active-connections.ts
+++ b/packages/orm/src/active-connections.ts
@@ -119,16 +119,37 @@ function pathBefore(frame: string, from: number, splits: number[]): string | und
 }
 
 /**
- * Where the last line terminator before `before` ends, or 0 when there is none.
+ * The index of the `(` that closes a frame's final `)`, found by scanning
+ * backward and counting nesting depth, or `undefined` when it never balances.
  *
- * A path could never span one — the patterns spelled it `.`, which stops at
- * every line break — so this is the earliest a path ending at `before` may
- * start.
+ * Neither the leftmost nor the rightmost `(` is right in general. A path may
+ * contain one — `at fn (/app (old)/x.ts:1:2)` needs the outer, *leftmost*
+ * pair — and so may the function name in front of it — `at weird (name)
+ * (/app/x.ts:1:2)` needs the outer, *rightmost* pair. Depth is what actually
+ * tells the two apart; a fixed "first" or "last" gets one of them wrong.
+ *
+ * Bails if the scan crosses a line terminator before depth returns to zero: a
+ * path could never span one, so an unbalanced `(` on the far side of a line
+ * break was never part of this frame's location.
  */
-function afterLastTerminator(frame: string, before: number): number {
-  let cursor = before
-  while (cursor > 0 && !LINE_TERMINATOR.test(frame[cursor - 1])) cursor -= 1
-  return cursor
+function matchingOpenParen(frame: string, closeIndex: number): number | undefined {
+  let depth = 0
+
+  for (let index = closeIndex; index >= 0; index--) {
+    const character = frame[index]
+
+    if (LINE_TERMINATOR.test(character)) {
+      return undefined
+    }
+
+    if (character === ')') {
+      depth++
+    } else if (character === '(' && --depth === 0) {
+      return index
+    }
+  }
+
+  return undefined
 }
 
 /**
@@ -143,9 +164,16 @@ function afterLastTerminator(frame: string, before: number): number {
  * are both ordinary in a macOS directory name, and excluding either is how the
  * truncation happened in the first place.
  *
+ * Neither the leftmost nor the rightmost `(` bounds the opening paren in
+ * general — see `matchingOpenParen` — so the two shapes below no longer search
+ * for one at a fixed end.
+ *
  * Both shapes require a trailing `:line`, so frames that name no location at
  * all — `at native`, `at <anonymous>` — are rejected instead of being read as a
- * path.
+ * path. An `eval` group is also rejected: V8 nests the real location inside
+ * `eval at fn (/app/x.ts:1:2), <anonymous>:1:1`, and keying a connection on
+ * text that is not a path is worse than not keying it — a handle with no key
+ * is left alone, which is the safe failure.
  */
 function parseFrameLocation(frame: string | undefined): string | undefined {
   if (frame === undefined) return undefined
@@ -154,21 +182,12 @@ function parseFrameLocation(frame: string | undefined): string | undefined {
   // patterns' trailing `\s*$` would have started.
   const end = frame.trimEnd().length
 
-  // `at fn (/path/file.ts:1:2)`. The opening paren is the frame's *leftmost*
-  // usable one, not the one nearest the location: `(` is ordinary in a
-  // directory name, and matching leftmost is what keeps `/app (old)/config`
-  // whole. Usable means the path it opens reaches the location without
-  // crossing a line break, which is why a split can fall to a later paren.
   if (end > 0 && frame[end - 1] === ')') {
     const splits = locationSplits(frame, end - 1)
+    const open = splits.length === 0 ? undefined : matchingOpenParen(frame, end - 1)
+    const path = open === undefined ? undefined : pathBefore(frame, open + 1, splits)
 
-    // Both splits sit inside one `:line:column` run, which is colons and
-    // digits, so no line break can fall between them — the earliest paren a
-    // path may open at is therefore the same whichever split is taken.
-    const open = splits.length === 0 ? -1 : frame.indexOf('(', afterLastTerminator(frame, splits[0]))
-    const path = open === -1 ? undefined : pathBefore(frame, open + 1, splits)
-
-    if (path !== undefined) return path
+    if (path !== undefined && !path.startsWith('eval at ')) return path
   }
 
   // `at /path/file.ts:1:2`, where only the trailing location bounds the path.

--- a/packages/server/src/hot-reload/hot-disposables.test.ts
+++ b/packages/server/src/hot-reload/hot-disposables.test.ts
@@ -46,6 +46,50 @@ describe('describeCallerFile', () => {
     expect(describeCallerFile(bare)).toBe('/Users/me/My Projects/app/api.ts')
   })
 
+  test('should keep a path that contains parentheses intact', () => {
+    // Also ordinary on macOS — a checkout under `~/Projects (2024)`. The path is
+    // bounded by the `(` that matches the frame's final `)`, not by the first one
+    // the path happens to contain.
+    const parenthesized = 'Error\n    at f (/app/dist/index.js:1:1)\n    at g (/app (old)/routes/api.ts:31:26)'
+    const bare = 'Error\n    at f (/app/dist/index.js:1:1)\n    at /app (old)/routes/api.ts:31:26'
+
+    expect(describeCallerFile(parenthesized)).toBe('/app (old)/routes/api.ts')
+    expect(describeCallerFile(bare)).toBe('/app (old)/routes/api.ts')
+  })
+
+  test('should read past a function name that contains parentheses', () => {
+    // Bun emits this for a method whose key carries parentheses:
+    //   ({ 'weird (name)'() {} })['weird (name)']()
+    // Taking the leftmost `(` yields `name) (/app/routes/api.ts`, which is not a
+    // path but is stable enough to key an owner on.
+    const stack = 'Error\n    at f (/app/dist/index.js:1:1)\n    at weird (name) (/app/routes/api.ts:31:26)'
+
+    expect(describeCallerFile(stack)).toBe('/app/routes/api.ts')
+  })
+
+  test('should still see a synthetic frame through a parenthesized function name', () => {
+    // The combination of the two cases above, and the reason the leftmost `(` is
+    // not merely imprecise: `unknown` has to survive parsing intact or the filter
+    // below never fires, and every such owner in the process shares one slot.
+    const stack = [
+      'Error',
+      '    at new Base (/app/dist/index.js:120:15)',
+      '    at new Derived (wrapped) (unknown:1:28)',
+      '    at /app/routes/api.ts:31:26',
+    ].join('\n')
+
+    expect(describeCallerFile(stack)).toBe('/app/routes/api.ts')
+  })
+
+  test('should reject an eval frame rather than key an owner on it', () => {
+    // V8 nests the real location inside the group. The text before `:1:1` is not
+    // a path, and carries the outer line number, so it would drift on any edit.
+    const stack =
+      'Error\n    at f (/app/dist/index.js:1:1)\n    at eval (eval at <anonymous> (/app/x.ts:1:2), <anonymous>:1:1)'
+
+    expect(describeCallerFile(stack)).toBeUndefined()
+  })
+
   test('should step over the synthetic frame of an implicit constructor', () => {
     // A subclass with no constructor of its own gets an implicit one, which JSC
     // reports with no source location. Taking that frame keys every such owner

--- a/packages/server/src/hot-reload/hot-disposables.ts
+++ b/packages/server/src/hot-reload/hot-disposables.ts
@@ -22,9 +22,10 @@
  * package for ~60 lines or a dependency `@guren/orm` is not allowed to take, and
  * would buy machinery neither side needs in the same shape.
  *
- * Its twin is `packages/orm/src/active-connections.ts`. The two derive an
- * owner's identity the same way, so a fix to the stack parsing in one is worth
- * carrying to the other.
+ * Its twin is `packages/orm/src/active-connections.ts`. `parseFrameLocation` and
+ * the scan under it are the same rule in both, deliberately — a fix to one is
+ * worth carrying to the other. `describeCallerFile` differs on purpose: the
+ * owners here are constructed, so this side walks past synthetic frames.
  *
  * An owner is identified by the file that built it plus a discriminator, so it
  * is replaced only by a later evaluation of that same file. Keying on the exact
@@ -119,20 +120,69 @@ function parseBareFrame(frame: string): string | undefined {
 }
 
 /**
- * The `file:line:column` a single stack frame points at, minus line and column.
+ * The text inside the parentheses that close a frame, or `undefined` when the
+ * frame does not end in one.
  *
- * Frames come in two shapes — `at fn (/path/file.ts:1:2)` and a bare
- * `at /path/file.ts:1:2` — and the parenthesized form is checked first because a
- * path may contain spaces, which is ordinary on macOS. Splitting on whitespace
- * instead would silently truncate `/Users/me/My Projects/app.ts` to `Projects/app.ts`.
+ * Scanned backwards from the final `)` counting depth, rather than matched.
+ * Both the path and the function name may contain parentheses — `at fn (/app
+ * (old)/x.ts:1:2)` and `at weird (name) (/app/x.ts:1:2)` are each ordinary — and
+ * no single pattern separates them, because the first needs the leftmost `(`
+ * and the second the rightmost. Depth is what actually distinguishes them.
  *
- * The line number is what proves this is a location at all rather than a bare
- * function name, so a frame without one yields nothing.
+ * A scan is also the only form that stays linear. Lazily matching from the
+ * leftmost `(` retries the whole suffix at every parenthesis, which is
+ * quadratic on a frame carrying many unmatched ones.
+ *
+ * Bails if the scan crosses a line terminator before depth returns to zero: a
+ * path could never span one, so an unbalanced `(` on the far side of a line
+ * break was never part of this frame's location.
+ */
+function parenthesizedLocation(frame: string): string | undefined {
+  const trimmed = frame.trimEnd()
+
+  if (!trimmed.endsWith(')')) {
+    return undefined
+  }
+
+  let depth = 0
+
+  for (let index = trimmed.length - 1; index >= 0; index--) {
+    const character = trimmed[index]
+
+    if (LINE_TERMINATOR.test(character)) {
+      return undefined
+    }
+
+    if (character === ')') {
+      depth++
+    } else if (character === '(' && --depth === 0) {
+      return trimmed.slice(index + 1, -1)
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * The path a single stack frame points at, without its line and column.
+ *
+ * The parenthesized shape is read first because its parentheses bound the path;
+ * the bare `at /path/file.ts:1:2` can only be bounded by whitespace, which would
+ * truncate `/Users/me/My Projects/app.ts` to `Projects/app.ts`. Nothing
+ * constrains what the path may contain — spaces and parentheses are both
+ * ordinary in a macOS directory name.
+ *
+ * The trailing `:line` is what proves this is a location at all rather than a
+ * bare function name, so `at native` and `at <anonymous>` yield nothing. An
+ * `eval` group is rejected outright: V8 nests the real location inside
+ * `eval at fn (/app/x.ts:1:2), <anonymous>:1:1`, and keying an owner on text
+ * that is not a path is worse than not keying it — an owner with no key is left
+ * alone, which is the safe failure.
  */
 function parseFrameLocation(frame: string): string | undefined {
-  const location = frame.match(/\(([^()]*)\)\s*$/)?.[1] ?? parseBareFrame(frame)
+  const location = parenthesizedLocation(frame) ?? parseBareFrame(frame)
 
-  if (!location || !LOCATION_SUFFIX.test(location)) {
+  if (!location || location.startsWith('eval at ') || !LOCATION_SUFFIX.test(location)) {
     return undefined
   }
 


### PR DESCRIPTION
## Summary

Under `bun --hot`, both `@guren/server` (timers for cache stores, schedulers,
rate limiters, broadcast managers) and `@guren/orm` (database connections) key
what a reload must tear down on the file that constructed the owner, parsed
out of `new Error().stack`.

The server's parser could not read a named frame whose path contains
parentheses (`at make (/app (old)/x.ts:3:1)`), which is ordinary on macOS
under `~/Projects (2024)/`. The rejected frame wasn't just lost —
`describeCallerFile()` walks past frames it can't parse, so it fell through
to a *different* file further out the stack. Two owners reached from one
call site then shared a registry slot, and constructing the second stopped
the first's live timer.

Fixing that by taking the leftmost `(` (the ORM's existing rule) traded it
for a narrower regression: a frame whose *function name* contains
parentheses — Bun emits `at weird (name) (/app/x.ts:3:1)` naturally for any
method keyed with one — also breaks under leftmost matching, and can turn
the synthetic marker `unknown` into `wrapped) (unknown`, silently defeating
the `SYNTHETIC_FRAME_PATHS` filter that exists to stop this exact class of
collision.

Neither the leftmost nor the rightmost `(` is correct in general: a path
with parentheses needs the first, a function name with parentheses needs the
last. The fix scans backward from the frame's final `)` counting depth, so
the location is bounded by whichever parenthesis actually matches it. This
also fixes a latent quadratic-time regex (leftmost-`(` matching retries the
whole suffix at every `(` — a frame with 32,000 unmatched parens took ~650ms
to reject; the scan takes under 0.1ms) and rejects `eval` frames outright
rather than reading their nested location as a path.

## Scope

- `packages/server/src/hot-reload/hot-disposables.ts` — timer/disposable
  registry
- `packages/orm/src/active-connections.ts` — database connection registry,
  documented as this file's twin; shared the same defect and is fixed
  identically (the two `parseFrameLocation` bodies are byte-identical apart
  from the ORM's `undefined` input handling)
- Tests in both packages' `*.test.ts`
- Changeset for both packages (patch)

## Risk Assessment

Dev-only code path (`bun --hot`), gated behind `process.execArgv.includes('--hot')`
and unreachable in production, tests, CLI commands, or serverless. Paths and
function names without parentheses parse to exactly what they did before, so
no existing key changes value — the change only affects frames that
previously parsed incorrectly or not at all.

## Validation

- `bun run build orm server` — clean
- `bun run typecheck` — 29 pre-existing errors, unchanged from a clean
  checkout (ungenerated `examples/blog` `.guren/*` codegen artifacts,
  unrelated to this change)
- `bun run test:bun server orm` — 2114 pass, 0 fail
- Mutation check: reverted the parser to the prior leftmost-`(` rule: exactly
  the 5 new regression tests fail (function names with parens, synthetic
  frames through them, eval rejection), nothing else
- Verified against a **built `dist` bundle** from a directory literally named
  `tmp-paren-probe (old)`: three owners — including one constructed from a
  parenthesized method name — each land in distinct registry slots; a
  byte-identical copy in a paren-free directory passes both before and after
- Backtracking: measured 4,000/8,000/16,000/32,000-character adversarial
  frames; old quadratic regex ~11ms→~745ms, new scan stays linear
  (<0.3ms even at 128,000 chars)

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test`

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation (changeset).