### PR TITLE
docs: update README version badge and MySQL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Laravel-style conventions, end-to-end type safety, and built-in agent introspection and verification — routing, controllers, ORM, authentication, and Inertia.js + React in one cohesive experience that humans and AI coding agents navigate from the same map.
 
-> **v1.0** — Stable. Breaking changes only in major releases, per the [release policy](docs/en/guides/release-policy.md).
+> **v2** — Stable. Breaking changes only in major releases, per the [release policy](docs/en/guides/release-policy.md).
 
 ---
 
@@ -54,7 +54,7 @@ Run `bun run codegen` after adding features to regenerate types. When you are re
 - **Agent-ready by default** — `guren context` hands an agent the project map with API signatures, `guren check` and `guren audit` verify its work mechanically, and every new app ships an agent harness. In a [public, blind-scored evaluation](https://github.com/gurenjs/framework-comparison/tree/main/agent-eval), every agent trial shipped a working feature
 - **Laravel-style MVC** — routes, controllers, and an Eloquent-inspired Model API
 - **Inertia.js + React** — SPA-like UX without a separate frontend app
-- **Drizzle ORM** — swap database backends through an adapter (PostgreSQL / SQLite)
+- **Drizzle ORM** — swap database backends through an adapter (PostgreSQL / MySQL / SQLite)
 - **End-to-end type safety** — `bunx guren codegen` generates types from schema to frontend props
 - **Batteries included** — auth, queues, mail, cache, notifications, storage, broadcasting, scheduling
 - **Bun-first, deploy anywhere** — develop on the Bun toolchain, then self-host on a Bun server or ship to AWS Lambda, Vercel, or Cloudflare Workers with first-party plugins


### PR DESCRIPTION
## Summary
- Update the README's version note from `v1.0` to `v2` — `@guren/server`, `@guren/orm`, and `@guren/cli` are all on 2.1.0, with a 2.0.0 major release (RFC 0006 mass-assignment protection) already shipped.
- Add MySQL to the ORM feature bullet's supported-database list (PostgreSQL / MySQL / SQLite) — MySQL has been a supported Drizzle adapter but wasn't mentioned.

## Verification
- Confirmed package versions directly (`server`/`orm`/`cli` at 2.1.0, `core` at 1.5.0) and the 2.0.0 major changelog entry.
- Confirmed `createMySqlDatabase` is exported from `@guren/orm`.
- Checked that the README's Controller/Model code samples still work under the v2 mass-assignment rules (a model without `static fillable` stays permissive rather than throwing).
- Confirmed `create-guren-app --auth` still exists in `packages/create-app/src/cli.ts`.
- Cross-checked the `guren add <sub>` command list and scaffolded app `package.json` scripts referenced in Quick Start against current CLI source — all accurate, no changes needed there.

## Test plan
- [x] Docs-only change; no build/test impact.