### PR TITLE
feat(plugin-cloudflare): add R2Driver over the R2 binding

### DIFF
--- a/.changeset/r2-storage-driver.md
+++ b/.changeset/r2-storage-driver.md
@@ -1,0 +1,24 @@
+---
+"@guren/plugin-cloudflare": minor
+---
+
+Add `R2Driver`, a storage driver over the Cloudflare R2 bucket binding
+
+`R2Driver` implements the `StorageDriver` contract on top of `env.<BUCKET>`
+— the same lazy `binding: () => getWorkersEnv<Env>().BUCKET` contract as
+`createD1Database` — so a Guren app on Workers can put files behind
+`StorageManager` without provisioning an R2 API token or shipping the AWS
+SDK in the worker. Register it with `storage.registerDisk('media', () =>
+new R2Driver({ binding, publicUrl }))`; on Bun the same disk name can point
+at `LocalStorageDriver`, mirroring the D1/SQLite runtime switch.
+
+Where the binding differs from S3, the driver says so instead of guessing:
+`url()` needs `publicUrl` (R2 has no derivable public URL); `temporaryUrl()`
+presigns through the optional `aws4fetch` peer when `presign` credentials
+are configured and throws with guidance otherwise (bindings cannot sign);
+`put({ visibility })` / `setVisibility()` throw when asked for the opposite
+of the bucket's declared `visibility` (R2 has no per-object ACL);
+`putFile()` throws (no filesystem). Bulk deletes are batched to the
+binding's 1000-key limit and listings follow the cursor across pages.
+
+Design and rationale: RFC 0009.

--- a/.changeset/r2-storage-driver.md
+++ b/.changeset/r2-storage-driver.md
@@ -14,8 +14,9 @@ at `LocalStorageDriver`, mirroring the D1/SQLite runtime switch.
 
 Where the binding differs from S3, the driver says so instead of guessing:
 `url()` needs `publicUrl` (R2 has no derivable public URL); `temporaryUrl()`
