### PR TITLE
fix(cli): stop the agent testing rule from documenting a TestApp form that throws

### DIFF
--- a/.changeset/agent-rule-testapp-from-app.md
+++ b/.changeset/agent-rule-testapp-from-app.md
@@ -1,0 +1,21 @@
+---
+'@guren/cli': patch
+---
+
+Stop the agent testing rule from documenting a TestApp form that throws
+
+The harness rule shipped `const app = TestApp.fromFetch((req) => app.fetch(req))`
+as the way to wrap an existing app. The arrow is not the problem — the shadowing
+is. Inside it, `app` resolves to the `const app` being declared on that same line,
+which is the `TestApp`, and `TestApp` has no public `fetch`. An agent that copied
+the line got `TypeError: app.fetch is not a function` at the first request, from
+text that reads fine.
+
+`TestApp.fromApp(app)` was added for this footgun and is now published, so the rule
+documents it as the way to test against a real `Application`: it boots the app and
+binds `fetch` itself. `fromFetch` stays for the case it actually models — an
+arbitrary fetch function — with an example that does not shadow. The `(not async)`
+note travels with `fromFetch`, since `fromApp` must be awaited.
+
+Existing apps pick this up through `guren agent:sync`, which owns everything under
+`.claude/rules/`.

--- a/docs/en/guides/testing.md
+++ b/docs/en/guides/testing.md
@@ -46,7 +46,7 @@ await app.delete('/posts/1')
 
 ### Wrapping the real application
 
-`TestApp.create({ ... })` assembles an app from the parts you pass — good for isolated slices, but the subset can silently drift from what the server actually runs (providers, `auth`, `i18n`, security defaults). For tests that should exercise the real configuration, boot the app your project exports and wrap its fetch handler:
+`TestApp.create({ ... })` assembles an app from the parts you pass — good for isolated slices, but the subset can silently drift from what the server actually runs (providers, `auth`, `i18n`, security defaults). For tests that should exercise the real configuration, wrap the app your project exports:
 
 ```ts
 import { TestApp } from '@guren/testing'
@@ -55,8 +55,7 @@ import app from '../src/app.js'
 let http: TestApp
 
 beforeAll(async () => {
-  await app.boot()
-  http = TestApp.fromFetch((request) => app.fetch(request))
+  http = await TestApp.fromApp(app)
 })
 
 test('serves the home page', async () => {
@@ -64,7 +63,14 @@ test('serves the home page', async () => {
 })
 ```
 
-This is the pattern scaffolded apps ship with. Pass `app.fetch` through an arrow function — the method reads instance state, so handing the unbound reference over throws on the first request.
+`fromApp()` boots the app and binds its fetch handler for you. Several test files may call it on the same instance — `boot()` is idempotent and reuses the first boot.
+
+You may also see the longer form below, which does the same thing by hand. Note the arrow function: `fetch` reads instance state, so handing the unbound `app.fetch` reference to `fromFetch` throws on the first request. `fromApp()` exists to remove that footgun; reach for `fromFetch` when you have an arbitrary fetch function rather than a Guren application.
+
+```ts
+await app.boot()
+http = TestApp.fromFetch((request) => app.fetch(request))
+```
 
 When you do assemble an app from parts, `TestApp.create()` mirrors `createApp`'s options: pass `auth` to mount session + CSRF middleware, and `i18n` when controllers under test use `this.t()` / `this.tc()`:
 

