### PR TITLE
fix(orm): load eager relations in QueryBuilder.paginate()

### DIFF
--- a/.changeset/query-builder-paginate-eager-load.md
+++ b/.changeset/query-builder-paginate-eager-load.md
@@ -1,0 +1,17 @@
+---
+"@guren/orm": patch
+---
+
+Load eager relations in `QueryBuilder.paginate()`
+
+`Post.newQuery().with('author').paginate({ page, perPage })` returned the page
+without `author` on any row. `get()` and `first()` both run their rows through
+the builder's eager loader, but `paginate()` returned the adapter's rows as-is,
+so a `.with()` on the chain was accepted and then silently dropped. The blog
+blueprint's `PostController.index` uses exactly this chain, which is why its
+posts index never received `author` and `PostResource.whenLoaded('author')`
+omitted it without an error.
+
+`paginate()` now attaches every relation named on the builder, the same way
+`get()` and `first()` do. `Model.withPaginate()` was the working alternative all
+along and is unchanged.

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -360,11 +360,12 @@ export class QueryBuilder<
   async first(): Promise<TResult | null> {
     const prev = this.options.limitValue
     this.options.limitValue = 1
-    const results = await this.executeQuery()
-    this.options.limitValue = prev
-    if (results.length === 0) return null
-    const loaded = await this.loadEagerRelations(results)
-    return loaded[0] as TResult
+    try {
+      const results = await this.get()
+      return results[0] ?? null
+    } finally {
+      this.options.limitValue = prev
+    }
   }
 
   /**
@@ -432,11 +433,14 @@ export class QueryBuilder<
     this.options.limitValue = sanitizedPerPage
     this.options.offsetValue = offset
 
-    const data = await this.executeQuery()
-
-    // Restore
-    this.options.limitValue = prevLimit
-    this.options.offsetValue = prevOffset
+    // get() is the one path that also attaches `.with()` relations.
+    let data: TResult[]
+    try {
+      data = await this.get()
+    } finally {
+      this.options.limitValue = prevLimit
+      this.options.offsetValue = prevOffset
+    }
 
     const from = total === 0 ? 0 : offset + 1
     const to = total === 0 ? 0 : offset + data.length

--- a/packages/orm/tests/model-enhancements.test.ts
+++ b/packages/orm/tests/model-enhancements.test.ts
@@ -198,59 +198,64 @@ describe('Phase 2: Serialization', () => {
 // =============================================================================
 
 describe('Phase 3: QueryBuilder.with()', () => {
-  it('loads relations via QueryBuilder.with()', async () => {
-    type PostRecord = { id: number; title: string; authorId: number }
+  type PostRecord = { id: number; title: string; authorId: number }
 
-    class User extends Model<UserRecord> {
-      static table = 'users'
-    }
+  // One in-memory adapter over several tables: the eager loader queries the
+  // related table through the same adapter the parent model uses.
+  function createMultiAdapter(stores: Record<string, PlainObject[]>): ORMAdapter {
+    const matches = (where: PlainObject) => (r: PlainObject) =>
+      Object.entries(where).every(([k, v]) => (Array.isArray(v) ? v.includes(r[k]) : r[k] === v))
+    const rows = (table: unknown) => stores[String(table)] ?? []
 
-    class Post extends Model<PostRecord> {
-      static table = 'posts'
-    }
-
-    User.hasMany('posts', Post, 'authorId', 'id')
-
-    const stores = {
-      users: [
-        { id: 1, name: 'Alice' },
-        { id: 2, name: 'Bob' },
-      ] as UserRecord[],
-      posts: [
-        { id: 10, title: 'Post A', authorId: 1 },
-        { id: 11, title: 'Post B', authorId: 1 },
-        { id: 12, title: 'Post C', authorId: 2 },
-      ] as PostRecord[],
-    }
-
-    const multiAdapter: ORMAdapter = {
+    return {
       async findMany<T extends PlainObject>(table: unknown, options?: FindManyOptions<T>): Promise<T[]> {
-        const store = table === 'users' ? stores.users : stores.posts
-        const { where } = options ?? {}
-        let results = where
-          ? store.filter((r) =>
-              Object.entries(where as PlainObject).every(([k, v]) => {
-                if (Array.isArray(v)) return v.includes((r as PlainObject)[k])
-                return (r as PlainObject)[k] === v
-              }),
-            )
-          : [...store]
+        const { where, limit, offset } = options ?? {}
+        let results = where ? rows(table).filter(matches(where as PlainObject)) : [...rows(table)]
+        if (typeof offset === 'number') results = results.slice(offset)
+        if (typeof limit === 'number') results = results.slice(0, limit)
         return results.map((r) => ({ ...r })) as unknown as T[]
       },
       async findUnique<T extends PlainObject>(table: unknown, where: WhereClause<T>): Promise<T | null> {
-        const store = table === 'users' ? stores.users : stores.posts
-        const record = store.find((r) =>
-          Object.entries(where as PlainObject).every(([k, v]) => (r as PlainObject)[k] === v),
-        )
+        const record = rows(table).find(matches(where as PlainObject))
         return (record ? { ...record } : null) as unknown as T | null
       },
       async create<T extends PlainObject>(table: unknown, data: PlainObject): Promise<T> {
         return data as unknown as T
       },
+      async count(table: unknown): Promise<number> {
+        return rows(table).length
+      },
     }
+  }
 
-    User.useAdapter(multiAdapter)
-    Post.useAdapter(multiAdapter)
+  function defineBlog(stores: Record<string, PlainObject[]>) {
+    class User extends Model<UserRecord> {
+      static table = 'users'
+    }
+    class Post extends Model<PostRecord> {
+      static table = 'posts'
+    }
+    User.hasMany('posts', Post, 'authorId', 'id')
+    Post.belongsTo('author', User, 'authorId', 'id')
+
+    const adapter = createMultiAdapter(stores)
+    User.useAdapter(adapter)
+    Post.useAdapter(adapter)
+    return { User, Post }
+  }
+
+  it('loads relations via QueryBuilder.with()', async () => {
+    const { User } = defineBlog({
+      users: [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+      ],
+      posts: [
+        { id: 10, title: 'Post A', authorId: 1 },
+        { id: 11, title: 'Post B', authorId: 1 },
+        { id: 12, title: 'Post C', authorId: 2 },
+      ],
+    })
 
     const users = await User.where({ name: 'Alice' }).with('posts').get() as any[]
     expect(users).toHaveLength(1)
@@ -259,48 +264,52 @@ describe('Phase 3: QueryBuilder.with()', () => {
   })
 
   it('loads relations via first().with()', async () => {
-    type PostRecord = { id: number; title: string; authorId: number }
-
-    class User extends Model<UserRecord> {
-      static table = 'users'
-    }
-
-    class Post extends Model<PostRecord> {
-      static table = 'posts'
-    }
-
-    User.hasMany('posts', Post, 'authorId', 'id')
-
-    const stores = {
-      users: [{ id: 1, name: 'Alice' }] as UserRecord[],
-      posts: [{ id: 10, title: 'Post A', authorId: 1 }] as PostRecord[],
-    }
-
-    const multiAdapter: ORMAdapter = {
-      async findMany<T extends PlainObject>(table: unknown, options?: FindManyOptions<T>): Promise<T[]> {
-        const store = table === 'users' ? stores.users : stores.posts
-        const { where, limit } = options ?? {}
-        let results = where
-          ? store.filter((r) =>
-              Object.entries(where as PlainObject).every(([k, v]) => {
-                if (Array.isArray(v)) return v.includes((r as PlainObject)[k])
-                return (r as PlainObject)[k] === v
-              }),
-            )
-          : [...store]
-        if (typeof limit === 'number') results = results.slice(0, limit)
-        return results.map((r) => ({ ...r })) as unknown as T[]
-      },
-      async findUnique<T extends PlainObject>(): Promise<T | null> { return null },
-      async create<T extends PlainObject>(table: unknown, data: PlainObject): Promise<T> { return data as unknown as T },
-    }
-
-    User.useAdapter(multiAdapter)
-    Post.useAdapter(multiAdapter)
+    const { User } = defineBlog({
+      users: [{ id: 1, name: 'Alice' }],
+      posts: [{ id: 10, title: 'Post A', authorId: 1 }],
+    })
 
     const user = await User.newQuery().with('posts').first() as any
     expect(user).not.toBeNull()
     expect(user.posts).toHaveLength(1)
+  })
+
+  it('loads relations via with().paginate()', async () => {
+    const { Post } = defineBlog({
+      users: [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+      ],
+      posts: [
+        { id: 10, title: 'Post A', authorId: 1 },
+        { id: 11, title: 'Post B', authorId: 2 },
+        { id: 12, title: 'Post C', authorId: 1 },
+      ],
+    })
+
+    const page = await Post.newQuery().with('author').paginate({ page: 1, perPage: 2 }) as any
+    expect(page.meta.total).toBe(3)
+    expect(page.data).toHaveLength(2)
+    expect(page.data[0].author).toMatchObject({ id: 1, name: 'Alice' })
+    expect(page.data[1].author).toMatchObject({ id: 2, name: 'Bob' })
+
+    const last = await Post.newQuery().with('author').paginate({ page: 2, perPage: 2 }) as any
+    expect(last.data).toHaveLength(1)
+    expect(last.data[0].author).toMatchObject({ id: 1, name: 'Alice' })
+  })
+
+  it('restores limit/offset when eager loading fails in first() and paginate()', async () => {
+    const { Post } = defineBlog({
+      users: [{ id: 1, name: 'Alice' }],
+      // Enough rows that both queries fetch something: an empty page never
+      // reaches the eager loader, so it could not fail there.
+      posts: Array.from({ length: 5 }, (_, i) => ({ id: 10 + i, title: `Post ${i}`, authorId: 1 })),
+    })
+
+    const query = Post.newQuery().with('missing').limit(5).offset(3)
+    await expect(query.first()).rejects.toThrow('unknown relation "missing"')
+    await expect(query.paginate({ page: 1, perPage: 1 })).rejects.toThrow('unknown relation "missing"')
+    expect(query.getOptions()).toMatchObject({ limitValue: 5, offsetValue: 3 })
   })
 })
 


### PR DESCRIPTION
## Summary

- `Post.newQuery().with('author').paginate({ page, perPage })` returned rows without `author` attached, even though `get()` and `first()` both eager-load correctly. `paginate()` returned the adapter's raw rows instead of running them through `loadEagerRelations()`.
- The blog blueprint's `PostController.index` uses exactly this chain (`.with('author').orderBy(...).paginate(...)`), so its posts index page and `PostResource.whenLoaded('author')` silently omitted the author with no error.
- `first()` and `paginate()` now delegate to `get()` (executeQuery + loadEagerRelations) inside their saved limit/offset window, instead of hand-wiring the two steps — this is the single seam a future terminal method can't bypass. Restoration of the saved limit/offset now happens in a `finally` so it still runs if eager loading itself rejects (e.g. an unknown relation name).
- `Model.withPaginate()` was already correct and is unchanged.

## Test plan

- [x] Added a regression test in `packages/orm/tests/model-enhancements.test.ts` (`with().paginate()`) asserting eager-loaded relations appear on every paginated row across two pages; confirmed it fails without the fix.
- [x] Added a test asserting `limit`/`offset` are restored even when eager loading rejects; confirmed it fails without the `finally`.
- [x] Refactored the three tests in `describe('Phase 3: QueryBuilder.with()')` to share one in-memory multi-table adapter instead of three near-duplicate copies.
- [x] `bun run build:orm` — passes
- [x] `bun run test:bun orm` — 367 pass, 11 skip, 0 fail
- [x] Two independent Codex reviews (before and after a simplify pass) — no outstanding findings
- [x] Added a patch changeset for `@guren/orm`