### PR TITLE
fix(server): enforce CSRF token mode at verification, not just at minting

### DIFF
--- a/.changeset/csrf-verify-mode-enforcement.md
+++ b/.changeset/csrf-verify-mode-enforcement.md
@@ -1,0 +1,27 @@
+---
+'@guren/server': patch
+---
+
+Fix CSRF verification accepting a guest token on a request that carries a session
+
+`verifyCsrfToken` picked its validation mode from the submitted token alone: a
+token without a `sid` claim took the stateless double-submit path, which only
+compares the token against the `XSRF-TOKEN` cookie. Because that check ran even
+when the request carried a session, a guest-mode token — which anyone can mint
+by visiting the site — could authorize a state-changing request for a logged-in
+user, provided the attacker also controlled the `XSRF-TOKEN` cookie. That cookie
+carries no `Domain` restriction and no `__Host-` prefix, so any sibling
+subdomain of the same site can set it, and a same-site request still sends the
+`SameSite=Lax` session cookie. The token-minting path already enforced this rule;
+only verification was missing it.
+
+Verification now fixes the mode from the request — whether it carries a bindable
+session — and requires the token to be in that mode.
+
+Issuing had to move with it. A session created during the current request stays
+`isNew` for its whole lifetime, so the response that logs a user in was minting a
+guest token for a session that later requests authenticate with; under the new
+rule that token would be rejected on the next mutation. `Session` gains an
+optional `willPersist()` reporting whether the session survives the response
+under its current id, and the CSRF cookie is now settled after the handler runs
+rather than before, so a login response hands back a session-bound token.

--- a/.changeset/csrf-verify-mode-enforcement.md
+++ b/.changeset/csrf-verify-mode-enforcement.md
@@ -21,7 +21,24 @@ session — and requires the token to be in that mode.
 Issuing had to move with it. A session created during the current request stays
 `isNew` for its whole lifetime, so the response that logs a user in was minting a
 guest token for a session that later requests authenticate with; under the new
-rule that token would be rejected on the next mutation. `Session` gains an
-optional `willPersist()` reporting whether the session survives the response
-under its current id, and the CSRF cookie is now settled after the handler runs
-rather than before, so a login response hands back a session-bound token.
+rule that token would be rejected on the next mutation. Three changes keep
+issuing in step:
+
+- `Session` gains an optional `willPersist()` reporting whether the session
+  survives the response under its current id. `bindableSessionId` asks that
+  instead of `!isNew`.
+- `getCsrfToken()` now tracks the session as it stands at the moment of the
+  call, re-issuing when a handler changes it. Previously the first call in a
+  request fixed the answer, so a handler that logged a user in and then
+  rendered the token put a guest token in the response body while the cookie
+  carried a session-bound one — and submitting that form was rejected.
+- Excluded paths (and the dev MCP endpoint) skip verification but no longer
+  skip issuance, so an exempt endpoint that establishes a session — an OAuth
+  callback — still hands back a bound token.
+
+`createCsrfMiddleware` settles the response cookie after the handler returns, so
+it must be mounted directly inside the session middleware. Middleware layered
+between the two that rotates or invalidates the session after its own
+`await next()` moves the id after CSRF has committed to a token. The automatic
+registration in `AuthServiceProvider` already mounts them adjacently; the
+requirement is now documented for hand-composed chains.

