### PR TITLE
ci: parallelize package builds and cancel superseded CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,60 @@ jobs:
       - name: Bundle budget audit
         run: bun run audit:bundle-budgets
 
+      - name: Run tests
+        run: bun run test
+
+      - name: Testing package tests (vitest)
+        run: bun run test:testing
+
+  # Scaffolding smokes, split from build-and-test so the unit-test critical
+  # path doesn't wait ~2 minutes for them. They rebuild the packages
+  # themselves and run in parallel with everything else.
+  starter-smokes:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: guren
+          POSTGRES_PASSWORD: guren
+          POSTGRES_DB: guren
+        ports:
+          - 54322:5432
+        options: >-
+          --health-cmd "pg_isready -U guren"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: guren
+          MYSQL_USER: guren
+          MYSQL_PASSWORD: guren
+          MYSQL_DATABASE: guren
+        ports:
+          - 33306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h127.0.0.1 -uguren -pguren"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      APP_KEY: base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.14'
+
+      - run: bun install --frozen-lockfile
+
+      - name: Build packages
+        run: bun run build
+
       - name: Fresh app smoke (default)
         run: bun run smoke:starter
 
@@ -165,15 +219,11 @@ jobs:
       - name: Golden path smoke test (mysql)
         run: bun run smoke:golden-path:mysql
 
-      - name: Run tests
-        run: bun run test
-
-      - name: Testing package tests (vitest)
-        run: bun run test:testing
-
   sqlite-smoke:
     runs-on: ubuntu-latest
-    # No redis service — verifies all tests gracefully skip when Redis is unavailable
+    # No redis service — verifies all tests gracefully skip when Redis is
+    # unavailable. Typecheck is deliberately absent: it is environment-
+    # independent and already covered by build-and-test.
     env:
       APP_KEY: base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
     steps:
@@ -185,7 +235,6 @@ jobs:
       - run: bun run build
       - name: Generate route types
         run: bun run build:routes
-      - run: bun run typecheck
       - name: Run tests (no Redis)
         run: bun run test:bun
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
       - main
   pull_request:
 
+# Superseded runs of the same PR are cancelled; pushes to main always run to
+# completion (each gets its own group via the commit SHA).
+concurrency:
+  group: ci-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,13 @@ on:
     # so a quiet week can still surface new findings.
     - cron: '0 3 * * 1'
 
+# Superseded runs of the same PR are cancelled; pushes to main always run to
+# completion (each gets its own group via the commit SHA), and scheduled runs
+# queue rather than cancel.
+concurrency:
+  group: codeql-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,8 @@ bun run db:seed       # Run seeders
 
 `bun run build` runs `scripts/build-packages.ts`, which discovers every package
 under `packages/` that has a `build` script, topologically sorts them by their
