### PR TITLE
fix(cli): wire providers through one registrar that writes once

### DIFF
--- a/.changeset/provider-wiring-single-write.md
+++ b/.changeset/provider-wiring-single-write.md
@@ -1,0 +1,50 @@
+---
+'@guren/cli': patch
+---
+
+Wire providers into the app entry through one registrar that writes once
+
+Three implementations of "register a provider in the app entry and report the
+outcome" coexisted — the blueprints' `installProvider`, `make:auth`'s
+`wireProvider`, and two inline copies inside `make:auth` for the framework's own
+mail and OAuth service providers. They are now one shared helper, which closes
+the gaps between them.
+
+`guren add cache` — and every other infrastructure blueprint, and `guren plugin`
+— probed only `src/app.ts`. An app that keeps its entry at the root (`app.ts`,
+which `guren add auth` and `guren make:module` both already found) was reported
+as having no app file at all. The entry now comes from one shared candidate
+list, and the generated import is relative to whichever entry was found, so a
+root `app.ts` gets `./app/Providers/CacheProvider.js` rather than a path that
+climbs out of the project.
+
+`guren add auth` still added each provider's import *before* registering it, as
+did `guren plugin`. On an app whose `providers: [ ... ]` array cannot be located
+— a hand-edited entry, or one that never had the array — the run reported a
+failure having already written an import nothing references, which stops the app
+compiling under `noUnusedLocals`. `guren plugin` was the worst of the two: it
+throws rather than warning, so it left the orphan import behind and refused to
+finish.
+
+Registering before importing, as the blueprints already did, is not the whole
+fix. The two patches each read and rewrite the entry independently, so whichever
+runs second can fail on its own — a permissions change, a full disk, an
+interrupt — and the state that leaves, "registered but not imported", is worse
+than the one being avoided: an unresolved identifier throws at runtime rather
+than merely failing a lint. Both edits are now composed in memory, through a
+pure `insertProvider` beside the existing `insertImport`, and applied in a
+single write. An entry that cannot take one half receives neither. This is the
+shape `addRouteRegistrarCall` already used for the same reason, and what
+`insertImport`'s own documentation was written for.
+
+`guren make:module` had the same import-first hazard against its
+`modules: [ ... ]` patch, and is fixed the same way.
+
+Reporting stays per command, because the three callers genuinely differ: the
+blueprints warn and name what to register by hand, `guren add auth` narrates
+each step, and `guren plugin` throws and collects structured messages rather
+than touching the console. Only the entry resolution and the patch primitive are
+shared. One nicety falls out of the consolidation — inside a single
+`guren add auth` run, the framework's own service providers now report the way
+the scaffolded ones always did, instead of staying silent when they were already
+registered.

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -1,4 +1,3 @@
-import { consola } from 'consola'
 import { assertNotApiOnly } from './app-surface'
 import { fileExists, readIfExists } from './discovery'
 import { makeAuth } from './make-auth'
@@ -16,7 +15,8 @@ import { makeModel } from './make-model'
 import { makeNotification } from './make-notification'
 import { makeRoute } from './make-route'
 import { makeView } from './make-view'
-import { addImport, addProvider, detectSchemaDialect, ensureDrizzleImports, ensureMysqlImports, ensureSqliteImports, insertImport } from './patch-helpers'
+import { detectSchemaDialect, ensureDrizzleImports, ensureMysqlImports, ensureSqliteImports, insertImport } from './patch-helpers'
+import { wireProviders } from './provider-registrar'
 import { DEFAULT_ROUTES_FILE, findRouteRegistrar, wireRouteRegistrar } from './route-registrar'
 import { assertCwdUnsupported, camelCase, pascalCase, writeScaffoldFiles, type WriterOptions } from './utils'
 import { readFile, writeFile } from 'node:fs/promises'
@@ -39,44 +39,6 @@ export interface RunBlueprintOptions extends WriterOptions {
 export interface BlueprintDefinition {
   description: string
   run: (options: RunBlueprintOptions) => Promise<string[]>
-}
-
-/** The one file the infrastructure blueprints register their providers in. */
-const APP_FILE = 'src/app.ts'
-
-/**
- * Registers a provider in the app file, reporting every outcome.
- *
- * Nothing here may be silent. `addImport`/`addProvider` return
- * `{ modified: false, reason }` rather than throwing, and the results used to be
- * discarded: an app with no `src/app.ts`, or one whose providers array the patch
- * cannot find, got its provider file written, nothing registered, and a success
- * report — and then booted without the feature the CLI just said it installed.
- *
- * Same rule as `wireRouteRegistrar()`, and for the same reason the scaffold is
- * not refused here: every file these blueprints write is deletable, so an
- * unpatchable app file earns a warning naming what to register by hand.
- */
-async function installProvider(importStatement: string, providerName: string): Promise<void> {
-  // The array first: on a file whose providers array cannot be patched, the
-  // import would be a binding nothing uses, and the app it was scaffolded into
-  // stops compiling under noUnusedLocals over a feature it never received.
-  const registration = await addProvider(APP_FILE, providerName)
-
-  if (registration.modified || registration.reason === 'Provider already registered') {
-    const imported = await addImport(APP_FILE, importStatement)
-    if (!imported.modified && imported.reason !== 'Import already exists') {
-      consola.warn(`Could not add the ${providerName} import to ${APP_FILE}: ${imported.reason}. Add it by hand: ${importStatement}`)
-    }
-    return
-  }
-
-  if (registration.reason === 'File not found') {
-    consola.warn(`Could not find ${APP_FILE} — ${providerName} was not registered.`)
-  } else {
-    consola.warn(`Could not register ${providerName} in ${APP_FILE}: ${registration.reason}.`)
-  }
-  consola.info(`Add ${providerName} to your createApp() providers array by hand: ${importStatement}`)
 }
 
 async function scaffoldFeatureFiles(
@@ -329,14 +291,10 @@ export default registerOAuthRoutes
         },
       ], writerOptions)
 
-      await installProvider(
-        "import { OAuthServiceProvider as CoreOAuthServiceProvider } from '@guren/core'",
-        'CoreOAuthServiceProvider',
-      )
-      await installProvider(
-        "import OAuthProvider from '../app/Providers/OAuthProvider.js'",
-        'OAuthProvider',
-      )
+      await wireProviders([
+        { name: 'CoreOAuthServiceProvider', importStatement: "import { OAuthServiceProvider as CoreOAuthServiceProvider } from '@guren/core'" },
+        { name: 'OAuthProvider' },
+      ])
 
       await wireRouteRegistrar('registerOAuthRoutes', "import registerOAuthRoutes from './oauth.js'")
 
@@ -379,14 +337,10 @@ export class ApplicationCache {
         },
       ], writerOptions)
 
-      await installProvider(
-        "import { CacheServiceProvider as CoreCacheServiceProvider } from '@guren/core'",
-        'CoreCacheServiceProvider',
-      )
-      await installProvider(
-        "import CacheProvider from '../app/Providers/CacheProvider.js'",
-        'CacheProvider',
-      )
+      await wireProviders([
+        { name: 'CoreCacheServiceProvider', importStatement: "import { CacheServiceProvider as CoreCacheServiceProvider } from '@guren/core'" },
+        { name: 'CacheProvider' },
+      ])
 
       return created
     },
@@ -420,14 +374,10 @@ export default class EventProvider extends ServiceProvider {
         },
       ], writerOptions)
 
