### PR TITLE
fix(server): keep the dev listener alive across bun --hot reloads

### DIFF
--- a/.changeset/dev-hot-reload-keeps-listener.md
+++ b/.changeset/dev-hot-reload-keeps-listener.md
@@ -1,0 +1,26 @@
+---
+'@guren/server': patch
+---
+
+Keep the dev server listening across `bun --hot` reloads by reusing the managed Vite dev server
+
+Editing a backend file in a scaffolded app — or running `guren add resource` /
+`guren add auth`, which edit several — killed the dev server silently. `bun
+--hot` re-runs the entrypoint, and the new `listen()` stopped the previous Bun
+server first, then awaited the previous Vite dev server's `close()`. Vite
+waits for every open connection, and a browser tab holding its HMR socket can
+keep that wait alive indefinitely — so the process stayed up with no HTTP
+listener at all, no error printed, and every checkpoint URL dead until a
+manual restart.
+
+`listen()` now adopts the still-listening Vite dev server a previous run left
+on `globalThis` (which `bun --hot` preserves) instead of tearing it down. The
+browser keeps its HMR socket, the reload skips the `close()` wait entirely,
+and the Bun listener re-binds immediately. Explicit `vite` options still force
+a restart — the running server was built from the previous call's options.
+
+Two failure paths harden alongside: the previous Bun server is force-closed
+(a dev reload must not wait on in-flight requests — an open SSE stream used to
+be able to hang it the same way), and the paths that do close Vite abandon a
+`close()` that has not resolved within `GUREN_VITE_CLOSE_TIMEOUT_MS` (default
+5000) with a loud warning instead of hanging the process.

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -200,41 +200,45 @@ function viteCloseTimeoutMs(): number {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : 5000
 }
 
