### PR TITLE
ci: cache built package dist/ and Playwright browsers

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -1,0 +1,50 @@
+name: Set up Bun and build packages
+description: >-
+  setup-bun, restore packages/*/dist from an exact-match cache, install
+  dependencies, and run the package build only on a cache miss. Owning the
+  whole coupled unit here keeps the cache key — the correctness mechanism —
+  in exactly one place, and keeps the Bun version in the toolchain and in the
+  key from ever drifting apart.
+
+inputs:
+  bun-version:
+    description: Bun version to install; also part of the dist cache key.
+    required: false
+    default: '1.3.14'
+
+outputs:
+  cache-hit:
+    description: Whether dist/ was restored from an exact cache match.
+    value: ${{ steps.dist-cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    # Exact-match only (no restore-keys): a partial hit would restore a stale
+    # dist/, this repo's best-documented footgun. The key covers every build
+    # input — package sources and configs, the root package.json defining the
+    # build command, the lockfile, the root tsconfig the packages extend, the
+    # build scripts (build order affects DTS output), and the Bun version —
+    # so a hit means dist/ is byte-for-byte what a fresh build would produce.
+    # The negations drop files verified NOT to feed tsup (tests, templates
+    # read at runtime, changelogs, a stray tarball), so test-only or
+    # template-only changes keep hitting the cache.
+    - name: Restore built packages
+      id: dist-cache
+      uses: actions/cache@v4
+      with:
+        path: packages/*/dist
+        key: dist-${{ runner.os }}-bun${{ inputs.bun-version }}-${{ hashFiles('packages/**', '!packages/**/*.test.ts', '!packages/*/templates/**', '!packages/*/tests/**', '!packages/**/CHANGELOG.md', '!packages/**/*.tgz', 'package.json', 'bun.lock', 'tsconfig.json', 'scripts/build-packages.ts', 'scripts/workspace-packages.ts') }}
+
+    - name: Install dependencies
+      shell: bash
+      run: bun install --frozen-lockfile
+
+    - name: Build packages
+      if: steps.dist-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,22 @@ jobs:
         with:
           bun-version: ${{ matrix.bun-version }}
 
+      # Exact-match only (no restore-keys): a partial hit would restore a
+      # stale dist/, this repo's best-documented footgun. The key covers every
+      # build input — package sources and configs, the lockfile, the root
+      # tsconfig the packages extend, the build scripts, and the Bun version —
+      # so a hit means dist/ is byte-for-byte what a fresh build would produce.
+      - name: Restore built packages
+        id: dist-cache
+        uses: actions/cache@v4
+        with:
+          path: packages/*/dist
+          key: dist-${{ runner.os }}-bun${{ matrix.bun-version }}-${{ hashFiles('packages/**', 'bun.lock', 'tsconfig.json', 'scripts/build-packages.ts', 'scripts/workspace-packages.ts') }}
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Build packages
+        if: steps.dist-cache.outputs.cache-hit != 'true'
         run: bun run build
 
       - name: Generate route types
@@ -190,9 +203,18 @@ jobs:
         with:
           bun-version: '1.3.14'
 
+      # Same exact-match dist cache as build-and-test — see the comment there.
+      - name: Restore built packages
+        id: dist-cache
+        uses: actions/cache@v4
+        with:
+          path: packages/*/dist
+          key: dist-${{ runner.os }}-bun1.3.14-${{ hashFiles('packages/**', 'bun.lock', 'tsconfig.json', 'scripts/build-packages.ts', 'scripts/workspace-packages.ts') }}
+
       - run: bun install --frozen-lockfile
 
       - name: Build packages
+        if: steps.dist-cache.outputs.cache-hit != 'true'
         run: bun run build
 
       - name: Fresh app smoke (default)
@@ -237,8 +259,17 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.14'
+      # Same exact-match dist cache as build-and-test — see the comment there.
+      - name: Restore built packages
+        id: dist-cache
+        uses: actions/cache@v4
+        with:
+          path: packages/*/dist
+          key: dist-${{ runner.os }}-bun1.3.14-${{ hashFiles('packages/**', 'bun.lock', 'tsconfig.json', 'scripts/build-packages.ts', 'scripts/workspace-packages.ts') }}
       - run: bun install --frozen-lockfile
-      - run: bun run build
+      - name: Build packages
+        if: steps.dist-cache.outputs.cache-hit != 'true'
+        run: bun run build
       - name: Generate route types
         run: bun run build:routes
       - name: Run tests (no Redis)
@@ -275,9 +306,18 @@ jobs:
         with:
           bun-version: '1.3.14'
 
+      # Same exact-match dist cache as build-and-test — see the comment there.
+      - name: Restore built packages
+        id: dist-cache
+        uses: actions/cache@v4
+        with:
+          path: packages/*/dist
+          key: dist-${{ runner.os }}-bun1.3.14-${{ hashFiles('packages/**', 'bun.lock', 'tsconfig.json', 'scripts/build-packages.ts', 'scripts/workspace-packages.ts') }}
+
       - run: bun install --frozen-lockfile
 
       - name: Build packages
