### PR TITLE
feat(cli): typed translation keys and guren check --i18n

### DIFF
--- a/.changeset/i18n-typed-keys.md
+++ b/.changeset/i18n-typed-keys.md
@@ -1,0 +1,25 @@
+---
+'@guren/cli': minor
+'@guren/server': minor
+'@guren/inertia-client': minor
+---
+
+Typed translation keys and translation catalog checks
+
+`guren codegen` now emits `.guren/translations.gen.ts` for apps with a
+`lang/` directory: a `TranslationKey` union built from every
+`lang/<locale>/*.json` catalog (namespace = file name, nested keys
+flattened to dot notation), plus declaration-merging augmentations that
+register it with the server and client. `this.t()` / `this.tc()` in
+controllers and `useTranslation()` in pages then autocomplete keys and
+reject unknown ones at compile time. Apps without `lang/` (or without the
+generated file) keep plain `string` keys — the new `GurenTranslationKeys`
+registry defaults to empty. The Vite route-types plugin watches `lang/`
+and regenerates on change.
+
+`guren check` gains translation catalog checks, content-activated like
+`--docs`: unparseable catalog JSON (fail — the loader silently skips such
+files), keys missing from individual locales (fail — they render in the
+fallback language), and interpolation placeholders that differ between
+locales for the same key (warn). `guren check --i18n` runs them alone and
+exits non-zero on failures.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ bunx guren check --json         # Check results as JSON
 bunx guren check --arch         # Architecture boundary checks only (guren.arch.ts) — fast path for edit hooks
 bunx guren check --docs         # Doc-link checks only: OKF frontmatter (type/entities/related) + body markdown links + @docs tags (exits non-zero on failures)
 bunx guren check --spec         # Spec drift checks only: docs/spec/ vs regenerated views (exits non-zero on failures)
+bunx guren check --i18n         # Translation catalog checks only: lang/<locale> key parity + interpolation placeholders (exits non-zero on failures)
 bunx guren spec:generate        # Generate spec views (er/domain/screens/modules) into docs/spec/ — deterministic, committed, drift-gated
 bunx guren check --changed      # Restrict file-scanning checks to files changed vs. the merge base with main
 bunx guren audit                # Security audit: validation/auth on mutating routes, raw SQL, secrets, mass assignment
@@ -370,6 +371,8 @@ export const handler = createLambdaHandler(app)
 | `packages/cli/src/docs-frontmatter.ts` | AI agent: the YAML-subset frontmatter parser (OKF fields) |
 | `packages/cli/src/docs-links.ts` | AI agent: markdown link scanning shared by check, graph, and renderer |
 | `packages/cli/src/docs-check.ts` | AI agent: doc-link validation (`guren check --docs`) |
+| `packages/cli/src/i18n-types.ts` | AI agent: typed translation keys (`.guren/translations.gen.ts` from `lang/`) |
+| `packages/cli/src/i18n-check.ts` | AI agent: translation catalog checks (`guren check --i18n`) |
 | `packages/cli/src/make-adr.ts` | AI agent: numbered ADR scaffolding (`make:adr`) |
 | `packages/cli/src/spec-generate.ts` | AI agent: spec view orchestration (`spec:generate`, RFC 0004) |
 | `packages/cli/src/spec-check.ts` | AI agent: spec drift gate (`guren check --spec`) |

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -38,6 +38,7 @@ import { showMigrationStatus } from './db-status'
 import type { WriterOptions } from './utils'
 import { generateRouteTypes } from './routes-types'
 import { generatePageTypes } from './pages-types'
+import { generateTranslationTypes } from './i18n-types'
 import { generateDataTypes } from './data-types'
 import { generateApiClientTypes } from './api-client-types'
 import { generateOpenApiSpec } from './openapi-generate'
@@ -894,6 +895,16 @@ const codegenCommand = defineCommand({
       ...writerOptions,
     })
     if (pagesOutputPath) consola.success(`Page helpers generated at ${pagesOutputPath}`)
+
+    // Translation keys only exist for apps with a lang/ directory; the
+    // generator emits nothing otherwise, keeping t() keys plain strings.
+    const { outputPath: translationsOutputPath, keyCount } = await generateTranslationTypes({
+      appRoot: args.app,
+      ...writerOptions,
+    })
+    if (translationsOutputPath) {
+      consola.success(`Translation keys generated at ${translationsOutputPath} (${keyCount} keys)`)
+    }
 
     // Route/API artifacts default to routes/web.ts; skip only when no routes file exists.
     const { existsSync } = await import('node:fs')