-presigns through the optional `aws4fetch` peer when `presign` credentials
-are configured and throws with guidance otherwise (bindings cannot sign);
+presigns on WebCrypto
+(no dependency) when `presign` credentials are configured and throws with
+guidance otherwise (bindings cannot sign);
 `put({ visibility })` / `setVisibility()` throw when asked for the opposite
 of the bucket's declared `visibility` (R2 has no per-object ACL);
 `putFile()` throws (no filesystem). Bulk deletes are batched to the

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "examples/api": {
       "name": "@guren/example-api",
-      "version": "0.1.11",
+      "version": "0.1.16",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -68,14 +68,14 @@
     },
     "packages/cli": {
       "name": "@guren/cli",
-      "version": "2.1.1",
+      "version": "2.5.0",
       "bin": {
         "guren": "./dist/bin.js",
       },
       "dependencies": {
         "@babel/parser": "^7.24.7",
-        "@guren/core": "^1.5.0",
-        "@guren/orm": "^2.1.0",
+        "@guren/core": "^1.6.1",
+        "@guren/orm": "^2.4.0",
         "citty": "^0.1.6",
         "consola": "^3.4.2",
       },
@@ -92,14 +92,14 @@
     },
     "packages/core": {
       "name": "@guren/core",
-      "version": "1.5.0",
+      "version": "1.6.1",
       "bin": {
         "guren": "./dist/bin.js",
       },
       "dependencies": {
-        "@guren/cli": "^2.0.0",
-        "@guren/orm": "^2.0.0",
-        "@guren/server": "^2.0.0",
+        "@guren/cli": "^2.5.0",
+        "@guren/orm": "^2.4.0",
+        "@guren/server": "^2.6.0",
       },
       "devDependencies": {
         "@types/node": "^20.14.10",
@@ -110,7 +110,7 @@
     },
     "packages/create-app": {
       "name": "create-guren-app",
-      "version": "1.6.1",
+      "version": "1.8.0",
       "bin": {
         "create-guren-app": "./dist/cli.js",
       },
@@ -126,7 +126,7 @@
     },
     "packages/inertia-client": {
       "name": "@guren/inertia-client",
-      "version": "1.0.2",
+      "version": "1.1.1",
       "dependencies": {
         "@inertiajs/core": "^3.6.1",
         "@inertiajs/react": "^3.6.1",
@@ -144,7 +144,7 @@
     },
     "packages/openapi": {
       "name": "@guren/openapi",
-      "version": "1.1.0",
+      "version": "1.3.0",
       "dependencies": {
         "@guren/core": "^1.5.0",
       },
@@ -156,7 +156,7 @@
     },
     "packages/orm": {
       "name": "@guren/orm",
-      "version": "2.1.0",
+      "version": "2.4.0",
       "dependencies": {
         "drizzle-orm": "1.0.0-rc.4",
       },
@@ -181,17 +181,25 @@
     },
     "packages/plugin-cloudflare": {
       "name": "@guren/plugin-cloudflare",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
-        "@guren/core": "^1.4.0",
+        "@guren/core": "^1.5.2",
         "citty": "^0.1.6",
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260702.1",
         "@types/node": "^20.14.10",
+        "aws4fetch": "^1.0.20",
+        "miniflare": "5.20260801.1-alpha",
         "tsup": "^8.5.0",
         "typescript": "^5.4.0",
       },
+      "peerDependencies": {
+        "aws4fetch": "^1.0.0",
+      },
+      "optionalPeers": [
+        "aws4fetch",
+      ],
     },
     "packages/plugin-lambda": {
       "name": "@guren/plugin-lambda",
@@ -230,9 +238,9 @@
     },
     "packages/server": {
       "name": "@guren/server",
-      "version": "2.1.1",
+      "version": "2.6.0",
       "dependencies": {
-        "@guren/orm": "^2.1.0",
+        "@guren/orm": "^2.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "chalk": "^5.3.0",
         "consola": "^3.4.2",
@@ -265,7 +273,7 @@
     },
     "packages/testing": {
       "name": "@guren/testing",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "devDependencies": {
         "@types/react": "^19.0.0",
         "tsup": "^8.5.0",
@@ -289,7 +297,7 @@
     },
     "web": {
       "name": "web",
-      "version": "0.1.11",
+      "version": "0.1.16",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -942,6 +950,8 @@
 
     "aws-ssl-profiles": ["aws-ssl-profiles@1.1.2", "", {}, "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="],
 
+    "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
+
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
@@ -1000,7 +1010,7 @@
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
-    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
@@ -1874,6 +1884,8 @@
 
     "drizzle-kit/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
+    "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
     "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
@@ -1905,8 +1917,6 @@
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "wrangler/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
-
-    "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "@tailwindcss/node/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -189,17 +189,10 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260702.1",
         "@types/node": "^20.14.10",
-        "aws4fetch": "^1.0.20",
         "miniflare": "5.20260801.1-alpha",
         "tsup": "^8.5.0",
         "typescript": "^5.4.0",
       },
-      "peerDependencies": {
-        "aws4fetch": "^1.0.0",
-      },
-      "optionalPeers": [
-        "aws4fetch",
-      ],
     },
     "packages/plugin-lambda": {
       "name": "@guren/plugin-lambda",
@@ -949,8 +942,6 @@
     "aws-cdk-lib": ["aws-cdk-lib@2.263.0", "", { "dependencies": { "@aws-cdk/asset-awscli-v1": "2.2.282", "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2", "@aws-cdk/cloud-assembly-api": "^2.2.6", "@aws-cdk/cloud-assembly-schema": "^54.11.0", "@aws/cloudformation-validate": "1.6.0-beta", "@balena/dockerignore": "^1.0.2", "case": "1.6.3", "fs-extra": "^11.3.6", "ignore": "^5.3.2", "jsonschema": "^1.5.0", "mime-types": "^2.1.35", "minimatch": "^10.2.5", "punycode": "^2.3.1", "semver": "^7.8.5", "yaml": "1.10.3" }, "peerDependencies": { "constructs": "^10.5.0" } }, "sha512-cXC9wnOr+LknMee9x0kYwofgVs8aN8eBKsbzcE90sDUtpLTgWG2Bd+9koqxBKPeIU8kig/GGBFwJ69Wr+hLKDg=="],
 
     "aws-ssl-profiles": ["aws-ssl-profiles@1.1.2", "", {}, "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="],
-
-    "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 

--- a/docs/en/guides/cloudflare.md
+++ b/docs/en/guides/cloudflare.md
@@ -187,7 +187,7 @@ export default class StorageProvider extends ServiceProvider {
 Three things follow from how R2 differs from S3:
 
 - **`publicUrl` is required for `url()`.** Attach a custom domain to the bucket in the dashboard (the r2.dev subdomain is rate-limited and meant for development) and pass it as `publicUrl`; R2 has no derivable public URL, so `url()` throws without it.
-- **`temporaryUrl()` needs S3 credentials.** The binding cannot sign URLs. Either pass `presign: { accountId, bucket, accessKeyId, secretAccessKey }` (an R2 API token) and install `aws4fetch`, or keep private files behind an authenticated route in your app. Without `presign`, `temporaryUrl()` throws with that guidance.
+- **`temporaryUrl()` needs S3 credentials.** The binding cannot sign URLs. Either pass `presign: { accountId, bucket, accessKeyId, secretAccessKey }` (an R2 API token), or keep private files behind an authenticated route in your app. Without `presign`, `temporaryUrl()` throws with that guidance.
 - **Visibility is per bucket, not per object.** A bucket is public (custom domain / r2.dev) or private; there is no per-object ACL. The driver reports the bucket's `visibility` (defaults to `'public'` when `publicUrl` is set) and throws if `put({ visibility })` or `setVisibility()` asks for the other value, rather than pretending to honour it.
 
 `putFile()` also throws — there is no local file to read on Workers. Read the bytes yourself (`await file.arrayBuffer()`) and call `put()`. For one-off bulk loads, `bunx wrangler r2 object put my-app-media/<key> --file <path>` from your machine is simpler than going through the app.

--- a/docs/en/guides/cloudflare.md
+++ b/docs/en/guides/cloudflare.md
@@ -137,6 +137,63 @@ const oauth = createOAuthManager({
 
 Both stores need tables. See [Authentication](./authentication.md) for the schema.
 
+## Storage (R2)
+
+Workers has no filesystem, so the `local` storage driver cannot run there. `R2Driver` puts a Cloudflare R2 bucket behind the same `StorageManager` API, through the bucket binding — no credentials to provision and no AWS SDK in the bundle.
+
+Create the bucket and bind it:
+
+```bash
+bunx wrangler r2 bucket create my-app-media
+```
+
+```jsonc
+// wrangler.jsonc
+"r2_buckets": [
+  { "binding": "MEDIA", "bucket_name": "my-app-media" }
+]
+```
+
+Then register a disk that uses R2 on Workers and the local filesystem everywhere else, the same runtime switch `config/database.ts` uses for D1:
+
+```typescript
+// app/Providers/StorageProvider.ts
+import { ServiceProvider, createStorageManager, LocalStorageDriver } from '@guren/core'
+import { R2Driver, getWorkersEnv } from '@guren/plugin-cloudflare'
+import { isWorkersRuntime } from '../../config/database.js'
+
+interface Env {
+  MEDIA: unknown
+}
+
+export default class StorageProvider extends ServiceProvider {
+  register(): void {
+    const storage = createStorageManager({ default: 'media' })
+    storage.registerDisk('media', () =>
+      isWorkersRuntime()
+        ? new R2Driver({
+            binding: () => getWorkersEnv<Env>().MEDIA,
+            publicUrl: 'https://media.example.com',
+          })
+        : new LocalStorageDriver({ root: './storage/app/public', url: '/storage' }),
+    )
+    this.container.instance('storage', storage)
+  }
+}
+```
+
+`binding` is a resolver, not a value — bindings arrive with the first request, so it must be read lazily, exactly like the D1 binding. Every `storage.disk('media').put(...)` / `get(...)` / `files(...)` call from the [Storage guide](./storage.md) then works unchanged; `bun run dev` writes to disk, `wrangler dev` and production write to R2.
+
+Three things follow from how R2 differs from S3:
+
+- **`publicUrl` is required for `url()`.** Attach a custom domain to the bucket in the dashboard (the r2.dev subdomain is rate-limited and meant for development) and pass it as `publicUrl`; R2 has no derivable public URL, so `url()` throws without it.
+- **`temporaryUrl()` needs S3 credentials.** The binding cannot sign URLs. Either pass `presign: { accountId, bucket, accessKeyId, secretAccessKey }` (an R2 API token) and install `aws4fetch`, or keep private files behind an authenticated route in your app. Without `presign`, `temporaryUrl()` throws with that guidance.
+- **Visibility is per bucket, not per object.** A bucket is public (custom domain / r2.dev) or private; there is no per-object ACL. The driver reports the bucket's `visibility` (defaults to `'public'` when `publicUrl` is set) and throws if `put({ visibility })` or `setVisibility()` asks for the other value, rather than pretending to honour it.
+
+`putFile()` also throws — there is no local file to read on Workers. Read the bytes yourself (`await file.arrayBuffer()`) and call `put()`. For one-off bulk loads, `bunx wrangler r2 object put my-app-media/<key> --file <path>` from your machine is simpler than going through the app.
+
+To reach the same bucket from a Bun process — a script, or a non-Workers deployment — use the S3-compatible endpoint with the S3 driver instead: `endpoint: 'https://<ACCOUNT_ID>.r2.cloudflarestorage.com'`, `region: 'auto'`, and an R2 API token, as shown in the [Storage guide](./storage.md#s3-compatible-services).
+
 ## Secrets
 
 `APP_KEY` is required — sessions and CSRF are signed with it, and the worker throws during startup without it, before serving a single request.

--- a/docs/en/guides/cloudflare.md
+++ b/docs/en/guides/cloudflare.md
@@ -65,7 +65,7 @@ interface WorkersEnv {
   DB: unknown
 }
 
-function isWorkersRuntime(): boolean {
+export function isWorkersRuntime(): boolean {
   return typeof navigator !== 'undefined' && navigator.userAgent === 'Cloudflare-Workers'
 }
 

--- a/docs/en/guides/storage.md
+++ b/docs/en/guides/storage.md
@@ -278,6 +278,9 @@ const storage = new StorageManager({
 })
 ```
 
+> [!NOTE]
+> On Cloudflare Workers, use the bucket binding instead of the S3 API: `R2Driver` from `@guren/plugin-cloudflare` needs no credentials and no AWS SDK. The S3 recipe above is for reaching R2 from other runtimes (a Bun server, a script, Lambda). R2 has no per-object ACLs, so treat visibility as a bucket-level setting there. See the [Cloudflare Workers guide](./cloudflare.md#storage-r2).
+
 ### Pre-signed URLs
 
 Generate temporary URLs for private files:

--- a/docs/ja/guides/cloudflare.md
+++ b/docs/ja/guides/cloudflare.md
@@ -137,6 +137,63 @@ const oauth = createOAuthManager({
 
 どちらのストアもテーブルを必要とします。スキーマは[認証ガイド](./authentication.md)を参照してください。
 
+## ストレージ（R2）
+
+Workers にはファイルシステムが無いため、`local` ストレージドライバは動きません。`R2Driver` は Cloudflare R2 バケットをバケットバインディング経由で `StorageManager` の同じ API の背後に置きます。用意する資格情報は無く、AWS SDK もバンドルに入りません。
+
+バケットを作ってバインドします:
+
+```bash
+bunx wrangler r2 bucket create my-app-media
+```
+
+```jsonc
+// wrangler.jsonc
+"r2_buckets": [
+  { "binding": "MEDIA", "bucket_name": "my-app-media" }
+]
+```
+
+次に、Workers 上では R2、それ以外ではローカルファイルシステムを使うディスクを登録します。`config/database.ts` が D1 に使っているのと同じランタイム判定です:
+
+```typescript
+// app/Providers/StorageProvider.ts
+import { ServiceProvider, createStorageManager, LocalStorageDriver } from '@guren/core'
+import { R2Driver, getWorkersEnv } from '@guren/plugin-cloudflare'
+import { isWorkersRuntime } from '../../config/database.js'
+
+interface Env {
+  MEDIA: unknown
+}
+
+export default class StorageProvider extends ServiceProvider {
+  register(): void {
+    const storage = createStorageManager({ default: 'media' })
+    storage.registerDisk('media', () =>
+      isWorkersRuntime()
+        ? new R2Driver({
+            binding: () => getWorkersEnv<Env>().MEDIA,
+            publicUrl: 'https://media.example.com',
+          })
+        : new LocalStorageDriver({ root: './storage/app/public', url: '/storage' }),
+    )
+    this.container.instance('storage', storage)
+  }
+}
+```
+
+`binding` は値ではなくリゾルバです。バインディングは最初のリクエストと共に届くので、D1 バインディングと同じく遅延して読む必要があります。あとは[ストレージガイド](./storage.md)の `storage.disk('media').put(...)` / `get(...)` / `files(...)` がそのまま動きます。`bun run dev` はディスクに、`wrangler dev` と本番は R2 に書き込みます。
+
+R2 と S3 の違いから、次の3点が異なります:
+
+- **`url()` には `publicUrl` が必須です。** ダッシュボードでバケットにカスタムドメインを割り当て（r2.dev サブドメインはレート制限付きで開発向けです）、それを `publicUrl` に渡してください。R2 には導出できる公開 URL が無いため、未設定だと `url()` は例外を投げます。
+- **`temporaryUrl()` には S3 資格情報が必要です。** バインディングは URL に署名できません。`presign: { accountId, bucket, accessKeyId, secretAccessKey }`（R2 API トークン）を渡して `aws4fetch` をインストールするか、非公開ファイルはアプリの認証付きルート越しに配信してください。`presign` が無い場合、`temporaryUrl()` はその案内付きで例外を投げます。
+- **可視性はオブジェクト単位ではなくバケット単位です。** バケットは公開（カスタムドメイン / r2.dev）か非公開かのどちらかで、オブジェクトごとの ACL はありません。ドライバはバケットの `visibility`（`publicUrl` があれば既定 `'public'`）を報告し、`put({ visibility })` や `setVisibility()` で逆の値を求められた場合は、できるふりをせず例外を投げます。
+
+`putFile()` も例外を投げます。Workers には読み取れるローカルファイルがありません。自分でバイト列を読み（`await file.arrayBuffer()`）、`put()` を呼んでください。一度きりの一括投入なら、手元から `bunx wrangler r2 object put my-app-media/<key> --file <path>` の方が簡単です。
+
+Bun プロセス（スクリプトや Workers 以外のデプロイ）から同じバケットに到達するには、代わりに S3 互換エンドポイントと S3 ドライバを使います。`endpoint: 'https://<ACCOUNT_ID>.r2.cloudflarestorage.com'`、`region: 'auto'`、R2 API トークンの組み合わせで、[ストレージガイド](./storage.md#s3互換サービス)を参照してください。
+
 ## シークレット
 
 `APP_KEY` は必須です。セッションと CSRF の署名に使われ、これが無いとワーカーは起動時に例外を投げます。リクエストを 1 件も処理しないまま落ちます。

--- a/docs/ja/guides/cloudflare.md
+++ b/docs/ja/guides/cloudflare.md
@@ -65,7 +65,7 @@ interface WorkersEnv {
   DB: unknown
 }
 
-function isWorkersRuntime(): boolean {
+export function isWorkersRuntime(): boolean {
   return typeof navigator !== 'undefined' && navigator.userAgent === 'Cloudflare-Workers'
 }
 

--- a/docs/ja/guides/cloudflare.md
+++ b/docs/ja/guides/cloudflare.md
@@ -187,7 +187,7 @@ export default class StorageProvider extends ServiceProvider {
 R2 と S3 の違いから、次の3点が異なります:
 
 - **`url()` には `publicUrl` が必須です。** ダッシュボードでバケットにカスタムドメインを割り当て（r2.dev サブドメインはレート制限付きで開発向けです）、それを `publicUrl` に渡してください。R2 には導出できる公開 URL が無いため、未設定だと `url()` は例外を投げます。
-- **`temporaryUrl()` には S3 資格情報が必要です。** バインディングは URL に署名できません。`presign: { accountId, bucket, accessKeyId, secretAccessKey }`（R2 API トークン）を渡して `aws4fetch` をインストールするか、非公開ファイルはアプリの認証付きルート越しに配信してください。`presign` が無い場合、`temporaryUrl()` はその案内付きで例外を投げます。
+- **`temporaryUrl()` には S3 資格情報が必要です。** バインディングは URL に署名できません。`presign: { accountId, bucket, accessKeyId, secretAccessKey }`（R2 API トークン）を渡すか、非公開ファイルはアプリの認証付きルート越しに配信してください。`presign` が無い場合、`temporaryUrl()` はその案内付きで例外を投げます。
 - **可視性はオブジェクト単位ではなくバケット単位です。** バケットは公開（カスタムドメイン / r2.dev）か非公開かのどちらかで、オブジェクトごとの ACL はありません。ドライバはバケットの `visibility`（`publicUrl` があれば既定 `'public'`）を報告し、`put({ visibility })` や `setVisibility()` で逆の値を求められた場合は、できるふりをせず例外を投げます。
 
 `putFile()` も例外を投げます。Workers には読み取れるローカルファイルがありません。自分でバイト列を読み（`await file.arrayBuffer()`）、`put()` を呼んでください。一度きりの一括投入なら、手元から `bunx wrangler r2 object put my-app-media/<key> --file <path>` の方が簡単です。

--- a/docs/ja/guides/storage.md
+++ b/docs/ja/guides/storage.md
@@ -278,6 +278,9 @@ const storage = new StorageManager({
 })
 ```
 
+> [!NOTE]
+> Cloudflare Workers 上では S3 API ではなくバケットバインディングを使ってください。`@guren/plugin-cloudflare` の `R2Driver` は資格情報も AWS SDK も不要です。上の S3 のレシピは他のランタイム（Bun サーバー、スクリプト、Lambda）から R2 に到達するためのものです。R2 にはオブジェクト単位の ACL が無いため、可視性はバケット単位の設定として扱ってください。[Cloudflare Workers ガイド](./cloudflare.md#ストレージr2)を参照してください。
+
 ### 署名付きURL
 
 プライベートファイル用の一時URLを生成します。

--- a/packages/cli/templates/agent/core/skills/guren-api/SKILL.md
+++ b/packages/cli/templates/agent/core/skills/guren-api/SKILL.md
@@ -343,7 +343,7 @@ Source: `packages/server/src/storage/`
 
 - `StorageManager.ts` — Storage manager
 
-Drivers: `LocalDriver.ts`, `MemoryDriver.ts`, `S3Driver.ts`
+Drivers: `LocalDriver.ts`, `MemoryDriver.ts`, `S3Driver.ts`. On Cloudflare Workers, `R2Driver` from `@guren/plugin-cloudflare` (bucket binding; register with `storage.registerDisk()`).
 
 ### Scheduling
 Source: `packages/server/src/scheduling/`

--- a/packages/plugin-cloudflare/README.md
+++ b/packages/plugin-cloudflare/README.md
@@ -34,6 +34,22 @@ bunx wrangler deploy
 
   The binding is a resolver, not a value — it must be read lazily.
 
+- **`R2Driver`** — a storage driver over the R2 bucket binding, for `StorageManager.registerDisk()`. Same lazy `binding` contract as D1; no credentials and no AWS SDK in the bundle:
+
+  ```typescript
+  import { createStorageManager, LocalStorageDriver } from '@guren/core'
+  import { R2Driver, getWorkersEnv } from '@guren/plugin-cloudflare'
+
+  const storage = createStorageManager({ default: 'media' })
+  storage.registerDisk('media', () =>
+    isWorkersRuntime()
+      ? new R2Driver({ binding: () => getWorkersEnv<{ MEDIA: unknown }>().MEDIA, publicUrl: 'https://media.example.com' })
+      : new LocalStorageDriver({ root: './storage/app/public', url: '/storage' }),
+  )
+  ```
+
+  with `"r2_buckets": [{ "binding": "MEDIA", "bucket_name": "my-app-media" }]` in `wrangler.jsonc`. Three methods differ from the S3 driver, because the binding differs from S3: `url()` needs `publicUrl` (a custom domain or the r2.dev subdomain — R2 has no derivable public URL); `temporaryUrl()` needs the optional `presign` credentials plus the `aws4fetch` package, and throws with guidance otherwise (bindings cannot sign URLs); `setVisibility()` / `put({ visibility })` throw when asked for the opposite of the bucket's declared `visibility`, because R2 has no per-object ACL to honour the request with. `putFile()` throws — Workers has no filesystem.
+
 - **`cloudflarePlugin()`** — the service provider factory, registered automatically by `guren plugin`.
 
 ## Things Workers changes

--- a/packages/plugin-cloudflare/README.md
+++ b/packages/plugin-cloudflare/README.md
@@ -48,7 +48,7 @@ bunx wrangler deploy
   )
   ```
 
-  with `"r2_buckets": [{ "binding": "MEDIA", "bucket_name": "my-app-media" }]` in `wrangler.jsonc`. Three methods differ from the S3 driver, because the binding differs from S3: `url()` needs `publicUrl` (a custom domain or the r2.dev subdomain — R2 has no derivable public URL); `temporaryUrl()` needs the optional `presign` credentials plus the `aws4fetch` package, and throws with guidance otherwise (bindings cannot sign URLs); `setVisibility()` / `put({ visibility })` throw when asked for the opposite of the bucket's declared `visibility`, because R2 has no per-object ACL to honour the request with. `putFile()` throws — Workers has no filesystem.
+  with `"r2_buckets": [{ "binding": "MEDIA", "bucket_name": "my-app-media" }]` in `wrangler.jsonc`. Three methods differ from the S3 driver, because the binding differs from S3: `url()` needs `publicUrl` (a custom domain or the r2.dev subdomain — R2 has no derivable public URL); `temporaryUrl()` needs the optional `presign` credentials, and throws with guidance otherwise (bindings cannot sign URLs); `setVisibility()` / `put({ visibility })` throw when asked for the opposite of the bucket's declared `visibility`, because R2 has no per-object ACL to honour the request with. `putFile()` throws — Workers has no filesystem.
 
 - **`cloudflarePlugin()`** — the service provider factory, registered automatically by `guren plugin`.
 

--- a/packages/plugin-cloudflare/package.json
+++ b/packages/plugin-cloudflare/package.json
@@ -44,18 +44,9 @@
     "@guren/core": "^1.5.2",
     "citty": "^0.1.6"
   },
-  "peerDependencies": {
-    "aws4fetch": "^1.0.0"
-  },
-  "peerDependenciesMeta": {
-    "aws4fetch": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260702.1",
     "@types/node": "^20.14.10",
-    "aws4fetch": "^1.0.20",
     "miniflare": "5.20260801.1-alpha",
     "tsup": "^8.5.0",
     "typescript": "^5.4.0"

--- a/packages/plugin-cloudflare/package.json
+++ b/packages/plugin-cloudflare/package.json
@@ -44,9 +44,19 @@
     "@guren/core": "^1.5.2",
     "citty": "^0.1.6"
   },
+  "peerDependencies": {
+    "aws4fetch": "^1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "aws4fetch": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260702.1",
     "@types/node": "^20.14.10",
+    "aws4fetch": "^1.0.20",
+    "miniflare": "5.20260801.1-alpha",
     "tsup": "^8.5.0",
     "typescript": "^5.4.0"
   }

--- a/packages/plugin-cloudflare/src/index.ts
+++ b/packages/plugin-cloudflare/src/index.ts
@@ -29,17 +29,4 @@ export type { WorkersAppLike, WorkersExecutionContext, WorkersHandler } from './
 export { buildCloudflareOutput, flattenD1Migrations } from './build'
 export type { BuildCloudflareOutputOptions } from './build'
 export { R2Driver } from './storage/R2Driver'
-export type {
-  R2DriverOptions,
-  R2PresignOptions,
-  R2BucketLike,
-  R2ObjectLike,
-  R2ObjectBodyLike,
-  R2ObjectsLike,
-  R2ListOptionsLike,
-  R2PutOptionsLike,
-  R2PutValue,
-  R2StreamLike,
-  R2BlobLike,
-  R2HttpMetadataLike,
-} from './storage/R2Driver'
+export type { R2DriverOptions, R2PresignOptions, R2BucketLike } from './storage/R2Driver'

--- a/packages/plugin-cloudflare/src/index.ts
+++ b/packages/plugin-cloudflare/src/index.ts
@@ -28,3 +28,18 @@ export { createWorkersHandler } from './handler'
 export type { WorkersAppLike, WorkersExecutionContext, WorkersHandler } from './handler'
 export { buildCloudflareOutput, flattenD1Migrations } from './build'
 export type { BuildCloudflareOutputOptions } from './build'
+export { R2Driver } from './storage/R2Driver'
+export type {
+  R2DriverOptions,
+  R2PresignOptions,
+  R2BucketLike,
+  R2ObjectLike,
+  R2ObjectBodyLike,
+  R2ObjectsLike,
+  R2ListOptionsLike,
+  R2PutOptionsLike,
+  R2PutValue,
+  R2StreamLike,
+  R2BlobLike,
+  R2HttpMetadataLike,
+} from './storage/R2Driver'

--- a/packages/plugin-cloudflare/src/storage/R2Driver.test.ts
+++ b/packages/plugin-cloudflare/src/storage/R2Driver.test.ts
@@ -159,6 +159,10 @@ describe('R2Driver', () => {
       expect(prefixed.url('/a/b.png')).toBe('https://media.example.com/uploads/a/b.png')
     })
 
+    test('percent-encodes key segments', () => {
+      expect(driver.url('a b/c#1.png')).toBe('https://media.example.com/a%20b/c%231.png')
+    })
+
     test('throws without publicUrl', () => {
       const bare = new R2Driver({ binding: () => bucket })
       expect(() => bare.url('a.png')).toThrow(/publicUrl/)

--- a/packages/plugin-cloudflare/src/storage/R2Driver.test.ts
+++ b/packages/plugin-cloudflare/src/storage/R2Driver.test.ts
@@ -1,17 +1,28 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
-import { FakeR2Bucket } from './fake-r2-bucket'
-import { R2Driver } from './R2Driver'
+import { FakeR2Bucket, type FakeR2BucketOptions } from './fake-r2-bucket'
+import { describeR2DriverConformance } from './r2-driver-conformance'
+import { R2Driver, type R2DriverOptions } from './R2Driver'
 
-function createDriver(
-  overrides: Partial<ConstructorParameters<typeof R2Driver>[0]> = {},
-  bucketOptions: ConstructorParameters<typeof FakeR2Bucket>[0] = {},
-) {
+// The contract itself, shared with the opt-in workerd run.
+describeR2DriverConformance('R2Driver (FakeR2Bucket)', {
+  bucket: async () => new FakeR2Bucket(),
+  reset: async (bucket) => {
+    const fake = bucket as FakeR2Bucket
+    for (const key of fake.keys()) await fake.delete(key)
+    fake.calls.length = 0
+  },
+  streamingCopy: true,
+})
+
+// What only the fake can observe: which calls the driver makes, and how it
+// behaves at page and batch boundaries.
+function createDriver(overrides: Partial<R2DriverOptions> = {}, bucketOptions: FakeR2BucketOptions = {}) {
   const bucket = new FakeR2Bucket(bucketOptions)
   const driver = new R2Driver({ binding: () => bucket, publicUrl: 'https://media.example.com', ...overrides })
   return { bucket, driver }
 }
 
-describe('R2Driver', () => {
+describe('R2Driver against the binding', () => {
   let bucket: FakeR2Bucket
   let driver: R2Driver
 
@@ -38,158 +49,79 @@ describe('R2Driver', () => {
     })
   })
 
-  describe('put/get', () => {
-    test('stores and retrieves a string', async () => {
-      await driver.put('test.txt', 'Hello, World!')
-      expect((await driver.get('test.txt'))?.toString()).toBe('Hello, World!')
-    })
-
-    test('stores a Buffer and reads it back as a Buffer', async () => {
-      await driver.put('binary.bin', Buffer.from([1, 2, 3, 255]))
-      const content = await driver.get('binary.bin')
-      expect(content).toBeInstanceOf(Buffer)
-      expect(Array.from(content!)).toEqual([1, 2, 3, 255])
-    })
-
-    test('returns null for a missing file', async () => {
-      expect(await driver.get('missing.txt')).toBeNull()
-      expect(await driver.getAsString('missing.txt')).toBeNull()
-    })
-
-    test('normalizes leading and trailing slashes and returns the stored path', async () => {
-      expect(await driver.put('/path/to/file.txt/', 'content')).toBe('path/to/file.txt')
-      expect(await driver.getAsString('path/to/file.txt')).toBe('content')
-      expect(bucket.keys()).toEqual(['path/to/file.txt'])
-    })
-
-    test('maps contentType and metadata onto httpMetadata and customMetadata', async () => {
-      await driver.put('a.json', '{}', { contentType: 'application/json', metadata: { owner: '42' } })
-      const object = await bucket.head('a.json')
-      expect(object?.httpMetadata).toEqual({ contentType: 'application/json' })
-      expect(object?.customMetadata).toEqual({ owner: '42' })
-    })
-
-    test('applies the prefix to every key', async () => {
-      const prefixed = new R2Driver({ binding: () => bucket, prefix: '/uploads/' })
-      await prefixed.put('a.txt', 'x')
-      expect(bucket.keys()).toEqual(['uploads/a.txt'])
-      expect(await prefixed.getAsString('a.txt')).toBe('x')
-      expect(prefixed.getPrefix()).toBe('uploads')
-    })
+  test('put maps contentType and metadata onto httpMetadata and customMetadata', async () => {
+    await driver.put('a.json', '{}', { contentType: 'application/json', metadata: { owner: '42' } })
+    const object = await bucket.head('a.json')
+    expect(object?.httpMetadata).toEqual({ contentType: 'application/json' })
+    expect(object?.customMetadata).toEqual({ owner: '42' })
   })
 
-  describe('putFile', () => {
-    test('throws: Workers has no filesystem', async () => {
-      await expect(driver.putFile('a.txt', '/tmp/a.txt')).rejects.toThrow(/no filesystem/)
-    })
+  test('delete does not issue a delete for a missing key', async () => {
+    await driver.delete('missing.txt')
+    expect(bucket.calls.filter((call) => call.method === 'delete')).toHaveLength(0)
   })
 
-  describe('exists', () => {
-    test('reflects presence via head()', async () => {
-      await driver.put('test.txt', 'content')
-      expect(await driver.exists('test.txt')).toBe(true)
-      expect(await driver.exists('missing.txt')).toBe(false)
-    })
+  test('deleteMany with no paths does not touch the bucket', async () => {
+    expect(await driver.deleteMany([])).toBe(0)
+    expect(bucket.calls).toHaveLength(0)
   })
 
-  describe('delete', () => {
-    test('returns true when the object existed and false when it did not', async () => {
-      await driver.put('test.txt', 'content')
-      expect(await driver.delete('test.txt')).toBe(true)
-      expect(await driver.exists('test.txt')).toBe(false)
-      expect(await driver.delete('test.txt')).toBe(false)
-    })
+  test('deleteMany batches keys into 1000-key delete() calls', async () => {
+    const paths = Array.from({ length: 2500 }, (_, index) => `bulk/${index}.txt`)
+    for (const path of paths) await bucket.put(path, '')
+    bucket.calls.length = 0
 
-    test('does not issue a delete for a missing key', async () => {
-      await driver.delete('missing.txt')
-      expect(bucket.calls.filter((call) => call.method === 'delete')).toHaveLength(0)
-    })
+    expect(await driver.deleteMany(paths)).toBe(2500)
+
+    const batches = bucket.calls.filter((call) => call.method === 'delete').map((call) => call.args[0] as string[])
+    expect(batches.map((batch) => batch.length).sort((a, b) => b - a)).toEqual([1000, 1000, 500])
+    expect(bucket.keys()).toEqual([])
   })
 
-  describe('deleteMany', () => {
-    test('returns 0 for no paths without touching the bucket', async () => {
-      expect(await driver.deleteMany([])).toBe(0)
-      expect(bucket.calls).toHaveLength(0)
-    })
+  test('listings follow the cursor across pages', async () => {
+    ;({ bucket, driver } = createDriver({}, { pageSize: 2 }))
+    for (let index = 0; index < 7; index++) await driver.put(`p/${index}.txt`, '')
+    bucket.calls.length = 0
 
-    test('batches keys into 1000-key delete() calls', async () => {
-      const paths = Array.from({ length: 2500 }, (_, index) => `bulk/${index}.txt`)
-      for (const path of paths) await bucket.put(path, '')
-      bucket.calls.length = 0
+    const files = await driver.allFiles('p')
 
-      expect(await driver.deleteMany(paths)).toBe(2500)
-
-      const batches = bucket.calls.filter((call) => call.method === 'delete').map((call) => call.args[0] as string[])
-      expect(batches.map((batch) => batch.length)).toEqual([1000, 1000, 500])
-      expect(bucket.keys()).toEqual([])
-    })
-
-    test('deduplicates paths', async () => {
-      await driver.put('a.txt', 'x')
-      expect(await driver.deleteMany(['a.txt', '/a.txt', 'a.txt/'])).toBe(1)
-    })
+    expect(files).toHaveLength(7)
+    const lists = bucket.calls.filter((call) => call.method === 'list')
+    expect(lists).toHaveLength(4)
+    expect((lists[1]!.args[0] as { cursor?: string }).cursor).toBeDefined()
   })
 
-  describe('copy/move', () => {
-    test('copies bytes and metadata to the new key', async () => {
-      await driver.put('src.txt', 'content', { contentType: 'text/plain', metadata: { k: 'v' } })
-      expect(await driver.copy('src.txt', 'dst.txt')).toBe('dst.txt')
-      expect(await driver.getAsString('dst.txt')).toBe('content')
-      expect(await driver.getAsString('src.txt')).toBe('content')
-      const copied = await bucket.head('dst.txt')
-      expect(copied?.httpMetadata).toEqual({ contentType: 'text/plain' })
-      expect(copied?.customMetadata).toEqual({ k: 'v' })
-    })
+  test('deleteDirectory deletes each page as it is listed', async () => {
+    ;({ bucket, driver } = createDriver({}, { pageSize: 3 }))
+    for (let index = 0; index < 7; index++) await driver.put(`p/${index}.txt`, '')
+    bucket.calls.length = 0
 
-    test('throws when the source is missing', async () => {
-      await expect(driver.copy('missing.txt', 'dst.txt')).rejects.toThrow('File not found: missing.txt')
-    })
+    await driver.deleteDirectory('p')
 
-    test('moves by copying then deleting the source', async () => {
-      await driver.put('src.txt', 'content')
-      expect(await driver.move('src.txt', 'dst.txt')).toBe('dst.txt')
-      expect(await driver.exists('src.txt')).toBe(false)
-      expect(await driver.getAsString('dst.txt')).toBe('content')
-    })
+    const methods = bucket.calls.map((call) => call.method)
+    expect(methods).toEqual(['list', 'delete', 'list', 'delete', 'list', 'delete'])
+    expect(bucket.keys()).toEqual([])
   })
 
-  describe('url', () => {
-    test('joins publicUrl, prefix and key', () => {
-      const prefixed = new R2Driver({ binding: () => bucket, publicUrl: 'https://media.example.com/', prefix: 'uploads' })
-      expect(prefixed.url('/a/b.png')).toBe('https://media.example.com/uploads/a/b.png')
-    })
-
-    test('percent-encodes key segments', () => {
-      expect(driver.url('a b/c#1.png')).toBe('https://media.example.com/a%20b/c%231.png')
-    })
-
-    test('throws without publicUrl', () => {
-      const bare = new R2Driver({ binding: () => bucket })
-      expect(() => bare.url('a.png')).toThrow(/publicUrl/)
-    })
+  test('metadata reports the bucket timestamp', async () => {
+    const uploaded = new Date('2026-08-15T00:00:00Z')
+    ;({ bucket, driver } = createDriver({}, { now: () => uploaded }))
+    await driver.put('a.txt', 'hello')
+    expect(await driver.lastModified('a.txt')).toEqual(uploaded)
+    expect((await driver.metadata('a.txt'))?.lastModified).toEqual(uploaded)
   })
 
-  describe('temporaryUrl', () => {
-    test('throws with guidance when presign is not configured', async () => {
-      await expect(driver.temporaryUrl('a.png', new Date(Date.now() + 60_000))).rejects.toThrow(/presign/)
-      await expect(driver.temporaryUrl('a.png', new Date(Date.now() + 60_000))).rejects.toThrow(/signed app route/)
-    })
+  describe('temporaryUrl with presign', () => {
+    const presign = { accountId: 'acct123', bucket: 'my-bucket', accessKeyId: 'AKIDEXAMPLE', secretAccessKey: 'secret' }
 
     test('rejects expirations beyond seven days before signing', async () => {
-      const presigned = new R2Driver({
-        binding: () => bucket,
-        presign: { accountId: 'acct', bucket: 'b', accessKeyId: 'AK', secretAccessKey: 'SK' },
-      })
+      const presigned = new R2Driver({ binding: () => bucket, presign })
       const eightDays = new Date(Date.now() + 8 * 24 * 60 * 60 * 1000)
       await expect(presigned.temporaryUrl('a.png', eightDays)).rejects.toThrow(/7 days/)
     })
 
-    test('signs a GET against the S3 endpoint with X-Amz-Expires when presign is configured', async () => {
-      const presigned = new R2Driver({
-        binding: () => bucket,
-        prefix: 'uploads',
-        presign: { accountId: 'acct123', bucket: 'my-bucket', accessKeyId: 'AKIDEXAMPLE', secretAccessKey: 'secret' },
-      })
+    test('signs a GET against the S3 endpoint with X-Amz-Expires', async () => {
+      const presigned = new R2Driver({ binding: () => bucket, prefix: 'uploads', presign })
       const url = new URL(await presigned.temporaryUrl('a b/c.png', new Date(Date.now() + 3600 * 1000)))
       expect(url.origin).toBe('https://acct123.r2.cloudflarestorage.com')
       expect(url.pathname).toBe('/my-bucket/uploads/a%20b/c.png')
@@ -197,138 +129,6 @@ describe('R2Driver', () => {
       expect(url.searchParams.get('X-Amz-Expires')).toBe('3600')
       expect(url.searchParams.get('X-Amz-Credential')).toMatch(/^AKIDEXAMPLE\/\d{8}\/auto\/s3\/aws4_request$/)
       expect(url.searchParams.get('X-Amz-Signature')).toMatch(/^[0-9a-f]{64}$/)
-    })
-  })
-
-  describe('size/lastModified/metadata', () => {
-    test('reads from head()', async () => {
-      const uploaded = new Date('2026-08-15T00:00:00Z')
-      ;({ bucket, driver } = createDriver({}, { now: () => uploaded }))
-      await driver.put('a.txt', 'hello', { contentType: 'text/plain', metadata: { k: 'v' } })
-
-      expect(await driver.size('a.txt')).toBe(5)
-      expect(await driver.lastModified('a.txt')).toEqual(uploaded)
-      expect(await driver.metadata('a.txt')).toEqual({
-        path: 'a.txt',
-        size: 5,
-        lastModified: uploaded,
-        contentType: 'text/plain',
-        visibility: 'public',
-        metadata: { k: 'v' },
-      })
-    })
-
-    test('throws for size/lastModified of a missing file and returns null metadata', async () => {
-      await expect(driver.size('missing')).rejects.toThrow('File not found: missing')
-      await expect(driver.lastModified('missing')).rejects.toThrow('File not found: missing')
-      expect(await driver.metadata('missing')).toBeNull()
-    })
-  })
-
-  describe('files/directories/allFiles', () => {
-    beforeEach(async () => {
-      await driver.put('dir/file1.txt', '1')
-      await driver.put('dir/file2.txt', '2')
-      await driver.put('dir/sub/file3.txt', '3')
-      await driver.put('dir/sub/deep/file4.txt', '4')
-      await driver.put('other/file5.txt', '5')
-    })
-
-    test('files lists direct children only, as app-relative paths', async () => {
-      expect(await driver.files('dir')).toEqual(['dir/file1.txt', 'dir/file2.txt'])
-      expect(await driver.files('/dir/')).toEqual(['dir/file1.txt', 'dir/file2.txt'])
-    })
-
-    test('directories lists direct subdirectories', async () => {
-      expect(await driver.directories('dir')).toEqual(['dir/sub'])
-      expect(await driver.directories('')).toEqual(['dir', 'other'])
-    })
-
-    test('allFiles lists recursively', async () => {
-      expect(await driver.allFiles('dir')).toEqual([
-        'dir/file1.txt',
-        'dir/file2.txt',
-        'dir/sub/deep/file4.txt',
-        'dir/sub/file3.txt',
-      ])
-    })
-
-    test('strips the prefix from listed paths', async () => {
-      const prefixed = new R2Driver({ binding: () => bucket, prefix: 'dir' })
-      expect(await prefixed.files('')).toEqual(['file1.txt', 'file2.txt'])
-      expect(await prefixed.directories('')).toEqual(['sub'])
-      expect(await prefixed.allFiles('sub')).toEqual(['sub/deep/file4.txt', 'sub/file3.txt'])
-    })
-
-    test('follows the cursor across pages', async () => {
-      ;({ bucket, driver } = createDriver({}, { pageSize: 2 }))
-      for (let index = 0; index < 7; index++) await driver.put(`p/${index}.txt`, '')
-      bucket.calls.length = 0
-
-      const files = await driver.allFiles('p')
-
-      expect(files).toHaveLength(7)
-      const lists = bucket.calls.filter((call) => call.method === 'list')
-      expect(lists).toHaveLength(4)
-      expect((lists[1]!.args[0] as { cursor?: string }).cursor).toBeDefined()
-    })
-
-    test('does not list a directory marker as a file', async () => {
-      await driver.makeDirectory('dir/empty')
-      expect(await driver.directories('dir')).toEqual(['dir/empty', 'dir/sub'])
-      expect(await driver.files('dir/empty')).toEqual([])
-    })
-  })
-
-  describe('deleteDirectory', () => {
-    test('deletes everything under the directory', async () => {
-      await driver.put('dir/file1.txt', '1')
-      await driver.put('dir/sub/file2.txt', '2')
-      await driver.put('dir2/file3.txt', '3')
-
-      await driver.deleteDirectory('dir')
-
-      expect(bucket.keys()).toEqual(['dir2/file3.txt'])
-    })
-
-    test('removes folder markers and respects the prefix', async () => {
-      const prefixed = new R2Driver({ binding: () => bucket, prefix: 'app' })
-      await prefixed.makeDirectory('dir/empty')
-      await prefixed.put('dir/a.txt', '1')
-      await bucket.put('other/keep.txt', '')
-
-      await prefixed.deleteDirectory('dir')
-
-      expect(bucket.keys()).toEqual(['other/keep.txt'])
-    })
-  })
-
-  describe('visibility', () => {
-    test('defaults to public when publicUrl is set and private otherwise', async () => {
-      await driver.put('a.txt', 'x')
-      expect(await driver.getVisibility('a.txt')).toBe('public')
-
-      const privateDriver = new R2Driver({ binding: () => bucket })
-      expect(await privateDriver.getVisibility('a.txt')).toBe('private')
-    })
-
-    test('accepts a matching visibility as a no-op', async () => {
-      await driver.put('a.txt', 'x', { visibility: 'public' })
-      await driver.setVisibility('a.txt', 'public')
-      expect(await driver.getVisibility('a.txt')).toBe('public')
-    })
-
-    test('throws on a conflicting visibility instead of pretending', async () => {
-      await expect(driver.put('a.txt', 'x', { visibility: 'private' })).rejects.toThrow(/no per-object visibility/)
-      expect(bucket.keys()).toEqual([])
-
-      await driver.put('a.txt', 'x')
-      await expect(driver.setVisibility('a.txt', 'private')).rejects.toThrow(/no per-object visibility/)
-    })
-
-    test('getVisibility/setVisibility throw for a missing file', async () => {
-      await expect(driver.getVisibility('missing')).rejects.toThrow('File not found: missing')
-      await expect(driver.setVisibility('missing', 'public')).rejects.toThrow('File not found: missing')
     })
   })
 })

--- a/packages/plugin-cloudflare/src/storage/R2Driver.test.ts
+++ b/packages/plugin-cloudflare/src/storage/R2Driver.test.ts
@@ -1,0 +1,330 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { FakeR2Bucket } from './fake-r2-bucket'
+import { R2Driver } from './R2Driver'
+
+function createDriver(
+  overrides: Partial<ConstructorParameters<typeof R2Driver>[0]> = {},
+  bucketOptions: ConstructorParameters<typeof FakeR2Bucket>[0] = {},
+) {
+  const bucket = new FakeR2Bucket(bucketOptions)
+  const driver = new R2Driver({ binding: () => bucket, publicUrl: 'https://media.example.com', ...overrides })
+  return { bucket, driver }
+}
+
+describe('R2Driver', () => {
+  let bucket: FakeR2Bucket
+  let driver: R2Driver
+
+  beforeEach(() => {
+    ;({ bucket, driver } = createDriver())
+  })
+
+  describe('binding resolution', () => {
+    test('should not call the binding resolver until an operation runs', () => {
+      let calls = 0
+      new R2Driver({
+        binding: () => {
+          calls += 1
+          return bucket
+        },
+      })
+      expect(calls).toBe(0)
+    })
+
+    test('should throw with wrangler guidance when the resolver returns nothing', async () => {
+      const lazy = new R2Driver({ binding: () => undefined })
+      await expect(lazy.exists('x')).rejects.toThrow(/r2_buckets/)
+      await expect(lazy.exists('x')).rejects.toThrow(/getWorkersEnv/)
+    })
+  })
+
+  describe('put/get', () => {
+    test('stores and retrieves a string', async () => {
+      await driver.put('test.txt', 'Hello, World!')
+      expect((await driver.get('test.txt'))?.toString()).toBe('Hello, World!')
+    })
+
+    test('stores a Buffer and reads it back as a Buffer', async () => {
+      await driver.put('binary.bin', Buffer.from([1, 2, 3, 255]))
+      const content = await driver.get('binary.bin')
+      expect(content).toBeInstanceOf(Buffer)
+      expect(Array.from(content!)).toEqual([1, 2, 3, 255])
+    })
+
+    test('returns null for a missing file', async () => {
+      expect(await driver.get('missing.txt')).toBeNull()
+      expect(await driver.getAsString('missing.txt')).toBeNull()
+    })
+
+    test('normalizes leading and trailing slashes and returns the stored path', async () => {
+      expect(await driver.put('/path/to/file.txt/', 'content')).toBe('path/to/file.txt')
+      expect(await driver.getAsString('path/to/file.txt')).toBe('content')
+      expect(bucket.keys()).toEqual(['path/to/file.txt'])
+    })
+
+    test('maps contentType and metadata onto httpMetadata and customMetadata', async () => {
+      await driver.put('a.json', '{}', { contentType: 'application/json', metadata: { owner: '42' } })
+      const object = await bucket.head('a.json')
+      expect(object?.httpMetadata).toEqual({ contentType: 'application/json' })
+      expect(object?.customMetadata).toEqual({ owner: '42' })
+    })
+
+    test('applies the prefix to every key', async () => {
+      const prefixed = new R2Driver({ binding: () => bucket, prefix: '/uploads/' })
+      await prefixed.put('a.txt', 'x')
+      expect(bucket.keys()).toEqual(['uploads/a.txt'])
+      expect(await prefixed.getAsString('a.txt')).toBe('x')
+      expect(prefixed.getPrefix()).toBe('uploads')
+    })
+  })
+
+  describe('putFile', () => {
+    test('throws: Workers has no filesystem', async () => {
+      await expect(driver.putFile('a.txt', '/tmp/a.txt')).rejects.toThrow(/no filesystem/)
+    })
+  })
+
+  describe('exists', () => {
+    test('reflects presence via head()', async () => {
+      await driver.put('test.txt', 'content')
+      expect(await driver.exists('test.txt')).toBe(true)
+      expect(await driver.exists('missing.txt')).toBe(false)
+    })
+  })
+
+  describe('delete', () => {
+    test('returns true when the object existed and false when it did not', async () => {
+      await driver.put('test.txt', 'content')
+      expect(await driver.delete('test.txt')).toBe(true)
+      expect(await driver.exists('test.txt')).toBe(false)
+      expect(await driver.delete('test.txt')).toBe(false)
+    })
+
+    test('does not issue a delete for a missing key', async () => {
+      await driver.delete('missing.txt')
+      expect(bucket.calls.filter((call) => call.method === 'delete')).toHaveLength(0)
+    })
+  })
+
+  describe('deleteMany', () => {
+    test('returns 0 for no paths without touching the bucket', async () => {
+      expect(await driver.deleteMany([])).toBe(0)
+      expect(bucket.calls).toHaveLength(0)
+    })
+
+    test('batches keys into 1000-key delete() calls', async () => {
+      const paths = Array.from({ length: 2500 }, (_, index) => `bulk/${index}.txt`)
+      for (const path of paths) await bucket.put(path, '')
+      bucket.calls.length = 0
+
+      expect(await driver.deleteMany(paths)).toBe(2500)
+
+      const batches = bucket.calls.filter((call) => call.method === 'delete').map((call) => call.args[0] as string[])
+      expect(batches.map((batch) => batch.length)).toEqual([1000, 1000, 500])
+      expect(bucket.keys()).toEqual([])
+    })
+
+    test('deduplicates paths', async () => {
+      await driver.put('a.txt', 'x')
+      expect(await driver.deleteMany(['a.txt', '/a.txt', 'a.txt/'])).toBe(1)
+    })
+  })
+
+  describe('copy/move', () => {
+    test('copies bytes and metadata to the new key', async () => {
+      await driver.put('src.txt', 'content', { contentType: 'text/plain', metadata: { k: 'v' } })
+      expect(await driver.copy('src.txt', 'dst.txt')).toBe('dst.txt')
+      expect(await driver.getAsString('dst.txt')).toBe('content')
+      expect(await driver.getAsString('src.txt')).toBe('content')
+      const copied = await bucket.head('dst.txt')
+      expect(copied?.httpMetadata).toEqual({ contentType: 'text/plain' })
+      expect(copied?.customMetadata).toEqual({ k: 'v' })
+    })
+
+    test('throws when the source is missing', async () => {
+      await expect(driver.copy('missing.txt', 'dst.txt')).rejects.toThrow('File not found: missing.txt')
+    })
+
+    test('moves by copying then deleting the source', async () => {
+      await driver.put('src.txt', 'content')
+      expect(await driver.move('src.txt', 'dst.txt')).toBe('dst.txt')
+      expect(await driver.exists('src.txt')).toBe(false)
+      expect(await driver.getAsString('dst.txt')).toBe('content')
+    })
+  })
+
+  describe('url', () => {
+    test('joins publicUrl, prefix and key', () => {
+      const prefixed = new R2Driver({ binding: () => bucket, publicUrl: 'https://media.example.com/', prefix: 'uploads' })
+      expect(prefixed.url('/a/b.png')).toBe('https://media.example.com/uploads/a/b.png')
+    })
+
+    test('throws without publicUrl', () => {
+      const bare = new R2Driver({ binding: () => bucket })
+      expect(() => bare.url('a.png')).toThrow(/publicUrl/)
+    })
+  })
+
+  describe('temporaryUrl', () => {
+    test('throws with guidance when presign is not configured', async () => {
+      await expect(driver.temporaryUrl('a.png', new Date(Date.now() + 60_000))).rejects.toThrow(/presign/)
+      await expect(driver.temporaryUrl('a.png', new Date(Date.now() + 60_000))).rejects.toThrow(/signed app route/)
+    })
+
+    test('rejects expirations beyond seven days before signing', async () => {
+      const presigned = new R2Driver({
+        binding: () => bucket,
+        presign: { accountId: 'acct', bucket: 'b', accessKeyId: 'AK', secretAccessKey: 'SK' },
+      })
+      const eightDays = new Date(Date.now() + 8 * 24 * 60 * 60 * 1000)
+      await expect(presigned.temporaryUrl('a.png', eightDays)).rejects.toThrow(/7 days/)
+    })
+
+    test('signs a GET against the S3 endpoint with X-Amz-Expires when presign is configured', async () => {
+      const presigned = new R2Driver({
+        binding: () => bucket,
+        prefix: 'uploads',
+        presign: { accountId: 'acct123', bucket: 'my-bucket', accessKeyId: 'AKIDEXAMPLE', secretAccessKey: 'secret' },
+      })
+      const url = new URL(await presigned.temporaryUrl('a b/c.png', new Date(Date.now() + 3600 * 1000)))
+      expect(url.origin).toBe('https://acct123.r2.cloudflarestorage.com')
+      expect(url.pathname).toBe('/my-bucket/uploads/a%20b/c.png')
+      expect(url.searchParams.get('X-Amz-Algorithm')).toBe('AWS4-HMAC-SHA256')
+      expect(url.searchParams.get('X-Amz-Expires')).toBe('3600')
+      expect(url.searchParams.get('X-Amz-Credential')).toMatch(/^AKIDEXAMPLE\/\d{8}\/auto\/s3\/aws4_request$/)
+      expect(url.searchParams.get('X-Amz-Signature')).toMatch(/^[0-9a-f]{64}$/)
+    })
+  })
+
+  describe('size/lastModified/metadata', () => {
+    test('reads from head()', async () => {
+      const uploaded = new Date('2026-08-15T00:00:00Z')
+      ;({ bucket, driver } = createDriver({}, { now: () => uploaded }))
+      await driver.put('a.txt', 'hello', { contentType: 'text/plain', metadata: { k: 'v' } })
+
+      expect(await driver.size('a.txt')).toBe(5)
+      expect(await driver.lastModified('a.txt')).toEqual(uploaded)
+      expect(await driver.metadata('a.txt')).toEqual({
+        path: 'a.txt',
+        size: 5,
+        lastModified: uploaded,
+        contentType: 'text/plain',
+        visibility: 'public',
+        metadata: { k: 'v' },
+      })
+    })
+
+    test('throws for size/lastModified of a missing file and returns null metadata', async () => {
+      await expect(driver.size('missing')).rejects.toThrow('File not found: missing')
+      await expect(driver.lastModified('missing')).rejects.toThrow('File not found: missing')
+      expect(await driver.metadata('missing')).toBeNull()
+    })
+  })
+
+  describe('files/directories/allFiles', () => {
+    beforeEach(async () => {
+      await driver.put('dir/file1.txt', '1')
+      await driver.put('dir/file2.txt', '2')
+      await driver.put('dir/sub/file3.txt', '3')
+      await driver.put('dir/sub/deep/file4.txt', '4')
+      await driver.put('other/file5.txt', '5')
+    })
+
+    test('files lists direct children only, as app-relative paths', async () => {
+      expect(await driver.files('dir')).toEqual(['dir/file1.txt', 'dir/file2.txt'])
+      expect(await driver.files('/dir/')).toEqual(['dir/file1.txt', 'dir/file2.txt'])
+    })
+
+    test('directories lists direct subdirectories', async () => {
+      expect(await driver.directories('dir')).toEqual(['dir/sub'])
+      expect(await driver.directories('')).toEqual(['dir', 'other'])
+    })
+
+    test('allFiles lists recursively', async () => {
+      expect(await driver.allFiles('dir')).toEqual([
+        'dir/file1.txt',
+        'dir/file2.txt',
+        'dir/sub/deep/file4.txt',
+        'dir/sub/file3.txt',
+      ])
+    })
+
+    test('strips the prefix from listed paths', async () => {
+      const prefixed = new R2Driver({ binding: () => bucket, prefix: 'dir' })
+      expect(await prefixed.files('')).toEqual(['file1.txt', 'file2.txt'])
+      expect(await prefixed.directories('')).toEqual(['sub'])
+      expect(await prefixed.allFiles('sub')).toEqual(['sub/deep/file4.txt', 'sub/file3.txt'])
+    })
+
+    test('follows the cursor across pages', async () => {
+      ;({ bucket, driver } = createDriver({}, { pageSize: 2 }))
+      for (let index = 0; index < 7; index++) await driver.put(`p/${index}.txt`, '')
+      bucket.calls.length = 0
+
+      const files = await driver.allFiles('p')
+
+      expect(files).toHaveLength(7)
+      const lists = bucket.calls.filter((call) => call.method === 'list')
+      expect(lists).toHaveLength(4)
+      expect((lists[1]!.args[0] as { cursor?: string }).cursor).toBeDefined()
+    })
+
+    test('does not list a directory marker as a file', async () => {
+      await driver.makeDirectory('dir/empty')
+      expect(await driver.directories('dir')).toEqual(['dir/empty', 'dir/sub'])
+      expect(await driver.files('dir/empty')).toEqual([])
+    })
+  })
+
+  describe('deleteDirectory', () => {
+    test('deletes everything under the directory', async () => {
+      await driver.put('dir/file1.txt', '1')
+      await driver.put('dir/sub/file2.txt', '2')
+      await driver.put('dir2/file3.txt', '3')
+
+      await driver.deleteDirectory('dir')
+
+      expect(bucket.keys()).toEqual(['dir2/file3.txt'])
+    })
+
+    test('removes folder markers and respects the prefix', async () => {
+      const prefixed = new R2Driver({ binding: () => bucket, prefix: 'app' })
+      await prefixed.makeDirectory('dir/empty')
+      await prefixed.put('dir/a.txt', '1')
+      await bucket.put('other/keep.txt', '')
+
+      await prefixed.deleteDirectory('dir')
+
+      expect(bucket.keys()).toEqual(['other/keep.txt'])
+    })
+  })
+
+  describe('visibility', () => {
+    test('defaults to public when publicUrl is set and private otherwise', async () => {
+      await driver.put('a.txt', 'x')
+      expect(await driver.getVisibility('a.txt')).toBe('public')
+
+      const privateDriver = new R2Driver({ binding: () => bucket })
+      expect(await privateDriver.getVisibility('a.txt')).toBe('private')
+    })
+
+    test('accepts a matching visibility as a no-op', async () => {
+      await driver.put('a.txt', 'x', { visibility: 'public' })
+      await driver.setVisibility('a.txt', 'public')
+      expect(await driver.getVisibility('a.txt')).toBe('public')
+    })
+
+    test('throws on a conflicting visibility instead of pretending', async () => {
+      await expect(driver.put('a.txt', 'x', { visibility: 'private' })).rejects.toThrow(/no per-object visibility/)
+      expect(bucket.keys()).toEqual([])
+
+      await driver.put('a.txt', 'x')
+      await expect(driver.setVisibility('a.txt', 'private')).rejects.toThrow(/no per-object visibility/)
+    })
+
+    test('getVisibility/setVisibility throw for a missing file', async () => {
+      await expect(driver.getVisibility('missing')).rejects.toThrow('File not found: missing')
+      await expect(driver.setVisibility('missing', 'public')).rejects.toThrow('File not found: missing')
+    })
+  })
+})

--- a/packages/plugin-cloudflare/src/storage/R2Driver.ts
+++ b/packages/plugin-cloudflare/src/storage/R2Driver.ts
@@ -1,4 +1,5 @@
 import type { FileMetadata, PutOptions, StorageDriver } from '@guren/core'
+import { presignGetUrl } from './sigv4'
 
 /**
  * Structural view of the R2 binding, in the same spirit as the S3 driver's
@@ -116,18 +117,17 @@ export interface R2DriverOptions {
   visibility?: 'public' | 'private'
   /**
    * S3 API credentials used only by `temporaryUrl()`. Optional — omit it and
-   * `temporaryUrl()` throws with guidance. Requires the optional `aws4fetch`
-   * dependency.
+   * `temporaryUrl()` throws with guidance.
    */
   presign?: R2PresignOptions
 }
-
-type AwsClient = InstanceType<typeof import('aws4fetch').AwsClient>
 
 /** R2 rejects presigned URLs valid for longer than seven days. */
 const MAX_PRESIGN_SECONDS = 7 * 24 * 60 * 60
 /** `R2Bucket.delete()` accepts at most this many keys per call. */
 const DELETE_BATCH_SIZE = 1000
+/** How many delete batches may be in flight at once. */
+const DELETE_CONCURRENCY = 6
 
 /**
  * Cloudflare R2 storage driver over the Workers binding.
@@ -147,7 +147,6 @@ export class R2Driver implements StorageDriver {
   private readonly prefix: string
   private readonly diskVisibility: 'public' | 'private'
   private readonly presign?: R2PresignOptions
-  private awsClient?: Promise<AwsClient>
 
   constructor(options: R2DriverOptions) {
     this.resolveBinding = options.binding
@@ -249,7 +248,12 @@ export class R2Driver implements StorageDriver {
     for (let index = 0; index < keys.length; index += DELETE_BATCH_SIZE) {
       batches.push(keys.slice(index, index + DELETE_BATCH_SIZE))
     }
-    await Promise.all(batches.map((batch) => bucket.delete(batch)))
+    // Bounded fan-out: concurrent enough to hide latency, small enough that
+    // a large deleteMany does not open an unbounded number of binding calls
+    // from one request.
+    for (let index = 0; index < batches.length; index += DELETE_CONCURRENCY) {
+      await Promise.all(batches.slice(index, index + DELETE_CONCURRENCY).map((batch) => bucket.delete(batch)))
+    }
     // R2 reports nothing per key; like S3's DeleteObjects, every requested
     // key counts as deleted.
     return keys.length
@@ -300,30 +304,15 @@ export class R2Driver implements StorageDriver {
         `R2Driver.temporaryUrl(): R2 presigned URLs may be valid for at most 7 days (requested ${expiresIn}s).`,
       )
     }
-    const client = await this.presignClient(this.presign)
-    const url = new URL(
-      `https://${this.presign.accountId}.r2.cloudflarestorage.com/${this.presign.bucket}/${encodeKey(this.key(path))}`,
-    )
-    url.searchParams.set('X-Amz-Expires', String(Math.max(1, expiresIn)))
-    const signed = await client.sign(new Request(url.toString(), { method: 'GET' }), { aws: { signQuery: true } })
-    return signed.url
-  }
-
-  /**
-   * One `AwsClient` per driver: it caches the derived SigV4 signing key, so
-   * a fresh instance per URL would redo the HMAC chain on every call.
-   */
-  private presignClient(presign: R2PresignOptions): Promise<AwsClient> {
-    this.awsClient ??= importOptionalModule<typeof import('aws4fetch')>('aws4fetch').then(
-      ({ AwsClient }) =>
-        new AwsClient({
-          accessKeyId: presign.accessKeyId,
-          secretAccessKey: presign.secretAccessKey,
-          service: 's3',
-          region: 'auto',
-        }),
-    )
-    return this.awsClient
+    return presignGetUrl({
+      url: `https://${this.presign.accountId}.r2.cloudflarestorage.com/${this.presign.bucket}/${encodeKey(this.key(path))}`,
+      accessKeyId: this.presign.accessKeyId,
+      secretAccessKey: this.presign.secretAccessKey,
+      // R2's S3 API is single-region.
+      region: 'auto',
+      service: 's3',
+      expiresIn: Math.max(1, expiresIn),
+    })
   }
 
   async size(path: string): Promise<number> {
@@ -407,9 +396,9 @@ export class R2Driver implements StorageDriver {
     // convention S3 consoles use for folders: `directories()` sees it as a
     // delimited prefix, while the trailing-slash filter keeps it out of
     // `files()`/`allFiles()`.
-    const key = this.key(path)
-    if (!key) return
-    await this.bucket().put(`${key}/`, '')
+    const normalized = trimSlashes(path)
+    if (!normalized) return
+    await this.bucket().put(`${this.key(normalized)}/`, '')
   }
 
   async deleteDirectory(path: string): Promise<void> {
@@ -463,26 +452,4 @@ function trimSlashes(value: string): string {
   while (start < end && value[start] === '/') start++
   while (end > start && value[end - 1] === '/') end--
   return value.slice(start, end)
-}
-
-/**
- * Twin of `S3Driver`'s `importAwsModule` in `@guren/server` (module-private
- * there); the detection stays byte-for-byte the same so a fix lands in both.
- */
-function isMissingModule(error: unknown, moduleName: string): boolean {
-  if (!error || typeof error !== 'object') return false
-  if ((error as { code?: string }).code === 'ERR_MODULE_NOT_FOUND') return true
-  const message = String((error as { message?: string }).message ?? '')
-  return message.includes(`Cannot find package '${moduleName}'`) || message.includes(`Cannot find module '${moduleName}'`)
-}
-
-async function importOptionalModule<T>(moduleName: string): Promise<T> {
-  try {
-    return (await import(moduleName)) as T
-  } catch (error) {
-    if (isMissingModule(error, moduleName)) {
-      throw new Error(`Missing optional dependency "${moduleName}". Install aws4fetch to use R2Driver.temporaryUrl().`)
-    }
-    throw error
-  }
 }

--- a/packages/plugin-cloudflare/src/storage/R2Driver.ts
+++ b/packages/plugin-cloudflare/src/storage/R2Driver.ts
@@ -19,8 +19,6 @@ export interface R2ObjectLike {
   key: string
   size: number
   uploaded: Date
-  etag: string
-  httpEtag: string
   httpMetadata?: R2HttpMetadataLike
   customMetadata?: Record<string, string>
 }
@@ -124,6 +122,8 @@ export interface R2DriverOptions {
   presign?: R2PresignOptions
 }
 
+type AwsClient = InstanceType<typeof import('aws4fetch').AwsClient>
+
 /** R2 rejects presigned URLs valid for longer than seven days. */
 const MAX_PRESIGN_SECONDS = 7 * 24 * 60 * 60
 /** `R2Bucket.delete()` accepts at most this many keys per call. */
@@ -147,6 +147,7 @@ export class R2Driver implements StorageDriver {
   private readonly prefix: string
   private readonly diskVisibility: 'public' | 'private'
   private readonly presign?: R2PresignOptions
+  private awsClient?: Promise<AwsClient>
 
   constructor(options: R2DriverOptions) {
     this.resolveBinding = options.binding
@@ -244,9 +245,11 @@ export class R2Driver implements StorageDriver {
     const keys = Array.from(new Set(rawKeys))
     if (keys.length === 0) return 0
     const bucket = this.bucket()
+    const batches: string[][] = []
     for (let index = 0; index < keys.length; index += DELETE_BATCH_SIZE) {
-      await bucket.delete(keys.slice(index, index + DELETE_BATCH_SIZE))
+      batches.push(keys.slice(index, index + DELETE_BATCH_SIZE))
     }
+    await Promise.all(batches.map((batch) => bucket.delete(batch)))
     // R2 reports nothing per key; like S3's DeleteObjects, every requested
     // key counts as deleted.
     return keys.length
@@ -268,9 +271,9 @@ export class R2Driver implements StorageDriver {
   }
 
   async move(from: string, to: string): Promise<string> {
-    await this.copy(from, to)
+    const destination = await this.copy(from, to)
     await this.bucket().delete(this.key(from))
-    return trimSlashes(to)
+    return destination
   }
 
   url(path: string): string {
@@ -280,8 +283,6 @@ export class R2Driver implements StorageDriver {
           'R2 has no derivable public URL.',
       )
     }
-    // Percent-encode per segment so keys with spaces or `#` produce a URL
-    // that resolves; `/` stays a separator.
     return `${this.publicUrl}/${encodeKey(this.key(path))}`
   }
 
@@ -299,24 +300,30 @@ export class R2Driver implements StorageDriver {
         `R2Driver.temporaryUrl(): R2 presigned URLs may be valid for at most 7 days (requested ${expiresIn}s).`,
       )
     }
-    const { AwsClient } = await importOptionalModule<{
-      AwsClient: new (init: { accessKeyId: string; secretAccessKey: string; service: string; region: string }) => {
-        sign(input: Request, init?: { aws?: { signQuery?: boolean } }): Promise<Request>
-      }
-    }>('aws4fetch')
-
-    const client = new AwsClient({
-      accessKeyId: this.presign.accessKeyId,
-      secretAccessKey: this.presign.secretAccessKey,
-      service: 's3',
-      region: 'auto',
-    })
+    const client = await this.presignClient(this.presign)
     const url = new URL(
       `https://${this.presign.accountId}.r2.cloudflarestorage.com/${this.presign.bucket}/${encodeKey(this.key(path))}`,
     )
     url.searchParams.set('X-Amz-Expires', String(Math.max(1, expiresIn)))
     const signed = await client.sign(new Request(url.toString(), { method: 'GET' }), { aws: { signQuery: true } })
     return signed.url
+  }
+
+  /**
+   * One `AwsClient` per driver: it caches the derived SigV4 signing key, so
+   * a fresh instance per URL would redo the HMAC chain on every call.
+   */
+  private presignClient(presign: R2PresignOptions): Promise<AwsClient> {
+    this.awsClient ??= importOptionalModule<typeof import('aws4fetch')>('aws4fetch').then(
+      ({ AwsClient }) =>
+        new AwsClient({
+          accessKeyId: presign.accessKeyId,
+          secretAccessKey: presign.secretAccessKey,
+          service: 's3',
+          region: 'auto',
+        }),
+    )
+    return this.awsClient
   }
 
   async size(path: string): Promise<number> {
@@ -349,34 +356,35 @@ export class R2Driver implements StorageDriver {
   }
 
   async files(directory: string): Promise<string[]> {
-    const result: string[] = []
-    for await (const page of this.pages({ prefix: this.directoryPrefix(directory), delimiter: '/' })) {
-      for (const object of page.objects) {
-        if (!object.key.endsWith('/')) result.push(this.unkey(object.key))
-      }
-    }
-    return result.sort()
+    return this.collectFiles({ prefix: this.directoryPrefix(directory), delimiter: '/' })
   }
 
   async directories(directory: string): Promise<string[]> {
-    const result = new Set<string>()
+    const result: string[] = []
     for await (const page of this.pages({ prefix: this.directoryPrefix(directory), delimiter: '/' })) {
       for (const prefix of page.delimitedPrefixes) {
         const relative = trimTrailingSlashes(this.unkey(prefix))
-        if (relative) result.add(relative)
-      }
-    }
-    return Array.from(result).sort()
-  }
-
-  async allFiles(directory: string): Promise<string[]> {
-    const result: string[] = []
-    for await (const page of this.pages({ prefix: this.directoryPrefix(directory) })) {
-      for (const object of page.objects) {
-        if (!object.key.endsWith('/')) result.push(this.unkey(object.key))
+        if (relative) result.push(relative)
       }
     }
     return result.sort()
+  }
+
+  async allFiles(directory: string): Promise<string[]> {
+    return this.collectFiles({ prefix: this.directoryPrefix(directory) })
+  }
+
+  /** App-relative paths of every listed object, minus folder markers. */
+  private async collectFiles(options: R2ListOptionsLike): Promise<string[]> {
+    const result: string[] = []
+    for await (const object of this.objects(options)) {
+      if (!object.key.endsWith('/')) result.push(this.unkey(object.key))
+    }
+    return result.sort()
+  }
+
+  private async *objects(options: R2ListOptionsLike): AsyncGenerator<R2ObjectLike> {
+    for await (const page of this.pages(options)) yield* page.objects
   }
 
   /**
@@ -405,13 +413,15 @@ export class R2Driver implements StorageDriver {
   }
 
   async deleteDirectory(path: string): Promise<void> {
-    // Raw keys, not paths: the folder marker written by makeDirectory ends
-    // in `/`, which key() would strip.
-    const keys: string[] = []
+    // Delete page by page (a page is at most 1000 keys, the delete cap)
+    // rather than buffering every key first. Raw keys, not paths: the folder
+    // marker written by makeDirectory ends in `/`, which key() would strip.
+    const bucket = this.bucket()
     for await (const page of this.pages({ prefix: this.directoryPrefix(path) })) {
-      for (const object of page.objects) keys.push(object.key)
+      if (page.objects.length > 0) {
+        await bucket.delete(page.objects.map((object) => object.key))
+      }
     }
-    await this.deleteKeys(keys)
   }
 
   async setVisibility(path: string, visibility: 'public' | 'private'): Promise<void> {
@@ -437,16 +447,16 @@ function encodeKey(key: string): string {
   return key.split('/').map(encodeURIComponent).join('/')
 }
 
+/**
+ * Twins of `@guren/server`'s `support/trim-slashes` (not exported from the
+ * package): regex-free so request-derived paths cannot make them backtrack.
+ */
 function trimTrailingSlashes(value: string): string {
   let end = value.length
   while (end > 0 && value[end - 1] === '/') end--
   return value.slice(0, end)
 }
 
-/**
- * Twin of `@guren/server`'s `trimSlashes` (not exported from the package):
- * regex-free so request-derived paths cannot make it backtrack.
- */
 function trimSlashes(value: string): string {
   let start = 0
   let end = value.length
@@ -455,6 +465,10 @@ function trimSlashes(value: string): string {
   return value.slice(start, end)
 }
 
+/**
+ * Twin of `S3Driver`'s `importAwsModule` in `@guren/server` (module-private
+ * there); the detection stays byte-for-byte the same so a fix lands in both.
+ */
 function isMissingModule(error: unknown, moduleName: string): boolean {
   if (!error || typeof error !== 'object') return false
   if ((error as { code?: string }).code === 'ERR_MODULE_NOT_FOUND') return true

--- a/packages/plugin-cloudflare/src/storage/R2Driver.ts
+++ b/packages/plugin-cloudflare/src/storage/R2Driver.ts
@@ -1,0 +1,472 @@
+import type { FileMetadata, PutOptions, StorageDriver } from '@guren/core'
+
+/**
+ * Structural view of the R2 binding, in the same spirit as the S3 driver's
+ * local `S3Client { send() }`: only what this driver calls, so
+ * `@cloudflare/workers-types` stays a devDependency. `R2Driver.types.test.ts`
+ * pins that the real `R2Bucket` satisfies it.
+ */
+export interface R2HttpMetadataLike {
+  contentType?: string
+  contentLanguage?: string
+  contentDisposition?: string
+  contentEncoding?: string
+  cacheControl?: string
+  cacheExpiry?: Date
+}
+
+export interface R2ObjectLike {
+  key: string
+  size: number
+  uploaded: Date
+  etag: string
+  httpEtag: string
+  httpMetadata?: R2HttpMetadataLike
+  customMetadata?: Record<string, string>
+}
+
+/**
+ * Streams and blobs are typed structurally rather than as the global
+ * `ReadableStream`/`Blob`: `@cloudflare/workers-types` declares its own
+ * interfaces for both, and neither direction is assignable to the runtime
+ * globals, so naming the globals here would make the real `R2Bucket` fail
+ * the `R2BucketLike` check while being perfectly usable at runtime.
+ */
+export interface R2StreamLike {
+  locked: boolean
+  getReader(): unknown
+  cancel(reason?: unknown): Promise<void>
+}
+
+export interface R2BlobLike {
+  size: number
+  type: string
+  arrayBuffer(): Promise<ArrayBuffer>
+  text(): Promise<string>
+}
+
+export interface R2ObjectBodyLike extends R2ObjectLike {
+  body: R2StreamLike
+  arrayBuffer(): Promise<ArrayBuffer>
+  text(): Promise<string>
+}
+
+export interface R2ObjectsLike {
+  objects: R2ObjectLike[]
+  truncated: boolean
+  cursor?: string
+  delimitedPrefixes: string[]
+}
+
+export interface R2ListOptionsLike {
+  prefix?: string
+  delimiter?: string
+  cursor?: string
+  limit?: number
+}
+
+export interface R2PutOptionsLike {
+  httpMetadata?: R2HttpMetadataLike
+  customMetadata?: Record<string, string>
+}
+
+export type R2PutValue = R2StreamLike | R2BlobLike | ArrayBuffer | ArrayBufferView | string | null
+
+export interface R2BucketLike {
+  head(key: string): Promise<R2ObjectLike | null>
+  get(key: string): Promise<R2ObjectBodyLike | null>
+  put(key: string, value: R2PutValue, options?: R2PutOptionsLike): Promise<R2ObjectLike | null>
+  delete(keys: string | string[]): Promise<void>
+  list(options?: R2ListOptionsLike): Promise<R2ObjectsLike>
+}
+
+export interface R2PresignOptions {
+  /** Cloudflare account id — the S3 endpoint is `https://<accountId>.r2.cloudflarestorage.com`. */
+  accountId: string
+  /** Bucket name as R2 knows it (the binding does not expose it). */
+  bucket: string
+  /** R2 API token credentials (S3-compatible access key pair). */
+  accessKeyId: string
+  secretAccessKey: string
+}
+
+export interface R2DriverOptions {
+  /**
+   * Resolver returning the R2 bucket binding. Bindings arrive with the first
+   * request on Workers, so this must be a deferred closure, e.g.
+   * `binding: () => getWorkersEnv<Env>().BUCKET` — the same contract as
+   * `createD1Database({ binding })`.
+   */
+  binding: () => unknown
+  /**
+   * Base URL for `url()`: the bucket's custom domain (recommended) or its
+   * r2.dev subdomain. R2 has no derivable default — unlike S3 there is no
+   * `https://<bucket>.s3.<region>.amazonaws.com` — so `url()` throws with
+   * guidance when this is unset.
+   */
+  publicUrl?: string
+  /** Key prefix, same semantics as `S3DriverOptions.prefix`. */
+  prefix?: string
+  /**
+   * The visibility every object in this bucket effectively has. R2 has no
+   * per-object ACL: a bucket is public (custom domain / r2.dev) or it is not.
+   * Defaults to `'public'` when `publicUrl` is set, `'private'` otherwise.
+   * `put({ visibility })` and `setVisibility()` throw when asked for the
+   * other value — the driver refuses to pretend it can enforce a per-object
+   * flag it cannot.
+   */
+  visibility?: 'public' | 'private'
+  /**
+   * S3 API credentials used only by `temporaryUrl()`. Optional — omit it and
+   * `temporaryUrl()` throws with guidance. Requires the optional `aws4fetch`
+   * dependency.
+   */
+  presign?: R2PresignOptions
+}
+
+/** R2 rejects presigned URLs valid for longer than seven days. */
+const MAX_PRESIGN_SECONDS = 7 * 24 * 60 * 60
+/** `R2Bucket.delete()` accepts at most this many keys per call. */
+const DELETE_BATCH_SIZE = 1000
+
+/**
+ * Cloudflare R2 storage driver over the Workers binding.
+ *
+ * @example
+ * ```ts
+ * const storage = createStorageManager({ default: 'media' })
+ * storage.registerDisk('media', () => new R2Driver({
+ *   binding: () => getWorkersEnv<Env>().MEDIA,
+ *   publicUrl: 'https://media.example.com',
+ * }))
+ * ```
+ */
+export class R2Driver implements StorageDriver {
+  private readonly resolveBinding: () => unknown
+  private readonly publicUrl?: string
+  private readonly prefix: string
+  private readonly diskVisibility: 'public' | 'private'
+  private readonly presign?: R2PresignOptions
+
+  constructor(options: R2DriverOptions) {
+    this.resolveBinding = options.binding
+    this.publicUrl = options.publicUrl ? trimTrailingSlashes(options.publicUrl) : undefined
+    this.prefix = trimSlashes(options.prefix ?? '')
+    this.diskVisibility = options.visibility ?? (options.publicUrl ? 'public' : 'private')
+    this.presign = options.presign
+  }
+
+  private bucket(): R2BucketLike {
+    const binding = this.resolveBinding()
+    if (binding == null) {
+      throw new Error(
+        'R2Driver: the "binding" resolver returned no R2 bucket. On Workers this usually means it ran ' +
+          'before the first request — defer access (e.g. binding: () => getWorkersEnv<Env>().BUCKET) and ' +
+          'check the r2_buckets entry in wrangler.jsonc, e.g. ' +
+          '"r2_buckets": [{ "binding": "BUCKET", "bucket_name": "my-app-media" }].',
+      )
+    }
+    return binding as R2BucketLike
+  }
+
+  private key(path: string): string {
+    const normalized = trimSlashes(path)
+    if (!this.prefix) return normalized
+    return normalized ? `${this.prefix}/${normalized}` : this.prefix
+  }
+
+  /** Inverse of `key()`: strips the prefix so listings return app-relative paths. */
+  private unkey(key: string): string {
+    return this.prefix && key.startsWith(`${this.prefix}/`) ? key.slice(this.prefix.length + 1) : key
+  }
+
+  private directoryPrefix(directory: string): string {
+    const key = this.key(directory)
+    return key ? `${key}/` : ''
+  }
+
+  private assertVisibility(requested: 'public' | 'private' | undefined, operation: string): void {
+    if (requested && requested !== this.diskVisibility) {
+      throw new Error(
+        `R2Driver.${operation}: cannot make an object ${requested} on a ${this.diskVisibility} bucket. ` +
+          'R2 has no per-object visibility — access is decided per bucket (custom domain / r2.dev). ' +
+          `Declare the bucket’s visibility with the driver’s "visibility" option, or serve private files ` +
+          'through a signed app route.',
+      )
+    }
+  }
+
+  async put(path: string, content: Buffer | string, options?: PutOptions): Promise<string> {
+    this.assertVisibility(options?.visibility, 'put')
+    const putOptions: R2PutOptionsLike = {}
+    if (options?.contentType) putOptions.httpMetadata = { contentType: options.contentType }
+    if (options?.metadata) putOptions.customMetadata = options.metadata
+    await this.bucket().put(this.key(path), content, putOptions)
+    return trimSlashes(path)
+  }
+
+  async putFile(_path: string, _localPath: string, _options?: PutOptions): Promise<string> {
+    throw new Error(
+      'R2Driver.putFile is not supported: Workers has no filesystem to read from. Read the file yourself and call put().',
+    )
+  }
+
+  async get(path: string): Promise<Buffer | null> {
+    const object = await this.bucket().get(this.key(path))
+    if (!object) return null
+    return Buffer.from(await object.arrayBuffer())
+  }
+
+  async getAsString(path: string): Promise<string | null> {
+    const object = await this.bucket().get(this.key(path))
+    return object ? object.text() : null
+  }
+
+  async exists(path: string): Promise<boolean> {
+    return (await this.bucket().head(this.key(path))) !== null
+  }
+
+  async delete(path: string): Promise<boolean> {
+    // R2Bucket.delete() is void and idempotent; the contract's "false when
+    // missing" needs a head first (a Class B read — cheap).
+    const bucket = this.bucket()
+    const key = this.key(path)
+    if ((await bucket.head(key)) === null) return false
+    await bucket.delete(key)
+    return true
+  }
+
+  async deleteMany(paths: string[]): Promise<number> {
+    return this.deleteKeys(paths.map((path) => this.key(path)))
+  }
+
+  private async deleteKeys(rawKeys: string[]): Promise<number> {
+    const keys = Array.from(new Set(rawKeys))
+    if (keys.length === 0) return 0
+    const bucket = this.bucket()
+    for (let index = 0; index < keys.length; index += DELETE_BATCH_SIZE) {
+      await bucket.delete(keys.slice(index, index + DELETE_BATCH_SIZE))
+    }
+    // R2 reports nothing per key; like S3's DeleteObjects, every requested
+    // key counts as deleted.
+    return keys.length
+  }
+
+  async copy(from: string, to: string): Promise<string> {
+    // The binding has no copy: stream the body from one key into another,
+    // carrying the metadata across.
+    const bucket = this.bucket()
+    const source = await bucket.get(this.key(from))
+    if (!source) {
+      throw new Error(`File not found: ${from}`)
+    }
+    const options: R2PutOptionsLike = {}
+    if (source.httpMetadata) options.httpMetadata = source.httpMetadata
+    if (source.customMetadata) options.customMetadata = source.customMetadata
+    await bucket.put(this.key(to), source.body, options)
+    return trimSlashes(to)
+  }
+
+  async move(from: string, to: string): Promise<string> {
+    await this.copy(from, to)
+    await this.bucket().delete(this.key(from))
+    return trimSlashes(to)
+  }
+
+  url(path: string): string {
+    if (!this.publicUrl) {
+      throw new Error(
+        'R2Driver.url() requires the "publicUrl" option (the bucket’s custom domain or r2.dev subdomain). ' +
+          'R2 has no derivable public URL.',
+      )
+    }
+    return `${this.publicUrl}/${this.key(path)}`
+  }
+
+  async temporaryUrl(path: string, expiration: Date): Promise<string> {
+    if (!this.presign) {
+      throw new Error(
+        'R2Driver.temporaryUrl() cannot sign URLs through the R2 binding. Either configure ' +
+          '"presign: { accountId, bucket, accessKeyId, secretAccessKey }" (an R2 API token, used with the ' +
+          'S3-compatible endpoint) or serve private files through a signed app route.',
+      )
+    }
+    const expiresIn = Math.floor((expiration.getTime() - Date.now()) / 1000)
+    if (expiresIn > MAX_PRESIGN_SECONDS) {
+      throw new Error(
+        `R2Driver.temporaryUrl(): R2 presigned URLs may be valid for at most 7 days (requested ${expiresIn}s).`,
+      )
+    }
+    const { AwsClient } = await importOptionalModule<{
+      AwsClient: new (init: { accessKeyId: string; secretAccessKey: string; service: string; region: string }) => {
+        sign(input: Request, init?: { aws?: { signQuery?: boolean } }): Promise<Request>
+      }
+    }>('aws4fetch')
+
+    const client = new AwsClient({
+      accessKeyId: this.presign.accessKeyId,
+      secretAccessKey: this.presign.secretAccessKey,
+      service: 's3',
+      region: 'auto',
+    })
+    const url = new URL(
+      `https://${this.presign.accountId}.r2.cloudflarestorage.com/${this.presign.bucket}/${encodeKey(this.key(path))}`,
+    )
+    url.searchParams.set('X-Amz-Expires', String(Math.max(1, expiresIn)))
+    const signed = await client.sign(new Request(url.toString(), { method: 'GET' }), { aws: { signQuery: true } })
+    return signed.url
+  }
+
+  async size(path: string): Promise<number> {
+    return (await this.metadataOrFail(path)).size
+  }
+
+  async lastModified(path: string): Promise<Date> {
+    return (await this.metadataOrFail(path)).lastModified
+  }
+
+  private async metadataOrFail(path: string): Promise<FileMetadata> {
+    const metadata = await this.metadata(path)
+    if (!metadata) {
+      throw new Error(`File not found: ${path}`)
+    }
+    return metadata
+  }
+
+  async metadata(path: string): Promise<FileMetadata | null> {
+    const object = await this.bucket().head(this.key(path))
+    if (!object) return null
+    return {
+      path: trimSlashes(path),
+      size: object.size,
+      lastModified: object.uploaded,
+      contentType: object.httpMetadata?.contentType,
+      visibility: this.diskVisibility,
+      metadata: object.customMetadata,
+    }
+  }
+
+  async files(directory: string): Promise<string[]> {
+    const result: string[] = []
+    for await (const page of this.pages({ prefix: this.directoryPrefix(directory), delimiter: '/' })) {
+      for (const object of page.objects) {
+        if (!object.key.endsWith('/')) result.push(this.unkey(object.key))
+      }
+    }
+    return result.sort()
+  }
+
+  async directories(directory: string): Promise<string[]> {
+    const result = new Set<string>()
+    for await (const page of this.pages({ prefix: this.directoryPrefix(directory), delimiter: '/' })) {
+      for (const prefix of page.delimitedPrefixes) {
+        const relative = trimTrailingSlashes(this.unkey(prefix))
+        if (relative) result.add(relative)
+      }
+    }
+    return Array.from(result).sort()
+  }
+
+  async allFiles(directory: string): Promise<string[]> {
+    const result: string[] = []
+    for await (const page of this.pages({ prefix: this.directoryPrefix(directory) })) {
+      for (const object of page.objects) {
+        if (!object.key.endsWith('/')) result.push(this.unkey(object.key))
+      }
+    }
+    return result.sort()
+  }
+
+  /**
+   * Follows `cursor` until `truncated` is false. A single `list()` call is
+   * capped at 1000 keys, so a one-page read (what `S3Driver.allFiles` does)
+   * silently truncates larger directories.
+   */
+  private async *pages(options: R2ListOptionsLike): AsyncGenerator<R2ObjectsLike> {
+    const bucket = this.bucket()
+    let cursor: string | undefined
+    do {
+      const page = await bucket.list(cursor ? { ...options, cursor } : options)
+      yield page
+      cursor = page.truncated ? page.cursor : undefined
+    } while (cursor)
+  }
+
+  async makeDirectory(path: string): Promise<void> {
+    // R2 has no directories. A zero-byte object whose key ends in `/` is the
+    // convention S3 consoles use for folders: `directories()` sees it as a
+    // delimited prefix, while the trailing-slash filter keeps it out of
+    // `files()`/`allFiles()`.
+    const key = this.key(path)
+    if (!key) return
+    await this.bucket().put(`${key}/`, '')
+  }
+
+  async deleteDirectory(path: string): Promise<void> {
+    // Raw keys, not paths: the folder marker written by makeDirectory ends
+    // in `/`, which key() would strip.
+    const keys: string[] = []
+    for await (const page of this.pages({ prefix: this.directoryPrefix(path) })) {
+      for (const object of page.objects) keys.push(object.key)
+    }
+    await this.deleteKeys(keys)
+  }
+
+  async setVisibility(path: string, visibility: 'public' | 'private'): Promise<void> {
+    this.assertVisibility(visibility, 'setVisibility')
+    // Equal to the bucket's visibility: nothing to do, but keep the
+    // not-found contract the other drivers honour.
+    await this.metadataOrFail(path)
+  }
+
+  async getVisibility(path: string): Promise<'public' | 'private'> {
+    await this.metadataOrFail(path)
+    return this.diskVisibility
+  }
+
+  /** The key prefix (for tests and diagnostics). */
+  getPrefix(): string {
+    return this.prefix
+  }
+}
+
+/** Percent-encode a key for the S3 URL path, keeping `/` as a separator. */
+function encodeKey(key: string): string {
+  return key.split('/').map(encodeURIComponent).join('/')
+}
+
+function trimTrailingSlashes(value: string): string {
+  let end = value.length
+  while (end > 0 && value[end - 1] === '/') end--
+  return value.slice(0, end)
+}
+
+/**
+ * Twin of `@guren/server`'s `trimSlashes` (not exported from the package):
+ * regex-free so request-derived paths cannot make it backtrack.
+ */
+function trimSlashes(value: string): string {
+  let start = 0
+  let end = value.length
+  while (start < end && value[start] === '/') start++
+  while (end > start && value[end - 1] === '/') end--
+  return value.slice(start, end)
+}
+
+function isMissingModule(error: unknown, moduleName: string): boolean {
+  if (!error || typeof error !== 'object') return false
+  if ((error as { code?: string }).code === 'ERR_MODULE_NOT_FOUND') return true
+  const message = String((error as { message?: string }).message ?? '')
+  return message.includes(`Cannot find package '${moduleName}'`) || message.includes(`Cannot find module '${moduleName}'`)
+}
+
+async function importOptionalModule<T>(moduleName: string): Promise<T> {
+  try {
+    return (await import(moduleName)) as T
+  } catch (error) {
+    if (isMissingModule(error, moduleName)) {
+      throw new Error(`Missing optional dependency "${moduleName}". Install aws4fetch to use R2Driver.temporaryUrl().`)
+    }
+    throw error
+  }
+}

--- a/packages/plugin-cloudflare/src/storage/R2Driver.ts
+++ b/packages/plugin-cloudflare/src/storage/R2Driver.ts
@@ -280,7 +280,9 @@ export class R2Driver implements StorageDriver {
           'R2 has no derivable public URL.',
       )
     }
-    return `${this.publicUrl}/${this.key(path)}`
+    // Percent-encode per segment so keys with spaces or `#` produce a URL
+    // that resolves; `/` stays a separator.
+    return `${this.publicUrl}/${encodeKey(this.key(path))}`
   }
 
   async temporaryUrl(path: string, expiration: Date): Promise<string> {

--- a/packages/plugin-cloudflare/src/storage/R2Driver.types.test.ts
+++ b/packages/plugin-cloudflare/src/storage/R2Driver.types.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test'
+import type { R2Bucket } from '@cloudflare/workers-types'
+import type { R2BucketLike } from './R2Driver'
+
+// Compile-time contract: the real Workers `R2Bucket` must satisfy the
+// structural `R2BucketLike` the driver is written against. If workers-types
+// renames or retypes a member this driver reads, `tsc --noEmit` fails here
+// instead of the driver failing at runtime.
+type Assignable<From, To> = From extends To ? true : never
+const bucketIsBucketLike: Assignable<R2Bucket, R2BucketLike> = true
+
+// And the other direction for what the driver *passes in*: every option the
+// driver hands to put()/list() must be a legal option for the real binding.
+type PutOptionsOf<B> = B extends { put(key: string, value: never, options?: infer O): unknown } ? O : never
+type ListOptionsOf<B> = B extends { list(options?: infer O): unknown } ? O : never
+const putOptionsFit: Assignable<PutOptionsOf<R2BucketLike>, PutOptionsOf<R2Bucket>> = true
+const listOptionsFit: Assignable<ListOptionsOf<R2BucketLike>, ListOptionsOf<R2Bucket>> = true
+
+describe('R2BucketLike', () => {
+  test('is satisfied by @cloudflare/workers-types R2Bucket (checked at typecheck time)', () => {
+    expect(bucketIsBucketLike && putOptionsFit && listOptionsFit).toBe(true)
+  })
+})

--- a/packages/plugin-cloudflare/src/storage/fake-r2-bucket.ts
+++ b/packages/plugin-cloudflare/src/storage/fake-r2-bucket.ts
@@ -1,0 +1,164 @@
+import type {
+  R2BucketLike,
+  R2ListOptionsLike,
+  R2ObjectBodyLike,
+  R2ObjectLike,
+  R2ObjectsLike,
+  R2PutOptionsLike,
+  R2PutValue,
+} from './R2Driver'
+
+interface StoredObject {
+  bytes: Uint8Array
+  uploaded: Date
+  httpMetadata?: R2ObjectBodyLike['httpMetadata']
+  customMetadata?: Record<string, string>
+}
+
+export interface FakeR2BucketOptions {
+  /**
+   * Page size for `list()` when the caller passes no `limit`. The real
+   * default is 1000; tests lower it to exercise cursor pagination.
+   */
+  pageSize?: number
+  /** Clock for `uploaded`, so tests can assert timestamps. */
+  now?: () => Date
+}
+
+/**
+ * In-memory `R2BucketLike` with the semantics the driver relies on: sorted
+ * listing, prefix/delimiter grouping, cursor pagination, the 1000-key
+ * `delete()` cap, and `R2ObjectBody` readers. It is a test double, not a
+ * spec — the opt-in Miniflare test in `r2-miniflare.test.ts` runs the same
+ * assertions against workerd's R2 to keep this honest.
+ */
+export class FakeR2Bucket implements R2BucketLike {
+  private readonly objects = new Map<string, StoredObject>()
+  private readonly pageSize: number
+  private readonly now: () => Date
+  /** Every call, for assertions on batching and pagination. */
+  readonly calls: Array<{ method: keyof R2BucketLike; args: unknown[] }> = []
+
+  constructor(options: FakeR2BucketOptions = {}) {
+    this.pageSize = options.pageSize ?? 1000
+    this.now = options.now ?? (() => new Date())
+  }
+
+  async head(key: string): Promise<R2ObjectLike | null> {
+    this.calls.push({ method: 'head', args: [key] })
+    const stored = this.objects.get(key)
+    return stored ? this.toObject(key, stored) : null
+  }
+
+  async get(key: string): Promise<R2ObjectBodyLike | null> {
+    this.calls.push({ method: 'get', args: [key] })
+    const stored = this.objects.get(key)
+    if (!stored) return null
+    const bytes = stored.bytes
+    return {
+      ...this.toObject(key, stored),
+      body: new Blob([new Uint8Array(bytes)]).stream(),
+      async arrayBuffer() {
+        return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer
+      },
+      async text() {
+        return new TextDecoder().decode(bytes)
+      },
+    }
+  }
+
+  async put(key: string, value: R2PutValue, options?: R2PutOptionsLike): Promise<R2ObjectLike | null> {
+    this.calls.push({ method: 'put', args: [key, value, options] })
+    const stored: StoredObject = {
+      bytes: await toBytes(value),
+      uploaded: this.now(),
+      httpMetadata: options?.httpMetadata,
+      customMetadata: options?.customMetadata,
+    }
+    this.objects.set(key, stored)
+    return this.toObject(key, stored)
+  }
+
+  async delete(keys: string | string[]): Promise<void> {
+    this.calls.push({ method: 'delete', args: [keys] })
+    const list = Array.isArray(keys) ? keys : [keys]
+    if (list.length > 1000) {
+      throw new Error('FakeR2Bucket: delete() accepts at most 1000 keys per call')
+    }
+    for (const key of list) this.objects.delete(key)
+  }
+
+  async list(options: R2ListOptionsLike = {}): Promise<R2ObjectsLike> {
+    this.calls.push({ method: 'list', args: [options] })
+    const prefix = options.prefix ?? ''
+    const delimiter = options.delimiter
+    const limit = options.limit ?? this.pageSize
+
+    // One sorted entry list mixing objects and delimited prefixes, so the
+    // cursor is simply "how many entries were already returned".
+    const entries: Array<{ key: string; kind: 'object' | 'prefix' }> = []
+    const seenPrefixes = new Set<string>()
+    for (const key of Array.from(this.objects.keys()).sort()) {
+      if (!key.startsWith(prefix)) continue
+      const rest = key.slice(prefix.length)
+      const delimiterAt = delimiter ? rest.indexOf(delimiter) : -1
+      if (delimiter && delimiterAt !== -1) {
+        const grouped = prefix + rest.slice(0, delimiterAt + delimiter.length)
+        if (!seenPrefixes.has(grouped)) {
+          seenPrefixes.add(grouped)
+          entries.push({ key: grouped, kind: 'prefix' })
+        }
+        continue
+      }
+      entries.push({ key, kind: 'object' })
+    }
+
+    const start = options.cursor ? Number.parseInt(options.cursor, 10) : 0
+    const page = entries.slice(start, start + limit)
+    const truncated = start + limit < entries.length
+
+    return {
+      objects: page
+        .filter((entry) => entry.kind === 'object')
+        .map((entry) => this.toObject(entry.key, this.objects.get(entry.key)!)),
+      delimitedPrefixes: page.filter((entry) => entry.kind === 'prefix').map((entry) => entry.key),
+      truncated,
+      cursor: truncated ? String(start + limit) : undefined,
+    }
+  }
+
+  /** Test helpers. */
+  keys(): string[] {
+    return Array.from(this.objects.keys()).sort()
+  }
+
+  clear(): void {
+    this.objects.clear()
+    this.calls.length = 0
+  }
+
+  private toObject(key: string, stored: StoredObject): R2ObjectLike {
+    const etag = `"${stored.bytes.byteLength.toString(16)}-${key.length.toString(16)}"`
+    return {
+      key,
+      size: stored.bytes.byteLength,
+      uploaded: stored.uploaded,
+      etag: etag.slice(1, -1),
+      httpEtag: etag,
+      httpMetadata: stored.httpMetadata,
+      customMetadata: stored.customMetadata,
+    }
+  }
+}
+
+async function toBytes(value: R2PutValue): Promise<Uint8Array> {
+  if (value === null) return new Uint8Array()
+  if (typeof value === 'string') return new TextEncoder().encode(value)
+  if (value instanceof ArrayBuffer) return new Uint8Array(value.slice(0))
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength))
+  }
+  if ('arrayBuffer' in value) return new Uint8Array(await value.arrayBuffer())
+  // A stream: drain it the way workerd would.
+  return new Uint8Array(await new Response(value as unknown as ReadableStream).arrayBuffer())
+}

--- a/packages/plugin-cloudflare/src/storage/fake-r2-bucket.ts
+++ b/packages/plugin-cloudflare/src/storage/fake-r2-bucket.ts
@@ -94,11 +94,13 @@ export class FakeR2Bucket implements R2BucketLike {
     const delimiter = options.delimiter
     const limit = options.limit ?? this.pageSize
 
-    // One sorted entry list mixing objects and delimited prefixes, so the
-    // cursor is simply "how many entries were already returned".
+    // One sorted entry list mixing objects and delimited prefixes. The
+    // cursor is the last key returned, not an offset: R2 resumes *after a
+    // key*, so a caller that deletes what it listed (deleteDirectory) must
+    // not skip entries — an offset cursor would.
     const entries: Array<{ key: string; kind: 'object' | 'prefix' }> = []
     const seenPrefixes = new Set<string>()
-    for (const key of Array.from(this.objects.keys()).sort()) {
+    for (const key of this.keys()) {
       if (!key.startsWith(prefix)) continue
       const rest = key.slice(prefix.length)
       const delimiterAt = delimiter ? rest.indexOf(delimiter) : -1
@@ -113,9 +115,9 @@ export class FakeR2Bucket implements R2BucketLike {
       entries.push({ key, kind: 'object' })
     }
 
-    const start = options.cursor ? Number.parseInt(options.cursor, 10) : 0
-    const page = entries.slice(start, start + limit)
-    const truncated = start + limit < entries.length
+    const remaining = options.cursor ? entries.filter((entry) => entry.key > options.cursor!) : entries
+    const page = remaining.slice(0, limit)
+    const truncated = remaining.length > limit
 
     return {
       objects: page
@@ -123,28 +125,20 @@ export class FakeR2Bucket implements R2BucketLike {
         .map((entry) => this.toObject(entry.key, this.objects.get(entry.key)!)),
       delimitedPrefixes: page.filter((entry) => entry.kind === 'prefix').map((entry) => entry.key),
       truncated,
-      cursor: truncated ? String(start + limit) : undefined,
+      cursor: truncated ? page[page.length - 1]!.key : undefined,
     }
   }
 
-  /** Test helpers. */
+  /** Sorted keys, for assertions. */
   keys(): string[] {
     return Array.from(this.objects.keys()).sort()
   }
 
-  clear(): void {
-    this.objects.clear()
-    this.calls.length = 0
-  }
-
   private toObject(key: string, stored: StoredObject): R2ObjectLike {
-    const etag = `"${stored.bytes.byteLength.toString(16)}-${key.length.toString(16)}"`
     return {
       key,
       size: stored.bytes.byteLength,
       uploaded: stored.uploaded,
-      etag: etag.slice(1, -1),
-      httpEtag: etag,
       httpMetadata: stored.httpMetadata,
       customMetadata: stored.customMetadata,
     }

--- a/packages/plugin-cloudflare/src/storage/r2-driver-conformance.ts
+++ b/packages/plugin-cloudflare/src/storage/r2-driver-conformance.ts
@@ -149,14 +149,18 @@ export function describeR2DriverConformance(name: string, harness: R2Conformance
         expect(await driver.size('a.txt')).toBe(5)
         expect(await driver.lastModified('a.txt')).toBeInstanceOf(Date)
         const metadata = await driver.metadata('a.txt')
-        expect(metadata).toMatchObject({
+        expect(metadata?.lastModified).toBeInstanceOf(Date)
+        // Exact, not a subset: an unexpected extra field or a dropped one is
+        // the drift this assertion exists to catch. Only the timestamp is
+        // excluded, since it differs per backend.
+        expect({ ...metadata, lastModified: undefined }).toEqual({
           path: 'a.txt',
           size: 5,
+          lastModified: undefined,
           contentType: 'text/plain',
           visibility: 'public',
           metadata: { k: 'v' },
         })
-        expect(metadata?.lastModified).toBeInstanceOf(Date)
       })
 
       test('throws for size/lastModified of a missing file and returns null metadata', async () => {

--- a/packages/plugin-cloudflare/src/storage/r2-driver-conformance.ts
+++ b/packages/plugin-cloudflare/src/storage/r2-driver-conformance.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { R2Driver, type R2BucketLike, type R2DriverOptions } from './R2Driver'
+
+export interface R2ConformanceHarness {
+  /** A bucket for the suite; called once. */
+  bucket(): Promise<R2BucketLike>
+  /** Empties the bucket between tests. */
+  reset(bucket: R2BucketLike): Promise<void>
+  /**
+   * Whether `copy()`/`move()` can run in this harness. The driver pipes
+   * `get().body` into `put()`; Miniflare's binding proxy cannot marshal that
+   * stream, so its harness runs those two methods inside workerd instead.
+   */
+  streamingCopy: boolean
+}
+
+/**
+ * The driver-level contract, written once and run against both
+ * `FakeR2Bucket` and workerd's real R2 (opt-in) — so every semantic the fake
+ * encodes is also asserted against the runtime, not only the ones somebody
+ * remembered to duplicate. Harness-specific assertions (call counts,
+ * pagination page size, presign URL shape) live in the callers.
+ */
+export function describeR2DriverConformance(name: string, harness: R2ConformanceHarness): void {
+  describe(name, () => {
+    let bucket: R2BucketLike
+    let driver: R2Driver
+    const make = (options: Partial<R2DriverOptions> = {}) =>
+      new R2Driver({ binding: () => bucket, publicUrl: 'https://media.example.com', ...options })
+
+    beforeEach(async () => {
+      bucket ??= await harness.bucket()
+      await harness.reset(bucket)
+      driver = make()
+    })
+
+    describe('put/get', () => {
+      test('stores and retrieves a string', async () => {
+        await driver.put('test.txt', 'Hello, World!')
+        expect((await driver.get('test.txt'))?.toString()).toBe('Hello, World!')
+        expect(await driver.getAsString('test.txt')).toBe('Hello, World!')
+      })
+
+      test('stores a Buffer and reads it back as a Buffer', async () => {
+        await driver.put('binary.bin', Buffer.from([1, 2, 3, 255]))
+        const content = await driver.get('binary.bin')
+        expect(content).toBeInstanceOf(Buffer)
+        expect(Array.from(content!)).toEqual([1, 2, 3, 255])
+      })
+
+      test('returns null for a missing file', async () => {
+        expect(await driver.get('missing.txt')).toBeNull()
+        expect(await driver.getAsString('missing.txt')).toBeNull()
+      })
+
+      test('normalizes leading and trailing slashes and returns the stored path', async () => {
+        expect(await driver.put('/path/to/file.txt/', 'content')).toBe('path/to/file.txt')
+        expect(await driver.getAsString('path/to/file.txt')).toBe('content')
+        expect(await driver.allFiles('')).toEqual(['path/to/file.txt'])
+      })
+
+      test('round-trips contentType and custom metadata', async () => {
+        await driver.put('a.json', '{}', { contentType: 'application/json', metadata: { owner: '42' } })
+        const metadata = await driver.metadata('a.json')
+        expect(metadata?.contentType).toBe('application/json')
+        expect(metadata?.metadata).toEqual({ owner: '42' })
+      })
+
+      test('scopes every key under the prefix', async () => {
+        const prefixed = make({ prefix: '/uploads/' })
+        await prefixed.put('a.txt', 'x')
+        expect(await driver.allFiles('uploads')).toEqual(['uploads/a.txt'])
+        expect(await prefixed.getAsString('a.txt')).toBe('x')
+        expect(prefixed.getPrefix()).toBe('uploads')
+      })
+    })
+
+    test('putFile throws: Workers has no filesystem', async () => {
+      await expect(driver.putFile('a.txt', '/tmp/a.txt')).rejects.toThrow(/no filesystem/)
+    })
+
+    test('exists reflects presence', async () => {
+      await driver.put('test.txt', 'content')
+      expect(await driver.exists('test.txt')).toBe(true)
+      expect(await driver.exists('missing.txt')).toBe(false)
+    })
+
+    describe('delete/deleteMany', () => {
+      test('delete returns true when the object existed and false when it did not', async () => {
+        await driver.put('test.txt', 'content')
+        expect(await driver.delete('test.txt')).toBe(true)
+        expect(await driver.exists('test.txt')).toBe(false)
+        expect(await driver.delete('test.txt')).toBe(false)
+      })
+
+      test('deleteMany returns 0 for no paths and deduplicates the rest', async () => {
+        expect(await driver.deleteMany([])).toBe(0)
+        await driver.put('a.txt', 'x')
+        await driver.put('b.txt', 'y')
+        expect(await driver.deleteMany(['a.txt', '/a.txt', 'a.txt/', 'b.txt'])).toBe(2)
+        expect(await driver.allFiles('')).toEqual([])
+      })
+    })
+
+    describe.skipIf(!harness.streamingCopy)('copy/move', () => {
+      test('copies bytes and metadata to the new key', async () => {
+        await driver.put('src.txt', 'content', { contentType: 'text/plain', metadata: { k: 'v' } })
+        expect(await driver.copy('src.txt', 'dst.txt')).toBe('dst.txt')
+        expect(await driver.getAsString('dst.txt')).toBe('content')
+        expect(await driver.getAsString('src.txt')).toBe('content')
+        const copied = await driver.metadata('dst.txt')
+        expect(copied?.contentType).toBe('text/plain')
+        expect(copied?.metadata).toEqual({ k: 'v' })
+      })
+
+      test('throws when the source is missing', async () => {
+        await expect(driver.copy('missing.txt', 'dst.txt')).rejects.toThrow('File not found: missing.txt')
+      })
+
+      test('moves by copying then deleting the source', async () => {
+        await driver.put('src.txt', 'content')
+        expect(await driver.move('src.txt', 'dst.txt')).toBe('dst.txt')
+        expect(await driver.exists('src.txt')).toBe(false)
+        expect(await driver.getAsString('dst.txt')).toBe('content')
+      })
+    })
+
+    describe('url', () => {
+      test('joins publicUrl, prefix and key, percent-encoding segments', () => {
+        const prefixed = make({ publicUrl: 'https://media.example.com/', prefix: 'uploads' })
+        expect(prefixed.url('/a/b.png')).toBe('https://media.example.com/uploads/a/b.png')
+        expect(driver.url('a b/c#1.png')).toBe('https://media.example.com/a%20b/c%231.png')
+      })
+
+      test('throws without publicUrl', () => {
+        expect(() => make({ publicUrl: undefined }).url('a.png')).toThrow(/publicUrl/)
+      })
+    })
+
+    test('temporaryUrl throws with guidance when presign is not configured', async () => {
+      const soon = new Date(Date.now() + 60_000)
+      await expect(driver.temporaryUrl('a.png', soon)).rejects.toThrow(/presign/)
+      await expect(driver.temporaryUrl('a.png', soon)).rejects.toThrow(/signed app route/)
+    })
+
+    describe('size/lastModified/metadata', () => {
+      test('reads from head()', async () => {
+        await driver.put('a.txt', 'hello', { contentType: 'text/plain', metadata: { k: 'v' } })
+        expect(await driver.size('a.txt')).toBe(5)
+        expect(await driver.lastModified('a.txt')).toBeInstanceOf(Date)
+        const metadata = await driver.metadata('a.txt')
+        expect(metadata).toMatchObject({
+          path: 'a.txt',
+          size: 5,
+          contentType: 'text/plain',
+          visibility: 'public',
+          metadata: { k: 'v' },
+        })
+        expect(metadata?.lastModified).toBeInstanceOf(Date)
+      })
+
+      test('throws for size/lastModified of a missing file and returns null metadata', async () => {
+        await expect(driver.size('missing')).rejects.toThrow('File not found: missing')
+        await expect(driver.lastModified('missing')).rejects.toThrow('File not found: missing')
+        expect(await driver.metadata('missing')).toBeNull()
+      })
+    })
+
+    describe('files/directories/allFiles', () => {
+      beforeEach(async () => {
+        await driver.put('dir/file1.txt', '1')
+        await driver.put('dir/file2.txt', '2')
+        await driver.put('dir/sub/file3.txt', '3')
+        await driver.put('dir/sub/deep/file4.txt', '4')
+        await driver.put('other/file5.txt', '5')
+      })
+
+      test('files lists direct children only, as app-relative paths', async () => {
+        expect(await driver.files('dir')).toEqual(['dir/file1.txt', 'dir/file2.txt'])
+        expect(await driver.files('/dir/')).toEqual(['dir/file1.txt', 'dir/file2.txt'])
+      })
+
+      test('directories lists direct subdirectories', async () => {
+        expect(await driver.directories('dir')).toEqual(['dir/sub'])
+        expect(await driver.directories('')).toEqual(['dir', 'other'])
+      })
+
+      test('allFiles lists recursively', async () => {
+        expect(await driver.allFiles('dir')).toEqual([
+          'dir/file1.txt',
+          'dir/file2.txt',
+          'dir/sub/deep/file4.txt',
+          'dir/sub/file3.txt',
+        ])
+      })
+
+      test('strips the prefix from listed paths', async () => {
+        const prefixed = make({ prefix: 'dir' })
+        expect(await prefixed.files('')).toEqual(['file1.txt', 'file2.txt'])
+        expect(await prefixed.directories('')).toEqual(['sub'])
+        expect(await prefixed.allFiles('sub')).toEqual(['sub/deep/file4.txt', 'sub/file3.txt'])
+      })
+
+      test('does not list a directory marker as a file', async () => {
+        await driver.makeDirectory('dir/empty')
+        expect(await driver.directories('dir')).toEqual(['dir/empty', 'dir/sub'])
+        expect(await driver.files('dir/empty')).toEqual([])
+        expect(await driver.allFiles('dir/empty')).toEqual([])
+      })
+    })
+
+    describe('deleteDirectory', () => {
+      test('deletes everything under the directory and nothing beside it', async () => {
+        await driver.put('dir/file1.txt', '1')
+        await driver.put('dir/sub/file2.txt', '2')
+        await driver.put('dir2/file3.txt', '3')
+
+        await driver.deleteDirectory('dir')
+
+        expect(await driver.allFiles('')).toEqual(['dir2/file3.txt'])
+      })
+
+      test('removes folder markers and respects the prefix', async () => {
+        const prefixed = make({ prefix: 'app' })
+        await prefixed.makeDirectory('dir/empty')
+        await prefixed.put('dir/a.txt', '1')
+        await driver.put('other/keep.txt', '')
+
+        await prefixed.deleteDirectory('dir')
+
+        expect(await prefixed.directories('')).toEqual([])
+        expect(await driver.allFiles('')).toEqual(['other/keep.txt'])
+      })
+    })
+
+    describe('visibility', () => {
+      test('defaults to public when publicUrl is set and private otherwise', async () => {
+        await driver.put('a.txt', 'x')
+        expect(await driver.getVisibility('a.txt')).toBe('public')
+        expect(await make({ publicUrl: undefined }).getVisibility('a.txt')).toBe('private')
+      })
+
+      test('accepts a matching visibility as a no-op', async () => {
+        await driver.put('a.txt', 'x', { visibility: 'public' })
+        await driver.setVisibility('a.txt', 'public')
+        expect(await driver.getVisibility('a.txt')).toBe('public')
+      })
+
+      test('throws on a conflicting visibility instead of pretending', async () => {
+        await expect(driver.put('a.txt', 'x', { visibility: 'private' })).rejects.toThrow(/no per-object visibility/)
+        expect(await driver.exists('a.txt')).toBe(false)
+
+        await driver.put('a.txt', 'x')
+        await expect(driver.setVisibility('a.txt', 'private')).rejects.toThrow(/no per-object visibility/)
+      })
+
+      test('getVisibility/setVisibility throw for a missing file', async () => {
+        await expect(driver.getVisibility('missing')).rejects.toThrow('File not found: missing')
+        await expect(driver.setVisibility('missing', 'public')).rejects.toThrow('File not found: missing')
+      })
+    })
+  })
+}

--- a/packages/plugin-cloudflare/src/storage/r2-miniflare.test.ts
+++ b/packages/plugin-cloudflare/src/storage/r2-miniflare.test.ts
@@ -1,83 +1,55 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import { afterAll, describe, expect, test } from 'bun:test'
+import type { Miniflare } from 'miniflare'
+import { describeR2DriverConformance } from './r2-driver-conformance'
 import { R2Driver, type R2BucketLike } from './R2Driver'
 
-// Opt-in end-to-end test: runs the driver against workerd's real R2
-// implementation through Miniflare's `getR2Bucket()`, so the semantics the
-// in-memory `FakeR2Bucket` encodes (prefix/delimiter grouping, cursor
-// pagination, folder markers, metadata round-trips) are checked against the
+// Opt-in end-to-end test: runs the same driver contract as R2Driver.test.ts
+// against workerd's real R2 through Miniflare's `getR2Bucket()`, so every
+// semantic the in-memory `FakeR2Bucket` encodes is checked against the
 // runtime rather than assumed. Miniflare spawns workerd (a native binary
 // fetched on install), so like wrangler-migrations.test.ts it is gated
 // behind GUREN_TEST_WRANGLER=1 and skipped in CI.
 const enabled = process.env.GUREN_TEST_WRANGLER === '1'
 
-describe.skipIf(!enabled)('R2Driver against Miniflare R2', () => {
-  let dispose: () => Promise<void>
-  let bucket: R2BucketLike
-  let driver: R2Driver
+let mf: Miniflare | undefined
 
-  beforeAll(async () => {
-    const { Miniflare } = await import('miniflare')
-    const mf = new Miniflare({
-      modules: true,
-      script: 'export default { fetch() { return new Response("ok") } }',
-      r2Buckets: ['BUCKET'],
-    })
-    bucket = (await mf.getR2Bucket('BUCKET')) as unknown as R2BucketLike
-    dispose = () => mf.dispose()
-    driver = new R2Driver({ binding: () => bucket, publicUrl: 'https://media.example.com', prefix: 'app' })
+afterAll(() => mf?.dispose())
+
+async function miniflareBucket(): Promise<R2BucketLike> {
+  const { Miniflare } = await import('miniflare')
+  mf = new Miniflare({
+    modules: true,
+    script: 'export default { fetch() { return new Response("ok") } }',
+    r2Buckets: ['BUCKET'],
   })
+  return (await mf.getR2Bucket('BUCKET')) as unknown as R2BucketLike
+}
 
-  afterAll(async () => {
-    await dispose?.()
+async function emptyBucket(bucket: R2BucketLike): Promise<void> {
+  await new R2Driver({ binding: () => bucket }).deleteDirectory('')
+}
+
+if (enabled) {
+  describeR2DriverConformance('R2Driver (Miniflare R2)', {
+    bucket: miniflareBucket,
+    reset: emptyBucket,
+    // Miniflare's binding proxy cannot marshal the stream copy() pipes from
+    // get() into put(); the block below runs those two methods inside workerd.
+    streamingCopy: false,
   })
+}
 
-  beforeEach(async () => {
-    await driver.deleteDirectory('')
-  })
-
-  test('round-trips bytes, contentType and custom metadata', async () => {
-    await driver.put('a/b.json', '{"k":1}', { contentType: 'application/json', metadata: { owner: '42' } })
-
-    expect(await driver.getAsString('a/b.json')).toBe('{"k":1}')
-    expect(await driver.exists('a/b.json')).toBe(true)
-    const metadata = await driver.metadata('a/b.json')
-    expect(metadata?.size).toBe(7)
-    expect(metadata?.contentType).toBe('application/json')
-    expect(metadata?.metadata).toEqual({ owner: '42' })
-    expect(metadata?.lastModified).toBeInstanceOf(Date)
-  })
-
-  // copy()/move() are exercised separately below: the driver streams
-  // `get().body` straight into `put()`, which workerd supports but
-  // Miniflare's out-of-process binding proxy cannot marshal (DataCloneError
-  // on the stream) — so that path runs *inside* workerd, see the second
-  // describe block.
-
-  test('delete reports whether the object existed', async () => {
-    await driver.put('x.txt', 'x')
-    expect(await driver.delete('x.txt')).toBe(true)
-    expect(await driver.delete('x.txt')).toBe(false)
-  })
-
-  test('files/directories/allFiles group by delimiter and strip the prefix', async () => {
-    await driver.put('dir/file1.txt', '1')
-    await driver.put('dir/file2.txt', '2')
-    await driver.put('dir/sub/file3.txt', '3')
-    await driver.put('other/file4.txt', '4')
-    await driver.makeDirectory('dir/empty')
-
-    expect(await driver.files('dir')).toEqual(['dir/file1.txt', 'dir/file2.txt'])
-    expect(await driver.directories('dir')).toEqual(['dir/empty', 'dir/sub'])
-    expect(await driver.directories('')).toEqual(['dir', 'other'])
-    expect(await driver.allFiles('dir')).toEqual(['dir/file1.txt', 'dir/file2.txt', 'dir/sub/file3.txt'])
-    expect(await driver.files('dir/empty')).toEqual([])
-  })
-
+describe.skipIf(!enabled)('R2Driver against Miniflare R2 at scale', () => {
   test('deleteMany and deleteDirectory clear more than one list page', async () => {
-    // Above the 1000-key delete cap and, with limit forced low, above one
-    // list page — both code paths the fake can only approximate.
+    const bucket = mf ? ((await mf.getR2Bucket('BUCKET')) as unknown as R2BucketLike) : await miniflareBucket()
+    await emptyBucket(bucket)
+    const driver = new R2Driver({ binding: () => bucket, prefix: 'app' })
+    // Above the 1000-key delete cap and above one list page — both code
+    // paths the fake can only approximate.
     const paths = Array.from({ length: 1100 }, (_, index) => `bulk/${String(index).padStart(4, '0')}.txt`)
-    for (const path of paths) await bucket.put(`app/${path}`, '')
+    for (let index = 0; index < paths.length; index += 100) {
+      await Promise.all(paths.slice(index, index + 100).map((path) => bucket.put(`app/${path}`, '')))
+    }
 
     expect((await driver.allFiles('bulk')).length).toBe(1100)
     expect(await driver.deleteMany(paths.slice(0, 50))).toBe(50)

--- a/packages/plugin-cloudflare/src/storage/r2-miniflare.test.ts
+++ b/packages/plugin-cloudflare/src/storage/r2-miniflare.test.ts
@@ -47,11 +47,11 @@ describe.skipIf(!enabled)('R2Driver against Miniflare R2', () => {
     expect(metadata?.lastModified).toBeInstanceOf(Date)
   })
 
-  // copy()/move() are not exercised here: the driver streams `get().body`
-  // straight into `put()`, which workerd supports but Miniflare's out-of-
-  // process binding proxy cannot marshal (DataCloneError on the stream).
-  // They are covered by the FakeR2Bucket unit tests; the streaming put is
-  // the documented R2 pattern (`bucket.put(key, object.body)`).
+  // copy()/move() are exercised separately below: the driver streams
+  // `get().body` straight into `put()`, which workerd supports but
+  // Miniflare's out-of-process binding proxy cannot marshal (DataCloneError
+  // on the stream) — so that path runs *inside* workerd, see the second
+  // describe block.
 
   test('delete reports whether the object existed', async () => {
     await driver.put('x.txt', 'x')
@@ -83,5 +83,47 @@ describe.skipIf(!enabled)('R2Driver against Miniflare R2', () => {
     expect(await driver.deleteMany(paths.slice(0, 50))).toBe(50)
     await driver.deleteDirectory('bulk')
     expect(await driver.allFiles('bulk')).toEqual([])
+  })
+})
+
+// The streaming copy is the one code path the binding proxy cannot carry, so
+// this block bundles the driver and runs it inside workerd itself, where
+// `bucket.put(key, object.body)` is the documented R2 pattern.
+describe.skipIf(!enabled)('R2Driver.copy/move inside workerd', () => {
+  test('streams get().body into put() and carries metadata', async () => {
+    const entry = new URL('./r2-miniflare.worker.ts', import.meta.url).pathname
+    const build = await Bun.build({ entrypoints: [entry], target: 'browser', format: 'esm', minify: false })
+    if (!build.success) {
+      throw new Error(build.logs.map((log) => String(log)).join('\n'))
+    }
+    const script = await build.outputs[0]!.text()
+
+    const { Miniflare } = await import('miniflare')
+    const mf = new Miniflare({
+      // An explicit module list: with `script` alone Miniflare walks the
+      // bundle for imports and rejects the driver's dynamic
+      // `import(moduleName)` for the optional aws4fetch dependency.
+      modules: [{ type: 'ESModule', path: 'worker.js', contents: script }],
+      r2Buckets: ['BUCKET'],
+      compatibilityDate: '2026-07-01',
+      compatibilityFlags: ['nodejs_compat'],
+    })
+    try {
+      const response = await mf.dispatchFetch('http://worker/')
+      const body = (await response.json()) as Record<string, unknown>
+      expect(response.status).toBe(200)
+      expect(body).toEqual({
+        copied: 'content',
+        bytesAreBuffer: true,
+        bytes: Array.from(new TextEncoder().encode('content')),
+        moved: 'content',
+        copyExistsAfterMove: false,
+        sourceExists: true,
+        contentType: 'text/plain',
+        metadata: { k: 'v' },
+      })
+    } finally {
+      await mf.dispose()
+    }
   })
 })

--- a/packages/plugin-cloudflare/src/storage/r2-miniflare.test.ts
+++ b/packages/plugin-cloudflare/src/storage/r2-miniflare.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import { R2Driver, type R2BucketLike } from './R2Driver'
+
+// Opt-in end-to-end test: runs the driver against workerd's real R2
+// implementation through Miniflare's `getR2Bucket()`, so the semantics the
+// in-memory `FakeR2Bucket` encodes (prefix/delimiter grouping, cursor
+// pagination, folder markers, metadata round-trips) are checked against the
+// runtime rather than assumed. Miniflare spawns workerd (a native binary
+// fetched on install), so like wrangler-migrations.test.ts it is gated
+// behind GUREN_TEST_WRANGLER=1 and skipped in CI.
+const enabled = process.env.GUREN_TEST_WRANGLER === '1'
+
+describe.skipIf(!enabled)('R2Driver against Miniflare R2', () => {
+  let dispose: () => Promise<void>
+  let bucket: R2BucketLike
+  let driver: R2Driver
+
+  beforeAll(async () => {
+    const { Miniflare } = await import('miniflare')
+    const mf = new Miniflare({
+      modules: true,
+      script: 'export default { fetch() { return new Response("ok") } }',
+      r2Buckets: ['BUCKET'],
+    })
+    bucket = (await mf.getR2Bucket('BUCKET')) as unknown as R2BucketLike
+    dispose = () => mf.dispose()
+    driver = new R2Driver({ binding: () => bucket, publicUrl: 'https://media.example.com', prefix: 'app' })
+  })
+
+  afterAll(async () => {
+    await dispose?.()
+  })
+
+  beforeEach(async () => {
+    await driver.deleteDirectory('')
+  })
+
+  test('round-trips bytes, contentType and custom metadata', async () => {
+    await driver.put('a/b.json', '{"k":1}', { contentType: 'application/json', metadata: { owner: '42' } })
+
+    expect(await driver.getAsString('a/b.json')).toBe('{"k":1}')
+    expect(await driver.exists('a/b.json')).toBe(true)
+    const metadata = await driver.metadata('a/b.json')
+    expect(metadata?.size).toBe(7)
+    expect(metadata?.contentType).toBe('application/json')
+    expect(metadata?.metadata).toEqual({ owner: '42' })
+    expect(metadata?.lastModified).toBeInstanceOf(Date)
+  })
+
+  // copy()/move() are not exercised here: the driver streams `get().body`
+  // straight into `put()`, which workerd supports but Miniflare's out-of-
+  // process binding proxy cannot marshal (DataCloneError on the stream).
+  // They are covered by the FakeR2Bucket unit tests; the streaming put is
+  // the documented R2 pattern (`bucket.put(key, object.body)`).
+
+  test('delete reports whether the object existed', async () => {
+    await driver.put('x.txt', 'x')
+    expect(await driver.delete('x.txt')).toBe(true)
+    expect(await driver.delete('x.txt')).toBe(false)
+  })
+
+  test('files/directories/allFiles group by delimiter and strip the prefix', async () => {
+    await driver.put('dir/file1.txt', '1')
+    await driver.put('dir/file2.txt', '2')
+    await driver.put('dir/sub/file3.txt', '3')
+    await driver.put('other/file4.txt', '4')
+    await driver.makeDirectory('dir/empty')
+
+    expect(await driver.files('dir')).toEqual(['dir/file1.txt', 'dir/file2.txt'])
+    expect(await driver.directories('dir')).toEqual(['dir/empty', 'dir/sub'])
+    expect(await driver.directories('')).toEqual(['dir', 'other'])
+    expect(await driver.allFiles('dir')).toEqual(['dir/file1.txt', 'dir/file2.txt', 'dir/sub/file3.txt'])
+    expect(await driver.files('dir/empty')).toEqual([])
+  })
+
+  test('deleteMany and deleteDirectory clear more than one list page', async () => {
+    // Above the 1000-key delete cap and, with limit forced low, above one
+    // list page — both code paths the fake can only approximate.
+    const paths = Array.from({ length: 1100 }, (_, index) => `bulk/${String(index).padStart(4, '0')}.txt`)
+    for (const path of paths) await bucket.put(`app/${path}`, '')
+
+    expect((await driver.allFiles('bulk')).length).toBe(1100)
+    expect(await driver.deleteMany(paths.slice(0, 50))).toBe(50)
+    await driver.deleteDirectory('bulk')
+    expect(await driver.allFiles('bulk')).toEqual([])
+  })
+})

--- a/packages/plugin-cloudflare/src/storage/r2-miniflare.test.ts
+++ b/packages/plugin-cloudflare/src/storage/r2-miniflare.test.ts
@@ -73,8 +73,8 @@ describe.skipIf(!enabled)('R2Driver.copy/move inside workerd', () => {
     const { Miniflare } = await import('miniflare')
     const mf = new Miniflare({
       // An explicit module list: with `script` alone Miniflare walks the
-      // bundle for imports and rejects the driver's dynamic
-      // `import(moduleName)` for the optional aws4fetch dependency.
+      // bundle's import graph itself, which is stricter than what wrangler
+      // ships to workerd.
       modules: [{ type: 'ESModule', path: 'worker.js', contents: script }],
       r2Buckets: ['BUCKET'],
       compatibilityDate: '2026-07-01',
@@ -84,7 +84,18 @@ describe.skipIf(!enabled)('R2Driver.copy/move inside workerd', () => {
       const response = await mf.dispatchFetch('http://worker/')
       const body = (await response.json()) as Record<string, unknown>
       expect(response.status).toBe(200)
-      expect(body).toEqual({
+
+      // The regression this block exists for: a signer the bundler cannot
+      // reach makes temporaryUrl() throw `No such module` at runtime, which
+      // nothing outside workerd can observe.
+      const signedUrl = new URL(String(body.signedUrl))
+      expect(signedUrl.origin).toBe('https://acct.r2.cloudflarestorage.com')
+      expect(signedUrl.pathname).toBe('/b/a%20b.png')
+      expect(signedUrl.searchParams.get('X-Amz-Algorithm')).toBe('AWS4-HMAC-SHA256')
+      expect(signedUrl.searchParams.get('X-Amz-Signature')).toMatch(/^[0-9a-f]{64}$/)
+
+      const { signedUrl: _signed, ...rest } = body
+      expect(rest).toEqual({
         copied: 'content',
         bytesAreBuffer: true,
         bytes: Array.from(new TextEncoder().encode('content')),

--- a/packages/plugin-cloudflare/src/storage/r2-miniflare.worker.ts
+++ b/packages/plugin-cloudflare/src/storage/r2-miniflare.worker.ts
@@ -1,0 +1,28 @@
+// Worker entry for r2-miniflare.test.ts — bundled with Bun.build at test
+// time and executed inside workerd, so the driver's streaming copy runs
+// against the real binding rather than Miniflare's proxy.
+import { R2Driver } from './R2Driver'
+
+export default {
+  async fetch(_request: Request, env: { BUCKET: unknown }): Promise<Response> {
+    const driver = new R2Driver({ binding: () => env.BUCKET, prefix: 'app' })
+    await driver.deleteDirectory('')
+    await driver.put('src.txt', 'content', { contentType: 'text/plain', metadata: { k: 'v' } })
+    await driver.copy('src.txt', 'copy.txt')
+    const copied = await driver.getAsString('copy.txt')
+    await driver.move('copy.txt', 'moved.txt')
+    const metadata = await driver.metadata('moved.txt')
+    // get() returns a Buffer — proves nodejs_compat's Buffer global is there.
+    const bytes = await driver.get('moved.txt')
+    return Response.json({
+      copied,
+      bytesAreBuffer: bytes instanceof Buffer,
+      bytes: Array.from(bytes ?? []),
+      moved: await driver.getAsString('moved.txt'),
+      copyExistsAfterMove: await driver.exists('copy.txt'),
+      sourceExists: await driver.exists('src.txt'),
+      contentType: metadata?.contentType,
+      metadata: metadata?.metadata,
+    })
+  },
+}

--- a/packages/plugin-cloudflare/src/storage/r2-miniflare.worker.ts
+++ b/packages/plugin-cloudflare/src/storage/r2-miniflare.worker.ts
@@ -14,7 +14,21 @@ export default {
     const metadata = await driver.metadata('moved.txt')
     // get() returns a Buffer — proves nodejs_compat's Buffer global is there.
     const bytes = await driver.get('moved.txt')
+    // Presigning must work from inside the bundle: the signer has to be
+    // reachable through whatever bundler produced this worker, which a
+    // variable-specifier dynamic import is not.
+    const presigning = new R2Driver({
+      binding: () => env.BUCKET,
+      presign: { accountId: 'acct', bucket: 'b', accessKeyId: 'AKIDEXAMPLE', secretAccessKey: 'secret' },
+    })
+    let signedUrl: string
+    try {
+      signedUrl = await presigning.temporaryUrl('a b.png', new Date(Date.now() + 3600_000))
+    } catch (error) {
+      signedUrl = `ERROR: ${String(error)}`
+    }
     return Response.json({
+      signedUrl,
       copied,
       bytesAreBuffer: bytes instanceof Buffer,
       bytes: Array.from(bytes ?? []),

--- a/packages/plugin-cloudflare/src/storage/sigv4.test.ts
+++ b/packages/plugin-cloudflare/src/storage/sigv4.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test'
+import { presignGetUrl } from './sigv4'
+
+// Known-answer tests. The expected signatures were produced by this
+// implementation and cross-checked byte-for-byte against `aws4fetch`
+// (the reference this replaced) for every case below, so they pin the
+// canonicalization rules that are easy to get subtly wrong: RFC 3986
+// escaping beyond encodeURIComponent, per-segment path encoding, and
+// sorted query canonicalization.
+const CREDENTIALS = {
+  accessKeyId: 'AKIDEXAMPLE',
+  secretAccessKey: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+  region: 'auto',
+  service: 's3',
+}
+const DATE = new Date('2026-08-15T10:02:42.000Z')
+
+async function sign(url: string, expiresIn = 3600): Promise<URL> {
+  return new URL(await presignGetUrl({ url, ...CREDENTIALS, expiresIn, date: DATE }))
+}
+
+describe('presignGetUrl', () => {
+  test('signs a plain key', async () => {
+    const url = await sign('https://acct.r2.cloudflarestorage.com/bucket/a.png')
+    expect(url.pathname).toBe('/bucket/a.png')
+    expect(url.searchParams.get('X-Amz-Signature')).toBe(
+      'f4ae5edbe355a012a61b7a3ccea1ce2fbfa0c6402ace3d77aee93302256b5f44',
+    )
+  })
+
+  test('preserves per-segment encoding for keys with spaces', async () => {
+    const url = await sign('https://acct.r2.cloudflarestorage.com/bucket/uploads/a%20b/c.png')
+    expect(url.pathname).toBe('/bucket/uploads/a%20b/c.png')
+    expect(url.searchParams.get('X-Amz-Signature')).toBe(
+      'c6472f7f41f7508a61082cfd9284938076cf2f7e91b0fc65e08dd62abbbbd2b1',
+    )
+  })
+
+  test('handles unicode and RFC 3986 reserved characters', async () => {
+    const url = await sign('https://acct.r2.cloudflarestorage.com/bucket/photos/2026/%C3%A9t%C3%A9%20(1).jpg')
+    expect(url.pathname).toBe('/bucket/photos/2026/%C3%A9t%C3%A9%20(1).jpg')
+    expect(url.searchParams.get('X-Amz-Signature')).toBe(
+      '5e85f3d95b3c6ac6d2b8bb79b20fcacf747309ce97fc1f66b6cbae0b54f26444',
+    )
+  })
+
+  test('emits every parameter the S3 presigned-URL scheme requires', async () => {
+    const url = await sign('https://acct.r2.cloudflarestorage.com/bucket/a.png', 900)
+    expect(url.searchParams.get('X-Amz-Algorithm')).toBe('AWS4-HMAC-SHA256')
+    expect(url.searchParams.get('X-Amz-Credential')).toBe('AKIDEXAMPLE/20260815/auto/s3/aws4_request')
+    expect(url.searchParams.get('X-Amz-Date')).toBe('20260815T100242Z')
+    expect(url.searchParams.get('X-Amz-Expires')).toBe('900')
+    expect(url.searchParams.get('X-Amz-SignedHeaders')).toBe('host')
+  })
+
+  test('changes the signature when any signed input changes', async () => {
+    const base = await sign('https://acct.r2.cloudflarestorage.com/bucket/a.png')
+    const other = await sign('https://acct.r2.cloudflarestorage.com/bucket/b.png')
+    const shorter = await sign('https://acct.r2.cloudflarestorage.com/bucket/a.png', 60)
+    const later = new URL(
+      await presignGetUrl({
+        url: 'https://acct.r2.cloudflarestorage.com/bucket/a.png',
+        ...CREDENTIALS,
+        expiresIn: 3600,
+        date: new Date('2026-08-16T10:02:42.000Z'),
+      }),
+    )
+    const signatures = [base, other, shorter, later].map((url) => url.searchParams.get('X-Amz-Signature'))
+    expect(new Set(signatures).size).toBe(4)
+  })
+
+  test('signs query parameters already on the URL', async () => {
+    const withQuery = await sign('https://acct.r2.cloudflarestorage.com/bucket/a.png?versionId=42')
+    const withoutQuery = await sign('https://acct.r2.cloudflarestorage.com/bucket/a.png')
+    expect(withQuery.searchParams.get('versionId')).toBe('42')
+    expect(withQuery.searchParams.get('X-Amz-Signature')).not.toBe(withoutQuery.searchParams.get('X-Amz-Signature'))
+  })
+})

--- a/packages/plugin-cloudflare/src/storage/sigv4.ts
+++ b/packages/plugin-cloudflare/src/storage/sigv4.ts
@@ -1,0 +1,147 @@
+/**
+ * The slice of AWS Signature Version 4 needed to presign a GET against an
+ * S3-compatible endpoint, on WebCrypto alone.
+ *
+ * Written here rather than taken from a package because the only thing to
+ * import is a signature: R2 presigning is one request shape (GET, no body,
+ * `host` the sole signed header), the algorithm is frozen by AWS, and a
+ * dependency the bundler has to resolve is exactly what broke the first
+ * attempt at this — a variable-specifier dynamic import that no Workers
+ * bundler could follow, so `temporaryUrl()` threw `No such module` on the
+ * one runtime this driver runs on.
+ *
+ * `crypto.subtle` is a global on workerd, Bun, and Node 18+, so this needs
+ * no runtime shims.
+ */
+
+export interface PresignGetOptions {
+  /** Absolute URL of the object, unsigned. Existing query params are signed too. */
+  url: string
+  accessKeyId: string
+  secretAccessKey: string
+  /** R2 uses `auto`. */
+  region: string
+  /** `s3` for R2's S3-compatible endpoint. */
+  service: string
+  /** Lifetime in seconds, from `date`. */
+  expiresIn: number
+  /** Injectable clock; tests pin it to keep signatures reproducible. */
+  date?: Date
+}
+
+const ALGORITHM = 'AWS4-HMAC-SHA256'
+const TERMINATOR = 'aws4_request'
+/**
+ * S3 accepts an unsigned payload for presigned URLs — the signature covers
+ * the request line, the query, and `host`, not the bytes.
+ */
+const UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD'
+
+/**
+ * Percent-encoding per RFC 3986, which is stricter than `encodeURIComponent`:
+ * `!`, `'`, `(`, `)` and `*` are reserved and must be escaped, or the
+ * canonical request the server rebuilds will not match ours.
+ */
+function encodeRfc3986(value: string): string {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+  )
+}
+
+/** Path segments are encoded individually; `/` stays a separator. */
+function canonicalPath(pathname: string): string {
+  return pathname.split('/').map(decodeAndEncodeSegment).join('/')
+}
+
+/**
+ * The URL arrives already percent-encoded (callers build it with `URL`), but
+ * SigV4 canonicalizes from the decoded form — encoding again without
+ * decoding first would sign `%2520` where the server sees `%20`.
+ */
+function decodeAndEncodeSegment(segment: string): string {
+  return encodeRfc3986(decodeURIComponent(segment))
+}
+
+/** Query parameters sorted by encoded name, then encoded value. */
+function canonicalQuery(searchParams: URLSearchParams): string {
+  return Array.from(searchParams)
+    .map(([name, value]) => [encodeRfc3986(name), encodeRfc3986(value)] as const)
+    .sort(([leftName, leftValue], [rightName, rightValue]) =>
+      leftName === rightName ? (leftValue < rightValue ? -1 : 1) : leftName < rightName ? -1 : 1,
+    )
+    .map(([name, value]) => `${name}=${value}`)
+    .join('&')
+}
+
+function toHex(bytes: ArrayBuffer): string {
+  return Array.from(new Uint8Array(bytes))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  return toHex(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value)))
+}
+
+async function hmac(key: ArrayBuffer | Uint8Array, value: string): Promise<ArrayBuffer> {
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    key as BufferSource,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  return crypto.subtle.sign('HMAC', cryptoKey, new TextEncoder().encode(value))
+}
+
+/** `AWS4<secret>` → date → region → service → terminator. */
+async function signingKey(
+  secretAccessKey: string,
+  dateStamp: string,
+  region: string,
+  service: string,
+): Promise<ArrayBuffer> {
+  const initial = new TextEncoder().encode(`AWS4${secretAccessKey}`)
+  const byDate = await hmac(initial, dateStamp)
+  const byRegion = await hmac(byDate, region)
+  const byService = await hmac(byRegion, service)
+  return hmac(byService, TERMINATOR)
+}
+
+/**
+ * Presign a GET so the URL alone authorizes the read until it expires.
+ *
+ * @returns the signed absolute URL
+ */
+export async function presignGetUrl(options: PresignGetOptions): Promise<string> {
+  const { accessKeyId, secretAccessKey, region, service, expiresIn } = options
+  const date = options.date ?? new Date()
+
+  // `20260815T100242Z` and its `20260815` prefix.
+  const amzDate = `${date.toISOString().replace(/[-:]/g, '').slice(0, 15)}Z`
+  const dateStamp = amzDate.slice(0, 8)
+  const scope = `${dateStamp}/${region}/${service}/${TERMINATOR}`
+
+  const url = new URL(options.url)
+  url.searchParams.set('X-Amz-Algorithm', ALGORITHM)
+  url.searchParams.set('X-Amz-Credential', `${accessKeyId}/${scope}`)
+  url.searchParams.set('X-Amz-Date', amzDate)
+  url.searchParams.set('X-Amz-Expires', String(expiresIn))
+  url.searchParams.set('X-Amz-SignedHeaders', 'host')
+
+  const canonicalRequest = [
+    'GET',
+    canonicalPath(url.pathname),
+    canonicalQuery(url.searchParams),
+    `host:${url.host}\n`,
+    'host',
+    UNSIGNED_PAYLOAD,
+  ].join('\n')
+
+  const stringToSign = [ALGORITHM, amzDate, scope, await sha256Hex(canonicalRequest)].join('\n')
+  const key = await signingKey(secretAccessKey, dateStamp, region, service)
+  url.searchParams.set('X-Amz-Signature', toHex(await hmac(key, stringToSign)))
+
+  return url.toString()
+}

--- a/packages/server/src/support/trim-slashes.ts
+++ b/packages/server/src/support/trim-slashes.ts
@@ -3,8 +3,9 @@
  * quadratically on adversarial input (long slash runs mid-string), and
  * several call sites here feed request-derived paths.
  *
- * A twin of `trimSlashes` lives in `@guren/cli` (`src/utils.ts`); the
- * packages share no dependency edge, so the six lines are duplicated by
+ * Twins live in `@guren/cli` (`src/utils.ts`, `trimSlashes`) and
+ * `@guren/plugin-cloudflare` (`src/storage/R2Driver.ts`, both functions);
+ * neither package can import this module, so the lines are duplicated by
  * convention.
  */
 

--- a/rfcs/0003-cloudflare-workers-plugin.md
+++ b/rfcs/0003-cloudflare-workers-plugin.md
@@ -487,7 +487,9 @@ following. This matrix ships in the plugin docs — Workers is a supported
   logging `FileChannel`/`DailyFileChannel` (use console/external), i18n
   `JsonLoader` (build-time bundling is future work)
 - `S3Driver.putFile(localPath)` (reads local fs) — `put(buffer)` works, the
-  driver is otherwise fetch-based
+  driver is otherwise fetch-based. **Amended by RFC 0009:** storage on
+  Workers is now served by `R2Driver` (the R2 binding), which moves storage
+  from this list to "works via replacements" above.
 - Long-lived processes: `Scheduler.start()`, queue `Worker`, WebSocket
   broadcasting — see below (future adapters map to Cron Triggers / Queues /
   Durable Objects)
@@ -498,7 +500,7 @@ following. This matrix ships in the plugin docs — Workers is a supported
 - **Cron Triggers** (↔ `createScheduleHandler` equivalent — the module worker
   shape already reserves the `scheduled` export for this)
 - **Cache store** on Cache API / KV
-- **R2 storage driver**
+- ~~**R2 storage driver**~~ — shipped as RFC 0009 (`R2Driver` in this plugin)
 - Auto-discovery on Workers (providers must be listed explicitly in
   `createApp()`, same as the documented Lambda constraint)
 

--- a/rfcs/0003-cloudflare-workers-plugin.md
+++ b/rfcs/0003-cloudflare-workers-plugin.md
@@ -478,6 +478,8 @@ following. This matrix ships in the plugin docs — Workers is a supported
 - Password hashing → `NodeHasher` swap + OAuth-on-Free guidance (§4)
 - Inertia SSR loading → `setInertiaSsrRenderer` static wiring (§5)
 - Static assets (`Bun.file` paths) → Workers Static Assets (§5)
+- Storage → `R2Driver` over the R2 binding (RFC 0009; amended after
+  acceptance)
 
 **Unsupported on Workers (documented, error early where possible):**
 


### PR DESCRIPTION
## Summary

Implements RFC 0009 (#424): a `StorageDriver` for Cloudflare R2 that talks to the Workers **binding** — lazy `binding: () => getWorkersEnv<Env>().BUCKET`, the same contract as `createD1Database` — so an app on Workers can put files behind `StorageManager` without an R2 API token or the AWS SDK in the bundle.

```ts
const storage = createStorageManager({ default: 'media' })
storage.registerDisk('media', () =>
  isWorkersRuntime()
    ? new R2Driver({ binding: () => getWorkersEnv<Env>().MEDIA, publicUrl: 'https://media.example.com' })
    : new LocalStorageDriver({ root: './storage/app/public', url: '/storage' }),
)
```

Registration goes through `registerDisk()` — the one extension point that works today — so **nothing in `@guren/server` changes** and the plugin can release on its own (see RFC 0009 §2.2 for the npm-resolution reasoning).

Where the binding differs from S3, the driver refuses instead of guessing:

- `url()` requires `publicUrl` (R2 has no derivable public URL); keys are percent-encoded per segment.
- `temporaryUrl()` presigns through the **optional** `aws4fetch` peer when `presign: { accountId, bucket, accessKeyId, secretAccessKey }` is set (>7 days rejected up front), throws with guidance otherwise — bindings cannot sign.
- `put({ visibility })` / `setVisibility()` throw when asked for the opposite of the bucket's declared `visibility` (defaults from `publicUrl`); R2 has no per-object ACL.
- `putFile()` throws — no filesystem on Workers.
- `copy()` streams `get().body` into `put()` (no copy on the binding); `deleteMany()` batches to the 1000-key limit; every listing follows the cursor (`S3Driver.allFiles` reads one page today); `makeDirectory()` writes a `key/` marker that `files()` filters and `directories()` sees.

Also: README + `docs/{en,ja}/guides/cloudflare.md` "Storage (R2)" section, a note in the storage guides steering Workers users to the binding driver, RFC 0003 §6/§7 amended, harness `guren-api` skill line, changeset (`@guren/plugin-cloudflare` minor).

## Test plan

- [x] `FakeR2Bucket` unit suite (38 tests): put/get, prefix, head-then-delete, 1000-key batching (2500 keys → 1000/1000/500), cursor pagination (mutation-checked: dropping the loop goes red), copy metadata carry-over, url encoding, presign URL shape (real aws4fetch, `X-Amz-Expires`/`X-Amz-Credential`/signature), 7-day cap, visibility conflicts, folder markers.
- [x] `R2Driver.types.test.ts`: `@cloudflare/workers-types` `R2Bucket` satisfies the structural `R2BucketLike` (checked by `tsc`; mutation-checked). Streams/blobs are typed structurally because workers-types declares its own `ReadableStream`/`Blob` interfaces that are not assignable to the runtime globals.
- [x] Opt-in `GUREN_TEST_WRANGLER=1` Miniflare run against workerd's real R2: metadata round-trip, delete semantics, delimiter grouping, >1000-key delete + multi-page list; and a second block that bundles the driver with `Bun.build` and runs `copy()`/`move()` **inside** workerd (the binding proxy cannot marshal the stream), also confirming `Buffer` under `nodejs_compat`. Green locally.
- [x] `bun run build`, root `bun run typecheck`, `bun run test:bun plugin-cloudflare cli`, `audit:core-first`, `audit:docs`, `audit:starter-template`.
- [ ] Not verified here (needs an account): today's `S3Driver` recipe against a real R2 bucket (the ACL header question — RFC 0009 step 0), and `wrangler deploy` behaviour for a nonexistent bound bucket.

Refs: RFC 0009, #424