### PR TITLE
chore(web): drop the leftover postgres dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "examples/api": {
       "name": "@guren/example-api",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -68,7 +68,7 @@
     },
     "packages/cli": {
       "name": "@guren/cli",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "bin": {
         "guren": "./dist/bin.js",
       },
@@ -110,7 +110,7 @@
     },
     "packages/create-app": {
       "name": "create-guren-app",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "bin": {
         "create-guren-app": "./dist/cli.js",
       },
@@ -181,7 +181,7 @@
     },
     "packages/plugin-cloudflare": {
       "name": "@guren/plugin-cloudflare",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "dependencies": {
         "@guren/core": "^1.5.2",
         "citty": "^0.1.6",
@@ -231,7 +231,7 @@
     },
     "packages/server": {
       "name": "@guren/server",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "dependencies": {
         "@guren/orm": "^2.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -274,7 +274,7 @@
         "vitest": "^3.2.6",
       },
       "peerDependencies": {
-        "@guren/server": ">=1.0.0",
+        "@guren/server": ">=2.2.0",
         "@inertiajs/react": "^3.6.1",
         "@testing-library/react": "^14.0.0 || ^15.0.0 || ^16.0.0",
         "hono": "^4.12.29",
@@ -290,7 +290,7 @@
     },
     "web": {
       "name": "web",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -301,7 +301,6 @@
         "@inertiajs/core": "^3.6.1",
         "@inertiajs/react": "^3.6.1",
         "drizzle-orm": "1.0.0-rc.4",
-        "postgres": "^3.4.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "sanitize-html": "^2.17.6",

--- a/web/README.md
+++ b/web/README.md
@@ -5,12 +5,12 @@ Welcome to your new Guren application. This template ships with Inertia server-s
 ## Prerequisites
 
 - [Bun](https://bun.sh/) installed locally.
-- PostgreSQL reachable at `postgres://guren:guren@localhost:54322/guren` (or override `DATABASE_URL` in `.env`). You can use any Postgres instance; Docker is fine as long as the URL matches.
+- No database server. Local development uses SQLite at `SQLITE_DATABASE_PATH` (`./data/guren.db` by default); production runs on Cloudflare D1 through the `DB` binding in `wrangler.jsonc`.
 
 ## Quickstart
 
 1. Install dependencies: `bun install`.
-2. Copy environment: `cp .env.example .env` and adjust `DATABASE_URL` if needed.
+2. Copy environment: `cp .env.example .env` and set `APP_KEY`, which is required to boot.
 3. Generate route and page manifests once so the client picks up links: `bun run codegen`.
 4. Start dev servers (Bun API + Vite dev server with hot reload): `bun run dev`.
 

--- a/web/package.json
+++ b/web/package.json
@@ -30,7 +30,6 @@
     "@inertiajs/core": "^3.6.1",
     "@inertiajs/react": "^3.6.1",
     "drizzle-orm": "1.0.0-rc.4",
-    "postgres": "^3.4.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "sanitize-html": "^2.17.6",

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -25,6 +25,13 @@
     "@guren/cli": "./.cloudflare/stub-guren-cli.js",
     "@modelcontextprotocol/sdk/server/mcp.js": "./.cloudflare/stub-mcp-server.js",
     "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js": "./.cloudflare/stub-mcp-transport.js",
+    // @guren/orm names every dialect's client in a literal dynamic import,
+    // which a bundler follows even though D1 is the only database Workers
+    // has. Without these the deploy fails on a database this app never chose.
+    "postgres": "./.cloudflare/stub-postgres.js",
+    "mysql2": "./.cloudflare/stub-mysql2.js",
+    "mysql2/promise": "./.cloudflare/stub-mysql2-promise.js",
+    "@aws-sdk/client-rds-data": "./.cloudflare/stub-rds-data.js",
     "shiki": "./stubs/shiki.js",
     // Monorepo-only: app code resolves @guren/core through tsconfig paths to
     // source while prebuilt dist files resolve @guren/orm through


### PR DESCRIPTION
## Summary

`web/` (guren.dev) declares `postgres: ^3.4.3` but has run on D1 (Workers) and SQLite (local) since it moved off Postgres. Nothing in it imports the package: `web/config/database.ts` uses `createD1Database`/`createSqliteDatabase`, `drizzle.config.ts` is `dialect: 'sqlite'`, and both migrations are SQLite. The dependency dates from the workspace's first commit (`425b708`, 2025-11-06) — before the move to D1 — and is a leftover.

It was not inert: it is the reason the bug fixed in #428 stayed invisible for months. `@guren/orm` names each dialect's client in a literal dynamic import, which a bundler follows whether or not the branch can be taken, so a Workers app without those clients installed fails to bundle. `web/` carrying `postgres` is why this repo's only Workers app bundled cleanly.

Follow-up to #428, which is what makes the removal safe. Supersedes #430, which GitHub auto-closed when #428's branch was deleted (a closed PR can be neither reopened nor retargeted once its base is gone).

## Scope

`web/` only (`package.json`, `wrangler.jsonc`, `README.md`) plus the root lockfile. No published package changes, so no changeset.

**`web/wrangler.jsonc` needed the four stub aliases added**, which is the non-obvious part of this PR. The alias table lives in the app's committed config, which the build deliberately never overwrites (`wx` flag in `scaffoldWranglerConfig`), so web's predates #428 and listed only the five older entries. Without them the deploy fails once the clients are not installed.

`README.md`'s Postgres prerequisite went with it — `.env.example` already documents SQLite and D1 correctly, leaving the README the last thing pointing newcomers at a Postgres setup.

## Risk Assessment

No runtime behavior change. The stubs replace modules that are only reachable through a dialect branch Workers never takes; D1 is unaffected. Local dev and `preview` do not go through wrangler, so the aliases do not apply there.

Two things a reviewer should know:

**This does not make `web/` a canary for the stubs in this repo.** `packages/orm` devDepends on all three clients and `web/node_modules/@guren/orm` symlinks to it, so the bundler still resolves them through `packages/orm/node_modules/` whatever `web` declares. With the stubs neutralized and this dependency gone, the dry-run is still green — it only turns red once those devDependencies are hidden too. The de-masking holds for apps installing a published `@guren/orm`, which is the case that was broken.

**The lockfile hunk carries seven unrelated workspace version corrections** (`server` 2.6.0 → 2.7.0 and friends). `main`'s `bun.lock` has been stale against `main`'s own `package.json` files since #427, and bun refreshes all of it whenever a dependency change makes it rewrite the file. `bun install` and `bun install --force` produce no such diff on their own, so this cannot be split out without hand-editing generated output into a state bun never emits.

## Validation

Deploy path verified end to end, with a mutation control — the ORM's own client devDependencies moved aside so the workspace resembles a published install:

| ORM clients on disk | Stub aliases | `wrangler deploy --dry-run` |
|---|---|---|
| absent | absent | **exit 1** — `Could not resolve "postgres"` / `"mysql2"` at `packages/orm/dist/index.js:3099` |
| absent | present | exit 0, bundles clean |
| present (repo's real state) | present | exit 0, bundles clean |

Removing the protection makes the check fail, so the deploy is now carried by #428's stubs rather than by the leftover dependency — which is the point of doing this separately. Both green arms re-run after rebasing onto post-merge `main`.

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` — 4466 pass, 0 fail; examples 108/42, web 112

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [ ] I added/updated tests for behavior changes. — no behavior change; the deploy path has no automated gate (see below)
- [x] I updated relevant documentation.

## Follow-ups, not in this PR

- **No gate bundles `web/` with wrangler.** `web-app` in CI stops at build/test; `deploy-web.yml` runs `wrangler deploy` only on push to `main`. A stale alias table would surface as a failed production deploy, not a red check.
- **#428's upgrade warning cannot fire for the apps that need it.** `warnMissingBuildOwnedKeys` reads the config with `JSON.parse` and bails silently on failure, so any `wrangler.jsonc` that actually contains comments — the normal case, and why `web/` got no warning here — is skipped. Being fixed separately.