### PR TITLE
fix(cli): build emailed auth links from APP_URL, not the request host

### DIFF
--- a/.changeset/auth-links-from-app-url.md
+++ b/.changeset/auth-links-from-app-url.md
@@ -1,0 +1,40 @@
+---
+"@guren/cli": patch
+"create-guren-app": minor
+---
+
+Build emailed auth links from `APP_URL` instead of the request host
+
+The password reset flow scaffolded by `guren add auth` (and by
+`create-guren-app --auth`) built its link from the request:
+
+```js
+buildPasswordResetUrl(`${new URL(this.request.url).origin}/reset-password`, token, email)
+```
+
+A server request's URL is reconstructed from the `Host` header, which any
+client can forge — the framework's own host-authorization middleware says so,
+reading `ctx.req.header('host') ?? new URL(ctx.req.url).host` as one value. So
+an unauthenticated attacker could `POST /forgot-password` with someone else's
+address in the body and `Host: attacker.tld`, and the app would mail *that
+person* a genuine, single-use reset link pointing at the attacker's server. The
+victim sees a legitimate mail from the real service; one click — or one
+link-prefetching mail scanner — hands over the token, and `ResetPasswordController`
+accepts it with no session binding or second factor.
+
+Scaffolds now route every emailed link through a generated `app/Auth/AppUrl.ts`,
+which reads `APP_URL` and **fails closed in production** rather than falling back
+to the request. Development keeps working with no configuration. The three email
+verification sites got the same treatment: they mail the requester's own address,
+so they were not exploitable, but they were the same pattern.
+
+Templates also stop disabling host authorization in production. It was
+`process.env.NODE_ENV === 'production' ? false : { ... }`, which removed the
+middleware in exactly the environment that needed it; the production branch now
+derives its allowlist from `APP_URL`'s hostname, and health-check paths stay
+excluded so load balancers reaching the app by IP are unaffected.
+
+**Action required for new apps:** `APP_URL` must be set in production. It is
+already present in the scaffolded `.env.example`. Existing apps are unchanged —
+if yours has a `ForgotPasswordController` generated before this release, apply
+the same change by hand, or re-run `guren add auth --force`.

--- a/.changeset/auth-links-from-app-url.md
+++ b/.changeset/auth-links-from-app-url.md
@@ -1,5 +1,6 @@
 ---
 "@guren/cli": patch
+"@guren/server": patch
 "create-guren-app": minor
 ---
 
@@ -32,7 +33,18 @@ Templates also stop disabling host authorization in production. It was
 `process.env.NODE_ENV === 'production' ? false : { ... }`, which removed the
 middleware in exactly the environment that needed it; the production branch now
 derives its allowlist from `APP_URL`'s hostname, and health-check paths stay
-excluded so load balancers reaching the app by IP are unaffected.
+excluded so load balancers reaching the app by IP are unaffected. When `APP_URL`
+is not readable at module scope the template warns and leaves the check off
+rather than throwing — the Cloudflare worker imports the app before wrangler
+`vars` reach `process.env`, and a throw there would stop the app booting at all.
+`guren audit` now also flags `hostAuthorization: false`, which it previously
+walked past while the templates themselves shipped it.
+
+In `@guren/server`, a `host:*` allowlist entry now means "this host on any
+**port**". `compileHostMatcher` accepted anything after the colon, so
+`example.com:*` also matched a `Host` of `example.com:attacker.tld`. The same
+middleware stops re-parsing the whole request URL to read its path on every
+request, which it now does in production rather than only in development.
 
 **Action required for new apps:** `APP_URL` must be set in production. It is
 already present in the scaffolded `.env.example`. Existing apps are unchanged —

