### PR TITLE
docs(guides): document auth shared props as scaffolded, not hand-wired

### DIFF
--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -329,32 +329,40 @@ export default class DashboardController extends Controller {
 
 Use `this.validateBody()` / `this.validateQuery()` / `this.validateParams()` with Zod schemas for typed validation. Reserve `FormRequest` for compatibility code.
 
-To surface the logged-in user on every Inertia page without repeating controller code, register shared props during app boot:
+Surfacing the logged-in user on every Inertia page is already wired for you. The `app/Providers/AuthProvider.ts` that `bunx guren add auth` (equivalently `bunx guren make:auth --install`) generates registers it in `boot()`, so `auth.user` is readable from every page's props right after scaffolding — it is what the generated layout reads to toggle between **Sign in** and **Log out**.
 
 ```ts
-// config/inertia.ts
-import { setInertiaSharedProps, AUTH_CONTEXT_KEY, type AuthContext } from '@guren/core'
+// app/Providers/AuthProvider.ts (generated; register()'s useModel setup elided)
+import { ServiceProvider, shareInertiaProps, AUTH_CONTEXT_KEY } from '@guren/core'
+import type { AuthContext } from '@guren/core'
 
-setInertiaSharedProps(async (ctx) => {
-  const auth = ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
-  return { auth: { user: await auth?.user() } }
-})
+export default class AuthProvider extends ServiceProvider {
+  boot(): void {
+    shareInertiaProps(async (ctx) => {
+      const auth = ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
+      return { auth: { user: await auth?.user() } }
+    })
+  }
+}
 ```
+
+If you assembled authentication by hand, make the same call from your own service provider's `boot()`.
 
 Sharing `auth.user()` this way is safe by default: the record is sanitized before it leaves the auth layer, so the password hash never reaches the browser (see [Sanitized User Records](#sanitized-user-records)).
 
 Augment `InertiaSharedProps` (see the Controllers guide) to type this `auth` payload for React pages.
 
-> `setInertiaSharedProps` replaces the whole resolver. When several parts of
-> your app contribute shared props (auth, i18n, flash, …), use
-> `shareInertiaProps` instead — it merges its props over whatever was
-> registered before:
+> `shareInertiaProps` merges its props over whatever was registered before, so
+> several parts of your app (auth, i18n, flash, …) can each contribute without
+> clobbering one another:
 >
 > ```ts
-> import { shareInertiaProps } from '@guren/core'
->
 > shareInertiaProps((ctx) => ({ i18n: { locale: detectLocale(ctx) } }))
 > ```
+>
+> `setInertiaSharedProps` replaces the resolver rather than merging, dropping
+> whatever is registered at the moment it runs. Reach for it only when you mean
+> to replace the whole thing.
 
 Route middleware makes protecting endpoints straightforward:
 

--- a/docs/en/guides/controllers.md
+++ b/docs/en/guides/controllers.md
@@ -236,6 +236,47 @@ Only methods that exist on your controller are registered. Limit the routes with
 router.resource('/posts', PostsController, { only: ['index', 'show'] })
 ```
 
+## Sharing Data Between Methods
+
+Controllers are instantiated per request, so one method can set an instance field for a helper method to reuse. For data every page needs (the signed-in user, for example), reach for Inertia shared props or middleware instead.
+
+## Inertia Shared Props
+
+Use `shareInertiaProps()` to inject application-wide data into every Inertia response. The natural home for the call is a service provider's `boot()` (generate one with `bunx guren make:provider`).
+
+```ts
+// app/Providers/LocaleProvider.ts
+import { ServiceProvider, shareInertiaProps } from '@guren/core'
+
+export default class LocaleProvider extends ServiceProvider {
+  boot(): void {
+    shareInertiaProps((ctx) => ({
+      i18n: { locale: ctx.req.header('accept-language')?.split(',')[0] ?? 'en' },
+    }))
+  }
+}
+```
+
+It merges its props over whatever resolver was registered before, so several providers can each contribute shared props without clobbering one another.
+
+> [!NOTE]
+> Sharing the signed-in user (`auth.user`) is already registered for you by the `AuthProvider` that `bunx guren add auth` generates — there's no need to register it again. See the [Authentication guide](./authentication.md) for details.
+
+Augment the exported `InertiaSharedProps` interface to keep these props typed across controllers and React pages:
+
+```ts
+// types/inertia.d.ts
+import type { UserRecord } from '@/app/Models/User'
+
+declare module '@guren/core' {
+  interface InertiaSharedProps {
+    auth: { user: UserRecord | null }
+  }
+}
+```
+
+When you need the component's prop type, `InferInertiaProps<ReturnType<Controller['action']>>` gives you both the action props and the shared props.
+
 ## Testing Controllers
 
 `TestApp` boots a lightweight instance of your app for expressive HTTP testing:

--- a/docs/en/tutorials/authentication.md
+++ b/docs/en/tutorials/authentication.md
@@ -50,18 +50,18 @@ bun run codegen
 
 `bun run codegen` folds the scaffolding's new pages and routes into the type manifests (if `bun run dev` is running, the watcher already did this, so it's effectively a no-op). For how the generated auth stack works — guards, providers, safe handling of user records — see the [Authentication guide](../guides/authentication.md).
 
-### Share the sign-in state with your pages
+### How the sign-in state reaches your pages
 
-The generated shared layout (`resources/js/components/Layout.tsx`) reads `auth.user` from the shared props to toggle between **Sign in** and **Log out** — but nothing shares that prop yet. Wire it up by adding a `boot()` to `app/Providers/AuthProvider.ts`:
+The generated shared layout (`resources/js/components/Layout.tsx`) reads `auth.user` from the shared props to toggle between **Sign in** and **Log out**. The wiring that shares that prop is generated too — open `app/Providers/AuthProvider.ts` and you'll find it in `boot()`. There's nothing to change here, but it's worth reading, because later parts build on it:
 
 ```ts
+// app/Providers/AuthProvider.ts (generated)
 import { ServiceProvider, shareInertiaProps, AUTH_CONTEXT_KEY } from '@guren/core'
 import type { AuthContext, AuthManager } from '@guren/core'
 import { User } from '../Models/User.js'
 
 export default class AuthProvider extends ServiceProvider {
   register(): void {
-    // Keep the generated useModel configuration as is
     const auth = this.container.make<AuthManager>('auth')
     auth.useModel(User, {
       usernameColumn: 'email',
@@ -86,7 +86,7 @@ export default class AuthProvider extends ServiceProvider {
 
 With the dev server running (`bun run dev` if you stopped it), open [http://localhost:3333/login](http://localhost:3333/login).
 
-1. Sign in as **demo@example.com** / **secret** — you land on `/dashboard` with a personalized greeting, and the header navigation flips from **Sign in** to **Log out** (the shared props you just wired).
+1. Sign in as **demo@example.com** / **secret** — you land on `/dashboard` with a personalized greeting, and the header navigation flips from **Sign in** to **Log out** (the shared props from `AuthProvider` at work).
 2. Try a wrong password — the form shows "Invalid credentials."
 3. Open `/dashboard` in a private browsing window — you're redirected to `/login`. Protected routes are actually protected.
 

--- a/docs/en/tutorials/relationships.md
+++ b/docs/en/tutorials/relationships.md
@@ -323,7 +323,7 @@ export default function PostShow({ post, comments }: Props) {
 
 Highlights:
 
-- `usePage().props.auth?.user` reads the shared auth props you wired into `AuthProvider`'s `boot()` in Part 2 — that's how the page decides between the form and the sign-in hint.
+- `usePage().props.auth?.user` reads the shared auth props that `AuthProvider`'s `boot()` registers, which you saw in Part 2 — that's how the page decides between the form and the sign-in hint.
 - On success, the redirect re-renders the page with fresh comments, and `form.reset()` clears the textarea.
 
 Close the loop as usual: `bun run codegen` (automatic under `bun run dev`) picks up the `comments.store` route and the new `Props`, and `bunx guren check` verifies the wiring (you'll see one more missing-test warning — for `CommentController` — proof that `check` is paying attention).

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -327,31 +327,39 @@ export default class DashboardController extends Controller {
 
 バリデーションには `this.validateBody()` / `this.validateQuery()` / `this.validateParams()` を Zod スキーマと共に使います。`FormRequest` は互換用途に限定してください。
 
-Inertia の全ページでログインユーザーを共有したい場合は、アプリ起動時に共有 props を登録します。
+Inertia の全ページでログインユーザーを共有する配線は、スキャフォルドが済ませています。`bunx guren add auth`（= `bunx guren make:auth --install`）が生成する `app/Providers/AuthProvider.ts` の `boot()` に次の登録が入っているため、生成直後から全ページの props で `auth.user` を読めます。生成されるレイアウトが **Sign in** と **Log out** を出し分けているのもこの props です。
 
 ```ts
-// config/inertia.ts
-import { setInertiaSharedProps, AUTH_CONTEXT_KEY, type AuthContext } from '@guren/core'
+// app/Providers/AuthProvider.ts（生成済み。register() の useModel 設定は省略）
+import { ServiceProvider, shareInertiaProps, AUTH_CONTEXT_KEY } from '@guren/core'
+import type { AuthContext } from '@guren/core'
 
-setInertiaSharedProps(async (ctx) => {
-  const auth = ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
-  return { auth: { user: await auth?.user() } }
-})
+export default class AuthProvider extends ServiceProvider {
+  boot(): void {
+    shareInertiaProps(async (ctx) => {
+      const auth = ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
+      return { auth: { user: await auth?.user() } }
+    })
+  }
+}
 ```
+
+認証を手動で組み立てた場合は、自分のサービスプロバイダーの `boot()` で同じ呼び出しを行ってください。
 
 このように `auth.user()` を共有する方法はデフォルトで安全です。レコードは認証レイヤーを出る前にサニタイズされるため、パスワードハッシュがブラウザに届くことはありません（後述の「サニタイズされたユーザーレコード」を参照）。
 
 `InertiaSharedProps` を拡張し、React 側でも型付けしてください（詳細はコントローラーガイドを参照）。
 
-> `setInertiaSharedProps` はリゾルバー全体を置き換えます。auth・i18n・flash
-> など複数箇所から共有 props を提供する場合は、既存の props にマージする
-> `shareInertiaProps` を使ってください:
+> `shareInertiaProps` は先に登録されたリゾルバーの props にマージするため、
+> auth・i18n・flash など複数箇所から共有 props を提供しても互いを壊しません:
 >
 > ```ts
-> import { shareInertiaProps } from '@guren/core'
->
 > shareInertiaProps((ctx) => ({ i18n: { locale: detectLocale(ctx) } }))
 > ```
+>
+> `setInertiaSharedProps` はマージせずリゾルバーを置き換えるため、実行時点で
+> 登録済みのものを丸ごと捨てます。意図的に全部を差し替えたいときだけ使って
+> ください。
 
 ルートミドルウェアを使うと保護が簡単です。
 

--- a/docs/ja/guides/controllers.md
+++ b/docs/ja/guides/controllers.md
@@ -258,17 +258,25 @@ FormRequest クラスとバリデーションルールの定義については�
 コントローラーはリクエストごとにインスタンス化されるため、あるメソッドでインスタンスフィールドを設定して、ヘルパーメソッドで再利用できます。全ページ共通のデータ（例: ユーザー情報）については、Inertia の共有プロパティやミドルウェアの利用を検討してください。
 
 ## Inertia 共有プロパティ
-`setInertiaSharedProps()` を使って、すべての Inertia レスポンスにアプリケーション全体のデータ（認証ユーザーなど）を注入できます。
+`shareInertiaProps()` を使って、すべての Inertia レスポンスにアプリケーション全体のデータを注入できます。サービスプロバイダー（`bunx guren make:provider` で生成）の `boot()` から呼ぶのが定位置です。
 
 ```ts
-// config/inertia.ts
-import { setInertiaSharedProps, AUTH_CONTEXT_KEY, type AuthContext } from '@guren/core'
+// app/Providers/LocaleProvider.ts
+import { ServiceProvider, shareInertiaProps } from '@guren/core'
 
-setInertiaSharedProps(async (ctx) => {
-  const auth = ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
-  return { auth: { user: await auth?.user() } }
-})
+export default class LocaleProvider extends ServiceProvider {
+  boot(): void {
+    shareInertiaProps((ctx) => ({
+      i18n: { locale: ctx.req.header('accept-language')?.split(',')[0] ?? 'en' },
+    }))
+  }
+}
 ```
+
+先に登録されたリゾルバーの props にマージされるので、複数のプロバイダーがそれぞれ共有 props を足しても互いを壊しません。
+
+> [!NOTE]
+> 認証ユーザー（`auth.user`）の共有は `bunx guren add auth` が生成する `AuthProvider` が既に登録済みです。自分で登録し直す必要はありません — 詳細は[認証ガイド](./authentication.md)を参照してください。
 
 エクスポートされた `InertiaSharedProps` インターフェースを拡張して、コントローラーと React ページ全体でプロパティの型を維持しましょう。
 

--- a/docs/ja/tutorials/authentication.md
+++ b/docs/ja/tutorials/authentication.md
@@ -50,18 +50,18 @@ bun run codegen
 
 `bun run codegen` は、雛形が追加した新しいページとルートを型マニフェストに反映します（`bun run dev` が動いていれば監視が自動で実行するので、実質不要です）。生成された認証スタックの仕組み — ガード、プロバイダー、ユーザーレコードの安全な取り扱い — は[認証ガイド](../guides/authentication.md)が詳しく解説しています。
 
-### サインイン状態をページに共有する
+### サインイン状態がページに届く仕組み
 
-生成された共有レイアウト（`resources/js/components/Layout.tsx`）は、共有 props の `auth.user` を読んで **Sign in** と **Log out** を出し分けます — が、デフォルトではこの prop を共有する配線がまだありません。`app/Providers/AuthProvider.ts` に `boot()` を追加して配線します。
+生成された共有レイアウト（`resources/js/components/Layout.tsx`）は、共有 props の `auth.user` を読んで **Sign in** と **Log out** を出し分けます。この prop を共有する配線も生成済みです — `app/Providers/AuthProvider.ts` を開くと `boot()` に入っています。手を加える必要はありませんが、この後の Part で使うので中身を見ておきます。
 
 ```ts
+// app/Providers/AuthProvider.ts（生成済み）
 import { ServiceProvider, shareInertiaProps, AUTH_CONTEXT_KEY } from '@guren/core'
 import type { AuthContext, AuthManager } from '@guren/core'
 import { User } from '../Models/User.js'
 
 export default class AuthProvider extends ServiceProvider {
   register(): void {
-    // 生成されたままの useModel 設定はそのまま残します
     const auth = this.container.make<AuthManager>('auth')
     auth.useModel(User, {
       usernameColumn: 'email',
@@ -86,7 +86,7 @@ export default class AuthProvider extends ServiceProvider {
 
 開発サーバーが動いている状態で（止めていたら `bun run dev`）、[http://localhost:3333/login](http://localhost:3333/login) を開きます。
 
-1. **demo@example.com** / **secret** でサインインします — `/dashboard` に着地し、名前入りの挨拶が表示されます。ヘッダーのナビゲーションも **Sign in** から **Log out** に切り替わっています（先ほど配線した共有 props の効果です）。
+1. **demo@example.com** / **secret** でサインインします — `/dashboard` に着地し、名前入りの挨拶が表示されます。ヘッダーのナビゲーションも **Sign in** から **Log out** に切り替わっています（`AuthProvider` が共有している props の効果です）。
 2. 間違ったパスワードを試します — フォームに "Invalid credentials." が表示されます。
 3. プライベートブラウジングのウィンドウで `/dashboard` を開きます — `/login` にリダイレクトされます。保護されたルートは本当に保護されています。
 

--- a/docs/ja/tutorials/relationships.md
+++ b/docs/ja/tutorials/relationships.md
@@ -323,7 +323,7 @@ export default function PostShow({ post, comments }: Props) {
 
 ポイント:
 
-- `usePage().props.auth?.user` は、Part 2 で `AuthProvider` の `boot()` に配線した共有 auth props を読み取ります — ページはこれを見て、フォームとサインインの案内のどちらを表示するか決めています。
+- `usePage().props.auth?.user` は、Part 2 で見た `AuthProvider` の `boot()` が共有している auth props を読み取ります — ページはこれを見て、フォームとサインインの案内のどちらを表示するか決めています。
 - 成功するとリダイレクトによってページが最新のコメント付きで再描画され、`form.reset()` がテキストエリアをクリアします。
 
 いつものループで締めます: `bun run codegen`（`bun run dev` 中なら自動）で `comments.store` ルートと新しい `Props` をマニフェストに反映し、`bunx guren check` で配線を検証します（`CommentController` のテスト未作成警告が増えているはずです — `check` はちゃんと見ています）。


### PR DESCRIPTION
## Summary

`@guren/cli@2.1.0` (#297) made `guren add auth` / `guren make:auth --install` generate an `AuthProvider` whose `boot()` already registers `shareInertiaProps` for the signed-in user. The docs hadn't caught up:

- The auth guides (ja/en) still told scaffold users to hand-write the shared-props registration in `config/inertia.ts` via `setInertiaSharedProps`.
- The auth tutorials (ja/en) went further and stated the wiring "doesn't exist yet," instructing readers to add `boot()` to `AuthProvider.ts` themselves — describing work the scaffold now does automatically.
- The relationships tutorial (ja/en) back-referenced that now-fictional "wiring step" from Part 2.
- `docs/ja/guides/controllers.md` still showed `setInertiaSharedProps` as the way to share `auth.user`.

## Changes

- **guides/authentication.md** (ja/en): lead with the generated `AuthProvider.boot()` wiring; keep a short note for readers who assembled auth by hand.
- **tutorials/authentication.md** (ja/en): reframe the "wire it up" section as reading the generated file instead of writing it.
- **tutorials/relationships.md** (ja/en): fix the stale Part 2 back-reference.
- **guides/controllers.md** (ja): swap the `auth.user` example for a generic `shareInertiaProps` example (a locale provider) and point to the auth guide for the auth-specific case.
- Everywhere touched, promote `shareInertiaProps` (merges over prior resolvers) to the primary example and demote `setInertiaSharedProps` (replaces the resolver outright) to a caveat.

## Test plan

- [x] `bun run audit:docs` — passes
- [x] `bun run audit:core-first` — passes
- [x] swept edited files for disallowed internal terms (`packages/*`, `citty`, `consola`, `@guren/server`) — clean
- [x] verified `guren add auth` and `guren make:auth --install` both resolve to the same `makeAuth({ install: true })` path (`blueprints.ts`), so both docs entry points describe the same generated file
- [x] verified against `shared.ts` that `shareInertiaProps` merges and `setInertiaSharedProps` replaces, to make sure the new caveat wording is accurate (not order-dependent)