### PR TITLE
feat(create-app): adopt the HTTP QUERY method in the blog starter

### DIFF
--- a/.changeset/query-template-adoption.md
+++ b/.changeset/query-template-adoption.md
@@ -1,0 +1,10 @@
+---
+"@guren/cli": patch
+"create-guren-app": minor
+---
+
+The generated API client now compiles against its own documented usage, and the blog starter puts it to work on an HTTP QUERY search endpoint.
+
+`createApiClient<ApiRoutes>()` rejected every real call site: the `Record<...>` generic constraint turned away the generated `ApiRoutes` interface (interfaces carry no implicit index signature), and param-less routes — emitted as `params: Record<string, never>` — were misread as requiring a `params` argument because `keyof Record<string, never>` is `string`, not `never`. The constraint is now a mapped-object type and the param check matches the emitted shape, with a compile-level test that runs `tsc` over the generated module and its documented usage.
+
+The blog blueprint gains `QUERY /posts/search` (RFC 10008): a route-bound Zod body schema, a read-only controller action, a starter test driving `TestApp.query()`, and a search box on the posts page calling the endpoint through the generated typed client — the first template consumer of `createApiClient`.

--- a/packages/cli/src/api-client-types.ts
+++ b/packages/cli/src/api-client-types.ts
@@ -93,8 +93,10 @@ export type ApiRouteMethod<T extends ApiRouteName> = ApiRoutes[T]['method']
 export type ApiRoutePath<T extends ApiRouteName> = ApiRoutes[T]['path']
 export type ApiRouteParams<T extends ApiRouteName> = ApiRoutes[T]['params']
 
+// Param-less routes are emitted as \`Record<string, never>\`, whose \`keyof\` is
+// \`string\` — so this must compare against that shape, not against \`never\`.
 type HasParams<T extends ApiRouteName> =
-  [keyof ApiRoutes[T]['params']] extends [never] ? false : true
+  ApiRoutes[T]['params'] extends Record<string, never> ? false : true
 
 export type ApiRequestOptions<T extends ApiRouteName> =
   HasParams<T> extends true
@@ -173,13 +175,18 @@ function isSameOrigin(url: string): boolean {
  * const post = await client.request('posts.show', { params: { id: 1 } })
  * \`\`\`
  */
-export function createApiClient<TRoutes extends Record<string, { method: string; path: string; params: unknown }>>(
+// The mapped-object constraint (rather than \`Record<...>\`) is what lets the
+// generated \`ApiRoutes\` interface satisfy it — interfaces have no implicit
+// index signature, so \`Record<string, ...>\` would reject them.
+export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method: string; path: string; params: unknown } }>(
   config: { baseUrl: string; headers?: Record<string, string>; credentials?: RequestInit['credentials'] },
 ) {
   return {
     async request<TName extends keyof TRoutes & string>(
       name: TName,
-      ...args: [keyof TRoutes[TName]['params']] extends [never]
+      // Param-less routes carry \`params: Record<string, never>\` — match that
+      // shape (its \`keyof\` is \`string\`, so \`extends [never]\` never fires).
+      ...args: TRoutes[TName]['params'] extends Record<string, never>
         ? [options?: { body?: unknown; query?: Record<string, unknown> }]
         : [options: { params: TRoutes[TName]['params']; body?: unknown; query?: Record<string, unknown> }]
     ): Promise<Response> {

--- a/packages/cli/src/api-client-types.ts
+++ b/packages/cli/src/api-client-types.ts
@@ -93,15 +93,20 @@ export type ApiRouteMethod<T extends ApiRouteName> = ApiRoutes[T]['method']
 export type ApiRoutePath<T extends ApiRouteName> = ApiRoutes[T]['path']
 export type ApiRouteParams<T extends ApiRouteName> = ApiRoutes[T]['params']
 
-// Param-less routes are emitted as \`Record<string, never>\`, whose \`keyof\` is
-// \`string\` — so this must compare against that shape, not against \`never\`.
-type HasParams<T extends ApiRouteName> =
-  ApiRoutes[T]['params'] extends Record<string, never> ? false : true
+// Param-less routes are emitted as \`params: Record<string, never>\`, whose
+// \`keyof\` is \`string\` — so this compares against that shape, not against
+// \`never\`. The one predicate serves both \`ApiRequestOptions\` and \`request()\`
+// below; keep them on it, or a fix lands in one spelling and not the other.
+type HasBoundParams<TParams> = TParams extends Record<string, never> ? false : true
+
+// The request body type a route declares through its bound schema — \`unknown\`
+// for routes without one.
+type BodyOf<TRoute> = TRoute extends { body: infer TBody } ? TBody : unknown
 
 export type ApiRequestOptions<T extends ApiRouteName> =
-  HasParams<T> extends true
-    ? { params: ApiRouteParams<T>; body?: unknown; query?: Record<string, unknown> }
-    : { params?: never; body?: unknown; query?: Record<string, unknown> }
+  HasBoundParams<ApiRouteParams<T>> extends false
+    ? { params?: never; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
+    : { params: ApiRouteParams<T>; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
 
 // The wire contract these mirror is owned by Guren's CSRF middleware: it
 // writes the XSRF-TOKEN cookie and reads either header name. Change them
@@ -166,6 +171,9 @@ function isSameOrigin(url: string): boolean {
  * Cookies follow the \`credentials\` option (\`'same-origin'\` by default; use
  * \`'include'\` cross-origin, with a CORS setup that allows it).
  *
+ * Routes that bind a \`body\` schema type the \`body\` option with that schema's
+ * request shape; routes without one accept \`unknown\`.
+ *
  * @example
  * \`\`\`typescript
  * import type { ApiRoutes } from '@/.guren/api-client.gen'
@@ -184,11 +192,9 @@ export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method
   return {
     async request<TName extends keyof TRoutes & string>(
       name: TName,
-      // Param-less routes carry \`params: Record<string, never>\` — match that
-      // shape (its \`keyof\` is \`string\`, so \`extends [never]\` never fires).
-      ...args: TRoutes[TName]['params'] extends Record<string, never>
-        ? [options?: { body?: unknown; query?: Record<string, unknown> }]
-        : [options: { params: TRoutes[TName]['params']; body?: unknown; query?: Record<string, unknown> }]
+      ...args: HasBoundParams<TRoutes[TName]['params']> extends false
+        ? [options?: { params?: never; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
+        : [options: { params: TRoutes[TName]['params']; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
     ): Promise<Response> {
       const route = (routes as Record<string, { method: string; path: string }>)[name]
       if (!route) throw new Error(\`Route [\${name}] not defined.\`)

--- a/packages/cli/tests/api-client-types.test.ts
+++ b/packages/cli/tests/api-client-types.test.ts
@@ -3,14 +3,45 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
+import ts from 'typescript'
+import { z } from 'zod'
+import { checkTypes, COLD_TSC_TIMEOUT } from './helpers'
 import { buildApiClientContent, type RouteDefinitionLike } from '../src/api-client-types'
 
 const definitions: RouteDefinitionLike[] = [
   { method: 'GET', path: '/posts', name: 'posts.index' },
   { method: 'GET', path: '/posts/:id', name: 'posts.show' },
   { method: 'POST', path: '/posts', name: 'posts.store' },
-  { method: 'QUERY', path: '/posts/search', name: 'posts.search' },
+  {
+    method: 'QUERY',
+    path: '/posts/search',
+    name: 'posts.search',
+    schemas: { body: z.object({ keywords: z.array(z.string()) }) },
+  },
 ]
+
+// One emitted module shared by every suite below: the compile gate reads the
+// .ts source next to its usage probe, the runtime suite imports the
+// transpiled .mjs.
+let dir: string
+let usageFile: string
+let modulePath: string
+
+beforeAll(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'guren-cli-api-client-'))
+  usageFile = join(dir, 'usage.ts')
+  modulePath = join(dir, 'api-client.gen.mjs')
+  const source = buildApiClientContent(definitions)
+  await Promise.all([
+    writeFile(join(dir, 'api-client.gen.ts'), source, 'utf8'),
+    writeFile(usageFile, USAGE_PROBE, 'utf8'),
+    writeFile(modulePath, new Bun.Transpiler({ loader: 'ts' }).transformSync(source), 'utf8'),
+  ])
+})
+
+afterAll(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
 
 describe('buildApiClientContent', () => {
   it('emits the cookie-to-header names the CSRF middleware expects', () => {
@@ -26,51 +57,60 @@ describe('buildApiClientContent', () => {
   })
 })
 
-/**
- * The generated module lands in app code no monorepo tsconfig covers, so its
- * types have no other compile gate — which is how `createApiClient<ApiRoutes>`
- * shipped rejecting its own documented usage twice (an interface never
- * satisfies a `Record<...>` constraint, and param-less routes' `Record<string,
- * never>` made `keyof ... extends never` demand params). Compile the emitted
- * source against that usage; the `@ts-expect-error` lines keep the check able
- * to fail in both directions.
- */
-describe('generated api client types', () => {
-  it('compiles the documented usage against the emitted module', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'guren-cli-api-client-tsc-'))
-    try {
-      await writeFile(join(dir, 'api-client.gen.ts'), buildApiClientContent(definitions), 'utf8')
-      await writeFile(
-        join(dir, 'usage.ts'),
-        `import { createApiClient, type ApiRoutes } from './api-client.gen'
+const USAGE_PROBE = `import { createApiClient, type ApiRoutes, type ApiRequestOptions } from './api-client.gen'
 
 const client = createApiClient<ApiRoutes>({ baseUrl: 'http://localhost:3000' })
 
 void client.request('posts.index')
-void client.request('posts.search', { body: { keywords: ['guren'] } })
 void client.request('posts.show', { params: { id: 1 } })
+void client.request('posts.search', { body: { keywords: ['guren'] } })
 
 // @ts-expect-error a route with path params requires them
 void client.request('posts.show')
 
 // @ts-expect-error unknown route names must not compile
 void client.request('posts.missing')
-`,
-        'utf8',
-      )
 
