### PR TITLE
ci: audit workspace scripts for registry-resolved guren invocations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,12 @@ jobs:
       - name: Core-first audit
         run: bun run audit:core-first
 
+      # `guren` is not on npm: `bunx guren` in a workspace manifest 404s
+      # whenever the local .bin link is missing. Template trees are exempt —
+      # scaffolded apps install @guren/cli from npm and get a real bin.
+      - name: Workspace scripts audit
+        run: bun run audit:workspace-scripts
+
       - name: Contract audit
         run: bun run audit:contracts
 

--- a/examples/api/config/app.ts
+++ b/examples/api/config/app.ts
@@ -5,7 +5,7 @@ let bootstrapped = false
 /**
  * Seeding is one-shot provisioning, not part of booting: production boots
  * repeatedly on serverless cold starts, and a bundle has no resolver for the
- * raw db/seeders/*.ts files. Run `bunx guren db:seed` explicitly instead.
+ * raw db/seeders/*.ts files. Run `bun run db:seed` explicitly instead.
  */
 function shouldSeedOnBoot(): boolean {
   return process.env.NODE_ENV !== 'production'

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -7,10 +7,10 @@
     "dev": "bun --hot bin/serve.ts",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "openapi:generate": "bunx guren openapi:generate --routes routes/api.ts --title \"Guren Example API\" --version \"0.1.0\" --description \"Example API for authentication, tokens, and task management.\" --out .guren/openapi.gen.json",
-    "db:make": "bunx guren make:migration",
-    "db:migrate": "bunx guren db:migrate",
-    "db:seed": "bunx guren db:seed"
+    "openapi:generate": "bun ../../packages/cli/src/bin.ts openapi:generate --routes routes/api.ts --title \"Guren Example API\" --version \"0.1.0\" --description \"Example API for authentication, tokens, and task management.\" --out .guren/openapi.gen.json",
+    "db:make": "bun ../../packages/cli/src/bin.ts make:migration",
+    "db:migrate": "bun ../../packages/cli/src/bin.ts db:migrate",
+    "db:seed": "bun ../../packages/cli/src/bin.ts db:seed"
   },
   "dependencies": {
     "@guren/cli": "workspace:*",

--- a/examples/blog/config/app.ts
+++ b/examples/blog/config/app.ts
@@ -20,7 +20,7 @@ function hasMigrations(): boolean {
 /**
  * Seeding is one-shot provisioning, not part of booting: production boots
  * repeatedly on serverless cold starts, and a bundle has no resolver for the
- * raw db/seeders/*.ts files. Run `bunx guren db:seed` explicitly instead.
+ * raw db/seeders/*.ts files. Run `bun run db:seed` explicitly instead.
  */
 function shouldSeedOnBoot(): boolean {
   return process.env.NODE_ENV !== 'production'

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -17,9 +17,9 @@
     "e2e:ui": "playwright test --ui",
     "typecheck": "tsc --noEmit",
     "preview": "NODE_ENV=production bun bin/serve.ts",
-    "db:make": "bunx guren make:migration",
-    "db:migrate": "bunx guren db:migrate",
-    "db:seed": "bunx guren db:seed"
+    "db:make": "bun ../../packages/cli/src/bin.ts make:migration",
+    "db:migrate": "bun ../../packages/cli/src/bin.ts db:migrate",
+    "db:seed": "bun ../../packages/cli/src/bin.ts db:seed"
   },
   "dependencies": {
     "@guren/cli": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build:create-app": "bun run --cwd packages/create-app build",
     "build:inertia": "bun run --cwd packages/inertia-client build",
     "audit:core-first": "bun run ./scripts/smoke/core-first-audit.ts",
+    "audit:workspace-scripts": "bun run ./scripts/smoke/workspace-scripts-audit.ts",
     "audit:contracts": "bun run ./scripts/smoke/contract-audit.ts",
     "audit:feature-runtime": "bun run ./scripts/smoke/feature-runtime-audit.ts",
     "audit:bundle-budgets": "bun run ./scripts/smoke/build-budget.ts --max-kb 600",

--- a/scripts/smoke/workspace-scripts-audit.ts
+++ b/scripts/smoke/workspace-scripts-audit.ts
@@ -19,10 +19,39 @@ import { dirname, join, resolve } from 'node:path'
 const repoRoot = resolve(import.meta.dir, '../..')
 
 // `bunx guren`, `bunx --bun guren`, `bun x guren`, `npx guren`, `pnpm dlx
-// guren`, `guren@…` — the registry-resolving spellings of the CLI. The
-// trailing lookahead keeps distinct packages (`guren-cli`, `guren/foo`) out.
-const REGISTRY_GUREN =
-  /\b(?:bunx|bun\s+x|npx|npm\s+exec|pnpm\s+(?:dlx|exec)|yarn\s+(?:dlx|exec))\s+(?:--?\S+\s+)*guren(?=\s|$|@)/
+// guren`, `guren@…` — the registry-resolving spellings of the CLI, as token
+// sequences rather than a regex: a run of `--flag`/`-f` tokens between the
+// runner and `guren` is unbounded and package-manager flags are unbounded
+// too, and a regex expressing "skip N flag tokens" backtracks exponentially
+// on pathological input (CodeQL flagged exactly this). A token scan is
+// linear by construction.
+const RUNNER_TOKEN_SEQUENCES: readonly (readonly string[])[] = [
+  ['bunx'],
+  ['bun', 'x'],
+  ['npx'],
+  ['npm', 'exec'],
+  ['pnpm', 'dlx'],
+  ['pnpm', 'exec'],
+  ['yarn', 'dlx'],
+  ['yarn', 'exec'],
+]
+
+function isGurenTarget(token: string): boolean {
+  return token === 'guren' || token.startsWith('guren@')
+}
+
+function invokesRegistryGuren(command: string): boolean {
+  const tokens = command.split(/\s+/).filter(Boolean)
+  for (let i = 0; i < tokens.length; i++) {
+    for (const sequence of RUNNER_TOKEN_SEQUENCES) {
+      if (!sequence.every((expected, offset) => tokens[i + offset] === expected)) continue
+      let next = i + sequence.length
+      while (next < tokens.length && tokens[next].startsWith('-')) next++
+      if (next < tokens.length && isGurenTarget(tokens[next])) return true
+    }
+  }
+  return false
+}
 
 // The sanctioned replacement, when spelled dot-relative. Cwd-shifting forms
 // (`cd .. && bun packages/cli/src/bin.ts …`) can't be resolved statically and
@@ -43,7 +72,7 @@ interface Violation {
 function collectViolations(manifestPath: string, manifest: Manifest): Violation[] {
   const violations: Violation[] = []
   for (const [script, command] of Object.entries(manifest.scripts ?? {})) {
-    if (REGISTRY_GUREN.test(command)) {
+    if (invokesRegistryGuren(command)) {
       violations.push({
         manifest: manifestPath,
         script,

--- a/scripts/smoke/workspace-scripts-audit.ts
+++ b/scripts/smoke/workspace-scripts-audit.ts
@@ -1,0 +1,103 @@
+// Asserts that no workspace-internal package.json script invokes the CLI as
+// `bunx guren` (or `bun x guren` / `npx guren`).
+//
+// The `guren` package does not exist on npm. Inside this checkout the CLI is
+// only reachable through the workspace link (`node_modules/.bin/guren`), and
+// whenever that link is missing — fresh clone, partial install, CI cache — the
+// runner falls back to the registry and dies on a 404. Workspace apps must run
+// the CLI source directly: `bun <path-to>/packages/cli/src/bin.ts`.
+//
+// Scope: the root manifest plus every workspace member resolved from the root
+// `workspaces` globs. Template trees (`packages/create-app/templates/**`,
+// `packages/cli/templates/**`) are structurally out of scope — they are not
+// workspace members — and `bunx guren` is *correct* there, because scaffolded
+// apps install @guren/cli from npm and get a real `node_modules/.bin/guren`.
+
+import { existsSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+
+const repoRoot = resolve(import.meta.dir, '../..')
+
+// `bunx guren`, `bunx --bun guren`, `bun x guren`, `npx guren`, `pnpm dlx
+// guren`, `guren@…` — the registry-resolving spellings of the CLI. The
+// trailing lookahead keeps distinct packages (`guren-cli`, `guren/foo`) out.
+const REGISTRY_GUREN =
+  /\b(?:bunx|bun\s+x|npx|npm\s+exec|pnpm\s+(?:dlx|exec)|yarn\s+(?:dlx|exec))\s+(?:--?\S+\s+)*guren(?=\s|$|@)/
+
+// The sanctioned replacement, when spelled dot-relative. Cwd-shifting forms
+// (`cd .. && bun packages/cli/src/bin.ts …`) can't be resolved statically and
+// are left to the negative check above.
+const RELATIVE_CLI_PATH = /\bbun\s+((?:\.\.?\/)\S*packages\/cli\/src\/bin\.ts)\b/g
+
+interface Manifest {
+  workspaces?: string[]
+  scripts?: Record<string, string>
+}
+
+interface Violation {
+  manifest: string
+  script: string
+  problem: string
+}
+
+function collectViolations(manifestPath: string, manifest: Manifest): Violation[] {
+  const violations: Violation[] = []
+  for (const [script, command] of Object.entries(manifest.scripts ?? {})) {
+    if (REGISTRY_GUREN.test(command)) {
+      violations.push({
+        manifest: manifestPath,
+        script,
+        problem: `resolves \`guren\` from the registry: ${command}`,
+      })
+    }
+    for (const [, cliPath] of command.matchAll(RELATIVE_CLI_PATH)) {
+      if (!existsSync(resolve(repoRoot, dirname(manifestPath), cliPath))) {
+        violations.push({
+          manifest: manifestPath,
+          script,
+          problem: `points at a CLI entry that does not exist from this directory: ${cliPath}`,
+        })
+      }
+    }
+  }
+  return violations
+}
+
+async function main(): Promise<void> {
+  const rootManifest = (await Bun.file(join(repoRoot, 'package.json')).json()) as Manifest
+  if (!Array.isArray(rootManifest.workspaces) || rootManifest.workspaces.length === 0) {
+    throw new Error('Root package.json declares no workspaces — audit scope would be empty.')
+  }
+
+  const memberManifestPaths: string[] = []
+  for (const pattern of rootManifest.workspaces) {
+    const glob = new Bun.Glob(`${pattern}/package.json`)
+    for await (const path of glob.scan({ cwd: repoRoot })) {
+      memberManifestPaths.push(path)
+    }
+  }
+  memberManifestPaths.sort()
+
+  if (memberManifestPaths.length === 0) {
+    throw new Error('No workspace members resolved — the workspaces globs no longer match this audit.')
+  }
+
+  const violations = collectViolations('package.json', rootManifest)
+  for (const manifestPath of memberManifestPaths) {
+    const manifest = (await Bun.file(join(repoRoot, manifestPath)).json()) as Manifest
+    violations.push(...collectViolations(manifestPath, manifest))
+  }
+
+  if (violations.length > 0) {
+    console.error('Workspace scripts audit failed: `guren` is not published to npm, so scripts must run packages/cli/src/bin.ts directly — and through a path that resolves.')
+    for (const { manifest, script, problem } of violations) {
+      console.error(`  ${manifest} → "${script}" ${problem}`)
+    }
+    console.error('Fix: run the CLI source directly, e.g. `bun ../../packages/cli/src/bin.ts <command>` (adjust the relative path to the member directory).')
+    process.exit(1)
+  }
+
+  console.log(`Workspace scripts audit passed: ${memberManifestPaths.length} workspace members + root manifest invoke the CLI locally.`)
+}
+
+await main()

--- a/web/config/app.ts
+++ b/web/config/app.ts
@@ -44,7 +44,7 @@ export async function bootModels(): Promise<void> {
     // D1 seeding is a CLI workflow (`wrangler d1 execute`); the factory's
     // seedDatabase() intentionally throws on Workers. Seeding is also one-shot
     // provisioning rather than part of booting, so it stays out of production
-    // boots on every runtime — run `bunx guren db:seed` explicitly instead.
+    // boots on every runtime — run `bun run db:seed` explicitly instead.
     if (!isWorkersRuntime() && process.env.NODE_ENV !== 'production') {
       await seedDatabase()
     }

--- a/web/package.json
+++ b/web/package.json
@@ -14,9 +14,9 @@
     "test": "bun run prerender:stub && bunx vitest run",
     "build": "bun run codegen && bun run prerender && bunx vite build && bunx vite build --ssr",
     "preview": "NODE_ENV=production bun bin/serve.ts",
-    "db:make": "bunx guren make:migration",
-    "db:migrate": "bunx guren db:migrate",
-    "db:seed": "bunx guren db:seed",
+    "db:make": "bun ../packages/cli/src/bin.ts make:migration",
+    "db:migrate": "bun ../packages/cli/src/bin.ts db:migrate",
+    "db:seed": "bun ../packages/cli/src/bin.ts db:seed",
     "cloudflare:build": "bun run build && bun scripts/cloudflare-build.ts",
     "deploy:cloudflare": "bun run cloudflare:build && bunx wrangler deploy"
   },


### PR DESCRIPTION
## Summary

- `guren` is not published to npm, so `bunx guren` in a workspace member's `package.json` scripts falls back to a registry 404 whenever bun has not linked a local `.bin/guren` — this has already broken `examples/blog`, `examples/api`, and `web`.
- Add `scripts/smoke/workspace-scripts-audit.ts`, wired as `audit:workspace-scripts` in CI (alongside `audit:core-first` and friends). It resolves members from the root `workspaces` globs and fails on any registry-resolving spelling of the CLI (`bunx`/`bun x`/`npx`/`npm exec`/`pnpm dlx`/`yarn dlx`). It also verifies that dot-relative `bun …/packages/cli/src/bin.ts` replacements actually resolve from their member directory, so a copy-pasted wrong relative depth fails the audit instead of dying at run time.
- Template trees (`packages/create-app/templates/**`, `packages/cli/templates/**`) are out of scope by construction — they aren't workspace members, and `bunx guren` is correct there since scaffolded apps install `@guren/cli` from npm.
- Rewrite the existing violations in `examples/blog`, `examples/api`, and `web` to run `packages/cli/src/bin.ts` directly, and point the seeding comments at `bun run db:seed` instead of a hardcoded CLI invocation.

Reviewed with Codex + `/simplify` (4 parallel angles) before merge; findings applied: replaced hand-rolled glob expansion with `Bun.Glob`, made manifest parsing fail loud instead of silently skipping malformed members, fixed a regex false-positive (`guren-cli`/`guren/foo` matching), and extended the registry-spelling coverage to `npm exec`/`pnpm dlx`/`yarn dlx`.

A follow-up was flagged separately (not in this PR): `packages/cli/src/vite/route-types.ts:37` spawns the CLI via `bun x --bun guren`, which has the same registry-404 exposure inside this monorepo, papered over today by a `process.env.CI` early-return. Fixing that needs to resolve `@guren/cli`'s own entry rather than a hardcoded monorepo path, since the plugin also ships to npm-installed scaffolded apps.

## Test plan

- [x] `bun run audit:workspace-scripts` passes (14 workspace members + root)
- [x] Mutation-tested the audit: `bunx guren`, `pnpm dlx guren`, and a wrong-depth `bun ../packages/cli/src/bin.ts` each fail with exit 1; restoring passes again
- [x] Verified rewritten CLI paths resolve and run (`--help`) from `examples/blog`, `examples/api`, and `web`
- [x] `bun run typecheck` (root) passes
- [x] `bun run audit:core-first`, `audit:docs`, `audit:template-deps` pass