### PR TITLE
fix(server): fail closed on unknown HTTP methods in authorizeResourceMiddleware

### DIFF
--- a/.changeset/authorize-resource-fail-closed.md
+++ b/.changeset/authorize-resource-fail-closed.md
@@ -1,0 +1,18 @@
+---
+'@guren/server': minor
+---
+
+`authorizeResourceMiddleware` now fails closed on HTTP methods outside its built-in mapping
+
+Previously an unknown verb (e.g. a custom `PURGE` route registered via `router.on()`) fell through to the `view` ability, so a user with only view permission passed the gate in front of a handler that may mutate state. Unknown methods are now denied with a 403 (`AuthorizationException`).
+
+- The built-in mapping is now explicit: GET/HEAD/QUERY → `view` (QUERY is safe per RFC 10008, matching CSRF and `guren audit` classifications), POST → `create`, PUT/PATCH → `update`, DELETE → `delete`. Behavior for these methods is unchanged.
+- Custom verbs can opt in via the new `abilityFor` option (`AuthorizeResourceOptions`): return an ability name for a method, or `undefined` to fall back to the built-in mapping.
+
+```ts
+authorizeResourceMiddleware(getPost, {
+  abilityFor: (method) => (method === 'PURGE' ? 'delete' : undefined),
+})
+```
+
+If you relied on custom verbs passing as `view` checks, add an `abilityFor` mapping for them.

--- a/packages/server/src/authorization/index.ts
+++ b/packages/server/src/authorization/index.ts
@@ -9,6 +9,7 @@ export type {
   AuthorizationResponse,
   GateOptions,
   AuthorizeOptions,
+  AuthorizeResourceOptions,
   PolicyRegistration,
   ResourceAction,
   ResponseBuilder,

--- a/packages/server/src/authorization/middleware.ts
+++ b/packages/server/src/authorization/middleware.ts
@@ -1,6 +1,6 @@
 import type { Context } from '../http/Application'
 import type { Middleware } from '../http/middleware'
-import type { AuthUser, AuthorizeOptions } from './types'
+import type { AuthUser, AuthorizeOptions, AuthorizeResourceOptions } from './types'
 import { Gate, getGate, denialToException } from './Gate'
 import { AuthorizationException } from '../errors'
 
@@ -76,43 +76,52 @@ export function authorizeAllMiddleware(
   }
 }
 
