### PR TITLE
fix(cli): report the CLI version for --version

### DIFF
--- a/.changeset/cli-version-flag.md
+++ b/.changeset/cli-version-flag.md
@@ -25,6 +25,14 @@ instance. citty ignores flags it does not recognise, so without a working
 `--version` there was no cheap way to detect an older CLI: passing an
 unsupported flag to it exits 0 and silently does something else.
 
+The version prints on plain stdout, like every other command that emits a
+payload rather than a diagnostic (`model:list`, `context`, `route:list`). citty's
+own `runMain` logs it through consola, which makes the version unreadable
+exactly where it gets read: consola's non-TTY reporter prefixes the level, so CI
+and any piped caller saw `[log] 2.6.1`, and a configured log level could drop the
+line entirely. `guren --version` now emits a bare version line regardless of
+`CI`, `NODE_ENV`, or log level.
+
 An unreadable manifest leaves `meta.version` unset rather than throwing. The
 root command module is evaluated for every command, so that failure costs only
 `--version`, which falls back to the message above, and never `make:model`.

--- a/.changeset/cli-version-flag.md
+++ b/.changeset/cli-version-flag.md
@@ -1,0 +1,30 @@
+---
+"@guren/cli": patch
+---
+
+Report the CLI version for `guren --version`
+
+`guren --version` printed `ERROR  No version specified` and exited 1, behind a
+full usage dump. The root command is built with citty, whose `--version`
+handler reads `meta.version`, and the root command's `meta` only ever set
+`name` and `description` — so the flag reported the absence of a version rather
+than the version.
+
+The root command now carries its own package version, read from the manifest at
+startup rather than written into the source as a literal, which would drift at
+every release:
+
+```
+$ guren --version
+2.6.1
+```
+
+This is the obvious capability probe for tooling and AI agents that need to know
+which Guren CLI an app has — whether `agent:init --target` is available, for
+instance. citty ignores flags it does not recognise, so without a working
+`--version` there was no cheap way to detect an older CLI: passing an
+unsupported flag to it exits 0 and silently does something else.
+
+An unreadable manifest leaves `meta.version` unset rather than throwing. The
+root command module is evaluated for every command, so that failure costs only
+`--version`, which falls back to the message above, and never `make:model`.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
-import { pathToFileURL } from 'node:url'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { consola } from 'consola'
 import { defineCommand, showUsage } from 'citty'
 import type { CommandDef } from 'citty'
@@ -2650,10 +2651,36 @@ try {
   consola.warn(`Failed to discover plugin commands: ${error instanceof Error ? error.message : String(error)}`)
 }
 
