### PR TITLE
feat(create-app): wire i18n into the starter templates and revise the i18n guide

### DIFF
--- a/.changeset/template-i18n-wiring.md
+++ b/.changeset/template-i18n-wiring.md
@@ -5,12 +5,11 @@
 
 Wire i18n into the starter templates
 
-Scaffolded apps now ship a `lang/en/messages.json` catalog and pass
-`i18n: { supported: ['en'] }` to `createApp`, with the home page message
-translated through `this.t()` — adding a locale directory is all it takes
-to translate the app. The template test boots the real `src/app.ts` and
-wraps it with `TestApp.fromFetch()`, so tests always exercise the app's
-actual configuration.
+Apps scaffolded from the default and blog blueprints now ship a
+`lang/en/messages.json` catalog and pass `i18n: { supported: ['en'] }` to
+`createApp`; the default blueprint's home page message renders through
+`this.t()`. Adding a locale directory is all it takes to translate the
+app.
 
 `TestApp.create()` additionally accepts an `i18n` option mirroring
 `createApp({ i18n })`, for tests that assemble an app from parts and hit

--- a/.changeset/template-i18n-wiring.md
+++ b/.changeset/template-i18n-wiring.md
@@ -1,0 +1,17 @@
+---
+'create-guren-app': minor
+'@guren/testing': minor
+---
+
+Wire i18n into the starter templates
+
+Scaffolded apps now ship a `lang/en/messages.json` catalog and pass
+`i18n: { supported: ['en'] }` to `createApp`, with the home page message
+translated through `this.t()` — adding a locale directory is all it takes
+to translate the app. The template test boots the real `src/app.ts` and
+wraps it with `TestApp.fromFetch()`, so tests always exercise the app's
+actual configuration.
+
+`TestApp.create()` additionally accepts an `i18n` option mirroring
+`createApp({ i18n })`, for tests that assemble an app from parts and hit
+controllers using `this.t()`.

--- a/docs/en/guides/controllers.md
+++ b/docs/en/guides/controllers.md
@@ -245,17 +245,20 @@ Controllers are instantiated per request, so one method can set an instance fiel
 Use `shareInertiaProps()` to inject application-wide data into every Inertia response. The natural home for the call is a service provider's `boot()` (generate one with `bunx guren make:provider`).
 
 ```ts
-// app/Providers/LocaleProvider.ts
+// app/Providers/AppInfoProvider.ts
 import { ServiceProvider, shareInertiaProps } from '@guren/core'
 
-export default class LocaleProvider extends ServiceProvider {
+export default class AppInfoProvider extends ServiceProvider {
   boot(): void {
-    shareInertiaProps((ctx) => ({
-      i18n: { locale: ctx.req.header('accept-language')?.split(',')[0] ?? 'en' },
+    shareInertiaProps(() => ({
+      appVersion: process.env.APP_VERSION ?? 'dev',
     }), this.container)
   }
 }
 ```
+
+> [!NOTE]
+> The request locale and translation catalogs are already shared for you when the app is created with `createApp({ i18n })` — see the [i18n guide](./i18n.md). There's no need to hand-roll locale detection here.
 
 It merges its props over whatever resolver was registered before, so several providers can each contribute shared props without clobbering one another.
 

--- a/docs/en/guides/i18n.md
+++ b/docs/en/guides/i18n.md
@@ -9,6 +9,7 @@ Enable i18n by passing the `i18n` option to `createApp` and putting your catalog
 ```ts
 // src/app.ts
 import { createApp } from '@guren/core'
+import { registerWebRoutes } from '../routes/web.js'
 
 const app = createApp({
   routes: registerWebRoutes,
@@ -153,7 +154,7 @@ this.tc('messages.item', 10)  // '10 items'
 | English, German, Spanish, Italian, Portuguese, Dutch | 2 | 1 = singular, else plural |
 | French, Brazilian Portuguese | 2 | 0-1 = singular, else plural |
 | Japanese, Chinese, Korean, Vietnamese, Thai | 1 | No plural forms |
-| Russian, Ukrainian | 3 | one, few (2-4), many (5+) |
+| Russian, Ukrainian | 3 | one / few / many by mod-10 and mod-100 (21 is "one", 22-24 "few") |
 | Polish, Czech, Slovak | 3 | Complex rules |
 | Arabic | 6 | Most complex pluralization |
 
@@ -229,14 +230,15 @@ const { t, tc, locale } = useTranslation()
 
 Client-side translation matches the server's semantics exactly — interpolation, plural forms, fallback lookup — so a key renders identically whether translated in a controller or in the browser. Server-side rendering needs no extra wiring; the shared prop covers both passes.
 
-Outside components (or for advanced cases) build a translator directly from the prop:
+Code that already holds the Inertia page object — outside the hook — can build a translator directly from the prop:
 
 ```tsx
 import { createTranslator, type I18nPageProps } from '@guren/inertia-client'
-import { usePage } from '@inertiajs/react'
+import type { Page } from '@inertiajs/core'
 
-const i18n = usePage().props._i18n as I18nPageProps
-const translator = createTranslator(i18n)
+export function translatorFor(page: Page) {
+  return createTranslator(page.props._i18n as I18nPageProps)
+}
 ```
 
 Set `share: false` on the `i18n` option to keep catalogs out of page props (e.g. an app that only translates server-side).
@@ -254,7 +256,7 @@ this.t('messages.welcmoe')   // ✗ compile error
 bunx guren codegen
 ```
 
-The dev server regenerates automatically when files under `lang/` change. Apps without a `lang/` directory keep plain `string` keys.
+The dev server regenerates automatically when translation JSON files under `lang/` change. Apps without a `lang/` directory keep plain `string` keys.
 
 ## Checking Catalogs
 
@@ -266,8 +268,8 @@ bunx guren check --i18n
 
 It reports:
 
-- **Invalid JSON** — an unparseable catalog file is skipped by the loader, so all of its keys silently fall back at runtime.
-- **Missing keys** — a key present in one locale but missing from another renders in the fallback language for that locale's users.
+- **Invalid JSON** — an unparseable catalog file is skipped by the loader (with only a console warning), so all of its keys fall back at runtime.
+- **Missing keys** — a key present in one locale but missing from another renders in the fallback language for that locale's users (or echoes the key when the fallback lacks it too).
 - **Placeholder mismatches** — `:name`/`{name}` placeholders that differ between locales for the same key usually mean a lost variable in translation. Reported as a warning (a locale can legitimately drop a placeholder), so it does not affect the exit code.
 - **Unreachable keys** — property or file names containing literal dots, which the runtime cannot resolve.
 
@@ -339,7 +341,8 @@ const i18n = createI18n({
   loader: new JsonLoader('./lang', { cache: true }),
 })
 
-await i18n.loadLocale('ja')
+// The manager loads nothing on construction — load every locale you use.
+await i18n.loadLocales(['en', 'ja'])
 
 i18n.t('messages.hello')
 i18n.tc('messages.items', 5)

--- a/docs/en/guides/i18n.md
+++ b/docs/en/guides/i18n.md
@@ -1,110 +1,151 @@
 # Internationalization (i18n) Guide
 
-Guren provides a comprehensive internationalization system with translation management, pluralization support for multiple languages, and both file-based and memory-based loading.
+Guren ships internationalization end to end: file-based translation catalogs, per-request locale detection, translation helpers in controllers and React pages, pluralization rules for 15+ languages, typed translation keys, and a consistency checker for your catalogs.
 
-## Core Concepts
+## Quick Start
 
-- **I18nManager** – Central hub for managing translations and locales.
-- **Translator** – Instance for performing translations with context.
-- **TranslationLoader** – Interface for loading translations (JSON files or memory).
-- **Pluralization** – Built-in rules for 15+ languages with customizable forms.
-
-## Basic Usage
-
-### Quick Start
+Enable i18n by passing the `i18n` option to `createApp` and putting your catalogs under `lang/<locale>/`:
 
 ```ts
-import { createI18n, setI18n, t, tc } from '@guren/core'
+// src/app.ts
+import { createApp } from '@guren/core'
 
-const i18n = createI18n({
-  locale: 'en',
-  fallbackLocale: 'en',
-  messages: {
-    en: {
-      messages: {
-        hello: 'Hello',
-        welcome: 'Welcome, :name!',
-        items: 'One item|:count items',
-      },
-    },
-    ja: {
-      messages: {
-        hello: 'こんにちは',
-        welcome: 'ようこそ、:nameさん！',
-      },
-    },
+const app = createApp({
+  routes: registerWebRoutes,
+  i18n: {
+    supported: ['en', 'ja'], // first entry is the default/fallback locale
   },
 })
-
-setI18n(i18n)
-
-// Translate
-t('messages.hello')                    // 'Hello'
-t('messages.welcome', { name: 'John' }) // 'Welcome, John!'
-
-// Pluralize
-tc('messages.items', 1)  // 'One item'
-tc('messages.items', 5)  // '5 items'
 ```
 
-### Replacement Syntax
-
-Two formats are supported for variable replacement:
-
-```ts
-// Laravel-style :variable
-const messages = { greeting: 'Hello, :name!' }
-t('greeting', { name: 'World' }) // 'Hello, World!'
-
-// Brace-style {variable}
-const messages = { greeting: 'Hello, {name}!' }
-t('greeting', { name: 'World' }) // 'Hello, World!'
-```
-
-### Nested Keys
-
-Use dot notation to access nested translation keys:
-
-```ts
-const messages = {
-  en: {
-    user: {
-      profile: {
-        title: 'User Profile',
-        settings: 'Settings',
-      },
-    },
-  },
+```json
+// lang/en/messages.json
+{
+  "hello": "Hello",
+  "welcome": "Welcome, :name!",
+  "items": "One item|:count items"
 }
+```
 
-t('user.profile.title')    // 'User Profile'
-t('user.profile.settings') // 'Settings'
+```json
+// lang/ja/messages.json
+{
+  "hello": "こんにちは",
+  "welcome": "ようこそ、:nameさん！",
+  "items": ":count個"
+}
+```
+
+That single option wires everything:
+
+- Every supported locale is loaded from `lang/<locale>/*.json` during boot.
+- Each request's locale is detected from the `?locale=` query parameter, a `locale` cookie, or the `Accept-Language` header (in that order), restricted to `supported`.
+- Controllers translate with `this.t()` / `this.tc()`, and Inertia pages with `useTranslation()`.
+- Inertia responses carry the resolved locale into `<html lang>` and share the active catalogs with the client.
+
+Translate in a controller:
+
+```ts
+import { Controller } from '@guren/core'
+
+export default class HomeController extends Controller {
+  async index() {
+    return this.inertia(pages.Home, {
+      message: this.t('messages.welcome', { name: 'Guren' }),
+    })
+  }
+}
+```
+
+And in a React page or component:
+
+```tsx
+import { useTranslation } from '@guren/inertia-client'
+
+export default function Nav() {
+  const { t, tc, locale } = useTranslation()
+
+  return (
+    <nav>
+      <span>{t('messages.hello')}</span>
+      <span>{tc('messages.items', 5)}</span> {/* '5 items' / '5個' */}
+    </nav>
+  )
+}
+```
+
+A visitor with `Accept-Language: ja` (or `?locale=ja`, or a `locale=ja` cookie) sees the Japanese catalog everywhere — server-rendered text, client-side text, and `<html lang="ja">` — with no further wiring.
+
+## Translation Files
+
+Catalogs live in one directory per locale; each JSON file becomes a namespace, and nested objects become dot-notation keys:
+
+```
+lang/
+├── en/
+│   ├── messages.json     # keys: messages.*
+│   ├── validation.json   # keys: validation.*
+│   └── errors.json       # keys: errors.*
+└── ja/
+    ├── messages.json
+    ├── validation.json
+    └── errors.json
+```
+
+```json
+// lang/en/messages.json
+{
+  "hello": "Hello",
+  "user": {
+    "profile": "Profile",
+    "settings": "Settings"
+  }
+}
+```
+
+```ts
+this.t('messages.hello')        // 'Hello'
+this.t('messages.user.profile') // 'Profile'
+```
+
+Dots are always path separators: a property name or file name containing a literal dot (`"a.b": "..."`, `nav.admin.json`) can never be resolved and is reported by `guren check --i18n`. Nest objects instead.
+
+A key missing from the active locale falls back to the fallback locale (the first entry in `supported`, or the `fallback` option); a key missing everywhere is returned as-is.
+
+## Interpolation
+
+Two placeholder styles are supported, and both insert values literally — replacement values are never interpreted as patterns:
+
+```json
+{
+  "greeting": "Hello, :name!",
+  "braced": "Hello, {name}!"
+}
+```
+
+```ts
+this.t('messages.greeting', { name: 'World' }) // 'Hello, World!'
+this.t('messages.braced', { name: 'World' })   // 'Hello, World!'
 ```
 
 ## Pluralization
 
-### Basic Pluralization
+Separate plural forms with `|` and translate with `tc()`; the form is chosen by the active locale's rule and `:count` is available as a replacement automatically:
 
-Separate plural forms with `|`:
+```json
+{
+  "apple": "apple|apples",
+  "item": "One item|:count items"
+}
+```
 
 ```ts
