### PR TITLE
fix(orm): reject a connection URI where the sqlite driver expects a file path

### DIFF
--- a/.changeset/sqlite-reject-connection-uri.md
+++ b/.changeset/sqlite-reject-connection-uri.md
@@ -1,0 +1,38 @@
+---
+"@guren/orm": patch
+---
+
+Reject a connection URI where the SQLite driver expects a file path
+
+`createSqliteDatabase()` treats its `filename` as a path, and creates the
+directory above it with `mkdir -p`. So a connection string handed to a SQLite
+app did not fail — it *succeeded*. `postgres://guren:guren@localhost:54322/guren`
+became a real `postgres:/guren:guren@localhost:54322/` directory tree with a
+real database inside it, and `db:migrate` and `db:status` then agreed with each
+other about that stray file. The only symptom was that the database the app
+actually reads stayed empty, which reads as "migrate claims success but does
+nothing" rather than "migrate wrote somewhere else". A SQLite-backed Nightly
+Canary failed this way for two weeks.
+
+The resolved filename is now rejected when it names a database server, before
+the `mkdir` runs:
+
+```
+createSqliteDatabase() received a connection URI where it expects a file path:
+postgres://guren:guren@localhost:54322/guren (from DATABASE_URL). Left alone it
+would be created as a directory tree and migrated into silently.
+```
+
+The check is on the resolved value rather than on the option, so it also covers
+the `filename`-less path, where the driver falls back to `process.env.DATABASE_URL`
+— an ambient Postgres URL that a SQLite app never meant to consume is the
+likeliest way to hit this, and the option is not involved.
+
+Rejected are `postgres://…`, `mysql://…`, `libsql://…` and anything else naming
+a server. Filenames are not, and that includes two shapes a plain authority
+check would have swept up: `file:` is sqlite's own URI scheme and never
+addresses a server, so `file:///absolute/path.db` keeps working alongside
+`file:local.db` and `file::memory:`; and a one-letter scheme is a Windows drive
+rather than a scheme, so `C://data/app.db` keeps working alongside
+`C:/data/app.db`. Plain `:memory:`, `./data/guren.db` and absolute paths were
+never in scope.

--- a/packages/orm/src/sqlite.test.ts
+++ b/packages/orm/src/sqlite.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { sql } from 'drizzle-orm'
 import { createSqliteDatabase, type SqliteDatabase, type SqliteDatabaseOptions } from './sqlite'
 
@@ -272,5 +272,116 @@ describe('createSqliteDatabase closeDatabase', () => {
     await database.closeDatabase()
 
     expect(isOpen(db)).toBe(false)
+  })
+})
+
+describe('createSqliteDatabase connection-URI filenames', () => {
+  const POSTGRES_URI = 'postgres://guren:guren@localhost:54322/guren'
+  let originalDatabaseUrl: string | undefined
+
+  beforeEach(() => {
+    originalDatabaseUrl = process.env.DATABASE_URL
+    delete process.env.DATABASE_URL
+  })
+
+  afterEach(() => {
+    if (originalDatabaseUrl === undefined) delete process.env.DATABASE_URL
+    else process.env.DATABASE_URL = originalDatabaseUrl
+  })
+
+  test('should reject a connection URI passed as the filename', async () => {
+    const database = createSqliteDatabase({
+      migrationsFolder: join(workDir, 'migrations'),
+      filename: POSTGRES_URI,
+    })
+
+    await expect(database.getDatabase()).rejects.toThrow(/connection URI where it expects a file path/)
+  })
+
+  // The failure this guards is not the rejection but what used to happen instead:
+  // the driver mkdir -p's the filename's directory, so an unguarded URI is created
+  // as a `postgres:/guren:guren@localhost:54322` tree and migrated into silently.
+  test('should create no directory tree for the rejected URI', async () => {
+    const database = createSqliteDatabase({
+      migrationsFolder: join(workDir, 'migrations'),
+      filename: POSTGRES_URI,
+    })
+
+    await expect(database.getDatabase()).rejects.toThrow()
+
+    expect(existsSync(resolve('postgres:'))).toBe(false)
+  })
+
+  // An app that never passes `filename` still inherits DATABASE_URL, which is how
+  // a sqlite-backed Nightly Canary spent two weeks migrating a stray database.
+  test('should reject a connection URI inherited from DATABASE_URL', async () => {
+    process.env.DATABASE_URL = POSTGRES_URI
+
+    const database = createSqliteDatabase({ migrationsFolder: join(workDir, 'migrations') })
+
+    await expect(database.getDatabase()).rejects.toThrow(/from DATABASE_URL/)
+    expect(existsSync(resolve('postgres:'))).toBe(false)
+  })
+
+  test.each([':memory:', '', 'file::memory:', 'file::memory:?cache=shared'])(
+    'should accept %p, which carries a scheme but no authority',
+    async (filename) => {
+      const database = createSqliteDatabase({ migrationsFolder: join(workDir, 'migrations'), filename })
+
+      const db = await database.getDatabase()
+      expect(isOpen(db)).toBe(true)
+
+      await database.closeDatabase()
+    },
+  )
+
+  // `file:` never addresses a database server, so no form of it is a connection
+  // string — including the authority-shaped one, which is sqlite's own spelling
+  // of an absolute path and opens today.
+  test('should accept file:// with an absolute path', async () => {
+    const database = createSqliteDatabase({
+      migrationsFolder: join(workDir, 'migrations'),
+      filename: `file://${join(workDir, 'abs.db')}`,
+    })
+
+    const db = await database.getDatabase()
+    expect(isOpen(db)).toBe(true)
+
+    await database.closeDatabase()
+  })
+
+  // A one-letter scheme is always a Windows drive, never a registered scheme.
+  test('should accept a Windows drive path whose separator got doubled', async () => {
+    const database = createSqliteDatabase({
+      migrationsFolder: join(workDir, 'migrations'),
+      filename: 'C://db/app.db',
+    })
+
+    try {
+      // Resolved against the cwd on a POSIX host, so this asserts the guard's
+      // decision — reaching the open at all means the URI check let it through.
+      const db = await database.getDatabase()
+      expect(isOpen(db)).toBe(true)
+      await database.closeDatabase()
+    } finally {
+      rmSync(resolve('C:'), { recursive: true, force: true })
+    }
+  })
+
+  test('should accept file:local.db, which sqlite resolves to a real file', async () => {
+    // sqlite resolves this URI against the cwd rather than workDir, so the file it
+    // creates is cleaned up here rather than by the suite's workDir teardown.
+    const database = createSqliteDatabase({
+      migrationsFolder: join(workDir, 'migrations'),
+      filename: 'file:local.db',
+    })
+
+    try {
+      const db = await database.getDatabase()
+      expect(isOpen(db)).toBe(true)
+      await database.closeDatabase()
+    } finally {
+      rmSync(resolve('local.db'), { force: true })
+    }
   })
 })

