### PR TITLE
ci: run the deploy bundle gates in the nightly canary

### DIFF
--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -131,6 +131,25 @@ jobs:
       - name: Run tests
         run: bun run test
 
+      # -- Deploy bundle gates (nightly only) --
+
+      # These four tests are opt-in, and until now ran nowhere: no workflow
+      # set either variable, so all three deploy plugins shipped their bundle
+      # gates switched off. They cover an app failing to bundle on a database
+      # it never chose, which reached users twice because nothing in the repo
+      # bundled a real app.
+      #
+      # Nightly rather than PR CI: each probe installs @guren/orm from a
+      # tarball plus its clients from npm, and `bunx wrangler` resolves the
+      # latest release rather than the version this repo pins. An upstream
+      # publish can therefore turn these red with no change here — a canary
+      # signal, not a reason to block a merge.
+      - name: Deploy bundle gates
+        run: bun run test:bun plugin-cloudflare plugin-lambda plugin-vercel
+        env:
+          GUREN_TEST_WRANGLER: '1'
+          GUREN_TEST_BUNDLE: '1'
+
       # -- Benchmarks (nightly only) --
 
       - name: Run benchmarks

--- a/packages/plugin-cloudflare/src/wrangler-bundle.test.ts
+++ b/packages/plugin-cloudflare/src/wrangler-bundle.test.ts
@@ -17,8 +17,9 @@ import { DEV_ONLY_MODULES, SQL_CLIENT_MODULES } from '@guren/core/internal/deplo
 // from before it moved to D1, which masked the failure.
 //
 // Requires network on first run (bunx downloads wrangler + workerd), so it is
-// gated behind GUREN_TEST_WRANGLER=1 and skipped in CI, like
-// wrangler-migrations.test.ts.
+// gated behind GUREN_TEST_WRANGLER=1 rather than run on every PR, like
+// wrangler-migrations.test.ts. The nightly canary sets the variable, so this
+// does run — the gate it replaces was one nothing switched on at all.
 const enabled = process.env.GUREN_TEST_WRANGLER === '1'
 
 /** Installed directories that would let wrangler resolve a client for real. */

--- a/packages/plugin-cloudflare/src/wrangler-migrations.test.ts
+++ b/packages/plugin-cloudflare/src/wrangler-migrations.test.ts
@@ -8,7 +8,8 @@ import { flattenD1Migrations } from './build'
 // generated SQL (tab indentation, backtick quoting, `--> statement-breakpoint`
 // separators, 0000_-prefixed filename ordering) against a local D1 database.
 // Requires network on first run (bunx downloads wrangler + workerd), so it is
