### PR TITLE
fix(server): make asset path containment survive symlinks

### DIFF
--- a/.changeset/asset-path-containment-symlinks.md
+++ b/.changeset/asset-path-containment-symlinks.md
@@ -30,5 +30,12 @@ legitimately have the resolved module symlinked out of its own directory.
 Closing this needs local write access inside the project, so it is defense in
 depth rather than a live hole. It is a behavior change all the same: an asset
 deliberately symlinked out of `public/` is no longer served through the
-root-level public asset route. Serve it through `/public/*` (Hono's
-`serveStatic`, unaffected) or copy the file into the tree.
+root-level public asset route. Copy the file into the tree instead.
+
+The scope is the framework's own handlers. `/public/*` and `/resources/css/*`
+are delegated to Hono's `serveStatic`, which follows symlinks out of its root
+by design, as nginx and `express.static` do — it normalizes `..` and absolute
+remainders, so lexical traversal is still refused there, but a symlink is not.
+So the same linked file that the root-level route now refuses still serves
+under `/public/*`. `tests/http/serve-static-symlinks.test.ts` asserts both
+halves, so that boundary is machine-checked rather than described.

--- a/.changeset/asset-path-containment-symlinks.md
+++ b/.changeset/asset-path-containment-symlinks.md
@@ -33,9 +33,15 @@ deliberately symlinked out of `public/` is no longer served through the
 root-level public asset route. Copy the file into the tree instead.
 
 The scope is the framework's own handlers. `/public/*` and `/resources/css/*`
-are delegated to Hono's `serveStatic`, which follows symlinks out of its root
-by design, as nginx and `express.static` do — it normalizes `..` and absolute
-remainders, so lexical traversal is still refused there, but a symlink is not.
-So the same linked file that the root-level route now refuses still serves
-under `/public/*`. `tests/http/serve-static-symlinks.test.ts` asserts both
-halves, so that boundary is machine-checked rather than described.
+are delegated to Hono's `serveStatic`, whose path handling leaves no lexical
+escape but which follows symlinks out of its root by design, as nginx and
+`express.static` do. So the same linked file that the root-level public asset
+route now refuses still serves under `/public/*`. Guren does not enforce
+symlink containment on the delegated routes; a deployment that must not follow
+symlinks out of `public/` should not rely on `/public/*` for that.
+
+Hono's `onFound` hook cannot close this — it runs after the content has been
+read and cannot reject — so guarding the delegated routes would mean either
+mirroring Hono's own path resolution in a second place or reimplementing static
+serving. Both were judged worse than the gap, and the gap is left explicit
+rather than papered over.

--- a/.changeset/asset-path-containment-symlinks.md
+++ b/.changeset/asset-path-containment-symlinks.md
@@ -1,0 +1,34 @@
+---
+'@guren/server': patch
+---
+
+Make asset path containment survive symlinks
+
+`resolve()` collapses `..` but does not follow symlinks, while every reader
+downstream of these checks does — `Bun.file().text()`, `.arrayBuffer()`, and
+`new Response(file)`. So a request for `resources/js/link/secret.txt`, where
+`link` points out of the tree, resolved to a path lexically under the root,
+passed the containment check, and was served from wherever the link led. The
+dev transpiler route, both Inertia client routes, and the root public asset
+middleware were all affected.
+
+Containment is now judged on canonicalized paths, once the target is known to
+exist — the point at which it can be canonicalized, and, for the dev
+transpiler, the point at which extension probing has settled which file is
+actually read. Both sides are canonicalized, not just the candidate: a root
+reached through a symlink is routine (workspace and pnpm layouts, containers,
+macOS `/var`), and canonicalizing only the candidate would reject every asset
+such an app serves.
+
+The four call sites now share `isPathWithin` / `isRealPathWithin`, so this
+decision lives in one place instead of four copies of a `startsWith`.
+
+The configured entry points are deliberately exempt: they come from
+configuration rather than from the request, and a package layout may
+legitimately have the resolved module symlinked out of its own directory.
+
+Closing this needs local write access inside the project, so it is defense in
+depth rather than a live hole. It is a behavior change all the same: an asset
+deliberately symlinked out of `public/` is no longer served through the
+root-level public asset route. Serve it through `/public/*` (Hono's
+`serveStatic`, unaffected) or copy the file into the tree.

--- a/packages/server/src/http/dev-assets.ts
+++ b/packages/server/src/http/dev-assets.ts
@@ -1,10 +1,11 @@
 import type { Context } from 'hono'
 import { serveStatic } from 'hono/bun'
-import { dirname, extname, resolve, sep } from 'node:path'
+import { dirname, extname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createRequire } from 'node:module'
 import type { Application } from './Application'
 import { registerRootPublicAssets, type RootPublicAssetsConfig } from './public-assets'
+import { isPathWithin, isRealPathWithin } from '../support/contained-path'
 
 declare const Bun: any
 
@@ -136,21 +137,27 @@ export function registerDevAssets(app: Application, options: DevAssetsOptions): 
     app.hono.get(inertiaClientPattern, (ctx) => {
       const relativeRequest = ctx.req.path.slice(inertiaClientBase.length) || inertiaClientRequestPath
 
+      // The configured entry is not request-derived, so it is served without a
+      // containment check: it may legitimately sit outside `inertiaClientDir`
+      // when the resolved module is itself a symlink into another tree.
       if (relativeRequest === inertiaClientRequestPath) {
         return transpileFile(inertiaClientSource, reactImportPattern, tsxTranspiler, tsTranspiler, jsxRuntimeUrl)
       }
 
       const candidatePath = resolve(inertiaClientDir, relativeRequest)
 
-      // A doubled slash in the request path leaves `relativeRequest` absolute,
-      // which `resolve` returns verbatim — so the separator is what keeps a
-      // sibling directory whose name merely extends this one (`…/inertia` vs
-      // `…/inertia-secrets`) out.
-      if (!candidatePath.startsWith(inertiaClientDir + sep)) {
+      if (!isPathWithin(inertiaClientDir, candidatePath)) {
         return ctx.notFound()
       }
 
-      return transpileFile(candidatePath, reactImportPattern, tsxTranspiler, tsTranspiler, jsxRuntimeUrl)
+      return transpileFile(
+        candidatePath,
+        reactImportPattern,
+        tsxTranspiler,
+        tsTranspiler,
+        jsxRuntimeUrl,
+        inertiaClientDir,
+      )
     })
   }
 