+/**
+ * This package's own version, for `guren --version`. Read from the manifest
+ * rather than written here as a literal, which would drift at every
+ * `changeset version`.
+ *
+ * `../package.json` is this package's root from either layout: built output
+ * puts `bin.js` directly in `dist/`, and running from source puts `bin.ts`
+ * directly in `src/` — the same idiom `agent-harness.ts` uses to find
+ * `templates/`.
+ *
+ * Returns `undefined` rather than throwing: this module is evaluated for
+ * every command, so an unreadable manifest must cost only `--version` (which
+ * falls back to the usage-plus-error path in `runCli`) and not take
+ * `make:model` down with it.
+ */
+function readOwnVersion(): string | undefined {
+  try {
+    const manifestPath = fileURLToPath(new URL('../package.json', import.meta.url))
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { version?: unknown }
+    return typeof manifest.version === 'string' ? manifest.version : undefined
+  } catch {
+    return undefined
+  }
+}
+
 const main = defineCommand({
   meta: {
     name: 'guren',
     description: 'Guren framework CLI utilities.',
+    version: readOwnVersion(),
   },
   args: {
     help: {

--- a/packages/cli/src/run-cli.ts
+++ b/packages/cli/src/run-cli.ts
@@ -82,7 +82,13 @@ export async function runCli(cmd: AnyCommandDef, rawArgs: string[]): Promise<num
       if (!meta?.version) {
         return failWithUsage('No version specified')
       }
-      consola.log(meta.version)
+      // Plain stdout, like every other command that prints a payload rather
+      // than a diagnostic (`model:list`, `context`, `route:list`). citty's own
+      // `runMain` uses `consola.log` here, which makes the version unreadable
+      // exactly where it gets read: consola's non-TTY reporter prefixes the
+      // level, so CI and any piped caller see `[log] 2.6.1`, and a configured
+      // log level can drop the line entirely.
+      console.log(meta.version)
       return 0
     }
 

--- a/packages/cli/tests/bin-version.test.ts
+++ b/packages/cli/tests/bin-version.test.ts
@@ -18,10 +18,18 @@ async function manifestVersion(): Promise<string> {
 }
 
 async function runBin(bin: string, args: string[], cwd: string): Promise<{ exitCode: number; stdout: string }> {
-  // `bun test` sets NODE_ENV=test, which drops consola below the log level
-  // `--version` prints at. Real invocations do not.
-  const { NODE_ENV: _testEnv, ...env } = process.env
-  const proc = Bun.spawn(['bun', bin, ...args], { cwd, env, stdout: 'pipe', stderr: 'pipe' })
+  // Deliberately keeps the environment `bun test` provides, including
+  // NODE_ENV=test. The version is a payload, not a diagnostic, so neither
+  // consola's log level nor its reporter may touch it: under NODE_ENV=test
+  // consola sits at the warn level and would drop the line entirely, and
+  // CI=1 selects the non-TTY reporter that prefixes it (`[log] 2.6.1`).
+  // Both shapes are how a script or an agent actually invokes this.
+  const proc = Bun.spawn(['bun', bin, ...args], {
+    cwd,
+    env: { ...process.env, CI: '1' },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
   const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
   return { exitCode, stdout: stripAnsi(stdout) }
 }
@@ -42,9 +50,11 @@ describe('guren --version', () => {
         const { exitCode, stdout } = await runBin(bin, ['--version'], workspace.dir)
 
         expect(exitCode).toBe(0)
-        // Other packages can log to stdout during module load (@guren/orm's
-        // duplicate-copy warning, for one), so assert the version is among
-        // the output lines rather than that it is all of it.
+        // A dependency can log to stdout while the module graph loads
+        // (@guren/orm's duplicate-copy warning is one), so look for the
+        // version among the lines rather than expecting it to be all of the
+        // output — but require a line that is *exactly* the version, which a
+        // reporter-prefixed `[log] 2.6.1` would not satisfy.
         const lines = stdout.split('\n').map((line) => line.trim())
         expect(lines).toContain(await manifestVersion())
       } finally {

--- a/packages/cli/tests/bin-version.test.ts
+++ b/packages/cli/tests/bin-version.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { stripAnsi } from 'consola/utils'
+import {
+  CLI_BIN_PATH,
+  CLI_DIST_BIN,
+  SERVER_DIST_ENTRY,
+  assertWorkspaceBuilt,
+  createTempWorkspace,
+} from './helpers'
+
+const MANIFEST_PATH = join(import.meta.dir, '../package.json')
+
+async function manifestVersion(): Promise<string> {
+  const manifest = JSON.parse(await readFile(MANIFEST_PATH, 'utf8')) as { version: string }
+  return manifest.version
+}
+
+async function runBin(bin: string, args: string[], cwd: string): Promise<{ exitCode: number; stdout: string }> {
+  // `bun test` sets NODE_ENV=test, which drops consola below the log level
+  // `--version` prints at. Real invocations do not.
+  const { NODE_ENV: _testEnv, ...env } = process.env
+  const proc = Bun.spawn(['bun', bin, ...args], { cwd, env, stdout: 'pipe', stderr: 'pipe' })
+  const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+  return { exitCode, stdout: stripAnsi(stdout) }
+}
+
+describe('guren --version', () => {
+  // The version is read relative to the entry file, so `src/` and `dist/`
+  // are genuinely different resolutions; only the built entry answers the
+  // question an installed app asks. Both run from a temp directory outside
+  // the repo, where no workspace `package.json` can stand in for the CLI's.
+  for (const [label, bin, artifacts] of [
+    ['from source', CLI_BIN_PATH, [SERVER_DIST_ENTRY]],
+    ['from the built entry', CLI_DIST_BIN, [SERVER_DIST_ENTRY, CLI_DIST_BIN]],
+  ] as const) {
+    it(`prints the version from package.json and exits 0 (${label})`, async () => {
+      assertWorkspaceBuilt([...artifacts])
+      const workspace = await createTempWorkspace('guren-cli-version-')
+      try {
+        const { exitCode, stdout } = await runBin(bin, ['--version'], workspace.dir)
+
+        expect(exitCode).toBe(0)
+        // Other packages can log to stdout during module load (@guren/orm's
+        // duplicate-copy warning, for one), so assert the version is among
+        // the output lines rather than that it is all of it.
+        const lines = stdout.split('\n').map((line) => line.trim())
+        expect(lines).toContain(await manifestVersion())
+      } finally {
+        await workspace.cleanup()
+      }
+    })
+  }
+})

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -12,6 +12,14 @@ const repoRoot = resolve(import.meta.dir, '../../..')
 export const CLI_BIN_PATH = join(repoRoot, 'packages/cli/src/bin.ts')
 
 /**
+ * The *built* CLI entry, for assertions about how the published package
+ * behaves rather than how the sources do. `CLI_BIN_PATH` runs from `src/`,
+ * where anything resolved relative to `import.meta.url` lands somewhere else
+ * than it does in `dist/`.
+ */
+export const CLI_DIST_BIN = join(repoRoot, 'packages/cli/dist/bin.js')
+
+/**
  * The built artifact this package's tests reach `@guren/server` through.
  * `@guren/core` resolves to source, but its `export * from '@guren/server'`
  * follows the workspace symlink to server's `exports`, which point at


### PR DESCRIPTION
## Summary

`guren --version` printed `ERROR  No version specified` and exited 1, behind a full usage dump. Reproduced against `@guren/cli` 2.6.1, both via `bunx guren` and `bun packages/cli/src/bin.ts`.

The root command is built with citty, whose `--version` handling reads `meta.version`, and the root command's `meta` in `packages/cli/src/bin.ts` only ever set `name` and `description`. So the flag reported the absence of a version rather than the version. Note the code path is not citty's own `runMain` but `runCli` in `packages/cli/src/run-cli.ts`, which deliberately stands in for it and mirrors that `meta.version` branch.

This is the obvious capability probe for tooling and AI agents that need to know which Guren CLI an app has — whether `agent:init --target` from 2.5.0 is available, for instance. citty ignores flags it does not recognise, so without a working `--version` there was no cheap way to detect an older CLI: passing an unsupported flag to it exits 0 and silently does something else.

The root command now carries its own package version, read from the manifest at startup rather than written into the source as a literal, which would drift at every `changeset version`:

```
$ guren --version
2.6.1
```

**No existing helper fit.** `guren upgrade` and the plugin compatibility check both reason about the *app's* installed versions and the npm registry; nothing in `packages/cli/src` read this package's own manifest. The new `readOwnVersion()` instead follows the house idiom for package-relative resources — `new URL('../package.json', import.meta.url)`, the same shape `agent-harness.ts` uses to find `templates/` and `docs-viewer.ts` to find `assets/`. `../package.json` is the package root from either layout, since built output puts `bin.js` directly in `dist/` and sources put `bin.ts` directly in `src/`.

A JSON import (`with { type: 'json' }`) was rejected: esbuild inlines it, turning the version into a build-time constant and defeating the point of reading it.

### The version prints on plain stdout

CI caught a second half to this. citty's `runMain` logs the version through consola, and `runCli` mirrored that — which makes the version unreadable exactly where it gets read. consola's non-TTY reporter prefixes the level, so CI and any piped caller got `[log] 2.6.1`; and under a raised log level (`NODE_ENV=test` puts consola at warn) the line vanished entirely. Since the whole point of `--version` is to be a capability probe for tooling and agents, and CI is where such a probe runs, that defeated the fix.

It now uses `console.log`, matching every other command that emits a payload rather than a diagnostic — `model:list`, `context` and `route:list` all print through `console.log`, and none of them uses `consola.log`. Verified bare across environments:

```
<none>                       => 2.6.1
CI=true                      => 2.6.1
NODE_ENV=test                => 2.6.1
CI=true NODE_ENV=production  => 2.6.1
```

## Scope

- `cli` — `src/bin.ts` (fix), `tests/bin-version.test.ts` (new), `tests/helpers.ts` (new `CLI_DIST_BIN` constant)
- changeset: `@guren/cli` patch

No templates, docs, or other packages touched.

## Risk Assessment

**An unreadable manifest degrades rather than throws.** `readOwnVersion()` returns `undefined` on any failure. This module is evaluated for every command, so an eager throw would take `make:model` down with it; instead the cost is confined to `--version`, which falls back to today's message.

**One user-visible side effect:** citty renders `meta.version` in the usage header, so the banner changes from `Guren framework CLI utilities. (guren)` to `(guren v2.6.1)`. Checked that no docs or examples paste that string verbatim.

**No release-plumbing follow-up needed.** The `@guren/cli` patch bump would normally require a companion `create-guren-app` bump, but #439's `plan-create-app-bump.ts` now writes that changeset ahead of `changeset version`, and this cycle already carries a `create-guren-app: patch` changeset.

Only bare `--version` is handled, since `run-cli.ts` gates on `rawArgs.length === 1`. No `-v` alias was added; that would be a separate change.

## Validation

The test spawns **both the source and the built entry** from a temp directory outside the repo. The version resolves relative to the entry file, so `src/` and `dist/` are genuinely different resolutions and only the built one answers the question an installed app asks — a src-only test would pass regardless.

It runs with `CI=1` and *keeps* the `NODE_ENV=test` that `bun test` sets, rather than stripping it: those are the two shapes that mangled or suppressed the output, and both are how a script actually invokes this. It requires a line that is exactly the version, which `[log] 2.6.1` does not satisfy. `@guren/orm`'s duplicate-copy warning lands on stdout in a workspace checkout, so the assertion looks for the version among the lines rather than expecting it to be all of the output. The expected value is read from `packages/cli/package.json` at test time so it does not break at every release.

**Mutation-checked, twice:** removing `version` from `meta` turns both tests red (`Received: [""]` for the message path); reverting `console.log` to `consola.log` also turns them red, because under `CI=1` + `NODE_ENV=test` the version is emitted nowhere at all.

Manual check from outside the repo:

```
$ cd "$(mktemp -d)" && bun /path/to/packages/cli/dist/bin.js --version
2.6.1        # exit 0
```

- [x] `bun run build` (`build:clean`)
- [x] `bun run typecheck` — exit 0
- [x] `bun run test` — `test:bun` 4527 pass / 0 fail; `test:examples` 112 pass
- [x] `bun run audit:core-first` — passed
- [x] `bun run audit:docs` — passed

Starter-template audits and smokes were not run: nothing under `packages/create-app/templates/**` or `packages/cli/templates/**` changed.

The first `typecheck` run reported 29 errors from missing `.guren/*.gen` modules. That was a fresh worktree without codegen, not a regression — green after running codegen in `examples/blog` and `web`.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
