### PR TITLE
ci: stop the sqlite golden path from following an ambient DATABASE_URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
           POSTGRES_PASSWORD: guren
           POSTGRES_DB: guren
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U guren"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -27,7 +27,7 @@ jobs:
           POSTGRES_PASSWORD: guren
           POSTGRES_DB: guren
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U guren"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -148,7 +148,7 @@ jobs:
           POSTGRES_PASSWORD: guren
           POSTGRES_DB: guren
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U guren"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/scripts/smoke-golden-path.sh
+++ b/scripts/smoke-golden-path.sh
@@ -34,7 +34,17 @@ CREATE_APP_BIN="$REPO_ROOT/packages/create-app/src/cli.ts"
 # service containers to the same ports).
 SMOKE_DB="${GUREN_SMOKE_DB:-sqlite}"
 
-if [ "$SMOKE_DB" = "postgres" ]; then
+if [ "$SMOKE_DB" = "sqlite" ]; then
+  # The scaffolded app resolves its database as `process.env.DATABASE_URL ??
+  # <sqlite file>`, so an ambient DATABASE_URL silently redirects db:migrate
+  # at that server while the assertions below still read the sqlite file —
+  # migrations report success against one database and the check finds the
+  # other one empty. The script owns driver selection for the other two
+  # drivers; owning it here too is what makes that guarantee hold for every
+  # caller (a workflow with a job-level DATABASE_URL, or a developer who
+  # exports one in their shell).
+  unset DATABASE_URL
+elif [ "$SMOKE_DB" = "postgres" ]; then
   # Use a dedicated database so db:reset never touches a developer's data
   # on the shared compose instance. CI maps its service to the same port.
   export DATABASE_URL="${GUREN_SMOKE_DATABASE_URL:-postgres://guren:guren@localhost:54322/guren_smoke}"
@@ -423,6 +433,9 @@ const tables = db.query(\"SELECT name FROM sqlite_master WHERE type='table'\").a
 for (const required of ['users', 'posts', 'comments', '__drizzle_migrations']) {
   if (!tables.includes(required)) {
     console.error('Missing table after db:migrate: ' + required + ' (found: ' + tables.join(', ') + ')')
+    // An empty table list here usually means db:migrate wrote somewhere else
+    // rather than that it silently executed nothing, so name both databases.
+    console.error('Checked sqlite file: ./data/guren.db (DATABASE_URL=' + (process.env.DATABASE_URL ?? '<unset>') + ')')
     process.exit(1)
   }
 }


### PR DESCRIPTION
## Summary

Nightly Canary has failed on every scheduled run for at least two weeks. This fixes the cause and re-enables the part of the canary that was never reached.

The failure was **not** the postgres healthcheck. `pg_isready` reports the server as up whichever role it names, so the `FATAL: role "root" does not exist` lines in the service log are health-probe noise at the 10s interval — `Initialize containers` was green on every failed run and 23 steps executed before the failure.

The actual failure was in `Golden path smoke test`:

```
✓ applied  20260811032909_create_users_table
[success] All migrations applied.
Missing table after db:migrate: users (found: )
```

`nightly-canary.yml` defines a job-level `DATABASE_URL` for its postgres service, and `scripts/smoke-golden-path.sh` only ever *set* that variable for the postgres and mysql drivers — it never cleared an inherited one for sqlite.

For sqlite that value is not a connection string but a **filename**. The scaffolded app resolves `process.env.DATABASE_URL ?? './data/guren.db'` (`packages/create-app/src/blueprints.ts`), and the driver then runs `mkdirSync(dirname(resolve(path)), { recursive: true })` (`packages/orm/src/sqlite.ts`). So a connection-string-shaped value does not fail — it is created as a real nested directory tree, and the migrations apply cleanly into a stray file:

```
<app>/postgres:/guren:guren@localhost:54322/guren
```

`db:migrate` and `db:status` both report success because they agree on that stray file, while the table assertion reads `./data/guren.db` and finds it empty. CI never saw this because its `starter-smokes` job defines no `DATABASE_URL` while running the same script.

The second commit is the healthcheck alignment, kept separate because it is cosmetic: three service definitions still ran a bare `pg_isready` where `release.yml` already passed `-U guren`. It removes log noise; it blocked nothing.

## Scope

- `scripts/smoke-golden-path.sh` — sqlite branch now unsets an inherited `DATABASE_URL`; the table assertion names the file it checked
- `.github/workflows/nightly-canary.yml`, `.github/workflows/ci.yml` — postgres healthchecks aligned with `release.yml`

No framework or product code changed.

## Risk Assessment

Low. The behavior change is confined to the smoke script, and only for the sqlite driver, which previously had no defined behavior under an ambient `DATABASE_URL` — it silently migrated elsewhere. The postgres and mysql paths are untouched: they already exported their own `DATABASE_URL` and still honor the `GUREN_SMOKE_DATABASE_URL` override.

The job-level `DATABASE_URL` in `nightly-canary.yml` is deliberately left in place — other steps in that job may rely on it, and making the script hermetic fixes the problem for every caller rather than for one workflow. It also protects a developer who has `DATABASE_URL` exported in their shell, who would otherwise have their own database migrated and seeded by a "sqlite" smoke run.

The healthcheck change makes all six postgres service definitions in the repo byte-identical to the form `release.yml` has run in production for a long time.

## Validation

Mechanism reproduced and fixed, rather than inferred:

- With the canary's exact env, the pre-fix script fails byte-identically to CI: `Missing table after db:migrate: users (found: )`
- With the same env, the fixed script passes that check: `DB tables OK: __drizzle_migrations, users, sqlite_sequence, comments, posts`
- The stray-path behavior was confirmed directly — replaying the driver's `mkdirSync` + `new Database(url)` creates `./postgres:/guren:guren@localhost:54322/guren` instead of erroring

Full `Nightly Canary` run on this branch: **all three jobs green** ([run 31483115693](https://github.com/gurenjs/guren/actions/runs/31483115693)). That run covers `bun run typecheck` and `bun run test` on this branch, plus every audit and smoke.

Note `Run tests` and `Run benchmarks` had **never executed** during the failure streak — both pass, so no second regression was hiding behind the first.

- [x] `bun run build` — run locally in this worktree (exit 0)
- [x] `bun run typecheck` — via the canary run above
- [x] `bun run test` — via the canary run above

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [ ] I added/updated tests for behavior changes. — the changed file *is* the test harness; the canary run is the regression check
- [ ] I updated relevant documentation. — no documented behavior changed

## Known issue, not addressed here

`smoke:golden-path` also fails on **macOS** at a later step (`GET /posts does not contain the created post title`), on a clean build with `DATABASE_URL` unset. It passes on Linux CI on the same commit, so it is environment-specific and pre-existing, unrelated to this change. Tracked separately.
