### PR TITLE
fix(create-app,web): refuse any scheme in the sqlite drizzle config

### DIFF
--- a/.changeset/sqlite-drizzle-config-scheme-guard.md
+++ b/.changeset/sqlite-drizzle-config-scheme-guard.md
@@ -1,0 +1,36 @@
+---
+"create-guren-app": patch
+---
+
+Refuse a scheme in DATABASE_URL for scaffolded SQLite apps
+
+`DATABASE_URL` names the SQLite database for two different implementations. The
+app opens it with `bun:sqlite`, which honours URI filenames; drizzle-kit opens
+it with `node:sqlite`, which does not. So `file:` is not a shared spelling of
+anything:
+
+| `DATABASE_URL` | app | drizzle-kit |
+| --- | --- | --- |
+| `./data/guren.db` | `data/guren.db` | same |
+| `file:local.db` | `local.db` | a file *named* `file:local.db` |
+| `file::memory:` | in-memory | a file *named* `file::memory:` |
+| `file:///abs.db` | `/abs.db` | fails to open |
+
+The first two rows are the dangerous ones: neither side errors, so migrations
+land in one database while the app reads another — the same silent split a
+connection string used to cause before `@guren/orm` started rejecting those.
+
+The generated `drizzle.config.ts` now refuses any scheme rather than only one
+carrying an authority, so the accepted set is what both implementations agree
+on: plain paths and `:memory:`. The scheme must be two characters or more,
+since no registered scheme is one letter while `C:/data/app.db` is a Windows
+drive path.
+
+Postgres and MySQL are untouched — `DATABASE_URL` really is a connection string
+there, and their generated config is byte-identical to before.
+
+Note this is deliberately stricter than the rule `@guren/orm` applies to
+`createSqliteDatabase({ filename })`, which accepts `file:` URIs. There
+`bun:sqlite` is the only consumer and the URI forms genuinely work; the
+config's value has to satisfy both implementations, so its safe set is the
+intersection.

