### PR TITLE
refactor(orm): share one single-flight helper across the database drivers

### DIFF
--- a/.changeset/single-flight-connection-handles.md
+++ b/.changeset/single-flight-connection-handles.md
@@ -1,0 +1,14 @@
+---
+'@guren/orm': patch
+---
+
+Stop a superseded connection attempt from evicting a newer one
+
+Every database factory memoizes its connection and migration handle in a
+promise, clearing it on rejection so the next caller retries. The clear was
+unconditional, so a rejection arriving after `closeDatabase()` (or
+`resetDatabase()`) had already dropped the handle and a newer attempt had
+replaced it would evict that newer attempt — a second connection where one was
+expected. Clearing now happens only while the cell still holds the attempt that
+failed. The five drivers share one internal `singleFlight()` helper instead of
+hand-rolling the pattern eight times.

--- a/packages/orm/src/aws-data-api.ts
+++ b/packages/orm/src/aws-data-api.ts
@@ -126,8 +126,8 @@ export function createAwsDataApiDatabase(options: AwsDataApiDatabaseOptions): Aw
     } as DrizzleConfig
   }
 
-  const migrations = singleFlight(
-    async (): Promise<void> => {
+  const migrations = singleFlight(async (): Promise<void> => {
+    try {
       if (!hasDrizzleMigrations(resolvedMigrationsFolder)) {
         warnIgnoredFlatSqlMigrations(resolvedMigrationsFolder)
         return
@@ -135,12 +135,11 @@ export function createAwsDataApiDatabase(options: AwsDataApiDatabaseOptions): Aw
 
       const { migrate } = await loadAwsDataApiModules()
       await withAdminDb((db) => migrate(db, { migrationsFolder: resolvedMigrationsFolder }))
-    },
-    (error) => {
+    } catch (error) {
       const reason = error instanceof Error ? error.message : String(error)
-      return new Error(`Failed to run database migrations: ${reason}`)
-    },
-  )
+      throw new Error(`Failed to run database migrations: ${reason}`)
+    }
+  })
 
   async function migrateOnce(): Promise<void> {
     await migrations.get()

--- a/packages/orm/src/aws-data-api.ts
+++ b/packages/orm/src/aws-data-api.ts
@@ -89,8 +89,8 @@ export function createAwsDataApiDatabase(options: AwsDataApiDatabaseOptions): Aw
 
   let client: { destroy?: () => void } | undefined
   let activeKey: string | undefined
-  // Captured here, not in getDatabase(), so the caller of this factory is the
-  // frame that identifies the handle across hot reloads.
+  // Captured here, not in the connection factory, so the caller of this factory
+  // is the frame that identifies the handle across hot reloads.
   const callSite = new Error().stack
 
   function resolveConnection(): ResolvedConnection {
@@ -141,13 +141,9 @@ export function createAwsDataApiDatabase(options: AwsDataApiDatabaseOptions): Aw
     }
   })
 
-  async function migrateOnce(): Promise<void> {
-    await migrations.get()
-  }
-
   const databaseHandle = singleFlight(async (): Promise<AwsDataApiPgDatabase> => {
     if (migrateOnStart) {
-      await migrateOnce()
+      await migrations.get()
     }
     const { drizzle } = await loadAwsDataApiModules()
     const connection = resolveConnection()
@@ -161,10 +157,6 @@ export function createAwsDataApiDatabase(options: AwsDataApiDatabaseOptions): Aw
 
     return db
   })
-
-  function getDatabase(): Promise<AwsDataApiPgDatabase> {
-    return databaseHandle.get()
-  }
 
   async function closeDatabase(): Promise<void> {
     if (!client) {
@@ -186,7 +178,7 @@ export function createAwsDataApiDatabase(options: AwsDataApiDatabaseOptions): Aw
   }
 
   async function configureOrm(): Promise<void> {
-    const db = await getDatabase()
+    const db = await databaseHandle.get()
     DrizzleAdapter.configure(db as unknown as Parameters<typeof DrizzleAdapter.configure>[0])
   }
 
@@ -195,7 +187,7 @@ export function createAwsDataApiDatabase(options: AwsDataApiDatabaseOptions): Aw
       throw new Error('No seeders folder configured. Provide "seedersFolder" when calling createAwsDataApiDatabase().')
     }
 
-    const db = await getDatabase()
+    const db = await databaseHandle.get()
     await runSeeders(db, resolvedSeedersFolder)
   }
 
@@ -254,8 +246,8 @@ export function createAwsDataApiDatabase(options: AwsDataApiDatabaseOptions): Aw
   }
 
   return {
-    getDatabase,
-    migrateDatabase: migrateOnce,
+    getDatabase: databaseHandle.get,
+    migrateDatabase: migrations.get,
     closeDatabase,
     configureOrm,
     seedDatabase,

--- a/packages/orm/src/aws-data-api.ts
+++ b/packages/orm/src/aws-data-api.ts
@@ -5,6 +5,7 @@ import { hotReloadKey, releaseActiveConnection, replaceActiveConnection } from '
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
 import { buildMigrationStatus, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
 import { runSeeders } from './seeder'
+import { singleFlight } from './single-flight'
 
 type ConnectionResolver = string | (() => string | undefined)
 type AwsDataApiDrizzle = typeof import('drizzle-orm/aws-data-api/pg')
@@ -86,8 +87,6 @@ export function createAwsDataApiDatabase(options: AwsDataApiDatabaseOptions): Aw
   const resolvedSeedersFolder =
     seedersFolder == null ? undefined : seedersFolder instanceof URL ? fileURLToPath(seedersFolder) : resolve(String(seedersFolder))
 
-  let migrationsPromise: Promise<void> | undefined
-  let databasePromise: Promise<AwsDataApiPgDatabase> | undefined
   let client: { destroy?: () => void } | undefined
   let activeKey: string | undefined
   // Captured here, not in getDatabase(), so the caller of this factory is the
@@ -127,12 +126,8 @@ export function createAwsDataApiDatabase(options: AwsDataApiDatabaseOptions): Aw
     } as DrizzleConfig
   }
 
