### PR TITLE
fix(cli): stop guren audit from missing commented-out validation

### DIFF
--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -458,13 +458,18 @@ interface ControllerMethodInfo {
 /**
  * Method bodies below are judged with regexes (VALIDATE_BODY_PATTERN,
  * AUTH_CALL_PATTERN, BODY_ACCESS_PATTERN, FORCE_WRITE_PATTERN), which cannot
- * tell live code from a commented-out line or a string that merely mentions an
- * API. A commented `// await this.validateBody(...)` must not count as
- * validation, and a `forceCreate` inside an error message must not warn.
- * Blank comments, string/regex literal contents, and template quasis with
- * spaces — offsets are preserved, so method-body slices taken from the result
- * line up with the original AST positions. Template *expressions* are kept:
- * they are live code.
+ * tell live code from a commented-out line, a string that merely mentions an
+ * API, JSX text, or a type-only declaration. A commented
+ * `// await this.validateBody(...)` must not count as validation, a
+ * `forceCreate` inside an error message must not warn, and neither must a
+ * local `type Decoy = { validateBody(): void }` nested in the method body —
+ * TS allows local type/interface declarations inside a function, and their
+ * member signatures read exactly like the runtime call the regexes look for.
+ * Blank comments, string/regex/JSX-text contents, template quasis, and whole
+ * type-alias/interface declarations (never executable, so blanking the full
+ * range is always safe) with spaces — offsets are preserved, so method-body
+ * slices taken from the result line up with the original AST positions.
+ * Template *expressions* are kept: they are live code.
  */
 function blankCommentsAndStrings(source: string, ast: File): string {
   const ranges: [number, number][] = []
@@ -478,8 +483,13 @@ function blankCommentsAndStrings(source: string, ast: File): string {
     if (typeof start !== 'number' || typeof end !== 'number') return
     if (type === 'StringLiteral' || type === 'DirectiveLiteral') {
       ranges.push([start + 1, end - 1])
-    } else if (type === 'TemplateElement' || type === 'RegExpLiteral') {
+    } else if (type === 'TemplateElement' || type === 'RegExpLiteral' || type === 'JSXText') {
       ranges.push([start, end])
+    } else if (type === 'TSTypeAliasDeclaration' || type === 'TSInterfaceDeclaration') {
+      // Blank the whole declaration and stop descending — it contributes no
+      // runtime code, so there is nothing further inside worth walking.
+      ranges.push([start, end])
+      return false
     }
   })
   if (ranges.length === 0) return source

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -1,6 +1,7 @@
 import { resolve, relative } from 'node:path'
 import { readFile } from 'node:fs/promises'
 import { consola } from 'consola'
+import type { File } from '@babel/types'
 import {
   collectFiles,
   discoverControllerFiles,
@@ -25,6 +26,7 @@ import {
   resolveModelStringArrayConfig,
 } from './model-parser'
 import { parseSourceFile } from './parse-cache'
+import { walk } from './ast-walk'
 import { parseSchemaTableColumns } from './schema-parser'
 import { loadAuditConfig, type AuditIgnoreEntry } from './audit-config'
 
@@ -454,6 +456,46 @@ interface ControllerMethodInfo {
 }
 
 /**
+ * Method bodies below are judged with regexes (VALIDATE_BODY_PATTERN,
+ * AUTH_CALL_PATTERN, BODY_ACCESS_PATTERN, FORCE_WRITE_PATTERN), which cannot
+ * tell live code from a commented-out line or a string that merely mentions an
+ * API. A commented `// await this.validateBody(...)` must not count as
+ * validation, and a `forceCreate` inside an error message must not warn.
+ * Blank comments, string/regex literal contents, and template quasis with
+ * spaces — offsets are preserved, so method-body slices taken from the result
+ * line up with the original AST positions. Template *expressions* are kept:
+ * they are live code.
+ */
+function blankCommentsAndStrings(source: string, ast: File): string {
+  const ranges: [number, number][] = []
+  for (const comment of ast.comments ?? []) {
+    if (typeof comment.start === 'number' && typeof comment.end === 'number') {
+      ranges.push([comment.start, comment.end])
+    }
+  }
+  walk(ast.program, (node) => {
+    const { type, start, end } = node
+    if (typeof start !== 'number' || typeof end !== 'number') return
+    if (type === 'StringLiteral' || type === 'DirectiveLiteral') {
+      ranges.push([start + 1, end - 1])
+    } else if (type === 'TemplateElement' || type === 'RegExpLiteral') {
+      ranges.push([start, end])
+    }
+  })
+  if (ranges.length === 0) return source
+
+  // split('') keeps UTF-16 code-unit indexing — Babel offsets are code units,
+  // and a code-point spread would shift everything after an astral character.
+  const chars = source.split('')
+  for (const [start, end] of ranges) {
+    for (let i = start; i < end && i < chars.length; i++) {
+      if (chars[i] !== '\n') chars[i] = ' '
+    }
+  }
+  return chars.join('')
+}
+
+/**
  * Map of `ClassName.method` → method body source, for every controller in
  * app/Http/Controllers (module-aware — see discoverControllerFiles).
  *
@@ -482,6 +524,7 @@ async function parseControllerMethods(cwd: string, findings: AuditFinding[]): Pr
 
     const ast = parseSourceFile(source, filePath)
     if (!ast) continue
+    const scrubbed = blankCommentsAndStrings(source, ast)
 
     for (const node of ast.program.body) {
       const classDecl = extractClassDeclaration(node)
@@ -509,7 +552,7 @@ async function parseControllerMethods(cwd: string, findings: AuditFinding[]): Pr
           const start = member.body.start ?? 0
           const end = member.body.end ?? 0
           methods.set(`${className}.${member.key.name}`, {
-            body: source.slice(start, end),
+            body: scrubbed.slice(start, end),
             filePath: relPath,
           })
         }

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -1726,6 +1726,72 @@ export default function registerRoutes(router: any) {
       await workspace.cleanup()
     }
   })
+
+  it('does not count validateBody inside JSX text as validation', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-jsx-text-')
+
+    try {
+      // .tsx isn't a discovered controller extension, but the parser falls
+      // back to the jsx-enabled dialect for a plain .ts file whenever the
+      // non-jsx dialects fail to parse it (see parserPluginCandidates), so
+      // JSX syntax reaches a real controller file this way too.
+      await writeController(
+        workspace.dir,
+        'PostController',
+        `export default class PostController {
+  async store() {
+    const decoy = <div>call this.validateBody(schema) first</div>
+    const data = await this.request.json()
+    return decoy
+  }
+}`,
+      )
+      await writeRoutes(workspace.dir, POST_ROUTE)
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      expect(report.routesAnalyzed).toBe(true)
+      const validation = report.findings.find(f => f.key === 'validation:POST /posts')
+      expect(validation).toBeDefined()
+      expect(validation!.status).toBe('fail')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('does not count validateBody/forceCreate inside a local type declaration as live code', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-type-decoy-')
+
+    try {
+      await writeController(
+        workspace.dir,
+        'PostController',
+        `export default class PostController {
+  async store() {
+    type Decoy = {
+      validateBody(schema: unknown): void
+      forceCreate(data: unknown): void
+    }
+    const data = await this.request.json()
+    return null
+  }
+}`,
+      )
+      await writeRoutes(workspace.dir, POST_ROUTE)
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      expect(report.routesAnalyzed).toBe(true)
+      const validation = report.findings.find(f => f.key === 'validation:POST /posts')
+      expect(validation).toBeDefined()
+      expect(validation!.status).toBe('fail')
+
+      const forceWrite = report.findings.find(f => f.key === 'force-write-request-data:PostController.store')
+      expect(forceWrite).toBeUndefined()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
 })
 
 const WEBHOOK_ROUTE = `export default function registerRoutes(router: any) {

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -1632,6 +1632,102 @@ export const billingModule = {
   })
 })
 
+describe('runAudit comment/string blanking', () => {
+  const POST_ROUTE = `class PostController {
+  async store() { return null }
+}
+export default function registerRoutes(router: any) {
+  router.post('/posts', [PostController, 'store'])
+}`
+
+  it.each([
+    ['line comment', `// const data = await this.validateBody(schema)`],
+    ['block comment', `/* const data = await this.validateBody(schema) */`],
+    ['string literal', `const hint = 'call this.validateBody(schema) before reading the body'`],
+    ['template literal', 'const hint = `call this.validateBody(schema) first`'],
+  ])('does not count validateBody inside a %s as validation', async (_kind, decoy) => {
+    const workspace = await createTempWorkspace('guren-cli-audit-blanking-')
+
+    try {
+      await writeController(
+        workspace.dir,
+        'PostController',
+        `export default class PostController {
+  async store() {
+    ${decoy}
+    const data = await this.request.json()
+    return null
+  }
+}`,
+      )
+      await writeRoutes(workspace.dir, POST_ROUTE)
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      expect(report.routesAnalyzed).toBe(true)
+      const validation = report.findings.find(f => f.key === 'validation:POST /posts')
+      expect(validation).toBeDefined()
+      expect(validation!.status).toBe('fail')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('warns when a validated method really calls forceCreate', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-force-live-')
+
+    try {
+      await writeController(
+        workspace.dir,
+        'PostController',
+        `export default class PostController {
+  async store() {
+    const data = await this.validateBody(schema)
+    await Post.forceCreate(data)
+    return null
+  }
+}`,
+      )
+      await writeRoutes(workspace.dir, POST_ROUTE)
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const forceWrite = report.findings.find(f => f.key === 'force-write-request-data:PostController.store')
+      expect(forceWrite).toBeDefined()
+      expect(forceWrite!.status).toBe('warn')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('does not warn about a forceCreate that only appears in a comment', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-force-comment-')
+
+    try {
+      await writeController(
+        workspace.dir,
+        'PostController',
+        `export default class PostController {
+  async store() {
+    const data = await this.validateBody(schema)
+    // await Post.forceCreate(data)
+    await Post.create(data)
+    return null
+  }
+}`,
+      )
+      await writeRoutes(workspace.dir, POST_ROUTE)
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const forceWrite = report.findings.find(f => f.key === 'force-write-request-data:PostController.store')
+      expect(forceWrite).toBeUndefined()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})
+
 const WEBHOOK_ROUTE = `export default function registerRoutes(router: any) {
   router.post('/webhooks/stripe', (c: any) => null)
 }`


### PR DESCRIPTION
## Summary
- `parseControllerMethods` in `packages/cli/src/audit.ts` sliced controller method bodies straight from raw source text, and every regex-based check in the audit (`VALIDATE_BODY_PATTERN`, `AUTH_CALL_PATTERN`, `BODY_ACCESS_PATTERN`, `FORCE_WRITE_PATTERN`) ran against that raw slice.
- A commented-out `// const data = await this.validateBody(schema)` therefore counted as real validation, silently suppressing the A03 finding for a method that actually reads the request body unvalidated (`this.request.json()`). The same blind spot applied to auth detection and the `forceCreate`/`forceUpdate` mass-assignment warning.
- Fix: build the method-body slice from a scrubbed copy of the source where comments and string/template/regex literal contents are blanked out (offsets preserved via the existing Babel AST), so the regexes only ever see live code.

## Test plan
- [x] Added tests in `packages/cli/tests/audit.test.ts` (`runAudit comment/string blanking`): commented-out/string-embedded `validateBody` no longer suppresses the validation failure; a commented-out `forceCreate` no longer warns; a real `validateBody` + `forceCreate` still warns (positive control).
- [x] `bun run build`
- [x] `bun run test:bun cli` (1336 pass)
- [x] Mutation check: reverting the body-slice source back to raw text makes 5 of the 6 new tests fail as expected, confirming the tests actually exercise the fix.