### PR TITLE
fix(server): include the query string in the default Inertia page url

### DIFF
--- a/.changeset/inertia-page-url-keeps-query.md
+++ b/.changeset/inertia-page-url-keeps-query.md
@@ -1,0 +1,24 @@
+---
+'@guren/server': patch
+'@guren/testing': patch
+'@guren/cli': patch
+'create-guren-app': patch
+---
+
+Keep the query string in the default Inertia page url
+
+`Controller.inertia()` resolved the page `url` from `ctx.req.path`, which is
+the pathname only — so `usePage().url` never saw the current query
+parameters. Anything deriving state from the query (pagination, filters,
+sort order) silently lost it on every visit, and navigation components that
+propagate the active query onto their links emitted bare paths. The Inertia
+protocol expects `url` to include the query string (`"/posts?page=1"`).
+
+The default is now the pathname plus the query string, derived from the full
+request URL, and stays relative as the protocol expects. An explicit
+`options.url` still overrides it. The `@guren/testing` controller mock
+mirrors the same default.
+
+The `make:auth` scaffolds and the create-app templates no longer pass
+`url: this.request.path` — they rely on the default, so generated apps get
+the query-preserving value instead of re-introducing the lossy form.

--- a/.changeset/inertia-page-url-keeps-query.md
+++ b/.changeset/inertia-page-url-keeps-query.md
@@ -14,10 +14,15 @@ sort order) silently lost it on every visit, and navigation components that
 propagate the active query onto their links emitted bare paths. The Inertia
 protocol expects `url` to include the query string (`"/posts?page=1"`).
 
