### PR TITLE
docs(cloudflare): record why the Workers handler keeps its own boot dedup

### DIFF
--- a/packages/plugin-cloudflare/README.md
+++ b/packages/plugin-cloudflare/README.md
@@ -21,7 +21,7 @@ bunx wrangler deploy
 ## API
 
 - **`createWorkersHandler(app)`** — wraps a Guren `Application` in a Workers module handler. Boot is lazy and deduplicated on the first request, because `boot()` performs I/O that workerd forbids in global scope. The handler deduplicates boot itself, so boot-once holds for anything matching `WorkersAppLike`, not only Guren's `Application`.
-- **`getWorkersEnv<Env>()`** — exposes the first request's bindings to boot-time config through a write-once holder. Use it to hand a D1 binding to the ORM:
+- **`getWorkersEnv<Env>()`** — exposes the first request's bindings to boot-time config through a write-once holder. workerd can also expose bindings at module scope via `cloudflare:workers`, but importing that from shared config would break every other runtime (Bun, Lambda, Vercel) — the holder keeps `config/*.ts` portable. Use it to hand a D1 binding to the ORM:
 
   ```typescript
   import { createD1Database } from '@guren/core'

--- a/packages/plugin-cloudflare/README.md
+++ b/packages/plugin-cloudflare/README.md
@@ -20,7 +20,7 @@ bunx wrangler deploy
 
 ## API
 
-- **`createWorkersHandler(app)`** — wraps a Guren `Application` in a Workers module handler. Boot is lazy and deduplicated on the first request, because bindings only arrive with `fetch` and cannot be read at module scope.
+- **`createWorkersHandler(app)`** — wraps a Guren `Application` in a Workers module handler. Boot is lazy and deduplicated on the first request, because bindings only arrive with `fetch` and cannot be read at module scope. The handler does that deduplication itself, so boot-once holds for anything matching `WorkersAppLike` — not only for Guren's `Application`, whose `boot()` also memoizes on its own.
 - **`getWorkersEnv<Env>()`** — exposes the first request's bindings to boot-time config through a write-once holder. Use it to hand a D1 binding to the ORM:
 
   ```typescript

--- a/packages/plugin-cloudflare/README.md
+++ b/packages/plugin-cloudflare/README.md
@@ -20,7 +20,7 @@ bunx wrangler deploy
 
 ## API
 
