### PR TITLE
fix(orm): apply global scopes to soft delete, restore, and force delete

### DIFF
--- a/.changeset/orm-soft-delete-scopes-reach-writes.md
+++ b/.changeset/orm-soft-delete-scopes-reach-writes.md
@@ -1,0 +1,44 @@
+---
+'@guren/orm': patch
+---
+
+Apply global scopes to `SoftDeletes`' `delete()`, `restore()`, and `forceDelete()`
+
+The companion to the fix for the static write shortcuts: the `SoftDeletes` mixin
+overrides all three, and each forwarded the caller's `where` straight to the
+adapter, dropping every global scope. On a multi-tenant app with a `tenant`
+scope, `delete()` soft-deleted, `restore()` un-deleted, and `forceDelete()`
+*permanently* removed another tenant's row — the sharpest of the three, since a
+hard delete cannot be undone. `withTrashed()` and `onlyTrashed()` had the mirror
+of the same bug: they dropped every scope to escape the soft-delete filter, so
+they returned other tenants' trashed rows.
+
+The three writes now run through the scope-applying builder. `delete()` uses the
+full scope set, so it marks only a live row the current scopes can see;
+`restore()` and `forceDelete()` drop the `softDelete` scope alone, reaching
+trashed rows while a tenant scope keeps them in bounds. `withTrashed()` /
+`onlyTrashed()` do the same, which makes the documented equivalence between
+`withTrashed()` and `withoutGlobalScope('softDelete')` literally true for the
+first time.
+
+Two supporting changes made that possible:
+
+- The mixin no longer registers its filter as `defaultScope` in addition to the
+  named `'softDelete'` scope. `withoutGlobalScope()` re-applies `defaultScope`,
+  so the double registration made the filter unremovable by name. `defaultScope`
+  is therefore gone from the `SoftDeletesStatic` type (re-exported from
+  `@guren/core`); reading `Post.defaultScope` still compiles through `Model`'s
+  own optional declaration, but calling it unguarded no longer does.
+- A subclass that registers its own scope now seeds its registry from the
+  inherited one instead of starting empty. Without this,
+  `class Post extends SoftDeletes(Base)` followed by
+  `Post.addGlobalScope('tenant')` silently dropped the inherited `softDelete`
+  filter — masked until now by the `defaultScope` registration above. The copy
+  is a snapshot: scopes added to a parent after a subclass first registers or
+  removes one do not propagate.
+
+Two visible behavior changes: `Post.delete({ id })` on an already-trashed row is
+now a no-op rather than refreshing `deletedAt`, since the soft-delete scope
+excludes it; and `withTrashed()` / `onlyTrashed()` no longer return rows that
+other global scopes exclude. The mixin's `delete` override still bypasses the
+`deleting` / `deleted` hooks, exactly as before.

--- a/docs/en/guides/database.md
+++ b/docs/en/guides/database.md
@@ -489,7 +489,7 @@ User.removeGlobalScope('active')
 ```
 
 > [!TIP]
-> The `SoftDeletes` mixin registers a global scope named `'softDelete'`. You can bypass it with `withoutGlobalScope('softDelete')` instead of `withTrashed()` if you prefer.
+> The `SoftDeletes` mixin registers a global scope named `'softDelete'`. `withTrashed()` *is* `withoutGlobalScope('softDelete')` — either spelling reaches trashed rows while every other global scope stays applied, so a `tenant` scope keeps isolating them. `withoutGlobalScopes()` is the one that drops those too.
 
 ## Model Hooks
 
@@ -567,13 +567,21 @@ export class Post extends SoftDeletes(defineModel(posts)) {}
 ```
 
 ```ts
-await Post.delete({ id: 1 })                // Sets deletedAt (row remains)
+await Post.delete({ id: 1 })                // Sets deletedAt on a live row (the row remains)
 const active = await Post.all()              // Excludes soft-deleted
 const all = await Post.withTrashed().get()   // Includes soft-deleted
 const trashed = await Post.onlyTrashed().get()
 await Post.restore({ id: 1 })               // Clears deletedAt
 await Post.forceDelete({ id: 1 })           // Permanent removal
 ```
