### PR TITLE
test(orm): cover with().paginate() against the real sqlite driver

### DIFF
--- a/docs/en/guides/database.md
+++ b/docs/en/guides/database.md
@@ -370,7 +370,7 @@ const posts = await Post.with('author')             // posts[0].author is UserRe
 const filtered = await Post.with('author', { authorId: [1, 2] })
 ```
 
-Eager loading also works on the QueryBuilder, so you can combine it with filters and ordering:
+Eager loading also works on the QueryBuilder, so you can combine it with filters and ordering. The record-returning methods — `get()`, `first()`, `firstOrFail()`, and `paginate()` — all attach the relations:
 
 ```ts
 const activeUsers = await User.where('active', true)
@@ -379,6 +379,9 @@ const activeUsers = await User.where('active', true)
   .get()
 
 const user = await User.newQuery().with('posts').first()
+
+// Each row of the page carries its author
+const page = await Post.newQuery().with('author').orderBy('id', 'desc').paginate({ page: 1, perPage: 10 })
 ```
 
 Nested relations use dot notation:

--- a/docs/ja/guides/database.md
+++ b/docs/ja/guides/database.md
@@ -876,7 +876,7 @@ const posts = await Post.with('author', { authorId: [1, 2] })
 // posts[0].author は関連する UserRecord か null（belongsTo の場合）
 ```
 
-QueryBuilder 上でも eager loading が使えるので、フィルタやソートと組み合わせられます。
+QueryBuilder 上でも eager loading が使えるので、フィルタやソートと組み合わせられます。レコードを返す `get()`、`first()`、`firstOrFail()`、`paginate()` のいずれでもリレーションが付与されます。
 
 ```ts
 const activeUsers = await User.where('active', true)
@@ -885,6 +885,9 @@ const activeUsers = await User.where('active', true)
   .get()
 
 const user = await User.newQuery().with('posts').first()
+
+// ページの各行にも author が付きます
+const page = await Post.newQuery().with('author').orderBy('id', 'desc').paginate({ page: 1, perPage: 10 })
 ```
 
 ネストリレーションはドット記法で指定します。

--- a/packages/orm/tests/model-relations-sqlite.test.ts
+++ b/packages/orm/tests/model-relations-sqlite.test.ts
@@ -91,4 +91,54 @@ describe('relations on real bun:sqlite driver', () => {
     const posts = await Post.where({ authorId: 1 }).orWhere({ authorId: [2] }).get()
     expect(posts).toHaveLength(3)
   })
+
+  // paginate() once handed back the raw rows from executeQuery(), so
+  // `.with('author').paginate(...)` returned pages whose relation was missing
+  // while the same chain ending in `.get()` attached it — the blog starter's
+  // /posts index rendered without author names because of it. It delegates to
+  // get() now; these assert that on the real driver, which the in-memory
+  // adapter used elsewhere cannot speak for.
+  it('should eager load through paginate() like get() does', async () => {
+    type PostWithAuthor = PostRecord & { author: UserRecord | null }
+
+    const query = () => Post.newQuery().with('author').orderBy('id', 'desc')
+
+    const viaGet = (await query().limit(2).get()) as PostWithAuthor[]
+    const page = await query().paginate({ page: 1, perPage: 2 })
+    const viaPaginate = page.data as PostWithAuthor[]
+
+    expect(viaPaginate.map((p) => p.title)).toEqual(['B1', 'A2'])
+    expect(viaPaginate.map((p) => p.author?.name)).toEqual(['Bob', 'Alice'])
+    expect(viaPaginate).toEqual(viaGet)
+    expect(page.meta).toMatchObject({ total: 3, perPage: 2, currentPage: 1, totalPages: 2, hasMore: true })
+
+    // The remaining page loads its relation as well.
+    const last = await query().paginate({ page: 2, perPage: 2 })
+    expect((last.data as PostWithAuthor[]).map((p) => [p.title, p.author?.name])).toEqual([['A1', 'Alice']])
+  })
+
+  it('should eager load nested paths through paginate()', async () => {
+    type UserWithPosts = UserRecord & { posts: Array<PostRecord & { author: UserRecord | null }> }
+
+    const page = await User.newQuery().with('posts.author').orderBy('id', 'asc').paginate(1, 2)
+    const users = page.data as UserWithPosts[]
+
+    expect(users.map((u) => u.name)).toEqual(['Alice', 'Bob'])
+    expect(users[0].posts.map((p) => p.title).sort()).toEqual(['A1', 'A2'])
+    expect(users[0].posts.every((p) => p.author?.name === 'Alice')).toBe(true)
+    expect(users[1].posts.map((p) => p.author?.name)).toEqual(['Bob'])
+  })
+
+  it('should restore the builder\'s own limit/offset after paginate()', async () => {
+    type PostWithAuthor = PostRecord & { author: UserRecord | null }
+
+    // The builder carries its own slice (rows 2..3); paginate() must not
+    // leave its page-2 slice (row 3 only) behind, nor clear the slice.
+    const builder = Post.newQuery().with('author').orderBy('id', 'asc').limit(2).offset(1)
+    const page = await builder.paginate({ page: 2, perPage: 1 })
+    expect((page.data as PostWithAuthor[]).map((p) => [p.title, p.author?.name])).toEqual([['A2', 'Alice']])
+
+    const after = (await builder.get()) as PostWithAuthor[]
+    expect(after.map((p) => [p.title, p.author?.name])).toEqual([['A2', 'Alice'], ['B1', 'Bob']])
+  })
 })


### PR DESCRIPTION
## Summary

This PR started as a duplicate of #444 — both fixed `QueryBuilder.paginate()` dropping `.with()` relations. #444 landed first with the better implementation (`first()`/`paginate()` delegate to `get()`, so a future terminal method can't repeat the omission), so **the source fix here has been dropped** and this branch was rebased onto it. What remains is additive:

- **Real-driver coverage.** #444's regression tests run against the in-memory adapter in `model-enhancements.test.ts`. These run against the real `bun:sqlite` driver, which per `packages/orm/CLAUDE.md` is the level that catches SQL placeholder bugs the fake adapter cannot express.
- **Nested eager paths through pagination** — `with('posts.author').paginate(...)`, not covered by #444.
- **Equivalence with `get()`** — the paginated page equals the same chain ending in `.get()`, which is the property that was actually violated.
- **limit/offset restoration on the success path**, with a builder that carries its *own* `limit`/`offset` — #444 covers the rejecting path (`with('missing')`), so this pins the other half.
- **Docs (en/ja).** The Eager Loading section only demonstrated `get()` and `first()`, which is part of why the dropped relation read as intended behaviour. It now names the record-returning methods (`get()`, `first()`, `firstOrFail()`, `paginate()`) and shows a `paginate` example.

No changeset: the user-visible fix ships with #444's, and this adds tests and docs only.

## Test plan

- [x] `bun run build orm`
- [x] root `bun run typecheck`
- [x] `bun run test:bun orm` — 370 pass, 11 skip, 0 fail
- [x] `bun run audit:docs`
- [x] Mutation-checked: reverting #444's `paginate()` delegation back to `executeQuery()` makes all three new tests fail, so they are real guards rather than restatements.