### PR TITLE
fix(plugin-cloudflare): stub unused database clients in the bundle

### DIFF
--- a/.changeset/workers-sql-client-stubs.md
+++ b/.changeset/workers-sql-client-stubs.md
@@ -1,0 +1,34 @@
+---
+"@guren/core": patch
+"@guren/plugin-cloudflare": patch
+---
+
+Stub the unused database clients in the Cloudflare worker bundle
+
+A scaffolded app switched to D1 could not be deployed. `wrangler deploy`
+failed with `Could not resolve "postgres"` — naming a database its author had
+deliberately not chosen — and then `mysql2/promise` and
+`@aws-sdk/client-rds-data` behind it.
+
+`@guren/orm` names each dialect's client in a *literal* dynamic import, and a
+bundler follows those whether or not the branch can be taken. On Workers none
+of them can be: D1 is the only database there is. `cloudflare:build` now
+writes a stub for each and aliases it, the same way it already handles
+`bun:sqlite` and the Vite dev server. Apps that worked around this by
+installing `postgres` and `mysql2` they never used can drop them.
+
+The clients live in their own `SQL_CLIENT_MODULES` list rather than the
+existing dev-only one, because whether they are dead weight is a property of
+the platform: Lambda and Vercel connect to Postgres through them, and
+stubbing them there would break a working deploy. Each platform's message
+table is now keyed on the modules it actually stubs, so a Workers-only entry
+cannot silently demand a message from a plugin that never renders it.
+
+Nothing had caught this: no gate ran wrangler over an app that imports the
+ORM, and the one Workers app in this repository carries a leftover `postgres`
+dependency from before it moved to D1, which masked the failure. An opt-in
+`GUREN_TEST_WRANGLER=1` test now bundles such an app with no client
+installed. It installs the ORM from a tarball rather than a local path,
+because a linked install resolves out into this repository's own
+`node_modules` — which is how the first version of the test passed with no
+stubs at all.

--- a/packages/core/src/internal/deploy-build.test.ts
+++ b/packages/core/src/internal/deploy-build.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import {
   assertOutputDirOutsideRoot,
   DEV_ONLY_MODULES,
+  renderDevOnlyStub,
   importSpecifier,
   MCP_SDK_SUBPATH_PREFIX,
   readManifest,
@@ -320,5 +321,48 @@ describe('the module graph this list describes', () => {
     for (const name of exportNames) {
       expect(source).toContain(name)
     }
+  })
+})
+
+describe('renderDevOnlyStub', () => {
+  // The message lands in the file twice, and only the thrown copy is safe on
+  // its own: `JSON.stringify` escapes it, while the leading comment would end
+  // at the first line terminator and run whatever followed as code. Callers
+  // pass literals today — the escape exists because this is where the file is
+  // constructed, not because the strings are untrusted.
+  const LINE_SEPARATOR = String.fromCharCode(0x2028)
+  const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029)
+
+  const terminators: Array<[string, string]> = [
+    ['line feed', '\n'],
+    ['carriage return', '\r'],
+    ['CRLF', '\r\n'],
+    ['line separator', LINE_SEPARATOR],
+    ['paragraph separator', PARAGRAPH_SEPARATOR],
+  ]
+
+  for (const [name, terminator] of terminators) {
+    test(`keeps a ${name} inside the leading comment`, () => {
+      const stub = renderDevOnlyStub(
+        { specifier: 'x', kind: 'sqlite', exportNames: [] },
+        `unavailable${terminator}globalThis.INJECTED = true //`,
+      )
+
+      const [comment] = stub.split(new RegExp(`\r\n|[\r\n${LINE_SEPARATOR}${PARAGRAPH_SEPARATOR}]`))
+      expect(comment).toBe('// unavailable globalThis.INJECTED = true //')
+    })
+  }
+
+  test('still names every export the importer destructures', () => {
+    const stub = renderDevOnlyStub(
+      { specifier: 'x', kind: 'sqlite', exportNames: ['Database', 'open'] },
+      'nope',
+    )
+
+    expect(stub).toContain('export function Database()')
+    expect(stub).toContain('export function open()')
+    // Callable, because `import pgClient from "postgres"` calls its default.
+    expect(stub).toContain('function unavailable()')
+    expect(stub).toContain('export default Object.assign(unavailable, { Database, open })')
   })
 })