--- a/docs/ja/guides/testing.md
+++ b/docs/ja/guides/testing.md
@@ -38,7 +38,7 @@ describe('Posts API', () => {
 
 ### 実アプリをラップする
 
-`TestApp.create({ ... })`は渡したパーツからアプリを組み立てます — 単体スライスのテストには便利ですが、その部分集合はサーバーが実際に動かす構成(プロバイダー、`auth`、`i18n`、セキュリティデフォルト)から静かにドリフトし得ます。実構成を検証したいテストでは、プロジェクトがエクスポートするアプリをbootしてfetchハンドラをラップします:
+`TestApp.create({ ... })`は渡したパーツからアプリを組み立てます — 単体スライスのテストには便利ですが、その部分集合はサーバーが実際に動かす構成(プロバイダー、`auth`、`i18n`、セキュリティデフォルト)から静かにドリフトし得ます。実構成を検証したいテストでは、プロジェクトがエクスポートするアプリをラップします:
 
 ```ts
 import { TestApp } from '@guren/testing'
@@ -47,8 +47,7 @@ import app from '../src/app.js'
 let http: TestApp
 
 beforeAll(async () => {
-  await app.boot()
-  http = TestApp.fromFetch((request) => app.fetch(request))
+  http = await TestApp.fromApp(app)
 })
 
 test('ホームページを返す', async () => {
@@ -56,7 +55,14 @@ test('ホームページを返す', async () => {
 })
 ```
 
-scaffoldされたアプリはこのパターンを同梱しています。`app.fetch`は必ずアロー関数経由で渡してください — メソッドはインスタンス状態を読むため、束縛せずに渡すと最初のリクエストで例外になります。
+`fromApp()`はアプリのbootとfetchハンドラの束縛を代わりに行います。同じインスタンスに対して複数のテストファイルから呼んで構いません — `boot()`は冪等で、最初のbootを再利用します。
+
+同じことを手作業で行う次の長い形も見かけるでしょう。アロー関数に注目してください — `fetch`はインスタンス状態を読むため、束縛していない`app.fetch`をそのまま`fromFetch`に渡すと最初のリクエストで例外になります。`fromApp()`はこの罠を取り除くために存在します。`fromFetch`は、Gurenアプリケーションではなく任意のfetch関数を持っている場合に使ってください。
+
+```ts
+await app.boot()
+http = TestApp.fromFetch((request) => app.fetch(request))
+```
 
 パーツから組み立てる場合、`TestApp.create()`は`createApp`のオプションをミラーします: セッション+CSRFミドルウェアには`auth`を、テスト対象のコントローラーが`this.t()` / `this.tc()`を使うなら`i18n`を渡します:
 

--- a/packages/cli/templates/agent/.claude/rules/testing.md
+++ b/packages/cli/templates/agent/.claude/rules/testing.md
@@ -13,29 +13,45 @@ Requests run in-process through `app.fetch()` — no server, no port.
 ```typescript
 import { TestApp } from '@guren/testing'
 
-const app = await TestApp.create()             // boots a fresh Application
-const app = await TestApp.create({ boot, providers, routes })  // all optional
-const app = TestApp.fromFetch((req) => app.fetch(req))  // wrap an existing fetch fn (not async)
+const http = await TestApp.create()             // boots a fresh Application
+const http = await TestApp.create({ boot, providers, routes })  // all optional
+const http = await TestApp.fromApp(app)         // wrap the app exported by src/app.ts
 ```
 
 **Prefer wrapping the real app.** Scaffolded apps export the configured
-application from `src/app.ts` — boot it and wrap it so tests exercise the
-app's actual configuration (providers, auth, i18n, security defaults)
-instead of reconstructing a subset that silently drifts:
+application from `src/app.ts` — wrap it so tests exercise the app's actual
+configuration (providers, auth, i18n, security defaults) instead of
+reconstructing a subset that silently drifts:
 
 ```typescript
 import app from '../src/app.js'
 
-await app.boot()
-const http = TestApp.fromFetch((request) => app.fetch(request))
+const http = await TestApp.fromApp(app)
 ```
 
-Keep `TestApp.create({ ... })` for isolated slices (a single route or
-middleware under test). Pass `app.fetch` through an arrow — the method
-reads instance state, so handing the unbound reference over throws at the
-first request.
+`fromApp()` boots the app for you and binds its `fetch` to the instance.
+It is `async` — `await` it. Calling it from several test files is fine:
+`Application.boot()` is idempotent and reuses the first boot.
 
-Both set `GUREN_TESTING=1` so `actingAs()` header auth is accepted.
+Keep `TestApp.create({ ... })` for isolated slices (a single route or
+middleware under test).
+
+`TestApp.fromFetch(fn)` — the only one of the three that is *not* async —
+wraps an arbitrary fetch function, e.g. a bare Hono app:
+
+```typescript
+const hono = new Hono()
+const http = TestApp.fromFetch((request) => hono.fetch(request))
+```
+
+Do not reach for it to wrap a Guren `Application`; use `fromApp()`. Hand-wiring
+one is where the footgun lives: `Application.fetch` reads instance state, so
+`fromFetch(app.fetch)` throws `undefined is not an object (evaluating
+'this.hono')` at the first request. It has to be an arrow —
+`fromFetch((request) => app.fetch(request))` — which is exactly what
+`fromApp()` does for you.
+
+All three set `GUREN_TESTING=1` so `actingAs()` header auth is accepted.
 
 **Session + CSRF in tests.** `TestApp.create()` accepts `auth` just like `createApp({ auth: {} })`. Without it, session + CSRF middleware are **not** mounted — JSON requests (`app.json().post(...)`) pass with no CSRF check at all, which is fine for quick validation/auth-guard checks but not representative of production. To exercise real CSRF behavior (and for `withCsrf()` to work — it throws `"did not set an XSRF-TOKEN cookie"` otherwise):
 


### PR DESCRIPTION
## Summary

`packages/cli/templates/agent/.claude/rules/testing.md` documented this as the way to wrap an existing app:

```typescript
const app = TestApp.fromFetch((req) => app.fetch(req))  // wrap an existing fetch fn (not async)
```

The arrow is not the problem — the **shadowing** is. Inside it, `app` resolves to the `const app` being declared on that same line, which is the `TestApp`, and `TestApp` has no public `fetch` (`fetchFn` is private). An agent that copies the line gets `TypeError: app.fetch is not a function` at the first request, out of text that type-checks by eye. The rule ships to every app that runs `guren agent:init` / `agent:sync`.

`TestApp.fromApp(app)` was added for exactly this footgun and is published (`@guren/testing@1.4.0`, in v2.3.0), so the rule now documents it as the way to test against a real `Application` — it boots the app and binds `fetch` itself. `fromFetch` keeps the case it actually models, an arbitrary fetch function, with an example that does not shadow. The `(not async)` note travels with `fromFetch`, since `fromApp` must be awaited.

The en/ja testing guides were **not** broken — they already passed `app.fetch` through an arrow — but they hand-wire what `fromApp()` now does, so both move to it and keep the longer form as the explained alternative.

## Scope

- `cli` — the framework-managed agent harness rule (the actual fix)
- `docs` — `docs/{en,ja}/guides/testing.md`, kept in sync

Existing apps pick the rule up through `guren agent:sync`: `.claude/rules/` is in `MANAGED_PREFIXES`, so sync overwrites a stale copy while leaving user-owned files alone.

## Risk Assessment

Documentation only — no runtime code changed. No API is deprecated: `fromFetch` keeps its signature and its use case.

Two things deliberately left out of scope:

1. `packages/create-app/templates/{default,blog}/tests/HomeController.test.ts` still ship the manual `await app.boot()` + `fromFetch` form. It is correct, just longer, and the templates pin `@guren/testing: ^1.4.0` so a migration is safe — but touching templates pulls in `audit:starter-template` and the starter smokes.
2. `docs/{en,ja}/guides/i18n.md:312` shows the same long form. Also correct, also not urgent.

## Validation

Verified by execution, not by reading — the point of the bug is that the old text looks fine:

| form | result |
|---|---|
| `await TestApp.fromApp(app)` | request served |
| old rule line 18 (shadowed `app`) | `TypeError: app.fetch is not a function` |
| unbound `Application.fetch` | `undefined is not an object (evaluating 'this.hono')` |
| `fromFetch((request) => app.fetch(request))` | request served |

While drafting, the rule briefly warned that unbound `hono.fetch` throws. Measured it: Hono binds `fetch`, so that was wrong, and the warning is now attached to the `Application` case that does throw.

`agent:init` / `agent:sync` driven for real against a temp app: init writes the fixed rule; after replacing it with the old broken text, `agent:sync` reports `Wrote .claude/rules/testing.md` and the broken form is gone, while user-owned `CLAUDE.md` is skipped.

- [x] `bun run build` (`build:clean`)
- [x] `bun run typecheck` — 0 errors after running codegen in `examples/blog`; the 29 errors on a fresh worktree are missing `.guren/*.gen` artifacts, unrelated to a markdown-only diff
- [x] `bun run test:bun cli` — 1317 pass / 0 fail; `packages/testing` — 139 pass / 0 fail
- [x] `bun run audit:docs`, `bun run audit:core-first` — pass

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [ ] I added/updated tests for behavior changes. — no behavior change; the documented forms were verified by execution as described above
- [x] I updated relevant documentation.