### PR TITLE
refactor(server): keep one copy of the store expiry rules

### DIFF
--- a/.changeset/store-expiry-single-copy.md
+++ b/.changeset/store-expiry-single-copy.md
@@ -1,0 +1,28 @@
+---
+'@guren/server': patch
+'@guren/core': patch
+---
+
+Collapse the duplicated store expiry rules into a single implementation
+
+`toDate`, `isExpired` and `toOptionalExpiry` existed twice: once in
+`packages/server/src/support/expiry.ts` for the Redis-backed stores and the
+authoritative `verifyApiToken` / OAuth checks, and once in
+`packages/core/src/store-utils.ts` for the database-backed stores. The copies
+were identical and deliberate — `@guren/core` depends on `@guren/server` and
+not the other way around, so core was unreachable from the server package —
+but two copies of an expiry rule is how the next boundary-case fix lands in
+one backend and silently misses its sibling. That is the failure mode the
+Redis and database stores have already hit once.
+
+`@guren/server` now exposes the rules on a `@guren/server/support/expiry`
+subpath and `packages/core/src/store-utils.ts` re-exports them, leaving one
+implementation for both backends. The dependency direction already ran
+core → server, so this adds no cycle.
+
+No behavior change and no public API change: the two implementations were
+byte-identical, and neither package's index exports these — `@guren/core`'s
+index opens with `export * from '@guren/server'`, so a test now pins that they
+stay off the public surface. `decodeJsonColumn` stays in core as a drizzle
+column concern; the Redis stores decode their payloads through
+`redis-values.ts`.

