### PR TITLE
build: plan the create-guren-app bump before changeset version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "changeset": "changeset",
     "sync:template-deps": "bun run ./scripts/sync-template-deps.ts",
     "audit:template-deps": "bun run ./scripts/sync-template-deps.ts --check",
-    "version-packages": "changeset version && bun run ./scripts/sync-template-deps.ts --release && bun run audit:plugin-compat && bun install",
+    "version-packages": "bun run ./scripts/plan-create-app-bump.ts && changeset version && bun run ./scripts/sync-template-deps.ts --release && bun run audit:plugin-compat && bun install",
     "release": "bun run build && changeset publish",
     "test:bun": "bun run ./scripts/test-packages.ts",
     "test:bun:list": "bun run ./scripts/test-packages.ts --list",

--- a/scripts/plan-create-app-bump.test.ts
+++ b/scripts/plan-create-app-bump.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { repoRoot } from './workspace-packages.ts'
+import {
+  MANAGED_CHANGESET,
+  packagesTemplatesDeclare,
+  planScaffolderBump,
+  renderChangeset,
+  type ReleasePlan,
+} from './plan-create-app-bump.ts'
+
+/**
+ * The bump has to be conditional to be worth having: a script that always adds
+ * `create-guren-app` to the plan would publish a tarball identical to the last
+ * one on every deploy-plugin release, and would look exactly like a working one
+ * from the release that needs the bump. So both directions are pinned here, and
+ * the negative direction is checked against the *real* template manifests — a
+ * mocked "declared" set would keep passing on the day a template starts
+ * depending on the package the negative case names.
+ */
+const plan = (...names: string[]): ReleasePlan => ({
+  releases: names.map((name) => ({ name, oldVersion: '1.0.0', newVersion: '1.0.1' })),
+})
+
+/** A package changesets pulled into the plan but left at its current version. */
+const unmoved = (name: string) => ({ name, oldVersion: '1.0.0', newVersion: '1.0.0' })
+
+describe('planScaffolderBump', () => {
+  it('bumps the scaffolder when a package the templates declare is releasing', () => {
+    expect(planScaffolderBump(plan('@guren/cli'), new Set(['@guren/cli']))).toEqual({
+      bump: true,
+      moving: ['@guren/cli'],
+    })
+  })
+
+  it('lists every declared package that moves, and only those', () => {
+    const decision = planScaffolderBump(
+      plan('@guren/core', '@guren/plugin-cloudflare', '@guren/orm'),
+      new Set(['@guren/core', '@guren/orm']),
+    )
+
+    expect(decision).toEqual({ bump: true, moving: ['@guren/core', '@guren/orm'] })
+  })
+
+  it('leaves a release the templates do not depend on alone', () => {
+    expect(planScaffolderBump(plan('@guren/plugin-cloudflare'), new Set(['@guren/core']))).toEqual({
+      bump: false,
+      reason: 'templates-unaffected',
+    })
+  })
+
+  /**
+   * `changeset status` lists a package it pulled in but left alone with its
+   * version unchanged — `@guren/example-blog` does this today, because it is the
+   * one entry in the config's `ignore`. Such an entry rewrites no range, so a
+   * name-only match here would bump the scaffolder into publishing a tarball
+   * identical to the last one.
+   */
+  it('ignores a planned release that does not move a version', () => {
+    expect(planScaffolderBump({ releases: [unmoved('@guren/orm')] }, new Set(['@guren/orm']))).toEqual({
+      bump: false,
+      reason: 'templates-unaffected',
+    })
+  })
+
+  it('adds nothing when the scaffolder is already releasing', () => {
+    expect(planScaffolderBump(plan('@guren/cli', 'create-guren-app'), new Set(['@guren/cli']))).toEqual({
+      bump: false,
+      reason: 'already-releasing',
+    })
+  })
+
+  it('still bumps when the scaffolder is in the plan without moving', () => {
+    const releases = [...plan('@guren/cli').releases, unmoved('create-guren-app')]
+
+    expect(planScaffolderBump({ releases }, new Set(['@guren/cli']))).toEqual({
+      bump: true,
+      moving: ['@guren/cli'],
+    })
+  })
+
+  it('distinguishes an empty plan from a plan that needs no bump', () => {
+    expect(planScaffolderBump(plan(), new Set(['@guren/cli']))).toEqual({
+      bump: false,
+      reason: 'no-release',
+    })
+  })
+})
+
+describe('the packages the templates actually declare', () => {
+  it('covers the framework packages a scaffolded app resolves from npm', async () => {
+    const declared = await packagesTemplatesDeclare()
+
+    // Not an exhaustive list: a template gaining a dependency is fine, and the
+    // script reads the manifests rather than a list like this one. What would
+    // not be fine is a template quietly dropping the packages whose versions
+    // are the whole reason the scaffolder has to be republished.
+    for (const name of ['@guren/cli', '@guren/core', '@guren/inertia-client', '@guren/orm', '@guren/testing']) {
+      expect(declared.has(name)).toBe(true)
+    }
+  })
+
+  it('does not declare the deploy plugins the negative case relies on', async () => {
+    const declared = await packagesTemplatesDeclare()
+
+    for (const plugin of ['@guren/plugin-cloudflare', '@guren/plugin-lambda', '@guren/plugin-vercel']) {
+      expect(declared.has(plugin)).toBe(false)
+    }
+  })
+})
+
+/**
+ * The script's whole value is in being invoked, and ahead of `changeset
+ * version` — behind it, the plan it reads is already spent. Nothing else here
+ * would notice it being dropped from the release command: every unit test above
+ * keeps passing, and the release goes back to being refused by
+ * `sync-template-deps --release` with a human writing the changeset by hand,
+ * which is the state this exists to leave.
+ */
+describe('the version-packages wiring', () => {
+  const versionPackages = (
+    JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')) as {
+      scripts: Record<string, string>
+    }
+  ).scripts['version-packages']
+
+  it('runs the planner before changeset version', () => {
+    const planner = versionPackages.indexOf('plan-create-app-bump')
+    const version = versionPackages.indexOf('changeset version')
+
+    expect(planner).toBeGreaterThanOrEqual(0)
+    expect(version).toBeGreaterThanOrEqual(0)
+    expect(planner).toBeLessThan(version)
+  })
+
+  it('still runs the sync gate that refuses a release without the bump', () => {
+    expect(versionPackages).toContain('sync-template-deps.ts --release')
+  })
+})
+
+describe('renderChangeset', () => {
+  it('bumps create-guren-app by a patch and names what is releasing', () => {
+    const body = renderChangeset(['@guren/cli', '@guren/orm'])
+
+    expect(body.split('\n').slice(0, 3)).toEqual(['---', '"create-guren-app": patch', '---'])
+    expect(body).toContain('`@guren/cli`, `@guren/orm`')
+    expect(body.endsWith('\n')).toBe(true)
+  })
+
+  it('is written where changesets will pick it up', () => {
+    expect(MANAGED_CHANGESET.startsWith('.changeset/')).toBe(true)
+    expect(MANAGED_CHANGESET.endsWith('.md')).toBe(true)
+  })
+})

