### PR TITLE
feat: support the HTTP QUERY method (RFC 10008)

### DIFF
--- a/.changeset/http-query-method.md
+++ b/.changeset/http-query-method.md
@@ -1,0 +1,30 @@
+---
+'@guren/server': minor
+'@guren/core': minor
+'@guren/testing': minor
+'@guren/cli': minor
+'@guren/openapi': minor
+---
+
+First-class support for the HTTP QUERY method (RFC 10008)
+
+QUERY is safe and idempotent like GET but carries a request body like POST — the right verb for search and filter endpoints whose criteria don't fit in a URL.
+
+- `router.query(path, options, handler)` registers QUERY routes with the same overloads as the other verbs, on the router and inside `middleware(...)` group builders (which also gain the generic `on()` for arbitrary methods).
+
+```ts
+router.query('/posts/search', {
+  name: 'posts.search',
+  body: z.object({ keywords: z.array(z.string()) }),
+}, [PostsController, 'search'])
+```
+
+- `TestApp.query(path, body?)` drives QUERY routes in tests.
+- Codegen picks QUERY routes up automatically; the generated API client sends them with a body (`client.request('posts.search', { body })`).
+- CSRF protection deliberately skips QUERY by default: it is a safe method, and browsers cannot send it without a CORS preflight. Keep QUERY handlers read-only, or opt into protection via the middleware's `methods` option — the generated client keeps sending the XSRF header on same-origin browser requests, so that opt-in works there (cross-origin clients supply their own header, as with every method).
+- `guren audit` checks body validation on QUERY routes without demanding auth middleware on them, matching GET.
+- The OpenAPI generator now allowlists the methods OpenAPI 3.1 can express and skips others (QUERY included) with a warning — previously a QUERY route would silently produce an invalid document. Mounted docs surface those warnings once via `console.warn`.
+
+Also fixed: `createCorsMiddleware` used to hand Hono an explicit `allowMethods: undefined`, which erased Hono's default and made every preflight answer without an `Access-Control-Allow-Methods` header. Guren now owns the default list (GET, HEAD, PUT, POST, DELETE, PATCH, QUERY).
+
+Deployment note: Guren's fetch-based adapters (Bun, the Cloudflare Workers and Vercel plugins) do not block QUERY, but verify your platform's ingress accepts the method — CloudFront, which fronts the app in the Lambda plugin's asset setup, does not forward it.

--- a/.claude/skills/guren-api/SKILL.md
+++ b/.claude/skills/guren-api/SKILL.md
@@ -149,6 +149,11 @@ export function registerWebRoutes(baseRouter: Router): void {
 }
 ```
 
+**Verbs**: `get / post / put / patch / delete / query` share the same overloads;
+`router.on(method, path, ...)` covers anything else. `query()` registers HTTP QUERY
+(RFC 10008) — safe like GET but body-carrying; read-only handlers only (CSRF skips it),
+not expressible in OpenAPI 3.1, not sendable from Inertia forms (use the API client).
+
 **Route contract options** — attach `body`, `params`, `query` schemas to routes:
 - Schemas are metadata for codegen (not double-validated for Controller actions)
 - `bunx guren codegen` extracts schemas → generates typed `ApiRoutes` interface

--- a/docs/en/guides/csrf.md
+++ b/docs/en/guides/csrf.md
@@ -20,7 +20,7 @@ app.use('*', createCsrfMiddleware())
 The middleware automatically:
 - Generates a token per session, or a stateless double-submit token for guests
 - Validates tokens on state-changing requests (POST, PUT, PATCH, DELETE)
-- Allows safe methods (GET, HEAD, OPTIONS) without validation
+- Allows safe methods (GET, HEAD, OPTIONS, QUERY) without validation — QUERY (RFC 10008) is safe by contract, so keep QUERY handlers read-only, or add `'QUERY'` to the `methods` option to require tokens anyway
 
 ## Including the Token in Forms
 

--- a/docs/en/guides/routing.md
+++ b/docs/en/guides/routing.md
@@ -23,7 +23,28 @@ export function registerWebRoutes(router: Router): void {
 }
 ```
 
