### PR TITLE
fix(server): accept controller actions in middleware-scoped route contracts

### DIFF
--- a/.changeset/olive-jars-shave.md
+++ b/.changeset/olive-jars-shave.md
@@ -1,0 +1,16 @@
+---
+"@guren/server": patch
+"@guren/cli": patch
+---
+
+Accept controller actions alongside route contract options inside `router.middleware(...)` chains
+
+`router.middleware('auth').post('/posts', { name: 'posts.store', body: Schema }, [PostController, 'store'])`
+raised TS2769 even though it worked at runtime: the middleware-scoped builder carried only
+two overloads per HTTP verb, missing the contract-options + `[Controller, 'method']` variant
+the router itself has. All five verbs now expose it, so the direct chain no longer needs a
+`.group()` wrapper to compile.
+
+Route docs and the `make:feature` next-steps hint now capture the `aliasMiddleware()` return
+value, which later `.middleware()` calls require — a bare call registers the handler at runtime
+but leaves the alias name invisible to the type system.

--- a/.claude/skills/guren-api/SKILL.md
+++ b/.claude/skills/guren-api/SKILL.md
@@ -133,8 +133,10 @@ Source: `packages/server/src/mvc/Router.ts`
 import { Router, requireAuthenticated } from '@guren/core'
 import { PostPayloadSchema } from '../app/Http/Validators/PostValidator.js'
 
