### PR TITLE
docs: add RFC 0009 (R2 storage driver) and RFC 0010 (model attachments)

### DIFF
--- a/rfcs/0009-cloudflare-r2-storage-driver.md
+++ b/rfcs/0009-cloudflare-r2-storage-driver.md
@@ -29,7 +29,7 @@ files. Today's options, checked against the code:
      `getVisibility` issue `PutObjectAcl` / `GetObjectAcl`. R2's S3 API
      reference lists `x-amz-acl` and the ACL operations as unsupported.
      Whether R2 ignores or rejects the header must be checked against a real
-     bucket (§6, step 0); the ACL calls will not work either way. So the
+     bucket (§5, step 0); the ACL calls will not work either way. So the
      documented recipe is at best partially true, and it is untested — there
      is no `S3Driver` test in `packages/server/tests/storage/storage.test.ts`
      (only `LocalDriver`, `MemoryDriver`, `StorageManager`).
@@ -39,22 +39,45 @@ The typical first need on Workers is public reads (images, downloads) plus an
 authenticated upload path — exactly the shape the binding API serves best,
 with no credentials to provision and nothing extra in the bundle.
 
-## Verified premises (2026-08-15)
+## Verified constraints (2026-08-15)
 
-The plan below was written against the code, not the docs. Corrections to the
-working assumptions the plan started from:
+Read out of the code and the R2 API rather than assumed. Each one rules out a
+design this plan would otherwise have reached for:
 
-| Assumption | Reality in the code |
-|---|---|
-| `StorageDriver` has "about 20 methods" | **21**: `put`, `putFile`, `get`, `getAsString`, `exists`, `delete`, `deleteMany`, `copy`, `move`, `url`, `temporaryUrl`, `size`, `lastModified`, `metadata`, `files`, `directories`, `allFiles`, `makeDirectory`, `deleteDirectory`, `setVisibility`, `getVisibility` (`packages/server/src/storage/types.ts:59-201`). Content is `Buffer \| string`; reads return `Buffer \| null`. |
-| `StorageManager.registerDriver()` is a usable extension point for third-party drivers | Only half true. `registerDriver(name, factory)` exists (`StorageManager.ts:132`), but the constructor resolves every `disks` entry **eagerly** (`registerDiskFromConfig`, `StorageManager.ts:82-94`) and throws `Unknown storage driver: r2` for a driver registered afterwards. `DriverConfig` is also a **closed** union of `'local' \| 's3' \| 'memory'` (`types.ts:293-296`), so `{ driver: 'r2' }` does not type-check. **`registerDisk(name, () => driver)` is the extension point that actually works today** (`StorageManager.ts:123`), and it is what this plan uses. |
-| `S3Driver` dynamically imports `@aws-sdk/client-s3` | Correct — via `importAwsModule()` with a "Missing optional dependency" error (`S3Driver.ts:463-474`). The plan reused this pattern for the presign dependency; **that was wrong on Workers** — see §1.2. |
-| The Cloudflare plugin uses a lazy `binding: () => getWorkersEnv<Env>().DB` closure | Correct (`packages/orm/src/d1.ts:6-25`, `packages/plugin-cloudflare/src/env.ts`). `getWorkersEnv()` throws before the first request; `web/app/Http/Middleware/site-analytics.ts:90-97` shows the pattern for an *optional* binding (try/catch → undefined off-Workers), and `web/config/database.ts:9-11` the `isWorkersRuntime()` switch (`navigator.userAgent === 'Cloudflare-Workers'`). |
-| `cloudflarePlugin()` registers services | It does not — `register() {}` is empty and `CloudflarePluginConfig` is an empty interface "reserved for upcoming RFC 0003 parts" (`packages/plugin-cloudflare/src/index.ts`). This plan keeps it that way (§2.2). |
-| `cloudflare:build` scaffolds `wrangler.jsonc` | Correct — once, `wx` flag, never overwritten; `warnMissingBuildOwnedKeys` only reports **build-owned** keys (`alias`, `define`, `migrations_dir`) (`build.ts:308-396`). |
-| Workers-side R2 API | Verified against the R2 Workers API reference (fetched 2026-08-15): `head(key)`, `get(key, {onlyIf, range})` → `R2ObjectBody \| R2Object \| null`, `put(key, ReadableStream \| ArrayBuffer \| ArrayBufferView \| string \| null \| Blob, {httpMetadata, customMetadata, onlyIf, md5…})`, `delete(key \| key[])` → `void`, **max 1000 keys per call**, `list({limit ≤ 1000, prefix, cursor, delimiter, include})` → `{objects, truncated, cursor?, delimitedPrefixes}`. `R2Object` carries `key, size, etag, httpEtag, uploaded (Date), httpMetadata, customMetadata, writeHttpMetadata(headers)`. **There is no `copy` on the binding**, and no presigned-URL API. |
-| Presigned URLs | Verified: generated client-side with SigV4 against `https://<ACCOUNT_ID>.r2.cloudflarestorage.com`, need an R2 API token (access key id + secret), **max expiry 7 days**. Not available from a binding. |
-| Cloudflare Images binding | Verified: `env.IMAGES.input(stream).transform({width…}).output({format}).response()`; billed per unique transformation. Relevant only to RFC 0010 (variants). |
+- **`StorageDriver` is 21 methods** (`storage/types.ts`); content is
+  `Buffer | string`, reads return `Buffer | null`.
+- **`StorageManager.registerDriver()` is not a usable extension point.** The
+  constructor resolves every `disks` entry eagerly, so a driver registered
+  afterwards still throws `Unknown storage driver`, and `DriverConfig` is a
+  closed union of `'local' | 's3' | 'memory'`, so `{ driver: 'r2' }` does not
+  type-check. **`registerDisk(name, () => driver)` is what works today**, and
+  it is what this plan uses.
+- **`S3Driver` loads `@aws-sdk/client-s3` through a lazy `importAwsModule()`**
+  with a "Missing optional dependency" error. The plan reused that pattern for
+  the presign dependency; **that was wrong on Workers** — see §1.2.
+- **Bindings must be read lazily.** `createD1Database({ binding })` and
+  `getWorkersEnv()` establish the contract: the resolver runs per call, and
+  `getWorkersEnv()` throws before the first request. `config/database.ts` in
+  the guren.dev app shows the `isWorkersRuntime()` switch
+  (`navigator.userAgent === 'Cloudflare-Workers'`) that picks a driver per
+  runtime.
+- **`cloudflarePlugin()` registers nothing.** `register()` is empty and its
+  config interface is a placeholder, so the plugin has no service-container
+  seam to hang a disk on (§2.2).
+- **`cloudflare:build` scaffolds `wrangler.jsonc` once** (`wx` flag, never
+  overwritten) and warns only about *build-owned* keys — `alias`, `define`,
+  `migrations_dir` (§2.1).
+- **The R2 binding API** (verified against the Workers API reference):
+  `head(key)`; `get(key, { onlyIf, range })` → `R2ObjectBody | R2Object |
+  null`; `put(key, ReadableStream | ArrayBuffer | ArrayBufferView | string |
+  null | Blob, { httpMetadata, customMetadata, … })`; `delete(key | key[])` →
+  `void`, **max 1000 keys per call**; `list({ limit ≤ 1000, prefix, cursor,
+  delimiter })` → `{ objects, truncated, cursor?, delimitedPrefixes }`.
+  `R2Object` carries `key, size, uploaded, httpMetadata, customMetadata`.
+  **There is no `copy` on the binding, and no presigned-URL API.**
+- **Presigned URLs are a client-side SigV4 construction** against
+  `https://<ACCOUNT_ID>.r2.cloudflarestorage.com`, requiring an R2 API token
+  and capped at **7 days**. A binding cannot produce one.
 
 ## Proposed Solution
 
@@ -172,10 +195,10 @@ the `r2_buckets` entry in wrangler.jsonc."*
 | `getAsString(path)` | `bucket.get(key)` → `obj.text()` | Avoids the Buffer round trip. |
 | `exists(path)` | `(await bucket.head(key)) !== null` | |
 | `delete(path)` | `head` then `delete` | `R2Bucket.delete()` returns `void` and is idempotent, so the contract's *"false if not found"* needs a `head` first (a Class B op — cheap). `S3Driver.delete` returns `true` unconditionally, but Local/Memory are exact; follow the exact ones. |
-| `deleteMany(paths)` | `bucket.delete(chunk)` per **1000-key chunk** | Returns `paths.length` (dedupe first). R2 gives no per-key result; `S3Driver` returns `Deleted.length`, which S3 also reports for missing keys, so the observable contract matches. |
+| `deleteMany(paths)` | `bucket.delete(chunk)` per **1000-key chunk** | Returns `paths.length` (dedupe first). R2 gives no per-key result. The alternative — head-then-delete per key, for an exact count — costs N extra reads to report something `S3Driver` does not report either: it returns `Deleted.length`, which S3 also counts for missing keys, so the observable contract already matches. |
 | `copy(from, to)` | `get(from)` → `put(to, obj.body, { httpMetadata: obj.httpMetadata, customMetadata: obj.customMetadata })` | **No copy on the binding** — stream the body through. `obj === null` throws `File not found: ${from}` (Memory precedent). Single-`put` size limits apply (multipart is out of scope). |
 | `move(from, to)` | `copy` + `delete(from)` | |
-| `url(path)` | `${publicUrl}/${key}` | Throws when `publicUrl` is unset (no derivable default; fail closed rather than return a URL that 404s). No percent-encoding, matching `S3Driver.url` — noted as an Open Question. |
+| `url(path)` | `${publicUrl}/${key}` | Throws when `publicUrl` is unset (no derivable default; fail closed rather than return a URL that 404s). **Amended in implementation:** percent-encodes each key segment, unlike `S3Driver.url` (Open Question 3). |
 | `temporaryUrl(path, expiration)` | SigV4 presign on WebCrypto against `https://${accountId}.r2.cloudflarestorage.com/${bucket}/${key}` with `X-Amz-Expires` | Only when `presign` is configured; else throws with guidance naming the option and the signed-route alternative. Expiry > 7 days throws up front (R2 rejects it; the S3 driver would only find out from AWS). **Amended in implementation:** the signer is written in-package, not taken from a dependency — see §1.2. |
 | `size` / `lastModified` | `head(key)` → `size` / `uploaded` | Throw `File not found` on `null` (S3/Memory precedent). |
 | `metadata(path)` | `head(key)` → `{ path, size, lastModified: uploaded, contentType: httpMetadata?.contentType, metadata: customMetadata, visibility }` | `visibility` is the disk's configured value (§1.3). |
@@ -210,7 +233,7 @@ Three options were weighed:
       Workers bundler can follow `import(moduleName)`, so the presign path
       threw `No such module` at runtime while every test stayed green (under
       Bun the same import resolves from `node_modules`). This is invisible to
-      any test that does not run inside workerd — see §4.2. A literal
+      any test that does not run inside workerd — see §4. A literal
       `import('aws4fetch')` bundles correctly but then fails the *build* for
       every app that never signs a URL, since an optional dependency is not
       installed.
@@ -251,8 +274,9 @@ nothing per object. The candidates:
   call site with a message that names the option. Portable code that never
   passes `visibility` (the common case) is unaffected.
 
-This is called out as an Open Question because it is stricter than S3/Local
-behave; the reasoning is fail-closed over silent no-op.
+This is stricter than S3/Local behave, and the alternative considered was to
+warn once per disk and proceed; fail-closed beat silent no-op, because the
+failure this prevents is a leak that looks like success.
 
 #### 1.4 Design decision: `putFile`
 
@@ -386,135 +410,96 @@ network), and either `wrangler dev` (local emulated R2, exercises the real
 driver) or `STORAGE_DISK=s3` pointed at the R2 endpoint when a shared,
 persistent bucket is wanted from a Bun process.
 
-### 3. Files
+### 3. Where it lands
 
-| Action | Path | What |
-|---|---|---|
-| add | `packages/plugin-cloudflare/src/storage/R2Driver.ts` | Driver, `R2DriverOptions`, `R2BucketLike` + object/list shapes, `trimSlashes` |
-| add | `packages/plugin-cloudflare/src/storage/R2Driver.test.ts` | Unit tests against an in-memory `FakeR2Bucket` (§4.1) |
-| add | `packages/plugin-cloudflare/src/storage/fake-r2-bucket.ts` | Test double implementing `R2BucketLike` with real `prefix`/`delimiter`/`cursor` semantics; also exported for app tests? — Open Question |
-| add | `packages/plugin-cloudflare/src/storage/R2Driver.types.test.ts` | `R2Bucket` (workers-types) satisfies `R2BucketLike` |
-| add | `packages/plugin-cloudflare/src/storage/r2-miniflare.test.ts` | Opt-in e2e (`GUREN_TEST_WRANGLER=1`) against a real local R2 (§4.2) |
-| edit | `packages/plugin-cloudflare/src/index.ts` | exports |
-| add | `packages/plugin-cloudflare/src/storage/sigv4.ts` (+ `sigv4.test.ts`) | WebCrypto SigV4 presigning for the one request shape `temporaryUrl()` needs (§1.2) |
-| edit | `packages/plugin-cloudflare/package.json` | devDependency `miniflare` for §4.2. **No runtime dependency is added** |
-| edit | `packages/plugin-cloudflare/README.md` | "Storage (R2)" section under API |
-| edit | `docs/en/guides/cloudflare.md`, `docs/ja/guides/cloudflare.md` | "Storage (R2)" section: binding, `wrangler.jsonc` snippet, `StorageProvider` switch, custom domain, `wrangler r2 object put` for one-off uploads |
-| edit | `docs/en/guides/storage.md`, `docs/ja/guides/storage.md` | Replace the "Cloudflare R2 via `driver: 's3'`" recipe with the binding driver for Workers; keep the S3-API recipe only if step 0 proves it works, and say what it cannot do (ACL) |
-| edit | `rfcs/0003-cloudflare-workers-plugin.md` | §6 support matrix: move storage from "unsupported" to "works via `R2Driver`"; §7: strike "R2 storage driver", point here |
-| edit | `packages/cli/templates/agent/core/skills/guren-api/SKILL.md` | Storage section: mention `R2Driver` on Workers (agent harness) |
-| add | `.changeset/*.md` | `@guren/plugin-cloudflare` **minor** (0.2.x → 0.3.0) |
-| sibling PR | `packages/cli/src/blueprints.ts` (`storage` blueprint), `packages/server/src/storage/drivers/S3Driver.ts` | `guren add storage` scaffold reads `STORAGE_DISK` (§2.4); `S3DriverOptions.acl?: boolean` (§2.4 option 1). Neither blocks the plugin release; both touch npm-resolved packages, so they ship on the server/cli train |
-| edit | `web/` | nothing required; optional: register an R2 disk for the guren.dev CMS as the in-repo dogfooding app (§4.3) |
+| Package | Change |
+|---|---|
+| `@guren/plugin-cloudflare` | The driver, its structural binding types, the WebCrypto signer (§1.2), and their tests; four new type exports (`R2Driver`, `R2DriverOptions`, `R2PresignOptions`, `R2BucketLike`). No runtime dependency is added |
+| Docs | A "Storage (R2)" section in the Cloudflare guide (both languages); the storage guide's R2-over-S3 recipe gains the "on Workers, use the binding" pointer and the ACL caveat from step 0; RFC 0003's §6 matrix moves storage out of "unsupported" |
+| Agent harness | The `guren-api` skill's storage section names `R2Driver` on Workers |
+| Sibling PR (`@guren/server`, `@guren/cli`) | `S3DriverOptions.acl` and the `STORAGE_DISK` scaffold (§2.4). Neither blocks this release |
 
-Nothing under `packages/server`, `packages/core`, `packages/create-app`, or
-`packages/cli/src` changes, so none of `audit:starter-template`,
-`smoke:starter*`, `sync:template-deps` are in play. `bun run audit:docs` is
-content-coupled (`scripts/smoke/docs-audit.ts`) — adding an assertion that
-`cloudflare.md` names `R2Driver` is optional but cheap and keeps the docs from
-drifting.
+Nothing in `@guren/server`, `@guren/core`, `@guren/create-app`, or the CLI's
+own source changes, so none of the template audits or starter smokes are in
+play (§2.2 explains why that matters for the release order).
 
 ### 4. Test strategy
 
-#### 4.1 Unit tests (always on)
+Three layers, because each catches something the one below cannot:
 
-`R2Driver.test.ts` mirrors the `describe` structure of the `MemoryDriver`
-block in `packages/server/tests/storage/storage.test.ts` (put/get, exists,
-delete, copy/move, url, size/lastModified, files/directories, visibility,
-deleteDirectory) against `FakeR2Bucket`, plus the R2-specific behaviours:
+1. **Unit tests against an in-memory `FakeR2Bucket`** implementing
+   `R2BucketLike` with real prefix/delimiter/cursor semantics. This is where
+   the driver's own logic is pinned — key scoping, the 1000-key delete
+   batching, cursor following (which `S3Driver.allFiles` gets wrong today by
+   reading one page), folder markers, and the visibility and presign refusals.
+   The fake also records calls, so "deletes each page as it lists it" is
+   assertable at all.
+2. **A type-level test** that the real `R2Bucket` from
+   `@cloudflare/workers-types` satisfies `R2BucketLike`, so drift in
+   workers-types is a typecheck failure rather than a runtime one. **Learned
+   in implementation:** streams and blobs inside that interface must be
+   structural too (`R2StreamLike`, `R2BlobLike`), not the global
+   `ReadableStream`/`Blob` — workers-types declares its own interfaces for
+   both, and neither direction is assignable to the runtime globals, so naming
+   the globals makes the real `R2Bucket` fail a check it should pass.
+3. **An opt-in run against workerd's real R2** through Miniflare, gated
+   behind `GUREN_TEST_WRANGLER=1` exactly like `wrangler-migrations.test.ts`
+   (it fetches a native binary on first run, so CI skips it). The same
+   conformance suite runs against both the fake and the real bucket, so every
+   semantic the fake encodes is checked against the runtime rather than
+   assumed.
 
