### PR TITLE
fix(cli): reject path-traversal names in scaffolders, harden secureCompare

### DIFF
--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -13,7 +13,7 @@ import { makeNotification } from './make-notification'
 import { makeRoute } from './make-route'
 import { makeView } from './make-view'
 import { addImport, addProvider, detectSchemaDialect, ensureDrizzleImports, ensureMysqlImports, ensureSqliteImports, findClosingDelimiter } from './patch-helpers'
-import { camelCase, pascalCase, writeFilesSafe, type WriterOptions } from './utils'
+import { camelCase, pascalCase, writeScaffoldFiles, type WriterOptions } from './utils'
 import { readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
@@ -39,7 +39,7 @@ async function scaffoldFeatureFiles(
   files: Array<{ path: string; contents: string }>,
   options: WriterOptions,
 ): Promise<string[]> {
-  return writeFilesSafe(files, options)
+  return writeScaffoldFiles(files, options)
 }
 
 const blueprintRegistry: Record<string, BlueprintDefinition> = {

--- a/packages/cli/src/deploy.ts
+++ b/packages/cli/src/deploy.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import { basename, resolve } from 'node:path'
-import { kebabCase, writeFilesSafe, type WriterOptions } from './utils'
+import { kebabCase, writeScaffoldFiles, type WriterOptions } from './utils'
 
 export type DeployTarget = 'docker' | 'fly' | 'railway' | 'all'
 
@@ -160,5 +160,5 @@ export async function scaffoldDeploy(options: DeployOptions = {}): Promise<strin
   const port = normalizePort(options.port)
   const appName = sanitizeFlyAppName(options.appName ?? await inferAppName())
   const files = filesForTarget(target, appName, port)
-  return writeFilesSafe(files, { force: Boolean(options.force) })
+  return writeScaffoldFiles(files, { force: Boolean(options.force) })
 }

--- a/packages/cli/src/make-adr.ts
+++ b/packages/cli/src/make-adr.ts
@@ -4,7 +4,7 @@ import { resolve } from 'node:path'
 import { consola } from 'consola'
 
 import type { WriterOptions } from './utils'
-import { safeModuleName, slugifyProse, writeFileSafe } from './utils'
+import { safeModuleName, slugifyProse, writeScaffoldFile } from './utils'
 import {
   discoverControllerFiles,
   discoverResourceFiles,
@@ -217,7 +217,7 @@ export async function makeAdr(title: string, options: MakeAdrOptions = {}): Prom
   ])
   const sequence = await nextSequenceNumber(dir)
 