--- a/examples/blog/vitest.config.ts
+++ b/examples/blog/vitest.config.ts
@@ -63,6 +63,14 @@ export default defineConfig({
         find: /^@guren\/server$/,
         replacement: resolve(rootDir, '../../packages/server/src/index.ts'),
       },
+      // Exact match must precede the prefix rule below, which consumes the
+      // separator without restoring it and would yield 'srcsupport/expiry'
+      // (resolve() normalizes the replacement's trailing slash away). Same
+      // reason the orm's drizzle subpath is listed explicitly.
+      {
+        find: /^@guren\/server\/support\/expiry$/,
+        replacement: resolve(rootDir, '../../packages/server/src/support/expiry.ts'),
+      },
       {
         find: /^@guren\/server\//,
         replacement: resolve(rootDir, '../../packages/server/src/'),

--- a/packages/core/src/store-utils.ts
+++ b/packages/core/src/store-utils.ts
@@ -1,56 +1,28 @@
 /**
- * Shared coercion for database-backed stores (api tokens, sessions, OAuth
+ * Coercion for the database-backed stores (api tokens, sessions, OAuth
  * state). Drizzle returns Date for timestamp-mode columns, but plain columns
  * yield numbers, bigints (MySQL / postgres.js BIGINT), numeric strings, or
  * ISO strings — reads must accept all of them.
  *
- * Unparseable values return null, and that includes Date instances wrapping
- * garbage: drizzle's timestamp mappers hand whatever the driver returned to
- * `new Date(...)`, so a corrupt column reaches callers as an Invalid Date
- * rather than as a parse failure. Normalizing it here is what lets callers
- * express their expiry policy with a single null check.
- */
-export function toDate(value: unknown): Date | null {
-  const date = coerceDate(value)
-  return date !== null && !Number.isNaN(date.getTime()) ? date : null
-}
-
-function coerceDate(value: unknown): Date | null {
-  if (value == null) return null
-  if (value instanceof Date) return value
-  if (typeof value === 'number' || typeof value === 'bigint') return new Date(Number(value))
-  if (typeof value === 'string') return new Date(/^\d+$/.test(value) ? Number(value) : value)
-  return null
-}
-
-/**
- * Fail-closed expiry check for columns that must always carry an expiry
- * (sessions, OAuth state): a missing or unparseable value counts as expired,
- * so a malformed row can never be accepted indefinitely.
- */
-export function isExpired(value: unknown, now: number = Date.now()): boolean {
-  const date = toDate(value)
-  return date === null || date.getTime() <= now
-}
-
-/**
- * Fail-closed expiry coercion for columns where NULL legitimately means
- * "never expires" — API tokens, whose `expiresAt` is nullable by design.
+ * The expiry rules live in `@guren/server` rather than here, because the
+ * Redis-backed stores ship there and cannot import from `@guren/core`
+ * without a dependency cycle (core depends on server, never the reverse).
+ * Re-exporting keeps one implementation for both backends: a fix to a
+ * boundary case can no longer land in one and silently miss its sibling.
  *
- * An absent value and an unparseable one are not the same thing: the first is
- * a token created without an expiry, the second is a malformed row. Collapsing
- * both to null would make a corrupt row read as immortal, so anything present
- * but unparseable degrades to a long-past date and reads as expired.
+ * Not exported from this package's index: `index.ts` opens with
+ * `export * from '@guren/server'`, so anything re-exported there becomes
+ * public `@guren/core` API.
  */
-export function toOptionalExpiry(value: unknown): Date | null {
-  if (value == null) return null
-  return toDate(value) ?? new Date(0)
-}
+export { isExpired, toDate, toOptionalExpiry } from '@guren/server/support/expiry'
 
 /**
  * Decode a JSON-capable column that may hold either the native value
  * (drizzle json mode) or a text-encoded string. Corrupt text falls back
  * instead of throwing, so one bad row cannot break every read.
+ *
+ * Stays here: it is a drizzle column concern, and the Redis stores decode
+ * their own JSON payloads through `redis-values.ts` instead.
  */
 export function decodeJsonColumn<T>(value: unknown, fallback: T): T {
   if (typeof value === 'string') {

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -12,6 +12,16 @@ describe('@guren/core', () => {
     expect(core.defineModel).toBeDefined()
   })
 
+  // The expiry helpers live in @guren/server so the Redis stores share them,
+  // and index.ts opens with `export * from '@guren/server'` — so re-exporting
+  // them anywhere near the barrel would make them public @guren/core API.
+  // They are reachable only through the internal subpath.
+  it('does not leak the store expiry helpers into the public surface', () => {
+    for (const name of ['toDate', 'isExpired', 'toOptionalExpiry', 'decodeJsonColumn']) {
+      expect(core[name as keyof typeof core]).toBeUndefined()
+    }
+  })
+
   it('bin entry proxies to @guren/cli', async () => {
     const path = fileURLToPath(new URL('../src/bin.ts', import.meta.url))
     const content = await readFile(path, 'utf8')

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -100,6 +100,10 @@
     "./redis": {
       "types": "./dist/redis/index.d.ts",
       "default": "./dist/redis/index.js"
+    },
+    "./support/expiry": {
+      "types": "./dist/support/expiry.d.ts",
+      "default": "./dist/support/expiry.js"
     }
   },
   "scripts": {

--- a/packages/server/src/support/expiry.ts
+++ b/packages/server/src/support/expiry.ts
@@ -2,11 +2,15 @@
  * Expiry coercion and the one predicate that decides whether a stored expiry
  * has passed.
  *
- * These mirror `toDate`/`isExpired`/`toOptionalExpiry` in
- * `packages/core/src/store-utils.ts` — deliberately, not accidentally.
- * `@guren/core` depends on `@guren/server` and not the other way around, so
- * core is unreachable from here without a dependency cycle. Keep the two in
- * step until the shared copy moves under this package and core re-exports it.
+ * This is the single copy. `packages/core/src/store-utils.ts` re-exports
+ * `toDate`/`isExpired`/`toOptionalExpiry` from here through the
+ * `@guren/server/support/expiry` subpath, so the database-backed stores and
+ * the Redis ones decide expiry with the same code. It lives in this package
+ * because `@guren/core` depends on `@guren/server` and not the other way
+ * around — core is unreachable from here without a dependency cycle.
+ *
+ * Not part of the public API: the subpath exists for that re-export, and
+ * neither package's index exposes these.
  */
 
 /**

--- a/packages/server/tsup.config.ts
+++ b/packages/server/tsup.config.ts
@@ -34,6 +34,9 @@ export default defineConfig({
     'src/vite/index.ts',
     'src/lambda/index.ts',
     'src/mcp/index.ts',
+    // Not public API: @guren/core's database stores re-export the expiry
+    // rules from here so the two packages cannot drift apart.
+    'src/support/expiry.ts',
   ],
   format: ['esm'],
   // Multiple entry points MUST share chunks: with splitting disabled each

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -11,6 +11,12 @@ export default defineConfig({
       { find: /^@guren\/testing$/, replacement: resolveFromRoot('../packages/testing/src/index.ts') },
       { find: /^@guren\/testing\//, replacement: resolveFromRoot('../packages/testing/src/') },
       { find: /^@guren\/server$/, replacement: resolveFromRoot('../packages/server/src/index.ts') },
+      // Exact match must precede the prefix rule below, which consumes the
+      // separator without restoring it and would yield 'srcsupport/expiry'.
+      {
+        find: /^@guren\/server\/support\/expiry$/,
+        replacement: resolveFromRoot('../packages/server/src/support/expiry.ts'),
+      },
       { find: /^@guren\/server\//, replacement: resolveFromRoot('../packages/server/src/') },
       { find: /^@guren\/core$/, replacement: resolveFromRoot('../packages/core/src/index.ts') },
       { find: /^@guren\/core\//, replacement: resolveFromRoot('../packages/core/src/') },


### PR DESCRIPTION
## Summary

Rebased onto `main` after #333 landed. That PR fixed the fail-open expiry handling, the `'"*"'` abilities wildcard, and the unguarded `new Date(...)` in the Redis stores — all of which this PR originally also fixed, independently. **Everything already covered by #333 has been dropped**; what remains is the one step #333 explicitly deferred.

`packages/server/src/support/expiry.ts` said so in its own header:

> Keep the two in step until the shared copy moves under this package and core re-exports it.

This does that.

## The problem

`toDate`, `isExpired` and `toOptionalExpiry` existed twice:

- `packages/server/src/support/expiry.ts` — the Redis stores plus the authoritative `verifyApiToken` / OAuth state checks
- `packages/core/src/store-utils.ts` — the database-backed stores

The copies were byte-identical, and the duplication was deliberate rather than sloppy: `@guren/core` depends on `@guren/server` and not the reverse, so core was unreachable from the server package without a dependency cycle. But two copies of an expiry rule is how the next boundary-case fix lands in one backend and silently misses its sibling — the exact failure these stores have already hit once (the OAuth `binding` field that neither the database nor the Redis store persisted, while only the Memory store's tests were green).

## What changed

- `@guren/server` exposes the rules on a `@guren/server/support/expiry` subpath (`exports` entry + tsup entry).
- `packages/core/src/store-utils.ts` re-exports `toDate` / `isExpired` / `toOptionalExpiry` from it instead of redeclaring them. The dependency direction already ran core → server, so no cycle is introduced.
- `decodeJsonColumn` stays in core — it is a drizzle column concern, and the Redis stores decode their payloads through `redis-values.ts`.
- The now-satisfied "keep the two in step" note in `support/expiry.ts` is replaced with what is actually true.
- Two in-repo vitest suites alias `@guren/server/*` to source and need an exact-match entry for the new subpath: the generic prefix rule consumes the separator without restoring it (`path.resolve` normalizes the replacement's trailing slash away), so it would yield `srcsupport/expiry`. Same pre-existing reason `@guren/orm/drizzle` and `@guren/testing/vitest` are listed explicitly.

No behavior change and no public API change — the two implementations were identical, and neither package's index exports these.

## Test plan

- [x] `bun run build:clean` — no cycle introduced (`scripts/workspace-packages.ts` fails the build on an unexpected one)
- [x] `bun run typecheck` (root) — 0 errors
- [x] `bun run test:bun` — 3862 pass, 0 fail
- [x] `bun run test:examples` — all three suites green (blog 29, api 15, web 16)
- [x] `bun run audit:core-first` / `audit:docs` — both pass
- [x] `@guren/server/support/expiry` resolves from the built artifact
- [x] **The re-export is live, not decorative**: breaking `toDate` in *server's* copy alone fails 4 tests in `packages/core`'s suite (`store-utils.test.ts`, `api-token-store.test.ts`). Before this change those tests exercised core's separate copy and would have stayed green.
- [x] `packages/core/tests/core.test.ts` pins that the helpers stay off `@guren/core`'s public root export (`index.ts` opens with `export * from '@guren/server'`)