### PR TITLE
fix(server): drop the raw dev stylesheet link when Vite owns the entry

### DIFF
--- a/.changeset/dev-styles-link-under-vite.md
+++ b/.changeset/dev-styles-link-under-vite.md
@@ -12,7 +12,8 @@ page load. The link contributed nothing: the compiled CSS already arrives
 through Vite's module graph via the `app.tsx` import.
 
 The document renderer now drops exactly that dev-default path when the script
-entry is served from a dev server (an absolute http(s) URL). Explicitly
-configured stylesheet hrefs are left alone, fallback mode (no Vite; the entry
-served same-origin) keeps the link — there the raw file is the only styling —
-and production manifest-derived links are untouched.
+entry is served from a dev server (an absolute http(s) URL). A per-call
+`styles` option is an explicit choice and is never filtered; other
+env-configured hrefs are left alone; fallback mode (no Vite; the entry served
+same-origin) keeps the link — there the raw file is the only styling — and
+production manifest-derived links are untouched.

--- a/.changeset/dev-styles-link-under-vite.md
+++ b/.changeset/dev-styles-link-under-vite.md
@@ -1,0 +1,18 @@
+---
+'@guren/server': patch
+---
+
+Stop linking the raw dev stylesheet when a Vite dev server owns the entry
+
+In development the Inertia document linked `/resources/css/app.css` — the
+*source* file, served raw by the app server. With Tailwind in it (every
+scaffolded app), the browser then requests the bare `@import 'tailwindcss'`
+specifier as a relative URL, 404s, and logs a MIME-type console error on every
+page load. The link contributed nothing: the compiled CSS already arrives
+through Vite's module graph via the `app.tsx` import.
+
+The document renderer now drops exactly that dev-default path when the script
+entry is served from a dev server (an absolute http(s) URL). Explicitly
+configured stylesheet hrefs are left alone, fallback mode (no Vite; the entry
+served same-origin) keeps the link — there the raw file is the only styling —
+and production manifest-derived links are untouched.

