### PR TITLE
fix(server): treat a policy denial response as denied, not allowed

### DIFF
--- a/.changeset/authorization-middleware-denial-response.md
+++ b/.changeset/authorization-middleware-denial-response.md
@@ -1,0 +1,18 @@
+---
+'@guren/server': patch
+---
+
+Carry the policy's own denial through the authorization middleware
+
+`authorizeMiddleware` and `authorizeResourceMiddleware` called `allows()`,
+discarded the response, and threw a generic 403 — so a policy answering with
+`denyAsNotFound()` produced a 404 through `Controller.authorize()` and a 403
+through the middleware. Both now go through the same response, keeping the
+policy's message and status; `options.message` still overrides. Multi-ability
+(`any`) checks have no single response to carry and stay generic.
+
+Gate and policy `before` hooks are normalized too: previously anything that was
+not a boolean was read as "keep checking", so a `Response.deny()` returned from
+`before` was dropped and a permissive ability method then allowed the action.
+Only `undefined` continues. `GateCallback`, `GateBeforeCallback`, `Policy.before`
+and `definePolicy`'s `before` accept `PolicyResult` to match.

--- a/.changeset/broadcasting-private-channel-authorization.md
+++ b/.changeset/broadcasting-private-channel-authorization.md
@@ -1,0 +1,35 @@
+---
+'@guren/cli': patch
+'@guren/server': patch
+---
+
+Make the generated private-channel check the check that actually runs
+
+`make:channel --private` generated a `PrivateChannel` subclass with an
+`authorize(ctx)` method, and `make:channel --presence` a `join(ctx)`. Neither
+ever ran. `BroadcastManager.authorize()` resolves a channel only through the
+callbacks registered with `channel()` / `privateChannel()` / `presenceChannel()`
+and never calls a method on a channel instance, so both were dead code — with no
+TODO or comment to say so. The presence one could not have worked in any case:
+its signature contradicted the inherited `join(member)`, which is what adds an
+already-authorized member.
+
+Meanwhile the `broadcasting` blueprint registered the callback that *did* run:
+
+```ts
+broadcast.privateChannel(userFeed.getBaseName(), () => true)
+```
+
+Allow-all, on `users.{id}.feed`, next to a generated file that reads as though it
+authorizes. That registration also defeats the manager's own fail-closed default,
+which denies unregistered `private-`/`presence-` names.
+
+The generated methods now take the `ChannelAuthorizer` signature
+(`channelName, user`) so they can be registered, the presence hook is
+`authorizeJoin()` to stop colliding with `join(member)`, and a pattern carrying
+`{id}` gets an ownership check rather than a bare "is logged in". The blueprint
+registers the channel's own method.
+
+`BroadcastManager.authorize()` also normalizes its result. Callers read anything
+that is not `false`/`null` as authorized, so an authorizer with an
+implicit-`undefined` return path used to grant access; it now denies.

--- a/.changeset/gate-policy-response-normalization.md
+++ b/.changeset/gate-policy-response-normalization.md
@@ -1,0 +1,36 @@
+---
+'@guren/server': patch
+---
+
+Fix a policy denial being read as an approval
+
+`Policy` ships `deny()`, `denyWithStatus()` and `denyAsNotFound()`, which return
+an `AuthorizationResponse` object rather than `false`. `Gate.check()` returned
+the policy method's value unchanged, so every consumer truthy-tested that object
+and read the denial as an approval: `authorize()` did not throw, `allows()` and
+`Controller.can()` returned truthy, `denies()` returned `false`, `inspect()`
+reported `allowed: true`, and `authorizeMiddleware`'s `if (!authorized)` guard
+passed. A policy written as
+
+```typescript
+update(user: AuthUser | null, post: Post) {
+  return user?.id === post.authorId ? true : this.deny('You do not own this post.')
+}
+```
+
+therefore let any user through the exact check meant to stop them. Nothing
+flagged it: the helpers are `protected`, so a policy ability method is their only
+possible call site, and `PolicyMethod` was exported but never applied to policy
+classes, so the method's return type was inferred from its body with nothing to
+check it against.
+
+`Gate` now normalizes every policy and gate return value through one path. An
+`AuthorizationResponse` is honoured as written, `true` allows, and anything else
+denies — unknown shapes fail closed rather than open. A new `checkResponse()`
+keeps the full response so `inspect()` reports the policy's own message, and
+`authorize()` propagates `denyWithStatus()` / `denyAsNotFound()` into the thrown
+exception's status instead of flattening every denial to 403.
+
+`PolicyMethod` and `definePolicy()` now accept `PolicyResult`
+(`boolean | AuthorizationResponse`), so the type matches what `Policy` has always
+offered. `PolicyResult` and the `isAuthorizationResponse()` guard are exported.

--- a/.changeset/oauth-session-option.md
+++ b/.changeset/oauth-session-option.md
@@ -1,0 +1,25 @@
+---
+'@guren/server': minor
+'@guren/cli': patch
+---
+
+Let the OAuth manager keep the browser binding in the session itself
+
+Binding a flow via `bindTo` worked but pushed four steps into every
+controller: mint a random value, store it in the session, read it back in the
+callback, forget it — guarded on the session existing, twice. Every scaffold
+and example carried the same twelve lines.
+
+`authorize()` and `handleCallback()` now also accept a `session`. Hand them
+`this.auth.session()` and the manager mints the per-flow binding, parks it in
+the session under `OAUTH_SESSION_BINDING_KEY`, and consumes it during callback
+verification — reading and removing it in one step, so a replayed callback
+finds nothing. A missing session (no session middleware) flows through as an
+unbound state exactly as before, warning included. The parameter is typed as
+`OAuthBindingSession` — the three session methods the manager needs — so the
+framework session satisfies it structurally and tests can pass a plain stub.
+
+`bindTo` remains for bindings kept elsewhere (an encrypted cookie, secure
+storage) and takes precedence when both are given. `make:auth`, the `oauth`
+blueprint, the docs, and the blog example now pass `session` instead of
+hand-rolling the plumbing.

--- a/.changeset/oauth-state-browser-binding.md
+++ b/.changeset/oauth-state-browser-binding.md
@@ -1,0 +1,35 @@
+---
+'@guren/server': patch
+'@guren/cli': patch
+---
+
+Let OAuth `state` be bound to the browser that started the flow
+
+`createOAuthState` stored `{ provider, redirectTo, expiresAt }` and
+`verifyOAuthState` checked only that the provider matched. Nothing tied the
+state to a browser, and the manager is a process-wide singleton, so a state
+minted for one browser was consumable by any other. `state` was unguessable and
+single-use, but *transferable* — which is the one property it exists to prevent
+(RFC 6749 §10.12).
+
+That is login CSRF. An attacker requests `/auth/github` on the target app and
+captures the `state` from the redirect, separately authorizes the app against
+their own provider account and captures the `code` without letting their browser
+reach the callback, then induces a visitor into a top-level navigation to
+`/auth/github/callback?code=…&state=…`. The state verifies, the code exchanges
+for the attacker's profile, and the visitor's session is logged into the
+attacker's account. The visitor keeps using the app believing it is theirs, so
+whatever they write next — posts, uploads, a connected payment method — lands in
+an account the attacker can read. It could not be fixed from application code:
+`handleCallback()` verified state internally and accepted no session-bound value.
+
+`authorize()` now takes `bindTo` and `handleCallback()` takes it back. Only a
+hash of the value reaches the state store, and comparison is timing-safe. Pass a
+value only that browser can present — a session id, or a random value stored in
+the session, which also makes a logged-out visitor's session persist across the
+round trip.
+
+A state created without a binding still verifies, so apps written against the
+earlier API keep working; `authorize()` warns once per process when called
+without `bindTo`, and those apps stay exposed until they adopt it. `make:auth`,
+the `oauth` blueprint, the docs, and the blog example all pass it now.

--- a/.changeset/oauth-state-store-binding-persistence.md
+++ b/.changeset/oauth-state-store-binding-persistence.md
@@ -1,0 +1,20 @@
+---
+'@guren/core': patch
+'@guren/server': patch
+---
+
+Persist the OAuth state binding in the shared state stores
+
+`createOAuthState` recorded the browser binding in the payload, but
+`DatabaseOAuthStateStore` and `RedisOAuthStateStore` neither wrote nor restored
+it. Every bound state came back unbound, and `verifyOAuthState` then accepted
+any browser — so `authorize({ bindTo })` was inert on both shared stores,
+including the database store the docs recommend for production. Only the
+in-process memory store, which the docs tell you not to deploy, carried it.
+
+Both stores now round-trip `binding`. The database store needs a nullable
+`binding` column on the `oauth_states` table; without it the state cannot be
+persisted at all.
+
+`bindingMatches` also moves to `secureCompare`, the hex-decoding comparator, to
+match the other stored-hash comparison in the package.

--- a/.changeset/orm-global-scope-entry-points.md
+++ b/.changeset/orm-global-scope-entry-points.md
@@ -23,8 +23,3 @@ All of these now route through the scope-applying builder. `newQuery()` with no
 scopes registered constructs exactly what the bare builder did, so an app that
 uses no global scopes is unaffected. `withoutGlobalScope(s)` remains the way out.
 
-`QueryBuilder` also stops silently dropping conditions it cannot express. On an
-adapter that implements neither `findManyAdvanced` nor `countAdvanced`, a query
-using `not in` or `is not null` fell back to `where: undefined` — discarding
-every condition, global scopes included, and returning the whole table. It now
-throws. The shipped Drizzle adapter implements both and never reaches this path.

--- a/.changeset/orm-global-scope-entry-points.md
+++ b/.changeset/orm-global-scope-entry-points.md
@@ -1,0 +1,30 @@
+---
+'@guren/orm': patch
+---
+
+Apply global scopes on every query entry point, not just four of them
+
+`defaultScope` and the `addGlobalScope()` registry were applied by `newQuery()`,
+and by `all()` / `find()` / `first()` which branch into it. Every other entry
+point skipped them: `where()` and its `whereNull` / `whereNotNull` / `whereIn` /
+`whereNotIn` / `select` / `scope` siblings constructed a bare `QueryBuilder`, and
+`orderBy()` / `paginate()` called the adapter directly. The relation loaders go
+through `where()`, so eager loading dropped the *related* model's scopes too.
+
+The docs present global scopes as a filter that always applies, name
+multi-tenancy as the first use case, and state that `where()` is covered — so an
+app following the documented pattern got no tenant isolation on the most common
+entry point. `SoftDeletes` is implemented as a global scope and inherited every
+hole, which is how a scaffolded `index()` — `make:feature` generates it as
+`Model.paginate(...)` on a route with no auth — served soft-deleted rows.
+`paginate()` leaked the unscoped row count through `meta.total` as well.
+
+All of these now route through the scope-applying builder. `newQuery()` with no
+scopes registered constructs exactly what the bare builder did, so an app that
+uses no global scopes is unaffected. `withoutGlobalScope(s)` remains the way out.
+
+`QueryBuilder` also stops silently dropping conditions it cannot express. On an
+adapter that implements neither `findManyAdvanced` nor `countAdvanced`, a query
+using `not in` or `is not null` fell back to `where: undefined` — discarding
+every condition, global scopes included, and returning the whole table. It now
+throws. The shipped Drizzle adapter implements both and never reaches this path.

--- a/.changeset/orm-refuse-inexpressible-conditions.md
+++ b/.changeset/orm-refuse-inexpressible-conditions.md
@@ -1,0 +1,21 @@
+---
+'@guren/orm': minor
+---
+
+Refuse, rather than silently drop, conditions the adapter cannot express
+
+On an adapter implementing neither `findManyAdvanced` nor `countAdvanced`,
+`QueryBuilder` flattened its conditions into a simple where-object and passed
+`where: undefined` whenever that conversion failed — discarding every condition,
+global scopes included, and returning the whole table. It now throws.
+
+This is a **runtime behavior change beyond the global-scope fix it came from**,
+which is why it is a minor rather than a patch. The conversion fails for more
+than the exotic cases: every comparison operator (`>`, `<`, `>=`, `<=`, `!=`,
+`like`), `not in`, `is not null`, and any `orWhere` group. So on such an adapter
+`Post.where('views', '>', 100).get()` now throws where it previously returned
+rows — rows that were unfiltered, and therefore wrong, but returned.
+
+The shipped `DrizzleAdapter` implements both methods and never reaches this
+path. Custom adapters and hand-rolled test doubles are what this affects; the
+fix is to implement `findManyAdvanced`/`countAdvanced`.

--- a/.changeset/orm-scope-condition-collision.md
+++ b/.changeset/orm-scope-condition-collision.md
@@ -1,0 +1,12 @@
+---
+'@guren/orm': patch
+---
+
+Refuse a query whose conditions collide on a scoped column
+
+On an adapter without `findManyAdvanced`/`countAdvanced`, conditions are
+flattened into one where-object, so a second condition on a field overwrote the
+first. A global scope pinning `tenantId` was therefore replaced by a caller's own
+`where('tenantId', …)` — the filter meant to enforce isolation handed back
+another tenant's rows. Only a repeat of the same value collapses now; a genuine
+conflict throws, like the operators that already cannot be flattened.

