### PR TITLE
fix(plugin-cloudflare): clear captured env when boot throws synchronously

### DIFF
--- a/.changeset/workers-handler-sync-boot-throw.md
+++ b/.changeset/workers-handler-sync-boot-throw.md
@@ -1,0 +1,25 @@
+---
+'@guren/plugin-cloudflare': patch
+---
+
+Clear the captured Workers env when `boot()` throws synchronously
+
+`createWorkersHandler` boots on the first request and, when that boot fails,
+drops both the shared boot promise and the write-once env holder so the retry
+starts from the new request's bindings. The `app.boot()` call sat one line
+above the `try`, so only a *rejected promise* reached that cleanup. An
+implementation that throws before returning a promise skipped it, leaving the
+holder populated with the failed request's `env` — and since the holder is
+first-call-wins, every later request would then boot against those stale
+bindings, which is the exact failure the catch exists to prevent.
+
+`Application.boot()` is `async` and so cannot reach this, but the handler
+publishes `WorkersAppLike`, a structural type requiring only
+`boot(): Promise<void>`; a conforming non-async implementation can throw
+synchronously. The call now happens inside the `try`. On a synchronous throw
+the assignment never runs, so the promise is already `undefined` and the
+existing reset stays a no-op.
+
+`@guren/plugin-vercel`'s `createVercelHandler` is not affected on either count:
+it is an `async` function, which converts a synchronous throw into a rejection,
+and it keeps no module-scope env holder to leave stale.

--- a/packages/plugin-cloudflare/src/handler.test.ts
+++ b/packages/plugin-cloudflare/src/handler.test.ts
@@ -103,6 +103,38 @@ describe('createWorkersHandler', () => {
     expect(getWorkersEnv<TestEnv>()).toBe(secondEnv)
   })
 
