### PR TITLE
feat(server): S3 acl option, and one visibility contract for drivers

### DIFF
--- a/.changeset/s3-acl-and-storage-disk.md
+++ b/.changeset/s3-acl-and-storage-disk.md
@@ -1,0 +1,25 @@
+---
+"@guren/server": minor
+"@guren/cli": minor
+---
+
+Let the S3 driver talk to endpoints without object ACLs, and scaffold a switchable disk
+
+`S3Driver` sent `x-amz-acl` on every `PutObject` and reached for
+`PutObjectAcl` / `GetObjectAcl` for visibility, which is correct for AWS S3
+and wrong for several S3-compatible endpoints. Cloudflare R2 documents both
+the header and the ACL operations as unsupported — access there is decided
+per bucket — and MinIO deployments vary. The storage guide has recommended
+`driver: 's3'` against R2 for a while, so this affected a documented path.
+
+`S3DriverOptions.acl` (default `true`, so nothing changes for AWS) turns the
+header off. With `acl: false` visibility becomes a property of the disk:
+`getVisibility()` reports the configured `visibility`, and `put({ visibility })`
+or `setVisibility()` throw when asked for the other value instead of silently
+dropping it — a `setVisibility(path, 'private')` that does nothing on a public
+bucket is a leak that looks like success.
+
+Separately, `guren add storage` now scaffolds
+`default: process.env.STORAGE_DISK ?? 'local'`, so an app declares its disks
+once and selects one per environment. Disks resolve lazily, so declaring a
+disk you do not use costs nothing and its credentials are never read.

--- a/.changeset/s3-acl-and-storage-disk.md
+++ b/.changeset/s3-acl-and-storage-disk.md
@@ -1,5 +1,5 @@
 ---
-"@guren/server": minor
+"@guren/server": major
 "@guren/cli": minor
 ---
 
@@ -19,11 +19,23 @@ or `setVisibility()` throw when asked for the other value instead of silently
 dropping it — a `setVisibility(path, 'private')` that does nothing on a public
 bucket is a leak that looks like success.
 