--- a/packages/orm/src/sqlite.ts
+++ b/packages/orm/src/sqlite.ts
@@ -37,6 +37,43 @@ function isInMemory(dbPath: string): boolean {
   return dbPath === ':memory:' || dbPath === '' || dbPath.startsWith('file::memory:')
 }
 
+/**
+ * A scheme *with an authority* — the `//` is what separates a connection URI
+ * from a filename — for every scheme that could name a database server.
+ *
+ * Two exclusions keep legal filenames out of it. `file:` is sqlite's own URI
+ * scheme and never addresses a server, so all of its forms stay legal, the
+ * authority-shaped `file:///absolute/path.db` included. And the scheme must be
+ * at least two characters: no registered scheme is one letter, while `C://db`
+ * is a Windows drive path whose separator merely got doubled.
+ *
+ * Everything without a scheme is untouched — `:memory:`, `file::memory:`,
+ * `file:local.db`, and every relative and absolute path.
+ */
+const CONNECTION_URI = /^(?!file:)[a-z][a-z0-9+.-]+:\/\//i
+
+/**
+ * This driver `mkdir -p`s the filename's directory, which is what makes a
+ * connection string dangerous rather than merely wrong: `postgres://u:pw@host/db`
+ * does not fail, it *succeeds* — creating a `postgres:/u:pw@host/db` tree and
+ * migrating into a database nobody ever reads, while `db:migrate` and
+ * `db:status` agree with each other on that stray file. Rejecting before the
+ * mkdir is the difference between a stop and a silent success.
+ *
+ * The likeliest source is an ambient `DATABASE_URL` that a sqlite app never
+ * meant to consume — the resolved value is checked, not the option, so the
+ * env fallback below is covered too.
+ */
+function assertNotConnectionUri(dbPath: string, source: string): void {
+  if (!CONNECTION_URI.test(dbPath)) return
+
+  throw new Error(
+    `createSqliteDatabase() received a connection URI where it expects a file path: ${dbPath} (from ${source}). ` +
+      'Left alone it would be created as a directory tree and migrated into silently. ' +
+      'Pass a path such as "./data/guren.db", or ":memory:".',
+  )
+}
+
 export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteDatabase {
   const { migrationsFolder, filename, seedersFolder, relations } = options
 
@@ -59,7 +96,18 @@ export function createSqliteDatabase(options: SqliteDatabaseOptions): SqliteData
 
   function resolveFilename(): string {
     const value = typeof filename === 'function' ? filename() : filename
-    return value ?? process.env.DATABASE_URL ?? './data/guren.db'
+    if (value != null) {
+      assertNotConnectionUri(value, 'the "filename" option')
+      return value
+    }
+
+    const fromEnv = process.env.DATABASE_URL
+    if (fromEnv != null) {
+      assertNotConnectionUri(fromEnv, 'DATABASE_URL')
+      return fromEnv
+    }
+
+    return './data/guren.db'
   }
 
   // Unlike the other drivers, this flight must not open with


### PR DESCRIPTION
## Summary

`createSqliteDatabase()` treats its `filename` as a path and creates the directory above it with `mkdir -p`. That is what makes a connection string dangerous rather than merely wrong: it does not fail, it *succeeds*. `postgres://guren:guren@localhost:54322/guren` became a real `postgres:/guren:guren@localhost:54322/` tree with a real database inside it, and `db:migrate` and `db:status` then agreed with each other about that stray file while the database the app actually reads stayed empty. The symptom reads as "migrate claims success but does nothing" rather than "migrate wrote somewhere else".

This adds the guard at the driver, so every Guren app gets it rather than each app re-deriving one. Two details are load-bearing:

- **The resolved filename is checked, not the `filename` option.** The driver falls back to `process.env.DATABASE_URL` when no option is given, and that fallback — an ambient Postgres URL a SQLite app never meant to consume — is the path a SQLite-backed Nightly Canary hit for two weeks (#362). A check on the option alone is green against the bug that actually shipped.
- **It runs before the `mkdir`.** Rejecting afterwards would still leave the directory tree behind, which passes a naive exit-code check while doing the damage.

Only a scheme that could name a database server is refused. Two exclusions keep working filenames out of it, both confirmed by execution rather than inspection:

- `file:` is sqlite's own URI scheme and never addresses a server. `file:///absolute/path.db` opens today under Bun, so it stays valid alongside `file:local.db` and `file::memory:`.
- A scheme must be at least two characters. No registered scheme is one letter, while `C://data/app.db` is a Windows drive path whose separator merely got doubled.

Verified matrix — rejected: `postgres://`, `postgresql://`, `mysql://`, `libsql://`, `mongodb+srv://`, `redis://`, `POSTGRES://`. Accepted: `:memory:`, `''`, `file::memory:`, `file::memory:?cache=shared`, `file:local.db`, `file:///abs.db`, `FILE:///abs.db`, `./data/guren.db`, absolute paths, `C:\db\app.db`, `C:/db/app.db`, `C://db/app.db`.

## Scope

`orm` — `packages/orm/src/sqlite.ts` and its tests. No API surface added, no exports changed.

## Risk Assessment

A configuration that previously "worked" by writing to a stray database now fails at `getDatabase()`. No legitimate configuration is affected: every value that opened a database the app then read still opens it. Changeset is `patch` accordingly.

**One divergence a reviewer should decide on.** #437 landed a scheme guard in `web/drizzle.config.ts` with `/^([a-z+]+):\/\//i`, which refuses `file://` and any one-letter scheme. This PR's driver guard is deliberately narrower on both points, so the two halves of `web` now disagree for those two shapes. Confirmed on this branch with `SQLITE_DATABASE_PATH=file:///…/data/abs.db`:

```
guren db:migrate  -> ✔ Database migrations completed.
drizzle-kit check -> Error  SQLITE_DATABASE_PATH must be a file path, but starts with "file://".
```

That is the same class of split #437 set out to close, so it is worth reconciling — but the direction is a judgment call (loosen the drizzle config, or tighten the driver to match), and it is the newer decision, so I have not edited that file here. Happy to align it either way in this PR.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck` — 0 errors
- [x] `bun run test` — `test:bun` 4502 pass / 0 fail (`test:examples` needs a Postgres container and touches nothing here, so it was not run)

Also `audit:core-first`, `audit:docs`, `audit:contracts` — all pass. Templates are untouched, so the starter-template audit and smokes are out of scope.

Mutation-tested rather than assumed: with the guard disabled, the three rejection tests fail *and* the run materializes `postgres:/guren:guren@localhost:54322/guren` with its `-wal`/`-shm` sidecars in the working tree — the bug reproduced in place, which is what makes the "no directory created" assertion falsifiable. Reverting only the two exclusions fails exactly the two tests covering them.

End-to-end through the real CLI, after rebuilding so the repro exercised `packages/orm/dist` rather than source:

| `SQLITE_DATABASE_PATH` | Result |
| --- | --- |
| `postgres://guren:guren@localhost:54322/guren` | exit 1, no `postgres:` tree created |
| `file:///…/data/abs.db` | migrations completed |
| unset (default `./data/guren.db`) | migrations completed |

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation — no doc change needed; the guard is a runtime error whose message names the offending value and its source. `audit:docs` passes.