-      await installProvider(
-        "import { EventServiceProvider as CoreEventServiceProvider } from '@guren/core'",
-        'CoreEventServiceProvider',
-      )
-      await installProvider(
-        "import EventProvider from '../app/Providers/EventProvider.js'",
-        'EventProvider',
-      )
+      await wireProviders([
+        { name: 'CoreEventServiceProvider', importStatement: "import { EventServiceProvider as CoreEventServiceProvider } from '@guren/core'" },
+        { name: 'EventProvider' },
+      ])
 
       return [eventPath, listenerPath, ...created]
     },
@@ -467,14 +417,10 @@ export default class MailProvider extends ServiceProvider {
         },
       ], writerOptions)
 
-      await installProvider(
-        "import { MailServiceProvider as CoreMailServiceProvider } from '@guren/core'",
-        'CoreMailServiceProvider',
-      )
-      await installProvider(
-        "import MailProvider from '../app/Providers/MailProvider.js'",
-        'MailProvider',
-      )
+      await wireProviders([
+        { name: 'CoreMailServiceProvider', importStatement: "import { MailServiceProvider as CoreMailServiceProvider } from '@guren/core'" },
+        { name: 'MailProvider' },
+      ])
 
       return [mailPath, ...created]
     },
@@ -516,14 +462,10 @@ export default class QueueProvider extends ServiceProvider {
         },
       ], writerOptions)
 
-      await installProvider(
-        "import { QueueServiceProvider as CoreQueueServiceProvider } from '@guren/core'",
-        'CoreQueueServiceProvider',
-      )
-      await installProvider(
-        "import QueueProvider from '../app/Providers/QueueProvider.js'",
-        'QueueProvider',
-      )
+      await wireProviders([
+        { name: 'CoreQueueServiceProvider', importStatement: "import { QueueServiceProvider as CoreQueueServiceProvider } from '@guren/core'" },
+        { name: 'QueueProvider' },
+      ])
 
       return [jobPath, ...created]
     },
@@ -554,14 +496,10 @@ export default class NotificationProvider extends ServiceProvider {
         },
       ], writerOptions)
 
-      await installProvider(
-        "import { NotificationServiceProvider as CoreNotificationServiceProvider } from '@guren/core'",
-        'CoreNotificationServiceProvider',
-      )
-      await installProvider(
-        "import NotificationProvider from '../app/Providers/NotificationProvider.js'",
-        'NotificationProvider',
-      )
+      await wireProviders([
+        { name: 'CoreNotificationServiceProvider', importStatement: "import { NotificationServiceProvider as CoreNotificationServiceProvider } from '@guren/core'" },
+        { name: 'NotificationProvider' },
+      ])
 
       return [notificationPath, ...created]
     },
@@ -603,14 +541,10 @@ export class FileStorage {
         },
       ], writerOptions)
 
-      await installProvider(
-        "import { StorageServiceProvider as CoreStorageServiceProvider } from '@guren/core'",
-        'CoreStorageServiceProvider',
-      )
-      await installProvider(
-        "import StorageProvider from '../app/Providers/StorageProvider.js'",
-        'StorageProvider',
-      )
+      await wireProviders([
+        { name: 'CoreStorageServiceProvider', importStatement: "import { StorageServiceProvider as CoreStorageServiceProvider } from '@guren/core'" },
+        { name: 'StorageProvider' },
+      ])
 
       return created
     },
@@ -658,14 +592,10 @@ export default class BroadcastProvider extends ServiceProvider {
         },
       ], writerOptions)
 
-      await installProvider(
-        "import { BroadcastServiceProvider as CoreBroadcastServiceProvider } from '@guren/core'",
-        'CoreBroadcastServiceProvider',
-      )
-      await installProvider(
-        "import BroadcastProvider from '../app/Providers/BroadcastProvider.js'",
-        'BroadcastProvider',
-      )
+      await wireProviders([
+        { name: 'CoreBroadcastServiceProvider', importStatement: "import { BroadcastServiceProvider as CoreBroadcastServiceProvider } from '@guren/core'" },
+        { name: 'BroadcastProvider' },
+      ])
 
       return [publicChannelPath, privateChannelPath, ...created]
     },
@@ -739,10 +669,7 @@ export default scheduleTasksKernel
         },
       ], writerOptions)
 
-      await installProvider(
-        "import { SchedulingServiceProvider as CoreSchedulingServiceProvider } from '@guren/core'",
-        'CoreSchedulingServiceProvider',
-      )
+      await wireProviders([{ name: 'CoreSchedulingServiceProvider', importStatement: "import { SchedulingServiceProvider as CoreSchedulingServiceProvider } from '@guren/core'" }])
 
       return created
     },

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -1,21 +1,21 @@
-import { readFile, writeFile } from 'node:fs/promises'
-import { dirname, relative, resolve, sep as pathSep } from 'node:path'
+import { writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
 import { consola } from 'consola'
 import { assertCwdUnsupported, writeScaffoldFiles, type WriterOptions } from './utils'
 import { assertNotApiOnly } from './app-surface'
 import {
-  addImport,
-  addProvider,
   addCreateAppOption,
   detectSchemaDialect,
   ensureDrizzleImports,
   ensureMysqlImports,
   ensureSqliteImports,
+  PATCH_REASONS,
   readSchemaDialect,
   seederContextTypes,
   type SchemaDialect,
 } from './patch-helpers'
 import { readIfExists } from './discovery'
+import { APP_ENTRY_CANDIDATES, resolveAppEntry, wireAppProvider, wireProvider } from './provider-registrar'
 import { wireRouteRegistrar } from './route-registrar'
 import { makeMigration } from './make-migration'
 
@@ -2105,7 +2105,7 @@ async function warnAboutStalePasswordScaffold(): Promise<void> {
   }
   if (leftovers.some((path) => MAIL_SCAFFOLD_PATHS.includes(path))) {
     consola.warn(
-      'src/app.ts may still register MailProvider and CoreMailServiceProvider from that run — remove them too if nothing else sends mail.',
+      'Your app entry may still register MailProvider and CoreMailServiceProvider from that run — remove them too if nothing else sends mail.',
     )
   }
 }