-- `delete` returns `false` for a missing key (head-then-delete);
-- `deleteMany` with 2 500 keys issues 3 `delete` calls of 1000/1000/500;
-- `allFiles` over a bucket where the fake returns `truncated: true` pages
-  follows `cursor` to the end (the S3 driver's single-page bug is what this
-  guards against);
-- `copy` preserves `httpMetadata.contentType` and `customMetadata`;
-- `url()` without `publicUrl` throws, with `publicUrl` joins the prefix;
-- `temporaryUrl()` without `presign` throws with the RFC 0010 hint; with
-  `presign` and a fixed `datetime` produces a URL containing
-  `X-Amz-Algorithm=AWS4-HMAC-SHA256`, `X-Amz-Expires=<n>`, `X-Amz-Signature`
-  (the signer takes an injectable clock, so the test is deterministic);
-  expiry > 7 days throws before signing;
-- `put({ visibility })` / `setVisibility` matching the disk → no-op,
-  conflicting → throw naming the `visibility` option;
-- `binding()` returning `undefined` throws the guidance message;
-- `putFile` throws.
+**Two things only layer 3 can see, and both were real.** Miniflare's binding
+proxy cannot marshal a `ReadableStream`, so `copy()`/`move()` — the methods
+that pipe `get().body` into `put()`, because the binding has no copy — have to
+run *inside* workerd, which the suite does by bundling the driver into a
+worker. And `temporaryUrl()` must sign from inside that same bundle: the first
+implementation loaded its signer through a lazy import that no Workers bundler
+can follow, which no test outside workerd could observe (§1.2).
 
