### PR TITLE
test(cli): fail on an unbuilt checkout instead of reading it as a verdict

### DIFF
--- a/packages/cli/tests/assert-workspace-built.test.ts
+++ b/packages/cli/tests/assert-workspace-built.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { SERVER_DIST_ENTRY, assertWorkspaceBuilt } from './helpers'
+
+/**
+ * The guard exists to keep an unbuilt checkout from being read as a verdict,
+ * and CI always builds before testing — so it only ever fires locally, where
+ * nothing else would notice it had stopped firing.
+ */
+describe('assertWorkspaceBuilt', () => {
+  it('names every missing artifact and the command that produces it', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'guren-built-guard-'))
+    try {
+      const present = join(dir, 'present.js')
+      await writeFile(present, 'export {}\n', 'utf8')
+
+      expect(() => assertWorkspaceBuilt([present, join(dir, 'gone.js'), join(dir, 'also-gone.js')])).toThrow(
+        /build:clean[\s\S]*missing[\s\S]*gone\.js[\s\S]*also-gone\.js/,
+      )
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('passes when the artifact is on disk', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'guren-built-guard-ok-'))
+    try {
+      const artifact = join(dir, 'index.js')
+      await writeFile(artifact, 'export {}\n', 'utf8')
+
+      expect(() => assertWorkspaceBuilt([artifact])).not.toThrow()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  // The path the spawn helper guards is only useful if it is the one the
+  // resolution actually goes through, and a typo in it would make the guard
+  // silently unfalsifiable — it would pass on every checkout, built or not.
+  it('points at the built server entry the spawned CLI resolves through', () => {
+    expect(SERVER_DIST_ENTRY).toEndWith('packages/server/dist/index.js')
+    expect(() => assertWorkspaceBuilt([SERVER_DIST_ENTRY])).not.toThrow()
+  })
+})

--- a/packages/cli/tests/bin-error-output.test.ts
+++ b/packages/cli/tests/bin-error-output.test.ts
@@ -1,11 +1,10 @@
-import { resolve } from 'node:path'
 import { describe, expect, it } from 'bun:test'
 import { stripAnsi } from 'consola/utils'
-import { createTempWorkspace } from './helpers'
-
-const CLI_BIN_PATH = resolve(import.meta.dir, '../src/bin.ts')
+import { CLI_BIN_PATH, SERVER_DIST_ENTRY, assertWorkspaceBuilt, createTempWorkspace } from './helpers'
 
 async function runBin(args: string[], cwd: string): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  assertWorkspaceBuilt([SERVER_DIST_ENTRY])
+
   // `bun test` sets NODE_ENV=test, which drops consola to the warn level and
   // hides the usage output these assertions inspect. Real invocations do not.
   const { NODE_ENV: _testEnv, ...env } = process.env

--- a/packages/cli/tests/check-ci-flag.test.ts
+++ b/packages/cli/tests/check-ci-flag.test.ts
@@ -1,19 +1,7 @@
 import { mkdir, writeFile } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
