### PR TITLE
fix(cli): refuse the auth scaffold on API-only apps

### DIFF
--- a/.changeset/auth-scaffold-refuses-api-only.md
+++ b/.changeset/auth-scaffold-refuses-api-only.md
@@ -1,0 +1,29 @@
+---
+'@guren/cli': patch
+---
+
+Refuse the auth scaffold on an API-only app instead of writing pages it cannot render
+
+`guren add auth` and `guren make:auth` scaffold an Inertia sign-in experience, and
+on an app created from the `api` blueprint none of it worked. The controllers
+return Inertia responses and the pages they name (`resources/js/pages/auth/*.tsx`,
+`resources/js/components/Layout.tsx`) are React components, so nothing typechecked
+against a `@guren/inertia-client` the API starter never installs. The route wiring
+targets `routes/web.ts`, which that starter does not have — it registers
+`registerApiRoutes` from `routes/api.ts` — so `routes/auth.ts` was written and
+mounted by nothing, and the CLI still printed that you could visit `/login`.
+
+Auth also patches `db/schema.ts` and generates a users migration, so the check runs
+before the first write rather than before the first file: a run stopped halfway
+through those leaves changes no `--force` rerun undoes. It refuses with a message
+naming both signals it read and leaves the app exactly as it was.
+
+The refusal points at the token flow the framework already ships —
+`createBearerTokenMiddleware` over a `DatabaseApiTokenStore` or
+`RedisApiTokenStore` — rather than scaffolding it. Generating that variant is a
+separate piece of work, not a smaller one: it needs a parallel set of controller
+and route templates for each of the four sign-in shapes this command supports, an
+`api_tokens` table and migration alongside the users one, a routes target other
+than the hardcoded `routes/web.ts`, and an answer for the registration, password
+reset, and email verification flows, which mail absolute links whose only landing
+pages are the ones being refused.

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -70,6 +70,14 @@ scaffolded from the `api` blueprint — no `@guren/inertia-client` dependency an
 controller that does not typecheck and a routes file nothing mounts. Add an admin
 endpoint to `routes/api.ts` by hand instead.
 
+`add auth` needs a fullstack app for the same reason, and refuses on the same two
+signals — as does `make:auth`, which reaches the same scaffold. Auth also patches
+`db/schema.ts` and generates a migration, so the refusal comes before all of that,
+not just before the first file: the app is left exactly as it was. For a
+token-based API, guard `routes/api.ts` with `createBearerTokenMiddleware` from
+`@guren/core` and issue tokens with `createApiToken` — see the
+[API tokens guide](./api-tokens.md).
+
 ## Core Commands
 
 | Command | Description | Example |

--- a/docs/en/guides/ship-api.md
+++ b/docs/en/guides/ship-api.md
@@ -180,21 +180,31 @@ curl -X DELETE http://localhost:3333/api/tasks/1
 
 ## 9. Add API Token Authentication
 
-For routes that require authentication, add token-based auth:
-
-```bash
-bunx guren add auth --api
-```
-
-Then protect routes with the `auth:api` middleware:
+For routes that require authentication, wire up API tokens. There is no scaffold
+for this — `guren add auth` generates an Inertia sign-in experience and refuses to
+run on an API-only app, so build the middleware yourself:
 
 ```typescript
-router.middleware('auth:api').group((auth) => {
+import { createBearerTokenMiddleware, DatabaseApiTokenStore } from '@guren/core'
+import { apiTokens } from '@/db/schema'
+
+const store = new DatabaseApiTokenStore(apiTokens)
+
+export const requireApiToken = createBearerTokenMiddleware({ store })
+```
+
+Then protect the mutating routes with it:
+
+```typescript
+router.middleware(requireApiToken).group((auth) => {
   auth.post('/api/tasks', [TaskController, 'store']).name('tasks.store')
   auth.put('/api/tasks/:id', [TaskController, 'update']).name('tasks.update')
   auth.delete('/api/tasks/:id', [TaskController, 'destroy']).name('tasks.destroy')
 })
 ```
+
+See the [API tokens guide](./api-tokens.md) for the `api_tokens` table, issuing
+tokens with `createApiToken`, and scoping them with abilities.
 
 Clients include the token in the `Authorization` header:
 

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -68,6 +68,14 @@ bunx guren add admin --public
 ファイルを書く代わりに、コマンドが理由を示して中断し何も生成しません。管理用の
 エンドポイントは `routes/api.ts` に手動で追加してください。
 