-export function registerWebRoutes(router: Router): void {
-  router.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
+export function registerWebRoutes(baseRouter: Router): void {
+  // aliasMiddleware() returns a Router carrying the alias name in its type —
+  // capture it, or a later .middleware('auth') will not compile.
+  const router = baseRouter.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
 
   router.get('/posts', [PostController, 'index']).name('posts.index')
   // Attach body schema to mutation routes for codegen type extraction

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,8 +230,10 @@ const all = await Post.where('published', true).get()
 ```typescript
 import { Router, requireAuthenticated } from '@guren/core'
 
-export function registerWebRoutes(router: Router): void {
-  router.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
+export function registerWebRoutes(baseRouter: Router): void {
+  // aliasMiddleware() returns a Router carrying the alias name in its type —
+  // capture it, or a later .middleware('auth') will not compile.
+  const router = baseRouter.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
 
   router.get('/posts', [PostController, 'index'])
   router.post('/posts', [PostController, 'store'])

--- a/docs/en/guides/architecture.md
+++ b/docs/en/guides/architecture.md
@@ -131,8 +131,8 @@ export default class AppServiceProvider extends ServiceProvider {
 import { Router, requireAuthenticated } from '@guren/core'
 import PostController from '@/app/Http/Controllers/PostController'
 
-export function registerWebRoutes(router: Router): void {
-  router.aliasMiddleware('auth', requireAuthenticated())
+export function registerWebRoutes(baseRouter: Router): void {
+  const router = baseRouter.aliasMiddleware('auth', requireAuthenticated())
   router.bind('post', Post)
 
   router.get('/', [PostController, 'index'])

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -363,9 +363,10 @@ import { Router, requireAuthenticated, requireGuest } from '@guren/core'
 import LoginController from '@/app/Http/Controllers/Auth/LoginController'
 import DashboardController from '@/app/Http/Controllers/DashboardController'
 
-export function registerWebRoutes(router: Router): void {
-  router.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
-  router.aliasMiddleware('guest', requireGuest({ redirectTo: '/dashboard' }))
+export function registerWebRoutes(baseRouter: Router): void {
+  const router = baseRouter
+    .aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
+    .aliasMiddleware('guest', requireGuest({ redirectTo: '/dashboard' }))
 
   router.middleware('guest').group((guest) => {
     guest.get('/login', [LoginController, 'show'])

--- a/docs/en/guides/middleware.md
+++ b/docs/en/guides/middleware.md
@@ -46,12 +46,16 @@ import { Router, requireAuthenticated } from '@guren/core'
 import { requireAdmin } from '@/app/Http/middleware/admin'
 import { csrfProtection } from '@/app/Http/middleware/csrf'
 
-export function registerWebRoutes(router: Router): void {
-  router.aliasMiddleware('auth', requireAuthenticated())
-  router.aliasMiddleware('admin', requireAdmin())
-  router.aliasMiddleware('csrf', csrfProtection())
+export function registerWebRoutes(baseRouter: Router): void {
+  const router = baseRouter
+    .aliasMiddleware('auth', requireAuthenticated())
+    .aliasMiddleware('admin', requireAdmin())
+    .aliasMiddleware('csrf', csrfProtection())
 }
 ```
+
+> [!IMPORTANT]
+> `aliasMiddleware()` returns a **new `Router` type** carrying the alias name it just registered. Call it without capturing the result and the name never reaches the type, so a later `.middleware('auth')` fails to compile. Always chain and assign, as above.
 
 Once registered, use the alias string anywhere middleware is accepted:
 
@@ -62,11 +66,16 @@ router.post('/settings', [SettingsController, 'update']).middleware('auth', 'csr
 
 ## Middleware Groups
 
-Bundle multiple middleware aliases under a single group name. This is useful for stacks that commonly run together:
+Bundle multiple middleware aliases under a single group name. This is useful for stacks that commonly run together. Every member of a group must already be a registered alias:
 
 ```ts
-router.groupMiddleware('web', ['session', 'csrf'])
-router.groupMiddleware('api', ['throttle:60'])
+const router = new Router()
+  .aliasMiddleware('auth', requireAuthenticated())
+  .aliasMiddleware('session', createSessionMiddleware())
+  .aliasMiddleware('csrf', createCsrfMiddleware())
+  .aliasMiddleware('throttle', createRateLimitMiddleware({ limit: 60, windowMs: 60_000 }))
+  .groupMiddleware('web', ['session', 'csrf'])
+  .groupMiddleware('api', ['throttle'])
 ```
 
 Apply a group to a route group using `router.middleware()`:
@@ -119,8 +128,9 @@ import { attachAuthContext, requireAuthenticated } from '@guren/core'
 app.use('*', attachAuthContext(() => authManager.createGuard('web')))
 
 // Using middleware alias (recommended)
-router.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
-router.aliasMiddleware('guest', requireGuest({ redirectTo: '/dashboard' }))
+const router = new Router()
+  .aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
+  .aliasMiddleware('guest', requireGuest({ redirectTo: '/dashboard' }))
 
 router.middleware('auth').group((auth) => {
   auth.get('/settings', [SettingsController, 'index'])
@@ -133,7 +143,7 @@ router.middleware('auth').group((auth) => {
 The CSRF middleware validates tokens on state-changing requests (POST, PUT, PATCH, DELETE):
 
 ```ts
-router.aliasMiddleware('csrf', csrfProtection())
+const router = new Router().aliasMiddleware('csrf', createCsrfMiddleware())
 
 router.middleware('csrf').group((csrf) => {
   csrf.post('/posts', [PostsController, 'store'])
@@ -145,9 +155,9 @@ router.middleware('csrf').group((csrf) => {
 Apply rate limiting to routes or groups:
 
 ```ts
-import { rateLimit } from '@guren/core'
+import { createRateLimitMiddleware } from '@guren/core'
 
-router.aliasMiddleware('throttle', rateLimit({ max: 60, windowMs: 60_000 }))
+const router = new Router().aliasMiddleware('throttle', createRateLimitMiddleware({ limit: 60, windowMs: 60_000 }))
 
 router.middleware('throttle').group((throttle) => {
   throttle.post('/api/login', [AuthController, 'login'])
@@ -175,7 +185,9 @@ export const requireSubscription = defineMiddleware(async (ctx, next) => {
 Register it as an alias for convenient use:
 
 ```ts
-router.aliasMiddleware('subscribed', requireSubscription)
+const router = new Router()
+  .aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
+  .aliasMiddleware('subscribed', requireSubscription)
 
 router.middleware('auth', 'subscribed').group((group) => {
   group.get('/premium', [PremiumController, 'index'])

--- a/docs/en/guides/routing.md
+++ b/docs/en/guides/routing.md
@@ -87,19 +87,29 @@ Give middleware functions short names so you can reference them as strings:
 import { Router, requireAuthenticated } from '@guren/core'
 import { requireAdmin } from '@/app/Http/middleware/admin'
 
-export function registerWebRoutes(router: Router): void {
-  router.aliasMiddleware('auth', requireAuthenticated())
-  router.aliasMiddleware('admin', requireAdmin())
+export function registerWebRoutes(baseRouter: Router): void {
+  const router = baseRouter
+    .aliasMiddleware('auth', requireAuthenticated())
+    .aliasMiddleware('admin', requireAdmin())
 }
 ```
 
+> [!IMPORTANT]
+> `aliasMiddleware()` returns a **new `Router` type** carrying the alias name it just registered. Call it without capturing the result and the name never reaches the type, so a later `.middleware('auth')` fails to compile. Always chain and assign, as above.
+
 ### Middleware Groups
 
-Bundle related middleware under a single name:
+Bundle related middleware under a single name. Group members must already be registered aliases:
 
 ```ts
-router.groupMiddleware('web', ['session', 'csrf'])
-router.groupMiddleware('api', ['throttle'])
+const router = new Router()
+  .aliasMiddleware('auth', requireAuthenticated())
+  .aliasMiddleware('admin', requireAdmin())
+  .aliasMiddleware('session', createSessionMiddleware())
+  .aliasMiddleware('csrf', createCsrfMiddleware())
+  .aliasMiddleware('throttle', createRateLimitMiddleware({ limit: 60, windowMs: 60_000 }))
+  .groupMiddleware('web', ['session', 'csrf'])
+  .groupMiddleware('api', ['throttle'])
 ```
 
 ### Applying Middleware

--- a/docs/en/tutorials/authentication.md
+++ b/docs/en/tutorials/authentication.md
@@ -76,10 +76,10 @@ import HomeController from '../app/Http/Controllers/HomeController.js'
 import PostController from '../app/Http/Controllers/PostController.js'
 import { PostPayloadSchema } from '../app/Http/Validators/PostValidator.js'
 
-export function registerWebRoutes(router: Router): void {
-  registerAuthRoutes(router)
+export function registerWebRoutes(baseRouter: Router): void {
+  const router = baseRouter.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
 
-  router.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
+  registerAuthRoutes(router)
 
   router.get('/', [HomeController, 'index'])
 
@@ -95,7 +95,7 @@ export function registerWebRoutes(router: Router): void {
 }
 ```
 
-`aliasMiddleware` names a middleware once so routes can reference it as `'auth'`. Reading and viewing posts stays public; `/posts/create` and the `POST /posts` submission now redirect guests to `/login`. If you have several protected routes, wrap them in a group instead of tagging each one:
+`aliasMiddleware` names a middleware once so routes can reference it as `'auth'`. It returns a new `Router` carrying that name in its type, so capture it with `const router = baseRouter.aliasMiddleware(...)` — drop the return value and the later `.middleware('auth')` will not compile. Reading and viewing posts stays public; `/posts/create` and the `POST /posts` submission now redirect guests to `/login`. If you have several protected routes, wrap them in a group instead of tagging each one:
 
 ```ts
 posts.middleware('auth').group((authed) => {

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -360,9 +360,10 @@ import { Router, requireAuthenticated, requireGuest } from '@guren/core'
 import LoginController from '@/app/Http/Controllers/Auth/LoginController'
 import DashboardController from '@/app/Http/Controllers/DashboardController'
 
-export function registerWebRoutes(router: Router): void {
-  router.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
-  router.aliasMiddleware('guest', requireGuest({ redirectTo: '/dashboard' }))
+export function registerWebRoutes(baseRouter: Router): void {
+  const router = baseRouter
+    .aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
+    .aliasMiddleware('guest', requireGuest({ redirectTo: '/dashboard' }))
 
   router.middleware('guest').group((guest) => {
     guest.get('/login', [LoginController, 'show'])

--- a/docs/ja/guides/routing.md
+++ b/docs/ja/guides/routing.md
@@ -43,9 +43,10 @@ router.group('/posts', (posts) => {
 import { Router, requireAuthenticated } from '@guren/core'
 import { requireAdmin } from '@/app/Http/middleware/admin'
 
-export function registerWebRoutes(router: Router): void {
-  router.aliasMiddleware('auth', requireAuthenticated())
-  router.aliasMiddleware('admin', requireAdmin())
+export function registerWebRoutes(baseRouter: Router): void {
+  const router = baseRouter
+    .aliasMiddleware('auth', requireAuthenticated())
+    .aliasMiddleware('admin', requireAdmin())
 
   router.get('/admin', [AdminController, 'index']).middleware('auth', 'admin')
 }
@@ -59,11 +60,15 @@ export function registerWebRoutes(router: Router): void {
 import { Router, requireAuthenticated } from '@guren/core'
 import { requireAdmin } from '@/app/Http/middleware/admin'
 
-export function registerWebRoutes(router: Router): void {
-  router.aliasMiddleware('auth', requireAuthenticated())
-  router.aliasMiddleware('admin', requireAdmin())
+export function registerWebRoutes(baseRouter: Router): void {
+  const router = baseRouter
+    .aliasMiddleware('auth', requireAuthenticated())
+    .aliasMiddleware('admin', requireAdmin())
 }
 ```
+
+> [!IMPORTANT]
+> `aliasMiddleware()` は登録済みのエイリアス名を型に載せた**新しい `Router` 型**を返します。戻り値を受け取らずに呼び出すと登録名が型に伝わらず、後続の `.middleware('auth')` が型エラーになります。上記のように必ずチェーンして受け取ってください。
 
 エイリアスを登録すれば、ミドルウェアが受け入れられる場所ならどこでも文字列名で使えます。
 
@@ -74,11 +79,17 @@ router.get('/admin', [AdminController, 'index']).middleware('auth', 'admin')
 
 ### ミドルウェアグループ
 
-よく使うミドルウェアの組み合わせを一つの名前にまとめられます。
+よく使うミドルウェアの組み合わせを一つの名前にまとめられます。グループのメンバーは、先にエイリアス登録済みの名前でなければなりません。
 
 ```ts
-router.groupMiddleware('web', ['session', 'csrf'])
-router.groupMiddleware('api', ['throttle:60'])
+const router = new Router()
+  .aliasMiddleware('auth', requireAuthenticated())
+  .aliasMiddleware('admin', requireAdmin())
+  .aliasMiddleware('session', createSessionMiddleware())
+  .aliasMiddleware('csrf', createCsrfMiddleware())
+  .aliasMiddleware('throttle', createRateLimitMiddleware({ limit: 60, windowMs: 60_000 }))
+  .groupMiddleware('web', ['session', 'csrf'])
+  .groupMiddleware('api', ['throttle'])
 ```
 
 ミドルウェアグループをルートグループに適用します。

--- a/docs/ja/tutorials/authentication.md
+++ b/docs/ja/tutorials/authentication.md
@@ -76,10 +76,10 @@ import HomeController from '../app/Http/Controllers/HomeController.js'
 import PostController from '../app/Http/Controllers/PostController.js'
 import { PostPayloadSchema } from '../app/Http/Validators/PostValidator.js'
 
-export function registerWebRoutes(router: Router): void {
-  registerAuthRoutes(router)
+export function registerWebRoutes(baseRouter: Router): void {
+  const router = baseRouter.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
 
-  router.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
+  registerAuthRoutes(router)
 
   router.get('/', [HomeController, 'index'])
 
@@ -95,7 +95,7 @@ export function registerWebRoutes(router: Router): void {
 }
 ```
 
-`aliasMiddleware` はミドルウェアに一度だけ名前を付け、ルートからは `'auth'` として参照できるようにします。投稿の一覧と閲覧は公開のまま、`/posts/create` と `POST /posts` の送信は、未ログインの訪問者を `/login` にリダイレクトするようになりました。保護したいルートが複数あるなら、1 つずつタグ付けする代わりにグループでまとめられます。
+`aliasMiddleware` はミドルウェアに一度だけ名前を付け、ルートからは `'auth'` として参照できるようにします。戻り値はエイリアス名を型に載せた新しい `Router` なので、`const router = baseRouter.aliasMiddleware(...)` のように必ず受け取ってください（受け取らないと後続の `.middleware('auth')` が型エラーになります）。投稿の一覧と閲覧は公開のまま、`/posts/create` と `POST /posts` の送信は、未ログインの訪問者を `/login` にリダイレクトするようになりました。保護したいルートが複数あるなら、1 つずつタグ付けする代わりにグループでまとめられます。
 
 ```ts
 posts.middleware('auth').group((authed) => {

--- a/examples/blog/routes/auth.ts
+++ b/examples/blog/routes/auth.ts
@@ -13,13 +13,9 @@ import { ForgotPasswordSchema } from '../app/Http/Validators/ForgotPasswordValid
 import { ResetPasswordSchema } from '../app/Http/Validators/ResetPasswordValidator.js'
 import { ProfileUpdateSchema } from '../app/Http/Validators/ProfileValidator.js'
 
-// Relies on the 'auth'/'guest' aliases the caller (routes/web.ts) has
-// already registered on this router via aliasMiddleware() — reusing them
-// (via .group(), not direct .middleware(name).post() chaining, since the
-// latter's RouterMiddlewareGroupBuilder doesn't support the
-// [Controller, 'method'] tuple + typed body-schema combination) keeps this
-// middleware visible to `guren audit`'s static route inspection, unlike
-// passing requireAuthenticated()/requireGuest() call results inline.
+// Relies on the 'auth'/'guest' aliases the caller (routes/web.ts) registered
+// via aliasMiddleware(), which is why the parameter is typed Router<'auth' | 'guest'>
+// rather than Router — the alias names have to be in the type to be referenced here.
 export function registerAuthRoutes(router: Router<'auth' | 'guest'>): void {
   router.middleware('guest').group((guest) => {
     guest.get('/login', { name: 'login' }, [LoginController, 'show'])

--- a/packages/cli/src/make-feature.ts
+++ b/packages/cli/src/make-feature.ts
@@ -102,7 +102,6 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
     consola.success(`Created ${file}`)
   }
 
-  const authSuffix = withAuth ? `.middleware('auth')` : ''
   const schemaPath = schemaPathFor(moduleName)
   const routesPath = moduleName ? `modules/${moduleName}/routes.ts` : 'routes/web.ts'
   const controllerImportPath = moduleName ? './app/Http/Controllers' : '../app/Http/Controllers'
@@ -113,18 +112,9 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
   consola.info(`  2. Register routes in ${routesPath} with body schemas:`)
   consola.info(`     import ${singular}Controller from '${controllerImportPath}/${singular}Controller.js'`)
   consola.info(`     import { ${singular}PayloadSchema } from '${validatorImportPath}/${singular}Validator.js'`)
-  if (withAuth) {
-    consola.info(`     router.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))`)
+  for (const line of buildRouteRegistrationHint({ singular, routeName, routeVar, withAuth })) {
+    consola.info(`     ${line}`)
   }
-  consola.info(`     router.group('/${routeName}', (${routeVar}) => {`)
-  consola.info(`       ${routeVar}.get('/', [${singular}Controller, 'index']).name('${routeName}.index')`)
-  consola.info(`       ${routeVar}.get('/create', [${singular}Controller, 'create']).name('${routeName}.create')`)
-  consola.info(`       ${routeVar}.get('/:id', [${singular}Controller, 'show']).name('${routeName}.show')`)
-  consola.info(`       ${routeVar}.get('/:id/edit', [${singular}Controller, 'edit']).name('${routeName}.edit')`)
-  consola.info(`       ${routeVar}.post('/', { name: '${routeName}.store', body: ${singular}PayloadSchema }, [${singular}Controller, 'store'])${authSuffix}`)
-  consola.info(`       ${routeVar}.put('/:id', { name: '${routeName}.update', body: ${singular}PayloadSchema }, [${singular}Controller, 'update'])${authSuffix}`)
-  consola.info(`       ${routeVar}.delete('/:id', { name: '${routeName}.destroy' }, [${singular}Controller, 'destroy'])${authSuffix}`)
-  consola.info(`     })`)
   consola.info(`  3. Run: bunx guren db:migrate`)
   consola.info(`  4. Run: bunx guren codegen`)
   if (withPolicy) {
@@ -148,6 +138,41 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
   }
 
   return created
+}
+
+/**
+ * The route-registration block `make:feature` prints for the developer to paste
+ * into their registrar. It has to compile verbatim inside
+ * `export function register*Routes(router: Router)` — the shape both the default
+ * app template and `make:module` scaffold — so the auth alias binds a *new* name
+ * instead of assuming a differently-named parameter or shadowing `router`.
+ * Capturing that return value is what puts `'auth'` into the router's type;
+ * discard it and every `.middleware('auth')` below stops compiling.
+ */
+export function buildRouteRegistrationHint(options: {
+  singular: string
+  routeName: string
+  routeVar: string
+  withAuth: boolean
+}): string[] {
+  const { singular, routeName, routeVar, withAuth } = options
+  const authSuffix = withAuth ? `.middleware('auth')` : ''
+  const groupRouter = withAuth ? 'authRouter' : 'router'
+
+  return [
+    ...(withAuth
+      ? [`const ${groupRouter} = router.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))`]
+      : []),
+    `${groupRouter}.group('/${routeName}', (${routeVar}) => {`,
+    `  ${routeVar}.get('/', [${singular}Controller, 'index']).name('${routeName}.index')`,
+    `  ${routeVar}.get('/create', [${singular}Controller, 'create']).name('${routeName}.create')`,
+    `  ${routeVar}.get('/:id', [${singular}Controller, 'show']).name('${routeName}.show')`,
+    `  ${routeVar}.get('/:id/edit', [${singular}Controller, 'edit']).name('${routeName}.edit')`,
+    `  ${routeVar}.post('/', { name: '${routeName}.store', body: ${singular}PayloadSchema }, [${singular}Controller, 'store'])${authSuffix}`,
+    `  ${routeVar}.put('/:id', { name: '${routeName}.update', body: ${singular}PayloadSchema }, [${singular}Controller, 'update'])${authSuffix}`,
+    `  ${routeVar}.delete('/:id', { name: '${routeName}.destroy' }, [${singular}Controller, 'destroy'])${authSuffix}`,
+    `})`,
+  ]
 }
 
 // --- Template generators ---

--- a/packages/cli/templates/agent/.claude/rules/routes-codegen.md
+++ b/packages/cli/templates/agent/.claude/rules/routes-codegen.md
@@ -12,11 +12,14 @@ globs:
 ```typescript
 import { Router, requireAuthenticated } from '@guren/core'
 
-export function registerWebRoutes(router: Router): void {
+export function registerWebRoutes(baseRouter: Router): void {
+  // aliasMiddleware() returns a Router carrying the alias name in its type —
+  // capture it, or a later .middleware('auth') will not compile.
+  const router = baseRouter.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
+
   router.get('/posts', [PostController, 'index']).name('posts.index')
   router.post('/posts', { name: 'posts.store', body: CreatePostSchema }, [PostController, 'store'])
 
-  router.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
   router.middleware('auth').group((group) => {
     group.get('/dashboard', [DashboardController, 'index'])
   })

--- a/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
+++ b/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
@@ -133,8 +133,10 @@ Source: `packages/server/src/mvc/Router.ts`
 import { Router, requireAuthenticated } from '@guren/core'
 import { PostPayloadSchema } from '../app/Http/Validators/PostValidator.js'
 
-export function registerWebRoutes(router: Router): void {
-  router.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
+export function registerWebRoutes(baseRouter: Router): void {
+  // aliasMiddleware() returns a Router carrying the alias name in its type —
+  // capture it, or a later .middleware('auth') will not compile.
+  const router = baseRouter.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
 
   router.get('/posts', [PostController, 'index']).name('posts.index')
   // Attach body schema to mutation routes for codegen type extraction

--- a/packages/cli/templates/agent/CLAUDE.md
+++ b/packages/cli/templates/agent/CLAUDE.md
@@ -167,7 +167,9 @@ export class Post extends defineModel(posts) {
 - Attaching a Zod schema to a route both validates the request automatically and
   feeds `bunx guren codegen` typed manifests. Details in `.claude/rules/routes-codegen.md`.
 - Middleware: `defineMiddleware(async (c, next) => { ... })` from `@guren/core`;
-  register aliases via `router.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))`.
+  register aliases via `const router = baseRouter.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))`
+  — the return value carries the alias name in the router's type, so dropping it makes
+  a later `.middleware('auth')` fail to compile.
 
 ## Testing
 

--- a/packages/cli/tests/make-feature.test.ts
+++ b/packages/cli/tests/make-feature.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
-import { makeFeature } from '../src/make-feature'
+import { makeFeature, buildRouteRegistrationHint } from '../src/make-feature'
 import { parseFieldsString } from '../src/fields'
 import { createTempWorkspace } from './helpers'
 
@@ -337,5 +337,48 @@ describe('makeFeature', () => {
     } finally {
       await workspace.cleanup()
     }
+  })
+})
+
+describe('buildRouteRegistrationHint', () => {
+  // Scaffolded registrars — the default app template and every `make:module`
+  // module — name their parameter `router`. The printed block is meant to be
+  // pasted in as-is, so it may only reference `router` and names it binds itself.
+  const REGISTRAR_PARAM = 'router'
+
+  it('only references identifiers a scaffolded registrar actually has', () => {
+    const lines = buildRouteRegistrationHint({
+      singular: 'Post', routeName: 'posts', routeVar: 'posts', withAuth: true,
+    })
+
+    const bound = new Set([REGISTRAR_PARAM, 'posts'])
+    for (const declaration of lines.join('\n').matchAll(/\bconst (\w+) =/gu)) {
+      bound.add(declaration[1] as string)
+    }
+
+    for (const receiver of lines.join('\n').matchAll(/^\s*(\w+)\./gmu)) {
+      expect(bound).toContain(receiver[1] as string)
+    }
+  })
+
+  it('binds a fresh name from the registrar parameter instead of shadowing it', () => {
+    const [aliasLine] = buildRouteRegistrationHint({
+      singular: 'Post', routeName: 'posts', routeVar: 'posts', withAuth: true,
+    })
+
+    // Capturing the return value is what puts 'auth' in the router's type; a bare
+    // `router.aliasMiddleware(...)` leaves every `.middleware('auth')` below broken.
+    expect(aliasLine).toMatch(/^const (\w+) = router\.aliasMiddleware\('auth', /u)
+    expect(aliasLine).not.toContain(`const ${REGISTRAR_PARAM} =`)
+  })
+
+  it('omits the alias registration and middleware suffixes when --public', () => {
+    const lines = buildRouteRegistrationHint({
+      singular: 'Post', routeName: 'posts', routeVar: 'posts', withAuth: false,
+    })
+
+    expect(lines.join('\n')).not.toContain('aliasMiddleware')
+    expect(lines.join('\n')).not.toContain(".middleware('auth')")
+    expect(lines[0]).toBe(`${REGISTRAR_PARAM}.group('/posts', (posts) => {`)
   })
 })

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -688,6 +688,17 @@ class RouterMiddlewareGroupBuilder<M extends string = never> {
     options: RouteContractOptions<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
     handler: TypedRouteHandler<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
   ): RouteBuilder<M>
+  get<
+    C extends ControllerConstructor,
+    TParamsSchema extends SchemaLike<unknown>,
+    TQuerySchema extends SchemaLike<unknown>,
+    TBodySchema extends SchemaLike<unknown>,
+    TOutputSchema extends SchemaLike<unknown>,
+  >(
+    path: string,
+    options: RouteContractOptions<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
+    handler: ControllerAction<C>,
+  ): RouteBuilder<M>
   get(path: string, handlerOrOptions: unknown, ...rest: unknown[]): RouteBuilder<M> {
     return this.router.applyMiddlewareScope(this.names, () => this.router.get(path, handlerOrOptions as never, ...(rest as never[])))
   }
@@ -702,6 +713,17 @@ class RouterMiddlewareGroupBuilder<M extends string = never> {
     path: string,
     options: RouteContractOptions<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
     handler: TypedRouteHandler<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
+  ): RouteBuilder<M>
+  post<
+    C extends ControllerConstructor,
+    TParamsSchema extends SchemaLike<unknown>,
+    TQuerySchema extends SchemaLike<unknown>,
+    TBodySchema extends SchemaLike<unknown>,
+    TOutputSchema extends SchemaLike<unknown>,
+  >(
+    path: string,
+    options: RouteContractOptions<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
+    handler: ControllerAction<C>,
   ): RouteBuilder<M>
   post(path: string, handlerOrOptions: unknown, ...rest: unknown[]): RouteBuilder<M> {
     return this.router.applyMiddlewareScope(this.names, () => this.router.post(path, handlerOrOptions as never, ...(rest as never[])))
@@ -718,6 +740,17 @@ class RouterMiddlewareGroupBuilder<M extends string = never> {
     options: RouteContractOptions<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
     handler: TypedRouteHandler<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
   ): RouteBuilder<M>
+  put<
+    C extends ControllerConstructor,
+    TParamsSchema extends SchemaLike<unknown>,
+    TQuerySchema extends SchemaLike<unknown>,
+    TBodySchema extends SchemaLike<unknown>,
+    TOutputSchema extends SchemaLike<unknown>,
+  >(
+    path: string,
+    options: RouteContractOptions<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
+    handler: ControllerAction<C>,
+  ): RouteBuilder<M>
   put(path: string, handlerOrOptions: unknown, ...rest: unknown[]): RouteBuilder<M> {
     return this.router.applyMiddlewareScope(this.names, () => this.router.put(path, handlerOrOptions as never, ...(rest as never[])))
   }
@@ -733,6 +766,17 @@ class RouterMiddlewareGroupBuilder<M extends string = never> {
     options: RouteContractOptions<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
     handler: TypedRouteHandler<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
   ): RouteBuilder<M>
+  patch<
+    C extends ControllerConstructor,
+    TParamsSchema extends SchemaLike<unknown>,
+    TQuerySchema extends SchemaLike<unknown>,
+    TBodySchema extends SchemaLike<unknown>,
+    TOutputSchema extends SchemaLike<unknown>,
+  >(
+    path: string,
+    options: RouteContractOptions<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
+    handler: ControllerAction<C>,
+  ): RouteBuilder<M>
   patch(path: string, handlerOrOptions: unknown, ...rest: unknown[]): RouteBuilder<M> {
     return this.router.applyMiddlewareScope(this.names, () => this.router.patch(path, handlerOrOptions as never, ...(rest as never[])))
   }
@@ -747,6 +791,17 @@ class RouterMiddlewareGroupBuilder<M extends string = never> {
     path: string,
     options: RouteContractOptions<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
     handler: TypedRouteHandler<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
+  ): RouteBuilder<M>
+  delete<
+    C extends ControllerConstructor,
+    TParamsSchema extends SchemaLike<unknown>,
+    TQuerySchema extends SchemaLike<unknown>,
+    TBodySchema extends SchemaLike<unknown>,
+    TOutputSchema extends SchemaLike<unknown>,
+  >(
+    path: string,
+    options: RouteContractOptions<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
+    handler: ControllerAction<C>,
   ): RouteBuilder<M>
   delete(path: string, handlerOrOptions: unknown, ...rest: unknown[]): RouteBuilder<M> {
     return this.router.applyMiddlewareScope(this.names, () => this.router.delete(path, handlerOrOptions as never, ...(rest as never[])))

--- a/packages/server/tests/mvc/router.test.ts
+++ b/packages/server/tests/mvc/router.test.ts
@@ -132,6 +132,64 @@ describe('Router route contract metadata', () => {
   })
 })
 
+// `RouterMiddlewareGroupBuilder` mirrors `Router`'s per-verb overloads by hand,
+// and drifting out of sync is exactly the bug these tests were added for. This
+// assignment fails to compile the moment the builder stops accepting everything
+// `Router` does — including overloads added long after this was written, which a
+// per-call test can never anticipate. Root `tsc --noEmit` covers this directory.
+const _verbParityGuard: Pick<Router<'auth'>, 'get' | 'post' | 'put' | 'patch' | 'delete'> =
+  new Router<'auth'>().aliasMiddleware('auth', async (_c, next) => { await next() }).middleware('auth')
+void _verbParityGuard
+
+describe('Router middleware group builder with contract options', () => {
+  const body = z.object({ title: z.string().min(1) })
+
+  it('accepts a controller action alongside contract options on every verb', () => {
+    // The alias name is inferred from the captured aliasMiddleware() return —
+    // the form the routing docs teach — rather than declared as `new Router<'auth'>()`.
+    const router = new Router().aliasMiddleware('auth', async (_c, next) => { await next() })
+
+    const scoped = router.middleware('auth')
+    scoped.get('/posts/:id/edit', { name: 'posts.edit' }, [StubController, 'edit'])
+    scoped.post('/posts', { name: 'posts.store', body }, [StubController, 'store'])
+    scoped.put('/posts/:id', { name: 'posts.update', body }, [StubController, 'update'])
+    scoped.patch('/posts/:id', { name: 'posts.patch', body }, [StubController, 'update'])
+    scoped.delete('/posts/:id', { name: 'posts.destroy' }, [StubController, 'destroy'])
+
+    expect(router.definitions().map((d) => `${d.method} ${d.path}`)).toEqual([
+      'GET /posts/:id/edit',
+      'POST /posts',
+      'PUT /posts/:id',
+      'PATCH /posts/:id',
+      'DELETE /posts/:id',
+    ])
+
+    const post = router.definitions()[1]
+    expect(post!.name).toBe('posts.store')
+    expect(post!.middlewareNames).toEqual(['auth'])
+    expect(post!.schemas?.body).toBe(body)
+    expect(post!.controller).toEqual({ name: 'StubController', action: 'store' })
+  })
+
+  it('routes the request through the aliased middleware', async () => {
+    const router = new Router<'auth'>()
+    const seen: string[] = []
+    router.aliasMiddleware('auth', async (_c, next) => { seen.push('auth'); await next() })
+    router.middleware('auth').post('/posts', { name: 'posts.store', body }, [StubController, 'store'])
+
+    const app = new Hono()
+    router.mount(app)
+    const response = await app.request('/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Hello' }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(seen).toEqual(['auth'])
+  })
+})
+
 describe('Router definition introspection', () => {
   it('exposes controller binding for controller action routes', () => {
     const router = new Router()

--- a/scripts/smoke/docs-audit.ts
+++ b/scripts/smoke/docs-audit.ts
@@ -79,7 +79,7 @@ async function auditEnglishDocs(root: string): Promise<void> {
 
   const middleware = await read(root, 'docs/en/guides/middleware.md')
   assert(middleware.includes("import { Router } from '@guren/core'"), 'Middleware guide must use Router from @guren/core.')
-  assert(middleware.includes('router.aliasMiddleware('), 'Middleware guide must use router.aliasMiddleware().')
+  assert(middleware.includes('.aliasMiddleware('), 'Middleware guide must register aliases through the chained .aliasMiddleware() form.')
   assert(!middleware.includes('Route.aliasMiddleware('), 'Middleware guide must not use legacy Route.aliasMiddleware().')
 
   const validation = await read(root, 'docs/en/guides/validation.md')
@@ -321,7 +321,29 @@ async function auditJapaneseDocs(root: string): Promise<void> {
 // are leftovers from the old `@/*` -> `./app/*` mapping and no longer resolve.
 const STALE_APP_ALIAS_PATTERN = /['"]@\/(?:Http|Models|Policies|Events|Jobs|Listeners|Mail|Notifications|Providers|Services|Validators|Console|Exceptions|utils)\//u
 
-async function auditAliasConvention(root: string): Promise<void> {
+// `aliasMiddleware()` returns a *new* Router type carrying the alias name, so a
+// call whose value is thrown away registers the handler at runtime while leaving
+// the name invisible to the type system — every later `.middleware('auth')` then
+// fails to compile. Match a statement that opens with a plain or member
+// expression and drops the result; `const router = base.aliasMiddleware(...)`,
+// chain continuations opening with `.`, and same-line chains ending in another
+// call are all correct and must not match.
+const DISCARDED_ALIAS_MIDDLEWARE_PATTERN = /^[\w$]+(?:\.[\w$]+)*\.aliasMiddleware\((?!.*\)\s*\.\w)/u
+
+const DOC_LINE_RULES: { pattern: RegExp; describe: (location: string) => string }[] = [
+  {
+    pattern: STALE_APP_ALIAS_PATTERN,
+    describe: (location) =>
+      `${location} uses an app-relative alias import (e.g. \`@/Http/...\`); the \`@/\` alias resolves from the project root, so write \`@/app/...\` instead.`,
+  },
+  {
+    pattern: DISCARDED_ALIAS_MIDDLEWARE_PATTERN,
+    describe: (location) =>
+      `${location} discards the aliasMiddleware() return value, so the alias name never reaches the router's type and a later \`.middleware('auth')\` will not compile. Write \`const router = baseRouter.aliasMiddleware(...)\`, or declare the names up front with \`new Router<'auth'>()\`.`,
+  },
+]
+
+async function auditDocLineRules(root: string): Promise<void> {
   const docsDir = join(root, 'docs')
   const entries = await readdir(docsDir, { recursive: true, withFileTypes: true })
 
@@ -332,11 +354,11 @@ async function auditAliasConvention(root: string): Promise<void> {
 
     const filePath = join(entry.parentPath, entry.name)
     const lines = (await readFile(filePath, 'utf8')).split('\n')
-    const hit = lines.findIndex((line) => STALE_APP_ALIAS_PATTERN.test(line))
-    assert(
-      hit === -1,
-      `${relative(root, filePath)}:${hit + 1} uses an app-relative alias import (e.g. \`@/Http/...\`); the \`@/\` alias resolves from the project root, so write \`@/app/...\` instead.`,
-    )
+
+    for (const { pattern, describe } of DOC_LINE_RULES) {
+      const hit = lines.findIndex((line) => pattern.test(line.trim()))
+      assert(hit === -1, describe(`${relative(root, filePath)}:${hit + 1}`))
+    }
   }
 }
 
@@ -344,7 +366,7 @@ async function main(): Promise<void> {
   const root = resolve(process.argv[2] ?? '.')
   await auditEnglishDocs(root)
   await auditJapaneseDocs(root)
-  await auditAliasConvention(root)
+  await auditDocLineRules(root)
   console.log(`Docs audit passed for ${root}`)
 }
 


### PR DESCRIPTION
## Summary

- `router.middleware('auth').post('/posts', { name, body: Schema }, [Controller, 'store'])` raised `TS2769` even though it worked at runtime: `RouterMiddlewareGroupBuilder` carried only two overloads per HTTP verb, missing the contract-options + `[Controller, 'method']` variant `Router` itself has. All five verbs (`get`/`post`/`put`/`patch`/`delete`) now expose the missing overload, so the direct chain no longer needs a `.group()` wrapper to compile.
- Added a type-level parity guard (`Pick<Router<M>, ...>` assignment) in `packages/server/tests/mvc/router.test.ts` so a future `Router` overload can't silently drift out of sync with the builder again — verified it fails to compile when an overload is removed from just one side.
- Docs, the CLI agent-harness templates, and `examples/blog/routes/auth.ts`'s stale comment taught (or referenced) a discarded `router.aliasMiddleware(...)` call. `aliasMiddleware()` returns a *new* `Router` type carrying the alias name; dropping the return value registers the middleware at runtime but leaves the name invisible to the type system, so every later `.middleware('auth')` fails to compile. Fixed across `docs/{en,ja}/guides/{routing,middleware,authentication,architecture}.md`, `docs/{en,ja}/tutorials/authentication.md`, `CLAUDE.md`, `.claude/skills/guren-api/SKILL.md`, and the CLI's `packages/cli/templates/agent/**` copies.
- Folded the new doc-audit rule into the existing `docs/`-wide line-rule walker in `scripts/smoke/docs-audit.ts` instead of hand-wiring 8 file-specific assertions — now covers all of `docs/`, not just the files this PR happened to touch.
- Found and fixed a second, independent bug the same audit run surfaced: the `make:feature` next-steps hint printed `const router = baseRouter.aliasMiddleware(...)`, but the scaffolded registrar's actual parameter is named `router` — pasting the hint gave an undefined `baseRouter` plus a `const router` redeclaration. Extracted the hint into a tested `buildRouteRegistrationHint()` helper that binds a fresh name instead of assuming the caller's parameter name.

## Test plan

- [x] `bun run typecheck` (root + `examples/blog` + `examples/api`)
- [x] `bun test ./packages/server/tests/mvc/router.test.ts` — includes a mutation check that the new type-parity guard fails to compile when an overload is dropped
- [x] `bun test ./packages/cli/tests/make-feature.test.ts` — includes a mutation check that the old hint form fails the new assertions
- [x] `bun run test:bun server cli` — 2960 pass / 0 fail
- [x] `bun run audit:docs`, `audit:core-first`, `audit:starter-template`, `audit:template-deps`
- [x] Manually ran `bunx guren make:feature` and verified the printed hint pastes and compiles verbatim into the default scaffold's `routes/web.ts`