### PR TITLE
feat(cli): report and prune stale managed harness files in agent:sync

### DIFF
--- a/.changeset/agent-sync-prune.md
+++ b/.changeset/agent-sync-prune.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': minor
+---
+
+`agent:sync` now reports files left behind in framework-managed directories when a canonical rule or skill is renamed or removed — including the stale `.cursor/rules/guren-*.mdc` and `.github/instructions/guren-*.instructions.md` copies Cursor and Copilot keep auto-loading — and `agent:sync --prune` deletes them. Without `--prune`, sync never deletes anything, so user files under colliding names stay safe by default.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ bunx guren doctor --next        # Doctor report + actionable next steps
 # Agent harness (in scaffolded apps)
 bunx guren agent:init           # Install AI agent harness (CLAUDE.md, .claude/ rules, skills, hooks, .mcp.json)
 bunx guren agent:sync           # Refresh framework-managed harness files to the latest version
+bunx guren agent:sync --prune   # Also delete managed-directory files that left the harness (reported-only by default)
 
 # Code generation
 bunx guren guidelines           # Auto-generate project-specific coding guidelines

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -273,6 +273,8 @@ What each selection writes:
 
 `agent:init --target` accepts `claude` (the default), `codex`, `cursor`, `copilot`, `opencode`, and `all`. `agent:sync` never overwrites user-owned files — `CLAUDE.md`, `AGENTS.md`, `.claude/settings.json`, and the MCP client configs — so your customizations survive framework updates (a user-owned file you deleted is recreated). When an MCP config already exists, `agent:init` leaves it alone and prints the snippet to merge by hand.
 
+When a framework rule or skill is renamed or removed in a release, the old copies stay behind in every root that received them — and Cursor and Copilot keep auto-loading stale `.cursor/rules/guren-*.mdc` / `.github/instructions/guren-*.instructions.md` files. `agent:sync` lists any files in the framework-managed directories (the rules/skills roots and the `guren-*` native rules) that are no longer part of the harness; `agent:sync --prune` deletes them. Without `--prune` nothing is ever deleted, so a rule of your own that lives in a managed directory is safe by default — but note that `--prune` removes *everything* the report lists, including such files, so review the list first (or keep your own rules elsewhere, e.g. in `CLAUDE.md`/`AGENTS.md` or under names outside the `guren-` prefix for Cursor/Copilot).
+
 ## Deployment Recipes
 
 Generate deployment config files directly from the CLI:

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -271,6 +271,8 @@ Inertiaのページは `modules/<name>/` 配下にコロケーションされま
 
 `agent:init --target` には `claude`(既定)・`codex`・`cursor`・`copilot`・`opencode`・`all` を指定できます。`agent:sync` はユーザー所有のファイル(`CLAUDE.md`・`AGENTS.md`・`.claude/settings.json`・各 MCP クライアント設定)を上書きしないため、カスタマイズはフレームワークの更新後も維持されます(削除したユーザー所有ファイルは再作成されます)。MCP 設定が既に存在する場合、`agent:init` はファイルを上書きせず、手動で追記するためのスニペットを表示します。
 
+リリースでフレームワークのルールやスキルが改名・削除されると、旧ファイルは配布先の全ルートに残り続けます。特に Cursor・Copilot は古い `.cursor/rules/guren-*.mdc` / `.github/instructions/guren-*.instructions.md` を glob で読み込み続けます。`agent:sync` はフレームワーク管理ディレクトリ(rules/skills のルートと `guren-*` ネイティブルール)内で現行ハーネスに含まれないファイルを一覧表示し、`agent:sync --prune` を付けるとそれらを削除します。`--prune` なしでは一切削除しないため、管理ディレクトリに置いた自作ルールが既定で消えることはありません。ただし `--prune` は一覧に出たものを自作ファイル含めてすべて削除するので、実行前に一覧を確認してください(自作ルールは `CLAUDE.md`/`AGENTS.md` に書くか、Cursor/Copilot では `guren-` プレフィックス以外の名前にしておくと対象外になります)。
+
 ## デプロイレシピ生成
 
 CLI からデプロイ設定ファイルを直接生成できます。