--- a/packages/create-app/src/blueprints.ts
+++ b/packages/create-app/src/blueprints.ts
@@ -373,14 +373,45 @@ async function resolveSchema(destination: string, driver: DatabaseDriver): Promi
 function generateDrizzleConfig(driver: DatabaseDriver): string {
   const { url, dialect } = DATABASE_DEFAULTS[driver]
 
-  return `import { defineConfig } from 'drizzle-kit'
+  // Only SQLite names a file. Postgres and MySQL take a real connection string
+  // here, so the scheme check would reject every valid value they have.
+  const preamble =
+    driver !== 'sqlite'
+      ? ''
+      : `
+const filename = process.env.DATABASE_URL ?? '${url}'
 
+/**
+ * DATABASE_URL is read by two different SQLite implementations that disagree
+ * about URI filenames: the app opens it with \`bun:sqlite\`, which honours them,
+ * while drizzle-kit opens it with \`node:sqlite\`, which does not. So \`file:\` is
+ * not a shared spelling of anything — \`file:local.db\` migrates the app into
+ * \`local.db\` and drizzle-kit into a file *named* \`file:local.db\`. The safe set
+ * is what both agree on: plain paths, and \`:memory:\`.
+ *
+ * The scheme must be two characters or more, since no registered scheme is one
+ * letter while \`C:/data/app.db\` is a Windows drive path.
+ */
+const uriScheme = /^([a-z][a-z0-9+.-]+):/i.exec(filename)
+
+if (uriScheme) {
+  throw new Error(
+    \`DATABASE_URL must be a plain file path for SQLite, but starts with "\${uriScheme[1]}:". \` +
+      'Point it at a file such as ${url}, or use ":memory:".',
+  )
+}
+`
+
+  const credentialUrl = driver === 'sqlite' ? 'filename' : `process.env.DATABASE_URL ?? '${url}'`
+
+  return `import { defineConfig } from 'drizzle-kit'
+${preamble}
 export default defineConfig({
   schema: './db/schema.ts',
   out: './db/migrations',
   dialect: '${dialect}',
   dbCredentials: {
-    url: process.env.DATABASE_URL ?? '${url}',
+    url: ${credentialUrl},
   },
 })
 `

--- a/packages/create-app/tests/drizzle-config-guard.test.ts
+++ b/packages/create-app/tests/drizzle-config-guard.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { scaffoldAppBlueprint } from '../src/blueprints'
+import { createTempWorkspace } from './helpers'
+
+/**
+ * `DATABASE_URL` names the SQLite database for two different implementations:
+ * the app opens it with `bun:sqlite`, drizzle-kit with `node:sqlite`. Only the
+ * first honours URI filenames, so `file:local.db` migrates the app into
+ * `local.db` and drizzle-kit into a file *named* `file:local.db` — two
+ * databases, no error from either. The generated config refuses any scheme so
+ * that split cannot happen, and these tests run the generated file rather than
+ * matching its text, so a guard that is present but inert still fails.
+ *
+ * Postgres and MySQL take a real connection string here and must not inherit
+ * the check.
+ */
+function runGeneratedConfig(source: string, databaseUrl?: string): { dbCredentials: { url: string } } {
+  const body = source
+    .replace("import { defineConfig } from 'drizzle-kit'", 'const defineConfig = (config) => config')
+    .replace('export default ', 'return ')
+
+  return new Function('process', body)({ env: { DATABASE_URL: databaseUrl } })
+}
+
+async function generateConfig(driver: 'sqlite' | 'postgres' | 'mysql'): Promise<string> {
+  const workspace = await createTempWorkspace(`guren-drizzle-guard-${driver}-`)
+  try {
+    const dest = join(workspace.dir, 'test-app')
+    await scaffoldAppBlueprint({ destination: dest, renderingMode: 'spa', database: driver })
+    return await readFile(join(dest, 'drizzle.config.ts'), 'utf8')
+  } finally {
+    await workspace.cleanup()
+  }
+}
+
+describe('generated drizzle.config.ts DATABASE_URL guard', () => {
+  it('refuses a connection string for --db sqlite', async () => {
+    const config = await generateConfig('sqlite')
+
+    expect(() => runGeneratedConfig(config, 'postgres://guren:guren@localhost:54322/guren')).toThrow(
+      /must be a plain file path/,
+    )
+  })
+
+  // The value both guards used to allow, and the one that splits silently
+  // rather than failing: neither implementation errors on it.
+  it('refuses a file: URI for --db sqlite', async () => {
+    const config = await generateConfig('sqlite')
+
+    expect(() => runGeneratedConfig(config, 'file:local.db')).toThrow(/must be a plain file path/)
+    expect(() => runGeneratedConfig(config, 'file::memory:')).toThrow(/must be a plain file path/)
+  })
+
+  it.each(['./data/guren.db', '/srv/data/app.db', 'data/app.db', ':memory:', 'C:/data/app.db'])(
+    'accepts %p for --db sqlite',
+    async (url) => {
+      const config = await generateConfig('sqlite')
+
+      expect(runGeneratedConfig(config, url).dbCredentials.url).toBe(url)
+    },
+  )
+
+  it('falls back to the default path when DATABASE_URL is unset', async () => {
+    const config = await generateConfig('sqlite')
+
+    expect(runGeneratedConfig(config, undefined).dbCredentials.url).toBe('./data/guren.db')
+  })
+
+  it.each(['postgres', 'mysql'] as const)('leaves a %s connection string alone', async (driver) => {
+    const config = await generateConfig(driver)
+    const url = driver === 'postgres' ? 'postgres://guren@localhost:54322/guren' : 'mysql://guren@localhost:33306/guren'
+
+    expect(runGeneratedConfig(config, url).dbCredentials.url).toBe(url)
+  })
+})

--- a/web/drizzle.config.ts
+++ b/web/drizzle.config.ts
@@ -9,17 +9,30 @@ import { defineConfig } from 'drizzle-kit'
 const filename = process.env.SQLITE_DATABASE_PATH ?? './data/guren.db'
 
 /**
- * `file:local.db` and `:memory:` are legitimate sqlite values, so this matches
- * only a scheme *with* an authority — the shape of a connection string that
- * sqlite would otherwise silently accept as a filename.
+ * This variable is read by two different SQLite implementations that disagree
+ * about URI filenames: the app opens it with `bun:sqlite`, which honours them,
+ * while drizzle-kit opens it with `node:sqlite`, which does not. So `file:` is
+ * not a shared spelling of anything — `file:local.db` migrates the app into
+ * `local.db` and drizzle-kit into a file *named* `file:local.db`, which is the
+ * silent split this variable exists to avoid. The safe set is what both agree
+ * on: plain paths, and `:memory:`.
+ *
+ * Hence any scheme is refused, not just one carrying an authority. The scheme
+ * must be two characters or more, since no registered scheme is one letter
+ * while `C:/data/app.db` is a Windows drive path. `@guren/orm` applies a
+ * narrower rule to the app's own filename, where `bun:sqlite` is the only
+ * consumer and URI forms do work.
  */
-const uriScheme = /^([a-z+]+):\/\//i.exec(filename)
+const uriScheme = /^([a-z][a-z0-9+.-]+):/i.exec(filename)
 
 if (uriScheme) {
   throw new Error(
-    `SQLITE_DATABASE_PATH must be a file path, but starts with "${uriScheme[1]}://". ` +
-      'This app runs on SQLite locally and D1 in production through the wrangler ' +
-      'binding — there is no connection string.',
+    `SQLITE_DATABASE_PATH must be a plain file path, but starts with "${uriScheme[1]}:". ` +
+      (uriScheme[1].toLowerCase() === 'file'
+        ? 'drizzle-kit reads a `file:` URI as a literal filename while the app resolves it ' +
+          'as a URI, so the two would open different databases. Drop the scheme.'
+        : 'This app runs on SQLite locally and D1 in production through the wrangler ' +
+          'binding — there is no connection string.'),
   )
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #437 and #438. Those two landed scheme guards on the same variable from opposite ends and disagreed about `file:`, so I measured what the two consumers actually do. The answer is that neither guard was right, and the divergence was not the real problem.

The variable naming the SQLite database is read by **two different SQLite implementations**: the app opens it with `bun:sqlite`, which honours URI filenames, and drizzle-kit opens it with `node:sqlite`, which does not. So `file:` is not a shared spelling of anything:

| value | app (`bun:sqlite`) | drizzle-kit (`node:sqlite`) | |
| --- | --- | --- | --- |
| `./data/guren.db` | `data/guren.db` | same | agree |
| `:memory:` | in-memory | in-memory | agree |
| `file:local.db` | `local.db` | a file *named* `file:local.db` | **silent split** |
| `file::memory:` | in-memory | a file *named* `file::memory:` | **silent split** |
| `file:///abs.db` | `/abs.db` | fails to open | loud |
| `C://d/w.db` | opens | fails to open | loud |

The first two divergences are the dangerous ones: neither side errors. `SQLITE_DATABASE_PATH=file:local.db` migrates the app into `local.db` (49KB, real tables) and leaves drizzle-kit with an empty `file:local.db`. That is exactly the split #437 set out to close, and **both** current guards allow it, because both only match a scheme carrying an authority.

So this widens the check from "scheme with authority" to "any scheme", leaving the set both implementations agree on: plain paths and `:memory:`.

```
- /^([a-z+]+):\/\//i
+ /^([a-z][a-z0-9+.-]+):/i
```

The two-character minimum keeps `C:/data/app.db` valid, since no registered scheme is one letter while that is a Windows drive path.

## Why this does *not* match `@guren/orm`'s rule

Deliberately. `createSqliteDatabase({ filename })` is a framework API whose only consumer is `bun:sqlite`, where `file:` URIs genuinely work — #438 accepts them for that reason and should keep doing so. A config value has to satisfy **both** implementations, so its safe set is the intersection. Converging the two rules, in either direction, would make one of them wrong. I noted the divergence as something to reconcile in #438's description; that was the wrong conclusion and this supersedes it.

## Scope

- `web/drizzle.config.ts` — widened guard, and the error now explains the `file:` case specifically rather than talking about connection strings for every scheme.
- `packages/create-app/src/blueprints.ts` — same guard in the generated `drizzle.config.ts`, **sqlite only**. Postgres and MySQL take a real connection string there; their generated output is byte-identical to before (verified by rendering both).
- New `packages/create-app/tests/drizzle-config-guard.test.ts`.

Scaffolded apps had the same hole: their `config/database.ts` and `drizzle.config.ts` both read `DATABASE_URL`, so `file:local.db` split them the same way.

## Risk Assessment

Narrowing what an env var accepts. Every value that previously pointed both halves at the *same* database still works. The values now refused are the ones that pointed them at different databases, or that only one of them could open. `:memory:` and plain paths are unaffected.

The static `templates/*/drizzle.config.ts` files are left alone: `applyDatabaseConfig` overwrites that path unconditionally during scaffolding, so the generator is the only thing that reaches a user.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck` — 0 errors
- [x] `bun run test` — `test:bun` 4512 pass / 0 fail; `create-app` 64 pass / 0 fail
- [x] `audit:starter-template`, `audit:template-deps`, `audit:core-first`, `audit:docs`, `audit:contracts` — all pass
- [x] `smoke:starter` exit 0 (18 passed), `smoke:starter:api` exit 0 (4 passed) — required here since templates changed

The new tests **execute** the generated config rather than matching its text, so a guard that is present but inert still fails. Mutation-checked: restoring the authority-only rule fails exactly one test, the `file:` one — the behavior this PR is about.

End-to-end against `web`:

```
file:local.db    -> Error  ... starts with "file:". drizzle-kit reads a `file:` URI as a
                    literal filename while the app resolves it as a URI ...
postgres://a/b   -> Error  ... starts with "postgres:". ... there is no connection string.
./data/guren.db  -> Everything's fine 🐶🔥
:memory:         -> Everything's fine 🐶🔥
```

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation — the rule and its rationale live in the config comments, including why it differs from `@guren/orm`'s. `audit:docs` passes.