+// HTTP method → policy ability. QUERY (RFC 10008) is safe like GET, so it
+// reads as 'view' — the same classification the CSRF middleware and
+// `guren audit` apply. Uppercase keys cannot collide with Object.prototype
+// properties, so a plain lookup is safe for arbitrary request methods.
+const RESOURCE_ABILITY_BY_METHOD: Record<string, string> = {
+  GET: 'view',
+  HEAD: 'view',
+  QUERY: 'view',
+  POST: 'create',
+  PUT: 'update',
+  PATCH: 'update',
+  DELETE: 'delete',
+}
+
 /**
  * Middleware factory for resource authorization.
  * Automatically maps HTTP methods to policy abilities.
+ *
+ * Methods outside the built-in mapping (custom verbs registered via
+ * `router.on()`) are denied with a 403 rather than downgraded to a `view`
+ * check — the middleware cannot know whether an unknown verb mutates, so
+ * guessing would let a view-only user reach a mutating handler. Map custom
+ * verbs explicitly with `options.abilityFor`.
  *
  * @example
  * ```typescript
  * // Authorize resource actions based on HTTP method
  * app.use('/posts/:id', authorizeResourceMiddleware(getPost))
- * // GET -> view, POST -> create, PUT/PATCH -> update, DELETE -> delete
+ * // GET/HEAD/QUERY -> view, POST -> create, PUT/PATCH -> update, DELETE -> delete
+ *
+ * // Custom verbs must be mapped explicitly, or they are denied
+ * authorizeResourceMiddleware(getPost, {
+ *   abilityFor: (method) => (method === 'PURGE' ? 'delete' : undefined),
+ * })
  * ```
  */
 export function authorizeResourceMiddleware(
   modelResolver: (ctx: Context) => unknown | Promise<unknown>,
-  options: AuthorizeOptions = {}
+  options: AuthorizeResourceOptions = {}
 ): Middleware {
   return async (ctx, next) => {
     const method = ctx.req.method.toUpperCase()
+    const ability = options.abilityFor?.(method) ?? RESOURCE_ABILITY_BY_METHOD[method]
 
-    // Map HTTP methods to policy abilities
-    let ability: string
-    switch (method) {
-      case 'GET':
-      case 'HEAD':
-        ability = 'view'
-        break
-      case 'POST':
-        ability = 'create'
-        break
-      case 'PUT':
-      case 'PATCH':
-        ability = 'update'
-        break
-      case 'DELETE':
-        ability = 'delete'
-        break
-      default:
-        ability = 'view'
+    if (ability === undefined) {
+      throw new AuthorizationException(options.message ?? 'This action is unauthorized.')
     }
 
     const gate = getGate()

--- a/packages/server/src/authorization/types.ts
+++ b/packages/server/src/authorization/types.ts
@@ -107,6 +107,19 @@ export interface AuthorizeOptions {
 }
 
 /**
+ * Options for `authorizeResourceMiddleware`.
+ */
+export interface AuthorizeResourceOptions extends AuthorizeOptions {
+  /**
+   * Map an HTTP method (always uppercased) to a policy ability, overriding
+   * or extending the built-in mapping. Return `undefined` to fall back to
+   * the default mapping; a method with no ability from either source is
+   * denied with a 403.
+   */
+  abilityFor?: (method: string) => string | undefined
+}
+
+/**
  * Policy registration.
  */
 export interface PolicyRegistration {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -752,6 +752,7 @@ export type {
   AuthorizationResponse,
   GateOptions,
   AuthorizeOptions,
+  AuthorizeResourceOptions,
   PolicyRegistration,
   ResourceAction,
   ResponseBuilder,

--- a/packages/server/tests/authorization/authorization.test.ts
+++ b/packages/server/tests/authorization/authorization.test.ts
@@ -10,7 +10,11 @@ import {
   authorize,
   Policy,
   definePolicy,
+  authorizeResourceMiddleware,
 } from '../../src/authorization'
+import type { AuthorizeResourceOptions } from '../../src/authorization'
+import { AuthorizationException } from '../../src/errors'
+import type { Context } from '../../src/http/Application'
 
 // Test models
 class Post {
@@ -694,5 +698,85 @@ describe('Authorization Integration', () => {
     expect(await user.allows('manage-users')).toBe(false)
     expect(await user.allows('update', post)).toBe(true) // Owner
     expect(await user.allows('view', post)).toBe(true) // Owner can view unpublished
+  })
+})
+
+// ===================
+// authorizeResourceMiddleware Tests
+// ===================
+
+describe('authorizeResourceMiddleware', () => {
+  let checkedAbilities: string[]
+
+  beforeEach(() => {
+    checkedAbilities = []
+    const gate = new Gate()
+    for (const ability of ['view', 'create', 'update', 'delete', 'purge']) {
+      gate.define(ability, () => {
+        checkedAbilities.push(ability)
+        return true
+      })
+    }
+    setGate(gate)
+  })
+
+  const run = async (method: string, options?: AuthorizeResourceOptions) => {
+    const middleware = authorizeResourceMiddleware(() => ({ id: 1 }), options)
+    const ctx = {
+      req: { method },
+      get: () => ({ id: 1 }),
+    } as unknown as Context
+    let nextCalled = false
+    await middleware(ctx, async () => {
+      nextCalled = true
+    })
+    return nextCalled
+  }
+
+  test('maps known methods to resource abilities', async () => {
+    const expected: Array<[string, string]> = [
+      ['GET', 'view'],
+      ['HEAD', 'view'],
+      ['QUERY', 'view'],
+      ['POST', 'create'],
+      ['PUT', 'update'],
+      ['PATCH', 'update'],
+      ['DELETE', 'delete'],
+    ]
+    for (const [method, ability] of expected) {
+      checkedAbilities = []
+      expect(await run(method)).toBe(true)
+      expect(checkedAbilities).toEqual([ability])
+    }
+  })
+
+  test('denies unknown methods without consulting the gate', async () => {
+    await expect(run('PURGE')).rejects.toThrow(AuthorizationException)
+    expect(checkedAbilities).toEqual([])
+  })
+
+  test('uses options.message when denying an unknown method', async () => {
+    await expect(run('PURGE', { message: 'Custom denial' })).rejects.toThrow('Custom denial')
+  })
+
+  test('abilityFor maps a custom method to an ability', async () => {
+    const abilityFor = (method: string) => (method === 'PURGE' ? 'purge' : undefined)
+    expect(await run('PURGE', { abilityFor })).toBe(true)
+    expect(checkedAbilities).toEqual(['purge'])
+  })
+
+  test('abilityFor returning undefined falls back to the default mapping', async () => {
+    const abilityFor = () => undefined
+    expect(await run('DELETE', { abilityFor })).toBe(true)
+    expect(checkedAbilities).toEqual(['delete'])
+    checkedAbilities = []
+    await expect(run('PURGE', { abilityFor })).rejects.toThrow(AuthorizationException)
+    expect(checkedAbilities).toEqual([])
+  })
+
+  test('abilityFor can override a built-in mapping', async () => {
+    const abilityFor = (method: string) => (method === 'POST' ? 'update' : undefined)
+    expect(await run('POST', { abilityFor })).toBe(true)
+    expect(checkedAbilities).toEqual(['update'])
   })
 })


### PR DESCRIPTION
## Summary

`authorizeResourceMiddleware()` mapped HTTP methods to policy abilities with a `switch` whose `default` fell through to `'view'`. Any verb outside the known set — e.g. a custom `PURGE` route registered via `router.on()` — therefore passed the resource gate with only view permission, while its handler may mutate state (fail-open).

- Unknown methods are now denied with a 403 (`AuthorizationException`) before the gate is consulted.
- The built-in mapping is explicit: GET/HEAD/QUERY → `view`, POST → `create`, PUT/PATCH → `update`, DELETE → `delete`. QUERY (RFC 10008) is safe like GET, matching the classification already used by the CSRF middleware and `guren audit`. Behavior for these methods is unchanged.
- New `abilityFor` option (`AuthorizeResourceOptions`) lets apps map custom verbs explicitly; returning `undefined` falls back to the built-in mapping, and a method with no ability from either source is denied.

The CSRF middleware's method list is intentionally untouched: custom verbs are non-simple methods, so browsers cannot send them cross-site without a CORS preflight, which makes the fail-open there harmless in practice.

## Impact

`authorizeResourceMiddleware` is exported but not used by any template, example, or doc, so the blast radius of the behavior change is small. Apps that relied on custom verbs passing as `view` checks must add an `abilityFor` mapping. Shipped as a minor with a changeset describing the migration.

## Testing

- `bun run build`
- `bun run typecheck`
- `bun run test:bun` (adds `authorizeResourceMiddleware` coverage: full method→ability mapping, unknown-verb denial without consulting the gate, `abilityFor` mapping/override/fallback, custom denial message)
- `bun run audit:core-first`, `bun run audit:docs`