### PR TITLE
fix(examples): repair blog smoke test and stop bunx guren fallback

### DIFF
--- a/examples/api/config/app.ts
+++ b/examples/api/config/app.ts
@@ -5,7 +5,7 @@ let bootstrapped = false
 /**
  * Seeding is one-shot provisioning, not part of booting: production boots
  * repeatedly on serverless cold starts, and a bundle has no resolver for the
- * raw db/seeders/*.ts files. Run `bunx guren db:seed` explicitly instead.
+ * raw db/seeders/*.ts files. Run `bun run db:seed` explicitly instead.
  */
 function shouldSeedOnBoot(): boolean {
   return process.env.NODE_ENV !== 'production'

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -7,10 +7,10 @@
     "dev": "bun --hot bin/serve.ts",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "openapi:generate": "bunx guren openapi:generate --routes routes/api.ts --title \"Guren Example API\" --version \"0.1.0\" --description \"Example API for authentication, tokens, and task management.\" --out .guren/openapi.gen.json",
-    "db:make": "bunx guren make:migration",
-    "db:migrate": "bunx guren db:migrate",
-    "db:seed": "bunx guren db:seed"
+    "openapi:generate": "bun ../../packages/cli/src/bin.ts openapi:generate --routes routes/api.ts --title \"Guren Example API\" --version \"0.1.0\" --description \"Example API for authentication, tokens, and task management.\" --out .guren/openapi.gen.json",
+    "db:make": "bun ../../packages/cli/src/bin.ts make:migration",
+    "db:migrate": "bun ../../packages/cli/src/bin.ts db:migrate",
+    "db:seed": "bun ../../packages/cli/src/bin.ts db:seed"
   },
   "dependencies": {
     "@guren/cli": "workspace:*",

--- a/examples/blog/config/app.ts
+++ b/examples/blog/config/app.ts
@@ -20,7 +20,7 @@ function hasMigrations(): boolean {
 /**
  * Seeding is one-shot provisioning, not part of booting: production boots
  * repeatedly on serverless cold starts, and a bundle has no resolver for the
- * raw db/seeders/*.ts files. Run `bunx guren db:seed` explicitly instead.
+ * raw db/seeders/*.ts files. Run `bun run db:seed` explicitly instead.
  */
 function shouldSeedOnBoot(): boolean {
   return process.env.NODE_ENV !== 'production'

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -17,9 +17,9 @@
     "e2e:ui": "playwright test --ui",
     "typecheck": "tsc --noEmit",
     "preview": "NODE_ENV=production bun bin/serve.ts",
-    "db:make": "bunx guren make:migration",
-    "db:migrate": "bunx guren db:migrate",
-    "db:seed": "bunx guren db:seed"
+    "db:make": "bun ../../packages/cli/src/bin.ts make:migration",
+    "db:migrate": "bun ../../packages/cli/src/bin.ts db:migrate",
+    "db:seed": "bun ../../packages/cli/src/bin.ts db:seed"
   },
   "dependencies": {
     "@guren/cli": "workspace:*",

--- a/examples/blog/smoke.ts
+++ b/examples/blog/smoke.ts
@@ -1,41 +1,41 @@
+import { createTestClient, PendingTestResponse } from '@guren/testing'
 import app, { ready } from './src/main.ts'
+
+// A missing database is the one boot failure worth skipping: contributors run
+// this without postgres up. Anything else is a regression the smoke must fail.
+const CONNECTIVITY_ERROR =
+  /ECONNREFUSED|ECONNRESET|ENOTFOUND|ETIMEDOUT|EHOSTUNREACH|cannot connect to the database/i
 
 async function main() {
   try {
     await ready
   } catch (error) {
-    console.warn('Skipping smoke test: database is not reachable.', error)
-    return
+    if (CONNECTIVITY_ERROR.test(String(error))) {
+      console.warn('Skipping smoke test: database is not reachable.', error)
+      return
+    }
+    throw error
   }
 
-  const root = await app.fetch(new Request('http://example.local/'))
-  if (root.status !== 200) {
-    throw new Error(`Unexpected status for /: ${root.status}`)
-  }
+  // createTestClient's default base URL is http://localhost, which src/app.ts
+  // host authorization admits outside production.
+  const client = createTestClient((request) => app.fetch(request))
 
-  const rootHtml = await root.text()
-  if (!rootHtml.includes('Latest Posts')) {
-    throw new Error('SSR markup missing expected content for posts index')
-  }
+  // data-server-rendered is Inertia's SSR marker; the client-side fallback
+  // shell ships an empty <div id="app"></div> without it.
+  const root = await client.get('/').send()
+  root.assertStatus(200)
+  await root.assertBodyContains('data-server-rendered="true"')
 
-  const posts = await app.fetch(
-    new Request('http://example.local/posts', {
-      headers: {
-        'X-Inertia': 'true',
-        Accept: 'application/json',
-      },
-    }),
-  )
-  if (posts.status !== 200) {
-    throw new Error(`Unexpected status for /posts: ${posts.status}`)
-  }
-
-  const payload = await posts.json()
-  if (payload.component !== 'posts/Index') {
-    throw new Error('Inertia component mismatch for posts index')
-  }
+  await new PendingTestResponse(client.get('/posts').asInertia().acceptJson().send())
+    .assertOk()
+    .assertInertia('posts/Index')
 
   console.log('Smoke test passed: SSR HTML and JSON endpoints responded successfully')
 }
 
 await main()
+
+// The booted app holds live handles (DB pool, scheduler), so the process
+// never exits on its own. Failures above still exit non-zero via the throw.
+process.exit(0)

--- a/web/config/app.ts
+++ b/web/config/app.ts
@@ -44,7 +44,7 @@ export async function bootModels(): Promise<void> {
     // D1 seeding is a CLI workflow (`wrangler d1 execute`); the factory's
     // seedDatabase() intentionally throws on Workers. Seeding is also one-shot
     // provisioning rather than part of booting, so it stays out of production
-    // boots on every runtime — run `bunx guren db:seed` explicitly instead.
+    // boots on every runtime — run `bun run db:seed` explicitly instead.
     if (!isWorkersRuntime() && process.env.NODE_ENV !== 'production') {
       await seedDatabase()
     }

--- a/web/package.json
+++ b/web/package.json
@@ -14,9 +14,9 @@
     "test": "bun run prerender:stub && bunx vitest run",
     "build": "bun run codegen && bun run prerender && bunx vite build && bunx vite build --ssr",
     "preview": "NODE_ENV=production bun bin/serve.ts",
-    "db:make": "bunx guren make:migration",
-    "db:migrate": "bunx guren db:migrate",
-    "db:seed": "bunx guren db:seed",
+    "db:make": "bun ../packages/cli/src/bin.ts make:migration",
+    "db:migrate": "bun ../packages/cli/src/bin.ts db:migrate",
+    "db:seed": "bun ../packages/cli/src/bin.ts db:seed",
     "cloudflare:build": "bun run build && bun scripts/cloudflare-build.ts",
     "deploy:cloudflare": "bun run cloudflare:build && bunx wrangler deploy"
   },


### PR DESCRIPTION
## Summary
- `examples/blog/smoke.ts` had bit-rotted three ways at once: it requested `http://example.local/`, which `src/app.ts` `hostAuthorization()` rejects with 403 outside production (only `localhost:*`/`127.0.0.1:*` are allowed); its SSR assertion checked for the string "Latest Posts", which no longer exists anywhere after the v1.0-alpha copy redesign; and on success the process never exited because the booted app holds live DB/scheduler handles.
- Rewrote the smoke script to hit `http://localhost/`, assert Inertia's SSR marker (`data-server-rendered="true"`) instead of page copy so it survives future copy changes, reuse `@guren/testing`'s `createTestClient`/`PendingTestResponse` instead of hand-rolled request/assertion code (without pulling in `TestApp`'s `GUREN_TESTING` env flag, which would change the security posture being exercised), only skip the check on genuine connectivity errors instead of swallowing every boot failure, and exit explicitly.
- Replaced `bunx guren` with the workspace-relative CLI path (`bun ../../packages/cli/src/bin.ts ...`) in `examples/blog`, `examples/api`, and `web` `package.json` scripts, matching the existing `codegen` script and CI usage — `guren` isn't published to npm, so `bunx` was silently falling through to a registry 404 instead of resolving the workspace package. Also updated the `db:seed` comments in each app's `config/app.ts` that pointed at the old form.

## Test plan
- [x] `bun run --cwd examples/blog typecheck`
- [x] `bun run --cwd examples/blog smoke` against local Postgres — passes, exits 0
- [x] Mutation test: forced a wrong Inertia component name and confirmed the smoke script fails with a clear error and exit 1
- [x] Forced a connection-refused DB URL and confirmed the script takes the skip path (warn + exit 0)
- [x] `bun run audit:core-first`, `bun run audit:docs`