-  return writeFileSafe(
+  return writeScaffoldFile(
     `${dir}/${sequence}-${adrSlug(title)}.md`,
     adrTemplate(title.trim(), actor, new Date().toISOString(), prefill),
     options,

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import { dirname, relative, resolve, sep as pathSep } from 'node:path'
 import { consola } from 'consola'
-import { writeFilesSafe, type WriterOptions } from './utils'
+import { writeScaffoldFiles, type WriterOptions } from './utils'
 import {
   addImport,
   addProvider,
@@ -2273,7 +2273,7 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
     )
   }
 
-  const created = await writeFilesSafe(files, options)
+  const created = await writeScaffoldFiles(files, options)
 
   await updateSchema(features)
   await updatePageContracts()

--- a/packages/cli/src/make-feature.ts
+++ b/packages/cli/src/make-feature.ts
@@ -1,5 +1,5 @@
 import { consola } from 'consola'
-import { writeFilesSafe, type WriterOptions, pascalCase, camelCase, kebabCase, pagesAccessor, safeModuleName } from './utils'
+import { writeScaffoldFiles, type WriterOptions, pascalCase, camelCase, kebabCase, pagesAccessor, safeModuleName } from './utils'
 import { pluralize } from './inflect'
 import { makeModel } from './make-model'
 import { makePolicy } from './make-policy'
@@ -45,7 +45,7 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
   // and the ones `make:validator` writes cannot drift apart.
   const validatorPath = await makeValidator(singular, { ...writerOptions, fields })
 
-  const created = await writeFilesSafe([
+  const created = await writeScaffoldFiles([
     {
       path: `${appPrefix}app/Http/Resources/${singular}Resource.ts`,
       contents: generateResource(singular, fields),

--- a/packages/cli/src/make-module.ts
+++ b/packages/cli/src/make-module.ts
@@ -1,5 +1,5 @@
 import { consola } from 'consola'
-import { camelCase, pascalCase, relativeImportPath, safeModuleName, writeFilesSafe, type WriterOptions } from './utils'
+import { camelCase, pascalCase, relativeImportPath, safeModuleName, writeScaffoldFiles, type WriterOptions } from './utils'
 import { addImport, addToArrayOption } from './patch-helpers'
 import { fileExists } from './discovery'
 
@@ -46,7 +46,7 @@ export function register${pascalName}Routes(router: Router): void {
 // Re-exported into the project's db/schema.ts by \`guren make:module\`.
 `
 
-  const filesCreated = await writeFilesSafe(
+  const filesCreated = await writeScaffoldFiles(
     [
       { path: `${moduleDir}/index.ts`, contents: indexContents },
       { path: `${moduleDir}/routes.ts`, contents: routesContents },

--- a/packages/cli/src/make-test.ts
+++ b/packages/cli/src/make-test.ts
@@ -1,4 +1,4 @@
-import { resourceName, trimSlashes, writeFileSafe, ensureSuffix, safeModuleName } from './utils'
+import { resourceName, safePathSegments, writeScaffoldFile, ensureSuffix, safeModuleName } from './utils'
 import type { WriterOptions } from './utils'
 import { fileExists, readIfExists } from './discovery'
 
@@ -76,15 +76,12 @@ export async function makeTest(name: string, options: MakeTestOptions = {}): Pro
     throw new Error('Test name is required.')
   }
 
+  // Validate before `detectRunner()` — it stats up to seven files, and every
+  // one of them is wasted when the name turns out to be a traversal.
+  const segments = safePathSegments(trimmed, 'test name')
   const runner = options.runner ?? (await detectRunner())
 
-  const normalizedPath = trimSlashes(trimmed)
-  if (!normalizedPath) {
-    throw new Error('Test name cannot be empty.')
-  }
-
-  const segments = normalizedPath.split('/').filter(Boolean)
-  const baseSegment = segments.pop() ?? 'Example'
+  const baseSegment = segments.pop()!
   const baseName = baseSegment.replace(/\.(test\.)?(t|j)sx?$/giu, '')
   const { className: baseClassName } = resourceName(baseName)
   const className = options.controller ? ensureSuffix(baseClassName, 'Controller') : baseClassName
@@ -95,5 +92,5 @@ export async function makeTest(name: string, options: MakeTestOptions = {}): Pro
     : `${testRoot}/${[...segments, fileName].join('/')}`
 
   const { runner: _runner, controller: _controller, ...writer } = options
-  return writeFileSafe(filePath, testTemplate(className, runner), writer)
+  return writeScaffoldFile(filePath, testTemplate(className, runner), writer)
 }

--- a/packages/cli/src/make-view.ts
+++ b/packages/cli/src/make-view.ts
@@ -1,5 +1,5 @@
 import type { WriterOptions } from './utils'
-import { pascalCase, trimSlashes, writeFileSafe } from './utils'
+import { pascalCase, safePathSegments, writeScaffoldFile } from './utils'
 
 const VIEW_ROOT = 'resources/js/pages'
 
@@ -24,8 +24,8 @@ export default ${componentName}
 }
 
 export async function makeView(name: string, options: WriterOptions = {}): Promise<string> {
-  const normalized = trimSlashes(name)
-  const componentName = pascalCase(normalized.split('/').pop() ?? normalized)
-  const filePath = `${VIEW_ROOT}/${normalized}.tsx`
-  return writeFileSafe(filePath, viewTemplate(componentName), options)
+  const segments = safePathSegments(name, 'view name')
+  const componentName = pascalCase(segments[segments.length - 1]!)
+  const filePath = `${VIEW_ROOT}/${segments.join('/')}.tsx`
+  return writeScaffoldFile(filePath, viewTemplate(componentName), options)
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -59,6 +59,42 @@ export async function runCommand(
   })
 }
 
+/**
+ * Throws unless `relativePath` stays under the project root.
+ *
+ * Scaffolders build their output path out of a name they were handed, and
+ * those names are not all developer-typed: `guren mcp` exposes them as a
+ * request field. `..` survives both `trimSlashes()` and `kebabCase()`, so
+ * without this a name like `../../../../tmp/evil` writes outside the project.
+ *
+ * Reach for it through `writeScaffoldFile`/`writeScaffoldFiles` rather than
+ * calling it directly — a generator that picks the right writer gets
+ * containment for free, and one that picks `writeFileSafe` is visibly opting
+ * out. Codegen is the reason the check cannot simply live in `writeFileSafe`:
+ * `guren codegen --out` takes a caller-supplied directory that may
+ * legitimately sit outside `process.cwd()`.
+ */
+export function assertScaffoldPath(relativePath: string): void {
+  const root = process.cwd()
+  const fullPath = resolve(root, relativePath)
+
+  if (fullPath !== root && !fullPath.startsWith(root + pathSep)) {
+    throw new Error(
+      `Refusing to write "${relativePath}" — it resolves outside the project root (${fullPath}).`,
+    )
+  }
+}
+
+/** `writeFileSafe` for generated scaffolds: containment-checked. */
+export async function writeScaffoldFile(
+  relativePath: string,
+  contents: string,
+  options: WriterOptions = {},
+): Promise<string> {
+  assertScaffoldPath(relativePath)
+  return writeFileSafe(relativePath, contents, options)
+}
+
 export async function writeFileSafe(relativePath: string, contents: string, options: WriterOptions = {}): Promise<string> {
   const fullPath = resolve(process.cwd(), relativePath)
 
@@ -111,10 +147,15 @@ export async function writeGeneratedFile(
   return writeFileSafe(relativePath, contents, options)
 }
 
-export async function writeFilesSafe(
+/** `writeScaffoldFile` over a batch — every path is checked before any write. */
+export async function writeScaffoldFiles(
   entries: Array<{ path: string; contents: string }>,
   options: WriterOptions = {},
 ): Promise<string[]> {
+  for (const entry of entries) {
+    assertScaffoldPath(entry.path)
+  }
+
   const created: string[] = []
 
   for (const entry of entries) {
@@ -132,7 +173,7 @@ export async function scaffoldFile(name: string, config: ScaffoldConfig, options
   const dir = options.root ? `modules/${safeModuleName(options.root)}/${config.dir}` : config.dir
   const filePath = extension ? `${dir}/${baseName}.${extension}` : `${dir}/${baseName}`
   const contents = config.template({ rawName: name, className, fileName, normalizedName })
-  return writeFileSafe(filePath, contents, options)
+  return writeScaffoldFile(filePath, contents, options)
 }
 
 export function pascalCase(value: string): string {
@@ -242,6 +283,45 @@ export function safeModuleName(value: string): string {
     )
   }
   return name
+}
+
+/** A backslash is a separator on Windows; NUL truncates the path syscall-side. */
+const PATH_SEGMENT_SEPARATOR_RE = /[\\\u0000]/u
+
+/**
+ * Splits a nested generator name (`make:view posts/Index`,
+ * `make:test auth/Login`) into path segments, rejecting any segment that is a
+ * directory traversal rather than a name.
+ *
+ * `trimSlashes()` only touches the edges, so `..` survives
+ * `split('/').filter(Boolean)` — it is non-empty — and walks out of the
+ * generator's output directory once interpolated into the path. Segments are
+ * rejected rather than stripped because nesting is the documented feature
+ * here: silently rewriting the path would put the file somewhere the caller
+ * did not ask for.
+ *
+ * Only traversal is rejected, not unusual characters. `pascalCase()` already
+ * accepts space-separated words, so narrowing to an identifier charset here
+ * would break `make:test "admin/my page"` — which the filesystem, and every
+ * release before this check, accepted.
+ */
+export function safePathSegments(value: string, label: string): string[] {
+  const segments = trimSlashes(value).split('/').filter(Boolean)
+
+  if (segments.length === 0) {
+    throw new Error(`A ${label} is required.`)
+  }
+
+  for (const segment of segments) {
+    if (segment === '.' || segment === '..' || PATH_SEGMENT_SEPARATOR_RE.test(segment)) {
+      throw new Error(
+        `Invalid ${label} "${value}" — "${segment}" is a path traversal, not a name. `
+        + `Use plain nested names such as "posts/Index".`,
+      )
+    }
+  }
+
+  return segments
 }
 
 export function resourceName(value: string): { className: string; fileName: string } {

--- a/packages/cli/tests/make-route.test.ts
+++ b/packages/cli/tests/make-route.test.ts
@@ -21,6 +21,20 @@ describe('makeRoute', () => {
     }
   })
 
+  // `make:route` keeps the kebab-cased name as the file name, and `kebabCase()`
+  // preserves `/` and `.` — so the containment check in the scaffold writer is
+  // the only thing between the raw name and a write outside the project.
+  it('refuses a name whose file name escapes the output directory', async () => {
+    const workspace = await createTempWorkspace('guren-cli-route-escape-')
+    try {
+      await expect(makeRoute('../../../../tmp/evil', { force: true })).rejects.toThrow(
+        'resolves outside the project root',
+      )
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   // The controller name has to be the one make:feature generates. Stripping a
   // lone trailing `s` gave `CategorieController` for `categories`, so the route
   // pointed at a controller no other generator ever writes.

--- a/packages/cli/tests/make-test.test.ts
+++ b/packages/cli/tests/make-test.test.ts
@@ -19,6 +19,31 @@ describe('makeTest', () => {
     }
   })
 
+  it('keeps accepting a name with a space, the way pascalCase always has', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-test-space-')
+    try {
+      const result = await makeTest('admin/my page', { runner: 'bun' })
+
+      expect(result).toContain('tests/admin/MyPage.test.ts')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('rejects directory segments that escape the test root', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-test-traversal-')
+    try {
+      await expect(makeTest('../../../../tmp/evil/x', { runner: 'bun', force: true })).rejects.toThrow(
+        'is a path traversal',
+      )
+      await expect(makeTest('auth/../../../tmp/evil/x', { runner: 'bun', force: true })).rejects.toThrow(
+        'is a path traversal',
+      )
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('throws when the test name is empty', async () => {
     const workspace = await createTempWorkspace('guren-cli-make-test-empty-')
     try {

--- a/packages/cli/tests/make-view.test.ts
+++ b/packages/cli/tests/make-view.test.ts
@@ -17,4 +17,30 @@ describe('makeView', () => {
       await workspace.cleanup()
     }
   })
+
+  it('keeps accepting a name with a space, the way pascalCase always has', async () => {
+    const workspace = await createTempWorkspace('guren-cli-view-space-')
+    try {
+      const result = await makeView('admin/my page')
+
+      expect(result).toContain('resources/js/pages/admin/my page.tsx')
+      expect(await readFile(result, 'utf8')).toContain('const MyPage')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('rejects a name whose segments escape the page root', async () => {
+    const workspace = await createTempWorkspace('guren-cli-view-traversal-')
+    try {
+      await expect(makeView('../../../../tmp/pwned', { force: true })).rejects.toThrow(
+        'is a path traversal',
+      )
+      await expect(makeView('posts/../../../tmp/pwned', { force: true })).rejects.toThrow(
+        'is a path traversal',
+      )
+    } finally {
+      await workspace.cleanup()
+    }
+  })
 })

--- a/packages/cli/tests/utils.test.ts
+++ b/packages/cli/tests/utils.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'bun:test'
+import { createTempWorkspace } from './helpers'
+import { assertScaffoldPath, safePathSegments } from '../src/utils'
+
+describe('assertScaffoldPath', () => {
+  it('accepts a nested path inside the project root', () => {
+    expect(() => assertScaffoldPath('tests/auth/Login.test.ts')).not.toThrow()
+  })
+
+  it('refuses a path that escapes the project root', () => {
+    expect(() => assertScaffoldPath('tests/../../../../tmp/evil.ts')).toThrow(
+      'resolves outside the project root',
+    )
+    expect(() => assertScaffoldPath('/tmp/evil.ts')).toThrow('resolves outside the project root')
+  })
+
+  it('does not treat a sibling directory sharing the root prefix as inside', async () => {
+    const workspace = await createTempWorkspace('guren-cli-scaffold-sibling-')
+    try {
+      const sibling = `../${workspace.dir.split('/').pop()}-evil/x.ts`
+      expect(() => assertScaffoldPath(sibling)).toThrow('resolves outside the project root')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})
+
+describe('safePathSegments', () => {
+  it('splits a nested name into segments', () => {
+    expect(safePathSegments('posts/Index', 'view name')).toEqual(['posts', 'Index'])
+    expect(safePathSegments('/auth/Login/', 'test name')).toEqual(['auth', 'Login'])
+    expect(safePathSegments('Login.test.ts', 'test name')).toEqual(['Login.test.ts'])
+  })
+
+  it('accepts names the filesystem accepts, narrowing only traversal', () => {
+    expect(safePathSegments('admin/my page', 'view name')).toEqual(['admin', 'my page'])
+    expect(safePathSegments('顧客/Index', 'view name')).toEqual(['顧客', 'Index'])
+    expect(safePathSegments('reports+/Login', 'test name')).toEqual(['reports+', 'Login'])
+    expect(safePathSegments('...', 'view name')).toEqual(['...'])
+  })
+
+  it('throws when the name has no segments', () => {
+    expect(() => safePathSegments('', 'view name')).toThrow('A view name is required')
+    expect(() => safePathSegments('///', 'test name')).toThrow('A test name is required')
+  })
+
+  it('rejects traversal segments', () => {
+    expect(() => safePathSegments('../outside', 'view name')).toThrow('is a path traversal')
+    expect(() => safePathSegments('posts/../../outside', 'view name')).toThrow(
+      'is a path traversal',
+    )
+    expect(() => safePathSegments('posts/./Index', 'view name')).toThrow('is a path traversal')
+    expect(() => safePathSegments('posts/..\\..\\outside', 'view name')).toThrow(
+      'is a path traversal',
+    )
+  })
+})

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -23,14 +23,22 @@ export function generateId(): string {
 
 /**
  * Securely compare two hex strings using timing-safe comparison.
+ *
+ * Input that is not strict, even-length hex is rejected rather than compared:
+ * `Buffer.from(value, 'hex')` stops at the first invalid pair, so 'zzzz' and
+ * 'yyyy' both decode to nothing — and 'abcz' and 'abdz' both decode to the
+ * one byte they share — and would compare equal. A short decode is how the
+ * decoder reports that, which beats restating its grammar in a regex here.
+ * Use `secureStringCompare` for values that are not hex.
  */
 export function secureCompare(a: string, b: string): boolean {
   if (a.length !== b.length) return false
-  try {
-    return timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex'))
-  } catch {
-    return false
-  }
+
+  const bufA = Buffer.from(a, 'hex')
+  const bufB = Buffer.from(b, 'hex')
+  if (bufA.length !== a.length / 2 || bufB.length !== b.length / 2) return false
+
+  return timingSafeEqual(bufA, bufB)
 }
 
 /**

--- a/packages/server/tests/auth/utils.test.ts
+++ b/packages/server/tests/auth/utils.test.ts
@@ -85,6 +85,23 @@ describe('auth/utils', () => {
       // timingSafeEqual with zero-length buffers returns true
       expect(secureCompare('', '')).toBe(true)
     })
+
+    test('should return false for different non-hex strings that decode alike', () => {
+      // Buffer.from(value, 'hex') stops at the first invalid pair, so both of
+      // these would decode to the same empty buffer and compare equal.
+      expect(secureCompare('zzzz', 'yyyy')).toBe(false)
+      expect(secureCompare('g0000000', 'z0000000')).toBe(false)
+    })
+
+    test('should return false when a shared hex prefix precedes invalid input', () => {
+      expect(secureCompare('abcz', 'abdz')).toBe(false)
+    })
+
+    test('should return false for odd-length hex that truncates to a shared byte', () => {
+      // Both decode to the single byte 0xab without the strict-length check.
+      expect(secureCompare('abc', 'abd')).toBe(false)
+      expect(secureCompare('abc', 'abc')).toBe(false)
+    })
   })
 
   describe('secureStringCompare', () => {


### PR DESCRIPTION
## Summary

- `make:test`/`make:view` interpolated caller-supplied nested names (`posts/Index`, `auth/Login`) straight into their output path. `..` survived `trimSlashes()` + `split('/')`, and `writeFileSafe()` had no root-containment check, so a name like `../../../../tmp/evil` wrote outside the project. The name isn't always developer-typed — the MCP tool `guren_make_component` exposes it as an unvalidated request field, so an agent processing untrusted content (or any local process reaching the loopback MCP endpoint) could reach it.
- Every `make:*` scaffolder now writes through new `writeScaffoldFile()`/`writeScaffoldFiles()` wrappers that assert containment by construction, instead of relying on each call site to remember an assertion. `scaffoldFile()` (backing `make:controller`/`make:model`/`make:route`/etc.) and the `writeFilesSafe()` callers (`make:feature`, `make:auth`, `make:module`, blueprints, deploy) previously had no containment check at all and were safe only incidentally — the same way `make:route` wasn't.
- Nested-name validation (`safePathSegments()`) rejects `.`/`..`/separator segments rather than stripping them, and is narrowed to only what can actually escape — an earlier draft over-tightened to an identifier charset and broke space-containing names like `"admin/my page"`, which `pascalCase()` has always supported. Caught independently by Codex review and a reuse-focused simplify pass.
- Separately hardens `secureCompare()` in `auth/utils.ts`: `Buffer.from(str, 'hex')` truncates at the first invalid pair, so two different non-hex strings sharing an invalid prefix (or an odd length) could decode to identical buffers and compare equal via `timingSafeEqual`. It now rejects input whose hex decode doesn't round-trip to the original length. The only internal caller (`api-token.ts`) already passes strict hex; this only changes the public export's behavior for out-of-contract input.

## Known residual gap (not fixed here)

Scaffold writes still follow symlinks: if a scaffold output directory contains a symlink to an external path, the containment check passes lexically but the write follows the link. Requires the attacker to have pre-planted a symlink inside the project, a materially stronger precondition than the fixed issue, and resolving it (e.g. `realpath`-based containment) risks breaking legitimate symlinked directories in monorepo setups — left as a follow-up.

## Test plan

- [x] `bun run build:clean`
- [x] `bun run typecheck`
- [x] `bun run test:bun` — 3525 pass / 0 fail / 55 skip
- [x] `bun run audit:core-first`, `bun run audit:docs`
- [x] Mutation-tested all three guards (segment rejection, root containment, hex round-trip length) by disabling each and confirming the corresponding new tests fail, then restored
- [x] Manually verified previously-working names still work post-fix: `make:test "admin/my page"`, `make:view "顧客/Index"`