### PR TITLE
fix(orm): dedupe concurrent SQLite connection attempts

### DIFF
--- a/.changeset/sqlite-connection-single-flight.md
+++ b/.changeset/sqlite-connection-single-flight.md
@@ -1,0 +1,13 @@
+---
+'@guren/orm': patch
+---
+
+Stop concurrent callers from opening a second SQLite handle
+
+`createSqliteDatabase()` was the one driver still memoizing its connection by
+hand, and the check ran five awaits before the memo was written — so two callers
+arriving together both opened a client, ran `PRAGMA journal_mode = WAL` on it,
+and the second overwrote the first. `closeDatabase()` only ever closes the
+client it can still see, leaving the first one open for the life of the process.
+The connection now shares the `singleFlight()` helper the other four drivers
+already use, so one attempt serves every caller that races it.

--- a/packages/orm/src/sqlite.test.ts
+++ b/packages/orm/src/sqlite.test.ts
@@ -218,6 +218,49 @@ describe('createSqliteDatabase resetDatabase', () => {
   })
 })
 
+describe('createSqliteDatabase concurrent getDatabase', () => {
+  test('should open one handle when two callers race', async () => {
+    // `getDatabase()` awaits the migration run before the connection, and with
+    // no migrations to apply that await still yields — so both callers reach the
+    // connection with nothing opened yet. Anything short of sharing one
+    // in-flight promise opens a second client here, and `closeDatabase()` only
+    // ever closes the latest one.
+    const database = createSqliteDatabase({
+      migrationsFolder: join(workDir, 'migrations'),
+      filename: join(workDir, 'app.db'),
+    })
+
+    const [first, second] = await Promise.all([database.getDatabase(), database.getDatabase()])
+    expect(first).toBe(second)
+    expect(isOpen(first)).toBe(true)
+
+    // One close has to reach every client that was opened. It only can if there
+    // was one: a second client is unreachable from here, and the factory holds
+    // no reference that could close it either.
+    await database.closeDatabase()
+    expect(isOpen(first)).toBe(false)
+  })
+
+  test('should open one handle when two callers race a reopen', async () => {
+    // The shared promise has to be dropped on close and only on close: keep it
+    // and the reopen hands back the handle that was just closed, drop it too
+    // eagerly and the two callers race their way to a second client again.
+    const database = createSqliteDatabase({
+      migrationsFolder: join(workDir, 'migrations'),
+      filename: join(workDir, 'app.db'),
+    })
+
+    await database.getDatabase()
+    await database.closeDatabase()
+
+    const [first, second] = await Promise.all([database.getDatabase(), database.getDatabase()])
+    expect(first).toBe(second)
+    expect(isOpen(first)).toBe(true)
+
+    await database.closeDatabase()
+  })
+})
+
 describe('createSqliteDatabase closeDatabase', () => {
   test('should close the underlying handle', async () => {
     const database = createSqliteDatabase({

--- a/packages/orm/src/sqlite.ts
+++ b/packages/orm/src/sqlite.ts
@@ -49,13 +49,12 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
         ? fileURLToPath(seedersFolder)
         : resolve(String(seedersFolder))
 
-  let db: unknown
   let sqliteClient:
     | { query(sql: string): { all(): unknown[] }; exec(sql: string): void; close(): void }
     | undefined
   let activeKey: string | undefined
-  // Captured here, not in ensureDatabase(), so the caller of this factory is
-  // the frame that identifies the handle across hot reloads.
+  // Captured here, not in the connection factory, so the caller of this factory
+  // is the frame that identifies the handle across hot reloads.
   const callSite = new Error().stack
 
   function resolveFilename(): string {
@@ -63,9 +62,11 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
     return value ?? process.env.DATABASE_URL ?? './data/guren.db'
   }
 
-  async function ensureDatabase(): Promise<unknown> {
-    if (db) return db
-
+  // Unlike the other drivers, this flight must not open with
+  // `await migrations.get()`: sqlite migrates over this very handle, so the
+  // migration flight awaits `database.get()` and the two would deadlock.
+  // `getDatabase()` sequences them from outside instead.
+  const database = singleFlight(async (): Promise<unknown> => {
     const dbPath = resolveFilename()
 
     // Ensure the directory exists
@@ -77,17 +78,25 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
       // directory may already exist
     }
 
+    // Both driver modules are resolved before any client exists. An attempt
+    // that rejects with the client already open strands it — the memo is
+    // dropped, so the retry opens a second one and overwrites `sqliteClient` —
+    // and a missing `drizzle-orm/bun-sqlite` is the likeliest way to reject
+    // here. Keeping the two loads above `new Database()` also leaves
+    // `replaceActiveConnection` as the only await the attempt takes once the
+    // client is live.
     const { Database } = await import('bun:sqlite')
+    const { drizzle } = await import('drizzle-orm/bun-sqlite')
+    type DrizzleConfig = NonNullable<Exclude<Parameters<typeof drizzle>[0], string>>
+
     const sqlite = new Database(dbPath)
     sqlite.exec('PRAGMA journal_mode = WAL;')
     sqliteClient = sqlite
-
-    const { drizzle } = await import('drizzle-orm/bun-sqlite')
-    type DrizzleConfig = NonNullable<Exclude<Parameters<typeof drizzle>[0], string>>
-    // Held locally as well as in closure state: a newer evaluation may close
-    // this handle while the await below is suspended, which clears `db`.
-    const database = drizzle({ client: sqlite, ...(relations ? { relations } : {}) } as DrizzleConfig)
-    db = database
+    // Returned from this local, not from closure state: a newer evaluation may
+    // close this handle while the await below is suspended, clearing
+    // `sqliteClient` and dropping the memo this attempt is filling. The attempt
+    // still owes its own callers the handle it built.
+    const handle = drizzle({ client: sqlite, ...(relations ? { relations } : {}) } as DrizzleConfig)
 
     // In-memory databases share no underlying file, so two of them are distinct
     // handles even when every option matches — there is nothing to key them on.
@@ -96,20 +105,20 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
       await replaceActiveConnection(activeKey, closeDatabase)
     }
 
-    return database
-  }
+    return handle
+  })
 
   async function closeDatabase(): Promise<void> {
-    if (!db) return
+    if (!sqliteClient) return
 
     const key = activeKey
     activeKey = undefined
 
     try {
-      sqliteClient?.close()
+      sqliteClient.close()
     } finally {
-      db = undefined
       sqliteClient = undefined
+      database.reset()
       if (key) {
         releaseActiveConnection(key, closeDatabase)
       }
@@ -123,9 +132,9 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
         return
       }
 
-      const database = await ensureDatabase()
+      const db = await database.get()
       const { migrate } = await import('drizzle-orm/bun-sqlite/migrator')
-      await migrate(database as any, { migrationsFolder: resolvedMigrationsFolder }) // eslint-disable-line @typescript-eslint/no-explicit-any
+      await migrate(db as any, { migrationsFolder: resolvedMigrationsFolder }) // eslint-disable-line @typescript-eslint/no-explicit-any
     } catch (error) {
       // No endpoint: a SQLite file has no host, so only the cause chain adds signal.
       throw migrationFailure(error)
@@ -135,7 +144,7 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
   return {
     async getDatabase() {
       await migrations.get()
-      return ensureDatabase()
+      return database.get()
     },
 
     migrateDatabase: migrations.get,
@@ -143,7 +152,7 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
     closeDatabase,
 
     async resetDatabase() {
-      await ensureDatabase()
+      await database.get()
       if (!sqliteClient) return
 
       // Anything left behind fails the next migration run, and three things
@@ -176,7 +185,7 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
       const localMigrations = listLocalMigrations(resolvedMigrationsFolder)
       if (localMigrations.length === 0) return []
 
-      await ensureDatabase()
+      await database.get()
       let appliedRows: Array<{ name: string | null; appliedAt: string | null }> = []
       try {
         const rows = sqliteClient
@@ -191,19 +200,19 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
     },
 
     async configureOrm() {
-      const database = await ensureDatabase()
+      const db = await database.get()
       await migrations.get()
-      DrizzleAdapter.configure(database as Parameters<typeof DrizzleAdapter.configure>[0])
+      DrizzleAdapter.configure(db as Parameters<typeof DrizzleAdapter.configure>[0])
     },
 
     async seedDatabase() {
       if (!resolvedSeedersFolder) {
         throw new Error('No seeders folder configured. Provide "seedersFolder" when calling createSqliteDatabase().')
       }
-      const database = await ensureDatabase()
+      const db = await database.get()
       try {
         // No endpoint: a SQLite file has no host, so only the cause chain adds signal.
-        await runSeeders(database, resolvedSeedersFolder)
+        await runSeeders(db, resolvedSeedersFolder)
       } catch (error) {
         throw seedFailure(error)
       }


### PR DESCRIPTION
## Summary

`createSqliteDatabase()` was the last driver memoizing its connection by hand:

```ts
let db: unknown
async function ensureDatabase() {
  if (db) return db
  // ... five awaits ...
  db = database
}
```

Five `await`s ran before the memo was written. `getDatabase()` is `await migrateOnce(); return ensureDatabase()`, and `migrateOnce()` always yields — so two callers arriving together both fell through the guard: two `new Database(dbPath)`, two `PRAGMA journal_mode = WAL`, and `sqliteClient` overwritten by the second. `closeDatabase()` only ever closes the client it can still see, so the first handle stayed open for the life of the process.

The connection now shares the `singleFlight()` helper the other four drivers already use (#339). `sqliteClient` becomes the sole liveness flag and `closeDatabase()` drops the memo, exactly as `postgres.ts` / `mysql.ts` / `aws-data-api.ts` do.

Two details worth a reviewer's attention:

**The driver imports are hoisted above `new Database()`, and that ordering is load-bearing.** An attempt that rejects with the client already open strands it — `singleFlight` drops the memo, so the retry opens a second client and overwrites `sqliteClient` — and a missing `drizzle-orm/bun-sqlite` is the likeliest way to reject there. The hoist also leaves `replaceActiveConnection` as the only `await` the attempt takes once the client is live. **Nothing tests this**; a future cleanup that moves the import back down reintroduces the window silently. The comment at the import site is the only enforcement.

**This flight cannot open with `await migrations.get()` the way postgres and mysql do.** sqlite migrates over this very handle, so the migration flight awaits `database.get()`; folding migrations into the connection flight is a real cycle. `getDatabase()` and `configureOrm()` sequence the two from outside, in opposite orders, and both are acyclic because the connection flight awaits nothing of migrations.

## Scope

`orm` only — `packages/orm/src/sqlite.ts` plus its tests and a changeset. No public API change; `ensureDatabase` was private and the exported interface is unchanged.

## Risk Assessment

**One behavior change, in the fix's favor.** `closeDatabase()` now guards on `sqliteClient` rather than on the handle. On the success path the two are equivalent — no `await` separates the client assignment from the handle built on it. They differ only when an attempt rejects with the client already open (a malformed `relations` object reaching `drizzle()` is a reachable example): the old guard returned early and left that client open, the new one closes it.

**A second manifestation of the same bug that this also closes**, worth knowing about because it is more alarming than a leaked fd: on the old code a `getDatabase()` / `resetDatabase()` race opened two clients, and `resetDatabase` then dropped tables through whichever one won the `sqliteClient` assignment — a handle nobody else was holding. No test covers it; the race is real but not observable from the public API, so a test for it would pass on the buggy code.

**Pre-existing, not addressed here.** Even with the imports hoisted, `drizzle()` and `replaceActiveConnection` can still reject after the client is open, stranding it on retry. The other four drivers are identical in this respect; fixing it belongs with the shared lifecycle, not in one driver.

## Validation

- [x] `bun run build:clean` — all 11 packages (used instead of `build` per the stale-`dist/` rule; this branch is based on a commit that rewrote `packages/orm/src`)
- [x] `bun run typecheck` (root) — clean
- [x] `bun run test:bun` — 3871 pass / 0 fail / 235 files
- [ ] `bun run test:examples` — not run; the blog example needs a Postgres container and this change is sqlite-only

Both new tests were mutation-checked rather than assumed:

| mutation | result |
|---|---|
| restore the pre-fix hand-rolled memo | both new tests fail |
| drop `database.reset()` from `closeDatabase()` | reopen test fails, plus the existing explicit-close test |

The `isOpen(first) === true` assertion before the close is deliberate: without it an implementation returning `undefined` to both callers would satisfy the identity check.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation. (changeset; no user-facing docs describe this internal memoization)

## Follow-ups (not in this PR)

- All five drivers now keep the same `client` + flight + `reset()` trio by hand. The root cause is that `SingleFlight` offers no synchronous view of settled state, so each driver needs a parallel liveness flag. Collapsing it touches five files with real per-driver variance and is not patch-sized.
- The migration/connection ordering has no test coverage in any direction: no sqlite drizzle-migrations fixture exists in the repo, so every sqlite test takes the `hasDrizzleMigrations()` early return and `migrations.get()` never reaches `database.get()`. A minimal fixture would cover both the prescribed sequencing and the deadlock the comments warn about.
- `replaceActiveConnection` installs a claim in the registry before its own call finishes, so a third overlapping hot-reload claim can tear down the second claim's client before that claim's caller runs. The existing overlap test only asserts the second result is defined, never that it is usable — which is weaker than the "every claim a usable handle" name promises.