### PR TITLE
fix(cli): coalesce rapid route-types regeneration runs

### DIFF
--- a/packages/cli/src/vite/route-types.test.ts
+++ b/packages/cli/src/vite/route-types.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { EventEmitter } from 'node:events'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { HmrContext, Logger, Plugin, ResolvedConfig, ViteDevServer } from 'vite'
+import { routeTypesPlugin, type RouteTypesPluginOptions } from './route-types'
+
+describe('routeTypesPlugin', () => {
+  let tempDir: string
+  let runLog: string
+  let originalCi: string | undefined
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'guren-route-types-'))
+    runLog = join(tempDir, 'runs.log')
+    originalCi = process.env.CI
+    delete process.env.CI
+  })
+
+  afterEach(async () => {
+    if (originalCi === undefined) {
+      delete process.env.CI
+    } else {
+      process.env.CI = originalCi
+    }
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  function createPlugin(options: RouteTypesPluginOptions = {}): Plugin {
+    return routeTypesPlugin({
+      appRoot: tempDir,
+      executable: 'bash',
+      args: ['-c', 'echo run >> "$RUN_LOG"'],
+      env: { RUN_LOG: runLog },
+      ...options,
+    })
+  }
+
+  function resolveConfig(plugin: Plugin, logger?: Partial<Logger>): Promise<void> {
+    const handler = plugin.configResolved as (config: ResolvedConfig) => Promise<void>
+    return handler({ root: tempDir, logger } as unknown as ResolvedConfig)
+  }
+
+  function hotUpdate(plugin: Plugin, file: string): Promise<unknown> {
+    const handler = plugin.handleHotUpdate as (ctx: HmrContext) => Promise<unknown>
+    const ctx = {
+      file,
+      server: { config: { root: tempDir } },
+      modules: [],
+    } as unknown as HmrContext
+    return handler(ctx)
+  }
+
+  function connectWatcher(plugin: Plugin): EventEmitter {
+    const watcher = new EventEmitter()
+    const handler = plugin.configureServer as (server: ViteDevServer) => void
+    handler({ watcher, config: { root: tempDir } } as unknown as ViteDevServer)
+    return watcher
+  }
+
+  async function readRuns(): Promise<string[]> {
+    const content = await readFile(runLog, 'utf8').catch(() => '')
+    return content.split('\n').filter(Boolean)
+  }
+
+  async function waitForRuns(count: number): Promise<string[]> {
+    const deadline = Date.now() + 2000
+    let runs = await readRuns()
+    while (runs.length < count && Date.now() < deadline) {
+      await Bun.sleep(10)
+      runs = await readRuns()
+    }
+    return runs
+  }
+
+  it('should coalesce events arriving during a run into one follow-up run', async () => {
+    const plugin = createPlugin()
+    const pageFile = (name: string) => resolve(tempDir, 'resources/js/pages', name)
+
+    const updates = ['A.tsx', 'B.tsx', 'C.tsx', 'D.tsx', 'E.tsx'].map((name) =>
+      hotUpdate(plugin, pageFile(name)),
+    )
+    await Promise.all(updates)
+
+    expect(await readRuns()).toHaveLength(2)
+  })
+
+  it('should run again for events after the previous run finished', async () => {
+    const plugin = createPlugin()
+    const pageFile = resolve(tempDir, 'resources/js/pages/A.tsx')
+
+    await hotUpdate(plugin, pageFile)
+    await hotUpdate(plugin, pageFile)
+
+    expect(await readRuns()).toHaveLength(2)
+  })
+
+  it('should not regenerate for files outside the watched paths', async () => {
+    const plugin = createPlugin()
+
+    await hotUpdate(plugin, resolve(tempDir, 'src/unrelated.ts'))
+
+    expect(await readRuns()).toHaveLength(0)
+  })
+
+  it('should regenerate when the watcher reports added files', async () => {
+    const plugin = createPlugin()
+    const watcher = connectWatcher(plugin)
+
+    watcher.emit('add', resolve(tempDir, 'resources/js/pages/New.tsx'))
+    watcher.emit('unlink', resolve(tempDir, 'src/unrelated.ts'))
+
+    expect(await waitForRuns(1)).toHaveLength(1)
+  })
+
+  it('should log generator failures without rejecting, and keep accepting runs', async () => {
+    const errors: string[] = []
+    const plugin = createPlugin({ args: ['-c', 'echo run >> "$RUN_LOG"; echo boom >&2; exit 1'] })
+
+    await resolveConfig(plugin, {
+      info: () => {},
+      error: (message: string) => {
+        errors.push(message)
+      },
+    })
+    await hotUpdate(plugin, resolve(tempDir, 'resources/js/pages/A.tsx'))
+
+    expect(await readRuns()).toHaveLength(2)
+    expect(errors).toHaveLength(2)
+    expect(errors[0]).toContain('boom')
+  })
+
+  it('should skip generation entirely when disabled', async () => {
+    const plugin = createPlugin({ enabled: false })
+    const watcher = connectWatcher(plugin)
+
+    await resolveConfig(plugin)
+    await hotUpdate(plugin, resolve(tempDir, 'resources/js/pages/A.tsx'))
+    watcher.emit('add', resolve(tempDir, 'resources/js/pages/New.tsx'))
+
+    expect(await readRuns()).toHaveLength(0)
+  })
+
+  it('should default to disabled when CI is set', async () => {
+    process.env.CI = '1'
+    const plugin = createPlugin()
+
+    await resolveConfig(plugin)
+    await hotUpdate(plugin, resolve(tempDir, 'resources/js/pages/A.tsx'))
+
+    expect(await readRuns()).toHaveLength(0)
+  })
+})

