### PR TITLE
fix(cli): thread explicit cwd through scaffolders instead of process.chdir

### DIFF
--- a/packages/cli/bunfig.toml
+++ b/packages/cli/bunfig.toml
@@ -1,0 +1,6 @@
+# `bun test` run from this directory (the package's own `test` script) does not
+# inherit the root bunfig, and `scripts/test-packages.ts` only passes --preload
+# on the monorepo-wide run. Without this, the package-local path — the one that
+# exercises the make:* generators most heavily — runs unguarded.
+[test]
+preload = ["../../scripts/test-cwd-guard.ts"]

--- a/packages/cli/src/api-client-types.ts
+++ b/packages/cli/src/api-client-types.ts
@@ -5,8 +5,8 @@
  * a fully typed client interface for consuming Guren APIs from
  * separate frontend applications.
  */
-import { relative, resolve } from 'node:path'
-import { escapeSingleQuoted as escapeSingleQuotes, writeGeneratedFile, type WriterOptions } from './utils'
+import { resolve } from 'node:path'
+import { escapeSingleQuoted as escapeSingleQuotes, resolveAppRoot, writeGeneratedFileIn, type WriterOptions } from './utils'
 import { schemaToTypeString } from './schema-type-extractor'
 
 export interface RouteDefinitionLike {
@@ -38,13 +38,12 @@ export async function generateApiClientTypes(
   definitions: RouteDefinitionLike[],
   options: GenerateApiClientOptions = {},
 ): Promise<{ outputPath: string }> {
-  const appRoot = options.appRoot ? resolve(options.appRoot) : process.cwd()
+  const appRoot = resolveAppRoot(options)
   const outputFile = resolve(appRoot, options.outputFile ?? DEFAULT_OUTPUT_FILE)
 
   const module = buildApiClientContent(definitions)
 
-  const relativeTarget = relative(process.cwd(), outputFile) || outputFile
-  const outputPath = await writeGeneratedFile(relativeTarget, module, { force: options.force })
+  const outputPath = await writeGeneratedFileIn(appRoot, outputFile, module, { force: options.force })
 
   return { outputPath }
 }

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -13,7 +13,7 @@ import { makeNotification } from './make-notification'
 import { makeRoute } from './make-route'
 import { makeView } from './make-view'
 import { addImport, addProvider, detectSchemaDialect, ensureDrizzleImports, ensureMysqlImports, ensureSqliteImports, findClosingDelimiter } from './patch-helpers'
-import { camelCase, pascalCase, writeScaffoldFiles, type WriterOptions } from './utils'
+import { assertCwdUnsupported, camelCase, pascalCase, writeScaffoldFiles, type WriterOptions } from './utils'
 import { readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
@@ -845,5 +845,6 @@ export function getBlueprint(name: string): BlueprintDefinition {
 }
 
 export async function runBlueprint(name: string, options: RunBlueprintOptions = {}): Promise<string[]> {
+  assertCwdUnsupported(options, 'guren new --blueprint')
   return getBlueprint(name).run(options)
 }

--- a/packages/cli/src/channel-types.ts
+++ b/packages/cli/src/channel-types.ts
@@ -2,12 +2,7 @@ import { readdir, readFile } from 'node:fs/promises'
 import { relative, resolve } from 'node:path'
 import { walk, type BabelNode } from './ast-walk'
 import { parseSourceFile } from './parse-cache'
-import {
-  escapeSingleQuoted as esc,
-  escapeTemplateLiteral as escapeTemplatePart,
-  writeGeneratedFile,
-  type WriterOptions,
-} from './utils'
+import { escapeSingleQuoted as esc, escapeTemplateLiteral as escapeTemplatePart, resolveAppRoot, writeGeneratedFileIn, type WriterOptions } from './utils'
 
 export interface GenerateChannelTypesOptions extends WriterOptions {
   appRoot?: string
@@ -35,7 +30,7 @@ const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx'])
 export async function generateChannelTypes(
   options: GenerateChannelTypesOptions = {},
 ): Promise<{ outputPath: string; channels: string[] }> {
-  const appRoot = options.appRoot ? resolve(options.appRoot) : process.cwd()
+  const appRoot = resolveAppRoot(options)
   const sourceDir = resolve(appRoot, options.sourceDir ?? DEFAULT_SOURCE_DIR)
   const outputFile = resolve(appRoot, options.outputFile ?? DEFAULT_OUTPUT_FILE)
 
@@ -45,8 +40,7 @@ export async function generateChannelTypes(
     source: relative(appRoot, sourceDir) || DEFAULT_SOURCE_DIR,
   })
 
-  const relativeTarget = relative(process.cwd(), outputFile) || outputFile
-  const outputPath = await writeGeneratedFile(relativeTarget, module, { force: options.force })
+  const outputPath = await writeGeneratedFileIn(appRoot, outputFile, module, { force: options.force })
 
   return { outputPath, channels }
 }

--- a/packages/cli/src/data-types.ts
+++ b/packages/cli/src/data-types.ts
@@ -7,7 +7,7 @@
  */
 import { readdir, readFile } from 'node:fs/promises'
 import { dirname, extname, relative, resolve } from 'node:path'
-import { writeGeneratedFile, type WriterOptions } from './utils'
+import { resolveAppRoot, writeGeneratedFileIn, type WriterOptions } from './utils'
 import { parseSourceFile } from './parse-cache'
 
 export interface ResourceDefinition {
@@ -33,7 +33,7 @@ const DEFAULT_OUTPUT_FILE = '.guren/data.gen.ts'
 export async function generateDataTypes(
   options: GenerateDataTypesOptions = {},
 ): Promise<{ outputPath: string; definitions: ResourceDefinition[] }> {
-  const appRoot = options.appRoot ? resolve(options.appRoot) : process.cwd()
+  const appRoot = resolveAppRoot(options)
   const resourcesDir = resolve(appRoot, options.resourcesDir ?? DEFAULT_RESOURCES_DIR)
   const outputFile = resolve(appRoot, options.outputFile ?? DEFAULT_OUTPUT_FILE)
   const outputDirectory = dirname(outputFile)
@@ -49,8 +49,7 @@ export async function generateDataTypes(
     source: relative(appRoot, resourcesDir) || DEFAULT_RESOURCES_DIR,
   })
 
-  const relativeTarget = relative(process.cwd(), outputFile) || outputFile
-  const outputPath = await writeGeneratedFile(relativeTarget, module, { force: options.force })
+  const outputPath = await writeGeneratedFileIn(appRoot, outputFile, module, { force: options.force })
 
   return { outputPath, definitions }
 }

--- a/packages/cli/src/deploy.ts
+++ b/packages/cli/src/deploy.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import { basename, resolve } from 'node:path'
-import { kebabCase, writeScaffoldFiles, type WriterOptions } from './utils'
+import { assertCwdUnsupported, kebabCase, writeScaffoldFiles, type WriterOptions } from './utils'
 
 export type DeployTarget = 'docker' | 'fly' | 'railway' | 'all'
 
@@ -156,6 +156,7 @@ function filesForTarget(target: DeployTarget, appName: string, port: number): De
 }
 
 export async function scaffoldDeploy(options: DeployOptions = {}): Promise<string[]> {
+  assertCwdUnsupported(options, 'guren deploy')
   const target = options.target ?? 'docker'
   const port = normalizePort(options.port)
   const appName = sanitizeFlyAppName(options.appName ?? await inferAppName())

--- a/packages/cli/src/make-adr.ts
+++ b/packages/cli/src/make-adr.ts
@@ -4,7 +4,7 @@ import { resolve } from 'node:path'
 import { consola } from 'consola'
 
 import type { WriterOptions } from './utils'
-import { safeModuleName, slugifyProse, writeScaffoldFile } from './utils'
+import { assertCwdUnsupported, safeModuleName, slugifyProse, writeScaffoldFile } from './utils'
 import {
   discoverControllerFiles,
   discoverResourceFiles,
@@ -209,6 +209,7 @@ async function nextSequenceNumber(dir: string): Promise<string> {
 }
 
 export async function makeAdr(title: string, options: MakeAdrOptions = {}): Promise<string> {
+  assertCwdUnsupported(options, 'make:adr')
   const moduleName = options.root ? safeModuleName(options.root) : undefined
   const dir = moduleName ? `modules/${moduleName}/${ADR_DIR}` : ADR_DIR
   const [prefill, actor] = await Promise.all([

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import { dirname, relative, resolve, sep as pathSep } from 'node:path'
 import { consola } from 'consola'
-import { writeScaffoldFiles, type WriterOptions } from './utils'
+import { assertCwdUnsupported, writeScaffoldFiles, type WriterOptions } from './utils'
 import {
   addImport,
   addProvider,
@@ -2202,6 +2202,7 @@ function resolveAuthFeatures(options: MakeAuthOptions): AuthFeatures {
 }
 
 export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]> {
+  assertCwdUnsupported(options, 'make:auth')
   const features = resolveAuthFeatures(options)
   const { includeExtras, includeVerify, includePassword, passwordOnlySignUp, oauthProviders } = features
   const includeOAuth = oauthProviders.length > 0

--- a/packages/cli/src/make-command.ts
+++ b/packages/cli/src/make-command.ts
@@ -59,11 +59,16 @@ function commandSpecifier(fromFile: string, file: string): string {
  * whenever the target file is missing or shaped in a way the patch can't
  * edit — never failing the scaffold itself over it. `guren check` reports
  * whatever stays unregistered.
+ *
+ * Takes only `root`, not the full `MakeCommandOptions`: the patching goes
+ * through `patch-helpers`, which still resolves against `process.cwd()`, so
+ * the signature does not advertise a `cwd` it would ignore. Follow
+ * `readSchemaDialect(cwd = process.cwd())` in that file when threading it.
  */
 export async function registerScaffoldedCommand(
   name: string,
   file: string,
-  options: MakeCommandOptions = {},
+  options: Pick<MakeCommandOptions, 'root'> = {},
 ): Promise<void> {
   const className = ensureSuffix(resourceName(name).className, 'Command')
 

--- a/packages/cli/src/make-feature.ts
+++ b/packages/cli/src/make-feature.ts
@@ -1,5 +1,5 @@
 import { consola } from 'consola'
-import { writeScaffoldFiles, type WriterOptions, pascalCase, camelCase, kebabCase, pagesAccessor, safeModuleName } from './utils'
+import { camelCase, kebabCase, pagesAccessor, pascalCase, safeModuleName, writeScaffoldFiles, writerOptionsFrom, type WriterOptions } from './utils'
 import { pluralize } from './inflect'
 import { makeModel } from './make-model'
 import { makePolicy } from './make-policy'
@@ -29,7 +29,7 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
   const variableName = singular.charAt(0).toLowerCase() + singular.slice(1)
   const withAuth = !options.publicAccess
   const withPolicy = Boolean(options.withPolicy)
-  const writerOptions: WriterOptions = { force: Boolean(options.force), root: options.root }
+  const writerOptions: WriterOptions = writerOptionsFrom(options)
 
   // `--module <name>` moves app/ output under modules/<name>/ (handled by
   // scaffoldFile for makeModel/makePolicy/makeTest below), but pages are

--- a/packages/cli/src/make-module.ts
+++ b/packages/cli/src/make-module.ts
@@ -1,5 +1,5 @@
 import { consola } from 'consola'
-import { camelCase, pascalCase, relativeImportPath, safeModuleName, writeScaffoldFiles, type WriterOptions } from './utils'
+import { assertCwdUnsupported, camelCase, pascalCase, relativeImportPath, safeModuleName, writeScaffoldFiles, type WriterOptions } from './utils'
 import { addImport, addToArrayOption } from './patch-helpers'
 import { fileExists } from './discovery'
 
@@ -20,6 +20,7 @@ export interface MakeModuleResult {
  * hand-edited app.ts.
  */
 export async function makeModule(name: string, options: WriterOptions = {}): Promise<MakeModuleResult> {
+  assertCwdUnsupported(options, 'make:module')
   const moduleName = safeModuleName(name)
   const pascalName = pascalCase(name)
   const camelName = camelCase(name)

--- a/packages/cli/src/make-seeder.ts
+++ b/packages/cli/src/make-seeder.ts
@@ -14,7 +14,7 @@ export default defineSeeder(async ({ db }: ${context}) => {
 }
 
 export async function makeSeeder(name: string, options: WriterOptions = {}): Promise<string> {
-  const context = seederContextTypes[await readSchemaDialect()]
+  const context = seederContextTypes[await readSchemaDialect(options.cwd)]
 
   return scaffoldFile(name, {
     dir: DB_ARTIFACT_DIRS.Seeder,

--- a/packages/cli/src/make-test.ts
+++ b/packages/cli/src/make-test.ts
@@ -79,7 +79,8 @@ export async function makeTest(name: string, options: MakeTestOptions = {}): Pro
   // Validate before `detectRunner()` — it stats up to seven files, and every
   // one of them is wasted when the name turns out to be a traversal.
   const segments = safePathSegments(trimmed, 'test name')
-  const runner = options.runner ?? (await detectRunner())
+  // Detected in the project being scaffolded into, not the process directory.
+  const runner = options.runner ?? (await detectRunner(options.cwd))
 
   const baseSegment = segments.pop()!
   const baseName = baseSegment.replace(/\.(test\.)?(t|j)sx?$/giu, '')

--- a/packages/cli/src/openapi-generate.ts
+++ b/packages/cli/src/openapi-generate.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path'
 import { loadRouteDefinitions } from './load-routes'
 import { readIfExists } from './discovery'
-import type { WriterOptions } from './utils'
+import { resolveAppRoot, type WriterOptions } from './utils'
 
 export interface GenerateOpenApiSpecOptions extends WriterOptions {
   routesFile?: string
@@ -47,7 +47,7 @@ export async function generateOpenApiSpec(
     importer?: () => Promise<OpenApiModule>
   } = {},
 ): Promise<GenerateOpenApiSpecResult> {
-  const appRoot = options.appRoot ? resolve(options.appRoot) : process.cwd()
+  const appRoot = resolveAppRoot(options)
   const routesFile = resolve(appRoot, options.routesFile ?? DEFAULT_ROUTES_FILE)
   const definitions = await loadRouteDefinitions(routesFile, appRoot)
 

--- a/packages/cli/src/pages-types.ts
+++ b/packages/cli/src/pages-types.ts
@@ -1,6 +1,6 @@
 import { readdir } from 'node:fs/promises'
 import { dirname, extname, relative, resolve } from 'node:path'
-import { writeGeneratedFile, type WriterOptions } from './utils'
+import { resolveAppRoot, writeGeneratedFileIn, type WriterOptions } from './utils'
 import { extractPageProps, type ExtractedPageProps } from './page-props-extractor'
 
 export type PageDefinition = {
@@ -35,7 +35,7 @@ export async function appEmitsPageManifest(appRoot: string, pagesDir?: string): 
 export async function generatePageTypes(
   options: GeneratePageTypesOptions = {},
 ): Promise<{ outputPath: string; definitions: PageDefinition[] }> {
-  const appRoot = options.appRoot ? resolve(options.appRoot) : process.cwd()
+  const appRoot = resolveAppRoot(options)
   const pagesDir = resolve(appRoot, options.pagesDir ?? DEFAULT_PAGES_DIR)
   const outputFile = resolve(appRoot, options.outputFile ?? DEFAULT_OUTPUT_FILE)
   const definitions = await collectPageDefinitions(pagesDir)
@@ -68,8 +68,7 @@ export async function generatePageTypes(
     propsMap,
   })
 
-  const relativeTarget = relative(process.cwd(), outputFile) || outputFile
-  const outputPath = await writeGeneratedFile(relativeTarget, module, { force: options.force })
+  const outputPath = await writeGeneratedFileIn(appRoot, outputFile, module, { force: options.force })
 
   return { outputPath, definitions }
 }

--- a/packages/cli/src/plugin.ts
+++ b/packages/cli/src/plugin.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import type { WriterOptions } from './utils'
-import { runCommand } from './utils'
+import { assertCwdUnsupported, runCommand } from './utils'
 import { addImport, addProvider } from './patch-helpers'
 import {
   applyEnvEntries,
@@ -109,6 +109,7 @@ async function hasDependency(packageName: string): Promise<boolean> {
 }
 
 export async function installPlugin(options: InstallPluginOptions): Promise<PluginInstallMessage[]> {
+  assertCwdUnsupported(options, 'guren plugin')
   const packageName = options.packageName.trim()
   if (!packageName) {
     throw new Error('Plugin package name is required.')

--- a/packages/cli/src/routes-types.ts
+++ b/packages/cli/src/routes-types.ts
@@ -1,10 +1,5 @@
 import { relative, resolve } from 'node:path'
-import {
-  escapeSingleQuoted as escapeSingleQuotes,
-  escapeTemplateLiteral as escapeTemplateSegment,
-  writeGeneratedFile,
-  type WriterOptions,
-} from './utils'
+import { escapeSingleQuoted as escapeSingleQuotes, escapeTemplateLiteral as escapeTemplateSegment, resolveAppRoot, writeGeneratedFileIn, type WriterOptions } from './utils'
 import { loadRouteDefinitions } from './load-routes'
 import {
   DECLARATION_MODULE_AUGMENTATION,
@@ -33,7 +28,7 @@ const DEFAULT_RUNTIME_OUTPUT_FILE = '.guren/routes.gen.ts'
 export async function generateRouteTypes(
   options: GenerateRouteTypesOptions = {},
 ): Promise<{ outputPath: string; runtimeOutputPath: string; definitions: RouteDefinition[] }> {
-  const appRoot = options.appRoot ? resolve(options.appRoot) : process.cwd()
+  const appRoot = resolveAppRoot(options)
   const routesFile = resolve(appRoot, options.routesFile ?? DEFAULT_ROUTES_FILE)
   const outputFile = resolve(appRoot, options.outputFile ?? DEFAULT_OUTPUT_FILE)
   const runtimeOutputFile = resolve(appRoot, options.runtimeOutputFile ?? DEFAULT_RUNTIME_OUTPUT_FILE)
@@ -50,10 +45,8 @@ export async function generateRouteTypes(
     source: relative(appRoot, routesFile) || DEFAULT_ROUTES_FILE,
   })
 
-  const relativeTarget = relative(process.cwd(), outputFile) || outputFile
-  const relativeRuntimeTarget = relative(process.cwd(), runtimeOutputFile) || runtimeOutputFile
-  const outputPath = await writeGeneratedFile(relativeTarget, declaration, { force: options.force })
-  const runtimeOutputPath = await writeGeneratedFile(relativeRuntimeTarget, runtimeModule, { force: options.force })
+  const outputPath = await writeGeneratedFileIn(appRoot, outputFile, declaration, { force: options.force })
+  const runtimeOutputPath = await writeGeneratedFileIn(appRoot, runtimeOutputFile, runtimeModule, { force: options.force })
 
   return {
     outputPath,

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -5,6 +5,17 @@ import { dirname, relative, resolve, sep as pathSep } from 'node:path'
 export interface WriterOptions {
   force?: boolean
   /**
+   * Project root a generator's relative output path resolves against.
+   * Defaults to `process.cwd()`, which is what the one-shot CLI wants.
+   *
+   * Callers that are not a one-shot process name the directory instead of
+   * steering into it: `process.cwd()` is per-process state, so `chdir` is
+   * never a local choice. `guren mcp` serves a workspace from a long-lived
+   * server where it would race concurrent requests, and Bun runs every test
+   * file in one process where it relocates all the others.
+   */
+  cwd?: string
+  /**
    * When set (via `--module <name>`), prefixes a generator's output
    * directory with `modules/<kebab-case root>/` instead of writing to the
    * project root — e.g. `app/Http/Controllers` becomes
@@ -73,9 +84,15 @@ export async function runCommand(
  * out. Codegen is the reason the check cannot simply live in `writeFileSafe`:
  * `guren codegen --out` takes a caller-supplied directory that may
  * legitimately sit outside `process.cwd()`.
+ *
+ * `cwd` has to be the same root the write itself resolves against — both are
+ * taken from one `WriterOptions` in `writeScaffoldFile`. Checking containment
+ * against one directory while writing relative to another is not a weaker
+ * guard, it is no guard at all: every path sits inside a root that nothing is
+ * ever written to.
  */
-export function assertScaffoldPath(relativePath: string): void {
-  const root = process.cwd()
+export function assertScaffoldPath(relativePath: string, cwd: string = process.cwd()): void {
+  const root = resolve(cwd)
   const fullPath = resolve(root, relativePath)
 
   if (fullPath !== root && !fullPath.startsWith(root + pathSep)) {
@@ -85,18 +102,31 @@ export function assertScaffoldPath(relativePath: string): void {
   }
 }
 
+/**
+ * Resolves the root a writer works against, once.
+ *
+ * Callers must pin this before checking a path and reuse the result for the
+ * write, rather than reading `options.cwd` twice: with `cwd` omitted or
+ * relative, the second read can land on a different directory than the one
+ * that was checked, and the containment check then guarantees nothing.
+ */
+function writeRoot(options: WriterOptions): string {
+  return resolve(options.cwd ?? process.cwd())
+}
+
 /** `writeFileSafe` for generated scaffolds: containment-checked. */
 export async function writeScaffoldFile(
   relativePath: string,
   contents: string,
   options: WriterOptions = {},
 ): Promise<string> {
-  assertScaffoldPath(relativePath)
-  return writeFileSafe(relativePath, contents, options)
+  const cwd = writeRoot(options)
+  assertScaffoldPath(relativePath, cwd)
+  return writeFileSafe(relativePath, contents, { ...options, cwd })
 }
 
 export async function writeFileSafe(relativePath: string, contents: string, options: WriterOptions = {}): Promise<string> {
-  const fullPath = resolve(process.cwd(), relativePath)
+  const fullPath = resolve(options.cwd ?? process.cwd(), relativePath)
 
   await mkdir(dirname(fullPath), { recursive: true })
   try {
@@ -132,7 +162,7 @@ export async function writeGeneratedFile(
   contents: string,
   options: WriterOptions = {},
 ): Promise<string> {
-  const fullPath = resolve(process.cwd(), relativePath)
+  const fullPath = resolve(options.cwd ?? process.cwd(), relativePath)
 
   try {
     if ((await readFile(fullPath, 'utf8')) === contents) {
@@ -147,19 +177,78 @@ export async function writeGeneratedFile(
   return writeFileSafe(relativePath, contents, options)
 }
 
+/**
+ * `writeGeneratedFile` for an artifact whose absolute path was already built
+ * from `appRoot`. Keeps the "already exists" message project-relative while
+ * pinning the write to the same root the path came from.
+ */
+export async function writeGeneratedFileIn(
+  appRoot: string,
+  outputFile: string,
+  contents: string,
+  options: WriterOptions = {},
+): Promise<string> {
+  const root = resolve(appRoot)
+  return writeGeneratedFile(relative(root, outputFile) || outputFile, contents, {
+    ...options,
+    cwd: root,
+  })
+}
+
+/**
+ * The project root a command works in: an explicit `appRoot`, else the `cwd`
+ * every `WriterOptions` carries, else the process directory.
+ */
+export function resolveAppRoot(options: { appRoot?: string } & WriterOptions): string {
+  return resolve(options.appRoot ?? options.cwd ?? process.cwd())
+}
+
+/**
+ * Copies the whole of `WriterOptions` across when a command builds a fresh
+ * options bag for a generator it composes.
+ *
+ * Rebuilding the bag field by field is how `cwd` gets silently dropped and the
+ * generator writes to the process directory instead of the requested one; this
+ * keeps the field list in one place so a new option reaches every caller.
+ */
+export function writerOptionsFrom(options: WriterOptions): WriterOptions {
+  return { force: Boolean(options.force), root: options.root, cwd: options.cwd }
+}
+
+/**
+ * Refuses an explicit `cwd` on a command that cannot honour it yet.
+ *
+ * `cwd` rides on the shared `WriterOptions`, so commands inherit the field
+ * long before they thread it through every path they touch. Those commands
+ * write some files relative to `cwd` and others relative to the process
+ * directory, which splits one scaffold across two projects. Until each is
+ * migrated, passing `cwd` fails loudly rather than half-working. Omitting it
+ * is unaffected, so no existing caller changes behaviour.
+ */
+export function assertCwdUnsupported(options: WriterOptions, command: string): void {
+  if (options.cwd === undefined) return
+  throw new Error(
+    `${command} does not support an explicit cwd yet — it still resolves part of its work against `
+    + `the process directory, so honouring cwd here would scaffold into two projects at once. `
+    + `Run it with the process working directory set to the target project instead.`,
+  )
+}
+
 /** `writeScaffoldFile` over a batch — every path is checked before any write. */
 export async function writeScaffoldFiles(
   entries: Array<{ path: string; contents: string }>,
   options: WriterOptions = {},
 ): Promise<string[]> {
+  const cwd = writeRoot(options)
+
   for (const entry of entries) {
-    assertScaffoldPath(entry.path)
+    assertScaffoldPath(entry.path, cwd)
   }
 
   const created: string[] = []
 
   for (const entry of entries) {
-    created.push(await writeFileSafe(entry.path, entry.contents, options))
+    created.push(await writeFileSafe(entry.path, entry.contents, { ...options, cwd }))
   }
 
   return created

--- a/packages/cli/tests/codegen-app-root.test.ts
+++ b/packages/cli/tests/codegen-app-root.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { generateChannelTypes } from '../src/channel-types'
+import { generateDataTypes } from '../src/data-types'
+import { generatePageTypes } from '../src/pages-types'
+import { generateRouteTypes } from '../src/routes-types'
+import { makeController } from '../src/make-controller'
+import { makeModel } from '../src/make-model'
+import { makeRoute } from '../src/make-route'
+import { makeTest } from '../src/make-test'
+import { makeView } from '../src/make-view'
+import { writeWorkspaceFiles } from './helpers'
+
+/**
+ * The codegen generators have to honour `appRoot` on its own — without the
+ * caller also steering `process.cwd()` into the project.
+ *
+ * `guren mcp` is the caller that needs it: it serves a workspace from a
+ * long-lived server, so it cannot chdir per request. Every other generator
+ * test uses `createTempWorkspace`, which chdir()s — there `appRoot` and
+ * `process.cwd()` are the same directory, so a generator that ignored
+ * `appRoot` would still pass. These deliberately do not chdir.
+ */
+describe('codegen resolves against appRoot rather than process.cwd()', () => {
+  let appRoot: string
+  let cwdBefore: string
+
+  beforeEach(async () => {
+    appRoot = await mkdtemp(join(tmpdir(), 'guren-cli-codegen-approot-'))
+    cwdBefore = process.cwd()
+  })
+
+  afterEach(async () => {
+    expect(process.cwd()).toBe(cwdBefore)
+    await rm(appRoot, { recursive: true, force: true })
+  })
+
+  it('writes page types under appRoot', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      'resources/js/pages/posts/Index.tsx': 'export default function Index() { return null }\n',
+    })
+
+    const { outputPath } = await generatePageTypes({ appRoot, force: true, extractProps: false })
+
+    expect(outputPath).toBe(join(appRoot, '.guren/pages.gen.ts'))
+    expect(existsSync(join(appRoot, '.guren/pages.gen.ts'))).toBe(true)
+  })
+
+  it('writes data types under appRoot', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      'app/Http/Resources/PostResource.ts':
+        "import { JsonResource } from '@guren/core'\n\n"
+        + 'export class PostResource extends JsonResource {\n'
+        + '  toArray(): { id: number } {\n'
+        + '    return { id: 1 }\n'
+        + '  }\n'
+        + '}\n',
+    })
+
+    const { outputPath } = await generateDataTypes({ appRoot, force: true })
+
+    expect(outputPath).toBe(join(appRoot, '.guren/data.gen.ts'))
+  })
+
+  it('writes channel types under appRoot', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      'app/Broadcasting/OrderChannel.ts':
+        "import { Channel } from '@guren/core'\n\nexport class OrderChannel extends Channel {}\n",
+    })
+
+    const { outputPath } = await generateChannelTypes({ appRoot, force: true })
+
+    expect(outputPath).toBe(join(appRoot, '.guren/channels.gen.ts'))
+  })
+
+  it('writes route types under appRoot', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      'routes/web.ts':
+        "import type { Router } from '@guren/core'\n\n"
+        + 'export function registerWebRoutes(router: Router): void {\n'
+        + "  router.get('/posts', [Object as never, 'index']).name('posts.index')\n"
+        + '}\n',
+    })
+
+    // Route generation emits two artifacts; `outputPath` names the declaration
+    // file, and the runtime manifest lands beside it under `.guren/`.
+    const { outputPath } = await generateRouteTypes({ appRoot, force: true })
+
+    expect(outputPath).toBe(join(appRoot, 'types/generated/routes.d.ts'))
+    expect(existsSync(join(appRoot, '.guren/routes.gen.ts'))).toBe(true)
+  })
+
+  it('leaves no generated output in the directory the process is actually in', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      'resources/js/pages/posts/Index.tsx': 'export default function Index() { return null }\n',
+    })
+
+    await generatePageTypes({ appRoot, force: true, extractProps: false })
+
+    expect(existsSync(join(process.cwd(), '.guren/pages.gen.ts'))).toBe(false)
+  })
+})
+
+/**
+ * The five scaffolders `guren mcp`'s `guren_make_component` dispatches to.
+ * Their own test files chdir(), so nothing else covers them being handed an
+ * explicit `cwd` — the contract the MCP handler relies on.
+ */
+describe('single-component scaffolders honour an explicit cwd', () => {
+  let root: string
+  let cwdBefore: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'guren-cli-scaffold-cwd-'))
+    cwdBefore = process.cwd()
+  })
+
+  afterEach(async () => {
+    expect(process.cwd()).toBe(cwdBefore)
+    await rm(root, { recursive: true, force: true })
+  })
+
+  const cases: Array<[string, (name: string, opts: { cwd: string }) => Promise<string>, string]> = [
+    ['makeController', makeController, 'app/Http/Controllers/ProbeController.ts'],
+    ['makeModel', makeModel, 'app/Models/Probe.ts'],
+    ['makeView', makeView, 'resources/js/pages/Probe.tsx'],
+    ['makeRoute', makeRoute, 'routes/probe.ts'],
+  ]
+
+  for (const [label, scaffold, expected] of cases) {
+    it(`${label} writes under the given cwd`, async () => {
+      const written = await scaffold('Probe', { cwd: root })
+
+      expect(written).toBe(join(root, expected))
+      expect(existsSync(join(process.cwd(), expected))).toBe(false)
+    })
+  }
+
+  it('makeTest detects the runner in the target project, not the process cwd', async () => {
+    // The fixture has to disagree with the directory the process is in, or the
+    // assertion proves nothing. This monorepo's own package.json lists vitest,
+    // so `detectRunner()` reading process.cwd() answers "vitest"; a project
+    // with neither a vitest config nor the dependency must get bun:test.
+    await writeWorkspaceFiles(root, { 'package.json': '{ "name": "probe-app" }\n' })
+
+    const written = await makeTest('Probe', { cwd: root })
+
+    expect(written).toBe(join(root, 'tests/Probe.test.ts'))
+    const contents = await readFile(written, 'utf8')
+    expect(contents).toContain("from 'bun:test'")
+    expect(contents).not.toContain("from 'vitest'")
+  })
+})

--- a/packages/cli/tests/make-commands.test.ts
+++ b/packages/cli/tests/make-commands.test.ts
@@ -2,23 +2,24 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import { makeChannel } from '../src/make-channel'
-import { makeCommand } from '../src/make-command'
-import { makeEvent } from '../src/make-event'
-import { makeException } from '../src/make-exception'
-import { makeFactory } from '../src/make-factory'
-import { makeJob } from '../src/make-job'
-import { makeListener } from '../src/make-listener'
-import { makeMail } from '../src/make-mail'
-import { makeMiddleware } from '../src/make-middleware'
-import { makeNotification } from '../src/make-notification'
-import { makePolicy } from '../src/make-policy'
-import { makeProvider } from '../src/make-provider'
-import { makeResource } from '../src/make-resource'
-import { makeSeeder } from '../src/make-seeder'
-import { makeValidator } from '../src/make-validator'
-import { makeFeature } from '../src/make-feature'
+import { makeChannel as scaffoldChannel } from '../src/make-channel'
+import { makeCommand as scaffoldCommand } from '../src/make-command'
+import { makeEvent as scaffoldEvent } from '../src/make-event'
+import { makeException as scaffoldException } from '../src/make-exception'
+import { makeFactory as scaffoldFactory } from '../src/make-factory'
+import { makeJob as scaffoldJob } from '../src/make-job'
+import { makeListener as scaffoldListener } from '../src/make-listener'
+import { makeMail as scaffoldMail } from '../src/make-mail'
+import { makeMiddleware as scaffoldMiddleware } from '../src/make-middleware'
+import { makeNotification as scaffoldNotification } from '../src/make-notification'
+import { makePolicy as scaffoldPolicy } from '../src/make-policy'
+import { makeProvider as scaffoldProvider } from '../src/make-provider'
+import { makeResource as scaffoldResource } from '../src/make-resource'
+import { makeSeeder as scaffoldSeeder } from '../src/make-seeder'
+import { makeValidator as scaffoldValidator } from '../src/make-validator'
+import { makeFeature as scaffoldFeature } from '../src/make-feature'
 import { parseFieldsString } from '../src/fields'
+import type { WriterOptions } from '../src/utils'
 
 // A fixed, predictable path under the shared OS temp dir let another process
 // pre-plant a symlink there before a test wrote through it. mkdtempSync's
@@ -26,15 +27,58 @@ import { parseFieldsString } from '../src/fields'
 // unguessable, so it has to be created fresh per test rather than reused.
 let TEST_DIR: string
 
+/**
+ * Binds a generator to the per-test workspace, so no test has to chdir() the
+ * shared process, and fails if the generator ignores the directory it was
+ * given.
+ *
+ * The check is what makes the assertions below mean anything. They match on
+ * the returned path (`toContain('app/Jobs/SendEmailJob.ts')`) and on the file
+ * existing — both of which still hold when `cwd` is dropped, because the
+ * generator really did write that file, just into the checkout instead. Only
+ * comparing against the workspace root can tell the two apart.
+ */
+function inWorkspace<O extends WriterOptions, R>(
+  scaffold: (name: string, options?: O) => Promise<R>,
+): (name: string, options?: O) => Promise<R> {
+  return async (name, options) => {
+    const result = await scaffold(name, { ...options, cwd: TEST_DIR } as O)
+
+    for (const written of [result].flat()) {
+      if (typeof written === 'string' && !written.startsWith(TEST_DIR + path.sep)) {
+        throw new Error(
+          `generator ignored cwd and wrote outside the workspace: ${written} (expected under ${TEST_DIR})`,
+        )
+      }
+    }
+
+    return result
+  }
+}
+
+const makeChannel = inWorkspace(scaffoldChannel)
+const makeCommand = inWorkspace(scaffoldCommand)
+const makeEvent = inWorkspace(scaffoldEvent)
+const makeException = inWorkspace(scaffoldException)
+const makeFactory = inWorkspace(scaffoldFactory)
+const makeJob = inWorkspace(scaffoldJob)
+const makeListener = inWorkspace(scaffoldListener)
+const makeMail = inWorkspace(scaffoldMail)
+const makeMiddleware = inWorkspace(scaffoldMiddleware)
+const makeNotification = inWorkspace(scaffoldNotification)
+const makePolicy = inWorkspace(scaffoldPolicy)
+const makeProvider = inWorkspace(scaffoldProvider)
+const makeResource = inWorkspace(scaffoldResource)
+const makeSeeder = inWorkspace(scaffoldSeeder)
+const makeValidator = inWorkspace(scaffoldValidator)
+const makeFeature = inWorkspace(scaffoldFeature)
+
 describe('CLI make:* commands', () => {
   beforeEach(() => {
     TEST_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'guren-cli-test-'))
-    process.chdir(TEST_DIR)
   })
 
   afterEach(() => {
-    // Restore working directory
-    process.chdir('/')
     if (fs.existsSync(TEST_DIR)) {
       fs.rmSync(TEST_DIR, { recursive: true })
     }

--- a/packages/cli/tests/utils.test.ts
+++ b/packages/cli/tests/utils.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { createTempWorkspace } from './helpers'
-import { assertScaffoldPath, safePathSegments } from '../src/utils'
+import { assertScaffoldPath, safePathSegments, writeScaffoldFile } from '../src/utils'
 
 describe('assertScaffoldPath', () => {
   it('accepts a nested path inside the project root', () => {
@@ -18,10 +21,60 @@ describe('assertScaffoldPath', () => {
     const workspace = await createTempWorkspace('guren-cli-scaffold-sibling-')
     try {
       const sibling = `../${workspace.dir.split('/').pop()}-evil/x.ts`
-      expect(() => assertScaffoldPath(sibling)).toThrow('resolves outside the project root')
+      expect(() => assertScaffoldPath(sibling, workspace.dir)).toThrow(
+        'resolves outside the project root',
+      )
     } finally {
       await workspace.cleanup()
     }
+  })
+
+  // The containment root has to be the directory the write resolves against.
+  // These cover the failure mode where `cwd` reaches the writer but not the
+  // guard: the guard would then vet paths against process.cwd() while the file
+  // lands under `cwd`, so nothing it approves has actually been checked.
+  describe('with an explicit cwd', () => {
+    let root: string
+
+    beforeEach(async () => {
+      root = await mkdtemp(join(tmpdir(), 'guren-cli-scaffold-cwd-'))
+    })
+
+    afterEach(async () => {
+      await rm(root, { recursive: true, force: true })
+    })
+
+    it('still refuses a path that escapes the given root', () => {
+      expect(() => assertScaffoldPath('tests/../../../../tmp/evil.ts', root)).toThrow(
+        'resolves outside the project root',
+      )
+      expect(() => assertScaffoldPath('/tmp/evil.ts', root)).toThrow(
+        'resolves outside the project root',
+      )
+    })
+
+    it('judges containment against the given root, not process.cwd()', () => {
+      // Inside the process's own directory, so a guard still reading
+      // process.cwd() would wave this through — but it escapes `root`, which
+      // is where the write would land.
+      const escapesRootButNotCwd = `${process.cwd()}/escaped.ts`
+
+      expect(() => assertScaffoldPath(escapesRootButNotCwd, root)).toThrow(
+        'resolves outside the project root',
+      )
+    })
+
+    it('refuses to write outside the given root', async () => {
+      await expect(
+        writeScaffoldFile('../escaped.ts', 'export {}\n', { cwd: root }),
+      ).rejects.toThrow('resolves outside the project root')
+    })
+
+    it('writes a contained path under the given root rather than process.cwd()', async () => {
+      const written = await writeScaffoldFile('app/Jobs/Contained.ts', 'export {}\n', { cwd: root })
+
+      expect(written).toBe(join(root, 'app/Jobs/Contained.ts'))
+    })
   })
 })
 

--- a/packages/server/src/mcp/create-mcp-server.ts
+++ b/packages/server/src/mcp/create-mcp-server.ts
@@ -2,14 +2,23 @@ import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mc
 import { z } from 'zod'
 
 /**
- * Options the `.guren/*.gen.ts` generators are called with. Only `force`
- * reaches them — they resolve every path against the process cwd, which the
- * codegen tool sets before calling. `cwd` rides along to name the project the
- * call is for.
+ * Options the `.guren/*.gen.ts` generators are called with. `cwd` is the
+ * project they resolve every output path against; nothing here changes
+ * `process.cwd()`, which is process-wide and shared by concurrent requests.
  */
 export interface CodegenOptions {
   cwd: string
   force?: boolean
+}
+
+/**
+ * What every scaffolder takes. `cwd` names the project the scaffold belongs
+ * to, for the same reason: this server handles requests for a workspace
+ * without a per-request `process.cwd()` to fall back on.
+ */
+export interface ScaffoldOptions {
+  force?: boolean
+  cwd?: string
 }
 
 /**
@@ -71,13 +80,13 @@ export interface GurenCliApi {
   suggestNextSteps(opts: { cwd: string }): Promise<unknown>
   makeFeature(
     name: string,
-    opts: { fields?: string; withTest?: boolean; force?: boolean },
+    opts: ScaffoldOptions & { fields?: string; withTest?: boolean },
   ): Promise<string[]>
-  makeController(name: string, opts: { force?: boolean }): Promise<string | string[]>
-  makeModel(name: string, opts: { force?: boolean }): Promise<string | string[]>
-  makeView(name: string, opts: { force?: boolean }): Promise<string | string[]>
-  makeTest(name: string, opts: { force?: boolean }): Promise<string | string[]>
-  makeRoute(name: string, opts: { force?: boolean }): Promise<string | string[]>
+  makeController(name: string, opts: ScaffoldOptions): Promise<string | string[]>
+  makeModel(name: string, opts: ScaffoldOptions): Promise<string | string[]>
+  makeView(name: string, opts: ScaffoldOptions): Promise<string | string[]>
+  makeTest(name: string, opts: ScaffoldOptions): Promise<string | string[]>
+  makeRoute(name: string, opts: ScaffoldOptions): Promise<string | string[]>
   generateRouteTypes(opts: CodegenOptions): Promise<CodegenResult | void>
   generatePageTypes(opts: CodegenOptions): Promise<CodegenResult | void>
   generateDataTypes(opts: CodegenOptions): Promise<CodegenResult | void>
@@ -257,15 +266,9 @@ export function createMcpServer(options: CreateMcpServerOptions): McpServer {
       force: z.boolean().default(false).describe('Overwrite existing files'),
     },
     async ({ name, fields, withTest, force }) => {
-      const originalCwd = process.cwd()
-      try {
-        process.chdir(cwd)
-        const createdFiles = await cli.makeFeature(name, { fields, withTest, force })
-        return {
-          content: [{ type: 'text', text: JSON.stringify({ created: createdFiles }, null, 2) }],
-        }
-      } finally {
-        process.chdir(originalCwd)
+      const createdFiles = await cli.makeFeature(name, { fields, withTest, force, cwd })
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ created: createdFiles }, null, 2) }],
       }
     },
   )
@@ -299,40 +302,34 @@ export function createMcpServer(options: CreateMcpServerOptions): McpServer {
       force: z.boolean().default(false).describe('Overwrite existing files'),
     },
     async ({ type, name, force }) => {
-      const originalCwd = process.cwd()
-      try {
-        process.chdir(cwd)
-        const makers: Record<
-          string,
-          ((name: string, opts: { force?: boolean }) => Promise<string | string[]>) | undefined
-        > = {
-          controller: cli.makeController,
-          model: cli.makeModel,
-          view: cli.makeView,
-          test: cli.makeTest,
-          route: cli.makeRoute,
-        }
+      const makers: Record<
+        string,
+        ((name: string, opts: ScaffoldOptions) => Promise<string | string[]>) | undefined
+      > = {
+        controller: cli.makeController,
+        model: cli.makeModel,
+        view: cli.makeView,
+        test: cli.makeTest,
+        route: cli.makeRoute,
+      }
 
-        const maker = makers[type]
-        if (!maker) {
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: `Component type "${type}" is not yet supported via MCP. Use the CLI: bunx guren make:${type} ${name}`,
-              },
-            ],
-            isError: true,
-          }
-        }
-
-        const result = await maker(name, { force })
-        const created = Array.isArray(result) ? result : [result]
+      const maker = makers[type]
+      if (!maker) {
         return {
-          content: [{ type: 'text', text: JSON.stringify({ created }, null, 2) }],
+          content: [
+            {
+              type: 'text' as const,
+              text: `Component type "${type}" is not yet supported via MCP. Use the CLI: bunx guren make:${type} ${name}`,
+            },
+          ],
+          isError: true,
         }
-      } finally {
-        process.chdir(originalCwd)
+      }
+
+      const result = await maker(name, { force, cwd })
+      const created = Array.isArray(result) ? result : [result]
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ created }, null, 2) }],
       }
     },
   )
@@ -342,74 +339,67 @@ export function createMcpServer(options: CreateMcpServerOptions): McpServer {
     'Generate the type-safe route, page, data, and channel manifests plus the API client (.guren/ and types/generated/).',
     {},
     async () => {
-      const originalCwd = process.cwd()
-      try {
-        process.chdir(cwd)
+      // `force` matches what `guren codegen` passes: every artifact below is
+      // generated output, so overwriting it is the whole point — without it
+      // the writer rejects each one as "already exists" from the second run
+      // onwards.
+      const options: CodegenOptions = { cwd, force: true }
 
-        // `force` matches what `guren codegen` passes: every artifact below is
-        // generated output, so overwriting it is the whole point — without it
-        // the writer rejects each one as "already exists" from the second run
-        // onwards.
-        const options: CodegenOptions = { cwd, force: true }
+      const generated: string[] = []
+      const skipped: Array<{ artifacts: string[]; reason: string }> = []
+      let failed = false
 
-        const generated: string[] = []
-        const skipped: Array<{ artifacts: string[]; reason: string }> = []
-        let failed = false
-
-        /**
-         * Runs one generator and files its artifacts under `generated` or
-         * `skipped`. A generator that returns an empty `outputPath` had
-         * nothing to describe, which is a normal shape for a project rather
-         * than a failure; a throw is the opposite, and is what `isError`
-         * reports on.
-         */
-        const run = async (
-          artifacts: string[],
-          generate: () => Promise<CodegenResult | void>,
-        ): Promise<CodegenResult | void> => {
-          try {
-            const result = await generate()
-            if (result?.outputPath === '') {
-              skipped.push({ artifacts, reason: 'nothing to generate' })
-            } else {
-              generated.push(...artifacts)
-            }
-            return result
-          } catch (error) {
-            failed = true
-            skipped.push({
-              artifacts,
-              reason: error instanceof Error ? error.message : String(error),
-            })
+      /**
+       * Runs one generator and files its artifacts under `generated` or
+       * `skipped`. A generator that returns an empty `outputPath` had
+       * nothing to describe, which is a normal shape for a project rather
+       * than a failure; a throw is the opposite, and is what `isError`
+       * reports on.
+       */
+      const run = async (
+        artifacts: string[],
+        generate: () => Promise<CodegenResult | void>,
+      ): Promise<CodegenResult | void> => {
+        try {
+          const result = await generate()
+          if (result?.outputPath === '') {
+            skipped.push({ artifacts, reason: 'nothing to generate' })
+          } else {
+            generated.push(...artifacts)
           }
+          return result
+        } catch (error) {
+          failed = true
+          skipped.push({
+            artifacts,
+            reason: error instanceof Error ? error.message : String(error),
+          })
         }
+      }
 
-        // Ordered as `guren codegen` orders it, and for the same reason at the
-        // end: the API client is built from the route manifest, so it can only
-        // run once routes has produced one.
-        const routes = await run(
-          ['.guren/routes.gen.ts', 'types/generated/routes.d.ts'],
-          () => cli.generateRouteTypes(options),
-        )
-        await run(['.guren/pages.gen.ts'], () => cli.generatePageTypes(options))
-        await run(['.guren/data.gen.ts'], () => cli.generateDataTypes(options))
-        await run(['.guren/channels.gen.ts'], () => cli.generateChannelTypes(options))
-        await run(['.guren/api-client.gen.ts'], () => {
-          if (!routes?.definitions) {
-            throw new Error('route generation produced no manifest to build a client from')
-          }
-          return cli.generateApiClientTypes(routes.definitions, options)
-        })
-
-        return {
-          content: [{ type: 'text', text: JSON.stringify({ generated, skipped }, null, 2) }],
-          // A generator that found nothing to describe is not a failure — an
-          // app with no page components is a normal shape — so only a thrown
-          // one makes the run an error, even when other artifacts landed.
-          isError: failed,
+      // Ordered as `guren codegen` orders it, and for the same reason at the
+      // end: the API client is built from the route manifest, so it can only
+      // run once routes has produced one.
+      const routes = await run(
+        ['.guren/routes.gen.ts', 'types/generated/routes.d.ts'],
+        () => cli.generateRouteTypes(options),
+      )
+      await run(['.guren/pages.gen.ts'], () => cli.generatePageTypes(options))
+      await run(['.guren/data.gen.ts'], () => cli.generateDataTypes(options))
+      await run(['.guren/channels.gen.ts'], () => cli.generateChannelTypes(options))
+      await run(['.guren/api-client.gen.ts'], () => {
+        if (!routes?.definitions) {
+          throw new Error('route generation produced no manifest to build a client from')
         }
-      } finally {
-        process.chdir(originalCwd)
+        return cli.generateApiClientTypes(routes.definitions, options)
+      })
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ generated, skipped }, null, 2) }],
+        // A generator that found nothing to describe is not a failure — an
+        // app with no page components is a normal shape — so only a thrown
+        // one makes the run an error, even when other artifacts landed.
+        isError: failed,
       }
     },
   )

--- a/scripts/test-cwd-guard.test.ts
+++ b/scripts/test-cwd-guard.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { isAllowed, strayScaffoldOutput } from './test-cwd-guard.ts'
+
+/**
+ * The guard is the thing that turns a silent, intermittent repo-pollution bug
+ * into a failing test, so a guard that quietly stops detecting is worse than
+ * none. Its two predicates are pure, which is what makes them testable here
+ * without reaching into a lifecycle hook.
+ */
+describe('test-cwd-guard predicates', () => {
+  const repoRoot = resolve(import.meta.dir, '..')
+
+  describe('isAllowed', () => {
+    it('accepts the directory the run started in', () => {
+      expect(isAllowed(process.cwd())).toBe(true)
+    })
+
+    it('accepts a temp workspace, which tests legitimately chdir into', () => {
+      expect(isAllowed(mkdtempSync(join(tmpdir(), 'guren-cwd-guard-')))).toBe(true)
+    })
+
+    it('rejects a package directory — the directory the reported stray output was rooted at', () => {
+      expect(isAllowed(join(repoRoot, 'packages/cli'))).toBe(false)
+    })
+
+    it('rejects the filesystem root', () => {
+      expect(isAllowed('/')).toBe(false)
+    })
+
+    it('does not treat a sibling sharing the temp-dir prefix as inside it', () => {
+      expect(isAllowed(`${tmpdir()}-evil`)).toBe(false)
+    })
+  })
+
+  describe('strayScaffoldOutput', () => {
+    it('reports nothing for a clean checkout', () => {
+      // Every watched directory is either absent or was present before the run
+      // started; both mean "not this run's doing".
+      expect(strayScaffoldOutput()).toEqual([])
+    })
+  })
+})

--- a/scripts/test-cwd-guard.ts
+++ b/scripts/test-cwd-guard.ts
@@ -1,0 +1,176 @@
+// Preloaded into `bun test` to make working-directory leaks loud.
+//
+// Bun runs every test file in one shared process, so `process.cwd()` is global
+// state and the `make:*` generators resolve their output against it. A test
+// that chdir()s and does not restore relocates every test after it, and the
+// next generator call scaffolds into whatever directory was left behind.
+//
+// Two invariants, checked at the granularity each one needs:
+//   - after every test, cwd is the repo root or a temp directory;
+//   - a test file leaves cwd exactly where it found it, and creates none of
+//     the directories a scaffolded application owns inside the checkout.
+
+import { afterAll, afterEach, beforeAll } from 'bun:test'
+import { existsSync, mkdtempSync, readdirSync, realpathSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve, sep } from 'node:path'
+
+import { repoRoot as workspaceRoot } from './workspace-packages.ts'
+
+// Compared against `process.cwd()`, which the OS returns canonicalized — a
+// symlinked checkout would otherwise look like a permanent leak.
+const repoRoot = realpathSync(workspaceRoot)
+
+// macOS reports /var/folders/... from mkdtemp but /private/var/folders/... from
+// realpath, so both spellings have to count as "a temp directory".
+const tempRoots = [...new Set([tmpdir(), realpathSync(tmpdir())])]
+
+// Where this test process began. `bun run test:bun` starts at the repo root,
+// but `bun test` inside a package starts there instead — both are legitimate,
+// so the invariant is "cwd is where the run started", not a fixed directory.
+// (Writes into the checkout are caught by the stray-output arm regardless.)
+const startCwd = realpathSync(process.cwd())
+
+/** Somewhere cwd is legitimate: where the run started, or a temp directory. */
+export function isAllowed(cwd: string): boolean {
+  if (cwd === startCwd || cwd === repoRoot) return true
+  return tempRoots.some((root) => cwd === root || cwd.startsWith(root + sep))
+}
+
+// Directories a scaffolded application owns. Inside this repository they are
+// generator output that resolved against the wrong directory — which is the
+// case the cwd invariant cannot see, because a generator called with no
+// explicit cwd while the process sits legitimately on the repo root never
+// moves cwd at all.
+const SCAFFOLD_DIRS = ['app', 'config', 'db', 'modules', 'resources', 'routes', 'lang', 'storage']
+
+// `src/` and `tests/` are scaffold output at the repo root, but every package
+// has both — so they are only watched where they cannot legitimately appear.
+const ROOT_ONLY_DIRS = ['src', 'tests']
+
+// A leaked cwd lands on a package directory as readily as on the repo root:
+// `bun run --cwd packages/cli test` is a supported way to run this suite.
+const watchedPaths: string[] = [
+  ...SCAFFOLD_DIRS.map((dir) => join(repoRoot, dir)),
+  ...ROOT_ONLY_DIRS.map((dir) => join(repoRoot, dir)),
+  ...readdirSync(join(repoRoot, 'packages'), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .flatMap((entry) => SCAFFOLD_DIRS.map((dir) => join(repoRoot, 'packages', entry.name, dir))),
+]
+
+// Anything already on disk before the tests ran is somebody's real work, and
+// these paths get deleted. Snapshotting means the watch list never has to be
+// an accurate inventory of what the repo does not contain — a package that
+// legitimately grows a `config/` is simply never reported.
+const preexisting = new Set(watchedPaths.filter((path) => existsSync(path)))
+
+/** Watched directories that this run created. */
+export function strayScaffoldOutput(): string[] {
+  return watchedPaths.filter((path) => !preexisting.has(path) && existsSync(path))
+}
+
+// Created only when something actually leaks. A leaked test is sent here
+// rather than back to the repo root: the repo root is the one directory a
+// stray `make:*` must not write into, and an empty throwaway is inert.
+let quarantine: string | undefined
+
+/** Where the most recent chdir() came from, for blaming a leak. */
+let lastChdir: { target: string; error: Error } | undefined
+const originalChdir = process.chdir.bind(process)
+
+process.chdir = (directory: string): void => {
+  // The Error is constructed eagerly but never formatted unless a leak is
+  // reported — capturing the frame is far cheaper than stringifying it.
+  lastChdir = { target: directory, error: new Error() }
+  originalChdir(directory)
+}
+
+function blame(): string {
+  if (!lastChdir) return '  no chdir() was recorded — cwd changed by something else'
+  const frames = (lastChdir.error.stack ?? '')
+    .split('\n')
+    .filter((line) => !line.includes('test-cwd-guard'))
+    .slice(1, 5)
+    .join('\n')
+  return `  last chdir() -> ${lastChdir.target}\n${frames}`
+}
+
+const CWD_ADVICE = [
+  '',
+  "  process.cwd() is shared by every test file in Bun's single test process,",
+  '  and the make:* generators resolve their output against it. Pass an explicit',
+  '  cwd (WriterOptions) instead of calling process.chdir(), or restore the',
+  '  previous directory in an afterEach/afterAll.',
+].join('\n')
+
+let fileStartCwd: string
+
+beforeAll(() => {
+  fileStartCwd = process.cwd()
+})
+
+// Per test, because the test that leaves cwd somewhere unusable is the one
+// worth naming. Cheap: one cwd read and a string compare.
+afterEach(() => {
+  const cwd = process.cwd()
+  if (isAllowed(cwd)) return
+
+  quarantine ??= mkdtempSync(join(tmpdir(), 'guren-cwd-quarantine-'))
+  // Moved off the bad directory before reporting, so the next test is judged
+  // on its own behaviour instead of inheriting this one's.
+  originalChdir(quarantine)
+
+  throw new Error(
+    [
+      'working directory leaked out of a test',
+      `  cwd after this test: ${cwd}`,
+      `  expected: ${startCwd} (where this run started) or a directory under ${tempRoots.join(' or ')}`,
+      blame(),
+      CWD_ADVICE,
+    ].join('\n'),
+  )
+})
+
+// Per file. A stray directory is a persistent filesystem fact, so scanning
+// once per file rather than after each of ~3600 tests costs a fraction as much
+// and still names the file that produced it. The cwd comparison belongs here
+// too: a file that chdir()s into its own temp workspace is legitimate mid-file
+// but must not hand that directory to the next file.
+afterAll(() => {
+  const problems: string[] = []
+
+  const stray = strayScaffoldOutput()
+  if (stray.length > 0) {
+    for (const path of stray) rmSync(path, { recursive: true, force: true })
+
+    problems.push(
+      [
+        'scaffold output was written into the checkout:',
+        ...stray.map((path) => `    ${path.slice(repoRoot.length + 1)}`),
+        '',
+        '  A make:* generator resolved its output against process.cwd() rather',
+        '  than an explicit directory. Pass `cwd` (WriterOptions) pointing at the',
+        '  test workspace. Left alone this lands untracked files in the checkout,',
+        '  which then break typecheck and get collected as extra test files.',
+      ].join('\n'),
+    )
+  }
+
+  const cwd = process.cwd()
+  if (cwd !== fileStartCwd) {
+    quarantine ??= mkdtempSync(join(tmpdir(), 'guren-cwd-quarantine-'))
+    originalChdir(isAllowed(fileStartCwd) ? fileStartCwd : quarantine)
+
+    problems.push(
+      [
+        'this test file changed the working directory and did not restore it',
+        `  started in: ${fileStartCwd}`,
+        `  ended in:   ${cwd}`,
+        blame(),
+        CWD_ADVICE,
+      ].join('\n'),
+    )
+  }
+
+  if (problems.length > 0) throw new Error(problems.join('\n\n'))
+})

--- a/scripts/test-packages.ts
+++ b/scripts/test-packages.ts
@@ -16,6 +16,8 @@
 // Positional arguments select packages by directory name or package name.
 // Everything after a bare `--` is forwarded to `bun test` verbatim.
 
+import { join } from 'node:path'
+
 import { collectPackages, parseArgs, repoRoot, selectPackages } from './workspace-packages.ts'
 
 // Packages on a runner other than Bun's own (@guren/testing uses vitest) keep
@@ -61,11 +63,24 @@ async function testPathFor(pkg: { dir: string; relativeDir: string }): Promise<s
   return pkg.relativeDir
 }
 
+// Fails any test that leaves process.cwd() somewhere unexpected, or scaffolds
+// into the checkout. Absolute, because a relative preload path stops resolving
+// the moment cwd moves.
+const cwdGuard = join(import.meta.dir, 'test-cwd-guard.ts')
+
+// The guard's own predicates live outside packages/, so a package sweep would
+// never run them — and a detector that silently stops detecting is worth
+// nothing. Included only on an unfiltered run, so `test:bun cli` stays narrow.
+const guardTests = selectors.length === 0 ? ['scripts/test-cwd-guard.test.ts'] : []
+
 const testArgs = [
   'test',
   '--isolate',
+  '--preload',
+  cwdGuard,
   ...forwarded,
   ...(await Promise.all(targets.map(testPathFor))),
+  ...guardTests,
 ]
 
 console.log(`[test] ${targets.map((pkg) => pkg.name).join(', ')}`)


### PR DESCRIPTION
## Summary

Bun runs every test file in one shared process, so `process.cwd()` is global state. `createTempWorkspace()` in `packages/cli/tests/helpers.ts` calls `process.chdir()`, and the `make:*` generators resolve their output paths against `process.cwd()` — so a test that leaked its cwd left stray generator output committed nowhere inside the checkout (e.g. `packages/cli/app/`, root `resources/`, `tests/Widget.test.ts`), which then broke `bun run typecheck` and inflated the test-file count.

This is slice 1 of threading an explicit working directory through the generators instead of steering the process into it. It does not remove every `chdir` in the codebase — see "Deferred" below.

- Adds `WriterOptions.cwd` (defaults to `process.cwd()`) threaded through the CLI's writers (`writeScaffoldFile`, `writeScaffoldFiles`, `writeFileSafe`, `writeGeneratedFile`). The path-traversal containment check (`assertScaffoldPath`, from #300) is pinned to the same root the write resolves against — checking one directory while writing to another is not a weaker guard, it's no guard at all.
- Removes all six `process.chdir()` calls from `packages/server/src/mcp/create-mcp-server.ts`. It's a long-lived server; chdir'ing around an `await` corrupts concurrent requests. Handlers now pass `cwd`/`appRoot` explicitly.
- Collapses the five codegen generators' (`pages`, `data`, `channel`, `routes`, `api-client` types) `relative(...) + writeGeneratedFile(...)` pairs into one `writeGeneratedFileIn()` helper, and makes them all honour `cwd` via `resolveAppRoot()`.
- Several commands accept `cwd` via `WriterOptions` but don't yet honour it end-to-end (`make:auth`, `make:module`, `deploy`, `plugin install`, `make:adr`, blueprints — they still resolve part of their work against `process.cwd()`). These now reject an explicit `cwd` via `assertCwdUnsupported()` rather than silently splitting one scaffold across two projects. No existing caller passes `cwd` to them, so this doesn't change current behavior.
- Adds `scripts/test-cwd-guard.ts`, a `bun test --preload` guard with two invariants: a test file must leave `process.cwd()` where it found it (or a temp directory), and it must not leave scaffold-shaped directories (`app/`, `config/`, `db/`, etc.) inside the checkout. On violation it quarantines/cleans up and fails with a message naming the offending test and `chdir()` call site. Wired into both the monorepo-wide (`scripts/test-packages.ts`) and per-package (`packages/cli/bunfig.toml`) test runs.
- Migrates `packages/cli/tests/make-commands.test.ts` (57 tests) off `chdir` entirely, and fixes real bugs the migration surfaced: `make-feature` was rebuilding its options object and dropping `cwd`; `makeSeeder` read the schema dialect from the wrong directory; `makeTest` detected the test runner from `process.cwd()` while writing to `options.cwd`.

## Deferred

Not in this slice — the writers and `patch-helpers.ts` (13 `process.cwd()` reads) still need it, along with `packages/create-app`'s own `chdir` and six CLI test files that chdir directly. `registerScaffoldedCommand` documents in its JSDoc that it accepts `root` but not yet `cwd`, for the same reason.

## Test plan

- [x] `bun run build:clean` — all packages build
- [x] `bun run typecheck` — root, examples/blog, examples/api all pass
- [x] `bun run test:bun` — 3600 tests / 219 files, 0 fail, 3 consecutive clean runs with zero stray files and zero leaked temp directories
- [x] `bun run test:bun cli` (narrowed invocation) and `cd packages/cli && bun test` (package-local invocation, now guarded via `packages/cli/bunfig.toml`) both green
- [x] `bun run audit:core-first`, `audit:docs`, `audit:contracts`, `audit:deps` — all pass
- [x] Mutation-tested the new assertions (path-traversal containment, `make-commands.test.ts`'s cwd check, `makeTest`'s runner detection) by reverting the fix and confirming the test goes red
- [x] Reviewed with Codex and `/simplify`; applied fixes for a root-freezing gap in `writeScaffoldFiles`, an unbounded temp-directory leak in the guard (6281 stale dirs cleaned up), and a cwd-leak case the guard's temp-dir allowance let through unnoticed