### PR TITLE
fix(cli): wake the screens spec drift gate for module files under --changed

### DIFF
--- a/.changeset/spec-changed-covers-module-routes-dir.md
+++ b/.changeset/spec-changed-covers-module-routes-dir.md
@@ -1,0 +1,18 @@
+---
+'@guren/cli': patch
+---
+
+Wake the screens spec drift gate for module files under `--changed`
+
+`guren check --spec --changed` decides which spec views to regenerate by
+matching changed paths against each view's source patterns. The screens view
+listed only `modules/*/routes.ts` and `modules/*/index.ts`, but the route
+graph is a runtime import: `loadRouteDefinitions` evaluates
+`modules/<name>/index.ts` and everything the module registrar reaches from
+there — files under `modules/<name>/routes/` (where `make:route --module`
+writes), a prefix constant, or any other module file. A change touching only
+such a file reported `screens.md` as fresh while it was stale, and `--spec`
+sets the exit code, so CI waved the drift through. The screens view's module
+source now matches the whole `modules/<name>/` tree; over-selection only
+costs a regeneration, and the modules view already matched any source file
+for the same reason.

--- a/packages/cli/src/spec-generate.ts
+++ b/packages/cli/src/spec-generate.ts
@@ -61,7 +61,17 @@ export const SPEC_VIEWS: SpecViewDescriptor[] = [
     fileName: 'screens.md',
     sources: [
       { pattern: /^routes\//, label: 'routes/' },
-      { pattern: /^modules\/[^/]+\/(routes|index)\.ts$/, label: 'modules/*/routes.ts' },
+      // A module feeds the route graph through a runtime import:
+      // `loadRouteDefinitions` evaluates `modules/<name>/index.ts` and
+      // whatever the registrar it names reaches from there — `routes.ts`,
+      // files under `routes/` (where `make:route --module` writes), or any
+      // other module file holding a prefix constant or helper. Like the
+      // modules view's any-source rule, the pattern matches that honest
+      // input set rather than an allow-list of conventional names — an
+      // allow-list of `routes.ts`/`index.ts` is how a stale screens.md
+      // once slipped through `--changed`, and over-selection only costs a
+      // regeneration.
+      { pattern: /^modules\/[^/]+\//, label: 'modules/' },
       { pattern: /(^|\/)app\/Http\/Controllers\//, label: 'app/Http/Controllers/' },
       { pattern: /^resources\/js\/pages\//, label: 'resources/js/pages/' },
     ],

--- a/packages/cli/tests/docs-graph.test.ts
+++ b/packages/cli/tests/docs-graph.test.ts
@@ -261,6 +261,25 @@ related: [app/Http/Controllers/PostController.ts]
     }
   })
 
+  it('reaches the screens view from a module routes-directory path', async () => {
+    const workspace = await createTempWorkspace('guren-cli-docs-graph-module-routes-')
+    try {
+      const dir = workspace.dir
+      await mkdir(join(dir, 'docs/spec'), { recursive: true })
+      await writeFile(join(dir, 'package.json'), '{}', 'utf8')
+      await writeFile(join(dir, 'docs/spec/screens.md'), '---\ntype: spec\n---\n# Screens\n', 'utf8')
+
+      // Where `make:route --module` writes; the module source node covers
+      // the whole module tree because the route graph is a runtime import.
+      const report = await buildDocsGraphReport({ cwd: dir, path: 'modules/billing/routes/invoice.ts' })
+
+      expect(report.focus).toContain('modules/')
+      expect(report.nodes.some((n) => n.id === 'docs/spec/screens.md')).toBe(true)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('matches glob-form related entries and normalizes the query path', async () => {
     const workspace = await createTempWorkspace('guren-cli-docs-graph-glob-')
     try {

--- a/packages/cli/tests/spec-check.test.ts
+++ b/packages/cli/tests/spec-check.test.ts
@@ -112,6 +112,30 @@ export class Post extends defineModel(posts) {}
     expect(keys).not.toContain('spec-drift:screens.md')
   })
 
+  it('regenerates the screens view when a module routes-directory file changed', async () => {
+    // Where `make:route --module billing` writes: the file is reached
+    // transitively through the module registrar, so it can change screens.md
+    // without touching modules/billing/routes.ts itself.
+    const results = await runSpecCheck({
+      cwd: workspace.dir,
+      changedFiles: new Set(['modules/billing/routes/invoice.ts']),
+    })
+
+    expect(results.map((r) => r.key)).toContain('spec-drift:screens.md')
+  })
+
+  it('regenerates the screens view for a module file outside the scaffold conventions', async () => {
+    // A registrar may import a prefix constant or helper from anywhere in
+    // its module — the source set is the import closure of index.ts, not a
+    // list of conventional file names.
+    const results = await runSpecCheck({
+      cwd: workspace.dir,
+      changedFiles: new Set(['modules/billing/route-config.ts']),
+    })
+
+    expect(results.map((r) => r.key)).toContain('spec-drift:screens.md')
+  })
+
   it('re-verifies a view when its committed file itself changed', async () => {
     const results = await runSpecCheck({
       cwd: workspace.dir,

--- a/packages/cli/tests/spec-screens.test.ts
+++ b/packages/cli/tests/spec-screens.test.ts
@@ -290,3 +290,83 @@ export const renderMissing = function (this: any) {
     expect(content).not.toContain('## Unrouted pages')
   })
 })
+
+describe('screens spec (module routes directory)', () => {
+  let workspace: TempWorkspace
+
+  beforeAll(async () => {
+    workspace = await createTempWorkspace('guren-cli-spec-screens-module-routes-dir-')
+    const dir = workspace.dir
+    await writeScreensFixture(dir, { routes: true })
+
+    // The shape `make:route Invoice --module billing` scaffolds: the route
+    // definitions live under modules/billing/routes/, reached only through
+    // the module's registrar entry.
+    await mkdir(join(dir, 'modules/billing/routes'), { recursive: true })
+    await mkdir(join(dir, 'modules/billing/app/Http/Controllers'), { recursive: true })
+
+    await writeFile(
+      join(dir, 'modules/billing/index.ts'),
+      `import { registerBillingRoutes } from './routes'
+
+export default {
+  name: 'billing',
+  providers: [],
+  routes: registerBillingRoutes,
+}
+`,
+      'utf8',
+    )
+    await writeFile(
+      join(dir, 'modules/billing/routes.ts'),
+      `import type { Router } from '@guren/core'
+import { registerInvoiceRoutes } from './routes/invoice'
+
+export function registerBillingRoutes(router: Router): void {
+  registerInvoiceRoutes(router)
+}
+`,
+      'utf8',
+    )
+    await writeFile(
+      join(dir, 'modules/billing/routes/invoice.ts'),
+      `import type { Router } from '@guren/core'
+
+class InvoiceController {
+  index() {}
+}
+
+export function registerInvoiceRoutes(router: Router): void {
+  router.get('/billing/invoices', [InvoiceController, 'index'] as any).name('billing.invoices.index')
+}
+`,
+      'utf8',
+    )
+    await writeFile(
+      join(dir, 'modules/billing/app/Http/Controllers/InvoiceController.ts'),
+      `export class InvoiceController {
+  async index() {
+    return this.inertia('billing/Invoices', { invoices: [] })
+  }
+}
+`,
+      'utf8',
+    )
+  })
+
+  afterAll(async () => {
+    await workspace.cleanup()
+  })
+
+  it('derives routes from files under modules/*/routes/, so those files are a screens.md source', async () => {
+    const { content } = await generateScreensSpec(workspace.dir)
+
+    // The route reaching the document exists only in
+    // modules/billing/routes/invoice.ts — proof that a change to a module
+    // routes-directory file can change screens.md, which is what the
+    // matching source pattern in SPEC_VIEWS promises `check --spec --changed`.
+    const row = content.split('\n').find((line) => line.startsWith('| billing/Invoices '))
+    expect(row).toBeDefined()
+    expect(row).toContain('GET /billing/invoices → InvoiceController.index')
+  })
+})


### PR DESCRIPTION
## Summary

`guren check --spec --changed` decides which spec views to regenerate by matching changed paths against each view's source patterns in `SPEC_VIEWS`. The screens view listed only `modules/*/routes.ts` and `modules/*/index.ts` — but the route graph is a runtime import: `loadRouteDefinitions` evaluates `modules/<name>/index.ts` and everything the module registrar reaches from there, including files under `modules/<name>/routes/` (where `make:route --module` writes), prefix constants, and helpers anywhere in the module. A change touching only such a file reported `screens.md` as fresh while it was stale, and `--spec` sets the exit code, so CI waved the drift through.

The screens view's module source now matches the whole `modules/<name>/` tree — the same honest-superset shape the modules view already uses for its own runtime-import input problem. Over-selection only costs a regeneration and cannot produce false drift, since generation is deterministic. The docs-graph derivation label becomes `modules/`, which also stops understating the source set (the old label claimed `routes.ts` while the pattern already matched `index.ts`).

The modules view needed no change: its source pattern already matches any source file.

## Scope

cli (`spec-generate.ts` source patterns; tests for `spec-check`, `spec-screens`, `docs-graph`; changeset)

## Risk Assessment

No behavior change outside `--changed` selection and the docs-graph label. Full (non-`--changed`) `check --spec` runs were never affected. The wider pattern can only add regenerations, never skip one that previously ran, so the gate strictly tightens. `guren docs:graph` renders the module derivation node as `modules/` instead of `modules/*/routes.ts`.

## Validation

- [x] `bun run build` (clean build, all packages)
- [x] `bun run typecheck` (root + examples, exit 0)
- [x] `bun run test:bun cli` — 1255 pass / 0 fail (change is confined to `packages/cli`; full suite left to CI)

Additional verification:
- A new `spec-screens` fixture proves the derivation claim empirically: a route defined only in `modules/billing/routes/invoice.ts`, reached via `index.ts → routes.ts → routes/invoice.ts` exactly as `make:route --module` scaffolds, appears in the generated `screens.md`.
- Mutation check: narrowing the pattern back to the conventional allow-list makes both new gate tests fail, so the tests genuinely pin the fix.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation. (No docs describe the source patterns; the changeset covers the user-facing change.)