### PR TITLE
fix(cli): stop Hono path modifiers leaking into route param types

### DIFF
--- a/.changeset/hono-path-modifier-params.md
+++ b/.changeset/hono-path-modifier-params.md
@@ -1,0 +1,17 @@
+---
+"@guren/cli": patch
+"@guren/server": patch
+"@guren/openapi": patch
+"@guren/inertia-client": patch
+"create-guren-app": patch
+---
+
+Fix Hono path modifiers (`{regex}`, `?`, `*`) leaking into generated route param types, substituted URLs, and OpenAPI output.
+
+A route path like `/items/:id{[0-9]+}` or `/archive/:slug?` previously produced a `RouteParams<'items.show'>` key of `"id{[0-9]+}"` instead of `"id"`, and `router.route()` / the generated API client / `<Link>`/`<Form>` left the modifier text in the substituted URL (`/items/5{[0-9]+}`). The shared `PathParamKeys` type helper and `substituteParams` runtime helper (`@guren/cli`'s `routes-types-fragments.ts`, mirrored in `@guren/inertia-client`'s `components.tsx`, and duplicated in `@guren/server`'s `Router.route()`) now strip a regex constraint and a trailing `?` before deriving the param key. `@guren/openapi`'s `toOpenApiPath`/`extractPathParamNames`/`buildOperationId` get the same treatment, converting `/items/:id{[0-9]+}` to the valid template `/items/{id}` instead of `/items/{id}{[0-9]+}`.
+
+`:name*` is deliberately **not** treated as a modifier: verified directly against Hono, it is not wildcard syntax — it registers a literal, single-segment param whose real runtime key is `name*` (asterisk included). The param-key rule now keeps that key as-is rather than stripping it, so generated types and substituted URLs agree with what Hono actually does. `@guren/openapi` is the one exception — OpenAPI path templates follow RFC 6570, where `{name*}` already means "explode", so the `*` is dropped there to avoid emitting a template that means something else. Route model binding (`Router`'s `resolveModelBindings`/`serializeBindings`) is not extended to resolve a `:name*` key; docs now call out `:name*` as a pattern to avoid, recommending a constrained parameter like `:path{.+}` for multi-segment matching instead.
+
+`@guren/server`'s `Router.route()`, `resolveModelBindings`, and `serializeBindings` also stop misreading a `:` that appears inside a regex constraint's character class (e.g. `{[a-z:]+}`) as the start of another param.
+
+`create-guren-app`'s `default` and `blog` template `.guren/routes.gen.ts` / `.guren/api-client.gen.ts` are regenerated with the fix.

--- a/docs/en/guides/routing.md
+++ b/docs/en/guides/routing.md
@@ -243,6 +243,8 @@ const id = this.ctx.req.param('id')
 const userId = this.ctx.req.param('userId')
 ```
 
+Optional segments (`router.get('/posts/:id?', handler)`) and regex constraints (`router.get('/items/:id{[0-9]+}', handler)`) follow Hono's pattern support. To match across multiple segments, use a constrained parameter such as `:path{.+}`. Note that `/:slug*` is not Hono wildcard syntax: it registers a single-segment parameter literally named `slug*`, so avoid it.
+
 > [!NOTE]
 > For large apps, split routes into multiple registrars (`routes/api.ts`, `routes/admin.ts`) and compose them from `src/app.ts`.
 

--- a/docs/ja/guides/routing.md
+++ b/docs/ja/guides/routing.md
@@ -146,7 +146,7 @@ router.get('/posts/:id', [PostsController, 'show'])
 
 コントローラー内では `this.validateParams()` か `this.ctx.req.param('id')` でパラメータを読み取ります。
 
-オプショナルセグメントには Hono のパターンサポート（`router.get('/posts/:id?', handler)`）を使い、ワイルドカードには `*`（例: `/:slug*`）を使います。
+オプショナルセグメント（`router.get('/posts/:id?', handler)`）や正規表現制約（`router.get('/items/:id{[0-9]+}', handler)`）も Hono のパターンサポートで利用できます。複数セグメントにまたがるマッチには `:path{.+}` のような制約付きパラメータを使います。なお `/:slug*` は Hono のワイルドカード構文ではありません。`slug*` という名前の単一セグメントパラメータとして登録されてしまうため、使わないでください。
 
 ## ルートモデルバインディング
 

--- a/packages/cli/src/routes-types-fragments.ts
+++ b/packages/cli/src/routes-types-fragments.ts
@@ -32,6 +32,19 @@ declare module '@inertiajs/core' {
  * keys a route path literal binds, whether it binds any, and the params
  * object they form.
  *
+ * Hono path params carry optional modifiers the key extraction must see
+ * through: a regex constraint (\`:id{[0-9]+}\`, which may itself contain \`/\`
+ * but never \`}\`) and a trailing \`?\` (optional segment). \`StripParamPatterns\`
+ * removes constraint bodies before the path is split into \`:\`/\`/\`-delimited
+ * segments, so a constraint's own \`/\` cannot be mistaken for a path
+ * separator; \`NormalizeParamKey\` then drops a trailing \`?\`.
+ *
+ * A trailing \`*\` is deliberately left alone. Unlike \`?\` and \`{...}\`, \`*\` is
+ * not a Hono modifier — \`:slug*\` names a literal, single-segment param whose
+ * runtime key really is \`slug*\` (verified against Hono directly; see
+ * docs/*\/guides/routing.md). Stripping it would type a key Hono never
+ * produces.
+ *
  * Emitted into every generated module that answers those questions — the
  * route manifest and the API client — so they all derive the answers from
  * the path string the server routes on, not from whatever shape their
@@ -44,9 +57,13 @@ declare module '@inertiajs/core' {
  */
 export const PATH_PARAM_TYPE_HELPERS = `\
 type NormalizeParamKey<TValue extends string> = TValue extends \`\${infer Key}?\` ? Key : TValue
-type PathParamKeys<TPath extends string> =
+type StripParamPatterns<TPath extends string> = TPath extends \`\${infer Head}{\${string}}\${infer Tail}\`
+  ? \`\${Head}\${StripParamPatterns<Tail>}\`
+  : TPath
+type PathParamKeys<TPath extends string> = ExtractParamKeys<StripParamPatterns<TPath>>
+type ExtractParamKeys<TPath extends string> =
   TPath extends \`\${string}:\${infer Param}/\${infer Rest}\`
-    ? NormalizeParamKey<Param> | PathParamKeys<\`/\${Rest}\`>
+    ? NormalizeParamKey<Param> | ExtractParamKeys<\`/\${Rest}\`>
     : TPath extends \`\${string}:\${infer Param}\`
       ? NormalizeParamKey<Param>
       : never
@@ -95,11 +112,17 @@ export function route<TName extends RouteName>(name: TName, ...args: RouteArgs<T
 
 /**
  * The runtime half of the path-param rule: how a bound key is substituted
- * into the path. Token-based — whole `:param` tokens are replaced by key
- * lookup — so a param whose name is a prefix of another (`:id` vs
- * `:identifier`) can never corrupt it, and a key the path lacks really is a
- * no-op. A per-key `path.replace(':key', ...)` loop has neither property;
- * that spelling is what this fragment exists to keep out of the generators.
+ * into the path. Token-based — whole `:param` tokens, modifiers included,
+ * are replaced by key lookup — so a param whose name is a prefix of another
+ * (`:id` vs `:identifier`) can never corrupt it, and a key the path lacks
+ * really is a no-op. A per-key `path.replace(':key', ...)` loop has neither
+ * property; that spelling is what this fragment exists to keep out of the
+ * generators.
+ *
+ * The key capture group mirrors PATH_PARAM_TYPE_HELPERS: a trailing regex
+ * constraint (`{...}`) and `?` are modifiers consumed with the token but
+ * excluded from the key, while a trailing `*` is part of the literal key
+ * (Hono's own behavior for `:slug*` — see that fragment's doc comment).
  *
  * Mirrored verbatim in @guren/inertia-client's components.tsx alongside
  * PATH_PARAM_TYPE_HELPERS, under the same pin test.
@@ -110,7 +133,7 @@ function substituteParams(path: string, params?: Record<string, string | number>
     return path
   }
 
-  return path.replace(/:([A-Za-z0-9_-]+)/gu, (match, key) => {
+  return path.replace(/:([A-Za-z0-9_-]+\\*?)(?:\\{[^}]*\\})?\\??/gu, (match, key) => {
     if (!Object.prototype.hasOwnProperty.call(params, key)) {
       return match
     }

--- a/packages/cli/src/routes-types.ts
+++ b/packages/cli/src/routes-types.ts
@@ -126,7 +126,11 @@ export function toTypeLiteral(path: string): string {
     return `'${escapeSingleQuotes(path)}'`
   }
 
-  const segments = path.split('/')
+  // A Hono regex constraint (`:id{[0-9]+}`) may contain `/`, so it must be
+  // stripped before splitting the path into segments — otherwise a `/`
+  // inside the constraint is mistaken for a path separator.
+  const withoutPatterns = path.replace(/\{[^}]*\}/gu, '')
+  const segments = withoutPatterns.split('/')
   const rendered = segments
     .map((segment) => {
       if (!segment) {
@@ -223,5 +227,9 @@ function renderHelperNode(segment: string, node: HelperTreeNode, depth: number):
 }
 
 function extractParamNames(path: string): string[] {
-  return Array.from(path.matchAll(/:([A-Za-z0-9_-]+)/gu), (match) => match[1])
+  // A Hono regex constraint (`:id{[0-9]+}`) may itself contain `:`, so it
+  // must be dropped before scanning for param labels — otherwise a `:`
+  // inside the constraint can be mistaken for the start of another param.
+  const withoutPatterns = path.replace(/\{[^}]*\}/gu, '')
+  return Array.from(withoutPatterns.matchAll(/:([A-Za-z0-9_-]+)/gu), (match) => match[1])
 }

--- a/packages/cli/tests/api-client-types.test.ts
+++ b/packages/cli/tests/api-client-types.test.ts
@@ -14,6 +14,8 @@ const definitions: RouteDefinitionLike[] = [
   { method: 'GET', path: '/library/:identifier', name: 'library.show' },
   { method: 'GET', path: '/posts', name: 'posts.index' },
   { method: 'GET', path: '/posts/:id', name: 'posts.show' },
+  { method: 'GET', path: '/items/:id{[0-9]+}', name: 'items.show' },
+  { method: 'GET', path: '/foo/:slug*', name: 'foo.show' },
   { method: 'POST', path: '/posts', name: 'posts.store' },
   {
     method: 'QUERY',
@@ -69,7 +71,15 @@ const client = createApiClient<ApiRoutes>({ baseUrl: 'http://localhost:3000' })
 
 void client.request('posts.index')
 void client.request('posts.show', { params: { id: 1 } })
+void client.request('items.show', { params: { id: 1 } })
+void client.request('foo.show', { params: { 'slug*': 'x' } })
 void client.request('posts.search', { body: { keywords: ['guren'] } })
+
+// @ts-expect-error the regex constraint must not leak into the param key
+void client.request('items.show', { params: { 'id{[0-9]+}': 1 } })
+
+// @ts-expect-error the bare name is not the real key — '*' is part of it
+void client.request('foo.show', { params: { slug: 'x' } })
 
 // @ts-expect-error a route with path params requires them
 void client.request('posts.show')
@@ -242,6 +252,25 @@ describe('generated createApiClient', () => {
     await createApiClient({ baseUrl: PAGE_ORIGIN }).request('library.show', { params: { id: 1, identifier: 2 } })
 
     expect(calls[0]!.url).toBe(`${PAGE_ORIGIN}/library/2`)
+  })
+
+  it('substitutes params through Hono modifiers in the URL', async () => {
+    const { calls } = stubFetch()
+
+    await createApiClient({ baseUrl: 'http://api.example.com' }).request('items.show', { params: { id: 7 } })
+
+    expect(calls[0]!.url).toBe('http://api.example.com/items/7')
+  })
+
+  // `:slug*` is not Hono wildcard syntax (verified directly against Hono;
+  // see docs/*/guides/routing.md): it registers a single-segment param whose
+  // runtime key really is the literal string `slug*`.
+  it('substitutes a literal `:name*` param under its real key', async () => {
+    const { calls } = stubFetch()
+
+    await createApiClient({ baseUrl: 'http://api.example.com' }).request('foo.show', { params: { 'slug*': 'x' } })
+
+    expect(calls[0]!.url).toBe('http://api.example.com/foo/x')
   })
 
   it('omits the header on safe methods', async () => {

--- a/packages/cli/tests/routes-types.test.ts
+++ b/packages/cli/tests/routes-types.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'bun:test'
 import { mkdtemp, rm, readFile, mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { pathToFileURL } from 'node:url'
+import ts from 'typescript'
+import { checkTypes, COLD_TSC_TIMEOUT } from './helpers'
 import {
   buildDeclarationContent,
   buildRouteModuleContent,
@@ -33,6 +36,14 @@ describe('toTypeLiteral', () => {
 
   it('handles path without leading slash', () => {
     expect(toTypeLiteral('users/:id')).toBe('`/users/${string}`')
+  })
+
+  it('drops Hono regex constraints from dynamic segments', () => {
+    expect(toTypeLiteral('/items/:id{[0-9]+}')).toBe('`/items/${string}`')
+  })
+
+  it('keeps segments intact when a constraint contains a slash', () => {
+    expect(toTypeLiteral('/docs/:path{[^/]+}/meta')).toBe('`/docs/${string}/meta`')
   })
 })
 
@@ -232,3 +243,115 @@ describe('buildRouteModuleContent', () => {
     }
   })
 })
+
+/**
+ * The generated module is app-facing code, so string assertions only prove it
+ * mentions the right names. These run it (transpile, import, call `route()`)
+ * and compile a usage probe against it, covering the one bug class both
+ * gates exist for: Hono path modifiers (`{regex}`, `?`, `*`) leaking into
+ * param keys or substituted URLs.
+ */
+describe('generated route() with Hono path modifiers', () => {
+  const definitions: RouteDefinition[] = [
+    { method: 'GET', path: '/items/:id{[0-9]+}', name: 'items.show' },
+    { method: 'GET', path: '/archive/:slug?', name: 'archive.show' },
+    { method: 'GET', path: '/tags/:code{[a-z]+}?', name: 'tags.show' },
+    { method: 'GET', path: '/docs/:path{[^/]+}/meta', name: 'docs.meta' },
+    { method: 'GET', path: '/posts/:id/:idx', name: 'posts.pair' },
+    { method: 'GET', path: '/foo/:slug*', name: 'foo.show' },
+  ]
+
+  type RouteFn = (name: string, ...args: unknown[]) => string
+
+  let dir: string
+  let usageFile: string
+  let route: RouteFn
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'guren-cli-routes-gen-'))
+    usageFile = join(dir, 'usage.ts')
+    const source = buildRouteModuleContent(definitions, { source: 'routes/web.ts' })
+    const modulePath = join(dir, 'routes.gen.mjs')
+    await Promise.all([
+      writeFile(join(dir, 'routes.gen.ts'), source, 'utf8'),
+      writeFile(usageFile, ROUTES_USAGE_PROBE, 'utf8'),
+      writeFile(modulePath, new Bun.Transpiler({ loader: 'ts' }).transformSync(source), 'utf8'),
+    ])
+    ;({ route } = await import(pathToFileURL(modulePath).href))
+  })
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('substitutes a regex-constrained param without leaking the constraint', () => {
+    expect(route('items.show', { id: 7 })).toBe('/items/7')
+  })
+
+  it('substitutes an optional param without leaving the ? marker', () => {
+    expect(route('archive.show', { slug: 'news' })).toBe('/archive/news')
+  })
+
+  it('substitutes an optional regex-constrained param', () => {
+    expect(route('tags.show', { code: 'abc' })).toBe('/tags/abc')
+  })
+
+  it('substitutes a param whose constraint contains a slash character class', () => {
+    expect(route('docs.meta', { path: 'intro' })).toBe('/docs/intro/meta')
+  })
+
+  it('does not clobber a longer param that shares a prefix', () => {
+    expect(route('posts.pair', { id: 1, idx: 2 })).toBe('/posts/1/2')
+  })
+
+  it('substitutes a literal `:name*` param under its real Hono key (name + `*`)', () => {
+    expect(route('foo.show', { 'slug*': 'x' })).toBe('/foo/x')
+  })
+
+  it('still appends the query string after a modifier substitution', () => {
+    expect(route('items.show', { id: 7 }, { tab: 'specs' })).toBe('/items/7?tab=specs')
+  })
+
+  it('compiles the usage probe against the emitted module', () => {
+    expect(checkTypes([usageFile], routesCompilerOptions)).toEqual([])
+  }, COLD_TSC_TIMEOUT)
+})
+
+const ROUTES_USAGE_PROBE = `import { route, routes } from './routes.gen'
+
+// Modifiers must normalize to the bare label in RouteParams keys, except a
+// literal '*' (not a Hono modifier — see PATH_PARAM_TYPE_HELPERS), which
+// stays part of the key.
+void route('items.show', { id: 1 })
+void route('archive.show', { slug: 'news' })
+void route('tags.show', { code: 'abc' })
+void route('docs.meta', { path: 'intro' })
+void route('foo.show', { 'slug*': 'x' })
+void routes.items.show({ id: 1 })
+
+// @ts-expect-error the regex constraint must not leak into the param key
+void route('items.show', { 'id{[0-9]+}': 1 })
+
+// @ts-expect-error the optional marker must not leak into the param key
+void route('archive.show', { 'slug?': 'news' })
+
+// @ts-expect-error the bare name is not the real key — '*' is part of it
+void route('foo.show', { slug: 'x' })
+
+// @ts-expect-error a route with path params requires them
+void route('items.show')
+`
+
+const routesCompilerOptions: ts.CompilerOptions = {
+  strict: true,
+  noEmit: true,
+  skipLibCheck: true,
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  lib: ['lib.es2022.d.ts', 'lib.dom.d.ts'],
+  // No @types scan: the default type-root walk climbs ancestor directories,
+  // so a TMPDIR inside a workspace would silently pull in — and type-check —
+  // every @types package it finds there.
+  types: [],
+}

--- a/packages/create-app/templates/blog/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/blog/.guren/api-client.gen.ts
@@ -91,9 +91,13 @@ export type ApiRouteMethod<T extends ApiRouteName> = ApiRoutes[T]['method']
 export type ApiRoutePath<T extends ApiRouteName> = ApiRoutes[T]['path']
 
 type NormalizeParamKey<TValue extends string> = TValue extends `${infer Key}?` ? Key : TValue
-type PathParamKeys<TPath extends string> =
+type StripParamPatterns<TPath extends string> = TPath extends `${infer Head}{${string}}${infer Tail}`
+  ? `${Head}${StripParamPatterns<Tail>}`
+  : TPath
+type PathParamKeys<TPath extends string> = ExtractParamKeys<StripParamPatterns<TPath>>
+type ExtractParamKeys<TPath extends string> =
   TPath extends `${string}:${infer Param}/${infer Rest}`
-    ? NormalizeParamKey<Param> | PathParamKeys<`/${Rest}`>
+    ? NormalizeParamKey<Param> | ExtractParamKeys<`/${Rest}`>
     : TPath extends `${string}:${infer Param}`
       ? NormalizeParamKey<Param>
       : never
@@ -231,7 +235,7 @@ function substituteParams(path: string, params?: Record<string, string | number>
     return path
   }
 
-  return path.replace(/:([A-Za-z0-9_-]+)/gu, (match, key) => {
+  return path.replace(/:([A-Za-z0-9_-]+\*?)(?:\{[^}]*\})?\??/gu, (match, key) => {
     if (!Object.prototype.hasOwnProperty.call(params, key)) {
       return match
     }

--- a/packages/create-app/templates/blog/.guren/routes.gen.ts
+++ b/packages/create-app/templates/blog/.guren/routes.gen.ts
@@ -31,9 +31,13 @@ type QueryValue = PrimitiveQueryValue | readonly PrimitiveQueryValue[]
 export type RouteQuery = Record<string, QueryValue>
 
 type NormalizeParamKey<TValue extends string> = TValue extends `${infer Key}?` ? Key : TValue
-type PathParamKeys<TPath extends string> =
+type StripParamPatterns<TPath extends string> = TPath extends `${infer Head}{${string}}${infer Tail}`
+  ? `${Head}${StripParamPatterns<Tail>}`
+  : TPath
+type PathParamKeys<TPath extends string> = ExtractParamKeys<StripParamPatterns<TPath>>
+type ExtractParamKeys<TPath extends string> =
   TPath extends `${string}:${infer Param}/${infer Rest}`
-    ? NormalizeParamKey<Param> | PathParamKeys<`/${Rest}`>
+    ? NormalizeParamKey<Param> | ExtractParamKeys<`/${Rest}`>
     : TPath extends `${string}:${infer Param}`
       ? NormalizeParamKey<Param>
       : never
@@ -104,7 +108,7 @@ function substituteParams(path: string, params?: Record<string, string | number>
     return path
   }
 
-  return path.replace(/:([A-Za-z0-9_-]+)/gu, (match, key) => {
+  return path.replace(/:([A-Za-z0-9_-]+\*?)(?:\{[^}]*\})?\??/gu, (match, key) => {
     if (!Object.prototype.hasOwnProperty.call(params, key)) {
       return match
     }

--- a/packages/create-app/templates/default/.guren/api-client.gen.ts
+++ b/packages/create-app/templates/default/.guren/api-client.gen.ts
@@ -21,9 +21,13 @@ export type ApiRouteMethod<T extends ApiRouteName> = ApiRoutes[T]['method']
 export type ApiRoutePath<T extends ApiRouteName> = ApiRoutes[T]['path']
 
 type NormalizeParamKey<TValue extends string> = TValue extends `${infer Key}?` ? Key : TValue
-type PathParamKeys<TPath extends string> =
+type StripParamPatterns<TPath extends string> = TPath extends `${infer Head}{${string}}${infer Tail}`
+  ? `${Head}${StripParamPatterns<Tail>}`
+  : TPath
+type PathParamKeys<TPath extends string> = ExtractParamKeys<StripParamPatterns<TPath>>
+type ExtractParamKeys<TPath extends string> =
   TPath extends `${string}:${infer Param}/${infer Rest}`
-    ? NormalizeParamKey<Param> | PathParamKeys<`/${Rest}`>
+    ? NormalizeParamKey<Param> | ExtractParamKeys<`/${Rest}`>
     : TPath extends `${string}:${infer Param}`
       ? NormalizeParamKey<Param>
       : never
@@ -161,7 +165,7 @@ function substituteParams(path: string, params?: Record<string, string | number>
     return path
   }
 
-  return path.replace(/:([A-Za-z0-9_-]+)/gu, (match, key) => {
+  return path.replace(/:([A-Za-z0-9_-]+\*?)(?:\{[^}]*\})?\??/gu, (match, key) => {
     if (!Object.prototype.hasOwnProperty.call(params, key)) {
       return match
     }

--- a/packages/create-app/templates/default/.guren/routes.gen.ts
+++ b/packages/create-app/templates/default/.guren/routes.gen.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // Generated from routes/web.ts — DO NOT EDIT
 // Run `guren codegen` to regenerate.
 
@@ -16,9 +15,13 @@ type QueryValue = PrimitiveQueryValue | readonly PrimitiveQueryValue[]
 export type RouteQuery = Record<string, QueryValue>
 
 type NormalizeParamKey<TValue extends string> = TValue extends `${infer Key}?` ? Key : TValue
-type PathParamKeys<TPath extends string> =
+type StripParamPatterns<TPath extends string> = TPath extends `${infer Head}{${string}}${infer Tail}`
+  ? `${Head}${StripParamPatterns<Tail>}`
+  : TPath
+type PathParamKeys<TPath extends string> = ExtractParamKeys<StripParamPatterns<TPath>>
+type ExtractParamKeys<TPath extends string> =
   TPath extends `${string}:${infer Param}/${infer Rest}`
-    ? NormalizeParamKey<Param> | PathParamKeys<`/${Rest}`>
+    ? NormalizeParamKey<Param> | ExtractParamKeys<`/${Rest}`>
     : TPath extends `${string}:${infer Param}`
       ? NormalizeParamKey<Param>
       : never
@@ -61,7 +64,7 @@ function substituteParams(path: string, params?: Record<string, string | number>
     return path
   }
 
-  return path.replace(/:([A-Za-z0-9_-]+)/gu, (match, key) => {
+  return path.replace(/:([A-Za-z0-9_-]+\*?)(?:\{[^}]*\})?\??/gu, (match, key) => {
     if (!Object.prototype.hasOwnProperty.call(params, key)) {
       return match
     }

--- a/packages/inertia-client/src/components.tsx
+++ b/packages/inertia-client/src/components.tsx
@@ -37,9 +37,13 @@ export interface RouteManifestLike {
 // routes-types-fragments.ts (its JSDoc has the why); pinned character for
 // character by routes-types-fragments.test.ts there.
 type NormalizeParamKey<TValue extends string> = TValue extends `${infer Key}?` ? Key : TValue
-type PathParamKeys<TPath extends string> =
+type StripParamPatterns<TPath extends string> = TPath extends `${infer Head}{${string}}${infer Tail}`
+  ? `${Head}${StripParamPatterns<Tail>}`
+  : TPath
+type PathParamKeys<TPath extends string> = ExtractParamKeys<StripParamPatterns<TPath>>
+type ExtractParamKeys<TPath extends string> =
   TPath extends `${string}:${infer Param}/${infer Rest}`
-    ? NormalizeParamKey<Param> | PathParamKeys<`/${Rest}`>
+    ? NormalizeParamKey<Param> | ExtractParamKeys<`/${Rest}`>
     : TPath extends `${string}:${infer Param}`
       ? NormalizeParamKey<Param>
       : never
@@ -60,7 +64,7 @@ function substituteParams(path: string, params?: Record<string, string | number>
     return path
   }
 
-  return path.replace(/:([A-Za-z0-9_-]+)/gu, (match, key) => {
+  return path.replace(/:([A-Za-z0-9_-]+\*?)(?:\{[^}]*\})?\??/gu, (match, key) => {
     if (!Object.prototype.hasOwnProperty.call(params, key)) {
       return match
     }

--- a/packages/inertia-client/tests/components.test.ts
+++ b/packages/inertia-client/tests/components.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'bun:test'
+import type { ReactElement } from 'react'
+import { createTypedLink } from '../src/components'
+
+const manifest = {
+  'items.show': { method: 'GET', path: '/items/:id{[0-9]+}' },
+  'archive.show': { method: 'GET', path: '/archive/:slug?' },
+  'tags.show': { method: 'GET', path: '/tags/:code{[a-z]+}?' },
+  'docs.meta': { method: 'GET', path: '/docs/:path{[^/]+}/meta' },
+  'posts.pair': { method: 'GET', path: '/posts/:id/:idx' },
+  'posts.index': { method: 'GET', path: '/posts' },
+  'foo.show': { method: 'GET', path: '/foo/:slug*' },
+} as const
+
+const Link = createTypedLink(manifest)
+
+/** The element is inspected without rendering: `href` is computed in the factory. */
+function hrefOf(element: ReactElement): string {
+  return (element.props as { href: string }).href
+}
+
+describe('createTypedLink param substitution', () => {
+  it('substitutes a regex-constrained param without leaking the constraint', () => {
+    expect(hrefOf(Link({ route: 'items.show', params: { id: 7 } }))).toBe('/items/7')
+  })
+
+  it('substitutes an optional param without leaving the ? marker', () => {
+    expect(hrefOf(Link({ route: 'archive.show', params: { slug: 'news' } }))).toBe('/archive/news')
+  })
+
+  it('substitutes an optional regex-constrained param', () => {
+    expect(hrefOf(Link({ route: 'tags.show', params: { code: 'abc' } }))).toBe('/tags/abc')
+  })
+
+  it('substitutes a param whose constraint contains a slash character class', () => {
+    expect(hrefOf(Link({ route: 'docs.meta', params: { path: 'intro' } }))).toBe('/docs/intro/meta')
+  })
+
+  it('does not clobber a longer param that shares a prefix', () => {
+    expect(hrefOf(Link({ route: 'posts.pair', params: { id: 1, idx: 2 } }))).toBe('/posts/1/2')
+  })
+
+  // `:slug*` is not Hono wildcard syntax — its runtime param key really is
+  // the literal `slug*` (verified directly against Hono; see
+  // docs/*/guides/routing.md), so the substituted href must be keyed the
+  // same way.
+  it('substitutes a literal `:name*` param under its real Hono key (name + `*`)', () => {
+    expect(hrefOf(Link({ route: 'foo.show', params: { 'slug*': 'x' } }))).toBe('/foo/x')
+  })
+
+  it('encodes substituted values', () => {
+    expect(hrefOf(Link({ route: 'archive.show', params: { slug: 'a b' } }))).toBe('/archive/a%20b')
+  })
+
+  it('keeps the path as-is for param-less routes', () => {
+    expect(hrefOf(Link({ route: 'posts.index' }))).toBe('/posts')
+  })
+
+  it('throws on an unknown route name', () => {
+    expect(() => Link({ route: 'missing' as never })).toThrow('Route [missing] not defined.')
+  })
+})

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -589,18 +589,29 @@ function normalizeServers(servers?: OpenApiDocumentOptions['servers']): OpenApiS
 }
 
 function toOpenApiPath(path: string): string {
-  return path.replace(/:([A-Za-z0-9_-]+)/gu, '{$1}')
+  // Consume a Hono regex constraint (`{...}`) or trailing `?`/`*` with the
+  // token — OpenAPI path templates carry only the bare label
+  // (`/items/:id{[0-9]+}` -> `/items/{id}`). Unlike the TS/runtime param-key
+  // rule (routes-types-fragments.ts), `*` is dropped here too: RFC 6570 (the
+  // URI Template spec OpenAPI path templates follow) gives `{name*}` its own
+  // "explode" meaning, so keeping a literal `:slug*`'s `*` would produce a
+  // template that means something else entirely.
+  return path.replace(/:([A-Za-z0-9_-]+)(?:\{[^}]*\})?[?*]?/gu, '{$1}')
 }
 
 function extractPathParamNames(path: string): string[] {
-  return Array.from(path.matchAll(/:([A-Za-z0-9_-]+)/gu)).map((match) => match[1] ?? '')
+  // A regex constraint (`:id{[0-9]+}`) may itself contain `:` or `/`, so it
+  // must be dropped before scanning for param labels.
+  const withoutPatterns = path.replace(/\{[^}]*\}/gu, '')
+  return Array.from(withoutPatterns.matchAll(/:([A-Za-z0-9_-]+)/gu)).map((match) => match[1] ?? '')
 }
 
 function buildOperationId(definition: RouteDefinition): string {
   const fragments = definition.path
+    .replace(/\{[^}]*\}/gu, '')
     .split('/')
     .filter(Boolean)
-    .map((segment) => segment.startsWith(':') ? `By${capitalize(segment.slice(1))}` : capitalize(segment))
+    .map((segment) => segment.startsWith(':') ? `By${capitalize(segment.slice(1).replace(/[?*]$/u, ''))}` : capitalize(segment))
 
   return `${definition.method.toLowerCase()}${fragments.join('') || 'Root'}`
 }

--- a/packages/openapi/tests/openapi.test.ts
+++ b/packages/openapi/tests/openapi.test.ts
@@ -59,6 +59,47 @@ describe('@guren/openapi', () => {
     expect(document.paths['/posts/{id}']?.post?.responses['422']).toBeDefined()
   })
 
+  it('keeps Hono path modifiers out of path templates, parameters, and operation ids', () => {
+    // No `name`: operationId falls back to `name` when present, and these
+    // routes have to exercise buildOperationId's own path-derived id.
+    const definitions: RouteDefinition[] = [
+      { method: 'GET', path: '/items/:id{[0-9]+}' },
+      { method: 'GET', path: '/tags/:code{[a-z]+}?' },
+      { method: 'GET', path: '/docs/:path{[^/]+}/meta' },
+      // `:slug*` is not Hono wildcard syntax — its runtime param key is the
+      // literal `slug*`. OpenAPI path templates follow RFC 6570, where
+      // `{name*}` already means "explode", so the `*` is dropped here rather
+      // than kept (unlike the TS/runtime param-key rule, which keeps it —
+      // see PATH_PARAM_TYPE_HELPERS in @guren/cli's routes-types-fragments.ts).
+      { method: 'GET', path: '/foo/:slug*' },
+    ]
+
+    const { document, warnings } = generateOpenApiDocument(definitions, {
+      title: 'Blog API',
+      version: '1.0.0',
+    })
+
+    expect(warnings).toEqual([])
+    expect(Object.keys(document.paths).sort()).toEqual([
+      '/docs/{path}/meta',
+      '/foo/{slug}',
+      '/items/{id}',
+      '/tags/{code}',
+    ])
+    expect(document.paths['/items/{id}']?.get?.parameters).toEqual([
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ])
+    expect(document.paths['/tags/{code}']?.get?.parameters).toEqual([
+      { name: 'code', in: 'path', required: true, schema: { type: 'string' } },
+    ])
+    expect(document.paths['/foo/{slug}']?.get?.parameters).toEqual([
+      { name: 'slug', in: 'path', required: true, schema: { type: 'string' } },
+    ])
+    expect(document.paths['/items/{id}']?.get?.operationId).toBe('getItemsById')
+    expect(document.paths['/tags/{code}']?.get?.operationId).toBe('getTagsByCode')
+    expect(document.paths['/foo/{slug}']?.get?.operationId).toBe('getFooBySlug')
+  })
+
   it('returns warnings for non-zod schemas', () => {
     const definitions: RouteDefinition[] = [
       {

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -977,7 +977,12 @@ function createRouteBuilder<M extends string = never>(route: RegisteredRoute, na
 }
 
 function substituteParams(path: string, params: Record<string, string | number>): string {
-  return path.replace(/:([A-Za-z0-9_-]+)/gu, (match, key) => {
+  // A trailing regex constraint (`{...}`) or `?` is a Hono modifier consumed
+  // with the token but excluded from the key; a trailing `*` is part of the
+  // literal key (`:slug*` names a single-segment param whose Hono runtime
+  // key really is `slug*`) — see PATH_PARAM_TYPE_HELPERS in
+  // @guren/cli's routes-types-fragments.ts for the full rule this mirrors.
+  return path.replace(/:([A-Za-z0-9_-]+\*?)(?:\{[^}]*\})?\??/gu, (match, key) => {
     if (!Object.prototype.hasOwnProperty.call(params, key)) {
       return match
     }
@@ -1246,8 +1251,12 @@ async function resolveModelBindings(
   const resolved: unknown[] = []
   const params = c.req.param()
 
-  // Get path params in order from the route pattern
-  const pathParams = path?.match(/:([a-zA-Z0-9_-]+)/g)?.map(p => p.slice(1)) ?? []
+  // Get path params in order from the route pattern. A regex constraint
+  // (`:id{[0-9]+}`) may itself contain `:`, so it must be dropped first —
+  // otherwise a `:` inside the constraint reads as another param and shifts
+  // this positional list out of sync with modelBindings' insertion order.
+  const withoutPatterns = path?.replace(/\{[^}]*\}/gu, '')
+  const pathParams = withoutPatterns?.match(/:([a-zA-Z0-9_-]+)/g)?.map(p => p.slice(1)) ?? []
 
   for (const param of pathParams) {
     const resolver = modelBindings.get(param)
@@ -1315,7 +1324,12 @@ function serializeBindings(
 ): Record<string, string> | undefined {
   const entries = new Map<string, string>()
 
-  for (const param of path.match(/:(\w+)/g) ?? []) {
+  // A regex constraint (`:id{[0-9]+}`) may itself contain `:`, so it must be
+  // dropped first — otherwise a `:` inside the constraint reads as another
+  // param name.
+  const withoutPatterns = path.replace(/\{[^}]*\}/gu, '')
+
+  for (const param of withoutPatterns.match(/:(\w+)/g) ?? []) {
     const name = routerBindingNames.get(param.slice(1))
     if (name) entries.set(param.slice(1), name)
   }

--- a/packages/server/tests/mvc/router.test.ts
+++ b/packages/server/tests/mvc/router.test.ts
@@ -854,3 +854,62 @@ describe('Router QUERY method (RFC 10008)', () => {
     expect(def!.middlewareNames).toEqual(['auth'])
   })
 })
+
+describe('Router route() with Hono path modifiers', () => {
+  it('substitutes a regex-constrained param without leaking the constraint', () => {
+    const router = new Router()
+    router.get('/items/:id{[0-9]+}', [StubController, 'show']).name('items.show')
+
+    expect(router.route('items.show', { id: 7 })).toBe('/items/7')
+  })
+
+  it('substitutes an optional param without leaving the ? marker', () => {
+    const router = new Router()
+    router.get('/archive/:slug?', [StubController, 'show']).name('archive.show')
+
+    expect(router.route('archive.show', { slug: 'news' })).toBe('/archive/news')
+  })
+
+  it('substitutes an optional regex-constrained param', () => {
+    const router = new Router()
+    router.get('/tags/:code{[a-z]+}?', [StubController, 'show']).name('tags.show')
+
+    expect(router.route('tags.show', { code: 'abc' })).toBe('/tags/abc')
+  })
+
+  it('substitutes a param whose constraint contains a slash character class', () => {
+    const router = new Router()
+    router.get('/docs/:path{[^/]+}/meta', [StubController, 'show']).name('docs.meta')
+
+    expect(router.route('docs.meta', { path: 'intro' })).toBe('/docs/intro/meta')
+  })
+
+  it('leaves the whole token in place when the param is not supplied', () => {
+    const router = new Router()
+    router.get('/items/:id{[0-9]+}', [StubController, 'show']).name('items.show')
+
+    expect(router.route('items.show', {})).toBe('/items/:id{[0-9]+}')
+  })
+
+  it('does not clobber a longer param that shares a prefix', () => {
+    const router = new Router()
+    router.get('/posts/:id/:idx', [StubController, 'show']).name('posts.pair')
+
+    expect(router.route('posts.pair', { id: 1, idx: 2 })).toBe('/posts/1/2')
+  })
+
+  it('substitutes a literal `:name*` param under its real Hono key (name + `*`)', async () => {
+    // `:slug*` is not Hono wildcard syntax — verified directly against Hono
+    // (see docs/*/guides/routing.md): it registers a single-segment param
+    // whose runtime key is the literal string `slug*`, not `slug`.
+    const router = new Router()
+    router.get('/foo/:slug*', [StubController, 'show']).name('foo.show')
+
+    expect(router.route('foo.show', { 'slug*': 'x' })).toBe('/foo/x')
+
+    const app = new Hono()
+    router.mount(app)
+    const response = await app.request('/foo/x')
+    expect(response.status).toBe(200)
+  })
+})


### PR DESCRIPTION
## Summary
- A route path like `/items/:id{[0-9]+}` or `/archive/:slug?` typed `RouteParams<'items.show'>`'s key as `"id{[0-9]+}"`/`"slug?"` instead of `"id"`/`"slug"`, and left the modifier text in URLs substituted by `router.route()`, the generated API client, and `<Link>`/`<Form>`. `PathParamKeys`/`substituteParams` (the shared fragment in `@guren/cli`, mirrored in `@guren/inertia-client`, duplicated in `@guren/server`'s `Router.route()`) now strip a regex constraint and a trailing `?` before deriving the key. `@guren/openapi`'s `toOpenApiPath`/`extractPathParamNames`/`buildOperationId` get the matching fix, so `/items/:id{[0-9]+}` becomes the valid `/items/{id}` instead of `/items/{id}{[0-9]+}`.
- `:name*` is deliberately **not** treated as a modifier — verified directly against Hono 4.13.1, it is not wildcard syntax: it registers a literal, single-segment param whose real runtime key is `name*` (asterisk included, confirmed via `c.req.param()`). The fix keeps that key as-is so the generated type and substituted URL agree with what Hono actually does. `@guren/openapi` is the one place that still drops the `*` — OpenAPI path templates follow RFC 6570, where `{name*}` already means "explode".
- `Router`'s `resolveModelBindings`/`serializeBindings` also stop misreading a `:` inside a regex constraint's character class (e.g. `{[a-z:]+}`) as another param, which could shift positional model-binding order.
- Docs (`docs/en` + `docs/ja` `guides/routing.md`) now document optional and regex-constrained params, and correct the previously-wrong `ja` guidance that recommended `:slug*` as wildcard syntax — it's a single-segment literal param, not a wildcard; `:path{.+}` is the correct multi-segment form.
- `create-guren-app`'s `default` and `blog` templates are regenerated (`.guren/routes.gen.ts`, `.guren/api-client.gen.ts`). The `default` template's `routes.gen.ts` also drops a stale `@ts-nocheck` that #406 intended to remove but never actually regenerated for that file.

## Scope note
Route model binding (`Router.bind()`) is **not** extended to resolve a `:name*` key — its param-name extraction still yields the bare name (`slug`), which won't match Hono's real key (`slug*`), so binding on such a param silently resolves nothing. Docs call out `:name*` as a pattern to avoid rather than fixing binding for it; a `guren check` warning for this pattern is tracked separately.

## Test plan
- [x] `bun run build:clean`
- [x] `bun run test:bun` (4220 pass, 0 fail)
- [x] `bun run typecheck` (root + examples/blog + examples/api)
- [x] `bun run audit:core-first`
- [x] `bun run audit:docs`
- [x] `bun run audit:starter-template`
- [x] `bun run smoke:starter` (default blueprint)
- [x] `bun run smoke:starter:blog`
- [x] Empirically verified Hono's actual `:slug*` and `{regex}` param-key behavior against the pinned `hono` version before designing the fix