### PR TITLE
feat(cli): flag a routes file the entry registrar never calls

### DIFF
--- a/.changeset/orphaned-routes-file-check.md
+++ b/.changeset/orphaned-routes-file-check.md
@@ -1,0 +1,17 @@
+---
+"@guren/cli": minor
+---
+
+`guren check` now reports a `routes/*.ts` file whose registrar nothing reachable from the app's entry registrar calls.
+
+Such a file compiles, type-checks, and reads as wired from the inside — its only symptom is a 404 in production. That is the state `guren add admin|oauth|resource|auth` left behind in any app scaffolded from the blog blueprint, because the wiring step matched only a registrar whose parameter was literally named `router`. Fixing the scaffolders does nothing for the apps already in that state; this reports them, and names the import-and-call line to add. It also covers the files nothing wires automatically — `make:route` writes its routes file and leaves mounting to you.
+
+Mounting spreads outward from the entry file (`routes/web.ts`, or `--routes`) and is tracked per exported name: a file counts as mounted once some already-mounted file uses a binding that traces back to one of its registrar exports. So a nested registrar, a barrel re-export, a namespace import, an `await import()`, and a registrar the entry only re-exports all count — while an import with no call, an import of some *other* export from the same file, and a registrar called only from a file that nothing calls in turn do not. A module's own `modules/<name>/routes.ts` is out of scope: `defineModule({ routes })` mounts it without going through the entry registrar. Content-activated — an app whose `routes/` holds nothing but the entry file contributes no results.
+
+Two wirings it cannot see, both reported as unmounted: a chain that leaves `routes/` (`web.ts` → `app/routing.ts` → `routes/admin.ts`), and a registrar reached by anything less direct than importing its file.
+
+Reported as a `warn`, like the console-command registration check, so plain `guren check` still exits zero. `guren check --ci` gates on non-advisory warns, so a project already using that flag will start failing on an unmounted routes file — which is the point, but it can surface on upgrade rather than on the commit that introduced it.
+
+That gate is in the CI workflow both app templates scaffold, and `make:route` deliberately leaves mounting to you — so `make:route` now says so on the spot rather than letting the next push explain it.
+
+Also fixes the entry file being *assumed* to be `routes/web.ts` when no `--routes` was given: `guren check` and `guren doctor` now share one candidate list, so the API-only scaffold (`routes/api.ts`, no `routes/web.ts`) is read against its real entry.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ bunx guren model:list           # List models with relationships
 bunx guren model:list --format json  # Models as JSON
 
 # Integrity checking
-bunx guren check                # Validate route↔controller↔page consistency, console command registration, Postgres timestamp time zones, architecture boundaries, and doc links (informational; only --arch/--docs/--spec set the exit code)
+bunx guren check                # Validate route↔controller↔page consistency, console command registration, route registrar wiring (every routes/*.ts reached from the entry registrar), Postgres timestamp time zones, architecture boundaries, and doc links (informational; only --arch/--docs/--spec set the exit code)
 bunx guren check --json         # Check results as JSON
 bunx guren check --arch         # Architecture boundary checks only (guren.arch.ts) — fast path for edit hooks
 bunx guren check --docs         # Doc-link checks only: OKF frontmatter (type/entities/related) + body markdown links + @docs tags (exits non-zero on failures)
@@ -383,6 +383,7 @@ export const handler = createLambdaHandler(app)
 | `packages/cli/src/route-registrar.ts` | The one rule for what counts as an app's route registrar, and the patch that wires a scaffolded routes file into it. `load-routes.ts` resolves the same export names at runtime — a scaffolder that picked its own target patches a function the framework never calls, and the routes look wired while mounting nothing |
 | `packages/cli/src/check.ts` | AI agent: integrity checking |
 | `packages/cli/src/console-check.ts` | AI agent: console command registration checks (part of `guren check`) |
+| `packages/cli/src/routes-check.ts` | AI agent: route registrar wiring checks — a `routes/*.ts` the entry registrar never calls (part of `guren check`) |
 | `packages/cli/src/schema-check.ts` | AI agent: Postgres `timestamptz` schema checks (part of `guren check`) |
 | `packages/cli/src/arch-check.ts` | AI agent: architecture boundary checking (`guren.arch.ts`, see RFC 0002) |
 | `packages/cli/src/arch/index.ts` | `defineArchRules()` + types, published as the `@guren/cli/arch` subpath |

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -94,7 +94,7 @@ Validate your app before shipping — these commands are also designed for AI co
 
 | Command | Description | Example |
 |---------|-------------|---------|
-| `check` | Validate integrity across routes, controllers, pages, and models, plus doc links, spec-view freshness, and architecture boundaries | `bunx guren check --json` |
+| `check` | Validate integrity across routes, controllers, pages, and models — including whether every file in `routes/` is actually reached from your entry registrar — plus doc links, spec-view freshness, and architecture boundaries | `bunx guren check --json` |
 | `audit` | Security audit: missing input validation or authentication on mutating routes, raw SQL with interpolation, hardcoded credentials, disabled security defaults, mass-assignment configuration, sensitive columns not listed in `static hidden`, emailed links built from the request host | `bunx guren audit --json` |
 | `doctor` | Project health report (env, config, generated files) with actionable next steps | `bunx guren doctor --next` |
 | `context [Entity]` | Project context map — or, with an entity name, everything about one model: table, relationships, routes with schemas, pages with Props, resource, policy, linked docs (`--module` disambiguates, `"app"` = project root) | `bunx guren context User --json` |

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -92,7 +92,7 @@ bunx guren add admin --public
 
 | コマンド | 説明 | 例 |
 |---------|------|-----|
-| `check` | ルート・コントローラ・ページ・モデル間の整合性に加え、docリンク・スペックビューの鮮度・アーキテクチャ境界を検証 | `bunx guren check --json` |
+| `check` | ルート・コントローラ・ページ・モデル間の整合性（`routes/` 配下の各ファイルがエントリのレジストラから実際に呼ばれているかを含む）に加え、docリンク・スペックビューの鮮度・アーキテクチャ境界を検証 | `bunx guren check --json` |
 | `audit` | セキュリティ監査: 変更系ルートのバリデーション/認証の欠如、文字列補間付き生SQL、ハードコードされた認証情報、無効化されたセキュリティ既定値、mass assignment 設定、`static hidden` 未登録の機微カラム、リクエストのホストから組み立てられたメール内リンクを検査 | `bunx guren audit --json` |
 | `doctor` | プロジェクトの健全性レポート(環境変数・設定・生成ファイル)と次のアクション | `bunx guren doctor --next` |
 | `context [Entity]` | プロジェクトコンテキストマップ。エンティティ名を渡すと1モデルのすべて — テーブル・リレーション・スキーマ付きルート・Props付きページ・Resource・Policy・紐付きdocs — を出力(同名モデルは `--module` で解決、`"app"` はプロジェクトルート) | `bunx guren context User --json` |

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -92,13 +92,8 @@ const FIELDS_ARG = {
   description: 'Comma-separated fields, e.g. "title:string,body:text,published:boolean" (append ? for nullable).',
 }
 