--- a/packages/server/src/http/inertia-assets.ts
+++ b/packages/server/src/http/inertia-assets.ts
@@ -13,6 +13,7 @@ import {
 import { registerRootPublicAssets } from './public-assets'
 import { isPathWithin, isRealPathWithin } from '../support/contained-path'
 import { parseImportMap } from '../support/import-map'
+import { DEFAULT_DEV_STYLES_ENTRY } from '../support/inertia-defaults'
 import { trimTrailingSlashes } from '../support/trim-slashes'
 import { hash } from '../encryption/Hash'
 
@@ -37,7 +38,6 @@ export interface AutoConfigureInertiaOptions extends InertiaAssetsOptions {
 }
 
 const DEFAULT_STYLES_ENTRY = '/public/assets/app.css'
-const DEFAULT_DEV_STYLES_ENTRY = '/resources/css/app.css'
 const DEFAULT_SCRIPT_ENTRY = '/assets/app.js'
 const DEFAULT_VENDOR_CLIENT_PATH = '/vendor/inertia-client.tsx'
 

--- a/packages/server/src/mvc/inertia/InertiaEngine.ts
+++ b/packages/server/src/mvc/inertia/InertiaEngine.ts
@@ -233,12 +233,21 @@ async function renderDocument(
     process.env.GUREN_INERTIA_ENTRY ?? "/resources/js/app.tsx";
   const entry = options.entry ?? defaultEntry;
   const title = escapeHtml(options.title ?? DEFAULT_TITLE);
-  const styles =
+  const isProduction = process.env.NODE_ENV === "production";
+  const configuredStyles =
     options.styles ?? parseStylesEnv(process.env.GUREN_INERTIA_STYLES);
+  // The dev-default stylesheet path points at the *source* file, which only
+  // works when nothing has to compile it. With a Vite dev server on the
+  // entry, the compiled CSS already arrives through the module graph, and the
+  // raw file is broken besides: Tailwind's `@import 'tailwindcss'` is a bare
+  // specifier only a bundler resolves, so the browser 404s it on every page.
+  const styles =
+    !isProduction && isDevServerEntry(entry)
+      ? configuredStyles.filter((href) => href !== DEV_STYLES_SOURCE_PATH)
+      : configuredStyles;
   const envImportMap = parseImportMap(process.env.GUREN_INERTIA_IMPORT_MAP, {
     context: "GUREN_INERTIA_IMPORT_MAP",
   });
-  const isProduction = process.env.NODE_ENV === "production";
   const importMapEntries = {
     ...(isProduction ? {} : DEV_FALLBACK_IMPORT_MAP),
     ...envImportMap,
@@ -417,6 +426,23 @@ function normalizeSsrSpecifier(specifier: string): string {
 
 function isUrlLike(specifier: string): boolean {
   return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(specifier);
+}
+
+/**
+ * The stylesheet source path the dev configuration falls back to. Kept in
+ * sync with `DEFAULT_DEV_STYLES_ENTRY` in `http/inertia-assets.ts`; the
+ * document renderer drops exactly this path when a dev server owns the entry
+ * (see `renderDocument`), and leaves every explicitly configured href alone.
+ */
+const DEV_STYLES_SOURCE_PATH = "/resources/css/app.css";
+
+/**
+ * An absolute http(s) entry means an asset dev server (Vite) is serving the
+ * module graph. A same-origin path means the fallback pipeline is serving
+ * source files directly — there the raw stylesheet link is the only styling.
+ */
+function isDevServerEntry(entry: string): boolean {
+  return /^https?:\/\//iu.test(entry);
 }
 
 function renderStyles(styles: string[]): string {

--- a/packages/server/src/mvc/inertia/InertiaEngine.ts
+++ b/packages/server/src/mvc/inertia/InertiaEngine.ts
@@ -2,6 +2,7 @@ import { isAbsolute, resolve as resolvePath } from "node:path";
 import { pathToFileURL } from "node:url";
 import { ensureErrorStackTracePolyfill } from "../../support/error-polyfill";
 import { parseImportMap } from "../../support/import-map";
+import { DEFAULT_DEV_STYLES_ENTRY } from "../../support/inertia-defaults";
 
 ensureErrorStackTracePolyfill();
 
@@ -241,9 +242,11 @@ async function renderDocument(
   // entry, the compiled CSS already arrives through the module graph, and the
   // raw file is broken besides: Tailwind's `@import 'tailwindcss'` is a bare
   // specifier only a bundler resolves, so the browser 404s it on every page.
+  // A per-call `options.styles` is an explicit choice and is never filtered;
+  // only the ambient (env-derived) styles can carry the dev fallback.
   const styles =
-    !isProduction && isDevServerEntry(entry)
-      ? configuredStyles.filter((href) => href !== DEV_STYLES_SOURCE_PATH)
+    !isProduction && options.styles === undefined && isDevServerEntry(entry)
+      ? configuredStyles.filter((href) => href !== DEFAULT_DEV_STYLES_ENTRY)
       : configuredStyles;
   const envImportMap = parseImportMap(process.env.GUREN_INERTIA_IMPORT_MAP, {
     context: "GUREN_INERTIA_IMPORT_MAP",
@@ -427,14 +430,6 @@ function normalizeSsrSpecifier(specifier: string): string {
 function isUrlLike(specifier: string): boolean {
   return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(specifier);
 }
-
-/**
- * The stylesheet source path the dev configuration falls back to. Kept in
- * sync with `DEFAULT_DEV_STYLES_ENTRY` in `http/inertia-assets.ts`; the
- * document renderer drops exactly this path when a dev server owns the entry
- * (see `renderDocument`), and leaves every explicitly configured href alone.
- */
-const DEV_STYLES_SOURCE_PATH = "/resources/css/app.css";
 
 /**
  * An absolute http(s) entry means an asset dev server (Vite) is serving the

--- a/packages/server/src/support/inertia-defaults.ts
+++ b/packages/server/src/support/inertia-defaults.ts
@@ -1,0 +1,13 @@
+/**
+ * The stylesheet *source* path the dev asset configuration falls back to.
+ *
+ * Lives in a leaf module because two sides read it and must agree: the dev
+ * configuration in `http/inertia-assets.ts` publishes it into
+ * `GUREN_INERTIA_STYLES`, and the document renderer in
+ * `mvc/inertia/InertiaEngine.ts` drops exactly this path again when a dev
+ * server owns the script entry (the compiled CSS then arrives through the
+ * module graph). Importing either of those modules from the other would drag
+ * runtime-specific dependencies across the Workers/Lambda boundary or create
+ * an import cycle.
+ */
+export const DEFAULT_DEV_STYLES_ENTRY = '/resources/css/app.css'

--- a/packages/server/tests/mvc/InertiaEngine.test.ts
+++ b/packages/server/tests/mvc/InertiaEngine.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { inertia, setInertiaDocument, setInertiaSsrRenderer } from '../../src'
 
 describe('InertiaEngine SSR integration', () => {
@@ -353,5 +353,74 @@ describe('Inertia asset version mismatch', () => {
         process.env.GUREN_INERTIA_VERSION = original
       }
     }
+  })
+})
+
+describe('InertiaEngine dev stylesheet links', () => {
+  const ENV_KEYS = ['GUREN_INERTIA_ENTRY', 'GUREN_INERTIA_STYLES', 'NODE_ENV'] as const
+  let saved: Record<string, string | undefined>
+
+  beforeEach(() => {
+    saved = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]))
+  })
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = saved[key]
+      }
+    }
+  })
+
+  it('drops the dev source stylesheet when a Vite dev server owns the entry', async () => {
+    // The raw `/resources/css/app.css` is the *source* file — with Tailwind
+    // in it, the browser 404s its bare `@import 'tailwindcss'` on every page
+    // while the compiled CSS already arrives through Vite's module graph.
+    process.env.NODE_ENV = 'development'
+    process.env.GUREN_INERTIA_ENTRY = 'http://localhost:5173/resources/js/dev-entry.ts'
+    process.env.GUREN_INERTIA_STYLES = '/resources/css/app.css'
+
+    const response = await inertia('Dashboard', {}, { url: '/dashboard' })
+    const body = await response.text()
+
+    expect(body).not.toContain('/resources/css/app.css')
+  })
+
+  it('keeps explicitly configured stylesheets under a Vite dev server entry', async () => {
+    process.env.NODE_ENV = 'development'
+    process.env.GUREN_INERTIA_ENTRY = 'http://localhost:5173/resources/js/dev-entry.ts'
+    process.env.GUREN_INERTIA_STYLES = '/public/custom.css,/resources/css/app.css'
+
+    const response = await inertia('Dashboard', {}, { url: '/dashboard' })
+    const body = await response.text()
+
+    expect(body).toContain('<link rel="stylesheet" href="/public/custom.css" />')
+    expect(body).not.toContain('/resources/css/app.css')
+  })
+
+  it('keeps the dev source stylesheet when the fallback pipeline serves the entry', async () => {
+    // No Vite: the entry is a same-origin path and the raw stylesheet link is
+    // the only styling the page gets.
+    process.env.NODE_ENV = 'development'
+    process.env.GUREN_INERTIA_ENTRY = '/resources/js/app.tsx'
+    process.env.GUREN_INERTIA_STYLES = '/resources/css/app.css'
+
+    const response = await inertia('Dashboard', {}, { url: '/dashboard' })
+    const body = await response.text()
+
+    expect(body).toContain('<link rel="stylesheet" href="/resources/css/app.css" />')
+  })
+
+  it('leaves production stylesheet links untouched', async () => {
+    process.env.NODE_ENV = 'production'
+    process.env.GUREN_INERTIA_ENTRY = '/public/assets/app-abc123.js'
+    process.env.GUREN_INERTIA_STYLES = '/public/assets/app-abc123.css'
+
+    const response = await inertia('Dashboard', {}, { url: '/dashboard' })
+    const body = await response.text()
+
+    expect(body).toContain('<link rel="stylesheet" href="/public/assets/app-abc123.css" />')
   })
 })

