### PR TITLE
feat(server): return the bound address from Application.listen()

### DIFF
--- a/.changeset/guren-dev-reports-bound-address.md
+++ b/.changeset/guren-dev-reports-bound-address.md
@@ -1,0 +1,17 @@
+---
+'@guren/cli': patch
+---
+
+Report the port `guren dev` actually bound, and stop swallowing `PORT=0`
+
+`guren dev` carried its own copy of the entrypoint idiom this release removes
+elsewhere: `Number.parseInt(process.env.PORT ?? '', 10) || 3333`, which turns
+`PORT=0` into 3333 so "let the OS pick a free port" could not be expressed.
+
+It also announced `http://${hostname}:${port}` from the values it *requested*,
+without awaiting `listen()`. Those are not the bound values once the framework
+walks past a busy port — so the one line telling you where to point your browser
+was the line most likely to be wrong, and it printed the raw `0.0.0.0` wildcard
+rather than something dialable. It now awaits `listen()` and reports the address
+it returns, falling back to the requested values for an app whose installed
+`@guren/server` predates that return value.

--- a/.changeset/listen-returns-bound-address.md
+++ b/.changeset/listen-returns-bound-address.md
@@ -1,0 +1,45 @@
+---
+'@guren/server': minor
+---
+
+Return the bound address from `Application.listen()`, and move the busy-port walk into it
+
+`listen()` called `Bun.serve({ port })` and discarded `server.port`, returning
+`Promise<void>`. The framework knew the port it had bound and threw it away, so
+the only way to find out was to scrape the dev banner — ANSI-coloured prose
+written for humans. `listen()` now returns `{ port, hostname, url }`, read off
+the running server rather than echoed back from the request.
+
+That mattered because the port asked for and the port bound are routinely
+different numbers. The walk past a busy port lived in four copies of
+application code (`bin/serve.ts` in both starter templates, the blog example,
+and the docs site), each wrapping the framework call that should have owned it.
+Copies drift, and none of them could report where the app ended up. The walk now
+lives in `listen()` behind `portFallback`: `true` walks the next 20 ports,
+`false` fails fast. Left unset it walks outside production, which is what the
+loops it replaces did. Moving the walk inside also makes it dramatically
+cheaper — a retry used to re-enter `listen()` and restart the managed Vite dev
+server (~600ms per busy port); it is now a bare re-bind.
+
+A bind that gives up now shuts the managed Vite dev server down on its way out.
+`listen()` starts Vite before anything tries to bind, so an exhausted walk — or
+a strict-port failure, which is precisely the case automated callers *handle*
+rather than exit on — used to leave an asset server and its published
+environment variables running in a process with no application server.
+
+`GUREN_STRICT_PORT=1` forces fail-fast from outside the app. This is the case the
+walk actively harms: a smoke script, a Playwright `webServer`, or a CI job that
+pins a port needs to know the app answering is the one it started. Walking past a
+busy port makes that failure silent and inverted — the run goes green against
+somebody else's server. `bun run dev` keeps the convenience by default.
+
+`PORT=0` also works now. `Number.parseInt(process.env.PORT ?? '', 10) || 3333`
+turned 0 into 3333, so "let the OS pick a free port and tell me which" could not
+be expressed — and it is the natural way to run tests in parallel. The walk is
+skipped for port 0, which has nothing to recover from and would otherwise march
+into the privileged range.
+
+The starter templates keep their own loop for now: they resolve `@guren/*` from
+npm, so they cannot use a `listen()` option until the release that ships it.
+They do honour `GUREN_STRICT_PORT` and parse `PORT=0` correctly, which needs no
+new API.

--- a/.changeset/serve-template-port-handling.md
+++ b/.changeset/serve-template-port-handling.md
@@ -1,0 +1,27 @@
+---
+'create-guren-app': patch
+---
+
+Make the scaffolded `bin/serve.ts` honour `PORT=0` and `GUREN_STRICT_PORT=1`
+
+`Number.parseInt(process.env.PORT ?? '', 10) || 3333` turned `PORT=0` into 3333,
+so "let the OS pick a free port" — the natural way to run a scaffolded app
+alongside others, or in parallel tests — could not be expressed. The parse now
+tests for a number instead of for truthiness.
+
+The entrypoint also walks to the next port when the requested one is busy, which
+is a convenience for `bun run dev` and a hazard everywhere else: a smoke script,
+an E2E runner, or a CI job that pins a port gets a server on a *different* port
+while it keeps testing the original one — so the run passes against whatever was
+already listening there. `GUREN_STRICT_PORT=1` now binds the requested port or
+fails with `EADDRINUSE`. The walk is also skipped for `PORT=0`, which has nothing
+to recover from and would otherwise march into the privileged range.
+
+The generated file keeps its own retry loop rather than delegating to the
+framework: templates resolve `@guren/*` from npm, so they cannot use the new
+`listen({ portFallback })` option until the release that ships it. Because the
+loop stays, the entrypoint now also sets `GUREN_STRICT_PORT=1` for itself before
+looping — the framework walks inside `listen()` in newer versions, and a caret
+range floats a scaffolded app onto one of those without any template change.
+Nesting the two loops would search far past the intended range and warn about
+the wrong ports; this keeps the retry in exactly one place on every version.

--- a/docs/en/guides/architecture.md
+++ b/docs/en/guides/architecture.md
@@ -229,7 +229,19 @@ export class Post extends defineModel(posts) {
    })
    ```
 3. `await app.boot()` to mount routes, run provider register/boot hooks, and prepare middleware.
-4. `await app.listen()` to start the HTTP server.
+4. `await app.listen()` to start the HTTP server. It resolves to the address it
+   actually bound — `{ port, hostname, url }` — which is not always the port you
+   asked for: `port: 0` lets the OS choose, and outside production a busy port
+   makes it try the next one. Read the port from the return value rather than
+   assuming the requested one:
+
+   ```ts
+   const { url, port } = await app.listen({ port: 3333 })
+   console.log(`listening on ${url}`) // the port that is actually bound
+   ```
+
+   Pass `portFallback: false` (or set `GUREN_STRICT_PORT=1`) to fail fast on
+   `EADDRINUSE` instead of moving to another port.
 
 This process runs under Bun as a native module and is triggered by `bun run dev`.
 

--- a/docs/en/guides/deployment.md
+++ b/docs/en/guides/deployment.md
@@ -65,6 +65,7 @@ For reliability, wrap this command with a process manager (e.g. `systemd`, `pm2`
 
 - The startup banner only renders in non-production environments by default. If you want to show it (or disable it explicitly) set `GUREN_DEV_BANNER=1` or `GUREN_DEV_BANNER=0`.
 - The framework skips launching the Vite dev server when `NODE_ENV=production`. If you’re running a custom dev workflow in production-like environments, toggle it with `GUREN_DEV_VITE=1` (on) or `GUREN_DEV_VITE=0` (off).
+- Outside production, a busy port makes the server try the next one so `bun run dev` keeps working. Set `GUREN_STRICT_PORT=1` to bind the requested port or fail with `EADDRINUSE` instead. Use it anywhere a run has to know it reached the app it started — smoke scripts, E2E runners, CI — because walking to another port otherwise lets the run pass against whatever was already listening.
 
 ```ini
 [Unit]

