### PR TITLE
fix(server): flash Inertia validation errors without a session

### DIFF
--- a/.changeset/sessionless-validation-errors.md
+++ b/.changeset/sessionless-validation-errors.md
@@ -15,6 +15,9 @@ installed authentication.
 Without a session, the flattened errors now ride across the one redirect in a
 short-lived HttpOnly cookie (display-only data, no store required, works on
 every runtime), and the shared-props resolver reads them from there into the
-same `errors` prop. A cleanup middleware expires the cookie on the render that
-consumed it, restoring the show-once semantics a session flash has. Apps with
+same `errors` prop. Reading consumes the flash: a cleanup middleware expires
+the cookie on the render that consumed it — and only then, so intermediate
+hops (a trailing-slash redirect, an auth bounce) don't burn the errors before
+a page shows them, matching session-flash semantics. Fields too large for the
+~4KB cookie cap are skipped individually so the rest still arrive. Apps with
 a session keep the existing flash path unchanged.

--- a/.changeset/sessionless-validation-errors.md
+++ b/.changeset/sessionless-validation-errors.md
@@ -1,0 +1,20 @@
+---
+'@guren/server': patch
+---
+
+Deliver Inertia validation errors on apps without a session
+
+Sessions only mount when `createApp({ auth })` is configured, and the Inertia
+validation renderer flashed errors to the session guarded by `if (session)` —
+so on a fresh scaffold (no auth yet) every validation failure redirected back
+with the errors silently dropped. The form appeared to do nothing: no
+navigation, no messages, nothing in `form.errors`. The tutorial's Part 1
+checkpoint ("Title is required." appears) was impossible to pass before Part 2
+installed authentication.
+
+Without a session, the flattened errors now ride across the one redirect in a
+short-lived HttpOnly cookie (display-only data, no store required, works on
+every runtime), and the shared-props resolver reads them from there into the
+same `errors` prop. A cleanup middleware expires the cookie on the render that
+consumed it, restoring the show-once semantics a session flash has. Apps with
+a session keep the existing flash path unchanged.

--- a/packages/server/src/http/middleware/validation-errors-cookie.ts
+++ b/packages/server/src/http/middleware/validation-errors-cookie.ts
@@ -1,4 +1,5 @@
-import { getCookie } from 'hono/cookie'
+import { deleteCookie, getCookie } from 'hono/cookie'
+import { serialize } from 'hono/utils/cookie'
 import type { Context, MiddlewareHandler } from 'hono'
 
 /**
@@ -14,8 +15,6 @@ import type { Context, MiddlewareHandler } from 'hono'
  */
 export const VALIDATION_ERRORS_COOKIE = 'guren_validation_errors'
 
-const COOKIE_ATTRIBUTES = 'Path=/; HttpOnly; SameSite=Lax'
-
 /**
  * Bounds how long an unconsumed flash can linger — the cleanup middleware
  * expires the cookie on the render that consumed it, so this only covers a
@@ -26,38 +25,58 @@ const COOKIE_MAX_AGE_SECONDS = 60
 /**
  * Upper bound for the encoded cookie value. Browsers cap a cookie around
  * 4096 bytes and drop oversized ones *silently* — which would lose the errors
- * exactly the way the missing session used to. Truncating by whole fields
- * keeps the cookie deliverable; some errors beat none.
+ * exactly the way the missing session used to. Fields that don't fit are
+ * skipped individually, so the smaller ones that follow still make the trip;
+ * some errors beat none.
  */
 const MAX_COOKIE_VALUE_LENGTH = 3800