-Mutation check before merge (per `.claude/rules` "verification must be able
-to fail"): drop the cursor loop and confirm the pagination test goes red.
-
-#### 4.2 Real-runtime test (opt-in)
-
-Miniflare exposes a real R2 implementation to Node/Bun without HTTP:
-`new Miniflare({ modules: true, script: '…', r2Buckets: ['BUCKET'] })` then
-`await mf.getR2Bucket('BUCKET')` returns an `R2Bucket` backed by workerd's
-local R2. `r2-miniflare.test.ts` runs the same conformance block against it,
-gated behind `GUREN_TEST_WRANGLER=1` exactly like
-`wrangler-migrations.test.ts` (network on first run to fetch workerd; skipped
-in CI). This is what catches semantics the fake gets wrong (e.g. what `list`
-returns for `prefix: 'a/'` when only `a` exists, `head` on a zero-byte
-object). **Verified in implementation:** Miniflare 5 runs under `bun test`.
-One limit: the binding proxy cannot marshal a `ReadableStream`, so
-`copy()`/`move()` (which pipe `get().body` into `put()`) throw
-`DataCloneError` through `getR2Bucket()`. The suite therefore has a second
-block that bundles the driver with `Bun.build` and runs those two methods
-*inside* workerd (`modules: [{ type: 'ESModule', … }]`, since `script:`
-alone makes Miniflare walk the bundle and reject the driver's dynamic
-its import graph itself), which also
-confirms `Buffer` under `nodejs_compat`.
+Whatever a test protects, check it can fail: dropping the cursor loop must
+turn the pagination test red, and restoring the lazy signer import must turn
+the in-workerd presign test red.
 
 #### 4.3 Dogfooding (a real Workers app)
 
-The same loop RFC 0003 Part 4 ran with the guren.dev site (`web/`), which
-is already deployed on Workers + D1 and is the natural in-repo candidate:
+The same loop RFC 0003 Part 4 ran with the guren.dev site (`web/`), which is
+already deployed on Workers + D1:
 
 - Bucket + custom domain, `MEDIA` binding, `StorageProvider` switch as in §1.
-- Seeding existing files: `bunx wrangler r2 object put <bucket>/<key>
-  --file …` from a script — the driver has no filesystem access on Workers,
-  and a Bun script has no binding, so initial bulk loads go through wrangler
-  (or the S3 API), not the driver.
-- An authenticated upload path (`this.file()` → `put(buffer, { contentType })`,
-  the storage guide's existing example) exercised through `wrangler dev`, then
-  production.
-- Guard: a `GUREN_TEST_WRANGLER=1` run of §4.2 before the release PR.
+- Seeding existing files goes through `wrangler r2 object put` or the S3 API,
+  not the driver: the driver has no filesystem access on Workers, and a Bun
+  script has no binding.
+- An authenticated upload path (`this.file()` → `put(buffer, { contentType })`)
+  exercised through `wrangler dev`, then production.
 
-### 5. Implementation steps
+### 5. Implementation plan
 
-0. **Spike (½ day, before writing the driver):** against a throwaway R2
-   bucket, (a) run today's `S3Driver` recipe from the storage guide and record
-   whether `PutObject` with `x-amz-acl` succeeds, is ignored, or errors — this
-   decides what the storage-guide edit says; (b) confirm `wrangler deploy`
-   fails for a nonexistent bound bucket (decides §2.1's default); (c) confirm
-   Miniflare's `getR2Bucket` works under `bun test` (decides §4.2's shape).
-1. `R2Driver.ts` + `FakeR2Bucket` + unit tests. Land the driver with
-   `temporaryUrl` throwing unconditionally first if the signer slows review;
-   the throw message is the contract either way.
-2. `temporaryUrl` presign path + deterministic test; optional peer dep.
-3. Type-level test against `@cloudflare/workers-types`.
-4. Miniflare e2e (opt-in).
-5. Exports, README, `docs/{en,ja}/guides/{cloudflare,storage}.md`, RFC 0003
-   matrix update, harness SKILL.md line, changeset. Run `bun run
-   audit:core-first` (docs must import from `@guren/core` /
-   `@guren/plugin-cloudflare`, never `@guren/server`) and `bun run
-   audit:docs`.
-6. Release `@guren/plugin-cloudflare@0.3.0` (no other package moves).
-7. Dogfooding (§4.3): bucket, domain, provider switch, seeding, upload path.
-   Anything a real app needs that the driver lacks comes back here as a
-   follow-up.
+Split into parts, referencing this RFC:
 
-Steps 1–5 are one PR (`feat(plugin-cloudflare): add R2Driver`); step 6 is the
-release; step 7 is app-side work.
+0. **Spike.** Against a throwaway bucket, measure the two things §2.1 and §6
+   currently assume: whether R2 ignores or rejects `x-amz-acl` on `PutObject`
+   (which decides what the storage guide says, and how urgent the
+   `S3DriverOptions.acl` sibling PR is), and whether `wrangler deploy` refuses
+   a Worker bound to a bucket that does not exist (which decides the scaffold
+   default). Both are Open Questions until then.
+1. **Driver.** `R2Driver`, the structural binding types, `FakeR2Bucket`, the
+   unit and type-level tests.
+2. **Presigning.** The WebCrypto signer (§1.2) and its known-answer tests,
+   plus the in-workerd presign check. The driver is useful before this lands —
+   `temporaryUrl()` throwing with guidance is the contract either way.
+3. **Real-runtime coverage.** The opt-in Miniflare conformance run.
+4. **Docs and release.** Exports, README, both guides, the RFC 0003 matrix,
+   the harness skill, changeset; `@guren/plugin-cloudflare` minor.
+5. **Dogfooding** (§4.3). Anything a real app needs that the driver lacks
+   comes back here as a follow-up.
 
 ### 6. Documentation notes
 
-- The storage guide's "S3-Compatible Services → Cloudflare R2" block is
-  currently the only R2 mention. After this RFC it should say: on Workers use
-  `R2Driver` (binding, no credentials); from Bun/Lambda/Vercel the S3 API with
-  an R2 token is the route, with the ACL caveat from step 0 spelled out.
-- Both `en` and `ja` guides move together (a lesson recorded from earlier
-  reviews: en/ja drift).
-- No `packages/*` paths or RFC part numbers in user-facing docs
-  (`docs/CLAUDE.md`).
+The storage guide's "S3-Compatible Services → Cloudflare R2" block is
+currently the only R2 mention. After this RFC it says: on Workers use
+`R2Driver` (binding, no credentials); from Bun/Lambda/Vercel the S3 API with
+an R2 token is the route, with the ACL caveat from step 0 spelled out.
 
 ## Alternatives Considered
 
@@ -550,27 +535,26 @@ the token secrets. No deprecations.
 
 ## Open Questions
 
-1. **Strict visibility (§1.3)** — throw on a conflicting `put({ visibility })`
-   is stricter than every other driver. Alternative: warn once per disk and
-   proceed. Leaning throw; the guide's example would then need
-   `visibility` removed from the R2 variant.
-2. ~~**`url()` encoding**~~ — **Resolved in implementation (review
+1. **Does `wrangler deploy` refuse a Worker bound to a bucket that does not
+   exist?** §2.1 declines to scaffold `r2_buckets` on the strength of this,
+   and it is still unmeasured — if wrangler in fact deploys and only fails at
+   runtime, the scaffold decision should be revisited. Step 0 measures it.
+2. **What does R2 do with `x-amz-acl` on `PutObject`?** The storage guide's
+   S3-API recipe and the `S3DriverOptions.acl` sibling PR (§2.4) both hinge on
+   whether R2 ignores or rejects the header. Also step 0.
+3. ~~**`url()` encoding**~~ — **Resolved in implementation (review
    finding):** `R2Driver.url()` percent-encodes each key segment, since this
    is the first place a Workers app is steered to a driver's `url()` for
    public links. `S3Driver.url` / `LocalDriver.url` still do not; aligning
    them is a server change tracked separately.
-3. **Should `FakeR2Bucket` be exported** (e.g. from
+4. **Should `FakeR2Bucket` be exported** (e.g. from
    `@guren/plugin-cloudflare/testing`) so app tests can run against R2
    semantics without Miniflare? Useful for app-level tests; adds a public
    surface to maintain. Leaning yes, as a subpath export, once the fake has
-   survived §4.2 comparison.
-4. **`deleteMany` return value** — `paths.length` vs. head-then-delete per key
-   (N Class B ops). Leaning `paths.length`, matching what S3 observably does.
-5. **Streaming reads** — an optional `getStream?(path): Promise<ReadableStream
-   | null>` on `StorageDriver` would let RFC 0010's proxy route avoid
-   buffering; it is an additive server change and belongs with RFC 0010, but
-   the R2 driver could implement it ahead of the interface (structural
-   typing). Decide when RFC 0010 lands.
+   survived the real-runtime comparison in §4.
+5. ~~**Streaming reads**~~ — **owned by RFC 0010 §3**, which proposes the
+   optional `getStream?` on `StorageDriver` and consumes it; `R2Driver` will
+   implement it (`obj.body`) when that lands. Not open here.
 
 ## Follow-ups (not in this RFC)
 

--- a/rfcs/0009-cloudflare-r2-storage-driver.md
+++ b/rfcs/0009-cloudflare-r2-storage-driver.md
@@ -112,9 +112,14 @@ export class R2Driver implements StorageDriver { /* §1.1 */ }
 `R2BucketLike` interface (`head/get/put/delete/list` and the object shapes it
 reads), the same way `S3Driver` declares its own `S3Client { send() }`
 (`S3Driver.ts:6-8`). `@cloudflare/workers-types` stays a devDependency; a
-type-level test (`R2Driver.types.test.ts`, `const _: R2BucketLike =
-{} as R2Bucket`) pins that the real `R2Bucket` satisfies it, so drift in
-workers-types shows up at typecheck rather than at runtime.
+type-level test (`R2Driver.types.test.ts`) pins that the real `R2Bucket`
+satisfies it, so drift in workers-types shows up at typecheck rather than at
+runtime. **Learned in implementation:** streams and blobs inside that
+interface must be structural too (`R2StreamLike { locked, getReader(),
+cancel() }`, `R2BlobLike`), not the global `ReadableStream`/`Blob` —
+workers-types declares its own interfaces for both, and neither direction is
+assignable to the runtime globals, so naming the globals makes the real
+`R2Bucket` fail the check while being perfectly usable at runtime.
 
 **Registration** is through `StorageManager.registerDisk()` (the extension
 point that works today, see premises), and mirrors the D1 runtime switch:
@@ -177,7 +182,7 @@ the `r2_buckets` entry in wrangler.jsonc."*
 | `files(dir)` | `list({ prefix: `${key}/`, delimiter: '/' })`, loop on `truncated`/`cursor` | Strip prefix; drop keys ending in `/` (S3 precedent, covers `.keep`-style markers only when named so — see `makeDirectory`). |
 | `directories(dir)` | same `list`, read `delimitedPrefixes` | Strip prefix and trailing `/`. |
 | `allFiles(dir)` | `list({ prefix })`, paginate | Pagination is **not optional**: `S3Driver.allFiles` reads a single page (`S3Driver.ts:364-383`), which silently caps at 1000; the R2 driver loops. |
-| `makeDirectory(path)` | `put(`${path}/.keep`, '')` | S3 precedent. |
+| `makeDirectory(path)` | `put(`${key}/`, '')` — a zero-byte object whose key ends in `/` | **Amended in implementation** from the S3 driver's `.keep` marker: a trailing-slash key is the folder convention S3 consoles use, `directories()` sees it as a delimited prefix, and the trailing-slash filter keeps it out of `files()`/`allFiles()` — a `.keep` marker would be listed as a file, which is what `S3Driver` does today. `deleteDirectory()` deletes raw listed keys (not through `key()`, which would strip the slash). |
 | `deleteDirectory(path)` | `allFiles` + `deleteMany` (chunked) | |
 | `setVisibility(path, v)` | — | No per-object ACL in R2. **No-op when `v` equals the disk visibility, throws otherwise** (§1.3). |
 | `getVisibility(path)` | `head` for existence, then return the disk visibility | Throws `File not found` on `null` (Memory precedent). |
@@ -424,10 +429,15 @@ gated behind `GUREN_TEST_WRANGLER=1` exactly like
 `wrangler-migrations.test.ts` (network on first run to fetch workerd; skipped
 in CI). This is what catches semantics the fake gets wrong (e.g. what `list`
 returns for `prefix: 'a/'` when only `a` exists, `head` on a zero-byte
-object). **To verify in step 0:** Miniflare 4 under `bun test` — if workerd
-spawning misbehaves under Bun, fall back to `wrangler dev` + a temp worker
-that mounts the driver behind `/put`, `/get`, … and drive it with `fetch`
-(the migrations test already shells out to `bunx wrangler`).
+object). **Verified in implementation:** Miniflare 5 runs under `bun test`.
+One limit: the binding proxy cannot marshal a `ReadableStream`, so
+`copy()`/`move()` (which pipe `get().body` into `put()`) throw
+`DataCloneError` through `getR2Bucket()`. The suite therefore has a second
+block that bundles the driver with `Bun.build` and runs those two methods
+*inside* workerd (`modules: [{ type: 'ESModule', … }]`, since `script:`
+alone makes Miniflare walk the bundle and reject the driver's dynamic
+`import(moduleName)` for the optional aws4fetch dependency), which also
+confirms `Buffer` under `nodejs_compat`.
 
 #### 4.3 Dogfooding (a real Workers app)
 
@@ -520,11 +530,11 @@ the token secrets. No deprecations.
    is stricter than every other driver. Alternative: warn once per disk and
    proceed. Leaning throw; the guide's example would then need
    `visibility` removed from the R2 variant.
-2. **`url()` encoding** — `S3Driver.url` and `LocalDriver.url` do not
-   percent-encode the key. Keys with spaces or `#` produce broken URLs today
-   on every driver; fixing it only in R2 would be inconsistent, fixing it
-   everywhere is a server change. Proposal: match existing drivers here, open
-   a separate issue.
+2. ~~**`url()` encoding**~~ — **Resolved in implementation (review
+   finding):** `R2Driver.url()` percent-encodes each key segment, since this
+   is the first place a Workers app is steered to a driver's `url()` for
+   public links. `S3Driver.url` / `LocalDriver.url` still do not; aligning
+   them is a server change tracked separately.
 3. **Should `FakeR2Bucket` be exported** (e.g. from
    `@guren/plugin-cloudflare/testing`) so app tests can run against R2
    semantics without Miniflare? Useful for app-level tests; adds a public

--- a/rfcs/0009-cloudflare-r2-storage-driver.md
+++ b/rfcs/0009-cloudflare-r2-storage-driver.md
@@ -1,0 +1,558 @@
+# RFC: Cloudflare R2 Storage Driver (`R2Driver` in `@guren/plugin-cloudflare`)
+
+**Author:** 7nohe
+**Date:** 2026-08-15
+**Status:** Draft — implementation plan; the second half of this work (model
+attachments) is RFC 0010, which builds on the driver defined here.
+
+> RFC 0003 §7 lists "R2 storage driver" as explicitly out of scope, to be
+> covered by a future RFC. This is that RFC. It is additive: no existing API
+> changes, no breaking changes, and — deliberately — no change to
+> `@guren/server` on the critical path (see §2.2 for why that matters for the
+> release order).
+
+## Problem
+
+A Guren app deployed on Cloudflare Workers has no first-class way to store
+files. Today's options, checked against the code:
+
+- **`LocalDriver`** (`packages/server/src/storage/drivers/LocalDriver.ts`) —
+  needs a filesystem. RFC 0003 §6 already lists it as unsupported on Workers.
+- **`S3Driver`** against R2's S3-compatible endpoint — the storage guide
+  (`docs/en/guides/storage.md`, "S3-Compatible Services") advertises this
+  recipe today. Two problems:
+  1. It needs an R2 API token (access key + secret) shipped as a Worker
+     secret and pulls `@aws-sdk/client-s3` into the bundle, when the Worker
+     already holds a zero-credential binding to the bucket (`env.BUCKET`).
+  2. `S3Driver.put()` sends `ACL: 'public-read' | 'private'` on **every**
+     `PutObjectCommand` (`S3Driver.ts:106-113`), and `setVisibility` /
+     `getVisibility` issue `PutObjectAcl` / `GetObjectAcl`. R2's S3 API
+     reference lists `x-amz-acl` and the ACL operations as unsupported.
+     Whether R2 ignores or rejects the header must be checked against a real
+     bucket (§6, step 0); the ACL calls will not work either way. So the
+     documented recipe is at best partially true, and it is untested — there
+     is no `S3Driver` test in `packages/server/tests/storage/storage.test.ts`
+     (only `LocalDriver`, `MemoryDriver`, `StorageManager`).
+- **`MemoryDriver`** — loses everything between isolates.
+
+The typical first need on Workers is public reads (images, downloads) plus an
+authenticated upload path — exactly the shape the binding API serves best,
+with no credentials to provision and nothing extra in the bundle.
+
+## Verified premises (2026-08-15)
+
+The plan below was written against the code, not the docs. Corrections to the
+working assumptions the plan started from:
+
+| Assumption | Reality in the code |
+|---|---|
+| `StorageDriver` has "about 20 methods" | **21**: `put`, `putFile`, `get`, `getAsString`, `exists`, `delete`, `deleteMany`, `copy`, `move`, `url`, `temporaryUrl`, `size`, `lastModified`, `metadata`, `files`, `directories`, `allFiles`, `makeDirectory`, `deleteDirectory`, `setVisibility`, `getVisibility` (`packages/server/src/storage/types.ts:59-201`). Content is `Buffer \| string`; reads return `Buffer \| null`. |
+| `StorageManager.registerDriver()` is a usable extension point for third-party drivers | Only half true. `registerDriver(name, factory)` exists (`StorageManager.ts:132`), but the constructor resolves every `disks` entry **eagerly** (`registerDiskFromConfig`, `StorageManager.ts:82-94`) and throws `Unknown storage driver: r2` for a driver registered afterwards. `DriverConfig` is also a **closed** union of `'local' \| 's3' \| 'memory'` (`types.ts:293-296`), so `{ driver: 'r2' }` does not type-check. **`registerDisk(name, () => driver)` is the extension point that actually works today** (`StorageManager.ts:123`), and it is what this plan uses. |
+| `S3Driver` dynamically imports `@aws-sdk/client-s3` | Correct — via `importAwsModule()` with a "Missing optional dependency" error (`S3Driver.ts:463-474`). Same pattern is reused here for `aws4fetch`. |
+| The Cloudflare plugin uses a lazy `binding: () => getWorkersEnv<Env>().DB` closure | Correct (`packages/orm/src/d1.ts:6-25`, `packages/plugin-cloudflare/src/env.ts`). `getWorkersEnv()` throws before the first request; `web/app/Http/Middleware/site-analytics.ts:90-97` shows the pattern for an *optional* binding (try/catch → undefined off-Workers), and `web/config/database.ts:9-11` the `isWorkersRuntime()` switch (`navigator.userAgent === 'Cloudflare-Workers'`). |
+| `cloudflarePlugin()` registers services | It does not — `register() {}` is empty and `CloudflarePluginConfig` is an empty interface "reserved for upcoming RFC 0003 parts" (`packages/plugin-cloudflare/src/index.ts`). This plan keeps it that way (§2.2). |
+| `cloudflare:build` scaffolds `wrangler.jsonc` | Correct — once, `wx` flag, never overwritten; `warnMissingBuildOwnedKeys` only reports **build-owned** keys (`alias`, `define`, `migrations_dir`) (`build.ts:308-396`). |
+| Workers-side R2 API | Verified against the R2 Workers API reference (fetched 2026-08-15): `head(key)`, `get(key, {onlyIf, range})` → `R2ObjectBody \| R2Object \| null`, `put(key, ReadableStream \| ArrayBuffer \| ArrayBufferView \| string \| null \| Blob, {httpMetadata, customMetadata, onlyIf, md5…})`, `delete(key \| key[])` → `void`, **max 1000 keys per call**, `list({limit ≤ 1000, prefix, cursor, delimiter, include})` → `{objects, truncated, cursor?, delimitedPrefixes}`. `R2Object` carries `key, size, etag, httpEtag, uploaded (Date), httpMetadata, customMetadata, writeHttpMetadata(headers)`. **There is no `copy` on the binding**, and no presigned-URL API. |
+| Presigned URLs | Verified: generated client-side with SigV4 against `https://<ACCOUNT_ID>.r2.cloudflarestorage.com`, need an R2 API token (access key id + secret), **max expiry 7 days**. Not available from a binding. |
+| Cloudflare Images binding | Verified: `env.IMAGES.input(stream).transform({width…}).output({format}).response()`; billed per unique transformation. Relevant only to RFC 0010 (variants). |
+
+## Proposed Solution
+
+### 1. `R2Driver` in `@guren/plugin-cloudflare`
+
+A `StorageDriver` implementation over the R2 **binding** (not the S3 API),
+exported from the plugin package next to `createWorkersHandler` /
+`getWorkersEnv`.
+
+```ts
+// packages/plugin-cloudflare/src/storage/R2Driver.ts
+import type { StorageDriver, PutOptions, FileMetadata } from '@guren/core'
+
+export interface R2DriverOptions {
+  /**
+   * Resolver returning the R2 bucket binding. Bindings arrive with the first
+   * request on Workers, so this must be a deferred closure, e.g.
+   * `binding: () => getWorkersEnv<Env>().BUCKET`. (Same contract as
+   * `createD1Database({ binding })`.)
+   */
+  binding: () => unknown
+  /**
+   * Base URL for `url()`: the bucket's custom domain (recommended) or its
+   * r2.dev subdomain. R2 has no derivable default — unlike S3 there is no
+   * `https://<bucket>.s3.<region>.amazonaws.com` — so `url()` throws with
+   * guidance when this is unset.
+   */
+  publicUrl?: string
+  /** Key prefix, same semantics as `S3DriverOptions.prefix`. */
+  prefix?: string
+  /**
+   * The visibility every object in this bucket effectively has. R2 has no
+   * per-object ACL: a bucket is public (custom domain / r2.dev) or it is not.
+   * Defaults to `'public'` when `publicUrl` is set, `'private'` otherwise.
+   * See §1.3 for how put()/setVisibility() treat a conflicting request.
+   */
+  visibility?: 'public' | 'private'
+  /**
+   * S3 API credentials used only by `temporaryUrl()`. Optional — omit it and
+   * `temporaryUrl()` throws with guidance (RFC 0010's signed serving route is
+   * the credential-free alternative).
+   */
+  presign?: {
+    accountId: string
+    bucket: string
+    accessKeyId: string
+    secretAccessKey: string
+  }
+}
+
+export class R2Driver implements StorageDriver { /* §1.1 */ }
+```
+
+**Structural binding type.** The driver types the binding through a local
+`R2BucketLike` interface (`head/get/put/delete/list` and the object shapes it
+reads), the same way `S3Driver` declares its own `S3Client { send() }`
+(`S3Driver.ts:6-8`). `@cloudflare/workers-types` stays a devDependency; a
+type-level test (`R2Driver.types.test.ts`, `const _: R2BucketLike =
+{} as R2Bucket`) pins that the real `R2Bucket` satisfies it, so drift in
+workers-types shows up at typecheck rather than at runtime.
+
+**Registration** is through `StorageManager.registerDisk()` (the extension
+point that works today, see premises), and mirrors the D1 runtime switch:
+
+```ts
+// app/Providers/StorageProvider.ts
+import { ServiceProvider, createStorageManager, LocalStorageDriver } from '@guren/core'
+import { R2Driver, getWorkersEnv } from '@guren/plugin-cloudflare'
+import { isWorkersRuntime } from '../../config/database'
+
+interface Env { MEDIA: unknown }
+
+export default class StorageProvider extends ServiceProvider {
+  register(): void {
+    const storage = createStorageManager({ default: 'media' })
+    storage.registerDisk('media', () =>
+      isWorkersRuntime()
+        ? new R2Driver({
+            binding: () => getWorkersEnv<Env>().MEDIA,
+            publicUrl: 'https://media.example.com',
+          })
+        : new LocalStorageDriver({ root: './storage/app/public', url: '/storage' }),
+    )
+    this.container.instance('storage', storage)
+  }
+}
+```
+
+`bun run dev` keeps writing to disk; `wrangler dev` and production hit R2.
+`createStorageManager({ default: 'media' })` with no `disks` is fine: the
+constructor only auto-registers a `local` disk when the default is named
+`local` (`StorageManager.ts:54-56`).
+
+#### 1.1 Method mapping
+
+Key = `prefix ? `${prefix}/${path}` : path`, with leading/trailing slashes
+trimmed as `MemoryDriver.normalizePath` does (the plugin ships its own
+`trimSlashes`; `packages/server/src/support/trim-slashes` is not exported).
+The binding is resolved on every call (`binding()` is a holder read, not I/O);
+`null`/`undefined` throws the D1-shaped message: *"the "binding" resolver
+returned no R2 bucket. On Workers this usually means it ran before the first
+request — defer access (`binding: () => getWorkersEnv<Env>().BUCKET`) and check
+the `r2_buckets` entry in wrangler.jsonc."*
+
+| `StorageDriver` | R2 binding call | Notes / decision |
+|---|---|---|
+| `put(path, content, opts)` | `bucket.put(key, content, { httpMetadata: { contentType }, customMetadata: metadata })` | `Buffer` is a `Uint8Array` → accepted as `ArrayBufferView`; strings pass through. `opts.visibility` is checked against the disk visibility (§1.3). Returns `path`. |
+| `putFile(path, localPath)` | — | **Throws** `'putFile is not supported by R2Driver: Workers has no filesystem. Read the file yourself and call put().'` Same choice as `MemoryDriver.putFile` (`MemoryDriver.ts:93-96`); RFC 0003 §6 already documents `S3Driver.putFile` as unsupported on Workers. Under `wrangler dev`, `node:fs` is a virtual fs, so "try and let it fail" would produce a confusing ENOENT. |
+| `get(path)` | `bucket.get(key)` → `null` or `Buffer.from(await obj.arrayBuffer())` | Whole-object read, as the contract requires. Streaming (`obj.body`) is left to RFC 0010's proxy route via an optional driver extension. |
+| `getAsString(path)` | `bucket.get(key)` → `obj.text()` | Avoids the Buffer round trip. |
+| `exists(path)` | `(await bucket.head(key)) !== null` | |
+| `delete(path)` | `head` then `delete` | `R2Bucket.delete()` returns `void` and is idempotent, so the contract's *"false if not found"* needs a `head` first (a Class B op — cheap). `S3Driver.delete` returns `true` unconditionally, but Local/Memory are exact; follow the exact ones. |
+| `deleteMany(paths)` | `bucket.delete(chunk)` per **1000-key chunk** | Returns `paths.length` (dedupe first). R2 gives no per-key result; `S3Driver` returns `Deleted.length`, which S3 also reports for missing keys, so the observable contract matches. |
+| `copy(from, to)` | `get(from)` → `put(to, obj.body, { httpMetadata: obj.httpMetadata, customMetadata: obj.customMetadata })` | **No copy on the binding** — stream the body through. `obj === null` throws `File not found: ${from}` (Memory precedent). Single-`put` size limits apply (multipart is out of scope). |
+| `move(from, to)` | `copy` + `delete(from)` | |
+| `url(path)` | `${publicUrl}/${key}` | Throws when `publicUrl` is unset (no derivable default; fail closed rather than return a URL that 404s). No percent-encoding, matching `S3Driver.url` — noted as an Open Question. |
+| `temporaryUrl(path, expiration)` | `aws4fetch` SigV4 presign against `https://${accountId}.r2.cloudflarestorage.com/${bucket}/${key}` with `X-Amz-Expires` | Only when `presign` is configured; else throws *"R2 bindings cannot sign URLs. Either configure `presign: { accountId, bucket, accessKeyId, secretAccessKey }` (an R2 API token) or serve private files through a signed app route."* `aws4fetch` is an **optional** dependency loaded with the `importAwsModule`-style dynamic import (same missing-module error shape). Expiry > 7 days throws up front (R2 rejects it; the S3 driver would only find out from AWS). |
+| `size` / `lastModified` | `head(key)` → `size` / `uploaded` | Throw `File not found` on `null` (S3/Memory precedent). |
+| `metadata(path)` | `head(key)` → `{ path, size, lastModified: uploaded, contentType: httpMetadata?.contentType, metadata: customMetadata, visibility }` | `visibility` is the disk's configured value (§1.3). |
+| `files(dir)` | `list({ prefix: `${key}/`, delimiter: '/' })`, loop on `truncated`/`cursor` | Strip prefix; drop keys ending in `/` (S3 precedent, covers `.keep`-style markers only when named so — see `makeDirectory`). |
+| `directories(dir)` | same `list`, read `delimitedPrefixes` | Strip prefix and trailing `/`. |
+| `allFiles(dir)` | `list({ prefix })`, paginate | Pagination is **not optional**: `S3Driver.allFiles` reads a single page (`S3Driver.ts:364-383`), which silently caps at 1000; the R2 driver loops. |
+| `makeDirectory(path)` | `put(`${path}/.keep`, '')` | S3 precedent. |
+| `deleteDirectory(path)` | `allFiles` + `deleteMany` (chunked) | |
+| `setVisibility(path, v)` | — | No per-object ACL in R2. **No-op when `v` equals the disk visibility, throws otherwise** (§1.3). |
+| `getVisibility(path)` | `head` for existence, then return the disk visibility | Throws `File not found` on `null` (Memory precedent). |
+
+#### 1.2 Design decision: `temporaryUrl`
+
+Three options were weighed:
+
+1. **Always throw.** Simplest, but rules out the legitimate "private bucket +
+   time-limited download link" case that S3 users get for free.
+2. **Presign with S3 credentials when configured, throw otherwise** —
+   **chosen.** Matches how Cloudflare itself documents presigned URLs for R2
+   (client-side SigV4 with an API token; not something a binding can do), and
+   keeps the credential-free default: an app that never calls `temporaryUrl()`
+   never needs a token. `aws4fetch` (WebCrypto-based, ~6 KB, Workers-native)
+   is the signer, loaded lazily so it stays out of bundles that do not use it.
+   Hand-rolling SigV4 was rejected: it is 100 lines of easy-to-get-wrong
+   canonicalization for zero benefit over a 6 KB dependency.
+3. **Sign an app route instead** (a Guren-served `/storage/<signed>` URL). This
+   is the right long-term answer for *private* files and is exactly RFC 0010's
+   signed delivery route — which is why the throw message here points at it.
+   It is not the driver's job: `temporaryUrl()` returns a URL the app does not
+   have to serve, and coupling the driver to the router would break the
+   `StorageDriver` contract's independence from HTTP.
+
+#### 1.3 Design decision: `setVisibility` / `getVisibility` / `put({ visibility })`
+
+R2 has bucket-level public access (custom domain or the r2.dev subdomain) and
+nothing per object. The candidates:
+
+- **Silently accept and record nothing.** Rejected — `setVisibility(path,
+  'private')` on a public bucket that then does nothing is a data leak that
+  looks like success; the storage guide's upload example passes `visibility:
+  'public'` and readers will assume it did something.
+- **Record the requested value in `customMetadata` and enforce it in a serving
+  route.** That is an attachment-layer concern (RFC 0010 stores visibility on
+  the blob row, where it belongs). A driver that pretends to enforce a flag it
+  cannot enforce would be worse than one that refuses.
+- **Compare against the disk's configured visibility: equal → no-op, different
+  → throw** — **chosen.** The disk declares what the bucket *is*
+  (`visibility` option, defaulted from `publicUrl`), `getVisibility()` reports
+  it, and any request that would require per-object ACLs fails loudly at the
+  call site with a message that names the option. Portable code that never
+  passes `visibility` (the common case) is unaffected.
+
+This is called out as an Open Question because it is stricter than S3/Local
+behave; the reasoning is fail-closed over silent no-op.
+
+#### 1.4 Design decision: `putFile`
+
+Throws (see mapping). One nuance worth recording: the driver is only ever
+instantiated where a binding exists (workerd under `wrangler dev`, or
+production), and neither has the caller's real filesystem. There is no
+half-working case to preserve.
+
+### 2. Wiring, wrangler, and the build
+
+#### 2.1 `wrangler.jsonc`
+
+The binding entry the app needs:
+
+```jsonc
+"r2_buckets": [
+  { "binding": "MEDIA", "bucket_name": "my-app-media" }
+]
+```
+
+plus, for `publicUrl`, a custom domain attached to the bucket in the dashboard
+(the r2.dev subdomain is rate-limited and meant for development).
+
+**Decision: `cloudflare:build` does not scaffold `r2_buckets` by default.**
+The existing scaffold includes `d1_databases` because every Guren app has a
+database; storage is optional, and wrangler will not deploy a Worker whose
+bound bucket does not exist (to be re-confirmed in step 0), so an
+unconditional entry would break `wrangler deploy` for every app that never
+touches storage until they hand-edit the config — the opposite of the D1
+`TODO` placeholder, which only blocks apps that *do* need it. Instead:
+
+- the docs (`cloudflare.md` → new "Storage (R2)" section) carry the snippet;
+- the driver's missing-binding error prints the exact JSON entry to add;
+- `warnMissingBuildOwnedKeys` is left alone — `r2_buckets` is app-owned, not
+  build-owned, and that function's contract is "name what the build needs".
+
+If real usage shows most apps want a bucket, a `--with-r2 <BINDING>` flag on
+`cloudflare:build` (scaffold-time only, never rewriting an existing file) is
+the additive follow-up; it is not in this RFC.
+
+#### 2.2 Why nothing changes in `@guren/server` on the critical path
+
+The plugin resolves `@guren/core` from npm (`^1.5.2`) for its users, and the
+scaffold templates resolve `@guren/*` from npm too (`.claude/rules/common-pitfalls.md`,
+"Templates vs. Published Packages"). If `R2Driver` depended on a *new* server
+API (an open `DriverConfig`, lazy driver-factory resolution), the plugin
+release would have to trail a server/core release, and no app could use the
+driver until both shipped. Every piece of §1 uses APIs that exist in the
+published `@guren/core` today: the `StorageDriver` type, `registerDisk()`,
+`createStorageManager()`.
+
+The two server-side improvements this surfaced are real, and are listed as
+follow-ups (§7): (a) resolve driver factories lazily in `disk()` so
+`registerDriver()` after construction works and plugins can register drivers
+in `register()`; (b) an augmentable driver registry interface so
+`disks: { media: { driver: 'r2', ... } }` type-checks (Hono's
+`ContextVariableMap` pattern). Neither is needed to ship the driver.
+
+#### 2.3 Plugin surface
+
+`packages/plugin-cloudflare/src/index.ts` adds:
+
+```ts
+export { R2Driver } from './storage/R2Driver'
+export type { R2DriverOptions, R2BucketLike } from './storage/R2Driver'
+```
+
+`gurenPlugin.compatibility` (`>=1.0.0 <2.0.0`) is unaffected: the driver only
+consumes types and `registerDisk`, both present since 1.0.
+
+#### 2.4 Selecting the disk by environment, and reaching R2 off Workers
+
+Two questions come up together, so they are answered together.
+
+**Environment-driven disk selection works today** — `createStorageManager`
+already takes `default` and resolves disks lazily, so declaring every disk
+and choosing with an env var is the Laravel `FILESYSTEM_DISK` shape:
+
+```ts
+// app/Providers/StorageProvider.ts
+const storage = createStorageManager({
+  default: process.env.STORAGE_DISK ?? 'local',
+  disks: {
+    local: { driver: 'local', root: './storage/app/public', url: '/storage' },
+    s3:    { driver: 's3', bucket: process.env.S3_BUCKET!, region: 'ap-northeast-1' },
+  },
+})
+storage.registerDisk('r2', () => new R2Driver({ binding: () => getWorkersEnv<Env>().MEDIA, publicUrl: process.env.MEDIA_URL }))
+```
+
+`.env` → `STORAGE_DISK=local`; `wrangler.jsonc` → `"vars": { "STORAGE_DISK":
+"r2" }` (RFC 0003 §5: `nodejs_compat` populates `process.env` from `vars`
+for the scaffold's compatibility date). Unused disks are never constructed,
+so the `s3` entry costs nothing in dev. The `guren add storage` scaffold
+should adopt this shape (`STORAGE_DISK`) so apps get the switch for free —
+listed in §3. The one thing an env var cannot do is make `r2` work where the
+binding does not exist, which leads to:
+
+**R2 is reachable from anywhere; only the *binding* is Workers-only.** R2
+has four access paths, and the driver above covers one:
+
+| Path | From | Guren surface |
+|---|---|---|
+| Workers binding (`env.MEDIA`) | workerd only (`wrangler dev` uses a local emulated bucket; `wrangler dev --remote` the real one) | `R2Driver` (this RFC) |
+| S3-compatible API + R2 API token | Bun, Node, Lambda, Vercel, scripts — anywhere with `fetch` | today's `S3Driver` with `endpoint: https://<account>.r2.cloudflarestorage.com`, `region: 'auto'` — the storage guide's existing recipe, **modulo the ACL header** (below) |
+| Public bucket (custom domain / r2.dev) | any HTTP client, reads only | `publicUrl` / `disk.url()` |
+| `wrangler r2 object put/get`, REST API | CLI / CI | bulk loads, migrations |
+
+So a Bun dev server can talk to the **same** R2 bucket as production
+through the S3 API. Two options for how Guren exposes that:
+
+1. **`S3Driver` gets an `acl?: boolean` option (default `true`)** and R2/MinIO
+   users set `acl: false`, which suppresses `x-amz-acl` on `PutObject` and
+   makes `setVisibility`/`getVisibility` follow §1.3's rule (compare with the
+   disk's `visibility`, no `PutObjectAcl`). Small, additive, in
+   `@guren/server`, and needed regardless of this RFC because the current
+   unconditional ACL is a latent bug for every non-AWS S3 target. **Chosen
+   as a sibling PR**, not on this RFC's critical path (§2.2) — the R2Driver
+   ships without it, and step 0 decides how urgent it is.
+2. **`R2Driver` falls back to the S3 API through `aws4fetch` when the
+   binding is absent and `presign` credentials are set** — one driver
+   everywhere, no `@aws-sdk` in the bundle. Rejected for v1: `ListObjectsV2`
+   and `DeleteObjects` are XML in and out, so the fallback needs an XML
+   parser and serializer the plugin would then own; `S3Driver` already
+   does all of it. Revisit if the aws-sdk dependency proves a real burden
+   for non-Workers R2 users.
+
+The recommended dev story therefore has two rungs, both documented in the
+Cloudflare guide: `bun run dev` with `STORAGE_DISK=local` (fast loop, no
+network), and either `wrangler dev` (local emulated R2, exercises the real
+driver) or `STORAGE_DISK=s3` pointed at the R2 endpoint when a shared,
+persistent bucket is wanted from a Bun process.
+
+### 3. Files
+
+| Action | Path | What |
+|---|---|---|
+| add | `packages/plugin-cloudflare/src/storage/R2Driver.ts` | Driver, `R2DriverOptions`, `R2BucketLike` + object/list shapes, `trimSlashes`, `importOptionalModule('aws4fetch')` |
+| add | `packages/plugin-cloudflare/src/storage/R2Driver.test.ts` | Unit tests against an in-memory `FakeR2Bucket` (§4.1) |
+| add | `packages/plugin-cloudflare/src/storage/fake-r2-bucket.ts` | Test double implementing `R2BucketLike` with real `prefix`/`delimiter`/`cursor` semantics; also exported for app tests? — Open Question |
+| add | `packages/plugin-cloudflare/src/storage/R2Driver.types.test.ts` | `R2Bucket` (workers-types) satisfies `R2BucketLike` |
+| add | `packages/plugin-cloudflare/src/storage/r2-miniflare.test.ts` | Opt-in e2e (`GUREN_TEST_WRANGLER=1`) against a real local R2 (§4.2) |
+| edit | `packages/plugin-cloudflare/src/index.ts` | exports |
+| edit | `packages/plugin-cloudflare/package.json` | `peerDependencies: { aws4fetch: "^1" }` + `peerDependenciesMeta: { aws4fetch: { optional: true } }`; devDependency `aws4fetch` for the presign test; devDependency `miniflare` for §4.2 |
+| edit | `packages/plugin-cloudflare/README.md` | "Storage (R2)" section under API |
+| edit | `docs/en/guides/cloudflare.md`, `docs/ja/guides/cloudflare.md` | "Storage (R2)" section: binding, `wrangler.jsonc` snippet, `StorageProvider` switch, custom domain, `wrangler r2 object put` for one-off uploads |
+| edit | `docs/en/guides/storage.md`, `docs/ja/guides/storage.md` | Replace the "Cloudflare R2 via `driver: 's3'`" recipe with the binding driver for Workers; keep the S3-API recipe only if step 0 proves it works, and say what it cannot do (ACL) |
+| edit | `rfcs/0003-cloudflare-workers-plugin.md` | §6 support matrix: move storage from "unsupported" to "works via `R2Driver`"; §7: strike "R2 storage driver", point here |
+| edit | `packages/cli/templates/agent/core/skills/guren-api/SKILL.md` | Storage section: mention `R2Driver` on Workers (agent harness) |
+| add | `.changeset/*.md` | `@guren/plugin-cloudflare` **minor** (0.2.x → 0.3.0) |
+| sibling PR | `packages/cli/src/blueprints.ts` (`storage` blueprint), `packages/server/src/storage/drivers/S3Driver.ts` | `guren add storage` scaffold reads `STORAGE_DISK` (§2.4); `S3DriverOptions.acl?: boolean` (§2.4 option 1). Neither blocks the plugin release; both touch npm-resolved packages, so they ship on the server/cli train |
+| edit | `web/` | nothing required; optional: register an R2 disk for the guren.dev CMS as the in-repo dogfooding app (§4.3) |
+
+Nothing under `packages/server`, `packages/core`, `packages/create-app`, or
+`packages/cli/src` changes, so none of `audit:starter-template`,
+`smoke:starter*`, `sync:template-deps` are in play. `bun run audit:docs` is
+content-coupled (`scripts/smoke/docs-audit.ts`) — adding an assertion that
+`cloudflare.md` names `R2Driver` is optional but cheap and keeps the docs from
+drifting.
+
+### 4. Test strategy
+
+#### 4.1 Unit tests (always on)
+
+`R2Driver.test.ts` mirrors the `describe` structure of the `MemoryDriver`
+block in `packages/server/tests/storage/storage.test.ts` (put/get, exists,
+delete, copy/move, url, size/lastModified, files/directories, visibility,
+deleteDirectory) against `FakeR2Bucket`, plus the R2-specific behaviours:
+
+- `delete` returns `false` for a missing key (head-then-delete);
+- `deleteMany` with 2 500 keys issues 3 `delete` calls of 1000/1000/500;
+- `allFiles` over a bucket where the fake returns `truncated: true` pages
+  follows `cursor` to the end (the S3 driver's single-page bug is what this
+  guards against);
+- `copy` preserves `httpMetadata.contentType` and `customMetadata`;
+- `url()` without `publicUrl` throws, with `publicUrl` joins the prefix;
+- `temporaryUrl()` without `presign` throws with the RFC 0010 hint; with
+  `presign` and a fixed `datetime` produces a URL containing
+  `X-Amz-Algorithm=AWS4-HMAC-SHA256`, `X-Amz-Expires=<n>`, `X-Amz-Signature`
+  (aws4fetch accepts `aws: { datetime }`, so the test is deterministic);
+  expiry > 7 days throws before signing;
+- `put({ visibility })` / `setVisibility` matching the disk → no-op,
+  conflicting → throw naming the `visibility` option;
+- `binding()` returning `undefined` throws the guidance message;
+- `putFile` throws.
+
+Mutation check before merge (per `.claude/rules` "verification must be able
+to fail"): drop the cursor loop and confirm the pagination test goes red.
+
+#### 4.2 Real-runtime test (opt-in)
+
+Miniflare exposes a real R2 implementation to Node/Bun without HTTP:
+`new Miniflare({ modules: true, script: '…', r2Buckets: ['BUCKET'] })` then
+`await mf.getR2Bucket('BUCKET')` returns an `R2Bucket` backed by workerd's
+local R2. `r2-miniflare.test.ts` runs the same conformance block against it,
+gated behind `GUREN_TEST_WRANGLER=1` exactly like
+`wrangler-migrations.test.ts` (network on first run to fetch workerd; skipped
+in CI). This is what catches semantics the fake gets wrong (e.g. what `list`
+returns for `prefix: 'a/'` when only `a` exists, `head` on a zero-byte
+object). **To verify in step 0:** Miniflare 4 under `bun test` — if workerd
+spawning misbehaves under Bun, fall back to `wrangler dev` + a temp worker
+that mounts the driver behind `/put`, `/get`, … and drive it with `fetch`
+(the migrations test already shells out to `bunx wrangler`).
+
+#### 4.3 Dogfooding (a real Workers app)
+
+The same loop RFC 0003 Part 4 ran with the guren.dev site (`web/`), which
+is already deployed on Workers + D1 and is the natural in-repo candidate:
+
+- Bucket + custom domain, `MEDIA` binding, `StorageProvider` switch as in §1.
+- Seeding existing files: `bunx wrangler r2 object put <bucket>/<key>
+  --file …` from a script — the driver has no filesystem access on Workers,
+  and a Bun script has no binding, so initial bulk loads go through wrangler
+  (or the S3 API), not the driver.
+- An authenticated upload path (`this.file()` → `put(buffer, { contentType })`,
+  the storage guide's existing example) exercised through `wrangler dev`, then
+  production.
+- Guard: a `GUREN_TEST_WRANGLER=1` run of §4.2 before the release PR.
+
+### 5. Implementation steps
+
+0. **Spike (½ day, before writing the driver):** against a throwaway R2
+   bucket, (a) run today's `S3Driver` recipe from the storage guide and record
+   whether `PutObject` with `x-amz-acl` succeeds, is ignored, or errors — this
+   decides what the storage-guide edit says; (b) confirm `wrangler deploy`
+   fails for a nonexistent bound bucket (decides §2.1's default); (c) confirm
+   Miniflare's `getR2Bucket` works under `bun test` (decides §4.2's shape).
+1. `R2Driver.ts` + `FakeR2Bucket` + unit tests. Land the driver with
+   `temporaryUrl` throwing unconditionally first if the aws4fetch step slows
+   review; the throw message is the contract either way.
+2. `temporaryUrl` presign path + deterministic test; optional peer dep.
+3. Type-level test against `@cloudflare/workers-types`.
+4. Miniflare e2e (opt-in).
+5. Exports, README, `docs/{en,ja}/guides/{cloudflare,storage}.md`, RFC 0003
+   matrix update, harness SKILL.md line, changeset. Run `bun run
+   audit:core-first` (docs must import from `@guren/core` /
+   `@guren/plugin-cloudflare`, never `@guren/server`) and `bun run
+   audit:docs`.
+6. Release `@guren/plugin-cloudflare@0.3.0` (no other package moves).
+7. Dogfooding (§4.3): bucket, domain, provider switch, seeding, upload path.
+   Anything a real app needs that the driver lacks comes back here as a
+   follow-up.
+
+Steps 1–5 are one PR (`feat(plugin-cloudflare): add R2Driver`); step 6 is the
+release; step 7 is app-side work.
+
+### 6. Documentation notes
+
+- The storage guide's "S3-Compatible Services → Cloudflare R2" block is
+  currently the only R2 mention. After this RFC it should say: on Workers use
+  `R2Driver` (binding, no credentials); from Bun/Lambda/Vercel the S3 API with
+  an R2 token is the route, with the ACL caveat from step 0 spelled out.
+- Both `en` and `ja` guides move together (a lesson recorded from earlier
+  reviews: en/ja drift).
+- No `packages/*` paths or RFC part numbers in user-facing docs
+  (`docs/CLAUDE.md`).
+
+## Alternatives Considered
+
+- **Extend `S3Driver` with an "R2 mode" (skip ACL, presign via aws4fetch).**
+  Keeps one driver, but ships `@aws-sdk/client-s3` in the Worker and still
+  needs a token for every operation when a zero-credential binding is sitting
+  in `env`. Also leaves the plugin with nothing platform-specific to own. The
+  S3-API path stays *documented* for non-Workers runtimes; it just is not the
+  Workers driver.
+- **Put `R2Driver` in `@guren/server` next to `S3Driver`.** It would sit
+  behind the closed `DriverConfig` union and give `driver: 'r2'` for free, but
+  it couples the core release train to Cloudflare surface (RFC 0003 chose the
+  plugin for `createWorkersHandler` for the same reason) and forces the
+  server-side changes of §2.2 onto the critical path.
+- **Register the disk from `cloudflarePlugin({ storage: … })`.** Hides the
+  runtime switch inside the plugin's `boot()` (`container.make('storage')
+  .registerDisk(...)`). Rejected for now: it depends on the app's own
+  `StorageProvider` having bound `'storage'` first, and the D1 precedent is
+  explicit config in `config/*.ts`, not plugin magic. Revisit with §7(a) if the
+  explicit form proves noisy.
+- **Scaffold `r2_buckets` unconditionally in `wrangler.jsonc`.** See §2.1.
+- **Implement per-object visibility by key convention (`public/…` prefix)
+  or `customMetadata`.** Both are conventions the bucket does not enforce;
+  RFC 0010 owns visibility at the blob row where a serving route can enforce
+  it.
+
+## Migration Path
+
+Purely additive. Existing `S3Driver`-on-R2 users can keep the S3 API on
+non-Workers runtimes; on Workers they swap `driver: 's3'` config for a
+`registerDisk('…', () => new R2Driver({ binding, publicUrl }))` call and drop
+the token secrets. No deprecations.
+
+## Open Questions
+
+1. **Strict visibility (§1.3)** — throw on a conflicting `put({ visibility })`
+   is stricter than every other driver. Alternative: warn once per disk and
+   proceed. Leaning throw; the guide's example would then need
+   `visibility` removed from the R2 variant.
+2. **`url()` encoding** — `S3Driver.url` and `LocalDriver.url` do not
+   percent-encode the key. Keys with spaces or `#` produce broken URLs today
+   on every driver; fixing it only in R2 would be inconsistent, fixing it
+   everywhere is a server change. Proposal: match existing drivers here, open
+   a separate issue.
+3. **Should `FakeR2Bucket` be exported** (e.g. from
+   `@guren/plugin-cloudflare/testing`) so app tests can run against R2
+   semantics without Miniflare? Useful for app-level tests; adds a public
+   surface to maintain. Leaning yes, as a subpath export, once the fake has
+   survived §4.2 comparison.
+4. **`deleteMany` return value** — `paths.length` vs. head-then-delete per key
+   (N Class B ops). Leaning `paths.length`, matching what S3 observably does.
+5. **Streaming reads** — an optional `getStream?(path): Promise<ReadableStream
+   | null>` on `StorageDriver` would let RFC 0010's proxy route avoid
+   buffering; it is an additive server change and belongs with RFC 0010, but
+   the R2 driver could implement it ahead of the interface (structural
+   typing). Decide when RFC 0010 lands.
+
+## Follow-ups (not in this RFC)
+
+- (a) `StorageManager`: resolve driver factories lazily in `disk()` so
+  `registerDriver()` after construction serves config-declared disks; error
+  timing moves from construction to first use (needs a test update, not an
+  API change).
+- (b) Augmentable driver registry: `interface StorageDrivers { local: …; s3:
+  …; memory: … }` in `@guren/server`, `DriverConfig` derived from it,
+  `declare module '@guren/server' { interface StorageDrivers { r2:
+  R2DriverOptions } }` in the plugin.
+- (c) `S3Driver` tests — none exist; the ACL-on-R2 finding is the kind of
+  thing they would have caught.
+- (d) `cloudflare:build --with-r2 <BINDING>` if demand shows up.
+- (e) `S3DriverOptions.acl` and the `STORAGE_DISK` scaffold (§2.4) — sibling
+  PRs, tracked separately.
+- (f) `R2Driver` S3-API fallback via aws4fetch (§2.4 option 2) — only if
+  the aws-sdk dependency proves a burden for non-Workers R2 users.
+- (g) RFC 0010: attachments, signed delivery, direct upload, variants.

--- a/rfcs/0009-cloudflare-r2-storage-driver.md
+++ b/rfcs/0009-cloudflare-r2-storage-driver.md
@@ -48,7 +48,7 @@ working assumptions the plan started from:
 |---|---|
 | `StorageDriver` has "about 20 methods" | **21**: `put`, `putFile`, `get`, `getAsString`, `exists`, `delete`, `deleteMany`, `copy`, `move`, `url`, `temporaryUrl`, `size`, `lastModified`, `metadata`, `files`, `directories`, `allFiles`, `makeDirectory`, `deleteDirectory`, `setVisibility`, `getVisibility` (`packages/server/src/storage/types.ts:59-201`). Content is `Buffer \| string`; reads return `Buffer \| null`. |
 | `StorageManager.registerDriver()` is a usable extension point for third-party drivers | Only half true. `registerDriver(name, factory)` exists (`StorageManager.ts:132`), but the constructor resolves every `disks` entry **eagerly** (`registerDiskFromConfig`, `StorageManager.ts:82-94`) and throws `Unknown storage driver: r2` for a driver registered afterwards. `DriverConfig` is also a **closed** union of `'local' \| 's3' \| 'memory'` (`types.ts:293-296`), so `{ driver: 'r2' }` does not type-check. **`registerDisk(name, () => driver)` is the extension point that actually works today** (`StorageManager.ts:123`), and it is what this plan uses. |
-| `S3Driver` dynamically imports `@aws-sdk/client-s3` | Correct — via `importAwsModule()` with a "Missing optional dependency" error (`S3Driver.ts:463-474`). Same pattern is reused here for `aws4fetch`. |
+| `S3Driver` dynamically imports `@aws-sdk/client-s3` | Correct — via `importAwsModule()` with a "Missing optional dependency" error (`S3Driver.ts:463-474`). The plan reused this pattern for the presign dependency; **that was wrong on Workers** — see §1.2. |
 | The Cloudflare plugin uses a lazy `binding: () => getWorkersEnv<Env>().DB` closure | Correct (`packages/orm/src/d1.ts:6-25`, `packages/plugin-cloudflare/src/env.ts`). `getWorkersEnv()` throws before the first request; `web/app/Http/Middleware/site-analytics.ts:90-97` shows the pattern for an *optional* binding (try/catch → undefined off-Workers), and `web/config/database.ts:9-11` the `isWorkersRuntime()` switch (`navigator.userAgent === 'Cloudflare-Workers'`). |
 | `cloudflarePlugin()` registers services | It does not — `register() {}` is empty and `CloudflarePluginConfig` is an empty interface "reserved for upcoming RFC 0003 parts" (`packages/plugin-cloudflare/src/index.ts`). This plan keeps it that way (§2.2). |
 | `cloudflare:build` scaffolds `wrangler.jsonc` | Correct — once, `wx` flag, never overwritten; `warnMissingBuildOwnedKeys` only reports **build-owned** keys (`alias`, `define`, `migrations_dir`) (`build.ts:308-396`). |
@@ -176,7 +176,7 @@ the `r2_buckets` entry in wrangler.jsonc."*
 | `copy(from, to)` | `get(from)` → `put(to, obj.body, { httpMetadata: obj.httpMetadata, customMetadata: obj.customMetadata })` | **No copy on the binding** — stream the body through. `obj === null` throws `File not found: ${from}` (Memory precedent). Single-`put` size limits apply (multipart is out of scope). |
 | `move(from, to)` | `copy` + `delete(from)` | |
 | `url(path)` | `${publicUrl}/${key}` | Throws when `publicUrl` is unset (no derivable default; fail closed rather than return a URL that 404s). No percent-encoding, matching `S3Driver.url` — noted as an Open Question. |
-| `temporaryUrl(path, expiration)` | `aws4fetch` SigV4 presign against `https://${accountId}.r2.cloudflarestorage.com/${bucket}/${key}` with `X-Amz-Expires` | Only when `presign` is configured; else throws *"R2 bindings cannot sign URLs. Either configure `presign: { accountId, bucket, accessKeyId, secretAccessKey }` (an R2 API token) or serve private files through a signed app route."* `aws4fetch` is an **optional** dependency loaded with the `importAwsModule`-style dynamic import (same missing-module error shape). Expiry > 7 days throws up front (R2 rejects it; the S3 driver would only find out from AWS). |
+| `temporaryUrl(path, expiration)` | SigV4 presign on WebCrypto against `https://${accountId}.r2.cloudflarestorage.com/${bucket}/${key}` with `X-Amz-Expires` | Only when `presign` is configured; else throws with guidance naming the option and the signed-route alternative. Expiry > 7 days throws up front (R2 rejects it; the S3 driver would only find out from AWS). **Amended in implementation:** the signer is written in-package, not taken from a dependency — see §1.2. |
 | `size` / `lastModified` | `head(key)` → `size` / `uploaded` | Throw `File not found` on `null` (S3/Memory precedent). |
 | `metadata(path)` | `head(key)` → `{ path, size, lastModified: uploaded, contentType: httpMetadata?.contentType, metadata: customMetadata, visibility }` | `visibility` is the disk's configured value (§1.3). |
 | `files(dir)` | `list({ prefix: `${key}/`, delimiter: '/' })`, loop on `truncated`/`cursor` | Strip prefix; drop keys ending in `/` (S3 precedent, covers `.keep`-style markers only when named so — see `makeDirectory`). |
@@ -197,10 +197,33 @@ Three options were weighed:
    **chosen.** Matches how Cloudflare itself documents presigned URLs for R2
    (client-side SigV4 with an API token; not something a binding can do), and
    keeps the credential-free default: an app that never calls `temporaryUrl()`
-   never needs a token. `aws4fetch` (WebCrypto-based, ~6 KB, Workers-native)
-   is the signer, loaded lazily so it stays out of bundles that do not use it.
-   Hand-rolling SigV4 was rejected: it is 100 lines of easy-to-get-wrong
-   canonicalization for zero benefit over a 6 KB dependency.
+   never needs a token.
+
+   **The signer itself was amended twice in implementation, and the reason is
+   worth recording.** The plan said: use `aws4fetch` (WebCrypto-based, ~11 KB,
+   Workers-native), loaded lazily through the `importAwsModule` pattern so it
+   stays out of bundles that do not use it — and rejected hand-rolling SigV4
+   as "100 lines of easy-to-get-wrong canonicalization for zero benefit over a
+   small dependency". Both halves turned out to be wrong:
+
+   1. **A lazy import with a variable specifier cannot work on Workers.** No
+      Workers bundler can follow `import(moduleName)`, so the presign path
+      threw `No such module` at runtime while every test stayed green (under
+      Bun the same import resolves from `node_modules`). This is invisible to
+      any test that does not run inside workerd — see §4.2. A literal
+      `import('aws4fetch')` bundles correctly but then fails the *build* for
+      every app that never signs a URL, since an optional dependency is not
+      installed.
+   2. **The dependency is dormant.** Last release 2024-08, last commit
+      2024-12, 22 open issues (checked 2026-08-15).
+
+   So the driver signs with WebCrypto directly (`crypto.subtle`, a global on
+   workerd, Bun and Node 18+). R2 presigning is one request shape — GET, no
+   body, `host` the only signed header — which makes the canonicalization
+   ~70 lines, and it leaves nothing for a bundler to resolve. The
+   implementation was cross-checked byte-for-byte against `aws4fetch` on
+   plain, spaced, unicode and RFC-3986-reserved keys before that package was
+   removed; those signatures are frozen as known-answer tests.
 3. **Sign an app route instead** (a Guren-served `/storage/<signed>` URL). This
    is the right long-term answer for *private* files and is exactly RFC 0010's
    signed delivery route — which is why the throw message here points at it.
@@ -349,7 +372,7 @@ through the S3 API. Two options for how Guren exposes that:
    unconditional ACL is a latent bug for every non-AWS S3 target. **Chosen
    as a sibling PR**, not on this RFC's critical path (§2.2) — the R2Driver
    ships without it, and step 0 decides how urgent it is.
-2. **`R2Driver` falls back to the S3 API through `aws4fetch` when the
+2. **`R2Driver` falls back to the S3 API through its own signer when the
    binding is absent and `presign` credentials are set** — one driver
    everywhere, no `@aws-sdk` in the bundle. Rejected for v1: `ListObjectsV2`
    and `DeleteObjects` are XML in and out, so the fallback needs an XML
@@ -367,13 +390,14 @@ persistent bucket is wanted from a Bun process.
 
 | Action | Path | What |
 |---|---|---|
-| add | `packages/plugin-cloudflare/src/storage/R2Driver.ts` | Driver, `R2DriverOptions`, `R2BucketLike` + object/list shapes, `trimSlashes`, `importOptionalModule('aws4fetch')` |
+| add | `packages/plugin-cloudflare/src/storage/R2Driver.ts` | Driver, `R2DriverOptions`, `R2BucketLike` + object/list shapes, `trimSlashes` |
 | add | `packages/plugin-cloudflare/src/storage/R2Driver.test.ts` | Unit tests against an in-memory `FakeR2Bucket` (§4.1) |
 | add | `packages/plugin-cloudflare/src/storage/fake-r2-bucket.ts` | Test double implementing `R2BucketLike` with real `prefix`/`delimiter`/`cursor` semantics; also exported for app tests? — Open Question |
 | add | `packages/plugin-cloudflare/src/storage/R2Driver.types.test.ts` | `R2Bucket` (workers-types) satisfies `R2BucketLike` |
 | add | `packages/plugin-cloudflare/src/storage/r2-miniflare.test.ts` | Opt-in e2e (`GUREN_TEST_WRANGLER=1`) against a real local R2 (§4.2) |
 | edit | `packages/plugin-cloudflare/src/index.ts` | exports |
-| edit | `packages/plugin-cloudflare/package.json` | `peerDependencies: { aws4fetch: "^1" }` + `peerDependenciesMeta: { aws4fetch: { optional: true } }`; devDependency `aws4fetch` for the presign test; devDependency `miniflare` for §4.2 |
+| add | `packages/plugin-cloudflare/src/storage/sigv4.ts` (+ `sigv4.test.ts`) | WebCrypto SigV4 presigning for the one request shape `temporaryUrl()` needs (§1.2) |
+| edit | `packages/plugin-cloudflare/package.json` | devDependency `miniflare` for §4.2. **No runtime dependency is added** |
 | edit | `packages/plugin-cloudflare/README.md` | "Storage (R2)" section under API |
 | edit | `docs/en/guides/cloudflare.md`, `docs/ja/guides/cloudflare.md` | "Storage (R2)" section: binding, `wrangler.jsonc` snippet, `StorageProvider` switch, custom domain, `wrangler r2 object put` for one-off uploads |
 | edit | `docs/en/guides/storage.md`, `docs/ja/guides/storage.md` | Replace the "Cloudflare R2 via `driver: 's3'`" recipe with the binding driver for Workers; keep the S3-API recipe only if step 0 proves it works, and say what it cannot do (ACL) |
@@ -409,7 +433,7 @@ deleteDirectory) against `FakeR2Bucket`, plus the R2-specific behaviours:
 - `temporaryUrl()` without `presign` throws with the RFC 0010 hint; with
   `presign` and a fixed `datetime` produces a URL containing
   `X-Amz-Algorithm=AWS4-HMAC-SHA256`, `X-Amz-Expires=<n>`, `X-Amz-Signature`
-  (aws4fetch accepts `aws: { datetime }`, so the test is deterministic);
+  (the signer takes an injectable clock, so the test is deterministic);
   expiry > 7 days throws before signing;
 - `put({ visibility })` / `setVisibility` matching the disk → no-op,
   conflicting → throw naming the `visibility` option;
@@ -436,7 +460,7 @@ One limit: the binding proxy cannot marshal a `ReadableStream`, so
 block that bundles the driver with `Bun.build` and runs those two methods
 *inside* workerd (`modules: [{ type: 'ESModule', … }]`, since `script:`
 alone makes Miniflare walk the bundle and reject the driver's dynamic
-`import(moduleName)` for the optional aws4fetch dependency), which also
+its import graph itself), which also
 confirms `Buffer` under `nodejs_compat`.
 
 #### 4.3 Dogfooding (a real Workers app)
@@ -463,8 +487,8 @@ is already deployed on Workers + D1 and is the natural in-repo candidate:
    fails for a nonexistent bound bucket (decides §2.1's default); (c) confirm
    Miniflare's `getR2Bucket` works under `bun test` (decides §4.2's shape).
 1. `R2Driver.ts` + `FakeR2Bucket` + unit tests. Land the driver with
-   `temporaryUrl` throwing unconditionally first if the aws4fetch step slows
-   review; the throw message is the contract either way.
+   `temporaryUrl` throwing unconditionally first if the signer slows review;
+   the throw message is the contract either way.
 2. `temporaryUrl` presign path + deterministic test; optional peer dep.
 3. Type-level test against `@cloudflare/workers-types`.
 4. Miniflare e2e (opt-in).
@@ -494,7 +518,7 @@ release; step 7 is app-side work.
 
 ## Alternatives Considered
 
-- **Extend `S3Driver` with an "R2 mode" (skip ACL, presign via aws4fetch).**
+- **Extend `S3Driver` with an "R2 mode" (skip ACL, presign without the SDK).**
   Keeps one driver, but ships `@aws-sdk/client-s3` in the Worker and still
   needs a token for every operation when a zero-credential binding is sitting
   in `env`. Also leaves the plugin with nothing platform-specific to own. The
@@ -563,6 +587,6 @@ the token secrets. No deprecations.
 - (d) `cloudflare:build --with-r2 <BINDING>` if demand shows up.
 - (e) `S3DriverOptions.acl` and the `STORAGE_DISK` scaffold (§2.4) — sibling
   PRs, tracked separately.
-- (f) `R2Driver` S3-API fallback via aws4fetch (§2.4 option 2) — only if
+- (f) `R2Driver` S3-API fallback through its own signer (§2.4 option 2) — only if
   the aws-sdk dependency proves a burden for non-Workers R2 users.
 - (g) RFC 0010: attachments, signed delivery, direct upload, variants.

--- a/rfcs/0010-model-attachments.md
+++ b/rfcs/0010-model-attachments.md
@@ -76,8 +76,7 @@ These shape the design more than any preference does:
 - **Signing runs on Workers today.** `MessageSigner` is `node:crypto`
   (`createHmac`, `timingSafeEqual`), and RFC 0003 §6 verified — and guren.dev
   runs in production — that session-cookie signing works under
-  `nodejs_compat`. **A WebCrypto reimplementation is not needed**; the
-  earlier assumption that signed delivery required one is corrected here.
+  `nodejs_compat`, so signed delivery needs no WebCrypto reimplementation.
 - **Framework-owned tables ship as schema snippets, not migrations.**
   `DatabaseSessionStore` (`packages/core/src/session-store.ts`) takes the
   Drizzle table as `unknown`, documents the column contract in JSDoc and the
@@ -123,7 +122,7 @@ Where a driver lacks a capability, the layer picks the fallback below rather
 than failing — the choice is made once, from a **capability probe on the
 resolved disk** (`typeof disk.getStream === 'function'`, and for presigning a
 try/catch around `temporaryUrl()` at configure time or a per-driver
-declaration; Open Question 11), never from a driver name string, so
+declaration; Open Question 6), never from a driver name string, so
 third-party drivers get the same treatment as built-ins:
 
 | Feature | `local` | `s3` (AWS/MinIO/Spaces…) | `r2` (RFC 0009) | `memory` (tests) | third-party |
@@ -161,7 +160,8 @@ Two tables, Rails-shaped, dialect snippets shipped through docs + JSDoc +
 ```ts
 // sqlite / D1 flavour (pg/mysql snippets differ only in column builders)
 export const storageBlobs = sqliteTable('storage_blobs', {
-  id: text('id').primaryKey(),                       // ULID (sortable, no autoincrement race on D1)
+  id: text('id').primaryKey(),                       // ULID: sortable, no autoincrement race on D1, and
+                                                     // unguessable before a direct-upload id is signed
   key: text('key').notNull().unique(),               // object key on the disk
   disk: text('disk').notNull(),                      // StorageManager disk name
   filename: text('filename').notNull(),
@@ -192,6 +192,8 @@ export const storageAttachments = sqliteTable('storage_attachments', {
   'record')` is a plain relation.
 - Rails' third table (`variant_records`) is not adopted; variants use derived
   keys (§6).
+- The `storage_` prefix keeps both tables clear of app tables and of the
+  mail/notification "attachment" vocabulary already in `@guren/server`.
 
 `configureAttachments()` follows the session-store precedent — tables in,
 models out — plus the storage/signing wiring:
@@ -275,11 +277,9 @@ What the types then enforce, all at compile time:
   `visible` use), so an attachment named `title` on a table with a `title`
   column fails to compile instead of shadowing the column at load time.
 
-The runtime shape is unchanged (`Attachable` still writes
-`static attachments` on the anonymous subclass, which is what codegen and
-`guren check` read; the static-declaration spelling from the earlier draft
-stays *accepted* by the parser but is no longer the documented form). The
-mixin's statics, all keyed on `keyof TAttachments`:
+The runtime shape is `static attachments` on the anonymous subclass, which is
+what codegen and `guren check` read. The mixin's statics, all keyed on
+`keyof TAttachments`:
 
 | Static | Purpose |
 |---|---|
@@ -363,15 +363,17 @@ Rules that make this the security boundary the driver cannot be:
   `X-Content-Type-Options: nosniff`, so a user upload cannot become a
   same-origin script. Overridable per attachment declaration.
 - **Streaming.** Proxy mode uses `disk.getStream(key)` when the driver
-  implements it (RFC 0009 Open Question 5 adds an *optional*
-  `getStream?(path): Promise<ReadableStream | null>` to `StorageDriver`;
-  `R2Driver` returns `obj.body`), falling back to `disk.get()` (buffered)
-  otherwise. Range requests are out of scope for v1 (Open Question 6).
+  implements it. This RFC owns that addition: an optional
+  `getStream?(path): Promise<ReadableStream | null>` on `StorageDriver`
+  (§8), which `R2Driver` satisfies with `obj.body`. Where it is absent the
+  route falls back to `disk.get()` (buffered). Range requests are out of
+  scope for v1 (Open Question 3).
 - **Auth.** The signature *is* the authorization for private blobs (a
-  short-lived capability URL). Apps that need per-request checks (a
-  document only its owner may see, revocable) wrap `attachmentUrl()` in
-  their own controller and set `expiresIn` low; the RFC does not add a
-  second authorization layer to the delivery route.
+  short-lived capability URL). The alternative — an `authorize(blob, ctx)`
+  callback on `registerAttachmentRoutes` for revocable access — is not in
+  v1: apps that need per-request checks wrap `attachmentUrl()` in their own
+  controller and set `expiresIn` low. Revisit if that wrapper turns out to
+  be the common case rather than the exception.
 
 ### 4. Direct upload
 
@@ -413,7 +415,8 @@ POST /storage/direct-uploads      (registered by registerAttachmentRoutes; must 
   manually).
 - **Client helper** (`@guren/inertia-client`): `useDirectUpload({ model,
   name })` returning `{ upload(file) → signedId, progress }`, typed by
-  `AttachmentsMap`. Optional in v1.
+  `AttachmentsMap`. Ships with Part 2, since Part 5 dogfoods an upload UI on
+  it.
 
 ### 5. Lifecycle and purge
 
@@ -428,7 +431,7 @@ POST /storage/direct-uploads      (registered by registerAttachmentRoutes; must 
   breaks pages.
 - Record deletion: **explicit** `Post.purgeAttachments(id)` in the destroy
   action (documented in the guide, scaffolded by `make:feature --attach`?
-  — Open Question 8). A `deleting` hook is registered too, but only as a
+  — Open Question 4). A `deleting` hook is registered too, but only as a
   best-effort: it fires on one of three delete paths and receives the
   where clause, so it purges only when `where` carries the primary key.
   `attachments:purge-orphans` also removes attachment rows whose record no
@@ -505,7 +508,7 @@ buffers a 20 MB original.
 | `@guren/server` | additive optional `StorageDriver.getStream?` and `temporaryUploadUrl?`; `S3Driver` implements both |
 | `@guren/plugin-cloudflare` | `R2Driver.getStream`, `R2Driver.temporaryUploadUrl` (presign only), `CloudflareImagesTransformer` |
 | `@guren/cli` | `add attachments` blueprint, `attachments-types.ts` codegen, `check`/`audit` rules, `spec:generate` edges, `shouldRegenerate` |
-| `@guren/inertia-client` | `useDirectUpload` (optional, later) |
+| `@guren/inertia-client` | `useDirectUpload` (Part 2) |
 
 Release order (per `.claude/rules/common-pitfalls.md`, templates and plugins
 resolve `@guren/*` from npm): server/core additive methods → cli → plugin
@@ -579,42 +582,39 @@ in a column can backfill with `Post.attach(id, 'cover', { path: row.coverKey,
 disk: 'media' })` — no re-upload. No deprecations; the storage API is
 unchanged.
 
+## Follow-ups (not in this RFC)
+
+- **`parseRequestPayload` collapses arrays** (`http/request.ts`), so a
+  multi-file field reaches `validateBody` as its first file only. This RFC
+  routes around it with `this.files()`; changing the payload shape is a
+  server behaviour change with its own blast radius and belongs in its own
+  PR.
+- **A cross-driver `StorageDriver` conformance suite** (local/memory/s3/r2),
+  which §0's matrix currently asserts per-driver.
+
 ## Open Questions
 
 1. **Eager loading:** `Post.with('cover')` needs a per-name filter on
    `morphMany` (a `where` on the relation definition) that `@guren/orm` does
    not have; v1 ships `withAttachments()` instead. Add relation constraints
    to the ORM (general win) or keep the helper?
-2. **Codegen scope in v1:** ship `attachments.gen.ts` in Part 1 or defer to
-   Part 4? Leaning Part 4 — nothing in the model API needs it.
-3. **Checksum:** base64 SHA-256 (WebCrypto everywhere, R2 `sha256` put
+2. **Checksum:** base64 SHA-256 (WebCrypto everywhere, R2 `sha256` put
    option) vs. base64 MD5 (Rails/S3 `Content-MD5` compatible). Leaning
    SHA-256.
-4. **IDs:** ULID text PKs (proposed) vs. autoincrement — D1/SQLite
-   `INSERT … RETURNING` works for both; ULID keeps direct-upload blob ids
-   unguessable before they are signed.
-5. **Table names:** `storage_blobs`/`storage_attachments` vs.
-   `blobs`/`attachments`. Prefixed avoids collisions with app tables and
-   with the mail/notification "attachment" vocabulary.
-6. **Range requests** in proxy mode (video): v1 or later? R2 `get(key, {
+3. **Range requests** in proxy mode (video): v1 or later? R2 `get(key, {
    range })` supports it; the driver's `getStream` would need a range
    argument.
-7. **Delivery-route authorization hook:** is a capability URL enough, or
-   should `registerAttachmentRoutes` accept an `authorize(blob, ctx)`
-   callback for revocable access? Leaning: signature only in v1, low
-   `expiresIn`, document the wrapper pattern.
-8. **`make:feature --attach`** and whether `make:feature`'s destroy action
+4. **`make:feature --attach`** and whether `make:feature`'s destroy action
    should call `purgeAttachments` by default.
-9. **Multi-file `validateBody`:** should `parseRequestPayload` stop
-   collapsing arrays (`request.ts:22`) so `hasManyAttached` fields validate
-   through the normal path? That is a server behaviour change with its own
-   blast radius; the RFC uses `this.files()` and leaves the payload
-   collapse alone.
-10. **Modules (RFC 0002):** a module's model declaring attachments —
+5. **Modules (RFC 0002):** a module's model declaring attachments —
     `guren add attachments --module` scaffolds module-local tables, or all
     modules share the app-level pair? Leaning shared (one `configureAttachments`
     per app), matching the sessions table.
-11. **Capability detection (§0):** optional methods (`getStream?`,
+6. **Capability detection (§0):**
+7. **Variant mode default (§6):** `materialize` off-Workers and `url` on
+    Workers-with-a-custom-domain — but nothing says how that is selected.
+    Same class as the question above; fold it into whichever answer wins
+    there, or require `variants.mode` explicitly. optional methods (`getStream?`,
     `temporaryUploadUrl?`) are probed structurally, but "can `temporaryUrl()`
     produce a real signed URL" is not observable from the type — `LocalDriver`
     returns a plain URL, `R2Driver` throws without `presign`. Options: (a) an

--- a/rfcs/0010-model-attachments.md
+++ b/rfcs/0010-model-attachments.md
@@ -397,8 +397,8 @@ POST /storage/direct-uploads      (registered by registerAttachmentRoutes; must 
   client `PUT`s the bytes straight to the bucket, then submits `signedId`.
   This needs an additive, optional driver method
   `temporaryUploadUrl?(path, expiration, { contentType, checksum })` —
-  `S3Driver` via `PutObjectCommand` + presigner, `R2Driver` via aws4fetch
-  `PUT` — and a **blob "pending" state**: the row is created before the
+  `S3Driver` via `PutObjectCommand` + presigner, `R2Driver` via the WebCrypto
+  signer RFC 0009 §1.2 added (a `PUT` variant of the same shape) — and a **blob "pending" state**: the row is created before the
   bytes exist, and `attach(signedId)` verifies `disk.exists(key)` (and the
   size/checksum via `head`) before flipping it to attached.
 - **Auth is mandatory and app-owned.** `registerAttachmentRoutes` requires

--- a/rfcs/0010-model-attachments.md
+++ b/rfcs/0010-model-attachments.md
@@ -1,0 +1,626 @@
+# RFC: Model Attachments (blobs, signed delivery, direct upload, variants)
+
+**Author:** 7nohe
+**Date:** 2026-08-15
+**Status:** Draft
+
+## Problem
+
+Guren's storage layer is path-oriented (`storage.disk().put(path, buffer)`),
+and that is all it is. Every app that lets a user upload a file writes the
+same code around it — the storage guide's `UploadController` example
+(`docs/en/guides/storage.md`, "Handling Form Uploads") is 30 lines that
+generate a filename, `put()` the bytes, and hand the path back to the caller
+to store in *some* column. What is missing is the layer above the disk:
+
+1. **No model-level attachment.** There is no way to say "a `Post` has a
+   `cover` image and many `images`", load them with the post, or swap one out.
+   The ORM already has polymorphic relations (`morphMany`/`morphTo`,
+   `packages/orm/src/Model.ts:1394`, `:1423`, columns `${morph}Type` /
+   `${morph}Id`), so the *shape* is supported; nothing is built on it.
+2. **Private files are not actually private on two of three drivers.**
+   `LocalDriver.temporaryUrl()` returns the plain public URL
+   (`LocalDriver.ts:145-149`), and R2 bindings cannot presign at all
+   (RFC 0009 §1.2). Only S3 with credentials gives a real expiring URL. The
+   framework already ships a URL signer — `signUrl`/`verifySignedUrl`
+   (`packages/server/src/encryption/signed-url.ts`), HMAC over
+   `pathname + sorted query`, key rotation via `AppKeyring`, purpose-scoped
+   keys via `deriveAppKeyring(keyring, purpose)` — but it has **no production
+   caller** (only `tests/encryption/encryption.test.ts`).
+3. **Visibility cannot be enforced at the driver on R2.** RFC 0009 §1.3
+   settles that the driver refuses per-object visibility it cannot enforce
+   and points here: the place a "private" flag can be *enforced* is a serving
+   route that checks a row before it streams bytes.
+4. **Uploads have no lifecycle.** No orphan cleanup, no purge on detach, no
+   checksum, no direct-to-storage upload, no image variants. Every one of
+   those is a Rails ActiveStorage / Laravel Media Library table stake.
+
+None of this is specific to one backend. The layer proposed here sits on
+`StorageManager` and works against **any registered disk** — `local`, `s3`,
+`memory`, RFC 0009's `r2`, or a third-party `StorageDriver` — and degrades
+predictably where a driver lacks a capability (§0). R2 is the case that
+exposed the gaps most sharply (no presigning, no per-object ACL), which is
+why this RFC is sequenced after RFC 0009 and why the two are designed as one
+system split at the driver boundary; it is not the only target.
+
+### Verified constraints (2026-08-15, against the code)
+
+These shape the design more than any preference does:
+
+- **Model records are plain objects, statics are the API.** `Post.find(1)`
+  returns a `PlainObject`; relations are declared with static registrars
+  (`Post.morphMany('comments', Comment, 'commentable')`) plus a type-level
+  `static relationTypes`. There is no instance-method surface to hang
+  `post.cover.attach()` on. Mixins compose as `class Post extends
+  SoftDeletes(defineModel(posts))` (`packages/orm/src/SoftDeletes.ts:62`).
+- **There is no relation write API** (`attach`/`detach`/`sync` do not exist
+  on `Model` or `QueryBuilder`); this layer inserts its own rows.
+- **`Model.morphMap` is read off the base class** (`Model.ts:2340`:
+  `const morphMap = Model.morphMap ?? {}`), i.e. one app-wide registry, and
+  nested eager loading through `morphTo` throws (`Model.ts:2099-2102`).
+  `loadMorphMany` stores `this.name` (the class name) as the type
+  (`Model.ts:2304`) — consistent with the "never mangle class names" rule in
+  `.claude/rules/common-pitfalls.md`.
+- **Delete hooks are not a purge trigger.** `deleting`/`deleted` fire only on
+  the `Model.delete(where)` path (`Model.ts:1820-1850`), receive the *where
+  clause* rather than the deleted row (`whereData`), and do not fire from
+  `QueryBuilder.delete()` or the `SoftDeletes` override
+  (`SoftDeletes.ts:90`). Purge has to be explicit or swept.
+- **Uploads:** `Controller.file(name)` / `Controller.files(name)`
+  (`Controller.ts:189-205`) return web-standard `File`s via
+  `parseBody({ all: true })`; `parseRequestPayload` (`http/request.ts:11-27`)
+  collapses arrays to `value[0]`, so `validateBody` sees only the first file
+  of a multi-file field. Validation rules `file()`/`image()`/`mimes()`
+  (`http/validation/rules.ts:671, 712, 747`) accept a structural `FileLike`.
+  There is no `UploadedFile` abstraction.
+- **Signing runs on Workers today.** `MessageSigner` is `node:crypto`
+  (`createHmac`, `timingSafeEqual`), and RFC 0003 §6 verified — and guren.dev
+  runs in production — that session-cookie signing works under
+  `nodejs_compat`. **A WebCrypto reimplementation is not needed**; the
+  earlier assumption that signed delivery required one is corrected here.
+- **Framework-owned tables ship as schema snippets, not migrations.**
+  `DatabaseSessionStore` (`packages/core/src/session-store.ts`) takes the
+  Drizzle table as `unknown`, documents the column contract in JSDoc and the
+  guides, and absorbs dialect variance through an option (`dataMode:
+  'json' | 'text'`). `make-auth.ts` is the one generator that patches
+  `db/schema.ts` per dialect (via `packages/cli/src/patch-helpers.ts`).
+- **Codegen is extensible mechanically.** `.guren/*.gen.ts` generators live
+  in `packages/cli/src/*-types.ts`, are orchestrated by `codegenCommand`
+  (`bin.ts:912-987`), and re-run from the Vite plugin's `shouldRegenerate`
+  (`packages/cli/src/vite/route-types.ts:180`). `model-parser.ts` exposes
+  `findStaticClassProperty(classDecl, name)` (`:192`) — a `static
+  attachments = {...}` declaration is directly readable.
+- **Name collision:** `MailAttachment`, `NotificationAttachment`,
+  `SlackAttachment` are already exported from `@guren/server`. This RFC does
+  not export a bare `Attachment`.
+- **Cloudflare Images binding** (verified): `env.IMAGES.input(stream)
+  .transform({ width })...output({ format }).response()`; billed per unique
+  transformation. Zone-level `/cdn-cgi/image/<options>/<path>` also exists.
+
+## Proposed Solution
+
+Everything lives in **`@guren/core`** under `packages/core/src/attachments/`
+— it needs `@guren/orm` (`Model`) and `@guren/server` (storage, signing,
+router) at once, and RFC 0003 already established `@guren/core` as the home
+for exactly that kind of glue (`DatabaseSessionStore`, `DatabaseApiTokenStore`).
+Cloudflare-specific pieces (the Images transformer) go to
+`@guren/plugin-cloudflare`. Opt-in via `bunx guren add attachments`. Nothing
+here is required to use RFC 0009's driver.
+
+### 0. Storage-agnostic by construction
+
+The attachment layer never touches a driver directly. It resolves a disk by
+name from the app's `StorageManager` (`storage: () => container.make('storage')`,
+`disk: 'media'`) and speaks only the `StorageDriver` contract
+(`put`/`get`/`delete`/`deleteMany`/`exists`/`metadata`/`url`/`temporaryUrl`,
+plus the two *optional* additions this RFC proposes: `getStream?` and
+`temporaryUploadUrl?`). Every blob row records the `disk` it lives on, so an
+app can keep avatars on `local` and videos on `s3`, or switch disks per
+environment (the storage guide's existing `local` in dev / `s3` in production
+split), and the same `Post.attach()` / `attachmentUrl()` calls keep working.
+
+Where a driver lacks a capability, the layer picks the fallback below rather
+than failing — the choice is made once, from a **capability probe on the
+resolved disk** (`typeof disk.getStream === 'function'`, and for presigning a
+try/catch around `temporaryUrl()` at configure time or a per-driver
+declaration; Open Question 11), never from a driver name string, so
+third-party drivers get the same treatment as built-ins:
+
+| Feature | `local` | `s3` (AWS/MinIO/Spaces…) | `r2` (RFC 0009) | `memory` (tests) | third-party |
+|---|---|---|---|---|---|
+| Public blob URL (`attachmentUrl`) | `disk.url()` (`/storage/...`, via `storage:link` or a static route) | `disk.url()` (bucket/CDN URL) | `disk.url()` (custom domain / r2.dev) | `disk.url()` (`memory://`) | `disk.url()` |
+| Private blob URL | signed app route, **proxy** (nothing to redirect to) | signed app route → **redirect** to `temporaryUrl()` (presigned GET), or proxy | signed app route → redirect to presigned URL **if `presign` configured**, else **proxy** through the binding | proxy | redirect if `temporaryUrl()` works, else proxy |
+| Proxy body | `getStream()` if the driver adds it, else `get()` buffered | `getStream()` (SDK `Body` stream) | `getStream()` (`obj.body`) | `get()` | `getStream()` if present, else `get()` |
+| Direct upload | Worker/server-mediated (multipart → `put`) | **presigned PUT** via `temporaryUploadUrl()`, or mediated | presigned PUT if `presign` configured, else mediated | mediated | presigned if `temporaryUploadUrl` present, else mediated |
+| Visibility | enforced by the blob row + route (the driver's own `setVisibility` is *not* consulted) | same; the layer does not call `PutObjectAcl` | same (the driver would throw on a conflict; the layer never asks) | same | same |
+| Purge | `deleteMany` | `deleteMany` (1000-key batches inside the driver) | `deleteMany` (1000-key batches) | `deleteMany` | `deleteMany` |
+| Variants | `materialize` with `SharpTransformer` (Bun/Node/Lambda) | `materialize` with `SharpTransformer` | `url` (Cloudflare Image Resizing) or `materialize` with `CloudflareImagesTransformer` / any transformer | `materialize` with any transformer | `materialize` with any transformer |
+
+Two consequences worth stating:
+
+- **`local` gains a private-file story it never had.** Today
+  `LocalDriver.temporaryUrl()` returns the plain URL; with this layer a
+  private blob on the local disk is only reachable through the signed
+  proxy route, in dev and in production alike.
+- **`s3` keeps its presigning advantages** — redirect delivery and direct
+  browser→bucket uploads — and gets the same model API, purge, and variants
+  as everything else. Nothing in this RFC makes S3 users go through the
+  app for bytes.
+
+The one thing the layer does *not* abstract is filesystem ingestion:
+`Post.attach(id, name, { path, disk })` adopts an object that already exists
+on the disk; there is no `attachFromLocalPath` because `putFile` is
+unsupported on two of the four built-in drivers (memory, r2).
+
+### 1. Data model
+
+Two tables, Rails-shaped, dialect snippets shipped through docs + JSDoc +
+`guren add attachments` (which patches `db/schema.ts` with the
+`make-auth.ts` toolkit):
+
+```ts
+// sqlite / D1 flavour (pg/mysql snippets differ only in column builders)
+export const storageBlobs = sqliteTable('storage_blobs', {
+  id: text('id').primaryKey(),                       // ULID (sortable, no autoincrement race on D1)
+  key: text('key').notNull().unique(),               // object key on the disk
+  disk: text('disk').notNull(),                      // StorageManager disk name
+  filename: text('filename').notNull(),
+  contentType: text('content_type'),
+  byteSize: integer('byte_size').notNull(),
+  checksum: text('checksum'),                        // base64 sha256 (Open Q. 3)
+  visibility: text('visibility').notNull().default('private'), // enforced by §3, not the disk
+  metadata: text('metadata', { mode: 'json' }).$type<Record<string, unknown>>(),
+  createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+})
+
+export const storageAttachments = sqliteTable('storage_attachments', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),                      // 'cover', 'images'
+  recordType: text('record_type').notNull(),         // model class name (morph convention)
+  recordId: text('record_id').notNull(),             // text: covers int and uuid PKs
+  blobId: text('blob_id').notNull().references(() => storageBlobs.id),
+  position: integer('position').notNull().default(0),
+  createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+}, (t) => [uniqueIndex('storage_attachments_uniq').on(t.recordType, t.recordId, t.name, t.blobId)])
+```
+
+- `visibility` lives on the **blob row** — that is where §3 can enforce it,
+  and it is what RFC 0009's driver refuses to fake.
+- `recordType` follows the ORM's morph convention (class name), so
+  `Attachment.morphTo('record', 'record')` works with the existing
+  `Model.morphMap`, and `Post.morphMany('attachments', StorageAttachment,
+  'record')` is a plain relation.
+- Rails' third table (`variant_records`) is not adopted; variants use derived
+  keys (§6).
+
+`configureAttachments()` follows the session-store precedent — tables in,
+models out — plus the storage/signing wiring:
+
+```ts
+// config/attachments.ts
+import { configureAttachments } from '@guren/core'
+import { storageBlobs, storageAttachments } from '@/db/schema'
+
+export const attachments = configureAttachments({
+  tables: { blobs: storageBlobs, attachments: storageAttachments },
+  storage: () => container.make('storage'),      // StorageManager, resolved lazily
+  disk: 'media',                                 // default disk for new blobs
+  keyring: () => deriveAppKeyring(getAppKeyringFromEnv(), 'attachments'),
+  delivery: { mode: 'proxy', routePrefix: '/storage', expiresIn: 5 * 60 * 1000 },
+  purge: 'inline',                               // or 'queue' → PurgeBlobJob
+  jsonMode: 'json',                              // 'text' for plain-text metadata columns
+})
+```
+
+### 2. Model API
+
+The declaration is passed **into the mixin**, so the attachment names, kinds,
+and variant names are inferred as generics — no `as const`, no codegen, no
+static the subclass has to spell out. This is the same inference
+`defineModel(table, { fillable: [...] })` already relies on for its typed
+options (`Model.ts:2697`), and it composes with other mixins the way
+`SoftDeletes` does:
+
+```ts
+import { Attachable, hasOneAttached, hasManyAttached } from '@guren/core'
+
+export class Post extends Attachable(defineModel(posts), {
+  cover: hasOneAttached({
+    visibility: 'public',
+    accepts: ['image/*'],
+    maxSize: '5mb',
+    variants: { thumb: { width: 320 }, og: { width: 1200, height: 630, fit: 'cover' } },
+  }),
+  images: hasManyAttached({ visibility: 'public', accepts: ['image/*'] }),
+  draftPdf: hasOneAttached(),            // private by default, any type
+}) {}
+
+// Also legal, and equivalent:
+export class Post extends SoftDeletes(Attachable(defineModel(posts), { ... })) {}
+```
+
+Signature sketch:
+
+```ts
+type AttachmentSpec<Kind extends 'one' | 'many', V extends string = never> = {
+  kind: Kind; visibility: 'public' | 'private'; accepts?: string[]; maxSize?: number
+  variants?: Record<V, VariantSpec>
+}
+declare function hasOneAttached<const V extends string = never>(o?: {...; variants?: Record<V, VariantSpec>}): AttachmentSpec<'one', V>
+declare function hasManyAttached<const V extends string = never>(o?: {...}): AttachmentSpec<'many', V>
+
+declare function Attachable<
+  TBase extends typeof Model,
+  const TAttachments extends Record<string, AttachmentSpec<'one' | 'many', string>>,
+>(Base: TBase, attachments: TAttachments): TBase & AttachableStatic<TAttachments>
+```
+
+What the types then enforce, all at compile time:
+
+- **Names:** `Post.attach(id, 'covr', file)` is an error; the second
+  argument is `keyof TAttachments`.
+- **Kinds:** `withAttachments([post], ['cover', 'images'])` returns
+  `{ cover: AttachedFile | null; images: AttachedFile[] }` — `hasOne` is
+  nullable-single, `hasMany` is an array; `detach(id, 'cover', attachmentId)`
+  rejects the third argument on a `hasOne`.
+- **Variants:** `attachmentUrl(post, 'cover', { variant: 'thumb' })` accepts
+  only the names declared on `cover`; `{ variant: 'thumb' }` on `images` is
+  an error because it declared none (`V = never`). Ad-hoc `{ variant: {
+  width: 800 } }` remains allowed as an object.
+- **Records:** `withAttachments(records, names)` requires `records` to be
+  `TBase`'s record type, so passing a `User[]` to `Post.withAttachments` is
+  an error.
+- **Attribute collision:** `TAttachments` keys are checked against the
+  table's column names (`RecordKey<TTable>` — the same helper `hidden`/
+  `visible` use), so an attachment named `title` on a table with a `title`
+  column fails to compile instead of shadowing the column at load time.
+
+The runtime shape is unchanged (`Attachable` still writes
+`static attachments` on the anonymous subclass, which is what codegen and
+`guren check` read; the static-declaration spelling from the earlier draft
+stays *accepted* by the parser but is no longer the documented form). The
+mixin's statics, all keyed on `keyof TAttachments`:
+
+| Static | Purpose |
+|---|---|
+| `Post.attach(recordId, 'cover', source, opts?)` | `source`: `File`, `Blob`, `Buffer`, `{ path, disk }` for an already-stored key, or a **signed blob id** from §4. `hasOne` replaces (old blob purged per §5), `hasMany` appends. Inserts blob + attachment rows and `put()`s the bytes. |
+| `Post.detach(recordId, 'images', attachmentId?)` | Removes the attachment row; purges the blob if it has no other attachments. |
+| `Post.withAttachments(records, ['cover', 'images'])` | Batch-loads attachments + blobs for a page of records (`recordType` = class name, `recordId IN (...)`, `name IN (...)`), returning records with `cover: AttachedFile \| null`, `images: AttachedFile[]`. This is the v1 eager-load story; `Post.with('cover')` integration is Open Question 1. |
+| `Post.attachmentUrl(record \| recordId, 'cover', { variant?, expiresIn? })` | Public blob → `disk.url(key)`; private → signed §3 URL. |
+| `Post.purgeAttachments(recordId)` | Explicit purge for record deletion (hooks are not a reliable trigger — see constraints). |
+
+**Why not `defineModel(posts, { attachments: {...} })`?** It would infer
+just as well, but `defineModel` lives in `@guren/orm`, which must not know
+about storage or signing (`packages/orm/CLAUDE.md`: no `@guren/server`
+imports); the mixin keeps the ORM ignorant and lets `@guren/core` own the
+feature, exactly as `DatabaseSessionStore` does. Recorded as Alternatives.
+
+`AttachedFile` (the resource-facing shape, also the `Data.*` type in
+resources) is `{ id, name, filename, contentType, byteSize, checksum,
+visibility, url, variants?: Record<string, string> }`. Not named
+`Attachment` (collision).
+
+**Codegen (`.guren/attachments.gen.ts`)** is where cross-boundary typing
+comes from — the model itself is typed by `this`, but pages, resources, the
+API client, and `guren check` cannot see `typeof Post.attachments`:
+
+```ts
+// Generated by `guren codegen` — DO NOT EDIT
+export interface AttachmentsMap {
+  Post: { cover: 'one'; images: 'many'; draftPdf: 'one' }
+}
+export type AttachmentName<M extends keyof AttachmentsMap> = keyof AttachmentsMap[M]
+```
+
+Generator `packages/cli/src/attachments-types.ts` (shape of `data-types.ts`,
+discovery via `discoverParsedModels()`; the declaration is the second
+argument of the `Attachable(...)` call in the class's heritage clause, which
+`model-parser.ts` already walks to unwrap mixins around `defineModel`
+(`findDefineModelCall`, `:234`) — a `findMixinCall(classDecl, 'Attachable')`
+sibling reads it; conservative "unreadable ⇒ skip with warning" like the rest
+of the parser); wired into `codegenCommand` and into `shouldRegenerate`
+for `app/Models/**` and `modules/*/app/Models/**`. Consumers: the direct-upload
+client (§4) types its `{ model, name }` pair; `guren check` reports models
+that declare attachments in an app with no `configureAttachments()`;
+`spec:generate`'s ER/domain views render attachment edges; `guren context
+Post` lists them.
+
+### 3. Signed delivery routes — private files on every driver
+
+`registerAttachmentRoutes(router, attachments)` mounts, under
+`delivery.routePrefix`:
+
+| Route | Behaviour |
+|---|---|
+| `GET /storage/blobs/:signedId/:filename` | Verify with `verifySignedUrl` (purpose-scoped keyring, `requireExpiration: true`); resolve blob; **redirect mode**: 302 to `disk.temporaryUrl(key, exp)` when the disk can sign (S3, R2 with `presign`), else to `disk.url(key)` for public blobs; **proxy mode**: stream the object with `Content-Type`, `Content-Disposition`, `ETag`, `Cache-Control: private, max-age=<remaining>`. |
+| `GET /storage/variants/:signedId/:filename` | §6 — same verification, then serve (or lazily materialize) the variant. |
+
+Rules that make this the security boundary the driver cannot be:
+
+- **The signed URL is the temporary URL, on every driver.** A private
+  blob's URL is always `signUrl('/storage/blobs/<id>/<filename>', keyring,
+  { expiresIn })`. What happens *behind* the signature is the per-driver
+  choice from §0: redirect to a presigned URL where the disk can produce one
+  (S3, R2 with `presign`), otherwise proxy the bytes (local, memory, R2 via
+  the binding). Local disks, whose `temporaryUrl()` is not a signature at
+  all, and R2 bindings, which cannot presign, both become private-capable
+  through the same route; S3 apps keep redirecting to the bucket. This is
+  why RFC 0009 could refuse to fake presigning: the two RFCs are one design
+  split at the driver boundary.
+- **Public blobs never touch the route.** `attachmentUrl()` returns
+  `disk.url(key)` for `visibility: 'public'` — CDN-cacheable, zero app CPU,
+  on any driver that has a public base URL.
+- **Signature payload** = `{ blobId, disposition, variant? }` via
+  `MessageSigner` claims (`iat`, `exp`, `purpose: 'attachments'`); the
+  keyring is `deriveAppKeyring(root, 'attachments')` so a leaked signed URL
+  key cannot forge sessions and vice-versa. `filename` is not signed and is
+  only used for `Content-Disposition` (Rails does the same); it is
+  sanitized (`filename*` RFC 5987 encoding, no path separators).
+- **Inline vs. attachment.** Inline only for an allowlist (`image/png`,
+  `image/jpeg`, `image/gif`, `image/webp`, `image/avif`, `application/pdf`,
+  `video/mp4`, `audio/mpeg`, `text/plain`); everything else — notably
+  `image/svg+xml` and `text/html` — is forced to `attachment` with
+  `X-Content-Type-Options: nosniff`, so a user upload cannot become a
+  same-origin script. Overridable per attachment declaration.
+- **Streaming.** Proxy mode uses `disk.getStream(key)` when the driver
+  implements it (RFC 0009 Open Question 5 adds an *optional*
+  `getStream?(path): Promise<ReadableStream | null>` to `StorageDriver`;
+  `R2Driver` returns `obj.body`), falling back to `disk.get()` (buffered)
+  otherwise. Range requests are out of scope for v1 (Open Question 6).
+- **Auth.** The signature *is* the authorization for private blobs (a
+  short-lived capability URL). Apps that need per-request checks (a
+  document only its owner may see, revocable) wrap `attachmentUrl()` in
+  their own controller and set `expiresIn` low; the RFC does not add a
+  second authorization layer to the delivery route.
+
+### 4. Direct upload
+
+Two shapes, chosen by disk capability, both behind one endpoint:
+
+```
+POST /storage/direct-uploads      (registered by registerAttachmentRoutes; must be behind app auth — see below)
+```
+
+- **App-mediated (default; works on every driver).** Multipart `file` (+ `model`, `name`
+  typed via `AttachmentsMap`). The route validates with the existing
+  `file()`/`image()` rules against the declaration's `accepts`/`maxSize`,
+  computes the checksum server-side, creates the blob row, `put()`s the
+  bytes, and returns `{ signedId, attachedFile }`. The form then submits
+  `signedId` and the controller calls `Post.attach(id, 'cover', signedId)`
+  — a signed id is a `MessageSigner` token over `{ blobId }` with purpose
+  `'attachments:direct-upload'` and a short expiry, so a client cannot
+  attach an arbitrary blob. This is the path for `local`, `memory`, and R2
+  without credentials; the request body limit is whatever the runtime
+  imposes (Workers: 100 MB Free / 500 MB Paid), documented.
+- **Presigned (S3, or R2 with `presign`).** JSON `{ filename, contentType,
+  byteSize, checksum }` → returns `{ signedId, uploadUrl, headers }`; the
+  client `PUT`s the bytes straight to the bucket, then submits `signedId`.
+  This needs an additive, optional driver method
+  `temporaryUploadUrl?(path, expiration, { contentType, checksum })` —
+  `S3Driver` via `PutObjectCommand` + presigner, `R2Driver` via aws4fetch
+  `PUT` — and a **blob "pending" state**: the row is created before the
+  bytes exist, and `attach(signedId)` verifies `disk.exists(key)` (and the
+  size/checksum via `head`) before flipping it to attached.
+- **Auth is mandatory and app-owned.** `registerAttachmentRoutes` requires
+  `directUpload: { middleware: [...] }` (e.g. the app's `auth` alias); the
+  RFC does not ship an unauthenticated upload endpoint, and `guren audit`
+  should flag a direct-upload route with no auth middleware the same way it
+  flags mutating routes today.
+- **Orphans.** Blobs uploaded but never attached are swept by
+  `attachments:purge-unattached --older-than 24h` (console command; a Job
+  on runtimes with a queue worker; a Cron Trigger on Workers once RFC 0003
+  §7's scheduled export exists — until then, run it from CI or `wrangler`
+  manually).
+- **Client helper** (`@guren/inertia-client`): `useDirectUpload({ model,
+  name })` returning `{ upload(file) → signedId, progress }`, typed by
+  `AttachmentsMap`. Optional in v1.
+
+### 5. Lifecycle and purge
+
+- `attach` on `hasOne` replaces: new blob committed, then old attachment
+  removed and old blob purged (if unreferenced). Order: write-then-purge, so
+  a failed put never leaves the record without a cover.
+- `detach` / `purgeAttachments` delete rows first, then storage objects
+  (`disk.deleteMany`, chunked by the driver). A storage failure after the
+  row delete leaves an orphan object, not a dangling row — the sweeper
+  `attachments:purge-orphans` reconciles by listing under the blob key
+  prefix. The reverse order would leave rows pointing at nothing, which
+  breaks pages.
+- Record deletion: **explicit** `Post.purgeAttachments(id)` in the destroy
+  action (documented in the guide, scaffolded by `make:feature --attach`?
+  — Open Question 8). A `deleting` hook is registered too, but only as a
+  best-effort: it fires on one of three delete paths and receives the
+  where clause, so it purges only when `where` carries the primary key.
+  `attachments:purge-orphans` also removes attachment rows whose record no
+  longer exists (resolving `recordType` through `Model.morphMap`).
+- `purge: 'queue'` dispatches `PurgeBlobJob` instead of deleting inline —
+  for Bun/Lambda where a queue worker exists; Workers stays inline.
+- SoftDeletes: soft-deleting a record leaves attachments untouched
+  (restore must work); `forceDelete` paths call `purgeAttachments`.
+
+### 6. Variants (pluggable transformers)
+
+```ts
+export interface ImageTransformer {
+  supports(contentType: string): boolean
+  transform(
+    input: ReadableStream<Uint8Array> | Uint8Array,
+    spec: VariantSpec,                                    // { width?, height?, fit?, format?, quality? }
+  ): Promise<{ body: ReadableStream<Uint8Array> | Uint8Array; contentType: string }>
+}
+```
+
+Declared per attachment (`variants: { thumb: { width: 320 } }`) or ad hoc
+(`attachmentUrl(post, 'cover', { variant: { width: 800 } })`); named specs
+are what codegen can type. Two delivery strategies, chosen by
+`variants.mode`:
+
+- **`materialize` (default off-Workers).** `/storage/variants/:signedId/…`
+  transforms on first request and stores the result under a derived key
+  `variants/<blob.key>/<sha256(spec)>.<ext>` on the same disk; later hits
+  `head()` and serve. No `variant_records` table — the key is the record.
+  Transformers: `SharpTransformer` (optional `sharp` dep, Bun/Node/Lambda;
+  **not Workers**), and `CloudflareImagesTransformer` in
+  `@guren/plugin-cloudflare` (the `IMAGES` binding, verified API; billed per
+  unique transformation, so materializing keeps repeat cost at zero).
+- **`url` (default on Workers with a custom domain).** No transform in the
+  app: `attachmentUrl()` returns
+  `https://media.example.com/cdn-cgi/image/width=320,format=auto/<key>` —
+  Cloudflare's zone-level Image Resizing does the work at the edge, only
+  for public blobs (private ones fall back to `materialize`). Zero CPU in
+  the Worker; the right default for image-heavy public sites on Cloudflare.
+  Nothing Cloudflare-specific leaks into the interface: `url` mode is a
+  `UrlTransformer` (`variantUrl(publicUrl, spec) → string`) that any CDN
+  with URL-based resizing (imgix, Cloudinary fetch URLs, Fastly IO) can
+  implement.
+
+The transformer interface deliberately takes a stream so a Worker never
+buffers a 20 MB original.
+
+### 7. CLI, docs, harness
+
+- `bunx guren add attachments`: patches `db/schema.ts` (per dialect,
+  `patch-helpers.ts`), writes `config/attachments.ts` and
+  `app/Providers/AttachmentsProvider.ts` (which calls
+  `registerAttachmentRoutes`), wires the provider (`wireProviders`, as the
+  `storage` blueprint does in `blueprints.ts`), prints the `guren db:make`
+  step. `--module <name>` for RFC 0002 modules.
+- `make:feature Post --fields ... --attach cover:one,images:many` (Open
+  Question 8).
+- `guren check`: models declaring `attachments` without
+  `configureAttachments()`; a `configureAttachments()` whose tables are
+  missing from `db/schema.ts`.
+- `guren audit`: unauthenticated direct-upload route.
+- Docs: `docs/{en,ja}/guides/attachments.md`; storage guide cross-link;
+  Cloudflare guide "Storage (R2)" section gains an "Attachments on Workers"
+  subsection (proxy mode, `url` variants, body limits).
+- Harness: `guren-api` SKILL storage section + a rule line; the RFC 0008
+  targets get it through the shared canonical content.
+
+### 8. Where the pieces land
+
+| Package | Adds |
+|---|---|
+| `@guren/core` | `packages/core/src/attachments/{index,configure,attachable,models,routes,signed-ids,purge,variants,transformers/sharp}.ts`; exports `configureAttachments`, `Attachable`, `hasOneAttached`, `hasManyAttached`, `registerAttachmentRoutes`, `AttachedFile`, `ImageTransformer`, `PurgeBlobJob` |
+| `@guren/server` | additive optional `StorageDriver.getStream?` and `temporaryUploadUrl?`; `S3Driver` implements both |
+| `@guren/plugin-cloudflare` | `R2Driver.getStream`, `R2Driver.temporaryUploadUrl` (presign only), `CloudflareImagesTransformer` |
+| `@guren/cli` | `add attachments` blueprint, `attachments-types.ts` codegen, `check`/`audit` rules, `spec:generate` edges, `shouldRegenerate` |
+| `@guren/inertia-client` | `useDirectUpload` (optional, later) |
+
+Release order (per `.claude/rules/common-pitfalls.md`, templates and plugins
+resolve `@guren/*` from npm): server/core additive methods → cli → plugin
+uses `getStream`. The plugin's `compatibility` range must still admit the
+core line that carries `configureAttachments`.
+
+### Implementation plan
+
+1. **Part 1 — core:** tables + `configureAttachments` + `Attachable`
+   (`attach`/`detach`/`withAttachments`/`attachmentUrl`/`purgeAttachments`)
+   + signed delivery routes (proxy + redirect) + `guren add attachments` +
+   docs. Verified against `local`, `memory`, `s3` (MinIO in CI or the
+   opt-in live test) and `r2` (RFC 0009's Miniflare harness) from day one,
+   so the §0 matrix is a test table, not a promise.
+2. **Part 2 — direct upload:** app-mediated endpoint + signed ids +
+   orphan sweeper; presigned variant with `temporaryUploadUrl` on S3 and
+   R2(+presign); `audit` rule.
+3. **Part 3 — variants:** `ImageTransformer`, `materialize`/`url` modes,
+   `SharpTransformer`, `CloudflareImagesTransformer`.
+4. **Part 4 — tooling:** `attachments.gen.ts` codegen, `check` rules,
+   `spec:generate` edges, `guren context <Entity>` listing, harness content.
+5. **Part 5 — dogfooding + hardening:** a real app's upload UI on
+   `useDirectUpload` (the guren.dev CMS in `web/` is the in-repo
+   candidate), Range support if needed, `make:feature --attach`.
+
+Each part is one PR referencing this RFC; Parts 2–4 are independent of each
+other once Part 1 lands.
+
+## Alternatives Considered
+
+- **Keep the status quo (path-oriented storage + a column).** Zero new
+  surface, but every app rewrites upload/URL/purge, private files stay
+  unprotected on local and R2, and visibility is a lie on R2.
+- **Make it R2/Workers-only (ship it inside `@guren/plugin-cloudflare`).**
+  Would avoid the `@guren/core` release, but every mechanism here (rows,
+  signed routes, purge, variants) is driver-independent, and local dev needs
+  it as much as production does; a Cloudflare-only attachment layer would
+  force apps to write a second one for `bun run dev`.
+- **Presign everything, no app-served route.** Impossible on R2 bindings
+  without a token, and `LocalDriver` has nothing to presign; a serving route
+  is required anyway for local dev, so it becomes the common path.
+- **Instance-method API (`post.cover.attach(file)`).** Reads well but
+  Guren records are plain objects; the whole ORM is static-first
+  (`Post.where()`, `Post.morphMany()`), and an instance wrapper would be the
+  first of its kind. Statics keyed on `keyof This['attachments']` give the
+  same type safety.
+- **Codegen as the *only* typing mechanism.** Rejected: generic inference on
+  the mixin argument works without a build step; codegen is kept for what
+  only it can do (cross-boundary maps, check/spec).
+- **`static attachments = {...} as const` on the subclass** (the first
+  draft). Infers too, but needs `as const`, cannot check attachment names
+  against table columns, and lets a subclass forget the static entirely
+  while still extending `Attachable`. Passing the declaration to the mixin
+  removes all three.
+- **`defineModel(posts, { attachments })`.** Best ergonomics, but puts a
+  storage concept into `@guren/orm`, which is kept free of server
+  dependencies by design.
+- **Put it in `@guren/orm`.** It needs storage, signing, and a router;
+  RFC 0003 already made the call that such glue lives in `@guren/core`.
+- **A `variant_records` table (Rails 7).** Derived keys + `head()` are
+  enough, and it is one fewer table users must add to `db/schema.ts`.
+- **Visibility in driver `customMetadata`.** Rejected in RFC 0009 §1.3 — a
+  convention the bucket does not enforce.
+- **Purge purely via model hooks.** Verified unreliable (see constraints);
+  hooks are best-effort, explicit + sweeper is the contract.
+
+## Migration Path
+
+Additive and opt-in (`guren add attachments`). Apps that already store keys
+in a column can backfill with `Post.attach(id, 'cover', { path: row.coverKey,
+disk: 'media' })` — no re-upload. No deprecations; the storage API is
+unchanged.
+
+## Open Questions
+
+1. **Eager loading:** `Post.with('cover')` needs a per-name filter on
+   `morphMany` (a `where` on the relation definition) that `@guren/orm` does
+   not have; v1 ships `withAttachments()` instead. Add relation constraints
+   to the ORM (general win) or keep the helper?
+2. **Codegen scope in v1:** ship `attachments.gen.ts` in Part 1 or defer to
+   Part 4? Leaning Part 4 — nothing in the model API needs it.
+3. **Checksum:** base64 SHA-256 (WebCrypto everywhere, R2 `sha256` put
+   option) vs. base64 MD5 (Rails/S3 `Content-MD5` compatible). Leaning
+   SHA-256.
+4. **IDs:** ULID text PKs (proposed) vs. autoincrement — D1/SQLite
+   `INSERT … RETURNING` works for both; ULID keeps direct-upload blob ids
+   unguessable before they are signed.
+5. **Table names:** `storage_blobs`/`storage_attachments` vs.
+   `blobs`/`attachments`. Prefixed avoids collisions with app tables and
+   with the mail/notification "attachment" vocabulary.
+6. **Range requests** in proxy mode (video): v1 or later? R2 `get(key, {
+   range })` supports it; the driver's `getStream` would need a range
+   argument.
+7. **Delivery-route authorization hook:** is a capability URL enough, or
+   should `registerAttachmentRoutes` accept an `authorize(blob, ctx)`
+   callback for revocable access? Leaning: signature only in v1, low
+   `expiresIn`, document the wrapper pattern.
+8. **`make:feature --attach`** and whether `make:feature`'s destroy action
+   should call `purgeAttachments` by default.
+9. **Multi-file `validateBody`:** should `parseRequestPayload` stop
+   collapsing arrays (`request.ts:22`) so `hasManyAttached` fields validate
+   through the normal path? That is a server behaviour change with its own
+   blast radius; the RFC uses `this.files()` and leaves the payload
+   collapse alone.
+10. **Modules (RFC 0002):** a module's model declaring attachments —
+    `guren add attachments --module` scaffolds module-local tables, or all
+    modules share the app-level pair? Leaning shared (one `configureAttachments`
+    per app), matching the sessions table.
+11. **Capability detection (§0):** optional methods (`getStream?`,
+    `temporaryUploadUrl?`) are probed structurally, but "can `temporaryUrl()`
+    produce a real signed URL" is not observable from the type — `LocalDriver`
+    returns a plain URL, `R2Driver` throws without `presign`. Options: (a) an
+    optional `capabilities?: { presign: boolean }` on `StorageDriver`
+    (additive, drivers opt in; unknown ⇒ proxy); (b) `delivery.mode` set
+    explicitly per disk in `configureAttachments`; (c) probe once at
+    configure time by calling `temporaryUrl()` on a sentinel key inside
+    try/catch. Leaning (a) + (b) as an override; (c) does I/O at boot on
+    S3.


### PR DESCRIPTION
## Summary

Two RFC drafts, per `contributing/rfc-process.md`:

- **RFC 0009 — Cloudflare R2 Storage Driver.** RFC 0003 §7 deferred the R2 driver to a future RFC; this is it, written as an implementation plan. `R2Driver` lives in `@guren/plugin-cloudflare` over the R2 *binding* (lazy `binding: () => getWorkersEnv<Env>().BUCKET`, same contract as `createD1Database`), registered through `StorageManager.registerDisk()` — the one extension point that works today — so nothing in `@guren/server` sits on the release-critical path. Includes the full `StorageDriver` ↔ R2 API mapping, the decisions for `temporaryUrl` (aws4fetch presign when credentials are configured, throw otherwise), `setVisibility` (fail closed against the disk's declared visibility), `putFile` (throw), the `wrangler.jsonc` stance, env-driven disk selection (`STORAGE_DISK`), off-Workers access via the S3 API, and the test strategy (in-memory fake + opt-in Miniflare e2e).
- **RFC 0010 — Model Attachments.** Storage-agnostic layer on top of any registered disk: `storage_blobs` + polymorphic `storage_attachments`, an `Attachable(defineModel(posts), { cover: hasOneAttached() })` mixin typed by inference (names, kinds, variant names checked at compile time), signed delivery routes (proxy/redirect chosen per driver capability — this is what gives private files a story on `local` and on R2 without presigning), direct upload (app-mediated by default, presigned PUT where the disk can), lifecycle/purge, pluggable variants (`sharp`, Cloudflare Images binding, URL-based resizing), and codegen/check/spec integration.

## Verified premises worth calling out

- `StorageManager.registerDriver()` cannot serve `disks`-declared drivers registered after construction (eager resolution + closed `DriverConfig` union); `registerDisk()` is what works.
- `S3Driver` sends `x-amz-acl` on every `PutObject`; R2's S3 API lists it as unsupported, and there are no `S3Driver` tests. The storage guide's "R2 via `driver: 's3'`" recipe needs a real-bucket check (RFC 0009 step 0) and an `acl?: boolean` option (sibling PR).
- R2 bindings have no `copy` and no presign; `delete` takes ≤1000 keys; `list` needs cursor pagination (`S3Driver.allFiles` reads one page today).
- Signed delivery needs no WebCrypto rewrite: `signUrl`/`verifySignedUrl` + `deriveAppKeyring` exist, run under `nodejs_compat` (RFC 0003 §6), and have no production caller yet.
- Model delete hooks fire on one of three delete paths and receive the where clause, so purge is explicit + swept, not hook-driven.

## Test plan

Docs only — no code changes. `grep -rn "packages/" docs/` unaffected (rfcs/ is not user-facing docs).