### PR TITLE
feat: migrate scaffolds and docs to drizzle dialect barrels

### DIFF
--- a/.changeset/drizzle-dialect-barrel-migration.md
+++ b/.changeset/drizzle-dialect-barrel-migration.md
@@ -1,0 +1,14 @@
+---
+"@guren/cli": minor
+"create-guren-app": minor
+---
+
+Scaffold schemas from the dialect-specific `@guren/orm/drizzle/{pg,mysql,sqlite}` barrels
+
+Follow-up to #379: generated `db/schema.ts` files now import every column
+builder from the barrel matching the app's dialect, and `guren add auth` /
+`guren add resource` merge new builders into that barrel instead of the mixed
+`@guren/orm/drizzle` (PostgreSQL) or raw `drizzle-orm/*-core` (MySQL/SQLite)
+specifiers. Apps scaffolded before the barrels keep working: builders already
+in scope are left untouched, and only genuinely missing ones are imported via
+the barrel, which requires `@guren/orm` >= 2.3.0.

--- a/docs/en/guides/api-tokens.md
+++ b/docs/en/guides/api-tokens.md
@@ -245,7 +245,7 @@ Column property names must match the `ApiToken` fields:
 
 ```ts
 // db/schema.ts
-import { pgTable, text, timestamp, jsonb } from 'drizzle-orm/pg-core'
+import { pgTable, text, timestamp, jsonb } from '@guren/orm/drizzle/pg'
 
 export const apiTokens = pgTable('api_tokens', {
   id: text('id').primaryKey(),

--- a/docs/en/guides/database.md
+++ b/docs/en/guides/database.md
@@ -8,7 +8,7 @@ Define your table schema, configure the Drizzle adapter, and you are ready to qu
 
 ```ts
 // db/schema.ts
