### PR TITLE
fix(server): scope Inertia shared props to the application container

### DIFF
--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -341,7 +341,7 @@ export default class AuthProvider extends ServiceProvider {
     shareInertiaProps(async (ctx) => {
       const auth = ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
       return { auth: { user: await auth?.user() } }
-    })
+    }, this.container)
   }
 }
 ```
@@ -357,12 +357,15 @@ Augment `InertiaSharedProps` (see the Controllers guide) to type this `auth` pay
 > clobbering one another:
 >
 > ```ts
-> shareInertiaProps((ctx) => ({ i18n: { locale: detectLocale(ctx) } }))
+> shareInertiaProps((ctx) => ({ i18n: { locale: detectLocale(ctx) } }), this.container)
 > ```
 >
-> `setInertiaSharedProps` replaces the resolver rather than merging, dropping
-> whatever is registered at the moment it runs. Reach for it only when you mean
-> to replace the whole thing.
+> Pass `this.container` to scope the props to one application; without it they
+> are process-wide and leak into a second application booted alongside.
+>
+> `setInertiaSharedProps` replaces the process-wide resolver rather than
+> merging, dropping whatever is registered at the moment it runs. Reach for it
+> only when you mean to replace the whole thing.
 
 Route middleware makes protecting endpoints straightforward:
 

--- a/docs/en/guides/controllers.md
+++ b/docs/en/guides/controllers.md
@@ -252,12 +252,14 @@ export default class LocaleProvider extends ServiceProvider {
   boot(): void {
     shareInertiaProps((ctx) => ({
       i18n: { locale: ctx.req.header('accept-language')?.split(',')[0] ?? 'en' },
-    }))
+    }), this.container)
   }
 }
 ```
 
 It merges its props over whatever resolver was registered before, so several providers can each contribute shared props without clobbering one another.
+
+Passing `this.container` scopes the props to that one application. Omit it and the props are process-wide, so a second application booted in the same process (a test suite, a warm serverless instance) receives them too.
 
 > [!NOTE]
 > Sharing the signed-in user (`auth.user`) is already registered for you by the `AuthProvider` that `bunx guren add auth` generates — there's no need to register it again. See the [Authentication guide](./authentication.md) for details.

--- a/docs/en/tutorials/authentication.md
+++ b/docs/en/tutorials/authentication.md
@@ -75,12 +75,12 @@ export default class AuthProvider extends ServiceProvider {
     shareInertiaProps(async (ctx) => {
       const auth = ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
       return { auth: { user: await auth?.user() } }
-    })
+    }, this.container)
   }
 }
 ```
 
-`shareInertiaProps` merges this value into the props of every Inertia response. What `auth.user()` returns is the **sanitized** user — `passwordHash` and `rememberToken` are stripped at runtime, so sharing it wholesale never ships credentials to the browser. Part 3's comment form relies on this wiring too.
+`shareInertiaProps` merges this value into the props of every Inertia response, and `this.container` keeps it scoped to this application. What `auth.user()` returns is the **sanitized** user — `passwordHash` and `rememberToken` are stripped at runtime, so sharing it wholesale never ships credentials to the browser. Part 3's comment form relies on this wiring too.
 
 ## 2. Checkpoint: sign in
 

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -339,7 +339,7 @@ export default class AuthProvider extends ServiceProvider {
     shareInertiaProps(async (ctx) => {
       const auth = ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
       return { auth: { user: await auth?.user() } }
-    })
+    }, this.container)
   }
 }
 ```