--- a/scripts/plan-create-app-bump.ts
+++ b/scripts/plan-create-app-bump.ts
@@ -1,0 +1,190 @@
+/**
+ * Add the `create-guren-app` bump a release needs, before `changeset version`
+ * runs.
+ *
+ * The scaffold's `@guren/*` ranges are generated from the workspace versions, so
+ * any release that moves one of them also has to republish the scaffolder — see
+ * `assertCreateAppRepublishes` in `sync-template-deps.ts` for why. That refusal
+ * fired on both the v2.7.0 and v2.7.1 releases, and each time the recovery was a
+ * human writing a `create-guren-app: patch` changeset and starting the release
+ * over. This removes the recovery, not the refusal.
+ *
+ * The refusal stays as the backstop for what cannot be predicted here — a
+ * hand-edited template, most of all. It is a narrower backstop than it looks:
+ * `sync-template-deps` returns before asserting when it rewrote nothing, so it
+ * only covers a release that moved a range. For `@guren/*` ranges that is always
+ * the case, since they can only move at `changeset version`. A drizzle pin is
+ * different: `audit:template-deps` forces it to be synced in the ordinary PR
+ * that moved it, so by release time there is nothing left to rewrite and nothing
+ * asserts. That case is covered by neither half and is out of scope here.
+ *
+ * Deliberately writes a changeset rather than editing a version: changesets
+ * stays the one place a release is described, so the bump appears in the release
+ * PR diff and in the changelog like any other.
+ *
+ * Failing here is safe — under-bumping only puts the release back in the state
+ * above — so every path says out loud what it decided. A silent run is
+ * indistinguishable from a script that never executed.
+ */
+import { readFile, unlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { templateManifests } from '../packages/create-app/src/blueprints'
+import { DEPENDENCY_GROUPS } from './sync-template-deps'
+import { repoRoot } from './workspace-packages'
+
+const SCAFFOLDER = 'create-guren-app'
+
+/** The changeset this script owns; removed at the start of every run. */
+export const MANAGED_CHANGESET = '.changeset/create-app-template-ranges.md'
+
+/** One entry of `changeset status --output`; the rest of its fields go unread. */
+interface PlannedRelease {
+  name: string
+  oldVersion: string
+  newVersion: string
+}
+
+export interface ReleasePlan {
+  releases: PlannedRelease[]
+}
+
+export type BumpDecision =
+  | { bump: true; moving: string[] }
+  | { bump: false; reason: 'no-release' | 'already-releasing' | 'templates-unaffected' }
+
+/**
+ * Not every entry in the plan publishes something. Changesets lists a package it
+ * pulled in but left alone as `type: "none"`, with its version unchanged, and
+ * such an entry rewrites no range and uploads no tarball.
+ */
+function publishes(release: PlannedRelease): boolean {
+  return release.newVersion !== release.oldVersion
+}
+
+/** Every `@guren/*` package whose version a template writes into its manifest. */
+export async function packagesTemplatesDeclare(): Promise<Set<string>> {
+  const declared = new Set<string>()
+
+  for (const path of await templateManifests()) {
+    const manifest = JSON.parse(await readFile(path, 'utf8')) as Record<string, unknown>
+    for (const group of DEPENDENCY_GROUPS) {
+      const dependencies = manifest[group] as Record<string, string> | undefined
+      for (const dependency of Object.keys(dependencies ?? {})) {
+        if (dependency.startsWith('@guren/')) {
+          declared.add(dependency)
+        }
+      }
+    }
+  }
+
+  return declared
+}
+
+/**
+ * Does this release move a version a template declares?
+ *
+ * The answer has to agree with whether `sync-template-deps` rewrites a range,
+ * because a rewritten range is what makes the scaffolder's tarball stale. Hence
+ * the shared `DEPENDENCY_GROUPS` and the version comparison rather than a bare
+ * name match — the plan carries entries that publish nothing, and bumping the
+ * scaffolder for one would upload a tarball identical to the last.
+ */
+export function planScaffolderBump(plan: ReleasePlan, declared: ReadonlySet<string>): BumpDecision {
+  if (plan.releases.length === 0) {
+    return { bump: false, reason: 'no-release' }
+  }
+
+  if (plan.releases.some((release) => release.name === SCAFFOLDER && publishes(release))) {
+    return { bump: false, reason: 'already-releasing' }
+  }
+
+  const moving = plan.releases
+    .filter((release) => publishes(release) && declared.has(release.name))
+    .map((release) => release.name)
+
+  return moving.length === 0 ? { bump: false, reason: 'templates-unaffected' } : { bump: true, moving }
+}
+
+export function renderChangeset(moving: readonly string[]): string {
+  return [
+    '---',
+    `"${SCAFFOLDER}": patch`,
+    '---',
+    '',
+    'Ship template dependency ranges for this release',
+    '',
+    "The scaffold's `@guren/*` ranges are generated from the workspace versions,",
+    `and this release moves ${moving.map((name) => `\`${name}\``).join(', ')}.`,
+    '`changeset publish` only uploads packages whose own version moved, so',
+    'without this bump the updated ranges would sit in the repo and never reach',
+    'anyone running `create-guren-app`.',
+    '',
+    'No behaviour change; the scaffolded app just resolves the versions released',
+    'alongside it.',
+    '',
+  ].join('\n')
+}
+
+/**
+ * Ask changesets what this release will publish.
+ *
+ * Spawns the workspace's own `changeset` rather than `bunx changeset`: the
+ * plan's shape belongs to a particular `@changesets/cli`, and `bunx` will
+ * quietly fetch a different one from the registry when the workspace is not
+ * installed. A missing binary is a broken checkout, and saying so beats planning
+ * a release against whatever npm happened to hand over.
+ */
+async function readReleasePlan(): Promise<ReleasePlan> {
+  const bin = join(repoRoot, 'node_modules/.bin/changeset')
+  if (!(await Bun.file(bin).exists())) {
+    throw new Error(`${bin} is missing. Run \`bun install\` before preparing a release.`)
+  }
+
+  const output = join(tmpdir(), `guren-release-plan-${process.pid}.json`)
+  const status = Bun.spawnSync([bin, 'status', `--output=${output}`], {
+    cwd: repoRoot,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  if (!status.success) {
+    throw new Error(
+      `\`changeset status\` failed (exit ${status.exitCode}):\n${status.stderr.toString().trim()}`,
+    )
+  }
+
+  try {
+    return JSON.parse(await readFile(output, 'utf8')) as ReleasePlan
+  } finally {
+    await unlink(output).catch(() => {})
+  }
+}
+
+async function main(): Promise<void> {
+  // Before the plan is read, so a bump left behind by an abandoned release is
+  // not mistaken for a maintainer's own decision to publish the scaffolder: it
+  // would put `create-guren-app` in the plan, this script would see it already
+  // there and stay silent, and the stale bump would ship.
+  await unlink(join(repoRoot, MANAGED_CHANGESET)).catch(() => {})
+
+  const decision = planScaffolderBump(await readReleasePlan(), await packagesTemplatesDeclare())
+
+  if (!decision.bump) {
+    const reasons = {
+      'no-release': 'No changesets are pending, so there is no release to prepare.',
+      'already-releasing': `${SCAFFOLDER} is already in the release plan; nothing to add.`,
+      'templates-unaffected': `No package the templates declare is releasing; ${SCAFFOLDER} does not need a bump.`,
+    }
+    console.log(reasons[decision.reason])
+    return
+  }
+
+  await writeFile(join(repoRoot, MANAGED_CHANGESET), renderChangeset(decision.moving), 'utf8')
+  console.log(`Wrote ${MANAGED_CHANGESET}: ${SCAFFOLDER} patch, because ${decision.moving.join(', ')} moved.`)
+}
+
+if (import.meta.path === Bun.main) {
+  await main()
+}

--- a/scripts/sync-template-deps.ts
+++ b/scripts/sync-template-deps.ts
@@ -30,7 +30,18 @@ import {
 } from '../packages/cli/src/drizzle-pins'
 import { collectPackages, repoRoot } from './workspace-packages'
 
-const DEPENDENCY_GROUPS = ['dependencies', 'devDependencies', 'peerDependencies'] as const
+/**
+ * The groups this script rewrites a template's ranges in. Exported because
+ * `plan-create-app-bump.ts` has to predict, before `changeset version` runs,
+ * whether this script will rewrite anything — a group it read and this one did
+ * not would be a release that rewrites a range and plans no scaffolder bump.
+ *
+ * Deliberately not the four-group list in `scripts/smoke/local-packages.ts`:
+ * that one answers which packages a smoke must vendor, and a group there costs
+ * nothing extra, while a group here would rewrite a range this script does not
+ * own.
+ */
+export const DEPENDENCY_GROUPS = ['dependencies', 'devDependencies', 'peerDependencies'] as const
 
 const ORM_MANIFEST = 'packages/orm/package.json'
 


### PR DESCRIPTION
## Why

The scaffold's `@guren/*` ranges in `packages/create-app/templates/*/package.json` are generated from the workspace versions, so any release that moves one of them also has to republish `create-guren-app`. `changeset publish` only uploads packages whose own version moved, so without that bump the rewritten ranges sit in the repo and reach nobody.

`sync-template-deps --release` already refuses such a release (`assertCreateAppRepublishes`). That refusal is correct and stays. What this PR removes is the recovery: it fired on both the v2.7.0 and v2.7.1 releases, and each time a human read it, hand-wrote a `create-guren-app: patch` changeset, and re-ran `version-packages` from the top.

## What

`scripts/plan-create-app-bump.ts` runs ahead of `changeset version`. It reads the release plan (`changeset status --output`), collects every `@guren/*` package the templates declare (via `templateManifests()`), and writes `.changeset/create-app-template-ranges.md` when the plan moves one of them and the scaffolder is not already releasing.

It writes a changeset rather than editing a version, so changesets stays the single description of a release and the bump shows up in the release PR diff and the changelog like anything else.

A few details worth calling out:

- **It is a preparation step, not a gate.** `sync-template-deps --release` still runs and still refuses; it remains the backstop for what this script cannot see (a drizzle pin moving, a hand-edited template). Failing here is therefore safe, which is why every path prints what it decided rather than exiting quietly.
- **It removes its own changeset before reading the plan.** Otherwise a bump planned for a release that was then abandoned would put the scaffolder in the next plan, and the script — seeing it already there — would stay silent and let the stale bump ship.
- **It spawns the workspace's `changeset` binary, not `bunx changeset`.** The plan JSON's shape belongs to a particular `@changesets/cli`, and `bunx` quietly fetches a different one from the registry when the workspace is not installed. A missing binary is now a loud error.

## Verification

Both directions were run end to end against the real release machinery, not just unit-tested.

**Positive — `@guren/cli` patch changeset, full `bun run version-packages`:**

```
Wrote .changeset/create-app-template-ranges.md: create-guren-app patch (@guren/cli is releasing).
🦋  All files have been updated. Review them and commit at your leisure
packages/create-app/templates/default/package.json: @guren/cli ^2.6.1 -> ^2.6.2
packages/create-app/templates/api-only/package.json: @guren/cli ^2.6.1 -> ^2.6.2
plugin compatibility audit passed (12 @guren/* ranges, 3 plugin manifests, against @guren/core 1.6.2).
```

Exit 0 — `sync-template-deps --release` no longer refuses. `create-guren-app` went 1.8.2 → 1.8.3 with the changelog entry. The version bump was then discarded; no release is committed here.

**Negative — `@guren/plugin-cloudflare` patch changeset:**

```
No package the templates declare is releasing; create-guren-app does not need a bump.
Template dependency versions already match the workspace.
```

The second line is the part that makes the silence trustworthy: after `changeset version`, `sync-template-deps --release` rewrote no range at all and never reached `assertCreateAppRepublishes`. Staying quiet agreed with the actual contract, rather than merely producing no output.

Also verified by hand: a leftover managed changeset with no pending release is removed; a maintainer's own `create-guren-app` changeset is left alone; a checkout with no `node_modules/.bin/changeset` errors instead of silently planning against a registry copy.

## Tests

`scripts/plan-create-app-bump.test.ts`, picked up by the existing `scripts/**/*.test.ts` glob in `test-packages.ts`. It pins both directions, because a script that always bumps looks identical to a working one on the release that needs the bump. The negative case reads the **real** template manifests rather than a mocked set, so it cannot go vacuous the day a template starts depending on a deploy plugin. Both directions were mutation-checked (always-bump and declares-nothing each fail exactly one test).

`bun run build`, `bun run typecheck`, `bun run test:bun` (4501 pass / 0 fail), `bun run audit:template-deps`, `bun run audit:core-first` all pass. No changeset for this PR — it is repo tooling, not a published package.