+        if: steps.dist-cache.outputs.cache-hit != 'true'
         run: bun run build
 
       - name: Generate route types
@@ -285,6 +325,14 @@ jobs:
 
       - name: Build blog frontend
         run: bun run --cwd examples/blog build
+
+      # With a cache hit playwright skips the browser download and only
+      # installs system deps, so the install step stays unconditional.
+      - name: Restore Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('examples/blog/package.json') }}
 
       - name: Install Playwright browsers
         run: cd examples/blog && bunx playwright install --with-deps chromium
@@ -326,10 +374,19 @@ jobs:
         with:
           bun-version: "1.3.14"
 
+      # Same exact-match dist cache as build-and-test — see the comment there.
+      - name: Restore built packages
+        id: dist-cache
+        uses: actions/cache@v4
+        with:
+          path: packages/*/dist
+          key: dist-${{ runner.os }}-bun1.3.14-${{ hashFiles('packages/**', 'bun.lock', 'tsconfig.json', 'scripts/build-packages.ts', 'scripts/workspace-packages.ts') }}
+
       - name: Install workspace dependencies
         run: bun install --frozen-lockfile
 
       - name: Build packages
+        if: steps.dist-cache.outputs.cache-hit != 'true'
         run: bun run build
 
       - name: Generate route types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,28 +72,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+      # setup-bun + exact-match dist cache + install + build-on-miss.
+      # The cache key and its stale-dist rationale live in the action.
+      - name: Set up Bun and build packages
+        uses: ./.github/actions/setup-and-build
         with:
           bun-version: ${{ matrix.bun-version }}
-
-      # Exact-match only (no restore-keys): a partial hit would restore a
-      # stale dist/, this repo's best-documented footgun. The key covers every
-      # build input — package sources and configs, the lockfile, the root
-      # tsconfig the packages extend, the build scripts, and the Bun version —
-      # so a hit means dist/ is byte-for-byte what a fresh build would produce.
-      - name: Restore built packages
-        id: dist-cache
-        uses: actions/cache@v4
-        with:
-          path: packages/*/dist
-          key: dist-${{ runner.os }}-bun${{ matrix.bun-version }}-${{ hashFiles('packages/**', 'bun.lock', 'tsconfig.json', 'scripts/build-packages.ts', 'scripts/workspace-packages.ts') }}
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-      - name: Build packages
-        if: steps.dist-cache.outputs.cache-hit != 'true'
-        run: bun run build
 
       - name: Generate route types
         run: bun run build:routes
@@ -199,23 +183,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: '1.3.14'
-
-      # Same exact-match dist cache as build-and-test — see the comment there.
-      - name: Restore built packages
-        id: dist-cache
-        uses: actions/cache@v4
-        with:
-          path: packages/*/dist
-          key: dist-${{ runner.os }}-bun1.3.14-${{ hashFiles('packages/**', 'bun.lock', 'tsconfig.json', 'scripts/build-packages.ts', 'scripts/workspace-packages.ts') }}
-
-      - run: bun install --frozen-lockfile
-
-      - name: Build packages
-        if: steps.dist-cache.outputs.cache-hit != 'true'
-        run: bun run build
+      - name: Set up Bun and build packages
+        uses: ./.github/actions/setup-and-build
 
       - name: Fresh app smoke (default)
         run: bun run smoke:starter
@@ -256,20 +225,8 @@ jobs:
       APP_KEY: base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
     steps:
       - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: '1.3.14'
-      # Same exact-match dist cache as build-and-test — see the comment there.
-      - name: Restore built packages
-        id: dist-cache
-        uses: actions/cache@v4
-        with:
-          path: packages/*/dist
-          key: dist-${{ runner.os }}-bun1.3.14-${{ hashFiles('packages/**', 'bun.lock', 'tsconfig.json', 'scripts/build-packages.ts', 'scripts/workspace-packages.ts') }}
-      - run: bun install --frozen-lockfile
-      - name: Build packages
-        if: steps.dist-cache.outputs.cache-hit != 'true'
-        run: bun run build
+      - name: Set up Bun and build packages
+        uses: ./.github/actions/setup-and-build
       - name: Generate route types
         run: bun run build:routes
       - name: Run tests (no Redis)
