### PR TITLE
test(docs): raise the web suite timeout past a cold shiki start

### DIFF
--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -29,5 +29,13 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
+    // Every test here runs in single-digit milliseconds except the two that
+    // reach live shiki — FsDocsStore.getRendered and HomeController.index,
+    // which take the live-highlighting path because shouldUsePrerendered() is
+    // false outside production. Loading the WASM regex engine, the themes and
+    // one grammar per fenced language costs ~1.2s on its own, ~2s under normal
+    // full-suite contention and ~4s on an otherwise loaded machine, so the 5s
+    // default sits just above a cold shiki start and flakes under load.
+    testTimeout: 30_000,
   },
 })


### PR DESCRIPTION
## Summary

`bun run test` in `web/` fails intermittently — between 0 and 2 of 16 files, varying run to run on identical code:

- `tests/services/DocsStore.test.ts` > `FsDocsStore > should read raw markdown and render html for a known doc`
- `tests/controllers/HomeController.test.ts` > `HomeController > renders landing page metadata through inertia`

These are the only two tests in the suite that reach live shiki. Every other test runs in single-digit milliseconds; these load the WASM regex engine, two themes, and one grammar per fenced language. They are not hanging — they are slow tests hitting vitest's 5s default, which sits just above the cost of a cold shiki start.

Measured on the `FsDocsStore` case (8-core Mac):

| condition | duration |
|---|---|
| that file alone | 1,184ms |
| full suite, warm transform cache | 2,111ms |
| full suite, cold transform cache | 1,795ms |
| full suite + 2x CPU oversubscription | 2,991ms (`HomeController`: 4,176ms) |

The reported failures show ~9.5–10s alongside a `collect` time of 60–76s; the loaded run above reproduces `collect` at 57–80s, so the reporting machine is simply further along the same curve.

Prerendered content cannot absorb this cost: `shouldUsePrerendered()` returns `false` whenever `NODE_ENV !== 'production'` (the suite pins that behavior itself), so both call sites take the live-highlighting path under vitest regardless of what `web/.guren/` holds. Running the real prerender instead of `prerender:stub` would not help.

`testTimeout` is raised at the config level rather than on the two tests, so the next test that renders markdown does not rediscover the same wall. A `setupFiles` warm-up was considered and rejected: it would pay the shiki load in all 16 workers to fix 2.

### The Drizzle line is unrelated

The `DrizzleAdapter: database has not been configured` message that prints alongside these failures is not a boot failure and not causal:

- It originates in `web/modules/blog/routes.test.ts` — a third file, in a separate vitest worker. Neither failing test touches the ORM (`HomeController.test.ts` replaces `@guren/core` wholesale via `createControllerModuleMock()`).
- It comes from a request, not from boot: `BlogController.index` → `listPublishedPosts`.
- It is not a process-level unhandled rejection — it is `console.error('Unhandled exception:', error)` at `packages/server/src/errors/ExceptionHandler.ts:133`, the framework's label for a caught exception it could not map to a status. The wording is what makes it read like a boot failure.
- It is deliberate. That test's own comment: the request "reaches the controller (which may then fail on the unconfigured test database — anything but a redirect proves the route is not behind the guard)".

Left unchanged here. Silencing the noise is a reasonable separate change.

## Scope

`docs` (the `web/` documentation site) — test configuration only. No source or runtime behavior changes.

## Risk Assessment

None to shipped code: the diff is a comment plus one vitest option. The one trade-off is that a test that genuinely hangs now takes 30s to surface instead of 5s. Given the suite's median test is 1–5ms and only these two are measured in seconds, that seems the right side to err on.

## Validation

- Full `web/` suite, 3 consecutive runs under artificial CPU load: 16 files / 102 tests passed each time.
- Mutation check (the fix can fail): temporarily setting `testTimeout: 1_500` makes **exactly** the two reported tests fail with `Test timed out in 1500ms`, and nothing else — confirming this option governs these two and only these two.

```
 Test Files  2 failed | 14 passed (16)
      Tests  2 failed | 100 passed (102)
```

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` (`web/` suite; see above)

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [ ] I added/updated tests for behavior changes — no behavior change; this fixes a flaky threshold.
- [ ] I updated relevant documentation — the rationale lives in a comment next to the option.
