### PR TITLE
feat(cli): flag outbound links built from the request host in `guren audit`

### DIFF
--- a/.changeset/audit-request-host-links.md
+++ b/.changeset/audit-request-host-links.md
@@ -1,0 +1,66 @@
+---
+"@guren/cli": patch
+---
+
+`guren audit` flags outbound links built from the request host
+
+The auth scaffold used to build password-reset links from the request:
+
+```js
+buildPasswordResetUrl(`${new URL(this.request.url).origin}/reset-password`, token, email)
+```
+
+A request URL is reconstructed from the `Host` header, which any client can
+forge, so an unauthenticated attacker could `POST /forgot-password` with a
+victim's address and `Host: attacker.tld` and have the app mail that victim a
+genuine single-use reset token pointing at the attacker's server.
+
+Routing scaffolded links through `app/Auth/AppUrl.ts` fixed the *generated*
+output, which does nothing for the two populations that still have the bug:
+apps scaffolded before that release — told to hand-patch or re-run
+`guren add auth --force` — and anyone who wrote the controller themselves.
+`guren audit` ships with the CLI those users already run, so it is the one
+mechanism that reaches them. It returned green on the exact code the fix calls
+exploitable; it now warns:
+
+```
+[warn] [A07] app/Http/Controllers/Auth/ForgotPasswordController.ts:26: Absolute
+link built from the request host — the Host header is client-controlled, so a
+forged host makes the app send a genuine single-use token pointing at the
+attacker's server.
+     → Build the base URL from process.env.APP_URL instead of the request
+```
+
+The rule fires on a request-derived origin (`new URL(req.url)`), on a
+`host`/`x-forwarded-host` header read off the request, and on a request URL
+handed straight to a link builder — but only in a file that also names one of
+the framework's outbound-link builders (`buildTokenUrl` and its
+`buildPasswordResetUrl`, `buildVerificationUrl`, and `buildOAuthRedirectUrl`
+aliases). That second half is what keeps the generated `app/Auth/AppUrl.ts`
+clean: its non-production fallback returns a request origin on purpose, and it
+builds no link. Gating on behaviour rather than exempting the helper by path
+means the exemption survives a rename. Middleware that parses the request URL
+only to reach its path never matches. Use `// guren-audit-ignore` for a link
+that never leaves the app.
+
+Because that gate is a hand-maintained name list, a builder added to
+`@guren/core` would otherwise reach users as an affirmative *pass*. An audit
+test enumerates `@guren/core`'s `build*Url` exports against the list, with
+`buildOAuthAuthorizeUrl` as a documented exclusion — it builds the provider's
+authorize URL, a real but different risk this finding's wording would
+misdescribe.
+
+The boundary, stated so a green audit doesn't imply more than it checks: a
+controller that mails a link assembled by hand, without going through those
+builders, is not covered. Widening the gate to guessed-at mail helper names
+would trade a real false-positive cost for speculative coverage. The finding is
+worded conditionally for the same reason — co-occurrence in one file is not
+proof the host reaches the link.
+
+Note the rule also fires on `process.env.APP_URL ?? new URL(req.url).origin`.
+That is deliberate rather than a false positive — the fallback is fail-open, so
+a forged host still works whenever `APP_URL` is unset, which is exactly the
+production misconfiguration the scaffolded helper throws on instead.
+
+Findings are classified A07 / CWE-640, so `--json` consumers and the console
+prefix stay consistent with the other rules.

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -80,7 +80,7 @@ Validate your app before shipping — these commands are also designed for AI co
 | Command | Description | Example |
 |---------|-------------|---------|
 | `check` | Validate integrity across routes, controllers, pages, and models, plus doc links, spec-view freshness, and architecture boundaries | `bunx guren check --json` |
