### PR TITLE
feat(server): add a public Application.stop() to undo listen()

### DIFF
--- a/.changeset/application-public-stop.md
+++ b/.changeset/application-public-stop.md
@@ -1,0 +1,62 @@
+---
+'@guren/server': minor
+---
+
+Add a public `Application.stop()` to undo `listen()`
+
+`listen()` had no counterpart. It bound a socket, took the process-wide active
+server slot, started a managed Vite dev server, and registered SIGINT/SIGTERM/
+exit teardown — and the only path back out was the module-private
+`stopActiveBunServer()`, which an app could reach by signalling the process or
+by calling `listen()` again to replace the server, but never to simply stop.
+An app could be started programmatically but only stopped by ending the program.
+
+`await app.stop()` now closes the socket, clears the instance's server and the
+managed Vite dev server, and detaches the teardown handlers. It takes the same
+`closeActiveConnections` flag Bun's own `stop()` does, defaulting to `false`:
+a caller reaching for a public stop is usually shutting down deliberately,
+whereas the hot-reload path inside `listen()` keeps forcing the close, since a
+reload must not wait on the server it is replacing. Calling it when nothing is
+listening, or calling it twice, is a no-op.
+
+Vite goes down with it. `listen()` is what started the dev server, and
+`listen()`'s own bind-failure path already closes the one it started; stopping
+the application while leaving the asset server up would strand it, and its
+published environment variables, in a process with no application server. That
+close is best-effort on the same terms as every other shutdown path — bounded by
+`GUREN_VITE_CLOSE_TIMEOUT_MS`, and a dev server that overruns the bound is warned
+about and abandoned rather than holding `stop()` open. `GUREN_INERTIA_ENTRY` is
+now unpublished alongside the other managed variables, but only when it still
+holds the entry `listen()` published; an app that set its own is left alone.
+
+The global active-server slot is cleared only when it still points at this
+instance's server, mirroring the ownership check `closeViteDevServer()` already
+makes. A second `listen()` anywhere in the process force-stops the previous
+server and takes the slot over, so an app that stopped afterwards would
+otherwise clear a live server's teardown out from under it.
+
+`app.address` follows from that: it reports `undefined` once stopped, and the
+new address after a restart. Its documentation already treated a stop the
+framework can see as clearing the address, and `stop()` is now one of those —
+what it still cannot see is a caller reaching past the framework to the Bun
+server's own `stop()`.
+
+The teardown handlers are detached rather than forgotten, on both halves.
+Registration was guarded by a flag that only ever went `true`, so a close that
+merely reset the flag left the handlers attached while claiming otherwise, and
+the next `listen()` piled on another set. `stop()` now removes them and
+`listen()` re-attaches exactly one set, which is what makes an app restartable
+in a single process — a restarted app with no handlers is killed by SIGTERM's
+default disposition instead of shutting down through its own teardown.
+
+The Vite dev server's handlers had the same defect and are fixed with it, which
+matters more than the count: a leaked set keeps its own signal handler, and
+because handlers run in registration order a stale one could call `process.exit()`
+ahead of the live server's shutdown. Those handlers also captured the
+`Application`, so each leaked set pinned an entire app — container, routes and
+providers included. Both registrars now share one helper that attaches the
+SIGINT/SIGTERM/exit trio and returns the disposer for it, so neither can drift
+back to a memo that disagrees with what is actually attached.
+
+The starter templates are unchanged: they resolve `@guren/*` from npm and
+cannot call this until the release that ships it.

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -130,6 +130,12 @@ function clearManagedViteEnv(): void {
 
   if (process.env[MANAGED_VITE_ENV_FLAG] === '1') {
     delete process.env.VITE_DEV_SERVER_URL
+    // Unpublish only the entry this module published. `syncManagedInertiaDevEntry`
+    // leaves an app's custom entry alone, so the same test has to gate the
+    // removal — otherwise stopping would delete a value nothing here set.
+    if (process.env.GUREN_INERTIA_ENTRY?.endsWith(DEFAULT_DEV_ENTRY_PATH)) {
+      delete process.env.GUREN_INERTIA_ENTRY
+    }
   }
 
   delete process.env[MANAGED_VITE_ENV_FLAG]
@@ -182,6 +188,30 @@ async function stopActiveBunServer(closeActiveConnections = false): Promise<void
 
 function setActiveBunServer(server?: BunServer): void {
   getGlobalState().__gurenActiveServer = server
+}
+
+/**
+ * Attaches one SIGINT/SIGTERM/exit trio and returns the disposer that detaches
+ * it again. Both teardown registrars go through here so neither can drift back
+ * to the shape this replaces: a registrar guarded by a boolean that a close
+ * merely flips back leaves its handlers attached, and the next `listen()` adds
+ * a second set on top.
+ *
+ * The count is the lesser half of that. `process.once` fires handlers in
+ * registration order, and a stale set's signal handler still runs its own
+ * `process.exit()` — so it can end the process ahead of the live set's
+ * shutdown, which is the one thing the teardown exists to complete.
+ */
+function registerProcessTeardown(onSignal: () => void, onExit: () => void): () => void {
+  process.once('SIGINT', onSignal)
+  process.once('SIGTERM', onSignal)
+  process.on('exit', onExit)
+
+  return () => {
+    process.off('SIGINT', onSignal)
+    process.off('SIGTERM', onSignal)
+    process.off('exit', onExit)
+  }
 }
 
 /**
@@ -427,8 +457,14 @@ export class Application {
   private viteDevServer?: ViteServer
   private bunServer?: BunServer
   private boundAddress?: ListenAddress
-  private viteTeardownRegistered = false
-  private bunTeardownRegistered = false
+  /**
+   * Detach the process teardown handlers each half registered, and double as
+   * the "are they attached?" memo. One field apiece rather than a separate
+   * boolean: a memo and an undo that can disagree is how handlers end up
+   * attached while a flag says otherwise — see {@link registerProcessTeardown}.
+   */
+  private disposeViteTeardown?: () => void
+  private disposeBunTeardown?: () => void
   private autoSessionAttached = false
   private routesRegistered = false
   private bootPromise?: Promise<void>
@@ -865,22 +901,76 @@ export class Application {
    * carries.
    *
    * Liveness is only as good as the signal available: a server stopped through
-   * the framework — a later `listen()`, the process-exit teardown — clears the
-   * slot this reads, but one stopped by calling `stop()` on the Bun server
-   * directly does not, and this keeps reporting its address. Treat it as
-   * "where `listen()` put this app", not as a health check.
+   * the framework — {@link Application.stop}, a later `listen()`, the
+   * process-exit teardown — clears what this reads, but one stopped by reaching
+   * past the framework to the Bun server's own `stop()` does not, and this keeps
+   * reporting its address. Treat it as "where `listen()` put this app", not as a
+   * health check.
    */
   get address(): ListenAddress | undefined {
     // The `bunServer` half is for the app that never listened: without it, two
-    // `undefined`s would compare equal. Past that, a server this instance
-    // started counts as ours only while it is still the active one, which is
-    // false after a teardown and after the next `listen()` — including when
-    // the rebind that follows it fails.
+    // `undefined`s would compare equal. It also covers `stop()`, which clears
+    // both instance fields. Past that, a server this instance started counts as
+    // ours only while it is still the active one, which is false after a
+    // teardown and after the next `listen()` — including when the rebind that
+    // follows it fails. Both halves earn their place: `stop()` reaches only the
+    // instance, and a supersede or an exit teardown reaches only the slot.
     if (!this.bunServer || getGlobalState().__gurenActiveServer !== this.bunServer) {
       return undefined
     }
 
     return this.boundAddress
+  }
+
+  /**
+   * Stops the server {@link listen} started, undoing that call.
+   *
+   * Safe to call when nothing is listening, and safe to call twice — both are
+   * no-ops. A later `listen()` starts cleanly, so an app may be stopped and
+   * restarted in one process.
+   *
+   * `closeActiveConnections` forces in-flight requests closed instead of
+   * waiting for them, matching Bun's own `stop()` parameter. It defaults to
+   * `false` (graceful) because a caller reaching for a public stop is usually
+   * shutting down deliberately; the hot-reload path inside `listen()` forces
+   * the close, since a reload must not wait on the server it is replacing.
+   *
+   * The managed Vite dev server is taken down too. `listen()` is what started
+   * it, and `listen()`'s own bind-failure path already closes the one it
+   * started — leaving it running here would strand an asset server, and its
+   * published env vars, in a process with no application server. That close is
+   * best-effort on the same terms as every other path: it is bounded by
+   * {@link viteCloseTimeoutMs}, and a Vite server that overruns the bound is
+   * warned about and abandoned rather than holding this call open.
+   */
+  async stop(closeActiveConnections = false): Promise<void> {
+    const server = this.bunServer
+
+    if (server) {
+      try {
+        await Promise.resolve(server.stop?.(closeActiveConnections))
+      } catch (error) {
+        console.warn('Failed to stop Bun server:', error)
+      } finally {
+        // Only clear the global slot if it still points at *our* server — a
+        // later `listen()`, on this instance or another, has already replaced
+        // it, and clearing then would drop a live server's teardown.
+        // `closeViteDevServer()` guards the Vite slot the same way.
+        if (getGlobalState().__gurenActiveServer === server) {
+          setActiveBunServer()
+        }
+        this.bunServer = undefined
+        this.boundAddress = undefined
+      }
+    }
+
+    // Detach the process handlers rather than just forgetting them: a later
+    // `listen()` re-attaches, and that is what keeps a restarted app reachable
+    // by SIGINT/SIGTERM.
+    this.disposeBunTeardown?.()
+    this.disposeBunTeardown = undefined
+
+    await this.closeViteDevServer()
   }
 
   /**
@@ -918,51 +1008,48 @@ export class Application {
         setActiveViteDevServer()
       }
       this.viteDevServer = undefined
-      this.viteTeardownRegistered = false
+      this.disposeViteTeardown?.()
+      this.disposeViteTeardown = undefined
       clearManagedViteEnv()
     }
   }
 
   private registerViteTeardown(): void {
-    if (this.viteTeardownRegistered || !this.viteDevServer || typeof process === 'undefined') {
+    if (this.disposeViteTeardown || !this.viteDevServer || typeof process === 'undefined') {
       return
     }
 
-    this.viteTeardownRegistered = true
-
-    const exitHandler = () => {
-      this.closeViteDevServer()
-        .then(() => process.exit(0))
-        .catch(() => process.exit(1))
-    }
-
-    process.once('SIGINT', exitHandler)
-    process.once('SIGTERM', exitHandler)
-    process.on('exit', () => {
-      if (this.viteDevServer) {
-        void this.viteDevServer.close()
-      }
-    })
+    this.disposeViteTeardown = registerProcessTeardown(
+      () => {
+        this.closeViteDevServer()
+          .then(() => process.exit(0))
+          .catch(() => process.exit(1))
+      },
+      () => {
+        if (this.viteDevServer) {
+          void this.viteDevServer.close()
+        }
+      },
+    )
   }
 
   private registerBunTeardown(): void {
-    if (this.bunTeardownRegistered || typeof process === 'undefined') {
+    if (this.disposeBunTeardown || typeof process === 'undefined') {
       return
     }
 
-    this.bunTeardownRegistered = true
-
-    const exitHandler = () => {
-      stopActiveBunServer()
-        .then(() => process.exit(0))
-        .catch(() => process.exit(1))
-    }
-
-    process.once('SIGINT', exitHandler)
-    process.once('SIGTERM', exitHandler)
-    process.on('exit', () => {
-      void stopActiveBunServer()
-    })
+    // Both handlers read the global slot rather than capturing `server`, so one
+    // registration keeps tearing down whatever the latest `listen()` bound.
+    this.disposeBunTeardown = registerProcessTeardown(
+      () => {
+        stopActiveBunServer()
+          .then(() => process.exit(0))
+          .catch(() => process.exit(1))
+      },
+      () => {
+        void stopActiveBunServer()
+      },
+    )
   }
 }
 

--- a/packages/server/tests/http/application-listen-port.test.ts
+++ b/packages/server/tests/http/application-listen-port.test.ts
@@ -78,10 +78,10 @@ async function listen(
   options: Parameters<Application['listen']>[0],
 ): Promise<Awaited<ReturnType<Application['listen']>>> {
   const address = await app.listen(options)
-  const server = (app as unknown as { bunServer?: StoppableServer }).bunServer
-  if (server) {
-    openServers.push(server)
-  }
+  // `stop()` is the public undo for `listen()`, and an Application satisfies
+  // StoppableServer through it — so the shared `afterEach` drain closes apps and
+  // the raw Bun servers the helpers above bind through the same loop.
+  openServers.push(app)
   return address
 }
 

--- a/packages/server/tests/http/application-stop-restart-fixture.ts
+++ b/packages/server/tests/http/application-stop-restart-fixture.ts
@@ -1,0 +1,23 @@
+/**
+ * Subprocess fixture for the signal-teardown case in `application-stop.test.ts`.
+ *
+ * Runs a full stop/restart cycle and then parks, so the parent can signal it.
+ * The behaviour under test is only observable across a real process boundary:
+ * `stop()` detaches the SIGINT/SIGTERM handlers `listen()` registered, and the
+ * second `listen()` has to put them back. If it doesn't, SIGTERM falls through
+ * to its default disposition and kills the process by signal instead of the
+ * handler exiting 0.
+ */
+import { Application } from '../../src/http/Application'
+
+const app = new Application()
+
+await app.listen({ port: 0, hostname: '127.0.0.1', vite: false })
+await app.stop(true)
+const address = await app.listen({ port: 0, hostname: '127.0.0.1', vite: false })
+
+console.log(`READY ${address.port}`)
+
+// Park forever. The parent's signal is the only way out — an exit of any other
+// kind would make the assertion meaningless.
+await new Promise(() => {})

--- a/packages/server/tests/http/application-stop-vite.test.ts
+++ b/packages/server/tests/http/application-stop-vite.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+/**
+ * `stop()`'s Vite half, kept apart from `application-stop.test.ts` because it
+ * needs a stubbed `startViteDevServer` and that file binds real sockets.
+ *
+ * The real module is spread and only `startViteDevServer` overridden: replacing
+ * the module wholesale would strip its other exports for every test that loads
+ * it afterwards in the same process.
+ */
+const viteCloseMock = mock(async () => {})
+
+const startViteDevServerMock = mock(async () => ({
+  server: {
+    close: viteCloseMock,
+    httpServer: { listening: true },
+  },
+  localUrl: 'http://localhost:5174',
+  networkUrls: [],
+}))
+
+const realViteDevServer = await import('../../src/http/vite-dev-server')
+
+await mock.module('../../src/http/vite-dev-server', () => ({
+  ...realViteDevServer,
+  startViteDevServer: startViteDevServerMock,
+}))
+
+const { Application } = await import('../../src/http/Application')
+
+type GurenGlobal = typeof globalThis & {
+  __gurenActiveServer?: unknown
+  __gurenActiveViteDevServer?: unknown
+  __gurenActiveViteDevServerUrl?: string
+}
+
+const globalState = globalThis as GurenGlobal
+
+describe('Application.stop and the managed Vite dev server', () => {
+  const originalEnv = { ...process.env }
+  const originalServe = Bun.serve
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    process.env.NODE_ENV = 'development'
+    process.env.GUREN_DEV_BANNER = '0'
+    delete process.env.VITE_DEV_SERVER_URL
+    delete process.env.GUREN_MANAGED_VITE_DEV_SERVER
+    delete process.env.GUREN_INERTIA_ENTRY
+    startViteDevServerMock.mockClear()
+    viteCloseMock.mockClear()
+    globalState.__gurenActiveServer = undefined
+    globalState.__gurenActiveViteDevServer = undefined
+    globalState.__gurenActiveViteDevServerUrl = undefined
+    Bun.serve = mock(() => ({ stop: mock(async () => {}), port: 3400 })) as unknown as typeof Bun.serve
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+    Bun.serve = originalServe
+    globalState.__gurenActiveServer = undefined
+    globalState.__gurenActiveViteDevServer = undefined
+    globalState.__gurenActiveViteDevServerUrl = undefined
+  })
+
+  it('closes the Vite dev server listen() started, and unpublishes its env vars', async () => {
+    const app = new Application()
+    await app.listen({ port: 3400, hostname: '127.0.0.1' })
+
+    // Guard the premise: without a managed server actually started, the
+    // assertions below would pass against an app that never had one.
+    expect(startViteDevServerMock).toHaveBeenCalledTimes(1)
+    expect(process.env.VITE_DEV_SERVER_URL).toBe('http://localhost:5174')
+    expect(globalState.__gurenActiveViteDevServer).toBeDefined()
+
+    await app.stop(true)
+
+    expect(viteCloseMock).toHaveBeenCalledTimes(1)
+    expect(globalState.__gurenActiveViteDevServer).toBeUndefined()
+    expect(globalState.__gurenActiveViteDevServerUrl).toBeUndefined()
+    // Leaving these set would point a later process at an asset server that is
+    // no longer running.
+    expect(process.env.VITE_DEV_SERVER_URL).toBeUndefined()
+    expect(process.env.GUREN_MANAGED_VITE_DEV_SERVER).toBeUndefined()
+    expect(process.env.GUREN_INERTIA_ENTRY).toBeUndefined()
+  })
+
+  it('leaves an app-supplied Inertia entry alone when it unpublishes its own', async () => {
+    // `listen()` only overwrites the entry when it is unset or the managed
+    // default, so stopping must not delete one the app chose for itself.
+    process.env.GUREN_INERTIA_ENTRY = 'http://assets.example/custom-entry.ts'
+
+    const app = new Application()
+    await app.listen({ port: 3404, hostname: '127.0.0.1' })
+    expect(process.env.GUREN_INERTIA_ENTRY).toBe('http://assets.example/custom-entry.ts')
+
+    await app.stop(true)
+
+    expect(process.env.GUREN_INERTIA_ENTRY).toBe('http://assets.example/custom-entry.ts')
+  })
+
+  it('starts a fresh Vite dev server when a stopped app listens again', async () => {
+    const app = new Application()
+    await app.listen({ port: 3401, hostname: '127.0.0.1' })
+    await app.stop(true)
+
+    // The reuse path checks `__gurenActiveViteDevServer`, which stop() cleared —
+    // so the restart must start one rather than adopt a closed server.
+    await app.listen({ port: 3401, hostname: '127.0.0.1' })
+
+    expect(startViteDevServerMock).toHaveBeenCalledTimes(2)
+    expect(process.env.VITE_DEV_SERVER_URL).toBe('http://localhost:5174')
+
+    await app.stop(true)
+  })
+
+  /**
+   * The listener-count case in `application-stop.test.ts` runs `vite: false`, so
+   * it only ever watched the Bun half. This is the same guarantee on the half
+   * that starts a *second* set of handlers — and where a close that only reset
+   * a boolean used to leave the first set attached. The stale set is worse than
+   * its count: its signal handler runs its own `process.exit()`, so it can end
+   * the process before the live set has finished shutting down.
+   */
+  it('detaches the Vite teardown handlers too, across repeated cycles', async () => {
+    const counts = () => ({
+      exit: process.listenerCount('exit'),
+      sigint: process.listenerCount('SIGINT'),
+      sigterm: process.listenerCount('SIGTERM'),
+    })
+
+    const app = new Application()
+    const before = counts()
+
+    await app.listen({ port: 3403, hostname: '127.0.0.1' })
+    const listening = counts()
+    // Two sets while listening: the Bun half and the Vite half.
+    expect(listening.exit).toBe(before.exit + 2)
+    expect(listening.sigint).toBe(before.sigint + 2)
+    expect(listening.sigterm).toBe(before.sigterm + 2)
+
+    await app.stop(true)
+    expect(counts()).toEqual(before)
+
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      await app.listen({ port: 3403, hostname: '127.0.0.1' })
+      expect(counts()).toEqual(listening)
+      await app.stop(true)
+      expect(counts()).toEqual(before)
+    }
+  })
+
+  it('closes nothing extra when listen() started no Vite dev server', async () => {
+    // An externally supplied asset URL means listen() starts nothing of its
+    // own. It still clears the stale active server it found — that is
+    // listen()'s existing behaviour, not stop()'s — so the assertion that
+    // matters is that stop() adds no second close on top of it.
+    const strayClose = mock(async () => {})
+    process.env.VITE_DEV_SERVER_URL = 'http://localhost:6000'
+    globalState.__gurenActiveViteDevServer = { close: strayClose, httpServer: { listening: true } }
+    globalState.__gurenActiveViteDevServerUrl = 'http://localhost:6000'
+
+    const app = new Application()
+    await app.listen({ port: 3402, hostname: '127.0.0.1' })
+
+    expect(startViteDevServerMock).not.toHaveBeenCalled()
+    const closesAfterListen = strayClose.mock.calls.length
+
+    await app.stop(true)
+
+    expect(strayClose.mock.calls.length).toBe(closesAfterListen)
+  })
+})