+`add auth` も同じ理由でフルスタックアプリ専用で、同じ2つのシグナルを見て中断します。
+同じスキャフォールドを生成する `make:auth` も同様です。auth は `db/schema.ts` への
+パッチとマイグレーション生成も行うため、中断は最初のファイル書き込みだけでなく
+それらすべてより前に起こり、アプリは元のまま残ります。トークンベースのAPIに
+するには、`@guren/core` の `createBearerTokenMiddleware` で `routes/api.ts` を
+保護し、`createApiToken` でトークンを発行してください
+（[APIトークンガイド](./api-tokens.md)参照）。
+
 ## 主要コマンド
 
 | コマンド | 説明 | 例 |

--- a/docs/ja/guides/ship-api.md
+++ b/docs/ja/guides/ship-api.md
@@ -180,21 +180,31 @@ curl -X DELETE http://localhost:3333/api/tasks/1
 
 ## 9. API トークン認証を追加する
 
-認証が必要なルートにはトークンベースの認証を追加します:
-
-```bash
-bunx guren add auth --api
-```
-
-`auth:api` ミドルウェアでルートを保護します:
+認証が必要なルートにはAPIトークンを配線します。これにスキャフォールドはありません
+— `guren add auth` は Inertia のサインイン画面を生成するため、API 専用アプリでは
+実行を拒否します。ミドルウェアは自分で用意してください:
 
 ```typescript
-router.middleware('auth:api').group((auth) => {
+import { createBearerTokenMiddleware, DatabaseApiTokenStore } from '@guren/core'
+import { apiTokens } from '@/db/schema'
+
+const store = new DatabaseApiTokenStore(apiTokens)
+
+export const requireApiToken = createBearerTokenMiddleware({ store })
+```
+
+これで変更系のルートを保護します:
+
+```typescript
+router.middleware(requireApiToken).group((auth) => {
   auth.post('/api/tasks', [TaskController, 'store']).name('tasks.store')
   auth.put('/api/tasks/:id', [TaskController, 'update']).name('tasks.update')
   auth.delete('/api/tasks/:id', [TaskController, 'destroy']).name('tasks.destroy')
 })
 ```
+
+`api_tokens` テーブル、`createApiToken` でのトークン発行、abilities によるスコープ
+制限については[APIトークンガイド](./api-tokens.md)を参照してください。
 
 クライアントは `Authorization` ヘッダーにトークンを含めます:
 

--- a/packages/cli/src/app-surface.ts
+++ b/packages/cli/src/app-surface.ts
@@ -45,3 +45,27 @@ export async function isConfirmedApiOnlyApp(cwd: string): Promise<boolean> {
   const webRoutes = await Promise.all(WEB_ROUTES_CANDIDATES.map((file) => fileExists(cwd, file)))
   return !webRoutes.includes(true)
 }
+
+/**
+ * Refuses an API-only app on a scaffolder's behalf, before its first write.
+ *
+ * The middle of the message — which signals were read — belongs to the
+ * predicate above, not to each caller. Callers supplied it themselves until
+ * there were two of them saying it in two places, and a signal added or dropped
+ * here would have left both descriptions stale independently.
+ *
+ * `does` completes "guren add x scaffolds …" and `instead` is the whole
+ * alternative sentence, because what an app should do without this scaffold
+ * differs per command in a way no template can derive.
+ */
+export async function assertNotApiOnly(
+  cwd: string,
+  { does, instead }: { does: string; instead: string },
+): Promise<void> {
+  if (!(await isConfirmedApiOnlyApp(cwd))) return
+
+  throw new Error(
+    `${does}, but this app has no @guren/inertia-client dependency and no ${DEFAULT_ROUTES_FILE}. `
+    + `${instead}, or scaffold a fullstack app.`,
+  )
+}

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -1,4 +1,4 @@
-import { isConfirmedApiOnlyApp } from './app-surface'
+import { assertNotApiOnly } from './app-surface'
 import { makeAuth } from './make-auth'
 import { makeChannel } from './make-channel'
 import { buildRouteRegistrationHint, makeFeature } from './make-feature'