--- a/packages/cli/src/vite/route-types.ts
+++ b/packages/cli/src/vite/route-types.ts
@@ -33,6 +33,11 @@ export interface RouteTypesPluginOptions {
    * Additional environment variables passed to the spawned process.
    */
   env?: NodeJS.ProcessEnv
+  /**
+   * Whether the plugin regenerates types at all. Defaults to `!process.env.CI`
+   * (codegen runs as a separate build step in CI).
+   */
+  enabled?: boolean
 }
 
 const DEFAULT_EXECUTABLE = 'bun'
@@ -55,9 +60,11 @@ function defaultArgs(): string[] {
 }
 
 export function routeTypesPlugin(options: RouteTypesPluginOptions = {}): Plugin {
+  const enabled = options.enabled ?? !process.env.CI
   let appRoot = options.appRoot
   let logger: Logger | undefined
-  let queue: Promise<void> = Promise.resolve()
+  let running: Promise<void> | null = null
+  let queued = false
 
   function logLines(message: string, level: 'info' | 'error' = 'info'): void {
     const target = level === 'error' ? logger?.error : logger?.info
@@ -108,19 +115,33 @@ export function routeTypesPlugin(options: RouteTypesPluginOptions = {}): Plugin 
     })
   }
 
-  function enqueueGeneration(root: string): Promise<void> {
-    // CI runs codegen as its own build step; regenerating there — including
-    // from watcher or HMR events mid-E2E — would only add nondeterminism.
-    if (process.env.CI) return queue
+  function runGeneration(root: string): Promise<void> {
+    return spawnGenerator(root).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error)
+      logLines(message, 'error')
+    })
+  }
 
-    queue = queue
-      .then(() => spawnGenerator(root))
-      .catch((error) => {
-        const message = error instanceof Error ? error.message : String(error)
-        logLines(message, 'error')
-      })
+  function scheduleGeneration(root: string): Promise<void> {
+    if (!enabled) return Promise.resolve()
 
-    return queue
+    // Events arriving while a run is in flight collapse into a single
+    // follow-up run that picks up all of their changes at once.
+    if (running) {
+      queued = true
+      return running
+    }
+
+    running = (async () => {
+      do {
+        queued = false
+        await runGeneration(root)
+      } while (queued)
+    })().finally(() => {
+      running = null
+    })
+
+    return running
   }
 
   function shouldRegenerate(root: string, file: string): boolean {
@@ -145,7 +166,7 @@ export function routeTypesPlugin(options: RouteTypesPluginOptions = {}): Plugin 
     async configResolved(config: ResolvedConfig) {
       appRoot = resolve(config.root, options.appRoot ?? '.')
       logger = config.logger
-      await enqueueGeneration(appRoot)
+      await scheduleGeneration(appRoot)
     },
     configureServer(server: ViteDevServer) {
       // handleHotUpdate only fires for updates; creating or deleting a
@@ -153,7 +174,7 @@ export function routeTypesPlugin(options: RouteTypesPluginOptions = {}): Plugin 
       const root = () => appRoot ?? server.config.root
       const onFileEvent = (file: string) => {
         if (shouldRegenerate(root(), file)) {
-          void enqueueGeneration(root())
+          void scheduleGeneration(root())
         }
       }
       server.watcher.on('add', onFileEvent)
@@ -163,7 +184,7 @@ export function routeTypesPlugin(options: RouteTypesPluginOptions = {}): Plugin 
       const root = appRoot ?? ctx.server.config.root
 
       if (shouldRegenerate(root, ctx.file)) {
-        await enqueueGeneration(root)
+        await scheduleGeneration(root)
       }
 
       return ctx.modules


### PR DESCRIPTION
## Summary

- `enqueueGeneration()` in the Vite route-types plugin serialized watcher events into a strict FIFO promise chain, so saving several pages at once (or a tool rewriting a batch of resources) queued one full `codegen --force` child process per event, run back to back.
- Replaced it with a `running`/`queued` state machine: the first event starts a run immediately, and any events arriving while a run is in flight collapse into a single follow-up run.
- Promoted the previously-hardcoded `process.env.CI` skip to an `enabled` option, resolved once at plugin construction, so tests can gate the plugin without mutating `process.env.CI`.
- Error handling is unchanged: generator failures are logged via the Vite `Logger` and never reject the caller's promise.

## Test plan

- [x] `bun test packages/cli/src/vite/route-types.test.ts` — 7 new unit tests covering: coalescing 5 rapid `handleHotUpdate` events into 2 runs, sequential events after a run finishes each getting their own run, files outside the watched paths being ignored, the `configureServer` watcher (`add`/`unlink`) path triggering a run, generator failures being logged without rejecting and not blocking later runs, `enabled: false` skipping generation entirely, and `CI` defaulting the plugin to disabled.
- [x] `bun run test:bun cli` — full CLI suite, 1166 pass.
- [x] `bun run typecheck` — root typecheck green.
- [x] `bun run build cli` — package builds including DTS.
- [x] Manual verification in `examples/blog`: started the dev server, touched 6 files under `resources/js/pages` in quick succession, confirmed exactly 2 `[guren-route-types]` codegen runs in the server log instead of 6.