### PR TITLE
feat(testing): add TestApp.fromApp, make Application.boot idempotent

### DIFF
--- a/.changeset/testing-from-app-factory.md
+++ b/.changeset/testing-from-app-factory.md
@@ -3,17 +3,21 @@
 '@guren/server': minor
 ---
 
-Add `TestApp.fromApp(app)` and expose `Application.booted`
+Add `TestApp.fromApp(app)` and make `Application.boot()` idempotent
 
 Testing against the real application required
 `await app.boot(); TestApp.fromFetch((request) => app.fetch(request))` — and
 the arrow wrapper is load-bearing, because an unbound `app.fetch` reference
 throws (`Application.fetch` reads instance state). `TestApp.fromApp(app)`
-binds fetch internally and boots the app when it has not booted yet, removing
-both the boilerplate and the footgun.
+boots the app and binds fetch, removing both the boilerplate and the footgun.
 
-Boot-once semantics: `Application` now reports a read-only `booted` flag,
-which `fromApp()` trusts — an app booted elsewhere is not booted again (a
-second `boot()` would mount routes and middleware twice). For app-like objects
-without the flag, `fromApp()` tracks the instances it booted itself and still
-boots each at most once across calls.
+`Application.boot()` now reuses its first call, so booting twice is a no-op
+rather than mounting security middleware and routes a second time. This also
+covers two callers booting concurrently, which the previous code could not:
+each saw an unbooted app and mounted everything again. A boot that throws is
+not remembered, so a later call attempts boot again — it resumes on a
+partially mounted app rather than starting clean, which is how the Cloudflare
+Workers handler has always treated it.
+
+This is a behavior change to a public method: a second `boot()` used to
+duplicate the middleware chain and now does nothing.

