### PR TITLE
fix(server): serve the built Inertia client, not its sources, in production

### DIFF
--- a/.changeset/inertia-client-dir-from-package-root.md
+++ b/.changeset/inertia-client-dir-from-package-root.md
@@ -1,0 +1,31 @@
+---
+'@guren/server': patch
+---
+
+Serve the built Inertia client in production, not its TypeScript sources
+
+`configureInertiaAssets()` located the vendored client by resolving
+`@guren/inertia-client/app` and taking `dirname()` of whatever came back. That
+subpath is not a stable anchor: a tsconfig `paths` entry mapping
+`@guren/inertia-client/*` at the package's `src/` — which Bun applies to
+runtime resolution, `import.meta.resolve` and `require.resolve` alike —
+redirects it to `src/app.tsx`. The production route then looked for
+`src/app.js`, which does not exist, and 404'd; every `chunk-*.js` the entry
+imports resolved against `src/` too, so the fallback of "the entry at least
+loads" was not available either.
+
+Resolution is now anchored on `@guren/inertia-client/package.json` — a subpath
+no `paths` entry shadows, since a mapping at `src/` misses and falls back to
+real package resolution — and the client directory is that package root's
+`dist/`. The path is derived from the package rather than from whichever file a
+specifier happened to reach.
+
+This bites wherever such a `paths` mapping is in scope, which is this
+repository: the reference app, the smokes, and the E2E runs all serve
+production assets through it. An app that installs `@guren/*` from npm has no
+`@guren/*` mapping, so its resolution already landed on `dist/app.js` and its
+behavior is unchanged.
+
+The resolution is now `resolveInertiaClientDir()`, exported so it can be
+asserted directly. Its previous form lived inline in `configureInertiaAssets()`,
+where no test could observe which directory it had chosen.

--- a/packages/server/src/http/dev-assets.ts
+++ b/packages/server/src/http/dev-assets.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono'
 import { serveStatic } from 'hono/bun'
-import { dirname, extname, resolve } from 'node:path'
+import { dirname, extname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createRequire } from 'node:module'
 import type { Application } from './Application'
