### PR TITLE
docs(cli): close round-6 digest gaps (paginator wire shapes, empty-in)

### DIFF
--- a/packages/cli/src/api-digest.ts
+++ b/packages/cli/src/api-digest.ts
@@ -19,14 +19,16 @@ Verified quick reference — trust this and \`.claude/rules/*.md\` over grepping
   \`all()\` · \`create(data)\` · \`update(where, data)\` · \`delete(where)\` · \`paginate(options?)\` ·
   \`transaction(async (trx) => ...)\` · \`forceCreate/forceUpdate\` (bypass fillable — never pass request input)
 - Where: \`where({ a: 1, ids: [1, 2] })\` (object = AND, array value = IN) or \`where(field, op, value)\` —
-  operators (exact set): \`=\` \`!=\` \`>\` \`<\` \`>=\` \`<=\` \`like\` \`in\` \`not in\` \`is null\` \`is not null\`
+  operators (exact set): \`=\` \`!=\` \`>\` \`<\` \`>=\` \`<=\` \`like\` \`in\` \`not in\` \`is null\` \`is not null\`.
+  An empty \`in\` array compiles to SQL \`false\` — matches nothing, never throws
 - QueryBuilder chain: \`where / orWhere / whereNull / whereNotNull / whereIn / whereNotIn /
   orderBy(field, 'asc' | 'desc') / limit(n) / offset(n) / with(...relations) / scope(name)\` →
   terminate with \`get() / first() / firstOrFail() / count() / paginate(page?, perPage?) / update(data) / delete()\`
 - Pagination: \`Model.paginate({ page?, perPage?, where?, orderBy? })\` →
-  \`{ data, meta: { total, perPage, currentPage, totalPages, hasMore, from, to } }\`.
+  \`{ data, meta: { total, perPage, currentPage, totalPages, hasMore, from, to } }\` — no \`links\`.
   HTTP/Inertia links: \`paginate(result, { path?, query?, fragment? })\` from \`@guren/core\`
-  (those three fields are \`PaginatorOptions\`)
+  (those three fields are \`PaginatorOptions\`); it serializes as \`{ data, meta, links }\`.
+  In tests assert the shape the route actually returns, e.g. \`assertJsonPath('meta.total', 3)\`
 - Relations (declaration): \`hasOne/hasMany(name, related, foreignKey, localKey)\` ·
   \`belongsTo(name, related, foreignKey, ownerKey)\` ·
   \`belongsToMany(name, related, pivotTable, foreignPivotKey, relatedPivotKey, parentKey = 'id', relatedKey = 'id')\`

--- a/packages/cli/templates/agent/.claude/rules/orm-models.md
+++ b/packages/cli/templates/agent/.claude/rules/orm-models.md
@@ -58,6 +58,9 @@ await Post.where('views', '>', 100).orWhere('featured', true).get()
 
 Operators (exact set): `=` `!=` `>` `<` `>=` `<=` `like` `in` `not in` `is null` `is not null`
 
+An empty `in` array compiles to SQL `false` — the query matches nothing and never throws,
+so guarding `if (ids.length === 0)` before a `where in` is optional, not required.
+
 ## QueryBuilder chain
 
 `Post.where(...)` returns a `QueryBuilder`. Chainable:
@@ -80,6 +83,9 @@ const result = await Post.paginate({ page: 1, perPage: 15, where: {...}, orderBy
 
 For Inertia/HTTP pagination links wrap it with `paginate` from `@guren/core`:
 `paginate(result, { path?, query?, fragment? })` — those three fields are `PaginatorOptions`.
+The wrapped paginator serializes as `{ data, meta, links }`; the raw `PaginatedResult`
+has no `links`. In tests, assert against the shape the route actually returns
+(e.g. `assertJsonPath('meta.total', 3)`, `assertJsonCount(2, 'data')`).
 
 ## Relations — declaration signatures
 

--- a/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
+++ b/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: guren-api
-description: Guren framework API documentation, code patterns, and examples. Covers all subsystems — Controllers, Models, Routes, Middleware, Authentication, Authorization, Events, Jobs, Queue, Mail, Cache, Validation, Broadcasting, Notifications, Storage, Scheduling, I18n, Encryption, Health Checks, Error Handling, Container/ServiceProvider, Console Commands, and API Resources. Use when user asks "how to", "how does", "example of", "what is", or needs help understanding any Guren API — and proactively during implementation whenever you encounter an unfamiliar @guren/* API surface; check this before grepping node_modules dist files.
+description: Human-browsable Guren API reference — code patterns and examples for every subsystem (Controllers, Models, Routes, Middleware, Authentication, Authorization, Events, Jobs, Queue, Mail, Cache, Validation, Broadcasting, Notifications, Storage, Scheduling, I18n, Encryption, Health Checks, Error Handling, Container/ServiceProvider, Console Commands, API Resources). Use when the user asks "how to", "how does", "example of", or "what is" about a Guren API. Agent-critical signatures are already pushed into context via the guren context digest and .claude/rules/ — consult those first during implementation.
 ---
 
 # Guren API Documentation Skill


### PR DESCRIPTION
## Summary

Round 6 of the agent evaluation (run the day v2.0.0 shipped) showed shipped-harness agents still grepping `node_modules` for two API surfaces, and both baseline failures wrote tests around wrong guesses of exactly these shapes:

- **Paginated response wire shape** — raw `Model.paginate()` returns `{ data, meta }` with no `links`; the `@guren/core` `paginate()` wrapper serializes `{ data, meta, links }`. The digest and the orm-models rule now state both shapes and point tests at `assertJsonPath('meta.total', …)` / `assertJsonCount(n, 'data')`.
- **Empty `in` array** — compiles to SQL `false` (matches nothing, never throws). Verified against `drizzle-conditions.ts` and empirically on drizzle 1.0.0-rc.4.

All statements are source-verified (Model.ts, Paginator.ts, drizzle-conditions.ts, testing/http.ts). Digest and rules stay in sync per the digest's own contract.

## Verification

- `bun run build:clean` green, cli test suite 1078/1078, root typecheck clean

## Evidence

framework-comparison `agent-eval/PILOT.md` round 6; grep-term frequencies from trials guren-24..26 (paginate/PaginatorOptions 36 hits, inArray/conditions 22, testing 12).