### PR TITLE
fix(server): stop FormRequest documenting a no-op auth gate

### DIFF
--- a/.changeset/form-request-user-is-async.md
+++ b/.changeset/form-request-user-is-async.md
@@ -1,0 +1,43 @@
+---
+'@guren/server': patch
+---
+
+Fix the `FormRequest` JSDoc example that documented a no-op authorization gate
+
+`AuthContext.user()` is async, but `FormRequest`'s `protected user()` was
+declared `(): unknown` and returned its result unawaited. The class JSDoc built
+its `authorize()` example on that:
+
+```ts
+authorize() {
+  return this.user() !== null   // a pending promise — always true
+}
+```
+
+An app that copied it authorized every request, including logged-out ones. The
+precondition is an attached auth context, which is the normal case:
+`Application` attaches a fallback one in its constructor even when the app
+configures no `options.auth`. The `unknown` return type kept `tsc` quiet.
+
+`user()` is now `protected async user<TUser>(): Promise<TUser | null>` and the
+example awaits it. `authorize()` already accepted `boolean | Promise<boolean>`
+and `handle()` already awaited it, so nothing else moves — for callers that
+await, runtime behavior is identical before and after.
+
+`handle()`'s JSDoc also claimed it was `@internal Called by
+Controller.validate()`. That method does not exist and nothing in the framework
+calls `handle()`, so it now documents the real entry point:
+`await new StorePostRequest().handle(this.ctx)`.
+
+### Note for subclasses that override `user()`
+
+The new signature is source-incompatible for a subclass that **overrides** the
+helper — `protected user(): unknown` no longer satisfies the base declaration.
+It is `protected` on a deprecated class, so this is not public API surface, and
+subclasses that only *call* `user()` are unaffected.
+
+Migration: change an override to `protected async user<TUser = unknown>():
+Promise<TUser | null>`. Separately, a subclass that copied the old
+`this.user() !== null` line keeps compiling and keeps returning true — a
+promise is still legally `!== null` — so rewrite it as
+`(await this.user()) !== null`.

--- a/docs/en/guides/email-verification.md
+++ b/docs/en/guides/email-verification.md
@@ -413,12 +413,14 @@ describe('Email Verification', () => {
 
 ```ts
 // UserController.ts