--- a/packages/cli/src/agent-harness.ts
+++ b/packages/cli/src/agent-harness.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, readdir, rm, rmdir, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, readFile, readdir, rm, rmdir, writeFile } from 'node:fs/promises'
 import type { Dirent } from 'node:fs'
 import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -67,8 +67,8 @@ export interface AgentHarnessResult {
    * the default is report-only.
    */
   stale: string[]
-  /** The subset of `stale` that `prune: true` deleted. */
-  pruned: string[]
+  /** True when `prune` deleted the files listed in `stale` (always false without it). */
+  pruned: boolean
   /**
    * True when the installed MCP client config points at an endpoint no script
    * in the app enables. The endpoint is opt-in via `GUREN_MCP=1`; apps
@@ -179,63 +179,58 @@ async function detectInstalledComponents(
 
 /**
  * Files inside the active components' managed namespaces that the current
- * plan does not write. Planned-but-user-owned files (none live in a
- * namespace today) are excluded via the full planned path set, so a future
- * planner change cannot turn its own output into a prune candidate.
+ * plan does not write. Planned files (managed or user-owned) are excluded
+ * via the full planned path set, so a future planner change cannot turn its
+ * own output into a prune candidate. The comparison is case-insensitive: on
+ * a case-preserving filesystem the write loop can refresh a planned file
+ * through a differently-cased directory entry, and an exact match would then
+ * classify the file it just wrote as stale.
  */
 async function findStaleManagedFiles(
   cwd: string,
   components: HarnessComponent[],
-  plannedPaths: ReadonlySet<string>,
+  plannedPathsLower: ReadonlySet<string>,
 ): Promise<string[]> {
   const stale: string[] = []
   for (const namespace of managedNamespaces(components)) {
+    const root = join(cwd, namespace.dir)
+    // never claim through a symlinked root: readdir and rm would follow it,
+    // and a claim is only safe over files that live inside the app
+    let rootInfo
+    try {
+      rootInfo = await lstat(root)
+    } catch {
+      continue // namespace directory does not exist — nothing to clean
+    }
+    if (!rootInfo.isDirectory()) {
+      continue
+    }
     let entries: Dirent[]
     try {
-      entries = await readdir(join(cwd, namespace.dir), {
-        recursive: namespace.recursive,
+      entries = await readdir(root, {
+        recursive: namespace.kind === 'tree',
         withFileTypes: true,
       })
     } catch {
-      continue // namespace directory does not exist — nothing to clean
+      continue
     }
     for (const entry of entries) {
       if (!entry.isFile()) {
         continue
       }
       if (
-        namespace.fileName &&
-        !(entry.name.startsWith(namespace.fileName.prefix) && entry.name.endsWith(namespace.fileName.suffix))
+        namespace.kind === 'pattern' &&
+        !(entry.name.startsWith(namespace.prefix) && entry.name.endsWith(namespace.suffix))
       ) {
         continue
       }
       const relPath = toPosixRelative(cwd, join(entry.parentPath, entry.name))
-      if (!plannedPaths.has(relPath)) {
+      if (!plannedPathsLower.has(relPath.toLowerCase())) {
         stale.push(relPath)
       }
     }
   }
   return stale.sort()
-}
-
-/** Depth-first removal of directories pruning emptied (rmdir refuses non-empty ones). */
-async function removeEmptiedDirs(dir: string): Promise<void> {
-  let entries: Dirent[]
-  try {
-    entries = await readdir(dir, { withFileTypes: true })
-  } catch {
-    return
-  }
-  for (const entry of entries) {
-    if (entry.isDirectory()) {
-      await removeEmptiedDirs(join(dir, entry.name))
-    }
-  }
-  try {
-    await rmdir(dir)
-  } catch {
-    // still holds files — keep it
-  }
 }
 
 export async function installAgentHarness(options: AgentHarnessOptions = {}): Promise<AgentHarnessResult> {
@@ -285,17 +280,27 @@ export async function installAgentHarness(options: AgentHarnessOptions = {}): Pr
   // written, so "not in the plan" carries no leftover signal there.
   const stale =
     mode === 'sync'
-      ? await findStaleManagedFiles(cwd, components, new Set(plan.map((file) => file.path)))
+      ? await findStaleManagedFiles(
+          cwd,
+          components,
+          new Set(plan.map((file) => file.path.toLowerCase())),
+        )
       : []
-  const pruned: string[] = []
-  if (options.prune && stale.length > 0) {
+  const pruned = Boolean(options.prune) && stale.length > 0
+  if (pruned) {
     for (const relPath of stale) {
       await rm(join(cwd, relPath), { force: true })
-      pruned.push(relPath)
     }
-    for (const namespace of managedNamespaces(components)) {
-      if (pruned.some((relPath) => relPath.startsWith(`${namespace.dir}/`))) {
-        await removeEmptiedDirs(join(cwd, namespace.dir))
+    // sweep only what the deletions emptied: from each removed file, walk up
+    // and rmdir until a directory refuses (still holds files) — pre-existing
+    // empty directories elsewhere in a namespace are none of our business
+    for (const startDir of new Set(stale.map((relPath) => dirname(relPath)))) {
+      for (let dir = startDir; dir !== '.' && dir !== ''; dir = dirname(dir)) {
+        try {
+          await rmdir(join(cwd, dir))
+        } catch {
+          break
+        }
       }
     }
   }

--- a/packages/cli/src/agent-harness.ts
+++ b/packages/cli/src/agent-harness.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir, rm, rmdir, writeFile } from 'node:fs/promises'
+import type { Dirent } from 'node:fs'
 import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import process from 'node:process'
@@ -6,6 +7,7 @@ import { fileExists, readIfExists, toPosixRelative } from './discovery'
 import {
   DETECTABLE_COMPONENTS,
   componentsForTargets,
+  managedNamespaces,
   normalizeComponents,
   planComponents,
   type AgentTarget,
@@ -44,11 +46,29 @@ export interface AgentHarnessOptions {
    * default is whatever components are already installed on disk.
    */
   targets?: AgentTarget[]
+  /**
+   * Sync only: delete the files reported in `stale` instead of just listing
+   * them. Off by default because the managed namespaces can hold
+   * user-authored files under colliding names — the report names every
+   * candidate first, and deletion stays an explicit opt-in.
+   */
+  prune?: boolean
 }
 
 export interface AgentHarnessResult {
   written: string[]
   skipped: string[]
+  /**
+   * Sync only: files inside the framework-managed namespaces
+   * (`managedNamespaces`) that the current plan no longer writes — what a
+   * renamed or removed canonical rule/skill leaves behind, in every root it
+   * fanned out to. Reported so the user can decide; deleted only with
+   * `prune`. A user file under a colliding name lands here too, which is why
+   * the default is report-only.
+   */
+  stale: string[]
+  /** The subset of `stale` that `prune: true` deleted. */
+  pruned: string[]
   /**
    * True when the installed MCP client config points at an endpoint no script
    * in the app enables. The endpoint is opt-in via `GUREN_MCP=1`; apps
@@ -157,6 +177,67 @@ async function detectInstalledComponents(
   return normalizeComponents(components)
 }
 
+/**
+ * Files inside the active components' managed namespaces that the current
+ * plan does not write. Planned-but-user-owned files (none live in a
+ * namespace today) are excluded via the full planned path set, so a future
+ * planner change cannot turn its own output into a prune candidate.
+ */
+async function findStaleManagedFiles(
+  cwd: string,
+  components: HarnessComponent[],
+  plannedPaths: ReadonlySet<string>,
+): Promise<string[]> {
+  const stale: string[] = []
+  for (const namespace of managedNamespaces(components)) {
+    let entries: Dirent[]
+    try {
+      entries = await readdir(join(cwd, namespace.dir), {
+        recursive: namespace.recursive,
+        withFileTypes: true,
+      })
+    } catch {
+      continue // namespace directory does not exist — nothing to clean
+    }
+    for (const entry of entries) {
+      if (!entry.isFile()) {
+        continue
+      }
+      if (
+        namespace.fileName &&
+        !(entry.name.startsWith(namespace.fileName.prefix) && entry.name.endsWith(namespace.fileName.suffix))
+      ) {
+        continue
+      }
+      const relPath = toPosixRelative(cwd, join(entry.parentPath, entry.name))
+      if (!plannedPaths.has(relPath)) {
+        stale.push(relPath)
+      }
+    }
+  }
+  return stale.sort()
+}
+
+/** Depth-first removal of directories pruning emptied (rmdir refuses non-empty ones). */
+async function removeEmptiedDirs(dir: string): Promise<void> {
+  let entries: Dirent[]
+  try {
+    entries = await readdir(dir, { withFileTypes: true })
+  } catch {
+    return
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      await removeEmptiedDirs(join(dir, entry.name))
+    }
+  }
+  try {
+    await rmdir(dir)
+  } catch {
+    // still holds files — keep it
+  }
+}
+
 export async function installAgentHarness(options: AgentHarnessOptions = {}): Promise<AgentHarnessResult> {
   const cwd = resolve(options.cwd ?? process.cwd())
   const mode = options.mode ?? 'init'
@@ -174,7 +255,8 @@ export async function installAgentHarness(options: AgentHarnessOptions = {}): Pr
   const skipped: string[] = []
   const mcpMergeHints: AgentHarnessResult['mcpMergeHints'] = []
 
-  for (const file of planComponents(components, templates, appTitle)) {
+  const plan = planComponents(components, templates, appTitle)
+  for (const file of plan) {
     const destPath = join(cwd, file.path)
     const exists = await fileExists(cwd, file.path)
 
@@ -199,9 +281,30 @@ export async function installAgentHarness(options: AgentHarnessOptions = {}): Pr
     written.push(file.path)
   }
 
+  // Stale cleanup is a sync concern: init installs into places it has never
+  // written, so "not in the plan" carries no leftover signal there.
+  const stale =
+    mode === 'sync'
+      ? await findStaleManagedFiles(cwd, components, new Set(plan.map((file) => file.path)))
+      : []
+  const pruned: string[] = []
+  if (options.prune && stale.length > 0) {
+    for (const relPath of stale) {
+      await rm(join(cwd, relPath), { force: true })
+      pruned.push(relPath)
+    }
+    for (const namespace of managedNamespaces(components)) {
+      if (pruned.some((relPath) => relPath.startsWith(`${namespace.dir}/`))) {
+        await removeEmptiedDirs(join(cwd, namespace.dir))
+      }
+    }
+  }
+
   return {
     written,
     skipped,
+    stale,
+    pruned,
     mcpEndpointNotEnabled: !(await scriptsEnableMcp(cwd)),
     mcpMergeHints,
   }

--- a/packages/cli/src/agent-targets.ts
+++ b/packages/cli/src/agent-targets.ts
@@ -54,46 +54,49 @@ export type DetectableComponent = (typeof DETECTABLE_COMPONENTS)[number]
 const MCP_ENDPOINT_MARKER = '_guren/mcp'
 
 /**
- * A directory (or a name pattern within one) whose matching files the planner
- * owns outright: anything there that the current plan does not write is a
- * leftover from an earlier harness version — a renamed or removed canonical
- * rule or skill — and `agent:sync` may report it and, with `--prune`, delete
- * it.
+ * A claim over files the planner owns outright: anything matching it that the
+ * current plan does not write is a leftover from an earlier harness version —
+ * a renamed or removed canonical rule or skill — and `agent:sync` may report
+ * it and, with `--prune`, delete it. Two shapes exist: a `tree` claims a
+ * whole canonical root recursively; a `pattern` claims only framework-named
+ * files at the top of a directory shared with user-authored files.
  */
-export interface ManagedNamespace {
-  /** App-relative POSIX directory the claim applies under. */
-  dir: string
-  /**
-   * File-name pattern marking a file as framework-owned inside a directory
-   * shared with user-authored files. Absent → every file under `dir` is
-   * claimed (the canonical rules/skills roots).
-   */
-  fileName?: { prefix: string; suffix: string }
-  /** Whether the claim extends into subdirectories. */
-  recursive: boolean
+export type ManagedNamespace =
+  | { kind: 'tree'; dir: string }
+  | { kind: 'pattern'; dir: string; prefix: string; suffix: string }
+
+type PatternNamespace = Extract<ManagedNamespace, { kind: 'pattern' }>
+
+/**
+ * The one spelling of a family root's canonical directories. `planComponents`
+ * builds every written path from it and `managedNamespaces` claims the same
+ * value, so a renamed root cannot leave the claim pointing at the old
+ * location (where prune would then eat the freshly written files).
+ */
+function canonicalDirs(root: '.claude' | '.agents'): { rules: string; skills: string } {
+  return { rules: `${root}/rules`, skills: `${root}/skills` }
 }
 
 /**
  * The native-rule namespaces double as the path rule `planComponents` writes
  * with, so the prune pattern and the written names cannot drift apart.
  */
-const CURSOR_RULES_NAMESPACE = {
+const CURSOR_RULES_NAMESPACE: PatternNamespace = {
+  kind: 'pattern',
   dir: '.cursor/rules',
-  fileName: { prefix: 'guren-', suffix: '.mdc' },
-  recursive: false,
-} satisfies ManagedNamespace
+  prefix: 'guren-',
+  suffix: '.mdc',
+}
 
-const COPILOT_RULES_NAMESPACE = {
+const COPILOT_RULES_NAMESPACE: PatternNamespace = {
+  kind: 'pattern',
   dir: '.github/instructions',
-  fileName: { prefix: 'guren-', suffix: '.instructions.md' },
-  recursive: false,
-} satisfies ManagedNamespace
+  prefix: 'guren-',
+  suffix: '.instructions.md',
+}
 
-function nativeRulePath(
-  namespace: typeof CURSOR_RULES_NAMESPACE | typeof COPILOT_RULES_NAMESPACE,
-  stem: string,
-): string {
-  return `${namespace.dir}/${namespace.fileName.prefix}${stem}${namespace.fileName.suffix}`
+function nativeRulePath(namespace: PatternNamespace, stem: string): string {
+  return `${namespace.dir}/${namespace.prefix}${stem}${namespace.suffix}`
 }
 
 /**
@@ -109,11 +112,15 @@ function nativeRulePath(
 export function managedNamespaces(components: Iterable<HarnessComponent>): ManagedNamespace[] {
   const active = new Set<HarnessComponent>(components)
   const namespaces: ManagedNamespace[] = []
+  const claimFamily = (root: '.claude' | '.agents'): void => {
+    const dirs = canonicalDirs(root)
+    namespaces.push({ kind: 'tree', dir: dirs.rules }, { kind: 'tree', dir: dirs.skills })
+  }
   if (active.has('claude')) {
-    namespaces.push({ dir: '.claude/rules', recursive: true }, { dir: '.claude/skills', recursive: true })
+    claimFamily('.claude')
   }
   if (active.has('agents')) {
-    namespaces.push({ dir: '.agents/rules', recursive: true }, { dir: '.agents/skills', recursive: true })
+    claimFamily('.agents')
   }
   if (active.has('cursor')) {
     namespaces.push(CURSOR_RULES_NAMESPACE)
@@ -313,11 +320,12 @@ export function planComponents(
 
   /** The canonical rules + skills trees, rendered for one root directory. */
   const addCanonical = (root: '.claude' | '.agents'): void => {
+    const dirs = canonicalDirs(root)
     for (const [rel, content] of under('core/rules/')) {
-      add({ path: `${root}/rules/${rel}`, content: render(content), managed: true })
+      add({ path: `${dirs.rules}/${rel}`, content: render(content), managed: true })
     }
     for (const [rel, content] of under('core/skills/')) {
-      add({ path: `${root}/skills/${rel}`, content: render(content, `${root}/rules`), managed: true })
+      add({ path: `${dirs.skills}/${rel}`, content: render(content, dirs.rules), managed: true })
     }
   }
 
@@ -327,7 +335,7 @@ export function planComponents(
     // body; only the workflow section differs (hooks vs. manual loop).
     add({
       path: 'CLAUDE.md',
-      content: entryDoc('targets/claude/workflow.md', '.claude/rules'),
+      content: entryDoc('targets/claude/workflow.md', canonicalDirs('.claude').rules),
       managed: false,
     })
     addMcpConfig('.mcp.json', 'targets/claude/mcp.json')
@@ -348,7 +356,7 @@ export function planComponents(
   if (components.includes('agents')) {
     add({
       path: 'AGENTS.md',
-      content: entryDoc('targets/agents/workflow.md', '.agents/rules'),
+      content: entryDoc('targets/agents/workflow.md', canonicalDirs('.agents').rules),
       managed: false,
     })
     addCanonical('.agents')

--- a/packages/cli/src/agent-targets.ts
+++ b/packages/cli/src/agent-targets.ts
@@ -53,6 +53,77 @@ export type DetectableComponent = (typeof DETECTABLE_COMPONENTS)[number]
  */
 const MCP_ENDPOINT_MARKER = '_guren/mcp'
 
+/**
+ * A directory (or a name pattern within one) whose matching files the planner
+ * owns outright: anything there that the current plan does not write is a
+ * leftover from an earlier harness version — a renamed or removed canonical
+ * rule or skill — and `agent:sync` may report it and, with `--prune`, delete
+ * it.
+ */
+export interface ManagedNamespace {
+  /** App-relative POSIX directory the claim applies under. */
+  dir: string
+  /**
+   * File-name pattern marking a file as framework-owned inside a directory
+   * shared with user-authored files. Absent → every file under `dir` is
+   * claimed (the canonical rules/skills roots).
+   */
+  fileName?: { prefix: string; suffix: string }
+  /** Whether the claim extends into subdirectories. */
+  recursive: boolean
+}
+
+/**
+ * The native-rule namespaces double as the path rule `planComponents` writes
+ * with, so the prune pattern and the written names cannot drift apart.
+ */
+const CURSOR_RULES_NAMESPACE = {
+  dir: '.cursor/rules',
+  fileName: { prefix: 'guren-', suffix: '.mdc' },
+  recursive: false,
+} satisfies ManagedNamespace
+
+const COPILOT_RULES_NAMESPACE = {
+  dir: '.github/instructions',
+  fileName: { prefix: 'guren-', suffix: '.instructions.md' },
+  recursive: false,
+} satisfies ManagedNamespace
+
+function nativeRulePath(
+  namespace: typeof CURSOR_RULES_NAMESPACE | typeof COPILOT_RULES_NAMESPACE,
+  stem: string,
+): string {
+  return `${namespace.dir}/${namespace.fileName.prefix}${stem}${namespace.fileName.suffix}`
+}
+
+/**
+ * The namespaces the given components own. Deliberately narrower than the
+ * managed file set: `.claude/agents/` and `.claude/hooks/` ship managed files
+ * too, but those directories are the conventional home for user-authored
+ * subagents and hooks, and a name pattern cannot tell the two apart — so
+ * stale copies there are left to the user rather than claimed for pruning.
+ * The rules/skills roots are claimed wholesale: they are the fan-out set a
+ * rename multiplies across every root, and the entry documents present them
+ * as the framework's rule catalog.
+ */
+export function managedNamespaces(components: Iterable<HarnessComponent>): ManagedNamespace[] {
+  const active = new Set<HarnessComponent>(components)
+  const namespaces: ManagedNamespace[] = []
+  if (active.has('claude')) {
+    namespaces.push({ dir: '.claude/rules', recursive: true }, { dir: '.claude/skills', recursive: true })
+  }
+  if (active.has('agents')) {
+    namespaces.push({ dir: '.agents/rules', recursive: true }, { dir: '.agents/skills', recursive: true })
+  }
+  if (active.has('cursor')) {
+    namespaces.push(CURSOR_RULES_NAMESPACE)
+  }
+  if (active.has('copilot')) {
+    namespaces.push(COPILOT_RULES_NAMESPACE)
+  }
+  return namespaces
+}
+
 export interface PlannedFile {
   /** App-relative POSIX path, e.g. `.agents/rules/testing.md`. */
   path: string
@@ -297,14 +368,18 @@ export function planComponents(
 
   if (components.includes('cursor')) {
     for (const [stem, doc] of nativeRuleDocs) {
-      add({ path: `.cursor/rules/guren-${stem}.mdc`, content: renderCursorRule(doc), managed: true })
+      add({
+        path: nativeRulePath(CURSOR_RULES_NAMESPACE, stem),
+        content: renderCursorRule(doc),
+        managed: true,
+      })
     }
     addMcpConfig('.cursor/mcp.json', 'targets/cursor/mcp.json')
   }
   if (components.includes('copilot')) {
     for (const [stem, doc] of nativeRuleDocs) {
       add({
-        path: `.github/instructions/guren-${stem}.instructions.md`,
+        path: nativeRulePath(COPILOT_RULES_NAMESPACE, stem),
         content: renderCopilotRule(doc),
         managed: true,
       })

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -2002,13 +2002,15 @@ function reportAgentHarnessResult(result: AgentHarnessResult): void {
   if (result.skipped.length > 0) {
     consola.info(`Skipped ${result.skipped.length} existing file(s): ${result.skipped.join(', ')}`)
   }
-  if (result.pruned.length > 0) {
-    consola.success(`Removed ${result.pruned.length} stale managed file(s): ${result.pruned.join(', ')}`)
-  } else if (result.stale.length > 0) {
-    consola.info(
-      `Found ${result.stale.length} file(s) in framework-managed directories that are not part of the current harness: ${result.stale.join(', ')}\n` +
-        'If they are leftovers from an earlier harness version, remove them with `bunx guren agent:sync --prune`. Files you authored yourself are safe to keep — sync never deletes without --prune.',
-    )
+  if (result.stale.length > 0) {
+    if (result.pruned) {
+      consola.success(`Removed ${result.stale.length} stale managed file(s): ${result.stale.join(', ')}`)
+    } else {
+      consola.info(
+        `Found ${result.stale.length} file(s) in framework-managed directories that are not part of the current harness: ${result.stale.join(', ')}\n` +
+          'If they are leftovers from an earlier harness version, remove them with `bunx guren agent:sync --prune`. Files you authored yourself are safe to keep — sync never deletes without --prune.',
+      )
+    }
   }
   for (const hint of result.mcpMergeHints) {
     consola.info(
@@ -2081,7 +2083,7 @@ const agentSyncCommand = defineCommand({
     prune: {
       type: 'boolean',
       description:
-        'Delete files in framework-managed directories (rules/skills roots, guren-* native rules) that are no longer part of the harness. Without this flag they are only reported.',
+        'Delete files in framework-managed directories that are no longer part of the harness. Without this flag they are only reported.',
     },
     app: {
       type: 'string',

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -2002,6 +2002,14 @@ function reportAgentHarnessResult(result: AgentHarnessResult): void {
   if (result.skipped.length > 0) {
     consola.info(`Skipped ${result.skipped.length} existing file(s): ${result.skipped.join(', ')}`)
   }
+  if (result.pruned.length > 0) {
+    consola.success(`Removed ${result.pruned.length} stale managed file(s): ${result.pruned.join(', ')}`)
+  } else if (result.stale.length > 0) {
+    consola.info(
+      `Found ${result.stale.length} file(s) in framework-managed directories that are not part of the current harness: ${result.stale.join(', ')}\n` +
+        'If they are leftovers from an earlier harness version, remove them with `bunx guren agent:sync --prune`. Files you authored yourself are safe to keep — sync never deletes without --prune.',
+    )
+  }
   for (const hint of result.mcpMergeHints) {
     consola.info(
       `${hint.path} already exists, so it was left alone. Add the Guren MCP server to it yourself:\n${hint.snippet}`,
@@ -2070,6 +2078,11 @@ const agentSyncCommand = defineCommand({
       type: 'string',
       description: `${AGENT_TARGETS_HELP} Default: every target detected on disk.`,
     },
+    prune: {
+      type: 'boolean',
+      description:
+        'Delete files in framework-managed directories (rules/skills roots, guren-* native rules) that are no longer part of the harness. Without this flag they are only reported.',
+    },
     app: {
       type: 'string',
       description: 'Application root directory.',
@@ -2080,6 +2093,7 @@ const agentSyncCommand = defineCommand({
       cwd: args.app,
       mode: 'sync',
       targets: args.target ? parseTargetArg(args.target) : undefined,
+      prune: Boolean(args.prune),
     })
     reportAgentHarnessResult(result)
     consola.success('Agent harness synced to the latest framework version.')

--- a/packages/cli/tests/agent-harness.test.ts
+++ b/packages/cli/tests/agent-harness.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
-import { mkdtemp, mkdir, rm, readFile, rename, writeFile, access } from 'node:fs/promises'
+import { mkdtemp, mkdir, rm, readFile, rename, symlink, writeFile, access } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { installAgentHarness } from '../src/agent-harness'
@@ -250,15 +250,29 @@ describe('installAgentHarness', () => {
     expect(result.written).not.toContain('.codex/config.toml')
   })
 
+  /**
+   * Simulate an install from an older release whose canonical rule carried a
+   * different name: rename the rule's copies in whichever managed roots the
+   * install produced.
+   */
+  const renameInstalledRule = async (from: string, to: string): Promise<void> => {
+    const spellings = [
+      [`.claude/rules/${from}.md`, `.claude/rules/${to}.md`],
+      [`.agents/rules/${from}.md`, `.agents/rules/${to}.md`],
+      [`.cursor/rules/guren-${from}.mdc`, `.cursor/rules/guren-${to}.mdc`],
+      [
+        `.github/instructions/guren-${from}.instructions.md`,
+        `.github/instructions/guren-${to}.instructions.md`,
+      ],
+    ]
+    for (const [oldPath, newPath] of spellings) {
+      await rename(join(tempDir, oldPath), join(tempDir, newPath)).catch(() => {})
+    }
+  }
+
   it('sync reports what a renamed canonical rule left behind without deleting it', async () => {
     await installAgentHarness({ cwd: tempDir, mode: 'init', targets: ['claude', 'cursor'] })
-    // simulate an install from an older release whose canonical rule carried the old name
-    await rename(join(tempDir, '.claude/rules/orm-models.md'), join(tempDir, '.claude/rules/models.md'))
-    await rename(join(tempDir, '.agents/rules/orm-models.md'), join(tempDir, '.agents/rules/models.md'))
-    await rename(
-      join(tempDir, '.cursor/rules/guren-orm-models.mdc'),
-      join(tempDir, '.cursor/rules/guren-models.mdc'),
-    )
+    await renameInstalledRule('orm-models', 'models')
 
     const result = await installAgentHarness({ cwd: tempDir, mode: 'sync' })
 
@@ -267,7 +281,7 @@ describe('installAgentHarness', () => {
       '.claude/rules/models.md',
       '.cursor/rules/guren-models.mdc',
     ])
-    expect(result.pruned).toEqual([])
+    expect(result.pruned).toBe(false)
     // the current name is restored, the old copies stay until an explicit --prune
     expect(result.written).toContain('.claude/rules/orm-models.md')
     await access(join(tempDir, '.claude/rules/models.md'))
@@ -276,21 +290,12 @@ describe('installAgentHarness', () => {
 
   it('sync --prune deletes the renamed rule leftovers in every root', async () => {
     await installAgentHarness({ cwd: tempDir, mode: 'init', targets: ['claude', 'cursor', 'copilot'] })
-    await rename(join(tempDir, '.claude/rules/orm-models.md'), join(tempDir, '.claude/rules/models.md'))
-    await rename(join(tempDir, '.agents/rules/orm-models.md'), join(tempDir, '.agents/rules/models.md'))
-    await rename(
-      join(tempDir, '.cursor/rules/guren-orm-models.mdc'),
-      join(tempDir, '.cursor/rules/guren-models.mdc'),
-    )
-    await rename(
-      join(tempDir, '.github/instructions/guren-orm-models.instructions.md'),
-      join(tempDir, '.github/instructions/guren-models.instructions.md'),
-    )
+    await renameInstalledRule('orm-models', 'models')
 
     const result = await installAgentHarness({ cwd: tempDir, mode: 'sync', prune: true })
 
-    expect(result.pruned).toEqual(result.stale)
-    expect(result.pruned).toEqual([
+    expect(result.pruned).toBe(true)
+    expect(result.stale).toEqual([
       '.agents/rules/models.md',
       '.claude/rules/models.md',
       '.cursor/rules/guren-models.mdc',
@@ -311,7 +316,8 @@ describe('installAgentHarness', () => {
 
     const result = await installAgentHarness({ cwd: tempDir, mode: 'sync', prune: true })
 
-    expect(result.pruned).toEqual(['.claude/skills/retired-skill/SKILL.md'])
+    expect(result.stale).toEqual(['.claude/skills/retired-skill/SKILL.md'])
+    expect(result.pruned).toBe(true)
     await expect(access(join(tempDir, '.claude/skills/retired-skill'))).rejects.toThrow()
     await access(join(tempDir, '.claude/skills/dev-workflow/SKILL.md'))
   })
@@ -337,8 +343,72 @@ describe('installAgentHarness', () => {
     const result = await installAgentHarness({ cwd: tempDir, mode: 'sync' })
 
     expect(result.stale).toEqual(['.claude/rules/team-conventions.md'])
-    expect(result.pruned).toEqual([])
+    expect(result.pruned).toBe(false)
     expect(await readFile(join(tempDir, '.claude/rules/team-conventions.md'), 'utf8')).toBe('user rule\n')
+  })
+
+  it('sync --prune deletes a colliding user file — why deletion is opt-in', async () => {
+    await installAgentHarness({ cwd: tempDir, mode: 'init' })
+    await writeFile(join(tempDir, '.claude/rules/team-conventions.md'), 'user rule\n', 'utf8')
+
+    const result = await installAgentHarness({ cwd: tempDir, mode: 'sync', prune: true })
+
+    expect(result.stale).toEqual(['.claude/rules/team-conventions.md'])
+    await expect(access(join(tempDir, '.claude/rules/team-conventions.md'))).rejects.toThrow()
+  })
+
+  it('sync --prune never touches .claude/agents or .claude/hooks', async () => {
+    await installAgentHarness({ cwd: tempDir, mode: 'init' })
+    await writeFile(join(tempDir, '.claude/agents/my-agent.md'), 'user agent\n', 'utf8')
+    await writeFile(join(tempDir, '.claude/hooks/retired-hook.ts'), 'old hook\n', 'utf8')
+
+    const result = await installAgentHarness({ cwd: tempDir, mode: 'sync', prune: true })
+
+    expect(result.stale).toEqual([])
+    expect(await readFile(join(tempDir, '.claude/agents/my-agent.md'), 'utf8')).toBe('user agent\n')
+    expect(await readFile(join(tempDir, '.claude/hooks/retired-hook.ts'), 'utf8')).toBe('old hook\n')
+  })
+
+  it('sync --prune leaves unrelated empty directories in a shared namespace alone', async () => {
+    await installAgentHarness({ cwd: tempDir, mode: 'init', targets: ['cursor'] })
+    await mkdir(join(tempDir, '.cursor/rules/drafts'), { recursive: true })
+    await writeFile(join(tempDir, '.cursor/rules/guren-retired.mdc'), 'stale\n', 'utf8')
+
+    const result = await installAgentHarness({ cwd: tempDir, mode: 'sync', prune: true })
+
+    expect(result.stale).toEqual(['.cursor/rules/guren-retired.mdc'])
+    // the sweep follows the deleted files upward; it never removes empty
+    // directories the pruning did not create
+    await access(join(tempDir, '.cursor/rules/drafts'))
+  })
+
+  it('sync never claims through a symlinked managed root', async () => {
+    await installAgentHarness({ cwd: tempDir, mode: 'init' })
+    // an external rules directory linked into the app: scanning (and prune)
+    // must not reach through the link
+    await rename(join(tempDir, '.claude/rules'), join(tempDir, 'shared-rules'))
+    await symlink(join(tempDir, 'shared-rules'), join(tempDir, '.claude/rules'))
+    await writeFile(join(tempDir, 'shared-rules/legacy.md'), 'external\n', 'utf8')
+
+    const result = await installAgentHarness({ cwd: tempDir, mode: 'sync', prune: true })
+
+    expect(result.stale).toEqual([])
+    expect(await readFile(join(tempDir, 'shared-rules/legacy.md'), 'utf8')).toBe('external\n')
+  })
+
+  it('sync --prune spares a planned file reached through a differently-cased entry', async () => {
+    await installAgentHarness({ cwd: tempDir, mode: 'init' })
+    // case-preserving filesystems keep this entry name while the write loop
+    // refreshes the planned lowercase path through it
+    await rename(
+      join(tempDir, '.claude/rules/orm-models.md'),
+      join(tempDir, '.claude/rules/ORM-MODELS.md'),
+    )
+
+    const result = await installAgentHarness({ cwd: tempDir, mode: 'sync', prune: true })
+
+    expect(result.stale).not.toContain('.claude/rules/ORM-MODELS.md')
+    expect(await readFile(join(tempDir, '.claude/rules/orm-models.md'), 'utf8')).toContain('defineModel')
   })
 
   it('sync --prune scans only the namespaces of the components being synced', async () => {
@@ -351,6 +421,7 @@ describe('installAgentHarness', () => {
     const result = await installAgentHarness({ cwd: tempDir, mode: 'sync', prune: true })
 
     expect(result.stale).toEqual([])
+    expect(result.pruned).toBe(false)
     await access(join(tempDir, '.agents/rules/leftover.md'))
   })
 
@@ -360,7 +431,7 @@ describe('installAgentHarness', () => {
     const result = await installAgentHarness({ cwd: tempDir, mode: 'sync' })
 
     expect(result.stale).toEqual([])
-    expect(result.pruned).toEqual([])
+    expect(result.pruned).toBe(false)
   })
 
   it('init never reports or deletes stale candidates', async () => {
@@ -370,7 +441,7 @@ describe('installAgentHarness', () => {
     const result = await installAgentHarness({ cwd: tempDir, mode: 'init', prune: true })
 
     expect(result.stale).toEqual([])
-    expect(result.pruned).toEqual([])
+    expect(result.pruned).toBe(false)
     expect(await readFile(join(tempDir, '.claude/rules/extra.md'), 'utf8')).toBe('user rule\n')
   })
 

--- a/packages/cli/tests/agent-harness.test.ts
+++ b/packages/cli/tests/agent-harness.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
-import { mkdtemp, mkdir, rm, readFile, writeFile, access } from 'node:fs/promises'
+import { mkdtemp, mkdir, rm, readFile, rename, writeFile, access } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { installAgentHarness } from '../src/agent-harness'
+import { AGENT_TARGETS } from '../src/agent-targets'
 
 describe('installAgentHarness', () => {
   let tempDir: string
@@ -247,6 +248,130 @@ describe('installAgentHarness', () => {
     // the user-owned MCP snippet is not re-planned by a detected sync,
     // so a deleted .codex/config.toml stays deleted
     expect(result.written).not.toContain('.codex/config.toml')
+  })
+
+  it('sync reports what a renamed canonical rule left behind without deleting it', async () => {
+    await installAgentHarness({ cwd: tempDir, mode: 'init', targets: ['claude', 'cursor'] })
+    // simulate an install from an older release whose canonical rule carried the old name
+    await rename(join(tempDir, '.claude/rules/orm-models.md'), join(tempDir, '.claude/rules/models.md'))
+    await rename(join(tempDir, '.agents/rules/orm-models.md'), join(tempDir, '.agents/rules/models.md'))
+    await rename(
+      join(tempDir, '.cursor/rules/guren-orm-models.mdc'),
+      join(tempDir, '.cursor/rules/guren-models.mdc'),
+    )
+
+    const result = await installAgentHarness({ cwd: tempDir, mode: 'sync' })
+
+    expect(result.stale).toEqual([
+      '.agents/rules/models.md',
+      '.claude/rules/models.md',
+      '.cursor/rules/guren-models.mdc',
+    ])
+    expect(result.pruned).toEqual([])
+    // the current name is restored, the old copies stay until an explicit --prune
+    expect(result.written).toContain('.claude/rules/orm-models.md')
+    await access(join(tempDir, '.claude/rules/models.md'))
+    await access(join(tempDir, '.cursor/rules/guren-models.mdc'))
+  })
+
+  it('sync --prune deletes the renamed rule leftovers in every root', async () => {
+    await installAgentHarness({ cwd: tempDir, mode: 'init', targets: ['claude', 'cursor', 'copilot'] })
+    await rename(join(tempDir, '.claude/rules/orm-models.md'), join(tempDir, '.claude/rules/models.md'))
+    await rename(join(tempDir, '.agents/rules/orm-models.md'), join(tempDir, '.agents/rules/models.md'))
+    await rename(
+      join(tempDir, '.cursor/rules/guren-orm-models.mdc'),
+      join(tempDir, '.cursor/rules/guren-models.mdc'),
+    )
+    await rename(
+      join(tempDir, '.github/instructions/guren-orm-models.instructions.md'),
+      join(tempDir, '.github/instructions/guren-models.instructions.md'),
+    )
+
+    const result = await installAgentHarness({ cwd: tempDir, mode: 'sync', prune: true })
+
+    expect(result.pruned).toEqual(result.stale)
+    expect(result.pruned).toEqual([
+      '.agents/rules/models.md',
+      '.claude/rules/models.md',
+      '.cursor/rules/guren-models.mdc',
+      '.github/instructions/guren-models.instructions.md',
+    ])
+    await expect(access(join(tempDir, '.claude/rules/models.md'))).rejects.toThrow()
+    await expect(access(join(tempDir, '.cursor/rules/guren-models.mdc'))).rejects.toThrow()
+    // the rule under its current name is freshly written, not pruned
+    expect(await readFile(join(tempDir, '.cursor/rules/guren-orm-models.mdc'), 'utf8')).toContain(
+      'defineModel',
+    )
+  })
+
+  it('sync --prune removes a skill that left the canonical set, directory included', async () => {
+    await installAgentHarness({ cwd: tempDir, mode: 'init' })
+    await mkdir(join(tempDir, '.claude/skills/retired-skill'), { recursive: true })
+    await writeFile(join(tempDir, '.claude/skills/retired-skill/SKILL.md'), 'old skill\n', 'utf8')
+
+    const result = await installAgentHarness({ cwd: tempDir, mode: 'sync', prune: true })
+
+    expect(result.pruned).toEqual(['.claude/skills/retired-skill/SKILL.md'])
+    await expect(access(join(tempDir, '.claude/skills/retired-skill'))).rejects.toThrow()
+    await access(join(tempDir, '.claude/skills/dev-workflow/SKILL.md'))
+  })
+
+  it('sync --prune leaves user files outside the managed name patterns alone', async () => {
+    await installAgentHarness({ cwd: tempDir, mode: 'init', targets: ['cursor', 'copilot'] })
+    await writeFile(join(tempDir, '.cursor/rules/my-style.mdc'), 'user rule\n', 'utf8')
+    await writeFile(join(tempDir, '.github/instructions/team.instructions.md'), 'user instructions\n', 'utf8')
+
+    const result = await installAgentHarness({ cwd: tempDir, mode: 'sync', prune: true })
+
+    expect(result.stale).toEqual([])
+    expect(await readFile(join(tempDir, '.cursor/rules/my-style.mdc'), 'utf8')).toBe('user rule\n')
+    expect(await readFile(join(tempDir, '.github/instructions/team.instructions.md'), 'utf8')).toBe(
+      'user instructions\n',
+    )
+  })
+
+  it('sync reports a user file in the managed rules root but keeps it by default', async () => {
+    await installAgentHarness({ cwd: tempDir, mode: 'init' })
+    await writeFile(join(tempDir, '.claude/rules/team-conventions.md'), 'user rule\n', 'utf8')
+
+    const result = await installAgentHarness({ cwd: tempDir, mode: 'sync' })
+
+    expect(result.stale).toEqual(['.claude/rules/team-conventions.md'])
+    expect(result.pruned).toEqual([])
+    expect(await readFile(join(tempDir, '.claude/rules/team-conventions.md'), 'utf8')).toBe('user rule\n')
+  })
+
+  it('sync --prune scans only the namespaces of the components being synced', async () => {
+    await installAgentHarness({ cwd: tempDir, mode: 'init' })
+    // an .agents tree with no managed evidence is not a detected component,
+    // so its namespace is out of scope for this sync
+    await mkdir(join(tempDir, '.agents/rules'), { recursive: true })
+    await writeFile(join(tempDir, '.agents/rules/leftover.md'), 'x\n', 'utf8')
+
+    const result = await installAgentHarness({ cwd: tempDir, mode: 'sync', prune: true })
+
+    expect(result.stale).toEqual([])
+    await access(join(tempDir, '.agents/rules/leftover.md'))
+  })
+
+  it('a fresh full install syncs with nothing stale', async () => {
+    await installAgentHarness({ cwd: tempDir, mode: 'init', targets: [...AGENT_TARGETS] })
+
+    const result = await installAgentHarness({ cwd: tempDir, mode: 'sync' })
+
+    expect(result.stale).toEqual([])
+    expect(result.pruned).toEqual([])
+  })
+
+  it('init never reports or deletes stale candidates', async () => {
+    await mkdir(join(tempDir, '.claude/rules'), { recursive: true })
+    await writeFile(join(tempDir, '.claude/rules/extra.md'), 'user rule\n', 'utf8')
+
+    const result = await installAgentHarness({ cwd: tempDir, mode: 'init', prune: true })
+
+    expect(result.stale).toEqual([])
+    expect(result.pruned).toEqual([])
+    expect(await readFile(join(tempDir, '.claude/rules/extra.md'), 'utf8')).toBe('user rule\n')
   })
 
   it('reports that .mcp.json is dead when no script enables the endpoint', async () => {

--- a/packages/cli/tests/agent-targets.test.ts
+++ b/packages/cli/tests/agent-targets.test.ts
@@ -3,6 +3,7 @@ import {
   AGENT_TARGETS,
   BULK_TEMPLATE_PREFIXES,
   componentsForTargets,
+  managedNamespaces,
   parseTargetList,
   planComponents,
   type HarnessComponent,
@@ -201,6 +202,57 @@ describe('planComponents', () => {
 })
 
 const ALL_COMPONENTS: HarnessComponent[] = ['claude', 'agents', 'cursor', 'copilot', 'codex', 'opencode']
+
+describe('managedNamespaces', () => {
+  it('claims the rules and skills roots wholesale for claude and agents', () => {
+    expect(managedNamespaces(['claude', 'agents']).map((namespace) => namespace.dir)).toEqual([
+      '.claude/rules',
+      '.claude/skills',
+      '.agents/rules',
+      '.agents/skills',
+    ])
+    for (const namespace of managedNamespaces(['claude', 'agents'])) {
+      expect(namespace.fileName).toBeUndefined()
+      expect(namespace.recursive).toBe(true)
+    }
+  })
+
+  it('claims only guren-prefixed files in the shared cursor and copilot directories', () => {
+    const byDir = new Map(managedNamespaces(['cursor', 'copilot']).map((ns) => [ns.dir, ns]))
+    expect(byDir.get('.cursor/rules')?.fileName).toEqual({ prefix: 'guren-', suffix: '.mdc' })
+    expect(byDir.get('.github/instructions')?.fileName).toEqual({
+      prefix: 'guren-',
+      suffix: '.instructions.md',
+    })
+  })
+
+  it('claims nothing for codex and opencode, whose distinct files are user-owned', () => {
+    expect(managedNamespaces(['codex', 'opencode'])).toEqual([])
+  })
+
+  it('every planned file inside a shared namespace carries its ownership pattern', () => {
+    // .cursor/rules and .github/instructions also hold user files, so a
+    // managed file the pattern cannot claim would be orphaned on rename
+    const namespaces = managedNamespaces(ALL_COMPONENTS).filter((ns) => ns.fileName)
+    for (const file of planComponents(ALL_COMPONENTS, fakeTemplates(), 'My App')) {
+      for (const namespace of namespaces) {
+        if (!file.path.startsWith(`${namespace.dir}/`)) {
+          continue
+        }
+        const name = file.path.slice(namespace.dir.length + 1)
+        if (file.managed) {
+          expect(name).toStartWith(namespace.fileName!.prefix)
+          expect(name).toEndWith(namespace.fileName!.suffix)
+        } else {
+          // a user-owned planned file must never match the prune pattern
+          expect(
+            name.startsWith(namespace.fileName!.prefix) && name.endsWith(namespace.fileName!.suffix),
+          ).toBe(false)
+        }
+      }
+    }
+  })
+})
 
 describe('template completeness', () => {
   it('every shipped template file is consumed by the planner', async () => {

--- a/packages/cli/tests/agent-targets.test.ts
+++ b/packages/cli/tests/agent-targets.test.ts
@@ -205,25 +205,19 @@ const ALL_COMPONENTS: HarnessComponent[] = ['claude', 'agents', 'cursor', 'copil
 
 describe('managedNamespaces', () => {
   it('claims the rules and skills roots wholesale for claude and agents', () => {
-    expect(managedNamespaces(['claude', 'agents']).map((namespace) => namespace.dir)).toEqual([
-      '.claude/rules',
-      '.claude/skills',
-      '.agents/rules',
-      '.agents/skills',
+    expect(managedNamespaces(['claude', 'agents'])).toEqual([
+      { kind: 'tree', dir: '.claude/rules' },
+      { kind: 'tree', dir: '.claude/skills' },
+      { kind: 'tree', dir: '.agents/rules' },
+      { kind: 'tree', dir: '.agents/skills' },
     ])
-    for (const namespace of managedNamespaces(['claude', 'agents'])) {
-      expect(namespace.fileName).toBeUndefined()
-      expect(namespace.recursive).toBe(true)
-    }
   })
 
   it('claims only guren-prefixed files in the shared cursor and copilot directories', () => {
-    const byDir = new Map(managedNamespaces(['cursor', 'copilot']).map((ns) => [ns.dir, ns]))
-    expect(byDir.get('.cursor/rules')?.fileName).toEqual({ prefix: 'guren-', suffix: '.mdc' })
-    expect(byDir.get('.github/instructions')?.fileName).toEqual({
-      prefix: 'guren-',
-      suffix: '.instructions.md',
-    })
+    expect(managedNamespaces(['cursor', 'copilot'])).toEqual([
+      { kind: 'pattern', dir: '.cursor/rules', prefix: 'guren-', suffix: '.mdc' },
+      { kind: 'pattern', dir: '.github/instructions', prefix: 'guren-', suffix: '.instructions.md' },
+    ])
   })
 
   it('claims nothing for codex and opencode, whose distinct files are user-owned', () => {
@@ -233,7 +227,9 @@ describe('managedNamespaces', () => {
   it('every planned file inside a shared namespace carries its ownership pattern', () => {
     // .cursor/rules and .github/instructions also hold user files, so a
     // managed file the pattern cannot claim would be orphaned on rename
-    const namespaces = managedNamespaces(ALL_COMPONENTS).filter((ns) => ns.fileName)
+    const namespaces = managedNamespaces(ALL_COMPONENTS).filter(
+      (namespace) => namespace.kind === 'pattern',
+    )
     for (const file of planComponents(ALL_COMPONENTS, fakeTemplates(), 'My App')) {
       for (const namespace of namespaces) {
         if (!file.path.startsWith(`${namespace.dir}/`)) {
@@ -241,13 +237,11 @@ describe('managedNamespaces', () => {
         }
         const name = file.path.slice(namespace.dir.length + 1)
         if (file.managed) {
-          expect(name).toStartWith(namespace.fileName!.prefix)
-          expect(name).toEndWith(namespace.fileName!.suffix)
+          expect(name).toStartWith(namespace.prefix)
+          expect(name).toEndWith(namespace.suffix)
         } else {
           // a user-owned planned file must never match the prune pattern
-          expect(
-            name.startsWith(namespace.fileName!.prefix) && name.endsWith(namespace.fileName!.suffix),
-          ).toBe(false)
+          expect(name.startsWith(namespace.prefix) && name.endsWith(namespace.suffix)).toBe(false)
         }
       }
     }


### PR DESCRIPTION
## Problem

`agent:sync` writes the current managed file set but never removes managed files that have left the canonical set. The multi-agent harness (RFC 0008) fans managed rules out to up to four roots (`.claude/rules`, `.agents/rules`, `.cursor/rules/guren-*.mdc`, `.github/instructions/guren-*.instructions.md`), so a renamed or removed canonical rule leaves up to four stale copies behind — and Cursor and Copilot keep auto-loading the stale copies by glob.

## Solution

- **The planner owns the cleanup patterns.** `managedNamespaces()` in `agent-targets.ts` declares the namespaces the framework claims: the rules/skills roots wholesale (`.claude/rules`, `.claude/skills`, `.agents/rules`, `.agents/skills`) and `guren-`prefixed files in the shared `.cursor/rules` / `.github/instructions` directories. The native-rule paths `planComponents` writes and the prune patterns derive from the same constants, so they cannot drift apart.
- **Report-only by default.** `agent:sync` lists any file in those namespaces that the current plan no longer writes (`stale` in the result), with guidance in the CLI output. Nothing is deleted without the flag, so a user-authored file under a colliding name is never silently removed.
- **`agent:sync --prune` deletes.** Deletion is an explicit opt-in; it removes exactly the reported set and sweeps directories the pruning emptied (e.g. a removed skill's directory).
- **Deliberate exclusions.** `.claude/agents/` and `.claude/hooks/` ship managed files too, but they are the conventional home for user-authored subagents and hooks and a name pattern cannot tell the two apart, so they are not claimed. codex/opencode have no distinct managed files (their extras are user-owned). Scanning covers only the components being synced — an `.agents/` tree with no managed evidence stays untouched.

## Tests

- Rename of a canonical rule: old copies reported in every root, restored name rewritten; `--prune` deletes the leftovers in all four roots.
- Removal of a canonical skill: `--prune` removes the file and its emptied directory.
- User files outside the patterns (`.cursor/rules/my-style.mdc`, non-`guren-` instructions) are never candidates; colliding user files in the rules roots are reported but kept by default.
- A fresh full install syncs with zero stale findings (false-positive guard over the real templates); `init` never scans.
- `managedNamespaces` unit tests, including the invariant that every planned file inside a shared namespace carries the ownership pattern.

Docs (en/ja `guides/cli.md`) and a `@guren/cli` minor changeset included.

Stacked on #397.