### PR TITLE
fix(plugin-cloudflare): guard boot-failure cleanup by attempt identity

### DIFF
--- a/.changeset/workers-handler-stale-boot-cleanup.md
+++ b/.changeset/workers-handler-stale-boot-cleanup.md
@@ -1,0 +1,26 @@
+---
+'@guren/plugin-cloudflare': patch
+---
+
+Stop a stale boot waiter in `createWorkersHandler` from clearing a live retry
+
+When the first boot fails, every request awaiting that shared promise runs the
+catch block, and each one dropped the boot promise and the write-once env
+holder unconditionally. That is only correct for the waiter whose attempt is
+still the current one.
+
+A retry can start *between* two waiters' catches: the app may attach its own
+rejection reaction to the promise `boot()` returned, and reactions run in
+registration order, so the reaction can sit between waiter one and waiter two.
+`handler.fetch` captures the env and installs the new boot promise
+synchronously, before its first `await` — so by the time the second, now-stale
+waiter reaches its catch, the retry is already live. Clearing there wiped the
+retry's boot promise and its env, leaving a successfully booted app with an
+empty holder: `getWorkersEnv()` then threw for every subsequent request, and
+the next request booted a second time.
+
+The cleanup is now guarded by the identity of the attempt the request actually
+waited on, so only its owner clears state. A synchronous throw from `boot()`
+leaves both the captured attempt and the boot promise `undefined` — nothing can
+interleave before that catch runs, so the guard holds and the env captured by
+that same request is still cleared.

--- a/.changeset/workers-handler-stale-boot-cleanup.md
+++ b/.changeset/workers-handler-stale-boot-cleanup.md
@@ -23,7 +23,12 @@ empty holder: `getWorkersEnv()` then threw for every subsequent request, and
 the next request booted a second time.
 
 The cleanup is now guarded by the identity of the attempt the request actually
-waited on, so only its owner clears state. A synchronous throw from `boot()`
+waited on, so only its owner clears state. That ownership is per-handler, which
+matches what the generated worker builds: one `createWorkersHandler` call per
+module. Two handlers constructed in the same module still share the env holder
+without sharing a boot promise, so a boot failure in one can clear the holder
+the other captured — unchanged by this release, and out of reach of the
+generated topology. A synchronous throw from `boot()`
 leaves both the captured attempt and the boot promise `undefined` — nothing can
 interleave before that catch runs, so the guard holds and the env captured by
 that same request is still cleared.

--- a/.changeset/workers-handler-stale-boot-cleanup.md
+++ b/.changeset/workers-handler-stale-boot-cleanup.md
@@ -9,6 +9,9 @@ catch block, and each one dropped the boot promise and the write-once env
 holder unconditionally. That is only correct for the waiter whose attempt is
 still the current one.
 
+This is a long-standing race in the boot-failure cleanup, not a regression from
+the synchronous-throw fix released alongside it.
+
 A retry can start *between* two waiters' catches: the app may attach its own
 rejection reaction to the promise `boot()` returned, and reactions run in
 registration order, so the reaction can sit between waiter one and waiter two.