-const messages = {
-  en: {
-    apple: 'apple|apples',
-    item: 'One item|:count items',
-  },
-}
-
-tc('apple', 1)  // 'apple'
-tc('apple', 5)  // 'apples'
-
-tc('item', 1)   // 'One item'
-tc('item', 10)  // '10 items'
+this.tc('messages.apple', 1)  // 'apple'
+this.tc('messages.apple', 5)  // 'apples'
+this.tc('messages.item', 10)  // '10 items'
 ```
 
 ### Supported Languages
-
-Built-in pluralization rules for:
 
 | Language | Forms | Rule |
 |----------|-------|------|
@@ -115,388 +156,219 @@ Built-in pluralization rules for:
 | Polish, Czech, Slovak | 3 | Complex rules |
 | Arabic | 6 | Most complex pluralization |
 
-### Complex Pluralization
+Languages with more than two forms list them in rule order:
 
-For languages with multiple plural forms:
-
-```ts
-const messages = {
-  ru: {
-    // Russian: one | few | many
-    apple: 'яблоко|яблока|яблок',
-  },
+```json
+// lang/ru/messages.json — one | few | many
+{
+  "apple": "яблоко|яблока|яблок"
 }
-
-i18n.setLocale('ru')
-tc('apple', 1)   // 'яблоко' (one)
-tc('apple', 2)   // 'яблока' (few)
-tc('apple', 5)   // 'яблок' (many)
-tc('apple', 21)  // 'яблоко' (one - special case)
 ```
 
-### Custom Pluralization Rules
+```ts
+this.tc('messages.apple', 1)   // 'яблоко' (one)
+this.tc('messages.apple', 2)   // 'яблока' (few)
+this.tc('messages.apple', 5)   // 'яблок' (many)
+this.tc('messages.apple', 21)  // 'яблоко' (one — special case)
+```
+
+## Locale Detection
+
+`createApp({ i18n })` mounts locale detection automatically. Tune it with the `detect` option:
+
+```ts
+createApp({
+  i18n: {
+    supported: ['en', 'ja'],
+    fallback: 'en',              // defaults to the first supported locale
+    detect: {
+      sources: ['cookie', 'header'], // drop query-parameter detection
+      queryParam: 'locale',          // defaults shown
+      cookieName: 'locale',
+    },
+  },
+})
+```
+
+`Accept-Language` matching understands region subtags (`ja-JP` matches `ja`) and q-values. Detection only ever resolves to a locale in `supported`.
+
+Pass `detect: false` to mount `detectLocaleMiddleware` yourself — or to substitute your own middleware that sets the `locale` context variable (for example from a signed-in user's saved preference). Everything downstream — `this.t()`, `_i18n`, `<html lang>` — follows the context variable, even when other middleware overrides it after detection.
+
+Inertia responses use the resolved locale for the root `<html lang>` attribute. A per-response `lang` option always wins:
+
+```ts
+return this.inertia(pages.posts.Show, { post }, { lang: 'ja' })
+```
+
+## Controllers
+
+Every controller has translation helpers scoped to the current request's locale:
+
+```ts
+export default class PostController extends Controller {
+  async index() {
+    this.locale                                  // 'ja'
+    this.t('messages.hello')                     // 'こんにちは'
+    this.t('messages.welcome', { name: 'ゲスト' }) // interpolation
+    this.tc('messages.items', 3)                 // pluralization
+    // ...
+  }
+}
+```
+
+## React Pages
+
+The server shares the resolved locale and its catalogs (active locale plus fallback) with Inertia pages as the `_i18n` prop, and `useTranslation()` consumes it:
+
+```tsx
+import { useTranslation } from '@guren/inertia-client'
+
+const { t, tc, locale } = useTranslation()
+```
+
+Client-side translation matches the server's semantics exactly — interpolation, plural forms, fallback lookup — so a key renders identically whether translated in a controller or in the browser. Server-side rendering needs no extra wiring; the shared prop covers both passes.
+
+Outside components (or for advanced cases) build a translator directly from the prop:
+
+```tsx
+import { createTranslator } from '@guren/inertia-client'
+import { usePage } from '@inertiajs/react'
+
+const translator = createTranslator(usePage().props._i18n)
+```
+
+Set `share: false` on the `i18n` option to keep catalogs out of page props (e.g. an app that only translates server-side).
+
+## Typed Translation Keys
+
+`guren codegen` reads `lang/` and generates `.guren/translations.gen.ts`, registering every key as a TypeScript union. From then on `this.t()`, `this.tc()`, and `useTranslation()`'s `t`/`tc` autocomplete keys and reject unknown ones at compile time:
+
+```ts
+this.t('messages.welcome')   // ✓ autocompleted
+this.t('messages.welcmoe')   // ✗ compile error
+```
+
+```bash
+bunx guren codegen
+```
+
+The dev server regenerates automatically when files under `lang/` change. Apps without a `lang/` directory keep plain `string` keys.
+
+## Checking Catalogs
+
+`guren check` validates translation catalogs (and `--i18n` runs just these checks, exiting non-zero on failures — useful in CI):
+
+```bash
+bunx guren check --i18n
+```
+
+It reports:
+
+- **Invalid JSON** — an unparseable catalog file is skipped by the loader, so all of its keys silently fall back at runtime.
+- **Missing keys** — a key present in one locale but missing from another renders in the fallback language for that locale's users.
+- **Placeholder mismatches** — `:name`/`{name}` placeholders that differ between locales for the same key usually mean a lost variable in translation.
+- **Unreachable keys** — property or file names containing literal dots, which the runtime cannot resolve.
+
+## Serverless and Bundled Catalogs
+
+`lang/` is read from the filesystem, which serverless targets may not ship. Bundle the catalogs instead with a `MemoryLoader`:
+
+```ts
+import { createApp, MemoryLoader } from '@guren/core'
+import en from '../lang/en/messages.json'
+import ja from '../lang/ja/messages.json'
+
+const app = createApp({
+  i18n: {
+    supported: ['en', 'ja'],
+    loader: new MemoryLoader({
+      en: { messages: en },
+      ja: { messages: ja },
+    }),
+  },
+})
+```
+
+The `loader` option accepts anything implementing the `TranslationLoader` interface, so catalogs can also come from a database or a remote service. Note that codegen and `check --i18n` read the conventional `lang/` directory — keeping the JSON files there (and bundling them via imports as above) preserves typed keys and catalog checks.
+
+## Testing
+
+Translation behavior is easiest to test through the app, the same way requests exercise it:
+
+```ts
+import { describe, test, expect } from 'bun:test'
+import app from '../src/app'
+
+describe('i18n', () => {
+  test('serves Japanese for ?locale=ja', async () => {
+    await app.boot()
+    const response = await app.fetch(new Request('http://localhost/?locale=ja'))
+    expect(await response.text()).toContain('こんにちは')
+  })
+})
+```
+
+For unit tests of catalogs themselves, build a manager directly:
 
 ```ts
 import { createI18n } from '@guren/core'
 
 const i18n = createI18n({
-  locale: 'custom',
-  messages: { /* ... */ },
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages: {
+    en: { messages: { items: 'One item|:count items' } },
+  },
 })
 
-// Set custom rule
-i18n.setPluralizationRule('custom', (count) => {
+expect(i18n.tc('messages.items', 5)).toBe('5 items')
+```
+
+## Advanced: Direct Manager Usage
+
+`createApp({ i18n })` manages an `I18nManager` for you (available from the container as `i18n`). For scripts, custom middleware, or non-HTTP contexts you can drive one directly:
+
+```ts
+import { I18nManager, JsonLoader, MemoryLoader, createI18n } from '@guren/core'
+
+const i18n = createI18n({
+  locale: 'en',
+  fallbackLocale: 'en',
+  loader: new JsonLoader('./lang', { cache: true }),
+})
+
+await i18n.loadLocale('ja')
+
+i18n.t('messages.hello')
+i18n.tc('messages.items', 5)
+i18n.has('messages.hello', 'ja')
+i18n.getAvailableLocales()
+
+// A translator pinned to one locale — safe to use concurrently,
+// unlike calling setLocale() on a shared manager.
+const ja = i18n.forLocale('ja')
+ja.t('messages.hello') // 'こんにちは'
+```
+
+Custom pluralization rules:
+
+```ts
+const translator = i18n.getTranslator()
+translator.setPluralizationRule('custom', (count) => {
   if (count === 0) return 0
   if (count === 1) return 1
   return 2
 })
 ```
 
-## Loading Translations
-
-### JSON Loader
-
-Load translations from JSON files:
-
-```
-lang/
-├── en/
-│   ├── messages.json
-│   └── validation.json
-└── ja/
-    ├── messages.json
-    └── validation.json
-```
-
-```ts
-import { I18nManager, JsonLoader } from '@guren/core'
-
-const loader = new JsonLoader('./lang', {
-  cache: true, // Enable caching (default: true)
-})
-
-const i18n = new I18nManager({
-  locale: 'en',
-  loader,
-})
-
-// Load locale on demand
-await i18n.loadLocale('ja')
-```
-
-### Memory Loader
-
-For testing or embedded translations:
-
-```ts
-import { MemoryLoader, I18nManager } from '@guren/core'
-
-const loader = new MemoryLoader({
-  en: {
-    messages: { hello: 'Hello' },
-  },
-  ja: {
-    messages: { hello: 'こんにちは' },
-  },
-})
-
-// Dynamically add messages
-loader.addMessages('fr', { messages: { hello: 'Bonjour' } })
-
-// Remove locale
-loader.removeLocale('fr')
-```
-
-## I18nManager
-
-### Creating the Manager
-
-```ts
-import { I18nManager, JsonLoader } from '@guren/core'
-
-const i18n = new I18nManager({
-  locale: 'en',           // Current locale
-  fallbackLocale: 'en',   // Fallback when translation missing
-  loader: new JsonLoader('./lang'),
-  messages: {
-    // Optional initial messages
-    en: { /* ... */ },
-  },
-})
-```
-
-### Locale Management
-
-```ts
-// Get/set current locale
-const locale = i18n.getLocale()
-i18n.setLocale('ja')
-
-// Get/set fallback locale
-const fallback = i18n.getFallbackLocale()
-i18n.setFallbackLocale('en')
-
-// Check loaded locales
-i18n.isLocaleLoaded('en')      // true
-i18n.getAvailableLocales()     // ['en', 'ja']
-
-// Load locale
-await i18n.loadLocale('fr')
-```
-
-### Translation Methods
-
-```ts
-// Simple translation
-i18n.t('messages.hello')
-
-// With replacements
-i18n.t('messages.welcome', { name: 'John' })
-
-// Pluralization
-i18n.tc('messages.items', 5)
-i18n.tc('messages.items', 5, { type: 'apple' })
-
-// Check if translation exists
-i18n.has('messages.hello')       // true
-i18n.has('messages.hello', 'ja') // check specific locale
-```
-
-### Scoped Translators
-
-```ts
-// Create translator for specific locale
-const jaTranslator = i18n.forLocale('ja')
-jaTranslator.t('messages.hello') // 'こんにちは'
-
-// Original manager unchanged
-i18n.getLocale() // still 'en'
-```
-
-## Global Functions
-
-### Setup Global Manager
-
-```ts
-import { createI18n, setI18n, getI18n, t, tc } from '@guren/core'
-
-// In bootstrap file
-const i18n = createI18n({
-  locale: 'en',
-  messages: { /* ... */ },
-})
-
-setI18n(i18n)
-
-// Anywhere in application
-t('messages.hello')
-tc('messages.items', 5)
-
-// Access manager
-const i18n = getI18n()
-```
-
-## Request Middleware
-
-### Per-Request Locale
-
-Use the built-in `detectLocaleMiddleware` to resolve each request's locale from the `?locale=` query parameter, a `locale` cookie, or the `Accept-Language` header (in that order), restricted to your supported locales:
-
-```ts
-import { detectLocaleMiddleware } from '@guren/core'
-
-app.use('*', detectLocaleMiddleware({ supported: ['en', 'ja'] }))
-```
-
-The middleware sets the `locale` context variable — which Inertia responses use for the root `<html lang>` attribute — and, when an i18n manager is available (the global one from `setI18n()`, or one passed via the `i18n` option), binds request-scoped `t`/`tc` translator helpers:
-
-```ts
-export class PostController extends Controller {
-  async index() {
-    const t = this.ctx.get('t')
-    return this.json({ message: t('messages.hello') })
-  }
-}
-```
-
-Options: `fallback` (defaults to the first supported locale), `sources` to change the detection order (e.g. `['header']`), `queryParam`, `cookieName`, and `i18n` to pass a manager explicitly (or `false` to skip the translator binding). `Accept-Language` matching understands region subtags (`ja-JP` matches `ja`) and q-values. Keep `supported` in sync with the locales your translation files actually provide — a locale missing from the list is never detected.
-
-Without the middleware, Inertia responses fall back to the app-wide i18n locale, then `en`. A per-response `lang` option always wins:
-
-```ts
-return this.inertia(pages.posts.Show, { post }, { lang: 'ja' })
-```
-
-### Using in Controllers
-
-```ts
-import { Controller } from '@guren/core'
-
-export class UserController extends Controller {
-  async index() {
-    const t = this.ctx.get('t')
-
-    return this.json({
-      message: t('messages.hello'),
-    })
-  }
-}
-```
-
-## Configuration
-
-### Full Configuration Example
-
-```ts
-import { I18nManager, JsonLoader } from '@guren/core'
-
-const i18n = new I18nManager({
-  locale: 'en',
-  fallbackLocale: 'en',
-  loader: new JsonLoader('./lang', { cache: true }),
-  messages: {
-    en: {
-      messages: {
-        hello: 'Hello',
-        goodbye: 'Goodbye',
-      },
-      validation: {
-        required: 'The :field field is required',
-        email: 'Please enter a valid email address',
-        min: 'Must be at least :min characters',
-      },
-      errors: {
-        not_found: 'Resource not found',
-        unauthorized: 'Please log in to continue',
-      },
-    },
-    ja: {
-      messages: {
-        hello: 'こんにちは',
-        goodbye: 'さようなら',
-      },
-      validation: {
-        required: ':fieldは必須です',
-        email: '有効なメールアドレスを入力してください',
-        min: ':min文字以上で入力してください',
-      },
-    },
-  },
-})
-```
-
-## Testing
-
-```ts
-import { describe, test, expect, beforeEach } from 'bun:test'
-import { createI18n, MemoryLoader } from '@guren/core'
-
-describe('Translations', () => {
-  let i18n
-
-  beforeEach(() => {
-    i18n = createI18n({
-      locale: 'en',
-      fallbackLocale: 'en',
-      messages: {
-        en: {
-          hello: 'Hello',
-          welcome: 'Welcome, :name!',
-          items: 'One item|:count items',
-        },
-        ja: {
-          hello: 'こんにちは',
-        },
-      },
-    })
-  })
-
-  test('translates simple key', () => {
-    expect(i18n.t('hello')).toBe('Hello')
-  })
-
-  test('translates with replacements', () => {
-    expect(i18n.t('welcome', { name: 'John' })).toBe('Welcome, John!')
-  })
-
-  test('handles pluralization', () => {
-    expect(i18n.tc('items', 1)).toBe('One item')
-    expect(i18n.tc('items', 5)).toBe('5 items')
-  })
-
-  test('switches locale', () => {
-    i18n.setLocale('ja')
-    expect(i18n.t('hello')).toBe('こんにちは')
-  })
-
-  test('falls back for missing translation', () => {
-    i18n.setLocale('ja')
-    expect(i18n.t('welcome', { name: 'John' })).toBe('Welcome, John!')
-  })
-
-  test('returns key for missing translation', () => {
-    expect(i18n.t('missing.key')).toBe('missing.key')
-  })
-})
-```
-
-## Translation File Structure
-
-### Recommended Organization
-
-```
-lang/
-├── en/
-│   ├── messages.json     # General messages
-│   ├── validation.json   # Validation messages
-│   ├── errors.json       # Error messages
-│   └── emails.json       # Email templates
-└── ja/
-    ├── messages.json
-    ├── validation.json
-    ├── errors.json
-    └── emails.json
-```
-
-### Example JSON Files
-
-```json
-// lang/en/messages.json
-{
-  "hello": "Hello",
-  "welcome": "Welcome, :name!",
-  "items": "One item|:count items",
-  "user": {
-    "profile": "Profile",
-    "settings": "Settings"
-  }
-}
-
-// lang/en/validation.json
-{
-  "required": "The :field field is required",
-  "email": "Please enter a valid email",
-  "min": {
-    "string": "Must be at least :min characters",
-    "numeric": "Must be at least :min"
-  }
-}
-```
+A `setI18n()`/`t()` global registry also exists for simple scripts. Avoid it in request handlers: a shared manager's `setLocale()` is process-wide state, so concurrent requests would override each other's locale. The request-scoped helpers (`this.t()`, `useTranslation()`) are always safe.
 
 ## Best Practices
 
-1. **Use namespaced keys**: Organize translations by feature (`user.profile.title`).
-
-2. **Set fallback locale**: Always configure a fallback for missing translations.
-
-3. **Include count in pluralization**: Use `:count` placeholder for dynamic numbers.
-
-4. **Cache in production**: Enable caching for JSON loader in production.
-
-5. **Keep translations organized**: Use separate files for different concerns.
-
-6. **Handle missing keys gracefully**: Use `onMissingKey` callback for logging.
-
-7. **Test translations**: Write tests to ensure all keys exist in all locales.
-
-8. **Load locales on demand**: Use `loadLocale()` for better performance.
+1. **Wire i18n through `createApp`**: the `i18n` option gives you detection, request-scoped helpers, and client sharing in one place.
+2. **Use namespaced keys**: organize translations by feature (`user.profile.title`), one file per namespace.
+3. **Keep locales in parity**: run `guren check --i18n` in CI so a key added to one locale can't silently ship untranslated.
+4. **Generate typed keys**: `guren codegen` turns key typos into compile errors instead of runtime fallbacks.
+5. **Never call `setLocale()` per request**: rely on the detected locale and request-scoped helpers.
+6. **Bundle catalogs on serverless**: use `MemoryLoader` with imported JSON where there is no filesystem.
+7. **Include `:count` in plural forms**: it interpolates automatically in `tc()`.

--- a/docs/en/guides/i18n.md
+++ b/docs/en/guides/i18n.md
@@ -76,7 +76,7 @@ export default function Nav() {
 }
 ```
 
-A visitor with `Accept-Language: ja` (or `?locale=ja`, or a `locale=ja` cookie) sees the Japanese catalog everywhere — server-rendered text, client-side text, and `<html lang="ja">` — with no further wiring.
+A visitor whose locale resolves to `ja` sees the Japanese catalog everywhere — server-rendered text, client-side text, and `<html lang="ja">` — with no further wiring.
 
 ## Translation Files
 
@@ -275,7 +275,7 @@ It reports:
 
 ## Serverless and Bundled Catalogs
 
-`lang/` is read from the filesystem, which serverless targets may not ship. Bundle the catalogs instead with a `MemoryLoader`:
+`lang/` is read from the filesystem, which serverless targets (see the [Serverless guide](./serverless.md)) may not ship. Bundle the catalogs instead with a `MemoryLoader`:
 
 ```ts
 import { createApp, MemoryLoader } from '@guren/core'
@@ -297,17 +297,25 @@ The `loader` option accepts anything implementing the `TranslationLoader` interf
 
 ## Testing
 
-Translation behavior is easiest to test through the app, the same way requests exercise it:
+Translation behavior is easiest to test through the real app — boot it and wrap it with `TestApp` (see the [Testing guide](./testing.md)):
 
 ```ts
-import { describe, test, expect } from 'bun:test'
-import app from '../src/app'
+import { describe, test, beforeAll } from 'bun:test'
+import { TestApp } from '@guren/testing'
+import app from '../src/app.js'
 
 describe('i18n', () => {
-  test('serves Japanese for ?locale=ja', async () => {
+  let http: TestApp
+
+  beforeAll(async () => {
     await app.boot()
-    const response = await app.fetch(new Request('http://localhost/?locale=ja'))
-    expect(await response.text()).toContain('こんにちは')
+    http = TestApp.fromFetch((request) => app.fetch(request))
+  })
+
+  test('serves Japanese for ?locale=ja', async () => {
+    const response = await http.get('/?locale=ja')
+    response.assertOk()
+    await response.assertBodyContains('こんにちは')
   })
 })
 ```
@@ -370,10 +378,11 @@ A `setI18n()`/`t()` global registry also exists for simple scripts. Avoid it in 
 
 ## Best Practices
 
-1. **Wire i18n through `createApp`**: the `i18n` option gives you detection, request-scoped helpers, and client sharing in one place.
-2. **Use namespaced keys**: organize translations by feature (`user.profile.title`), one file per namespace.
-3. **Keep locales in parity**: run `guren check --i18n` in CI so a key added to one locale can't silently ship untranslated.
-4. **Generate typed keys**: `guren codegen` turns key typos into compile errors instead of runtime fallbacks.
-5. **Never call `setLocale()` per request**: rely on the detected locale and request-scoped helpers.
-6. **Bundle catalogs on serverless**: use `MemoryLoader` with imported JSON where there is no filesystem.
-7. **Include `:count` in plural forms**: it interpolates automatically in `tc()`.
+1. **Keep locales in parity**: run `guren check --i18n` in CI so a key added to one locale can't silently ship untranslated.
+2. **Never call `setLocale()` per request**: rely on the detected locale and the request-scoped helpers.
+3. **Use namespaced keys**: organize translations by feature (`user.profile.title`), one file per namespace.
+
+## Next Steps
+
+- [Testing](./testing.md) — assert translated responses through `TestApp`
+- [Serverless](./serverless.md) — deploy targets without a filesystem

--- a/docs/en/guides/i18n.md
+++ b/docs/en/guides/i18n.md
@@ -47,6 +47,7 @@ Translate in a controller:
 
 ```ts
 import { Controller } from '@guren/core'
+import { pages } from '@/.guren/pages.gen'
 
 export default class HomeController extends Controller {
   async index() {
@@ -231,10 +232,11 @@ Client-side translation matches the server's semantics exactly — interpolation
 Outside components (or for advanced cases) build a translator directly from the prop:
 
 ```tsx
-import { createTranslator } from '@guren/inertia-client'
+import { createTranslator, type I18nPageProps } from '@guren/inertia-client'
 import { usePage } from '@inertiajs/react'
 
-const translator = createTranslator(usePage().props._i18n)
+const i18n = usePage().props._i18n as I18nPageProps
+const translator = createTranslator(i18n)
 ```
 
 Set `share: false` on the `i18n` option to keep catalogs out of page props (e.g. an app that only translates server-side).
@@ -266,7 +268,7 @@ It reports:
 
 - **Invalid JSON** — an unparseable catalog file is skipped by the loader, so all of its keys silently fall back at runtime.
 - **Missing keys** — a key present in one locale but missing from another renders in the fallback language for that locale's users.
-- **Placeholder mismatches** — `:name`/`{name}` placeholders that differ between locales for the same key usually mean a lost variable in translation.
+- **Placeholder mismatches** — `:name`/`{name}` placeholders that differ between locales for the same key usually mean a lost variable in translation. Reported as a warning (a locale can legitimately drop a placeholder), so it does not affect the exit code.
 - **Unreachable keys** — property or file names containing literal dots, which the runtime cannot resolve.
 
 ## Serverless and Bundled Catalogs

--- a/docs/en/guides/i18n.md
+++ b/docs/en/guides/i18n.md
@@ -228,7 +228,7 @@ import { useTranslation } from '@guren/inertia-client'
 const { t, tc, locale } = useTranslation()
 ```
 
-Client-side translation matches the server's semantics exactly — interpolation, plural forms, fallback lookup — so a key renders identically whether translated in a controller or in the browser. Server-side rendering needs no extra wiring; the shared prop covers both passes.
+Client-side translation matches the server's default semantics — interpolation, plural forms, fallback lookup — so a key renders identically whether translated in a controller or in the browser. (Server-only Translator customizations such as custom pluralization rules or an `onMissingKey` handler are functions and cannot travel in the serialized prop, so they apply on the server only.) Server-side rendering needs no extra wiring; the shared prop covers both passes.
 
 Code that already holds the Inertia page object — outside the hook — can build a translator directly from the prop:
 
@@ -341,7 +341,7 @@ expect(i18n.tc('messages.items', 5)).toBe('5 items')
 `createApp({ i18n })` manages an `I18nManager` for you (available from the container as `i18n`). For scripts, custom middleware, or non-HTTP contexts you can drive one directly:
 
 ```ts
-import { I18nManager, JsonLoader, MemoryLoader, createI18n } from '@guren/core'
+import { JsonLoader, createI18n } from '@guren/core'
 
 const i18n = createI18n({
   locale: 'en',
@@ -374,7 +374,7 @@ translator.setPluralizationRule('custom', (count) => {
 })
 ```
 
-A `setI18n()`/`t()` global registry also exists for simple scripts. Avoid it in request handlers: a shared manager's `setLocale()` is process-wide state, so concurrent requests would override each other's locale. The request-scoped helpers (`this.t()`, `useTranslation()`) are always safe.
+A `setI18n()`/`t()` global registry also exists for simple scripts. Avoid it in request handlers: a shared manager's `setLocale()` is process-wide state, so concurrent requests would override each other's locale. In apps wired through `createApp({ i18n })`, the request-scoped helpers (`this.t()`, `useTranslation()`) are safe — they resolve through the request and the app's container, never through shared mutable locale state.
 
 ## Best Practices
 

--- a/docs/en/guides/testing.md
+++ b/docs/en/guides/testing.md
@@ -44,6 +44,37 @@ await app.patch('/posts/1', body)
 await app.delete('/posts/1')
 ```
 
+### Wrapping the real application
+
+`TestApp.create({ ... })` assembles an app from the parts you pass — good for isolated slices, but the subset can silently drift from what the server actually runs (providers, `auth`, `i18n`, security defaults). For tests that should exercise the real configuration, boot the app your project exports and wrap its fetch handler:
+
+```ts
+import { TestApp } from '@guren/testing'
+import app from '../src/app.js'
+
+let http: TestApp
+
+beforeAll(async () => {
+  await app.boot()
+  http = TestApp.fromFetch((request) => app.fetch(request))
+})
+
+test('serves the home page', async () => {
+  await http.get('/').assertOk()
+})
+```
+
+This is the pattern scaffolded apps ship with. Pass `app.fetch` through an arrow function — the method reads instance state, so handing the unbound reference over throws on the first request.
+
+When you do assemble an app from parts, `TestApp.create()` mirrors `createApp`'s options: pass `auth` to mount session + CSRF middleware, and `i18n` when controllers under test use `this.t()` / `this.tc()`:
+
+```ts
+const app = await TestApp.create({
+  routes: registerWebRoutes,
+  i18n: { supported: ['en'] },
+})
+```
+
 ### Fluent Assertions
 
 Chain assertions directly on the response:

--- a/docs/ja/guides/controllers.md
+++ b/docs/ja/guides/controllers.md
@@ -261,17 +261,20 @@ FormRequest クラスとバリデーションルールの定義については�
 `shareInertiaProps()` を使って、すべての Inertia レスポンスにアプリケーション全体のデータを注入できます。サービスプロバイダー（`bunx guren make:provider` で生成）の `boot()` から呼ぶのが定位置です。
 
 ```ts
-// app/Providers/LocaleProvider.ts
+// app/Providers/AppInfoProvider.ts
 import { ServiceProvider, shareInertiaProps } from '@guren/core'
 
-export default class LocaleProvider extends ServiceProvider {
+export default class AppInfoProvider extends ServiceProvider {
   boot(): void {
-    shareInertiaProps((ctx) => ({
-      i18n: { locale: ctx.req.header('accept-language')?.split(',')[0] ?? 'en' },
+    shareInertiaProps(() => ({
+      appVersion: process.env.APP_VERSION ?? 'dev',
     }), this.container)
   }
 }
 ```
+
+> [!NOTE]
+> リクエストのロケールと翻訳カタログは、`createApp({ i18n })` でアプリを作成していれば自動的に共有されます — [i18nガイド](./i18n.md)を参照してください。ここでロケール検出を手書きする必要はありません。
 
 先に登録されたリゾルバーの props にマージされるので、複数のプロバイダーがそれぞれ共有 props を足しても互いを壊しません。
 

--- a/docs/ja/guides/i18n.md
+++ b/docs/ja/guides/i18n.md
@@ -9,6 +9,7 @@ Gurenは国際化を一気通貫でサポートします: ファイルベース�
 ```ts
 // src/app.ts
 import { createApp } from '@guren/core'
+import { registerWebRoutes } from '../routes/web.js'
 
 const app = createApp({
   routes: registerWebRoutes,
@@ -153,7 +154,7 @@ this.tc('messages.item', 10)  // '10 items'
 | 英語・ドイツ語・スペイン語・イタリア語・ポルトガル語・オランダ語 | 2 | 1=単数、それ以外は複数 |
 | フランス語・ブラジルポルトガル語 | 2 | 0-1=単数、それ以外は複数 |
 | 日本語・中国語・韓国語・ベトナム語・タイ語 | 1 | 複数形なし |
-| ロシア語・ウクライナ語 | 3 | one、few(2-4)、many(5+) |
+| ロシア語・ウクライナ語 | 3 | mod-10/mod-100によるone/few/many(21は「one」、22-24は「few」) |
 | ポーランド語・チェコ語・スロバキア語 | 3 | 複雑なルール |
 | アラビア語 | 6 | 最も複雑な複数形化 |
 
@@ -229,14 +230,15 @@ const { t, tc, locale } = useTranslation()
 
 クライアント側の翻訳はサーバーとセマンティクスが完全に一致します — 補間、複数形、フォールバック解決。同じキーはコントローラーで翻訳してもブラウザで翻訳しても同じ結果になります。サーバーサイドレンダリングも共有props経由なので追加配線は不要です。
 
-コンポーネント外(または高度なケース)では、propから直接translatorを構築できます:
+Inertiaのpageオブジェクトを既に持っているコード(フックの外)では、propから直接translatorを構築できます:
 
 ```tsx
 import { createTranslator, type I18nPageProps } from '@guren/inertia-client'
-import { usePage } from '@inertiajs/react'
+import type { Page } from '@inertiajs/core'
 
-const i18n = usePage().props._i18n as I18nPageProps
-const translator = createTranslator(i18n)
+export function translatorFor(page: Page) {
+  return createTranslator(page.props._i18n as I18nPageProps)
+}
 ```
 
 サーバー側だけで翻訳するアプリでは、`i18n`オプションに`share: false`を設定するとカタログをページpropsに含めません。
@@ -254,7 +256,7 @@ this.t('messages.welcmoe')   // ✗ コンパイルエラー
 bunx guren codegen
 ```
 
-開発サーバーは`lang/`配下のファイル変更で自動再生成します。`lang/`ディレクトリのないアプリではキーは通常の`string`のままです。
+開発サーバーは`lang/`配下の翻訳JSONファイルの変更で自動再生成します。`lang/`ディレクトリのないアプリではキーは通常の`string`のままです。
 
 ## カタログのチェック
 
@@ -266,8 +268,8 @@ bunx guren check --i18n
 
 報告される項目:
 
-- **不正なJSON** — パースできないカタログファイルはローダーがスキップするため、そのキーは実行時に静かにフォールバックします。
-- **キーの欠落** — あるロケールにあって別のロケールにないキーは、そのロケールの利用者にフォールバック言語で表示されます。
+- **不正なJSON** — パースできないカタログファイルはローダーがスキップし(コンソール警告のみ)、そのキーは実行時にフォールバックします。
+- **キーの欠落** — あるロケールにあって別のロケールにないキーは、そのロケールの利用者にフォールバック言語で表示されます(フォールバックにもない場合はキー文字列がそのまま表示されます)。
 - **プレースホルダの不一致** — 同じキーでロケール間で`:name`/`{name}`が異なる場合、翻訳時に変数が失われている可能性が高いです。警告として報告され(ロケールによっては意図的にプレースホルダを省くこともあるため)、exit codeには影響しません。
 - **解決不能なキー** — リテラルのドットを含むプロパティ名・ファイル名。実行時に解決できません。
 
@@ -339,7 +341,8 @@ const i18n = createI18n({
   loader: new JsonLoader('./lang', { cache: true }),
 })
 
-await i18n.loadLocale('ja')
+// マネージャは構築時に何もロードしません — 使うロケールをすべてロードします。
+await i18n.loadLocales(['en', 'ja'])
 
 i18n.t('messages.hello')
 i18n.tc('messages.items', 5)

--- a/docs/ja/guides/i18n.md
+++ b/docs/ja/guides/i18n.md
@@ -76,7 +76,7 @@ export default function Nav() {
 }
 ```
 
-`Accept-Language: ja`(または`?locale=ja`、`locale=ja`クッキー)の訪問者には、サーバーレンダリングのテキストもクライアント側のテキストも`<html lang="ja">`も、追加の配線なしで日本語カタログが適用されます。
+ロケールが`ja`に解決された訪問者には、サーバーレンダリングのテキストもクライアント側のテキストも`<html lang="ja">`も、追加の配線なしで日本語カタログが適用されます。
 
 ## 翻訳ファイル
 
@@ -275,7 +275,7 @@ bunx guren check --i18n
 
 ## サーバーレスとバンドルカタログ
 
-`lang/`はファイルシステムから読まれますが、サーバーレス環境にはファイルシステムがない場合があります。`MemoryLoader`でカタログをバンドルしてください:
+`lang/`はファイルシステムから読まれますが、サーバーレス環境([サーバーレスガイド](./serverless.md)参照)にはファイルシステムがない場合があります。`MemoryLoader`でカタログをバンドルしてください:
 
 ```ts
 import { createApp, MemoryLoader } from '@guren/core'
@@ -297,17 +297,25 @@ const app = createApp({
 
 ## テスト
 
-翻訳の挙動は、実リクエストと同じ経路でアプリを通してテストするのが最も簡単です:
+翻訳の挙動は実アプリを通してテストするのが最も簡単です — bootして`TestApp`でラップします([テストガイド](./testing.md)参照):
 
 ```ts
-import { describe, test, expect } from 'bun:test'
-import app from '../src/app'
+import { describe, test, beforeAll } from 'bun:test'
+import { TestApp } from '@guren/testing'
+import app from '../src/app.js'
 
 describe('i18n', () => {
-  test('?locale=ja で日本語を返す', async () => {
+  let http: TestApp
+
+  beforeAll(async () => {
     await app.boot()
-    const response = await app.fetch(new Request('http://localhost/?locale=ja'))
-    expect(await response.text()).toContain('こんにちは')
+    http = TestApp.fromFetch((request) => app.fetch(request))
+  })
+
+  test('?locale=ja で日本語を返す', async () => {
+    const response = await http.get('/?locale=ja')
+    response.assertOk()
+    await response.assertBodyContains('こんにちは')
   })
 })
 ```
@@ -370,10 +378,11 @@ translator.setPluralizationRule('custom', (count) => {
 
 ## ベストプラクティス
 
-1. **i18nは`createApp`で配線する**: `i18n`オプションひとつで検出・リクエストスコープヘルパー・クライアント共有が揃います。
-2. **名前空間付きキーを使う**: 機能ごとに整理し(`user.profile.title`)、名前空間ごとに1ファイルにします。
-3. **ロケール間のパリティを保つ**: CIで`guren check --i18n`を回し、片方のロケールにだけ追加されたキーが未翻訳のまま出荷されるのを防ぎます。
-4. **型付きキーを生成する**: `guren codegen`でキーのtypoが実行時フォールバックではなくコンパイルエラーになります。
-5. **リクエスト中に`setLocale()`を呼ばない**: 検出済みロケールとリクエストスコープのヘルパーに任せます。
-6. **サーバーレスではカタログをバンドルする**: ファイルシステムのない環境ではJSON importと`MemoryLoader`を使います。
-7. **複数形には`:count`を入れる**: `tc()`で自動的に補間されます。
+1. **ロケール間のパリティを保つ**: CIで`guren check --i18n`を回し、片方のロケールにだけ追加されたキーが未翻訳のまま出荷されるのを防ぎます。
+2. **リクエスト中に`setLocale()`を呼ばない**: 検出済みロケールとリクエストスコープのヘルパーに任せます。
+3. **名前空間付きキーを使う**: 機能ごとに整理し(`user.profile.title`)、名前空間ごとに1ファイルにします。
+
+## 次のステップ
+
+- [テスト](./testing.md) — `TestApp`で翻訳済みレスポンスを検証する
+- [サーバーレス](./serverless.md) — ファイルシステムのないデプロイ先

--- a/docs/ja/guides/i18n.md
+++ b/docs/ja/guides/i18n.md
@@ -228,7 +228,7 @@ import { useTranslation } from '@guren/inertia-client'
 const { t, tc, locale } = useTranslation()
 ```
 
-クライアント側の翻訳はサーバーとセマンティクスが完全に一致します — 補間、複数形、フォールバック解決。同じキーはコントローラーで翻訳してもブラウザで翻訳しても同じ結果になります。サーバーサイドレンダリングも共有props経由なので追加配線は不要です。
+クライアント側の翻訳はサーバーのデフォルトセマンティクスと一致します — 補間、複数形、フォールバック解決。同じキーはコントローラーで翻訳してもブラウザで翻訳しても同じ結果になります。(カスタム複数形化ルールや`onMissingKey`ハンドラなどサーバー専用のTranslatorカスタマイズは関数のためシリアライズされたpropを越えられず、サーバー側のみに適用されます。)サーバーサイドレンダリングも共有props経由なので追加配線は不要です。
 
 Inertiaのpageオブジェクトを既に持っているコード(フックの外)では、propから直接translatorを構築できます:
 
@@ -341,7 +341,7 @@ expect(i18n.tc('messages.items', 5)).toBe('5 items')
 `createApp({ i18n })`は`I18nManager`を管理してくれます(コンテナから`i18n`で取得可能)。スクリプト、カスタムミドルウェア、HTTP以外の文脈では直接使えます:
 
 ```ts
-import { I18nManager, JsonLoader, MemoryLoader, createI18n } from '@guren/core'
+import { JsonLoader, createI18n } from '@guren/core'
 
 const i18n = createI18n({
   locale: 'en',
@@ -374,7 +374,7 @@ translator.setPluralizationRule('custom', (count) => {
 })
 ```
 
-シンプルなスクリプト向けに`setI18n()`/`t()`のグローバルレジストリもあります。ただしリクエストハンドラでは使わないでください: 共有マネージャの`setLocale()`はプロセス全体の状態なので、並行リクエストが互いのロケールを上書きします。リクエストスコープのヘルパー(`this.t()`、`useTranslation()`)は常に安全です。
+シンプルなスクリプト向けに`setI18n()`/`t()`のグローバルレジストリもあります。ただしリクエストハンドラでは使わないでください: 共有マネージャの`setLocale()`はプロセス全体の状態なので、並行リクエストが互いのロケールを上書きします。`createApp({ i18n })`で配線したアプリでは、リクエストスコープのヘルパー(`this.t()`、`useTranslation()`)は安全です — リクエストとアプリのコンテナ経由で解決され、共有の可変ロケール状態を通りません。
 
 ## ベストプラクティス
 

--- a/docs/ja/guides/i18n.md
+++ b/docs/ja/guides/i18n.md
@@ -47,6 +47,7 @@ const app = createApp({
 
 ```ts
 import { Controller } from '@guren/core'
+import { pages } from '@/.guren/pages.gen'
 
 export default class HomeController extends Controller {
   async index() {
@@ -231,10 +232,11 @@ const { t, tc, locale } = useTranslation()
 コンポーネント外(または高度なケース)では、propから直接translatorを構築できます:
 
 ```tsx
-import { createTranslator } from '@guren/inertia-client'
+import { createTranslator, type I18nPageProps } from '@guren/inertia-client'
 import { usePage } from '@inertiajs/react'
 
-const translator = createTranslator(usePage().props._i18n)
+const i18n = usePage().props._i18n as I18nPageProps
+const translator = createTranslator(i18n)
 ```
 
 サーバー側だけで翻訳するアプリでは、`i18n`オプションに`share: false`を設定するとカタログをページpropsに含めません。
@@ -266,7 +268,7 @@ bunx guren check --i18n
 
 - **不正なJSON** — パースできないカタログファイルはローダーがスキップするため、そのキーは実行時に静かにフォールバックします。
 - **キーの欠落** — あるロケールにあって別のロケールにないキーは、そのロケールの利用者にフォールバック言語で表示されます。
-- **プレースホルダの不一致** — 同じキーでロケール間で`:name`/`{name}`が異なる場合、翻訳時に変数が失われている可能性が高いです。
+- **プレースホルダの不一致** — 同じキーでロケール間で`:name`/`{name}`が異なる場合、翻訳時に変数が失われている可能性が高いです。警告として報告され(ロケールによっては意図的にプレースホルダを省くこともあるため)、exit codeには影響しません。
 - **解決不能なキー** — リテラルのドットを含むプロパティ名・ファイル名。実行時に解決できません。
 
 ## サーバーレスとバンドルカタログ

--- a/docs/ja/guides/i18n.md
+++ b/docs/ja/guides/i18n.md
@@ -1,502 +1,374 @@
-# 国際化（i18n）ガイド
+# 国際化(i18n)ガイド
 
-Guren は翻訳管理、複数言語の複数形サポート、ファイルベースとメモリベースの両方のローダーを備えた包括的な国際化システムを提供します。
+Gurenは国際化を一気通貫でサポートします: ファイルベースの翻訳カタログ、リクエスト単位のロケール検出、コントローラーとReactページの翻訳ヘルパー、15言語超の複数形化ルール、型付き翻訳キー、そしてカタログの整合性チェッカーです。
 
-## コアコンセプト
+## クイックスタート
 
-- **I18nManager** – 翻訳とロケールを管理する中央ハブ。
-- **Translator** – コンテキスト付きで翻訳を実行するインスタンス。
-- **TranslationLoader** – 翻訳を読み込むインターフェース（JSONファイルまたはメモリ）。
-- **複数形処理** – 15以上の言語に対応した組み込みルールとカスタマイズ可能な形式。
-
-## 基本的な使い方
-
-### クイックスタート
+`createApp`に`i18n`オプションを渡し、カタログを`lang/<locale>/`に置くだけで有効になります:
 
 ```ts
-import { createI18n, setI18n, t, tc } from '@guren/core'
+// src/app.ts
+import { createApp } from '@guren/core'
 
-const i18n = createI18n({
-  locale: 'en',
-  fallbackLocale: 'en',
-  messages: {
-    en: {
-      messages: {
-        hello: 'Hello',
-        welcome: 'Welcome, :name!',
-        items: 'One item|:count items',
-      },
-    },
-    ja: {
-      messages: {
-        hello: 'こんにちは',
-        welcome: 'ようこそ、:nameさん！',
-      },
-    },
-  },
-})
-
-setI18n(i18n)
-
-// 翻訳
-t('messages.hello')                    // 'Hello'
-t('messages.welcome', { name: 'John' }) // 'Welcome, John!'
-
-// 複数形
-tc('messages.items', 1)  // 'One item'
-tc('messages.items', 5)  // '5 items'
-```
-
-### 置換構文
-
-変数置換には2つの形式がサポートされています。
-
-```ts
-// Laravel形式 :variable
-const messages = { greeting: 'Hello, :name!' }
-t('greeting', { name: 'World' }) // 'Hello, World!'
-
-// ブレース形式 {variable}
-const messages = { greeting: 'Hello, {name}!' }
-t('greeting', { name: 'World' }) // 'Hello, World!'
-```
-
-### ネストされたキー
-
-ドット記法でネストされた翻訳キーにアクセスできます。
-
-```ts
-const messages = {
-  en: {
-    user: {
-      profile: {
-        title: 'ユーザープロフィール',
-        settings: '設定',
-      },
-    },
-  },
-}
-
-t('user.profile.title')    // 'ユーザープロフィール'
-t('user.profile.settings') // '設定'
-```
-
-## 複数形処理
-
-### 基本的な複数形処理
-
-複数形を`|`で区切ります。
-
-```ts
-const messages = {
-  en: {
-    apple: 'apple|apples',
-    item: 'One item|:count items',
-  },
-}
-
-tc('apple', 1)  // 'apple'
-tc('apple', 5)  // 'apples'
-
-tc('item', 1)   // 'One item'
-tc('item', 10)  // '10 items'
-```
-
-### サポートされている言語
-
-組み込みの複数形ルールは以下のとおりです。
-
-| 言語 | 形式数 | ルール |
-|------|--------|--------|
-| 英語、ドイツ語、スペイン語、イタリア語、ポルトガル語、オランダ語 | 2 | 1 = 単数、それ以外 = 複数 |
-| フランス語、ブラジルポルトガル語 | 2 | 0-1 = 単数、それ以外 = 複数 |
-| 日本語、中国語、韓国語、ベトナム語、タイ語 | 1 | 複数形なし |
-| ロシア語、ウクライナ語 | 3 | 1、少数（2-4）、多数（5+） |
-| ポーランド語、チェコ語、スロバキア語 | 3 | 複雑なルール |
-| アラビア語 | 6 | 最も複雑な複数形処理 |
-
-### 複雑な複数形処理
-
-複数の複数形を持つ言語の場合は次のように記述します。
-
-```ts
-const messages = {
-  ru: {
-    // ロシア語: 1 | 少数 | 多数
-    apple: 'яблоко|яблока|яблок',
-  },
-}
-
-i18n.setLocale('ru')
-tc('apple', 1)   // 'яблоко' (1)
-tc('apple', 2)   // 'яблока' (少数)
-tc('apple', 5)   // 'яблок' (多数)
-tc('apple', 21)  // 'яблоко' (1 - 特殊ケース)
-```
-
-### カスタム複数形ルール
-
-```ts
-import { createI18n } from '@guren/core'
-
-const i18n = createI18n({
-  locale: 'custom',
-  messages: { /* ... */ },
-})
-
-// カスタムルールを設定
-i18n.setPluralizationRule('custom', (count) => {
-  if (count === 0) return 0
-  if (count === 1) return 1
-  return 2
-})
-```
-
-## 翻訳の読み込み
-
-### JSONローダー
-
-JSONファイルから翻訳を読み込めます。
-
-```
-lang/
-├── en/
-│   ├── messages.json
-│   └── validation.json
-└── ja/
-    ├── messages.json
-    └── validation.json
-```
-
-```ts
-import { I18nManager, JsonLoader } from '@guren/core'
-
-const loader = new JsonLoader('./lang', {
-  cache: true, // キャッシュを有効化（デフォルト: true）
-})
-
-const i18n = new I18nManager({
-  locale: 'en',
-  loader,
-})
-
-// オンデマンドでロケールを読み込み
-await i18n.loadLocale('ja')
-```
-
-### メモリローダー
-
-テストや埋め込み翻訳に使用します。
-
-```ts
-import { MemoryLoader, I18nManager } from '@guren/core'
-
-const loader = new MemoryLoader({
-  en: {
-    messages: { hello: 'Hello' },
-  },
-  ja: {
-    messages: { hello: 'こんにちは' },
-  },
-})
-
-// 動的にメッセージを追加
-loader.addMessages('fr', { messages: { hello: 'Bonjour' } })
-
-// ロケールを削除
-loader.removeLocale('fr')
-```
-
-## I18nManager
-
-### マネージャーの作成
-
-```ts
-import { I18nManager, JsonLoader } from '@guren/core'
-
-const i18n = new I18nManager({
-  locale: 'en',           // 現在のロケール
-  fallbackLocale: 'en',   // 翻訳がない場合のフォールバック
-  loader: new JsonLoader('./lang'),
-  messages: {
-    // オプションの初期メッセージ
-    en: { /* ... */ },
+const app = createApp({
+  routes: registerWebRoutes,
+  i18n: {
+    supported: ['en', 'ja'], // 先頭がデフォルト(フォールバック)ロケール
   },
 })
 ```
-
-### ロケール管理
-
-```ts
-// 現在のロケールを取得/設定
-const locale = i18n.getLocale()
-i18n.setLocale('ja')
-
-// フォールバックロケールを取得/設定
-const fallback = i18n.getFallbackLocale()
-i18n.setFallbackLocale('en')
-
-// 読み込まれたロケールを確認
-i18n.isLocaleLoaded('en')      // true
-i18n.getAvailableLocales()     // ['en', 'ja']
-
-// ロケールを読み込み
-await i18n.loadLocale('fr')
-```
-
-### 翻訳メソッド
-
-```ts
-// シンプルな翻訳
-i18n.t('messages.hello')
-
-// 置換付き
-i18n.t('messages.welcome', { name: 'John' })
-
-// 複数形
-i18n.tc('messages.items', 5)
-i18n.tc('messages.items', 5, { type: 'apple' })
-
-// 翻訳が存在するか確認
-i18n.has('messages.hello')       // true
-i18n.has('messages.hello', 'ja') // 特定のロケールを確認
-```
-
-### スコープ付きトランスレーター
-
-```ts
-// 特定のロケール用のトランスレーターを作成
-const jaTranslator = i18n.forLocale('ja')
-jaTranslator.t('messages.hello') // 'こんにちは'
-
-// 元のマネージャーは変更されない
-i18n.getLocale() // まだ 'en'
-```
-
-## グローバル関数
-
-### グローバルマネージャーのセットアップ
-
-```ts
-import { createI18n, setI18n, getI18n, t, tc } from '@guren/core'
-
-// ブートストラップファイルで
-const i18n = createI18n({
-  locale: 'en',
-  messages: { /* ... */ },
-})
-
-setI18n(i18n)
-
-// アプリケーションのどこでも
-t('messages.hello')
-tc('messages.items', 5)
-
-// マネージャーにアクセス
-const i18n = getI18n()
-```
-
-## リクエストミドルウェア
-
-### リクエストごとのロケール
-
-組み込みの `detectLocaleMiddleware` を使うと、`?locale=` クエリパラメータ・`locale` Cookie・`Accept-Language` ヘッダーの順でリクエストのロケールを解決できます(サポート対象のロケールに限定されます):
-
-```ts
-import { detectLocaleMiddleware } from '@guren/core'
-
-app.use('*', detectLocaleMiddleware({ supported: ['en', 'ja'] }))
-```
-
-このミドルウェアは `locale` コンテキスト変数をセットし(Inertia レスポンスのルート `<html lang>` 属性に使われます)、i18n マネージャーが利用可能な場合(`setI18n()` のグローバル、または `i18n` オプションで渡したもの)はリクエストスコープの `t`/`tc` トランスレーターヘルパーもバインドします:
-
-```ts
-export class PostController extends Controller {
-  async index() {
-    const t = this.ctx.get('t')
-    return this.json({ message: t('messages.hello') })
-  }
-}
-```
-
-オプション: `fallback`(デフォルトはサポート対象の先頭)、検出順を変える `sources`(例: `['header']`)、`queryParam`、`cookieName`、マネージャーを明示的に渡す `i18n`(`false` でトランスレーターのバインドを停止)。`Accept-Language` のマッチングはリージョンサブタグ(`ja-JP` は `ja` にマッチ)と q 値を理解します。`supported` は翻訳ファイルが実際に提供するロケールと同期させてください — リストに無いロケールは検出されません。
-
-ミドルウェアを使わない場合、Inertia レスポンスはアプリ全体の i18n ロケール、それも無ければ `en` にフォールバックします。レスポンスごとの `lang` オプションが常に優先されます:
-
-```ts
-return this.inertia(pages.posts.Show, { post }, { lang: 'ja' })
-```
-
-### コントローラーでの使用
-
-```ts
-import { Controller } from '@guren/core'
-
-export class UserController extends Controller {
-  async index() {
-    const t = this.ctx.get('t')
-
-    return this.json({
-      message: t('messages.hello'),
-    })
-  }
-}
-```
-
-## 設定
-
-### 完全な設定例
-
-```ts
-import { I18nManager, JsonLoader } from '@guren/core'
-
-const i18n = new I18nManager({
-  locale: 'en',
-  fallbackLocale: 'en',
-  loader: new JsonLoader('./lang', { cache: true }),
-  messages: {
-    en: {
-      messages: {
-        hello: 'Hello',
-        goodbye: 'Goodbye',
-      },
-      validation: {
-        required: 'The :field field is required',
-        email: 'Please enter a valid email address',
-        min: 'Must be at least :min characters',
-      },
-      errors: {
-        not_found: 'Resource not found',
-        unauthorized: 'Please log in to continue',
-      },
-    },
-    ja: {
-      messages: {
-        hello: 'こんにちは',
-        goodbye: 'さようなら',
-      },
-      validation: {
-        required: ':fieldは必須です',
-        email: '有効なメールアドレスを入力してください',
-        min: ':min文字以上で入力してください',
-      },
-    },
-  },
-})
-```
-
-## テスト
-
-```ts
-import { describe, test, expect, beforeEach } from 'bun:test'
-import { createI18n, MemoryLoader } from '@guren/core'
-
-describe('翻訳', () => {
-  let i18n
-
-  beforeEach(() => {
-    i18n = createI18n({
-      locale: 'en',
-      fallbackLocale: 'en',
-      messages: {
-        en: {
-          hello: 'Hello',
-          welcome: 'Welcome, :name!',
-          items: 'One item|:count items',
-        },
-        ja: {
-          hello: 'こんにちは',
-        },
-      },
-    })
-  })
-
-  test('シンプルなキーを翻訳する', () => {
-    expect(i18n.t('hello')).toBe('Hello')
-  })
-
-  test('置換付きで翻訳する', () => {
-    expect(i18n.t('welcome', { name: 'John' })).toBe('Welcome, John!')
-  })
-
-  test('複数形を処理する', () => {
-    expect(i18n.tc('items', 1)).toBe('One item')
-    expect(i18n.tc('items', 5)).toBe('5 items')
-  })
-
-  test('ロケールを切り替える', () => {
-    i18n.setLocale('ja')
-    expect(i18n.t('hello')).toBe('こんにちは')
-  })
-
-  test('存在しない翻訳にフォールバックする', () => {
-    i18n.setLocale('ja')
-    expect(i18n.t('welcome', { name: 'John' })).toBe('Welcome, John!')
-  })
-
-  test('存在しない翻訳はキーを返す', () => {
-    expect(i18n.t('missing.key')).toBe('missing.key')
-  })
-})
-```
-
-## 翻訳ファイル構造
-
-### 推奨される構成
-
-```
-lang/
-├── en/
-│   ├── messages.json     # 一般的なメッセージ
-│   ├── validation.json   # バリデーションメッセージ
-│   ├── errors.json       # エラーメッセージ
-│   └── emails.json       # メールテンプレート
-└── ja/
-    ├── messages.json
-    ├── validation.json
-    ├── errors.json
-    └── emails.json
-```
-
-### JSONファイルの例
 
 ```json
 // lang/en/messages.json
 {
   "hello": "Hello",
   "welcome": "Welcome, :name!",
-  "items": "One item|:count items",
+  "items": "One item|:count items"
+}
+```
+
+```json
+// lang/ja/messages.json
+{
+  "hello": "こんにちは",
+  "welcome": "ようこそ、:nameさん！",
+  "items": ":count個"
+}
+```
+
+このオプションひとつで次がすべて配線されます:
+
+- 起動時に`lang/<locale>/*.json`からサポート対象の全ロケールをロード
+- 各リクエストのロケールを`?locale=`クエリパラメータ→`locale`クッキー→`Accept-Language`ヘッダの順で検出(`supported`の範囲内のみ)
+- コントローラーでは`this.t()` / `this.tc()`、Inertiaページでは`useTranslation()`で翻訳
+- Inertiaレスポンスは解決済みロケールを`<html lang>`に反映し、アクティブなカタログをクライアントへ共有
+
+コントローラーでの翻訳:
+
+```ts
+import { Controller } from '@guren/core'
+
+export default class HomeController extends Controller {
+  async index() {
+    return this.inertia(pages.Home, {
+      message: this.t('messages.welcome', { name: 'Guren' }),
+    })
+  }
+}
+```
+
+Reactページ・コンポーネントでの翻訳:
+
+```tsx
+import { useTranslation } from '@guren/inertia-client'
+
+export default function Nav() {
+  const { t, tc, locale } = useTranslation()
+
+  return (
+    <nav>
+      <span>{t('messages.hello')}</span>
+      <span>{tc('messages.items', 5)}</span> {/* '5 items' / '5個' */}
+    </nav>
+  )
+}
+```
+
+`Accept-Language: ja`(または`?locale=ja`、`locale=ja`クッキー)の訪問者には、サーバーレンダリングのテキストもクライアント側のテキストも`<html lang="ja">`も、追加の配線なしで日本語カタログが適用されます。
+
+## 翻訳ファイル
+
+カタログはロケールごとのディレクトリに置きます。JSONファイル1つが1つの名前空間になり、ネストしたオブジェクトはドット記法のキーになります:
+
+```
+lang/
+├── en/
+│   ├── messages.json     # キー: messages.*
+│   ├── validation.json   # キー: validation.*
+│   └── errors.json       # キー: errors.*
+└── ja/
+    ├── messages.json
+    ├── validation.json
+    └── errors.json
+```
+
+```json
+// lang/en/messages.json
+{
+  "hello": "Hello",
   "user": {
     "profile": "Profile",
     "settings": "Settings"
   }
 }
+```
 
-// lang/en/validation.json
+```ts
+this.t('messages.hello')        // 'Hello'
+this.t('messages.user.profile') // 'Profile'
+```
+
+ドットは常にパス区切りです。プロパティ名やファイル名にリテラルのドットが含まれる場合(`"a.b": "..."`、`nav.admin.json`)は実行時に解決できず、`guren check --i18n`が報告します。代わりにオブジェクトをネストしてください。
+
+アクティブロケールにないキーはフォールバックロケール(`supported`の先頭、または`fallback`オプション)にフォールバックし、どこにもないキーはキー文字列そのものが返ります。
+
+## 補間
+
+プレースホルダは2つの記法をサポートし、どちらも値をリテラルとして挿入します(置換値がパターンとして解釈されることはありません):
+
+```json
 {
-  "required": "The :field field is required",
-  "email": "Please enter a valid email",
-  "min": {
-    "string": "Must be at least :min characters",
-    "numeric": "Must be at least :min"
+  "greeting": "Hello, :name!",
+  "braced": "Hello, {name}!"
+}
+```
+
+```ts
+this.t('messages.greeting', { name: 'World' }) // 'Hello, World!'
+this.t('messages.braced', { name: 'World' })   // 'Hello, World!'
+```
+
+## 複数形化
+
+複数形は`|`で区切り、`tc()`で翻訳します。フォームはアクティブロケールのルールで選択され、`:count`は自動的に置換に使えます:
+
+```json
+{
+  "apple": "apple|apples",
+  "item": "One item|:count items"
+}
+```
+
+```ts
+this.tc('messages.apple', 1)  // 'apple'
+this.tc('messages.apple', 5)  // 'apples'
+this.tc('messages.item', 10)  // '10 items'
+```
+
+### サポート言語
+
+| 言語 | フォーム数 | ルール |
+|------|-----------|--------|
+| 英語・ドイツ語・スペイン語・イタリア語・ポルトガル語・オランダ語 | 2 | 1=単数、それ以外は複数 |
+| フランス語・ブラジルポルトガル語 | 2 | 0-1=単数、それ以外は複数 |
+| 日本語・中国語・韓国語・ベトナム語・タイ語 | 1 | 複数形なし |
+| ロシア語・ウクライナ語 | 3 | one、few(2-4)、many(5+) |
+| ポーランド語・チェコ語・スロバキア語 | 3 | 複雑なルール |
+| アラビア語 | 6 | 最も複雑な複数形化 |
+
+3フォーム以上の言語はルール順に列挙します:
+
+```json
+// lang/ru/messages.json — one | few | many
+{
+  "apple": "яблоко|яблока|яблок"
+}
+```
+
+```ts
+this.tc('messages.apple', 1)   // 'яблоко' (one)
+this.tc('messages.apple', 2)   // 'яблока' (few)
+this.tc('messages.apple', 5)   // 'яблок' (many)
+this.tc('messages.apple', 21)  // 'яблоко' (one — 特殊ケース)
+```
+
+## ロケール検出
+
+`createApp({ i18n })`はロケール検出を自動でマウントします。`detect`オプションで調整できます:
+
+```ts
+createApp({
+  i18n: {
+    supported: ['en', 'ja'],
+    fallback: 'en',              // 省略時はsupportedの先頭
+    detect: {
+      sources: ['cookie', 'header'], // クエリパラメータ検出を外す
+      queryParam: 'locale',          // 以下はデフォルト値
+      cookieName: 'locale',
+    },
+  },
+})
+```
+
+`Accept-Language`のマッチングは地域サブタグ(`ja-JP`は`ja`にマッチ)とq値を理解します。検出は必ず`supported`内のロケールに解決されます。
+
+`detect: false`を渡すと`detectLocaleMiddleware`を自分でマウントできます。あるいは`locale`コンテキスト変数を設定する独自ミドルウェア(例: ログインユーザーの保存済み設定から)に置き換えることもできます。下流のすべて — `this.t()`、`_i18n`、`<html lang>` — はコンテキスト変数に追従し、検出後に他のミドルウェアが上書きした場合もそちらが優先されます。
+
+Inertiaレスポンスは解決済みロケールをルートの`<html lang>`属性に使います。レスポンス単位の`lang`オプションが常に優先されます:
+
+```ts
+return this.inertia(pages.posts.Show, { post }, { lang: 'ja' })
+```
+
+## コントローラー
+
+すべてのコントローラーに、現在のリクエストのロケールにスコープされた翻訳ヘルパーがあります:
+
+```ts
+export default class PostController extends Controller {
+  async index() {
+    this.locale                                  // 'ja'
+    this.t('messages.hello')                     // 'こんにちは'
+    this.t('messages.welcome', { name: 'ゲスト' }) // 補間
+    this.tc('messages.items', 3)                 // 複数形化
+    // ...
   }
 }
 ```
 
+## Reactページ
+
+サーバーは解決済みロケールとそのカタログ(アクティブロケール+フォールバック)を`_i18n` propとしてInertiaページに共有し、`useTranslation()`がそれを読みます:
+
+```tsx
+import { useTranslation } from '@guren/inertia-client'
+
+const { t, tc, locale } = useTranslation()
+```
+
+クライアント側の翻訳はサーバーとセマンティクスが完全に一致します — 補間、複数形、フォールバック解決。同じキーはコントローラーで翻訳してもブラウザで翻訳しても同じ結果になります。サーバーサイドレンダリングも共有props経由なので追加配線は不要です。
+
+コンポーネント外(または高度なケース)では、propから直接translatorを構築できます:
+
+```tsx
+import { createTranslator } from '@guren/inertia-client'
+import { usePage } from '@inertiajs/react'
+
+const translator = createTranslator(usePage().props._i18n)
+```
+
+サーバー側だけで翻訳するアプリでは、`i18n`オプションに`share: false`を設定するとカタログをページpropsに含めません。
+
+## 型付き翻訳キー
+
+`guren codegen`は`lang/`を読んで`.guren/translations.gen.ts`を生成し、全キーをTypeScriptのユニオン型として登録します。以降、`this.t()`・`this.tc()`・`useTranslation()`の`t`/`tc`はキーを補完し、存在しないキーをコンパイル時に拒否します:
+
+```ts
+this.t('messages.welcome')   // ✓ 補完される
+this.t('messages.welcmoe')   // ✗ コンパイルエラー
+```
+
+```bash
+bunx guren codegen
+```
+
+開発サーバーは`lang/`配下のファイル変更で自動再生成します。`lang/`ディレクトリのないアプリではキーは通常の`string`のままです。
+
+## カタログのチェック
+
+`guren check`は翻訳カタログを検証します(`--i18n`でこの検査だけを実行し、失敗時に非ゼロで終了します — CI向け):
+
+```bash
+bunx guren check --i18n
+```
+
+報告される項目:
+
+- **不正なJSON** — パースできないカタログファイルはローダーがスキップするため、そのキーは実行時に静かにフォールバックします。
+- **キーの欠落** — あるロケールにあって別のロケールにないキーは、そのロケールの利用者にフォールバック言語で表示されます。
+- **プレースホルダの不一致** — 同じキーでロケール間で`:name`/`{name}`が異なる場合、翻訳時に変数が失われている可能性が高いです。
+- **解決不能なキー** — リテラルのドットを含むプロパティ名・ファイル名。実行時に解決できません。
+
+## サーバーレスとバンドルカタログ
+
+`lang/`はファイルシステムから読まれますが、サーバーレス環境にはファイルシステムがない場合があります。`MemoryLoader`でカタログをバンドルしてください:
+
+```ts
+import { createApp, MemoryLoader } from '@guren/core'
+import en from '../lang/en/messages.json'
+import ja from '../lang/ja/messages.json'
+
+const app = createApp({
+  i18n: {
+    supported: ['en', 'ja'],
+    loader: new MemoryLoader({
+      en: { messages: en },
+      ja: { messages: ja },
+    }),
+  },
+})
+```
+
+`loader`オプションは`TranslationLoader`インターフェースを実装するものなら何でも受け付けるため、データベースやリモートサービスからカタログを供給することもできます。なお、codegenと`check --i18n`は規約の`lang/`ディレクトリを読みます — 上記のようにJSONファイルを`lang/`に置いたままimportでバンドルすれば、型付きキーとカタログチェックはそのまま機能します。
+
+## テスト
+
+翻訳の挙動は、実リクエストと同じ経路でアプリを通してテストするのが最も簡単です:
+
+```ts
+import { describe, test, expect } from 'bun:test'
+import app from '../src/app'
+
+describe('i18n', () => {
+  test('?locale=ja で日本語を返す', async () => {
+    await app.boot()
+    const response = await app.fetch(new Request('http://localhost/?locale=ja'))
+    expect(await response.text()).toContain('こんにちは')
+  })
+})
+```
+
+カタログ自体のユニットテストにはマネージャを直接構築します:
+
+```ts
+import { createI18n } from '@guren/core'
+
+const i18n = createI18n({
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages: {
+    en: { messages: { items: 'One item|:count items' } },
+  },
+})
+
+expect(i18n.tc('messages.items', 5)).toBe('5 items')
+```
+
+## 高度な使い方: マネージャの直接利用
+
+`createApp({ i18n })`は`I18nManager`を管理してくれます(コンテナから`i18n`で取得可能)。スクリプト、カスタムミドルウェア、HTTP以外の文脈では直接使えます:
+
+```ts
+import { I18nManager, JsonLoader, MemoryLoader, createI18n } from '@guren/core'
+
+const i18n = createI18n({
+  locale: 'en',
+  fallbackLocale: 'en',
+  loader: new JsonLoader('./lang', { cache: true }),
+})
+
+await i18n.loadLocale('ja')
+
+i18n.t('messages.hello')
+i18n.tc('messages.items', 5)
+i18n.has('messages.hello', 'ja')
+i18n.getAvailableLocales()
+
+// 特定ロケールに固定したtranslator — 共有マネージャのsetLocale()と
+// 違って並行利用しても安全です。
+const ja = i18n.forLocale('ja')
+ja.t('messages.hello') // 'こんにちは'
+```
+
+カスタム複数形化ルール:
+
+```ts
+const translator = i18n.getTranslator()
+translator.setPluralizationRule('custom', (count) => {
+  if (count === 0) return 0
+  if (count === 1) return 1
+  return 2
+})
+```
+
+シンプルなスクリプト向けに`setI18n()`/`t()`のグローバルレジストリもあります。ただしリクエストハンドラでは使わないでください: 共有マネージャの`setLocale()`はプロセス全体の状態なので、並行リクエストが互いのロケールを上書きします。リクエストスコープのヘルパー(`this.t()`、`useTranslation()`)は常に安全です。
+
 ## ベストプラクティス
 
-1. **名前空間付きキーを使用**: 機能ごとに翻訳を整理（`user.profile.title`）。
-
-2. **フォールバックロケールを設定**: 存在しない翻訳に備えて常にフォールバックを設定。
-
-3. **複数形に数を含める**: 動的な数値には`:count`プレースホルダーを使用。
-
-4. **本番環境ではキャッシュを有効化**: JSONローダーのキャッシュを本番環境で有効に。
-
-5. **翻訳を整理して保持**: 異なる関心事には別々のファイルを使用。
-
-6. **存在しないキーを適切に処理**: ロギング用に`onMissingKey`コールバックを使用。
-
-7. **翻訳をテスト**: すべてのキーがすべてのロケールに存在することを確認するテストを作成。
-
-8. **ロケールをオンデマンドで読み込み**: パフォーマンス向上のため`loadLocale()`を使用。
+1. **i18nは`createApp`で配線する**: `i18n`オプションひとつで検出・リクエストスコープヘルパー・クライアント共有が揃います。
+2. **名前空間付きキーを使う**: 機能ごとに整理し(`user.profile.title`)、名前空間ごとに1ファイルにします。
+3. **ロケール間のパリティを保つ**: CIで`guren check --i18n`を回し、片方のロケールにだけ追加されたキーが未翻訳のまま出荷されるのを防ぎます。
+4. **型付きキーを生成する**: `guren codegen`でキーのtypoが実行時フォールバックではなくコンパイルエラーになります。
+5. **リクエスト中に`setLocale()`を呼ばない**: 検出済みロケールとリクエストスコープのヘルパーに任せます。
+6. **サーバーレスではカタログをバンドルする**: ファイルシステムのない環境ではJSON importと`MemoryLoader`を使います。
+7. **複数形には`:count`を入れる**: `tc()`で自動的に補間されます。

--- a/docs/ja/guides/testing.md
+++ b/docs/ja/guides/testing.md
@@ -36,6 +36,37 @@ describe('Posts API', () => {
 })
 ```
 
+### 実アプリをラップする
+
+`TestApp.create({ ... })`は渡したパーツからアプリを組み立てます — 単体スライスのテストには便利ですが、その部分集合はサーバーが実際に動かす構成(プロバイダー、`auth`、`i18n`、セキュリティデフォルト)から静かにドリフトし得ます。実構成を検証したいテストでは、プロジェクトがエクスポートするアプリをbootしてfetchハンドラをラップします:
+
+```ts
+import { TestApp } from '@guren/testing'
+import app from '../src/app.js'
+
+let http: TestApp
+
+beforeAll(async () => {
+  await app.boot()
+  http = TestApp.fromFetch((request) => app.fetch(request))
+})
+
+test('ホームページを返す', async () => {
+  await http.get('/').assertOk()
+})
+```
+
+scaffoldされたアプリはこのパターンを同梱しています。`app.fetch`は必ずアロー関数経由で渡してください — メソッドはインスタンス状態を読むため、束縛せずに渡すと最初のリクエストで例外になります。
+
+パーツから組み立てる場合、`TestApp.create()`は`createApp`のオプションをミラーします: セッション+CSRFミドルウェアには`auth`を、テスト対象のコントローラーが`this.t()` / `this.tc()`を使うなら`i18n`を渡します:
+
+```ts
+const app = await TestApp.create({
+  routes: registerWebRoutes,
+  i18n: { supported: ['en'] },
+})
+```
+
 ### リクエストの送信
 
 TestApp は標準的な HTTP メソッドをすべてサポートしています。

--- a/packages/cli/templates/agent/.claude/rules/testing.md
+++ b/packages/cli/templates/agent/.claude/rules/testing.md
@@ -13,10 +13,27 @@ Requests run in-process through `app.fetch()` — no server, no port.
 ```typescript
 import { TestApp } from '@guren/testing'
 
-const app = await TestApp.create()             // boots the real Application
+const app = await TestApp.create()             // boots a fresh Application
 const app = await TestApp.create({ boot, providers, routes })  // all optional
-const app = TestApp.fromFetch(app.fetch)       // wrap an existing fetch fn (not async)
+const app = TestApp.fromFetch((req) => app.fetch(req))  // wrap an existing fetch fn (not async)
 ```
+
+**Prefer wrapping the real app.** Scaffolded apps export the configured
+application from `src/app.ts` — boot it and wrap it so tests exercise the
+app's actual configuration (providers, auth, i18n, security defaults)
+instead of reconstructing a subset that silently drifts:
+
+```typescript
+import app from '../src/app.js'
+
+await app.boot()
+const http = TestApp.fromFetch((request) => app.fetch(request))
+```
+
+Keep `TestApp.create({ ... })` for isolated slices (a single route or
+middleware under test). Pass `app.fetch` through an arrow — the method
+reads instance state, so handing the unbound reference over throws at the
+first request.
 
 Both set `GUREN_TESTING=1` so `actingAs()` header auth is accepted.
 

--- a/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
+++ b/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
@@ -357,6 +357,14 @@ Source: `packages/server/src/i18n/`
 
 Loaders: `JsonLoader.ts`, `MemoryLoader.ts`
 
+App wiring: `createApp({ i18n: { supported: ['en', 'ja'] } })` loads
+`lang/<locale>/*.json`, mounts locale detection (query → cookie →
+Accept-Language), and shares the `_i18n` prop with Inertia pages.
+Translate with `this.t()` / `this.tc()` / `this.locale` in controllers and
+`useTranslation()` from `@guren/inertia-client` in pages. `guren codegen`
+emits typed keys (`.guren/translations.gen.ts`); `guren check --i18n`
+validates catalog parity and placeholders.
+
 ### Encryption
 Source: `packages/server/src/encryption/`
 

--- a/packages/create-app/templates/blog/src/app.ts
+++ b/packages/create-app/templates/blog/src/app.ts
@@ -40,6 +40,10 @@ const app = createApp({
   auth: {},
   routes: registerWebRoutes,
   providers: [DatabaseProvider, AuthProvider, AuthorizationProvider],
+  // Translations live in lang/<locale>/*.json. Add locales to `supported`
+  // and the request locale is detected from ?locale=, a locale cookie, or
+  // Accept-Language. `guren codegen` types the keys for t()/useTranslation().
+  i18n: { supported: ['en'] },
   hostAuthorization: hostAuthorization(),
 })
 

--- a/packages/create-app/templates/blog/tests/HomeController.test.ts
+++ b/packages/create-app/templates/blog/tests/HomeController.test.ts
@@ -1,19 +1,22 @@
-import { describe, it } from 'bun:test'
+import { beforeAll, describe, it } from 'bun:test'
 import { TestApp } from '@guren/testing'
-import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
-import { registerWebRoutes } from '../routes/web.js'
+import app from '../src/app.js'
 
-// The blog home page reads posts from the database, so exercising it here
-// would need migrations and fixtures — the golden-path flow already covers
-// it end to end. This starter test keeps `bun test` green out of the box;
-// replace it with real feature tests as you build.
+// Boot the real application so tests exercise the same configuration
+// (routes, providers, auth, i18n) the server runs with. The blog home page
+// reads posts from the database, so exercising it here would need
+// migrations and fixtures — the golden-path flow already covers it end to
+// end. This starter test keeps `bun test` green out of the box; replace it
+// with real feature tests as you build.
 describe('app', () => {
-  it('answers the health check', async () => {
-    const app = await TestApp.create({
-      routes: registerWebRoutes,
-      providers: [DatabaseProvider],
-    })
+  let http: TestApp
 
-    await app.get('/health').assertOk()
+  beforeAll(async () => {
+    await app.boot()
+    http = TestApp.fromFetch((request) => app.fetch(request))
+  })
+
+  it('answers the health check', async () => {
+    await http.get('/health').assertOk()
   })
 })

--- a/packages/create-app/templates/blog/tests/HomeController.test.ts
+++ b/packages/create-app/templates/blog/tests/HomeController.test.ts
@@ -2,12 +2,11 @@ import { beforeAll, describe, it } from 'bun:test'
 import { TestApp } from '@guren/testing'
 import app from '../src/app.js'
 
-// Boot the real application so tests exercise the same configuration
-// (routes, providers, auth, i18n) the server runs with. The blog home page
-// reads posts from the database, so exercising it here would need
-// migrations and fixtures — the golden-path flow already covers it end to
-// end. This starter test keeps `bun test` green out of the box; replace it
-// with real feature tests as you build.
+// Boots the real src/app.ts so tests share its configuration. The blog
+// home page reads posts from the database, so exercising it here would
+// need migrations and fixtures — the golden-path flow already covers it
+// end to end. This starter test keeps `bun test` green out of the box;
+// replace it with real feature tests as you build.
 describe('app', () => {
   let http: TestApp
 

--- a/packages/create-app/templates/default/app/Http/Controllers/HomeController.ts
+++ b/packages/create-app/templates/default/app/Http/Controllers/HomeController.ts
@@ -4,7 +4,9 @@ import { pages } from '@/.guren/pages.gen'
 export default class HomeController extends Controller {
   async index(): Promise<Response> {
     const props = {
-      message: 'Welcome to __APP_TITLE__!',
+      // Message text lives in lang/en/messages.json; `guren codegen` keeps
+      // the key typed. Add lang/<locale>/ directories to translate the app.
+      message: this.t('messages.welcome', { name: '__APP_TITLE__' }),
     }
 
     return this.inertia(pages.Home, props, { url: this.request.path, title: '__APP_TITLE__' })

--- a/packages/create-app/templates/default/app/Http/Controllers/HomeController.ts
+++ b/packages/create-app/templates/default/app/Http/Controllers/HomeController.ts
@@ -4,8 +4,7 @@ import { pages } from '@/.guren/pages.gen'
 export default class HomeController extends Controller {
   async index(): Promise<Response> {
     const props = {
-      // Message text lives in lang/en/messages.json; `guren codegen` keeps
-      // the key typed. Add lang/<locale>/ directories to translate the app.
+      // Message text lives in lang/en/messages.json (key typed by codegen).
       message: this.t('messages.welcome', { name: '__APP_TITLE__' }),
     }
 

--- a/packages/create-app/templates/default/lang/en/messages.json
+++ b/packages/create-app/templates/default/lang/en/messages.json
@@ -1,0 +1,3 @@
+{
+  "welcome": "Welcome to :name!"
+}

--- a/packages/create-app/templates/default/src/app.ts
+++ b/packages/create-app/templates/default/src/app.ts
@@ -38,6 +38,10 @@ function hostAuthorization() {
 const app = createApp({
   routes: registerWebRoutes,
   providers: [DatabaseProvider],
+  // Translations live in lang/<locale>/*.json. Add locales to `supported`
+  // and the request locale is detected from ?locale=, a locale cookie, or
+  // Accept-Language. `guren codegen` types the keys for t()/useTranslation().
+  i18n: { supported: ['en'] },
   hostAuthorization: hostAuthorization(),
 })
 

--- a/packages/create-app/templates/default/tests/HomeController.test.ts
+++ b/packages/create-app/templates/default/tests/HomeController.test.ts
@@ -2,8 +2,7 @@ import { beforeAll, describe, it } from 'bun:test'
 import { TestApp } from '@guren/testing'
 import app from '../src/app.js'
 
-// Boot the real application so tests exercise the same configuration
-// (routes, providers, i18n, security defaults) the server runs with.
+// Boots the real src/app.ts so tests share its configuration.
 describe('app', () => {
   let http: TestApp
 
@@ -12,11 +11,8 @@ describe('app', () => {
     http = TestApp.fromFetch((request) => app.fetch(request))
   })
 
-  it('serves the home page', async () => {
-    const response = await http.get('/')
-    response.assertOk()
-    // The message comes from lang/en/messages.json via this.t() — this
-    // catches a broken catalog or interpolation, not just a 200.
+  it('serves the translated home page', async () => {
+    const response = await http.get('/').assertOk()
     await response.assertBodyContains('Welcome to')
   })
 

--- a/packages/create-app/templates/default/tests/HomeController.test.ts
+++ b/packages/create-app/templates/default/tests/HomeController.test.ts
@@ -1,24 +1,22 @@
-import { describe, it } from 'bun:test'
+import { beforeAll, describe, it } from 'bun:test'
 import { TestApp } from '@guren/testing'
-import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
-import { registerWebRoutes } from '../routes/web.js'
+import app from '../src/app.js'
 
+// Boot the real application so tests exercise the same configuration
+// (routes, providers, i18n, security defaults) the server runs with.
 describe('app', () => {
-  it('serves the home page', async () => {
-    const app = await TestApp.create({
-      routes: registerWebRoutes,
-      providers: [DatabaseProvider],
-    })
+  let http: TestApp
 
-    await app.get('/').assertOk()
+  beforeAll(async () => {
+    await app.boot()
+    http = TestApp.fromFetch((request) => app.fetch(request))
+  })
+
+  it('serves the home page', async () => {
+    await http.get('/').assertOk()
   })
 
   it('answers the health check', async () => {
-    const app = await TestApp.create({
-      routes: registerWebRoutes,
-      providers: [DatabaseProvider],
-    })
-
-    await app.get('/health').assertOk()
+    await http.get('/health').assertOk()
   })
 })

--- a/packages/create-app/templates/default/tests/HomeController.test.ts
+++ b/packages/create-app/templates/default/tests/HomeController.test.ts
@@ -13,7 +13,11 @@ describe('app', () => {
   })
 
   it('serves the home page', async () => {
-    await http.get('/').assertOk()
+    const response = await http.get('/')
+    response.assertOk()
+    // The message comes from lang/en/messages.json via this.t() — this
+    // catches a broken catalog or interpolation, not just a 200.
+    await response.assertBodyContains('Welcome to')
   })
 
   it('answers the health check', async () => {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@guren/server": ">=1.0.0",
+    "@guren/server": ">=2.2.0",
     "@inertiajs/react": "^3.6.1",
     "@testing-library/react": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "hono": "^4.12.29",

--- a/packages/testing/src/test-app.ts
+++ b/packages/testing/src/test-app.ts
@@ -1,5 +1,5 @@
 import type { Hono } from 'hono'
-import type { Router } from '@guren/server'
+import type { I18nPluginOptions, Router } from '@guren/server'
 import { TestResponse } from './http'
 
 type BootCallback = (app: Hono) => void | Promise<void>
@@ -15,7 +15,7 @@ type ApplicationConstructor = new (options: {
   providers?: ProviderConstructor[]
   routes?: RouteRegistration
   auth?: Record<string, unknown>
-  i18n?: Record<string, unknown>
+  i18n?: I18nPluginOptions
 }) => ApplicationLike
 
 /**
@@ -39,7 +39,7 @@ export interface TestAppOptions {
    * `TestApp.fromFetch((request) => app.fetch(request))` so tests share its
    * full configuration.
    */
-  readonly i18n?: Record<string, unknown>
+  readonly i18n?: I18nPluginOptions
 }
 
 /**

--- a/packages/testing/src/test-app.ts
+++ b/packages/testing/src/test-app.ts
@@ -34,10 +34,7 @@ export interface TestAppOptions {
   readonly auth?: Record<string, unknown>
   /**
    * Mirrors `createApp({ i18n })`: required when controllers under test use
-   * `this.t()`/`this.tc()`. Ignored by the Hono fallback. Alternatively, boot
-   * the real app and wrap it with
-   * `TestApp.fromFetch((request) => app.fetch(request))` so tests share its
-   * full configuration.
+   * `this.t()`/`this.tc()`. Ignored by the Hono fallback.
    */
   readonly i18n?: I18nPluginOptions
 }

--- a/packages/testing/src/test-app.ts
+++ b/packages/testing/src/test-app.ts
@@ -15,6 +15,7 @@ type ApplicationConstructor = new (options: {
   providers?: ProviderConstructor[]
   routes?: RouteRegistration
   auth?: Record<string, unknown>
+  i18n?: Record<string, unknown>
 }) => ApplicationLike
 
 /**
@@ -31,6 +32,13 @@ export interface TestAppOptions {
    * `@guren/server` is not installed.
    */
   readonly auth?: Record<string, unknown>
+  /**
+   * Mirrors `createApp({ i18n })`: required when controllers under test use
+   * `this.t()`/`this.tc()`. Ignored by the Hono fallback. Alternatively, boot
+   * the real app and wrap it with `TestApp.fromFetch(app.fetch)` so tests
+   * share its full configuration.
+   */
+  readonly i18n?: Record<string, unknown>
 }
 
 /**
@@ -411,6 +419,7 @@ export class TestApp {
       providers: options.providers,
       routes: options.routes,
       auth: options.auth,
+      i18n: options.i18n,
     })
     await application.boot()
 

--- a/packages/testing/src/test-app.ts
+++ b/packages/testing/src/test-app.ts
@@ -35,8 +35,9 @@ export interface TestAppOptions {
   /**
    * Mirrors `createApp({ i18n })`: required when controllers under test use
    * `this.t()`/`this.tc()`. Ignored by the Hono fallback. Alternatively, boot
-   * the real app and wrap it with `TestApp.fromFetch(app.fetch)` so tests
-   * share its full configuration.
+   * the real app and wrap it with
+   * `TestApp.fromFetch((request) => app.fetch(request))` so tests share its
+   * full configuration.
    */
   readonly i18n?: Record<string, unknown>
 }
@@ -495,7 +496,7 @@ export class TestApp {
    * PUT, PATCH, and DELETE pass the CSRF middleware like a real browser.
    *
    * @example
-   * const http = (await TestApp.fromFetch(app.fetch)).actingAs(user)
+   * const http = TestApp.fromFetch((request) => app.fetch(request)).actingAs(user)
    * const csrf = await http.withCsrf()
    * await csrf.post('/tasks', { title: 'hello' }) // no more 403
    */


### PR DESCRIPTION
## Summary

Final PR of the i18n series (#309 server wiring, #310 client hook, #312 typed keys + checks), unblocked by the v2.2.0 release: templates resolve `@guren/*` from npm, and every API they now use shipped in that release (verified by `smoke:starter:npm`, below).

### Starter templates

Scaffolded apps come with i18n wired end to end:

- `lang/en/messages.json` catalog; adding a `lang/<locale>/` directory is all it takes to translate the app
- `createApp({ i18n: { supported: ['en'] } })` in `src/app.ts` (default and blog blueprints — blog inherits the default's catalog and overrides `app.ts`, so it needs the option for the inherited `HomeController`)
- The home page message renders through `this.t('messages.welcome', ...)`, so typed keys and `guren check --i18n` are exercised from the first `guren codegen`

The template test now boots the real `src/app.ts` and wraps it with `TestApp.fromFetch()` instead of assembling an app from parts — tests exercise the app's actual configuration and can't drift from it. (The old form broke here: `TestApp.create()` dropped the `i18n` option, so `this.t()` threw at request time.) `TestApp.create()` also gains an `i18n` passthrough mirroring `createApp({ i18n })` for tests that do assemble apps from parts.

### Docs

`docs/{en,ja}/guides/i18n.md` rewritten to lead with the `createApp({ i18n })` wiring: quick start (server + client), catalog layout, interpolation/pluralization, locale detection, controller helpers, `useTranslation()`, typed keys, `guren check --i18n`, and a serverless section (bundled catalogs via `MemoryLoader`). The previous guide opened with the global `setI18n()`/`t()` registry, which is unsafe under concurrent requests — it is now an explicitly-flagged advanced section. en/ja kept in sync. The agent harness `guren-api` skill documents the app-level i18n surface.

## Testing

- `bun run audit:starter-template` / `bun run audit:docs` / `bun run audit:core-first` / `guren check --docs`
- `bun run smoke:starter`, `smoke:starter:api`, `smoke:starter:blog` (vendored)
- **`bun run smoke:starter:npm`** — installs `@guren/*` from the registry; green against v2.2.0
- Root `bun run typecheck`, `bun run test:bun` (3796 pass), `bun run test:examples` (251 pass), `@guren/testing` vitest suite (164 pass)