### PR TITLE
fix(cli): refuse Data types codegen would have to guess at

### DIFF
--- a/.changeset/data-types-refuse-ambiguous-bodies.md
+++ b/.changeset/data-types-refuse-ambiguous-bodies.md
@@ -10,6 +10,10 @@ Three shapes each yielded *some* brace body with no warning — the wrong one, w
 - Two `interface PostResourceData` blocks in one file emitted the first and dropped the second's members, though TypeScript merges them.
 - `type PostResourceData = { id: number } & { title: string }` emitted only the first term. An alias's right-hand side runs to the end of the statement, so a body followed by `&`, `|`, or a conditional `extends` is not the whole type.
 
+`type PostResourceData = { id: number }[]` and `= { … }['payload']` emitted the object operand as if it were the whole type; both are refused now too.
+
+Declarations are matched at the top level only. A type of the same name inside a namespace, an ambient module, or a function body is a different type that merely shares it: its members were emitted as the Resource's payload when nothing at the top level declared one, and it counted as a second block against a top-level declaration that was in fact the only one.
+
 A generic declaration is refused too, as it always was, but now says so: `{ id: T }` copied out of `interface PostResourceData<T>` would not compile, and "not a plain object type" sent the author to rewrite a shape that was never the problem.
 
 Each is now named, with the reason and the shape to write instead. A `type X = { … }` whose body stands alone still reads exactly as before, and output for every shape that already worked is byte-identical.

--- a/.changeset/data-types-refuse-ambiguous-bodies.md
+++ b/.changeset/data-types-refuse-ambiguous-bodies.md
@@ -10,4 +10,6 @@ Three shapes each yielded *some* brace body with no warning — the wrong one, w
 - Two `interface PostResourceData` blocks in one file emitted the first and dropped the second's members, though TypeScript merges them.
 - `type PostResourceData = { id: number } & { title: string }` emitted only the first term. An alias's right-hand side runs to the end of the statement, so a body followed by `&`, `|`, or a conditional `extends` is not the whole type.
 
+A generic declaration is refused too, as it always was, but now says so: `{ id: T }` copied out of `interface PostResourceData<T>` would not compile, and "not a plain object type" sent the author to rewrite a shape that was never the problem.
+
 Each is now named, with the reason and the shape to write instead. A `type X = { … }` whose body stands alone still reads exactly as before, and output for every shape that already worked is byte-identical.

--- a/.changeset/data-types-refuse-ambiguous-bodies.md
+++ b/.changeset/data-types-refuse-ambiguous-bodies.md
@@ -1,0 +1,13 @@
+---
+"@guren/cli": patch
+---
+
+`guren codegen` refuses to emit a `Data.*` type it would have to guess at, and says which declaration it could not read.
+
+Three shapes each yielded *some* brace body with no warning — the wrong one, which is worse than none: the frontend gets a type that compiles and lies about the payload.
+
+- `interface PostResourceData extends Record<string, { nested: true }> { … }` emitted the generic argument, not the body. Detected by the heritage clause's unbalanced angle brackets, which is what a clause cut off at the wrong brace looks like.
+- Two `interface PostResourceData` blocks in one file emitted the first and dropped the second's members, though TypeScript merges them.
+- `type PostResourceData = { id: number } & { title: string }` emitted only the first term. An alias's right-hand side runs to the end of the statement, so a body followed by `&`, `|`, or a conditional `extends` is not the whole type.
+
+Each is now named, with the reason and the shape to write instead. A `type X = { … }` whose body stands alone still reads exactly as before, and output for every shape that already worked is byte-identical.