-import { createTempWorkspace } from './helpers'
-
-const CLI_BIN_PATH = resolve(import.meta.dir, '../src/bin.ts')
-
-async function runBin(args: string[], cwd: string): Promise<number> {
-  const proc = Bun.spawn(['bun', CLI_BIN_PATH, ...args], {
-    cwd,
-    stdout: 'pipe',
-    stderr: 'pipe',
-  })
-  await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
-  return proc.exited
-}
+import { createTempWorkspace, runCliBin as runBin } from './helpers'
 
 /**
  * In a real app `guren codegen` runs before `check --ci` (that is the

--- a/packages/cli/tests/check-exit-code.test.ts
+++ b/packages/cli/tests/check-exit-code.test.ts
@@ -1,19 +1,7 @@
 import { mkdir, writeFile } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
-import { createTempWorkspace } from './helpers'
-
-const CLI_BIN_PATH = resolve(import.meta.dir, '../src/bin.ts')
-
-async function runCli(args: string[], cwd: string): Promise<{ exitCode: number }> {
-  const proc = Bun.spawn(['bun', CLI_BIN_PATH, ...args], {
-    cwd,
-    stdout: 'ignore',
-    stderr: 'ignore',
-  })
-  const exitCode = await proc.exited
-  return { exitCode }
-}
+import { createTempWorkspace, runCliBin } from './helpers'
 
 async function writeArchViolation(dir: string): Promise<void> {
   await writeFile(
@@ -39,8 +27,7 @@ describe('guren check exit code', () => {
     const workspace = await createTempWorkspace('guren-cli-check-exitcode-default-')
     try {
       await writeArchViolation(workspace.dir)
-      const { exitCode } = await runCli(['check', '--app', workspace.dir], workspace.dir)
-      expect(exitCode).toBe(0)
+      expect(await runCliBin(['check', '--app', workspace.dir], workspace.dir)).toBe(0)
     } finally {
       await workspace.cleanup()
     }
@@ -59,8 +46,7 @@ describe('guren check exit code', () => {
         'utf8',
       )
 
-      const { exitCode } = await runCli(['check', '--app', workspace.dir], workspace.dir)
-      expect(exitCode).toBe(0)
+      expect(await runCliBin(['check', '--app', workspace.dir], workspace.dir)).toBe(0)
     } finally {
       await workspace.cleanup()
     }
@@ -70,8 +56,7 @@ describe('guren check exit code', () => {
     const workspace = await createTempWorkspace('guren-cli-check-exitcode-arch-')
     try {
       await writeArchViolation(workspace.dir)
-      const { exitCode } = await runCli(['check', '--arch', '--app', workspace.dir], workspace.dir)
-      expect(exitCode).toBe(1)
+      expect(await runCliBin(['check', '--arch', '--app', workspace.dir], workspace.dir)).toBe(1)
     } finally {
       await workspace.cleanup()
     }
@@ -88,8 +73,7 @@ describe('guren check exit code', () => {
       await mkdir(join(workspace.dir, 'app/Domain'), { recursive: true })
       await writeFile(join(workspace.dir, 'app/Domain/OrderService.ts'), `export class OrderService {}`, 'utf8')
 
-      const { exitCode } = await runCli(['check', '--arch', '--app', workspace.dir], workspace.dir)
-      expect(exitCode).toBe(0)
+      expect(await runCliBin(['check', '--arch', '--app', workspace.dir], workspace.dir)).toBe(0)
     } finally {
       await workspace.cleanup()
     }

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -1,8 +1,22 @@
 import { mock } from 'bun:test'
 import { consola as realConsola } from 'consola'
+import { existsSync } from 'node:fs'
 import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { dirname, join, relative, resolve } from 'node:path'
 import { tmpdir } from 'node:os'
+
+const repoRoot = resolve(import.meta.dir, '../../..')
+
+/** The CLI entry these tests spawn. */
+export const CLI_BIN_PATH = join(repoRoot, 'packages/cli/src/bin.ts')
+
+/**
+ * The built artifact this package's tests reach `@guren/server` through.
+ * `@guren/core` resolves to source, but its `export * from '@guren/server'`
+ * follows the workspace symlink to server's `exports`, which point at
+ * `dist/index.js` (see .claude/rules/common-pitfalls.md).
+ */
+export const SERVER_DIST_ENTRY = join(repoRoot, 'packages/server/dist/index.js')
 
 export interface TempWorkspace {
   dir: string
@@ -234,6 +248,42 @@ export async function createTempWorkspace(prefix: string): Promise<TempWorkspace
       await rm(dir, { recursive: true, force: true })
     },
   }