+
+Every one of these honors the model's *other* global scopes. `delete()` marks
+only a live row the current scopes can see — on an already-trashed row it
+matches nothing and leaves the original `deletedAt` alone. `restore()` and
+`forceDelete()` drop
+the `softDelete` filter so they reach trashed rows, and keep the rest — a
+`tenant` scope still stops a force delete, which cannot be undone, from reaching
+another tenant's row.
 
 > [!TIP]
 > Your schema must include a `deletedAt` timestamp column for soft deletes to work.

--- a/docs/ja/guides/database.md
+++ b/docs/ja/guides/database.md
@@ -449,7 +449,7 @@ User.removeGlobalScope('active')
 ```
 
 > [!TIP]
-> `SoftDeletes` ミックスインは `'softDelete'` という名前のグローバルスコープを登録します。`withTrashed()` の代わりに `withoutGlobalScope('softDelete')` でも同じ結果が得られます。
+> `SoftDeletes` ミックスインは `'softDelete'` という名前のグローバルスコープを登録します。`withTrashed()` は `withoutGlobalScope('softDelete')` そのものであり、どちらの書き方でも削除済みレコードに到達しつつ、他のグローバルスコープはそのまま適用されます。つまり `tenant` スコープによる分離は維持されます。それも含めてすべて外すのは `withoutGlobalScopes()` だけです。
 
 ## モデルフック
 
@@ -546,7 +546,7 @@ export class Post extends SoftDeletes(defineModel(posts)) {}
 ### ソフトデリートの操作
 
 ```ts
-// ソフトデリート - deletedAt を設定し、行は削除しない
+// ソフトデリート - 未削除の行に deletedAt を設定する（行自体は削除しない）
 await Post.delete({ id: 1 })
 
 // 削除されていないレコードのみ取得（デフォルトの動作）
