### PR TITLE
refactor(cli): read `:name*` route paths through the shared param pattern

### DIFF
--- a/.changeset/route-path-check-shared-lexer.md
+++ b/.changeset/route-path-check-shared-lexer.md
@@ -1,0 +1,9 @@
+---
+"@guren/cli": patch
+---
+
+The `:name*` route path check reads paths through the shared path-param pattern.
+
+The rule was written when no shared lexer existed, so it carried its own segment reading: split on `/`, take everything up to a `{`, strip a trailing `?`. `PATH_PARAM_PATTERN` now answers the same question — it anchors params at a segment boundary, consumes an attached constraint whole including one level of nesting, and keeps a trailing `*` as part of the label, which is the finding itself. Detection and the suggested rewrite are both driven by it, so the check and the code generators can no longer come to disagree about what a path binds.
+
+No behaviour change for any path a scaffolder or guide produces; the shared pattern is stricter than the old reading only for a label with punctuation in it (`:name.:ext*`).

--- a/packages/cli/src/route-path-check.ts
+++ b/packages/cli/src/route-path-check.ts
@@ -10,6 +10,7 @@ import {
   toPosixRelative,
 } from './discovery'
 import type { ParseCache } from './parse-cache'
+import { extractPathParamNames, PATH_PARAM_PATTERN } from './utils'
 import { check, type CheckResult } from './check-result'
 
 /**
@@ -44,75 +45,53 @@ const ROUTE_PATH_ARGUMENT: Record<string, number> = {
 }
 
 /**
- * One path segment that names a `:name*` parameter — the `/:slug*` shape —
- * or `null` for every other segment.
+ * The name Hono binds for the first `:name*` parameter in a path, or `null`
+ * when the path is fine.
  *
- * Detection and rewrite come out of the same read on purpose. Deriving the
- * corrected segment separately meant re-deciding, by string comparison,
- * whether the segment carried a constraint or a trailing `?`, and the two
- * reads had already disagreed: `/:slug*?` was reported and then handed back
- * to the user unchanged as its own fix.
+ * Read through the shared lexer rather than a rule of this file's own: a
+ * param starts only at a segment boundary, an attached `{constraint}` is
+ * consumed whole (including one level of nesting), and the label keeps a
+ * trailing `*` — which is the whole finding. `/files/:slug*` therefore reads
+ * as the parameter `slug*`, exactly as Hono registers it (`getPattern`,
+ * verified against hono 4.13.1): the route does not match `/files/a/b`, and
+ * `c.req.param('slug')` is undefined.
  *
- * Deliberately narrower than a path-param lexer: this asks a yes/no question
- * per segment rather than enumerating a path's parameter names, so it needs
- * none of the boundary and nesting rules a full lexer carries. The repo's
- * canonical one lives in `routes-types-fragments.ts` (mirrored into
- * @guren/inertia-client under a verbatim pin test) — derive from that if this
- * ever needs to answer more than "does this name end in a star?".
- *
- * The rule is Hono's own (`getPattern`, verified against hono 4.13.1): a
- * segment beginning `:` takes everything up to an optional `{constraint}` as
- * the parameter *name*, `[^{}]+`, with no special meaning for `*`. So
- * `/files/:slug*` registers a single-segment parameter literally named
- * `slug*` — it does not match `/files/a/b`, and `c.req.param('slug')` is
- * undefined.
- *
- * What must NOT match, and why the naive "does the segment contain `*`" test
- * is wrong: `:path{.+}`, `:path{.*}` and `:t{[0-9]{2}}` are legitimate
+ * What must NOT match, and why a rule of the form "does the segment contain
+ * `*`" is wrong: `:path{.+}`, `:path{.*}` and `:t{[0-9]{2}}` are legitimate
  * constrained parameters, and a bare `*` segment is Hono's real wildcard.
- * Only the name is examined, so all four are left alone.
- */
-function starSuffixedSegment(segment: string): { name: string; rewrite: string } | null {
-  if (!segment.startsWith(':')) return null
-
-  const brace = segment.indexOf('{')
-  const optional = brace === -1 && segment.endsWith('?')
-  const name = segment.slice(1, brace === -1 ? (optional ? -1 : undefined) : brace)
-  if (!name.endsWith('*')) return null
-
-  // A segment carrying both a star and a constraint (`:slug*{[a-z]+}`) has no
-  // single obvious rewrite, so it is left as written — the finding still names
-  // it, and the fallback half of the suggestion still applies.
-  const rewrite = brace === -1 ? `:${name.slice(0, -1)}{.+}${optional ? '?' : ''}` : segment
-  return { name, rewrite }
-}
-
-/**
- * The name Hono binds for the first `:name*` in a path, or `null` when the
- * path is fine. First rather than every one: the finding is phrased about a
- * single parameter, and the suggested path below fixes them all regardless.
+ * Only the label is examined, so all four are left alone.
+ *
+ * First rather than every one: the finding is phrased about a single
+ * parameter, and {@link withoutStarSuffixes} fixes them all regardless.
+ *
+ * Note what this check depends on: the shared pattern keeps the `*` as part
+ * of the label, so a change there that normalized it away would leave this
+ * silently reporting nothing. The detection tests fail on exactly that, which
+ * is the guard.
  */
 function firstStarSuffixedName(path: string): string | null {
-  for (const segment of path.split('/')) {
-    const found = starSuffixedSegment(segment)
-    if (found) return found.name
-  }
-  return null
+  return extractPathParamNames(path).find((name) => name.endsWith('*')) ?? null
 }
 
 /**
  * The path this one should have been, with every `:name*` rewritten to the
  * multi-segment form `:name{.+}`.
  *
- * Rebuilt from the split segments rather than patched by string replacement,
- * so a name appearing twice, or as a prefix of another, cannot rewrite the
- * wrong one.
+ * Driven by the same pattern that found the parameter, so detection and fix
+ * cannot disagree — they had, before this shared reading: `/:slug*?` was
+ * reported and then handed back unchanged as its own fix. Each token is
+ * replaced whole, so a name appearing twice, or as a prefix of another, cannot
+ * rewrite the wrong one.
+ *
+ * A parameter carrying both a star and a constraint (`:slug*{[a-z]+}`) has no
+ * single obvious rewrite, so it is left as written — the finding still names
+ * it, and the fallback half of the suggestion still applies.
  */
 function withoutStarSuffixes(path: string): string {
-  return path
-    .split('/')
-    .map((segment) => starSuffixedSegment(segment)?.rewrite ?? segment)
-    .join('/')
+  return path.replace(PATH_PARAM_PATTERN, (token: string, boundary: string, label: string) => {
+    if (!label.endsWith('*') || token.includes('{')) return token
+    return `${boundary}:${label.slice(0, -1)}{.+}${token.endsWith('?') ? '?' : ''}`
+  })
 }
 
 /** A route path literal found in a routes file. */