-  async function migrateOnce(): Promise<void> {
-    if (migrationsPromise) {
-      return migrationsPromise
-    }
-
-    const promise = (async (): Promise<void> => {
+  const migrations = singleFlight(
+    async (): Promise<void> => {
       if (!hasDrizzleMigrations(resolvedMigrationsFolder)) {
         warnIgnoredFlatSqlMigrations(resolvedMigrationsFolder)
         return
@@ -140,45 +135,36 @@ export function createAwsDataApiDatabase(options: AwsDataApiDatabaseOptions): Aw
 
       const { migrate } = await loadAwsDataApiModules()
       await withAdminDb((db) => migrate(db, { migrationsFolder: resolvedMigrationsFolder }))
-    })()
-
-    migrationsPromise = promise.catch((error) => {
-      migrationsPromise = undefined
+    },
+    (error) => {
       const reason = error instanceof Error ? error.message : String(error)
-      throw new Error(`Failed to run database migrations: ${reason}`)
-    })
+      return new Error(`Failed to run database migrations: ${reason}`)
+    },
+  )
 
-    await migrationsPromise
+  async function migrateOnce(): Promise<void> {
+    await migrations.get()
   }
 
-  async function getDatabase(): Promise<AwsDataApiPgDatabase> {
-    if (databasePromise) {
-      return databasePromise
+  const databaseHandle = singleFlight(async (): Promise<AwsDataApiPgDatabase> => {
+    if (migrateOnStart) {
+      await migrateOnce()
+    }
+    const { drizzle } = await loadAwsDataApiModules()
+    const connection = resolveConnection()
+    const db = drizzle(buildDrizzleConfig(connection)) as unknown as AwsDataApiPgDatabase
+    client = (db as { $client?: { destroy?: () => void } }).$client
+
+    activeKey = hotReloadKey('aws-data-api', callSite, `${connection.resourceArn}/${connection.database}`)
+    if (activeKey) {
+      await replaceActiveConnection(activeKey, closeDatabase)
     }
 
-    const promise = (async (): Promise<AwsDataApiPgDatabase> => {
-      if (migrateOnStart) {
-        await migrateOnce()
-      }
-      const { drizzle } = await loadAwsDataApiModules()
-      const connection = resolveConnection()
-      const db = drizzle(buildDrizzleConfig(connection)) as unknown as AwsDataApiPgDatabase
-      client = (db as { $client?: { destroy?: () => void } }).$client
+    return db
+  })
 
-      activeKey = hotReloadKey('aws-data-api', callSite, `${connection.resourceArn}/${connection.database}`)
-      if (activeKey) {
-        await replaceActiveConnection(activeKey, closeDatabase)
-      }
-
-      return db
-    })()
-
-    databasePromise = promise.catch((error) => {
-      databasePromise = undefined
-      throw error
-    })
-
-    return databasePromise
+  function getDatabase(): Promise<AwsDataApiPgDatabase> {
+    return databaseHandle.get()
   }
 
   async function closeDatabase(): Promise<void> {
@@ -193,7 +179,7 @@ export function createAwsDataApiDatabase(options: AwsDataApiDatabaseOptions): Aw
       client.destroy?.()
     } finally {
       client = undefined
-      databasePromise = undefined
+      databaseHandle.reset()
       if (key) {
         releaseActiveConnection(key, closeDatabase)
       }
@@ -239,7 +225,7 @@ export function createAwsDataApiDatabase(options: AwsDataApiDatabaseOptions): Aw
     })
 
     // Allow migrateDatabase() to re-apply everything from scratch.
-    migrationsPromise = undefined
+    migrations.reset()
   }
 
   async function migrationStatus(): Promise<MigrationStatusEntry[]> {

--- a/packages/orm/src/d1.ts
+++ b/packages/orm/src/d1.ts
@@ -56,7 +56,7 @@ export function createD1Database(options: D1DatabaseOptions): D1DatabaseHandle {
         ? relative(process.cwd(), fileURLToPath(migrationsFolder))
         : migrationsFolder
 
-  const database = singleFlight(async (): Promise<unknown> => {
+  const databaseHandle = singleFlight(async (): Promise<unknown> => {
     const client = binding()
     if (client == null) {
       throw new Error(
@@ -74,12 +74,8 @@ export function createD1Database(options: D1DatabaseOptions): D1DatabaseHandle {
     return drizzle(client as D1Client, relations ? ({ relations } as D1Config) : undefined)
   })
 
-  function ensureDatabase(): Promise<unknown> {
-    return database.get()
-  }
-
   return {
-    getDatabase: ensureDatabase,
+    getDatabase: databaseHandle.get,
 
     async migrateDatabase() {
       // The drizzle-kit SQL ↔ wrangler format contract is covered by the
@@ -95,11 +91,11 @@ export function createD1Database(options: D1DatabaseOptions): D1DatabaseHandle {
     async closeDatabase() {
       // D1 sessions have no connection to close; just drop the cached instance
       // (mirrors the sqlite factory).
-      database.reset()
+      databaseHandle.reset()
     },
 
     async configureOrm() {
-      const database = await ensureDatabase()
+      const database = await databaseHandle.get()
       DrizzleAdapter.configure(database as Parameters<typeof DrizzleAdapter.configure>[0])
     },
 

--- a/packages/orm/src/d1.ts
+++ b/packages/orm/src/d1.ts
@@ -1,6 +1,7 @@
 import { relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
+import { singleFlight } from './single-flight'
 
 export interface D1DatabaseOptions {
   /**
@@ -55,34 +56,26 @@ export function createD1Database(options: D1DatabaseOptions): D1DatabaseHandle {
         ? relative(process.cwd(), fileURLToPath(migrationsFolder))
         : migrationsFolder
 
-  let databasePromise: Promise<unknown> | undefined
+  const database = singleFlight(async (): Promise<unknown> => {
+    const client = binding()
+    if (client == null) {
+      throw new Error(
+        'createD1Database: the "binding" resolver returned no D1 binding. ' +
+          'On Workers this usually means it ran before the first request — defer access ' +
+          '(e.g. binding: () => getWorkersEnv<Env>().DB) and check the d1_databases entry in wrangler.jsonc.',
+      )
+    }
+
+    // drizzle-orm/d1 only accepts the positional (client, config) form —
+    // unlike bun-sqlite there is no `{ client }` object overload.
+    const { drizzle } = await import('drizzle-orm/d1')
+    type D1Client = Parameters<typeof drizzle>[0]
+    type D1Config = NonNullable<Parameters<typeof drizzle>[1]>
+    return drizzle(client as D1Client, relations ? ({ relations } as D1Config) : undefined)
+  })
 
   function ensureDatabase(): Promise<unknown> {
-    if (databasePromise) return databasePromise
-
-    const promise = (async () => {
-      const client = binding()
-      if (client == null) {
-        throw new Error(
-          'createD1Database: the "binding" resolver returned no D1 binding. ' +
-            'On Workers this usually means it ran before the first request — defer access ' +
-            '(e.g. binding: () => getWorkersEnv<Env>().DB) and check the d1_databases entry in wrangler.jsonc.',
-        )
-      }
-
-      // drizzle-orm/d1 only accepts the positional (client, config) form —
-      // unlike bun-sqlite there is no `{ client }` object overload.
-      const { drizzle } = await import('drizzle-orm/d1')
-      type D1Client = Parameters<typeof drizzle>[0]
-      type D1Config = NonNullable<Parameters<typeof drizzle>[1]>
-      return drizzle(client as D1Client, relations ? ({ relations } as D1Config) : undefined)
-    })()
-
-    databasePromise = promise.catch((error) => {
-      databasePromise = undefined
-      throw error
-    })
-    return databasePromise
+    return database.get()
   }
 
   return {
@@ -102,7 +95,7 @@ export function createD1Database(options: D1DatabaseOptions): D1DatabaseHandle {
     async closeDatabase() {
       // D1 sessions have no connection to close; just drop the cached instance
       // (mirrors the sqlite factory).
-      databasePromise = undefined
+      database.reset()
     },
 
     async configureOrm() {

--- a/packages/orm/src/mysql.ts
+++ b/packages/orm/src/mysql.ts
@@ -5,6 +5,7 @@ import { hotReloadKey, releaseActiveConnection, replaceActiveConnection } from '
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
 import { buildMigrationStatus, describeConnectionEndpoint, describeDatabaseFailure, isConnectionFailure, migrationFailure, seedFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
 import { runSeeders } from './seeder'
+import { singleFlight } from './single-flight'
 
 type ConnectionResolver = string | (() => string | undefined)
 type MySqlConnectionOptions = Record<string, unknown>
@@ -74,8 +75,6 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
   const resolvedSeedersFolder =
     seedersFolder == null ? undefined : seedersFolder instanceof URL ? fileURLToPath(seedersFolder) : resolve(String(seedersFolder))
 
-  let migrationsPromise: Promise<void> | undefined
-  let databasePromise: Promise<MySql2Database> | undefined
   let client: MySqlPool | undefined
   let activeKey: string | undefined
   // Captured here, not in getDatabase(), so the caller of this factory is the
@@ -93,17 +92,16 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
     return resolved
   }
 
-  async function migrateOnce(): Promise<void> {
-    if (migrationsPromise) {
-      return migrationsPromise
-    }
+  // Resolved inside the factory below: resolveConnectionString() throws when no
+  // connection string is configured, so it must not run before the
+  // no-migrations early return. The error mapper needs it afterwards, and each
+  // attempt clears it so a retry never reports a previous attempt's endpoint.
+  let endpoint: string | undefined
 
-    // Resolved inside the IIFE below: resolveConnectionString() throws when no
-    // connection string is configured, so it must not run before the
-    // no-migrations early return. The catch handler needs it afterwards.
-    let endpoint: string | undefined
+  const migrations = singleFlight(
+    async (): Promise<void> => {
+      endpoint = undefined
 
-    const promise = (async (): Promise<void> => {
       if (!hasDrizzleMigrations(resolvedMigrationsFolder)) {
         warnIgnoredFlatSqlMigrations(resolvedMigrationsFolder)
         return
@@ -123,47 +121,36 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
       } finally {
         await closePool(migrationClient)
       }
-    })()
+    },
+    (error) => migrationFailure(error, endpoint),
+  )
 
-    migrationsPromise = promise.catch((error) => {
-      migrationsPromise = undefined
-      throw migrationFailure(error, endpoint)
-    })
-
-    await migrationsPromise
+  async function migrateOnce(): Promise<void> {
+    await migrations.get()
   }
 
-  async function getDatabase(): Promise<MySql2Database> {
-    if (databasePromise) {
-      return databasePromise
+  const database = singleFlight(async (): Promise<MySql2Database> => {
+    await migrateOnce()
+    const { drizzle, createPool } = await loadMySqlModules()
+    const url = resolveConnectionString()
+    // Held locally as well as in closure state: a newer evaluation may close
+    // this client while the await below is suspended, which clears `client`.
+    const activeClient = createPool({ uri: url, ...clientOptions })
+    client = activeClient
+
+    activeKey = hotReloadKey('mysql', callSite, url)
+    if (activeKey) {
+      await replaceActiveConnection(activeKey, closeDatabase)
     }
 
-    const promise = (async (): Promise<MySql2Database> => {
-      await migrateOnce()
-      const { drizzle, createPool } = await loadMySqlModules()
-      const url = resolveConnectionString()
-      // Held locally as well as in closure state: a newer evaluation may close
-      // this client while the await below is suspended, which clears `client`.
-      const activeClient = createPool({ uri: url, ...clientOptions })
-      client = activeClient
+    return drizzle({
+      client: activeClient,
+      ...(relations ? { relations } : {}),
+    } as DrizzleConfig) as unknown as MySql2Database
+  })
 
-      activeKey = hotReloadKey('mysql', callSite, url)
-      if (activeKey) {
-        await replaceActiveConnection(activeKey, closeDatabase)
-      }
-
-      return drizzle({
-        client: activeClient,
-        ...(relations ? { relations } : {}),
-      } as DrizzleConfig) as unknown as MySql2Database
-    })()
-
-    databasePromise = promise.catch((error) => {
-      databasePromise = undefined
-      throw error
-    })
-
-    return databasePromise
+  function getDatabase(): Promise<MySql2Database> {
+    return database.get()
   }
 
   async function closeDatabase(): Promise<void> {
@@ -178,7 +165,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
       await closePool(client)
     } finally {
       client = undefined
-      databasePromise = undefined
+      database.reset()
       if (key) {
         releaseActiveConnection(key, closeDatabase)
       }
@@ -247,7 +234,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
     })
 
     // Allow migrateDatabase() to re-apply everything from scratch.
-    migrationsPromise = undefined
+    migrations.reset()
   }
 
   async function migrationStatus(): Promise<MigrationStatusEntry[]> {

--- a/packages/orm/src/mysql.ts
+++ b/packages/orm/src/mysql.ts
@@ -77,8 +77,8 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
 
   let client: MySqlPool | undefined
   let activeKey: string | undefined
-  // Captured here, not in getDatabase(), so the caller of this factory is the
-  // frame that identifies the handle across hot reloads.
+  // Captured here, not in the connection factory, so the caller of this factory
+  // is the frame that identifies the handle across hot reloads.
   const callSite = new Error().stack
 
   function resolveConnectionString(): string {
@@ -124,12 +124,8 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
     }
   })
 
-  async function migrateOnce(): Promise<void> {
-    await migrations.get()
-  }
-
   const database = singleFlight(async (): Promise<MySql2Database> => {
-    await migrateOnce()
+    await migrations.get()
     const { drizzle, createPool } = await loadMySqlModules()
     const url = resolveConnectionString()
     // Held locally as well as in closure state: a newer evaluation may close
@@ -147,10 +143,6 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
       ...(relations ? { relations } : {}),
     } as DrizzleConfig) as unknown as MySql2Database
   })
-
-  function getDatabase(): Promise<MySql2Database> {
-    return database.get()
-  }
 
   async function closeDatabase(): Promise<void> {
     if (!client) {
@@ -172,7 +164,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
   }
 
   async function configureOrm(): Promise<void> {
-    const db = await getDatabase()
+    const db = await database.get()
     DrizzleAdapter.configure(db as unknown as Parameters<typeof DrizzleAdapter.configure>[0])
   }
 
@@ -181,7 +173,7 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
       throw new Error('No seeders folder configured. Provide "seedersFolder" when calling createMySqlDatabase().')
     }
 
-    const db = await getDatabase()
+    const db = await database.get()
     try {
       await runSeeders(db, resolvedSeedersFolder)
     } catch (error) {
@@ -261,8 +253,8 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
   }
 
   return {
-    getDatabase,
-    migrateDatabase: migrateOnce,
+    getDatabase: database.get,
+    migrateDatabase: migrations.get,
     closeDatabase,
     configureOrm,
     seedDatabase,

--- a/packages/orm/src/mysql.ts
+++ b/packages/orm/src/mysql.ts
@@ -92,16 +92,14 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
     return resolved
   }
 
-  // Resolved inside the factory below: resolveConnectionString() throws when no
-  // connection string is configured, so it must not run before the
-  // no-migrations early return. The error mapper needs it afterwards, and each
-  // attempt clears it so a retry never reports a previous attempt's endpoint.
-  let endpoint: string | undefined
+  const migrations = singleFlight(async (): Promise<void> => {
+    // Scoped to this attempt, and resolved below rather than up front:
+    // resolveConnectionString() throws when no connection string is configured,
+    // so it must not run before the no-migrations early return. The catch needs
+    // it afterwards.
+    let endpoint: string | undefined
 
-  const migrations = singleFlight(
-    async (): Promise<void> => {
-      endpoint = undefined
-
+    try {
       if (!hasDrizzleMigrations(resolvedMigrationsFolder)) {
         warnIgnoredFlatSqlMigrations(resolvedMigrationsFolder)
         return
@@ -121,9 +119,10 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
       } finally {
         await closePool(migrationClient)
       }
-    },
-    (error) => migrationFailure(error, endpoint),
-  )
+    } catch (error) {
+      throw migrationFailure(error, endpoint)
+    }
+  })
 
   async function migrateOnce(): Promise<void> {
     await migrations.get()

--- a/packages/orm/src/postgres.ts
+++ b/packages/orm/src/postgres.ts
@@ -69,8 +69,8 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
 
   let client: ReturnType<typeof postgres> | undefined
   let activeKey: string | undefined
-  // Captured here, not in getDatabase(), so the caller of this factory is the
-  // frame that identifies the handle across hot reloads.
+  // Captured here, not in the connection factory, so the caller of this factory
+  // is the frame that identifies the handle across hot reloads.
   const callSite = new Error().stack
 
   function resolveConnectionString(): string {
@@ -116,12 +116,8 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
     }
   })
 
-  async function migrateOnce(): Promise<void> {
-    await migrations.get()
-  }
-
   const database = singleFlight(async (): Promise<PostgresJsDatabase> => {
-    await migrateOnce()
+    await migrations.get()
     const { drizzle, postgres: postgresFactory } = await loadPostgresModules()
     const url = resolveConnectionString()
     // Held locally as well as in closure state: a newer evaluation may close
@@ -143,10 +139,6 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
     } as DrizzleConfig) as unknown as PostgresJsDatabase
   })
 
-  function getDatabase(): Promise<PostgresJsDatabase> {
-    return database.get()
-  }
-
   async function closeDatabase(): Promise<void> {
     if (!client) {
       return
@@ -167,7 +159,7 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
   }
 
   async function configureOrm(): Promise<void> {
-    const db = await getDatabase()
+    const db = await database.get()
     DrizzleAdapter.configure(db as unknown as Parameters<typeof DrizzleAdapter.configure>[0])
   }
 
@@ -176,7 +168,7 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
       throw new Error('No seeders folder configured. Provide "seedersFolder" when calling createPostgresDatabase().')
     }
 
-    const db = await getDatabase()
+    const db = await database.get()
     try {
       await runSeeders(db, resolvedSeedersFolder)
     } catch (error) {
@@ -238,8 +230,8 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
   }
 
   return {
-    getDatabase,
-    migrateDatabase: migrateOnce,
+    getDatabase: database.get,
+    migrateDatabase: migrations.get,
     closeDatabase,
     configureOrm,
     seedDatabase,

--- a/packages/orm/src/postgres.ts
+++ b/packages/orm/src/postgres.ts
@@ -84,16 +84,14 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
     return resolved
   }
 
-  // Resolved inside the factory below: resolveConnectionString() throws when no
-  // connection string is configured, so it must not run before the
-  // no-migrations early return. The error mapper needs it afterwards, and each
-  // attempt clears it so a retry never reports a previous attempt's endpoint.
-  let endpoint: string | undefined
+  const migrations = singleFlight(async (): Promise<void> => {
+    // Scoped to this attempt, and resolved below rather than up front:
+    // resolveConnectionString() throws when no connection string is configured,
+    // so it must not run before the no-migrations early return. The catch needs
+    // it afterwards.
+    let endpoint: string | undefined
 
-  const migrations = singleFlight(
-    async (): Promise<void> => {
-      endpoint = undefined
-
+    try {
       if (!hasDrizzleMigrations(resolvedMigrationsFolder)) {
         warnIgnoredFlatSqlMigrations(resolvedMigrationsFolder)
         return
@@ -113,9 +111,10 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
       } finally {
         await migrationClient.end({ timeout: 0 })
       }
-    },
-    (error) => migrationFailure(error, endpoint),
-  )
+    } catch (error) {
+      throw migrationFailure(error, endpoint)
+    }
+  })
 
   async function migrateOnce(): Promise<void> {
     await migrations.get()

--- a/packages/orm/src/postgres.ts
+++ b/packages/orm/src/postgres.ts
@@ -6,6 +6,7 @@ import { hotReloadKey, releaseActiveConnection, replaceActiveConnection } from '
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
 import { buildMigrationStatus, describeConnectionEndpoint, describeDatabaseFailure, isConnectionFailure, migrationFailure, seedFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
 import { runSeeders } from './seeder'
+import { singleFlight } from './single-flight'
 
 type ConnectionResolver = string | (() => string | undefined)
 type PostgresJsDrizzle = typeof import('drizzle-orm/postgres-js')
@@ -66,8 +67,6 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
   const resolvedSeedersFolder =
     seedersFolder == null ? undefined : seedersFolder instanceof URL ? fileURLToPath(seedersFolder) : resolve(String(seedersFolder))
 
-  let migrationsPromise: Promise<void> | undefined
-  let databasePromise: Promise<PostgresJsDatabase> | undefined
   let client: ReturnType<typeof postgres> | undefined
   let activeKey: string | undefined
   // Captured here, not in getDatabase(), so the caller of this factory is the
@@ -85,17 +84,16 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
     return resolved
   }
 
-  async function migrateOnce(): Promise<void> {
-    if (migrationsPromise) {
-      return migrationsPromise
-    }
+  // Resolved inside the factory below: resolveConnectionString() throws when no
+  // connection string is configured, so it must not run before the
+  // no-migrations early return. The error mapper needs it afterwards, and each
+  // attempt clears it so a retry never reports a previous attempt's endpoint.
+  let endpoint: string | undefined
 
-    // Resolved inside the IIFE below: resolveConnectionString() throws when no
-    // connection string is configured, so it must not run before the
-    // no-migrations early return. The catch handler needs it afterwards.
-    let endpoint: string | undefined
+  const migrations = singleFlight(
+    async (): Promise<void> => {
+      endpoint = undefined
 
-    const promise = (async (): Promise<void> => {
       if (!hasDrizzleMigrations(resolvedMigrationsFolder)) {
         warnIgnoredFlatSqlMigrations(resolvedMigrationsFolder)
         return
@@ -115,50 +113,39 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
       } finally {
         await migrationClient.end({ timeout: 0 })
       }
-    })()
+    },
+    (error) => migrationFailure(error, endpoint),
+  )
 
-    migrationsPromise = promise.catch((error) => {
-      migrationsPromise = undefined
-      throw migrationFailure(error, endpoint)
-    })
-
-    await migrationsPromise
+  async function migrateOnce(): Promise<void> {
+    await migrations.get()
   }
 
-  async function getDatabase(): Promise<PostgresJsDatabase> {
-    if (databasePromise) {
-      return databasePromise
+  const database = singleFlight(async (): Promise<PostgresJsDatabase> => {
+    await migrateOnce()
+    const { drizzle, postgres: postgresFactory } = await loadPostgresModules()
+    const url = resolveConnectionString()
+    // Held locally as well as in closure state: a newer evaluation may close
+    // this client while the await below is suspended, which clears `client`.
+    const activeClient = postgresFactory(url, {
+      max: 1,
+      ...clientOptions,
+    })
+    client = activeClient
+
+    activeKey = hotReloadKey('postgres', callSite, url)
+    if (activeKey) {
+      await replaceActiveConnection(activeKey, closeDatabase)
     }
 
-    const promise = (async (): Promise<PostgresJsDatabase> => {
-      await migrateOnce()
-      const { drizzle, postgres: postgresFactory } = await loadPostgresModules()
-      const url = resolveConnectionString()
-      // Held locally as well as in closure state: a newer evaluation may close
-      // this client while the await below is suspended, which clears `client`.
-      const activeClient = postgresFactory(url, {
-        max: 1,
-        ...clientOptions,
-      })
-      client = activeClient
+    return drizzle({
+      client: activeClient,
+      ...(relations ? { relations } : {}),
+    } as DrizzleConfig) as unknown as PostgresJsDatabase
+  })
 
-      activeKey = hotReloadKey('postgres', callSite, url)
-      if (activeKey) {
-        await replaceActiveConnection(activeKey, closeDatabase)
-      }
-
-      return drizzle({
-        client: activeClient,
-        ...(relations ? { relations } : {}),
-      } as DrizzleConfig) as unknown as PostgresJsDatabase
-    })()
-
-    databasePromise = promise.catch((error) => {
-      databasePromise = undefined
-      throw error
-    })
-
-    return databasePromise
+  function getDatabase(): Promise<PostgresJsDatabase> {
+    return database.get()
   }
 
   async function closeDatabase(): Promise<void> {
@@ -173,7 +160,7 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
       await client.end({ timeout: 0 })
     } finally {
       client = undefined
-      databasePromise = undefined
+      database.reset()
       if (key) {
         releaseActiveConnection(key, closeDatabase)
       }
@@ -224,7 +211,7 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
     })
 
     // Allow migrateDatabase() to re-apply everything from scratch.
-    migrationsPromise = undefined
+    migrations.reset()
   }
 
   async function migrationStatus(): Promise<MigrationStatusEntry[]> {

--- a/packages/orm/src/single-flight.test.ts
+++ b/packages/orm/src/single-flight.test.ts
@@ -1,15 +1,7 @@
 import { describe, test, expect } from 'bun:test'
 import { singleFlight } from './single-flight'
 
-function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (error: unknown) => void } {
-  let resolve!: (value: T) => void
-  let reject!: (error: unknown) => void
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res
-    reject = rej
-  })
-  return { promise, resolve, reject }
-}
+const deferred = <T,>() => Promise.withResolvers<T>()
 
 describe('singleFlight', () => {
   test('should share one in-flight promise between concurrent callers', async () => {
@@ -110,25 +102,9 @@ describe('singleFlight', () => {
     expect(await fresh).toBe('connected')
   })
 
-  test('should surface an error the factory shaped, with per-attempt context', async () => {
-    // Mirrors the drivers: the factory resolves an endpoint partway through and
-    // wraps its own failure, so each attempt reports its own context.
-    const endpoints = ['db-a:5432', 'db-b:5432']
-    let calls = 0
-    const flight = singleFlight(async () => {
-      let endpoint: string | undefined
-      try {
-        endpoint = endpoints[calls++]
-        throw new Error('ECONNREFUSED')
-      } catch (error) {
-        throw new Error(`Failed to migrate against ${endpoint}: ${(error as Error).message}`)
-      }
-    })
-
-    await expect(flight.get()).rejects.toThrow('Failed to migrate against db-a:5432: ECONNREFUSED')
-    await expect(flight.get()).rejects.toThrow('Failed to migrate against db-b:5432: ECONNREFUSED')
-  })
-
+  // The drivers rely on this: they expose `migrateDatabase: migrations.get` and
+  // `getDatabase: database.get` straight off the returned object, so `get` and
+  // `reset` must not depend on a `this` binding.
   test('should keep method references usable when detached from the returned object', async () => {
     let calls = 0
     const flight = singleFlight(async () => {

--- a/packages/orm/src/single-flight.test.ts
+++ b/packages/orm/src/single-flight.test.ts
@@ -1,0 +1,136 @@
+import { describe, test, expect } from 'bun:test'
+import { singleFlight } from './single-flight'
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (error: unknown) => void } {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('singleFlight', () => {
+  test('should share one in-flight promise between concurrent callers', async () => {
+    let calls = 0
+    const gate = deferred<string>()
+    const flight = singleFlight(() => {
+      calls += 1
+      return gate.promise
+    })
+
+    const first = flight.get()
+    const second = flight.get()
+
+    expect(calls).toBe(1)
+    expect(first).toBe(second)
+
+    gate.resolve('db')
+    expect(await Promise.all([first, second])).toEqual(['db', 'db'])
+    expect(calls).toBe(1)
+  })
+
+  test('should keep the resolved result memoized for later callers', async () => {
+    let calls = 0
+    const flight = singleFlight(async () => {
+      calls += 1
+      return calls
+    })
+
+    expect(await flight.get()).toBe(1)
+    expect(await flight.get()).toBe(1)
+    expect(calls).toBe(1)
+  })
+
+  test('should retry after a rejection instead of memoizing the failure', async () => {
+    let calls = 0
+    const flight = singleFlight(async () => {
+      calls += 1
+      if (calls === 1) throw new Error('connection refused')
+      return 'connected'
+    })
+
+    await expect(flight.get()).rejects.toThrow('connection refused')
+    expect(await flight.get()).toBe('connected')
+    expect(calls).toBe(2)
+  })
+
+  test('should reject every concurrent caller of a failed attempt, then retry once', async () => {
+    let calls = 0
+    const gate = deferred<string>()
+    const flight = singleFlight(() => {
+      calls += 1
+      return calls === 1 ? gate.promise : Promise.resolve('connected')
+    })
+
+    const first = flight.get()
+    const second = flight.get()
+    gate.reject(new Error('connection refused'))
+
+    await expect(first).rejects.toThrow('connection refused')
+    await expect(second).rejects.toThrow('connection refused')
+    expect(await flight.get()).toBe('connected')
+    expect(calls).toBe(2)
+  })
+
+  test('should run the factory again after reset(), even when a result was memoized', async () => {
+    let calls = 0
+    const flight = singleFlight(async () => {
+      calls += 1
+      return calls
+    })
+
+    expect(await flight.get()).toBe(1)
+    flight.reset()
+    expect(await flight.get()).toBe(2)
+  })
+
+  test('should not evict a newer in-flight promise when a superseded attempt rejects', async () => {
+    const first = deferred<string>()
+    const second = deferred<string>()
+    const gates = [first, second]
+    let calls = 0
+    const flight = singleFlight(() => gates[calls++]!.promise)
+
+    const stale = flight.get()
+    // closeDatabase()/resetDatabase() drop the handle while the first attempt
+    // is still suspended.
+    flight.reset()
+    const fresh = flight.get()
+
+    first.reject(new Error('stale failure'))
+    await expect(stale).rejects.toThrow('stale failure')
+
+    // The late rejection must leave the newer attempt memoized.
+    expect(flight.get()).toBe(fresh)
+    expect(calls).toBe(2)
+
+    second.resolve('connected')
+    expect(await fresh).toBe('connected')
+  })
+
+  test('should map the rejection to the error callers see', async () => {
+    const flight = singleFlight(
+      async () => {
+        throw new Error('ECONNREFUSED')
+      },
+      (error) => new Error(`Failed to connect: ${(error as Error).message}`),
+    )
+
+    await expect(flight.get()).rejects.toThrow('Failed to connect: ECONNREFUSED')
+  })
+
+  test('should keep method references usable when detached from the returned object', async () => {
+    let calls = 0
+    const flight = singleFlight(async () => {
+      calls += 1
+      return calls
+    })
+    const { get, reset } = flight
+
+    expect(await get()).toBe(1)
+    reset()
+    expect(await get()).toBe(2)
+  })
+})

--- a/packages/orm/src/single-flight.test.ts
+++ b/packages/orm/src/single-flight.test.ts
@@ -110,15 +110,23 @@ describe('singleFlight', () => {
     expect(await fresh).toBe('connected')
   })
 
-  test('should map the rejection to the error callers see', async () => {
-    const flight = singleFlight(
-      async () => {
+  test('should surface an error the factory shaped, with per-attempt context', async () => {
+    // Mirrors the drivers: the factory resolves an endpoint partway through and
+    // wraps its own failure, so each attempt reports its own context.
+    const endpoints = ['db-a:5432', 'db-b:5432']
+    let calls = 0
+    const flight = singleFlight(async () => {
+      let endpoint: string | undefined
+      try {
+        endpoint = endpoints[calls++]
         throw new Error('ECONNREFUSED')
-      },
-      (error) => new Error(`Failed to connect: ${(error as Error).message}`),
-    )
+      } catch (error) {
+        throw new Error(`Failed to migrate against ${endpoint}: ${(error as Error).message}`)
+      }
+    })
 
-    await expect(flight.get()).rejects.toThrow('Failed to connect: ECONNREFUSED')
+    await expect(flight.get()).rejects.toThrow('Failed to migrate against db-a:5432: ECONNREFUSED')
+    await expect(flight.get()).rejects.toThrow('Failed to migrate against db-b:5432: ECONNREFUSED')
   })
 
   test('should keep method references usable when detached from the returned object', async () => {

--- a/packages/orm/src/single-flight.ts
+++ b/packages/orm/src/single-flight.ts
@@ -1,0 +1,56 @@
+/**
+ * Memoizes an async factory so concurrent callers share one in-flight promise.
+ *
+ * Internal to @guren/orm — every driver factory needs the same three
+ * behaviours for its connection and migration handles:
+ *
+ * - concurrent callers await the same promise (one connection, one migration run)
+ * - a resolved result stays memoized until it is explicitly invalidated
+ * - a rejection is *not* memoized, so the next caller retries
+ *
+ * `reset()` covers the invalidation the drivers do from outside the failure
+ * path: `closeDatabase()` drops the connection handle, `resetDatabase()` drops
+ * the migration handle so migrations can be re-applied from scratch.
+ */
+export interface SingleFlight<T> {
+  /** Runs the factory, or returns the promise an earlier call memoized. */
+  get(): Promise<T>
+  /** Drops the memoized promise so the next `get()` runs the factory again. */
+  reset(): void
+}
+
+export function singleFlight<T>(
+  factory: () => Promise<T>,
+  /** Maps a rejection to the error callers see. Defaults to rethrowing as-is. */
+  mapError?: (error: unknown) => unknown,
+): SingleFlight<T> {
+  // Closure state rather than instance fields: call sites hand these methods
+  // out by reference (`migrateDatabase: migrations.get`), which would lose a
+  // `this` binding.
+  let inFlight: Promise<T> | undefined
+
+  function get(): Promise<T> {
+    if (inFlight) {
+      return inFlight
+    }
+
+    const attempt = factory().catch((error) => {
+      // Only clear when the cell still holds *this* attempt. A late rejection
+      // from an attempt that `reset()` already superseded must not evict the
+      // newer one.
+      if (inFlight === attempt) {
+        inFlight = undefined
+      }
+      throw mapError ? mapError(error) : error
+    })
+
+    inFlight = attempt
+    return attempt
+  }
+
+  function reset(): void {
+    inFlight = undefined
+  }
+
+  return { get, reset }
+}

--- a/packages/orm/src/single-flight.ts
+++ b/packages/orm/src/single-flight.ts
@@ -11,6 +11,10 @@
  * `reset()` covers the invalidation the drivers do from outside the failure
  * path: `closeDatabase()` drops the connection handle, `resetDatabase()` drops
  * the migration handle so migrations can be re-applied from scratch.
+ *
+ * Error shaping stays in the factory. The drivers that wrap a migration failure
+ * need per-attempt state to do it (the endpoint resolved partway through), and
+ * a mapper living out here would read whatever the *latest* attempt left behind.
  */
 export interface SingleFlight<T> {
   /** Runs the factory, or returns the promise an earlier call memoized. */
@@ -19,11 +23,7 @@ export interface SingleFlight<T> {
   reset(): void
 }
 
-export function singleFlight<T>(
-  factory: () => Promise<T>,
-  /** Maps a rejection to the error callers see. Defaults to rethrowing as-is. */
-  mapError?: (error: unknown) => unknown,
-): SingleFlight<T> {
+export function singleFlight<T>(factory: () => Promise<T>): SingleFlight<T> {
   // Closure state rather than instance fields: call sites hand these methods
   // out by reference (`migrateDatabase: migrations.get`), which would lose a
   // `this` binding.
@@ -41,7 +41,7 @@ export function singleFlight<T>(
       if (inFlight === attempt) {
         inFlight = undefined
       }
-      throw mapError ? mapError(error) : error
+      throw error
     })
 
     inFlight = attempt

--- a/packages/orm/src/sqlite.ts
+++ b/packages/orm/src/sqlite.ts
@@ -132,17 +132,13 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
     }
   })
 
-  async function migrateOnce(): Promise<void> {
-    await migrations.get()
-  }
-
   return {
     async getDatabase() {
-      await migrateOnce()
+      await migrations.get()
       return ensureDatabase()
     },
 
-    migrateDatabase: migrateOnce,
+    migrateDatabase: migrations.get,
 
     closeDatabase,
 
@@ -196,7 +192,7 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
 
     async configureOrm() {
       const database = await ensureDatabase()
-      await migrateOnce()
+      await migrations.get()
       DrizzleAdapter.configure(database as Parameters<typeof DrizzleAdapter.configure>[0])
     },
 

--- a/packages/orm/src/sqlite.ts
+++ b/packages/orm/src/sqlite.ts
@@ -116,8 +116,8 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
     }
   }
 
-  const migrations = singleFlight(
-    async (): Promise<void> => {
+  const migrations = singleFlight(async (): Promise<void> => {
+    try {
       if (!hasDrizzleMigrations(resolvedMigrationsFolder)) {
         warnIgnoredFlatSqlMigrations(resolvedMigrationsFolder)
         return
@@ -126,10 +126,11 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
       const database = await ensureDatabase()
       const { migrate } = await import('drizzle-orm/bun-sqlite/migrator')
       await migrate(database as any, { migrationsFolder: resolvedMigrationsFolder }) // eslint-disable-line @typescript-eslint/no-explicit-any
-    },
-    // No endpoint: a SQLite file has no host, so only the cause chain adds signal.
-    (error) => migrationFailure(error),
-  )
+    } catch (error) {
+      // No endpoint: a SQLite file has no host, so only the cause chain adds signal.
+      throw migrationFailure(error)
+    }
+  })
 
   async function migrateOnce(): Promise<void> {
     await migrations.get()

--- a/packages/orm/src/sqlite.ts
+++ b/packages/orm/src/sqlite.ts
@@ -4,6 +4,7 @@ import { hotReloadKey, releaseActiveConnection, replaceActiveConnection } from '
 import { DrizzleAdapter } from './adapters/drizzle-adapter'
 import { buildMigrationStatus, migrationFailure, seedFailure, hasDrizzleMigrations, listLocalMigrations, warnIgnoredFlatSqlMigrations, type MigrationStatusEntry } from './migration-utils'
 import { runSeeders } from './seeder'
+import { singleFlight } from './single-flight'
 
 type ConnectionResolver = string | (() => string | undefined)
 
@@ -52,7 +53,6 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
   let sqliteClient:
     | { query(sql: string): { all(): unknown[] }; exec(sql: string): void; close(): void }
     | undefined
-  let migrationsPromise: Promise<void> | undefined
   let activeKey: string | undefined
   // Captured here, not in ensureDatabase(), so the caller of this factory is
   // the frame that identifies the handle across hot reloads.
@@ -116,10 +116,8 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
     }
   }
 
-  async function migrateOnce(): Promise<void> {
-    if (migrationsPromise) return migrationsPromise
-
-    migrationsPromise = (async () => {
+  const migrations = singleFlight(
+    async (): Promise<void> => {
       if (!hasDrizzleMigrations(resolvedMigrationsFolder)) {
         warnIgnoredFlatSqlMigrations(resolvedMigrationsFolder)
         return
@@ -128,15 +126,13 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
       const database = await ensureDatabase()
       const { migrate } = await import('drizzle-orm/bun-sqlite/migrator')
       await migrate(database as any, { migrationsFolder: resolvedMigrationsFolder }) // eslint-disable-line @typescript-eslint/no-explicit-any
-    })()
+    },
+    // No endpoint: a SQLite file has no host, so only the cause chain adds signal.
+    (error) => migrationFailure(error),
+  )
 
-    migrationsPromise = migrationsPromise.catch((error) => {
-      migrationsPromise = undefined
-      // No endpoint: a SQLite file has no host, so only the cause chain adds signal.
-      throw migrationFailure(error)
-    })
-
-    await migrationsPromise
+  async function migrateOnce(): Promise<void> {
+    await migrations.get()
   }
 
   return {
@@ -176,7 +172,7 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
       }
 
       // Allow migrateDatabase() to re-apply everything from scratch.
-      migrationsPromise = undefined
+      migrations.reset()
     },
 
     async migrationStatus() {


### PR DESCRIPTION
## Summary

Each of the five database factories in `packages/orm` hand-rolled the same memoized-promise pattern for its connection and migration handles: cache the promise, hand it to concurrent callers, clear it on rejection so the next caller retries.

The real count is larger than it looks from the `.catch` blocks alone — **8 memoization sites plus 7 places clearing the cells from outside the failure path**:

| Site | Memoized | Invalidated from |
|---|---|---|
| `postgres.ts` | `migrateOnce`, `getDatabase` | `closeDatabase`, `resetDatabase` |
| `mysql.ts` | `migrateOnce`, `getDatabase` | `closeDatabase`, `resetDatabase` |
| `sqlite.ts` | `migrateOnce` | `resetDatabase` |
| `d1.ts` | `ensureDatabase` | `closeDatabase` |
| `aws-data-api.ts` | `migrateOnce`, `getDatabase` | `closeDatabase`, `resetDatabase` |

All eight share one failure policy, so `reset()` is part of the helper's contract rather than an add-on.

## Behaviour change

This is not a pure extraction, deliberately. The old clear was unconditional:

```ts
databasePromise = promise.catch((error) => {
  databasePromise = undefined   // clears whatever is in the cell *now*
  throw error
})
```

So a rejection arriving after `closeDatabase()` had already dropped the handle and a newer attempt had replaced it would evict that newer attempt — a second connection where one was expected. The helper now clears only while the cell still holds the attempt that failed.

## Not converted

`sqlite.ts`'s `ensureDatabase()` is left alone. It memoizes a resolved *value* (`db`), not a promise, so it is not single-flight at all.

That means it does not dedupe concurrent first-callers: `db` is assigned only after five `await` points, so two callers racing the first `getDatabase()` each run `new Database(dbPath)`, `sqliteClient` ends up pointing at the second, and the first handle is never closed. Reachable, since `getDatabase()` is `await migrations.get()` followed by `ensureDatabase()` and the first await always yields.

It is still out of scope here, because converting it means changing `closeDatabase`'s liveness guard from `db` to `sqliteClient`, and that changes behaviour in the window between `sqliteClient = sqlite` and the flight resolving. Filed as a separate follow-up.

(An earlier revision of this description said `db` doubles as a liveness flag read by `closeDatabase`, `resetDatabase`, and `migrationStatus`. That was wrong: only `closeDatabase` reads `db`; the other two gate on `sqliteClient`.)

## Error shaping

Four sites rethrow raw and four wrap the error. An earlier revision passed a `mapError` callback to the helper; that turned out to be wrong, because `postgres`/`mysql` need per-attempt state (the endpoint resolved partway through the migration) and a factory-scope mapper reads whatever the *latest* attempt left behind. Error shaping now lives in each factory's own `try/catch`, which keeps `endpoint` per-attempt by scope rather than by discipline, and leaves `singleFlight()` with one job.

## Why the helper stays in `packages/orm`

`Application.boot()` and `createWorkersHandler()` have the same shape, but not the same exposure: neither has an external reset path, so no newer attempt can exist for a stale rejection to evict. The eviction window is specific to the drivers, where `closeDatabase()`/`resetDatabase()` clear the cell from outside the failure path. Combined with the dependency graph (nothing sits below both `server` and `orm`), the helper belongs here and stays unexported.

## Scope

Everything is inside `packages/orm`. The helper is internal — not exported from the package entry, and absent from the built `.d.ts`. The same pattern in `packages/server` and `packages/plugin-cloudflare` is untouched: nothing in the dependency graph sits below both `server` and `orm`, so a shared helper is not possible there.

## Tests

`single-flight.test.ts` covers concurrent callers sharing one in-flight promise, retry after rejection, a resolved result staying memoized, `reset()`, detached method references, and the superseded-rejection case above.

Two mutation checks, since a test that cannot fail is not verification:
- Removing the identity guard from the rejection handler makes the superseded-rejection test fail.
- Reimplementing the helper with `this`-based state fails **9 driver tests** — the drivers expose `getDatabase: database.get` and `migrateDatabase: migrations.get` directly, so the detachment guarantee is exercised by production paths, not only by its own test.

## Verification

- `bun run build:clean` / `bun run build` — pass
- `bun run typecheck` (from root) — pass
- `bun run test:bun` — 3869 pass, 0 fail
- `bun run test:examples` — 102 pass
- `packages/orm/tests/mysql-integration.test.ts` against a live MySQL 8.4 server (`MYSQL_URL` set) — 4 pass
- `bun run audit:core-first`, `bun run audit:docs` — pass

No template files touched, so the starter-template audits and smokes do not apply.
