### PR TITLE
feat(server): wire i18n into the app via createApp({ i18n })

### DIFF
--- a/.changeset/i18n-app-wiring.md
+++ b/.changeset/i18n-app-wiring.md
@@ -1,0 +1,37 @@
+---
+'@guren/server': minor
+---
+
+Wire i18n into the application: `createApp({ i18n })`, controller translation helpers, and Inertia `_i18n` shared props
+
+The i18n subsystem (I18nManager, Translator, pluralization, loaders) existed
+but had no path from an app's configuration into a request. `createApp` now
+accepts an `i18n` option:
+
+```ts
+createApp({
+  i18n: {
+    supported: ['en', 'ja'],   // first entry is the default fallback
+    path: 'lang',              // lang/<locale>/*.json via JsonLoader (default)
+    // loader: new MemoryLoader(...)  // e.g. bundled messages on serverless
+  },
+})
+```
+
+When set, `I18nServiceProvider` builds the `i18n` container binding from the
+options, preloads every supported locale during `boot()`, and mounts
+`detectLocaleMiddleware` (query → cookie → `Accept-Language`, opt out with
+`detect: false`). Apps that register their own `I18nServiceProvider` subclass
+keep ownership of the wiring.
+
+Controllers gain request-locale sugar: `this.t(key, replacements?)`,
+`this.tc(key, count, replacements?)`, and `this.locale`. They use the
+request-scoped translator bound by the locale middleware when present, and
+fall back to a translator scoped to the resolved locale from the container's
+`i18n` binding (then the `setI18n()` global) — the same resolution order the
+Inertia `<html lang>` default already used.
+
+Inertia responses share the resolved locale and its messages as the `_i18n`
+prop (`{ locale, fallbackLocale, messages }`, active locale plus fallback
+only; disable with `share: false`), laying the groundwork for a client-side
+`useTranslation()` hook.

--- a/.changeset/i18n-interpolation-literal.md
+++ b/.changeset/i18n-interpolation-literal.md
@@ -1,0 +1,12 @@
+---
+'@guren/server': patch
+---
+
+Make translation interpolation literal-safe
+
+`Translator.applyReplacements` built its `:key`/`{key}` patterns from the
+raw replacement key and passed the value straight to `String#replace`, so a
+key containing regex metacharacters could throw or match the wrong text,
+and a value containing `$` sequences (e.g. user input with `$&`) was
+expanded instead of inserted literally. Keys are now regex-escaped and
+values replaced via a callback, keeping both fully literal.

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -7,10 +7,13 @@ import { AuthManager } from '../auth/AuthManager'
 import { AuthServiceProvider } from '../providers/AuthServiceProvider'
 import { AuthorizationServiceProvider } from '../providers/AuthorizationServiceProvider'
 import { ErrorServiceProvider } from '../providers/ErrorServiceProvider'
+import { I18nServiceProvider } from '../providers/I18nServiceProvider'
 import { InertiaServiceProvider } from '../providers/InertiaServiceProvider'
 import { attachAuthContext } from './middleware/auth'
 import { SessionGuard } from '../auth/SessionGuard'
 import type { CreateSessionMiddlewareOptions } from './middleware/session'
+import type { DetectLocaleOptions } from './middleware/detect-locale'
+import type { TranslationLoader, TranslationMessages } from '../i18n'
 import { createSecurityHeaders, type SecurityHeadersOptions } from './middleware/security-headers'
 import { createHostAuthorizationMiddleware, type HostAuthorizationOptions } from './middleware/host-authorization'
 import { isMcpEndpointEnabled } from '../mcp/endpoint'
