### PR TITLE
fix(cli): stop scaffolding Inertia files into API-only apps

### DIFF
--- a/.changeset/make-controller-json-on-api-only.md
+++ b/.changeset/make-controller-json-on-api-only.md
@@ -1,0 +1,34 @@
+---
+'@guren/cli': patch
+---
+
+Adapt `make:controller` and refuse `make:view` on an API-only app instead of writing Inertia files that cannot typecheck
+
+On an app scaffolded from the `api` blueprint, the controller `guren
+make:controller` generated was the one file the app's own tsconfig would flag:
+it imports `@/.guren/pages.gen`, which codegen never writes there, and returns
+`this.inertia(...)` against a `@guren/inertia-client` that is not installed.
+Unlike the multi-file scaffolds (`add auth`, `add admin`, `add resource`), which
+refuse such an app, a lone controller has an obvious API dialect — so the
+template now adapts: on an app the two signals those refusals already read
+(no `@guren/inertia-client` dependency, no `routes/web.ts` or `routes/web.js`)
+confirm as API-only, the generated controller returns `this.json(...)` and can
+be wired into `routes/api.ts` as written. The refusals those scaffolds print
+now point at this command rather than telling you to write the controller by
+hand.
+
+`make:view` refuses on the same signals, because a page has no JSON dialect to
+adapt to — and the stray component would not stay harmless. The api starter's
+tsconfig skips `resources/`, but its own `dev` script runs `guren codegen`,
+which folds every page under `resources/js/pages` into `.guren/pages.gen.ts` —
+a file that tsconfig does include, importing the `@guren/inertia-client` the
+app never installs. One `make:view` flipped `typecheck` and `build` red two
+commands later, far from the command that caused it.
+
+The judgment stays positive-evidence only: whenever the signals cannot confirm
+an API-only app — no manifest to read, a hoisted workspace dependency, a web
+routes entry present — both commands behave exactly as before, and
+installing `@guren/inertia-client` switches an app back to the Inertia
+templates. Both commands judge the root the file is written into (resolved
+once and reused for the write), not the process directory, so `cwd`-passing
+callers such as the MCP server get the same answer the write acts on.

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -66,9 +66,10 @@ your own check later.
 
 `add admin` needs a fullstack app. The dashboard is an Inertia page, so on an app
 scaffolded from the `api` blueprint — no `@guren/inertia-client` dependency and no
-`routes/web.ts` — the command refuses and writes nothing rather than scaffolding a
-controller that does not typecheck and a routes file nothing mounts. Add an admin
-endpoint to `routes/api.ts` by hand instead.
+web routes entry (`routes/web.ts` or `routes/web.js`) — the command refuses and
+writes nothing rather than scaffolding a controller that does not typecheck and a
+routes file nothing mounts. Scaffold an admin endpoint with `make:controller`
+instead, and register it in `routes/api.ts`.
 
 `add auth` needs a fullstack app for the same reason, and refuses on the same two
 signals — as does `make:auth`, which reaches the same scaffold. Auth also patches
@@ -82,10 +83,23 @@ token-based API, guard `routes/api.ts` with `createBearerTokenMiddleware` from
 scaffolds React page components and a controller that returns Inertia responses.
 Its refusal likewise comes before the table it would otherwise append to your
 `db/schema.ts`. So does `make:feature`, which reaches the same scaffold
-directly. Add a JSON controller wired into `routes/api.ts` by hand instead.
-The single-file generators (`make:controller`, `make:view`) also emit
-Inertia-shaped output but are not guarded: one stray file is a deletion, not a
-broken scaffold.
+directly. Scaffold a JSON controller with `make:controller` instead, and wire it
+into `routes/api.ts`.
+
+`make:controller` reads the same two signals but adapts instead of refusing: on
+an app they identify as API-only, the generated controller returns JSON
+(`this.json(...)`) rather than an Inertia page, so it typechecks as written and
+can be wired into `routes/api.ts` as-is. Whenever the signals cannot confirm an
+API-only app, you get the usual Inertia template — installing
+`@guren/inertia-client` is enough to switch back.
+
+`make:view` refuses on those signals like the scaffolds above, because a page
+has no JSON shape to adapt to — and a stray one would not stay harmless:
+`guren codegen` (which `bun run dev` runs for you) folds every component under
+`resources/js/pages` into `.guren/pages.gen.ts`, and that file imports the
+`@guren/inertia-client` an API-only app never installs, breaking `typecheck`
+two commands later. Install `@guren/inertia-client` first when taking an API
+app fullstack, and the command works again.
 
 `add resource` also needs the two files it patches to be there, whatever shape the
 rest of your app is: it appends its table to `db/schema.ts` and registers the CRUD
