### PR TITLE
feat(orm): add typed allowlist options to defineModel

### DIFF
--- a/.changeset/typed-define-model-options.md
+++ b/.changeset/typed-define-model-options.md
@@ -1,0 +1,6 @@
+---
+'@guren/orm': minor
+'@guren/cli': minor
+---
+
+Add typed allowlist options to `defineModel`: `fillable`, `hidden`, `visible`, `accessors`, and `appends` can now be passed as options, checked at compile time against the table's columns (and, for `fillable`, fields contributed by the `base` such as `AuthenticatableModel`'s virtual `password`). Accessor functions receive the table's inferred record, and `appends` may only name declared accessors. `static` declarations keep working and shadow the options. `guren audit` and `guren check` recognize the option form with the same shadowing order.

--- a/docs/en/guides/database.md
+++ b/docs/en/guides/database.md
@@ -240,13 +240,14 @@ await Post.transaction(async (_trx, txPost) => {
 Control which fields can be set through `create()` and `update()`:
 
 ```ts
-export class Post extends defineModel(posts) {
-  // Allowlist — only these fields are assignable
-  static fillable = ['title', 'body', 'status']
-}
+export class Post extends defineModel(posts, {
+  // Allowlist — only these fields are assignable.
+  // Checked against the table's columns: a typo is a compile error.
+  fillable: ['title', 'body', 'status'],
+}) {}
 ```
 
-When `fillable` is set, passing any field outside the allowlist to `create()` or `update()` throws a `MassAssignmentException` (exported from `@guren/core`). The message names the blocked fields, so a typo or an injection attempt fails loudly at the call site instead of being silently discarded and resurfacing later as a confusing NOT NULL violation:
+The same allowlist can be declared as `static fillable = ['title', 'body', 'status']` on the class instead; the option form is preferred because TypeScript verifies every name against the table (a `static` declaration on the subclass shadows the option). When `fillable` is set, passing any field outside the allowlist to `create()` or `update()` throws a `MassAssignmentException` (exported from `@guren/core`). The message names the blocked fields, so a typo or an injection attempt fails loudly at the call site instead of being silently discarded and resurfacing later as a confusing NOT NULL violation:
 
 ```ts
 await Post.create({ title: 'Hello', body: '...', status: 'draft', authorId: 1 })
@@ -592,13 +593,16 @@ Accessors compute virtual attributes when reading records. Mutators transform va
 Define computed properties that are automatically applied when records are fetched:
 
 ```ts
-export class User extends defineModel(users) {
-  static accessors = {
+export class User extends defineModel(users, {
+  accessors: {
+    // `record` is typed as the table's record — field typos are compile errors
     fullName: (record) => `${record.firstName} ${record.lastName}`,
     isAdmin: (record) => record.role === 'admin',
-  }
-}
+  },
+}) {}
 ```
+
+(`static accessors = { ... }` on the class works too, without the typed `record` parameter.)
 
 ```ts
 const user = await User.find(1)
@@ -637,10 +641,12 @@ Control how model records appear in API responses and Inertia props.
 Exclude sensitive fields from serialized output:
 
 ```ts
-export class User extends defineModel(users) {
-  static hidden = ['passwordHash', 'rememberToken']
-}
+export class User extends defineModel(users, {
+  hidden: ['passwordHash', 'rememberToken'],
+}) {}
 ```
+
+Like `fillable`, the option is checked against the table's columns; `static hidden = [...]` also works.
 
 ```ts
 const user = await User.find(1)
@@ -656,9 +662,9 @@ Fields listed in `hidden` are also stripped from the record returned by `auth.us
 Use a whitelist instead of a blacklist:
 
 ```ts
-export class User extends defineModel(users) {
-  static visible = ['id', 'name', 'email']
-}
+export class User extends defineModel(users, {
+  visible: ['id', 'name', 'email'],
+}) {}
 ```
 
 When `visible` is set, only those fields appear. `visible` takes precedence over `hidden`.
@@ -668,14 +674,16 @@ When `visible` is set, only those fields appear. `visible` takes precedence over
 Include accessor-computed values in serialized output:
 
 ```ts
-export class User extends defineModel(users) {
-  static accessors = {
+export class User extends defineModel(users, {
+  accessors: {
     fullName: (record) => `${record.firstName} ${record.lastName}`,
-  }
-  static appends = ['fullName']
-  static hidden = ['firstName', 'lastName']
-}
+  },
+  appends: ['fullName'],
+  hidden: ['firstName', 'lastName'],
+}) {}
 ```
+
+`appends` may only name accessors declared in the same options object — an undeclared name is a compile error.
 
 ```ts
 const json = User.serialize(user)

--- a/docs/ja/guides/database.md
+++ b/docs/ja/guides/database.md
@@ -590,13 +590,16 @@ export class Post extends defineModel(posts) {
 レコード取得時に自動的に適用される計算プロパティを定義します。
 
 ```ts
-export class User extends defineModel(users) {
-  static accessors = {
+export class User extends defineModel(users, {
+  accessors: {
+    // `record` はテーブルのレコード型 — フィールド名のタイプミスはコンパイルエラー
     fullName: (record) => `${record.firstName} ${record.lastName}`,
     isAdmin: (record) => record.role === 'admin',
-  }
-}
+  },
+}) {}
 ```
+
+（クラス側の `static accessors = { ... }` も使えますが、`record` 引数には型が付きません。）
 
 ```ts
 const user = await User.find(1)
@@ -634,10 +637,12 @@ API レスポンスや Inertia プロップスでモデルレコードの表示�
 機密フィールドをシリアライズ出力から除外します。
 
 ```ts
-export class User extends defineModel(users) {
-  static hidden = ['passwordHash', 'rememberToken']
-}
+export class User extends defineModel(users, {
+  hidden: ['passwordHash', 'rememberToken'],
+}) {}
 ```
+
+`fillable` と同じく、オプションはテーブルのカラム名に対して型チェックされます。`static hidden = [...]` も引き続き使えます。
 
 ```ts
 const user = await User.find(1)
@@ -653,9 +658,9 @@ const json = User.serialize(user)
 ブラックリストの代わりにホワイトリストを使用することもできます。
 
 ```ts
-export class User extends defineModel(users) {
-  static visible = ['id', 'name', 'email']
-}
+export class User extends defineModel(users, {
+  visible: ['id', 'name', 'email'],
+}) {}
 ```
 
 `visible` が設定されている場合、そのフィールドのみが表示されます。`visible` は `hidden` より優先されます。
@@ -665,14 +670,16 @@ export class User extends defineModel(users) {
 アクセサで計算された値をシリアライズ出力に含めます。
 
 ```ts
-export class User extends defineModel(users) {
-  static accessors = {
+export class User extends defineModel(users, {
+  accessors: {
     fullName: (record) => `${record.firstName} ${record.lastName}`,
-  }
-  static appends = ['fullName']
-  static hidden = ['firstName', 'lastName']
-}
+  },
+  appends: ['fullName'],
+  hidden: ['firstName', 'lastName'],
+}) {}
 ```
+
+`appends` に書けるのは同じオプションの `accessors` で宣言した名前だけです — 未宣言の名前はコンパイルエラーになります。
 
 ```ts
 const json = User.serialize(user)
@@ -694,13 +701,14 @@ const json = User.serializeMany(users)
 `fillable` で、`create()` や `update()` で設定可能なフィールドを制御できます。
 
 ```ts
-export class Post extends defineModel(posts) {
-  // これらのフィールドのみ一括代入可能
-  static fillable = ['title', 'body', 'status']
-}
+export class Post extends defineModel(posts, {
+  // これらのフィールドのみ一括代入可能。
+  // テーブルのカラム名に対して型チェックされ、タイプミスはコンパイルエラーになる
+  fillable: ['title', 'body', 'status'],
+}) {}
 ```
 
-`fillable` を設定すると、許可リスト外のフィールドを `create()` や `update()` に渡した場合、`MassAssignmentException`（`@guren/core` からエクスポート）がスローされます。エラーメッセージにはブロックされたフィールド名が含まれるため、タイプミスやインジェクションの試みが黙って破棄されて後から NOT NULL 違反として現れるのではなく、呼び出し箇所でその場で検出できます。
+クラス側に `static fillable = ['title', 'body', 'status']` と宣言しても同じ許可リストになります。オプション形は TypeScript が全フィールド名をテーブルと照合するため推奨です（サブクラスの `static` 宣言はオプションを上書きします）。`fillable` を設定すると、許可リスト外のフィールドを `create()` や `update()` に渡した場合、`MassAssignmentException`（`@guren/core` からエクスポート）がスローされます。エラーメッセージにはブロックされたフィールド名が含まれるため、タイプミスやインジェクションの試みが黙って破棄されて後から NOT NULL 違反として現れるのではなく、呼び出し箇所でその場で検出できます。
 
 ```ts
 await Post.create({ title: 'Hello', body: '...', status: 'draft', authorId: 1 })

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -20,8 +20,10 @@ import {
   classUsesAuthenticatableBase,
   extractClassDeclaration,
   extractTableIdentifier,
+  findDefineModelOption,
   findStaticClassProperty,
   firstClassDeclaration,
+  resolveModelStringArrayConfig,
 } from './model-parser'
 import { parseSourceFile } from './parse-cache'
 import { parseSchemaTableColumns } from './schema-parser'
@@ -727,20 +729,10 @@ function parseModelSerializationInfo(source: string, filePath: string): ModelSer
 
     info.tableIdentifier = extractTableIdentifier(classDecl) ?? info.tableIdentifier
 
-    for (const member of classDecl.body.body) {
-      if (member.type !== 'ClassProperty' || !member.static || member.key.type !== 'Identifier') continue
-
-      if (
-        (member.key.name === 'hidden' || member.key.name === 'visible') &&
-        member.value?.type === 'ArrayExpression'
-      ) {
-        const entries: string[] = []
-        for (const element of member.value.elements) {
-          if (element?.type === 'StringLiteral') entries.push(element.value)
-        }
-        info[member.key.name] = entries
-      }
-    }
+    // Static declaration or defineModel option — resolved with the runtime's
+    // shadowing order (static wins).
+    info.hidden = resolveModelStringArrayConfig(classDecl, 'hidden') ?? info.hidden
+    info.visible = resolveModelStringArrayConfig(classDecl, 'visible') ?? info.visible
   }
 
   return info
@@ -760,7 +752,10 @@ async function auditModels(cwd: string, findings: AuditFinding[]): Promise<void>
     // protected, and a modifier-prefixed fillable must still count.
     const ast = parseSourceFile(source, filePath)
     const classDecl = ast ? firstClassDeclaration(ast.program.body) : null
-    const hasFillable = classDecl ? findStaticClassProperty(classDecl, 'fillable') !== null : false
+    const hasFillable = classDecl
+      ? findStaticClassProperty(classDecl, 'fillable') !== null ||
+        findDefineModelOption(classDecl, 'fillable') !== null
+      : false
     const isAuthenticatable = classDecl ? classUsesAuthenticatableBase(classDecl) : false
 
     // Authenticatable models are structurally protected: their credential
@@ -779,7 +774,7 @@ async function auditModels(cwd: string, findings: AuditFinding[]): Promise<void>
             : `${name} declares no fillable — all columns except 'id' are mass-assignable.`,
         hasFillable || isAuthenticatable
           ? undefined
-          : `Add 'static fillable = [...]' to ${relPath} to whitelist assignable columns.`,
+          : `Add a fillable allowlist to ${relPath} — the typed 'defineModel(table, { fillable: [...] })' option or 'static fillable = [...]'.`,
         relPath,
       ),
     )
@@ -811,8 +806,8 @@ async function auditModels(cwd: string, findings: AuditFinding[]): Promise<void>
         exposed.length === 0
           ? undefined
           : visibleActive
-            ? `Remove ${exposed.map((c) => `'${c}'`).join(', ')} from 'static visible' in ${relPath} (a non-empty visible allowlist overrides hidden).`
-            : `Add ${exposed.map((c) => `'${c}'`).join(', ')} to 'static hidden = [...]' in ${relPath}.`,
+            ? `Remove ${exposed.map((c) => `'${c}'`).join(', ')} from the visible allowlist in ${relPath} (a non-empty visible allowlist overrides hidden).`
+            : `Add ${exposed.map((c) => `'${c}'`).join(', ')} to the hidden list in ${relPath} — the typed 'defineModel(table, { hidden: [...] })' option or 'static hidden = [...]'.`,
         relPath,
       ),
     )

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -20,9 +20,8 @@ import {
   classUsesAuthenticatableBase,
   extractClassDeclaration,
   extractTableIdentifier,
-  findDefineModelOption,
-  findStaticClassProperty,
   firstClassDeclaration,
+  hasModelConfig,
   resolveModelStringArrayConfig,
 } from './model-parser'
 import { parseSourceFile } from './parse-cache'
@@ -752,10 +751,7 @@ async function auditModels(cwd: string, findings: AuditFinding[]): Promise<void>
     // protected, and a modifier-prefixed fillable must still count.
     const ast = parseSourceFile(source, filePath)
     const classDecl = ast ? firstClassDeclaration(ast.program.body) : null
-    const hasFillable = classDecl
-      ? findStaticClassProperty(classDecl, 'fillable') !== null ||
-        findDefineModelOption(classDecl, 'fillable') !== null
-      : false
+    const hasFillable = classDecl ? hasModelConfig(classDecl, 'fillable') : false
     const isAuthenticatable = classDecl ? classUsesAuthenticatableBase(classDecl) : false
 
     // Authenticatable models are structurally protected: their credential

--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -21,7 +21,7 @@ import {
   extractTableIdentifier,
   findStaticClassProperty,
   firstClassDeclaration,
-  staticStringArrayProperty,
+  resolveModelStringArrayConfig,
   staticStringProperty,
 } from './model-parser'
 import { checkConsoleCommandRegistration } from './console-check'
@@ -409,7 +409,7 @@ async function checkMassAssignmentConfig(
   }
 
   if (classUsesAuthenticatableBase(classDecl)) {
-    const fillable = staticStringArrayProperty(classDecl, 'fillable')
+    const fillable = resolveModelStringArrayConfig(classDecl, 'fillable')
     if (fillable) {
       const passwordField = staticStringProperty(classDecl, 'passwordField') ?? 'password'
       const hashField = staticStringProperty(classDecl, 'passwordHashField') ?? 'passwordHash'

--- a/packages/cli/src/guidelines.ts
+++ b/packages/cli/src/guidelines.ts
@@ -105,7 +105,7 @@ export async function generateGuidelines(options: GuidelinesOptions = {}): Promi
   lines.push("- Protect mutating routes: wrap in `router.middleware('auth').group(...)` or call `this.auth.userOrFail()` (optional reads like `auth.user()` do not enforce)")
   lines.push('- Never interpolate values into raw SQL (`sql.raw`) — drizzle `sql` templates bind values safely')
   lines.push('- Never hardcode credentials — read secrets via `process.env`')
-  lines.push('- Declare `static fillable` on models to whitelist mass-assignable columns')
+  lines.push('- Whitelist mass-assignable columns on every model — prefer the typed `defineModel(table, { fillable: [...] })` option (column typos become compile errors); `static fillable = [...]` also works')
   lines.push('')
 
   // Resources

--- a/packages/cli/src/model-parser.ts
+++ b/packages/cli/src/model-parser.ts
@@ -204,12 +204,19 @@ export function staticStringProperty(classDecl: ClassDeclaration, name: string):
   return property?.value?.type === 'StringLiteral' ? property.value.value : undefined
 }
 
-/** String-literal entries of an array-literal node, or undefined for any other node. */
+/**
+ * String-literal entries of an array-literal node, or undefined for any
+ * other node — including an array with a spread or computed element. A
+ * partial read is worse than none for the allowlist checks: `visible:
+ * ['id', ...EXPOSED]` read as `['id']` reports columns hidden that the
+ * runtime exposes.
+ */
 function stringArrayEntries(node: Node | null | undefined): string[] | undefined {
   if (node?.type !== 'ArrayExpression') return undefined
   const entries: string[] = []
   for (const element of node.elements) {
-    if (element?.type === 'StringLiteral') entries.push(element.value)
+    if (element?.type !== 'StringLiteral') return undefined
+    entries.push(element.value)
   }
   return entries
 }
@@ -234,14 +241,21 @@ function findDefineModelCall(node: Node): CallExpression | null {
   return null
 }
 
-/** The named property of the class's `defineModel(table, { ... })` options object, if present. */
+/**
+ * The named property of the class's `defineModel(table, { ... })` options
+ * object, if present. A literal `name: undefined` counts as absent — the
+ * runtime skips the assignment, so the model is configured by neither
+ * spelling.
+ */
 export function findDefineModelOption(classDecl: ClassDeclaration, name: string): ObjectProperty | null {
   if (!classDecl.superClass) return null
   const call = findDefineModelCall(classDecl.superClass)
   const options = call?.arguments[1]
   if (options?.type !== 'ObjectExpression') return null
   for (const property of options.properties) {
-    if (property.type === 'ObjectProperty' && propertyKeyName(property) === name) return property
+    if (property.type !== 'ObjectProperty' || propertyKeyName(property) !== name) continue
+    if (property.value.type === 'Identifier' && property.value.name === 'undefined') return null
+    return property
   }
   return null
 }
@@ -259,7 +273,13 @@ function defineModelStringArrayOption(classDecl: ClassDeclaration, name: string)
  * anything resolving these allowlists goes through here.
  */
 export function resolveModelStringArrayConfig(classDecl: ClassDeclaration, name: string): string[] | undefined {
-  return staticStringArrayProperty(classDecl, name) ?? defineModelStringArrayOption(classDecl, name)
+  // Precedence follows declaration presence, not parseability: a static
+  // whose value we cannot read (`static hidden = HIDDEN`) still shadows the
+  // option at runtime, so falling back to the option would report a list the
+  // runtime does not use. Unreadable resolves to undefined and the checks
+  // stay conservative.
+  if (findStaticClassProperty(classDecl, name)) return staticStringArrayProperty(classDecl, name)
+  return defineModelStringArrayOption(classDecl, name)
 }
 
 /**

--- a/packages/cli/src/model-parser.ts
+++ b/packages/cli/src/model-parser.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises'
-import type { Statement, Expression, ClassDeclaration, ClassBody, ClassProperty, Node, ObjectProperty } from '@babel/types'
+import type { Statement, Expression, ClassDeclaration, ClassBody, ClassProperty, CallExpression, Node, ObjectProperty } from '@babel/types'
 import { extractDocsTags } from './docs-index'
 import { discoverModelFiles, toPosixRelative, moduleNameFromRelPath } from './discovery'
 import { parseSourceFile } from './parse-cache'
@@ -225,15 +225,62 @@ export function staticStringProperty(classDecl: ClassDeclaration, name: string):
   return property?.value?.type === 'StringLiteral' ? property.value.value : undefined
 }
 
-/** Entries of `static <name> = ['a', 'b']`, or undefined when absent or not an array literal. */
-export function staticStringArrayProperty(classDecl: ClassDeclaration, name: string): string[] | undefined {
-  const property = findStaticClassProperty(classDecl, name)
-  if (property?.value?.type !== 'ArrayExpression') return undefined
+/** String-literal entries of an array-literal node, or undefined for any other node. */
+function stringArrayEntries(node: Node | null | undefined): string[] | undefined {
+  if (node?.type !== 'ArrayExpression') return undefined
   const entries: string[] = []
-  for (const element of property.value.elements) {
+  for (const element of node.elements) {
     if (element?.type === 'StringLiteral') entries.push(element.value)
   }
   return entries
+}
+
+/** Entries of `static <name> = ['a', 'b']`, or undefined when absent or not an array literal. */
+export function staticStringArrayProperty(classDecl: ClassDeclaration, name: string): string[] | undefined {
+  return stringArrayEntries(findStaticClassProperty(classDecl, name)?.value)
+}
+
+/**
+ * The `defineModel(...)` call in an extends clause, however wrapped —
+ * `defineModel(posts)` directly or through a mixin such as
+ * `SoftDeletes(defineModel(posts))`.
+ */
+function findDefineModelCall(node: Node): CallExpression | null {
+  if (node.type !== 'CallExpression') return null
+  if (node.callee.type === 'Identifier' && node.callee.name === 'defineModel') return node
+  for (const argument of node.arguments) {
+    const nested = findDefineModelCall(argument)
+    if (nested) return nested
+  }
+  return null
+}
+
+/** The named property of the class's `defineModel(table, { ... })` options object, if present. */
+export function findDefineModelOption(classDecl: ClassDeclaration, name: string): ObjectProperty | null {
+  if (!classDecl.superClass) return null
+  const call = findDefineModelCall(classDecl.superClass)
+  const options = call?.arguments[1]
+  if (options?.type !== 'ObjectExpression') return null
+  for (const property of options.properties) {
+    if (property.type === 'ObjectProperty' && propertyKeyName(property) === name) return property
+  }
+  return null
+}
+
+/** Entries of a string-array defineModel option (e.g. `fillable: ['a', 'b']`). */
+export function defineModelStringArrayOption(classDecl: ClassDeclaration, name: string): string[] | undefined {
+  return stringArrayEntries(findDefineModelOption(classDecl, name)?.value)
+}
+
+/**
+ * Resolve a string-array model config (`fillable`, `hidden`, `visible`, …)
+ * the way the runtime does: a `static` declaration on the subclass shadows
+ * the same-named defineModel option. Callers that read only the static
+ * spelling silently stop covering models written the option way, so
+ * anything resolving these allowlists goes through here.
+ */
+export function resolveModelStringArrayConfig(classDecl: ClassDeclaration, name: string): string[] | undefined {
+  return staticStringArrayProperty(classDecl, name) ?? defineModelStringArrayOption(classDecl, name)
 }
 
 function analyzeClassHeader(

--- a/packages/cli/src/model-parser.ts
+++ b/packages/cli/src/model-parser.ts
@@ -134,19 +134,8 @@ function propertyKeyName(property: ObjectProperty): string | undefined {
  * model written that way must not read as bindless.
  */
 function defineModelTableArgument(node: Node): string | undefined {
-  if (node.type !== 'CallExpression') return undefined
-
-  const callee = node.callee
-  if (callee.type === 'Identifier' && callee.name === 'defineModel') {
-    const firstArg = node.arguments[0]
-    return firstArg?.type === 'Identifier' ? firstArg.name : undefined
-  }
-
-  for (const argument of node.arguments) {
-    const nested = defineModelTableArgument(argument)
-    if (nested) return nested
-  }
-  return undefined
+  const firstArg = findDefineModelCall(node)?.arguments[0]
+  return firstArg?.type === 'Identifier' ? firstArg.name : undefined
 }
 
 /**
@@ -189,22 +178,12 @@ export function classUsesAuthenticatableBase(classDecl: ClassDeclaration): boole
   if (!superClass) return false
 
   // defineModel(users, { base: AuthenticatableModel }) — the auth base
-  // arrives as an option rather than as the superclass itself.
-  if (superClass.type === 'CallExpression') {
-    const callee = superClass.callee
-    if (callee.type === 'Identifier' && callee.name === 'defineModel') {
-      const options = superClass.arguments[1]
-      if (options?.type === 'ObjectExpression') {
-        const viaBase = options.properties.some(
-          (property) =>
-            property.type === 'ObjectProperty' &&
-            propertyKeyName(property) === 'base' &&
-            isAuthenticatableBase(property.value),
-        )
-        if (viaBase) return true
-      }
-    }
-  }
+  // arrives as an option rather than as the superclass itself. Resolved
+  // through findDefineModelOption so mixin wrapping is covered the same way
+  // it is for the table and the allowlist options.
+  const baseOption = findDefineModelOption(classDecl, 'base')
+  if (baseOption && isAuthenticatableBase(baseOption.value)) return true
+
   // AuthenticatableModel pattern
   return isAuthenticatableBase(superClass)
 }
@@ -236,7 +215,7 @@ function stringArrayEntries(node: Node | null | undefined): string[] | undefined
 }
 
 /** Entries of `static <name> = ['a', 'b']`, or undefined when absent or not an array literal. */
-export function staticStringArrayProperty(classDecl: ClassDeclaration, name: string): string[] | undefined {
+function staticStringArrayProperty(classDecl: ClassDeclaration, name: string): string[] | undefined {
   return stringArrayEntries(findStaticClassProperty(classDecl, name)?.value)
 }
 
@@ -268,7 +247,7 @@ export function findDefineModelOption(classDecl: ClassDeclaration, name: string)
 }
 
 /** Entries of a string-array defineModel option (e.g. `fillable: ['a', 'b']`). */
-export function defineModelStringArrayOption(classDecl: ClassDeclaration, name: string): string[] | undefined {
+function defineModelStringArrayOption(classDecl: ClassDeclaration, name: string): string[] | undefined {
   return stringArrayEntries(findDefineModelOption(classDecl, name)?.value)
 }
 
@@ -281,6 +260,16 @@ export function defineModelStringArrayOption(classDecl: ClassDeclaration, name: 
  */
 export function resolveModelStringArrayConfig(classDecl: ClassDeclaration, name: string): string[] | undefined {
   return staticStringArrayProperty(classDecl, name) ?? defineModelStringArrayOption(classDecl, name)
+}
+
+/**
+ * Whether the model declares the named config in either spelling — a static
+ * class property or a defineModel option — regardless of whether its value
+ * is a parseable array literal. The presence twin of
+ * `resolveModelStringArrayConfig`; keep the two composition rules together.
+ */
+export function hasModelConfig(classDecl: ClassDeclaration, name: string): boolean {
+  return findStaticClassProperty(classDecl, name) !== null || findDefineModelOption(classDecl, name) !== null
 }
 
 function analyzeClassHeader(

--- a/packages/cli/templates/agent/.claude/rules/orm-models.md
+++ b/packages/cli/templates/agent/.claude/rules/orm-models.md
@@ -15,8 +15,11 @@ import { posts } from '../../db/schema.js'
 
 export type PostRecord = typeof posts.$inferSelect
 
-export class Post extends defineModel(posts) {
-  static fillable = ['title', 'body', 'authorId']
+export class Post extends defineModel(posts, {
+  // Typed against the table's columns — a typo is a compile error.
+  // (`static fillable = [...]` on the class also works and shadows the option.)
+  fillable: ['title', 'body', 'authorId'],
+}) {
   static override relationTypes: { author: BelongsToRecord<UserRecord> } = { author: null }
 }
 Post.belongsTo('author', () => import('./User.js').then((m) => m.User), 'authorId', 'id')
@@ -159,8 +162,11 @@ For concurrency safety add a unique index and catch the constraint error, or wra
 
 ## Mass assignment
 
-- With `static fillable = [...]` set, `create()`/`update()` **throw `MassAssignmentException`**
-  on any unlisted input key; the primary key (`id`) is always silently stripped
+- With a fillable allowlist set — the typed `defineModel(table, { fillable: [...] })` option
+  (preferred) or `static fillable = [...]` — `create()`/`update()` **throw
+  `MassAssignmentException`** on any unlisted input key; the primary key (`id`) is always
+  silently stripped. The same typed options exist for `hidden`, `visible`, `accessors`,
+  and `appends`
 - Credential columns (`passwordHash`, `rememberToken`) **always throw** on authenticatable
   models — the framework denies them, listing them in `fillable` does not open them
 - `forceCreate()` / `forceUpdate()` bypass filtering — trusted server-side values only.

--- a/packages/cli/templates/agent/.claude/skills/feature/SKILL.md
+++ b/packages/cli/templates/agent/.claude/skills/feature/SKILL.md
@@ -132,10 +132,12 @@ interface Props {
 Always add `fillable` to generated models. This is the second defense layer after Zod validation — it prevents unintended fields from reaching the database even if the controller validation is bypassed or misconfigured:
 
 ```typescript
-export class <Name> extends defineModel(<names>) {
-  static fillable = ['title', 'body', 'authorId']  // only these fields pass to create()/update()
-}
+export class <Name> extends defineModel(<names>, {
+  fillable: ['title', 'body', 'authorId'],  // only these fields pass to create()/update()
+}) {}
 ```
+
+Prefer the `defineModel` option over `static fillable = [...]` — the option is typed against the table's columns, so a typo is a compile error (a `static` declaration still works and shadows the option).
 
 For User models, credential columns (`passwordHash`, `rememberToken`) are denied from
 mass assignment by `AuthenticatableModel` itself — never list them in `fillable`:
@@ -145,9 +147,8 @@ export class User extends defineModel(users, {
   base: AuthenticatableModel,
   optionalOnCreate: ['passwordHash'],
   requireOnCreate: ['password'],
-}) {
-  static fillable = ['name', 'email', 'password']
-}
+  fillable: ['name', 'email', 'password'],
+}) {}
 ```
 
 ## Generated Structure

--- a/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
+++ b/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
@@ -78,23 +78,23 @@ await Post.create({ title: 'Hello' })
 **Mass assignment protection** — prevent injection of unintended fields via `create()` / `update()`:
 
 ```typescript
-export class Post extends defineModel(posts) {
-  // Whitelist: only these fields are accepted (recommended)
-  static fillable = ['title', 'excerpt', 'body', 'authorId']
-}
+export class Post extends defineModel(posts, {
+  // Whitelist: only these fields are accepted (recommended).
+  // Typed against the table's columns — a typo is a compile error.
+  fillable: ['title', 'excerpt', 'body', 'authorId'],
+}) {}
 
 export class User extends defineModel(users, {
   base: AuthenticatableModel,
   // The model hashes a plain `password` into `passwordHash`
   optionalOnCreate: ['passwordHash'],
   requireOnCreate: ['password'],
-}) {
   // Whitelist for mass assignment (credential columns are denied by the base class)
-  static fillable = ['name', 'email', 'password']
-}
+  fillable: ['name', 'email', 'password'],
+}) {}
 ```
 
-- `fillable` (whitelist) — only listed fields pass through to `create()` / `update()`; unlisted input keys **throw `MassAssignmentException`**. The primary key (`id`) is always silently stripped.
+- `fillable` (whitelist) — only listed fields pass through to `create()` / `update()`; unlisted input keys **throw `MassAssignmentException`**. The primary key (`id`) is always silently stripped. `static fillable = [...]` on the class also works (untyped) and shadows the option; `hidden`, `visible`, `accessors`, and `appends` have the same typed option forms.
 - Credential columns (`passwordHash`, `rememberToken`) **always throw** on authenticatable models — the framework denies them; listing them in `fillable` does not open them
 - Enforced by `Model.filterFillable()`, called automatically before persistence
 - Always define `fillable` on models that accept user input — this is the second defense layer after Zod validation

--- a/packages/cli/templates/agent/CLAUDE.md
+++ b/packages/cli/templates/agent/CLAUDE.md
@@ -157,9 +157,9 @@ export class PostController extends Controller {
 }
 
 // app/Models/Post.ts
-export class Post extends defineModel(posts) {
-  static fillable = ['title', 'body', 'authorId']
-}
+export class Post extends defineModel(posts, {
+  fillable: ['title', 'body', 'authorId'],  // typed against the table's columns
+}) {}
 ```
 
 - Models: `await Post.findOrFail(id)` throws a 404; `Post.where(...)` starts a query

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -588,6 +588,33 @@ export default function registerRoutes(router: any) {
     }
   })
 
+  it('detects an authenticatable base through a mixin wrapper', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-mass-mixin-')
+
+    try {
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Models/User.ts'),
+        `import { AuthenticatableModel, defineModel, SoftDeletes } from '@guren/core'
+import { users } from '../../db/schema.js'
+
+export class User extends SoftDeletes(defineModel(users, {
+  base: AuthenticatableModel,
+})) {}`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const user = report.findings.find(f => f.key === 'mass-assignment:User')
+      expect(user).toBeDefined()
+      expect(user!.status).toBe('pass')
+      expect(user!.message).toContain('AuthenticatableModel')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('counts a fillable passed as a defineModel option', async () => {
     const workspace = await createTempWorkspace('guren-cli-audit-mass-option-')
 

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -697,6 +697,90 @@ export class Shadowed extends defineModel(users, {
     }
   })
 
+  it('stays conservative when the runtime-winning declaration is unreadable', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-hidden-unreadable-')
+
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'db/schema.ts'),
+        `import { pgTable, text } from 'drizzle-orm/pg-core'
+export const users = pgTable('users', {
+  id: text('id').primaryKey(),
+  passwordHash: text('password_hash').notNull(),
+})`,
+        'utf8',
+      )
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      // The static shadows the option at runtime but its value cannot be
+      // read — the option's list must NOT be reported as what serializes.
+      await writeFile(
+        join(workspace.dir, 'app/Models/User.ts'),
+        `import { defineModel } from '@guren/core'
+import { users } from '../../db/schema.js'
+import { HIDDEN } from './config.js'
+
+export class User extends defineModel(users, {
+  hidden: ['passwordHash'],
+}) {
+  static override hidden = HIDDEN
+}`,
+        'utf8',
+      )
+      // A spread makes the literal unreadable too — a partial read of
+      // ['passwordHash', ...] would also be wrong in the other direction.
+      await writeFile(
+        join(workspace.dir, 'app/Models/Spread.ts'),
+        `import { defineModel } from '@guren/core'
+import { users } from '../../db/schema.js'
+import { EXTRA } from './config.js'
+
+export class Spread extends defineModel(users, {
+  hidden: ['passwordHash', ...EXTRA],
+}) {}`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const shadowedByUnreadable = report.findings.find(f => f.key === 'hidden-columns:User')
+      expect(shadowedByUnreadable).toBeDefined()
+      expect(shadowedByUnreadable!.status).toBe('warn')
+
+      const spread = report.findings.find(f => f.key === 'hidden-columns:Spread')
+      expect(spread).toBeDefined()
+      expect(spread!.status).toBe('warn')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('does not count `fillable: undefined` as mass-assignment protection', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-mass-undef-')
+
+    try {
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Models/Post.ts'),
+        `import { defineModel } from '@guren/core'
+import { posts } from '../../db/schema.js'
+
+export class Post extends defineModel(posts, {
+  fillable: undefined,
+}) {}`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const post = report.findings.find(f => f.key === 'mass-assignment:Post')
+      expect(post).toBeDefined()
+      expect(post!.status).toBe('warn')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('resolves the table from defineModel, not just from `static table`', async () => {
     // A model that binds its table through defineModel() used to fall out of
     // this check entirely — the table never resolved, so no column was ever

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -588,6 +588,88 @@ export default function registerRoutes(router: any) {
     }
   })
 
+  it('counts a fillable passed as a defineModel option', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-mass-option-')
+
+    try {
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Models/Post.ts'),
+        `import { defineModel } from '@guren/core'
+import { posts } from '../../db/schema.js'
+
+export class Post extends defineModel(posts, {
+  fillable: ['title', 'body'],
+}) {}`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const post = report.findings.find(f => f.key === 'mass-assignment:Post')
+      expect(post).toBeDefined()
+      expect(post!.status).toBe('pass')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('counts hidden passed as a defineModel option, with static shadowing it', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-hidden-option-')
+
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'db/schema.ts'),
+        `import { pgTable, text } from 'drizzle-orm/pg-core'
+export const users = pgTable('users', {
+  id: text('id').primaryKey(),
+  email: text('email').notNull(),
+  passwordHash: text('password_hash').notNull(),
+})`,
+        'utf8',
+      )
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Models/User.ts'),
+        `import { defineModel } from '@guren/core'
+import { users } from '../../db/schema.js'
+
+export class User extends defineModel(users, {
+  hidden: ['passwordHash'],
+}) {}`,
+        'utf8',
+      )
+      // Same option, but a static declaration shadows it — the runtime
+      // serializes with the static list, so the audit must too.
+      await writeFile(
+        join(workspace.dir, 'app/Models/Shadowed.ts'),
+        `import { defineModel } from '@guren/core'
+import { users } from '../../db/schema.js'
+
+export class Shadowed extends defineModel(users, {
+  hidden: ['passwordHash'],
+}) {
+  static override hidden = ['email']
+}`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const viaOption = report.findings.find(f => f.key === 'hidden-columns:User')
+      expect(viaOption).toBeDefined()
+      expect(viaOption!.status).toBe('pass')
+
+      const shadowed = report.findings.find(f => f.key === 'hidden-columns:Shadowed')
+      expect(shadowed).toBeDefined()
+      expect(shadowed!.status).toBe('warn')
+      expect(shadowed!.message).toContain('passwordHash')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('resolves the table from defineModel, not just from `static table`', async () => {
     // A model that binds its table through defineModel() used to fall out of
     // this check entirely — the table never resolved, so no column was ever
@@ -814,7 +896,7 @@ export const invoices = pgTable('invoices', {
       const hidden = report.findings.find(f => f.key === 'hidden-columns:User')
       expect(hidden).toBeDefined()
       expect(hidden!.status).toBe('warn')
-      expect(hidden!.suggestion).toContain('static visible')
+      expect(hidden!.suggestion).toContain('visible allowlist overrides hidden')
     } finally {
       await workspace.cleanup()
     }

--- a/packages/cli/tests/check.test.ts
+++ b/packages/cli/tests/check.test.ts
@@ -886,3 +886,39 @@ export const posts = pgTable('posts', { createdAt: timestamp('created_at') })
     })
   })
 })
+
+describe('mass-assignment config via defineModel options', () => {
+  it('flags a denied credential column listed in the fillable option', async () => {
+    const report = await withWorkspace({
+      'app/Models/User.ts': `import { AuthenticatableModel, defineModel } from '@guren/core'
+import { users } from '../../db/schema.js'
+
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  fillable: ['name', 'email', 'passwordHash'],
+}) {}`,
+    })
+
+    const denied = report.checks.find(c => c.key === 'mass-assignment-denied:User')
+    expect(denied).toBeDefined()
+    expect(denied!.status).toBe('fail')
+    expect(denied!.message).toContain('passwordHash')
+  })
+
+  it('lets a static fillable shadow the option, matching the runtime', async () => {
+    const report = await withWorkspace({
+      'app/Models/User.ts': `import { AuthenticatableModel, defineModel } from '@guren/core'
+import { users } from '../../db/schema.js'
+
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  fillable: ['name', 'passwordHash'],
+}) {
+  static override fillable = ['name', 'email']
+}`,
+    })
+
+    const denied = report.checks.find(c => c.key === 'mass-assignment-denied:User')
+    expect(denied).toBeUndefined()
+  })
+})

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -2542,6 +2542,34 @@ type CreateKey<TTable extends TableShape, TBase extends typeof Model> =
   | keyof InferModelInsert<TTable>
   | keyof TCreateFor<TBase>
 
+/**
+ * Named fields a base class contributes to the create payload, such as
+ * `AuthenticatableModel`'s virtual `password`. A plain `Model` base has no
+ * declared createType, so its keys collapse to `string` — guard against that
+ * collapse, or every misspelling would pass the allowlist checks below.
+ */
+type BaseContributedKey<TBase extends typeof Model> =
+  string extends keyof TCreateFor<TBase> & string ? never : keyof TCreateFor<TBase> & string
+
+/** A key valid in a `fillable` allowlist: an insertable column, or a base-contributed field. */
+type FillableKey<TTable extends TableShape, TBase extends typeof Model> =
+  | (keyof InferModelInsert<TTable> & string)
+  | BaseContributedKey<TBase>
+
+/** A key of the record read back from the table. */
+type RecordKey<TTable extends TableShape> = keyof InferModelRecord<TTable> & string
+
+/**
+ * Accessor map keyed by TKey whose functions receive the table's inferred
+ * record. A homomorphic mapped type so TypeScript infers the key union from
+ * the object literal's keys — a plain `Record<string, fn>` constraint fails
+ * here: the accessor functions are context-sensitive, which defers inference
+ * past the point where the key type parameter falls back to its default.
+ */
+type AccessorsShape<TTable extends TableShape, TKey extends string> = {
+  [K in TKey]: (record: InferModelRecord<TTable>) => unknown
+}
+
 type CreateShape<
   TTable extends TableShape,
   TBase extends typeof Model,
@@ -2562,13 +2590,24 @@ type CreateShape<
  * virtual field required. `optionalOnCreate` and `requireOnCreate` reshape the
  * inferred type without any cast.
  *
+ * The allowlist statics (`fillable`, `hidden`, `visible`, `accessors`,
+ * `appends`) can be passed here instead of declared on the subclass: the
+ * option form checks every name against the table's columns (plus fields the
+ * `base` contributes), so a typo is a compile error instead of a silently
+ * ineffective entry. A `static` declaration on the subclass still works and
+ * shadows the option, matching normal class semantics.
+ *
  * @example
- * export class Post extends defineModel(posts) {}
+ * export class Post extends defineModel(posts, {
+ *   fillable: ['title', 'body'],
+ * }) {}
  *
  * export class User extends defineModel(users, {
  *   base: AuthenticatableModel,
  *   optionalOnCreate: ['passwordHash'],
  *   requireOnCreate: ['password'],
+ *   fillable: ['name', 'email', 'password'],
+ *   hidden: ['passwordHash', 'rememberToken'],
  * }) {}
  */
 export function defineModel<
@@ -2576,6 +2615,7 @@ export function defineModel<
   TBase extends typeof Model = typeof Model,
   const TOptional extends keyof InferModelInsert<TTable> = never,
   const TRequire extends CreateKey<TTable, TBase> = never,
+  TAccessorKey extends string = never,
 >(
   table: TTable,
   options: {
@@ -2592,6 +2632,31 @@ export function defineModel<
      * Type-level only.
      */
     requireOnCreate?: readonly TRequire[]
+    /**
+     * Typed form of `static fillable`: mass-assignment allowlist checked
+     * against insertable columns and base-contributed fields.
+     */
+    fillable?: readonly FillableKey<TTable, TBase>[]
+    /**
+     * Typed form of `static hidden`: fields excluded from serialization,
+     * checked against record columns and declared accessors.
+     */
+    hidden?: readonly (RecordKey<TTable> | NoInfer<TAccessorKey>)[]
+    /**
+     * Typed form of `static visible`: serialization allowlist, checked
+     * against record columns and declared accessors.
+     */
+    visible?: readonly (RecordKey<TTable> | NoInfer<TAccessorKey>)[]
+    /**
+     * Typed form of `static accessors`: each function receives the table's
+     * inferred record. Names declared here are what `appends` may reference.
+     */
+    accessors?: AccessorsShape<TTable, TAccessorKey>
+    /**
+     * Typed form of `static appends`: virtual attributes to serialize,
+     * checked against the names declared in `accessors`.
+     */
+    appends?: readonly NoInfer<TAccessorKey>[]
   } = {},
 ): ModelClassWithTable<TTable, TBase, CreateShape<TTable, TBase, TOptional, TRequire>> {
   type ResolvedCreate = CreateShape<TTable, TBase, TOptional, TRequire>
@@ -2604,6 +2669,12 @@ export function defineModel<
   ;(DefinedModel as typeof Model & { recordType: InferModelRecord<TTable> }).recordType =
     {} as InferModelRecord<TTable>
   ;(DefinedModel as typeof Model & { createType: ResolvedCreate }).createType = {} as ResolvedCreate
+
+  if (options.fillable) DefinedModel.fillable = [...options.fillable]
+  if (options.hidden) DefinedModel.hidden = [...options.hidden]
+  if (options.visible) DefinedModel.visible = [...options.visible]
+  if (options.accessors) DefinedModel.accessors = options.accessors as unknown as AccessorDefinitions
+  if (options.appends) DefinedModel.appends = [...options.appends]
 
   return DefinedModel as ModelClassWithTable<TTable, TBase, ResolvedCreate>
 }

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -2650,8 +2650,11 @@ export function defineModel<
     /**
      * Typed form of `static accessors`: each function receives the table's
      * inferred record. Names declared here are what `appends` may reference.
+     * The Record intersection rejects non-object values — with no keys to
+     * infer, the mapped type alone collapses to `{}`, which admits anything.
      */
-    accessors?: AccessorsShape<TTable, TAccessorKey>
+    accessors?: AccessorsShape<TTable, TAccessorKey> &
+      Record<string, (record: InferModelRecord<TTable>) => unknown>
     /**
      * Typed form of `static appends`: virtual attributes to serialize,
      * checked against the names declared in `accessors`.

--- a/packages/orm/tests/define-model-options.test.ts
+++ b/packages/orm/tests/define-model-options.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'bun:test'
+import { pgTable, serial, text } from 'drizzle-orm/pg-core'
+import { Model, defineModel } from '../src/Model'
+import { MassAssignmentException } from '../src/MassAssignmentException'
+
+const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  name: text('name').notNull(),
+  email: text('email').notNull(),
+  passwordHash: text('password_hash').notNull(),
+})
+
+type UserRecord = typeof users.$inferSelect
+
+const record: UserRecord = {
+  id: 1,
+  name: 'Alice',
+  email: 'alice@test.com',
+  passwordHash: 'secret',
+}
+
+describe('defineModel allowlist options', () => {
+  it('fillable option drives filterFillable exactly like a static declaration', () => {
+    class User extends defineModel(users, { fillable: ['name', 'email'] }) {}
+
+    expect(User.filterFillable({ name: 'Alice' })).toEqual({ name: 'Alice' })
+    expect(() => User.filterFillable({ name: 'Alice', isAdmin: true })).toThrow(
+      MassAssignmentException,
+    )
+  })
+
+  it('a static fillable declaration on the subclass shadows the option', () => {
+    class User extends defineModel(users, { fillable: ['name'] }) {
+      static override fillable = ['email']
+    }
+
+    expect(User.filterFillable({ email: 'a@b.c' })).toEqual({ email: 'a@b.c' })
+    expect(() => User.filterFillable({ name: 'Alice' })).toThrow(MassAssignmentException)
+  })
+
+  it('hidden option is applied by serialize', () => {
+    class User extends defineModel(users, { hidden: ['passwordHash'] }) {}
+
+    expect(User.serialize(record)).toEqual({ id: 1, name: 'Alice', email: 'alice@test.com' })
+  })
+
+  it('visible option is applied by serialize and wins over hidden', () => {
+    class User extends defineModel(users, {
+      visible: ['id', 'name'],
+      hidden: ['passwordHash'],
+    }) {}
+
+    expect(User.serialize(record)).toEqual({ id: 1, name: 'Alice' })
+  })
+
+  it('accessors and appends options serialize virtual attributes', () => {
+    class User extends defineModel(users, {
+      accessors: {
+        displayName: (r) => `${r.name} <${r.email}>`,
+      },
+      appends: ['displayName'],
+      hidden: ['passwordHash'],
+    }) {}
+
+    expect(User.serialize(record)).toEqual({
+      id: 1,
+      name: 'Alice',
+      email: 'alice@test.com',
+      displayName: 'Alice <alice@test.com>',
+    })
+  })
+
+  it('options stay on the defined class and do not leak to Model or siblings', () => {
+    class Configured extends defineModel(users, { fillable: ['name'], hidden: ['passwordHash'] }) {}
+    class Plain extends defineModel(users) {}
+
+    expect(Configured.fillable).toEqual(['name'])
+    expect(Model.fillable).toBeUndefined()
+    expect(Plain.fillable).toBeUndefined()
+    expect(Plain.hidden).toBeUndefined()
+    expect(Plain.serialize(record)).toEqual(record)
+  })
+})

--- a/packages/orm/tests/model.define-options.types.ts
+++ b/packages/orm/tests/model.define-options.types.ts
@@ -102,6 +102,12 @@ export class AppendsTypo extends defineModel(users, {
   appends: ['displayNam'],
 }) {}
 
+export class AccessorsNotObject extends defineModel(users, {
+  // @ts-expect-error accessors must be a map of functions — with no keys to
+  // infer, the mapped type alone would collapse to `{}` and admit anything
+  accessors: () => 1,
+}) {}
+
 export class AppendsWithoutAccessors extends defineModel(users, {
   // @ts-expect-error appends may only reference declared accessors
   appends: ['displayName'],

--- a/packages/orm/tests/model.define-options.types.ts
+++ b/packages/orm/tests/model.define-options.types.ts
@@ -1,0 +1,126 @@
+/**
+ * Type-level tests for defineModel's typed allowlist options
+ * (fillable / hidden / visible / accessors / appends).
+ *
+ * Compiled by `tsc -p tsconfig.typecheck.json`; never executed.
+ */
+import { pgTable, serial, text } from 'drizzle-orm/pg-core'
+import { Model, defineModel, type PlainObject } from '../src/Model'
+
+const posts = pgTable('posts', {
+  id: serial('id').primaryKey(),
+  title: text('title').notNull(),
+  body: text('body').notNull(),
+})
+
+const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  name: text('name').notNull(),
+  email: text('email').notNull(),
+  passwordHash: text('password_hash').notNull(),
+  rememberToken: text('remember_token'),
+})
+
+/**
+ * Stand-in for AuthenticatableModel (which lives in @guren/server and must
+ * not be imported here): a base whose createType contributes virtual fields.
+ */
+abstract class CredentialedModel<TRecord extends PlainObject = PlainObject> extends Model<TRecord> {
+  static override readonly createType: { password?: string } = undefined as unknown as {
+    password?: string
+  }
+}
+
+// --- fillable ---
+
+// Column names are accepted.
+export class FillableOk extends defineModel(posts, {
+  fillable: ['title', 'body'],
+}) {}
+
+export class FillableTypo extends defineModel(posts, {
+  // @ts-expect-error 'bod' is not a column of posts
+  fillable: ['title', 'bod'],
+}) {}
+
+// A base's contributed virtual field is accepted alongside columns.
+export class FillableWithBase extends defineModel(users, {
+  base: CredentialedModel,
+  optionalOnCreate: ['passwordHash'],
+  requireOnCreate: ['password'],
+  fillable: ['name', 'email', 'password'],
+}) {}
+
+export class FillableNoBaseVirtual extends defineModel(posts, {
+  // @ts-expect-error without a base, only columns are fillable — a plain
+  // Model base must not collapse the key type to `string`
+  fillable: ['password'],
+}) {}
+
+// --- hidden / visible ---
+
+export class HiddenOk extends defineModel(users, {
+  hidden: ['passwordHash', 'rememberToken'],
+}) {}
+
+export class HiddenTypo extends defineModel(users, {
+  // @ts-expect-error 'passwordhash' is not a column of users
+  hidden: ['passwordhash'],
+}) {}
+
+export class VisibleOk extends defineModel(users, {
+  visible: ['id', 'name', 'email'],
+}) {}
+
+export class VisibleTypo extends defineModel(users, {
+  // @ts-expect-error 'emial' is not a column of users
+  visible: ['emial'],
+}) {}
+
+// --- accessors / appends ---
+
+// Accessor functions receive the table's inferred record.
+export class AccessorsOk extends defineModel(users, {
+  accessors: {
+    displayName: (record) => `${record.name} <${record.email}>`,
+  },
+  appends: ['displayName'],
+}) {}
+
+export class AccessorsBadField extends defineModel(users, {
+  accessors: {
+    // @ts-expect-error 'nope' is not a field of the users record
+    broken: (record) => record.nope,
+  },
+}) {}
+
+export class AppendsTypo extends defineModel(users, {
+  accessors: {
+    displayName: (record) => record.name,
+  },
+  // @ts-expect-error 'displayNam' is not a declared accessor
+  appends: ['displayNam'],
+}) {}
+
+export class AppendsWithoutAccessors extends defineModel(users, {
+  // @ts-expect-error appends may only reference declared accessors
+  appends: ['displayName'],
+}) {}
+
+// hidden/visible may also name a declared accessor (serialize applies them
+// to appended virtual fields too).
+export class HiddenAccessorKey extends defineModel(users, {
+  accessors: {
+    displayName: (record) => record.name,
+  },
+  appends: ['displayName'],
+  hidden: ['passwordHash', 'displayName'],
+}) {}
+
+// --- legacy static declarations keep compiling (loosely typed) ---
+
+export class LegacyStatic extends defineModel(posts) {
+  static override fillable = ['title', 'not-checked-here']
+  static override hidden = ['whatever']
+  static override appends = ['anything']
+}


### PR DESCRIPTION
## Summary

`fillable`, `hidden`, `visible`, `accessors`, and `appends` can now be passed as `defineModel` options, checked at compile time against the table's columns:

```ts
export class Post extends defineModel(posts, {
  fillable: ['title', 'body'],   // 'bod' would be a compile error, with a "Did you mean" hint
  hidden: ['secretColumn'],
  accessors: { titleUpper: (r) => r.title.toUpperCase() },  // r is the table's record type
  appends: ['titleUpper'],       // only declared accessor names are accepted
}) {}
```

- `fillable` also accepts fields contributed by the `base` (e.g. `AuthenticatableModel`'s virtual `password`); with a plain `Model` base the key type is guarded against collapsing to `string`, so arbitrary names still fail.
- `accessors` uses a homomorphic mapped type to infer the key union — a plain `Record<string, fn>` constraint defers inference past the type parameter's default because the accessor functions are context-sensitive. `appends`/`hidden`/`visible` reference those keys through `NoInfer` so they cannot widen the inference themselves.
- Runtime is assignment-only: options are written onto the defined class, and a `static` declaration on the subclass shadows them (normal class semantics). Existing `static` declarations keep working unchanged — non-breaking, minor release.

## CLI

`guren audit` (mass-assignment and hidden-columns findings) and `guren check` (fillable × denied-columns contradiction) previously only parsed `static` declarations and would misreport option-form models as unprotected. They now resolve both spellings with the runtime's shadowing order via a shared helper in `model-parser.ts`.

## Docs

`docs/{en,ja}/guides/database.md` and the agent harness templates now lead with the option form and note the `static` alternative.

## Verification

- `bun run build`, root `bun run typecheck`, `bun run test:bun orm cli` (1371 pass)
- New type tests (`model.define-options.types.ts`) cover typo rejection per option, base-contributed fields, and legacy static compatibility; runtime tests cover option-driven `MassAssignmentException`, serialization, and static shadowing
- `guren audit` / `guren check` run against `examples/blog` and `web/` with no new findings (false-positive direction); new CLI tests cover the detection direction
- `audit:docs`, `audit:core-first`, `audit:starter-template`, `smoke:starter`, `smoke:starter:api` all green (agent templates under `packages/cli/templates/**` were touched)

Note: `packages/create-app/templates/**` intentionally stays on the `static` form until the release ships, since scaffolded apps install `@guren/orm` from npm.