--- a/packages/plugin-cloudflare/src/handler.test.ts
+++ b/packages/plugin-cloudflare/src/handler.test.ts
@@ -195,6 +195,12 @@ describe('createWorkersHandler', () => {
     expect(await retryResponse?.text()).toBe('ok')
     // The stale waiter must not have cleared the retry's env out from under it.
     expect(getWorkersEnv<TestEnv>()).toBe(retryEnv)
+
+    // ...nor its boot promise: a later request must reuse the retry's boot
+    // rather than start a third one.
+    await handler.fetch(new Request('https://example.com/three'), retryEnv, ctx)
+
+    expect(bootCalls).toBe(2)
   })
 
   test('should pass each request its own env and ctx through to app.fetch', async () => {

--- a/packages/plugin-cloudflare/src/handler.test.ts
+++ b/packages/plugin-cloudflare/src/handler.test.ts
@@ -154,6 +154,49 @@ describe('createWorkersHandler', () => {
     expect(getWorkersEnv<TestEnv>()).toBe(retryEnv)
   })
 
+  test('should leave a retry that started mid-failure alone when a stale waiter gives up', async () => {
+    let bootCalls = 0
+    const bootDeferred = deferred<void>()
+    const app: WorkersAppLike = {
+      boot() {
+        bootCalls += 1
+        return bootCalls === 1 ? bootDeferred.promise : Promise.resolve()
+      },
+      fetch() {
+        return new Response('ok')
+      },
+    }
+    const handler = createWorkersHandler(app)
+    const ctx = createExecutionContext()
+    const failedEnv = { DB: 'failed-db' }
+    const retryEnv = { DB: 'retry-db' }
+    let retryResponse: Response | undefined
+
+    // Registration order is the test. Rejection reactions run in the order
+    // they were attached, so the retry is queued between the two waiters and
+    // runs between their catches — and an app may legitimately attach one,
+    // since this is the very promise its `boot()` returned. `fetch` installs
+    // the new boot promise and captures the new env before its first `await`,
+    // so the retry is already live when the second waiter gives up. Reorder
+    // these three statements and the race stops being reproduced.
+    const first = handler.fetch(new Request('https://example.com/one'), failedEnv, ctx)
+    const retried = bootDeferred.promise.catch(async () => {
+      retryResponse = await handler.fetch(new Request('https://example.com/retry'), retryEnv, ctx)
+    })
+    const second = handler.fetch(new Request('https://example.com/two'), failedEnv, ctx)
+
+    bootDeferred.reject(new Error('boot failed'))
+    const settled = await Promise.allSettled([first, second])
+    await retried
+
+    expect(settled[0].status).toBe('rejected')
+    expect(settled[1].status).toBe('rejected')
+    expect(bootCalls).toBe(2)
+    expect(await retryResponse?.text()).toBe('ok')
+    // The stale waiter must not have cleared the retry's env out from under it.
+    expect(getWorkersEnv<TestEnv>()).toBe(retryEnv)
+  })
+
   test('should pass each request its own env and ctx through to app.fetch', async () => {
     const app: WorkersAppLike = {
       async boot() {},

--- a/packages/plugin-cloudflare/src/handler.ts
+++ b/packages/plugin-cloudflare/src/handler.ts
@@ -46,12 +46,16 @@ export function createWorkersHandler(app: WorkersAppLike): WorkersHandler {
         // promise and captures the new env before its first `await`, so a
         // stale waiter clearing unconditionally wipes a live retry.
         //
-        // The same token settles the env holder, which is module-global: it is
-        // first-call-wins and this is its only production reset, so still
-        // owning the boot promise means the holder still holds what this
-        // request captured. A synchronous throw leaves both sides `undefined`
-        // and nothing can interleave before the catch, so that path clears its
-        // own capture.
+        // The same token settles the env holder, which is first-call-wins and
+        // is reset nowhere else in production — so still owning the boot
+        // promise means the holder still holds what this request captured.
+        // That equivalence holds for the one-handler-per-module topology
+        // `buildCloudflareOutput` generates: the holder is module-global while
+        // this slot is per-handler, so a second handler in the same module
+        // shares the former without sharing the latter, and neither can guard
+        // the other. A synchronous throw leaves both sides `undefined` and
+        // nothing can interleave before the catch, so that path clears its own
+        // capture.
         if (bootPromise === attempt) {
           bootPromise = undefined
           resetWorkersEnv()

--- a/packages/plugin-cloudflare/src/handler.ts
+++ b/packages/plugin-cloudflare/src/handler.ts
@@ -31,13 +31,6 @@ export function createWorkersHandler(app: WorkersAppLike): WorkersHandler {
     async fetch(request: Request, env: unknown, ctx: WorkersExecutionContext): Promise<Response> {
       captureWorkersEnv(env)
 
-      // The boot attempt this request waited on. Every waiter on a shared
-      // failed boot reaches the catch, but only the one that still owns the
-      // state may clear it: a retry can start between two waiters' catches
-      // (the app can register a rejection reaction on the very promise
-      // `boot()` returned), and `fetch` installs the new boot promise and
-      // captures the new env before its first `await` — so a stale waiter
-      // clearing unconditionally wipes a live retry.
       let attempt: Promise<void> | undefined
 
       try {
@@ -46,9 +39,19 @@ export function createWorkersHandler(app: WorkersAppLike): WorkersHandler {
         attempt = bootPromise ??= app.boot()
         await attempt
       } catch (error) {
-        // A synchronous throw leaves both sides `undefined` — no promise was
-        // ever installed, and nothing can interleave before the catch, so the
-        // env captured above is still this request's to clear.
+        // Every waiter on a failed boot reaches here, but only the one whose
+        // attempt is still installed may clear: a retry can start between two
+        // waiters' catches — the app can register a rejection reaction on the
+        // very promise `boot()` returned — and `fetch` installs the new boot
+        // promise and captures the new env before its first `await`, so a
+        // stale waiter clearing unconditionally wipes a live retry.
+        //
+        // The same token settles the env holder, which is module-global: it is
+        // first-call-wins and this is its only production reset, so still
+        // owning the boot promise means the holder still holds what this
+        // request captured. A synchronous throw leaves both sides `undefined`
+        // and nothing can interleave before the catch, so that path clears its
+        // own capture.
         if (bootPromise === attempt) {
           bootPromise = undefined
           resetWorkersEnv()

--- a/packages/plugin-cloudflare/src/handler.ts
+++ b/packages/plugin-cloudflare/src/handler.ts
@@ -31,14 +31,28 @@ export function createWorkersHandler(app: WorkersAppLike): WorkersHandler {
     async fetch(request: Request, env: unknown, ctx: WorkersExecutionContext): Promise<Response> {
       captureWorkersEnv(env)
 
+      // The boot attempt this request waited on. Every waiter on a shared
+      // failed boot reaches the catch, but only the one that still owns the
+      // state may clear it: a retry can start between two waiters' catches
+      // (the app can register a rejection reaction on the very promise
+      // `boot()` returned), and `fetch` installs the new boot promise and
+      // captures the new env before its first `await` — so a stale waiter
+      // clearing unconditionally wipes a live retry.
+      let attempt: Promise<void> | undefined
+
       try {
         // Inside the try: a conforming non-async boot() can throw
         // synchronously, and that throw has to reach the cleanup too.
-        bootPromise ??= app.boot()
-        await bootPromise
+        attempt = bootPromise ??= app.boot()
+        await attempt
       } catch (error) {
-        bootPromise = undefined
-        resetWorkersEnv()
+        // A synchronous throw leaves both sides `undefined` — no promise was
+        // ever installed, and nothing can interleave before the catch, so the
+        // env captured above is still this request's to clear.
+        if (bootPromise === attempt) {
+          bootPromise = undefined
+          resetWorkersEnv()
+        }
         throw error
       }
 


### PR DESCRIPTION
Originally stacked on #337; that has since merged, so this is now rebased onto `main` and stands alone.

## The defect

`createWorkersHandler` boots on the first request and, when that boot fails, drops both the shared boot promise and the write-once env holder so the retry starts from the new request's bindings. Every waiter on a failed boot ran that cleanup **unconditionally** — but it is only correct for the waiter whose attempt is still the current one.

A retry can start *between* two waiters' catches:

1. Two concurrent requests share the boot promise installed by the first.
2. The app attaches its own rejection reaction to that promise — legitimate, since `bootPromise` is the very promise its `boot()` returned. Reactions run in registration order, so this one sits between waiter one and waiter two.
3. That reaction retries. `handler.fetch` runs `captureWorkersEnv(env)` and installs the new boot promise **synchronously**, before its first `await`, so the retry is live within that microtask.
4. The second, now-stale waiter's catch then clears both — wiping the retry's boot promise and its env.

The result is a successfully booted app with an empty env holder: `getWorkersEnv()` throws for every subsequent request, and the next request boots a second time.

Pre-existing, not a regression from #337: reproduced identically against `main` before that PR and against its head. The existing concurrency test cannot catch it because it deliberately awaits both catches before retrying.

## The fix

Cleanup is guarded by the identity of the attempt the request actually awaited, so only that attempt's owner clears state.

The synchronous-throw path #337 added is preserved without a special case: when `boot()` throws before returning a promise, the assignment never runs, so the captured attempt and `bootPromise` are both `undefined` and the guard holds. Nothing can interleave before that catch, so the env captured by that same request is still cleared. The single condition is deliberate — narrowing it to `attempt !== undefined && bootPromise === attempt` silently reopens the sync-throw path, which is why the comment says so at the comparison site.

Worth noting the same rule landed independently in #339: `singleFlight` in `@guren/orm` clears its cell "only while the cell still holds the attempt that failed." It is internal to that package so there is nothing to call from here, but the two are now the same shape.

## Verification

- New test reproduces the race with the registration order that makes it deterministic (reaction FIFO order is spec-defined, not a Bun detail), using the file's existing `deferred` helper.
- Three mutations, each isolating one part of the guard:
  - remove the guard → the new race test goes red (only that one);
  - narrow it to `attempt !== undefined && …` → the sync-throw case of the boot-failure test goes red;
  - hoist `bootPromise = undefined` out of the guard, leaving the env reset guarded → the new test goes red on the boot count. Before the follow-up request was added to that test, this mutation passed the whole suite, so half the guard was pinned by nothing.
- `bun install` + `bun run build:clean`, root `bun run typecheck`, `audit:core-first`, `audit:docs` — green.
- `bun run test:bun`: `plugin-cloudflare` 35 pass / 0 fail. The suite's residual failures are `packages/cli` subprocess-spawn tests hitting their 5s timeout under whole-suite load — `bun run test:bun cli` alone is 1213 pass / 0 fail, and this diff does not reach that package.

## Known limitation, deliberately not fixed here

The env holder is module-global while the boot promise is per-handler, so the guard scopes the boot half exactly but the env half only under the one-handler-per-module topology `buildCloudflareOutput` generates. With two handlers constructed in the same module, a boot failure in one clears the holder the other captured — reproduced directly, unchanged by this PR, and unreachable from the generated worker. The comment at the guard now names that assumption rather than implying the identity check scopes the env half too.

Related and best decided together: `index.ts` publicly exports `captureWorkersEnv`, the mutating half of a lifecycle the handler owns. Un-exporting it is a breaking change for a published package, so both are left for a separate decision.
