### PR TITLE
feat(web): first-party analytics and weekly adoption-metrics snapshots

### DIFF
--- a/.github/workflows/metrics-snapshot.yml
+++ b/.github/workflows/metrics-snapshot.yml
@@ -1,0 +1,50 @@
+# Weekly adoption-metrics snapshot, committed to the `metrics` branch.
+#
+# GitHub's traffic API retains only 14 days, so this must run on a schedule
+# or launch-week referrer data is unrecoverable. The traffic endpoints need
+# push access, which the default GITHUB_TOKEN does not carry (they map to the
+# repo Administration permission) — set a `METRICS_TOKEN` repo secret (a
+# fine-grained PAT with Administration: read on this repo) to include them.
+# Without it the snapshot still records npm downloads and star counts.
+name: Metrics Snapshot
+
+on:
+  schedule:
+    - cron: '0 0 * * 1' # Mondays 00:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Collect snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.METRICS_TOKEN || github.token }}
+        run: bun scripts/metrics-snapshot.ts --out "$RUNNER_TEMP/snapshot.json"
+
+      - name: Commit to metrics branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git ls-remote --exit-code origin metrics >/dev/null 2>&1; then
+            git checkout -B metrics origin/metrics
+          else
+            git checkout --orphan metrics
+            git rm -rf --quiet .
+          fi
+          mkdir -p snapshots
+          cp "$RUNNER_TEMP/snapshot.json" "snapshots/$(date -u +%F).json"
+          git add snapshots
+          git commit -m "metrics: snapshot $(date -u +%F)" || echo "nothing new to commit"
+          git push origin metrics

--- a/.github/workflows/metrics-snapshot.yml
+++ b/.github/workflows/metrics-snapshot.yml
@@ -1,11 +1,23 @@
-# Weekly adoption-metrics snapshot, committed to the `metrics` branch.
+# Weekly adoption-metrics snapshot, uploaded to a private R2 bucket.
 #
 # GitHub's traffic API retains only 14 days, so this must run on a schedule
-# or launch-week referrer data is unrecoverable. The traffic endpoints need
-# push access, which the default GITHUB_TOKEN does not carry (they map to the
-# repo Administration permission) — set a `METRICS_TOKEN` repo secret (a
-# fine-grained PAT with Administration: read on this repo) to include them.
-# Without it the snapshot still records npm downloads and star counts.
+# or launch-week referrer data is unrecoverable. The snapshots include the
+# repo's referrer list — data GitHub itself restricts to admins (a private
+# hostname can appear there, e.g. a company wiki linking to the repo), so it
+# goes to private storage rather than anywhere in this public repository.
+# R2's free tier (10 GB) dwarfs a ~5 KB weekly JSON.
+#
+# Setup:
+# - One-time: `bunx wrangler r2 bucket create guren-metrics`
+# - Repo secrets: CLOUDFLARE_ACCOUNT_ID, and CLOUDFLARE_API_TOKEN with the
+#   "Workers R2 Storage: Edit" permission.
+# - Optional repo secret METRICS_TOKEN: the traffic endpoints map to the repo
+#   Administration permission, which the default GITHUB_TOKEN cannot carry —
+#   set a fine-grained PAT (Administration: read on this repo) to include
+#   them. Without it the snapshot still records npm downloads and stars.
+#
+# Reading a snapshot back:
+#   bunx wrangler r2 object get guren-metrics/snapshots/<date>.json --pipe
 name: Metrics Snapshot
 
 on:
@@ -13,22 +25,20 @@ on:
     - cron: '0 0 * * 1' # Mondays 00:00 UTC
   workflow_dispatch:
 
-# A manual dispatch overlapping the scheduled run would race on the push to
-# the metrics branch; queue instead.
+# A manual dispatch overlapping the scheduled run would race on the upload;
+# queue instead. Same-key uploads are last-write-wins either way.
 concurrency:
   group: metrics-snapshot
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   snapshot:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -39,24 +49,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.METRICS_TOKEN || github.token }}
         run: bun scripts/metrics-snapshot.ts --out "$RUNNER_TEMP/snapshot.json"
 
-      - name: Commit to metrics branch
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git ls-remote --exit-code origin metrics >/dev/null 2>&1; then
-            git checkout -B metrics origin/metrics
-          else
-            git checkout --orphan metrics
-            git rm -rf --quiet .
-          fi
-          mkdir -p snapshots
-          cp "$RUNNER_TEMP/snapshot.json" "snapshots/$(date -u +%F).json"
-          git add snapshots
-          # Only a verified-empty index is a no-op; any other commit failure
-          # must fail the run instead of being swallowed.
-          if git diff --cached --quiet; then
-            echo "nothing new to commit"
-          else
-            git commit -m "metrics: snapshot $(date -u +%F)"
-            git push origin metrics
-          fi
+      - name: Upload to R2
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: >
+          bunx wrangler@4.118.0 r2 object put
+          "guren-metrics/snapshots/$(date -u +%F).json"
+          --file "$RUNNER_TEMP/snapshot.json" --remote

--- a/.github/workflows/metrics-snapshot.yml
+++ b/.github/workflows/metrics-snapshot.yml
@@ -13,6 +13,12 @@ on:
     - cron: '0 0 * * 1' # Mondays 00:00 UTC
   workflow_dispatch:
 
