### PR TITLE
fix(docs): mobile overflow fix + clearer homepage code samples and eval card

### DIFF
--- a/web/app/Services/highlight-code-examples.ts
+++ b/web/app/Services/highlight-code-examples.ts
@@ -7,8 +7,8 @@ import { HOME_CODE_EXAMPLES, HOME_SHIKI_THEME } from './home-code-examples.js'
 
 export async function highlightCodeExamples(): Promise<Record<string, string>> {
   const entries = await Promise.all(
-    Object.entries(HOME_CODE_EXAMPLES).map(async ([key, code]) => {
-      const html = await codeToHtml(code, { lang: 'typescript', theme: HOME_SHIKI_THEME })
+    Object.entries(HOME_CODE_EXAMPLES).map(async ([key, { code, lang }]) => {
+      const html = await codeToHtml(code, { lang, theme: HOME_SHIKI_THEME })
       return [key, html] as const
     }),
   )

--- a/web/app/Services/home-code-examples.ts
+++ b/web/app/Services/home-code-examples.ts
@@ -1,39 +1,74 @@
 // Landing-page code sample sources. Pure data — shared by the request-path
 // fallback (highlight-code-examples.ts) and scripts/prerender-docs.ts.
 
-export const HOME_CODE_EXAMPLES = {
-  Routes: `import { Router } from '@guren/core'
+export interface HomeCodeExample {
+  code: string
+  lang: 'typescript' | 'tsx'
+}
+
+export const HOME_CODE_EXAMPLES: Record<string, HomeCodeExample> = {
+  Routes: {
+    lang: 'typescript',
+    code: `import { Router } from '@guren/core'
 
 export function routes(router: Router) {
   router.get('/posts', [PostController, 'index'])
-  router.post('/posts', [PostController, 'store'])
+  router.get('/posts/:id', [PostController, 'show'])
 
-  router.middleware('auth').group((g) => {
-    g.get('/dashboard', [DashCtrl, 'index'])
+  router.middleware('auth').group((auth) => {
+    auth.post('/posts', [PostController, 'store'])
   })
 }`,
-  Controller: `export class PostController extends Controller {
+  },
+  Controller: {
+    lang: 'typescript',
+    code: `export class PostController extends Controller {
   async index() {
-    const result = await Post.paginate({ page: 1, perPage: 15 })
-    const paginator = paginate(result, { path: this.request.path ?? '/posts' })
-    return this.inertia(pages.posts.Index, {
-      data: result.data.map((post) => new PostResource(post).toJSON()),
-      pagination: paginator,
-    })
+    const posts = await Post.where('published', true).get()
+    return this.inertia(pages.posts.Index, { posts }) // props are type-checked
   }
 
   async store() {
-    const data = await this.validateBody(Schema)
-    await Post.create(data)
-    return this.redirect('/posts')
+    const data = await this.validateBody(CreatePostSchema) // bad input? 422
+    const user = await this.auth.userOrFail()              // no session? 401
+    const post = await Post.create({ ...data, authorId: user.id })
+    return this.redirect(\`/posts/\${post.id}\`)
   }
 }`,
-  Model: `export class Post extends defineModel(posts) {}
+  },
+  Model: {
+    lang: 'typescript',
+    code: `export class Post extends defineModel(posts) {}
 
-const post = await Post.findOrFail(1)
-const all = await Post
+const post = await Post.findOrFail(id) // missing row? that's a 404
+
+const latest = await Post
   .where('published', true)
+  .orderBy('createdAt', 'desc')
   .get()`,
-} as const
+  },
+  View: {
+    lang: 'tsx',
+    code: `import { Link } from '@inertiajs/react'
+import { route } from '@/.guren/routes.gen'
+import type { Data } from '@/.guren/data.gen'
+
+interface Props {
+  posts: Data.Post[] // the exact shape the controller sent
+}
+
+export default function Index({ posts }: Props) {
+  return (
+    <ul>
+      {posts.map((post) => (
+        <li key={post.id}>
+          <Link href={route('posts.show', { id: post.id })}>{post.title}</Link>
+        </li>
+      ))}
+    </ul>
+  )
+}`,
+  },
+}
 
 export const HOME_SHIKI_THEME = 'rose-pine-moon'

--- a/web/resources/js/pages/Home.tsx
+++ b/web/resources/js/pages/Home.tsx
@@ -121,12 +121,13 @@ const deployTargets = [
   },
 ]
 
-const agentArms = [
-  { name: 'With the shipped agent harness', pass: '3/3 pass', cost: '$4.90 median', accent: true },
-  { name: 'Same app, guidance stripped', pass: '1/3 pass', cost: '$6.94 median', accent: false },
+const agentEvalArms = [
+  { name: 'Shipped harness', passed: 3, total: 3, cost: 4.9, costDisplay: '$4.90', accent: true },
+  { name: 'Harness stripped', passed: 1, total: 3, cost: 6.94, costDisplay: '$6.94', accent: false },
 ]
+const agentEvalMaxCost = Math.max(...agentEvalArms.map((arm) => arm.cost))
 
-const TAB_KEYS = ['Routes', 'Controller', 'Model'] as const
+const TAB_KEYS = ['Routes', 'Controller', 'Model', 'View'] as const
 type TabKey = (typeof TAB_KEYS)[number]
 
 function CopyCommand({ command }: { command: string }) {
@@ -226,12 +227,12 @@ export default function Home({ codeExamples }: Props) {
             <div>
               <p className="text-sm font-semibold uppercase tracking-[0.3em] text-crimson-400">The shape of a Guren app</p>
               <h2 className="mt-3 text-3xl font-bold text-white md:text-4xl">
-                Three files, <br className="hidden sm:block" />one feature
+                Route to React, <br className="hidden sm:block" />one loop
               </h2>
               <p className="mt-4 text-base leading-relaxed text-white/60">
                 A route points at a controller. The controller validates input, queries a model,
-                and returns a typed Inertia page. That&apos;s the whole loop — no serializers, no
-                resolvers, no hand-written API client.
+                and returns an Inertia page — and the React component receives those exact props,
+                type-checked. No serializers, no resolvers, no hand-written API client.
               </p>
               <CodeBlock
                 lines={[
@@ -243,13 +244,13 @@ export default function Home({ codeExamples }: Props) {
               />
             </div>
             <div className="rounded-xl border border-white/10 bg-[#1a1212]">
-              <div className="flex border-b border-white/10">
+              <div className="flex overflow-x-auto border-b border-white/10">
                 {TAB_KEYS.map((tab) => (
                   <button
                     key={tab}
                     type="button"
                     onClick={() => setActiveTab(tab)}
-                    className={`px-5 py-3 text-sm font-medium transition ${
+                    className={`shrink-0 px-4 py-3 text-sm font-medium transition sm:px-5 ${
                       activeTab === tab
                         ? 'border-b-2 border-crimson-500 text-crimson-300'
                         : 'text-white/50 hover:text-white/80'
@@ -301,32 +302,70 @@ export default function Home({ codeExamples }: Props) {
             </div>
             <div className="rounded-xl border border-white/10 bg-white/[0.03] p-6">
               <p className="text-sm font-semibold text-white">
-                Measured on a day-old major release
+                Same task, same model — only the harness differs
               </p>
               <p className="mt-1 text-xs text-white/50">
-                Guren v2.0.0 shipped hours before these trials — the model has no training
-                data for its new APIs. Guidance has to carry what memory cannot.
+                Claude Code builds the same feature on Guren v2.0.0, hours after its release,
+                so the new APIs are in no model&apos;s training data. Three trials per arm.
               </p>
-              <div className="mt-6 space-y-4">
-                {agentArms.map((arm) => (
-                  <div
-                    key={arm.name}
-                    className={`rounded-lg border p-4 ${arm.accent ? 'border-crimson-400/40 bg-crimson-500/10' : 'border-white/10'}`}
-                  >
-                    <p className="text-xs font-medium text-white/60">{arm.name}</p>
-                    <div className="mt-1 flex items-baseline justify-between">
-                      <span className={`text-2xl font-extrabold ${arm.accent ? 'text-crimson-300' : 'text-white/70'}`}>
-                        {arm.pass}
+              <div className="mt-6">
+                <p className="text-[11px] font-semibold uppercase tracking-wider text-white/40">
+                  Trials that shipped a working feature
+                </p>
+                <div className="mt-3 space-y-3">
+                  {agentEvalArms.map((arm) => (
+                    <div key={arm.name} className="flex items-center justify-between gap-3">
+                      <span className="text-xs text-white/70">{arm.name}</span>
+                      <span className="flex items-center gap-1.5">
+                        {Array.from({ length: arm.total }, (_, i) => (
+                          <span
+                            key={i}
+                            className={`size-2.5 rounded-full ${
+                              i < arm.passed
+                                ? arm.accent
+                                  ? 'bg-crimson-400'
+                                  : 'bg-white/60'
+                                : 'border border-white/25'
+                            }`}
+                          />
+                        ))}
+                        <span
+                          className={`ml-1.5 text-sm font-bold ${arm.accent ? 'text-crimson-300' : 'text-white/70'}`}
+                        >
+                          {arm.passed}/{arm.total}
+                        </span>
                       </span>
-                      <span className="text-sm text-white/60">{arm.cost}</span>
                     </div>
-                  </div>
-                ))}
+                  ))}
+                </div>
+              </div>
+              <div className="mt-6">
+                <p className="text-[11px] font-semibold uppercase tracking-wider text-white/40">
+                  Median cost per feature
+                </p>
+                <div className="mt-3 space-y-3">
+                  {agentEvalArms.map((arm) => (
+                    <div key={arm.name}>
+                      <div className="flex items-baseline justify-between text-xs">
+                        <span className="text-white/70">{arm.name}</span>
+                        <span className={arm.accent ? 'font-bold text-crimson-300' : 'font-semibold text-white/70'}>
+                          {arm.costDisplay}
+                        </span>
+                      </div>
+                      <div className="mt-1.5 h-2 overflow-hidden rounded-full bg-white/10">
+                        <div
+                          className={`h-full rounded-full ${arm.accent ? 'bg-crimson-500' : 'bg-[#6b6363]'}`}
+                          style={{ width: `${((arm.cost / agentEvalMaxCost) * 100).toFixed(1)}%` }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
               </div>
               <p className="mt-5 text-xs leading-relaxed text-white/50">
                 Scored blind on a clean checkout: typecheck, the full test suite, and a hidden
                 HTTP smoke the agent never saw. Lifetime: 43 of 45 trials shipped a working
-                feature — the only failures are the stripped-guidance baseline above.
+                feature — the only failures are the stripped-harness arm above.
               </p>
               <a
                 href="https://github.com/gurenjs/framework-comparison/tree/main/agent-eval"

--- a/web/resources/js/pages/Home.tsx
+++ b/web/resources/js/pages/Home.tsx
@@ -222,7 +222,7 @@ export default function Home({ codeExamples }: Props) {
 
         {/* Code Showcase */}
         <section className="px-6 py-20">
-          <div className="mx-auto grid max-w-5xl items-start gap-12 lg:grid-cols-2">
+          <div className="mx-auto grid max-w-5xl grid-cols-1 items-start gap-12 lg:grid-cols-2">
             <div>
               <p className="text-sm font-semibold uppercase tracking-[0.3em] text-crimson-400">The shape of a Guren app</p>
               <h2 className="mt-3 text-3xl font-bold text-white md:text-4xl">
@@ -268,7 +268,7 @@ export default function Home({ codeExamples }: Props) {
 
         {/* Agent Evaluation */}
         <section className="border-t border-white/10 px-6 py-20">
-          <div className="mx-auto grid max-w-5xl items-start gap-12 lg:grid-cols-2">
+          <div className="mx-auto grid max-w-5xl grid-cols-1 items-start gap-12 lg:grid-cols-2">
             <div>
               <p className="text-sm font-semibold uppercase tracking-[0.3em] text-crimson-400">Agent-native</p>
               <h2 className="mt-3 text-3xl font-bold text-white md:text-4xl">


### PR DESCRIPTION
Two homepage fixes from a mobile review pass.

## 1. Horizontal page scroll on iPhone

On iPhone Safari the homepage could be panned horizontally — the document rendered 511px wide on a 390px viewport.

**Cause:** the two-column showcase grids use `grid … lg:grid-cols-2` with no column sizing below `lg`. The implicit `auto` track sizes to the min-content width of the Shiki code block (`white-space: pre`). WebKit propagates that track width to the page; Chromium clamps the scroll container's intrinsic contribution, which is why it only reproduced on iOS/WebKit.

**Fix:** declare `grid-cols-1` (`repeat(1, minmax(0, 1fr))`) on both grids, so the mobile track ignores content min-width and the code block scrolls inside its existing `overflow-x-auto` wrapper.

## 2. Code showcase: complete the loop, drop the noise

The tabs stopped at Routes/Controller/Model — no View, even though "route to React" type safety is the pitch. The samples also had a `DashCtrl` abbreviation and a controller calling `paginate` twice.

- New **View tab** (Shiki `tsx`): typed props via `Data.Post` from `data.gen`, `route()` from `routes.gen`, plain Inertia `Link` — matching what `make:feature` actually scaffolds.
- **Controller**: `where().get()` + typed `this.inertia`, and a `store` showing `validateBody` (422), `auth.userOrFail()` (401) — the "write the happy path" pitch in 12 lines.
- **Model**: `findOrFail` (404) and a `where().orderBy().get()` chain; no double-paginate.
- **Routes**: real controller names, `auth.post` inside the middleware group.
- Tab bar: `shrink-0` + `px-4` below `sm` so all four tabs fit 375px (verified down to 320px, where the bar falls back to its own horizontal scroll).
- `HOME_CODE_EXAMPLES` now carries a per-sample Shiki `lang` so the View tab highlights as TSX.

## 3. Agent-eval card: labeled mini-charts

"3/3 pass / $4.90 median" had no metric labels and the headline buried the design of the experiment. The card now reads as two labeled charts under an explicit headline ("Same task, same model — only the harness differs"):

- **Trials that shipped a working feature** — one dot per trial (3/3 vs 1/3)
- **Median cost per feature** — bars on a shared track ($4.90 vs $6.94)

Numbers, footnote (blind scoring, lifetime 43/45), and the raw-data link are unchanged.

## Verification

- Playwright WebKit (same engine as iPhone Safari), local server: `documentElement.scrollWidth` equals the viewport at 320/375/390px on `/`, `/docs/guides/getting-started`, `/blog` (was 511px on 390px before).
- Desktop grid unchanged: two 488px columns at 1280px, no overflow.
- `bun run typecheck` and `bun run test` (91 tests) pass in `web/`.