### PR TITLE
perf(server): split declaration emit from dts bundling

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -103,7 +103,7 @@
     }
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--max-old-space-size=8192' tsup",
+    "build": "tsup && tsc -p tsconfig.build.json && bun ../../scripts/fix-dts-extensions.ts dist",
     "dev": "bun --watch src/index.ts",
     "typecheck": "tsc --noEmit",
     "test": "bun test"

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "rootDir": "src",
+    // The root tsconfig maps @guren/* to package sources, which would pull
+    // sibling packages into this program and break rootDir. Clearing paths
+    // (as packages/core's tsconfig does) resolves @guren/orm through
+    // node_modules to its built declarations instead — the build runs in
+    // dependency order, so orm's dist exists. '@guren/cli' builds after
+    // server and may not resolve at all; its two dynamic import() sites
+    // already carry @ts-ignore and cast the module to local interfaces.
+    "paths": {}
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/server/tsup.config.ts
+++ b/packages/server/tsup.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
   // is invisible through another (e.g. registerJob via the root entry +
   // Worker via ./queue never saw each other's registry).
   splitting: true,
-  dts: { only: false },
+  dts: false,
   outDir: 'dist',
   clean: true,
   tsconfig: 'tsconfig.json',

--- a/scripts/fix-dts-extensions.ts
+++ b/scripts/fix-dts-extensions.ts
@@ -1,0 +1,97 @@
+/**
+ * Rewrites extensionless relative import specifiers in emitted .d.ts files to
+ * explicit .js specifiers (./foo -> ./foo.js, ./dir -> ./dir/index.js).
+ *
+ * `tsc --emitDeclarationOnly` preserves source specifiers verbatim, but
+ * declaration files in an ESM package must use runtime-resolvable specifiers
+ * for consumers on `moduleResolution: node16`/`nodenext` (TS maps the .js
+ * specifier back to the sibling .d.ts). Bundler-resolution consumers accept
+ * both forms.
+ *
+ * Usage: bun scripts/fix-dts-extensions.ts <distDir>
+ */
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+
+import ts from 'typescript'
+
+function collectDtsFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) collectDtsFiles(full, out)
+    else if (entry.name.endsWith('.d.ts')) out.push(full)
+  }
+  return out
+}
+
+function resolveRewrite(filePath: string, specifier: string): string | null {
+  const isRelative =
+    specifier === '.' ||
+    specifier === '..' ||
+    specifier.startsWith('./') ||
+    specifier.startsWith('../')
+  if (!isRelative) return null
+  if (/\.(js|mjs|cjs|json)$/.test(specifier)) return null
+  const base = resolve(dirname(filePath), specifier)
+  if (existsSync(`${base}.d.ts`)) return `${specifier}.js`
+  if (existsSync(join(base, 'index.d.ts'))) return `${specifier}/index.js`
+  throw new Error(`fix-dts-extensions: cannot resolve '${specifier}' from ${filePath}`)
+}
+
+/** String-literal specifier nodes: import/export declarations and import types. */
+function collectSpecifierNodes(sourceFile: ts.SourceFile): ts.StringLiteral[] {
+  const literals: ts.StringLiteral[] = []
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier !== undefined &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      literals.push(node.moduleSpecifier)
+    } else if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument) &&
+      ts.isStringLiteral(node.argument.literal)
+    ) {
+      literals.push(node.argument.literal)
+    } else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteral(node.arguments[0]!)
+    ) {
+      literals.push(node.arguments[0] as ts.StringLiteral)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return literals
+}
+
+const distDir = resolve(process.argv[2] ?? 'dist')
+let rewrittenFiles = 0
+
+for (const filePath of collectDtsFiles(distDir)) {
+  const text = readFileSync(filePath, 'utf8')
+  const sourceFile = ts.createSourceFile(filePath, text, ts.ScriptTarget.Latest, true)
+  const edits: Array<{ start: number; end: number; replacement: string }> = []
+  for (const literal of collectSpecifierNodes(sourceFile)) {
+    const rewritten = resolveRewrite(filePath, literal.text)
+    if (rewritten === null) continue
+    // Replace only the contents between the quotes.
+    edits.push({
+      start: literal.getStart(sourceFile) + 1,
+      end: literal.getEnd() - 1,
+      replacement: rewritten,
+    })
+  }
+  if (edits.length === 0) continue
+  let updated = text
+  for (const edit of edits.sort((a, b) => b.start - a.start)) {
+    updated = updated.slice(0, edit.start) + edit.replacement + updated.slice(edit.end)
+  }
+  writeFileSync(filePath, updated)
+  rewrittenFiles += 1
+}
+
+console.log(`fix-dts-extensions: rewrote relative specifiers in ${rewrittenFiles} file(s) under ${distDir}`)


### PR DESCRIPTION
## Summary

- `@guren/server`'s build took ~33s, almost entirely spent in tsup's DTS bundling (rollup-plugin-dts over 21 entry points). Plain `tsc --emitDeclarationOnly` over the same source takes ~3-4s.
- Disables tsup's `dts` and adds a `tsc -p tsconfig.build.json` step that emits per-file declarations straight into `dist/`, resolving sibling `@guren/*` packages the same way `packages/core`'s tsconfig already does (`paths: {}`, falling through to built `dist` declarations via the workspace symlink).
- `tsc` preserves extensionless relative import specifiers, which break under `node16`/`nodenext` module resolution. Added `scripts/fix-dts-extensions.ts`, a small AST-based post-processing step that rewrites `./foo` → `./foo.js` (and `./dir` → `./dir/index.js`) in the emitted `.d.ts` files, failing loudly if a specifier can't be resolved.
- Drops the `NODE_OPTIONS='--max-old-space-size=8192'` the old build needed only for DTS bundling (measured peak with the new build: ~386MB).

Result: `bun run build server` drops from ~33s to ~4s.

## Verification

- `@arethetypeswrong/cli --pack packages/server` produces an **identical compatibility matrix** before and after this change (node16 ESM 🟢, bundler 🟢; the CJS/node10 warnings are pre-existing, inherent to a pure-ESM package).
- `bun run build:clean` — all 11 packages build successfully in dependency order.
- `bun run typecheck` — green, including `examples/blog` and `examples/api` which consume the built `dist` types transitively through `@guren/core`.
- `bun run test:bun` — 3734 pass, 0 fail.
- `bun run audit:core-first` / `bun run audit:docs` — green.
- Manually verified failure-mode safety: building `@guren/server` standalone with `packages/orm/dist` removed fails loudly with `TS2307` (no silent type degradation); building with `packages/cli/dist` absent still succeeds (the only two `@guren/cli` imports are dynamic `import()` calls already guarded by `@ts-ignore` and cast to local interfaces).

## Reviewer notes

- Reviewed by Codex, which flagged the extensionless-specifier issue under `node16`/`nodenext` as a real regression risk — that's what `scripts/fix-dts-extensions.ts` fixes, confirmed via before/after `arethetypeswrong` comparison.
- `bun run build server` run in isolation (not via the root `build`/`build:clean` scripts) requires `packages/orm/dist` to already exist, since sibling package types now resolve through built declarations rather than source. Normal build flows (`build`, `build:clean`, CI) always build in dependency order, so this doesn't affect them.