--- a/docs/ja/guides/architecture.md
+++ b/docs/ja/guides/architecture.md
@@ -143,7 +143,14 @@ const { Cache, Events, Log, Mail, Queue } = createFacades(app.container)
 1. `routes/web.ts` から registrar を export する。
 2. `const app = createApp({ routes: registerWebRoutes, providers: [DatabaseProvider, ...] })` のように生成し、サービスを早期登録。
 3. `await app.boot()` でルートをマウントし、プロバイダーのブートフックを実行し、ミドルウェアを準備。
-4. `await app.listen()`（または Bun では `app.listen()`）で HTTP サーバーを開始。
+4. `await app.listen()`（または Bun では `app.listen()`）で HTTP サーバーを開始。戻り値は実際にバインドしたアドレス `{ port, hostname, url }` です。`port: 0` を指定すると OS が空きポートを選び、本番以外ではポートが使用中の場合に次のポートへ移動するため、要求したポートと一致するとは限りません。ポート番号は要求値ではなく戻り値から読み取ってください。
+
+   ```ts
+   const { url, port } = await app.listen({ port: 3333 })
+   console.log(`listening on ${url}`) // 実際にバインドされたポート
+   ```
+
+   ポート移動をやめて `EADDRINUSE` で即座に失敗させたい場合は `portFallback: false` を渡すか、`GUREN_STRICT_PORT=1` を設定します。
 
 この流れは Bun のネイティブモジュールで動作し、`bun run dev` で起動されます。
 

--- a/docs/ja/guides/deployment.md
+++ b/docs/ja/guides/deployment.md
@@ -65,6 +65,7 @@ NODE_ENV=production bun run bin/serve.ts
 
 - スタートアップバナーは本番では既定で非表示です。表示したい/明示的に消したい場合は `GUREN_DEV_BANNER=1` または `GUREN_DEV_BANNER=0` を設定。
 - `NODE_ENV=production` では Vite dev サーバーを起動しません。もし本番相当環境で起動したい/抑制したい場合は `GUREN_DEV_VITE=1`/`0` を切り替えてください。
+- 本番以外では、ポートが使用中の場合に次のポートへ移動して起動します（`bun run dev` の利便性のため）。`GUREN_STRICT_PORT=1` を設定すると、要求したポートにバインドできなければ `EADDRINUSE` で失敗します。smoke スクリプト・E2E ランナー・CI など「起動したアプリ自身に接続できたこと」を保証したい場面では必ず設定してください。ポートを移動してしまうと、既に待ち受けていた別のサーバーに対してテストが通ってしまいます。
 
 ```ini
 [Unit]

--- a/examples/api/bin/serve.ts
+++ b/examples/api/bin/serve.ts
@@ -7,11 +7,19 @@ try {
   process.exit(1)
 }
 
-const port = Number.parseInt(process.env.PORT ?? '', 10) || 3334
+// `PORT=0` means "any free port", so this tests for a number, not truthiness.
+const parsedPort = Number.parseInt(process.env.PORT ?? '', 10)
+const port = Number.isInteger(parsedPort) ? parsedPort : 3334
 const hostname = process.env.HOST ?? '0.0.0.0'
 
-await app.listen({ port, hostname, vite: false })
+// `portFallback: false` keeps this entrypoint's original fail-fast behaviour.
+// It never walked, and it must not start: the OpenAPI document it serves
+// advertises `http://localhost:3334` as the server, so binding 3335 instead
+// would hand clients a URL that answers nothing.
+const address = await app.listen({ port, hostname, vite: false, portFallback: false })
 
-console.log(`API server running at http://${hostname}:${port}`)
-console.log(`OpenAPI JSON available at http://${hostname}:${port}/api/openapi.json`)
-console.log(`API docs available at http://${hostname}:${port}/api/docs`)
+// Printed from the address listen() returned, not from the port that was
+// requested — with a port walk or PORT=0 those are different numbers.
+console.log(`API server running at ${address.url}`)
+console.log(`OpenAPI JSON available at ${address.url}/api/openapi.json`)
+console.log(`API docs available at ${address.url}/api/docs`)

--- a/examples/blog/bin/serve.ts
+++ b/examples/blog/bin/serve.ts
@@ -7,30 +7,13 @@ try {
   process.exit(1)
 }
 
-const requestedPort = Number.parseInt(process.env.PORT ?? '', 10) || 3333
+// `PORT=0` means "any free port", so this tests for a number, not truthiness.
+const parsedPort = Number.parseInt(process.env.PORT ?? '', 10)
+const port = Number.isInteger(parsedPort) ? parsedPort : 3333
 const hostname = process.env.HOST ?? '0.0.0.0'
-const isDevelopment = process.env.NODE_ENV !== 'production'
 
-for (let offset = 0; offset < 20; offset += 1) {
-  const port = requestedPort + offset
-
-  try {
-    await app.listen({ port, hostname })
-    break
-  } catch (error) {
-    if (!isDevelopment || !isAddressInUse(error) || offset === 19) {
-      throw error
-    }
-
-    console.warn(`Port ${port} is in use, trying ${port + 1}...`)
-  }
-}
-
-function isAddressInUse(error: unknown): boolean {
-  return Boolean(
-    error &&
-      typeof error === 'object' &&
-      'code' in error &&
-      (error as { code?: unknown }).code === 'EADDRINUSE',
-  )
-}
+// The walk past a busy port lives in listen() now, which is also the only
+// place that can report which port it ended up on. Set GUREN_STRICT_PORT=1 to
+// fail fast instead — what an automated consumer wants when it has to know
+// the app under test is the one answering.
+await app.listen({ port, hostname })

