### PR TITLE
fix(server,orm): match a stack frame's paren by depth on the debug page

### DIFF
--- a/packages/orm/src/active-connections.test.ts
+++ b/packages/orm/src/active-connections.test.ts
@@ -75,6 +75,20 @@ describe('describeCallerFile', () => {
     expect(describeCallerFile(named)).toBe('/app (old)/config/database.ts')
   })
 
+  test('should key a path that contains an unmatched closing parenthesis', () => {
+    // Nothing in the frame closes it, so counting depth alone runs off the front
+    // and the frame is skipped — the walk then keys the connection on whichever
+    // caller sits above it, collapsing every handle built through that caller
+    // into one slot. The leftmost `(` is the reading that keeps the path whole.
+    const stack = [
+      'Error',
+      '    at createPostgresDatabase (/app/dist/index.js:1:1)',
+      '    at makeDatabase (/app/name).ts:3:18)',
+    ].join('\n')
+
+    expect(describeCallerFile(stack)).toBe('/app/name).ts')
+  })
+
   test('should read past a function name that contains parentheses', () => {
     // Bun emits this for a method whose key carries parentheses. Taking the
     // leftmost `(` yields `name) (/app/config/database.ts` — not a path, but

--- a/packages/orm/src/active-connections.ts
+++ b/packages/orm/src/active-connections.ts
@@ -82,6 +82,14 @@ function isHotReloadRuntime(): boolean {
 const WHITESPACE = /\s/
 const LINE_TERMINATOR = /[\n\r\u2028\u2029]/
 
+const OPEN_PAREN = 0x28
+const CLOSE_PAREN = 0x29
+
+/** The characters a stack frame can never span, so a scan stops at them. */
+function isLineTerminator(code: number): boolean {
+  return code === 0x0a || code === 0x0d || code === 0x2028 || code === 0x2029
+}
+
 function isDigitAt(text: string, index: number): boolean {
   const code = text.charCodeAt(index)
   return code >= 48 && code <= 57
@@ -119,8 +127,9 @@ function pathBefore(frame: string, from: number, splits: number[]): string | und
 }
 
 /**
- * The index of the `(` that closes a frame's final `)`, found by scanning
- * backward and counting nesting depth, or `undefined` when it never balances.
+ * The index of the `(` that matches the `)` at `closeIndex`, or `undefined`
+ * when the frame carries no usable `(` at all. `closeIndex` must point at the
+ * frame's final `)`; anything else is rejected.
  *
  * Neither the leftmost nor the rightmost `(` is right in general. A path may
  * contain one — `at fn (/app (old)/x.ts:1:2)` needs the outer, *leftmost*
@@ -128,28 +137,46 @@ function pathBefore(frame: string, from: number, splits: number[]): string | und
  * (/app/x.ts:1:2)` needs the outer, *rightmost* pair. Depth is what actually
  * tells the two apart; a fixed "first" or "last" gets one of them wrong.
  *
- * Bails if the scan crosses a line terminator before depth returns to zero: a
- * path could never span one, so an unbalanced `(` on the far side of a line
- * break was never part of this frame's location.
+ * Depth alone would reject a frame whose location holds an *unmatched* `)`, as
+ * `/app/name).ts` or a URL ending `?label=)` does — the scan runs off the front
+ * still owing a paren. So the leftmost `(` it passed is kept as a fallback for
+ * exactly that case. Only frames the depth rule rejects outright can reach it.
+ *
+ * The scan stops at a line terminator: a path could never span one, so neither
+ * a balanced `(` nor the fallback may come from the far side of a break.
+ * Characters are compared by code rather than tested against `LINE_TERMINATOR`
+ * because this loop runs over every character of every frame.
+ *
+ * Its twin is `packages/server/src/support/stack-frames.ts`. The body there is
+ * identical character for character on purpose; only this prose differs. Keep
+ * the two in step.
  */
 function matchingOpenParen(frame: string, closeIndex: number): number | undefined {
+  if (frame.charCodeAt(closeIndex) !== CLOSE_PAREN) {
+    return undefined
+  }
+
   let depth = 0
+  let leftmostOpen: number | undefined
 
   for (let index = closeIndex; index >= 0; index--) {
-    const character = frame[index]
+    const code = frame.charCodeAt(index)
 
-    if (LINE_TERMINATOR.test(character)) {
-      return undefined
+    if (isLineTerminator(code)) {
+      break
     }
 
-    if (character === ')') {
+    if (code === CLOSE_PAREN) {
       depth++
-    } else if (character === '(' && --depth === 0) {
-      return index
+    } else if (code === OPEN_PAREN) {
+      if (--depth === 0) {
+        return index
+      }
+      leftmostOpen = index
     }
   }
 
-  return undefined
+  return leftmostOpen
 }
 
 /**

--- a/packages/server/src/errors/debug-page.test.ts
+++ b/packages/server/src/errors/debug-page.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from 'bun:test'
+import { renderDebugPage } from './debug-page'
+
+interface RenderedFrame {
+  func: string
+  location: string
+}
+
+const FRAME_PATTERN = /<span class="frame-method">([^<]*)<\/span>\s*<span class="frame-location">([^<]*)<\/span>/g
+
+/** Inverse of the page's own escaper, over the entities these fixtures produce. */
+function unescapeHtml(text: string): string {
+  return text.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&')
+}
+
+function pageFor(...frames: string[]): string {
+  const error = new Error('boom')
+  error.stack = ['Error: boom', ...frames].join('\n')
+  return renderDebugPage(error)
+}
+
+/**
+ * The frames a rendered page shows, which is the only form a developer ever
+ * sees — `parseStackTrace` itself is internal, and asserting on it would let the
+ * two halves of a frame be reported under the wrong headings unnoticed.
+ */
+function framesIn(html: string): RenderedFrame[] {
+  return [...html.matchAll(FRAME_PATTERN)].map(([, func, location]) => ({
+    func: unescapeHtml(func),
+    location: unescapeHtml(location),
+  }))
+}
+
+function framesOf(...frames: string[]): RenderedFrame[] {
+  return framesIn(pageFor(...frames))
+}
+
+describe('renderDebugPage stack frames', () => {
+  test('should read a frame that carries a function name', () => {
+    expect(framesOf('    at makeStore (/app/config/cache.ts:3:18)')).toEqual([
+      { func: 'makeStore', location: '/app/config/cache.ts:3:18' },
+    ])
+  })
+
+  test('should read a bare frame as anonymous', () => {
+    expect(framesOf('    at /app/config/cache.ts:3:18')).toEqual([
+      { func: '<anonymous>', location: '/app/config/cache.ts:3:18' },
+    ])
+  })
+
+  test('should keep a path that contains parentheses intact', () => {
+    // Ordinary on macOS — a checkout under `~/Projects (old)`. The path is
+    // bounded by the `(` that matches the frame's final `)`, not by the last one
+    // the frame happens to contain: taking that one reports the file as
+    // `old)/app/config/cache.ts`, a path that exists nowhere.
+    expect(framesOf('    at makeStore (/Users/me/Projects (old)/app/config/cache.ts:3:18)')).toEqual([
+      { func: 'makeStore', location: '/Users/me/Projects (old)/app/config/cache.ts:3:18' },
+    ])
+
+    expect(framesOf('    at /Users/me/Projects (old)/app/config/cache.ts:3:18')).toEqual([
+      { func: '<anonymous>', location: '/Users/me/Projects (old)/app/config/cache.ts:3:18' },
+    ])
+  })
+
+  test('should keep a path that contains spaces intact', () => {
+    expect(framesOf('    at /Users/me/My Projects/app/config/cache.ts:3:18')).toEqual([
+      { func: '<anonymous>', location: '/Users/me/My Projects/app/config/cache.ts:3:18' },
+    ])
+  })
+
+  test('should read past a function name that contains parentheses', () => {
+    // Emitted for a method whose key carries parentheses:
+    //   ({ 'weird (name)'() {} })['weird (name)']()
+    // Here the *rightmost* `(` is the correct one — the opposite of the case
+    // above, which is why neither end of the frame can be trusted on its own.
+    expect(framesOf('    at weird (name) (/app/config/cache.ts:3:18)')).toEqual([
+      { func: 'weird (name)', location: '/app/config/cache.ts:3:18' },
+    ])
+  })
+
+  test('should split a frame whose name and path both contain parentheses', () => {
+    // One developer's checkout directory away from the case above, and the
+    // reason the split counts nesting depth rather than preferring one end:
+    // every fixed choice of `(` gets this frame wrong.
+    expect(framesOf('    at weird (name) (/app (old)/config/cache.ts:3:18)')).toEqual([
+      { func: 'weird (name)', location: '/app (old)/config/cache.ts:3:18' },
+    ])
+  })
+
+  test('should keep a path that contains an unmatched closing parenthesis', () => {
+    // Nothing in the frame closes it, so counting depth alone runs off the
+    // front and would drop the frame rather than show the location sitting
+    // right there. Rarer than the case above, but a lost frame is worse than a
+    // mis-split one.
+    expect(framesOf('    at makeStore (/app/name).ts:3:18)')).toEqual([
+      { func: 'makeStore', location: '/app/name).ts:3:18' },
+    ])
+  })
+
+  test('should drop a frame that names no location', () => {
+    expect(framesOf('    at Object.<anonymous>', '    at makeStore (/app/config/cache.ts:3:18)')).toEqual([
+      { func: 'makeStore', location: '/app/config/cache.ts:3:18' },
+    ])
+  })
+
+  test('should drop a frame that carries a line but no column', () => {
+    // Unlike the hot-reload registry, which keys owners on the path alone and
+    // so accepts a bare `:line`, this page prints `file:line:col` and has
+    // nothing to show for a frame missing either half.
+    expect(framesOf('    at makeStore (/app/config/cache.ts:3)')).toEqual([])
+  })
+
+  test('should report how many frames it parsed', () => {
+    const html = pageFor('    at a (/app/x.ts:1:2)', '    at b (/app/y.ts:3:4)')
+
+    expect(html).toContain('<span class="badge">2 frames</span>')
+  })
+
+  test('should say so when there is no stack trace', () => {
+    const error = new Error('boom')
+    error.stack = undefined
+
+    expect(renderDebugPage(error)).toContain('No stack trace available.')
+  })
+
+  test('should HTML-escape frames so a crafted path cannot inject markup', () => {
+    const html = pageFor('    at <script>alert(1)</script> (/app/<img src=x>.ts:3:18)')
+
+    // Both halves, from the one render: the markup must be inert *and* still
+    // shown — a frame that was silently dropped would also pass `not.toContain`.
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(html).not.toContain('<script>alert(1)</script>')
+    expect(framesIn(html)).toEqual([
+      { func: '<script>alert(1)</script>', location: '/app/<img src=x>.ts:3:18' },
+    ])
+  })
+})

--- a/packages/server/src/errors/debug-page.ts
+++ b/packages/server/src/errors/debug-page.ts
@@ -1,4 +1,5 @@
 import type { MiddlewareHandler } from 'hono'
+import { matchingOpenParen } from '../support/stack-frames'
 
 /**
  * Render a rich HTML debug error page for development mode.
@@ -175,6 +176,10 @@ function splitLocation(location: string): { file: string; line: string; col: str
 // Parsed with string operations instead of `/\s+at\s+(.+?)\s+\((.+?):…/`,
 // whose lazy groups backtrack polynomially — error stacks can embed
 // request-derived messages.
+//
+// The parenthesized shape is read first because its parentheses bound the path;
+// only the bare shape has to fall back to whitespace, which truncates a path
+// that contains any.
 function parseStackTrace(stack: string): StackFrame[] {
   const lines = stack.split('\n').slice(1)
   return lines
@@ -185,8 +190,10 @@ function parseStackTrace(stack: string): StackFrame[] {
 
       // Format: at functionName (file:line:col)
       if (rest.endsWith(')')) {
-        const open = rest.lastIndexOf('(')
-        if (open > 0) {
+        const open = matchingOpenParen(rest, rest.length - 1)
+        // `open === 0` leaves no room for a function name in front of the
+        // group, so that frame is read as the bare shape below instead.
+        if (open !== undefined && open > 0) {
           const location = splitLocation(rest.slice(open + 1, -1))
           if (location) {
             return { func: rest.slice(0, open).trim(), ...location }

--- a/packages/server/src/hot-reload/hot-disposables.test.ts
+++ b/packages/server/src/hot-reload/hot-disposables.test.ts
@@ -57,6 +57,16 @@ describe('describeCallerFile', () => {
     expect(describeCallerFile(bare)).toBe('/app (old)/routes/api.ts')
   })
 
+  test('should key a path that contains an unmatched closing parenthesis', () => {
+    // Nothing in the frame closes it, so counting depth alone runs off the front
+    // and the frame is skipped — the walk then keys the owner on whichever
+    // caller sits above it, collapsing every owner built through that caller
+    // into one slot. The leftmost `(` is the reading that keeps the path whole.
+    const stack = 'Error\n    at f (/app/dist/index.js:1:1)\n    at g (/app/name).ts:31:26)'
+
+    expect(describeCallerFile(stack)).toBe('/app/name).ts')
+  })
+
   test('should read past a function name that contains parentheses', () => {
     // Bun emits this for a method whose key carries parentheses:
     //   ({ 'weird (name)'() {} })['weird (name)']()

--- a/packages/server/src/hot-reload/hot-disposables.ts
+++ b/packages/server/src/hot-reload/hot-disposables.ts
@@ -22,14 +22,20 @@
  * the same shape.
  *
  * Its twin is `packages/orm/src/active-connections.ts`. `parseFrameLocation` and
- * the scan under it follow the same rule in both, and `describeCallerFile`'s
- * walk past a synthetic frame is identical too — a fix to either has to be
- * carried to the other by hand. That has already failed once: this walk
- * predates the ORM's, and the ORM kept keying handles to `unknown` in the
- * meantime. Nothing forces the duplication — `@guren/server` already depends on
- * `@guren/orm`, so this layer could live there and be imported here — it is
- * only that the shared part is small next to the two packages' very different
- * teardown semantics (see above). Extract it if it drifts a third time.
+ * `describeCallerFile`'s walk past a synthetic frame follow the same rule in
+ * both — a fix to either has to be carried to the other by hand. That has
+ * already failed once: this walk predates the ORM's, and the ORM kept keying
+ * handles to `unknown` in the meantime. Nothing forces the duplication —
+ * `@guren/server` already depends on `@guren/orm`, so this layer could live
+ * there and be imported here — it is only that the shared part is small next to
+ * the two packages' very different teardown semantics (see above). Extract the
+ * rest if it drifts again.
+ *
+ * One piece already went that way, for a reason worth recording: the debug error
+ * page turned out to read frames too, and had written its own, wrong version of
+ * the paren rule. That scan now lives in `../support/stack-frames`, imported by
+ * both readers in this package — the ORM's copy of it is still hand-synced like
+ * everything else here.
  *
  * An owner is identified by the file that built it plus a discriminator, so it
  * is replaced only by a later evaluation of that same file. Keying on the exact
@@ -38,6 +44,8 @@
  * timer it was holding, during the very workflow this exists to fix. The file is
  * stable across every edit that isn't a rename.
  */
+
+import { matchingOpenParen } from '../support/stack-frames'
 
 type Dispose = () => void
 
@@ -128,19 +136,9 @@ function parseBareFrame(frame: string): string | undefined {
  * The text inside the parentheses that close a frame, or `undefined` when the
  * frame does not end in one.
  *
- * Scanned backwards from the final `)` counting depth, rather than matched.
- * Both the path and the function name may contain parentheses — `at fn (/app
- * (old)/x.ts:1:2)` and `at weird (name) (/app/x.ts:1:2)` are each ordinary — and
- * no single pattern separates them, because the first needs the leftmost `(`
- * and the second the rightmost. Depth is what actually distinguishes them.
- *
- * A scan is also the only form that stays linear. Lazily matching from the
- * leftmost `(` retries the whole suffix at every parenthesis, which is
- * quadratic on a frame carrying many unmatched ones.
- *
- * Bails if the scan crosses a line terminator before depth returns to zero: a
- * path could never span one, so an unbalanced `(` on the far side of a line
- * break was never part of this frame's location.
+ * Which `(` opens them is `matchingOpenParen`'s problem — both the path and the
+ * function name in front of it may contain parentheses, and neither end of the
+ * frame is the right place to look in general.
  */
 function parenthesizedLocation(frame: string): string | undefined {
   const trimmed = frame.trimEnd()
@@ -149,23 +147,9 @@ function parenthesizedLocation(frame: string): string | undefined {
     return undefined
   }
 
-  let depth = 0
+  const open = matchingOpenParen(trimmed, trimmed.length - 1)
 
-  for (let index = trimmed.length - 1; index >= 0; index--) {
-    const character = trimmed[index]
-
-    if (LINE_TERMINATOR.test(character)) {
-      return undefined
-    }
-
-    if (character === ')') {
-      depth++
-    } else if (character === '(' && --depth === 0) {
-      return trimmed.slice(index + 1, -1)
-    }
-  }
-
-  return undefined
+  return open === undefined ? undefined : trimmed.slice(open + 1, -1)
 }
 
 /**

--- a/packages/server/src/support/stack-frames.test.ts
+++ b/packages/server/src/support/stack-frames.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test'
+import { matchingOpenParen } from './stack-frames'
+
+/**
+ * What the frame's location group would be, read through the index under test.
+ * Both callers slice with it, so this is the property that matters — the index
+ * itself is only meaningful next to the text on either side of it.
+ */
+function groupIn(frame: string): string | undefined {
+  const open = matchingOpenParen(frame, frame.length - 1)
+  return open === undefined ? undefined : frame.slice(open + 1, -1)
+}
+
+describe('matchingOpenParen', () => {
+  test('should take the leftmost pair when the path contains parentheses', () => {
+    // Ordinary on macOS — a checkout under `~/Projects (old)`.
+    expect(groupIn('at fn (/app (old)/x.ts:1:2)')).toBe('/app (old)/x.ts:1:2')
+  })
+
+  test('should take the rightmost pair when the function name contains parentheses', () => {
+    // A method whose key carries them: ({ 'weird (name)'() {} })['weird (name)']()
+    expect(groupIn('at weird (name) (/app/x.ts:1:2)')).toBe('/app/x.ts:1:2')
+  })
+
+  test('should split a frame where both contain parentheses', () => {
+    // The two cases above want opposite ends of the frame, so this one is
+    // misread by any rule that picks a fixed end. Only depth gets it right.
+    expect(groupIn('at weird (name) (/app (old)/x.ts:1:2)')).toBe('/app (old)/x.ts:1:2')
+  })
+
+  test('should fall back to the leftmost paren when the frame never balances', () => {
+    // An unmatched `)` inside the location — a directory literally named
+    // `name)`, or a URL carrying one — leaves the depth scan owing a paren when
+    // it runs off the front. Dropping the frame loses a location that is right
+    // there; the leftmost `(` is the reading that keeps it whole.
+    expect(groupIn('at fn (/app/name).ts:1:2)')).toBe('/app/name).ts:1:2')
+    expect(groupIn('at fn (file:///app/x.ts?label=):1:2)')).toBe('file:///app/x.ts?label=):1:2')
+  })
+
+  test('should return undefined when the frame carries no opening paren', () => {
+    expect(groupIn('at fn /app/x.ts:1:2)')).toBeUndefined()
+  })
+
+  test('should reject an index that does not point at a closing paren', () => {
+    // Both callers establish the trailing `)` themselves; a frame that ends any
+    // other way has no group to find, and must not be read as if it had one.
+    expect(matchingOpenParen('at fn (/app/x.ts:1:2', 19)).toBeUndefined()
+  })
+
+  test('should not reach a paren on the far side of a line terminator', () => {
+    // U+2028 and U+2029 end a line without being `\n`, so a caller that split
+    // the stack on `\n` can still hand one over. Neither the balanced paren nor
+    // the fallback may come from beyond it.
+    expect(groupIn('at fn (/app/x.ts:1:2\u2028 tail)')).toBeUndefined()
+    expect(groupIn('at fn (\u2029/app/x.ts:1:2)')).toBeUndefined()
+  })
+
+  test('should not take time superlinear in the length of a frame', () => {
+    // Lazily matching from the leftmost `(` retried the whole suffix at every
+    // parenthesis. A run of unmatched ones is what made that quadratic — and a
+    // run of `)` is also what drives this scan all the way to the front, so the
+    // fallback is what answers here.
+    const frame = `at fn (/app/${')'.repeat(200_000)}x.ts:1:2)`
+    const started = performance.now()
+
+    expect(groupIn(frame)).toBe(frame.slice(frame.indexOf('(') + 1, -1))
+    expect(performance.now() - started).toBeLessThan(1_000)
+  })
+})

--- a/packages/server/src/support/stack-frames.ts
+++ b/packages/server/src/support/stack-frames.ts
@@ -1,0 +1,91 @@
+/**
+ * Which `(` opens the parenthesized location group at the end of a stack frame.
+ *
+ * That one question is all the package's two frame readers agree on — the debug
+ * error page's `parseStackTrace` and the hot-reload registry's
+ * `parseFrameLocation`. Everything after it differs on purpose: peeling
+ * `:line[:column]` off the right (the page requires a column and keeps the
+ * function name; the registry accepts a bare `:line`), and deciding which
+ * locations are worth keeping at all (the registry rejects `eval` groups and
+ * synthetic paths, because keying an owner on text that is not a path is worse
+ * than not keying it; the page is happy to display whatever it was handed).
+ * Keep every parenthesis fix here so those two cannot drift.
+ *
+ * A third reader, `packages/orm/src/active-connections.ts`, carries a copy of
+ * the function below whose *body* is identical character for character; only
+ * the prose around it differs, to speak about connections rather than frames.
+ * That package must not import this one, so the two are kept in step by hand —
+ * fix both, or neither.
+ */
+
+const OPEN_PAREN = 0x28
+const CLOSE_PAREN = 0x29
+
+/** The characters a stack frame can never span, so a scan stops at them. */
+function isLineTerminator(code: number): boolean {
+  return code === 0x0a || code === 0x0d || code === 0x2028 || code === 0x2029
+}
+
+/**
+ * The index of the `(` that matches the `)` at `closeIndex`, or `undefined`
+ * when the frame carries no usable `(` at all.
+ *
+ * `closeIndex` is a parameter rather than derived here because each caller
+ * already knows where its frame ends and gets there differently — two trim a
+ * copy of the frame, the ORM's twin keeps an `end` offset to avoid allocating
+ * one. It must point at the frame's final `)`; anything else is rejected.
+ *
+ * Neither the leftmost nor the rightmost `(` is right in general. A path may
+ * contain one — `at fn (/app (old)/x.ts:1:2)` needs the outer, *leftmost* pair
+ * — and so may the function name in front of it — `at weird (name)
+ * (/app/x.ts:1:2)` needs the outer, *rightmost* pair. Depth is what actually
+ * tells the two apart; a fixed "first" or "last" gets one of them wrong, and a
+ * frame carrying both — `at weird (name) (/app (old)/x.ts:1:2)`, which is one
+ * developer's checkout directory away from ordinary — is misread by either.
+ *
+ * A scan is also the only form that stays linear. Lazily matching from the
+ * leftmost `(` retries the whole suffix at every parenthesis, which is
+ * quadratic on a frame carrying many unmatched ones. Characters are compared by
+ * code rather than tested against a pattern for the same reason the patterns
+ * went: this loop runs over every character of every frame, and the one input
+ * whose length nothing bounds is a frame — an error message can embed
+ * request-derived text, and a continuation line of one that starts `at ` and
+ * ends `)` is scanned in full.
+ *
+ * Depth alone would reject a frame whose location holds an *unmatched* `)`, as
+ * `/app/name).ts` or a URL ending `?label=)` does — the scan runs off the front
+ * still owing a paren, and the frame is dropped rather than displayed. So the
+ * leftmost `(` the scan passed is kept as a fallback for exactly that case.
+ * Only frames the depth rule rejects outright can reach it, so it is never
+ * worse than depth alone, and it is the reading that keeps such a path whole.
+ *
+ * The scan stops at a line terminator: a path could never span one, so neither
+ * a balanced `(` nor the fallback may come from the far side of a break.
+ */
+export function matchingOpenParen(frame: string, closeIndex: number): number | undefined {
+  if (frame.charCodeAt(closeIndex) !== CLOSE_PAREN) {
+    return undefined
+  }
+
+  let depth = 0
+  let leftmostOpen: number | undefined
+
+  for (let index = closeIndex; index >= 0; index--) {
+    const code = frame.charCodeAt(index)
+
+    if (isLineTerminator(code)) {
+      break
+    }
+
+    if (code === CLOSE_PAREN) {
+      depth++
+    } else if (code === OPEN_PAREN) {
+      if (--depth === 0) {
+        return index
+      }
+      leftmostOpen = index
+    }
+  }
+
+  return leftmostOpen
+}


### PR DESCRIPTION
## Summary

- The debug error page's `parseStackTrace` picked a frame's opening paren with `rest.lastIndexOf('(')`. For a path containing parentheses — ordinary on macOS ("Projects (old)") — this splits in the wrong place, e.g. `at makeStore (/Users/me/Projects (old)/app/config/cache.ts:3:18)` parsed to `func: "makeStore (/Users/me/Projects"`, `file: "old)/app/config/cache.ts"`.
- Extracted the depth-counting paren scan already used by `packages/server/src/hot-reload/hot-disposables.ts` (fixed in #277/#278) into a new shared `packages/server/src/support/stack-frames.ts`, and made both the debug page and the hot-reload registry call it. Only the paren-matching shape is shared; each reader's acceptance rules (line/column requirements, `eval` rejection, synthetic-path filtering, keeping the function name) stay separate on purpose.
- While consolidating, found and fixed a narrower pre-existing gap in the depth-counting approach itself: a frame whose location holds an *unmatched* `)` (e.g. `/app/name).ts`, or a URL ending `?label=)`) made the depth count run off the front of the frame and drop it entirely, where the old `lastIndexOf` at least displayed something. The scan now falls back to the leftmost `(` it passed whenever depth never balances — reached only when the depth rule already rejects the frame outright, so it's never worse than before.
- `packages/orm/src/active-connections.ts` carries a hand-synced copy of the same function (that package must not import `@guren/server`), so the same fix — including the new fallback — was ported there too, with matching test coverage.

## Test plan

- [x] `bun test packages/server/src/support packages/server/src/errors packages/server/src/hot-reload packages/orm/src/active-connections.test.ts` — 116 pass / 0 fail
- [x] `bun run test:bun` (full suite, after building `orm`/`server`/`core`) — 3454 pass / 0 fail
- [x] `bun run typecheck` — clean under `packages/` (pre-existing `examples/blog` `.guren/*.gen` codegen-artifact errors are unrelated to this change)
- [x] Mutation check: reverting the fallback removal and reverting to `lastIndexOf('(')` each reproduce the exact failures described above