### PR TITLE
test(server): inject a clock into the rate limiter

### DIFF
--- a/packages/server/src/http/middleware/rate-limit.ts
+++ b/packages/server/src/http/middleware/rate-limit.ts
@@ -44,7 +44,10 @@ abstract class BaseMemoryStore implements RateLimitStore {
    */
   private readonly hotReloadClaim: HotDisposableClaim | undefined
 
-  constructor(cleanupIntervalMs = 60000) {
+  constructor(
+    cleanupIntervalMs = 60000,
+    protected readonly now: () => number = () => Date.now(),
+  ) {
     if (cleanupIntervalMs <= 0) {
       return
     }
@@ -93,7 +96,7 @@ export class MemoryRateLimitStore extends BaseMemoryStore {
   async get(key: string): Promise<RateLimitEntry | null> {
     const entry = this.entries.get(key)
     if (!entry) return null
-    if (Date.now() >= entry.resetAt) {
+    if (this.now() >= entry.resetAt) {
       this.entries.delete(key)
       return null
     }
@@ -101,7 +104,7 @@ export class MemoryRateLimitStore extends BaseMemoryStore {
   }
 
   async increment(key: string, windowMs: number): Promise<RateLimitEntry> {
-    const now = Date.now()
+    const now = this.now()
     const existing = this.entries.get(key)
 
     if (existing && now < existing.resetAt) {
@@ -119,7 +122,7 @@ export class MemoryRateLimitStore extends BaseMemoryStore {
   }
 
   cleanup(): void {
-    const now = Date.now()
+    const now = this.now()
     for (const [key, entry] of this.entries.entries()) {
       if (now >= entry.resetAt) {
         this.entries.delete(key)
@@ -197,6 +200,16 @@ export interface RateLimitOptions {
    * @default 'rl:'
    */
   keyPrefix?: string
+
+  /**
+   * Clock returning the current time in epoch milliseconds. Injectable so
+   * tests can advance time synchronously instead of sleeping. Drives the
+   * middleware's own calculations (Retry-After) and, when no `store` is
+   * supplied, the store created for this middleware. A custom store keeps
+   * its own clock — construct it with the same `now` to stay coherent.
+   * @default () => Date.now()
+   */
+  now?: () => number
 
   /**
    * Trust reverse-proxy headers for client IP resolution, checked in order:
@@ -340,13 +353,19 @@ export function createRateLimitMiddleware(options: RateLimitOptions = {}): Middl
     windowMs = 60000,
     trustProxy = false,
     keyGenerator = trustProxy ? proxyAwareKeyGenerator : defaultKeyGenerator,
-    store = getDefaultStore(),
+    // An injected clock must drive the default store too, or expiry would run
+    // on real time while Retry-After runs on the fake clock. The shared default
+    // store stays on real time, so build a dedicated store instead — without
+    // auto-cleanup, since a real-time sweep is meaningless on a fake clock and
+    // its interval would outlive tests.
+    store = options.now ? new MemoryRateLimitStore(0, options.now) : getDefaultStore(),
     skip,
     onRateLimited,
     headers = true,
     message = 'Too many requests, please try again later.',
     statusCode = 429,
     keyPrefix = 'rl:',
+    now = () => Date.now(),
   } = options
 
   return async (ctx, next) => {
@@ -362,7 +381,7 @@ export function createRateLimitMiddleware(options: RateLimitOptions = {}): Middl
     // Get or create rate limit entry
     const entry = await store.increment(key, windowMs)
     const remaining = Math.max(0, limit - entry.count)
-    const resetSeconds = Math.ceil((entry.resetAt - Date.now()) / 1000)
+    const resetSeconds = Math.max(0, Math.ceil((entry.resetAt - now()) / 1000))
 
     // Add rate limit headers
     if (headers) {
@@ -464,7 +483,7 @@ export class SlidingWindowRateLimitStore extends BaseMemoryStore {
     const entry = this.requests.get(key)
     if (!entry || entry.timestamps.length === 0) return null
 
-    const now = Date.now()
+    const now = this.now()
     const windowStart = now - entry.windowMs
     const timestamps = entry.timestamps.filter((t) => t > windowStart)
 
@@ -481,7 +500,7 @@ export class SlidingWindowRateLimitStore extends BaseMemoryStore {
   }
 
   async increment(key: string, windowMs: number): Promise<RateLimitEntry> {
-    const now = Date.now()
+    const now = this.now()
     const windowStart = now - windowMs
     const entry = this.requests.get(key)
     let timestamps = entry ? entry.timestamps.filter((t) => t > windowStart) : []
@@ -495,7 +514,7 @@ export class SlidingWindowRateLimitStore extends BaseMemoryStore {
   }
 
   cleanup(): void {
-    const now = Date.now()
+    const now = this.now()
     for (const [key, entry] of this.requests.entries()) {
       const windowStart = now - entry.windowMs
       const valid = entry.timestamps.filter((t) => t > windowStart)

--- a/packages/server/tests/http/middleware/rate-limit.test.ts
+++ b/packages/server/tests/http/middleware/rate-limit.test.ts
@@ -8,11 +8,17 @@ import {
   SlidingWindowRateLimitStore,
 } from '../../../src/http/middleware/rate-limit'
 
+// Far-future epoch (~2096): a store method that leaks Date.now() reads it as
+// the past, so entries the tests expect to expire stay live and the test fails.
+const FAKE_EPOCH = 4_000_000_000_000
+
 describe('MemoryRateLimitStore', () => {
   let store: MemoryRateLimitStore
+  let currentTime: number
 
   beforeEach(() => {
-    store = new MemoryRateLimitStore(0) // Disable auto cleanup for tests
+    currentTime = FAKE_EPOCH
+    store = new MemoryRateLimitStore(0, () => currentTime) // Disable auto cleanup for tests
   })
 
   afterEach(() => {
@@ -28,7 +34,7 @@ describe('MemoryRateLimitStore', () => {
     const entry = await store.increment('key', 60000)
 
     expect(entry.count).toBe(1)
-    expect(entry.resetAt).toBeGreaterThan(Date.now())
+    expect(entry.resetAt).toBe(currentTime + 60000)
   })
 
   it('increments existing entry', async () => {
@@ -41,10 +47,17 @@ describe('MemoryRateLimitStore', () => {
 
   it('resets entry after window expires', async () => {
     await store.increment('key', 100) // 100ms window
-    await new Promise((r) => setTimeout(r, 150))
+    currentTime += 150
 
     const entry = await store.increment('key', 100)
     expect(entry.count).toBe(1) // Reset to 1
+  })
+
+  it('returns null from get after window expires', async () => {
+    await store.increment('key', 100) // 100ms window
+    currentTime += 150
+
+    expect(await store.get('key')).toBeNull()
   })
 
   it('resets a key', async () => {
@@ -58,7 +71,7 @@ describe('MemoryRateLimitStore', () => {
   it('cleans up expired entries', async () => {
     await store.increment('expired', 1) // 1ms window
     await store.increment('valid', 60000) // 60s window
-    await new Promise((r) => setTimeout(r, 10))
+    currentTime += 10
 
     store.cleanup()
 
@@ -88,9 +101,11 @@ describe('MemoryRateLimitStore', () => {
 
 describe('SlidingWindowRateLimitStore', () => {
   let store: SlidingWindowRateLimitStore
+  let currentTime: number
 
   beforeEach(() => {
-    store = new SlidingWindowRateLimitStore(0)
+    currentTime = FAKE_EPOCH
+    store = new SlidingWindowRateLimitStore(0, () => currentTime)
   })
 
   afterEach(() => {
@@ -107,7 +122,7 @@ describe('SlidingWindowRateLimitStore', () => {
 
   it('removes old requests from window', async () => {
     await store.increment('key', 100) // 100ms window
-    await new Promise((r) => setTimeout(r, 150))
+    currentTime += 150
 
     const entry = await store.increment('key', 100)
     expect(entry.count).toBe(1) // Old request removed
@@ -115,7 +130,7 @@ describe('SlidingWindowRateLimitStore', () => {
 
   it('returns null when window has expired', async () => {
     await store.increment('key', 100) // 100ms window
-    await new Promise((r) => setTimeout(r, 150))
+    currentTime += 150
 
     const entry = await store.get('key')
     expect(entry).toBeNull()
@@ -138,9 +153,11 @@ describe('SlidingWindowRateLimitStore', () => {
 describe('createRateLimitMiddleware', () => {
   let store: MemoryRateLimitStore
   let app: Hono
+  let currentTime: number
 
   beforeEach(() => {
-    store = new MemoryRateLimitStore(0)
+    currentTime = FAKE_EPOCH
+    store = new MemoryRateLimitStore(0, () => currentTime)
     app = new Hono()
   })
 
@@ -216,17 +233,19 @@ describe('createRateLimitMiddleware', () => {
 
     expect(res.headers.get('X-RateLimit-Limit')).toBe('10')
     expect(res.headers.get('X-RateLimit-Remaining')).toBe('9')
-    expect(res.headers.get('X-RateLimit-Reset')).toBeDefined()
+    expect(res.headers.get('X-RateLimit-Reset')).toBe(
+      Math.ceil((currentTime + 60000) / 1000).toString()
+    )
   })
 
   it('returns Retry-After header when limited', async () => {
-    app.use('*', createRateLimitMiddleware({ limit: 1, store }))
+    app.use('*', createRateLimitMiddleware({ limit: 1, store, now: () => currentTime }))
     app.get('/', (c) => c.text('OK'))
 
     await app.request('/')
     const res = await app.request('/')
 
-    expect(res.headers.get('Retry-After')).toBeDefined()
+    expect(res.headers.get('Retry-After')).toBe('60')
   })
 
   it('skips requests when skip returns true', async () => {
@@ -365,6 +384,7 @@ describe('createRateLimitMiddleware', () => {
         limit: 1,
         windowMs: 100,
         store,
+        now: () => currentTime,
       })
     )
     app.get('/', (c) => c.text('OK'))
@@ -373,10 +393,44 @@ describe('createRateLimitMiddleware', () => {
     let res = await app.request('/')
     expect(res.status).toBe(429)
 
-    await new Promise((r) => setTimeout(r, 150))
+    currentTime += 150
 
     res = await app.request('/')
     expect(res.status).toBe(200)
+  })
+
+  it('drives the default store with the injected clock', async () => {
+    app.use('*', createRateLimitMiddleware({ limit: 1, windowMs: 100, now: () => currentTime }))
+    app.get('/', (c) => c.text('OK'))
+
+    await app.request('/')
+    let res = await app.request('/')
+    expect(res.status).toBe(429)
+    expect(res.headers.get('Retry-After')).toBe('1')
+
+    currentTime += 150
+
+    res = await app.request('/')
+    expect(res.status).toBe(200)
+  })
+
+  it('clamps Retry-After at zero when the clock is past the window reset', async () => {
+    app.use(
+      '*',
+      createRateLimitMiddleware({
+        limit: 1,
+        windowMs: 1000,
+        store,
+        now: () => currentTime + 5000,
+      })
+    )
+    app.get('/', (c) => c.text('OK'))
+
+    await app.request('/')
+    const res = await app.request('/')
+
+    expect(res.status).toBe(429)
+    expect(res.headers.get('Retry-After')).toBe('0')
   })
 })
 


### PR DESCRIPTION
## Summary

The rate-limit stores and middleware used raw `Date.now()`, so their tests
relied on real `setTimeout` sleeps (100-150ms) to exercise window-expiry
paths. This mirrors the injectable-clock pattern already used by
`MemorySessionStore` (`packages/server/src/http/middleware/session.ts`):
`BaseMemoryStore` and `createRateLimitMiddleware` now accept an optional
`now: () => number` provider, and every internal `Date.now()` call routes
through it.

When a middleware-level `now` is supplied without a custom `store`, the
middleware builds a dedicated `MemoryRateLimitStore` on that same clock
instead of falling back to the real-time shared default store — otherwise
`Retry-After` (computed from the injected clock) and the store's own expiry
(computed from real time) would desync. `Retry-After` is also clamped at
zero.

The converted tests seed their fake clocks at a far-future epoch
(`4_000_000_000_000`, ~2096) rather than a small offset. A small offset is
indistinguishable from "already expired" under real time, so a store method
that silently regresses to `Date.now()` would still pass; the far-future seed
makes that regression fail loudly.

## Scope

- `server` (rate-limit middleware + stores, and their tests)

## Risk Assessment

- Purely additive API: `now` is an optional parameter/option everywhere it
  was added, defaulting to `() => Date.now()`. No existing call site needs
  changes.
- Behavior change: when `now` is passed to `createRateLimitMiddleware`
  without an explicit `store`, the middleware no longer shares the module-level
  default `MemoryRateLimitStore` — it gets its own store on the injected
  clock. This only affects callers that pass `now`, which did not previously
  exist as an option.
- `Retry-After` can no longer go negative (clamped at 0), a minor
  correctness fix uncovered while wiring the clock through.

## Validation

- `bun run build` (server package + full workspace)
- `bun run typecheck` (root)
- `bun run test:bun server` — 2004 tests, 0 fail
- Mutation testing: broke window-expiry logic in both stores (fixed-window
  `get`/`increment`/`cleanup`, sliding-window `get`/`increment`) and the
  default-store clock wiring, one at a time — confirmed each mutation fails
  exactly the test(s) meant to catch it, then reverted and reran to green.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation. (no user-facing docs reference this internal test/DX-only option)