--- a/packages/server/tests/http/application-stop.test.ts
+++ b/packages/server/tests/http/application-stop.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+
+import { Application } from '../../src/http/Application'
+
+/**
+ * Like the port-binding tests next door, these bind real sockets on 127.0.0.1
+ * rather than stubbing `Bun.serve`. What `stop()` has to deliver is that the
+ * socket is genuinely released — a stub can only report that `stop()` was
+ * called, which is the one thing never in doubt.
+ */
+
+type BunServerSlot = { __gurenActiveServer?: unknown }
+
+const apps: Application[] = []
+
+function track(app: Application): Application {
+  apps.push(app)
+  return app
+}
+
+function activeServerSlot(): unknown {
+  return (globalThis as BunServerSlot).__gurenActiveServer
+}
+
+beforeEach(() => {
+  // Every sibling listen/stop test suppresses the banner; without this the
+  // ASCII art buries the results of this file's own assertions.
+  process.env.GUREN_DEV_BANNER = '0'
+})
+
+afterEach(async () => {
+  delete process.env.GUREN_DEV_BANNER
+  while (apps.length > 0) {
+    await apps.pop()?.stop(true)
+  }
+})
+
+describe('Application.stop', () => {
+  it('releases the port so the same one can be bound again', async () => {
+    const app = track(new Application())
+    const address = await app.listen({ port: 0, hostname: '127.0.0.1', vite: false })
+
+    // The server answers before the stop — otherwise a rebind below proves
+    // nothing, since an app that never bound also leaves the port free.
+    expect((await fetch(`${address.url}/__does-not-exist`)).status).toBe(404)
+
+    await app.stop(true)
+
+    // Re-binding the *same* port is the assertion. A refused connection could
+    // just as well mean the socket is in TIME_WAIT.
+    const second = track(new Application())
+    const rebound = await second.listen({
+      port: address.port,
+      hostname: '127.0.0.1',
+      vite: false,
+      // No walk: a fallback would quietly bind the next port up and pass.
+      portFallback: false,
+    })
+
+    expect(rebound.port).toBe(address.port)
+    expect((await fetch(`${rebound.url}/__does-not-exist`)).status).toBe(404)
+  })
+
+  /**
+   * `address` reports where `listen()` put this app, and its own docs treat a
+   * stop that the framework can see as clearing it. `stop()` is now such a stop,
+   * so leaving the stored address behind would have the accessor naming a socket
+   * that is closed.
+   */
+  it('stops reporting an address once stopped, and reports the new one after a restart', async () => {
+    const app = track(new Application())
+    expect(app.address).toBeUndefined()
+
+    const first = await app.listen({ port: 0, hostname: '127.0.0.1', vite: false })
+    expect(app.address).toEqual(first)
+
+    await app.stop(true)
+    expect(app.address).toBeUndefined()
+
+    const second = await app.listen({ port: 0, hostname: '127.0.0.1', vite: false })
+    expect(app.address).toEqual(second)
+  })
+
+  it('is a no-op when nothing is listening, and when called twice', async () => {
+    const neverListened = track(new Application())
+    await neverListened.stop()
+
+    const app = track(new Application())
+    await app.listen({ port: 0, hostname: '127.0.0.1', vite: false })
+
+    await app.stop(true)
+    await app.stop(true)
+  })
+
+  it('lets the same instance listen again after being stopped', async () => {
+    const app = track(new Application())
+
+    const first = await app.listen({ port: 0, hostname: '127.0.0.1', vite: false })
+    await app.stop(true)
+
+    const second = await app.listen({ port: 0, hostname: '127.0.0.1', vite: false })
+
+    expect((await fetch(`${second.url}/__does-not-exist`)).status).toBe(404)
+    // The restarted instance owns the global teardown slot again — otherwise a
+    // SIGINT after a restart would find nothing to stop.
+    expect(activeServerSlot()).toBeDefined()
+  })
+
+  /**
+   * Every other real-server case here forces connections closed. The default is
+   * the graceful path, and it is the one a caller gets by writing `app.stop()` —
+   * so it needs its own case rather than being covered only by the never-listened
+   * app, which returns before reaching Bun's `stop()` at all.
+   */
+  it('releases the socket on a graceful stop with no argument', async () => {
+    const app = track(new Application())
+    const address = await app.listen({ port: 0, hostname: '127.0.0.1', vite: false })
+    expect((await fetch(`${address.url}/__does-not-exist`)).status).toBe(404)
+
+    await app.stop()
+
+    const rebind = track(new Application())
+    const rebound = await rebind.listen({
+      port: address.port,
+      hostname: '127.0.0.1',
+      vite: false,
+      portFallback: false,
+    })
+    expect(rebound.port).toBe(address.port)
+  })
+
+  /**
+   * `listen()` guards its process-handler registration with a flag that only
+   * ever went `true`. `stop()` has to detach the handlers, not just reset the
+   * flag: resetting alone would let every stop/listen cycle attach another set,
+   * and leaving the flag set would be the same leak deferred to whoever resets
+   * it next.
+   */
+  it('detaches its process teardown handlers, and re-attaches exactly one set', async () => {
+    const counts = () => ({
+      exit: process.listenerCount('exit'),
+      sigint: process.listenerCount('SIGINT'),
+      sigterm: process.listenerCount('SIGTERM'),
+    })
+
+    const app = track(new Application())
+    const before = counts()
+
+    await app.listen({ port: 0, hostname: '127.0.0.1', vite: false })
+    const listening = counts()
+    expect(listening.exit).toBe(before.exit + 1)
+    expect(listening.sigint).toBe(before.sigint + 1)
+    expect(listening.sigterm).toBe(before.sigterm + 1)
+
+    await app.stop(true)
+    expect(counts()).toEqual(before)
+
+    // Cycling must not accumulate: without the detach, each pass leaves another
+    // handler behind and Node starts warning about a leak at eleven.
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      await app.listen({ port: 0, hostname: '127.0.0.1', vite: false })
+      expect(counts()).toEqual(listening)
+      await app.stop(true)
+      expect(counts()).toEqual(before)
+    }
+  })
+
+  /**
+   * The counterpart to the listener-count test above, and the half it cannot
+   * reach: that the re-attached handlers actually *fire*. `listenerCount` only
+   * reports Bun's bookkeeping, and a process exiting has its sockets reclaimed
+   * by the OS either way — so the discriminating signal is the exit *code*. A
+   * restarted app whose SIGTERM handler went missing dies by signal instead of
+   * exiting 0 through the teardown.
+   */
+  it('still tears down on a signal after a stop/restart cycle', async () => {
+    const child = Bun.spawn(
+      ['bun', 'run', new URL('./application-stop-restart-fixture.ts', import.meta.url).pathname],
+      { stdout: 'pipe', stderr: 'pipe' },
+    )
+
+    try {
+      const reader = child.stdout.getReader()
+      const decoder = new TextDecoder()
+      let output = ''
+      while (!output.includes('READY')) {
+        const { done, value } = await reader.read()
+        if (done) {
+          throw new Error(`Fixture exited before it was ready: ${output}`)
+        }
+        output += decoder.decode(value, { stream: true })
+      }
+
+      child.kill('SIGTERM')
+      await child.exited
+
+      // `signalCode` set means the default disposition killed it — the handler
+      // that should have exited 0 was gone.
+      expect(child.signalCode).toBeNull()
+      expect(child.exitCode).toBe(0)
+    } finally {
+      child.kill('SIGKILL')
+    }
+  }, 20_000)
+
+  it('leaves the global teardown slot alone when it points at another server', async () => {
+    const first = track(new Application())
+    await first.listen({ port: 0, hostname: '127.0.0.1', vite: false })
+
+    // A second listen() force-stops whatever the slot holds and takes it over
+    // — the hot-reload path. The first app still remembers its own (now dead)
+    // server, so its stop() must not clear a slot that has moved on, or the
+    // live server loses its exit teardown.
+    const second = track(new Application())
+    await second.listen({ port: 0, hostname: '127.0.0.1', vite: false })
+
+    const slotAfterSecondListen = activeServerSlot()
+    expect(slotAfterSecondListen).toBeDefined()
+
+    await first.stop(true)
+
+    expect(activeServerSlot()).toBe(slotAfterSecondListen)
+
+    // And the owner still clears it when it is the one stopping.
+    await second.stop(true)
+    expect(activeServerSlot()).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

`Application.listen()` had no counterpart. It binds a socket, takes the process-wide `__gurenActiveServer` slot, starts a managed Vite dev server, and registers SIGINT/SIGTERM/exit teardown — and the only path back out was the module-private `stopActiveBunServer()`. An app could reach that by signalling the process, or by calling `listen()` again to *replace* the server, but never to simply stop. An app could be started programmatically and only stopped by ending the program.

`await app.stop()` closes the socket, clears the instance's server and the managed Vite dev server, and detaches the teardown handlers. It takes the same `closeActiveConnections` flag Bun's own `stop()` does, defaulting to `false` (graceful) — the hot-reload path inside `listen()` keeps forcing the close, since a reload must not wait on the server it is replacing. Calling it when nothing is listening, or calling it twice, is a no-op, and a later `listen()` starts cleanly.

Four design points worth a reviewer's attention:

- **Vite goes down with it.** `listen()` is what started the dev server, and `listen()`'s own bind-failure path already closes the one it started. That close is best-effort on the same terms as every other shutdown path — bounded by `GUREN_VITE_CLOSE_TIMEOUT_MS`, warned about and abandoned if it overruns. `GUREN_INERTIA_ENTRY` is now unpublished alongside the other managed variables, but only when it still holds the entry `listen()` published; an app that set its own is left alone.
- **The global slot is cleared only when it still points at this instance's server**, mirroring the ownership check `closeViteDevServer()` already makes. A second `listen()` anywhere in the process force-stops the previous server and takes the slot over, so an app stopping afterwards would otherwise clear a live server's teardown.
- **`app.address` follows from that** (this PR was rebased onto #381, which added it). It reports `undefined` once stopped and the new address after a restart. The accessor's own documentation already treated a stop the framework can see as clearing the address, and `stop()` is now one of those; what it still cannot see is a caller reaching past the framework to the Bun server's own `stop()`, and that disclaimer is reworded rather than dropped. Its global-slot identity check is **kept**: `stop()` reaches only the instance fields, while a supersede or an exit teardown reaches only the slot, so both halves of the check are load-bearing.
- **Teardown handlers are detached rather than forgotten, on both halves.** Registration was guarded by a flag that only ever went `true`, so a close that merely reset it left the handlers attached while claiming otherwise, and the next `listen()` piled on another set. Both registrars now share one helper that attaches the SIGINT/SIGTERM/exit trio and returns its disposer, replacing the two booleans.

The Vite half had the same defect and is fixed with it. That matters more than the listener count: a leaked set keeps its own signal handler, and because handlers run in registration order a stale one could call `process.exit()` ahead of the live server's shutdown. Those handlers also captured the `Application`, so each leaked set pinned an entire app — container, routes and providers included. Measured before the fix, exit/SIGINT/SIGTERM listeners grew 2 → 3 → 4 across stop/listen cycles and never returned to baseline; they now return to baseline after every stop.

## Scope

`server` (`packages/server/src/http/Application.ts` + tests), plus a changeset. `@guren/server` minor.

Templates under `packages/create-app/templates` and `packages/cli/templates` are deliberately **not** touched — they resolve `@guren/*` from npm and cannot call this until the release that ships it.

## Risk Assessment

Additive: a new public method, no signature or behavior change to `listen()`. The one behavior change to an existing path is that `clearManagedViteEnv()` now also removes `GUREN_INERTIA_ENTRY` when it holds the managed default; a custom entry is preserved, gated by the same test `syncManagedInertiaDevEntry` uses to decide whether to write it.

`viteTeardownRegistered` and `bunTeardownRegistered` are both private and are replaced by disposer fields, so no public surface moves.

Two known limitations were reproduced during review and deliberately left out of scope, as they need a rework of `listen()`'s ownership model rather than an addition to it — both are filed as follow-ups:

- A stopped app can close a Vite dev server that a newer app adopted via the hot-reload reuse path (the instance identity guard cannot see through adoption, since it is the same object).
- A `stop()` concurrent with an in-flight `listen()` can leave the newly bound socket with no instance handle and no signal handlers. `listen()` and `stop()` are not serialized against each other.

Docs (`docs/en/guides/architecture.md` and its `ja` twin) do not yet document `stop()`; filed as a follow-up so en/ja move together.

## Validation

Re-run after rebasing onto `main` (`0e072be`, `9f21ce0`):

- [x] `bun run build`
- [x] `bun run typecheck` — 0 errors
- [x] `bun run test` — framework 4134 pass / 0 fail; `examples/blog` 108, `examples/api` 42, `web` 102, all passing
- [x] `bun run audit:core-first`, `bun run audit:docs` — both pass

Each behavioural decision was mutation-tested: the protection was removed and the suite confirmed red, in both directions where a flag and a detach could disagree. Covered that way — the socket close, the global-slot ownership guard, the handler detach, the re-attach on restart (verified through a real signal, not just a listener count), the Vite close, and both directions of the `GUREN_INERTIA_ENTRY` guard.

One honest exception: `stop()` also clears the instance's `bunServer` and `boundAddress`, and neither clear is *independently* observable — the `address` accessor short-circuits on the global-slot check, which is itself covered. They are kept as hygiene (releasing the references, and holding the contract if that short-circuit ever changes) rather than because a test pins them.

The signal-teardown case runs in a subprocess and asserts `exitCode 0` rather than `signalCode SIGTERM`: a process has its sockets reclaimed by the OS at exit either way, so the exit *code* is the only thing that distinguishes a restarted app that still tears down through its own handler from one whose handler went missing.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation — filed as a follow-up so the en and ja guides move together.