-The default is now the pathname plus the query string, derived from the full
-request URL, and stays relative as the protocol expects. An explicit
-`options.url` still overrides it. The `@guren/testing` controller mock
-mirrors the same default.
+The default now lives in the `inertia()` engine itself: when `options.url`
+is absent, the page url is derived from `options.request` as the pathname
+plus the query string, kept relative as the protocol expects. This covers
+every caller that hands the engine a request — `Controller.inertia()` and
+direct `inertia()` calls alike — and an explicit `options.url` still
+overrides it. The `@guren/testing` controller mock mirrors the same
+default. On a version-mismatch 409, `X-Inertia-Location` now falls back to
+the absolute request URL when no `url` override is given, matching what the
+client does with that header.
 
 The `make:auth` scaffolds and the create-app templates no longer pass
 `url: this.request.path` — they rely on the default, so generated apps get

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -320,7 +320,7 @@ import { pages } from '@/.guren/pages.gen'
 export default class DashboardController extends Controller {
   async index() {
     const user = await this.auth.user()       // returns user or null
-    return this.inertia(pages.dashboard.Index, { user }, { url: this.request.path })
+    return this.inertia(pages.dashboard.Index, { user })
   }
 
   async store() {

--- a/docs/en/guides/controllers.md
+++ b/docs/en/guides/controllers.md
@@ -101,6 +101,8 @@ export default class PostsController extends Controller {
 | `this.redirect(url)` | 302 | HTTP redirect |
 | `this.noContent()` | 204 | Empty response |
 
+`this.inertia()` sets the Inertia page `url` to the request path including the query string (e.g. `/posts?page=2`), which is what `usePage().url` returns on the client. Pass the `url` option only when you need to override it.
+
 ## Reading Input
 
 Controllers parse both JSON and form-encoded bodies automatically:

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -318,7 +318,7 @@ import { pages } from '@/.guren/pages.gen'
 export default class DashboardController extends Controller {
   async index() {
     const user = await this.auth.user()       // ユーザーまたは null を返す
-    return this.inertia(pages.dashboard.Index, { user }, { url: this.request.path })
+    return this.inertia(pages.dashboard.Index, { user })
   }
 
   async store() {

--- a/docs/ja/guides/controllers.md
+++ b/docs/ja/guides/controllers.md
@@ -159,6 +159,8 @@ if (await this.has('email')) {
 | `this.noContent()` | 空の 204 レスポンスを返します。 |
 | `this.redirect(url, status?)` | 別の場所にリダイレクトします（デフォルトステータス 302）。 |
 
+`this.inertia()` は Inertia ページの `url` にクエリ文字列を含むリクエストパス（例: `/posts?page=2`）を設定します。クライアント側の `usePage().url` はこの値を返します。上書きしたい場合のみ `url` オプションを渡してください。
+
 ### レスポンスヘルパーの例
 
 ```ts

--- a/examples/blog/app/Http/Controllers/Auth/ForgotPasswordController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/ForgotPasswordController.ts
@@ -33,8 +33,6 @@ export default class ForgotPasswordController extends Controller {
       await SendPasswordResetEmailJob.dispatch({ email, resetUrl })
     }
 
-    return this.inertia(pages.auth.ForgotPassword, { status: STATUS_MESSAGE }, {
-      title: 'Forgot password | Guren Blog',
-    })
+    return this.inertia(pages.auth.ForgotPassword, { status: STATUS_MESSAGE }, { title: 'Forgot password | Guren Blog' })
   }
 }

--- a/examples/blog/app/Http/Controllers/Auth/ForgotPasswordController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/ForgotPasswordController.ts
@@ -10,7 +10,7 @@ const STATUS_MESSAGE = "If an account exists for that email, we've sent a passwo
 
 export default class ForgotPasswordController extends Controller {
   async show(): Promise<Response> {
-    return this.inertia(pages.auth.ForgotPassword, {}, { url: this.request.path, title: 'Forgot password | Guren Blog' })
+    return this.inertia(pages.auth.ForgotPassword, {}, { title: 'Forgot password | Guren Blog' })
   }
 
   async store(): Promise<Response> {
@@ -34,7 +34,6 @@ export default class ForgotPasswordController extends Controller {
     }
 
     return this.inertia(pages.auth.ForgotPassword, { status: STATUS_MESSAGE }, {
-      url: this.request.path,
       title: 'Forgot password | Guren Blog',
     })
   }

--- a/examples/blog/app/Http/Controllers/Auth/LoginController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/LoginController.ts
@@ -7,7 +7,7 @@ import { pages } from '@/.guren/pages.gen'
 export default class LoginController extends Controller {
   async show(): Promise<Response> {
     const email = this.request.query('email') ?? ''
-    return this.inertia(pages.auth.Login, { email }, { url: this.request.path, title: 'Login | Guren Blog' })
+    return this.inertia(pages.auth.Login, { email }, { title: 'Login | Guren Blog' })
   }
 
   async store(): Promise<Response> {

--- a/examples/blog/app/Http/Controllers/Auth/RegisterController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/RegisterController.ts
@@ -9,7 +9,7 @@ import { pages } from '@/.guren/pages.gen'
 
 export default class RegisterController extends Controller {
   async show(): Promise<Response> {
-    return this.inertia(pages.auth.Register, {}, { url: this.request.path, title: 'Register | Guren Blog' })
+    return this.inertia(pages.auth.Register, {}, { title: 'Register | Guren Blog' })
   }
 
   async store(): Promise<Response> {

--- a/examples/blog/app/Http/Controllers/Auth/ResetPasswordController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/ResetPasswordController.ts
@@ -11,7 +11,6 @@ export default class ResetPasswordController extends Controller {
     const token = this.request.query('token') ?? ''
     const email = this.request.query('email') ?? ''
     return this.inertia(pages.auth.ResetPassword, { token, email }, {
-      url: this.request.path,
       title: 'Reset password | Guren Blog',
     })
   }

--- a/examples/blog/app/Http/Controllers/Auth/ResetPasswordController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/ResetPasswordController.ts
@@ -10,9 +10,7 @@ export default class ResetPasswordController extends Controller {
   async show(): Promise<Response> {
     const token = this.request.query('token') ?? ''
     const email = this.request.query('email') ?? ''
-    return this.inertia(pages.auth.ResetPassword, { token, email }, {
-      title: 'Reset password | Guren Blog',
-    })
+    return this.inertia(pages.auth.ResetPassword, { token, email }, { title: 'Reset password | Guren Blog' })
   }
 
   async store(): Promise<Response> {

--- a/examples/blog/app/Http/Controllers/Auth/VerifyEmailController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/VerifyEmailController.ts
@@ -40,9 +40,7 @@ export default class VerifyEmailController extends Controller {
     })
 
     if (!verifiedEmail) {
-      return this.inertia(pages.auth.VerifyEmail, { status: EXPIRED_MESSAGE }, {
-        title: 'Verify email | Guren Blog',
-      })
+      return this.inertia(pages.auth.VerifyEmail, { status: EXPIRED_MESSAGE }, { title: 'Verify email | Guren Blog' })
     }
 
     return this.redirect('/dashboard')

--- a/examples/blog/app/Http/Controllers/Auth/VerifyEmailController.ts
+++ b/examples/blog/app/Http/Controllers/Auth/VerifyEmailController.ts
@@ -14,7 +14,7 @@ export default class VerifyEmailController extends Controller {
       return this.redirect('/dashboard')
     }
 
-    return this.inertia(pages.auth.VerifyEmail, {}, { url: this.request.path, title: 'Verify email | Guren Blog' })
+    return this.inertia(pages.auth.VerifyEmail, {}, { title: 'Verify email | Guren Blog' })
   }
 
   async resend(): Promise<Response> {
@@ -28,7 +28,7 @@ export default class VerifyEmailController extends Controller {
 
     return this.inertia(pages.auth.VerifyEmail, {
       status: 'A new verification link has been sent to your email address.',
-    }, { url: this.request.path, title: 'Verify email | Guren Blog' })
+    }, { title: 'Verify email | Guren Blog' })
   }
 
   async confirm(): Promise<Response> {
@@ -41,7 +41,6 @@ export default class VerifyEmailController extends Controller {
 
     if (!verifiedEmail) {
       return this.inertia(pages.auth.VerifyEmail, { status: EXPIRED_MESSAGE }, {
-        url: this.request.path,
         title: 'Verify email | Guren Blog',
       })
     }

--- a/examples/blog/app/Http/Controllers/DashboardController.ts
+++ b/examples/blog/app/Http/Controllers/DashboardController.ts
@@ -4,6 +4,6 @@ import { pages } from '@/.guren/pages.gen'
 export default class DashboardController extends Controller {
   async index() {
     const user = await this.auth.user<{ id: number; name: string; email: string }>()
-    return this.inertia(pages.dashboard.Index, { user }, { url: this.request.path, title: 'Dashboard | Guren Blog' })
+    return this.inertia(pages.dashboard.Index, { user }, { title: 'Dashboard | Guren Blog' })
   }
 }

--- a/examples/blog/app/Http/Controllers/PostController.ts
+++ b/examples/blog/app/Http/Controllers/PostController.ts
@@ -33,7 +33,7 @@ export default class PostController extends Controller {
     const paginator = paginate(result, { path: this.request.path ?? '/' })
     const data = result.data.map((post) => new PostResource(post).toJSON())
     const pagination = { meta: paginator.meta(), links: paginator.links() }
-    return this.inertia(pages.posts.Index, { data, pagination }, { url: this.request.url ?? this.request.path, title: 'Posts | Guren Blog' })
+    return this.inertia(pages.posts.Index, { data, pagination }, { title: 'Posts | Guren Blog' })
   }
 
   async show(): Promise<InertiaResponse<'posts/Show', PostShowInertiaProps> | Response> {

--- a/examples/blog/app/Http/Controllers/PostController.ts
+++ b/examples/blog/app/Http/Controllers/PostController.ts
@@ -49,11 +49,11 @@ export default class PostController extends Controller {
       notificationArtifactPath: resource.notificationArtifactPath,
       broadcastChannels: resource.broadcastChannels,
     }
-    return this.inertia(pages.posts.Show, { post: payload }, { url: this.request.path, title: `${post.title} | Guren Blog` })
+    return this.inertia(pages.posts.Show, { post: payload }, { title: `${post.title} | Guren Blog` })
   }
 
   async create(): Promise<Response> {
-    return this.inertia(pages.posts.New, {}, { url: this.request.path, title: 'New Post | Guren Blog' })
+    return this.inertia(pages.posts.New, {}, { title: 'New Post | Guren Blog' })
   }
 
   async store(): Promise<Response> {
@@ -76,7 +76,7 @@ export default class PostController extends Controller {
     const post = await Post.findOrFail(id) as BoundPost
     const formPost = PostFormSchema.parse(post)
 
-    return this.inertia(pages.posts.Edit, { post: formPost, postId: post.id }, { url: this.request.path, title: `Edit ${formPost.title} | Guren Blog` })
+    return this.inertia(pages.posts.Edit, { post: formPost, postId: post.id }, { title: `Edit ${formPost.title} | Guren Blog` })
   }
 
   async update(): Promise<Response> {

--- a/examples/blog/app/Http/Controllers/ProfileController.ts
+++ b/examples/blog/app/Http/Controllers/ProfileController.ts
@@ -15,7 +15,7 @@ export default class ProfileController extends Controller {
 
     return this.inertia(pages.profile.Edit, {
       profile: { name: authed.name, email: authed.email },
-    }, { url: this.request.path, title: 'Edit Profile | Guren Blog' })
+    }, { title: 'Edit Profile | Guren Blog' })
   }
 
   async update(): Promise<Response> {
@@ -76,6 +76,6 @@ export default class ProfileController extends Controller {
       status: emailChanged
         ? 'Profile updated. Check your new email address for a verification link.'
         : 'Profile updated successfully.',
-    }, { url: this.request.path, title: 'Edit Profile | Guren Blog' })
+    }, { title: 'Edit Profile | Guren Blog' })
   }
 }

--- a/examples/blog/tests/controllers/LoginController.test.ts
+++ b/examples/blog/tests/controllers/LoginController.test.ts
@@ -59,7 +59,7 @@ describe('LoginController', () => {
     expect(format).toBe('json')
     expect(payload.component).toBe('auth/Login')
     expect(payload.props.email).toBe('jane@example.com')
-    expect(payload.url).toBe('/login')
+    expect(payload.url).toBe('/login?email=jane@example.com')
   })
 
   it('embeds Inertia page data in HTML for full visits', async () => {

--- a/examples/blog/tests/controllers/auth.test.ts
+++ b/examples/blog/tests/controllers/auth.test.ts
@@ -81,7 +81,7 @@ describe('LoginController', () => {
       expect(format).toBe('json')
       expect(payload.component).toBe('auth/Login')
       expect(payload.props.email).toBe('jane@example.com')
-      expect(payload.url).toBe('/login')
+      expect(payload.url).toBe('/login?email=jane@example.com')
     })
 
     it('embeds Inertia page data in HTML for full page visits', async () => {

--- a/examples/blog/tests/controllers/inertia.test.ts
+++ b/examples/blog/tests/controllers/inertia.test.ts
@@ -229,7 +229,7 @@ describe('Inertia Response Format', () => {
     expect((payload.props.user as { name: string }).name).toBe('Test <User>')
   })
 
-  it('preserves URL path in payload', async () => {
+  it('preserves URL path and query in payload', async () => {
     const mockUser = { id: 1, name: 'Test User', email: 'test@example.com' }
     const auth = createAuthStub(mockUser)
     const ctx = createControllerContext('http://blog.test/dashboard?tab=settings', {
@@ -240,7 +240,7 @@ describe('Inertia Response Format', () => {
     const response = await controller.index()
     const { payload } = await readInertiaResponse(response)
 
-    expect(payload.url).toBe('/dashboard')
+    expect(payload.url).toBe('/dashboard?tab=settings')
   })
 })
 

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -31,8 +31,8 @@ function buildLoginControllerTemplate(includePassword: boolean): string {
 
   const showBody = includePassword
     ? `    const email = this.request.query('email') ?? ''
-    return this.inertia(pages.auth.Login, { email }, { url: this.request.path, title: 'Login' })`
-    : `    return this.inertia(pages.auth.Login, {}, { url: this.request.path, title: 'Login' })`
+    return this.inertia(pages.auth.Login, { email }, { title: 'Login' })`
+    : `    return this.inertia(pages.auth.Login, {}, { title: 'Login' })`
 
   const storeAction = includePassword
     ? `
@@ -98,7 +98,7 @@ import { pages } from '@/.guren/pages.gen'
 
 export default class RegisterController extends Controller {
   async show(): Promise<Response> {
-    return this.inertia(pages.auth.Register, {}, { url: this.request.path, title: 'Register' })
+    return this.inertia(pages.auth.Register, {}, { title: 'Register' })
   }
 
   async store(): Promise<Response> {
@@ -134,7 +134,7 @@ const STATUS_MESSAGE = "If an account exists for that email, we've sent a passwo
 
 export default class ForgotPasswordController extends Controller {
   async show(): Promise<Response> {
-    return this.inertia(pages.auth.ForgotPassword, {}, { url: this.request.path, title: 'Forgot password' })
+    return this.inertia(pages.auth.ForgotPassword, {}, { title: 'Forgot password' })
   }
 
   async store(): Promise<Response> {
@@ -160,7 +160,6 @@ export default class ForgotPasswordController extends Controller {
     }
 
     return this.inertia(pages.auth.ForgotPassword, { status: STATUS_MESSAGE }, {
-      url: this.request.path,
       title: 'Forgot password',
     })
   }
@@ -180,7 +179,6 @@ export default class ResetPasswordController extends Controller {
     const token = this.request.query('token') ?? ''
     const email = this.request.query('email') ?? ''
     return this.inertia(pages.auth.ResetPassword, { token, email }, {
-      url: this.request.path,
       title: 'Reset password',
     })
   }
@@ -224,7 +222,7 @@ export default class VerifyEmailController extends Controller {
       return this.redirect('/dashboard')
     }
 
-    return this.inertia(pages.auth.VerifyEmail, {}, { url: this.request.path, title: 'Verify email' })
+    return this.inertia(pages.auth.VerifyEmail, {}, { title: 'Verify email' })
   }
 
   async resend(): Promise<Response> {
@@ -238,7 +236,7 @@ export default class VerifyEmailController extends Controller {
 
     return this.inertia(pages.auth.VerifyEmail, {
       status: 'A new verification link has been sent to your email address.',
-    }, { url: this.request.path, title: 'Verify email' })
+    }, { title: 'Verify email' })
   }
 
   async confirm(): Promise<Response> {
@@ -251,7 +249,6 @@ export default class VerifyEmailController extends Controller {
 
     if (!verifiedEmail) {
       return this.inertia(pages.auth.VerifyEmail, { status: EXPIRED_MESSAGE }, {
-        url: this.request.path,
         title: 'Verify email',
       })
     }
@@ -437,7 +434,7 @@ export default class DashboardController extends Controller {
           email: currentUser.email,
         }
       : null
-    return this.inertia(pages.dashboard.Index, { user }, { url: this.request.path, title: 'Dashboard' })
+    return this.inertia(pages.dashboard.Index, { user }, { title: 'Dashboard' })
   }
 }
 `
@@ -471,7 +468,7 @@ export default class ProfileController extends Controller {
         name: user.name,
         email: user.email,
       },
-    }, { url: this.request.path, title: 'Profile' })
+    }, { title: 'Profile' })
   }
 
   async update(): Promise<Response> {
@@ -493,7 +490,7 @@ export default class ProfileController extends Controller {
     return this.inertia(pages.profile.Edit, {
       profile: { name, email: user.email },
       status: 'Profile updated successfully.',
-    }, { url: this.request.path, title: 'Profile' })
+    }, { title: 'Profile' })
   }
 }
 `
@@ -562,7 +559,7 @@ export default class ProfileController extends Controller {
         name: user.name,
         email: user.email,
       },
-    }, { url: this.request.path, title: 'Profile' })
+    }, { title: 'Profile' })
   }
 
   async update(): Promise<Response> {
@@ -595,7 +592,7 @@ ${verifyResend}
     return this.inertia(pages.profile.Edit, {
       profile: { name, email },
       status: ${statusMessage},
-    }, { url: this.request.path, title: 'Profile' })
+    }, { title: 'Profile' })
   }
 }
 `

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -159,9 +159,7 @@ export default class ForgotPasswordController extends Controller {
       })
     }
 
