### PR TITLE
fix(cli): give codegen the rule that an API-only app gets no pages manifest

### DIFF
--- a/.changeset/mcp-codegen-skip-reason.md
+++ b/.changeset/mcp-codegen-skip-reason.md
@@ -1,0 +1,12 @@
+---
+'@guren/server': patch
+---
+
+Report why the MCP codegen tool skipped an artifact
+
+`guren_codegen` filed every empty generator result under `"nothing to generate"`.
+That is right for an app with no page components, and wrong for the one case where
+a generator declines on purpose: the pages manifest is not written into an app that
+cannot compile one. An agent that just wrote a page component and asked for codegen
+was told there was nothing to describe. Generators can now carry a sentence with the
+empty result, and the tool reports it in place of the generic reason.

--- a/.changeset/pages-manifest-owned-by-codegen.md
+++ b/.changeset/pages-manifest-owned-by-codegen.md
@@ -1,0 +1,43 @@
+---
+'@guren/cli': patch
+---
+
+Stop codegen writing a pages manifest into an app that cannot compile one
+
+`.guren/pages.gen.ts` imports `@guren/inertia-client`. An app scaffolded from the
+`api` blueprint does not install that package, and its `tsconfig.json` includes
+`.guren/**` (but not `resources/`), so a manifest generated there fails `tsc` on
+its first line. Nothing prevented one: `generatePageTypes` wrote a manifest
+whenever `resources/js/pages` contained a component, and that directory can fill
+up without anyone asking for it — a hand-copied page, a checkout, a generator
+written later — while the api starter's `dev` script runs codegen on every start.
+
+`guren check` already claimed this could not happen ("codegen never emits it in an
+API-only app"), and `guren doctor` leaned on the same claim silently. Neither
+enforced it. Codegen now owns the rule: `planPageManifest` answers "does this app
+get a pages manifest?" from the page components *and* `isConfirmedApiOnlyApp`, and
+check and doctor read that answer rather than restating it.
+
+Withholding the file inverts the risk that predicate was written for — where a
+wrong answer used to block a command loudly, it would now quietly deny a file
+every controller imports — so the suppressed state is reported rather than
+silent. `guren codegen` warns instead of printing a generated path, the MCP
+codegen tool reports the reason rather than "nothing to generate", and check and
+doctor both surface it, most sharply when a manifest generated before the app took
+this shape is still on disk: that leftover is what fails the typecheck, and both
+tools used to call it healthy on the strength of it merely existing. It outlives
+the page components that produced it, so it is reported even once they are
+deleted. Codegen does not delete it — if the rule is ever wrong about an app,
+removing the manifest turns a type error into a mystery — so the report names the
+file and both corrections: delete it, or declare the `@guren/inertia-client`
+dependency and `routes/web.ts` that make this a fullstack app.
+
+Severity follows the same rule: the leftover manifest really does fail `tsc`, so
+`guren check --ci` gates on it, while page components an API-only app simply never
+renders are advisory — failing a build over unused files would be its own bug.
+
+`make:view`'s refusal stands, but its reason changes with this: a page component
+in such an app is no longer a delayed `typecheck` failure, it is a screen nothing
+can reach, and the refusal is about saying so at the command that caused it. Its
+doc comment and the CLI guide now say that instead of restating a chain codegen
+no longer lets happen.

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -93,13 +93,14 @@ can be wired into `routes/api.ts` as-is. Whenever the signals cannot confirm an
 API-only app, you get the usual Inertia template — installing
 `@guren/inertia-client` is enough to switch back.
 
-`make:view` refuses on those signals like the scaffolds above, because a page
-has no JSON shape to adapt to — and a stray one would not stay harmless:
-`guren codegen` (which `bun run dev` runs for you) folds every component under
-`resources/js/pages` into `.guren/pages.gen.ts`, and that file imports the
-`@guren/inertia-client` an API-only app never installs, breaking `typecheck`
-two commands later. Install `@guren/inertia-client` first when taking an API
-app fullstack, and the command works again.
+`make:view` refuses on those signals like the scaffolds above, because a page has
+no JSON shape to adapt to and the app has no way to render one. `guren codegen`
+(which `bun run dev` runs for you) leaves such components out of
+`.guren/pages.gen.ts` rather than folding them in — that file imports the
+`@guren/inertia-client` an API-only app never installs — so the refusal is about
+saying so at the command that caused it, not about preventing a broken
+`typecheck`. Install `@guren/inertia-client` first when taking an API app
+fullstack, and the command works again.
 
 `add resource` also needs the two files it patches to be there, whatever shape the
 rest of your app is: it appends its table to `db/schema.ts` and registers the CRUD

--- a/docs/en/guides/ship-api.md
+++ b/docs/en/guides/ship-api.md
@@ -147,6 +147,30 @@ export function registerApiRoutes(router: Router): void {
 bun run codegen
 ```
 
+Codegen writes no `.guren/pages.gen.ts` here. That manifest imports
+`@guren/inertia-client`, which an API-only app does not install, while its
+`tsconfig.json` type-checks everything under `.guren/` — so generating one would
+break `bun run typecheck` on its first line.
+
+The rule is codegen's, not the scaffolders': if page components ever appear under
+`resources/js/pages` — copied in by hand, or arriving with a checkout — codegen
+still declines to write the manifest and says so:
+
+```
+[warn] 1 page component under resources/js/pages, but this app has no
+@guren/inertia-client dependency and no routes/web.ts, so codegen writes no
+.guren/pages.gen.ts
+```
+
+`guren check` and `guren doctor` report the same thing, and warn more sharply if
+a `.guren/pages.gen.ts` generated before the app took this shape is still on
+disk — that leftover is what fails `tsc`, so it is reported even after the page
+components that produced it are deleted, and `guren check --ci` fails on it
+(unused page components alone do not fail CI). Codegen never deletes it, because
+removing a file the app might genuinely need would turn a type error into a
+mystery. Delete it yourself, or, if the app does render Inertia pages, add its
+`@guren/inertia-client` dependency and `routes/web.ts`.
+
 ## 8. Test Your Endpoints
 
 Start the dev server:

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -92,12 +92,13 @@ JSON(`this.json(...)`)を返すため、そのまま型検査を通り、`routes
 元に戻ります。
 
 `make:view` は上記のスキャフォールドと同様、同じシグナルで中断します。ページには
-適応できる JSON 版が存在せず、置き去りのページは無害でもないためです。
-`guren codegen`(`bun run dev` が自動実行します)は `resources/js/pages` 配下の
-すべてのコンポーネントを `.guren/pages.gen.ts` に取り込み、このファイルは
-API専用アプリがインストールしない `@guren/inertia-client` を import するため、
-2コマンド後に `typecheck` が壊れます。API アプリをフルスタック化するときは、
-先に `@guren/inertia-client` をインストールすれば再び使えるようになります。
+適応できる JSON 版が存在せず、そのアプリにはページを描画する手段がないためです。
+`guren codegen`(`bun run dev` が自動実行します)はそうしたコンポーネントを
+`.guren/pages.gen.ts` に取り込まず除外します — このファイルは API専用アプリが
+インストールしない `@guren/inertia-client` を import するためです。つまり中断は
+`typecheck` の破壊を防ぐためではなく、原因となったコマンドの時点でそれを伝える
+ためのものです。API アプリをフルスタック化するときは、先に
+`@guren/inertia-client` をインストールすれば再び使えるようになります。
 
 `add resource` は、アプリの形がどうであれ、パッチ対象の2つのファイルがそこにあることも
 必要とします。テーブル定義を `db/schema.ts` に追記し、CRUD ルートを `routes/web.ts` に

--- a/docs/ja/guides/ship-api.md
+++ b/docs/ja/guides/ship-api.md
@@ -147,6 +147,30 @@ export function registerApiRoutes(router: Router): void {
 bun run codegen
 ```
 
+ここでは `.guren/pages.gen.ts` は生成されません。このマニフェストは
+`@guren/inertia-client` を import しますが、API 専用アプリはそのパッケージを
+インストールしていない一方で、`tsconfig.json` は `.guren/` 配下をすべて型検査
+します。生成してしまうと `bun run typecheck` が 1 行目で落ちます。
+
+この判断はスキャフォルダーではなく codegen が持っています。`resources/js/pages`
+にページコンポーネントが現れたとき — 手でコピーした場合でも、チェックアウトで
+入ってきた場合でも — codegen はマニフェストを書かず、その理由を出力します:
+
+```
+[warn] 1 page component under resources/js/pages, but this app has no
+@guren/inertia-client dependency and no routes/web.ts, so codegen writes no
+.guren/pages.gen.ts
+```
+
+`guren check` と `guren doctor` も同じ状態を報告します。アプリがこの形になる前に
+生成された `.guren/pages.gen.ts` がディスクに残っている場合はより強く警告します。
+`tsc` を落とすのはこの残骸なので、原因となったページコンポーネントを削除した後でも
+報告され、`guren check --ci` はこの状態で失敗します（未使用のページコンポーネント
+だけでは CI は失敗しません）。codegen はそのファイルを削除しません。本当に必要な
+ファイルを消してしまうと、型エラーが原因不明の不具合に変わるからです。不要なら
+自分で削除し、Inertia のページを描画するアプリであれば `@guren/inertia-client` の
+依存と `routes/web.ts` を追加してください。
+
 ## 8. エンドポイントをテストする
 
 開発サーバーを起動します:

--- a/packages/cli/src/app-surface.ts
+++ b/packages/cli/src/app-surface.ts
@@ -9,6 +9,16 @@ import { DEFAULT_ROUTES_FILE } from './route-registrar'
 const WEB_ROUTES_CANDIDATES = [DEFAULT_ROUTES_FILE, 'routes/web.js'] as const
 
 /**
+ * The signals this module read, in the wording every report of them shares —
+ * refusals, and codegen declining to write a pages manifest. It belongs to the
+ * predicate rather than to each caller: they supplied it themselves until there
+ * were several saying it in several places, and a signal added or dropped below
+ * would have left every description stale independently.
+ */
+export const API_ONLY_EVIDENCE =
+  `no @guren/inertia-client dependency and no ${DEFAULT_ROUTES_FILE}`
+
+/**
  * The one rule for "this app cannot render an Inertia page", for scaffolders
  * that emit a page component, a controller importing `@/.guren/pages.gen`, or a
  * route wired into `routes/web.ts`. On an app scaffolded from the `api`
@@ -19,10 +29,11 @@ const WEB_ROUTES_CANDIDATES = [DEFAULT_ROUTES_FILE, 'routes/web.js'] as const
  * Callers either refuse on a `true` (via `assertNotApiOnly` below) or, where
  * their output has an API dialect, adapt what they emit instead.
  *
- * Distinct from `appEmitsPageManifest` in `pages-types.ts`, which asks whether
- * codegen would write a pages manifest and answers from the page components on
- * disk. That signal cannot back a refusal — a fullstack app that has not
- * written its first page yet has none either.
+ * `planPageManifest` in `pages-types.ts` is the third kind: codegen declines to
+ * write `.guren/pages.gen.ts` into an app this recognizes, because that module
+ * imports the missing `@guren/inertia-client`. Page components on disk are the
+ * input it adds, and they cannot back a refusal on their own — a fullstack app
+ * that has not written its first page has none either.
  *
  * **Positive evidence only — every "cannot tell" answers `false`.** The cost of
  * the two mistakes is not symmetric: failing to recognize an API-only app
@@ -53,10 +64,8 @@ export async function isConfirmedApiOnlyApp(cwd: string): Promise<boolean> {
 /**
  * Refuses an API-only app on a scaffolder's behalf, before its first write.
  *
- * The middle of the message — which signals were read — belongs to the
- * predicate above, not to each caller. Callers supplied it themselves until
- * there were two of them saying it in two places, and a signal added or dropped
- * here would have left both descriptions stale independently.
+ * The middle of the message is {@link API_ONLY_EVIDENCE}, for the reason stated
+ * there.
  *
  * `does` completes "guren add x scaffolds …" and `instead` is the whole
  * alternative sentence, because what an app should do without this scaffold

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -37,7 +37,7 @@ import { runDatabaseMigrations, runDatabaseSeeders, resetDatabase } from './db-m
 import { showMigrationStatus } from './db-status'
 import type { WriterOptions } from './utils'
 import { generateRouteTypes } from './routes-types'
-import { generatePageTypes } from './pages-types'
+import { describePageManifestSuppression, generatePageTypes, type PageManifestPlan } from './pages-types'
 import { generateTranslationTypes } from './i18n-types'
 import { generateDataTypes } from './data-types'
 import { generateApiClientTypes } from './api-client-types'
@@ -835,6 +835,20 @@ const freshCommand = defineCommand({
   },
 })
 
+/**
+ * Says out loud that page components were found and deliberately not compiled
+ * into a manifest. Silence here would be the whole hazard of the rule: a
+ * fullstack app misread as API-only loses `.guren/pages.gen.ts` with nothing on
+ * screen to explain it. `guren check` and `guren doctor` report the same state
+ * for the run where nobody was watching this line go by.
+ */
+function reportSuppressedPageManifest(plan: PageManifestPlan): void {
+  const suppressed = describePageManifestSuppression(plan)
+  if (!suppressed) return
+
+  consola.warn(`${suppressed.message} ${suppressed.fix}`)
+}
+
 const routeTypesCommand = defineCommand({
   meta: {
     name: 'routes:types',
@@ -874,7 +888,7 @@ const routeTypesCommand = defineCommand({
   },
   async run({ args }) {
     const writerOptions = toWriterOptions(args)
-    const { outputPath: pagesOutputPath } = await generatePageTypes({
+    const { outputPath: pagesOutputPath, plan: pagesPlan } = await generatePageTypes({
       appRoot: args.app,
       pagesDir: args.pages,
       outputFile: args.pagesOut,
@@ -886,7 +900,8 @@ const routeTypesCommand = defineCommand({
       appRoot: args.app,
       ...writerOptions,
     })
-    consola.success(`Page helpers generated at ${pagesOutputPath}`)
+    if (pagesOutputPath) consola.success(`Page helpers generated at ${pagesOutputPath}`)
+    reportSuppressedPageManifest(pagesPlan)
     consola.success(`Route types generated at ${outputPath}`)
     consola.success(`Route helpers generated at ${runtimeOutputPath}`)
     process.exit(0)
@@ -907,7 +922,7 @@ const codegenCommand = defineCommand({
     // to protect hand-maintained files). --force is still accepted for
     // backward compatibility but is a no-op.
     const writerOptions: WriterOptions = { ...toWriterOptions(args), force: true }
-    const { outputPath: pagesOutputPath } = await generatePageTypes({
+    const { outputPath: pagesOutputPath, plan: pagesPlan } = await generatePageTypes({
       appRoot: args.app,
       pagesDir: args.pages,
       outputFile: args.pagesOut,
@@ -915,6 +930,7 @@ const codegenCommand = defineCommand({
       ...writerOptions,
     })
     if (pagesOutputPath) consola.success(`Page helpers generated at ${pagesOutputPath}`)
+    reportSuppressedPageManifest(pagesPlan)
 
     // Translation keys only exist for apps with a lang/ directory; the
     // generator emits nothing otherwise, keeping t() keys plain strings.

--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -30,7 +30,7 @@ import { checkSchemaTimestamps } from './schema-check'
 import { parseSchemaTables, schemaPathFor, type SchemaTable } from './schema-parser'
 import { ParseCache } from './parse-cache'
 import { extractInertiaPageRefs, resolveInertiaPageFile, expectedInertiaPagePath } from './inertia-pages'
-import { appEmitsPageManifest } from './pages-types'
+import { describePageManifestSuppression, PAGES_MANIFEST_FILE, planPageManifest } from './pages-types'
 import { runArchCheck } from './arch-check'
 import { runDocsCheck } from './docs-check'
 import { runI18nCheck } from './i18n-check'
@@ -190,13 +190,25 @@ export async function runCheck(options: RunCheckOptions = {}): Promise<CheckRepo
       checks.push({ ...check(`test:${name}`, `${name} tests`, hasTest ? 'pass' : 'warn', message, suggestion), advisory: true })
     }
 
-    // 5. Check generated manifests are present. The pages manifest only
-    // exists for apps with Inertia pages — codegen never emits it in an
-    // API-only app, so demanding it there is a false positive.
-    const hasPages = await appEmitsPageManifest(cwd)
+    // 5. Check generated manifests are present. Whether the pages manifest is
+    // one of them is codegen's call, not this file's — an app with no page
+    // components has none, and neither does an API-only app that somehow
+    // acquired some (see planPageManifest).
+    const pagesPlan = await planPageManifest(cwd)
+    // The suppressed manifest, reported rather than assumed. The manifest list
+    // below drops the file on this branch, so without this nothing would say a
+    // word about one left on disk importing a package the app does not have —
+    // which is the state that actually fails the typecheck.
+    const suppressed = describePageManifestSuppression(pagesPlan)
+    if (suppressed) {
+      checks.push({
+        ...check('pages-manifest', 'Pages manifest', 'warn', suppressed.message, suppressed.fix),
+        advisory: suppressed.advisory,
+      })
+    }
     const manifests = [
       '.guren/routes.gen.ts',
-      ...(hasPages ? ['.guren/pages.gen.ts'] : []),
+      ...(pagesPlan.reason === 'pages' ? [PAGES_MANIFEST_FILE] : []),
       '.guren/data.gen.ts',
     ]
     for (const manifest of manifests) {

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -18,7 +18,12 @@ import {
 } from './discovery'
 import { checkPluginCompatibility, readCoreVersion, readInstalledPluginManifests } from './plugin-manifest'
 import { compareVersions } from './codemods'
-import { appEmitsPageManifest } from './pages-types'
+import {
+  describePageManifestSuppression,
+  PAGES_MANIFEST_FILE,
+  planPageManifest,
+  type PageManifestPlan,
+} from './pages-types'
 import { extractClassDeclaration } from './model-parser'
 import { parseSourceFile } from './parse-cache'
 import { ROUTES_ENTRY_CANDIDATES } from './route-registrar'
@@ -112,7 +117,7 @@ interface DoctorRuleContext {
   // Shared so every rule that checks for Inertia pages sees the same
   // snapshot of the filesystem — computing it per-rule would let concurrent
   // rules disagree if a page file were added or removed mid-run.
-  pagesExpected: Promise<boolean>
+  pageManifest: Promise<PageManifestPlan>
 }
 
 interface DoctorRule {
@@ -128,8 +133,8 @@ type JsonReadResult<T> =
   | { exists: true; raw: string; value: null; parseError: Error }
 
 const APP_ENTRY_CANDIDATES = ['src/main.ts', 'src/main.mts', 'src/main.js', 'src/main.mjs']
-const PAGE_CONTRACT_CANDIDATES = ['.guren/pages.gen.ts']
-const GENERATED_FILES = ['.guren/routes.gen.ts', '.guren/pages.gen.ts', '.guren/data.gen.ts', '.guren/api-client.gen.ts', '.guren/channels.gen.ts']
+const PAGE_CONTRACT_CANDIDATES = [PAGES_MANIFEST_FILE]
+const GENERATED_FILES = ['.guren/routes.gen.ts', PAGES_MANIFEST_FILE, '.guren/data.gen.ts', '.guren/api-client.gen.ts', '.guren/channels.gen.ts']
 
 export const DOCTOR_RECOMMENDED_COMMANDS = [
   'bunx guren codegen --force',
@@ -292,14 +297,37 @@ async function detectRoutes(context: DoctorRuleContext): Promise<DoctorCheck> {
   return createCheck('routes', 'Route Sources', 'pass', `Found ${routesFile}.`)
 }
 
+/**
+ * The two rules below both report on `.guren/pages.gen.ts`, and both used to
+ * answer "is it there?" first. That is the wrong order once codegen can decline
+ * to write the file: the state worth reporting is a manifest that is present
+ * *and* would not be regenerated, because it imports a package the app does not
+ * have and is what fails the typecheck. What to say about it belongs to codegen
+ * — see `describePageManifestSuppression` — so these rules choose only the key
+ * and the title.
+ */
+function createSuppressedPagesCheck(
+  key: string,
+  title: string,
+  suppressed: NonNullable<ReturnType<typeof describePageManifestSuppression>>,
+): DoctorCheck {
+  return createCheck(key, title, 'warn', suppressed.message, { manualFix: suppressed.fix })
+}
+
 async function detectPageContracts(context: DoctorRuleContext): Promise<DoctorCheck> {
+  const plan = await context.pageManifest
+  const suppressed = describePageManifestSuppression(plan)
+
+  if (suppressed) {
+    return createSuppressedPagesCheck('page-contracts', 'Page Types', suppressed)
+  }
+
   const pageContracts = await findFirstExisting(context.cwd, PAGE_CONTRACT_CANDIDATES)
   if (pageContracts) {
     return createCheck('page-contracts', 'Page Types', 'pass', `Found ${pageContracts}.`)
   }
 
-  // An API-only app never gets a manifest out of codegen, so warning there is a false positive.
-  if (!(await context.pagesExpected)) {
+  if (plan.reason !== 'pages') {
     return createCheck(
       'page-contracts',
       'Page Types',
@@ -327,12 +355,18 @@ function createGeneratedManifestRule(generatedFile: string): DoctorRule {
     key,
     title: generatedFile,
     async detect(context) {
+      const plan = generatedFile === PAGES_MANIFEST_FILE ? await context.pageManifest : null
+      const suppressed = plan ? describePageManifestSuppression(plan) : null
+
+      if (suppressed) {
+        return createSuppressedPagesCheck(key, generatedFile, suppressed)
+      }
+
       if (await fileExists(context.cwd, generatedFile)) {
         return createCheck(key, generatedFile, 'pass', `Generated manifest present at ${generatedFile}.`)
       }
 
-      // An API-only app never gets a pages manifest out of codegen, so warning there is a false positive.
-      if (generatedFile === '.guren/pages.gen.ts' && !(await context.pagesExpected)) {
+      if (plan && plan.reason !== 'pages') {
         return createCheck(
           key,
           generatedFile,
@@ -1219,7 +1253,7 @@ export async function getDoctorRuleEvaluations(options: { cwd?: string } = {}): 
   evaluations: DoctorRuleEvaluation[]
 }> {
   const cwd = resolve(options.cwd ?? process.cwd())
-  const context: DoctorRuleContext = { cwd, pagesExpected: appEmitsPageManifest(cwd) }
+  const context: DoctorRuleContext = { cwd, pageManifest: planPageManifest(cwd) }
 
   // The deploy-runtime checks share one filesystem scan, computed once here
   // rather than through the DoctorRule interface (they need no autofix and no
@@ -1411,10 +1445,10 @@ export async function suggestNextSteps(options: { cwd?: string } = {}): Promise<
     // Ignore
   }
 
-  const hasPages = await appEmitsPageManifest(cwd)
+  const pagesPlan = await planPageManifest(cwd)
   const requiredManifests = [
     '.guren/routes.gen.ts',
-    ...(hasPages ? ['.guren/pages.gen.ts'] : []),
+    ...(pagesPlan.reason === 'pages' ? [PAGES_MANIFEST_FILE] : []),
     '.guren/data.gen.ts',
     '.guren/api-client.gen.ts',
   ]

--- a/packages/cli/src/make-view.ts
+++ b/packages/cli/src/make-view.ts
@@ -26,13 +26,11 @@ export default ${componentName}
 
 /**
  * Refuses a confirmed API-only app, like the multi-file scaffolds and unlike
- * `makeController`: a page has no JSON dialect to adapt to, and a stray one is
- * not inert either. The api starter's tsconfig skips `resources/`, but its own
- * `dev` script runs `guren codegen`, which folds every page under
- * `resources/js/pages` into `.guren/pages.gen.ts` — a file that tsconfig
- * *does* include, importing an `@guren/inertia-client` that is not installed.
- * One page flips `typecheck` red two commands later, far from the `make:view`
- * that caused it.
+ * `makeController`: a page has no JSON dialect to adapt to, and the app has no
+ * way to render one — codegen leaves it out of `.guren/pages.gen.ts`
+ * (`planPageManifest`), so the file would sit there describing a screen nothing
+ * can reach. Refusing says that at the command that caused it, rather than
+ * leaving the app to report an ignored component on its next `check`.
  */
 export async function makeView(name: string, options: WriterOptions = {}): Promise<string> {
   // Before the shape check, so a malformed name is reported as the usage

--- a/packages/cli/src/pages-types.ts
+++ b/packages/cli/src/pages-types.ts
@@ -1,5 +1,8 @@
 import { readdir } from 'node:fs/promises'
 import { dirname, extname, relative, resolve } from 'node:path'
+import { API_ONLY_EVIDENCE, isConfirmedApiOnlyApp } from './app-surface'
+import { fileExists } from './discovery'
+import { DEFAULT_ROUTES_FILE } from './route-registrar'
 import { resolveAppRoot, writeGeneratedFileIn, type WriterOptions } from './utils'
 import { extractPageProps, type ExtractedPageProps } from './page-props-extractor'
 
@@ -17,31 +20,157 @@ export interface GeneratePageTypesOptions extends WriterOptions {
 }
 
 const DEFAULT_PAGES_DIR = 'resources/js/pages'
-const DEFAULT_OUTPUT_FILE = '.guren/pages.gen.ts'
+/** The manifest's path, for everything that reports on it rather than writes it. */
+export const PAGES_MANIFEST_FILE = '.guren/pages.gen.ts'
 const PAGE_COMPONENT_EXTENSIONS = new Set(['.tsx', '.jsx'])
 
+/** Where the pages live and where the manifest goes, as `--pages` / `--pages-out` set them. */
+interface PagePathOptions {
+  pagesDir?: string
+  outputFile?: string
+}
+
+export interface PageManifestPlan {
+  /**
+   * `pages` — the app can render them, so codegen writes the manifest.
+   * `no-pages` — nothing to describe; the shape of a fullstack app before its
+   * first page. `api-only` — the app cannot render a page, see below.
+   */
+  reason: 'pages' | 'no-pages' | 'api-only'
+  pageCount: number
+  /** Effective paths, honouring `--pages` / `--pages-out`. */
+  pagesDir: string
+  manifestPath: string
+  /** A manifest already on disk that codegen would not write. */
+  staleManifest: boolean
+}
+
 /**
- * Whether codegen would emit a pages manifest for this app: true only when
- * the pages directory contains page components — `generatePageTypes` writes
- * nothing otherwise. check (and eventually doctor) share this predicate so
- * "is .guren/pages.gen.ts expected?" cannot drift from codegen's actual rule
- * (an API-only app must not be told to generate one).
+ * The one rule for "does this app get a `.guren/pages.gen.ts`?" — codegen's own
+ * decision, which `check` and `doctor` read rather than restate.
+ *
+ * Page components on disk are not sufficient on their own. The manifest imports
+ * `@guren/inertia-client`, and the api blueprint's `tsconfig.json` includes
+ * `.guren/**` (but not `resources/`) while the app never installs that package,
+ * so a manifest generated there fails `tsc` on its first line. Any route into
+ * `resources/js/pages` reaches that state — a hand-copied page, a checkout, a
+ * generator — and the app's `dev` script runs codegen, so it needs no deliberate
+ * act to happen.
+ *
+ * Suppressing the manifest inverts the risk profile `isConfirmedApiOnlyApp` was
+ * written for: there a wrong answer blocks a command loudly, here it would
+ * quietly withhold a file every controller imports. The compensation is that a
+ * suppressed manifest is a *reported* state rather than an absence — see
+ * {@link describePageManifestSuppression}. Codegen does not delete a manifest it
+ * would no longer write: if this rule is ever wrong about an app, removing the
+ * file turns a type error into a mystery.
  */
-export async function appEmitsPageManifest(appRoot: string, pagesDir?: string): Promise<boolean> {
-  const definitions = await collectPageDefinitions(resolve(appRoot, pagesDir ?? DEFAULT_PAGES_DIR))
-  return definitions.length > 0
+export async function planPageManifest(appRoot: string, options: PagePathOptions = {}): Promise<PageManifestPlan> {
+  return (await surveyPages(appRoot, options)).plan
+}
+
+/**
+ * The plan together with the page components it was decided from, so codegen
+ * does not walk the pages directory a second time to build what it already
+ * counted.
+ */
+async function surveyPages(
+  appRoot: string,
+  options: PagePathOptions,
+): Promise<{ plan: PageManifestPlan; definitions: PageDefinition[] }> {
+  const pagesDir = options.pagesDir ?? DEFAULT_PAGES_DIR
+  const manifestPath = options.outputFile ?? PAGES_MANIFEST_FILE
+  const definitions = await collectPageDefinitions(resolve(appRoot, pagesDir))
+  // A manifest left behind by an earlier run is the state that actually breaks
+  // the typecheck, and it outlives the page components that caused it — an app
+  // whose pages were deleted after one codegen run has none left to find, so
+  // asking about them first would let the file that fails `tsc` go unreported.
+  const staleManifest = await fileExists(appRoot, manifestPath)
+  const common = { pagesDir, manifestPath, pageCount: definitions.length }
+
+  if (definitions.length === 0 && !staleManifest) {
+    return { plan: { ...common, reason: 'no-pages', staleManifest: false }, definitions }
+  }
+
+  if (await isConfirmedApiOnlyApp(appRoot)) {
+    return { plan: { ...common, reason: 'api-only', staleManifest }, definitions }
+  }
+
+  // A fullstack app's leftovers are its own business: its next codegen run
+  // overwrites the manifest rather than declining to write one.
+  return {
+    plan: {
+      ...common,
+      reason: definitions.length > 0 ? 'pages' : 'no-pages',
+      staleManifest: false,
+    },
+    definitions,
+  }
+}
+
+export interface SuppressedPageManifest {
+  message: string
+  fix: string
+  /**
+   * A leftover manifest fails `tsc`, so `check --ci` gates on it. Page
+   * components an API-only app simply never renders break nothing, and gating
+   * CI on them would fail a build over unused files.
+   */
+  advisory: boolean
+}
+
+/**
+ * What to tell the user about a manifest codegen declined to write, or `null`
+ * when there is nothing to say — an API-only app with no page components and no
+ * leftover is the normal, healthy shape.
+ *
+ * Owned here, whole sentences included, for the reason `assertNotApiOnly` owns
+ * its middle sentence: `guren codegen`, `check`, and `doctor` all report this
+ * state, and each reassembling it from fragments is how the three of them come
+ * to describe one rule three stale ways. Callers choose only where it goes.
+ */
+export function describePageManifestSuppression(plan: PageManifestPlan): SuppressedPageManifest | null {
+  if (plan.reason !== 'api-only') return null
+
+  const fix =
+    `If this app does render Inertia pages, add its @guren/inertia-client dependency and ${DEFAULT_ROUTES_FILE}. `
+    + 'If it does not, the page components are unused.'
+  const pages = plan.pageCount === 1 ? '1 page component' : `${plan.pageCount} page components`
+  const why =
+    plan.pageCount > 0
+      ? `${pages} under ${plan.pagesDir}, but this app has ${API_ONLY_EVIDENCE}, so codegen writes no ${plan.manifestPath}`
+      : `this app has ${API_ONLY_EVIDENCE}, so codegen writes no ${plan.manifestPath}`
+
+  if (!plan.staleManifest) {
+    return { message: `${why}.`, fix, advisory: true }
+  }
+
+  return {
+    message: `${plan.manifestPath} is present but codegen would not write it: ${why}.`,
+    fix: `Delete ${plan.manifestPath} — it imports @guren/inertia-client, so tsc fails on it. ${fix}`,
+    advisory: false,
+  }
 }
 
 export async function generatePageTypes(
   options: GeneratePageTypesOptions = {},
-): Promise<{ outputPath: string; definitions: PageDefinition[] }> {
+): Promise<{
+  outputPath: string
+  definitions: PageDefinition[]
+  plan: PageManifestPlan
+  /** Why nothing was written, for callers that only see the result (MCP). */
+  skipped: SuppressedPageManifest | null
+}> {
+  // The app the manifest would be written into, which is the app the rule has
+  // to judge: `appRoot` is what MCP and `--app` steer, and it is free to differ
+  // from `process.cwd()`.
   const appRoot = resolveAppRoot(options)
   const pagesDir = resolve(appRoot, options.pagesDir ?? DEFAULT_PAGES_DIR)
-  const outputFile = resolve(appRoot, options.outputFile ?? DEFAULT_OUTPUT_FILE)
-  const definitions = await collectPageDefinitions(pagesDir)
+  const outputFile = resolve(appRoot, options.outputFile ?? PAGES_MANIFEST_FILE)
+  const { plan, definitions } = await surveyPages(appRoot, options)
 
-  if (definitions.length === 0) {
-    return { outputPath: '', definitions }
+  if (plan.reason !== 'pages') {
+    return { outputPath: '', definitions, plan, skipped: describePageManifestSuppression(plan) }
   }
 
   let propsMap: Map<string, ExtractedPageProps> | undefined
@@ -70,7 +199,7 @@ export async function generatePageTypes(
 
   const outputPath = await writeGeneratedFileIn(appRoot, outputFile, module, { force: options.force })
 
-  return { outputPath, definitions }
+  return { outputPath, definitions, plan, skipped: null }
 }
 
 interface BuildContext {

--- a/packages/cli/tests/check.test.ts
+++ b/packages/cli/tests/check.test.ts
@@ -3,7 +3,16 @@ import { spawnSync } from 'node:child_process'
 import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
 import { runCheck, type CheckReport, type CheckResult, type RunCheckOptions } from '../src/check'
-import { createTempWorkspace, writeWorkspaceFiles, MYSQL_SCHEMA_FIXTURE, PG_SCHEMA_FIXTURE } from './helpers'
+import {
+  API_ONLY_APP_FILES,
+  API_ONLY_REFUSAL,
+  BLOG_ROUTES_FIXTURE,
+  createTempWorkspace,
+  PAGE_COMPONENT_FIXTURE,
+  writeWorkspaceFiles,
+  MYSQL_SCHEMA_FIXTURE,
+  PG_SCHEMA_FIXTURE,
+} from './helpers'
 
 /** Run a check over a throwaway workspace built from path → content. */
 async function withWorkspace(
@@ -885,6 +894,80 @@ export const posts = pgTable('posts', { createdAt: timestamp('created_at') })
 
       expect(timestamptzFindings(report)).toHaveLength(0)
     })
+  })
+})
+
+/**
+ * `.guren/pages.gen.ts` imports `@guren/inertia-client`, and the api blueprint's
+ * tsconfig type-checks `.guren/**` without installing that package — so codegen
+ * declines to write the manifest there, however many page components turn up.
+ * That decision is only safe if it is visible: an app misread as API-only loses
+ * a file its controllers import, and a manifest generated before the app took
+ * this shape stays on disk failing the typecheck. Both states are reported here.
+ */
+describe('pages manifest on an API-only app', () => {
+  const withPage = { ...API_ONLY_APP_FILES, 'resources/js/pages/Home.tsx': PAGE_COMPONENT_FIXTURE }
+  const STALE_MANIFEST = '// generated when this app still had a client\n'
+
+  it('warns that a manifest on disk is one codegen would not write', async () => {
+    const report = await withWorkspace({ ...withPage, '.guren/pages.gen.ts': STALE_MANIFEST })
+
+    const pagesCheck = report.checks.find((c) => c.key === 'pages-manifest')
+
+    expect(pagesCheck?.status).toBe('warn')
+    expect(pagesCheck?.message).toContain('1 page component under resources/js/pages')
+    expect(pagesCheck?.message).toMatch(API_ONLY_REFUSAL)
+    // Reported, never removed — codegen leaving it on disk is covered in
+    // pages-types.test.ts, and is deliberate: if the rule is ever wrong about
+    // an app, deleting the manifest turns a type error into a mystery.
+    expect(pagesCheck?.suggestion).toContain('Delete .guren/pages.gen.ts')
+    // This one really does fail `tsc`, so `check --ci` has to gate on it.
+    expect(pagesCheck?.advisory).toBe(false)
+  })
+
+  // The page components can be deleted again while the manifest they produced
+  // stays; nothing else in the run looks at a file codegen would not write.
+  it('warns about the leftover manifest even after the pages are gone', async () => {
+    const report = await withWorkspace({ ...API_ONLY_APP_FILES, '.guren/pages.gen.ts': STALE_MANIFEST })
+
+    const pagesCheck = report.checks.find((c) => c.key === 'pages-manifest')
+
+    expect(pagesCheck?.status).toBe('warn')
+    expect(pagesCheck?.message).toContain('.guren/pages.gen.ts is present but codegen would not write it')
+    expect(pagesCheck?.message).not.toContain('page component')
+    expect(pagesCheck?.advisory).toBe(false)
+  })
+
+  it('reports page components no manifest will describe, without failing CI over them', async () => {
+    const report = await withWorkspace(withPage)
+
+    const pagesCheck = report.checks.find((c) => c.key === 'pages-manifest')
+
+    expect(pagesCheck?.status).toBe('warn')
+    expect(pagesCheck?.suggestion).toContain('add its @guren/inertia-client dependency')
+    // Unused page components break nothing, so `check --ci` must not fail on
+    // them the way it does on the leftover manifest above.
+    expect(pagesCheck?.advisory).toBe(true)
+    // Nothing is missing here, so the manifest must stay out of the list of
+    // artifacts codegen is told to produce.
+    expect(report.checks.some((c) => c.key === 'manifest:.guren/pages.gen.ts')).toBe(false)
+  })
+
+  it('says nothing about a fullstack app, which is still told to generate one', async () => {
+    const report = await withWorkspace({
+      ...withPage,
+      'routes/web.ts': BLOG_ROUTES_FIXTURE,
+    })
+
+    expect(report.checks.some((c) => c.key === 'pages-manifest')).toBe(false)
+    expect(report.checks.find((c) => c.key === 'manifest:.guren/pages.gen.ts')?.status).toBe('warn')
+  })
+
+  it('says nothing about an API-only app with no page components', async () => {
+    const report = await withWorkspace(API_ONLY_APP_FILES)
+
+    expect(report.checks.some((c) => c.key === 'pages-manifest')).toBe(false)
+    expect(report.checks.some((c) => c.key === 'manifest:.guren/pages.gen.ts')).toBe(false)
   })
 })
 

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -4,7 +4,16 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
 import { consola } from 'consola'
 import { getDoctorRuleEvaluations, runDoctor, buildJsonOutput, suggestNextSteps, renderDoctorReport } from '../src/doctor'
 import type { DoctorCheck, DoctorJsonOutput } from '../src/doctor'
-import { createTempWorkspace, writeInstalledPackage, writeWorkspaceFiles } from './helpers'
+import {
+  API_ONLY_APP_FILES,
+  API_ONLY_REFUSAL,
+  BLOG_ROUTES_FIXTURE,
+  createTempWorkspace,
+  PAGE_COMPONENT_FIXTURE,
+  seedApiOnlyApp,
+  writeInstalledPackage,
+  writeWorkspaceFiles,
+} from './helpers'
 
 let consoleLogSpy: ReturnType<typeof spyOn>
 const VALID_APP_KEY = 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
@@ -554,6 +563,11 @@ describe('runDoctor', () => {
       await mkdir(join(workspace.dir, '.guren'), { recursive: true })
       await mkdir(join(workspace.dir, 'resources/js/pages'), { recursive: true })
       await writeFile(join(workspace.dir, 'resources/js/pages/Home.tsx'), 'export default function Home() { return null }\n', 'utf8')
+      // routes/web.ts is what makes this a fullstack app rather than one
+      // codegen would decline to write a manifest for — without it the two
+      // checks below still warn, but about the suppressed manifest instead.
+      await mkdir(join(workspace.dir, 'routes'), { recursive: true })
+      await writeFile(join(workspace.dir, 'routes/web.ts'), BLOG_ROUTES_FIXTURE, 'utf8')
       await writeFile(
         join(workspace.dir, 'package.json'),
         JSON.stringify({ name: 'doctor-pages-warn' }, null, 2),
@@ -569,6 +583,72 @@ describe('runDoctor', () => {
     } finally {
       await workspace.cleanup()
     }
+  })
+
+  /**
+   * Both rules below used to answer "is the file there?" first, which is the
+   * wrong order once codegen can decline to write it: a manifest generated
+   * before the app took this shape sits there importing `@guren/inertia-client`,
+   * failing the typecheck, while doctor calls it healthy.
+   */
+  describe('a pages manifest codegen would not write', () => {
+    const apiOnlyAppWithPages = {
+      ...API_ONLY_APP_FILES,
+      'resources/js/pages/Home.tsx': PAGE_COMPONENT_FIXTURE,
+    }
+
+    async function checksFor(files: Record<string, string>): Promise<DoctorCheck[]> {
+      const workspace = await createTempWorkspace('guren-cli-doctor-suppressed-pages-')
+      try {
+        await writeWorkspaceFiles(workspace.dir, files)
+        return (await runDoctor({ cwd: workspace.dir, json: true })).checks
+      } finally {
+        await workspace.cleanup()
+      }
+    }
+
+    it('warns about the stale manifest instead of reporting it present', async () => {
+      const checks = await checksFor({
+        ...apiOnlyAppWithPages,
+        '.guren/pages.gen.ts': '// generated when this app still had a client\n',
+      })
+
+      for (const key of ['page-contracts', 'generated:.guren/pages.gen.ts']) {
+        const found = checks.find((check) => check.key === key)
+        expect(found?.status).toBe('warn')
+        expect(found?.message).toContain('present but codegen would not write it')
+        expect(found?.manualFix).toContain('Delete .guren/pages.gen.ts')
+      }
+    })
+
+    it('warns about the page components when no manifest was ever written', async () => {
+      const checks = await checksFor(apiOnlyAppWithPages)
+
+      for (const key of ['page-contracts', 'generated:.guren/pages.gen.ts']) {
+        const found = checks.find((check) => check.key === key)
+        expect(found?.status).toBe('warn')
+        expect(found?.message).toMatch(API_ONLY_REFUSAL)
+        expect(found?.manualFix).toContain('add its @guren/inertia-client dependency')
+      }
+    })
+
+    it('does not suggest codegen for the manifest it would decline to write', async () => {
+      const workspace = await createTempWorkspace('guren-cli-doctor-suppressed-next-steps-')
+      try {
+        await writeWorkspaceFiles(workspace.dir, {
+          ...apiOnlyAppWithPages,
+          '.guren/routes.gen.ts': 'export const routeManifest = {} as const\n',
+          '.guren/data.gen.ts': 'export namespace Data {}\n',
+          '.guren/api-client.gen.ts': 'export type ApiRoutes = {}\n',
+        })
+
+        const steps = await suggestNextSteps({ cwd: workspace.dir })
+
+        expect(steps.some((step) => step.title === 'Run codegen')).toBe(false)
+      } finally {
+        await workspace.cleanup()
+      }
+    })
   })
 
   it('warns when the @/* alias maps to the app directory instead of the project root', async () => {
@@ -1215,6 +1295,10 @@ describe('suggestNextSteps', () => {
     const workspace = await createTempWorkspace('guren-cli-doctor-next-steps-api-only-')
 
     try {
+      // A real API-only app, not merely one with no pages: without the
+      // package.json this fixture is an app the predicate cannot confirm, and
+      // the assertion below would hold with the whole rule removed.
+      await seedApiOnlyApp(workspace.dir)
       await mkdir(join(workspace.dir, '.guren'), { recursive: true })
       await writeFile(join(workspace.dir, '.guren/routes.gen.ts'), 'export const routeManifest = {} as const\n', 'utf8')
       await writeFile(join(workspace.dir, '.guren/data.gen.ts'), 'export namespace Data {}\n', 'utf8')

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -157,22 +157,28 @@ export function registerApiRoutes(router: Router): void {
  * The one spelling of "an app `isConfirmedApiOnlyApp` recognizes", for every
  * test that asks a scaffolder to refuse one.
  *
- * Each caller used to seed its own, and the copies had already drifted in which
- * dependencies they declared — so a change to what the predicate reads would
+ * Callers that build a file record rather than seeding a directory spread
+ * {@link API_ONLY_APP_FILES} instead. Each caller used to seed its own, and the
+ * copies had already drifted in which dependencies they declared — so a change to what the predicate reads would
  * have had to be re-verified against three subtly different apps. `db/schema.ts`
  * is here because a scaffolder that got past the refusal would patch it, and a
  * test cannot assert it was left alone unless it exists.
  */
-export async function seedApiOnlyApp(dir: string): Promise<void> {
-  await writeWorkspaceFiles(dir, {
-    'routes/api.ts': API_ROUTES_FIXTURE,
-    'db/schema.ts': PG_SCHEMA_FIXTURE,
-    'package.json': JSON.stringify({
-      name: 'api-app',
-      dependencies: { '@guren/cli': '^2.2.0', '@guren/core': '^1.5.1', '@guren/orm': '^2.2.0' },
-    }),
-  })
+export const API_ONLY_APP_FILES: Record<string, string> = {
+  'routes/api.ts': API_ROUTES_FIXTURE,
+  'db/schema.ts': PG_SCHEMA_FIXTURE,
+  'package.json': JSON.stringify({
+    name: 'api-app',
+    dependencies: { '@guren/cli': '^2.2.0', '@guren/core': '^1.5.1', '@guren/orm': '^2.2.0' },
+  }),
 }
+
+export async function seedApiOnlyApp(dir: string): Promise<void> {
+  await writeWorkspaceFiles(dir, API_ONLY_APP_FILES)
+}
+
+/** One page component, for tests about an app that acquired one it cannot render. */
+export const PAGE_COMPONENT_FIXTURE = 'export default function Home() { return null }\n'
 
 /**
  * The middle sentence `assertNotApiOnly` writes into every refusal — the two

--- a/packages/cli/tests/pages-types.test.ts
+++ b/packages/cli/tests/pages-types.test.ts
@@ -1,8 +1,27 @@
 import { describe, expect, it } from 'bun:test'
+import { existsSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { CLI_BIN_PATH, SERVER_DIST_ENTRY, assertWorkspaceBuilt, createTempWorkspace } from './helpers'
-import { buildPageModuleContent, generatePageTypes, type PageDefinition } from '../src/pages-types'
+import {
+  API_ONLY_REFUSAL,
+  assertWorkspaceBuilt,
+  BLOG_ROUTES_FIXTURE,
+  CLI_BIN_PATH,
+  createTempWorkspace,
+  PAGE_COMPONENT_FIXTURE as PAGE_FIXTURE,
+  seedApiOnlyApp,
+  SERVER_DIST_ENTRY,
+  writeWorkspaceFiles,
+} from './helpers'
+import {
+  buildPageModuleContent,
+  describePageManifestSuppression,
+  generatePageTypes,
+  planPageManifest,
+  type PageDefinition,
+} from '../src/pages-types'
+
+const DEFAULT_PATHS = { pagesDir: 'resources/js/pages', manifestPath: '.guren/pages.gen.ts' }
 
 describe('buildPageModuleContent', () => {
   it('generates a runtime manifest and nested page contracts', () => {
@@ -117,6 +136,178 @@ describe('generatePageTypes overwrite behavior', () => {
 
       const content = await readFile(join(workspace.dir, '.guren/pages.gen.ts'), 'utf8')
       expect(content).toContain("'Home': './pages/Home.tsx'")
+    } finally {
+      await workspace.cleanup()
+    }
+  }, 20000)
+})
+
+/**
+ * Page components can reach an API-only app by routes no scaffolder controls —
+ * a hand-copied file, a checkout, a generator written later — and the api
+ * blueprint's `dev` script runs codegen, so nobody has to ask for the manifest
+ * for it to appear. It would import `@guren/inertia-client`, which that app does
+ * not install, inside `.guren/**` that its tsconfig type-checks.
+ */
+describe('generatePageTypes on an API-only app', () => {
+  it('writes no manifest and says why', async () => {
+    const workspace = await createTempWorkspace('guren-cli-pages-api-only-')
+    try {
+      await seedApiOnlyApp(workspace.dir)
+      await writeWorkspaceFiles(workspace.dir, { 'resources/js/pages/Home.tsx': PAGE_FIXTURE })
+
+      const { outputPath, plan, skipped } = await generatePageTypes({
+        appRoot: workspace.dir,
+        extractProps: false,
+        force: true,
+      })
+
+      expect(outputPath).toBe('')
+      expect(plan).toEqual({ ...DEFAULT_PATHS, reason: 'api-only', pageCount: 1, staleManifest: false })
+      expect(existsSync(join(workspace.dir, '.guren/pages.gen.ts'))).toBe(false)
+      // Carried on the result so a caller that only sees the return value — the
+      // MCP codegen tool — can say more than "nothing to generate".
+      expect(skipped?.message).toMatch(API_ONLY_REFUSAL)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  // Deliberate: if the rule is ever wrong about an app, deleting the manifest
+  // turns a type error into a mystery. `check` and `doctor` report the leftover.
+  it('leaves a manifest generated before the app took this shape on disk', async () => {
+    const workspace = await createTempWorkspace('guren-cli-pages-api-only-stale-')
+    try {
+      await seedApiOnlyApp(workspace.dir)
+      await writeWorkspaceFiles(workspace.dir, {
+        'resources/js/pages/Home.tsx': PAGE_FIXTURE,
+        '.guren/pages.gen.ts': '// generated when this app still had a client\n',
+      })
+
+      const { plan } = await generatePageTypes({ appRoot: workspace.dir, extractProps: false, force: true })
+
+      expect(plan.staleManifest).toBe(true)
+      const content = await readFile(join(workspace.dir, '.guren/pages.gen.ts'), 'utf8')
+      expect(content).toContain('generated when this app still had a client')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  // The page components are what put the manifest there, but they are not what
+  // keeps failing the typecheck — deleting them again leaves the import behind.
+  it('still reports a leftover manifest once the page components are gone', async () => {
+    const workspace = await createTempWorkspace('guren-cli-pages-api-only-orphan-')
+    try {
+      await seedApiOnlyApp(workspace.dir)
+      await writeWorkspaceFiles(workspace.dir, { '.guren/pages.gen.ts': '// orphaned\n' })
+
+      const plan = await planPageManifest(workspace.dir)
+      const suppressed = describePageManifestSuppression(plan)
+
+      expect(plan).toEqual({ ...DEFAULT_PATHS, reason: 'api-only', pageCount: 0, staleManifest: true })
+      expect(suppressed?.message).toContain('.guren/pages.gen.ts is present but codegen would not write it')
+      expect(suppressed?.message).not.toContain('page component')
+      expect(suppressed?.advisory).toBe(false)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  // The counter-case that keeps the skip from degenerating into "any app whose
+  // package.json does not name @guren/inertia-client": one web routes entry is
+  // enough evidence, which is `isConfirmedApiOnlyApp`'s own rule.
+  it('still writes the manifest once the app has a web routes entry', async () => {
+    const workspace = await createTempWorkspace('guren-cli-pages-fullstack-')
+    try {
+      await seedApiOnlyApp(workspace.dir)
+      await writeWorkspaceFiles(workspace.dir, {
+        'resources/js/pages/Home.tsx': PAGE_FIXTURE,
+        'routes/web.ts': BLOG_ROUTES_FIXTURE,
+      })
+
+      const { outputPath, plan, skipped } = await generatePageTypes({
+        appRoot: workspace.dir,
+        extractProps: false,
+        force: true,
+      })
+
+      expect(plan).toEqual({ ...DEFAULT_PATHS, reason: 'pages', pageCount: 1, staleManifest: false })
+      expect(skipped).toBeNull()
+      expect(outputPath).toBe(join(workspace.dir, '.guren/pages.gen.ts'))
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reports the same plan through planPageManifest, which check and doctor read', async () => {
+    const workspace = await createTempWorkspace('guren-cli-pages-plan-')
+    try {
+      await seedApiOnlyApp(workspace.dir)
+
+      const empty = await planPageManifest(workspace.dir)
+      expect(empty).toEqual({ ...DEFAULT_PATHS, reason: 'no-pages', pageCount: 0, staleManifest: false })
+      expect(describePageManifestSuppression(empty)).toBeNull()
+
+      await writeWorkspaceFiles(workspace.dir, { 'resources/js/pages/Home.tsx': PAGE_FIXTURE })
+
+      expect(await planPageManifest(workspace.dir)).toEqual({
+        ...DEFAULT_PATHS,
+        reason: 'api-only',
+        pageCount: 1,
+        staleManifest: false,
+      })
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  // --pages / --pages-out move both files, and a report naming the defaults
+  // would send the user looking in directories this run never touched.
+  it('names the directories the run actually used', async () => {
+    const workspace = await createTempWorkspace('guren-cli-pages-custom-paths-')
+    try {
+      await seedApiOnlyApp(workspace.dir)
+      await writeWorkspaceFiles(workspace.dir, { 'frontend/screens/Home.tsx': PAGE_FIXTURE })
+
+      const { plan } = await generatePageTypes({
+        appRoot: workspace.dir,
+        pagesDir: 'frontend/screens',
+        outputFile: 'generated/client-pages.ts',
+        extractProps: false,
+        force: true,
+      })
+
+      expect(describePageManifestSuppression(plan)?.message).toBe(
+        '1 page component under frontend/screens, but this app has no @guren/inertia-client dependency '
+        + 'and no routes/web.ts, so codegen writes no generated/client-pages.ts.',
+      )
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  // The skip has to be audible. A user whose app was misread as API-only sees
+  // this line where a "Page helpers generated at …" used to be.
+  it('warns from the codegen command rather than skipping silently', async () => {
+    const workspace = await createTempWorkspace('guren-cli-pages-api-only-cli-')
+    try {
+      await seedApiOnlyApp(workspace.dir)
+      await writeWorkspaceFiles(workspace.dir, { 'resources/js/pages/Home.tsx': PAGE_FIXTURE })
+
+      assertWorkspaceBuilt([SERVER_DIST_ENTRY])
+
+      const proc = Bun.spawn(['bun', CLI_BIN_PATH, 'codegen', '--app', workspace.dir], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      const exitCode = await proc.exited
+      const output = `${await new Response(proc.stdout).text()}${await new Response(proc.stderr).text()}`
+
+      expect(exitCode).toBe(0)
+      expect(output).toMatch(API_ONLY_REFUSAL)
+      expect(output).not.toContain('Page helpers generated at')
+      expect(existsSync(join(workspace.dir, '.guren/pages.gen.ts'))).toBe(false)
     } finally {
       await workspace.cleanup()
     }

--- a/packages/server/src/mcp/create-mcp-server.ts
+++ b/packages/server/src/mcp/create-mcp-server.ts
@@ -26,6 +26,11 @@ export interface ScaffoldOptions {
  * found nothing to describe and wrote no file (a project with no page
  * components, for instance).
  *
+ * `skipped` is an optional sentence explaining that empty `outputPath` when
+ * "nothing to describe" would be wrong — the pages generator declines to write
+ * a manifest into an app that cannot compile one, and an agent reading this
+ * result is exactly who needs to hear that a page it just wrote was ignored.
+ *
  * `definitions` is the route manifest `generateRouteTypes` builds. It stays
  * opaque here — this package only carries it from one CLI call to the next
  * (`generateApiClientTypes` consumes it) and never reads inside it, so
@@ -34,6 +39,7 @@ export interface ScaffoldOptions {
 export interface CodegenResult {
   outputPath?: string
   definitions?: unknown[]
+  skipped?: { message: string } | null
 }
 
 /**
@@ -363,7 +369,7 @@ export function createMcpServer(options: CreateMcpServerOptions): McpServer {
         try {
           const result = await generate()
           if (result?.outputPath === '') {
-            skipped.push({ artifacts, reason: 'nothing to generate' })
+            skipped.push({ artifacts, reason: result.skipped?.message ?? 'nothing to generate' })
           } else {
             generated.push(...artifacts)
           }

--- a/packages/server/tests/mcp/mcp-server.test.ts
+++ b/packages/server/tests/mcp/mcp-server.test.ts
@@ -397,6 +397,27 @@ describe('Guren MCP Server', () => {
     ])
   })
 
+  test('guren_codegen reports why a generator declined, not just that it wrote nothing', async () => {
+    const client = await createTestClient({
+      generatePageTypes: async () => ({
+        outputPath: '',
+        skipped: { message: 'this app has no @guren/inertia-client dependency and no routes/web.ts' },
+      }),
+    })
+    const result = await client.callTool({ name: 'guren_codegen', arguments: {} })
+    const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text)
+
+    // "nothing to generate" would be false here — page components were found
+    // and deliberately ignored, and the agent that just wrote one is exactly
+    // who has to hear that.
+    expect(data.skipped).toEqual([
+      {
+        artifacts: ['.guren/pages.gen.ts'],
+        reason: 'this app has no @guren/inertia-client dependency and no routes/web.ts',
+      },
+    ])
+  })
+
   test('guren_codegen is an error when nothing could be generated', async () => {
     const failing = async () => {
       throw new Error('routes/web.ts not found')

--- a/rfcs/0007-security-capability-contract.md
+++ b/rfcs/0007-security-capability-contract.md
@@ -170,9 +170,8 @@ The API-only blueprint gets a variant without browser-specific steps.
 surfaced a pre-existing false positive that would have failed every API-only
 app's CI — `check` demanded `.guren/pages.gen.ts` unconditionally, but codegen
 never emits it for an app with no page components. The expectation now asks
-codegen's own rule (`appEmitsPageManifest`, a predicate over the same
-`collectPageDefinitions` scan), so the two cannot drift. `doctor` carries the
-same false positive and is tracked separately.
+codegen's own rule (`planPageManifest`), so the two cannot drift. `doctor` reads
+the same rule.
 
 ## Alternatives Considered
 


### PR DESCRIPTION
## Problem

`.guren/pages.gen.ts` imports `@guren/inertia-client`. An app scaffolded from the `api` blueprint does not install that package, and its `tsconfig.json` includes `.guren/**/*` (and not `resources/`), so a pages manifest generated there fails `tsc` on line 1:

```
.guren/pages.gen.ts(1,52): error TS2307: Cannot find module '@guren/inertia-client'
```

Nothing enforced that it could not appear. `generatePageTypes` wrote a manifest whenever `resources/js/pages` held a component, and that directory fills up by routes no scaffolder controls — a hand-copied page, a checkout — while the api starter's `dev` script runs codegen on every start. Meanwhile `check.ts` asserted in a comment that "codegen never emits it in an API-only app" (false as written: it emits whenever page files exist) and `doctor.ts` leaned on the same claim silently.

## Change

`planPageManifest` answers "does this app get a pages manifest?" once — from the page components **and** `isConfirmedApiOnlyApp` — and `check` and `doctor` read that answer instead of restating it.

Withholding a generated file inverts the risk profile `isConfirmedApiOnlyApp` was built for: a wrong answer used to block a command loudly, and would now quietly deny a file every controller imports. So the suppressed state is reported, never silent:

- `guren codegen` warns in place of the generated path, and the MCP codegen tool reports the reason rather than `"nothing to generate"`.
- `check` and `doctor` surface it — most sharply when a manifest generated before the app took this shape is still on disk. That leftover is what actually fails `tsc`, and both tools used to call it healthy on the strength of its mere existence (they short-circuited on file existence before asking anything else). It also outlives the page components that produced it, so it is reported after those are deleted.
- Severity follows the same rule: the leftover manifest gates `check --ci`; page components an API-only app simply never renders are advisory, because failing a build over unused files would be its own bug.

Codegen does not delete the leftover. If the rule is ever wrong about an app, removing the manifest turns a type error into a mystery — the report names the file and both corrections instead.

`make:view`'s refusal (#357) stands but its reason changes: a stray page is no longer a delayed `typecheck` failure, it is a screen nothing can reach. Its doc comment and the CLI guide say that now, rather than restating a chain codegen no longer lets happen.

## Verification

- Reproduced the hazard directly: the api-only template's `tsconfig.json` plus a generated manifest fails `tsc` with the error above.
- Mutation-tested each guard — inverting the API-only judgement, dropping the leftover probe, and flipping the advisory split each turn the corresponding tests red.
- Both directions on real apps in this repo: `examples/blog` and `web/` still generate the manifest and report nothing new; `examples/api` warns on all three surfaces when a page or a leftover manifest appears. `check --ci` there: clean 0, stray page 0, stray page + leftover manifest 1.
- `build`, root `typecheck`, `test:bun` (4072), `test:examples` (102), `audit:core-first`, `audit:docs`, `check --docs` all green.

Docs (en + ja) and changesets included. The `@guren/server` patch covers the MCP skip reason.
