### PR TITLE
test: unify the golden-path dbcheck fixtures behind one table list

### DIFF
--- a/scripts/smoke-golden-path.sh
+++ b/scripts/smoke-golden-path.sh
@@ -311,8 +311,13 @@ fi
 
 # Assert migrations actually created tables — db:migrate used to report
 # success while silently executing nothing.
-cp "$FIXTURES_DIR/dbcheck.$SMOKE_DB.ts" "$TEMP_DIR/dbcheck.ts"
-(cd "$APP_DIR" && bun "$TEMP_DIR/dbcheck.ts")
+#
+# Copied as a directory, keeping each fixture's own name, because the three
+# dbcheck bodies now share expected-tables.ts and a relative import only
+# resolves if the sibling travels with it. Naming a file list here instead is
+# how one of them would come to be left behind.
+cp -R "$FIXTURES_DIR" "$TEMP_DIR/fixtures"
+(cd "$APP_DIR" && bun "$TEMP_DIR/fixtures/dbcheck.$SMOKE_DB.ts")
 
 # One loopback address, used for both halves of the conversation: the app is
 # told to bind it and the assertions are addressed to it. `localhost` is not

--- a/scripts/smoke/dbcheck-fixtures.test.ts
+++ b/scripts/smoke/dbcheck-fixtures.test.ts
@@ -1,0 +1,126 @@
+// The dbcheck fixtures only ever run inside `smoke:golden-path`, one driver per
+// invocation, and the two server-backed drivers need a container — so a fixture
+// that quietly started checking less than its siblings would go unnoticed for as
+// long as nobody ran that driver by hand. That is the history here: three copies
+// of one table list, and sqlite drifted into asserting the migration tracker
+// merely *existed* while postgres and mysql counted its rows. These run in a
+// second and pin the shape that made the drift possible.
+import { describe, expect, test } from 'bun:test'
+import { readFile, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { tableNameFor } from '../../packages/cli/src/inflect'
+import { DATABASE_DRIVERS } from '../../packages/create-app/src/blueprints'
+import { MIGRATION_TRACKER, REQUIRED_APP_TABLES } from './fixtures/expected-tables'
+
+const fixturesDir = join(import.meta.dir, 'fixtures')
+const smokeScript = join(import.meta.dir, '..', 'smoke-golden-path.sh')
+
+// The drivers the smoke can be asked for, imported rather than restated:
+// `$SMOKE_DB` goes straight to `create-app --db`, so this set and the fixture
+// set have to move together. A local copy would let a fourth driver be added
+// with no fixture behind it while the count assertion below stayed green.
+const DRIVERS = DATABASE_DRIVERS
+
+// sqlite addresses a file, so it is the one driver with no URL to require.
+const SERVER_BACKED = DRIVERS.filter((driver) => driver !== 'sqlite')
+
+async function fixtureSource(driver: string): Promise<string> {
+  return await readFile(join(fixturesDir, `dbcheck.${driver}.ts`), 'utf8')
+}
+
+describe('dbcheck fixtures', () => {
+  test('there is exactly one fixture per driver the smoke dispatches on', async () => {
+    const found = (await readdir(fixturesDir))
+      .filter((name) => name.startsWith('dbcheck.'))
+      .map((name) => name.replace(/^dbcheck\.|\.ts$/g, ''))
+
+    expect(found.sort()).toEqual([...DRIVERS].sort())
+  })
+
+  test('the smoke resolves the fixture by driver name, with its shared module alongside', async () => {
+    const script = await readFile(smokeScript, 'utf8')
+
+    // The dispatch is what used to hold three inline copies. If it grows an
+    // `if [ "$SMOKE_DB" = ... ]` around dbcheck again, the copies are back.
+    expect(script).toContain('dbcheck.$SMOKE_DB.ts')
+    // A relative import only resolves if expected-tables.ts travels with the
+    // fixture, so the copy has to be of the directory, not of one file.
+    expect(script).toMatch(/cp -R "\$FIXTURES_DIR"/)
+  })
+
+  for (const driver of DRIVERS) {
+    describe(driver, () => {
+      test('takes its required-table list from the shared module', async () => {
+        const source = await fixtureSource(driver)
+
+        expect(source).toContain("from './expected-tables.ts'")
+        // The call, not the bare name, which the import alone satisfies — a
+        // fixture that imports the helper and never calls it checks nothing.
+        expect(source).toContain('assertRequiredTables(')
+      })
+
+      test('hard-codes no table names of its own', async () => {
+        const source = await fixtureSource(driver)
+
+        // The exact drift: a private list beside the shared one. Every table
+        // name must arrive through the shared module, so none may appear as a
+        // literal here. The tracker is included because writing it into the
+        // presence list is precisely how sqlite stopped counting its rows.
+        for (const table of [...REQUIRED_APP_TABLES, MIGRATION_TRACKER]) {
+          expect(source).not.toContain(`'${table}'`)
+          expect(source).not.toContain(`"${table}"`)
+        }
+      })
+
+      test('asserts the migration tracker is non-empty, not merely present', async () => {
+        const source = await fixtureSource(driver)
+
+        expect(source).toContain('assertTrackerNonEmpty(')
+        expect(source).toMatch(/count\(\*\)/)
+      })
+
+      test('does not smuggle the tracker into the required-table list', async () => {
+        const source = await fixtureSource(driver)
+
+        // Referencing the constant is fine; appending it to the list the
+        // presence check reads is not, because presence is a side effect of
+        // opening the migrator and proves no migration ran.
+        expect(source).not.toMatch(/REQUIRED_APP_TABLES\s*,\s*MIGRATION_TRACKER/)
+      })
+    })
+  }
+
+  for (const driver of SERVER_BACKED) {
+    test(`${driver} does not fall back to a default database URL`, async () => {
+      const source = await fixtureSource(driver)
+
+      // A default is a fail-open: postgres used to default to the *development*
+      // database while the smoke exports a dedicated one, so an unset URL would
+      // have inspected a database no migration under test had touched.
+      expect(source).toContain('requireDatabaseUrl()')
+      expect(source).not.toMatch(/DATABASE_URL\s*\?\?/)
+    })
+  }
+
+  test('the shared list keeps the tracker out', () => {
+    // REQUIRED_APP_TABLES feeds a presence-only check, so the tracker must not
+    // be a member of it however the fixtures are rewritten.
+    expect(REQUIRED_APP_TABLES as readonly string[]).not.toContain(MIGRATION_TRACKER)
+  })
+
+  test('the required-table list still matches what the smoke scaffolds', async () => {
+    const script = await readFile(smokeScript, 'utf8')
+
+    // The list is hand-written on purpose: it is the smoke's independent
+    // statement of intent, and deriving it from the app's own schema would let a
+    // scaffolder that emitted no table agree with itself and pass. What must not
+    // happen is that statement going stale in silence, so the resources the
+    // script actually asks for are cross-checked against it here. `users` comes
+    // from `add auth` rather than from a resource, so it is excluded.
+    const scaffolded = [...script.matchAll(/add resource (\w+)/g)].map((match) => tableNameFor(match[1]))
+
+    expect(scaffolded.length).toBeGreaterThan(0)
+    expect(scaffolded.sort()).toEqual(REQUIRED_APP_TABLES.filter((table) => table !== 'users').sort())
+  })
+})

--- a/scripts/smoke/fixtures/dbcheck.mysql.ts
+++ b/scripts/smoke/fixtures/dbcheck.mysql.ts
@@ -1,22 +1,22 @@
 import { createConnection } from 'mysql2/promise'
 
-const connection = await createConnection(process.env.DATABASE_URL ?? '')
+import {
+  MIGRATION_TRACKER,
+  assertRequiredTables,
+  assertTrackerNonEmpty,
+  requireDatabaseUrl,
+} from './expected-tables.ts'
+
+const connection = await createConnection(requireDatabaseUrl())
 const [rows] = await connection.query(
   'SELECT table_name AS name FROM information_schema.tables WHERE table_schema = DATABASE()',
 )
 const tables = (rows as Array<{ name: string }>).map((row) => row.name)
-for (const required of ['users', 'posts', 'comments']) {
-  if (!tables.includes(required)) {
-    console.error('Missing table after db:migrate: ' + required + ' (found: ' + tables.join(', ') + ')')
-    process.exit(1)
-  }
-}
-// The tracker table lives in the app database on MySQL, so the count below
-// doubles as its existence check — the query fails if it was never created.
-const [tracker] = await connection.query('SELECT count(*) AS c FROM __drizzle_migrations')
-if (Number((tracker as Array<{ c: number }>)[0].c) < 1) {
-  console.error('__drizzle_migrations is empty after db:migrate')
-  process.exit(1)
-}
+assertRequiredTables(tables)
+
+// The tracker table lives in the app database on MySQL, so this count doubles as
+// its existence check — the query fails if it was never created.
+const [tracker] = await connection.query(`SELECT count(*) AS c FROM \`${MIGRATION_TRACKER}\``)
+assertTrackerNonEmpty(Number((tracker as Array<{ c: number }>)[0].c), MIGRATION_TRACKER)
 await connection.end()
 console.log('DB tables OK (mysql): ' + tables.join(', '))

--- a/scripts/smoke/fixtures/dbcheck.postgres.ts
+++ b/scripts/smoke/fixtures/dbcheck.postgres.ts
@@ -1,19 +1,23 @@
 import postgres from 'postgres'
 
-const sql = postgres(process.env.DATABASE_URL ?? 'postgres://guren:guren@localhost:54322/guren', { max: 1 })
+import {
+  MIGRATION_TRACKER,
+  assertRequiredTables,
+  assertTrackerNonEmpty,
+  requireDatabaseUrl,
+} from './expected-tables.ts'
+
+const sql = postgres(requireDatabaseUrl(), { max: 1 })
 const rows = await sql`SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`
 const tables = rows.map((row) => row.table_name as string)
-for (const required of ['users', 'posts', 'comments']) {
-  if (!tables.includes(required)) {
-    console.error('Missing table after db:migrate: ' + required + ' (found: ' + tables.join(', ') + ')')
-    process.exit(1)
-  }
-}
-const tracker = await sql`SELECT count(*)::int AS c FROM drizzle.__drizzle_migrations`
-if (Number(tracker[0].c) < 1) {
-  console.error('drizzle.__drizzle_migrations is empty after db:migrate')
-  process.exit(1)
-}
+assertRequiredTables(tables)
+
+// The tracker lives in its own `drizzle` schema on postgres, so it is absent
+// from the `public` list above and gets its own query. Built with `unsafe`
+// because the identifier helper would quote "drizzle.__drizzle_migrations" as a
+// single name; the interpolated value is a constant in this repo, not input.
+const tracker = await sql.unsafe(`SELECT count(*)::int AS c FROM drizzle."${MIGRATION_TRACKER}"`)
+assertTrackerNonEmpty(Number(tracker[0].c), `drizzle.${MIGRATION_TRACKER}`)
 
 // Every timestamp a scaffold emits must carry a time zone. An offset-less
 // column stores a bare wall clock and leaves its meaning to the reader: the

--- a/scripts/smoke/fixtures/dbcheck.sqlite.ts
+++ b/scripts/smoke/fixtures/dbcheck.sqlite.ts
@@ -1,14 +1,31 @@
 import { Database } from 'bun:sqlite'
 
-const db = new Database('./data/guren.db')
-const tables = db.query("SELECT name FROM sqlite_master WHERE type='table'").all().map((r) => r.name)
-for (const required of ['users', 'posts', 'comments', '__drizzle_migrations']) {
-  if (!tables.includes(required)) {
-    console.error('Missing table after db:migrate: ' + required + ' (found: ' + tables.join(', ') + ')')
-    // An empty table list here usually means db:migrate wrote somewhere else
-    // rather than that it silently executed nothing, so name both databases.
-    console.error('Checked sqlite file: ./data/guren.db (DATABASE_URL=' + (process.env.DATABASE_URL ?? '<unset>') + ')')
-    process.exit(1)
-  }
+import { MIGRATION_TRACKER, assertRequiredTables, assertTrackerNonEmpty } from './expected-tables.ts'
+
+const DB_FILE = './data/guren.db'
+
+// An empty table list usually means db:migrate wrote somewhere else rather than
+// that it silently executed nothing, so every failure here names both databases.
+const WHERE = 'Checked sqlite file: ' + DB_FILE + ' (DATABASE_URL=' + (process.env.DATABASE_URL ?? '<unset>') + ')'
+
+const db = new Database(DB_FILE)
+const tables = db
+  .query("SELECT name FROM sqlite_master WHERE type='table'")
+  .all()
+  .map((row) => (row as { name: string }).name)
+
+assertRequiredTables(tables, WHERE)
+
+// Same policy as the other two dialects: the tracker must exist *and* be
+// non-empty. Presence is checked explicitly here only because sqlite_master is
+// already in hand and yields a better message than the failing count query that
+// stands in for this check on postgres and mysql.
+if (!tables.includes(MIGRATION_TRACKER)) {
+  console.error('Missing migration tracker after db:migrate: ' + MIGRATION_TRACKER)
+  console.error(WHERE)
+  process.exit(1)
 }
-console.log('DB tables OK: ' + tables.join(', '))
+const tracker = db.query(`SELECT count(*) AS c FROM \`${MIGRATION_TRACKER}\``).get()
+assertTrackerNonEmpty(Number((tracker as { c: number } | null)?.c), MIGRATION_TRACKER)
+
+console.log('DB tables OK (sqlite): ' + tables.join(', '))

--- a/scripts/smoke/fixtures/expected-tables.ts
+++ b/scripts/smoke/fixtures/expected-tables.ts
@@ -1,0 +1,75 @@
+// What every dialect's `dbcheck` must find after `db:migrate`, and the one
+// place that says so.
+//
+// The three dbcheck fixtures next to this file speak different dialects —
+// different client, different catalog query, different home for the migration
+// tracker — but the *policy* they enforce is identical, and that is the part
+// that drifted while each held its own copy of it: sqlite folded the tracker
+// into its required-table list and so only checked that it existed, while
+// postgres and mysql counted its rows. One copy of the policy, three of the SQL.
+
+// The tables `scripts/smoke-golden-path.sh` scaffolds before it runs a dbcheck:
+// `add auth` -> users, `add resource posts` -> posts, `add resource comments`
+// -> comments. Extend this when the smoke scaffolds another resource; it is a
+// subset assertion, so unrelated tables the scaffolds emit are ignored.
+export const REQUIRED_APP_TABLES = ['users', 'posts', 'comments'] as const
+
+// Drizzle's migration bookkeeping table. Deliberately *not* a member of
+// REQUIRED_APP_TABLES: its mere presence is a side effect of opening the
+// migrator and can be true with zero migrations applied, which is precisely
+// the failure these checks exist to catch (`db:migrate` reporting success while
+// silently executing nothing). It is verified by counting its rows instead —
+// see assertTrackerNonEmpty.
+export const MIGRATION_TRACKER = '__drizzle_migrations'
+
+/**
+ * Asserts every required application table was created.
+ *
+ * @param tables Table names read from the dialect's catalog.
+ * @param diagnostics Printed on failure, for what only the caller knows —
+ *   which file was opened, which database was addressed.
+ */
+export function assertRequiredTables(tables: string[], diagnostics?: string): void {
+  for (const required of REQUIRED_APP_TABLES) {
+    if (!tables.includes(required)) {
+      console.error('Missing table after db:migrate: ' + required + ' (found: ' + tables.join(', ') + ')')
+      if (diagnostics) console.error(diagnostics)
+      process.exit(1)
+    }
+  }
+}
+
+/**
+ * Asserts the migration tracker recorded at least one applied migration.
+ *
+ * Existence is the caller's business: the `SELECT count(*)` it runs fails on its
+ * own when the tracker was never created.
+ *
+ * @param count Row count returned by the caller's query.
+ * @param location How to name the tracker in the failure message; dialects
+ *   qualify it differently (a `drizzle` schema on postgres, the app database on
+ *   mysql, the app's file on sqlite).
+ */
+export function assertTrackerNonEmpty(count: number, location: string): void {
+  if (!Number.isFinite(count) || count < 1) {
+    console.error(location + ' is empty after db:migrate')
+    process.exit(1)
+  }
+}
+
+/**
+ * Returns DATABASE_URL, refusing to fall back to a guess.
+ *
+ * A default here is a fail-open: the postgres fixture used to default to the
+ * *development* database while the smoke exports a dedicated one, so an unset
+ * URL would have quietly inspected a database no migration under test had
+ * touched — and passed.
+ */
+export function requireDatabaseUrl(): string {
+  const url = process.env.DATABASE_URL
+  if (!url) {
+    console.error('DATABASE_URL is not set — refusing to guess which database to inspect')
+    process.exit(1)
+  }
+  return url
+}

--- a/scripts/test-packages.ts
+++ b/scripts/test-packages.ts
@@ -73,9 +73,24 @@ const cwdGuard = join(import.meta.dir, 'test-cwd-guard.ts')
 // nothing. The smoke package list is here for the same reason: the gates that
 // consume it take ten minutes each, so nothing else would notice it narrowing.
 // Included only on an unfiltered run, so `test:bun cli` stays narrow.
-const guardTests = selectors.length === 0
-  ? ['scripts/test-cwd-guard.test.ts', 'scripts/smoke/local-packages.test.ts']
-  : []
+//
+// Discovered rather than named, so the next scripts-level guard is covered by
+// existing — a hand-kept list is the shape local-packages.ts exists to end.
+// Globbed here rather than passed to `bun test` as a bare `scripts/` directory:
+// what reaches the command line stays a list of explicit file paths, which is
+// what it was before, so this cannot change how bun resolves its arguments.
+const guardTests = selectors.length === 0 ? await collectScriptTests() : []
+
+async function collectScriptTests(): Promise<string[]> {
+  const found: string[] = []
+  for await (const path of new Bun.Glob('scripts/**/*.test.ts').scan({ cwd: repoRoot })) {
+    found.push(path)
+  }
+  if (found.length === 0) {
+    throw new Error('No scripts-level guard tests found — the glob no longer matches this layout.')
+  }
+  return found.sort()
+}
 
 const testArgs = [
   'test',


### PR DESCRIPTION
## Summary

#368 moved the golden-path smoke's payloads out of heredocs into `scripts/smoke/fixtures/`, which made the dbcheck duplication visible without resolving it: each of the three dbcheck fixtures still carried its own copy of the tables `db:migrate` must create, and the copies had already drifted.

- **sqlite** folded `__drizzle_migrations` into its required-table *presence* list, so it only checked the tracker **existed**.
- **postgres** and **mysql** ran `SELECT count(*)` and asserted it was **non-empty**.

Presence alone is a side effect of opening the migrator and is true with zero migrations applied — which is exactly the failure this block exists to catch (`db:migrate` reporting success while silently executing nothing). So sqlite was not testing it, and sqlite is the default driver and the only one the nightly canary runs.

This gives the three fixtures one `expected-tables.ts` to import: the required tables, the tracker name, and the two assertions that were previously spelled out per dialect. The catalog query, the client, and the tracker's location stay per dialect because those differ legitimately. The `cp` becomes a directory copy, since a relative import only resolves if the sibling module travels with the fixture.

Two smaller fixes ride along:

- The postgres fixture's `DATABASE_URL ?? 'postgres://…/guren'` fallback is gone. It defaulted to the **development** database while the smoke exports a dedicated one, so an unset URL would have inspected a database no migration under test had touched — and passed. (mysql's `?? ''` only produced an unhelpful `Invalid URL`; both now refuse by name.)
- `scripts/smoke/dbcheck-fixtures.test.ts` pins the shape that made the drift possible. It takes the driver set from `DATABASE_DRIVERS` and cross-checks `REQUIRED_APP_TABLES` against the `add resource` calls the script actually makes, rather than restating either — a local copy of the driver list would let a fourth driver be added with no fixture behind it while the fixture-count assertion stayed green.

The table list stays hand-written rather than derived from the app's schema on purpose: it is the smoke's independent statement of intent, and a scaffolder that emitted no table would otherwise agree with itself and pass. The cross-check above is what keeps that statement from going stale in silence.

## Scope

- `scripts/` only — smoke-test tooling. No framework package, template, or example app is touched.
- `scripts/smoke/fixtures/dbcheck.{postgres,mysql,sqlite}.ts`, new `expected-tables.ts`, new `scripts/smoke/dbcheck-fixtures.test.ts`, plus one `cp` line in `scripts/smoke-golden-path.sh` and the guard-test registration in `scripts/test-packages.ts`.

## Risk Assessment

No runtime or published-package behavior changes; nothing here ships to users.

Two intentional behavior changes in the tooling:

1. **sqlite dbcheck is now stricter.** It asserts the migration tracker is non-empty, so a run where migrations genuinely apply nothing fails where it previously passed. That is the point of the change.
2. **`test:bun` discovers its scripts-level guard tests by glob** instead of naming them, so any future `scripts/**/*.test.ts` joins unfiltered `test:bun` runs automatically. The glob runs inside `test-packages.ts` and still hands `bun test` a list of explicit file paths, so nothing about how bun resolves its arguments changes; it throws rather than silently running nothing if the layout stops matching. Verified to resolve to exactly the three existing guard tests today.

## Validation

- [x] `bun run build` — exit 0
- [x] `bun run typecheck` — exit 0
- [x] `bun run test` — exit 0
- [x] `bun run smoke:golden-path` — exit 0, `=== Golden path smoke test PASSED ===`

Each assertion was verified by mutation rather than by observing green:

| Mutation | Result |
|---|---|
| Empty the migration tracker (sqlite) | fails — and the *old* sqlite logic passed the same database, confirming the gap was real |
| Empty the tracker (postgres, mysql — real migrated databases) | fails on both |
| Drop a required table (postgres, mysql) | fails on both |
| Drop the tracker table entirely (mysql) | fails via the count query, as documented |
| Make a timestamp column offset-less (postgres) | fails |
| Unset `DATABASE_URL` | refuses instead of inspecting the development database |
| Remove an `assertRequiredTables(...)` call but keep the import | caught |
| Re-add the tracker to the shared list, or spell it as a literal | caught |
| Add a fourth driver with no fixture behind it | caught |
| Scaffold a resource absent from `REQUIRED_APP_TABLES` | caught |

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation — no docs describe these fixtures; the rationale lives in the files.

## Follow-up

The fixtures are copied beside the app rather than into it, so Bun resolves `postgres`/`mysql2` from its global cache instead of the copy the app's own manifest pins — a mysql run resolved mysql2 3.23.3 while the workspace pinned 3.23.2. Copying them inside `$APP_DIR` instead makes each check run against the same driver the app migrated with, offline. Left out here because it applies equally to the `ensure-db` fixtures and is a property of the whole script rather than of dbcheck, so it belongs in its own change.
