### PR TITLE
test(cli): raise i18n compile-probe timeouts past a cold tsc start

### DIFF
--- a/packages/cli/tests/i18n-types-compile.test.ts
+++ b/packages/cli/tests/i18n-types-compile.test.ts
@@ -99,6 +99,15 @@ afterAll(async () => {
   await rm(dir, { recursive: true, force: true })
 })
 
+// Each check() builds a full tsc program over the built .d.ts surface. On a
+// warm TypeScript cache that takes a few seconds, but in a fresh worktree
+// (cold node_modules, no incremental state) a single probe has been measured
+// at 10–25s normally and 70s right after a full monorepo build — far past
+// bun:test's 5s default, which made both tests time out rather than fail.
+// check() is synchronous, so a timeout cannot interrupt it anyway; the limit
+// only needs to sit above the slowest observed cold start, not near it.
+const COLD_TSC_TIMEOUT = 180_000
+
 function check(rootNames: string[]): string[] {
   const program = ts.createProgram(rootNames, compilerOptions)
   return ts.getPreEmitDiagnostics(program).map((diagnostic) => {
@@ -117,7 +126,7 @@ describe('generated translation key augmentation', () => {
     // bad-key probe errored (an accepted bad key surfaces as TS2578,
     // "unused @ts-expect-error").
     expect(check([generatedFile, serverProbeFile, clientProbeFile])).toEqual([])
-  })
+  }, COLD_TSC_TIMEOUT)
 
   test('without the generated file the same probes fail (the gate can catch a broken augmentation)', () => {
     const diagnostics = check([serverProbeFile, clientProbeFile])
@@ -128,5 +137,5 @@ describe('generated translation key augmentation', () => {
     }
     expect(diagnostics.filter((d) => d.startsWith('server-probe.ts'))).toHaveLength(2)
     expect(diagnostics.filter((d) => d.startsWith('client-probe.ts'))).toHaveLength(2)
-  })
+  }, COLD_TSC_TIMEOUT)
 })


### PR DESCRIPTION
## Summary

The two tests in `packages/cli/tests/i18n-types-compile.test.ts` ("generated translation key augmentation") each build a full tsc program over the built `.d.ts` surface via `ts.createProgram`. On a warm TypeScript cache that takes a few seconds, but in a fresh git worktree (cold node_modules, no incremental state) a single probe takes 10–25s — and 70s was observed right after a full monorepo build on a loaded machine. bun:test's 5s default sits far below that, so both tests timed out consistently in fresh worktrees (0 pass, 2 fail) with no code change involved.

This gives both tests an explicit 180s timeout via a shared `COLD_TSC_TIMEOUT` constant — the same treatment 568cb39 applied to the web suite's cold shiki start. `check()` is synchronous, so a timeout cannot interrupt it anyway; the limit only needs to sit above the slowest observed cold start, not near it. 60s was tried first and still timed out (70.8s observed), which is why the final value carries ~2x headroom over the worst measurement.

## Verification

- Fresh worktree, cold cache: `bun test packages/cli/tests/i18n-types-compile.test.ts` → 2 pass, 0 fail (each probe ~80s)
- `bun run test:bun cli` → 1272 pass, 0 fail across 86 files