@@ -1800,6 +1811,10 @@ const checkCommand = defineCommand({
       type: 'boolean',
       description: 'Run only spec drift checks (docs/spec/ vs regenerated views).',
     },
+    i18n: {
+      type: 'boolean',
+      description: 'Run only translation catalog checks (lang/<locale> key and placeholder parity).',
+    },
     changed: {
       type: 'boolean',
       description: 'Restrict file-scanning checks to files changed vs. the merge base with main.',
@@ -1812,8 +1827,8 @@ const checkCommand = defineCommand({
   async run({ args }) {
     // --ci promises a full-suite gate; letting a suite flag narrow the run
     // underneath it would report success while docs/spec/core went unchecked.
-    if (args.ci && (args.arch || args.docs || args.spec)) {
-      consola.error('check --ci runs the full suite — drop --arch/--docs/--spec (they gate on their own).')
+    if (args.ci && (args.arch || args.docs || args.spec || args.i18n)) {
+      consola.error('check --ci runs the full suite — drop --arch/--docs/--spec/--i18n (they gate on their own).')
       process.exitCode = 1
       return
     }
@@ -1825,6 +1840,7 @@ const checkCommand = defineCommand({
       arch: Boolean(args.arch),
       docs: Boolean(args.docs),
       spec: Boolean(args.spec),
+      i18n: Boolean(args.i18n),
       changed: Boolean(args.changed),
     })
 
@@ -1840,7 +1856,7 @@ const checkCommand = defineCommand({
     // reserved for a major release). These flags are newer, with no prior
     // contract to preserve, so they can gate CI from day one — that's the
     // intended way to enforce checks in CI without breaking the default.
-    if ((args.arch || args.docs || args.spec) && report.failCount > 0) {
+    if ((args.arch || args.docs || args.spec || args.i18n) && report.failCount > 0) {
       process.exitCode = 1
     }
     // --ci also gates on warns: most integrity problems (a missing codegen

--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -248,10 +248,16 @@ export async function runCheck(options: RunCheckOptions = {}): Promise<CheckRepo
   }
 
   // 10.5. Translation catalog checks (lang/<locale>/*.json). Content-
-  // activated like docs: apps without lang/ contribute zero results.
+  // activated like docs: apps without lang/ contribute zero results. Parity
+  // is inherently whole-catalog, so --changed gates the suite as a unit:
+  // skip when no lang/ file changed, run fully otherwise.
   if (runs('i18n')) {
-    const i18nResults = await runI18nCheck({ cwd })
-    checks.push(...i18nResults)
+    const langChanged =
+      !changedFiles || [...changedFiles].some((file) => file === 'lang' || file.startsWith('lang/'))
+    if (langChanged) {
+      const i18nResults = await runI18nCheck({ cwd })
+      checks.push(...i18nResults)
+    }
   }
 
   // 11. Check architecture boundaries (guren.arch.ts + derived module rules)

--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -32,6 +32,7 @@ import { extractInertiaPageRefs, resolveInertiaPageFile, expectedInertiaPagePath
 import { appEmitsPageManifest } from './pages-types'
 import { runArchCheck } from './arch-check'
 import { runDocsCheck } from './docs-check'
+import { runI18nCheck } from './i18n-check'
 import { runSpecCheck } from './spec-check'
 import { getChangedFiles } from './changed-files'
 import { check, type CheckResult, type CheckReport, type CheckStatus } from './check-result'
@@ -62,6 +63,12 @@ export interface RunCheckOptions {
   docs?: boolean
   /** Run spec drift checks only (docs/spec/ vs regenerated views). */
   spec?: boolean
+  /**
+   * Run translation catalog checks only (lang/<locale>/*.json key and
+   * placeholder parity). Content-activated: apps without lang/ contribute
+   * zero results.
+   */
+  i18n?: boolean
 }
 
 /**
@@ -124,12 +131,13 @@ export async function runCheck(options: RunCheckOptions = {}): Promise<CheckRepo
 
   // `--arch` / `--docs` / `--spec` select suites; combining them runs the
   // union (never silently nothing). No flag = every suite.
-  const selected = new Set<'arch' | 'docs' | 'spec'>([
+  const selected = new Set<'arch' | 'docs' | 'spec' | 'i18n'>([
     ...(options.arch ? (['arch'] as const) : []),
     ...(options.docs ? (['docs'] as const) : []),
     ...(options.spec ? (['spec'] as const) : []),
+    ...(options.i18n ? (['i18n'] as const) : []),
   ])
-  const runs = (suite: 'core' | 'arch' | 'docs' | 'spec'): boolean =>
+  const runs = (suite: 'core' | 'arch' | 'docs' | 'spec' | 'i18n'): boolean =>
     selected.size === 0 || (suite !== 'core' && selected.has(suite))
 
   if (runs('core')) {
@@ -237,6 +245,13 @@ export async function runCheck(options: RunCheckOptions = {}): Promise<CheckRepo
   if (runs('spec')) {
     const specResults = await runSpecCheck({ cwd, routesFile: options.routesFile, changedFiles })
     checks.push(...specResults)
+  }
+
+  // 10.5. Translation catalog checks (lang/<locale>/*.json). Content-
+  // activated like docs: apps without lang/ contribute zero results.
+  if (runs('i18n')) {
+    const i18nResults = await runI18nCheck({ cwd })
+    checks.push(...i18nResults)
   }
 
   // 11. Check architecture boundaries (guren.arch.ts + derived module rules)

--- a/packages/cli/src/i18n-check.ts
+++ b/packages/cli/src/i18n-check.ts
@@ -51,7 +51,42 @@ export async function runI18nCheck(options: RunI18nCheckOptions): Promise<CheckR
     }
   }
 
+  // Keys with a literal dot in a JSON property or file name can never be
+  // resolved by t()/tc() — dots are always path separators at runtime.
+  const unreachable = new Map<string, string[]>()
+  for (const catalog of catalogs) {
+    for (const key of catalog.unreachableKeys) {
+      const locales = unreachable.get(key) ?? []
+      locales.push(catalog.locale)
+      unreachable.set(key, locales)
+    }
+  }
+  for (const [key, locales] of [...unreachable.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    results.push(
+      check(
+        `i18n-unreachable:${key}`,
+        `${key} reachability`,
+        'fail',
+        `'${key}' contains a literal dot in a JSON property or file name (${locales.join(', ')}) — dots are path separators, so t() can never resolve it.`,
+        'Nest objects instead of dotted property names, and keep dots out of catalog file names.',
+      ),
+    )
+  }
+
   const allKeys = new Set(catalogs.flatMap((catalog) => [...catalog.entries.keys()]))
+
+  if (allKeys.size === 0) {
+    results.push(
+      check(
+        'i18n-empty',
+        `${langDir}/ catalogs`,
+        'warn',
+        `${langDir}/ has locale directories but no resolvable translation keys.`,
+        `Add <namespace>.json files with string values under ${langDir}/<locale>/.`,
+      ),
+    )
+    return results
+  }
 
   for (const catalog of catalogs) {
     const missing = [...allKeys].filter((key) => !catalog.entries.has(key)).sort()
@@ -77,16 +112,22 @@ export async function runI18nCheck(options: RunI18nCheckOptions): Promise<CheckR
 }
 
 /**
- * Placeholders a message interpolates: `:name` and `{name}` forms. Requires
- * an identifier-style leading character so times (`9:00`) and ratios don't
- * read as placeholders.
+ * Placeholders a message interpolates: `:name` and `{name}` forms. The
+ * runtime accepts any replacement key, so this is deliberately narrower.
+ * The colon form matches ASCII identifiers only — it has no closing
+ * delimiter, so a wider class would swallow adjoining CJK text
+ * (`:count個` must read as `count`), and times (`9:00`) must not read as
+ * placeholders at all. The brace form is delimited and therefore accepts
+ * Unicode names, dots, and dashes (`{名前}`, `{user.name}`). Grammar
+ * shared with Translator.applyReplacements (server) and the client
+ * mirror; keep in sync.
  */
 export function extractPlaceholders(message: string): Set<string> {
   const placeholders = new Set<string>()
-  for (const match of message.matchAll(/:([A-Za-z_][A-Za-z0-9_]*)/g)) {
+  for (const match of message.matchAll(/:([A-Za-z_][A-Za-z0-9_-]*)/g)) {
     placeholders.add(match[1]!)
   }
-  for (const match of message.matchAll(/\{([A-Za-z_][A-Za-z0-9_]*)\}/g)) {
+  for (const match of message.matchAll(/\{([\p{L}_][\p{L}\p{N}_.-]*)\}/gu)) {
     placeholders.add(match[1]!)
   }
   return placeholders

--- a/packages/cli/src/i18n-check.ts
+++ b/packages/cli/src/i18n-check.ts
@@ -1,0 +1,132 @@
+/**
+ * Translation catalog consistency checks (`guren check --i18n`).
+ *
+ * Content-activated: apps without a `lang/` directory contribute zero
+ * results. Three rules over `lang/<locale>/*.json`:
+ *
+ * - **Invalid JSON** (`fail`): JsonLoader skips unparseable files with only
+ *   a console warning, so every key in the file silently disappears at
+ *   runtime.
+ * - **Key parity** (`fail`): a key present in some locale but missing from
+ *   another renders in the fallback language for that locale's users.
+ * - **Placeholder parity** (`warn`): `:name`/`{name}` placeholders that
+ *   differ between locales for the same key usually mean a lost or
+ *   mistranslated variable — warn rather than fail because a locale can
+ *   legitimately drop a placeholder (e.g. a plural-less phrasing).
+ *
+ * Usage scanning (`t('...')` call sites referencing unknown keys) is
+ * deliberately out of scope: the generated `TranslationKey` union already
+ * enforces that at compile time without the false positives of an AST
+ * heuristic.
+ */
+import { formatTruncatedList } from './discovery'
+import { readTranslationCatalogs, type TranslationCatalog } from './i18n-types'
+import { check, type CheckResult } from './check-result'
+
+export interface RunI18nCheckOptions {
+  cwd: string
+  /** Translation directory (defaults to `lang`). */
+  langDir?: string
+}
+
+export async function runI18nCheck(options: RunI18nCheckOptions): Promise<CheckResult[]> {
+  const langDir = options.langDir ?? 'lang'
+  const catalogs = await readTranslationCatalogs(options.cwd, langDir)
+  if (catalogs.length === 0) {
+    return []
+  }
+
+  const results: CheckResult[] = []
+
+  for (const catalog of catalogs) {
+    for (const file of catalog.invalidFiles) {
+      results.push(
+        check(
+          `i18n-json:${file}`,
+          `${file}`,
+          'fail',
+          `${file} is not valid JSON — the loader skips it, so all of its keys silently fall back at runtime.`,
+          'Fix the JSON syntax, then rerun `guren codegen`.',
+          file,
+        ),
+      )
+    }
+  }
+
+  const allKeys = new Set(catalogs.flatMap((catalog) => [...catalog.entries.keys()]))
+
+  for (const catalog of catalogs) {
+    const missing = [...allKeys].filter((key) => !catalog.entries.has(key)).sort()
+    results.push(
+      check(
+        `i18n-parity:${catalog.locale}`,
+        `${langDir}/${catalog.locale} key parity`,
+        missing.length === 0 ? 'pass' : 'fail',
+        missing.length === 0
+          ? `Covers all ${allKeys.size} translation keys.`
+          : `Missing ${missing.length} of ${allKeys.size} keys: ${formatTruncatedList(missing, 5)}. These render in the fallback locale.`,
+        missing.length === 0
+          ? undefined
+          : `Add the missing keys to ${langDir}/${catalog.locale}/ (namespace = file name).`,
+      ),
+    )
+  }
+
+  results.push(...checkPlaceholderParity(catalogs, langDir))
+
+  return results
+}
+
+/**
+ * Placeholders a message interpolates: `:name` and `{name}` forms. Requires
+ * an identifier-style leading character so times (`9:00`) and ratios don't
+ * read as placeholders.
+ */
+export function extractPlaceholders(message: string): Set<string> {
+  const placeholders = new Set<string>()
+  for (const match of message.matchAll(/:([A-Za-z_][A-Za-z0-9_]*)/g)) {
+    placeholders.add(match[1]!)
+  }
+  for (const match of message.matchAll(/\{([A-Za-z_][A-Za-z0-9_]*)\}/g)) {
+    placeholders.add(match[1]!)
+  }
+  return placeholders
+}
+
+function checkPlaceholderParity(catalogs: TranslationCatalog[], langDir: string): CheckResult[] {
+  const results: CheckResult[] = []
+  const allKeys = new Set(catalogs.flatMap((catalog) => [...catalog.entries.keys()]))
+
+  for (const key of [...allKeys].sort()) {
+    const holders = catalogs
+      .filter((catalog) => catalog.entries.has(key))
+      .map((catalog) => ({
+        locale: catalog.locale,
+        placeholders: extractPlaceholders(catalog.entries.get(key)!),
+      }))
+    if (holders.length < 2) continue
+
+    const union = new Set(holders.flatMap((holder) => [...holder.placeholders]))
+    const mismatched = holders.filter((holder) => holder.placeholders.size !== union.size)
+    if (mismatched.length === 0) continue
+
+    const detail = mismatched
+      .map((holder) => {
+        const missing = [...union].filter((name) => !holder.placeholders.has(name)).sort()
+        return `${holder.locale} lacks :${missing.join(', :')}`
+      })
+      .join('; ')
+
+    results.push(
+      check(
+        `i18n-placeholders:${key}`,
+        `${key} placeholders`,
+        'warn',
+        `Placeholder mismatch across locales (${detail}).`,
+        `Align the interpolated variables for '${key}' across ${langDir}/<locale>/, or confirm the wording intentionally drops them.`,
+      ),
+    )
+  }
+
+  return results
+}

--- a/packages/cli/src/i18n-check.ts
+++ b/packages/cli/src/i18n-check.ts
@@ -20,18 +20,16 @@
  * heuristic.
  */
 import { formatTruncatedList } from './discovery'
-import { readTranslationCatalogs, type TranslationCatalog } from './i18n-types'
+import { DEFAULT_LANG_DIR, readTranslationCatalogs, type TranslationCatalog } from './i18n-types'
 import { check, type CheckResult } from './check-result'
 
 export interface RunI18nCheckOptions {
   cwd: string
-  /** Translation directory (defaults to `lang`). */
-  langDir?: string
 }
 
 export async function runI18nCheck(options: RunI18nCheckOptions): Promise<CheckResult[]> {
-  const langDir = options.langDir ?? 'lang'
-  const catalogs = await readTranslationCatalogs(options.cwd, langDir)
+  const langDir = DEFAULT_LANG_DIR
+  const catalogs = await readTranslationCatalogs(options.cwd)
   if (catalogs.length === 0) {
     return []
   }
@@ -43,7 +41,7 @@ export async function runI18nCheck(options: RunI18nCheckOptions): Promise<CheckR
       results.push(
         check(
           `i18n-json:${file}`,
-          `${file}`,
+          file,
           'fail',
           `${file} is not valid JSON — the loader skips it, so all of its keys silently fall back at runtime.`,
           'Fix the JSON syntax, then rerun `guren codegen`.',
@@ -57,6 +55,7 @@ export async function runI18nCheck(options: RunI18nCheckOptions): Promise<CheckR
 
   for (const catalog of catalogs) {
     const missing = [...allKeys].filter((key) => !catalog.entries.has(key)).sort()
+
     results.push(
       check(
         `i18n-parity:${catalog.locale}`,
@@ -72,7 +71,7 @@ export async function runI18nCheck(options: RunI18nCheckOptions): Promise<CheckR
     )
   }
 
-  results.push(...checkPlaceholderParity(catalogs, langDir))
+  results.push(...checkPlaceholderParity(catalogs, allKeys, langDir))
 
   return results
 }
@@ -93,9 +92,12 @@ export function extractPlaceholders(message: string): Set<string> {
   return placeholders
 }
 
-function checkPlaceholderParity(catalogs: TranslationCatalog[], langDir: string): CheckResult[] {
+function checkPlaceholderParity(
+  catalogs: TranslationCatalog[],
+  allKeys: Set<string>,
+  langDir: string,
+): CheckResult[] {
   const results: CheckResult[] = []
-  const allKeys = new Set(catalogs.flatMap((catalog) => [...catalog.entries.keys()]))
 
   for (const key of [...allKeys].sort()) {
     const holders = catalogs

--- a/packages/cli/src/i18n-types.ts
+++ b/packages/cli/src/i18n-types.ts
@@ -1,0 +1,169 @@
+/**
+ * Generates typed translation keys from the app's `lang/` directory.
+ *
+ * Scans `lang/<locale>/*.json` (the layout `createApp({ i18n })` loads via
+ * JsonLoader: one namespace per file), flattens nested objects into
+ * dot-notation keys prefixed with the file's namespace, and emits
+ * `.guren/translations.gen.ts` exporting a `TranslationKey` union plus
+ * declaration-merging augmentations that type `this.t()` / `this.tc()` on
+ * the server and `useTranslation()` on the client. Apps without a `lang/`
+ * directory get no file — the registries stay empty and keys degrade to
+ * `string`.
+ *
+ * The union covers every key present in *any* locale (the CLI cannot know
+ * which locale the app configured as fallback); `guren check --i18n` is the
+ * companion that reports keys missing from individual locales.
+ */
+import { readdir, readFile } from 'node:fs/promises'
+import { dirname, extname, relative, resolve } from 'node:path'
+import { resolveAppRoot, writeGeneratedFileIn, type WriterOptions } from './utils'
+
+export interface GenerateTranslationTypesOptions extends WriterOptions {
+  appRoot?: string
+  /** Translation directory (defaults to `lang`). */
+  langDir?: string
+  outputFile?: string
+}
+
+const DEFAULT_LANG_DIR = 'lang'
+const DEFAULT_OUTPUT_FILE = '.guren/translations.gen.ts'
+
+export interface TranslationCatalog {
+  locale: string
+  /** Dot-notation key (namespace-prefixed, e.g. `nav.posts`) → message. */
+  entries: Map<string, string>
+  /** Files that failed to parse, relative to the app root. */
+  invalidFiles: string[]
+}
+
+/**
+ * Read every `<langDir>/<locale>/*.json` catalog. Returns an empty array
+ * when the directory does not exist.
+ */
+export async function readTranslationCatalogs(
+  appRoot: string,
+  langDir: string = DEFAULT_LANG_DIR,
+): Promise<TranslationCatalog[]> {
+  const base = resolve(appRoot, langDir)
+
+  let localeEntries
+  try {
+    localeEntries = await readdir(base, { withFileTypes: true })
+  } catch {
+    return []
+  }
+
+  const catalogs: TranslationCatalog[] = []
+
+  for (const entry of localeEntries) {
+    if (!entry.isDirectory()) continue
+    const locale = entry.name
+    const localePath = resolve(base, locale)
+    const entries = new Map<string, string>()
+    const invalidFiles: string[] = []
+
+    let files: string[]
+    try {
+      files = await readdir(localePath)
+    } catch {
+      continue
+    }
+
+    for (const file of files.sort()) {
+      if (extname(file) !== '.json') continue
+      const namespace = file.slice(0, -'.json'.length)
+      const filePath = resolve(localePath, file)
+
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(await readFile(filePath, 'utf-8'))
+      } catch {
+        invalidFiles.push(relative(appRoot, filePath))
+        continue
+      }
+
+      collectEntries(parsed, namespace, entries)
+    }
+
+    catalogs.push({ locale, entries, invalidFiles })
+  }
+
+  return catalogs.sort((a, b) => a.locale.localeCompare(b.locale))
+}
+
+function collectEntries(value: unknown, prefix: string, entries: Map<string, string>): void {
+  if (typeof value === 'string') {
+    entries.set(prefix, value)
+    return
+  }
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    for (const [child, childValue] of Object.entries(value)) {
+      collectEntries(childValue, `${prefix}.${child}`, entries)
+    }
+  }
+}
+
+export async function generateTranslationTypes(
+  options: GenerateTranslationTypesOptions = {},
+): Promise<{ outputPath: string | null; keyCount: number }> {
+  const appRoot = resolveAppRoot(options)
+  const langDir = options.langDir ?? DEFAULT_LANG_DIR
+  const catalogs = await readTranslationCatalogs(appRoot, langDir)
+
+  // No lang/ directory (or no locale subdirectories): the app does not use
+  // file-based translations — emit nothing so keys stay `string`.
+  if (catalogs.length === 0) {
+    return { outputPath: null, keyCount: 0 }
+  }
+
+  const keys = Array.from(new Set(catalogs.flatMap((catalog) => [...catalog.entries.keys()]))).sort()
+
+  const outputFile = resolve(appRoot, options.outputFile ?? DEFAULT_OUTPUT_FILE)
+  const content = buildTranslationTypesContent(keys, {
+    source: relative(appRoot, resolve(appRoot, langDir)) || langDir,
+    locales: catalogs.map((catalog) => catalog.locale),
+  })
+
+  const outputPath = await writeGeneratedFileIn(appRoot, outputFile, content, {
+    force: options.force,
+  })
+
+  return { outputPath, keyCount: keys.length }
+}
+
+export function buildTranslationTypesContent(
+  keys: string[],
+  context: { source: string; locales: string[] },
+): string {
+  const union =
+    keys.length > 0
+      ? keys.map((key) => `  | '${key.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`).join('\n')
+      : '  | never'
+
+  return `// Generated from ${context.source}/ (locales: ${context.locales.join(', ')}) — DO NOT EDIT
+// Run \`guren codegen\` to regenerate.
+
+/**
+ * Every translation key present in at least one locale. Missing-per-locale
+ * keys are reported by \`guren check --i18n\`, not here.
+ */
+export type TranslationKey =
+${union}
+
+// Type this app's translation helpers via declaration merging:
+// \`this.t()\` / \`this.tc()\` in controllers and \`useTranslation()\` in pages
+// autocomplete and reject unknown keys. Delete lang/ and regenerate to
+// return them to plain strings.
+declare module '@guren/core' {
+  interface GurenTranslationKeys {
+    keys: TranslationKey
+  }
+}
+
+declare module '@guren/inertia-client' {
+  interface GurenTranslationKeys {
+    keys: TranslationKey
+  }
+}
+`
+}

--- a/packages/cli/src/i18n-types.ts
+++ b/packages/cli/src/i18n-types.ts
@@ -14,7 +14,7 @@
  * which locale the app configured as fallback); `guren check --i18n` is the
  * companion that reports keys missing from individual locales.
  */
-import { readdir, readFile } from 'node:fs/promises'
+import { readdir, readFile, rm } from 'node:fs/promises'
 import { extname, relative, resolve } from 'node:path'
 import { escapeSingleQuoted, resolveAppRoot, writeGeneratedFileIn, type WriterOptions } from './utils'
 
@@ -37,6 +37,13 @@ export interface TranslationCatalog {
   entries: Map<string, string>
   /** Files that failed to parse, relative to the app root. */
   invalidFiles: string[]
+  /**
+   * Keys the runtime can never resolve: a JSON property name or catalog
+   * file name contains a literal dot, which the Translator always treats as
+   * a path separator. Excluded from `entries` (and thus the generated key
+   * union) and reported by `guren check --i18n`.
+   */
+  unreachableKeys: string[]
 }
 
 /**
@@ -62,8 +69,12 @@ export async function readTranslationCatalogs(
     if (!entry.isDirectory()) continue
     const locale = entry.name
     const localePath = resolve(base, locale)
-    const entries = new Map<string, string>()
-    const invalidFiles: string[] = []
+    const catalog: TranslationCatalog = {
+      locale,
+      entries: new Map(),
+      invalidFiles: [],
+      unreachableKeys: [],
+    }
 
     let files: string[]
     try {
@@ -81,27 +92,38 @@ export async function readTranslationCatalogs(
       try {
         parsed = JSON.parse(await readFile(filePath, 'utf-8'))
       } catch {
-        invalidFiles.push(relative(appRoot, filePath))
+        catalog.invalidFiles.push(relative(appRoot, filePath))
         continue
       }
 
-      collectEntries(parsed, namespace, entries)
+      collectEntries(parsed, namespace, catalog, namespace.includes('.'))
     }
 
-    catalogs.push({ locale, entries, invalidFiles })
+    catalogs.push(catalog)
   }
 
   return catalogs.sort((a, b) => a.locale.localeCompare(b.locale))
 }
 
-function collectEntries(value: unknown, prefix: string, entries: Map<string, string>): void {
+function collectEntries(
+  value: unknown,
+  prefix: string,
+  catalog: TranslationCatalog,
+  unreachable: boolean,
+): void {
   if (typeof value === 'string') {
-    entries.set(prefix, value)
+    if (unreachable) {
+      catalog.unreachableKeys.push(prefix)
+    } else {
+      catalog.entries.set(prefix, value)
+    }
     return
   }
-  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+  // Arrays index like objects at runtime (`items.0`), so Object.entries
+  // covers both.
+  if (value !== null && typeof value === 'object') {
     for (const [child, childValue] of Object.entries(value)) {
-      collectEntries(childValue, `${prefix}.${child}`, entries)
+      collectEntries(childValue, `${prefix}.${child}`, catalog, unreachable || child.includes('.'))
     }
   }
 }
@@ -111,19 +133,24 @@ export async function generateTranslationTypes(
 ): Promise<{ outputPath: string | null; keyCount: number }> {
   const appRoot = resolveAppRoot(options)
   const catalogs = await readTranslationCatalogs(appRoot)
+  const outputFile = resolve(appRoot, DEFAULT_OUTPUT_FILE)
 
   // No lang/ directory (or no locale subdirectories): the app does not use
-  // file-based translations — emit nothing so keys stay `string`.
+  // file-based translations. Remove a previously generated file so its
+  // stale augmentation stops applying and keys return to plain strings.
   if (catalogs.length === 0) {
+    await rm(outputFile, { force: true })
     return { outputPath: null, keyCount: 0 }
   }
 
   const keys = Array.from(new Set(catalogs.flatMap((catalog) => [...catalog.entries.keys()]))).sort()
 
-  const outputFile = resolve(appRoot, DEFAULT_OUTPUT_FILE)
   const content = buildTranslationTypesContent(keys, {
-    source: DEFAULT_LANG_DIR,
     locales: catalogs.map((catalog) => catalog.locale),
+    // The client augmentation must only be emitted when the module is
+    // resolvable: TypeScript rejects augmenting an uninstalled module
+    // (TS2664), which would break API-only apps.
+    augmentInertiaClient: await appUsesInertiaClient(appRoot),
   })
 
   const outputPath = await writeGeneratedFileIn(appRoot, outputFile, content, {
@@ -133,16 +160,46 @@ export async function generateTranslationTypes(
   return { outputPath, keyCount: keys.length }
 }
 
+async function appUsesInertiaClient(appRoot: string): Promise<boolean> {
+  try {
+    const packageJson = JSON.parse(await readFile(resolve(appRoot, 'package.json'), 'utf-8')) as {
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+    }
+    return Boolean(
+      packageJson.dependencies?.['@guren/inertia-client'] ??
+      packageJson.devDependencies?.['@guren/inertia-client'],
+    )
+  } catch {
+    return false
+  }
+}
+
+/** Keep interpolated names from breaking out of the generated header comment. */
+function sanitizeForComment(value: string): string {
+  return value.replace(/[\r\n\u2028\u2029]/gu, ' ')
+}
+
 export function buildTranslationTypesContent(
   keys: string[],
-  context: { source: string; locales: string[] },
+  context: { locales: string[]; augmentInertiaClient: boolean },
 ): string {
   const union =
     keys.length > 0
       ? keys.map((key) => `  | '${escapeSingleQuoted(key)}'`).join('\n')
       : '  | never'
 
-  return `// Generated from ${context.source}/ (locales: ${context.locales.join(', ')}) — DO NOT EDIT
+  const clientAugmentation = context.augmentInertiaClient
+    ? `
+
+declare module '@guren/inertia-client' {
+  interface GurenTranslationKeys {
+    keys: TranslationKey
+  }
+}`
+    : ''
+
+  return `// Generated from ${DEFAULT_LANG_DIR}/ (locales: ${sanitizeForComment(context.locales.join(', '))}) — DO NOT EDIT
 // Run \`guren codegen\` to regenerate.
 
 /**
@@ -160,12 +217,6 @@ declare module '@guren/core' {
   interface GurenTranslationKeys {
     keys: TranslationKey
   }
-}
-
-declare module '@guren/inertia-client' {
-  interface GurenTranslationKeys {
-    keys: TranslationKey
-  }
-}
+}${clientAugmentation}
 `
 }

--- a/packages/cli/src/i18n-types.ts
+++ b/packages/cli/src/i18n-types.ts
@@ -15,17 +15,20 @@
  * companion that reports keys missing from individual locales.
  */
 import { readdir, readFile } from 'node:fs/promises'
-import { dirname, extname, relative, resolve } from 'node:path'
-import { resolveAppRoot, writeGeneratedFileIn, type WriterOptions } from './utils'
+import { extname, relative, resolve } from 'node:path'
+import { escapeSingleQuoted, resolveAppRoot, writeGeneratedFileIn, type WriterOptions } from './utils'
 
 export interface GenerateTranslationTypesOptions extends WriterOptions {
   appRoot?: string
-  /** Translation directory (defaults to `lang`). */
-  langDir?: string
-  outputFile?: string
 }
 
-const DEFAULT_LANG_DIR = 'lang'
+/**
+ * The conventional translation directory all framework tooling assumes
+ * (codegen, `check --i18n`, the Vite watch). Apps relocating catalogs via
+ * `createApp({ i18n: { path } })` opt out of that tooling.
+ */
+export const DEFAULT_LANG_DIR = 'lang'
+
 const DEFAULT_OUTPUT_FILE = '.guren/translations.gen.ts'
 
 export interface TranslationCatalog {
@@ -107,8 +110,7 @@ export async function generateTranslationTypes(
   options: GenerateTranslationTypesOptions = {},
 ): Promise<{ outputPath: string | null; keyCount: number }> {
   const appRoot = resolveAppRoot(options)
-  const langDir = options.langDir ?? DEFAULT_LANG_DIR
-  const catalogs = await readTranslationCatalogs(appRoot, langDir)
+  const catalogs = await readTranslationCatalogs(appRoot)
 
   // No lang/ directory (or no locale subdirectories): the app does not use
   // file-based translations — emit nothing so keys stay `string`.
@@ -118,9 +120,9 @@ export async function generateTranslationTypes(
 
   const keys = Array.from(new Set(catalogs.flatMap((catalog) => [...catalog.entries.keys()]))).sort()
 
-  const outputFile = resolve(appRoot, options.outputFile ?? DEFAULT_OUTPUT_FILE)
+  const outputFile = resolve(appRoot, DEFAULT_OUTPUT_FILE)
   const content = buildTranslationTypesContent(keys, {
-    source: relative(appRoot, resolve(appRoot, langDir)) || langDir,
+    source: DEFAULT_LANG_DIR,
     locales: catalogs.map((catalog) => catalog.locale),
   })
 
@@ -137,7 +139,7 @@ export function buildTranslationTypesContent(
 ): string {
   const union =
     keys.length > 0
-      ? keys.map((key) => `  | '${key.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`).join('\n')
+      ? keys.map((key) => `  | '${escapeSingleQuoted(key)}'`).join('\n')
       : '  | never'
 
   return `// Generated from ${context.source}/ (locales: ${context.locales.join(', ')}) — DO NOT EDIT

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -293,7 +293,13 @@ export function trimSlashes(value: string): string {
  * fixes land once.
  */
 export function escapeSingleQuoted(value: string): string {
-  return value.replace(/\\/gu, '\\\\').replace(/'/gu, "\\'")
+  return value
+    .replace(/\\/gu, '\\\\')
+    .replace(/'/gu, "\\'")
+    .replace(/\n/gu, '\\n')
+    .replace(/\r/gu, '\\r')
+    .replace(/\u2028/gu, '\\u2028')
+    .replace(/\u2029/gu, '\\u2029')
 }
 
 /**

--- a/packages/cli/src/vite/route-types.ts
+++ b/packages/cli/src/vite/route-types.ts
@@ -20,6 +20,10 @@ export interface RouteTypesPluginOptions {
    */
   resourcesDir?: string
   /**
+   * Relative path (from the app root) to the translation directory. Defaults to `lang`.
+   */
+  langDir?: string
+  /**
    * Override the executable launched to regenerate route types. Defaults to `bun`.
    */
   executable?: string
@@ -38,6 +42,7 @@ const DEFAULT_ARGS = ['x', '--bun', 'guren', 'codegen', '--force']
 const DEFAULT_WATCH_FILE = 'routes/web.ts'
 const DEFAULT_PAGES_DIR = 'resources/js/pages'
 const DEFAULT_RESOURCES_DIR = 'app/Http/Resources'
+const DEFAULT_LANG_DIR = 'lang'
 
 export function routeTypesPlugin(options: RouteTypesPluginOptions = {}): Plugin {
   let appRoot = options.appRoot
@@ -118,12 +123,14 @@ export function routeTypesPlugin(options: RouteTypesPluginOptions = {}): Plugin 
       const watchFile = resolve(root, options.watchFile ?? DEFAULT_WATCH_FILE)
       const pagesDir = resolve(root, options.pagesDir ?? DEFAULT_PAGES_DIR)
       const resourcesDir = resolve(root, options.resourcesDir ?? DEFAULT_RESOURCES_DIR)
+      const langDir = resolve(root, options.langDir ?? DEFAULT_LANG_DIR)
       const changedFile = resolve(ctx.file)
 
       if (
         changedFile === watchFile ||
         changedFile.startsWith(`${pagesDir}/`) || changedFile === pagesDir ||
-        changedFile.startsWith(`${resourcesDir}/`) || changedFile === resourcesDir
+        changedFile.startsWith(`${resourcesDir}/`) || changedFile === resourcesDir ||
+        changedFile.startsWith(`${langDir}/`) || changedFile === langDir
       ) {
         await enqueueGeneration(root)
       }

--- a/packages/cli/src/vite/route-types.ts
+++ b/packages/cli/src/vite/route-types.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process'
 import { resolve } from 'node:path'
-import type { HmrContext, Logger, Plugin, ResolvedConfig } from 'vite'
+import type { HmrContext, Logger, Plugin, ResolvedConfig, ViteDevServer } from 'vite'
 
 export interface RouteTypesPluginOptions {
   /**
@@ -20,10 +20,6 @@ export interface RouteTypesPluginOptions {
    */
   resourcesDir?: string
   /**
-   * Relative path (from the app root) to the translation directory. Defaults to `lang`.
-   */
-  langDir?: string
-  /**
    * Override the executable launched to regenerate route types. Defaults to `bun`.
    */
   executable?: string
@@ -42,6 +38,7 @@ const DEFAULT_ARGS = ['x', '--bun', 'guren', 'codegen', '--force']
 const DEFAULT_WATCH_FILE = 'routes/web.ts'
 const DEFAULT_PAGES_DIR = 'resources/js/pages'
 const DEFAULT_RESOURCES_DIR = 'app/Http/Resources'
+// Fixed by convention across codegen and check (see cli/src/i18n-types.ts).
 const DEFAULT_LANG_DIR = 'lang'
 
 export function routeTypesPlugin(options: RouteTypesPluginOptions = {}): Plugin {
@@ -109,6 +106,23 @@ export function routeTypesPlugin(options: RouteTypesPluginOptions = {}): Plugin 
     return queue
   }
 
+  function shouldRegenerate(root: string, file: string): boolean {
+    const watchFile = resolve(root, options.watchFile ?? DEFAULT_WATCH_FILE)
+    const pagesDir = resolve(root, options.pagesDir ?? DEFAULT_PAGES_DIR)
+    const resourcesDir = resolve(root, options.resourcesDir ?? DEFAULT_RESOURCES_DIR)
+    const langDir = resolve(root, DEFAULT_LANG_DIR)
+    const changedFile = resolve(file)
+
+    return (
+      changedFile === watchFile ||
+      changedFile.startsWith(`${pagesDir}/`) || changedFile === pagesDir ||
+      changedFile.startsWith(`${resourcesDir}/`) || changedFile === resourcesDir ||
+      // Codegen only reads lang/<locale>/*.json — other files under lang/
+      // (notes, fixtures) never affect the generated union.
+      (changedFile.startsWith(`${langDir}/`) && changedFile.endsWith('.json'))
+    )
+  }
+
   return {
     name: 'guren-route-types',
     async configResolved(config: ResolvedConfig) {
@@ -118,20 +132,23 @@ export function routeTypesPlugin(options: RouteTypesPluginOptions = {}): Plugin 
       if (process.env.CI) return
       await enqueueGeneration(appRoot)
     },
+    configureServer(server: ViteDevServer) {
+      // handleHotUpdate only fires for updates; creating or deleting a
+      // page, resource, or translation file must regenerate too.
+      const root = () => appRoot ?? server.config.root
+      const onFileEvent = (file: string) => {
+        if (process.env.CI) return
+        if (shouldRegenerate(root(), file)) {
+          void enqueueGeneration(root())
+        }
+      }
+      server.watcher.on('add', onFileEvent)
+      server.watcher.on('unlink', onFileEvent)
+    },
     async handleHotUpdate(ctx: HmrContext) {
       const root = appRoot ?? ctx.server.config.root
-      const watchFile = resolve(root, options.watchFile ?? DEFAULT_WATCH_FILE)
-      const pagesDir = resolve(root, options.pagesDir ?? DEFAULT_PAGES_DIR)
-      const resourcesDir = resolve(root, options.resourcesDir ?? DEFAULT_RESOURCES_DIR)
-      const langDir = resolve(root, options.langDir ?? DEFAULT_LANG_DIR)
-      const changedFile = resolve(ctx.file)
 
-      if (
-        changedFile === watchFile ||
-        changedFile.startsWith(`${pagesDir}/`) || changedFile === pagesDir ||
-        changedFile.startsWith(`${resourcesDir}/`) || changedFile === resourcesDir ||
-        changedFile.startsWith(`${langDir}/`) || changedFile === langDir
-      ) {
+      if (shouldRegenerate(root, ctx.file)) {
         await enqueueGeneration(root)
       }
 

--- a/packages/cli/tests/i18n-codegen.test.ts
+++ b/packages/cli/tests/i18n-codegen.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect, afterEach } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { writeWorkspaceFiles } from './helpers'
+import { generateTranslationTypes, readTranslationCatalogs } from '../src/i18n-types'
+import { runI18nCheck, extractPlaceholders } from '../src/i18n-check'
+
+const cleanups: Array<() => Promise<void>> = []
+
+async function makeApp(files: Record<string, string>): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'guren-i18n-test-'))
+  cleanups.push(() => rm(dir, { recursive: true, force: true }))
+  await writeWorkspaceFiles(dir, files)
+  return dir
+}
+
+afterEach(async () => {
+  await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+})
+
+const EN_NAV = JSON.stringify({ posts: 'Posts', menu: { home: 'Home' } })
+const JA_NAV = JSON.stringify({ posts: '記事一覧', menu: { home: 'ホーム' } })
+
+describe('readTranslationCatalogs', () => {
+  test('flattens nested keys with the file namespace as prefix', async () => {
+    const dir = await makeApp({ 'lang/en/nav.json': EN_NAV })
+    const catalogs = await readTranslationCatalogs(dir)
+
+    expect(catalogs).toHaveLength(1)
+    expect([...catalogs[0]!.entries.keys()].sort()).toEqual(['nav.menu.home', 'nav.posts'])
+    expect(catalogs[0]!.entries.get('nav.posts')).toBe('Posts')
+  })
+
+  test('collects unparseable files instead of failing', async () => {
+    const dir = await makeApp({
+      'lang/en/nav.json': EN_NAV,
+      'lang/en/broken.json': '{ not json',
+    })
+    const [catalog] = await readTranslationCatalogs(dir)
+
+    expect(catalog!.invalidFiles).toEqual([join('lang', 'en', 'broken.json')])
+    expect(catalog!.entries.size).toBe(2)
+  })
+
+  test('returns empty for apps without lang/', async () => {
+    const dir = await makeApp({})
+    expect(await readTranslationCatalogs(dir)).toEqual([])
+  })
+})
+
+describe('generateTranslationTypes', () => {
+  test('emits a sorted key union covering every locale plus both augmentations', async () => {
+    const dir = await makeApp({
+      'lang/en/nav.json': EN_NAV,
+      'lang/ja/nav.json': JSON.stringify({ posts: '記事一覧', jaOnly: 'のみ' }),
+    })
+
+    const { outputPath, keyCount } = await generateTranslationTypes({ appRoot: dir })
+    expect(outputPath).toBe(join(dir, '.guren/translations.gen.ts'))
+    expect(keyCount).toBe(3)
+
+    const content = await readFile(outputPath!, 'utf-8')
+    expect(content).toContain("  | 'nav.jaOnly'\n  | 'nav.menu.home'\n  | 'nav.posts'")
+    expect(content).toContain("declare module '@guren/core'")
+    expect(content).toContain("declare module '@guren/inertia-client'")
+    expect(content).toContain('interface GurenTranslationKeys')
+  })
+
+  test('emits nothing without a lang/ directory', async () => {
+    const dir = await makeApp({})
+    const { outputPath, keyCount } = await generateTranslationTypes({ appRoot: dir })
+    expect(outputPath).toBeNull()
+    expect(keyCount).toBe(0)
+  })
+})
+
+describe('runI18nCheck', () => {
+  test('passes a clean catalog pair', async () => {
+    const dir = await makeApp({
+      'lang/en/nav.json': EN_NAV,
+      'lang/ja/nav.json': JA_NAV,
+    })
+
+    const results = await runI18nCheck({ cwd: dir })
+    expect(results).toHaveLength(2)
+    expect(results.every((result) => result.status === 'pass')).toBe(true)
+  })
+
+  test('contributes nothing for apps without lang/', async () => {
+    const dir = await makeApp({})
+    expect(await runI18nCheck({ cwd: dir })).toEqual([])
+  })
+
+  test('fails a locale missing keys and names them', async () => {
+    const dir = await makeApp({
+      'lang/en/nav.json': EN_NAV,
+      'lang/ja/nav.json': JSON.stringify({ posts: '記事一覧' }),
+    })
+
+    const results = await runI18nCheck({ cwd: dir })
+    const ja = results.find((result) => result.key === 'i18n-parity:ja')
+    expect(ja?.status).toBe('fail')
+    expect(ja?.message).toContain('nav.menu.home')
+
+    const en = results.find((result) => result.key === 'i18n-parity:en')
+    expect(en?.status).toBe('pass')
+  })
+
+  test('fails on unparseable JSON files', async () => {
+    const dir = await makeApp({
+      'lang/en/nav.json': EN_NAV,
+      'lang/en/broken.json': '{ nope',
+      'lang/ja/nav.json': JA_NAV,
+    })
+
+    const results = await runI18nCheck({ cwd: dir })
+    const invalid = results.find((result) => result.key.startsWith('i18n-json:'))
+    expect(invalid?.status).toBe('fail')
+    expect(invalid?.message).toContain('broken.json')
+  })
+
+  test('warns when placeholders differ between locales', async () => {
+    const dir = await makeApp({
+      'lang/en/messages.json': JSON.stringify({ welcome: 'Welcome, :name!' }),
+      'lang/ja/messages.json': JSON.stringify({ welcome: 'ようこそ！' }),
+    })
+
+    const results = await runI18nCheck({ cwd: dir })
+    const mismatch = results.find((result) => result.key === 'i18n-placeholders:messages.welcome')
+    expect(mismatch?.status).toBe('warn')
+    expect(mismatch?.message).toContain('ja lacks :name')
+  })
+
+  test('accepts placeholder unions across plural forms', async () => {
+    const dir = await makeApp({
+      'lang/en/messages.json': JSON.stringify({ items: 'One item|:count items' }),
+      'lang/ja/messages.json': JSON.stringify({ items: ':count個' }),
+    })
+
+    const results = await runI18nCheck({ cwd: dir })
+    expect(results.find((result) => result.key.startsWith('i18n-placeholders:'))).toBeUndefined()
+  })
+})
+
+describe('extractPlaceholders', () => {
+  test('captures :name and {name} forms', () => {
+    expect([...extractPlaceholders('Hi :name, {count} new')].sort()).toEqual(['count', 'name'])
+  })
+
+  test('ignores plain text and URLs without word placeholders', () => {
+    expect(extractPlaceholders('Visit https://example.com').size).toBe(0)
+  })
+
+  test('does not treat times or numeric colons as placeholders', () => {
+    expect(extractPlaceholders('Opens at 9:00').size).toBe(0)
+  })
+})

--- a/packages/cli/tests/i18n-codegen.test.ts
+++ b/packages/cli/tests/i18n-codegen.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, afterEach } from 'bun:test'
 import { mkdtemp, readFile, rm } from 'node:fs/promises'
+// (rm is reused by the stale-file test)
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { writeWorkspaceFiles } from './helpers'
@@ -49,9 +50,15 @@ describe('readTranslationCatalogs', () => {
   })
 })
 
+const INERTIA_PACKAGE_JSON = JSON.stringify({
+  name: 'app',
+  dependencies: { '@guren/inertia-client': '^2.0.0' },
+})
+
 describe('generateTranslationTypes', () => {
   test('emits a sorted key union covering every locale plus both augmentations', async () => {
     const dir = await makeApp({
+      'package.json': INERTIA_PACKAGE_JSON,
       'lang/en/nav.json': EN_NAV,
       'lang/ja/nav.json': JSON.stringify({ posts: '記事一覧', jaOnly: 'のみ' }),
     })
@@ -67,11 +74,65 @@ describe('generateTranslationTypes', () => {
     expect(content).toContain('interface GurenTranslationKeys')
   })
 
+  test('omits the client augmentation when @guren/inertia-client is not a dependency', async () => {
+    const dir = await makeApp({
+      'package.json': JSON.stringify({ name: 'api-app', dependencies: { '@guren/core': '^2.0.0' } }),
+      'lang/en/nav.json': EN_NAV,
+    })
+
+    const { outputPath } = await generateTranslationTypes({ appRoot: dir })
+    const content = await readFile(outputPath!, 'utf-8')
+    expect(content).toContain("declare module '@guren/core'")
+    expect(content).not.toContain('@guren/inertia-client')
+  })
+
   test('emits nothing without a lang/ directory', async () => {
     const dir = await makeApp({})
     const { outputPath, keyCount } = await generateTranslationTypes({ appRoot: dir })
     expect(outputPath).toBeNull()
     expect(keyCount).toBe(0)
+  })
+
+  test('removes a stale generated file once lang/ disappears', async () => {
+    const dir = await makeApp({
+      'package.json': INERTIA_PACKAGE_JSON,
+      'lang/en/nav.json': EN_NAV,
+    })
+
+    const { outputPath } = await generateTranslationTypes({ appRoot: dir })
+    expect(outputPath).not.toBeNull()
+
+    await rm(join(dir, 'lang'), { recursive: true })
+    const rerun = await generateTranslationTypes({ appRoot: dir })
+    expect(rerun.outputPath).toBeNull()
+    await expect(readFile(join(dir, '.guren/translations.gen.ts'), 'utf-8')).rejects.toThrow()
+  })
+
+  test('collects array entries as index keys, matching runtime lookup', async () => {
+    const dir = await makeApp({
+      'package.json': INERTIA_PACKAGE_JSON,
+      'lang/en/messages.json': JSON.stringify({ steps: ['First', 'Second'] }),
+    })
+
+    const { outputPath } = await generateTranslationTypes({ appRoot: dir })
+    const content = await readFile(outputPath!, 'utf-8')
+    expect(content).toContain("'messages.steps.0'")
+    expect(content).toContain("'messages.steps.1'")
+  })
+
+  test('excludes runtime-unreachable dotted keys from the union', async () => {
+    const dir = await makeApp({
+      'package.json': INERTIA_PACKAGE_JSON,
+      'lang/en/messages.json': JSON.stringify({ 'a.b': 'literal dot', ok: 'fine' }),
+      'lang/en/dotted.name.json': JSON.stringify({ key: 'unreachable namespace' }),
+    })
+
+    const { outputPath, keyCount } = await generateTranslationTypes({ appRoot: dir })
+    const content = await readFile(outputPath!, 'utf-8')
+    expect(keyCount).toBe(1)
+    expect(content).toContain("'messages.ok'")
+    expect(content).not.toContain('a.b')
+    expect(content).not.toContain('dotted')
   })
 })
 
@@ -140,6 +201,42 @@ describe('runI18nCheck', () => {
 
     const results = await runI18nCheck({ cwd: dir })
     expect(results.find((result) => result.key.startsWith('i18n-placeholders:'))).toBeUndefined()
+  })
+
+  test('fails runtime-unreachable dotted keys', async () => {
+    const dir = await makeApp({
+      'lang/en/messages.json': JSON.stringify({ 'a.b': 'dot', ok: 'fine' }),
+      'lang/ja/messages.json': JSON.stringify({ ok: '大丈夫' }),
+    })
+
+    const results = await runI18nCheck({ cwd: dir })
+    const unreachable = results.find((result) => result.key === 'i18n-unreachable:messages.a.b')
+    expect(unreachable?.status).toBe('fail')
+    expect(unreachable?.message).toContain('en')
+  })
+
+  test('warns when locale directories hold no resolvable keys', async () => {
+    const dir = await makeApp({
+      'lang/en/messages.json': JSON.stringify({}),
+      'lang/ja/messages.json': JSON.stringify({}),
+    })
+
+    const results = await runI18nCheck({ cwd: dir })
+    expect(results).toHaveLength(1)
+    expect(results[0]!.key).toBe('i18n-empty')
+    expect(results[0]!.status).toBe('warn')
+  })
+
+  test('compares unicode and dashed placeholders across locales', async () => {
+    const dir = await makeApp({
+      'lang/en/messages.json': JSON.stringify({ hello: 'Hi {user-name}, {名前}' }),
+      'lang/ja/messages.json': JSON.stringify({ hello: '{user-name}さん' }),
+    })
+
+    const results = await runI18nCheck({ cwd: dir })
+    const mismatch = results.find((result) => result.key === 'i18n-placeholders:messages.hello')
+    expect(mismatch?.status).toBe('warn')
+    expect(mismatch?.message).toContain('ja lacks :名前')
   })
 })
 

--- a/packages/create-app/templates/api-only/tsconfig.json
+++ b/packages/create-app/templates/api-only/tsconfig.json
@@ -15,6 +15,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["src/**/*", "app/**/*", "routes/**/*", "config/**/*", "db/**/*", "bin/**/*"],
+  "include": [".guren/**/*", "src/**/*", "app/**/*", "routes/**/*", "config/**/*", "db/**/*", "bin/**/*"],
   "exclude": ["node_modules"]
 }

--- a/packages/inertia-client/src/i18n.ts
+++ b/packages/inertia-client/src/i18n.ts
@@ -25,6 +25,19 @@ export type TranslationMessages = {
 
 export type ReplacementValues = Record<string, string | number>
 
+/**
+ * Registry for the app's generated translation keys. `guren codegen` emits
+ * `.guren/translations.gen.ts`, which augments this interface with a `keys`
+ * union derived from `lang/<locale>/*.json`. Left empty, translation
+ * helpers accept any string.
+ */
+export interface GurenTranslationKeys {}
+
+/** The app's translation-key union when codegen registered one, else `string`. */
+export type RegisteredTranslationKey = GurenTranslationKeys extends { keys: infer K extends string }
+  ? K
+  : string
+
 /** Shape of the `_i18n` Inertia shared prop (see the server's InertiaI18nProps). */
 export interface I18nPageProps {
   locale: string
@@ -36,9 +49,9 @@ export interface Translation {
   /** The locale resolved for the current request. */
   locale: string
   /** Translate a key, with optional `:name`/`{name}` interpolation. */
-  t: (key: string, replacements?: ReplacementValues) => string
+  t: (key: RegisteredTranslationKey, replacements?: ReplacementValues) => string
   /** Translate a key with a count for pluralization (`one|other` forms). */
-  tc: (key: string, count: number, replacements?: ReplacementValues) => string
+  tc: (key: RegisteredTranslationKey, count: number, replacements?: ReplacementValues) => string
 }
 
 type PluralizationRule = (count: number) => number

--- a/packages/inertia-client/src/index.ts
+++ b/packages/inertia-client/src/index.ts
@@ -29,6 +29,8 @@ export type {
   I18nPageProps,
   TranslationMessages,
   ReplacementValues,
+  GurenTranslationKeys,
+  RegisteredTranslationKey,
 } from './i18n'
 export { ErrorBoundary } from './ErrorBoundary'
 export type {

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -181,6 +181,10 @@ export interface I18nPluginOptions {
    * Directory containing `<path>/<locale>/*.json` translation files, loaded
    * with {@link JsonLoader}. Defaults to `'lang'`. Ignored when `loader` is
    * set.
+   *
+   * Framework tooling (typed keys from `guren codegen`, `guren check
+   * --i18n`, the Vite watch) assumes the default `lang/` location — a
+   * custom path or loader opts out of those.
    */
   readonly path?: string
   /**

--- a/packages/server/src/i18n/Translator.ts
+++ b/packages/server/src/i18n/Translator.ts
@@ -187,7 +187,10 @@ export class Translator {
     for (const [key, value] of Object.entries(replacements)) {
       // Support both :key and {key} formats. The key is escaped so regex
       // metacharacters match literally, and the value goes through a
-      // callback so `$` sequences in it are not expanded.
+      // callback so `$` sequences in it are not expanded. This grammar is
+      // also encoded in @guren/inertia-client's applyReplacements (parity-
+      // tested) and the CLI's extractPlaceholders (guren check --i18n) —
+      // keep the three in sync.
       const escaped = key.replace(REGEXP_SPECIALS, '\\$&')
       const replacement = (): string => String(value)
       result = result

--- a/packages/server/src/i18n/index.ts
+++ b/packages/server/src/i18n/index.ts
@@ -1,6 +1,8 @@
 export type {
   TranslationMessages,
   ReplacementValues,
+  GurenTranslationKeys,
+  RegisteredTranslationKey,
   PluralizationRule,
   TranslationLoader,
   TranslatorOptions,

--- a/packages/server/src/i18n/loaders/JsonLoader.ts
+++ b/packages/server/src/i18n/loaders/JsonLoader.ts
@@ -13,6 +13,12 @@ import type { TranslationLoader, TranslationMessages } from '../types'
  *   ja/
  *     messages.json
  *     validation.json
+ *
+ * This layout (locale subdirectories, namespace = file name) is a contract
+ * shared with the CLI: `guren codegen` (packages/cli/src/i18n-types.ts) and
+ * `guren check --i18n` (packages/cli/src/i18n-check.ts) re-implement the
+ * same walk statically. Changing the layout or parse tolerance here strands
+ * them on the old contract — update both together.
  */
 export class JsonLoader implements TranslationLoader {
   private basePath: string

--- a/packages/server/src/i18n/types.ts
+++ b/packages/server/src/i18n/types.ts
@@ -6,6 +6,23 @@ export type TranslationMessages = {
 }
 
 /**
+ * Registry for the app's generated translation keys. `guren codegen` emits
+ * `.guren/translations.gen.ts`, which augments this interface (declaration
+ * merging) with a `keys` union derived from `lang/<locale>/*.json`. Apps
+ * without the generated file leave it empty and translation helpers accept
+ * any string.
+ */
+export interface GurenTranslationKeys {}
+
+/**
+ * The app's translation-key union when codegen registered one, else `string`.
+ * Used by `Controller.t()`/`Controller.tc()` for compile-time key checking.
+ */
+export type RegisteredTranslationKey = GurenTranslationKeys extends { keys: infer K extends string }
+  ? K
+  : string
+
+/**
  * Replacement values for interpolation.
  */
 export type ReplacementValues = Record<string, string | number>

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -495,6 +495,8 @@ export type {
   TranslatorOptions,
   I18nConfig,
   TranslationLoaderFactory,
+  GurenTranslationKeys,
+  RegisteredTranslationKey,
 } from './i18n'
 // Database (Seeder & Factory)
 export {

--- a/packages/server/src/mvc/Controller.ts
+++ b/packages/server/src/mvc/Controller.ts
@@ -3,7 +3,7 @@ import { inertia, type InertiaOptions } from './inertia/InertiaEngine'
 import { resolveSharedInertiaProps, type ResolvedSharedInertiaProps } from './inertia/shared'
 import { AUTH_CONTEXT_KEY } from '../http/middleware/auth'
 import { getRequestLocale, getRequestTranslator, type TranslatorBinding } from '../http/middleware/detect-locale'
-import { tryGetI18n, type I18nManager, type ReplacementValues } from '../i18n'
+import { tryGetI18n, type I18nManager, type RegisteredTranslationKey, type ReplacementValues } from '../i18n'
 import { flattenRequestQueries, parseRequestPayload } from '../http/request'
 import type { AuthContext } from '../auth/types'
 import type { ServiceBindings } from '../container/bindings'
@@ -362,7 +362,7 @@ export class Controller {
    * this.t('posts.greeting', { name: user.name })
    * ```
    */
-  protected t(key: string, replacements?: ReplacementValues): string {
+  protected t(key: RegisteredTranslationKey, replacements?: ReplacementValues): string {
     return this.#requestTranslator().t(key, replacements)
   }
 
@@ -370,7 +370,7 @@ export class Controller {
    * Translate a key with a count for pluralization, using the same locale
    * resolution as {@link Controller.t}.
    */
-  protected tc(key: string, count: number, replacements?: ReplacementValues): string {
+  protected tc(key: RegisteredTranslationKey, count: number, replacements?: ReplacementValues): string {
     return this.#requestTranslator().tc(key, count, replacements)
   }
 


### PR DESCRIPTION
## Summary

Third PR in the i18n series (#309 server wiring, #310 client hook): the type-safety and machine-checking layer.

### Typed translation keys (`guren codegen`)

Apps with a `lang/` directory now get `.guren/translations.gen.ts`: a `TranslationKey` union built from every `lang/<locale>/*.json` catalog (namespace = file name, nested keys flattened to dot notation, union across locales), plus declaration-merging augmentations following the existing `InertiaSharedProps` pattern:

- `declare module '@guren/core'` types `this.t()` / `this.tc()` in controllers
- `declare module '@guren/inertia-client'` types `useTranslation()` in pages

Both packages gain an empty `GurenTranslationKeys` registry interface; unaugmented, keys stay plain `string`, so apps without `lang/` (or that never ran codegen) are unaffected. The Vite route-types plugin now watches `lang/` and regenerates on change.

Verified by mutation against examples/blog: a typo'd key fails `tsc` on both the client (`useTranslation`) and server (`this.t`) paths, and reverting returns to green.

### `guren check --i18n`

Content-activated translation catalog checks (apps without `lang/` contribute zero results), in the plain `guren check` run and standalone via `--i18n` (exit-code-gating like `--docs`/`--spec`):

- **Invalid JSON** (fail) — JsonLoader skips unparseable files with only a console warning, so their keys silently fall back at runtime
- **Key parity** (fail) — keys missing from individual locales, which render in the fallback language
- **Placeholder parity** (warn) — `:name`/`{name}` placeholders differing between locales for the same key; identifier-form matching so times like `9:00` don't false-positive

Call-site scanning (`t('...')` referencing unknown keys) is deliberately out of scope: the generated union enforces that at compile time without AST heuristics.

Verified both directions on real apps: clean examples/blog passes (exit 0), a planted missing ja key fails (exit 1), and web/ (no `lang/`) contributes nothing.

## Testing

- `bun run build` / root `bun run typecheck`
- `bun run test:bun` (3661 pass) including 14 new generator/check tests
- `bun run test:examples` (251 pass)
- `bun run audit:core-first` / `bun run audit:docs`
- Mutation verification on examples/blog as described above