### PR TITLE
fix(cli): stop guren audit from skipping custom-verb routes

### DIFF
--- a/.changeset/audit-custom-verb-fail-closed.md
+++ b/.changeset/audit-custom-verb-fail-closed.md
@@ -1,0 +1,9 @@
+---
+'@guren/cli': minor
+---
+
+`guren audit` now audits routes registered with custom HTTP verbs (`router.on('PURGE', ...)`) instead of silently skipping them.
+
+Route auditing enumerated the methods it knew: only POST/PUT/PATCH/DELETE were checked for authentication and only POST/PUT/PATCH/QUERY for body validation. A route registered with any other verb fell through both checks, so an unvalidated body plus a missing auth guard produced zero findings and the audit reported a clean pass.
+
+Method handling is now driven by a single fail-closed classification (`describeMethod`): GET/HEAD/OPTIONS stay unaudited (safe, body-less), QUERY keeps its body check without demanding auth, DELETE stays auth-only, and any other verb is treated as unsafe and body-carrying, so it gets both the authentication and the validation check. That includes TRACE — formally safe per RFC 9110, but deliberately left to the fail-closed default here. Apps using custom verbs may see new findings; genuinely body-less custom verbs can be suppressed via `config/audit.ts`. Output for apps using only GET/HEAD/OPTIONS/QUERY/POST/PUT/PATCH/DELETE is unchanged.

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -69,16 +69,47 @@ export interface RunAuditOptions {
   deps?: boolean
 }
 