--- a/examples/blog/playwright.config.ts
+++ b/examples/blog/playwright.config.ts
@@ -44,9 +44,19 @@ export default defineConfig({
     // development, not a test run that should hold still.
     // `CI=1` is passed explicitly: the server reads it to drop the cookie
     // `Secure` flag, without which Inertia's XHR POSTs fail over plain HTTP.
-    command: isCI ? 'CI=1 bun run e2e:server' : 'bun run dev',
+    //
+    // GUREN_STRICT_PORT=1 pins the port: the entrypoint otherwise walks past a
+    // busy 3333, and the run would then drive whatever else was answering
+    // there while `baseURL` still pointed at 3333.
+    command: isCI ? 'CI=1 GUREN_STRICT_PORT=1 bun run e2e:server' : 'GUREN_STRICT_PORT=1 bun run dev',
     url: 'http://localhost:3333',
-    reuseExistingServer: !isCI,
+    // A separate guarantee from the strict port above, and a real local
+    // trade-off: with `!isCI` a run attached to whatever was already on 3333 —
+    // a stale build, or another branch — and reported it as this branch's
+    // result. The cost is that `bun run dev` must be stopped before running
+    // E2E locally; the benefit is that a green run can no longer describe an
+    // app this checkout did not build.
+    reuseExistingServer: false,
     timeout: isCI ? 60_000 : 30_000,
   },
 })

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1670,18 +1670,27 @@ const devCommand = defineCommand({
       return
     }
 
-    const port = Number.parseInt(process.env.PORT ?? '', 10) || 3333
+    // `PORT=0` means "any free port", so this tests for a number, not truthiness.
+    const parsedPort = Number.parseInt(process.env.PORT ?? '', 10)
+    const port = Number.isInteger(parsedPort) ? parsedPort : 3333
     const hostname = process.env.HOST ?? '0.0.0.0'
 
+    let address: { url?: string } | undefined
     try {
-      app.listen?.({ port, hostname })
+      address = (await app.listen?.({ port, hostname })) as { url?: string } | undefined
     } catch (error) {
       consola.error('Failed to start application listener:', error)
       process.exit(1)
       return
     }
 
-    consola.success(`Development server listening on http://${hostname}:${port}`)
+    // Report where it actually bound. The requested port is not it once the
+    // walk moves past a busy one, or when PORT=0 lets the OS choose. Apps on a
+    // `@guren/server` older than the bound-address return still report nothing,
+    // hence the fallback.
+    consola.success(
+      `Development server listening on ${address?.url ?? `http://${hostname}:${port}`}`,
+    )
   },
 })
 

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -12,7 +12,15 @@ const MAIN_ENTRY_CANDIDATES = [
 ]
 
 export type MaybeApplication = {
-  listen?: (options?: { port?: number; hostname?: string }) => unknown
+  /**
+   * Resolves to the bound address on a current `@guren/server`. The `unknown`
+   * arm is not defensive padding — `guren dev` imports the *user's* app, which
+   * may resolve a version whose `listen()` predates the return value.
+   */
+  listen?: (options?: {
+    port?: number
+    hostname?: string
+  }) => unknown | Promise<{ port: number; hostname: string; url: string } | undefined>
   boot?: () => Promise<void> | void
 }
 

--- a/packages/create-app/templates/api-only/bin/serve.ts
+++ b/packages/create-app/templates/api-only/bin/serve.ts
@@ -7,18 +7,31 @@ try {
   process.exit(1)
 }
 
-const requestedPort = Number.parseInt(process.env.PORT ?? '', 10) || 3333
+// `PORT=0` means "any free port", so this tests for a number, not truthiness.
+const parsedPort = Number.parseInt(process.env.PORT ?? '', 10)
+const requestedPort = Number.isInteger(parsedPort) ? parsedPort : 3333
 const hostname = process.env.HOST ?? '0.0.0.0'
-const isDevelopment = process.env.NODE_ENV !== 'production'
 
