### PR TITLE
feat(server): expose the bound address on the application

### DIFF
--- a/.changeset/application-exposes-bound-address.md
+++ b/.changeset/application-exposes-bound-address.md
@@ -1,0 +1,34 @@
+---
+'@guren/server': minor
+---
+
+Expose the bound address on the application as `app.address`
+
+`Application.listen()` returns `{ port, hostname, url }`, but the instance kept
+only its private Bun server, so the address was available in exactly one place:
+whatever received `listen()`'s return value. Anything else that needs it — an
+OpenAPI `servers` entry, an absolute URL builder, a health report — had to have
+it threaded in from the entrypoint. The example API did this with a module-local
+variable and an exported setter re-exported through two files so that
+`bin/serve.ts` could push the address back down into the app that had just
+produced it. Every app mounting OpenAPI docs would have hand-rolled the same
+wiring.
+
+`app.address` now returns the same `ListenAddress` `listen()` returned, and
+`undefined` before `listen()`. It reads a value stored at bind time rather than
+re-deriving one from the live server, because `listen()` resolves the port
+through a fallback the socket no longer carries; the wildcard-host mapping
+(`0.0.0.0` → `127.0.0.1`, `::` → `::1`) stays in the single helper `listen()`
+already uses. `ListenAddress`'s fields are now `readonly`, since the object
+`listen()` hands back is the one every later reader sees.
+
+It reverts to `undefined` when the server is superseded or torn down through
+the framework — a later `listen()`, including one whose rebind fails, and the
+process-exit teardown. A server stopped by calling `stop()` on the Bun server
+directly leaves no signal behind, so the accessor keeps reporting its address:
+it answers "where did `listen()` put this app", not "is this app healthy".
+
+This does not replace passing a function to `@guren/openapi`'s `servers`
+option. Late resolution is what lets the document name an address the app did
+not have at mount time, and a function is the only form available when mounting
+against a plain Hono instance rather than an `Application`.

--- a/docs/en/guides/routing.md
+++ b/docs/en/guides/routing.md
@@ -368,14 +368,17 @@ When mounted on an `Application` instance, route definitions are read from the r
 The `servers` option accepts a function as well as a list. A mounted document is generated per request and the function is called each time, so it can advertise an address the process does not know when it mounts the docs. With `PORT=0` the operating system assigns the port, which therefore exists only once `listen()` has returned it — a fixed list would leave the document, and every client generated from it, pointing at an address nothing is listening on:
 
 ```ts
-let serverUrl = 'http://localhost:3000'
-
 mountOpenApiDocs(app, {
   title: 'Blog API',
   version: '1.0.0',
-  servers: () => [serverUrl],
+  servers: () => [app.address?.url ?? 'http://localhost:3000'],
 })
 
-const address = await app.listen({ port: 0 })
-serverUrl = address.url
+await app.listen({ port: 0 })
 ```
+
+`app.address` is where `listen()` bound this app, and `undefined` until it has.
+Reading it inside the function is what keeps the entrypoint out of it — nothing
+has to carry the address back down into the app that produced it. Mounting
+against a plain Hono instance leaves you without an `Application` to ask, so
+supply the value the function returns however that app knows it.

