### PR TITLE
fix(cli): refuse the resource blueprint on API-only apps

### DIFF
--- a/.changeset/resource-blueprint-refuses-api-only.md
+++ b/.changeset/resource-blueprint-refuses-api-only.md
@@ -1,0 +1,36 @@
+---
+'@guren/cli': patch
+---
+
+Refuse `add resource` on an API-only app instead of half-scaffolding and then crashing
+
+`guren add resource` is Inertia-shaped end to end, and on an app created from the
+`api` blueprint it wrote eight unusable files before failing. The four page
+components under `resources/js/pages/<collection>/` are React, the controller
+returns Inertia responses and imports `@/.guren/pages.gen`, and none of it
+typechecks against a `@guren/inertia-client` the API starter never installs.
+
+The failure then arrived from the wrong place. `updateResourceRoutes` opens
+`routes/web.ts` unconditionally, and the API starter registers
+`registerApiRoutes` from `routes/api.ts` instead, so the run ended in a raw
+`ENOENT: no such file or directory, open '.../routes/web.ts'` with a stack trace
+through `node:fs` — not a message about the app being the wrong shape for the
+command. Everything already written stayed on disk.
+
+That included one file the user wrote themselves: `updateResourceSchema` runs
+before the route wiring, so a `posts` table was appended to `db/schema.ts`.
+Deleting a scaffold does not undo that, which is what makes this worse than the
+same bug in `add admin` — there, every casualty was a new file.
+
+The blueprint now goes through `assertNotApiOnly()`, the same refusal the `admin`
+and `auth` scaffolds use, and fails with a message naming the Inertia-shaped
+output and the two signals it read, leaving nothing behind. The check runs after
+the name and `--fields` parsing, which are pure, so a bad invocation on an
+API-only app is still reported as a bad invocation rather than masked by the
+app's shape.
+
+An app that does declare the client but has no `routes/web.ts` is still
+permitted, and still fails inside `updateResourceRoutes` — as does any app whose
+routes file has no registrar, which has always thrown after the schema write.
+That residue is untouched here and pinned by a test so the two failures cannot
+be mistaken for each other.

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -78,6 +78,11 @@ token-based API, guard `routes/api.ts` with `createBearerTokenMiddleware` from
 `@guren/core` and issue tokens with `createApiToken` — see the
 [API tokens guide](./api-tokens.md).
 
+`add resource` refuses on those same two signals, and for the same reason: it
+scaffolds React page components and a controller that returns Inertia responses.
+Its refusal likewise comes before the table it would otherwise append to your
+`db/schema.ts`. Add a JSON controller wired into `routes/api.ts` by hand instead.
+
 ## Core Commands
 
 | Command | Description | Example |

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -76,6 +76,11 @@ bunx guren add admin --public
 保護し、`createApiToken` でトークンを発行してください
 （[APIトークンガイド](./api-tokens.md)参照）。
 
