### PR TITLE
fix(web): read SQLITE_DATABASE_PATH in the drizzle config

### DIFF
--- a/web/drizzle.config.ts
+++ b/web/drizzle.config.ts
@@ -1,10 +1,33 @@
 import { defineConfig } from 'drizzle-kit'
 
+/**
+ * The same variable `config/database.ts` reads, and deliberately not
+ * `DATABASE_URL`: that name carries a Postgres URI in existing environments,
+ * so naming it here would point `drizzle-kit studio`/`push`/`migrate` at a
+ * different database than the app itself opens.
+ */
+const filename = process.env.SQLITE_DATABASE_PATH ?? './data/guren.db'
+
+/**
+ * `file:local.db` and `:memory:` are legitimate sqlite values, so this matches
+ * only a scheme *with* an authority — the shape of a connection string that
+ * sqlite would otherwise silently accept as a filename.
+ */
+const uriScheme = /^([a-z+]+):\/\//i.exec(filename)
+
+if (uriScheme) {
+  throw new Error(
+    `SQLITE_DATABASE_PATH must be a file path, but starts with "${uriScheme[1]}://". ` +
+      'This app runs on SQLite locally and D1 in production through the wrangler ' +
+      'binding — there is no connection string.',
+  )
+}
+
 export default defineConfig({
   schema: './db/schema.ts',
   out: './db/migrations',
   dialect: 'sqlite',
   dbCredentials: {
-    url: process.env.DATABASE_URL ?? './data/guren.db',
+    url: filename,
   },
 })


### PR DESCRIPTION
## Summary

`web/config/database.ts` deliberately reads `SQLITE_DATABASE_PATH` rather than `DATABASE_URL`, with a comment explaining why: that name carries a Postgres URI in existing environments, and the sqlite factory would treat it as a file path. `web/drizzle.config.ts` never got the same treatment, so the two disagreed about which variable names web's database.

The genuinely silent case is the one nobody would notice: an operator who sets `SQLITE_DATABASE_PATH` per `.env.example` has it honored by the app and ignored by the drizzle config, which falls back to `./data/guren.db`. `drizzle-kit studio` / `push` / `migrate` then quietly operate on a different file than the app opens.

```
--- before, SQLITE_DATABASE_PATH=/tmp/scratch.db set ---
{ url: "./data/guren.db" }
--- after ---
{ url: "/tmp/scratch.db" }
```

This also rejects a value carrying a URI scheme with an authority before handing it to drizzle-kit, so a misconfigured environment fails loudly instead of letting a connection string through as a filename. `file:local.db` and `:memory:` stay valid — drizzle-kit's own `normaliseSQLiteUrl` accepts both, keeping `file:` for libsql and stripping it for the better-sqlite/bun drivers — so the check matches only a scheme *with* an authority. The error names the scheme rather than the value, so a URI carrying a password does not reach the logs.

## Scope

`web` (one file: `web/drizzle.config.ts`). `web/README.md` prerequisites were already corrected in #431; this was the last place naming `DATABASE_URL` in `web/` (the only remaining match is the explanatory comment in `config/database.ts`).

## Risk Assessment

**Two corrections to the premise this started from**, both verified rather than assumed:

1. **`bun run db:migrate` was never affected.** It routes through the Guren CLI to `config/database.ts`, which already read the right variable. Only `db:make` (`drizzle-kit generate`) reads `drizzle.config.ts`, and `generate` never connects, so it does not use `dbCredentials` at all. Confirmed by running `db:migrate` with `DATABASE_URL` exported to a Postgres URI on the unmodified config: it wrote to `./data/guren.db`, the correct location.
2. **`drizzle-kit` did not fail silently.** Running `drizzle-kit migrate` directly with the old config and `DATABASE_URL` set fails loudly with `unable to open database file` and creates nothing, because drizzle-kit uses `node:sqlite`, which does not `mkdir -p` the way Guren's own sqlite driver does. No stray directory tree was produced.

Behavior change: the throw happens at **config load**, not at connect time, so it also fires on `db:make` even though `generate` never opens a database. That is the intended fail-loud behavior, but it is worth knowing before someone hits it.

Not in scope, flagged rather than fixed silently: `web/config/database.ts` has no equivalent guard, and Guren's sqlite driver *does* `mkdir -p` its filename. That is the path that actually reproduces the original silent-stray-database failure, and the guard arguably belongs in `createSqliteDatabase` so every app gets it.

## Validation

Guard behavior, exercised across legitimate and rejected values (mutation-tested — the guard was observed firing, not just assumed present):

| `SQLITE_DATABASE_PATH` | result |
|---|---|
| `postgres://guren:guren@localhost:54322/guren` | throws |
| `MYSQL://x@y/z` | throws (case-insensitive) |
| `file://data/guren.db` | throws |
| `file:local.db` | ok |
| `:memory:` | ok |
| `./data/guren.db`, `/abs/path/app.db` | ok |
| unset | `./data/guren.db` |

Also confirmed with `DATABASE_URL` exported to a Postgres URI: `bun run --cwd web db:make` and `db:migrate` both succeed, and `drizzle-kit migrate` opens the path given by `SQLITE_DATABASE_PATH`.

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` — 16 files, 112 tests passed in `web`; full chain exit 0

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [ ] I added/updated tests for behavior changes — `web/drizzle.config.ts` is app config with no test harness covering it; verified by direct execution as above.
- [x] I updated relevant documentation — `.env.example` and `README.md` already described `SQLITE_DATABASE_PATH`; the config was the piece out of step.
