### PR TITLE
feat(cli): derive API client params from path literals and type responses

### DIFF
--- a/.changeset/api-client-path-derived-types.md
+++ b/.changeset/api-client-path-derived-types.md
@@ -1,0 +1,12 @@
+---
+"@guren/cli": minor
+"create-guren-app": patch
+---
+
+The generated API client derives params from path literals, types `json()` from bound output schemas, and closes a union-route-name type hole.
+
+Route params are no longer stored on the generated `ApiRoutes` entries as a `params` field. Both `ApiRequestOptions` and `request()` now derive them from each entry's `path` literal — the same string the server routes on — through the `PathParamKeys` helper the route manifest module already emits, so a future change to the entry shape can never silently flip `request()`'s call arity. `ApiRouteParams<T>` remains exported with the same meaning.
+
+`request()` now returns `Promise<TypedResponse<...>>`: on routes that bind an `output` schema, `json()` resolves to that schema's parsed shape instead of `any`; without one it resolves to `unknown`, so asserting the shape at the call site stays explicit.
+
+The path predicate is deliberately not distributed over a union route name. Previously `'posts.index' | 'posts.show'` accepted `params: {}` and could send a path with `:id` unresolved; now a union name requires every member's params (substituting a param a member's path lacks is a runtime no-op), which forces the safe call in both directions.

--- a/.changeset/api-client-path-derived-types.md
+++ b/.changeset/api-client-path-derived-types.md
@@ -1,5 +1,6 @@
 ---
 "@guren/cli": minor
+"@guren/inertia-client": patch
 "create-guren-app": patch
 ---
 
@@ -9,4 +10,6 @@ Route params are no longer stored on the generated `ApiRoutes` entries as a `par
 
 `request()` now returns `Promise<TypedResponse<...>>`: on routes that bind an `output` schema, `json()` resolves to that schema's parsed shape instead of `any`; without one it resolves to `unknown`, so asserting the shape at the call site stays explicit.
 
-The path predicate is deliberately not distributed over a union route name. Previously `'posts.index' | 'posts.show'` accepted `params: {}` and could send a path with `:id` unresolved; now a union name requires every member's params (substituting a param a member's path lacks is a runtime no-op), which forces the safe call in both directions.
+The path predicate is deliberately not distributed over a union route name. Previously `'posts.index' | 'posts.show'` accepted `params: {}` and could send a path with `:id` unresolved; now a union name requires every member's params, which forces the safe call in both directions.
+
+To make those extra params true runtime no-ops, the generated client's param substitution switched from a per-key `path.replace(':key', ...)` loop — which let a param whose name prefixes another (`:id` vs `:identifier`) corrupt the path — to the same token-based `substituteParams` the route manifest module already uses, now emitted from one shared fragment. `@guren/inertia-client`'s typed `<Link>`/`<Form>` components adopt the same substitution.

--- a/.changeset/api-client-path-derived-types.md
+++ b/.changeset/api-client-path-derived-types.md
@@ -5,7 +5,7 @@
 
 The generated API client derives params from path literals, types `json()` from bound output schemas, and closes a union-route-name type hole.
 
-Route params are no longer stored on the generated `ApiRoutes` entries as a `params` field. Both `ApiRequestOptions` and `request()` now derive them from each entry's `path` literal — the same string the server routes on — through the `PathParamKeys` helper the route manifest module already emits, so a future change to the entry shape can never silently flip `request()`'s call arity. `ApiRouteParams<T>` remains exported with the same meaning.
+Route params are no longer stored on the generated `ApiRoutes` entries as a `params` field. Both `ApiRequestOptions` and `request()` now derive them from each entry's `path` literal — the same string the server routes on — through one shared emitted fragment (`PathParamKeys`, `HasPathParams`, `PathParamsOf`) that the route manifest module's `RouteParams`/`RouteArgs` are also expressed with, so a future change to the entry shape can never silently flip `request()`'s call arity and the rule has a single spelling across the generated modules. `ApiRouteParams<T>` remains exported with the same meaning, and `@guren/inertia-client`'s hand-mirrored copy of the rule is now pinned to the fragment's exact text by a test.
 
 `request()` now returns `Promise<TypedResponse<...>>`: on routes that bind an `output` schema, `json()` resolves to that schema's parsed shape instead of `any`; without one it resolves to `unknown`, so asserting the shape at the call site stays explicit.
 

--- a/packages/cli/src/api-client-types.ts
+++ b/packages/cli/src/api-client-types.ts
@@ -120,6 +120,13 @@ type RequestOptionsOf<TRoute extends { path: string }> =
     ? { params?: never; body?: BodyOf<TRoute>; query?: Record<string, unknown> }
     : { params: PathParamsOf<TRoute['path']>; body?: BodyOf<TRoute>; query?: Record<string, unknown> }
 
+// Param-less routes may omit the options argument entirely; the same
+// predicate that shapes the options decides the arity.
+type RequestArgsOf<TRoute extends { path: string }> =
+  HasPathParams<TRoute['path']> extends false
+    ? [options?: RequestOptionsOf<TRoute>]
+    : [options: RequestOptionsOf<TRoute>]
+
 export type ApiRequestOptions<T extends ApiRouteName> = RequestOptionsOf<ApiRoutes[T]>
 
 // The wire contract these mirror is owned by Guren's CSRF middleware: it
@@ -211,9 +218,7 @@ export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method
   return {
     async request<TName extends keyof TRoutes & string>(
       name: TName,
-      ...args: HasPathParams<TRoutes[TName]['path']> extends false
-        ? [options?: RequestOptionsOf<TRoutes[TName]>]
-        : [options: RequestOptionsOf<TRoutes[TName]>]
+      ...args: RequestArgsOf<TRoutes[TName]>
     ): Promise<TypedResponse<ResponseOf<TRoutes[TName]>>> {
       const route = (routes as Record<string, { method: string; path: string }>)[name]
       if (!route) throw new Error(\`Route [\${name}] not defined.\`)

--- a/packages/cli/src/api-client-types.ts
+++ b/packages/cli/src/api-client-types.ts
@@ -7,6 +7,7 @@
  */
 import { resolve } from 'node:path'
 import { escapeSingleQuoted as escapeSingleQuotes, resolveAppRoot, writeGeneratedFileIn, type WriterOptions } from './utils'
+import { PATH_PARAM_TYPE_HELPERS } from './routes-types-fragments'
 import { schemaToTypeString } from './schema-type-extractor'
 
 export interface RouteDefinitionLike {
@@ -55,16 +56,11 @@ export function buildApiClientContent(definitions: RouteDefinitionLike[]): strin
 
   const routeEntries = named
     .map((d) => {
-      const params = extractParams(d.path)
-      const paramsType = params.length > 0
-        ? `{ ${params.map((p) => `${p}: string | number`).join('; ')} }`
-        : 'Record<string, never>'
       const bodyType = d.schemas?.body ? schemaToTypeString(d.schemas.body, { io: 'input' }) : undefined
       const responseType = d.schemas?.output ? schemaToTypeString(d.schemas.output, { io: 'output' }) : undefined
       let entry = `  '${escapeSingleQuotes(d.name)}': {
     method: '${d.method}'
-    path: '${escapeSingleQuotes(d.path)}'
-    params: ${paramsType}`
+    path: '${escapeSingleQuotes(d.path)}'`
       if (bodyType) entry += `\n    body: ${bodyType}`
       if (responseType) entry += `\n    response: ${responseType}`
       entry += '\n  }'
@@ -82,6 +78,8 @@ export function buildApiClientContent(definitions: RouteDefinitionLike[]): strin
  * \`body\` is the *request* shape — what you send. Coercing schemas are rendered
  * as they travel: \`z.coerce.date()\` is a \`string\` here, not the \`Date\` the
  * controller ends up with. \`response\` is the parsed shape you get back.
+ * Params are not stored on the entries: they are derived from each entry's
+ * \`path\` literal, the same string the server routes on.
  */
 export interface ApiRoutes {
 ${routeEntries || '  // No named routes found'}
@@ -91,20 +89,41 @@ export type ApiRouteName = keyof ApiRoutes
 
 export type ApiRouteMethod<T extends ApiRouteName> = ApiRoutes[T]['method']
 export type ApiRoutePath<T extends ApiRouteName> = ApiRoutes[T]['path']
-export type ApiRouteParams<T extends ApiRouteName> = ApiRoutes[T]['params']
 
-// Param-less routes are emitted as \`params: Record<string, never>\`, whose
-// \`keyof\` is \`string\` — so this compares against that shape, not against
-// \`never\`. The one predicate serves both \`ApiRequestOptions\` and \`request()\`
-// below; keep them on it, or a fix lands in one spelling and not the other.
-type HasBoundParams<TParams> = TParams extends Record<string, never> ? false : true
+${PATH_PARAM_TYPE_HELPERS}
+// Both derive from the path literal, so nothing about how the entries above
+// are emitted can silently flip \`request()\`'s call arity. Deliberately not
+// distributed over a union route name: the union of paths yields the union of
+// their param keys, so an un-narrowed name requires every member's params —
+// substituting a param a member's path lacks is a runtime no-op, while the
+// reverse (accepting one member's empty params) would send a path with its
+// \`:param\` unresolved. The one pair serves both \`ApiRequestOptions\` and
+// \`request()\` below; keep them on it, or a fix lands in one spelling and not
+// the other.
+type PathParamsOf<TPath extends string> =
+  [PathParamKeys<TPath>] extends [never]
+    ? Record<string, never>
+    : { [TKey in PathParamKeys<TPath>]: string | number }
+type HasPathParams<TPath extends string> = [PathParamKeys<TPath>] extends [never] ? false : true
+
+export type ApiRouteParams<T extends ApiRouteName> = PathParamsOf<ApiRoutePath<T>>
 
 // The request body type a route declares through its bound schema — \`unknown\`
 // for routes without one.
 type BodyOf<TRoute> = TRoute extends { body: infer TBody } ? TBody : unknown
 
+// The parsed shape a route declares through its bound output schema —
+// \`unknown\` for routes without one.
+type ResponseOf<TRoute> = TRoute extends { response: infer TResponse } ? TResponse : unknown
+
+// The runtime object is the plain fetch \`Response\`; only \`json()\` is narrowed
+// to the route's declared response shape.
+export interface TypedResponse<TData> extends Response {
+  json(): Promise<TData>
+}
+
 export type ApiRequestOptions<T extends ApiRouteName> =
-  HasBoundParams<ApiRouteParams<T>> extends false
+  HasPathParams<ApiRoutePath<T>> extends false
     ? { params?: never; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
     : { params: ApiRouteParams<T>; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
 
@@ -172,7 +191,10 @@ function isSameOrigin(url: string): boolean {
  * \`'include'\` cross-origin, with a CORS setup that allows it).
  *
  * Routes that bind a \`body\` schema type the \`body\` option with that schema's
- * request shape; routes without one accept \`unknown\`.
+ * request shape; routes without one accept \`unknown\`. Routes that bind an
+ * \`output\` schema type the response: \`json()\` on the returned \`Response\`
+ * resolves to that schema's parsed shape. Without one it resolves to
+ * \`unknown\` — validate before trusting it.
  *
  * @example
  * \`\`\`typescript
@@ -186,16 +208,16 @@ function isSameOrigin(url: string): boolean {
 // The mapped-object constraint (rather than \`Record<...>\`) is what lets the
 // generated \`ApiRoutes\` interface satisfy it — interfaces have no implicit
 // index signature, so \`Record<string, ...>\` would reject them.
-export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method: string; path: string; params: unknown } }>(
+export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method: string; path: string } }>(
   config: { baseUrl: string; headers?: Record<string, string>; credentials?: RequestInit['credentials'] },
 ) {
   return {
     async request<TName extends keyof TRoutes & string>(
       name: TName,
-      ...args: HasBoundParams<TRoutes[TName]['params']> extends false
+      ...args: HasPathParams<TRoutes[TName]['path']> extends false
         ? [options?: { params?: never; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
-        : [options: { params: TRoutes[TName]['params']; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
-    ): Promise<Response> {
+        : [options: { params: PathParamsOf<TRoutes[TName]['path']>; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
+    ): Promise<TypedResponse<ResponseOf<TRoutes[TName]>>> {
       const route = (routes as Record<string, { method: string; path: string }>)[name]
       if (!route) throw new Error(\`Route [\${name}] not defined.\`)
 
@@ -246,10 +268,5 @@ const routes: Record<string, { method: string; path: string }> = {
 ${named.map((d) => `  '${escapeSingleQuotes(d.name)}': { method: '${d.method}', path: '${escapeSingleQuotes(d.path)}' },`).join('\n')}
 }
 `
-}
-
-function extractParams(path: string): string[] {
-  const matches = path.match(/:([A-Za-z0-9_]+)/g)
-  return matches ? matches.map((m) => m.slice(1)) : []
 }
 