+# A manual dispatch overlapping the scheduled run would race on the push to
+# the metrics branch; queue instead.
+concurrency:
+  group: metrics-snapshot
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -26,7 +32,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: '1.3.14'
 
       - name: Collect snapshot
         env:
@@ -46,5 +52,11 @@ jobs:
           mkdir -p snapshots
           cp "$RUNNER_TEMP/snapshot.json" "snapshots/$(date -u +%F).json"
           git add snapshots
-          git commit -m "metrics: snapshot $(date -u +%F)" || echo "nothing new to commit"
-          git push origin metrics
+          # Only a verified-empty index is a no-op; any other commit failure
+          # must fail the run instead of being swallowed.
+          if git diff --cached --quiet; then
+            echo "nothing new to commit"
+          else
+            git commit -m "metrics: snapshot $(date -u +%F)"
+            git push origin metrics
+          fi

--- a/scripts/metrics-snapshot.ts
+++ b/scripts/metrics-snapshot.ts
@@ -2,7 +2,8 @@
 // package plus GitHub repository traffic. GitHub's traffic API only retains
 // 14 days, so without a periodic snapshot the referrer data around a launch
 // is lost for good. Run by .github/workflows/metrics-snapshot.yml, which
-// commits the JSON to the `metrics` branch.
+// uploads the JSON to a private R2 bucket — the referrer list is admin-only
+// data on GitHub and must not land anywhere in this public repository.
 //
 // Usage: bun scripts/metrics-snapshot.ts [--out path.json]
 //   GITHUB_TOKEN   token with push access to the repo (traffic endpoints

--- a/scripts/metrics-snapshot.ts
+++ b/scripts/metrics-snapshot.ts
@@ -14,6 +14,21 @@ import { resolve } from 'node:path'
 
 const REPO = 'gurenjs/guren'
 
