### PR TITLE
ci: align every workflow's Bun pin, and stop tests leaking globalThis.fetch

### DIFF
--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -161,7 +161,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
 
       - run: bun install --frozen-lockfile
 
@@ -207,7 +207,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
 
       - name: Install workspace dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/published-drift.yml
+++ b/.github/workflows/published-drift.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
 
       # The scaffolder itself runs from source and needs the workspace's own
       # dependencies. There is no `bun run build` step on purpose: npm mode

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,13 +42,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      # Bun version is centralized here for easy updates.
+      # Must match the first version in ci.yml's matrix, which is what every
+      # pull request is tested on — a release gate running a different Bun is a
+      # gate a green CI does not predict. `scripts/workflow-bun-version.test.ts`
+      # holds every workflow to that.
       # To test against multiple versions, convert the publish job
       # into a validate + publish split with a matrix on validate.
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.11"
+          bun-version: "1.3.14"
 
       - name: Setup Node for npm publish
         uses: actions/setup-node@v4

--- a/packages/server/tests/auth/oauth.test.ts
+++ b/packages/server/tests/auth/oauth.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import {
   OAuthManager,
   MemoryOAuthStateStore,
@@ -14,6 +14,19 @@ import {
   type OAuthProviderConfig,
 } from '../../src/auth/oauth'
 import { hashToken } from '../../src/auth/utils'
+
+// The OAuth cases below drive the manager by replacing `globalThis.fetch`
+// outright — `mock.restore()` only unwinds spies, so nothing here puts the real
+// one back. Bun runs every test file in one process, and whether a file's
+// globals reach the next one is a runtime detail rather than a promise: under
+// Bun 1.3.11 they do, so the replacement outlived this file and answered 200 to
+// the port tests' `fetch(...)` against their own freshly bound servers, whose
+// whole point is a 404.
+const realFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+})
 
 describe('oauth helpers', () => {
   it('builds authorize URL with required params and scopes', () => {

--- a/packages/server/tests/notifications/notifications.test.ts
+++ b/packages/server/tests/notifications/notifications.test.ts
@@ -108,6 +108,11 @@ class TestUser implements Notifiable {
   }
 }
 
+// Captured at module scope, before any describe body runs: a value read inside
+// a describe is already whatever an earlier describe left behind, so restoring
+// to it re-pins the replacement instead of clearing it.
+const realFetch = global.fetch
+
 describe('Notification', () => {
   describe('constructor', () => {
     it('should generate a unique ID', () => {
@@ -729,6 +734,13 @@ describe('SlackChannel', () => {
     global.fetch = fetchMock
   })
 
+  // Without this the stub outlives the describe: every later file in the run
+  // gets a fetch that answers 200 to anything, which reads as a passing HTTP
+  // call right up until a test asserts on the status.
+  afterEach(() => {
+    global.fetch = realFetch
+  })
+
   describe('send', () => {
     it('should send notification to Slack webhook', async () => {
       const channel = new SlackChannel('https://hooks.slack.com/test')
@@ -969,7 +981,6 @@ describe('Queued notifications', () => {
   let manager: NotificationManager
   let user: QueuedUser
   let dbChannel: DatabaseChannel
-  const originalFetch = global.fetch
 
   beforeEach(() => {
     driver = new MemoryDriver()
@@ -986,7 +997,7 @@ describe('Queued notifications', () => {
   })
 
   afterEach(() => {
-    global.fetch = originalFetch
+    global.fetch = realFetch
   })
 
   /**

--- a/scripts/test-global-fetch-guard.ts
+++ b/scripts/test-global-fetch-guard.ts
@@ -1,0 +1,67 @@
+// Preloaded into `bun test` to make a leaked `globalThis.fetch` loud.
+//
+// Tests stub `fetch` to drive code that talks HTTP. Whether that stub can reach
+// the *next* test file is a Bun implementation detail, not a promise: under
+// `--isolate` Bun 1.3.14 gives each file a fresh globals context, but 1.3.11
+// shares one for the whole run. On 1.3.11 an unrestored stub answered every
+// later `fetch()` in the process — including the port/stop tests fetching their
+// own freshly bound servers, which then read 200 where the app returns 404.
+// The suite passed on the version CI pinned and failed on the version the
+// release workflow pinned, which is the worst place to discover it.
+//
+// So the invariant is stated here rather than inherited from a runtime: a test
+// file leaves `globalThis.fetch` exactly as it found it.
+//
+// Per file, not per test. Bun runs `afterEach` hooks innermost-first, so a
+// per-test check here would fire *before* the restoring `afterEach` a
+// well-behaved file already registers, and report every one of them as a leak.
+// `afterAll` is also where the invariant actually bites — cross-file reach is
+// the whole hazard.
+
+import { afterAll, beforeAll } from 'bun:test'
+
+/** What `fetch` was when this file started. */
+let fileStartFetch: typeof globalThis.fetch
+
+// Snapshotted per file rather than once for the run: on a shared-context Bun a
+// process-wide baseline would blame every file downstream of the leak as well
+// as the one that caused it.
+beforeAll(() => {
+  fileStartFetch = globalThis.fetch
+})
+
+const ADVICE = [
+  '',
+  '  Capture the real fetch at module scope and put it back in an afterEach:',
+  '',
+  '    const realFetch = globalThis.fetch',
+  '    afterEach(() => { globalThis.fetch = realFetch })',
+  '',
+  '  Capture it at module scope, not inside a describe body — a value read',
+  '  there is already whatever an earlier describe left behind, so restoring',
+  '  to it re-pins the replacement instead of clearing it. `mock.restore()`',
+  '  does not help: it unwinds spyOn(), not a plain assignment.',
+].join('\n')
+
+afterAll(() => {
+  const current = globalThis.fetch
+  if (current === fileStartFetch) return
+
+  // Put it back before reporting, so the next file is judged on its own
+  // behaviour instead of inheriting this one's.
+  globalThis.fetch = fileStartFetch
+
+  throw new Error(
+    [
+      'this test file replaced globalThis.fetch and did not restore it',
+      `  left behind: ${describeFetch(current)}`,
+      `  expected:    ${describeFetch(fileStartFetch)}`,
+      ADVICE,
+    ].join('\n'),
+  )
+})
+
+function describeFetch(value: typeof globalThis.fetch): string {
+  const source = String(value)
+  return source.length > 120 ? `${source.slice(0, 120)}…` : source
+}

--- a/scripts/test-packages.ts
+++ b/scripts/test-packages.ts
@@ -70,6 +70,10 @@ async function testPathFor(pkg: { dir: string; relativeDir: string }): Promise<s
 // the moment cwd moves.
 const cwdGuard = join(import.meta.dir, 'test-cwd-guard.ts')
 
+// Fails any test file that leaves globalThis.fetch replaced. Absolute for the
+// same reason as the guard above.
+const fetchGuard = join(import.meta.dir, 'test-global-fetch-guard.ts')
+
 // Detectors whose own code lives outside packages/, so a package sweep would
 // never run them — and a detector that silently stops detecting is worth
 // nothing. The smoke package list is here for the same reason: the gates that
@@ -99,6 +103,8 @@ const testArgs = [
   '--isolate',
   '--preload',
   cwdGuard,
+  '--preload',
+  fetchGuard,
   ...forwarded,
   ...(await Promise.all(targets.map(testPathFor))),
   ...guardTests,

--- a/scripts/workflow-bun-version.test.ts
+++ b/scripts/workflow-bun-version.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { repoRoot } from './workspace-packages.ts'
+
+/**
+ * Every workflow pins its own Bun version, and nothing until now compared them.
+ * They drifted: CI moved to 1.3.14 while the release gate stayed on 1.3.11, so
+ * a green CI stopped being evidence that the release would be green — and the
+ * v2.6.0 release found out the expensive way, with five tests failing in the
+ * publish job on a commit CI had already passed. (`bun test --isolate` shares
+ * one globals context per run on 1.3.11 and one per file on 1.3.14, so a test
+ * that replaced `globalThis.fetch` reached the next file on the release runner
+ * and nowhere else.)
+ *
+ * The workflows are discovered rather than listed: a new one that pins Bun is
+ * covered the day it is added, which a hand-kept list cannot promise.
+ */
+const WORKFLOW_DIR = join(repoRoot, '.github/workflows')
+
+/**
+ * `bun-version: '1.2.3'`, list item or not, quoted or not — YAML allows both
+ * spellings and a guard that only recognised one would read the other as "this
+ * workflow pins nothing", which is a different (and wrong) complaint.
+ * `${{ ... }}` expressions, comments, and the matrix list are excluded.
+ */
+const PINNED =
+  /^[^\S\n]*(?:-[^\S\n]*)?bun-version:[^\S\n]*(?:(['"])([^'"]+)\1|([^\s'"#$[][^\s#]*))[^\S\n]*$/
+/** `bun-version: ['1.2.3', '1.4.0']` — CI's version matrix. */
+const MATRIX = /^[^\S\n]*bun-version:[^\S\n]*\[([^\]]*)\]/m
+
+function workflowFiles(): string[] {
+  return [...new Bun.Glob('*.{yml,yaml}').scanSync({ cwd: WORKFLOW_DIR })].sort()
+}
+
+/** Every literal Bun version a workflow pins, in file order. */
+export function pinnedVersions(source: string): string[] {
+  return source
+    .split('\n')
+    .map((line) => {
+      const match = PINNED.exec(line)
+      return match?.[2] ?? match?.[3]
+    })
+    .filter((version): version is string => version !== undefined)
+}
+
+/** The versions CI's matrix fans out over, in declaration order. */
+export function matrixVersions(source: string): string[] {
+  const list = MATRIX.exec(source)?.[1]
+  if (list === undefined) return []
+  return list
+    .split(',')
+    .map((entry) => entry.trim().replace(/^['"]|['"]$/g, ''))
+    .filter((entry) => entry.length > 0)
+}
+
+describe('workflow Bun pins', () => {
+  const ci = readFileSync(join(WORKFLOW_DIR, 'ci.yml'), 'utf8')
+  const matrix = matrixVersions(ci)
+
+  it('reads a version matrix out of ci.yml', () => {
+    // Everything below is measured against this, so a matrix this stops
+    // recognising has to fail loudly rather than vacuously pass.
+    expect(matrix.length).toBeGreaterThan(0)
+  })
+
+  // The first matrix entry, not the only one: adding a version to CI's matrix
+  // is how a new Bun is trialled, and that must not turn this into the check
+  // people delete.
+  const primary = matrix[0]!
+
+  it.each(workflowFiles().filter((file) => file !== 'ci.yml'))(
+    '%s pins the Bun version CI tests first',
+    (file) => {
+      const pins = pinnedVersions(readFileSync(join(WORKFLOW_DIR, file), 'utf8'))
+      for (const pin of pins) expect(pin).toBe(primary)
+    },
+  )
+
+  it("ci.yml's own pins stay inside its matrix", () => {
+    // `include:` entries repeat the version to attach per-version settings; a
+    // value that fell out of the matrix list would configure a job that never
+    // runs.
+    for (const pin of pinnedVersions(ci)) expect(matrix).toContain(pin)
+  })
+
+  it('leaves no workflow installing Bun unpinned', () => {
+    // A setup-bun step with no version follows whatever the action defaults to,
+    // which is the same drift by a quieter route.
+    const unpinned = workflowFiles().filter((file) => {
+      const source = readFileSync(join(WORKFLOW_DIR, file), 'utf8')
+      if (!source.includes('oven-sh/setup-bun')) return false
+      return pinnedVersions(source).length === 0 && matrixVersions(source).length === 0
+    })
+
+    expect(unpinned).toEqual([])
+  })
+})


### PR DESCRIPTION
## Why

The v2.6.0 release job (run 31711534725, commit 52587b4) failed five tests that CI had just passed on the same commit — every one of them asserting that a freshly bound `Application` answers 404 on an unknown path, and receiving 200.

Two faults had to meet.

**A leaked stub.** `packages/server/tests/auth/oauth.test.ts` replaces `globalThis.fetch` with a mock that answers 200 to anything, and never puts the real one back — `mock.restore()` unwinds `spyOn()`, not a plain assignment.

**A runtime difference the pins exposed.** Whether that stub reaches the *next* test file is a Bun implementation detail, not a promise. Measured directly, by counting preload evaluations:

| Bun | `--isolate` globals context |
|---|---|
| 1.3.11 (`release.yml`) | one for the whole run — preload evaluates once |
| 1.3.14 (`ci.yml`) | one per file — preload evaluates per file |

So the stub crossed file boundaries only on the version the release workflow pinned. Every assertion that went over the network failed; every 404 test dispatching in-process (`dev-assets`, the Lambda handler) passed — which is what distinguishes this from the port-collision reading.

Minimal repro, five failures on 1.3.11 and none once the stub is restored:

```
bun-1.3.11 test --isolate \
  packages/server/tests/auth/oauth.test.ts \
  packages/server/tests/http/application-stop.test.ts \
  packages/server/tests/http/application-listen-port.test.ts
```

## What

- **`oauth.test.ts`** restores `globalThis.fetch` in an `afterEach` (the cause).
- **`notifications.test.ts`** had the same gap in its `SlackChannel` describe. Both files now capture the real fetch at module scope: a value read inside a describe body is already whatever an earlier describe left behind, so restoring to it re-pins the replacement instead of clearing it.
- **`scripts/test-global-fetch-guard.ts`** states the invariant instead of inheriting it from a runtime — preloaded beside the cwd guard, it fails any file that leaves `globalThis.fetch` replaced. Per file, not per test: Bun runs `afterEach` hooks innermost-first, so a per-test check would fire *before* the restoring `afterEach` a well-behaved file registers, and report it as the leak.
- **Bun pins** in `release.yml`, `nightly-canary.yml` (×3) and `published-drift.yml` move 1.3.11 → 1.3.14, matching CI. `scripts/workflow-bun-version.test.ts` holds every non-matrix pin to `ci.yml`'s first matrix entry, while still allowing extra matrix entries — that is how a new Bun gets trialled, and a guard that blocked it would be a guard people delete.

## Verification

- Both guards mutation-tested. The fetch guard fires and names the file when the `oauth.test.ts` fix is reverted. The pin guard goes red on a reverted pin, judges quoted *and* unquoted YAML scalars, and stays green when a second version is added to CI's matrix.
- Full `test:bun` run on **both** 1.3.14 and 1.3.11: 4401 pass / 0 fail.
- `test:examples` 112 pass; `typecheck`, `audit:core-first`, `audit:docs` green.

No changeset: tests, workflows and scripts only.