### PR TITLE
fix(cli): refuse make:feature on API-only apps

### DIFF
--- a/.changeset/make-feature-refuses-api-only.md
+++ b/.changeset/make-feature-refuses-api-only.md
@@ -1,0 +1,16 @@
+---
+'@guren/cli': patch
+---
+
+Refuse `make:feature` on an API-only app, the same way `add resource` does
+
+`guren make:feature` reaches the same Inertia-shaped scaffold as `guren add
+resource` without passing through the blueprint registry, so the refusal that
+protects `add resource` did not cover it: on an API-only app it wrote the same
+unusable pages, controller, resource, validator, and model. It now refuses with
+the same message, after the same pure parsing — a usage error is still reported
+as one — and before its first write.
+
+Unlike the blueprints, which refuse an explicit `cwd` up front, `make:feature`
+honours one, so its check judges the root it writes into rather than the
+directory the process happens to sit in.

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -81,7 +81,8 @@ token-based API, guard `routes/api.ts` with `createBearerTokenMiddleware` from
 `add resource` refuses on those same two signals, and for the same reason: it
 scaffolds React page components and a controller that returns Inertia responses.
 Its refusal likewise comes before the table it would otherwise append to your
-`db/schema.ts`. Add a JSON controller wired into `routes/api.ts` by hand instead.
+`db/schema.ts`. So does `make:feature`, which reaches the same scaffold
+directly. Add a JSON controller wired into `routes/api.ts` by hand instead.
 
 `add resource` also needs the two files it patches to be there, whatever shape the
 rest of your app is: it appends its table to `db/schema.ts` and registers the CRUD

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -79,7 +79,8 @@ bunx guren add admin --public
 `add resource` も同じ2つのシグナルを見て、同じ理由で中断します。React のページ
 コンポーネントと Inertia レスポンスを返すコントローラーを生成するためです。中断は
 同様に、`db/schema.ts` へ追記されるはずだったテーブルよりも前の時点で起こります。
-JSON を返すコントローラーは `routes/api.ts` に手動で結線してください。
+同じスキャフォールドに直接到達する `make:feature` も同様に中断します。JSON を
+返すコントローラーは `routes/api.ts` に手動で結線してください。
 
 `add resource` は、アプリの形がどうであれ、パッチ対象の2つのファイルがそこにあることも
 必要とします。テーブル定義を `db/schema.ts` に追記し、CRUD ルートを `routes/web.ts` に

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -2,7 +2,7 @@ import { assertNotApiOnly } from './app-surface'
 import { fileExists, readIfExists } from './discovery'
 import { makeAuth } from './make-auth'
 import { makeChannel } from './make-channel'
-import { buildRouteRegistrationHint, makeFeature } from './make-feature'
+import { API_ONLY_FEATURE_ALTERNATIVE, buildRouteRegistrationHint, makeFeature } from './make-feature'
 import { parseFieldsString, type FieldDefinition, type FieldType } from './fields'
 import { collectionSlug, schemaIdentifierFor, singularize, tableNameFor } from './inflect'
 import { schemaPathFor } from './schema-parser'