@@ -354,12 +354,16 @@ export default class AuthProvider extends ServiceProvider {
 > auth・i18n・flash など複数箇所から共有 props を提供しても互いを壊しません:
 >
 > ```ts
-> shareInertiaProps((ctx) => ({ i18n: { locale: detectLocale(ctx) } }))
+> shareInertiaProps((ctx) => ({ i18n: { locale: detectLocale(ctx) } }), this.container)
 > ```
 >
-> `setInertiaSharedProps` はマージせずリゾルバーを置き換えるため、実行時点で
-> 登録済みのものを丸ごと捨てます。意図的に全部を差し替えたいときだけ使って
-> ください。
+> `this.container` を渡すとその props は1つのアプリケーションに閉じます。渡さ
+> ない場合はプロセス全体で共有され、同時に起動した別のアプリケーションにも
+> 漏れます。
+>
+> `setInertiaSharedProps` はマージせずプロセス全体のリゾルバーを置き換えるため、
+> 実行時点で登録済みのものを丸ごと捨てます。意図的に全部を差し替えたいときだけ
+> 使ってください。
 
 ルートミドルウェアを使うと保護が簡単です。
 

--- a/docs/ja/guides/controllers.md
+++ b/docs/ja/guides/controllers.md
@@ -268,12 +268,14 @@ export default class LocaleProvider extends ServiceProvider {
   boot(): void {
     shareInertiaProps((ctx) => ({
       i18n: { locale: ctx.req.header('accept-language')?.split(',')[0] ?? 'en' },
-    }))
+    }), this.container)
   }
 }
 ```
 
 先に登録されたリゾルバーの props にマージされるので、複数のプロバイダーがそれぞれ共有 props を足しても互いを壊しません。
+
+`this.container` を渡すと、その props はそのアプリケーションだけに閉じます。省略するとプロセス全体で共有されるため、同一プロセスで起動した2つ目のアプリケーション（テストスイートや暖機済みのサーバーレス環境）にも渡ってしまいます。
 
 > [!NOTE]
 > 認証ユーザー（`auth.user`）の共有は `bunx guren add auth` が生成する `AuthProvider` が既に登録済みです。自分で登録し直す必要はありません — 詳細は[認証ガイド](./authentication.md)を参照してください。

--- a/docs/ja/tutorials/authentication.md
+++ b/docs/ja/tutorials/authentication.md
@@ -75,12 +75,12 @@ export default class AuthProvider extends ServiceProvider {
     shareInertiaProps(async (ctx) => {
       const auth = ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
       return { auth: { user: await auth?.user() } }
-    })
+    }, this.container)
   }
 }
 ```
 
-`shareInertiaProps` は、すべての Inertia レスポンスの props にこの値をマージします。`auth.user()` が返すのは **サニタイズ済み** のユーザーです — `passwordHash` や `rememberToken` はランタイムで除去済みなので、丸ごと共有しても資格情報はブラウザに届きません。この配線は Part 3 のコメントフォームでも使います。
+`shareInertiaProps` は、すべての Inertia レスポンスの props にこの値をマージします。`this.container` を渡すことで、この props はこのアプリケーションだけに閉じます。`auth.user()` が返すのは **サニタイズ済み** のユーザーです — `passwordHash` や `rememberToken` はランタイムで除去済みなので、丸ごと共有しても資格情報はブラウザに届きません。この配線は Part 3 のコメントフォームでも使います。
 
 ## 2. チェックポイント: サインインする
 

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -637,10 +637,11 @@ export default class AuthProvider extends ServiceProvider {
     //
     // shareInertiaProps merges over resolvers registered earlier instead of
     // replacing them, so the framework's flashed \`errors\` still come through.
+    // Passing this.container scopes the props to this app.
     shareInertiaProps(async (ctx) => {
       const auth = ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
       return { auth: { user: await auth?.user() } }
-    })
+    }, this.container)
   }
 }
 `

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -12,7 +12,7 @@ import { makeAuth } from '../src/make-auth'
 const SHARE_INERTIA_AUTH_PROPS_SNIPPET = `shareInertiaProps(async (ctx) => {
       const auth = ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
       return { auth: { user: await auth?.user() } }
-    })`
+    }, this.container)`
 
 describe('makeAuth', () => {
   it('scaffolds auth resources and installs providers', async () => {

--- a/packages/create-app/templates/blog/app/Providers/AuthProvider.ts
+++ b/packages/create-app/templates/blog/app/Providers/AuthProvider.ts
@@ -20,9 +20,10 @@ export default class AuthProvider extends ServiceProvider {
     //
     // shareInertiaProps merges over resolvers registered earlier instead of
     // replacing them, so the framework's flashed `errors` still come through.
+    // Passing this.container scopes the props to this app.
     shareInertiaProps(async (ctx) => {
       const auth = ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
       return { auth: { user: await auth?.user() } }
-    })
+    }, this.container)
   }
 }

--- a/packages/server/src/container/bindings.ts
+++ b/packages/server/src/container/bindings.ts
@@ -17,6 +17,7 @@ import type { HealthManager } from '../health'
 import type { Scheduler } from '../scheduling'
 import type { Gate } from '../authorization/Gate'
 import type { ExceptionHandler } from '../errors'
+import type { SharedInertiaPropsRegistry } from '../mvc/inertia/shared'
 
 /**
  * Type-safe service binding map.
@@ -49,5 +50,7 @@ export interface ServiceBindings {
   health: HealthManager
   scheduler: Scheduler
   gate: Gate
+  /** Bound lazily on the first `shareInertiaProps(fn, container)` call. */
+  'inertia.sharedProps': SharedInertiaPropsRegistry
   'exception.handler': ExceptionHandler
 }

