### PR TITLE
fix(cli): detect controller body accessors in guren audit

### DIFF
--- a/.changeset/nervous-pugs-repeat.md
+++ b/.changeset/nervous-pugs-repeat.md
@@ -1,0 +1,11 @@
+---
+'@guren/cli': patch
+---
+
+fix(cli): detect controller body accessors in `guren audit`
+
+The A03 body-validation rule only recognized raw request reads (`this.request.json()`, `req.parseBody()`, …), so an action that read the payload through the documented controller helpers was reported as a pass ("does not consume the request body"). `this.input()`, `this.only()`, `this.except()`, `this.file()` and `this.files()` are now detected, including their generic forms — nested type arguments such as `this.input<Record<string, unknown>>('meta')` included.
+
+An action that only calls `this.has()` still passes, since a presence check yields no unvalidated value, but its finding no longer claims the body went unread.
+
+The accessor list is derived from a classification of `Controller`'s full public/protected surface, pinned by a test that re-parses `Controller.ts` — a new accessor added there now fails that test instead of silently defaulting to undetected. The `validateBody`/`validateBodySafe` detection is derived from the same classification, so it can no longer drift out of step with it.

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -120,8 +120,119 @@ export function authMiddlewareVerdict(
  * their own, so they intentionally do not count as protection.
  */
 const AUTH_CALL_PATTERN = /\bauth\s*\.\s*userOrFail\s*(?:<[^>]*>)?\s*\(|\bthis\s*\.\s*apiToken(?:UserId)?\s*(?:<[^>]*>)?\s*\(/
-const VALIDATE_BODY_PATTERN = /\bvalidateBody(Safe)?\s*(?:<[^>]*>)?\s*\(/
-const BODY_ACCESS_PATTERN = /\b(req|request)\s*\.\s*(json|formData|parseBody|text|body|raw)\b|\bparseRequestPayload\s*\(/
+
+/**
+ * What request data each member of `Controller` hands an action.
+ *
+ * The keys are the full public/protected method-and-getter surface of
+ * `packages/server/src/mvc/Controller.ts` — the only members app code can
+ * reach — and `controller-surface.test.ts` re-parses that file and fails when
+ * the two lists diverge. That test is the point of enumerating members this
+ * rule doesn't care about: a new accessor cannot be added over there and
+ * quietly default to "harmless" here, which is exactly how `input()` came to
+ * be missed. Which bucket a member belongs in is a semantic judgement about
+ * its body, so it stays a deliberate classification rather than something
+ * inferred from the name.
+ *
+ * Classifying a member is not the same as wiring it up: the patterns below are
+ * derived from these names but still assume call syntax, so a body-reading
+ * *getter* would need the pattern touched too, not just an entry here.
+ */
+export type ControllerMemberKind =
+  /**
+   * Hands back request-body content nothing has validated. `file()`/`files()`
+   * belong here because they are `req.parseBody()` under the hood
+   * (Controller.ts) — the raw call this rule has always flagged — and a helper
+   * cannot be a clean pass while the call it delegates to is a failure.
+   */
+  | 'body-payload'
+  /**
+   * Reads the body but yields nothing a schema would have caught: `has()`
+   * answers only whether a key is present. Not flagged, but not "does not
+   * consume the request body" either — see the finding below.
+   */
+  | 'body-incidental'
+  /** Reads the body in order to validate it — the remedy, not the problem. */
+  | 'body-validation'
+  /** Never touches the request body. */
+  | 'non-body'
+
+export const CONTROLLER_MEMBER_KINDS: Readonly<Record<string, ControllerMemberKind>> = {
+  input: 'body-payload',
+  only: 'body-payload',
+  except: 'body-payload',
+  file: 'body-payload',
+  files: 'body-payload',
+
+  has: 'body-incidental',
+
+  validateBody: 'body-validation',
+  validateBodySafe: 'body-validation',
+
+  setContext: 'non-body',
+  setContainer: 'non-body',
+  setResolvedModel: 'non-body',
+  model: 'non-body',
+  ctx: 'non-body',
+  /** Reached by name through RAW_BODY_READ_PATTERN, not as `this.request(`. */
+  request: 'non-body',
+  auth: 'non-body',
+  make: 'non-body',
+  apiToken: 'non-body',
+  apiTokenUserId: 'non-body',
+  authorize: 'non-body',
+  can: 'non-body',
+  inertia: 'non-body',
+  locale: 'non-body',
+  t: 'non-body',
+  tc: 'non-body',
+  json: 'non-body',
+  text: 'non-body',
+  redirect: 'non-body',
+  noContent: 'non-body',
+  created: 'non-body',
+  accepted: 'non-body',
+  query: 'non-body',
+  validateQuery: 'non-body',
+  validateParams: 'non-body',
+  validateQuerySafe: 'non-body',
+  validateParamsSafe: 'non-body',
+}
+
+function controllerMembers(kind: ControllerMemberKind): string[] {
+  return Object.entries(CONTROLLER_MEMBER_KINDS)
+    .filter(([, memberKind]) => memberKind === kind)
+    .map(([name]) => name)
+}
+
+/**
+ * `name(`, plus the generic forms these helpers are declared with. `[^()]*`
+ * rather than `[^>]*` so a nested type argument (`this.input<Array<string>>()`)
+ * still reaches the closing `(` — stopping at the first `>` silently skipped
+ * those calls. Longest name first so `validateBody` cannot shadow
+ * `validateBodySafe`.
+ */
+function accessorCallPattern(names: readonly string[]): string {
+  const alternation = [...names].sort((a, b) => b.length - a.length).join('|')
+  return `\\b(?:${alternation})\\s*(?:<[^()]*>)?\\s*\\(`
+}
+
+const VALIDATE_BODY_PATTERN = new RegExp(accessorCallPattern(controllerMembers('body-validation')))
+
+/** Reading the body without going through the controller's helpers at all. */
+const RAW_BODY_READ_PATTERN = /\b(req|request)\s*\.\s*(json|formData|parseBody|text|body|raw)\b|\bparseRequestPayload\s*\(/
+
+/**
+ * `this.` is required on the controller-accessor half: the members are
+ * `protected`, so a call through anything else is a different API.
+ */
+const BODY_ACCESS_PATTERN = new RegExp(
+  `${RAW_BODY_READ_PATTERN.source}|\\bthis\\s*\\.\\s*${accessorCallPattern(controllerMembers('body-payload'))}`,
+)
+
+const BODY_INCIDENTAL_PATTERN = new RegExp(
+  `\\bthis\\s*\\.\\s*${accessorCallPattern(controllerMembers('body-incidental'))}`,
+)
 
 function finding(
   key: string,
@@ -476,12 +587,17 @@ async function auditRoutes(
           ),
         )
       } else if (methodInfo && !readsBody) {
+        // A body-incidental read is still a read, so claiming the action never
+        // touches the body would be false — say what it actually took instead.
+        const incidental = BODY_INCIDENTAL_PATTERN.test(methodInfo.body)
         findings.push(
           finding(
             `validation:${routeLabel}`,
             routeLabel,
             'pass',
-            `${controllerKey} does not consume the request body.`,
+            incidental
+              ? `${controllerKey} only tests the request body for a key, so no unvalidated value reaches the app.`
+              : `${controllerKey} does not consume the request body.`,
           ),
         )
       } else if (methodInfo) {

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -51,6 +51,91 @@ export default function registerRoutes(router: any) {
     }
   })
 
+  it.each([
+    ['input', `const title = await this.input<string>('title')`],
+    ['input with a nested type argument', `const meta = await this.input<Record<string, unknown>>('meta')`],
+    ['only', `const data = await this.only('title', 'body')`],
+    ['except', `const data = await this.except('id')`],
+    // file()/files() are req.parseBody() underneath, which this rule has
+    // always flagged when called directly.
+    ['file', `const avatar = await this.file('avatar')`],
+    ['files', `const attachments = await this.files('attachments')`],
+  ])('fails when the body is read through this.%s() without validation', async (_accessor, read) => {
+    const workspace = await createTempWorkspace('guren-cli-audit-accessor-')
+
+    try {
+      await writeController(
+        workspace.dir,
+        'PostController',
+        `export default class PostController extends Controller {
+  async store() {
+    ${read}
+    return null
+  }
+}`,
+      )
+      await writeRoutes(
+        workspace.dir,
+        `class PostController {
+  async store() { return null }
+}
+export default function registerRoutes(router: any) {
+  router.post('/posts', [PostController, 'store'])
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const validation = report.findings.find(f => f.key === 'validation:POST /posts')
+      expect(validation).toBeDefined()
+      expect(validation!.status).toBe('fail')
+      expect(validation!.suggestion).toContain('validateBody')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('passes validation when the controller only checks the body for a key', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-has-')
+
+    try {
+      await writeController(
+        workspace.dir,
+        'PostController',
+        `export default class PostController extends Controller {
+  async store() {
+    if (await this.has('draft')) {
+      return this.redirect('/drafts')
+    }
+    return this.redirect('/posts')
+  }
+}`,
+      )
+      await writeRoutes(
+        workspace.dir,
+        `class PostController {
+  async store() { return null }
+}
+export default function registerRoutes(router: any) {
+  router.post('/posts', [PostController, 'store'])
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const validation = report.findings.find(f => f.key === 'validation:POST /posts')
+      expect(validation).toBeDefined()
+      // has() consumes the body but yields only a boolean, so no unvalidated
+      // value reaches the app and validateBody() would be the wrong advice.
+      expect(validation!.status).toBe('pass')
+      // ...but the action does read the body, so the report must not claim otherwise.
+      expect(validation!.message).not.toContain('does not consume')
+      expect(validation!.message).toContain('only tests the request body for a key')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('passes validation when the controller does not consume the body', async () => {
     const workspace = await createTempWorkspace('guren-cli-audit-nobody-')
 

--- a/packages/cli/tests/controller-surface.test.ts
+++ b/packages/cli/tests/controller-surface.test.ts
@@ -1,0 +1,70 @@
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'bun:test'
+import { CONTROLLER_MEMBER_KINDS } from '../src/audit'
+import { extractClassDeclaration } from '../src/model-parser'
+import { parseSourceFile } from '../src/parse-cache'
+
+/**
+ * Pins `CONTROLLER_MEMBER_KINDS` to the real `Controller` surface, because a
+ * member the audit's body-access rule doesn't know about is reported as a
+ * *pass* — the gap looks like a clean bill of health.
+ *
+ * Reads the source rather than `Controller.prototype`: `packages/cli` resolves
+ * `@guren/server` through `dist/`, so a prototype check would keep passing
+ * against a stale build, and TS `private` is erased at runtime, which would
+ * drag internals app code cannot call into the classification.
+ */
+const CONTROLLER_PATH = fileURLToPath(new URL('../../server/src/mvc/Controller.ts', import.meta.url))
+
+/**
+ * Method and getter names an action can call: instance members that are
+ * `protected` or (explicitly or by omission) `public`. Class *properties* are
+ * left out — the only one on the public surface is the static `inject` DI hint,
+ * which is configuration, not something a method body invokes.
+ *
+ * Throws on any eligible member this cannot name (a computed or string-literal
+ * key). Skipping those quietly would let one be added without classification,
+ * which is the failure this guard exists to prevent.
+ */
+async function publicControllerSurface(): Promise<string[]> {
+  const source = await readFile(CONTROLLER_PATH, 'utf8').catch(() => null)
+  if (source === null) {
+    throw new Error(
+      `Could not read ${CONTROLLER_PATH}. If Controller.ts moved, update CONTROLLER_PATH here `
+      + 'and re-check CONTROLLER_MEMBER_KINDS in src/audit.ts against the new location.',
+    )
+  }
+
+  const ast = parseSourceFile(source, CONTROLLER_PATH)
+  if (!ast) throw new Error(`Could not parse ${CONTROLLER_PATH}.`)
+
+  for (const node of ast.program.body) {
+    const classDecl = extractClassDeclaration(node)
+    if (classDecl?.id?.name !== 'Controller') continue
+
+    const names = new Set<string>()
+    for (const member of classDecl.body.body) {
+      if (member.type !== 'ClassMethod' && member.type !== 'TSDeclareMethod') continue
+      if (member.static || member.accessibility === 'private' || member.kind === 'constructor') continue
+      if (member.key.type !== 'Identifier') {
+        throw new Error(
+          `Controller has a public/protected member with a ${member.key.type} key, which this guard `
+          + 'cannot name. Give it an identifier key, or teach this test to resolve it — leaving it '
+          + 'unnamed would let a body-reading accessor slip past CONTROLLER_MEMBER_KINDS.',
+        )
+      }
+      names.add(member.key.name)
+    }
+
+    return [...names].sort()
+  }
+
+  throw new Error(`No 'Controller' class declaration found in ${CONTROLLER_PATH}.`)
+}
+
+describe('CONTROLLER_MEMBER_KINDS', () => {
+  it('classifies every public/protected member of Controller', async () => {
+    expect(Object.keys(CONTROLLER_MEMBER_KINDS).sort()).toEqual(await publicControllerSurface())
+  })
+})


### PR DESCRIPTION
## Summary

`guren audit`'s A03 body-validation rule matched only raw request reads (`this.request.json()`, `req.parseBody()`, `parseRequestPayload()`). An action reading the payload through the documented controller helpers was therefore reported as a **pass**, with the message "does not consume the request body" — a silent false negative on exactly the API the docs tell users to call.

Reproduced against `examples/blog`: replacing `store()`'s `await this.validateBody(PostPayloadSchema)` with three `await this.input<string>(...)` reads left the audit at `23 passed, 1 warnings, 0 failures`. The same action written with `await this.request.json()` fails, as it should.

What changed:

- **`this.input()`, `this.only()`, `this.except()`, `this.file()`, `this.files()` are now detected**, including nested type arguments (`this.input<Record<string, unknown>>('meta')` — the previous `<[^>]*>` group stopped at the first `>` and skipped those calls entirely).
- `file()`/`files()` are included because they are `req.parseBody()` underneath (`Controller.ts:190`, `:201`). A helper cannot be a clean pass while the call it delegates to is a failure — and `docs/*/guides/storage.md`'s own upload example, written with `this.request.formData()`, is already flagged today.
- An action that only calls `this.has()` still passes (a presence check yields no unvalidated value), but its finding no longer claims the body went unread.
- The accessor names are derived from `CONTROLLER_MEMBER_KINDS`, a classification of `Controller`'s full public/protected surface, **pinned by a test that re-parses `Controller.ts`**. A member added there now fails that test instead of silently defaulting to undetected.
- `VALIDATE_BODY_PATTERN` is derived from the same classification. It previously kept its own copy of `validateBody`/`validateBodySafe`, and that copy also gates `auditForceWrites()` (`audit.ts:473`) — drift there would have silently dropped the mass-assignment warning rather than merely over-reporting.

The drift guard reads source rather than `Controller.prototype` on purpose: `packages/cli` resolves `@guren/server` through `dist/`, so a prototype check would keep passing against a stale build, and TS `private` is erased at runtime, which would drag internals app code cannot call into the classification.

## Scope

`cli` (`packages/cli/src/audit.ts`, `packages/cli/tests/`). No changes to `server`, `orm`, templates, or docs.

## Risk Assessment

- **Behavior change:** controller actions using the five accessors above without validation now report `fail` instead of `pass`, and `guren audit` exits non-zero for them. That is the intended fix; apps relying on the false negative will see new failures.
- **No false positives observed on the real apps in this repo.** `examples/blog` and `web/` were audited before and after: every `validation:*` and `force-write:*` finding is unchanged (11 and 5 findings respectively, 0 status changes), and the totals stay at 23/1/0 and 16/1/0. Neither app calls these accessors, so that proves no regression rather than correctness of the new branch — the unit fixtures cover that.
- **Known limitation, unchanged:** the rule is regex-based over method-body source, so a `this.input(` inside a comment or string still counts as a read. This is a pre-existing property shared with the `request.json` half, not introduced here.
- **Known limitation, unchanged:** the emitted suggestion is always "Call `this.validateBody(schema)`", which is imperfect advice for an upload. That is already true for the equivalent `req.parseBody()`/`request.formData()` calls; giving uploads their own remedy is a separate change.
- No migration impact. `@guren/cli` patch changeset included.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` — `test:bun` 3749 pass / 0 fail; `test:examples` green
- [x] `bun run audit:core-first`, `bun run audit:docs`

Mutation-tested in both directions (each of these turns the suite red):

| mutation | result |
| --- | --- |
| `input` reclassified to `non-body` | 2 regression tests fail |
| nested-generic widening reverted to `<[^>]*>` | nested-type-argument test fails |
| `has` reclassified to `non-body` | message-accuracy test fails |
| new `protected` accessor added to `Controller.ts` | drift guard fails, naming it |
| computed-key member added to `Controller.ts` | drift guard throws rather than skipping |

End-to-end: with the repro applied to `examples/blog`, `POST /posts` becomes `fail` with `Route body schema is type-only for controller actions — PostController.store reads the body without calling validateBody().` and the command exits 1. The file is restored on this branch.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation. — no user-facing docs describe this rule's accessor list; the changeset covers the behavior change.
