### PR TITLE
fix(web): rewrite relative .md doc links to site routes

### DIFF
--- a/web/app/Services/FsDocsStore.ts
+++ b/web/app/Services/FsDocsStore.ts
@@ -108,7 +108,7 @@ export class FsDocsStore implements DocsStore {
       slug,
       title: extractDocTitle(markdown, slug),
       description: extractDocDescription(markdown),
-      html: await renderMarkdownToHtml(markdown),
+      html: await renderMarkdownToHtml(markdown, { locale, category }),
     }
   }
 

--- a/web/app/Services/MarkdownRenderer.ts
+++ b/web/app/Services/MarkdownRenderer.ts
@@ -1,6 +1,19 @@
+import { posix } from 'node:path'
+
 import { Marked, type Tokens } from 'marked'
 import { markedHighlight } from 'marked-highlight'
 import { codeToHtml } from 'shiki'
+
+import { docPaths, GITHUB_URL } from '../../config/site.js'
+import {
+  docCategoryDir,
+  docLocaleDir,
+  normalizeDocSlug,
+  DOC_CATEGORY_KEYS,
+  DOC_LOCALE_KEYS,
+  type DocCategory,
+  type DocLocale,
+} from './docs-config.js'
 
 const DOCS_THEMES = {
   light: 'rose-pine-dawn',
@@ -22,92 +35,73 @@ const ALERT_METADATA: Record<
   caution: { label: 'Caution', classSuffix: 'caution' },
 }
 
-const markedInstance = new Marked()
+export interface DocLinkContext {
+  locale: DocLocale
+  category: DocCategory
+}
 
-markedInstance.setOptions({
-  gfm: true,
-  breaks: false,
-  async: true,
-})
+const CATEGORY_BY_DIR = new Map(DOC_CATEGORY_KEYS.map((key) => [docCategoryDir(key), key]))
+const LOCALE_BY_DIR = new Map(DOC_LOCALE_KEYS.map((key) => [docLocaleDir(key), key]))
 