-import { pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core'
+import { pgTable, serial, text, timestamp } from '@guren/orm/drizzle/pg'
 
 export const posts = pgTable('posts', {
   id: serial('id').primaryKey(),

--- a/docs/en/guides/email-verification.md
+++ b/docs/en/guides/email-verification.md
@@ -303,7 +303,7 @@ export class DatabaseEmailVerificationStore implements EmailVerificationTokenSto
 
 ```ts
 // db/schema.ts
-import { pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+import { pgTable, text, timestamp } from '@guren/orm/drizzle/pg'
 
 export const emailVerifications = pgTable('email_verifications', {
   hashedToken: text('hashed_token').primaryKey(),

--- a/docs/en/guides/password-reset.md
+++ b/docs/en/guides/password-reset.md
@@ -279,7 +279,7 @@ export class DatabasePasswordResetStore implements PasswordResetTokenStore {
 
 ```ts
 // db/schema.ts
-import { pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+import { pgTable, text, timestamp } from '@guren/orm/drizzle/pg'
 
 export const passwordResets = pgTable('password_resets', {
   tokenHash: text('token_hash').primaryKey(),

--- a/docs/en/guides/ship-api.md
+++ b/docs/en/guides/ship-api.md
@@ -31,7 +31,7 @@ bun run db:up
 Open `db/schema.ts` and add a table. Here is a simple `tasks` table:
 
 ```typescript
-import { pgTable, serial, text, boolean, timestamp } from 'drizzle-orm/pg-core'
+import { pgTable, serial, text, boolean, timestamp } from '@guren/orm/drizzle/pg'
 
 export const tasks = pgTable('tasks', {
   id: serial('id').primaryKey(),

--- a/docs/ja/guides/api-tokens.md
+++ b/docs/ja/guides/api-tokens.md
@@ -245,7 +245,7 @@ const { plainTextToken } = await createApiToken(store, {
 
 ```ts
 // db/schema.ts
-import { pgTable, text, timestamp, jsonb } from 'drizzle-orm/pg-core'
+import { pgTable, text, timestamp, jsonb } from '@guren/orm/drizzle/pg'
 
 export const apiTokens = pgTable('api_tokens', {
   id: text('id').primaryKey(),

--- a/docs/ja/guides/database.md
+++ b/docs/ja/guides/database.md
@@ -17,7 +17,7 @@ Guren は Drizzle ORM と PostgreSQL を組み合わせて使います。この�
 `db/schema.ts` で Drizzle のスキーマビルダーを使います。
 
 ```ts
-import { pgTable, serial, text, boolean, timestamp, jsonb } from 'drizzle-orm/pg-core'
+import { pgTable, serial, text, boolean, timestamp, jsonb } from '@guren/orm/drizzle/pg'
 
 export const posts = pgTable('posts', {
   id: serial('id').primaryKey(),

--- a/docs/ja/guides/email-verification.md
+++ b/docs/ja/guides/email-verification.md
@@ -303,7 +303,7 @@ export class DatabaseEmailVerificationStore implements EmailVerificationTokenSto
 
 ```ts
 // db/schema.ts
-import { pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+import { pgTable, text, timestamp } from '@guren/orm/drizzle/pg'
 
 export const emailVerifications = pgTable('email_verifications', {
   hashedToken: text('hashed_token').primaryKey(),

--- a/docs/ja/guides/password-reset.md
+++ b/docs/ja/guides/password-reset.md
@@ -279,7 +279,7 @@ export class DatabasePasswordResetStore implements PasswordResetTokenStore {
 
 ```ts
 // db/schema.ts
-import { pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+import { pgTable, text, timestamp } from '@guren/orm/drizzle/pg'
 
 export const passwordResets = pgTable('password_resets', {
   tokenHash: text('token_hash').primaryKey(),

--- a/docs/ja/guides/ship-api.md
+++ b/docs/ja/guides/ship-api.md
@@ -31,7 +31,7 @@ bun run db:up
 `db/schema.ts` を開いてテーブルを追加します。以下はシンプルな `tasks` テーブルの例です:
 
 ```typescript
-import { pgTable, serial, text, boolean, timestamp } from 'drizzle-orm/pg-core'
+import { pgTable, serial, text, boolean, timestamp } from '@guren/orm/drizzle/pg'
 
 export const tasks = pgTable('tasks', {
   id: serial('id').primaryKey(),

--- a/examples/api/db/schema.ts
+++ b/examples/api/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, text, uniqueIndex, integer, boolean, timestamp } from 'drizzle-orm/pg-core'
+import { pgTable, serial, text, uniqueIndex, integer, boolean, timestamp } from '@guren/orm/drizzle/pg'
 
 export const users = pgTable(
   'users',

--- a/examples/api/vitest.config.ts
+++ b/examples/api/vitest.config.ts
@@ -45,6 +45,10 @@ export default defineConfig({
         replacement: resolveFromRoot('../../packages/orm/src/drizzle.ts'),
       },
       {
+        find: /^@guren\/orm\/drizzle\/(.+)$/,
+        replacement: resolveFromRoot('../../packages/orm/src/drizzle/$1.ts'),
+      },
+      {
         find: /^@guren\/orm\//,
         replacement: resolveFromRoot('../../packages/orm/src/'),
       },

--- a/examples/blog/db/schema.ts
+++ b/examples/blog/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, text, timestamp, uniqueIndex, integer } from '@guren/orm/drizzle'
+import { pgTable, serial, text, timestamp, uniqueIndex, integer } from '@guren/orm/drizzle/pg'
 
 export const users = pgTable(
   'users',

--- a/examples/blog/vitest.config.ts
+++ b/examples/blog/vitest.config.ts
@@ -84,6 +84,10 @@ export default defineConfig({
         replacement: resolve(rootDir, '../../packages/orm/src/drizzle.ts'),
       },
       {
+        find: /^@guren\/orm\/drizzle\/(.+)$/,
+        replacement: resolve(rootDir, '../../packages/orm/src/drizzle/$1.ts'),
+      },
+      {
         find: /^@guren\/orm\//,
         replacement: resolve(rootDir, '../../packages/orm/src/'),
       },

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -15,7 +15,7 @@ import { makeModel } from './make-model'
 import { makeNotification } from './make-notification'
 import { makeRoute } from './make-route'
 import { makeView } from './make-view'
-import { detectSchemaDialect, ensureDrizzleImports, ensureMysqlImports, ensureSqliteImports, insertImport } from './patch-helpers'
+import { detectSchemaDialect, ensureMysqlImports, ensurePgImports, ensureSqliteImports, insertImport } from './patch-helpers'
 import { wireProviders } from './provider-registrar'
 import { DEFAULT_ROUTES_FILE, findRouteRegistrar, wireRouteRegistrar } from './route-registrar'
 import { assertCwdUnsupported, camelCase, pascalCase, writeScaffoldFiles, type WriterOptions } from './utils'
@@ -789,7 +789,7 @@ async function updateResourceSchema(singular: string, fields: FieldDefinition[])
 
     const columns = fields.map((field) => buildColumn(PG_COLUMNS, field))
     const imports = [...new Set(['pgTable', 'serial', 'text', 'timestamp', ...columns.flatMap((c) => c.imports)])]
-    content = ensureDrizzleImports(content, imports)
+    content = ensurePgImports(content, imports)
 
     const fieldLines = fields.map((field, index) => `  ${field.name}: ${columns[index].code},`).join('\n')
     const schemaBlock = `\nexport const ${schemaIdentifier} = pgTable('${tableName}', {\n  id: serial('id').primaryKey(),\n${fieldLines}\n  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),\n})\n`

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -6,8 +6,8 @@ import { assertNotApiOnly } from './app-surface'
 import {
   addCreateAppOption,
   detectSchemaDialect,
-  ensureDrizzleImports,
   ensureMysqlImports,
+  ensurePgImports,
   ensureSqliteImports,
   PATCH_REASONS,
   readSchemaDialect,
@@ -1867,7 +1867,7 @@ function ensureAuthColumnImports(content: string, dialect: SchemaDialect): strin
   if (dialect === 'mysql') {
     return ensureMysqlImports(content, ['mysqlTable', 'int', 'varchar', 'timestamp'])
   }
-  return ensureDrizzleImports(content, ['pgTable', 'serial', 'text', 'timestamp'])
+  return ensurePgImports(content, ['pgTable', 'serial', 'text', 'timestamp'])
 }
 
 /**

--- a/packages/cli/src/patch-helpers.test.ts
+++ b/packages/cli/src/patch-helpers.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { addImport, addProvider, hasImport, hasAuthProvider, ensureDrizzleImports, ensureMysqlImports, ensureNamedImports, ensureSqliteImports } from './patch-helpers'
+import { addImport, addProvider, hasImport, hasAuthProvider, ensureMysqlImports, ensureNamedImports, ensurePgImports, ensureSqliteImports } from './patch-helpers'
 
 describe('patch-helpers', () => {
   let tempDir: string
@@ -239,35 +239,47 @@ const app = new Application()`
     })
   })
 
-  describe('ensureDrizzleImports', () => {
+  describe('ensurePgImports', () => {
     it('should add missing imports when no Drizzle import exists', () => {
       const content = `const x = 1\n`
-      const result = ensureDrizzleImports(content, ['pgTable', 'serial', 'text'])
+      const result = ensurePgImports(content, ['pgTable', 'serial', 'text'])
 
-      expect(result).toContain("import { pgTable, serial, text } from '@guren/orm/drizzle'")
+      expect(result).toContain("import { pgTable, serial, text } from '@guren/orm/drizzle/pg'")
       expect(result).toContain('const x = 1')
     })
 
     it('should merge into existing Drizzle import', () => {
-      const content = `import { pgTable, serial } from '@guren/orm/drizzle'\n\nexport const posts = pgTable('posts', {})\n`
-      const result = ensureDrizzleImports(content, ['pgTable', 'serial', 'text', 'timestamp'])
+      const content = `import { pgTable, serial } from '@guren/orm/drizzle/pg'\n\nexport const posts = pgTable('posts', {})\n`
+      const result = ensurePgImports(content, ['pgTable', 'serial', 'text', 'timestamp'])
 
-      expect(result).toContain("import { pgTable, serial, text, timestamp } from '@guren/orm/drizzle'")
+      expect(result).toContain("import { pgTable, serial, text, timestamp } from '@guren/orm/drizzle/pg'")
       expect(result).not.toContain("import { pgTable, serial }")
     })
 
     it('should not modify content when all imports already present', () => {
-      const content = `import { pgTable, serial, text, timestamp } from '@guren/orm/drizzle'\n\nexport const posts = pgTable('posts', {})\n`
-      const result = ensureDrizzleImports(content, ['pgTable', 'serial', 'text', 'timestamp'])
+      const content = `import { pgTable, serial, text, timestamp } from '@guren/orm/drizzle/pg'\n\nexport const posts = pgTable('posts', {})\n`
+      const result = ensurePgImports(content, ['pgTable', 'serial', 'text', 'timestamp'])
 
       expect(result).toBe(content)
     })
 
     it('should return content unchanged when needed list is empty', () => {
       const content = `const x = 1\n`
-      const result = ensureDrizzleImports(content, [])
+      const result = ensurePgImports(content, [])
 
       expect(result).toBe(content)
+    })
+
+    // Apps scaffolded before the dialect barrels import from the mixed
+    // `@guren/orm/drizzle` (or, for sqlite/mysql, `drizzle-orm/<dialect>-core`
+    // — the mechanism is identical). Names already in scope count as present;
+    // only genuinely new builders arrive via the barrel.
+    it('should add only the missing builders for a pre-barrel app', () => {
+      const legacy = `import { pgTable, serial, text, timestamp } from '@guren/orm/drizzle'\n\nexport const posts = pgTable('posts', {})\n`
+      const result = ensurePgImports(legacy, ['pgTable', 'serial', 'text', 'timestamp', 'boolean'])
+
+      expect(result).toContain("import { boolean } from '@guren/orm/drizzle/pg'")
+      expect(result).toContain("import { pgTable, serial, text, timestamp } from '@guren/orm/drizzle'")
     })
   })
 
@@ -276,20 +288,20 @@ const app = new Application()`
       const content = `const x = 1\n`
       const result = ensureSqliteImports(content, ['sqliteTable', 'integer', 'text'])
 
-      expect(result).toContain("import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'")
+      expect(result).toContain("import { integer, sqliteTable, text } from '@guren/orm/drizzle/sqlite'")
       expect(result).toContain('const x = 1')
     })
 
     it('should merge into existing SQLite import', () => {
-      const content = `import { sqliteTable, integer } from 'drizzle-orm/sqlite-core'\n\nexport const users = sqliteTable('users', {})\n`
+      const content = `import { sqliteTable, integer } from '@guren/orm/drizzle/sqlite'\n\nexport const users = sqliteTable('users', {})\n`
       const result = ensureSqliteImports(content, ['sqliteTable', 'integer', 'text'])
 
-      expect(result).toContain("import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'")
+      expect(result).toContain("import { integer, sqliteTable, text } from '@guren/orm/drizzle/sqlite'")
       expect(result).not.toContain("import { sqliteTable, integer }")
     })
 
     it('should not modify content when all imports already present', () => {
-      const content = `import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'\n\nexport const users = sqliteTable('users', {})\n`
+      const content = `import { integer, sqliteTable, text } from '@guren/orm/drizzle/sqlite'\n\nexport const users = sqliteTable('users', {})\n`
       const result = ensureSqliteImports(content, ['sqliteTable', 'integer', 'text'])
 
       expect(result).toBe(content)
@@ -305,13 +317,13 @@ const app = new Application()`
 
   describe('ensureMysqlImports', () => {
     // The header `create-guren-app --db mysql` scaffolds.
-    const scaffoldedSchema = `import { mysqlTable, int, varchar, timestamp } from 'drizzle-orm/mysql-core'\n\nexport const users = mysqlTable('users', {})\n`
+    const scaffoldedSchema = `import { mysqlTable, int, varchar, timestamp } from '@guren/orm/drizzle/mysql'\n\nexport const users = mysqlTable('users', {})\n`
 
     it('should add missing imports when no MySQL import exists', () => {
       const content = `const x = 1\n`
       const result = ensureMysqlImports(content, ['mysqlTable', 'int', 'varchar'])
 
-      expect(result).toContain("import { int, mysqlTable, varchar } from 'drizzle-orm/mysql-core'")
+      expect(result).toContain("import { int, mysqlTable, varchar } from '@guren/orm/drizzle/mysql'")
       expect(result).toContain('const x = 1')
     })
 
@@ -319,7 +331,7 @@ const app = new Application()`
       const result = ensureMysqlImports(scaffoldedSchema, ['mysqlTable', 'int', 'timestamp', 'boolean'])
 
       expect(result).toContain(
-        "import { boolean, int, mysqlTable, timestamp, varchar } from 'drizzle-orm/mysql-core'",
+        "import { boolean, int, mysqlTable, timestamp, varchar } from '@guren/orm/drizzle/mysql'",
       )
       // One import line, not a second one appended alongside it.
       expect(result.match(/^import /gmu)).toHaveLength(1)
@@ -338,12 +350,11 @@ const app = new Application()`
       expect(result).toBe(content)
     })
 
-    // Documents why the mysql scaffold must not import from
-    // `@guren/orm/drizzle`: the merge is not module-scoped, so a same-named
-    // builder already in scope from another dialect satisfies the requirement
-    // and the MySQL one is never imported. Scoping the match per module would
-    // be an improvement — update this test rather than treating it as a
-    // regression.
+    // Documents that the merge is not module-scoped: a same-named builder
+    // already in scope from another module satisfies the requirement, so a
+    // pre-barrel app is left untouched when nothing is missing. Scoping the
+    // match per module would be an improvement — update this test rather than
+    // treating it as a regression.
     it('should not re-import a name another module already brought into scope', () => {
       const mixed = `import { mysqlTable, int, varchar, timestamp } from '@guren/orm/drizzle'\n\nexport const users = mysqlTable('users', {})\n`
       const result = ensureMysqlImports(mixed, ['mysqlTable', 'int', 'varchar', 'timestamp'])

--- a/packages/cli/src/patch-helpers.ts
+++ b/packages/cli/src/patch-helpers.ts
@@ -479,11 +479,30 @@ export type { SchemaDialect }
  * case that matters most is a schema with no tables yet — hence the `pg`
  * fallback below, which a parse-based answer could not produce.
  */
+/**
+ * The `@guren/orm/drizzle/<dialect>` barrel each dialect's schema imports its
+ * column builders from: a dialect signal for `detectSchemaDialect`, and the
+ * module the `ensure*Imports` patchers below merge new builders into.
+ */
+export const DIALECT_BARRELS = {
+  sqlite: '@guren/orm/drizzle/sqlite',
+  pg: '@guren/orm/drizzle/pg',
+  mysql: '@guren/orm/drizzle/mysql',
+} as const satisfies Record<SchemaDialect, string>
+
 export function detectSchemaDialect(content: string): SchemaDialect {
-  if (content.includes('sqliteTable') || content.includes('drizzle-orm/sqlite-core')) {
+  if (
+    content.includes('sqliteTable') ||
+    content.includes('drizzle-orm/sqlite-core') ||
+    content.includes(DIALECT_BARRELS.sqlite)
+  ) {
     return 'sqlite'
   }
-  if (content.includes('mysqlTable') || content.includes('drizzle-orm/mysql-core')) {
+  if (
+    content.includes('mysqlTable') ||
+    content.includes('drizzle-orm/mysql-core') ||
+    content.includes(DIALECT_BARRELS.mysql)
+  ) {
     return 'mysql'
   }
   return 'pg'
@@ -552,16 +571,20 @@ export function ensureNamedImports(content: string, specifier: string, needed: s
   return match ? content.replace(existingImport, () => importLine) : `${importLine}\n${content}`
 }
 
-export function ensureDrizzleImports(content: string, needed: string[]): string {
-  return ensureNamedImports(content, '@guren/orm/drizzle', needed)
+// Pre-barrel apps keep their `@guren/orm/drizzle` / `drizzle-orm/<dialect>-core`
+// imports: those resolve to the same drizzle-orm copy as the barrels (see
+// drizzle-pins.ts), so the mixed specifiers a patch leaves behind are safe.
+
+export function ensurePgImports(content: string, needed: string[]): string {
+  return ensureNamedImports(content, DIALECT_BARRELS.pg, needed)
 }
 
 export function ensureSqliteImports(content: string, needed: string[]): string {
-  return ensureNamedImports(content, 'drizzle-orm/sqlite-core', needed)
+  return ensureNamedImports(content, DIALECT_BARRELS.sqlite, needed)
 }
 
 export function ensureMysqlImports(content: string, needed: string[]): string {
-  return ensureNamedImports(content, 'drizzle-orm/mysql-core', needed)
+  return ensureNamedImports(content, DIALECT_BARRELS.mysql, needed)
 }
 
 /**

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -137,12 +137,12 @@ describe('blueprints', () => {
     expect(schema).toContain("meta: json('meta').notNull()")
     expect(schema).toContain("published: boolean('published').notNull()")
     // Every builder — the scaffolded ones and the ones this run added — must
-    // come from mysql-core. `@guren/orm/drizzle` re-exports the pg builders
-    // under the same names, and mixing them is silent at build time.
+    // come from the MySQL dialect barrel. Builder names are shared across
+    // dialects, and mixing them is silent at build time.
     const importedModules = [...schema.matchAll(/import\s*\{[^}]*\}\s*from\s*['"]([^'"]+)['"]/g)].map(
       (match) => match[1],
     )
-    expect([...new Set(importedModules)]).toEqual(['drizzle-orm/mysql-core'])
+    expect([...new Set(importedModules)]).toEqual(['@guren/orm/drizzle/mysql'])
   })
 
   // The schema export, the model's import of it, and `guren check`'s table
@@ -505,7 +505,7 @@ export default function registerWebRoutes(appRouter: Router): void {
   const COLUMN_CASES = [
     {
       dialect: 'sqlite',
-      schema: `import { sqliteTable, integer, text } from '@guren/orm/drizzle'
+      schema: `import { sqliteTable, integer, text } from '@guren/orm/drizzle/sqlite'
 
 export const users = sqliteTable('users', {
   id: integer('id').primaryKey({ autoIncrement: true }),
@@ -523,7 +523,7 @@ export const users = sqliteTable('users', {
     },
     {
       dialect: 'mysql',
-      schema: `import { mysqlTable, int, varchar } from '@guren/orm/drizzle'
+      schema: `import { mysqlTable, int, varchar } from '@guren/orm/drizzle/mysql'
 
 export const users = mysqlTable('users', {
   id: int('id').primaryKey().autoincrement(),
@@ -541,7 +541,7 @@ export const users = mysqlTable('users', {
     },
     {
       dialect: 'postgres',
-      schema: `import { pgTable, serial, text } from '@guren/orm/drizzle'
+      schema: `import { pgTable, serial, text } from '@guren/orm/drizzle/pg'
 
 export const users = pgTable('users', {
   id: serial('id').primaryKey(),

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -79,11 +79,10 @@ export async function linkInstalledPackage(
 /**
  * The `db/schema.ts` a fresh app starts from, per dialect. Kept in the shape
  * `create-guren-app` scaffolds so the patchers are exercised against what
- * users actually have on disk — notably, MySQL apps import their builders
- * from `drizzle-orm/mysql-core`, never from the PostgreSQL-first
- * `@guren/orm/drizzle` subpath.
+ * users actually have on disk — each dialect imports its builders from its
+ * own `@guren/orm/drizzle/<dialect>` barrel.
  */
-export const PG_SCHEMA_FIXTURE = `import { pgTable, serial, text, timestamp } from '@guren/orm/drizzle'
+export const PG_SCHEMA_FIXTURE = `import { pgTable, serial, text, timestamp } from '@guren/orm/drizzle/pg'
 
 export const users = pgTable('users', {
   id: serial('id').primaryKey(),
@@ -93,7 +92,7 @@ export const users = pgTable('users', {
 })
 `
 
-export const MYSQL_SCHEMA_FIXTURE = `import { mysqlTable, int, varchar, timestamp } from 'drizzle-orm/mysql-core'
+export const MYSQL_SCHEMA_FIXTURE = `import { mysqlTable, int, varchar, timestamp } from '@guren/orm/drizzle/mysql'
 
 export const users = mysqlTable('users', {
   id: int('id').primaryKey().autoincrement(),
@@ -103,7 +102,7 @@ export const users = mysqlTable('users', {
 })
 `
 
-export const SQLITE_SCHEMA_FIXTURE = `import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core'
+export const SQLITE_SCHEMA_FIXTURE = `import { sqliteTable, integer, text } from '@guren/orm/drizzle/sqlite'
 
 export const users = sqliteTable('users', {
   id: integer('id').primaryKey({ autoIncrement: true }),

--- a/packages/create-app/src/blueprints.ts
+++ b/packages/create-app/src/blueprints.ts
@@ -293,9 +293,11 @@ export type AppSeederContext = ${seederContext}
 `
 }
 
+// Each dialect imports from its own `@guren/orm/drizzle/<dialect>` barrel —
+// the same modules `guren add auth` / `add resource` merge new columns into.
 function generateSchema(driver: DatabaseDriver): string {
   if (driver === 'postgres') {
-    return `import { pgTable, serial, text, timestamp } from '@guren/orm/drizzle'
+    return `import { pgTable, serial, text, timestamp } from '@guren/orm/drizzle/pg'
 
 export const users = pgTable('users', {
   id: serial('id').primaryKey(),
@@ -307,12 +309,7 @@ export const users = pgTable('users', {
   }
 
   if (driver === 'mysql') {
-    // MySQL uses drizzle-orm directly — @guren/orm/drizzle re-exports the
-    // PostgreSQL builders under the plain names (`timestamp`, `text`), so a
-    // MySQL table imported from there is built out of pg column builders.
-    // This is also the module `guren add auth` / `add resource` merge their
-    // new columns into.
-    return `import { mysqlTable, int, varchar, timestamp } from 'drizzle-orm/mysql-core'
+    return `import { mysqlTable, int, varchar, timestamp } from '@guren/orm/drizzle/mysql'
 
 export const users = mysqlTable('users', {
   id: int('id').primaryKey().autoincrement(),
@@ -323,8 +320,7 @@ export const users = mysqlTable('users', {
 `
   }
 
-  // SQLite uses drizzle-orm directly — @guren/orm/drizzle does not re-export SQLite helpers
-  return `import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core'
+  return `import { sqliteTable, integer, text } from '@guren/orm/drizzle/sqlite'
 
 export const users = sqliteTable('users', {
   id: integer('id').primaryKey({ autoIncrement: true }),

--- a/packages/create-app/templates/api-only/db/schema.ts
+++ b/packages/create-app/templates/api-only/db/schema.ts
@@ -1,3 +1,3 @@
-import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core'
+import { sqliteTable, integer, text } from '@guren/orm/drizzle/sqlite'
 
 export const schema = {}

--- a/packages/create-app/templates/blog/db/schema.mysql.ts
+++ b/packages/create-app/templates/blog/db/schema.mysql.ts
@@ -1,8 +1,4 @@
-// Imported from drizzle-orm/mysql-core rather than @guren/orm/drizzle, which
-// re-exports `text` and `timestamp` from pg-core only — taking them from there
-// would build a MySQL table out of PostgreSQL column builders. Drizzle happens
-// to emit the same DDL either way today; this does not rely on that.
-import { mysqlTable, int, varchar, text, timestamp } from 'drizzle-orm/mysql-core'
+import { mysqlTable, int, varchar, text, timestamp } from '@guren/orm/drizzle/mysql'
 
 export const users = mysqlTable('users', {
   id: int('id').primaryKey().autoincrement(),

--- a/packages/create-app/templates/blog/db/schema.postgres.ts
+++ b/packages/create-app/templates/blog/db/schema.postgres.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, integer, text, timestamp } from '@guren/orm/drizzle'
+import { pgTable, serial, integer, text, timestamp } from '@guren/orm/drizzle/pg'
 
 export const users = pgTable('users', {
   id: serial('id').primaryKey(),

--- a/packages/create-app/templates/blog/db/schema.sqlite.ts
+++ b/packages/create-app/templates/blog/db/schema.sqlite.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core'
+import { sqliteTable, integer, text } from '@guren/orm/drizzle/sqlite'
 
 export const users = sqliteTable('users', {
   id: integer('id').primaryKey({ autoIncrement: true }),

--- a/packages/create-app/templates/default/db/schema.ts
+++ b/packages/create-app/templates/default/db/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core'
+import { sqliteTable, integer, text } from '@guren/orm/drizzle/sqlite'
 
 export const users = sqliteTable('users', {
   id: integer('id').primaryKey({ autoIncrement: true }),

--- a/packages/create-app/tests/schema-dialect.test.ts
+++ b/packages/create-app/tests/schema-dialect.test.ts
@@ -11,13 +11,14 @@ import { createTempWorkspace } from './helpers'
  * still emits DDL and tsc still passes, so nothing downstream reports that a
  * MySQL table was built out of PostgreSQL columns.
  *
- * `@guren/orm/drizzle` re-exports the pg-core builders under those plain
- * names, which is why only the PostgreSQL scaffold may import from it.
+ * The `@guren/orm/drizzle/<dialect>` barrels re-export exactly one dialect's
+ * builders each, so importing from the matching barrel is what keeps every
+ * name dialect-pure.
  */
 const EXPECTED_SCHEMA_MODULE = {
-  postgres: '@guren/orm/drizzle',
-  mysql: 'drizzle-orm/mysql-core',
-  sqlite: 'drizzle-orm/sqlite-core',
+  postgres: '@guren/orm/drizzle/pg',
+  mysql: '@guren/orm/drizzle/mysql',
+  sqlite: '@guren/orm/drizzle/sqlite',
 } as const satisfies Record<DatabaseDriver, string>
 
 function importedModules(source: string): string[] {

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -1,4 +1,4 @@
-import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { integer, sqliteTable, text } from '@guren/orm/drizzle/sqlite'
 
 export const users = sqliteTable('users', {
   id: integer('id').primaryKey({ autoIncrement: true }),

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
       { find: /^@guren\/core$/, replacement: resolveFromRoot('../packages/core/src/index.ts') },
       { find: /^@guren\/core\//, replacement: resolveFromRoot('../packages/core/src/') },
       { find: /^@guren\/orm$/, replacement: resolveFromRoot('../packages/orm/src/index.ts') },
+      {
+        find: /^@guren\/orm\/drizzle\/(.+)$/,
+        replacement: resolveFromRoot('../packages/orm/src/drizzle/$1.ts'),
+      },
       { find: /^@guren\/orm\//, replacement: resolveFromRoot('../packages/orm/src/') },
       { find: /^@guren\/plugin-cloudflare$/, replacement: resolveFromRoot('../packages/plugin-cloudflare/src/index.ts') },
       { find: /^guren$/, replacement: resolveFromRoot('../packages/core/src/index.ts') },


### PR DESCRIPTION
## Summary

Follow-up to #379 / #387, unlocked by `@guren/orm` 2.3.0 shipping in v2.5.0. Every scaffold, patcher, example, and doc that imported drizzle column builders from the mixed `@guren/orm/drizzle` barrel or raw `drizzle-orm/*-core` subpaths now imports from the dialect-specific barrels: `@guren/orm/drizzle/pg`, `/mysql`, `/sqlite`.

- **create-app**: templates (`default`, `api-only`, `blog` postgres/mysql/sqlite variants) and `blueprints.ts`'s `generateSchema()` now emit dialect-barrel imports.
- **cli**: `ensureDrizzleImports` renamed to `ensurePgImports`; all three `ensure*Imports` patchers (used by `guren add auth` / `guren add resource`) merge new builders into their dialect's barrel via a new `DIALECT_BARRELS` constant. `detectSchemaDialect` recognizes the barrel specifiers too.
- **examples/blog, examples/api, web**: schema files migrated; `vitest.config.ts` in all three gained an exact alias for `@guren/orm/drizzle/<dialect>` — the existing `@guren/orm/` prefix alias silently mangles subpaths because `resolve()` strips the trailing separator.
- **docs**: en/ja guide code samples (database, ship-api, api-tokens, password-reset, email-verification) updated.
- Apps scaffolded before the barrels existed keep working: the import-merge check is not module-scoped, so names already in scope are left alone and only genuinely missing builders arrive via the barrel (covered by tests).
- Changeset: minor bump for `@guren/cli` and `create-guren-app`.

## Review

Went through Codex review + the `/simplify` 4-angle pass before opening this PR:
- Extracted a `DIALECT_BARRELS` constant (was duplicated across 5 call sites).
- Fixed a leftover `SQLITE_SCHEMA_FIXTURE` still on the pre-barrel specifier.
- Trimmed duplicated inline comments and generalized the vitest alias regex.
- Two Codex-flagged edge cases (aliased/type-only import names slipping past the non-module-scoped merge check; whole-file dialect sniffing matching text inside comments) were confirmed as pre-existing behavior unchanged by this diff, not regressions — left as-is.

## Test plan

- [x] `bun run build:clean`
- [x] `bun run typecheck` (root + web)
- [x] `bun run test:bun` (full suite, 4187+ pass)
- [x] `bun run test:examples` (blog + api + web)
- [x] `bun run audit:starter-template`, `audit:core-first`, `audit:docs`, `audit:template-deps`
- [x] `bun run smoke:starter`, `smoke:starter:api`, `smoke:starter:blog`
- [x] `bun run smoke:starter:npm` (installs `@guren/orm` 2.3.0 from the registry — confirms the published API is what the templates now depend on)