### PR TITLE
test: run the golden path smoke's payloads from files, not heredocs

### DIFF
--- a/scripts/smoke-golden-path.sh
+++ b/scripts/smoke-golden-path.sh
@@ -9,6 +9,18 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TEMP_DIR=""
 SERVER_PID=""
 
+# Every TypeScript payload this script runs against the scaffolded app lives
+# here as a real .ts file and is copied into place — none of them are heredocs
+# or `bun -e` strings. Files keep the payloads greppable and free of shell
+# quoting, and they sidestep a heredoc's one hard failure mode: bash writes a
+# heredoc under 64KB into a pipe, and it does that write *before* exec'ing the
+# reader, so the writer is its own reader and anything larger than the kernel's
+# pipe capacity deadlocks with no output. That capacity is not a constant — a
+# host under memory pressure can report a fraction of the usual value — so the
+# ceiling is not something this script can size a payload against. Add the next
+# payload as a file here too.
+FIXTURES_DIR="$REPO_ROOT/scripts/smoke/fixtures"
+
 # Redefined once the runtime smoke has a server to kill; until then there is
 # nothing to stop. Declared here so cleanup() can be written once — the same
 # handler ran before and after that point, and keeping one copy is what stops
@@ -256,49 +268,20 @@ stop_server() {
 if [ "$SMOKE_DB" = "sqlite" ]; then
   (cd "$APP_DIR" && bun run db:migrate)
 else
-  # Server-backed drivers get a dedicated database, created here if missing.
+  # The only gate on a non-sqlite $SMOKE_DB (sqlite is matched literally
+  # above). Driver-keyed fixture names are interpolated from this variable, so
+  # an unknown value has to die here rather than reach a `cp` as a missing
+  # filename.
   case "$SMOKE_DB" in
-    postgres)
-      # CREATE DATABASE has no IF NOT EXISTS on pg.
-      cat > "$TEMP_DIR/ensure-db.ts" <<'ENSUREDB'
-import postgres from 'postgres'
-
-const target = new URL(process.env.DATABASE_URL ?? '')
-const dbName = target.pathname.slice(1)
-const admin = new URL(target.toString())
-admin.pathname = '/postgres'
-
-const sql = postgres(admin.toString(), { max: 1 })
-const exists = await sql`SELECT 1 FROM pg_database WHERE datname = ${dbName}`
-if (exists.length === 0) {
-  await sql.unsafe(`CREATE DATABASE "${dbName.replaceAll('"', '""')}"`)
-  console.log(`Created database ${dbName}`)
-} else {
-  console.log(`Database ${dbName} already exists`)
-}
-await sql.end()
-ENSUREDB
-      ;;
-    mysql)
-      cat > "$TEMP_DIR/ensure-db.ts" <<'ENSUREDB'
-import { createConnection } from 'mysql2/promise'
-
-const target = new URL(process.env.DATABASE_URL ?? '')
-const dbName = decodeURIComponent(target.pathname.slice(1))
-const admin = new URL(target.toString())
-admin.pathname = '/'
-
-const connection = await createConnection(admin.toString())
-await connection.query(`CREATE DATABASE IF NOT EXISTS \`${dbName.replaceAll('`', '``')}\``)
-await connection.end()
-console.log(`Database ${dbName} ready`)
-ENSUREDB
-      ;;
+    postgres|mysql) ;;
     *)
       echo "ERROR: unknown GUREN_SMOKE_DB '$SMOKE_DB' (expected sqlite, postgres, or mysql)"
       exit 1
       ;;
   esac
+
+  # Server-backed drivers get a dedicated database, created here if missing.
+  cp "$FIXTURES_DIR/ensure-db.$SMOKE_DB.ts" "$TEMP_DIR/ensure-db.ts"
   (cd "$APP_DIR" && bun "$TEMP_DIR/ensure-db.ts")
 
   # Drop leftovers from previous runs and exercise resetDatabase().
@@ -328,91 +311,8 @@ fi
 
 # Assert migrations actually created tables — db:migrate used to report
 # success while silently executing nothing.