-| `audit` | Security audit: missing input validation or authentication on mutating routes, raw SQL with interpolation, hardcoded credentials, disabled security defaults, mass-assignment configuration, sensitive columns not listed in `static hidden` | `bunx guren audit --json` |
+| `audit` | Security audit: missing input validation or authentication on mutating routes, raw SQL with interpolation, hardcoded credentials, disabled security defaults, mass-assignment configuration, sensitive columns not listed in `static hidden`, emailed links built from the request host | `bunx guren audit --json` |
 | `doctor` | Project health report (env, config, generated files) with actionable next steps | `bunx guren doctor --next` |
 | `context [Entity]` | Project context map — or, with an entity name, everything about one model: table, relationships, routes with schemas, pages with Props, resource, policy, linked docs (`--module` disambiguates, `"app"` = project root) | `bunx guren context User --json` |
 | `docs:graph` | The OKF docs relation graph: documents, entities, and code paths as nodes, verified relations as edges. `--entity <Model>` or `--path <file>` narrows to a neighborhood — ask "what governs this?" before renaming | `bunx guren docs:graph --path app/Http/Controllers/PostController.ts` |

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -78,7 +78,7 @@ bunx guren plugin @acme/guren-plugin-audit
 | コマンド | 説明 | 例 |
 |---------|------|-----|
 | `check` | ルート・コントローラ・ページ・モデル間の整合性に加え、docリンク・スペックビューの鮮度・アーキテクチャ境界を検証 | `bunx guren check --json` |
-| `audit` | セキュリティ監査: 変更系ルートのバリデーション/認証の欠如、文字列補間付き生SQL、ハードコードされた認証情報、無効化されたセキュリティ既定値、mass assignment 設定、`static hidden` 未登録の機微カラムを検査 | `bunx guren audit --json` |
+| `audit` | セキュリティ監査: 変更系ルートのバリデーション/認証の欠如、文字列補間付き生SQL、ハードコードされた認証情報、無効化されたセキュリティ既定値、mass assignment 設定、`static hidden` 未登録の機微カラム、リクエストのホストから組み立てられたメール内リンクを検査 | `bunx guren audit --json` |
 | `doctor` | プロジェクトの健全性レポート(環境変数・設定・生成ファイル)と次のアクション | `bunx guren doctor --next` |
 | `context [Entity]` | プロジェクトコンテキストマップ。エンティティ名を渡すと1モデルのすべて — テーブル・リレーション・スキーマ付きルート・Props付きページ・Resource・Policy・紐付きdocs — を出力(同名モデルは `--module` で解決、`"app"` はプロジェクトルート) | `bunx guren context User --json` |
 | `docs:graph` | OKF docsのリレーショングラフ。文書・エンティティ・コードパスがノード、検証済みリレーションがエッジ。`--entity <Model>` / `--path <file>` で近傍に絞り、リネーム前に「これを統べるdocsはどれか」を照会 | `bunx guren docs:graph --path app/Http/Controllers/PostController.ts` |

--- a/packages/cli/src/audit-taxonomy.ts
+++ b/packages/cli/src/audit-taxonomy.ts
@@ -43,6 +43,10 @@ const RULE_CLASSIFICATIONS: Record<string, AuditClassification[]> = {
     cwe('CWE-798', 'Use of Hard-coded Credentials'),
   ],
   'raw-sql': [owasp('A03', 'Injection'), cwe('CWE-89', 'SQL Injection')],