-// Two orthogonal axes drive the route loop below: unsafe methods get the auth
-// check, body-carrying methods get the validation check. QUERY (RFC 10008) is
-// safe like GET but body-carrying, so it appears only in BODY_METHODS.
-// Sibling classifications that must stay coherent with these (no shared
-// constant — @guren/cli declares no @guren/server dependency): the CSRF
-// middleware's DEFAULT_PROTECTED_METHODS in packages/server, and the
-// generated client's CSRF_SAFE_METHODS in api-client-types.ts.
-const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
-const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH', 'QUERY'])
-const AUDITED_METHODS = new Set([...MUTATING_METHODS, ...BODY_METHODS])
+/**
+ * HTTP method semantics driving the two per-route phases in auditRoutes().
+ * The two sets are orthogonal axes rather than a partition: unsafe methods
+ * get the auth check, body-carrying methods get the validation check, and
+ * QUERY (RFC 10008) is both — safe like GET, but body-carrying like POST.
+ *
+ * `SAFE_METHODS` holds the verbs the authentication phase trusts not to
+ * change state. It is the RFC 9110 §9.2.1 safe set *minus TRACE*, on
+ * purpose: an app registering a TRACE route is unusual enough that the
+ * fail-closed default below is the better answer — do not "fix" the list
+ * back to the RFC. It is the same axis as `DEFAULT_PROTECTED_METHODS` in
+ * `@guren/server` (src/http/middleware/csrf.ts, expressed as its
+ * complement) and the emitted `CSRF_SAFE_METHODS` in api-client-types.ts;
+ * the packages share no dependency edge, so the list is duplicated by
+ * convention (see trimSlashes in utils.ts for the precedent).
+ *
+ * `BODYLESS_METHODS` are the verbs whose requests conventionally carry no
+ * body, so the validation phase demands no validateBody() for them.
+ */
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS', 'QUERY'])
+const BODYLESS_METHODS = new Set(['GET', 'HEAD', 'OPTIONS', 'DELETE'])
+
+/**
+ * Exported for tests. Classifies an HTTP method for the audit phases.
+ *
+ * Deliberately fail-closed: a verb neither set recognizes — anything an app
+ * registers via `router.on('PURGE', ...)` — is treated as unsafe AND
+ * body-carrying. The alternative (skipping it, as the pre-classification
+ * enumerations did) made a custom-verb route with an unvalidated body and no
+ * auth middleware produce zero findings, i.e. the routes the audit
+ * understands least reported the cleanest pass. A false-positive finding on
+ * a genuinely body-less custom verb can be suppressed via config/audit.ts;
+ * a silently skipped route cannot be seen at all.
+ */
+export function describeMethod(method: string): { safe: boolean; bodyCarrying: boolean } {
+  const upper = method.toUpperCase()
+  return {
+    safe: SAFE_METHODS.has(upper),
+    bodyCarrying: !BODYLESS_METHODS.has(upper),
+  }
+}
 
 /**
  * Paths that are expected to be reachable without authentication
@@ -565,7 +596,10 @@ async function auditRoutes(
 
   for (const route of definitions) {
     const method = route.method.toUpperCase()
-    if (!AUDITED_METHODS.has(method)) continue
+    const { safe, bodyCarrying } = describeMethod(method)
+    // No shared skip here on purpose: each phase gates on its own predicate,
+    // so a later-added phase chooses its own scope instead of silently
+    // inheriting "mutating-only" from a mid-loop `continue`.
 
     const routeLabel = `${method} ${route.path}`
     const controllerKey = route.controller
@@ -574,7 +608,7 @@ async function auditRoutes(
     const methodInfo = controllerKey ? controllerMethods.get(controllerKey) : undefined
 
     // 1. Input validation on body-carrying routes
-    if (BODY_METHODS.has(method)) {
+    if (bodyCarrying) {
       const hasRouteSchema = Boolean(route.schemas?.body)
       // Route-level body schemas are runtime-enforced only for inline handlers.
       // For controller actions the router intentionally leaves body validation
@@ -638,76 +672,77 @@ async function auditRoutes(
       }
     }
 
-    // 2. Authentication on mutating routes. Safe body-carrying methods
-    // (QUERY) are read routes, so they get the same treatment as GET here.
-    if (!MUTATING_METHODS.has(method)) continue
-    if (GUEST_PATH_PATTERN.test(route.path)) continue
+    // 2. Authentication on unsafe (state-changing) routes. Safe
+    // body-carrying methods (QUERY) are read routes, so they get the same
+    // treatment as GET here. Guest flows (login/register/password reset)
+    // are exempt — they must be reachable unauthenticated.
+    if (!safe && !GUEST_PATH_PATTERN.test(route.path)) {
+      const middlewareNames = route.middlewareNames ?? []
+      // Capability verdict (RFC 0007): the server stamps its auth guards
+      // (requireAuthenticated/requireGuest) and definitions() aggregates the
+      // stamps across aliases, groups, and inline handlers. An older server
+      // emits no `capabilities` field at all — only then fall back to the
+      // pre-capability name heuristic so mixed-version apps don't regress.
+      const verdict = authMiddlewareVerdict(route)
+      const hasAuthMiddleware = verdict === 'verified' || verdict === 'legacy-name-match'
+      const hasControllerAuth = methodInfo ? AUTH_CALL_PATTERN.test(methodInfo.body) : false
 
-    const middlewareNames = route.middlewareNames ?? []
-    // Capability verdict (RFC 0007): the server stamps its auth guards
-    // (requireAuthenticated/requireGuest) and definitions() aggregates the
-    // stamps across aliases, groups, and inline handlers. An older server
-    // emits no `capabilities` field at all — only then fall back to the
-    // pre-capability name heuristic so mixed-version apps don't regress.
-    const verdict = authMiddlewareVerdict(route)
-    const hasAuthMiddleware = verdict === 'verified' || verdict === 'legacy-name-match'
-    const hasControllerAuth = methodInfo ? AUTH_CALL_PATTERN.test(methodInfo.body) : false
-
-    if (hasAuthMiddleware || hasControllerAuth) {
-      findings.push(
-        finding(
-          `authz:${routeLabel}`,
-          routeLabel,
-          'pass',
-          verdict === 'verified'
-            ? 'Protected by an authentication guard (verified via middleware capabilities).'
-            : verdict === 'legacy-name-match'
-              ? `Protected by middleware: ${middlewareNames.join(', ')}.`
-              : `Controller checks authentication in ${controllerKey}.`,
-        ),
-      )
-    } else if (verdict === 'unverified-auth-name') {
-      findings.push(
-        finding(
-          `authz:${routeLabel}`,
-          routeLabel,
-          'warn',
-          `Middleware (${middlewareNames.join(', ')}) is named like an auth guard but is not one the framework recognizes.`,
-          UNRECOGNIZED_GUARD_SUGGESTION,
-        ),
-      )
-    } else if (route.hasInlineMiddleware) {
-      findings.push(
-        finding(
-          `authz:${routeLabel}`,
-          routeLabel,
-          'warn',
-          'Inline middleware is attached but is not a recognized authentication guard.',
-          UNRECOGNIZED_GUARD_SUGGESTION,
-        ),
-      )
-    } else if (WEBHOOK_PATH_PATTERN.test(route.path)) {
-      findings.push(
-        finding(
-          `authz:${routeLabel}`,
-          routeLabel,
-          'warn',
-          `Webhook-style route has no authentication check${controllerKey ? ` (${controllerKey})` : ''}.`,
-          'Webhooks cannot use session auth — verify the provider signature (e.g. HMAC header) before processing the payload.',
-          methodInfo?.filePath,
-        ),
-      )
-    } else {
-      findings.push(
-        finding(
-          `authz:${routeLabel}`,
-          routeLabel,
-          'warn',
-          `Mutating route has no authentication check${controllerKey ? ` (${controllerKey})` : ''}.`,
-          "Wrap the route in router.middleware('auth').group(...) or call this.auth.userOrFail() in the controller.",
-          methodInfo?.filePath,
-        ),
-      )
+      if (hasAuthMiddleware || hasControllerAuth) {
+        findings.push(
+          finding(
+            `authz:${routeLabel}`,
+            routeLabel,
+            'pass',
+            verdict === 'verified'
+              ? 'Protected by an authentication guard (verified via middleware capabilities).'
+              : verdict === 'legacy-name-match'
+                ? `Protected by middleware: ${middlewareNames.join(', ')}.`
+                : `Controller checks authentication in ${controllerKey}.`,
+          ),
+        )
+      } else if (verdict === 'unverified-auth-name') {
+        findings.push(
+          finding(
+            `authz:${routeLabel}`,
+            routeLabel,
+            'warn',
+            `Middleware (${middlewareNames.join(', ')}) is named like an auth guard but is not one the framework recognizes.`,
+            UNRECOGNIZED_GUARD_SUGGESTION,
+          ),
+        )
+      } else if (route.hasInlineMiddleware) {
+        findings.push(
+          finding(
+            `authz:${routeLabel}`,
+            routeLabel,
+            'warn',
+            'Inline middleware is attached but is not a recognized authentication guard.',
+            UNRECOGNIZED_GUARD_SUGGESTION,
+          ),
+        )
+      } else if (WEBHOOK_PATH_PATTERN.test(route.path)) {
+        findings.push(
+          finding(
+            `authz:${routeLabel}`,
+            routeLabel,
+            'warn',
+            `Webhook-style route has no authentication check${controllerKey ? ` (${controllerKey})` : ''}.`,
+            'Webhooks cannot use session auth — verify the provider signature (e.g. HMAC header) before processing the payload.',
+            methodInfo?.filePath,
+          ),
+        )
+      } else {
+        findings.push(
+          finding(
+            `authz:${routeLabel}`,
+            routeLabel,
+            'warn',
+            `Mutating route has no authentication check${controllerKey ? ` (${controllerKey})` : ''}.`,
+            "Wrap the route in router.middleware('auth').group(...) or call this.auth.userOrFail() in the controller.",
+            methodInfo?.filePath,
+          ),
+        )
+      }
     }
   }
 

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
-import { authMiddlewareVerdict, runAudit, LINK_BUILDER_PATTERN, type AuditReport } from '../src/audit'
+import { authMiddlewareVerdict, describeMethod, runAudit, LINK_BUILDER_PATTERN, type AuditReport } from '../src/audit'
 import { createTempWorkspace, writeWorkspaceFiles } from './helpers'
 
 async function writeRoutes(dir: string, contents: string): Promise<void> {
@@ -2020,5 +2020,114 @@ describe('authMiddlewareVerdict', () => {
         capabilities: { authentication: { mode: 'guest-only' } },
       }),
     ).toBe('none')
+  })
+})
+
+describe('describeMethod', () => {
+  it('classifies the standard verbs', () => {
+    expect(describeMethod('GET')).toEqual({ safe: true, bodyCarrying: false })
+    expect(describeMethod('HEAD')).toEqual({ safe: true, bodyCarrying: false })
+    expect(describeMethod('OPTIONS')).toEqual({ safe: true, bodyCarrying: false })
+    expect(describeMethod('POST')).toEqual({ safe: false, bodyCarrying: true })
+    expect(describeMethod('PUT')).toEqual({ safe: false, bodyCarrying: true })
+    expect(describeMethod('PATCH')).toEqual({ safe: false, bodyCarrying: true })
+    expect(describeMethod('DELETE')).toEqual({ safe: false, bodyCarrying: false })
+    // The two sets are independent axes, so QUERY (RFC 10008) lands on both:
+    // no auth demanded, body validation still checked.
+    expect(describeMethod('QUERY')).toEqual({ safe: true, bodyCarrying: true })
+  })
+
+  it('is case-insensitive', () => {
+    expect(describeMethod('get')).toEqual({ safe: true, bodyCarrying: false })
+    expect(describeMethod('delete')).toEqual({ safe: false, bodyCarrying: false })
+  })
+
+  it('defaults an unrecognized verb to unsafe and body-carrying', () => {
+    expect(describeMethod('PURGE')).toEqual({ safe: false, bodyCarrying: true })
+    // TRACE is formally safe per RFC 9110, but the classification leaves it
+    // to the fail-closed default on purpose — this pin records that decision.
+    expect(describeMethod('TRACE')).toEqual({ safe: false, bodyCarrying: true })
+  })
+})
+
+const CUSTOM_VERB_ROUTES = `class CacheController {
+  async flush() { return null }
+}
+export default function registerRoutes(router: any) {
+  router.on('PURGE', '/cache', [CacheController, 'flush'])
+}`
+
+describe('custom-verb routes (router.on)', () => {
+  it.each([
+    [
+      'flags an unvalidated body read without auth',
+      `export default class CacheController {
+  async flush() {
+    const data = await this.request.json()
+    return null
+  }
+}`,
+      'fail',
+      'warn',
+    ] as const,
+    [
+      'passes a validated body behind an auth check',
+      `export default class CacheController {
+  async flush() {
+    await this.auth.userOrFail()
+    const data = await this.validateBody(FlushSchema)
+    return null
+  }
+}`,
+      'pass',
+      'pass',
+    ] as const,
+  ])('%s', async (_name, controller, validationStatus, authzStatus) => {
+    const workspace = await createTempWorkspace('guren-cli-audit-custom-verb-')
+
+    try {
+      await writeController(workspace.dir, 'CacheController', controller)
+      await writeRoutes(workspace.dir, CUSTOM_VERB_ROUTES)
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      expect(report.routesAnalyzed).toBe(true)
+      const validation = report.findings.find(f => f.key === 'validation:PURGE /cache')
+      expect(validation).toBeDefined()
+      expect(validation!.status).toBe(validationStatus)
+      const authz = report.findings.find(f => f.key === 'authz:PURGE /cache')
+      expect(authz).toBeDefined()
+      expect(authz!.status).toBe(authzStatus)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('still skips safe verbs and keeps DELETE out of the validation phase', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-safe-verbs-')
+
+    try {
+      await writeRoutes(
+        workspace.dir,
+        `class PostController {
+  async index() { return null }
+  async destroy() { return null }
+}
+export default function registerRoutes(router: any) {
+  router.get('/posts', [PostController, 'index'])
+  router.delete('/posts/:id', [PostController, 'destroy'])
+}`,
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      expect(report.findings.find(f => f.key.endsWith('GET /posts'))).toBeUndefined()
+      expect(report.findings.find(f => f.key === 'validation:DELETE /posts/:id')).toBeUndefined()
+      const authz = report.findings.find(f => f.key === 'authz:DELETE /posts/:id')
+      expect(authz).toBeDefined()
+      expect(authz!.status).toBe('warn')
+    } finally {
+      await workspace.cleanup()
+    }
   })
 })


### PR DESCRIPTION
## Summary

`guren audit` classified route HTTP methods with hand-enumerated sets: `MUTATING_METHODS` (POST/PUT/PATCH/DELETE) gated the authentication check, `BODY_METHODS` (POST/PUT/PATCH/QUERY) gated the body-validation check, and their union `AUDITED_METHODS` gated the loop. Any verb outside that union — e.g. a route registered via `router.on('PURGE', ...)`, which `Router` accepts and #385 made reachable from group builders too — fell through both checks entirely. An unvalidated body plus a missing auth guard on such a route produced zero findings, so the routes the audit understood least reported the cleanest pass.

This replaces the enumerations with a single `describeMethod(method) → { safe, bodyCarrying }` classification, deliberately fail-closed: any verb neither `SAFE_METHODS` (GET/HEAD/OPTIONS/QUERY) nor `BODYLESS_METHODS` (GET/HEAD/OPTIONS/DELETE) recognizes is treated as unsafe *and* body-carrying, so it now gets both checks. The two sets are orthogonal axes rather than a partition, which is what lets QUERY (RFC 10008) stay safe-but-body-carrying — validation checked, no auth demanded — with no special case in the loop. TRACE is formally safe per RFC 9110 §9.2.1 but is deliberately left to the fail-closed default; the comment in `audit.ts` records that as a decision so it doesn't get "fixed" back to the RFC.

The per-route loop was also restructured so each phase gates on its own predicate (`bodyCarrying` for validation, `!safe && !guest-path` for auth) instead of the shared mid-loop `if (!MUTATING_METHODS.has(method)) continue` — that shared `continue` made every phase added after the auth check implicitly mutating-only, invisible to future editors.

- Output for apps using only GET/HEAD/OPTIONS/QUERY/POST/PUT/PATCH/DELETE is unchanged — verified by diffing `guren audit --json` findings (key + status) against the `origin/main` build on `examples/blog` (23 findings) and `web/` (16 findings): identical both times, re-run after rebasing onto #385.
- A temporarily-added `router.on('PURGE', '/cache', ...)` route on `examples/blog` produces `validation:PURGE /cache` (fail) and `authz:PURGE /cache` (warn) findings that were previously silent.
- Reviewed with Codex and `/simplify` (4 parallel angles); findings applied: removed a redundant/misleading mid-loop `continue`, fixed a comment overclaiming the RFC 9110 safe set, dropped an unused exported interface, and collapsed two near-duplicate integration tests into one `it.each`.

Changeset included (`@guren/cli` minor) — this changes audit output for apps using custom verbs. Genuinely body-less custom verbs can be suppressed via `config/audit.ts`.

## Test plan

- [x] `bun test packages/cli/tests/audit.test.ts` — 82 pass (includes #385's QUERY cases)
- [x] `bun run test:bun cli` — 1330 pass
- [x] `bun run typecheck` (root, includes examples/blog and examples/api)
- [x] `guren audit --json` diffed against the `origin/main` baseline for `examples/blog` and `web/` — identical findings
- [x] Manually verified a custom-verb route (`router.on('PURGE', ...)`) now produces both validation and authz findings, then reverted the temporary route