--- a/packages/server/tests/mvc/InertiaEngine.test.ts
+++ b/packages/server/tests/mvc/InertiaEngine.test.ts
@@ -388,7 +388,7 @@ describe('InertiaEngine dev stylesheet links', () => {
     expect(body).not.toContain('/resources/css/app.css')
   })
 
-  it('keeps explicitly configured stylesheets under a Vite dev server entry', async () => {
+  it('keeps other env-configured stylesheets under a Vite dev server entry', async () => {
     process.env.NODE_ENV = 'development'
     process.env.GUREN_INERTIA_ENTRY = 'http://localhost:5173/resources/js/dev-entry.ts'
     process.env.GUREN_INERTIA_STYLES = '/public/custom.css,/resources/css/app.css'
@@ -398,6 +398,22 @@ describe('InertiaEngine dev stylesheet links', () => {
 
     expect(body).toContain('<link rel="stylesheet" href="/public/custom.css" />')
     expect(body).not.toContain('/resources/css/app.css')
+  })
+
+  it('never filters a per-call styles override', async () => {
+    // `options.styles` is an explicit choice; only the ambient env-derived
+    // styles can carry the dev fallback the filter targets.
+    process.env.NODE_ENV = 'development'
+    process.env.GUREN_INERTIA_ENTRY = 'http://localhost:5173/resources/js/dev-entry.ts'
+
+    const response = await inertia(
+      'Dashboard',
+      {},
+      { url: '/dashboard', styles: ['/resources/css/app.css'] },
+    )
+    const body = await response.text()
+
+    expect(body).toContain('<link rel="stylesheet" href="/resources/css/app.css" />')
   })
 
   it('keeps the dev source stylesheet when the fallback pipeline serves the entry', async () => {


### PR DESCRIPTION
## Problem

Every page of a scaffolded app in dev logs this console error:

```
Refused to apply style from 'http://localhost:3333/resources/css/tailwindcss'
because its MIME type ('text/plain') is not a supported stylesheet MIME type
```

The dev document links `/resources/css/app.css` — the **source** file, served raw by the app server. The template's `app.css` is just `@import 'tailwindcss';`, a bare specifier only a bundler can resolve, so the browser requests it as a relative URL and 404s on every load. The link contributes nothing: the compiled Tailwind CSS already arrives through Vite's module graph (`app.tsx` imports `../css/app.css`) — verified in a real browser, where the styles render correctly with or without the link.

## Fix

`renderDocument` now drops **exactly** the dev-default path (`/resources/css/app.css`, kept in sync with `DEFAULT_DEV_STYLES_ENTRY`) when the script entry is an absolute http(s) URL — i.e. a Vite dev server owns the module graph. Everything else is untouched:

- explicitly configured stylesheet hrefs stay,
- fallback mode (no Vite; entry served same-origin) keeps the link — there the raw file is the only styling the page gets,
- production manifest-derived `/public/assets/*.css` links are unaffected.

## Verification

- 4 new tests: dropped under a dev-server entry, custom hrefs preserved, kept under the fallback entry, production untouched.
- End-to-end on a scaffolded app with the fixed dist vendored in: zero console errors, zero `tailwindcss` requests, and Tailwind styles still applied (computed styles verified in a real browser).
- `bun run build`, `bun run typecheck`, full `bun run test:bun` (4090 pass), `audit:core-first`, `audit:docs` all green.