-      const tsc = Bun.resolveSync('typescript/bin/tsc', import.meta.dir)
-      const result = Bun.spawnSync(
-        ['bun', tsc, '--noEmit', '--strict', '--target', 'es2022', '--module', 'esnext',
-          '--moduleResolution', 'bundler', '--lib', 'es2022,dom', 'usage.ts'],
-        { cwd: dir },
-      )
-      const output = `${result.stdout}${result.stderr}`
-      expect(result.exitCode === 0 ? 'ok' : output).toBe('ok')
-    } finally {
-      await rm(dir, { recursive: true, force: true })
-    }
-  }, 30000)
+// @ts-expect-error a bound body schema types the payload
+void client.request('posts.search', { body: { keywords: 'guren' } })
+
+export const indexOptions: ApiRequestOptions<'posts.index'> = {}
+export const showOptions: ApiRequestOptions<'posts.show'> = { params: { id: 1 } }
+
+// @ts-expect-error param-less routes reject a params member
+export const paramsRejected: ApiRequestOptions<'posts.index'> = { params: {} }
+
+// @ts-expect-error a route with path params requires them here too
+export const paramsRequired: ApiRequestOptions<'posts.show'> = {}
+`
+
+const compilerOptions: ts.CompilerOptions = {
+  strict: true,
+  noEmit: true,
+  skipLibCheck: true,
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  lib: ['lib.es2022.d.ts', 'lib.dom.d.ts'],
+  // No @types scan: the default type-root walk climbs ancestor directories,
+  // so a TMPDIR inside a workspace would silently pull in — and type-check —
+  // every @types package it finds there.
+  types: [],
+}
+
+/**
+ * The emitted module's types are only exercised where a call site exists —
+ * scaffolds compile the file, but with no consumer that proved nothing, which
+ * is how `createApiClient<ApiRoutes>` shipped rejecting its own documented
+ * usage twice (an interface never satisfies a `Record<...>` constraint, and
+ * param-less routes' `Record<string, never>` made the params check demand
+ * params). This gate is that call site: the `@ts-expect-error` probes keep it
+ * able to fail in both directions (an accepted probe surfaces as TS2578).
+ */
+describe('generated api client types', () => {
+  it('compiles the documented usage against the emitted module', () => {
+    expect(checkTypes([usageFile], compilerOptions)).toEqual([])
+  }, COLD_TSC_TIMEOUT)
 })
 
 /**
@@ -90,19 +130,10 @@ describe('generated createApiClient', () => {
   const originalGlobals = globalThis as { document?: unknown; location?: unknown }
   const restore = { document: originalGlobals.document, location: originalGlobals.location }
 
-  let dir: string
   let createApiClient: CreateApiClient
 
   beforeAll(async () => {
-    dir = await mkdtemp(join(tmpdir(), 'guren-cli-api-client-'))
-    const source = buildApiClientContent(definitions)
-    const modulePath = join(dir, 'api-client.gen.mjs')
-    await writeFile(modulePath, new Bun.Transpiler({ loader: 'ts' }).transformSync(source), 'utf8')
     createApiClient = (await import(pathToFileURL(modulePath).href)).createApiClient
-  })
-
-  afterAll(async () => {
-    await rm(dir, { recursive: true, force: true })
   })
 
   afterEach(() => {

--- a/packages/cli/tests/api-client-types.test.ts
+++ b/packages/cli/tests/api-client-types.test.ts
@@ -7,6 +7,7 @@ import { buildApiClientContent, type RouteDefinitionLike } from '../src/api-clie
 
 const definitions: RouteDefinitionLike[] = [
   { method: 'GET', path: '/posts', name: 'posts.index' },
+  { method: 'GET', path: '/posts/:id', name: 'posts.show' },
   { method: 'POST', path: '/posts', name: 'posts.store' },
   { method: 'QUERY', path: '/posts/search', name: 'posts.search' },
 ]
@@ -23,6 +24,53 @@ describe('buildApiClientContent', () => {
     // template it lands in is excluded from every tsconfig.
     expect(content).toContain('(globalThis as { document?: { cookie?: string } }).document?.cookie')
   })
+})
+
+/**
+ * The generated module lands in app code no monorepo tsconfig covers, so its
+ * types have no other compile gate — which is how `createApiClient<ApiRoutes>`
+ * shipped rejecting its own documented usage twice (an interface never
+ * satisfies a `Record<...>` constraint, and param-less routes' `Record<string,
+ * never>` made `keyof ... extends never` demand params). Compile the emitted
+ * source against that usage; the `@ts-expect-error` lines keep the check able
+ * to fail in both directions.
+ */
+describe('generated api client types', () => {
+  it('compiles the documented usage against the emitted module', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'guren-cli-api-client-tsc-'))
+    try {
+      await writeFile(join(dir, 'api-client.gen.ts'), buildApiClientContent(definitions), 'utf8')
+      await writeFile(
+        join(dir, 'usage.ts'),
+        `import { createApiClient, type ApiRoutes } from './api-client.gen'
+
+const client = createApiClient<ApiRoutes>({ baseUrl: 'http://localhost:3000' })
+
+void client.request('posts.index')
+void client.request('posts.search', { body: { keywords: ['guren'] } })
+void client.request('posts.show', { params: { id: 1 } })
+
+// @ts-expect-error a route with path params requires them
+void client.request('posts.show')
+
+// @ts-expect-error unknown route names must not compile
+void client.request('posts.missing')
+`,
+        'utf8',
+      )
+
+      const tsc = Bun.resolveSync('typescript/bin/tsc', import.meta.dir)
+      const result = Bun.spawnSync(
+        ['bun', tsc, '--noEmit', '--strict', '--target', 'es2022', '--module', 'esnext',
+          '--moduleResolution', 'bundler', '--lib', 'es2022,dom', 'usage.ts'],
+        { cwd: dir },
+      )
+      const output = `${result.stdout}${result.stderr}`
+      expect(result.exitCode === 0 ? 'ok' : output).toBe('ok')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  }, 30000)
 })
 
 /**

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -2,8 +2,9 @@ import { mock } from 'bun:test'
 import { consola as realConsola } from 'consola'
 import { existsSync } from 'node:fs'
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
-import { dirname, join, relative, resolve } from 'node:path'
+import { basename, dirname, join, relative, resolve } from 'node:path'
 import { tmpdir } from 'node:os'
+import ts from 'typescript'
 
 const repoRoot = resolve(import.meta.dir, '../../..')
 
@@ -339,6 +340,33 @@ export function assertWorkspaceBuilt(artifacts: string[]): void {
       ...missing.map((artifact) => `  missing ${relative(repoRoot, artifact)}`),
     ].join('\n'),
   )
+}
+
+// Each checkTypes() call builds a full tsc program. On a warm TypeScript
+// cache that takes a few seconds, but in a fresh worktree (cold node_modules,
+// no incremental state) a single probe has been measured at 10–25s normally
+// and 70s right after a full monorepo build — far past bun:test's 5s default.
+// checkTypes() is synchronous, so a timeout cannot interrupt it anyway; the
+// limit only needs to sit above the slowest observed cold start, not near it.
+export const COLD_TSC_TIMEOUT = 180_000
+
+/**
+ * Type-check `rootNames` in-process and return each diagnostic as a
+ * `file:line TSxxxx: message` string — the compile gate for generated output.
+ * An accepted `@ts-expect-error` probe surfaces as TS2578, so zero diagnostics
+ * proves both polarities: valid usage compiled AND every bad-usage probe
+ * errored.
+ */
+export function checkTypes(rootNames: string[], compilerOptions: ts.CompilerOptions): string[] {
+  const program = ts.createProgram(rootNames, compilerOptions)
+  return ts.getPreEmitDiagnostics(program).map((diagnostic) => {
+    const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ')
+    if (!diagnostic.file || diagnostic.start === undefined) {
+      return `TS${diagnostic.code}: ${message}`
+    }
+    const { line } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start)
+    return `${basename(diagnostic.file.fileName)}:${line + 1} TS${diagnostic.code}: ${message}`
+  })
 }
 
 /** Spawn the CLI bin as a subprocess and return its exit code. */

--- a/packages/cli/tests/i18n-types-compile.test.ts
+++ b/packages/cli/tests/i18n-types-compile.test.ts
@@ -1,9 +1,9 @@
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { basename, join, resolve } from 'node:path'
+import { join, resolve } from 'node:path'
 import ts from 'typescript'
-import { assertWorkspaceBuilt } from './helpers'
+import { assertWorkspaceBuilt, checkTypes, COLD_TSC_TIMEOUT } from './helpers'
 import { buildTranslationTypesContent } from '../src/i18n-types'
 
 /**
@@ -98,25 +98,8 @@ afterAll(async () => {
   await rm(dir, { recursive: true, force: true })
 })
 
-// Each check() builds a full tsc program over the built .d.ts surface. On a
-// warm TypeScript cache that takes a few seconds, but in a fresh worktree
-// (cold node_modules, no incremental state) a single probe has been measured
-// at 10–25s normally and 70s right after a full monorepo build — far past
-// bun:test's 5s default, which made both tests time out rather than fail.
-// check() is synchronous, so a timeout cannot interrupt it anyway; the limit
-// only needs to sit above the slowest observed cold start, not near it.
-const COLD_TSC_TIMEOUT = 180_000
-
 function check(rootNames: string[]): string[] {
-  const program = ts.createProgram(rootNames, compilerOptions)
-  return ts.getPreEmitDiagnostics(program).map((diagnostic) => {
-    const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ')
-    if (!diagnostic.file || diagnostic.start === undefined) {
-      return `TS${diagnostic.code}: ${message}`
-    }
-    const { line } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start)
-    return `${basename(diagnostic.file.fileName)}:${line + 1} TS${diagnostic.code}: ${message}`
-  })
+  return checkTypes(rootNames, compilerOptions)
 }
 
 describe('generated translation key augmentation', () => {

--- a/packages/create-app/templates/blog/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/blog/.guren/api-client.gen.ts
@@ -106,15 +106,20 @@ export type ApiRouteMethod<T extends ApiRouteName> = ApiRoutes[T]['method']
 export type ApiRoutePath<T extends ApiRouteName> = ApiRoutes[T]['path']
 export type ApiRouteParams<T extends ApiRouteName> = ApiRoutes[T]['params']
 
-// Param-less routes are emitted as `Record<string, never>`, whose `keyof` is
-// `string` — so this must compare against that shape, not against `never`.
-type HasParams<T extends ApiRouteName> =
-  ApiRoutes[T]['params'] extends Record<string, never> ? false : true
+// Param-less routes are emitted as `params: Record<string, never>`, whose
+// `keyof` is `string` — so this compares against that shape, not against
+// `never`. The one predicate serves both `ApiRequestOptions` and `request()`
+// below; keep them on it, or a fix lands in one spelling and not the other.
+type HasBoundParams<TParams> = TParams extends Record<string, never> ? false : true
+
+// The request body type a route declares through its bound schema — `unknown`
+// for routes without one.
+type BodyOf<TRoute> = TRoute extends { body: infer TBody } ? TBody : unknown
 
 export type ApiRequestOptions<T extends ApiRouteName> =
-  HasParams<T> extends true
-    ? { params: ApiRouteParams<T>; body?: unknown; query?: Record<string, unknown> }
-    : { params?: never; body?: unknown; query?: Record<string, unknown> }
+  HasBoundParams<ApiRouteParams<T>> extends false
+    ? { params?: never; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
+    : { params: ApiRouteParams<T>; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
 
 // The wire contract these mirror is owned by Guren's CSRF middleware: it
 // writes the XSRF-TOKEN cookie and reads either header name. Change them
@@ -179,6 +184,9 @@ function isSameOrigin(url: string): boolean {
  * Cookies follow the `credentials` option (`'same-origin'` by default; use
  * `'include'` cross-origin, with a CORS setup that allows it).
  *
+ * Routes that bind a `body` schema type the `body` option with that schema's
+ * request shape; routes without one accept `unknown`.
+ *
  * @example
  * ```typescript
  * import type { ApiRoutes } from '@/.guren/api-client.gen'