@@ -224,11 +231,11 @@ async function handleTranspileRequest(
   const relative = ctx.req.path.slice(prefix.length + 1)
   const fsPath = resolve(resourcesJsDir, relative)
 
-  if (!fsPath.startsWith(resourcesJsDir + sep)) {
+  if (!isPathWithin(resourcesJsDir, fsPath)) {
     return ctx.notFound()
   }
 
-  return transpileFile(fsPath, reactImportPattern, tsxTranspiler, tsTranspiler, jsxRuntimeUrl)
+  return transpileFile(fsPath, reactImportPattern, tsxTranspiler, tsTranspiler, jsxRuntimeUrl, resourcesJsDir)
 }
 
 /**
@@ -238,6 +245,7 @@ async function handleTranspileRequest(
  * @param tsxTranspiler The transpiler for TSX files.
  * @param tsTranspiler The transpiler for TS files.
  * @param jsxRuntimeUrl The URL for the JSX runtime.
+ * @param containmentRoot Directory the resolved file must really live under. Omit for configured (non request-derived) paths.
  * @returns A Promise that resolves to a Response object.
  */
 async function transpileFile(
@@ -246,6 +254,7 @@ async function transpileFile(
   tsxTranspiler: any,
   tsTranspiler: any,
   jsxRuntimeUrl: string,
+  containmentRoot?: string,
 ): Promise<Response> {
   const candidates = buildCandidatePaths(fsPath)
   let filePath: string | undefined
@@ -262,6 +271,14 @@ async function transpileFile(
   }
 
   if (!file || !filePath) {
+    return new Response('Not Found', { status: 404 })
+  }
+
+  // Re-checked here rather than at the call site because the extension probing
+  // above is what settles which file gets read, and because `filePath` is now
+  // known to exist — the precondition for canonicalizing it. Same 404 as a
+  // missing file, so an escape attempt learns nothing from the response.
+  if (containmentRoot && !(await isRealPathWithin(containmentRoot, filePath))) {
     return new Response('Not Found', { status: 404 })
   }
 

--- a/packages/server/src/http/dev-assets.ts
+++ b/packages/server/src/http/dev-assets.ts
@@ -12,6 +12,16 @@ declare const Bun: any
 const DEFAULT_PREFIX = '/resources/js'
 const DEFAULT_VENDOR_PATH = '/vendor/inertia-client.tsx'
 const DEFAULT_JSX_RUNTIME = 'https://esm.sh/react@19.0.0/jsx-dev-runtime?dev'
+const REACT_IMPORT_PATTERN = /from\s+['"]react['"]/u
+
+/** What {@link transpileFile} needs beyond the path it is asked to serve. */
+interface TranspileContext {
+  // Keyed by loader name, so the key that selects a transpiler is the same
+  // expression passed as `transformSync`'s `loader`.
+  tsx: any
+  ts: any
+  jsxRuntimeUrl: string
+}
 
 /**
  * Derive the mount point for the vendored Inertia client from its public
@@ -98,7 +108,6 @@ export function registerDevAssets(app: Application, options: DevAssetsOptions): 
   const jsxRuntimeUrl = options.jsxRuntimeUrl ?? DEFAULT_JSX_RUNTIME
 
   const resourcesJsDir = resolve(resourcesDir, 'js')
-  const reactImportPattern = /from\s+['"]react['"]/u
 
   const transpilerOptions = {
     target: 'browser' as const,
@@ -110,10 +119,13 @@ export function registerDevAssets(app: Application, options: DevAssetsOptions): 
     },
   }
 
-  const tsxTranspiler = new Bun.Transpiler({ loader: 'tsx', ...transpilerOptions })
-  const tsTranspiler = new Bun.Transpiler({ loader: 'ts', ...transpilerOptions })
+  const transpile: TranspileContext = {
+    tsx: new Bun.Transpiler({ loader: 'tsx', ...transpilerOptions }),
+    ts: new Bun.Transpiler({ loader: 'ts', ...transpilerOptions }),
+    jsxRuntimeUrl,
+  }
 
-  app.hono.get(`${prefix}/*`, (ctx) => handleTranspileRequest(ctx, resourcesJsDir, prefix, reactImportPattern, tsxTranspiler, tsTranspiler, jsxRuntimeUrl))
+  app.hono.get(`${prefix}/*`, (ctx) => handleTranspileRequest(ctx, resourcesJsDir, prefix, transpile))
 
   if (cssDir) {
     const cssRewrite = createStaticRewrite(cssRoute)
@@ -141,7 +153,7 @@ export function registerDevAssets(app: Application, options: DevAssetsOptions): 
       // containment check: it may legitimately sit outside `inertiaClientDir`
       // when the resolved module is itself a symlink into another tree.
       if (relativeRequest === inertiaClientRequestPath) {
-        return transpileFile(inertiaClientSource, reactImportPattern, tsxTranspiler, tsTranspiler, jsxRuntimeUrl)
+        return transpileFile(inertiaClientSource, transpile)
       }
 
       const candidatePath = resolve(inertiaClientDir, relativeRequest)
@@ -150,14 +162,7 @@ export function registerDevAssets(app: Application, options: DevAssetsOptions): 
         return ctx.notFound()
       }
 
-      return transpileFile(
-        candidatePath,
-        reactImportPattern,
-        tsxTranspiler,
-        tsTranspiler,
-        jsxRuntimeUrl,
-        inertiaClientDir,
-      )
+      return transpileFile(candidatePath, transpile, inertiaClientDir)
     })
   }
 
@@ -213,20 +218,14 @@ export function createStaticRewrite(route: string): (path: string) => string {
  * @param ctx The request context.
  * @param resourcesJsDir The directory containing the resource files.
  * @param prefix The URL prefix for the request.
- * @param reactImportPattern The regex pattern for detecting React imports.
- * @param tsxTranspiler The transpiler for TSX files.
- * @param tsTranspiler The transpiler for TS files.
- * @param jsxRuntimeUrl The URL for the JSX runtime.
+ * @param transpile The transpilers and JSX runtime to use.
  * @returns A Promise that resolves to a Response object.
  */
 async function handleTranspileRequest(
   ctx: Context,
   resourcesJsDir: string,
   prefix: string,
-  reactImportPattern: RegExp,
-  tsxTranspiler: any,
-  tsTranspiler: any,
-  jsxRuntimeUrl: string,
+  transpile: TranspileContext,
 ): Promise<Response> {
   const relative = ctx.req.path.slice(prefix.length + 1)
   const fsPath = resolve(resourcesJsDir, relative)
@@ -235,25 +234,19 @@ async function handleTranspileRequest(
     return ctx.notFound()
   }
 
-  return transpileFile(fsPath, reactImportPattern, tsxTranspiler, tsTranspiler, jsxRuntimeUrl, resourcesJsDir)
+  return transpileFile(fsPath, transpile, resourcesJsDir)
 }
 
 /**
  * Transpiles a file if it's a TSX or TS file, otherwise serves it as a static asset.
  * @param fsPath The file system path to the file.
- * @param reactImportPattern The regex pattern for detecting React imports.
- * @param tsxTranspiler The transpiler for TSX files.
- * @param tsTranspiler The transpiler for TS files.
- * @param jsxRuntimeUrl The URL for the JSX runtime.
+ * @param transpile The transpilers and JSX runtime to use.
  * @param containmentRoot Directory the resolved file must really live under. Omit for configured (non request-derived) paths.
  * @returns A Promise that resolves to a Response object.
  */
 async function transpileFile(
   fsPath: string,
-  reactImportPattern: RegExp,
-  tsxTranspiler: any,
-  tsTranspiler: any,
-  jsxRuntimeUrl: string,
+  transpile: TranspileContext,
   containmentRoot?: string,
 ): Promise<Response> {
   const candidates = buildCandidatePaths(fsPath)
@@ -274,10 +267,9 @@ async function transpileFile(
     return new Response('Not Found', { status: 404 })
   }
 
-  // Re-checked here rather than at the call site because the extension probing
-  // above is what settles which file gets read, and because `filePath` is now
-  // known to exist — the precondition for canonicalizing it. Same 404 as a
-  // missing file, so an escape attempt learns nothing from the response.
+  // Judged here rather than at the call site because the extension probing above
+  // is what settles which file gets read — and `filePath` is now known to exist,
+  // the precondition for canonicalizing it.
   if (containmentRoot && !(await isRealPathWithin(containmentRoot, filePath))) {
     return new Response('Not Found', { status: 404 })
   }
@@ -285,26 +277,20 @@ async function transpileFile(
   const ext = extname(filePath)
   let source = await file.text()
 
-  if (ext === '.tsx' && !reactImportPattern.test(source)) {
+  if (ext === '.tsx' && !REACT_IMPORT_PATTERN.test(source)) {
     source = "import React from 'react'\n" + source
   }
 
   if (ext === '.tsx' || ext === '.ts') {
-    const transpiled =
-      ext === '.tsx'
-        ? tsxTranspiler.transformSync(source, {
-          loader: 'tsx',
-          sourceMap: isDev() ? 'inline' : false,
-          filename: filePath,
-        })
-        : tsTranspiler.transformSync(source, {
-          loader: 'ts',
-          sourceMap: isDev() ? 'inline' : false,
-          filename: filePath,
-        })
+    const loader = ext === '.tsx' ? 'tsx' : 'ts'
+    const transpiled = transpile[loader].transformSync(source, {
+      loader,
+      sourceMap: isDev() ? 'inline' : false,
+      filename: filePath,
+    })
 
     const helpers = collectJsxHelpers(transpiled)
-    const runtimeShim = helpers.size ? createJsxRuntimeShim(helpers, jsxRuntimeUrl) : ''
+    const runtimeShim = helpers.size ? createJsxRuntimeShim(helpers, transpile.jsxRuntimeUrl) : ''
 
     return new Response(runtimeShim + transpiled, {
       headers: {

--- a/packages/server/src/http/inertia-assets.ts
+++ b/packages/server/src/http/inertia-assets.ts
@@ -1,10 +1,11 @@
 import { serveStatic } from 'hono/bun'
-import { dirname, resolve, join, sep } from 'node:path'
+import { dirname, resolve, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { readFileSync } from 'node:fs'
 import type { Application } from './Application'
 import { createStaticRewrite, registerDevAssets, resolveInertiaClientRoute, type DevAssetsOptions } from './dev-assets'
 import { registerRootPublicAssets } from './public-assets'
+import { isPathWithin, isRealPathWithin } from '../support/contained-path'
 import { parseImportMap } from '../support/import-map'
 import { trimTrailingSlashes } from '../support/trim-slashes'
 import { hash } from '../encryption/Hash'
@@ -110,48 +111,77 @@ export function configureInertiaAssets(app: Application, options: InertiaAssetsO
         throw new Error('Unable to resolve @guren/inertia-client entry')
       }
 
-      const inertiaClientDir = dirname(inertiaClientEntry)
-      const inertiaClientPath = options.inertiaClientPath ?? DEFAULT_VENDOR_CLIENT_PATH
-      const {
-        base: inertiaClientBase,
-        pattern: inertiaClientPattern,
-        requestPath: inertiaClientRequestPath,
-      } = resolveInertiaClientRoute(inertiaClientPath)
-
-      app.hono.get(inertiaClientPattern, async (ctx) => {
-        const relativeRequest = ctx.req.path.slice(inertiaClientBase.length) || inertiaClientRequestPath
-
-        let targetPath: string
-
-        if (relativeRequest === inertiaClientRequestPath) {
-          targetPath = join(inertiaClientDir, 'app.js')
-        } else {
-          targetPath = resolve(inertiaClientDir, relativeRequest)
-
-          if (!targetPath.startsWith(inertiaClientDir + sep)) {
-            return ctx.notFound()
-          }
-        }
-
-        const file = Bun.file(targetPath)
-
-        if (!(await file.exists())) {
-          return ctx.notFound()
-        }
-
-        const contentType = file.type || 'application/javascript; charset=utf-8'
-
-        return new Response(file, {
-          headers: {
-            'Content-Type': contentType,
-            'Cache-Control': 'public, max-age=31536000',
-          },
-        })
-      })
+      registerBuiltInertiaClient(
+        app,
+        dirname(inertiaClientEntry),
+        options.inertiaClientPath ?? DEFAULT_VENDOR_CLIENT_PATH,
+      )
     } catch (error) {
       console.warn('Unable to resolve @guren/inertia-client/app for production serving.', error)
     }
   }
+}
+
+/**
+ * Serves the built Inertia client and the chunks it imports out of the
+ * resolved package directory.
+ *
+ * Split out of {@link configureInertiaAssets} so it can be pointed at a
+ * directory: the caller derives `inertiaClientDir` from `import.meta.resolve`,
+ * which no test can redirect at a fixture.
+ */
+export function registerBuiltInertiaClient(
+  app: Application,
+  inertiaClientDir: string,
+  inertiaClientPath: string,
+): void {
+  const {
+    base: inertiaClientBase,
+    pattern: inertiaClientPattern,
+    requestPath: inertiaClientRequestPath,
+  } = resolveInertiaClientRoute(inertiaClientPath)
+
+  app.hono.get(inertiaClientPattern, async (ctx) => {
+    const relativeRequest = ctx.req.path.slice(inertiaClientBase.length) || inertiaClientRequestPath
+
+    let targetPath: string
+    // Left undefined for the entry: it is derived from configuration rather
+    // than from the request, and a package layout may well have it symlinked
+    // out of `inertiaClientDir`.
+    let containmentRoot: string | undefined
+
+    if (relativeRequest === inertiaClientRequestPath) {
+      targetPath = join(inertiaClientDir, 'app.js')
+    } else {
+      targetPath = resolve(inertiaClientDir, relativeRequest)
+      containmentRoot = inertiaClientDir
+
+      if (!isPathWithin(containmentRoot, targetPath)) {
+        return ctx.notFound()
+      }
+    }
+
+    const file = Bun.file(targetPath)
+
+    if (!(await file.exists())) {
+      return ctx.notFound()
+    }
+
+    // Canonicalized only now that the path exists: `resolve()` above collapsed
+    // `..` without following symlinks, and `new Response(file)` follows them.
+    if (containmentRoot && !(await isRealPathWithin(containmentRoot, targetPath))) {
+      return ctx.notFound()
+    }
+
+    const contentType = file.type || 'application/javascript; charset=utf-8'
+
+    return new Response(file, {
+      headers: {
+        'Content-Type': contentType,
+        'Cache-Control': 'public, max-age=31536000',
+      },
+    })
+  })
 }
 
 export function autoConfigureInertiaAssets(app: Application, options: AutoConfigureInertiaOptions): void {

--- a/packages/server/src/http/inertia-assets.ts
+++ b/packages/server/src/http/inertia-assets.ts
@@ -145,9 +145,9 @@ export function registerBuiltInertiaClient(
     const relativeRequest = ctx.req.path.slice(inertiaClientBase.length) || inertiaClientRequestPath
 
     let targetPath: string
-    // Left undefined for the entry: it is derived from configuration rather
-    // than from the request, and a package layout may well have it symlinked
-    // out of `inertiaClientDir`.
+    // Stays undefined for the entry: it is configuration-derived rather than
+    // request-derived, and a package layout may well have it symlinked out of
+    // `inertiaClientDir`.
     let containmentRoot: string | undefined
 
     if (relativeRequest === inertiaClientRequestPath) {
@@ -167,8 +167,7 @@ export function registerBuiltInertiaClient(
       return ctx.notFound()
     }
 
-    // Canonicalized only now that the path exists: `resolve()` above collapsed
-    // `..` without following symlinks, and `new Response(file)` follows them.
+    // Canonicalized only now: `realpath` needs a path that exists.
     if (containmentRoot && !(await isRealPathWithin(containmentRoot, targetPath))) {
       return ctx.notFound()
     }

--- a/packages/server/src/http/public-assets.ts
+++ b/packages/server/src/http/public-assets.ts
@@ -92,8 +92,7 @@ export function registerRootPublicAssets(app: Application, publicDir: string, co
       return next()
     }
 
-    // Only now that the path exists can it be canonicalized: `resolve()` above
-    // collapsed `..` but did not follow symlinks, and `new Response(file)` will.
+    // Canonicalized only now: `realpath` needs a path that exists.
     if (!(await isRealPathWithin(publicDir, candidatePath))) {
       return next()
     }

--- a/packages/server/src/http/public-assets.ts
+++ b/packages/server/src/http/public-assets.ts
@@ -1,6 +1,7 @@
-import { extname, resolve, sep } from 'node:path'
+import { extname, resolve } from 'node:path'
 import type { Application } from './Application'
 import { trimTrailingSlashes } from '../support/trim-slashes'
+import { isPathWithin, isRealPathWithin } from '../support/contained-path'
 
 declare const Bun: any
 
@@ -81,15 +82,19 @@ export function registerRootPublicAssets(app: Application, publicDir: string, co
 
     const candidatePath = resolve(publicDir, relativePath)
 
-    // Use publicDir + separator to prevent sibling-directory traversal
-    // (e.g., /tmp/public vs /tmp/publicity)
-    if (!candidatePath.startsWith(publicDir + sep) && candidatePath !== publicDir) {
+    if (!isPathWithin(publicDir, candidatePath) && candidatePath !== publicDir) {
       return next()
     }
 
     const file = Bun.file(candidatePath)
 
     if (!(await file.exists())) {
+      return next()
+    }
+
+    // Only now that the path exists can it be canonicalized: `resolve()` above
+    // collapsed `..` but did not follow symlinks, and `new Response(file)` will.
+    if (!(await isRealPathWithin(publicDir, candidatePath))) {
       return next()
     }
 

--- a/packages/server/src/support/contained-path.test.ts
+++ b/packages/server/src/support/contained-path.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, sep } from 'node:path'
+import { isPathWithin, isRealPathWithin } from './contained-path'
+
+describe('isPathWithin', () => {
+  it('accepts a path below the root', () => {
+    expect(isPathWithin(join(sep, 'srv', 'public'), join(sep, 'srv', 'public', 'app.css'))).toBe(true)
+  })
+
+  it('rejects the root itself', () => {
+    expect(isPathWithin(join(sep, 'srv', 'public'), join(sep, 'srv', 'public'))).toBe(false)
+  })
+
+  it('rejects a sibling directory whose name extends the root', () => {
+    expect(isPathWithin(join(sep, 'srv', 'public'), join(sep, 'srv', 'publicity', 'secret'))).toBe(false)
+  })
+
+  it('rejects an unrelated absolute path', () => {
+    expect(isPathWithin(join(sep, 'srv', 'public'), join(sep, 'etc', 'passwd'))).toBe(false)
+  })
+
+  it('treats a root that already ends in a separator the same way', () => {
+    expect(isPathWithin(join(sep, 'srv', 'public') + sep, join(sep, 'srv', 'public', 'app.css'))).toBe(true)
+  })
+})
+
+describe('isRealPathWithin', () => {
+  let tmpRoot: string
+  let root: string
+
+  beforeEach(async () => {
+    // Canonicalized up front: on macOS `os.tmpdir()` sits under `/var`, itself a
+    // symlink to `/private/var`, so a raw path here would fail containment for
+    // reasons that have nothing to do with what these tests assert.
+    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-contained-path-')))
+    root = join(tmpRoot, 'root')
+
+    await mkdir(join(root, 'nested'), { recursive: true })
+    await writeFile(join(root, 'nested', 'inside.txt'), 'inside')
+
+    await mkdir(join(tmpRoot, 'outside'), { recursive: true })
+    await writeFile(join(tmpRoot, 'outside', 'secret.txt'), 'secret')
+  })
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('accepts a real file below the root', async () => {
+    expect(await isRealPathWithin(root, join(root, 'nested', 'inside.txt'))).toBe(true)
+  })
+
+  it('rejects a path reached through a directory symlink pointing out of the root', async () => {
+    symlinkSync(join(tmpRoot, 'outside'), join(root, 'link'))
+
+    // Lexically this is inside `root` — only canonicalization reveals otherwise.
+    expect(isPathWithin(root, join(root, 'link', 'secret.txt'))).toBe(true)
+    expect(await isRealPathWithin(root, join(root, 'link', 'secret.txt'))).toBe(false)
+  })
+
+  it('rejects a file symlink pointing out of the root', async () => {
+    symlinkSync(join(tmpRoot, 'outside', 'secret.txt'), join(root, 'note.txt'))
+
+    expect(await isRealPathWithin(root, join(root, 'note.txt'))).toBe(false)
+  })
+
+  it('accepts files under a root that is itself reached through a symlink', async () => {
+    // Workspace, pnpm, and container layouts all do this. Canonicalizing only
+    // the candidate — and not the root — would reject every asset such an app
+    // serves, while leaving every escape test above green.
+    const linkedRoot = join(tmpRoot, 'root-link')
+    symlinkSync(root, linkedRoot)
+
+    expect(await isRealPathWithin(linkedRoot, join(linkedRoot, 'nested', 'inside.txt'))).toBe(true)
+  })
+
+  it('rejects a candidate that does not exist', async () => {
+    expect(await isRealPathWithin(root, join(root, 'missing.txt'))).toBe(false)
+  })
+
+  it('rejects when the root does not exist', async () => {
+    const missingRoot = join(tmpRoot, 'missing-root')
+
+    expect(await isRealPathWithin(missingRoot, join(missingRoot, 'inside.txt'))).toBe(false)
+  })
+})

--- a/packages/server/src/support/contained-path.test.ts
+++ b/packages/server/src/support/contained-path.test.ts
@@ -32,9 +32,8 @@ describe('isRealPathWithin', () => {
   let root: string
 
   beforeEach(async () => {
-    // Canonicalized up front: on macOS `os.tmpdir()` sits under `/var`, itself a
-    // symlink to `/private/var`, so a raw path here would fail containment for
-    // reasons that have nothing to do with what these tests assert.
+    // Canonicalized up front: `os.tmpdir()` is itself reached through a symlink
+    // on macOS (`/var` → `/private/var`).
     tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-contained-path-')))
     root = join(tmpRoot, 'root')
 
@@ -43,6 +42,11 @@ describe('isRealPathWithin', () => {
 
     await mkdir(join(tmpRoot, 'outside'), { recursive: true })
     await writeFile(join(tmpRoot, 'outside', 'secret.txt'), 'secret')
+
+    // Sibling whose name extends the root's own — the target that distinguishes
+    // a separator-anchored comparison from a bare prefix one.
+    await mkdir(join(tmpRoot, 'root-secrets'), { recursive: true })
+    await writeFile(join(tmpRoot, 'root-secrets', 'secret.txt'), 'secret')
   })
 
   afterEach(() => {
@@ -57,6 +61,19 @@ describe('isRealPathWithin', () => {
     symlinkSync(join(tmpRoot, 'outside'), join(root, 'link'))
 
     // Lexically this is inside `root` — only canonicalization reveals otherwise.
+    expect(isPathWithin(root, join(root, 'link', 'secret.txt'))).toBe(true)
+    expect(await isRealPathWithin(root, join(root, 'link', 'secret.txt'))).toBe(false)
+  })
+
+  it('rejects a symlink to a sibling whose name extends the canonical root', async () => {
+    // The separator has to anchor the comparison on *both* sides. Every other
+    // escape here links to a directory named `outside`, which a bare
+    // `realCandidate.startsWith(realRoot)` also rejects — and the lexical
+    // sibling-prefix cases never reach canonicalization, because the cheap
+    // pre-check refuses them first. Without this fixture, dropping the
+    // separator after canonicalization passes the whole suite.
+    symlinkSync(join(tmpRoot, 'root-secrets'), join(root, 'link'))
+
     expect(isPathWithin(root, join(root, 'link', 'secret.txt'))).toBe(true)
     expect(await isRealPathWithin(root, join(root, 'link', 'secret.txt'))).toBe(false)
   })

--- a/packages/server/src/support/contained-path.ts
+++ b/packages/server/src/support/contained-path.ts
@@ -1,0 +1,52 @@
+import { realpath } from 'node:fs/promises'
+import { sep } from 'node:path'
+
+/**
+ * Is `candidate` a path strictly below `root`, judged lexically?
+ *
+ * The trailing separator is what keeps out a sibling directory whose name
+ * merely extends the root's (`…/inertia` vs `…/inertia-secrets`), and what
+ * rejects an absolute `candidate` — which `resolve()` returns verbatim when a
+ * doubled slash in the request path left the relative part rooted.
+ *
+ * Cheap, but not sufficient on its own: `resolve()` collapses `..` without
+ * following symlinks. Use {@link isRealPathWithin} before reading the file.
+ */
+export function isPathWithin(root: string, candidate: string): boolean {
+  return candidate.startsWith(root.endsWith(sep) ? root : root + sep)
+}
+
+/**
+ * Is `candidate` a path strictly below `root` once both are canonicalized?
+ *
+ * Every reader downstream of these checks (`Bun.file().text()`,
+ * `.arrayBuffer()`, `new Response(file)`) follows symlinks, so a lexical check
+ * alone accepts `<root>/link/secret` where `link` points out of the tree.
+ * *Both* sides are canonicalized: a root reached through a symlink itself is
+ * routine (workspace and pnpm layouts, macOS `/var` → `/private/var`), and
+ * canonicalizing only the candidate would 404 every asset such an app serves.
+ *
+ * Call this on a path already known to exist — a path that does not exist
+ * cannot be read, and `realpath` rejects it, so either way this fails closed.
+ */
+export async function isRealPathWithin(root: string, candidate: string): Promise<boolean> {
+  if (!isPathWithin(root, candidate)) {
+    return false
+  }
+
+  const [realRoot, realCandidate] = await Promise.all([canonicalize(root), canonicalize(candidate)])
+
+  if (!realRoot || !realCandidate) {
+    return false
+  }
+
+  return isPathWithin(realRoot, realCandidate)
+}
+
+async function canonicalize(path: string): Promise<string | undefined> {
+  try {
+    return await realpath(path)
+  } catch {
+    return undefined
+  }
+}

--- a/packages/server/tests/http/asset-fixture.ts
+++ b/packages/server/tests/http/asset-fixture.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach } from 'bun:test'
+import { mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+export interface AssetFixture {
+  /** Absolute path of the directory created for the running test. */
+  readonly root: string
+  /** Absolute path of `segments` inside the fixture root. */
+  path(...segments: string[]): string
+  /** Create a directory (and its parents). Returns its absolute path. */
+  mkdir(relativePath: string): Promise<string>
+  /** Write a file, creating parent directories. Returns its absolute path. */
+  write(relativePath: string, contents: string): Promise<string>
+  /** Link `linkPath` to `targetPath`, both relative to the fixture root. */
+  symlink(targetPath: string, linkPath: string): void
+}
+
+/**
+ * A throwaway directory per test, for the asset handlers that judge whether a
+ * requested file really lives under their configured root.
+ *
+ * The root is canonicalized because `os.tmpdir()` is itself reached through a
+ * symlink on macOS (`/var` → `/private/var`): left raw, a containment assertion
+ * would be reporting the fixture rather than the handler under test.
+ *
+ * Call from a `describe` body, above the `beforeEach` that populates the
+ * directory — Bun runs the hooks in registration order.
+ */
+export function useAssetFixture(prefix: string): AssetFixture {
+  let root: string | undefined
+
+  function fixturePath(...segments: string[]): string {
+    if (!root) {
+      throw new Error('Asset fixture used outside a test; call useAssetFixture() from a describe body.')
+    }
+
+    return join(root, ...segments)
+  }
+
+  beforeEach(() => {
+    root = realpathSync(mkdtempSync(join(tmpdir(), prefix)))
+  })
+
+  afterEach(() => {
+    // Tolerant rather than guarded: teardown should never be what reports a
+    // fixture that was never set up.
+    if (root) {
+      rmSync(root, { recursive: true, force: true })
+    }
+
+    root = undefined
+  })
+
+  return {
+    get root(): string {
+      return fixturePath()
+    },
+    path: fixturePath,
+    async mkdir(relativePath: string): Promise<string> {
+      const target = fixturePath(relativePath)
+      await mkdir(target, { recursive: true })
+      return target
+    },
+    async write(relativePath: string, contents: string): Promise<string> {
+      const target = fixturePath(relativePath)
+      await mkdir(dirname(target), { recursive: true })
+      await Bun.write(target, contents)
+      return target
+    },
+    symlink(targetPath: string, linkPath: string): void {
+      symlinkSync(fixturePath(targetPath), fixturePath(linkPath))
+    },
+  }
+}

--- a/packages/server/tests/http/dev-assets.test.ts
+++ b/packages/server/tests/http/dev-assets.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs'
 import { mkdir } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -18,7 +18,10 @@ describe('registerDevAssets inertia client chunk handling', () => {
   }
 
   beforeEach(async () => {
-    tmpRoot = mkdtempSync(join(tmpdir(), 'guren-dev-assets-'))
+    // Canonicalized because `os.tmpdir()` is reached through a symlink on macOS
+    // (`/var` → `/private/var`); leaving it raw would make containment failures
+    // fixture artifacts rather than findings.
+    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-dev-assets-')))
 
     // minimal resources directory so the helper can mount the transpiler route
     await createFile('resources/js/app.tsx', "export const noop = () => 'noop'\n")
@@ -36,6 +39,14 @@ describe('registerDevAssets inertia client chunk handling', () => {
 
     // Sibling directory whose name extends the inertia client's own.
     await createFile('inertia-secrets/secret.ts', "export const secret = 'leaked'\n")
+
+    // A directory outside both served roots, linked into each of them. The link
+    // is what a lexical containment check cannot see: `resolve()` leaves the
+    // path under the root, and only the reader follows it out.
+    await createFile('outside/secret.ts', "export const secret = 'leaked'\n")
+    await createFile('outside/secret.txt', 'leaked\n')
+    symlinkSync(join(tmpRoot, 'outside'), join(tmpRoot, 'inertia', 'leak'))
+    symlinkSync(join(tmpRoot, 'outside'), join(tmpRoot, 'resources', 'js', 'leak'))
 
     app = new Application()
     registerDevAssets(app, {
@@ -86,10 +97,105 @@ describe('registerDevAssets inertia client chunk handling', () => {
     expect(response.status).toBe(404)
   })
 
+  it('returns 404 for a symlink leading out of the inertia client directory', async () => {
+    const response = await app.fetch(new Request('http://example.com/vendor/leak/secret.ts'))
+
+    expect(response.status).toBe(404)
+  })
+
+  it('transpiles files from the resources directory', async () => {
+    const response = await app.fetch(new Request('http://example.com/resources/js/app.tsx'))
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('noop')
+  })
+
+  it('returns 404 for requests escaping the resources directory', async () => {
+    const response = await app.fetch(new Request(`http://example.com/resources/js/${tmpRoot}/outside/secret.ts`))
+
+    expect(response.status).toBe(404)
+  })
+
+  it('returns 404 for a symlink leading out of the resources directory', async () => {
+    const response = await app.fetch(new Request('http://example.com/resources/js/leak/secret.ts'))
+
+    expect(response.status).toBe(404)
+  })
+
+  it('returns 404 for a non-transpiled file reached through a symlink out of the resources directory', async () => {
+    // A `.txt` target takes the static-serving branch rather than the transpiler,
+    // and containment is judged before that fork — so both branches are covered.
+    const response = await app.fetch(new Request('http://example.com/resources/js/leak/secret.txt'))
+
+    expect(response.status).toBe(404)
+  })
+
+  it('returns 404 for an extensionless request resolving through a symlink out of the resources directory', async () => {
+    // The extension probing that turns `secret` into `secret.ts` is what settles
+    // which file is read, so containment has to be judged after it — not on the
+    // extensionless path the request supplied.
+    const response = await app.fetch(new Request('http://example.com/resources/js/leak/secret'))
+
+    expect(response.status).toBe(404)
+  })
+
   it('serves css assets from the resources directory', async () => {
     const response = await app.fetch(new Request('http://example.com/resources/css/app.css'))
 
     expect(response.status).toBe(200)
     expect(await response.text()).toContain('background: red')
+  })
+})
+
+describe('registerDevAssets with roots reached through symlinks', () => {
+  let tmpRoot: string
+  let app: Application
+
+  const createFile = async (relative: string, contents: string) => {
+    const target = join(tmpRoot, relative)
+    await mkdir(dirname(target), { recursive: true })
+    await Bun.write(target, contents)
+    return target
+  }
+
+  beforeEach(async () => {
+    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-dev-assets-linked-')))
+
+    await createFile('real/resources/js/app.tsx', "export const noop = () => 'noop'\n")
+    await createFile('real/inertia/inertia-client.tsx', "export { chunkValue } from './chunk-helper.ts'\n")
+    await createFile('real/inertia/chunk-helper.ts', 'export const chunkValue = 42\n')
+
+    // Both roots are handed to the app through a symlink — the shape a workspace,
+    // pnpm, or container layout produces. Canonicalizing the candidate without
+    // also canonicalizing the root would 404 every request below.
+    symlinkSync(join(tmpRoot, 'real', 'resources'), join(tmpRoot, 'resources-link'))
+    symlinkSync(join(tmpRoot, 'real', 'inertia'), join(tmpRoot, 'inertia-link'))
+
+    app = new Application()
+    registerDevAssets(app, {
+      resourcesDir: join(tmpRoot, 'resources-link'),
+      inertiaClientSource: join(tmpRoot, 'inertia-link', 'inertia-client.tsx'),
+      inertiaClientPath: '/vendor/inertia-client.tsx',
+      inertiaClient: true,
+      publicPath: false,
+    })
+  })
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('transpiles resources reached through the symlinked root', async () => {
+    const response = await app.fetch(new Request('http://example.com/resources/js/app.tsx'))
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('noop')
+  })
+
+  it('serves inertia client chunks reached through the symlinked root', async () => {
+    const response = await app.fetch(new Request('http://example.com/vendor/chunk-helper.ts'))
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('export const chunkValue = 42')
   })
 })

--- a/packages/server/tests/http/dev-assets.test.ts
+++ b/packages/server/tests/http/dev-assets.test.ts
@@ -1,33 +1,18 @@
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs'
-import { mkdir } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
-import { tmpdir } from 'node:os'
+import { beforeEach, describe, expect, it } from 'bun:test'
 import { Application } from '../../src'
 import { registerDevAssets } from '../../src/runtime'
+import { useAssetFixture } from './asset-fixture'
 
 describe('registerDevAssets inertia client chunk handling', () => {
-  let tmpRoot: string
+  const fixture = useAssetFixture('guren-dev-assets-')
   let app: Application
 
-  const createFile = async (relative: string, contents: string) => {
-    const target = join(tmpRoot, relative)
-    await mkdir(dirname(target), { recursive: true })
-    await Bun.write(target, contents)
-    return target
-  }
-
   beforeEach(async () => {
-    // Canonicalized because `os.tmpdir()` is reached through a symlink on macOS
-    // (`/var` → `/private/var`); leaving it raw would make containment failures
-    // fixture artifacts rather than findings.
-    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-dev-assets-')))
-
     // minimal resources directory so the helper can mount the transpiler route
-    await createFile('resources/js/app.tsx', "export const noop = () => 'noop'\n")
-    await createFile('resources/css/app.css', 'body { background: red; }\n')
+    await fixture.write('resources/js/app.tsx', "export const noop = () => 'noop'\n")
+    await fixture.write('resources/css/app.css', 'body { background: red; }\n')
 
-    const inertiaEntry = await createFile(
+    const inertiaEntry = await fixture.write(
       'inertia/inertia-client.tsx',
       [
         "export const startInertiaClient = () => 'booted'\n",
@@ -35,31 +20,26 @@ describe('registerDevAssets inertia client chunk handling', () => {
       ].join(''),
     )
 
-    await createFile('inertia/chunk-helper.ts', "export const chunkValue = 42\n")
+    await fixture.write('inertia/chunk-helper.ts', "export const chunkValue = 42\n")
 
     // Sibling directory whose name extends the inertia client's own.
-    await createFile('inertia-secrets/secret.ts', "export const secret = 'leaked'\n")
+    await fixture.write('inertia-secrets/secret.ts', "export const secret = 'leaked'\n")
 
-    // A directory outside both served roots, linked into each of them. The link
-    // is what a lexical containment check cannot see: `resolve()` leaves the
-    // path under the root, and only the reader follows it out.
-    await createFile('outside/secret.ts', "export const secret = 'leaked'\n")
-    await createFile('outside/secret.txt', 'leaked\n')
-    symlinkSync(join(tmpRoot, 'outside'), join(tmpRoot, 'inertia', 'leak'))
-    symlinkSync(join(tmpRoot, 'outside'), join(tmpRoot, 'resources', 'js', 'leak'))
+    // A directory outside both served roots, linked into each of them: `resolve()`
+    // leaves the request path under the root, and only the reader follows it out.
+    await fixture.write('outside/secret.ts', "export const secret = 'leaked'\n")
+    await fixture.write('outside/secret.txt', 'leaked\n')
+    fixture.symlink('outside', 'inertia/leak')
+    fixture.symlink('outside', 'resources/js/leak')
 
     app = new Application()
     registerDevAssets(app, {
-      resourcesDir: join(tmpRoot, 'resources'),
+      resourcesDir: fixture.path('resources'),
       inertiaClientSource: inertiaEntry,
       inertiaClientPath: '/vendor/inertia-client.tsx',
       inertiaClient: true,
       publicPath: false,
     })
-  })
-
-  afterEach(() => {
-    rmSync(tmpRoot, { recursive: true, force: true })
   })
 
   it('serves the configured inertia client entry file', async () => {
@@ -91,7 +71,7 @@ describe('registerDevAssets inertia client chunk handling', () => {
     // survives `resolve()` untouched and lands next to — not inside — the
     // inertia client directory.
     const response = await app.fetch(
-      new Request(`http://example.com/vendor/${tmpRoot}/inertia-secrets/secret.ts`),
+      new Request(`http://example.com/vendor/${fixture.root}/inertia-secrets/secret.ts`),
     )
 
     expect(response.status).toBe(404)
@@ -111,7 +91,7 @@ describe('registerDevAssets inertia client chunk handling', () => {
   })
 
   it('returns 404 for requests escaping the resources directory', async () => {
-    const response = await app.fetch(new Request(`http://example.com/resources/js/${tmpRoot}/outside/secret.ts`))
+    const response = await app.fetch(new Request(`http://example.com/resources/js/${fixture.root}/outside/secret.ts`))
 
     expect(response.status).toBe(404)
   })
@@ -148,41 +128,28 @@ describe('registerDevAssets inertia client chunk handling', () => {
 })
 
 describe('registerDevAssets with roots reached through symlinks', () => {
-  let tmpRoot: string
+  const fixture = useAssetFixture('guren-dev-assets-linked-')
   let app: Application
 
-  const createFile = async (relative: string, contents: string) => {
-    const target = join(tmpRoot, relative)
-    await mkdir(dirname(target), { recursive: true })
-    await Bun.write(target, contents)
-    return target
-  }
-
   beforeEach(async () => {
-    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-dev-assets-linked-')))
-
-    await createFile('real/resources/js/app.tsx', "export const noop = () => 'noop'\n")
-    await createFile('real/inertia/inertia-client.tsx', "export { chunkValue } from './chunk-helper.ts'\n")
-    await createFile('real/inertia/chunk-helper.ts', 'export const chunkValue = 42\n')
+    await fixture.write('real/resources/js/app.tsx', "export const noop = () => 'noop'\n")
+    await fixture.write('real/inertia/inertia-client.tsx', "export { chunkValue } from './chunk-helper.ts'\n")
+    await fixture.write('real/inertia/chunk-helper.ts', 'export const chunkValue = 42\n')
 
     // Both roots are handed to the app through a symlink — the shape a workspace,
     // pnpm, or container layout produces. Canonicalizing the candidate without
     // also canonicalizing the root would 404 every request below.
-    symlinkSync(join(tmpRoot, 'real', 'resources'), join(tmpRoot, 'resources-link'))
-    symlinkSync(join(tmpRoot, 'real', 'inertia'), join(tmpRoot, 'inertia-link'))
+    fixture.symlink('real/resources', 'resources-link')
+    fixture.symlink('real/inertia', 'inertia-link')
 
     app = new Application()
     registerDevAssets(app, {
-      resourcesDir: join(tmpRoot, 'resources-link'),
-      inertiaClientSource: join(tmpRoot, 'inertia-link', 'inertia-client.tsx'),
+      resourcesDir: fixture.path('resources-link'),
+      inertiaClientSource: fixture.path('inertia-link', 'inertia-client.tsx'),
       inertiaClientPath: '/vendor/inertia-client.tsx',
       inertiaClient: true,
       publicPath: false,
     })
-  })
-
-  afterEach(() => {
-    rmSync(tmpRoot, { recursive: true, force: true })
   })
 
   it('transpiles resources reached through the symlinked root', async () => {

--- a/packages/server/tests/http/inertia-client-assets.test.ts
+++ b/packages/server/tests/http/inertia-client-assets.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { Application } from '../../src'
+import { registerBuiltInertiaClient } from '../../src/http/inertia-assets'
+
+// `configureInertiaAssets` derives this directory from `import.meta.resolve`,
+// which cannot be pointed at a fixture — hence the handler is registered
+// directly here.
+describe('registerBuiltInertiaClient', () => {
+  let tmpRoot: string
+  let clientDir: string
+  let app: Application
+
+  const createFile = async (relative: string, contents: string) => {
+    const target = join(tmpRoot, relative)
+    await mkdir(dirname(target), { recursive: true })
+    await Bun.write(target, contents)
+    return target
+  }
+
+  beforeEach(async () => {
+    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-inertia-client-')))
+    clientDir = join(tmpRoot, 'client')
+
+    await createFile('client/app.js', 'export const booted = true\n')
+    await createFile('client/chunk-abc.js', 'export const chunkValue = 42\n')
+    await createFile('outside/secret.js', "export const secret = 'leaked'\n")
+
+    // Sibling directory whose name merely extends the client's own.
+    await createFile('client-secrets/secret.js', "export const secret = 'leaked'\n")
+
+    symlinkSync(join(tmpRoot, 'outside'), join(clientDir, 'leak'))
+    symlinkSync(join(tmpRoot, 'outside', 'secret.js'), join(clientDir, 'linked.js'))
+
+    app = new Application()
+    registerBuiltInertiaClient(app, clientDir, '/vendor/inertia-client.tsx')
+  })
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('serves the built client entry', async () => {
+    const response = await app.fetch(new Request('http://example.com/vendor/inertia-client.tsx'))
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('export const booted = true')
+  })
+
+  it('serves sibling chunks the client imports', async () => {
+    const response = await app.fetch(new Request('http://example.com/vendor/chunk-abc.js'))
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('export const chunkValue = 42')
+  })
+
+  it('returns 404 for requests escaping the client directory', async () => {
+    const response = await app.fetch(new Request('http://example.com/vendor/../app.js'))
+
+    expect(response.status).toBe(404)
+  })
+
+  it('returns 404 for a sibling directory whose name extends the client directory', async () => {
+    // The doubled slash leaves the remainder after `/vendor/` absolute, so it
+    // survives `resolve()` untouched and lands next to — not inside — the
+    // client directory.
+    const response = await app.fetch(
+      new Request(`http://example.com/vendor/${tmpRoot}/client-secrets/secret.js`),
+    )
+
+    expect(response.status).toBe(404)
+  })
+
+  it('returns 404 for a directory symlink leading out of the client directory', async () => {
+    const response = await app.fetch(new Request('http://example.com/vendor/leak/secret.js'))
+
+    expect(response.status).toBe(404)
+  })
+
+  it('returns 404 for a file symlink leading out of the client directory', async () => {
+    const response = await app.fetch(new Request('http://example.com/vendor/linked.js'))
+
+    expect(response.status).toBe(404)
+  })
+})
+
+describe('registerBuiltInertiaClient with a client directory reached through a symlink', () => {
+  let tmpRoot: string
+  let app: Application
+
+  beforeEach(async () => {
+    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-inertia-client-linked-')))
+
+    await mkdir(join(tmpRoot, 'real', 'client'), { recursive: true })
+    await Bun.write(join(tmpRoot, 'real', 'client', 'app.js'), 'export const booted = true\n')
+    await Bun.write(join(tmpRoot, 'real', 'client', 'chunk-abc.js'), 'export const chunkValue = 42\n')
+
+    // The shape a published-package install produces: `node_modules/@guren/…`
+    // is a link into another tree.
+    symlinkSync(join(tmpRoot, 'real', 'client'), join(tmpRoot, 'client-link'))
+
+    app = new Application()
+    registerBuiltInertiaClient(app, join(tmpRoot, 'client-link'), '/vendor/inertia-client.tsx')
+  })
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('serves the entry through the symlinked client directory', async () => {
+    const response = await app.fetch(new Request('http://example.com/vendor/inertia-client.tsx'))
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('export const booted = true')
+  })
+
+  it('serves chunks through the symlinked client directory', async () => {
+    const response = await app.fetch(new Request('http://example.com/vendor/chunk-abc.js'))
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('export const chunkValue = 42')
+  })
+})

--- a/packages/server/tests/http/inertia-client-assets.test.ts
+++ b/packages/server/tests/http/inertia-client-assets.test.ts
@@ -1,46 +1,27 @@
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs'
-import { mkdir } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
-import { tmpdir } from 'node:os'
+import { beforeEach, describe, expect, it } from 'bun:test'
 import { Application } from '../../src'
 import { registerBuiltInertiaClient } from '../../src/http/inertia-assets'
+import { useAssetFixture } from './asset-fixture'
 
-// `configureInertiaAssets` derives this directory from `import.meta.resolve`,
-// which cannot be pointed at a fixture — hence the handler is registered
-// directly here.
+// Registered directly rather than through `configureInertiaAssets`, whose
+// client directory comes from `import.meta.resolve` and cannot reach a fixture.
 describe('registerBuiltInertiaClient', () => {
-  let tmpRoot: string
-  let clientDir: string
+  const fixture = useAssetFixture('guren-inertia-client-')
   let app: Application
 
-  const createFile = async (relative: string, contents: string) => {
-    const target = join(tmpRoot, relative)
-    await mkdir(dirname(target), { recursive: true })
-    await Bun.write(target, contents)
-    return target
-  }
-
   beforeEach(async () => {
-    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-inertia-client-')))
-    clientDir = join(tmpRoot, 'client')
-
-    await createFile('client/app.js', 'export const booted = true\n')
-    await createFile('client/chunk-abc.js', 'export const chunkValue = 42\n')
-    await createFile('outside/secret.js', "export const secret = 'leaked'\n")
+    await fixture.write('client/app.js', 'export const booted = true\n')
+    await fixture.write('client/chunk-abc.js', 'export const chunkValue = 42\n')
+    await fixture.write('outside/secret.js', "export const secret = 'leaked'\n")
 
     // Sibling directory whose name merely extends the client's own.
-    await createFile('client-secrets/secret.js', "export const secret = 'leaked'\n")
+    await fixture.write('client-secrets/secret.js', "export const secret = 'leaked'\n")
 
-    symlinkSync(join(tmpRoot, 'outside'), join(clientDir, 'leak'))
-    symlinkSync(join(tmpRoot, 'outside', 'secret.js'), join(clientDir, 'linked.js'))
+    fixture.symlink('outside', 'client/leak')
+    fixture.symlink('outside/secret.js', 'client/linked.js')
 
     app = new Application()
-    registerBuiltInertiaClient(app, clientDir, '/vendor/inertia-client.tsx')
-  })
-
-  afterEach(() => {
-    rmSync(tmpRoot, { recursive: true, force: true })
+    registerBuiltInertiaClient(app, fixture.path('client'), '/vendor/inertia-client.tsx')
   })
 
   it('serves the built client entry', async () => {
@@ -68,7 +49,7 @@ describe('registerBuiltInertiaClient', () => {
     // survives `resolve()` untouched and lands next to — not inside — the
     // client directory.
     const response = await app.fetch(
-      new Request(`http://example.com/vendor/${tmpRoot}/client-secrets/secret.js`),
+      new Request(`http://example.com/vendor/${fixture.root}/client-secrets/secret.js`),
     )
 
     expect(response.status).toBe(404)
@@ -88,26 +69,19 @@ describe('registerBuiltInertiaClient', () => {
 })
 
 describe('registerBuiltInertiaClient with a client directory reached through a symlink', () => {
-  let tmpRoot: string
+  const fixture = useAssetFixture('guren-inertia-client-linked-')
   let app: Application
 
   beforeEach(async () => {
-    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-inertia-client-linked-')))
-
-    await mkdir(join(tmpRoot, 'real', 'client'), { recursive: true })
-    await Bun.write(join(tmpRoot, 'real', 'client', 'app.js'), 'export const booted = true\n')
-    await Bun.write(join(tmpRoot, 'real', 'client', 'chunk-abc.js'), 'export const chunkValue = 42\n')
+    await fixture.write('real/client/app.js', 'export const booted = true\n')
+    await fixture.write('real/client/chunk-abc.js', 'export const chunkValue = 42\n')
 
     // The shape a published-package install produces: `node_modules/@guren/…`
     // is a link into another tree.
-    symlinkSync(join(tmpRoot, 'real', 'client'), join(tmpRoot, 'client-link'))
+    fixture.symlink('real/client', 'client-link')
 
     app = new Application()
-    registerBuiltInertiaClient(app, join(tmpRoot, 'client-link'), '/vendor/inertia-client.tsx')
-  })
-
-  afterEach(() => {
-    rmSync(tmpRoot, { recursive: true, force: true })
+    registerBuiltInertiaClient(app, fixture.path('client-link'), '/vendor/inertia-client.tsx')
   })
 
   it('serves the entry through the symlinked client directory', async () => {

--- a/packages/server/tests/http/public-assets.test.ts
+++ b/packages/server/tests/http/public-assets.test.ts
@@ -1,44 +1,25 @@
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs'
-import { mkdir } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
-import { tmpdir } from 'node:os'
+import { beforeEach, describe, expect, it } from 'bun:test'
 import { Application } from '../../src'
 import { registerRootPublicAssets } from '../../src/http/public-assets'
+import { useAssetFixture } from './asset-fixture'
 
 // These fixtures are real files rather than a stubbed `Bun.file`: containment is
 // a property of the filesystem, so a mocked reader would report every one of
 // these cases as a pass regardless of what the middleware does.
 describe('registerRootPublicAssets', () => {
-  let tmpRoot: string
-  let publicDir: string
+  const fixture = useAssetFixture('guren-public-assets-')
   let app: Application
 
-  const createFile = async (relative: string, contents: string) => {
-    const target = join(tmpRoot, relative)
-    await mkdir(dirname(target), { recursive: true })
-    await Bun.write(target, contents)
-    return target
-  }
-
   beforeEach(async () => {
-    // Canonicalized: `os.tmpdir()` is behind a symlink on macOS.
-    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-public-assets-')))
-    publicDir = join(tmpRoot, 'public')
+    await fixture.write('public/readme.txt', 'public readme\n')
+    await fixture.write('public/nested/notes.txt', 'nested notes\n')
+    await fixture.write('outside/secret.txt', 'secret\n')
 
-    await createFile('public/readme.txt', 'public readme\n')
-    await createFile('public/nested/notes.txt', 'nested notes\n')
-    await createFile('outside/secret.txt', 'secret\n')
-
-    symlinkSync(join(tmpRoot, 'outside'), join(publicDir, 'leak'))
-    symlinkSync(join(tmpRoot, 'outside', 'secret.txt'), join(publicDir, 'linked.txt'))
+    fixture.symlink('outside', 'public/leak')
+    fixture.symlink('outside/secret.txt', 'public/linked.txt')
 
     app = new Application()
-    registerRootPublicAssets(app, publicDir, { extensions: ['txt'] })
-  })
-
-  afterEach(() => {
-    rmSync(tmpRoot, { recursive: true, force: true })
+    registerRootPublicAssets(app, fixture.path('public'), { extensions: ['txt'] })
   })
 
   it('serves matching assets from the public directory', async () => {
@@ -64,7 +45,7 @@ describe('registerRootPublicAssets', () => {
   })
 
   it('falls through for requests escaping the public directory', async () => {
-    const response = await app.fetch(new Request(`http://example.com/${tmpRoot}/outside/secret.txt`))
+    const response = await app.fetch(new Request(`http://example.com/${fixture.root}/outside/secret.txt`))
 
     expect(response.status).toBe(404)
   })
@@ -83,21 +64,14 @@ describe('registerRootPublicAssets', () => {
 })
 
 describe('registerRootPublicAssets with a route prefix', () => {
-  let tmpRoot: string
+  const fixture = useAssetFixture('guren-public-assets-prefix-')
   let app: Application
 
   beforeEach(async () => {
-    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-public-assets-prefix-')))
-
-    await mkdir(join(tmpRoot, 'public', 'assets'), { recursive: true })
-    await Bun.write(join(tmpRoot, 'public', 'assets', 'readme.txt'), 'prefixed readme\n')
+    await fixture.write('public/assets/readme.txt', 'prefixed readme\n')
 
     app = new Application()
-    registerRootPublicAssets(app, join(tmpRoot, 'public'), { extensions: ['txt'], routePrefix: '/assets' })
-  })
-
-  afterEach(() => {
-    rmSync(tmpRoot, { recursive: true, force: true })
+    registerRootPublicAssets(app, fixture.path('public'), { extensions: ['txt'], routePrefix: '/assets' })
   })
 
   it('serves assets under the configured prefix', async () => {
@@ -115,22 +89,15 @@ describe('registerRootPublicAssets with a route prefix', () => {
 })
 
 describe('registerRootPublicAssets with a public directory reached through a symlink', () => {
-  let tmpRoot: string
+  const fixture = useAssetFixture('guren-public-assets-linked-')
   let app: Application
 
   beforeEach(async () => {
-    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-public-assets-linked-')))
-
-    await mkdir(join(tmpRoot, 'real', 'public'), { recursive: true })
-    await Bun.write(join(tmpRoot, 'real', 'public', 'readme.txt'), 'linked readme\n')
-    symlinkSync(join(tmpRoot, 'real', 'public'), join(tmpRoot, 'public-link'))
+    await fixture.write('real/public/readme.txt', 'linked readme\n')
+    fixture.symlink('real/public', 'public-link')
 
     app = new Application()
-    registerRootPublicAssets(app, join(tmpRoot, 'public-link'), { extensions: ['txt'] })
-  })
-
-  afterEach(() => {
-    rmSync(tmpRoot, { recursive: true, force: true })
+    registerRootPublicAssets(app, fixture.path('public-link'), { extensions: ['txt'] })
   })
 
   it('serves assets through the symlinked public directory', async () => {

--- a/packages/server/tests/http/public-assets.test.ts
+++ b/packages/server/tests/http/public-assets.test.ts
@@ -1,80 +1,142 @@
-import { describe, expect, it, spyOn } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { Application } from '../../src'
 import { registerRootPublicAssets } from '../../src/http/public-assets'
 
+// These fixtures are real files rather than a stubbed `Bun.file`: containment is
+// a property of the filesystem, so a mocked reader would report every one of
+// these cases as a pass regardless of what the middleware does.
 describe('registerRootPublicAssets', () => {
-  it('serves matching assets from the public directory', async () => {
-    const middlewares: Array<(ctx: any, next: () => Promise<unknown>) => Promise<Response | void>> = []
-    const app = {
-      hono: {
-        use: (fn: any) => middlewares.push(fn),
-      },
-    } as any
+  let tmpRoot: string
+  let publicDir: string
+  let app: Application
 
-    const bunRef = (
-      globalThis as {
-        Bun?: {
-          file?: (...args: any[]) => any
-        }
-      }
-    ).Bun
-    const originalBunFile = bunRef?.file
-    const fileMock = {
-      exists: async () => true,
-      type: 'text/plain',
-    }
-    if (bunRef) {
-      bunRef.file = () => fileMock
-    }
+  const createFile = async (relative: string, contents: string) => {
+    const target = join(tmpRoot, relative)
+    await mkdir(dirname(target), { recursive: true })
+    await Bun.write(target, contents)
+    return target
+  }
 
-    try {
-      registerRootPublicAssets(app, '/public', { extensions: ['txt'], routePrefix: '/assets' })
-      expect(middlewares).toHaveLength(1)
+  beforeEach(async () => {
+    // Canonicalized: `os.tmpdir()` is behind a symlink on macOS.
+    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-public-assets-')))
+    publicDir = join(tmpRoot, 'public')
 
-      const nextRef = { fn: async () => undefined }
-      const nextSpy = spyOn(nextRef, 'fn')
-      const response = await middlewares[0]({ req: { path: '/assets/readme.txt' } }, nextRef.fn)
+    await createFile('public/readme.txt', 'public readme\n')
+    await createFile('public/nested/notes.txt', 'nested notes\n')
+    await createFile('outside/secret.txt', 'secret\n')
 
-      expect(nextSpy).not.toHaveBeenCalled()
-      expect(response?.headers.get('Cache-Control')).toContain('max-age')
-      expect(response?.headers.get('Content-Type')).toContain('text/plain')
-    } finally {
-      if (bunRef) {
-        bunRef.file = originalBunFile
-      }
-    }
+    symlinkSync(join(tmpRoot, 'outside'), join(publicDir, 'leak'))
+    symlinkSync(join(tmpRoot, 'outside', 'secret.txt'), join(publicDir, 'linked.txt'))
+
+    app = new Application()
+    registerRootPublicAssets(app, publicDir, { extensions: ['txt'] })
   })
 
-  it('skips unmatched routes', async () => {
-    const middlewares: Array<(ctx: any, next: () => Promise<unknown>) => Promise<Response | void>> = []
-    const app = {
-      hono: {
-        use: (fn: any) => middlewares.push(fn),
-      },
-    } as any
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true })
+  })
 
-    const bunRef = (
-      globalThis as {
-        Bun?: {
-          file?: (...args: any[]) => any
-        }
-      }
-    ).Bun
-    const originalBunFile = bunRef?.file
-    if (bunRef) {
-      bunRef.file = () => ({ exists: async () => true })
-    }
+  it('serves matching assets from the public directory', async () => {
+    const response = await app.fetch(new Request('http://example.com/readme.txt'))
 
-    try {
-      registerRootPublicAssets(app, '/public', { extensions: ['txt'], routePrefix: '/assets' })
-      const nextRef = { fn: async () => undefined }
-      const nextSpy = spyOn(nextRef, 'fn')
-      await middlewares[0]({ req: { path: '/static/logo.png' } }, nextRef.fn)
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('public readme')
+    expect(response.headers.get('Cache-Control')).toContain('max-age')
+    expect(response.headers.get('Content-Type')).toContain('text/plain')
+  })
 
-      expect(nextSpy).toHaveBeenCalled()
-    } finally {
-      if (bunRef) {
-        bunRef.file = originalBunFile
-      }
-    }
+  it('serves matching assets from nested directories', async () => {
+    const response = await app.fetch(new Request('http://example.com/nested/notes.txt'))
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('nested notes')
+  })
+
+  it('falls through for extensions outside the allowlist', async () => {
+    const response = await app.fetch(new Request('http://example.com/readme.md'))
+
+    expect(response.status).toBe(404)
+  })
+
+  it('falls through for requests escaping the public directory', async () => {
+    const response = await app.fetch(new Request(`http://example.com/${tmpRoot}/outside/secret.txt`))
+
+    expect(response.status).toBe(404)
+  })
+
+  it('falls through for a directory symlink leading out of the public directory', async () => {
+    const response = await app.fetch(new Request('http://example.com/leak/secret.txt'))
+
+    expect(response.status).toBe(404)
+  })
+
+  it('falls through for a file symlink leading out of the public directory', async () => {
+    const response = await app.fetch(new Request('http://example.com/linked.txt'))
+
+    expect(response.status).toBe(404)
+  })
+})
+
+describe('registerRootPublicAssets with a route prefix', () => {
+  let tmpRoot: string
+  let app: Application
+
+  beforeEach(async () => {
+    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-public-assets-prefix-')))
+
+    await mkdir(join(tmpRoot, 'public', 'assets'), { recursive: true })
+    await Bun.write(join(tmpRoot, 'public', 'assets', 'readme.txt'), 'prefixed readme\n')
+
+    app = new Application()
+    registerRootPublicAssets(app, join(tmpRoot, 'public'), { extensions: ['txt'], routePrefix: '/assets' })
+  })
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('serves assets under the configured prefix', async () => {
+    const response = await app.fetch(new Request('http://example.com/assets/readme.txt'))
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('prefixed readme')
+  })
+
+  it('skips routes outside the configured prefix', async () => {
+    const response = await app.fetch(new Request('http://example.com/static/readme.txt'))
+
+    expect(response.status).toBe(404)
+  })
+})
+
+describe('registerRootPublicAssets with a public directory reached through a symlink', () => {
+  let tmpRoot: string
+  let app: Application
+
+  beforeEach(async () => {
+    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-public-assets-linked-')))
+
+    await mkdir(join(tmpRoot, 'real', 'public'), { recursive: true })
+    await Bun.write(join(tmpRoot, 'real', 'public', 'readme.txt'), 'linked readme\n')
+    symlinkSync(join(tmpRoot, 'real', 'public'), join(tmpRoot, 'public-link'))
+
+    app = new Application()
+    registerRootPublicAssets(app, join(tmpRoot, 'public-link'), { extensions: ['txt'] })
+  })
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('serves assets through the symlinked public directory', async () => {
+    const response = await app.fetch(new Request('http://example.com/readme.txt'))
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('linked readme')
   })
 })

--- a/packages/server/tests/http/serve-static-symlinks.test.ts
+++ b/packages/server/tests/http/serve-static-symlinks.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { Application } from '../../src'
+import { registerDevAssets } from '../../src/runtime'
+
+/**
+ * Pins the boundary of Guren's symlink containment.
+ *
+ * The framework's own asset handlers — the dev transpiler, both Inertia client
+ * routes, and the root-level public asset middleware — reject a target whose
+ * real location is outside the configured root. The `/public/*` and
+ * `/resources/css/*` routes are not framework handlers: they are delegated to
+ * Hono's `serveStatic`, which follows symlinks out of its root by design (as
+ * nginx and `express.static` do). It normalizes `..` and absolute remainders,
+ * so lexical traversal is still refused there.
+ *
+ * These assertions record that split rather than endorse it. Two of them assert
+ * a leak: if a future Hono release, or a decision here to stop delegating,
+ * changes that, this file is what says so instead of a comment nobody reruns.
+ */
+describe('symlink containment across the asset routes', () => {
+  let tmpRoot: string
+  let app: Application
+
+  beforeEach(async () => {
+    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-static-symlink-')))
+
+    await mkdir(join(tmpRoot, 'resources', 'js'), { recursive: true })
+    await mkdir(join(tmpRoot, 'resources', 'css'), { recursive: true })
+    await mkdir(join(tmpRoot, 'public'), { recursive: true })
+    await mkdir(join(tmpRoot, 'outside'), { recursive: true })
+
+    await Bun.write(join(tmpRoot, 'outside', 'secret.txt'), 'leaked\n')
+    await Bun.write(join(tmpRoot, 'outside', 'secret.css'), '/* leaked */\n')
+
+    // One directory outside every root, linked into the public and css roots.
+    symlinkSync(join(tmpRoot, 'outside'), join(tmpRoot, 'public', 'leak'))
+    symlinkSync(join(tmpRoot, 'outside'), join(tmpRoot, 'resources', 'css', 'leak'))
+
+    app = new Application()
+    registerDevAssets(app, {
+      resourcesDir: join(tmpRoot, 'resources'),
+      publicDir: join(tmpRoot, 'public'),
+      inertiaClient: false,
+    })
+  })
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('refuses a symlink out of the public root on the framework-served root route', async () => {
+    const response = await app.fetch(new Request('http://example.com/leak/secret.txt'))
+
+    expect(response.status).toBe(404)
+  })
+
+  it('still follows a symlink out of the public root under /public/* (delegated to serveStatic)', async () => {
+    const response = await app.fetch(new Request('http://example.com/public/leak/secret.txt'))
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('leaked')
+  })
+
+  it('still follows a symlink out of the css root under /resources/css/* (delegated to serveStatic)', async () => {
+    const response = await app.fetch(new Request('http://example.com/resources/css/leak/secret.css'))
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('leaked')
+  })
+
+  it('refuses lexical traversal under /public/* even though serveStatic follows symlinks', async () => {
+    const response = await app.fetch(new Request(`http://example.com/public/${tmpRoot}/outside/secret.txt`))
+
+    expect(response.status).toBe(404)
+  })
+})

--- a/packages/server/tests/http/serve-static-symlinks.test.ts
+++ b/packages/server/tests/http/serve-static-symlinks.test.ts
@@ -1,55 +1,45 @@
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs'
-import { mkdir } from 'node:fs/promises'
-import { join } from 'node:path'
-import { tmpdir } from 'node:os'
+import { beforeEach, describe, expect, it } from 'bun:test'
 import { Application } from '../../src'
 import { registerDevAssets } from '../../src/runtime'
+import { useAssetFixture } from './asset-fixture'
 
 /**
- * Pins the boundary of Guren's symlink containment.
+ * Pins the containment the framework itself enforces, on routes that sit beside
+ * ones it does not.
  *
- * The framework's own asset handlers — the dev transpiler, both Inertia client
- * routes, and the root-level public asset middleware — reject a target whose
- * real location is outside the configured root. The `/public/*` and
- * `/resources/css/*` routes are not framework handlers: they are delegated to
- * Hono's `serveStatic`, which follows symlinks out of its root by design (as
- * nginx and `express.static` do). It normalizes `..` and absolute remainders,
- * so lexical traversal is still refused there.
+ * Guren's own asset handlers — the dev transpiler, both Inertia client routes,
+ * and the root-level public asset middleware — reject a target whose real
+ * location is outside the configured root. `/public/*` and `/resources/css/*`
+ * are not Guren handlers: they are delegated to Hono's `serveStatic`, whose path
+ * handling makes lexical escape unavailable but which follows symlinks out of
+ * its root by design, as nginx and `express.static` do.
  *
- * These assertions record that split rather than endorse it. Two of them assert
- * a leak: if a future Hono release, or a decision here to stop delegating,
- * changes that, this file is what says so instead of a comment nobody reruns.
+ * So the assertions below are deliberately asymmetric. What Guren controls is
+ * asserted; the symlink behaviour of the delegated routes is not, in either
+ * direction — asserting the current leak would commit the suite to it and turn
+ * red if Hono ever tightens. Deployments that must not follow symlinks out of
+ * `public/` should not rely on `/public/*` for that.
  */
 describe('symlink containment across the asset routes', () => {
-  let tmpRoot: string
+  const fixture = useAssetFixture('guren-static-symlink-')
   let app: Application
 
   beforeEach(async () => {
-    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'guren-static-symlink-')))
-
-    await mkdir(join(tmpRoot, 'resources', 'js'), { recursive: true })
-    await mkdir(join(tmpRoot, 'resources', 'css'), { recursive: true })
-    await mkdir(join(tmpRoot, 'public'), { recursive: true })
-    await mkdir(join(tmpRoot, 'outside'), { recursive: true })
-
-    await Bun.write(join(tmpRoot, 'outside', 'secret.txt'), 'leaked\n')
-    await Bun.write(join(tmpRoot, 'outside', 'secret.css'), '/* leaked */\n')
+    await fixture.mkdir('resources/css')
+    await fixture.mkdir('public')
+    await fixture.write('outside/secret.txt', 'leaked\n')
+    await fixture.write('outside/secret.css', '/* leaked */\n')
 
     // One directory outside every root, linked into the public and css roots.
-    symlinkSync(join(tmpRoot, 'outside'), join(tmpRoot, 'public', 'leak'))
-    symlinkSync(join(tmpRoot, 'outside'), join(tmpRoot, 'resources', 'css', 'leak'))
+    fixture.symlink('outside', 'public/leak')
+    fixture.symlink('outside', 'resources/css/leak')
 
     app = new Application()
     registerDevAssets(app, {
-      resourcesDir: join(tmpRoot, 'resources'),
-      publicDir: join(tmpRoot, 'public'),
+      resourcesDir: fixture.path('resources'),
+      publicDir: fixture.path('public'),
       inertiaClient: false,
     })
-  })
-
-  afterEach(() => {
-    rmSync(tmpRoot, { recursive: true, force: true })
   })
 
   it('refuses a symlink out of the public root on the framework-served root route', async () => {
@@ -58,22 +48,21 @@ describe('symlink containment across the asset routes', () => {
     expect(response.status).toBe(404)
   })
 
-  it('still follows a symlink out of the public root under /public/* (delegated to serveStatic)', async () => {
-    const response = await app.fetch(new Request('http://example.com/public/leak/secret.txt'))
+  // The two below assert the property (no outside content served), not a
+  // mechanism: Hono rejects the doubled separator before joining, and its
+  // `defaultJoin` would treat the remainder as relative anyway rather than
+  // honouring it as absolute. Lexical escape is structurally unavailable there,
+  // which is why the symlink case is the one that gets through.
+  it('serves nothing from outside the root for an absolute-path request under /public/*', async () => {
+    const response = await app.fetch(new Request(`http://example.com/public/${fixture.root}/outside/secret.txt`))
 
-    expect(response.status).toBe(200)
-    expect(await response.text()).toContain('leaked')
+    expect(response.status).toBe(404)
   })
 
-  it('still follows a symlink out of the css root under /resources/css/* (delegated to serveStatic)', async () => {
-    const response = await app.fetch(new Request('http://example.com/resources/css/leak/secret.css'))
-
-    expect(response.status).toBe(200)
-    expect(await response.text()).toContain('leaked')
-  })
-
-  it('refuses lexical traversal under /public/* even though serveStatic follows symlinks', async () => {
-    const response = await app.fetch(new Request(`http://example.com/public/${tmpRoot}/outside/secret.txt`))
+  it('serves nothing from outside the root for an absolute-path request under /resources/css/*', async () => {
+    const response = await app.fetch(
+      new Request(`http://example.com/resources/css/${fixture.root}/outside/secret.css`),
+    )
 
     expect(response.status).toBe(404)
   })


### PR DESCRIPTION
## Summary

The four asset handlers resolved a request-derived path and then checked containment lexically (`resolve(dir, req)` followed by `startsWith(dir + sep)`). `path.resolve()` collapses `..` but does not follow symlinks, while every reader downstream of these checks does — `Bun.file().text()`, `.arrayBuffer()`, and `new Response(file)`. So a request for `resources/js/link/secret.txt`, where `link` points out of the tree, resolved to a path lexically under the root, passed the check, and was served from wherever the link led.

Containment is now judged on canonicalized paths. Two placement decisions carry the fix:

- **After the target is known to exist** — that is the precondition for canonicalizing it, and for the dev transpiler it is also the point at which extension probing (`secret` → `secret.ts`) has settled which file will actually be read. Judging the extensionless path the request supplied would miss it.
- **Both sides canonicalized, not just the candidate.** A root reached through a symlink is routine (workspace and pnpm layouts, containers, macOS `/var` → `/private/var`). Canonicalizing only the candidate refuses escapes just as well *and* 404s every asset such a deployment serves — while leaving every escape test green. See Risk Assessment for how that is pinned.

The four call sites now share `isPathWithin` / `isRealPathWithin` from a new internal `support/contained-path.ts`, so the decision lives in one place rather than in four copies of a `startsWith`. This subsumes the pending task to extract those checks into a shared helper.

Configured entry points stay exempt: they come from configuration rather than from the request, and a package layout may legitimately have the resolved module symlinked out of its own directory. A requester cannot steer which file the exempt branch serves — it is always the fixed configured target.

Closing this needs local write access inside the project, so it is defense in depth rather than a live hole. It is worth closing because the containment check read as authoritative and was shared across four sites.

## Scope

`server` — `http/dev-assets.ts` (the `/vendor/*` route and `handleTranspileRequest`), `http/inertia-assets.ts` (production handler), `http/public-assets.ts` (root-level public asset middleware), and the new `support/contained-path.ts`.

The production Inertia client handler is extracted as `registerBuiltInertiaClient`, because its directory comes from `import.meta.resolve` and no test could point it at a fixture — it previously had no coverage at all. The function is not exported from `runtime/index.ts` and is not reachable from `@guren/core`, so it stays internal and the changeset remains a patch.

### Refactoring carried in the same change

A cleanup pass rode along with the last commit, which is why `dev-assets.ts` and the test files show more churn than the containment fix alone would produce:

- `tests/http/asset-fixture.ts` (new) — `useAssetFixture()` registers the per-test tmpdir and teardown and exposes `root` / `path()` / `mkdir()` / `write()` / `symlink()`. It replaced eight copies of the mkdtemp + `realpathSync` + `rmSync` boilerplate and three identical `createFile` closures. The reason the root is canonicalized now lives in one doc comment instead of four. Kept in `tests/http/` rather than a package-level helpers file, since this package has none across its 81 test files.
- `transpileFile` went from six positional parameters to three and `handleTranspileRequest` from seven to four, with the four always-co-travelling arguments collected into a `TranspileContext` built once at registration.
- The duplicated `tsxTranspiler.transformSync(…) : tsTranspiler.transformSync(…)` ternary collapsed: `loader` is derived once and used as both the key selecting the transpiler and the value passed to `transformSync`, so the pairing cannot drift.
- `reactImportPattern` hoisted to a module-level constant (no `/g`, so `.test()` stays stateless).
- Comments that restated the code were cut; the ones carrying a non-obvious *why* were kept.

The mutation table below was re-derived after this pass, so it reflects the refactored code rather than the original.

## Risk Assessment

**Behavior change.** An asset deliberately symlinked out of `public/` is no longer served through the root-level public asset route. Copy the file into the tree instead.

**Not covered: the delegated static routes.** `/public/*` and `/resources/css/*` go to Hono's `serveStatic`, whose path handling leaves no lexical escape but which follows symlinks out of its root by design, as nginx and `express.static` do. So the same linked file the root-level route now refuses still serves under `/public/*`. This is stated explicitly rather than papered over, and a deployment that must not follow symlinks out of `public/` should not rely on `/public/*` for that.

Hono's `onFound` hook cannot close it — it runs after `getContent` has already read the file and cannot reject — so guarding those routes would mean either mirroring Hono's own path resolution in a second place (a second path computation that has to track upstream forever) or reimplementing static serving with its range, etag, precompressed, and mime behavior. Both were judged worse than the gap.

**TOCTOU remains.** Replacing the target with a symlink between the canonicalization and the read is not preventable with path-based checks; it needs descriptor-relative APIs that Bun does not expose. It is the same local-write actor already required to plant a symlink at all, so the boundary is unchanged.

**Cost.** Two `realpath` calls per *served* asset. The check sits after the existence test, so 404s still touch the filesystem no more than before, and served requests already do an `exists()` plus a read plus (in dev) a transpile.

**Mutation-verified, in both directions.** A guard that cannot fail proves nothing, and for a two-sided check the over-restrictive mistake passes every negative test:

| Mutation | Tests that fail |
|---|---|
| Lexical only (revert the fix) | 14 |
| Canonicalize the candidate but not the root | 5 — all positive, symlinked-root cases |
| Drop the separator *after* canonicalization | 1 |

The third was a genuine gap found in review: every escape fixture linked to a directory named `outside`, which a bare prefix comparison also rejects, and the lexical sibling-prefix cases never reach canonicalization because the cheap pre-check refuses them first. A symlink to a sibling whose name extends the root's real path closes it.

`public-assets.test.ts` moves from a stubbed `Bun.file` to real filesystem fixtures. Containment is a property of the filesystem, so a mocked reader reports every one of these cases as a pass regardless of what the middleware does.

## Validation

- [x] `bun run build` — via `bun run build:clean`, all packages green
- [x] `bun run typecheck` — clean at the repo root
- [x] `bun run test`

```
bun run test:bun     → 3899 pass, 55 skip, 0 fail (3954 across 237 files)
server http+support  → 368 pass, 0 fail (19 files)
audit:core-first     → passed
audit:docs           → passed
```

Two notes on the suite, both checked rather than assumed:

- `packages/cli`'s subprocess-spawning tests (`bin-error-output`, `check-ci-flag`, `i18n-types-compile`) fail under heavy machine load by pinning the 5000ms timeout, and one hang cascades into several apparent failures. They pass in isolation (15 pass, 11.5s) and the full suite is green on an idle machine.
- `web/`'s `HomeController` and `DocsStore` tests fail intermittently on the same timeout. Rebuilding `packages/server` from before these commits and re-running three times reproduced 1 failure of 16 every time, so this predates the branch. Filed separately along with a pre-existing production Inertia entry-resolution problem noticed while adding coverage there.

Templates were not touched, so the starter-template audits and smokes do not apply.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
