### PR TITLE
fix(plugin-cloudflare): read wrangler.jsonc as JSONC when checking an existing config

### DIFF
--- a/.changeset/cloudflare-jsonc-upgrade-warning.md
+++ b/.changeset/cloudflare-jsonc-upgrade-warning.md
@@ -1,0 +1,24 @@
+---
+'@guren/plugin-cloudflare': patch
+---
+
+Make the wrangler config upgrade warning reach commented configs, and suggest entries rather than whole keys
+
+`cloudflare:build` never overwrites an existing `wrangler.jsonc`; instead it warns
+about the keys it owns that the config is missing — notably the `alias` entries,
+without which `wrangler deploy` cannot resolve the stubbed modules. Two things
+kept that warning from doing its job.
+
+It read the file with `JSON.parse`, so any config carrying a comment failed to
+parse and the check bailed silently. Comments are the normal case in a `.jsonc`
+file, which meant the warning could not fire for the apps it exists to help: they
+saw nothing at build time and a resolution failure at deploy time instead. The
+config is now read with a JSONC-tolerant parser (comments and trailing commas,
+string-aware so a `//` inside a value survives), and a file that is still
+unparseable afterwards is reported rather than skipped.
+
+The warning also printed `alias` and `define` as complete objects holding only
+the build-owned entries, which reads as something to paste over what the file
+has. Apps keep their own entries under both keys, so following it could drop a
+pinned dependency alias or a second `define`. It now names only the individual
+entries that are missing, and says to add them alongside what is already there.

