### PR TITLE
feat(cli): inline API signature digest into guren context output

### DIFF
--- a/.changeset/context-api-digest.md
+++ b/.changeset/context-api-digest.md
@@ -1,0 +1,9 @@
+---
+"@guren/cli": patch
+---
+
+Append a compact Guren API signature digest to the `guren context` project map
+so coding agents see the exact ORM, controller, and testing signatures at
+session start — before their first edit attaches the glob-scoped rule files.
+Delivered through the agent harness's SessionStart hook and the
+`guren_get_context` MCP tool with no harness re-sync required.

--- a/.changeset/context-api-digest.md
+++ b/.changeset/context-api-digest.md
@@ -5,5 +5,6 @@
 Append a compact Guren API signature digest to the `guren context` project map
 so coding agents see the exact ORM, controller, and testing signatures at
 session start — before their first edit attaches the glob-scoped rule files.
-Delivered through the agent harness's SessionStart hook and the
-`guren_get_context` MCP tool with no harness re-sync required.
+The digest rides on every markdown rendering of the map: the agent harness's
+SessionStart hook and the markdown format of the `guren_get_context` MCP tool.
+Installed apps pick it up with a CLI upgrade alone.

--- a/packages/cli/src/api-digest.ts
+++ b/packages/cli/src/api-digest.ts
@@ -25,7 +25,7 @@ Verified quick reference — trust this and \`.claude/rules/*.md\` over grepping
   terminate with \`get() / first() / firstOrFail() / count() / paginate(page?, perPage?) / update(data) / delete()\`
 - Pagination: \`Model.paginate({ page?, perPage?, where?, orderBy? })\` →
   \`{ data, meta: { total, perPage, currentPage, totalPages, hasMore, from, to } }\`.
-  HTTP/Inertia links: \`paginate(result, { path, query?, fragment? })\` from \`@guren/core\`
+  HTTP/Inertia links: \`paginate(result, { path?, query?, fragment? })\` from \`@guren/core\`
   (those three fields are \`PaginatorOptions\`)
 - Relations (declaration): \`hasOne/hasMany(name, related, foreignKey, localKey)\` ·
   \`belongsTo(name, related, foreignKey, ownerKey)\` ·
@@ -39,8 +39,9 @@ Verified quick reference — trust this and \`.claude/rules/*.md\` over grepping
 ### Controllers (@guren/core)
 - \`await this.validateBody(schema)\` (throws → 422) · \`this.validateQuery(schema)\` · \`this.validateParams(schema)\` — any Zod-like schema
 - \`this.inertia(pages.posts.Show, props)\` · \`this.redirect(url)\` (302 GET, 303 non-GET) · \`this.json(data)\`
-- \`await this.auth.userOrFail<UserRecord>()\` (throws → 401; pass \`<T>\` — the default type has no \`.id\`) ·
-  \`this.auth.user<T>() / check() / login(user) / attempt(credentials) / logout()\`
+- \`this.auth\` — every method is async, always \`await\`: \`userOrFail<UserRecord>()\` (throws → 401;
+  pass \`<T>\` — the default type has no \`.id\`) · \`user<T>()\` · \`check()\` · \`guest()\` ·
+  \`login(user, remember?)\` · \`attempt(credentials, remember?)\` · \`logout()\`
 - Route model binding: route option \`bind: { id: Post }\` + \`this.model(Post)\` (already resolved, 404 on miss)
 - \`await this.authorize('update', [Post, post])\` (throws → 403)
 

--- a/packages/cli/src/api-digest.ts
+++ b/packages/cli/src/api-digest.ts
@@ -1,0 +1,52 @@
+/**
+ * Compact digest of the framework API signatures agents hunt for most.
+ *
+ * Appended to the `guren context` project map so the signatures arrive
+ * *before* any work starts — the map is injected at session start by the
+ * agent harness's SessionStart hook and served by the `guren_get_context`
+ * MCP tool. The glob-scoped rule files under `.claude/rules/` carry the
+ * full, verified reference, but they only attach once a matching file is
+ * edited; most API research happens earlier, so the essentials ride along
+ * here. Keep this digest a strict summary of those rule files — they are
+ * the source of truth, and anything stated here must match them.
+ */
+export const GUREN_API_DIGEST = `## Guren API Signatures (digest)
+
+Verified quick reference — trust this and \`.claude/rules/*.md\` over grepping \`node_modules/@guren/*\`.
+
+### Models (@guren/orm)
+- Statics: \`find(id)\` → record | null · \`findOrFail(id)\` (throws, renders 404) · \`first(where?)\` ·
+  \`all()\` · \`create(data)\` · \`update(where, data)\` · \`delete(where)\` · \`paginate(options?)\` ·
+  \`transaction(async (trx) => ...)\` · \`forceCreate/forceUpdate\` (bypass fillable — never pass request input)
+- Where: \`where({ a: 1, ids: [1, 2] })\` (object = AND, array value = IN) or \`where(field, op, value)\` —
+  operators (exact set): \`=\` \`!=\` \`>\` \`<\` \`>=\` \`<=\` \`like\` \`in\` \`not in\` \`is null\` \`is not null\`
+- QueryBuilder chain: \`where / orWhere / whereNull / whereNotNull / whereIn / whereNotIn /
+  orderBy(field, 'asc' | 'desc') / limit(n) / offset(n) / with(...relations) / scope(name)\` →
+  terminate with \`get() / first() / firstOrFail() / count() / paginate(page?, perPage?) / update(data) / delete()\`
+- Pagination: \`Model.paginate({ page?, perPage?, where?, orderBy? })\` →
+  \`{ data, meta: { total, perPage, currentPage, totalPages, hasMore, from, to } }\`.
+  HTTP/Inertia links: \`paginate(result, { path, query?, fragment? })\` from \`@guren/core\`
+  (those three fields are \`PaginatorOptions\`)
+- Relations (declaration): \`hasOne/hasMany(name, related, foreignKey, localKey)\` ·
+  \`belongsTo(name, related, foreignKey, ownerKey)\` ·
+  \`belongsToMany(name, related, pivotTable, foreignPivotKey, relatedPivotKey, parentKey = 'id', relatedKey = 'id')\`
+  (7 args; \`pivotTable\` is the Drizzle table) ·
+  \`hasManyThrough(name, related, through, firstKey, secondKey, localKey = 'id', secondLocalKey = 'id')\`
+- Eager loading: \`Model.with('tags')\` / \`with(['author', 'tags'], where?)\` / \`with('comments.author')\` ·
+  \`findWith(id, rels)\` · \`findWithOrFail(id, rels)\` · \`withCount('tags')\` · \`withPaginate('tags', { page })\`
+- No \`attach/detach/sync\` — create/delete rows on a pivot model. No \`firstOrCreate/updateOrCreate\` — hand-roll with \`first()\` + \`create()\`
+
+### Controllers (@guren/core)
+- \`await this.validateBody(schema)\` (throws → 422) · \`this.validateQuery(schema)\` · \`this.validateParams(schema)\` — any Zod-like schema
+- \`this.inertia(pages.posts.Show, props)\` · \`this.redirect(url)\` (302 GET, 303 non-GET) · \`this.json(data)\`
+- \`await this.auth.userOrFail<UserRecord>()\` (throws → 401; pass \`<T>\` — the default type has no \`.id\`) ·
+  \`this.auth.user<T>() / check() / login(user) / attempt(credentials) / logout()\`
+- Route model binding: route option \`bind: { id: Post }\` + \`this.model(Post)\` (already resolved, 404 on miss)
+- \`await this.authorize('update', [Post, post])\` (throws → 403)
+
+### Testing (@guren/testing)
+- \`const app = await TestApp.create()\` · \`app.actingAs(user)\` / \`app.json()\` / \`await app.withCsrf()\` — each returns a NEW TestApp
+- \`await app.get('/posts').assertOk()\` · assertions: \`assertStatus / assertCreated / assertRedirect(url?) /
+  assertUnprocessable / assertJson / assertJsonPath(path, value) / assertInertia(component, props?)\`
+
+Full reference and gotchas: \`.claude/rules/orm-models.md\`, \`controllers-http.md\`, \`routes-codegen.md\`, \`testing.md\`.`

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -16,6 +16,7 @@ import {
   readIfExists,
   excludeBarrelFiles,
 } from './discovery'