@@ -103,9 +117,9 @@ table to.
 |---------|-------------|---------|
 | `key:generate` | Generate a new `APP_KEY` value. Use `--write` to save it to `.env` | `bunx guren key:generate --write` |
 | `deploy` | Generate deployment recipe files for Docker/Fly.io/Railway/Vercel | `bunx guren deploy --target all --app my-app --port 3333` |
-| `make:controller <Name>` | Generates a controller in `app/Http/Controllers` | `bunx guren make:controller PostController` |
+| `make:controller <Name>` | Generates a controller in `app/Http/Controllers` (returns JSON instead of an Inertia page on an API-only app) | `bunx guren make:controller PostController` |
 | `make:model <Name>` | Generates a minimal model class and type definition in `app/Models` (imports `camelCase(Name)s` from `db/schema`) | `bunx guren make:model Post` |
-| `make:view <path>` | Generates a React component in `resources/js/pages` | `bunx guren make:view posts/Index` |
+| `make:view <path>` | Generates a React component in `resources/js/pages` (refuses on an API-only app) | `bunx guren make:view posts/Index` |
 | `make:auth` | Scaffolds login/logout, registration, and password reset controllers, providers, views, migration, seeder, and routes (`--minimal` skips registration and password reset, `--verify` also scaffolds email verification, `--oauth <providers>` also scaffolds OAuth login buttons for the given comma-separated providers, `--oauth-only` drops password login entirely and makes those providers the only way in) | `bunx guren make:auth --oauth github,google` |
 | `make:middleware <Name>` | Generates a middleware file in `app/Http/Middleware` | `bunx guren make:middleware Auth` |
 | `make:policy <Name>` | Generates an authorization policy in `app/Policies` with owner-based defaults | `bunx guren make:policy Post` |

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -63,10 +63,11 @@ bunx guren add admin --public
 `--public` を付けて後から独自のチェックを実装してください。
 
 `add admin` はフルスタックアプリ専用です。ダッシュボードは Inertia ページなので、
-`api` ブループリントで生成したアプリ（`@guren/inertia-client` 依存も `routes/web.ts`
-も持たない）では、型検査を通らないコントローラーとどこにもマウントされないルート
-ファイルを書く代わりに、コマンドが理由を示して中断し何も生成しません。管理用の
-エンドポイントは `routes/api.ts` に手動で追加してください。
+`api` ブループリントで生成したアプリ（`@guren/inertia-client` 依存も、web ルート
+エントリ（`routes/web.ts` または `routes/web.js`）も持たない）では、型検査を通らない
+コントローラーとどこにもマウントされないルートファイルを書く代わりに、コマンドが
+理由を示して中断し何も生成しません。管理用のエンドポイントは `make:controller` で
+生成し、`routes/api.ts` に登録してください。
 
 `add auth` も同じ理由でフルスタックアプリ専用で、同じ2つのシグナルを見て中断します。
 同じスキャフォールドを生成する `make:auth` も同様です。auth は `db/schema.ts` への
@@ -80,10 +81,23 @@ bunx guren add admin --public
 コンポーネントと Inertia レスポンスを返すコントローラーを生成するためです。中断は
 同様に、`db/schema.ts` へ追記されるはずだったテーブルよりも前の時点で起こります。
 同じスキャフォールドに直接到達する `make:feature` も同様に中断します。JSON を