-    return this.inertia(pages.auth.ForgotPassword, { status: STATUS_MESSAGE }, {
-      title: 'Forgot password',
-    })
+    return this.inertia(pages.auth.ForgotPassword, { status: STATUS_MESSAGE }, { title: 'Forgot password' })
   }
 }
 `
@@ -178,9 +176,7 @@ export default class ResetPasswordController extends Controller {
   async show(): Promise<Response> {
     const token = this.request.query('token') ?? ''
     const email = this.request.query('email') ?? ''
-    return this.inertia(pages.auth.ResetPassword, { token, email }, {
-      title: 'Reset password',
-    })
+    return this.inertia(pages.auth.ResetPassword, { token, email }, { title: 'Reset password' })
   }
 
   async store(): Promise<Response> {
@@ -248,9 +244,7 @@ export default class VerifyEmailController extends Controller {
     })
 
     if (!verifiedEmail) {
-      return this.inertia(pages.auth.VerifyEmail, { status: EXPIRED_MESSAGE }, {
-        title: 'Verify email',
-      })
+      return this.inertia(pages.auth.VerifyEmail, { status: EXPIRED_MESSAGE }, { title: 'Verify email' })
     }
 
     return this.redirect('/dashboard')

--- a/packages/create-app/templates/blog/app/Http/Controllers/Auth/LoginController.ts
+++ b/packages/create-app/templates/blog/app/Http/Controllers/Auth/LoginController.ts
@@ -5,7 +5,7 @@ import { pages } from '@/.guren/pages.gen'
 export default class LoginController extends Controller {
   async show(): Promise<Response> {
     const email = this.request.query('email') ?? ''
-    return this.inertia(pages.auth.Login, { email }, { url: this.request.path, title: 'Login' })
+    return this.inertia(pages.auth.Login, { email }, { title: 'Login' })
   }
 
   async store(): Promise<Response> {

--- a/packages/create-app/templates/blog/app/Http/Controllers/Auth/RegisterController.ts
+++ b/packages/create-app/templates/blog/app/Http/Controllers/Auth/RegisterController.ts
@@ -5,7 +5,7 @@ import { pages } from '@/.guren/pages.gen'
 
 export default class RegisterController extends Controller {
   async show(): Promise<Response> {
-    return this.inertia(pages.auth.Register, {}, { url: this.request.path, title: 'Register' })
+    return this.inertia(pages.auth.Register, {}, { title: 'Register' })
   }
 
   async store(): Promise<Response> {

--- a/packages/create-app/templates/blog/app/Http/Controllers/DashboardController.ts
+++ b/packages/create-app/templates/blog/app/Http/Controllers/DashboardController.ts
@@ -12,6 +12,6 @@ export default class DashboardController extends Controller {
           email: currentUser.email,
         }
       : null
-    return this.inertia(pages.dashboard.Index, { user }, { url: this.request.path, title: 'Dashboard' })
+    return this.inertia(pages.dashboard.Index, { user }, { title: 'Dashboard' })
   }
 }

--- a/packages/create-app/templates/blog/app/Http/Controllers/HomeController.ts
+++ b/packages/create-app/templates/blog/app/Http/Controllers/HomeController.ts
@@ -16,7 +16,7 @@ export default class HomeController extends Controller {
     return this.inertia(
       pages.Home,
       { latest: latest.map((post) => new PostResource(post).toJSON()) },
-      { url: this.request.path, title: '__APP_TITLE__' },
+      { title: '__APP_TITLE__' },
     )
   }
 }

--- a/packages/create-app/templates/blog/app/Http/Controllers/ProfileController.ts
+++ b/packages/create-app/templates/blog/app/Http/Controllers/ProfileController.ts
@@ -15,7 +15,7 @@ export default class ProfileController extends Controller {
         name: user.name,
         email: user.email,
       },
-    }, { url: this.request.path, title: 'Profile' })
+    }, { title: 'Profile' })
   }
 
   async update(): Promise<Response> {
@@ -49,6 +49,6 @@ export default class ProfileController extends Controller {
     return this.inertia(pages.profile.Edit, {
       profile: { name, email },
       status: 'Profile updated successfully.',
-    }, { url: this.request.path, title: 'Profile' })
+    }, { title: 'Profile' })
   }
 }

--- a/packages/create-app/templates/default/app/Http/Controllers/HomeController.ts
+++ b/packages/create-app/templates/default/app/Http/Controllers/HomeController.ts
@@ -8,6 +8,6 @@ export default class HomeController extends Controller {
       message: this.t('messages.welcome', { name: '__APP_TITLE__' }),
     }
 
-    return this.inertia(pages.Home, props, { url: this.request.path, title: '__APP_TITLE__' })
+    return this.inertia(pages.Home, props, { title: '__APP_TITLE__' })
   }
 }

--- a/packages/server/src/mvc/Controller.ts
+++ b/packages/server/src/mvc/Controller.ts
@@ -307,7 +307,10 @@ export class Controller {
   ): Promise<InertiaResponse<Component, Props & ResolvedSharedInertiaProps>> {
     const ctx = this.ctx
     const { url: overrideUrl, ...rest } = options
-    const url = overrideUrl ?? ctx.req.path ?? ctx.req.url ?? ''
+    // The Inertia protocol's page `url` is the path plus the query string
+    // (e.g. "/posts?page=1"). ctx.req.path is the pathname only, so derive
+    // the default from the full request URL instead.
+    const url = overrideUrl ?? inertiaPageUrl(ctx.req.url) ?? ctx.req.path ?? ''
     const component =
       typeof componentOrPage === 'string'
         ? componentOrPage
@@ -656,5 +659,17 @@ export class Controller {
     }
 
     return this.parsedBody
+  }
+}
+
+function inertiaPageUrl(requestUrl: string | undefined): string | undefined {
+  if (requestUrl === undefined) {
+    return undefined
+  }
+  try {
+    const { pathname, search } = new URL(requestUrl)
+    return `${pathname}${search}`
+  } catch {
+    return undefined
   }
 }

--- a/packages/server/src/mvc/Controller.ts
+++ b/packages/server/src/mvc/Controller.ts
@@ -306,11 +306,6 @@ export class Controller {
     options: InertiaResponseOptions = {},
   ): Promise<InertiaResponse<Component, Props & ResolvedSharedInertiaProps>> {
     const ctx = this.ctx
-    const { url: overrideUrl, ...rest } = options
-    // The Inertia protocol's page `url` is the path plus the query string
-    // (e.g. "/posts?page=1"). ctx.req.path is the pathname only, so derive
-    // the default from the full request URL instead.
-    const url = overrideUrl ?? inertiaPageUrl(ctx.req.url) ?? ctx.req.path ?? ''
     const component =
       typeof componentOrPage === 'string'
         ? componentOrPage
@@ -319,12 +314,13 @@ export class Controller {
     const sharedProps = await resolveSharedInertiaProps(ctx, this._container)
     const propsWithShared = { ...sharedProps, ...props } as Props & ResolvedSharedInertiaProps
 
+    // The engine derives the page url (path + query string) from the request
+    // when options.url is absent.
     const response = await inertia(component, propsWithShared as Record<string, unknown>, {
-      ...rest,
+      ...options,
       // No 'en' fallback here (unlike the locale getter): unconfigured apps
       // keep the Inertia engine's own default lang.
-      lang: rest.lang ?? this.#resolveLocale(),
-      url,
+      lang: options.lang ?? this.#resolveLocale(),
       request: ctx.req.raw,
     })
 
@@ -659,17 +655,5 @@ export class Controller {
     }
 
     return this.parsedBody
-  }
-}
-
-function inertiaPageUrl(requestUrl: string | undefined): string | undefined {
-  if (requestUrl === undefined) {
-    return undefined
-  }
-  try {
-    const { pathname, search } = new URL(requestUrl)
-    return `${pathname}${search}`
-  } catch {
-    return undefined
   }
 }

--- a/packages/server/src/mvc/inertia/InertiaEngine.ts
+++ b/packages/server/src/mvc/inertia/InertiaEngine.ts
@@ -170,7 +170,7 @@ export async function inertia(
   const page: InertiaPagePayload = {
     component,
     props,
-    url: options.url ?? "",
+    url: options.url ?? inertiaPageUrl(options.request) ?? "",
     version: resolvedVersion,
   };
 
@@ -224,6 +224,20 @@ export async function inertia(
       ...options.headers,
     },
   });
+}
+
+/**
+ * The Inertia protocol's page `url` is the request path including the query
+ * string (e.g. "/posts?page=1"), kept relative. Derive it from the request
+ * when the caller does not override it.
+ */
+function inertiaPageUrl(request: Request | undefined): string | undefined {
+  if (!request) {
+    return undefined;
+  }
+
+  const { pathname, search } = new URL(request.url);
+  return `${pathname}${search}`;
 }
 
 async function renderDocument(

--- a/packages/server/tests/application.test.ts
+++ b/packages/server/tests/application.test.ts
@@ -84,6 +84,24 @@ describe('Application routing integration', () => {
     })
   })
 
+  it('keeps the query string in the Inertia page url', async () => {
+    const app = new Application()
+    app.router.get('/dashboard', [InertiaController, 'index'])
+    await app.boot()
+
+    const response = await app.fetch(
+      new Request('http://example.com/dashboard?page=2&sort=desc', {
+        headers: {
+          'X-Inertia': 'true',
+          Accept: 'application/json',
+        },
+      }),
+    )
+
+    const payload = await response.json() as { url: string }
+    expect(payload.url).toBe('/dashboard?page=2&sort=desc')
+  })
+
   it('accepts page contract objects in controller inertia responses', async () => {
     const app = new Application()
     app.router.get('/dashboard', [ContractInertiaController, 'index'])

--- a/packages/server/tests/mvc/InertiaEngine.test.ts
+++ b/packages/server/tests/mvc/InertiaEngine.test.ts
@@ -277,6 +277,37 @@ describe('Inertia asset version mismatch', () => {
     expect(response.headers.get('X-Inertia-Location')).toBe('/dashboard')
   })
 
+  it('derives the page url from the request, keeping the query string', async () => {
+    const response = await inertia(
+      'Probe',
+      {},
+      {
+        request: new Request('http://example.com/probe?from=2026-07-01&to=2026-07-28', {
+          headers: { 'X-Inertia': 'true', Accept: 'application/json' },
+        }),
+      },
+    )
+    const payload = await response.json() as { url: string }
+
+    expect(payload.url).toBe('/probe?from=2026-07-01&to=2026-07-28')
+  })
+
+  it('options.url overrides the request-derived page url', async () => {
+    const response = await inertia(
+      'Probe',
+      {},
+      {
+        url: '/custom',
+        request: new Request('http://example.com/probe?x=1', {
+          headers: { 'X-Inertia': 'true', Accept: 'application/json' },
+        }),
+      },
+    )
+    const payload = await response.json() as { url: string }
+
+    expect(payload.url).toBe('/custom')
+  })
+
   it('falls back to request.url for X-Inertia-Location when options.url is absent', async () => {
     const response = await inertia(
       'Dashboard',

--- a/packages/testing/src/controller.ts
+++ b/packages/testing/src/controller.ts
@@ -131,10 +131,12 @@ export function createGurenControllerModule() {
         typeof componentOrPage === 'string'
           ? componentOrPage
           : componentOrPage.component ?? componentOrPage.id
+      // Mirrors the real Controller.inertia(): the page url defaults to the
+      // request's pathname plus query string, per the Inertia protocol.
+      const parsedUrl = new URL(request.url)
       const url =
         (options.url as string | undefined) ??
-        ctx.req.path ??
-        new URL(request.url).pathname
+        `${parsedUrl.pathname}${parsedUrl.search}`
       const status = (options.status as number | undefined) ?? 200
       const payload: InertiaPayload = {
         component,

--- a/packages/testing/src/controller.ts
+++ b/packages/testing/src/controller.ts
@@ -131,12 +131,13 @@ export function createGurenControllerModule() {
         typeof componentOrPage === 'string'
           ? componentOrPage
           : componentOrPage.component ?? componentOrPage.id
-      // Mirrors the real Controller.inertia(): the page url defaults to the
+      // Mirrors the real inertia() engine: the page url defaults to the
       // request's pathname plus query string, per the Inertia protocol.
-      const parsedUrl = new URL(request.url)
-      const url =
-        (options.url as string | undefined) ??
-        `${parsedUrl.pathname}${parsedUrl.search}`
+      let url = options.url as string | undefined
+      if (url === undefined) {
+        const { pathname, search } = new URL(request.url)
+        url = `${pathname}${search}`
+      }
       const status = (options.status as number | undefined) ?? 200
       const payload: InertiaPayload = {
         component,

--- a/packages/testing/tests/controller.test.ts
+++ b/packages/testing/tests/controller.test.ts
@@ -142,6 +142,21 @@ describe('createGurenControllerModule', () => {
     expect(payload.url).toBe('/custom')
   })
 
+  it('Controller.inertia defaults the URL to the request path plus query string', async () => {
+    const { Controller } = createGurenControllerModule()
+    const ctx = createControllerContext('http://example.com/posts?page=2&sort=desc', {
+      headers: { 'X-Inertia': 'true' },
+    })
+
+    const controller = new Controller()
+    controller.setContext(ctx as unknown as ControllerContext)
+
+    const response = controller.inertia('Component', {})
+    const { payload } = await readInertiaResponse(response)
+
+    expect(payload.url).toBe('/posts?page=2&sort=desc')
+  })
+
   it('parseRequestPayload parses JSON body', async () => {
     const module = createGurenControllerModule()
     const ctx = createControllerContext('http://example.com/', {

--- a/web/app/Http/Controllers/DocsController.ts
+++ b/web/app/Http/Controllers/DocsController.ts
@@ -66,7 +66,6 @@ export default class DocsController extends Controller {
       pages.Docs.Index,
       { categories, locale, locales, basePath },
       {
-        url: this.request.path,
         title: this.#titleForLocale(locale),
         lang: locale,
       },
@@ -102,7 +101,6 @@ export default class DocsController extends Controller {
       pages.Docs.Show,
       { categories, doc, active, locale, locales, basePath },
       {
-        url: this.request.path,
         title,
         status: doc ? 200 : 404,
         lang: locale,

--- a/web/app/Http/Controllers/HomeController.ts
+++ b/web/app/Http/Controllers/HomeController.ts
@@ -28,7 +28,6 @@ export default class HomeController extends Controller {
     const codeExamples = await getHighlightedExamples()
 
     return this.inertia(pages.Home, { codeExamples }, {
-      url: this.request.path,
       title: SITE_TITLE,
     })
   }

--- a/web/app/Http/Controllers/HomeController.ts
+++ b/web/app/Http/Controllers/HomeController.ts
@@ -27,8 +27,6 @@ export default class HomeController extends Controller {
   async index(): Promise<Response> {
     const codeExamples = await getHighlightedExamples()
 
-    return this.inertia(pages.Home, { codeExamples }, {
-      title: SITE_TITLE,
-    })
+    return this.inertia(pages.Home, { codeExamples }, { title: SITE_TITLE })
   }
 }

--- a/web/modules/blog/app/Http/Controllers/Admin/PostsController.ts
+++ b/web/modules/blog/app/Http/Controllers/Admin/PostsController.ts
@@ -44,7 +44,7 @@ export default class PostsController extends Controller {
     return this.inertia(
       pages.admin.Posts,
       { posts },
-      { url: this.request.path, title: pageTitle('Admin') },
+      { title: pageTitle('Admin') },
     )
   }
 
@@ -52,7 +52,7 @@ export default class PostsController extends Controller {
     return this.inertia(
       pages.admin.PostForm,
       { post: null },
-      { url: this.request.path, title: pageTitle('New post') },
+      { title: pageTitle('New post') },
     )
   }
 
@@ -97,7 +97,7 @@ export default class PostsController extends Controller {
           bodyMarkdown: post.bodyMarkdown,
         },
       },
-      { url: this.request.path, title: pageTitle('Edit post') },
+      { title: pageTitle('Edit post') },
     )
   }
 

--- a/web/modules/blog/app/Http/Controllers/BlogController.ts
+++ b/web/modules/blog/app/Http/Controllers/BlogController.ts
@@ -28,7 +28,7 @@ export default class BlogController extends Controller {
     return this.inertia(
       pages.blog.Index,
       { posts },
-      { url: this.request.path, title: pageTitle('Blog') },
+      { title: pageTitle('Blog') },
     )
   }
 
@@ -41,7 +41,7 @@ export default class BlogController extends Controller {
       return this.inertia(
         pages.blog.Show,
         { post: null },
-        { url: this.request.path, title: pageTitle('Post not found'), status: 404 },
+        { title: pageTitle('Post not found'), status: 404 },
       )
     }
 
@@ -53,7 +53,7 @@ export default class BlogController extends Controller {
           bodyHtml: record.bodyHtml,
         },
       },
-      { url: this.request.path, title: pageTitle(record.title) },
+      { title: pageTitle(record.title) },
     )
   }
 


### PR DESCRIPTION
Fixes #378

## Problem

The Inertia page `url` was resolved from `ctx.req.path`, which is the pathname only — the query string was dropped. The Inertia protocol treats `url` as the path **including** the query string (`"/posts?page=1"`), so any page reading `usePage().url` lost pagination, filter, and sort state, and navigation components propagating the active query emitted bare paths. The failure is silent, and the framework's own scaffolds (`{ url: this.request.path }`) taught the lossy form. `examples/blog` had even grown a local workaround (`url: this.request.url ?? this.request.path` — an absolute URL, a different wrong answer), which is a good sign the default belonged in the framework.

## Changes

- **`@guren/server`**: the default lives in the `inertia()` engine — the one place that builds the page payload and already receives the request. When `options.url` is absent, the page url is derived from `options.request` as `pathname + search`, kept relative as the protocol expects. This covers `Controller.inertia()` and direct `inertia()` calls alike (the latter previously got `url: ""`); an explicit `options.url` still overrides. `Controller.inertia()` becomes a plain pass-through. On a version-mismatch 409, `X-Inertia-Location` now falls back to the absolute request URL when no override is given, which matches how the client consumes that header.
- **`@guren/testing`**: the controller mock mirrors the same default, with a test pinning it.
- **`@guren/cli` / `create-guren-app`**: `make:auth` scaffolds and the app templates no longer pass `url: this.request.path`; they rely on the default. (Omitting the option is behavior-identical on the currently published server, so templates don't depend on an unreleased API.)
- **`examples/blog` / `web`**: same cleanup, including the posts-index absolute-URL workaround; blog test expectations updated to the query-preserving values.
- **Docs**: the controllers guide (en/ja) now states that the page `url` includes the query string; the auth guide example drops the explicit `url` option.

## Verification

- Engine tests: a request-derived url keeps the query string; `options.url` overrides it. Integration test: an `X-Inertia` request to `/dashboard?page=2&sort=desc` gets that exact `url` in the payload.
- `bun run build:clean`, `bun run typecheck`, `bun run test` all green.
- `bun run audit:core-first`, `audit:docs`, `audit:starter-template` pass.
- `bun run smoke:starter` and `smoke:starter:api` pass (templates and server both touched).

## Follow-up (not in this PR)

Apps scaffolded by earlier releases still carry `url: this.request.path` in their controllers and won't pick up the fix. The `guren upgrade` deprecation/codemod registries are the idiomatic place to detect and migrate that pattern.