+import { GUREN_API_DIGEST } from './api-digest'
 import { parseModelFile, type ModelInfo } from './model-parser'
 import { loadContextRoutes, escapeMarkdownTableCell, type ContextRoute } from './context-route'
 import { listInertiaPageIds } from './inertia-pages'
@@ -195,6 +196,12 @@ export function renderContextMarkdown(ctx: ProjectContext): string {
       lines.push('')
     }
   }
+
+  // The digest rides along on every markdown rendering (session-start hook,
+  // MCP guren_get_context, ad-hoc CLI runs) so agents see the signatures
+  // before their first edit attaches the glob-scoped rule files.
+  lines.push(GUREN_API_DIGEST)
+  lines.push('')
 
   return lines.join('\n')
 }

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -197,9 +197,6 @@ export function renderContextMarkdown(ctx: ProjectContext): string {
     }
   }
 
-  // The digest rides along on every markdown rendering (session-start hook,
-  // MCP guren_get_context, ad-hoc CLI runs) so agents see the signatures
-  // before their first edit attaches the glob-scoped rule files.
   lines.push(GUREN_API_DIGEST)
   lines.push('')
 

--- a/packages/cli/templates/agent/.claude/rules/orm-models.md
+++ b/packages/cli/templates/agent/.claude/rules/orm-models.md
@@ -79,7 +79,7 @@ const result = await Post.paginate({ page: 1, perPage: 15, where: {...}, orderBy
 ```
 
 For Inertia/HTTP pagination links wrap it with `paginate` from `@guren/core`:
-`paginate(result, { path, query?, fragment? })` — those three fields are `PaginatorOptions`.
+`paginate(result, { path?, query?, fragment? })` — those three fields are `PaginatorOptions`.
 
 ## Relations — declaration signatures
 

--- a/packages/cli/templates/agent/CLAUDE.md
+++ b/packages/cli/templates/agent/CLAUDE.md
@@ -19,7 +19,9 @@ bunx guren make:adr "..."  # record an architecture decision under docs/adr/ (--
 ```
 
 This project ships with an agent harness wired into `.claude/settings.json`:
-a `SessionStart` hook injects the `guren context` project map, and a
+a `SessionStart` hook injects the `guren context` project map — **including a
+"Guren API Signatures" digest of the ORM, controller, and testing APIs, so the
+exact signatures are already in your context before you write any code** — and a
 `PostToolUse` hook (`.claude/hooks/check-after-edit.ts`) re-runs `guren check`
 after edits to routes, controllers, models, schema, or pages and reports
 failures back immediately. Framework-managed files (`.claude/rules`, `skills`,
@@ -30,8 +32,8 @@ based on the files you are editing (glob-scoped): `orm-models.md` (models, queri
 relations), `controllers-http.md` (validation, Inertia, auth), `routes-codegen.md`
 (route options, schema binding, codegen), `testing.md` (TestApp assertions),
 `docs-and-spec.md` (linked ADRs/docs, generated spec views).
-Read the matching rule file before reading `node_modules/@guren/*` — it covers the
-exact signatures.
+Never grep `node_modules/@guren/*` for signatures — the session-start digest
+plus the matching rule file cover them, verified against this framework version.
 
 ## Project Structure
 

--- a/packages/cli/templates/agent/CLAUDE.md
+++ b/packages/cli/templates/agent/CLAUDE.md
@@ -19,21 +19,22 @@ bunx guren make:adr "..."  # record an architecture decision under docs/adr/ (--
 ```
 
 This project ships with an agent harness wired into `.claude/settings.json`:
-a `SessionStart` hook injects the `guren context` project map — **including a
-"Guren API Signatures" digest of the ORM, controller, and testing APIs, so the
-exact signatures are already in your context before you write any code** — and a
+a `SessionStart` hook injects the `guren context` project map, and a
 `PostToolUse` hook (`.claude/hooks/check-after-edit.ts`) re-runs `guren check`
 after edits to routes, controllers, models, schema, or pages and reports
-failures back immediately. Framework-managed files (`.claude/rules`, `skills`,
-`agents`, `hooks`) can be refreshed anytime with `bunx guren agent:sync`.
+failures back immediately. The injected map ends with a "Guren API Signatures"
+digest of the ORM, controller, and testing APIs — those signatures are already
+in your context before you write any code. Framework-managed files
+(`.claude/rules`, `skills`, `agents`, `hooks`) can be refreshed anytime with
+`bunx guren agent:sync`.
 
 Detailed, verified API rules live in `.claude/rules/*.md` and load automatically
 based on the files you are editing (glob-scoped): `orm-models.md` (models, queries,
 relations), `controllers-http.md` (validation, Inertia, auth), `routes-codegen.md`
 (route options, schema binding, codegen), `testing.md` (TestApp assertions),
 `docs-and-spec.md` (linked ADRs/docs, generated spec views).
-Never grep `node_modules/@guren/*` for signatures — the session-start digest
-plus the matching rule file cover them, verified against this framework version.
+For framework signatures, check the session-start digest first, then the matching
+rule file; only read `node_modules/@guren/*` for APIs neither covers.
 
 ## Project Structure
 

--- a/packages/cli/tests/context.test.ts
+++ b/packages/cli/tests/context.test.ts
@@ -128,4 +128,34 @@ describe('renderContextMarkdown', () => {
     expect(md).toContain('- PostController')
     expect(md).toContain('## Console Commands (1)')
   })
+
+  it('appends the API signature digest so agents get signatures before their first edit', () => {
+    const md = renderContextMarkdown({
+      framework: { name: 'Guren', version: '1.0.0' },
+      models: [],
+      routes: [],
+      pages: [],
+      controllers: [],
+      resources: [],
+      events: [],
+      jobs: [],
+      middleware: [],
+      listeners: [],
+      validators: [],
+      policies: [],
+      commands: [],
+    })
+
+    expect(md).toContain('## Guren API Signatures (digest)')
+    // The signatures agents were observed grepping node_modules for
+    expect(md).toContain('`paginate(result, { path, query?, fragment? })`')
+    expect(md).toContain('PaginatorOptions')
+    expect(md).toContain(
+      '`belongsToMany(name, related, pivotTable, foreignPivotKey, relatedPivotKey, parentKey = \'id\', relatedKey = \'id\')`',
+    )
+    expect(md).toContain('`withPaginate(\'tags\', { page })`')
+    expect(md).toContain('`in` `not in` `is null` `is not null`')
+    // It must route agents to the rule files, not node_modules
+    expect(md).toContain('.claude/rules/orm-models.md')
+  })
 })

--- a/packages/cli/tests/context.test.ts
+++ b/packages/cli/tests/context.test.ts
@@ -1,6 +1,7 @@
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
+import { GUREN_API_DIGEST } from '../src/api-digest'
 import { generateContext, renderContextMarkdown } from '../src/context'
 import { createTempWorkspace } from './helpers'
 
@@ -127,35 +128,43 @@ describe('renderContextMarkdown', () => {
     expect(md).toContain('- posts/Index')
     expect(md).toContain('- PostController')
     expect(md).toContain('## Console Commands (1)')
+    // Delivered at session start via the harness SessionStart hook
+    expect(md).toContain(GUREN_API_DIGEST)
   })
+})
 
-  it('appends the API signature digest so agents get signatures before their first edit', () => {
-    const md = renderContextMarkdown({
-      framework: { name: 'Guren', version: '1.0.0' },
-      models: [],
-      routes: [],
-      pages: [],
-      controllers: [],
-      resources: [],
-      events: [],
-      jobs: [],
-      middleware: [],
-      listeners: [],
-      validators: [],
-      policies: [],
-      commands: [],
+describe('GUREN_API_DIGEST', () => {
+  // The rule files are the source of truth; the digest is a hand-written
+  // summary of them. Each token must appear in BOTH, so a one-sided edit
+  // — fixing a rule file without the digest, or vice versa — fails here.
+  const tokensByRuleFile: Record<string, string[]> = {
+    'orm-models.md': [
+      '`=` `!=` `>` `<` `>=` `<=` `like` `in` `not in` `is null` `is not null`',
+      "belongsToMany(name, related, pivotTable, foreignPivotKey, relatedPivotKey, parentKey = 'id', relatedKey = 'id')",
+      "hasManyThrough(name, related, through, firstKey, secondKey, localKey = 'id', secondLocalKey = 'id')",
+      'paginate(result, { path?, query?, fragment? })',
+      'PaginatorOptions',
+      'withPaginate',
+    ],
+    'controllers-http.md': [
+      'validateBody',
+      'userOrFail',
+      'bind: { id: Post }',
+      "await this.authorize('update', [Post, post])",
+    ],
+    'testing.md': ['actingAs', 'withCsrf', 'assertUnprocessable', 'assertInertia'],
+  }
+
+  for (const [ruleFile, tokens] of Object.entries(tokensByRuleFile)) {
+    it(`stays in sync with the ${ruleFile} rule file`, async () => {
+      const ruleText = await readFile(
+        new URL(`../templates/agent/.claude/rules/${ruleFile}`, import.meta.url),
+        'utf8',
+      )
+      for (const token of tokens) {
+        expect(GUREN_API_DIGEST).toContain(token)
+        expect(ruleText).toContain(token)
+      }
     })
-
-    expect(md).toContain('## Guren API Signatures (digest)')
-    // The signatures agents were observed grepping node_modules for
-    expect(md).toContain('`paginate(result, { path, query?, fragment? })`')
-    expect(md).toContain('PaginatorOptions')
-    expect(md).toContain(
-      '`belongsToMany(name, related, pivotTable, foreignPivotKey, relatedPivotKey, parentKey = \'id\', relatedKey = \'id\')`',
-    )
-    expect(md).toContain('`withPaginate(\'tags\', { page })`')
-    expect(md).toContain('`in` `not in` `is null` `is not null`')
-    // It must route agents to the rule files, not node_modules
-    expect(md).toContain('.claude/rules/orm-models.md')
-  })
+  }
 })


### PR DESCRIPTION
## Summary

Coding-agent session traces showed that most `node_modules/@guren/*/dist` grepping for framework signatures (`paginate`/`PaginatorOptions`, `belongsToMany`, `withPaginate`, the `where` operator set) happens **before the agent's first edit**, during API research. The glob-scoped `.claude/rules/*.md` files that document exactly these signatures only attach on edit of a matching file, so they arrive too late — and the CLAUDE.md instruction to read them first is routinely ignored. Injected content, by contrast, is reliably read.

This PR pushes the signatures instead of pointing at them:

- **New `packages/cli/src/api-digest.ts`** — a compact digest of the most-hunted ORM, controller, and testing signatures, kept as a strict summary of the rule files (which remain the source of truth) and ending with pointers to them.
- **`renderContextMarkdown()` appends the digest**, so it rides along on every markdown rendering of the project map: the agent harness's `SessionStart` hook (`bunx guren context`), the markdown format of the `guren_get_context` MCP tool, and ad-hoc CLI runs. `--json` output is unchanged.
- **Harness template `CLAUDE.md`** now states the signatures are already in context at session start and sets the lookup order: digest → matching rule file → `node_modules/@guren/*` only for what neither covers.
- **Drift guard test**: key signature tokens must appear in *both* the digest and the rule file it summarizes, so a one-sided edit to either fails `packages/cli` tests (mutation-tested by reverting one side).

Delivery is the point of the design: `CLAUDE.md` and `.claude/settings.json` are user-owned (never rewritten by `agent:sync`), but the SessionStart hook just runs `bunx guren context` — so every installed app picks up the digest on a CLI upgrade alone.

Review pass fixed two accuracy issues before merge: `PaginatorOptions.path` is optional (`{ path?, query?, fragment? }` — also corrected in `orm-models.md`, which had the same drift), and every `this.auth` method is async, which the digest now states explicitly so agents don't write `if (this.auth.check())`.

Digest signatures were checked against the source declarations (`belongsToMany` 7-arg form, `hasManyThrough`, `withPaginate`, `PaginatorOptions`, model statics, `AuthContext`).

## Testing

- `bun run test:bun` — full suite green (includes the new drift-guard tests)
- `bun run test:examples` — 91 pass
- `bun run typecheck` — clean
- `bun run audit:core-first`, `audit:docs`, `audit:starter-template`, `audit:template-deps` — pass
- `bun run smoke:starter` and `smoke:starter:api` — pass (template files touched)