@@ -2310,11 +2310,11 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
     await installAuth(features, migrationGenerated)
   } else {
     consola.info('Next steps:')
-    consola.info('  • Register AuthProvider in src/app.ts providers array')
+    consola.info('  • Register AuthProvider in your createApp() providers array')
     consola.info('  • Enable sessions and CSRF by adding `auth: {}` to your createApp() options')
     consola.info('  • Import registerAuthRoutes from routes/auth.ts and call it from your routes/web.ts registrar')
     if (includeExtras) {
-      consola.info('  • Register MailProvider in src/app.ts providers array (used to send password reset emails)')
+      consola.info('  • Register MailProvider in your createApp() providers array (used to send password reset emails)')
       consola.info('  • Set APP_URL in your .env to the public base URL of this app — emailed links are built from it, and production refuses to send without it')
     }
     if (!migrationGenerated) {
@@ -2323,7 +2323,7 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
     consola.info(includePassword ? '  • Run `bun run db:migrate` and `bun run db:seed`' : '  • Run `bun run db:migrate`')
     consola.info('  • Install zod if not already installed: `bun add zod`')
     if (includeOAuth) {
-      consola.info('  • Register CoreOAuthServiceProvider (from @guren/core) and OAuthProvider in src/app.ts providers array')
+      consola.info('  • Register CoreOAuthServiceProvider (from @guren/core) and OAuthProvider in your createApp() providers array')
       for (const provider of oauthProviders) {
         const upper = provider.toUpperCase()
         consola.info(`  • Set OAUTH_${upper}_CLIENT_ID / OAUTH_${upper}_CLIENT_SECRET / OAUTH_${upper}_REDIRECT_URI in your .env (see .env.example)`)
@@ -2334,58 +2334,23 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
   return created
 }
 
-async function wireProvider(appPath: string, providerName: string, providerRelativePath: string): Promise<void> {
-  const importPath = (() => {
-    const base = dirname(appPath)
-    const rel = relative(base, providerRelativePath) || providerRelativePath
-    const normalized = rel.split(pathSep).join('/').replace(/^\.$/, providerRelativePath)
-    return normalized.startsWith('.') ? normalized : `./${normalized}`
-  })()
-
-  const importResult = await addImport(appPath, `import ${providerName} from '${importPath}'`)
-  if (importResult.modified) {
-    consola.success(`Added ${providerName} import to ${appPath}`)
-  } else if (importResult.reason === 'Import already exists') {
-    consola.info(`${providerName} import already exists in ${appPath}`)
-  }
-
-  const providerResult = await addProvider(appPath, providerName)
-  if (providerResult.modified) {
-    consola.success(`Added ${providerName} to providers array in ${appPath}`)
-  } else if (providerResult.reason === 'Provider already registered') {
-    consola.info(`${providerName} already registered in ${appPath}`)
-  } else {
-    consola.warn(`Could not add ${providerName}: ${providerResult.reason}`)
-  }
-}
-
 async function installAuth(
   { includeExtras, includePassword, oauthProviders }: AuthFeatures,
   migrationGenerated: boolean,
 ): Promise<void> {
   consola.info('Installing authentication configuration...')
 
-  // Determine app file location (try src/app.ts first, then app.ts)
-  const appPaths = ['src/app.ts', 'app.ts']
-  let appPath: string | undefined
-
-  for (const path of appPaths) {
-    try {
-      await readFile(resolve(process.cwd(), path), 'utf8')
-      appPath = path
-      break
-    } catch {
-      // File doesn't exist, try next
-    }
-  }
+  const appPath = await resolveAppEntry()
 
   if (!appPath) {
-    consola.warn('Could not find src/app.ts or app.ts - skipping auto-configuration')
+    consola.warn(`Could not find ${APP_ENTRY_CANDIDATES.join(' or ')} - skipping auto-configuration`)
     consola.info('Please manually register AuthProvider in your Application providers')
     return
   }
 
-  await wireProvider(appPath, 'AuthProvider', 'app/Providers/AuthProvider.js')
+  const wiring = { appPath, verbose: true } as const
+
+  await wireAppProvider('AuthProvider', wiring)
 
   if (includeExtras) {
     // Wire CoreMailServiceProvider before our own MailProvider — matching
@@ -2393,33 +2358,21 @@ async function installAuth(
     // 'mail', ...)` resolves to our configured manager rather than Core's
     // empty-config default, regardless of whether `add mail` also runs
     // (before or after this) against the same app.
-    const coreMailImportResult = await addImport(appPath, "import { MailServiceProvider as CoreMailServiceProvider } from '@guren/core'")
-    if (coreMailImportResult.modified) {
-      consola.success(`Added CoreMailServiceProvider import to ${appPath}`)
-    }
-    const coreMailProviderResult = await addProvider(appPath, 'CoreMailServiceProvider')
-    if (coreMailProviderResult.modified) {
-      consola.success(`Added CoreMailServiceProvider to providers array in ${appPath}`)
-    } else if (coreMailProviderResult.reason !== 'Provider already registered') {
-      consola.warn(`Could not add CoreMailServiceProvider: ${coreMailProviderResult.reason}`)
-    }
-
-    await wireProvider(appPath, 'MailProvider', 'app/Providers/MailProvider.js')
+    await wireProvider(
+      'CoreMailServiceProvider',
+      "import { MailServiceProvider as CoreMailServiceProvider } from '@guren/core'",
+      wiring,
+    )
+    await wireAppProvider('MailProvider', wiring)
   }
 
   if (oauthProviders.length > 0) {
-    const coreImportResult = await addImport(appPath, "import { OAuthServiceProvider as CoreOAuthServiceProvider } from '@guren/core'")
-    if (coreImportResult.modified) {
-      consola.success(`Added CoreOAuthServiceProvider import to ${appPath}`)
-    }
-    const coreProviderResult = await addProvider(appPath, 'CoreOAuthServiceProvider')
-    if (coreProviderResult.modified) {
-      consola.success(`Added CoreOAuthServiceProvider to providers array in ${appPath}`)
-    } else if (coreProviderResult.reason !== 'Provider already registered') {
-      consola.warn(`Could not add CoreOAuthServiceProvider: ${coreProviderResult.reason}`)
-    }
-
-    await wireProvider(appPath, 'OAuthProvider', 'app/Providers/OAuthProvider.js')
+    await wireProvider(
+      'CoreOAuthServiceProvider',
+      "import { OAuthServiceProvider as CoreOAuthServiceProvider } from '@guren/core'",
+      wiring,
+    )
+    await wireAppProvider('OAuthProvider', wiring)
   }
 
   // Enable session + CSRF middleware: AuthServiceProvider is only registered
@@ -2427,7 +2380,7 @@ async function installAuth(
   const authOptionResult = await addCreateAppOption(appPath, 'auth', '{}')
   if (authOptionResult.modified) {
     consola.success(`Enabled sessions and CSRF via auth option in ${appPath}`)
-  } else if (authOptionResult.reason === 'Option already set') {
+  } else if (authOptionResult.reason === PATCH_REASONS.optionAlreadySet) {
     consola.info(`auth option already set in ${appPath}`)
   } else {
     consola.warn(`Could not set the auth option automatically: ${authOptionResult.reason}`)

--- a/packages/cli/src/make-command.ts
+++ b/packages/cli/src/make-command.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path'
 import { consola } from 'consola'
 import type { WriterOptions } from './utils'
 import { camelCase, ensureSuffix, kebabCase, relativeImportPath, resourceName, safeModuleName, scaffoldFile } from './utils'
-import { addImport, addToArrayArgument, addToArrayOption } from './patch-helpers'
+import { addImport, addToArrayArgument, addToArrayOption, PATCH_REASONS } from './patch-helpers'
 import { fileExists, readIfExists } from './discovery'
 import { registersCommandsOf } from './console-check'
 
@@ -93,7 +93,7 @@ async function registerRootCommand(className: string, file: string): Promise<voi
   // an unused import behind.
   const registration = await addToArrayArgument(CONSOLE_ENTRY, 'registerMany', className)
 
-  if (!registration.modified && registration.reason !== 'Already present') {
+  if (!registration.modified && registration.reason !== PATCH_REASONS.alreadyPresent) {
     consola.warn(`Could not register ${className} automatically: ${registration.reason}`)
     printRootRegistrationGuidance(className, specifier)
     return
@@ -122,7 +122,7 @@ async function registerModuleCommand(className: string, file: string, moduleName
 
   const registration = await addToArrayOption(indexPath, 'commands', className, 'defineModule')
 
-  if (!registration.modified && registration.reason !== 'Already present') {
+  if (!registration.modified && registration.reason !== PATCH_REASONS.alreadyPresent) {
     consola.warn(`Could not register ${className} automatically: ${registration.reason}`)
     consola.info(`Add \`commands: [${className}]\` to defineModule() in ${indexPath}, importing it from '${specifier}'.`)
     return

--- a/packages/cli/src/make-module.ts
+++ b/packages/cli/src/make-module.ts
@@ -1,7 +1,8 @@
 import { consola } from 'consola'
 import { assertCwdUnsupported, camelCase, pascalCase, relativeImportPath, safeModuleName, writeScaffoldFiles, type WriterOptions } from './utils'
-import { addImport, addToArrayOption } from './patch-helpers'
+import { addImport, addToArrayOption, PATCH_REASONS } from './patch-helpers'
 import { fileExists } from './discovery'
+import { APP_ENTRY_CANDIDATES, resolveAppEntry } from './provider-registrar'
 
 export interface MakeModuleResult {
   moduleDir: string
@@ -77,7 +78,7 @@ async function patchRootSchema(moduleDir: string): Promise<void> {
 
   if (result.modified) {
     consola.success(`Added schema re-export to ${rootSchemaPath}`)
-  } else if (result.reason === 'Import already exists') {
+  } else if (result.reason === PATCH_REASONS.importAlreadyExists) {
     consola.info(`Schema re-export already present in ${rootSchemaPath}`)
   } else {
     consola.warn(`Could not add the schema re-export automatically: ${result.reason}`)
@@ -86,20 +87,11 @@ async function patchRootSchema(moduleDir: string): Promise<void> {
 }
 
 async function patchAppEntry(moduleDir: string, camelName: string): Promise<void> {
-  const appPaths = ['src/app.ts', 'app.ts']
-  let appPath: string | undefined
-
-  for (const candidate of appPaths) {
-    if (await fileExists(process.cwd(), candidate)) {
-      appPath = candidate
-      break
-    }
-  }
-
+  const appPath = await resolveAppEntry()
   const moduleBinding = `${camelName}Module`
 
   if (!appPath) {
-    consola.warn('Could not find src/app.ts or app.ts — skipping auto-registration.')
+    consola.warn(`Could not find ${APP_ENTRY_CANDIDATES.join(' or ')} — skipping auto-registration.`)
     consola.info(`Import ${moduleBinding} from './${moduleDir}' and add it to createApp({ modules: [...] }) manually.`)
     return
   }
@@ -107,20 +99,25 @@ async function patchAppEntry(moduleDir: string, camelName: string): Promise<void
   const importPath = relativeImportPath(appPath, moduleDir)
   const moduleImport = `import { ${moduleBinding} } from '${importPath}'`
 
-  const importResult = await addImport(appPath, moduleImport)
-  if (importResult.modified) {
-    consola.success(`Added ${moduleBinding} import to ${appPath}`)
-  } else if (importResult.reason === 'Import already exists') {
-    consola.info(`${moduleBinding} import already exists in ${appPath}`)
-  }
-
+  // Registration first, import only once it lands — the same ordering
+  // `addProviderRegistration` enforces, and for the same reason: an import of
+  // a binding nothing references is an unused local, which stops the app
+  // compiling under `noUnusedLocals`.
   const modulesResult = await addToArrayOption(appPath, 'modules', moduleBinding)
   if (modulesResult.modified) {
     consola.success(`Registered ${moduleBinding} in ${appPath}`)
-  } else if (modulesResult.reason === 'Already present') {
+  } else if (modulesResult.reason === PATCH_REASONS.alreadyPresent) {
     consola.info(`${moduleBinding} already registered in ${appPath}`)
   } else {
     consola.warn(`Could not register the module automatically: ${modulesResult.reason}`)
     consola.info(`Add \`modules: [${moduleBinding}]\` to your createApp() options.`)
+    return
+  }
+
+  const importResult = await addImport(appPath, moduleImport)
+  if (importResult.modified) {
+    consola.success(`Added ${moduleBinding} import to ${appPath}`)
+  } else if (importResult.reason === PATCH_REASONS.importAlreadyExists) {
+    consola.info(`${moduleBinding} import already exists in ${appPath}`)
   }
 }

--- a/packages/cli/src/patch-helpers.ts
+++ b/packages/cli/src/patch-helpers.ts
@@ -9,6 +9,20 @@ export interface PatchResult {
 }
 
 /**
+ * The reason vocabulary the patchers below return. Consumers branch on these
+ * to tell "already done" from "could not do it" — defined once so a reworded
+ * reason cannot silently turn a consumer's no-op path into its failure path.
+ */
+export const PATCH_REASONS = {
+  fileNotFound: 'File not found',
+  importAlreadyExists: 'Import already exists',
+  providersArrayNotFound: 'Could not find providers array',
+  providerAlreadyRegistered: 'Provider already registered',
+  alreadyPresent: 'Already present',
+  optionAlreadySet: 'Option already set',
+} as const
+
+/**
  * A copy of `source` with the contents of comments and string literals
  * blanked out, character for character, so every index still lines up with
  * the original.
@@ -186,13 +200,13 @@ export async function addImport(
   const content = await readIfExists(process.cwd(), filePath)
 
   if (content === null) {
-    return { modified: false, reason: 'File not found' }
+    return { modified: false, reason: PATCH_REASONS.fileNotFound }
   }
 
   const updatedContent = insertImport(content, importStatement)
 
   if (updatedContent === null) {
-    return { modified: false, reason: 'Import already exists' }
+    return { modified: false, reason: PATCH_REASONS.importAlreadyExists }
   }
 
   await writeFile(absolutePath, updatedContent, 'utf8')
@@ -200,10 +214,28 @@ export async function addImport(
 }
 
 /**
- * Adds a provider to the providers array in Application initialization.
+ * Either the patched content or the reason it could not be produced. The
+ * in-memory counterpart of `PatchResult`, for patches whose "nothing to do"
+ * and "cannot do it" outcomes are more than one bit — `insertImport` gets away
+ * with `string | null` because it has only one.
  */
-export async function addProvider(
-  filePath: string,
+export type InsertResult = { content: string; reason?: undefined } | { content?: undefined; reason: string }
+
+/**
+ * `content` with `providerName` appended to its `providers: [ ... ]` array.
+ *
+ * Pure, and split out for the same reason as `insertImport`: a caller that
+ * also has to add the provider's import applies both here and writes once, so
+ * a failure cannot leave one half of the pair on disk. Composed with
+ * `insertImport` by `addProviderRegistration`.
+ *
+ * The array is re-joined from its parsed entries rather than appended to in
+ * place (what `appendArrayEntry` does), so a multi-line `providers` array is
+ * collapsed onto one line. That is long-standing output every provider-wiring
+ * test pins; it is preserved deliberately.
+ */
+export function insertProvider(
+  content: string,
   providerName: string,
   /**
    * Custom "already registered" check over the existing array entries.
@@ -212,40 +244,52 @@ export async function addProvider(
    * counts as registered.
    */
   isRegistered?: (entries: string[]) => boolean,
-): Promise<PatchResult> {
-  const absolutePath = resolve(process.cwd(), filePath)
-  const content = await readIfExists(process.cwd(), filePath)
-
-  if (content === null) {
-    return { modified: false, reason: 'File not found' }
-  }
-
-  // Find the providers array and add the provider
+): InsertResult {
   const providersArrayPattern = /providers:\s*\[([\s\S]*?)\]/
   const match = content.match(providersArrayPattern)
 
   if (!match) {
-    return { modified: false, reason: 'Could not find providers array' }
+    return { reason: PATCH_REASONS.providersArrayNotFound }
   }
 
-  const providersContent = match[1]
-  const providers = parseArrayEntries(providersContent)
+  const providers = parseArrayEntries(match[1])
 
   const alreadyRegistered = isRegistered
     ? isRegistered(providers)
     : providers.some(p => p === providerName)
   if (alreadyRegistered) {
-    return { modified: false, reason: 'Provider already registered' }
+    return { reason: PATCH_REASONS.providerAlreadyRegistered }
   }
 
   providers.push(providerName)
-  const newProvidersContent = providers.join(', ')
-  const updatedContent = content.replace(
-    providersArrayPattern,
-    `providers: [${newProvidersContent}]`,
-  )
 
-  await writeFile(absolutePath, updatedContent, 'utf8')
+  return {
+    content: content.replace(providersArrayPattern, `providers: [${providers.join(', ')}]`),
+  }
+}
+
+/**
+ * Adds a provider to the providers array in Application initialization.
+ */
+export async function addProvider(
+  filePath: string,
+  providerName: string,
+  isRegistered?: (entries: string[]) => boolean,
+): Promise<PatchResult> {
+  const absolutePath = resolve(process.cwd(), filePath)
+  const content = await readIfExists(process.cwd(), filePath)
+
+  if (content === null) {
+    return { modified: false, reason: PATCH_REASONS.fileNotFound }
+  }
+
+  const inserted = insertProvider(content, providerName, isRegistered)
+
+  if (inserted.content === undefined) {
+    return { modified: false, reason: inserted.reason }
+  }
+
+  await writeFile(absolutePath, inserted.content, 'utf8')
   return { modified: true }
 }
 
@@ -299,7 +343,7 @@ export async function addToArrayOption(
   const content = await readIfExists(process.cwd(), filePath)
 
   if (content === null) {
-    return { modified: false, reason: 'File not found' }
+    return { modified: false, reason: PATCH_REASONS.fileNotFound }
   }
 
   const span = findCallOptionsSpan(content, callName)
@@ -325,7 +369,7 @@ export async function addToArrayOption(
   const interior = content.slice(open + 1, close)
 
   if (parseArrayEntries(interior).some((entry) => entry === valueSource)) {
-    return { modified: false, reason: 'Already present' }
+    return { modified: false, reason: PATCH_REASONS.alreadyPresent }
   }
 
   const updatedContent
@@ -355,7 +399,7 @@ export async function addToArrayArgument(
   const content = await readIfExists(process.cwd(), filePath)
 
   if (content === null) {
-    return { modified: false, reason: 'File not found' }
+    return { modified: false, reason: PATCH_REASONS.fileNotFound }
   }
 
   // The leading lookbehind is what keeps `unregisterMany([])` from matching
@@ -379,7 +423,7 @@ export async function addToArrayArgument(
   const interior = content.slice(open + 1, close)
 
   if (parseArrayEntries(interior).some((entry) => entry === valueSource)) {
-    return { modified: false, reason: 'Already present' }
+    return { modified: false, reason: PATCH_REASONS.alreadyPresent }
   }
 
   const updatedContent
@@ -538,7 +582,7 @@ export async function addCreateAppOption(
   const content = await readIfExists(process.cwd(), filePath)
 
   if (content === null) {
-    return { modified: false, reason: 'File not found' }
+    return { modified: false, reason: PATCH_REASONS.fileNotFound }
   }
 
   const span = findCallOptionsSpan(content, callName)
@@ -551,7 +595,7 @@ export async function addCreateAppOption(
   const optionsSource = content.slice(openBraceIndex, closeBraceIndex + 1)
   const keyPattern = new RegExp(`(^|[{,]\\s*)${escapeRegExp(key)}\\s*:`, 'm')
   if (keyPattern.test(optionsSource)) {
-    return { modified: false, reason: 'Option already set' }
+    return { modified: false, reason: PATCH_REASONS.optionAlreadySet }
   }
 
   const insertion = `\n  ${key}: ${valueSource},`

--- a/packages/cli/src/plugin.ts
+++ b/packages/cli/src/plugin.ts
@@ -1,7 +1,8 @@
 import type { WriterOptions } from './utils'
 import { assertCwdUnsupported, runCommand } from './utils'
 import { appDependsOn } from './discovery'
-import { addImport, addProvider } from './patch-helpers'
+import { PATCH_REASONS } from './patch-helpers'
+import { addProviderRegistration, APP_ENTRY_CANDIDATES, resolveAppEntry } from './provider-registrar'
 import {
   applyEnvEntries,
   applyPublishes,
@@ -149,27 +150,30 @@ export async function installPlugin(options: InstallPluginOptions): Promise<Plug
     const providerExpression = factoryName ? `${factoryName}()` : providerName
     const providerImport = `import { ${providerName} } from '${packageName}'`
 
-    const appPath = 'src/app.ts'
-    const imported = await addImport(appPath, providerImport)
+    const appPath = await resolveAppEntry()
+
+    if (!appPath) {
+      throw new Error(`Could not find ${APP_ENTRY_CANDIDATES.join(' or ')}. Run this command inside a Guren app.`)
+    }
+
     // A user may already have a configured call (e.g. `vercelPlugin({ ... })`)
     // registered; any entry invoking the factory counts as registered.
-    const registered = await addProvider(
+    const wiring = await addProviderRegistration(
       appPath,
       providerExpression,
+      providerImport,
       factoryName ? (entries) => entries.some((entry) => entry.startsWith(`${factoryName}(`)) : undefined,
     )
 
-    if (imported.reason === 'File not found' || registered.reason === 'File not found') {
-      throw new Error('src/app.ts was not found. Run this command inside a Guren app.')
+    if (!wiring.registered) {
+      throw wiring.provider.reason === PATCH_REASONS.providersArrayNotFound
+        ? new Error(`Could not find providers array in ${appPath}. Please register the provider manually.`)
+        : new Error(`Could not register ${providerName} in ${appPath}: ${wiring.provider.reason}`)
     }
 
-    if (!registered.modified && registered.reason === 'Could not find providers array') {
-      throw new Error('Could not find providers array in src/app.ts. Please register the provider manually.')
-    }
-
-    if (imported.modified || registered.modified) {
+    if (wiring.provider.modified || wiring.import.modified) {
       messages.push({ kind: 'updated', text: appPath })
-    } else if (imported.reason === 'Import already exists' && registered.reason === 'Provider already registered') {
+    } else {
       messages.push({ kind: 'checked', text: `${appPath} (already registered)` })
     }
   }

--- a/packages/cli/src/provider-registrar.ts
+++ b/packages/cli/src/provider-registrar.ts
@@ -1,0 +1,205 @@
+import { consola } from 'consola'
+import { writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { findFirstExisting, readIfExists } from './discovery'
+import { insertImport, insertProvider, PATCH_REASONS, type PatchResult } from './patch-helpers'
+import { relativeImportPath } from './utils'
+
+/**
+ * Entry files that may hold the app's `createApp({ ... })` call, in the order
+ * they are probed. The default template ships `src/app.ts`; a flattened app
+ * keeps `app.ts` at the root. One list for every command that patches the app
+ * entry — two copies is how `guren add auth` came to find a root `app.ts`
+ * while `guren add cache` warned that `src/app.ts` was missing.
+ */
+export const APP_ENTRY_CANDIDATES = ['src/app.ts', 'app.ts'] as const
+
+/** The first existing app entry under `cwd`, or `null` when the project has none. */
+export async function resolveAppEntry(cwd: string = process.cwd()): Promise<string | null> {
+  return findFirstExisting(cwd, APP_ENTRY_CANDIDATES)
+}
+
+export type ProviderWiring =
+  | { registered: false; provider: PatchResult }
+  | { registered: true; provider: PatchResult; import: PatchResult }
+
+/**
+ * Registers `providerName` in `appPath`'s `providers: [...]` array and adds
+ * `importStatement`, in **one write**.
+ *
+ * Both halves have to land together or neither may: an import whose
+ * registration never happened is an unused binding that stops the app
+ * compiling under `noUnusedLocals`, and a registration whose import never
+ * happened is an unresolved identifier — worse, since it also throws at
+ * runtime. Two sequenced file-level patches can produce either one; composing
+ * the pure `insertProvider`/`insertImport` transforms and writing once cannot.
+ * This is the shape `addRouteRegistrarCall` already uses for the same reason.
+ *
+ * Silent by design: callers with a reporting policy of their own (`guren
+ * plugin` throws and collects structured messages) read the outcome instead of
+ * the console.
+ */
+export async function addProviderRegistration(
+  appPath: string,
+  providerName: string,
+  importStatement: string,
+  isRegistered?: (entries: string[]) => boolean,
+): Promise<ProviderWiring> {
+  const content = await readIfExists(process.cwd(), appPath)
+
+  if (content === null) {
+    return { registered: false, provider: { modified: false, reason: PATCH_REASONS.fileNotFound } }
+  }
+
+  const inserted = insertProvider(content, providerName, isRegistered)
+  const alreadyRegistered = inserted.reason === PATCH_REASONS.providerAlreadyRegistered
+
+  if (inserted.content === undefined && !alreadyRegistered) {
+    return { registered: false, provider: { modified: false, reason: inserted.reason } }
+  }
+
+  // An already-registered provider still needs its import checked: the two can
+  // fall out of sync when a user removes one by hand.
+  const withProvider = inserted.content ?? content
+  const withImport = insertImport(withProvider, importStatement)
+
+  const provider: PatchResult = alreadyRegistered
+    ? { modified: false, reason: PATCH_REASONS.providerAlreadyRegistered }
+    : { modified: true }
+  const importResult: PatchResult = withImport === null
+    ? { modified: false, reason: PATCH_REASONS.importAlreadyExists }
+    : { modified: true }
+
+  if (provider.modified || importResult.modified) {
+    await writeFile(resolve(process.cwd(), appPath), withImport ?? withProvider, 'utf8')
+  }
+
+  return { registered: true, provider, import: importResult }
+}
+
+export interface WireProviderOptions {
+  /** App entry to patch; resolved from {@link APP_ENTRY_CANDIDATES} when omitted. */
+  appPath?: string
+  /** Also report each success / already-present step (the interactive `guren add auth` flow). */
+  verbose?: boolean
+}
+
+/** The import line for a provider scaffolded as `app/Providers/<Name>.ts`. */
+function scaffoldedProviderImport(appPath: string, providerName: string): string {
+  return `import ${providerName} from '${relativeImportPath(appPath, `app/Providers/${providerName}.js`)}'`
+}
+
+/** What the app author has to do by hand for a provider this could not wire. */
+function reportManualStep(providerName: string, importStatement: string): void {
+  consola.info(`Add ${providerName} to your createApp() providers array by hand: ${importStatement}`)
+}
+
+function warnNoAppEntry(providerName: string, importStatement: string): void {
+  consola.warn(`Could not find ${APP_ENTRY_CANDIDATES.join(' or ')} — ${providerName} was not registered.`)
+  reportManualStep(providerName, importStatement)
+}
+
+function report(
+  appPath: string,
+  providerName: string,
+  importStatement: string,
+  wiring: ProviderWiring,
+  verbose: boolean,
+): void {
+  if (!wiring.registered) {
+    consola.warn(`Could not register ${providerName} in ${appPath}: ${wiring.provider.reason}.`)
+    reportManualStep(providerName, importStatement)
+    return
+  }
+
+  if (!verbose) return
+
+  if (wiring.import.modified) {
+    consola.success(`Added ${providerName} import to ${appPath}`)
+  } else {
+    consola.info(`${providerName} import already exists in ${appPath}`)
+  }
+
+  if (wiring.provider.modified) {
+    consola.success(`Added ${providerName} to providers array in ${appPath}`)
+  } else {
+    consola.info(`${providerName} already registered in ${appPath}`)
+  }
+}
+
+/**
+ * `addProviderRegistration` against the app's entry file, reporting every
+ * failure.
+ */
+export async function wireProvider(
+  providerName: string,
+  importStatement: string,
+  options: WireProviderOptions = {},
+): Promise<void> {
+  const appPath = options.appPath ?? (await resolveAppEntry())
+
+  if (!appPath) {
+    warnNoAppEntry(providerName, importStatement)
+    return
+  }
+
+  const wiring = await addProviderRegistration(appPath, providerName, importStatement)
+  report(appPath, providerName, importStatement, wiring, Boolean(options.verbose))
+}
+
+/**
+ * `wireProvider` for a provider scaffolded at `app/Providers/<Name>.ts` — the
+ * one place that knows those are default exports, and that their import is
+ * relative to whichever entry was found.
+ */
+export async function wireAppProvider(providerName: string, options: WireProviderOptions = {}): Promise<void> {
+  const appPath = options.appPath ?? (await resolveAppEntry())
+
+  if (!appPath) {
+    // The import is only derivable from an entry, so name the conventional one.
+    warnNoAppEntry(providerName, scaffoldedProviderImport(APP_ENTRY_CANDIDATES[0], providerName))
+    return
+  }
+
+  await wireProvider(providerName, scaffoldedProviderImport(appPath, providerName), { ...options, appPath })
+}
+
+export interface ProviderRegistration {
+  /** Identifier to add to `providers: [ ... ]`. */
+  name: string
+  /**
+   * Import to add. Omitted for a provider scaffolded at
+   * `app/Providers/<name>.ts`, whose import is derived from the resolved entry.
+   */
+  importStatement?: string
+}
+
+/**
+ * Wires several providers into the app entry, resolving that entry **once**.
+ *
+ * A blueprint installs Core's service provider alongside its own; resolving
+ * per provider probes the filesystem twice for an answer that cannot change
+ * mid-run, and reports the missing-entry warning once per provider rather than
+ * once per command.
+ */
+export async function wireProviders(
+  registrations: readonly ProviderRegistration[],
+  options: WireProviderOptions = {},
+): Promise<void> {
+  const appPath = options.appPath ?? (await resolveAppEntry())
+
+  // Named one by one even with no entry to patch: a blueprint installs Core's
+  // provider *and* its own, and an app missing either one is missing the
+  // feature — so a single warning naming the pair would under-report the work
+  // left to the author.
+  for (const { name, importStatement } of registrations) {
+    const statement = importStatement ?? scaffoldedProviderImport(appPath ?? APP_ENTRY_CANDIDATES[0], name)
+
+    if (!appPath) {
+      warnNoAppEntry(name, statement)
+      continue
+    }
+
+    await wireProvider(name, statement, { ...options, appPath })
+  }
+}

--- a/packages/cli/src/route-registrar.ts
+++ b/packages/cli/src/route-registrar.ts
@@ -5,7 +5,7 @@ import type { ArrowFunctionExpression, File, FunctionDeclaration, FunctionExpres
 import { walk } from './ast-walk'
 import { readIfExists } from './discovery'
 import { parseSourceFile } from './parse-cache'
-import { insertImport, type PatchResult } from './patch-helpers'
+import { insertImport, PATCH_REASONS, type PatchResult } from './patch-helpers'
 
 /**
  * The export names `@guren/core`'s route loader looks for, in the order it
@@ -255,7 +255,7 @@ export async function addRouteRegistrarCall(
   const content = await readIfExists(process.cwd(), filePath)
 
   if (content === null) {
-    return { modified: false, reason: 'File not found' }
+    return { modified: false, reason: PATCH_REASONS.fileNotFound }
   }
 
   const ast = parseSourceFile(content, filePath)
@@ -315,7 +315,7 @@ export async function wireRouteRegistrar(functionName: string, importStatement: 
     return
   }
 
-  if (result.reason === 'File not found') {
+  if (result.reason === PATCH_REASONS.fileNotFound) {
     consola.warn(`Could not find ${DEFAULT_ROUTES_FILE} — import ${functionName} and call it from your route registrar once you add one.`)
     return
   }

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -649,9 +649,26 @@ export const users = pgTable('users', {
       // Both halves of the install are named: the core provider supplies the
       // 'cache' binding, the app provider configures it, and an app missing
       // either one is missing the feature.
-      expect(warningText).toContain('Could not find src/app.ts — CoreCacheServiceProvider was not registered.')
-      expect(warningText).toContain('Could not find src/app.ts — CacheProvider was not registered.')
+      expect(warningText).toContain('Could not find src/app.ts or app.ts — CoreCacheServiceProvider was not registered.')
+      expect(warningText).toContain('Could not find src/app.ts or app.ts — CacheProvider was not registered.')
       expect(existsSync('src/app.ts')).toBe(false)
+      expect(existsSync('app.ts')).toBe(false)
+    })
+
+    // A flattened app keeps its entry at the root. `guren add auth` and
+    // `guren make:module` already found it there; the blueprints probed only
+    // `src/app.ts` and reported an app that has an entry as having none.
+    it('registers into a root app.ts when src/app.ts is absent', async () => {
+      await writeFile('app.ts', APP_FIXTURE)
+
+      const { warnings } = await captureWarnings(() => runBlueprint('cache'))
+
+      expect(warnings).toEqual([])
+      const patched = await readFile('app.ts', 'utf8')
+      expect(patched).toContain("import { CacheServiceProvider as CoreCacheServiceProvider } from '@guren/core'")
+      // Relative to the entry that was actually found, not to src/app.ts.
+      expect(patched).toContain("import CacheProvider from './app/Providers/CacheProvider.js'")
+      expect(patched).toContain('providers: [CoreCacheServiceProvider, CacheProvider]')
     })
 
     it('leaves an unpatchable app file untouched rather than importing into it', async () => {

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { consola } from 'consola'
-import { API_ONLY_REFUSAL, API_ROUTES_FIXTURE, BLOG_ROUTES_FIXTURE, createTempWorkspace, MYSQL_SCHEMA_FIXTURE, PG_SCHEMA_FIXTURE, seedApiOnlyApp, SQLITE_SCHEMA_FIXTURE } from './helpers'
+import { API_ONLY_REFUSAL, API_ROUTES_FIXTURE, BLOG_ROUTES_FIXTURE, captureWarnings, createTempWorkspace, DEFAULT_ROUTES_FIXTURE, MYSQL_SCHEMA_FIXTURE, PG_SCHEMA_FIXTURE, seedApiOnlyApp, SQLITE_SCHEMA_FIXTURE, writeWorkspaceFiles } from './helpers'
 import { makeAuth } from '../src/make-auth'
 
 // Shared with packages/create-app/templates/blog/app/Providers/AuthProvider.ts,
@@ -931,7 +931,7 @@ export const posts = pgTable('posts', {
       // table does not neutralize it.
       expect(report).toContain('still runs on `db:seed`')
       // Nothing rewrites the providers array, so the mail wiring survives too.
-      expect(report).toContain('src/app.ts may still register MailProvider')
+      expect(report).toContain('Your app entry may still register MailProvider')
     } finally {
       consola.warn = originalWarn
       await workspace.cleanup()
@@ -1096,6 +1096,88 @@ export function registerWebRoutes(router: Router): void {
       expect(appContent).toContain("import { OAuthServiceProvider as CoreOAuthServiceProvider } from '@guren/core'")
       expect(appContent).toContain("import OAuthProvider from '../app/Providers/OAuthProvider.js'")
       expect(appContent).toContain('providers: [DatabaseProvider, AuthProvider, CoreOAuthServiceProvider, OAuthProvider]')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  /** A project holding `appSource` at `entry`, plus the routes and schema makeAuth patches. */
+  async function seedAuthWorkspace(prefix: string, entry: string, appSource: string) {
+    const workspace = await createTempWorkspace(prefix)
+    await writeWorkspaceFiles(workspace.dir, {
+      [entry]: appSource,
+      'routes/web.ts': DEFAULT_ROUTES_FIXTURE,
+      'db/schema.ts': `export const posts = 'posts'\n`,
+      'resources/js/pages/Home.tsx': `interface Props { message: string }\nexport default function Home({ message }: Props) { return <h1>{message}</h1> }\n`,
+    })
+    return workspace
+  }
+
+  // Every provider makeAuth can wire, in one run: AuthProvider,
+  // CoreMailServiceProvider, MailProvider (both from includeExtras, which
+  // --minimal would switch off), CoreOAuthServiceProvider and OAuthProvider.
+  // A regression that restored import-first ordering at only one of those five
+  // call sites has to fail here.
+  it('withholds every provider import when the providers array cannot be found', async () => {
+    const workspace = await seedAuthWorkspace(
+      'guren-cli-make-auth-providerless-',
+      'src/app.ts',
+      `import { createApp } from '@guren/core'
+import registerWebRoutes from '../routes/web.js'
+
+const app = createApp({
+  routes: registerWebRoutes,
+})
+
+export default app
+`,
+    )
+
+    try {
+      const { warnings } = await captureWarnings(() =>
+        makeAuth({ install: true, force: true, oauth: 'github' }))
+
+      const reported = warnings.join('\n')
+      for (const provider of ['AuthProvider', 'CoreMailServiceProvider', 'MailProvider', 'CoreOAuthServiceProvider', 'OAuthProvider']) {
+        expect(reported).toContain(`Could not register ${provider} in src/app.ts: Could not find providers array.`)
+      }
+
+      // The failed array patch must not leave imports behind: an import whose
+      // registration never landed is an unused binding, and the app stops
+      // compiling under noUnusedLocals.
+      const appContent = await readFile(join(workspace.dir, 'src/app.ts'), 'utf8')
+      for (const provider of ['AuthProvider', 'MailServiceProvider', 'MailProvider', 'OAuthServiceProvider', 'OAuthProvider']) {
+        expect(appContent).not.toContain(provider)
+      }
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('installs auth into a root app.ts when src/app.ts is absent', async () => {
+    const workspace = await seedAuthWorkspace(
+      'guren-cli-make-auth-root-entry-',
+      'app.ts',
+      `import { createApp } from '@guren/core'
+import registerWebRoutes from './routes/web.js'
+
+const app = createApp({
+  routes: registerWebRoutes,
+  providers: [],
+})
+
+export default app
+`,
+    )
+
+    try {
+      await makeAuth({ install: true, force: true, minimal: true })
+
+      const appContent = await readFile(join(workspace.dir, 'app.ts'), 'utf8')
+      // Relative to the entry that was actually found, not to src/app.ts.
+      expect(appContent).toContain("import AuthProvider from './app/Providers/AuthProvider.js'")
+      expect(appContent).toContain('providers: [AuthProvider]')
+      expect(appContent).toContain('auth: {}')
     } finally {
       await workspace.cleanup()
     }

--- a/packages/cli/tests/make-module.test.ts
+++ b/packages/cli/tests/make-module.test.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
 import { makeModule } from '../src/make-module'
-import { createTempWorkspace } from './helpers'
+import { captureWarnings, createTempWorkspace } from './helpers'
 
 describe('makeModule', () => {
   it('scaffolds index.ts, routes.ts, and db/schema.ts', async () => {
@@ -135,6 +135,30 @@ export default app
 
       const appContent = await readFile(join(workspace.dir, 'src/app.ts'), 'utf8')
       expect(appContent).toContain('modules: [inventoryModule, billingModule]')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  // Same invariant `addProviderRegistration` enforces for providers: an import
+  // of a binding nothing references is an unused local, and the app it was
+  // written into stops compiling under noUnusedLocals.
+  it('withholds the module import when the app entry cannot be patched', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-module-unpatchable-')
+    try {
+      await mkdir(join(workspace.dir, 'src'), { recursive: true })
+      const appSource = `import { Application } from '@guren/core'
+
+const app = new Application()
+
+export default app
+`
+      await writeFile(join(workspace.dir, 'src/app.ts'), appSource, 'utf8')
+
+      const { warnings } = await captureWarnings(() => makeModule('billing'))
+
+      expect(warnings.join('\n')).toContain('Could not register the module automatically')
+      expect(await readFile(join(workspace.dir, 'src/app.ts'), 'utf8')).toBe(appSource)
     } finally {
       await workspace.cleanup()
     }

--- a/packages/cli/tests/plugin.test.ts
+++ b/packages/cli/tests/plugin.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, afterEach, describe, expect, it } from 'bun:test'
-import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { CAN_DENY_FILE_READS, createTempWorkspace, writeInstalledPackage, type TempWorkspace } from './helpers'
 import { installPlugin, type PluginInstallMessage } from '../src/plugin'
@@ -322,6 +322,49 @@ export default app
       expect(textsOf(messages, 'skipped')).toContain('config/audit.ts (already exists, use --force to overwrite)')
       expect(await readFile('config/audit.ts', 'utf8')).toBe('export const custom = true\n')
     })
+  })
+
+  // The refusal is the whole point here: this command throws where the
+  // scaffolders warn, so an import written before the array patch is one the
+  // user is left to clean up by hand — and under noUnusedLocals it stops the
+  // app compiling.
+  it('leaves the app entry untouched when the providers array cannot be found', async () => {
+    const providerless = `import { createApp } from '@guren/core'
+
+const app = createApp({
+  routes: () => {},
+})
+
+export default app
+`
+    await writeFile('src/app.ts', providerless)
+
+    await expect(installPlugin({ packageName: '@acme/guren-plugin-audit' })).rejects.toThrow(
+      'Could not find providers array in src/app.ts',
+    )
+
+    expect(await readFile('src/app.ts', 'utf8')).toBe(providerless)
+  })
+
+  it('registers into a root app.ts when src/app.ts is absent', async () => {
+    await rm('src/app.ts')
+    await writeFile('app.ts', `import { createApp } from '@guren/core'
+
+const app = createApp({
+  routes: () => {},
+  providers: [],
+})
+
+export default app
+`)
+
+    const messages = await installPlugin({ packageName: '@acme/guren-plugin-audit' })
+
+    expect(textsOf(messages, 'updated')).toContain('app.ts')
+
+    const app = await readFile('app.ts', 'utf8')
+    expect(app).toContain("import { AcmeGurenPluginAuditProvider } from '@acme/guren-plugin-audit'")
+    expect(app).toContain('providers: [AcmeGurenPluginAuditProvider]')
   })
 
   it('rejects the official Vercel plugin for non-SSR apps', async () => {


### PR DESCRIPTION
Three implementations of "register a provider in the app entry and report the outcome" coexisted in `packages/cli` and had drifted apart. Each carried a different defect, and the defects were invisible to each other because no two commands shared any code.

## The app entry was hardcoded in two of the three

`guren add cache` — and every other infrastructure blueprint — probed only `src/app.ts`. A project that keeps its entry at the root (`app.ts`, which `guren add auth` and `guren make:module` both already found) got `Could not find src/app.ts` and no wiring at all. `guren plugin` had the same hardcoding, and threw.

Resolution now comes from one shared candidate list, and the generated import is relative to whichever entry was found — a root `app.ts` gets `./app/Providers/CacheProvider.js` rather than a path that climbs out of the project.

## All three wrote the import before the registration

On an app whose `providers: [ ... ]` array cannot be located — a hand-edited entry, or one that never had the array — every command reported a failure having already written an import nothing references. Under `noUnusedLocals` that stops the app compiling. `guren plugin` was the worst case: it throws rather than warning, so it left the orphan import behind *and* refused to finish.

## Ordering the two patches would only move the problem

The obvious fix is to register first and import only on success. That is not enough on its own. The provider-array patch and the import patch each read and rewrite the whole file, so whichever runs second can fail independently (a permissions change, a full disk, an interrupt) — and the state it leaves, "registered but not imported", is worse than the one being avoided: an unresolved identifier throws at runtime rather than merely failing a lint.

Both edits are now composed in memory and applied in a **single write**, through a pure `insertProvider` added beside the existing `insertImport`. An app entry that cannot take one half receives neither. This is the shape `addRouteRegistrarCall` already used for exactly this reason — `insertImport`'s own doc comment describes the two-pass alternative as the thing it was split out to avoid.

`addProvider` keeps its signature and becomes `read → insertProvider → write`, so its existing unit tests pass unchanged; they are the regression net for the extraction.

`guren make:module` had the same import-first hazard against its `modules: [ ... ]` patch, and is fixed the same way.

## What is deliberately not shared

Reporting. The three callers genuinely differ: the blueprints warn, `guren add auth` narrates each step, and `guren plugin` throws and collects structured messages rather than touching the console. Only the entry resolution and the patch primitive are shared.

One nicety falls out of the consolidation: inside a single `guren add auth` run, the framework's own service providers now report the same way the scaffolded ones always did, instead of staying silent when they were already registered.

Also folded in, since the change makes them load-bearing: the patch-result reason vocabulary now lives in one `PATCH_REASONS` constant (it previously covered four of seven reasons, so the protection its doc comment promises did not hold for the rest), and the messages that named `src/app.ts` in prose no longer do so after patching a root `app.ts`.

## Verification

`bun run test:bun cli` (1280 pass), root `bun run typecheck`, `bun run build`, `audit:core-first`, `audit:docs` — all green.

Mutation-tested, since the register-then-import invariant is new behavior rather than something the suite previously pinned:

- Writing the import even when the array patch fails → 3 failures, in `blueprints`, `make-auth`, and `plugin` (the throw path, which had no coverage at all before this PR).
- Removing the `return` guard in `make:module` → its new test fails.

The `make-auth` failure test drives all five providers a single run can wire (non-minimal plus `--oauth`), so a regression at only one of the five call sites cannot pass.

Checked end-to-end against the built CLI, not just the sources: `guren add cache` on an `app.ts`-only project wires both providers with a correct root-relative import, and on a providerless entry leaves the file byte-identical.