--- a/packages/cli/tests/check.test.ts
+++ b/packages/cli/tests/check.test.ts
@@ -1838,6 +1838,19 @@ ${body}
     expect(finding?.suggestion).toContain("'/files/:slug{.+}?'")
   })
 
+  // A star alongside a constraint has no single obvious rewrite, so the
+  // suggestion falls back to naming the path rather than inventing one.
+  it('leaves a constrained star parameter as written in the suggestion', async () => {
+    const report = await withWorkspace({
+      'routes/web.ts': entryWith(`  router.get('/files/:slug*{[a-z]+}', [FileController, 'show'])`),
+    })
+
+    const [finding] = modifiers(report)
+    expect(finding?.message).toContain("named literally 'slug*'")
+    expect(finding?.suggestion).toContain("'/files/:slug*{[a-z]+}'")
+    expect(finding?.suggestion).toContain("drop the '*' instead")
+  })
+
   // A single star param at a time: the sentence is about one parameter, while
   // the suggested path fixes them all.
   it('reports one finding per path, however many stars it carries', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #411. The `:name*` route path check now reads paths through `PATH_PARAM_PATTERN` instead of its own segment reading.

#411 was written on a branch that predated #408, so it carried a second lexing rule: split the path on `/`, take everything up to a `{` as the parameter name, strip a trailing `?`. `PATH_PARAM_PATTERN` (`packages/cli/src/utils.ts`) answers exactly that question and is already shared by the route generators, `Router`, and `@guren/openapi`. Both halves of the check — which parameter is reported, and the corrected path it suggests — are now driven by it.

## Why it lines up

The shared pattern anchors a parameter at a segment boundary, consumes an attached constraint whole (including one level of nesting), and **keeps a trailing `*` as part of the label** — which is the finding itself:

| path | `extractPathParamNames` |
|---|---|
| `/files/:slug*` | `["slug*"]` |
| `/files/:slug*?` | `["slug*"]` |
| `/docs/:path{.+}`, `/docs/:path{.*}`, `/docs/:path{[^/]*}` | `["path"]` |
| `/reports/:month{[0-9]{2}}` | `["month"]` |
| `/assets/*` | `[]` |
| `/posts/:id?`, `/posts/:id` | `["id"]` |

The rewrite is driven by the same pattern, replacing each token whole, so detection and fix cannot disagree — the failure mode #411's review caught, where `/:slug*?` was reported and handed back unchanged as its own fix.

## Behaviour

No change for any path a scaffolder or guide produces. The shared pattern is stricter than the old reading in one place: a label with punctuation in it (`:name.:ext*`) reads as the parameter `name`, so it no longer warns. That is the model the repo has settled on for every other consumer of the pattern, and following it is the point of this change.

## Verification

- All 15 route-path tests pass unchanged, plus a new one pinning the constrained-star fallback (`:slug*{[a-z]+}` has no single obvious rewrite, so the suggestion leaves it as written).
- Mutation-verified: dropping the constraint fallback, dropping the optional-marker preservation, and — the dependency this change introduces — normalizing the `*` out of the shared label each fail the tests that cover them. That last one fails twelve of fifteen, which is the drift guard the source comment claims.
- `examples/blog` reports zero findings; injecting `/files/:slug*?` fires with the corrected `'/files/:slug{.+}?'`.
- `bun run typecheck`, `bun run test:bun` (4342 pass), `audit:core-first`, `audit:docs` all pass.