--- a/packages/cli/src/api-client-types.ts
+++ b/packages/cli/src/api-client-types.ts
@@ -189,7 +189,9 @@ function isSameOrigin(url: string): boolean {
  * request shape; routes without one accept \`unknown\`. Routes that bind an
  * \`output\` schema type the response: \`json()\` on the returned \`Response\`
  * resolves to that schema's parsed shape. Without one it resolves to
- * \`unknown\` — validate before trusting it.
+ * \`unknown\` — validate before trusting it. Either way the typed shape
+ * describes the success body only: error statuses carry their own (a 422
+ * from validation is \`{ errors: ... }\`), so check \`ok\` before reading it.
  *
  * @example
  * \`\`\`typescript

--- a/packages/cli/src/api-client-types.ts
+++ b/packages/cli/src/api-client-types.ts
@@ -7,7 +7,7 @@
  */
 import { resolve } from 'node:path'
 import { escapeSingleQuoted as escapeSingleQuotes, resolveAppRoot, writeGeneratedFileIn, type WriterOptions } from './utils'
-import { PATH_PARAM_TYPE_HELPERS } from './routes-types-fragments'
+import { PATH_PARAM_RUNTIME_HELPERS, PATH_PARAM_TYPE_HELPERS } from './routes-types-fragments'
 import { schemaToTypeString } from './schema-type-extractor'
 
 export interface RouteDefinitionLike {
@@ -209,6 +209,12 @@ function isSameOrigin(url: string): boolean {
  * const post = await client.request('posts.show', { params: { id: 1 } })
  * \`\`\`
  */
+// Token-based substitution shared with the route manifest module: whole
+// \`:param\` tokens are replaced by key lookup, so a key the path lacks is a
+// true no-op — the property the union-name rule above relies on — and a
+// param name that prefixes another (\`:id\` vs \`:identifier\`) cannot corrupt
+// it the way a per-key \`path.replace(':key', ...)\` loop would.
+${PATH_PARAM_RUNTIME_HELPERS}
 // The mapped-object constraint (rather than \`Record<...>\`) is what lets the
 // generated \`ApiRoutes\` interface satisfy it — interfaces have no implicit
 // index signature, so \`Record<string, ...>\` would reject them.
@@ -223,13 +229,8 @@ export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method
       const route = (routes as Record<string, { method: string; path: string }>)[name]
       if (!route) throw new Error(\`Route [\${name}] not defined.\`)
 
-      const opts = (args as unknown[])[0] as { params?: Record<string, unknown>; body?: unknown; query?: Record<string, unknown> } | undefined
-      let path = route.path
-      if (opts?.params) {
-        for (const [key, value] of Object.entries(opts.params)) {
-          path = path.replace(\`:$\{key}\`, encodeURIComponent(String(value)))
-        }
-      }
+      const opts = (args as unknown[])[0] as { params?: Record<string, string | number>; body?: unknown; query?: Record<string, unknown> } | undefined
+      const path = substituteParams(route.path, opts?.params)
 
       let url = \`$\{config.baseUrl}$\{path}\`
       if (opts?.query) {

--- a/packages/cli/src/api-client-types.ts
+++ b/packages/cli/src/api-client-types.ts
@@ -91,21 +91,6 @@ export type ApiRouteMethod<T extends ApiRouteName> = ApiRoutes[T]['method']
 export type ApiRoutePath<T extends ApiRouteName> = ApiRoutes[T]['path']
 
 ${PATH_PARAM_TYPE_HELPERS}
-// Both derive from the path literal, so nothing about how the entries above
-// are emitted can silently flip \`request()\`'s call arity. Deliberately not
-// distributed over a union route name: the union of paths yields the union of
-// their param keys, so an un-narrowed name requires every member's params —
-// substituting a param a member's path lacks is a runtime no-op, while the
-// reverse (accepting one member's empty params) would send a path with its
-// \`:param\` unresolved. The one pair serves both \`ApiRequestOptions\` and
-// \`request()\` below; keep them on it, or a fix lands in one spelling and not
-// the other.
-type PathParamsOf<TPath extends string> =
-  [PathParamKeys<TPath>] extends [never]
-    ? Record<string, never>
-    : { [TKey in PathParamKeys<TPath>]: string | number }
-type HasPathParams<TPath extends string> = [PathParamKeys<TPath>] extends [never] ? false : true
-
 export type ApiRouteParams<T extends ApiRouteName> = PathParamsOf<ApiRoutePath<T>>
 
 // The request body type a route declares through its bound schema — \`unknown\`
@@ -122,10 +107,20 @@ export interface TypedResponse<TData> extends Response {
   json(): Promise<TData>
 }
 
-export type ApiRequestOptions<T extends ApiRouteName> =
-  HasPathParams<ApiRoutePath<T>> extends false
-    ? { params?: never; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
-    : { params: ApiRouteParams<T>; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
+// Params derive from the path literal, so nothing about how the entries above
+// are emitted can silently flip \`request()\`'s call arity. Deliberately not
+// distributed over a union route name (the conditional checks
+// \`HasPathParams<...>\`, never a bare type parameter): the union of paths
+// yields the union of their param keys, so an un-narrowed name requires every
+// member's params — substituting a param a member's path lacks is a runtime
+// no-op, while the reverse (accepting one member's empty params) would send a
+// path with its \`:param\` unresolved.
+type RequestOptionsOf<TRoute extends { path: string }> =
+  HasPathParams<TRoute['path']> extends false
+    ? { params?: never; body?: BodyOf<TRoute>; query?: Record<string, unknown> }
+    : { params: PathParamsOf<TRoute['path']>; body?: BodyOf<TRoute>; query?: Record<string, unknown> }
+
+export type ApiRequestOptions<T extends ApiRouteName> = RequestOptionsOf<ApiRoutes[T]>
 
 // The wire contract these mirror is owned by Guren's CSRF middleware: it
 // writes the XSRF-TOKEN cookie and reads either header name. Change them
@@ -215,8 +210,8 @@ export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method
     async request<TName extends keyof TRoutes & string>(
       name: TName,
       ...args: HasPathParams<TRoutes[TName]['path']> extends false
-        ? [options?: { params?: never; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
-        : [options: { params: PathParamsOf<TRoutes[TName]['path']>; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
+        ? [options?: RequestOptionsOf<TRoutes[TName]>]
+        : [options: RequestOptionsOf<TRoutes[TName]>]
     ): Promise<TypedResponse<ResponseOf<TRoutes[TName]>>> {
       const route = (routes as Record<string, { method: string; path: string }>)[name]
       if (!route) throw new Error(\`Route [\${name}] not defined.\`)

--- a/packages/cli/src/routes-types-fragments.ts
+++ b/packages/cli/src/routes-types-fragments.ts
@@ -93,12 +93,18 @@ export function route<TName extends RouteName>(name: TName, ...args: RouteArgs<T
 }
 `
 
-/** Runtime utility functions used by the `route()` helper. */
-export const RUNTIME_UTILITY_FUNCTIONS = `\
-function hasPathParams(path: string): boolean {
-  return /:[A-Za-z0-9_-]+/u.test(path)
-}
-
+/**
+ * The runtime half of the path-param rule: how a bound key is substituted
+ * into the path. Token-based — whole `:param` tokens are replaced by key
+ * lookup — so a param whose name is a prefix of another (`:id` vs
+ * `:identifier`) can never corrupt it, and a key the path lacks really is a
+ * no-op. A per-key `path.replace(':key', ...)` loop has neither property;
+ * that spelling is what this fragment exists to keep out of the generators.
+ *
+ * Mirrored verbatim in @guren/inertia-client's components.tsx alongside
+ * PATH_PARAM_TYPE_HELPERS, under the same pin test.
+ */
+export const PATH_PARAM_RUNTIME_HELPERS = `\
 function substituteParams(path: string, params?: Record<string, string | number>): string {
   if (!params) {
     return path
@@ -112,7 +118,15 @@ function substituteParams(path: string, params?: Record<string, string | number>
     return encodeURIComponent(String(params[key]))
   })
 }
+`
 
+/** Runtime utility functions used by the `route()` helper. */
+export const RUNTIME_UTILITY_FUNCTIONS = `\
+function hasPathParams(path: string): boolean {
+  return /:[A-Za-z0-9_-]+/u.test(path)
+}
+
+${PATH_PARAM_RUNTIME_HELPERS}
 function appendQueryString(path: string, query?: RouteQuery): string {
   if (!query) {
     return path

--- a/packages/cli/src/routes-types-fragments.ts
+++ b/packages/cli/src/routes-types-fragments.ts
@@ -28,16 +28,19 @@ declare module '@inertiajs/core' {
 `
 
 /**
- * Param-key extraction from a route path literal.
+ * The path-param rule, from key extraction down to the derived shapes: which
+ * keys a route path literal binds, whether it binds any, and the params
+ * object they form.
  *
- * Emitted into every generated module that answers "does this path take
- * params?" — the route manifest and the API client — so they all derive the
- * answer from the path string the server routes on, not from whatever shape
- * their generator happens to emit alongside it.
+ * Emitted into every generated module that answers those questions — the
+ * route manifest and the API client — so they all derive the answers from
+ * the path string the server routes on, not from whatever shape their
+ * generator happens to emit alongside it.
  *
- * `ExtractParams` in @guren/inertia-client's components.tsx spells the same
- * rule for library code that cannot embed an emitted fragment; keep the two
- * in lockstep.
+ * @guren/inertia-client's components.tsx carries the same rule for library
+ * code that cannot embed an emitted fragment; routes-types-fragments.test.ts
+ * asserts it contains this fragment verbatim, so a change here fails there
+ * until both move.
  */
 export const PATH_PARAM_TYPE_HELPERS = `\
 type NormalizeParamKey<TValue extends string> = TValue extends \`\${infer Key}?\` ? Key : TValue
@@ -47,6 +50,11 @@ type PathParamKeys<TPath extends string> =
     : TPath extends \`\${string}:\${infer Param}\`
       ? NormalizeParamKey<Param>
       : never
+type HasPathParams<TPath extends string> = [PathParamKeys<TPath>] extends [never] ? false : true
+type PathParamsOf<TPath extends string> =
+  HasPathParams<TPath> extends false
+    ? Record<string, never>
+    : { [TKey in PathParamKeys<TPath>]: string | number }
 `
 
 /** Type definitions emitted after the route manifest object. */
@@ -61,13 +69,10 @@ type QueryValue = PrimitiveQueryValue | readonly PrimitiveQueryValue[]
 export type RouteQuery = Record<string, QueryValue>
 
 ${PATH_PARAM_TYPE_HELPERS}
-export type RouteParams<TName extends RouteName> =
-  [PathParamKeys<RouteManifest[TName]['path']>] extends [never]
-    ? Record<string, never>
-    : { [TKey in PathParamKeys<RouteManifest[TName]['path']>]: string | number }
+export type RouteParams<TName extends RouteName> = PathParamsOf<RouteManifest[TName]['path']>
 
 type RouteArgs<TName extends RouteName> =
-  [PathParamKeys<RouteManifest[TName]['path']>] extends [never]
+  HasPathParams<RouteManifest[TName]['path']> extends false
     ? [query?: RouteQuery]
     : [params: RouteParams<TName>, query?: RouteQuery]
 `

--- a/packages/cli/src/routes-types-fragments.ts
+++ b/packages/cli/src/routes-types-fragments.ts
@@ -27,6 +27,28 @@ declare module '@inertiajs/core' {
 }
 `
 
+/**
+ * Param-key extraction from a route path literal.
+ *
+ * Emitted into every generated module that answers "does this path take
+ * params?" — the route manifest and the API client — so they all derive the
+ * answer from the path string the server routes on, not from whatever shape
+ * their generator happens to emit alongside it.
+ *
+ * `ExtractParams` in @guren/inertia-client's components.tsx spells the same
+ * rule for library code that cannot embed an emitted fragment; keep the two
+ * in lockstep.
+ */
+export const PATH_PARAM_TYPE_HELPERS = `\
+type NormalizeParamKey<TValue extends string> = TValue extends \`\${infer Key}?\` ? Key : TValue
+type PathParamKeys<TPath extends string> =
+  TPath extends \`\${string}:\${infer Param}/\${infer Rest}\`
+    ? NormalizeParamKey<Param> | PathParamKeys<\`/\${Rest}\`>
+    : TPath extends \`\${string}:\${infer Param}\`
+      ? NormalizeParamKey<Param>
+      : never
+`
+
 /** Type definitions emitted after the route manifest object. */
 export const RUNTIME_TYPE_DEFINITIONS = `\
 export type RouteManifest = typeof routeManifest
@@ -38,14 +60,7 @@ type PrimitiveQueryValue = string | number | boolean | null | undefined
 type QueryValue = PrimitiveQueryValue | readonly PrimitiveQueryValue[]
 export type RouteQuery = Record<string, QueryValue>
 
-type NormalizeParamKey<TValue extends string> = TValue extends \`\${infer Key}?\` ? Key : TValue
-type PathParamKeys<TPath extends string> =
-  TPath extends \`\${string}:\${infer Param}/\${infer Rest}\`
-    ? NormalizeParamKey<Param> | PathParamKeys<\`/\${Rest}\`>
-    : TPath extends \`\${string}:\${infer Param}\`
-      ? NormalizeParamKey<Param>
-      : never
-
+${PATH_PARAM_TYPE_HELPERS}
 export type RouteParams<TName extends RouteName> =
   [PathParamKeys<RouteManifest[TName]['path']>] extends [never]
     ? Record<string, never>

--- a/packages/cli/tests/api-client-types.test.ts
+++ b/packages/cli/tests/api-client-types.test.ts
@@ -16,7 +16,10 @@ const definitions: RouteDefinitionLike[] = [
     method: 'QUERY',
     path: '/posts/search',
     name: 'posts.search',
-    schemas: { body: z.object({ keywords: z.array(z.string()) }) },
+    schemas: {
+      body: z.object({ keywords: z.array(z.string()) }),
+      output: z.object({ data: z.array(z.object({ id: z.number(), title: z.string() })) }),
+    },
   },
 ]
 
@@ -74,14 +77,36 @@ void client.request('posts.missing')
 // @ts-expect-error a bound body schema types the payload
 void client.request('posts.search', { body: { keywords: 'guren' } })
 
+// A bound output schema types json(); without one it stays unknown.
+export const searchResults: { data: Array<{ id: number; title: string }> } =
+  await (await client.request('posts.search', { body: { keywords: ['guren'] } })).json()
+
+// @ts-expect-error routes without an output schema parse to unknown
+export const untypedResults: { data: unknown[] } = await (await client.request('posts.index')).json()
+
+// A union route name must stay callable in the way that is safe for every
+// member: params are required whenever any member's path has them.
+declare const eitherRoute: 'posts.index' | 'posts.show'
+void client.request(eitherRoute, { params: { id: 1 } })
+
+// @ts-expect-error a union name requires the params its members need
+void client.request(eitherRoute)
+
+// @ts-expect-error empty params must not satisfy a union name either
+void client.request(eitherRoute, { params: {} })
+
 export const indexOptions: ApiRequestOptions<'posts.index'> = {}
 export const showOptions: ApiRequestOptions<'posts.show'> = { params: { id: 1 } }
+export const unionOptions: ApiRequestOptions<'posts.index' | 'posts.show'> = { params: { id: 1 } }
 
 // @ts-expect-error param-less routes reject a params member
 export const paramsRejected: ApiRequestOptions<'posts.index'> = { params: {} }
 
 // @ts-expect-error a route with path params requires them here too
 export const paramsRequired: ApiRequestOptions<'posts.show'> = {}
+
+// @ts-expect-error the union options type requires every member's params
+export const unionParamsRequired: ApiRequestOptions<'posts.index' | 'posts.show'> = {}
 `
 
 const compilerOptions: ts.CompilerOptions = {

--- a/packages/cli/tests/api-client-types.test.ts
+++ b/packages/cli/tests/api-client-types.test.ts
@@ -84,6 +84,12 @@ export const searchResults: { data: Array<{ id: number; title: string }> } =
 // @ts-expect-error routes without an output schema parse to unknown
 export const untypedResults: { data: unknown[] } = await (await client.request('posts.index')).json()
 
+// The assignability probe above would also pass if json() regressed to \`any\`
+// (or \`never\`) — this one would not: both make the directive unused (TS2578).
+// @ts-expect-error the typed json() rejects a mismatched shape
+export const mismatchedResults: { data: Array<{ id: string }> } =
+  await (await client.request('posts.search', { body: { keywords: ['guren'] } })).json()
+
 // A union route name must stay callable in the way that is safe for every
 // member: params are required whenever any member's path has them.
 declare const eitherRoute: 'posts.index' | 'posts.show'

--- a/packages/cli/tests/api-client-types.test.ts
+++ b/packages/cli/tests/api-client-types.test.ts
@@ -9,6 +9,9 @@ import { checkTypes, COLD_TSC_TIMEOUT } from './helpers'
 import { buildApiClientContent, type RouteDefinitionLike } from '../src/api-client-types'
 
 const definitions: RouteDefinitionLike[] = [
+  // ':identifier' has ':id' as a prefix — the substitution suite below feeds
+  // both keys at once, the exact shape a union route name produces.
+  { method: 'GET', path: '/library/:identifier', name: 'library.show' },
   { method: 'GET', path: '/posts', name: 'posts.index' },
   { method: 'GET', path: '/posts/:id', name: 'posts.show' },
   { method: 'POST', path: '/posts', name: 'posts.store' },
@@ -154,7 +157,12 @@ describe('generated createApiClient', () => {
     baseUrl: string
     headers?: Record<string, string>
     credentials?: RequestCredentials
-  }) => { request: (name: string, options?: { body?: unknown }) => Promise<Response> }
+  }) => {
+    request: (
+      name: string,
+      options?: { params?: Record<string, string | number>; body?: unknown },
+    ) => Promise<Response>
+  }
 
   const PAGE_ORIGIN = 'http://localhost:3000'
   const originalFetch = globalThis.fetch
@@ -220,6 +228,20 @@ describe('generated createApiClient', () => {
     await createApiClient({ baseUrl: PAGE_ORIGIN }).request('posts.store', { body: {} })
 
     expect(headersOf(calls[0]!.init)['X-XSRF-TOKEN']).toBe('right')
+  })
+
+  // A union route name requires every member's params, so request() gets
+  // handed keys the selected path does not bind. Token-based substitution
+  // keeps those a no-op — a per-key replace loop would let the ':id' pass
+  // corrupt '/library/:identifier' into '/library/1entifier' before
+  // ':identifier' could ever match.
+  it('substitutes whole param tokens, so extra or prefix-colliding keys cannot corrupt the path', async () => {
+    const { calls } = stubFetch()
+    browsingAt(PAGE_ORIGIN, 'XSRF-TOKEN=abc')
+
+    await createApiClient({ baseUrl: PAGE_ORIGIN }).request('library.show', { params: { id: 1, identifier: 2 } })
+
+    expect(calls[0]!.url).toBe(`${PAGE_ORIGIN}/library/2`)
   })
 
   it('omits the header on safe methods', async () => {

--- a/packages/cli/tests/routes-types-fragments.test.ts
+++ b/packages/cli/tests/routes-types-fragments.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { PATH_PARAM_TYPE_HELPERS } from '../src/routes-types-fragments'
+
+describe('PATH_PARAM_TYPE_HELPERS', () => {
+  // @guren/inertia-client ships as a library, so it cannot embed the emitted
+  // fragment — it carries a hand-written mirror instead. Nothing at compile
+  // time can see the two drift apart (each side type-checks on its own), so
+  // the mirror is pinned to the fragment's exact text: a change to the rule
+  // fails here until both spellings move together.
+  it('is mirrored verbatim by @guren/inertia-client components.tsx', async () => {
+    const componentsSource = await readFile(
+      join(import.meta.dir, '../../inertia-client/src/components.tsx'),
+      'utf8',
+    )
+
+    expect(componentsSource).toContain(PATH_PARAM_TYPE_HELPERS)
+  })
+})

--- a/packages/cli/tests/routes-types-fragments.test.ts
+++ b/packages/cli/tests/routes-types-fragments.test.ts
@@ -1,19 +1,24 @@
 import { describe, expect, it } from 'bun:test'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { PATH_PARAM_TYPE_HELPERS } from '../src/routes-types-fragments'
+import { PATH_PARAM_RUNTIME_HELPERS, PATH_PARAM_TYPE_HELPERS } from '../src/routes-types-fragments'
 
-describe('PATH_PARAM_TYPE_HELPERS', () => {
-  // The mirror exists because a shipped library cannot embed an emitted
+describe('path-param fragments', () => {
+  // The mirrors exist because a shipped library cannot embed an emitted
   // fragment (the PATH_PARAM_TYPE_HELPERS JSDoc has the full story). Each
   // side type-checks on its own, so only this exact-text pin sees drift: a
-  // change to the rule fails here until both spellings move together.
-  it('is mirrored verbatim by @guren/inertia-client components.tsx', async () => {
-    const componentsSource = await readFile(
-      join(import.meta.dir, '../../inertia-client/src/components.tsx'),
-      'utf8',
-    )
+  // change to either rule fails here until both spellings move together.
+  for (const [name, fragment] of [
+    ['PATH_PARAM_TYPE_HELPERS', PATH_PARAM_TYPE_HELPERS],
+    ['PATH_PARAM_RUNTIME_HELPERS', PATH_PARAM_RUNTIME_HELPERS],
+  ] as const) {
+    it(`${name} is mirrored verbatim by @guren/inertia-client components.tsx`, async () => {
+      const componentsSource = await readFile(
+        join(import.meta.dir, '../../inertia-client/src/components.tsx'),
+        'utf8',
+      )
 
-    expect(componentsSource).toContain(PATH_PARAM_TYPE_HELPERS)
-  })
+      expect(componentsSource).toContain(fragment)
+    })
+  }
 })

--- a/packages/cli/tests/routes-types-fragments.test.ts
+++ b/packages/cli/tests/routes-types-fragments.test.ts
@@ -4,11 +4,10 @@ import { join } from 'node:path'
 import { PATH_PARAM_TYPE_HELPERS } from '../src/routes-types-fragments'
 
 describe('PATH_PARAM_TYPE_HELPERS', () => {
-  // @guren/inertia-client ships as a library, so it cannot embed the emitted
-  // fragment — it carries a hand-written mirror instead. Nothing at compile
-  // time can see the two drift apart (each side type-checks on its own), so
-  // the mirror is pinned to the fragment's exact text: a change to the rule
-  // fails here until both spellings move together.
+  // The mirror exists because a shipped library cannot embed an emitted
+  // fragment (the PATH_PARAM_TYPE_HELPERS JSDoc has the full story). Each
+  // side type-checks on its own, so only this exact-text pin sees drift: a
+  // change to the rule fails here until both spellings move together.
   it('is mirrored verbatim by @guren/inertia-client components.tsx', async () => {
     const componentsSource = await readFile(
       join(import.meta.dir, '../../inertia-client/src/components.tsx'),

--- a/packages/create-app/templates/blog/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/blog/.guren/api-client.gen.ts
@@ -132,6 +132,13 @@ type RequestOptionsOf<TRoute extends { path: string }> =
     ? { params?: never; body?: BodyOf<TRoute>; query?: Record<string, unknown> }
     : { params: PathParamsOf<TRoute['path']>; body?: BodyOf<TRoute>; query?: Record<string, unknown> }
 
+// Param-less routes may omit the options argument entirely; the same
+// predicate that shapes the options decides the arity.
+type RequestArgsOf<TRoute extends { path: string }> =
+  HasPathParams<TRoute['path']> extends false
+    ? [options?: RequestOptionsOf<TRoute>]
+    : [options: RequestOptionsOf<TRoute>]
+
 export type ApiRequestOptions<T extends ApiRouteName> = RequestOptionsOf<ApiRoutes[T]>
 
 // The wire contract these mirror is owned by Guren's CSRF middleware: it
@@ -223,9 +230,7 @@ export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method
   return {
     async request<TName extends keyof TRoutes & string>(
       name: TName,
-      ...args: HasPathParams<TRoutes[TName]['path']> extends false
-        ? [options?: RequestOptionsOf<TRoutes[TName]>]
-        : [options: RequestOptionsOf<TRoutes[TName]>]
+      ...args: RequestArgsOf<TRoutes[TName]>
     ): Promise<TypedResponse<ResponseOf<TRoutes[TName]>>> {
       const route = (routes as Record<string, { method: string; path: string }>)[name]
       if (!route) throw new Error(`Route [${name}] not defined.`)

--- a/packages/create-app/templates/blog/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/blog/.guren/api-client.gen.ts
@@ -8,95 +8,80 @@
  * `body` is the *request* shape — what you send. Coercing schemas are rendered
  * as they travel: `z.coerce.date()` is a `string` here, not the `Date` the
  * controller ends up with. `response` is the parsed shape you get back.
+ * Params are not stored on the entries: they are derived from each entry's
+ * `path` literal, the same string the server routes on.
  */
 export interface ApiRoutes {
   'dashboard': {
     method: 'GET'
     path: '/dashboard'
-    params: Record<string, never>
   }
   'home': {
     method: 'GET'
     path: '/'
-    params: Record<string, never>
   }
   'login': {
     method: 'GET'
     path: '/login'
-    params: Record<string, never>
   }
   'login.store': {
     method: 'POST'
     path: '/login'
-    params: Record<string, never>
   }
   'logout': {
     method: 'POST'
     path: '/logout'
-    params: Record<string, never>
   }
   'posts.create': {
     method: 'GET'
     path: '/posts/create'
-    params: Record<string, never>
   }
   'posts.destroy': {
     method: 'DELETE'
     path: '/posts/:id'
-    params: { id: string | number }
   }
   'posts.edit': {
     method: 'GET'
     path: '/posts/:id/edit'
-    params: { id: string | number }
   }
   'posts.index': {
     method: 'GET'
     path: '/posts'
-    params: Record<string, never>
   }
   'posts.search': {
     method: 'QUERY'
     path: '/posts/search'
-    params: Record<string, never>
     body: { keywords: string[]; limit?: number }
   }
   'posts.show': {
     method: 'GET'
     path: '/posts/:id'
-    params: { id: string | number }
   }
   'posts.store': {
     method: 'POST'
     path: '/posts'
-    params: Record<string, never>
     body: { title: string; excerpt: string; body: string }
   }
   'posts.update': {
     method: 'PUT'
     path: '/posts/:id'
-    params: { id: string | number }
     body: { title: string; excerpt: string; body: string }
   }
   'profile.edit': {
     method: 'GET'
     path: '/profile'
-    params: Record<string, never>
   }
   'profile.update': {
     method: 'PUT'
     path: '/profile'
-    params: Record<string, never>
   }
   'register': {
     method: 'GET'
     path: '/register'
-    params: Record<string, never>
   }
   'register.store': {
     method: 'POST'
     path: '/register'
-    params: Record<string, never>
   }
 }
 
@@ -104,20 +89,48 @@ export type ApiRouteName = keyof ApiRoutes
 
 export type ApiRouteMethod<T extends ApiRouteName> = ApiRoutes[T]['method']
 export type ApiRoutePath<T extends ApiRouteName> = ApiRoutes[T]['path']
-export type ApiRouteParams<T extends ApiRouteName> = ApiRoutes[T]['params']
 
-// Param-less routes are emitted as `params: Record<string, never>`, whose
-// `keyof` is `string` — so this compares against that shape, not against
-// `never`. The one predicate serves both `ApiRequestOptions` and `request()`
-// below; keep them on it, or a fix lands in one spelling and not the other.
-type HasBoundParams<TParams> = TParams extends Record<string, never> ? false : true
+type NormalizeParamKey<TValue extends string> = TValue extends `${infer Key}?` ? Key : TValue
+type PathParamKeys<TPath extends string> =
+  TPath extends `${string}:${infer Param}/${infer Rest}`
+    ? NormalizeParamKey<Param> | PathParamKeys<`/${Rest}`>
+    : TPath extends `${string}:${infer Param}`
+      ? NormalizeParamKey<Param>
+      : never
+
+// Both derive from the path literal, so nothing about how the entries above
+// are emitted can silently flip `request()`'s call arity. Deliberately not
+// distributed over a union route name: the union of paths yields the union of
+// their param keys, so an un-narrowed name requires every member's params —
+// substituting a param a member's path lacks is a runtime no-op, while the
+// reverse (accepting one member's empty params) would send a path with its
+// `:param` unresolved. The one pair serves both `ApiRequestOptions` and
+// `request()` below; keep them on it, or a fix lands in one spelling and not
+// the other.
+type PathParamsOf<TPath extends string> =
+  [PathParamKeys<TPath>] extends [never]
+    ? Record<string, never>
+    : { [TKey in PathParamKeys<TPath>]: string | number }
+type HasPathParams<TPath extends string> = [PathParamKeys<TPath>] extends [never] ? false : true
+
+export type ApiRouteParams<T extends ApiRouteName> = PathParamsOf<ApiRoutePath<T>>
 
 // The request body type a route declares through its bound schema — `unknown`
 // for routes without one.
 type BodyOf<TRoute> = TRoute extends { body: infer TBody } ? TBody : unknown
 
+// The parsed shape a route declares through its bound output schema —
+// `unknown` for routes without one.
+type ResponseOf<TRoute> = TRoute extends { response: infer TResponse } ? TResponse : unknown
+
+// The runtime object is the plain fetch `Response`; only `json()` is narrowed
+// to the route's declared response shape.
+export interface TypedResponse<TData> extends Response {
+  json(): Promise<TData>
+}
+
 export type ApiRequestOptions<T extends ApiRouteName> =
-  HasBoundParams<ApiRouteParams<T>> extends false
+  HasPathParams<ApiRoutePath<T>> extends false
     ? { params?: never; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
     : { params: ApiRouteParams<T>; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
 
@@ -185,7 +198,10 @@ function isSameOrigin(url: string): boolean {
  * `'include'` cross-origin, with a CORS setup that allows it).
  *
  * Routes that bind a `body` schema type the `body` option with that schema's
- * request shape; routes without one accept `unknown`.
+ * request shape; routes without one accept `unknown`. Routes that bind an
+ * `output` schema type the response: `json()` on the returned `Response`
+ * resolves to that schema's parsed shape. Without one it resolves to
+ * `unknown` — validate before trusting it.
  *
  * @example
  * ```typescript
@@ -199,16 +215,16 @@ function isSameOrigin(url: string): boolean {
 // The mapped-object constraint (rather than `Record<...>`) is what lets the
 // generated `ApiRoutes` interface satisfy it — interfaces have no implicit
 // index signature, so `Record<string, ...>` would reject them.
-export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method: string; path: string; params: unknown } }>(
+export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method: string; path: string } }>(
   config: { baseUrl: string; headers?: Record<string, string>; credentials?: RequestInit['credentials'] },
 ) {
   return {
     async request<TName extends keyof TRoutes & string>(
       name: TName,
-      ...args: HasBoundParams<TRoutes[TName]['params']> extends false
+      ...args: HasPathParams<TRoutes[TName]['path']> extends false
         ? [options?: { params?: never; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
-        : [options: { params: TRoutes[TName]['params']; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
-    ): Promise<Response> {
+        : [options: { params: PathParamsOf<TRoutes[TName]['path']>; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
+    ): Promise<TypedResponse<ResponseOf<TRoutes[TName]>>> {
       const route = (routes as Record<string, { method: string; path: string }>)[name]
       if (!route) throw new Error(`Route [${name}] not defined.`)
 

--- a/packages/create-app/templates/blog/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/blog/.guren/api-client.gen.ts
@@ -201,7 +201,9 @@ function isSameOrigin(url: string): boolean {
  * request shape; routes without one accept `unknown`. Routes that bind an
  * `output` schema type the response: `json()` on the returned `Response`
  * resolves to that schema's parsed shape. Without one it resolves to
- * `unknown` — validate before trusting it.
+ * `unknown` — validate before trusting it. Either way the typed shape
+ * describes the success body only: error statuses carry their own (a 422
+ * from validation is `{ errors: ... }`), so check `ok` before reading it.
  *
  * @example
  * ```typescript

--- a/packages/create-app/templates/blog/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/blog/.guren/api-client.gen.ts
@@ -221,6 +221,25 @@ function isSameOrigin(url: string): boolean {
  * const post = await client.request('posts.show', { params: { id: 1 } })
  * ```
  */
+// Token-based substitution shared with the route manifest module: whole
+// `:param` tokens are replaced by key lookup, so a key the path lacks is a
+// true no-op — the property the union-name rule above relies on — and a
+// param name that prefixes another (`:id` vs `:identifier`) cannot corrupt
+// it the way a per-key `path.replace(':key', ...)` loop would.
+function substituteParams(path: string, params?: Record<string, string | number>): string {
+  if (!params) {
+    return path
+  }
+
+  return path.replace(/:([A-Za-z0-9_-]+)/gu, (match, key) => {
+    if (!Object.prototype.hasOwnProperty.call(params, key)) {
+      return match
+    }
+
+    return encodeURIComponent(String(params[key]))
+  })
+}
+
 // The mapped-object constraint (rather than `Record<...>`) is what lets the
 // generated `ApiRoutes` interface satisfy it — interfaces have no implicit
 // index signature, so `Record<string, ...>` would reject them.
@@ -235,13 +254,8 @@ export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method
       const route = (routes as Record<string, { method: string; path: string }>)[name]
       if (!route) throw new Error(`Route [${name}] not defined.`)
 
-      const opts = (args as unknown[])[0] as { params?: Record<string, unknown>; body?: unknown; query?: Record<string, unknown> } | undefined
-      let path = route.path
-      if (opts?.params) {
-        for (const [key, value] of Object.entries(opts.params)) {
-          path = path.replace(`:${key}`, encodeURIComponent(String(value)))
-        }
-      }
+      const opts = (args as unknown[])[0] as { params?: Record<string, string | number>; body?: unknown; query?: Record<string, unknown> } | undefined
+      const path = substituteParams(route.path, opts?.params)
 
       let url = `${config.baseUrl}${path}`
       if (opts?.query) {

--- a/packages/create-app/templates/blog/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/blog/.guren/api-client.gen.ts
@@ -97,21 +97,11 @@ type PathParamKeys<TPath extends string> =
     : TPath extends `${string}:${infer Param}`
       ? NormalizeParamKey<Param>
       : never
-
-// Both derive from the path literal, so nothing about how the entries above
-// are emitted can silently flip `request()`'s call arity. Deliberately not
-// distributed over a union route name: the union of paths yields the union of
-// their param keys, so an un-narrowed name requires every member's params —
-// substituting a param a member's path lacks is a runtime no-op, while the
-// reverse (accepting one member's empty params) would send a path with its
-// `:param` unresolved. The one pair serves both `ApiRequestOptions` and
-// `request()` below; keep them on it, or a fix lands in one spelling and not
-// the other.
+type HasPathParams<TPath extends string> = [PathParamKeys<TPath>] extends [never] ? false : true
 type PathParamsOf<TPath extends string> =
-  [PathParamKeys<TPath>] extends [never]
+  HasPathParams<TPath> extends false
     ? Record<string, never>
     : { [TKey in PathParamKeys<TPath>]: string | number }
-type HasPathParams<TPath extends string> = [PathParamKeys<TPath>] extends [never] ? false : true
 
 export type ApiRouteParams<T extends ApiRouteName> = PathParamsOf<ApiRoutePath<T>>
 
@@ -129,10 +119,20 @@ export interface TypedResponse<TData> extends Response {
   json(): Promise<TData>
 }
 
-export type ApiRequestOptions<T extends ApiRouteName> =
-  HasPathParams<ApiRoutePath<T>> extends false
-    ? { params?: never; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
-    : { params: ApiRouteParams<T>; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
+// Params derive from the path literal, so nothing about how the entries above
+// are emitted can silently flip `request()`'s call arity. Deliberately not
+// distributed over a union route name (the conditional checks
+// `HasPathParams<...>`, never a bare type parameter): the union of paths
+// yields the union of their param keys, so an un-narrowed name requires every
+// member's params — substituting a param a member's path lacks is a runtime
+// no-op, while the reverse (accepting one member's empty params) would send a
+// path with its `:param` unresolved.
+type RequestOptionsOf<TRoute extends { path: string }> =
+  HasPathParams<TRoute['path']> extends false
+    ? { params?: never; body?: BodyOf<TRoute>; query?: Record<string, unknown> }
+    : { params: PathParamsOf<TRoute['path']>; body?: BodyOf<TRoute>; query?: Record<string, unknown> }
+
+export type ApiRequestOptions<T extends ApiRouteName> = RequestOptionsOf<ApiRoutes[T]>
 
 // The wire contract these mirror is owned by Guren's CSRF middleware: it
 // writes the XSRF-TOKEN cookie and reads either header name. Change them
@@ -222,8 +222,8 @@ export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method
     async request<TName extends keyof TRoutes & string>(
       name: TName,
       ...args: HasPathParams<TRoutes[TName]['path']> extends false
-        ? [options?: { params?: never; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
-        : [options: { params: PathParamsOf<TRoutes[TName]['path']>; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
+        ? [options?: RequestOptionsOf<TRoutes[TName]>]
+        : [options: RequestOptionsOf<TRoutes[TName]>]
     ): Promise<TypedResponse<ResponseOf<TRoutes[TName]>>> {
       const route = (routes as Record<string, { method: string; path: string }>)[name]
       if (!route) throw new Error(`Route [${name}] not defined.`)

--- a/packages/create-app/templates/blog/.guren/routes.gen.ts
+++ b/packages/create-app/templates/blog/.guren/routes.gen.ts
@@ -37,14 +37,16 @@ type PathParamKeys<TPath extends string> =
     : TPath extends `${string}:${infer Param}`
       ? NormalizeParamKey<Param>
       : never
-
-export type RouteParams<TName extends RouteName> =
-  [PathParamKeys<RouteManifest[TName]['path']>] extends [never]
+type HasPathParams<TPath extends string> = [PathParamKeys<TPath>] extends [never] ? false : true
+type PathParamsOf<TPath extends string> =
+  HasPathParams<TPath> extends false
     ? Record<string, never>
-    : { [TKey in PathParamKeys<RouteManifest[TName]['path']>]: string | number }
+    : { [TKey in PathParamKeys<TPath>]: string | number }
+
+export type RouteParams<TName extends RouteName> = PathParamsOf<RouteManifest[TName]['path']>
 
 type RouteArgs<TName extends RouteName> =
-  [PathParamKeys<RouteManifest[TName]['path']>] extends [never]
+  HasPathParams<RouteManifest[TName]['path']> extends false
     ? [query?: RouteQuery]
     : [params: RouteParams<TName>, query?: RouteQuery]
 

--- a/packages/create-app/templates/blog/resources/js/pages/posts/Index.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/posts/Index.tsx
@@ -37,6 +37,8 @@ export default function PostsIndex({ data, pagination }: Props) {
         setError('Search failed — try fewer or shorter keywords.')
         return
       }
+      // The route binds no `output` schema, so json() resolves to unknown and
+      // the shape is asserted here. Bind one to have codegen type json() itself.
       const payload = (await response.json()) as { data: PostResourceData[] }
       setResults(payload.data)
     } catch {

--- a/packages/create-app/templates/default/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/default/.guren/api-client.gen.ts
@@ -151,6 +151,25 @@ function isSameOrigin(url: string): boolean {
  * const post = await client.request('posts.show', { params: { id: 1 } })
  * ```
  */
+// Token-based substitution shared with the route manifest module: whole
+// `:param` tokens are replaced by key lookup, so a key the path lacks is a
+// true no-op — the property the union-name rule above relies on — and a
+// param name that prefixes another (`:id` vs `:identifier`) cannot corrupt
+// it the way a per-key `path.replace(':key', ...)` loop would.
+function substituteParams(path: string, params?: Record<string, string | number>): string {
+  if (!params) {
+    return path
+  }
+
+  return path.replace(/:([A-Za-z0-9_-]+)/gu, (match, key) => {
+    if (!Object.prototype.hasOwnProperty.call(params, key)) {
+      return match
+    }
+
+    return encodeURIComponent(String(params[key]))
+  })
+}
+
 // The mapped-object constraint (rather than `Record<...>`) is what lets the
 // generated `ApiRoutes` interface satisfy it — interfaces have no implicit
 // index signature, so `Record<string, ...>` would reject them.
@@ -165,13 +184,8 @@ export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method
       const route = (routes as Record<string, { method: string; path: string }>)[name]
       if (!route) throw new Error(`Route [${name}] not defined.`)
 
-      const opts = (args as unknown[])[0] as { params?: Record<string, unknown>; body?: unknown; query?: Record<string, unknown> } | undefined
-      let path = route.path
-      if (opts?.params) {
-        for (const [key, value] of Object.entries(opts.params)) {
-          path = path.replace(`:${key}`, encodeURIComponent(String(value)))
-        }
-      }
+      const opts = (args as unknown[])[0] as { params?: Record<string, string | number>; body?: unknown; query?: Record<string, unknown> } | undefined
+      const path = substituteParams(route.path, opts?.params)
 
       let url = `${config.baseUrl}${path}`
       if (opts?.query) {

--- a/packages/create-app/templates/default/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/default/.guren/api-client.gen.ts
@@ -8,6 +8,8 @@
  * `body` is the *request* shape — what you send. Coercing schemas are rendered
  * as they travel: `z.coerce.date()` is a `string` here, not the `Date` the
  * controller ends up with. `response` is the parsed shape you get back.
+ * Params are not stored on the entries: they are derived from each entry's
+ * `path` literal, the same string the server routes on.
  */
 export interface ApiRoutes {
   // No named routes found
@@ -17,20 +19,48 @@ export type ApiRouteName = keyof ApiRoutes
 
 export type ApiRouteMethod<T extends ApiRouteName> = ApiRoutes[T]['method']
 export type ApiRoutePath<T extends ApiRouteName> = ApiRoutes[T]['path']
-export type ApiRouteParams<T extends ApiRouteName> = ApiRoutes[T]['params']
 
-// Param-less routes are emitted as `params: Record<string, never>`, whose
-// `keyof` is `string` — so this compares against that shape, not against
-// `never`. The one predicate serves both `ApiRequestOptions` and `request()`
-// below; keep them on it, or a fix lands in one spelling and not the other.
-type HasBoundParams<TParams> = TParams extends Record<string, never> ? false : true
+type NormalizeParamKey<TValue extends string> = TValue extends `${infer Key}?` ? Key : TValue
+type PathParamKeys<TPath extends string> =
+  TPath extends `${string}:${infer Param}/${infer Rest}`
+    ? NormalizeParamKey<Param> | PathParamKeys<`/${Rest}`>
+    : TPath extends `${string}:${infer Param}`
+      ? NormalizeParamKey<Param>
+      : never
+
+// Both derive from the path literal, so nothing about how the entries above
+// are emitted can silently flip `request()`'s call arity. Deliberately not
+// distributed over a union route name: the union of paths yields the union of
+// their param keys, so an un-narrowed name requires every member's params —
+// substituting a param a member's path lacks is a runtime no-op, while the
+// reverse (accepting one member's empty params) would send a path with its
+// `:param` unresolved. The one pair serves both `ApiRequestOptions` and
+// `request()` below; keep them on it, or a fix lands in one spelling and not
+// the other.
+type PathParamsOf<TPath extends string> =
+  [PathParamKeys<TPath>] extends [never]
+    ? Record<string, never>
+    : { [TKey in PathParamKeys<TPath>]: string | number }
+type HasPathParams<TPath extends string> = [PathParamKeys<TPath>] extends [never] ? false : true
+
+export type ApiRouteParams<T extends ApiRouteName> = PathParamsOf<ApiRoutePath<T>>
 
 // The request body type a route declares through its bound schema — `unknown`
 // for routes without one.
 type BodyOf<TRoute> = TRoute extends { body: infer TBody } ? TBody : unknown
 
+// The parsed shape a route declares through its bound output schema —
+// `unknown` for routes without one.
+type ResponseOf<TRoute> = TRoute extends { response: infer TResponse } ? TResponse : unknown
+
+// The runtime object is the plain fetch `Response`; only `json()` is narrowed
+// to the route's declared response shape.
+export interface TypedResponse<TData> extends Response {
+  json(): Promise<TData>
+}
+
 export type ApiRequestOptions<T extends ApiRouteName> =
-  HasBoundParams<ApiRouteParams<T>> extends false
+  HasPathParams<ApiRoutePath<T>> extends false
     ? { params?: never; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
     : { params: ApiRouteParams<T>; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
 
@@ -98,7 +128,10 @@ function isSameOrigin(url: string): boolean {
  * `'include'` cross-origin, with a CORS setup that allows it).
  *
  * Routes that bind a `body` schema type the `body` option with that schema's
- * request shape; routes without one accept `unknown`.
+ * request shape; routes without one accept `unknown`. Routes that bind an
+ * `output` schema type the response: `json()` on the returned `Response`
+ * resolves to that schema's parsed shape. Without one it resolves to
+ * `unknown` — validate before trusting it.
  *
  * @example
  * ```typescript
@@ -112,16 +145,16 @@ function isSameOrigin(url: string): boolean {
 // The mapped-object constraint (rather than `Record<...>`) is what lets the
 // generated `ApiRoutes` interface satisfy it — interfaces have no implicit
 // index signature, so `Record<string, ...>` would reject them.
-export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method: string; path: string; params: unknown } }>(
+export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method: string; path: string } }>(
   config: { baseUrl: string; headers?: Record<string, string>; credentials?: RequestInit['credentials'] },
 ) {
   return {
     async request<TName extends keyof TRoutes & string>(
       name: TName,
-      ...args: HasBoundParams<TRoutes[TName]['params']> extends false
+      ...args: HasPathParams<TRoutes[TName]['path']> extends false
         ? [options?: { params?: never; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
-        : [options: { params: TRoutes[TName]['params']; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
-    ): Promise<Response> {
+        : [options: { params: PathParamsOf<TRoutes[TName]['path']>; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
+    ): Promise<TypedResponse<ResponseOf<TRoutes[TName]>>> {
       const route = (routes as Record<string, { method: string; path: string }>)[name]
       if (!route) throw new Error(`Route [${name}] not defined.`)
 

--- a/packages/create-app/templates/default/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/default/.guren/api-client.gen.ts
@@ -62,6 +62,13 @@ type RequestOptionsOf<TRoute extends { path: string }> =
     ? { params?: never; body?: BodyOf<TRoute>; query?: Record<string, unknown> }
     : { params: PathParamsOf<TRoute['path']>; body?: BodyOf<TRoute>; query?: Record<string, unknown> }
 
+// Param-less routes may omit the options argument entirely; the same
+// predicate that shapes the options decides the arity.
+type RequestArgsOf<TRoute extends { path: string }> =
+  HasPathParams<TRoute['path']> extends false
+    ? [options?: RequestOptionsOf<TRoute>]
+    : [options: RequestOptionsOf<TRoute>]
+
 export type ApiRequestOptions<T extends ApiRouteName> = RequestOptionsOf<ApiRoutes[T]>
 
 // The wire contract these mirror is owned by Guren's CSRF middleware: it
@@ -153,9 +160,7 @@ export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method
   return {
     async request<TName extends keyof TRoutes & string>(
       name: TName,
-      ...args: HasPathParams<TRoutes[TName]['path']> extends false
-        ? [options?: RequestOptionsOf<TRoutes[TName]>]
-        : [options: RequestOptionsOf<TRoutes[TName]>]
+      ...args: RequestArgsOf<TRoutes[TName]>
     ): Promise<TypedResponse<ResponseOf<TRoutes[TName]>>> {
       const route = (routes as Record<string, { method: string; path: string }>)[name]
       if (!route) throw new Error(`Route [${name}] not defined.`)

--- a/packages/create-app/templates/default/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/default/.guren/api-client.gen.ts
@@ -27,21 +27,11 @@ type PathParamKeys<TPath extends string> =
     : TPath extends `${string}:${infer Param}`
       ? NormalizeParamKey<Param>
       : never
-
-// Both derive from the path literal, so nothing about how the entries above
-// are emitted can silently flip `request()`'s call arity. Deliberately not
-// distributed over a union route name: the union of paths yields the union of
-// their param keys, so an un-narrowed name requires every member's params —
-// substituting a param a member's path lacks is a runtime no-op, while the
-// reverse (accepting one member's empty params) would send a path with its
-// `:param` unresolved. The one pair serves both `ApiRequestOptions` and
-// `request()` below; keep them on it, or a fix lands in one spelling and not
-// the other.
+type HasPathParams<TPath extends string> = [PathParamKeys<TPath>] extends [never] ? false : true
 type PathParamsOf<TPath extends string> =
-  [PathParamKeys<TPath>] extends [never]
+  HasPathParams<TPath> extends false
     ? Record<string, never>
     : { [TKey in PathParamKeys<TPath>]: string | number }
-type HasPathParams<TPath extends string> = [PathParamKeys<TPath>] extends [never] ? false : true
 
 export type ApiRouteParams<T extends ApiRouteName> = PathParamsOf<ApiRoutePath<T>>
 
@@ -59,10 +49,20 @@ export interface TypedResponse<TData> extends Response {
   json(): Promise<TData>
 }
 
-export type ApiRequestOptions<T extends ApiRouteName> =
-  HasPathParams<ApiRoutePath<T>> extends false
-    ? { params?: never; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
-    : { params: ApiRouteParams<T>; body?: BodyOf<ApiRoutes[T]>; query?: Record<string, unknown> }
+// Params derive from the path literal, so nothing about how the entries above
+// are emitted can silently flip `request()`'s call arity. Deliberately not
+// distributed over a union route name (the conditional checks
+// `HasPathParams<...>`, never a bare type parameter): the union of paths
+// yields the union of their param keys, so an un-narrowed name requires every
+// member's params — substituting a param a member's path lacks is a runtime
+// no-op, while the reverse (accepting one member's empty params) would send a
+// path with its `:param` unresolved.
+type RequestOptionsOf<TRoute extends { path: string }> =
+  HasPathParams<TRoute['path']> extends false
+    ? { params?: never; body?: BodyOf<TRoute>; query?: Record<string, unknown> }
+    : { params: PathParamsOf<TRoute['path']>; body?: BodyOf<TRoute>; query?: Record<string, unknown> }
+
+export type ApiRequestOptions<T extends ApiRouteName> = RequestOptionsOf<ApiRoutes[T]>
 
 // The wire contract these mirror is owned by Guren's CSRF middleware: it
 // writes the XSRF-TOKEN cookie and reads either header name. Change them
@@ -152,8 +152,8 @@ export function createApiClient<TRoutes extends { [K in keyof TRoutes]: { method
     async request<TName extends keyof TRoutes & string>(
       name: TName,
       ...args: HasPathParams<TRoutes[TName]['path']> extends false
-        ? [options?: { params?: never; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
-        : [options: { params: PathParamsOf<TRoutes[TName]['path']>; body?: BodyOf<TRoutes[TName]>; query?: Record<string, unknown> }]
+        ? [options?: RequestOptionsOf<TRoutes[TName]>]
+        : [options: RequestOptionsOf<TRoutes[TName]>]
     ): Promise<TypedResponse<ResponseOf<TRoutes[TName]>>> {
       const route = (routes as Record<string, { method: string; path: string }>)[name]
       if (!route) throw new Error(`Route [${name}] not defined.`)

--- a/packages/create-app/templates/default/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/default/.guren/api-client.gen.ts
@@ -131,7 +131,9 @@ function isSameOrigin(url: string): boolean {
  * request shape; routes without one accept `unknown`. Routes that bind an
  * `output` schema type the response: `json()` on the returned `Response`
  * resolves to that schema's parsed shape. Without one it resolves to
- * `unknown` — validate before trusting it.
+ * `unknown` — validate before trusting it. Either way the typed shape
+ * describes the success body only: error statuses carry their own (a 422
+ * from validation is `{ errors: ... }`), so check `ok` before reading it.
  *
  * @example
  * ```typescript

--- a/packages/create-app/templates/default/.guren/routes.gen.ts
+++ b/packages/create-app/templates/default/.guren/routes.gen.ts
@@ -22,14 +22,16 @@ type PathParamKeys<TPath extends string> =
     : TPath extends `${string}:${infer Param}`
       ? NormalizeParamKey<Param>
       : never
-
-export type RouteParams<TName extends RouteName> =
-  [PathParamKeys<RouteManifest[TName]['path']>] extends [never]
+type HasPathParams<TPath extends string> = [PathParamKeys<TPath>] extends [never] ? false : true
+type PathParamsOf<TPath extends string> =
+  HasPathParams<TPath> extends false
     ? Record<string, never>
-    : { [TKey in PathParamKeys<RouteManifest[TName]['path']>]: string | number }
+    : { [TKey in PathParamKeys<TPath>]: string | number }
+
+export type RouteParams<TName extends RouteName> = PathParamsOf<RouteManifest[TName]['path']>
 
 type RouteArgs<TName extends RouteName> =
-  [PathParamKeys<RouteManifest[TName]['path']>] extends [never]
+  HasPathParams<RouteManifest[TName]['path']> extends false
     ? [query?: RouteQuery]
     : [params: RouteParams<TName>, query?: RouteQuery]
 

--- a/packages/inertia-client/src/components.tsx
+++ b/packages/inertia-client/src/components.tsx
@@ -33,24 +33,23 @@ export interface RouteManifestLike {
   [name: string]: { method: string; path: string }
 }
 
-// Same rule as PATH_PARAM_TYPE_HELPERS in @guren/cli's
+// The verbatim text of PATH_PARAM_TYPE_HELPERS in @guren/cli's
 // routes-types-fragments.ts, which the generated modules embed. This package
-// ships as a library — it cannot import an emitted fragment — so the two
-// spellings have to be kept in lockstep by hand.
-type ExtractParams<TPath extends string> =
+// ships as a library — it cannot import an emitted fragment — so the fragment
+// is mirrored here and routes-types-fragments.test.ts asserts the mirror
+// character for character.
+type NormalizeParamKey<TValue extends string> = TValue extends `${infer Key}?` ? Key : TValue
+type PathParamKeys<TPath extends string> =
   TPath extends `${string}:${infer Param}/${infer Rest}`
-    ? (Param extends `${infer Key}?` ? Key : Param) | ExtractParams<`/${Rest}`>
+    ? NormalizeParamKey<Param> | PathParamKeys<`/${Rest}`>
     : TPath extends `${string}:${infer Param}`
-      ? Param extends `${infer Key}?` ? Key : Param
+      ? NormalizeParamKey<Param>
       : never
-
-type RouteParamsFor<TPath extends string> =
-  [ExtractParams<TPath>] extends [never]
+type HasPathParams<TPath extends string> = [PathParamKeys<TPath>] extends [never] ? false : true
+type PathParamsOf<TPath extends string> =
+  HasPathParams<TPath> extends false
     ? Record<string, never>
-    : { [K in ExtractParams<TPath>]: string | number }
-
-type HasParams<TPath extends string> =
-  [ExtractParams<TPath>] extends [never] ? false : true
+    : { [TKey in PathParamKeys<TPath>]: string | number }
 
 // ─── Link component ──────────────────────────────────────────
 
@@ -62,8 +61,8 @@ export type TypedLinkProps<
 > = OmitHref<InertiaLinkProps> & {
   route: TName
 } & (
-  HasParams<TManifest[TName]['path']> extends true
-    ? { params: RouteParamsFor<TManifest[TName]['path']> }
+  HasPathParams<TManifest[TName]['path']> extends true
+    ? { params: PathParamsOf<TManifest[TName]['path']> }
     : { params?: never }
 )
 
@@ -110,8 +109,8 @@ export type TypedFormProps<
   route: TName
   method?: 'get' | 'post' | 'put' | 'patch' | 'delete'
 } & (
-  HasParams<TManifest[TName]['path']> extends true
-    ? { params: RouteParamsFor<TManifest[TName]['path']> }
+  HasPathParams<TManifest[TName]['path']> extends true
+    ? { params: PathParamsOf<TManifest[TName]['path']> }
     : { params?: never }
 )
 

--- a/packages/inertia-client/src/components.tsx
+++ b/packages/inertia-client/src/components.tsx
@@ -51,13 +51,22 @@ type PathParamsOf<TPath extends string> =
 
 // ─── Link component ──────────────────────────────────────────
 
+// Verbatim mirror of PATH_PARAM_RUNTIME_HELPERS, from the same fragment
+// module and under the same pin test as the type helpers above: token-based
+// substitution, so a param name that prefixes another cannot corrupt it and
+// keys the path lacks are no-ops.
 function substituteParams(path: string, params?: Record<string, string | number>): string {
-  if (!params) return path
-  let result = path
-  for (const [key, value] of Object.entries(params)) {
-    result = result.replace(`:${key}`, encodeURIComponent(String(value)))
+  if (!params) {
+    return path
   }
-  return result
+
+  return path.replace(/:([A-Za-z0-9_-]+)/gu, (match, key) => {
+    if (!Object.prototype.hasOwnProperty.call(params, key)) {
+      return match
+    }
+
+    return encodeURIComponent(String(params[key]))
+  })
 }
 
 type OmitHref<T> = Omit<T, 'href'>

--- a/packages/inertia-client/src/components.tsx
+++ b/packages/inertia-client/src/components.tsx
@@ -33,11 +33,9 @@ export interface RouteManifestLike {
   [name: string]: { method: string; path: string }
 }
 
-// The verbatim text of PATH_PARAM_TYPE_HELPERS in @guren/cli's
-// routes-types-fragments.ts, which the generated modules embed. This package
-// ships as a library — it cannot import an emitted fragment — so the fragment
-// is mirrored here and routes-types-fragments.test.ts asserts the mirror
-// character for character.
+// Verbatim mirror of PATH_PARAM_TYPE_HELPERS in @guren/cli's
+// routes-types-fragments.ts (its JSDoc has the why); pinned character for
+// character by routes-types-fragments.test.ts there.
 type NormalizeParamKey<TValue extends string> = TValue extends `${infer Key}?` ? Key : TValue
 type PathParamKeys<TPath extends string> =
   TPath extends `${string}:${infer Param}/${infer Rest}`
@@ -52,6 +50,15 @@ type PathParamsOf<TPath extends string> =
     : { [TKey in PathParamKeys<TPath>]: string | number }
 
 // ─── Link component ──────────────────────────────────────────
+
+function substituteParams(path: string, params?: Record<string, string | number>): string {
+  if (!params) return path
+  let result = path
+  for (const [key, value] of Object.entries(params)) {
+    result = result.replace(`:${key}`, encodeURIComponent(String(value)))
+  }
+  return result
+}
 
 type OmitHref<T> = Omit<T, 'href'>
 
@@ -85,12 +92,7 @@ export function createTypedLink<TManifest extends RouteManifestLike>(manifest: T
     const entry = manifest[routeName]
     if (!entry) throw new Error(`Route [${routeName}] not defined.`)
 
-    let href = entry.path
-    if (params) {
-      for (const [key, value] of Object.entries(params)) {
-        href = href.replace(`:${key}`, encodeURIComponent(String(value)))
-      }
-    }
+    const href = substituteParams(entry.path, params)
 
     return React.createElement(InertiaLink, { ...rest, href } as any)
   }
@@ -125,12 +127,7 @@ export function createTypedForm<TManifest extends RouteManifestLike>(manifest: T
     const entry = manifest[routeName]
     if (!entry) throw new Error(`Route [${routeName}] not defined.`)
 
-    let action = entry.path
-    if (params) {
-      for (const [key, value] of Object.entries(params)) {
-        action = action.replace(`:${key}`, encodeURIComponent(String(value)))
-      }
-    }
+    const action = substituteParams(entry.path, params)
 
     const httpMethod = method ?? entry.method.toLowerCase()
 

--- a/packages/inertia-client/src/components.tsx
+++ b/packages/inertia-client/src/components.tsx
@@ -33,6 +33,10 @@ export interface RouteManifestLike {
   [name: string]: { method: string; path: string }
 }
 
+// Same rule as PATH_PARAM_TYPE_HELPERS in @guren/cli's
+// routes-types-fragments.ts, which the generated modules embed. This package
+// ships as a library — it cannot import an emitted fragment — so the two
+// spellings have to be kept in lockstep by hand.
 type ExtractParams<TPath extends string> =
   TPath extends `${string}:${infer Param}/${infer Rest}`
     ? (Param extends `${infer Key}?` ? Key : Param) | ExtractParams<`/${Rest}`>


### PR DESCRIPTION
## Summary

Closes out the three items left open by the #402 review of the generated API client (`packages/cli/src/api-client-types.ts`).

### 1. Params derive from the path literal, through one shared fragment

The `params: Record<string, never>` sentinel on generated `ApiRoutes` entries is gone. `ApiRequestOptions` and `request()` now derive params from each entry's `path` literal — the same string the server routes on — so no future change to the entry shape can silently flip `request()`'s call arity.

The rule lives in one place: `PATH_PARAM_TYPE_HELPERS` in `routes-types-fragments.ts` now carries the whole derivation (`PathParamKeys`, `HasPathParams`, `PathParamsOf`), the route manifest's `RouteParams`/`RouteArgs` are expressed through it, and the API client embeds the same fragment. `@guren/inertia-client` ships as a library and cannot embed an emitted fragment, so its copy now repeats the fragment text verbatim and a test pins the mirror character for character — drift fails the suite instead of relying on a lockstep comment.

### 2. `response` is wired: typed `json()`

`request()` returns `Promise<TypedResponse<...>>`: routes binding an `output` schema get a `json()` typed to that schema's parsed shape; without one it resolves to `unknown` instead of `any`, so asserting the shape stays explicit — the blog starter's cast remains the documented pattern for schema-less routes, and the JSDoc spells out that the typed shape describes the success body only (check `ok` first; a 422 carries `{ errors: ... }`).

### 3. Union route names can no longer skip params

The path predicate is deliberately not distributed over a union route name. `'posts.index' | 'posts.show'` used to accept `params: {}` and could send `:id` unresolved; a union name now requires every member's params (substituting a param a member's path lacks is a runtime no-op). Usage probes pin both polarities, including an `any`/`never` regression guard on the typed `json()`.

Template `.guren` artifacts regenerated for blog and default via a real scaffold + codegen; `routes.gen.ts` changes spelling only (exported types keep their names and meaning), and the generated client's runtime body is unchanged.

## Validation

- `bun run build`, `bun run typecheck`, `bun run test` (framework + examples) all green
- `bun test packages/cli/tests/api-client-types.test.ts` — compile gate with union, response, and `any`-regression probes
- `bun run audit:starter-template`, `audit:core-first`, `audit:docs`
- `bun run smoke:starter` and `bun run smoke:starter:blog` (scaffold, install, typecheck, tests) both pass

## Changeset

`@guren/cli` minor (generated module shape changes), `create-guren-app` patch (regenerated artifacts).