@@ -564,6 +564,13 @@ await Post.restore({ id: 1 })
 // 完全に削除（ソフトデリートをバイパス）
 await Post.forceDelete({ id: 1 })
 ```
+
+これらはいずれもモデルの「他の」グローバルスコープを尊重します。`delete()` が
+`deletedAt` を設定するのは、現在のスコープから見える未削除の行だけです。すでに削除済みの
+行に対しては何にもマッチせず、元の `deletedAt` はそのまま残ります。`restore()` と
+`forceDelete()` は削除済みレコードに到達するために `softDelete` フィルタだけを外し、
+残りのスコープは維持します。したがって `tenant` スコープがあれば、取り消しのきかない
+`forceDelete()` が別テナントの行に届くことはありません。
 
 ## 属性キャスト
 

--- a/packages/orm/src/GlobalScopeRegistry.ts
+++ b/packages/orm/src/GlobalScopeRegistry.ts
@@ -42,6 +42,22 @@ export class GlobalScopeRegistry {
     this.scopes.clear()
   }
 
+  /**
+   * Copy this registry's entries into a new one.
+   *
+   * A subclass that registers its own scope needs a registry of its own, but it
+   * must keep the ones it inherited: starting from empty is how a model that
+   * mixes in `SoftDeletes` and then adds a `tenant` scope silently loses the
+   * `softDelete` filter.
+   */
+  clone(): GlobalScopeRegistry {
+    const copy = new GlobalScopeRegistry()
+    for (const [name, fn] of this.scopes) {
+      copy.add(name, fn)
+    }
+    return copy
+  }
+
   get size(): number {
     return this.scopes.size
   }

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -502,9 +502,26 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
   // ---------------------------------------------------------------------------
   // ---------------------------------------------------------------------------
 
+  /**
+   * The registry this class may mutate, creating it on first write.
+   *
+   * The new registry is seeded from the inherited one: the read paths
+   * (`newQuery()`, `hasScopes()`) resolve `globalScopeRegistry` through the
+   * prototype chain, so a subclass that started from an empty registry would
+   * shadow — and silently drop — every scope it inherited. That is exactly the
+   * `class Post extends SoftDeletes(Base)` then `Post.addGlobalScope('tenant')`
+   * case, which would otherwise lose the `softDelete` filter.
+   *
+   * The copy is a snapshot: scopes added to the parent *after* a subclass first
+   * registers or removes one do not reach that subclass. Nothing in the
+   * framework relies on later propagation — the `SoftDeletes` mixin registers
+   * `softDelete` synchronously while building the class, before any user code
+   * can touch it.
+   */
   protected static getGlobalScopes(): GlobalScopeRegistry {
     if (!Object.prototype.hasOwnProperty.call(this, 'globalScopeRegistry') || !this.globalScopeRegistry) {
-      this.globalScopeRegistry = new GlobalScopeRegistry()
+      const inherited = this.globalScopeRegistry
+      this.globalScopeRegistry = inherited ? inherited.clone() : new GlobalScopeRegistry()
     }
     return this.globalScopeRegistry
   }
@@ -526,6 +543,12 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
 
   /**
    * Start a query excluding specific global scope(s).
+   *
+   * Only *named* scopes can be excluded: `defaultScope` is re-applied here
+   * whatever this is asked to drop. A mixin whose filter users must be able to
+   * opt out of therefore has to register a named scope and nothing else —
+   * registering as both makes the filter unremovable, which is how `SoftDeletes`
+   * once made `withoutGlobalScope('softDelete')` a no-op.
    *
    * @example
    * const all = await User.withoutGlobalScope('active').get()

--- a/packages/orm/src/SoftDeletes.ts
+++ b/packages/orm/src/SoftDeletes.ts
@@ -1,5 +1,5 @@
 import type { Model, PlainObject } from './Model'
-import type { QueryBuilder } from './QueryBuilder'
+import { PREPARED_UPDATE, type QueryBuilder } from './QueryBuilder'
 
 /**
  * Interface describing the static methods added by the SoftDeletes mixin.
@@ -7,8 +7,6 @@ import type { QueryBuilder } from './QueryBuilder'
 export interface SoftDeletesStatic {
   /** Column name used for tracking soft deletion timestamp. */
   deletedAtColumn: string
-  /** Default scope that excludes soft-deleted records. */
-  defaultScope: (q: QueryBuilder<any>) => QueryBuilder<any> // eslint-disable-line @typescript-eslint/no-explicit-any
   /** Start a query that includes soft-deleted records. */
   withTrashed(): QueryBuilder<PlainObject>
   /** Start a query that returns only soft-deleted records. */
@@ -17,6 +15,20 @@ export interface SoftDeletesStatic {
   restore(where: Partial<Record<string, unknown>>): Promise<PlainObject>
   /** Permanently delete records from the database, bypassing soft delete. */
   forceDelete(where: Partial<Record<string, unknown>>): Promise<number | PlainObject | void>
+}
+
+/** A query carrying every global scope this model has, including softDelete. */
+function scopedQuery(model: typeof Model, where: Partial<Record<string, unknown>>): QueryBuilder<PlainObject> {
+  return (model.newQuery() as QueryBuilder<PlainObject>).where(where)
+}
+
+/** A query carrying every global scope *except* softDelete, so it sees trashed rows. */
+function withoutSoftDeleteScope(model: typeof Model): QueryBuilder<PlainObject> {
+  return model.withoutGlobalScope('softDelete') as QueryBuilder<PlainObject>
+}
+
+function trashedScopedQuery(model: typeof Model, where: Partial<Record<string, unknown>>): QueryBuilder<PlainObject> {
+  return withoutSoftDeleteScope(model).where(where)
 }
 
 /**
@@ -52,9 +64,12 @@ export function SoftDeletes<TBase extends typeof Model>(Base: TBase): TBase & So
 
   SoftDeleteModel.deletedAtColumn = 'deletedAt'
 
-  // Register as both defaultScope (backward compat) and named global scope
+  // Registered only as a *named* global scope, never as `defaultScope`.
+  // `withoutGlobalScope('softDelete')` keeps applying `defaultScope`, so a
+  // double registration would make the filter unremovable — and `restore()` /
+  // `forceDelete()` have to reach trashed rows while every *other* global scope
+  // (a tenant filter, say) stays on.
   const scopeFn = (q: QueryBuilder<any>) => q.whereNull('deletedAt') // eslint-disable-line @typescript-eslint/no-explicit-any
-  SoftDeleteModel.defaultScope = scopeFn
   ;(SoftDeleteModel as unknown as typeof Model).addGlobalScope('softDelete', scopeFn)
 
   // Override delete to do a soft delete (set deletedAt)
@@ -66,19 +81,22 @@ export function SoftDeletes<TBase extends typeof Model>(Base: TBase): TBase & So
     if (!adapter.update) {
       throw new Error('Configured adapter does not support update operations (needed for soft delete).')
     }
-    const table = this.resolveTable()
     const column = (this as unknown as SoftDeletesStatic).deletedAtColumn
-    return adapter.update(table, where, { [column]: new Date() }) as Promise<PlainObject>
+    // Through the scoped builder, not straight to the adapter: the caller's
+    // `where` alone ignores every global scope, so one tenant could soft-delete
+    // another tenant's row. `newQuery()` also carries the softDelete filter, so
+    // only a live row is marked. The payload is written as-is, as before —
+    // the prepared-payload terminal skips mutators and casts.
+    return scopedQuery(this, where)[PREPARED_UPDATE]({ [column]: new Date() })
   } as typeof Model.delete
 
   SoftDeleteModel.withTrashed = function (this: typeof Model): QueryBuilder<PlainObject> {
-    return (this as unknown as { withoutGlobalScopes(): QueryBuilder<PlainObject> }).withoutGlobalScopes()
+    return withoutSoftDeleteScope(this)
   }
 
   SoftDeleteModel.onlyTrashed = function (this: typeof Model): QueryBuilder<PlainObject> {
     const column = (this as unknown as SoftDeletesStatic).deletedAtColumn
-    return (this as unknown as { withoutGlobalScopes(): QueryBuilder<PlainObject> }).withoutGlobalScopes()
-      .whereNotNull(column)
+    return withoutSoftDeleteScope(this).whereNotNull(column)
   }
 
   SoftDeleteModel.restore = async function (
@@ -89,9 +107,10 @@ export function SoftDeletes<TBase extends typeof Model>(Base: TBase): TBase & So
     if (!adapter.update) {
       throw new Error('Configured adapter does not support update operations (needed for restore).')
     }
-    const table = this.resolveTable()
     const column = (this as unknown as SoftDeletesStatic).deletedAtColumn
-    return adapter.update(table, where, { [column]: null }) as Promise<PlainObject>
+    // Drops only the softDelete filter, so this reaches a trashed row while a
+    // tenant scope still stops it from un-deleting somebody else's.
+    return trashedScopedQuery(this, where)[PREPARED_UPDATE]({ [column]: null })
   }
 
   SoftDeleteModel.forceDelete = async function (
@@ -102,8 +121,10 @@ export function SoftDeletes<TBase extends typeof Model>(Base: TBase): TBase & So
     if (!adapter.delete) {
       throw new Error('Configured adapter does not support delete operations.')
     }
-    const table = this.resolveTable()
-    return adapter.delete(table, where)
+    // The sharpest of the three: an unscoped hard delete is unrecoverable, so
+    // the tenant scope has to survive. Only the softDelete filter is dropped,
+    // which is what lets a force delete reach trashed rows as well as live ones.
+    return trashedScopedQuery(this, where).delete()
   }
 
   return SoftDeleteModel

--- a/packages/orm/tests/model.query.types.ts
+++ b/packages/orm/tests/model.query.types.ts
@@ -284,3 +284,16 @@ async function _softDeletesPreservesInference() {
   }
 }
 void _softDeletesPreservesInference
+
+// The mixin registers its filter as a *named* global scope only: a second
+// registration as `defaultScope` would make it unremovable, because
+// `withoutGlobalScope()` re-applies `defaultScope` whatever it was asked to
+// drop. This pins the type half — the property survives only as `Model`'s
+// optional declaration, so calling it unguarded is an error, and putting it back
+// on `SoftDeletesStatic` makes this directive unused. The runtime half is pinned
+// behaviorally in tests/soft-deletes.test.ts.
+function _softDeleteScopeIsNotADefaultScope() {
+  // @ts-expect-error defaultScope is not registered by the SoftDeletes mixin
+  SoftAccount.defaultScope({} as never)
+}
+void _softDeleteScopeIsNotADefaultScope

--- a/packages/orm/tests/soft-deletes.test.ts
+++ b/packages/orm/tests/soft-deletes.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  Model,
+  type FindManyOptions,
+  type ORMAdapter,
+  type PlainObject,
+  type WhereClause,
+} from '../src/Model'
+import { SoftDeletes } from '../src/SoftDeletes'
+import type { WhereCondition } from '../src/QueryBuilder'
+
+/**
+ * Soft deletes on a multi-tenant model.
+ *
+ * The mixin's three write entry points used to hand the caller's `where`
+ * straight to the adapter, so every global scope the model carried was dropped:
+ * `delete()` soft-deleted, `restore()` un-deleted, and `forceDelete()`
+ * *permanently* removed rows belonging to another tenant. The read helpers had
+ * the mirror-image bug — `withTrashed()` / `onlyTrashed()` dropped every scope
+ * to escape the softDelete filter, and returned other tenants' trashed rows.
+ */
+
+type PostRecord = {
+  id: number
+  title: string
+  tenantId: number
+  deletedAt: Date | null
+}
+
+// Rows carry an explicit `deletedAt: null` because the soft-delete write path
+// matches on it (`deletedAt IS NULL`), and an absent field is not the same as a
+// null one for a strict matcher.
+const SEED: PostRecord[] = [
+  { id: 1, title: 'ours-live', tenantId: 1, deletedAt: null },
+  { id: 2, title: 'ours-trashed', tenantId: 1, deletedAt: new Date('2020-01-01') },
+  { id: 3, title: 'theirs-live', tenantId: 2, deletedAt: null },
+  { id: 4, title: 'theirs-trashed', tenantId: 2, deletedAt: new Date('2020-01-01') },
+]
+
+function matchesSimple(record: PlainObject, where: PlainObject): boolean {
+  return Object.entries(where).every(([k, v]) => {
+    if (Array.isArray(v)) return v.includes(record[k])
+    if (v === null) return record[k] == null
+    return record[k] === v
+  })
+}
+
+function matchesConditions(record: PlainObject, conditions: WhereCondition[]): boolean {
+  return conditions.every((condition) => {
+    if (condition.type !== 'simple') {
+      throw new Error('test adapter only models simple conditions')
+    }
+    const actual = record[condition.field]
+    switch (condition.operator) {
+      case '=':
+        return actual === condition.value
+      case 'is null':
+        return actual == null
+      case 'is not null':
+        return actual != null
+      case 'in':
+        return (condition.value as unknown[]).includes(actual)
+      default:
+        throw new Error(`test adapter does not model operator ${condition.operator}`)
+    }
+  })
+}
+
+/**
+ * Reads go through `findManyAdvanced` because `onlyTrashed()`'s `IS NOT NULL`
+ * cannot survive the simple-where conversion. Writes deliberately have no
+ * `updateAdvanced` / `deleteAdvanced`, so they exercise the
+ * `toSimpleWhereClause()` fallback — the shipped Drizzle adapter implements the
+ * advanced pair and produces the same shape from the same conditions.
+ */
+function createAdapter(store: PostRecord[]): ORMAdapter {
+  return {
+    async findMany<T extends PlainObject>(_table: unknown, options?: FindManyOptions<T>): Promise<T[]> {
+      const where = options?.where as PlainObject | undefined
+      const rows = where ? store.filter((r) => matchesSimple(r, where)) : [...store]
+      return rows.map((r) => ({ ...r })) as unknown as T[]
+    },
+    async findManyAdvanced<T extends PlainObject>(_table: unknown, conditions: WhereCondition[]): Promise<T[]> {
+      return store.filter((r) => matchesConditions(r, conditions)).map((r) => ({ ...r })) as unknown as T[]
+    },
+    async findUnique<T extends PlainObject>(_table: unknown, where: WhereClause<T>): Promise<T | null> {
+      const record = store.find((r) => matchesSimple(r, where as PlainObject))
+      return (record ? { ...record } : null) as unknown as T | null
+    },
+    async create<T extends PlainObject>(_table: unknown, data: PlainObject): Promise<T> {
+      const record = { ...data, id: store.length + 1 } as unknown as PostRecord
+      store.push(record)
+      return { ...record } as unknown as T
+    },
+    async update<T extends PlainObject>(_table: unknown, where: WhereClause<T>, data: PlainObject): Promise<T> {
+      const record = store.find((r) => matchesSimple(r, where as PlainObject))
+      // A no-match write must not silently look like a success.
+      if (!record) throw new Error('Not found')
+      Object.assign(record, data)
+      return { ...record } as unknown as T
+    },
+    async delete<T extends PlainObject>(_table: unknown, where: WhereClause<T>): Promise<number> {
+      const idx = store.findIndex((r) => matchesSimple(r, where as PlainObject))
+      if (idx === -1) return 0
+      store.splice(idx, 1)
+      return 1
+    },
+    async count<T extends PlainObject>(_table: unknown, where?: WhereClause<T>): Promise<number> {
+      if (!where) return store.length
+      return store.filter((r) => matchesSimple(r, where as PlainObject)).length
+    },
+  } as ORMAdapter
+}
+
+/**
+ * A fresh class per test. `withoutGlobalScope()` installs an own registry as a
+ * side effect of reading, so a shared class would carry state between tests.
+ */
+function tenantScopedPost() {
+  const store = SEED.map((r) => ({ ...r }))
+
+  class Post extends SoftDeletes(Model<PostRecord>) {
+    static table = 'posts'
+  }
+  Post.useAdapter(createAdapter(store))
+  // Registered on the subclass, after the mixin registered 'softDelete' on the
+  // class it built — this is the composition that used to shadow the inherited
+  // registry with a fresh empty one.
+  ;(Post as unknown as typeof Model).addGlobalScope('tenant', (q) => q.where('tenantId', 1))
+
+  return { Post, store }
+}
+
+const titles = (rows: PlainObject[]) => rows.map((r) => r.title as string).sort()
+
+describe('SoftDeletes: reads', () => {
+  it('excludes trashed rows and other tenants from the default query', async () => {
+    // Both halves of the fix are load-bearing here: the mixin no longer
+    // registers softDelete as a `defaultScope`, so the only thing still hiding
+    // trashed rows is the named scope reaching the subclass through the cloned
+    // registry.
+    const { Post } = tenantScopedPost()
+    expect(titles(await Post.all())).toEqual(['ours-live'])
+  })
+
+  it('keeps the inherited softDelete scope when the mixin is applied over an already-scoped base', async () => {
+    // The reverse composition order: the base already carries a scope when the
+    // mixin registers its own, so the mixin's `addGlobalScope` is the call that
+    // must not start from an empty registry.
+    const store = SEED.map((r) => ({ ...r }))
+
+    class Base extends Model<PostRecord> {
+      static table = 'posts'
+    }
+    Base.addGlobalScope('tenant', (q) => q.where('tenantId', 1))
+
+    class Post extends SoftDeletes(Base) {}
+    Post.useAdapter(createAdapter(store))
+
+    expect(titles(await Post.all())).toEqual(['ours-live'])
+  })
+
+  it('withTrashed() reaches trashed rows but stays inside the tenant', async () => {
+    const { Post } = tenantScopedPost()
+    expect(titles(await Post.withTrashed().get())).toEqual(['ours-live', 'ours-trashed'])
+  })
+
+  it('onlyTrashed() returns this tenant\'s trashed rows and no one else\'s', async () => {
+    const { Post } = tenantScopedPost()
+    expect(titles(await Post.onlyTrashed().get())).toEqual(['ours-trashed'])
+  })
+
+  it('withoutGlobalScope("softDelete") is what withTrashed() does — the documented equivalence', async () => {
+    const { Post } = tenantScopedPost()
+    const viaHelper = titles(await Post.withTrashed().get())
+    const viaScopeName = titles(await (Post as unknown as typeof Model).withoutGlobalScope('softDelete').get())
+
+    expect(viaScopeName).toEqual(viaHelper)
+    expect(viaScopeName).toEqual(['ours-live', 'ours-trashed'])
+  })
+
+  it('withoutGlobalScopes() still drops everything, tenant included', async () => {
+    const { Post } = tenantScopedPost()
+    expect(await (Post as unknown as typeof Model).withoutGlobalScopes().get()).toHaveLength(4)
+  })
+})
+
+describe('SoftDeletes: delete()', () => {
+  it('soft-deletes a live row inside the tenant', async () => {
+    const { Post, store } = tenantScopedPost()
+    await Post.delete({ id: 1 })
+
+    expect(store.find((r) => r.id === 1)?.deletedAt).toBeInstanceOf(Date)
+    expect(titles(await Post.all())).toEqual([])
+  })
+
+  it('cannot soft-delete another tenant\'s row', async () => {
+    const { Post, store } = tenantScopedPost()
+    await Post.delete({ id: 3 }).catch(() => {})
+
+    expect(store.find((r) => r.id === 3)?.deletedAt).toBeNull()
+  })
+
+  it('leaves an already-trashed row\'s deletedAt alone', async () => {
+    // The softDelete scope is applied here too, so a second delete matches
+    // nothing rather than refreshing the timestamp — documented in the guide.
+    const { Post, store } = tenantScopedPost()
+    const original = store.find((r) => r.id === 2)!.deletedAt
+
+    await Post.delete({ id: 2 }).catch(() => {})
+
+    expect(store.find((r) => r.id === 2)?.deletedAt).toBe(original)
+  })
+
+  it('leaves the row in place for the other tenant to read', async () => {
+    const { Post, store } = tenantScopedPost()
+    await Post.delete({ id: 3 }).catch(() => {})
+
+    class OtherTenantPost extends SoftDeletes(Model<PostRecord>) {
+      static table = 'posts'
+    }
+    OtherTenantPost.useAdapter(createAdapter(store))
+    ;(OtherTenantPost as unknown as typeof Model).addGlobalScope('tenant', (q) => q.where('tenantId', 2))
+
+    expect(titles(await OtherTenantPost.all())).toEqual(['theirs-live'])
+  })
+})
+
+describe('SoftDeletes: restore()', () => {
+  it('restores a trashed row inside the tenant', async () => {
+    const { Post, store } = tenantScopedPost()
+    await Post.restore({ id: 2 })
+
+    expect(store.find((r) => r.id === 2)?.deletedAt).toBeNull()
+    expect(titles(await Post.all())).toEqual(['ours-live', 'ours-trashed'])
+  })
+
+  it('cannot restore another tenant\'s trashed row', async () => {
+    const { Post, store } = tenantScopedPost()
+    await Post.restore({ id: 4 }).catch(() => {})
+
+    expect(store.find((r) => r.id === 4)?.deletedAt).toBeInstanceOf(Date)
+  })
+})
+
+describe('SoftDeletes: forceDelete()', () => {
+  it('hard-deletes a trashed row inside the tenant', async () => {
+    const { Post, store } = tenantScopedPost()
+    await Post.forceDelete({ id: 2 })
+
+    expect(store.find((r) => r.id === 2)).toBeUndefined()
+  })
+
+  it('hard-deletes a live row inside the tenant', async () => {
+    // Dropping only the softDelete scope must not turn forceDelete into a
+    // trashed-rows-only operation.
+    const { Post, store } = tenantScopedPost()
+    await Post.forceDelete({ id: 1 })
+
+    expect(store.find((r) => r.id === 1)).toBeUndefined()
+  })
+
+  it('cannot hard-delete another tenant\'s trashed row', async () => {
+    // The sharpest case in the whole mixin: this delete is unrecoverable.
+    const { Post, store } = tenantScopedPost()
+    await Post.forceDelete({ id: 4 }).catch(() => {})
+
+    expect(store.find((r) => r.id === 4)).toBeDefined()
+  })
+
+  it('cannot hard-delete another tenant\'s live row', async () => {
+    const { Post, store } = tenantScopedPost()
+    await Post.forceDelete({ id: 3 }).catch(() => {})
+
+    expect(store.find((r) => r.id === 3)).toBeDefined()
+  })
+})
+
+describe('SoftDeletes: models with no other scopes', () => {
+  it('still soft-deletes, restores, and force-deletes', async () => {
+    const store = SEED.map((r) => ({ ...r }))
+
+    class Post extends SoftDeletes(Model<PostRecord>) {
+      static table = 'posts'
+    }
+    Post.useAdapter(createAdapter(store))
+
+    await Post.delete({ id: 1 })
+    expect(store.find((r) => r.id === 1)?.deletedAt).toBeInstanceOf(Date)
+
+    await Post.restore({ id: 1 })
+    expect(store.find((r) => r.id === 1)?.deletedAt).toBeNull()
+
+    await Post.forceDelete({ id: 1 })
+    expect(store.find((r) => r.id === 1)).toBeUndefined()
+  })
+
+  it('reports the adapter gap rather than silently doing nothing', async () => {
+    class Post extends SoftDeletes(Model<PostRecord>) {
+      static table = 'posts'
+    }
+    Post.useAdapter({ ...createAdapter([]), update: undefined, delete: undefined } as unknown as ORMAdapter)
+
+    expect(Post.delete({ id: 1 })).rejects.toThrow('needed for soft delete')
+    expect(Post.restore({ id: 1 })).rejects.toThrow('needed for restore')
+    expect(Post.forceDelete({ id: 1 })).rejects.toThrow('does not support delete operations')
+  })
+})


### PR DESCRIPTION
## Summary

`SoftDeletes` overrides `delete()`, `restore()`, and `forceDelete()`, and each one
forwarded the caller's `where` straight to the adapter, dropping every global
scope the model carried. On a multi-tenant app with a `tenant` scope, `delete()`
soft-deleted, `restore()` un-deleted, and `forceDelete()` **permanently** removed
another tenant's row — the sharpest of the three, since a hard delete cannot be
undone. `withTrashed()` / `onlyTrashed()` had the mirror of the same bug: they
dropped *every* scope in order to escape the soft-delete filter, so they returned
other tenants' trashed rows.

The three writes now run through the scope-applying builder. `delete()` uses the
full scope set, so it marks only a live row the current scopes can see;
`restore()` and `forceDelete()` drop the `softDelete` scope alone, reaching
trashed rows while a tenant scope keeps them in bounds. The two read helpers do
the same.

Two supporting changes had to land with it — the reason this could not be a
one-liner:

1. **The mixin no longer registers its filter as `defaultScope` as well as the
   named `'softDelete'` scope.** `withoutGlobalScope()` re-applies `defaultScope`
   whatever it is asked to drop, so the double registration made the filter
   unremovable by name. `defaultScope` is therefore gone from the
   `SoftDeletesStatic` type; reading `Post.defaultScope` still compiles through
   `Model`'s own optional declaration, but calling it unguarded no longer does.
2. **A subclass registering its own scope now seeds its registry from the
   inherited one** instead of starting empty (`GlobalScopeRegistry.clone()`).
   Without this, `class Post extends SoftDeletes(Base)` followed by
   `Post.addGlobalScope('tenant')` silently dropped the inherited `softDelete`
   filter — latent until now, masked by the `defaultScope` registration above.
   The read paths already resolved the registry through the prototype chain; only
   the write path shadowed it.

A side effect worth naming: the docs have always claimed
`withoutGlobalScope('softDelete')` is equivalent to `withTrashed()`. That claim
was false (the `defaultScope` re-application), and is now literally true.

## Rebased onto the landed dependency

This change was originally stacked on the work that became #371, which has since
merged. The branch is now rebased onto `main` and the diff is a single commit.

#371 landed with the prepared-payload terminal renamed from a public
`updateWithPreparedPayload()` method to a symbol-keyed `[PREPARED_UPDATE]`, kept
off the package entry point so it cannot be reached as public API. The three
writes here call the merged form.

## Scope

`orm`, `docs`

- `packages/orm/src/SoftDeletes.ts` — the three writes and the two read helpers
- `packages/orm/src/Model.ts` — registry inheritance in `getGlobalScopes()`, plus a
  note on `withoutGlobalScope()` that `defaultScope` is deliberately not
  bypassable by name
- `packages/orm/src/GlobalScopeRegistry.ts` — `clone()`
- `packages/orm/tests/soft-deletes.test.ts` — new, 18 tests
- `packages/orm/tests/model.query.types.ts` — pins the `defaultScope` type removal
- `docs/en/guides/database.md`, `docs/ja/guides/database.md`

## Risk Assessment

Two visible behavior changes, both intended:

- `Post.delete({ id })` on an **already-trashed** row is now a no-op rather than
  refreshing `deletedAt`, since the soft-delete scope excludes it.
- `withTrashed()` / `onlyTrashed()` no longer return rows that other global
  scopes exclude.

Type surface: `SoftDeletesStatic.defaultScope` is removed (re-exported from
`@guren/core`). Access still compiles via `Model`'s optional declaration; an
unguarded call does not.

Unchanged on purpose: the mixin's `delete` override still bypasses the
`deleting` / `deleted` hooks, exactly as before.

Changeset added (`@guren/orm`: patch).

## Validation

Every guard was mutation-tested — the fix was reverted one piece at a time and
the corresponding tests confirmed to fail, then restored:

| Mutation | Tests that failed |
|---|---|
| `getGlobalScopes()` starts from an empty registry | 4 (both composition orders) |
| re-add the `defaultScope` registration | 6 |
| `withTrashed`/`onlyTrashed` drop all scopes again | 6 |
| `delete` / `restore` / `forceDelete` call the adapter directly | 2 / 1 / 2 |
| `delete()` stops applying the softDelete scope | 1 (already-trashed no-op) |

The matrix was re-run in full after the rebase, against a baseline verified green
before and after (18 pass, 0 fail at rest).
| re-add `defaultScope` to `SoftDeletesStatic` | `typecheck` (unused `@ts-expect-error`) |

- [x] `bun run build` (`build:clean`)
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 4076 pass, 0 fail (on the rebased branch)
- [x] `bun run audit:docs`, `bun run audit:core-first`

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