--- a/examples/blog/app/Auth/AppUrl.ts
+++ b/examples/blog/app/Auth/AppUrl.ts
@@ -12,7 +12,12 @@ export function appUrl(request: { url: string }): string {
   const configured = process.env.APP_URL?.trim()
 
   if (configured) {
-    return configured.endsWith('/') ? configured.slice(0, -1) : configured
+    // Parsed rather than concatenated: a malformed APP_URL has to fail here,
+    // where every caller hits it, not later inside one particular link build.
+    // Dropping any query/fragment and the trailing slash keeps the result
+    // safe to append a path to.
+    const parsed = new URL(configured)
+    return `${parsed.origin}${parsed.pathname.replace(/\/+$/, '')}`
   }
 
   if (process.env.NODE_ENV === 'production') {

--- a/examples/blog/app/Auth/AppUrl.ts
+++ b/examples/blog/app/Auth/AppUrl.ts
@@ -1,0 +1,26 @@
+/**
+ * Absolute base URL for links that leave the app (password reset, email
+ * verification).
+ *
+ * Deliberately not derived from the request in production. A request URL is
+ * reconstructed from the `Host` header, which any client can forge, so a
+ * forged host would make the app mail a genuine single-use token to a link
+ * pointing at the attacker's own server. `APP_URL` is the only trustworthy
+ * source, and production fails closed rather than falling back to the request.
+ */
+export function appUrl(request: { url: string }): string {
+  const configured = process.env.APP_URL?.trim()
+
+  if (configured) {
+    return configured.endsWith('/') ? configured.slice(0, -1) : configured
+  }
+
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error(
+      'APP_URL is not set. Set it to the public base URL of this app (for example ' +
+        'https://example.com): links sent by email must not be derived from the request host.',
+    )
+  }
+
+  return new URL(request.url).origin
+}

--- a/examples/blog/app/Http/Controllers/Auth/ForgotPasswordController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/ForgotPasswordController.ts
@@ -2,6 +2,7 @@ import { Controller, createPasswordResetToken, buildPasswordResetUrl } from '@gu
 import { ForgotPasswordSchema } from '../../Validators/ForgotPasswordValidator.js'
 import { User } from '../../../Models/User.js'
 import { passwordResetStore } from '../../../Auth/PasswordResetStore.js'
+import { appUrl } from '../../../Auth/AppUrl.js'
 import { SendPasswordResetEmailJob } from '../../../Jobs/SendPasswordResetEmailJob.js'
 import { pages } from '@/.guren/pages.gen'
 
@@ -23,7 +24,7 @@ export default class ForgotPasswordController extends Controller {
     const [user] = await User.where({ email })
     if (user) {
       const { token } = await createPasswordResetToken(email, passwordResetStore)
-      const resetUrl = buildPasswordResetUrl(`${new URL(this.request.url).origin}/reset-password`, token, email)
+      const resetUrl = buildPasswordResetUrl(`${appUrl(this.request)}/reset-password`, token, email)
       await SendPasswordResetEmailJob.dispatch({ email, resetUrl })
     }
 

--- a/examples/blog/app/Http/Controllers/Auth/ForgotPasswordController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/ForgotPasswordController.ts
@@ -16,6 +16,11 @@ export default class ForgotPasswordController extends Controller {
   async store(): Promise<Response> {
     const { email } = await this.validateBody(ForgotPasswordSchema)
 
+    // Resolved before the lookup on purpose: a misconfigured APP_URL throws,
+    // and throwing only for addresses that turned out to exist would answer
+    // the question the generic status message below refuses to.
+    const resetBaseUrl = `${appUrl(this.request)}/reset-password`
+
     // Always respond with the same status message whether or not the
     // account exists, to avoid leaking which emails are registered. The
     // email itself is dispatched to a queue rather than awaited inline, so
@@ -24,7 +29,7 @@ export default class ForgotPasswordController extends Controller {
     const [user] = await User.where({ email })
     if (user) {
       const { token } = await createPasswordResetToken(email, passwordResetStore)
-      const resetUrl = buildPasswordResetUrl(`${appUrl(this.request)}/reset-password`, token, email)
+      const resetUrl = buildPasswordResetUrl(resetBaseUrl, token, email)
       await SendPasswordResetEmailJob.dispatch({ email, resetUrl })
     }
 

--- a/examples/blog/app/Http/Controllers/Auth/RegisterController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/RegisterController.ts
@@ -2,6 +2,7 @@ import { Controller, ValidationException, createEmailVerificationToken, buildVer
 import { RegisterSchema } from '../../Validators/RegisterValidator.js'
 import { User } from '../../../Models/User.js'
 import { emailVerificationStore } from '../../../Auth/EmailVerificationStore.js'
+import { appUrl } from '../../../Auth/AppUrl.js'
 import { sendEmailVerificationMail } from '../../../Mail/EmailVerificationMail.js'
 import { SendWelcomeEmailJob } from '../../../Jobs/SendWelcomeEmailJob.js'
 import { pages } from '@/.guren/pages.gen'
@@ -26,7 +27,7 @@ export default class RegisterController extends Controller {
     await SendWelcomeEmailJob.dispatch({ userId: user.id })
 
     const { token } = await createEmailVerificationToken(user.email, emailVerificationStore)
-    const verifyUrl = buildVerificationUrl(`${new URL(this.request.url).origin}/verify-email/confirm`, token, user.email)
+    const verifyUrl = buildVerificationUrl(`${appUrl(this.request)}/verify-email/confirm`, token, user.email)
     await sendEmailVerificationMail(this.make('mail'), user.email, verifyUrl)
 
     this.auth.session()?.regenerate()

--- a/examples/blog/app/Http/Controllers/Auth/VerifyEmailController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/VerifyEmailController.ts
@@ -1,6 +1,7 @@
 import { Controller, createEmailVerificationToken, completeEmailVerification, buildVerificationUrl } from '@guren/core'
 import { User, type UserRecord } from '../../../Models/User.js'
 import { emailVerificationStore } from '../../../Auth/EmailVerificationStore.js'
+import { appUrl } from '../../../Auth/AppUrl.js'
 import { sendEmailVerificationMail } from '../../../Mail/EmailVerificationMail.js'
 import { pages } from '@/.guren/pages.gen'
 
@@ -21,7 +22,7 @@ export default class VerifyEmailController extends Controller {
 
     if (!user.emailVerifiedAt) {
       const { token } = await createEmailVerificationToken(user.email, emailVerificationStore)
-      const verifyUrl = buildVerificationUrl(`${new URL(this.request.url).origin}/verify-email/confirm`, token, user.email)
+      const verifyUrl = buildVerificationUrl(`${appUrl(this.request)}/verify-email/confirm`, token, user.email)
       await sendEmailVerificationMail(this.make('mail'), user.email, verifyUrl)
     }
 

--- a/examples/blog/app/Http/Controllers/ProfileController.ts
+++ b/examples/blog/app/Http/Controllers/ProfileController.ts
@@ -2,6 +2,7 @@ import { Controller, ValidationException, createEmailVerificationToken, buildVer
 import { ProfileUpdateSchema } from '../Validators/ProfileValidator.js'
 import { User, type UserRecord } from '../../Models/User.js'
 import { emailVerificationStore } from '../../Auth/EmailVerificationStore.js'
+import { appUrl } from '../../Auth/AppUrl.js'
 import { sendEmailVerificationMail } from '../../Mail/EmailVerificationMail.js'
 import { pages } from '@/.guren/pages.gen'
 
@@ -66,7 +67,7 @@ export default class ProfileController extends Controller {
 
     if (emailChanged) {
       const { token } = await createEmailVerificationToken(email, emailVerificationStore)
-      const verifyUrl = buildVerificationUrl(`${new URL(this.request.url).origin}/verify-email/confirm`, token, email)
+      const verifyUrl = buildVerificationUrl(`${appUrl(this.request)}/verify-email/confirm`, token, email)
       await sendEmailVerificationMail(this.make('mail'), email, verifyUrl)
     }
 

--- a/examples/blog/src/app.ts
+++ b/examples/blog/src/app.ts
@@ -23,6 +23,32 @@ import '../config/inertia.js'
 
 const secureCookies = process.env.NODE_ENV === 'production' && !process.env.CI
 
+// The Host header is client-controlled, so production should answer only to the
+// host this app is deployed as, which APP_URL carries.
+//
+// Read at module scope, where not every platform has populated process.env yet
+// (the Cloudflare worker imports this module before wrangler `vars` land). A
+// missing value therefore warns and leaves the check off, rather than throwing
+// and stopping the app from booting at all. Emailed links do not depend on this
+// — app/Auth/AppUrl.ts resolves those per request and fails closed there.
+function hostAuthorization() {
+  const exclude = ['/healthcheck', '/up']
+
+  if (process.env.NODE_ENV !== 'production') {
+    return { allowedHosts: ['localhost:*', '127.0.0.1:*'], exclude }
+  }
+
+  const appUrl = process.env.APP_URL?.trim()
+  if (!appUrl) {
+    console.warn('[app] APP_URL is not set — host authorization is disabled. Set it to the public base URL of this app.')
+    return false
+  }
+
+  // `hostname:*` rather than the bare host: the hostname is the security
+  // boundary, and a proxy may or may not include the default port in `Host`.
+  return { allowedHosts: [`${new URL(appUrl).hostname}:*`], exclude }
+}
+
 const app = createApp({
   routes: registerWebRoutes,
   providers: [
@@ -54,10 +80,7 @@ const app = createApp({
       },
     },
   },
-  hostAuthorization: {
-    allowedHosts: ['localhost:*', '127.0.0.1:*'],
-    exclude: ['/healthcheck', '/up'],
-  },
+  hostAuthorization: hostAuthorization(),
 })
 
 app.use('*', requestLogger)

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -663,7 +663,10 @@ async function auditSourceFiles(cwd: string, findings: AuditFinding[]): Promise<
       }
 
       // Disabled security defaults
-      const toggleMatch = /\b(autoCsrf|securityHeaders|csrf)\s*:\s*false\b/.exec(line)
+      // `hostAuthorization` belongs here for the same reason as the rest: the
+      // templates themselves shipped `hostAuthorization: ... ? false : {...}`,
+      // which turned the check off in production and audited clean.
+      const toggleMatch = /\b(autoCsrf|securityHeaders|csrf|hostAuthorization)\s*:\s*false\b/.exec(line)
       if (toggleMatch) {
         toggleCount++
         findings.push(

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -75,13 +75,14 @@ function buildRegisterControllerTemplate(includeVerify: boolean): string {
   const verifyImports = includeVerify
     ? `
 import { emailVerificationStore } from '../../../Auth/EmailVerificationStore.js'
+import { appUrl } from '../../../Auth/AppUrl.js'
 import { sendEmailVerificationMail } from '../../../Mail/EmailVerificationMail.js'`
     : ''
 
   const sendVerification = includeVerify
     ? `
     const { token } = await createEmailVerificationToken(user.email, emailVerificationStore)
-    const verifyUrl = buildVerificationUrl(\`\${new URL(this.request.url).origin}/verify-email/confirm\`, token, user.email)
+    const verifyUrl = buildVerificationUrl(\`\${appUrl(this.request)}/verify-email/confirm\`, token, user.email)
     await sendEmailVerificationMail(this.make('mail'), user.email, verifyUrl)
 `
     : ''
@@ -123,6 +124,7 @@ const forgotPasswordControllerTemplate = `import { Controller, createPasswordRes
 import { ForgotPasswordSchema } from '../../Validators/ForgotPasswordValidator.js'
 import { User } from '../../../Models/User.js'
 import { passwordResetStore } from '../../../Auth/PasswordResetStore.js'
+import { appUrl } from '../../../Auth/AppUrl.js'
 import { sendPasswordResetMail } from '../../../Mail/PasswordResetMail.js'
 import { pages } from '@/.guren/pages.gen'
 
@@ -144,7 +146,7 @@ export default class ForgotPasswordController extends Controller {
     const [user] = await User.where({ email })
     if (user) {
       const { token } = await createPasswordResetToken(email, passwordResetStore)
-      const resetUrl = buildPasswordResetUrl(\`\${new URL(this.request.url).origin}/reset-password\`, token, email)
+      const resetUrl = buildPasswordResetUrl(\`\${appUrl(this.request)}/reset-password\`, token, email)
       void sendPasswordResetMail(this.make('mail'), email, resetUrl).catch((error) => {
         console.error('Failed to send password reset email:', error)
       })
@@ -202,6 +204,7 @@ export default class ResetPasswordController extends Controller {
 const verifyEmailControllerTemplate = `import { Controller, createEmailVerificationToken, completeEmailVerification, buildVerificationUrl } from '@guren/core'
 import { User, type UserRecord } from '../../../Models/User.js'
 import { emailVerificationStore } from '../../../Auth/EmailVerificationStore.js'
+import { appUrl } from '../../../Auth/AppUrl.js'
 import { sendEmailVerificationMail } from '../../../Mail/EmailVerificationMail.js'
 import { pages } from '@/.guren/pages.gen'
 
@@ -222,7 +225,7 @@ export default class VerifyEmailController extends Controller {
 
     if (!user.emailVerifiedAt) {
       const { token } = await createEmailVerificationToken(user.email, emailVerificationStore)
-      const verifyUrl = buildVerificationUrl(\`\${new URL(this.request.url).origin}/verify-email/confirm\`, token, user.email)
+      const verifyUrl = buildVerificationUrl(\`\${appUrl(this.request)}/verify-email/confirm\`, token, user.email)
       await sendEmailVerificationMail(this.make('mail'), user.email, verifyUrl)
     }
 
@@ -491,6 +494,7 @@ function buildProfileControllerTemplate({ includeVerify, includePassword, provid
   const verifyImports = includeVerify
     ? `
 import { emailVerificationStore } from '../../Auth/EmailVerificationStore.js'
+import { appUrl } from '../../Auth/AppUrl.js'
 import { sendEmailVerificationMail } from '../../Mail/EmailVerificationMail.js'`
     : ''
 
@@ -506,7 +510,7 @@ import { sendEmailVerificationMail } from '../../Mail/EmailVerificationMail.js'`
     ? `
     if (emailChanged) {
       const { token } = await createEmailVerificationToken(email, emailVerificationStore)
-      const verifyUrl = buildVerificationUrl(\`\${new URL(this.request.url).origin}/verify-email/confirm\`, token, email)
+      const verifyUrl = buildVerificationUrl(\`\${appUrl(this.request)}/verify-email/confirm\`, token, email)
       await sendEmailVerificationMail(this.make('mail'), email, verifyUrl)
     }
 `
@@ -657,6 +661,34 @@ export default class MailProvider extends ServiceProvider {
   register(): void {
     this.container.singleton('mail', () => createMailManager(mailConfig))
   }
+}
+`
+
+const appUrlTemplate = `/**
+ * Absolute base URL for links that leave the app (password reset, email
+ * verification).
+ *
+ * Deliberately not derived from the request in production. A request URL is
+ * reconstructed from the \`Host\` header, which any client can forge, so a
+ * forged host would make the app mail a genuine single-use token to a link
+ * pointing at the attacker's own server. \`APP_URL\` is the only trustworthy
+ * source, and production fails closed rather than falling back to the request.
+ */
+export function appUrl(request: { url: string }): string {
+  const configured = process.env.APP_URL?.trim()
+
+  if (configured) {
+    return configured.endsWith('/') ? configured.slice(0, -1) : configured
+  }
+
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error(
+      'APP_URL is not set. Set it to the public base URL of this app (for example ' +
+        'https://example.com): links sent by email must not be derived from the request host.',
+    )
+  }
+
+  return new URL(request.url).origin
 }
 `
 
@@ -2008,6 +2040,7 @@ const PASSWORD_SCAFFOLD_PATHS = [
   'resources/js/pages/auth/ForgotPassword.tsx',
   'resources/js/pages/auth/ResetPassword.tsx',
   'resources/js/pages/auth/VerifyEmail.tsx',
+  'app/Auth/AppUrl.ts',
   'app/Auth/PasswordResetStore.ts',
   'app/Auth/EmailVerificationStore.ts',
   'app/Mail/PasswordResetMail.ts',
@@ -2180,6 +2213,12 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
     )
   }
 
+  // Both the reset and the verification flow mail absolute links, and both
+  // must build them from APP_URL rather than the request host.
+  if (includeExtras || includeVerify) {
+    files.push({ path: 'app/Auth/AppUrl.ts', contents: appUrlTemplate })
+  }
+
   if (includeExtras) {
     files.push(
       { path: 'app/Http/Controllers/Auth/RegisterController.ts', contents: buildRegisterControllerTemplate(includeVerify) },
@@ -2232,6 +2271,9 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
     consola.info('  • Import registerAuthRoutes from routes/auth.ts and call it from your routes/web.ts registrar')
     if (includeExtras) {
       consola.info('  • Register MailProvider in src/app.ts providers array (used to send password reset emails)')
+    }
+    if (includeExtras || includeVerify) {
+      consola.info('  • Set APP_URL in your .env to this app\'s public base URL — emailed links are built from it, and production refuses to start a mail send without it')
     }
     if (!migrationGenerated) {
       consola.info('  • Run `bun run db:make` to generate the users migration')

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -138,6 +138,11 @@ export default class ForgotPasswordController extends Controller {
   async store(): Promise<Response> {
     const { email } = await this.validateBody(ForgotPasswordSchema)
 
+    // Resolved before the lookup on purpose: a misconfigured APP_URL throws,
+    // and throwing only for addresses that turned out to exist would answer
+    // the question the generic status message below refuses to.
+    const resetBaseUrl = \`\${appUrl(this.request)}/reset-password\`
+
     // Always respond with the same status message whether or not the
     // account exists, to avoid leaking which emails are registered. The
     // mail send is deliberately not awaited: the transport round-trip only
@@ -146,7 +151,7 @@ export default class ForgotPasswordController extends Controller {
     const [user] = await User.where({ email })
     if (user) {
       const { token } = await createPasswordResetToken(email, passwordResetStore)
-      const resetUrl = buildPasswordResetUrl(\`\${appUrl(this.request)}/reset-password\`, token, email)
+      const resetUrl = buildPasswordResetUrl(resetBaseUrl, token, email)
       void sendPasswordResetMail(this.make('mail'), email, resetUrl).catch((error) => {
         console.error('Failed to send password reset email:', error)
       })
@@ -678,7 +683,12 @@ export function appUrl(request: { url: string }): string {
   const configured = process.env.APP_URL?.trim()
 
   if (configured) {
-    return configured.endsWith('/') ? configured.slice(0, -1) : configured
+    // Parsed rather than concatenated: a malformed APP_URL has to fail here,
+    // where every caller hits it, not later inside one particular link build.
+    // Dropping any query/fragment and the trailing slash keeps the result
+    // safe to append a path to.
+    const parsed = new URL(configured)
+    return \`\${parsed.origin}\${parsed.pathname.replace(/\\/+$/, '')}\`
   }
 
   if (process.env.NODE_ENV === 'production') {
@@ -2213,14 +2223,11 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
     )
   }
 
-  // Both the reset and the verification flow mail absolute links, and both
-  // must build them from APP_URL rather than the request host.
-  if (includeExtras || includeVerify) {
-    files.push({ path: 'app/Auth/AppUrl.ts', contents: appUrlTemplate })
-  }
-
   if (includeExtras) {
     files.push(
+      // Every flow that mails an absolute link routes through this, so that
+      // none of them build one from the request host.
+      { path: 'app/Auth/AppUrl.ts', contents: appUrlTemplate },
       { path: 'app/Http/Controllers/Auth/RegisterController.ts', contents: buildRegisterControllerTemplate(includeVerify) },
       { path: 'app/Http/Validators/RegisterValidator.ts', contents: registerValidatorTemplate },
       { path: 'resources/js/pages/auth/Register.tsx', contents: buildRegisterViewTemplate(oauthProviders) },
@@ -2271,9 +2278,7 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
     consola.info('  • Import registerAuthRoutes from routes/auth.ts and call it from your routes/web.ts registrar')
     if (includeExtras) {
       consola.info('  • Register MailProvider in src/app.ts providers array (used to send password reset emails)')
-    }
-    if (includeExtras || includeVerify) {
-      consola.info('  • Set APP_URL in your .env to this app\'s public base URL — emailed links are built from it, and production refuses to start a mail send without it')
+      consola.info('  • Set APP_URL in your .env to the public base URL of this app — emailed links are built from it, and production refuses to send without it')
     }
     if (!migrationGenerated) {
       consola.info('  • Run `bun run db:make` to generate the users migration')

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -56,8 +56,9 @@ export function registerWebRoutes(router: Router): void {
 
       const created = await makeAuth({ install: true, force: true })
 
-      expect(created).toHaveLength(26)
+      expect(created).toHaveLength(27)
       expect(created).toEqual(expect.arrayContaining([
+        expect.stringContaining('AppUrl.ts'),
         expect.stringContaining('LoginController.ts'),
         expect.stringContaining('routes/auth.ts'),
         expect.stringContaining('ProfileController.ts'),
@@ -104,6 +105,24 @@ export function registerWebRoutes(router: Router): void {
       expect(authRoutes).toContain("router.post('/forgot-password'")
       expect(authRoutes).toContain("router.get('/reset-password'")
       expect(authRoutes).toContain("router.post('/reset-password'")
+
+      // Emailed links must never be built from the request URL: it is
+      // reconstructed from the `Host` header, so a forged host would mail the
+      // victim a genuine reset token pointing at the attacker's server.
+      const forgotPasswordController = await readFile(
+        join(workspace.dir, 'app/Http/Controllers/Auth/ForgotPasswordController.ts'),
+        'utf8',
+      )
+      expect(forgotPasswordController).not.toContain('new URL(this.request.url).origin')
+      expect(forgotPasswordController).toContain("import { appUrl } from '../../../Auth/AppUrl.js'")
+      expect(forgotPasswordController).toContain('buildPasswordResetUrl(`${appUrl(this.request)}/reset-password`')
+
+      // ...and the helper they route through has to fail closed in production
+      // rather than falling back to the request.
+      const appUrlHelper = await readFile(join(workspace.dir, 'app/Auth/AppUrl.ts'), 'utf8')
+      expect(appUrlHelper).toContain('process.env.APP_URL')
+      expect(appUrlHelper).toContain("process.env.NODE_ENV === 'production'")
+      expect(appUrlHelper).toContain('throw new Error(')
 
       const loginPage = await readFile(join(workspace.dir, 'resources/js/pages/auth/Login.tsx'), 'utf8')
       expect(loginPage).toContain('interface Props')

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -114,15 +114,17 @@ export function registerWebRoutes(router: Router): void {
         'utf8',
       )
       expect(forgotPasswordController).not.toContain('new URL(this.request.url).origin')
-      expect(forgotPasswordController).toContain("import { appUrl } from '../../../Auth/AppUrl.js'")
-      expect(forgotPasswordController).toContain('buildPasswordResetUrl(`${appUrl(this.request)}/reset-password`')
+      expect(forgotPasswordController).toContain('const resetBaseUrl = `${appUrl(this.request)}/reset-password`')
+      // Resolved before the account lookup: a misconfigured APP_URL throws, and
+      // throwing only for addresses that exist would leak which ones do.
+      expect(forgotPasswordController.indexOf('appUrl(this.request)')).toBeLessThan(
+        forgotPasswordController.indexOf('await User.where({ email })'),
+      )
 
-      // ...and the helper they route through has to fail closed in production
-      // rather than falling back to the request.
+      // ...and the helper they route through reads APP_URL and fails closed in
+      // production rather than falling back to the request.
       const appUrlHelper = await readFile(join(workspace.dir, 'app/Auth/AppUrl.ts'), 'utf8')
-      expect(appUrlHelper).toContain('process.env.APP_URL')
-      expect(appUrlHelper).toContain("process.env.NODE_ENV === 'production'")
-      expect(appUrlHelper).toContain('throw new Error(')
+      expect(appUrlHelper).toMatch(/process\.env\.APP_URL[\s\S]*NODE_ENV === 'production'[\s\S]*throw new Error\(/)
 
       const loginPage = await readFile(join(workspace.dir, 'resources/js/pages/auth/Login.tsx'), 'utf8')
       expect(loginPage).toContain('interface Props')

--- a/packages/create-app/templates/api-only/src/app.ts
+++ b/packages/create-app/templates/api-only/src/app.ts
@@ -2,32 +2,36 @@ import { createApp } from '@guren/core'
 import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
 import { registerApiRoutes } from '../routes/api.js'
 
-// The Host header is client-controlled, so production answers only to the host
-// this app is actually deployed as. APP_URL carries that host and is required
-// in production — anything derived from an unchecked Host (absolute links in
-// emails, cached responses) would otherwise point wherever a caller asked.
-function allowedHosts(): string[] {
+// The Host header is client-controlled, so production should answer only to the
+// host this app is deployed as, which APP_URL carries.
+//
+// Read at module scope, where not every platform has populated process.env yet
+// (the Cloudflare worker imports this module before wrangler `vars` land). A
+// missing value therefore warns and leaves the check off, rather than throwing
+// and stopping the app from booting at all. Emailed links do not depend on this
+// — app/Auth/AppUrl.ts resolves those per request and fails closed there.
+function hostAuthorization() {
+  const exclude = ['/health']
+
   if (process.env.NODE_ENV !== 'production') {
-    return ['localhost:*', '127.0.0.1:*']
+    return { allowedHosts: ['localhost:*', '127.0.0.1:*'], exclude }
   }
 
   const appUrl = process.env.APP_URL?.trim()
   if (!appUrl) {
-    throw new Error('APP_URL must be set in production: it defines the host this app answers to.')
+    console.warn('[app] APP_URL is not set — host authorization is disabled. Set it to the public base URL of this app.')
+    return false
   }
 
   // `hostname:*` rather than the bare host: the hostname is the security
   // boundary, and a proxy may or may not include the default port in `Host`.
-  return [`${new URL(appUrl).hostname}:*`]
+  return { allowedHosts: [`${new URL(appUrl).hostname}:*`], exclude }
 }
 
 const app = createApp({
   routes: registerApiRoutes,
   providers: [DatabaseProvider],
-  hostAuthorization: {
-    allowedHosts: allowedHosts(),
-    exclude: ['/health'],
-  },
+  hostAuthorization: hostAuthorization(),
 })
 
 export default app

--- a/packages/create-app/templates/api-only/src/app.ts
+++ b/packages/create-app/templates/api-only/src/app.ts
@@ -2,11 +2,30 @@ import { createApp } from '@guren/core'
 import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
 import { registerApiRoutes } from '../routes/api.js'
 
+// The Host header is client-controlled, so production answers only to the host
+// this app is actually deployed as. APP_URL carries that host and is required
+// in production — anything derived from an unchecked Host (absolute links in
+// emails, cached responses) would otherwise point wherever a caller asked.
+function allowedHosts(): string[] {
+  if (process.env.NODE_ENV !== 'production') {
+    return ['localhost:*', '127.0.0.1:*']
+  }
+
+  const appUrl = process.env.APP_URL?.trim()
+  if (!appUrl) {
+    throw new Error('APP_URL must be set in production: it defines the host this app answers to.')
+  }
+
+  // `hostname:*` rather than the bare host: the hostname is the security
+  // boundary, and a proxy may or may not include the default port in `Host`.
+  return [`${new URL(appUrl).hostname}:*`]
+}
+
 const app = createApp({
   routes: registerApiRoutes,
   providers: [DatabaseProvider],
-  hostAuthorization: process.env.NODE_ENV === 'production' ? false : {
-    allowedHosts: ['localhost:*', '127.0.0.1:*'],
+  hostAuthorization: {
+    allowedHosts: allowedHosts(),
     exclude: ['/health'],
   },
 })

--- a/packages/create-app/templates/blog/src/app.ts
+++ b/packages/create-app/templates/blog/src/app.ts
@@ -10,12 +10,31 @@ setInertiaDocument({
   head: '<link rel="icon" type="image/svg+xml" href="/favicon.svg" />',
 })
 
+// The Host header is client-controlled, so production answers only to the host
+// this app is actually deployed as. APP_URL carries that host and is required
+// in production — anything derived from an unchecked Host (absolute links in
+// emails, cached responses) would otherwise point wherever a caller asked.
+function allowedHosts(): string[] {
+  if (process.env.NODE_ENV !== 'production') {
+    return ['localhost:*', '127.0.0.1:*']
+  }
+
+  const appUrl = process.env.APP_URL?.trim()
+  if (!appUrl) {
+    throw new Error('APP_URL must be set in production: it defines the host this app answers to.')
+  }
+
+  // `hostname:*` rather than the bare host: the hostname is the security
+  // boundary, and a proxy may or may not include the default port in `Host`.
+  return [`${new URL(appUrl).hostname}:*`]
+}
+
 const app = createApp({
   auth: {},
   routes: registerWebRoutes,
   providers: [DatabaseProvider, AuthProvider, AuthorizationProvider],
-  hostAuthorization: process.env.NODE_ENV === 'production' ? false : {
-    allowedHosts: ['localhost:*', '127.0.0.1:*'],
+  hostAuthorization: {
+    allowedHosts: allowedHosts(),
     exclude: ['/healthcheck', '/up'],
   },
 })

--- a/packages/create-app/templates/blog/src/app.ts
+++ b/packages/create-app/templates/blog/src/app.ts
@@ -10,33 +10,37 @@ setInertiaDocument({
   head: '<link rel="icon" type="image/svg+xml" href="/favicon.svg" />',
 })
 
-// The Host header is client-controlled, so production answers only to the host
-// this app is actually deployed as. APP_URL carries that host and is required
-// in production — anything derived from an unchecked Host (absolute links in
-// emails, cached responses) would otherwise point wherever a caller asked.
-function allowedHosts(): string[] {
+// The Host header is client-controlled, so production should answer only to the
+// host this app is deployed as, which APP_URL carries.
+//
+// Read at module scope, where not every platform has populated process.env yet
+// (the Cloudflare worker imports this module before wrangler `vars` land). A
+// missing value therefore warns and leaves the check off, rather than throwing
+// and stopping the app from booting at all. Emailed links do not depend on this
+// — app/Auth/AppUrl.ts resolves those per request and fails closed there.
+function hostAuthorization() {
+  const exclude = ['/healthcheck', '/up']
+
   if (process.env.NODE_ENV !== 'production') {
-    return ['localhost:*', '127.0.0.1:*']
+    return { allowedHosts: ['localhost:*', '127.0.0.1:*'], exclude }
   }
 
   const appUrl = process.env.APP_URL?.trim()
   if (!appUrl) {
-    throw new Error('APP_URL must be set in production: it defines the host this app answers to.')
+    console.warn('[app] APP_URL is not set — host authorization is disabled. Set it to the public base URL of this app.')
+    return false
   }
 
   // `hostname:*` rather than the bare host: the hostname is the security
   // boundary, and a proxy may or may not include the default port in `Host`.
-  return [`${new URL(appUrl).hostname}:*`]
+  return { allowedHosts: [`${new URL(appUrl).hostname}:*`], exclude }
 }
 
 const app = createApp({
   auth: {},
   routes: registerWebRoutes,
   providers: [DatabaseProvider, AuthProvider, AuthorizationProvider],
-  hostAuthorization: {
-    allowedHosts: allowedHosts(),
-    exclude: ['/healthcheck', '/up'],
-  },
+  hostAuthorization: hostAuthorization(),
 })
 
 export default app

--- a/packages/create-app/templates/default/src/app.ts
+++ b/packages/create-app/templates/default/src/app.ts
@@ -9,32 +9,36 @@ setInertiaDocument({
   head: '<link rel="icon" type="image/svg+xml" href="/favicon.svg" />',
 })
 
-// The Host header is client-controlled, so production answers only to the host
-// this app is actually deployed as. APP_URL carries that host and is required
-// in production — anything derived from an unchecked Host (absolute links in
-// emails, cached responses) would otherwise point wherever a caller asked.
-function allowedHosts(): string[] {
+// The Host header is client-controlled, so production should answer only to the
+// host this app is deployed as, which APP_URL carries.
+//
+// Read at module scope, where not every platform has populated process.env yet
+// (the Cloudflare worker imports this module before wrangler `vars` land). A
+// missing value therefore warns and leaves the check off, rather than throwing
+// and stopping the app from booting at all. Emailed links do not depend on this
+// — app/Auth/AppUrl.ts resolves those per request and fails closed there.
+function hostAuthorization() {
+  const exclude = ['/healthcheck', '/up']
+
   if (process.env.NODE_ENV !== 'production') {
-    return ['localhost:*', '127.0.0.1:*']
+    return { allowedHosts: ['localhost:*', '127.0.0.1:*'], exclude }
   }
 
   const appUrl = process.env.APP_URL?.trim()
   if (!appUrl) {
-    throw new Error('APP_URL must be set in production: it defines the host this app answers to.')
+    console.warn('[app] APP_URL is not set — host authorization is disabled. Set it to the public base URL of this app.')
+    return false
   }
 
   // `hostname:*` rather than the bare host: the hostname is the security
   // boundary, and a proxy may or may not include the default port in `Host`.
-  return [`${new URL(appUrl).hostname}:*`]
+  return { allowedHosts: [`${new URL(appUrl).hostname}:*`], exclude }
 }
 
 const app = createApp({
   routes: registerWebRoutes,
   providers: [DatabaseProvider],
-  hostAuthorization: {
-    allowedHosts: allowedHosts(),
-    exclude: ['/healthcheck', '/up'],
-  },
+  hostAuthorization: hostAuthorization(),
 })
 
 export default app

--- a/packages/create-app/templates/default/src/app.ts
+++ b/packages/create-app/templates/default/src/app.ts
@@ -9,11 +9,30 @@ setInertiaDocument({
   head: '<link rel="icon" type="image/svg+xml" href="/favicon.svg" />',
 })
 
+// The Host header is client-controlled, so production answers only to the host
+// this app is actually deployed as. APP_URL carries that host and is required
+// in production — anything derived from an unchecked Host (absolute links in
+// emails, cached responses) would otherwise point wherever a caller asked.
+function allowedHosts(): string[] {
+  if (process.env.NODE_ENV !== 'production') {
+    return ['localhost:*', '127.0.0.1:*']
+  }
+
+  const appUrl = process.env.APP_URL?.trim()
+  if (!appUrl) {
+    throw new Error('APP_URL must be set in production: it defines the host this app answers to.')
+  }
+
+  // `hostname:*` rather than the bare host: the hostname is the security
+  // boundary, and a proxy may or may not include the default port in `Host`.
+  return [`${new URL(appUrl).hostname}:*`]
+}
+
 const app = createApp({
   routes: registerWebRoutes,
   providers: [DatabaseProvider],
-  hostAuthorization: process.env.NODE_ENV === 'production' ? false : {
-    allowedHosts: ['localhost:*', '127.0.0.1:*'],
+  hostAuthorization: {
+    allowedHosts: allowedHosts(),
     exclude: ['/healthcheck', '/up'],
   },
 })

--- a/packages/plugin-lambda/README.md
+++ b/packages/plugin-lambda/README.md
@@ -49,7 +49,9 @@ new GurenLambdaApp(stack, 'App', {
     resourceArn: process.env.DATABASE_RESOURCE_ARN!,
     secretArn: process.env.DATABASE_SECRET_ARN!,
   },
-  environment: { APP_KEY: process.env.APP_KEY! },
+  // APP_URL is the app's public base URL. Emailed links (password reset,
+  // email verification) are built from it rather than the request host.
+  environment: { APP_KEY: process.env.APP_KEY!, APP_URL: process.env.APP_URL! },
 })
 ```
 

--- a/packages/server/src/http/middleware/host-authorization.ts
+++ b/packages/server/src/http/middleware/host-authorization.ts
@@ -28,7 +28,9 @@ export function createHostAuthorizationMiddleware(options: HostAuthorizationOpti
   const matchers = allowedHosts.map(compileHostMatcher)
 
   return async (ctx, next) => {
-    const path = new URL(ctx.req.url).pathname
+    // Hono already parsed and cached this; re-parsing the whole URL here costs
+    // more than the rest of the check put together, on every request.
+    const path = ctx.req.path
 
     if (isExcluded(path, exclude)) {
       await next()
@@ -81,7 +83,11 @@ function compileHostMatcher(pattern: string): HostMatcher {
     const hostname = pattern.slice(0, -2).toLowerCase()
     return (host) => {
       const h = host.toLowerCase()
-      return h === hostname || h.startsWith(hostname + ':')
+      if (h === hostname) return true
+      if (!h.startsWith(hostname + ':')) return false
+      // The wildcard stands for a port, so only a port may follow. Accepting
+      // anything made `example.com:attacker.tld` match `example.com:*`.
+      return /^\d+$/.test(h.slice(hostname.length + 1))
     }
   }
 


### PR DESCRIPTION
## Summary

A framework-wide security review found a HIGH-severity Host header injection in the auth scaffold. The password reset flow emitted by `guren add auth` (and by `create-guren-app --auth`) built its link from the request:

```js
buildPasswordResetUrl(`${new URL(this.request.url).origin}/reset-password`, token, email)
```

A server request's URL is reconstructed from the `Host` header, which any client can forge — the framework's own host-authorization middleware treats `ctx.req.header('host')` and `new URL(ctx.req.url).host` as one value for exactly that reason. So an unauthenticated attacker could `POST /forgot-password` with someone else's address in the body and `Host: attacker.tld`, and the app would mail **that person** a genuine, single-use reset link pointing at the attacker's server. The victim sees a legitimate mail from the real service; one click — or one link-prefetching mail scanner — hands over the token, and `ResetPasswordController` accepts it with no session binding or second factor.

The templates made this reachable: `hostAuthorization: process.env.NODE_ENV === 'production' ? false : { ... }` removed the one check that would have rejected the forged host, in exactly the environment that needed it.

## Changes

**`APP_URL` becomes the single source for any absolute URL that leaves the app.** Scaffolds now route emailed links through a generated `app/Auth/AppUrl.ts` that parses `APP_URL` with `new URL()` and **fails closed in production** rather than falling back to the request. Development keeps working with no configuration. The three email-verification sites use the same helper — they mail the requester's own address so they were not exploitable, but leaving the pattern in place is how it returns.

**Templates stop disabling host authorization in production.** The production branch derives its allowlist from `APP_URL`'s hostname; health-check paths stay excluded so load balancers reaching the app by IP are unaffected.

**`@guren/server`:** a `host:*` allowlist entry now means that host on any *port*. `compileHostMatcher` accepted anything after the colon, so `example.com:*` also matched a `Host` of `example.com:attacker.tld`. The same middleware now reads `ctx.req.path` instead of re-parsing the whole request URL — a cost it newly pays on every production request rather than only in development.

**`guren audit`** flags `hostAuthorization: false`, which it previously walked past while the templates themselves shipped it.

## Two deliberate asymmetries

These look like inconsistencies and are not:

- **`AppUrl.ts` throws when `APP_URL` is missing; the templates only warn and disable the check.** The generated Cloudflare worker imports the app before wrangler `vars` reach `process.env` — which is why the plugin substitutes `NODE_ENV` at build time — so a module-scope throw would stop the worker booting at all. Per-request (lazy) may fail closed; module-scope (eager) may not. Emailed links do not depend on host authorization and still fail closed per request.
- **The fix lives in the code generator, not in `@guren/server`.** Templates resolve `@guren/*` from npm, so a framework API added in the same PR would strand every scaffold until the next release. Fixing the emitter lets this land now.

## Action required

New apps must set `APP_URL` in production. It is already present in the scaffolded `.env.example`.

Existing apps are unchanged. An app with a `ForgotPasswordController` generated before this release needs the same change applied by hand, or `guren add auth --force`. A follow-up `guren audit` rule flagging request-derived link origins is tracked separately — that is the mechanism that reaches apps the generator cannot.

## Verification

- `bun run test:bun` — 3466 pass, 0 fail
- `bun run typecheck` (root) — clean
- `audit:core-first`, `audit:docs`, `audit:starter-template`, `audit:template-deps` — all pass
- `smoke:starter`, `smoke:starter:api`, `smoke:starter:blog` — all pass
- `appUrl()` exercised across configured / trailing-slash / multi-slash / path-prefix / query-fragment / whitespace / malformed / unset-in-production / dev-fallback
- Host allowlist exercised against forged hosts (`attacker.tld`, `real.example.com.evil.tld`, `evilreal.example.com`, `example.com:attacker.tld`) plus the excluded health-check path
- Mutation-checked: reverting the fix turns the new regression test red
