### PR TITLE
chore: add changeset for the scaffolder path-traversal fix

### DIFF
--- a/.changeset/scaffold-path-traversal.md
+++ b/.changeset/scaffold-path-traversal.md
@@ -1,0 +1,36 @@
+---
+"@guren/cli": patch
+"@guren/server": patch
+---
+
+Reject path-traversal names in the `make:*` scaffolders
+
+`make:test` and `make:view` accept a nested name (`make:view posts/Index`,
+`make:test auth/Login`) and interpolated its segments straight into the output
+path. `trimSlashes()` only strips the edges and `split('/').filter(Boolean)`
+keeps `..` — it is non-empty — so a name like `../../../../tmp/evil` wrote
+outside the project, and `--force` overwrote whatever was already there. The
+name is not always something you typed: the MCP tool `guren_make_component`
+declares it as an unvalidated request field, so an agent working from untrusted
+content could reach it.
+
+Nested names are now split with traversal rejected rather than stripped, and
+every `make:*` scaffolder writes through a writer that asserts the resolved path
+stays under the project root. `scaffoldFile()` (behind `make:controller`,
+`make:model`, `make:route`, …) and the batch writer behind `make:feature`,
+`make:auth`, and `make:module` had no containment check at all before this and
+were safe only because `pascalCase()` happens to strip separators — the same
+incidental safety `make:route` did not have.
+
+Only traversal is rejected, so names the filesystem accepts still work:
+`guren make:test "admin/my page"` and `guren make:view "顧客/Index"` behave
+exactly as before. Codegen (`guren codegen --out`) is deliberately exempt, since
+its output directory is yours to choose and may sit outside the project.
+
+`secureCompare()` from `@guren/server/auth` is hardened in the same release.
+`Buffer.from(value, 'hex')` stops decoding at the first invalid pair, so two
+different strings that share an invalid prefix — `'zzzz'` and `'yyyy'`, or
+`'abcz'` and `'abdz'` — decoded to identical buffers and compared **equal**. It
+now rejects input whose hex decode does not round-trip to the original length.
+If you called it with UUIDs, base64 tokens, or anything else that is not strict
+hex, switch to `secureStringCompare()`, which is built for exactly that.


### PR DESCRIPTION
## Summary

Follow-up to #300, which shipped the `make:*` path-traversal fix and the `secureCompare()` hardening **without a changeset**. Without one, `changeset version` won't bump `@guren/cli` or `@guren/server`, so the fix never reaches npm — and scaffolded apps resolve `@guren/*` from the registry, meaning they'd keep installing the vulnerable generator no matter how many releases go out.

Both packages are marked `patch`. The `secureCompare()` narrowing is a behavior change on a public export, but what it previously accepted it compared *incorrectly* — any caller depending on `secureCompare('zzzz', 'yyyy') === true` was depending on the bug — so it's a fix, not a break. The changeset body calls it out explicitly and points affected callers at `secureStringCompare()`.

## Verification

Every behavioral claim in the changeset was checked against the merged code on `main`, not assumed:

```
make:test "admin/my page"  -> tests/admin/MyPage.test.ts        (still works)
make:view "顧客/Index"      -> resources/js/pages/顧客/Index.tsx  (still works)
make:view "../../../../tmp/evil" -> throws "is a path traversal"
secureCompare('zzzz','yyyy') = false    secureCompare('abcz','abdz') = false
secureCompare('abcd','abcd') = true     secureCompare('ABCD','abcd') = true
```

## Note on templates

No template changes are needed, confirmed rather than assumed: no template, plugin, or example references `secureCompare`; the renamed internal writer was never in `@guren/cli`'s export surface (`.`, `./bin`, `./vite`, `./arch` only, and it was never listed in `src/index.ts`); and `create-app` has no dependency on `@guren/cli`. So `audit:starter-template` / `smoke:starter` aren't triggered by this line of work.