### PR TITLE
fix(cli): stop generating deprecated zod .email() and hidden static in make:auth

### DIFF
--- a/examples/api/app/Models/User.ts
+++ b/examples/api/app/Models/User.ts
@@ -9,9 +9,9 @@ export class User extends defineModel(users, {
   base: AuthenticatableModel,
   optionalOnCreate: ['passwordHash'],
   requireOnCreate: ['password'],
+  fillable: ['name', 'email', 'password'],
+  hidden: ['passwordHash'],
 }) {
-  static fillable = ['name', 'email', 'password']
-  static override hidden = ['passwordHash']
   static override relationTypes: { tasks: HasManyRecord<TaskRecord> } = {
     tasks: [],
   }

--- a/examples/blog/app/Http/Validators/ForgotPasswordValidator.ts
+++ b/examples/blog/app/Http/Validators/ForgotPasswordValidator.ts
@@ -5,10 +5,10 @@ export const ForgotPasswordSchema = z.object({
     .string({ error: 'Email is required.' })
     .trim()
     .min(1, 'Email is required.')
-    .email('The email address is badly formatted.')
     // Lowercased to match how registration stores emails and how the
     // password-reset token helpers normalize emails internally.
-    .toLowerCase(),
+    .toLowerCase()
+    .pipe(z.email('The email address is badly formatted.')),
 })
 
 export type ForgotPasswordInput = z.infer<typeof ForgotPasswordSchema>

--- a/examples/blog/app/Http/Validators/LoginValidator.ts
+++ b/examples/blog/app/Http/Validators/LoginValidator.ts
@@ -5,12 +5,12 @@ export const LoginSchema = z.object({
     .string({ error: 'Email is required.' })
     .trim()
     .min(1, 'Email is required.')
-    .email('The email address is badly formatted.')
     // Registration stores emails lowercased, so normalize here too —
     // otherwise a user who registered as Ada@Example.com and logs in with
     // the same casing gets "Invalid credentials" from a case-sensitive
     // database lookup.
-    .toLowerCase(),
+    .toLowerCase()
+    .pipe(z.email('The email address is badly formatted.')),
   password: z
     .string({ error: 'Password is required.' })
     .min(1, 'Password is required.'),

--- a/examples/blog/app/Http/Validators/ProfileValidator.ts
+++ b/examples/blog/app/Http/Validators/ProfileValidator.ts
@@ -18,8 +18,8 @@ export const ProfileUpdateSchema = z
       .string({ error: 'Email is required.' })
       .trim()
       .min(1, 'Email is required.')
-      .email('Please provide a valid email address.')
-      .toLowerCase(),
+      .toLowerCase()
+      .pipe(z.email('Please provide a valid email address.')),
     password: optionalPasswordField,
     passwordConfirmation: optionalPasswordField,
   })

--- a/examples/blog/app/Http/Validators/RegisterValidator.ts
+++ b/examples/blog/app/Http/Validators/RegisterValidator.ts
@@ -11,12 +11,12 @@ export const RegisterSchema = z
       .string({ error: 'Email is required.' })
       .trim()
       .min(1, 'Email is required.')
-      .email('The email address is badly formatted.')
       // Lowercased so it round-trips correctly through the password-reset
       // and email-verification token helpers (@guren/core), which both
       // normalize emails to lowercase internally before matching against
       // stored records.
-      .toLowerCase(),
+      .toLowerCase()
+      .pipe(z.email('The email address is badly formatted.')),
     password: z
       .string({ error: 'Password is required.' })
       .min(8, 'Password must be at least 8 characters.'),

--- a/examples/blog/app/Models/User.ts
+++ b/examples/blog/app/Models/User.ts
@@ -9,9 +9,9 @@ export class User extends defineModel(users, {
   base: AuthenticatableModel,
   optionalOnCreate: ['passwordHash'],
   requireOnCreate: ['password'],
+  fillable: ['name', 'email', 'password', 'emailVerifiedAt', 'githubId', 'googleId'],
+  hidden: ['passwordHash', 'rememberToken'],
 }) {
-  static fillable = ['name', 'email', 'password', 'emailVerifiedAt', 'githubId', 'googleId']
-  static override hidden = ['passwordHash', 'rememberToken']
   static override relationTypes: { posts: HasManyRecord<PostRecord> } = {
     posts: [],
   }

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -608,12 +608,11 @@ export class User extends defineModel(users, {
   base: AuthenticatableModel,
   // Derived from the plain \`password\`, so callers never set it directly
   optionalOnCreate: ['passwordHash'],${requireOnCreate}
+  // Never serialized by Model.serialize() and stripped from auth.user()
+  hidden: ['passwordHash', 'rememberToken'],
 }) {
   // passwordHash and rememberToken are denied from mass assignment by
   // AuthenticatableModel itself — no per-model configuration needed.
-
-  // Never serialized by Model.serialize() and stripped from auth.user()
-  static override hidden = ['passwordHash', 'rememberToken']
 }
 `
 }
@@ -794,8 +793,8 @@ export const LoginSchema = z.object({
     .string()
     .trim()
     .min(1, 'Email is required.')
-    .email('The email address is badly formatted.')
-    .toLowerCase(),
+    .toLowerCase()
+    .pipe(z.email('The email address is badly formatted.')),
   password: z
     .string()
     .min(1, 'Password is required.'),
@@ -830,8 +829,8 @@ export const RegisterSchema = z
       .string()
       .trim()
       .min(1, 'Email is required.')
-      .email('The email address is badly formatted.')
-      .toLowerCase(),
+      .toLowerCase()
+      .pipe(z.email('The email address is badly formatted.')),
     password: z
       .string()
       .min(8, 'Password must be at least 8 characters.'),
@@ -856,8 +855,8 @@ export const ForgotPasswordSchema = z.object({
     .string()
     .trim()
     .min(1, 'Email is required.')
-    .email('The email address is badly formatted.')
-    .toLowerCase(),
+    .toLowerCase()
+    .pipe(z.email('The email address is badly formatted.')),
 })
 
 export type ForgotPasswordInput = z.infer<typeof ForgotPasswordSchema>
@@ -894,8 +893,8 @@ function buildProfileValidatorTemplate({ includePassword, providerOwnedEmail }: 
     .string()
     .trim()
     .min(1, 'Email is required.')
-    .email('Enter a valid email address.')
-    .toLowerCase(),`
+    .toLowerCase()
+    .pipe(z.email('Enter a valid email address.')),`
 
   const passwordField = includePassword
     ? `

--- a/packages/cli/templates/agent/.claude/rules/orm-models.md
+++ b/packages/cli/templates/agent/.claude/rules/orm-models.md
@@ -34,9 +34,8 @@ export class User extends defineModel(users, {
   base: AuthenticatableModel,
   optionalOnCreate: ['passwordHash'],
   requireOnCreate: ['password'],
-}) {
-  static override hidden = ['passwordHash', 'rememberToken']
-}
+  hidden: ['passwordHash', 'rememberToken'],
+}) {}
 ```
 
 Drop `requireOnCreate` when accounts can also be created without a password (OAuth-only sign-up).

--- a/packages/create-app/templates/blog/app/Http/Validators/LoginValidator.ts
+++ b/packages/create-app/templates/blog/app/Http/Validators/LoginValidator.ts
@@ -7,8 +7,8 @@ export const LoginSchema = z.object({
     .string()
     .trim()
     .min(1, 'Email is required.')
-    .email('The email address is badly formatted.')
-    .toLowerCase(),
+    .toLowerCase()
+    .pipe(z.email('The email address is badly formatted.')),
   password: z
     .string()
     .min(1, 'Password is required.'),

--- a/packages/create-app/templates/blog/app/Http/Validators/ProfileValidator.ts
+++ b/packages/create-app/templates/blog/app/Http/Validators/ProfileValidator.ts
@@ -10,8 +10,8 @@ export const ProfileUpdateSchema = z.object({
     .string()
     .trim()
     .min(1, 'Email is required.')
-    .email('Enter a valid email address.')
-    .toLowerCase(),
+    .toLowerCase()
+    .pipe(z.email('Enter a valid email address.')),
   password: z
     .string()
     .trim()

--- a/packages/create-app/templates/blog/app/Http/Validators/RegisterValidator.ts
+++ b/packages/create-app/templates/blog/app/Http/Validators/RegisterValidator.ts
@@ -14,8 +14,8 @@ export const RegisterSchema = z
       .string()
       .trim()
       .min(1, 'Email is required.')
-      .email('The email address is badly formatted.')
-      .toLowerCase(),
+      .toLowerCase()
+      .pipe(z.email('The email address is badly formatted.')),
     password: z
       .string()
       .min(8, 'Password must be at least 8 characters.'),

--- a/packages/create-app/templates/blog/app/Models/User.ts
+++ b/packages/create-app/templates/blog/app/Models/User.ts
@@ -9,16 +9,14 @@ export class User extends defineModel(users, {
   // Derived from the plain `password`, so callers never set it directly
   optionalOnCreate: ['passwordHash'],
   requireOnCreate: ['password'],
-}) {
   // passwordHash and rememberToken are denied from mass assignment by
   // AuthenticatableModel itself. `name` and `email` are the only remaining
   // columns, so this fillable list matches what would be mass-assignable
   // anyway — it stays explicit so a later column addition needs an opt-in.
-  static fillable = ['name', 'email', 'password']
-
+  fillable: ['name', 'email', 'password'],
   // Never serialized by Model.serialize() and stripped from auth.user()
-  static override hidden = ['passwordHash', 'rememberToken']
-
+  hidden: ['passwordHash', 'rememberToken'],
+}) {
   static override relationTypes: { posts: HasManyRecord<PostRecord> } = {
     posts: [],
   }

--- a/web/modules/blog/app/Models/User.ts
+++ b/web/modules/blog/app/Models/User.ts
@@ -10,7 +10,6 @@ export type NewUserRecord = typeof users.$inferInsert
 export class User extends defineModel(users, {
   base: AuthenticatableModel,
   optionalOnCreate: ['passwordHash'],
-}) {
-  static fillable = ['name', 'email', 'githubId']
-  static override hidden = ['passwordHash', 'rememberToken']
-}
+  fillable: ['name', 'email', 'githubId'],
+  hidden: ['passwordHash', 'rememberToken'],
+}) {}


### PR DESCRIPTION
## Summary

- `make:auth`-generated validators used `z.string().email(...)`, deprecated in Zod 4 in favor of `z.email(...)`. Migrated to `z.string().trim().min(1, ...).toLowerCase().pipe(z.email(...))` rather than a naive swap — `z.email()` runs its format check before any chained `.trim()`, so a straight substitution would newly reject whitespace-padded input and reorder the required/format error messages.
- The generated `User` model used `static override hidden = [...]`; switched to `defineModel`'s typed `hidden` option (added in #295), consistent with the `fillable` option used alongside it — a typo'd column name is now a compile error instead of silently ineffective.
- Applied both fixes everywhere the old form was generated or hand-copied from generator output: `make:auth` templates, the `create-app` blog blueprint, `examples/blog`, `examples/api`, `web/modules/blog`, and the agent-harness `orm-models.md` rule.

## Test plan

- [x] `bun run build:clean`
- [x] `bun run test:bun` (4180 pass)
- [x] `bun run typecheck` (root + web, checked by exit code)
- [x] `bun run test:examples` (102 pass)
- [x] `bun run audit:core-first`, `audit:docs`, `audit:starter-template`
- [x] `bun run smoke:starter:blog`
- [x] `bun run smoke:golden-path` (exercises `guren add auth` against a live scaffold)