-返すコントローラーは `routes/api.ts` に手動で結線してください。単一ファイルを生成
-するコマンド（`make:controller`・`make:view`）も Inertia 形の出力を書きますが、
-ガードの対象外です — 1ファイルなら削除で済み、壊れたスキャフォールドにはならない
-ためです。
+返すコントローラーは `make:controller` で生成し、`routes/api.ts` に結線して
+ください。
+
+`make:controller` は同じ2つのシグナルを読みますが、中断ではなく適応します。
+API専用と判定されたアプリでは、生成されるコントローラーは Inertia ページではなく
+JSON(`this.json(...)`)を返すため、そのまま型検査を通り、`routes/api.ts` に
+そのまま結線できます。シグナルが API専用と確認できない場合は通常の Inertia
+テンプレートが生成されます — `@guren/inertia-client` をインストールすれば
+元に戻ります。
+
+`make:view` は上記のスキャフォールドと同様、同じシグナルで中断します。ページには
+適応できる JSON 版が存在せず、置き去りのページは無害でもないためです。
+`guren codegen`(`bun run dev` が自動実行します)は `resources/js/pages` 配下の
+すべてのコンポーネントを `.guren/pages.gen.ts` に取り込み、このファイルは
+API専用アプリがインストールしない `@guren/inertia-client` を import するため、
+2コマンド後に `typecheck` が壊れます。API アプリをフルスタック化するときは、
+先に `@guren/inertia-client` をインストールすれば再び使えるようになります。
 
 `add resource` は、アプリの形がどうであれ、パッチ対象の2つのファイルがそこにあることも
 必要とします。テーブル定義を `db/schema.ts` に追記し、CRUD ルートを `routes/web.ts` に
@@ -101,9 +115,9 @@ bunx guren add admin --public
 |----------|------|----|
 | `key:generate` | 新しい `APP_KEY` 値を生成。`--write` で `.env` に保存 | `bunx guren key:generate --write` |
 | `deploy` | Docker/Fly.io/Railway/Vercel 向けデプロイ設定ファイルを生成 | `bunx guren deploy --target all --app my-app --port 3333` |
-| `make:controller <Name>` | `app/Http/Controllers` にコントローラーを生成 | `bunx guren make:controller PostController` |
+| `make:controller <Name>` | `app/Http/Controllers` にコントローラーを生成(API専用アプリでは Inertia ページの代わりに JSON を返す) | `bunx guren make:controller PostController` |
 | `make:model <Name>` | 最小のモデルクラスと型定義を `app/Models` に生成（`db/schema` から `camelCase(Name)s` を import） | `bunx guren make:model Post` |
-| `make:view <path>` | `resources/js/pages` に React コンポーネントを生成 | `bunx guren make:view posts/Index` |
+| `make:view <path>` | `resources/js/pages` に React コンポーネントを生成(API専用アプリでは中断) | `bunx guren make:view posts/Index` |
 | `make:auth` | ログイン/ログアウト・新規登録・パスワードリセットのコントローラー、プロバイダー、ビュー、マイグレーション、シーダー、ルートをスキャフォールド（`--minimal` で登録・パスワードリセットを省略、`--verify` でメール確認も追加、`--oauth <providers>` でカンマ区切りのプロバイダー向け OAuth ログインボタンも追加、`--oauth-only` でパスワードログインを完全に外して OAuth のみにする） | `bunx guren make:auth --oauth github,google` |
 | `make:middleware <Name>` | `app/Http/Middleware` にミドルウェアを生成 | `bunx guren make:middleware Auth` |
 | `make:seeder <Name>` | データベースシーダーファイルを生成 | `bunx guren make:seeder UserSeeder` |

--- a/packages/cli/src/app-surface.ts
+++ b/packages/cli/src/app-surface.ts
@@ -16,6 +16,9 @@ const WEB_ROUTES_CANDIDATES = [DEFAULT_ROUTES_FILE, 'routes/web.js'] as const
  * not typecheck against a missing `@guren/inertia-client`, and the routes file
  * is mounted by nothing.
  *
+ * Callers either refuse on a `true` (via `assertNotApiOnly` below) or, where
+ * their output has an API dialect, adapt what they emit instead.
+ *
  * Distinct from `appEmitsPageManifest` in `pages-types.ts`, which asks whether
  * codegen would write a pages manifest and answers from the page components on
  * disk. That signal cannot back a refusal — a fullstack app that has not
@@ -24,7 +27,8 @@ const WEB_ROUTES_CANDIDATES = [DEFAULT_ROUTES_FILE, 'routes/web.js'] as const
  * **Positive evidence only — every "cannot tell" answers `false`.** The cost of
  * the two mistakes is not symmetric: failing to recognize an API-only app
  * leaves the mess callers already handle today, while wrongly accusing one