--- a/docs/ja/guides/routing.md
+++ b/docs/ja/guides/routing.md
@@ -323,14 +323,13 @@ mountOpenApiDocs(app, {
 `servers` オプションには配列だけでなく関数も渡せます。マウントされたドキュメントはリクエストごとに生成され、関数もそのたびに呼ばれるため、マウント時点ではまだ分からないアドレスを載せられます。たとえば `PORT=0` の場合、ポートは OS が割り当てるため `listen()` が返るまで確定せず、固定の配列ではドキュメントも、そこから生成したクライアントも、何も待ち受けていないアドレスを指したままになります。
 
 ```ts
-let serverUrl = 'http://localhost:3000'
-
 mountOpenApiDocs(app, {
   title: 'Blog API',
   version: '1.0.0',
-  servers: () => [serverUrl],
+  servers: () => [app.address?.url ?? 'http://localhost:3000'],
 })
 
-const address = await app.listen({ port: 0 })
-serverUrl = address.url
+await app.listen({ port: 0 })
 ```
+
+`app.address` は `listen()` がこのアプリをバインドしたアドレスで、バインド前は `undefined` です。関数の中でこれを読むことで、エントリポイントを経由せずに済みます。アドレスを生み出したアプリへ、わざわざ外から渡し直す必要がありません。素の Hono インスタンスにマウントする場合は尋ねる先の `Application` がないため、そのアプリが知っている方法で関数の戻り値を組み立ててください。

--- a/examples/api/bin/serve.ts
+++ b/examples/api/bin/serve.ts
@@ -1,4 +1,4 @@
-import app, { ready, setOpenApiServerUrl } from '../src/main.js'
+import app, { ready } from '../src/main.js'
 
 try {
   await ready
@@ -16,11 +16,6 @@ const hostname = process.env.HOST ?? '0.0.0.0'
 // a busy port is a misconfiguration worth reporting, not something to paper
 // over by serving an API on a port nobody was told about.
 const address = await app.listen({ port, hostname, vite: false, portFallback: false })
-
-// The socket is already accepting by the time `listen()` resolves, so this
-// goes first: anything above it widens the window where the OpenAPI document
-// still names the placeholder address.
-setOpenApiServerUrl(address.url)
 
 // Printed from the address listen() returned, not from the port that was
 // requested — with a port walk or PORT=0 those are different numbers.

--- a/examples/api/src/app.ts
+++ b/examples/api/src/app.ts
@@ -30,23 +30,17 @@ const app = createApp({
   ],
 })
 
-// The default for callers that never bind a socket (`app.fetch()`, tests).
-// `bin/serve.ts` replaces it with the address it really got: under `PORT=0` the
-// OS picks the port, so it does not exist until `listen()` returns.
-let openApiServerUrl = 'http://localhost:3334'
-
-export function setOpenApiServerUrl(url: string): void {
-  openApiServerUrl = url
-}
-
 mountOpenApiDocs(app, {
   title: 'Guren Example API',
   version: '0.1.0',
   description: 'Example API for authentication, tokens, and task management.',
   jsonPath: '/api/openapi.json',
   docsPath: '/api/docs',
-  // A function, not a list: read per request, so a later address still lands.
-  servers: () => [openApiServerUrl],
+  // A function, not a list: read per request, so the address the app bound
+  // still lands. Under `PORT=0` the OS picks the port, so it does not exist
+  // until `listen()` returns; the fallback covers callers that never bind a
+  // socket at all (`app.fetch()`, tests).
+  servers: () => [app.address?.url ?? 'http://localhost:3334'],
 })
 
 export default app

--- a/examples/api/src/main.ts
+++ b/examples/api/src/main.ts
@@ -1,7 +1,5 @@
 import app from './app.js'
 
-export { setOpenApiServerUrl } from './app.js'
-
 export async function bootstrap() {
   await app.boot()
   return app

--- a/packages/openapi/tests/openapi.test.ts
+++ b/packages/openapi/tests/openapi.test.ts
@@ -148,6 +148,48 @@ describe('@guren/openapi', () => {
     expect(await readServers()).toEqual([{ url: 'http://127.0.0.1:52341' }])
   })
 
+  // The pattern the example API uses, end to end over a real socket: `port: 0`
+  // means nothing outside the app knows the port, so the document can only
+  // name it by reading the address back off the app that bound it.
+  it('names the address the app bound when servers reads app.address', async () => {
+    const unbound = 'http://localhost:3334'
+    const app = createApp({
+      routes(router) {
+        router.get('/posts', { name: 'posts.index' }, async () => [])
+      },
+    })
+
+    mountOpenApiDocs(app, {
+      title: 'Blog API',
+      version: '1.0.0',
+      servers: () => [app.address?.url ?? unbound],
+    })
+
+    await app.boot()
+
+    const originalEnv = { ...process.env }
+    process.env.GUREN_DEV_BANNER = '0'
+
+    try {
+      const address = await app.listen({ port: 0, hostname: '127.0.0.1', vite: false })
+
+      const response = await fetch(`${address.url}/openapi.json`)
+      expect(response.status).toBe(200)
+      const document = await response.json() as { servers?: Array<{ url: string }> }
+      expect(document.servers).toEqual([{ url: address.url }])
+      // Guards the assertion above against a document that happens to match
+      // because the app fell back to the placeholder.
+      expect(address.url).not.toBe(unbound)
+    } finally {
+      process.env = { ...originalEnv }
+      // `Application` has no public stop; the same reach-in appears in
+      // packages/server's own port-binding tests.
+      const server = (app as unknown as { bunServer?: { stop?: (close?: boolean) => unknown } })
+        .bunServer
+      await server?.stop?.(true)
+    }
+  })
+
   it('omits servers when a servers function resolves to an empty list', () => {
     const { document } = generateOpenApiDocument([], {
       title: 'Blog API',

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -326,17 +326,21 @@ export interface ApplicationListenOptions {
  * port from the port they asked for — with a port walk or `PORT=0` in play,
  * those are different numbers, and scraping the human-readable dev banner is
  * the only alternative.
+ *
+ * Read-only because {@link Application.address} hands back the very object
+ * `listen()` returned: a caller that adjusted its own copy would change what
+ * every later reader sees.
  */
 export interface ListenAddress {
   /**
    * The port the socket is bound to — what the runtime reports, falling back
    * to the port the successful `Bun.serve` call was made with.
    */
-  port: number
+  readonly port: number
   /** The hostname the socket is bound to. */
-  hostname: string
+  readonly hostname: string
   /** A URL that reaches the server, with a wildcard bind resolved to localhost. */
-  url: string
+  readonly url: string
 }
 
 /**
@@ -353,6 +357,7 @@ export class Application {
   private readonly authManager: AuthManager
   private viteDevServer?: ViteServer
   private bunServer?: BunServer
+  private boundAddress?: ListenAddress
   private viteTeardownRegistered = false
   private bunTeardownRegistered = false
   private autoSessionAttached = false
@@ -731,7 +736,14 @@ export class Application {
     }
 
     const boundHostname = server.hostname ?? hostname
+    const address: ListenAddress = {
+      port: boundPort,
+      hostname: boundHostname,
+      url: toConnectableUrl(boundHostname, boundPort),
+    }
+
     this.bunServer = server
+    this.boundAddress = address
     setActiveBunServer(server)
     this.registerBunTeardown()
 
@@ -747,11 +759,38 @@ export class Application {
       })
     }
 
-    return {
-      port: boundPort,
-      hostname: boundHostname,
-      url: toConnectableUrl(boundHostname, boundPort),
+    return address
+  }
+
+  /**
+   * The address {@link Application.listen} bound, or `undefined` before it has
+   * been called and once this app's server has been superseded or torn down.
+   *
+   * The same object `listen()` returned, so callers that need the address
+   * later — an OpenAPI `servers` entry, an absolute URL, a health report —
+   * read it here instead of threading it out of the entrypoint.
+   *
+   * The stored value is preferred over re-reading the live server, because
+   * `listen()` resolves the port through a fallback the socket no longer
+   * carries.
+   *
+   * Liveness is only as good as the signal available: a server stopped through
+   * the framework — a later `listen()`, the process-exit teardown — clears the
+   * slot this reads, but one stopped by calling `stop()` on the Bun server
+   * directly does not, and this keeps reporting its address. Treat it as
+   * "where `listen()` put this app", not as a health check.
+   */
+  get address(): ListenAddress | undefined {
+    // The `bunServer` half is for the app that never listened: without it, two
+    // `undefined`s would compare equal. Past that, a server this instance
+    // started counts as ours only while it is still the active one, which is
+    // false after a teardown and after the next `listen()` — including when
+    // the rebind that follows it fails.
+    if (!this.bunServer || getGlobalState().__gurenActiveServer !== this.bunServer) {
+      return undefined
     }
+
+    return this.boundAddress
   }
 
   /**

--- a/packages/server/tests/http/application-listen-port.test.ts
+++ b/packages/server/tests/http/application-listen-port.test.ts
@@ -168,6 +168,11 @@ describe('Application.listen port binding', () => {
     expect(address.port).toBeGreaterThan(0)
     const response = await fetch(`${address.url}/__does-not-exist`)
     expect(response.status).toBe(404)
+
+    // The case the accessor exists for: with `port: 0` nothing outside the app
+    // knows the port, so a caller that did not receive the value above — an
+    // OpenAPI `servers` entry built inside the app — has no other source.
+    expect(app.address).toEqual(address)
   })
 
   it('fails fast with EADDRINUSE when GUREN_STRICT_PORT=1', async () => {

--- a/packages/server/tests/http/application-listen.test.ts
+++ b/packages/server/tests/http/application-listen.test.ts
@@ -16,28 +16,38 @@ await mock.module('../../src/http/vite-dev-server', () => ({
 
 const { Application } = await import('../../src/http/Application')
 
+const originalEnv = { ...process.env }
+const originalServe = Bun.serve
+
+beforeEach(() => {
+  process.env = { ...originalEnv }
+  process.env.NODE_ENV = 'development'
+  process.env.GUREN_DEV_BANNER = '0'
+  startViteDevServerMock.mockClear()
+  viteCloseMock.mockClear()
+})
+
+afterEach(() => {
+  process.env = { ...originalEnv }
+  Bun.serve = originalServe
+})
+
+/**
+ * Stubs a bind that succeeds while reporting no `port` and no `hostname`.
+ *
+ * Both omissions are load-bearing: `listen()` has to fall back to the port it
+ * bound and the hostname it was asked for, and a stub written before it read
+ * either field must keep working.
+ */
+function stubBunServe() {
+  const serveMock = mock(() => ({ stop: mock(async () => {}) }))
+  Bun.serve = serveMock as unknown as typeof Bun.serve
+  return serveMock
+}
+
 describe('Application.listen', () => {
-  const originalEnv = { ...process.env }
-  const originalServe = Bun.serve
-
-  beforeEach(() => {
-    process.env = { ...originalEnv }
-    process.env.NODE_ENV = 'development'
-    process.env.GUREN_DEV_BANNER = '0'
-    startViteDevServerMock.mockClear()
-    viteCloseMock.mockClear()
-  })
-
-  afterEach(() => {
-    process.env = { ...originalEnv }
-    Bun.serve = originalServe
-  })
-
   it('restarts the managed Vite dev server after a watch reload', async () => {
-    // Deliberately reports no `port`: a stub that predates the bound-address
-    // return must keep working, so listen() falls back to the port it bound.
-    const serveMock = mock(() => ({ stop: mock(async () => {}) }))
-    Bun.serve = serveMock as unknown as typeof Bun.serve
+    const serveMock = stubBunServe()
 
     process.env.VITE_DEV_SERVER_URL = 'http://localhost:5173'
     process.env.GUREN_MANAGED_VITE_DEV_SERVER = '1'
@@ -81,5 +91,59 @@ describe('Application.listen', () => {
     // teardown clears them.
     expect(process.env.VITE_DEV_SERVER_URL).toBeUndefined()
     expect(process.env.GUREN_MANAGED_VITE_DEV_SERVER).toBeUndefined()
+  })
+})
+
+describe('Application.address', () => {
+  it('is undefined before listen()', () => {
+    expect(new Application().address).toBeUndefined()
+  })
+
+  it('reports the address listen() resolved, not what the live server reports', async () => {
+    // Re-deriving the address from the server would lose the port fallback the
+    // stub forces here — and `port: 0` has no fallback at all, which is the
+    // case the accessor exists for.
+    stubBunServe()
+
+    const app = new Application()
+    const address = await app.listen({ port: 3333, hostname: '0.0.0.0', vite: false })
+
+    expect(app.address).toEqual(address)
+    expect(app.address?.port).toBe(3333)
+    // The wildcard bind is mapped once, in listen(), and the accessor hands
+    // back that same mapping rather than repeating it.
+    expect(app.address?.url).toBe('http://127.0.0.1:3333')
+  })
+
+  it('reverts to undefined when a rebind fails after the old server stopped', async () => {
+    // `listen()` stops the running server before it tries to bind again, so a
+    // failed rebind leaves the app serving nothing. Reporting the old address
+    // here would point callers at a socket that is already closed.
+    stubBunServe()
+
+    const app = new Application()
+    await app.listen({ port: 3333, hostname: '127.0.0.1', vite: false })
+    expect(app.address?.port).toBe(3333)
+
+    Bun.serve = mock(() => {
+      throw Object.assign(new Error('Failed to start server.'), { code: 'EADDRINUSE' })
+    }) as unknown as typeof Bun.serve
+
+    await expect(
+      app.listen({ port: 3333, hostname: '127.0.0.1', vite: false, portFallback: false }),
+    ).rejects.toMatchObject({ code: 'EADDRINUSE' })
+
+    expect(app.address).toBeUndefined()
+  })
+
+  it('follows the app to a new address across a restart', async () => {
+    stubBunServe()
+
+    const app = new Application()
+    await app.listen({ port: 3333, hostname: '127.0.0.1', vite: false })
+    await app.listen({ port: 4444, hostname: '127.0.0.1', vite: false })
+
+    expect(app.address?.port).toBe(4444)
+    expect(app.address?.url).toBe('http://127.0.0.1:4444')
   })
 })


### PR DESCRIPTION
## Summary

`Application.listen()` returns `{ port, hostname, url }`, but the instance kept only its private `bunServer`, so the address was reachable from exactly one place: whatever received `listen()`'s return value. Anything else that needs it had to have it threaded in from the entrypoint.

`examples/api` showed the cost. It held a module-local `openApiServerUrl` plus an exported `setOpenApiServerUrl()`, re-exported through `src/main.ts`, so that `bin/serve.ts` could push the address back down into the app that had just produced it. Every app mounting OpenAPI docs, building absolute URLs, or reporting its own address would hand-roll the same wiring.

This adds `get address(): ListenAddress | undefined` on `Application`, and reduces the example's OpenAPI wiring to one line.

**Design decisions worth a look:**

- **Stored, not re-derived.** The accessor returns a value captured at bind time rather than reading `this.bunServer`, because `listen()` resolves the port through a fallback the socket no longer carries — and under `PORT=0` there is no fallback at all, which is the case the accessor exists for. The wildcard-host mapping (`0.0.0.0` → `127.0.0.1`, `::` → `::1`) stays in the single `toConnectableUrl()` helper.
- **Liveness is honest about its limits.** The accessor reverts to `undefined` when the server is superseded or torn down through the framework, by consulting the same global slot `listen()` already uses to stop a previous server. That covers the process-exit teardown and the next `listen()`, including one whose rebind fails — reporting the old address there would point callers at a socket that is already closed. A server stopped by calling `stop()` on the Bun server directly leaves no signal behind, so the accessor keeps reporting its address; the doc comment says so rather than claiming a guarantee that does not hold.
- **`ListenAddress` fields are now `readonly`.** The object `listen()` hands back is the one every later reader sees, so a caller mutating their copy would change what the OpenAPI document advertises.
- **The `servers`-as-function seam is not obsoleted.** Late resolution is what makes it work at all, and a function is the only form available when mounting against a plain Hono instance rather than an `Application`.

## Scope

`server`, `openapi` (tests only), `docs`, `examples`.

Templates under `packages/create-app/templates` and `packages/cli/templates` are deliberately untouched: they resolve `@guren/*` from npm and cannot use an API that has not been released yet.

`docs/{en,ja}/guides/routing.md` walked through the module-local-variable pattern this change replaces. Both locales are updated together.

## Risk Assessment

Additive. `@guren/server` minor, changeset included.

The one behaviour-adjacent change is `ListenAddress`'s fields becoming `readonly`. Nothing in the repo assigns to them; it only rejects callers that were mutating a value they should not have been.

Nothing else about `listen()` changes: it builds the same object, one allocation, and now stores it before returning it.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck` (from the repo root — per-package typecheck misses cross-package resolution)
- [x] `bun run test` — 4101 bun tests, plus 108 / 42 / 102 in `examples/blog`, `examples/api`, `web`
- [x] `bun run audit:contracts`, `bun run audit:docs`, `bun run audit:core-first`

**Runtime check.** Ran `examples/api` with `PORT=0`, read the port from the app's own startup banner rather than assuming the requested one, and confirmed the `servers` entry in `/api/openapi.json` matched it (`http://127.0.0.1:57808`).

**Mutation check on that verification.** With the accessor forced to return a stale address, the runtime check fails as intended and 5 unit tests go red. Restored and re-confirmed green. Note the `console.log` lines in `bin/serve.ts` deliberately still read `listen()`'s return value, not `app.address` — that keeps the printed port an independent source, so a stale accessor cannot move both sides together and hide the failure.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.

## Notes for the reviewer

Test coverage sits at two layers. `packages/server` pins the accessor itself (before `listen()`, the stored-value-over-live-server choice, the failed rebind, a restart). `packages/openapi` pins the pattern end to end over a real socket: `port: 0`, then a document fetched from the bound address that names that same address. The example's own vitest suite runs on Node, where `listen()` cannot work, so a real-socket guard is not possible there — the openapi test guards the mechanism, not the example's one line of wiring.

Two things surfaced in review that are out of scope here:

1. `Application` has no public `stop()`. Its absence is why the accessor's liveness signal is partial and why two test files reach through `as unknown as { bunServer }` from different packages. Worth its own PR.
2. It is arguable that `examples/api` should drop the `servers` option entirely: its route paths are root-absolute, and an omitted `servers` defaults to `/` resolved against the document's own URL, which is also correct behind a proxy where a bind address is not. That would unwind #374 rather than build on it, so it is left as a question rather than a change.
