### PR TITLE
feat(openapi): accept a function for the servers option

### DIFF
--- a/.changeset/openapi-servers-resolver.md
+++ b/.changeset/openapi-servers-resolver.md
@@ -1,0 +1,24 @@
+---
+'@guren/openapi': minor
+---
+
+Accept a function for the `servers` option, resolved every time a document is generated
+
+A mounted document is rendered per request, but `servers` could only be given as a fixed list — so an app could advertise no address it did not already know when the module ran. With `PORT=0` the OS assigns the port during `listen()`, leaving the document pointing generated clients and the Scalar "try it" button at a port nothing is listening on.
+
+`servers` now also accepts `() => Array<string | OpenApiServer>`, called once per generated document:
+
+```ts
+let serverUrl = 'http://localhost:3334'
+
+mountOpenApiDocs(app, {
+  title: 'Example API',
+  version: '1.0.0',
+  servers: () => [serverUrl],
+})
+
+const address = await app.listen({ port: 0 })
+serverUrl = address.url
+```
+
+Passing an array behaves exactly as before.

--- a/docs/en/guides/routing.md
+++ b/docs/en/guides/routing.md
@@ -364,3 +364,18 @@ mountOpenApiDocs(app, {
 ```
 
 When mounted on an `Application` instance, route definitions are read from the router automatically. For a plain Hono instance, pass `definitions` explicitly.
+
+The `servers` option accepts a function as well as a list. A mounted document is generated per request and the function is called each time, so it can advertise an address the process does not know when it mounts the docs. With `PORT=0` the operating system assigns the port, which therefore exists only once `listen()` has returned it — a fixed list would leave the document, and every client generated from it, pointing at an address nothing is listening on:
+
+```ts
+let serverUrl = 'http://localhost:3000'
+
+mountOpenApiDocs(app, {
+  title: 'Blog API',
+  version: '1.0.0',
+  servers: () => [serverUrl],
+})
+
+const address = await app.listen({ port: 0 })
+serverUrl = address.url
+```

--- a/docs/ja/guides/routing.md
+++ b/docs/ja/guides/routing.md
@@ -319,3 +319,18 @@ mountOpenApiDocs(app, {
 ```
 
 `Application` インスタンスにマウントする場合、ルート定義はルーターから自動的に読み取られます。素の Hono インスタンスの場合は `definitions` を明示的に渡してください。
+
+`servers` オプションには配列だけでなく関数も渡せます。マウントされたドキュメントはリクエストごとに生成され、関数もそのたびに呼ばれるため、マウント時点ではまだ分からないアドレスを載せられます。たとえば `PORT=0` の場合、ポートは OS が割り当てるため `listen()` が返るまで確定せず、固定の配列ではドキュメントも、そこから生成したクライアントも、何も待ち受けていないアドレスを指したままになります。
+
+```ts
+let serverUrl = 'http://localhost:3000'
+
+mountOpenApiDocs(app, {
+  title: 'Blog API',
+  version: '1.0.0',
+  servers: () => [serverUrl],
+})
+
+const address = await app.listen({ port: 0 })
+serverUrl = address.url
+```

--- a/examples/api/bin/serve.ts
+++ b/examples/api/bin/serve.ts
@@ -1,4 +1,4 @@
-import app, { ready } from '../src/main.js'
+import app, { ready, setOpenApiServerUrl } from '../src/main.js'
 
 try {
   await ready
@@ -12,11 +12,15 @@ const parsedPort = Number.parseInt(process.env.PORT ?? '', 10)
 const port = Number.isInteger(parsedPort) ? parsedPort : 3334
 const hostname = process.env.HOST ?? '0.0.0.0'
 
-// `portFallback: false` keeps this entrypoint's original fail-fast behaviour.
-// It never walked, and it must not start: the OpenAPI document it serves
-// advertises `http://localhost:3334` as the server, so binding 3335 instead
-// would hand clients a URL that answers nothing.
+// `portFallback: false` keeps this entrypoint's original fail-fast behaviour:
+// a busy port is a misconfiguration worth reporting, not something to paper
+// over by serving an API on a port nobody was told about.
 const address = await app.listen({ port, hostname, vite: false, portFallback: false })
+
+// The socket is already accepting by the time `listen()` resolves, so this
+// goes first: anything above it widens the window where the OpenAPI document
+// still names the placeholder address.
+setOpenApiServerUrl(address.url)
 
 // Printed from the address listen() returned, not from the port that was
 // requested — with a port walk or PORT=0 those are different numbers.

--- a/examples/api/src/app.ts
+++ b/examples/api/src/app.ts
@@ -30,13 +30,23 @@ const app = createApp({
   ],
 })
 
+// The default for callers that never bind a socket (`app.fetch()`, tests).
+// `bin/serve.ts` replaces it with the address it really got: under `PORT=0` the
+// OS picks the port, so it does not exist until `listen()` returns.
+let openApiServerUrl = 'http://localhost:3334'
+
+export function setOpenApiServerUrl(url: string): void {
+  openApiServerUrl = url
+}
+
 mountOpenApiDocs(app, {
   title: 'Guren Example API',
   version: '0.1.0',
   description: 'Example API for authentication, tokens, and task management.',
   jsonPath: '/api/openapi.json',
   docsPath: '/api/docs',
-  servers: ['http://localhost:3334'],
+  // A function, not a list: read per request, so a later address still lands.
+  servers: () => [openApiServerUrl],
 })
 
 export default app

--- a/examples/api/src/main.ts
+++ b/examples/api/src/main.ts
@@ -1,5 +1,7 @@
 import app from './app.js'
 
+export { setOpenApiServerUrl } from './app.js'
+
 export async function bootstrap() {
   await app.boot()
   return app

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -38,7 +38,14 @@ export interface OpenApiDocumentOptions {
   title: string
   version: string
   description?: string
-  servers?: Array<string | OpenApiServer>
+  /**
+   * A function is resolved every time a document is generated — for
+   * `mountOpenApiDocs()`, on every request to the JSON endpoint. That is how an
+   * app advertises an address it does not know at mount time: the port it binds
+   * under `PORT=0` is assigned by the OS, so a fixed list written beside the
+   * mount would send clients to a port nothing is listening on.
+   */
+  servers?: Array<string | OpenApiServer> | (() => Array<string | OpenApiServer>)
 }
 
 export interface WriteOpenApiDocumentOptions extends OpenApiDocumentOptions, WriterOptions {
@@ -542,12 +549,13 @@ function toOpenApiSchema(schema: unknown, warnings: string[], label: string, io:
   }
 }
 
-function normalizeServers(servers?: Array<string | OpenApiServer>): OpenApiServer[] | undefined {
-  if (!servers || servers.length === 0) {
+function normalizeServers(servers?: OpenApiDocumentOptions['servers']): OpenApiServer[] | undefined {
+  const resolved = typeof servers === 'function' ? servers() : servers
+  if (!resolved || resolved.length === 0) {
     return undefined
   }
 
-  return servers.map((server) => typeof server === 'string' ? { url: server } : server)
+  return resolved.map((server) => typeof server === 'string' ? { url: server } : server)
 }
 
 function toOpenApiPath(path: string): string {

--- a/packages/openapi/tests/openapi.test.ts
+++ b/packages/openapi/tests/openapi.test.ts
@@ -115,6 +115,49 @@ describe('@guren/openapi', () => {
     expect(html).toContain('/openapi.json')
   })
 
+  // An app only learns the address it serves on after it binds, so a mounted
+  // document has to be able to pick the value up afterwards. Both fetches
+  // matter: one alone passes just as well against a list frozen at mount.
+  it('re-resolves a servers function on every mounted request', async () => {
+    let serverUrl = 'http://localhost:3334'
+    const app = createApp({
+      routes(router) {
+        router.get('/posts', { name: 'posts.index' }, async () => [])
+      },
+    })
+
+    mountOpenApiDocs(app, {
+      title: 'Blog API',
+      version: '1.0.0',
+      servers: () => [serverUrl],
+    })
+
+    await app.boot()
+
+    const readServers = async () => {
+      const response = await app.fetch(new Request('http://localhost/openapi.json'))
+      expect(response.status).toBe(200)
+      const document = await response.json() as { servers?: Array<{ url: string }> }
+      return document.servers ?? []
+    }
+
+    expect(await readServers()).toEqual([{ url: 'http://localhost:3334' }])
+
+    serverUrl = 'http://127.0.0.1:52341'
+
+    expect(await readServers()).toEqual([{ url: 'http://127.0.0.1:52341' }])
+  })
+
+  it('omits servers when a servers function resolves to an empty list', () => {
+    const { document } = generateOpenApiDocument([], {
+      title: 'Blog API',
+      version: '1.0.0',
+      servers: () => [],
+    })
+
+    expect(document.servers).toBeUndefined()
+  })
+
   it('marks request bodies optional when an empty payload passes validation', () => {
     const definitions: RouteDefinition[] = [
       {


### PR DESCRIPTION
## Problem

`examples/api` serves an OpenAPI document whose `servers` entry was the hardcoded literal `http://localhost:3334`, evaluated at module load in `src/app.ts`.

`portFallback: false` already closes the common mismatch — a busy port fails fast rather than walking. The remaining gap is `PORT=0`: the OS assigns a real port, the app happily serves `/api/openapi.json` advertising `http://localhost:3334`, and generated clients plus the Scalar "try it" button in `/api/docs` target a port nothing is listening on. `PORT=0` is newly expressible — `Number.parseInt(...) || 3334` used to coerce `0` away, and #370 fixed that parse.

## Change

`mountOpenApiDocs` already regenerates the document on every request to the JSON endpoint, but `servers` was the one input that could only be given as a fixed list. It now also accepts a function:

```ts
servers?: Array<string | OpenApiServer> | (() => Array<string | OpenApiServer>)
```

Resolution lives in `normalizeServers`, so `generateOpenApiDocument` and `writeOpenApiDocument` both get it. Passing an array behaves exactly as before — the change is a widening of an optional field, hence a minor for `@guren/openapi`.

`examples/api` keeps the advertised address in a module-local value with an exported setter; `bin/serve.ts` calls it with `address.url` as its first statement after `listen()` resolves. The default stays `http://localhost:3334` so callers that never bind a socket (`app.fetch()`, tests) still carry a sensible value.

The comment justifying `portFallback: false` on the grounds that the document hardcoded 3334 is rewritten — that reasoning is false after this change. Fail-fast stays, for its own reason.

### Alternatives rejected

- **Mutating the caller's `options` object after mount.** Works today, because `options` is captured by reference and read per request. But nothing pins that timing: a future refactor that snapshots `options` at mount would silently revert the example to a hardcoded URL with no test failing.
- **Deferring the mount into `bin/serve.ts`.** Would drop the docs endpoints for every other entrypoint and for `app.fetch()`.
- **An env var both sides agree on.** Impossible for `PORT=0` — the port does not exist until `listen()` returns.
- **Defaulting `servers` to the incoming request's own origin.** The handler does have the context, so this is possible, and it would need no app wiring at all. Rejected on scheme policy: the framework keeps proxy trust opt-in (`trustProxy` defaults to `false`), so such a default would either trust a client-settable header on every deployment or advertise `http://` for TLS-terminated production deploys, breaking docs that work today. It would also make `servers` mean something different in the mounted path than in `openapi:generate`.

## Verification

Package test pins the behavior with two fetches and a mutation between them — one fetch alone passes just as well against a list frozen at mount.

End to end, the example was run with `PORT=0`, reading the port from the app's own startup banner rather than assuming the one requested:

```
banner URL: http://127.0.0.1:49298
GET http://127.0.0.1:49298/api/openapi.json -> 200
advertised servers[0].url: http://127.0.0.1:49298
```

Both directions were mutation-checked: freezing `options` at mount reddens the package test, and restoring the literal `servers` reddens the end-to-end check with the original symptom (`advertises http://localhost:3334 but the app bound http://127.0.0.1:63057`).

Gates: root `typecheck`, `audit:contracts`, `audit:docs`, `audit:core-first`, `test:bun` (4078 pass / 0 fail), `examples/api` tests (42 pass).

## Follow-up, not in scope

`Application.listen()` returns a `ListenAddress` but the instance stores only a private `bunServer` — there is no accessor for the address it bound. That is why the example has to be *told* the address rather than reading it. Exposing it would let the example collapse to `servers: () => [app.address?.url ?? '…']` and delete the setter. It would not obsolete this seam: late resolution is what makes it work at all, and it is the only form available when mounting against a plain Hono instance.