- * blocks a command that would have worked. Both signals are therefore required,
+ * blocks a command that would have worked — or, for the adapting caller, hands
+ * a fullstack app the wrong dialect. Both signals are therefore required,
  * and each is individually ambiguous: `@guren/inertia-client` is the stronger
  * of the two but is read from a `package.json` that may be absent or hoisted to
  * a workspace root, and an app with no web routes entry may just be a fullstack

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -94,7 +94,7 @@ const blueprintRegistry: Record<string, BlueprintDefinition> = {
       // partial scaffold here is only harder to clean up than none.
       await assertNotApiOnly(process.cwd(), {
         does: 'guren add admin scaffolds an Inertia dashboard',
-        instead: 'Add an admin endpoint to routes/api.ts by hand',
+        instead: 'Scaffold an admin endpoint with guren make:controller and register it in routes/api.ts',
       })
 
       const writerOptions: WriterOptions = { force: Boolean(options.force) }

--- a/packages/cli/src/make-controller.ts
+++ b/packages/cli/src/make-controller.ts
@@ -1,9 +1,10 @@
+import { isConfirmedApiOnlyApp } from './app-surface'
 import type { WriterOptions } from './utils'
-import { kebabCase, pagesAccessor, safeModuleName, scaffoldFile } from './utils'
+import { kebabCase, pagesAccessor, safeModuleName, scaffoldFile, writeRoot } from './utils'
 
 const CONTROLLERS_DIR = 'app/Http/Controllers'
 
-function controllerTemplate(className: string, resourcePath: string, moduleName: string | undefined): string {
+function inertiaControllerTemplate(className: string, resourcePath: string, moduleName: string | undefined): string {
   const pageVar = resourcePath.replace(/-([a-z])/g, (_, char: string) => char.toUpperCase())
   return `import { Controller } from '@guren/core'
 import { pages } from '@/.guren/pages.gen'
@@ -18,14 +19,43 @@ export default class ${className} extends Controller {
 `
 }
 
+/** The dialect for an app `isConfirmedApiOnlyApp` recognizes. */
+function jsonControllerTemplate(className: string): string {
+  return `import { Controller } from '@guren/core'
+
+export default class ${className} extends Controller {
+  async index(): Promise<Response> {
+    return this.json({
+      data: [],
+    })
+  }
+}
+`
+}
+
+/**
+ * Adapts rather than refuses on an API-only app, unlike the multi-file
+ * scaffolds: one controller has an obvious API dialect where a whole sign-in
+ * flow does not. The Inertia template is the one file such an app's own
+ * tsconfig flags — it imports a `@/.guren/pages.gen` codegen never writes
+ * there — so emitting JSON is what the app asked for, not a lesser fallback.
+ */
 export async function makeController(name: string, options: WriterOptions = {}): Promise<string> {
   const moduleName = options.root ? safeModuleName(options.root) : undefined
+  // Resolved once and handed to the write as well: a relative `cwd`
+  // re-resolved after the probe's awaits could name a different app than the
+  // one judged.
+  const appRoot = writeRoot(options)
+  const apiOnly = await isConfirmedApiOnlyApp(appRoot)
   return scaffoldFile(name, {
     dir: CONTROLLERS_DIR,
     suffix: 'Controller',
     template: ({ normalizedName }) => {
+      if (apiOnly) {
+        return jsonControllerTemplate(normalizedName)
+      }
       const resourcePath = kebabCase(normalizedName.replace(/Controller$/u, ''))
-      return controllerTemplate(normalizedName, resourcePath, moduleName)
+      return inertiaControllerTemplate(normalizedName, resourcePath, moduleName)
     },
-  }, options)
+  }, { ...options, cwd: appRoot })
 }

--- a/packages/cli/src/make-feature.ts
+++ b/packages/cli/src/make-feature.ts
@@ -13,8 +13,12 @@ import { schemaPathFor } from './schema-parser'
  * The alternative the API-only refusal names, shared with the resource
  * blueprint: both doors lead to this one scaffold, so they point at the same
  * way out.
+ *
+ * It names `make:controller` rather than telling the reader to write the file:
+ * on the app this refusal fires for, that command emits the JSON controller
+ * itself.
  */