-if [ "$SMOKE_DB" = "postgres" ]; then
-  cat > "$TEMP_DIR/dbcheck.ts" <<'DBCHECK'
-import postgres from 'postgres'
-
-const sql = postgres(process.env.DATABASE_URL ?? 'postgres://guren:guren@localhost:54322/guren', { max: 1 })
-const rows = await sql`SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`
-const tables = rows.map((row) => row.table_name as string)
-for (const required of ['users', 'posts', 'comments']) {
-  if (!tables.includes(required)) {
-    console.error('Missing table after db:migrate: ' + required + ' (found: ' + tables.join(', ') + ')')
-    process.exit(1)
-  }
-}
-const tracker = await sql`SELECT count(*)::int AS c FROM drizzle.__drizzle_migrations`
-if (Number(tracker[0].c) < 1) {
-  console.error('drizzle.__drizzle_migrations is empty after db:migrate')
-  process.exit(1)
-}
-
-// Every timestamp a scaffold emits must carry a time zone. An offset-less
-// column stores a bare wall clock and leaves its meaning to the reader: the
-// app itself stays self-consistent (drizzle parses the column as UTC), which
-// is why no HTTP round trip below can catch this, but every other reader sees
-// a different instant and a `defaultNow()` column records the DB session's
-// local wall clock. Asked as "which columns are wrong" rather than against a
-// list of names, so a scaffold that grows a new timestamp is covered too.
-const offsetlessColumns = await sql`
-  SELECT table_name, column_name, data_type FROM information_schema.columns
-  WHERE table_schema = 'public'
-    AND data_type LIKE 'timestamp%'
-    AND data_type <> 'timestamp with time zone'
-`
-if (offsetlessColumns.length > 0) {
-  const named = offsetlessColumns.map((c) => c.table_name + '.' + c.column_name + ' (' + c.data_type + ')')
-  console.error('Expected every timestamp column to be timestamptz, but found: ' + named.join(', '))
-  process.exit(1)
-}
-
-await sql.end()
-console.log('DB tables OK (postgres): ' + tables.join(', ') + ' — timestamp columns are timestamptz')
-DBCHECK
-  (cd "$APP_DIR" && bun "$TEMP_DIR/dbcheck.ts")
-elif [ "$SMOKE_DB" = "mysql" ]; then
-  cat > "$TEMP_DIR/dbcheck.ts" <<'DBCHECK'
-import { createConnection } from 'mysql2/promise'
-
-const connection = await createConnection(process.env.DATABASE_URL ?? '')
-const [rows] = await connection.query(
-  'SELECT table_name AS name FROM information_schema.tables WHERE table_schema = DATABASE()',
-)
-const tables = (rows as Array<{ name: string }>).map((row) => row.name)
-for (const required of ['users', 'posts', 'comments']) {
-  if (!tables.includes(required)) {
-    console.error('Missing table after db:migrate: ' + required + ' (found: ' + tables.join(', ') + ')')
-    process.exit(1)
-  }
-}
-// The tracker table lives in the app database on MySQL, so the count below
-// doubles as its existence check — the query fails if it was never created.
-const [tracker] = await connection.query('SELECT count(*) AS c FROM __drizzle_migrations')
-if (Number((tracker as Array<{ c: number }>)[0].c) < 1) {
-  console.error('__drizzle_migrations is empty after db:migrate')
-  process.exit(1)
-}
-await connection.end()
-console.log('DB tables OK (mysql): ' + tables.join(', '))
-DBCHECK
-  (cd "$APP_DIR" && bun "$TEMP_DIR/dbcheck.ts")
-else
-  (cd "$APP_DIR" && bun -e "
-import { Database } from 'bun:sqlite'
-const db = new Database('./data/guren.db')
-const tables = db.query(\"SELECT name FROM sqlite_master WHERE type='table'\").all().map((r) => r.name)
-for (const required of ['users', 'posts', 'comments', '__drizzle_migrations']) {
-  if (!tables.includes(required)) {
-    console.error('Missing table after db:migrate: ' + required + ' (found: ' + tables.join(', ') + ')')
-    // An empty table list here usually means db:migrate wrote somewhere else
-    // rather than that it silently executed nothing, so name both databases.
-    console.error('Checked sqlite file: ./data/guren.db (DATABASE_URL=' + (process.env.DATABASE_URL ?? '<unset>') + ')')
-    process.exit(1)
-  }
-}
-console.log('DB tables OK: ' + tables.join(', '))
-")
-fi
+cp "$FIXTURES_DIR/dbcheck.$SMOKE_DB.ts" "$TEMP_DIR/dbcheck.ts"
+(cd "$APP_DIR" && bun "$TEMP_DIR/dbcheck.ts")
 
 # One loopback address, used for both halves of the conversation: the app is
 # told to bind it and the assertions are addressed to it. `localhost` is not
@@ -709,57 +609,7 @@ stop_server
 # ---------------------------------------------------------------------------
 step 17 "Add-on runtime smoke (queue dispatch + mail send)"
 
-cat > "$APP_DIR/addons-check.ts" <<'ADDONS'
-import app, { ready } from './src/main.js'
-import { Job, registerJob } from '@guren/core'
-
-await ready
-
-// Queue: the scaffolded default is the sync driver — dispatch must execute
-// the handler inline, in this process, with no worker.
-let probeRan = false
-class SmokeProbeJob extends Job<Record<string, never>> {
-  async handle(): Promise<void> {
-    probeRan = true
-  }
-}
-registerJob(SmokeProbeJob)
-const jobId = await SmokeProbeJob.dispatch({})
-if (typeof jobId !== 'string' || jobId.length === 0) {
-  console.error('Job dispatch did not return a job id')
-  process.exit(1)
-}
-if (!probeRan) {
-  console.error('SyncDriver did not execute the dispatched job inline')
-  process.exit(1)
-}
-console.log('Queue OK: sync dispatch executed the job inline')
-
-// The scaffolded sample job must dispatch cleanly too.
-const { ProcessWelcomeSequenceJob } = await import('./app/Jobs/ProcessWelcomeSequenceJob.js')
-await ProcessWelcomeSequenceJob.dispatch({ source: 'smoke' })
-
-// Mail: the scaffolded default is the log transport — send() must succeed
-// and report the log response.
-const mailManager = app.container.make('mail') as never
-const { WelcomeEmailMail } = await import('./app/Mail/WelcomeEmailMail.js')
-const result = (await new WelcomeEmailMail(mailManager).to('smoke@example.com').send()) as {
-  success: boolean
-  response?: string
-  error?: string
-}
-if (!result.success) {
-  console.error('Mail send failed: ' + JSON.stringify(result))
-  process.exit(1)
-}
-if (result.response !== 'Message written to log') {
-  console.error('Expected the log transport to handle the message, got: ' + JSON.stringify(result))
-  process.exit(1)
-}
-console.log('Mail OK: ' + result.response)
-
-process.exit(0)
-ADDONS
+cp "$FIXTURES_DIR/addons-check.ts" "$APP_DIR/addons-check.ts"
 
 (cd "$APP_DIR" && bun addons-check.ts)
 rm -f "$APP_DIR/addons-check.ts"

--- a/scripts/smoke/fixtures/addons-check.ts
+++ b/scripts/smoke/fixtures/addons-check.ts
@@ -1,0 +1,52 @@
+// Copied to the scaffolded app's root by scripts/smoke-golden-path.sh and run
+// from there — the relative imports below resolve against that app, not this
+// directory, so this file does not resolve when opened or run in place.
+import app, { ready } from './src/main.js'
+import { Job, registerJob } from '@guren/core'
+
+await ready
+
+// Queue: the scaffolded default is the sync driver — dispatch must execute
+// the handler inline, in this process, with no worker.
+let probeRan = false
+class SmokeProbeJob extends Job<Record<string, never>> {
+  async handle(): Promise<void> {
+    probeRan = true
+  }
+}
+registerJob(SmokeProbeJob)
+const jobId = await SmokeProbeJob.dispatch({})
+if (typeof jobId !== 'string' || jobId.length === 0) {
+  console.error('Job dispatch did not return a job id')
+  process.exit(1)
+}
+if (!probeRan) {
+  console.error('SyncDriver did not execute the dispatched job inline')
+  process.exit(1)
+}
+console.log('Queue OK: sync dispatch executed the job inline')
+
+// The scaffolded sample job must dispatch cleanly too.
+const { ProcessWelcomeSequenceJob } = await import('./app/Jobs/ProcessWelcomeSequenceJob.js')
+await ProcessWelcomeSequenceJob.dispatch({ source: 'smoke' })
+
+// Mail: the scaffolded default is the log transport — send() must succeed
+// and report the log response.
+const mailManager = app.container.make('mail') as never
+const { WelcomeEmailMail } = await import('./app/Mail/WelcomeEmailMail.js')
+const result = (await new WelcomeEmailMail(mailManager).to('smoke@example.com').send()) as {
+  success: boolean
+  response?: string
+  error?: string
+}
+if (!result.success) {
+  console.error('Mail send failed: ' + JSON.stringify(result))
+  process.exit(1)
+}
+if (result.response !== 'Message written to log') {
+  console.error('Expected the log transport to handle the message, got: ' + JSON.stringify(result))
+  process.exit(1)
+}
+console.log('Mail OK: ' + result.response)
+
+process.exit(0)

--- a/scripts/smoke/fixtures/dbcheck.mysql.ts
+++ b/scripts/smoke/fixtures/dbcheck.mysql.ts
@@ -1,0 +1,22 @@
+import { createConnection } from 'mysql2/promise'
+
+const connection = await createConnection(process.env.DATABASE_URL ?? '')
+const [rows] = await connection.query(
+  'SELECT table_name AS name FROM information_schema.tables WHERE table_schema = DATABASE()',
+)
+const tables = (rows as Array<{ name: string }>).map((row) => row.name)
+for (const required of ['users', 'posts', 'comments']) {
+  if (!tables.includes(required)) {
+    console.error('Missing table after db:migrate: ' + required + ' (found: ' + tables.join(', ') + ')')
+    process.exit(1)
+  }
+}
+// The tracker table lives in the app database on MySQL, so the count below
+// doubles as its existence check — the query fails if it was never created.
+const [tracker] = await connection.query('SELECT count(*) AS c FROM __drizzle_migrations')
+if (Number((tracker as Array<{ c: number }>)[0].c) < 1) {
+  console.error('__drizzle_migrations is empty after db:migrate')
+  process.exit(1)
+}
+await connection.end()
+console.log('DB tables OK (mysql): ' + tables.join(', '))

--- a/scripts/smoke/fixtures/dbcheck.postgres.ts
+++ b/scripts/smoke/fixtures/dbcheck.postgres.ts
@@ -1,0 +1,38 @@
+import postgres from 'postgres'
+
+const sql = postgres(process.env.DATABASE_URL ?? 'postgres://guren:guren@localhost:54322/guren', { max: 1 })
+const rows = await sql`SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`
+const tables = rows.map((row) => row.table_name as string)
+for (const required of ['users', 'posts', 'comments']) {
+  if (!tables.includes(required)) {
+    console.error('Missing table after db:migrate: ' + required + ' (found: ' + tables.join(', ') + ')')
+    process.exit(1)
+  }
+}
+const tracker = await sql`SELECT count(*)::int AS c FROM drizzle.__drizzle_migrations`
+if (Number(tracker[0].c) < 1) {
+  console.error('drizzle.__drizzle_migrations is empty after db:migrate')
+  process.exit(1)
+}
+
+// Every timestamp a scaffold emits must carry a time zone. An offset-less
+// column stores a bare wall clock and leaves its meaning to the reader: the
+// app itself stays self-consistent (drizzle parses the column as UTC), which
+// is why the smoke's later HTTP steps cannot catch this, but every other reader sees
+// a different instant and a `defaultNow()` column records the DB session's
+// local wall clock. Asked as "which columns are wrong" rather than against a
+// list of names, so a scaffold that grows a new timestamp is covered too.
+const offsetlessColumns = await sql`
+  SELECT table_name, column_name, data_type FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND data_type LIKE 'timestamp%'
+    AND data_type <> 'timestamp with time zone'
+`
+if (offsetlessColumns.length > 0) {
+  const named = offsetlessColumns.map((c) => c.table_name + '.' + c.column_name + ' (' + c.data_type + ')')
+  console.error('Expected every timestamp column to be timestamptz, but found: ' + named.join(', '))
+  process.exit(1)
+}
+
+await sql.end()
+console.log('DB tables OK (postgres): ' + tables.join(', ') + ' — timestamp columns are timestamptz')

--- a/scripts/smoke/fixtures/dbcheck.sqlite.ts
+++ b/scripts/smoke/fixtures/dbcheck.sqlite.ts
@@ -1,0 +1,14 @@
+import { Database } from 'bun:sqlite'
+
+const db = new Database('./data/guren.db')
+const tables = db.query("SELECT name FROM sqlite_master WHERE type='table'").all().map((r) => r.name)
+for (const required of ['users', 'posts', 'comments', '__drizzle_migrations']) {
+  if (!tables.includes(required)) {
+    console.error('Missing table after db:migrate: ' + required + ' (found: ' + tables.join(', ') + ')')
+    // An empty table list here usually means db:migrate wrote somewhere else
+    // rather than that it silently executed nothing, so name both databases.
+    console.error('Checked sqlite file: ./data/guren.db (DATABASE_URL=' + (process.env.DATABASE_URL ?? '<unset>') + ')')
+    process.exit(1)
+  }
+}
+console.log('DB tables OK: ' + tables.join(', '))

--- a/scripts/smoke/fixtures/ensure-db.mysql.ts
+++ b/scripts/smoke/fixtures/ensure-db.mysql.ts
@@ -1,0 +1,11 @@
+import { createConnection } from 'mysql2/promise'
+
+const target = new URL(process.env.DATABASE_URL ?? '')
+const dbName = decodeURIComponent(target.pathname.slice(1))
+const admin = new URL(target.toString())
+admin.pathname = '/'
+
+const connection = await createConnection(admin.toString())
+await connection.query(`CREATE DATABASE IF NOT EXISTS \`${dbName.replaceAll('`', '``')}\``)
+await connection.end()
+console.log(`Database ${dbName} ready`)

--- a/scripts/smoke/fixtures/ensure-db.postgres.ts
+++ b/scripts/smoke/fixtures/ensure-db.postgres.ts
@@ -1,0 +1,17 @@
+// CREATE DATABASE has no IF NOT EXISTS on pg, hence the explicit lookup.
+import postgres from 'postgres'
+
+const target = new URL(process.env.DATABASE_URL ?? '')
+const dbName = target.pathname.slice(1)
+const admin = new URL(target.toString())
+admin.pathname = '/postgres'
+
+const sql = postgres(admin.toString(), { max: 1 })
+const exists = await sql`SELECT 1 FROM pg_database WHERE datname = ${dbName}`
+if (exists.length === 0) {
+  await sql.unsafe(`CREATE DATABASE "${dbName.replaceAll('"', '""')}"`)
+  console.log(`Created database ${dbName}`)
+} else {
+  console.log(`Database ${dbName} already exists`)
+}
+await sql.end()


### PR DESCRIPTION
## Summary

`scripts/smoke-golden-path.sh` embedded six TypeScript payloads directly in the shell script — five as heredocs and one as a `bun -e` string. Each is now a committed file under `scripts/smoke/fixtures/`, copied into place at the same destination it was written to before.

The motivation is a failure mode heredocs have and files do not. Bash writes a heredoc under 64KB into a pipe, and it performs that write *before* exec'ing the reader — so the writer is its own reader, and any payload larger than the kernel's pipe capacity deadlocks with no output at all. That capacity is not a constant: a host under memory pressure can report a fraction of the usual value, which is not something the script can size a payload against. Four of the six payloads sat in that window. Using files removes the mechanism rather than trying to stay under a moving ceiling.

This surfaced as the smoke hanging at step 17 with no output, but it is worth being precise about what this PR is and is not: **the trigger was a single host in a degraded state, not a defect in the script and not macOS generally.** CI and healthy machines were never affected. This is hardening — it makes the script independent of that host condition — not a root-cause fix.

Two side benefits: the payloads become greppable and free of shell quoting (the sqlite one lost a set of `\"` escapes), and with the bodies out of the way the driver dispatch collapses. The `ensure-db` `case` and the `dbcheck` `if`/`elif` chains had branches differing only in a filename that is already `$SMOKE_DB`, so each becomes a single interpolated `cp`. The `case` stays as the validity gate it already was — fixture names are interpolated from that variable, so an unknown driver must die there rather than reach a `cp` as a missing filename. Net −196 lines in the script.

## Scope

`scripts/` only. No package, template, or documentation changes.

## Risk Assessment

No intended behavior change. Copy destinations and working directories are unchanged, so the payloads run exactly where they ran before.

- Payload bodies are unchanged apart from three comments: the pg `CREATE DATABASE` note moved into the fixture it explains, a "no HTTP round trip below" reference was reworded now that nothing is below it, and `addons-check.ts` gained a header noting its relative imports resolve at the destination rather than in place. Verified mechanically against `HEAD`: the two mysql fixtures are byte-identical, and the deltas in the other files are comment lines only, with zero code changes.
- The one execution-mode change is the sqlite dbcheck, which moves from `bun -e "…"` to `bun file.ts`. This is safe because `bun:sqlite` is a builtin (no `node_modules` lookup from `$TEMP_DIR`) and `./data/guren.db` is cwd-relative with cwd still `$APP_DIR` via the same subshell.
- The `cp` into a directory outside the repo is load-bearing and should not be "simplified" away: bun resolves bare specifiers from the importing file's path, and the repo root has a `node_modules` that does not contain `postgres`/`mysql2`, so running these fixtures in place fails to resolve their drivers.

## Validation

- [x] `bun run build` — succeeded
- [x] `bun run typecheck` — exit 0
- [x] `bun run test` (`test:bun`) — 4023 pass, 55 skip, **0 fail** across 240 files
- [x] `bun run smoke:golden-path` — exit 0, `=== Golden path smoke test PASSED ===`
- [x] `bun run audit:core-first`, `bun run audit:docs` — both passed

Note on `typecheck`: it first failed in this worktree with `Cannot find module '@/.guren/routes.gen'` across `examples/blog`. That is environmental — `.guren/` is gitignored generated output that had never been produced in a fresh worktree. Running the blog's `codegen` makes typecheck exit 0, and this commit touches only `scripts/`.

Verification is reported in two tiers, deliberately:

- **sqlite (default) — verified by execution.** The full smoke passes end to end, and step 17's own assertions print (`Queue OK: sync dispatch executed the job inline`, `Mail OK: Message written to log`), so the copied fixtures really ran. The new `dbcheck.sqlite.ts` was additionally mutation-tested in both directions: it exits 1 with `Missing table after db:migrate: users` against an empty database, and 0 once the required tables exist.
- **postgres / mysql — not executed** (no database containers running here). Verified by unchanged copy destinations, comment-only deltas from `HEAD`, and a parse check of all six fixtures via `Bun.Transpiler`. CI exercises these paths.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.

## Follow-up (not in this PR)

Extracting the payloads made a pre-existing duplication visible: the list of tables that must exist after `db:migrate` is hard-coded in all three `dbcheck.*` fixtures, and the copies have already drifted — sqlite includes `__drizzle_migrations` in its required-table list, while postgres and mysql omit it there and assert the tracker separately with a `count(*)` query. So "the tracker is non-empty" is checked on two drivers and only "it exists" on the third. Consolidating into one module is not the fix, since it would have to import `postgres`, `mysql2/promise`, and `bun:sqlite` together and resolve drivers it does not need; a shared constants module is the more likely shape. Tracked separately.