--- a/.changeset/testing-from-app-factory.md
+++ b/.changeset/testing-from-app-factory.md
@@ -1,0 +1,19 @@
+---
+'@guren/testing': minor
+'@guren/server': minor
+---
+
+Add `TestApp.fromApp(app)` and expose `Application.booted`
+
+Testing against the real application required
+`await app.boot(); TestApp.fromFetch((request) => app.fetch(request))` — and
+the arrow wrapper is load-bearing, because an unbound `app.fetch` reference
+throws (`Application.fetch` reads instance state). `TestApp.fromApp(app)`
+binds fetch internally and boots the app when it has not booted yet, removing
+both the boilerplate and the footgun.
+
+Boot-once semantics: `Application` now reports a read-only `booted` flag,
+which `fromApp()` trusts — an app booted elsewhere is not booted again (a
+second `boot()` would mount routes and middleware twice). For app-like objects
+without the flag, `fromApp()` tracks the instances it booted itself and still
+boots each at most once across calls.

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -244,6 +244,7 @@ export class Application {
   private bunTeardownRegistered = false
   private autoSessionAttached = false
   private routesRegistered = false
+  private hasBooted = false
 
   constructor(private readonly options: ApplicationOptions = {}) {
     this.hono = new Hono()
@@ -383,6 +384,14 @@ export class Application {
   }
 
   /**
+   * Whether `boot()` has completed. `TestApp.fromApp()` reads this to avoid
+   * booting twice — a second boot would mount routes and middleware again.
+   */
+  get booted(): boolean {
+    return this.hasBooted
+  }
+
+  /**
    * Executes provider registration, boot callback, mounts routes, and boots providers.
    */
   async boot(): Promise<void> {
@@ -409,6 +418,7 @@ export class Application {
       'GUREN_DOCS=1 but the docs viewer could not load — is @guren/cli resolvable from this app?',
     )
     await this.providerManager.bootAll()
+    this.hasBooted = true
   }
 
   /**

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -244,7 +244,7 @@ export class Application {
   private bunTeardownRegistered = false
   private autoSessionAttached = false
   private routesRegistered = false
-  private hasBooted = false
+  private bootPromise?: Promise<void>
 
   constructor(private readonly options: ApplicationOptions = {}) {
     this.hono = new Hono()
@@ -384,17 +384,26 @@ export class Application {
   }
 
   /**
-   * Whether `boot()` has completed. `TestApp.fromApp()` reads this to avoid
-   * booting twice — a second boot would mount routes and middleware again.
-   */
-  get booted(): boolean {
-    return this.hasBooted
-  }
-
-  /**
    * Executes provider registration, boot callback, mounts routes, and boots providers.
+   *
+   * Booting twice is a no-op: the first call's promise is reused, so security
+   * middleware and routes are never mounted a second time — including when two
+   * callers boot concurrently, before the first has finished. A boot that
+   * throws is not remembered, so a later call attempts boot again (it resumes
+   * on a partially mounted app rather than starting clean).
    */
   async boot(): Promise<void> {
+    this.bootPromise ??= this.bootOnce()
+
+    try {
+      await this.bootPromise
+    } catch (error) {
+      this.bootPromise = undefined
+      throw error
+    }
+  }
+
+  private async bootOnce(): Promise<void> {
     this.mountSecurityDefaults()
     await this.providerManager.registerAll()
 
@@ -418,7 +427,6 @@ export class Application {
       'GUREN_DOCS=1 but the docs viewer could not load — is @guren/cli resolvable from this app?',
     )
     await this.providerManager.bootAll()
-    this.hasBooted = true
   }
 
   /**

--- a/packages/server/tests/application-boot-idempotency.test.ts
+++ b/packages/server/tests/application-boot-idempotency.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'bun:test'
+import { Application } from '../src'
+
+/**
+ * An Application that boots twice mounts security middleware and routes twice,
+ * so every request runs a duplicated middleware chain. `boot()` therefore
+ * reuses its first call — these tests pin that for the sequential and the
+ * concurrent case, and for the retry after a boot that threw.
+ */
+function createCountingApp() {
+  let bootCallbackCalls = 0
+  let middlewareCalls = 0
+
+  const app = new Application({
+    boot: (hono) => {
+      bootCallbackCalls++
+      hono.use('*', async (_c, next) => {
+        middlewareCalls++
+        await next()
+      })
+      hono.get('/ping', (c) => c.text('pong'))
+    },
+  })
+
+  return {
+    app,
+    get bootCallbackCalls() {
+      return bootCallbackCalls
+    },
+    get middlewareCalls() {
+      return middlewareCalls
+    },
+  }
+}
+
+describe('Application.boot idempotency', () => {
+  it('runs the boot callback once when booted twice in sequence', async () => {
+    const counting = createCountingApp()
+
+    await counting.app.boot()
+    await counting.app.boot()
+
+    expect(counting.bootCallbackCalls).toBe(1)
+  })
+
+  it('runs the boot callback once when two callers boot concurrently', async () => {
+    const counting = createCountingApp()
+
+    await Promise.all([counting.app.boot(), counting.app.boot()])
+
+    expect(counting.bootCallbackCalls).toBe(1)
+  })
+
+  it('mounts each middleware and route on Hono only once', async () => {
+    const counting = createCountingApp()
+
+    await counting.app.boot()
+    const mountedAfterFirstBoot = counting.app.hono.routes.length
+    await counting.app.boot()
+
+    expect(counting.app.hono.routes.length).toBe(mountedAfterFirstBoot)
+  })
+
+  it('serves requests normally after a repeated boot', async () => {
+    const counting = createCountingApp()
+
+    await counting.app.boot()
+    await counting.app.boot()
+    const response = await counting.app.fetch(new Request('http://localhost/ping'))
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('pong')
+    expect(counting.middlewareCalls).toBe(1)
+  })
+
+  it('attempts boot again after a boot that threw', async () => {
+    let attempts = 0
+    const app = new Application({
+      boot: () => {
+        attempts++
+        if (attempts === 1) {
+          throw new Error('database unavailable')
+        }
+      },
+    })
+
+    await expect(app.boot()).rejects.toThrow('database unavailable')
+    await app.boot()
+
+    expect(attempts).toBe(2)
+  })
+})

--- a/packages/testing/src/test-app.fromApp.test.ts
+++ b/packages/testing/src/test-app.fromApp.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { TestApp } from './test-app'
+
+/**
+ * Minimal ApplicationLike whose fetch reads instance state, mirroring
+ * @guren/server's Application — an unbound `app.fetch` reference throws.
+ */
+class FakeApplication {
+  bootCalls = 0
+  booted?: boolean
+  private response = 'not booted'
+
+  constructor(withBootedFlag: boolean) {
+    if (withBootedFlag) {
+      this.booted = false
+    }
+  }
+
+  async boot(): Promise<void> {
+    this.bootCalls++
+    this.response = 'ok'
+    if (this.booted !== undefined) {
+      this.booted = true
+    }
+  }
+
+  fetch(request: Request): Response {
+    return new Response(`${this.response} ${new URL(request.url).pathname}`)
+  }
+}
+
+describe('TestApp.fromApp', () => {
+  it('boots the app and binds fetch to the instance', async () => {
+    const app = new FakeApplication(true)
+
+    const http = await TestApp.fromApp(app)
+    const response = await http.get('/posts')
+
+    expect(app.bootCalls).toBe(1)
+    expect(await response.text()).toBe('ok /posts')
+  })
+
+  it('does not boot again when the app reports booted: true', async () => {
+    const app = new FakeApplication(true)
+    await app.boot()
+
+    await TestApp.fromApp(app)
+
+    expect(app.bootCalls).toBe(1)
+  })
+
+  it('boots an app without a booted property at most once across calls', async () => {
+    const app = new FakeApplication(false)
+
+    await TestApp.fromApp(app)
+    await TestApp.fromApp(app)
+
+    expect(app.bootCalls).toBe(1)
+  })
+
+  it('retries boot on a later call when the first boot throws', async () => {
+    const app = new FakeApplication(false)
+    let failFirstBoot = true
+    const originalBoot = app.boot.bind(app)
+    app.boot = async () => {
+      if (failFirstBoot) {
+        failFirstBoot = false
+        throw new Error('database unavailable')
+      }
+      await originalBoot()
+    }
+
+    await expect(TestApp.fromApp(app)).rejects.toThrow('database unavailable')
+
+    const http = await TestApp.fromApp(app)
+    await http.get('/').assertOk()
+    expect(app.bootCalls).toBe(1)
+  })
+
+  it('respects a custom base URL', async () => {
+    const app = new FakeApplication(true)
+    let seenUrl: string | undefined
+    app.fetch = (request: Request) => {
+      seenUrl = request.url
+      return new Response('ok')
+    }
+
+    const http = await TestApp.fromApp(app, 'http://example.test')
+    await http.get('/x')
+
+    expect(seenUrl).toBe('http://example.test/x')
+  })
+
+  it('enables GUREN_TESTING so actingAs works against the app', async () => {
+    delete process.env.GUREN_TESTING
+
+    await TestApp.fromApp(new FakeApplication(true))
+
+    expect(process.env.GUREN_TESTING).toBe('1')
+  })
+})

--- a/packages/testing/src/test-app.fromApp.test.ts
+++ b/packages/testing/src/test-app.fromApp.test.ts
@@ -4,24 +4,24 @@ import { TestApp } from './test-app'
 /**
  * Minimal ApplicationLike whose fetch reads instance state, mirroring
  * @guren/server's Application — an unbound `app.fetch` reference throws.
+ * Its `boot()` is idempotent for the same reason the real one is.
  */
 class FakeApplication {
   bootCalls = 0
-  booted?: boolean
+  failNextBoot = false
+  private booted = false
   private response = 'not booted'
 
-  constructor(withBootedFlag: boolean) {
-    if (withBootedFlag) {
-      this.booted = false
-    }
-  }
-
   async boot(): Promise<void> {
+    if (this.failNextBoot) {
+      this.failNextBoot = false
+      throw new Error('database unavailable')
+    }
+    if (this.booted) return
+
     this.bootCalls++
     this.response = 'ok'
-    if (this.booted !== undefined) {
-      this.booted = true
-    }
+    this.booted = true
   }
 
   fetch(request: Request): Response {
@@ -31,7 +31,7 @@ class FakeApplication {
 
 describe('TestApp.fromApp', () => {
   it('boots the app and binds fetch to the instance', async () => {
-    const app = new FakeApplication(true)
+    const app = new FakeApplication()
 
     const http = await TestApp.fromApp(app)
     const response = await http.get('/posts')
@@ -40,17 +40,8 @@ describe('TestApp.fromApp', () => {
     expect(await response.text()).toBe('ok /posts')
   })
 
-  it('does not boot again when the app reports booted: true', async () => {
-    const app = new FakeApplication(true)
-    await app.boot()
-
-    await TestApp.fromApp(app)
-
-    expect(app.bootCalls).toBe(1)
-  })
-
-  it('boots an app without a booted property at most once across calls', async () => {
-    const app = new FakeApplication(false)
+  it('leaves booting to the app, so repeated calls boot once', async () => {
+    const app = new FakeApplication()
 
     await TestApp.fromApp(app)
     await TestApp.fromApp(app)
@@ -58,27 +49,18 @@ describe('TestApp.fromApp', () => {
     expect(app.bootCalls).toBe(1)
   })
 
-  it('retries boot on a later call when the first boot throws', async () => {
-    const app = new FakeApplication(false)
-    let failFirstBoot = true
-    const originalBoot = app.boot.bind(app)
-    app.boot = async () => {
-      if (failFirstBoot) {
-        failFirstBoot = false
-        throw new Error('database unavailable')
-      }
-      await originalBoot()
-    }
+  it('propagates a boot failure instead of returning an unbooted TestApp', async () => {
+    const app = new FakeApplication()
+    app.failNextBoot = true
 
     await expect(TestApp.fromApp(app)).rejects.toThrow('database unavailable')
 
     const http = await TestApp.fromApp(app)
     await http.get('/').assertOk()
-    expect(app.bootCalls).toBe(1)
   })
 
   it('respects a custom base URL', async () => {
-    const app = new FakeApplication(true)
+    const app = new FakeApplication()
     let seenUrl: string | undefined
     app.fetch = (request: Request) => {
       seenUrl = request.url
@@ -91,11 +73,19 @@ describe('TestApp.fromApp', () => {
     expect(seenUrl).toBe('http://example.test/x')
   })
 
-  it('enables GUREN_TESTING so actingAs works against the app', async () => {
+  it('enables GUREN_TESTING before booting, so boot-time code sees test mode', async () => {
     delete process.env.GUREN_TESTING
+    let seenDuringBoot: string | undefined
 
-    await TestApp.fromApp(new FakeApplication(true))
+    const app = new FakeApplication()
+    const originalBoot = app.boot.bind(app)
+    app.boot = async () => {
+      seenDuringBoot = process.env.GUREN_TESTING
+      await originalBoot()
+    }
 
-    expect(process.env.GUREN_TESTING).toBe('1')
+    await TestApp.fromApp(app)
+
+    expect(seenDuringBoot).toBe('1')
   })
 })

--- a/packages/testing/src/test-app.ts
+++ b/packages/testing/src/test-app.ts
@@ -9,6 +9,8 @@ type RouteRegistration = (router: Router) => void | Promise<void>
 type ApplicationLike = {
   boot(): Promise<void>
   fetch(request: Request): Response | Promise<Response>
+  /** Reported by @guren/server's Application; `fromApp()` skips boot when true. */
+  readonly booted?: boolean
 }
 type ApplicationConstructor = new (options: {
   boot?: BootCallback
@@ -419,6 +421,45 @@ export class TestApp {
   }
 
   /**
+   * Create a TestApp from an existing Application instance (typically the one
+   * exported by `src/app.ts`), booting it first if it has not booted yet.
+   *
+   * `fetch` is bound to the instance internally, so there is no need for the
+   * `TestApp.fromFetch((request) => app.fetch(request))` arrow wrapper — an
+   * unbound `app.fetch` reference throws because it reads instance state.
+   *
+   * Boot-once semantics: when the app reports its boot state (a `booted`
+   * property, as @guren/server's Application does), it is trusted — apps
+   * booted elsewhere are not booted again. Without that property, `fromApp()`
+   * still boots each instance at most once across calls, but cannot detect a
+   * boot performed outside this helper.
+   *
+   * @example
+   * import app from '../src/app'
+   *
+   * const http = await TestApp.fromApp(app)
+   * await http.get('/').assertOk()
+   */
+  static async fromApp(
+    app: ApplicationLike,
+    baseUrl = 'http://localhost',
+  ): Promise<TestApp> {
+    process.env.GUREN_TESTING = '1'
+
+    const alreadyBooted =
+      typeof app.booted === 'boolean' ? app.booted : appsBootedByFromApp.has(app)
+    if (!alreadyBooted) {
+      await app.boot()
+      appsBootedByFromApp.add(app)
+    }
+
+    return new TestApp(
+      (request) => Promise.resolve(app.fetch(request)),
+      baseUrl,
+    )
+  }
+
+  /**
    * Create a TestApp from an existing fetch function.
    * Useful when you already have a Hono app or Application instance.
    */
@@ -658,6 +699,12 @@ export async function factory<T>(
 }
 
 // --- Internal helpers ---
+
+// Instances fromApp() has booted itself, for apps that do not report a
+// `booted` property. Test files share one process, so the same module-scoped
+// app instance can reach fromApp() many times — booting it again would mount
+// routes and middleware twice.
+const appsBootedByFromApp = new WeakSet<ApplicationLike>()
 
 function getNestedValue(obj: unknown, path: string): unknown {
   const parts = path.split('.')

--- a/packages/testing/src/test-app.ts
+++ b/packages/testing/src/test-app.ts
@@ -9,8 +9,6 @@ type RouteRegistration = (router: Router) => void | Promise<void>
 type ApplicationLike = {
   boot(): Promise<void>
   fetch(request: Request): Response | Promise<Response>
-  /** Reported by @guren/server's Application; `fromApp()` skips boot when true. */
-  readonly booted?: boolean
 }
 type ApplicationConstructor = new (options: {
   boot?: BootCallback
@@ -421,18 +419,16 @@ export class TestApp {
   }
 
   /**
-   * Create a TestApp from an existing Application instance (typically the one
-   * exported by `src/app.ts`), booting it first if it has not booted yet.
+   * Create a TestApp from an existing Application instance — typically the one
+   * exported by `src/app.ts` — booting it if it has not booted yet.
    *
    * `fetch` is bound to the instance internally, so there is no need for the
-   * `TestApp.fromFetch((request) => app.fetch(request))` arrow wrapper — an
+   * `TestApp.fromFetch((request) => app.fetch(request))` arrow wrapper: an
    * unbound `app.fetch` reference throws because it reads instance state.
    *
-   * Boot-once semantics: when the app reports its boot state (a `booted`
-   * property, as @guren/server's Application does), it is trusted — apps
-   * booted elsewhere are not booted again. Without that property, `fromApp()`
-   * still boots each instance at most once across calls, but cannot detect a
-   * boot performed outside this helper.
+   * Booting is left to the app, whose `boot()` is expected to be idempotent
+   * (@guren/server's Application reuses its first boot), so several test files
+   * may call this on the same instance.
    *
    * @example
    * import app from '../src/app'
@@ -440,23 +436,12 @@ export class TestApp {
    * const http = await TestApp.fromApp(app)
    * await http.get('/').assertOk()
    */
-  static async fromApp(
-    app: ApplicationLike,
-    baseUrl = 'http://localhost',
-  ): Promise<TestApp> {
+  static async fromApp(app: ApplicationLike, baseUrl = 'http://localhost'): Promise<TestApp> {
+    // Set before boot() so boot-time code sees test mode; fromFetch repeats it.
     process.env.GUREN_TESTING = '1'
+    await app.boot()
 
-    const alreadyBooted =
-      typeof app.booted === 'boolean' ? app.booted : appsBootedByFromApp.has(app)
-    if (!alreadyBooted) {
-      await app.boot()
-      appsBootedByFromApp.add(app)
-    }
-
-    return new TestApp(
-      (request) => Promise.resolve(app.fetch(request)),
-      baseUrl,
-    )
+    return TestApp.fromFetch((request) => app.fetch(request), baseUrl)
   }
 
   /**
@@ -699,12 +684,6 @@ export async function factory<T>(
 }
 
 // --- Internal helpers ---
-
-// Instances fromApp() has booted itself, for apps that do not report a
-// `booted` property. Test files share one process, so the same module-scoped
-// app instance can reach fromApp() many times — booting it again would mount
-// routes and middleware twice.
-const appsBootedByFromApp = new WeakSet<ApplicationLike>()
 
 function getNestedValue(obj: unknown, path: string): unknown {
   const parts = path.split('.')


### PR DESCRIPTION
## Summary

Testing against the real application currently requires:

```ts
await app.boot()
const http = TestApp.fromFetch((request) => app.fetch(request))
```

The arrow wrapper is load-bearing — an unbound `app.fetch` reference throws because `Application.fetch` reads instance state. This PR adds a factory that removes the boilerplate and the footgun:

```ts
const http = await TestApp.fromApp(app)
```

## The boot fix underneath it

`fromApp` has to answer "what if the app is already booted?", because `Application.boot()` was not idempotent — a second boot re-runs `mountSecurityDefaults()`, the app's own boot callback, and `router.mount()`, duplicating the middleware chain.

The first version of this PR answered it from the caller side (a `booted` flag on `Application` plus a `WeakSet` in `@guren/testing`). Review found two problems with that:

- It still lost the race. Both calls in `Promise.all([TestApp.fromApp(app), TestApp.fromApp(app)])` read the flag before either finished booting, so both booted. Measured against the real `Application`: the boot callback ran twice.
- It was the *second* caller-side workaround for the same defect. `packages/plugin-cloudflare/src/handler.ts` already keeps its own `bootPromise ??= app.boot()` with reset-on-failure.

So the fix moved into `boot()` itself, which now stores its own promise. Repeated and concurrent boots reuse the first one. A boot that throws is not remembered, so a later call attempts boot again — matching what the Workers handler has always done.

That deletes rather than adds: no `booted` getter on `Application` (a test-only concern that would have been permanent public API), no `WeakSet`, no dual-rule branch in `fromApp`, which is now boot-and-delegate-to-`fromFetch`.

## Behavior change

A second `Application.boot()` used to duplicate the middleware chain and now does nothing. No call site in this repo boots the same instance twice on purpose, and the Cloudflare handler actively avoids it. Flagged in the changeset.

`plugin-cloudflare`'s own `bootPromise` is now redundant but still correct; removing it is left to a follow-up.

## Not in this PR (npm ordering)

Migrating the create-app template tests, `docs/{en,ja}/guides/testing.md`, and the agent-harness testing rule to `fromApp` waits for the release that ships this API — templates resolve `@guren/testing` from npm.

## Verification

- New `packages/server/tests/application-boot-idempotency.test.ts`: the boot callback runs once for the sequential and the concurrent case, and Hono's mounted route count does not grow after a second boot. Confirmed these **fail against the previous `boot()`** (route entries went 3 → 5) and pass after.
- `build:clean`, root `typecheck`, `test:bun` (3801), `test:examples` (102), `@guren/testing` vitest (169), `audit:core-first`, `audit:docs` — all green.
- Re-measured against the real `Application`: sequential, concurrent, and pre-booted `fromApp` all boot exactly once and run the middleware chain once.