### PR TITLE
fix(create-app): bound the scaffolder's git calls and isolate the tests

### DIFF
--- a/.changeset/create-app-git-timeout.md
+++ b/.changeset/create-app-git-timeout.md
@@ -1,0 +1,34 @@
+---
+"create-guren-app": patch
+---
+
+`create-guren-app` gives up on a stalled `git` instead of hanging
+
+`--git` shells out to `git init`, `git add -A`, and `git commit` through
+`spawnSync`, with no bound on how long any of them may take. That call blocks
+the process outright, so a `git` that stops making progress leaves the user
+staring at `Initializing git repository...` with the app already written to
+disk — nothing to do but Ctrl-C and guess at what state the repository is in.
+
+The child inherits no terminal, which is what makes this reachable rather than
+theoretical. A commit-signing passphrase prompt, a credential helper, or a
+stalled name lookup while git guesses the committer identity all wait on input
+that can never arrive. It surfaced as CI test timeouts, where one wedged
+`git commit` blocked the runner long enough to take down neighbouring tests too.
+
+Every invocation now runs under a 30-second budget — one budget shared across
+all three steps, so the whole call is bounded, not each subprocess
+independently — and a child that overruns it is killed. The result is the
+warning the scaffolder already printed when git failed outright:
+
+```
+Created a git repository, but the initial commit failed (git identity may be unset).
+Set `git config user.name` and `git config user.email`, then run `git commit -m "chore: initial commit"`.
+```
+
+The children also get `GIT_TERMINAL_PROMPT=0`, so git fails fast rather than
+waiting on a terminal it does not have. Nothing changes for a scaffold where
+git behaves: the budget is far above what `git init`/`add`/`commit` take on a
+fresh app, and the repository is still created with the user's own
+`init.defaultBranch`, identity, and signing configuration rather than
+overrides forced by the scaffolder.

--- a/.changeset/create-app-git-timeout.md
+++ b/.changeset/create-app-git-timeout.md
@@ -27,8 +27,22 @@ Set `git config user.name` and `git config user.email`, then run `git commit -m 
 ```
 
 The children also get `GIT_TERMINAL_PROMPT=0`, so git fails fast rather than
-waiting on a terminal it does not have. Nothing changes for a scaffold where
-git behaves: the budget is far above what `git init`/`add`/`commit` take on a
-fresh app, and the repository is still created with the user's own
-`init.defaultBranch`, identity, and signing configuration rather than
-overrides forced by the scaffolder.
+waiting on a terminal it does not have. The probe that decides whether the
+target already sits inside a repository answers "yes" when it has to be killed:
+the scaffolder uses that answer to *decline* `git init`, and declining on an
+unreadable answer beats nesting a repository inside the user's checkout. A
+missing git still answers "no", so a machine without git stays on the
+"initialize the repository manually" path rather than silently skipping the
+step.
+
+The bound is deliberately tied to how these particular children run rather than
+applied to every subprocess the scaffolder starts. `bun install` and the app's
+own CLI inherit the terminal — they can answer a prompt, they show progress,
+and a long one is visibly working, so a deadline there would kill a slow but
+healthy install. Only the git calls run silently with no terminal, where
+"stalled" and "working" look identical from the user's seat.
+
+Nothing changes for a scaffold where git behaves: the budget is far above what
+`git init`/`add`/`commit` take on a fresh app, and the repository is still
+created with the user's own `init.defaultBranch`, identity, and signing
+configuration rather than overrides forced by the scaffolder.

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -111,6 +111,15 @@ export async function writeWorkspaceFiles(
   }
 }
 
