### PR TITLE
fix(cli): resolve the guren bin from @guren/cli instead of bun x

### DIFF
--- a/.claude/rules/common-pitfalls.md
+++ b/.claude/rules/common-pitfalls.md
@@ -18,7 +18,7 @@ Lessons learned from code review cycles. Check these before submitting changes.
 ## CI Environment
 
 - **Never use `bunx guren` in CI.** The `guren` package is not on npm. Use `bun packages/cli/src/bin.ts` directly.
-- **Vite route-types plugin calls `bunx guren` internally.** The plugin skips generation when `process.env.CI` is set.
+- **Vite route-types plugin resolves `@guren/cli/bin` and spawns it with `bun` directly** (no `bunx guren`, which 404s in this monorepo). It still skips generation when `process.env.CI` is set — CI runs codegen as its own step, and watcher-triggered regeneration during E2E would be nondeterministic.
 - **E2E webServer in CI uses `bun run e2e:server`** — not `bun run dev` (triggers codegen) and not `bun run dev:server` (runs under `bun --hot`, so the server would reload mid-test if anything touched a watched file).
 - **`bun run --cwd` with `bunx` can resolve from npm instead of local.** Use `cd dir && bun ...` or direct paths.
 

--- a/packages/cli/src/vite/route-types.ts
+++ b/packages/cli/src/vite/route-types.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process'
 import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import type { HmrContext, Logger, Plugin, ResolvedConfig, ViteDevServer } from 'vite'
 
 export interface RouteTypesPluginOptions {
@@ -24,7 +25,8 @@ export interface RouteTypesPluginOptions {
    */
   executable?: string
   /**
-   * Arguments passed to the executable. Defaults to `['x', '--bun', 'guren', 'codegen', '--force']`.
+   * Arguments passed to the executable. Defaults to running this package's own
+   * `guren` bin entry with `['codegen', '--force']`.
    */
   args?: string[]
   /**
@@ -34,12 +36,23 @@ export interface RouteTypesPluginOptions {
 }
 
 const DEFAULT_EXECUTABLE = 'bun'
-const DEFAULT_ARGS = ['x', '--bun', 'guren', 'codegen', '--force']
 const DEFAULT_WATCH_FILE = 'routes/web.ts'
 const DEFAULT_PAGES_DIR = 'resources/js/pages'
 const DEFAULT_RESOURCES_DIR = 'app/Http/Resources'
 // Fixed by convention across codegen and check (see cli/src/i18n-types.ts).
 const DEFAULT_LANG_DIR = 'lang'
+
+let cachedDefaultArgs: string[] | undefined
+
+// Self-referencing this package's name needs no linked `.bin/guren` (`bun x
+// guren` consults the npm registry, where the package does not exist) and
+// works for workspace links and npm installs alike. Lazy so consumers who
+// override `args` never resolve, and a failure surfaces through the
+// generation error path instead of breaking the module import.
+function defaultArgs(): string[] {
+  cachedDefaultArgs ??= [fileURLToPath(import.meta.resolve('@guren/cli/bin')), 'codegen', '--force']
+  return cachedDefaultArgs
+}
 
 export function routeTypesPlugin(options: RouteTypesPluginOptions = {}): Plugin {
   let appRoot = options.appRoot
@@ -59,7 +72,7 @@ export function routeTypesPlugin(options: RouteTypesPluginOptions = {}): Plugin 
   function spawnGenerator(root: string): Promise<void> {
     return new Promise((resolvePromise, rejectPromise) => {
       const executable = options.executable ?? DEFAULT_EXECUTABLE
-      const args = options.args ?? DEFAULT_ARGS
+      const args = options.args ?? defaultArgs()
       const child = spawn(executable, args, {
         cwd: root,
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -96,6 +109,10 @@ export function routeTypesPlugin(options: RouteTypesPluginOptions = {}): Plugin 
   }
 
   function enqueueGeneration(root: string): Promise<void> {
+    // CI runs codegen as its own build step; regenerating there — including
+    // from watcher or HMR events mid-E2E — would only add nondeterminism.
+    if (process.env.CI) return queue
+
     queue = queue
       .then(() => spawnGenerator(root))
       .catch((error) => {
@@ -128,8 +145,6 @@ export function routeTypesPlugin(options: RouteTypesPluginOptions = {}): Plugin 
     async configResolved(config: ResolvedConfig) {
       appRoot = resolve(config.root, options.appRoot ?? '.')
       logger = config.logger
-      // Skip route type generation in CI (codegen runs as a separate build step)
-      if (process.env.CI) return
       await enqueueGeneration(appRoot)
     },
     configureServer(server: ViteDevServer) {
@@ -137,7 +152,6 @@ export function routeTypesPlugin(options: RouteTypesPluginOptions = {}): Plugin 
       // page, resource, or translation file must regenerate too.
       const root = () => appRoot ?? server.config.root
       const onFileEvent = (file: string) => {
-        if (process.env.CI) return
         if (shouldRegenerate(root(), file)) {
           void enqueueGeneration(root())
         }


### PR DESCRIPTION
## Summary

- The `routeTypesPlugin` Vite plugin defaulted to spawning `bun x --bun guren codegen --force` to regenerate route types. `guren` is not published to npm, so whenever bun had not linked a workspace `.bin/guren` (as in this monorepo), `bun x` fell through to a registry lookup and 404'd instead of running codegen.
- Resolve the CLI's own `./bin` export instead, via `import.meta.resolve('@guren/cli/bin')` — this resolves correctly for both workspace links and npm installs, with no dependency on a linked bin and no hardcoded monorepo path.
- Collapsed the three duplicated `process.env.CI` early-returns into a single check inside `enqueueGeneration`. The old per-call-site guards were missing from `handleHotUpdate`, so watcher-triggered HMR could still regenerate types during CI/E2E runs.

## Test plan

- [x] `bun run build:clean` — full monorepo build green
- [x] `bun run typecheck` (root) — green
- [x] `bun run test:bun cli` — 1159 pass, 0 fail
- [x] Verified the plugin against a built `dist/vite/index.js`, invoking `configResolved`/`handleHotUpdate` under both Bun and Node, in both normal and `CI=1` modes — codegen runs and produces all expected artifacts with no errors in normal mode, and produces zero output in CI mode (including through `handleHotUpdate`, closing the previous gap)
- [x] `bun run smoke:starter` — full fresh-app scaffold + vite build shows successful `[guren-route-types]` generation logs with the new bin-resolution default, no fallback triggered
- [x] `bun run audit:core-first` / `bun run audit:docs` — green