+  'request-host-url': [
+    owasp('A07', 'Identification and Authentication Failures'),
+    cwe('CWE-640', 'Weak Password Recovery Mechanism for Forgotten Password'),
+  ],
   'security-toggle': [
     owasp('A05', 'Security Misconfiguration'),
     cwe('CWE-693', 'Protection Mechanism Failure'),

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -597,6 +597,84 @@ const SECRET_ALLOWLIST = /(process\.env|import\.meta\.env|\bz\.|example|placehol
 const RAW_SQL_PATTERN = /\bsql\.raw\s*\(\s*`[^`]*\$\{/
 const UNSAFE_SQL_PATTERN = /\.unsafe\s*\(\s*`[^`]*\$\{/
 
+/**
+ * Absolute links that leave the app — password reset, email verification —
+ * must not be derived from the request. A request URL is reconstructed from
+ * the `Host` header, which any client can forge, so an unauthenticated
+ * attacker can make the app mail a victim a genuine single-use token whose
+ * link points at the attacker's own server.
+ *
+ * The origin anchor deliberately does *not* require a `.origin`/`.host` read.
+ * Requiring one missed the two most idiomatic spellings of the same bug —
+ * `const url = new URL(req.url)` and `const { origin } = new URL(req.url)`,
+ * both used a line or more later. Middleware that parses the request URL only
+ * to reach its path is already excluded by the builder gate below, so the
+ * accessor requirement bought no protection those files did not already have;
+ * only the path-ish accessors stay excluded, for a same-line read inside a
+ * file that does build links.
+ *
+ * The `[^)]` runs are bounded rather than `*`. Unbounded, a line of the shape
+ * `new URL(` + whitespace + `request.url` + filler took 15s to reject here —
+ * the audit reads whatever source the app happens to contain, so a generated
+ * or vendored long line is enough to hang it. Measured on that input: 15,111ms
+ * unbounded, 0.02ms bounded, with no change on any real match. Dropping the
+ * redundant `\s*` after `\(` (it overlapped `[^)]*`) is the other half; alone
+ * it still left 4-5s cases, so both are load-bearing.
+ */
+const REQUEST_ORIGIN_PATTERN =
+  /new\s+URL\s*\([^)]{0,200}\b(?:req|request)\s*\.\s*url\b[^)]{0,200}\)(?!\s*\.\s*(?:pathname|searchParams|search|hash)\b)/
+
+/** `.header('host')`, `.get('host')`, `.headers.host` — and the forwarded/HTTP2 spellings. */
+const HOST_HEADER_READ_PATTERN =
+  /\.\s*(?:header|get)\s*\(\s*['"`](?:host|x-forwarded-host|:authority)['"`]\s*\)|\.\s*headers\s*\??\s*\.\s*host\b/i
+
+/**
+ * Pairs with the above so `response.headers.get('host')` — reading a host back
+ * off something the app itself produced — stays clean.
+ */
+const REQUEST_RECEIVER_PATTERN = /\b(?:req|request)\b/i
+
+/**
+ * The framework's own outbound-link builders. Their presence anywhere in the
+ * file is what promotes a request-derived origin from "reads its own host" to
+ * "mails its own host to someone else" — and it is the whole reason the
+ * generated `app/Auth/AppUrl.ts` stays clean, since its non-production
+ * fallback returns a request origin but builds no link. Exempting that helper
+ * by path instead would break the moment a user renames it.
+ *
+ * `buildTokenUrl` is the implementation; `buildPasswordResetUrl`,
+ * `buildVerificationUrl`, and `buildOAuthRedirectUrl` are literal aliases of
+ * it, and the latter three are what `@guren/core` actually exports. Matching
+ * the bare name rather than a call also covers an aliased import
+ * (`buildVerificationUrl as makeUrl`), which would otherwise skip the file
+ * silently. `buildOAuthAuthorizeUrl` is deliberately absent: it builds the
+ * *provider's* authorize URL, so a request-derived `redirect_uri` there is a
+ * real risk but a different one, and this finding's wording would misdescribe
+ * it. An audit test enumerates `@guren/core`'s `build*Url` exports against
+ * this list so a fifth builder cannot land here as a silent pass.
+ *
+ * The boundary this draws: a controller that mails a link assembled by hand,
+ * without going through these builders, is invisible here. Widening the gate
+ * to guessed-at mail helper names would trade a real false-positive cost for
+ * speculative coverage — the gate is a *requirement*, so loosening it makes
+ * every unrelated request-origin read in a mailing file a finding.
+ */
+const LINK_BUILDER_NAMES = 'TokenUrl|PasswordResetUrl|VerificationUrl|OAuthRedirectUrl'
+
+export const LINK_BUILDER_PATTERN = new RegExp(`\\bbuild(?:${LINK_BUILDER_NAMES})\\b`)
+
+/**
+ * A builder handed the request URL directly. Kept as its own anchor rather
+ * than folded into `LINK_BUILDER_PATTERN.test(line) && /req\.url/.test(line)`:
+ * `[^)]*` cannot cross the inner `)`, which is exactly what keeps the
+ * *sanctioned* one-liner `buildVerificationUrl(`${appUrl(this.request)}/x`, …)`
+ * — what the scaffold generates today — from matching. Both patterns are built
+ * from one name list so a new builder cannot reach only one of them.
+ */
+const LINK_BUILDER_FROM_REQUEST_PATTERN = new RegExp(
+  `\\bbuild(?:${LINK_BUILDER_NAMES})\\s*\\([^)]{0,200}\\b(?:req|request)\\s*\\.\\s*url\\b`,
+)
+
 async function auditSourceFiles(cwd: string, findings: AuditFinding[]): Promise<void> {
   const files: string[] = []
   for (const dir of SCAN_DIRECTORIES) {
@@ -612,6 +690,7 @@ async function auditSourceFiles(cwd: string, findings: AuditFinding[]): Promise<
   let secretCount = 0
   let rawSqlCount = 0
   let toggleCount = 0
+  let requestHostUrlCount = 0
 
   for (const filePath of files) {
     if (filePath.endsWith('.test.ts') || filePath.endsWith('.test.js')) continue
@@ -619,6 +698,10 @@ async function auditSourceFiles(cwd: string, findings: AuditFinding[]): Promise<
     const relPath = relative(cwd, filePath)
     const source = await readFile(filePath, 'utf-8')
     const lines = source.split('\n')
+
+    // File-level gate for the request-host rule below: the origin only
+    // becomes a finding once the same file also builds a link out of it.
+    const buildsOutboundLink = LINK_BUILDER_PATTERN.test(source)
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!
@@ -681,6 +764,32 @@ async function auditSourceFiles(cwd: string, findings: AuditFinding[]): Promise<
           ),
         )
       }
+
+      // Outbound links built from the client-controlled request host.
+      // Phrased conditionally, like the force-write rule: co-occurrence in one
+      // file is not proof the host reaches the link, and static analysis here
+      // cannot establish that it does.
+      if (
+        buildsOutboundLink &&
+        (REQUEST_ORIGIN_PATTERN.test(line) ||
+          (REQUEST_RECEIVER_PATTERN.test(line) && HOST_HEADER_READ_PATTERN.test(line)) ||
+          LINK_BUILDER_FROM_REQUEST_PATTERN.test(line))
+      ) {
+        requestHostUrlCount++
+        findings.push(
+          finding(
+            `request-host-url:${relPath}:${lineNumber}`,
+            `${relPath}:${lineNumber}`,
+            'warn',
+            "Request-derived host in a file that builds outbound links — if it reaches the link, a forged "
+            + "Host header points a genuine single-use token at the attacker's server.",
+            'Build the base URL from process.env.APP_URL and fail closed when it is unset — a request-host '
+            + 'fallback is still forgeable. `guren add auth` scaffolds app/Auth/AppUrl.ts for this.',
+            relPath,
+            lineNumber,
+          ),
+        )
+      }
     }
   }
 
@@ -692,6 +801,9 @@ async function auditSourceFiles(cwd: string, findings: AuditFinding[]): Promise<
   }
   if (toggleCount === 0) {
     findings.push(finding('security-toggle:none', 'Security defaults', 'pass', 'No disabled security defaults detected.'))
+  }
+  if (requestHostUrlCount === 0) {
+    findings.push(finding('request-host-url:none', 'Request-derived link URLs', 'pass', 'No outbound links built from the request host.'))
   }
 }
 

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -1,8 +1,8 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
-import { authMiddlewareVerdict, runAudit } from '../src/audit'
-import { createTempWorkspace } from './helpers'
+import { authMiddlewareVerdict, runAudit, LINK_BUILDER_PATTERN, type AuditReport } from '../src/audit'
+import { createTempWorkspace, writeWorkspaceFiles } from './helpers'
 
 async function writeRoutes(dir: string, contents: string): Promise<void> {
   await mkdir(join(dir, 'routes'), { recursive: true })
@@ -551,6 +551,244 @@ export default function registerRoutes(router: any) {
     } finally {
       await workspace.cleanup()
     }
+  })
+
+  describe('request-derived link URLs', () => {
+    /** Findings this rule raised against fixture files (not the `:none` pass row). */
+    function hostFindings(report: AuditReport) {
+      return report.findings.filter(f => f.key.startsWith('request-host-url:app/'))
+    }
+
+    /** Audit a throwaway workspace built from path → content, cleaning up after. */
+    async function withWorkspace(files: Record<string, string>): Promise<AuditReport> {
+      const workspace = await createTempWorkspace('guren-cli-audit-request-host-')
+      try {
+        await writeWorkspaceFiles(workspace.dir, files)
+        return await runAudit({ cwd: workspace.dir })
+      } finally {
+        await workspace.cleanup()
+      }
+    }
+
+    const CONTROLLER = 'app/Http/Controllers/Auth/ForgotPasswordController.ts'
+
+    // The pre-fix ForgotPasswordController body, verbatim: an unauthenticated
+    // attacker POSTing with a forged Host had the app mail the victim a real
+    // single-use token pointing at the attacker's server.
+    const vulnerableController = [
+      `import { Controller, createPasswordResetToken, buildPasswordResetUrl } from '@guren/core'`,
+      ``,
+      `export default class ForgotPasswordController extends Controller {`,
+      `  async store(): Promise<Response> {`,
+      `    const { email } = await this.validateBody(ForgotPasswordSchema)`,
+      `    const { token } = await createPasswordResetToken(email, passwordResetStore)`,
+      `    const resetUrl = buildPasswordResetUrl(\`\${new URL(this.request.url).origin}/reset-password\`, token, email)`,
+      `    await SendPasswordResetEmailJob.dispatch({ email, resetUrl })`,
+      `  }`,
+      `}`,
+    ].join('\n') + '\n'
+
+    it('warns when a reset link is built from the request host', async () => {
+      const report = await withWorkspace({ [CONTROLLER]: vulnerableController })
+
+      const found = hostFindings(report)
+      expect(found).toHaveLength(1)
+      expect(found[0]!.status).toBe('warn')
+      expect(found[0]!.line).toBe(7)
+      expect(found[0]!.suggestion).toContain('APP_URL')
+      // Classified so --json consumers and the console prefix stay stable.
+      expect(found[0]!.classifications?.map(c => c.id).sort()).toEqual(['A07', 'CWE-640'])
+      // The rule fires once per line, not once per matching pattern.
+      expect(report.findings.find(f => f.key === 'request-host-url:none')).toBeUndefined()
+    })
+
+    // buildOAuthRedirectUrl is a literal alias of buildTokenUrl and is exported
+    // from @guren/core; missing it made the audit report an affirmative pass on
+    // the exact exploit. See the drift test at the end of this block.
+    it('warns when an OAuth redirect link is built from the request host', async () => {
+      const report = await withWorkspace({
+        [CONTROLLER]: [
+          `import { buildOAuthRedirectUrl } from '@guren/core'`,
+          `const link = buildOAuthRedirectUrl(\`\${new URL(this.request.url).origin}/oauth/finish\`, token, email)`,
+        ].join('\n') + '\n',
+      })
+
+      expect(hostFindings(report)).toHaveLength(1)
+    })
+
+    it('warns when the request host header feeds a link builder', async () => {
+      const report = await withWorkspace({
+        [CONTROLLER]: [
+          `import { buildVerificationUrl } from '@guren/core'`,
+          `export default class C extends Controller {`,
+          `  async store() {`,
+          `    const host = this.request.header('host')`,
+          `    return buildVerificationUrl(\`https://\${host}/verify-email\`, token, email)`,
+          `  }`,
+          `}`,
+        ].join('\n') + '\n',
+      })
+
+      const found = hostFindings(report)
+      expect(found).toHaveLength(1)
+      expect(found[0]!.line).toBe(4)
+    })
+
+    // A host read off something the app produced is not the request host.
+    it('does not flag a host header read from a response', async () => {
+      const report = await withWorkspace({
+        [CONTROLLER]: [
+          `import { buildVerificationUrl } from '@guren/core'`,
+          `const upstreamHost = response.headers.get('host')`,
+          `const link = buildVerificationUrl(process.env.APP_URL + '/verify', token, email)`,
+        ].join('\n') + '\n',
+      })
+
+      expect(hostFindings(report)).toHaveLength(0)
+    })
+
+    it('warns when the request URL is passed straight to a link builder', async () => {
+      const report = await withWorkspace({
+        [CONTROLLER]: [
+          `import { buildVerificationUrl } from '@guren/core'`,
+          `const link = buildVerificationUrl(this.request.url, token, email)`,
+        ].join('\n') + '\n',
+      })
+
+      const found = hostFindings(report)
+      expect(found).toHaveLength(1)
+      expect(found[0]!.line).toBe(2)
+    })
+
+    // The two spellings an accessor requirement used to miss: the origin is
+    // read a line or more after the URL is parsed.
+    it.each([
+      ['a hoisted URL object', `    const url = new URL(this.request.url)`],
+      ['a destructured origin', `    const { origin } = new URL(this.request.url)`],
+    ])('warns when the origin is taken from %s', async (_label, parseLine) => {
+      const report = await withWorkspace({
+        [CONTROLLER]: [
+          `import { buildPasswordResetUrl } from '@guren/core'`,
+          `export default class C extends Controller {`,
+          `  async store() {`,
+          parseLine,
+          `    return buildPasswordResetUrl(\`\${origin}/reset-password\`, token, email)`,
+          `  }`,
+          `}`,
+        ].join('\n') + '\n',
+      })
+
+      const found = hostFindings(report)
+      expect(found).toHaveLength(1)
+      expect(found[0]!.line).toBe(4)
+    })
+
+    // The exact one-liner the scaffold generates today. `[^)]*` in the
+    // direct-pass anchor cannot cross the inner `)` of `appUrl(this.request)`,
+    // which is the only thing keeping the sanctioned fix from matching — so
+    // this asserts that property rather than leaving it incidental.
+    it('does not flag the scaffolded appUrl() one-liner', async () => {
+      const report = await withWorkspace({
+        [CONTROLLER]: [
+          `import { buildVerificationUrl } from '@guren/core'`,
+          `import { appUrl } from '../../../Auth/AppUrl.js'`,
+          `const verifyUrl = buildVerificationUrl(\`\${appUrl(this.request)}/verify-email/confirm\`, token, user.email)`,
+        ].join('\n') + '\n',
+      })
+
+      expect(hostFindings(report)).toHaveLength(0)
+    })
+
+    // The sanctioned helper `guren add auth` generates. Its non-production
+    // fallback returns a request-derived origin on purpose — it is the fix,
+    // not the bug, and must stay clean without being exempted by path.
+    it('does not flag the AppUrl helper that builds no links', async () => {
+      const report = await withWorkspace({
+        'app/Auth/AppUrl.ts': [
+          `export function appUrl(request: { url: string }): string {`,
+          `  const configured = process.env.APP_URL?.trim()`,
+          `  if (configured) {`,
+          `    const parsed = new URL(configured)`,
+          `    return \`\${parsed.origin}\${parsed.pathname.replace(/\\/+$/, '')}\``,
+          `  }`,
+          `  if (process.env.NODE_ENV === 'production') {`,
+          `    throw new Error('APP_URL is not set.')`,
+          `  }`,
+          `  return new URL(request.url).origin`,
+          `}`,
+        ].join('\n') + '\n',
+      })
+
+      expect(hostFindings(report)).toHaveLength(0)
+      expect(report.findings.find(f => f.key === 'request-host-url:none')?.status).toBe('pass')
+    })
+
+    // Reading the path off the request URL is not taking its host. The fixture
+    // calls a builder on purpose, so the gate passes and only the anchor can
+    // decide — without it this would prove nothing about the anchor at all.
+    it('does not flag a request URL parsed for its path inside a builder file', async () => {
+      const report = await withWorkspace({
+        'app/Http/Middleware/canonical-host.ts': [
+          `import { buildVerificationUrl } from '@guren/core'`,
+          `export const middleware = defineMiddleware(async (c, next) => {`,
+          `  const path = new URL(c.req.url).pathname`,
+          `  if (path === '/verify') return c.redirect(buildVerificationUrl(process.env.APP_URL + '/v', t))`,
+          `  return next()`,
+          `})`,
+        ].join('\n') + '\n',
+      })
+
+      expect(hostFindings(report)).toHaveLength(0)
+    })
+
+    it('suppresses the finding with guren-audit-ignore', async () => {
+      const report = await withWorkspace({
+        [CONTROLLER]: vulnerableController.replace(
+          '    const resetUrl =',
+          '    // guren-audit-ignore -- internal admin link, never emailed\n    const resetUrl =',
+        ),
+      })
+
+      expect(hostFindings(report)).toHaveLength(0)
+    })
+
+    // The audit reads whatever source the app contains, and CI runs it over
+    // examples/blog on fork pull requests — so one crafted line must not hang
+    // it. Many `new URL(req.url` runs with no `)` between them is the shape
+    // that blows up; it also carries a builder call, so the gate lets it
+    // through. Measured on this exact input: 6918ms with `[^)]*`, 5ms with
+    // `[^)]{0,200}`. The threshold sits between the two, so dropping the
+    // bounds fails this test rather than merely slowing it down.
+    it('rejects a pathological line without catastrophic backtracking', async () => {
+      const pathological = 'const x = new URL(' + 'new URL(req.url '.repeat(1200) + '\n'
+
+      const started = Bun.nanoseconds()
+      const report = await withWorkspace({
+        [CONTROLLER]: `import { buildPasswordResetUrl } from '@guren/core'\n${pathological}`,
+      })
+      const elapsedMs = (Bun.nanoseconds() - started) / 1e6
+
+      expect(elapsedMs).toBeLessThan(1500)
+      expect(hostFindings(report)).toHaveLength(0)
+    })
+
+    // The gate is a hand-maintained name list, so a builder added to
+    // @guren/core reaches users as an affirmative `pass` — which is how
+    // buildOAuthRedirectUrl was missed. This fails when a fifth one lands.
+    it('covers every build*Url that @guren/core exports', async () => {
+      const core = await import('@guren/core')
+      const exported = Object.keys(core).filter(name => /^build[A-Za-z]*Url$/.test(name))
+
+      // Builds the *provider's* authorize URL, not a link the app mails to a
+      // user. A request-derived redirect_uri there is a real risk but a
+      // different one, and this rule's wording would misdescribe it.
+      const excluded = new Set(['buildOAuthAuthorizeUrl'])
+
+      expect(exported.length).toBeGreaterThan(0)
+      for (const name of exported) {
+        expect(LINK_BUILDER_PATTERN.test(name) || excluded.has(name)).toBe(true)
+      }
+    })
   })
 
   it('warns about models without fillable or guarded', async () => {


### PR DESCRIPTION
## Why

#293 fixed a HIGH-severity Host header injection in the auth scaffold. Password-reset links were built as:

```ts
buildPasswordResetUrl(`${new URL(this.request.url).origin}/reset-password`, token, email)
```

`this.request.url` is reconstructed from the client-controlled `Host` header, so an unauthenticated attacker could `POST /forgot-password` with a victim's email and `Host: attacker.tld` and have the app mail that victim a genuine single-use reset token pointing at the attacker's server.

That fix changed only **generated** output — the auth scaffold now emits an `app/Auth/AppUrl.ts` helper reading `APP_URL`. It therefore does not reach:

- apps scaffolded before that release — #293's changeset tells those users to hand-patch or re-run `guren add auth --force`
- anyone hand-writing the controller

`guren audit` ships with the CLI those users already run and has no template/npm-release coupling, so it is the one mechanism that reaches that population. It returned green on the exact code the changeset calls exploitable.

## What this adds

A `request-host-url:*` rule in `auditSourceFiles`, `warn` severity, classified **A07 / CWE-640**.

**Anchors** (any one, per line):
- a request-derived origin — `new URL(req.url)`, excluding a same-line path-ish accessor (`.pathname`, `.searchParams`, …)
- a `host` / `x-forwarded-host` / `:authority` read off the request — `.header('host')`, `.get('host')`, `.headers.host`, optional-chained
- a request URL handed straight to a link builder

**Gate** (file level): the file must also name one of the framework's outbound-link builders — `buildTokenUrl` and its `buildPasswordResetUrl`, `buildVerificationUrl`, and `buildOAuthRedirectUrl` aliases. Matching the bare name rather than a call also covers an aliased import (`buildVerificationUrl as makeUrl`), which would otherwise skip the file silently.

## False-positive discipline

The gate is what keeps the generated `app/Auth/AppUrl.ts` clean. Its non-production fallback returns `new URL(request.url).origin` **on purpose** — it is the fix, not the bug — and it builds no link. Gating on behaviour rather than exempting the helper by path means the exemption survives a user renaming it.

Two more properties are load-bearing and now have their own tests rather than being incidental:

- **The scaffold's own one-liner must not match.** Three of the four post-#293 call sites in `examples/blog` are `buildVerificationUrl(\`${appUrl(this.request)}/…\`, …)` on one line. `[^)]` cannot cross the inner `)` of `appUrl(this.request)`, which is the only thing keeping the sanctioned output clean.
- **A host read off a response is not the request host.** `response.headers.get('host')` requires a request receiver on the line to match.

Validated in both directions against the real apps in this repo, not just fixtures:

| Subject | Result |
|---|---|
| `examples/blog` (post-#293) | **0 findings** — despite `app/Auth/AppUrl.ts` containing a request-derived origin and four controllers calling the link builders |
| `web/` | **0 findings** — `canonical-host.ts` and `site-analytics.ts` parse the request URL only to reach its path |
| `examples/blog` (pre-#293, `ab18e90`) | exactly its **4 vulnerable sites**, nothing else |
| pre-#293 `ForgotPasswordController` restored *alongside* the fixed `AppUrl.ts` | exactly **1 finding**, on the vulnerable line; the helper stays clean |

## Keeping the gate honest

The gate is a hand-maintained name list, so a builder added to `@guren/core` would reach users as an affirmative **`pass`** — which is exactly how `buildOAuthRedirectUrl` (a literal alias of `buildTokenUrl`, exported from `@guren/core`) was missed in the first draft of this rule. A test enumerates `@guren/core`'s `/^build[A-Za-z]*Url$/` exports against the list, with `buildOAuthAuthorizeUrl` as a **documented exclusion** — it builds the *provider's* authorize URL, a real but different risk this finding's wording would misdescribe.

## Not catastrophic-backtracking

The audit reads whatever source the app contains, and CI runs it over `examples/blog` on `pull_request` — i.e. on fork branches. The `[^)]` runs are bounded, and the redundant `\s*` that overlapped them is gone; both were needed, measured separately.

| input | unbounded | bounded |
|---|---|---|
| 19 KB gate-reachable line | 6918 ms | 5 ms |
| 16 KB gate-reachable line | 3512 ms | 6 ms |
| 800 KB ungated line | 61 s | 1.4 ms |

Growth is linear. A regression test pins it with the threshold set **between** the two measured values, so removing the bounds fails the test rather than merely slowing it.

## What it deliberately does not catch

A controller that mails a link assembled by hand, without going through those builders, is invisible to the gate. Widening it to guessed-at mail helper names would trade a real false-positive cost for speculative coverage. Stated in the changeset and in a source comment so a green audit doesn't imply more than it checks.

The finding is worded conditionally, matching the sibling `force-write-request-data` rule: co-occurrence in one file is not proof the host reaches the link, and static analysis here cannot establish that it does.

The rule *does* fire on `process.env.APP_URL ?? new URL(req.url).origin`. That is deliberate: the fallback is fail-open, so a forged host still works whenever `APP_URL` is unset — exactly the production misconfiguration the scaffolded helper throws on instead.

## Mutation-checked

Each guard fails only its own test:

- gate forced `false` (rule never fires) → the positive tests fail
- gate forced `true` (gate removed) → the `AppUrl.ts` test fails
- `buildOAuthRedirectUrl` dropped from the list → 2 fail, including the drift test
- `[^)]` bounds removed → the backtracking test fails at 5646 ms
- request-receiver requirement dropped → the response-header test fails

## Verification

- `bun run test:bun cli` — 1098 pass, 0 fail
- `bun run test:bun` — 3479 pass, 0 fail
- `bun run test:examples` — 16 files / 102 tests, pass
- `bun run typecheck` from the repo root — clean
- `bun run audit:docs`, `bun run audit:core-first` — pass

No template or scaffold files touched, so the starter-template audits and smokes are not implicated.