### PR TITLE
fix(examples): stop npm 404 fallback in route-types Vite plugin

### DIFF
--- a/examples/blog/vite.config.ts
+++ b/examples/blog/vite.config.ts
@@ -1,10 +1,19 @@
 import { routeTypesPlugin } from '@guren/cli/vite'
 import guren from '@guren/core/vite'
-import { defineConfig, type PluginOption } from 'vite'
+import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   publicDir: false,
-  plugins: [routeTypesPlugin(), guren(), react(), tailwindcss()],
-})
+  plugins: [
+    // The `guren` package is not on npm, so the plugin's default
+    // `bun x --bun guren` fails in the monorepo — delegate to this app's
+    // codegen script instead. Dev-server only: the build script already
+    // runs codegen before `vite build`.
+    ...(command === 'serve' ? [routeTypesPlugin({ args: ['run', 'codegen'] })] : []),
+    guren(),
+    react(),
+    tailwindcss(),
+  ],
+}))

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,7 +4,17 @@ import guren from '@guren/core/vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   publicDir: false,
-  plugins: [routeTypesPlugin(), guren(), react(), tailwindcss()],
-})
+  plugins: [
+    // The `guren` package is not on npm, so the plugin's default
+    // `bun x --bun guren` fails in the monorepo — delegate to this app's
+    // codegen script instead. Dev-server only: the plugin re-running the
+    // codegen script during `vite build` would overwrite the real
+    // prerender output with stubs (the script runs `prerender:stub`).
+    ...(command === 'serve' ? [routeTypesPlugin({ args: ['run', 'codegen'] })] : []),
+    guren(),
+    react(),
+    tailwindcss(),
+  ],
+}))


### PR DESCRIPTION
## Summary

- `examples/blog/vite.config.ts` and `web/vite.config.ts` both called `routeTypesPlugin()` with no options, so every codegen run (initial `configResolved` and every HMR trigger) spawned the plugin's default `bun x --bun guren codegen --force`. The `guren` package does not exist on npm, so this 404'd on every run (see `.claude/rules/common-pitfalls.md`: "Never use `bunx guren` in CI").
- PR #316 fixed the blog app's `package.json` scripts to call the local CLI directly, but the Vite plugin instantiation was never updated to match.
- This PR passes explicit `args: ['run', 'codegen']` so the plugin delegates to each app's existing `codegen` script (which already calls `bun ../../packages/cli/src/bin.ts codegen ...` / the `web` equivalent), and gates the plugin to `command === 'serve'` so it only runs during `vite dev` — both apps' `build` scripts already run codegen up front, so the plugin re-running it during `vite build` was redundant work. In `web/`, it was also unsafe: the `web` codegen script runs `prerender:stub` first, so the plugin re-running it during a build would silently overwrite the real prerendered docs output with stubs.

## Test plan

- [x] `bun run build` (all packages)
- [x] `bun run typecheck` (root, including blog/api)
- [x] `web` typecheck (`bun run --cwd web typecheck`)
- [x] Booted the `blog` dev server; confirmed initial `configResolved` codegen and an HMR-triggered codegen (touched a file under `resources/js/pages`) both succeeded with `[guren-route-types] ✔ ...` logs and zero `registry.npmjs.org` 404s
- [x] Ran `bunx vite build` for `blog` and confirmed the plugin does not run (gated to dev only)
- [x] Booted the `web` dev server; confirmed the same initial + HMR codegen success with zero 404s, and the docs homepage rendered correctly