+}
+
+/**
+ * Throw unless every named build artifact exists.
+ *
+ * An unbuilt checkout does not fail as a wrong answer, it fails as no answer:
+ * a spawned CLI dies on module resolution and exits 1, which an exit-code
+ * assertion cannot tell apart from the command reporting a real failure — and
+ * a test that reads that as a verdict sends the next reader hunting a
+ * regression in product code that is fine. Checked as a precondition rather
+ * than sniffed from a crash so it also covers the tests that reach built code
+ * by importing a fixture, and so it never blames the build for a fixture's own
+ * unresolvable import.
+ */
+export function assertWorkspaceBuilt(artifacts: string[]): void {
+  const missing = artifacts.filter((artifact) => !existsSync(artifact))
+  if (missing.length === 0) return
+
+  throw new Error(
+    [
+      'the workspace has not been built — run `bun run build:clean` first:',
+      ...missing.map((artifact) => `  missing ${relative(repoRoot, artifact)}`),
+    ].join('\n'),
+  )
+}
+
+/** Spawn the CLI bin as a subprocess and return its exit code. */
+export async function runCliBin(args: string[], cwd: string): Promise<number> {
+  assertWorkspaceBuilt([SERVER_DIST_ENTRY])
+
+  const proc = Bun.spawn(['bun', CLI_BIN_PATH, ...args], {
+    cwd,
+    stdout: 'ignore',
+    stderr: 'ignore',
+  })
+  return proc.exited
 }
 
 /**

--- a/packages/cli/tests/i18n-types-compile.test.ts
+++ b/packages/cli/tests/i18n-types-compile.test.ts
@@ -1,9 +1,9 @@
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
-import { existsSync } from 'node:fs'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join, resolve } from 'node:path'
 import ts from 'typescript'
+import { assertWorkspaceBuilt } from './helpers'
 import { buildTranslationTypesContent } from '../src/i18n-types'
 
 /**
@@ -73,11 +73,10 @@ let serverProbeFile: string
 let clientProbeFile: string
 
 beforeAll(async () => {
-  for (const file of [coreTypes, inertiaClientTypes]) {
-    if (!existsSync(file)) {
-      throw new Error(`${file} is missing — run \`bun run build\` first. This test type-checks probe code against the built .d.ts, the surface real apps import.`)
-    }
-  }
+  // This test type-checks probe code against the built .d.ts, the surface real
+  // apps import — so an unbuilt checkout has to fail as itself, not as a
+  // probe that mysteriously stopped narrowing.
+  assertWorkspaceBuilt([coreTypes, inertiaClientTypes])
 
   dir = await mkdtemp(join(tmpdir(), 'guren-i18n-compile-'))
   generatedFile = join(dir, 'translations.gen.ts')

--- a/packages/cli/tests/new-command.test.ts
+++ b/packages/cli/tests/new-command.test.ts
@@ -1,7 +1,7 @@
-import { resolve } from 'node:path'
 import { describe, expect, it } from 'bun:test'
 import { runCommand } from 'citty'
 import { stripAnsi } from 'consola/utils'
+import { CLI_BIN_PATH, SERVER_DIST_ENTRY, assertWorkspaceBuilt } from './helpers'
 import { createNewCommand } from '../src/new-command'
 
 /**
@@ -112,8 +112,10 @@ describe('guren new', () => {
   // path that exercises the real wiring without spawning `create-guren-app`:
   // `runCli` renders usage and returns before `run()` is reached.
   it('is registered in the CLI, and its help lists the flags it forwards', async () => {
+    assertWorkspaceBuilt([SERVER_DIST_ENTRY])
+
     const { NODE_ENV: _testEnv, ...env } = process.env
-    const proc = Bun.spawn(['bun', resolve(import.meta.dir, '../src/bin.ts'), 'new', '--help'], {
+    const proc = Bun.spawn(['bun', CLI_BIN_PATH, 'new', '--help'], {
       env,
       stdout: 'pipe',
       stderr: 'pipe',

--- a/packages/cli/tests/pages-types.test.ts
+++ b/packages/cli/tests/pages-types.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it } from 'bun:test'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
-import { createTempWorkspace } from './helpers'
+import { join } from 'node:path'
+import { CLI_BIN_PATH, SERVER_DIST_ENTRY, assertWorkspaceBuilt, createTempWorkspace } from './helpers'
 import { buildPageModuleContent, generatePageTypes, type PageDefinition } from '../src/pages-types'
-
-const CLI_BIN_PATH = resolve(import.meta.dir, '../src/bin.ts')
 
 describe('buildPageModuleContent', () => {
   it('generates a runtime manifest and nested page contracts', () => {
@@ -94,6 +92,8 @@ describe('generatePageTypes overwrite behavior', () => {
         'export default function Home() { return null }\n',
         'utf8',
       )
+
+      assertWorkspaceBuilt([SERVER_DIST_ENTRY])
 
       const runCodegen = () =>
         Bun.spawn(['bun', CLI_BIN_PATH, 'codegen', '--app', workspace.dir], {


### PR DESCRIPTION
## Summary

`packages/cli/tests/check-ci-flag.test.ts` was reported failing on `main` — `expect(await runBin(['check', '--ci'], dir)).toBe(0)` receiving 1 — and read as a regression from the new route-registrar wiring checks (#343, #350), i.e. that `--ci` had started gating on a warn the fixture's shape now produces.

There is no regression. The gating logic is unchanged and correct: reproducing the fixture by hand, `check --ci` reports only the missing-test warn and exits 0, exactly as the test's comment states.

The tests spawn `packages/cli/src/bin.ts` and assert only its exit code. This package reaches `@guren/server` through its built `dist/` (documented in `.claude/rules/common-pitfalls.md`: `@guren/core` resolves to source, but its `export * from '@guren/server'` follows the workspace symlink to server's `exports`, which point at `dist/index.js`). On a checkout where nothing has been built, the spawned bin dies on module resolution and exits 1 before the command ever runs — and because both spawn helpers discarded stderr, that is indistinguishable from the command reporting a real failure.

So the failure mode is not a flake, it is a misdirection: `check --ci` exiting 1 for want of a build reads exactly like `check --ci` gating on a finding, and sends the next reader hunting a defect in product code that is fine.

This adds `assertWorkspaceBuilt()`, which checks the precondition rather than waiting for the crash and names both the missing artifact and the command that produces it. An earlier revision of this branch sniffed the child's stderr for Bun's module-resolution message instead; that was replaced because it is both too broad (`check` prints user-derived doc targets verbatim, so a fixture could trigger it on a healthy run) and too narrow (it misses stale-`dist` subpath failures, signal termination, and non-zero exits with empty stderr). The precondition has neither failure mode, and it is less code.

The i18n compile gate had already grown its own `existsSync` check for the same invariant. It now calls the shared helper, so one invariant has one mechanism rather than two drifting ones.

Coverage is 5 of 5 bin-spawn sites, not 2 of 5. Because the guard is a standalone predicate rather than part of a spawn wrapper, the three sites that assert on the bin's *output* (and so cannot share a spawn helper) are covered by one line each. `pages-types.test.ts` in particular asserted `expect(await first.exited).toBe(0)` — the same shape as the misdiagnosis that prompted this.

The guard itself is tested. It only ever fires locally (CI builds before it tests), so nothing else would notice it silently stopping — the same reasoning `scripts/test-cwd-guard.test.ts` already applies to its sibling guard.

## Scope

`cli` — tests only. No product code is touched, and no test's assertions change; the tests assert the same things about the same commands.

## Risk Assessment

No behavior change to any shipped package. The one way this could bite is a false positive making a legitimately-built checkout fail; `existsSync` on a path pinned by a test makes that shape unavailable.

Note for reviewers: this branch's earlier revision also raised the timeout on `i18n-types-compile.test.ts` to 60s. That has been reverted. The justification was a contaminated measurement — the ~10s figure was taken while unrelated local work had the machine at a load average near 900. Re-measured idle, those tests take ~1.4s each against a 5s default, and the full framework suite runs 4026 tests in 44s with no timeouts. The remaining intermittent failures reported alongside the original bug were a load-driven timeout cascade, not a defect.

## Validation

- [x] `bun run build` (`build:clean`)
- [x] `bun run typecheck` — exit 0
- [x] `bun run test:bun` — 3971 pass, 0 fail, 4026 tests across 239 files
- [x] `bun run test:bun cli` — 1272 pass, 0 fail
- [x] Mutation check: with `packages/server/dist` moved aside, all five spawn sites fail in ~2ms with `the workspace has not been built — run bun run build:clean first: missing packages/server/dist/index.js`, and go green again once it is restored. Without this change, the same condition surfaces as `expect(0).toBe(1)`.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation. — no user-facing behavior changed; the constraint this encodes is already documented in `.claude/rules/common-pitfalls.md`, which the new helper cites.