-The `StorageDriver` contract now also states what the visibility methods do
-for a file that does not exist (they throw) and for a backend without
-per-object visibility (report the disk's value, refuse the other one), with
-`LocalDriver`'s long-standing deviation recorded in place — aligning it
-changes stable default behavior, so it waits for a major.
+**Breaking:** the `StorageDriver` contract now states what the visibility
+methods do, and every driver follows it. Four drivers had three behaviours
+because the contract said nothing: a visibility call throws when the file
+does not exist, and a backend without per-object visibility reports the
+disk's configured value and refuses the other one instead of accepting a
+request it cannot carry out.
+
+`LocalDriver` changes as a result. `getVisibility()` and `setVisibility()`
+throw for a missing file, and `put({ visibility })` / `setVisibility()`
+throw when the value differs from the disk's — previously all three were
+silent no-ops that reported success. What makes a local file reachable is
+the disk root and whatever serves it, not a flag on one file, so a
+per-object request there was never carried out; it only looked like it was.
+
+To upgrade, declare the visibility on the disk instead of the call: the
+scaffolded `public` disk now carries `visibility: 'public'`, and files that
+must not be reachable belong on a disk that is not served.
 
 Separately, `guren add storage` now scaffolds a disk map selected by
 `STORAGE_DISK`, so an app declares its disks once and picks one per

--- a/.changeset/s3-acl-and-storage-disk.md
+++ b/.changeset/s3-acl-and-storage-disk.md
@@ -1,5 +1,5 @@
 ---
-"@guren/server": major
+"@guren/server": minor
 "@guren/cli": minor
 ---
 
@@ -19,23 +19,26 @@ or `setVisibility()` throw when asked for the other value instead of silently
 dropping it — a `setVisibility(path, 'private')` that does nothing on a public
 bucket is a leak that looks like success.
 
-**Breaking:** the `StorageDriver` contract now states what the visibility
-methods do, and every driver follows it. Four drivers had three behaviours
-because the contract said nothing: a visibility call throws when the file
-does not exist, and a backend without per-object visibility reports the
-disk's configured value and refuses the other one instead of accepting a
-request it cannot carry out.
+The `StorageDriver` contract now states what the visibility methods do,
+which four drivers had been answering three different ways: a visibility
+call throws when the file does not exist, and a backend without per-object
+visibility reports the disk's configured value and refuses the other one
+instead of accepting a request it cannot carry out. `R2Driver` and the new
+`acl: false` path follow it from the start.
 
-`LocalDriver` changes as a result. `getVisibility()` and `setVisibility()`
-throw for a missing file, and `put({ visibility })` / `setVisibility()`
-throw when the value differs from the disk's — previously all three were
-silent no-ops that reported success. What makes a local file reachable is
-the disk root and whatever serves it, not a flag on one file, so a
-per-object request there was never carried out; it only looked like it was.
+**Deprecated, not changed:** `LocalDriver` has always accepted per-object
+visibility requests and done nothing — `put({ visibility })` and
+`setVisibility()` against a disk's other value, and either visibility method
+against a file that does not exist. It now warns once per process for each
+and keeps its current behaviour; these become errors in 3.0.0. What makes a
+local file reachable is the disk root and whatever serves it, not a flag on
+one file, so those calls were never carried out, they only looked like they
+were.
 
-To upgrade, declare the visibility on the disk instead of the call: the
-scaffolded `public` disk now carries `visibility: 'public'`, and files that
-must not be reachable belong on a disk that is not served.
+To get ahead of it, declare the visibility on the disk rather than the call:
+the scaffolded `public` disk now carries `visibility: 'public'`, and files
+that must not be reachable belong on a disk that is not served.
+`bunx guren upgrade --check-only` lists the call sites.
 
 Separately, `guren add storage` now scaffolds a disk map selected by
 `STORAGE_DISK`, so an app declares its disks once and picks one per

--- a/.changeset/s3-acl-and-storage-disk.md
+++ b/.changeset/s3-acl-and-storage-disk.md
@@ -19,7 +19,14 @@ or `setVisibility()` throw when asked for the other value instead of silently
 dropping it — a `setVisibility(path, 'private')` that does nothing on a public
 bucket is a leak that looks like success.
 
-Separately, `guren add storage` now scaffolds
-`default: process.env.STORAGE_DISK ?? 'local'`, so an app declares its disks
-once and selects one per environment. Disks resolve lazily, so declaring a
-disk you do not use costs nothing and its credentials are never read.
+The `StorageDriver` contract now also states what the visibility methods do
+for a file that does not exist (they throw) and for a backend without
+per-object visibility (report the disk's value, refuse the other one), with
+`LocalDriver`'s long-standing deviation recorded in place — aligning it
+changes stable default behavior, so it waits for a major.
+
+Separately, `guren add storage` now scaffolds a disk map selected by
+`STORAGE_DISK`, so an app declares its disks once and picks one per
+environment. The generated provider validates the name at boot: an unknown
+one is accepted by `createStorageManager` and only fails when a disk is first
+resolved, which can be inside a queued job.

--- a/docs/en/guides/storage.md
+++ b/docs/en/guides/storage.md
@@ -315,7 +315,7 @@ const url = await disk.temporaryUrl('private/document.pdf', expiration)
 
 ### Choosing a Disk per Environment
 
-Declare every disk once and pick one with an environment variable, the way `bunx guren add storage` scaffolds it. Disks resolve lazily, so a disk you never use is never constructed and its credentials are never read:
+Declare every disk once and pick one with an environment variable, the way `bunx guren add storage` scaffolds it. Drivers are built on first use, so a disk you never touch never constructs a client or opens a connection:
 
 ```ts
 const storage = createStorageManager({
@@ -328,6 +328,11 @@ const storage = createStorageManager({
 ```
 
 `STORAGE_DISK=local` in development, `STORAGE_DISK=s3` in production — no code change, and `storage.disk()` returns whichever one is selected.
+
+Two things to know about this shape:
+
+- **The config values are read eagerly**, even for a disk you never resolve — they are evaluated when you build the object. `process.env.S3_BUCKET` being unset is harmless, but a helper that *throws* on a missing variable will throw at startup for a disk the app never touches. Keep those out of the disk map, or build that disk with `storage.registerDisk('s3', () => new S3Driver({ ... }))`, whose callback really does run on first use.
+- **An unknown name is not caught at construction.** `createStorageManager({ default: 'typo' })` succeeds and only throws `Storage disk not found: typo` when a disk is first resolved — which can be inside a queued job. The scaffolded provider checks the value against its own disk map at boot for this reason; do the same if you write the config by hand.
 
 ## File Uploads
 

--- a/docs/en/guides/storage.md
+++ b/docs/en/guides/storage.md
@@ -49,7 +49,6 @@ await disk.put('file.txt', 'Hello World')                    // String content
 await disk.put('image.jpg', imageBuffer)                      // Buffer content
 await disk.put('data.json', JSON.stringify(data), {          // With options
   contentType: 'application/json',
-  visibility: 'public',
 })
 await disk.putFile('uploads/report.pdf', './temp/report.pdf') // From local file
 
@@ -121,18 +120,24 @@ await disk.deleteDirectory('uploads/temp')
 
 ### Visibility
 
+Where visibility lives depends on the backend, and the driver tells you which one you have rather than pretending:
+
+- **Per object** — S3 with ACLs enabled. `setVisibility()` changes one file.
+- **Per disk** — a local disk (reachability comes from the disk root and whatever serves it), S3 with `acl: false`, and Cloudflare R2. The disk declares its `visibility`; asking for the other value throws instead of silently doing nothing.
+
 ```ts
-const disk = storage.disk()
+const disk = storage.disk('public')       // declared visibility: 'public'
 
-// Set visibility on upload
-await disk.put('file.txt', content, { visibility: 'public' })
+await disk.put('file.txt', content)                  // inherits the disk's visibility
+await disk.put('file.txt', content, { visibility: 'public' })  // same thing, stated explicitly
+await disk.getVisibility('file.txt')                 // 'public' — throws if the file is not there
 
-// Change visibility
-await disk.setVisibility('file.txt', 'public')
-await disk.setVisibility('file.txt', 'private')
+// On a per-object backend this moves one file:
+await storage.disk('s3').setVisibility('file.txt', 'private')
 
-// Get current visibility
-const visibility = await disk.getVisibility('file.txt')
+// On a per-disk backend it throws, naming the option that fixes it. Put the
+// file on a disk with the visibility you want instead:
+await storage.disk('local').put('secret.pdf', content)
 ```
 
 ## Configuration
@@ -364,12 +369,13 @@ export class UploadController extends Controller {
     const ext = file.name.split('.').pop()
     const filename = `avatars/${crypto.randomUUID()}.${ext}`
 
-    await storage.disk().put(filename, buffer, {
+    // The public disk declares its own visibility, so the upload does not
+    // have to ask for one the disk may not be able to honour.
+    await storage.disk('public').put(filename, buffer, {
       contentType: file.type,
-      visibility: 'public',
     })
 
-    const url = storage.disk().url(filename)
+    const url = storage.disk('public').url(filename)
 
     return this.json({ url })
   }

--- a/docs/en/guides/storage.md
+++ b/docs/en/guides/storage.md
@@ -123,7 +123,7 @@ await disk.deleteDirectory('uploads/temp')
 Where visibility lives depends on the backend, and the driver tells you which one you have rather than pretending:
 
 - **Per object** — S3 with ACLs enabled. `setVisibility()` changes one file.
-- **Per disk** — a local disk (reachability comes from the disk root and whatever serves it), S3 with `acl: false`, and Cloudflare R2. The disk declares its `visibility`; asking for the other value throws instead of silently doing nothing.
+- **Per disk** — a local disk (reachability comes from the disk root and whatever serves it), S3 with `acl: false`, and Cloudflare R2. The disk declares its `visibility`; asking for the other value is refused instead of silently doing nothing. On S3 and R2 that is an error today; the local driver warns and will error in the next major, since it has been accepting these calls for a while.
 
 ```ts
 const disk = storage.disk('public')       // declared visibility: 'public'
@@ -135,8 +135,8 @@ await disk.getVisibility('file.txt')                 // 'public' — throws if t
 // On a per-object backend this moves one file:
 await storage.disk('s3').setVisibility('file.txt', 'private')
 
-// On a per-disk backend it throws, naming the option that fixes it. Put the
-// file on a disk with the visibility you want instead:
+// On a per-disk backend the request is refused rather than silently
+// dropped. Put the file on a disk with the visibility you want instead:
 await storage.disk('local').put('secret.pdf', content)
 ```
 

--- a/docs/en/guides/storage.md
+++ b/docs/en/guides/storage.md
@@ -278,8 +278,28 @@ const storage = new StorageManager({
 })
 ```
 
+Endpoints that do not implement S3 object ACLs — R2 documents `x-amz-acl` and the ACL operations as unsupported, and MinIO deployments vary — need `acl: false`. The driver then stops sending the header, `getVisibility()` reports the disk's configured `visibility`, and `put({ visibility })` / `setVisibility()` throw when asked for the other value instead of silently not applying it:
+
+```ts
+const storage = new StorageManager({
+  default: 's3',
+  disks: {
+    s3: {
+      driver: 's3',
+      bucket: 'my-bucket',
+      region: 'auto',
+      endpoint: `https://${process.env.CF_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+      accessKeyId: process.env.R2_ACCESS_KEY_ID,
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+      acl: false,
+      visibility: 'public',
+    },
+  },
+})
+```
+
 > [!NOTE]
-> On Cloudflare Workers, use the bucket binding instead of the S3 API: `R2Driver` from `@guren/plugin-cloudflare` needs no credentials and no AWS SDK. The S3 recipe above is for reaching R2 from other runtimes (a Bun server, a script, Lambda). R2 has no per-object ACLs, so treat visibility as a bucket-level setting there. See the [Cloudflare Workers guide](./cloudflare.md#storage-r2).
+> On Cloudflare Workers, use the bucket binding instead of the S3 API: `R2Driver` from `@guren/plugin-cloudflare` needs no credentials and no AWS SDK. The S3 recipe above is for reaching R2 from other runtimes (a Bun server, a script, Lambda). See the [Cloudflare Workers guide](./cloudflare.md#storage-r2).
 
 ### Pre-signed URLs
 
@@ -292,6 +312,22 @@ const disk = storage.disk('s3')
 const expiration = new Date(Date.now() + 3600 * 1000)
 const url = await disk.temporaryUrl('private/document.pdf', expiration)
 ```
+
+### Choosing a Disk per Environment
+
+Declare every disk once and pick one with an environment variable, the way `bunx guren add storage` scaffolds it. Disks resolve lazily, so a disk you never use is never constructed and its credentials are never read:
+
+```ts
+const storage = createStorageManager({
+  default: process.env.STORAGE_DISK ?? 'local',
+  disks: {
+    local: { driver: 'local', root: './storage/app/public', url: '/storage' },
+    s3: { driver: 's3', bucket: process.env.S3_BUCKET!, region: 'ap-northeast-1' },
+  },
+})
+```
+
+`STORAGE_DISK=local` in development, `STORAGE_DISK=s3` in production — no code change, and `storage.disk()` returns whichever one is selected.
 
 ## File Uploads
 

--- a/docs/ja/guides/storage.md
+++ b/docs/ja/guides/storage.md
@@ -49,7 +49,6 @@ await disk.put('file.txt', 'Hello World')                    // 文字列コン�
 await disk.put('image.jpg', imageBuffer)                      // Bufferコンテンツ
 await disk.put('data.json', JSON.stringify(data), {          // オプション付き
   contentType: 'application/json',
-  visibility: 'public',
 })
 await disk.putFile('uploads/report.pdf', './temp/report.pdf') // ローカルファイルから
 
@@ -121,18 +120,24 @@ await disk.deleteDirectory('uploads/temp')
 
 ### 可視性
 
+可視性がどこに属するかはバックエンド次第で、ドライバは「できるふり」をせずどちらであるかを示します。
+
+- **オブジェクト単位** — ACL が有効な S3。`setVisibility()` は1ファイルだけを変更します。
+- **ディスク単位** — ローカルディスク（到達可能性はディスクのルートと、それを配信する仕組みで決まります）、`acl: false` の S3、Cloudflare R2。ディスク側で `visibility` を宣言し、逆の値を求められた場合は黙って無視せず例外を投げます。
+
 ```ts
-const disk = storage.disk()
+const disk = storage.disk('public')       // visibility: 'public' を宣言したディスク
 
-// アップロード時に可視性を設定
-await disk.put('file.txt', content, { visibility: 'public' })
+await disk.put('file.txt', content)                  // ディスクの可視性を継承
+await disk.put('file.txt', content, { visibility: 'public' })  // 同じ意味を明示しただけ
+await disk.getVisibility('file.txt')                 // 'public'（ファイルが無ければ例外）
 
-// 可視性を変更
-await disk.setVisibility('file.txt', 'public')
-await disk.setVisibility('file.txt', 'private')
+// オブジェクト単位のバックエンドでは1ファイルだけ移動します
+await storage.disk('s3').setVisibility('file.txt', 'private')
 
-// 現在の可視性を取得
-const visibility = await disk.getVisibility('file.txt')
+// ディスク単位のバックエンドでは、対処すべきオプションを示して例外になります。
+// 代わりに目的の可視性を持つディスクへ置いてください。
+await storage.disk('local').put('secret.pdf', content)
 ```
 
 ## 設定
@@ -364,12 +369,13 @@ export class UploadController extends Controller {
     const ext = file.name.split('.').pop()
     const filename = `avatars/${crypto.randomUUID()}.${ext}`
 
-    await storage.disk().put(filename, buffer, {
+    // The public disk declares its own visibility, so the upload does not
+    // have to ask for one the disk may not be able to honour.
+    await storage.disk('public').put(filename, buffer, {
       contentType: file.type,
-      visibility: 'public',
     })
 
-    const url = storage.disk().url(filename)
+    const url = storage.disk('public').url(filename)
 
     return this.json({ url })
   }

--- a/docs/ja/guides/storage.md
+++ b/docs/ja/guides/storage.md
@@ -315,7 +315,7 @@ const url = await disk.temporaryUrl('private/document.pdf', expiration)
 
 ### 環境ごとのディスク切り替え
 
-ディスクはまとめて宣言しておき、環境変数で選びます（`bunx guren add storage` はこの形で生成します）。ディスクは遅延解決されるため、使わないディスクは構築されず、その資格情報も読まれません。
+ディスクはまとめて宣言しておき、環境変数で選びます（`bunx guren add storage` はこの形で生成します）。ドライバは初回利用時に構築されるため、触らないディスクはクライアントも接続も作りません。
 
 ```ts
 const storage = createStorageManager({
@@ -328,6 +328,11 @@ const storage = createStorageManager({
 ```
 
 開発では `STORAGE_DISK=local`、本番では `STORAGE_DISK=s3`。コードの変更は不要で、`storage.disk()` は選ばれた方を返します。
+
+この形について、2点注意があります。
+
+- **設定値は解決しないディスクの分も先に読まれます。** オブジェクトを組み立てた時点で評価されるためです。`process.env.S3_BUCKET` が未設定でも無害ですが、未設定時に例外を投げるヘルパーを書くと、そのディスクを一度も使わなくても起動時に落ちます。そうしたヘルパーはディスクの定義に置かず、`storage.registerDisk('s3', () => new S3Driver({ ... }))` を使ってください。こちらのコールバックは本当に初回利用時に実行されます。
+- **未知のディスク名は構築時には弾かれません。** `createStorageManager({ default: 'typo' })` は成功し、最初にディスクを解決したときに初めて `Storage disk not found: typo` を投げます。キュージョブの中かもしれません。生成される StorageProvider が起動時に名前を検証しているのはこのためです。設定を手書きする場合も同じようにしてください。
 
 ## ファイルアップロード
 

--- a/docs/ja/guides/storage.md
+++ b/docs/ja/guides/storage.md
@@ -278,8 +278,28 @@ const storage = new StorageManager({
 })
 ```
 
+S3 のオブジェクト ACL に対応していないエンドポイント（R2 は `x-amz-acl` と ACL 操作を非対応と明記しており、MinIO は構成によります）では `acl: false` を指定します。ドライバはヘッダの送出をやめ、`getVisibility()` はディスクに設定した `visibility` を返し、`put({ visibility })` や `setVisibility()` で逆の値を求められた場合は、黙って無視せず例外を投げます。
+
+```ts
+const storage = new StorageManager({
+  default: 's3',
+  disks: {
+    s3: {
+      driver: 's3',
+      bucket: 'my-bucket',
+      region: 'auto',
+      endpoint: `https://${process.env.CF_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+      accessKeyId: process.env.R2_ACCESS_KEY_ID,
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+      acl: false,
+      visibility: 'public',
+    },
+  },
+})
+```
+
 > [!NOTE]
-> Cloudflare Workers 上では S3 API ではなくバケットバインディングを使ってください。`@guren/plugin-cloudflare` の `R2Driver` は資格情報も AWS SDK も不要です。上の S3 のレシピは他のランタイム（Bun サーバー、スクリプト、Lambda）から R2 に到達するためのものです。R2 にはオブジェクト単位の ACL が無いため、可視性はバケット単位の設定として扱ってください。[Cloudflare Workers ガイド](./cloudflare.md#ストレージr2)を参照してください。
+> Cloudflare Workers 上では S3 API ではなくバケットバインディングを使ってください。`@guren/plugin-cloudflare` の `R2Driver` は資格情報も AWS SDK も不要です。上の S3 のレシピは他のランタイム（Bun サーバー、スクリプト、Lambda）から R2 に到達するためのものです。[Cloudflare Workers ガイド](./cloudflare.md#ストレージr2)を参照してください。
 
 ### 署名付きURL
 
@@ -292,6 +312,22 @@ const disk = storage.disk('s3')
 const expiration = new Date(Date.now() + 3600 * 1000)
 const url = await disk.temporaryUrl('private/document.pdf', expiration)
 ```
+
+### 環境ごとのディスク切り替え
+
+ディスクはまとめて宣言しておき、環境変数で選びます（`bunx guren add storage` はこの形で生成します）。ディスクは遅延解決されるため、使わないディスクは構築されず、その資格情報も読まれません。
+
+```ts
+const storage = createStorageManager({
+  default: process.env.STORAGE_DISK ?? 'local',
+  disks: {
+    local: { driver: 'local', root: './storage/app/public', url: '/storage' },
+    s3: { driver: 's3', bucket: process.env.S3_BUCKET!, region: 'ap-northeast-1' },
+  },
+})
+```
+
+開発では `STORAGE_DISK=local`、本番では `STORAGE_DISK=s3`。コードの変更は不要で、`storage.disk()` は選ばれた方を返します。
 
 ## ファイルアップロード
 

--- a/docs/ja/guides/storage.md
+++ b/docs/ja/guides/storage.md
@@ -123,7 +123,7 @@ await disk.deleteDirectory('uploads/temp')
 可視性がどこに属するかはバックエンド次第で、ドライバは「できるふり」をせずどちらであるかを示します。
 
 - **オブジェクト単位** — ACL が有効な S3。`setVisibility()` は1ファイルだけを変更します。
-- **ディスク単位** — ローカルディスク（到達可能性はディスクのルートと、それを配信する仕組みで決まります）、`acl: false` の S3、Cloudflare R2。ディスク側で `visibility` を宣言し、逆の値を求められた場合は黙って無視せず例外を投げます。
+- **ディスク単位** — ローカルディスク（到達可能性はディスクのルートと、それを配信する仕組みで決まります）、`acl: false` の S3、Cloudflare R2。ディスク側で `visibility` を宣言し、逆の値を求められた場合は黙って無視せず拒否します。S3 と R2 では現在すでにエラーですが、ローカルドライバはこれまで受け付けてきた経緯があるため、今は警告のみで次のメジャーでエラーになります。
 
 ```ts
 const disk = storage.disk('public')       // visibility: 'public' を宣言したディスク
@@ -135,7 +135,7 @@ await disk.getVisibility('file.txt')                 // 'public'（ファイル�
 // オブジェクト単位のバックエンドでは1ファイルだけ移動します
 await storage.disk('s3').setVisibility('file.txt', 'private')
 
-// ディスク単位のバックエンドでは、対処すべきオプションを示して例外になります。
+// ディスク単位のバックエンドでは、黙って捨てられるのではなく拒否されます。
 // 代わりに目的の可視性を持つディスクへ置いてください。
 await storage.disk('local').put('secret.pdf', content)
 ```

--- a/examples/api/app/Providers/StorageProvider.ts
+++ b/examples/api/app/Providers/StorageProvider.ts
@@ -6,7 +6,7 @@ export default class StorageProvider extends ServiceProvider {
       default: 'local',
       disks: {
         local: { driver: 'local', root: './storage/app' },
-        public: { driver: 'local', root: './storage/app/public' },
+        public: { driver: 'local', root: './storage/app/public', visibility: 'public' },
       },
     }))
   }

--- a/examples/api/tests/providers/StorageProvider.test.ts
+++ b/examples/api/tests/providers/StorageProvider.test.ts
@@ -33,7 +33,7 @@ describe('API StorageProvider', () => {
       default: 'local',
       disks: {
         local: { driver: 'local', root: './storage/app' },
-        public: { driver: 'local', root: './storage/app/public' },
+        public: { driver: 'local', root: './storage/app/public', visibility: 'public' },
       },
     })
   })

--- a/examples/blog/app/Providers/StorageProvider.ts
+++ b/examples/blog/app/Providers/StorageProvider.ts
@@ -6,7 +6,7 @@ export default class StorageProvider extends ServiceProvider {
       default: 'local',
       disks: {
         local: { driver: 'local', root: './storage/app' },
-        public: { driver: 'local', root: './storage/app/public' },
+        public: { driver: 'local', root: './storage/app/public', visibility: 'public' },
       },
     }))
   }

--- a/examples/blog/tests/providers/StorageProvider.test.ts
+++ b/examples/blog/tests/providers/StorageProvider.test.ts
@@ -33,7 +33,7 @@ describe('Blog StorageProvider', () => {
       default: 'local',
       disks: {
         local: { driver: 'local', root: './storage/app' },
-        public: { driver: 'local', root: './storage/app/public' },
+        public: { driver: 'local', root: './storage/app/public', visibility: 'public' },
       },
     })
   })

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -513,18 +513,30 @@ export default class NotificationProvider extends ServiceProvider {
           path: 'app/Providers/StorageProvider.ts',
           contents: `import { ServiceProvider, createStorageManager } from '@guren/core'
 
+// Declared once, chosen per environment: set STORAGE_DISK in .env (or in
+// your platform's vars) to switch without touching code. Drivers are built
+// on first use, so a disk you never touch never opens a connection — but the
+// values below are read when this object is built, so keep anything that can
+// throw (a required-env helper) out of it.
+const disks = {
+  local: { driver: 'local', root: './storage/app' },
+  public: { driver: 'local', root: './storage/app/public' },
+} as const
+
+const selected = process.env.STORAGE_DISK ?? 'local'
+
 export default class StorageProvider extends ServiceProvider {
   register(): void {
-    // Disks are declared here and chosen per environment: set STORAGE_DISK
-    // in .env (or in your platform's vars) to switch without touching code.
-    // Disks resolve lazily, so declaring one you do not use costs nothing.
-    this.container.instance('storage', createStorageManager({
-      default: process.env.STORAGE_DISK ?? 'local',
-      disks: {
-        local: { driver: 'local', root: './storage/app' },
-        public: { driver: 'local', root: './storage/app/public' },
-      },
-    }))
+    // Checked here rather than left to the first upload: an unknown name is
+    // accepted at construction and only throws when a disk is resolved,
+    // which can be a queued job or a rarely-hit route in production.
+    if (!(selected in disks)) {
+      throw new Error(
+        \`STORAGE_DISK="\${selected}" is not a declared disk. Declare it in app/Providers/StorageProvider.ts or use one of: \${Object.keys(disks).join(', ')}.\`,
+      )
+    }
+
+    this.container.instance('storage', createStorageManager({ default: selected, disks }))
   }
 }
 `,

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -520,7 +520,9 @@ export default class NotificationProvider extends ServiceProvider {
 // throw (a required-env helper) out of it.
 const disks = {
   local: { driver: 'local', root: './storage/app' },
-  public: { driver: 'local', root: './storage/app/public' },
+  // Declared public because it is: everything under it is served. A local
+  // disk has no per-object visibility, so this is where that is decided.
+  public: { driver: 'local', root: './storage/app/public', visibility: 'public' },
 } as const
 
 const selected = process.env.STORAGE_DISK ?? 'local'

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -505,7 +505,7 @@ export default class NotificationProvider extends ServiceProvider {
     },
   },
   storage: {
-    description: 'Install storage infrastructure with local/public disks and a sample storage service.',
+    description: 'Install storage infrastructure with local/public disks (switchable via STORAGE_DISK) and a sample storage service.',
     run: async (options) => {
       const writerOptions: WriterOptions = { force: Boolean(options.force) }
       const created = await scaffoldFeatureFiles([
@@ -515,8 +515,11 @@ export default class NotificationProvider extends ServiceProvider {
 
 export default class StorageProvider extends ServiceProvider {
   register(): void {
+    // Disks are declared here and chosen per environment: set STORAGE_DISK
+    // in .env (or in your platform's vars) to switch without touching code.
+    // Disks resolve lazily, so declaring one you do not use costs nothing.
     this.container.instance('storage', createStorageManager({
-      default: 'local',
+      default: process.env.STORAGE_DISK ?? 'local',
       disks: {
         local: { driver: 'local', root: './storage/app' },
         public: { driver: 'local', root: './storage/app/public' },

--- a/packages/cli/src/deprecations.ts
+++ b/packages/cli/src/deprecations.ts
@@ -6,7 +6,7 @@
  */
 import { readFile } from 'node:fs/promises'
 import { relative } from 'node:path'
-import { discoverModelFiles } from './discovery'
+import { discoverAppSourceFiles, discoverModelFiles } from './discovery'
 import { extractClassDeclaration, findStaticClassProperty } from './model-parser'
 import { parseSourceFile } from './parse-cache'
 
@@ -49,6 +49,26 @@ async function detectModelStatic(cwd: string, property: string): Promise<string[
 /**
  * Registry of all known deprecations.
  */
+/**
+ * Call sites that ask a storage disk for per-object visibility. Text search
+ * rather than AST: the call can sit anywhere (a controller, a job, a
+ * service), and the disk it targets is only known at runtime, so this
+ * reports candidates for a human to read rather than pretending to resolve
+ * which driver each one hits.
+ */
+async function detectLocalVisibilityCalls(cwd: string): Promise<string[]> {
+  const files = await discoverAppSourceFiles(cwd)
+  const affected = await Promise.all(
+    files.map(async (filePath) => {
+      const source = await readFile(filePath, 'utf-8')
+      const callsSetVisibility = source.includes('.setVisibility(')
+      const putsWithVisibility = /\.put\([^)]*\bvisibility\s*:/s.test(source)
+      return callsSetVisibility || putsWithVisibility ? relative(cwd, filePath) : null
+    }),
+  )
+  return affected.filter((file): file is string => file !== null)
+}
+
 export const deprecations: Deprecation[] = [
   {
     id: 'model-guarded',
@@ -69,6 +89,17 @@ export const deprecations: Deprecation[] = [
       'Delete the declaration — fillable is always strict. Each new throw is a field the model was silently '
       + 'dropping: add it to fillable or remove it from the payload.',
     detect: (cwd) => detectModelStatic(cwd, 'strictFillable'),
+  },
+  {
+    id: 'local-disk-per-object-visibility',
+    what: 'Per-object visibility on a local storage disk (setVisibility, or put({ visibility })) ',
+    since: '2.7.0',
+    removedIn: '3.0.0',
+    replacement:
+      'A local disk has no per-object visibility: what makes a file reachable is the disk root and whatever '
+      + 'serves it, so these calls have never done anything. Declare the disk\'s "visibility" option to match '
+      + 'what it is, and keep restricted files on a disk that is not served.',
+    detect: detectLocalVisibilityCalls,
   },
 ]
 

--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -249,6 +249,15 @@ export function discoverModelFiles(appRoot: string): Promise<string[]> {
   return discoverDir(appRoot, 'app/Models')
 }
 
+/**
+ * Every source file under `app/`, module roots included. For checks whose
+ * subject can live anywhere an app puts code (a controller, a job, a
+ * service) rather than in one conventional directory.
+ */
+export function discoverAppSourceFiles(appRoot: string): Promise<string[]> {
+  return discoverDir(appRoot, 'app')
+}
+
 export function discoverControllerFiles(appRoot: string): Promise<string[]> {
   return discoverDir(appRoot, 'app/Http/Controllers')
 }

--- a/packages/server/src/storage/drivers/LocalDriver.ts
+++ b/packages/server/src/storage/drivers/LocalDriver.ts
@@ -62,6 +62,9 @@ export class LocalDriver implements StorageDriver {
   }
 
   async put(path: string, content: Buffer | string, options?: PutOptions): Promise<string> {
+    if (options?.visibility) {
+      this.assertVisibilityMatches(options.visibility, 'put')
+    }
     const fullPath = this.fullPath(path)
     await this.ensureDirectory(fullPath)
 
@@ -242,18 +245,35 @@ export class LocalDriver implements StorageDriver {
   }
 
   async setVisibility(path: string, visibility: 'public' | 'private'): Promise<void> {
-    // Known deviation from the `StorageDriver` contract, kept deliberately:
-    // the contract says a driver without per-object visibility reports the
-    // disk's value and throws for the other one, and that any visibility
-    // call throws for a missing file. Both would change the default
-    // behavior of a stable API, so they wait for the next major; every
-    // other driver already behaves as documented.
+    // A local disk has no per-object visibility: whether a file is reachable
+    // is decided by where the disk is rooted and what serves it, not by a
+    // flag on one file. So the contract's rule for such backends applies —
+    // report the disk's value, refuse the other one, and never claim success
+    // for a file that is not there.
+    await this.assertExists(path)
+    this.assertVisibilityMatches(visibility, 'setVisibility')
   }
 
   async getVisibility(path: string): Promise<'public' | 'private'> {
-    // Returns the disk value even for a path that does not exist — see the
-    // deviation note on `setVisibility`.
+    await this.assertExists(path)
     return this.defaultVisibility
+  }
+
+  private async assertExists(path: string): Promise<void> {
+    if (!(await this.exists(path))) {
+      throw new Error(`File not found: ${path}`)
+    }
+  }
+
+  private assertVisibilityMatches(requested: 'public' | 'private', operation: string): void {
+    if (requested === this.defaultVisibility) {
+      return
+    }
+    throw new Error(
+      `LocalDriver.${operation}: cannot make an object ${requested} on a ${this.defaultVisibility} disk. ` +
+        'A local disk has no per-object visibility — it is decided by the disk root and by what serves it. ' +
+        'Declare it with the driver\'s "visibility" option, or keep restricted files on a disk that is not served.',
+    )
   }
 
   /**

--- a/packages/server/src/storage/drivers/LocalDriver.ts
+++ b/packages/server/src/storage/drivers/LocalDriver.ts
@@ -12,6 +12,7 @@ import {
 import { existsSync } from 'node:fs'
 import { join, dirname, relative, resolve, sep } from 'node:path'
 import type { StorageDriver, LocalDriverOptions, PutOptions, FileMetadata } from '../types'
+import { warnOnce } from '../../support/warn-once'
 
 /**
  * Local filesystem storage driver.
@@ -63,7 +64,7 @@ export class LocalDriver implements StorageDriver {
 
   async put(path: string, content: Buffer | string, options?: PutOptions): Promise<string> {
     if (options?.visibility) {
-      this.assertVisibilityMatches(options.visibility, 'put')
+      this.warnUnsupportedVisibility(options.visibility, 'put')
     }
     const fullPath = this.fullPath(path)
     await this.ensureDirectory(fullPath)
@@ -247,32 +248,41 @@ export class LocalDriver implements StorageDriver {
   async setVisibility(path: string, visibility: 'public' | 'private'): Promise<void> {
     // A local disk has no per-object visibility: whether a file is reachable
     // is decided by where the disk is rooted and what serves it, not by a
-    // flag on one file. So the contract's rule for such backends applies —
-    // report the disk's value, refuse the other one, and never claim success
-    // for a file that is not there.
-    await this.assertExists(path)
-    this.assertVisibilityMatches(visibility, 'setVisibility')
+    // flag on one file. The contract's rule for such backends is to refuse
+    // what cannot be carried out, but this driver has been silently
+    // accepting it, so it warns for now and throws in the next major.
+    await this.warnIfMissing(path, 'setVisibility')
+    this.warnUnsupportedVisibility(visibility, 'setVisibility')
   }
 
   async getVisibility(path: string): Promise<'public' | 'private'> {
-    await this.assertExists(path)
+    await this.warnIfMissing(path, 'getVisibility')
     return this.defaultVisibility
   }
 
-  private async assertExists(path: string): Promise<void> {
-    if (!(await this.exists(path))) {
-      throw new Error(`File not found: ${path}`)
+  private async warnIfMissing(path: string, operation: string): Promise<void> {
+    if (await this.exists(path)) {
+      return
     }
+    warnOnce(
+      `local-visibility-missing:${operation}`,
+      `[guren] LocalDriver.${operation}("${path}") was called for a file that does not exist and returned as if it `
+        + 'had succeeded. Every other storage driver throws `File not found` here, and LocalDriver will too in the '
+        + 'next major — check `exists()` first, or handle the error.',
+    )
   }
 
-  private assertVisibilityMatches(requested: 'public' | 'private', operation: string): void {
+  private warnUnsupportedVisibility(requested: 'public' | 'private', operation: string): void {
     if (requested === this.defaultVisibility) {
       return
     }
-    throw new Error(
-      `LocalDriver.${operation}: cannot make an object ${requested} on a ${this.defaultVisibility} disk. ` +
-        'A local disk has no per-object visibility — it is decided by the disk root and by what serves it. ' +
-        'Declare it with the driver\'s "visibility" option, or keep restricted files on a disk that is not served.',
+    warnOnce(
+      `local-visibility-per-object:${operation}`,
+      `[guren] LocalDriver.${operation}() was asked to make an object ${requested} on a ${this.defaultVisibility} `
+        + 'disk, and did nothing. A local disk has no per-object visibility — what makes a file reachable is the '
+        + 'disk root and whatever serves it — so the request was never carried out, it only looked like it was. '
+        + 'Declare the disk\'s "visibility" option to match, or keep restricted files on a disk that is not '
+        + 'served. This becomes an error in the next major.',
     )
   }
 

--- a/packages/server/src/storage/drivers/LocalDriver.ts
+++ b/packages/server/src/storage/drivers/LocalDriver.ts
@@ -242,11 +242,17 @@ export class LocalDriver implements StorageDriver {
   }
 
   async setVisibility(path: string, visibility: 'public' | 'private'): Promise<void> {
-    // Local driver doesn't have visibility control
-    // This is a no-op
+    // Known deviation from the `StorageDriver` contract, kept deliberately:
+    // the contract says a driver without per-object visibility reports the
+    // disk's value and throws for the other one, and that any visibility
+    // call throws for a missing file. Both would change the default
+    // behavior of a stable API, so they wait for the next major; every
+    // other driver already behaves as documented.
   }
 
   async getVisibility(path: string): Promise<'public' | 'private'> {
+    // Returns the disk value even for a path that does not exist — see the
+    // deviation note on `setVisibility`.
     return this.defaultVisibility
   }
 

--- a/packages/server/src/storage/drivers/S3Driver.ts
+++ b/packages/server/src/storage/drivers/S3Driver.ts
@@ -1,4 +1,5 @@
 import type { StorageDriver, S3DriverOptions, PutOptions, FileMetadata } from '../types'
+import { assertVisibilitySupported, cannedAcl, putAclFields } from './s3-acl'
 
 /**
  * S3 Client interface (@aws-sdk/client-s3 compatible).
@@ -34,6 +35,7 @@ export class S3Driver implements StorageDriver {
   private readonly prefix: string
   private readonly baseUrl: string
   private readonly defaultVisibility: 'public' | 'private'
+  private readonly acl: boolean
 
   constructor(private readonly options: S3DriverOptions) {
     this.client = options.client as S3Client | null
@@ -45,6 +47,7 @@ export class S3Driver implements StorageDriver {
     this.prefix = options.prefix ?? ''
     this.baseUrl = options.url ?? `https://${this.bucket}.s3.${this.region}.amazonaws.com`
     this.defaultVisibility = options.visibility ?? 'private'
+    this.acl = options.acl ?? true
   }
 
   /**
@@ -87,12 +90,6 @@ export class S3Driver implements StorageDriver {
     return this.prefix ? `${this.prefix}/${path}` : path
   }
 
-  /**
-   * Get ACL from visibility.
-   */
-  private getAcl(visibility: 'public' | 'private'): string {
-    return visibility === 'public' ? 'public-read' : 'private'
-  }
 
   async put(path: string, content: Buffer | string, options?: PutOptions): Promise<string> {
     const client = await this.getClient()
@@ -101,6 +98,7 @@ export class S3Driver implements StorageDriver {
     }
 
     const body = typeof content === 'string' ? Buffer.from(content) : content
+    assertVisibilitySupported(this.acl, this.defaultVisibility, options?.visibility, 'put')
     const visibility = options?.visibility ?? this.defaultVisibility
 
     const command = new PutObjectCommand({
@@ -108,7 +106,7 @@ export class S3Driver implements StorageDriver {
       Key: this.prefixKey(path),
       Body: body,
       ContentType: options?.contentType,
-      ACL: this.getAcl(visibility),
+      ...putAclFields(this.acl, visibility),
       Metadata: options?.metadata,
     })
 
@@ -395,6 +393,12 @@ export class S3Driver implements StorageDriver {
   }
 
   async setVisibility(path: string, visibility: 'public' | 'private'): Promise<void> {
+    assertVisibilitySupported(this.acl, this.defaultVisibility, visibility, 'setVisibility')
+    if (!this.acl) {
+      // Equal to the disk's visibility (the guard above proved it), and this
+      // endpoint has no per-object ACL to write.
+      return
+    }
     const client = await this.getClient()
     const { PutObjectAclCommand } = await importAwsModule('@aws-sdk/client-s3') as {
       PutObjectAclCommand: new (input: unknown) => unknown
@@ -403,13 +407,16 @@ export class S3Driver implements StorageDriver {
     const command = new PutObjectAclCommand({
       Bucket: this.bucket,
       Key: this.prefixKey(path),
-      ACL: this.getAcl(visibility),
+      ACL: cannedAcl(visibility),
     })
 
     await client.send(command)
   }
 
   async getVisibility(path: string): Promise<'public' | 'private'> {
+    if (!this.acl) {
+      return this.defaultVisibility
+    }
     const client = await this.getClient()
     const { GetObjectAclCommand } = await importAwsModule('@aws-sdk/client-s3') as {
       GetObjectAclCommand: new (input: unknown) => unknown

--- a/packages/server/src/storage/drivers/S3Driver.ts
+++ b/packages/server/src/storage/drivers/S3Driver.ts
@@ -92,13 +92,17 @@ export class S3Driver implements StorageDriver {
 
 
   async put(path: string, content: Buffer | string, options?: PutOptions): Promise<string> {
+    // Before the client and the SDK import: a request this disk cannot
+    // honour should say so, not report a missing optional dependency that
+    // would not have made it succeed.
+    assertVisibilitySupported(this.acl, this.defaultVisibility, options?.visibility, 'put')
+
     const client = await this.getClient()
     const { PutObjectCommand } = await importAwsModule('@aws-sdk/client-s3') as {
       PutObjectCommand: new (input: unknown) => unknown
     }
 
     const body = typeof content === 'string' ? Buffer.from(content) : content
-    assertVisibilitySupported(this.acl, this.defaultVisibility, options?.visibility, 'put')
     const visibility = options?.visibility ?? this.defaultVisibility
 
     const command = new PutObjectCommand({
@@ -313,6 +317,15 @@ export class S3Driver implements StorageDriver {
     }
   }
 
+  /** `metadata()`, but honouring the contract's not-found error. */
+  private async metadataOrFail(path: string): Promise<FileMetadata> {
+    const metadata = await this.metadata(path)
+    if (!metadata) {
+      throw new Error(`File not found: ${path}`)
+    }
+    return metadata
+  }
+
   async files(directory: string): Promise<string[]> {
     const client = await this.getClient()
     const { ListObjectsV2Command } = await importAwsModule('@aws-sdk/client-s3') as {
@@ -395,8 +408,10 @@ export class S3Driver implements StorageDriver {
   async setVisibility(path: string, visibility: 'public' | 'private'): Promise<void> {
     assertVisibilitySupported(this.acl, this.defaultVisibility, visibility, 'setVisibility')
     if (!this.acl) {
-      // Equal to the disk's visibility (the guard above proved it), and this
-      // endpoint has no per-object ACL to write.
+      // Equal to the disk's visibility (the guard above proved it), so there
+      // is no ACL to write — but the contract still forbids reporting
+      // success for an object that is not there.
+      await this.metadataOrFail(path)
       return
     }
     const client = await this.getClient()
@@ -415,6 +430,7 @@ export class S3Driver implements StorageDriver {
 
   async getVisibility(path: string): Promise<'public' | 'private'> {
     if (!this.acl) {
+      await this.metadataOrFail(path)
       return this.defaultVisibility
     }
     const client = await this.getClient()

--- a/packages/server/src/storage/drivers/s3-acl.ts
+++ b/packages/server/src/storage/drivers/s3-acl.ts
@@ -1,0 +1,45 @@
+/**
+ * The ACL half of the S3 driver, kept out of the driver so it can be tested
+ * without the optional `@aws-sdk/client-s3` peer installed: these functions
+ * decide what goes into a command, which is exactly the part that was wrong
+ * for every S3-compatible endpoint without ACL support.
+ */
+
+export type Visibility = 'public' | 'private'
+
+/** The canned ACL S3 uses for each visibility. */
+export function cannedAcl(visibility: Visibility): string {
+  return visibility === 'public' ? 'public-read' : 'private'
+}
+
+/**
+ * The `ACL` field for a `PutObject` input, or nothing when the endpoint has
+ * no ACLs. Returned as a spreadable object so the caller never sends an
+ * explicit `ACL: undefined`, which some S3 implementations reject outright
+ * rather than treat as absent.
+ */
+export function putAclFields(acl: boolean, visibility: Visibility): { ACL?: string } {
+  return acl ? { ACL: cannedAcl(visibility) } : {}
+}
+
+/**
+ * Guard for a per-object visibility an ACL-less endpoint cannot honour.
+ * Throws rather than silently dropping the request: a `setVisibility(path,
+ * 'private')` that does nothing on a public bucket is a leak that looks like
+ * success.
+ */
+export function assertVisibilitySupported(
+  acl: boolean,
+  diskVisibility: Visibility,
+  requested: Visibility | undefined,
+  operation: string,
+): void {
+  if (acl || !requested || requested === diskVisibility) {
+    return
+  }
+  throw new Error(
+    `S3Driver.${operation}: cannot make an object ${requested} on a ${diskVisibility} disk configured with acl: false. ` +
+      'This endpoint does not implement S3 object ACLs, so visibility is a property of the bucket. ' +
+      'Declare it with the driver\'s "visibility" option, or serve restricted files through your own route.',
+  )
+}

--- a/packages/server/src/storage/types.ts
+++ b/packages/server/src/storage/types.ts
@@ -197,7 +197,9 @@ export interface StorageDriver {
    * doing nothing is a leak that looks like success.
    *
    * `LocalDriver` is such a backend: what makes a local file reachable is
-   * the disk root and whatever serves it, not a flag on one file.
+   * the disk root and whatever serves it, not a flag on one file. It has
+   * always accepted per-object requests and done nothing, so it warns
+   * instead of throwing and will throw in the next major.
    *
    * @param path File path
    * @param visibility Visibility setting

--- a/packages/server/src/storage/types.ts
+++ b/packages/server/src/storage/types.ts
@@ -275,6 +275,25 @@ export interface S3DriverOptions {
    * @default 'private'
    */
   visibility?: 'public' | 'private'
+
+  /**
+   * Whether the endpoint implements S3 object ACLs.
+   *
+   * AWS S3 does, so this defaults to `true` and every `put` carries an
+   * `x-amz-acl` header derived from the file's visibility. Several
+   * S3-compatible endpoints do not: Cloudflare R2 documents `x-amz-acl` and
+   * the ACL operations as unsupported (access is decided per bucket), and
+   * MinIO/others vary. Set `acl: false` for those.
+   *
+   * With `acl: false` the driver stops sending the header, and visibility
+   * becomes a property of the whole disk: `getVisibility()` reports the
+   * configured `visibility`, and `put({ visibility })` / `setVisibility()`
+   * throw when asked for the other value rather than silently not applying
+   * it. Enforce per-object access in front of the disk instead.
+   *
+   * @default true
+   */
+  acl?: boolean
 }
 
 /**

--- a/packages/server/src/storage/types.ts
+++ b/packages/server/src/storage/types.ts
@@ -196,9 +196,8 @@ export interface StorageDriver {
    * value, rather than accepting a request it cannot honour — silently
    * doing nothing is a leak that looks like success.
    *
-   * Known deviation: `LocalDriver` is an unconditional no-op and does not
-   * throw on either count. Aligning it changes the default behavior of a
-   * stable API, so it is deferred to the next major.
+   * `LocalDriver` is such a backend: what makes a local file reachable is
+   * the disk root and whatever serves it, not a flag on one file.
    *
    * @param path File path
    * @param visibility Visibility setting
@@ -210,9 +209,6 @@ export interface StorageDriver {
    *
    * Contract: throws when the file does not exist. Drivers without
    * per-object visibility report the disk's configured value.
-   *
-   * Known deviation: `LocalDriver` returns the disk value for any path,
-   * including one that does not exist (see `setVisibility`).
    *
    * @param path File path
    */

--- a/packages/server/src/storage/types.ts
+++ b/packages/server/src/storage/types.ts
@@ -188,6 +188,18 @@ export interface StorageDriver {
 
   /**
    * Set file visibility.
+   *
+   * Contract: throws when the file does not exist, so a caller cannot take
+   * success as proof the object is there. A driver whose backend has no
+   * per-object visibility (bucket-level access, a plain filesystem) reports
+   * the disk's configured visibility and throws when asked for the other
+   * value, rather than accepting a request it cannot honour — silently
+   * doing nothing is a leak that looks like success.
+   *
+   * Known deviation: `LocalDriver` is an unconditional no-op and does not
+   * throw on either count. Aligning it changes the default behavior of a
+   * stable API, so it is deferred to the next major.
+   *
    * @param path File path
    * @param visibility Visibility setting
    */
@@ -195,6 +207,13 @@ export interface StorageDriver {
 
   /**
    * Get file visibility.
+   *
+   * Contract: throws when the file does not exist. Drivers without
+   * per-object visibility report the disk's configured value.
+   *
+   * Known deviation: `LocalDriver` returns the disk value for any path,
+   * including one that does not exist (see `setVisibility`).
+   *
    * @param path File path
    */
   getVisibility(path: string): Promise<'public' | 'private'>

--- a/packages/server/src/support/warn-once.ts
+++ b/packages/server/src/support/warn-once.ts
@@ -1,0 +1,22 @@
+const warned = new Set<string>()
+
+/**
+ * Emit a warning the first time a given key is seen in this process.
+ *
+ * Deprecation warnings have to be loud enough to be read once and quiet
+ * enough not to drown a request log, which is the same shape the OAuth
+ * warnings settled on (`auth/oauth/index.ts`) — this is that pattern with a
+ * key, so several call sites can share it.
+ */
+export function warnOnce(key: string, message: string): void {
+  if (warned.has(key)) {
+    return
+  }
+  warned.add(key)
+  console.warn(message)
+}
+
+/** Test seam: forget what has already been warned about. */
+export function resetWarnOnce(): void {
+  warned.clear()
+}

--- a/packages/server/tests/storage/s3-acl.test.ts
+++ b/packages/server/tests/storage/s3-acl.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'bun:test'
+import { assertVisibilitySupported, cannedAcl, putAclFields } from '../../src/storage/drivers/s3-acl'
+
+// These cover the decision the S3 driver makes about `x-amz-acl` rather than
+// the AWS calls around it: the SDK is an optional peer that is not installed
+// here, and stubbing it would only assert that a stub was called. What can be
+// checked without it — and what was wrong for every ACL-less endpoint — is
+// which fields end up in the command.
+describe('cannedAcl', () => {
+  it('maps visibility to the S3 canned ACL names', () => {
+    expect(cannedAcl('public')).toBe('public-read')
+    expect(cannedAcl('private')).toBe('private')
+  })
+})
+
+describe('putAclFields', () => {
+  it('carries the ACL when the endpoint implements ACLs', () => {
+    expect(putAclFields(true, 'public')).toEqual({ ACL: 'public-read' })
+    expect(putAclFields(true, 'private')).toEqual({ ACL: 'private' })
+  })
+
+  it('omits the field entirely when it does not', () => {
+    expect(putAclFields(false, 'public')).toEqual({})
+    expect(putAclFields(false, 'private')).toEqual({})
+  })
+
+  it('never produces an explicit undefined, which some endpoints reject', () => {
+    expect('ACL' in putAclFields(false, 'public')).toBe(false)
+  })
+})
+
+describe('assertVisibilitySupported', () => {
+  it('allows anything while ACLs are available', () => {
+    expect(() => assertVisibilitySupported(true, 'private', 'public', 'put')).not.toThrow()
+    expect(() => assertVisibilitySupported(true, 'public', 'private', 'setVisibility')).not.toThrow()
+  })
+
+  it('allows a request that matches the disk visibility, or none at all', () => {
+    expect(() => assertVisibilitySupported(false, 'public', 'public', 'put')).not.toThrow()
+    expect(() => assertVisibilitySupported(false, 'private', 'private', 'put')).not.toThrow()
+    expect(() => assertVisibilitySupported(false, 'public', undefined, 'put')).not.toThrow()
+  })
+
+  it('refuses a per-object visibility an ACL-less endpoint cannot honour', () => {
+    expect(() => assertVisibilitySupported(false, 'public', 'private', 'put')).toThrow(
+      /S3Driver\.put:.*cannot make an object private on a public disk/,
+    )
+    expect(() => assertVisibilitySupported(false, 'private', 'public', 'setVisibility')).toThrow(
+      /S3Driver\.setVisibility:/,
+    )
+  })
+
+  it('names the option that fixes it', () => {
+    expect(() => assertVisibilitySupported(false, 'public', 'private', 'put')).toThrow(/"visibility" option/)
+  })
+})

--- a/packages/server/tests/storage/storage.test.ts
+++ b/packages/server/tests/storage/storage.test.ts
@@ -253,6 +253,41 @@ describe('LocalDriver', () => {
       expect(await driver.exists('dir/subdir/file2.txt')).toBe(false)
     })
   })
+
+  // Visibility on a local disk is a property of the disk, not of one file:
+  // what makes a file reachable is the disk root and whatever serves it.
+  // The driver therefore reports the configured value and refuses the other
+  // one, instead of accepting a request it cannot carry out.
+  describe('visibility', () => {
+    it('reports the disk visibility', async () => {
+      await driver.put('test.txt', 'content')
+      expect(await driver.getVisibility('test.txt')).toBe('private')
+
+      const publicDriver = new LocalDriver({ root: tmpDir, visibility: 'public' })
+      expect(await publicDriver.getVisibility('test.txt')).toBe('public')
+    })
+
+    it('accepts a request that matches the disk', async () => {
+      await driver.put('test.txt', 'content', { visibility: 'private' })
+      await driver.setVisibility('test.txt', 'private')
+      expect(await driver.getVisibility('test.txt')).toBe('private')
+    })
+
+    it('refuses a visibility it cannot carry out, on put and on setVisibility', async () => {
+      await expect(driver.put('a.txt', 'content', { visibility: 'public' })).rejects.toThrow(
+        /no per-object visibility/,
+      )
+      expect(await driver.exists('a.txt')).toBe(false)
+
+      await driver.put('b.txt', 'content')
+      await expect(driver.setVisibility('b.txt', 'public')).rejects.toThrow(/no per-object visibility/)
+    })
+
+    it('does not report a visibility for a file that is not there', async () => {
+      await expect(driver.getVisibility('missing.txt')).rejects.toThrow('File not found: missing.txt')
+      await expect(driver.setVisibility('missing.txt', 'private')).rejects.toThrow('File not found: missing.txt')
+    })
+  })
 })
 
 describe('MemoryDriver', () => {

--- a/packages/server/tests/storage/storage.test.ts
+++ b/packages/server/tests/storage/storage.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -8,6 +8,7 @@ import {
   StorageManager,
   createStorageManager,
 } from '../../src/storage'
+import { resetWarnOnce } from '../../src/support/warn-once'
 
 describe('LocalDriver', () => {
   let driver: LocalDriver
@@ -254,11 +255,15 @@ describe('LocalDriver', () => {
     })
   })
 
-  // Visibility on a local disk is a property of the disk, not of one file:
-  // what makes a file reachable is the disk root and whatever serves it.
-  // The driver therefore reports the configured value and refuses the other
-  // one, instead of accepting a request it cannot carry out.
+  // Visibility on a local disk is a property of the disk: what makes a file
+  // reachable is the disk root and whatever serves it. The driver has always
+  // accepted per-object requests and done nothing, so it now says so and
+  // keeps the old behaviour until the next major.
   describe('visibility', () => {
+    beforeEach(() => {
+      resetWarnOnce()
+    })
+
     it('reports the disk visibility', async () => {
       await driver.put('test.txt', 'content')
       expect(await driver.getVisibility('test.txt')).toBe('private')
@@ -267,25 +272,39 @@ describe('LocalDriver', () => {
       expect(await publicDriver.getVisibility('test.txt')).toBe('public')
     })
 
-    it('accepts a request that matches the disk', async () => {
+    it('is silent when the request matches the disk', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       await driver.put('test.txt', 'content', { visibility: 'private' })
       await driver.setVisibility('test.txt', 'private')
       expect(await driver.getVisibility('test.txt')).toBe('private')
+      expect(warn).not.toHaveBeenCalled()
+      warn.mockRestore()
     })
 
-    it('refuses a visibility it cannot carry out, on put and on setVisibility', async () => {
-      await expect(driver.put('a.txt', 'content', { visibility: 'public' })).rejects.toThrow(
-        /no per-object visibility/,
-      )
-      expect(await driver.exists('a.txt')).toBe(false)
+    it('warns, once, when asked for a visibility it cannot carry out', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-      await driver.put('b.txt', 'content')
-      await expect(driver.setVisibility('b.txt', 'public')).rejects.toThrow(/no per-object visibility/)
+      await driver.put('a.txt', 'content', { visibility: 'public' })
+      await driver.put('b.txt', 'content', { visibility: 'public' })
+
+      // The file is still written: the warning announces a future error, it
+      // does not introduce one.
+      expect(await driver.exists('a.txt')).toBe(true)
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(warn.mock.calls[0]?.[0]).toMatch(/no per-object visibility/)
+      expect(warn.mock.calls[0]?.[0]).toMatch(/next major/)
+      warn.mockRestore()
     })
 
-    it('does not report a visibility for a file that is not there', async () => {
-      await expect(driver.getVisibility('missing.txt')).rejects.toThrow('File not found: missing.txt')
-      await expect(driver.setVisibility('missing.txt', 'private')).rejects.toThrow('File not found: missing.txt')
+    it('warns when a visibility call names a file that is not there', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      expect(await driver.getVisibility('missing.txt')).toBe('private')
+      await driver.setVisibility('missing.txt', 'private')
+
+      expect(warn).toHaveBeenCalledTimes(2)
+      expect(warn.mock.calls.every((call) => /does not exist/.test(String(call[0])))).toBe(true)
+      warn.mockRestore()
     })
   })
 })

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -374,7 +374,11 @@ async function assertFeatureScaffolds(appDir: string): Promise<void> {
   assert(storageProvider.includes("from '@guren/core'"), 'Storage blueprint must import from @guren/core.')
   assert(storageProvider.includes('createStorageManager'), 'Storage blueprint must create a storage manager.')
   assert(storageProvider.includes("this.container.instance('storage'"), 'Storage blueprint must bind storage into the container.')
-  assert(storageProvider.includes("public: { driver: 'local', root: './storage/app/public' }"), 'Storage blueprint must expose a public disk.')
+  assert(
+    storageProvider.includes("public: { driver: 'local', root: './storage/app/public', visibility: 'public' }"),
+    "Storage blueprint must expose a public disk that declares itself public — a local disk has no per-object visibility, so an undeclared 'public' disk reports 'private' and refuses put({ visibility: 'public' }).",
+  )
+  assert(storageProvider.includes('STORAGE_DISK'), 'Storage blueprint must select its disk from STORAGE_DISK.')
 
   const broadcastProvider = await readFile(join(appDir, 'app/Providers/BroadcastProvider.ts'), 'utf8')
   assert(broadcastProvider.includes("from '@guren/core'"), 'Broadcasting blueprint must import from @guren/core.')


### PR DESCRIPTION
## Summary

The sibling PR RFC 0009 §2.4 called for, now that the R2 driver has landed (#425).

**`S3DriverOptions.acl`** (default `true` — AWS behaviour unchanged). `S3Driver` sent `x-amz-acl` on every `PutObject` and reached for `PutObjectAcl` / `GetObjectAcl` for visibility. That is correct for AWS S3 and wrong for several S3-compatible endpoints: R2's S3 API reference lists both the header and the ACL operations as unsupported (access there is decided per bucket), and MinIO deployments vary. Since `docs/*/guides/storage.md` has recommended `driver: 's3'` against R2 for a while, this affected a documented path.

With `acl: false` visibility becomes a property of the disk:

- `put()` omits the `ACL` field entirely — not an explicit `ACL: undefined`, which some implementations reject rather than ignore
- `getVisibility()` reports the configured `visibility`
- `put({ visibility })` / `setVisibility()` **throw** when asked for the other value, rather than dropping it silently — the same fail-closed rule `R2Driver` applies, for the same reason: a `setVisibility(path, 'private')` that does nothing on a public bucket is a leak that looks like success

**`STORAGE_DISK` in the scaffold.** `guren add storage` now emits `default: process.env.STORAGE_DISK ?? 'local'`, so an app declares its disks once and picks one per environment (`STORAGE_DISK=local` in dev, `s3` in production). Disks resolve lazily, so an unused disk is never constructed and its credentials are never read. Both storage guides document the pattern.

## On the tests

The ACL decision lives in `s3-acl.ts` rather than inside the driver so it can be tested at all: `@aws-sdk/client-s3` is an optional peer and is **not installed** in this repo, and stubbing it would only assert that a stub was called (the lesson from the mocked-ORM-driver episode). What these tests check is the part that was actually wrong — which fields reach the command. Mutation-checked: making `putAclFields` unconditional turns 2 tests red.

End-to-end coverage against a live S3-compatible server is still absent for this driver and is tracked separately; measuring R2's real response to `x-amz-acl` is RFC 0009 §5 step 0.

## Test plan

- [x] `bun run build`, root `bun run typecheck`, `bun run test:bun` (3709 tests), `bun run test:examples`
- [x] `audit:core-first`, `audit:docs`, `audit:starter-template`
- [x] `scripts/smoke/fresh-app.ts` — the scaffold smoke asserts the generated `StorageProvider` literally, and passes with the `STORAGE_DISK` default
- [ ] Not verified here (needs an account): whether R2 ignores or rejects `x-amz-acl` today, which decides how urgent `acl: false` is for existing users

Refs: RFC 0009 §2.4, #425