### PR TITLE
fix(cli): reject module names starting with a digit

### DIFF
--- a/.changeset/module-name-must-start-with-letter.md
+++ b/.changeset/module-name-must-start-with-letter.md
@@ -1,0 +1,11 @@
+---
+"@guren/cli": patch
+---
+
+`make:module` and `--module` refuse a name starting with a digit.
+
+A module name is not only a directory. Codegen PascalCases it to qualify the identifiers it emits for that module, so a Resource in `modules/billing/` is exported as `Data.BillingInvoice`. `modules/2fa/` yields `2faInvoice`, which is not a TypeScript identifier — the Data-type generator has to drop the definition and tell the author to rename the directory. The validator accepted the name, so the scaffolder created a module the generator would later refuse.
+
+The one segment that reaches the front of an identifier is the first, so only its leading character is constrained: `s3` and `billing-2fa` are still accepted, `2fa` and `2FA` are not, and the error names the reason rather than leaving it to be discovered at codegen time.
+
+This is deliberately a break for an app that already has a `modules/<digit…>/` directory: the directory keeps working everywhere it is discovered from disk (`check`, `context`, `codegen`), but `make:controller Invoice --module 2fa` and its siblings now refuse it. The name was never usable end to end — its generated Data types were already being dropped — so the refusal moves an existing failure to the point where it can still be fixed with a rename. The runtime check in the generator stays as a backstop, since a `modules/` directory can be created by hand.

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -416,7 +416,7 @@ export function referencesIdentifier(body: string, name: string): boolean {
   return new RegExp(`\\b${escapeRegExp(name)}\\b`, 'u').test(body)
 }
 
-const SAFE_MODULE_NAME_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/u
+const SAFE_MODULE_NAME_RE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/u
 
 /**
  * kebab-cases a `--module <name>`/`make:module <name>` value and rejects
@@ -427,13 +427,25 @@ const SAFE_MODULE_NAME_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/u
  * the result to be one or more alphanumeric segments joined by single
  * hyphens rejects those, plus anything else that isn't a plain directory
  * name (empty, all-symbol, leading/trailing hyphen, etc.) in one check.
+ *
+ * The first segment must additionally start with a letter, because the name
+ * is not only a directory: codegen PascalCases it to qualify the identifiers
+ * it emits for that module (`modules/billing/InvoiceResource` becomes
+ * `Data.BillingInvoice`), and no TypeScript identifier may start with a
+ * digit. `modules/2fa/` would yield `2faInvoice`, which the generator has to
+ * drop. Refusing the name here is the whole of the fix: every generator that
+ * qualifies a generated identifier by module name inherits the constraint,
+ * so this validator — not any one generator — is where it belongs. Later
+ * segments are unconstrained; only the leading character reaches the front
+ * of an identifier.
  */
 export function safeModuleName(value: string): string {
   const name = kebabCase(value)
   if (!SAFE_MODULE_NAME_RE.test(name)) {
     throw new Error(
-      `Invalid module name "${value}" — it becomes a directory segment under modules/, so it must be one or `
-      + `more alphanumeric segments joined by hyphens (e.g. "billing", "billing-ops").`,
+      `Invalid module name "${value}" — it becomes a directory segment under modules/ and is PascalCased into `
+      + `generated type names, so it must be one or more alphanumeric segments joined by hyphens, starting with `
+      + `a letter (e.g. "billing", "billing-ops", "two-factor" rather than "2fa").`,
     )
   }
   return name

--- a/packages/cli/tests/make-module.test.ts
+++ b/packages/cli/tests/make-module.test.ts
@@ -57,6 +57,19 @@ describe('makeModule', () => {
     }
   })
 
+  it('rejects a module name starting with a digit', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-module-digit-')
+    try {
+      // `modules/2fa/` would be PascalCased into `2faInvoice` by codegen.
+      await expect(makeModule('2fa')).rejects.toThrow(/Invalid module name/)
+
+      const created = await readFile(join(workspace.dir, 'modules/2fa/index.ts'), 'utf8').catch(() => null)
+      expect(created).toBeNull()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('patches an existing db/schema.ts with a re-export', async () => {
     const workspace = await createTempWorkspace('guren-cli-make-module-schema-patch-')
     try {

--- a/packages/cli/tests/safe-module-name.test.ts
+++ b/packages/cli/tests/safe-module-name.test.ts
@@ -8,6 +8,19 @@ describe('safeModuleName', () => {
     expect(safeModuleName('billing_ops')).toBe('billing-ops')
   })
 
+  it('accepts digits after the leading letter', () => {
+    expect(safeModuleName('s3')).toBe('s3')
+    expect(safeModuleName('billing-2fa')).toBe('billing-2fa')
+  })
+
+  it('rejects a name starting with a digit', () => {
+    // It is PascalCased into generated type names, and `2faInvoice` is not a
+    // TypeScript identifier.
+    expect(() => safeModuleName('2fa')).toThrow(/Invalid module name/)
+    // Kebab-cases to `2-fa`, so only checking the first segment catches it.
+    expect(() => safeModuleName('2FA')).toThrow(/Invalid module name/)
+  })
+
   it('rejects a name that escapes modules/ via ..', () => {
     expect(() => safeModuleName('../../outside')).toThrow(/Invalid module name/)
     expect(() => safeModuleName('..')).toThrow(/Invalid module name/)


### PR DESCRIPTION
## Summary

- `SAFE_MODULE_NAME_RE` in `packages/cli/src/utils.ts` permitted a leading digit, so `guren make:module 2fa` succeeded and created `modules/2fa/`.
- PR #412 makes `guren codegen`'s Data-type generator module-aware, qualifying a module's Resource types with the PascalCased module name (`modules/billing/InvoiceResource` → `Data.BillingInvoice`). For `modules/2fa/` that yields `2faInvoice`, which is not a valid TypeScript identifier, so the generator drops the definition and warns the user to rename the directory. The scaffolder blessed a name the generator later refused.
- Tightens the regex to `^[a-z][a-z0-9]*(-[a-z0-9]+)*$` so `make:module`/`--module` reject the name up front with a clear reason, instead of a working scaffold whose generated type silently disappears later. Only the first segment's leading character is constrained — `s3` and `billing-2fa` are still accepted.
- The runtime check in `data-types.ts` (from #412) stays as a backstop, since a `modules/` directory can be created by hand.

## Scope note (intentional behavior change)

Every caller of `safeModuleName` takes CLI input (`options.root` or the `make:module` argument) — confirmed by checking every call site. `discovery.ts` derives module names from paths without going through this validator, so an existing `modules/2fa/`-style directory keeps working everywhere it's discovered from disk (`check`, `context`, `codegen`). Only `make:controller Invoice --module 2fa` and its siblings now refuse the name. The name was never usable end to end anyway — its generated Data type was already being dropped — so this moves the failure to a point where it can still be fixed with a rename.

Added a `patch` changeset for `@guren/cli` describing this tradeoff.

## Test plan

- [x] Added `safe-module-name.test.ts` cases pinning both directions: accepts `s3`/`billing-2fa`, rejects `2fa` and `2FA` (kebab-cases to `2-fa`, so this proves the check isn't just "contains no digits")
- [x] Added `make-module.test.ts` end-to-end case: `makeModule('2fa')` rejects and writes nothing
- [x] Mutation check: reverted the regex locally, confirmed the new tests fail without the fix, then restored
- [x] `bun run build` — passes
- [x] `bun run typecheck` (root) — clean, after running codegen in `examples/blog` (fresh worktree)
- [x] `bun run test:bun cli` — 1441 pass / 0 fail