### PR TITLE
feat(orm): add callback-style condition grouping to QueryBuilder

### DIFF
--- a/.changeset/where-callback-grouping.md
+++ b/.changeset/where-callback-grouping.md
@@ -1,0 +1,10 @@
+---
+"@guren/orm": minor
+"create-guren-app": patch
+---
+
+`where(callback)` and `orWhere(callback)` compose parenthesized condition groups, Laravel's `where(fn ($q) => ...)`.
+
+Until now `orWhere()` always pushed a top-level OR, so "(title LIKE ? OR excerpt LIKE ?) AND published = true" was inexpressible from application code — any AND filter next to an OR keyword chain (a published flag, tenancy, soft deletes) was silently OR'd away. The callback form collects conditions on a nested builder and folds them into a single group AND-ed with the rest of the query (`orWhere(callback)` ORs the whole group instead). Sequential semantics inside the callback match the top level: `.where(a).where(b).orWhere(c)` reads `(a AND b) OR c`, and callbacks nest. Groups render through the existing Drizzle condition tree, verified against the real sqlite driver alongside SoftDeletes and global scopes.
+
+The blog starter's `posts.search` action now groups its keyword OR chain this way, so filters added after it apply to every match.

--- a/.changeset/where-callback-grouping.md
+++ b/.changeset/where-callback-grouping.md
@@ -1,5 +1,7 @@
 ---
 "@guren/orm": minor
+"@guren/core": patch
+"@guren/cli": patch
 "create-guren-app": patch
 ---
 

--- a/docs/en/guides/database.md
+++ b/docs/en/guides/database.md
@@ -155,6 +155,14 @@ const trending = await Post.where('status', 'published')
 
 // Object syntax for simple equality
 const drafts = await Post.where({ status: 'draft', authorId: 1 }).get()
+
+// Callback syntax groups conditions in parentheses:
+// (title LIKE ? OR excerpt LIKE ?) AND status = 'published'
+const hits = await Post.where((q) => {
+  q.where('title', 'like', '%bun%').orWhere('excerpt', 'like', '%bun%')
+})
+  .where('status', 'published')
+  .get()
 ```
 
 > [!TIP]
@@ -165,7 +173,9 @@ const drafts = await Post.where({ status: 'draft', authorId: 1 }).get()
 | `.where(column, value)` | Filter by equality |
 | `.where(column, op, value)` | Filter with operator (`>`, `<`, `!=`, `LIKE`) |
 | `.where(object)` | Filter by multiple equalities |
+| `.where(callback)` | Parenthesized condition group, AND-ed with the rest |
 | `.orWhere(column, value)` | OR condition |
+| `.orWhere(callback)` | OR a parenthesized condition group |
 | `.orderBy(column, direction?)` | Sort results |
 | `.limit(n)` / `.offset(n)` | Limit and skip |
 | `.get()` | Execute and return array |

--- a/docs/ja/guides/database.md
+++ b/docs/ja/guides/database.md
@@ -290,6 +290,14 @@ const popular = await Post.where('status', 'published')
 // オブジェクト構文によるシンプルな等値比較
 const admins = await User.where({ role: 'admin' })
 
+// コールバック構文は条件を括弧でグループ化する:
+// (title LIKE ? OR excerpt LIKE ?) AND status = 'published'
+const hits = await Post.where((q) => {
+  q.where('title', 'like', '%bun%').orWhere('excerpt', 'like', '%bun%')
+})
+  .where('status', 'published')
+  .get()
+
 // thenable - .get() なしで直接 await 可能
 const users = await User.where({ role: 'admin' })
 ```
@@ -303,8 +311,10 @@ const users = await User.where({ role: 'admin' })
 | `.where(column, value)` | 等値でフィルタ |
 | `.where(column, operator, value)` | 演算子でフィルタ（`>`、`<`、`>=`、`<=`、`!=`、`LIKE`） |
 | `.where(object)` | 複数の等値条件でフィルタ |
+| `.where(callback)` | 括弧でグループ化した条件を AND で結合 |
 | `.orWhere(column, value)` | OR 条件 |
 | `.orWhere(column, operator, value)` | 演算子付き OR 条件 |
+| `.orWhere(callback)` | 括弧でグループ化した条件を OR で結合 |
 | `.orderBy(column, direction?)` | 結果をソート（`'asc'` または `'desc'`） |
 | `.limit(n)` | 結果件数を制限 |
 | `.offset(n)` | 最初の n 件をスキップ |