--- a/.changeset/vite-dev-server-loopback-default.md
+++ b/.changeset/vite-dev-server-loopback-default.md
@@ -1,0 +1,30 @@
+---
+'@guren/server': patch
+---
+
+Stop binding the managed Vite dev server to every interface
+
+`Application.listen()` starts a Vite dev server on every non-production boot,
+and both the launcher and `gurenVitePlugin` replaced Vite's localhost-only
+default with `host: true`. Vite serves any file under its root — transformed
+source for `.ts`/`.tsx`, raw bytes for everything else — with no
+authentication, no origin check and no loopback gate. Anyone on the same
+network could read a developer's application source, and the scaffold's default
+`DATABASE_URL=./data/guren.db` puts the SQLite database inside that root and
+outside Vite's `server.fs.deny`, so `GET http://<dev-machine>:5173/data/guren.db`
+returned the users table — password hashes included — to any LAN peer.
+
+The framework already treats LAN reachability as in scope: `/_guren/mcp` and
+`/_guren/docs` are gated on a loopback socket peer precisely because templates
+bind `0.0.0.0`. The dev server it starts itself had no equivalent gate.
+
+`host` is now left unset, so Vite's own default applies and the project's
+`vite.config.ts` decides. Exposing the dev server on the network is an explicit
+opt-in — `--host`, `server.host` in `vite.config.ts`, or
+`app.listen({ vite: { host: true } })`.
+
+`preview.host` is unchanged: `vite preview` serves only `build.outDir`, never
+the project root, so it carries none of this.
+
+`resolveViteDevServerConfig()` is exported for callers that need the inline
+config the managed dev server would start with.

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "examples/api": {
       "name": "@guren/example-api",
-      "version": "0.1.9",
+      "version": "0.1.11",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -68,14 +68,14 @@
     },
     "packages/cli": {
       "name": "@guren/cli",
-      "version": "2.0.0",
+      "version": "2.1.1",
       "bin": {
         "guren": "./dist/bin.js",
       },
       "dependencies": {
         "@babel/parser": "^7.24.7",
         "@guren/core": "^1.5.0",
-        "@guren/orm": "^2.0.0",
+        "@guren/orm": "^2.1.0",
         "citty": "^0.1.6",
         "consola": "^3.4.2",
       },
@@ -110,7 +110,7 @@
     },
     "packages/create-app": {
       "name": "create-guren-app",
-      "version": "1.5.0",
+      "version": "1.6.1",
       "bin": {
         "create-guren-app": "./dist/cli.js",
       },
@@ -146,7 +146,7 @@
       "name": "@guren/openapi",
       "version": "1.1.0",
       "dependencies": {
-        "@guren/core": "^1.0.0",
+        "@guren/core": "^1.5.0",
       },
       "devDependencies": {
         "@types/node": "^20.14.10",
@@ -156,7 +156,7 @@
     },
     "packages/orm": {
       "name": "@guren/orm",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "drizzle-orm": "1.0.0-rc.4",
       },
@@ -230,9 +230,9 @@
     },
     "packages/server": {
       "name": "@guren/server",
-      "version": "2.0.0",
+      "version": "2.1.1",
       "dependencies": {
-        "@guren/orm": "^2.0.0",
+        "@guren/orm": "^2.1.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "chalk": "^5.3.0",
         "consola": "^3.4.2",
@@ -289,7 +289,7 @@
     },
     "web": {
       "name": "web",
-      "version": "0.1.9",
+      "version": "0.1.11",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -328,12 +328,15 @@
     "@hono/node-server": "^2.0.5",
     "axios": "^1.17.0",
     "body-parser": "^2.3.0",
+    "dompurify": "^3.4.13",
     "fast-uri": "^3.1.3",
     "follow-redirects": "^1.16.0",
     "form-data": "^4.0.6",
     "hono": "^4.12.34",
     "ip-address": "^10.2.0",
     "lodash-es": "^4.18.1",
+    "mermaid": "^11.16.1",
+    "nanoid": "^3.3.17",
     "path-to-regexp": "^8.4.0",
     "postcss": "^8.5.18",
     "qs": "^6.15.2",
@@ -1133,7 +1136,7 @@
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
-    "dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
+    "dompurify": ["dompurify@3.4.13", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
@@ -1313,7 +1316,7 @@
 
     "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
-    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "jsbi": ["jsbi@4.3.2", "", {}, "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew=="],
 
@@ -1401,7 +1404,7 @@
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
-    "mermaid": ["mermaid@11.16.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA=="],
+    "mermaid": ["mermaid@11.16.1", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g=="],
 
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 
@@ -1435,7 +1438,7 @@
 
     "named-placeholders": ["named-placeholders@1.1.6", "", { "dependencies": { "lru.min": "^1.1.0" } }, "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -1893,7 +1896,7 @@
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
-    "read-yaml-file/js-yaml": ["js-yaml@3.15.0", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog=="],
+    "read-yaml-file/js-yaml": ["js-yaml@3.15.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag=="],
 
     "sanitize-html/htmlparser2": ["htmlparser2@12.0.0", "", { "dependencies": { "domelementtype": "^3.0.0", "domhandler": "^6.0.0", "domutils": "^4.0.2", "entities": "^8.0.0" } }, "sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw=="],
 

--- a/docs/en/guides/database.md
+++ b/docs/en/guides/database.md
@@ -457,7 +457,12 @@ User.addGlobalScope('tenant', (q) => q.where('tenantId', currentTenantId()))
 User.addGlobalScope('active', (q) => q.where('active', true))
 ```
 
-Every query through `all()`, `find()`, `where()`, and `newQuery()` now applies both scopes automatically.
+Every query entry point applies both scopes automatically — `all()`, `find()`,
+`first()`, `where()` and its `whereIn`/`whereNull`/`select` siblings, `scope()`,
+`orderBy()`, `paginate()` (the count as well as the rows), `newQuery()`, and the
+queries that eager-load a relation, which apply the *related* model's scopes.
+
+The only way past them is to ask explicitly, below.
 
 ### Bypassing Global Scopes
 

--- a/docs/en/guides/oauth.md
+++ b/docs/en/guides/oauth.md
@@ -46,8 +46,12 @@ const OAUTH_BINDING_KEY = 'oauth.binding'
 export default class GitHubOAuthController extends Controller {
   async start() {
     // Ties the flow to this browser — see "Binding state to the browser" below.
-    const binding = crypto.randomUUID()
-    this.auth.session()?.set(OAUTH_BINDING_KEY, binding)
+    const session = this.auth.session()
+    let binding: string | undefined
+    if (session) {
+      binding = crypto.randomUUID()
+      session.set(OAUTH_BINDING_KEY, binding)
+    }
 
     const { url } = await oauth.authorize('github', {
       redirectTo: this.query('redirect_to'),
@@ -125,6 +129,11 @@ the callback request carries the same one.
 
 A session id works as `bindTo` too, but only where a session already exists —
 the value above is generated for the purpose and works for logged-out visitors.
+
+Bind only when there is somewhere to keep the value. Sending `bindTo` from an
+app with no session middleware records a binding the callback can never present,
+and every login then fails with `Invalid or expired OAuth state` — pointing at
+the wrong cause. The scaffolds guard on `this.auth.session()` for that reason.
 
 > [!WARNING]
 > `authorize()` without `bindTo` still works, so apps written against the earlier

--- a/docs/en/guides/oauth.md
+++ b/docs/en/guides/oauth.md
@@ -41,21 +41,13 @@ const CallbackQuerySchema = z.object({
   state: z.string(),
 })
 
-const OAUTH_BINDING_KEY = 'oauth.binding'
-
 export default class GitHubOAuthController extends Controller {
   async start() {
-    // Ties the flow to this browser — see "Binding state to the browser" below.
-    const session = this.auth.session()
-    let binding: string | undefined
-    if (session) {
-      binding = crypto.randomUUID()
-      session.set(OAUTH_BINDING_KEY, binding)
-    }
-
+    // Passing the session ties the flow to this browser — see
+    // "Binding State to the Browser" below.
     const { url } = await oauth.authorize('github', {
       redirectTo: this.query('redirect_to'),
-      bindTo: binding,
+      session: this.auth.session(),
     })
     return this.redirect(url)
   }
@@ -63,11 +55,11 @@ export default class GitHubOAuthController extends Controller {
   async callback() {
     const { code, state } = this.validateQuery(CallbackQuerySchema)
 
-    const session = this.auth.session()
-    const binding = session?.get<string>(OAUTH_BINDING_KEY)
-    session?.forget(OAUTH_BINDING_KEY)
-
-    const { profile, redirectTo } = await oauth.handleCallback('github', { code, state, bindTo: binding })
+    const { profile, redirectTo } = await oauth.handleCallback('github', {
+      code,
+      state,
+      session: this.auth.session(),
+    })
 
     let user = await User.where('githubId', profile.id).first()
     if (!user) {
@@ -107,39 +99,34 @@ succeeds and logs that visitor into the **attacker's** account. Everything the
 visitor writes afterwards — posts, uploads, a saved payment method — lands in an
 account the attacker can also read.
 
-Pass `bindTo` to close it:
+Pass the session to both legs of the flow to close it:
 
 ```ts
 // starting the flow
-const binding = crypto.randomUUID()
-this.auth.session()?.set('oauth.binding', binding)
-const { url } = await oauth.authorize('github', { bindTo: binding })
+const { url } = await oauth.authorize('github', { session: this.auth.session() })
 
 // in the callback
-const session = this.auth.session()
-const binding = session?.get<string>('oauth.binding')
-session?.forget('oauth.binding')
-await oauth.handleCallback('github', { code, state, bindTo: binding })
+await oauth.handleCallback('github', { code, state, session: this.auth.session() })
 ```
 
-Only a hash of the value reaches the state store, and `handleCallback` refuses a
-state whose binding it cannot match. Writing to the session is also what makes a
-first-time visitor's session persist across the round trip to the provider, so
-the callback request carries the same one.
+`authorize()` mints a fresh per-flow value, keeps it in the session, and stores
+only its hash with the state; `handleCallback()` reads the value back (removing
+it in the same step) and refuses a state whose binding it cannot match. Writing
+to the session is also what makes a first-time visitor's session persist across
+the round trip to the provider, so the callback request carries the same one.
+When `this.auth.session()` returns `undefined` — no session middleware — the
+state is simply left unbound, so nothing breaks; it just stays unprotected.
 
-A session id works as `bindTo` too, but only where a session already exists —
-the value above is generated for the purpose and works for logged-out visitors.
-
-Bind only when there is somewhere to keep the value. Sending `bindTo` from an
-app with no session middleware records a binding the callback can never present,
-and every login then fails with `Invalid or expired OAuth state` — pointing at
-the wrong cause. The scaffolds guard on `this.auth.session()` for that reason.
+If the binding must live somewhere other than the session (an encrypted cookie,
+a native app's secure storage), manage the value yourself with `bindTo`: pass a
+value only this browser can present back to `authorize()`, and hand the same
+value to `handleCallback()`. `bindTo` wins when both options are given.
 
 > [!WARNING]
-> `authorize()` without `bindTo` still works, so apps written against the earlier
-> API keep running, and it logs a warning once per process. Those apps remain
-> open to the attack above until they adopt it. `make:auth` and the `oauth`
-> blueprint generate the bound version.
+> `authorize()` without `session` or `bindTo` still works, so apps written
+> against the earlier API keep running, and it logs a warning once per process.
+> Those apps remain open to the attack above until they adopt it. `make:auth`
+> and the `oauth` blueprint generate the bound version.
 
 ## Redirect After Login
 
@@ -284,7 +271,8 @@ export const oauthStates = sqliteTable('oauth_states', {
 The `binding` column holds the hashed browser binding from
 [Binding State to the Browser](#binding-state-to-the-browser). Without it the
 store cannot persist a binding, and every bound state comes back unbound — which
-silently reverts the protection. Add the column before enabling `bindTo`.
+silently reverts the protection. Add the column before binding flows via
+`session` or `bindTo`.
 
 Expired state rows are removed as they are encountered; call `store.deleteExpired()` from a scheduled job for bulk cleanup. Redis remains available for apps that already run it:
 
@@ -349,7 +337,7 @@ describe('GitHub OAuth', () => {
 
 ## Best Practices
 
-1. **Never skip state verification**: `handleCallback` verifies and consumes the state automatically — don't build a custom callback path that trusts `code` alone. Always pass `bindTo` as well; state verification on its own does not tell you the flow started in the same browser (see [Binding State to the Browser](#binding-state-to-the-browser)).
+1. **Never skip state verification**: `handleCallback` verifies and consumes the state automatically — don't build a custom callback path that trusts `code` alone. Always pass `session` (or `bindTo`) as well; state verification on its own does not tell you the flow started in the same browser (see [Binding State to the Browser](#binding-state-to-the-browser)).
 
 2. **Set `allowedRedirectHosts` explicitly**: without it, only app-relative `redirectTo` paths are honored, which is the safest default. Add hosts only if you redirect to a separate domain after login.
 

--- a/docs/en/guides/oauth.md
+++ b/docs/en/guides/oauth.md
@@ -41,17 +41,29 @@ const CallbackQuerySchema = z.object({
   state: z.string(),
 })
 
+const OAUTH_BINDING_KEY = 'oauth.binding'
+
 export default class GitHubOAuthController extends Controller {
   async start() {
+    // Ties the flow to this browser — see "Binding state to the browser" below.
+    const binding = crypto.randomUUID()
+    this.auth.session()?.set(OAUTH_BINDING_KEY, binding)
+
     const { url } = await oauth.authorize('github', {
       redirectTo: this.query('redirect_to'),
+      bindTo: binding,
     })
     return this.redirect(url)
   }
 
   async callback() {
     const { code, state } = this.validateQuery(CallbackQuerySchema)
-    const { profile, redirectTo } = await oauth.handleCallback('github', { code, state })
+
+    const session = this.auth.session()
+    const binding = session?.get<string>(OAUTH_BINDING_KEY)
+    session?.forget(OAUTH_BINDING_KEY)
+
+    const { profile, redirectTo } = await oauth.handleCallback('github', { code, state, bindTo: binding })
 
     let user = await User.where('githubId', profile.id).first()
     if (!user) {
@@ -75,6 +87,50 @@ export function registerWebRoutes(router: Router): void {
   router.get('/auth/github/callback', [GitHubOAuthController, 'callback'])
 }
 ```
+
+## Binding State to the Browser
+
+`state` is unguessable and single-use, but on its own it is also *transferable*.
+An attacker can start a flow on your app, authorize their own provider account,
+keep the resulting `code` unconsumed, and then get a visitor to open
+
+```
+https://your.app/auth/github/callback?code=<attacker's>&state=<attacker's>
+```
+
+Nothing in the pair identifies whose browser began the flow, so the callback
+succeeds and logs that visitor into the **attacker's** account. Everything the
+visitor writes afterwards — posts, uploads, a saved payment method — lands in an
+account the attacker can also read.
+
+Pass `bindTo` to close it:
+
+```ts
+// starting the flow
+const binding = crypto.randomUUID()
+this.auth.session()?.set('oauth.binding', binding)
+const { url } = await oauth.authorize('github', { bindTo: binding })
+
+// in the callback
+const session = this.auth.session()
+const binding = session?.get<string>('oauth.binding')
+session?.forget('oauth.binding')
+await oauth.handleCallback('github', { code, state, bindTo: binding })
+```
+
+Only a hash of the value reaches the state store, and `handleCallback` refuses a
+state whose binding it cannot match. Writing to the session is also what makes a
+first-time visitor's session persist across the round trip to the provider, so
+the callback request carries the same one.
+
+A session id works as `bindTo` too, but only where a session already exists —
+the value above is generated for the purpose and works for logged-out visitors.
+
+> [!WARNING]
+> `authorize()` without `bindTo` still works, so apps written against the earlier
+> API keep running, and it logs a warning once per process. Those apps remain
+> open to the attack above until they adopt it. `make:auth` and the `oauth`
+> blueprint generate the bound version.
 
 ## Redirect After Login
 
@@ -278,7 +334,7 @@ describe('GitHub OAuth', () => {
 
 ## Best Practices
 
-1. **Never skip state verification**: `handleCallback` verifies and consumes the state automatically — don't build a custom callback path that trusts `code` alone.
+1. **Never skip state verification**: `handleCallback` verifies and consumes the state automatically — don't build a custom callback path that trusts `code` alone. Always pass `bindTo` as well; state verification on its own does not tell you the flow started in the same browser (see [Binding State to the Browser](#binding-state-to-the-browser)).
 
 2. **Set `allowedRedirectHosts` explicitly**: without it, only app-relative `redirectTo` paths are honored, which is the safest default. Add hosts only if you redirect to a separate domain after login.
 

--- a/docs/en/guides/oauth.md
+++ b/docs/en/guides/oauth.md
@@ -277,8 +277,14 @@ export const oauthStates = sqliteTable('oauth_states', {
   provider: text('provider').notNull(),
   redirectTo: text('redirect_to'),
   expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
+  binding: text('binding'),
 })
 ```
+
+The `binding` column holds the hashed browser binding from
+[Binding State to the Browser](#binding-state-to-the-browser). Without it the
+store cannot persist a binding, and every bound state comes back unbound — which
+silently reverts the protection. Add the column before enabling `bindTo`.
 
 Expired state rows are removed as they are encountered; call `store.deleteExpired()` from a scheduled job for bulk cleanup. Redis remains available for apps that already run it:
 

--- a/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
@@ -22,6 +22,13 @@ function identityWhere(provider: OAuthProvider, profileId: string): Partial<User
   return identities[provider]
 }
 
+// Where the per-browser binding for the OAuth `state` is kept. Without it,
+// `state` is unguessable and single-use but transferable: an attacker can
+// authorize their own account, keep the `code` unconsumed, and walk a
+// visitor's browser through the callback — logging that visitor into the
+// attacker's account.
+const OAUTH_BINDING_KEY = 'oauth.binding'
+
 export default class OAuthController extends Controller {
   private oauth(): OAuthManager {
     return this.make<OAuthManager>('oauth')
@@ -32,8 +39,14 @@ export default class OAuthController extends Controller {
   async redirectToProvider(): Promise<Response> {
     const { provider } = this.validateParams(ProviderParamSchema)
 
+    // Writing to the session is also what makes a visitor's brand-new session
+    // persist, so the callback request arrives carrying the same one.
+    const binding = randomUUID()
+    this.auth.session()?.set(OAUTH_BINDING_KEY, binding)
+
     const { url } = await this.oauth().authorize(provider, {
       redirectTo: this.request.query('redirectTo') ?? undefined,
+      bindTo: binding,
     })
 
     return this.redirect(url)
@@ -43,7 +56,11 @@ export default class OAuthController extends Controller {
     const { provider } = this.validateParams(ProviderParamSchema)
     const { code, state } = this.validateQuery(CallbackQuerySchema)
 
-    const { profile, redirectTo } = await this.oauth().handleCallback(provider, { code, state })
+    const session = this.auth.session()
+    const binding = session?.get<string>(OAUTH_BINDING_KEY)
+    session?.forget(OAUTH_BINDING_KEY)
+
+    const { profile, redirectTo } = await this.oauth().handleCallback(provider, { code, state, bindTo: binding })
 
     // GitHub accounts with a private email are handled upstream:
     // createGitHubOAuthProviderConfig falls back to /user/emails, so

--- a/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
@@ -22,8 +22,6 @@ function identityWhere(provider: OAuthProvider, profileId: string): Partial<User
   return identities[provider]
 }
 
-const OAUTH_BINDING_KEY = 'oauth.binding'
-
 export default class OAuthController extends Controller {
   private oauth(): OAuthManager {
     return this.make<OAuthManager>('oauth')
@@ -34,22 +32,13 @@ export default class OAuthController extends Controller {
   async redirectToProvider(): Promise<Response> {
     const { provider } = this.validateParams(ProviderParamSchema)
 
-    // Ties `state` to this browser: without it an attacker can authorize their
-    // own account, hold the `code`, and walk a visitor through the callback to
-    // log them into the attacker's account. Writing to the session also makes a
-    // visitor's brand-new session persist across the provider round trip. Bound
-    // only when a session exists to hold it — otherwise the callback has
-    // nothing to present and rejects its own flow.
-    const session = this.auth.session()
-    let binding: string | undefined
-    if (session) {
-      binding = randomUUID()
-      session.set(OAUTH_BINDING_KEY, binding)
-    }
-
+    // Passing the session ties `state` to this browser: the manager keeps a
+    // binding in it that the callback must present back. Without it an
+    // attacker could authorize their own account, hold the `code`, and walk a
+    // visitor through the callback to log them into the attacker's account.
     const { url } = await this.oauth().authorize(provider, {
       redirectTo: this.request.query('redirectTo') ?? undefined,
-      bindTo: binding,
+      session: this.auth.session(),
     })
 
     return this.redirect(url)
@@ -59,11 +48,11 @@ export default class OAuthController extends Controller {
     const { provider } = this.validateParams(ProviderParamSchema)
     const { code, state } = this.validateQuery(CallbackQuerySchema)
 
-    const session = this.auth.session()
-    const binding = session?.get<string>(OAUTH_BINDING_KEY)
-    session?.forget(OAUTH_BINDING_KEY)
-
-    const { profile, redirectTo } = await this.oauth().handleCallback(provider, { code, state, bindTo: binding })
+    const { profile, redirectTo } = await this.oauth().handleCallback(provider, {
+      code,
+      state,
+      session: this.auth.session(),
+    })
 
     // GitHub accounts with a private email are handled upstream:
     // createGitHubOAuthProviderConfig falls back to /user/emails, so

--- a/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
@@ -22,11 +22,6 @@ function identityWhere(provider: OAuthProvider, profileId: string): Partial<User
   return identities[provider]
 }
 
-// Where the per-browser binding for the OAuth `state` is kept. Without it,
-// `state` is unguessable and single-use but transferable: an attacker can
-// authorize their own account, keep the `code` unconsumed, and walk a
-// visitor's browser through the callback — logging that visitor into the
-// attacker's account.
 const OAUTH_BINDING_KEY = 'oauth.binding'
 
 export default class OAuthController extends Controller {
@@ -39,10 +34,12 @@ export default class OAuthController extends Controller {
   async redirectToProvider(): Promise<Response> {
     const { provider } = this.validateParams(ProviderParamSchema)
 
-    // Writing to the session is also what makes a visitor's brand-new session
-    // persist, so the callback request arrives carrying the same one. Bound
-    // only when there is a session to hold the value: sending `bindTo` with
-    // nowhere to keep it would make the callback reject its own flow.
+    // Ties `state` to this browser: without it an attacker can authorize their
+    // own account, hold the `code`, and walk a visitor through the callback to
+    // log them into the attacker's account. Writing to the session also makes a
+    // visitor's brand-new session persist across the provider round trip. Bound
+    // only when a session exists to hold it — otherwise the callback has
+    // nothing to present and rejects its own flow.
     const session = this.auth.session()
     let binding: string | undefined
     if (session) {

--- a/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/OAuthController.ts
@@ -40,9 +40,15 @@ export default class OAuthController extends Controller {
     const { provider } = this.validateParams(ProviderParamSchema)
 
     // Writing to the session is also what makes a visitor's brand-new session
-    // persist, so the callback request arrives carrying the same one.
-    const binding = randomUUID()
-    this.auth.session()?.set(OAUTH_BINDING_KEY, binding)
+    // persist, so the callback request arrives carrying the same one. Bound
+    // only when there is a session to hold the value: sending `bindTo` with
+    // nowhere to keep it would make the callback reject its own flow.
+    const session = this.auth.session()
+    let binding: string | undefined
+    if (session) {
+      binding = randomUUID()
+      session.set(OAUTH_BINDING_KEY, binding)
+    }
 
     const { url } = await this.oauth().authorize(provider, {
       redirectTo: this.request.query('redirectTo') ?? undefined,

--- a/examples/blog/tests/controllers/OAuthController.test.ts
+++ b/examples/blog/tests/controllers/OAuthController.test.ts
@@ -37,11 +37,22 @@ function createOAuthStub() {
   }
 }
 
-function createController() {
+/** Enough of a Session for the controller's state binding to round-trip. */
+function createSessionStub() {
+  const data = new Map<string, unknown>()
+  return {
+    regenerate: vi.fn(),
+    set: vi.fn((key: string, value: unknown) => { data.set(key, value) }),
+    get: vi.fn((key: string) => data.get(key)),
+    forget: vi.fn((key: string) => { data.delete(key) }),
+  }
+}
+
+function createController(session = createSessionStub()) {
   const controller = new OAuthController()
   Object.defineProperty(controller, 'auth', {
     value: {
-      session: vi.fn().mockReturnValue({ regenerate: vi.fn() }),
+      session: vi.fn().mockReturnValue(session),
       login: vi.fn().mockResolvedValue(undefined),
     },
     configurable: true,
@@ -60,9 +71,30 @@ describe('OAuthController', () => {
 
       const response = await controller.redirectToProvider()
 
-      expect(oauth.authorize).toHaveBeenCalledWith('github', { redirectTo: undefined })
+      // `bindTo` ties the flow to this browser: without it an attacker can
+      // authorize their own account, hold the `code`, and walk a visitor
+      // through the callback to log them into the attacker's account.
+      expect(oauth.authorize).toHaveBeenCalledWith('github', {
+        redirectTo: undefined,
+        bindTo: expect.any(String),
+      })
       expect(response.status).toBe(302)
       expect(response.headers.get('Location')).toBe('https://github.com/login/oauth/authorize?client_id=abc')
+    })
+
+    it('hands the callback the same binding it stored in the session', async () => {
+      const oauth = createOAuthStub()
+      const session = createSessionStub()
+      const controller = createController(session)
+      const ctx = createControllerContext('http://blog.test/auth/github', {}, { oauth }) as unknown as Context
+      controller.setContext(ctx)
+      ;(ctx as unknown as { req: { param: () => Record<string, string> } }).req.param = () => ({ provider: 'github' })
+
+      await controller.redirectToProvider()
+
+      const { bindTo } = (oauth.authorize as unknown as { mock: { calls: Array<[string, { bindTo: string }]> } }).mock.calls[0][1]
+      expect(session.set).toHaveBeenCalledWith('oauth.binding', bindTo)
+      expect(session.get('oauth.binding')).toBe(bindTo)
     })
   })
 

--- a/examples/blog/tests/controllers/OAuthController.test.ts
+++ b/examples/blog/tests/controllers/OAuthController.test.ts
@@ -96,6 +96,22 @@ describe('OAuthController', () => {
       expect(session.set).toHaveBeenCalledWith('oauth.binding', bindTo)
       expect(session.get('oauth.binding')).toBe(bindTo)
     })
+
+    // Sending a binding the callback can never present would make every login
+    // fail with "Invalid or expired OAuth state" — pointing at the wrong cause.
+    it('sends no binding when there is no session to hold it', async () => {
+      const oauth = createOAuthStub()
+      // `null`, not `undefined` — the default parameter would substitute a stub.
+      const controller = createController(null as unknown as ReturnType<typeof createSessionStub>)
+      const ctx = createControllerContext('http://blog.test/auth/github', {}, { oauth }) as unknown as Context
+      controller.setContext(ctx)
+      ;(ctx as unknown as { req: { param: () => Record<string, string> } }).req.param = () => ({ provider: 'github' })
+
+      const response = await controller.redirectToProvider()
+
+      expect(oauth.authorize).toHaveBeenCalledWith('github', { redirectTo: undefined, bindTo: undefined })
+      expect(response.status).toBe(302)
+    })
   })
 
   describe('callback()', () => {

--- a/examples/blog/tests/controllers/OAuthController.test.ts
+++ b/examples/blog/tests/controllers/OAuthController.test.ts
@@ -64,42 +64,29 @@ describe('OAuthController', () => {
   describe('redirectToProvider()', () => {
     it('redirects to the provider authorization URL', async () => {
       const oauth = createOAuthStub()
-      const controller = createController()
-      const ctx = createControllerContext('http://blog.test/auth/github', {}, { oauth }) as unknown as Context
-      controller.setContext(ctx)
-      ;(ctx as unknown as { req: { param: () => Record<string, string> } }).req.param = () => ({ provider: 'github' })
-
-      const response = await controller.redirectToProvider()
-
-      // `bindTo` ties the flow to this browser: without it an attacker can
-      // authorize their own account, hold the `code`, and walk a visitor
-      // through the callback to log them into the attacker's account.
-      expect(oauth.authorize).toHaveBeenCalledWith('github', {
-        redirectTo: undefined,
-        bindTo: expect.any(String),
-      })
-      expect(response.status).toBe(302)
-      expect(response.headers.get('Location')).toBe('https://github.com/login/oauth/authorize?client_id=abc')
-    })
-
-    it('hands the callback the same binding it stored in the session', async () => {
-      const oauth = createOAuthStub()
       const session = createSessionStub()
       const controller = createController(session)
       const ctx = createControllerContext('http://blog.test/auth/github', {}, { oauth }) as unknown as Context
       controller.setContext(ctx)
       ;(ctx as unknown as { req: { param: () => Record<string, string> } }).req.param = () => ({ provider: 'github' })
 
-      await controller.redirectToProvider()
+      const response = await controller.redirectToProvider()
 
-      const { bindTo } = (oauth.authorize as unknown as { mock: { calls: Array<[string, { bindTo: string }]> } }).mock.calls[0][1]
-      expect(session.set).toHaveBeenCalledWith('oauth.binding', bindTo)
-      expect(session.get('oauth.binding')).toBe(bindTo)
+      // Passing the session lets the manager bind `state` to this browser:
+      // without it an attacker can authorize their own account, hold the
+      // `code`, and walk a visitor through the callback to log them into the
+      // attacker's account.
+      expect(oauth.authorize).toHaveBeenCalledWith('github', {
+        redirectTo: undefined,
+        session,
+      })
+      expect(response.status).toBe(302)
+      expect(response.headers.get('Location')).toBe('https://github.com/login/oauth/authorize?client_id=abc')
     })
 
-    // Sending a binding the callback can never present would make every login
-    // fail with "Invalid or expired OAuth state" — pointing at the wrong cause.
-    it('sends no binding when there is no session to hold it', async () => {
+    // The manager treats a missing session as an unbound flow; forwarding it
+    // untouched is what keeps a session-less setup working.
+    it('passes the missing session through so the flow stays unbound', async () => {
       const oauth = createOAuthStub()
       // `null`, not `undefined` — the default parameter would substitute a stub.
       const controller = createController(null as unknown as ReturnType<typeof createSessionStub>)
@@ -109,7 +96,7 @@ describe('OAuthController', () => {
 
       const response = await controller.redirectToProvider()
 
-      expect(oauth.authorize).toHaveBeenCalledWith('github', { redirectTo: undefined, bindTo: undefined })
+      expect(oauth.authorize).toHaveBeenCalledWith('github', { redirectTo: undefined, session: null })
       expect(response.status).toBe(302)
     })
   })
@@ -123,13 +110,17 @@ describe('OAuthController', () => {
       })
       mockUserWhere.mockResolvedValue([{ id: 1, email: 'ada@example.com', githubId: 'gh-1' }])
 
-      const controller = createController()
+      const session = createSessionStub()
+      const controller = createController(session)
       const ctx = createControllerContext('http://blog.test/auth/github/callback?code=abc&state=xyz', {}, { oauth }) as unknown as Context
       controller.setContext(ctx)
       ;(ctx as unknown as { req: { param: () => Record<string, string> } }).req.param = () => ({ provider: 'github' })
 
       const response = await controller.callback()
 
+      // The manager reads the binding back from the same session that
+      // authorize() stored it in.
+      expect(oauth.handleCallback).toHaveBeenCalledWith('github', { code: 'abc', state: 'xyz', session })
       expect(mockUserCreate).not.toHaveBeenCalled()
       expect(response.status).toBe(302)
       expect(response.headers.get('Location')).toBe('/dashboard')

--- a/package.json
+++ b/package.json
@@ -95,6 +95,9 @@
     "body-parser": "^2.3.0",
     "ws": "^8.20.1",
     "form-data": "^4.0.6",
-    "undici": "7.29.0"
+    "undici": "7.29.0",
+    "dompurify": "^3.4.13",
+    "mermaid": "^11.16.1",
+    "nanoid": "^3.3.17"
   }
 }

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -220,9 +220,15 @@ export default class OAuthController extends Controller {
     const provider = this.validateProvider(this.request.param('provider'))
 
     // Writing to the session is also what makes a visitor's brand-new session
-    // persist, so the callback request arrives carrying the same one.
-    const binding = crypto.randomUUID()
-    this.auth.session()?.set(OAUTH_BINDING_KEY, binding)
+    // persist, so the callback request arrives carrying the same one. Bound
+    // only when there is a session to hold the value: sending \`bindTo\` with
+    // nowhere to keep it would make the callback reject its own flow.
+    const session = this.auth.session()
+    let binding: string | undefined
+    if (session) {
+      binding = crypto.randomUUID()
+      session.set(OAUTH_BINDING_KEY, binding)
+    }
 
     // \`?redirectTo=\` is user input — the manager only keeps app-relative
     // paths (or hosts allowlisted via stateConfig.allowedRedirectHosts).

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -202,13 +202,6 @@ type SupportedProvider = 'github' | 'google' | 'discord'
 
 const SUPPORTED_PROVIDERS = new Set<SupportedProvider>(['github', 'google', 'discord'])
 
-// Where the per-browser binding for the OAuth \`state\` is kept. Without it,
-// \`state\` is unguessable and single-use but transferable: an attacker can
-// authorize their own account, keep the \`code\` unconsumed, and walk a
-// visitor's browser through the callback — logging that visitor into the
-// attacker's account.
-const OAUTH_BINDING_KEY = 'oauth.binding'
-
 export default class OAuthController extends Controller {
   private oauth(): OAuthManager {
     return this.make<OAuthManager>('oauth')
@@ -219,22 +212,16 @@ export default class OAuthController extends Controller {
   async redirectToProvider(): Promise<Response> {
     const provider = this.validateProvider(this.request.param('provider'))
 
-    // Writing to the session is also what makes a visitor's brand-new session
-    // persist, so the callback request arrives carrying the same one. Bound
-    // only when there is a session to hold the value: sending \`bindTo\` with
-    // nowhere to keep it would make the callback reject its own flow.
-    const session = this.auth.session()
-    let binding: string | undefined
-    if (session) {
-      binding = crypto.randomUUID()
-      session.set(OAUTH_BINDING_KEY, binding)
-    }
-
+    // Passing the session ties \`state\` to this browser: the manager keeps a
+    // binding in it that the callback must present back. Without it an
+    // attacker could authorize their own account, keep the \`code\` unconsumed,
+    // and walk a visitor through the callback — logging that visitor into the
+    // attacker's account.
     // \`?redirectTo=\` is user input — the manager only keeps app-relative
     // paths (or hosts allowlisted via stateConfig.allowedRedirectHosts).
     const { url } = await this.oauth().authorize(provider, {
       redirectTo: this.request.query('redirectTo'),
-      bindTo: binding,
+      session: this.auth.session(),
     })
     return this.redirect(url)
   }
@@ -248,17 +235,17 @@ export default class OAuthController extends Controller {
       return this.json({ error: 'Missing OAuth callback parameters.' }, { status: 400 })
     }
 
-    const session = this.auth.session()
-    const binding = session?.get<string>(OAUTH_BINDING_KEY)
-    session?.forget(OAUTH_BINDING_KEY)
-
     // Replace this with your own account linking: look the user up by
     // profile.email, create one when missing, then \`await this.auth.login(user)\`
     // and finish with \`return this.redirect(redirectTo ?? '/')\` —
     // \`redirectTo\` is already sanitized against open redirects. Refuse to
     // create an account when \`profile.emailVerified === false\`: the provider
     // is saying it never checked that the address belongs to this user.
-    const { profile, redirectTo } = await this.oauth().handleCallback(provider, { code, state, bindTo: binding })
+    const { profile, redirectTo } = await this.oauth().handleCallback(provider, {
+      code,
+      state,
+      session: this.auth.session(),
+    })
     return this.json({ provider, profile, redirectTo }, { status: 200 })
   }
 

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -202,6 +202,13 @@ type SupportedProvider = 'github' | 'google' | 'discord'
 
 const SUPPORTED_PROVIDERS = new Set<SupportedProvider>(['github', 'google', 'discord'])
 
+// Where the per-browser binding for the OAuth \`state\` is kept. Without it,
+// \`state\` is unguessable and single-use but transferable: an attacker can
+// authorize their own account, keep the \`code\` unconsumed, and walk a
+// visitor's browser through the callback — logging that visitor into the
+// attacker's account.
+const OAUTH_BINDING_KEY = 'oauth.binding'
+
 export default class OAuthController extends Controller {
   private oauth(): OAuthManager {
     return this.make<OAuthManager>('oauth')
@@ -211,10 +218,17 @@ export default class OAuthController extends Controller {
   // Controller.redirect() helper used below.
   async redirectToProvider(): Promise<Response> {
     const provider = this.validateProvider(this.request.param('provider'))
+
+    // Writing to the session is also what makes a visitor's brand-new session
+    // persist, so the callback request arrives carrying the same one.
+    const binding = crypto.randomUUID()
+    this.auth.session()?.set(OAUTH_BINDING_KEY, binding)
+
     // \`?redirectTo=\` is user input — the manager only keeps app-relative
     // paths (or hosts allowlisted via stateConfig.allowedRedirectHosts).
     const { url } = await this.oauth().authorize(provider, {
       redirectTo: this.request.query('redirectTo'),
+      bindTo: binding,
     })
     return this.redirect(url)
   }
@@ -228,13 +242,17 @@ export default class OAuthController extends Controller {
       return this.json({ error: 'Missing OAuth callback parameters.' }, { status: 400 })
     }
 
+    const session = this.auth.session()
+    const binding = session?.get<string>(OAUTH_BINDING_KEY)
+    session?.forget(OAUTH_BINDING_KEY)
+
     // Replace this with your own account linking: look the user up by
     // profile.email, create one when missing, then \`await this.auth.login(user)\`
     // and finish with \`return this.redirect(redirectTo ?? '/')\` —
     // \`redirectTo\` is already sanitized against open redirects. Refuse to
     // create an account when \`profile.emailVerified === false\`: the provider
     // is saying it never checked that the address belongs to this user.
-    const { profile, redirectTo } = await this.oauth().handleCallback(provider, { code, state })
+    const { profile, redirectTo } = await this.oauth().handleCallback(provider, { code, state, bindTo: binding })
     return this.json({ provider, profile, redirectTo }, { status: 200 })
   }
 

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -582,8 +582,11 @@ export default class BroadcastProvider extends ServiceProvider {
     const orders = new OrdersChannel(broadcast)
     const userFeed = new UserFeedChannel(broadcast)
 
+    // A public channel is open by definition. A private one is not: register
+    // the channel's own authorize() so the check in UserFeedChannel is the
+    // check that runs.
     broadcast.channel(orders.getChannelName(), () => true)
-    broadcast.privateChannel(userFeed.getBaseName(), () => true)
+    broadcast.privateChannel(userFeed.getBaseName(), (channelName, user) => userFeed.authorize(channelName, user))
   }
 }
 `,

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -336,13 +336,6 @@ ${identityEntries}
   return identities[provider]
 }
 
-// Where the per-browser binding for the OAuth \`state\` is kept. Without it,
-// \`state\` is unguessable and single-use but transferable: an attacker can
-// authorize their own account, keep the \`code\` unconsumed, and walk a
-// visitor's browser through the callback — logging that visitor into the
-// attacker's account.
-const OAUTH_BINDING_KEY = 'oauth.binding'
-
 export default class OAuthController extends Controller {
   private oauth(): OAuthManager {
     return this.make<OAuthManager>('oauth')
@@ -353,20 +346,14 @@ export default class OAuthController extends Controller {
   async redirectToProvider(): Promise<Response> {
     const { provider } = this.validateParams(ProviderParamSchema)
 
-    // Writing to the session is also what makes a visitor's brand-new session
-    // persist, so the callback request arrives carrying the same one. Bound
-    // only when there is a session to hold the value: sending \`bindTo\` with
-    // nowhere to keep it would make the callback reject its own flow.
-    const session = this.auth.session()
-    let binding: string | undefined
-    if (session) {
-      binding = crypto.randomUUID()
-      session.set(OAUTH_BINDING_KEY, binding)
-    }
-
+    // Passing the session ties \`state\` to this browser: the manager keeps a
+    // binding in it that the callback must present back. Without it an
+    // attacker could authorize their own account, keep the \`code\` unconsumed,
+    // and walk a visitor through the callback — logging that visitor into the
+    // attacker's account.
     const { url } = await this.oauth().authorize(provider, {
       redirectTo: this.request.query('redirectTo') ?? undefined,
-      bindTo: binding,
+      session: this.auth.session(),
     })
 
     return this.redirect(url)
@@ -376,11 +363,11 @@ export default class OAuthController extends Controller {
     const { provider } = this.validateParams(ProviderParamSchema)
     const { code, state } = this.validateQuery(CallbackQuerySchema)
 
-    const session = this.auth.session()
-    const binding = session?.get<string>(OAUTH_BINDING_KEY)
-    session?.forget(OAUTH_BINDING_KEY)
-
-    const { profile, redirectTo } = await this.oauth().handleCallback(provider, { code, state, bindTo: binding })
+    const { profile, redirectTo } = await this.oauth().handleCallback(provider, {
+      code,
+      state,
+      session: this.auth.session(),
+    })
 
     // Lowercased to match how registration stores emails; provider casing
     // isn't guaranteed to be stable across logins.

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -354,9 +354,15 @@ export default class OAuthController extends Controller {
     const { provider } = this.validateParams(ProviderParamSchema)
 
     // Writing to the session is also what makes a visitor's brand-new session
-    // persist, so the callback request arrives carrying the same one.
-    const binding = crypto.randomUUID()
-    this.auth.session()?.set(OAUTH_BINDING_KEY, binding)
+    // persist, so the callback request arrives carrying the same one. Bound
+    // only when there is a session to hold the value: sending \`bindTo\` with
+    // nowhere to keep it would make the callback reject its own flow.
+    const session = this.auth.session()
+    let binding: string | undefined
+    if (session) {
+      binding = crypto.randomUUID()
+      session.set(OAUTH_BINDING_KEY, binding)
+    }
 
     const { url } = await this.oauth().authorize(provider, {
       redirectTo: this.request.query('redirectTo') ?? undefined,

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -336,6 +336,13 @@ ${identityEntries}
   return identities[provider]
 }
 
+// Where the per-browser binding for the OAuth \`state\` is kept. Without it,
+// \`state\` is unguessable and single-use but transferable: an attacker can
+// authorize their own account, keep the \`code\` unconsumed, and walk a
+// visitor's browser through the callback — logging that visitor into the
+// attacker's account.
+const OAUTH_BINDING_KEY = 'oauth.binding'
+
 export default class OAuthController extends Controller {
   private oauth(): OAuthManager {
     return this.make<OAuthManager>('oauth')
@@ -346,8 +353,14 @@ export default class OAuthController extends Controller {
   async redirectToProvider(): Promise<Response> {
     const { provider } = this.validateParams(ProviderParamSchema)
 
+    // Writing to the session is also what makes a visitor's brand-new session
+    // persist, so the callback request arrives carrying the same one.
+    const binding = crypto.randomUUID()
+    this.auth.session()?.set(OAUTH_BINDING_KEY, binding)
+
     const { url } = await this.oauth().authorize(provider, {
       redirectTo: this.request.query('redirectTo') ?? undefined,
+      bindTo: binding,
     })
 
     return this.redirect(url)
@@ -357,7 +370,11 @@ export default class OAuthController extends Controller {
     const { provider } = this.validateParams(ProviderParamSchema)
     const { code, state } = this.validateQuery(CallbackQuerySchema)
 
-    const { profile, redirectTo } = await this.oauth().handleCallback(provider, { code, state })
+    const session = this.auth.session()
+    const binding = session?.get<string>(OAUTH_BINDING_KEY)
+    session?.forget(OAUTH_BINDING_KEY)
+
+    const { profile, redirectTo } = await this.oauth().handleCallback(provider, { code, state, bindTo: binding })
 
     // Lowercased to match how registration stores emails; provider casing
     // isn't guaranteed to be stable across logins.

--- a/packages/cli/src/make-channel.ts
+++ b/packages/cli/src/make-channel.ts
@@ -3,24 +3,60 @@ import { kebabCase, scaffoldFile } from './utils'
 
 const CHANNELS_DIR = 'app/Broadcasting'
 
-function channelTemplate(className: string, channelName: string, isPrivate: boolean, isPresence: boolean): string {
-  const baseClass = isPresence ? 'PresenceChannel' : isPrivate ? 'PrivateChannel' : 'Channel'
+/**
+ * The body of a generated `authorize()`.
+ *
+ * A pattern carrying an `{id}` placeholder is per-user by convention, so the
+ * default check ties the subscription to that user. Anything else can only
+ * default to "any authenticated user" plus a TODO — the scaffolder cannot know
+ * the ownership rule, and a check that silently allows everyone is the thing
+ * this is meant to avoid.
+ */
+function privateAuthorize(channelName: string): { param: string; body: string } {
+  if (channelName.includes('{id}')) {
+    const ownerPattern = channelName.replace('{id}', '${(user as { id: string | number }).id}')
 
+    return {
+      param: 'channelName',
+      body: `    if (!user) return false
+
+    // \`${channelName}\` is per-user: only the owner may subscribe.
+    return channelName === \`private-${ownerPattern}\``,
+    }
+  }
+
+  return {
+    param: '_channelName',
+    body: `    // TODO: narrow this. Every authenticated user can subscribe as written.
+    return user != null`,
+  }
+}
+
+function channelTemplate(className: string, channelName: string, isPrivate: boolean, isPresence: boolean): string {
   if (isPresence) {
-    return `import { PresenceChannel, type BroadcastManager, type Context } from '@guren/core'
+    return `import { PresenceChannel, type BroadcastManager, type PresenceMember } from '@guren/core'
 
 export default class ${className} extends PresenceChannel {
   constructor(manager: BroadcastManager) {
     super('${channelName}', manager.driver())
   }
 
-  async join(ctx: Context): Promise<{ id: string; name?: string } | false> {
-    const user = ctx.get('user')
-    if (!user) return false
+  /**
+   * Decide who may join, and what the other members see.
+   *
+   * Return \`null\` to refuse. Register it so it runs:
+   *   broadcast.presenceChannel(channel.getBaseName(), (name, user) => channel.authorizeJoin(name, user))
+   *
+   * Named apart from the inherited \`join(member)\`, which adds an already
+   * authorized member to the channel.
+   */
+  async authorizeJoin(_channelName: string, user: unknown): Promise<PresenceMember | null> {
+    if (!user) return null
 
+    const member = user as { id: string | number; name?: string }
     return {
-      id: String(user.id),
-      name: user.name,
+      id: member.id,
+      info: { name: member.name },
     }
   }
 }
@@ -28,16 +64,21 @@ export default class ${className} extends PresenceChannel {
   }
 
   if (isPrivate) {
-    return `import { PrivateChannel, type BroadcastManager, type Context } from '@guren/core'
+    const { param, body } = privateAuthorize(channelName)
+
+    return `import { PrivateChannel, type BroadcastManager } from '@guren/core'
 
 export default class ${className} extends PrivateChannel {
   constructor(manager: BroadcastManager) {
     super('${channelName}', manager.driver())
   }
 
-  async authorize(ctx: Context): Promise<boolean> {
-    const user = ctx.get('user')
-    return !!user
+  /**
+   * Decide who may subscribe. Register it so it runs:
+   *   broadcast.privateChannel(channel.getBaseName(), (name, user) => channel.authorize(name, user))
+   */
+  async authorize(${param}: string, user: unknown): Promise<boolean> {
+${body}
   }
 }
 `

--- a/packages/cli/src/make-channel.ts
+++ b/packages/cli/src/make-channel.ts
@@ -1,35 +1,40 @@
 import type { WriterOptions } from './utils'
-import { kebabCase, scaffoldFile } from './utils'
+import { escapeTemplateLiteral, kebabCase, scaffoldFile } from './utils'
 
 const CHANNELS_DIR = 'app/Broadcasting'
 
 /**
- * The body of a generated `authorize()`.
+ * The generated `authorize()` method, signature and body together.
  *
- * A pattern carrying an `{id}` placeholder is per-user by convention, so the
- * default check ties the subscription to that user. Anything else can only
- * default to "any authenticated user" plus a TODO — the scaffolder cannot know
- * the ownership rule, and a check that silently allows everyone is the thing
- * this is meant to avoid.
+ * A single placeholder is per-user by convention, so the default check ties
+ * the subscription to that user. Anything else can only default to "any
+ * authenticated user" plus a TODO — the scaffolder cannot know the ownership
+ * rule, and a check that silently allows everyone is what this exists to
+ * avoid. Returned as one string so the parameter name cannot drift out of
+ * step with whether the body uses it.
  */
-function privateAuthorize(channelName: string): { param: string; body: string } {
-  if (channelName.includes('{id}')) {
-    const ownerPattern = channelName.replace('{id}', '${(user as { id: string | number }).id}')
+function privateAuthorizeMethod(channelName: string): string {
+  const placeholders = channelName.match(/\{[^}]+\}/gu) ?? []
 
-    return {
-      param: 'channelName',
-      body: `    if (!user) return false
+  const signature = (param: string) =>
+    `  async authorize(${param}: string, user: unknown): Promise<boolean> {`
+
+  if (placeholders.length !== 1) {
+    return `${signature('_channelName')}
+    // TODO: narrow this. Every authenticated user can subscribe as written.
+    return user != null
+  }`
+  }
+
+  const owner = escapeTemplateLiteral(channelName)
+    .replace(escapeTemplateLiteral(placeholders[0]), '${(user as { id: string | number }).id}')
+
+  return `${signature('channelName')}
+    if (!user) return false
 
     // \`${channelName}\` is per-user: only the owner may subscribe.
-    return channelName === \`private-${ownerPattern}\``,
-    }
-  }
-
-  return {
-    param: '_channelName',
-    body: `    // TODO: narrow this. Every authenticated user can subscribe as written.
-    return user != null`,
-  }
+    return channelName === \`private-${owner}\`
+  }`
 }
 
 function channelTemplate(className: string, channelName: string, isPrivate: boolean, isPresence: boolean): string {
@@ -64,8 +69,6 @@ export default class ${className} extends PresenceChannel {
   }
 
   if (isPrivate) {
-    const { param, body } = privateAuthorize(channelName)
-
     return `import { PrivateChannel, type BroadcastManager } from '@guren/core'
 
 export default class ${className} extends PrivateChannel {
@@ -77,9 +80,7 @@ export default class ${className} extends PrivateChannel {
    * Decide who may subscribe. Register it so it runs:
    *   broadcast.privateChannel(channel.getBaseName(), (name, user) => channel.authorize(name, user))
    */
-  async authorize(${param}: string, user: unknown): Promise<boolean> {
-${body}
-  }
+${privateAuthorizeMethod(channelName)}
 }
 `
   }

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -281,6 +281,15 @@ export default app
     expect(notificationFiles.some((file) => file.endsWith('app/Providers/NotificationProvider.ts'))).toBe(true)
     expect(storageFiles.some((file) => file.endsWith('app/Providers/StorageProvider.ts'))).toBe(true)
     expect(broadcastingFiles.some((file) => file.endsWith('app/Providers/BroadcastProvider.ts'))).toBe(true)
+
+    // The private channel must be registered with the channel's own check, not
+    // an allow-all — otherwise UserFeedChannel.authorize() never runs and any
+    // caller can subscribe to another user's feed.
+    const broadcastProviderSource = await readFile('app/Providers/BroadcastProvider.ts', 'utf8')
+    expect(broadcastProviderSource).toContain(
+      'broadcast.privateChannel(userFeed.getBaseName(), (channelName, user) => userFeed.authorize(channelName, user))',
+    )
+    expect(broadcastProviderSource).not.toContain('broadcast.privateChannel(userFeed.getBaseName(), () => true)')
     expect(oauthFiles.some((file) => file.endsWith('app/Providers/OAuthProvider.ts'))).toBe(true)
     expect(oauthFiles.some((file) => file.endsWith('app/Http/Controllers/Auth/OAuthController.ts'))).toBe(true)
 

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -431,22 +431,18 @@ export const posts = pgTable('posts', {
       expect(controller).toContain('this.oauth().authorize(provider')
       expect(controller).toContain('this.oauth().handleCallback(provider')
       // OAuth accounts are passwordless — no synthetic password is generated
-      // or hashed. (`randomUUID` still appears, for the state binding below.)
+      // or hashed.
       expect(controller).not.toContain('password:')
       expect(controller).not.toContain('password: randomUUID')
 
       // `state` alone is transferable between browsers: an attacker can
       // authorize their own account, hold the `code`, and walk a visitor
-      // through the callback to log them into the attacker's account. The
-      // binding is what makes the state useless in any other browser.
-      expect(controller).toContain('bindTo: binding')
-      expect(controller).toContain('{ code, state, bindTo: binding }')
-      expect(controller).toContain('session.set(OAUTH_BINDING_KEY, binding)')
-      expect(controller).toContain('session?.forget(OAUTH_BINDING_KEY)')
-      // Guarded on a session existing: a binding the callback can never
-      // present would fail every login with "Invalid or expired OAuth state".
-      expect(controller).toContain('const session = this.auth.session()')
-      expect(controller).toContain('if (session) {')
+      // through the callback to log them into the attacker's account. Handing
+      // the session to the manager is what binds the state to this browser.
+      expect(controller).toContain('session: this.auth.session()')
+      // Both legs must present the same session — authorize() stores the
+      // binding in it, handleCallback() reads it back.
+      expect((controller.match(/session: this\.auth\.session\(\)/g) ?? []).length).toBe(2)
       expect(controller).toContain('already exists. Sign in with the method you originally used.')
 
       // Returning an email is not a claim that the provider checked it, so the

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -430,9 +430,19 @@ export const posts = pgTable('posts', {
       expect(controller).toContain("this.make<OAuthManager>('oauth')")
       expect(controller).toContain('this.oauth().authorize(provider')
       expect(controller).toContain('this.oauth().handleCallback(provider')
-      // OAuth accounts are passwordless — no synthetic password is hashed.
-      expect(controller).not.toContain('randomUUID')
+      // OAuth accounts are passwordless — no synthetic password is generated
+      // or hashed. (`randomUUID` still appears, for the state binding below.)
       expect(controller).not.toContain('password:')
+      expect(controller).not.toContain('password: randomUUID')
+
+      // `state` alone is transferable between browsers: an attacker can
+      // authorize their own account, hold the `code`, and walk a visitor
+      // through the callback to log them into the attacker's account. The
+      // binding is what makes the state useless in any other browser.
+      expect(controller).toContain('bindTo: binding')
+      expect(controller).toContain('{ code, state, bindTo: binding }')
+      expect(controller).toContain('this.auth.session()?.set(OAUTH_BINDING_KEY, binding)')
+      expect(controller).toContain('session?.forget(OAUTH_BINDING_KEY)')
       expect(controller).toContain('already exists. Sign in with the method you originally used.')
 
       // Returning an email is not a claim that the provider checked it, so the

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -441,8 +441,12 @@ export const posts = pgTable('posts', {
       // binding is what makes the state useless in any other browser.
       expect(controller).toContain('bindTo: binding')
       expect(controller).toContain('{ code, state, bindTo: binding }')
-      expect(controller).toContain('this.auth.session()?.set(OAUTH_BINDING_KEY, binding)')
+      expect(controller).toContain('session.set(OAUTH_BINDING_KEY, binding)')
       expect(controller).toContain('session?.forget(OAUTH_BINDING_KEY)')
+      // Guarded on a session existing: a binding the callback can never
+      // present would fail every login with "Invalid or expired OAuth state".
+      expect(controller).toContain('const session = this.auth.session()')
+      expect(controller).toContain('if (session) {')
       expect(controller).toContain('already exists. Sign in with the method you originally used.')
 
       // Returning an email is not a claim that the provider checked it, so the

--- a/packages/cli/tests/make-commands.test.ts
+++ b/packages/cli/tests/make-commands.test.ts
@@ -478,6 +478,15 @@ describe('CLI make:* commands', () => {
       expect(content).toContain('return channelName === `private-users.${(user as { id: string | number }).id}.feed`')
     })
 
+    // Any single placeholder means per-user, not just the literal `{id}` —
+    // otherwise `orders.{orderId}` silently got the allow-any-user fallback.
+    it('ties a per-user private channel named with any placeholder', async () => {
+      const result = await makeChannel('Orders', { private: true, channel: 'orders.{orderId}.items' })
+      const content = fs.readFileSync(result, 'utf-8')
+      expect(content).toContain('async authorize(channelName: string, user: unknown)')
+      expect(content).toContain('return channelName === `private-orders.${(user as { id: string | number }).id}.items`')
+    })
+
     it('generates presence channel template', async () => {
       const result = await makeChannel('Room', { presence: true })
       const content = fs.readFileSync(result, 'utf-8')

--- a/packages/cli/tests/make-commands.test.ts
+++ b/packages/cli/tests/make-commands.test.ts
@@ -464,14 +464,28 @@ describe('CLI make:* commands', () => {
       const result = await makeChannel('Notifications', { private: true })
       const content = fs.readFileSync(result, 'utf-8')
       expect(content).toContain('extends PrivateChannel')
-      expect(content).toContain('authorize(ctx: Context)')
+      // The signature has to match ChannelAuthorizer, or the method cannot be
+      // registered and silently never runs.
+      expect(content).toContain('async authorize(_channelName: string, user: unknown): Promise<boolean>')
+      expect(content).toContain('broadcast.privateChannel(')
+    })
+
+    it('ties a per-user private channel to the subscriber', async () => {
+      const result = await makeChannel('UserFeed', { private: true, channel: 'users.{id}.feed' })
+      const content = fs.readFileSync(result, 'utf-8')
+      expect(content).toContain('async authorize(channelName: string, user: unknown): Promise<boolean>')
+      expect(content).toContain('if (!user) return false')
+      expect(content).toContain('return channelName === `private-users.${(user as { id: string | number }).id}.feed`')
     })
 
     it('generates presence channel template', async () => {
       const result = await makeChannel('Room', { presence: true })
       const content = fs.readFileSync(result, 'utf-8')
       expect(content).toContain('extends PresenceChannel')
-      expect(content).toContain('join(ctx: Context)')
+      // Not `join`: the base class already has `join(member)`, and overriding
+      // it with an incompatible signature is how the previous template ended up
+      // never adding a member.
+      expect(content).toContain('async authorizeJoin(_channelName: string, user: unknown): Promise<PresenceMember | null>')
     })
 
     it('uses custom channel name', async () => {

--- a/packages/core/src/oauth-state-store.ts
+++ b/packages/core/src/oauth-state-store.ts
@@ -13,7 +13,7 @@ import { isExpired, toDate } from './store-utils.js'
  *
  * Pass the Drizzle table for your `oauth_states` schema. Column property
  * names must match `stateHash` (text primary key), `provider`,
- * `redirectTo`, and `expiresAt`:
+ * `redirectTo`, `expiresAt`, and `binding`:
  *
  * ```ts
  * export const oauthStates = sqliteTable('oauth_states', {
@@ -21,8 +21,13 @@ import { isExpired, toDate } from './store-utils.js'
  *   provider: text('provider').notNull(),
  *   redirectTo: text('redirect_to'),
  *   expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
+ *   binding: text('binding'),
  * })
  * ```
+ *
+ * `binding` is required for `authorize({ bindTo })` to survive the round trip
+ * to the provider. Without the column the store cannot persist it, and every
+ * bound state comes back unbound.
  *
  * @example
  * ```ts
@@ -49,6 +54,8 @@ export class DatabaseOAuthStateStore implements OAuthStateStore {
       provider: payload.provider,
       redirectTo: payload.redirectTo ?? null,
       expiresAt: payload.expiresAt,
+      // Persisted, not derived: an unbound state verifies for any browser.
+      binding: payload.binding ?? null,
     })
   }
 
@@ -145,6 +152,7 @@ function mapRecordToPayload(record: Record<string, unknown>): OAuthStatePayload 
     redirectTo: record.redirectTo == null ? undefined : String(record.redirectTo),
     // fetchLive's isExpired check guarantees this parses.
     expiresAt: toDate(record.expiresAt) as Date,
+    binding: record.binding == null ? undefined : String(record.binding),
   }
 }
 

--- a/packages/core/tests/oauth-state-store.test.ts
+++ b/packages/core/tests/oauth-state-store.test.ts
@@ -10,6 +10,7 @@ const oauthStates = sqliteTable('oauth_states', {
   provider: text('provider').notNull(),
   redirectTo: text('redirect_to'),
   expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
+  binding: text('binding'),
 })
 
 describe('DatabaseOAuthStateStore', () => {
@@ -23,7 +24,8 @@ describe('DatabaseOAuthStateStore', () => {
         state_hash text primary key,
         provider text not null,
         redirect_to text,
-        expires_at integer not null
+        expires_at integer not null,
+        binding text
       );
     `)
     DrizzleAdapter.configure(drizzle({ client: sqlite }) as never)
@@ -49,6 +51,28 @@ describe('DatabaseOAuthStateStore', () => {
     expect(result!.redirectTo).toBe('/dashboard')
     expect(result!.expiresAt).toBeInstanceOf(Date)
     expect(result!.expiresAt.getTime()).toBe(expiresAt.getTime())
+  })
+
+  // A store that drops the binding hands back an unbound state, which then
+  // verifies for any browser — silently undoing the login-CSRF fix.
+  test('round-trips the browser binding', async () => {
+    await store.store('hash-bound', {
+      provider: 'github',
+      expiresAt: new Date(Date.now() + 60_000),
+      binding: 'hashed-binding',
+    })
+
+    expect((await store.find('hash-bound'))!.binding).toBe('hashed-binding')
+    expect((await store.consume('hash-bound'))!.binding).toBe('hashed-binding')
+  })
+
+  test('leaves binding undefined when the state was not bound', async () => {
+    await store.store('hash-unbound', {
+      provider: 'github',
+      expiresAt: new Date(Date.now() + 60_000),
+    })
+
+    expect((await store.find('hash-unbound'))!.binding).toBeUndefined()
   })
 
   test('returns null for an unknown state hash', async () => {

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -988,7 +988,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     operatorOrValue?: unknown,
     value?: unknown,
   ): QueryBuilder<TRecordFor<T>> {
-    const builder = new QueryBuilder<TRecordFor<T>>(this)
+    const builder = this.newQuery()
 
     if (typeof fieldOrConditions === 'object' && fieldOrConditions !== null) {
       return builder.where(fieldOrConditions as Partial<Record<keyof TRecordFor<T> & string, unknown>>)
@@ -1012,7 +1012,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     this: T,
     field: keyof TRecordFor<T> & string,
   ): QueryBuilder<TRecordFor<T>> {
-    return new QueryBuilder<TRecordFor<T>>(this).whereNull(field)
+    return this.newQuery().whereNull(field)
   }
 
   /**
@@ -1023,7 +1023,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     this: T,
     field: keyof TRecordFor<T> & string,
   ): QueryBuilder<TRecordFor<T>> {
-    return new QueryBuilder<TRecordFor<T>>(this).whereNotNull(field)
+    return this.newQuery().whereNotNull(field)
   }
 
   /**
@@ -1036,7 +1036,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     field: keyof TRecordFor<T> & string,
     values: readonly TRecordFor<T>[keyof TRecordFor<T> & string][],
   ): QueryBuilder<TRecordFor<T>> {
-    return new QueryBuilder<TRecordFor<T>>(this).whereIn(field, values)
+    return this.newQuery().whereIn(field, values)
   }
 
   /**
@@ -1049,7 +1049,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     field: keyof TRecordFor<T> & string,
     values: readonly TRecordFor<T>[keyof TRecordFor<T> & string][],
   ): QueryBuilder<TRecordFor<T>> {
-    return new QueryBuilder<TRecordFor<T>>(this).whereNotIn(field, values)
+    return this.newQuery().whereNotIn(field, values)
   }
 
   /**
@@ -1063,7 +1063,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     this: T,
     ...fields: readonly Keys[]
   ): QueryBuilder<TRecordFor<T>, Pick<TRecordFor<T>, Keys>> {
-    return new QueryBuilder<TRecordFor<T>>(this).select(...fields)
+    return this.newQuery().select(...fields)
   }
 
   /**
@@ -1078,6 +1078,17 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
    *   .limit(10)
    *   .get()
    */
+  /**
+   * Whether this model carries a filter that every query must apply.
+   *
+   * The entry points that talk to the adapter directly check this to decide
+   * whether they can take the fast path; anything that returns a QueryBuilder
+   * goes through `newQuery()` unconditionally.
+   */
+  protected static hasScopes(): boolean {
+    return Boolean(this.defaultScope) || Boolean(this.globalScopeRegistry && this.globalScopeRegistry.size > 0)
+  }
+
   static newQuery<T extends typeof Model>(this: T, queryOptions?: ModelQueryOptions): QueryBuilder<TRecordFor<T>> {
     const builder = new QueryBuilder<TRecordFor<T>>(this, queryOptions)
     if (this.defaultScope) {
@@ -1116,7 +1127,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     if (!scopes || typeof scopes[name] !== 'function') {
       throw new Error(`${this.name}: unknown scope "${name}".`)
     }
-    const builder = new QueryBuilder<TRecordFor<T>>(this)
+    const builder = this.newQuery()
     return scopes[name](builder) as QueryBuilder<TRecordFor<T>>
   }
 
@@ -1420,8 +1431,20 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     where?: WhereClauseFor<T>,
     queryOptions?: ModelQueryOptions,
   ): Promise<TRecordFor<T>[]> {
-    const table = this.resolveTable()
     const orderBy = normalizeOrderBy(order)
+
+    if (this.hasScopes()) {
+      const builder = this.newQuery(queryOptions)
+      if (where && Object.keys(where).length > 0) {
+        builder.where(where as Partial<Record<string, unknown>>)
+      }
+      for (const clause of orderBy) {
+        builder.orderBy(clause.column as keyof TRecordFor<T> & string, clause.direction)
+      }
+      return builder.get()
+    }
+
+    const table = this.resolveTable()
     const options: FindManyOptions<TRecordFor<T>> = { orderBy }
 
     if (where && Object.keys(where).length > 0) {
@@ -1456,6 +1479,21 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     options: PaginateOptions<TRecordFor<T>> = {},
     queryOptions?: ModelQueryOptions,
   ): Promise<PaginatedResult<TRecordFor<T>>> {
+    // The count matters as much as the rows: an unscoped `meta.total` reports
+    // how many records the filter was meant to hide.
+    if (this.hasScopes()) {
+      const builder = this.newQuery(queryOptions)
+      if (options.where && Object.keys(options.where).length > 0) {
+        builder.where(options.where as Partial<Record<string, unknown>>)
+      }
+      if (options.orderBy) {
+        for (const clause of normalizeOrderBy(options.orderBy)) {
+          builder.orderBy(clause.column as keyof TRecordFor<T> & string, clause.direction)
+        }
+      }
+      return builder.paginate({ page: options.page, perPage: options.perPage })
+    }
+
     const table = this.resolveTable()
     const adapter = this.getAdapter()
 

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -780,8 +780,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
    * const users = await User.all()
    */
   static async all<T extends typeof Model>(this: T, queryOptions?: ModelQueryOptions): Promise<Array<TRecordFor<T>>> {
-    const hasGlobalScopes = this.globalScopeRegistry && this.globalScopeRegistry.size > 0
-    if (this.defaultScope || hasGlobalScopes) {
+    if (this.hasScopes()) {
       return this.newQuery(queryOptions).get()
     }
     const table = this.resolveTable()
@@ -809,7 +808,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     key: keyof TRecordFor<T> & string = 'id' as keyof TRecordFor<T> & string,
     queryOptions?: ModelQueryOptions,
   ): Promise<TRecordFor<T> | null> {
-    if (this.defaultScope || (this.globalScopeRegistry && this.globalScopeRegistry.size > 0)) {
+    if (this.hasScopes()) {
       return this.newQuery(queryOptions).where(key, id as TRecordFor<T>[typeof key]).first()
     }
     const table = this.resolveTable()
@@ -940,7 +939,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     where?: WhereClauseFor<T>,
     queryOptions?: ModelQueryOptions,
   ): Promise<TRecordFor<T> | null> {
-    if (this.defaultScope || (this.globalScopeRegistry && this.globalScopeRegistry.size > 0)) {
+    if (this.hasScopes()) {
       const builder = this.newQuery(queryOptions).limit(1)
       if (where) {
         builder.where(where as Partial<Record<string, unknown>>)
@@ -1078,17 +1077,6 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
    *   .limit(10)
    *   .get()
    */
-  /**
-   * Whether this model carries a filter that every query must apply.
-   *
-   * The entry points that talk to the adapter directly check this to decide
-   * whether they can take the fast path; anything that returns a QueryBuilder
-   * goes through `newQuery()` unconditionally.
-   */
-  protected static hasScopes(): boolean {
-    return Boolean(this.defaultScope) || Boolean(this.globalScopeRegistry && this.globalScopeRegistry.size > 0)
-  }
-
   static newQuery<T extends typeof Model>(this: T, queryOptions?: ModelQueryOptions): QueryBuilder<TRecordFor<T>> {
     const builder = new QueryBuilder<TRecordFor<T>>(this, queryOptions)
     if (this.defaultScope) {
@@ -1110,6 +1098,17 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
    */
   static newQueryWithoutScopes<T extends typeof Model>(this: T, queryOptions?: ModelQueryOptions): QueryBuilder<TRecordFor<T>> {
     return new QueryBuilder<TRecordFor<T>>(this, queryOptions)
+  }
+
+  /**
+   * Whether this model carries a filter that every query must apply.
+   *
+   * The entry points that talk to the adapter directly check this to decide
+   * whether they can take the fast path; anything that returns a QueryBuilder
+   * goes through `newQuery()` unconditionally.
+   */
+  protected static hasScopes(): boolean {
+    return Boolean(this.defaultScope) || Boolean(this.globalScopeRegistry && this.globalScopeRegistry.size > 0)
   }
 
   /**

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -545,12 +545,33 @@ export class QueryBuilder<
 
     // Fallback: convert to simple where clause if possible
     const simpleWhere = this.toSimpleWhereClause()
+    this.assertConditionsExpressible(simpleWhere)
     return this.adapter.findMany<TResult>(this.table, {
       where: (simpleWhere ?? undefined) as FindManyOptions<TResult>['where'],
       orderBy: this.options.orderBy.length > 0 ? (this.options.orderBy as OrderByClause) : undefined,
       limit: this.options.limitValue,
       offset: this.options.offsetValue,
     }, { trx: this.options.trx })
+  }
+
+  /**
+   * Refuse to run a query whose conditions the adapter cannot express.
+   *
+   * `toSimpleWhereClause()` returns null for anything it cannot represent, and
+   * passing that on as `where: undefined` drops every condition — including a
+   * global scope carrying the tenant or soft-delete filter — and returns the
+   * whole table. Failing is the only safe answer.
+   */
+  private assertConditionsExpressible(simpleWhere: Record<string, unknown> | null): void {
+    if (this.conditions.length === 0 || simpleWhere !== null) {
+      return
+    }
+
+    throw new Error(
+      `${this.modelClass.name}: this query uses conditions the configured adapter cannot express `
+      + `(it implements neither findManyAdvanced nor countAdvanced). Running it would drop every `
+      + `condition, including any global scope, and return unfiltered rows.`,
+    )
   }
 
   /**

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -543,35 +543,23 @@ export class QueryBuilder<
       }, { trx: this.options.trx })
     }
 
-    // Fallback: convert to simple where clause if possible
+    // Fallback: convert to simple where clause if possible. Passing a null
+    // conversion on as `where: undefined` would drop every condition — global
+    // scopes included — and return the whole table, so refuse instead.
     const simpleWhere = this.toSimpleWhereClause()
-    this.assertConditionsExpressible(simpleWhere)
+    if (simpleWhere === null && this.conditions.length > 0) {
+      throw new Error(
+        `${this.modelClass.name}: this query uses conditions the configured adapter cannot express `
+        + `(it implements neither findManyAdvanced nor countAdvanced). Running it would drop every `
+        + `condition, including any global scope, and return unfiltered rows.`,
+      )
+    }
     return this.adapter.findMany<TResult>(this.table, {
       where: (simpleWhere ?? undefined) as FindManyOptions<TResult>['where'],
       orderBy: this.options.orderBy.length > 0 ? (this.options.orderBy as OrderByClause) : undefined,
       limit: this.options.limitValue,
       offset: this.options.offsetValue,
     }, { trx: this.options.trx })
-  }
-
-  /**
-   * Refuse to run a query whose conditions the adapter cannot express.
-   *
-   * `toSimpleWhereClause()` returns null for anything it cannot represent, and
-   * passing that on as `where: undefined` drops every condition — including a
-   * global scope carrying the tenant or soft-delete filter — and returns the
-   * whole table. Failing is the only safe answer.
-   */
-  private assertConditionsExpressible(simpleWhere: Record<string, unknown> | null): void {
-    if (this.conditions.length === 0 || simpleWhere !== null) {
-      return
-    }
-
-    throw new Error(
-      `${this.modelClass.name}: this query uses conditions the configured adapter cannot express `
-      + `(it implements neither findManyAdvanced nor countAdvanced). Running it would drop every `
-      + `condition, including any global scope, and return unfiltered rows.`,
-    )
   }
 
   /**
@@ -591,15 +579,26 @@ export class QueryBuilder<
         return null // Cannot convert OR groups to simple where
       }
 
-      if (condition.operator === '=') {
-        result[condition.field] = condition.value
-      } else if (condition.operator === 'in') {
-        result[condition.field] = condition.value
+      let value: unknown
+      if (condition.operator === '=' || condition.operator === 'in') {
+        value = condition.value
       } else if (condition.operator === 'is null') {
-        result[condition.field] = null
+        value = null
       } else {
         return null // Cannot convert comparison operators to simple where
       }
+
+      // A flat object holds one value per field, so a second condition on the
+      // same field would overwrite the first. AND-ing two constraints is not
+      // the same as keeping only the later one: a global scope pinning
+      // `tenantId` would be replaced by a caller's own `where('tenantId', …)`,
+      // handing them another tenant's rows. Only a repeat of the same value is
+      // safe to collapse.
+      if (condition.field in result && !Object.is(result[condition.field], value)) {
+        return null
+      }
+
+      result[condition.field] = value
     }
 
     return result

--- a/packages/orm/tests/model-enhancements.test.ts
+++ b/packages/orm/tests/model-enhancements.test.ts
@@ -509,3 +509,145 @@ describe('Phase 5: Global Scopes', () => {
     User.defaultScope = undefined
   })
 })
+
+// =============================================================================
+// Global scopes on every query entry point
+// =============================================================================
+
+describe('global scopes apply on every query entry point', () => {
+  // The docs recommend global scopes for multi-tenancy ("any filter that should
+  // always be active"), so an entry point that drops the scope is a tenant
+  // isolation hole, not just a missing filter.
+  function tenantScopedUser() {
+    class User extends Model<UserRecord> {
+      static table = 'users'
+      static scopes = {
+        named: (q: any) => q.where('active', true),
+      }
+    }
+
+    User.useAdapter(createAdapter([
+      { id: 1, name: 'Ours', tenantId: 1, active: true, deletedAt: null },
+      { id: 2, name: 'Theirs', tenantId: 2, active: true, deletedAt: null },
+      { id: 3, name: 'Theirs too', tenantId: 2, active: false, deletedAt: null },
+    ]))
+    User.addGlobalScope('tenant', (q) => q.where('tenantId', 1))
+
+    return User
+  }
+
+  function names(records: PlainObject[]): string[] {
+    return records.map((record) => String(record.name))
+  }
+
+  it('applies the scope to where()', async () => {
+    const User = tenantScopedUser()
+    expect(names(await User.where('active', true).get())).toEqual(['Ours'])
+    expect(names(await User.where({ active: true }).get())).toEqual(['Ours'])
+  })
+
+  it('applies the scope to whereIn()', async () => {
+    const User = tenantScopedUser()
+    expect(names(await User.whereIn('id', [1, 2, 3]).get())).toEqual(['Ours'])
+  })
+
+  it('applies the scope to whereNull()', async () => {
+    const User = tenantScopedUser()
+    expect(names(await User.whereNull('deletedAt').get())).toEqual(['Ours'])
+  })
+
+  // `not in` / `is not null` have no simple-where representation. On a basic
+  // adapter the builder used to fall back to `where: undefined`, dropping the
+  // tenant scope along with the condition and returning every row. Refusing is
+  // the only safe answer; the shipped Drizzle adapter implements
+  // findManyAdvanced and never reaches this path.
+  it('refuses rather than dropping conditions a basic adapter cannot express', async () => {
+    const User = tenantScopedUser()
+
+    expect(User.whereNotIn('id', [99]).get()).rejects.toThrow('return unfiltered rows')
+    expect(User.whereNotNull('name').get()).rejects.toThrow('return unfiltered rows')
+  })
+
+  it('applies the scope to select()', async () => {
+    const User = tenantScopedUser()
+    expect(await User.select('id', 'name').get()).toHaveLength(1)
+  })
+
+  it('applies the scope to a named scope()', async () => {
+    const User = tenantScopedUser()
+    expect(names(await User.scope('named').get())).toEqual(['Ours'])
+  })
+
+  it('applies the scope to orderBy()', async () => {
+    const User = tenantScopedUser()
+    expect(names(await User.orderBy('id'))).toEqual(['Ours'])
+  })
+
+  it('applies the scope to paginate(), including the count', async () => {
+    const User = tenantScopedUser()
+    const result = await User.paginate({ page: 1, perPage: 10 })
+
+    expect(names(result.data)).toEqual(['Ours'])
+    // An unscoped count leaks how many rows the other tenants hold.
+    expect(result.meta.total).toBe(1)
+  })
+
+  it('still lets withoutGlobalScopes() opt out', async () => {
+    const User = tenantScopedUser()
+    expect(await User.withoutGlobalScopes().get()).toHaveLength(3)
+    expect(await User.withoutGlobalScope('tenant').get()).toHaveLength(3)
+  })
+
+  it("applies the related model's scope when eager loading", async () => {
+    type PostRecord = { id: number; title: string; authorId: number; deletedAt?: string | null }
+
+    class User extends Model<UserRecord> {
+      static table = 'users'
+    }
+
+    class Post extends Model<PostRecord> {
+      static table = 'posts'
+    }
+
+    const stores = {
+      users: [{ id: 1, name: 'Alice' }] as UserRecord[],
+      posts: [
+        { id: 10, title: 'Live', authorId: 1, deletedAt: null },
+        { id: 11, title: 'Retracted', authorId: 1, deletedAt: '2026-01-01' },
+      ] as PostRecord[],
+    }
+
+    const adapter: ORMAdapter = {
+      async findMany<T extends PlainObject>(table: unknown, options?: FindManyOptions<T>): Promise<T[]> {
+        const store = (table === 'users' ? stores.users : stores.posts) as PlainObject[]
+        const { where } = options ?? {}
+        const results = where
+          ? store.filter((r) =>
+              Object.entries(where as PlainObject).every(([k, v]) => {
+                if (Array.isArray(v)) return v.includes(r[k])
+                if (v === null) return r[k] == null
+                return r[k] === v
+              }),
+            )
+          : [...store]
+        return results.map((r) => ({ ...r })) as unknown as T[]
+      },
+      async findUnique(): Promise<null> { return null },
+      async create<T extends PlainObject>(): Promise<T> { throw new Error('unused') },
+      async update<T extends PlainObject>(): Promise<T> { throw new Error('unused') },
+      async delete(): Promise<number> { return 0 },
+    }
+
+    User.useAdapter(adapter)
+    Post.useAdapter(adapter)
+    User.hasMany('posts', Post, 'authorId', 'id')
+    Post.addGlobalScope('notRetracted', (q) => q.whereNull('deletedAt'))
+
+    const [user] = await User.with('posts')
+    const posts = (user as unknown as { posts: PostRecord[] }).posts
+
+    expect(posts.map((post) => post.title)).toEqual(['Live'])
+
+    Post.removeGlobalScope('notRetracted')
+  })
+})

--- a/packages/orm/tests/model-enhancements.test.ts
+++ b/packages/orm/tests/model-enhancements.test.ts
@@ -546,6 +546,21 @@ describe('global scopes apply on every query entry point', () => {
     expect(names(await User.where({ active: true }).get())).toEqual(['Ours'])
   })
 
+  // A flat where-object holds one value per field, so a caller's condition on
+  // the scoped column used to overwrite the scope's — handing them another
+  // tenant's rows through the very filter meant to stop that.
+  it('refuses when a condition would overwrite the scope on the same field', async () => {
+    const User = tenantScopedUser()
+
+    expect(User.where('tenantId', 2).get()).rejects.toThrow('return unfiltered rows')
+  })
+
+  it('still collapses a condition that repeats the scope value', async () => {
+    const User = tenantScopedUser()
+
+    expect(names(await User.where('tenantId', 1).get())).toEqual(['Ours'])
+  })
+
   it('applies the scope to whereIn()', async () => {
     const User = tenantScopedUser()
     expect(names(await User.whereIn('id', [1, 2, 3]).get())).toEqual(['Ours'])

--- a/packages/server/src/auth/oauth/index.ts
+++ b/packages/server/src/auth/oauth/index.ts
@@ -121,18 +121,45 @@ export interface OAuthStateConfig {
   allowedRedirectHosts?: string[]
 }
 
+/**
+ * The slice of a session the manager needs to bind an OAuth flow to a
+ * browser. The framework `Session` satisfies it structurally, so controllers
+ * pass `this.auth.session()` straight through; anything else with these three
+ * methods (a cookie jar wrapper, a test double) works too.
+ */
+export interface OAuthBindingSession {
+  get<T = unknown>(key: string): T | undefined
+  set<T = unknown>(key: string, value: T): void
+  forget(key: string): void
+}
+
+/** Session key holding the per-browser binding between authorize and callback. */
+export const OAUTH_SESSION_BINDING_KEY = 'guren:oauth.binding'
+
 export interface OAuthAuthorizeOptions {
   scope?: string[]
   redirectTo?: string
   state?: string
   extraParams?: Record<string, string>
   /**
-   * Bind the flow to the browser that started it.
+   * Session of the browser starting the flow — pass `this.auth.session()`.
    *
-   * Pass a value only this browser can present back — a session id, or the
-   * `binding` this call returns once you store it in the session. Whatever it
-   * is, only its hash reaches the state store, and `handleCallback()` then
-   * requires the same value.
+   * The manager mints a per-browser binding, keeps it in the session, and
+   * hashes it into the state; `handleCallback({ session })` presents it back.
+   * Writing to the session is also what makes a visitor's brand-new session
+   * persist across the provider round trip. `undefined` (no session
+   * middleware, or none established yet) leaves the state unbound — the flow
+   * still works, and `authorize()` warns once about the exposure.
+   */
+  session?: OAuthBindingSession
+  /**
+   * Bind the flow to the browser that started it, keeping the value yourself.
+   *
+   * Prefer `session` — it does the storing and consuming for you. Use this
+   * when the binding lives somewhere else (an encrypted cookie, a test): pass
+   * a value only this browser can present back. Only its hash reaches the
+   * state store, and `handleCallback()` then requires the same value. Takes
+   * precedence over `session` when both are given.
    */
   bindTo?: string
 }
@@ -141,8 +168,14 @@ export interface OAuthCallbackPayload {
   code: string
   state: string
   /**
+   * The same session handed to `authorize({ session })`. The binding is read
+   * from it and removed in one step, so a replayed callback finds nothing.
+   */
+  session?: OAuthBindingSession
+  /**
    * The value handed to `authorize({ bindTo })`, read back from wherever the
-   * app kept it. Required when the state was created with a binding.
+   * app kept it. Required when the state was created with a binding. Takes
+   * precedence over `session` when both are given.
    */
   bindTo?: string
 }
@@ -164,11 +197,11 @@ function warnOnceAboutUnboundState(): void {
   if (warnedAboutUnboundState) return
   warnedAboutUnboundState = true
   console.warn(
-    '[guren] OAuth authorize() was called without `bindTo`, so `state` is not tied to the '
-    + 'browser that started the flow. An attacker can then complete their own authorization in '
-    + "a victim's browser and log the victim into the attacker's account. Pass a per-browser "
-    + 'value (a session id, or a random value you store in the session) as `bindTo`, and hand '
-    + 'the same value back to handleCallback(). See: https://guren.dev/docs/guides/oauth',
+    '[guren] OAuth authorize() was called without `session` or `bindTo`, so `state` is not tied '
+    + 'to the browser that started the flow. An attacker can then complete their own authorization '
+    + "in a victim's browser and log the victim into the attacker's account. Pass the current "
+    + 'session (`this.auth.session()`) as `session` to both authorize() and handleCallback(), or '
+    + 'manage a per-browser value yourself via `bindTo`. See: https://guren.dev/docs/guides/oauth',
   )
 }
 
@@ -189,6 +222,26 @@ function warnOnceAboutDroppedBinding(): void {
     + 'DatabaseOAuthStateStore this usually means the `oauth_states` table has no `binding` '
     + 'column. See: https://guren.dev/docs/guides/oauth',
   )
+}
+
+/**
+ * Mint a fresh binding and park it in the session for the callback. A new
+ * value per flow (rather than the session id) keeps session identifiers out
+ * of the state store's inputs entirely and survives a login-triggered
+ * session-id rotation happening mid-flow.
+ */
+function issueSessionBinding(session: OAuthBindingSession | undefined): string | undefined {
+  if (!session) return undefined
+  const binding = generateToken(DEFAULT_STATE_LENGTH)
+  session.set(OAUTH_SESSION_BINDING_KEY, binding)
+  return binding
+}
+
+function consumeSessionBinding(session: OAuthBindingSession | undefined): string | undefined {
+  if (!session) return undefined
+  const binding = session.get<unknown>(OAUTH_SESSION_BINDING_KEY)
+  session.forget(OAUTH_SESSION_BINDING_KEY)
+  return typeof binding === 'string' ? binding : undefined
 }
 
 const DEFAULT_STATE_EXPIRES_IN = 10 * 60 * 1000
@@ -290,7 +343,8 @@ export class OAuthManager {
 
   async authorize(providerName: string, options: OAuthAuthorizeOptions = {}): Promise<{ url: string; state: string; expiresAt: Date }> {
     const provider = this.getProvider(providerName)
-    if (!options.bindTo) {
+    const bindTo = options.bindTo ?? issueSessionBinding(options.session)
+    if (!bindTo) {
       warnOnceAboutUnboundState()
     }
 
@@ -300,7 +354,7 @@ export class OAuthManager {
       this.stateConfig,
       options.redirectTo,
       options.state,
-      options.bindTo,
+      bindTo,
     )
     const scope = options.scope ?? provider.scopes
     const url = buildOAuthAuthorizeUrl(provider, state, { scope, extraParams: options.extraParams })
@@ -328,7 +382,7 @@ export class OAuthManager {
       providerName,
       this.stateStore,
       this.stateConfig,
-      payload.bindTo,
+      payload.bindTo ?? consumeSessionBinding(payload.session),
     )
     if (!verified) {
       throw new AuthenticationException('Invalid or expired OAuth state.')

--- a/packages/server/src/auth/oauth/index.ts
+++ b/packages/server/src/auth/oauth/index.ts
@@ -172,6 +172,25 @@ function warnOnceAboutUnboundState(): void {
   )
 }
 
+let warnedAboutDroppedBinding = false
+
+/**
+ * The flow was bound at authorize time but the state came back without one,
+ * so the configured `OAuthStateStore` is not persisting `binding` — which
+ * silently reverts the protection to the transferable state it replaced.
+ */
+function warnOnceAboutDroppedBinding(): void {
+  if (warnedAboutDroppedBinding) return
+  warnedAboutDroppedBinding = true
+  console.warn(
+    '[guren] An OAuth state was created with `bindTo` but came back from the state store '
+    + 'without its binding, so the callback could not be tied to the browser that started the '
+    + 'flow. The configured OAuthStateStore is dropping `OAuthStatePayload.binding` — for '
+    + 'DatabaseOAuthStateStore this usually means the `oauth_states` table has no `binding` '
+    + 'column. See: https://guren.dev/docs/guides/oauth',
+  )
+}
+
 const DEFAULT_STATE_EXPIRES_IN = 10 * 60 * 1000
 const DEFAULT_STATE_LENGTH = 24
 const DEFAULT_STATE_HASH_ALGORITHM: NonNullable<OAuthStateConfig['hashAlgorithm']> = 'sha256'
@@ -381,7 +400,15 @@ function bindingMatches(
   presented: string | undefined,
   hashAlgorithm: 'sha256' | 'sha512',
 ): boolean {
-  if (!stored) return true
+  if (!stored) {
+    // The caller bound this flow, so a payload coming back without one means
+    // the store dropped the field rather than that the state was never bound.
+    // Verification cannot tell the two apart, so it stays permissive — but a
+    // store that silently discards the binding turns the protection off, and
+    // nothing else would say so.
+    if (presented) warnOnceAboutDroppedBinding()
+    return true
+  }
   if (!presented) return false
   // Both sides are hex digests, so this takes the hex-decoding comparator —
   // the same one the API-token store uses for stored-hash checks.

--- a/packages/server/src/auth/oauth/index.ts
+++ b/packages/server/src/auth/oauth/index.ts
@@ -4,7 +4,7 @@ import {
   isAppRelativePath,
   normalizeRedirectTarget,
 } from '../../support/redirect-target'
-import { buildTokenUrl, generateToken, hashToken, parseTokenUrl, secureStringCompare } from '../utils'
+import { buildTokenUrl, generateToken, hashToken, parseTokenUrl, secureCompare } from '../utils'
 
 export interface OAuthProviderConfig {
   clientId: string
@@ -383,7 +383,9 @@ function bindingMatches(
 ): boolean {
   if (!stored) return true
   if (!presented) return false
-  return secureStringCompare(stored, hashToken(presented, hashAlgorithm))
+  // Both sides are hex digests, so this takes the hex-decoding comparator —
+  // the same one the API-token store uses for stored-hash checks.
+  return secureCompare(stored, hashToken(presented, hashAlgorithm))
 }
 
 // Fallback for stores without consume(): two concurrent callbacks can both

--- a/packages/server/src/auth/oauth/index.ts
+++ b/packages/server/src/auth/oauth/index.ts
@@ -4,7 +4,7 @@ import {
   isAppRelativePath,
   normalizeRedirectTarget,
 } from '../../support/redirect-target'
-import { buildTokenUrl, generateToken, hashToken, parseTokenUrl } from '../utils'
+import { buildTokenUrl, generateToken, hashToken, parseTokenUrl, secureStringCompare } from '../utils'
 
 export interface OAuthProviderConfig {
   clientId: string
@@ -80,6 +80,16 @@ export interface OAuthStatePayload {
   provider: string
   redirectTo?: string
   expiresAt: Date
+  /**
+   * Hash of the value tying this state to the browser that started the flow.
+   *
+   * Without it `state` is unguessable and single-use but *transferable*: an
+   * attacker can start a flow, capture their own `code`, and walk a victim's
+   * browser through the callback, logging the victim into the attacker's
+   * account. RFC 6749 §10.12 requires the binding; storing only the provider
+   * name does not provide it.
+   */
+  binding?: string
 }
 
 export interface OAuthStateStore {
@@ -116,16 +126,50 @@ export interface OAuthAuthorizeOptions {
   redirectTo?: string
   state?: string
   extraParams?: Record<string, string>
+  /**
+   * Bind the flow to the browser that started it.
+   *
+   * Pass a value only this browser can present back — a session id, or the
+   * `binding` this call returns once you store it in the session. Whatever it
+   * is, only its hash reaches the state store, and `handleCallback()` then
+   * requires the same value.
+   */
+  bindTo?: string
 }
 
 export interface OAuthCallbackPayload {
   code: string
   state: string
+  /**
+   * The value handed to `authorize({ bindTo })`, read back from wherever the
+   * app kept it. Required when the state was created with a binding.
+   */
+  bindTo?: string
 }
 
 export interface OAuthManagerOptions {
   stateStore?: OAuthStateStore
   stateConfig?: OAuthStateConfig
+}
+
+let warnedAboutUnboundState = false
+
+/**
+ * An unbound `state` is transferable between browsers, which is exactly the
+ * attack `state` exists to stop. Verification stays permissive so apps written
+ * against the previous API keep working, so this is the only thing that tells
+ * them they are exposed.
+ */
+function warnOnceAboutUnboundState(): void {
+  if (warnedAboutUnboundState) return
+  warnedAboutUnboundState = true
+  console.warn(
+    '[guren] OAuth authorize() was called without `bindTo`, so `state` is not tied to the '
+    + 'browser that started the flow. An attacker can then complete their own authorization in '
+    + "a victim's browser and log the victim into the attacker's account. Pass a per-browser "
+    + 'value (a session id, or a random value you store in the session) as `bindTo`, and hand '
+    + 'the same value back to handleCallback(). See: https://guren.dev/docs/guides/oauth',
+  )
 }
 
 const DEFAULT_STATE_EXPIRES_IN = 10 * 60 * 1000
@@ -227,12 +271,17 @@ export class OAuthManager {
 
   async authorize(providerName: string, options: OAuthAuthorizeOptions = {}): Promise<{ url: string; state: string; expiresAt: Date }> {
     const provider = this.getProvider(providerName)
+    if (!options.bindTo) {
+      warnOnceAboutUnboundState()
+    }
+
     const { state, expiresAt } = await createOAuthState(
       providerName,
       this.stateStore,
       this.stateConfig,
       options.redirectTo,
       options.state,
+      options.bindTo,
     )
     const scope = options.scope ?? provider.scopes
     const url = buildOAuthAuthorizeUrl(provider, state, { scope, extraParams: options.extraParams })
@@ -255,7 +304,13 @@ export class OAuthManager {
     payload: OAuthCallbackPayload,
   ): Promise<{ profile: OAuthUserProfile; redirectTo?: string }> {
     const provider = this.getProvider(providerName)
-    const verified = await verifyOAuthState(payload.state, providerName, this.stateStore, this.stateConfig)
+    const verified = await verifyOAuthState(
+      payload.state,
+      providerName,
+      this.stateStore,
+      this.stateConfig,
+      payload.bindTo,
+    )
     if (!verified) {
       throw new AuthenticationException('Invalid or expired OAuth state.')
     }
@@ -276,6 +331,7 @@ export async function createOAuthState(
   config: OAuthStateConfig = {},
   redirectTo?: string,
   fixedState?: string,
+  bindTo?: string,
 ): Promise<{ state: string; expiresAt: Date }> {
   const state = fixedState ?? generateToken(config.stateLength ?? DEFAULT_STATE_LENGTH)
   const hashAlgorithm = config.hashAlgorithm ?? DEFAULT_STATE_HASH_ALGORITHM
@@ -285,6 +341,9 @@ export async function createOAuthState(
     provider,
     redirectTo: sanitizeOAuthRedirect(redirectTo, config.allowedRedirectHosts),
     expiresAt,
+    // Only the hash is stored, so a leaked state store does not hand out
+    // session ids.
+    binding: bindTo ? hashToken(bindTo, hashAlgorithm) : undefined,
   })
   return { state, expiresAt }
 }
@@ -294,6 +353,7 @@ export async function verifyOAuthState(
   provider: string,
   store: OAuthStateStore,
   config: OAuthStateConfig = {},
+  bindTo?: string,
 ): Promise<OAuthStatePayload | null> {
   const hashAlgorithm = config.hashAlgorithm ?? DEFAULT_STATE_HASH_ALGORITHM
   const stateHash = hashToken(state, hashAlgorithm)
@@ -302,9 +362,28 @@ export async function verifyOAuthState(
     : await findAndDeleteState(store, stateHash)
   if (!payload) return null
   if (payload.provider !== provider) return null
+  if (!bindingMatches(payload.binding, bindTo, hashAlgorithm)) return null
   // Re-sanitize on the way out so custom stores and states persisted before
   // an allowlist change cannot smuggle an unsafe target through.
   return { ...payload, redirectTo: sanitizeOAuthRedirect(payload.redirectTo, config.allowedRedirectHosts) }
+}
+
+/**
+ * Whether the presented value matches the binding recorded at authorize time.
+ *
+ * A state created without a binding still verifies, so an app that has not
+ * adopted `bindTo` keeps working. A state created *with* one is useless to a
+ * browser that cannot present it, which is the whole point — so a missing or
+ * wrong value fails.
+ */
+function bindingMatches(
+  stored: string | undefined,
+  presented: string | undefined,
+  hashAlgorithm: 'sha256' | 'sha512',
+): boolean {
+  if (!stored) return true
+  if (!presented) return false
+  return secureStringCompare(stored, hashToken(presented, hashAlgorithm))
 }
 
 // Fallback for stores without consume(): two concurrent callbacks can both

--- a/packages/server/src/authorization/Gate.ts
+++ b/packages/server/src/authorization/Gate.ts
@@ -10,7 +10,7 @@ import type {
   AuthorizationResponse,
   ResponseBuilder,
 } from './types'
-import { AuthorizationException } from '../errors'
+import { AuthorizationException, HttpException } from '../errors'
 
 /**
  * Response builder for authorization checks.
@@ -31,6 +31,49 @@ export const Response: ResponseBuilder = {
   denyAsNotFound(message?: string): AuthorizationResponse & { status: 404 } {
     return { allowed: false, message: message ?? 'Not found.', status: 404 }
   },
+}
+
+/**
+ * Narrow a policy/gate return value to an `AuthorizationResponse`.
+ *
+ * Policies may return either a boolean or one of the `Response` objects
+ * produced by `allow()`/`deny()`/`denyWithStatus()`/`denyAsNotFound()`.
+ */
+export function isAuthorizationResponse(value: unknown): value is AuthorizationResponse {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && typeof (value as AuthorizationResponse).allowed === 'boolean'
+  )
+}
+
+/**
+ * Normalize whatever a policy or gate callback returned into a response.
+ *
+ * A `{ allowed: false }` object is truthy, so anything that decides access
+ * from the raw return value fails open. Every path in this class routes
+ * through here, and unknown shapes deny.
+ */
+function toAuthorizationResponse(value: unknown): AuthorizationResponse {
+  if (isAuthorizationResponse(value)) {
+    return value
+  }
+  return value === true ? Response.allow() : Response.deny()
+}
+
+/**
+ * Build the exception for a denial, honouring `denyWithStatus()` /
+ * `denyAsNotFound()` so a policy can hide a record as a 404.
+ */
+function denialToException(response: AuthorizationResponse): Error {
+  const message = response.message ?? 'This action is unauthorized.'
+  const status = (response as AuthorizationResponse & { status?: number }).status
+
+  if (typeof status === 'number' && status !== 403) {
+    return new HttpException(status, message)
+  }
+
+  return new AuthorizationException(message)
 }
 
 /**
@@ -208,10 +251,10 @@ export class Gate {
    * Authorize the ability or throw an exception.
    */
   async authorize(ability: string, ...args: unknown[]): Promise<void> {
-    const allowed = await this.allows(ability, ...args)
+    const response = await this.checkResponse(ability, this.currentUser, ...args)
 
-    if (!allowed) {
-      throw new AuthorizationException(`This action is unauthorized.`)
+    if (!response.allowed) {
+      throw denialToException(response)
     }
   }
 
@@ -219,20 +262,34 @@ export class Gate {
    * Get the authorization response.
    */
   async inspect(ability: string, ...args: unknown[]): Promise<AuthorizationResponse> {
-    const allowed = await this.check(ability, this.currentUser, ...args)
-    return allowed ? Response.allow() : Response.deny()
+    return this.checkResponse(ability, this.currentUser, ...args)
   }
 
   /**
    * Check the ability with a specific user.
    */
   async check(ability: string, user: AuthUser | null, ...args: unknown[]): Promise<boolean> {
+    const response = await this.checkResponse(ability, user, ...args)
+    return response.allowed
+  }
+
+  /**
+   * Check the ability with a specific user and keep the full response.
+   *
+   * Policies may answer with a boolean or with a `Response` object. Both
+   * shapes are normalized here so no caller has to truthy-test a
+   * `{ allowed: false }` object.
+   */
+  async checkResponse(
+    ability: string,
+    user: AuthUser | null,
+    ...args: unknown[]
+  ): Promise<AuthorizationResponse> {
     // Run before callbacks
     for (const beforeCallback of this.beforeCallbacks) {
       const result = await beforeCallback(user, ability, ...args)
       if (typeof result === 'boolean') {
-        await this.runAfterCallbacks(user, ability, result, args)
-        return result
+        return this.settle(user, ability, Response[result ? 'allow' : 'deny'](), args)
       }
     }
 
@@ -241,8 +298,7 @@ export class Gate {
     if (model !== undefined && model !== null) {
       const policyResult = await this.checkPolicy(ability, user, model, args.slice(1))
       if (policyResult !== undefined) {
-        await this.runAfterCallbacks(user, ability, policyResult, args)
-        return policyResult
+        return this.settle(user, ability, toAuthorizationResponse(policyResult), args)
       }
     }
 
@@ -250,13 +306,24 @@ export class Gate {
     const gate = this.gates.get(ability)
     if (gate) {
       const result = await gate.callback(user, ...args)
-      await this.runAfterCallbacks(user, ability, result, args)
-      return result
+      return this.settle(user, ability, toAuthorizationResponse(result), args)
     }
 
     // No gate or policy found
-    await this.runAfterCallbacks(user, ability, false, args)
-    return false
+    return this.settle(user, ability, Response.deny(), args)
+  }
+
+  /**
+   * Run after callbacks with the normalized result and return the response.
+   */
+  protected async settle(
+    user: AuthUser | null,
+    ability: string,
+    response: AuthorizationResponse,
+    args: unknown[]
+  ): Promise<AuthorizationResponse> {
+    await this.runAfterCallbacks(user, ability, response.allowed, args)
+    return response
   }
 
   /**
@@ -272,7 +339,7 @@ export class Gate {
     user: AuthUser | null,
     model: unknown,
     additionalArgs: unknown[]
-  ): Promise<boolean | undefined> {
+  ): Promise<boolean | AuthorizationResponse | undefined> {
     let policyKey: unknown
     let subject: unknown = model
     let hasSubject = true

--- a/packages/server/src/authorization/Gate.ts
+++ b/packages/server/src/authorization/Gate.ts
@@ -65,7 +65,7 @@ function toAuthorizationResponse(value: unknown): AuthorizationResponse {
  * Build the exception for a denial, honouring `denyWithStatus()` /
  * `denyAsNotFound()` so a policy can hide a record as a 404.
  */
-function denialToException(response: AuthorizationResponse): Error {
+export function denialToException(response: AuthorizationResponse): Error {
   const message = response.message ?? 'This action is unauthorized.'
   const status = (response as AuthorizationResponse & { status?: number }).status
 
@@ -285,11 +285,13 @@ export class Gate {
     user: AuthUser | null,
     ...args: unknown[]
   ): Promise<AuthorizationResponse> {
-    // Run before callbacks
+    // Run before callbacks. Only `undefined` means "keep checking" — anything
+    // else is an answer, and a `Response.deny()` object read as "not a boolean,
+    // so continue" would drop the denial on the floor.
     for (const beforeCallback of this.beforeCallbacks) {
       const result = await beforeCallback(user, ability, ...args)
-      if (typeof result === 'boolean') {
-        return this.settle(user, ability, Response[result ? 'allow' : 'deny'](), args)
+      if (result !== undefined) {
+        return this.settle(user, ability, toAuthorizationResponse(result), args)
       }
     }
 
@@ -313,9 +315,6 @@ export class Gate {
     return this.settle(user, ability, Response.deny(), args)
   }
 
-  /**
-   * Run after callbacks with the normalized result and return the response.
-   */
   protected async settle(
     user: AuthUser | null,
     ability: string,
@@ -370,10 +369,11 @@ export class Gate {
 
     const policy = this.getPolicyInstance(policyClass)
 
-    // Check before method
+    // Check before method — same rule as the gate-level before callbacks:
+    // only `undefined` continues to the ability method.
     if (policy.before) {
       const beforeResult = await policy.before(user, ability)
-      if (typeof beforeResult === 'boolean') {
+      if (beforeResult !== undefined) {
         return beforeResult
       }
     }

--- a/packages/server/src/authorization/Policy.ts
+++ b/packages/server/src/authorization/Policy.ts
@@ -42,7 +42,7 @@ export abstract class Policy implements PolicyInterface {
    * Perform pre-authorization checks.
    * Return true to allow, false to deny, undefined to continue to specific check.
    */
-  before?(user: AuthUser | null, ability: string): boolean | undefined | Promise<boolean | undefined>
+  before?(user: AuthUser | null, ability: string): PolicyResult | undefined | Promise<PolicyResult | undefined>
 
   /**
    * Allow the action.
@@ -78,7 +78,7 @@ export abstract class Policy implements PolicyInterface {
  */
 export function definePolicy<T>(
   definition: {
-    before?: (user: AuthUser | null, ability: string) => boolean | undefined | Promise<boolean | undefined>
+    before?: (user: AuthUser | null, ability: string) => PolicyResult | undefined | Promise<PolicyResult | undefined>
     viewAny?: (user: AuthUser | null) => PolicyResult | Promise<PolicyResult>
     view?: (user: AuthUser | null, model: T) => PolicyResult | Promise<PolicyResult>
     create?: (user: AuthUser | null) => PolicyResult | Promise<PolicyResult>

--- a/packages/server/src/authorization/Policy.ts
+++ b/packages/server/src/authorization/Policy.ts
@@ -1,4 +1,4 @@
-import type { AuthUser, Policy as PolicyInterface, AuthorizationResponse } from './types'
+import type { AuthUser, Policy as PolicyInterface, AuthorizationResponse, PolicyResult } from './types'
 import { Response } from './Gate'
 
 /**
@@ -79,46 +79,46 @@ export abstract class Policy implements PolicyInterface {
 export function definePolicy<T>(
   definition: {
     before?: (user: AuthUser | null, ability: string) => boolean | undefined | Promise<boolean | undefined>
-    viewAny?: (user: AuthUser | null) => boolean | Promise<boolean>
-    view?: (user: AuthUser | null, model: T) => boolean | Promise<boolean>
-    create?: (user: AuthUser | null) => boolean | Promise<boolean>
-    update?: (user: AuthUser | null, model: T) => boolean | Promise<boolean>
-    delete?: (user: AuthUser | null, model: T) => boolean | Promise<boolean>
-    restore?: (user: AuthUser | null, model: T) => boolean | Promise<boolean>
-    forceDelete?: (user: AuthUser | null, model: T) => boolean | Promise<boolean>
+    viewAny?: (user: AuthUser | null) => PolicyResult | Promise<PolicyResult>
+    view?: (user: AuthUser | null, model: T) => PolicyResult | Promise<PolicyResult>
+    create?: (user: AuthUser | null) => PolicyResult | Promise<PolicyResult>
+    update?: (user: AuthUser | null, model: T) => PolicyResult | Promise<PolicyResult>
+    delete?: (user: AuthUser | null, model: T) => PolicyResult | Promise<PolicyResult>
+    restore?: (user: AuthUser | null, model: T) => PolicyResult | Promise<PolicyResult>
+    forceDelete?: (user: AuthUser | null, model: T) => PolicyResult | Promise<PolicyResult>
   } & Record<
     string,
-    ((user: AuthUser | null, ...args: any[]) => boolean | undefined | Promise<boolean | undefined>) | undefined
+    ((user: AuthUser | null, ...args: any[]) => PolicyResult | undefined | Promise<PolicyResult | undefined>) | undefined
   >
 ): new () => Policy {
   return class extends Policy {
     before = definition.before
 
-    viewAny(user: AuthUser | null): boolean | Promise<boolean> {
+    viewAny(user: AuthUser | null): PolicyResult | Promise<PolicyResult> {
       return definition.viewAny?.(user) ?? false
     }
 
-    view(user: AuthUser | null, model: T): boolean | Promise<boolean> {
+    view(user: AuthUser | null, model: T): PolicyResult | Promise<PolicyResult> {
       return definition.view?.(user, model) ?? false
     }
 
-    create(user: AuthUser | null): boolean | Promise<boolean> {
+    create(user: AuthUser | null): PolicyResult | Promise<PolicyResult> {
       return definition.create?.(user) ?? false
     }
 
-    update(user: AuthUser | null, model: T): boolean | Promise<boolean> {
+    update(user: AuthUser | null, model: T): PolicyResult | Promise<PolicyResult> {
       return definition.update?.(user, model) ?? false
     }
 
-    delete(user: AuthUser | null, model: T): boolean | Promise<boolean> {
+    delete(user: AuthUser | null, model: T): PolicyResult | Promise<PolicyResult> {
       return definition.delete?.(user, model) ?? false
     }
 
-    restore(user: AuthUser | null, model: T): boolean | Promise<boolean> {
+    restore(user: AuthUser | null, model: T): PolicyResult | Promise<PolicyResult> {
       return definition.restore?.(user, model) ?? false
     }
 
-    forceDelete(user: AuthUser | null, model: T): boolean | Promise<boolean> {
+    forceDelete(user: AuthUser | null, model: T): PolicyResult | Promise<PolicyResult> {
       return definition.forceDelete?.(user, model) ?? false
     }
   } as unknown as new () => Policy

--- a/packages/server/src/authorization/index.ts
+++ b/packages/server/src/authorization/index.ts
@@ -3,6 +3,7 @@ export type {
   GateCallback,
   GateDefinition,
   PolicyMethod,
+  PolicyResult,
   Policy as PolicyInterface,
   PolicyClass,
   AuthorizationResponse,
@@ -16,6 +17,7 @@ export type {
 export {
   Gate,
   Response,
+  isAuthorizationResponse,
   createGate,
   setGate,
   getGate,

--- a/packages/server/src/authorization/middleware.ts
+++ b/packages/server/src/authorization/middleware.ts
@@ -1,7 +1,7 @@
 import type { Context } from '../http/Application'
 import type { Middleware } from '../http/middleware'
 import type { AuthUser, AuthorizeOptions } from './types'
-import { Gate, getGate } from './Gate'
+import { Gate, getGate, denialToException } from './Gate'
 import { AuthorizationException } from '../errors'
 
 /**
@@ -32,20 +32,18 @@ export function authorizeMiddleware(
     const abilities = Array.isArray(ability) ? ability : [ability]
     const model = modelResolver ? await modelResolver(ctx) : undefined
 
-    let authorized = false
-
     if (Array.isArray(ability)) {
-      // Check if user has any of the abilities
-      authorized = await gateForUser.any(abilities, model)
+      // Any-of has no single response to carry, so a denial can only be generic.
+      if (!(await gateForUser.any(abilities, model))) {
+        throw new AuthorizationException(options.message ?? 'This action is unauthorized.')
+      }
     } else {
-      // Check single ability
-      authorized = await gateForUser.allows(ability, model)
-    }
-
-    if (!authorized) {
-      throw new AuthorizationException(
-        options.message ?? 'This action is unauthorized.'
-      )
+      // Single ability: keep the policy's own message and status, so the same
+      // denial reads the same here as through `Controller.authorize()`.
+      const response = await gateForUser.checkResponse(ability, user, model)
+      if (!response.allowed) {
+        throw denialToException(options.message ? { ...response, message: options.message } : response)
+      }
     }
 
     await next()
@@ -122,12 +120,10 @@ export function authorizeResourceMiddleware(
     const gateForUser = gate.forUser(user)
 
     const model = await modelResolver(ctx)
-    const authorized = await gateForUser.allows(ability, model)
+    const response = await gateForUser.checkResponse(ability, user, model)
 
-    if (!authorized) {
-      throw new AuthorizationException(
-        options.message ?? 'This action is unauthorized.'
-      )
+    if (!response.allowed) {
+      throw denialToException(options.message ? { ...response, message: options.message } : response)
     }
 
     await next()

--- a/packages/server/src/authorization/types.ts
+++ b/packages/server/src/authorization/types.ts
@@ -37,13 +37,22 @@ export interface GateDefinition {
 }
 
 /**
+ * What a policy ability or gate callback may answer.
+ *
+ * `Response.deny()` and friends return an object, so it must be part of the
+ * type — a signature of just `boolean` is what let a denial object be read
+ * as an approval.
+ */
+export type PolicyResult = boolean | AuthorizationResponse
+
+/**
  * Policy method type.
  */
 export type PolicyMethod<T = unknown> = (
   user: AuthUser | null,
   model?: T,
   ...args: unknown[]
-) => boolean | Promise<boolean>
+) => PolicyResult | Promise<PolicyResult>
 
 /**
  * Policy class interface.

--- a/packages/server/src/authorization/types.ts
+++ b/packages/server/src/authorization/types.ts
@@ -14,7 +14,7 @@ export type GateCallback<Args extends unknown[] = unknown[]> = {
   bivarianceHack(
     user: AuthUser | null,
     ...args: Args
-  ): boolean | Promise<boolean>
+  ): PolicyResult | Promise<PolicyResult>
 }['bivarianceHack']
 
 /**
@@ -26,7 +26,7 @@ export type GateBeforeCallback<Args extends unknown[] = unknown[]> = {
     user: AuthUser | null,
     ability: string,
     ...args: Args
-  ): boolean | undefined | Promise<boolean | undefined>
+  ): PolicyResult | undefined | Promise<PolicyResult | undefined>
 }['bivarianceHack']
 
 /**
@@ -62,7 +62,7 @@ export interface Policy {
    * Run before all other authorization checks.
    * Return true to allow, false to deny, undefined to continue to specific check.
    */
-  before?(user: AuthUser | null, ability: string): boolean | undefined | Promise<boolean | undefined>
+  before?(user: AuthUser | null, ability: string): PolicyResult | undefined | Promise<PolicyResult | undefined>
 }
 
 /**

--- a/packages/server/src/broadcasting/BroadcastManager.ts
+++ b/packages/server/src/broadcasting/BroadcastManager.ts
@@ -218,12 +218,16 @@ export class BroadcastManager {
       return !(channelName.startsWith('private-') || channelName.startsWith('presence-'))
     }
 
+    // Callers read anything that is not `false`/`null` as authorized, so
+    // normalize here: an authorizer with an implicit-`undefined` return path
+    // must deny rather than grant.
     if (registration.type === 'presence') {
       const presenceAuth = registration.authorizer as PresenceChannelAuthorizer
-      return await presenceAuth(channelName, user)
+      const member = await presenceAuth(channelName, user)
+      return typeof member === 'object' && member !== null ? member : false
     }
 
-    return await (registration.authorizer as ChannelAuthorizer)(channelName, user)
+    return await (registration.authorizer as ChannelAuthorizer)(channelName, user) === true
   }
 
   /**

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -448,7 +448,7 @@ export class Application {
         const { server, localUrl } = await startViteDevServer({
           root: viteOptions?.root ?? process.cwd(),
           config: viteOptions?.config,
-          host: viteOptions?.host ?? true,
+          host: viteOptions?.host,
           port: viteOptions?.port,
         })
         this.viteDevServer = server

--- a/packages/server/src/http/vite-dev-server.ts
+++ b/packages/server/src/http/vite-dev-server.ts
@@ -3,6 +3,12 @@ import type { InlineConfig, ViteDevServer } from 'vite'
 export interface StartViteDevServerOptions {
   root?: string
   config?: InlineConfig
+  /**
+   * What the dev server binds to. Left unset it follows Vite's own
+   * localhost-only default, which is the safe choice: the dev server serves
+   * every file under the project root, including the default SQLite database,
+   * with no authentication. Pass `true` to expose it on the network.
+   */
   host?: boolean | string
   port?: number
 }
@@ -13,13 +19,19 @@ export interface StartedViteDevServer {
   networkUrls: string[]
 }
 
-export async function startViteDevServer(
+/**
+ * Build the inline config the managed dev server starts with.
+ *
+ * `server.host` is only set when the caller asked for one. Left undefined it
+ * is dropped during Vite's config merge, so the project's own `vite.config.ts`
+ * decides, falling back to Vite's localhost-only default.
+ */
+export function resolveViteDevServerConfig(
   options: StartViteDevServerOptions = {},
-): Promise<StartedViteDevServer> {
-  const { root = process.cwd(), config = {}, host = true, port } = options
-  const { createServer } = await import('vite')
+): InlineConfig {
+  const { root = process.cwd(), config = {}, host, port } = options
 
-  const mergedConfig: InlineConfig = {
+  return {
     clearScreen: false,
     ...config,
     root: config.root ?? root,
@@ -29,8 +41,15 @@ export async function startViteDevServer(
       ...(config.server ?? {}),
     },
   }
+}
 
-  const server = await createServer(mergedConfig)
+export async function startViteDevServer(
+  options: StartViteDevServerOptions = {},
+): Promise<StartedViteDevServer> {
+  const { host, port } = options
+  const { createServer } = await import('vite')
+
+  const server = await createServer(resolveViteDevServerConfig(options))
   await server.listen()
 
   const resolved = server.resolvedUrls

--- a/packages/server/src/redis/RedisOAuthStateStore.ts
+++ b/packages/server/src/redis/RedisOAuthStateStore.ts
@@ -60,6 +60,8 @@ export class RedisOAuthStateStore implements OAuthStateStore {
       provider: payload.provider,
       redirectTo: payload.redirectTo,
       expiresAt: payload.expiresAt.toISOString(),
+      // Persisted, not derived: an unbound state verifies for any browser.
+      binding: payload.binding,
     })
 
     await this.redis.psetex(`${this.prefix}${stateHash}`, ttlMs, data)
@@ -101,11 +103,17 @@ export class RedisOAuthStateStore implements OAuthStateStore {
 
   private parsePayload(data: string): OAuthStatePayload | null {
     try {
-      const parsed = JSON.parse(data) as { provider: string; redirectTo?: string; expiresAt: string }
+      const parsed = JSON.parse(data) as {
+        provider: string
+        redirectTo?: string
+        expiresAt: string
+        binding?: string
+      }
       return {
         provider: parsed.provider,
         redirectTo: parsed.redirectTo,
         expiresAt: new Date(parsed.expiresAt),
+        binding: parsed.binding,
       }
     } catch {
       return null

--- a/packages/server/src/vite/plugin.ts
+++ b/packages/server/src/vite/plugin.ts
@@ -81,10 +81,12 @@ function ensureAliases(config: Record<string, any>, options: Required<GurenViteP
 function ensureServer(config: Record<string, any>, options: Required<GurenVitePluginOptions>) {
   config.server ??= {}
 
-  if (config.server.host === undefined) {
-    config.server.host = true
-  }
-
+  // `server.host` is deliberately left alone so Vite's localhost-only default
+  // applies. The dev server serves any file under the project root — source,
+  // and the default SQLite database at `data/guren.db`, which `server.fs.deny`
+  // does not cover — with no authentication or origin check. Binding it to
+  // every interface hands that to anyone on the same network, so LAN exposure
+  // stays an explicit opt-in (`--host`, or `server.host` in vite.config.ts).
   if (config.server.port === undefined) {
     config.server.port = options.devPort
   }
@@ -93,6 +95,10 @@ function ensureServer(config: Record<string, any>, options: Required<GurenVitePl
 function ensurePreview(config: Record<string, any>, options: Required<GurenVitePluginOptions>) {
   config.preview ??= {}
 
+  // Unlike the dev server above, preview serves only the build output
+  // (`build.outDir`), never the project root, so binding it to every interface
+  // exposes assets that are about to ship publicly anyway. Kept on for
+  // checking a production build from a phone on the same network.
   if (config.preview.host === undefined) {
     config.preview.host = true
   }

--- a/packages/server/tests/auth/oauth.test.ts
+++ b/packages/server/tests/auth/oauth.test.ts
@@ -46,6 +46,53 @@ describe('oauth helpers', () => {
     expect(secondUse).toBeNull()
   })
 
+  // Without a binding, `state` is unguessable and single-use but transferable:
+  // the attacker starts a flow, keeps their own `code` unconsumed, and walks
+  // the victim's browser through the callback — logging the victim into the
+  // attacker's account.
+  it('rejects a state bound to another browser', async () => {
+    const store = new MemoryOAuthStateStore()
+    const { state } = await createOAuthState('github', store, {}, '/dashboard', undefined, 'attacker-session')
+
+    expect(await verifyOAuthState(state, 'github', store, {}, 'victim-session')).toBeNull()
+  })
+
+  it('rejects a bound state presented with no binding at all', async () => {
+    const store = new MemoryOAuthStateStore()
+    const { state } = await createOAuthState('github', store, {}, undefined, undefined, 'starting-session')
+
+    expect(await verifyOAuthState(state, 'github', store, {})).toBeNull()
+  })
+
+  it('accepts the browser that started the flow', async () => {
+    const store = new MemoryOAuthStateStore()
+    const { state } = await createOAuthState('github', store, {}, '/dashboard', undefined, 'starting-session')
+
+    const payload = await verifyOAuthState(state, 'github', store, {}, 'starting-session')
+    expect(payload?.provider).toBe('github')
+    expect(payload?.redirectTo).toBe('/dashboard')
+  })
+
+  it('stores only the hash of the binding', async () => {
+    const store = new MemoryOAuthStateStore()
+    const { state } = await createOAuthState('github', store, {}, undefined, 'fixed-state', 'session-abc')
+
+    const stored = await store.find(hashToken('fixed-state'))
+    expect(stored?.binding).toBe(hashToken('session-abc'))
+    expect(stored?.binding).not.toBe('session-abc')
+    expect(state).toBe('fixed-state')
+  })
+
+  // Apps written against the previous API pass no binding at all. They stay
+  // exposed to the transfer above — authorize() warns about it — but must not
+  // break on upgrade.
+  it('still verifies a state created without a binding', async () => {
+    const store = new MemoryOAuthStateStore()
+    const { state } = await createOAuthState('github', store, {})
+
+    expect(await verifyOAuthState(state, 'github', store, {})).not.toBeNull()
+  })
+
   it('drops unsafe redirectTo values when creating state', async () => {
     const store = new MemoryOAuthStateStore()
     const { state } = await createOAuthState('github', store, {}, 'https://evil.example.com/phish')

--- a/packages/server/tests/auth/oauth.test.ts
+++ b/packages/server/tests/auth/oauth.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, mock } from 'bun:test'
 import {
   OAuthManager,
   MemoryOAuthStateStore,
+  OAUTH_SESSION_BINDING_KEY,
   buildOAuthAuthorizeUrl,
   createDiscordOAuthProviderConfig,
   createGitHubOAuthProviderConfig,
@@ -9,6 +10,7 @@ import {
   createOAuthState,
   verifyOAuthState,
   sanitizeOAuthRedirect,
+  type OAuthBindingSession,
   type OAuthProviderConfig,
 } from '../../src/auth/oauth'
 import { hashToken } from '../../src/auth/utils'
@@ -363,6 +365,76 @@ describe('OAuthManager', () => {
 
     const allowlisted = await roundTrip('https://trusted.example.com/welcome')
     expect(allowlisted.redirectTo).toBe('https://trusted.example.com/welcome')
+  })
+
+  describe('session-bound flows', () => {
+    const createSessionStub = (): OAuthBindingSession & { data: Map<string, unknown> } => {
+      const data = new Map<string, unknown>()
+      return {
+        data,
+        get: <T,>(key: string) => data.get(key) as T | undefined,
+        set: (key: string, value: unknown) => { data.set(key, value) },
+        forget: (key: string) => { data.delete(key) },
+      }
+    }
+
+    const createManager = () => {
+      const manager = new OAuthManager({ stateStore: new MemoryOAuthStateStore() })
+      manager.registerProvider('github', githubConfig)
+      return manager
+    }
+
+    it('mints a binding into the session and accepts the callback carrying it', async () => {
+      const manager = createManager()
+      installOAuthFetchMock({ access_token: 'token-123' }, { id: 42 })
+
+      const session = createSessionStub()
+      const { state } = await manager.authorize('github', { session })
+      expect(session.get(OAUTH_SESSION_BINDING_KEY)).toBeString()
+
+      const { profile } = await manager.handleCallback('github', { code: 'auth-code', state, session })
+      expect(profile.id).toBe('42')
+    })
+
+    it('rejects the callback when a different session presents the state', async () => {
+      const manager = createManager()
+      installOAuthFetchMock({ access_token: 'token-123' }, { id: 42 })
+
+      const startingSession = createSessionStub()
+      const { state } = await manager.authorize('github', { session: startingSession })
+
+      // The victim's browser has its own session, which never saw authorize().
+      const otherSession = createSessionStub()
+      await expect(
+        manager.handleCallback('github', { code: 'auth-code', state, session: otherSession }),
+      ).rejects.toThrow('Invalid or expired OAuth state.')
+    })
+
+    it('consumes the session binding even when verification fails', async () => {
+      const manager = createManager()
+      installOAuthFetchMock({ access_token: 'token-123' }, { id: 42 })
+
+      const session = createSessionStub()
+      await manager.authorize('github', { session })
+
+      await expect(
+        manager.handleCallback('github', { code: 'auth-code', state: 'forged-state', session }),
+      ).rejects.toThrow()
+      expect(session.get(OAUTH_SESSION_BINDING_KEY)).toBeUndefined()
+    })
+
+    it('prefers an explicit bindTo over the session', async () => {
+      const manager = createManager()
+      installOAuthFetchMock({ access_token: 'token-123' }, { id: 42 })
+
+      const session = createSessionStub()
+      const { state } = await manager.authorize('github', { bindTo: 'external-value', session })
+      // The session was not written to — the caller owns the binding.
+      expect(session.data.size).toBe(0)
+
+      const { profile } = await manager.handleCallback('github', { code: 'auth-code', state, bindTo: 'external-value' })
+      expect(profile.id).toBe('42')
+    })
   })
 
   it('reports the provider verification signal from the configured key', async () => {

--- a/packages/server/tests/auth/oauth.test.ts
+++ b/packages/server/tests/auth/oauth.test.ts
@@ -86,6 +86,27 @@ describe('oauth helpers', () => {
   // Apps written against the previous API pass no binding at all. They stay
   // exposed to the transfer above — authorize() warns about it — but must not
   // break on upgrade.
+  // A store that drops `binding` reverts the protection with no other signal,
+  // so the mismatch between "bound at authorize" and "unbound at callback" is
+  // reported rather than passing silently.
+  it('warns when a bound flow comes back from the store unbound', async () => {
+    const store = new MemoryOAuthStateStore()
+    const original = console.warn
+    const warnings: string[] = []
+    console.warn = (message: unknown) => { warnings.push(String(message)) }
+
+    try {
+      const { state } = await createOAuthState('github', store, {}, undefined, 'dropped-state')
+      // Simulate the store losing the field: the state was minted unbound, but
+      // the caller presents one, which is the shape a dropping store produces.
+      expect(await verifyOAuthState(state, 'github', store, {}, 'session-abc')).not.toBeNull()
+    } finally {
+      console.warn = original
+    }
+
+    expect(warnings.some((line) => line.includes('without its binding'))).toBe(true)
+  })
+
   it('still verifies a state created without a binding', async () => {
     const store = new MemoryOAuthStateStore()
     const { state } = await createOAuthState('github', store, {})

--- a/packages/server/tests/authorization/authorization.test.ts
+++ b/packages/server/tests/authorization/authorization.test.ts
@@ -430,13 +430,13 @@ describe('Policy returning an AuthorizationResponse', () => {
   test('authorize throws for a denial response and keeps the message', async () => {
     const stranger = gate.forUser({ id: 2, role: 'user' } as TestUser)
 
-    expect(stranger.authorize('update', post)).rejects.toThrow('You do not own this post.')
+    await expect(stranger.authorize('update', post)).rejects.toThrow('You do not own this post.')
   })
 
   test('authorize does not throw for an allow response', async () => {
     const owner = gate.forUser({ id: 1, role: 'user' } as TestUser)
 
-    expect(owner.authorize('update', post)).resolves.toBeUndefined()
+    await expect(owner.authorize('update', post)).resolves.toBeUndefined()
   })
 
   test('inspect reports the denial with its message', async () => {
@@ -456,6 +456,42 @@ describe('Policy returning an AuthorizationResponse', () => {
     const paymentRequired = await stranger.authorize('publish', post).catch((error: unknown) => error)
     expect((paymentRequired as { statusCode: number }).statusCode).toBe(402)
     expect((paymentRequired as Error).message).toBe('Upgrade required.')
+  })
+
+  // `before` used to keep checking on anything that was not a boolean, so a
+  // denial object fell through and a permissive ability method then allowed it.
+  test('honours a denial response from a gate before callback', async () => {
+    gate.before(() => Response.deny('banned'))
+    gate.define('view', () => true)
+
+    const userGate = gate.forUser({ id: 2, role: 'user' } as TestUser)
+
+    expect(await userGate.allows('view')).toBe(false)
+    expect((await userGate.inspect('view')).message).toBe('banned')
+  })
+
+  test('honours a denial response from a policy before method', async () => {
+    class BeforePolicy extends Policy {
+      before() {
+        return this.deny('suspended')
+      }
+
+      update() {
+        return true
+      }
+    }
+
+    const policyGate = new Gate()
+    policyGate.policy(Post, BeforePolicy)
+
+    expect(await policyGate.forUser({ id: 1, role: 'user' } as TestUser).allows('update', post)).toBe(false)
+  })
+
+  test('still continues to the ability method when before returns undefined', async () => {
+    gate.before(() => undefined)
+    gate.define('view', () => true)
+
+    expect(await gate.forUser({ id: 2, role: 'user' } as TestUser).allows('view')).toBe(true)
   })
 
   test('reports the denial to after callbacks as a boolean', async () => {

--- a/packages/server/tests/authorization/authorization.test.ts
+++ b/packages/server/tests/authorization/authorization.test.ts
@@ -385,6 +385,92 @@ describe('Policy', () => {
 })
 
 // ===================
+// AuthorizationResponse Tests
+// ===================
+
+describe('Policy returning an AuthorizationResponse', () => {
+  class ResponsePolicy extends Policy {
+    update(user: TestUser | null, post: Post) {
+      return user?.id === post.authorId ? this.allow() : this.deny('You do not own this post.')
+    }
+
+    delete(user: TestUser | null, post: Post) {
+      return user?.id === post.authorId ? true : this.denyAsNotFound()
+    }
+
+    publish(user: TestUser | null, _post: Post) {
+      return user?.id === 1 ? true : this.denyWithStatus(402, 'Upgrade required.')
+    }
+  }
+
+  const post = new Post(1, 1)
+  let gate: Gate
+
+  beforeEach(() => {
+    gate = new Gate()
+    gate.policy(Post, ResponsePolicy)
+  })
+
+  test('treats a denial response as denied, not allowed', async () => {
+    const stranger = gate.forUser({ id: 2, role: 'user' } as TestUser)
+
+    expect(await stranger.allows('update', post)).toBe(false)
+    expect(await stranger.denies('update', post)).toBe(true)
+    expect(await stranger.any(['update'], post)).toBe(false)
+    expect(await stranger.all(['update'], post)).toBe(false)
+  })
+
+  test('treats an allow response as allowed', async () => {
+    const owner = gate.forUser({ id: 1, role: 'user' } as TestUser)
+
+    expect(await owner.allows('update', post)).toBe(true)
+    expect(await owner.denies('update', post)).toBe(false)
+  })
+
+  test('authorize throws for a denial response and keeps the message', async () => {
+    const stranger = gate.forUser({ id: 2, role: 'user' } as TestUser)
+
+    expect(stranger.authorize('update', post)).rejects.toThrow('You do not own this post.')
+  })
+
+  test('authorize does not throw for an allow response', async () => {
+    const owner = gate.forUser({ id: 1, role: 'user' } as TestUser)
+
+    expect(owner.authorize('update', post)).resolves.toBeUndefined()
+  })
+
+  test('inspect reports the denial with its message', async () => {
+    const stranger = gate.forUser({ id: 2, role: 'user' } as TestUser)
+    const response = await stranger.inspect('update', post)
+
+    expect(response.allowed).toBe(false)
+    expect(response.message).toBe('You do not own this post.')
+  })
+
+  test('propagates the response status to the thrown exception', async () => {
+    const stranger = gate.forUser({ id: 2, role: 'user' } as TestUser)
+
+    const notFound = await stranger.authorize('delete', post).catch((error: unknown) => error)
+    expect((notFound as { statusCode: number }).statusCode).toBe(404)
+
+    const paymentRequired = await stranger.authorize('publish', post).catch((error: unknown) => error)
+    expect((paymentRequired as { statusCode: number }).statusCode).toBe(402)
+    expect((paymentRequired as Error).message).toBe('Upgrade required.')
+  })
+
+  test('reports the denial to after callbacks as a boolean', async () => {
+    const seen: unknown[] = []
+    gate.after((_user, _ability, result) => {
+      seen.push(result)
+    })
+
+    await gate.forUser({ id: 2, role: 'user' } as TestUser).allows('update', post)
+
+    expect(seen).toEqual([false])
+  })
+})
+
+// ===================
 // definePolicy Tests
 // ===================
 

--- a/packages/server/tests/broadcasting/broadcasting.test.ts
+++ b/packages/server/tests/broadcasting/broadcasting.test.ts
@@ -603,6 +603,22 @@ describe('BroadcastManager', () => {
       const result = await manager.authorize('unregistered', null)
       expect(result).toBe(true)
     })
+
+    it('should deny when an authorizer falls off the end without returning', async () => {
+      // Callers read anything that is not false/null as authorized, so an
+      // implicit undefined must not read as a grant.
+      manager.privateChannel('orders.{id}', (() => undefined) as unknown as () => boolean)
+
+      const result = await manager.authorize('private-orders.123', { id: 1 })
+      expect(result).toBe(false)
+    })
+
+    it('should deny a presence channel whose authorizer returns undefined', async () => {
+      manager.presenceChannel('chat.{id}', (() => undefined) as unknown as () => null)
+
+      const result = await manager.authorize('presence-chat.1', { id: 1 })
+      expect(result).toBe(false)
+    })
   })
 
   describe('broadcast', () => {

--- a/packages/server/tests/http/vite-dev-server.test.ts
+++ b/packages/server/tests/http/vite-dev-server.test.ts
@@ -18,7 +18,7 @@ await mock.module('vite', () => ({
   },
 }))
 
-const { startViteDevServer } = await import('../../src/http/vite-dev-server')
+const { startViteDevServer, resolveViteDevServerConfig } = await import('../../src/http/vite-dev-server')
 
 describe('startViteDevServer', () => {
   beforeEach(() => {
@@ -40,5 +40,31 @@ describe('startViteDevServer', () => {
       expect(result.localUrl).toBe('http://localhost:4321')
       expect(result.networkUrls).toEqual(['http://192.168.0.10:4321'])
     }
+  })
+})
+
+describe('resolveViteDevServerConfig', () => {
+  it('does not bind the dev server to every interface by default', () => {
+    // The dev server serves every file under the project root — application
+    // source and the default SQLite database — with no authentication. Setting
+    // `host` here would override Vite's localhost-only default and hand that to
+    // anyone on the same network, so it must stay unset.
+    const config = resolveViteDevServerConfig({ root: '/tmp/app' })
+
+    expect(config.server?.host).toBeUndefined()
+  })
+
+  it('passes an explicit host through', () => {
+    expect(resolveViteDevServerConfig({ host: true }).server?.host).toBe(true)
+    expect(resolveViteDevServerConfig({ host: '0.0.0.0' }).server?.host).toBe('0.0.0.0')
+  })
+
+  it("lets the project's own vite config win over the caller's host", () => {
+    const config = resolveViteDevServerConfig({
+      host: true,
+      config: { server: { host: '127.0.0.1' } },
+    })
+
+    expect(config.server?.host).toBe('127.0.0.1')
   })
 })

--- a/packages/server/tests/redis/RedisOAuthStateStore.test.ts
+++ b/packages/server/tests/redis/RedisOAuthStateStore.test.ts
@@ -57,6 +57,20 @@ describe('RedisOAuthStateStore', () => {
     expect(await store.find('hash-1')).toBeNull()
   })
 
+  // A store that drops the binding hands back an unbound state, which then
+  // verifies for any browser — silently undoing the login-CSRF fix.
+  it('round-trips the browser binding', async () => {
+    const store = createStore()
+    await store.store('hash-bound', {
+      provider: 'github',
+      expiresAt: new Date(Date.now() + 60_000),
+      binding: 'hashed-binding',
+    })
+
+    expect((await store.find('hash-bound'))!.binding).toBe('hashed-binding')
+    expect((await store.consume('hash-bound'))!.binding).toBe('hashed-binding')
+  })
+
   it('consume returns null for an unknown state hash', async () => {
     const store = createStore()
     expect(await store.consume('missing')).toBeNull()

--- a/packages/server/tests/vite/plugin.test.ts
+++ b/packages/server/tests/vite/plugin.test.ts
@@ -14,8 +14,9 @@ describe('gurenVitePlugin', () => {
         expect.objectContaining({ find: '@resources' }),
       ]),
     )
-    expect(config.server.host).toBe(true)
+    expect(config.server.host).toBeUndefined()
     expect(config.server.port).toBe(5173)
+    expect(config.preview.host).toBe(true)
     expect(config.preview.port).toBe(4173)
     expect(config.build.outDir).toBe('public/assets')
     expect(config.build.manifest).toBe(true)
@@ -24,6 +25,15 @@ describe('gurenVitePlugin', () => {
     expect(config.publicDir).toBe(false)
     expect(typeof config.build.rollupOptions.output.manualChunks).toBe('function')
     expect(config.base).toBe('/public/assets/')
+  })
+
+  it('leaves an explicit server.host alone', () => {
+    const plugin = gurenVitePlugin()
+    const config: Record<string, any> = { server: { host: true } }
+
+    plugin.config?.(config, { command: 'serve' })
+
+    expect(config.server.host).toBe(true)
   })
 
   it('applies SSR build defaults', () => {

--- a/web/db/migrations/20260808140545_striped_agent_zero/migration.sql
+++ b/web/db/migrations/20260808140545_striped_agent_zero/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `oauth_states` ADD `binding` text;

--- a/web/db/migrations/20260808140545_striped_agent_zero/snapshot.json
+++ b/web/db/migrations/20260808140545_striped_agent_zero/snapshot.json
@@ -1,0 +1,330 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "632cfb20-9a53-4d35-ba99-923a2a4f498a",
+  "prevIds": [
+    "6578adc0-dce7-4aeb-b6de-0353862632cf"
+  ],
+  "ddl": [
+    {
+      "name": "oauth_states",
+      "entityType": "tables"
+    },
+    {
+      "name": "posts",
+      "entityType": "tables"
+    },
+    {
+      "name": "sessions",
+      "entityType": "tables"
+    },
+    {
+      "name": "users",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state_hash",
+      "entityType": "columns",
+      "table": "oauth_states"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "oauth_states"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "redirect_to",
+      "entityType": "columns",
+      "table": "oauth_states"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "oauth_states"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "binding",
+      "entityType": "columns",
+      "table": "oauth_states"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "body_markdown",
+      "entityType": "columns",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "body_html",
+      "entityType": "columns",
+      "table": "posts"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "table": "posts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "posts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "password_hash",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remember_token",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_id",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "columns": [
+        "state_hash"
+      ],
+      "nameExplicit": false,
+      "name": "oauth_states_pk",
+      "table": "oauth_states",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "posts_pk",
+      "table": "posts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pk",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pk",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "posts_slug_unique",
+      "entityType": "uniques",
+      "table": "posts"
+    },
+    {
+      "columns": [
+        "email"
+      ],
+      "nameExplicit": false,
+      "name": "users_email_unique",
+      "entityType": "uniques",
+      "table": "users"
+    },
+    {
+      "columns": [
+        "github_id"
+      ],
+      "nameExplicit": false,
+      "name": "users_github_id_unique",
+      "entityType": "uniques",
+      "table": "users"
+    }
+  ],
+  "renames": []
+}

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -25,6 +25,9 @@ export const oauthStates = sqliteTable('oauth_states', {
   provider: text('provider').notNull(),
   redirectTo: text('redirect_to'),
   expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
+  // Hash of the value tying a state to the browser that started the flow.
+  // Nullable: states minted before this column existed carry none.
+  binding: text('binding'),
 })
 
 export const posts = sqliteTable('posts', {

--- a/web/modules/blog/app/Http/Controllers/Auth/OAuthController.ts
+++ b/web/modules/blog/app/Http/Controllers/Auth/OAuthController.ts
@@ -22,8 +22,14 @@ export default class OAuthController extends Controller {
     // own account, keep the `code` unconsumed, and walk a visitor's browser
     // through the callback. Writing to the session is also what makes a
     // visitor's brand-new session persist across the provider round trip.
-    const binding = crypto.randomUUID()
-    this.auth.session()?.set(OAUTH_BINDING_KEY, binding)
+    // Bound only when there is a session to hold the value: sending `bindTo`
+    // with nowhere to keep it would make the callback reject its own flow.
+    const session = this.auth.session()
+    let binding: string | undefined
+    if (session) {
+      binding = crypto.randomUUID()
+      session.set(OAUTH_BINDING_KEY, binding)
+    }
 
     const { url } = await this.oauth().authorize('github', {
       redirectTo: this.request.query('redirectTo') ?? undefined,

--- a/web/modules/blog/app/Http/Controllers/Auth/OAuthController.ts
+++ b/web/modules/blog/app/Http/Controllers/Auth/OAuthController.ts
@@ -8,6 +8,8 @@ const CallbackQuerySchema = z.object({
   state: z.string(),
 })
 
+const OAUTH_BINDING_KEY = 'oauth.binding'
+
 export default class OAuthController extends Controller {
   private oauth(): OAuthManager {
     return this.make<OAuthManager>('oauth')
@@ -16,8 +18,16 @@ export default class OAuthController extends Controller {
   // Note: not named `redirect` — that would shadow the base
   // Controller.redirect() helper used below.
   async redirectToProvider(): Promise<Response> {
+    // Ties `state` to this browser. Without it an attacker can authorize their
+    // own account, keep the `code` unconsumed, and walk a visitor's browser
+    // through the callback. Writing to the session is also what makes a
+    // visitor's brand-new session persist across the provider round trip.
+    const binding = crypto.randomUUID()
+    this.auth.session()?.set(OAUTH_BINDING_KEY, binding)
+
     const { url } = await this.oauth().authorize('github', {
       redirectTo: this.request.query('redirectTo') ?? undefined,
+      bindTo: binding,
     })
 
     return this.redirect(url)
@@ -26,7 +36,11 @@ export default class OAuthController extends Controller {
   async callback(): Promise<Response> {
     const { code, state } = this.validateQuery(CallbackQuerySchema)
 
-    const { profile, redirectTo } = await this.oauth().handleCallback('github', { code, state })
+    const session = this.auth.session()
+    const binding = session?.get<string>(OAUTH_BINDING_KEY)
+    session?.forget(OAUTH_BINDING_KEY)
+
+    const { profile, redirectTo } = await this.oauth().handleCallback('github', { code, state, bindTo: binding })
 
     // Enforced before any account lookup or creation: this is a single-admin
     // blog, so arbitrary GitHub users must never get accounts.

--- a/web/modules/blog/app/Http/Controllers/Auth/OAuthController.ts
+++ b/web/modules/blog/app/Http/Controllers/Auth/OAuthController.ts
@@ -8,8 +8,6 @@ const CallbackQuerySchema = z.object({
   state: z.string(),
 })
 
-const OAUTH_BINDING_KEY = 'oauth.binding'
-
 export default class OAuthController extends Controller {
   private oauth(): OAuthManager {
     return this.make<OAuthManager>('oauth')
@@ -18,22 +16,13 @@ export default class OAuthController extends Controller {
   // Note: not named `redirect` — that would shadow the base
   // Controller.redirect() helper used below.
   async redirectToProvider(): Promise<Response> {
-    // Ties `state` to this browser. Without it an attacker can authorize their
-    // own account, keep the `code` unconsumed, and walk a visitor's browser
-    // through the callback. Writing to the session is also what makes a
-    // visitor's brand-new session persist across the provider round trip.
-    // Bound only when there is a session to hold the value: sending `bindTo`
-    // with nowhere to keep it would make the callback reject its own flow.
-    const session = this.auth.session()
-    let binding: string | undefined
-    if (session) {
-      binding = crypto.randomUUID()
-      session.set(OAUTH_BINDING_KEY, binding)
-    }
-
+    // Passing the session ties `state` to this browser: the manager keeps a
+    // binding in it that the callback must present back. Without it an
+    // attacker could authorize their own account, keep the `code` unconsumed,
+    // and walk a visitor's browser through the callback.
     const { url } = await this.oauth().authorize('github', {
       redirectTo: this.request.query('redirectTo') ?? undefined,
-      bindTo: binding,
+      session: this.auth.session(),
     })
 
     return this.redirect(url)
@@ -42,11 +31,11 @@ export default class OAuthController extends Controller {
   async callback(): Promise<Response> {
     const { code, state } = this.validateQuery(CallbackQuerySchema)
 
-    const session = this.auth.session()
-    const binding = session?.get<string>(OAUTH_BINDING_KEY)
-    session?.forget(OAUTH_BINDING_KEY)
-
-    const { profile, redirectTo } = await this.oauth().handleCallback('github', { code, state, bindTo: binding })
+    const { profile, redirectTo } = await this.oauth().handleCallback('github', {
+      code,
+      state,
+      session: this.auth.session(),
+    })
 
     // Enforced before any account lookup or creation: this is a single-admin
     // blog, so arbitrary GitHub users must never get accounts.


### PR DESCRIPTION
`Policy.deny()`, `denyWithStatus()` and `denyAsNotFound()` return an
`AuthorizationResponse` object, but `Gate.check()` returned the policy
method's value unchanged. That object is truthy, so `authorize()` did not
throw, `allows()` and `Controller.can()` returned truthy, `denies()`
returned false, `inspect()` reported `allowed: true`, and
`authorizeMiddleware`'s `if (!authorized)` guard passed. A policy that
denied a non-owner therefore let the write through.

Normalize every policy and gate return value through one path: an
`AuthorizationResponse` is honoured, `true` allows, anything else denies.
`checkResponse()` keeps the full response so `inspect()` reports the
policy's message and `authorize()` propagates `denyWithStatus()` /
`denyAsNotFound()` into the thrown exception's status.

Widen `PolicyMethod` and `definePolicy()` to `PolicyResult`
(`boolean | AuthorizationResponse`) so the type matches what `Policy`
offers, and export `PolicyResult` and `isAuthorizationResponse()`.