-async function stopActiveViteDevServer(): Promise<void> {
-  const state = getGlobalState()
-  const previous = state.__gurenActiveViteDevServer
-
-  if (!previous) {
-    setActiveViteDevServer()
-    clearManagedViteEnv()
-    return
-  }
-
+/**
+ * `close()` bounded by {@link viteCloseTimeoutMs}: resolves once the server
+ * closed, failed to close (warned), or ran out the clock (warned, abandoned).
+ * Every shutdown path shares this — the exit handlers and the bind-failure
+ * cleanup hang on a held HMR socket exactly like a hot reload does.
+ */
+async function closeViteDevServerBounded(server: ViteServer): Promise<void> {
   let timer: ReturnType<typeof setTimeout> | undefined
-  const close = previous.close().then(
-    () => 'closed' as const,
-    (error: unknown) => {
-      console.warn('Failed to stop previous Vite dev server:', error)
-      return 'failed' as const
-    },
-  )
+  const close = server.close().catch((error: unknown) => {
+    console.warn('Failed to stop Vite dev server:', error)
+  })
 
   try {
     const timeoutMs = viteCloseTimeoutMs()
-    const outcome = await Promise.race([
-      close,
-      new Promise<'timeout'>((resolve) => {
-        timer = setTimeout(() => resolve('timeout'), timeoutMs)
+    const timedOut = await Promise.race([
+      close.then(() => false),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(true), timeoutMs)
       }),
     ])
 
-    if (outcome === 'timeout') {
+    if (timedOut) {
       console.warn(
-        `Previous Vite dev server did not close within ${timeoutMs}ms — abandoning it. A stale asset server may still hold its port.`,
+        `Vite dev server did not close within ${timeoutMs}ms — abandoning it. A stale asset server may still hold its port.`,
       )
     }
   } finally {
     clearTimeout(timer)
+  }
+}
+
+async function stopActiveViteDevServer(): Promise<void> {
+  const previous = getGlobalState().__gurenActiveViteDevServer
+
+  try {
+    if (previous) {
+      await closeViteDevServerBounded(previous)
+    }
+  } finally {
     setActiveViteDevServer()
     clearManagedViteEnv()
   }
@@ -250,9 +254,17 @@ function setActiveViteDevServer(server?: ViteServer, localUrl?: string): void {
  * The managed Vite dev server a previous `listen()` left running in this same
  * process — `bun --hot` re-runs the entrypoint but preserves `globalThis`.
  * Reusing it keeps the browser's HMR socket connected and avoids the Vite
- * `close()` wait described on {@link viteCloseTimeoutMs}.
+ * `close()` wait described on {@link viteCloseTimeoutMs}. Explicit `vite`
+ * options veto reuse: the running server was built from the *previous* call's
+ * options, and this call's may differ.
  */
-function reusableActiveViteDevServer(): { server: ViteServer; localUrl: string } | undefined {
+function reusableActiveViteDevServer(
+  viteOption: ApplicationListenOptions['vite'],
+): { server: ViteServer; localUrl: string } | undefined {
+  if (typeof viteOption === 'object') {
+    return undefined
+  }
+
   const state = getGlobalState()
   const server = state.__gurenActiveViteDevServer
   const localUrl = state.__gurenActiveViteDevServerUrl
@@ -697,26 +709,32 @@ export class Application {
       !resolvedAssetsUrl &&
       process.env?.GUREN_DEV_VITE !== '0'
 
+    // Wires a managed Vite dev server into this listen() call — instance
+    // field, active-server global, published env vars, entry sync, teardown —
+    // identically for a freshly started server and one adopted from a
+    // previous hot-reload run.
+    const adoptViteDevServer = (viteServer: ViteServer, localUrl: string): void => {
+      this.viteDevServer = viteServer
+      setActiveViteDevServer(viteServer, localUrl)
+      resolvedAssetsUrl = localUrl
+      if (typeof process !== 'undefined') {
+        process.env.VITE_DEV_SERVER_URL = localUrl
+        process.env[MANAGED_VITE_ENV_FLAG] = '1'
+      }
+      syncManagedInertiaDevEntry(localUrl)
+      this.registerViteTeardown()
+    }
+
     // On a hot reload, adopt the previous run's Vite dev server instead of
     // restarting it: the browser keeps its HMR socket, and the reload skips
-    // the `close()` wait entirely. Explicit `vite` options opt out — the
-    // running server was built from the *previous* call's options, and this
-    // call's may differ.
-    const reusableVite =
-      shouldStartVite && typeof vite !== 'object' ? reusableActiveViteDevServer() : undefined
+    // the `close()` wait entirely.
+    const reusableVite = shouldStartVite ? reusableActiveViteDevServer(vite) : undefined
 
     // Only this call's Vite server is ours to close if the bind fails below.
     let startedViteHere = false
 
     if (reusableVite) {
-      this.viteDevServer = reusableVite.server
-      resolvedAssetsUrl = reusableVite.localUrl
-      if (typeof process !== 'undefined') {
-        process.env.VITE_DEV_SERVER_URL = resolvedAssetsUrl
-        process.env[MANAGED_VITE_ENV_FLAG] = '1'
-      }
-      syncManagedInertiaDevEntry(resolvedAssetsUrl)
-      this.registerViteTeardown()
+      adoptViteDevServer(reusableVite.server, reusableVite.localUrl)
     } else {
       await stopActiveViteDevServer()
     }
@@ -733,15 +751,7 @@ export class Application {
           host: viteOptions?.host,
           port: viteOptions?.port,
         })
-        this.viteDevServer = server
-        setActiveViteDevServer(server, localUrl)
-        resolvedAssetsUrl = localUrl
-        if (typeof process !== 'undefined') {
-          process.env.VITE_DEV_SERVER_URL = resolvedAssetsUrl
-          process.env[MANAGED_VITE_ENV_FLAG] = '1'
-        }
-        syncManagedInertiaDevEntry(resolvedAssetsUrl)
-        this.registerViteTeardown()
+        adoptViteDevServer(server, localUrl)
         startedViteHere = true
       } catch (error) {
         console.error('Failed to start Vite dev server:', error)
@@ -863,9 +873,7 @@ export class Application {
     }
 
     try {
-      await this.viteDevServer.close()
-    } catch (error) {
-      console.error('Error while shutting down Vite dev server:', error)
+      await closeViteDevServerBounded(this.viteDevServer)
     } finally {
       if (getGlobalState().__gurenActiveViteDevServer === this.viteDevServer) {
         setActiveViteDevServer()

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -155,13 +155,14 @@ function syncManagedInertiaDevEntry(devServerUrl: string): void {
 type GurenGlobal = typeof globalThis & {
   __gurenActiveServer?: BunServer
   __gurenActiveViteDevServer?: ViteServer
+  __gurenActiveViteDevServerUrl?: string
 }
 
 function getGlobalState(): GurenGlobal {
   return globalThis as GurenGlobal
 }
 
-async function stopActiveBunServer(): Promise<void> {
+async function stopActiveBunServer(closeActiveConnections = false): Promise<void> {
   const state = getGlobalState()
   const previous = state.__gurenActiveServer
 
@@ -171,7 +172,7 @@ async function stopActiveBunServer(): Promise<void> {
   }
 
   try {
-    await Promise.resolve(previous.stop())
+    await Promise.resolve(previous.stop(closeActiveConnections))
   } catch (error) {
     console.warn('Failed to stop previous Bun server:', error)
   } finally {
@@ -183,28 +184,84 @@ function setActiveBunServer(server?: BunServer): void {
   getGlobalState().__gurenActiveServer = server
 }
 
+/**
+ * How long a Vite `close()` may take before shutdown abandons it. Vite waits
+ * for every open connection, and a browser tab holding its HMR socket can keep
+ * that wait alive indefinitely. An abandoned (still-listening) old asset
+ * server is recoverable noise; a `listen()` that never returns is not — the
+ * Bun server is already stopped by the time Vite is torn down, so hanging here
+ * leaves the process alive with no HTTP listener at all.
+ */
+function viteCloseTimeoutMs(): number {
+  const parsed =
+    typeof process !== 'undefined'
+      ? Number.parseInt(process.env.GUREN_VITE_CLOSE_TIMEOUT_MS ?? '', 10)
+      : Number.NaN
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 5000
+}
+
 async function stopActiveViteDevServer(): Promise<void> {
   const state = getGlobalState()
   const previous = state.__gurenActiveViteDevServer
 
   if (!previous) {
-    state.__gurenActiveViteDevServer = undefined
+    setActiveViteDevServer()
     clearManagedViteEnv()
     return
   }
 
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const close = previous.close().then(
+    () => 'closed' as const,
+    (error: unknown) => {
+      console.warn('Failed to stop previous Vite dev server:', error)
+      return 'failed' as const
+    },
+  )
+
   try {
-    await previous.close()
-  } catch (error) {
-    console.warn('Failed to stop previous Vite dev server:', error)
+    const timeoutMs = viteCloseTimeoutMs()
+    const outcome = await Promise.race([
+      close,
+      new Promise<'timeout'>((resolve) => {
+        timer = setTimeout(() => resolve('timeout'), timeoutMs)
+      }),
+    ])
+
+    if (outcome === 'timeout') {
+      console.warn(
+        `Previous Vite dev server did not close within ${timeoutMs}ms — abandoning it. A stale asset server may still hold its port.`,
+      )
+    }
   } finally {
-    state.__gurenActiveViteDevServer = undefined
+    clearTimeout(timer)
+    setActiveViteDevServer()
     clearManagedViteEnv()
   }
 }
 
-function setActiveViteDevServer(server?: ViteServer): void {
-  getGlobalState().__gurenActiveViteDevServer = server
+function setActiveViteDevServer(server?: ViteServer, localUrl?: string): void {
+  const state = getGlobalState()
+  state.__gurenActiveViteDevServer = server
+  state.__gurenActiveViteDevServerUrl = server ? localUrl : undefined
+}
+
+/**
+ * The managed Vite dev server a previous `listen()` left running in this same
+ * process — `bun --hot` re-runs the entrypoint but preserves `globalThis`.
+ * Reusing it keeps the browser's HMR socket connected and avoids the Vite
+ * `close()` wait described on {@link viteCloseTimeoutMs}.
+ */
+function reusableActiveViteDevServer(): { server: ViteServer; localUrl: string } | undefined {
+  const state = getGlobalState()
+  const server = state.__gurenActiveViteDevServer
+  const localUrl = state.__gurenActiveViteDevServerUrl
+
+  if (!server || !localUrl || !server.httpServer?.listening) {
+    return undefined
+  }
+
+  return { server, localUrl }
 }
 
 export type BootCallback = (app: Hono) => void | Promise<void>
@@ -621,8 +678,10 @@ export class Application {
       throw new Error('Bun runtime is required to call Application.listen')
     }
 
-    await stopActiveBunServer()
-    await stopActiveViteDevServer()
+    // Force-close: this path only runs when a previous `listen()` in the same
+    // process is being replaced (`bun --hot` re-running the entrypoint), and a
+    // dev reload must not wait on whatever requests the old server still holds.
+    await stopActiveBunServer(true)
 
     const { port = 3000, hostname = '0.0.0.0', assetsUrl, vite, portFallback } = options
     const externalAssetsUrl =
@@ -638,10 +697,31 @@ export class Application {
       !resolvedAssetsUrl &&
       process.env?.GUREN_DEV_VITE !== '0'
 
+    // On a hot reload, adopt the previous run's Vite dev server instead of
+    // restarting it: the browser keeps its HMR socket, and the reload skips
+    // the `close()` wait entirely. Explicit `vite` options opt out — the
+    // running server was built from the *previous* call's options, and this
+    // call's may differ.
+    const reusableVite =
+      shouldStartVite && typeof vite !== 'object' ? reusableActiveViteDevServer() : undefined
+
     // Only this call's Vite server is ours to close if the bind fails below.
     let startedViteHere = false
 
-    if (shouldStartVite) {
+    if (reusableVite) {
+      this.viteDevServer = reusableVite.server
+      resolvedAssetsUrl = reusableVite.localUrl
+      if (typeof process !== 'undefined') {
+        process.env.VITE_DEV_SERVER_URL = resolvedAssetsUrl
+        process.env[MANAGED_VITE_ENV_FLAG] = '1'
+      }
+      syncManagedInertiaDevEntry(resolvedAssetsUrl)
+      this.registerViteTeardown()
+    } else {
+      await stopActiveViteDevServer()
+    }
+
+    if (shouldStartVite && !reusableVite) {
       const viteOptions: StartViteDevServerOptions | undefined =
         typeof vite === 'object' ? vite : undefined
 
@@ -654,7 +734,7 @@ export class Application {
           port: viteOptions?.port,
         })
         this.viteDevServer = server
-        setActiveViteDevServer(server)
+        setActiveViteDevServer(server, localUrl)
         resolvedAssetsUrl = localUrl
         if (typeof process !== 'undefined') {
           process.env.VITE_DEV_SERVER_URL = resolvedAssetsUrl

--- a/packages/server/tests/http/application-listen-reuse.test.ts
+++ b/packages/server/tests/http/application-listen-reuse.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+const viteCloseMock = mock(async () => {})
+
+const startViteDevServerMock = mock(async () => ({
+  server: {
+    close: viteCloseMock,
+    httpServer: { listening: true },
+  },
+  localUrl: 'http://localhost:5174',
+  networkUrls: [],
+}))
+
+await mock.module('../../src/http/vite-dev-server', () => ({
+  startViteDevServer: startViteDevServerMock,
+}))
+
+const { Application } = await import('../../src/http/Application')
+
+type GurenGlobal = typeof globalThis & {
+  __gurenActiveServer?: unknown
+  __gurenActiveViteDevServer?: unknown
+  __gurenActiveViteDevServerUrl?: string
+}
+
+const globalState = globalThis as GurenGlobal
+
+describe('Application.listen Vite dev server reuse on hot reload', () => {
+  const originalEnv = { ...process.env }
+  const originalServe = Bun.serve
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    process.env.NODE_ENV = 'development'
+    process.env.GUREN_DEV_BANNER = '0'
+    delete process.env.VITE_DEV_SERVER_URL
+    delete process.env.GUREN_MANAGED_VITE_DEV_SERVER
+    delete process.env.GUREN_INERTIA_ENTRY
+    startViteDevServerMock.mockClear()
+    viteCloseMock.mockClear()
+    globalState.__gurenActiveServer = undefined
+    globalState.__gurenActiveViteDevServer = undefined
+    globalState.__gurenActiveViteDevServerUrl = undefined
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+    Bun.serve = originalServe
+    globalState.__gurenActiveServer = undefined
+    globalState.__gurenActiveViteDevServer = undefined
+    globalState.__gurenActiveViteDevServerUrl = undefined
+  })
+
+  it('reuses a still-listening managed Vite dev server instead of closing it', async () => {
+    // `bun --hot` re-runs the entrypoint but preserves globalThis, so a
+    // reload arrives here with the previous run's Vite server still alive.
+    // Closing it can hang forever on the browser's open HMR socket — after
+    // the Bun server was already stopped — leaving the process without any
+    // HTTP listener. Reuse is the fix; this pins it.
+    const previousClose = mock(async () => {})
+    globalState.__gurenActiveViteDevServer = {
+      close: previousClose,
+      httpServer: { listening: true },
+    }
+    globalState.__gurenActiveViteDevServerUrl = 'http://localhost:5175'
+
+    Bun.serve = mock(() => ({ stop: mock(async () => {}) })) as unknown as typeof Bun.serve
+
+    const app = new Application()
+    await app.listen({ port: 3345, hostname: '127.0.0.1' })
+
+    expect(startViteDevServerMock).not.toHaveBeenCalled()
+    expect(previousClose).not.toHaveBeenCalled()
+    expect(process.env.VITE_DEV_SERVER_URL).toBe('http://localhost:5175')
+    expect(process.env.GUREN_MANAGED_VITE_DEV_SERVER).toBe('1')
+    expect(process.env.GUREN_INERTIA_ENTRY).toBe(
+      'http://localhost:5175/resources/js/dev-entry.ts',
+    )
+    // The reused server stays recorded for the next reload.
+    expect(globalState.__gurenActiveViteDevServerUrl).toBe('http://localhost:5175')
+  })
+
+  it('restarts Vite when the previous server is no longer listening', async () => {
+    const previousClose = mock(async () => {})
+    globalState.__gurenActiveViteDevServer = {
+      close: previousClose,
+      httpServer: { listening: false },
+    }
+    globalState.__gurenActiveViteDevServerUrl = 'http://localhost:5175'
+
+    Bun.serve = mock(() => ({ stop: mock(async () => {}) })) as unknown as typeof Bun.serve
+
+    const app = new Application()
+    await app.listen({ port: 3346, hostname: '127.0.0.1' })
+
+    expect(previousClose).toHaveBeenCalledTimes(1)
+    expect(startViteDevServerMock).toHaveBeenCalledTimes(1)
+    expect(process.env.VITE_DEV_SERVER_URL).toBe('http://localhost:5174')
+  })
+
+  it('does not reuse when the call passes explicit Vite options', async () => {
+    // The running server was built from the previous call's options; explicit
+    // options on this call may differ, so they force a restart.
+    const previousClose = mock(async () => {})
+    globalState.__gurenActiveViteDevServer = {
+      close: previousClose,
+      httpServer: { listening: true },
+    }
+    globalState.__gurenActiveViteDevServerUrl = 'http://localhost:5175'
+
+    Bun.serve = mock(() => ({ stop: mock(async () => {}) })) as unknown as typeof Bun.serve
+
+    const app = new Application()
+    await app.listen({ port: 3347, hostname: '127.0.0.1', vite: { port: 5199 } })
+
+    expect(previousClose).toHaveBeenCalledTimes(1)
+    expect(startViteDevServerMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('abandons a previous Vite server whose close() never resolves', async () => {
+    // The zombie this guards against: close() hanging after the Bun server
+    // was stopped would leave the process alive with no listener at all.
+    process.env.GUREN_VITE_CLOSE_TIMEOUT_MS = '50'
+
+    globalState.__gurenActiveViteDevServer = {
+      close: () => new Promise(() => {}),
+      httpServer: { listening: false },
+    }
+    globalState.__gurenActiveViteDevServerUrl = 'http://localhost:5175'
+
+    Bun.serve = mock(() => ({ stop: mock(async () => {}) })) as unknown as typeof Bun.serve
+
+    const app = new Application()
+    await app.listen({ port: 3348, hostname: '127.0.0.1' })
+
+    expect(startViteDevServerMock).toHaveBeenCalledTimes(1)
+    expect(process.env.VITE_DEV_SERVER_URL).toBe('http://localhost:5174')
+  })
+})


### PR DESCRIPTION
## Problem

In a freshly scaffolded app (`create-guren-app`, published packages), the dev server dies silently whenever a watched backend file's content changes:

- editing `routes/web.ts` (or any backend module) by hand
- running `bunx guren add resource` / `bunx guren add auth`, which edit several

The process stays alive, nothing is printed, and nothing listens on the port anymore — every URL is dead until a manual restart. Reproduced 4 times while dogfooding the Build-a-Mini-Blog tutorial, which explicitly tells readers to keep `bun run dev` running while generating.

## Root cause

`bun --hot` re-runs the entrypoint. The new `listen()` call first stopped the previous Bun server, then awaited the previous managed Vite dev server's `close()`. Vite's `close()` waits for every open connection, and a browser tab holding its HMR socket can keep that wait alive indefinitely. Probes placed in the published dist pinned the hang exactly there:

```
[probe] listen entered
[probe] bun server stopped      ← port is now dead
(nothing further — "vite dev server stopped" never prints)
```

## Fix

- `listen()` now **adopts the still-listening Vite dev server** a previous run left on `globalThis` (which `--hot` preserves) instead of tearing it down. The browser keeps its HMR socket; the reload skips the `close()` wait entirely; the Bun listener re-binds immediately. Explicit `vite` options still force a restart — the running server was built from the previous call's options.
- The remaining close paths **abandon an unresolved `close()`** after `GUREN_VITE_CLOSE_TIMEOUT_MS` (default 5000ms) with a loud warning, so a future hang degrades to noise instead of a zombie process.
- The previous Bun server is **force-closed** on this path: a dev reload must not wait on in-flight requests (an open SSE stream could hang it the same way).

## Verification

- New tests pin all four behaviors (reuse, restart-when-dead, explicit-options restart, hanging-close abandonment); full `@guren/server` suite green (2091 pass).
- End-to-end on a scaffolded app with the fixed dist vendored in: three consecutive backend reloads (`routes/web.ts`, controller, `src/app.ts`) all re-bind and serve 200, with the same Vite instance surviving throughout.
- `bun run build`, `bun run typecheck`, `bun run test`, `audit:core-first`, `audit:docs` all green.

Why this never showed in the monorepo: `examples/blog` runs Vite as a separate process (`VITE_DEV_SERVER_URL`), so the embedded-Vite teardown path never executes there. Scaffolded apps use the embedded Vite dev server and hit it on every backend reload.