+  test('should clear the env holder when boot throws synchronously rather than rejecting', async () => {
+    let bootCalls = 0
+    const app: WorkersAppLike = {
+      // Not `async`: `WorkersAppLike` only requires a promise-returning
+      // `boot()`, so a conforming app can throw before returning one.
+      boot() {
+        bootCalls += 1
+        if (bootCalls === 1) {
+          throw new Error('boot failed')
+        }
+        return Promise.resolve()
+      },
+      fetch() {
+        return new Response('ok')
+      },
+    }
+    const handler = createWorkersHandler(app)
+    const ctx = createExecutionContext()
+    const firstEnv = { DB: 'first-db' }
+    const secondEnv = { DB: 'second-db' }
+
+    await expect(
+      handler.fetch(new Request('https://example.com/one'), firstEnv, ctx),
+    ).rejects.toThrow('boot failed')
+
+    const response = await handler.fetch(new Request('https://example.com/two'), secondEnv, ctx)
+
+    expect(bootCalls).toBe(2)
+    expect(await response.text()).toBe('ok')
+    expect(getWorkersEnv<TestEnv>()).toBe(secondEnv)
+  })
+
   test('should reject every concurrent request sharing a failed boot, then recover on retry', async () => {
     let bootCalls = 0
     const bootDeferred = deferred<void>()

--- a/packages/plugin-cloudflare/src/handler.test.ts
+++ b/packages/plugin-cloudflare/src/handler.test.ts
@@ -75,25 +75,9 @@ describe('createWorkersHandler', () => {
   })
 
   // The two ways a first boot can fail. `WorkersAppLike` requires only a
-  // `boot(): Promise<void>`, so a conforming app need not be `async` and can
-  // throw before it ever returns a promise — parameterized rather than copied
-  // so the async/sync axis stays visible instead of living in one keyword.
-  const failingBoots: Array<[string, (failFirst: () => void) => WorkersAppLike['boot']]> = [
-    // `async`, so the throw surfaces as a rejected promise.
-    ['rejecting', (failFirst) => async () => failFirst()],
-    // Not `async`, so the throw escapes before any promise exists.
-    [
-      'throwing synchronously',
-      (failFirst) => () => {
-        failFirst()
-        return Promise.resolve()
-      },
-    ],
-  ]
-
-  test.each(failingBoots)(
-    'should clear boot promise and env holder on a first boot %s, then retry cleanly',
-    async (_label, makeBoot) => {
+  // `boot(): Promise<void>`, so a conforming app need not be `async`.
+  for (const mode of ['rejects', 'throws synchronously'] as const) {
+    test(`should clear boot promise and env holder on a first boot that ${mode}, then retry cleanly`, async () => {
       let bootCalls = 0
       const failFirst = () => {
         bootCalls += 1
@@ -102,11 +86,22 @@ describe('createWorkersHandler', () => {
         }
       }
       const app: WorkersAppLike = {
-        boot: makeBoot(failFirst),
+        boot:
+          mode === 'rejects'
+            ? async () => failFirst()
+            : () => {
+                failFirst()
+                return Promise.resolve()
+              },
         fetch() {
           return new Response('ok')
         },
       }
+      // Pins the axis rather than trusting it to a keyword: making the second
+      // boot `async` would turn its throw into a rejection, and the case would
+      // silently become a copy of the first.
+      expect(app.boot.constructor.name).toBe(mode === 'rejects' ? 'AsyncFunction' : 'Function')
+
       const handler = createWorkersHandler(app)
       const ctx = createExecutionContext()
       const firstEnv = { DB: 'first-db' }
@@ -121,8 +116,8 @@ describe('createWorkersHandler', () => {
       expect(bootCalls).toBe(2)
       expect(await response.text()).toBe('ok')
       expect(getWorkersEnv<TestEnv>()).toBe(secondEnv)
-    },
-  )
+    })
+  }
 
   test('should reject every concurrent request sharing a failed boot, then recover on retry', async () => {
     let bootCalls = 0

--- a/packages/plugin-cloudflare/src/handler.test.ts
+++ b/packages/plugin-cloudflare/src/handler.test.ts
@@ -74,66 +74,55 @@ describe('createWorkersHandler', () => {
     expect(await secondResponse.text()).toBe('ok:/second')
   })
 
-  test('should clear boot promise and env holder on boot failure, then retry cleanly', async () => {
-    let bootCalls = 0
-    const app: WorkersAppLike = {
-      async boot() {
-        bootCalls += 1
-        if (bootCalls === 1) {
-          throw new Error('boot failed')
-        }
-      },
-      fetch() {
-        return new Response('ok')
-      },
-    }
-    const handler = createWorkersHandler(app)
-    const ctx = createExecutionContext()
-    const firstEnv = { DB: 'first-db' }
-    const secondEnv = { DB: 'second-db' }
-
-    await expect(
-      handler.fetch(new Request('https://example.com/one'), firstEnv, ctx),
-    ).rejects.toThrow('boot failed')
-
-    const response = await handler.fetch(new Request('https://example.com/two'), secondEnv, ctx)
-
-    expect(bootCalls).toBe(2)
-    expect(await response.text()).toBe('ok')
-    expect(getWorkersEnv<TestEnv>()).toBe(secondEnv)
-  })
-
-  test('should clear the env holder when boot throws synchronously rather than rejecting', async () => {
-    let bootCalls = 0
-    const app: WorkersAppLike = {
-      // Not `async`: `WorkersAppLike` only requires a promise-returning
-      // `boot()`, so a conforming app can throw before returning one.
-      boot() {
-        bootCalls += 1
-        if (bootCalls === 1) {
-          throw new Error('boot failed')
-        }
+  // The two ways a first boot can fail. `WorkersAppLike` requires only a
+  // `boot(): Promise<void>`, so a conforming app need not be `async` and can
+  // throw before it ever returns a promise — parameterized rather than copied
+  // so the async/sync axis stays visible instead of living in one keyword.
+  const failingBoots: Array<[string, (failFirst: () => void) => WorkersAppLike['boot']]> = [
+    // `async`, so the throw surfaces as a rejected promise.
+    ['rejecting', (failFirst) => async () => failFirst()],
+    // Not `async`, so the throw escapes before any promise exists.
+    [
+      'throwing synchronously',
+      (failFirst) => () => {
+        failFirst()
         return Promise.resolve()
       },
-      fetch() {
-        return new Response('ok')
-      },
-    }
-    const handler = createWorkersHandler(app)
-    const ctx = createExecutionContext()
-    const firstEnv = { DB: 'first-db' }
-    const secondEnv = { DB: 'second-db' }
+    ],
+  ]
 
-    await expect(
-      handler.fetch(new Request('https://example.com/one'), firstEnv, ctx),
-    ).rejects.toThrow('boot failed')
+  test.each(failingBoots)(
+    'should clear boot promise and env holder on a first boot %s, then retry cleanly',
+    async (_label, makeBoot) => {
+      let bootCalls = 0
+      const failFirst = () => {
+        bootCalls += 1
+        if (bootCalls === 1) {
+          throw new Error('boot failed')
+        }
+      }
+      const app: WorkersAppLike = {
+        boot: makeBoot(failFirst),
+        fetch() {
+          return new Response('ok')
+        },
+      }
+      const handler = createWorkersHandler(app)
+      const ctx = createExecutionContext()
+      const firstEnv = { DB: 'first-db' }
+      const secondEnv = { DB: 'second-db' }
 
-    const response = await handler.fetch(new Request('https://example.com/two'), secondEnv, ctx)
+      await expect(
+        handler.fetch(new Request('https://example.com/one'), firstEnv, ctx),
+      ).rejects.toThrow('boot failed')
 
-    expect(bootCalls).toBe(2)
-    expect(await response.text()).toBe('ok')
-    expect(getWorkersEnv<TestEnv>()).toBe(secondEnv)
-  })
+      const response = await handler.fetch(new Request('https://example.com/two'), secondEnv, ctx)
+
+      expect(bootCalls).toBe(2)
+      expect(await response.text()).toBe('ok')
+      expect(getWorkersEnv<TestEnv>()).toBe(secondEnv)
+    },
+  )
 
   test('should reject every concurrent request sharing a failed boot, then recover on retry', async () => {
     let bootCalls = 0

--- a/packages/plugin-cloudflare/src/handler.ts
+++ b/packages/plugin-cloudflare/src/handler.ts
@@ -32,9 +32,8 @@ export function createWorkersHandler(app: WorkersAppLike): WorkersHandler {
       captureWorkersEnv(env)
 
       try {
-        // Called inside the try because `WorkersAppLike` only requires a
-        // `boot()` returning a promise — a non-async implementation can throw
-        // synchronously, and that error has to reach the cleanup too.
+        // Inside the try: a conforming non-async boot() can throw
+        // synchronously, and that throw has to reach the cleanup too.
         bootPromise ??= app.boot()
         await bootPromise
       } catch (error) {

--- a/packages/plugin-cloudflare/src/handler.ts
+++ b/packages/plugin-cloudflare/src/handler.ts
@@ -31,9 +31,11 @@ export function createWorkersHandler(app: WorkersAppLike): WorkersHandler {
     async fetch(request: Request, env: unknown, ctx: WorkersExecutionContext): Promise<Response> {
       captureWorkersEnv(env)
 
-      bootPromise ??= app.boot()
-
       try {
+        // Called inside the try because `WorkersAppLike` only requires a
+        // `boot()` returning a promise — a non-async implementation can throw
+        // synchronously, and that error has to reach the cleanup too.
+        bootPromise ??= app.boot()
         await bootPromise
       } catch (error) {
         bootPromise = undefined


### PR DESCRIPTION
## Problem

`createWorkersHandler` boots on the first request and, when that boot fails, drops both the shared boot promise and the write-once env holder so the retry starts from the new request's bindings (the existing boot-failure test pins this).

The `app.boot()` call sat one line *above* the `try`:

```ts
bootPromise ??= app.boot()   // outside the try

try {
  await bootPromise
} catch (error) {
  bootPromise = undefined
  resetWorkersEnv()
  throw error
}
```

so only a **rejected promise** reached that cleanup. An implementation that throws *before* returning a promise skipped it, leaving the holder in `src/env.ts` populated with the failed request's `env`. Because that holder is first-call-wins, every later request would then boot against those stale bindings — exactly the failure the catch exists to prevent.

## Reachability

`Application.boot()` is `async`, so Guren's own app can never reach this. But the handler publishes `WorkersAppLike` from `src/index.ts`, a structural type requiring only `boot(): Promise<void>`, and a conforming non-async implementation can throw synchronously. The gap is real for the contract the handler publishes.

## Fix

The `??=` now happens inside the `try`. On a synchronous throw the assignment never runs, so `bootPromise` is already `undefined` and the existing `bootPromise = undefined` stays a no-op — verified, not assumed. A short-circuited `??=` on later requests behaves identically, and the concurrent-failure path is unchanged.

## Verification

The pre-existing boot-failure test and the new synchronous-throw case now run one body over a table of the two ways a first boot can fail, because as separate tests they differed only in whether the fake's `boot()` was declared `async` — a distinction a later tidy-up could erase silently.

Both cases also assert *which kind of function* the fake's `boot()` is. That guard is not decorative: without it, adding `async` to the synchronous case left the suite fully green, i.e. the only regression guard for this fix could be turned into a copy of its neighbour with nothing going red.

Two mutations were run to confirm the tests can fail:

| mutation | result |
|---|---|
| revert the handler fix | synchronous case fails on `getWorkersEnv()` — the rejecting case still passes, so the coverage is genuinely new |
| revert the fix **and** make the synchronous case `async` | fails on the function-kind assertion instead |

Note that `rejects.toThrow('boot failed')` passes either way; the env-holder assertion is what discriminates.

`bun run build`, root `bun run typecheck`, and `bun run test:bun` all clean.

## Sibling handlers checked

- **`@guren/plugin-vercel`** — `createVercelHandler` has no analogous gap, for two independent reasons: it is an `async` function, so a synchronous throw from `app.boot()` becomes a rejection of the returned promise; and it keeps no module-scope env holder to leave stale (`index.ts` is the package's only source file).
- **`createLambdaHandler`** (`packages/server/src/lambda`) — takes the concrete `Application` type, does no boot dedup at all (the documented flow awaits `app.boot()` at cold start before constructing the handler), and captures no env. Nothing to leak.

## Follow-up (not in this PR)

Review surfaced a **pre-existing** race on the rejected-promise path, confirmed by reproduction and confirmed to fail identically against `main`: every waiter on a shared failed boot clears the state unconditionally, so a retry starting between two waiters' catch blocks has its fresh promise and env wiped by the second, stale waiter. It is out of scope here — this diff does not touch that path, and a synchronous throw never publishes a promise multiple requests could share. Addressed separately in #341.