+// npm's own package-name grammar. Everything fetched or persisted flows
+// through this and the shaping helpers below, so a hostile value in a
+// package.json or an API response cannot smuggle URL segments or arbitrary
+// payload shapes into the snapshot.
+const NPM_NAME_PATTERN = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/
+
+function asCount(value: unknown): number | null {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function asText(value: unknown, maxLength: number): string {
+  return typeof value === 'string' ? value.slice(0, maxLength) : ''
+}
+
 interface NpmDownloads {
   package: string
   downloads: number | null
@@ -30,7 +45,12 @@ async function publicPackageNames(): Promise<string[]> {
       const manifest = JSON.parse(
         await readFile(resolve(packagesDir, entry.name, 'package.json'), 'utf8'),
       ) as { name?: string; private?: boolean }
-      if (manifest.name && !manifest.private) names.push(manifest.name)
+      if (!manifest.name || manifest.private) continue
+      if (!NPM_NAME_PATTERN.test(manifest.name)) {
+        console.warn(`skipping ${entry.name}: "${manifest.name}" is not a valid npm name`)
+        continue
+      }
+      names.push(manifest.name)
     } catch {
       // A directory without a readable package.json is not a package.
     }
@@ -44,8 +64,13 @@ async function npmLastWeek(name: string): Promise<NpmDownloads> {
     console.warn(`npm downloads for ${name}: HTTP ${response.status}`)
     return { package: name, downloads: null }
   }
-  const data = (await response.json()) as { downloads: number; start: string; end: string }
-  return { package: name, downloads: data.downloads, start: data.start, end: data.end }
+  const data = (await response.json()) as Record<string, unknown>
+  return {
+    package: name,
+    downloads: asCount(data.downloads),
+    start: asText(data.start, 10),
+    end: asText(data.end, 10),
+  }
 }
 
 async function github(path: string, token: string | undefined): Promise<unknown | null> {
@@ -62,6 +87,39 @@ async function github(path: string, token: string | undefined): Promise<unknown 
   return response.json()
 }
 
+/** Daily views/clones series: {count, uniques, <key>: [{timestamp, count, uniques}]} */
+function shapeSeries(raw: unknown, key: 'views' | 'clones') {
+  if (raw === null || typeof raw !== 'object') return null
+  const record = raw as Record<string, unknown>
+  const entries = Array.isArray(record[key]) ? (record[key] as unknown[]) : []
+  return {
+    count: asCount(record.count),
+    uniques: asCount(record.uniques),
+    days: entries.map((entry) => {
+      const point = (entry ?? {}) as Record<string, unknown>
+      return {
+        timestamp: asText(point.timestamp, 32),
+        count: asCount(point.count),
+        uniques: asCount(point.uniques),
+      }
+    }),
+  }
+}
+
+/** Top-10 referrers/paths: keep only the documented fields, length-capped. */
+function shapeRanking(raw: unknown, nameKey: 'referrer' | 'path') {
+  if (!Array.isArray(raw)) return null
+  return raw.slice(0, 20).map((entry) => {
+    const record = (entry ?? {}) as Record<string, unknown>
+    return {
+      [nameKey]: asText(record[nameKey], 300),
+      ...(nameKey === 'path' ? { title: asText(record.title, 300) } : {}),
+      count: asCount(record.count),
+      uniques: asCount(record.uniques),
+    }
+  })
+}
+
 const outFlag = process.argv.indexOf('--out')
 const outPath = outFlag === -1 ? 'metrics-snapshot.json' : process.argv[outFlag + 1]
 if (!outPath) {
@@ -72,11 +130,7 @@ if (!outPath) {
 const token = process.env.GITHUB_TOKEN
 const packages = await publicPackageNames()
 
-const repoInfo = (await github('', token)) as {
-  stargazers_count?: number
-  forks_count?: number
-  open_issues_count?: number
-} | null
+const repoInfo = ((await github('', token)) ?? {}) as Record<string, unknown>
 
 const snapshot = {
   takenAt: new Date().toISOString(),
@@ -86,15 +140,15 @@ const snapshot = {
   },
   github: {
     repo: REPO,
-    stars: repoInfo?.stargazers_count ?? null,
-    forks: repoInfo?.forks_count ?? null,
-    openIssues: repoInfo?.open_issues_count ?? null,
+    stars: asCount(repoInfo.stargazers_count),
+    forks: asCount(repoInfo.forks_count),
+    openIssues: asCount(repoInfo.open_issues_count),
     // Each traffic payload covers the trailing 14 days.
     traffic: {
-      views: await github('/traffic/views', token),
-      clones: await github('/traffic/clones', token),
-      referrers: await github('/traffic/popular/referrers', token),
-      paths: await github('/traffic/popular/paths', token),
+      views: shapeSeries(await github('/traffic/views', token), 'views'),
+      clones: shapeSeries(await github('/traffic/clones', token), 'clones'),
+      referrers: shapeRanking(await github('/traffic/popular/referrers', token), 'referrer'),
+      paths: shapeRanking(await github('/traffic/popular/paths', token), 'path'),
     },
   },
 }
@@ -103,6 +157,6 @@ await writeFile(outPath, `${JSON.stringify(snapshot, null, 2)}\n`)
 console.log(`Wrote ${outPath}`)
 console.log(
   `npm last-week: ${snapshot.npm.downloads
-    .map((d) => `${d.package}=${d.downloads ?? '?'}`)
+    .map((entry) => `${entry.package}=${entry.downloads ?? '?'}`)
     .join(', ')}`,
 )

--- a/scripts/metrics-snapshot.ts
+++ b/scripts/metrics-snapshot.ts
@@ -1,0 +1,107 @@
+// Weekly adoption-metrics snapshot: npm downloads for every public workspace
+// package plus GitHub repository traffic. GitHub's traffic API only retains
+// 14 days, so without a periodic snapshot the referrer data around a launch
+// is lost for good. Run by .github/workflows/metrics-snapshot.yml, which
+// commits the JSON to the `metrics` branch.
+//
+// Usage: bun scripts/metrics-snapshot.ts [--out path.json]
+//   GITHUB_TOKEN   token with push access to the repo (traffic endpoints
+//                  need it; without one they are skipped with a warning)
+
+import { readdir, readFile, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const REPO = 'gurenjs/guren'
+
+interface NpmDownloads {
+  package: string
+  downloads: number | null
+  start?: string
+  end?: string
+}
+
+async function publicPackageNames(): Promise<string[]> {
+  const packagesDir = resolve(import.meta.dir, '../packages')
+  const names: string[] = []
+  for (const entry of await readdir(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    try {
+      const manifest = JSON.parse(
+        await readFile(resolve(packagesDir, entry.name, 'package.json'), 'utf8'),
+      ) as { name?: string; private?: boolean }
+      if (manifest.name && !manifest.private) names.push(manifest.name)
+    } catch {
+      // A directory without a readable package.json is not a package.
+    }
+  }
+  return names.sort()
+}
+
+async function npmLastWeek(name: string): Promise<NpmDownloads> {
+  const response = await fetch(`https://api.npmjs.org/downloads/point/last-week/${name}`)
+  if (!response.ok) {
+    console.warn(`npm downloads for ${name}: HTTP ${response.status}`)
+    return { package: name, downloads: null }
+  }
+  const data = (await response.json()) as { downloads: number; start: string; end: string }
+  return { package: name, downloads: data.downloads, start: data.start, end: data.end }
+}
+
+async function github(path: string, token: string | undefined): Promise<unknown | null> {
+  const response = await fetch(`https://api.github.com/repos/${REPO}${path}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  })
+  if (!response.ok) {
+    console.warn(`GitHub ${path}: HTTP ${response.status} (traffic endpoints need push access)`)
+    return null
+  }
+  return response.json()
+}
+
+const outFlag = process.argv.indexOf('--out')
+const outPath = outFlag === -1 ? 'metrics-snapshot.json' : process.argv[outFlag + 1]
+if (!outPath) {
+  console.error('--out requires a path')
+  process.exit(1)
+}
+
+const token = process.env.GITHUB_TOKEN
+const packages = await publicPackageNames()
+
+const repoInfo = (await github('', token)) as {
+  stargazers_count?: number
+  forks_count?: number
+  open_issues_count?: number
+} | null
+
+const snapshot = {
+  takenAt: new Date().toISOString(),
+  npm: {
+    // last-week is a rolling window; `start`/`end` in each entry record it.
+    downloads: await Promise.all(packages.map(npmLastWeek)),
+  },
+  github: {
+    repo: REPO,
+    stars: repoInfo?.stargazers_count ?? null,
+    forks: repoInfo?.forks_count ?? null,
+    openIssues: repoInfo?.open_issues_count ?? null,
+    // Each traffic payload covers the trailing 14 days.
+    traffic: {
+      views: await github('/traffic/views', token),
+      clones: await github('/traffic/clones', token),
+      referrers: await github('/traffic/popular/referrers', token),
+      paths: await github('/traffic/popular/paths', token),
+    },
+  },
+}
+
+await writeFile(outPath, `${JSON.stringify(snapshot, null, 2)}\n`)
+console.log(`Wrote ${outPath}`)
+console.log(
+  `npm last-week: ${snapshot.npm.downloads
+    .map((d) => `${d.package}=${d.downloads ?? '?'}`)
+    .join(', ')}`,
+)

--- a/web/app/Http/Middleware/site-analytics.ts
+++ b/web/app/Http/Middleware/site-analytics.ts
@@ -1,0 +1,126 @@
+import { defineMiddleware } from '@guren/core'
+import { getWorkersEnv } from '@guren/plugin-cloudflare'
+
+/**
+ * First-party, cookie-less request analytics into Workers Analytics Engine.
+ *
+ * Server-side measurement is the only kind this site's audience does not
+ * defeat: developers run ad blockers that drop client-side beacons, and AI
+ * agents fetching the Markdown mirrors never execute JavaScript at all.
+ * Nothing user-identifying is stored — no cookies, no IPs, no full referrer
+ * URLs — so no consent banner is needed.
+ *
+ * Data point layout (query these positions via the SQL API):
+ *   index1: user-agent class (human / ai-agent / bot / unknown)
+ *   blob1:  pathname
+ *   blob2:  content class (home / docs / blog / markdown / llms / other)
+ *   blob3:  user-agent class (again, so blobs are self-contained)
+ *   blob4:  referrer host ('' for direct or same-site)
+ *   blob5:  primary Accept-Language subtag
+ *   blob6:  country code from Cloudflare
+ *   blob7:  HTTP method
+ *   blob8:  navigation type (initial / inertia)
+ *   double1: response status
+ *   double2: duration in milliseconds
+ */
+
+interface AnalyticsEngineDataset {
+  writeDataPoint(event: { blobs?: string[]; doubles?: number[]; indexes?: string[] }): void
+}
+
+interface AnalyticsEnv {
+  SITE_ANALYTICS?: AnalyticsEngineDataset
+}
+
+// AI agents and assistants, checked before the generic bot pattern — most of
+// their user agents also contain "bot". Sources: the crawlers each vendor
+// documents for robots.txt, plus the coding-agent CLIs seen in access logs.
+const AI_AGENT_PATTERN =
+  /GPTBot|OAI-SearchBot|ChatGPT-User|ClaudeBot|Claude-Web|Claude-User|Claude-SearchBot|claude-code|anthropic-ai|PerplexityBot|Perplexity-User|Google-Extended|GoogleAgent|Applebot-Extended|meta-externalagent|cohere-ai|DuckAssistBot|YouBot|MistralAI|Devin|Cursor/i
+
+const BOT_PATTERN =
+  /bot|crawler|spider|crawl|slurp|headless|python-requests|python-httpx|python-urllib|go-http-client|curl|wget|scrapy|feedfetcher|facebookexternalhit|preview|monitor|uptime/i
+
+export type UserAgentClass = 'human' | 'ai-agent' | 'bot' | 'unknown'
+
+export function classifyUserAgent(userAgent: string): UserAgentClass {
+  if (!userAgent) return 'unknown'
+  if (AI_AGENT_PATTERN.test(userAgent)) return 'ai-agent'
+  if (BOT_PATTERN.test(userAgent)) return 'bot'
+  return 'human'
+}
+
+export function classifyContent(pathname: string): string {
+  if (pathname === '/llms.txt' || pathname === '/llms-full.txt') return 'llms'
+  if (pathname.endsWith('.md')) return 'markdown'
+  if (pathname === '/' || pathname === '') return 'home'
+  if (pathname === '/docs' || pathname.startsWith('/docs/')) return 'docs'
+  if (pathname === '/blog' || pathname.startsWith('/blog/')) return 'blog'
+  return 'other'
+}
+
+export function referrerHost(referrer: string | undefined, ownHost: string): string {
+  if (!referrer) return ''
+  try {
+    const host = new URL(referrer).hostname
+    return host === ownHost ? '' : host
+  } catch {
+    return ''
+  }
+}
+
+export function primaryLanguage(acceptLanguage: string | undefined): string {
+  if (!acceptLanguage) return ''
+  const first = acceptLanguage.split(',', 1)[0] ?? ''
+  const tag = first.split(';', 1)[0]?.trim() ?? ''
+  const subtag = tag.split('-', 1)[0] ?? ''
+  // An unparseable header yields garbage, not a language; cap defensively.
+  return /^[a-zA-Z]{2,8}$/.test(subtag) ? subtag.toLowerCase() : ''
+}
+
+function workersDataset(): AnalyticsEngineDataset | undefined {
+  try {
+    return getWorkersEnv<AnalyticsEnv>().SITE_ANALYTICS
+  } catch {
+    // Not on Workers (Bun dev server, tests) — analytics is a no-op there.
+    return undefined
+  }
+}
+
+export function createSiteAnalyticsMiddleware(
+  resolveDataset: () => AnalyticsEngineDataset | undefined = workersDataset,
+) {
+  return defineMiddleware(async (c, next) => {
+    const startedAt = Date.now()
+    try {
+      await next()
+    } finally {
+      try {
+        const dataset = resolveDataset()
+        if (dataset) {
+          const url = new URL(c.req.url)
+          const uaClass = classifyUserAgent(c.req.header('user-agent') ?? '')
+          const cf = (c.req.raw as { cf?: { country?: string } }).cf
+          dataset.writeDataPoint({
+            indexes: [uaClass],
+            blobs: [
+              url.pathname,
+              classifyContent(url.pathname),
+              uaClass,
+              referrerHost(c.req.header('referer'), url.hostname),
+              primaryLanguage(c.req.header('accept-language')),
+              cf?.country ?? '',
+              c.req.method,
+              c.req.header('x-inertia') ? 'inertia' : 'initial',
+            ],
+            doubles: [c.res?.status ?? 0, Date.now() - startedAt],
+          })
+        }
+      } catch {
+        // Analytics must never break a response.
+      }
+    }
+  })
+}
+
+export const recordSiteAnalytics = createSiteAnalyticsMiddleware()

--- a/web/app/Http/Middleware/site-analytics.ts
+++ b/web/app/Http/Middleware/site-analytics.ts
@@ -7,8 +7,9 @@ import { getWorkersEnv } from '@guren/plugin-cloudflare'
  * Server-side measurement is the only kind this site's audience does not
  * defeat: developers run ad blockers that drop client-side beacons, and AI
  * agents fetching the Markdown mirrors never execute JavaScript at all.
- * Nothing user-identifying is stored — no cookies, no IPs, no full referrer
- * URLs — so no consent banner is needed.
+ * No cookies, no IP addresses, and no full referrer URLs are stored — only
+ * the request path (length-capped) and the referrer's hostname — so no
+ * consent banner is needed.
  *
  * Data point layout (query these positions via the SQL API):
  *   index1: user-agent class (human / ai-agent / bot / unknown)
@@ -59,11 +60,18 @@ export function classifyContent(pathname: string): string {
   return 'other'
 }
 
+// Analytics Engine rejects a whole data point when its blobs exceed the size
+// limit, and request URLs can be as long as Cloudflare accepts (~16 KB). Real
+// paths on this site are short; anything longer is scanner noise, so truncate
+// rather than lose the data point.
+const MAX_PATH_LENGTH = 512
+const MAX_HOST_LENGTH = 256
+
 export function referrerHost(referrer: string | undefined, ownHost: string): string {
   if (!referrer) return ''
   try {
     const host = new URL(referrer).hostname
-    return host === ownHost ? '' : host
+    return host === ownHost ? '' : host.slice(0, MAX_HOST_LENGTH)
   } catch {
     return ''
   }
@@ -104,7 +112,7 @@ export function createSiteAnalyticsMiddleware(
           dataset.writeDataPoint({
             indexes: [uaClass],
             blobs: [
-              url.pathname,
+              url.pathname.slice(0, MAX_PATH_LENGTH),
               classifyContent(url.pathname),
               uaClass,
               referrerHost(c.req.header('referer'), url.hostname),

--- a/web/scripts/analytics-report.ts
+++ b/web/scripts/analytics-report.ts
@@ -1,0 +1,94 @@
+// Query the site's Workers Analytics Engine dataset over the SQL API and
+// print a small weekly report. Reads, not writes — safe to run any time.
+//
+// Usage:
+//   CLOUDFLARE_ACCOUNT_ID=... CLOUDFLARE_API_TOKEN=... bun scripts/analytics-report.ts [--days 7]
+//
+// The token needs the "Account Analytics: Read" permission.
+
+const DATASET = 'guren_dev_analytics'
+
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID
+const apiToken = process.env.CLOUDFLARE_API_TOKEN
+
+if (!accountId || !apiToken) {
+  console.error('Set CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN (Account Analytics: Read).')
+  process.exit(1)
+}
+
+const daysFlag = process.argv.indexOf('--days')
+const days = daysFlag === -1 ? 7 : Number(process.argv[daysFlag + 1] ?? 7)
+if (!Number.isFinite(days) || days <= 0) {
+  console.error('--days must be a positive number')
+  process.exit(1)
+}
+
+// Data point layout: see web/app/Http/Middleware/site-analytics.ts.
+const WINDOW = `timestamp > NOW() - INTERVAL '${Math.floor(days)}' DAY`
+
+const queries: Array<{ title: string; sql: string }> = [
+  {
+    title: 'Requests by visitor class',
+    sql: `SELECT blob3 AS visitor, SUM(_sample_interval) AS requests
+          FROM ${DATASET} WHERE ${WINDOW}
+          GROUP BY visitor ORDER BY requests DESC`,
+  },
+  {
+    title: 'Top pages (humans)',
+    sql: `SELECT blob1 AS path, SUM(_sample_interval) AS requests
+          FROM ${DATASET} WHERE ${WINDOW} AND blob3 = 'human' AND blob7 = 'GET'
+          GROUP BY path ORDER BY requests DESC LIMIT 15`,
+  },
+  {
+    title: 'Top referrers (humans)',
+    sql: `SELECT blob4 AS referrer, SUM(_sample_interval) AS requests
+          FROM ${DATASET} WHERE ${WINDOW} AND blob3 = 'human' AND blob4 != ''
+          GROUP BY referrer ORDER BY requests DESC LIMIT 15`,
+  },
+  {
+    title: 'Agent traffic: markdown mirrors and llms.txt',
+    sql: `SELECT blob2 AS content, blob3 AS visitor, SUM(_sample_interval) AS requests
+          FROM ${DATASET} WHERE ${WINDOW} AND blob2 IN ('markdown', 'llms')
+          GROUP BY content, visitor ORDER BY requests DESC LIMIT 15`,
+  },
+  {
+    title: 'Top docs pages fetched by AI agents',
+    sql: `SELECT blob1 AS path, SUM(_sample_interval) AS requests
+          FROM ${DATASET} WHERE ${WINDOW} AND blob3 = 'ai-agent'
+          GROUP BY path ORDER BY requests DESC LIMIT 15`,
+  },
+  {
+    title: 'Languages (humans)',
+    sql: `SELECT blob5 AS language, SUM(_sample_interval) AS requests
+          FROM ${DATASET} WHERE ${WINDOW} AND blob3 = 'human' AND blob5 != ''
+          GROUP BY language ORDER BY requests DESC LIMIT 10`,
+  },
+]
+
+async function runQuery(sql: string): Promise<Array<Record<string, unknown>>> {
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/analytics_engine/sql`,
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiToken}` },
+      body: sql,
+    },
+  )
+  if (!response.ok) {
+    throw new Error(`SQL API ${response.status}: ${await response.text()}`)
+  }
+  const payload = (await response.json()) as { data?: Array<Record<string, unknown>> }
+  return payload.data ?? []
+}
+
+console.log(`# guren.dev analytics — last ${Math.floor(days)} day(s)\n`)
+for (const { title, sql } of queries) {
+  console.log(`## ${title}`)
+  const rows = await runQuery(sql)
+  if (rows.length === 0) {
+    console.log('(no data)\n')
+    continue
+  }
+  console.table(rows)
+  console.log('')
+}

--- a/web/scripts/analytics-report.ts
+++ b/web/scripts/analytics-report.ts
@@ -18,13 +18,14 @@ if (!accountId || !apiToken) {
 
 const daysFlag = process.argv.indexOf('--days')
 const days = daysFlag === -1 ? 7 : Number(process.argv[daysFlag + 1] ?? 7)
-if (!Number.isFinite(days) || days <= 0) {
-  console.error('--days must be a positive number')
+// Analytics Engine retains roughly three months, so cap the window there.
+if (!Number.isSafeInteger(days) || days < 1 || days > 90) {
+  console.error('--days must be an integer between 1 and 90')
   process.exit(1)
 }
 
 // Data point layout: see web/app/Http/Middleware/site-analytics.ts.
-const WINDOW = `timestamp > NOW() - INTERVAL '${Math.floor(days)}' DAY`
+const WINDOW = `timestamp > NOW() - INTERVAL '${days}' DAY`
 
 const queries: Array<{ title: string; sql: string }> = [
   {
@@ -81,7 +82,7 @@ async function runQuery(sql: string): Promise<Array<Record<string, unknown>>> {
   return payload.data ?? []
 }
 
-console.log(`# guren.dev analytics — last ${Math.floor(days)} day(s)\n`)
+console.log(`# guren.dev analytics — last ${days} day(s)\n`)
 for (const { title, sql } of queries) {
   console.log(`## ${title}`)
   const rows = await runQuery(sql)

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -5,6 +5,7 @@ import {
   setInertiaDocument,
 } from '@guren/core'
 import { redirectToCanonicalHost } from '../app/Http/Middleware/canonical-host.js'
+import { recordSiteAnalytics } from '../app/Http/Middleware/site-analytics.js'
 import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
 import {
   COLOR_MODE_PREPAINT_SCRIPT,
@@ -51,5 +52,8 @@ const app = createApp({
 // Both hostnames are routed to this worker, so the redirect lives here
 // rather than in DNS.
 app.use('*', redirectToCanonicalHost)
+
+// After the canonical redirect, so www.-redirect responses are not counted.
+app.use('*', recordSiteAnalytics)
 
 export default app

--- a/web/tests/middleware/site-analytics.test.ts
+++ b/web/tests/middleware/site-analytics.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// The real module drags in the Cloudflare build pipeline, which vitest cannot
+// resolve; every test here injects its own dataset resolver anyway.
+vi.mock('@guren/plugin-cloudflare', () => ({
+  getWorkersEnv: () => {
+    throw new Error('workers env is not captured in tests')
+  },
+}))
+
+import {
+  classifyContent,
+  classifyUserAgent,
+  createSiteAnalyticsMiddleware,
+  primaryLanguage,
+  referrerHost,
+} from '../../app/Http/Middleware/site-analytics.js'
+
+type Middleware = ReturnType<typeof createSiteAnalyticsMiddleware>
+type MiddlewareContext = Parameters<Middleware>[0]
+
+interface DataPoint {
+  blobs?: string[]
+  doubles?: number[]
+  indexes?: string[]
+}
+
+function contextFor(
+  url: string,
+  { headers = {}, cf, status = 200 }: {
+    headers?: Record<string, string>
+    cf?: { country?: string }
+    status?: number
+  } = {},
+) {
+  const lowered = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+  )
+  return {
+    req: {
+      url,
+      method: 'GET',
+      header: (name: string) => lowered[name.toLowerCase()],
+      raw: { cf },
+    },
+    res: { status },
+  } as unknown as MiddlewareContext
+}
+
+async function record(url: string, options?: Parameters<typeof contextFor>[1]) {
+  const points: DataPoint[] = []
+  const middleware = createSiteAnalyticsMiddleware(() => ({
+    writeDataPoint: (point: DataPoint) => {
+      points.push(point)
+    },
+  }))
+  await middleware(contextFor(url, options), async () => {})
+  return points
+}
+
+describe('classifyUserAgent', () => {
+  it('should classify AI agents before the generic bot pattern matches', () => {
+    expect(classifyUserAgent('Mozilla/5.0 (compatible; ClaudeBot/1.0)')).toBe('ai-agent')
+    expect(classifyUserAgent('Mozilla/5.0 (compatible; GPTBot/1.1)')).toBe('ai-agent')
+    expect(classifyUserAgent('PerplexityBot/1.0')).toBe('ai-agent')
+  })
+
+  it('should classify crawlers and HTTP clients as bots', () => {
+    expect(classifyUserAgent('Mozilla/5.0 (compatible; Googlebot/2.1)')).toBe('bot')
+    expect(classifyUserAgent('curl/8.4.0')).toBe('bot')
+  })
+
+  it('should classify browsers as human and empty as unknown', () => {
+    expect(
+      classifyUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) Safari/604.1'),
+    ).toBe('human')
+    expect(classifyUserAgent('')).toBe('unknown')
+  })
+})
+
+describe('classifyContent', () => {
+  it('should bucket the agent-facing mirrors separately from pages', () => {
+    expect(classifyContent('/llms.txt')).toBe('llms')
+    expect(classifyContent('/docs/guides/getting-started.md')).toBe('markdown')
+    expect(classifyContent('/docs/guides/getting-started')).toBe('docs')
+    expect(classifyContent('/blog/some-post')).toBe('blog')
+    expect(classifyContent('/')).toBe('home')
+    expect(classifyContent('/login')).toBe('other')
+  })
+})
+
+describe('referrerHost', () => {
+  it('should keep only the host and drop same-site referrers', () => {
+    expect(referrerHost('https://news.ycombinator.com/item?id=1', 'guren.dev')).toBe(
+      'news.ycombinator.com',
+    )
+    expect(referrerHost('https://guren.dev/docs', 'guren.dev')).toBe('')
+    expect(referrerHost('not a url', 'guren.dev')).toBe('')
+    expect(referrerHost(undefined, 'guren.dev')).toBe('')
+  })
+})
+
+describe('primaryLanguage', () => {
+  it('should reduce Accept-Language to the primary subtag', () => {
+    expect(primaryLanguage('ja-JP,ja;q=0.9,en;q=0.8')).toBe('ja')
+    expect(primaryLanguage('en-US')).toBe('en')
+    expect(primaryLanguage('*')).toBe('')
+    expect(primaryLanguage(undefined)).toBe('')
+  })
+})
+
+describe('createSiteAnalyticsMiddleware', () => {
+  it('should write one data point with the documented layout', async () => {
+    const points = await record('https://guren.dev/docs/guides/getting-started', {
+      headers: {
+        'user-agent': 'Mozilla/5.0 Safari/604.1',
+        referer: 'https://zenn.dev/some-article',
+        'accept-language': 'ja-JP,ja;q=0.9',
+      },
+      cf: { country: 'JP' },
+    })
+
+    expect(points).toHaveLength(1)
+    const point = points[0]!
+    expect(point.indexes).toEqual(['human'])
+    expect(point.blobs?.slice(0, 8)).toEqual([
+      '/docs/guides/getting-started',
+      'docs',
+      'human',
+      'zenn.dev',
+      'ja',
+      'JP',
+      'GET',
+      'initial',
+    ])
+    expect(point.doubles?.[0]).toBe(200)
+    expect(point.doubles?.[1]).toBeGreaterThanOrEqual(0)
+  })
+
+  it('should mark Inertia navigations and AI agent fetches', async () => {
+    const [inertia] = await record('https://guren.dev/blog', {
+      headers: { 'user-agent': 'Mozilla/5.0', 'x-inertia': 'true' },
+    })
+    expect(inertia?.blobs?.[7]).toBe('inertia')
+
+    const [agent] = await record('https://guren.dev/docs/guides/getting-started.md', {
+      headers: { 'user-agent': 'Claude-User/1.0' },
+    })
+    expect(agent?.indexes).toEqual(['ai-agent'])
+    expect(agent?.blobs?.[1]).toBe('markdown')
+  })
+
+  it('should still record when the downstream handler throws', async () => {
+    const points: DataPoint[] = []
+    const middleware = createSiteAnalyticsMiddleware(() => ({
+      writeDataPoint: (point: DataPoint) => {
+        points.push(point)
+      },
+    }))
+
+    await expect(
+      middleware(contextFor('https://guren.dev/boom', { status: 500 }), async () => {
+        throw new Error('downstream failure')
+      }),
+    ).rejects.toThrow('downstream failure')
+    expect(points).toHaveLength(1)
+  })
+
+  it('should be a no-op without a dataset and never break the response', async () => {
+    const middleware = createSiteAnalyticsMiddleware(() => undefined)
+    let reached = false
+    await middleware(contextFor('https://guren.dev/'), async () => {
+      reached = true
+    })
+    expect(reached).toBe(true)
+
+    const throwing = createSiteAnalyticsMiddleware(() => {
+      throw new Error('env not captured')
+    })
+    await expect(
+      throwing(contextFor('https://guren.dev/'), async () => {}),
+    ).resolves.toBeUndefined()
+  })
+})

--- a/web/tests/middleware/site-analytics.test.ts
+++ b/web/tests/middleware/site-analytics.test.ts
@@ -150,6 +150,13 @@ describe('createSiteAnalyticsMiddleware', () => {
     expect(agent?.blobs?.[1]).toBe('markdown')
   })
 
+  it('should cap oversized paths so the data point stays writable', async () => {
+    const [point] = await record(`https://guren.dev/${'a'.repeat(20_000)}`, {
+      headers: { 'user-agent': 'Mozilla/5.0' },
+    })
+    expect(point?.blobs?.[0]?.length).toBeLessThanOrEqual(512)
+  })
+
   it('should still record when the downstream handler throws', async () => {
     const points: DataPoint[] = []
     const middleware = createSiteAnalyticsMiddleware(() => ({

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -40,6 +40,14 @@
   "assets": {
     "directory": ".cloudflare/assets"
   },
+  // Cookie-less first-party analytics (see app/Http/Middleware/site-analytics.ts).
+  // Free-plan quota: 100k data points written per day.
+  "analytics_engine_datasets": [
+    {
+      "binding": "SITE_ANALYTICS",
+      "dataset": "guren_dev_analytics"
+    }
+  ],
   "d1_databases": [
     {
       "binding": "DB",


### PR DESCRIPTION
Measurement infrastructure ahead of the promotion push, so launch-week referrer data exists to act on. Everything stays inside the current $0/month Cloudflare setup.

## Site analytics (Workers Analytics Engine)

A cookie-less middleware ([site-analytics.ts](web/app/Http/Middleware/site-analytics.ts)) writes one data point per request:

| field | value |
|---|---|
| index1 / blob3 | visitor class: `human` / `ai-agent` / `bot` / `unknown` |
| blob1 / blob2 | path (capped at 512 chars) + content class (`home` / `docs` / `blog` / `markdown` / `llms` / `other`) |
| blob4 | referrer host only, capped at 256 chars (no full URLs; same-site collapsed to `''`) |
| blob5 / blob6 | primary `Accept-Language` subtag, CF country |
| blob7 / blob8 | method, `initial` vs `inertia` navigation |
| doubles | status, duration ms |

Why server-side: this site's audience runs ad blockers that drop client-side beacons, and the AI agents fetching the Markdown mirrors / `llms.txt` never execute JS — the "agent traffic share" number only exists server-side. No cookies, no IPs, no full referrer URLs, no consent banner needed.

- Registered after the canonical-host redirect so `www.` redirects are not counted; recording happens in `finally` so error responses are counted too; a missing binding (Bun dev, tests) makes it a no-op.
- `analytics_engine_datasets` binding added to `wrangler.jsonc` (`SITE_ANALYTICS` → `guren_dev_analytics`). Free-plan quota is 100k points/day.
- [analytics-report.ts](web/scripts/analytics-report.ts) prints a weekly report over the SQL API (visitor classes, top pages/referrers for humans, agent-fetched docs, languages). `--days` accepts an integer in 1..90. Needs `CLOUDFLARE_ACCOUNT_ID` + an `Account Analytics: Read` token.

## Weekly adoption-metrics snapshots → private R2

GitHub's traffic API retains only 14 days, so [metrics-snapshot.yml](.github/workflows/metrics-snapshot.yml) runs Mondays (plus `workflow_dispatch`): npm last-week downloads for every public workspace package (derived from `packages/*/package.json`, so new packages are picked up automatically) plus repo stars/forks and traffic views, clones, referrers, and popular paths.

Snapshots upload to a **private R2 bucket** (`guren-metrics`), not to a branch: the referrer list is data GitHub itself restricts to admins (a private hostname — e.g. a company wiki linking here — can appear in it), so it must not land anywhere in this public repository. This also removes the `contents: write` permission and orphan-branch machinery entirely; the upload is a single last-write-wins object put with the wrangler version pinned inline. Read one back with `bunx wrangler r2 object get guren-metrics/snapshots/<date>.json --pipe`.

## Setup required after merge

1. One-time: `bunx wrangler r2 bucket create guren-metrics`
2. Repo secrets: `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` with **Workers R2 Storage: Edit** (this PR); the deploy workflow in #288 wants the same token to also carry Workers Scripts: Edit + D1: Edit.
3. Optional `METRICS_TOKEN` secret (fine-grained PAT, this repo, Administration: read) to include traffic data — without it the snapshot records npm counts and stars and logs a warning.
4. Deploy guren.dev — the Analytics Engine binding is created automatically on deploy.

## Verification

- 11 vitest cases: classifier tables, data-point layout, Inertia/agent marking, oversized-path capping, recording on thrown downstream errors, no-op without a binding. Full web suite green; `bun run typecheck` (web + root tsc) clean; `audit:core-first` passed.
- `wrangler dev` smoke on the built worker: binding resolves (`env.SITE_ANALYTICS (guren_dev_analytics)`), `/` and `/docs/*.md` serve 200. (`/llms.txt` 500s locally because the local D1 has no `posts` table — pre-existing local-env condition, and it exercised the error-path recording.)
- `scripts/metrics-snapshot.ts` run against the real APIs: all 11 packages' npm counts, stars, and 14-day traffic captured.
- The orphan-branch commit logic this PR briefly contained was replaced by the R2 upload after review; the remaining external review findings were applied in 3659dd9 (path/referrer length caps, `--days` validation, workflow concurrency, verified-empty-index commit guard — now moot, bun pin).