+`add resource` も同じ2つのシグナルを見て、同じ理由で中断します。React のページ
+コンポーネントと Inertia レスポンスを返すコントローラーを生成するためです。中断は
+同様に、`db/schema.ts` へ追記されるはずだったテーブルよりも前の時点で起こります。
+JSON を返すコントローラーは `routes/api.ts` に手動で結線してください。
+
 ## 主要コマンド
 
 | コマンド | 説明 | 例 |

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -626,6 +626,17 @@ export default class BroadcastProvider extends ServiceProvider {
       const routeVar = camelCase(routeName)
       const fields = parseFieldsString(options.fields ?? '')
 
+      // Last of the checks, and still before the first write: everything above
+      // is pure, so a usage error is reported as one rather than being masked
+      // by the app's shape. The page components and the Inertia-returning
+      // controller are unusable on an API-only app, and `updateResourceSchema`
+      // runs before the route wiring can fail — so reaching that failure
+      // appends a table to the app's own `db/schema.ts` as well.
+      await assertNotApiOnly(process.cwd(), {
+        does: 'guren add resource scaffolds Inertia pages and a controller that returns Inertia responses',
+        instead: 'Add a JSON controller to routes/api.ts by hand',
+      })
+
       const created = await makeFeature(singular, {
         force: Boolean(options.force),
         fields: options.fields,

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -645,6 +645,124 @@ describe('auth blueprint on an API-only app', () => {
   })
 })
 
+describe('resource blueprint on an API-only app', () => {
+  let workspace: TempWorkspace
+
+  beforeEach(async () => {
+    workspace = await createTempWorkspace('guren-cli-resource-api-only-')
+  })
+
+  afterEach(async () => {
+    await workspace.cleanup()
+  })
+
+  it('refuses, naming the two signals it read', async () => {
+    await seedApiOnlyApp(workspace.dir)
+
+    await expect(runBlueprint('resource', { name: 'Post' })).rejects.toThrow(
+      /no @guren\/inertia-client dependency and no routes\/web\.ts/,
+    )
+  })
+
+  // The half that matters. `updateResourceSchema` runs before the route wiring
+  // can fail, so the old run appended a table to a file the user wrote — the
+  // one casualty deleting a scaffold does not undo.
+  it('writes nothing at all, and leaves db/schema.ts byte-identical', async () => {
+    await seedApiOnlyApp(workspace.dir)
+
+    await expect(runBlueprint('resource', { name: 'Post' })).rejects.toThrow()
+
+    // `existsSync` rather than the `fileExists` the predicate itself calls: a
+    // bug in that helper must not be able to make this assertion pass.
+    for (const path of [
+      'app/Models/Post.ts',
+      'app/Http/Controllers/PostController.ts',
+      'app/Http/Resources/PostResource.ts',
+      'app/Http/Validators/PostValidator.ts',
+      'resources/js/pages/posts/Index.tsx',
+      'resources/js/pages/posts/Show.tsx',
+      'resources/js/pages/posts/New.tsx',
+      'resources/js/pages/posts/Edit.tsx',
+    ]) {
+      expect(existsSync(resolve(workspace.dir, path))).toBe(false)
+    }
+    // No `posts` table appended, and the app's own routes file untouched.
+    expect(await readFile('db/schema.ts', 'utf8')).toBe(PG_SCHEMA_FIXTURE)
+    expect(await readFile('routes/api.ts', 'utf8')).toBe(API_ROUTES_FIXTURE)
+  })
+
+  // The template is what `create-guren-app` ships; the fixture above is its
+  // reduction, not a substitute for it.
+  it('refuses the api-only template as shipped', async () => {
+    const templateDir = resolve(import.meta.dir, '../../create-app/templates/api-only')
+    await mkdir('routes', { recursive: true })
+    await mkdir('db', { recursive: true })
+    await writeFile('routes/api.ts', await readFile(resolve(templateDir, 'routes/api.ts'), 'utf8'))
+    await writeFile('db/schema.ts', await readFile(resolve(templateDir, 'db/schema.ts'), 'utf8'))
+    await writeFile('package.json', await readFile(resolve(templateDir, 'package.json'), 'utf8'))
+
+    await expect(runBlueprint('resource', { name: 'Post' })).rejects.toThrow(
+      'guren add resource scaffolds Inertia pages',
+    )
+  })
+
+  // A usage error must not be reported as an environment one, so the guard is
+  // the last check rather than the first: on an API-only app a bad invocation
+  // is still reported as a bad invocation.
+  it('still reports a missing resource name first', async () => {
+    await seedApiOnlyApp(workspace.dir)
+
+    await expect(runBlueprint('resource', {})).rejects.toThrow(
+      'The resource blueprint requires a resource name.',
+    )
+  })
+
+  it('still reports an invalid field type first', async () => {
+    await seedApiOnlyApp(workspace.dir)
+
+    await expect(runBlueprint('resource', { name: 'Post', fields: 'title:bogus' })).rejects.toThrow(
+      'Invalid field type "bogus"',
+    )
+  })
+
+  // The manifest signal alone is enough to permit: a fullstack app in a
+  // workspace whose deps are hoisted to the root has no client to find.
+  // (The other direction — an absent manifest — cannot be isolated here,
+  // because every scaffold that succeeds needs the `routes/web.ts` that
+  // rescues it anyway. It is pinned in the admin block above.)
+  it('scaffolds when routes/web.ts exists but the manifest does not name the client', async () => {
+    await seedResourceWorkspace(PG_SCHEMA_FIXTURE)
+    await writeFile('package.json', JSON.stringify({ name: 'workspace-member' }))
+
+    const created = await runBlueprint('resource', { name: 'Post' })
+
+    expect(created.some((file) => file.endsWith('resources/js/pages/posts/Index.tsx'))).toBe(true)
+    expect(await readFile('routes/web.ts', 'utf8')).toContain("router.group('/posts'")
+  })
+
+  // The other signal on its own: an app that declares the client is never
+  // refused as API-only. It still fails further in, because
+  // `updateResourceRoutes` reads `routes/web.ts` unconditionally — a
+  // pre-existing rough edge this guard does not address. Matched on `ENOENT`,
+  // which only the later failure can produce: the guard's own message names
+  // `routes/web.ts` too, so that string alone would not tell them apart.
+  it('does not refuse an app that declares the client', async () => {
+    await mkdir('resources/js/pages', { recursive: true })
+    await mkdir('routes', { recursive: true })
+    await mkdir('db', { recursive: true })
+    await writeFile('routes/api.ts', API_ROUTES_FIXTURE)
+    await writeFile('db/schema.ts', PG_SCHEMA_FIXTURE)
+    await writeFile('package.json', JSON.stringify({
+      name: 'web-app',
+      dependencies: { '@guren/inertia-client': '^1.1.0' },
+    }))
+
+    await expect(runBlueprint('resource', { name: 'Post' })).rejects.toThrow(
+      /ENOENT.*routes\/web\.ts/,
+    )
+  })
+})
+
 describe('oauth blueprint output', () => {
   let workspace: TempWorkspace
 


### PR DESCRIPTION
## Summary

`guren add resource` is Inertia-shaped end to end, and on an app scaffolded from the `api` blueprint it wrote eight unusable files before failing. The four page components under `resources/js/pages/<collection>/` are React, the controller returns Inertia responses and imports `@/.guren/pages.gen`, and none of it typechecks against a `@guren/inertia-client` the API starter never installs.

The failure then arrived from the wrong place. `updateResourceRoutes` opens `routes/web.ts` unconditionally, and the API starter registers `registerApiRoutes` from `routes/api.ts` instead, so the run ended in a raw `ENOENT: no such file or directory, open '.../routes/web.ts'` with a stack trace through `node:fs` — not a message about the app being the wrong shape for the command. Everything already written stayed on disk.

That included one file the user wrote themselves: `updateResourceSchema` runs before the route wiring, so a table was appended to `db/schema.ts`. Deleting a scaffold does not undo that, which is what makes this worse than the same bug in `add admin` (#340) — there, every casualty was a new file.

The blueprint now reuses the `add admin` check (`isConfirmedApiOnlyApp`, unchanged) and fails with a message naming the Inertia-shaped output and the two signals it read, leaving nothing behind.

Reproduced against the shipped template before and after:

```
# before
ERROR ENOENT: no such file or directory, open '.../routes/web.ts'
      at async updateResourceRoutes (packages/cli/src/blueprints.ts:804:23)
      → 8 files written, db/schema.ts patched

# after
ERROR guren add resource scaffolds Inertia pages and a controller that returns
      Inertia responses, but this app has no @guren/inertia-client dependency and
      no routes/web.ts. Add a JSON controller to routes/api.ts by hand, or
      scaffold a fullstack app.
      → 0 files written, db/schema.ts byte-identical
```

Two details worth a reviewer's attention:

- **The check runs last, not first.** It sits after the name check and `--fields` parsing, both of which are pure. A bad invocation on an API-only app is therefore still reported as a bad invocation (`Invalid field type "bogus"`) rather than masked by the app's shape. Pinned by two tests.
- **The clause naming the signals moved into `apiOnlyRefusal()` in `app-surface.ts`**, next to the rule it describes, instead of being hand-written into each blueprint. Both the `admin` and `resource` messages are unchanged — verified byte-identical against the previous literal.

## Scope

`cli`, `docs`.

- `packages/cli/src/blueprints.ts` — the guard, plus `admin` switched to the shared message builder
- `packages/cli/src/app-surface.ts` — new `apiOnlyRefusal()` builder
- `packages/cli/tests/blueprints.test.ts` — new `describe('resource blueprint on an API-only app')`
- `docs/en/guides/cli.md`, `docs/ja/guides/cli.md` — kept in sync
- changeset (`@guren/cli`: patch)

## Risk Assessment

A command that previously produced a broken half-scaffold now fails on a narrow, positively-identified population. Detection is the existing predicate, unchanged: it refuses only on a readable `package.json` without `@guren/inertia-client` **and** no `routes/web.ts` or `routes/web.js`. Every "cannot tell" permits the scaffold, so a fullstack app cannot be blocked by a hoisted workspace manifest or an unreadable one.

No behavior change for any app that was working. No API or migration impact.

**Known residue, deliberately out of scope.** An app that declares the client but has no `routes/web.ts` is still permitted and still fails inside `updateResourceRoutes` after the writes. Codex flagged this as blocking; I scoped it out because the same late failure is not API-only-specific — the existing test `fails the resource blueprint rather than dropping its routes` already pins that an ordinary fullstack app whose routes file has no registrar also throws *after* the schema write. Closing it means hoisting the registrar check above the writes, which changes that test's semantics. Tracked separately.

Also noted while reviewing: `guren make:feature` and `guren make:auth` call `makeFeature`/`makeAuth` directly without going through `blueprintRegistry`, so they still write the same Inertia output onto an API-only app and exit 0. Neither file imports `app-surface`. Tracked separately; guarding inside those two functions would cover four commands with two call sites.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck` — 0 errors from the repo root
- [x] `bun run test` — `test:bun` 3886 pass / 0 fail / 55 skip; `test:examples` all pass

Additionally:

- `audit:core-first`, `audit:docs`, `guren check --docs` — all pass
- **Mutation check:** disabling the guard fails exactly the three tests that assert it (`refuses…`, `writes nothing at all…`, `refuses the api-only template as shipped`), re-verified after the message refactor
- End-to-end against a copy of `packages/create-app/templates/api-only`: refusal message only, zero files created, `db/schema.ts` unchanged; and `--fields "title:bogus"` reports the field error rather than the refusal

One `test:bun cli` run showed 3 failures at 140s under concurrent load; three consecutive re-runs are green at 24/28/31s. Consistent with Bun's timeout-cascade behaviour, not a real failure.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