-for (let offset = 0; offset < 20; offset += 1) {
+// In development a busy port moves to the next one. Set GUREN_STRICT_PORT=1 to
+// bind the requested port or fail — see the deployment guide.
+const isDevelopment = process.env.NODE_ENV !== 'production'
+const canWalkPorts =
+  isDevelopment && requestedPort !== 0 && process.env.GUREN_STRICT_PORT !== '1'
+const attempts = canWalkPorts ? 20 : 1
+
+// This file owns the retry, so the framework must not retry underneath it —
+// newer framework versions walk inside listen() themselves, and the two loops
+// would nest into a much wider search reported against the wrong ports.
+process.env.GUREN_STRICT_PORT = '1'
+
+for (let offset = 0; offset < attempts; offset += 1) {
   const port = requestedPort + offset
 
   try {
     await app.listen({ port, hostname })
     break
   } catch (error) {
-    if (!isDevelopment || !isAddressInUse(error) || offset === 19) {
+    if (!isAddressInUse(error) || offset === attempts - 1) {
       throw error
     }
 

--- a/packages/create-app/templates/default/bin/serve.ts
+++ b/packages/create-app/templates/default/bin/serve.ts
@@ -7,18 +7,31 @@ try {
   process.exit(1)
 }
 
-const requestedPort = Number.parseInt(process.env.PORT ?? '', 10) || 3333
+// `PORT=0` means "any free port", so this tests for a number, not truthiness.
+const parsedPort = Number.parseInt(process.env.PORT ?? '', 10)
+const requestedPort = Number.isInteger(parsedPort) ? parsedPort : 3333
 const hostname = process.env.HOST ?? '0.0.0.0'
-const isDevelopment = process.env.NODE_ENV !== 'production'
 
-for (let offset = 0; offset < 20; offset += 1) {
+// In development a busy port moves to the next one. Set GUREN_STRICT_PORT=1 to
+// bind the requested port or fail — see the deployment guide.
+const isDevelopment = process.env.NODE_ENV !== 'production'
+const canWalkPorts =
+  isDevelopment && requestedPort !== 0 && process.env.GUREN_STRICT_PORT !== '1'
+const attempts = canWalkPorts ? 20 : 1
+
+// This file owns the retry, so the framework must not retry underneath it —
+// newer framework versions walk inside listen() themselves, and the two loops
+// would nest into a much wider search reported against the wrong ports.
+process.env.GUREN_STRICT_PORT = '1'
+
+for (let offset = 0; offset < attempts; offset += 1) {
   const port = requestedPort + offset
 
   try {
     await app.listen({ port, hostname })
     break
   } catch (error) {
-    if (!isDevelopment || !isAddressInUse(error) || offset === 19) {
+    if (!isAddressInUse(error) || offset === attempts - 1) {
       throw error
     }
 

--- a/packages/create-app/tests/serve-template.test.ts
+++ b/packages/create-app/tests/serve-template.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { createTempWorkspace } from './helpers'
+
+/**
+ * Behavioural coverage for the scaffolded `bin/serve.ts`.
+ *
+ * The file decides which port a generated app binds, and nothing tested it —
+ * which is how `PORT=0` silently became 3333 and how a port walk could hand an
+ * automated run somebody else's server. Asserting the file's *text* would pin
+ * none of that, so each case runs the real template against a stub `src/main.js`
+ * and reads back the ports it actually asked for.
+ */
+
+const templatesDir = fileURLToPath(new URL('../templates', import.meta.url))
+
+const DEFAULT_SERVE = join(templatesDir, 'default/bin/serve.ts')
+const API_ONLY_SERVE = join(templatesDir, 'api-only/bin/serve.ts')
+
+/**
+ * Stands in for a booted app. Records every port `listen()` is asked for and
+ * fails the first `FAIL_TIMES` attempts with the error shape Bun throws for a
+ * taken port — `code: 'EADDRINUSE'`, and a message that never says so.
+ */
+const STUB_MAIN = `
+const failTimes = Number(process.env.FAIL_TIMES ?? 0)
+let attempts = 0
+
+const app = {
+  async listen(options) {
+    attempts += 1
+    console.log('LISTEN ' + options.port)
+
+    if (attempts <= failTimes) {
+      const error = new Error('Failed to start server. Is port ' + options.port + ' in use?')
+      error.code = 'EADDRINUSE'
+      throw error
+    }
+
+    console.log('BOUND ' + options.port)
+  },
+}
+
+export default app
+export const ready = Promise.resolve()
+`
+
+type RunResult = {
+  exitCode: number
+  requestedPorts: number[]
+  boundPort: number | undefined
+  stderr: string
+}
+
+async function runServeTemplate(
+  serveTemplate: string,
+  env: Record<string, string>,
+): Promise<RunResult> {
+  const workspace = await createTempWorkspace('guren-serve-')
+
+  try {
+    await mkdir(join(workspace.dir, 'bin'), { recursive: true })
+    await mkdir(join(workspace.dir, 'src'), { recursive: true })
+    await writeFile(join(workspace.dir, 'src/main.js'), STUB_MAIN)
+    await writeFile(join(workspace.dir, 'bin/serve.ts'), await readFile(serveTemplate, 'utf8'))
+
+    const proc = Bun.spawnSync({
+      cmd: ['bun', 'bin/serve.ts'],
+      cwd: workspace.dir,
+      env: {
+        PATH: process.env.PATH ?? '',
+        HOME: process.env.HOME ?? '',
+        ...env,
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+
+    const stdout = proc.stdout.toString()
+
+    return {
+      exitCode: proc.exitCode ?? 0,
+      requestedPorts: [...stdout.matchAll(/^LISTEN (\d+)$/gmu)].map((match) => Number(match[1])),
+      boundPort: [...stdout.matchAll(/^BOUND (\d+)$/gmu)].map((match) => Number(match[1]))[0],
+      stderr: proc.stderr.toString(),
+    }
+  } finally {
+    await workspace.cleanup()
+  }
+}
+
+describe('scaffolded bin/serve.ts', () => {
+  it('keeps the two starter templates identical', async () => {
+    // The port logic existed in four hand-maintained copies; the two that ship
+    // to users must at least not drift from each other.
+    expect(await readFile(API_ONLY_SERVE, 'utf8')).toBe(await readFile(DEFAULT_SERVE, 'utf8'))
+  })
+
+  it('defaults to port 3333 when PORT is unset', async () => {
+    const result = await runServeTemplate(DEFAULT_SERVE, {})
+
+    expect(result.exitCode).toBe(0)
+    expect(result.requestedPorts).toEqual([3333])
+  })
+
+  it('passes PORT=0 through instead of falling back to 3333', async () => {
+    // `Number.parseInt(...) || 3333` swallowed 0, so "let the OS pick a free
+    // port" was not expressible.
+    const result = await runServeTemplate(DEFAULT_SERVE, { PORT: '0' })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.requestedPorts).toEqual([0])
+    expect(result.boundPort).toBe(0)
+  })
+
+  it('never walks off port 0 into the privileged range', async () => {
+    // A walk from 0 would try 1, 2, 3. There is nothing to recover from
+    // either: the OS was already asked for any free port.
+    const result = await runServeTemplate(DEFAULT_SERVE, { PORT: '0', FAIL_TIMES: '1' })
+
+    expect(result.exitCode).not.toBe(0)
+    expect(result.requestedPorts).toEqual([0])
+  })
+
+  it('walks to the next free port in development', async () => {
+    const result = await runServeTemplate(DEFAULT_SERVE, { PORT: '4000', FAIL_TIMES: '2' })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.requestedPorts).toEqual([4000, 4001, 4002])
+    expect(result.boundPort).toBe(4002)
+    expect(result.stderr).toContain('Port 4000 is in use, trying 4001...')
+  })
+
+  it('fails fast on a busy port when GUREN_STRICT_PORT=1', async () => {
+    const result = await runServeTemplate(DEFAULT_SERVE, {
+      PORT: '4000',
+      FAIL_TIMES: '1',
+      GUREN_STRICT_PORT: '1',
+    })
+
+    expect(result.exitCode).not.toBe(0)
+    // The walk is what makes an automated run silently test the wrong app, so
+    // the strict flag has to stop it at the first attempt.
+    expect(result.requestedPorts).toEqual([4000])
+    expect(result.boundPort).toBeUndefined()
+  })
+
+  it('does not walk in production', async () => {
+    const result = await runServeTemplate(DEFAULT_SERVE, {
+      PORT: '4000',
+      FAIL_TIMES: '1',
+      NODE_ENV: 'production',
+    })
+
+    expect(result.exitCode).not.toBe(0)
+    expect(result.requestedPorts).toEqual([4000])
+  })
+
+  it('still targets a @guren/core that predates listen({ portFallback })', async () => {
+    // The retry loop above duplicates what `Application.listen()` already does.
+    // It stays only because templates resolve `@guren/*` from npm, so they
+    // cannot call a framework option until the release that ships it.
+    //
+    // This pins the exit condition rather than leaving it to a changeset
+    // sentence that `changeset version` deletes — in the very release that
+    // unblocks the migration. `sync:template-deps` rewrites this range at
+    // release time, so when it moves, this fails and says what to do.
+    const templatePkg = JSON.parse(
+      await readFile(join(templatesDir, 'default/package.json'), 'utf8'),
+    ) as { dependencies?: Record<string, string> }
+
+    expect(
+      templatePkg.dependencies?.['@guren/core'],
+      'The template @guren/core range moved, so listen({ portFallback }) is now published. ' +
+        'Replace the retry loop in templates/{default,api-only}/bin/serve.ts with ' +
+        'app.listen({ port, hostname }) and delete this test.',
+    ).toBe('^1.5.2')
+  })
+})

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -18,7 +18,12 @@ import { createSecurityHeaders, type SecurityHeadersOptions } from './middleware
 import { createHostAuthorizationMiddleware, type HostAuthorizationOptions } from './middleware/host-authorization'
 import { isMcpEndpointEnabled } from '../mcp/endpoint'
 import { isDocsViewerEnabled } from '../docs-viewer/endpoint'
-import { logDevServerBanner, type DevBannerOptions } from './dev-banner'
+import {
+  formatHostPort,
+  isWildcardHost,
+  logDevServerBanner,
+  type DevBannerOptions,
+} from './dev-banner'
 import { startViteDevServer, type StartViteDevServerOptions } from './vite-dev-server'
 
 // Bun is only available at runtime. The declaration keeps TypeScript happy while
@@ -36,10 +41,85 @@ declare const Bun:
 type BunServer = {
   stop?: (closeConnections?: boolean) => void | Promise<void>
   requestIP?: (request: Request) => { address?: string } | null
+  port?: number
+  hostname?: string
 }
 type ViteServer = Awaited<ReturnType<typeof startViteDevServer>>['server']
 const MANAGED_VITE_ENV_FLAG = 'GUREN_MANAGED_VITE_DEV_SERVER'
 const DEFAULT_DEV_ENTRY_PATH = '/resources/js/dev-entry.ts'
+
+/**
+ * Opt-in strict port binding.
+ *
+ * Pairs with the `portFallback` option exactly as `GUREN_DEV_VITE=0` pairs
+ * with `vite: false` a few lines below: the env var can only *subtract* the
+ * convenience, never switch it on, so an operator can pin a port from outside
+ * an app whose entrypoint they don't want to edit. That is the case the walk
+ * actively harms — a smoke script, a Playwright `webServer`, a CI job — while
+ * `bun run dev` keeps the convenience by default.
+ *
+ * Spelled `=== '1'` rather than following `GUREN_DEV_*`'s `!== '0'` because a
+ * harness reads more clearly as adding a guarantee than as removing a comfort.
+ * Deliberately not `GUREN_PORT_FALLBACK=0`: that would sit next to `PORT=0`
+ * with two unrelated meanings of zero.
+ */
+const STRICT_PORT_ENV_FLAG = 'GUREN_STRICT_PORT'
+
+/**
+ * Total bind attempts when the walk is enabled — the requested port plus 19
+ * more. Counts *attempts*, not offsets, so it matches the loop in the starter
+ * templates one-for-one; an off-by-one here means a scaffolded app and the
+ * framework give up on different ports.
+ */
+const DEFAULT_PORT_WALK_ATTEMPTS = 20
+
+function isAddressInUse(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      (error as { code?: unknown }).code === 'EADDRINUSE',
+  )
+}
+
+/**
+ * How many ports `listen()` may try in total, counting the requested one.
+ *
+ * `PORT=0` means "let the OS pick a free port", so there is no such thing as
+ * EADDRINUSE to recover from — and walking would march into 1, 2, 3, which are
+ * privileged. The walk is therefore skipped outright for 0 rather than merely
+ * being unreachable.
+ */
+function resolvePortAttempts(option: boolean | undefined, port: number): number {
+  if (port === 0) {
+    return 1
+  }
+
+  if (typeof process !== 'undefined' && process.env?.[STRICT_PORT_ENV_FLAG] === '1') {
+    return 1
+  }
+
+  if (typeof option === 'boolean') {
+    return option ? DEFAULT_PORT_WALK_ATTEMPTS : 1
+  }
+
+  // Unset: convenience while developing, fail fast in production.
+  return typeof process !== 'undefined' && process.env?.NODE_ENV === 'production'
+    ? 1
+    : DEFAULT_PORT_WALK_ATTEMPTS
+}
+
+/**
+ * A wildcard bind is reached through a loopback address of the same family.
+ *
+ * Deliberately not `localhost`: that name resolves to whichever family the
+ * host prefers, so an IPv4-only `0.0.0.0` bind can hand back a URL a client
+ * tries over `::1` and fails to reach.
+ */
+function toConnectableUrl(hostname: string, port: number): string {
+  const host = isWildcardHost(hostname) ? (hostname === '::' ? '::1' : '127.0.0.1') : hostname
+  return `http://${formatHostPort(host, port)}`
+}
 
 function clearManagedViteEnv(): void {
   if (typeof process === 'undefined') {
@@ -224,6 +304,37 @@ export interface ApplicationListenOptions {
   hostname?: string
   assetsUrl?: string
   vite?: StartViteDevServerOptions | false
+  /**
+   * What to do when the requested port is already taken.
+   *
+   * `true` walks forward through the next 20 ports; `false` fails fast with
+   * the original EADDRINUSE. Unset walks outside production, matching the loop
+   * this option replaces.
+   *
+   * `GUREN_STRICT_PORT=1` forces fail-fast regardless, and `port: 0` never
+   * walks — the OS is already picking a free port.
+   */
+  portFallback?: boolean
+}
+
+/**
+ * Where the server actually ended up listening.
+ *
+ * Returned by {@link Application.listen} so callers never have to infer the
+ * port from the port they asked for — with a port walk or `PORT=0` in play,
+ * those are different numbers, and scraping the human-readable dev banner is
+ * the only alternative.
+ */
+export interface ListenAddress {
+  /**
+   * The port the socket is bound to — what the runtime reports, falling back
+   * to the port the successful `Bun.serve` call was made with.
+   */
+  port: number
+  /** The hostname the socket is bound to. */
+  hostname: string
+  /** A URL that reaches the server, with a wildcard bind resolved to localhost. */
+  url: string
 }
 
 /**
@@ -503,7 +614,7 @@ export class Application {
   /**
    * Convenience helper to start a Bun server when available.
    */
-  async listen(options: ApplicationListenOptions = {}): Promise<void> {
+  async listen(options: ApplicationListenOptions = {}): Promise<ListenAddress> {
     if (!Bun) {
       throw new Error('Bun runtime is required to call Application.listen')
     }
@@ -511,7 +622,7 @@ export class Application {
     await stopActiveBunServer()
     await stopActiveViteDevServer()
 
-    const { port = 3000, hostname = '0.0.0.0', assetsUrl, vite } = options
+    const { port = 3000, hostname = '0.0.0.0', assetsUrl, vite, portFallback } = options
     const externalAssetsUrl =
       typeof process !== 'undefined' && process.env?.[MANAGED_VITE_ENV_FLAG] !== '1'
         ? process.env?.VITE_DEV_SERVER_URL
@@ -524,6 +635,9 @@ export class Application {
       process.env?.NODE_ENV !== 'production' &&
       !resolvedAssetsUrl &&
       process.env?.GUREN_DEV_VITE !== '0'
+
+    // Only this call's Vite server is ours to close if the bind fails below.
+    let startedViteHere = false
 
     if (shouldStartVite) {
       const viteOptions: StartViteDevServerOptions | undefined =
@@ -546,20 +660,75 @@ export class Application {
         }
         syncManagedInertiaDevEntry(resolvedAssetsUrl)
         this.registerViteTeardown()
+        startedViteHere = true
       } catch (error) {
         console.error('Failed to start Vite dev server:', error)
         process.exit(1)
       }
     }
 
-    const server = Bun.serve({
-      port,
-      hostname,
-      // `{ server }` is Bun's convention for reaching the live server from a
-      // handler; middleware reads `ctx.env.server.requestIP()` through it to
-      // learn the socket peer (the MCP access guard, the rate limiter).
-      fetch: (request: Request, server: BunServer) => this.fetch(request, { server }),
-    })
+    const attempts = resolvePortAttempts(portFallback, port)
+    let server: BunServer | undefined
+    let attemptPort = port
+
+    for (let offset = 0; offset < attempts; offset += 1) {
+      attemptPort = port + offset
+
+      try {
+        server = Bun.serve({
+          port: attemptPort,
+          hostname,
+          // `{ server }` is Bun's convention for reaching the live server from a
+          // handler; middleware reads `ctx.env.server.requestIP()` through it to
+          // learn the socket peer (the MCP access guard, the rate limiter).
+          fetch: (request: Request, server: BunServer) => this.fetch(request, { server }),
+        })
+        break
+      } catch (error) {
+        if (offset === attempts - 1 || !isAddressInUse(error)) {
+          // Vite was started above, before anything tried to bind. Letting the
+          // throw escape past it strands an asset server and its published env
+          // vars in a process that has no application server — visible to any
+          // caller that handles the rejection instead of exiting, which is
+          // exactly what `GUREN_STRICT_PORT=1` invites callers to do.
+          if (startedViteHere) {
+            await this.closeViteDevServer()
+          }
+
+          throw error
+        }
+
+        console.warn(`[guren] Port ${attemptPort} is in use, trying ${attemptPort + 1}...`)
+      }
+    }
+
+    if (!server) {
+      throw new Error('Bun.serve did not return a server instance')
+    }
+
+    // Prefer what the runtime reports; `attemptPort` is the honest fallback,
+    // because `Bun.serve` returned for exactly that port — unlike the
+    // *requested* port, which a walk has already made wrong.
+    //
+    // `port: 0` is the one case with no fallback: the OS chose, and a stub
+    // that reports nothing leaves the answer genuinely unknowable. Everything
+    // else degrades rather than turning a reporting gap into an outage, since
+    // the socket is already open by this point.
+    let boundPort = server.port
+    if (typeof boundPort !== 'number') {
+      if (port === 0) {
+        // Nothing has registered this socket's teardown yet, so close it here
+        // rather than leaking it for the process lifetime.
+        await server.stop?.(true)
+        throw new Error(
+          'Bun.serve did not report a bound port for `port: 0`. Application.listen cannot report the address it is serving on.',
+        )
+      }
+
+      boundPort = attemptPort
+    }
+
+    const boundHostname = server.hostname ?? hostname
     this.bunServer = server
     setActiveBunServer(server)
     this.registerBunTeardown()
@@ -570,10 +739,16 @@ export class Application {
 
     if (shouldLogBanner) {
       this.logDevServerBanner({
-        hostname,
-        port,
+        hostname: boundHostname,
+        port: boundPort,
         assetsUrl: resolvedAssetsUrl ?? 'http://localhost:5173',
       })
+    }
+
+    return {
+      port: boundPort,
+      hostname: boundHostname,
+      url: toConnectableUrl(boundHostname, boundPort),
     }
   }
 

--- a/packages/server/src/http/dev-banner.ts
+++ b/packages/server/src/http/dev-banner.ts
@@ -30,15 +30,31 @@ export interface DevBannerOptions {
   assetsUrl?: string
 }
 
+/**
+ * A wildcard bind answers on every interface but is not itself dialable on
+ * every platform.
+ *
+ * Lives here rather than beside its other caller because the banner and
+ * `Application.listen()`'s returned address are two renderings of one fact,
+ * and a platform caveat added to only one of them is the drift this replaces.
+ */
+export function isWildcardHost(hostname: string): boolean {
+  return hostname === '0.0.0.0' || hostname === '::'
+}
+
+/** `host:port`, bracketing an IPv6 literal so the result is dialable. */
+export function formatHostPort(hostname: string, port: number): string {
+  return `${hostname.includes(':') ? `[${hostname}]` : hostname}:${port}`
+}
+
 export function logDevServerBanner({
   hostname,
   port,
   assetsUrl = 'http://localhost:5173',
 }: DevBannerOptions): void {
   const localUrl = `http://localhost:${port}`
-  const boundUrl = `http://${hostname}:${port}`
-  const boundLabel =
-    hostname === '0.0.0.0' || hostname === '::' ? ' (all interfaces)' : ''
+  const boundUrl = `http://${formatHostPort(hostname, port)}`
+  const boundLabel = isWildcardHost(hostname) ? ' (all interfaces)' : ''
 
   const header = [
     GUREN_ASCII_ART,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,7 +3,12 @@ import { ensureErrorStackTracePolyfill } from './support/error-polyfill'
 ensureErrorStackTracePolyfill()
 
 export { Application, createApp } from './http/Application'
-export type { Context, ApplicationListenOptions, ServiceProviderConstructor } from './http/Application'
+export type {
+  Context,
+  ApplicationListenOptions,
+  ListenAddress,
+  ServiceProviderConstructor,
+} from './http/Application'
 export { parseRequestPayload, formatValidationErrors } from './http/request'
 export { Controller } from './mvc/Controller'
 export type { InertiaResponse, InferInertiaProps, ControllerInertiaProps, AuthPayload } from './mvc/Controller'

--- a/packages/server/tests/http/application-listen-port.test.ts
+++ b/packages/server/tests/http/application-listen-port.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+
+import { Application } from '../../src/http/Application'
+
+/**
+ * These tests bind real sockets rather than stubbing `Bun.serve`.
+ *
+ * The behaviour under test *is* what happens when a port is genuinely taken —
+ * a stub that throws a hand-made `EADDRINUSE` would pin the framework's
+ * reaction to its own fixture, not to the runtime. Everything here is on
+ * 127.0.0.1 and closed in `afterEach`.
+ */
+
+type StoppableServer = { stop?: (closeConnections?: boolean) => void | Promise<void> }
+
+const openServers: StoppableServer[] = []
+
+function occupyPort(): number {
+  const server = Bun.serve({
+    port: 0,
+    hostname: '127.0.0.1',
+    fetch: () => new Response('occupied'),
+  })
+  openServers.push(server)
+  if (typeof server.port !== 'number') {
+    throw new Error('Bun.serve did not report a port for the occupying server')
+  }
+  return server.port
+}
+
+function occupyExactPort(port: number): StoppableServer {
+  const server = Bun.serve({
+    port,
+    hostname: '127.0.0.1',
+    fetch: () => new Response('occupied'),
+  })
+  openServers.push(server)
+  return server
+}
+
+async function stopServer(server: StoppableServer | undefined): Promise<void> {
+  await server?.stop?.(true)
+}
+
+/**
+ * A base port with `length` consecutive free ports after it.
+ *
+ * Binding the whole run up front and releasing it is the only way to know the
+ * run is free; probing one port at a time would race with whatever else on the
+ * machine is handing out ephemeral ports.
+ */
+function findFreeRun(length: number): number | undefined {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const base = occupyPort()
+    const held: StoppableServer[] = []
+
+    try {
+      for (let offset = 1; offset < length; offset += 1) {
+        held.push(
+          Bun.serve({ port: base + offset, hostname: '127.0.0.1', fetch: () => new Response('') }),
+        )
+      }
+    } catch {
+      held.forEach((server) => server.stop?.(true))
+      continue
+    }
+
+    held.forEach((server) => server.stop?.(true))
+    // `base` itself stays held by `openServers` so nothing reclaims it.
+    return base
+  }
+
+  return undefined
+}
+
+async function listen(
+  app: Application,
+  options: Parameters<Application['listen']>[0],
+): Promise<Awaited<ReturnType<Application['listen']>>> {
+  const address = await app.listen(options)
+  const server = (app as unknown as { bunServer?: StoppableServer }).bunServer
+  if (server) {
+    openServers.push(server)
+  }
+  return address
+}
+
+// Assertions below match on `code`, not the message: Bun's message is
+// "Failed to start server. Is port N in use?" and never says EADDRINUSE, and
+// `code` is what the framework's own `isAddressInUse()` reads.
+const ADDRESS_IN_USE = { code: 'EADDRINUSE' }
+
+afterEach(async () => {
+  delete process.env.GUREN_STRICT_PORT
+  while (openServers.length > 0) {
+    const server = openServers.pop()
+    await server?.stop?.(true)
+  }
+})
+
+describe('Application.listen port binding', () => {
+  it('reports the port it actually bound, not the one that was requested', async () => {
+    const app = new Application()
+    const requested = occupyPort()
+
+    const address = await listen(app, {
+      port: requested,
+      hostname: '127.0.0.1',
+      vite: false,
+      portFallback: true,
+    })
+
+    expect(address.port).not.toBe(requested)
+    expect(address.port).toBeGreaterThan(requested)
+    expect(address.port).toBeLessThanOrEqual(requested + 20)
+    expect(address.url).toBe(`http://127.0.0.1:${address.port}`)
+
+    // The returned address is the one that answers — the whole point of
+    // returning it is that a caller can use it without guessing.
+    const response = await fetch(`${address.url}/__does-not-exist`)
+    expect(response.status).toBe(404)
+  })
+
+  it('gives up after exactly 20 ports, matching the scaffolded loop', async () => {
+    // The `<= requested + 20` assertion above cannot tell 20 attempts from 21.
+    // The boundary needs its own case: a scaffolded app and the framework must
+    // give up on the same port, or the two disagree about when a range is
+    // exhausted — and the scaffolded loop is the behaviour being preserved.
+    const base = findFreeRun(20)
+    if (base === undefined) {
+      throw new Error('No run of 20 consecutive free ports available to test the boundary')
+    }
+
+    // `findFreeRun` already holds `base`; add base+1 .. base+18 so 19 of the
+    // 20 attempts are busy and base+19 is the 20th and final one.
+    for (let offset = 1; offset <= 18; offset += 1) {
+      occupyExactPort(base + offset)
+    }
+
+    const address = await listen(new Application(), {
+      port: base,
+      hostname: '127.0.0.1',
+      vite: false,
+      portFallback: true,
+    })
+    expect(address.port).toBe(base + 19)
+
+    // Hand base+19 to a blocker too: all 20 attempts are now busy, and the
+    // walk must run out rather than reach base + 20.
+    await stopServer(openServers.pop())
+    occupyExactPort(base + 19)
+
+    await expect(
+      listen(new Application(), {
+        port: base,
+        hostname: '127.0.0.1',
+        vite: false,
+        portFallback: true,
+      }),
+    ).rejects.toMatchObject(ADDRESS_IN_USE)
+  })
+
+  it('resolves an OS-assigned port when asked for port 0', async () => {
+    const app = new Application()
+
+    const address = await listen(app, { port: 0, hostname: '127.0.0.1', vite: false })
+
+    expect(address.port).toBeGreaterThan(0)
+    const response = await fetch(`${address.url}/__does-not-exist`)
+    expect(response.status).toBe(404)
+  })
+
+  it('fails fast with EADDRINUSE when GUREN_STRICT_PORT=1', async () => {
+    const app = new Application()
+    const requested = occupyPort()
+    process.env.GUREN_STRICT_PORT = '1'
+
+    const attempt = listen(app, {
+      port: requested,
+      hostname: '127.0.0.1',
+      vite: false,
+      // Even an explicit opt-in to the walk loses to the strict flag: an
+      // automated consumer pins the port from the outside, without editing
+      // the app's entrypoint.
+      portFallback: true,
+    })
+
+    await expect(attempt).rejects.toMatchObject(ADDRESS_IN_USE)
+  })
+
+  it('fails fast with EADDRINUSE when the walk is disabled', async () => {
+    const app = new Application()
+    const requested = occupyPort()
+
+    const attempt = listen(app, {
+      port: requested,
+      hostname: '127.0.0.1',
+      vite: false,
+      portFallback: false,
+    })
+
+    await expect(attempt).rejects.toMatchObject(ADDRESS_IN_USE)
+  })
+
+  it('logs the bound port in the dev banner after a walk', async () => {
+    const app = new Application()
+    const requested = occupyPort()
+
+    const originalLog = console.log
+    const originalWarn = console.warn
+    const logs: string[] = []
+    const warnings: string[] = []
+    console.log = (...args: unknown[]) => {
+      logs.push(args.join(' '))
+    }
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.join(' '))
+    }
+
+    const originalNodeEnv = process.env.NODE_ENV
+    try {
+      delete process.env.GUREN_DEV_BANNER
+      // The banner is suppressed in production, so an inherited
+      // NODE_ENV=production would fail this on correct behaviour.
+      process.env.NODE_ENV = 'development'
+      const address = await listen(app, {
+        port: requested,
+        hostname: '127.0.0.1',
+        vite: false,
+        portFallback: true,
+      })
+
+      const banner = logs.join('\n')
+      expect(banner).toContain(String(address.port))
+      // The requested port is busy; printing it would send the developer to
+      // somebody else's server.
+      expect(banner).not.toContain(String(requested))
+      expect(warnings.join('\n')).toContain(`Port ${requested} is in use`)
+    } finally {
+      console.log = originalLog
+      console.warn = originalWarn
+      if (originalNodeEnv === undefined) {
+        delete process.env.NODE_ENV
+      } else {
+        process.env.NODE_ENV = originalNodeEnv
+      }
+    }
+  })
+})

--- a/packages/server/tests/http/application-listen.test.ts
+++ b/packages/server/tests/http/application-listen.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
+const viteCloseMock = mock(async () => {})
+
 const startViteDevServerMock = mock(async () => ({
   server: {
-    close: mock(async () => {}),
+    close: viteCloseMock,
   },
   localUrl: 'http://localhost:5174',
   networkUrls: [],
@@ -23,6 +25,7 @@ describe('Application.listen', () => {
     process.env.NODE_ENV = 'development'
     process.env.GUREN_DEV_BANNER = '0'
     startViteDevServerMock.mockClear()
+    viteCloseMock.mockClear()
   })
 
   afterEach(() => {
@@ -31,6 +34,8 @@ describe('Application.listen', () => {
   })
 
   it('restarts the managed Vite dev server after a watch reload', async () => {
+    // Deliberately reports no `port`: a stub that predates the bound-address
+    // return must keep working, so listen() falls back to the port it bound.
     const serveMock = mock(() => ({ stop: mock(async () => {}) }))
     Bun.serve = serveMock as unknown as typeof Bun.serve
 
@@ -46,5 +51,35 @@ describe('Application.listen', () => {
     expect(process.env.GUREN_MANAGED_VITE_DEV_SERVER).toBe('1')
     expect(process.env.GUREN_INERTIA_ENTRY).toBe('http://localhost:5174/resources/js/dev-entry.ts')
     expect(serveMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('shuts the managed Vite dev server down when the bind fails', async () => {
+    // Vite is started before anything tries to bind, so a bind that throws
+    // past it would strand an asset server and its published env vars in a
+    // process with no application server. `GUREN_STRICT_PORT=1` makes that the
+    // expected path for automated callers, which handle the rejection rather
+    // than exiting.
+    const addressInUse = Object.assign(new Error('Failed to start server.'), {
+      code: 'EADDRINUSE',
+    })
+    Bun.serve = mock(() => {
+      throw addressInUse
+    }) as unknown as typeof Bun.serve
+
+    process.env.GUREN_STRICT_PORT = '1'
+
+    const app = new Application()
+    await expect(app.listen({ port: 3333, hostname: '127.0.0.1' })).rejects.toMatchObject({
+      code: 'EADDRINUSE',
+    })
+
+    expect(startViteDevServerMock).toHaveBeenCalledTimes(1)
+    expect(viteCloseMock).toHaveBeenCalled()
+    // The discriminating assertions: `listen()` also closes a *previous*
+    // server on the way in, so the call count alone proves nothing. These env
+    // vars were published by this call's Vite start, and only this call's
+    // teardown clears them.
+    expect(process.env.VITE_DEV_SERVER_URL).toBeUndefined()
+    expect(process.env.GUREN_MANAGED_VITE_DEV_SERVER).toBeUndefined()
   })
 })

--- a/web/bin/serve.ts
+++ b/web/bin/serve.ts
@@ -7,30 +7,13 @@ try {
   process.exit(1)
 }
 
-const requestedPort = Number.parseInt(process.env.PORT ?? '', 10) || 3333
+// `PORT=0` means "any free port", so this tests for a number, not truthiness.
+const parsedPort = Number.parseInt(process.env.PORT ?? '', 10)
+const port = Number.isInteger(parsedPort) ? parsedPort : 3333
 const hostname = process.env.HOST ?? '0.0.0.0'
-const isDevelopment = process.env.NODE_ENV !== 'production'
 
-for (let offset = 0; offset < 20; offset += 1) {
-  const port = requestedPort + offset
-
-  try {
-    await app.listen({ port, hostname })
-    break
-  } catch (error) {
-    if (!isDevelopment || !isAddressInUse(error) || offset === 19) {
-      throw error
-    }
-
-    console.warn(`Port ${port} is in use, trying ${port + 1}...`)
-  }
-}
-
-function isAddressInUse(error: unknown): boolean {
-  return Boolean(
-    error &&
-      typeof error === 'object' &&
-      'code' in error &&
-      (error as { code?: unknown }).code === 'EADDRINUSE',
-  )
-}
+// The walk past a busy port lives in listen() now, which is also the only
+// place that can report which port it ended up on. Set GUREN_STRICT_PORT=1 to
+// fail fast instead — what an automated consumer wants when it has to know
+// the app under test is the one answering.
+await app.listen({ port, hostname })


### PR DESCRIPTION
## Summary

`Application.listen()` called `Bun.serve({ port, hostname })` and discarded `server.port`, returning `Promise<void>`. The framework knew which port it had bound and threw it away — which is why #367 had to recover it by parsing the ANSI-coloured dev banner. `listen()` now resolves to `{ port, hostname, url }`, read off the running server.

That matters because the requested port and the bound port are routinely different numbers. The EADDRINUSE walk lived in **four copies of application code** (both starter templates, the blog example, the docs site), each wrapping the framework call that should have owned it, and none of them could report where the app ended up.

The walk now lives in `listen()` behind a `portFallback` option, and `GUREN_STRICT_PORT=1` forces fail-fast from outside the app — for consumers that pin a port and *cannot* adapt to a different one. `PORT=0` is honoured too; `|| 3333` used to coerce it away, so "let the OS pick a free port" could not be expressed.

Moving the walk inside also makes a retry ~600ms cheaper: it used to re-enter `listen()` and restart the managed Vite dev server on every busy port (measured on `examples/blog`: ~557ms warm Vite start vs ~0.5ms per in-`listen()` attempt).

**Relationship to #367:** that PR fixed the same hazard at the harness, by reading the bound port instead of assuming it. This PR fixes it at the source, so the port is a return value rather than something to parse out of human-readable output. The two are complementary and #367's approach is kept as-is — **`scripts/smoke-golden-path.sh` is untouched by this branch.** An earlier revision of this PR set `GUREN_STRICT_PORT=1` there; that was dropped on rebase because #367 is better for that caller: a busy port makes it address the app it actually started, where the strict flag would just fail the run.

**Two bugs found while reviewing this change are fixed here as well:**
- A bind that gives up now shuts down the Vite dev server it started. `listen()` starts Vite *before* anything tries to bind, so an exhausted walk — or a strict-port failure, which is exactly the case automated callers *handle* rather than exit on — left an asset server and its published env vars running in a process with no application server.
- The framework tried **21** ports where the loop it replaces tried **20**, so a scaffolded app and the framework disagreed about when a range was exhausted.

## Scope

`server`, `cli`, `create-app` (templates), `examples`, `web`, `docs` (en + ja), Playwright config.

Three changesets: `@guren/server` minor (API addition), `create-guren-app` patch (template behaviour), `@guren/cli` patch (`guren dev`).

## Risk Assessment

1. **`examples/blog/playwright.config.ts` no longer reuses an existing server**, and pins the port. Unlike the smoke, Playwright's `baseURL` is a fixed `http://localhost:3333` and cannot follow a walked port, so failing to bind is the only safe outcome. `reuseExistingServer: !isCI` separately meant a local run attached to whatever was already on 3333 and reported it as this branch's result. This is a real local DX cost — `bun run dev` must be stopped before running E2E — taken deliberately, and the two guarantees are commented separately.
2. **`examples/api` keeps its previous fail-fast behaviour explicitly** via `portFallback: false`. It never had a retry loop, and its OpenAPI document advertises `http://localhost:3334`, so binding 3335 would hand clients a URL that answers nothing.
3. **`listen()` returning a value instead of `void` is source-compatible** for every caller in the repo (all either ignore or consume it). An external consumer that explicitly typed the method as `Promise<void>` could be affected.
4. **`ListenAddress.port` prefers what the runtime reports and falls back to the port the successful `Bun.serve` call was made with.** It throws only for `port: 0`, where there is genuinely no fallback. This keeps existing `Bun.serve` stubs working rather than turning a reporting gap into an outage after the socket is already open.
5. **Templates deliberately keep their own retry loop** — they resolve `@guren/*` from npm and cannot call a `listen()` option added in the same release (see `.claude/rules/common-pitfalls.md`, "Templates vs. Published Packages"). To stop the two loops nesting once the new server ships (a caret range floats a scaffolded app onto it with no template change), the entrypoint sets `GUREN_STRICT_PORT=1` for itself after reading it. A test pins the template's `@guren/core` range so the deferred migration fails loudly at the release that unblocks it, rather than living only in a changeset the release deletes.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck` (root — covers cross-package resolution, plus blog/api)
- [x] `bun run test` — 4044 pass, 0 fail (4099 across 243 files)
- [x] `bun run audit:starter-template`, `audit:core-first`, `audit:docs`, `audit:template-deps`, `audit:plugin-compat`, `audit:contracts`, `audit:workspace-scripts`
- [x] `bun run smoke:golden-path` — **PASSED**
- [x] `bun run smoke:starter`, `bun run smoke:starter:api`

All run after the rebase onto `main`.

`smoke:golden-path` could not complete on macOS when this PR was opened — it hung in a `cat` heredoc before any application code ran, reproducibly on unmodified `main` too. #368 replaced those heredocs with fixture files, so the full golden path now runs end to end on this branch.

New tests, each verified by mutation (removing the protection turns them red):
- `packages/server/tests/http/application-listen-port.test.ts` — binds real sockets: bound-port reporting, `PORT=0`, strict-port and `portFallback: false` fail-fast, the exact 20-port boundary, and the banner printing the bound port.
- `packages/create-app/tests/serve-template.test.ts` — runs the real template `bin/serve.ts` against a stub app and asserts the ports it actually requests.
- `application-listen.test.ts` — the Vite teardown on bind failure.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation (en + ja: architecture and deployment guides).