--- a/packages/plugin-cloudflare/src/build.test.ts
+++ b/packages/plugin-cloudflare/src/build.test.ts
@@ -384,13 +384,28 @@ describe('workers runtime configuration', () => {
     // above — or report `define` as missing when the file has it.
     expect(warning).not.toContain('process.env.NODE_ENV')
     expect(warning).not.toContain('could not parse')
-    // Only the missing entry is suggested. A suggestion carrying the entries
-    // the file already has reads as an object to paste over `alias`, which
-    // would drop the app's own `shiki` stub along with them.
-    expect(warning).not.toContain('shiki')
-    for (const key of kept) {
-      expect(warning).not.toContain(scaffolded.alias[key])
+    // Only the missing entry is suggested, so nothing the file already has —
+    // the app's own `shiki` stub included — is named. A suggestion carrying
+    // those entries reads as an object to paste over `alias`, which would
+    // drop the ones the build does not own.
+    for (const [specifier, target] of Object.entries(alias)) {
+      expect(warning).not.toContain(specifier)
+      expect(warning).not.toContain(target)
     }
+  })
+
+  test('should warn rather than throw when alias is not an object', async () => {
+    scaffoldApp(root)
+    // Malformed rather than outdated. `in` on a string throws, and this
+    // warning runs inside the scaffold's catch block, so the TypeError would
+    // escape as a build failure instead of the guidance the check exists for.
+    writeFileSync(join(root, 'wrangler.jsonc'), '{ "name": "legacy", "alias": "./stubs" }\n')
+
+    const warning = await captureWarnings(async () => {
+      await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
+    })
+
+    expect(warning).toContain('bun:sqlite')
   })
 
   test('should stay silent when a commented config already has every build-owned key', async () => {

--- a/packages/plugin-cloudflare/src/build.test.ts
+++ b/packages/plugin-cloudflare/src/build.test.ts
@@ -8,6 +8,18 @@ function writeJson(path: string, value: unknown): void {
   writeFileSync(path, JSON.stringify(value, null, 2))
 }
 
+async function captureWarnings(run: () => Promise<void>): Promise<string> {
+  const warnings: string[] = []
+  const original = console.warn
+  console.warn = (message: string) => warnings.push(message)
+  try {
+    await run()
+  } finally {
+    console.warn = original
+  }
+  return warnings.join('\n')
+}
+
 function scaffoldApp(root: string, options: { ssr?: boolean; renderExport?: string } = {}): void {
   const { ssr = true, renderExport = 'export const render = () => ({ body: "", head: [] })' } = options
 
@@ -312,20 +324,99 @@ describe('workers runtime configuration', () => {
       main: '.cloudflare/worker.js',
       d1_databases: [{ binding: 'DB', migrations_dir: 'db/migrations' }],
     })
-    const warnings: string[] = []
-    const original = console.warn
-    console.warn = (message: string) => warnings.push(message)
-
-    try {
+    const warning = await captureWarnings(async () => {
       await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
-    } finally {
-      console.warn = original
-    }
+    })
 
-    const warning = warnings.join('\n')
     expect(warning).toContain('alias')
     expect(warning).toContain('process.env.NODE_ENV')
     expect(warning).toContain('.cloudflare/d1-migrations')
+  })
+
+  test('should warn about a missing alias in a config carrying comments and trailing commas', async () => {
+    scaffoldApp(root)
+    const configPath = join(root, 'wrangler.jsonc')
+
+    // Scaffold first, then take one alias back out — the expectation is
+    // derived from the alias map the build itself owns, so this test keeps
+    // holding as that list grows.
+    await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
+    const scaffolded = JSON.parse(readFileSync(configPath, 'utf8'))
+    const [dropped, ...kept] = Object.keys(scaffolded.alias)
+    const alias = {
+      ...Object.fromEntries(kept.map((key) => [key, scaffolded.alias[key]])),
+      // An app's own alias, the kind the suggestion must not read as
+      // something to paste over.
+      shiki: './stubs/shiki.js',
+    }
+
+    // Every JSONC hazard a real config carries: a line comment, a block
+    // comment, a trailing comma, `//` inside a string, and escaped quotes.
+    writeFileSync(
+      configPath,
+      `{
+  // Kept by the app, not the build.
+  "name": "legacy",
+  "main": ".cloudflare/worker.js",
+  /* The build owns these. */
+  "alias": ${JSON.stringify(alias, null, 2)},
+  "define": {
+    "process.env.NODE_ENV": "\\"production\\"",
+    "import.meta.url": "\\"file:///worker.js\\"",
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "migrations_dir": ".cloudflare/d1-migrations",
+    },
+  ],
+}
+`,
+    )
+
+    const warning = await captureWarnings(async () => {
+      await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
+    })
+
+    expect(warning).toContain(dropped)
+    // A stripper that mangled `"\"file:///worker.js\""` or the escaped quotes
+    // around `"production"` would either fail to parse — losing the alias line
+    // above — or report `define` as missing when the file has it.
+    expect(warning).not.toContain('process.env.NODE_ENV')
+    expect(warning).not.toContain('could not parse')
+    // Only the missing entry is suggested. A suggestion carrying the entries
+    // the file already has reads as an object to paste over `alias`, which
+    // would drop the app's own `shiki` stub along with them.
+    expect(warning).not.toContain('shiki')
+    for (const key of kept) {
+      expect(warning).not.toContain(scaffolded.alias[key])
+    }
+  })
+
+  test('should stay silent when a commented config already has every build-owned key', async () => {
+    scaffoldApp(root)
+    const configPath = join(root, 'wrangler.jsonc')
+
+    await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
+    const scaffolded = readFileSync(configPath, 'utf8')
+    writeFileSync(configPath, `// An app comment, added after scaffolding.\n${scaffolded}`)
+
+    const warning = await captureWarnings(async () => {
+      await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
+    })
+
+    expect(warning).toBe('')
+  })
+
+  test('should report a config it cannot parse rather than skipping the check', async () => {
+    scaffoldApp(root)
+    writeFileSync(join(root, 'wrangler.jsonc'), '{ "name": "legacy", oops }\n')
+
+    const warning = await captureWarnings(async () => {
+      await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
+    })
+
+    expect(warning).toContain('could not parse')
   })
 
   test('should write a stub file for every aliased specifier', async () => {

--- a/packages/plugin-cloudflare/src/build.ts
+++ b/packages/plugin-cloudflare/src/build.ts
@@ -455,7 +455,13 @@ function warnMissingBuildOwnedKeys(configPath: string, outRelative: string): voi
   }
 
   const missing: string[] = []
-  const alias = (config.alias as Record<string, string> | undefined) ?? {}
+  // A non-object `alias` is malformed rather than merely outdated, and `in`
+  // would throw it out of a function whose whole point is to warn instead of
+  // failing the build. Treat it as holding no entries and name them all.
+  const configAlias = config.alias
+  const alias = (
+    typeof configAlias === 'object' && configAlias !== null ? configAlias : {}
+  ) as Record<string, string>
   for (const [specifier, target] of Object.entries(devOnlyAliases(outRelative))) {
     if (!(specifier in alias)) {
       missing.push(`${JSON.stringify(specifier)}: ${JSON.stringify(target)} (inside "alias")`)

--- a/packages/plugin-cloudflare/src/build.ts
+++ b/packages/plugin-cloudflare/src/build.ts
@@ -358,30 +358,112 @@ function scaffoldWranglerConfig(root: string, out: string, packageName: string |
 }
 
 /**
+ * `wrangler.jsonc` is JSONC by name and by habit — the scaffold writes plain
+ * JSON, but every app that has touched the file since has comments in it, and
+ * `JSON.parse` rejects the first one. Reading it with `JSON.parse` meant the
+ * upgrade warning below could not fire for the population it was written for.
+ *
+ * Only comments and trailing commas are stripped, which is the whole of what
+ * wrangler accepts beyond JSON. The scan tracks string literals rather than
+ * pattern-matching, because a config carries both hazards for real: `define`
+ * holds `"\"file:///worker.js\""`, where the `//` is inside a string and the
+ * quotes around it are escaped.
+ */
+function parseJsonc(text: string): unknown {
+  const out: string[] = []
+  let index = 0
+
+  while (index < text.length) {
+    const char = text[index]
+
+    if (char === '"') {
+      const start = index
+      index += 1
+      while (index < text.length) {
+        if (text[index] === '\\') {
+          index += 2
+          continue
+        }
+        if (text[index] === '"') {
+          index += 1
+          break
+        }
+        index += 1
+      }
+      out.push(text.slice(start, index))
+      continue
+    }
+
+    if (char === '/' && text[index + 1] === '/') {
+      while (index < text.length && text[index] !== '\n') {
+        index += 1
+      }
+      continue
+    }
+
+    if (char === '/' && text[index + 1] === '*') {
+      const end = text.indexOf('*/', index + 2)
+      index = end === -1 ? text.length : end + 2
+      continue
+    }
+
+    if (char === '}' || char === ']') {
+      // Every chunk is one character except a string literal, which is
+      // emitted whole and can never be blank or a bare comma. So the last
+      // non-blank chunk being a comma means a trailing one, not a comma
+      // inside a value.
+      let back = out.length - 1
+      while (back >= 0 && /^\s+$/.test(out[back])) {
+        back -= 1
+      }
+      if (back >= 0 && out[back] === ',') {
+        out.splice(back, 1)
+      }
+    }
+
+    out.push(char)
+    index += 1
+  }
+
+  return JSON.parse(out.join(''))
+}
+
+/**
  * The scaffold never overwrites an existing config, but `alias`, `define`,
  * and `migrations_dir` are build-owned invariants pointing into the output
  * directory — an app scaffolded before they existed deploys a worker that
  * cannot resolve `bun:sqlite` or never applies its migrations. Name exactly
  * what is missing rather than failing the build.
+ *
+ * Individual entries, never a whole `"alias"` or `"define"` object: apps keep
+ * their own entries under both keys — a `shiki` stub, a pinned `@guren/orm`,
+ * an extra `define` — and a suggestion shaped like a complete object reads as
+ * one to paste over what is there, which would drop them.
  */
 function warnMissingBuildOwnedKeys(configPath: string, outRelative: string): void {
   let config: Record<string, unknown>
   try {
-    config = JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>
+    config = parseJsonc(readFileSync(configPath, 'utf8')) as Record<string, unknown>
   } catch {
-    // Comments or trailing commas — a real JSONC file we should not guess at.
+    // Past the comment and trailing-comma stripping, so the file is malformed
+    // by wrangler's reckoning too — say so rather than pass silently, because
+    // the keys below going unchecked is how a deploy fails later instead.
+    console.warn(
+      `Cloudflare build: could not parse ${configPath}, so its build-owned keys went unchecked. Fix the file, or compare it against a config scaffolded in an empty directory.`,
+    )
     return
   }
 
   const missing: string[] = []
-  const alias = config.alias as Record<string, string> | undefined
-  const expectedAliases = devOnlyAliases(outRelative)
-  if (!alias || Object.keys(expectedAliases).some((key) => !(key in alias))) {
-    missing.push(`"alias": ${JSON.stringify(expectedAliases)}`)
+  const alias = (config.alias as Record<string, string> | undefined) ?? {}
+  for (const [specifier, target] of Object.entries(devOnlyAliases(outRelative))) {
+    if (!(specifier in alias)) {
+      missing.push(`${JSON.stringify(specifier)}: ${JSON.stringify(target)} (inside "alias")`)
+    }
   }
   const define = config.define as Record<string, string> | undefined
   if (!define?.['process.env.NODE_ENV']) {
-    missing.push('"define": { "process.env.NODE_ENV": "\\"production\\"" }')
+    missing.push('"process.env.NODE_ENV": "\\"production\\"" (inside "define")')
   }
   const d1 = (config.d1_databases as Array<Record<string, unknown>> | undefined)?.[0]
   if (d1 && d1.migrations_dir !== `${outRelative}/d1-migrations`) {
@@ -390,7 +472,7 @@ function warnMissingBuildOwnedKeys(configPath: string, outRelative: string): voi
 
   if (missing.length > 0) {
     console.warn(
-      `Cloudflare build: ${configPath} predates this plugin version. Add the following or the worker will fail to start or skip migrations:\n  ${missing.join('\n  ')}`,
+      `Cloudflare build: ${configPath} predates this plugin version. Add these entries, alongside whatever the file already has under the same keys, or the worker will fail to start or skip migrations:\n  ${missing.join('\n  ')}`,
     )
   }
 }


### PR DESCRIPTION
## Summary

`cloudflare:build` never overwrites an existing `wrangler.jsonc`. Instead it warns about the build-owned keys the config is missing — notably the `alias` entries, without which `wrangler deploy` cannot resolve the stubbed modules. Two things kept that warning from doing its job.

**It read the file with `JSON.parse`.** Any config carrying a comment failed to parse and the check bailed silently ("Comments or trailing commas — a real JSONC file we should not guess at."). Comments are the normal case in a `.jsonc` file, so the warning could not fire for the population it was written for: those apps see nothing at build time and a resolution failure at deploy time instead. This repo's own `web/wrangler.jsonc` has 17 comment lines and throws `Unrecognized token '/'` on `JSON.parse`.

The config is now read with a JSONC-tolerant parser — comments and trailing commas only, which is the whole of what wrangler accepts beyond JSON. The scan tracks string literals rather than pattern-matching, because a real config carries both hazards: `define` holds `"\"file:///worker.js\""`, where the `//` is inside a string and the quotes around it are escaped. Input still unparseable afterwards is reported rather than skipped.

**The suggestion was shaped like a replacement.** The warning printed `alias` and `define` as complete objects holding only the build-owned entries, which reads as something to paste over what the file has. Apps keep their own entries under both keys — `web/wrangler.jsonc` has a `shiki` stub and a pinned `@guren/orm` alias, plus an `import.meta.url` define — so following it could drop them, and the `@guren/orm` pin exists precisely to keep two ORM copies out of the bundle. The warning now names only the individual entries that are missing, in the `(inside ...)` form `migrations_dir` already used:

```
Cloudflare build: <path> predates this plugin version. Add these entries, alongside whatever the file already has under the same keys, or the worker will fail to start or skip migrations:
  "vite": "./.cloudflare/stub-vite.js" (inside "alias")
```

No new dependency: the parser is ~40 lines local to `build.ts`. tsup externalizes dependencies, so a JSONC package would have been install surface on a published plugin.

## Scope

`packages/plugin-cloudflare` only (`src/build.ts`, `src/build.test.ts`) plus a changeset. No template or scaffold files touched.

## Risk Assessment

Patch. Two user-visible behavior changes, both on the existing-config path (`scaffoldWranglerConfig` still never overwrites):

- Configs that previously parsed continue to parse identically — verified against every valid JSON file tracked in the repo (56 files, 0 divergences from `JSON.parse`).
- A config that is unparseable even after stripping now prints a warning where it used to be silent. Intentional: the keys going unchecked is how a deploy fails later instead.

Independent of #428. That PR only changes the *contents* of `devOnlyAliases`, not the warning path, so the two do not conflict — it is what made the bug visible (four new required aliases, no warning, then `Could not resolve "postgres"` at `wrangler deploy --dry-run`).

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` — 4525 unit tests (0 fail), 112 example tests
- [x] `bun run audit:core-first`, `bun run audit:docs`

Four tests added, and the alias expectation is derived from the map the build itself owns (scaffold once, remove one key), so it keeps holding as that list grows rather than needing an edit when #428 lands.

The second commit fixes two review findings on the first: `?? {}` left a non-object `alias` value reaching `specifier in alias`, which threw a TypeError out of a warn-only path and failed the whole build (`"alias": ""` was a regression against main, where `!alias ||` short-circuited on falsy values — verified by running the same probe against `git show main:...build.ts`). And a test assertion that named the app's own `shiki` alias could not fail, because the old suggestion printed only `devOnlyAliases()` and never contained it; it now asserts that no specifier or target the file already has is named.

Mutation-checked — each protection was removed to confirm the tests can fail:

| Mutation | Result |
| --- | --- |
| Restore `JSON.parse` | 2 fail |
| Naive regex stripper (not string-aware) | 2 fail |
| Restore the whole-object `"alias"` suggestion | 1 fail |
| Drop the non-object `alias` guard | 1 fail |

Verified end-to-end against the real `web/wrangler.jsonc`, both directions: silent when complete, and when one alias is removed it names that entry and mentions neither `shiki`, `@guren/orm`, nor `import.meta.url`. Parsing that file also preserves everything the warning never reads (`routes`, `analytics_engine_datasets`, `observability`, both `migrations` tags, all 13 top-level keys).

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation — no docs describe this warning's text.