--- a/packages/server/src/http/middleware/csrf.ts
+++ b/packages/server/src/http/middleware/csrf.ts
@@ -81,25 +81,20 @@ function randomNonce(): string {
 }
 
 /**
- * A session that outlives this response under its current id is bind-able.
- * An empty brand-new session is not: under the write-reduction rules it is
- * never persisted, so there is no id for a later request to match.
+ * The session id a token may anchor to, or undefined for a guest request.
  *
- * `!isNew` is not the test. A session created during *this* request stays
- * `isNew` for its whole lifetime, so a login response would mint a guest
- * (stateless) token even though the session it just wrote is what the next
- * request authenticates with — and that token would then be rejected by
- * `verifyCsrfToken`'s mode rule. `willPersist()` answers the actual
- * question; the `!isNew` fallback keeps custom `Session` implementations
- * that predate it working as before.
+ * `Session.willPersist()` is the question being asked — see its definition
+ * for why `!isNew` is the wrong predicate. A custom `Session` that predates
+ * the method falls back to `!isNew`, which reproduces the pre-fix behaviour
+ * for that implementation: its login response mints a guest token that the
+ * next request then rejects. Implement `willPersist()` to avoid that.
  */
 function bindableSessionId(session: Session | undefined): string | undefined {
   if (!session) {
     return undefined
   }
 
-  const persists = session.willPersist ? session.willPersist() : !session.isNew
-  return persists ? session.id : undefined
+  return (session.willPersist?.() ?? !session.isNew) ? session.id : undefined
 }
 
 /**
@@ -120,12 +115,18 @@ function verifiedClaims(token: string): CsrfClaims | null {
 }
 
 /**
- * A cookie token is reusable only in the mode it was minted for: a bound
- * token only for its own session, a stateless token only while there is
- * still no session to bind to.
+ * The one statement of the mode rule, shared by issuing and verification: a
+ * bound token is usable only for its own session, a stateless token only
+ * while there is no session to bind to. Both callers must agree — a mint
+ * that outruns verification locks users out, and a verification looser than
+ * minting is a CSRF bypass.
  */
 function claimsUsableFor(claims: CsrfClaims, boundId: string | undefined): boolean {
-  return claims.sid !== undefined ? claims.sid === boundId : boundId === undefined
+  if (claims.sid === undefined) {
+    return boundId === undefined
+  }
+
+  return boundId !== undefined && secureCompare(claims.sid, boundId)
 }
 
 function matchesPattern(path: string, pattern: string): boolean {
@@ -153,6 +154,12 @@ function isMcpEndpointRequest(path: string): boolean {
   return path === MCP_ENDPOINT_PATH && isMcpEndpointEnabled()
 }
 
+/** The token issued so far this request, and the mode it was issued for. */
+interface IssuedCsrfToken {
+  token: string
+  boundId: string | undefined
+}
+
 /**
  * Get the request's CSRF token.
  *
@@ -161,58 +168,41 @@ function isMcpEndpointRequest(path: string): boolean {
  * server-side, so anonymous page views cost no session writes. A cookie
  * token that is still valid for this request's mode is reused; otherwise a
  * fresh token is minted and set on the response by the middleware.
+ *
+ * The answer tracks the session as it stands *at the moment of the call*,
+ * because a handler can change it: log a user in and the correct token stops
+ * being the guest one it would have got a line earlier. A token cached from
+ * before that point would be rendered into the response body while the
+ * response cookie carried a session-bound one, and `verifyCsrfToken` would
+ * then reject the form on submit. So the per-request cache is keyed by the
+ * mode it was issued for, and re-issues when the mode moves — which also
+ * makes re-reads free, since the common case is that nothing changed.
  */
 export function getCsrfToken(ctx: Context): string {
-  const pending = ctx.get(CSRF_CONTEXT_KEY) as string | undefined
-  if (pending) {
-    return pending
-  }
-
-  return issueCsrfToken(ctx)
-}
-
-/**
- * Mint (or reuse the cookie's token) against the session state as it stands
- * right now, caching the result on the context.
- */
-function issueCsrfToken(ctx: Context): string {
   const boundId = bindableSessionId(getSessionFromContext(ctx))
 
-  const cookieToken = getCookie(ctx, XSRF_COOKIE_NAME)
-  if (cookieToken) {
-    const claims = verifiedClaims(cookieToken)
-    if (claims && claimsUsableFor(claims, boundId)) {
-      ctx.set(CSRF_CONTEXT_KEY, cookieToken)
-      return cookieToken
-    }
+  const issued = ctx.get(CSRF_CONTEXT_KEY) as IssuedCsrfToken | undefined
+  if (issued && issued.boundId === boundId) {
+    return issued.token
   }
 
-  const token = mintCsrfToken(boundId)
-  ctx.set(CSRF_CONTEXT_KEY, token)
-  return token
+  return remember(ctx, reusableCookieToken(ctx, boundId) ?? mintCsrfToken(boundId), boundId)
 }
 
-/**
- * The token to write to the response cookie, re-checked against the session
- * as the handler left it.
- *
- * A token chosen before the handler ran can be the wrong mode by the time
- * the response is written — a login turns a guest request into a session-
- * bearing one — and a stale stateless token would be rejected on the next
- * mutation now that verification enforces the mode rule.
- */
-function refreshCsrfToken(ctx: Context): string {
-  const pending = ctx.get(CSRF_CONTEXT_KEY) as string | undefined
-  if (pending) {
-    const boundId = bindableSessionId(getSessionFromContext(ctx))
-    const claims = verifiedClaims(pending)
-    if (claims && claimsUsableFor(claims, boundId)) {
-      return pending
-    }
+/** The request's `XSRF-TOKEN`, if it is valid for this mode. */
+function reusableCookieToken(ctx: Context, boundId: string | undefined): string | undefined {
+  const cookieToken = getCookie(ctx, XSRF_COOKIE_NAME)
+  if (!cookieToken) {
+    return undefined
   }
 
-  ctx.set(CSRF_CONTEXT_KEY, undefined)
-  return issueCsrfToken(ctx)
+  const claims = verifiedClaims(cookieToken)
+  return claims && claimsUsableFor(claims, boundId) ? cookieToken : undefined
+}
+
+function remember(ctx: Context, token: string, boundId: string | undefined): string {
+  ctx.set(CSRF_CONTEXT_KEY, { token, boundId } satisfies IssuedCsrfToken)
+  return token
 }
 
 /**
@@ -246,25 +236,18 @@ export function verifyCsrfToken(ctx: Context, token: string | undefined): boolea
   }
 
   const claims = verifiedClaims(token)
-  if (claims) {
-    // The mode is chosen by the *request*, not by the token: a request that
-    // carries a bindable session must clear the session-bound check, and a
-    // stateless token is only ever accepted where there is no session to
-    // bind to. Reading the mode off the token instead would let a guest
-    // token — which anyone can mint by visiting the site — authorize a
-    // mutation for a logged-in user, so long as it matched the `XSRF-TOKEN`
-    // cookie, and that cookie is writable by any sibling subdomain.
-    const boundId = bindableSessionId(getSessionFromContext(ctx))
-
+  if (claims && claimsUsableFor(claims, bindableSessionId(getSessionFromContext(ctx)))) {
+    // A bound token is already proven by the session match `claimsUsableFor`
+    // just made. A stateless one proves only that this server minted it —
+    // anyone can get one by visiting the site — so it still has to match the
+    // cookie.
     if (claims.sid !== undefined) {
-      if (boundId !== undefined && secureCompare(claims.sid, boundId)) {
-        return true
-      }
-    } else if (boundId === undefined) {
-      const cookieToken = getCookie(ctx, XSRF_COOKIE_NAME)
-      if (cookieToken && secureCompare(token, cookieToken)) {
-        return true
-      }
+      return true
+    }
+
+    const cookieToken = getCookie(ctx, XSRF_COOKIE_NAME)
+    if (cookieToken && secureCompare(token, cookieToken)) {
+      return true
     }
   }
 
@@ -344,6 +327,14 @@ async function getTokenFromRequest(ctx: Context): Promise<string | undefined> {
  * verify without the cookie; guest (stateless) tokens require the cookie, so
  * disable it only for session-authenticated flows.
  *
+ * **Mount it directly inside the session middleware.** The response cookie is
+ * settled once the handler returns, reading the session id as it stands then.
+ * Middleware layered *between* the two that mutates the session after its own
+ * `await next()` — regenerating or invalidating it — moves the id after this
+ * has already committed to a token, and the next mutation is rejected. The
+ * automatic registration in `AuthServiceProvider` mounts them adjacently;
+ * hand-composed chains have to keep that property.
+ *
  * @example
  * ```ts
  * import { createCsrfMiddleware } from '@guren/server'
@@ -365,30 +356,35 @@ export function createCsrfMiddleware(options: CsrfOptions = {}): MiddlewareHandl
 
   const protectedMethods = new Set(methods.map((m) => m.toUpperCase()))
 
+  // Always settled after the handler: a request that establishes a session
+  // has to leave with a token bound to it, or the next mutation is rejected.
+  // Handlers reach the same value through getCsrfToken(), which re-issues on
+  // the same rule, so the body and the cookie cannot disagree.
+  const settleCookie = (ctx: Context): void => {
+    if (enableCookie) {
+      setXsrfCookie(ctx, getCsrfToken(ctx), cookieOptions)
+    }
+  }
+
   return async (ctx, next) => {
     const method = ctx.req.method.toUpperCase()
     const path = new URL(ctx.req.url).pathname
 
-    // For safe methods, just ensure a token is available to the handler and
-    // set the cookie. The cookie value is settled *after* the handler, since
-    // a handler that establishes a session changes which mode the token has
-    // to be in.
     if (!protectedMethods.has(method)) {
-      getCsrfToken(ctx)
       await next()
-      if (enableCookie) {
-        setXsrfCookie(ctx, refreshCsrfToken(ctx), cookieOptions)
-      }
+      settleCookie(ctx)
       return
     }
 
-    // Check if path is excluded
+    // Excluded and MCP paths skip *verification*, not issuance: an exempt
+    // endpoint that logs a user in (an OAuth callback is the usual one) still
+    // has to hand back a bound token, or every later mutation is rejected.
     if (isExcluded(path, exclude) || isMcpEndpointRequest(path)) {
       await next()
+      settleCookie(ctx)
       return
     }
 
-    // Validate CSRF token for protected methods
     const requestToken = await getTokenFromRequest(ctx)
     const isValid = verifyCsrfToken(ctx, requestToken)
 
@@ -401,12 +397,7 @@ export function createCsrfMiddleware(options: CsrfOptions = {}): MiddlewareHandl
     }
 
     await next()
-
-    // Refresh the cookie after successful mutation. A login POST lands here
-    // having verified a guest token, and must leave with a session-bound one.
-    if (enableCookie) {
-      setXsrfCookie(ctx, refreshCsrfToken(ctx), cookieOptions)
-    }
+    settleCookie(ctx)
   }
 }
 

--- a/packages/server/src/http/middleware/csrf.ts
+++ b/packages/server/src/http/middleware/csrf.ts
@@ -81,12 +81,25 @@ function randomNonce(): string {
 }
 
 /**
- * A session with a stable, already-persisted id is bind-able. A brand-new
- * (isNew) session has no stable id yet — under the write-reduction rules it
- * may not even be persisted — so it must not anchor a token.
+ * A session that outlives this response under its current id is bind-able.
+ * An empty brand-new session is not: under the write-reduction rules it is
+ * never persisted, so there is no id for a later request to match.
+ *
+ * `!isNew` is not the test. A session created during *this* request stays
+ * `isNew` for its whole lifetime, so a login response would mint a guest
+ * (stateless) token even though the session it just wrote is what the next
+ * request authenticates with — and that token would then be rejected by
+ * `verifyCsrfToken`'s mode rule. `willPersist()` answers the actual
+ * question; the `!isNew` fallback keeps custom `Session` implementations
+ * that predate it working as before.
  */
 function bindableSessionId(session: Session | undefined): string | undefined {
-  return session && !session.isNew ? session.id : undefined
+  if (!session) {
+    return undefined
+  }
+
+  const persists = session.willPersist ? session.willPersist() : !session.isNew
+  return persists ? session.id : undefined
 }
 
 /**
@@ -155,6 +168,14 @@ export function getCsrfToken(ctx: Context): string {
     return pending
   }
 
+  return issueCsrfToken(ctx)
+}
+
+/**
+ * Mint (or reuse the cookie's token) against the session state as it stands
+ * right now, caching the result on the context.
+ */
+function issueCsrfToken(ctx: Context): string {
   const boundId = bindableSessionId(getSessionFromContext(ctx))
 
   const cookieToken = getCookie(ctx, XSRF_COOKIE_NAME)
@@ -172,6 +193,29 @@ export function getCsrfToken(ctx: Context): string {
 }
 
 /**
+ * The token to write to the response cookie, re-checked against the session
+ * as the handler left it.
+ *
+ * A token chosen before the handler ran can be the wrong mode by the time
+ * the response is written — a login turns a guest request into a session-
+ * bearing one — and a stale stateless token would be rejected on the next
+ * mutation now that verification enforces the mode rule.
+ */
+function refreshCsrfToken(ctx: Context): string {
+  const pending = ctx.get(CSRF_CONTEXT_KEY) as string | undefined
+  if (pending) {
+    const boundId = bindableSessionId(getSessionFromContext(ctx))
+    const claims = verifiedClaims(pending)
+    if (claims && claimsUsableFor(claims, boundId)) {
+      return pending
+    }
+  }
+
+  ctx.set(CSRF_CONTEXT_KEY, undefined)
+  return issueCsrfToken(ctx)
+}
+
+/**
  * Generate an HTML hidden input field containing the CSRF token.
  */
 export function csrfField(ctx: Context): string {
@@ -183,11 +227,13 @@ export function csrfField(ctx: Context): string {
  * Verify a request token.
  *
  * The token must first carry a valid app-key signature (proving this server
- * minted it). Then, by mode:
- * - **Session-bound** (token carries a `sid`): the id must match the live
- *   session. This is immune to cookie injection — a sibling-subdomain
- *   attacker can plant a cookie but cannot know the victim's session id.
- * - **Stateless** (guest, no `sid`): the token must match the `XSRF-TOKEN`
+ * minted it). The mode is then fixed by the request — whether it carries a
+ * bindable session — and the token has to be in that mode:
+ * - **Session-bound** (request has a session; token must carry a matching
+ *   `sid`): immune to cookie injection — a sibling-subdomain attacker can
+ *   plant a cookie but cannot know the victim's session id. A stateless
+ *   token is rejected here, which is the point: anyone can mint one.
+ * - **Stateless** (request has no session, so no `sid`): the token must match the `XSRF-TOKEN`
  *   cookie (double-submit). Guests hold no authenticated state to protect.
  *
  * Legacy fallback: tokens stored in sessions by earlier releases keep
@@ -201,12 +247,20 @@ export function verifyCsrfToken(ctx: Context, token: string | undefined): boolea
 
   const claims = verifiedClaims(token)
   if (claims) {
+    // The mode is chosen by the *request*, not by the token: a request that
+    // carries a bindable session must clear the session-bound check, and a
+    // stateless token is only ever accepted where there is no session to
+    // bind to. Reading the mode off the token instead would let a guest
+    // token — which anyone can mint by visiting the site — authorize a
+    // mutation for a logged-in user, so long as it matched the `XSRF-TOKEN`
+    // cookie, and that cookie is writable by any sibling subdomain.
+    const boundId = bindableSessionId(getSessionFromContext(ctx))
+
     if (claims.sid !== undefined) {
-      const boundId = bindableSessionId(getSessionFromContext(ctx))
       if (boundId !== undefined && secureCompare(claims.sid, boundId)) {
         return true
       }
-    } else {
+    } else if (boundId === undefined) {
       const cookieToken = getCookie(ctx, XSRF_COOKIE_NAME)
       if (cookieToken && secureCompare(token, cookieToken)) {
         return true
@@ -315,12 +369,15 @@ export function createCsrfMiddleware(options: CsrfOptions = {}): MiddlewareHandl
     const method = ctx.req.method.toUpperCase()
     const path = new URL(ctx.req.url).pathname
 
-    // For safe methods, just ensure token exists and set cookie
+    // For safe methods, just ensure a token is available to the handler and
+    // set the cookie. The cookie value is settled *after* the handler, since
+    // a handler that establishes a session changes which mode the token has
+    // to be in.
     if (!protectedMethods.has(method)) {
-      const token = getCsrfToken(ctx)
+      getCsrfToken(ctx)
       await next()
       if (enableCookie) {
-        setXsrfCookie(ctx, token, cookieOptions)
+        setXsrfCookie(ctx, refreshCsrfToken(ctx), cookieOptions)
       }
       return
     }
@@ -345,9 +402,10 @@ export function createCsrfMiddleware(options: CsrfOptions = {}): MiddlewareHandl
 
     await next()
 
-    // Refresh the cookie after successful mutation
+    // Refresh the cookie after successful mutation. A login POST lands here
+    // having verified a guest token, and must leave with a session-bound one.
     if (enableCookie) {
-      setXsrfCookie(ctx, getCsrfToken(ctx), cookieOptions)
+      setXsrfCookie(ctx, refreshCsrfToken(ctx), cookieOptions)
     }
   }
 }

--- a/packages/server/src/http/middleware/session.ts
+++ b/packages/server/src/http/middleware/session.ts
@@ -115,8 +115,10 @@ export interface Session {
    * CSRF token binding — has to ask this rather than `!isNew`, or it
    * anchors to nothing across the login response.
    *
-   * Optional so that a custom `Session` implementation predating this
-   * method still type-checks; callers fall back to `!isNew`.
+   * Optional only so a custom `Session` predating it still type-checks.
+   * Callers fall back to `!isNew`, which for that implementation reproduces
+   * the bug this method exists to prevent — a login response anchors to
+   * nothing, and the next mutation is rejected. Implement it.
    */
   willPersist?(): boolean
   flash(key: string, value: unknown): void

--- a/packages/server/src/http/middleware/session.ts
+++ b/packages/server/src/http/middleware/session.ts
@@ -105,6 +105,20 @@ export interface Session {
    */
   regenerate(): void
   invalidate(): void
+  /**
+   * Whether this session survives the current response under `id`.
+   *
+   * `isNew` alone cannot answer this: a session created *during* this
+   * request stays `isNew` for its whole lifetime, yet once a handler
+   * writes to it (logging a user in) it is persisted under `id` and every
+   * later request finds it. Anything anchoring a value to the session id —
+   * CSRF token binding — has to ask this rather than `!isNew`, or it
+   * anchors to nothing across the login response.
+   *
+   * Optional so that a custom `Session` implementation predating this
+   * method still type-checks; callers fall back to `!isNew`.
+   */
+  willPersist?(): boolean
   flash(key: string, value: unknown): void
   getFlash<T = unknown>(key: string): T | undefined
   reflash(): void
@@ -243,6 +257,18 @@ class SessionImpl implements Session {
     // Empty brand-new sessions are not persisted: an anonymous request that
     // never stores anything must not cost a database write (or a cookie).
     return this.dirty || (this.isNew && this.hasContent())
+  }
+
+  willPersist(): boolean {
+    if (this.destroyed) {
+      return false
+    }
+
+    // An established session survives even when untouched (rolling expiry
+    // refreshes its TTL). A brand-new one only survives once something has
+    // written to it — which is also the moment its id becomes worth binding
+    // to, since that is the id the middleware is about to write.
+    return !this.isNew || this.shouldPersist()
   }
 
   private hasContent(): boolean {

--- a/packages/server/tests/http/middleware/csrf.test.ts
+++ b/packages/server/tests/http/middleware/csrf.test.ts
@@ -1,7 +1,7 @@
 process.env.APP_KEY = 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
 
 import { afterEach, describe, expect, it } from 'bun:test'
-import { Hono } from 'hono'
+import { Hono, type Context } from 'hono'
 import { MCP_ENDPOINT_PATH } from '../../../src/mcp/endpoint'
 import {
   createCsrfMiddleware,
@@ -713,23 +713,48 @@ describe('session-bound tokens (cookie-injection immunity)', () => {
 })
 
 describe('mode enforcement between minting and verification', () => {
-  function createApp() {
+  // Mirrors what SessionGuard.login() does: rotate the id, then store the
+  // user. Testing with a bare set() would miss the regenerate path entirely.
+  function logIn(c: Context) {
+    const session = getSessionFromContext(c)
+    session?.regenerate()
+    session?.set('userId', 1)
+  }
+
+  function createApp(csrfOptions?: Parameters<typeof createCsrfMiddleware>[0]) {
     const store = new MemorySessionStore()
     const app = new Hono()
     app.use(createSessionMiddleware({ store }))
-    app.use(createCsrfMiddleware())
+    app.use(createCsrfMiddleware(csrfOptions))
     app.get('/guest', (c) => c.json({ token: getCsrfToken(c) }))
-    app.get('/login', (c) => {
-      getSessionFromContext(c)?.set('userId', 1)
+    app.on(['GET', 'POST'], '/login', (c) => {
+      logIn(c)
       return c.text('ok')
     })
-    app.post('/login', (c) => {
-      getSessionFromContext(c)?.set('userId', 1)
+    // Reads the token, establishes the session, then reads it again to
+    // render — shared props or a layout touching the token before the
+    // controller logs the user in. The second read has to reflect the
+    // session that now exists, not the guest answer cached by the first.
+    app.get('/login-and-render', (c) => {
+      const before = getCsrfToken(c)
+      logIn(c)
+      return c.json({ before, token: getCsrfToken(c) })
+    })
+    app.post('/logout', (c) => {
+      getSessionFromContext(c)?.invalidate()
       return c.text('ok')
     })
-    app.get('/form', (c) => c.json({ token: getCsrfToken(c) }))
+    app.post('/exempt-login', (c) => {
+      logIn(c)
+      return c.text('ok')
+    })
     app.post('/submit', (c) => c.text('ok'))
     return app
+  }
+
+  function xsrfFrom(res: Response): string {
+    const pair = pickCookie(res, 'XSRF-TOKEN')
+    return pair ? decodeURIComponent(pair.slice('XSRF-TOKEN='.length)) : ''
   }
 
   it('rejects a guest token on a request that carries a session', async () => {
@@ -739,6 +764,11 @@ describe('mode enforcement between minting and verification', () => {
     const guestRes = await app.request('/guest')
     const { token: guestToken } = (await guestRes.json()) as { token: string }
     const guestXsrf = pickCookie(guestRes, 'XSRF-TOKEN')
+
+    // Without these the test could pass for the wrong reason: no planted
+    // cookie at all would fail double-submit rather than the mode rule.
+    expect(guestXsrf).not.toBe('')
+    expect(xsrfFrom(guestRes)).toBe(guestToken)
 
     // A logged-in victim. Only their session cookie is carried over — the
     // XSRF cookie is the attacker's guest one, which is the whole point of
@@ -780,9 +810,7 @@ describe('mode enforcement between minting and verification', () => {
     expect(loggedIn).toContain('XSRF-TOKEN=')
 
     // The token issued by that same response must work on the next mutation.
-    const issued = decodeURIComponent(
-      loggedIn.split('; ').find((c) => c.startsWith('XSRF-TOKEN='))!.slice('XSRF-TOKEN='.length),
-    )
+    const issued = xsrfFrom(loginRes)
     expect(issued).not.toBe(guestToken)
 
     const post = await app.request('/submit', {
@@ -793,15 +821,72 @@ describe('mode enforcement between minting and verification', () => {
     expect(post.status).toBe(200)
   })
 
-  it('still accepts a guest token when the request has no session', async () => {
+  it('hands the handler the same token it writes to the cookie', async () => {
     const app = createApp()
 
-    const guestRes = await app.request('/guest')
-    const { token } = (await guestRes.json()) as { token: string }
+    // A handler that logs the user in and then renders the token — a form's
+    // hidden `_token`, or Inertia shared props. If it were handed the token
+    // computed before the session existed, the rendered form would carry a
+    // guest token while the cookie carried a bound one, and submitting that
+    // form would 403.
+    const res = await app.request('/login-and-render')
+    const { before, token: rendered } = (await res.json()) as { before: string; token: string }
+
+    // The pre-login read is the guest answer; re-reading after the login has
+    // to move on from it, and land on what the cookie gets.
+    expect(rendered).not.toBe(before)
+    expect(rendered).toBe(xsrfFrom(res))
 
     const post = await app.request('/submit', {
       method: 'POST',
-      headers: { Cookie: extractCookie(guestRes), [CSRF_HEADER_NAME]: token },
+      headers: { Cookie: extractCookie(res), [CSRF_HEADER_NAME]: rendered },
+    })
+
+    expect(post.status).toBe(200)
+  })
+
+  it('refreshes the token on an excluded path that establishes a session', async () => {
+    // Exempt endpoints skip verification, but an OAuth callback still logs
+    // the user in — so it has to leave with a bound token like any other
+    // response, or the user's next mutation is rejected.
+    const app = createApp({ exclude: ['/exempt-login'] })
+
+    const res = await app.request('/exempt-login', { method: 'POST' })
+    expect(res.status).toBe(200)
+    expect(pickCookie(res, 'guren.session')).not.toBe('')
+
+    const issued = xsrfFrom(res)
+    expect(issued).not.toBe('')
+
+    const post = await app.request('/submit', {
+      method: 'POST',
+      headers: { Cookie: extractCookie(res), [CSRF_HEADER_NAME]: issued },
+    })
+
+    expect(post.status).toBe(200)
+  })
+
+  it('returns the user to guest mode after the session is invalidated', async () => {
+    const app = createApp()
+
+    const loginRes = await app.request('/login')
+    const logoutRes = await app.request('/logout', {
+      method: 'POST',
+      headers: { Cookie: extractCookie(loginRes), [CSRF_HEADER_NAME]: xsrfFrom(loginRes) },
+    })
+    expect(logoutRes.status).toBe(200)
+
+    // The session is gone, so the response must hand back a stateless token
+    // that the now-sessionless client can actually use.
+    const issued = xsrfFrom(logoutRes)
+    expect(issued).not.toBe('')
+
+    const post = await app.request('/submit', {
+      method: 'POST',
+      headers: {
+        Cookie: `XSRF-TOKEN=${encodeURIComponent(issued)}`,
+        [CSRF_HEADER_NAME]: issued,
+      },
     })
 
     expect(post.status).toBe(200)

--- a/packages/server/tests/http/middleware/csrf.test.ts
+++ b/packages/server/tests/http/middleware/csrf.test.ts
@@ -30,6 +30,18 @@ afterEach(() => {
   process.env = { ...originalEnv }
 })
 
+/**
+ * A single `name=value` pair from the response, or ''. Needed wherever a test
+ * must control which XSRF cookie the server sees: `extractCookie` joins every
+ * Set-Cookie, so carrying a logged-in response wholesale also carries that
+ * session's own XSRF token, which then shadows any planted one.
+ */
+function pickCookie(res: Response, name: string): string {
+  const cookies = res.headers.getSetCookie?.() ?? []
+  const match = cookies.find((cookie) => cookie.startsWith(`${name}=`))
+  return match ? match.split(';')[0] : ''
+}
+
 function extractCookie(res: Response): string {
   // When multiple Set-Cookie headers exist (session + XSRF-TOKEN),
   // collect all cookies and join them so the session is preserved.
@@ -694,6 +706,102 @@ describe('session-bound tokens (cookie-injection immunity)', () => {
     const post = await app.request('/submit', {
       method: 'POST',
       headers: { Cookie: session, [CSRF_HEADER_NAME]: token },
+    })
+
+    expect(post.status).toBe(200)
+  })
+})
+
+describe('mode enforcement between minting and verification', () => {
+  function createApp() {
+    const store = new MemorySessionStore()
+    const app = new Hono()
+    app.use(createSessionMiddleware({ store }))
+    app.use(createCsrfMiddleware())
+    app.get('/guest', (c) => c.json({ token: getCsrfToken(c) }))
+    app.get('/login', (c) => {
+      getSessionFromContext(c)?.set('userId', 1)
+      return c.text('ok')
+    })
+    app.post('/login', (c) => {
+      getSessionFromContext(c)?.set('userId', 1)
+      return c.text('ok')
+    })
+    app.get('/form', (c) => c.json({ token: getCsrfToken(c) }))
+    app.post('/submit', (c) => c.text('ok'))
+    return app
+  }
+
+  it('rejects a guest token on a request that carries a session', async () => {
+    const app = createApp()
+
+    // Anyone can mint a validly-signed guest token just by visiting.
+    const guestRes = await app.request('/guest')
+    const { token: guestToken } = (await guestRes.json()) as { token: string }
+    const guestXsrf = pickCookie(guestRes, 'XSRF-TOKEN')
+
+    // A logged-in victim. Only their session cookie is carried over — the
+    // XSRF cookie is the attacker's guest one, which is the whole point of
+    // planting it. Sending the victim's own XSRF cookie too would make the
+    // request fail on the cookie mismatch instead of on the mode rule.
+    const victimSession = pickCookie(await app.request('/login'), 'guren.session')
+    expect(victimSession).not.toBe('')
+
+    // Double-submit is satisfied (header value === cookie value), but the
+    // request has a session to bind to, so the stateless path must be closed.
+    const post = await app.request('/submit', {
+      method: 'POST',
+      headers: {
+        Cookie: [victimSession, guestXsrf].join('; '),
+        [CSRF_HEADER_NAME]: guestToken,
+      },
+    })
+
+    expect(post.status).toBe(403)
+  })
+
+  it('issues a session-bound token on the response that establishes the session', async () => {
+    const app = createApp()
+
+    // The login response has to hand back a token for the session it just
+    // created, not the guest token the request came in with.
+    const guestRes = await app.request('/guest')
+    const { token: guestToken } = (await guestRes.json()) as { token: string }
+    const guestCookies = extractCookie(guestRes)
+
+    const loginRes = await app.request('/login', {
+      method: 'POST',
+      headers: { Cookie: guestCookies, [CSRF_HEADER_NAME]: guestToken },
+    })
+    expect(loginRes.status).toBe(200)
+
+    const loggedIn = extractCookie(loginRes)
+    expect(loggedIn).toContain('guren.session=')
+    expect(loggedIn).toContain('XSRF-TOKEN=')
+
+    // The token issued by that same response must work on the next mutation.
+    const issued = decodeURIComponent(
+      loggedIn.split('; ').find((c) => c.startsWith('XSRF-TOKEN='))!.slice('XSRF-TOKEN='.length),
+    )
+    expect(issued).not.toBe(guestToken)
+
+    const post = await app.request('/submit', {
+      method: 'POST',
+      headers: { Cookie: loggedIn, [CSRF_HEADER_NAME]: issued },
+    })
+
+    expect(post.status).toBe(200)
+  })
+
+  it('still accepts a guest token when the request has no session', async () => {
+    const app = createApp()
+
+    const guestRes = await app.request('/guest')
+    const { token } = (await guestRes.json()) as { token: string }
+
+    const post = await app.request('/submit', {
+      method: 'POST',
+      headers: { Cookie: extractCookie(guestRes), [CSRF_HEADER_NAME]: token },
     })
 
     expect(post.status).toBe(200)

--- a/packages/server/tests/http/middleware/session.test.ts
+++ b/packages/server/tests/http/middleware/session.test.ts
@@ -4,6 +4,7 @@ import {
   createSessionMiddleware,
   getSessionFromContext,
   MemorySessionStore,
+  type Session,
   type SessionStore,
 } from '../../../src/http/middleware/session'
 
@@ -663,5 +664,73 @@ describe('getSessionFromContext', () => {
     const res = await app.request('/test')
     const body = await res.json()
     expect(body).toEqual({ hasSession: false })
+  })
+})
+
+describe('willPersist agrees with what the next request finds', () => {
+  // willPersist() restates the finalizer's survival decision so that callers
+  // anchoring a value to the session id (CSRF token binding) can ask for it
+  // up front. Nothing in the type system keeps the two in step, so pin every
+  // lifecycle branch here: if the finalizer's write-reduction rules change
+  // and willPersist() is not updated with them, a token gets bound to an id
+  // no later request can match, and the symptom surfaces as a CSRF 403 far
+  // from the edit.
+  const paths: Array<{ name: string; act: (session: Session) => void }> = [
+    { name: 'untouched brand-new session', act: () => {} },
+    { name: 'new session that stores data', act: (s) => s.set('userId', 1) },
+    { name: 'new session with only flash', act: (s) => s.flash('notice', 'hi') },
+    { name: 'new session regenerated then written', act: (s) => { s.regenerate(); s.set('userId', 1) } },
+    { name: 'invalidated session', act: (s) => { s.set('userId', 1); s.invalidate() } },
+  ]
+
+  for (const { name, act } of paths) {
+    it(name, async () => {
+      const store = new MemorySessionStore()
+      const app = new Hono()
+      app.use(createSessionMiddleware({ store }))
+
+      let claimed: boolean | undefined
+      let claimedId: string | undefined
+      app.get('/act', (c) => {
+        const session = getSessionFromContext(c)!
+        act(session)
+        claimed = session.willPersist!()
+        claimedId = session.id
+        return c.text('ok')
+      })
+
+      await app.request('/act')
+
+      // The claim made mid-request must match what the store actually holds
+      // once the response is finalized.
+      const stored = await store.read(claimedId!)
+      expect(claimed).toBe(stored !== undefined)
+    })
+  }
+
+  it('an established session survives an untouched request (rolling expiry)', async () => {
+    const store = new MemorySessionStore()
+    const app = new Hono()
+    app.use(createSessionMiddleware({ store }))
+
+    let claimed: boolean | undefined
+    let claimedId: string | undefined
+    app.get('/login', (c) => {
+      getSessionFromContext(c)!.set('userId', 1)
+      return c.text('ok')
+    })
+    app.get('/idle', (c) => {
+      const session = getSessionFromContext(c)!
+      claimed = session.willPersist!()
+      claimedId = session.id
+      return c.text('ok')
+    })
+
+    const login = await app.request('/login')
+    const cookie = login.headers.getSetCookie().map((c) => c.split(';')[0]).join('; ')
+    await app.request('/idle', { headers: { Cookie: cookie } })
+
+    expect(claimed).toBe(true)
+    expect(await store.read(claimedId!)).toBeDefined()
   })
 })

--- a/scripts/smoke-golden-path.sh
+++ b/scripts/smoke-golden-path.sh
@@ -481,13 +481,44 @@ if [ -z "$XSRF" ]; then
 fi
 echo "  OK: XSRF-TOKEN cookie present"
 
-# Login with the seeded demo user
+# Login with the seeded demo user. This token was minted while the client was
+# a guest, which is exactly what it is valid for.
+PRE_LOGIN_XSRF="$XSRF"
 http_expect "POST /login (valid credentials + CSRF)" 303 \
   -b "$COOKIES" -c "$COOKIES" -X POST "$RUNTIME_URL/login" \
   -H "Content-Type: application/json" -H "X-XSRF-TOKEN: $XSRF" \
   -d '{"email":"demo@example.com","password":"secret","remember":false}'
 
 http_expect "GET /dashboard (authenticated)" 200 -b "$COOKIES" "$RUNTIME_URL/dashboard"
+
+# Establishing the session re-issues the token bound to it, so the login
+# response rewrote the jar. Re-read it — a browser client does this implicitly
+# by reading the XSRF-TOKEN cookie on every request.
+XSRF=$(awk '$6 == "XSRF-TOKEN" { print $7 }' "$COOKIES")
+if [ "$XSRF" = "$PRE_LOGIN_XSRF" ]; then
+  echo "ERROR: XSRF-TOKEN was not re-issued when the session was established"
+  exit 1
+fi
+echo "  OK: XSRF-TOKEN re-issued on login"
+
+# A guest token is minted by anyone who can reach the site, so it must not
+# authorize a mutation once the request carries a session. The XSRF-TOKEN
+# cookie carries no Domain restriction and no __Host- prefix, so any sibling
+# subdomain can write it — meaning double-submit alone (cookie and header
+# agreeing on a guest token) has to be rejected here, or that subdomain could
+# ride a logged-in session. Both are planted, so this fails on the mode rule
+# rather than on a cookie mismatch, which is what makes it worth asserting.
+SESSION_COOKIE=$(awk '$6 == "guren.session" { print $7 }' "$COOKIES")
+if [ -z "$SESSION_COOKIE" ]; then
+  echo "ERROR: no guren.session cookie after login"
+  exit 1
+fi
+http_expect "POST /posts (session + planted guest token)" 403 \
+  -X POST "$RUNTIME_URL/posts" \
+  -H "Content-Type: application/json" \
+  -H "Cookie: guren.session=$SESSION_COOKIE; XSRF-TOKEN=$PRE_LOGIN_XSRF" \
+  -H "X-XSRF-TOKEN: $PRE_LOGIN_XSRF" \
+  -d '{"title":"planted guest token","body":"must be rejected"}'
 
 # CRUD create + read
 http_expect "POST /posts (authenticated)" 303 \


### PR DESCRIPTION
## Problem

`verifyCsrfToken` chose its validation mode from the submitted token alone:

```ts
if (claims.sid !== undefined) {
  // session-bound: compare against the live session id
} else {
  // stateless: compare against the XSRF-TOKEN cookie
}
```

The stateless branch was entered whenever the token carried no `sid`, **without
checking whether the request had a session to bind to**. The minting path
already enforced that rule through `claimsUsableFor()`; verification did not.

So a guest-mode token — which anyone can mint by making one request to the site
— was accepted on a request carrying an authenticated session, as long as it
matched the `XSRF-TOKEN` cookie. That cookie sets no `Domain` and has no
`__Host-` prefix, so any sibling subdomain of the same site can write it, and a
same-site request still sends the `SameSite=Lax` session cookie. The result is
a CSRF bypass against logged-in users for anyone with a foothold on a
subdomain, defeating exactly the cookie-injection immunity the module documents.

`createCsrfMiddleware` is mounted automatically for any app using the built-in
auth option (`createApp({ auth: {} })`), which is what the blog blueprint and
`guren add auth` produce.

## Fix

**Verification fixes the mode from the request**, then requires the token to be
in that mode. `claimsUsableFor()` is now the single statement of that rule —
verification previously held an inline copy, which is the PR's own invariant in
two encodings, where divergence is silent in the worst direction. It compares
session ids with `secureCompare` so the shared predicate is constant-time for
every caller.

**Issuing had to move with it**, or the fix locks legitimate users out. A
session created during the current request stays `isNew` for its whole lifetime,
so the response that logs a user in was minting a *guest* token for the very
session later requests authenticate with. Three changes:

- `Session` gains an optional `willPersist()`: whether the session survives this
  response under its current id. `bindableSessionId` asks that instead of
  `!isNew`, falling back to `!isNew` for a custom `Session` predating the method.
- `getCsrfToken()` tracks the session **at the moment of the call**. It used to
  fix its answer on the first call in a request, so a handler that logged a user
  in and *then* rendered the token — a form's hidden `_token`, Inertia shared
  props — put a guest token in the response body while the cookie carried a
  session-bound one. That form then 403'd on submit. The per-request cache is
  keyed by the mode it was issued for and re-issues when the mode moves.
- Excluded paths and the dev MCP endpoint skip *verification*, not issuance. An
  exempt endpoint that establishes a session — an OAuth callback is the usual
  one — previously returned before the cookie was written, leaving the browser
  on its guest token.

The cookie is settled after the handler on every path, which requires CSRF to be
mounted directly inside the session middleware: middleware layered between them
that rotates or invalidates the session after its own `await next()` moves the
id after CSRF has committed to a token. `AuthServiceProvider` already mounts them
adjacently; the requirement is now documented for hand-composed chains.

Collapsing issuance back into `getCsrfToken` also removes a separate refresh
pass that re-verified the token on every response (2 HKDF + 2 HMAC per GET where
`main` does 1). Re-reads now cost no crypto when nothing changed, so per-request
work returns to baseline.

## Verification

Every guard was confirmed to **fail the suite when removed**, not merely to pass
with it — six mutations, six failures:

| Mutation | Test that catches it |
|---|---|
| stateless branch of `claimsUsableFor` always true | guest token accepted on a session-bearing request (the vulnerability) |
| `bindableSessionId` back to `!session.isNew` | login response hands back an unusable token |
| excluded path stops refreshing the cookie | exempt login leaves a stale guest token |
| `getCsrfToken` caches regardless of mode change | rendered token diverges from the cookie |
| `willPersist()` drops its `isNew` clause | three lifecycle branches disagree with the store |
| `willPersist()` ignores `destroyed` | invalidated session still claims to persist |

Two tests initially passed against broken code and were rewritten. The first
carried the logged-in response's cookies wholesale, so the victim's own XSRF
token shadowed the planted one and the request failed on the cookie mismatch
rather than the mode rule — hence the `pickCookie` helper. The second read the
token only *after* the login, so it never exercised the stale-cache path.

`willPersist()` restates the session finalizer's survival decision and nothing
in the type system keeps them in step, so a test pins the two together across
every lifecycle branch.

Gates: `build`, root `typecheck`, `test:bun` (3560 pass / 0 fail), `test:examples`
(blog 29 files, api 15, web 16 — covering real login → authenticated mutation
flows), `audit:core-first`, `audit:docs`.

## Deliberately not in this PR

Migrating the cookie to a `__Host-` prefix would stop a sibling subdomain from
writing it at all, as defence in depth. It is a coordinated breaking change —
`packages/cli/src/api-client-types.ts`, `TestApp.withCsrf()` in `@guren/testing`,
and two test suites hardcode the `XSRF-TOKEN` name — so it belongs in its own PR.

Two adjacent defects are left for separate issues: a cookie whose signature
verifies but whose store row is gone is still treated as an existing session
(`session.ts`), and `GUREN_TESTING` is checked by string truthiness, so `"0"`
and `"false"` enable the testing auth override.


### The golden-path smoke was asserting the vulnerable behaviour

CI caught this: `POST /posts` returned 403 after a successful login. The smoke
captured `XSRF-TOKEN` from the guest `GET /login` and reused that one value for
every later mutation, including after the session existed. It passed on `main`
only because a guest token *was* accepted on an authenticated request. A browser
client re-reads the cookie per request, which the script now does — it already
did exactly that after `POST /posts`, with a comment noting the token rotates.

Two assertions added there. The token must change when the session is
established (catching the lockout direction — an unchanged token means the login
response handed back one the next mutation rejects), and a session cookie paired
with a **planted** guest token in *both* the cookie and the header must be
refused. The first version of that second assertion sent only the header, so it
failed on a cookie mismatch and passed on `main` too; planting both makes it fail
on the mode rule. Reverting only the verification-side guard turns it into a 303,
reproducing the bypass end to end in a real scaffolded app.