--- a/packages/server/src/container/types.ts
+++ b/packages/server/src/container/types.ts
@@ -1,6 +1,15 @@
 import type { Container } from './Container'
 
 /**
+ * Structural type for DI containers, avoiding a hard dependency on Container
+ * where only resolution is needed (controllers, Inertia shared props).
+ */
+export interface ContainerLike {
+  make(key: string): unknown
+  has?(key: string): boolean
+}
+
+/**
  * Service factory function.
  */
 export type ServiceFactory<T> = (container: Container) => T

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -34,6 +34,7 @@ export type {
   SharedInertiaPropsResolver,
   InertiaSharedProps,
   ResolvedSharedInertiaProps,
+  SharedPropsContainer,
 } from './mvc/inertia/shared'
 // Service Providers
 export {

--- a/packages/server/src/mvc/Controller.ts
+++ b/packages/server/src/mvc/Controller.ts
@@ -7,16 +7,11 @@ import { tryGetI18n, type I18nManager, type RegisteredTranslationKey, type Repla
 import { flattenRequestQueries, parseRequestPayload } from '../http/request'
 import type { AuthContext } from '../auth/types'
 import type { ServiceBindings } from '../container/bindings'
+import type { ContainerLike } from '../container/types'
 import { ValidationException } from '../errors/exceptions/ValidationException'
 import { getApiTokenOrFail } from '../auth/api-token'
 import { getGate } from '../authorization/Gate'
 import type { AuthUser } from '../authorization/types'
-
-/** Structural type for DI containers, avoiding a hard dependency on Container. */
-interface ContainerLike {
-  make(key: string): unknown
-  has?(key: string): boolean
-}
 
 /**
  * Duck-type interface for Zod-like schemas.
@@ -318,7 +313,7 @@ export class Controller {
         ? componentOrPage
         : componentOrPage.component ?? componentOrPage.id
 
-    const sharedProps = await resolveSharedInertiaProps(ctx)
+    const sharedProps = await resolveSharedInertiaProps(ctx, this._container)
     const propsWithShared = { ...sharedProps, ...props } as Props & ResolvedSharedInertiaProps
 
     const response = await inertia(component, propsWithShared as Record<string, unknown>, {

--- a/packages/server/src/mvc/inertia/shared.ts
+++ b/packages/server/src/mvc/inertia/shared.ts
@@ -1,4 +1,5 @@
 import type { Context } from 'hono'
+import type { ContainerLike } from '../../container/types'
 
 /**
  * Application-level shared props shape for Inertia responses.
@@ -13,16 +14,142 @@ export type SharedInertiaPropsResolver<Props extends Record<string, unknown> = R
   ctx: Context,
 ) => Promise<Props> | Props
 
-let resolver: SharedInertiaPropsResolver<ResolvedSharedInertiaProps> | null = null
+/**
+ * Container able to own a scoped registry. `Container` satisfies this; the
+ * read-only {@link ContainerLike} does not, so a partial container cannot
+ * silently register app props into the module-global registry.
+ */
+export interface SharedPropsContainer extends ContainerLike {
+  has(key: string): boolean
+  instance(key: string, value: unknown): unknown
+}
 
+/** Container binding key for the scoped {@link SharedInertiaPropsRegistry}. */
+export const INERTIA_SHARED_PROPS_BINDING = 'inertia.sharedProps'
+
+/**
+ * Registrations are numbered from one process-wide counter so that props keep
+ * resolving in registration order — later registrations win on conflicting
+ * keys — no matter which registry each one landed in.
+ */
+let registrationSequence = 0
+
+interface OrderedResolver {
+  seq: number
+  resolve: SharedInertiaPropsResolver<ResolvedSharedInertiaProps>
+}
+
+/**
+ * Holds the shared-props resolvers for one scope: either a single
+ * Application's container or the module-global fallback for bare-Hono apps.
+ */
+export class SharedInertiaPropsRegistry {
+  private resolvers: OrderedResolver[] = []
+
+  /** Replace every resolver registered in this scope. */
+  set<Props extends Record<string, unknown> = ResolvedSharedInertiaProps>(
+    resolverFn: SharedInertiaPropsResolver<Props> | null,
+  ): void {
+    this.resolvers = resolverFn ? [orderedResolver(resolverFn)] : []
+  }
+
+  /**
+   * Register additional shared props without replacing resolvers registered
+   * earlier — the new resolver's props are merged over the previous ones.
+   */
+  share<Props extends Record<string, unknown>>(resolverFn: SharedInertiaPropsResolver<Props>): void {
+    this.resolvers.push(orderedResolver(resolverFn))
+  }
+
+  /** The resolvers registered in this scope, ordered by registration. */
+  entries(): readonly OrderedResolver[] {
+    return this.resolvers
+  }
+
+  /**
+   * The scope's registrations composed into one resolver, or null when empty.
+   * The composition is a snapshot: resolvers registered later are not picked up.
+   */
+  get(): SharedInertiaPropsResolver<ResolvedSharedInertiaProps> | null {
+    if (this.resolvers.length === 0) return null
+    if (this.resolvers.length === 1) return this.resolvers[0]!.resolve
+
+    const snapshot = [...this.resolvers]
+    return (ctx) => applyResolvers(snapshot, ctx)
+  }
+
+  async resolve(ctx: Context): Promise<ResolvedSharedInertiaProps> {
+    return applyResolvers(this.resolvers, ctx)
+  }
+}
+
+function orderedResolver<Props extends Record<string, unknown>>(
+  resolverFn: SharedInertiaPropsResolver<Props>,
+): OrderedResolver {
+  return {
+    seq: registrationSequence++,
+    resolve: resolverFn as SharedInertiaPropsResolver<ResolvedSharedInertiaProps>,
+  }
+}
+
+async function applyResolvers(
+  entries: readonly OrderedResolver[],
+  ctx: Context,
+): Promise<ResolvedSharedInertiaProps> {
+  const merged: Record<string, unknown> = {}
+
+  for (const entry of entries) {
+    const props = await entry.resolve(ctx)
+    if (props && typeof props === 'object') {
+      Object.assign(merged, props)
+    }
+  }
+
+  return merged as ResolvedSharedInertiaProps
+}
+
+// Module-global fallback registry, for bare-Hono apps and any provider that
+// registers without a container. Framework providers register on the
+// container-scoped registry so two Application instances booted in one process
+// (test suites, serverless warm reuse) don't cross-contaminate.
+const globalRegistry = new SharedInertiaPropsRegistry()
+
+/** The registry bound to `container`, or null when it owns none yet. */
+function scopedRegistry(container?: ContainerLike | null): SharedInertiaPropsRegistry | null {
+  if (!container?.has?.(INERTIA_SHARED_PROPS_BINDING)) return null
+  return container.make(INERTIA_SHARED_PROPS_BINDING) as SharedInertiaPropsRegistry
+}
+
+/**
+ * The shared-props registry scoped to `container`, binding a fresh one on
+ * first use.
+ */
+export function ensureSharedInertiaPropsRegistry(container: SharedPropsContainer): SharedInertiaPropsRegistry {
+  const existing = scopedRegistry(container)
+  if (existing) return existing
+
+  const registry = new SharedInertiaPropsRegistry()
+  container.instance(INERTIA_SHARED_PROPS_BINDING, registry)
+  return registry
+}
+
+/**
+ * Replace the module-global shared props resolver. Props registered on an
+ * application's container (see {@link shareInertiaProps}) are unaffected.
+ */
 export function setInertiaSharedProps<Props extends Record<string, unknown> = ResolvedSharedInertiaProps>(
   resolverFn: SharedInertiaPropsResolver<Props> | null,
 ): void {
-  resolver = resolverFn as SharedInertiaPropsResolver<ResolvedSharedInertiaProps> | null
+  globalRegistry.set(resolverFn)
 }
 
+/**
+ * The module-global registrations composed into one resolver, for manual
+ * composition. Container-scoped props are not included — get those from
+ * `ensureSharedInertiaPropsRegistry(container).get()`.
+ */
 export function getInertiaSharedPropsResolver(): SharedInertiaPropsResolver<ResolvedSharedInertiaProps> | null {
-  return resolver
+  return globalRegistry.get()
 }
 
 /**
@@ -30,25 +157,42 @@ export function getInertiaSharedPropsResolver(): SharedInertiaPropsResolver<Reso
  * earlier — the new resolver's props are merged over the previous ones.
  * Use this from app providers so multiple providers can each contribute
  * shared props (setInertiaSharedProps replaces the resolver wholesale).
+ *
+ * Pass the provider's `this.container` to scope the props to one application.
+ * Without it the props are module-global, so a second Application booted in
+ * the same process shares them.
+ *
+ * @example
+ * ```typescript
+ * export class AuthProvider extends ServiceProvider {
+ *   boot(): void {
+ *     shareInertiaProps(async (ctx) => ({ auth: { user: await currentUser(ctx) } }), this.container)
+ *   }
+ * }
+ * ```
  */
 export function shareInertiaProps<Props extends Record<string, unknown>>(
   resolverFn: SharedInertiaPropsResolver<Props>,
+  container?: SharedPropsContainer,
 ): void {
-  const previous = resolver
-  resolver = async (ctx) => {
-    const prev = previous ? await previous(ctx) : ({} as ResolvedSharedInertiaProps)
-    const next = await resolverFn(ctx)
-    return { ...prev, ...next } as ResolvedSharedInertiaProps
-  }
+  const registry = container ? ensureSharedInertiaPropsRegistry(container) : globalRegistry
+  registry.share(resolverFn)
 }
 
-export async function resolveSharedInertiaProps(ctx: Context): Promise<ResolvedSharedInertiaProps> {
-  if (!resolver) return {} as ResolvedSharedInertiaProps
+/**
+ * Resolve shared props for a request, merging the module-global registrations
+ * with those scoped to `container` in registration order.
+ */
+export async function resolveSharedInertiaProps(
+  ctx: Context,
+  container?: ContainerLike | null,
+): Promise<ResolvedSharedInertiaProps> {
+  const scoped = scopedRegistry(container)
+  if (!scoped) return globalRegistry.resolve(ctx)
 
-  const shared = await resolver(ctx)
-  if (shared && typeof shared === 'object') {
-    return shared as ResolvedSharedInertiaProps
-  }
+  const globalEntries = globalRegistry.entries()
+  if (globalEntries.length === 0) return scoped.resolve(ctx)
 
-  return {} as ResolvedSharedInertiaProps
+  const ordered = [...globalEntries, ...scoped.entries()].sort((a, b) => a.seq - b.seq)
+  return applyResolvers(ordered, ctx)
 }

--- a/packages/server/src/providers/I18nServiceProvider.ts
+++ b/packages/server/src/providers/I18nServiceProvider.ts
@@ -112,7 +112,7 @@ export class I18nServiceProvider extends ServiceProvider {
         }
 
         return { _i18n: i18nProps }
-      })
+      }, this.container)
     }
   }
 