-- **`createWorkersHandler(app)`** — wraps a Guren `Application` in a Workers module handler. Boot is lazy and deduplicated on the first request, because bindings only arrive with `fetch` and cannot be read at module scope. The handler does that deduplication itself, so boot-once holds for anything matching `WorkersAppLike` — not only for Guren's `Application`, whose `boot()` also memoizes on its own.
+- **`createWorkersHandler(app)`** — wraps a Guren `Application` in a Workers module handler. Boot is lazy and deduplicated on the first request, because `boot()` performs I/O that workerd forbids in global scope. The handler deduplicates boot itself, so boot-once holds for anything matching `WorkersAppLike`, not only Guren's `Application`.
 - **`getWorkersEnv<Env>()`** — exposes the first request's bindings to boot-time config through a write-once holder. Use it to hand a D1 binding to the ORM:
 
   ```typescript

--- a/packages/plugin-cloudflare/src/handler.test.ts
+++ b/packages/plugin-cloudflare/src/handler.test.ts
@@ -27,7 +27,7 @@ describe('createWorkersHandler', () => {
     resetWorkersEnv()
   })
 
-  test('should call app.boot exactly once across multiple sequential fetches', async () => {
+  test('should call app.boot exactly once across sequential fetches even when the app boot() is not idempotent', async () => {
     let bootCalls = 0
     const app: WorkersAppLike = {
       async boot() {

--- a/packages/plugin-cloudflare/src/handler.ts
+++ b/packages/plugin-cloudflare/src/handler.ts
@@ -7,8 +7,8 @@ export interface WorkersExecutionContext {
 
 /**
  * The shape `createWorkersHandler` needs from an app. Structural rather than
- * `Application` itself, so `boot()` is not assumed to be idempotent — the
- * handler guarantees boot-once for anything conforming to this type.
+ * `Application` itself, so `boot()` is not assumed to be idempotent — each
+ * handler dedupes boot across its own requests for anything conforming here.
  */
 export interface WorkersAppLike {
   boot(): Promise<void>
@@ -20,11 +20,11 @@ export interface WorkersHandler {
 }
 
 export function createWorkersHandler(app: WorkersAppLike): WorkersHandler {
-  // Bindings only arrive with `fetch`, so boot is deferred to the first request
-  // and shared by everything that races it. `Application.boot()` memoizes the
-  // same way, but this is not redundant: `WorkersAppLike` is a published
-  // structural type, so the app here need not be a Guren `Application`. Drop
-  // this and the guarantee narrows to "whatever you passed already dedupes".
+  // Boot is deferred to the first request because it performs I/O (ORM setup
+  // against D1), which workerd forbids in global scope — not because bindings
+  // are unreachable there (RFC 0003). Deduped here rather than delegated to
+  // the app: conforming to `WorkersAppLike` does not imply an idempotent
+  // `boot()`.
   let bootPromise: Promise<void> | undefined
 
   return {

--- a/packages/plugin-cloudflare/src/handler.ts
+++ b/packages/plugin-cloudflare/src/handler.ts
@@ -5,6 +5,11 @@ export interface WorkersExecutionContext {
   passThroughOnException?(): void
 }
 
+/**
+ * The shape `createWorkersHandler` needs from an app. Structural rather than
+ * `Application` itself, so `boot()` is not assumed to be idempotent — the
+ * handler guarantees boot-once for anything conforming to this type.
+ */
 export interface WorkersAppLike {
   boot(): Promise<void>
   fetch(request: Request, env?: unknown, executionCtx?: unknown): Response | Promise<Response>
@@ -15,6 +20,11 @@ export interface WorkersHandler {
 }
 
 export function createWorkersHandler(app: WorkersAppLike): WorkersHandler {
+  // Bindings only arrive with `fetch`, so boot is deferred to the first request
+  // and shared by everything that races it. `Application.boot()` memoizes the
+  // same way, but this is not redundant: `WorkersAppLike` is a published
+  // structural type, so the app here need not be a Guren `Application`. Drop
+  // this and the guarantee narrows to "whatever you passed already dedupes".
   let bootPromise: Promise<void> | undefined
 
   return {


### PR DESCRIPTION
## Summary

Investigated collapsing `createWorkersHandler`'s hand-rolled single-flight boot
into a plain `await app.boot()`, now that `Application.boot()` memoizes its own
boot promise (#331, `Application.ts:395-404`).

**The dedup should stay.** This PR records why, and along the way corrects a
rationale that both the source and the README had backwards. No behavior change.

## Why the dedup is not redundant

`WorkersAppLike` is a **published structural type** (exported from the package
index alongside `createWorkersHandler`). It only requires `boot()` and `fetch()`,
so the app reaching the handler need not be a Guren `Application`. Removing the
local `bootPromise` narrows a published guarantee from "the handler dedupes any
conforming app" to "your app must already dedupe" — and a non-idempotent app
would then re-mount middleware and routes on every request, which is exactly the
class of bug #331 fixed.

The saving would have been six lines.

Two alternatives were considered and rejected. Extracting a shared
`singleFlight()` helper has no legal home: nothing in the dependency graph sits
below both `server` and `orm`. Narrowing `WorkersAppLike` to `Application` would
be a breaking change to a published type, and would turn the
two-installed-copies-of-`@guren/core` case into a hard type error.

## The prediction that the tests would still pass is false

`handler.test.ts` pins the guarantee against the structural type, using fakes
that are deliberately non-idempotent. Applying the naive removal and running the
suite: **3 of 5 tests fail.**

| Test | Expected | Got |
| --- | --- | --- |
| boot exactly once across sequential fetches | `bootCalls === 1` | `3` |
| single boot shared across concurrent first requests | `bootCalls === 1` | `2` |
| every concurrent request sharing a failed boot rejects | `'rejected'` | `'fulfilled'` |

The third is worth stating precisely. A real `Application` would still reject
both concurrent requests — the second caller awaits the same pending promise the
first one did, before the rejection clears it. But `WorkersAppLike` permits apps
whose `boot()` is *not* single-flight, and for those the second concurrent
request boots again and succeeds while the first is failing. That is what the
fake models, and what the handler-local dedup prevents.

These failures can't be repaired by making the fakes memoize: that would test
that the fake memoizes, which is already `Application`'s own test.

Since the tests are the real enforcement and the comments only explanatory, the
first test is renamed so its failure reads as intent rather than a stale fake.

## Drive-by correction

The existing README sentence — and the comment initially added here — said boot
is deferred "because bindings only arrive with `fetch` and cannot be read at
module scope". RFC 0003 states the opposite: workerd *does* expose module-scope
bindings via `import { env } from 'cloudflare:workers'`. Boot is deferred
because it performs I/O (ORM configuration against D1) that workerd forbids in
global scope, and the plugin avoids that import so `config/*.ts` stays portable
across Bun, Lambda, and Vercel.

Both places now say that, and the `getWorkersEnv()` bullet gained the
portability reason — with the corrected rationale the write-once holder no
longer explains itself.

## Verification

- `bun run build` — green
- `bun run typecheck` — green
- `bun run test:bun` — 3801 tests, 0 fail (4 runs)

One earlier run of `test:bun` reported 2 failures and took 120s against the
usual ~30s; it was run while several background agents were saturating the
machine, and the failures did not reproduce in any subsequent run. The
identities were not captured. Flagging rather than omitting — the diff is
comments plus one test-name string, so it cannot cause a failure, but the
observation shouldn't be silently dropped.