-export const API_ONLY_FEATURE_ALTERNATIVE = 'Add a JSON controller to routes/api.ts by hand'
+export const API_ONLY_FEATURE_ALTERNATIVE = 'Scaffold a JSON controller with guren make:controller and register it in routes/api.ts'
 
 export interface MakeFeatureOptions extends WriterOptions {
   fields?: string

--- a/packages/cli/src/make-view.ts
+++ b/packages/cli/src/make-view.ts
@@ -1,5 +1,6 @@
+import { assertNotApiOnly } from './app-surface'
 import type { WriterOptions } from './utils'
-import { pascalCase, safePathSegments, writeScaffoldFile } from './utils'
+import { pascalCase, safePathSegments, writeRoot, writeScaffoldFile } from './utils'
 
 const VIEW_ROOT = 'resources/js/pages'
 
@@ -23,9 +24,26 @@ export default ${componentName}
 `
 }
 
+/**
+ * Refuses a confirmed API-only app, like the multi-file scaffolds and unlike
+ * `makeController`: a page has no JSON dialect to adapt to, and a stray one is
+ * not inert either. The api starter's tsconfig skips `resources/`, but its own
+ * `dev` script runs `guren codegen`, which folds every page under
+ * `resources/js/pages` into `.guren/pages.gen.ts` — a file that tsconfig
+ * *does* include, importing an `@guren/inertia-client` that is not installed.
+ * One page flips `typecheck` red two commands later, far from the `make:view`
+ * that caused it.
+ */
 export async function makeView(name: string, options: WriterOptions = {}): Promise<string> {
+  // Before the shape check, so a malformed name is reported as the usage
+  // error it is rather than being masked by the app's shape.
   const segments = safePathSegments(name, 'view name')
   const componentName = pascalCase(segments[segments.length - 1]!)
   const filePath = `${VIEW_ROOT}/${segments.join('/')}.tsx`
-  return writeScaffoldFile(filePath, viewTemplate(componentName), options)
+  const appRoot = writeRoot(options)
+  await assertNotApiOnly(appRoot, {
+    does: 'guren make:view scaffolds a React page component',
+    instead: 'Scaffold a JSON controller with guren make:controller and register it in routes/api.ts',
+  })
+  return writeScaffoldFile(filePath, viewTemplate(componentName), { ...options, cwd: appRoot })
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -109,9 +109,15 @@ export function assertScaffoldPath(relativePath: string, cwd: string = process.c
  * write, rather than reading `options.cwd` twice: with `cwd` omitted or
  * relative, the second read can land on a different directory than the one
  * that was checked, and the containment check then guarantees nothing.
+ *
+ * Exported because a generator that probes the app before writing
+ * (`make:feature`, `make:controller`, `make:view`) has to judge the same root
+ * the write will resolve to, and can only do that by asking this one. It
+ * delegates to `resolveAppRoot` rather than re-deriving the expression, so the
+ * probe and the write it decides are not two resolvers that merely agree today.
  */
 export function writeRoot(options: WriterOptions): string {
-  return resolve(options.cwd ?? process.cwd())
+  return resolveAppRoot(options)
 }
 
 /** `writeFileSafe` for generated scaffolds: containment-checked. */

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -15,7 +15,9 @@ import {
   REGISTRAR_LESS_ROUTES_FIXTURE,
   captureWarnings,
   createTempWorkspace,
+  readApiOnlyTemplateFile,
   seedApiOnlyApp,
+  seedShippedApiOnlyApp,
   type TempWorkspace,
 } from './helpers'
 import { listBlueprints, runBlueprint } from '../src/blueprints'
@@ -25,16 +27,6 @@ import { runCheck } from '../src/check'
 async function seedAppFile(source: string): Promise<void> {
   await mkdir('src', { recursive: true })
   await writeFile('src/app.ts', source)
-}
-
-/**
- * A file from the api-only starter as `create-guren-app` ships it.
- *
- * Read rather than approximated: the reduced fixtures in `helpers.ts` are how
- * these tests describe a *shape*, not a substitute for the template itself.
- */
-async function readApiOnlyTemplateFile(relativePath: string): Promise<string> {
-  return readFile(resolve(import.meta.dir, '../../create-app/templates/api-only', relativePath), 'utf8')
 }
 
 /** Minimum project shape the resource blueprint patches into. */
@@ -802,9 +794,7 @@ describe('admin blueprint on an API-only app', () => {
   // The template is what `create-guren-app` ships; the fixture above is its
   // reduction, not a substitute for it.
   it('refuses the api-only template as shipped', async () => {
-    await mkdir('routes', { recursive: true })
-    await writeFile('routes/api.ts', await readApiOnlyTemplateFile('routes/api.ts'))
-    await writeFile('package.json', await readApiOnlyTemplateFile('package.json'))
+    await seedShippedApiOnlyApp(workspace.dir)
 
     await expect(runBlueprint('admin')).rejects.toThrow('guren add admin scaffolds an Inertia dashboard')
   })
@@ -931,11 +921,11 @@ describe('resource blueprint on an API-only app', () => {
   // The template is what `create-guren-app` ships; the fixture above is its
   // reduction, not a substitute for it.
   it('refuses the api-only template as shipped', async () => {
-    await mkdir('routes', { recursive: true })
+    await seedShippedApiOnlyApp(workspace.dir)
+    // Beyond the two files the predicate reads: this blueprint would append a
+    // table to it, so the assertion below needs the real schema present.
     await mkdir('db', { recursive: true })
-    await writeFile('routes/api.ts', await readApiOnlyTemplateFile('routes/api.ts'))
     await writeFile('db/schema.ts', await readApiOnlyTemplateFile('db/schema.ts'))
-    await writeFile('package.json', await readApiOnlyTemplateFile('package.json'))
 
     await expect(runBlueprint('resource', { name: 'Post' })).rejects.toThrow(
       'guren add resource scaffolds Inertia pages',

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -1,7 +1,7 @@
 import { mock } from 'bun:test'
 import { consola as realConsola } from 'consola'
 import { existsSync } from 'node:fs'
-import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { dirname, join, relative, resolve } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -181,6 +181,35 @@ export async function seedApiOnlyApp(dir: string): Promise<void> {
  * would have meant hunting every copy across three files.
  */
 export const API_ONLY_REFUSAL = /no @guren\/inertia-client dependency and no routes\/web\.ts/
+
+/**
+ * A file from the api-only starter as `create-guren-app` ships it.
+ *
+ * Read rather than approximated: the reduced fixtures above are how these tests
+ * describe a *shape*, not a substitute for the template itself.
+ */
+export async function readApiOnlyTemplateFile(relativePath: string): Promise<string> {
+  return readFile(join(import.meta.dir, '../../create-app/templates/api-only', relativePath), 'utf8')
+}
+
+/**
+ * The api-only starter as shipped, reduced to the two files
+ * `isConfirmedApiOnlyApp` reads — for tests that only need the predicate to
+ * recognize a real starter rather than the whole app on disk.
+ *
+ * `seedApiOnlyApp` above is a hand-written approximation, and an approximation
+ * cannot notice the template gaining an `@guren/inertia-client` dependency or a
+ * `routes/web.ts`: every synthetic test would stay green while real users
+ * stopped being recognized. Whichever behaviour hangs off the predicate — a
+ * refusal, or `make:controller` flipping its output dialect — wants one case
+ * seeded from the shipped files.
+ */
+export async function seedShippedApiOnlyApp(dir: string): Promise<void> {
+  await writeWorkspaceFiles(dir, {
+    'routes/api.ts': await readApiOnlyTemplateFile('routes/api.ts'),
+    'package.json': await readApiOnlyTemplateFile('package.json'),
+  })
+}
 
 export const BLOG_ROUTES_FIXTURE = `import { Router, requireAuthenticated } from '@guren/core'
 

--- a/packages/cli/tests/make-controller.test.ts
+++ b/packages/cli/tests/make-controller.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, readFile, access } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { makeController } from '../src/make-controller'
+import { seedApiOnlyApp, seedShippedApiOnlyApp } from './helpers'
 
 describe('makeController', () => {
   let tempDir: string
@@ -133,5 +134,65 @@ describe('makeController', () => {
 
   it('rejects a --module value that would escape modules/ (path traversal)', async () => {
     await expect(makeController('Invoice', { root: '../../outside' })).rejects.toThrow(/Invalid module name/)
+  })
+
+  // Only the wiring is pinned here — see makeController's doc comment for why
+  // it adapts where the multi-file scaffolds refuse. "Cannot tell" keeps
+  // Inertia via the tests above, which run in a tempDir with no manifest, and
+  // the predicate's own branches are pinned in blueprints.test.ts.
+  describe('on an API-only app', () => {
+    it('emits a JSON controller instead of the Inertia template', async () => {
+      await seedApiOnlyApp(tempDir)
+
+      const result = await makeController('User')
+
+      const content = await readFile(result, 'utf8')
+      expect(content).toContain('return this.json(')
+      expect(content).toContain('class UserController extends Controller')
+      expect(content).not.toContain('pages.gen')
+      expect(content).not.toContain('this.inertia(')
+    })
+
+    // The predicate must judge the root the file is written into, not the
+    // process directory — an explicit cwd names a different app.
+    it('judges the app at an explicit cwd, not the process directory', async () => {
+      const apiAppDir = await mkdtemp(join(tmpdir(), 'guren-cli-controller-api-cwd-'))
+      try {
+        await seedApiOnlyApp(apiAppDir)
+
+        // process.cwd() is tempDir: no manifest at all, so judged there the
+        // template would stay Inertia.
+        const result = await makeController('User', { cwd: apiAppDir })
+
+        expect(result).toContain(join(apiAppDir, 'app/Http/Controllers/UserController.ts'))
+        expect(await readFile(result, 'utf8')).toContain('return this.json(')
+      } finally {
+        await rm(apiAppDir, { recursive: true, force: true })
+      }
+    })
+
+    // The template is what `create-guren-app` ships; the fixture above is its
+    // reduction, not a substitute for it. This command's *output* flips on the
+    // predicate, so a starter that quietly gained the client would hand users
+    // the Inertia template back with every synthetic test still green.
+    it('emits the JSON dialect for the api-only template as shipped', async () => {
+      await seedShippedApiOnlyApp(tempDir)
+
+      const result = await makeController('User')
+
+      expect(await readFile(result, 'utf8')).toContain('return this.json(')
+    })
+
+    // Judged at the app root even when the file lands under modules/ — a
+    // probe against modules/billing/ would find neither signal and answer
+    // "cannot tell" for an app that is confirmed API-only.
+    it('emits the JSON dialect under --module too, judging the app root', async () => {
+      await seedApiOnlyApp(tempDir)
+
+      const result = await makeController('Invoice', { root: 'billing' })
+
+      expect(result).toContain('modules/billing/app/Http/Controllers/InvoiceController.ts')
+      expect(await readFile(result, 'utf8')).toContain('return this.json(')
+    })
   })
 })

--- a/packages/cli/tests/make-view.test.ts
+++ b/packages/cli/tests/make-view.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'bun:test'
+import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
-import { createTempWorkspace } from './helpers'
+import { join } from 'node:path'
+import { API_ONLY_REFUSAL, createTempWorkspace, seedApiOnlyApp, seedShippedApiOnlyApp } from './helpers'
 import { makeView } from '../src/make-view'
 
 describe('makeView', () => {
@@ -25,6 +27,38 @@ describe('makeView', () => {
 
       expect(result).toContain('resources/js/pages/admin/my page.tsx')
       expect(await readFile(result, 'utf8')).toContain('const MyPage')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  // Refuses before the write, like the multi-file scaffolds — see makeView's
+  // doc comment for why a page has no dialect to adapt to. The "cannot tell"
+  // direction is carried by the tests above, which run in a workspace with no
+  // manifest; the predicate's own branches are pinned in blueprints.test.ts.
+  it('refuses an API-only app, writing nothing', async () => {
+    const workspace = await createTempWorkspace('guren-cli-view-api-only-')
+    try {
+      await seedApiOnlyApp(workspace.dir)
+
+      await expect(makeView('posts/Index')).rejects.toThrow(API_ONLY_REFUSAL)
+
+      expect(existsSync(join(workspace.dir, 'resources/js/pages/posts/Index.tsx'))).toBe(false)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  // The template is what `create-guren-app` ships; the fixture above is its
+  // reduction, not a substitute for it.
+  it('refuses the api-only template as shipped', async () => {
+    const workspace = await createTempWorkspace('guren-cli-view-api-only-shipped-')
+    try {
+      await seedShippedApiOnlyApp(workspace.dir)
+
+      await expect(makeView('posts/Index')).rejects.toThrow(
+        'guren make:view scaffolds a React page component',
+      )
     } finally {
       await workspace.cleanup()
     }


### PR DESCRIPTION
## Problem

`guren make:controller` always emitted a controller importing `@/.guren/pages.gen` and returning `this.inertia(...)`. On an app scaffolded from the `api` blueprint that file never typechecks: codegen writes no pages manifest there, and `@guren/inertia-client` is not installed.

The multi-file scaffolds (`add auth`, `add admin`, `add resource`, and since #349 `make:feature`) already refuse such an app via `assertNotApiOnly`. The single-file generators were exempted on the theory that one stray file is a deletion, not a broken scaffold. That theory holds for `make:controller` — but turned out to be wrong for `make:view`.

## Change

**`make:controller` adapts instead of refusing.** On an app the same two signals confirm as API-only (no `@guren/inertia-client` dependency, and no `routes/web.ts` or `routes/web.js`), it emits a JSON controller that typechecks as written and can be registered in `routes/api.ts` as-is. One controller has an obvious API dialect where a whole sign-in flow does not.

```ts
export default class UserController extends Controller {
  async index(): Promise<Response> {
    return this.json({ data: [] })
  }
}
```

**`make:view` refuses.** A page has no JSON dialect to adapt to — and the stray component is not inert, which is the part the exemption got wrong. The api starter's tsconfig skips `resources/`, but its own `dev` script runs `guren codegen`, which folds every page under `resources/js/pages` into `.guren/pages.gen.ts` — a file that tsconfig *does* include, importing the `@guren/inertia-client` the app never installs. One `make:view` flips `typecheck` and `build` red two commands later, far from the command that caused it. Verified by reproduction against the shipped template, not by reading.

**Both judge the root the file is written into**, via the `writeRoot()` #349 exported for exactly this purpose, so a `cwd`-passing caller (the MCP server) cannot probe one app and write into another.

**The judgment stays positive-evidence only.** Every "cannot tell" — no manifest to read, a dependency hoisted to a workspace root, a web routes entry present — behaves exactly as before, and installing `@guren/inertia-client` switches an app back to the Inertia templates.

## Drive-by, caused by this change

`API_ONLY_FEATURE_ALTERNATIVE` (and the admin blueprint's own message) told users to write a JSON controller **by hand**. `make:controller` now scaffolds exactly that file, so the refusals point at it instead. Docs follow.

`writeRoot()` now delegates to `resolveAppRoot()` rather than re-deriving the same expression: this change relies on "the root probed is the root written to", and that invariant should not rest on two independent resolvers happening to agree.

`readApiOnlyTemplateFile()` moves from `blueprints.test.ts` into `helpers.ts` alongside a new `seedShippedApiOnlyApp()`, so the two test files that now need the shipped starter share one path literal.

## Verification

- CLI suite: 1293 pass, 0 fail. Root `typecheck`, `audit:core-first`, `audit:docs` all pass. Rebased onto current `main` (#349/#353 landed the `make:feature` guard in the meantime; conflicts resolved in favour of main's shared constant and helper, with their values updated).
- **Mutation-checked**: forcing `isConfirmedApiOnlyApp` to return `false` turns the new tests red, so they can actually fail.
- New tests cover the JSON dialect, an explicit `cwd`, `--module`, the `make:view` refusal writing nothing, and — for both commands — the api-only template **as shipped**, not just the reduced fixture. `make:controller` is the one command whose *output* flips on this predicate, so a starter that quietly gained the client would otherwise hand users the Inertia template back with every synthetic test still green.

## Known gap, filed separately

The invariant "an API-only app has no pages manifest" has no owner: `check.ts` and `doctor.ts` assume it, and after this PR it is upheld indirectly by generators refusing to create pages. It arguably belongs in codegen — but a codegen skip would invert the predicate's risk profile from fail-loud (a blocked command with an explanatory error) to fail-silent (a fullstack app left with no `pages.gen.ts` and unresolvable imports), so it needs its own design pass rather than a patch here.
