### PR TITLE
refactor(create-app): scaffold starter tests with TestApp.fromApp

### DIFF
--- a/.changeset/starter-tests-use-from-app.md
+++ b/.changeset/starter-tests-use-from-app.md
@@ -1,0 +1,14 @@
+---
+'create-guren-app': patch
+---
+
+Scaffold starter tests with `TestApp.fromApp(app)`
+
+The `default` and `blog` starter tests hand-wired what `fromApp()` does:
+`await app.boot()` followed by `TestApp.fromFetch((request) => app.fetch(request))`.
+Correct, but it is the first test a new app ever reads, and it teaches the arrow
+wrapper as something the author has to remember — the arrow being load-bearing,
+since `Application.fetch` reads instance state.
+
+`@guren/testing@1.4.0` is published and the templates already admit it (`^1.4.0`),
+so the scaffold now shows the short form.

--- a/docs/en/guides/i18n.md
+++ b/docs/en/guides/i18n.md
@@ -297,7 +297,7 @@ The `loader` option accepts anything implementing the `TranslationLoader` interf
 
 ## Testing
 
-Translation behavior is easiest to test through the real app — boot it and wrap it with `TestApp` (see the [Testing guide](./testing.md)):
+Translation behavior is easiest to test through the real app — wrap it with `TestApp` (see the [Testing guide](./testing.md)):
 
 ```ts
 import { describe, test, beforeAll } from 'bun:test'
@@ -308,8 +308,7 @@ describe('i18n', () => {
   let http: TestApp
 
   beforeAll(async () => {
-    await app.boot()
-    http = TestApp.fromFetch((request) => app.fetch(request))
+    http = await TestApp.fromApp(app)
   })
 
   test('serves Japanese for ?locale=ja', async () => {

--- a/docs/ja/guides/i18n.md
+++ b/docs/ja/guides/i18n.md
@@ -297,7 +297,7 @@ const app = createApp({
 
 ## テスト
 
-翻訳の挙動は実アプリを通してテストするのが最も簡単です — bootして`TestApp`でラップします([テストガイド](./testing.md)参照):
+翻訳の挙動は実アプリを通してテストするのが最も簡単です — `TestApp`でラップします([テストガイド](./testing.md)参照):
 
 ```ts
 import { describe, test, beforeAll } from 'bun:test'
@@ -308,8 +308,7 @@ describe('i18n', () => {
   let http: TestApp
 
   beforeAll(async () => {
-    await app.boot()
-    http = TestApp.fromFetch((request) => app.fetch(request))
+    http = await TestApp.fromApp(app)
   })
 
   test('?locale=ja で日本語を返す', async () => {

--- a/packages/create-app/templates/blog/tests/HomeController.test.ts
+++ b/packages/create-app/templates/blog/tests/HomeController.test.ts
@@ -11,8 +11,7 @@ describe('app', () => {
   let http: TestApp
 
   beforeAll(async () => {
-    await app.boot()
-    http = TestApp.fromFetch((request) => app.fetch(request))
+    http = await TestApp.fromApp(app)
   })
 
   it('answers the health check', async () => {

--- a/packages/create-app/templates/default/tests/HomeController.test.ts
+++ b/packages/create-app/templates/default/tests/HomeController.test.ts
@@ -7,8 +7,7 @@ describe('app', () => {
   let http: TestApp
 
   beforeAll(async () => {
-    await app.boot()
-    http = TestApp.fromFetch((request) => app.fetch(request))
+    http = await TestApp.fromApp(app)
   })
 
   it('serves the translated home page', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #363, which fixed the agent harness rule. Two places still hand-wired what `TestApp.fromApp(app)` does:

```ts
await app.boot()
http = TestApp.fromFetch((request) => app.fetch(request))
```

Neither is broken — the arrow is there and correct. But the starter test is the first test a new app ever reads, and this form teaches the arrow wrapper as something the author has to remember, when the arrow is load-bearing: `Application.fetch` reads instance state, so an unbound reference throws at the first request. That is the footgun `fromApp()` was added to remove.

## Scope

- `create-app` — `templates/{default,blog}/tests/HomeController.test.ts`
- `docs` — `docs/{en,ja}/guides/i18n.md` testing section, kept in sync

`api-only`'s `tests/app.test.ts` is deliberately left alone: it uses `TestApp.create({ routes, providers })` to exercise a slice on purpose, which is a different pattern rather than the one being replaced here.

## Risk Assessment

The template-vs-npm hazard is the one that matters here, since `packages/create-app/templates/**` resolves `@guren/*` from the **registry**, not this checkout. It does not apply:

- `@guren/testing@1.4.0` is published, and the templates already pin `^1.4.0`.
- Verified against the published tarball rather than the workspace build — `npm view @guren/testing@1.4.0 dist.tarball`, unpacked, and `dist/index.d.ts` carries `static fromApp(app: ApplicationLike, baseUrl?: string): Promise<TestApp>`.

So this is not a template reaching for an API that only exists after the next release. Behavior of the scaffolded test is unchanged: `fromApp()` sets `GUREN_TESTING=1`, awaits `boot()`, and binds `fetch`.

## Validation

- [x] `bun run audit:starter-template` — pass
- [x] `bun run audit:template-deps` — "Template dependency versions match the workspace"
- [x] `bun run audit:docs` — pass
- [x] `bun run smoke:starter` — 18 passed, 0 failures
- [x] `bun run smoke:starter:blog` — 17 passed, 0 failures

Both smokes scaffold a real app and run `bun test` inside it (`scripts/smoke/fresh-app.ts:715`), so the changed test files were executed, not merely type-checked.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes. — the changed files *are* the scaffolded tests; they run green inside a real scaffold via the smokes above
- [x] I updated relevant documentation.