--- a/packages/cli/src/data-types.ts
+++ b/packages/cli/src/data-types.ts
@@ -253,35 +253,40 @@ async function extractResourceType(
   const masked = maskCommentsAndStrings(source)
 
   // Strategy 1: an interface named after the class, `interface PostResourceData { ... }`
-  const interfaceBody = readObjectTypeBody(source, masked, `${baseName}(?:Resource)?Data`)
-  if (interfaceBody) {
-    return { ...common, rawType: interfaceBody }
+  const named = readObjectType(source, masked, `${baseName}(?:Resource)?Data`)
+  if (named.kind === 'body') {
+    return { ...common, rawType: named.body }
   }
 
   // Strategy 2: Explicit return type on toArray(): `toArray(): SomeType {`
   const returnTypeMatch = masked.match(/toArray\s*\(\s*\)\s*:\s*(\w+(?:Data)?)\s*\{/)
   if (returnTypeMatch) {
     const typeName = returnTypeMatch[1]
-    const body = readObjectTypeBody(source, masked, typeName)
-    if (body) {
-      return { ...common, rawType: body }
+    const annotated = readObjectType(source, masked, typeName)
+    if (annotated.kind === 'body') {
+      return { ...common, rawType: annotated.body }
     }
 
     // The annotation names a type this file does not hand over. Which of the
     // two reasons it is decides what the author has to change, so say which:
     // a declaration that is simply elsewhere is a different fix from one that
     // is right here in a form that cannot be copied.
-    const declaredHere = new RegExp(`(?:interface|type)\\s+${typeName}\\b`, 'u').test(masked)
     warnings.push(
-      declaredHere
-        ? `Resource ${className} (${relPath}) annotates toArray(): ${typeName} and declares `
-          + `${typeName} in that file, but only a plain object type can be copied into `
-          + `data.gen.ts — omitted. Write ${typeName} as \`interface ${typeName} { … }\` or `
-          + `\`type ${typeName} = { … }\`, without type parameters.`
+      annotated.kind === 'unreadable'
+        ? `Resource ${className} (${relPath}) annotates toArray(): ${typeName} and `
+          + describeUnreadable(annotated)
         : `Resource ${className} (${relPath}) annotates toArray(): ${typeName}, but no `
           + `interface or type ${typeName} is declared in that file — omitted from data.gen.ts. `
           + "Only the resource's own source is read, so move the declaration into it.",
     )
+    return { ...common, rawType: null }
+  }
+
+  // An unannotated `toArray()` whose payload interface is right there but
+  // unreadable is a different sentence again, and the one Strategy 1 alone can
+  // reach.
+  if (named.kind === 'unreadable') {
+    warnings.push(`Resource ${className} (${relPath}) ${describeUnreadable(named)}`)
     return { ...common, rawType: null }
   }
 
@@ -314,8 +319,22 @@ async function extractResourceType(
 }
 
 /**
+ * What the file declares under `namePattern`: a copyable object body, nothing
+ * at all, or a declaration that exists but cannot be copied.
+ *
+ * The third case is why this is not just `string | null`. Every shape in it
+ * used to yield *some* brace body — the wrong one — which is worse than
+ * yielding none: the frontend gets a type that compiles and lies. Refusing
+ * costs one `Data` member; guessing costs the trust in all of them.
+ */
+type ObjectTypeRead =
+  | { kind: 'body'; body: string }
+  | { kind: 'none' }
+  | { kind: 'unreadable'; typeName: string; reason: string }
+
+/**
  * The body of `interface <name> { … }` / `type <name> = { … }`, declared
- * anywhere in `source`, or `null` when the file declares no such object type.
+ * anywhere in `source`.
  *
  * `masked` is {@link maskCommentsAndStrings} of the same string: everything is
  * *matched* against it and *sliced* from `source`, so offsets stay usable
@@ -328,21 +347,84 @@ async function extractResourceType(
  * searching forward for the next `{`: a `type PostData = string` followed by
  * the class declaration would otherwise hand back the class body.
  */
-function readObjectTypeBody(source: string, masked: string, namePattern: string): string | null {
+function readObjectType(source: string, masked: string, namePattern: string): ObjectTypeRead {
   const declaration = new RegExp(
     // `[^{;]*` for the heritage clause, so `extends Record<string, unknown>`
     // is stepped over; `;` bounds it so an aliasless declaration cannot run
     // into a later statement's brace.
-    `(?:export\\s+)?(?:interface|type)\\s+(?:${namePattern})\\s*(?:=\\s*|extends[^{;]*)?\\{`,
+    `(?:export\\s+)?(?:interface|type)\\s+(${namePattern})\\b\\s*(?:(=)\\s*|(extends[^{;]*))?\\{`,
     'u',
   )
   const match = declaration.exec(masked)
-  if (!match) return null
+  if (!match) {
+    // Declared, but not in a form with a body at all — `type X = string`, an
+    // intersection, a generic. Distinguishing this from "not declared here"
+    // is what lets the caller say which of the two it is.
+    const anyDeclaration = new RegExp(`(?:interface|type)\\s+(${namePattern})\\b`, 'u').exec(masked)
+    return anyDeclaration
+      ? { kind: 'unreadable', typeName: anyDeclaration[1], reason: 'is not a plain object type' }
+      : { kind: 'none' }
+  }
+
+  const [, typeName, isAlias, heritage] = match
+
+  // An `extends` clause holding an object type — `extends Record<string, { … }>`
+  // — puts a brace in front of the real one, and the heritage pattern stops at
+  // the first. Unbalanced angle brackets are what gives that away: the clause
+  // was cut mid-generic. `=>` is stripped so a function type's arrow does not
+  // read as a closing one.
+  if (heritage) {
+    const brackets = heritage.replace(/=>/gu, '')
+    if (countOccurrences(brackets, '<') !== countOccurrences(brackets, '>')) {
+      return {
+        kind: 'unreadable',
+        typeName,
+        reason: 'has an `extends` clause containing an object type, which cannot be told apart '
+          + 'from the body itself',
+      }
+    }
+  }
 
   const openIndex = match.index + match[0].length - 1
   const end = findBodyEnd(masked, openIndex)
+  if (end === null) return { kind: 'unreadable', typeName, reason: 'is not a plain object type' }
 
-  return end === null ? null : source.slice(openIndex, end)
+  // Declaration merging: TypeScript unions every block, this reads one.
+  const declarations = masked.match(new RegExp(`(?:interface|type)\\s+${typeName}\\b`, 'gu'))
+  if (declarations && declarations.length > 1) {
+    return {
+      kind: 'unreadable',
+      typeName,
+      reason: 'is declared more than once, and only one of the blocks would be copied',
+    }
+  }
+
+  // A type alias's right-hand side runs to the end of the statement, so a body
+  // followed by `&`, `|` or a conditional `extends` is only its first term. An
+  // interface always ends at its brace, so this cannot apply to one.
+  if (isAlias) {
+    const rest = masked.slice(end)
+    if (/^\s*[&|]/u.test(rest) || /^\s*extends\b/u.test(rest)) {
+      return {
+        kind: 'unreadable',
+        typeName,
+        reason: 'composes other types, and only its first object body would be copied',
+      }
+    }
+  }
+
+  return { kind: 'body', body: source.slice(openIndex, end) }
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1
+}
+
+/** The half of an unreadable-declaration warning that does not name the Resource. */
+function describeUnreadable(read: { typeName: string; reason: string }): string {
+  return `declares ${read.typeName} in that file, but it ${read.reason} — omitted from `
+    + `data.gen.ts. Write ${read.typeName} as a single \`interface ${read.typeName} { … }\` or `
+    + `\`type ${read.typeName} = { … }\` with its members inline.`
 }
 
 /**

--- a/packages/cli/src/data-types.ts
+++ b/packages/cli/src/data-types.ts
@@ -357,13 +357,23 @@ function readObjectType(source: string, masked: string, namePattern: string): Ob
   )
   const match = declaration.exec(masked)
   if (!match) {
-    // Declared, but not in a form with a body at all — `type X = string`, an
-    // intersection, a generic. Distinguishing this from "not declared here"
+    // Declared, but not in a form with a body this can copy — `type X = string`,
+    // an intersection, a generic. Distinguishing this from "not declared here"
     // is what lets the caller say which of the two it is.
-    const anyDeclaration = new RegExp(`(?:interface|type)\\s+(${namePattern})\\b`, 'u').exec(masked)
-    return anyDeclaration
-      ? { kind: 'unreadable', typeName: anyDeclaration[1], reason: 'is not a plain object type' }
-      : { kind: 'none' }
+    const anyDeclaration = new RegExp(`(?:interface|type)\\s+(${namePattern})\\b(\\s*<)?`, 'u')
+      .exec(masked)
+    if (!anyDeclaration) return { kind: 'none' }
+
+    return {
+      kind: 'unreadable',
+      typeName: anyDeclaration[1],
+      // A generic *is* an object type, so saying it is not one sends the
+      // author to rewrite the shape rather than the one thing in the way.
+      // `{ id: T }` copied out of its declaration does not compile.
+      reason: anyDeclaration[2]
+        ? 'takes type parameters, which have no meaning once the body is copied out'
+        : 'is not a plain object type',
+    }
   }
 
   const [, typeName, isAlias, heritage] = match
@@ -423,8 +433,9 @@ function countOccurrences(haystack: string, needle: string): number {
 /** The half of an unreadable-declaration warning that does not name the Resource. */
 function describeUnreadable(read: { typeName: string; reason: string }): string {
   return `declares ${read.typeName} in that file, but it ${read.reason} — omitted from `
-    + `data.gen.ts. Write ${read.typeName} as a single \`interface ${read.typeName} { … }\` or `
-    + `\`type ${read.typeName} = { … }\` with its members inline.`
+    + `data.gen.ts. Write ${read.typeName} as a single non-generic `
+    + `\`interface ${read.typeName} { … }\` or \`type ${read.typeName} = { … }\` with its `
+    + 'members inline.'
 }
 
 /**

--- a/packages/cli/src/data-types.ts
+++ b/packages/cli/src/data-types.ts
@@ -330,7 +330,7 @@ async function extractResourceType(
 type ObjectTypeRead =
   | { kind: 'body'; body: string }
   | { kind: 'none' }
-  | { kind: 'unreadable'; typeName: string; reason: string }
+  | { kind: 'unreadable'; typeName: string; reason: string; fix?: string }
 
 /**
  * The body of `interface <name> { … }` / `type <name> = { … }`, declared
@@ -349,19 +349,27 @@ type ObjectTypeRead =
  */
 function readObjectType(source: string, masked: string, namePattern: string): ObjectTypeRead {
   const declaration = new RegExp(
+    // Anchored to column 0, which is what "the file's payload type" means
+    // here: a declaration nested in a namespace, an ambient module or a
+    // function body is a different type that merely shares the name, and
+    // emitting its members as the Resource's payload is silently wrong. No
+    // formatter indents a top-level declaration, so the anchor costs nothing.
+    //
     // `[^{;]*` for the heritage clause, so `extends Record<string, unknown>`
     // is stepped over; `;` bounds it so an aliasless declaration cannot run
     // into a later statement's brace.
-    `(?:export\\s+)?(?:interface|type)\\s+(${namePattern})\\b\\s*(?:(=)\\s*|(extends[^{;]*))?\\{`,
-    'u',
+    `^(?:export\\s+)?(?:interface|type)\\s+(${namePattern})\\b\\s*(?:(=)\\s*|(extends[^{;]*))?\\{`,
+    'mu',
   )
   const match = declaration.exec(masked)
   if (!match) {
     // Declared, but not in a form with a body this can copy — `type X = string`,
     // an intersection, a generic. Distinguishing this from "not declared here"
     // is what lets the caller say which of the two it is.
-    const anyDeclaration = new RegExp(`(?:interface|type)\\s+(${namePattern})\\b(\\s*<)?`, 'u')
-      .exec(masked)
+    const anyDeclaration = new RegExp(
+      `^(?:export\\s+)?(?:interface|type)\\s+(${namePattern})\\b(\\s*<)?`,
+      'mu',
+    ).exec(masked)
     if (!anyDeclaration) return { kind: 'none' }
 
     return {
@@ -397,10 +405,24 @@ function readObjectType(source: string, masked: string, namePattern: string): Ob
 
   const openIndex = match.index + match[0].length - 1
   const end = findBodyEnd(masked, openIndex)
-  if (end === null) return { kind: 'unreadable', typeName, reason: 'is not a plain object type' }
+  if (end === null) {
+    // Distinct from "not an object type": the shape is right and the file is
+    // truncated. Telling the author to rewrite the type sends them past it.
+    return {
+      kind: 'unreadable',
+      typeName,
+      reason: 'opens a body that is never closed',
+      fix: 'Close it.',
+    }
+  }
 
-  // Declaration merging: TypeScript unions every block, this reads one.
-  const declarations = masked.match(new RegExp(`(?:interface|type)\\s+${typeName}\\b`, 'gu'))
+  // Declaration merging: TypeScript unions every block, this reads one. Same
+  // anchor as above — only top-level declarations merge with each other, so a
+  // same-named type inside a namespace or a function body is not a second
+  // block and must not cost this one its type.
+  const declarations = masked.match(
+    new RegExp(`^(?:export\\s+)?(?:interface|type)\\s+${typeName}\\b`, 'gmu'),
+  )
   if (declarations && declarations.length > 1) {
     return {
       kind: 'unreadable',
@@ -410,15 +432,18 @@ function readObjectType(source: string, masked: string, namePattern: string): Ob
   }
 
   // A type alias's right-hand side runs to the end of the statement, so a body
-  // followed by `&`, `|` or a conditional `extends` is only its first term. An
-  // interface always ends at its brace, so this cannot apply to one.
+  // followed by an operator is only its first term: `&`/`|` compose, a
+  // conditional `extends` branches, and `[` makes the body an operand —
+  // `{ … }[]` is an array of it and `{ … }['k']` is one member of it, neither
+  // of which is the body. An interface always ends at its brace, so none of
+  // this can apply to one.
   if (isAlias) {
     const rest = masked.slice(end)
-    if (/^\s*[&|]/u.test(rest) || /^\s*extends\b/u.test(rest)) {
+    if (/^\s*[&|[]/u.test(rest) || /^\s*extends\b/u.test(rest)) {
       return {
         kind: 'unreadable',
         typeName,
-        reason: 'composes other types, and only its first object body would be copied',
+        reason: 'uses its object body as one operand of a larger type, not as the type itself',
       }
     }
   }
@@ -431,11 +456,13 @@ function countOccurrences(haystack: string, needle: string): number {
 }
 
 /** The half of an unreadable-declaration warning that does not name the Resource. */
-function describeUnreadable(read: { typeName: string; reason: string }): string {
+function describeUnreadable(read: { typeName: string; reason: string; fix?: string }): string {
+  const fix = read.fix
+    ?? `Write ${read.typeName} as a single non-generic \`interface ${read.typeName} { … }\` or `
+      + `\`type ${read.typeName} = { … }\` with its members inline.`
+
   return `declares ${read.typeName} in that file, but it ${read.reason} — omitted from `
-    + `data.gen.ts. Write ${read.typeName} as a single non-generic `
-    + `\`interface ${read.typeName} { … }\` or \`type ${read.typeName} = { … }\` with its `
-    + 'members inline.'
+    + `data.gen.ts. ${fix}`
 }
 
 /**

--- a/packages/cli/tests/data-types.test.ts
+++ b/packages/cli/tests/data-types.test.ts
@@ -447,6 +447,25 @@ describe('generateDataTypes reports Resource classes it could not extract', () =
     expect(warnings[0]).toContain('composes other types')
   })
 
+  it('names the type parameters rather than calling a generic a non-object', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      // Refusing is right — `{ id: T }` copied out of its declaration does not
+      // compile — but "not a plain object type" sends the author to rewrite
+      // the shape instead of the one thing in the way.
+      'app/Http/Resources/PostResource.ts': postResourceFile(
+        'export interface PostResourceData<T = string> {\n  id: T\n}',
+        'PostResourceData',
+      ),
+    })
+
+    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
+
+    expect(definitions.map((d) => d.rawType)).toEqual([null])
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('takes type parameters')
+    expect(warnings[0]).not.toContain('is not a plain object type')
+  })
+
   it('still reads an alias whose object body stands alone', async () => {
     await writeWorkspaceFiles(appRoot, {
       'app/Http/Resources/PostResource.ts': postResourceFile(

--- a/packages/cli/tests/data-types.test.ts
+++ b/packages/cli/tests/data-types.test.ts
@@ -444,7 +444,60 @@ describe('generateDataTypes reports Resource classes it could not extract', () =
 
     expect(definitions.map((d) => d.rawType)).toEqual([null])
     expect(warnings).toHaveLength(1)
-    expect(warnings[0]).toContain('composes other types')
+    expect(warnings[0]).toContain('one operand of a larger type')
+  })
+
+  it('refuses an alias that uses its body as an operand', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      // `{ … }[]` is an array of the body and `{ … }['k']` is one member of
+      // it. Emitting the body itself describes neither.
+      'app/Http/Resources/PostResource.ts': postResourceFile(
+        'export type PostResourceData = { id: number }[]',
+        'PostResourceData',
+      ),
+    })
+
+    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
+
+    expect(definitions.map((d) => d.rawType)).toEqual([null])
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('one operand of a larger type')
+  })
+
+  it('refuses an alias indexed into, rather than emitting what it indexes', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      'app/Http/Resources/PostResource.ts': postResourceFile(
+        "export type PostResourceData = { payload: { id: number } }['payload']",
+        'PostResourceData',
+      ),
+    })
+
+    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
+
+    // The outer body is the *container*; emitting it types the route with a
+    // wrapper the server never sends.
+    expect(definitions.map((d) => d.rawType)).toEqual([null])
+    expect(warnings[0]).toContain('one operand of a larger type')
+  })
+
+  it('tells the author to close an unterminated body instead of rewriting it', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      'app/Http/Resources/PostResource.ts':
+        "import { Resource } from '@guren/core'\n\n"
+        + 'export interface PostResourceData {\n  id: number\n\n'
+        + 'export class PostResource extends Resource<Record<string, unknown>> {\n'
+        + '  toArray(): PostResourceData {\n'
+        + '    return {} as never\n'
+        + '  }\n'
+        + '}\n',
+    })
+
+    const { warnings } = await generateDataTypes({ appRoot, force: true })
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('opens a body that is never closed')
+    expect(warnings[0]).toContain('Close it.')
+    expect(warnings[0]).not.toContain('with its members inline')
   })
 
   it('names the type parameters rather than calling a generic a non-object', async () => {
@@ -636,6 +689,46 @@ describe('generateDataTypes reads a type body by brace depth', () => {
     const { definitions } = await generateDataTypes({ appRoot, force: true })
 
     expect(definitions[0]?.rawType?.endsWith('  id: number\n}')).toBe(true)
+  })
+
+  it('ignores a same-named declaration nested in an inner scope', async () => {
+    // A type inside a function body is a different type that merely shares the
+    // name. Counting it as a second block costs the real one its `Data` member.
+    await writeResource(
+      'export interface PostResourceData { id: number }\n\n'
+      + 'function hidden() {\n'
+      + '  interface PostResourceData { hidden: string }\n'
+      + '  return null\n'
+      + '}',
+      'PostResourceData',
+    )
+
+    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
+
+    expect(warnings).toEqual([])
+    expect(definitions.map((d) => d.rawType)).toEqual(['{ id: number }'])
+  })
+
+  it('does not take a namespaced declaration for the payload type', async () => {
+    // Nothing at the top level declares the payload, so the members of an
+    // unrelated scoped type must not be emitted as `Data.Post`.
+    await writeResource(
+      'namespace Hidden {\n  export interface PostResourceData { hidden: string }\n}',
+    )
+
+    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
+
+    expect(definitions.map((d) => d.rawType)).toEqual([null])
+    expect(warnings).toHaveLength(1)
+  })
+
+  it('reads a declaration whose brace opens on the next line', async () => {
+    await writeResource('export interface PostResourceData\n{\n  id: number\n}', 'PostResourceData')
+
+    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
+
+    expect(warnings).toEqual([])
+    expect(definitions.map((d) => d.rawType)).toEqual(['{\n  id: number\n}'])
   })
 
   it('ignores a same-named alias that declares no object type', async () => {

--- a/packages/cli/tests/data-types.test.ts
+++ b/packages/cli/tests/data-types.test.ts
@@ -389,8 +389,76 @@ describe('generateDataTypes reports Resource classes it could not extract', () =
 
     expect(warnings).toHaveLength(1)
     expect(warnings[0]).toContain('declares PostPayload in that file')
-    expect(warnings[0]).toContain('only a plain object type can be copied')
+    expect(warnings[0]).toContain('is not a plain object type')
     expect(warnings[0]).not.toContain('move the declaration into it')
+  })
+
+  it('refuses a declaration whose extends clause holds an object type', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      // `extends[^{;]*` stops at the generic argument's brace, so the type
+      // emitted was the argument — a payload the route never sends, with
+      // nothing said about it.
+      'app/Http/Resources/PostResource.ts': postResourceFile(
+        'export interface PostResourceData extends Record<string, { nested: true }> {\n'
+        + '  id: number\n}',
+        'PostResourceData',
+      ),
+    })
+
+    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
+
+    expect(definitions.map((d) => d.rawType)).toEqual([null])
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('`extends` clause containing an object type')
+  })
+
+  it('refuses a type merged across two declarations', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      'app/Http/Resources/PostResource.ts': postResourceFile(
+        'export interface PostResourceData {\n  id: number\n}\n\n'
+        + 'export interface PostResourceData {\n  title: string\n}',
+        'PostResourceData',
+      ),
+    })
+
+    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
+
+    // Emitting the first block alone drops `title` from a payload that
+    // carries it — a type that compiles and is wrong.
+    expect(definitions.map((d) => d.rawType)).toEqual([null])
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('declared more than once')
+  })
+
+  it('refuses an alias that composes its object body with another type', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      // The shape the "write `type X = { … }`" advice sits next to, so
+      // getting it wrong silently is the likeliest way this misleads.
+      'app/Http/Resources/PostResource.ts': postResourceFile(
+        'export type PostResourceData = { id: number } & { title: string }',
+        'PostResourceData',
+      ),
+    })
+
+    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
+
+    expect(definitions.map((d) => d.rawType)).toEqual([null])
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('composes other types')
+  })
+
+  it('still reads an alias whose object body stands alone', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      'app/Http/Resources/PostResource.ts': postResourceFile(
+        'export type PostResourceData = {\n  id: number\n}',
+        'PostResourceData',
+      ),
+    })
+
+    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
+
+    expect(warnings).toEqual([])
+    expect(definitions.map((d) => d.rawType)).toEqual(['{\n  id: number\n}'])
   })
 
   it('quotes an annotation it does not read instead of calling it absent', async () => {


### PR DESCRIPTION
Follow-up to #416, which named the Resource classes codegen could not extract a type from. Reviewing that change surfaced three shapes with the opposite failure: each yielded *some* brace body and no warning — the wrong one.

A missing `Data` member is a compile error at the call site. A wrong one type-checks and lies about the payload, which is the failure the extractor's tombstones exist to avoid.

## Measured before

| Declaration | Emitted | Actual payload |
|---|---|---|
| `interface X extends Record<string, { nested: true }> { id: number }` | `{ nested: true }` | `{ id: number }` |
| `interface X { id }` + `interface X { title }` | `{ id: number }` | `id` and `title` |
| `type X = { id: number } & { title: string }` | `{ id: number }` | `id` and `title` |

All three with `warnings: 0`.

The third is the one that matters most in practice: composing a payload type with `&` is ordinary, and #416's own warning text tells authors to write `type X = { … }`, so it sits right next to the advice.

## Change

Each is detected and refused, with the reason and the shape to write instead:

- **Heritage clause holding an object type** — the pattern stops at the generic argument's brace. Unbalanced angle brackets in the clause are what a heritage cut off mid-generic looks like (`=>` stripped first, so a function type's arrow does not read as a closing bracket).
- **Declaration merging** — more than one `interface|type X` in the file.
- **Composed alias** — an alias's right-hand side runs to the end of the statement, so a body followed by `&`, `|`, or a conditional `extends` is only its first term. An interface always ends at its brace, so this check applies to aliases only.

A fourth shape was already refused but misdiagnosed: `interface PostResourceData<T>` is a plain object type, so reporting it as not being one sent the author to rewrite the shape rather than drop the type parameter. It now says which.

`readObjectTypeBody` becomes `readObjectType`, returning a body, nothing, or an unreadable declaration carrying its reason — that third case is what lets the caller say which it is instead of re-deriving it from a null.

## From review

Codex review of the above found one regression this PR introduced and three more shapes of the same kind, all reproduced against real fixtures before being acted on:

- **Regression**: a same-named type inside a namespace, an ambient module, or a function body counted as a second declaration, so a resource that worked on `main` lost its type. The same unanchored search also emitted a scoped type's members as the payload when nothing at the top level declared one. Both declaration matching and the merge count are now anchored to column 0 — no formatter indents a top-level declaration, and a brace opening on the next line still matches.
- `type X = { … }[]` and `type X = { … }['payload']` emitted the object operand as though it were the whole type. Refused with the composition cases, which they are a kind of.
- An unterminated body reported "is not a plain object type", which describes a shape the author would go and rewrite. It now says the body is never closed and asks them to close it.

Two findings are deliberately **not** fixed here and are filed as #418: `interface X extends Base` dropping inherited members (the correct fix inlines a local base's members while still dropping `extends Record<string, unknown>` on purpose, which is a feature with a design question in it, not a guard), and a parenthesized alias getting the wrong reason text.

## Verification

- Output is **byte-identical** against `main` for `examples/blog`, `examples/api`, both `create-app` templates, and `web/` — every app root in the repo, all still at zero warnings.
- A `type X = { … }` whose body stands alone still reads exactly as before (pinned by its own test, so the composed-alias check cannot over-reach).
- Each refusal has a test asserting the tombstone *and* the reason, so a message that stops matching its cause fails.
- `typecheck` and `test:bun` green (4383 pass).