--- a/packages/server/src/providers/InertiaServiceProvider.ts
+++ b/packages/server/src/providers/InertiaServiceProvider.ts
@@ -2,7 +2,7 @@ import { ServiceProvider } from '../container/ServiceProvider'
 import { inertia } from '../mvc/inertia/InertiaEngine'
 import { ViewEngine } from '../mvc/ViewEngine'
 import { ValidationException } from '../errors/exceptions/ValidationException'
-import { getInertiaSharedPropsResolver, setInertiaSharedProps } from '../mvc/inertia/shared'
+import { shareInertiaProps } from '../mvc/inertia/shared'
 import { getSessionFromContext } from '../http/middleware/session'
 import type { ExceptionHandler } from '../errors/ExceptionHandler'
 import type { Context } from 'hono'
@@ -68,19 +68,15 @@ export class InertiaServiceProvider extends ServiceProvider {
   }
 
   /**
-   * Wrap existing shared props resolver to auto-inject flashed `errors`.
+   * Auto-inject flashed `errors` into shared props. Scoped to this app's
+   * container so a second Application booted in the same process keeps its
+   * own registrations.
    */
   private registerSharedErrors(): void {
-    const previous = getInertiaSharedPropsResolver()
-
-    setInertiaSharedProps(async (ctx: Context) => {
-      const prev = previous ? await previous(ctx) : {}
+    shareInertiaProps(async (ctx: Context) => {
       const session = getSessionFromContext(ctx)
       const errors = session?.getFlash<Record<string, string>>('errors')
-      return {
-        ...prev,
-        ...(errors && Object.keys(errors).length > 0 ? { errors } : {}),
-      }
-    })
+      return errors && Object.keys(errors).length > 0 ? { errors } : {}
+    }, this.container)
   }
 }