-function createMakeCommand(
-  commandName: string,
-  description: string,
-  argDescription: string,
-  makeFn: (name: string, options: WriterOptions) => Promise<string>,
-  resourceName: string,
-) {
+function createMakeCommand(spec: MakeCommandSpec) {
+  const { name: commandName, description, argDescription, makeFn, resourceName, nextStep } = spec
   return defineCommand({
     meta: { name: commandName, description },
     args: {
@@ -109,6 +104,7 @@ function createMakeCommand(
     async run({ args }) {
       const file = await makeFn(args.name, toWriterOptions(args))
       consola.success(`${resourceName} created at ${file}`)
+      if (nextStep) consola.info(nextStep)
     },
   })
 }
@@ -119,13 +115,37 @@ type MakeCommandSpec = {
   argDescription: string
   makeFn: (name: string, options: WriterOptions) => Promise<string>
   resourceName: string
+  /**
+   * Printed after the success line, for a generator whose output does not
+   * work until the user does something else.
+   *
+   * Only `make:route` needs one: every other generator here writes something
+   * the framework discovers, while a routes file does nothing until its
+   * registrar is called. `guren check` now reports that gap and the
+   * scaffolded CI workflow gates on it, so a generator that stayed silent
+   * would hand the user a red build to diagnose later.
+   */
+  nextStep?: string
 }
 
 const makeCommandSpecs: MakeCommandSpec[] = [
   { name: 'make:controller', description: 'Generate a new controller file.', argDescription: 'Controller class name', makeFn: makeController, resourceName: 'Controller' },
   { name: 'make:model', description: 'Generate a new model file.', argDescription: 'Model class name', makeFn: makeModel, resourceName: 'Model' },
   { name: 'make:view', description: 'Generate a new view component.', argDescription: 'View component path', makeFn: makeView, resourceName: 'View' },
-  { name: 'make:route', description: 'Generate a new route group.', argDescription: 'Route group name', makeFn: makeRoute, resourceName: 'Route' },
+  {
+    name: 'make:route',
+    description: 'Generate a new route group.',
+    argDescription: 'Route group name',
+    makeFn: makeRoute,
+    resourceName: 'Route',
+    // Deliberately says nothing about `guren check` reporting it: that check
+    // scopes to the project's own `routes/`, and `--module` sends this file to
+    // `modules/<name>/routes/` instead, where nothing reports the gap. The
+    // imperative half is true in both places.
+    nextStep:
+      'Nothing mounts it yet — import its registerRoutes from your route registrar and call it, '
+      + "passing that registrar's router.",
+  },
   { name: 'make:job', description: 'Generate a new job class.', argDescription: 'Job class name', makeFn: makeJob, resourceName: 'Job' },
   { name: 'make:event', description: 'Generate a new event class.', argDescription: 'Event class name', makeFn: makeEvent, resourceName: 'Event' },
   { name: 'make:mail', description: 'Generate a new mailable class.', argDescription: 'Mail class name', makeFn: makeMail, resourceName: 'Mail' },
@@ -247,7 +267,7 @@ const makeValidatorCommand = defineCommand({
 const makeCommands = Object.fromEntries(
   makeCommandSpecs.map((spec) => [
     spec.name,
-    createMakeCommand(spec.name, spec.description, spec.argDescription, spec.makeFn, spec.resourceName),
+    createMakeCommand(spec),
   ]),
 )
 

--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -25,6 +25,7 @@ import {
   staticStringProperty,
 } from './model-parser'
 import { checkConsoleCommandRegistration } from './console-check'
+import { checkRouteRegistrarWiring, ROUTES_DIR } from './routes-check'
 import { checkSchemaTimestamps } from './schema-check'
 import { parseSchemaTables, schemaPathFor, type SchemaTable } from './schema-parser'
 import { ParseCache } from './parse-cache'
@@ -53,6 +54,10 @@ export interface RunCheckOptions {
    * Restrict file-scanning checks (empty methods, arch boundaries) to files
    * changed vs. the merge base with main, plus uncommitted/untracked files.
    * Falls back to checking everything when not in a git repo.
+   *
+   * Two checks answer a whole-directory question rather than a per-file one
+   * — translation parity and route registrar wiring — so `--changed` gates
+   * each as a unit on its own directory instead of filtering its inputs.
    */
   changed?: boolean
   /**
@@ -221,6 +226,25 @@ export async function runCheck(options: RunCheckOptions = {}): Promise<CheckRepo
     // contribute nothing here.
     const commandRegistrationResults = await checkConsoleCommandRegistration(cwd, cache)
     checks.push(...commandRegistrationResults)
+
+    // 7.5. Check every routes file's registrar is reached from the app's entry
+    // registrar (the wiring `guren add admin|oauth|auth` performs
+    // automatically — this catches routes files written, moved, or unhooked by
+    // hand, whose only other symptom is a 404). Not an architecture boundary
+    // rule, so it stays out of `--arch`'s fast path alongside checks 6-8.
+    //
+    // Gated as a unit under --changed, the way check 10.5 gates i18n — see
+    // checkRouteRegistrarWiring for why filtering by changed *candidate*
+    // would miss the edit that usually breaks the wiring.
+    const routesChanged =
+      !changedFiles
+      || [...changedFiles].some(
+        (file) => file === ROUTES_DIR || file.startsWith(`${ROUTES_DIR}/`) || file === options.routesFile,
+      )
+    if (routesChanged) {
+      const routeWiringResults = await checkRouteRegistrarWiring({ cwd, cache, routesFile: options.routesFile })
+      checks.push(...routeWiringResults)
+    }
 
     // 8. Check Postgres timestamp columns carry a time zone. Content-activated
     // and dialect-gated: apps with no schema, or a non-Postgres one, contribute

--- a/packages/cli/src/console-check.ts
+++ b/packages/cli/src/console-check.ts
@@ -7,7 +7,7 @@ import {
   toPosixRelative,
   moduleNameFor,
 } from './discovery'
-import { camelCase, escapeRegExp } from './utils'
+import { camelCase, escapeRegExp, referencesIdentifier } from './utils'
 import { ParseCache } from './parse-cache'
 import { check, type CheckResult } from './check-result'
 
@@ -64,14 +64,9 @@ function bindingsFromModule(entry: EntrySource, moduleName: string): string[] {
     .flatMap((imported) => imported.names)
 }
 
-/** Whether `body` uses `name` as an identifier. */
-function referencesName(body: string, name: string): boolean {
-  return new RegExp(`\\b${escapeRegExp(name)}\\b`, 'u').test(body)
-}
-
 /**
  * Whether `entry` imports `name` from inside `modules/<moduleName>/`. Pairing
- * this with {@link referencesName} is what stops one module's registration
+ * this with {@link referencesIdentifier} is what stops one module's registration
  * from covering another's identically-named command — two modules may each
  * ship an `InvoiceCommand`, and the bare name cannot tell them apart.
  */
@@ -83,7 +78,7 @@ function importsNameFromModule(entry: EntrySource, moduleName: string, name: str
 
 /** Whether `entry` registers `name`, having imported it from that module. */
 function registersModuleCommand(entry: EntrySource | null, moduleName: string, name: string): boolean {
-  return entry !== null && importsNameFromModule(entry, moduleName, name) && referencesName(entry.body, name)
+  return entry !== null && importsNameFromModule(entry, moduleName, name) && referencesIdentifier(entry.body, name)
 }
 
 /**
@@ -199,7 +194,7 @@ export async function checkConsoleCommandRegistration(cwd: string, cache: ParseC
       // it through a barrel (`export * from './commands.js'`) that never spells
       // the class name out.
       const registered
-        = referencesName(entrySource.body, name)
+        = referencesIdentifier(entrySource.body, name)
         || (moduleName !== null && registersModuleCommand(consoleEntry ?? null, moduleName, name))
       const suggestion = moduleName
         ? `Import ${name} in ${entry} and add it to defineModule({ commands: [...] }).`

--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -96,6 +96,21 @@ export async function fileExists(cwd: string, relativePath: string): Promise<boo
   }
 }
 
+/**
+ * The first of `candidates` (project-relative, in preference order) that
+ * exists under `cwd`, or `null`.
+ *
+ * One probe for every caller that has to *find* a conventional file rather
+ * than assume one — `doctor` locating the app's routes entry, `guren check`
+ * doing the same. Two copies could disagree about preference order, which
+ * decides which file the whole command then reads.
+ */
+export async function findFirstExisting(cwd: string, candidates: readonly string[]): Promise<string | null> {
+  const results = await Promise.all(candidates.map((candidate) => fileExists(cwd, candidate)))
+  const index = results.indexOf(true)
+  return index === -1 ? null : candidates[index]
+}
+
 export async function readIfExists(cwd: string, relativePath: string): Promise<string | null> {
   if (!(await fileExists(cwd, relativePath))) {
     return null
@@ -241,6 +256,20 @@ export function discoverPolicyFiles(appRoot: string): Promise<string[]> {
  * for tooling only: `guren context` lists them, and `guren check` warns about
  * any that no console entrypoint references.
  */
+/**
+ * Route files under the project's own `routes/`, tests excluded.
+ *
+ * Scoped to the application root on purpose, unlike the `discover*Files`
+ * siblings that fan out over `listAppRoots()`: a module mounts its routes
+ * through `defineModule({ routes })` rather than through the project's entry
+ * registrar, so the two are not the same question.
+ */
+export function discoverRoutesFiles(appRoot: string): Promise<string[]> {
+  return collectFiles(resolve(appRoot, 'routes'), IMPORTABLE_EXTENSIONS).then((files) =>
+    files.filter((file) => !TEST_FILE_PATTERN.test(file)),
+  )
+}
+
 export function discoverCommandFiles(appRoot: string): Promise<string[]> {
   return discoverDir(appRoot, 'app/Console/Commands')
 }

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -8,6 +8,7 @@ import {
   discoverModelFiles,
   discoverTestFiles,
   fileExists,
+  findFirstExisting,
   hasControllerTest,
   describeControllerTestMiss,
   moduleFlagFor,
@@ -20,6 +21,7 @@ import { compareVersions } from './codemods'
 import { appEmitsPageManifest } from './pages-types'
 import { extractClassDeclaration } from './model-parser'
 import { parseSourceFile } from './parse-cache'
+import { ROUTES_ENTRY_CANDIDATES } from './route-registrar'
 import {
   analyzeDeployRuntime,
   bunlessTargets,
@@ -126,7 +128,6 @@ type JsonReadResult<T> =
   | { exists: true; raw: string; value: null; parseError: Error }
 
 const APP_ENTRY_CANDIDATES = ['src/main.ts', 'src/main.mts', 'src/main.js', 'src/main.mjs']
-const ROUTE_CANDIDATES = ['routes/web.ts', 'routes/web.js', 'routes/api.ts', 'routes/api.js']
 const PAGE_CONTRACT_CANDIDATES = ['.guren/pages.gen.ts']
 const GENERATED_FILES = ['.guren/routes.gen.ts', '.guren/pages.gen.ts', '.guren/data.gen.ts', '.guren/api-client.gen.ts', '.guren/channels.gen.ts']
 
@@ -162,12 +163,6 @@ type TsconfigShape = {
     baseUrl?: string
     paths?: Record<string, string[]>
   }
-}
-
-async function findFirstExisting(cwd: string, candidates: readonly string[]): Promise<string | null> {
-  const results = await Promise.all(candidates.map((c) => fileExists(cwd, c)))
-  const index = results.indexOf(true)
-  return index === -1 ? null : candidates[index]
 }
 
 async function readJsonIfExists<T>(cwd: string, relativePath: string): Promise<JsonReadResult<T>> {
@@ -280,7 +275,7 @@ async function detectAppEntry(context: DoctorRuleContext): Promise<DoctorCheck> 
 }
 
 async function detectRoutes(context: DoctorRuleContext): Promise<DoctorCheck> {
-  const routesFile = await findFirstExisting(context.cwd, ROUTE_CANDIDATES)
+  const routesFile = await findFirstExisting(context.cwd, ROUTES_ENTRY_CANDIDATES)
   if (!routesFile) {
     return createCheck(
       'routes',
@@ -739,7 +734,7 @@ async function detectConfigDrift(context: DoctorRuleContext): Promise<DoctorChec
     combinedSource.includes('routes:') ||
     combinedSource.includes('routes,')
   )
-  const routeFileExists = await findFirstExisting(context.cwd, ROUTE_CANDIDATES)
+  const routeFileExists = await findFirstExisting(context.cwd, ROUTES_ENTRY_CANDIDATES)
 
   if (routeFileExists && !hasRoutesImport) {
     issues.push('Route file exists but may not be wired into createApp()')

--- a/packages/cli/src/openapi-generate.ts
+++ b/packages/cli/src/openapi-generate.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path'
-import { loadRouteDefinitions } from './load-routes'
+import { DEFAULT_ROUTES_FILE, loadRouteDefinitions } from './load-routes'
 import { readIfExists } from './discovery'
 import { resolveAppRoot, type WriterOptions } from './utils'
 
@@ -39,7 +39,6 @@ type PackageMetadata = {
   description?: string
 }
 
-const DEFAULT_ROUTES_FILE = 'routes/web.ts'
 
 export async function generateOpenApiSpec(
   options: GenerateOpenApiSpecOptions = {},

--- a/packages/cli/src/route-registrar.ts
+++ b/packages/cli/src/route-registrar.ts
@@ -27,8 +27,41 @@ export const REGISTRAR_EXPORT_NAMES = [
 
 export const REGISTRAR_PATTERN = /^register\w*Routes$/u
 
+/**
+ * The name an import/export specifier node refers to — `export { x as "y" }`
+ * is legal, so the exported name is not always an identifier.
+ */
+export function specifierName(node: { type: string; name?: string; value?: string }): string {
+  return node.type === 'Identifier' ? (node.name ?? '') : (node.value ?? '')
+}
+
+/**
+ * Whether an export named `name` is one the route loader would accept as a
+ * registrar — the same question `resolveRegistrar()` asks, minus the
+ * preference order it needs to pick *one* of several.
+ *
+ * Every entry in {@link REGISTRAR_EXPORT_NAMES} other than `default` already
+ * matches {@link REGISTRAR_PATTERN}, so the two clauses below cover the list
+ * without repeating it; a name added there that did not match the pattern
+ * would have to be added here too.
+ */
+export function isRegistrarExportName(name: string): boolean {
+  return name === 'default' || REGISTRAR_PATTERN.test(name)
+}
+
 /** Conventional routes entry file, shared by every command that loads routes. */
 export const DEFAULT_ROUTES_FILE = 'routes/web.ts'
+
+/**
+ * Entry files to look for, in order, when a caller was given no `--routes`.
+ *
+ * {@link DEFAULT_ROUTES_FILE} is only the *first* of these: the API-only
+ * template ships `routes/api.ts` and no `routes/web.ts`, wiring `--routes
+ * routes/api.ts` into its own `codegen` script — so a command that assumes
+ * the default without probing reports a freshly scaffolded API app as having
+ * no routes at all. Shared with `doctor`, which has always probed this list.
+ */
+export const ROUTES_ENTRY_CANDIDATES = [DEFAULT_ROUTES_FILE, 'routes/web.js', 'routes/api.ts', 'routes/api.js']
 
 export interface RouteRegistrar {
   /**
@@ -133,8 +166,7 @@ function registrarCandidates(body: Statement[]): RegistrarFunction[] {
     // — the exported name is what the loader sees.
     for (const specifier of statement.specifiers) {
       if (specifier.type !== 'ExportSpecifier') continue
-      const exported = specifier.exported.type === 'Identifier' ? specifier.exported.name : specifier.exported.value
-      if (exported === 'default' || REGISTRAR_PATTERN.test(exported)) {
+      if (isRegistrarExportName(specifierName(specifier.exported))) {
         add(declarations.get(specifier.local.name))
       }
     }

--- a/packages/cli/src/routes-check.ts
+++ b/packages/cli/src/routes-check.ts
@@ -1,0 +1,562 @@
+import { stat } from 'node:fs/promises'
+import { dirname, extname, isAbsolute, join, relative, resolve } from 'node:path'
+import type { Statement } from '@babel/types'
+import { walk } from './ast-walk'
+import { discoverRoutesFiles, fileExists, findFirstExisting, formatTruncatedList, toPosixRelative } from './discovery'
+import type { ParseCache } from './parse-cache'
+import { DEFAULT_ROUTES_FILE, isRegistrarExportName, ROUTES_ENTRY_CANDIDATES, specifierName } from './route-registrar'
+import { referencesIdentifier, relativeImportPath } from './utils'
+import { check, type CheckResult } from './check-result'
+
+/** The directory whose files this check asks about. */
+export const ROUTES_DIR = 'routes'
+
+/**
+ * Stands in for "every export", for `import * as routes` and
+ * `export * from './x'`. Safe as a sentinel because `*` is not a legal
+ * export name.
+ */
+const EVERY_EXPORT = '*'
+
+/** Extensions a specifier without one may resolve to, in preference order. */
+const RESOLVED_EXTENSIONS = ['.ts', '.tsx', '.mts', '.js', '.jsx', '.mjs']
+
+/**
+ * Source extension → the runtime extension it is emitted as.
+ *
+ * Load-bearing in both directions, not a nicety. Read backwards, it is how a
+ * specifier reaches its file: apps following Node's ESM rules import the
+ * *emitted* path, so `routes/web.ts` names its sibling `'./auth.js'` while
+ * the file on disk is `auth.ts` — the shape `examples/blog` and every `guren
+ * add` scaffold use. A resolver that only tried the specifier as written
+ * would find no edges at all in a real app and report every routes file as
+ * unmounted. Read forwards, it is how a suggested import line is printed, and
+ * how an emitted `auth.js` sitting beside its own `auth.ts` is recognized as
+ * a build artifact rather than a second routes file.
+ */
+const SOURCE_TO_RUNTIME_EXTENSION: Record<string, string> = {
+  '.ts': '.js',
+  '.tsx': '.jsx',
+  '.mts': '.mjs',
+}
+
+const RUNTIME_TO_SOURCE_EXTENSION: Record<string, string> = Object.fromEntries(
+  Object.entries(SOURCE_TO_RUNTIME_EXTENSION).map(([source, runtime]) => [runtime, source]),
+)
+
+/** `path` with its extension swapped per `map`, or `null` if it isn't in `map`. */
+function swapExtension(path: string, map: Record<string, string>): string | null {
+  const extension = extname(path)
+  const swapped = map[extension]
+  return swapped ? `${path.slice(0, -extension.length)}${swapped}` : null
+}
+
+/** A name a file binds from another file, and the export it came from. */
+interface ImportBinding {
+  local: string
+  /** The imported export's name, `'default'`, or {@link EVERY_EXPORT}. */
+  imported: string
+  /**
+   * Absolute path of the file the specifier resolved to, or `null` for a
+   * specifier that leaves `routes/`. Those bindings are kept rather than
+   * dropped because the local name still matters for the collision note in
+   * {@link wiringSuggestion} — only the filesystem probe is skipped.
+   */
+  from: string | null
+}
+
+/** An `export ... from './x'` edge: `exported` here is `imported` there. */
+interface ReexportEdge {
+  exported: string
+  imported: string
+  from: string
+}
+
+/**
+ * One routes file, reduced to what deciding "is this registrar called?" needs.
+ *
+ * The body/import split is the same one `console-check.ts` makes, for the same
+ * reason: an import alone is not a use. A `routes/web.ts` left holding
+ * `import registerAdminRoutes from './admin.js'` after someone deleted the
+ * call is exactly the state this check exists to report, and it is
+ * indistinguishable from wired-up unless the two halves are kept apart.
+ */
+interface RoutesFileFacts {
+  /** Exports the file itself declares that the route loader would accept. */
+  registrarExports: string[]
+  imports: ImportBinding[]
+  reexports: ReexportEdge[]
+  /** Files reached by `await import('./x.js')`, which binds no static name. */
+  dynamicImports: string[]
+  /** Top-level statements minus imports and `... from` re-exports. */
+  body: string
+}
+
+async function isFile(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isFile()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Absolute path a specifier points at, before extension guessing: relative to
+ * the importing file, or to the app root for the `@/` alias the templates
+ * configure. Package specifiers yield `null` — nothing outside the app can
+ * mount a routes file.
+ *
+ * Pure string work, which is what makes it worth having separately from
+ * {@link resolveSpecifier}: only an edge landing inside `routes/` can change
+ * an answer here, so callers rule the rest out before touching the disk. In
+ * `examples/blog` that is 16 of 17 filesystem probes not made — the entry
+ * file's controller, model, and validator imports.
+ */
+function specifierBase(cwd: string, fromFile: string, specifier: string): string | null {
+  if (specifier.startsWith('.')) return resolve(dirname(fromFile), specifier)
+  if (specifier.startsWith('@/')) return resolve(cwd, specifier.slice(2))
+  return null
+}
+
+/**
+ * The file `base` names, or `null` when it names nothing on disk.
+ *
+ * Existence is probed rather than assumed (unlike `spec-modules.ts`, which
+ * only needs a path prefix for attribution): a specifier that resolves
+ * nowhere must not create a graph edge, or a typo'd import would read as
+ * wiring.
+ */
+async function resolveSpecifier(base: string): Promise<string | null> {
+  const source = swapExtension(base, RUNTIME_TO_SOURCE_EXTENSION)
+  const candidates = [
+    // Ahead of the specifier as written, so a TypeScript app that also has a
+    // stale compiled `auth.js` beside `auth.ts` is read from source.
+    ...(source === null ? [] : [source]),
+    base,
+    ...RESOLVED_EXTENSIONS.map((ext) => `${base}${ext}`),
+    ...RESOLVED_EXTENSIONS.map((ext) => join(base, `index${ext}`)),
+  ]
+
+  for (const candidate of candidates) {
+    if (await isFile(candidate)) return candidate
+  }
+
+  return null
+}
+
+/**
+ * Whether an `export default` declaration is something the loader would call.
+ *
+ * The loader takes the default export only when `typeof` it is a function
+ * (`load-routes.ts`), so counting every default export would report a
+ * `routes/prefixes.ts` whose default is a plain object as an unmounted
+ * registrar. An `Identifier` counts because `export default registerAdminRoutes`
+ * — what every `guren add` scaffold writes — is the common indirection.
+ */
+function isDefaultRegistrar(declaration: { type: string }): boolean {
+  return (
+    declaration.type === 'FunctionDeclaration'
+    || declaration.type === 'FunctionExpression'
+    || declaration.type === 'ArrowFunctionExpression'
+    || declaration.type === 'Identifier'
+  )
+}
+
+/**
+ * Registrar-shaped exports a statement declares *itself*. A re-export
+ * (`export { registerAdminRoutes } from './admin.js'`) is deliberately not
+ * one: a barrel that forwards a registrar does not own it, and reporting the
+ * barrel would name a file whose only fix is in another one.
+ */
+function declaredRegistrarExports(node: Statement): string[] {
+  if (node.type === 'ExportDefaultDeclaration') {
+    return isDefaultRegistrar(node.declaration) ? ['default'] : []
+  }
+  if (node.type !== 'ExportNamedDeclaration' || node.source) return []
+  if (node.exportKind === 'type') return []
+
+  const names: string[] = []
+  const declaration = node.declaration
+
+  if (declaration?.type === 'FunctionDeclaration' && declaration.id) {
+    names.push(declaration.id.name)
+  } else if (declaration?.type === 'VariableDeclaration') {
+    for (const declarator of declaration.declarations) {
+      if (declarator.id.type === 'Identifier') names.push(declarator.id.name)
+    }
+  }
+
+  for (const specifier of node.specifiers) {
+    if (specifier.type === 'ExportSpecifier') names.push(specifierName(specifier.exported))
+  }
+
+  return names.filter(isRegistrarExportName)
+}
+
+/** Files `await import('./x.js')` reaches, for the edges no static name records. */
+async function dynamicImportTargets(
+  program: unknown,
+  resolveEdge: (specifier: string) => Promise<string | null>,
+): Promise<string[]> {
+  const specifiers: string[] = []
+
+  walk(program, (node) => {
+    if (node.type !== 'CallExpression') return
+    const callee = node.callee as { type?: string } | undefined
+    const [argument] = (node.arguments ?? []) as Array<{ type?: string; value?: unknown }>
+    if (callee?.type === 'Import' && argument?.type === 'StringLiteral' && typeof argument.value === 'string') {
+      specifiers.push(argument.value)
+    }
+  })
+
+  const resolved = await Promise.all(specifiers.map(resolveEdge))
+  return resolved.filter((file): file is string => file !== null)
+}
+
+async function readFacts(
+  cwd: string,
+  cache: ParseCache,
+  filePath: string,
+  routesDir: string,
+): Promise<RoutesFileFacts | null> {
+  const parsed = await cache.get(filePath)
+  if (!parsed) return null
+
+  const facts: RoutesFileFacts = { registrarExports: [], imports: [], reexports: [], dynamicImports: [], body: '' }
+  const bodyNodes: Statement[] = []
+
+  // Only an edge landing inside `routes/` can change an answer, so everything
+  // else is ruled out by string comparison before any filesystem probe.
+  const resolveEdge = async (specifier: string): Promise<string | null> => {
+    const base = specifierBase(cwd, filePath, specifier)
+    return base !== null && isInside(routesDir, base) ? resolveSpecifier(base) : null
+  }
+
+  for (const node of parsed.ast.program.body) {
+    if (node.type === 'ImportDeclaration') {
+      // A type-only import compiles away — it can never mount anything.
+      if (node.importKind === 'type') continue
+      const from = await resolveEdge(node.source.value)
+
+      for (const specifier of node.specifiers) {
+        if (specifier.type === 'ImportDefaultSpecifier') {
+          facts.imports.push({ local: specifier.local.name, imported: 'default', from })
+        } else if (specifier.type === 'ImportNamespaceSpecifier') {
+          facts.imports.push({ local: specifier.local.name, imported: EVERY_EXPORT, from })
+        } else if (specifier.type === 'ImportSpecifier' && specifier.importKind !== 'type') {
+          facts.imports.push({ local: specifier.local.name, imported: specifierName(specifier.imported), from })
+        }
+      }
+      continue
+    }
+
+    if (node.type === 'ExportAllDeclaration') {
+      const from = await resolveEdge(node.source.value)
+      if (from !== null) facts.reexports.push({ exported: EVERY_EXPORT, imported: EVERY_EXPORT, from })
+      continue
+    }
+
+    if (node.type === 'ExportNamedDeclaration' && node.source) {
+      const from = await resolveEdge(node.source.value)
+      if (from === null) continue
+      for (const specifier of node.specifiers) {
+        if (specifier.type === 'ExportSpecifier') {
+          facts.reexports.push({
+            exported: specifierName(specifier.exported),
+            imported: specifierName(specifier.local),
+            from,
+          })
+        } else if (specifier.type === 'ExportNamespaceSpecifier') {
+          facts.reexports.push({ exported: specifierName(specifier.exported), imported: EVERY_EXPORT, from })
+        }
+      }
+      continue
+    }
+
+    bodyNodes.push(node)
+    facts.registrarExports.push(...declaredRegistrarExports(node))
+  }
+
+  facts.body = bodyNodes.map((node) => parsed.source.slice(node.start ?? 0, node.end ?? 0)).join('\n')
+  facts.dynamicImports = await dynamicImportTargets(parsed.ast.program, resolveEdge)
+
+  return facts
+}
+
+/** Whether `filePath` sits inside `directory`. */
+function isInside(directory: string, filePath: string): boolean {
+  const rel = relative(directory, filePath)
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel)
+}
+
+export interface RoutesCheckOptions {
+  cwd: string
+  cache: ParseCache
+  /**
+   * `--routes <file>`, project-relative. Omitted, the entry is probed from
+   * {@link ROUTES_ENTRY_CANDIDATES} rather than assumed.
+   */
+  routesFile?: string
+}
+
+/**
+ * Verifies every registrar under `routes/` is reached from the app's entry
+ * registrar — the wiring `guren add admin|oauth|resource|auth` performs
+ * automatically, so a warning here means a routes file was written, moved, or
+ * unhooked by hand (`make:route`, notably, writes its file and leaves the
+ * wiring to you).
+ *
+ * Nothing else reports this. A routes file nobody imports still compiles,
+ * still type-checks, and still looks wired from the inside — the only symptom
+ * is a 404 in production, which is why the scaffolders' own regex matching
+ * only a registrar parameter literally named `router` went unnoticed against
+ * the blog template's `baseRouter`. Fixing the scaffolders does nothing for
+ * the apps already in that state; this does.
+ *
+ * Mounting spreads outward from the entry file rather than over everything
+ * parsed, and it is *named*: a file is mounted only once some already-mounted
+ * file uses a binding that traces back to one of its registrar exports. Both
+ * halves are load-bearing. Crediting a whole file for any binding would pass
+ * an `admin.ts` whose `ADMIN_PREFIX` constant is imported while its registrar
+ * is not; crediting from any parsed file would pass an `admin.ts` called only
+ * by a `group.ts` that nothing calls in turn.
+ *
+ * "Uses" is a name reference outside the file's imports (see
+ * {@link referencesIdentifier}), not a call expression — a registrar can be
+ * handed onward as a value. That looseness runs one way: a name in a comment
+ * or a string reads as used, so this can miss an orphan but not invent one.
+ * `warn` rather than `fail` for the same reason.
+ *
+ * Two wirings it cannot see, both reported as unmounted: a chain that leaves
+ * `routes/` (`web.ts` → `app/routing.ts` → `routes/admin.ts`), since
+ * following it means parsing the project to answer a question about a handful
+ * of files; and a registrar reached by anything less direct than an import or
+ * `await import()` of its file.
+ *
+ * Not filtered by changed *candidates*, unlike `runCheck`'s file-scanning
+ * checks: the edit that breaks the wiring is to `routes/web.ts`, not to
+ * `routes/admin.ts`. `runCheck` instead gates the whole check on `routes/`
+ * having changed, which covers both. Content-activated — an app whose
+ * `routes/` holds nothing but the entry file contributes zero results.
+ */
+export async function checkRouteRegistrarWiring(options: RoutesCheckOptions): Promise<CheckResult[]> {
+  const { cwd, cache } = options
+  const routesDir = resolve(cwd, ROUTES_DIR)
+
+  // An explicit `--routes` is honoured as given, including when it names a
+  // file that doesn't exist — reporting that is the point. Otherwise probe,
+  // for the reason ROUTES_ENTRY_CANDIDATES documents.
+  const entryFile = options.routesFile ?? (await findFirstExisting(cwd, ROUTES_ENTRY_CANDIDATES)) ?? DEFAULT_ROUTES_FILE
+  const entryPath = resolve(cwd, entryFile)
+
+  const routesFiles = await discoverRoutesFiles(cwd)
+  const candidates = withoutEmittedTwins(routesFiles)
+    // By resolved path, not by name: `--routes` may point anywhere, and under
+    // a custom entry `routes/web.ts` is an ordinary candidate.
+    .filter((filePath) => filePath !== entryPath)
+    .sort()
+
+  if (candidates.length === 0) return []
+
+  const entryKey = `route-entry:${entryFile}`
+  const entryTitle = 'Route registrar entrypoint'
+  const describeCandidates = (): string => formatTruncatedList(candidates.map((file) => toPosixRelative(cwd, file)))
+
+  // Probed separately because `readFacts` returns null for a missing file and
+  // an unparseable one alike, and those want different advice.
+  if (!(await fileExists(cwd, entryFile))) {
+    return [
+      check(
+        entryKey,
+        entryTitle,
+        'warn',
+        `${describeCandidates()} ${candidates.length === 1 ? 'exists' : 'exist'} but there is no ${entryFile} to `
+        + `mount ${candidates.length === 1 ? 'it' : 'them'} from.`,
+        `Create ${entryFile} exporting a register*Routes function, then call each routes file's registrar from it.`,
+      ),
+    ]
+  }
+
+  const facts = new Map<string, RoutesFileFacts>()
+  for (const filePath of [entryPath, ...candidates]) {
+    const read = await readFacts(cwd, cache, filePath, routesDir)
+    if (read) facts.set(filePath, read)
+  }
+
+  const entryFacts = facts.get(entryPath)
+
+  if (!entryFacts) {
+    // One warning, not one per candidate: an unparseable entry is a single
+    // fact about a single file, and fanning it out would read as every routes
+    // file being broken.
+    return [
+      check(
+        entryKey,
+        entryTitle,
+        'warn',
+        `${entryFile} could not be parsed, so ${describeCandidates()} cannot be verified as mounted.`,
+        `Check ${entryFile} for a syntax error.`,
+        entryFile,
+      ),
+    ]
+  }
+
+  const mounted = mountedFrom(facts, entryPath, entryFacts)
+  const entryBindings = new Set(entryFacts.imports.map((binding) => binding.local))
+
+  return candidates.flatMap((filePath) => {
+    const candidateFacts = facts.get(filePath)
+    // A routes file exporting no registrar is a helper, not something the
+    // loader could mount; an unparseable one is already reported by the
+    // shared `scan-coverage` warning.
+    if (!candidateFacts || candidateFacts.registrarExports.length === 0) return []
+
+    const relPath = toPosixRelative(cwd, filePath)
+    const isMounted = mounted.has(filePath)
+    const name = candidateFacts.registrarExports.find((exported) => exported !== 'default')
+
+    return check(
+      `route-registrar:${relPath}`,
+      `${relPath} wiring`,
+      isMounted ? 'pass' : 'warn',
+      isMounted
+        ? `${relPath}'s registrar is called from ${entryFile}.`
+        : `${relPath} exports a route registrar that nothing reachable from ${entryFile} calls, `
+          + 'so its routes are never mounted and every request to them 404s.',
+      isMounted ? undefined : wiringSuggestion(cwd, entryFile, filePath, relPath, name, entryBindings),
+      relPath,
+    )
+  })
+}
+
+/**
+ * Drops an emitted `auth.js` sitting beside the `auth.ts` it was built from.
+ *
+ * The pair is one routes file, and the specifier resolver already prefers the
+ * source. Left in, the artifact is a second candidate that nothing imports by
+ * that path — so an in-place TypeScript build would turn a working `routes/`
+ * into a failing check.
+ */
+function withoutEmittedTwins(files: string[]): string[] {
+  const present = new Set(files)
+  return files.filter((file) => {
+    const source = swapExtension(file, RUNTIME_TO_SOURCE_EXTENSION)
+    return source === null || !present.has(source)
+  })
+}
+
+/**
+ * Files whose registrar the app will actually call, spreading outward from
+ * the entry.
+ */
+function mountedFrom(
+  facts: Map<string, RoutesFileFacts>,
+  entryPath: string,
+  entryFacts: RoutesFileFacts,
+): Set<string> {
+  const mounted = new Set<string>([entryPath])
+  const pending = [entryPath]
+  const credited = new Set<string>()
+
+  const mount = (file: string): void => {
+    if (mounted.has(file)) return
+    mounted.add(file)
+    pending.push(file)
+  }
+
+  /**
+   * Credits `file` with `name` being used, following `export ... from` edges
+   * so a barrel forwards the credit to whichever file actually declares the
+   * registrar.
+   */
+  const credit = (file: string, name: string): void => {
+    const visit = `${file} ${name}`
+    if (credited.has(visit)) return
+    credited.add(visit)
+
+    const forwarded = facts.get(file)
+    const declares = name === EVERY_EXPORT
+      ? (forwarded?.registrarExports.length ?? 0) > 0
+      : forwarded?.registrarExports.includes(name)
+    if (declares) mount(file)
+    if (!forwarded) return
+
+    if (name === EVERY_EXPORT) {
+      for (const edge of forwarded.reexports) credit(edge.from, edge.imported)
+      return
+    }
+
+    // An explicit named re-export shadows every `export *` in the same file,
+    // per ES semantics — following both would credit a `legacy-admin.ts` the
+    // barrel deliberately overrides.
+    const explicit = forwarded.reexports.filter((edge) => edge.exported === name)
+    if (explicit.length > 0) {
+      for (const edge of explicit) credit(edge.from, edge.imported)
+      return
+    }
+
+    for (const edge of forwarded.reexports) {
+      if (edge.exported === EVERY_EXPORT) credit(edge.from, name)
+    }
+  }
+
+  // The loader resolves a registrar from the entry file's *exports*, so one
+  // the entry merely forwards (`export * from './admin.js'`) is called just
+  // as surely as one it declares.
+  for (const edge of entryFacts.reexports) {
+    if (edge.exported === EVERY_EXPORT || isRegistrarExportName(edge.exported)) {
+      credit(edge.from, edge.imported)
+    }
+  }
+
+  while (pending.length > 0) {
+    const file = pending.shift() as string
+    const source = facts.get(file)
+    if (!source) continue
+
+    for (const binding of source.imports) {
+      if (binding.from !== null && referencesIdentifier(source.body, binding.local)) {
+        credit(binding.from, binding.imported)
+      }
+    }
+    // A dynamic import binds its names by destructuring the awaited module,
+    // so there is no static local to look for — the import itself is the use.
+    for (const target of source.dynamicImports) credit(target, EVERY_EXPORT)
+  }
+
+  return mounted
+}
+
+/**
+ * The import-and-call line to add, spelled out rather than described: this is
+ * the user's only guidance, since nothing regenerates the wiring for a routes
+ * file that already exists.
+ */
+function wiringSuggestion(
+  cwd: string,
+  entryFile: string,
+  filePath: string,
+  relPath: string,
+  name: string | undefined,
+  entryBindings: Set<string>,
+): string {
+  const tail = `and call it from your route registrar, passing that registrar's router.`
+
+  if (name === undefined) {
+    // Default-only export: there is no name to spell, so name the file.
+    return `Import the default export of ${relPath} in ${entryFile} ${tail}`
+  }
+
+  // Printed with the runtime extension the app's own imports use, so the line
+  // can be pasted rather than adapted.
+  const printed = relativeImportPath(resolve(cwd, entryFile), filePath)
+  const specifier = swapExtension(printed, SOURCE_TO_RUNTIME_EXTENSION) ?? printed
+
+  // Two `make:route` files both export `registerRoutes`, so the obvious import
+  // line does not always compile as written.
+  const collision = entryBindings.has(name)
+    ? ` (under an alias — ${entryFile} already binds ${name})`
+    : ''
+
+  return `Add to ${entryFile}: import { ${name} } from '${specifier}'${collision}, ${tail}`
+}

--- a/packages/cli/src/routes-types.ts
+++ b/packages/cli/src/routes-types.ts
@@ -1,6 +1,6 @@
 import { relative, resolve } from 'node:path'
 import { escapeSingleQuoted as escapeSingleQuotes, escapeTemplateLiteral as escapeTemplateSegment, resolveAppRoot, writeGeneratedFileIn, type WriterOptions } from './utils'
-import { loadRouteDefinitions } from './load-routes'
+import { DEFAULT_ROUTES_FILE, loadRouteDefinitions } from './load-routes'
 import {
   DECLARATION_MODULE_AUGMENTATION,
   RUNTIME_TYPE_DEFINITIONS,
@@ -21,7 +21,6 @@ export interface GenerateRouteTypesOptions extends WriterOptions {
   appRoot?: string
 }
 
-const DEFAULT_ROUTES_FILE = 'routes/web.ts'
 const DEFAULT_OUTPUT_FILE = 'types/generated/routes.d.ts'
 const DEFAULT_RUNTIME_OUTPUT_FILE = '.guren/routes.gen.ts'
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -357,6 +357,27 @@ export function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
+/**
+ * Whether `body` — source text with its `import` declarations already removed
+ * — uses `name` as an identifier.
+ *
+ * Shared by the registration checks (console commands, route registrars),
+ * which all ask the same question of an entrypoint: does it *use* this name,
+ * having imported it? A word-boundary match over source rather than an AST
+ * identifier walk, because "use" is deliberately broader than "call" — a
+ * registrar handed to `defineModule({ routes: registerBlogRoutes })`, a
+ * command pushed through `[SendDigestCommand].forEach(...)`, and a plain
+ * `registerAuthRoutes(router)` all count, and only the last is a call
+ * expression.
+ *
+ * The looseness cuts one way on purpose: it can call a name used in a comment
+ * or a string registered, never the reverse. These checks warn rather than
+ * fail, so a missed alarm is the cheaper error.
+ */
+export function referencesIdentifier(body: string, name: string): boolean {
+  return new RegExp(`\\b${escapeRegExp(name)}\\b`, 'u').test(body)
+}
+
 const SAFE_MODULE_NAME_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/u
 
 /**

--- a/packages/cli/tests/check.test.ts
+++ b/packages/cli/tests/check.test.ts
@@ -1,7 +1,8 @@
 import { mkdir, writeFile } from 'node:fs/promises'
+import { spawnSync } from 'node:child_process'
 import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
-import { runCheck, type CheckReport, type RunCheckOptions } from '../src/check'
+import { runCheck, type CheckReport, type CheckResult, type RunCheckOptions } from '../src/check'
 import { createTempWorkspace, writeWorkspaceFiles, MYSQL_SCHEMA_FIXTURE, PG_SCHEMA_FIXTURE } from './helpers'
 
 /** Run a check over a throwaway workspace built from path → content. */
@@ -920,5 +921,463 @@ export class User extends defineModel(users, {
 
     const denied = report.checks.find(c => c.key === 'mass-assignment-denied:User')
     expect(denied).toBeUndefined()
+  })
+})
+describe('route registrar wiring', () => {
+  /** Every `route-registrar:` finding, keyed by the file it names. */
+  function wiring(report: CheckReport): Map<string, CheckResult> {
+    return new Map(
+      report.checks
+        .filter((c) => c.key.startsWith('route-registrar:'))
+        .map((c) => [c.key.replace('route-registrar:', ''), c]),
+    )
+  }
+
+  const statusOf = (report: CheckReport, relPath: string): string | undefined =>
+    wiring(report).get(relPath)?.status
+
+  /** An entry registrar that mounts nothing but itself. */
+  const PLAIN_ENTRY = `import { Router } from '@guren/core'
+
+export function registerWebRoutes(baseRouter: Router): void {
+  baseRouter.get('/', [HomeController, 'index'])
+}
+`
+
+  const API_ENTRY = `import { Router } from '@guren/core'
+
+export function registerApiRoutes(baseRouter: Router): void {
+  baseRouter.get('/api/posts', [PostController, 'index'])
+}
+`
+
+  const ROUTES_ENTRY = `import { Router } from '@guren/core'
+import { registerAdminRoutes } from './admin.js'
+
+export function registerWebRoutes(baseRouter: Router): void {
+  registerAdminRoutes(baseRouter)
+}
+`
+
+  const ADMIN_ROUTES = `import { Router } from '@guren/core'
+
+export function registerAdminRoutes(router: Router): void {
+  router.get('/admin', [AdminController, 'index'])
+}
+
+export default registerAdminRoutes
+`
+
+  // The specifier a Node-ESM app actually writes: `./admin.js` for a file
+  // that is `admin.ts` on disk. Nothing else in this suite would notice a
+  // resolver that only tried the specifier as written — it would report
+  // every real app's routes files as unmounted.
+  it('resolves a .js specifier back to the .ts file it names', async () => {
+    const report = await withWorkspace({ 'routes/web.ts': ROUTES_ENTRY, 'routes/admin.ts': ADMIN_ROUTES })
+
+    expect(statusOf(report, 'routes/admin.ts')).toBe('pass')
+  })
+
+  it('warns about a routes file the entry never imports', async () => {
+    const report = await withWorkspace({ 'routes/web.ts': PLAIN_ENTRY, 'routes/admin.ts': ADMIN_ROUTES })
+
+    const finding = wiring(report).get('routes/admin.ts')
+    expect(finding?.status).toBe('warn')
+    expect(finding!.message).toContain('404')
+    expect(finding!.suggestion).toContain("import { registerAdminRoutes } from './admin.js'")
+  })
+
+  // The state the scaffolders' own patch is careful never to produce, and the
+  // reason detection looks outside the imports rather than at them.
+  it('warns when the entry imports the registrar but never calls it', async () => {
+    const report = await withWorkspace({
+      'routes/web.ts': `import { Router } from '@guren/core'
+import { registerAdminRoutes } from './admin.js'
+
+export function registerWebRoutes(baseRouter: Router): void {
+  baseRouter.get('/', [HomeController, 'index'])
+}
+`,
+      'routes/admin.ts': ADMIN_ROUTES,
+    })
+
+    expect(statusOf(report, 'routes/admin.ts')).toBe('warn')
+  })
+
+  // Crediting the whole file for any binding would pass this: the entry uses
+  // admin.ts, but only for a constant — the registrar beside it is dead.
+  it('does not credit a file whose non-registrar export is the one imported', async () => {
+    const report = await withWorkspace({
+      'routes/web.ts': `import { Router } from '@guren/core'
+import { ADMIN_PREFIX } from './admin.js'
+
+export function registerWebRoutes(baseRouter: Router): void {
+  baseRouter.group(ADMIN_PREFIX, (group) => group.get('/health', [HealthController, 'index']))
+}
+`,
+      'routes/admin.ts': `import { Router } from '@guren/core'
+
+export const ADMIN_PREFIX = '/admin'
+
+export function registerAdminRoutes(router: Router): void {
+  router.get('/users', [AdminController, 'index'])
+}
+`,
+    })
+
+    expect(statusOf(report, 'routes/admin.ts')).toBe('warn')
+  })
+
+  it('follows a nested registrar called from another routes file', async () => {
+    const report = await withWorkspace({
+      'routes/web.ts': ROUTES_ENTRY,
+      'routes/admin.ts': `import { Router } from '@guren/core'
+import { registerAdminUserRoutes } from './admin-users.js'
+
+export function registerAdminRoutes(router: Router): void {
+  registerAdminUserRoutes(router)
+}
+`,
+      'routes/admin-users.ts': `import { Router } from '@guren/core'
+
+export function registerAdminUserRoutes(router: Router): void {
+  router.get('/admin/users', [UserController, 'index'])
+}
+`,
+    })
+
+    expect(statusOf(report, 'routes/admin.ts')).toBe('pass')
+    expect(statusOf(report, 'routes/admin-users.ts')).toBe('pass')
+  })
+
+  // Mounting spreads from the entry, not over everything parsed: group.ts is
+  // reachable (the entry re-exports it under a non-registrar name) but nobody
+  // calls it, so the registrar it calls in turn is dead too.
+  it('does not let an unmounted intermediate mount its descendants', async () => {
+    const report = await withWorkspace({
+      'routes/web.ts': `import { Router } from '@guren/core'
+
+export { registerGroupRoutes as GROUP_REGISTRAR } from './group.js'
+
+export function registerWebRoutes(baseRouter: Router): void {
+  baseRouter.get('/', [HomeController, 'index'])
+}
+`,
+      'routes/group.ts': `import { Router } from '@guren/core'
+import { registerAdminRoutes } from './admin.js'
+
+export function registerGroupRoutes(router: Router): void {
+  registerAdminRoutes(router)
+}
+`,
+      'routes/admin.ts': ADMIN_ROUTES,
+    })
+
+    expect(statusOf(report, 'routes/group.ts')).toBe('warn')
+    expect(statusOf(report, 'routes/admin.ts')).toBe('warn')
+  })
+
+  // The barrel forwards the name; only `admin.ts` declares it, so credit has
+  // to travel back along the `export ... from` edge.
+  it('credits a registrar reached through a re-export barrel', async () => {
+    const report = await withWorkspace({
+      'routes/web.ts': `import { Router } from '@guren/core'
+import { registerAdminRoutes } from './index.js'
+
+export function registerWebRoutes(baseRouter: Router): void {
+  registerAdminRoutes(baseRouter)
+}
+`,
+      'routes/index.ts': `export { registerAdminRoutes } from './admin.js'
+`,
+      'routes/admin.ts': ADMIN_ROUTES,
+    })
+
+    expect(statusOf(report, 'routes/admin.ts')).toBe('pass')
+    // The barrel declares no registrar of its own, so it is not a candidate.
+    expect(wiring(report).has('routes/index.ts')).toBe(false)
+  })
+
+  // ES semantics: the explicit re-export wins, so the same name coming through
+  // `export *` is shadowed and its file is never called.
+  it('does not credit an export * shadowed by an explicit re-export', async () => {
+    const report = await withWorkspace({
+      'routes/web.ts': `import { Router } from '@guren/core'
+import { registerAdminRoutes } from './index.js'
+
+export function registerWebRoutes(baseRouter: Router): void {
+  registerAdminRoutes(baseRouter)
+}
+`,
+      'routes/index.ts': `export * from './legacy-admin.js'
+export { registerAdminRoutes } from './admin.js'
+`,
+      'routes/admin.ts': ADMIN_ROUTES,
+      'routes/legacy-admin.ts': `import { Router } from '@guren/core'
+
+export function registerAdminRoutes(router: Router): void {
+  router.get('/legacy-admin', [LegacyAdminController, 'index'])
+}
+`,
+    })
+
+    expect(statusOf(report, 'routes/admin.ts')).toBe('pass')
+    expect(statusOf(report, 'routes/legacy-admin.ts')).toBe('warn')
+  })
+
+  // The loader resolves the registrar off the entry's exports, so one the
+  // entry only forwards is called exactly as surely as one it declares.
+  it('credits a registrar the entry re-exports rather than calls', async () => {
+    const report = await withWorkspace({
+      'routes/web.ts': `export * from './admin.js'
+`,
+      'routes/admin.ts': ADMIN_ROUTES,
+    })
+
+    expect(statusOf(report, 'routes/admin.ts')).toBe('pass')
+  })
+
+  it('credits a registrar called through a namespace import', async () => {
+    const report = await withWorkspace({
+      'routes/web.ts': `import { Router } from '@guren/core'
+import * as admin from './admin.js'
+
+export function registerWebRoutes(baseRouter: Router): void {
+  admin.registerAdminRoutes(baseRouter)
+}
+`,
+      'routes/admin.ts': ADMIN_ROUTES,
+    })
+
+    expect(statusOf(report, 'routes/admin.ts')).toBe('pass')
+  })
+
+  // The runtime awaits an async registrar, so this really does mount — and a
+  // dynamic import binds its names by destructuring, with no static local for
+  // the reference test to find.
+  it('credits a registrar reached by a dynamic import', async () => {
+    const report = await withWorkspace({
+      'routes/web.ts': `import { Router } from '@guren/core'
+
+export async function registerWebRoutes(baseRouter: Router): Promise<void> {
+  const { registerAdminRoutes } = await import('./admin.js')
+  registerAdminRoutes(baseRouter)
+}
+`,
+      'routes/admin.ts': ADMIN_ROUTES,
+    })
+
+    expect(statusOf(report, 'routes/admin.ts')).toBe('pass')
+  })
+
+  it('ignores a routes file that exports no registrar', async () => {
+    const report = await withWorkspace({
+      'routes/web.ts': PLAIN_ENTRY,
+      'routes/prefixes.ts': `export const ADMIN_PREFIX = '/admin'
+`,
+    })
+
+    expect(wiring(report).has('routes/prefixes.ts')).toBe(false)
+  })
+
+  // The loader takes a default export only when it is a function, so a routes
+  // file defaulting to a config object is not an unmounted registrar.
+  it('ignores a file whose default export is not a function', async () => {
+    const report = await withWorkspace({
+      'routes/web.ts': PLAIN_ENTRY,
+      'routes/prefixes.ts': `export default { admin: '/admin', api: '/api' }
+`,
+    })
+
+    expect(wiring(report).has('routes/prefixes.ts')).toBe(false)
+  })
+
+  // An in-place TypeScript build drops `admin.js` beside `admin.ts`. The pair
+  // is one routes file; counting the artifact separately would turn a working
+  // routes/ into a failing check.
+  it('ignores an emitted .js file sitting beside its .ts source', async () => {
+    const report = await withWorkspace({
+      'routes/web.ts': ROUTES_ENTRY,
+      'routes/web.js': ROUTES_ENTRY,
+      'routes/admin.ts': ADMIN_ROUTES,
+      'routes/admin.js': ADMIN_ROUTES,
+    })
+
+    expect([...wiring(report).keys()]).toEqual(['routes/admin.ts'])
+    expect(statusOf(report, 'routes/admin.ts')).toBe('pass')
+  })
+
+  it('contributes nothing when routes/ holds only the entry file', async () => {
+    const report = await withWorkspace({ 'routes/web.ts': PLAIN_ENTRY })
+
+    expect(wiring(report).size).toBe(0)
+  })
+
+  // `--routes` may point anywhere, so the entry is excluded by resolved path,
+  // not by matching the conventional name.
+  it('treats routes/web.ts as a candidate under a custom --routes entry', async () => {
+    const report = await withWorkspace(
+      { 'routes/api.ts': API_ENTRY, 'routes/web.ts': PLAIN_ENTRY },
+      { routesFile: 'routes/api.ts' },
+    )
+
+    expect(statusOf(report, 'routes/web.ts')).toBe('warn')
+    expect(wiring(report).has('routes/api.ts')).toBe(false)
+  })
+
+  // A module mounts its routes through `defineModule({ routes })`, which never
+  // touches the app's entry registrar — flagging it would be a false alarm.
+  it('leaves a module routes file alone', async () => {
+    const report = await withWorkspace({
+      'routes/web.ts': ROUTES_ENTRY,
+      'routes/admin.ts': ADMIN_ROUTES,
+      'modules/billing/routes.ts': `import { Router } from '@guren/core'
+
+export function registerBillingRoutes(router: Router): void {
+  router.get('/billing', [BillingController, 'index'])
+}
+`,
+      'modules/billing/index.ts': `import { defineModule } from '@guren/core'
+import { registerBillingRoutes } from './routes.js'
+
+export const billingModule = defineModule({ name: 'billing', routes: registerBillingRoutes, providers: [] })
+`,
+    })
+
+    expect(statusOf(report, 'routes/admin.ts')).toBe('pass')
+    expect([...wiring(report).keys()].some((key) => key.startsWith('modules/'))).toBe(false)
+  })
+
+  it('reports a missing entry file once, not once per routes file', async () => {
+    const report = await withWorkspace({
+      'routes/admin.ts': ADMIN_ROUTES,
+      'routes/oauth.ts': `import { Router } from '@guren/core'
+
+export function registerOAuthRoutes(router: Router): void {
+  router.get('/auth/github', [OAuthController, 'redirect'])
+}
+`,
+    })
+
+    expect(wiring(report).size).toBe(0)
+    const entry = report.checks.filter((c) => c.key === 'route-entry:routes/web.ts')
+    expect(entry).toHaveLength(1)
+    expect(entry[0].status).toBe('warn')
+    expect(entry[0].message).toContain('routes/admin.ts')
+  })
+
+  it('reports an unparseable entry file once, without judging the candidates', async () => {
+    const report = await withWorkspace({
+      'routes/web.ts': `export function registerWebRoutes(router {{{`,
+      'routes/admin.ts': ADMIN_ROUTES,
+    })
+
+    expect(wiring(report).size).toBe(0)
+    const entry = report.checks.find((c) => c.key === 'route-entry:routes/web.ts')
+    expect(entry?.status).toBe('warn')
+    expect(entry?.message).toContain('could not be parsed')
+  })
+
+  // Two `make:route` outputs both export `registerRoutes`, so the obvious
+  // import line would not compile once the first one is wired.
+  it('flags the name collision two make:route files produce', async () => {
+    const report = await withWorkspace({
+      'routes/web.ts': `import { Router } from '@guren/core'
+import { registerRoutes } from './reports.js'
+
+export function registerWebRoutes(baseRouter: Router): void {
+  registerRoutes(baseRouter)
+}
+`,
+      'routes/reports.ts': `import { Router } from '@guren/core'
+
+export function registerRoutes(router: Router): void {
+  router.get('/reports', [ReportController, 'index'])
+}
+`,
+      'routes/invoices.ts': `import { Router } from '@guren/core'
+
+export function registerRoutes(router: Router): void {
+  router.get('/invoices', [InvoiceController, 'index'])
+}
+`,
+    })
+
+    expect(statusOf(report, 'routes/reports.ts')).toBe('pass')
+    expect(statusOf(report, 'routes/invoices.ts')).toBe('warn')
+    expect(wiring(report).get('routes/invoices.ts')!.suggestion).toContain('under an alias')
+  })
+
+  // The API-only template ships `routes/api.ts` and no `routes/web.ts`, and
+  // wires `--routes routes/api.ts` into its own codegen script — a bare
+  // `guren check` there must not report the app as having no entry at all.
+  it('falls back to routes/api.ts when there is no routes/web.ts', async () => {
+    const report = await withWorkspace({ 'routes/api.ts': API_ENTRY })
+
+    expect(wiring(report).size).toBe(0)
+    expect(report.checks.some((c) => c.key.startsWith('route-entry:'))).toBe(false)
+  })
+
+  it('judges candidates against routes/api.ts when that is the only entry', async () => {
+    const report = await withWorkspace({ 'routes/api.ts': API_ENTRY, 'routes/admin.ts': ADMIN_ROUTES })
+
+    const finding = wiring(report).get('routes/admin.ts')
+    expect(finding?.status).toBe('warn')
+    expect(finding!.message).toContain('routes/api.ts')
+    expect(finding!.suggestion).toContain('Add to routes/api.ts')
+  })
+
+  // The edit hook runs `runCheck({ changed: true })` on every save of a
+  // controller, model, or page — none of which can move this answer, and all
+  // of which would otherwise re-parse routes/ to re-derive it.
+  it('is skipped under --changed when nothing under routes/ changed', async () => {
+    const workspace = await createTempWorkspace('guren-cli-check-routes-changed-')
+
+    try {
+      await writeWorkspaceFiles(workspace.dir, {
+        'routes/web.ts': PLAIN_ENTRY,
+        'routes/admin.ts': ADMIN_ROUTES,
+        'app/Http/Controllers/PostController.ts': 'export default class PostController {}\n',
+      })
+      const git = (...args: string[]): void => {
+        spawnSync('git', args, { cwd: workspace.dir, stdio: 'ignore' })
+      }
+      git('init', '-b', 'main')
+      git('config', 'user.email', 'test@example.com')
+      git('config', 'user.name', 'Test')
+      git('add', '.')
+      git('commit', '-m', 'initial')
+
+      // An unrelated edit must not wake it.
+      await writeFile(
+        join(workspace.dir, 'app/Http/Controllers/PostController.ts'),
+        'export default class PostController { async index() {} }\n',
+        'utf8',
+      )
+      expect(wiring(await runCheck({ cwd: workspace.dir, changed: true })).size).toBe(0)
+
+      // A brand-new, never-committed routes file does — this is how
+      // `make:route` output reaches the check, and the gate only sees it
+      // because getChangedFiles unions `ls-files --others`.
+      await writeFile(join(workspace.dir, 'routes/orphan.ts'), ADMIN_ROUTES, 'utf8')
+      expect(statusOf(await runCheck({ cwd: workspace.dir, changed: true }), 'routes/orphan.ts')).toBe('warn')
+
+      // Editing the entry — the change that actually breaks wiring — does.
+      await writeFile(join(workspace.dir, 'routes/web.ts'), `${PLAIN_ENTRY}\n`, 'utf8')
+      expect(statusOf(await runCheck({ cwd: workspace.dir, changed: true }), 'routes/admin.ts')).toBe('warn')
+    } finally {
+      await workspace.cleanup()
+    }
+    // Spawns git and runs the suite twice; the default 5s budget is tight
+    // enough that an unrelated slow machine turns this red.
+  }, 30_000)
+
+  it('does not run under --arch', async () => {
+    const report = await withWorkspace(
+      { 'routes/web.ts': ROUTES_ENTRY, 'routes/admin.ts': ADMIN_ROUTES },
+      { arch: true },
+    )
+
+    expect(wiring(report).size).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary

`guren check` now reports a `routes/*.ts` file whose registrar nothing reachable from the app's entry registrar calls.

Such a file compiles, type-checks, and reads as wired from the inside — its only symptom is a 404 in production. That is the state `guren add admin|oauth|resource|auth` left behind in any app scaffolded from the blog blueprint, because the wiring step matched only a registrar whose parameter was literally named `router` (#335). Fixing the scaffolders does nothing for the apps already in that state; this reports them, and names the import-and-call line to add. It also covers the files nothing wires automatically — `make:route` writes its routes file and leaves mounting to you.

Mounting spreads outward from the entry file (`routes/web.ts`, or `--routes`) and is tracked **per exported name**: a file counts as mounted once some already-mounted file uses a binding that traces back to one of its registrar exports. Both halves are load-bearing — crediting a whole file for any binding passes an `admin.ts` whose `ADMIN_PREFIX` constant is imported while its registrar is dead; crediting from any *parsed* file passes an `admin.ts` called only by a `group.ts` that nothing calls in turn.

What counts as a registrar comes from `route-registrar.ts`, the same contract the route loader resolves at runtime, so the check cannot disagree with what the framework will actually mount.

Counted as mounted: a nested registrar, a barrel re-export (with `export *` correctly shadowed by an explicit named re-export), a namespace import, an `await import()`, and a registrar the entry only re-exports. Not counted: an import with no call, an import of some *other* export from the same file, and a registrar reached only through an unmounted intermediate.

Two wirings it cannot see, both reported as unmounted and documented as such: a chain that leaves `routes/` (`web.ts` → `app/routing.ts` → `routes/admin.ts`), and a registrar reached by anything less direct than importing its file.

Detection is a name reference outside the file's imports rather than a call expression, identical to the console-command registration check and for the same reason: a registrar can be handed onward as a value, and an import with no call is precisely the broken state, so the two halves must be judged apart. That looseness runs one way — a name in a comment reads as used — so the check can miss an orphan but not invent one.

Two smaller fixes fall out of the same work:

- **The entry file was *assumed* to be `routes/web.ts`.** The API-only template ships `routes/api.ts` and no `routes/web.ts`, so the new rule reported a freshly scaffolded API app as having no entry at all. `guren check` and `guren doctor` now share one candidate list. An explicit `--routes` is still honoured as given.
- **`make:route` said nothing about wiring.** It writes a routes file and leaves mounting to the user, while both app templates scaffold a CI workflow running `guren check --ci` — so it now says so at generation time rather than letting the next push explain it.

## Scope

`cli` (new `routes-check.ts`; `check`, `route-registrar`, `discovery`, `doctor`, `utils`, `console-check`, `bin`, `routes-types`, `openapi-generate`), `docs` (en + ja CLI guide), root `CLAUDE.md`.

Module routes (`modules/<name>/routes/`) are deliberately out of scope: `defineModule({ routes })` mounts a module's routes without going through the entry registrar, so the module analogue of "the entry" is a different file and needs the two-entrypoint structure `checkConsoleCommandRegistration` uses. Recorded in the code and the changeset, and filed as follow-up work.

`ROUTES_ENTRY_CANDIDATES` is shared with `doctor` only. The route *loaders* (`route-list`, `context-route`, `entity-context`, `spec-screens`) still default to `routes/web.ts` on purpose — making them probe is a behavior change with its own failure surface (a probe that silently picks `routes/api.ts` when the user meant a missing `routes/web.ts` turns a clear error into a confusing empty result). The private `DEFAULT_ROUTES_FILE` duplicates in `routes-types` and `openapi-generate` *are* folded into the shared export, since that is the same value with no behavior change.

## Risk Assessment

**`guren check --ci` gains a new failure mode.** The finding is a `warn`, like the console-command registration check, so plain `guren check` still exits zero. But `--ci` gates on any non-advisory warn, and both app templates ship a CI workflow that runs it — so a project already using that flag will start failing on an unmounted routes file. That is the point of the rule, but it can surface on upgrade rather than on the commit that introduced it. Verified by A/B: the rule alone flips the exit code 0 → 1 and back once wired. Deliberately not marked `advisory` — an unmounted route is an integrity problem, the same class as an unregistered console command, not a nudge like the test-coverage warn.

**Performance.** The edit hook runs `runCheck({ changed: true })` on every save of a controller, model, or page — none of which can move this answer. The check is therefore gated as a unit on `routes/` having changed, the way translation parity is gated on `lang/`. Filtering by changed *candidate* would be wrong (the edit that breaks the wiring is to `routes/web.ts`, not to `routes/admin.ts`), which the directory gate covers. Specifiers landing outside `routes/` are ruled out by string comparison before any filesystem probe — 17 → 1 probe on `examples/blog`.

**Content-activated.** An app whose `routes/` holds nothing but the entry file contributes zero results.

`referencesIdentifier` moved from `console-check.ts` to `utils.ts` unchanged (same escaped `\b…\b` pattern, same `u` flag); `findFirstExisting` moved from `doctor.ts` to `discovery.ts` unchanged.

## Validation

- [x] `bun run build` — exit 0
- [x] `bun run typecheck` — 0 errors across `packages/`
- [x] `bun run test` — `test:bun` 3885 pass / 55 skip / 0 fail; `test:examples` 102 pass

Also run: `audit:core-first`, `audit:docs`, `audit:starter-template`, `audit:template-deps` — all pass. `smoke:starter`, `smoke:starter:api`, `smoke:starter:blog` — all exit 0, and each scaffolds a real app and runs `guren check --ci` against it.

**Verified against real apps, both directions:**

| target | result |
|---|---|
| `examples/blog` | `routes/auth.ts` **pass** (via the `'./auth.js'` → `auth.ts` specifier) |
| `examples/blog` + a throwaway orphan | **warn**, and flips to pass when the suggested line is applied |
| `web/` | silent; its `modules/blog/routes.ts` is not flagged, confirmed with a candidate present so the run is not vacuous |
| `default` / `api-only` / `blog` templates | no findings, no findings, `routes/auth.ts` pass |

**Mutation-tested.** Each behavior is pinned by exactly one test — reverting it turns that one test red and nothing else:

| reverted behavior | test that fails |
|---|---|
| name-scoped crediting | `does not credit a file whose non-registrar export is the one imported` |
| propagate only from mounted files | `does not let an unmounted intermediate mount its descendants` |
| explicit re-export shadows `export *` | `does not credit an export * shadowed by an explicit re-export` |
| default export must be a function | `ignores a file whose default export is not a function` |
| emitted `.js` twin excluded | `ignores an emitted .js file sitting beside its .ts source` |
| dynamic-import edges | `credits a registrar reached by a dynamic import` |
| entry re-export seeding | `credits a registrar the entry re-exports rather than calls` |
| `.js` → `.ts` specifier resolution | 6 tests (the load-bearing case — without it the rule finds no edges in any real app) |
| `routes/api.ts` entry fallback | 2 tests |
| the `--changed` gate | fails when forced always-closed *and* always-open |

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks — see the `--ci` note under Risk Assessment.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation — en + ja CLI guides, `CLAUDE.md`, changeset.