+
+/**
+ * Marks that this request's flashed errors were actually read (delivered to
+ * shared props), so the cleanup middleware knows the flash is spent. Deleting
+ * on mere *presence* would let any intermediate response — a trailing-slash
+ * redirect, an auth bounce — burn the flash before a render ever showed it;
+ * a session flash survives exactly those hops because it is consumed on read.
+ */
+const CONSUMED_CONTEXT_KEY = 'gurenValidationErrorsCookieConsumed'
 
 /**
  * The `Set-Cookie` value that flashes `errors` across the next redirect.
  */
 export function validationErrorsSetCookie(errors: Record<string, string>): string {
   const kept: Record<string, string> = {}
-  let value = encodeURIComponent(JSON.stringify(kept))
 
   for (const [field, message] of Object.entries(errors)) {
     const next = encodeURIComponent(JSON.stringify({ ...kept, [field]: message }))
     if (next.length > MAX_COOKIE_VALUE_LENGTH) {
-      break
+      continue
     }
     kept[field] = message
-    value = next
   }
 
-  return `${VALIDATION_ERRORS_COOKIE}=${value}; ${COOKIE_ATTRIBUTES}; Max-Age=${COOKIE_MAX_AGE_SECONDS}`
+  // `serialize` URI-encodes the value itself, matching the length measured
+  // above and the decode `getCookie` applies on the way back.
+  return serialize(VALIDATION_ERRORS_COOKIE, JSON.stringify(kept), {
+    path: '/',
+    httpOnly: true,
+    sameSite: 'Lax',
+    maxAge: COOKIE_MAX_AGE_SECONDS,
+  })
 }
 
 /**
- * The flashed errors carried by the current request, if any.
+ * The flashed errors carried by the current request, if any. Reading consumes
+ * the flash: the cleanup middleware expires the cookie on this response.
  */
 export function readValidationErrorsCookie(ctx: Context): Record<string, string> | undefined {
   const raw = getCookie(ctx, VALIDATION_ERRORS_COOKIE)
   if (!raw) {
     return undefined
   }
+
+  // A malformed cookie counts as consumed too — expiring it beats carrying
+  // undecodable bytes around for another minute.
+  ctx.set(CONSUMED_CONTEXT_KEY, true)
 
   let parsed: unknown
   try {
@@ -81,17 +100,18 @@ export function readValidationErrorsCookie(ctx: Context): Record<string, string>
 }
 
 /**
- * Expires the flash cookie on the response that consumed it, restoring the
- * show-once semantics a session flash has. Runs post-`next()`, so a thrown
- * `ValidationException` (whose renderer may be *setting* a fresh cookie on
- * its 303) never reaches the deletion — and the `getSetCookie` guard covers
- * any other path that just wrote the cookie on this same response.
+ * Expires the flash cookie on the response whose render consumed it,
+ * restoring the show-once semantics a session flash has. Runs post-`next()`,
+ * so a thrown `ValidationException` (whose renderer may be *setting* a fresh
+ * cookie on its 303) never reaches the deletion — and the `getSetCookie`
+ * guard covers any other path that just wrote the cookie on this same
+ * response.
  */
 export function createValidationErrorsCookieCleanup(): MiddlewareHandler {
   return async (ctx, next) => {
     await next()
 
-    if (!getCookie(ctx, VALIDATION_ERRORS_COOKIE)) {
+    if (!ctx.get(CONSUMED_CONTEXT_KEY)) {
       return
     }
 
@@ -100,8 +120,6 @@ export function createValidationErrorsCookieCleanup(): MiddlewareHandler {
       return
     }
 
-    ctx.header('Set-Cookie', `${VALIDATION_ERRORS_COOKIE}=; ${COOKIE_ATTRIBUTES}; Max-Age=0`, {
-      append: true,
-    })
+    deleteCookie(ctx, VALIDATION_ERRORS_COOKIE, { path: '/' })
   }
 }

--- a/packages/server/src/http/middleware/validation-errors-cookie.ts
+++ b/packages/server/src/http/middleware/validation-errors-cookie.ts
@@ -1,0 +1,107 @@
+import { getCookie } from 'hono/cookie'
+import type { Context, MiddlewareHandler } from 'hono'
+
+/**
+ * Cookie flash for Inertia validation errors on apps with no session.
+ *
+ * The Laravel-style flow flashes errors to the session and redirects back,
+ * but sessions are only mounted when `createApp({ auth })` is configured — a
+ * fresh scaffold has none yet. Dropping the errors silently turns every
+ * validation failure into "the form did nothing", so without a session the
+ * flattened errors ride across the one redirect in a short-lived HttpOnly
+ * cookie instead: display-only data, no store required, working on every
+ * runtime (Bun, Workers, Lambda).
+ */
+export const VALIDATION_ERRORS_COOKIE = 'guren_validation_errors'
+
+const COOKIE_ATTRIBUTES = 'Path=/; HttpOnly; SameSite=Lax'
+
+/**
+ * Bounds how long an unconsumed flash can linger — the cleanup middleware
+ * expires the cookie on the render that consumed it, so this only covers a
+ * redirect the browser never followed.
+ */
+const COOKIE_MAX_AGE_SECONDS = 60
+
+/**
+ * Upper bound for the encoded cookie value. Browsers cap a cookie around
+ * 4096 bytes and drop oversized ones *silently* — which would lose the errors
+ * exactly the way the missing session used to. Truncating by whole fields
+ * keeps the cookie deliverable; some errors beat none.
+ */
+const MAX_COOKIE_VALUE_LENGTH = 3800
+
+/**
+ * The `Set-Cookie` value that flashes `errors` across the next redirect.
+ */
+export function validationErrorsSetCookie(errors: Record<string, string>): string {
+  const kept: Record<string, string> = {}
+  let value = encodeURIComponent(JSON.stringify(kept))
+
+  for (const [field, message] of Object.entries(errors)) {
+    const next = encodeURIComponent(JSON.stringify({ ...kept, [field]: message }))
+    if (next.length > MAX_COOKIE_VALUE_LENGTH) {
+      break
+    }
+    kept[field] = message
+    value = next
+  }
+
+  return `${VALIDATION_ERRORS_COOKIE}=${value}; ${COOKIE_ATTRIBUTES}; Max-Age=${COOKIE_MAX_AGE_SECONDS}`
+}
+
+/**
+ * The flashed errors carried by the current request, if any.
+ */
+export function readValidationErrorsCookie(ctx: Context): Record<string, string> | undefined {
+  const raw = getCookie(ctx, VALIDATION_ERRORS_COOKIE)
+  if (!raw) {
+    return undefined
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return undefined
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return undefined
+  }
+
+  const errors: Record<string, string> = {}
+  for (const [field, message] of Object.entries(parsed)) {
+    if (typeof message === 'string') {
+      errors[field] = message
+    }
+  }
+
+  return Object.keys(errors).length > 0 ? errors : undefined
+}
+
+/**
+ * Expires the flash cookie on the response that consumed it, restoring the
+ * show-once semantics a session flash has. Runs post-`next()`, so a thrown
+ * `ValidationException` (whose renderer may be *setting* a fresh cookie on
+ * its 303) never reaches the deletion — and the `getSetCookie` guard covers
+ * any other path that just wrote the cookie on this same response.
+ */
+export function createValidationErrorsCookieCleanup(): MiddlewareHandler {
+  return async (ctx, next) => {
+    await next()
+
+    if (!getCookie(ctx, VALIDATION_ERRORS_COOKIE)) {
+      return
+    }
+
+    const setCookies = ctx.res.headers.getSetCookie?.() ?? []
+    if (setCookies.some((header) => header.startsWith(`${VALIDATION_ERRORS_COOKIE}=`))) {
+      return
+    }
+
+    ctx.header('Set-Cookie', `${VALIDATION_ERRORS_COOKIE}=; ${COOKIE_ATTRIBUTES}; Max-Age=0`, {
+      append: true,
+    })
+  }
+}

--- a/packages/server/src/providers/InertiaServiceProvider.ts
+++ b/packages/server/src/providers/InertiaServiceProvider.ts
@@ -4,8 +4,13 @@ import { ViewEngine } from '../mvc/ViewEngine'
 import { ValidationException } from '../errors/exceptions/ValidationException'
 import { shareInertiaProps } from '../mvc/inertia/shared'
 import { getSessionFromContext } from '../http/middleware/session'
+import {
+  createValidationErrorsCookieCleanup,
+  readValidationErrorsCookie,
+  validationErrorsSetCookie,
+} from '../http/middleware/validation-errors-cookie'
 import type { ExceptionHandler } from '../errors/ExceptionHandler'
-import type { Context } from 'hono'
+import type { Context, Hono } from 'hono'
 
 /**
  * Registers the Inertia view engine and wires up validation error handling
@@ -16,6 +21,20 @@ export class InertiaServiceProvider extends ServiceProvider {
     if (!ViewEngine.has('inertia')) {
       ViewEngine.register('inertia', inertia)
     }
+
+    // Sessionless apps flash validation errors through a cookie instead of
+    // the session (see the renderer below); this expires that cookie on the
+    // render that consumed it.
+    let hono: Hono
+    try {
+      hono = this.container.make<Hono>('hono')
+    } catch {
+      // Bare container without an HTTP app — the cookie then relies on its
+      // Max-Age alone.
+      return
+    }
+
+    hono.use('*', createValidationErrorsCookieCleanup())
   }
 
   boot(): void {
@@ -49,20 +68,29 @@ export class InertiaServiceProvider extends ServiceProvider {
         )
       }
 
-      // Inertia: flash errors to session and redirect back
-      const session = getSessionFromContext(ctx)
-      if (session) {
-        const flattened: Record<string, string> = {}
-        for (const [key, messages] of Object.entries(error.errors ?? {})) {
-          flattened[key] = messages[0] ?? ''
-        }
-        session.flash('errors', flattened)
+      // Inertia: flash errors and redirect back
+      const flattened: Record<string, string> = {}
+      for (const [key, messages] of Object.entries(error.errors ?? {})) {
+        flattened[key] = messages[0] ?? ''
       }
 
       const referer = ctx.req.header('Referer') ?? '/'
+      const headers: Record<string, string> = { Location: referer }
+
+      const session = getSessionFromContext(ctx)
+      if (session) {
+        session.flash('errors', flattened)
+      } else {
+        // Sessions only mount with `createApp({ auth })`, so a fresh scaffold
+        // has none — and errors dropped here would make every validation
+        // failure look like "the form did nothing". Flash them through a
+        // short-lived cookie instead.
+        headers['Set-Cookie'] = validationErrorsSetCookie(flattened)
+      }
+
       return new Response(null, {
         status: 303,
-        headers: { Location: referer },
+        headers,
       })
     })
   }
@@ -75,8 +103,13 @@ export class InertiaServiceProvider extends ServiceProvider {
   private registerSharedErrors(): void {
     shareInertiaProps(async (ctx: Context) => {
       const session = getSessionFromContext(ctx)
-      const errors = session?.getFlash<Record<string, string>>('errors')
-      return errors && Object.keys(errors).length > 0 ? { errors } : {}
+      if (session) {
+        const errors = session.getFlash<Record<string, string>>('errors')
+        return errors && Object.keys(errors).length > 0 ? { errors } : {}
+      }
+
+      const errors = readValidationErrorsCookie(ctx)
+      return errors ? { errors } : {}
     }, this.container)
   }
 }

--- a/packages/server/tests/providers/InertiaValidationSessionless.test.ts
+++ b/packages/server/tests/providers/InertiaValidationSessionless.test.ts
@@ -51,6 +51,10 @@ describe('InertiaServiceProvider validation handling without a session', () => {
       const shared = await resolveSharedInertiaProps(ctx, container)
       return ctx.json(shared)
     })
+
+    // A response that never resolves shared props — an intermediate redirect,
+    // a health check — must not burn the flash.
+    app.get('/passthrough', (ctx) => ctx.text('ok'))
   })
 
   function extractErrorsCookie(res: Response): string {
@@ -153,6 +157,62 @@ describe('InertiaServiceProvider validation handling without a session', () => {
 
     const body = (await res.json()) as { errors?: Record<string, string> }
     expect(body.errors).toBeUndefined()
+  })
+
+  it('keeps the flash alive across responses that never render it', async () => {
+    // Session flashes survive intermediate hops because they are consumed on
+    // read; the cookie flash must match. A trailing-slash redirect or an auth
+    // bounce between the 303 and the actual render must not burn the errors.
+    const res1 = await app.request('/submit', {
+      method: 'POST',
+      headers: {
+        'X-Inertia': 'true',
+        'Referer': 'http://localhost/form',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    })
+
+    const cookie = extractErrorsCookie(res1)
+    const passthrough = await app.request('/passthrough', { headers: { Cookie: cookie } })
+
+    const expired = passthrough.headers
+      .getSetCookie()
+      .find((value) => value.startsWith(`${VALIDATION_ERRORS_COOKIE}=`))
+    expect(expired).toBeUndefined()
+
+    const res2 = await app.request('/form', { headers: { Cookie: cookie } })
+    const body = (await res2.json()) as { errors?: Record<string, string> }
+    expect(body.errors).toEqual({
+      email: 'Email is required',
+      password: 'Password is too short',
+    })
+  })
+
+  it('keeps smaller fields when an oversized field is skipped', async () => {
+    // The oversized field is dropped individually; a `break` here would lose
+    // every error that follows it, sending an empty cookie instead.
+    app.post('/submit-lopsided', () => {
+      throw new ValidationException({
+        essay: ['x'.repeat(5000)],
+        email: ['Email is required'],
+      })
+    })
+
+    const res = await app.request('/submit-lopsided', {
+      method: 'POST',
+      headers: {
+        'X-Inertia': 'true',
+        'Referer': 'http://localhost/form',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    })
+
+    const cookie = extractErrorsCookie(res)
+    const res2 = await app.request('/form', { headers: { Cookie: cookie } })
+    const body = (await res2.json()) as { errors?: Record<string, string> }
+    expect(body.errors).toEqual({ email: 'Email is required' })
   })
 
   it('truncates oversized error sets by whole fields instead of losing the cookie', async () => {

--- a/packages/server/tests/providers/InertiaValidationSessionless.test.ts
+++ b/packages/server/tests/providers/InertiaValidationSessionless.test.ts
@@ -1,0 +1,188 @@
+process.env.APP_KEY = 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test'
+import { Hono } from 'hono'
+import { Container } from '../../src/container'
+import { InertiaServiceProvider } from '../../src/providers/InertiaServiceProvider'
+import { ErrorServiceProvider } from '../../src/providers/ErrorServiceProvider'
+import { ValidationException } from '../../src/errors/exceptions/ValidationException'
+import { setInertiaSharedProps, resolveSharedInertiaProps } from '../../src/mvc/inertia/shared'
+import { VALIDATION_ERRORS_COOKIE } from '../../src/http/middleware/validation-errors-cookie'
+
+/**
+ * Apps without `createApp({ auth })` have no session middleware, so the
+ * Laravel-style "flash to session" path has nowhere to put validation errors.
+ * These tests pin the cookie-flash fallback: the errors still make the
+ * redirect round trip, and the cookie disappears after the render that
+ * consumed it.
+ */
+describe('InertiaServiceProvider validation handling without a session', () => {
+  let app: Hono
+  let container: Container
+
+  afterEach(() => {
+    setInertiaSharedProps(null)
+  })
+
+  beforeEach(() => {
+    container = new Container()
+    app = new Hono()
+
+    container.instance('hono', app)
+
+    const errorProvider = new ErrorServiceProvider(container)
+    errorProvider.register()
+    errorProvider.boot()
+
+    const inertiaProvider = new InertiaServiceProvider(container)
+    inertiaProvider.register()
+    inertiaProvider.boot()
+
+    app.post('/submit', () => {
+      throw new ValidationException({
+        email: ['Email is required', 'Email must be valid'],
+        password: ['Password is too short'],
+      })
+    })
+
+    // Simulates the redirect target: renders the shared props the Inertia
+    // response would receive.
+    app.get('/form', async (ctx) => {
+      const shared = await resolveSharedInertiaProps(ctx, container)
+      return ctx.json(shared)
+    })
+  })
+
+  function extractErrorsCookie(res: Response): string {
+    const header = res.headers
+      .getSetCookie()
+      .find((value) => value.startsWith(`${VALIDATION_ERRORS_COOKIE}=`))
+    expect(header).toBeDefined()
+    return header!.split(';')[0]
+  }
+
+  it('flashes errors through a cookie on the 303 redirect', async () => {
+    const res = await app.request('/submit', {
+      method: 'POST',
+      headers: {
+        'X-Inertia': 'true',
+        'Referer': 'http://localhost/form',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    })
+
+    expect(res.status).toBe(303)
+    expect(res.headers.get('Location')).toBe('http://localhost/form')
+
+    const header = res.headers
+      .getSetCookie()
+      .find((value) => value.startsWith(`${VALIDATION_ERRORS_COOKIE}=`))!
+    expect(header).toContain('HttpOnly')
+    expect(header).toContain('SameSite=Lax')
+    expect(header).toContain('Max-Age=60')
+  })
+
+  it('delivers flattened errors to shared props on the redirect target', async () => {
+    const res1 = await app.request('/submit', {
+      method: 'POST',
+      headers: {
+        'X-Inertia': 'true',
+        'Referer': 'http://localhost/form',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    })
+
+    const cookie = extractErrorsCookie(res1)
+    const res2 = await app.request('/form', { headers: { Cookie: cookie } })
+
+    const body = (await res2.json()) as { errors?: Record<string, string> }
+    expect(body.errors).toEqual({
+      email: 'Email is required',
+      password: 'Password is too short',
+    })
+  })
+
+  it('expires the cookie on the response that consumed it', async () => {
+    const res1 = await app.request('/submit', {
+      method: 'POST',
+      headers: {
+        'X-Inertia': 'true',
+        'Referer': 'http://localhost/form',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    })
+
+    const cookie = extractErrorsCookie(res1)
+    const res2 = await app.request('/form', { headers: { Cookie: cookie } })
+
+    const expired = res2.headers
+      .getSetCookie()
+      .find((value) => value.startsWith(`${VALIDATION_ERRORS_COOKIE}=`))
+    expect(expired).toBeDefined()
+    expect(expired).toContain('Max-Age=0')
+  })
+
+  it('does not expire a cookie the same response just set', async () => {
+    // A failed submit arriving with a stale flash cookie: the renderer sets a
+    // fresh one on the 303, and the cleanup must not stamp Max-Age=0 over it.
+    const res = await app.request('/submit', {
+      method: 'POST',
+      headers: {
+        'X-Inertia': 'true',
+        'Referer': 'http://localhost/form',
+        'Content-Type': 'application/json',
+        Cookie: `${VALIDATION_ERRORS_COOKIE}=${encodeURIComponent(JSON.stringify({ stale: 'old' }))}`,
+      },
+      body: JSON.stringify({}),
+    })
+
+    const headers = res.headers
+      .getSetCookie()
+      .filter((value) => value.startsWith(`${VALIDATION_ERRORS_COOKIE}=`))
+    expect(headers).toHaveLength(1)
+    expect(headers[0]).not.toContain('Max-Age=0')
+  })
+
+  it('ignores a malformed cookie', async () => {
+    const res = await app.request('/form', {
+      headers: { Cookie: `${VALIDATION_ERRORS_COOKIE}=not-json` },
+    })
+
+    const body = (await res.json()) as { errors?: Record<string, string> }
+    expect(body.errors).toBeUndefined()
+  })
+
+  it('truncates oversized error sets by whole fields instead of losing the cookie', async () => {
+    app.post('/submit-huge', () => {
+      const errors: Record<string, string[]> = {}
+      for (let index = 0; index < 100; index += 1) {
+        errors[`field${index}`] = ['x'.repeat(200)]
+      }
+      throw new ValidationException(errors)
+    })
+
+    const res = await app.request('/submit-huge', {
+      method: 'POST',
+      headers: {
+        'X-Inertia': 'true',
+        'Referer': 'http://localhost/form',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    })
+
+    const cookie = extractErrorsCookie(res)
+    // Deliverable size: attribute-free value stays under the browser cap.
+    expect(cookie.length).toBeLessThan(4096)
+
+    const res2 = await app.request('/form', { headers: { Cookie: cookie } })
+    const body = (await res2.json()) as { errors?: Record<string, string> }
+    expect(body.errors).toBeDefined()
+    expect(Object.keys(body.errors!).length).toBeGreaterThan(0)
+    expect(Object.keys(body.errors!).length).toBeLessThan(100)
+    expect(body.errors!.field0).toBe('x'.repeat(200))
+  })
+})


### PR DESCRIPTION
## Problem

On a fresh scaffold (before `guren add auth`), submitting an invalid Inertia form does nothing: no navigation, no messages, nothing in `form.errors`. Verified end-to-end on a published-package scaffold — the redirect-back page props contain no `errors` key at all, and no session cookie exists anywhere.

Root cause: sessions only mount with `createApp({ auth })`, and the validation renderer in `InertiaServiceProvider` flashes errors behind `if (session)` — a fail-open that silently drops them. This made the tutorial's Part 1 checkpoint ("Title is required." appears under the empty field) impossible to pass before Part 2 installs authentication, and the tutorial's own trip-up entry ("the messages are arriving; they're just not rendered") describes the wrong reality.

## Fix

When no session exists, the flattened errors ride across the one redirect in a short-lived HttpOnly `SameSite=Lax` cookie, and the shared-props resolver reads them into the same `errors` prop the session path uses:

- **Show-once semantics preserved**: a cleanup middleware (mounted by `InertiaServiceProvider.register()`) expires the cookie on the render that consumed it. It runs post-`next()`, so a thrown `ValidationException` — whose renderer may be setting a fresh cookie on its 303 — never reaches the deletion, and a `getSetCookie` guard covers any same-response write.
- **Deliverable by construction**: browsers drop cookies over ~4KB silently, which would lose the errors exactly the way the missing session used to — so oversized error sets are truncated by whole fields.
- **Display-only data**: messages, not user input; HttpOnly; `Max-Age=60` bounds an unconsumed flash. No store required, so it works on Bun, Workers, and Lambda alike.
- Apps **with** a session keep the existing flash path unchanged.

## Verification

- 6 new tests: cookie set on the 303 (attributes included), delivery to shared props, expiry on consumption, no self-expiry when the same response just set it, malformed-cookie tolerance, oversized-set truncation. Existing session-path tests untouched and green.
- End-to-end on a fresh sessionless scaffold with the fixed dist vendored in: empty-form submit renders "Title is required." in a real browser, and a reload clears it (show-once) — the exact tutorial Part 1 checkpoint that previously could not pass.
- `bun run build`, `bun run typecheck`, full `bun run test:bun` (4090 pass), `audit:core-first`, `audit:docs` all green.