@@ -79,7 +79,24 @@ export interface DevAssetsOptions {
 // without it installed.
 const require = createRequire(import.meta.url)
 function resolveGurenInertiaClient(): string {
+  // Dev *wants* the `./app` specifier's answer, sources included: a tsconfig
+  // `paths` entry mapping the subpath at `src/` hands back `src/app.tsx`, and
+  // the transpile route serves that just fine.
   return require.resolve('@guren/inertia-client/app')
+}
+
+/**
+ * Absolute path to `@guren/inertia-client`'s build output, the directory
+ * production serves the vendored client and its chunks from.
+ *
+ * Unlike {@link resolveGurenInertiaClient}, this must not follow a tsconfig
+ * `paths` mapping to the package's TypeScript sources — production serves
+ * files, it cannot transpile them. So it anchors on `./package.json`, a
+ * subpath such a mapping misses (there is no `src/package.json`) and real
+ * package resolution answers with the package root.
+ */
+export function resolveInertiaClientDir(): string {
+  return join(dirname(require.resolve('@guren/inertia-client/package.json')), 'dist')
 }
 
 /**

--- a/packages/server/src/http/inertia-assets.ts
+++ b/packages/server/src/http/inertia-assets.ts
@@ -3,7 +3,13 @@ import { dirname, resolve, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { readFileSync } from 'node:fs'
 import type { Application } from './Application'
-import { createStaticRewrite, registerDevAssets, resolveInertiaClientRoute, type DevAssetsOptions } from './dev-assets'
+import {
+  createStaticRewrite,
+  registerDevAssets,
+  resolveInertiaClientDir,
+  resolveInertiaClientRoute,
+  type DevAssetsOptions,
+} from './dev-assets'
 import { registerRootPublicAssets } from './public-assets'
 import { isPathWithin, isRealPathWithin } from '../support/contained-path'
 import { parseImportMap } from '../support/import-map'
@@ -94,30 +100,15 @@ export function configureInertiaAssets(app: Application, options: InertiaAssetsO
 
   registerRootPublicAssets(app, publicDir, options.rootPublicAssets)
 
-  if (isProduction && options.inertiaClient !== false) {
+  if (options.inertiaClient !== false) {
     try {
-      let inertiaClientEntry: string | undefined
-
-      if (typeof (import.meta as any).resolve === 'function') {
-        try {
-          const resolved = (import.meta as any).resolve('@guren/inertia-client/app', import.meta.url)
-          inertiaClientEntry = fileURLToPath(new URL(resolved))
-        } catch {
-          inertiaClientEntry = undefined
-        }
-      }
-
-      if (!inertiaClientEntry) {
-        throw new Error('Unable to resolve @guren/inertia-client entry')
-      }
-
       registerBuiltInertiaClient(
         app,
-        dirname(inertiaClientEntry),
+        resolveInertiaClientDir(),
         options.inertiaClientPath ?? DEFAULT_VENDOR_CLIENT_PATH,
       )
     } catch (error) {
-      console.warn('Unable to resolve @guren/inertia-client/app for production serving.', error)
+      console.warn('Unable to resolve @guren/inertia-client for production serving.', error)
     }
   }
 }

--- a/packages/server/tests/http/inertia-client-assets.test.ts
+++ b/packages/server/tests/http/inertia-client-assets.test.ts
@@ -1,7 +1,27 @@
 import { beforeEach, describe, expect, it } from 'bun:test'
+import { dirname, join, resolve } from 'node:path'
 import { Application } from '../../src'
+import { resolveInertiaClientDir } from '../../src/http/dev-assets'
 import { registerBuiltInertiaClient } from '../../src/http/inertia-assets'
 import { useAssetFixture } from './asset-fixture'
+
+describe('resolveInertiaClientDir', () => {
+  // The bug this pins is in the resolution, not in the serving: a tsconfig
+  // `paths` entry for `@guren/inertia-client/*` sends the `./app` subpath to
+  // `src/app.tsx`, so a directory derived from it holds sources rather than a
+  // build. Asserted against the package's own `exports` contract so it does
+  // not need `dist/` on disk — and so the resolver's `dist` and the serving
+  // route's `app.js` both go red here if the package's build layout moves.
+  it('resolves the directory the package exports its built entry from', async () => {
+    const clientDir = resolveInertiaClientDir()
+    const packageRoot = dirname(clientDir)
+
+    const manifest = await Bun.file(join(packageRoot, 'package.json')).json()
+
+    expect(manifest.name).toBe('@guren/inertia-client')
+    expect(resolve(packageRoot, manifest.exports['./app'].default)).toBe(join(clientDir, 'app.js'))
+  })
+})
 
 // Registered directly rather than through `configureInertiaAssets`, whose
 // client directory comes from `import.meta.resolve` and cannot reach a fixture.


### PR DESCRIPTION
## Summary

`configureInertiaAssets()` located the vendored Inertia client by resolving `@guren/inertia-client/app` and taking `dirname()` of whatever came back. That subpath is not a stable anchor: a tsconfig `paths` entry mapping `@guren/inertia-client/*` at the package's `src/` — which Bun applies to runtime resolution, `import.meta.resolve` and `require.resolve` alike — redirects it to `src/app.tsx`. The production route then served from `src/`, where neither `app.js` nor any `chunk-*.js` the entry imports exist, so the vendored client 404'd.

Resolution is now anchored on `@guren/inertia-client/package.json` — a subpath such a mapping misses (there is no `src/package.json`), so real package resolution answers with the package root — and the client directory is that root's `dist/`. The resolver is `resolveInertiaClientDir()` in `dev-assets.ts`, beside the dev-path resolver and sharing its `createRequire`; the two resolution rules (dev deliberately tolerates sources, production must not) are documented against each other.

This bites wherever such a `paths` mapping is in scope — this repository's reference app, smokes, and E2E runs all serve production assets through it. Apps installing `@guren/*` from npm have no `@guren/*` mapping, already resolved to `dist/app.js`, and are unchanged.

Not a regression from the symlink-containment work; it predates it and was noticed while reviewing it.

## Scope

- server: `packages/server/src/http/{inertia-assets,dev-assets}.ts`
- tests: `packages/server/tests/http/inertia-client-assets.test.ts`
- changeset: `@guren/server` patch

## Risk Assessment

- Behavior change only under a runtime-applied `paths` mapping (monorepo/workspace layouts), where the previous behavior was a broken page; npm-installed apps resolve identically before and after.
- `@guren/inertia-client` remains an optional peer: resolution failure still lands in the existing `try`/`catch` and warns instead of crashing API-only apps.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck` (root tsc + blog + api)
- [x] `bun run test` (`test:bun` 3919 pass / 0 fail; `test:examples` 102 pass)
- Mutation check: temporarily restoring the old `/app`-anchored resolution fails the new test.
- End-to-end probe against the real package: with `NODE_ENV=production`, `/vendor/inertia-client.tsx` returns 200 with the built entry and its chunks (404 before the fix).
- The new test asserts the resolved directory against the package's own `exports['./app']` target, so a `dist/`-layout or entry-name change goes red in tests before it breaks production.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation. (changeset; no user-facing docs describe this internal path)