--- a/packages/server/tests/i18n/i18n-plugin.test.ts
+++ b/packages/server/tests/i18n/i18n-plugin.test.ts
@@ -1,6 +1,14 @@
-import { describe, test, expect, afterEach } from 'bun:test'
-import { Controller, createApp, MemoryLoader, I18nServiceProvider, type I18nManager, type I18nPluginOptions } from '../../src'
-import { setInertiaSharedProps } from '../../src/mvc/inertia/shared'
+import { describe, test, expect } from 'bun:test'
+import {
+  Controller,
+  createApp,
+  MemoryLoader,
+  I18nServiceProvider,
+  ServiceProvider,
+  shareInertiaProps,
+  type I18nManager,
+  type I18nPluginOptions,
+} from '../../src'
 
 const MESSAGES = {
   en: {
@@ -67,12 +75,6 @@ async function inertiaPageProps(app: ReturnType<typeof makeApp>, path = '/page')
   const page = (await response.json()) as { props: Record<string, any> }
   return page.props
 }
-
-afterEach(() => {
-  // The Inertia shared-props resolver is module-global state; each booted
-  // app's I18nServiceProvider appends to it.
-  setInertiaSharedProps(null)
-})
 
 describe('createApp({ i18n })', () => {
   test('preloads every supported locale during boot', async () => {
@@ -159,6 +161,51 @@ describe('createApp({ i18n })', () => {
 
     const props = await inertiaPageProps(app)
     expect(props._i18n).toBeUndefined()
+  })
+
+  test('two booted apps keep their shared props isolated', async () => {
+    // Shared props are registered on each app's container, not module-global
+    // state — a second Application booted in the same process (test suites,
+    // serverless warm reuse) must not see the first app's resolvers.
+    const sharing = makeApp({ fallback: 'ja' })
+    const silent = makeApp({ share: false })
+    await sharing.boot()
+    await silent.boot()
+
+    const sharingProps = await inertiaPageProps(sharing)
+    expect(sharingProps._i18n.locale).toBe('ja')
+
+    const silentProps = await inertiaPageProps(silent)
+    expect(silentProps._i18n).toBeUndefined()
+  })
+
+  test('app providers passing their container stay isolated too', async () => {
+    // The path scaffolded providers take: shareInertiaProps(fn, this.container).
+    abstract class OwnerProvider extends ServiceProvider {
+      protected abstract readonly owner: string
+
+      register(): void { }
+
+      override boot(): void {
+        shareInertiaProps(() => ({ owner: this.owner }), this.container)
+      }
+    }
+    class OwnerAProvider extends OwnerProvider {
+      protected readonly owner = 'A'
+    }
+    class OwnerBProvider extends OwnerProvider {
+      protected readonly owner = 'B'
+    }
+
+    const appA = makeApp()
+    const appB = makeApp()
+    appA.register(OwnerAProvider)
+    appB.register(OwnerBProvider)
+    await appA.boot()
+    await appB.boot()
+
+    expect((await inertiaPageProps(appA)).owner).toBe('A')
+    expect((await inertiaPageProps(appB)).owner).toBe('B')
   })
 
   test('fallback option overrides the first supported locale', async () => {

--- a/packages/server/tests/mvc/inertia-shared.test.ts
+++ b/packages/server/tests/mvc/inertia-shared.test.ts
@@ -1,19 +1,22 @@
 import { describe, expect, it, beforeEach } from 'bun:test'
 import type { Context } from 'hono'
+import { Container } from '../../src/container'
 import {
   setInertiaSharedProps,
   shareInertiaProps,
   getInertiaSharedPropsResolver,
+  ensureSharedInertiaPropsRegistry,
   resolveSharedInertiaProps,
+  INERTIA_SHARED_PROPS_BINDING,
 } from '../../src/mvc/inertia/shared'
 
 const fakeCtx = {} as Context
 
-describe('shareInertiaProps', () => {
-  beforeEach(() => {
-    setInertiaSharedProps(null)
-  })
+beforeEach(() => {
+  setInertiaSharedProps(null)
+})
 
+describe('shareInertiaProps', () => {
   it('merges props over a resolver registered via setInertiaSharedProps', async () => {
     setInertiaSharedProps(() => ({ appName: 'Test' }))
     shareInertiaProps(() => ({ i18n: { locale: 'ja' } }))
@@ -50,5 +53,79 @@ describe('shareInertiaProps', () => {
 
     const shared = await resolveSharedInertiaProps(fakeCtx)
     expect(shared).toEqual({ base: true, extra: 1 })
+  })
+
+  it('composes the global registrations made before it was read', async () => {
+    shareInertiaProps(() => ({ first: 1 }))
+    shareInertiaProps(() => ({ second: 2 }))
+
+    const composed = getInertiaSharedPropsResolver()!
+    // A snapshot: registrations made after the read are not picked up.
+    shareInertiaProps(() => ({ third: 3 }))
+
+    expect(await composed(fakeCtx)).toEqual({ first: 1, second: 2 })
+  })
+})
+
+describe('container-scoped shared props', () => {
+  it('binds one registry per container and reuses it', () => {
+    const container = new Container()
+
+    const registry = ensureSharedInertiaPropsRegistry(container)
+    expect(container.has(INERTIA_SHARED_PROPS_BINDING)).toBe(true)
+    expect(ensureSharedInertiaPropsRegistry(container)).toBe(registry)
+  })
+
+  it('keeps two containers isolated and leaves the global registry untouched', async () => {
+    const containerA = new Container()
+    const containerB = new Container()
+
+    shareInertiaProps(() => ({ app: 'A' }), containerA)
+    shareInertiaProps(() => ({ app: 'B' }), containerB)
+
+    expect(await resolveSharedInertiaProps(fakeCtx, containerA)).toEqual({ app: 'A' })
+    expect(await resolveSharedInertiaProps(fakeCtx, containerB)).toEqual({ app: 'B' })
+    expect(await resolveSharedInertiaProps(fakeCtx)).toEqual({})
+  })
+
+  it('resolves global and scoped props in registration order', async () => {
+    const container = new Container()
+
+    shareInertiaProps(() => ({ fromGlobal: true, overlap: 'global' }))
+    shareInertiaProps(() => ({ overlap: 'scoped' }), container)
+
+    expect(await resolveSharedInertiaProps(fakeCtx, container)).toEqual({
+      fromGlobal: true,
+      overlap: 'scoped',
+    })
+  })
+
+  it('lets a globally registered resolver override an earlier scoped one', async () => {
+    // Registration order wins across both scopes — an app provider registered
+    // after a framework one can still override its props.
+    const container = new Container()
+
+    shareInertiaProps(() => ({ _i18n: { locale: 'en' } }), container)
+    shareInertiaProps(() => ({ _i18n: { locale: 'ja' } }))
+
+    expect(await resolveSharedInertiaProps(fakeCtx, container)).toEqual({ _i18n: { locale: 'ja' } })
+  })
+
+  it('falls back to global-only resolution for a container with no registry', async () => {
+    const container = new Container()
+    setInertiaSharedProps(() => ({ appName: 'Global' }))
+
+    expect(await resolveSharedInertiaProps(fakeCtx, container)).toEqual({ appName: 'Global' })
+    expect(container.has(INERTIA_SHARED_PROPS_BINDING)).toBe(false)
+  })
+
+  it('setInertiaSharedProps(null) leaves scoped registrations intact', async () => {
+    const container = new Container()
+    shareInertiaProps(() => ({ scoped: true }), container)
+    setInertiaSharedProps(() => ({ global: true }))
+
+    setInertiaSharedProps(null)
+
+    expect(await resolveSharedInertiaProps(fakeCtx, container)).toEqual({ scoped: true })
   })
 })

--- a/packages/server/tests/providers/InertiaValidation.test.ts
+++ b/packages/server/tests/providers/InertiaValidation.test.ts
@@ -1,6 +1,6 @@
 process.env.APP_KEY = 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
 
-import { describe, expect, it, beforeEach } from 'bun:test'
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test'
 import { Hono } from 'hono'
 import { Container } from '../../src/container'
 import { InertiaServiceProvider } from '../../src/providers/InertiaServiceProvider'
@@ -18,10 +18,14 @@ describe('InertiaServiceProvider validation handling', () => {
   let container: Container
   let store: MemorySessionStore
 
-  beforeEach(() => {
-    // Reset shared props
+  // The provider registers shared props on the container, so a fresh container
+  // per test isolates it; only the one test using the module-global registry
+  // needs this reset.
+  afterEach(() => {
     setInertiaSharedProps(null)
+  })
 
+  beforeEach(() => {
     container = new Container()
     app = new Hono()
     store = new MemorySessionStore()
@@ -149,19 +153,15 @@ describe('InertiaServiceProvider validation handling', () => {
     expect(body3.errors).toBeNull()
   })
 
-  it('injects errors into shared props resolver', async () => {
-    // Set a base shared props resolver
+  it('merges flashed errors over module-global shared props', async () => {
+    // A bare-Hono style global resolver stays underneath the provider's
+    // container-scoped errors resolver.
     setInertiaSharedProps(async () => ({ appName: 'Test' }))
-
-    // Re-boot InertiaServiceProvider to wrap the new resolver
-    const inertiaProvider = new InertiaServiceProvider(container)
-    inertiaProvider.register()
-    inertiaProvider.boot()
 
     // Route that returns resolved shared props
     app.get('/shared', async (ctx) => {
       const { resolveSharedInertiaProps } = await import('../../src/mvc/inertia/shared')
-      const shared = await resolveSharedInertiaProps(ctx)
+      const shared = await resolveSharedInertiaProps(ctx, container)
       return ctx.json(shared)
     })
 


### PR DESCRIPTION
## Summary

The Inertia shared-props resolver in `@guren/server` was module-global state (`let resolver` in `packages/server/src/mvc/inertia/shared.ts`). Framework providers composed onto it twice (`InertiaServiceProvider` for flashed errors, `I18nServiceProvider` for `_i18n`), so two `Application` instances booted in one process — test suites, serverless warm reuse — cross-contaminated each other's shared props. Every booted app's `I18nManager` and prop caches were also retained for the process lifetime, since nothing ever unwound the global chain.

This introduces `SharedInertiaPropsRegistry` and binds one per `Application` container, with the existing module-global registry kept as a fallback for bare-Hono callers. The public API (`setInertiaSharedProps` / `shareInertiaProps` / `getInertiaSharedPropsResolver`) is preserved; `shareInertiaProps(fn, container?)` gained an optional second argument to scope registration to one app.

Registrations across both the global and container-scoped registries are ordered by a shared, monotonically increasing sequence counter, so a later-registered resolver still overrides an earlier one regardless of which scope it landed in — this matters because framework providers (I18n, Inertia's flashed errors) and app providers can now land in different scopes, and registration-order-wins semantics must survive that split.

`InertiaServiceProvider`, `I18nServiceProvider`, the scaffolded `AuthProvider` template, `make:auth`, and the docs (guides + tutorials, en/ja) are all updated to pass `this.container`.

## Scope

- `server`: `mvc/inertia/shared.ts`, `mvc/Controller.ts`, `container/types.ts`, `container/bindings.ts`, `providers/InertiaServiceProvider.ts`, `providers/I18nServiceProvider.ts`, `index.ts`, plus test migrations
- `cli`: `make-auth.ts` template + its test
- `create-app`: `templates/blog/app/Providers/AuthProvider.ts`
- `docs`: `guides/controllers.md`, `guides/authentication.md`, `tutorials/authentication.md` (en + ja)

## Risk Assessment

- Public API is additive-only (`shareInertiaProps` gained an optional second param); no signature became required.
- Behavior change: shared props merge order is now "global registrations and container-scoped registrations interleaved by registration sequence" rather than "one linear chain." Verified this preserves later-registration-wins semantics with a dedicated test, and that disabling the container-scoped path makes the new isolation tests fail (mutation check).
- Templates (`create-app`, `make:auth`) now emit `shareInertiaProps(fn, this.container)`. Per the repo's own template-drift rules, `smoke:starter:npm` will be red until this release ships to npm, since the template uses the new optional-argument form immediately — this is expected and matches documented practice for template-facing API changes.
- No database/migration impact.

## Validation

- `bun run build:clean` — pass
- `bun run typecheck` — pass (root, blog example, api example)
- `bun run test:bun` — 3675 pass / 55 skip / 0 fail
- `bun run test:examples` — 102 pass
- `bun run audit:core-first` / `audit:docs` / `audit:starter-template` / `audit:template-deps` — all pass
- `bun run smoke:starter` / `smoke:starter:blog` — pass (pre-existing unrelated warnings only)
- Mutation test: reverting the container-scoped resolution path to global-only makes the new isolation tests fail, confirming they exercise real behavior.
- Reviewed via Codex (two real cross-contamination scenarios reproduced end-to-end and fixed) and a 4-angle `/simplify` pass (reuse, simplification, efficiency, altitude) prior to opening this PR.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.