### PR TITLE
fix(cli): stop suppressing typecheck on empty route manifests

### DIFF
--- a/packages/cli/src/routes-types-fragments.ts
+++ b/packages/cli/src/routes-types-fragments.ts
@@ -60,7 +60,7 @@ type RouteArgs<TName extends RouteName> =
 /** The `route()` function emitted into the runtime module. */
 export const RUNTIME_ROUTE_FUNCTION = `\
 export function route<TName extends RouteName>(name: TName, ...args: RouteArgs<TName>): string {
-  const definition = routeManifest[name]
+  const definition: { method: RouteMethod; path: RoutePath } | undefined = routeManifest[name]
   if (!definition) {
     throw new Error(\`Route [\${String(name)}] not defined.\`)
   }

--- a/packages/cli/src/routes-types.ts
+++ b/packages/cli/src/routes-types.ts
@@ -106,10 +106,8 @@ export function buildRouteModuleContent(definitions: RouteDefinition[], context:
   const helperTree = buildHelperTree(namedDefinitions)
   const helperObject = renderHelperTree(helperTree, 1)
 
-  const tsNoCheck = namedDefinitions.length === 0 ? '// @ts-nocheck\n' : ''
-
   return `\
-${tsNoCheck}// Generated from ${context.source} — DO NOT EDIT
+// Generated from ${context.source} — DO NOT EDIT
 // Run \`guren codegen\` to regenerate.
 
 export const routeManifest = {

--- a/packages/cli/tests/routes-types.test.ts
+++ b/packages/cli/tests/routes-types.test.ts
@@ -178,4 +178,57 @@ describe('buildRouteModuleContent', () => {
     expect(content).toContain("home: (query?: RouteQuery) => route('home', query)")
     expect(content).toContain("show: (params: RouteParams<'posts.show'>, query?: RouteQuery) => route('posts.show', params, query)")
   })
+
+  it('emits no @ts-nocheck when no routes are named', () => {
+    const content = buildRouteModuleContent([{ method: 'GET', path: '/' }], { source: 'routes/web.ts' })
+
+    expect(content).not.toContain('@ts-nocheck')
+  })
+
+  // The empty manifest used to ship under `@ts-nocheck`, which made the
+  // scaffolded app's typecheck skip this file entirely. Compiling both shapes
+  // is what keeps that suppression from coming back as a hidden type error.
+  it('type-checks under strict tsc with and without named routes', async () => {
+    const ts = (await import('typescript')).default
+    const dir = await mkdtemp(join(tmpdir(), 'guren-routes-types-'))
+    try {
+      const cases: Record<string, string> = {
+        'empty-manifest.ts': buildRouteModuleContent(
+          [{ method: 'GET', path: '/' }],
+          { source: 'routes/web.ts' },
+        ),
+        'named-manifest.ts': buildRouteModuleContent(
+          [
+            { method: 'GET', path: '/', name: 'home' },
+            { method: 'GET', path: '/posts/:id', name: 'posts.show' },
+          ],
+          { source: 'routes/web.ts' },
+        ),
+      }
+
+      const files: string[] = []
+      for (const [name, content] of Object.entries(cases)) {
+        const path = join(dir, name)
+        await writeFile(path, content, 'utf8')
+        files.push(path)
+      }
+
+      const program = ts.createProgram(files, {
+        strict: true,
+        noUnusedLocals: true,
+        noUnusedParameters: true,
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        noEmit: true,
+      })
+      const diagnostics = ts.getPreEmitDiagnostics(program)
+
+      expect(
+        diagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')),
+      ).toEqual([])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
 })

--- a/packages/create-app/templates/blog/.guren/routes.gen.ts
+++ b/packages/create-app/templates/blog/.guren/routes.gen.ts
@@ -48,7 +48,7 @@ type RouteArgs<TName extends RouteName> =
     : [params: RouteParams<TName>, query?: RouteQuery]
 
 export function route<TName extends RouteName>(name: TName, ...args: RouteArgs<TName>): string {
-  const definition = routeManifest[name]
+  const definition: { method: RouteMethod; path: RoutePath } | undefined = routeManifest[name]
   if (!definition) {
     throw new Error(`Route [${String(name)}] not defined.`)
   }

--- a/packages/create-app/templates/default/.guren/routes.gen.ts
+++ b/packages/create-app/templates/default/.guren/routes.gen.ts
@@ -7,8 +7,8 @@ export const routeManifest = {
 
 export type RouteManifest = typeof routeManifest
 export type RouteName = keyof RouteManifest
-export type RouteMethod = RouteManifest[RouteName]['method']
-export type RoutePath = RouteManifest[RouteName]['path']
+export type RouteMethod = [RouteName] extends [never] ? string : RouteManifest[RouteName]['method']
+export type RoutePath = [RouteName] extends [never] ? string : RouteManifest[RouteName]['path']
 
 type PrimitiveQueryValue = string | number | boolean | null | undefined
 type QueryValue = PrimitiveQueryValue | readonly PrimitiveQueryValue[]
@@ -33,7 +33,7 @@ type RouteArgs<TName extends RouteName> =
     : [params: RouteParams<TName>, query?: RouteQuery]
 
 export function route<TName extends RouteName>(name: TName, ...args: RouteArgs<TName>): string {
-  const definition = routeManifest[name]
+  const definition: { method: RouteMethod; path: RoutePath } | undefined = routeManifest[name]
   if (!definition) {
     throw new Error(`Route [${String(name)}] not defined.`)
   }


### PR DESCRIPTION
## Summary
- `buildRouteModuleContent` in `packages/cli/src/routes-types.ts` emitted `// @ts-nocheck` at the top of the generated `routes.gen.ts` whenever the route manifest had no named routes. This silently disabled typechecking for the entire file, including the shipped `.guren/routes.gen.ts` in the default scaffold template (any app with only unnamed routes ships this way).
- The `[RouteName] extends [never]` guard in `routes-types-fragments.ts` already handles the empty-manifest case structurally for the `RouteMethod`/`RoutePath` type aliases, but the `route()` function body still resolved `routeManifest[name]` to `never` without an explicit annotation, so removing `@ts-nocheck` surfaced a real `TS2339: Property 'path' does not exist on type 'never'` error.
- Fix: annotate `definition` in `route()` with the already-guarded `{ method: RouteMethod; path: RoutePath } | undefined` type so the function typechecks under strict tsc with or without named routes, then drop the `@ts-nocheck` emission entirely.
- Regenerated both shipped templates' `.guren/routes.gen.ts` (`default` and `blog`) to match the new generator output.

## Test plan
- [x] Added a unit test asserting the empty-manifest output no longer contains `@ts-nocheck`
- [x] Added a unit test that compiles both the empty-manifest and named-manifest generated modules under strict `tsc` (via the TypeScript compiler API) and asserts zero diagnostics; verified this test fails without the fix (reverted the annotation, confirmed the TS2339 errors surface, restored the fix)
- [x] `bun run typecheck` (root) — passing
- [x] `bun run test:bun` — 4187 pass
- [x] `bun run test:bun cli` — 1340 pass
- [x] `bun run test:examples` — 112 pass
- [x] `bun run audit:core-first`, `bun run audit:docs`, `bun run audit:starter-template` — all passing
- [x] `bun run smoke:starter` (default blueprint, vendored) — passed, 0 failures
- [x] `bun run smoke:starter:blog` — passed, 0 failures