@@ -56,13 +56,10 @@ const blueprintRegistry: Record<string, BlueprintDefinition> = {
     run: async (options) => {
       // Before the first write: every file below is Inertia-shaped, so a
       // partial scaffold here is only harder to clean up than none.
-      if (await isConfirmedApiOnlyApp(process.cwd())) {
-        throw new Error(
-          'guren add admin scaffolds an Inertia dashboard, but this app has no @guren/inertia-client '
-          + 'dependency and no routes/web.ts. Add an admin endpoint to routes/api.ts by hand, '
-          + 'or scaffold a fullstack app.',
-        )
-      }
+      await assertNotApiOnly(process.cwd(), {
+        does: 'guren add admin scaffolds an Inertia dashboard',
+        instead: 'Add an admin endpoint to routes/api.ts by hand',
+      })
 
       const writerOptions: WriterOptions = { force: Boolean(options.force) }
       // Same default as `make:feature`: guarded unless the caller opts out.
@@ -158,6 +155,10 @@ export default registerAdminRoutes
   },
   auth: {
     description: 'Install the default authentication stack for the current app.',
+    // The API-only refusal lives inside makeAuth() rather than here, unlike the
+    // admin blueprint's: `guren make:auth` reaches the same scaffold without
+    // passing through this registry, so a guard placed here would leave that
+    // door open.
     run: async (options) => makeAuth({ force: Boolean(options.force), install: true }),
   },
   oauth: {

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { dirname, relative, resolve, sep as pathSep } from 'node:path'
 import { consola } from 'consola'
 import { assertCwdUnsupported, writeScaffoldFiles, type WriterOptions } from './utils'
+import { assertNotApiOnly } from './app-surface'
 import {
   addImport,
   addProvider,
@@ -2215,6 +2216,16 @@ function resolveAuthFeatures(options: MakeAuthOptions): AuthFeatures {
 
 export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]> {
   assertCwdUnsupported(options, 'make:auth')
+
+  // Every variant of this scaffold is Inertia-shaped, and the refusal has to
+  // precede the schema patch and the migration as well as the first write — a
+  // run stopped halfway through those is harder to undo than one that never
+  // started.
+  await assertNotApiOnly(process.cwd(), {
+    does: 'The auth scaffold renders Inertia sign-in pages',
+    instead: 'Guard routes/api.ts with createBearerTokenMiddleware from @guren/core instead',
+  })
+
   const features = resolveAuthFeatures(options)
   const { includeExtras, includeVerify, includePassword, passwordOnlySignUp, oauthProviders } = features
   const includeOAuth = oauthProviders.length > 0

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -12,6 +12,7 @@ import {
   REGISTRAR_LESS_ROUTES_FIXTURE,
   captureWarnings,
   createTempWorkspace,
+  seedApiOnlyApp,
   type TempWorkspace,
 } from './helpers'
 import { listBlueprints, runBlueprint } from '../src/blueprints'
@@ -515,17 +516,8 @@ describe('admin blueprint on an API-only app', () => {
     await workspace.cleanup()
   })
 
-  async function seedApiOnlyWorkspace(): Promise<void> {
-    await mkdir('routes', { recursive: true })
-    await writeFile('routes/api.ts', API_ROUTES_FIXTURE)
-    await writeFile('package.json', JSON.stringify({
-      name: 'api-app',
-      dependencies: { '@guren/cli': '^2.2.0', '@guren/core': '^1.5.1', '@guren/orm': '^2.2.0' },
-    }))
-  }
-
   it('refuses, naming the two signals it read', async () => {
-    await seedApiOnlyWorkspace()
+    await seedApiOnlyApp(workspace.dir)
 
     await expect(runBlueprint('admin')).rejects.toThrow(
       /no @guren\/inertia-client dependency and no routes\/web\.ts/,
@@ -535,7 +527,7 @@ describe('admin blueprint on an API-only app', () => {
   // The half that matters: refusing after the first write would leave exactly
   // the mess the refusal exists to prevent.
   it('writes nothing at all', async () => {
-    await seedApiOnlyWorkspace()
+    await seedApiOnlyApp(workspace.dir)
 
     await expect(runBlueprint('admin')).rejects.toThrow()
 
@@ -626,6 +618,30 @@ describe('admin blueprint on an API-only app', () => {
     } finally {
       await chmod('package.json', 0o644)
     }
+  })
+})
+
+describe('auth blueprint on an API-only app', () => {
+  let workspace: TempWorkspace
+
+  beforeEach(async () => {
+    workspace = await createTempWorkspace('guren-cli-auth-api-only-')
+  })
+
+  afterEach(async () => {
+    await workspace.cleanup()
+  })
+
+  // One test, because this blueprint is pure delegation to makeAuth() — the
+  // only thing it can get wrong is failing to reach the guard at all. What the
+  // guard then does, and every branch of the shared predicate behind it, is
+  // pinned in make-auth.test.ts and in the admin block above.
+  it('reaches the refusal inside makeAuth', async () => {
+    await seedApiOnlyApp(workspace.dir)
+
+    await expect(runBlueprint('auth')).rejects.toThrow(
+      /no @guren\/inertia-client dependency and no routes\/web\.ts/,
+    )
   })
 })
 

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -139,6 +139,27 @@ export function registerApiRoutes(router: Router): void {
 }
 `
 
+/**
+ * The one spelling of "an app `isConfirmedApiOnlyApp` recognizes", for every
+ * test that asks a scaffolder to refuse one.
+ *
+ * Each caller used to seed its own, and the copies had already drifted in which
+ * dependencies they declared — so a change to what the predicate reads would
+ * have had to be re-verified against three subtly different apps. `db/schema.ts`
+ * is here because a scaffolder that got past the refusal would patch it, and a
+ * test cannot assert it was left alone unless it exists.
+ */
+export async function seedApiOnlyApp(dir: string): Promise<void> {
+  await writeWorkspaceFiles(dir, {
+    'routes/api.ts': API_ROUTES_FIXTURE,
+    'db/schema.ts': PG_SCHEMA_FIXTURE,
+    'package.json': JSON.stringify({
+      name: 'api-app',
+      dependencies: { '@guren/cli': '^2.2.0', '@guren/core': '^1.5.1', '@guren/orm': '^2.2.0' },
+    }),
+  })
+}
+
 export const BLOG_ROUTES_FIXTURE = `import { Router, requireAuthenticated } from '@guren/core'
 
 export function registerWebRoutes(baseRouter: Router): void {

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'bun:test'
+import { existsSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { consola } from 'consola'
-import { BLOG_ROUTES_FIXTURE, createTempWorkspace, MYSQL_SCHEMA_FIXTURE, PG_SCHEMA_FIXTURE, SQLITE_SCHEMA_FIXTURE } from './helpers'
+import { API_ROUTES_FIXTURE, BLOG_ROUTES_FIXTURE, createTempWorkspace, MYSQL_SCHEMA_FIXTURE, PG_SCHEMA_FIXTURE, seedApiOnlyApp, SQLITE_SCHEMA_FIXTURE } from './helpers'
 import { makeAuth } from '../src/make-auth'
 
 // Shared with packages/create-app/templates/blog/app/Providers/AuthProvider.ts,
@@ -1195,5 +1196,59 @@ export function registerWebRoutes(router: Router): void {
     } finally {
       await workspace.cleanup()
     }
+  })
+
+  // `guren add auth` reaches this same function through the blueprint registry,
+  // which is where the sibling `add admin` refusal lives. These cover the other
+  // door: `guren make:auth` calls makeAuth() directly.
+  describe('on an API-only app', () => {
+    it('refuses, naming the two signals it read', async () => {
+      const workspace = await createTempWorkspace('guren-cli-make-auth-api-only-')
+      try {
+        await seedApiOnlyApp(workspace.dir)
+
+        await expect(makeAuth({ force: true })).rejects.toThrow(
+          /no @guren\/inertia-client dependency and no routes\/web\.ts/,
+        )
+      } finally {
+        await workspace.cleanup()
+      }
+    })
+
+    // The refusal has to land before the schema patch and the migration, not
+    // just before the first file write: `--force` reruns overwrite scaffolded
+    // files, but nothing undoes a patched db/schema.ts.
+    it('leaves the schema and the routes file untouched', async () => {
+      const workspace = await createTempWorkspace('guren-cli-make-auth-api-only-intact-')
+      try {
+        await seedApiOnlyApp(workspace.dir)
+
+        await expect(makeAuth({ force: true })).rejects.toThrow()
+
+        expect(await readFile(join(workspace.dir, 'db/schema.ts'), 'utf8')).toBe(PG_SCHEMA_FIXTURE)
+        expect(await readFile(join(workspace.dir, 'routes/api.ts'), 'utf8')).toBe(API_ROUTES_FIXTURE)
+        expect(existsSync(join(workspace.dir, 'app/Models/User.ts'))).toBe(false)
+        expect(existsSync(join(workspace.dir, 'resources/js/pages/auth/Login.tsx'))).toBe(false)
+      } finally {
+        await workspace.cleanup()
+      }
+    })
+
+    // The app shape is reported ahead of the flag validation, which would
+    // otherwise reject this same call for `--oauth-only` without `--oauth`.
+    // Fixing the flags gets you no further here, so naming that first would
+    // send the caller down a path that ends in this error anyway.
+    it('reports the app shape ahead of an invalid flag combination', async () => {
+      const workspace = await createTempWorkspace('guren-cli-make-auth-api-only-oauth-')
+      try {
+        await seedApiOnlyApp(workspace.dir)
+
+        await expect(makeAuth({ force: true, oauthOnly: true })).rejects.toThrow(
+          'The auth scaffold renders Inertia sign-in pages',
+        )
+      } finally {
+        await workspace.cleanup()
+      }
+    })
   })
 })


### PR DESCRIPTION
## Summary

`guren add auth` and `guren make:auth` scaffold an Inertia sign-in experience, and on an app created from the `api` blueprint every file they wrote was unusable — the same defect #340 fixed for `add admin`, in a worse shape. The controllers return Inertia responses and the pages they name (`resources/js/pages/auth/*.tsx`, a shared `Layout.tsx`) are React components, so nothing typechecked against a `@guren/inertia-client` the API starter never installs. The route wiring targets `routes/web.ts`, which that starter does not have, so `routes/auth.ts` was written and mounted by nothing — and the CLI still printed that you could visit `/login`.

Both commands now refuse up front with a message naming the two signals read, leaving the app exactly as it was.

Design decisions:

- **The guard lives in `makeAuth()`, not the blueprint registry.** Unlike `add admin`, this scaffold has a second door: `guren make:auth` calls `makeAuth()` directly without passing through the registry, so a registry-level guard would cover one entry point of two.
- **It runs before every side effect, not just the first write.** Auth also patches `db/schema.ts` and generates a users migration; a run stopped halfway through those leaves changes no `--force` rerun undoes.
- **Both refusals (admin's and auth's) now go through a shared `assertNotApiOnly()`** next to `isConfirmedApiOnlyApp()` in `app-surface.ts`. Each caller used to spell out which signals the predicate read, and the two copies had already drifted — both under-reported `routes/web.js`. The helper owns that sentence; callers supply only what their scaffold does and what to do instead.
- **Rejection over an API variant, for now.** The refusal points at the token flow the framework already ships (`createBearerTokenMiddleware` over `DatabaseApiTokenStore` / `RedisApiTokenStore`) rather than scaffolding it. Generating that variant is a separate piece of work: parallel controller/route templates for each of the four sign-in shapes this command supports, an `api_tokens` migration alongside the users one, a routes target other than the hardcoded `routes/web.ts`, and an answer for the registration/reset/verification flows that mail absolute links whose only landing pages are the ones being refused.

Also fixed in passing: the ship-api guide told API-app readers to run `guren add auth --api` — a flag that does not exist, against an `auth:api` middleware alias nothing registers, and a command this change makes throw. It now wires `createBearerTokenMiddleware` over `DatabaseApiTokenStore` directly, the path the refusal message points at.

## Scope

- **cli**: `make-auth.ts` (the guard), `app-surface.ts` (`assertNotApiOnly`), `blueprints.ts` (admin routed through the helper; comment on why auth's guard is elsewhere)
- **cli tests**: shared `seedApiOnlyApp` fixture replacing three drifting copies; refusal tests in `make-auth.test.ts`; one delegation test in `blueprints.test.ts`
- **docs**: `add auth`/`make:auth` refusal documented in `cli.md` (en/ja); `ship-api.md` (en/ja) rewritten to the real token API

## Risk Assessment

Behavior change: `guren add auth` / `guren make:auth` now throw on an app with a readable `package.json` that lacks `@guren/inertia-client` **and** no `routes/web.ts`/`routes/web.js`. Detection is positive-evidence-only (same predicate as #340): no manifest, an unreadable one, hoisted workspace deps, or any web routes entry all still permit the scaffold, so a working fullstack app cannot be refused by a "cannot tell". No API changes; `assertNotApiOnly` is a new internal export of `@guren/cli`.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck` (root + blog + api examples)
- [x] `bun run test:bun` — 3887 pass / 0 fail (cli: 1227 pass)
- [x] `bun run audit:docs`, `bun run audit:core-first`
- [x] Mutation check: disabling the guard fails 7 tests (3 admin + 4 auth) — the new tests can fail
- [x] Predicate probed against real apps: `examples/blog` false, `web/` false, `examples/api` true

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.