@@ -135,6 +138,12 @@ export interface ApplicationOptions {
   readonly boot?: BootCallback
   readonly providers?: Array<ServiceProviderConstructor>
   readonly auth?: AuthPluginOptions
+  /**
+   * Configure internationalization: translation loading, locale detection,
+   * and Inertia `_i18n` shared props. When set, {@link I18nServiceProvider}
+   * is registered automatically.
+   */
+  readonly i18n?: I18nPluginOptions
   readonly discover?: boolean
   readonly routes?: RouteRegistration
   /**
@@ -156,6 +165,45 @@ export interface ApplicationOptions {
    * The `create-app` template includes a default localhost configuration.
    */
   readonly hostAuthorization?: HostAuthorizationOptions | false
+}
+
+export interface I18nPluginOptions {
+  /**
+   * Locales the app supports. Locale detection only ever resolves to one of
+   * these, and all of them are preloaded during `boot()`.
+   */
+  readonly supported: readonly string[]
+  /**
+   * Fallback (and default) locale. Defaults to the first supported locale.
+   */
+  readonly fallback?: string
+  /**
+   * Directory containing `<path>/<locale>/*.json` translation files, loaded
+   * with {@link JsonLoader}. Defaults to `'lang'`. Ignored when `loader` is
+   * set.
+   */
+  readonly path?: string
+  /**
+   * Custom translation loader (e.g. `MemoryLoader` on serverless targets
+   * without a filesystem). Takes precedence over `path`.
+   */
+  readonly loader?: TranslationLoader
+  /**
+   * Preloaded messages. Locales given here count as loaded and are not
+   * fetched from the loader.
+   */
+  readonly messages?: Record<string, TranslationMessages>
+  /**
+   * Locale detection middleware options. `detectLocaleMiddleware` is mounted
+   * automatically with the `supported` locales above; pass `false` to mount
+   * (or skip) it yourself.
+   */
+  readonly detect?: Omit<DetectLocaleOptions, 'supported' | 'i18n'> | false
+  /**
+   * Share the request locale and its messages with Inertia pages as the
+   * `_i18n` prop. Defaults to `true`.
+   */
+  readonly share?: boolean
 }
 
 export interface AuthPluginOptions {
@@ -253,6 +301,16 @@ export class Application {
       ...moduleProviders,
     ]
 
+    // I18n (translator binding + locale detection + Inertia shared props) is
+    // registered when options.i18n is set — unless the app supplies its own
+    // I18nServiceProvider subclass, which then owns the wiring.
+    const hasUserI18nProvider = userProviders.some(
+      (provider) => provider === I18nServiceProvider || provider.prototype instanceof I18nServiceProvider,
+    )
+    if (this.options.i18n && !hasUserI18nProvider) {
+      this.providerManager.register(I18nServiceProvider)
+    }
+
     // Exception rendering is on by default so HttpExceptions map to their
     // status codes (404/422/403) instead of opaque 500s. Registered before
     // user providers so a custom ErrorServiceProvider subclass wins via
@@ -289,6 +347,10 @@ export class Application {
 
   get authOptions(): AuthPluginOptions | undefined {
     return this.options.auth
+  }
+
+  get i18nOptions(): I18nPluginOptions | undefined {
+    return this.options.i18n
   }
 
   markAutoSessionAttached(): void {

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -13,7 +13,7 @@ import { attachAuthContext } from './middleware/auth'
 import { SessionGuard } from '../auth/SessionGuard'
 import type { CreateSessionMiddlewareOptions } from './middleware/session'
 import type { DetectLocaleOptions } from './middleware/detect-locale'
-import type { TranslationLoader, TranslationMessages } from '../i18n'
+import type { TranslationLoader } from '../i18n'
 import { createSecurityHeaders, type SecurityHeadersOptions } from './middleware/security-headers'
 import { createHostAuthorizationMiddleware, type HostAuthorizationOptions } from './middleware/host-authorization'
 import { isMcpEndpointEnabled } from '../mcp/endpoint'
@@ -184,21 +184,16 @@ export interface I18nPluginOptions {
    */
   readonly path?: string
   /**
-   * Custom translation loader (e.g. `MemoryLoader` on serverless targets
-   * without a filesystem). Takes precedence over `path`.
+   * Custom translation loader (e.g. `MemoryLoader` for bundled messages on
+   * serverless targets without a filesystem). Takes precedence over `path`.
    */
   readonly loader?: TranslationLoader
   /**
-   * Preloaded messages. Locales given here count as loaded and are not
-   * fetched from the loader.
-   */
-  readonly messages?: Record<string, TranslationMessages>
-  /**
    * Locale detection middleware options. `detectLocaleMiddleware` is mounted
-   * automatically with the `supported` locales above; pass `false` to mount
-   * (or skip) it yourself.
+   * automatically with the `supported` locales and `fallback` above; pass
+   * `false` to mount (or skip) it yourself.
    */
-  readonly detect?: Omit<DetectLocaleOptions, 'supported' | 'i18n'> | false
+  readonly detect?: Omit<DetectLocaleOptions, 'supported' | 'fallback' | 'i18n'> | false
   /**
    * Share the request locale and its messages with Inertia pages as the
    * `_i18n` prop. Defaults to `true`.
@@ -301,13 +296,14 @@ export class Application {
       ...moduleProviders,
     ]
 
+    // A user-supplied subclass of a default provider takes ownership of that
+    // subsystem's wiring, so the default registration below is skipped.
+    const hasUserProviderOf = (base: ServiceProviderConstructor): boolean =>
+      userProviders.some((provider) => provider === base || provider.prototype instanceof base)
+
     // I18n (translator binding + locale detection + Inertia shared props) is
-    // registered when options.i18n is set — unless the app supplies its own
-    // I18nServiceProvider subclass, which then owns the wiring.
-    const hasUserI18nProvider = userProviders.some(
-      (provider) => provider === I18nServiceProvider || provider.prototype instanceof I18nServiceProvider,
-    )
-    if (this.options.i18n && !hasUserI18nProvider) {
+    // registered when options.i18n is set.
+    if (this.options.i18n && !hasUserProviderOf(I18nServiceProvider)) {
       this.providerManager.register(I18nServiceProvider)
     }
 
@@ -315,10 +311,7 @@ export class Application {
     // status codes (404/422/403) instead of opaque 500s. Registered before
     // user providers so a custom ErrorServiceProvider subclass wins via
     // its later hono.onError() call.
-    const hasUserErrorProvider = userProviders.some(
-      (provider) => provider === ErrorServiceProvider || provider.prototype instanceof ErrorServiceProvider,
-    )
-    if (!hasUserErrorProvider) {
+    if (!hasUserProviderOf(ErrorServiceProvider)) {
       this.providerManager.register(ErrorServiceProvider)
     }
 
@@ -333,10 +326,7 @@ export class Application {
     // providers: the first matching exception renderer wins, so a custom
     // ValidationException renderer registered by a user provider keeps
     // taking precedence over this default.
-    const hasUserInertiaProvider = userProviders.some(
-      (provider) => provider === InertiaServiceProvider || provider.prototype instanceof InertiaServiceProvider,
-    )
-    if (!hasUserInertiaProvider) {
+    if (!hasUserProviderOf(InertiaServiceProvider)) {
       this.providerManager.register(InertiaServiceProvider)
     }
   }

--- a/packages/server/src/http/middleware/detect-locale.ts
+++ b/packages/server/src/http/middleware/detect-locale.ts
@@ -121,33 +121,29 @@ export function detectLocaleMiddleware(options: DetectLocaleOptions) {
     return undefined
   }
 
-  // Bound t/tc helpers, created once per locale (the set is bounded by
-  // `supported`). Messages added to the manager after a locale is cached are
-  // not picked up — acceptable for the load-once translation lifecycle.
+  // Bound t/tc helpers, cached per locale. Only supported, already-loaded
+  // locales are cached: the bound-on-uncached-locale case rebuilds per call
+  // (and self-heals once the locale loads), and an unvalidated override from
+  // downstream middleware cannot grow the map without bound. Messages added
+  // to the manager after a locale is cached are not picked up — acceptable
+  // for the load-once translation lifecycle.
   const translators = new Map<string, TranslatorBinding>()
+  const supportedSet = new Set(supported)
 
-  const resolveTranslator = async (locale: string): Promise<TranslatorBinding | undefined> => {
-    if (options.i18n === false) {
-      return undefined
-    }
-
+  const bindingFor = (locale: string, i18n: I18nManager): TranslatorBinding => {
     const cached = translators.get(locale)
     if (cached) {
       return cached
     }
 
-    const i18n = options.i18n ?? tryGetI18n()
-    if (!i18n) {
-      return undefined
-    }
-
-    await i18n.loadLocale(locale).catch(() => {})
     const translator = i18n.forLocale(locale)
     const binding: TranslatorBinding = {
       t: translator.t.bind(translator),
       tc: translator.tc.bind(translator),
     }
-    translators.set(locale, binding)
+    if (supportedSet.has(locale) && i18n.isLocaleLoaded(locale)) {
+      translators.set(locale, binding)
+    }
     return binding
   }
 
@@ -169,10 +165,16 @@ export function detectLocaleMiddleware(options: DetectLocaleOptions) {
 
     c.set(LOCALE_CONTEXT_KEY, resolved)
 
-    const binding = await resolveTranslator(resolved)
-    if (binding) {
-      c.set('t', binding.t)
-      c.set('tc', binding.tc)
+    const i18n = options.i18n === false ? undefined : options.i18n ?? tryGetI18n()
+    if (i18n) {
+      await i18n.loadLocale(resolved).catch(() => {})
+
+      // Resolve the translator per call, not per request: middleware running
+      // after detection may override the `locale` context variable (e.g. a
+      // per-user preference from the session), and t/tc must follow it.
+      const current = () => bindingFor(getRequestLocale(c) ?? resolved, i18n)
+      c.set('t', (key, replacements) => current().t(key, replacements))
+      c.set('tc', (key, count, replacements) => current().tc(key, count, replacements))
     }
 
     await next()

--- a/packages/server/src/http/middleware/detect-locale.ts
+++ b/packages/server/src/http/middleware/detect-locale.ts
@@ -1,10 +1,36 @@
+import type { Context } from 'hono'
 import { createMiddleware } from 'hono/factory'
 import { getCookie } from 'hono/cookie'
 import { parseAccept } from 'hono/utils/accept'
-import { getI18n, type I18nManager, type Translator } from '../../i18n'
+import { tryGetI18n, type I18nManager, type Translator } from '../../i18n'
 
 /** Context key for the resolved request locale (read by Inertia for `<html lang>`). */
 export const LOCALE_CONTEXT_KEY = 'locale'
+
+/** Request-scoped translator surface bound by {@link detectLocaleMiddleware}. */
+export type TranslatorBinding = { t: Translator['t']; tc: Translator['tc'] }
+
+/**
+ * Read the request locale resolved by {@link detectLocaleMiddleware} (or any
+ * middleware that sets the `locale` context variable).
+ */
+export function getRequestLocale(c: Context): string | undefined {
+  const locale = (c.var as Record<string, unknown> | undefined)?.[LOCALE_CONTEXT_KEY]
+  return typeof locale === 'string' && locale.length > 0 ? locale : undefined
+}
+
+/**
+ * Read the request-scoped `t`/`tc` translator bound by
+ * {@link detectLocaleMiddleware}, when present.
+ */
+export function getRequestTranslator(c: Context): TranslatorBinding | undefined {
+  const vars = c.var as Record<string, unknown> | undefined
+  const t = vars?.['t']
+  const tc = vars?.['tc']
+  return typeof t === 'function' && typeof tc === 'function'
+    ? ({ t, tc } as TranslatorBinding)
+    : undefined
+}
 
 export type LocaleSource = 'query' | 'cookie' | 'header'
 
@@ -36,8 +62,6 @@ export interface DetectLocaleOptions {
 }
 
 const DEFAULT_SOURCES: readonly LocaleSource[] = ['query', 'cookie', 'header']
-
-type TranslatorBinding = { t: Translator['t']; tc: Translator['tc'] }
 
 /**
  * Middleware that resolves the request locale from the query string, a cookie,
@@ -112,7 +136,7 @@ export function detectLocaleMiddleware(options: DetectLocaleOptions) {
       return cached
     }
 
-    const i18n = options.i18n ?? tryGlobalI18n()
+    const i18n = options.i18n ?? tryGetI18n()
     if (!i18n) {
       return undefined
     }
@@ -153,12 +177,4 @@ export function detectLocaleMiddleware(options: DetectLocaleOptions) {
 
     await next()
   })
-}
-
-function tryGlobalI18n(): I18nManager | undefined {
-  try {
-    return getI18n()
-  } catch {
-    return undefined
-  }
 }

--- a/packages/server/src/http/middleware/index.ts
+++ b/packages/server/src/http/middleware/index.ts
@@ -89,6 +89,9 @@ export { requestLoggingMiddleware } from './request-logging'
 export {
   detectLocaleMiddleware,
   LOCALE_CONTEXT_KEY,
+  getRequestLocale,
+  getRequestTranslator,
+  type TranslatorBinding,
   type DetectLocaleOptions,
   type DetectLocaleVariables,
   type LocaleSource,

--- a/packages/server/src/i18n/I18nManager.ts
+++ b/packages/server/src/i18n/I18nManager.ts
@@ -175,13 +175,23 @@ export class I18nManager {
     return new Translator({
       locale,
       fallbackLocale: this.config.fallbackLocale,
-      messages: {
-        [locale]: this.translator.getMessages(locale),
-        ...(this.config.fallbackLocale
-          ? { [this.config.fallbackLocale]: this.translator.getMessages(this.config.fallbackLocale) }
-          : {}),
-      },
+      messages: this.messagesForLocale(locale),
     })
+  }
+
+  /**
+   * The message catalogs that accompany a locale: the fallback locale's
+   * (when it differs) plus the locale's own, in that order — so consumers
+   * that flatten the record let the active locale win on key collisions.
+   */
+  messagesForLocale(locale: string): Record<string, TranslationMessages> {
+    const fallback = this.config.fallbackLocale
+    const messages: Record<string, TranslationMessages> = {}
+    if (fallback && fallback !== locale) {
+      messages[fallback] = this.translator.getMessages(fallback)
+    }
+    messages[locale] = this.translator.getMessages(locale)
+    return messages
   }
 }
 
@@ -210,6 +220,13 @@ export function getI18n(): I18nManager {
     throw new Error('I18n manager not initialized. Call setI18n() first.')
   }
   return globalI18n
+}
+
+/**
+ * Get the global I18n manager, or `undefined` when none was registered.
+ */
+export function tryGetI18n(): I18nManager | undefined {
+  return globalI18n ?? undefined
 }
 
 /**

--- a/packages/server/src/i18n/Translator.ts
+++ b/packages/server/src/i18n/Translator.ts
@@ -6,6 +6,8 @@ import type {
 } from './types'
 import { getPluralizationRule, selectPluralForm } from './pluralization'
 
+const REGEXP_SPECIALS = /[.*+?^${}()|[\]\\]/g
+
 /**
  * Translator class for handling translations.
  */
@@ -183,10 +185,14 @@ export class Translator {
     let result = translation
 
     for (const [key, value] of Object.entries(replacements)) {
-      // Support both :key and {key} formats
+      // Support both :key and {key} formats. The key is escaped so regex
+      // metacharacters match literally, and the value goes through a
+      // callback so `$` sequences in it are not expanded.
+      const escaped = key.replace(REGEXP_SPECIALS, '\\$&')
+      const replacement = (): string => String(value)
       result = result
-        .replace(new RegExp(`:${key}`, 'g'), String(value))
-        .replace(new RegExp(`\\{${key}\\}`, 'g'), String(value))
+        .replace(new RegExp(`:${escaped}`, 'g'), replacement)
+        .replace(new RegExp(`\\{${escaped}\\}`, 'g'), replacement)
     }
 
     return result

--- a/packages/server/src/i18n/index.ts
+++ b/packages/server/src/i18n/index.ts
@@ -21,6 +21,7 @@ export {
   createI18n,
   setI18n,
   getI18n,
+  tryGetI18n,
   t,
   tc,
 } from './I18nManager'

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -817,7 +817,8 @@ export { renderErrorPage } from './errors/error-page'
 export { NodeHasher } from './auth/password/NodeHasher'
 // Hash: convenience alias for ScryptHasher (used as default in docs)
 export { DefaultHasher, DefaultHasher as Hash } from './auth/password/DefaultHasher'
-export type { ApplicationOptions, AuthPluginOptions } from './http/Application'
+export type { ApplicationOptions, AuthPluginOptions, I18nPluginOptions } from './http/Application'
+export type { InertiaI18nProps } from './providers/I18nServiceProvider'
 // Queue: SQS adapter
 export { SqsDriver, createSqsAdapter } from './queue/drivers/SqsDriver'
 // Broadcasting: typed broadcaster

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -197,6 +197,8 @@ export {
   // Locale detection
   detectLocaleMiddleware,
   LOCALE_CONTEXT_KEY,
+  getRequestLocale,
+  getRequestTranslator,
 }
   from './http/middleware'
 export { AUTH_CONTEXT_KEY } from './http/middleware/auth'
@@ -232,6 +234,7 @@ export type {
   // Locale detection types
   DetectLocaleOptions,
   DetectLocaleVariables,
+  TranslatorBinding,
   LocaleSource,
 }  from './http/middleware'
 // Validation (advanced)
@@ -480,6 +483,7 @@ export {
   createI18n,
   setI18n,
   getI18n,
+  tryGetI18n,
   t,
   tc,
 } from './i18n'

--- a/packages/server/src/mvc/Controller.ts
+++ b/packages/server/src/mvc/Controller.ts
@@ -2,8 +2,8 @@ import type { Context } from 'hono'
 import { inertia, type InertiaOptions } from './inertia/InertiaEngine'
 import { resolveSharedInertiaProps, type ResolvedSharedInertiaProps } from './inertia/shared'
 import { AUTH_CONTEXT_KEY } from '../http/middleware/auth'
-import { LOCALE_CONTEXT_KEY } from '../http/middleware/detect-locale'
-import { getI18n, type I18nManager, type ReplacementValues } from '../i18n'
+import { getRequestLocale, getRequestTranslator, type TranslatorBinding } from '../http/middleware/detect-locale'
+import { tryGetI18n, type I18nManager, type ReplacementValues } from '../i18n'
 import { flattenRequestQueries, parseRequestPayload } from '../http/request'
 import type { AuthContext } from '../auth/types'
 import type { ServiceBindings } from '../container/bindings'
@@ -34,12 +34,6 @@ interface ZodLikeSchema<T> {
 export type SafeValidationResult<T> =
   | { success: true; data: T }
   | { success: false; errors: Record<string, string> }
-
-/** Minimal translator surface shared by I18nManager, Translator, and the middleware bindings. */
-type RequestTranslator = {
-  t(key: string, replacements?: ReplacementValues): string
-  tc(key: string, count: number, replacements?: ReplacementValues): string
-}
 
 type DefaultInertiaProps = Record<string, unknown>
 
@@ -329,7 +323,9 @@ export class Controller {
 
     const response = await inertia(component, propsWithShared as Record<string, unknown>, {
       ...rest,
-      lang: rest.lang ?? this.#defaultInertiaLang(),
+      // No 'en' fallback here (unlike the locale getter): unconfigured apps
+      // keep the Inertia engine's own default lang.
+      lang: rest.lang ?? this.#resolveLocale(),
       url,
       request: ctx.req.raw,
     })
@@ -340,15 +336,6 @@ export class Controller {
     }
 
     return response as InertiaResponse<Component, typeof propsWithShared>
-  }
-
-  /**
-   * Default `<html lang>` for Inertia responses when `options.lang` is not
-   * provided — same resolution as the `locale` getter, but without its
-   * `'en'` fallback so unconfigured apps keep emitting no lang attribute.
-   */
-  #defaultInertiaLang(): string | undefined {
-    return this.#resolveLocale()
   }
 
   /**
@@ -387,19 +374,10 @@ export class Controller {
     return this.#requestTranslator().tc(key, count, replacements)
   }
 
-  #translator?: RequestTranslator
-
-  #requestTranslator(): RequestTranslator {
-    if (this.#translator) {
-      return this.#translator
-    }
-
-    const vars = this.ctx.var as Record<string, unknown> | undefined
-    const t = vars?.['t']
-    const tc = vars?.['tc']
-    if (typeof t === 'function' && typeof tc === 'function') {
-      this.#translator = { t, tc } as RequestTranslator
-      return this.#translator
+  #requestTranslator(): TranslatorBinding {
+    const bound = getRequestTranslator(this.ctx)
+    if (bound) {
+      return bound
     }
 
     const i18n = this.#resolveI18n()
@@ -409,16 +387,13 @@ export class Controller {
       )
     }
 
-    const locale = this.#resolveLocale()
-    this.#translator = locale && locale !== i18n.getLocale() ? i18n.forLocale(locale) : i18n
-    return this.#translator
+    const locale = getRequestLocale(this.ctx)
+    return locale && locale !== i18n.getLocale() ? i18n.forLocale(locale) : i18n
   }
 
   #resolveLocale(): string | undefined {
-    const vars = this.ctx.var as Record<string, unknown> | undefined
-
-    const requestLocale = vars?.[LOCALE_CONTEXT_KEY]
-    if (typeof requestLocale === 'string' && requestLocale.length > 0) {
+    const requestLocale = getRequestLocale(this.ctx)
+    if (requestLocale) {
       return requestLocale
     }
 
@@ -431,11 +406,7 @@ export class Controller {
       return this._container.make('i18n') as I18nManager
     }
 
-    try {
-      return getI18n()
-    } catch {
-      return undefined
-    }
+    return tryGetI18n()
   }
 
   protected json<T>(data: T, init: ResponseInit = {}): Response {

--- a/packages/server/src/mvc/Controller.ts
+++ b/packages/server/src/mvc/Controller.ts
@@ -3,7 +3,7 @@ import { inertia, type InertiaOptions } from './inertia/InertiaEngine'
 import { resolveSharedInertiaProps, type ResolvedSharedInertiaProps } from './inertia/shared'
 import { AUTH_CONTEXT_KEY } from '../http/middleware/auth'
 import { LOCALE_CONTEXT_KEY } from '../http/middleware/detect-locale'
-import { getI18n } from '../i18n'
+import { getI18n, type I18nManager, type ReplacementValues } from '../i18n'
 import { flattenRequestQueries, parseRequestPayload } from '../http/request'
 import type { AuthContext } from '../auth/types'
 import type { ServiceBindings } from '../container/bindings'
@@ -34,6 +34,12 @@ interface ZodLikeSchema<T> {
 export type SafeValidationResult<T> =
   | { success: true; data: T }
   | { success: false; errors: Record<string, string> }
+
+/** Minimal translator surface shared by I18nManager, Translator, and the middleware bindings. */
+type RequestTranslator = {
+  t(key: string, replacements?: ReplacementValues): string
+  tc(key: string, count: number, replacements?: ReplacementValues): string
+}
 
 type DefaultInertiaProps = Record<string, unknown>
 
@@ -338,11 +344,77 @@ export class Controller {
 
   /**
    * Default `<html lang>` for Inertia responses when `options.lang` is not
-   * provided: the request-scoped `locale` context variable (set by locale
-   * middleware) wins over the app-wide i18n locale (the router-injected
-   * container binding, then the `setI18n()` global).
+   * provided — same resolution as the `locale` getter, but without its
+   * `'en'` fallback so unconfigured apps keep emitting no lang attribute.
    */
   #defaultInertiaLang(): string | undefined {
+    return this.#resolveLocale()
+  }
+
+  /**
+   * Locale resolved for the current request: the request-scoped `locale`
+   * context variable (set by locale middleware) wins over the app-wide i18n
+   * locale (the router-injected container binding, then the `setI18n()`
+   * global). Falls back to `'en'` when no i18n is configured.
+   */
+  protected get locale(): string {
+    return this.#resolveLocale() ?? 'en'
+  }
+
+  /**
+   * Translate a key for the current request locale.
+   *
+   * Uses the request-scoped translator bound by the locale detection
+   * middleware when present, falling back to a translator scoped to
+   * `this.locale` from the container's `i18n` binding (then the `setI18n()`
+   * global).
+   *
+   * @example
+   * ```typescript
+   * this.t('posts.created')
+   * this.t('posts.greeting', { name: user.name })
+   * ```
+   */
+  protected t(key: string, replacements?: ReplacementValues): string {
+    return this.#requestTranslator().t(key, replacements)
+  }
+
+  /**
+   * Translate a key with a count for pluralization, using the same locale
+   * resolution as {@link Controller.t}.
+   */
+  protected tc(key: string, count: number, replacements?: ReplacementValues): string {
+    return this.#requestTranslator().tc(key, count, replacements)
+  }
+
+  #translator?: RequestTranslator
+
+  #requestTranslator(): RequestTranslator {
+    if (this.#translator) {
+      return this.#translator
+    }
+
+    const vars = this.ctx.var as Record<string, unknown> | undefined
+    const t = vars?.['t']
+    const tc = vars?.['tc']
+    if (typeof t === 'function' && typeof tc === 'function') {
+      this.#translator = { t, tc } as RequestTranslator
+      return this.#translator
+    }
+
+    const i18n = this.#resolveI18n()
+    if (!i18n) {
+      throw new Error(
+        'Controller.t() requires i18n to be configured. Pass createApp({ i18n }) or register an I18nManager.',
+      )
+    }
+
+    const locale = this.#resolveLocale()
+    this.#translator = locale && locale !== i18n.getLocale() ? i18n.forLocale(locale) : i18n
+    return this.#translator
+  }
+
+  #resolveLocale(): string | undefined {
     const vars = this.ctx.var as Record<string, unknown> | undefined
 
     const requestLocale = vars?.[LOCALE_CONTEXT_KEY]
@@ -350,20 +422,20 @@ export class Controller {
       return requestLocale
     }
 
-    let i18n: { getLocale?: () => string } | undefined
+    const locale = this.#resolveI18n()?.getLocale()
+    return typeof locale === 'string' && locale.length > 0 ? locale : undefined
+  }
 
+  #resolveI18n(): I18nManager | undefined {
     if (this._container?.has?.('i18n')) {
-      i18n = this._container.make('i18n') as { getLocale?: () => string }
-    } else {
-      try {
-        i18n = getI18n()
-      } catch {
-        i18n = undefined
-      }
+      return this._container.make('i18n') as I18nManager
     }
 
-    const locale = i18n?.getLocale?.()
-    return typeof locale === 'string' && locale.length > 0 ? locale : undefined
+    try {
+      return getI18n()
+    } catch {
+      return undefined
+    }
   }
 
   protected json<T>(data: T, init: ResponseInit = {}): Response {

--- a/packages/server/src/mvc/Controller.ts
+++ b/packages/server/src/mvc/Controller.ts
@@ -383,7 +383,7 @@ export class Controller {
     const i18n = this.#resolveI18n()
     if (!i18n) {
       throw new Error(
-        'Controller.t() requires i18n to be configured. Pass createApp({ i18n }) or register an I18nManager.',
+        'Controller i18n helpers require i18n to be configured. Pass createApp({ i18n }) or register an I18nManager.',
       )
     }
 

--- a/packages/server/src/providers/I18nServiceProvider.ts
+++ b/packages/server/src/providers/I18nServiceProvider.ts
@@ -30,8 +30,15 @@ export class I18nServiceProvider extends ServiceProvider {
     const app = this.application()
     const options = app?.i18nOptions
 
-    if (options && options.supported.length === 0) {
-      throw new Error('createApp({ i18n }) requires at least one supported locale.')
+    if (options) {
+      if (options.supported.length === 0) {
+        throw new Error('createApp({ i18n }) requires at least one supported locale.')
+      }
+      if (options.fallback && !options.supported.includes(options.fallback)) {
+        throw new Error(
+          `createApp({ i18n }): fallback locale '${options.fallback}' must be one of the supported locales (${options.supported.join(', ')}).`,
+        )
+      }
     }
 
     this.container.singleton('i18n', () => {
@@ -65,6 +72,18 @@ export class I18nServiceProvider extends ServiceProvider {
 
     const manager = this.container.make<I18nManager>('i18n')
     await manager.loadLocales([...options.supported])
+
+    // A missing lang directory or unparseable file surfaces as an empty
+    // catalog rather than a boot failure (JsonLoader tolerates both) — warn
+    // so a broken path is visible instead of silently untranslated.
+    for (const locale of options.supported) {
+      if (Object.keys(manager.getMessages(locale)).length === 0) {
+        console.warn(
+          `[guren] i18n: no translations loaded for locale '${locale}'` +
+          (options.loader ? '.' : ` — expected ${options.path ?? 'lang'}/${locale}/*.json.`),
+        )
+      }
+    }
 
     if (options.share !== false) {
       const fallback = manager.getFallbackLocale() ?? manager.getLocale()

--- a/packages/server/src/providers/I18nServiceProvider.ts
+++ b/packages/server/src/providers/I18nServiceProvider.ts
@@ -1,11 +1,99 @@
+import type { Context } from 'hono'
 import { ServiceProvider } from '../container/ServiceProvider'
-import { createI18n } from '../i18n'
+import { createI18n, type I18nManager, type TranslationMessages } from '../i18n'
+import { detectLocaleMiddleware, LOCALE_CONTEXT_KEY } from '../http/middleware/detect-locale'
+import { shareInertiaProps } from '../mvc/inertia/shared'
+import type { Application, I18nPluginOptions } from '../http/Application'
+
+/**
+ * Shape of the `_i18n` Inertia shared prop injected when `createApp({ i18n })`
+ * is configured (unless `i18n.share` is `false`). The client-side
+ * `useTranslation()` hook consumes this.
+ */
+export interface InertiaI18nProps {
+  locale: string
+  fallbackLocale: string
+  messages: Record<string, TranslationMessages>
+}
 
 /**
  * Binds the I18nManager as a singleton in the container.
+ *
+ * When the app is created with `createApp({ i18n })`, this provider also
+ * mounts locale detection middleware (unless `i18n.detect` is `false`),
+ * preloads every supported locale during boot, and shares the request locale
+ * and its messages with Inertia pages as the `_i18n` prop (unless
+ * `i18n.share` is `false`).
  */
 export class I18nServiceProvider extends ServiceProvider {
   register(): void {
-    this.container.singleton('i18n', () => createI18n({ locale: 'en' }))
+    const app = this.application()
+    const options = app?.i18nOptions
+
+    if (options && options.supported.length === 0) {
+      throw new Error('createApp({ i18n }) requires at least one supported locale.')
+    }
+
+    this.container.singleton('i18n', () => {
+      if (!options) {
+        return createI18n({ locale: 'en' })
+      }
+
+      const fallback = resolveFallback(options)
+      return createI18n({
+        locale: fallback,
+        fallbackLocale: fallback,
+        path: options.loader ? undefined : options.path ?? 'lang',
+        loader: options.loader,
+        messages: options.messages,
+      })
+    })
+
+    if (app && options && options.detect !== false) {
+      app.use('*', detectLocaleMiddleware({
+        fallback: resolveFallback(options),
+        ...options.detect,
+        supported: options.supported,
+        i18n: this.container.make<I18nManager>('i18n'),
+      }))
+    }
   }
+
+  async boot(): Promise<void> {
+    const options = this.application()?.i18nOptions
+    if (!options) return
+
+    const manager = this.container.make<I18nManager>('i18n')
+    await manager.loadLocales([...options.supported])
+
+    if (options.share !== false) {
+      const fallback = resolveFallback(options)
+
+      shareInertiaProps((ctx: Context) => {
+        const requestLocale = (ctx.var as Record<string, unknown> | undefined)?.[LOCALE_CONTEXT_KEY]
+        const locale =
+          typeof requestLocale === 'string' && requestLocale.length > 0 ? requestLocale : fallback
+
+        // Insertion order matters to the client: fallback first so the
+        // active locale's messages win on key collisions when flattened.
+        const messages: Record<string, TranslationMessages> = {}
+        if (fallback !== locale) {
+          messages[fallback] = manager.getMessages(fallback)
+        }
+        messages[locale] = manager.getMessages(locale)
+
+        const i18nProps: InertiaI18nProps = { locale, fallbackLocale: fallback, messages }
+        return { _i18n: i18nProps }
+      })
+    }
+  }
+
+  /** The provider works standalone on a bare container (no `app` binding). */
+  private application(): Application | undefined {
+    return this.container.has('app') ? this.container.make<Application>('app') : undefined
+  }
+}
+
+function resolveFallback(options: I18nPluginOptions): string {
+  return options.fallback ?? options.supported[0]!
 }

--- a/packages/server/src/providers/I18nServiceProvider.ts
+++ b/packages/server/src/providers/I18nServiceProvider.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono'
 import { ServiceProvider } from '../container/ServiceProvider'
 import { createI18n, type I18nManager, type TranslationMessages } from '../i18n'
-import { detectLocaleMiddleware, LOCALE_CONTEXT_KEY } from '../http/middleware/detect-locale'
+import { detectLocaleMiddleware, getRequestLocale } from '../http/middleware/detect-locale'
 import { shareInertiaProps } from '../mvc/inertia/shared'
 import type { Application, I18nPluginOptions } from '../http/Application'
 
@@ -39,22 +39,22 @@ export class I18nServiceProvider extends ServiceProvider {
         return createI18n({ locale: 'en' })
       }
 
-      const fallback = resolveFallback(options)
+      const fallback = options.fallback ?? options.supported[0]!
       return createI18n({
         locale: fallback,
         fallbackLocale: fallback,
         path: options.loader ? undefined : options.path ?? 'lang',
         loader: options.loader,
-        messages: options.messages,
       })
     })
 
     if (app && options && options.detect !== false) {
+      const manager = this.container.make<I18nManager>('i18n')
       app.use('*', detectLocaleMiddleware({
-        fallback: resolveFallback(options),
         ...options.detect,
         supported: options.supported,
-        i18n: this.container.make<I18nManager>('i18n'),
+        fallback: manager.getLocale(),
+        i18n: manager,
       }))
     }
   }
@@ -67,22 +67,31 @@ export class I18nServiceProvider extends ServiceProvider {
     await manager.loadLocales([...options.supported])
 
     if (options.share !== false) {
-      const fallback = resolveFallback(options)
+      const fallback = manager.getFallbackLocale() ?? manager.getLocale()
+      const supported = new Set(options.supported)
+
+      // Props are built once per supported locale; messages added to the
+      // manager after a locale is cached are not picked up — same load-once
+      // lifecycle as the locale middleware's translators. Locales outside
+      // `supported` (a custom middleware setting an unvalidated `locale`
+      // context variable) are served uncached so the map stays bounded.
+      const propsByLocale = new Map<string, InertiaI18nProps>()
 
       shareInertiaProps((ctx: Context) => {
-        const requestLocale = (ctx.var as Record<string, unknown> | undefined)?.[LOCALE_CONTEXT_KEY]
-        const locale =
-          typeof requestLocale === 'string' && requestLocale.length > 0 ? requestLocale : fallback
+        const locale = getRequestLocale(ctx) ?? fallback
 
-        // Insertion order matters to the client: fallback first so the
-        // active locale's messages win on key collisions when flattened.
-        const messages: Record<string, TranslationMessages> = {}
-        if (fallback !== locale) {
-          messages[fallback] = manager.getMessages(fallback)
+        let i18nProps = propsByLocale.get(locale)
+        if (!i18nProps) {
+          i18nProps = {
+            locale,
+            fallbackLocale: fallback,
+            messages: manager.messagesForLocale(locale),
+          }
+          if (supported.has(locale)) {
+            propsByLocale.set(locale, i18nProps)
+          }
         }
-        messages[locale] = manager.getMessages(locale)
 
-        const i18nProps: InertiaI18nProps = { locale, fallbackLocale: fallback, messages }
         return { _i18n: i18nProps }
       })
     }
@@ -92,8 +101,4 @@ export class I18nServiceProvider extends ServiceProvider {
   private application(): Application | undefined {
     return this.container.has('app') ? this.container.make<Application>('app') : undefined
   }
-}
-
-function resolveFallback(options: I18nPluginOptions): string {
-  return options.fallback ?? options.supported[0]!
 }

--- a/packages/server/tests/i18n/fixtures/lang/en/messages.json
+++ b/packages/server/tests/i18n/fixtures/lang/en/messages.json
@@ -1,0 +1,6 @@
+{
+  "hello": "Hello",
+  "welcome": "Welcome, :name!",
+  "items": "One item|:count items",
+  "enOnly": "English only"
+}

--- a/packages/server/tests/i18n/fixtures/lang/ja/messages.json
+++ b/packages/server/tests/i18n/fixtures/lang/ja/messages.json
@@ -1,0 +1,5 @@
+{
+  "hello": "こんにちは",
+  "welcome": "ようこそ、:nameさん！",
+  "items": ":count個"
+}

--- a/packages/server/tests/i18n/i18n-plugin.test.ts
+++ b/packages/server/tests/i18n/i18n-plugin.test.ts
@@ -51,13 +51,13 @@ function makeApp(overrides: Partial<I18nPluginOptions> = {}) {
   return app
 }
 
-async function greet(app: Awaited<ReturnType<typeof makeApp>>, path = '/greet', headers: Record<string, string> = {}) {
+async function greet(app: ReturnType<typeof makeApp>, path = '/greet', headers: Record<string, string> = {}) {
   const response = await app.fetch(new Request(`http://example.com${path}`, { headers }))
   expect(response.status).toBe(200)
   return response.json() as Promise<Record<string, string>>
 }
 
-async function inertiaPageProps(app: Awaited<ReturnType<typeof makeApp>>, path = '/page'): Promise<Record<string, any>> {
+async function inertiaPageProps(app: ReturnType<typeof makeApp>, path = '/page'): Promise<Record<string, any>> {
   const response = await app.fetch(
     new Request(`http://example.com${path}`, {
       headers: { 'X-Inertia': 'true', 'X-Inertia-Version': '1' },
@@ -192,14 +192,15 @@ describe('createApp({ i18n })', () => {
     expect(body.hello).toBe('Hello')
   })
 
-  test('preloaded messages work without a loader', async () => {
+  test('loads lang/<locale>/*.json fixtures through the default JsonLoader path', async () => {
     const app = createApp({
-      i18n: { supported: ['en', 'ja'], messages: structuredClone(MESSAGES), path: undefined },
+      i18n: { supported: ['en', 'ja'], path: new URL('./fixtures/lang', import.meta.url).pathname },
     })
     app.router.get('/greet', [GreetingController, 'show'])
     await app.boot()
 
     const body = await greet(app, '/greet?locale=ja')
     expect(body.hello).toBe('こんにちは')
+    expect(body.fallback).toBe('English only')
   })
 })

--- a/packages/server/tests/i18n/i18n-plugin.test.ts
+++ b/packages/server/tests/i18n/i18n-plugin.test.ts
@@ -192,6 +192,35 @@ describe('createApp({ i18n })', () => {
     expect(body.hello).toBe('Hello')
   })
 
+  test('a downstream locale override is honored by t/tc, locale, and _i18n alike', async () => {
+    // Simulates middleware running after locale detection that replaces the
+    // request locale (e.g. a per-user preference read from the session).
+    const app = createApp({
+      i18n: { supported: ['en', 'ja'], loader: new MemoryLoader(structuredClone(MESSAGES)) },
+      boot: (hono) => {
+        hono.use('*', async (c, next) => {
+          c.set('locale' as never, 'ja' as never)
+          await next()
+        })
+      },
+    })
+    app.router.get('/greet', [GreetingController, 'show'])
+    app.router.get('/page', [PageController, 'show'])
+    await app.boot()
+
+    const body = await greet(app)
+    expect(body.locale).toBe('ja')
+    expect(body.hello).toBe('こんにちは')
+
+    const props = await inertiaPageProps(app)
+    expect(props._i18n.locale).toBe('ja')
+  })
+
+  test('rejects a fallback that is not in supported', async () => {
+    const app = makeApp({ fallback: 'fr' })
+    await expect(app.boot()).rejects.toThrow('fallback')
+  })
+
   test('loads lang/<locale>/*.json fixtures through the default JsonLoader path', async () => {
     const app = createApp({
       i18n: { supported: ['en', 'ja'], path: new URL('./fixtures/lang', import.meta.url).pathname },

--- a/packages/server/tests/i18n/i18n-plugin.test.ts
+++ b/packages/server/tests/i18n/i18n-plugin.test.ts
@@ -1,0 +1,205 @@
+import { describe, test, expect, afterEach } from 'bun:test'
+import { Controller, createApp, MemoryLoader, I18nServiceProvider, type I18nManager, type I18nPluginOptions } from '../../src'
+import { setInertiaSharedProps } from '../../src/mvc/inertia/shared'
+
+const MESSAGES = {
+  en: {
+    messages: {
+      hello: 'Hello',
+      welcome: 'Welcome, :name!',
+      items: 'One item|:count items',
+      enOnly: 'English only',
+    },
+  },
+  ja: {
+    messages: {
+      hello: 'こんにちは',
+      welcome: 'ようこそ、:nameさん！',
+      items: ':count個',
+    },
+  },
+}
+
+class GreetingController extends Controller {
+  async show() {
+    return this.json({
+      locale: this.locale,
+      hello: this.t('messages.hello'),
+      welcome: this.t('messages.welcome', { name: 'Guren' }),
+      many: this.tc('messages.items', 5),
+      fallback: this.t('messages.enOnly'),
+    })
+  }
+}
+
+class PageController extends Controller {
+  async show() {
+    return this.inertia('Docs/Show', {})
+  }
+}
+
+function makeApp(overrides: Partial<I18nPluginOptions> = {}) {
+  const app = createApp({
+    i18n: {
+      supported: ['en', 'ja'],
+      loader: new MemoryLoader(structuredClone(MESSAGES)),
+      ...overrides,
+    },
+  })
+  app.router.get('/greet', [GreetingController, 'show'])
+  app.router.get('/page', [PageController, 'show'])
+  return app
+}
+
+async function greet(app: Awaited<ReturnType<typeof makeApp>>, path = '/greet', headers: Record<string, string> = {}) {
+  const response = await app.fetch(new Request(`http://example.com${path}`, { headers }))
+  expect(response.status).toBe(200)
+  return response.json() as Promise<Record<string, string>>
+}
+
+async function inertiaPageProps(app: Awaited<ReturnType<typeof makeApp>>, path = '/page'): Promise<Record<string, any>> {
+  const response = await app.fetch(
+    new Request(`http://example.com${path}`, {
+      headers: { 'X-Inertia': 'true', 'X-Inertia-Version': '1' },
+    }),
+  )
+  expect(response.status).toBe(200)
+  const page = (await response.json()) as { props: Record<string, any> }
+  return page.props
+}
+
+afterEach(() => {
+  // The Inertia shared-props resolver is module-global state; each booted
+  // app's I18nServiceProvider appends to it.
+  setInertiaSharedProps(null)
+})
+
+describe('createApp({ i18n })', () => {
+  test('preloads every supported locale during boot', async () => {
+    const app = makeApp()
+    await app.boot()
+
+    const manager = app.container.make<I18nManager>('i18n')
+    expect(manager.isLocaleLoaded('en')).toBe(true)
+    expect(manager.isLocaleLoaded('ja')).toBe(true)
+  })
+
+  test('throws when supported is empty', async () => {
+    const app = makeApp({ supported: [] })
+    await expect(app.boot()).rejects.toThrow('at least one supported locale')
+  })
+
+  test('controller t/tc/locale use the fallback locale by default', async () => {
+    const app = makeApp()
+    await app.boot()
+
+    expect(await greet(app)).toEqual({
+      locale: 'en',
+      hello: 'Hello',
+      welcome: 'Welcome, Guren!',
+      many: '5 items',
+      fallback: 'English only',
+    })
+  })
+
+  test('locale detection resolves the query parameter and translates per request', async () => {
+    const app = makeApp()
+    await app.boot()
+
+    expect(await greet(app, '/greet?locale=ja')).toEqual({
+      locale: 'ja',
+      hello: 'こんにちは',
+      welcome: 'ようこそ、Gurenさん！',
+      many: '5個',
+      fallback: 'English only',
+    })
+  })
+
+  test('locale detection resolves Accept-Language', async () => {
+    const app = makeApp()
+    await app.boot()
+
+    const body = await greet(app, '/greet', { 'Accept-Language': 'ja-JP,ja;q=0.9' })
+    expect(body.locale).toBe('ja')
+    expect(body.hello).toBe('こんにちは')
+  })
+
+  test('detect: false skips the locale detection middleware', async () => {
+    const app = makeApp({ detect: false })
+    await app.boot()
+
+    const body = await greet(app, '/greet?locale=ja')
+    expect(body.locale).toBe('en')
+    expect(body.hello).toBe('Hello')
+  })
+
+  test('shares _i18n with Inertia pages for the resolved locale', async () => {
+    const app = makeApp()
+    await app.boot()
+
+    const props = await inertiaPageProps(app, '/page?locale=ja')
+    expect(props._i18n.locale).toBe('ja')
+    expect(props._i18n.fallbackLocale).toBe('en')
+    expect(Object.keys(props._i18n.messages)).toEqual(['en', 'ja'])
+    expect(props._i18n.messages.ja.messages.hello).toBe('こんにちは')
+  })
+
+  test('shares only the fallback messages when it is the resolved locale', async () => {
+    const app = makeApp()
+    await app.boot()
+
+    const props = await inertiaPageProps(app)
+    expect(props._i18n.locale).toBe('en')
+    expect(Object.keys(props._i18n.messages)).toEqual(['en'])
+  })
+
+  test('share: false leaves Inertia props untouched', async () => {
+    const app = makeApp({ share: false })
+    await app.boot()
+
+    const props = await inertiaPageProps(app)
+    expect(props._i18n).toBeUndefined()
+  })
+
+  test('fallback option overrides the first supported locale', async () => {
+    const app = makeApp({ supported: ['en', 'ja'], fallback: 'ja' })
+    await app.boot()
+
+    const body = await greet(app)
+    expect(body.locale).toBe('ja')
+    expect(body.hello).toBe('こんにちは')
+  })
+
+  test('a user-supplied I18nServiceProvider subclass owns the wiring', async () => {
+    let registered = 0
+
+    class CustomI18nProvider extends I18nServiceProvider {
+      override register(): void {
+        registered += 1
+        super.register()
+      }
+    }
+
+    const app = createApp({
+      i18n: { supported: ['en'], loader: new MemoryLoader(structuredClone(MESSAGES)) },
+      providers: [CustomI18nProvider],
+    })
+    app.router.get('/greet', [GreetingController, 'show'])
+    await app.boot()
+
+    expect(registered).toBe(1)
+    const body = await greet(app)
+    expect(body.hello).toBe('Hello')
+  })
+
+  test('preloaded messages work without a loader', async () => {
+    const app = createApp({
+      i18n: { supported: ['en', 'ja'], messages: structuredClone(MESSAGES), path: undefined },
+    })
+    app.router.get('/greet', [GreetingController, 'show'])
+    await app.boot()
+
+    const body = await greet(app, '/greet?locale=ja')
+    expect(body.hello).toBe('こんにちは')
+  })
+})

--- a/packages/server/tests/i18n/i18n.test.ts
+++ b/packages/server/tests/i18n/i18n.test.ts
@@ -148,6 +148,20 @@ describe('Translator', () => {
       translator.addMessages('en', { format: 'Hello, {name}!' })
       expect(translator.t('format', { name: 'World' })).toBe('Hello, World!')
     })
+
+    it('keeps $ sequences in replacement values literal', () => {
+      expect(translator.t('welcome', { name: '$& $1 $$' })).toBe('Welcome, $& $1 $$!')
+    })
+
+    it('treats regex metacharacters in replacement keys literally', () => {
+      translator.addMessages('en', { special: 'Total: :price[0] / {price[0]}' })
+      expect(translator.t('special', { 'price[0]': '42' })).toBe('Total: 42 / 42')
+    })
+
+    it('returns an empty translation as-is', () => {
+      translator.addMessages('en', { empty: '' })
+      expect(translator.t('empty')).toBe('')
+    })
   })
 
   describe('tc()', () => {
@@ -164,6 +178,11 @@ describe('Translator', () => {
       translator.addMessages('en', { message: ':count :type|:count :types' })
       expect(translator.tc('message', 1, { type: 'apple', types: 'apples' })).toBe('1 apple')
       expect(translator.tc('message', 3, { type: 'apple', types: 'apples' })).toBe('3 apples')
+    })
+
+    it('treats an empty translation as missing', () => {
+      translator.addMessages('en', { empty: '' })
+      expect(translator.tc('empty', 2)).toBe('empty')
     })
   })
 


### PR DESCRIPTION
## Summary

The i18n subsystem (I18nManager, Translator, pluralization, JSON/memory loaders, `detectLocaleMiddleware`) existed but had no path from an app's configuration into a request: `I18nServiceProvider` was a stub hard-coding `locale: 'en'`, controllers had no translation helpers, and nothing reached the Inertia client. This PR wires the subsystem into the application. It is the first of a series (client `useTranslation()` hook and typed translation keys follow separately).

### `createApp({ i18n })`

```ts
createApp({
  i18n: {
    supported: ['en', 'ja'],   // first entry is the default fallback
    path: 'lang',              // lang/<locale>/*.json via JsonLoader (default)
    // loader: new MemoryLoader(...)  // e.g. bundled messages on serverless
  },
})
```

When set, `I18nServiceProvider` builds the `i18n` container binding from the options, preloads every supported locale during `boot()` (no module-scope I/O, so serverless targets stay safe), and mounts `detectLocaleMiddleware` (query → cookie → `Accept-Language`; opt out with `detect: false`). Apps registering their own `I18nServiceProvider` subclass keep ownership of the wiring, following the existing Error/Inertia provider override convention — now shared as one `hasUserProviderOf()` helper.

### Controller helpers

`this.t(key, replacements?)`, `this.tc(key, count, replacements?)`, and `this.locale` resolve through the request-scoped translator bound by the locale middleware, falling back to a translator scoped to the resolved locale from the container's `i18n` binding (then the `setI18n()` global) — the same order the Inertia `<html lang>` default already used. The context reads are centralized as `getRequestLocale()` / `getRequestTranslator()` exported from the middleware module.

### Inertia `_i18n` shared props

Responses share `{ locale, fallbackLocale, messages }` (active locale plus fallback only, built once per supported locale; disable with `share: false`) via `shareInertiaProps`, laying the groundwork for the client-side hook. The fallback+active catalog pairing lives in `I18nManager.messagesForLocale()`, shared with `forLocale()`.

## Testing

- `bun run build` / root `bun run typecheck`
- `bun run test:bun` (3572 pass) including new integration tests for boot preloading, per-request locale detection (query / Accept-Language), `detect: false` / `share: false` opt-outs, fallback override, user-subclass ownership, and the default JsonLoader path against `lang/<locale>/*.json` fixtures
- `bun run test:examples` (251 pass)
- `bun run audit:core-first` / `bun run audit:docs`