### PR TITLE
test: absorb the epoll race in lazy stdio creation under bun test --isolate

### DIFF
--- a/scripts/test-packages.ts
+++ b/scripts/test-packages.ts
@@ -16,6 +16,8 @@
 // Positional arguments select packages by directory name or package name.
 // Everything after a bare `--` is forwarded to `bun test` verbatim.
 
+import { closeSync, mkdtempSync, openSync, readSync, rmSync, writeSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { collectPackages, parseArgs, repoRoot, selectPackages } from './workspace-packages.ts'
@@ -104,10 +106,82 @@ const testArgs = [
 
 console.log(`[test] ${targets.map((pkg) => pkg.name).join(', ')}`)
 
+// On Linux the child's stdout/stderr go to temp files, pumped back to this
+// process's own fds — NOT inherited pipes. Under `--isolate` every test file
+// gets a fresh globals context, and Bun re-creates process.stderr lazily per
+// context as a WriteStream whose fast path registers fd 2 with epoll. When
+// fd 2 is a pipe (any CI runner), that registration intermittently collides
+// with one another sink still holds and the construction dies with "EEXIST:
+// file already exists, epoll_ctl" — uncatchably: it surfaces as an "Unhandled
+// error between tests", kills the whole file mid-load, and the summary says
+// "N tests failed:" while naming none. It cannot be defused from inside the
+// test process either: reading, defineProperty-ing or even delete-ing
+// process.stderr reifies the lazy property first, constructing the exact
+// stream whose construction is the hazard (each variant verified on Bun
+// 1.3.14). A regular file is the one stdio target epoll cannot register, so
+// redirecting removes the race structurally. macOS keeps inherit: kqueue has
+// no such failure mode, and a local TTY keeps its colors.
+const redirectStdio = process.platform === 'linux'
+
+if (!redirectStdio) {
+  const proc = Bun.spawn([process.execPath, ...testArgs], {
+    cwd: repoRoot,
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  process.exit(await proc.exited)
+}
+
+// One fd per channel, opened read-write: the child inherits a duplicate for
+// its writes while this process pread()s the same descriptor at explicit
+// offsets. Reopening the path for reading would work too, but a second open
+// of a just-created path is a textbook time-of-check/time-of-use shape.
+const stdioDir = mkdtempSync(join(tmpdir(), 'guren-test-stdio-'))
+const channels = [
+  { fd: openSync(join(stdioDir, 'stdout.log'), 'w+'), offset: 0, targetFd: 1 },
+  { fd: openSync(join(stdioDir, 'stderr.log'), 'w+'), offset: 0, targetFd: 2 },
+]
+
+// Forwarded with synchronous reads and writes on raw fds: this process's own
+// process.stdout/stderr are the same lazy WriteStreams the redirect exists to
+// avoid, so the pump must not touch them.
+const chunk = Buffer.alloc(65536)
+function pump(): void {
+  for (const channel of channels) {
+    for (;;) {
+      const bytes = readSync(channel.fd, chunk, 0, chunk.length, channel.offset)
+      if (bytes <= 0) break
+      channel.offset += bytes
+      let written = 0
+      while (written < bytes) {
+        try {
+          written += writeSync(channel.targetFd, chunk, written, bytes - written)
+        } catch (error) {
+          // EAGAIN: our own stdio can be a full non-blocking pipe — give its
+          // reader a beat instead of spinning hot. Anything else is
+          // unwritable output; drop it rather than wedge the run.
+          if ((error as NodeJS.ErrnoException).code === 'EAGAIN') Bun.sleepSync(1)
+          else written = bytes
+        }
+      }
+    }
+  }
+}
+
 const proc = Bun.spawn([process.execPath, ...testArgs], {
   cwd: repoRoot,
-  stdout: 'inherit',
-  stderr: 'inherit',
+  stdout: channels[0]!.fd,
+  stderr: channels[1]!.fd,
 })
 
-process.exit(await proc.exited)
+const pumpTimer = setInterval(pump, 50)
+const exitCode = await proc.exited
+clearInterval(pumpTimer)
+pump()
+
+for (const channel of channels) {
+  closeSync(channel.fd)
+}
+rmSync(stdioDir, { recursive: true, force: true })
+
+process.exit(exitCode)


### PR DESCRIPTION
## Problem

The `sqlite-smoke` CI job (and any Linux `bun run test:bun`) intermittently fails with a signature unrelated to the commit under test — runs 31598889427 (a docs-only change on main), 31604478807, and 31605514426, all on 2026-08-12:

- Several `# Unhandled error between tests` blocks at test-file boundaries:
  - `error: EEXIST: file already exists, epoll_ctl` at `new WriteStream (internal:fs/streams:244:58)`, some with a full stack through `internal:util/colors` → `node:assert` → `redis-errors` → `ioredis`
  - `TypeError: undefined is not an object (evaluating 'process.stderr.fd')` in `debug`'s `useColors()` via ioredis
  - `error: Cannot call describe() after the test run has completed` pointing at the first `describe()` of the affected file
- The summary says `N tests failed:` but lists **no test names** — there is no `(fail)` line anywhere in the log.

## Root cause

`test:bun` runs `bun test --isolate`. Every test file gets a fresh globals context, and Bun re-creates `process.stderr` lazily per context as an `fs.WriteStream` whose fast path is `Bun.file(2).writer()` — which registers fd 2 with epoll. When fd 2 is a pipe (any CI runner), that registration intermittently collides with one another sink still holds, and the construction fails with `EEXIST`. Linux-only: kqueue has no such failure mode, which is why this never reproduces on macOS.

The first touch of `process.stderr` in a context typically happens deep inside module loading: the first file whose import graph reaches `@guren/server`'s ioredis import evaluates `ioredis` → `redis-errors` → `node:assert` → `internal:util/colors`, whose `refresh()` calls `shouldColorize(process.stderr)`. The file dies with no named test; the throwing CJS module is left un-cached, so a later file can hit the same thing again (hence multiple incidents per run).

## Why this can't be fixed inside the test process

Four preload-based variants were tried against a container that reproduces the flake on every run; each still crashed, with the "Unhandled error between tests" stack pointing at the preload's own line:

1. The failure is **not a synchronous throw**: `try { process.stderr } catch {}` records the construction stack in the error but never catches.
2. It is **not a stream `'error'` event** either: a listener attached synchronously to the returned stream never fires.
3. `Object.defineProperty(process, 'stderr', { value: standIn })` **reifies the lazy property first** — the native getter runs and constructs the exact stream the replacement was trying to avoid.
4. So does `delete process.stderr`.

Every own-property operation triggers the construction once per context, and the construction failure is uncatchable from JS.

## Fix

Remove the race structurally, in the harness: on Linux, `scripts/test-packages.ts` now gives the child `bun test` temp **files** for stdout/stderr — a regular file is the one stdio target epoll cannot register — and pumps them back to its own fds with synchronous reads/writes (the pump deliberately never touches its own `process.stdout`/`process.stderr` objects, which are the same lazy WriteStreams). macOS keeps `inherit`: kqueue has no such failure mode, and a local TTY keeps its colors.

## Verification

All runs in a 2-CPU `oven/bun:1.3.14` container with piped stderr (as under a CI runner), full `bun run test:bun` per run:

| variant | runs | runs with `EEXIST` |
|---|---|---|
| baseline (inherit) | 8 | **8** (4–6 errors each) |
| preload variants (touch / error-listener / replace / delete+replace) | 3 / 10 / 3 / 5 | 1 / 2 / 1 / 4 |
| **this PR (file redirect)** | **20** | **0** |

- The container's named failures with the redirect are exactly the same set as the baseline's environment-caused ones (missing git identity etc.) — the redirect introduces no new failures, and forwarded output is intact (the same reporter text arrives on the parent's stderr).
- macOS: full `bun run test:bun` green (4169 pass / 0 fail, the redirect is Linux-gated), `bun run typecheck` green.

An upstream issue for Bun (uncatchable epoll collision, property reification on defineProperty/delete, and the reporter naming no tests for between-tests failures) is drafted and can be filed separately.