### PR TITLE
fix(cli): wire scaffolded route files into the registrar the loader calls

### DIFF
--- a/.changeset/silly-donkeys-attack.md
+++ b/.changeset/silly-donkeys-attack.md
@@ -1,0 +1,23 @@
+---
+'@guren/cli': patch
+'create-guren-app': patch
+---
+
+Wire scaffolded route files into the registrar the framework actually calls
+
+`guren add admin`, `guren add oauth`, `guren add resource`, and `guren add auth`
+located the app's route registrar with a regex that only matched `export
+function register*Routes(router: Router)`. An app scaffolded from the blog
+blueprint names that parameter `baseRouter`, so the routes file was written but
+never imported or called — and because the wiring ran inside a `try {} catch {}`,
+nothing was reported.
+
+The registrar is now found by parsing `routes/web.ts` and selecting the export
+the route loader itself resolves, so any parameter name, a multi-line signature,
+an arrow-function or default-export registrar, and a `Router` imported under an
+alias all wire correctly, while an unrelated exported helper that merely takes a
+router does not. The generated call passes the registrar's own parameter, which
+is the only name guaranteed to be in scope. The call and its import land in one
+write, so a routes file that cannot be patched is left untouched instead of
+gaining an import for routes nothing registers — and that outcome is now
+reported rather than swallowed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -380,6 +380,7 @@ export const handler = createLambdaHandler(app)
 | `packages/cli/src/schema-parser.ts` | Shared Drizzle schema AST parser (tables, columns, FKs, dialect, column options) |
 | `packages/cli/src/inflect.ts` | The one pluralization rule: collection, route slug, schema identifier, and table name for an entity. Every scaffolder and `guren check` derive names through it — a second rule is how the model's import and the schema's export drift apart |
 | `packages/cli/src/drizzle-pins.ts` | The one rule keeping `drizzle-orm`/`drizzle-kit` on the copy `@guren/orm` installs. `guren upgrade` applies it to an installed app, `scripts/sync-template-deps.ts` to the scaffold templates — a second rule is how a scaffolded app ends up with two ORM copies in one process |
+| `packages/cli/src/route-registrar.ts` | The one rule for what counts as an app's route registrar, and the patch that wires a scaffolded routes file into it. `load-routes.ts` resolves the same export names at runtime — a scaffolder that picked its own target patches a function the framework never calls, and the routes look wired while mounting nothing |
 | `packages/cli/src/check.ts` | AI agent: integrity checking |
 | `packages/cli/src/console-check.ts` | AI agent: console command registration checks (part of `guren check`) |
 | `packages/cli/src/schema-check.ts` | AI agent: Postgres `timestamptz` schema checks (part of `guren check`) |

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -1,6 +1,6 @@
 import { makeAuth } from './make-auth'
 import { makeChannel } from './make-channel'
-import { makeFeature } from './make-feature'
+import { buildRouteRegistrationHint, makeFeature } from './make-feature'
 import { parseFieldsString, type FieldDefinition, type FieldType } from './fields'
 import { collectionSlug, schemaIdentifierFor, singularize, tableNameFor } from './inflect'
 import { makeController } from './make-controller'
@@ -12,7 +12,8 @@ import { makeModel } from './make-model'
 import { makeNotification } from './make-notification'
 import { makeRoute } from './make-route'
 import { makeView } from './make-view'
-import { addImport, addProvider, detectSchemaDialect, ensureDrizzleImports, ensureMysqlImports, ensureSqliteImports, findClosingDelimiter } from './patch-helpers'
+import { addImport, addProvider, detectSchemaDialect, ensureDrizzleImports, ensureMysqlImports, ensureSqliteImports, insertImport } from './patch-helpers'
+import { findRouteRegistrar, wireRouteRegistrar } from './route-registrar'
 import { assertCwdUnsupported, camelCase, pascalCase, writeScaffoldFiles, type WriterOptions } from './utils'
 import { readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
@@ -120,23 +121,7 @@ export default registerAdminRoutes
         },
       ], writerOptions)
 
-      try {
-        const webRoutesPath = 'routes/web.ts'
-        const absoluteWebRoutesPath = resolve(process.cwd(), webRoutesPath)
-        const adminImport = "import registerAdminRoutes from './admin.js'"
-        await addImport(webRoutesPath, adminImport)
-
-        let routesContent = await readFile(absoluteWebRoutesPath, 'utf8')
-        if (!routesContent.includes('registerAdminRoutes(router)')) {
-          const registrarPattern = /(export function [^(]+\(\s*router\s*:\s*Router\s*\)\s*(?::\s*[^{]+)?\{\n)/u
-          if (registrarPattern.test(routesContent)) {
-            routesContent = routesContent.replace(registrarPattern, `$1  registerAdminRoutes(router)\n`)
-            await writeFile(absoluteWebRoutesPath, routesContent, 'utf8')
-          }
-        }
-      } catch {
-        // skip route auto-wiring when routes/web.ts doesn't exist yet
-      }
+      await wireRouteRegistrar('registerAdminRoutes', "import registerAdminRoutes from './admin.js'")
 
       return created
     },
@@ -280,23 +265,7 @@ export default registerOAuthRoutes
       await addImport('src/app.ts', "import OAuthProvider from '../app/Providers/OAuthProvider.js'")
       await addProvider('src/app.ts', 'OAuthProvider')
 
-      try {
-        const webRoutesPath = 'routes/web.ts'
-        const absoluteWebRoutesPath = resolve(process.cwd(), webRoutesPath)
-        const oauthImport = "import registerOAuthRoutes from './oauth.js'"
-        await addImport(webRoutesPath, oauthImport)
-
-        let routesContent = await readFile(absoluteWebRoutesPath, 'utf8')
-        if (!routesContent.includes('registerOAuthRoutes(router)')) {
-          const registrarPattern = /(export function [^(]+\(\s*router\s*:\s*Router\s*\)\s*(?::\s*[^{]+)?\{\n)/u
-          if (registrarPattern.test(routesContent)) {
-            routesContent = routesContent.replace(registrarPattern, `$1  registerOAuthRoutes(router)\n`)
-            await writeFile(absoluteWebRoutesPath, routesContent, 'utf8')
-          }
-        }
-      } catch {
-        // skip route auto-wiring when routes/web.ts doesn't exist yet
-      }
+      await wireRouteRegistrar('registerOAuthRoutes', "import registerOAuthRoutes from './oauth.js'")
 
       return created
     },
@@ -801,46 +770,41 @@ async function updateResourceSchema(singular: string, fields: FieldDefinition[])
 }
 
 async function updateResourceRoutes(singular: string, routeName: string, routeVar: string): Promise<void> {
-  const controllerName = `${singular}Controller`
   const routesPath = resolve(process.cwd(), 'routes/web.ts')
   let content = await readFile(routesPath, 'utf8')
-  const controllerImport = `import ${controllerName} from '../app/Http/Controllers/${controllerName}.js'`
-  const validatorImport = `import { ${singular}PayloadSchema } from '../app/Http/Validators/${singular}Validator.js'`
-
-  if (!content.includes(controllerImport)) {
-    content = content.replace(
-      /(import[^\n]+\n)(\n)?export function/u,
-      `$1${controllerImport}\n\nexport function`,
-    )
-  }
-
-  if (!content.includes(validatorImport)) {
-    content = content.replace(
-      /(import[^\n]+\n)(\n)?export function/u,
-      `$1${validatorImport}\n\nexport function`,
-    )
-  }
 
   if (!content.includes(`'${routeName}.index'`) && !content.includes(`/${routeName}'`)) {
