### PR TITLE
fix(cli): anchor the resource blueprint's already-registered probe

### DIFF
--- a/.changeset/resource-blueprint-slug-anchoring.md
+++ b/.changeset/resource-blueprint-slug-anchoring.md
@@ -1,0 +1,34 @@
+---
+'@guren/cli': patch
+---
+
+Stop `add resource` from reading an unrelated path as "these routes are already registered"
+
+`guren add resource` skips its route registration when the app already has the
+routes, and one of the two signals it looked for matched the collection slug as
+a quoted-path suffix. An app with an unrelated `router.get('/admin/posts',
+...)` therefore answered yes for a `Post` resource: the run reported success,
+`db/schema.ts` got the `posts` table, eight files were scaffolded, and the
+controller and validator imports were appended to `routes/web.ts` — but no route
+group was ever registered. The two imports are then bindings nothing uses, which
+stops the app compiling under `noUnusedLocals`.
+
+The path signal is now anchored on both sides, matching the full literal the
+registration emits (`'/posts'`), the way the sibling `'posts.index'` signal
+already was. The imports also moved inside the guard: they exist for the group,
+so a run that (correctly) skips registration — an app that hand-wired `/posts`
+itself — no longer appends imports nothing uses either.
+
+Both signals are still needed and neither is redundant. An app that hand-wired
+`/posts` has none of the generated `.name()` calls, so the path literal is the
+only thing left to recognise it by — anchoring any tighter than the quoted path
+would register a second, conflicting set of routes over it.
+
+One behavior change beyond the fix: an app that registers the resource under a
+prefix without the literal (`router.group('/blog/posts', ...)` with no `posts.*`
+route names) now gets a `/posts` group inserted rather than being skipped. That
+app genuinely has no `/posts` routes, so registering them is the correct reading
+— but it is a change from what the previous match did. A nested prefix that does
+contain the literal (`router.group('/admin', (admin) => admin.get('/posts', ...))`)
+still suppresses registration; that is the honest boundary of matching source
+text rather than resolving the route table.

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -803,7 +803,10 @@ async function updateResourceRoutes(singular: string, routeName: string, routeVa
   const routesPath = resolve(process.cwd(), 'routes/web.ts')
   let content = await readFile(routesPath, 'utf8')
 
-  if (!content.includes(`'${routeName}.index'`) && !content.includes(`/${routeName}'`)) {
+  // Matching `/${routeName}'` unanchored made an unrelated `/admin/posts`
+  // read as "the posts routes are already registered", so the run reported
+  // success while registering nothing.
+  if (!content.includes(`'${routeName}.index'`) && !content.includes(`'/${routeName}'`)) {
     const registrar = findRouteRegistrar(content)
 
     // Located before anything is written: an app whose routes file cannot be
@@ -828,13 +831,17 @@ async function updateResourceRoutes(singular: string, routeName: string, routeVa
     // Insert before the closing brace of the route registrar function.
     const groupBlock = `\n${group.map((line) => `  ${line}`).join('\n')}\n`
     content = content.slice(0, registrar.bodyEnd) + groupBlock + content.slice(registrar.bodyEnd)
-  }
 
-  for (const statement of [
-    `import ${singular}Controller from '../app/Http/Controllers/${singular}Controller.js'`,
-    `import { ${singular}PayloadSchema } from '../app/Http/Validators/${singular}Validator.js'`,
-  ]) {
-    content = insertImport(content, statement) ?? content
+    // Inside the guard: these identifiers are only used by the group above,
+    // so a skipped registration must skip them too — appended unconditionally
+    // they are unused bindings, and the app stops compiling under
+    // noUnusedLocals.
+    for (const statement of [
+      `import ${singular}Controller from '../app/Http/Controllers/${singular}Controller.js'`,
+      `import { ${singular}PayloadSchema } from '../app/Http/Validators/${singular}Validator.js'`,
+    ]) {
+      content = insertImport(content, statement) ?? content
+    }
   }
 
   await writeFile(routesPath, content, 'utf8')

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -18,11 +18,11 @@ import { listBlueprints, runBlueprint } from '../src/blueprints'
 import { runCheck } from '../src/check'
 
 /** Minimum project shape the resource blueprint patches into. */
-async function seedResourceWorkspace(schema: string): Promise<void> {
+async function seedResourceWorkspace(schema: string, routes = DEFAULT_ROUTES_FIXTURE): Promise<void> {
   await mkdir('resources/js/pages', { recursive: true })
   await mkdir('routes', { recursive: true })
   await mkdir('db', { recursive: true })
-  await writeFile('routes/web.ts', DEFAULT_ROUTES_FIXTURE)
+  await writeFile('routes/web.ts', routes)
   await writeFile('db/schema.ts', schema)
 }
 
@@ -166,6 +166,68 @@ describe('blueprints', () => {
     const schema = await readFile('db/schema.ts', 'utf8')
     expect(schema).toContain("__dunder__: text('__dunder__')")
     expect(schema).toContain("publishedAt: timestamp('published_at', { withTimezone: true })")
+  })
+
+  // The suppression check used to match the collection slug as a quoted-path
+  // suffix, so an unrelated `/admin/posts` answered "the posts routes are
+  // already registered" for a `Post` resource: eight files scaffolded, the
+  // table added — and no route group.
+  it('registers the group when the slug only appears inside a longer path', async () => {
+    await seedResourceWorkspace(PG_SCHEMA_FIXTURE, `import { Router } from '@guren/core'
+
+export function registerWebRoutes(router: Router): void {
+  router.get('/admin/posts', () => 'admin posts')
+}
+
+export default registerWebRoutes
+`)
+
+    await runBlueprint('resource', { name: 'Post' })
+
+    const routes = await readFile('routes/web.ts', 'utf8')
+    expect(routes).toContain("router.group('/posts'")
+    expect(routes).toContain("name('posts.index')")
+    // The imports the group needs are only sound because the group is there.
+    expect(routes).toContain("import PostController from '../app/Http/Controllers/PostController.js'")
+    // The route that triggered the false positive is left alone.
+    expect(routes).toContain("router.get('/admin/posts', () => 'admin posts')")
+  })
+
+  // The direction the anchoring could overshoot in. A hand-wired `/posts` has
+  // none of the generated `.name()` calls, so the path literal is the only
+  // thing left to recognise it by — anchor it any tighter (on `.group(`, say)
+  // and the blueprint registers a second, conflicting set of routes.
+  it('leaves hand-registered routes for the same collection alone', async () => {
+    await seedResourceWorkspace(PG_SCHEMA_FIXTURE, `import { Router } from '@guren/core'
+
+export function registerWebRoutes(router: Router): void {
+  router.get('/posts', () => 'posts')
+}
+
+export default registerWebRoutes
+`)
+
+    await runBlueprint('resource', { name: 'Post' })
+
+    const routes = await readFile('routes/web.ts', 'utf8')
+    expect(routes).not.toContain("router.group('/posts'")
+    // A skipped registration must skip its imports too: appended anyway they
+    // are unused bindings, and the app stops compiling under noUnusedLocals.
+    expect(routes).not.toContain('import PostController')
+  })
+
+  // A second run is suppressed by both clauses of the guard — run 1 emits the
+  // path literal and the route names. This pins the run-twice contract itself,
+  // including the import dedupe, not either clause.
+  it('registers the resource group once when re-run', async () => {
+    await seedResourceWorkspace(PG_SCHEMA_FIXTURE)
+
+    await runBlueprint('resource', { name: 'Post' })
+    await runBlueprint('resource', { name: 'Post', force: true })
+
+    const routes = await readFile('routes/web.ts', 'utf8')
+    expect(routes.match(/\.group\('\/posts'/g)).toHaveLength(1)
+    expect(routes.match(/import PostController from/g)).toHaveLength(1)
   })
 
   it('rejects unknown blueprints', async () => {


### PR DESCRIPTION
## Summary

The guard deciding whether `guren add resource` still needs to register its CRUD route group matched the collection slug as a quoted-path suffix (`content.includes(`/posts'`)`). An app whose `routes/web.ts` contains an unrelated `router.get('/admin/posts', ...)` therefore read as "the posts routes are already registered" when scaffolding a `Post` resource: the run reported success, `db/schema.ts` got the `posts` table, eight files were scaffolded, and the `PostController` / `PostPayloadSchema` imports were appended — but no route group was ever registered. The imports are then unused bindings, which breaks the app under `noUnusedLocals`.

Two changes in `updateResourceRoutes()`:

1. **Anchor the path probe on both sides** (`'/posts'`), matching the full literal the registration emits, the way the sibling `'posts.index'` probe already was.
2. **Move the two imports inside the guard.** They exist for the group, so a run that correctly skips registration (an app that hand-wired `/posts` itself) previously still appended imports nothing uses — the same `noUnusedLocals` failure through the other door.

Both probes remain necessary: a hand-wired `/posts` has none of the generated `.name()` calls, so the path literal is the only thing left to recognise it by — anchoring tighter than the quoted path would register a second, conflicting set of routes over it.

## Scope

cli (`packages/cli/src/blueprints.ts`, tests, changeset)

## Risk Assessment

- One behavior change beyond the fix, disclosed in the changeset: an app registering the resource under a prefix without the literal (`router.group('/blog/posts', ...)`, no `posts.*` names) now gets a `/posts` group inserted instead of being skipped. That app genuinely has no `/posts` routes, so this is the correct reading.
- A nested prefix that does contain the literal (`router.group('/admin', (admin) => admin.get('/posts', ...))`) still suppresses registration — the honest boundary of matching source text rather than resolving the route table.
- More apps now enter the registration branch, so more can reach the pre-existing `Could not find a route registrar` failure; that path and its ordering are unchanged by this PR.

## Validation

- `bun test packages/cli/tests/blueprints.test.ts` — 36 pass / 0 fail
- Both fixes were mutation-tested: un-anchoring the probe fails the new hand-wired test; moving the imports back outside the guard fails its import assertion. The `/admin/posts` regression test was written first and failed against the old code with exactly the reported shape (imports appended, no group).
- `bun run test:bun cli` — blueprints suite green; a handful of unrelated `runBin` subprocess tests time out under full-suite load, pass in isolation, and fail identically with this change stashed.
- [x] `bun run build`
- [x] `bun run typecheck` (remaining errors are `examples/blog` `@/.guren/*` codegen artifacts not generated in this worktree; `packages/cli` is clean)
- [x] `bun run test` (via `test:bun cli`, see above)

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation. (changeset; no docs reference this probe)