--- a/packages/cli/templates/agent/.claude/rules/orm-models.md
+++ b/packages/cli/templates/agent/.claude/rules/orm-models.md
@@ -56,6 +56,13 @@ denies the hash and remember-token columns from mass assignment entirely; `force
 await Post.where({ status: 'active', authorId: 1 }).get()  // object form = AND
 await Post.where({ id: [1, 2, 3] }).get()                  // array value = IN
 await Post.where('views', '>', 100).orWhere('featured', true).get()
+
+// Callback form groups conditions in parentheses — required when an OR
+// chain must sit next to AND filters, or the ANDs get OR'd away:
+// (title LIKE ? OR excerpt LIKE ?) AND published = true
+await Post.where((q) => q.where('title', 'like', p).orWhere('excerpt', 'like', p))
+  .where('published', true)
+  .get()
 ```
 
 Operators (exact set): `=` `!=` `>` `<` `>=` `<=` `like` `in` `not in` `is null` `is not null`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,7 @@ export type {
   SoftDeletesStatic,
   WhereOperator,
   WhereCondition,
+  WhereGroupCallback,
   SimpleCondition,
   GroupCondition,
   ORMAdapterAdvanced,

--- a/packages/create-app/templates/blog/app/Http/Controllers/PostController.ts
+++ b/packages/create-app/templates/blog/app/Http/Controllers/PostController.ts
@@ -28,18 +28,20 @@ export default class PostController extends Controller {
   // Serves the HTTP QUERY route `posts.search` — a safe read that carries its
   // criteria in a JSON body. Matches posts with any keyword in title or
   // excerpt; `%` and `_` in a keyword act as SQL LIKE wildcards, which this
-  // starter treats as a feature. The keyword matching is a chain of top-level
-  // OR conditions — group it before mixing in AND filters (a published flag,
-  // tenancy), or those filters will be OR'd away.
+  // starter treats as a feature. Each keyword's OR pair is grouped in a
+  // `where(callback)`, so AND filters added later (a published flag, tenancy)
+  // apply to every match instead of being OR'd away.
   async search(): Promise<Response> {
     const { keywords, limit } = await this.validateBody(PostSearchSchema)
 
     const query = Post.newQuery().with('author')
-    for (const keyword of keywords) {
-      const pattern = `%${keyword}%`
-      query.orWhere('title', 'like', pattern)
-      query.orWhere('excerpt', 'like', pattern)
-    }
+    query.where((q) => {
+      for (const keyword of keywords) {
+        const pattern = `%${keyword}%`
+        q.orWhere('title', 'like', pattern)
+        q.orWhere('excerpt', 'like', pattern)
+      }
+    })
     const posts = await query.orderBy('id', 'desc').limit(limit).get()
 
     return this.json({ data: PostResource.collection(posts) })

--- a/packages/create-app/templates/blog/app/Http/Controllers/PostController.ts
+++ b/packages/create-app/templates/blog/app/Http/Controllers/PostController.ts
@@ -28,21 +28,24 @@ export default class PostController extends Controller {
   // Serves the HTTP QUERY route `posts.search` — a safe read that carries its
   // criteria in a JSON body. Matches posts with any keyword in title or
   // excerpt; `%` and `_` in a keyword act as SQL LIKE wildcards, which this
-  // starter treats as a feature. Each keyword's OR pair is grouped in a
-  // `where(callback)`, so AND filters added later (a published flag, tenancy)
-  // apply to every match instead of being OR'd away.
+  // starter treats as a feature. All keyword OR pairs sit inside one
+  // `where(callback)`, keeping this an any-keyword match while AND filters
+  // added later (a published flag, tenancy) apply to every hit instead of
+  // being OR'd away.
   async search(): Promise<Response> {
     const { keywords, limit } = await this.validateBody(PostSearchSchema)
 
-    const query = Post.newQuery().with('author')
-    query.where((q) => {
-      for (const keyword of keywords) {
-        const pattern = `%${keyword}%`
-        q.orWhere('title', 'like', pattern)
-        q.orWhere('excerpt', 'like', pattern)
-      }
-    })
-    const posts = await query.orderBy('id', 'desc').limit(limit).get()
+    const posts = await Post.newQuery()
+      .with('author')
+      .where((q) => {
+        for (const keyword of keywords) {
+          const pattern = `%${keyword}%`
+          q.orWhere('title', 'like', pattern).orWhere('excerpt', 'like', pattern)
+        }
+      })
+      .orderBy('id', 'desc')
+      .limit(limit)
+      .get()
 
     return this.json({ data: PostResource.collection(posts) })
   }

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -9,7 +9,7 @@ import { executeObservers } from './ModelObserver'
 import type { ModelObserver, ModelObserverConstructor } from './ModelObserver'
 import { ModelNotFoundException } from './ModelNotFoundException'
 import { QueryBuilder, PREPARED_UPDATE } from './QueryBuilder'
-import type { WhereOperator } from './QueryBuilder'
+import type { WhereGroupCallback, WhereOperator } from './QueryBuilder'
 import { serializeRecord, serializeRecords } from './serialization'
 import { MassAssignmentException } from './MassAssignmentException'
 
@@ -1001,16 +1001,21 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
    *   .limit(10)
    *   .get()
    */
+  static where<T extends typeof Model>(this: T, callback: WhereGroupCallback<TRecordFor<T>>): QueryBuilder<TRecordFor<T>>
   static where<T extends typeof Model>(this: T, conditions: WhereClauseFor<T>): QueryBuilder<TRecordFor<T>>
   static where<T extends typeof Model>(this: T, field: keyof TRecordFor<T> & string, value: unknown): QueryBuilder<TRecordFor<T>>
   static where<T extends typeof Model>(this: T, field: keyof TRecordFor<T> & string, operator: WhereOperator, value: unknown): QueryBuilder<TRecordFor<T>>
   static where<T extends typeof Model>(
     this: T,
-    fieldOrConditions: (keyof TRecordFor<T> & string) | WhereClauseFor<T>,
+    fieldOrConditions: (keyof TRecordFor<T> & string) | WhereClauseFor<T> | WhereGroupCallback<TRecordFor<T>>,
     operatorOrValue?: unknown,
     value?: unknown,
   ): QueryBuilder<TRecordFor<T>> {
     const builder = this.newQuery()
+
+    if (typeof fieldOrConditions === 'function') {
+      return builder.where(fieldOrConditions)
+    }
 
     if (typeof fieldOrConditions === 'object' && fieldOrConditions !== null) {
       return builder.where(fieldOrConditions as Partial<Record<keyof TRecordFor<T> & string, unknown>>)

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -439,10 +439,14 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
    */
   static inTransaction<T extends typeof Model>(this: T, trx: TransactionHandle): TransactionModelScope<T> {
     const where: TransactionModelScope<T>['where'] = (
-      fieldOrConditions: FieldFor<T> | WhereClauseFor<T>,
+      fieldOrConditions: FieldFor<T> | WhereClauseFor<T> | WhereGroupCallback<TRecordFor<T>>,
       operatorOrValue?: unknown,
       value?: unknown,
     ) => {
+      if (typeof fieldOrConditions === 'function') {
+        return this.newQuery({ trx }).where(fieldOrConditions)
+      }
+
       if (typeof fieldOrConditions === 'object' && fieldOrConditions !== null) {
         return this.newQuery({ trx }).where(fieldOrConditions as Partial<Record<keyof TRecordFor<T> & string, unknown>>)
       }
@@ -2478,6 +2482,7 @@ export interface TransactionModelScope<T extends typeof Model> {
   find(id: unknown): Promise<TRecordFor<T> | null>
   findOrFail(id: unknown): Promise<TRecordFor<T>>
   first(where?: WhereClauseFor<T>): Promise<TRecordFor<T> | null>
+  where(callback: WhereGroupCallback<TRecordFor<T>>): QueryBuilder<TRecordFor<T>>
   where(conditions: WhereClauseFor<T>): QueryBuilder<TRecordFor<T>>
   where(field: FieldFor<T>, value: unknown): QueryBuilder<TRecordFor<T>>
   where(field: FieldFor<T>, operator: WhereOperator, value: unknown): QueryBuilder<TRecordFor<T>>

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -43,6 +43,14 @@ export interface GroupCondition {
 /** A where condition - either simple or grouped. */
 export type WhereCondition = SimpleCondition | GroupCondition
 
+/**
+ * Callback receiving a nested builder to compose a parenthesized
+ * condition group, mirroring Laravel's `where(fn ($q) => ...)`.
+ */
+export type WhereGroupCallback<TRecord extends PlainObject = PlainObject> = (
+  query: QueryBuilder<TRecord>,
+) => void
+
 /** Options carried by the QueryBuilder for query execution. */
 export interface QueryBuilderOptions {
   orderBy: Array<{ column: string; direction: OrderDirection }>
@@ -97,19 +105,41 @@ export class QueryBuilder<
   /**
    * Add a where condition (AND).
    *
-   * Supports three calling signatures:
+   * Supports four calling signatures:
    * - `where(field, value)` - equality check
    * - `where(field, operator, value)` - comparison
    * - `where(object)` - multiple equality conditions
+   * - `where(callback)` - parenthesized condition group, AND-ed with the rest
+   *
+   * @example
+   * // (title LIKE ? OR excerpt LIKE ?) AND published = true
+   * await Post.where((q) => {
+   *   q.where('title', 'like', pattern).orWhere('excerpt', 'like', pattern)
+   * }).where('published', true)
    */
+  where(callback: WhereGroupCallback<TRecord>): this
   where<TKey extends FieldKey<TRecord>>(field: TKey, value: TRecord[TKey]): this
   where<TKey extends FieldKey<TRecord>>(field: TKey, operator: WhereOperator, value: unknown): this
   where(conditions: Partial<Record<FieldKey<TRecord>, unknown>>): this
   where(
-    fieldOrConditions: FieldKey<TRecord> | Partial<Record<FieldKey<TRecord>, unknown>>,
+    fieldOrConditions: FieldKey<TRecord> | Partial<Record<FieldKey<TRecord>, unknown>> | WhereGroupCallback<TRecord>,
     operatorOrValue?: unknown,
     value?: unknown,
   ): this {
+    if (typeof fieldOrConditions === 'function') {
+      const grouped = this.buildCallbackGroup(fieldOrConditions)
+      if (grouped) {
+        // A bare OR group at the top level would fold the preceding
+        // conditions into its OR; wrap it so it stays one AND-ed condition.
+        this.conditions.push(
+          grouped.type === 'group' && grouped.boolean === 'or'
+            ? { type: 'group', boolean: 'and', conditions: [grouped] }
+            : grouped,
+        )
+      }
+      return this
+    }
+
     if (typeof fieldOrConditions === 'object' && fieldOrConditions !== null) {
       for (const [key, val] of Object.entries(fieldOrConditions)) {
         if (val !== undefined) {
@@ -136,15 +166,26 @@ export class QueryBuilder<
    *
    * Same overloads as `where()`, but joins with OR logic.
    * Creates an OR group containing the new condition(s).
+   * With a callback, the group's conditions are parenthesized as a whole:
+   * `(preceding conditions) OR (callback group)`.
    */
+  orWhere(callback: WhereGroupCallback<TRecord>): this
   orWhere<TKey extends FieldKey<TRecord>>(field: TKey, value: TRecord[TKey]): this
   orWhere<TKey extends FieldKey<TRecord>>(field: TKey, operator: WhereOperator, value: unknown): this
   orWhere(conditions: Partial<Record<FieldKey<TRecord>, unknown>>): this
   orWhere(
-    fieldOrConditions: FieldKey<TRecord> | Partial<Record<FieldKey<TRecord>, unknown>>,
+    fieldOrConditions: FieldKey<TRecord> | Partial<Record<FieldKey<TRecord>, unknown>> | WhereGroupCallback<TRecord>,
     operatorOrValue?: unknown,
     value?: unknown,
   ): this {
+    if (typeof fieldOrConditions === 'function') {
+      const grouped = this.buildCallbackGroup(fieldOrConditions)
+      if (grouped) {
+        this.conditions.push({ type: 'group', boolean: 'or', conditions: [grouped] })
+      }
+      return this
+    }
+
     const orConditions: SimpleCondition[] = []
 
     if (typeof fieldOrConditions === 'object' && fieldOrConditions !== null) {
@@ -546,6 +587,21 @@ export class QueryBuilder<
     return { ...this.options }
   }
 
+  /**
+   * Run a grouping callback against a nested builder and fold the collected
+   * conditions into a single condition node.
+   *
+   * The nested builder intentionally skips global scopes (`defaultScope`,
+   * SoftDeletes): the outer builder already carries them, and re-applying
+   * them inside every group would duplicate — or, inside an OR group,
+   * weaken — their filters.
+   */
+  private buildCallbackGroup(callback: WhereGroupCallback<TRecord>): WhereCondition | null {
+    const nested = new QueryBuilder<TRecord>(this.modelClass, { trx: this.options.trx })
+    callback(nested)
+    return normalizeConditionSequence(nested.conditions)
+  }
+
   private addSimpleCondition(field: string, operator: WhereOperator, value: unknown): void {
     this.conditions.push({
       type: 'simple',
@@ -648,6 +704,49 @@ export class QueryBuilder<
 
     return copies as TResult[]
   }
+}
+
+/**
+ * Fold a builder's sequential condition list into one condition node.
+ *
+ * A builder's condition list has sequential semantics that only the
+ * top-level adapter rendering implements: an OR group folds everything
+ * before it into the OR (`.where(a).where(b).orWhere(c)` reads
+ * `(a AND b) OR c`). Inside a GroupCondition, adapters join members
+ * flatly with the group's boolean, so a nested list must be normalized
+ * here into a tree whose flat joins already express those semantics.
+ *
+ * Returns null when the list holds no renderable condition.
+ */
+function normalizeConditionSequence(conditions: WhereCondition[]): WhereCondition | null {
+  let folded: WhereCondition | null = null
+  let pendingAnd: WhereCondition[] = []
+
+  for (const condition of conditions) {
+    if (condition.type === 'group' && condition.boolean === 'or') {
+      if (condition.conditions.length === 0) continue
+      const andBlock = combineAnd(pendingAnd, folded)
+      pendingAnd = []
+      if (andBlock) {
+        folded = { type: 'group', boolean: 'or', conditions: [andBlock, ...condition.conditions] }
+      } else if (condition.conditions.length === 1) {
+        folded = condition.conditions[0]!
+      } else {
+        folded = { type: 'group', boolean: 'or', conditions: [...condition.conditions] }
+      }
+    } else {
+      pendingAnd.push(condition)
+    }
+  }
+
+  return combineAnd(pendingAnd, folded)
+}
+
+function combineAnd(andParts: WhereCondition[], existing: WhereCondition | null): WhereCondition | null {
+  const all = existing ? [existing, ...andParts] : [...andParts]
+  if (all.length === 0) return null
+  if (all.length === 1) return all[0]!
+  return { type: 'group', boolean: 'and', conditions: all }
 }
 
 /**

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -46,6 +46,10 @@ export type WhereCondition = SimpleCondition | GroupCondition
 /**
  * Callback receiving a nested builder to compose a parenthesized
  * condition group, mirroring Laravel's `where(fn ($q) => ...)`.
+ *
+ * Only the conditions added on the nested builder are read back —
+ * ordering, limits, eager loads, and terminal calls made inside the
+ * callback are not part of the group.
  */
 export type WhereGroupCallback<TRecord extends PlainObject = PlainObject> = (
   query: QueryBuilder<TRecord>,

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_PAGINATION_SIZE } from './Model'
 import { ModelNotFoundException } from './ModelNotFoundException'
+import { normalizeConditionSequence } from './where-conditions'
 import type {
   AdapterQueryOptions,
   FindManyOptions,
@@ -131,16 +132,7 @@ export class QueryBuilder<
     value?: unknown,
   ): this {
     if (typeof fieldOrConditions === 'function') {
-      const grouped = this.buildCallbackGroup(fieldOrConditions)
-      if (grouped) {
-        // A bare OR group at the top level would fold the preceding
-        // conditions into its OR; wrap it so it stays one AND-ed condition.
-        this.conditions.push(
-          grouped.type === 'group' && grouped.boolean === 'or'
-            ? { type: 'group', boolean: 'and', conditions: [grouped] }
-            : grouped,
-        )
-      }
+      this.pushCallbackGroup(fieldOrConditions, 'and')
       return this
     }
 
@@ -183,10 +175,7 @@ export class QueryBuilder<
     value?: unknown,
   ): this {
     if (typeof fieldOrConditions === 'function') {
-      const grouped = this.buildCallbackGroup(fieldOrConditions)
-      if (grouped) {
-        this.conditions.push({ type: 'group', boolean: 'or', conditions: [grouped] })
-      }
+      this.pushCallbackGroup(fieldOrConditions, 'or')
       return this
     }
 
@@ -592,18 +581,28 @@ export class QueryBuilder<
   }
 
   /**
-   * Run a grouping callback against a nested builder and fold the collected
-   * conditions into a single condition node.
+   * Run a grouping callback against a nested builder, fold the collected
+   * conditions into a single node, and push it joined by `boolean`.
    *
    * The nested builder intentionally skips global scopes (`defaultScope`,
    * SoftDeletes): the outer builder already carries them, and re-applying
    * them inside every group would duplicate — or, inside an OR group,
    * weaken — their filters.
    */
-  private buildCallbackGroup(callback: WhereGroupCallback<TRecord>): WhereCondition | null {
+  private pushCallbackGroup(callback: WhereGroupCallback<TRecord>, boolean: 'and' | 'or'): void {
     const nested = new QueryBuilder<TRecord>(this.modelClass, { trx: this.options.trx })
     callback(nested)
-    return normalizeConditionSequence(nested.conditions)
+    const grouped = normalizeConditionSequence(nested.conditions)
+    if (!grouped) return
+
+    // An or-group node means two different things by position: in member
+    // position it is a parenthesized disjunction, but at the top level it is
+    // an orWhere continuation that folds the preceding conditions into its
+    // OR. Wrapping puts the node in member position, selecting the first
+    // reading; for `where(callback)` an and-rooted or simple node already
+    // reads correctly at the top level, so it is pushed bare.
+    const needsWrap = boolean === 'or' || (grouped.type === 'group' && grouped.boolean === 'or')
+    this.conditions.push(needsWrap ? { type: 'group', boolean, conditions: [grouped] } : grouped)
   }
 
   private addSimpleCondition(field: string, operator: WhereOperator, value: unknown): void {
@@ -708,49 +707,6 @@ export class QueryBuilder<
 
     return copies as TResult[]
   }
-}
-
-/**
- * Fold a builder's sequential condition list into one condition node.
- *
- * A builder's condition list has sequential semantics that only the
- * top-level adapter rendering implements: an OR group folds everything
- * before it into the OR (`.where(a).where(b).orWhere(c)` reads
- * `(a AND b) OR c`). Inside a GroupCondition, adapters join members
- * flatly with the group's boolean, so a nested list must be normalized
- * here into a tree whose flat joins already express those semantics.
- *
- * Returns null when the list holds no renderable condition.
- */
-function normalizeConditionSequence(conditions: WhereCondition[]): WhereCondition | null {
-  let folded: WhereCondition | null = null
-  let pendingAnd: WhereCondition[] = []
-
-  for (const condition of conditions) {
-    if (condition.type === 'group' && condition.boolean === 'or') {
-      if (condition.conditions.length === 0) continue
-      const andBlock = combineAnd(pendingAnd, folded)
-      pendingAnd = []
-      if (andBlock) {
-        folded = { type: 'group', boolean: 'or', conditions: [andBlock, ...condition.conditions] }
-      } else if (condition.conditions.length === 1) {
-        folded = condition.conditions[0]!
-      } else {
-        folded = { type: 'group', boolean: 'or', conditions: [...condition.conditions] }
-      }
-    } else {
-      pendingAnd.push(condition)
-    }
-  }
-
-  return combineAnd(pendingAnd, folded)
-}
-
-function combineAnd(andParts: WhereCondition[], existing: WhereCondition | null): WhereCondition | null {
-  const all = existing ? [existing, ...andParts] : [...andParts]
-  if (all.length === 0) return null
-  if (all.length === 1) return all[0]!
-  return { type: 'group', boolean: 'and', conditions: all }
 }
 
 /**

--- a/packages/orm/src/adapters/drizzle-conditions.ts
+++ b/packages/orm/src/adapters/drizzle-conditions.ts
@@ -1,6 +1,7 @@
 import { and, eq, gt, gte, inArray, isNotNull, isNull, like, lt, lte, ne, notInArray, or } from 'drizzle-orm'
 import type { AnyColumn, SQL } from 'drizzle-orm'
 import type { GroupCondition, SimpleCondition, WhereCondition } from '../QueryBuilder'
+import { normalizeConditionSequence } from '../where-conditions'
 
 type DrizzleTableLike = Record<string, unknown>
 
@@ -108,79 +109,18 @@ function buildSingleCondition(table: unknown, condition: WhereCondition): SQL | 
  * Translates an array of QueryBuilder WhereConditions into a single
  * Drizzle ORM condition expression.
  *
- * The top-level conditions are joined with AND. OR conditions are
- * represented as GroupCondition nodes with `boolean: 'or'`.
- *
- * When an OR group is encountered, it creates:
- *   AND(previous_conditions, OR(previous_and_block, or_conditions))
- *
- * This matches the typical SQL builder behavior where:
+ * The list's sequential semantics — top-level conditions AND together,
+ * an OR group folds everything before it into the OR, so
  *   .where('a', 1).where('b', 2).orWhere('c', 3)
- * produces: (a = 1 AND b = 2) OR (c = 3)
+ * produces `(a = 1 AND b = 2) OR (c = 3)` — are applied by
+ * `normalizeConditionSequence` (shared with QueryBuilder's grouping
+ * callbacks), leaving only a flat-join tree to render here.
  *
  * @param table - The Drizzle table object
  * @param conditions - Array of WhereCondition objects from QueryBuilder
  * @returns A Drizzle SQL condition or undefined if no conditions
  */
 export function buildDrizzleConditions(table: unknown, conditions: WhereCondition[]): SQL | undefined {
-  if (conditions.length === 0) {
-    return undefined
-  }
-
-  // Separate AND conditions and OR groups
-  // Strategy: collect AND conditions, when we hit an OR group,
-  // wrap current AND block with the OR group.
-  let currentAnd: SQL[] = []
-  let result: SQL | undefined
-
-  for (const condition of conditions) {
-    if (condition.type === 'group' && condition.boolean === 'or') {
-      // Build the OR group's conditions
-      const orParts = condition.conditions
-        .map((c) => buildSingleCondition(table, c))
-        .filter((c): c is SQL => c !== undefined)
-
-      if (orParts.length > 0) {
-        // Combine current AND conditions into one block
-        const andBlock = combineAnd(currentAnd, result)
-        if (andBlock) {
-          result = or(andBlock, ...orParts)
-        } else {
-          result = orParts.length === 1 ? orParts[0] : or(...orParts)
-        }
-        currentAnd = []
-      }
-    } else {
-      const built = buildSingleCondition(table, condition)
-      if (built) {
-        currentAnd.push(built)
-      }
-    }
-  }
-
-  // Combine remaining AND conditions with result
-  return combineAnd(currentAnd, result)
-}
-
-/**
- * Combines an array of AND conditions with an optional existing result.
- */
-function combineAnd(andParts: SQL[], existing: SQL | undefined): SQL | undefined {
-  const all: SQL[] = []
-
-  if (existing) {
-    all.push(existing)
-  }
-
-  all.push(...andParts)
-
-  if (all.length === 0) {
-    return undefined
-  }
-
-  if (all.length === 1) {
-    return all[0]
-  }
-
-  return and(...all)
+  const normalized = normalizeConditionSequence(conditions)
+  return normalized ? buildSingleCondition(table, normalized) : undefined
 }

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -40,6 +40,7 @@ export { QueryBuilder } from './QueryBuilder'
 export type {
   WhereOperator,
   WhereCondition,
+  WhereGroupCallback,
   SimpleCondition,
   GroupCondition,
   ORMAdapterAdvanced,

--- a/packages/orm/src/where-conditions.ts
+++ b/packages/orm/src/where-conditions.ts
@@ -1,0 +1,36 @@
+import type { WhereCondition } from './QueryBuilder'
+
+/**
+ * Fold a builder's sequential condition list into one condition node.
+ *
+ * A condition list has sequential semantics: an OR group folds everything
+ * before it into the OR, so `.where(a).where(b).orWhere(c)` reads
+ * `(a AND b) OR c`. Inside a GroupCondition, members are joined flatly
+ * with the group's boolean. This is the one implementation of that fold —
+ * the Drizzle renderer applies it to the top-level list before rendering,
+ * and QueryBuilder applies it to a grouping callback's collected list, so
+ * the two can never drift apart.
+ *
+ * Returns null when the list holds no renderable condition.
+ */
+export function normalizeConditionSequence(conditions: WhereCondition[]): WhereCondition | null {
+  let pending: WhereCondition[] = []
+
+  for (const condition of conditions) {
+    if (!(condition.type === 'group' && condition.boolean === 'or')) {
+      pending.push(condition)
+      continue
+    }
+    if (condition.conditions.length === 0) continue
+    const andBlock = combine('and', pending)
+    pending = [combine('or', andBlock ? [andBlock, ...condition.conditions] : condition.conditions)!]
+  }
+
+  return combine('and', pending)
+}
+
+function combine(boolean: 'and' | 'or', parts: WhereCondition[]): WhereCondition | null {
+  if (parts.length === 0) return null
+  if (parts.length === 1) return parts[0]!
+  return { type: 'group', boolean, conditions: [...parts] }
+}

--- a/packages/orm/tests/query-builder.test.ts
+++ b/packages/orm/tests/query-builder.test.ts
@@ -193,6 +193,94 @@ describe('QueryBuilder', () => {
     })
   })
 
+  describe('callback condition groups', () => {
+    it('should AND a grouped OR with surrounding conditions', async () => {
+      const results = await qb()
+        .where((q) => q.where('name', 'Alice').orWhere('name', 'Bob'))
+        .where('role', 'admin')
+        .get()
+      // (name = Alice OR name = Bob) AND role = admin — Bob is a user
+      expect(results).toHaveLength(1)
+      expect(results[0].name).toBe('Alice')
+    })
+
+    it('should keep a preceding where out of the group OR', async () => {
+      const results = await qb()
+        .where('role', 'user')
+        .where((q) => q.where('score', '>', 85).orWhere('name', 'Bob'))
+        .get()
+      // role = user AND (score > 85 OR name = Bob) — Eve and Bob
+      expect(results).toHaveLength(2)
+      expect(results.map((r) => r.name).sort()).toEqual(['Bob', 'Eve'])
+    })
+
+    it('should preserve sequential orWhere semantics inside a callback', async () => {
+      const results = await qb()
+        .where((q) => q.where('role', 'admin').where('score', '>', 90).orWhere('name', 'Eve'))
+        .whereNotNull('email')
+        .get()
+      // ((admin AND score > 90) OR Eve) AND email NOT NULL — Eve has no email
+      expect(results).toHaveLength(1)
+      expect(results[0].name).toBe('Alice')
+    })
+
+    it('should group a callback made only of orWhere calls', async () => {
+      const results = await qb()
+        .where((q) => q.orWhere('name', 'Alice').orWhere('name', 'Bob'))
+        .where('role', 'admin')
+        .get()
+      expect(results).toHaveLength(1)
+      expect(results[0].name).toBe('Alice')
+    })
+
+    it('should OR a whole callback group with orWhere', async () => {
+      const results = await qb()
+        .where('role', 'admin')
+        .orWhere((q) => q.where('role', 'user').where('score', '>=', 90))
+        .get()
+      // role = admin OR (role = user AND score >= 90) — Alice, Diana, Eve
+      expect(results).toHaveLength(3)
+      expect(results.map((r) => r.name).sort()).toEqual(['Alice', 'Diana', 'Eve'])
+    })
+
+    it('should support nesting callbacks inside callbacks', async () => {
+      const results = await qb()
+        .where((q) => {
+          q.where('role', 'user')
+          q.where((inner) => inner.where('score', '>=', 90).orWhere('name', 'Bob'))
+        })
+        .get()
+      // role = user AND (score >= 90 OR name = Bob)
+      expect(results).toHaveLength(2)
+      expect(results.map((r) => r.name).sort()).toEqual(['Bob', 'Eve'])
+    })
+
+    it('should treat an empty callback as a no-op', async () => {
+      const results = await qb().where(() => {}).orWhere(() => {}).get()
+      expect(results).toHaveLength(5)
+    })
+
+    it('should count with grouped conditions', async () => {
+      const count = await qb()
+        .where((q) => q.where('name', 'Alice').orWhere('name', 'Bob'))
+        .where('role', 'admin')
+        .count()
+      expect(count).toBe(1)
+    })
+
+    it('should not fold a preceding where into the group when the callback starts with orWhere', () => {
+      // Regression pin: the outer builder's conditions must never leak into
+      // the nested normalization.
+      const builder = qb()
+        .where('role', 'admin')
+        .where((q) => q.orWhere('name', 'Alice'))
+      const conditions = builder.getConditions()
+      expect(conditions).toHaveLength(2)
+      expect(conditions[0]).toEqual({ type: 'simple', field: 'role', operator: '=', value: 'admin' })
+      expect(conditions[1]).toEqual({ type: 'simple', field: 'name', operator: '=', value: 'Alice' })
+    })
+  })
+
   describe('whereNull / whereNotNull', () => {
     it('should filter null values', async () => {
       const results = await qb().whereNull('email').get()

--- a/packages/orm/tests/where-group-sqlite.test.ts
+++ b/packages/orm/tests/where-group-sqlite.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { drizzle } from 'drizzle-orm/bun-sqlite'
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { Model } from '../src/Model'
+import { SoftDeletes } from '../src/SoftDeletes'
+import { DrizzleAdapter } from '../src/adapters/drizzle-adapter'
+
+// Integration test against the real bun:sqlite driver. Callback groups only
+// exist so that AND filters (published flags, soft deletes, global scopes)
+// survive next to OR keyword chains — the fake-adapter tests cannot prove
+// the Drizzle renderer parenthesizes the generated SQL the same way.
+
+const postsTable = sqliteTable('posts', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  title: text('title').notNull(),
+  excerpt: text('excerpt').notNull(),
+  published: integer('published', { mode: 'boolean' }).notNull(),
+  deletedAt: text('deleted_at'),
+})
+
+type PostRecord = typeof postsTable.$inferSelect
+
+describe('callback where groups on real bun:sqlite driver', () => {
+  let sqlite: Database
+
+  class Post extends Model<PostRecord> {
+    static override table = postsTable
+  }
+
+  class SoftPost extends SoftDeletes(Model<PostRecord>) {
+    static override table = postsTable
+  }
+
+  beforeEach(() => {
+    sqlite = new Database(':memory:')
+    sqlite.exec(`
+      CREATE TABLE posts (
+        id integer primary key autoincrement,
+        title text not null,
+        excerpt text not null,
+        published integer not null,
+        deleted_at text
+      );
+      INSERT INTO posts (title, excerpt, published, deleted_at) VALUES
+        ('Bun speed',      'runtime notes',   1, NULL),
+        ('Draft on bun',   'unfinished',      0, NULL),
+        ('Hono routing',   'try it with bun', 1, NULL),
+        ('Deleted bun',    'gone',            1, '2026-01-01T00:00:00Z'),
+        ('Unrelated',      'nothing here',    1, NULL);
+    `)
+    DrizzleAdapter.configure(drizzle({ client: sqlite }) as never)
+  })
+
+  afterEach(() => {
+    sqlite.close()
+  })
+
+  it('should keep an AND filter next to an OR keyword group', async () => {
+    const posts = await Post.where((q) => {
+      q.where('title', 'like', '%bun%').orWhere('excerpt', 'like', '%bun%')
+    }).where('published', true)
+
+    // Without grouping, `published = true` would be OR'd away and the
+    // unpublished draft would leak through.
+    expect(posts.map((p) => p.title).sort()).toEqual(['Bun speed', 'Deleted bun', 'Hono routing'])
+  })
+
+  it('should stack keyword groups for multiple keywords', async () => {
+    const query = Post.newQuery().where('published', true)
+    for (const keyword of ['bun', 'routing']) {
+      const pattern = `%${keyword}%`
+      query.where((q) => q.where('title', 'like', pattern).orWhere('excerpt', 'like', pattern))
+    }
+    const posts = await query.get()
+
+    // published AND (title/excerpt ~ bun) AND (title/excerpt ~ routing)
+    expect(posts.map((p) => p.title)).toEqual(['Hono routing'])
+  })
+
+  it('should not let orWhere groups escape the soft-delete scope', async () => {
+    const posts = await SoftPost.where((q) => {
+      q.where('title', 'like', '%bun%').orWhere('excerpt', 'like', '%bun%')
+    }).where('published', true)
+
+    expect(posts.map((p) => p.title).sort()).toEqual(['Bun speed', 'Hono routing'])
+  })
+
+  it('should OR a whole callback group against preceding conditions', async () => {
+    const posts = await Post.where('published', false)
+      .orWhere((q) => q.where('title', 'like', '%Hono%').where('published', true))
+      .get()
+
+    // published = false OR (title ~ Hono AND published = true)
+    expect(posts.map((p) => p.title).sort()).toEqual(['Draft on bun', 'Hono routing'])
+  })
+
+  it('should render nested callbacks inside callbacks', async () => {
+    const posts = await Post.where((q) => {
+      q.where('published', true)
+      q.where((inner) => inner.where('title', 'like', '%speed%').orWhere('excerpt', 'like', '%nothing%'))
+    }).whereNull('deletedAt')
+
+    expect(posts.map((p) => p.title).sort()).toEqual(['Bun speed', 'Unrelated'])
+  })
+
+  it('should apply grouped conditions to bulk update and delete', async () => {
+    await Post.newQuery()
+      .where((q) => q.where('title', 'like', '%bun%').orWhere('excerpt', 'like', '%bun%'))
+      .where('published', true)
+      .forceUpdate({ excerpt: 'matched' })
+
+    const updated = sqlite.query<{ n: number }, []>("SELECT count(*) AS n FROM posts WHERE excerpt = 'matched'").get()
+    expect(updated?.n).toBe(3)
+
+    const deleted = await Post.newQuery()
+      .where((q) => q.where('published', false).orWhere('deletedAt', 'is not null', null))
+      .delete()
+    expect(deleted).toBeDefined()
+
+    const remaining = sqlite.query<{ n: number }, []>('SELECT count(*) AS n FROM posts').get()
+    expect(remaining?.n).toBe(3)
+  })
+})

--- a/packages/orm/tests/where-group-sqlite.test.ts
+++ b/packages/orm/tests/where-group-sqlite.test.ts
@@ -119,6 +119,18 @@ describe('callback where groups on real bun:sqlite driver', () => {
     expect(posts.map((p) => p.title).sort()).toEqual(['Bun speed', 'Unrelated'])
   })
 
+  it('should accept a grouping callback on the transaction-bound scope', async () => {
+    const titles = await Post.transaction(async (_trx, txPost) => {
+      const posts = await txPost
+        .where((q) => q.where('title', 'like', '%bun%').orWhere('excerpt', 'like', '%bun%'))
+        .where('published', true)
+        .get()
+      return posts.map((p) => p.title).sort()
+    })
+
+    expect(titles).toEqual(['Bun speed', 'Deleted bun', 'Hono routing'])
+  })
+
   it('should apply grouped conditions to bulk update and delete', async () => {
     await Post.newQuery()
       .where((q) => q.where('title', 'like', '%bun%').orWhere('excerpt', 'like', '%bun%'))

--- a/packages/orm/tests/where-group-sqlite.test.ts
+++ b/packages/orm/tests/where-group-sqlite.test.ts
@@ -66,6 +66,21 @@ describe('callback where groups on real bun:sqlite driver', () => {
     expect(posts.map((p) => p.title).sort()).toEqual(['Bun speed', 'Deleted bun', 'Hono routing'])
   })
 
+  it('should match any keyword when all OR pairs share one group (blog template shape)', async () => {
+    const posts = await Post.newQuery()
+      .where((q) => {
+        for (const keyword of ['speed', 'routing']) {
+          const pattern = `%${keyword}%`
+          q.orWhere('title', 'like', pattern).orWhere('excerpt', 'like', pattern)
+        }
+      })
+      .where('published', true)
+      .get()
+
+    // (title/excerpt ~ speed OR title/excerpt ~ routing) AND published
+    expect(posts.map((p) => p.title).sort()).toEqual(['Bun speed', 'Hono routing'])
+  })
+
   it('should stack keyword groups for multiple keywords', async () => {
     const query = Post.newQuery().where('published', true)
     for (const keyword of ['bun', 'routing']) {


### PR DESCRIPTION
## Summary

- Add `where(callback)` / `orWhere(callback)` to the ORM `QueryBuilder` (and the static `Model.where`, the transaction-bound scope), mirroring Laravel's `where(fn ($q) => ...)`. Until now `orWhere()` always pushed a top-level OR group, so `(title LIKE ? OR excerpt LIKE ?) AND published = true` was inexpressible — any AND filter next to an OR keyword chain (a published flag, tenancy, soft deletes) was silently OR'd away.
- The sequential fold ("an OR group folds everything before it") that only the Drizzle renderer used to implement now lives in one shared `normalizeConditionSequence` (`packages/orm/src/where-conditions.ts`), consumed by both the grouping callback and the top-level renderer, so the two can't drift apart.
- The blog starter's `posts.search` keyword-OR chain is rewritten to use the new grouping, with the guard comment updated to match.
- Changeset: `@guren/orm` minor, `@guren/core`/`@guren/cli`/`create-guren-app` patch (both re-export/ship changed files that `^2.3.0` on orm wouldn't otherwise pull into the release).

## Review

- `code-review` agent pass (pre-consolidation): confirmed the fold/wrap logic correct by hand-trace; one must-fix (changeset missing core/cli) applied.
- `/simplify` (4 parallel angles) → consolidated the duplicated fold into `where-conditions.ts`, unified the `where`/`orWhere` callback branches into one `pushCallbackGroup` helper, fixed a template comment that described a different query shape than the code built.
- Codex review of the final diff → found and fixed one real gap: `TransactionModelScope.where` was missing the callback overload (compile error inside `Model.transaction()`, despite the runtime path happening to work). Its 100k-case generated-tree comparison found no divergence between the new normalize-then-render path and the old adapter-only fold.

## Test plan

- [x] `bun run build` / `bun run build:clean`
- [x] `bun run typecheck` (root)
- [x] `bun run test:bun` (4258 tests, 0 fail)
- [x] `bun run test:examples`
- [x] New unit tests (fake advanced adapter) + real `bun:sqlite` + Drizzle integration tests covering SoftDeletes, global scopes, transactions, bulk update/delete, and the blog-template query shape
- [x] `bun run audit:core-first` / `audit:docs` / `audit:starter-template` / `sync-template-deps --check`
- [x] `bun run smoke:starter` / `smoke:starter:blog`