-    const groupBlock = `\n  router.group('/${routeName}', (${routeVar}) => {\n    ${routeVar}.get('/', [${controllerName}, 'index']).name('${routeName}.index')\n    ${routeVar}.get('/create', [${controllerName}, 'create']).name('${routeName}.create')\n    ${routeVar}.get('/:id', [${controllerName}, 'show']).name('${routeName}.show')\n    ${routeVar}.get('/:id/edit', [${controllerName}, 'edit']).name('${routeName}.edit')\n    ${routeVar}.post('/', { name: '${routeName}.store', body: ${singular}PayloadSchema }, [${controllerName}, 'store'])\n    ${routeVar}.put('/:id', { name: '${routeName}.update', body: ${singular}PayloadSchema }, [${controllerName}, 'update'])\n    ${routeVar}.delete('/:id', { name: '${routeName}.destroy' }, [${controllerName}, 'destroy'])\n  })\n`
+    const registrar = findRouteRegistrar(content)
 
-    // Insert before the closing brace of the route registrar function.
-    const registrarMatch = content.match(/export function [^(]*\(\s*router\s*:\s*Router\s*\)[^{]*\{/u)
-    let inserted = false
-    if (registrarMatch && registrarMatch.index !== undefined) {
-      const openIndex = registrarMatch.index + registrarMatch[0].length - 1
-      const closeIndex = findClosingDelimiter(content, openIndex, '{', '}')
-      if (closeIndex !== -1) {
-        content = content.slice(0, closeIndex) + groupBlock + content.slice(closeIndex)
-        inserted = true
-      }
-    }
-
-    if (!inserted) {
+    // Located before anything is written: an app whose routes file cannot be
+    // patched keeps the file it had, rather than two imports for routes that
+    // were never registered.
+    if (!registrar) {
       throw new Error(
         `Could not find a route registrar in routes/web.ts. Register the /${routeName} routes manually.`,
       )
     }
+
+    // The same CRUD block `make:feature` prints for hand-wiring, hung off the
+    // registrar's own parameter — whatever it is named.
+    const group = buildRouteRegistrationHint({
+      singular,
+      routeName,
+      routeVar,
+      withAuth: false,
+      receiver: registrar.parameterName,
+    })
+
+    // Insert before the closing brace of the route registrar function.
+    const groupBlock = `\n${group.map((line) => `  ${line}`).join('\n')}\n`
+    content = content.slice(0, registrar.bodyEnd) + groupBlock + content.slice(registrar.bodyEnd)
+  }
+
+  for (const statement of [
+    `import ${singular}Controller from '../app/Http/Controllers/${singular}Controller.js'`,
+    `import { ${singular}PayloadSchema } from '../app/Http/Validators/${singular}Validator.js'`,
+  ]) {
+    content = insertImport(content, statement) ?? content
   }
 
   await writeFile(routesPath, content, 'utf8')

--- a/packages/cli/src/load-routes.ts
+++ b/packages/cli/src/load-routes.ts
@@ -3,24 +3,17 @@ import { pathToFileURL } from 'node:url'
 import { consola } from 'consola'
 import { Router, mountModuleRoutes, type GurenModule, type RouteDefinition } from '@guren/core'
 import { listModuleNames } from './discovery'
+import { REGISTRAR_EXPORT_NAMES, REGISTRAR_PATTERN } from './route-registrar'
 
 type RouteRegistrar = (router: Router) => void | Promise<void>
 
-/** Conventional routes entry file, shared by every command that loads routes. */
-export const DEFAULT_ROUTES_FILE = 'routes/web.ts'
-
-const REGISTRAR_EXPORTS = [
-  'registerRoutes',
-  'registerWebRoutes',
-  'registerApiRoutes',
-  'registerAuthRoutes',
-  'default',
-] as const
-
-const REGISTRAR_PATTERN = /^register\w*Routes$/u
+// Re-exported so the many commands that resolve the routes entry file keep
+// importing it from here; the constant lives beside the registrar name
+// contract, which the scaffolders need without pulling in `@guren/core`.
+export { DEFAULT_ROUTES_FILE } from './route-registrar'
 
 function resolveRegistrar(moduleExports: Record<string, unknown>): RouteRegistrar | undefined {
-  for (const name of REGISTRAR_EXPORTS) {
+  for (const name of REGISTRAR_EXPORT_NAMES) {
     const candidate = moduleExports[name]
     if (typeof candidate === 'function') {
       return candidate as RouteRegistrar

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -15,6 +15,7 @@ import {
   type SchemaDialect,
 } from './patch-helpers'
 import { readIfExists } from './discovery'
+import { wireRouteRegistrar } from './route-registrar'
 import { makeMigration } from './make-migration'
 
 // Passwordless apps keep show() (the OAuth button page) and destroy()
@@ -2422,35 +2423,7 @@ async function installAuth(
     consola.info('Add `auth: {}` to your createApp() options to enable sessions and CSRF.')
   }
 
-  // Add auth routes import to routes/web.ts
-  const webRoutesPath = 'routes/web.ts'
-  try {
-    const absoluteWebRoutesPath = resolve(process.cwd(), webRoutesPath)
-    let routesContent = await readFile(absoluteWebRoutesPath, 'utf8')
-    const routesImport = "import { registerAuthRoutes } from './auth.js'"
-    const routesImportResult = await addImport(webRoutesPath, routesImport)
-
-    if (routesImportResult.modified) {
-      consola.success(`Added auth route registrar import to ${webRoutesPath}`)
-    } else if (routesImportResult.reason === 'Import already exists') {
-      consola.info(`Auth route registrar import already exists in ${webRoutesPath}`)
-    }
-
-    routesContent = await readFile(absoluteWebRoutesPath, 'utf8')
-
-    if (!routesContent.includes('registerAuthRoutes(router)')) {
-      const registrarPattern = /(export function [^(]+\(\s*router\s*:\s*Router\s*\)\s*(?::\s*[^{]+)?\{\n)/u
-      if (registrarPattern.test(routesContent)) {
-        routesContent = routesContent.replace(registrarPattern, `$1  registerAuthRoutes(router)\n`)
-        await writeFile(absoluteWebRoutesPath, routesContent, 'utf8')
-        consola.success(`Registered auth routes inside ${webRoutesPath}`)
-      } else {
-        consola.warn(`Could not locate a route registrar in ${webRoutesPath} - add registerAuthRoutes(router) manually`)
-      }
-    }
-  } catch {
-    consola.warn(`Could not find ${webRoutesPath} - you may need to manually import and call registerAuthRoutes(router)`)
-  }
+  await wireRouteRegistrar('registerAuthRoutes', "import { registerAuthRoutes } from './auth.js'")
 
   consola.success('Authentication configuration installed!')
   consola.info('Session middleware is auto-configured via AuthServiceProvider (autoSession: true)')

--- a/packages/cli/src/make-feature.ts
+++ b/packages/cli/src/make-feature.ts
@@ -141,27 +141,39 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
 }
 
 /**
- * The route-registration block `make:feature` prints for the developer to paste
- * into their registrar. It has to compile verbatim inside
- * `export function register*Routes(router: Router)` — the shape both the default
- * app template and `make:module` scaffold — so the auth alias binds a *new* name
- * instead of assuming a differently-named parameter or shadowing `router`.
- * Capturing that return value is what puts `'auth'` into the router's type;
- * discard it and every `.middleware('auth')` below stops compiling.
+ * The route-registration block for a resource: what `make:feature` prints for
+ * the developer to paste into their registrar, and what `guren add resource`
+ * writes into `routes/web.ts` directly. One builder for both, so the CRUD set
+ * cannot drift between the routes an app is told to register and the ones the
+ * blueprint registers for it.
+ *
+ * It has to compile verbatim inside `export function register*Routes(router:
+ * Router)` — the shape both the default app template and `make:module`
+ * scaffold — so the auth alias binds a *new* name instead of assuming a
+ * differently-named parameter or shadowing `router`. Capturing that return
+ * value is what puts `'auth'` into the router's type; discard it and every
+ * `.middleware('auth')` below stops compiling.
+ *
+ * `receiver` is the router the group hangs off when there is no auth alias to
+ * bind. The blueprint passes the registrar's own parameter, which is the only
+ * name guaranteed to be in scope — a registrar that rebinds it (the blog
+ * template's `const router = baseRouter.aliasMiddleware(...)`) does so partway
+ * down the body.
  */
 export function buildRouteRegistrationHint(options: {
   singular: string
   routeName: string
   routeVar: string
   withAuth: boolean
+  receiver?: string
 }): string[] {
-  const { singular, routeName, routeVar, withAuth } = options
+  const { singular, routeName, routeVar, withAuth, receiver = 'router' } = options
   const authSuffix = withAuth ? `.middleware('auth')` : ''
-  const groupRouter = withAuth ? 'authRouter' : 'router'
+  const groupRouter = withAuth ? 'authRouter' : receiver
 
   return [
     ...(withAuth
-      ? [`const ${groupRouter} = router.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))`]
+      ? [`const ${groupRouter} = ${receiver}.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))`]
       : []),
     `${groupRouter}.group('/${routeName}', (${routeVar}) => {`,
     `  ${routeVar}.get('/', [${singular}Controller, 'index']).name('${routeName}.index')`,

--- a/packages/cli/src/patch-helpers.ts
+++ b/packages/cli/src/patch-helpers.ts
@@ -75,7 +75,7 @@ function matchInCode(content: string, pattern: RegExp): RegExpExecArray | null {
  * depth over the masked source, so nesting is respected and a bracket inside
  * a string or comment does not shift the result.
  */
-export function findClosingDelimiter(content: string, openIndex: number, open: string, close: string): number {
+function findClosingDelimiter(content: string, openIndex: number, open: string, close: string): number {
   const masked = maskNonCode(content)
   let depth = 0
 
@@ -121,26 +121,20 @@ function appendArrayEntry(arrayInterior: string, valueSource: string): string {
 }
 
 /**
- * Adds an import statement to a file if not already present.
- * Inserts the import at the top of the file, after any existing imports.
+ * `content` with `importStatement` inserted after the last existing import, or
+ * `null` when it is already there.
+ *
+ * Split out from `addImport` so a patch that also edits the body can apply both
+ * in one write: the alternative is a second file-level pass that can leave an
+ * import behind when the body edit is the one that failed.
  */
-export async function addImport(
-  filePath: string,
-  importStatement: string,
-): Promise<PatchResult> {
-  const absolutePath = resolve(process.cwd(), filePath)
-  const content = await readIfExists(process.cwd(), filePath)
-
-  if (content === null) {
-    return { modified: false, reason: 'File not found' }
-  }
-
+export function insertImport(content: string, importStatement: string): string | null {
   const normalizedImport = importStatement.trim()
   const importPattern = escapeRegExp(normalizedImport)
   const regex = new RegExp(`^\\s*${importPattern}\\s*$`, 'm')
 
   if (regex.test(content)) {
-    return { modified: false, reason: 'Import already exists' }
+    return null
   }
 
   const lines = content.split('\n')
@@ -177,7 +171,29 @@ export async function addImport(
   insertIndex = lastImportIndex >= 0 ? lastImportIndex + 1 : 0
 
   lines.splice(insertIndex, 0, normalizedImport)
-  const updatedContent = lines.join('\n')
+  return lines.join('\n')
+}
+
+/**
+ * Adds an import statement to a file if not already present.
+ * Inserts the import at the top of the file, after any existing imports.
+ */
+export async function addImport(
+  filePath: string,
+  importStatement: string,
+): Promise<PatchResult> {
+  const absolutePath = resolve(process.cwd(), filePath)
+  const content = await readIfExists(process.cwd(), filePath)
+
+  if (content === null) {
+    return { modified: false, reason: 'File not found' }
+  }
+
+  const updatedContent = insertImport(content, importStatement)
+
+  if (updatedContent === null) {
+    return { modified: false, reason: 'Import already exists' }
+  }
 
   await writeFile(absolutePath, updatedContent, 'utf8')
   return { modified: true }

--- a/packages/cli/src/route-registrar.ts
+++ b/packages/cli/src/route-registrar.ts
@@ -1,0 +1,293 @@
+import { consola } from 'consola'
+import { writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import type { ArrowFunctionExpression, File, FunctionDeclaration, FunctionExpression, Statement } from '@babel/types'
+import { walk } from './ast-walk'
+import { readIfExists } from './discovery'
+import { parseSourceFile } from './parse-cache'
+import { insertImport, type PatchResult } from './patch-helpers'
+
+/**
+ * The export names `@guren/core`'s route loader looks for, in the order it
+ * tries them, and the pattern it falls back to.
+ *
+ * The one rule for "what counts as this app's route registrar", shared with
+ * `load-routes.ts`, which resolves the same names at runtime. A scaffolder that
+ * decided for itself which function to patch would eventually patch one the
+ * framework never calls — the routes would be written, mounted nowhere, and
+ * look wired in the file.
+ */
+export const REGISTRAR_EXPORT_NAMES = [
+  'registerRoutes',
+  'registerWebRoutes',
+  'registerApiRoutes',
+  'registerAuthRoutes',
+  'default',
+] as const
+
+export const REGISTRAR_PATTERN = /^register\w*Routes$/u
+
+/** Conventional routes entry file, shared by every command that loads routes. */
+export const DEFAULT_ROUTES_FILE = 'routes/web.ts'
+
+export interface RouteRegistrar {
+  /**
+   * The name the registrar gave its router parameter. The default app template
+   * calls it `router`; the blog template calls it `baseRouter`, because it goes
+   * on to declare `const router = baseRouter.aliasMiddleware(...)`.
+   */
+  parameterName: string
+  /** Index just past the registrar body's opening `{`. */
+  bodyStart: number
+  /** Index of the registrar body's closing `}`. */
+  bodyEnd: number
+}
+
+type RegistrarFunction = FunctionDeclaration | FunctionExpression | ArrowFunctionExpression
+
+/** Top-level `function f() {}` / `const f = () => {}` declarations, by name. */
+function declaredFunctions(body: Statement[]): Map<string, RegistrarFunction> {
+  const declarations = new Map<string, RegistrarFunction>()
+
+  for (const statement of body) {
+    const declaration = statement.type === 'ExportNamedDeclaration' ? statement.declaration : statement
+
+    if (declaration?.type === 'FunctionDeclaration' && declaration.id) {
+      declarations.set(declaration.id.name, declaration)
+      continue
+    }
+
+    if (declaration?.type === 'VariableDeclaration') {
+      for (const declarator of declaration.declarations) {
+        const init = declarator.init
+        if (declarator.id.type !== 'Identifier') continue
+        if (init?.type === 'ArrowFunctionExpression' || init?.type === 'FunctionExpression') {
+          declarations.set(declarator.id.name, init)
+        }
+      }
+    }
+  }
+
+  return declarations
+}
+
+/**
+ * Every function this file *exports* that the route loader would accept as the
+ * registrar, in source order.
+ *
+ * Two things decide it, and both come from the loader rather than from shape.
+ * The function has to be exported — a local `registerAdminRoutes` helper is
+ * never what the framework calls, so patching it writes routes nothing mounts.
+ * And the export name has to match, rather than the parameter being
+ * `Router`-annotated: the annotation can be an alias (`import { Router as
+ * AppRouter }`), and a helper that merely takes a router —
+ * `buildPrefix(prefix: string, router: Router)` — is not the entry point, so
+ * choosing by shape picks the wrong function and then hands the call that
+ * function's first parameter.
+ */
+function registrarCandidates(body: Statement[]): RegistrarFunction[] {
+  const declarations = declaredFunctions(body)
+  const candidates: RegistrarFunction[] = []
+
+  const add = (candidate: RegistrarFunction | undefined): void => {
+    if (candidate) candidates.push(candidate)
+  }
+
+  for (const statement of body) {
+    if (statement.type === 'ExportDefaultDeclaration') {
+      const declaration = statement.declaration
+      // A default export needs no matching name — the loader takes it as-is,
+      // including the anonymous `export default function (router) {}` and the
+      // `export default registerWebRoutes` indirection.
+      if (
+        declaration.type === 'FunctionDeclaration'
+        || declaration.type === 'FunctionExpression'
+        || declaration.type === 'ArrowFunctionExpression'
+      ) {
+        add(declaration)
+      } else if (declaration.type === 'Identifier') {
+        add(declarations.get(declaration.name))
+      }
+      continue
+    }
+
+    if (statement.type !== 'ExportNamedDeclaration') continue
+
+    const declaration = statement.declaration
+
+    if (declaration?.type === 'FunctionDeclaration' && declaration.id && REGISTRAR_PATTERN.test(declaration.id.name)) {
+      add(declaration)
+      continue
+    }
+
+    if (declaration?.type === 'VariableDeclaration') {
+      for (const declarator of declaration.declarations) {
+        if (declarator.id.type === 'Identifier' && REGISTRAR_PATTERN.test(declarator.id.name)) {
+          add(declarations.get(declarator.id.name))
+        }
+      }
+      continue
+    }
+
+    // `export { registerWebRoutes }` / `export { register as registerRoutes }`
+    // — the exported name is what the loader sees.
+    for (const specifier of statement.specifiers) {
+      if (specifier.type !== 'ExportSpecifier') continue
+      const exported = specifier.exported.type === 'Identifier' ? specifier.exported.name : specifier.exported.value
+      if (exported === 'default' || REGISTRAR_PATTERN.test(exported)) {
+        add(declarations.get(specifier.local.name))
+      }
+    }
+  }
+
+  return candidates
+}
+
+function registrarIn(ast: File): RouteRegistrar | null {
+  for (const fn of registrarCandidates(ast.program.body)) {
+    const [parameter] = fn.params
+    // A concise arrow body (`=> router.get(...)`) has nowhere to insert a
+    // statement, and a rest/destructured first parameter has no name to pass.
+    if (parameter?.type !== 'Identifier' || fn.body.type !== 'BlockStatement') continue
+    if (typeof fn.body.start !== 'number' || typeof fn.body.end !== 'number') continue
+
+    return { parameterName: parameter.name, bodyStart: fn.body.start + 1, bodyEnd: fn.body.end - 1 }
+  }
+
+  return null
+}
+
+/**
+ * Where the app's route registrar keeps its body, and what it named its router.
+ *
+ * Callers splice text at the returned offsets rather than printing the AST
+ * back out, so the rest of the file — formatting, comments, the lot — is
+ * untouched. Both values are needed because neither is fixed: patches used to
+ * hardcode `router` for both, so a registrar named anything else (the blog
+ * template's `baseRouter`) matched nothing and the whole wiring step no-oped.
+ * The parameter name is also the only argument a caller may safely pass — a
+ * registrar that rebinds its parameter does so with a `const` partway down the
+ * body, and a call inserted above that reads it before initialization.
+ *
+ * Parsed rather than pattern-matched, per the rule in `packages/cli/CLAUDE.md`:
+ * reading a signature means reading a grammar, and the regex this replaced got
+ * three shapes wrong that Babel gets right for free — a registrar quoted inside
+ * a regex literal (which the string mask cannot see into) was patched as if it
+ * were real, an overload signature contributed its parameter name to the
+ * implementation's body, and only `function` declarations were recognized even
+ * though the loader accepts an arrow registrar too. Source Babel cannot parse
+ * yields `null`, and callers report that instead of guessing.
+ */
+export function findRouteRegistrar(content: string): RouteRegistrar | null {
+  const ast = parseSourceFile(content, DEFAULT_ROUTES_FILE)
+  return ast === null ? null : registrarIn(ast)
+}
+
+/** Whether `functionName` is already called somewhere in the file. */
+function callsFunction(ast: File, functionName: string): boolean {
+  let found = false
+
+  walk(ast.program, (node) => {
+    if (found) return false
+    if (node.type !== 'CallExpression') return
+    const callee = node.callee as { type?: string; name?: string } | undefined
+    if (callee?.type === 'Identifier' && callee.name === functionName) {
+      found = true
+      return false
+    }
+  })
+
+  return found
+}
+
+/**
+ * Imports a scaffolded routes file into `routes/web.ts` and calls its registrar
+ * from the app's own, in a single write.
+ *
+ * The call and the import land together on purpose: an import of a registrar
+ * nothing calls is an unused binding, which under `noUnusedLocals` stops the
+ * scaffolded app compiling, and a call without its import does not resolve. A
+ * routes file this cannot patch is left exactly as it was.
+ *
+ * "Already wired" is decided by looking for a *call* to that name anywhere in
+ * the file, not for the rendered `name(router)` text: the argument depends on
+ * what the registrar named its parameter, and a text match would append a
+ * second call to a file that already had one under a different name.
+ */
+export async function addRouteRegistrarCall(
+  filePath: string,
+  functionName: string,
+  importStatement: string,
+): Promise<PatchResult> {
+  const absolutePath = resolve(process.cwd(), filePath)
+  const content = await readIfExists(process.cwd(), filePath)
+
+  if (content === null) {
+    return { modified: false, reason: 'File not found' }
+  }
+
+  const ast = parseSourceFile(content, filePath)
+
+  if (ast === null) {
+    return { modified: false, reason: 'Could not parse the file' }
+  }
+
+  if (callsFunction(ast, functionName)) {
+    // The call is there; the import may still be missing if someone removed it.
+    const withImport = insertImport(content, importStatement)
+    if (withImport === null) {
+      return { modified: false, reason: 'Already registered' }
+    }
+
+    await writeFile(absolutePath, withImport, 'utf8')
+    return { modified: true }
+  }
+
+  const registrar = registrarIn(ast)
+
+  if (registrar === null) {
+    return { modified: false, reason: 'Could not find a route registrar' }
+  }
+
+  // The trailing newline keeps the call from absorbing whatever comment the
+  // registrar's first statement carries.
+  const called
+    = content.slice(0, registrar.bodyStart)
+    + `\n  ${functionName}(${registrar.parameterName})\n`
+    + content.slice(registrar.bodyStart)
+
+  await writeFile(absolutePath, insertImport(called, importStatement) ?? called, 'utf8')
+  return { modified: true }
+}
+
+/**
+ * `addRouteRegistrarCall` against the app's `routes/web.ts`, reporting every
+ * outcome.
+ *
+ * Nothing here may be silent. This replaced a `try {} catch {}` around a regex
+ * that only matched a registrar whose parameter was literally named `router`:
+ * in an app scaffolded from the blog template (`baseRouter`) the scaffolder
+ * wrote its routes file, wired nothing, and said nothing — and a routes file
+ * that is never mounted looks exactly like a working one until someone requests
+ * the route.
+ */
+export async function wireRouteRegistrar(functionName: string, importStatement: string): Promise<void> {
+  const result = await addRouteRegistrarCall(DEFAULT_ROUTES_FILE, functionName, importStatement)
+
+  if (result.modified) {
+    consola.success(`Registered ${functionName}() inside ${DEFAULT_ROUTES_FILE}`)
+    return
+  }
+
+  if (result.reason === 'Already registered') {
+    return
+  }
+
+  if (result.reason === 'File not found') {
+    consola.warn(`Could not find ${DEFAULT_ROUTES_FILE} — import ${functionName} and call it from your route registrar once you add one.`)
+    return
+  }
+
+  consola.warn(`Could not wire ${functionName}() into ${DEFAULT_ROUTES_FILE}: ${result.reason}.`)
+  consola.info(`Import ${functionName} there and call it from your route registrar, passing that registrar's router.`)
+}

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -1,24 +1,25 @@
 import { beforeEach, afterEach, describe, expect, it } from 'bun:test'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { createTempWorkspace, MYSQL_SCHEMA_FIXTURE, PG_SCHEMA_FIXTURE, type TempWorkspace } from './helpers'
+import { resolve } from 'node:path'
+import {
+  BLOG_ROUTES_FIXTURE,
+  DEFAULT_ROUTES_FIXTURE,
+  MYSQL_SCHEMA_FIXTURE,
+  PG_SCHEMA_FIXTURE,
+  REGISTRAR_LESS_ROUTES_FIXTURE,
+  captureWarnings,
+  createTempWorkspace,
+  type TempWorkspace,
+} from './helpers'
 import { listBlueprints, runBlueprint } from '../src/blueprints'
 import { runCheck } from '../src/check'
-
-const ROUTES_FIXTURE = `import { Router } from '@guren/core'
-
-export function registerWebRoutes(router: Router): void {
-  router.get('/', () => 'home')
-}
-
-export default registerWebRoutes
-`
 
 /** Minimum project shape the resource blueprint patches into. */
 async function seedResourceWorkspace(schema: string): Promise<void> {
   await mkdir('resources/js/pages', { recursive: true })
   await mkdir('routes', { recursive: true })
   await mkdir('db', { recursive: true })
-  await writeFile('routes/web.ts', ROUTES_FIXTURE)
+  await writeFile('routes/web.ts', DEFAULT_ROUTES_FIXTURE)
   await writeFile('db/schema.ts', schema)
 }
 
@@ -168,6 +169,135 @@ describe('blueprints', () => {
     await expect(runBlueprint('unknown')).rejects.toThrow('Unknown blueprint')
   })
 
+  // An app scaffolded from the blog template names the registrar's parameter
+  // `baseRouter`. The wiring used to match the literal name `router`, so the
+  // blueprint wrote routes/admin.ts, registered nothing, added no import, and
+  // — inside a try/catch — said nothing about any of it.
+  describe('route wiring for a registrar not named `router`', () => {
+    beforeEach(async () => {
+      await mkdir('routes', { recursive: true })
+      await writeFile('routes/web.ts', BLOG_ROUTES_FIXTURE)
+    })
+
+    it('imports and calls the admin registrar with the parameter that exists', async () => {
+      await runBlueprint('admin')
+
+      const routes = await readFile('routes/web.ts', 'utf8')
+      expect(routes).toContain("import registerAdminRoutes from './admin.js'")
+      expect(routes).toContain('registerAdminRoutes(baseRouter)')
+      // `router` is declared below the call site: passing it would read a
+      // `const` before its initialization.
+      expect(routes).not.toContain('registerAdminRoutes(router)')
+      // The existing import block stays intact, and the call goes inside the
+      // registrar rather than above it.
+      expect(routes).toContain(`export function registerWebRoutes(baseRouter: Router): void {
+  registerAdminRoutes(baseRouter)
+
+  const router = baseRouter.aliasMiddleware(`)
+    })
+
+    it('wires each blueprint once, however the argument is spelled', async () => {
+      await runBlueprint('admin')
+      await runBlueprint('admin', { force: true })
+      await runBlueprint('oauth')
+      await runBlueprint('oauth', { force: true })
+
+      const routes = await readFile('routes/web.ts', 'utf8')
+      expect(routes.match(/registerAdminRoutes\(/g)).toHaveLength(1)
+      expect(routes.match(/registerOAuthRoutes\(/g)).toHaveLength(1)
+      expect(routes.match(/import registerAdminRoutes from/g)).toHaveLength(1)
+    })
+
+    it('hangs the resource group off the registrar parameter', async () => {
+      await mkdir('resources/js/pages', { recursive: true })
+      await mkdir('db', { recursive: true })
+      await writeFile('db/schema.ts', PG_SCHEMA_FIXTURE)
+
+      await runBlueprint('resource', { name: 'Post' })
+
+      const routes = await readFile('routes/web.ts', 'utf8')
+      expect(routes).toContain("baseRouter.group('/posts'")
+      expect(routes).not.toContain("  router.group('/posts'")
+    })
+
+    // The imports used to be anchored on the literal text `export function`,
+    // so a registrar exported any other way got the route group and neither
+    // import — routes referencing identifiers the file never imported.
+    it('imports the controller and validator whatever the registrar exports', async () => {
+      await mkdir('resources/js/pages', { recursive: true })
+      await mkdir('db', { recursive: true })
+      await writeFile('db/schema.ts', PG_SCHEMA_FIXTURE)
+      await writeFile('routes/web.ts', `import { Router } from '@guren/core'
+
+export default function registerWebRoutes(appRouter: Router): void {
+  appRouter.get('/', () => 'home')
+}
+`)
+
+      await runBlueprint('resource', { name: 'Post' })
+
+      const routes = await readFile('routes/web.ts', 'utf8')
+      expect(routes).toContain("import PostController from '../app/Http/Controllers/PostController.js'")
+      expect(routes).toContain("import { PostPayloadSchema } from '../app/Http/Validators/PostValidator.js'")
+      expect(routes).toContain("appRouter.group('/posts'")
+    })
+  })
+
+  // The template is what `create-guren-app` actually ships, so it is the one
+  // input the wiring has to survive verbatim — the fixtures above are its
+  // reduction, not a substitute for it.
+  it('wires into the blog template routes file as shipped', async () => {
+    await mkdir('resources/js/pages', { recursive: true })
+    await mkdir('routes', { recursive: true })
+    await mkdir('db', { recursive: true })
+    await writeFile('db/schema.ts', PG_SCHEMA_FIXTURE)
+    await writeFile(
+      'routes/web.ts',
+      await readFile(resolve(import.meta.dir, '../../create-app/templates/blog/routes/web.ts'), 'utf8'),
+    )
+
+    await runBlueprint('admin')
+    await runBlueprint('resource', { name: 'Comment' })
+
+    const routes = await readFile('routes/web.ts', 'utf8')
+    expect(routes).toContain("import registerAdminRoutes from './admin.js'")
+    expect(routes).toContain('registerAdminRoutes(baseRouter)')
+    expect(routes).toContain("import CommentController from '../app/Http/Controllers/CommentController.js'")
+    expect(routes).toContain("baseRouter.group('/comments'")
+    // The template's own wiring survives untouched.
+    expect(routes).toContain('registerAuthRoutes(router)')
+    expect(routes.match(/registerAuthRoutes\(/g)).toHaveLength(1)
+  })
+
+  // Silence is the failure mode being fixed: a routes file with no registrar
+  // to patch has to be reported, not swallowed.
+  describe('route wiring failures', () => {
+    beforeEach(async () => {
+      await mkdir('routes', { recursive: true })
+      await writeFile('routes/web.ts', REGISTRAR_LESS_ROUTES_FIXTURE)
+    })
+
+    it('warns instead of writing an unreachable admin routes file', async () => {
+      const { result: created, warnings } = await captureWarnings(() => runBlueprint('admin'))
+
+      expect(created.some((file) => file.endsWith('routes/admin.ts'))).toBe(true)
+      expect(warnings.join('\n')).toContain('Could not wire registerAdminRoutes()')
+      // Not even the import: a registrar nobody calls is an unused binding, and
+      // the app it was scaffolded into stops compiling under noUnusedLocals.
+      expect(await readFile('routes/web.ts', 'utf8')).toBe(REGISTRAR_LESS_ROUTES_FIXTURE)
+    })
+
+    it('fails the resource blueprint rather than dropping its routes', async () => {
+      await mkdir('resources/js/pages', { recursive: true })
+      await mkdir('db', { recursive: true })
+      await writeFile('db/schema.ts', PG_SCHEMA_FIXTURE)
+
+      await expect(runBlueprint('resource', { name: 'Post' })).rejects.toThrow(
+        'Could not find a route registrar',
+      )
+    })
+  })
+
   // Every field type has to map to a column in every dialect. A missing case
   // silently falls through to the text/varchar default, which then rejects the
   // value the generated validator produces (a `date` field is the example: a
@@ -260,7 +390,7 @@ const app = createApp({
 
 export default app
 `)
-    await writeFile('routes/web.ts', ROUTES_FIXTURE)
+    await writeFile('routes/web.ts', DEFAULT_ROUTES_FIXTURE)
 
     const adminFiles = await runBlueprint('admin')
     const queueFiles = await runBlueprint('queue')

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -99,6 +99,64 @@ export const users = sqliteTable('users', {
 })
 `
 
+/**
+ * The `routes/web.ts` the two app templates scaffold.
+ *
+ * The blog one is the shape that broke every route-wiring patch: it names the
+ * registrar's parameter `baseRouter` and rebinds it to `router` inside the
+ * body, because `aliasMiddleware()` has to be captured for the return type
+ * that carries the alias names. Kept here so the parser, the blueprints, and
+ * `make:auth` are all tested against one copy of what users have on disk.
+ */
+export const DEFAULT_ROUTES_FIXTURE = `import { Router } from '@guren/core'
+
+export function registerWebRoutes(router: Router): void {
+  router.get('/', () => 'home')
+}
+
+export default registerWebRoutes
+`
+
+export const BLOG_ROUTES_FIXTURE = `import { Router, requireAuthenticated } from '@guren/core'
+
+export function registerWebRoutes(baseRouter: Router): void {
+  const router = baseRouter.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
+
+  router.get('/', () => 'home')
+}
+
+export default registerWebRoutes
+`
+
+/** A routes file with no registrar to patch — the loud-failure path. */
+export const REGISTRAR_LESS_ROUTES_FIXTURE = `import { Router } from '@guren/core'
+
+const router = new Router()
+router.get('/', () => 'home')
+
+export default router
+`
+
+/**
+ * Runs `task` with `consola.warn` collecting into an array instead of
+ * printing. Scoped to the call and restored in a `finally`, unlike
+ * `createConsolaStub`, which is for the process-wide `mock.module('consola')`
+ * path and cannot observe a module that imported consola directly.
+ */
+export async function captureWarnings<T>(task: () => Promise<T>): Promise<{ result: T; warnings: string[] }> {
+  const warnings: string[] = []
+  const original = realConsola.warn
+  realConsola.warn = ((...args: unknown[]) => {
+    warnings.push(args.map(String).join(' '))
+  }) as typeof realConsola.warn
+
+  try {
+    return { result: await task(), warnings }
+  } finally {
+    realConsola.warn = original
+  }
+}
+
 /** Materialize a fixture tree from `relative path → contents` under `dir`. */
 export async function writeWorkspaceFiles(
   dir: string,

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { consola } from 'consola'
-import { createTempWorkspace, MYSQL_SCHEMA_FIXTURE, PG_SCHEMA_FIXTURE, SQLITE_SCHEMA_FIXTURE } from './helpers'
+import { BLOG_ROUTES_FIXTURE, createTempWorkspace, MYSQL_SCHEMA_FIXTURE, PG_SCHEMA_FIXTURE, SQLITE_SCHEMA_FIXTURE } from './helpers'
 import { makeAuth } from '../src/make-auth'
 
 // Shared with packages/create-app/templates/blog/app/Providers/AuthProvider.ts,
@@ -240,6 +240,49 @@ export function registerWebRoutes(router: Router): void {
       expect(loginPage).not.toContain('href="/register"')
       expect(loginPage).not.toContain('href="/forgot-password"')
       expect(loginPage).toContain('Contact your administrator.')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  // A blog-shaped registrar takes `baseRouter` and rebinds it to `router`
+  // inside the body. Wiring keyed on the literal name `router` matched no
+  // registrar at all here, so the auth routes were scaffolded and never
+  // mounted; passing `router` instead of the parameter would be worse still,
+  // since that `const` is declared below the call.
+  it('calls the auth registrar with the parameter its registrar declares', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-auth-base-router-')
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await mkdir(join(workspace.dir, 'routes'), { recursive: true })
+      await mkdir(join(workspace.dir, 'src'), { recursive: true })
+      await writeFile(join(workspace.dir, 'db/schema.ts'), `export const posts = 'posts'\n`, 'utf8')
+      await writeFile(
+        join(workspace.dir, 'src/app.ts'),
+        `import { createApp } from '@guren/core'
+import registerWebRoutes from '../routes/web.js'
+
+const app = createApp({
+  routes: registerWebRoutes,
+  providers: [],
+})
+
+export default app
+`,
+        'utf8',
+      )
+      await writeFile(join(workspace.dir, 'routes/web.ts'), BLOG_ROUTES_FIXTURE, 'utf8')
+
+      await makeAuth({ force: true, install: true })
+      // Re-running must not append a second call just because the argument in
+      // the file is not the one this run would have written.
+      await makeAuth({ force: true, install: true })
+
+      const routesContent = await readFile(join(workspace.dir, 'routes/web.ts'), 'utf8')
+      expect(routesContent).toContain("import { registerAuthRoutes } from './auth.js'")
+      expect(routesContent).toContain('registerAuthRoutes(baseRouter)')
+      expect(routesContent).not.toContain('registerAuthRoutes(router)')
+      expect(routesContent.match(/registerAuthRoutes\(/g)).toHaveLength(1)
     } finally {
       await workspace.cleanup()
     }

--- a/packages/cli/tests/route-registrar.test.ts
+++ b/packages/cli/tests/route-registrar.test.ts
@@ -1,0 +1,246 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { describe, expect, it } from 'bun:test'
+import { addRouteRegistrarCall, findRouteRegistrar } from '../src/route-registrar'
+import {
+  BLOG_ROUTES_FIXTURE,
+  DEFAULT_ROUTES_FIXTURE,
+  REGISTRAR_LESS_ROUTES_FIXTURE,
+  createTempWorkspace,
+  type TempWorkspace,
+} from './helpers'
+
+/** The body text the returned offsets delimit, for asserting *which* function was picked. */
+function body(source: string): string | null {
+  const registrar = findRouteRegistrar(source)
+  return registrar === null ? null : source.slice(registrar.bodyStart, registrar.bodyEnd)
+}
+
+describe('findRouteRegistrar', () => {
+  it('reads the parameter name off the default template', () => {
+    expect(findRouteRegistrar(DEFAULT_ROUTES_FIXTURE)?.parameterName).toBe('router')
+  })
+
+  // The blog template rebinds its parameter to `router` inside the body, so a
+  // matcher keyed on the literal name `router` saw no registrar here at all.
+  it('reads a parameter named anything else', () => {
+    expect(findRouteRegistrar(BLOG_ROUTES_FIXTURE)?.parameterName).toBe('baseRouter')
+  })
+
+  it('reads a multi-line signature with a trailing comma', () => {
+    const source = `export function registerWebRoutes(
+  appRouter: Router<'auth' | 'guest'>,
+): Promise<void> {
+  appRouter.get('/', () => 'home')
+}
+`
+    const registrar = findRouteRegistrar(source)
+
+    expect(registrar?.parameterName).toBe('appRouter')
+    expect(source.slice(registrar!.bodyEnd)).toBe('}\n')
+  })
+
+  // `resolveRegistrar` in load-routes.ts calls any exported function value, so
+  // these forms boot today and must be wirable.
+  it.each([
+    ['arrow function', `export const registerWebRoutes = (appRouter: Router): void => {\n  appRouter.get('/', () => 'home')\n}\n`],
+    ['named default export', `export default function registerWebRoutes(appRouter: Router): void {\n  appRouter.get('/', () => 'home')\n}\n`],
+    ['anonymous default export', `export default function (appRouter: Router): void {\n  appRouter.get('/', () => 'home')\n}\n`],
+    ['declaration exported separately', `function registerWebRoutes(appRouter: Router): void {\n  appRouter.get('/', () => 'home')\n}\n\nexport default registerWebRoutes\n`],
+  ])('recognizes a registrar declared as a %s', (_shape, source) => {
+    expect(findRouteRegistrar(source)?.parameterName).toBe('appRouter')
+  })
+
+  it('accepts a router annotated through an import alias', () => {
+    const source = `import { Router as AppRouter } from '@guren/core'
+
+export function registerWebRoutes(appRouter: AppRouter): void {
+  appRouter.get('/', () => 'home')
+}
+`
+    expect(findRouteRegistrar(source)?.parameterName).toBe('appRouter')
+  })
+
+  // Selection is by the name the route loader resolves, not by "takes a
+  // Router" — otherwise a helper that happens to accept one is patched, and
+  // the call is handed that helper's first parameter.
+  it('skips an unrelated exported function that also takes a router', () => {
+    const source = `export function buildPrefix(prefix: string, router: Router): void {}
+
+export function registerWebRoutes(baseRouter: Router): void {
+  baseRouter.get('/', () => 'home')
+}
+`
+    expect(findRouteRegistrar(source)?.parameterName).toBe('baseRouter')
+  })
+
+  // A regex literal is invisible to a string/comment mask, so the old scanner
+  // read the braces inside one as a registrar body and patched into it.
+  it('ignores a registrar that only exists inside a regex literal', () => {
+    const source = `const pattern = /export function fake(router: Router) {}/
+
+export function registerWebRoutes(real: Router): void {
+  real.get('/', () => 'home')
+}
+`
+    expect(findRouteRegistrar(source)?.parameterName).toBe('real')
+  })
+
+  it('does not let a regex literal in the body close it early', () => {
+    const source = `export function registerWebRoutes(router: Router): void {
+  const close = /}/
+  router.get('/', () => close.source)
+}
+`
+    expect(body(source)).toContain("router.get('/'")
+  })
+
+  // An overload signature carries a parameter name but no body; taking the
+  // first of each produced a call passing a name that exists in neither.
+  it('takes the implementation of an overloaded registrar, not its signature', () => {
+    const source = `export function registerWebRoutes(router: Router): void
+export function registerWebRoutes(baseRouter: Router): void {
+  baseRouter.get('/', () => 'home')
+}
+`
+    expect(findRouteRegistrar(source)?.parameterName).toBe('baseRouter')
+  })
+
+  it('skips a registrar that only appears in a comment', () => {
+    expect(findRouteRegistrar(`// export function registerWebRoutes(router: Router): void {
+const noop = 1
+`)).toBeNull()
+  })
+
+  it('declines a routes file with no registrar at all', () => {
+    expect(findRouteRegistrar(REGISTRAR_LESS_ROUTES_FIXTURE)).toBeNull()
+  })
+
+  it('declines source it cannot parse rather than guessing', () => {
+    expect(findRouteRegistrar('export function registerWebRoutes(router: Router): void { <<< }\n')).toBeNull()
+  })
+})
+
+describe('addRouteRegistrarCall', () => {
+  const ADMIN_IMPORT = "import registerAdminRoutes from './admin.js'"
+
+  async function seedRoutes(workspace: TempWorkspace, source: string): Promise<string> {
+    await mkdir(join(workspace.dir, 'routes'), { recursive: true })
+    const target = join(workspace.dir, 'routes/web.ts')
+    await writeFile(target, source, 'utf8')
+    return target
+  }
+
+  it('calls the registrar with its own parameter, not a hardcoded `router`', async () => {
+    const workspace = await createTempWorkspace('guren-cli-registrar-call-')
+    try {
+      const target = await seedRoutes(workspace, BLOG_ROUTES_FIXTURE)
+
+      const result = await addRouteRegistrarCall('routes/web.ts', 'registerAdminRoutes', ADMIN_IMPORT)
+      expect(result.modified).toBe(true)
+
+      const content = await readFile(target, 'utf8')
+      expect(content).toContain('registerAdminRoutes(baseRouter)')
+      // `router` is a `const` declared below the insertion point: passing it
+      // here reads it before initialization.
+      expect(content).not.toContain('registerAdminRoutes(router)')
+      expect(content).toContain(ADMIN_IMPORT)
+      expect(content).toContain(`export function registerWebRoutes(baseRouter: Router): void {
+  registerAdminRoutes(baseRouter)
+
+  const router = baseRouter`)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('does not add a second call when one is already there under another argument', async () => {
+    const workspace = await createTempWorkspace('guren-cli-registrar-call-idempotent-')
+    try {
+      const target = await seedRoutes(workspace, BLOG_ROUTES_FIXTURE)
+
+      await addRouteRegistrarCall('routes/web.ts', 'registerAdminRoutes', ADMIN_IMPORT)
+      const second = await addRouteRegistrarCall('routes/web.ts', 'registerAdminRoutes', ADMIN_IMPORT)
+
+      expect(second.modified).toBe(false)
+      expect(second.reason).toBe('Already registered')
+      const content = await readFile(target, 'utf8')
+      expect(content.match(/registerAdminRoutes\(/g)).toHaveLength(1)
+      expect(content.match(/import registerAdminRoutes from/g)).toHaveLength(1)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  // A call is a call — a same-named declaration or a mention in a comment is
+  // not, and the old text match counted both.
+  it('does not mistake a same-named declaration for a wired call', async () => {
+    const workspace = await createTempWorkspace('guren-cli-registrar-call-shadow-')
+    try {
+      const target = await seedRoutes(workspace, `import { Router } from '@guren/core'
+
+// registerAdminRoutes(router) goes here eventually
+function registerAdminRoutes(router: Router): void {}
+
+export function registerWebRoutes(baseRouter: Router): void {
+  baseRouter.get('/', () => 'home')
+}
+`)
+
+      const result = await addRouteRegistrarCall('routes/web.ts', 'registerAdminRoutes', ADMIN_IMPORT)
+
+      expect(result.modified).toBe(true)
+      expect(await readFile(target, 'utf8')).toContain('registerAdminRoutes(baseRouter)')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('leaves a routes file it cannot wire exactly as it was', async () => {
+    const workspace = await createTempWorkspace('guren-cli-registrar-call-missing-')
+    try {
+      const target = await seedRoutes(workspace, REGISTRAR_LESS_ROUTES_FIXTURE)
+
+      const result = await addRouteRegistrarCall('routes/web.ts', 'registerAdminRoutes', ADMIN_IMPORT)
+
+      expect(result.modified).toBe(false)
+      expect(result.reason).toBe('Could not find a route registrar')
+      // Not even the import: a registrar nothing calls is an unused binding,
+      // and the app it was scaffolded into stops compiling under noUnusedLocals.
+      expect(await readFile(target, 'utf8')).toBe(REGISTRAR_LESS_ROUTES_FIXTURE)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('restores an import removed from an already-wired routes file', async () => {
+    const workspace = await createTempWorkspace('guren-cli-registrar-call-reimport-')
+    try {
+      const target = await seedRoutes(workspace, `import { Router } from '@guren/core'
+
+export function registerWebRoutes(router: Router): void {
+  registerAdminRoutes(router)
+}
+`)
+
+      const result = await addRouteRegistrarCall('routes/web.ts', 'registerAdminRoutes', ADMIN_IMPORT)
+
+      expect(result.modified).toBe(true)
+      const content = await readFile(target, 'utf8')
+      expect(content).toContain(ADMIN_IMPORT)
+      expect(content.match(/registerAdminRoutes\(/g)).toHaveLength(1)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('distinguishes a missing routes file from an unwirable one', async () => {
+    const workspace = await createTempWorkspace('guren-cli-registrar-call-absent-')
+    try {
+      const result = await addRouteRegistrarCall('routes/web.ts', 'registerAdminRoutes', ADMIN_IMPORT)
+      expect(result).toEqual({ modified: false, reason: 'File not found' })
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

`guren add admin`, `guren add oauth`, `guren add resource`, and `guren add auth` auto-wire the routes file they scaffold into the app's `routes/web.ts`. They located the registrar with a regex that only matched `export function register*Routes(router: Router)`.

The blog template names that parameter `baseRouter`, because the documented pattern is `const router = baseRouter.aliasMiddleware('auth', ...)`. So in an app scaffolded from that blueprint the regex matched nothing: `routes/admin.ts` was written, never imported, never called — and since the whole wiring block sat inside a `try {} catch {}`, nothing was reported. The route file only looks inert once someone requests the route.

The registrar is now located by parsing `routes/web.ts` through `parseSourceFile()` and selecting the export the route loader itself resolves. The name contract lives in a new `packages/cli/src/route-registrar.ts` shared with `load-routes.ts`, so a scaffolder cannot patch a function the framework never calls.

Parsing rather than pattern-matching also settles three shapes the regex got wrong, each reproduced against the old implementation before the rewrite:

| input | old behavior |
| --- | --- |
| a registrar quoted inside a regex literal above the real one | patched the literal (the string mask cannot see into a regex) |
| `buildPrefix(prefix: string, router: Router)` declared above the registrar | selected `buildPrefix`, then passed `prefix` as the router |
| an overload signature followed by its implementation | took the signature's parameter name against the implementation's body, producing an undefined reference |

Beyond that, the generated call passes the registrar's own parameter — the only name guaranteed to be in scope, since a registrar that rebinds it does so with a `const` partway down the body, and a call inserted above that would read it before initialization. The call and its import land in a single write, so a routes file that cannot be patched keeps the file it had instead of gaining an import for routes nothing registers (an unused binding fails `noUnusedLocals`). Failure to wire is reported instead of swallowed.

Two adjacent defects fixed while here:

- The resource blueprint anchored its import insertion on the literal text `export function`, so a registrar exported any other way got the route group and **neither** import — routes referencing `PostController` and `PostPayloadSchema` with nothing importing them. It goes through the shared import inserter now.
- Its CRUD block duplicated the one `make:feature` prints for hand-wiring; both now come from `buildRouteRegistrationHint()`, so the route set cannot drift between what an app is told to register and what the blueprint registers for it.

## Scope

- `cli` — new `route-registrar.ts` (registrar name contract + AST lookup + the wiring patch); `blueprints.ts`, `make-auth.ts`, `make-feature.ts`, `patch-helpers.ts`, `load-routes.ts` updated to use it
- `docs` — key-file table entry in `CLAUDE.md`
- changeset: `@guren/cli` patch, `create-guren-app` patch (template ranges are regenerated on release)

## Risk Assessment

- **Behavior change, intended:** an unwirable `routes/web.ts` now produces a warning with manual instructions instead of silence. The resource blueprint still throws, as before.
- **Behavior change, intended:** the wiring no longer writes an import when the call could not be inserted.
- Source Babel cannot parse yields "could not parse" and the file is left alone, where the old regex would have attempted a patch. Declining is the safe direction for a patcher, and such a file would already break `codegen` and `audit`.
- `findClosingDelimiter` is no longer exported from `patch-helpers.ts` — this change removed its last out-of-module caller.
- No change to already-scaffolded apps: this fixes the scaffolder, not existing breakage. A `guren check` rule that flags a routes file whose registrar is never called is the follow-up that would reach those apps.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck` — root, `examples/blog`, `examples/api` all clean
- [x] `bun run test` — 3770 CLI/framework + 108 + 42 + 102, 0 failures
- [x] `audit:core-first`, `audit:docs`, `audit:template-deps`, `audit:contracts`
- Mutation-checked: hardcoding `router` as the argument fails 5 tests; dropping the "must be exported" rule fails 1; restoring the `router`-only match fails 8.
- New tests cover the blog-shaped registrar, arrow / default-export / separately-exported registrars, an aliased `Router` import, multi-line signatures, the three shapes in the table above, idempotent re-runs, and the loud-failure path. One test runs the blueprints against `templates/blog/routes/web.ts` exactly as shipped.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