+/**
+ * Known hazard, deliberately left in place: the `process.chdir()` below is
+ * global state in Bun's shared test process, so a test that overruns can
+ * chdir and `rm -rf` out from under whichever test started meanwhile. See
+ * packages/create-app/tests/helpers.ts, where the same helper dropped it.
+ * Untangling it here is a real refactor rather than a test-side edit — most
+ * of this package's commands resolve paths against `process.cwd()`, and
+ * several test files chdir directly instead of going through this helper.
+ */
 export async function createTempWorkspace(prefix: string): Promise<TempWorkspace> {
   const dir = await mkdtemp(join(tmpdir(), prefix))
   const originalCwd = process.cwd()

--- a/packages/create-app/CLAUDE.md
+++ b/packages/create-app/CLAUDE.md
@@ -7,6 +7,9 @@ Scaffolding CLI that copies templates from `templates/default` and replaces toke
 - `src/cli.ts`: Citty command definition
 - `src/blueprints.ts`: blueprint registry, template layering, database-variant files
 - `src/utils.ts`: filesystem helpers (`directoryExists`, `isDirectoryEmpty`, etc.)
+- `src/git.ts`: the `--git` subprocess calls. Every invocation is bounded — the
+  child has no terminal, so a git that decides to prompt would otherwise block
+  `spawnSync` forever with the app already on disk.
 - `templates/default`: Bun project template; token map lives in `cli.ts`
 - `templates/blog`: curated blog starter, overlaid on `templates/default`
 

--- a/packages/create-app/CLAUDE.md
+++ b/packages/create-app/CLAUDE.md
@@ -7,9 +7,7 @@ Scaffolding CLI that copies templates from `templates/default` and replaces toke
 - `src/cli.ts`: Citty command definition
 - `src/blueprints.ts`: blueprint registry, template layering, database-variant files
 - `src/utils.ts`: filesystem helpers (`directoryExists`, `isDirectoryEmpty`, etc.)
-- `src/git.ts`: the `--git` subprocess calls. Every invocation is bounded — the
-  child has no terminal, so a git that decides to prompt would otherwise block
-  `spawnSync` forever with the app already on disk.
+- `src/git.ts`: the `--git` subprocess calls, each bounded by a timeout
 - `templates/default`: Bun project template; token map lives in `cli.ts`
 - `templates/blog`: curated blog starter, overlaid on `templates/default`
 

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -5,6 +5,7 @@ import { consola } from 'consola'
 import { defineCommand, runMain } from 'citty'
 import { DATABASE_DRIVERS, getAppBlueprint, listAppBlueprints, scaffoldAppBlueprint, usesDatabaseContainer, type DatabaseDriver, type RenderingMode } from './blueprints'
 import { directoryExists, isDirectoryEmpty } from './utils'
+import { initGitRepository, isInsideGitWorkTree } from './git'
 
 const RENDERING_MODES = ['spa', 'ssr'] as const
 const RENDERING_MODE_SET = new Set<RenderingMode>(RENDERING_MODES)
@@ -134,7 +135,7 @@ async function resolveGitInit(flagValue: unknown, target: { dir: string; wasEmpt
 
   // A nested repository inside an existing checkout is never what the user
   // wanted, so this wins even over an explicit --git.
-  if (await isInsideGitWorkTree(target.dir)) {
+  if (isInsideGitWorkTree(target.dir)) {
     return declined('the target directory is already inside a git repository.')
   }
 
@@ -150,39 +151,23 @@ async function resolveGitInit(flagValue: unknown, target: { dir: string; wasEmpt
   return result === true
 }
 
-async function isInsideGitWorkTree(cwd: string): Promise<boolean> {
-  const { spawnSync } = await import('node:child_process')
-  const result = spawnSync('git', ['rev-parse', '--is-inside-work-tree'], { cwd, stdio: 'pipe', env: process.env })
-  // `status === 0` first: a missing git binary leaves stdout null, and the
-  // short-circuit is what keeps this a graceful "not a repo" rather than a throw.
-  return result.status === 0 && result.stdout.toString().trim() === 'true'
-}
-
-async function initGitRepository(cwd: string): Promise<void> {
-  const { spawnSync } = await import('node:child_process')
-  // Plain `git init` so the user's own init.defaultBranch decides the branch name.
-  // `env` is passed explicitly (not omitted) so a caller that sets
-  // GIT_AUTHOR_*/GIT_COMMITTER_* on process.env just before this runs — the
-  // test suite does, to give the commit an identity in CI — is guaranteed to
-  // reach the child process.
-  const run = (args: string[]) => spawnSync('git', args, { cwd, stdio: 'pipe', env: process.env })
-
+function reportGitInit(cwd: string): void {
   consola.start('Initializing git repository...')
 
-  for (const args of [['init'], ['add', '-A']]) {
-    if (run(args).status !== 0) {
-      consola.warn(`Failed to run \`git ${args.join(' ')}\`. Initialize the repository manually.`)
-      return
-    }
+  const result = initGitRepository(cwd)
+  if (result.ok) {
+    consola.success('Initialized a git repository with an initial commit')
+    return
   }
 
-  if (run(['commit', '-m', 'chore: initial commit']).status !== 0) {
+  if (result.failedStep === 'commit') {
     consola.warn('Created a git repository, but the initial commit failed (git identity may be unset).')
     consola.warn('Set `git config user.name` and `git config user.email`, then run `git commit -m "chore: initial commit"`.')
     return
   }
 
-  consola.success('Initialized a git repository with an initial commit')
+  const args = result.failedStep === 'init' ? 'init' : 'add -A'
+  consola.warn(`Failed to run \`git ${args}\`. Initialize the repository manually.`)
 }
 
 async function installDependencies(cwd: string): Promise<boolean> {
@@ -319,7 +304,7 @@ const command = defineCommand({
 
     // Last, so the harness and auth scaffolding land in the initial commit.
     if (shouldInitGit) {
-      await initGitRepository(targetDir)
+      reportGitInit(targetDir)
     }
 
     const relativeTarget = relative(process.cwd(), targetDir) || '.'

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -166,8 +166,7 @@ function reportGitInit(cwd: string): void {
     return
   }
 
-  const args = result.failedStep === 'init' ? 'init' : 'add -A'
-  consola.warn(`Failed to run \`git ${args}\`. Initialize the repository manually.`)
+  consola.warn(`Failed to run \`${result.command}\`. Initialize the repository manually.`)
 }
 
 async function installDependencies(cwd: string): Promise<boolean> {

--- a/packages/create-app/src/git.ts
+++ b/packages/create-app/src/git.ts
@@ -1,57 +1,69 @@
-import { spawnSync } from 'node:child_process'
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
 
 /**
  * How long the scaffolder waits on `git` before giving up.
  *
- * The child gets no terminal, so anything that decides to prompt — a signing
- * passphrase, a credential helper, a stalled name lookup while git guesses the
- * committer identity — would block forever with the app already written to
- * disk. Bounding it turns that into the caller's manual-recovery warning.
- * Generous enough that an ordinary commit on a loaded machine never trips it.
+ * The bound is tied to how these children are run, not applied to every child
+ * the scaffolder spawns. `bun install` and the app's own CLI inherit the
+ * terminal: they can answer a prompt, they show progress, and a long one is
+ * visibly working. These run with `stdio: 'pipe'` and no terminal, where a
+ * signing passphrase prompt, a credential helper, or a stalled name lookup
+ * while git guesses the committer identity waits on input that can never
+ * arrive — silently, with the app already written to disk. Generous enough
+ * that an ordinary commit on a loaded machine never trips it.
  */
 export const GIT_TIMEOUT_MS = 30_000
 
 export interface GitCommandOptions {
-  /** Budget for the whole call, not per subprocess; only overridden by tests. */
+  /**
+   * Budget for the whole call rather than for each subprocess. Exists so the
+   * deadline can be exercised without waiting out the full budget.
+   */
   timeoutMs?: number
 }
 
-/** Which step failed, so the caller can explain what to finish by hand. */
-export type GitInitFailure = 'init' | 'add' | 'commit'
+type GitStep = 'init' | 'add' | 'commit'
 
-export type GitInitResult = { ok: true } | { ok: false; failedStep: GitInitFailure }
+export type GitInitResult =
+  | { ok: true }
+  /** `command` so the caller can name the step without restating its arguments. */
+  | { ok: false; failedStep: GitStep; command: string }
 
-function runGit(cwd: string, args: string[], timeoutMs: number): boolean {
-  const result = spawnSync('git', args, {
+function runGit(cwd: string, args: string[], timeoutMs = GIT_TIMEOUT_MS): SpawnSyncReturns<Buffer> {
+  return spawnSync('git', args, {
     cwd,
     stdio: 'pipe',
-    // `env` is passed explicitly (not omitted) so a caller that sets
-    // GIT_AUTHOR_*/GIT_COMMITTER_* on process.env just before this runs is
-    // guaranteed to reach the child process. GIT_TERMINAL_PROMPT keeps git
-    // from waiting on a terminal this child does not have.
+    // Read at call time rather than hoisted: a caller that sets
+    // GIT_AUTHOR_*/GIT_COMMITTER_* just before this runs has to reach the
+    // child. GIT_TERMINAL_PROMPT keeps git from waiting on a terminal it does
+    // not have.
     env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
-    // Never zero or negative: spawnSync treats that as "no timeout".
+    // spawnSync reads a non-positive timeout as "no timeout".
     timeout: Math.max(1, timeoutMs),
     // SIGTERM leaves a git blocked in a syscall alive, and spawnSync would go
     // on blocking with it.
     killSignal: 'SIGKILL',
   })
+}
 
-  // A timed-out child reports `status: null`, so this covers both a git that
-  // failed and a git that had to be killed.
-  return result.status === 0
+function wasKilledByTimeout(result: SpawnSyncReturns<Buffer>): boolean {
+  return (result.error as NodeJS.ErrnoException | undefined)?.code === 'ETIMEDOUT'
 }
 
 export function isInsideGitWorkTree(cwd: string, options: GitCommandOptions = {}): boolean {
-  const result = spawnSync('git', ['rev-parse', '--is-inside-work-tree'], {
-    cwd,
-    stdio: 'pipe',
-    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
-    timeout: Math.max(1, options.timeoutMs ?? GIT_TIMEOUT_MS),
-    killSignal: 'SIGKILL',
-  })
+  const result = runGit(cwd, ['rev-parse', '--is-inside-work-tree'], options.timeoutMs)
+
+  // A probe that had to be killed answers "yes". The caller uses this to
+  // *decline* `git init`, so an unreadable answer should decline too — the
+  // alternative is nesting a repository inside the user's checkout, which is
+  // the outcome the caller calls never what they wanted.
+  if (wasKilledByTimeout(result)) {
+    return true
+  }
+
   // `status === 0` first: a missing git binary leaves stdout null, and the
-  // short-circuit is what keeps this a graceful "not a repo" rather than a throw.
+  // short-circuit is what keeps that a graceful "not a repo" rather than a
+  // throw — `git init` then fails with its own warning.
   return result.status === 0 && result.stdout.toString().trim() === 'true'
 }
 
@@ -61,18 +73,20 @@ export function initGitRepository(cwd: string, options: GitCommandOptions = {}):
   // times the wait it thinks it agreed to.
   const deadline = Date.now() + (options.timeoutMs ?? GIT_TIMEOUT_MS)
 
-  // Plain `git init` so the user's own init.defaultBranch decides the branch name.
-  const steps: Array<{ step: GitInitFailure; args: string[] }> = [
-    { step: 'init', args: ['init'] },
-    { step: 'add', args: ['add', '-A'] },
-    { step: 'commit', args: ['commit', '-m', 'chore: initial commit'] },
-  ]
-
-  for (const { step, args } of steps) {
-    if (!runGit(cwd, args, deadline - Date.now())) {
-      return { ok: false, failedStep: step }
-    }
+  const run = (failedStep: GitStep, args: string[]): GitInitResult => {
+    const remaining = deadline - Date.now()
+    // Spending an exhausted budget on one more child would leave the call
+    // unbounded in exactly the case the bound exists for.
+    const ok = remaining > 0 && runGit(cwd, args, remaining).status === 0
+    return ok ? { ok: true } : { ok: false, failedStep, command: `git ${args.join(' ')}` }
   }
 
-  return { ok: true }
+  // Plain `git init` so the user's own init.defaultBranch decides the branch name.
+  const init = run('init', ['init'])
+  if (!init.ok) return init
+
+  const add = run('add', ['add', '-A'])
+  if (!add.ok) return add
+
+  return run('commit', ['commit', '-m', 'chore: initial commit'])
 }

--- a/packages/create-app/src/git.ts
+++ b/packages/create-app/src/git.ts
@@ -1,0 +1,78 @@
+import { spawnSync } from 'node:child_process'
+
+/**
+ * How long the scaffolder waits on `git` before giving up.
+ *
+ * The child gets no terminal, so anything that decides to prompt — a signing
+ * passphrase, a credential helper, a stalled name lookup while git guesses the
+ * committer identity — would block forever with the app already written to
+ * disk. Bounding it turns that into the caller's manual-recovery warning.
+ * Generous enough that an ordinary commit on a loaded machine never trips it.
+ */
+export const GIT_TIMEOUT_MS = 30_000
+
+export interface GitCommandOptions {
+  /** Budget for the whole call, not per subprocess; only overridden by tests. */
+  timeoutMs?: number
+}
+
+/** Which step failed, so the caller can explain what to finish by hand. */
+export type GitInitFailure = 'init' | 'add' | 'commit'
+
+export type GitInitResult = { ok: true } | { ok: false; failedStep: GitInitFailure }
+
+function runGit(cwd: string, args: string[], timeoutMs: number): boolean {
+  const result = spawnSync('git', args, {
+    cwd,
+    stdio: 'pipe',
+    // `env` is passed explicitly (not omitted) so a caller that sets
+    // GIT_AUTHOR_*/GIT_COMMITTER_* on process.env just before this runs is
+    // guaranteed to reach the child process. GIT_TERMINAL_PROMPT keeps git
+    // from waiting on a terminal this child does not have.
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    // Never zero or negative: spawnSync treats that as "no timeout".
+    timeout: Math.max(1, timeoutMs),
+    // SIGTERM leaves a git blocked in a syscall alive, and spawnSync would go
+    // on blocking with it.
+    killSignal: 'SIGKILL',
+  })
+
+  // A timed-out child reports `status: null`, so this covers both a git that
+  // failed and a git that had to be killed.
+  return result.status === 0
+}
+
+export function isInsideGitWorkTree(cwd: string, options: GitCommandOptions = {}): boolean {
+  const result = spawnSync('git', ['rev-parse', '--is-inside-work-tree'], {
+    cwd,
+    stdio: 'pipe',
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    timeout: Math.max(1, options.timeoutMs ?? GIT_TIMEOUT_MS),
+    killSignal: 'SIGKILL',
+  })
+  // `status === 0` first: a missing git binary leaves stdout null, and the
+  // short-circuit is what keeps this a graceful "not a repo" rather than a throw.
+  return result.status === 0 && result.stdout.toString().trim() === 'true'
+}
+
+export function initGitRepository(cwd: string, options: GitCommandOptions = {}): GitInitResult {
+  // One deadline across all three steps rather than one budget each: the caller
+  // needs a bound on the whole call, and three independent budgets is three
+  // times the wait it thinks it agreed to.
+  const deadline = Date.now() + (options.timeoutMs ?? GIT_TIMEOUT_MS)
+
+  // Plain `git init` so the user's own init.defaultBranch decides the branch name.
+  const steps: Array<{ step: GitInitFailure; args: string[] }> = [
+    { step: 'init', args: ['init'] },
+    { step: 'add', args: ['add', '-A'] },
+    { step: 'commit', args: ['commit', '-m', 'chore: initial commit'] },
+  ]
+
+  for (const { step, args } of steps) {
+    if (!runGit(cwd, args, deadline - Date.now())) {
+      return { ok: false, failedStep: step }
+    }
+  }
+
+  return { ok: true }
+}

--- a/packages/create-app/tests/cli.test.ts
+++ b/packages/create-app/tests/cli.test.ts
@@ -1,9 +1,10 @@
-import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test'
+import { describe, expect, it, mock } from 'bun:test'
 import { readFile, access, mkdir, writeFile } from 'node:fs/promises'
 import { spawnSync } from 'node:child_process'
 import { join } from 'node:path'
 import { DATABASE_DRIVERS } from '../src/blueprints'
-import { createTempWorkspace } from './helpers'
+import { GIT_TIMEOUT_MS } from '../src/git'
+import { createTempWorkspace, useGitIdentity } from './helpers'
 
 let capturedCommand: any
 const successMock = mock(() => {})
@@ -47,41 +48,16 @@ await mock.module('consola', () => ({
 
 await import('../src/cli')
 
-// `git commit` needs an identity, and CI runners don't configure one globally
-// the way most developer machines do. initGitRepository() intentionally leaves
-// that to the user's own `git config`, so supply one here — file-wide rather
-// than around a single test, because a per-test restore in a `finally` runs
-// late when that test overruns, leaving the variables set for whatever ran in
-// the meantime.
-const GIT_IDENTITY = {
-  GIT_AUTHOR_NAME: 'Guren Test',
-  GIT_AUTHOR_EMAIL: 'guren-test@example.com',
-  GIT_COMMITTER_NAME: 'Guren Test',
-  GIT_COMMITTER_EMAIL: 'guren-test@example.com',
-} as const
+useGitIdentity()
 
-const previousGitIdentity = Object.fromEntries(
-  Object.keys(GIT_IDENTITY).map((key) => [key, process.env[key]]),
-)
-
-// Must stay above GIT_TIMEOUT_MS, the scaffolder's budget for the whole git
-// sequence: a wedged `git` then surfaces as its "initialize the repository
-// manually" warning — an assertion failure naming the real problem — instead of
-// a bare timeout, whose leftover blocking time Bun charges to the *next* test.
-const GIT_TEST_TIMEOUT_MS = 60_000
+// Derived, not a second literal: staying above the scaffolder's own budget for
+// the whole git sequence is what makes a wedged `git` surface as its
+// "initialize the repository manually" warning — an assertion failure naming
+// the real problem — instead of a bare timeout, whose leftover blocking time
+// Bun charges to the *next* test.
+const GIT_TEST_TIMEOUT_MS = GIT_TIMEOUT_MS * 2
 
 describe('create-guren-app CLI', () => {
-  beforeAll(() => {
-    Object.assign(process.env, GIT_IDENTITY)
-  })
-
-  afterAll(() => {
-    for (const [key, value] of Object.entries(previousGitIdentity)) {
-      if (value === undefined) delete process.env[key]
-      else process.env[key] = value
-    }
-  })
-
   it('scaffolds a SPA project and replaces tokens', async () => {
     const workspace = await createTempWorkspace('guren-create-app-cli-')
     try {
@@ -420,9 +396,6 @@ describe('create-guren-app CLI', () => {
     } finally {
       await workspace.cleanup()
     }
-    // Five `git` subprocesses on a contended runner have no business fitting in
-    // the 5s default: overrunning it charged the leftover blocking time to the
-    // *next* test, which then timed out too.
   }, GIT_TEST_TIMEOUT_MS)
 
   it('does not commit pre-existing files when --force scaffolds into a used directory', async () => {

--- a/packages/create-app/tests/cli.test.ts
+++ b/packages/create-app/tests/cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock } from 'bun:test'
+import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test'
 import { readFile, access, mkdir, writeFile } from 'node:fs/promises'
 import { spawnSync } from 'node:child_process'
 import { join } from 'node:path'
@@ -47,14 +47,48 @@ await mock.module('consola', () => ({
 
 await import('../src/cli')
 
+// `git commit` needs an identity, and CI runners don't configure one globally
+// the way most developer machines do. initGitRepository() intentionally leaves
+// that to the user's own `git config`, so supply one here — file-wide rather
+// than around a single test, because a per-test restore in a `finally` runs
+// late when that test overruns, leaving the variables set for whatever ran in
+// the meantime.
+const GIT_IDENTITY = {
+  GIT_AUTHOR_NAME: 'Guren Test',
+  GIT_AUTHOR_EMAIL: 'guren-test@example.com',
+  GIT_COMMITTER_NAME: 'Guren Test',
+  GIT_COMMITTER_EMAIL: 'guren-test@example.com',
+} as const
+
+const previousGitIdentity = Object.fromEntries(
+  Object.keys(GIT_IDENTITY).map((key) => [key, process.env[key]]),
+)
+
+// Must stay above GIT_TIMEOUT_MS, the scaffolder's budget for the whole git
+// sequence: a wedged `git` then surfaces as its "initialize the repository
+// manually" warning — an assertion failure naming the real problem — instead of
+// a bare timeout, whose leftover blocking time Bun charges to the *next* test.
+const GIT_TEST_TIMEOUT_MS = 60_000
+
 describe('create-guren-app CLI', () => {
+  beforeAll(() => {
+    Object.assign(process.env, GIT_IDENTITY)
+  })
+
+  afterAll(() => {
+    for (const [key, value] of Object.entries(previousGitIdentity)) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  })
+
   it('scaffolds a SPA project and replaces tokens', async () => {
     const workspace = await createTempWorkspace('guren-create-app-cli-')
     try {
       warnMock.mockClear()
       await capturedCommand.run({
         args: {
-          target: 'my-app',
+          target: join(workspace.dir, 'my-app'),
           force: false,
           mode: 'spa',
           auth: false,
@@ -104,7 +138,7 @@ describe('create-guren-app CLI', () => {
       logMock.mockClear()
       await capturedCommand.run({
         args: {
-          target: 'ssr-app',
+          target: join(workspace.dir, 'ssr-app'),
           force: false,
           mode: 'ssr',
           auth: false,
@@ -133,7 +167,7 @@ describe('create-guren-app CLI', () => {
     try {
       await capturedCommand.run({
         args: {
-          target: 'blog-app',
+          target: join(workspace.dir, 'blog-app'),
           force: false,
           mode: 'ssr',
           auth: false,
@@ -170,7 +204,7 @@ describe('create-guren-app CLI', () => {
     try {
       await capturedCommand.run({
         args: {
-          target: 'pg-blog',
+          target: join(workspace.dir, 'pg-blog'),
           force: false,
           mode: 'spa',
           auth: false,
@@ -202,7 +236,7 @@ describe('create-guren-app CLI', () => {
       infoMock.mockClear()
       await capturedCommand.run({
         args: {
-          target: 'auth-blog',
+          target: join(workspace.dir, 'auth-blog'),
           force: false,
           mode: 'spa',
           auth: true,
@@ -226,7 +260,7 @@ describe('create-guren-app CLI', () => {
       await expect(
         capturedCommand.run({
           args: {
-            target: 'bad-app',
+            target: join(workspace.dir, 'bad-app'),
             force: false,
             mode: 'invalid',
             auth: false,
@@ -244,7 +278,7 @@ describe('create-guren-app CLI', () => {
       await expect(
         capturedCommand.run({
           args: {
-            target: 'bad-app',
+            target: join(workspace.dir, 'bad-app'),
             force: false,
             mode: 'spa',
             auth: false,
@@ -262,7 +296,7 @@ describe('create-guren-app CLI', () => {
     try {
       await capturedCommand.run({
         args: {
-          target: 'pg-app',
+          target: join(workspace.dir, 'pg-app'),
           force: false,
           mode: 'spa',
           auth: false,
@@ -298,7 +332,7 @@ describe('create-guren-app CLI', () => {
     try {
       await capturedCommand.run({
         args: {
-          target: 'ignored-app',
+          target: join(workspace.dir, 'ignored-app'),
           force: false,
           mode: 'spa',
           auth: false,
@@ -334,7 +368,7 @@ describe('create-guren-app CLI', () => {
     try {
       await capturedCommand.run({
         args: {
-          target: 'ssr-ignored',
+          target: join(workspace.dir, 'ssr-ignored'),
           force: false,
           mode: 'ssr',
           auth: false,
@@ -353,21 +387,10 @@ describe('create-guren-app CLI', () => {
 
   it('initializes a git repository without committing the generated .env', async () => {
     const workspace = await createTempWorkspace('guren-create-app-cli-git-')
-    // `git commit` needs an identity, and CI runners don't configure one
-    // globally (unlike most developer machines, which is why this only
-    // surfaced in CI). initGitRepository() intentionally leaves that to the
-    // user's own `git config` — scope it here instead so the test observes
-    // the commit succeeding rather than the graceful "identity unset" warning.
-    const gitEnvKeys = ['GIT_AUTHOR_NAME', 'GIT_AUTHOR_EMAIL', 'GIT_COMMITTER_NAME', 'GIT_COMMITTER_EMAIL'] as const
-    const previousGitEnv = Object.fromEntries(gitEnvKeys.map((key) => [key, process.env[key]]))
-    process.env.GIT_AUTHOR_NAME = 'Guren Test'
-    process.env.GIT_AUTHOR_EMAIL = 'guren-test@example.com'
-    process.env.GIT_COMMITTER_NAME = 'Guren Test'
-    process.env.GIT_COMMITTER_EMAIL = 'guren-test@example.com'
     try {
       await capturedCommand.run({
         args: {
-          target: 'git-app',
+          target: join(workspace.dir, 'git-app'),
           force: false,
           mode: 'spa',
           auth: false,
@@ -395,16 +418,12 @@ describe('create-guren-app CLI', () => {
       expect(files).toContain('.gitignore')
       expect(files).toContain('package.json')
     } finally {
-      for (const key of gitEnvKeys) {
-        if (previousGitEnv[key] === undefined) {
-          delete process.env[key]
-        } else {
-          process.env[key] = previousGitEnv[key]
-        }
-      }
       await workspace.cleanup()
     }
-  })
+    // Five `git` subprocesses on a contended runner have no business fitting in
+    // the 5s default: overrunning it charged the leftover blocking time to the
+    // *next* test, which then timed out too.
+  }, GIT_TEST_TIMEOUT_MS)
 
   it('does not commit pre-existing files when --force scaffolds into a used directory', async () => {
     const workspace = await createTempWorkspace('guren-create-app-cli-git-force-')
@@ -416,7 +435,7 @@ describe('create-guren-app CLI', () => {
 
       await capturedCommand.run({
         args: {
-          target: 'used-app',
+          target: join(workspace.dir, 'used-app'),
           force: true,
           mode: 'spa',
           auth: false,
@@ -445,7 +464,7 @@ describe('create-guren-app CLI', () => {
 
       await capturedCommand.run({
         args: {
-          target: 'forced-app',
+          target: join(workspace.dir, 'forced-app'),
           force: true,
           mode: 'spa',
           auth: false,
@@ -471,7 +490,7 @@ describe('create-guren-app CLI', () => {
 
       await capturedCommand.run({
         args: {
-          target: 'nested-app',
+          target: join(workspace.dir, 'nested-app'),
           force: false,
           mode: 'spa',
           auth: false,
@@ -486,14 +505,14 @@ describe('create-guren-app CLI', () => {
     } finally {
       await workspace.cleanup()
     }
-  })
+  }, GIT_TEST_TIMEOUT_MS)
 
   it('leaves SQLite projects without container scripts or driver packages', async () => {
     const workspace = await createTempWorkspace('guren-create-app-cli-sqlite-db-')
     try {
       await capturedCommand.run({
         args: {
-          target: 'lite-app',
+          target: join(workspace.dir, 'lite-app'),
           force: false,
           mode: 'spa',
           auth: false,

--- a/packages/create-app/tests/git.test.ts
+++ b/packages/create-app/tests/git.test.ts
@@ -1,0 +1,97 @@
+import { chmod, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'bun:test'
+import { GIT_TIMEOUT_MS, initGitRepository, isInsideGitWorkTree } from '../src/git'
+import { createTempWorkspace } from './helpers'
+
+const originalPath = process.env.PATH ?? ''
+
+/**
+ * Put a `git` on PATH that never returns for the given subcommand.
+ *
+ * The scaffolder shells out to whatever `git` the user has, and the failure
+ * this guards against — a git that blocks instead of exiting — cannot be
+ * provoked from a real one on demand.
+ */
+async function stallingGitOnPath(dir: string, subcommand: string): Promise<void> {
+  const shim = join(dir, 'git')
+  await writeFile(
+    shim,
+    [
+      '#!/bin/sh',
+      'for arg in "$@"; do',
+      `  if [ "$arg" = "${subcommand}" ]; then`,
+      // Outlives any timeout under test, and survives SIGTERM the way a
+      // process blocked in a syscall would.
+      "    trap '' TERM INT",
+      '    sleep 60',
+      '  fi',
+      'done',
+      'exit 0',
+    ].join('\n'),
+    'utf8',
+  )
+  await chmod(shim, 0o755)
+  process.env.PATH = `${dir}:${originalPath}`
+}
+
+describe('git helpers', () => {
+  afterEach(() => {
+    process.env.PATH = originalPath
+  })
+
+  it('gives up on a git that never exits instead of hanging the scaffolder', async () => {
+    const workspace = await createTempWorkspace('guren-create-app-git-stall-')
+    try {
+      await stallingGitOnPath(workspace.dir, 'commit')
+
+      const started = Date.now()
+      // The budget covers all three steps, so leave the preceding `init`/`add`
+      // room to clear — including the one-off cost Bun's first timed spawn pays.
+      const result = initGitRepository(workspace.dir, { timeoutMs: 4_000 })
+      const elapsed = Date.now() - started
+
+      expect(result).toEqual({ ok: false, failedStep: 'commit' })
+      // Without the timeout this call never returns; the bound is what the
+      // caller's "initialize the repository manually" warning depends on.
+      expect(elapsed).toBeLessThan(20_000)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reports "not a work tree" rather than hanging when git stalls', async () => {
+    const workspace = await createTempWorkspace('guren-create-app-git-stall-rev-parse-')
+    try {
+      await stallingGitOnPath(workspace.dir, 'rev-parse')
+
+      expect(isInsideGitWorkTree(workspace.dir, { timeoutMs: 500 })).toBe(false)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reports the step that failed', async () => {
+    const workspace = await createTempWorkspace('guren-create-app-git-missing-')
+    try {
+      // An empty PATH entry leaves no `git` to find at all.
+      process.env.PATH = workspace.dir
+
+      expect(initGitRepository(workspace.dir)).toEqual({ ok: false, failedStep: 'init' })
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('commits a real repository through the default budget', async () => {
+    const workspace = await createTempWorkspace('guren-create-app-git-real-')
+    try {
+      await writeFile(join(workspace.dir, 'file.txt'), 'contents\n', 'utf8')
+
+      expect(GIT_TIMEOUT_MS).toBeGreaterThan(0)
+      expect(initGitRepository(workspace.dir)).toEqual({ ok: true })
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})

--- a/packages/create-app/tests/git.test.ts
+++ b/packages/create-app/tests/git.test.ts
@@ -1,8 +1,11 @@
 import { chmod, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
 import { afterEach, describe, expect, it } from 'bun:test'
-import { GIT_TIMEOUT_MS, initGitRepository, isInsideGitWorkTree } from '../src/git'
-import { createTempWorkspace } from './helpers'
+import { initGitRepository, isInsideGitWorkTree } from '../src/git'
+import { createTempWorkspace, useGitIdentity } from './helpers'
+
+useGitIdentity()
 
 const originalPath = process.env.PATH ?? ''
 
@@ -15,23 +18,15 @@ const originalPath = process.env.PATH ?? ''
  */
 async function stallingGitOnPath(dir: string, subcommand: string): Promise<void> {
   const shim = join(dir, 'git')
-  await writeFile(
-    shim,
-    [
-      '#!/bin/sh',
-      'for arg in "$@"; do',
-      `  if [ "$arg" = "${subcommand}" ]; then`,
-      // Outlives any timeout under test, and survives SIGTERM the way a
-      // process blocked in a syscall would.
-      "    trap '' TERM INT",
-      '    sleep 60',
-      '  fi',
-      'done',
-      'exit 0',
-    ].join('\n'),
-    'utf8',
-  )
+  // `trap` makes it survive SIGTERM the way a process blocked in a syscall
+  // would; the sleep outlives any budget under test.
+  const script = `#!/bin/sh\n[ "$1" = "${subcommand}" ] && { trap '' TERM INT; sleep 60; }\nexit 0\n`
+  await writeFile(shim, script, 'utf8')
   await chmod(shim, 0o755)
+  // The first exec of a freshly written file costs a few hundred milliseconds;
+  // spending it here keeps it out of the budgets the tests hand the scaffolder,
+  // which would otherwise have to be padded past it.
+  spawnSync(shim, ['--warm'], { stdio: 'pipe' })
   process.env.PATH = `${dir}:${originalPath}`
 }
 
@@ -45,39 +40,39 @@ describe('git helpers', () => {
     try {
       await stallingGitOnPath(workspace.dir, 'commit')
 
-      const started = Date.now()
-      // The budget covers all three steps, so leave the preceding `init`/`add`
-      // room to clear — including the one-off cost Bun's first timed spawn pays.
-      const result = initGitRepository(workspace.dir, { timeoutMs: 4_000 })
-      const elapsed = Date.now() - started
-
-      expect(result).toEqual({ ok: false, failedStep: 'commit' })
-      // Without the timeout this call never returns; the bound is what the
-      // caller's "initialize the repository manually" warning depends on.
-      expect(elapsed).toBeLessThan(20_000)
+      // Without the budget this call never returns, and the caller's
+      // "initialize the repository manually" warning is never reached.
+      expect(initGitRepository(workspace.dir, { timeoutMs: 500 }))
+        .toMatchObject({ ok: false, failedStep: 'commit' })
     } finally {
       await workspace.cleanup()
     }
   })
 
-  it('reports "not a work tree" rather than hanging when git stalls', async () => {
+  it('treats a work-tree probe it had to kill as "inside a repository"', async () => {
     const workspace = await createTempWorkspace('guren-create-app-git-stall-rev-parse-')
     try {
       await stallingGitOnPath(workspace.dir, 'rev-parse')
 
-      expect(isInsideGitWorkTree(workspace.dir, { timeoutMs: 500 })).toBe(false)
+      // The caller declines `git init` on true, so an unreadable answer has to
+      // decline as well rather than nest a repository in the user's checkout.
+      expect(isInsideGitWorkTree(workspace.dir, { timeoutMs: 200 })).toBe(true)
     } finally {
       await workspace.cleanup()
     }
   })
 
-  it('reports the step that failed', async () => {
+  it('stays on the graceful path when there is no git at all', async () => {
     const workspace = await createTempWorkspace('guren-create-app-git-missing-')
     try {
-      // An empty PATH entry leaves no `git` to find at all.
+      // An empty PATH entry leaves no `git` to find.
       process.env.PATH = workspace.dir
 
-      expect(initGitRepository(workspace.dir)).toEqual({ ok: false, failedStep: 'init' })
+      // Not "inside a repository" — a missing git must not read as one, or the
+      // scaffolder would silently skip git init instead of reporting it.
+      expect(isInsideGitWorkTree(workspace.dir)).toBe(false)
+      expect(initGitRepository(workspace.dir))
+        .toEqual({ ok: false, failedStep: 'init', command: 'git init' })
     } finally {
       await workspace.cleanup()
     }
@@ -88,7 +83,6 @@ describe('git helpers', () => {
     try {
       await writeFile(join(workspace.dir, 'file.txt'), 'contents\n', 'utf8')
 
-      expect(GIT_TIMEOUT_MS).toBeGreaterThan(0)
       expect(initGitRepository(workspace.dir)).toEqual({ ok: true })
     } finally {
       await workspace.cleanup()

--- a/packages/create-app/tests/helpers.ts
+++ b/packages/create-app/tests/helpers.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { afterAll, beforeAll } from 'bun:test'
 
 export interface TempWorkspace {
   dir: string
@@ -25,4 +26,38 @@ export async function createTempWorkspace(prefix: string): Promise<TempWorkspace
       await rm(dir, { recursive: true, force: true })
     },
   }
+}
+
+const GIT_IDENTITY = {
+  GIT_AUTHOR_NAME: 'Guren Test',
+  GIT_AUTHOR_EMAIL: 'guren-test@example.com',
+  GIT_COMMITTER_NAME: 'Guren Test',
+  GIT_COMMITTER_EMAIL: 'guren-test@example.com',
+} as const
+
+/**
+ * Give `git commit` an identity for the duration of the calling file.
+ *
+ * The scaffolder deliberately leaves identity to the user's own `git config`,
+ * and CI runners don't configure one globally the way most developer machines
+ * do — so a test that commits has to supply one, or it passes only on the
+ * machines that happen to have it. File-wide rather than per test: a per-test
+ * restore in a `finally` runs late when that test overruns, leaving the
+ * variables set for whatever ran in the meantime.
+ */
+export function useGitIdentity(): void {
+  const previous = Object.fromEntries(
+    Object.keys(GIT_IDENTITY).map((key) => [key, process.env[key]]),
+  )
+
+  beforeAll(() => {
+    Object.assign(process.env, GIT_IDENTITY)
+  })
+
+  afterAll(() => {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  })
 }

--- a/packages/create-app/tests/helpers.ts
+++ b/packages/create-app/tests/helpers.ts
@@ -4,20 +4,24 @@ import { tmpdir } from 'node:os'
 
 export interface TempWorkspace {
   dir: string
-  originalCwd: string
   cleanup: () => Promise<void>
 }
 
+/**
+ * A throwaway directory for one test.
+ *
+ * Deliberately does *not* `process.chdir()` into it: Bun runs every test file
+ * in one shared process, so the working directory is global state. A test that
+ * times out keeps running, and its `finally` then chdir'd and `rm -rf`'d out
+ * from under whichever test had started in the meantime — one slow test failed
+ * three. Callers pass absolute paths instead.
+ */
 export async function createTempWorkspace(prefix: string): Promise<TempWorkspace> {
   const dir = await mkdtemp(join(tmpdir(), prefix))
-  const originalCwd = process.cwd()
-  process.chdir(dir)
 
   return {
     dir,
-    originalCwd,
     async cleanup() {
-      process.chdir(originalCwd)
       await rm(dir, { recursive: true, force: true })
     },
   }


### PR DESCRIPTION
Three tests in `packages/create-app/tests/cli.test.ts` failed intermittently in CI while passing everywhere else, forcing `gh run rerun --failed` — the habit that lets a real failure through.

## Root cause

A single `git commit` inside the scaffolder that stalls for ≥10s. Two amplifiers turn one stall into three or four failures:

1. **Bun charges a timed-out test's leftover blocking time to the next test.** `spawnSync` blocks the JS thread, so when the watchdog times out test 1 at 5000ms it starts test 2's clock while test 2 has not run a line. A ≥10s stall therefore produces *two* timeouts exactly 5.0000s apart — which is what the CI logs show, to the tenth of a millisecond.
2. **`process.chdir` in the temp-workspace helper.** Bun shares one process across every test file, so the timed-out test's late `finally` chdir'd and `rm -rf`'d out from under whichever test had started in the meantime. That is the `'already contained files'` assertion failure and the `ENOENT: chdir` crash.

Reproduced deterministically in a Linux container with a `git` shim that stalls the commit 12s: same two timeouts, same assertion failure, same ENOENT.

## The stall itself

`--git` shells out to `git init`, `git add -A`, and `git commit` through `spawnSync` with no bound. That call blocks the process outright, so a git that stops making progress leaves the user staring at `Initializing git repository...` with the app already written to disk. The child inherits no terminal, which is what makes it reachable rather than theoretical: a signing passphrase prompt, a credential helper, or a stalled name lookup while git guesses the committer identity all wait on input that can never arrive.

The three steps now share one 30s deadline — one budget for the whole call, not one per subprocess — and a child that overruns it is SIGKILLed. The result is the manual-recovery warning the scaffolder already printed when git failed outright. Children also get `GIT_TERMINAL_PROMPT=0`. Nothing changes for a scaffold where git behaves; the repository is still created with the user's own `init.defaultBranch`, identity, and signing configuration rather than overrides forced by the scaffolder.

## Test changes

- `tests/helpers.ts` no longer touches the working directory; callers pass absolute paths. This is what caps the blast radius at one test.
- Git identity is set file-wide instead of in a per-test `finally`, which runs late exactly when the test overruns.
- The two git-spawning tests get a budget above the scaffolder's own, so a wedged git surfaces as an assertion failure naming the real problem instead of a bare timeout.
- New `tests/git.test.ts` covers the timeout with a stalling-`git` shim on `PATH`.

## Verification

| Scenario | Before | After |
|---|---|---|
| 12s stalled `git commit` (Linux, shim) | 4 failures | 0 failures |
| Permanently wedged `git` (shim) | 4 failures + `ENOENT` crash | 1 assertion failure, bounded at 30.1s |
| `bun run test:bun`, 30 iterations, this machine | — | 0 failures |

Two caveats stated plainly:

- **The underlying stall does not reproduce on this machine.** 19 clean full-suite iterations, three Linux container runs, and a run pinned to 0.3 CPU all stayed green — the git test costs 190–270ms even when starved, against a 55ms norm and a 5000ms cliff in CI. That 100x gap is a hang, not contention, so the shim repro is the evidence here, not a green loop.
- **`commit.gpgsign` is ruled out as the CI cause**, tested rather than assumed: with a failing gpg, `git commit` exits in 17ms rather than blocking. The timeout is what makes the specific cause irrelevant.

`packages/cli/tests/helpers.ts` has the same `process.chdir`, but its ~50 consumers depend on it and the one file there that commits (`changed-files.test.ts`) passes explicit `cwd` and sets identity per-repo via `git config`, so it does not share this exposure. Left alone deliberately.

Changeset included: the spawn bound is shipped behavior.

## Checks

`bun run build:clean`, `bun run typecheck`, `bun run test`, `bun run audit:core-first`, `bun run audit:docs`, `bun run smoke:starter` — all green.