-`dependencies`/`peerDependencies`, and builds them sequentially. **New packages
+`dependencies`/`peerDependencies`, and builds them in dependency order —
+independent packages run in parallel (`--sequential` opts out). **New packages
 (plugins included) need no script wiring** — they are picked up automatically.
 
 ```bash

--- a/scripts/build-packages.ts
+++ b/scripts/build-packages.ts
@@ -27,25 +27,43 @@ import {
   type WorkspacePackage,
 } from './workspace-packages.ts'
 
-/** Returns the child's exit code; a non-zero code means the caller should stop and propagate it. */
-async function build(pkg: WorkspacePackage): Promise<number> {
+/**
+ * Returns the child's exit code; a non-zero code means the caller should stop
+ * and propagate it. Never rejects — the scheduler's bookkeeping depends on
+ * every build settling with a code.
+ */
+async function build(pkg: WorkspacePackage, stream: boolean): Promise<number> {
   const started = Date.now()
-  // Output is buffered and replayed on completion so concurrent builds don't
-  // interleave their lines.
-  const proc = Bun.spawn([process.execPath, 'run', 'build'], {
-    cwd: pkg.dir,
-    stdout: 'pipe',
-    stderr: 'pipe',
-  })
-
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ])
-
-  if (stdout) process.stdout.write(stdout)
-  if (stderr) process.stderr.write(stderr)
+  let exitCode: number
+  try {
+    if (stream) {
+      const proc = Bun.spawn([process.execPath, 'run', 'build'], {
+        cwd: pkg.dir,
+        stdout: 'inherit',
+        stderr: 'inherit',
+      })
+      exitCode = await proc.exited
+    } else {
+      // Output is buffered and replayed on completion so concurrent builds
+      // don't interleave their lines.
+      const proc = Bun.spawn([process.execPath, 'run', 'build'], {
+        cwd: pkg.dir,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      const [stdout, stderr, code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ])
+      if (stdout) process.stdout.write(stdout)
+      if (stderr) process.stderr.write(stderr)
+      exitCode = code
+    }
+  } catch (error) {
+    console.error(`[build] ${pkg.name} did not run:`, error)
+    return 1
+  }
 
   if (exitCode !== 0) {
     console.error(`[build] ${pkg.name} failed with exit code ${exitCode}`)
@@ -64,8 +82,12 @@ async function build(pkg: WorkspacePackage): Promise<number> {
 async function buildAll(
   targets: WorkspacePackage[],
   limit: number,
+  allPackages: WorkspacePackage[],
 ): Promise<number> {
-  const { remainingDeps, dependents } = dependencySchedule(targets)
+  // The closure over the full workspace keeps transitive order for subset
+  // selections: `build server openapi` still runs server before openapi even
+  // though the core package between them is not selected.
+  const { remainingDeps, dependents } = dependencySchedule(targets, allPackages)
 
   // `targets` is already dependency-sorted, so the ready queue starts (and
   // stays) in a deterministic order.
@@ -78,7 +100,7 @@ async function buildAll(
       while (exitCode === 0 && running < limit && ready.length > 0) {
         const pkg = ready.shift()!
         running += 1
-        void build(pkg).then((code) => {
+        void build(pkg, limit === 1).then((code) => {
           running -= 1
           if (code !== 0) {
             if (exitCode === 0) exitCode = code
@@ -112,9 +134,8 @@ const listOnly = flags.list
 // — before filtering, so a buildable package that transitively depends on a
 // non-buildable one keeps its correct relative order. This also rejects any
 // undeclared dependency cycle before the scheduler runs.
-const buildable = sortByDependencies(await collectPackages()).filter(
-  (pkg) => pkg.scripts.build,
-)
+const allPackages = sortByDependencies(await collectPackages())
+const buildable = allPackages.filter((pkg) => pkg.scripts.build)
 const targets = selectPackages(buildable, selectors)
 
 if (listOnly) {
@@ -140,5 +161,5 @@ const limit = flags.sequential
 console.log(`[build] ${targets.map((pkg) => pkg.name).join(' → ')}`)
 if (limit > 1) console.log(`[build] up to ${limit} packages in parallel`)
 
-const exitCode = await buildAll(targets, limit)
+const exitCode = await buildAll(targets, limit, allPackages)
 if (exitCode !== 0) process.exit(exitCode)

--- a/scripts/build-packages.ts
+++ b/scripts/build-packages.ts
@@ -20,7 +20,7 @@ import { join } from 'node:path'
 
 import {
   collectPackages,
-  dependencyGraph,
+  dependencySchedule,
   parseArgs,
   selectPackages,
   sortByDependencies,
@@ -65,18 +65,7 @@ async function buildAll(
   targets: WorkspacePackage[],
   limit: number,
 ): Promise<number> {
-  const graph = dependencyGraph(targets)
-
-  const remainingDeps = new Map<string, number>()
-  const dependents = new Map<string, WorkspacePackage[]>()
-  for (const pkg of targets) {
-    const deps = graph.get(pkg.name)!
-    remainingDeps.set(pkg.name, deps.length)
-    for (const dep of deps) {
-      if (!dependents.has(dep)) dependents.set(dep, [])
-      dependents.get(dep)!.push(pkg)
-    }
-  }
+  const { remainingDeps, dependents } = dependencySchedule(targets)
 
   // `targets` is already dependency-sorted, so the ready queue starts (and
   // stays) in a deterministic order.
@@ -136,9 +125,11 @@ if (listOnly) {
 }
 
 if (clean) {
-  for (const pkg of targets) {
-    await rm(join(pkg.dir, 'dist'), { recursive: true, force: true })
-  }
+  await Promise.all(
+    targets.map((pkg) =>
+      rm(join(pkg.dir, 'dist'), { recursive: true, force: true }),
+    ),
+  )
   console.log(`[build] removed dist/ from ${targets.length} package(s)`)
 }
 

--- a/scripts/build-packages.ts
+++ b/scripts/build-packages.ts
@@ -1,4 +1,5 @@
-// Builds every workspace package under packages/ in dependency order.
+// Builds every workspace package under packages/ in dependency order, running
+// independent packages in parallel (bounded by the machine's core count).
 //
 // The order is derived from each package.json rather than hand-maintained, so
 // adding a package (a plugin, for example) needs no change here or in the root
@@ -7,16 +8,19 @@
 //   bun run ./scripts/build-packages.ts                  # build everything
 //   bun run ./scripts/build-packages.ts --clean          # wipe dist/ first
 //   bun run ./scripts/build-packages.ts --list           # print the order only
+//   bun run ./scripts/build-packages.ts --sequential     # one package at a time
 //   bun run ./scripts/build-packages.ts cli plugin-cloudflare
 //
 // Positional arguments select packages by directory name or package name; the
 // dependency order of the selection is preserved.
 
 import { rm } from 'node:fs/promises'
+import { availableParallelism } from 'node:os'
 import { join } from 'node:path'
 
 import {
   collectPackages,
+  dependencyGraph,
   parseArgs,
   selectPackages,
   sortByDependencies,
@@ -26,13 +30,23 @@ import {
 /** Returns the child's exit code; a non-zero code means the caller should stop and propagate it. */
 async function build(pkg: WorkspacePackage): Promise<number> {
   const started = Date.now()
+  // Output is buffered and replayed on completion so concurrent builds don't
+  // interleave their lines.
   const proc = Bun.spawn([process.execPath, 'run', 'build'], {
     cwd: pkg.dir,
-    stdout: 'inherit',
-    stderr: 'inherit',
+    stdout: 'pipe',
+    stderr: 'pipe',
   })
 
-  const exitCode = await proc.exited
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+
+  if (stdout) process.stdout.write(stdout)
+  if (stderr) process.stderr.write(stderr)
+
   if (exitCode !== 0) {
     console.error(`[build] ${pkg.name} failed with exit code ${exitCode}`)
     return exitCode
@@ -42,16 +56,73 @@ async function build(pkg: WorkspacePackage): Promise<number> {
   return 0
 }
 
+/**
+ * Builds the packages as their dependencies complete, at most `limit` at a
+ * time. On a failure no new builds start; in-flight ones finish and their
+ * output is still printed. Returns the first failure's exit code, or 0.
+ */
+async function buildAll(
+  targets: WorkspacePackage[],
+  limit: number,
+): Promise<number> {
+  const graph = dependencyGraph(targets)
+
+  const remainingDeps = new Map<string, number>()
+  const dependents = new Map<string, WorkspacePackage[]>()
+  for (const pkg of targets) {
+    const deps = graph.get(pkg.name)!
+    remainingDeps.set(pkg.name, deps.length)
+    for (const dep of deps) {
+      if (!dependents.has(dep)) dependents.set(dep, [])
+      dependents.get(dep)!.push(pkg)
+    }
+  }
+
+  // `targets` is already dependency-sorted, so the ready queue starts (and
+  // stays) in a deterministic order.
+  const ready = targets.filter((pkg) => remainingDeps.get(pkg.name) === 0)
+  let running = 0
+  let exitCode = 0
+
+  await new Promise<void>((done) => {
+    const pump = (): void => {
+      while (exitCode === 0 && running < limit && ready.length > 0) {
+        const pkg = ready.shift()!
+        running += 1
+        void build(pkg).then((code) => {
+          running -= 1
+          if (code !== 0) {
+            if (exitCode === 0) exitCode = code
+          } else {
+            for (const dependent of dependents.get(pkg.name) ?? []) {
+              const left = remainingDeps.get(dependent.name)! - 1
+              remainingDeps.set(dependent.name, left)
+              if (left === 0) ready.push(dependent)
+            }
+          }
+          pump()
+        })
+      }
+      if (running === 0 && (exitCode !== 0 || ready.length === 0)) done()
+    }
+    pump()
+  })
+
+  return exitCode
+}
+
 const { flags, positionals: selectors } = parseArgs(process.argv.slice(2), [
   'clean',
   'list',
+  'sequential',
 ])
 const clean = flags.clean
 const listOnly = flags.list
 
 // Sort the full workspace graph — including packages without a `build` script
 // — before filtering, so a buildable package that transitively depends on a
-// non-buildable one keeps its correct relative order.
+// non-buildable one keeps its correct relative order. This also rejects any
+// undeclared dependency cycle before the scheduler runs.
 const buildable = sortByDependencies(await collectPackages()).filter(
   (pkg) => pkg.scripts.build,
 )
@@ -71,9 +142,12 @@ if (clean) {
   console.log(`[build] removed dist/ from ${targets.length} package(s)`)
 }
 
-console.log(`[build] ${targets.map((pkg) => pkg.name).join(' → ')}`)
+const limit = flags.sequential
+  ? 1
+  : Math.max(1, Math.min(availableParallelism(), targets.length))
 
-for (const pkg of targets) {
-  const exitCode = await build(pkg)
-  if (exitCode !== 0) process.exit(exitCode)
-}
+console.log(`[build] ${targets.map((pkg) => pkg.name).join(' → ')}`)
+if (limit > 1) console.log(`[build] up to ${limit} packages in parallel`)
+
+const exitCode = await buildAll(targets, limit)
+if (exitCode !== 0) process.exit(exitCode)

--- a/scripts/workspace-packages.ts
+++ b/scripts/workspace-packages.ts
@@ -116,25 +116,49 @@ export interface DependencySchedule {
 /**
  * The Kahn bookkeeping shared by the topological sort and the parallel build
  * scheduler: in-workspace dependency counts and the reverse index, with
- * `ignoredEdges` removed. Only packages present in `packages` count as
- * dependencies, so a subset selection treats its outside dependencies as
- * already satisfied. Returns fresh maps — callers mutate `remainingDeps` as
- * packages complete.
+ * `ignoredEdges` removed. Returns fresh maps — callers mutate `remainingDeps`
+ * as packages complete.
+ *
+ * When `closureThrough` is wider than `packages` (a subset selection), edges
+ * are followed through the unselected packages, so `server` still orders
+ * before `openapi` when `core` sits between them but is not selected.
+ * Dependencies outside `closureThrough` entirely are treated as satisfied.
  */
 export function dependencySchedule(
   packages: WorkspacePackage[],
+  closureThrough: WorkspacePackage[] = packages,
 ): DependencySchedule {
-  const byName = new Map(packages.map((pkg) => [pkg.name, pkg]))
+  const selected = new Set(packages.map((pkg) => pkg.name))
+  const byName = new Map(closureThrough.map((pkg) => [pkg.name, pkg]))
   const ignored = new Set(ignoredEdges.map(([from, to]) => `${from} ${to}`))
+
+  const directDeps = (pkg: WorkspacePackage): string[] =>
+    pkg.dependencies.filter(
+      (dep) => byName.has(dep) && !ignored.has(`${pkg.name} ${dep}`),
+    )
 
   const remainingDeps = new Map<string, number>()
   const dependents = new Map<string, WorkspacePackage[]>()
 
   for (const pkg of packages) {
-    const deps = pkg.dependencies.filter(
-      (dep) => byName.has(dep) && !ignored.has(`${pkg.name} ${dep}`),
-    )
-    remainingDeps.set(pkg.name, deps.length)
+    // BFS that stops at selected packages and traverses through unselected
+    // ones. With closureThrough === packages every dependency is selected, so
+    // this degenerates to the direct-edge case the sorter uses.
+    const deps = new Set<string>()
+    const visited = new Set<string>()
+    const queue = directDeps(pkg)
+    while (queue.length > 0) {
+      const name = queue.shift()!
+      if (visited.has(name)) continue
+      visited.add(name)
+      if (selected.has(name)) {
+        deps.add(name)
+        continue
+      }
+      queue.push(...directDeps(byName.get(name)!))
+    }
+
+    remainingDeps.set(pkg.name, deps.size)
     for (const dep of deps) {
       if (!dependents.has(dep)) dependents.set(dep, [])
       dependents.get(dep)!.push(pkg)

--- a/scripts/workspace-packages.ts
+++ b/scripts/workspace-packages.ts
@@ -106,9 +106,14 @@ const ignoredEdges: Array<[dependent: string, dependency: string]> = [
   ['@guren/core', '@guren/cli'],
 ]
 
-export function sortByDependencies(
+/**
+ * In-workspace dependencies per package name, with `ignoredEdges` removed.
+ * Only packages present in `packages` appear as keys or as dependencies, so a
+ * subset selection treats its outside dependencies as already satisfied.
+ */
+export function dependencyGraph(
   packages: WorkspacePackage[],
-): WorkspacePackage[] {
+): Map<string, string[]> {
   const byName = new Map(packages.map((pkg) => [pkg.name, pkg]))
   const ignored = new Set(ignoredEdges.map(([from, to]) => `${from} ${to}`))
 
@@ -121,6 +126,23 @@ export function sortByDependencies(
     }
   }
 
+  const graph = new Map<string, string[]>()
+  for (const pkg of packages) {
+    graph.set(
+      pkg.name,
+      pkg.dependencies.filter(
+        (dep) => byName.has(dep) && !ignored.has(`${pkg.name} ${dep}`),
+      ),
+    )
+  }
+  return graph
+}
+
+export function sortByDependencies(
+  packages: WorkspacePackage[],
+): WorkspacePackage[] {
+  const graph = dependencyGraph(packages)
+
   // Kahn's algorithm: track each package's remaining dependency count and the
   // set of packages waiting on it, so finishing one package only touches its
   // actual dependents instead of rescanning every still-pending package.
@@ -128,9 +150,7 @@ export function sortByDependencies(
   const dependents = new Map<string, WorkspacePackage[]>()
 
   for (const pkg of packages) {
-    const deps = pkg.dependencies.filter(
-      (dep) => byName.has(dep) && !ignored.has(`${pkg.name} ${dep}`),
-    )
+    const deps = graph.get(pkg.name)!
     remainingDeps.set(pkg.name, deps.length)
     for (const dep of deps) {
       if (!dependents.has(dep)) dependents.set(dep, [])

--- a/scripts/workspace-packages.ts
+++ b/scripts/workspace-packages.ts
@@ -106,17 +106,50 @@ const ignoredEdges: Array<[dependent: string, dependency: string]> = [
   ['@guren/core', '@guren/cli'],
 ]
 
+export interface DependencySchedule {
+  /** Count of unsatisfied in-workspace dependencies per package name. */
+  remainingDeps: Map<string, number>
+  /** Packages waiting on each package name. */
+  dependents: Map<string, WorkspacePackage[]>
+}
+
 /**
- * In-workspace dependencies per package name, with `ignoredEdges` removed.
- * Only packages present in `packages` appear as keys or as dependencies, so a
- * subset selection treats its outside dependencies as already satisfied.
+ * The Kahn bookkeeping shared by the topological sort and the parallel build
+ * scheduler: in-workspace dependency counts and the reverse index, with
+ * `ignoredEdges` removed. Only packages present in `packages` count as
+ * dependencies, so a subset selection treats its outside dependencies as
+ * already satisfied. Returns fresh maps — callers mutate `remainingDeps` as
+ * packages complete.
  */
-export function dependencyGraph(
+export function dependencySchedule(
   packages: WorkspacePackage[],
-): Map<string, string[]> {
+): DependencySchedule {
   const byName = new Map(packages.map((pkg) => [pkg.name, pkg]))
   const ignored = new Set(ignoredEdges.map(([from, to]) => `${from} ${to}`))
 
+  const remainingDeps = new Map<string, number>()
+  const dependents = new Map<string, WorkspacePackage[]>()
+
+  for (const pkg of packages) {
+    const deps = pkg.dependencies.filter(
+      (dep) => byName.has(dep) && !ignored.has(`${pkg.name} ${dep}`),
+    )
+    remainingDeps.set(pkg.name, deps.length)
+    for (const dep of deps) {
+      if (!dependents.has(dep)) dependents.set(dep, [])
+      dependents.get(dep)!.push(pkg)
+    }
+  }
+
+  return { remainingDeps, dependents }
+}
+
+export function sortByDependencies(
+  packages: WorkspacePackage[],
+): WorkspacePackage[] {
+  // The stale check lives here rather than in dependencySchedule so it prints
+  // once per run — every build/test entry point sorts before scheduling.
+  const byName = new Map(packages.map((pkg) => [pkg.name, pkg]))
   for (const [from, to] of ignoredEdges) {
     const dependent = byName.get(from)
     if (dependent && !dependent.dependencies.includes(to)) {
@@ -126,37 +159,7 @@ export function dependencyGraph(
     }
   }
 
-  const graph = new Map<string, string[]>()
-  for (const pkg of packages) {
-    graph.set(
-      pkg.name,
-      pkg.dependencies.filter(
-        (dep) => byName.has(dep) && !ignored.has(`${pkg.name} ${dep}`),
-      ),
-    )
-  }
-  return graph
-}
-
-export function sortByDependencies(
-  packages: WorkspacePackage[],
-): WorkspacePackage[] {
-  const graph = dependencyGraph(packages)
-
-  // Kahn's algorithm: track each package's remaining dependency count and the
-  // set of packages waiting on it, so finishing one package only touches its
-  // actual dependents instead of rescanning every still-pending package.
-  const remainingDeps = new Map<string, number>()
-  const dependents = new Map<string, WorkspacePackage[]>()
-
-  for (const pkg of packages) {
-    const deps = graph.get(pkg.name)!
-    remainingDeps.set(pkg.name, deps.length)
-    for (const dep of deps) {
-      if (!dependents.has(dep)) dependents.set(dep, [])
-      dependents.get(dep)!.push(pkg)
-    }
-  }
+  const { remainingDeps, dependents } = dependencySchedule(packages)
 
   const queue = packages.filter((pkg) => remainingDeps.get(pkg.name) === 0)
   const ordered: WorkspacePackage[] = []


### PR DESCRIPTION
## Summary

- Parallelize `scripts/build-packages.ts`: independent workspace packages now build concurrently (bounded by core count) instead of strictly one at a time. `--sequential` opts back into the old one-at-a-time behavior with live-streamed output.
- Move the eight fresh-app/golden-path smoke steps (~110s) out of `build-and-test` into their own `starter-smokes` job that runs in parallel, so the unit-test suite no longer waits behind them. Drop the redundant environment-independent typecheck from `sqlite-smoke`.
- Add `concurrency` blocks to `ci.yml` and `codeql.yml` so a force-pushed/updated PR cancels its own superseded runs instead of burning runner minutes on stale ones; pushes to `main` always run to completion.
- Extract the Kahn indegree/dependents bookkeeping shared between `sortByDependencies` and the new scheduler into `dependencySchedule()` in `scripts/workspace-packages.ts`.

## Why

CI wall time had crept up; investigation showed `build-and-test` was the critical path, with the sequential `bun run build` (~116s) and the inline smoke steps (~110s) dominating it — the actual test suite (3763 tests) only takes ~40s.

## Measured result

CI wall time on this branch: **~6:35 → 4:16** (run 10:09–10:13 UTC, all jobs green). `build-and-test` went from 6:18 to 4:13; `starter-smokes` finishes in parallel at 4:09; `sqlite-smoke` dropped from 2:55 to 2:21.

## Notable review findings fixed before merge

An independent Codex review and a 4-angle `/simplify` pass caught two real bugs in the initial scheduler, both fixed on this branch:

- **Subset builds could lose transitive ordering.** `bun run build server openapi` treats packages outside the selection as already-satisfied dependencies, so if an unselected package (e.g. `core`) sits between two selected ones, they'd build concurrently instead of in order. Fixed by having `dependencySchedule()` traverse edges through the full workspace closure, not just the selected subset.
- **A spawn failure would hang the scheduler forever.** `build()`'s promise had no rejection handler, so `Bun.spawn` throwing (e.g. missing cwd) left the running-count stuck and the run never completing. `build()` now always resolves with an exit code.

`/simplify` also caught the stale-`ignoredEdges` warning firing twice per run (now prints once, back at the topological-sort entry point) and parallelized the `--clean` `dist/` removal.

## Test plan

- [x] `bun run build:clean` (full parallel build) — succeeds
- [x] `bun run build server openapi` — verified server (29s) completes before openapi (4s) starts, confirming transitive order is preserved through the unselected `core` package
- [x] `bun run build --sequential create-app` — streams output live, single-package build succeeds
- [x] Mutation test: forced `@guren/server`'s build script to `exit 3` — dependents never started and the exit code propagated correctly
- [x] Verified `Bun.spawn` with a nonexistent cwd throws, confirming the new try/catch in `build()` is reachable
- [x] `bun run typecheck` (root) — passes
- [x] `bun run test:bun` — 3723 tests pass; `bun run test:examples` — 251 tests pass
- [x] `bun run audit:docs`, `bun run audit:core-first` — pass
- [x] CI on this branch: all five jobs green with the new topology, wall time 4:16