--- a/packages/core/src/internal/deploy-build.test.ts
+++ b/packages/core/src/internal/deploy-build.test.ts
@@ -353,6 +353,24 @@ describe('renderDevOnlyStub', () => {
     })
   }
 
+  // JSON and JavaScript disagree here: JSON leaves U+2028/U+2029 raw, and
+  // JavaScript below ES2019 reads them as line terminators — so a message
+  // carrying one would end the `throw` statement it was embedded in.
+  for (const [name, separator] of [
+    ['line separator', LINE_SEPARATOR],
+    ['paragraph separator', PARAGRAPH_SEPARATOR],
+  ] as const) {
+    test(`escapes a ${name} in the thrown message`, () => {
+      const stub = renderDevOnlyStub(
+        { specifier: 'x', kind: 'sqlite', exportNames: [] },
+        `unavailable${separator}globalThis.INJECTED = true //`,
+      )
+
+      expect(stub).not.toContain(separator)
+      expect(stub).toContain(separator === LINE_SEPARATOR ? '\\u2028' : '\\u2029')
+    })
+  }
+
   test('still names every export the importer destructures', () => {
     const stub = renderDevOnlyStub(
       { specifier: 'x', kind: 'sqlite', exportNames: ['Database', 'open'] },

--- a/packages/core/src/internal/deploy-build.ts
+++ b/packages/core/src/internal/deploy-build.ts
@@ -307,7 +307,7 @@ export function stageStaticAssets(publicDir: string, assetsOut: string): void {
 }
 
 /** What a dev-only module is needed for, so a plugin can word its own message. */
-export type DevOnlyModuleKind = 'sqlite' | 'vite' | 'mcp'
+export type DevOnlyModuleKind = 'sqlite' | 'vite' | 'mcp' | 'sql-driver'
 
 export interface DevOnlyModule {
   readonly specifier: string
@@ -337,6 +337,10 @@ export interface DevOnlyModule {
  * - `mcp` — the opt-in MCP endpoint's lazy imports, which drag the CLI
  *   generators (and Babel) plus the MCP SDK in behind them.
  *
+ * SQL client libraries are deliberately *not* here: they are dev-only on
+ * Workers, where D1 is the only database, and load-bearing on Lambda and
+ * Vercel, which connect to Postgres. See `SQL_CLIENT_MODULES`.
+ *
  * `as const` so a consumer can key an exhaustive table on the specifiers and
  * have a new entry here surface as a compile error there.
  */
@@ -356,6 +360,45 @@ export const DEV_ONLY_MODULES = [
   },
 ] as const satisfies readonly DevOnlyModule[]
 
+/**
+ * The database client libraries `@guren/orm`'s Postgres, MySQL and Aurora
+ * Data API factories reach for.
+ *
+ * They sit apart from `DEV_ONLY_MODULES` because whether they are dead weight
+ * depends on the platform: on Workers, D1 is the only database there is, so
+ * every one of these is unreachable; on Lambda and Vercel the app connects to
+ * Postgres through them and stubbing them would break a working deploy.
+ *
+ * A platform where they are unreachable has to stub them rather than ignore
+ * them. `@guren/orm` names them in *literal* dynamic imports, which a bundler
+ * follows whether or not the branch can be taken — so a D1 app failed to
+ * bundle on `Could not resolve "postgres"`, naming a database its author had
+ * deliberately not chosen. Both the client and the drizzle entry point that
+ * imports it need stubbing: aliasing only the client leaves drizzle's own
+ * `import pgClient from "postgres"` to resolve.
+ *
+ * Export names are read off drizzle-orm's driver and session modules, which
+ * is what a bundler checks a stub against.
+ */
+export const SQL_CLIENT_MODULES = [
+  { specifier: 'postgres', kind: 'sql-driver', exportNames: [] },
+  { specifier: 'mysql2', kind: 'sql-driver', exportNames: [] },
+  { specifier: 'mysql2/promise', kind: 'sql-driver', exportNames: ['createPool'] },
+  {
+    specifier: '@aws-sdk/client-rds-data',
+    kind: 'sql-driver',
+    exportNames: [
+      'RDSDataClient',
+      'BeginTransactionCommand',
+      'CommitTransactionCommand',
+      'ExecuteStatementCommand',
+      'RollbackTransactionCommand',
+    ],
+  },
+] as const satisfies readonly DevOnlyModule[]
+
+export type SqlClientSpecifier = (typeof SQL_CLIENT_MODULES)[number]['specifier']
+
 export type DevOnlySpecifier = (typeof DEV_ONLY_MODULES)[number]['specifier']
 
 /**
@@ -370,14 +413,19 @@ export type DevOnlySpecifier = (typeof DEV_ONLY_MODULES)[number]['specifier']
  * @param message Platform-specific explanation, including the replacement API.
  */
 export function renderDevOnlyStub(module: DevOnlyModule, message: string): string {
-  if (module.exportNames.length === 0) {
-    return `// ${message}\nexport {}\n`
-  }
-
+  const error = `throw new Error(${JSON.stringify(message)})`
   const throwing = module.exportNames
-    .map((name) => `export function ${name}() { throw new Error(${JSON.stringify(message)}) }`)
+    .map((name) => `export function ${name}() { ${error} }`)
     .join('\n')
-  return `${throwing}\nexport default { ${module.exportNames.join(', ')} }\n`
+
+  // The default export is a *function*, not an object of the named ones:
+  // `drizzle-orm/postgres-js` does `import pgClient from "postgres"` and calls
+  // it, and a module with no default at all fails the bundle outright with
+  // "no matching export". Attaching the named exports keeps the previous
+  // object-shaped access working.
+  const named = module.exportNames.length > 0 ? `, { ${module.exportNames.join(', ')} }` : ''
+  const fallback = `function unavailable() { ${error} }`
+  return `// ${message}\n${throwing}\n${fallback}\nexport default Object.assign(unavailable${named})\n`
 }
 
 /**

--- a/packages/core/src/internal/deploy-build.ts
+++ b/packages/core/src/internal/deploy-build.ts
@@ -413,6 +413,12 @@ export type DevOnlySpecifier = (typeof DEV_ONLY_MODULES)[number]['specifier']
  * @param message Platform-specific explanation, including the replacement API.
  */
 export function renderDevOnlyStub(module: DevOnlyModule, message: string): string {
+  // The message reaches the file twice, and only one of those is safe on its
+  // own: `JSON.stringify` handles the thrown string, but the leading comment
+  // would end at the first line terminator and run whatever followed as code.
+  // Callers pass literals today; the escape is here because this is where the
+  // file is constructed, not where the strings happen to come from.
+  const comment = message.replace(/[\r\n\u2028\u2029]+/g, ' ')
   const error = `throw new Error(${JSON.stringify(message)})`
   const throwing = module.exportNames
     .map((name) => `export function ${name}() { ${error} }`)
@@ -425,7 +431,7 @@ export function renderDevOnlyStub(module: DevOnlyModule, message: string): strin
   // object-shaped access working.
   const named = module.exportNames.length > 0 ? `, { ${module.exportNames.join(', ')} }` : ''
   const fallback = `function unavailable() { ${error} }`
-  return `// ${message}\n${throwing}\n${fallback}\nexport default Object.assign(unavailable${named})\n`
+  return `// ${comment}\n${throwing}\n${fallback}\nexport default Object.assign(unavailable${named})\n`
 }
 
 /**

--- a/packages/core/src/internal/deploy-build.ts
+++ b/packages/core/src/internal/deploy-build.ts
@@ -412,14 +412,26 @@ export type DevOnlySpecifier = (typeof DEV_ONLY_MODULES)[number]['specifier']
  *
  * @param message Platform-specific explanation, including the replacement API.
  */
+/**
+ * A JavaScript string literal for `value`.
+ *
+ * `JSON.stringify` alone is not one: JSON and JavaScript disagree about
+ * U+2028 and U+2029, which JSON leaves raw while JavaScript reads them as
+ * line terminators — so a message containing either ends the statement it was
+ * embedded in on any target below ES2019.
+ */
+function toJsStringLiteral(value: string): string {
+  return JSON.stringify(value).replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029')
+}
+
 export function renderDevOnlyStub(module: DevOnlyModule, message: string): string {
-  // The message reaches the file twice, and only one of those is safe on its
-  // own: `JSON.stringify` handles the thrown string, but the leading comment
-  // would end at the first line terminator and run whatever followed as code.
-  // Callers pass literals today; the escape is here because this is where the
-  // file is constructed, not where the strings happen to come from.
+  // The message reaches the file twice and needs different escaping each
+  // time: as a string literal in the thrown error, and as text in a comment
+  // that any line terminator would end, running whatever followed as code.
+  // Callers pass literals today; the escaping is here because this is where
+  // the file is constructed, not where the strings happen to come from.
   const comment = message.replace(/[\r\n\u2028\u2029]+/g, ' ')
-  const error = `throw new Error(${JSON.stringify(message)})`
+  const error = `throw new Error(${toJsStringLiteral(message)})`
   const throwing = module.exportNames
     .map((name) => `export function ${name}() { ${error} }`)
     .join('\n')

--- a/packages/plugin-cloudflare/src/build.ts
+++ b/packages/plugin-cloudflare/src/build.ts
@@ -3,6 +3,7 @@ import { relative, resolve, sep } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import {
   DEV_ONLY_MODULES,
+  SQL_CLIENT_MODULES,
   importSpecifier,
   renderDevOnlyStub,
   assertOutputDirOutsideRoot,
@@ -14,6 +15,7 @@ import {
   type ClientAssetEnv,
   type DevOnlyModule,
   type DevOnlySpecifier,
+  type SqlClientSpecifier,
   type PathLike,
 } from '@guren/core/internal/deploy-build'
 
@@ -96,10 +98,20 @@ const MCP_UNAVAILABLE = 'The MCP endpoint is unavailable on Cloudflare Workers �
  * Why the dev-only modules in `DEV_ONLY_MODULES` cannot run here, worded for
  * this platform: each names the Workers-appropriate replacement.
  */
-const UNAVAILABLE_ON_WORKERS: Record<DevOnlyModule['kind'], string> = {
+/**
+ * Both lists: on Workers the SQL clients are as unreachable as the dev-only
+ * modules, because D1 is the only database the platform has.
+ */
+const STUBBED_MODULES = [...DEV_ONLY_MODULES, ...SQL_CLIENT_MODULES]
+
+const UNAVAILABLE_ON_WORKERS: Record<(typeof STUBBED_MODULES)[number]['kind'], string> = {
   sqlite: 'bun:sqlite is unavailable on Cloudflare Workers — use createD1Database().',
   vite: 'The Vite dev server is unavailable on Cloudflare Workers — assets are served by Workers Static Assets.',
   mcp: MCP_UNAVAILABLE,
+  'sql-driver':
+    'This database client is unavailable on Cloudflare Workers — use createD1Database(). '
+    + 'It is stubbed because @guren/orm names it in a dynamic import that bundlers follow '
+    + 'even when the branch cannot be taken.',
 }
 
 /**
@@ -113,16 +125,20 @@ const UNAVAILABLE_ON_WORKERS: Record<DevOnlyModule['kind'], string> = {
  * compile error here until it gets a filename — the drift a derived name would
  * have prevented, caught by the type system instead.
  */
-const STUB_FILES: Record<DevOnlySpecifier, string> = {
+const STUB_FILES: Record<DevOnlySpecifier | SqlClientSpecifier, string> = {
   'bun:sqlite': 'stub-bun-sqlite.js',
   vite: 'stub-vite.js',
   '@guren/cli': 'stub-guren-cli.js',
   '@modelcontextprotocol/sdk/server/mcp.js': 'stub-mcp-server.js',
   '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js': 'stub-mcp-transport.js',
+  postgres: 'stub-postgres.js',
+  mysql2: 'stub-mysql2.js',
+  'mysql2/promise': 'stub-mysql2-promise.js',
+  '@aws-sdk/client-rds-data': 'stub-rds-data.js',
 }
 
 function writeDevOnlyStubs(out: string): void {
-  for (const module of DEV_ONLY_MODULES) {
+  for (const module of STUBBED_MODULES) {
     writeFileSync(
       resolve(out, STUB_FILES[module.specifier]),
       renderDevOnlyStub(module, UNAVAILABLE_ON_WORKERS[module.kind]),
@@ -138,7 +154,7 @@ function writeDevOnlyStubs(out: string): void {
  */
 function devOnlyAliases(outRelative: string): Record<string, string> {
   return Object.fromEntries(
-    DEV_ONLY_MODULES.map((module) => [
+    STUBBED_MODULES.map((module) => [
       module.specifier,
       `./${outRelative}/${STUB_FILES[module.specifier]}`,
     ]),

--- a/packages/plugin-cloudflare/src/wrangler-bundle.test.ts
+++ b/packages/plugin-cloudflare/src/wrangler-bundle.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
+import { existsSync, mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DEV_ONLY_MODULES, SQL_CLIENT_MODULES } from '@guren/core/internal/deploy-build'
+
+// Opt-in end-to-end contract test: proves wrangler can actually bundle a
+// worker that imports `@guren/orm`, with only the stubs `cloudflare:build`
+// scaffolds and none of the database clients installed.
+//
+// This is the gap that let a real defect ship. `@guren/orm` names every
+// dialect's client in a *literal* dynamic import, and a bundler follows those
+// whether or not the branch can be taken — so a D1 app failed on
+// `Could not resolve "postgres"`, naming a database its author had not
+// chosen. Nothing caught it: no gate ran wrangler over a scaffolded app, and
+// the one Workers app in this repo carries a leftover `postgres` dependency
+// from before it moved to D1, which masked the failure.
+//
+// Requires network on first run (bunx downloads wrangler + workerd), so it is
+// gated behind GUREN_TEST_WRANGLER=1 and skipped in CI, like
+// wrangler-migrations.test.ts.
+const enabled = process.env.GUREN_TEST_WRANGLER === '1'
+
+/** Installed directories that would let wrangler resolve a client for real. */
+const DRIVER_PACKAGES = ['postgres', 'mysql2', '@aws-sdk']
+
+function wrangler(cwd: string, args: string[]): { exitCode: number; output: string } {
+  const result = Bun.spawnSync({ cmd: ['bunx', 'wrangler', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
+  return { exitCode: result.exitCode, output: `${result.stdout.toString()}${result.stderr.toString()}` }
+}
+
+describe.skipIf(!enabled)('wrangler bundles a worker importing @guren/orm', () => {
+  let root: string
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'guren-wrangler-bundle-'))
+    mkdirSync(join(root, 'stubs'), { recursive: true })
+
+    // Only @guren/orm — no `postgres`, no `mysql2`, no AWS Data API client,
+    // which is what a D1 app actually installs.
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'bundle-probe', type: 'module', private: true }),
+    )
+    // Installed from a tarball, not `file:` — a local path install links the
+    // package, and resolution then walks out of the probe into this
+    // repository's own `node_modules`, where the database clients *are*
+    // installed. That made an earlier version of this test pass with no stubs
+    // at all: it was measuring the monorepo, not the app.
+    const ormDir = new URL('../../orm', import.meta.url).pathname
+    const packed = Bun.spawnSync({
+      cmd: ['bun', 'pm', 'pack', '--destination', root],
+      cwd: ormDir,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    if (packed.exitCode !== 0) {
+      throw new Error(`bundle probe could not pack @guren/orm:\n${packed.stderr.toString()}`)
+    }
+    const tarball = readdirSync(root).find((file) => file.endsWith('.tgz'))
+    if (!tarball) {
+      throw new Error(`bundle probe found no tarball in ${root}`)
+    }
+    const install = Bun.spawnSync({
+      cmd: ['bun', 'add', join(root, tarball)],
+      cwd: root,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    if (install.exitCode !== 0) {
+      // Without this the bundle fails on `@guren/orm` itself and the test
+      // reports the very symptom it is meant to detect, for the wrong reason.
+      throw new Error(`bundle probe setup failed to install @guren/orm:\n${install.stderr.toString()}`)
+    }
+
+    // A real D1 app installs no database client, so neither does the probe.
+    // Asserted rather than assumed: if a future installer pulls the ORM's
+    // optional peers in, wrangler would resolve them for real and this test
+    // would pass no matter what the stubs say.
+    for (const client of DRIVER_PACKAGES) {
+      rmSync(join(root, 'node_modules', client), { recursive: true, force: true })
+      if (existsSync(join(root, 'node_modules', client))) {
+        throw new Error(`bundle probe still has ${client} installed; the test would pass vacuously`)
+      }
+    }
+
+    writeFileSync(
+      join(root, 'worker.ts'),
+      `import { createD1Database } from '@guren/orm'\n`
+        + `export default {\n`
+        + `  async fetch(_r: Request, env: { DB: unknown }): Promise<Response> {\n`
+        + `    return new Response(typeof createD1Database({ binding: () => env.DB }).getDatabase)\n`
+        + `  },\n`
+        + `}\n`,
+    )
+
+    // The stubs and aliases `cloudflare:build` scaffolds, written directly so
+    // the test pins the contract rather than the command that emits it.
+    const stubbed = [...DEV_ONLY_MODULES, ...SQL_CLIENT_MODULES]
+    const alias: Record<string, string> = {}
+    for (const module of stubbed) {
+      const file = `${module.specifier.replace(/[^a-zA-Z0-9]+/g, '-')}.js`
+      const throwing = module.exportNames
+        .map((name) => `export function ${name}() { throw new Error('stubbed') }`)
+        .join('\n')
+      const named = module.exportNames.length > 0 ? `, { ${module.exportNames.join(', ')} }` : ''
+      writeFileSync(
+        join(root, 'stubs', file),
+        `${throwing}\nfunction unavailable() { throw new Error('stubbed') }\nexport default Object.assign(unavailable${named})\n`,
+      )
+      alias[module.specifier] = `./stubs/${file}`
+    }
+
+    writeFileSync(
+      join(root, 'wrangler.jsonc'),
+      JSON.stringify({
+        name: 'bundle-probe',
+        main: 'worker.ts',
+        compatibility_date: '2026-07-01',
+        compatibility_flags: ['nodejs_compat'],
+        alias,
+      }),
+    )
+  })
+
+  afterAll(() => {
+    if (root) rmSync(root, { recursive: true, force: true })
+  })
+
+  test(
+    'resolves every module the ORM reaches for, with no database client installed',
+    () => {
+      const result = wrangler(root, ['deploy', '--dry-run', '--outdir', join(root, 'out')])
+
+      // Name what is missing rather than only that something is: the failure
+      // mode this guards against reports a package the app never chose.
+      expect(result.output).not.toMatch(/Could not resolve/)
+      expect(result.exitCode).toBe(0)
+    },
+    180_000,
+  )
+})

--- a/packages/plugin-lambda/src/build.ts
+++ b/packages/plugin-lambda/src/build.ts
@@ -47,7 +47,12 @@ const MCP_UNAVAILABLE = 'The MCP endpoint is unavailable on AWS Lambda — it ge
  * Why the dev-only modules in `DEV_ONLY_MODULES` cannot run here, worded for
  * this platform: each names the Lambda-appropriate replacement.
  */
-const UNAVAILABLE_ON_LAMBDA: Record<DevOnlyModule['kind'], string> = {
+/**
+ * Keyed on the kinds this platform actually stubs, not on every kind that
+ * exists: Lambda connects to Postgres and the Data API, so the SQL clients
+ * are load-bearing here and never reach `renderDevOnlyStub`.
+ */
+const UNAVAILABLE_ON_LAMBDA: Record<(typeof DEV_ONLY_MODULES)[number]['kind'], string> = {
   sqlite: 'bun:sqlite is unavailable on AWS Lambda — use createAwsDataApiDatabase() or createPostgresDatabase().',
   vite: 'The Vite dev server is unavailable on AWS Lambda — serve assets from S3/CloudFront.',
   mcp: MCP_UNAVAILABLE,


### PR DESCRIPTION
Found by post-release verification of v2.7.0. Not a regression from that release — this has been broken for as long as the Cloudflare plugin has existed.

## The bug

A scaffolded app switched to D1 exactly as the [Cloudflare guide](https://guren.dev/docs/guides/cloudflare) instructs **cannot be deployed**:

```
✘ [ERROR] Could not resolve "postgres"
    node_modules/@guren/orm/dist/index.js:3099:13
✘ [ERROR] Could not resolve "mysql2/promise"
✘ [ERROR] Could not resolve "@aws-sdk/client-rds-data"
```

The first error names a database the author deliberately did not choose, which makes it close to undiagnosable.

`@guren/orm` names each dialect's client in a **literal** dynamic import, and a bundler follows those whether or not the branch can be taken. On Workers none of them can be: D1 is the only database there is. (This is the exact inverse of the `aws4fetch` bug fixed in #425 — there a *variable* specifier meant the bundler could **not** follow an import that was needed.)

## Why nothing caught it

Two independent reasons, both worth fixing:

1. **No gate runs wrangler over an app that imports the ORM.** The starter smokes stop at `typecheck`; the packed smoke checks tarball contents. Nothing bundles.
2. **`web/` masks it.** The one Workers app in this repo carries `postgres: ^3.4.3`, added in the very first web-workspace commit (`425b708`, 2025-11-06) — before it moved to D1. Not a deliberate workaround; a leftover that happens to make the failure invisible here.

## The fix

`cloudflare:build` writes a stub for each client and aliases it, the same mechanism already used for `bun:sqlite` and the Vite dev server.

The clients live in a new `SQL_CLIENT_MODULES` list rather than joining `DEV_ONLY_MODULES`, because **whether they are dead weight is a property of the platform**: Lambda and Vercel connect to Postgres through them, and stubbing them there would break a working deploy. Each platform's message table is now keyed on the modules it actually stubs, so a Workers-only kind cannot demand a message from a plugin that never renders one.

`renderDevOnlyStub` also had to emit a **callable default export** — drizzle does `import pgClient from "postgres"` and calls it, and a module with no default fails the bundle outright with "no matching export".

## The gate

`wrangler-bundle.test.ts` (opt-in, `GUREN_TEST_WRANGLER=1`, same gating as the existing migrations test) bundles a worker that imports `@guren/orm` with **no database client installed**.

Getting this to actually test something took two corrections worth recording:

- It installs the ORM **from a tarball**, not a local path. A linked install resolves out of the probe into this repository's own `node_modules`, where the clients *are* present — which is how the first version passed with no stubs at all.
- It **asserts** the clients are absent rather than assuming, so a future installer that pulls the ORM's optional peers in makes the test fail loudly instead of passing vacuously.

Mutation-checked: emptying `SQL_CLIENT_MODULES` turns it red with the six original errors.

## Verification

Beyond the unit gate, end to end on a real app: `create-guren-app` → switch to D1 per the guide → `guren cloudflare:build` → `wrangler deploy --dry-run` bundles clean (3.5 MB / 638 KB gzip) with **no database client installed**, and the resulting worker boots in workerd and routes a request.

`build`, root `typecheck`, `test:bun` (4525), `audit:{core-first,contracts,feature-runtime,starter-template,docs,plugin-compat,template-deps}` all green.

## Follow-ups, not in this PR

- **`web/`'s leftover `postgres` dependency** can be dropped now; it is worth doing separately so its removal is the thing under test.
- **Lambda and Vercel have the same shape of problem for the dialects an app does not use** — a Postgres app there still drags `mysql2` and the Data API client into the graph. Fixing it needs the build to know which dialect the app picked, which is a bigger change than this one.