@@ -302,23 +259,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: '1.3.14'
-
-      # Same exact-match dist cache as build-and-test — see the comment there.
-      - name: Restore built packages
-        id: dist-cache
-        uses: actions/cache@v4
-        with:
-          path: packages/*/dist
-          key: dist-${{ runner.os }}-bun1.3.14-${{ hashFiles('packages/**', 'bun.lock', 'tsconfig.json', 'scripts/build-packages.ts', 'scripts/workspace-packages.ts') }}
-
-      - run: bun install --frozen-lockfile
-
-      - name: Build packages
-        if: steps.dist-cache.outputs.cache-hit != 'true'
-        run: bun run build
+      - name: Set up Bun and build packages
+        uses: ./.github/actions/setup-and-build
 
       - name: Generate route types
         run: bun run build:routes
@@ -326,16 +268,30 @@ jobs:
       - name: Build blog frontend
         run: bun run --cwd examples/blog build
 
-      # With a cache hit playwright skips the browser download and only
-      # installs system deps, so the install step stays unconditional.
+      # Keyed on the resolved Playwright version, not a hashed manifest: the
+      # caret range in examples/blog/package.json means a lockfile-only bump
+      # must invalidate this cache, and an unrelated dependency bump must not.
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(cd examples/blog && bunx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
       - name: Restore Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('examples/blog/package.json') }}
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: cd examples/blog && bunx playwright install --with-deps chromium
+
+      # On a hit the browsers are already in place and the runner image ships
+      # Chromium's system libraries; a plain install is a fast no-op safety
+      # net that skips the ~30s apt work --with-deps would repeat.
+      - name: Install Playwright browsers (cached)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: cd examples/blog && bunx playwright install chromium
 
       - name: Set up blog .env
         run: |
@@ -369,25 +325,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      # Same exact-match dist cache as build-and-test — see the comment there.
-      - name: Restore built packages
-        id: dist-cache
-        uses: actions/cache@v4
-        with:
-          path: packages/*/dist
-          key: dist-${{ runner.os }}-bun1.3.14-${{ hashFiles('packages/**', 'bun.lock', 'tsconfig.json', 'scripts/build-packages.ts', 'scripts/workspace-packages.ts') }}
-
-      - name: Install workspace dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Build packages
-        if: steps.dist-cache.outputs.cache-hit != 'true'
-        run: bun run build
+      - name: Set up Bun and build packages
+        uses: ./.github/actions/setup-and-build
 
       - name: Generate route types
         run: |

--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -43,6 +43,9 @@ jobs:
       # canary-specific checks (e.g. extended smoke tests, upgrade
       # scenarios) are appended after the CI-equivalent steps.
       # When adding a new step to ci.yml, mirror it here as well.
+      # Exception: CI's dist-cache/build-skip steps are deliberately NOT
+      # mirrored — the canary always builds from scratch, so it stays the
+      # ground truth that would catch a poisoned or stale cache.
       # ----------------------------------------------------------------
 
       - uses: actions/checkout@v6


### PR DESCRIPTION
Stacked on #317 — merge that first (without deleting its branch), then retarget this PR to `main`.

## Summary

- Restore `packages/*/dist` from an exact-match cache and skip `bun run build` (~100s per job, five jobs) on a hit. The whole coupled unit (setup-bun + cache + install + build-on-miss) lives in a new composite action `.github/actions/setup-and-build`, so the cache key — the correctness mechanism — exists in exactly one place and the Bun version can't drift between the toolchain and the key.
- Cache Playwright browsers in the e2e job, keyed on the resolved Playwright version; on a hit the ~30s `--with-deps` apt work is skipped too.

## Stale-dist safety

Stale `dist/` is this repo's best-documented footgun, so the cache is deliberately conservative:

- **No `restore-keys`.** A partial match would restore an outdated `dist/`; any key miss falls back to a full build instead.
- **The key hashes every build input**: `packages/**` (minus verified non-inputs: `*.test.ts`, runtime-read `templates/`, changelogs, a stray tarball), the root `package.json` (defines the build command), `bun.lock`, the root `tsconfig.json` all packages extend, both build scripts (build order affects DTS output), and the Bun version.
- The key is evaluated right after checkout, before `bun install` writes anything into the tree.
- `nightly-canary` deliberately does **not** get the cache: its always-fresh build is the ground truth that would catch a poisoned cache (documented in its header).

## Measured result

| run | scenario | CI wall time |
|---|---|---|
| baseline (before #317) | — | ~6:35 |
| after #317 | — | 4:16 |
| this PR, cache miss | first build under a key | 4:20 (build runs, cache saved) |
| this PR, cache hit | no package changes | **2:42** |

On the hit run the composite step (setup-bun + restore + `bun install`, build skipped) took **5 seconds** vs ~100s with a build. All downstream consumers of the restored dist — typecheck, audits, example builds, 3763 unit tests, smokes, e2e — were green, which is the end-to-end proof the restored cache is complete.

## Test plan

- [x] YAML validated; all five jobs consume the composite action; no leftover inline setup/build steps
- [x] CI run (cache miss): full builds, all green, cache saved under the new key
- [x] CI run (cache hit, empty commit): build skipped (composite step 5s), all five jobs green end-to-end
- [x] Playwright cache saved under resolved-version key (`playwright-Linux-1.62.1`, 269MB) and hit on the following run