+const RegisterSchema = z.object({
+  name: z.string().min(2),
+  email: z.email(),
+  password: z.string().min(8),
+})
+
 async register() {
-  const { name, email, password } = await this.validate({
-    name: z.string().min(2),
-    email: z.email(),
-    password: z.string().min(8),
-  })
+  const { name, email, password } = await this.validateBody(RegisterSchema)
 
   // Create user
   const user = await User.create({

--- a/docs/ja/guides/controllers.md
+++ b/docs/ja/guides/controllers.md
@@ -164,14 +164,14 @@ if (await this.has('email')) {
 ```ts
 export default class PostsController extends Controller {
   async store() {
-    const data = await this.validate(StorePostRequest)
+    const data = await this.validateBody(StorePostSchema)
     const post = await Post.create(data)
     return this.created({ post })
   }
 
   async update() {
     const post = await Post.findOrFail(this.ctx.req.param('id'))
-    const data = await this.validate(UpdatePostRequest)
+    const data = await this.validateBody(StorePostSchema)
     await Post.update(post.id, data)
     return this.accepted({ post: { ...post, ...data } })
   }
@@ -243,7 +243,7 @@ export default class PostsController extends Controller {
 
 ```ts
 async store() {
-  const data = await this.validate(StorePostRequest)
+  const data = await new StorePostRequest().handle(this.ctx)
   // `data` は StorePostRequest に基づいて完全に型付けされています
   const post = await Post.create(data)
   return this.redirect('/posts')

--- a/docs/ja/guides/email-verification.md
+++ b/docs/ja/guides/email-verification.md
@@ -413,12 +413,14 @@ describe('メール確認', () => {
 
 ```ts
 // UserController.ts
+const RegisterSchema = z.object({
+  name: z.string().min(2),
+  email: z.email(),
+  password: z.string().min(8),
+})
+
 async register() {
-  const { name, email, password } = await this.validate({
-    name: z.string().min(2),
-    email: z.email(),
-    password: z.string().min(8),
-  })
+  const { name, email, password } = await this.validateBody(RegisterSchema)
 
   // ユーザーを作成
   const user = await User.create({

--- a/packages/server/src/http/FormRequest.ts
+++ b/packages/server/src/http/FormRequest.ts
@@ -30,17 +30,16 @@ import type { AuthContext } from '../auth'
  *     }
  *   }
  *
- *   authorize() {
- *     return this.user() !== null
+ *   async authorize() {
+ *     return (await this.user()) !== null
  *   }
  * }
  *
  * // In controller:
- * const data = await this.validate(StorePostRequest)
+ * const data = await new StorePostRequest().handle(this.ctx)
  * // data is typed as StorePostData
  * ```
- */
-/**
+ *
  * @deprecated Legacy compatibility layer — prefer schema-first validation
  * via `this.validateBody()` / `validateQuery()` / `validateParams()`.
  */
@@ -79,15 +78,19 @@ export abstract class FormRequest<T = Record<string, unknown>> {
 
   /**
    * Get the authenticated user from the request context.
+   *
+   * Awaiting is load-bearing: `this.user() !== null` compiles and is always
+   * true, because an unawaited call is a pending promise.
    */
-  protected user(): unknown {
+  protected async user<TUser = unknown>(): Promise<TUser | null> {
     const auth = this.ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
-    return auth?.user?.() ?? null
+    return (await auth?.user<TUser>()) ?? null
   }
 
   /**
    * Handle the form request: authorize, parse body, validate, return typed data.
-   * @internal Called by Controller.validate()
+   * Call it from a controller with the request context:
+   * `const data = await new StorePostRequest().handle(this.ctx)`.
    */
   async handle(ctx: Context): Promise<T> {
     this.ctx = ctx

--- a/packages/server/tests/http/form-request.test.ts
+++ b/packages/server/tests/http/form-request.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from 'bun:test'
+import { Hono } from 'hono'
+import type { Context } from 'hono'
+import { createMockAuthContext } from '@guren/testing'
+import { FormRequest } from '../../src/http/FormRequest'
+import { attachAuthContext, type AuthContext } from '../../src/http/middleware/auth'
+import { AuthorizationException } from '../../src/errors/exceptions/AuthorizationException'
+import { ValidationException } from '../../src/errors/exceptions/ValidationException'
+import { required, string } from '../../src/http/validation/rules'
+
+interface StorePostData {
+  title: string
+}
+
+class StorePostRequest extends FormRequest<StorePostData> {
+  rules() {
+    return {
+      title: [required(), string()],
+    }
+  }
+}
+
+/**
+ * Builds a real Hono context, routing the auth context through
+ * `attachAuthContext()` so the tests see whatever the framework actually
+ * stores under that key.
+ */
+async function createContext(body: Record<string, unknown>, auth?: AuthContext): Promise<Context> {
+  const app = new Hono()
+  let captured: Context | undefined
+
+  if (auth) {
+    app.use(attachAuthContext(() => auth))
+  }
+
+  app.post('/posts', (ctx) => {
+    captured = ctx
+    return ctx.body(null, 204)
+  })
+
+  await app.request('/posts', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+  if (!captured) {
+    throw new Error('The route did not run, so no context was captured.')
+  }
+
+  return captured
+}
+
+describe('FormRequest', () => {
+  describe('user', () => {
+    /** Records what `user()` resolved to, which is otherwise unobservable. */
+    class ProbeRequest extends StorePostRequest {
+      resolved: unknown = 'never ran'
+
+      async authorize(): Promise<boolean> {
+        this.resolved = await this.user()
+        return true
+      }
+    }
+
+    test('resolves the authenticated user', async () => {
+      const request = new ProbeRequest()
+      await request.handle(await createContext({ title: 'Hello' }, createMockAuthContext({ isAuthenticated: true })))
+
+      expect(request.resolved).toEqual({ id: 1, name: 'Test User' })
+    })
+
+    test('resolves null for a logged-out visitor', async () => {
+      const request = new ProbeRequest()
+      await request.handle(await createContext({ title: 'Hello' }, createMockAuthContext({ isAuthenticated: false })))
+
+      expect(request.resolved).toBeNull()
+    })
+
+    test('resolves null when no auth context is attached', async () => {
+      const request = new ProbeRequest()
+      await request.handle(await createContext({ title: 'Hello' }))
+
+      expect(request.resolved).toBeNull()
+    })
+  })
+
+  describe('handle', () => {
+    test('returns the validated payload, dropping fields the rules do not cover', async () => {
+      const data = await new StorePostRequest().handle(await createContext({ title: 'Hello', extra: 'dropped' }))
+
+      expect(data).toEqual({ title: 'Hello' })
+    })
+
+    test('throws AuthorizationException when authorize() returns false', async () => {
+      class DeniedRequest extends StorePostRequest {
+        authorize(): boolean {
+          return false
+        }
+      }
+
+      await expect(new DeniedRequest().handle(await createContext({ title: 'Hello' }))).rejects.toThrow(
+        AuthorizationException,
+      )
+    })
+
+    test('throws ValidationException when the payload fails the rules', async () => {
+      await expect(new StorePostRequest().handle(await createContext({}))).rejects.toThrow(ValidationException)
+    })
+  })
+})

--- a/packages/server/tests/http/form-request.types.ts
+++ b/packages/server/tests/http/form-request.types.ts
@@ -1,0 +1,40 @@
+import { FormRequest } from '../../src/http/FormRequest'
+import { required, string } from '../../src/http/validation/rules'
+
+/**
+ * A type-only fixture: nothing here is ever executed, and `bun run typecheck`
+ * is the assertion.
+ *
+ * `FormRequest.user()` used to be declared `(): unknown` while the
+ * `AuthContext.user()` it delegates to was already async, so it handed back a
+ * pending promise that the return type hid. No runtime test can hold that
+ * line — every caller that awaits behaves identically under both signatures —
+ * so the assignment below is the guard: it fails to compile if `user()` ever
+ * goes back to returning a non-promise.
+ */
+export class TypedUserRequest extends FormRequest<{ title: string }> {
+  rules() {
+    return {
+      title: [required(), string()],
+    }
+  }
+
+  async authorize(): Promise<boolean> {
+    const pending: Promise<unknown> = this.user()
+    return (await pending) !== null
+  }
+}
+
+/** The generic flows through to the resolved value, not just to `unknown`. */
+export class TypedUserRecordRequest extends FormRequest<{ title: string }> {
+  rules() {
+    return {
+      title: [required(), string()],
+    }
+  }
+
+  async authorize(): Promise<boolean> {
+    const user = await this.user<{ id: number }>()
+    return user !== null && user.id > 0
+  }
+}

--- a/scripts/smoke/docs-audit.ts
+++ b/scripts/smoke/docs-audit.ts
@@ -330,7 +330,19 @@ const STALE_APP_ALIAS_PATTERN = /['"]@\/(?:Http|Models|Policies|Events|Jobs|List
 // call are all correct and must not match.
 const DISCARDED_ALIAS_MIDDLEWARE_PATTERN = /^[\w$]+(?:\.[\w$]+)*\.aliasMiddleware\((?!.*\)\s*\.\w)/u
 
+// `Controller.validate()` no longer exists. Samples calling it read as the
+// mainline validation path while naming a method the framework never had, so
+// nothing an author copies from them can run. Match the bare call only —
+// `validateBody` / `validateQuery` / `validateParams` are the real helpers, and
+// `FormRequest`'s own `validate` never lived on the controller.
+const PHANTOM_CONTROLLER_VALIDATE_PATTERN = /\bthis\.validate\(/u
+
 const DOC_LINE_RULES: { pattern: RegExp; describe: (location: string) => string }[] = [
+  {
+    pattern: PHANTOM_CONTROLLER_VALIDATE_PATTERN,
+    describe: (location) =>
+      `${location} calls \`this.validate(...)\`, which does not exist on Controller. Use \`this.validateBody(schema)\` / \`validateQuery\` / \`validateParams\`, or — for the legacy FormRequest compatibility layer — \`await new StorePostRequest().handle(this.ctx)\`.`,
+  },
   {
     pattern: STALE_APP_ALIAS_PATTERN,
     describe: (location) =>


### PR DESCRIPTION
## What

`FormRequest`'s `protected user()` was declared `(): unknown` and returned the result of the async `AuthContext.user()` unawaited. The class JSDoc built its `authorize()` example on that:

```ts
authorize() {
  return this.user() !== null   // a pending promise — always true
}
```

An app that copied it authorized every request, logged-out ones included.

`user()` is now `protected async user<TUser = unknown>(): Promise<TUser | null>` and the example awaits it. `authorize()` already accepted `boolean | Promise<boolean>` and `handle()` already awaited it, so nothing else moves.

`handle()`'s JSDoc also claimed `@internal Called by Controller.validate()` — a method that does not exist, and nothing in the framework calls `handle()`. It now documents the real entry point, `await new StorePostRequest().handle(this.ctx)`, which I compiled inside `examples/blog` before writing it into the docs.

## Why the precondition matters

The gate only fails open when an auth context is attached — which is the normal case. `Application` registers `AuthServiceProvider` when `options.auth` is set and otherwise attaches a fallback `attachAuthContext` in its own constructor (`packages/server/src/http/Application.ts:293-297`). With no auth context at all the old code returned `null` correctly, which is why the shape survives a casual read. The `unknown` return type kept `tsc` quiet either way.

Reproduced before fixing: a `FormRequest` whose `authorize()` used the documented line, given a context whose `user()` resolves `null`, was authorized.

## What this does not fix

A subclass that already copied the old line still compiles and still returns true — `Promise` vs `null` is a legal `!==`, and the typed return does not force an error at the comparison site. Such an `authorize()` has to be rewritten by hand. The changeset says so.

## Docs

Four samples across both languages called the same phantom `this.validate(...)`:

- `docs/ja/guides/controllers.md:167,174` — the response-helpers section. English shows `await this.validateBody(StorePostSchema)` there, so ja now matches; that section should not be teaching a deprecated class.
- `docs/ja/guides/controllers.md:246` — inside the ja-only 「FormRequest 互換レイヤー」 section, so this one correctly becomes `new StorePostRequest().handle(this.ctx)`.
- `docs/{en,ja}/guides/email-verification.md:417` — passed a bare record of Zod fields, which no helper accepts. Now `validateBody(RegisterSchema)`.

`scripts/smoke/docs-audit.ts` grows a `DOC_LINE_RULES` entry banning `this.validate(` so it cannot come back. Verified failing and passing: re-adding the call to a guide exits 1.

## Tests

No runtime test can guard this change — awaiting behaves identically under both signatures, so every test that awaits is green against the old implementation too. The guard is therefore type-only, in the shape this package already uses for `Router.middleware()` (`packages/server/tests/mvc/router-middleware.types.ts`): `packages/server/tests/http/form-request.types.ts` pins the signature via `const pending: Promise<unknown> = this.user()`. Mutation-tested — reverting `user()` to the old body fails root `typecheck` with 4 errors.

`packages/server/tests/http/form-request.test.ts` is first coverage for a class that had none (authorize → parse → validate → throw, and what `user()` resolves to). It builds a real Hono context through `attachAuthContext()` and uses `createMockAuthContext` from `@guren/testing`, matching `tests/http/middleware/auth.test.ts`.

## Semver

Marked `patch`. The signature is source-incompatible for a subclass that **overrides** `user()`, which a strict reading of `docs/en/guides/release-policy.md` would call major. I kept `patch` because the member is `protected` on a `@deprecated` class with zero callers repo-wide, while a major on `@guren/server` cascades through the `@guren/core`/`cli` ranges at `changeset version`. Happy to flip it — it is one word in the changeset. The migration note is in there either way.

## Deliberately not done

- Removing the deprecated class outright (a public-export break needing a major).
- Passing the resolved user into `authorize(user)` — the only change that makes the footgun unrepresentable, but an API change to a deprecated class.
- Exporting `resolveAuth()` from `http/middleware/auth.ts`; `Controller.ts:208`, `:284` and `FormRequest.ts` each hand-roll the same cast. Pre-existing, not created here.
- Declaring `@guren/testing` as a devDep of `packages/server` — two sibling tests already import it via hoisting. It would not create a build-graph cycle (`scripts/workspace-packages.ts` reads only `dependencies`/`peerDependencies`), but it is a separate change.
- The English docs name `FormRequest` as the compatibility path but never show how to invoke it, so `handle()` appears in one English place: the class JSDoc. That en/ja divergence is pre-existing and an editorial call.

## Checks

`build`, root `typecheck`, full `test:bun` (4029 pass / 0 fail across 241 files), `audit:docs`, `audit:core-first` — all green.