-Available methods: `router.get`, `router.post`, `router.put`, `router.patch`, `router.delete`, and the generic `router.on(method, path, handler)`.
+Available methods: `router.get`, `router.post`, `router.put`, `router.patch`, `router.delete`, `router.query`, and the generic `router.on(method, path, handler)`.
+
+### The QUERY method
+
+`router.query()` registers a route for the HTTP QUERY method ([RFC 10008](https://www.rfc-editor.org/info/rfc10008/)): safe and idempotent like GET, but the request carries a body like POST. Use it for search and filter endpoints whose criteria are too complex for a URL:
+
+```ts
+import { z } from 'zod'
+
+router.query('/posts/search', {
+  name: 'posts.search',
+  body: z.object({ keywords: z.array(z.string()), limit: z.number().default(20) }),
+}, [PostsController, 'search'])
+```
+
+Things to know before reaching for it:
+
+- **Handlers must not mutate state.** QUERY is a safe method, and Guren's CSRF protection skips it on that assumption (browsers cannot send QUERY without a CORS preflight, so cross-site request forgery is not a concern — as long as the handler really is read-only). To force CSRF tokens anyway, add `'QUERY'` to the CSRF middleware's `methods` option.
+- **Call it with `fetch` or the generated API client** (`client.request('posts.search', { body })`). HTML forms and Inertia form helpers cannot send QUERY.
+- **Check your deployment path.** Guren's fetch-based adapters (Bun, the Cloudflare Workers and Vercel plugins) do not block QUERY, but verify that your platform's ingress accepts it — some proxies and CDNs reject methods outside the classic set. Notably CloudFront, which the Lambda plugin's asset distribution puts in front of your app, does not forward QUERY. Intermediary caching of QUERY responses is also not widely implemented yet.
+- **OpenAPI 3.1 cannot express QUERY**, so `guren openapi:generate` skips QUERY routes with a warning.
+- To advertise support to clients, set the `Accept-Query` response header yourself, e.g. `ctx.header('Accept-Query', 'application/json')` on the resource's GET handler.
 
 Pass the registrar to `createApp()` in `src/app.ts`:
 

--- a/docs/en/guides/testing.md
+++ b/docs/en/guides/testing.md
@@ -42,6 +42,7 @@ await app.post('/posts', body)
 await app.put('/posts/1', body)
 await app.patch('/posts/1', body)
 await app.delete('/posts/1')
+await app.query('/posts/search', body) // HTTP QUERY (RFC 10008)
 ```
 
 ### Wrapping the real application

--- a/docs/ja/guides/csrf.md
+++ b/docs/ja/guides/csrf.md
@@ -20,7 +20,7 @@ app.use('*', createCsrfMiddleware())
 ミドルウェアは自動的に以下を行います。
 - セッションごとにトークンを生成（ゲストにはステートレスな double-submit トークン）
 - 状態を変更するリクエスト（POST、PUT、PATCH、DELETE）でトークンを検証
-- 安全なメソッド（GET、HEAD、OPTIONS）は検証なしで許可
+- 安全なメソッド（GET、HEAD、OPTIONS、QUERY）は検証なしで許可 — QUERY（RFC 10008）は仕様上安全なメソッドのため、QUERY ハンドラーは読み取り専用に保つこと。トークンを要求したい場合は `methods` オプションに `'QUERY'` を追加
 
 ## フォームにトークンを含める
 

--- a/docs/ja/guides/routing.md
+++ b/docs/ja/guides/routing.md
@@ -19,7 +19,28 @@ export function registerWebRoutes(router: Router): void {
 - コントローラータプル `[ControllerClass, 'method']`
 - インラインハンドラー `(ctx) => new Response('...')`
 
-利用できるメソッドは `router.get`、`router.post`、`router.put`、`router.patch`、`router.delete`、そして汎用の `router.on(method, path, handler)` です。
+利用できるメソッドは `router.get`、`router.post`、`router.put`、`router.patch`、`router.delete`、`router.query`、そして汎用の `router.on(method, path, handler)` です。
+
+### QUERY メソッド
+
+`router.query()` は HTTP QUERY メソッド([RFC 10008](https://www.rfc-editor.org/info/rfc10008/))のルートを登録します。GET と同じく安全(safe)かつ冪等ですが、POST のようにリクエストボディを持てます。URL に収まらない複雑な検索・フィルタ条件を受け取るエンドポイントに使ってください。
+
+```ts
+import { z } from 'zod'
+
+router.query('/posts/search', {
+  name: 'posts.search',
+  body: z.object({ keywords: z.array(z.string()), limit: z.number().default(20) }),
+}, [PostsController, 'search'])
+```
+
+利用前に知っておくべきこと:
+
+- **ハンドラーで状態を変更してはいけません。** QUERY は安全なメソッドであり、Guren の CSRF 保護はその前提で QUERY をスキップします(ブラウザは CORS プリフライトなしに QUERY を送信できないため、ハンドラーが読み取り専用である限り CSRF の心配はありません)。それでも CSRF トークンを要求したい場合は、CSRF ミドルウェアの `methods` オプションに `'QUERY'` を追加してください。
+- **呼び出しは `fetch` か生成された API クライアント**(`client.request('posts.search', { body })`)で行います。HTML フォームや Inertia のフォームヘルパーは QUERY を送信できません。
+- **デプロイ経路を確認してください。** Guren の fetch ベースのアダプター(Bun、Cloudflare Workers / Vercel プラグイン)は QUERY をブロックしませんが、プラットフォーム側の入口が QUERY を受け付けるかは確認が必要です。旧来のメソッドセット以外を拒否するプロキシや CDN があり、特に Lambda プラグインのアセット配信で前段に入る CloudFront は QUERY を転送しません。また、中間キャッシュによる QUERY レスポンスのキャッシュもまだ広くは実装されていません。
+- **OpenAPI 3.1 は QUERY を表現できない**ため、`guren openapi:generate` は QUERY ルートを警告付きでスキップします。
+- クライアントに対応を広告するには、リソースの GET ハンドラーなどで `Accept-Query` レスポンスヘッダーを自分で設定してください(例: `ctx.header('Accept-Query', 'application/json')`)。
 
 ## ルートグループ
 `router.group(prefix, callback)` を使って、共通のパスプレフィックスとミドルウェアを適用できます。

--- a/docs/ja/guides/testing.md
+++ b/docs/ja/guides/testing.md
@@ -83,6 +83,7 @@ await app.post('/posts', body)
 await app.put('/posts/1', body)
 await app.patch('/posts/1', body)
 await app.delete('/posts/1')
+await app.query('/posts/search', body) // HTTP QUERY (RFC 10008)
 ```
 
 ### Fluent アサーション

--- a/packages/cli/src/api-client-types.ts
+++ b/packages/cli/src/api-client-types.ts
@@ -106,6 +106,10 @@ export type ApiRequestOptions<T extends ApiRouteName> =
 // together.
 const XSRF_COOKIE_NAME = 'XSRF-TOKEN'
 const XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+// QUERY (RFC 10008) is deliberately NOT listed even though the server's CSRF
+// default skips it: the redundant token header is harmless there, and keeping
+// it is what makes a server that opts QUERY into protection (the middleware's
+// \`methods\` option) work with this client unchanged.
 const CSRF_SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS']
 const CSRF_HEADER_NAMES = [XSRF_HEADER_NAME.toLowerCase(), 'x-csrf-token']
 

--- a/packages/cli/src/api-digest.ts
+++ b/packages/cli/src/api-digest.ts
@@ -49,6 +49,7 @@ Verified quick reference — trust this and \`.claude/rules/*.md\` over grepping
 
 ### Testing (@guren/testing)
 - \`const app = await TestApp.create()\` · \`app.actingAs(user)\` / \`app.json()\` / \`await app.withCsrf()\` — each returns a NEW TestApp
+- HTTP helpers: \`get(path)\` · \`post/put/patch/delete/query(path, body?)\` (\`query\` = HTTP QUERY, RFC 10008)
 - \`await app.get('/posts').assertOk()\` · assertions: \`assertStatus / assertCreated / assertRedirect(url?) /
   assertUnprocessable / assertJson / assertJsonPath(path, value) / assertInertia(component, props?)\`
 

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -69,8 +69,16 @@ export interface RunAuditOptions {
   deps?: boolean
 }
 
+// Two orthogonal axes drive the route loop below: unsafe methods get the auth
+// check, body-carrying methods get the validation check. QUERY (RFC 10008) is
+// safe like GET but body-carrying, so it appears only in BODY_METHODS.
+// Sibling classifications that must stay coherent with these (no shared
+// constant — @guren/cli declares no @guren/server dependency): the CSRF
+// middleware's DEFAULT_PROTECTED_METHODS in packages/server, and the
+// generated client's CSRF_SAFE_METHODS in api-client-types.ts.
 const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
-const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH'])
+const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH', 'QUERY'])
+const AUDITED_METHODS = new Set([...MUTATING_METHODS, ...BODY_METHODS])
 
 /**
  * Paths that are expected to be reachable without authentication
@@ -557,7 +565,7 @@ async function auditRoutes(
 
   for (const route of definitions) {
     const method = route.method.toUpperCase()
-    if (!MUTATING_METHODS.has(method)) continue
+    if (!AUDITED_METHODS.has(method)) continue
 
     const routeLabel = `${method} ${route.path}`
     const controllerKey = route.controller
@@ -630,7 +638,9 @@ async function auditRoutes(
       }
     }
 
-    // 2. Authentication on mutating routes
+    // 2. Authentication on mutating routes. Safe body-carrying methods
+    // (QUERY) are read routes, so they get the same treatment as GET here.
+    if (!MUTATING_METHODS.has(method)) continue
     if (GUEST_PATH_PATTERN.test(route.path)) continue
 
     const middlewareNames = route.middlewareNames ?? []

--- a/packages/cli/src/route-list.ts
+++ b/packages/cli/src/route-list.ts
@@ -141,6 +141,7 @@ function padMethod(method: string): string {
     PUT: '\x1b[34m',     // blue
     PATCH: '\x1b[36m',   // cyan
     DELETE: '\x1b[31m',  // red
+    QUERY: '\x1b[32m',   // green — safe like GET
     HEAD: '\x1b[35m',    // magenta
     OPTIONS: '\x1b[90m', // gray
   }

--- a/packages/cli/templates/agent/.claude/rules/routes-codegen.md
+++ b/packages/cli/templates/agent/.claude/rules/routes-codegen.md
@@ -39,6 +39,13 @@ Schemas attached here do double duty: requests are **validated automatically**
 index/create/store/show/edit/update/destroy (GET/POST/PUT/DELETE, `:id` param) named `posts.index` etc.
 Model binding: `bind: { id: Post }` + `this.model(Post)` in the controller.
 
+Verbs: `get / post / put / patch / delete / query` (all with the same overloads), plus
+`router.on(method, path, ...)` for anything else. `query()` registers the HTTP QUERY
+method (RFC 10008): safe and idempotent like GET but carries a request body — use it
+for complex search/filter endpoints, never for mutations (CSRF skips it on that
+assumption). Not expressible in OpenAPI 3.1 output, and Inertia forms cannot send it —
+call it via `createApiClient` or `fetch`.
+
 ## Route Schema Binding: concrete input → output
 
 ```typescript

--- a/packages/cli/templates/agent/.claude/rules/testing.md
+++ b/packages/cli/templates/agent/.claude/rules/testing.md
@@ -97,6 +97,7 @@ name with `Controller` and writes to `tests/controllers/${ClassName}.test.ts`, m
 app.get(path)                 // → PendingTestResponse (awaitable AND chainable)
 app.post(path, body?)         // body auto-JSON-encoded unless FormData
 app.put(path, body?) / app.patch(path, body?) / app.delete(path, body?)
+app.query(path, body?)        // HTTP QUERY (RFC 10008) — safe method with a body
 
 app.actingAs(user)            // returns a NEW TestApp with the user injected
 app.json()                    // returns a NEW TestApp with Accept: application/json

--- a/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
+++ b/packages/cli/templates/agent/.claude/skills/guren-api/SKILL.md
@@ -149,6 +149,11 @@ export function registerWebRoutes(baseRouter: Router): void {
 }
 ```
 
+**Verbs**: `get / post / put / patch / delete / query` share the same overloads;
+`router.on(method, path, ...)` covers anything else. `query()` registers HTTP QUERY
+(RFC 10008) — safe like GET but body-carrying; read-only handlers only (CSRF skips it),
+not expressible in OpenAPI 3.1, not sendable from Inertia forms (use the API client).
+
 **Route contract options** — attach `body`, `params`, `query` schemas to routes:
 - Schemas are metadata for codegen (not double-validated for Controller actions)
 - `bunx guren codegen` extracts schemas → generates typed `ApiRoutes` interface

--- a/packages/cli/tests/api-client-types.test.ts
+++ b/packages/cli/tests/api-client-types.test.ts
@@ -8,6 +8,7 @@ import { buildApiClientContent, type RouteDefinitionLike } from '../src/api-clie
 const definitions: RouteDefinitionLike[] = [
   { method: 'GET', path: '/posts', name: 'posts.index' },
   { method: 'POST', path: '/posts', name: 'posts.store' },
+  { method: 'QUERY', path: '/posts/search', name: 'posts.search' },
 ]
 
 describe('buildApiClientContent', () => {
@@ -118,6 +119,20 @@ describe('generated createApiClient', () => {
     await createApiClient({ baseUrl: PAGE_ORIGIN }).request('posts.index')
 
     expect(headersOf(calls[0]!.init)['X-XSRF-TOKEN']).toBeUndefined()
+  })
+
+  // QUERY is CSRF-exempt server-side by default, so the token is redundant —
+  // but an app can opt QUERY into protection via the middleware's `methods`
+  // option, and the client keeping the header is what makes that opt-in work.
+  it('sends the QUERY method with a body and the XSRF header', async () => {
+    const { calls } = stubFetch()
+    browsingAt(PAGE_ORIGIN, 'XSRF-TOKEN=abc')
+
+    await createApiClient({ baseUrl: PAGE_ORIGIN }).request('posts.search', { body: { q: 'hi' } })
+
+    expect(calls[0]!.init.method).toBe('QUERY')
+    expect(calls[0]!.init.body).toBe(JSON.stringify({ q: 'hi' }))
+    expect(headersOf(calls[0]!.init)['X-XSRF-TOKEN']).toBe('abc')
   })
 
   // The cookie belongs to the page's origin. Attaching it to a caller-supplied

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -551,6 +551,47 @@ export default function registerRoutes(router: any) {
     }
   })
 
+  it.each([
+    ['reads the body raw', 'const criteria = await this.request.json()', 'fail'],
+    ['validates the body', 'const criteria = await this.validateBody(SearchSchema)', 'pass'],
+  ] as const)('checks QUERY body validation (%s) without demanding auth', async (_variant, read, expected) => {
+    const workspace = await createTempWorkspace('guren-cli-audit-query-')
+
+    try {
+      await writeController(
+        workspace.dir,
+        'SearchController',
+        `export default class SearchController {
+  async index() {
+    ${read}
+    return null
+  }
+}`,
+      )
+      await writeRoutes(
+        workspace.dir,
+        `class SearchController {
+  async index() { return null }
+}
+export default function registerRoutes(router: any) {
+  router.query('/posts/search', [SearchController, 'index'])
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      expect(report.routesAnalyzed).toBe(true)
+      const validation = report.findings.find(f => f.key === 'validation:QUERY /posts/search')
+      expect(validation).toBeDefined()
+      expect(validation!.status).toBe(expected)
+      // QUERY is safe (RFC 10008), so no mutating-route auth finding at all.
+      const authz = report.findings.find(f => f.key === 'authz:QUERY /posts/search')
+      expect(authz).toBeUndefined()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('suppresses findings marked with guren-audit-ignore', async () => {
     const workspace = await createTempWorkspace('guren-cli-audit-ignore-')
 

--- a/packages/cli/tests/context.test.ts
+++ b/packages/cli/tests/context.test.ts
@@ -152,7 +152,7 @@ describe('GUREN_API_DIGEST', () => {
       'bind: { id: Post }',
       "await this.authorize('update', [Post, post])",
     ],
-    'testing.md': ['actingAs', 'withCsrf', 'assertUnprocessable', 'assertInertia'],
+    'testing.md': ['actingAs', 'withCsrf', 'assertUnprocessable', 'assertInertia', 'query(path, body?)'],
   }
 
   for (const [ruleFile, tokens] of Object.entries(tokensByRuleFile)) {

--- a/packages/cli/tests/routes-types.test.ts
+++ b/packages/cli/tests/routes-types.test.ts
@@ -68,6 +68,7 @@ describe('buildDeclarationContent', () => {
       { method: 'PUT', path: '/resource/:id' },
       { method: 'PATCH', path: '/resource/:id' },
       { method: 'DELETE', path: '/resource/:id' },
+      { method: 'QUERY', path: '/resource/search' },
     ]
 
     const content = buildDeclarationContent(definitions, { source: 'routes/web.ts' })
@@ -77,6 +78,7 @@ describe('buildDeclarationContent', () => {
     expect(content).toContain("'PUT'")
     expect(content).toContain("'PATCH'")
     expect(content).toContain("'DELETE'")
+    expect(content).toContain("'QUERY'")
   })
 
   it('generates template literals for dynamic routes', () => {

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -57,6 +57,12 @@ export interface MountOpenApiDocsOptions extends OpenApiDocumentOptions {
   jsonPath?: string
   docsPath?: string
   definitions?: RouteDefinition[] | (() => RouteDefinition[])
+  /**
+   * Sink for generation warnings (e.g. routes the document cannot express).
+   * Called once per distinct warning across the mount's lifetime.
+   * Defaults to `console.warn` with a `[guren/openapi]` prefix.
+   */
+  onWarning?: (warning: string) => void
 }
 
 export interface OpenApiInfoObject {
@@ -139,18 +145,31 @@ const DEFAULT_OUTPUT_FILE = '.guren/openapi.gen.json'
 const DEFAULT_JSON_PATH = '/openapi.json'
 const DEFAULT_DOCS_PATH = '/docs'
 
+// The only method keys an OpenAPI 3.1 Path Item may carry. Routes registered
+// with any other method (QUERY, or a custom verb via router.on()) would make
+// the emitted document invalid, so they are skipped with a warning instead.
+// OpenAPI 3.2 adds `query`/`additionalOperations`; revisit when the generator
+// targets it.
+const OPENAPI_31_METHOD_KEYS = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'])
+
 export function generateOpenApiDocument(
   definitions: RouteDefinition[],
   options: OpenApiDocumentOptions,
 ): GenerateOpenApiDocumentResult {
   const warnings: string[] = []
   // Route-derived path keys go through a Map so a literal `__proto__` route
-  // cannot pollute Object.prototype; method keys are fixed HTTP verbs.
+  // cannot pollute Object.prototype; method keys are allowlisted below.
   const pathEntries = new Map<string, Record<string, OpenApiOperationObject>>()
 
   for (const definition of definitions) {
     const pathKey = toOpenApiPath(definition.path)
     const methodKey = definition.method.toLowerCase()
+    if (!OPENAPI_31_METHOD_KEYS.has(methodKey)) {
+      warnings.push(
+        `Skipped ${definition.method} ${definition.path}: OpenAPI 3.1 cannot express the ${definition.method} method.`,
+      )
+      continue
+    }
     const operation = buildOperation(definition, warnings)
 
     const operations = pathEntries.get(pathKey)
@@ -204,8 +223,19 @@ export function mountOpenApiDocs(
   const docsPath = options.docsPath ?? DEFAULT_DOCS_PATH
   const getDefinitions = resolveDefinitions(target, options.definitions)
 
+  // Serving silently would hide routes the generator had to skip (e.g. QUERY
+  // under OpenAPI 3.1). Definitions resolve lazily per request and can grow
+  // after mount, so dedupe per distinct warning — not once ever — or a route
+  // registered after the first fetch would be skipped without a trace.
+  const onWarning = options.onWarning ?? ((warning: string) => console.warn(`[guren/openapi] ${warning}`))
+  const emitted = new Set<string>()
   hono.get(jsonPath, (context: HonoLikeContext) => {
-    const { document } = generateOpenApiDocument(getDefinitions(), options)
+    const { document, warnings } = generateOpenApiDocument(getDefinitions(), options)
+    for (const warning of warnings) {
+      if (emitted.has(warning)) continue
+      emitted.add(warning)
+      onWarning(warning)
+    }
     return context.json(document)
   })
 

--- a/packages/openapi/tests/openapi.test.ts
+++ b/packages/openapi/tests/openapi.test.ts
@@ -115,6 +115,62 @@ describe('@guren/openapi', () => {
     expect(html).toContain('/openapi.json')
   })
 
+  it('skips methods OpenAPI 3.1 cannot express and says so in a warning', () => {
+    const definitions: RouteDefinition[] = [
+      { method: 'GET', path: '/posts', name: 'posts.index' },
+      { method: 'QUERY', path: '/posts/search', name: 'posts.search' },
+      { method: 'PURGE', path: '/cache', name: 'cache.purge' },
+    ]
+
+    const { document, warnings } = generateOpenApiDocument(definitions, {
+      title: 'Blog API',
+      version: '1.0.0',
+    })
+
+    expect(document.paths['/posts']?.get).toBeDefined()
+    expect(document.paths['/posts/search']).toBeUndefined()
+    expect(document.paths['/cache']).toBeUndefined()
+    expect(warnings).toEqual([
+      'Skipped QUERY /posts/search: OpenAPI 3.1 cannot express the QUERY method.',
+      'Skipped PURGE /cache: OpenAPI 3.1 cannot express the PURGE method.',
+    ])
+  })
+
+  it('surfaces skip warnings once when the document is served mounted', async () => {
+    const app = createApp({
+      routes(router) {
+        router.get('/posts', { name: 'posts.index' }, async () => [])
+        router.query('/posts/search', { name: 'posts.search' }, async () => [])
+      },
+    })
+
+    mountOpenApiDocs(app, {
+      title: 'Blog API',
+      version: '1.0.0',
+    })
+
+    await app.boot()
+
+    const warned: string[] = []
+    const originalWarn = console.warn
+    console.warn = (...args: unknown[]) => { warned.push(args.join(' ')) }
+    try {
+      const first = await app.fetch(new Request('http://localhost/openapi.json'))
+      expect(first.status).toBe(200)
+      const document = await first.json() as { paths: Record<string, unknown> }
+      expect(document.paths['/posts/search']).toBeUndefined()
+
+      const second = await app.fetch(new Request('http://localhost/openapi.json'))
+      expect(second.status).toBe(200)
+    } finally {
+      console.warn = originalWarn
+    }
+
+    expect(warned).toEqual([
+      '[guren/openapi] Skipped QUERY /posts/search: OpenAPI 3.1 cannot express the QUERY method.',
+    ])
+  })
+
   // An app only learns the address it serves on after it binds, so a mounted
   // document has to be able to pick the value up afterwards. Both fetches
   // matter: one alone passes just as well against a list frozen at mount.

--- a/packages/server/src/http/middleware/cors.test.ts
+++ b/packages/server/src/http/middleware/cors.test.ts
@@ -49,6 +49,28 @@ describe('createCorsMiddleware', () => {
     }).toThrow('credentials requires an explicit origin')
   })
 
+  // Passing `allowMethods: undefined` through to Hono spreads over its default
+  // and produces preflights with NO Access-Control-Allow-Methods, so Guren
+  // owns the default list. QUERY (RFC 10008) is part of it.
+  test('preflight without explicit allowMethods advertises the default methods', async () => {
+    const app = new Hono()
+    app.use('*', createCorsMiddleware({ origin: 'https://example.com' }))
+    app.on('QUERY', '/search', (c) => c.json({ ok: true }))
+
+    const res = await app.request('/search', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://example.com',
+        'Access-Control-Request-Method': 'QUERY',
+      },
+    })
+
+    const allowMethods = res.headers.get('Access-Control-Allow-Methods')
+    expect(allowMethods).not.toBeNull()
+    expect(allowMethods).toContain('QUERY')
+    expect(allowMethods).toContain('GET')
+  })
+
   test('should handle preflight OPTIONS request', async () => {
     const app = new Hono()
     app.use('*', createCorsMiddleware({

--- a/packages/server/src/http/middleware/cors.ts
+++ b/packages/server/src/http/middleware/cors.ts
@@ -9,7 +9,7 @@ export interface CorsOptions {
    * - A function: dynamic origin evaluation
    */
   origin?: string | string[] | ((origin: string, ctx: unknown) => string | undefined | null)
-  /** Allowed HTTP methods. Default: ['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH'] */
+  /** Allowed HTTP methods. Default: ['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH', 'QUERY'] */
   allowMethods?: string[]
   /** Allowed request headers. */
   allowHeaders?: string[]
@@ -20,6 +20,13 @@ export interface CorsOptions {
   /** Allow credentials (cookies, authorization headers). Default: false */
   credentials?: boolean
 }
+
+// Guren owns the method default instead of relying on Hono's: the supported
+// Hono range (^4.12.29) starts before Hono's own list gained QUERY, and Hono
+// spreads caller options over its defaults, so a key passed as `undefined`
+// would erase the default entirely (a preflight with no
+// Access-Control-Allow-Methods at all).
+const DEFAULT_ALLOW_METHODS = ['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH', 'QUERY']
 
 /**
  * CORS middleware powered by Hono's built-in CORS support.
@@ -54,12 +61,15 @@ export function createCorsMiddleware(options: CorsOptions = {}): MiddlewareHandl
   // This is safer than defaulting to '*' which would allow any origin.
   const origin = options.origin ?? (() => '')
 
+  // Omit unset keys rather than forwarding `undefined` — see the
+  // DEFAULT_ALLOW_METHODS note for why an explicit `undefined` is not
+  // equivalent to leaving a key out.
   return cors({
     origin,
-    allowMethods: options.allowMethods,
-    allowHeaders: options.allowHeaders,
-    exposeHeaders: options.exposeHeaders,
-    maxAge: options.maxAge,
-    credentials: options.credentials,
+    allowMethods: options.allowMethods ?? DEFAULT_ALLOW_METHODS,
+    ...(options.allowHeaders !== undefined && { allowHeaders: options.allowHeaders }),
+    ...(options.exposeHeaders !== undefined && { exposeHeaders: options.exposeHeaders }),
+    ...(options.maxAge !== undefined && { maxAge: options.maxAge }),
+    ...(options.credentials !== undefined && { credentials: options.credentials }),
   })
 }

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -139,7 +139,7 @@ interface RegisteredRoute {
  * Represents a registered route definition for introspection.
  */
 export interface RouteDefinition {
-  /** HTTP method (GET, POST, PUT, PATCH, DELETE) */
+  /** Uppercased HTTP method (GET, POST, PUT, PATCH, DELETE, QUERY, or any custom method registered via on()) */
   method: string
   /** URL path pattern (e.g., '/users/:id') */
   path: string
@@ -479,6 +479,38 @@ export class Router<M extends string = never> {
   ): RouteBuilder<M>
   delete(path: string, handlerOrOptions: unknown, ...rest: unknown[]): RouteBuilder<M> {
     return this.register('DELETE', path, handlerOrOptions, rest)
+  }
+
+  /**
+   * Registers a route for the HTTP QUERY method (RFC 10008): safe and
+   * idempotent like GET, but the request carries a body like POST. Handlers
+   * must not mutate state — CSRF protection deliberately skips QUERY on that
+   * assumption (see `createCsrfMiddleware`'s `methods` option to opt in).
+   */
+  query<C extends ControllerConstructor>(path: string, handler: RouteHandler<C>, ...middlewares: MiddlewareHandler[]): RouteBuilder<M>
+  query<
+    TParamsSchema extends SchemaLike<unknown>,
+    TQuerySchema extends SchemaLike<unknown>,
+    TBodySchema extends SchemaLike<unknown>,
+    TOutputSchema extends SchemaLike<unknown>,
+  >(
+    path: string,
+    options: RouteContractOptions<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
+    handler: TypedRouteHandler<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
+  ): RouteBuilder<M>
+  query<
+    C extends ControllerConstructor,
+    TParamsSchema extends SchemaLike<unknown>,
+    TQuerySchema extends SchemaLike<unknown>,
+    TBodySchema extends SchemaLike<unknown>,
+    TOutputSchema extends SchemaLike<unknown>,
+  >(
+    path: string,
+    options: RouteContractOptions<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
+    handler: ControllerAction<C>,
+  ): RouteBuilder<M>
+  query(path: string, handlerOrOptions: unknown, ...rest: unknown[]): RouteBuilder<M> {
+    return this.register('QUERY', path, handlerOrOptions, rest)
   }
 
   group(prefix: string, callback: (router: Router<M>) => void): this {
@@ -871,6 +903,60 @@ class RouterMiddlewareGroupBuilder<M extends string = never> {
   ): RouteBuilder<M>
   delete(path: string, handlerOrOptions: unknown, ...rest: unknown[]): RouteBuilder<M> {
     return this.router.applyMiddlewareScope(this.items, () => this.router.delete(path, handlerOrOptions as never, ...(rest as never[])))
+  }
+
+  query<C extends ControllerConstructor>(path: string, handler: RouteHandler<C>, ...middlewares: MiddlewareHandler[]): RouteBuilder<M>
+  query<
+    TParamsSchema extends SchemaLike<unknown>,
+    TQuerySchema extends SchemaLike<unknown>,
+    TBodySchema extends SchemaLike<unknown>,
+    TOutputSchema extends SchemaLike<unknown>,
+  >(
+    path: string,
+    options: RouteContractOptions<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
+    handler: TypedRouteHandler<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
+  ): RouteBuilder<M>
+  query<
+    C extends ControllerConstructor,
+    TParamsSchema extends SchemaLike<unknown>,
+    TQuerySchema extends SchemaLike<unknown>,
+    TBodySchema extends SchemaLike<unknown>,
+    TOutputSchema extends SchemaLike<unknown>,
+  >(
+    path: string,
+    options: RouteContractOptions<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
+    handler: ControllerAction<C>,
+  ): RouteBuilder<M>
+  query(path: string, handlerOrOptions: unknown, ...rest: unknown[]): RouteBuilder<M> {
+    return this.router.applyMiddlewareScope(this.items, () => this.router.query(path, handlerOrOptions as never, ...(rest as never[])))
+  }
+
+  on<C extends ControllerConstructor>(method: string, path: string, handler: RouteHandler<C>, ...middlewares: MiddlewareHandler[]): RouteBuilder<M>
+  on<
+    TParamsSchema extends SchemaLike<unknown>,
+    TQuerySchema extends SchemaLike<unknown>,
+    TBodySchema extends SchemaLike<unknown>,
+    TOutputSchema extends SchemaLike<unknown>,
+  >(
+    method: string,
+    path: string,
+    options: RouteContractOptions<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
+    handler: TypedRouteHandler<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
+  ): RouteBuilder<M>
+  on<
+    C extends ControllerConstructor,
+    TParamsSchema extends SchemaLike<unknown>,
+    TQuerySchema extends SchemaLike<unknown>,
+    TBodySchema extends SchemaLike<unknown>,
+    TOutputSchema extends SchemaLike<unknown>,
+  >(
+    method: string,
+    path: string,
+    options: RouteContractOptions<TParamsSchema, TQuerySchema, TBodySchema, TOutputSchema>,
+    handler: ControllerAction<C>,
+  ): RouteBuilder<M>
+  on(method: string, path: string, handlerOrOptions: unknown, ...rest: unknown[]): RouteBuilder<M> {
+    return this.router.applyMiddlewareScope(this.items, () => this.router.on(method, path, handlerOrOptions as never, ...(rest as never[])))
   }
 }
 

--- a/packages/server/tests/http/middleware/csrf.test.ts
+++ b/packages/server/tests/http/middleware/csrf.test.ts
@@ -292,6 +292,55 @@ describe('createCsrfMiddleware', () => {
     expect(deleteRes.status).toBe(403)
   })
 
+  it('allows QUERY requests without token by default (RFC 10008 safe method)', async () => {
+    const app = createTestApp()
+
+    app.on('QUERY', '/search', (c) => c.json({ ok: true }))
+
+    const res = await app.request('/search', {
+      method: 'QUERY',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ q: 'hello' }),
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+  })
+
+  it('protects QUERY when opted in via the methods option', async () => {
+    const app = createTestApp({
+      methods: ['POST', 'PUT', 'PATCH', 'DELETE', 'QUERY'],
+    })
+    let token: string | undefined
+
+    app.get('/api/token', (c) => {
+      token = getCsrfToken(c)
+      return c.json({ token })
+    })
+    app.on('QUERY', '/search', (c) => c.json({ ok: true }))
+
+    const tokenless = await app.request('/search', {
+      method: 'QUERY',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ q: 'hello' }),
+    })
+    expect(tokenless.status).toBe(403)
+
+    const getRes = await app.request('/api/token')
+    const cookie = extractCookie(getRes)
+
+    const withToken = await app.request('/search', {
+      method: 'QUERY',
+      headers: {
+        [CSRF_HEADER_NAME]: token!,
+        'Content-Type': 'application/json',
+        Cookie: cookie,
+      },
+      body: JSON.stringify({ q: 'hello' }),
+    })
+    expect(withToken.status).toBe(200)
+    expect(await withToken.json()).toEqual({ ok: true })
+  })
+
   it('excludes specified paths from protection', async () => {
     const app = createTestApp({
       exclude: ['/api/webhooks/*', '/health'],

--- a/packages/server/tests/mvc/router.test.ts
+++ b/packages/server/tests/mvc/router.test.ts
@@ -137,7 +137,7 @@ describe('Router route contract metadata', () => {
 // assignment fails to compile the moment the builder stops accepting everything
 // `Router` does — including overloads added long after this was written, which a
 // per-call test can never anticipate. Root `tsc --noEmit` covers this directory.
-const _verbParityGuard: Pick<Router<'auth'>, 'get' | 'post' | 'put' | 'patch' | 'delete'> =
+const _verbParityGuard: Pick<Router<'auth'>, 'get' | 'post' | 'put' | 'patch' | 'delete' | 'query' | 'on'> =
   new Router<'auth'>().aliasMiddleware('auth', async (_c, next) => { await next() }).middleware('auth')
 void _verbParityGuard
 
@@ -792,5 +792,65 @@ describe('Router capability aggregation', () => {
 
     expect(capabilitiesOf(requireAuthenticated())).toEqual({ authentication: { mode: 'required' } })
     expect(capabilitiesOf(requireGuest())).toEqual({ authentication: { mode: 'guest-only' } })
+  })
+})
+
+describe('Router QUERY method (RFC 10008)', () => {
+  it('query() registers a QUERY route with contract metadata', () => {
+    const body = z.object({ q: z.string().min(1) })
+    const router = new Router()
+    router.query('/posts/search', { name: 'posts.search', body }, [StubController, 'index'])
+
+    const [def] = router.definitions()
+    expect(def!.method).toBe('QUERY')
+    expect(def!.path).toBe('/posts/search')
+    expect(def!.name).toBe('posts.search')
+    expect(def!.schemas?.body).toBe(body)
+    expect(def!.controller).toEqual({ name: 'StubController', action: 'index' })
+  })
+
+  it('dispatches QUERY requests with a validated body through mount()', async () => {
+    const router = new Router()
+    router.query('/search', {
+      body: z.object({ q: z.string(), limit: z.number().default(10) }),
+    }, async ({ body }) => ({ q: body.q, limit: body.limit }))
+
+    const app = new Hono()
+    router.mount(app)
+
+    const response = await app.request('/search', {
+      method: 'QUERY',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ q: 'hello' }),
+    })
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ q: 'hello', limit: 10 })
+  })
+
+  it('middleware group builder supports query()', async () => {
+    const router = new Router<'auth'>()
+    const seen: string[] = []
+    router.aliasMiddleware('auth', async (_c, next) => { seen.push('auth'); await next() })
+    router.middleware('auth').query('/search', { name: 'search' }, async () => ({ ok: true }))
+
+    const [def] = router.definitions()
+    expect(def!.method).toBe('QUERY')
+    expect(def!.middlewareNames).toEqual(['auth'])
+
+    const app = new Hono()
+    router.mount(app)
+    const response = await app.request('/search', { method: 'QUERY' })
+    expect(response.status).toBe(200)
+    expect(seen).toEqual(['auth'])
+  })
+
+  it('middleware group builder supports on() for arbitrary methods', () => {
+    const router = new Router<'auth'>()
+    router.aliasMiddleware('auth', async (_c, next) => { await next() })
+    router.middleware('auth').on('QUERY', '/reports', { name: 'reports.query' }, async () => ({ ok: true }))
+
+    const [def] = router.definitions()
+    expect(def!.method).toBe('QUERY')
+    expect(def!.middlewareNames).toEqual(['auth'])
   })
 })

--- a/packages/testing/src/http.ts
+++ b/packages/testing/src/http.ts
@@ -479,6 +479,14 @@ export class TestClient {
   }
 
   /**
+   * Create a QUERY request (RFC 10008): safe and idempotent like GET, but
+   * carries a request body like POST.
+   */
+  query(path: string): TestRequestBuilder {
+    return this.request('QUERY', path)
+  }
+
+  /**
    * Create a request with any method.
    */
   request(method: string, path: string): TestRequestBuilder {

--- a/packages/testing/src/test-app.fromApp.test.ts
+++ b/packages/testing/src/test-app.fromApp.test.ts
@@ -89,3 +89,27 @@ describe('TestApp.fromApp', () => {
     expect(seenDuringBoot).toBe('1')
   })
 })
+
+describe('TestApp.query', () => {
+  it('sends a QUERY request with a JSON body', async () => {
+    const app = {
+      async boot(): Promise<void> {},
+      async fetch(request: Request): Promise<Response> {
+        return Response.json({
+          method: request.method,
+          contentType: request.headers.get('content-type'),
+          body: await request.json(),
+        })
+      },
+    }
+
+    const http = await TestApp.fromApp(app)
+    const response = await http.query('/search', { q: 'hello', limit: 10 })
+
+    expect(await response.json()).toEqual({
+      method: 'QUERY',
+      contentType: 'application/json',
+      body: { q: 'hello', limit: 10 },
+    })
+  })
+})

--- a/packages/testing/src/test-app.ts
+++ b/packages/testing/src/test-app.ts
@@ -622,6 +622,14 @@ export class TestApp {
   }
 
   /**
+   * Make a QUERY request (RFC 10008): safe and idempotent like GET, but
+   * carries a request body like POST.
+   */
+  query(path: string, body?: unknown): PendingTestResponse {
+    return this.request('QUERY', path, body)
+  }
+
+  /**
    * Make a request with any HTTP method.
    */
   private request(method: string, path: string, body?: unknown): PendingTestResponse {


### PR DESCRIPTION
## Summary

Adds first-class support for the HTTP QUERY method ([RFC 10008](https://www.rfc-editor.org/info/rfc10008/), June 2026): safe and idempotent like GET, but the request carries a body like POST — the right verb for search/filter endpoints whose criteria don't fit in a URL, and a natural fit for agent-facing APIs where the safe/idempotent contract informs retry decisions.

The runtime already passed QUERY through (`mountRoute` hands Hono a dynamic method string), so this PR is about making it first-class across the toolchain:

- **Router**: `router.query(path, options, handler)` with the same overloads as the other verbs, both on `Router` and inside `middleware(...)` group builders. Group builders also gain the generic `on()` for arbitrary methods, and the compile-time verb-parity guard now covers `query`/`on`.
- **Testing**: `TestApp.query(path, body?)` and `TestClient.query(path)`.
- **Codegen**: no changes needed — routes.gen/api-client are method-string-driven; QUERY flowing through is now pinned by tests. The generated client sends QUERY with a body and keeps attaching the XSRF header (see CSRF below).
- **audit**: QUERY routes get the body-validation check without the mutating-route auth requirement, matching GET. The loop gate is now `AUDITED_METHODS`, the derived union of the mutating and body-carrying sets.
- **OpenAPI**: the generator now allowlists the methods OpenAPI 3.1 can express; QUERY (or any custom verb) is skipped with a per-route warning instead of silently emitting an invalid document. Mounted docs no longer discard generation warnings — they flow through a new `onWarning` option (default `console.warn`), deduped per distinct warning so routes registered after the first fetch still get reported.
- **CORS fix (pre-existing bug)**: `createCorsMiddleware` handed Hono an explicit `allowMethods: undefined`, which spreads over Hono's default and produced preflights with **no `Access-Control-Allow-Methods` header at all**. Guren now owns the default list (`GET, HEAD, PUT, POST, DELETE, PATCH, QUERY`) and omits unset option keys entirely.
- **Docs**: routing/testing/csrf guides (en + ja), agent harness rules/skills, API digest, `route:list` coloring.

## Design decisions

- **CSRF skips QUERY by default.** QUERY is a safe method: browsers cannot send it via forms, and scripted cross-origin QUERY always triggers a CORS preflight, so CSRF is not exploitable as long as handlers honor the safety contract (documented prominently). Protecting it by default would recreate the "API client never fetches a token" problem the MCP endpoint hit. Apps can opt in via the middleware's existing `methods` option — and the generated client deliberately keeps sending the XSRF header on same-origin requests so that opt-in works unchanged (pinned by tests in both directions).
- **OpenAPI stays on 3.1.** Only OpenAPI 3.2 can express QUERY; migrating the generator is a separate, output-changing PR.
- **Templates unchanged.** `query()` isn't used in scaffolds until a release ships it (templates resolve `@guren/*` from npm).

## Scope

server, core (re-export), testing, cli, openapi, docs. One changeset, minor across those five packages.

## Risk Assessment

- The CORS change alters default preflight responses: previously (no `allowMethods` configured) preflights advertised no methods at all — which broke non-simple cross-origin requests — now they advertise the default list. This is a fix, but it is a behavior change visible on the wire.
- OpenAPI output changes only for apps that register non-3.1 methods (previously invalid documents, now skipped + warned).
- `guren audit` output changes only for apps with QUERY routes (new validation findings).
- Deployment caveat documented: Guren's fetch-based adapters pass QUERY through, but platform ingress must accept it — CloudFront (fronting Lambda-plugin apps with assets) does not forward QUERY.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` (test:bun 4125 pass / 0 fail, test:examples 102 pass)
- [x] `bun run audit:core-first`, `audit:docs`, `audit:starter-template`
- [x] `bun run smoke:starter` and `smoke:starter:api` (agent template files touched)
- [x] Dogfood on examples/blog: temporary QUERY route → codegen emits `posts.search` into routes.gen/api-client, `tsc --noEmit` clean, audit reports `validation: pass` and no authz finding
- [x] Bun 1.3.14 + Hono end-to-end probe: `QUERY /search` with JSON body round-trips 200

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.