@@ -165,6 +165,10 @@ export default registerAdminRoutes
   },
   oauth: {
     description: 'Install OAuth scaffolding with GitHub, Google, and Discord provider presets.',
+    // No API-only guard, on purpose: this is the one entry that touches
+    // routes/web.ts without needing it. The controller answers with
+    // `this.json(...)`, and `wireRouteRegistrar` warns instead of throwing when
+    // the file is absent — the scaffold genuinely works on an API-only app.
     run: async (options) => {
       const writerOptions: WriterOptions = { force: Boolean(options.force) }
       const created = await scaffoldFeatureFiles([
@@ -636,7 +640,7 @@ export default class BroadcastProvider extends ServiceProvider {
       // appends a table to the app's own `db/schema.ts` as well.
       await assertNotApiOnly(process.cwd(), {
         does: 'guren add resource scaffolds Inertia pages and a controller that returns Inertia responses',
-        instead: 'Add a JSON controller to routes/api.ts by hand',
+        instead: API_ONLY_FEATURE_ALTERNATIVE,
       })
 
       // Second, so that an app the check above recognizes hears about its

--- a/packages/cli/src/make-feature.ts
+++ b/packages/cli/src/make-feature.ts
@@ -1,5 +1,6 @@
 import { consola } from 'consola'
-import { camelCase, kebabCase, pagesAccessor, pascalCase, safeModuleName, writeScaffoldFiles, writerOptionsFrom, type WriterOptions } from './utils'
+import { assertNotApiOnly } from './app-surface'
+import { camelCase, kebabCase, pagesAccessor, pascalCase, safeModuleName, writeRoot, writeScaffoldFiles, writerOptionsFrom, type WriterOptions } from './utils'
 import { pluralize } from './inflect'
 import { makeModel } from './make-model'
 import { makePolicy } from './make-policy'
@@ -7,6 +8,13 @@ import { makeTest } from './make-test'
 import { makeValidator } from './make-validator'
 import { parseFieldsString, type FieldDefinition, type FieldType } from './fields'
 import { schemaPathFor } from './schema-parser'
+
+/**
+ * The alternative the API-only refusal names, shared with the resource
+ * blueprint: both doors lead to this one scaffold, so they point at the same
+ * way out.
+ */
+export const API_ONLY_FEATURE_ALTERNATIVE = 'Add a JSON controller to routes/api.ts by hand'
 
 export interface MakeFeatureOptions extends WriterOptions {
   fields?: string
@@ -39,6 +47,17 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
   const moduleName = options.root ? safeModuleName(options.root) : undefined
   const appPrefix = moduleName ? `modules/${moduleName}/` : ''
   const pagePrefix = moduleName ? `${moduleName}/` : ''
+
+  // Same ordering rule as the resource blueprint's guard: everything above is
+  // pure, so a usage error is reported as one, and the check still precedes
+  // the first write below. It lives here as well because `guren make:feature`
+  // reaches this scaffold without passing through the blueprint registry.
+  // Judged at `writeRoot()` — this command honours `options.cwd`, so the app
+  // judged must be the app written into.
+  await assertNotApiOnly(writeRoot(options), {
+    does: 'guren make:feature scaffolds Inertia pages and a controller that returns Inertia responses',
+    instead: API_ONLY_FEATURE_ALTERNATIVE,
+  })
 
   // Composed rather than emitted inline — the same way makeModel/makePolicy/
   // makeTest are below — so the schema names the generated controller imports

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -110,7 +110,7 @@ export function assertScaffoldPath(relativePath: string, cwd: string = process.c
  * relative, the second read can land on a different directory than the one
  * that was checked, and the containment check then guarantees nothing.
  */
-function writeRoot(options: WriterOptions): string {
+export function writeRoot(options: WriterOptions): string {
   return resolve(options.cwd ?? process.cwd())
 }
 

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs'
 import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import {
+  API_ONLY_REFUSAL,
   API_ROUTES_FIXTURE,
   BLOG_ROUTES_FIXTURE,
   CAN_DENY_FILE_READS,
@@ -708,9 +709,7 @@ describe('admin blueprint on an API-only app', () => {
   it('refuses, naming the two signals it read', async () => {
     await seedApiOnlyApp(workspace.dir)
 
-    await expect(runBlueprint('admin')).rejects.toThrow(
-      /no @guren\/inertia-client dependency and no routes\/web\.ts/,
-    )
+    await expect(runBlueprint('admin')).rejects.toThrow(API_ONLY_REFUSAL)
   })
 
   // The half that matters: refusing after the first write would leave exactly
@@ -827,9 +826,7 @@ describe('auth blueprint on an API-only app', () => {
   it('reaches the refusal inside makeAuth', async () => {
     await seedApiOnlyApp(workspace.dir)
 
-    await expect(runBlueprint('auth')).rejects.toThrow(
-      /no @guren\/inertia-client dependency and no routes\/web\.ts/,
-    )
+    await expect(runBlueprint('auth')).rejects.toThrow(API_ONLY_REFUSAL)
   })
 })
 
@@ -847,9 +844,7 @@ describe('resource blueprint on an API-only app', () => {
   it('refuses, naming the two signals it read', async () => {
     await seedApiOnlyApp(workspace.dir)
 
-    await expect(runBlueprint('resource', { name: 'Post' })).rejects.toThrow(
-      /no @guren\/inertia-client dependency and no routes\/web\.ts/,
-    )
+    await expect(runBlueprint('resource', { name: 'Post' })).rejects.toThrow(API_ONLY_REFUSAL)
   })
 
   // The half that matters. `updateResourceSchema` runs before the route wiring

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -160,6 +160,14 @@ export async function seedApiOnlyApp(dir: string): Promise<void> {
   })
 }
 
+/**
+ * The middle sentence `assertNotApiOnly` writes into every refusal — the two
+ * signals it read. One spelling for the same reason `seedApiOnlyApp` is: the
+ * tests used to hand-copy this regex, and a wording change in app-surface.ts
+ * would have meant hunting every copy across three files.
+ */
+export const API_ONLY_REFUSAL = /no @guren\/inertia-client dependency and no routes\/web\.ts/
+
 export const BLOG_ROUTES_FIXTURE = `import { Router, requireAuthenticated } from '@guren/core'
 
 export function registerWebRoutes(baseRouter: Router): void {

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { consola } from 'consola'
-import { API_ROUTES_FIXTURE, BLOG_ROUTES_FIXTURE, createTempWorkspace, MYSQL_SCHEMA_FIXTURE, PG_SCHEMA_FIXTURE, seedApiOnlyApp, SQLITE_SCHEMA_FIXTURE } from './helpers'
+import { API_ONLY_REFUSAL, API_ROUTES_FIXTURE, BLOG_ROUTES_FIXTURE, createTempWorkspace, MYSQL_SCHEMA_FIXTURE, PG_SCHEMA_FIXTURE, seedApiOnlyApp, SQLITE_SCHEMA_FIXTURE } from './helpers'
 import { makeAuth } from '../src/make-auth'
 
 // Shared with packages/create-app/templates/blog/app/Providers/AuthProvider.ts,
@@ -1207,9 +1207,7 @@ export function registerWebRoutes(router: Router): void {
       try {
         await seedApiOnlyApp(workspace.dir)
 
-        await expect(makeAuth({ force: true })).rejects.toThrow(
-          /no @guren\/inertia-client dependency and no routes\/web\.ts/,
-        )
+        await expect(makeAuth({ force: true })).rejects.toThrow(API_ONLY_REFUSAL)
       } finally {
         await workspace.cleanup()
       }

--- a/packages/cli/tests/make-feature.test.ts
+++ b/packages/cli/tests/make-feature.test.ts
@@ -1,9 +1,10 @@
+import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
 import { makeFeature, buildRouteRegistrationHint } from '../src/make-feature'
 import { parseFieldsString } from '../src/fields'
-import { createTempWorkspace } from './helpers'
+import { API_ONLY_REFUSAL, API_ROUTES_FIXTURE, createTempWorkspace, seedApiOnlyApp } from './helpers'
 
 describe('parseFieldsString', () => {
   it('parses simple fields', () => {
@@ -380,5 +381,34 @@ describe('buildRouteRegistrationHint', () => {
     expect(lines.join('\n')).not.toContain('aliasMiddleware')
     expect(lines.join('\n')).not.toContain(".middleware('auth')")
     expect(lines[0]).toBe(`${REGISTRAR_PARAM}.group('/posts', (posts) => {`)
+  })
+})
+
+// `guren make:feature` reaches this scaffold without passing through the
+// blueprint registry, so the refusal has to live here too — the resource
+// blueprint's own guard cannot cover the direct command. The predicate's
+// branches are pinned in the admin block of blueprints.test.ts; this only has
+// to prove makeFeature() refuses before its first write.
+describe('makeFeature on an API-only app', () => {
+  it('refuses, naming the two signals, and writes nothing', async () => {
+    const workspace = await createTempWorkspace('guren-cli-feature-api-only-')
+    try {
+      await seedApiOnlyApp(workspace.dir)
+
+      await expect(makeFeature('Post', { fields: 'title:string' })).rejects.toThrow(API_ONLY_REFUSAL)
+
+      for (const path of [
+        'app/Models/Post.ts',
+        'app/Http/Controllers/PostController.ts',
+        'app/Http/Resources/PostResource.ts',
+        'app/Http/Validators/PostValidator.ts',
+        'resources/js/pages/posts/Index.tsx',
+      ]) {
+        expect(existsSync(join(workspace.dir, path))).toBe(false)
+      }
+      expect(await readFile(join(workspace.dir, 'routes/api.ts'), 'utf8')).toBe(API_ROUTES_FIXTURE)
+    } finally {
+      await workspace.cleanup()
+    }
   })
 })


### PR DESCRIPTION
Follow-up to #340 (`add admin`), #346 (`add auth`), #347 (`add resource`), and #351 (resource patch preflight). Those four merged while this branch was in flight, so it has been rebased to carry only what none of them covered.

## Problem

`guren make:feature` reaches the same Inertia-shaped scaffold as `guren add resource` **without passing through the blueprint registry**, so the refusal #347 added to the resource blueprint does not cover it. On an API-only app it wrote the same unusable output: four React page components, a controller importing `@/.guren/pages.gen` and `@guren/inertia-client/typed-forms`, a resource, a validator, and a model — none of which typechecks against a client the API starter never installs.

## Fix

`makeFeature()` now calls the shared `assertNotApiOnly()` itself — the same reasoning that put the auth guard inside `makeAuth()` rather than the registry. Details:

- **Same ordering rule as the resource blueprint's guard** (#347): the check runs after the pure field parsing, so a usage error is still reported as one, and still before the first write.
- **Judged at `writeRoot(options)`**, now exported from utils instead of hand-copying `options.cwd ?? process.cwd()`: unlike the blueprints (which refuse an explicit `cwd` via `assertCwdUnsupported`), `make:feature` honours `options.cwd`, so the app judged has to be the app written into. Judging `process.cwd()` unconditionally broke `make-commands.test.ts`, which scaffolds into a workspace via `cwd` while the process sits in this monorepo — a directory the predicate correctly reads as API-only.
- The refusal message matches the resource blueprint's, and the `instead` sentence both doors share now lives once as `API_ONLY_FEATURE_ALTERNATIVE`.

## Review cleanups riding along

- The tests' hand-copied refusal regexes (admin, auth, resource, make-auth, make-feature) collapse into `API_ONLY_REFUSAL` in `tests/helpers.ts`, next to `seedApiOnlyApp` and for the same reason its docstring gives.
- The `oauth` entry documents why it is the one `routes/web.ts`-touching blueprint without a guard: its controller answers JSON and `wireRouteRegistrar` warns instead of throwing, so the scaffold genuinely works on an API-only app.

## Tests

- `make-feature.test.ts`: `makeFeature on an API-only app` — refuses naming the two signals, and writes nothing (every scaffolded path absent, `routes/api.ts` byte-identical)
- Verified against the real CLI: `guren make:feature Post` on a seeded API-only app exits 1 with the refusal and leaves the app untouched
- `bun run build`, root `bun run typecheck`, full cli suite (1277 tests), `audit:core-first`, `audit:docs` all pass

## Docs

The `add resource` refusal paragraphs in `docs/en/guides/cli.md` and `docs/ja/guides/cli.md` gain one sentence noting `make:feature` refuses the same way. Changeset: `@guren/cli` patch.