-// gated behind GUREN_TEST_WRANGLER=1 and skipped in CI.
+// gated behind GUREN_TEST_WRANGLER=1 rather than run on every PR. The nightly
+// canary sets the variable.
 const enabled = process.env.GUREN_TEST_WRANGLER === '1'
 
 function wrangler(cwd: string, args: string[]): { exitCode: number; output: string } {

--- a/packages/plugin-lambda/tests/orm-bundle.test.ts
+++ b/packages/plugin-lambda/tests/orm-bundle.test.ts
@@ -29,6 +29,7 @@ import { buildLambdaOutput } from '../src/build'
 //
 // Needs the network to install @guren/orm and postgres, so it is gated behind
 // GUREN_TEST_BUNDLE=1 like the Workers bundle test's GUREN_TEST_WRANGLER.
+// The nightly canary sets both.
 const enabled = process.env.GUREN_TEST_BUNDLE === '1'
 
 /**

--- a/packages/plugin-vercel/tests/orm-bundle.test.ts
+++ b/packages/plugin-vercel/tests/orm-bundle.test.ts
@@ -29,6 +29,7 @@ import { buildVercelOutput } from '../src/index'
 //
 // Needs the network to install @guren/orm and postgres, so it is gated behind
 // GUREN_TEST_BUNDLE=1 like the Workers bundle test's GUREN_TEST_WRANGLER.
+// The nightly canary sets both.
 //
 // This platform is also where the stub mechanism is newest: `bun build` was
 // spawned as a subprocess until this build moved to Bun's JS API, which is


### PR DESCRIPTION
## Summary

Three deploy plugins ship an end-to-end bundle test, and **none of them ran anywhere**. Neither `GUREN_TEST_WRANGLER` nor `GUREN_TEST_BUNDLE` was set by any workflow, so all four opt-in tests were skipped on every run:

| Package | Test |
|---|---|
| `plugin-cloudflare` | `wrangler-bundle.test.ts`, `wrangler-migrations.test.ts` |
| `plugin-lambda` | `orm-bundle.test.ts` |
| `plugin-vercel` | `orm-bundle.test.ts` |

They guard an app failing to bundle on a database it never chose — the defect class that reached users twice, on Workers (#428) and on Lambda and Vercel (#432). Each fix arrived carrying the gate that would have caught it, switched off.

Found while closing out #431, whose follow-up list said "no gate bundles `web/` with wrangler". The honest fix turned out not to be a web-specific check: `warnMissingBuildOwnedKeys` already owns the "is this config missing build-owned keys?" rule (and #433 is repairing it), so a parallel assertion in `web/` would have been a third copy of that rule. The real gap was that the gates the framework already has never execute.

## Scope

`.github/workflows/nightly-canary.yml` plus comment-only edits to the four test headers. No source or behavior change, so no changeset.

## Risk Assessment

Nightly rather than PR CI, deliberately. Every probe installs `@guren/orm` from a tarball plus its clients from npm, and `bunx wrangler` resolves the **latest** release rather than the version this repo pins — it fetched 4.123.0 here against web's `^4.118.0`. An upstream publish can therefore turn these red with no change in this repository. That is a canary signal, not a reason to block a merge, and it matches how `published-drift.yml` is already treated.

The trade is explicit: a PR that breaks the stubs merges green and is caught the following night rather than pre-merge. Given both fixes in this area just landed with unit coverage, that seemed the right balance against making every PR depend on npm and a floating wrangler.

The existing `Run tests` step is untouched — the gates run as an appended canary-only step, which is the convention the file documents for canary-specific checks.

## Validation

The wiring, measured rather than assumed:

| | Result |
|---|---|
| gates off (today's behaviour) | 123 pass, **21 skip** |
| gates on (as the canary runs it) | **162 pass**, 3 skip, 10s |

And the Workers gate is able to fail — dropping `SQL_CLIENT_MODULES` from the stubs it writes turns it red with the six original resolve errors, naming `postgres`, `mysql2`, `mysql2/promise` and the Data API client:

```
✘ [ERROR] Could not resolve "postgres"
    node_modules/@guren/orm/dist/index.js:3099:13
✘ [ERROR] Could not resolve "mysql2"
✘ [ERROR] Could not resolve "@aws-sdk/client-rds-data"   (drizzle-orm/aws-data-api/pg/driver.js)
✘ [ERROR] Could not resolve "mysql2/promise"             (drizzle-orm/mysql2/driver.js)
```

Workflow YAML parsed and the new step inspected structurally; the `Run tests` step verified unchanged.

- [x] `bun run typecheck`
- [x] `bun run test:bun plugin-cloudflare plugin-lambda plugin-vercel` — both with and without the variables

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes. — no behavior change; this makes existing tests execute
- [x] I updated relevant documentation. — the four test headers no longer claim they are skipped in CI

## Follow-up, not in this PR

`web/`'s committed alias table still has no gate of its own. After #433 lands, a stale table produces a *warning* during `cloudflare:build`, which the `web-app` job runs — but a warning fails nothing, and grepping for one is fail-open the moment its wording changes. Closing that properly means making the plugin's check exit non-zero, which is a framework behavior change and belongs with the file #433 is editing.