-markedInstance.use(
-  markedHighlight({
-    async: true,
-    highlight: async (code: string, lang?: string) => {
-      const normalizedLang = lang?.trim() || DEFAULT_LANGUAGE
+/**
+ * Docs source keeps GitHub-compatible relative `.md` links; the site rewrites
+ * them at render time. Links that resolve to a published doc become route
+ * paths (`/docs/ja/guides/routing`), links that escape the docs tree point at
+ * the file on GitHub, and everything else (absolute URLs, anchors, non-md
+ * relative paths) passes through untouched.
+ */
+export function rewriteDocLink(href: string, context: DocLinkContext): string {
+  if (/^(?:[a-z][a-z0-9+.-]*:|\/|#)/iu.test(href)) {
+    return href
+  }
 
-      try {
-        return await codeToHtml(code, {
-          lang: normalizedLang,
-          themes: DOCS_THEMES,
-          defaultColor: 'light',
-        })
-      }
-      catch {
-        return await codeToHtml(code, {
-          lang: DEFAULT_LANGUAGE,
-          themes: DOCS_THEMES,
-          defaultColor: 'light',
-        })
-      }
-    },
-  }),
-)
+  const hashIndex = href.indexOf('#')
+  const hash = hashIndex === -1 ? '' : href.slice(hashIndex)
+  const beforeHash = hashIndex === -1 ? href : href.slice(0, hashIndex)
+  const queryIndex = beforeHash.indexOf('?')
+  const suffix = queryIndex === -1 ? hash : `${beforeHash.slice(queryIndex)}${hash}`
+  const path = queryIndex === -1 ? beforeHash : beforeHash.slice(0, queryIndex)
 
-markedInstance.use({
-  walkTokens(token) {
-    if (token.type !== 'blockquote' || !token.tokens?.length) {
-      return
+  if (!/\.md$/iu.test(path)) {
+    return href
+  }
+
+  // Resolve against the source file's repo directory: docs/<locale>/<category>/.
+  const joined = posix.join(
+    'docs',
+    docLocaleDir(context.locale),
+    docCategoryDir(context.category),
+    path,
+  )
+  if (joined === '..' || joined.startsWith('../')) {
+    return href
+  }
+
+  const segments = joined.split('/')
+  if (segments.length === 4 && segments[0] === 'docs') {
+    const locale = LOCALE_BY_DIR.get(segments[1])
+    const category = CATEGORY_BY_DIR.get(segments[2])
+    const slug = segments[3].replace(/\.md$/iu, '')
+    // A slug the docs routes would reject (normalizeDocSlug) is not a
+    // published page — fall through to the GitHub source link instead.
+    if (locale && category && normalizeDocSlug(slug) === slug) {
+      return `${docPaths(category, slug)[locale]}${suffix}`
     }
+  }
 
-    const first = token.tokens[0]
-    if (first.type !== 'paragraph') {
-      return
-    }
+  return `${GITHUB_URL}/blob/main/${joined}${suffix}`
+}
 
-    const alertType = extractAlertType(first as Tokens.Paragraph)
-    if (!alertType) {
-      return
-    }
-
-    ;(token as Tokens.Blockquote & { alertType?: AlertType }).alertType = alertType
-
-    if (!first.text.trim()) {
-      token.tokens.shift()
-    }
-  },
-  renderer: {
-    blockquote(token) {
-      const content = this.parser.parse(token.tokens ?? [])
-      const alertType = (token as Tokens.Blockquote & { alertType?: AlertType }).alertType
-
-      if (!alertType) {
-        return `<blockquote>\n${content}</blockquote>\n`
-      }
-
-      const meta = ALERT_METADATA[alertType]
-      const className = `docs-alert docs-alert--${meta.classSuffix}`
-
-      return `<div class="${className}">
-  <p class="docs-alert__label">${meta.label}</p>
-  <div class="docs-alert__body">
-${content}
-  </div>
-</div>`
-    },
-  },
-})
-
-export async function renderMarkdownToHtml(markdown: string): Promise<string> {
-  // Per-render slug deduplication — safe for concurrent requests.
-  // Create a lightweight wrapper that only overrides the heading renderer
-  // with a closure-scoped slug map, inheriting everything else from the
-  // shared markedInstance (highlight, alert walkTokens, blockquote renderer).
+export async function renderMarkdownToHtml(
+  markdown: string,
+  linkContext?: DocLinkContext,
+): Promise<string> {
+  // A fresh instance per render keeps the heading slug map and link context
+  // request-scoped — safe for concurrent requests.
   const seenSlugs = new Map<string, number>()
   const instance = new Marked()
   instance.setOptions({ gfm: true, breaks: false, async: true })
 
-  // Re-use the shared plugins
   instance.use(
     markedHighlight({
       async: true,
@@ -122,9 +116,12 @@ export async function renderMarkdownToHtml(markdown: string): Promise<string> {
     }),
   )
 
-  // Alert walkTokens + blockquote renderer (same as shared instance)
   instance.use({
     walkTokens(token) {
+      if (linkContext && token.type === 'link' && typeof token.href === 'string') {
+        token.href = rewriteDocLink(token.href, linkContext)
+        return
+      }
       if (token.type !== 'blockquote' || !token.tokens?.length) return
       const first = token.tokens[0]
       if (first.type !== 'paragraph') return

--- a/web/tests/services/MarkdownRenderer.test.ts
+++ b/web/tests/services/MarkdownRenderer.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it, vi } from 'vitest'
 const mockCodeToHtml = vi.fn(async () => '<pre>code</pre>')
 vi.mock('shiki', () => ({ codeToHtml: mockCodeToHtml }))
 
-const { renderMarkdownToHtml } = await import('../../app/Services/MarkdownRenderer.js')
+const { renderMarkdownToHtml, rewriteDocLink } = await import(
+  '../../app/Services/MarkdownRenderer.js'
+)
 
 describe('renderMarkdownToHtml', () => {
   it('renders alert blocks', async () => {
@@ -16,5 +18,74 @@ describe('renderMarkdownToHtml', () => {
     const html = await renderMarkdownToHtml('```js\nconsole.log("hi")\n```')
     expect(html).toContain('<pre>code</pre>')
     expect(mockCodeToHtml).toHaveBeenCalled()
+  })
+
+  it('rewrites relative .md links to doc routes when a link context is given', async () => {
+    const html = await renderMarkdownToHtml('[Glossary](./glossary.md)', {
+      locale: 'ja',
+      category: 'guides',
+    })
+    expect(html).toContain('href="/docs/ja/guides/glossary"')
+  })
+
+  it('leaves .md links untouched without a link context', async () => {
+    const html = await renderMarkdownToHtml('[Glossary](./glossary.md)')
+    expect(html).toContain('href="./glossary.md"')
+  })
+})
+
+describe('rewriteDocLink', () => {
+  const ja = { locale: 'ja', category: 'guides' } as const
+  const en = { locale: 'en', category: 'guides' } as const
+
+  it('maps same-category links onto the locale base path', () => {
+    expect(rewriteDocLink('./glossary.md', ja)).toBe('/docs/ja/guides/glossary')
+    expect(rewriteDocLink('./glossary.md', en)).toBe('/docs/guides/glossary')
+  })
+
+  it('preserves heading anchors', () => {
+    expect(rewriteDocLink('./validation.md#array-style-query-parameters', en)).toBe(
+      '/docs/guides/validation#array-style-query-parameters',
+    )
+  })
+
+  it('resolves cross-category links', () => {
+    expect(rewriteDocLink('../tutorials/overview.md', ja)).toBe('/docs/ja/tutorials/overview')
+    expect(rewriteDocLink('../guides/database.md', { locale: 'en', category: 'tutorials' })).toBe(
+      '/docs/guides/database',
+    )
+  })
+
+  it('preserves query strings', () => {
+    expect(rewriteDocLink('./validation.md?tab=query', en)).toBe(
+      '/docs/guides/validation?tab=query',
+    )
+    expect(rewriteDocLink('./validation.md?tab=query#anchor', en)).toBe(
+      '/docs/guides/validation?tab=query#anchor',
+    )
+  })
+
+  it('points links that escape the docs tree at GitHub', () => {
+    expect(rewriteDocLink('../../../contributing/plugin-contract.md', en)).toBe(
+      'https://github.com/gurenjs/guren/blob/main/contributing/plugin-contract.md',
+    )
+  })
+
+  it('points slugs the docs routes would reject at GitHub', () => {
+    expect(rewriteDocLink('./weird..name.md', en)).toBe(
+      'https://github.com/gurenjs/guren/blob/main/docs/en/guides/weird..name.md',
+    )
+  })
+
+  it('leaves links that traverse past the repo root untouched', () => {
+    expect(rewriteDocLink('../../../../etc/passwd.md', en)).toBe('../../../../etc/passwd.md')
+  })
+
+  it('passes through absolute URLs, site paths, anchors, and non-md links', () => {
+    expect(rewriteDocLink('https://example.com/x.md', ja)).toBe('https://example.com/x.md')
+    expect(rewriteDocLink('/adr/0002-orders.md', ja)).toBe('/adr/0002-orders.md')
+    expect(rewriteDocLink('#section', ja)).toBe('#section')
+    expect(rewriteDocLink('./image.png', ja)).toBe('./image.png')
+    expect(rewriteDocLink('mailto:hi@example.com', ja)).toBe('mailto:hi@example.com')
   })
 })


### PR DESCRIPTION
## Summary
- Docs source (`docs/en`, `docs/ja`) uses GitHub-compatible relative `.md` links, but guren.dev rendered them verbatim — every cross-reference on the site pointed at the raw Markdown endpoint (`/docs/ja/guides/getting-started.md`) instead of the rendered page.
- Add render-time link rewriting in `MarkdownRenderer.ts`: links resolving to a published doc become locale-aware route paths via the existing `docPaths()` helper (preserving query strings and heading anchors); links escaping the docs tree, or whose resulting slug the docs routes would reject, point at the file on GitHub instead; absolute URLs, site-absolute paths, anchors, and non-`.md` relative links pass through untouched.
- The raw `.md` endpoints and `llms-full.txt` are unaffected — they still serve unmodified source via `getRaw()`, which agents rely on.
- Also removed a dead module-level `Marked` instance that had no consumers and had already drifted from the per-render instance actually used.

## Test plan
- [x] `bun run test` (web) — 112/112 passing, including new coverage for cross-category resolution, heading anchors, query strings, GitHub fallback, and slugs the docs routes would reject
- [x] `bun run typecheck` (web + root)
- [x] Verified live via dev server: `/docs/ja/guides/getting-started` links resolve to site routes, `/docs/ja/guides/plugins` correctly falls back to a GitHub blob link, `/docs/guides/routing` preserves a heading anchor
- [x] Verified the build-time prerender path (`prerender-docs.ts`) produces the same rewritten HTML, since production serves prerendered docs