@@ -197,11 +205,9 @@ export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method
   return {
     async request<TName extends keyof TRoutes & string>(
       name: TName,
-      // Param-less routes carry `params: Record<string, never>` — match that
-      // shape (its `keyof` is `string`, so `extends [never]` never fires).
-      ...args: TRoutes[TName]['params'] extends Record<string, never>
-        ? [options?: { body?: unknown; query?: Record<string, unknown> }]
-        : [options: { params: TRoutes[TName]['params']; body?: unknown; query?: Record<string, unknown> }]
+      ...args: HasBoundParams<TRoutes[TName]['params']> extends false
+        ? [options?: { params?: never; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
+        : [options: { params: TRoutes[TName]['params']; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
     ): Promise<Response> {
       const route = (routes as Record<string, { method: string; path: string }>)[name]
       if (!route) throw new Error(`Route [${name}] not defined.`)

--- a/packages/create-app/templates/blog/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/blog/.guren/api-client.gen.ts
@@ -55,6 +55,12 @@ export interface ApiRoutes {
     path: '/posts'
     params: Record<string, never>
   }
+  'posts.search': {
+    method: 'QUERY'
+    path: '/posts/search'
+    params: Record<string, never>
+    body: { keywords: string[]; limit?: number }
+  }
   'posts.show': {
     method: 'GET'
     path: '/posts/:id'
@@ -100,16 +106,78 @@ export type ApiRouteMethod<T extends ApiRouteName> = ApiRoutes[T]['method']
 export type ApiRoutePath<T extends ApiRouteName> = ApiRoutes[T]['path']
 export type ApiRouteParams<T extends ApiRouteName> = ApiRoutes[T]['params']
 
+// Param-less routes are emitted as `Record<string, never>`, whose `keyof` is
+// `string` — so this must compare against that shape, not against `never`.
 type HasParams<T extends ApiRouteName> =
-  [keyof ApiRoutes[T]['params']] extends [never] ? false : true
+  ApiRoutes[T]['params'] extends Record<string, never> ? false : true
 
 export type ApiRequestOptions<T extends ApiRouteName> =
   HasParams<T> extends true
     ? { params: ApiRouteParams<T>; body?: unknown; query?: Record<string, unknown> }
     : { params?: never; body?: unknown; query?: Record<string, unknown> }
 
+// The wire contract these mirror is owned by Guren's CSRF middleware: it
+// writes the XSRF-TOKEN cookie and reads either header name. Change them
+// together.
+const XSRF_COOKIE_NAME = 'XSRF-TOKEN'
+const XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+// QUERY (RFC 10008) is deliberately NOT listed even though the server's CSRF
+// default skips it: the redundant token header is harmless there, and keeping
+// it is what makes a server that opts QUERY into protection (the middleware's
+// `methods` option) work with this client unchanged.
+const CSRF_SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS']
+const CSRF_HEADER_NAMES = [XSRF_HEADER_NAME.toLowerCase(), 'x-csrf-token']
+
+/**
+ * Read the `XSRF-TOKEN` cookie issued by Guren's CSRF middleware.
+ *
+ * Reached through `globalThis` so this module stays importable — and
+ * type-checkable — outside the browser, where `document` does not exist.
+ */
+function readXsrfToken(): string | undefined {
+  const cookies = (globalThis as { document?: { cookie?: string } }).document?.cookie
+  if (!cookies) return undefined
+  for (const part of cookies.split(';')) {
+    const entry = part.trim()
+    if (!entry.startsWith(`${XSRF_COOKIE_NAME}=`)) continue
+    const value = entry.slice(XSRF_COOKIE_NAME.length + 1)
+    try {
+      return decodeURIComponent(value)
+    } catch {
+      return value
+    }
+  }
+  return undefined
+}
+
+/**
+ * Whether `url` targets the page's own origin.
+ *
+ * The `XSRF-TOKEN` cookie belongs to that origin, so it must never ride along
+ * to a third-party `baseUrl`: that would hand this page's CSRF token to
+ * another server, which a permissive CORS policy there is enough to accept.
+ * Outside the browser there is no origin — and no cookie — so nothing is sent.
+ */
+function isSameOrigin(url: string): boolean {
+  const location = (globalThis as { location?: { href?: string; origin?: string } }).location
+  if (!location?.href || !location.origin) return false
+  try {
+    return new URL(url, location.href).origin === location.origin
+  } catch {
+    return false
+  }
+}
+
 /**
  * Create a typed API client for consuming Guren routes.
+ *
+ * Same-origin state-changing requests automatically copy the `XSRF-TOKEN`
+ * cookie into the `X-XSRF-TOKEN` header, which is what Guren's CSRF
+ * middleware expects. Pass your own `X-XSRF-TOKEN` / `X-CSRF-TOKEN` header
+ * to opt out — you have to, for a `baseUrl` on another origin (the cookie is
+ * never sent there) or for a server configured with `csrf({ cookie: false })`.
+ * Cookies follow the `credentials` option (`'same-origin'` by default; use
+ * `'include'` cross-origin, with a CORS setup that allows it).
  *
  * @example
  * ```typescript
@@ -120,13 +188,18 @@ export type ApiRequestOptions<T extends ApiRouteName> =
  * const post = await client.request('posts.show', { params: { id: 1 } })
  * ```
  */
-export function createApiClient<TRoutes extends Record<string, { method: string; path: string; params: unknown }>>(
-  config: { baseUrl: string; headers?: Record<string, string> },
+// The mapped-object constraint (rather than `Record<...>`) is what lets the
+// generated `ApiRoutes` interface satisfy it — interfaces have no implicit
+// index signature, so `Record<string, ...>` would reject them.
+export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method: string; path: string; params: unknown } }>(
+  config: { baseUrl: string; headers?: Record<string, string>; credentials?: RequestInit['credentials'] },
 ) {
   return {
     async request<TName extends keyof TRoutes & string>(
       name: TName,
-      ...args: [keyof TRoutes[TName]['params']] extends [never]
+      // Param-less routes carry `params: Record<string, never>` — match that
+      // shape (its `keyof` is `string`, so `extends [never]` never fires).
+      ...args: TRoutes[TName]['params'] extends Record<string, never>
         ? [options?: { body?: unknown; query?: Record<string, unknown> }]
         : [options: { params: TRoutes[TName]['params']; body?: unknown; query?: Record<string, unknown> }]
     ): Promise<Response> {
@@ -151,11 +224,23 @@ export function createApiClient<TRoutes extends Record<string, { method: string;
         if (qs) url += `?${qs}`
       }
 
-      const init: RequestInit = {
-        method: route.method,
-        headers: { 'Content-Type': 'application/json', ...config.headers },
+      const method = route.method.toUpperCase()
+      const headers: Record<string, string> = { 'Content-Type': 'application/json', ...config.headers }
+      if (
+        !CSRF_SAFE_METHODS.includes(method) &&
+        !Object.keys(headers).some((key) => CSRF_HEADER_NAMES.includes(key.toLowerCase())) &&
+        isSameOrigin(url)
+      ) {
+        const token = readXsrfToken()
+        if (token) headers[XSRF_HEADER_NAME] = token
       }
-      if (opts?.body && route.method !== 'GET') {
+
+      const init: RequestInit = {
+        method,
+        headers,
+        credentials: config.credentials ?? 'same-origin',
+      }
+      if (opts?.body && method !== 'GET') {
         init.body = JSON.stringify(opts.body)
       }
 
@@ -174,6 +259,7 @@ const routes: Record<string, { method: string; path: string }> = {
   'posts.destroy': { method: 'DELETE', path: '/posts/:id' },
   'posts.edit': { method: 'GET', path: '/posts/:id/edit' },
   'posts.index': { method: 'GET', path: '/posts' },
+  'posts.search': { method: 'QUERY', path: '/posts/search' },
   'posts.show': { method: 'GET', path: '/posts/:id' },
   'posts.store': { method: 'POST', path: '/posts' },
   'posts.update': { method: 'PUT', path: '/posts/:id' },

--- a/packages/create-app/templates/blog/.guren/routes.gen.ts
+++ b/packages/create-app/templates/blog/.guren/routes.gen.ts
@@ -11,6 +11,7 @@ export const routeManifest = {
   'posts.destroy': { method: 'DELETE', path: '/posts/:id' },
   'posts.edit': { method: 'GET', path: '/posts/:id/edit' },
   'posts.index': { method: 'GET', path: '/posts' },
+  'posts.search': { method: 'QUERY', path: '/posts/search' },
   'posts.show': { method: 'GET', path: '/posts/:id' },
   'posts.store': { method: 'POST', path: '/posts' },
   'posts.update': { method: 'PUT', path: '/posts/:id' },
@@ -75,6 +76,7 @@ export const routes = {
     destroy: (params: RouteParams<'posts.destroy'>, query?: RouteQuery) => route('posts.destroy', params, query),
     edit: (params: RouteParams<'posts.edit'>, query?: RouteQuery) => route('posts.edit', params, query),
     index: (query?: RouteQuery) => route('posts.index', query),
+    search: (query?: RouteQuery) => route('posts.search', query),
     show: (params: RouteParams<'posts.show'>, query?: RouteQuery) => route('posts.show', params, query),
     store: (query?: RouteQuery) => route('posts.store', query),
     update: (params: RouteParams<'posts.update'>, query?: RouteQuery) => route('posts.update', params, query)

--- a/packages/create-app/templates/blog/README.md
+++ b/packages/create-app/templates/blog/README.md
@@ -24,6 +24,17 @@ the database container.
 - `/` — landing page with the latest posts
 - `/posts` — paginated post list, `/posts/:id` — a single post
 - `/posts/create`, `/posts/:id/edit` — write and edit, signed in only
+- `QUERY /posts/search` — JSON search endpoint using the HTTP QUERY method
+  ([RFC 10008](https://www.rfc-editor.org/info/rfc10008/)): safe like GET, but
+  the criteria travel in a JSON body. The posts page calls it through the
+  generated typed client (`.guren/api-client.gen.ts`), or try it directly:
+
+  ```bash
+  curl --request QUERY http://localhost:3333/posts/search \
+    --header 'content-type: application/json' \
+    --data '{"keywords":["guren"]}'
+  ```
+
 - `/login`, `/register`, `/dashboard`, `/profile` — session authentication
 
 Posts belong to their author. `app/Providers/AuthorizationProvider.ts` binds

--- a/packages/create-app/templates/blog/app/Http/Controllers/PostController.ts
+++ b/packages/create-app/templates/blog/app/Http/Controllers/PostController.ts
@@ -3,7 +3,7 @@ import { pages } from '@/.guren/pages.gen'
 import { Post } from '../../Models/Post.js'
 import type { UserRecord } from '../../Models/User.js'
 import { PostResource, type PostResourceData } from '../Resources/PostResource.js'
-import { PostIdParamSchema, PostPayloadSchema, ListPostsQuerySchema } from '../Validators/PostValidator.js'
+import { PostIdParamSchema, PostPayloadSchema, PostSearchSchema, ListPostsQuerySchema } from '../Validators/PostValidator.js'
 
 type PostsIndexProps = PaginatedPageProps<PostResourceData>
 
@@ -23,6 +23,22 @@ export default class PostController extends Controller {
         links: paginator.links(),
       },
     } satisfies PostsIndexProps)
+  }
+
+  // Serves the HTTP QUERY route `posts.search` — a safe read that carries its
+  // criteria in a JSON body. Matches posts with any keyword in title or excerpt.
+  async search(): Promise<Response> {
+    const { keywords, limit } = await this.validateBody(PostSearchSchema)
+
+    const query = Post.newQuery().with('author')
+    for (const keyword of keywords) {
+      const pattern = `%${keyword}%`
+      query.orWhere('title', 'like', pattern)
+      query.orWhere('excerpt', 'like', pattern)
+    }
+    const posts = await query.orderBy('id', 'desc').limit(limit).get()
+
+    return this.json({ data: posts.map((post) => new PostResource(post).toJSON()) })
   }
 
   async show(): Promise<Response> {

--- a/packages/create-app/templates/blog/app/Http/Controllers/PostController.ts
+++ b/packages/create-app/templates/blog/app/Http/Controllers/PostController.ts
@@ -26,7 +26,11 @@ export default class PostController extends Controller {
   }
 
   // Serves the HTTP QUERY route `posts.search` — a safe read that carries its
-  // criteria in a JSON body. Matches posts with any keyword in title or excerpt.
+  // criteria in a JSON body. Matches posts with any keyword in title or
+  // excerpt; `%` and `_` in a keyword act as SQL LIKE wildcards, which this
+  // starter treats as a feature. The keyword matching is a chain of top-level
+  // OR conditions — group it before mixing in AND filters (a published flag,
+  // tenancy), or those filters will be OR'd away.
   async search(): Promise<Response> {
     const { keywords, limit } = await this.validateBody(PostSearchSchema)
 
@@ -38,7 +42,7 @@ export default class PostController extends Controller {
     }
     const posts = await query.orderBy('id', 'desc').limit(limit).get()
 
-    return this.json({ data: posts.map((post) => new PostResource(post).toJSON()) })
+    return this.json({ data: PostResource.collection(posts) })
   }
 
   async show(): Promise<Response> {

--- a/packages/create-app/templates/blog/app/Http/Validators/PostValidator.ts
+++ b/packages/create-app/templates/blog/app/Http/Validators/PostValidator.ts
@@ -8,6 +8,14 @@ export const ListPostsQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
 })
 
+export const PostSearchSchema = z.object({
+  keywords: z
+    .array(z.string().trim().min(1, 'Keywords must not be blank.'))
+    .min(1, 'Provide at least one keyword.')
+    .max(10, 'Provide at most 10 keywords.'),
+  limit: z.number().int().min(1).max(50).default(10),
+})
+
 export const PostPayloadSchema = z.object({
   title: z.string().trim().min(1, 'Title is required.').max(255, 'Title must be 255 characters or fewer.'),
   excerpt: z.string().trim().min(1, 'Excerpt is required.').max(500, 'Excerpt must be 500 characters or fewer.'),

--- a/packages/create-app/templates/blog/resources/js/pages/posts/Index.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/posts/Index.tsx
@@ -1,20 +1,92 @@
+import { useState, type FormEvent } from 'react'
 import { Head, Link } from '@inertiajs/react'
 import type { PaginatedPageProps } from '@guren/core'
 import type { PostResourceData } from '@/app/Http/Resources/PostResource'
 import { route } from '@/.guren/routes.gen'
+import { createApiClient, type ApiRoutes } from '@/.guren/api-client.gen'
 import Layout from '../../components/Layout.js'
 
 interface Props extends PaginatedPageProps<PostResourceData> {}
 
+type PostSearchBody = ApiRoutes['posts.search']['body']
+
+// posts.search is an HTTP QUERY route (RFC 10008): safe like GET, but the
+// criteria travel in a JSON body — HTML forms and Inertia navigation cannot
+// send it, so the page calls it through the generated typed client.
+const api = createApiClient<ApiRoutes>({ baseUrl: '' })
+
+const fieldClass =
+  'w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring'
+
 export default function PostsIndex({ data, pagination }: Props) {
+  const [keywords, setKeywords] = useState('')
+  const [results, setResults] = useState<PostResourceData[] | null>(null)
+  const [searching, setSearching] = useState(false)
+
+  async function search(event: FormEvent) {
+    event.preventDefault()
+    const terms = keywords.split(/\s+/).filter((term) => term.length > 0)
+    if (terms.length === 0) {
+      setResults(null)
+      return
+    }
+
+    setSearching(true)
+    try {
+      const body: PostSearchBody = { keywords: terms }
+      const response = await api.request('posts.search', { body })
+      if (response.ok) {
+        const payload = (await response.json()) as { data: PostResourceData[] }
+        setResults(payload.data)
+      }
+    } finally {
+      setSearching(false)
+    }
+  }
+
+  const posts = results ?? data
+
   return (
     <Layout>
       <Head title="Posts" />
       <section className="space-y-6">
         <h1 className="text-3xl font-semibold text-emerald-300">Posts</h1>
 
+        <form className="flex gap-2" onSubmit={search}>
+          <input
+            type="search"
+            value={keywords}
+            onChange={(event) => setKeywords(event.target.value)}
+            placeholder="Search posts…"
+            className={fieldClass}
+          />
+          <button
+            type="submit"
+            disabled={searching}
+            className="rounded border border-emerald-500 px-4 py-2 text-sm text-emerald-200 transition hover:bg-emerald-500/10 disabled:opacity-50"
+          >
+            Search
+          </button>
+        </form>
+
+        {results !== null && (
+          <p className="text-sm text-slate-400">
+            {results.length} {results.length === 1 ? 'result' : 'results'} ·{' '}
+            <button
+              type="button"
+              onClick={() => {
+                setKeywords('')
+                setResults(null)
+              }}
+              className="text-emerald-300 transition hover:text-emerald-200"
+            >
+              Clear
+            </button>
+          </p>
+        )}
+
         <div className="space-y-4">
-          {data.map((post) => (
+          {posts.map((post) => (
             <article key={post.id} className="rounded-lg border border-slate-800 bg-slate-900/40 p-5">
               <Link
                 href={route('posts.show', { id: post.id })}
@@ -30,7 +102,7 @@ export default function PostsIndex({ data, pagination }: Props) {
           ))}
         </div>
 
-        {pagination?.links?.pages && (
+        {results === null && pagination?.links?.pages && (
           <nav className="flex gap-2">
             {pagination.links.pages.map((page) => (
               <Link

--- a/packages/create-app/templates/blog/resources/js/pages/posts/Index.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/posts/Index.tsx
@@ -8,37 +8,39 @@ import Layout from '../../components/Layout.js'
 
 interface Props extends PaginatedPageProps<PostResourceData> {}
 
-type PostSearchBody = ApiRoutes['posts.search']['body']
-
 // posts.search is an HTTP QUERY route (RFC 10008): safe like GET, but the
 // criteria travel in a JSON body — HTML forms and Inertia navigation cannot
-// send it, so the page calls it through the generated typed client.
+// send it, so the page calls it through the generated typed client. The
+// client types the request body from the schema bound to the route.
 const api = createApiClient<ApiRoutes>({ baseUrl: '' })
-
-const fieldClass =
-  'w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring'
 
 export default function PostsIndex({ data, pagination }: Props) {
   const [keywords, setKeywords] = useState('')
   const [results, setResults] = useState<PostResourceData[] | null>(null)
   const [searching, setSearching] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   async function search(event: FormEvent) {
     event.preventDefault()
     const terms = keywords.split(/\s+/).filter((term) => term.length > 0)
     if (terms.length === 0) {
       setResults(null)
+      setError(null)
       return
     }
 
     setSearching(true)
+    setError(null)
     try {
-      const body: PostSearchBody = { keywords: terms }
-      const response = await api.request('posts.search', { body })
-      if (response.ok) {
-        const payload = (await response.json()) as { data: PostResourceData[] }
-        setResults(payload.data)
+      const response = await api.request('posts.search', { body: { keywords: terms } })
+      if (!response.ok) {
+        setError('Search failed — try fewer or shorter keywords.')
+        return
       }
+      const payload = (await response.json()) as { data: PostResourceData[] }
+      setResults(payload.data)
+    } catch {
+      setError('Search failed — check your connection and try again.')
     } finally {
       setSearching(false)
     }
@@ -58,7 +60,7 @@ export default function PostsIndex({ data, pagination }: Props) {
             value={keywords}
             onChange={(event) => setKeywords(event.target.value)}
             placeholder="Search posts…"
-            className={fieldClass}
+            className="w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
           />
           <button
             type="submit"
@@ -69,6 +71,8 @@ export default function PostsIndex({ data, pagination }: Props) {
           </button>
         </form>
 
+        {error !== null && <p className="text-sm text-rose-400">{error}</p>}
+
         {results !== null && (
           <p className="text-sm text-slate-400">
             {results.length} {results.length === 1 ? 'result' : 'results'} ·{' '}
@@ -77,6 +81,7 @@ export default function PostsIndex({ data, pagination }: Props) {
               onClick={() => {
                 setKeywords('')
                 setResults(null)
+                setError(null)
               }}
               className="text-emerald-300 transition hover:text-emerald-200"
             >

--- a/packages/create-app/templates/blog/routes/web.ts
+++ b/packages/create-app/templates/blog/routes/web.ts
@@ -1,7 +1,7 @@
 import { Router, requireAuthenticated, requireGuest } from '@guren/core'
 import HomeController from '../app/Http/Controllers/HomeController.js'
 import PostController from '../app/Http/Controllers/PostController.js'
-import { PostPayloadSchema } from '../app/Http/Validators/PostValidator.js'
+import { PostPayloadSchema, PostSearchSchema } from '../app/Http/Validators/PostValidator.js'
 import { registerAuthRoutes } from './auth.js'
 
 export function registerWebRoutes(baseRouter: Router): void {
@@ -30,5 +30,10 @@ export function registerWebRoutes(baseRouter: Router): void {
 
     posts.get('/', [PostController, 'index']).name('posts.index')
     posts.get('/:id', [PostController, 'show']).name('posts.show')
+
+    // HTTP QUERY (RFC 10008): safe and idempotent like GET, but carries its
+    // search criteria in a JSON body. Only fetch-based clients can send it —
+    // the posts page calls it through the generated API client.
+    posts.query('/search', { name: 'posts.search', body: PostSearchSchema }, [PostController, 'search'])
   })
 }

--- a/packages/create-app/templates/blog/tests/PostController.test.ts
+++ b/packages/create-app/templates/blog/tests/PostController.test.ts
@@ -1,0 +1,20 @@
+import { beforeAll, describe, it } from 'bun:test'
+import { TestApp } from '@guren/testing'
+import app from '../src/app.js'
+
+// posts.search is an HTTP QUERY route (RFC 10008) whose body schema is bound
+// to the route, so invalid payloads are rejected with 422 before the
+// controller — and the database — is ever reached. That keeps this starter
+// test green without migrations or fixtures; cover the happy path with real
+// feature tests once your test database is set up.
+describe('posts.search', () => {
+  let http: TestApp
+
+  beforeAll(async () => {
+    http = await TestApp.fromApp(app)
+  })
+
+  it('rejects a search without keywords', async () => {
+    await http.query('/posts/search', { keywords: [] }).assertStatus(422)
+  })
+})

--- a/packages/create-app/templates/blog/tests/PostController.test.ts
+++ b/packages/create-app/templates/blog/tests/PostController.test.ts
@@ -2,9 +2,11 @@ import { beforeAll, describe, it } from 'bun:test'
 import { TestApp } from '@guren/testing'
 import app from '../src/app.js'
 
-// posts.search is an HTTP QUERY route (RFC 10008) whose body schema is bound
-// to the route, so invalid payloads are rejected with 422 before the
-// controller — and the database — is ever reached. That keeps this starter
+// posts.search is an HTTP QUERY route (RFC 10008). Its controller validates
+// the body with validateBody() before building any query — the schema bound
+// to the route feeds codegen and `guren audit`, while body parsing stays in
+// the controller so the request stream is read once — so an invalid payload
+// gets a 422 without the database ever being touched. That keeps this starter
 // test green without migrations or fixtures; cover the happy path with real
 // feature tests once your test database is set up.
 describe('posts.search', () => {

--- a/packages/create-app/templates/default/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/default/.guren/api-client.gen.ts
@@ -19,8 +19,10 @@ export type ApiRouteMethod<T extends ApiRouteName> = ApiRoutes[T]['method']
 export type ApiRoutePath<T extends ApiRouteName> = ApiRoutes[T]['path']
 export type ApiRouteParams<T extends ApiRouteName> = ApiRoutes[T]['params']
 
+// Param-less routes are emitted as `Record<string, never>`, whose `keyof` is
+// `string` — so this must compare against that shape, not against `never`.
 type HasParams<T extends ApiRouteName> =
-  [keyof ApiRoutes[T]['params']] extends [never] ? false : true
+  ApiRoutes[T]['params'] extends Record<string, never> ? false : true
 
 export type ApiRequestOptions<T extends ApiRouteName> =
   HasParams<T> extends true
@@ -32,6 +34,10 @@ export type ApiRequestOptions<T extends ApiRouteName> =
 // together.
 const XSRF_COOKIE_NAME = 'XSRF-TOKEN'
 const XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+// QUERY (RFC 10008) is deliberately NOT listed even though the server's CSRF
+// default skips it: the redundant token header is harmless there, and keeping
+// it is what makes a server that opts QUERY into protection (the middleware's
+// `methods` option) work with this client unchanged.
 const CSRF_SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS']
 const CSRF_HEADER_NAMES = [XSRF_HEADER_NAME.toLowerCase(), 'x-csrf-token']
 
@@ -95,13 +101,18 @@ function isSameOrigin(url: string): boolean {
  * const post = await client.request('posts.show', { params: { id: 1 } })
  * ```
  */
-export function createApiClient<TRoutes extends Record<string, { method: string; path: string; params: unknown }>>(
+// The mapped-object constraint (rather than `Record<...>`) is what lets the
+// generated `ApiRoutes` interface satisfy it — interfaces have no implicit
+// index signature, so `Record<string, ...>` would reject them.
+export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method: string; path: string; params: unknown } }>(
   config: { baseUrl: string; headers?: Record<string, string>; credentials?: RequestInit['credentials'] },
 ) {
   return {
     async request<TName extends keyof TRoutes & string>(
       name: TName,
-      ...args: [keyof TRoutes[TName]['params']] extends [never]
+      // Param-less routes carry `params: Record<string, never>` — match that
+      // shape (its `keyof` is `string`, so `extends [never]` never fires).
+      ...args: TRoutes[TName]['params'] extends Record<string, never>
         ? [options?: { body?: unknown; query?: Record<string, unknown> }]
         : [options: { params: TRoutes[TName]['params']; body?: unknown; query?: Record<string, unknown> }]
     ): Promise<Response> {

--- a/packages/create-app/templates/default/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/default/.guren/api-client.gen.ts
@@ -19,15 +19,20 @@ export type ApiRouteMethod<T extends ApiRouteName> = ApiRoutes[T]['method']
 export type ApiRoutePath<T extends ApiRouteName> = ApiRoutes[T]['path']
 export type ApiRouteParams<T extends ApiRouteName> = ApiRoutes[T]['params']
 
-// Param-less routes are emitted as `Record<string, never>`, whose `keyof` is
-// `string` — so this must compare against that shape, not against `never`.
-type HasParams<T extends ApiRouteName> =
-  ApiRoutes[T]['params'] extends Record<string, never> ? false : true
+// Param-less routes are emitted as `params: Record<string, never>`, whose
+// `keyof` is `string` — so this compares against that shape, not against
+// `never`. The one predicate serves both `ApiRequestOptions` and `request()`
+// below; keep them on it, or a fix lands in one spelling and not the other.
+type HasBoundParams<TParams> = TParams extends Record<string, never> ? false : true
+
+// The request body type a route declares through its bound schema — `unknown`
+// for routes without one.
+type BodyOf<TRoute> = TRoute extends { body: infer TBody } ? TBody : unknown
 
 export type ApiRequestOptions<T extends ApiRouteName> =
-  HasParams<T> extends true
-    ? { params: ApiRouteParams<T>; body?: unknown; query?: Record<string, unknown> }
-    : { params?: never; body?: unknown; query?: Record<string, unknown> }
+  HasBoundParams<ApiRouteParams<T>> extends false
+    ? { params?: never; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
+    : { params: ApiRouteParams<T>; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
 
 // The wire contract these mirror is owned by Guren's CSRF middleware: it
 // writes the XSRF-TOKEN cookie and reads either header name. Change them
@@ -92,6 +97,9 @@ function isSameOrigin(url: string): boolean {
  * Cookies follow the `credentials` option (`'same-origin'` by default; use
  * `'include'` cross-origin, with a CORS setup that allows it).
  *
+ * Routes that bind a `body` schema type the `body` option with that schema's
+ * request shape; routes without one accept `unknown`.
+ *
  * @example
  * ```typescript
  * import type { ApiRoutes } from '@/.guren/api-client.gen'
@@ -110,11 +118,9 @@ export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method
   return {
     async request<TName extends keyof TRoutes & string>(
       name: TName,
-      // Param-less routes carry `params: Record<string, never>` — match that
-      // shape (its `keyof` is `string`, so `extends [never]` never fires).
-      ...args: TRoutes[TName]['params'] extends Record<string, never>
-        ? [options?: { body?: unknown; query?: Record<string, unknown> }]
-        : [options: { params: TRoutes[TName]['params']; body?: unknown; query?: Record<string, unknown> }]
+      ...args: HasBoundParams<TRoutes[TName]['params']> extends false
+        ? [options?: { params?: never; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
+        : [options: { params: TRoutes[TName]['params']; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
     ): Promise<Response> {
       const route = (routes as Record<string, { method: string; path: string }>)[name]
       if (!route) throw new Error(`Route [${name}] not defined.`)

--- a/packages/create-app/templates/default/.guren/pages.gen.ts
+++ b/packages/create-app/templates/default/.guren/pages.gen.ts
@@ -22,7 +22,9 @@ export function isPageId(value: string): value is PageId {
  * Auto-extracted Props types from page components.
  */
 export interface PagePropsMap {
-  'Home': Record<string, unknown>
+  'Home': {
+  message: string
+}
 }
 
 export type InferPageProps<TId extends PageId> =
@@ -43,5 +45,5 @@ function defineGeneratedPage<TId extends string, TProps extends PagePropsRecord 
 }
 
 export const pages = {
-  Home: defineGeneratedPage('Home', pageManifest['Home'])
+  Home: defineGeneratedPage<'Home', PagePropsMap['Home']>('Home', pageManifest['Home'])
 } as const

--- a/packages/create-app/templates/default/.guren/routes.gen.ts
+++ b/packages/create-app/templates/default/.guren/routes.gen.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // Generated from routes/web.ts — DO NOT EDIT
 // Run `guren codegen` to regenerate.
 
@@ -7,8 +8,8 @@ export const routeManifest = {
 
 export type RouteManifest = typeof routeManifest
 export type RouteName = keyof RouteManifest
-export type RouteMethod = RouteManifest[RouteName]['method']
-export type RoutePath = RouteManifest[RouteName]['path']
+export type RouteMethod = [RouteName] extends [never] ? string : RouteManifest[RouteName]['method']
+export type RoutePath = [RouteName] extends [never] ? string : RouteManifest[RouteName]['path']
 
 type PrimitiveQueryValue = string | number | boolean | null | undefined
 type QueryValue = PrimitiveQueryValue | readonly PrimitiveQueryValue[]


### PR DESCRIPTION
## Summary

Follows up on #385 (HTTP QUERY support, published in v2.5.0) by adopting the method where a starter actually benefits: the blog blueprint gains `QUERY /posts/search`, and the posts page consumes it through the generated typed API client — the first template consumer of `createApiClient`.

Dogfooding that consumer surfaced two type-level bugs in the generated client, fixed here first:

- `createApiClient<ApiRoutes>()` — the generated file's own JSDoc example — did not compile: the `Record<...>` generic constraint rejects the generated `ApiRoutes` **interface** (interfaces carry no implicit index signature).
- Param-less routes are emitted as `params: Record<string, never>`, whose `keyof` is `string`, so the `extends [never]` check inverted and `request('posts.index')` demanded a `params` argument.

Nothing type-checked the emitted module against a call site before (scaffolds compile it, but with no consumer that proved nothing), so a new test compiles the generated source plus its documented usage in-process (`ts.createProgram`, shared `checkTypes()` helper also adopted by the i18n compile gate); `@ts-expect-error` probes keep the gate able to fail in both directions (mutation-verified).

## Blog starter changes

- `PostSearchSchema` (keywords array + optional limit) bound to the route — it feeds codegen's typed `body` and `guren audit`; body validation itself runs in the controller (`validateBody`), which the framework does deliberately so the request stream is read once. An invalid payload still 422s without touching the database.
- Read-only `PostController.search()` matching any keyword against title or excerpt via `PostResource.collection()`
- Search box on the posts index calling `posts.search` through the typed client; the request body is now typed end-to-end from the bound schema (`BodyOf<TRoute>` in the generated client), and search failures surface as an inline error instead of being swallowed
- Starter test driving `TestApp.query()` (green without migrations), README endpoint docs with a `curl --request QUERY` example
- Shipped `.guren` artifacts regenerated (blog: new route + fixed client; default: fixed client — its smoke regenerates before typechecking, so these were only stale on npm)

## Where QUERY was deliberately **not** adopted

- **make:feature / Inertia pages** — Inertia navigation and form helpers cannot send QUERY; scaffolds stay on GET
- **api-only template** — has no data model; a demo search over nothing would be noise. The agent-harness rules already teach `router.query()` for API apps
- Pagination-style simple queries stay on GET query strings, per the routing guide

## Pre-merge review

A Codex review plus a four-angle cleanup pass ran over the diff; applied findings are in the last commit (silent search failures, single emitted params predicate, typed request body, in-process compile gate, resource collection reuse, corrected test comment). Known limitations noted for follow-up rather than patched here:

- Union route names (`'posts.index' | 'posts.show'`) can satisfy the params conditional non-distributively — narrowing before calling is required (Codex, medium; tracked as a follow-up)
- `%`/`_` in keywords act as SQL LIKE wildcards — documented as intentional in the controller
- The flat `orWhere` chain must be grouped before AND filters join the query; grouping support in `QueryBuilder` is a framework follow-up, and the controller comment warns about it

## Verification

- `bun run typecheck`, `bun run test:bun` (4186 pass), `bun run test:examples` — green
- `bun run audit:core-first`, `audit:docs`, `audit:template-deps`, `audit:starter-template` — green
- `bun run smoke:starter:blog`, `smoke:starter`, `smoke:starter:api` — all pass (vendored), re-run after the review commit
- Scaffolded blog app exercised end to end: `QUERY /posts/search` returns matching seeded posts (200), empty keywords 422, browser search box filters via the typed client (network shows `QUERY … → 200`) and shows the inline error on a 422, `guren check --ci` / `audit --no-deps` pass on the scaffold

## Release note

`smoke:starter:npm:blog` is expected red until the release ships: the template's `Index.tsx` needs the fixed `@guren/cli` codegen (`^2.4.0` picks it up as a patch). Changesets bump `@guren/cli` (patch) and `create-guren-app` (minor) together, so the published template and the CLI that regenerates its client land in the same release.