### PR TITLE
test(server): share the Vite dev server mocking setup across listen tests

### DIFF
--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -152,11 +152,22 @@ function syncManagedInertiaDevEntry(devServerUrl: string): void {
   }
 }
 
-type GurenGlobal = typeof globalThis & {
+/**
+ * The ambient slots `listen()` plants on `globalThis` so a `bun --hot` reload,
+ * which re-runs the entrypoint but keeps `globalThis`, can find what the
+ * previous run left running.
+ *
+ * Exported so the tests that plant stand-ins in these slots can name them
+ * against this declaration instead of restating it. Not part of the public
+ * API: `src/index.ts` re-exports by name and does not list it.
+ */
+export interface GurenGlobalSlots {
   __gurenActiveServer?: BunServer
   __gurenActiveViteDevServer?: ViteServer
   __gurenActiveViteDevServerUrl?: string
 }
+
+type GurenGlobal = typeof globalThis & GurenGlobalSlots
 
 function getGlobalState(): GurenGlobal {
   return globalThis as GurenGlobal

--- a/packages/server/tests/http/application-listen-reuse.test.ts
+++ b/packages/server/tests/http/application-listen-reuse.test.ts
@@ -1,29 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-const viteCloseMock = mock(async () => {})
+import { createViteDevServerMocks, gurenGlobals, resetGurenGlobals } from './vite-dev-server-fixture'
 
-const startViteDevServerMock = mock(async () => ({
-  server: {
-    close: viteCloseMock,
-    httpServer: { listening: true },
-  },
-  localUrl: 'http://localhost:5174',
-  networkUrls: [],
-}))
+const vite = createViteDevServerMocks()
 
-await mock.module('../../src/http/vite-dev-server', () => ({
-  startViteDevServer: startViteDevServerMock,
-}))
+await mock.module('../../src/http/vite-dev-server', vite.moduleFactory)
 
 const { Application } = await import('../../src/http/Application')
-
-type GurenGlobal = typeof globalThis & {
-  __gurenActiveServer?: unknown
-  __gurenActiveViteDevServer?: unknown
-  __gurenActiveViteDevServerUrl?: string
-}
-
-const globalState = globalThis as GurenGlobal
 
 describe('Application.listen Vite dev server reuse on hot reload', () => {
   const originalEnv = { ...process.env }
@@ -36,19 +19,32 @@ describe('Application.listen Vite dev server reuse on hot reload', () => {
     delete process.env.VITE_DEV_SERVER_URL
     delete process.env.GUREN_MANAGED_VITE_DEV_SERVER
     delete process.env.GUREN_INERTIA_ENTRY
-    startViteDevServerMock.mockClear()
-    viteCloseMock.mockClear()
-    globalState.__gurenActiveServer = undefined
-    globalState.__gurenActiveViteDevServer = undefined
-    globalState.__gurenActiveViteDevServerUrl = undefined
+    vite.clear()
+    resetGurenGlobals()
   })
 
   afterEach(() => {
     process.env = { ...originalEnv }
     Bun.serve = originalServe
-    globalState.__gurenActiveServer = undefined
-    globalState.__gurenActiveViteDevServer = undefined
-    globalState.__gurenActiveViteDevServerUrl = undefined
+    resetGurenGlobals()
+  })
+
+  it('keeps the rest of the vite-dev-server module reachable behind the stub', async () => {
+    // Reads what `mock.module` installed, not what the fixture would hand it:
+    // this is the one assertion that fails if the module is replaced wholesale
+    // rather than spread. Every other test here would pass either way, and the
+    // stripped export would surface in whichever file loads it next instead.
+    //
+    // Load-order dependent, so run it the way CI does. Under `bun run test:bun
+    // server` this catches a dropped spread; in a narrower run that loads the
+    // module elsewhere first, Bun patches the named export in place and leaves
+    // the others reachable, which hides the difference.
+    const mocked = await import('../../src/http/vite-dev-server')
+
+    expect(typeof mocked.resolveViteDevServerConfig).toBe('function')
+    // Cast because the import is typed as the real module: the stub answers
+    // with a stand-in server, not a `ViteDevServer`. Identity is the assertion.
+    expect(mocked.startViteDevServer as unknown).toBe(vite.startViteDevServer)
   })
 
   it('reuses a still-listening managed Vite dev server instead of closing it', async () => {
@@ -58,18 +54,18 @@ describe('Application.listen Vite dev server reuse on hot reload', () => {
     // the Bun server was already stopped — leaving the process without any
     // HTTP listener. Reuse is the fix; this pins it.
     const previousClose = mock(async () => {})
-    globalState.__gurenActiveViteDevServer = {
+    gurenGlobals.__gurenActiveViteDevServer = {
       close: previousClose,
       httpServer: { listening: true },
     }
-    globalState.__gurenActiveViteDevServerUrl = 'http://localhost:5175'
+    gurenGlobals.__gurenActiveViteDevServerUrl = 'http://localhost:5175'
 
     Bun.serve = mock(() => ({ stop: mock(async () => {}) })) as unknown as typeof Bun.serve
 
     const app = new Application()
     await app.listen({ port: 3345, hostname: '127.0.0.1' })
 
-    expect(startViteDevServerMock).not.toHaveBeenCalled()
+    expect(vite.startViteDevServer).not.toHaveBeenCalled()
     expect(previousClose).not.toHaveBeenCalled()
     expect(process.env.VITE_DEV_SERVER_URL).toBe('http://localhost:5175')
     expect(process.env.GUREN_MANAGED_VITE_DEV_SERVER).toBe('1')
@@ -77,16 +73,16 @@ describe('Application.listen Vite dev server reuse on hot reload', () => {
       'http://localhost:5175/resources/js/dev-entry.ts',
     )
     // The reused server stays recorded for the next reload.
-    expect(globalState.__gurenActiveViteDevServerUrl).toBe('http://localhost:5175')
+    expect(gurenGlobals.__gurenActiveViteDevServerUrl).toBe('http://localhost:5175')
   })
 
   it('restarts Vite when the previous server is no longer listening', async () => {
     const previousClose = mock(async () => {})
-    globalState.__gurenActiveViteDevServer = {
+    gurenGlobals.__gurenActiveViteDevServer = {
       close: previousClose,
       httpServer: { listening: false },
     }
-    globalState.__gurenActiveViteDevServerUrl = 'http://localhost:5175'
+    gurenGlobals.__gurenActiveViteDevServerUrl = 'http://localhost:5175'
 
     Bun.serve = mock(() => ({ stop: mock(async () => {}) })) as unknown as typeof Bun.serve
 
@@ -94,7 +90,7 @@ describe('Application.listen Vite dev server reuse on hot reload', () => {
     await app.listen({ port: 3346, hostname: '127.0.0.1' })
 
     expect(previousClose).toHaveBeenCalledTimes(1)
-    expect(startViteDevServerMock).toHaveBeenCalledTimes(1)
+    expect(vite.startViteDevServer).toHaveBeenCalledTimes(1)
     expect(process.env.VITE_DEV_SERVER_URL).toBe('http://localhost:5174')
   })
 
@@ -102,11 +98,11 @@ describe('Application.listen Vite dev server reuse on hot reload', () => {
     // The running server was built from the previous call's options; explicit
     // options on this call may differ, so they force a restart.
     const previousClose = mock(async () => {})
-    globalState.__gurenActiveViteDevServer = {
+    gurenGlobals.__gurenActiveViteDevServer = {
       close: previousClose,
       httpServer: { listening: true },
     }
-    globalState.__gurenActiveViteDevServerUrl = 'http://localhost:5175'
+    gurenGlobals.__gurenActiveViteDevServerUrl = 'http://localhost:5175'
 
     Bun.serve = mock(() => ({ stop: mock(async () => {}) })) as unknown as typeof Bun.serve
 
@@ -114,7 +110,7 @@ describe('Application.listen Vite dev server reuse on hot reload', () => {
     await app.listen({ port: 3347, hostname: '127.0.0.1', vite: { port: 5199 } })
 
     expect(previousClose).toHaveBeenCalledTimes(1)
-    expect(startViteDevServerMock).toHaveBeenCalledTimes(1)
+    expect(vite.startViteDevServer).toHaveBeenCalledTimes(1)
   })
 
   it('abandons a previous Vite server whose close() never resolves', async () => {
@@ -122,18 +118,18 @@ describe('Application.listen Vite dev server reuse on hot reload', () => {
     // was stopped would leave the process alive with no listener at all.
     process.env.GUREN_VITE_CLOSE_TIMEOUT_MS = '50'
 
-    globalState.__gurenActiveViteDevServer = {
+    gurenGlobals.__gurenActiveViteDevServer = {
       close: () => new Promise(() => {}),
       httpServer: { listening: false },
     }
-    globalState.__gurenActiveViteDevServerUrl = 'http://localhost:5175'
+    gurenGlobals.__gurenActiveViteDevServerUrl = 'http://localhost:5175'
 
     Bun.serve = mock(() => ({ stop: mock(async () => {}) })) as unknown as typeof Bun.serve
 
     const app = new Application()
     await app.listen({ port: 3348, hostname: '127.0.0.1' })
 
-    expect(startViteDevServerMock).toHaveBeenCalledTimes(1)
+    expect(vite.startViteDevServer).toHaveBeenCalledTimes(1)
     expect(process.env.VITE_DEV_SERVER_URL).toBe('http://localhost:5174')
   })
 })

--- a/packages/server/tests/http/application-listen.test.ts
+++ b/packages/server/tests/http/application-listen.test.ts
@@ -1,18 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-const viteCloseMock = mock(async () => {})
+import { createViteDevServerMocks, resetGurenGlobals } from './vite-dev-server-fixture'
 
-const startViteDevServerMock = mock(async () => ({
-  server: {
-    close: viteCloseMock,
-  },
-  localUrl: 'http://localhost:5174',
-  networkUrls: [],
-}))
+const vite = createViteDevServerMocks()
 
-await mock.module('../../src/http/vite-dev-server', () => ({
-  startViteDevServer: startViteDevServerMock,
-}))
+await mock.module('../../src/http/vite-dev-server', vite.moduleFactory)
 
 const { Application } = await import('../../src/http/Application')
 
@@ -23,13 +15,19 @@ beforeEach(() => {
   process.env = { ...originalEnv }
   process.env.NODE_ENV = 'development'
   process.env.GUREN_DEV_BANNER = '0'
-  startViteDevServerMock.mockClear()
-  viteCloseMock.mockClear()
+  vite.clear()
+  // Each test here starts a server that `listen()` records on `globalThis`,
+  // and a still-listening record sends the next `listen()` down the hot-reload
+  // reuse path instead of the one under test. Bun shares a process across test
+  // files, so the leftover can arrive from a sibling file as easily as from
+  // the test above — hence a reset on both sides.
+  resetGurenGlobals()
 })
 
 afterEach(() => {
   process.env = { ...originalEnv }
   Bun.serve = originalServe
+  resetGurenGlobals()
 })
 
 /**
@@ -56,7 +54,7 @@ describe('Application.listen', () => {
     const app = new Application()
     await app.listen({ port: 3333, hostname: '127.0.0.1' })
 
-    expect(startViteDevServerMock).toHaveBeenCalledTimes(1)
+    expect(vite.startViteDevServer).toHaveBeenCalledTimes(1)
     expect(process.env.VITE_DEV_SERVER_URL).toBe('http://localhost:5174')
     expect(process.env.GUREN_MANAGED_VITE_DEV_SERVER).toBe('1')
     expect(process.env.GUREN_INERTIA_ENTRY).toBe('http://localhost:5174/resources/js/dev-entry.ts')
@@ -83,8 +81,8 @@ describe('Application.listen', () => {
       code: 'EADDRINUSE',
     })
 
-    expect(startViteDevServerMock).toHaveBeenCalledTimes(1)
-    expect(viteCloseMock).toHaveBeenCalled()
+    expect(vite.startViteDevServer).toHaveBeenCalledTimes(1)
+    expect(vite.viteClose).toHaveBeenCalled()
     // The discriminating assertions: `listen()` also closes a *previous*
     // server on the way in, so the call count alone proves nothing. These env
     // vars were published by this call's Vite start, and only this call's

--- a/packages/server/tests/http/vite-dev-server-fixture.ts
+++ b/packages/server/tests/http/vite-dev-server-fixture.ts
@@ -1,0 +1,88 @@
+import { mock } from 'bun:test'
+
+import * as realViteDevServer from '../../src/http/vite-dev-server'
+import type { GurenGlobalSlots } from '../../src/http/Application'
+
+/**
+ * Shared setup for the `Application` tests that stub the managed Vite dev
+ * server. What they each need is a stand-in `startViteDevServer`, a view of the
+ * ambient `__guren*` slots loose enough to hold fake servers, and a way to
+ * clear those slots between tests.
+ *
+ * The `mock.module()` call itself deliberately stays at each call site. When it
+ * runs, relative to the imports around it, is the part of this setup most
+ * likely to matter; moving it here would hide that ordering behind an import.
+ */
+
+/**
+ * The test-side view of {@link GurenGlobalSlots}: the slot names come from the
+ * one declaration in `Application.ts`, so a misspelled slot in a test does not
+ * compile, while the values widen to `unknown` because these tests plant plain
+ * objects where the runtime keeps real Bun and Vite servers.
+ */
+type GurenTestGlobal = typeof globalThis & {
+  [Slot in keyof GurenGlobalSlots]?: unknown
+}
+
+export const gurenGlobals = globalThis as GurenTestGlobal
+
+/**
+ * Clear every slot Guren plants on `globalThis`, so one test's leftover server
+ * cannot be picked up as another's "previous run".
+ *
+ * Swept by prefix rather than by a list of names: the list would be one more
+ * copy of the contract this fixture exists to keep in a single place, and it
+ * would go stale silently. `__guren*` on `globalThis` is Guren's alone —
+ * `__gurenInertia`, the one other name in this family, lives on response
+ * objects rather than the global.
+ *
+ * A plain function, not a `beforeEach` of its own: the callers register their
+ * hooks at different levels, and hook order across files is not something this
+ * fixture should be quietly deciding.
+ */
+export function resetGurenGlobals(): void {
+  const slots = globalThis as Record<string, unknown>
+
+  for (const key of Object.keys(slots)) {
+    if (key.startsWith('__guren')) {
+      delete slots[key]
+    }
+  }
+}
+
+/**
+ * Build the Vite dev server mocks and the module body that installs them.
+ *
+ * `moduleFactory()` spreads the module and overrides only `startViteDevServer`:
+ * Bun shares one module registry across test files, so replacing it wholesale
+ * would strip its other exports for every test that loads it afterwards. The
+ * reuse test pins this by reading back what `mock.module()` installed.
+ */
+export function createViteDevServerMocks() {
+  const viteClose = mock(async () => {})
+
+  const startViteDevServer = mock(async () => ({
+    server: {
+      close: viteClose,
+      // A server that just started is listening. Tests that need the other
+      // answer plant their own `__gurenActiveViteDevServer` instead of
+      // reshaping this one.
+      httpServer: { listening: true },
+    },
+    // Spelled out again in the callers' assertions on purpose: a test that
+    // imported this value would compare the fixture against itself and stay
+    // green whatever it published.
+    localUrl: 'http://localhost:5174',
+    networkUrls: [] as string[],
+  }))
+
+  return {
+    viteClose,
+    startViteDevServer,
+    moduleFactory: () => ({ ...realViteDevServer, startViteDevServer }),
+    clear: () => {
+      viteClose.mockClear()
+      startViteDevServer.mockClear()
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Three test files under `packages/server/tests/http/` each carried a near-identical copy of the same Vite dev server mocking setup: a `viteClose` mock, a `startViteDevServer` mock, a locally re-declared type naming the ambient `__gurenActiveServer` / `__gurenActiveViteDevServer` / `__gurenActiveViteDevServerUrl` slots, and hooks resetting env plus those globals.

The cost was not the line count. The copies disagreed on what the mock replaces — one spreads the real module and overrides a single export, the others substitute the module wholesale, which strips its other exports for every test that loads it later in the same Bun process. Forking that pattern means the correct version reaches one file out of several.

This extracts `packages/server/tests/http/vite-dev-server-fixture.ts`, following the `asset-fixture.ts` precedent, and converts the two call sites that exist on `main`.

Design notes for reviewers:

- **`mock.module()` stays at each call site.** Only the module body comes from the fixture. When the call runs relative to the imports around it is the load-bearing part; hiding it behind an import would obscure that.
- **`Application.ts` now exports the slot shape as `GurenGlobalSlots`.** The tests derive their (value-widened) view from that one declaration instead of restating it, so a misspelled slot fails to compile — confirmed: injecting `__gurenActiveVitDevServer` produces `TS2551 … Did you mean '__gurenActiveViteDevServer'?`. It is not public API: `src/index.ts` re-exports by name and does not list it.
- **`resetGurenGlobals()` sweeps `globalThis` by the `__guren` prefix** rather than iterating a name list, so a fourth slot needs no fixture edit. `__gurenInertia`, the only other name in that family, lives on response objects rather than the global.
- **`resetGurenGlobals()` is a plain function, not a self-registering hook** (unlike `useAssetFixture`). The two callers register hooks at different levels, and `application-listen.test.ts` has two `describe` blocks, so a fixture-owned `beforeEach` would have covered half that file.
- **The `http://localhost:5174` literal is deliberately not exported.** A test importing it would compare the fixture against itself and stay green whatever the fixture published.

## Scope

`server` — tests only, plus one type-only export in `src/http/Application.ts` (fully erased at runtime).

Duplication goes from 4 copies to 3, not to 1: two further copies (`application-stop-vite.test.ts`, `application-stop.test.ts`) belong to an in-flight `Application.stop()` branch that is not on `main`. Adopting the fixture there is a small change that belongs to that PR, whose author currently owns those files.

## Risk Assessment

No runtime behavior change. `GurenGlobalSlots` is `interface` + `type` only.

One intentional test-behavior change: unifying the stub gives `application-listen.test.ts` a server reporting `httpServer: { listening: true }`, which it previously lacked, so `resetGurenGlobals()` was added to its `beforeEach` and `afterEach` (it had no globals reset at all). Both directions were verified to be load-bearing, not decorative:

- Remove both resets → its second test takes the hot-reload reuse path and never calls `startViteDevServer`. Red.
- Keep only the `afterEach`, and make the sibling file leave its globals dirty → the same test fails on cross-file leakage in the shared Bun process. Red.

## Validation

Mutation-tested rather than assumed — a fixture refactor that silently disables assertions is the main risk here:

| Mutation | Result |
|---|---|
| Fixture reports a different `localUrl` | 3 failures across both files |
| `moduleFactory()` stops spreading the real module | exactly the new guard test fails |
| `mock.module()` call removed entirely | the new guard test fails (it did **not** before this change — see below) |
| Both `resetGurenGlobals()` calls removed from `application-listen.test.ts` | its second test fails |

The guard test initially asserted against `vite.moduleFactory()` — the fixture's own return value, called a second time — so deleting the `mock.module()` line left it green. It now reads back `await import('../../src/http/vite-dev-server')`, i.e. what was actually installed. Its discriminating power is load-order dependent, which is noted in a comment next to the assertion: `bun run test:bun server` exercises it; a narrower run that loads the module elsewhere first does not.

Separately verified: the fallback branch in `vite-dev-server.test.ts` that degrades to `expect(result.localUrl.startsWith('http://'))` is **not** currently taken (made it throw, ran the full suite, zero hits). That file's exposure is pre-existing and is reduced by this change, since the spread is what keeps `resolveViteDevServerConfig` reachable.

- [x] `bun run build` — exit 0
- [x] `bun run typecheck` — exit 0, 0 errors
- [x] `bun run test` — exit 0 (`test:bun`: 2112 pass / 45 skip / 0 fail across 2157 tests; examples: 102 passed)

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation. — none needed; no user-facing surface changed.

No changeset: tests only, plus a type-only export that is not part of the published API surface.
