### PR TITLE
feat(server): bind a route parameter by a column other than the primary key

### DIFF
--- a/.changeset/route-binding-by-column.md
+++ b/.changeset/route-binding-by-column.md
@@ -30,19 +30,28 @@ Router-level `router.bind(param, ...)` accepts the same tuple, and its model
 bindings — class or tuple — now feed `this.model(Post)` too. Values from
 `router.bind()` still arrive as positional arguments after the context, in
 path-parameter order; that is the only channel for a custom resolver function,
-which has no model class to look the record up by. Neither ever landed on the
-Hono context: the routing guide told readers to use `this.ctx.get('post')`,
-which has always been `undefined`. The English and Japanese guides, the agent
-harness rules, and the `guren context` API digest now describe the two channels
-that exist. A router test pins each of them, so the docs cannot drift from the
-implementation unnoticed again.
+which has no model class to look the record up by. Because `this.model()` is
+keyed by the model class, a route's own `bind` wins whenever both levels would
+write the same class — a same-param override, or two params bound to one
+model. The router-level binding still resolves and still fills its positional
+slot, so a custom resolver's side effects are never skipped.
+
+Neither channel ever landed on the Hono context: the routing guide told
+readers to use `this.ctx.get('post')`, which has always been `undefined`. The
+English and Japanese guides, the agent harness rules, and the `guren context`
+API digest now describe the two channels that exist, including the one limit
+`router.bind()` has always had — bindings resolve for controller-action routes,
+never for inline handlers, which take Hono's `(ctx, next)`. A router test pins
+each behavior, so the docs cannot drift from the implementation unnoticed
+again.
 
 `this.model(Post)` is also typed as the model's record now. Its return type
 was read off `findOrFail`, which is generic in `this`, so `ReturnType` widened
 it to the base row (`Record<string, unknown>`) and `post.id` came back
 `unknown` — the docs claimed `PostRecord` all along. The record type now comes
-from the `recordType` marker `defineModel()` sets; classes without the marker
-keep the previous fallback.
+from the `recordType` marker `defineModel()` sets; anything without a usable
+marker — including an adapter whose `recordType` names something other than a
+record — keeps the previous fallback.
 
 `BindableModel` and the new `RouteModelBinding` type are exported from
 `@guren/core` for code that builds `bind` maps outside a route call.

--- a/.changeset/route-binding-by-column.md
+++ b/.changeset/route-binding-by-column.md
@@ -1,0 +1,48 @@
+---
+"@guren/server": minor
+"@guren/core": minor
+"@guren/cli": patch
+---
+
+Bind a route parameter by a column other than the primary key
+
+`bind: { id: Post }` resolves the parameter with `Post.findOrFail(value)`, so a
+`/posts/:slug` route could not use route model binding: the router looked the
+slug up as a primary key and answered 404 for every real post. The only way
+through was an adapter object (`{ findOrFail: (v) => Post.findOrFail(v, 'slug') }`)
+passed to both `bind:` and `this.model()`, which worked by accident of the
+structural type and appeared nowhere in the docs.
+
+The `bind` option now also accepts a `[Model, column]` tuple. The router calls
+`Post.findOrFail(value, column)` and `this.model(Post)` returns that record, so
+the class-only form and the tuple form read the same in the controller:
+
+```ts
+router.get('/posts/:id',   { bind: { id: Post } },              [PostController, 'show'])
+router.get('/posts/:slug', { bind: { slug: [Post, 'slug'] } },  [PostController, 'show'])
+
+async show() {
+  const post = this.model(Post)
+}
+```
+
+Router-level `router.bind(param, ...)` accepts the same tuple, and its model
+bindings — class or tuple — now feed `this.model(Post)` too. Values from
+`router.bind()` still arrive as positional arguments after the context, in
+path-parameter order; that is the only channel for a custom resolver function,
+which has no model class to look the record up by. Neither ever landed on the
+Hono context: the routing guide told readers to use `this.ctx.get('post')`,
+which has always been `undefined`. The English and Japanese guides, the agent
+harness rules, and the `guren context` API digest now describe the two channels
+that exist. A router test pins each of them, so the docs cannot drift from the
+implementation unnoticed again.
+
+`this.model(Post)` is also typed as the model's record now. Its return type
+was read off `findOrFail`, which is generic in `this`, so `ReturnType` widened
+it to the base row (`Record<string, unknown>`) and `post.id` came back
+`unknown` — the docs claimed `PostRecord` all along. The record type now comes
+from the `recordType` marker `defineModel()` sets; classes without the marker
+keep the previous fallback.
+
+`BindableModel` and the new `RouteModelBinding` type are exported from
+`@guren/core` for code that builds `bind` maps outside a route call.

--- a/docs/en/guides/routing.md
+++ b/docs/en/guides/routing.md
@@ -203,7 +203,7 @@ The column name is a plain string — a misspelled column fails the query rather
 
 ### Router-level bindings
 
-`router.bind(param, ...)` binds a parameter name once for every route on that router whose path contains it. It accepts the same model forms as the `bind` option (`Post` or `[Post, 'slug']`), plus a custom resolver function:
+`router.bind(param, ...)` binds a parameter name once for every controller-action route on that router whose path contains it. It accepts the same model forms as the `bind` option (`Post` or `[Post, 'slug']`), plus a custom resolver function:
 
 ```ts
 router.bind('post', Post)                    // by primary key
@@ -224,7 +224,7 @@ async show(_ctx: Context, post: PostRecord) {
 ```
 
 > [!NOTE]
-> Bound values are not stored on the Hono context — `this.ctx.get('post')` returns `undefined`. Use `this.model(Post)` or the positional argument.
+> Bound values are not stored on the Hono context — `this.ctx.get('post')` returns `undefined`. Use `this.model(Post)` or the positional argument. Bindings resolve for controller-action routes only; an inline handler receives Hono's `(ctx, next)` and has to look the record up itself.
 
 ## Resource Routes
 

--- a/docs/en/guides/routing.md
+++ b/docs/en/guides/routing.md
@@ -171,29 +171,60 @@ async show() {
 }
 ```
 
-With model binding, Guren resolves the model automatically:
+With model binding, Guren resolves the model automatically. Declare the binding on the route with the `bind` option and read the record in the controller with `this.model()`:
 
 ```ts
-// Register bindings (top of routes file)
-router.bind('post', Post)
-
-// Route uses :post instead of :id
-router.get('/posts/:post', [PostsController, 'show'])
+// routes/web.ts — :id is looked up with Post.findOrFail(id)
+router.get('/posts/:id', { bind: { id: Post }, name: 'posts.show' }, [PostsController, 'show'])
 
 // Controller receives the resolved model — no lookup needed
 async show() {
-  const post = this.ctx.get('post') as PostRecord
+  const post = this.model(Post)  // typed as PostRecord
   return this.inertia(pages.posts.Show, { post: new PostResource(post).toJSON() })
 }
 ```
 
 If the record is not found, a 404 is returned automatically.
 
-You can also bind with a custom resolver for slug-based lookups:
+### Binding by another column
+
+The class alone always looks up by primary key. To resolve a slug (or any other unique column), bind a `[Model, column]` tuple — the router calls `Post.findOrFail(value, 'slug')` and `this.model(Post)` returns the same record:
 
 ```ts
-router.bind('post', async (value) => Post.where('slug', value).firstOrFail())
+router.get('/posts/:slug', { bind: { slug: [Post, 'slug'] }, name: 'posts.show' }, [PostsController, 'show'])
+
+async show() {
+  const post = this.model(Post)  // resolved by slug
+  // ...
+}
 ```
+
+The column name is a plain string — a misspelled column fails the query rather than returning 404, so keep it aligned with your schema. When the same parameter is bound both on the router (below) and on the route, the route's own `bind` wins and the record is looked up once.
+
+### Router-level bindings
+
+`router.bind(param, ...)` binds a parameter name once for every route on that router whose path contains it. It accepts the same model forms as the `bind` option (`Post` or `[Post, 'slug']`), plus a custom resolver function:
+
+```ts
+router.bind('post', Post)                    // by primary key
+router.bind('post', [Post, 'slug'])          // by slug
+router.bind('post', async (value) => Post.where('slug', value).firstOrFail())  // custom resolver
+
+router.get('/posts/:post', [PostsController, 'show'])
+```
+
+Router-level bindings reach the controller as **positional arguments after the context**, in path-parameter order. A model binding (`Post` or `[Post, 'slug']`) is also available through `this.model(Post)`; a custom resolver's value is only available positionally, since there is no model class to look it up by:
+
+```ts
+import type { Context } from '@guren/core'
+
+async show(_ctx: Context, post: PostRecord) {
+  return this.inertia(pages.posts.Show, { post: new PostResource(post).toJSON() })
+}
+```
+
+> [!NOTE]
+> Bound values are not stored on the Hono context — `this.ctx.get('post')` returns `undefined`. Use `this.model(Post)` or the positional argument.
 
 ## Resource Routes
 
@@ -285,7 +316,7 @@ Available contract fields:
 | `body` | Zod schema for the request body |
 | `output` | Zod schema for the response body |
 | `resource` | Resource class response hint — types the API client without a schema |
-| `bind` | Route model binding map |
+| `bind` | Route model binding map — `{ id: Post }` (primary key) or `{ slug: [Post, 'slug'] }` (another column) |
 | `middlewares` | Array of middleware handlers |
 
 > [!NOTE]

--- a/docs/ja/guides/routing.md
+++ b/docs/ja/guides/routing.md
@@ -184,7 +184,7 @@ async show() {
 
 ### ルーターレベルのバインディング
 
-`router.bind(param, ...)` は、そのルーターに登録されたルートのうちパスに同名パラメータを含むものすべてに対して一度でバインドします。`bind` オプションと同じモデル形式（`Post` または `[Post, 'slug']`）に加え、独自 resolver 関数も渡せます。
+`router.bind(param, ...)` は、そのルーターに登録されたコントローラータプルのルートのうち、パスに同名パラメータを含むものすべてに対して一度でバインドします。`bind` オプションと同じモデル形式（`Post` または `[Post, 'slug']`）に加え、独自 resolver 関数も渡せます。
 
 ```ts
 router.bind('post', Post)                    // 主キーで検索
@@ -205,7 +205,7 @@ async show(_ctx: Context, post: PostRecord) {
 ```
 
 > [!NOTE]
-> バインドされた値は Hono のコンテキストには格納されません。`this.ctx.get('post')` は `undefined` を返すので、`this.model(Post)` か位置引数を使ってください。
+> バインドされた値は Hono のコンテキストには格納されません。`this.ctx.get('post')` は `undefined` を返すので、`this.model(Post)` か位置引数を使ってください。バインディングが解決されるのはコントローラータプルのルートだけです。インラインハンドラーは Hono の `(ctx, next)` を受け取るため、レコードは自分で取得してください。
 
 ## ブートストラップ
 `src/app.ts` で registrar を `createApp()` に渡します。

--- a/docs/ja/guides/routing.md
+++ b/docs/ja/guides/routing.md
@@ -150,26 +150,62 @@ router.get('/posts/:id', [PostsController, 'show'])
 
 ## ルートモデルバインディング
 
-毎回 `findOrFail()` を書きたくない場合は、ルートパラメータにモデルをバインドできます。
+毎回 `findOrFail()` を書きたくない場合は、ルートパラメータにモデルをバインドできます。ルートの `bind` オプションでバインディングを宣言し、コントローラーでは `this.model()` でレコードを受け取ります。
 
 ```ts
 import { PostResource } from '@/app/Http/Resources/PostResource'
 import { pages } from '@/.guren/pages.gen'
 
-router.bind('post', Post)
-router.get('/posts/:post', [PostsController, 'show'])
+// routes/web.ts: :id は Post.findOrFail(id) で解決される
+router.get('/posts/:id', { bind: { id: Post }, name: 'posts.show' }, [PostsController, 'show'])
 
 async show() {
-  const post = this.ctx.get('post') as PostRecord
+  const post = this.model(Post)  // PostRecord として型付け済み
   return this.inertia(pages.posts.Show, { post: new PostResource(post).toJSON() })
 }
 ```
 
-slug ベースの解決にしたい場合は、独自 resolver も渡せます。
+レコードが見つからなければ自動的に 404 を返します。
+
+### 主キー以外のカラムでバインドする
+
+モデルクラスだけを渡した場合は常に主キーで検索します。slug など別のユニークカラムで解決したいときは `[Model, column]` のタプルを渡してください。ルーターは `Post.findOrFail(value, 'slug')` を呼び、`this.model(Post)` は同じレコードを返します。
 
 ```ts
-router.bind('post', async (value) => Post.where('slug', value).firstOrFail())
+router.get('/posts/:slug', { bind: { slug: [Post, 'slug'] }, name: 'posts.show' }, [PostsController, 'show'])
+
+async show() {
+  const post = this.model(Post)  // slug で解決済み
+  // ...
+}
 ```
+
+カラム名はただの文字列です。綴りを間違えると 404 ではなくクエリ自体が失敗するので、スキーマと揃えてください。同じパラメータをルーター（後述）とルートの両方でバインドした場合はルート側の `bind` が優先され、検索は 1 回だけ行われます。
+
+### ルーターレベルのバインディング
+
+`router.bind(param, ...)` は、そのルーターに登録されたルートのうちパスに同名パラメータを含むものすべてに対して一度でバインドします。`bind` オプションと同じモデル形式（`Post` または `[Post, 'slug']`）に加え、独自 resolver 関数も渡せます。
+
+```ts
+router.bind('post', Post)                    // 主キーで検索
+router.bind('post', [Post, 'slug'])          // slug で検索
+router.bind('post', async (value) => Post.where('slug', value).firstOrFail())  // 独自 resolver
+
+router.get('/posts/:post', [PostsController, 'show'])
+```
+
+ルーターレベルのバインディングで解決された値は、コンテキストの後ろに**位置引数として**パスパラメータの順に渡されます。モデルバインディング（`Post` や `[Post, 'slug']`）は `this.model(Post)` でも受け取れますが、独自 resolver の値は参照するためのモデルクラスがないため位置引数でのみ受け取れます。
+
+```ts
+import type { Context } from '@guren/core'
+
+async show(_ctx: Context, post: PostRecord) {
+  return this.inertia(pages.posts.Show, { post: new PostResource(post).toJSON() })
+}
+```
+
+> [!NOTE]
+> バインドされた値は Hono のコンテキストには格納されません。`this.ctx.get('post')` は `undefined` を返すので、`this.model(Post)` か位置引数を使ってください。
 
 ## ブートストラップ
 `src/app.ts` で registrar を `createApp()` に渡します。
@@ -238,7 +274,7 @@ router.get('/posts/:id', {
 | `body` | リクエストボディの Zod スキーマ |
 | `output` | レスポンスボディの Zod スキーマ |
 | `resource` | Resource クラスによるレスポンスヒント（スキーマなしで API クライアントを型付け） |
-| `bind` | ルートモデルバインディングマップ |
+| `bind` | ルートモデルバインディングマップ。`{ id: Post }`（主キー）または `{ slug: [Post, 'slug'] }`（別カラム） |
 | `middlewares` | ミドルウェアハンドラーの配列 |
 
 > [!NOTE]

--- a/packages/cli/src/api-digest.ts
+++ b/packages/cli/src/api-digest.ts
@@ -44,7 +44,10 @@ Verified quick reference — trust this and \`.claude/rules/*.md\` over grepping
 - \`this.auth\` — every method is async, always \`await\`: \`userOrFail<UserRecord>()\` (throws → 401;
   pass \`<T>\` — the default type has no \`.id\`) · \`user<T>()\` · \`check()\` · \`guest()\` ·
   \`login(user, remember?)\` · \`attempt(credentials, remember?)\` · \`logout()\`
-- Route model binding: route option \`bind: { id: Post }\` + \`this.model(Post)\` (already resolved, 404 on miss)
+- Route model binding: route option \`bind: { id: Post }\` (primary key) or \`bind: { slug: [Post, 'slug'] }\` (another column)
+  + \`this.model(Post)\` (already resolved, 404 on miss). Router-level \`router.bind(param, Post | [Post, 'slug'] | resolverFn)\`
+  binds every route with that param; its value arrives as a positional arg after the context (models also via \`this.model()\`) —
+  never on \`this.ctx.get()\`
 - \`await this.authorize('update', [Post, post])\` (throws → 403)
 
 ### Testing (@guren/testing)

--- a/packages/cli/templates/agent/core/rules/controllers-http.md
+++ b/packages/cli/templates/agent/core/rules/controllers-http.md
@@ -64,10 +64,12 @@ async show() {
 `[Model, column]` tuple — `bind: { slug: [Post, 'slug'] }` — and `this.model(Post)` returns the record
 resolved by that column. Never adapt around this with a custom `{ findOrFail }` object.
 
-Router-level `router.bind('post', Post | [Post, 'slug'] | async (value) => ...)` binds every route whose
-path has `:post`; the resolved value reaches the action as a **positional argument after the context**
+Router-level `router.bind('post', Post | [Post, 'slug'] | async (value) => ...)` binds every
+controller-action route whose path has `:post` (inline handlers never receive bindings); the resolved
+value reaches the action as a **positional argument after the context**
 (`async show(_ctx: Context, post: PostRecord)`), and model bindings are also available via `this.model(Post)`.
 A custom resolver's value is positional-only. Nothing is stored on the Hono context — `this.ctx.get('post')` is `undefined`.
+When a param is bound at both levels, or two params bind the same model class, the route's own `bind` is what `this.model()` returns.
 
 ## Auth helpers
 

--- a/packages/cli/templates/agent/core/rules/controllers-http.md
+++ b/packages/cli/templates/agent/core/rules/controllers-http.md
@@ -60,6 +60,15 @@ async show() {
 }
 ```
 
+`bind: { id: Post }` always looks up by primary key. For a slug (or any other unique column) bind a
+`[Model, column]` tuple — `bind: { slug: [Post, 'slug'] }` — and `this.model(Post)` returns the record
+resolved by that column. Never adapt around this with a custom `{ findOrFail }` object.
+
+Router-level `router.bind('post', Post | [Post, 'slug'] | async (value) => ...)` binds every route whose
+path has `:post`; the resolved value reaches the action as a **positional argument after the context**
+(`async show(_ctx: Context, post: PostRecord)`), and model bindings are also available via `this.model(Post)`.
+A custom resolver's value is positional-only. Nothing is stored on the Hono context — `this.ctx.get('post')` is `undefined`.
+
 ## Auth helpers
 
 `this.auth` (requires `AuthServiceProvider`) exposes:

--- a/packages/cli/templates/agent/core/rules/routes-codegen.md
+++ b/packages/cli/templates/agent/core/rules/routes-codegen.md
@@ -29,7 +29,7 @@ export function registerWebRoutes(baseRouter: Router): void {
 
 Options object (second arg) is `RouteContractOptions`:
 `name?` · `middlewares?: MiddlewareHandler[]` · `params?` / `query?` / `body?` / `output?`
-(Zod schemas) · `bind?: Record<string, BindableModel>` · plus OpenAPI metadata
+(Zod schemas) · `bind?: Record<string, RouteModelBinding>` (`Post` or `[Post, 'slug']`) · plus OpenAPI metadata
 (`summary?`, `description?`, `tags?`, `operationId?`, `deprecated?`).
 
 Schemas attached here do double duty: requests are **validated automatically**
@@ -37,7 +37,8 @@ Schemas attached here do double duty: requests are **validated automatically**
 
 `router.resource('/posts', PostController, { name?, param?, only?, except? })` registers
 index/create/store/show/edit/update/destroy (GET/POST/PUT/DELETE, `:id` param) named `posts.index` etc.
-Model binding: `bind: { id: Post }` + `this.model(Post)` in the controller.
+Model binding: `bind: { id: Post }` (primary key) or `bind: { slug: [Post, 'slug'] }` (another column)
++ `this.model(Post)` in the controller. See `controllers-http.md` for router-level `router.bind()`.
 
 Verbs: `get / post / put / patch / delete / query` (all with the same overloads), plus
 `router.on(method, path, ...)` for anything else. `query()` registers the HTTP QUERY

--- a/packages/cli/tests/context.test.ts
+++ b/packages/cli/tests/context.test.ts
@@ -150,6 +150,7 @@ describe('GUREN_API_DIGEST', () => {
       'validateBody',
       'userOrFail',
       'bind: { id: Post }',
+      "bind: { slug: [Post, 'slug'] }",
       "await this.authorize('update', [Post, post])",
     ],
     'testing.md': ['actingAs', 'withCsrf', 'assertUnprocessable', 'assertInertia', 'query(path, body?)'],

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -14,10 +14,12 @@ export { Controller } from './mvc/Controller'
 export type { InertiaResponse, InferInertiaProps, ControllerInertiaProps, AuthPayload } from './mvc/Controller'
 export { Router } from './mvc/Router'
 export type {
+  BindableModel,
   RouteBuilder,
   RouteContractOptions,
   RouteDefinition,
   RouteMiddlewareInput,
+  RouteModelBinding,
   RouteOpenApiMetadata,
   ResourceAction as RouteResourceAction,
   ResourceResponseHint,

--- a/packages/server/src/mvc/Controller.ts
+++ b/packages/server/src/mvc/Controller.ts
@@ -35,13 +35,17 @@ export type SafeValidationResult<T> =
  * carry their row type as a `recordType` marker (set by `defineModel()`);
  * `findOrFail`'s own return type cannot be read off the class because the
  * method is generic in `this`, and `ReturnType` widens it to the base row.
- * Anything without the marker — a class extending `Model` directly without
- * redeclaring it, or a plain `{ findOrFail }` adapter — falls back to
- * whatever its `findOrFail` resolves to.
+ * Anything without a usable marker — a class extending `Model` directly
+ * without redeclaring it, or a plain `{ findOrFail }` adapter — falls back to
+ * whatever its `findOrFail` resolves to. The marker is only trusted when it
+ * names an object type: `Model`'s own is `unknown`, and an unrelated
+ * `recordType` on some adapter (a string tag, say) describes no record.
  */
 export type BoundModelRecord<T extends { findOrFail(...args: any[]): Promise<any> }> =
   T extends { readonly recordType: infer R }
-    ? unknown extends R ? Awaited<ReturnType<T['findOrFail']>> : R
+    ? unknown extends R
+      ? Awaited<ReturnType<T['findOrFail']>>
+      : R extends object ? R : Awaited<ReturnType<T['findOrFail']>>
     : Awaited<ReturnType<T['findOrFail']>>
 
 type DefaultInertiaProps = Record<string, unknown>

--- a/packages/server/src/mvc/Controller.ts
+++ b/packages/server/src/mvc/Controller.ts
@@ -30,6 +30,20 @@ export type SafeValidationResult<T> =
   | { success: true; data: T }
   | { success: false; errors: Record<string, string> }
 
+/**
+ * The record `Controller.model()` returns for a bound model class. ORM models
+ * carry their row type as a `recordType` marker (set by `defineModel()`);
+ * `findOrFail`'s own return type cannot be read off the class because the
+ * method is generic in `this`, and `ReturnType` widens it to the base row.
+ * Anything without the marker — a class extending `Model` directly without
+ * redeclaring it, or a plain `{ findOrFail }` adapter — falls back to
+ * whatever its `findOrFail` resolves to.
+ */
+export type BoundModelRecord<T extends { findOrFail(...args: any[]): Promise<any> }> =
+  T extends { readonly recordType: infer R }
+    ? unknown extends R ? Awaited<ReturnType<T['findOrFail']>> : R
+    : Awaited<ReturnType<T['findOrFail']>>
+
 type DefaultInertiaProps = Record<string, unknown>
 
 export type AuthPayload = Record<string, unknown> & { user: unknown }
@@ -131,12 +145,16 @@ export class Controller {
   }
 
   /**
-   * Retrieve a model instance resolved via route model binding.
+   * Retrieve a model instance resolved via route model binding — a per-route
+   * `bind` option or a router-level `router.bind(param, Model)`. Look up by
+   * primary key with the class alone, or by another column with a
+   * `[Model, column]` tuple.
    *
    * @example
    * ```typescript
    * // routes/web.ts
    * posts.get('/:id', { bind: { id: Post }, name: 'posts.show' }, [PostController, 'show'])
+   * posts.get('/by-slug/:slug', { bind: { slug: [Post, 'slug'] } }, [PostController, 'show'])
    *
    * // PostController.ts
    * async show() {
@@ -147,15 +165,15 @@ export class Controller {
    */
   protected model<T extends { findOrFail(...args: any[]): Promise<any> }>(
     modelClass: T,
-  ): Awaited<ReturnType<T['findOrFail']>> {
+  ): BoundModelRecord<T> {
     const instance = this.resolvedModels?.get(modelClass)
     if (instance === undefined) {
       throw new Error(
         `No model binding found for ${(modelClass as { name?: string }).name ?? 'unknown'}. ` +
-        'Ensure the route has a matching bind option in RouteContractOptions.',
+        'Ensure the route has a matching bind option in RouteContractOptions, or the router a bind(param, Model) call.',
       )
     }
-    return instance as Awaited<ReturnType<T['findOrFail']>>
+    return instance as BoundModelRecord<T>
   }
 
   protected get ctx(): Context {

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -55,10 +55,49 @@ type ModelBindingResolver = (value: string) => Promise<unknown>
 /**
  * Model class with findOrFail static method.
  */
-interface BindableModel {
+export interface BindableModel {
   findOrFail(id: unknown, key?: string): Promise<unknown>
   /** Bound values are model classes at runtime; the constructor name is the introspection payload. */
   readonly name?: string
+}
+
+/**
+ * A model bound to a route parameter: the model class alone looks the value
+ * up by primary key (`Model.findOrFail(value)`); a `[Model, column]` tuple
+ * looks it up by that column (`Model.findOrFail(value, column)`), e.g.
+ * `bind: { slug: [Post, 'slug'] }`. Either way the controller reads the
+ * resolved record with `this.model(Model)`.
+ */
+export type RouteModelBinding = BindableModel | readonly [BindableModel, string]
+
+/** {@link RouteModelBinding} normalized for resolution. */
+interface ModelBinding {
+  model: BindableModel
+  /** Column to look up by; `undefined` means the model's primary key. */
+  key?: string
+}
+
+/**
+ * A router-level `bind(param, ...)` entry. `model` is present when the
+ * binding is a model (class or `[Model, column]`) — those records are also
+ * handed to `Controller.model()` — and absent for custom resolvers, whose
+ * value only reaches the action as a positional argument.
+ */
+interface RegisteredBinding {
+  resolve: ModelBindingResolver
+  model?: BindableModel
+}
+
+function normalizeModelBinding(binding: RouteModelBinding): ModelBinding {
+  if (Array.isArray(binding)) {
+    const [model, key] = binding as readonly [BindableModel, string]
+    return { model, key }
+  }
+  return { model: binding as BindableModel }
+}
+
+async function resolveModelBinding({ model, key }: ModelBinding, value: string): Promise<unknown> {
+  return key === undefined ? model.findOrFail(value) : model.findOrFail(value, key)
 }
 
 /**
@@ -142,7 +181,13 @@ export interface RouteContractOptions<
    * it is the one actually enforced.
    */
   resource?: ResourceResponseHint
-  bind?: Record<string, BindableModel>
+  /**
+   * Route model bindings: param name → model (see {@link RouteModelBinding}).
+   * `{ id: Post }` resolves by primary key, `{ slug: [Post, 'slug'] }` by
+   * that column; both throw the model's not-found exception (404) on a miss
+   * and expose the record to the controller via `this.model(Post)`.
+   */
+  bind?: Record<string, RouteModelBinding>
 }
 
 export interface RouteOpenApiMetadata {
@@ -171,7 +216,7 @@ interface RegisteredRoute {
   }
   resource?: ResourceResponseHint
   openapi?: RouteOpenApiMetadata
-  bindings?: Map<string, BindableModel>
+  bindings?: Map<string, ModelBinding>
 }
 
 /**
@@ -325,9 +370,7 @@ export class Router<M extends string = never> {
   private readonly middlewareStack: MiddlewareScopeEntry[][] = []
   private readonly middlewareAliases: Map<string, MiddlewareHandler> = new Map()
   private readonly middlewareGroups: Map<string, string[]> = new Map()
-  private readonly modelBindings: Map<string, ModelBindingResolver> = new Map()
-  /** Model class names for router-level bind(param, Model) calls — resolver-only binds carry no name. */
-  private readonly modelBindingNames: Map<string, string> = new Map()
+  private readonly modelBindings: Map<string, RegisteredBinding> = new Map()
 
   aliasMiddleware<N extends string>(name: N, handler: MiddlewareHandler): Router<M | N> {
     this.middlewareAliases.set(name, handler)
@@ -347,25 +390,32 @@ export class Router<M extends string = never> {
     return new RouterMiddlewareGroupBuilder(this, items)
   }
 
-  bind(param: string, modelOrResolver: BindableModel | ModelBindingResolver): this {
-    if (typeof modelOrResolver === 'function' && 'findOrFail' in modelOrResolver) {
-      // Model class with static findOrFail — wrap in resolver
-      const model = modelOrResolver as unknown as BindableModel
-      if (model.name) this.modelBindingNames.set(param, model.name)
-      this.modelBindings.set(param, async (value: string) => {
-        return model.findOrFail(value)
-      })
-    } else if (typeof modelOrResolver === 'function') {
-      // Custom resolver function
-      this.modelBindings.set(param, modelOrResolver as ModelBindingResolver)
-    } else {
-      // Object with findOrFail (e.g., model instance or plain object)
-      const model = modelOrResolver
-      this.modelBindings.set(param, async (value: string) => {
-        return model.findOrFail(value)
-      })
+  /**
+   * Bind a route parameter for every route on this router whose path names
+   * it. A model (class or `[Model, column]`) resolves through `findOrFail`
+   * and reaches the controller both via `this.model(Model)` and as a
+   * positional argument after the context; a custom resolver's value only
+   * arrives positionally, in path-parameter order:
+   *
+   * ```ts
+   * router.bind('post', async (slug) => Post.where('slug', slug).firstOrFail())
+   * router.get('/posts/:post', [PostController, 'show'])
+   *
+   * async show(_ctx: Context, post: PostRecord) { ... }
+   * ```
+   */
+  bind(param: string, modelOrResolver: RouteModelBinding | ModelBindingResolver): this {
+    if (typeof modelOrResolver === 'function' && !('findOrFail' in modelOrResolver)) {
+      this.modelBindings.set(param, { resolve: modelOrResolver as ModelBindingResolver })
+      return this
     }
 
+    // A model class, a `[Model, column]` tuple, or any object exposing findOrFail.
+    const binding = normalizeModelBinding(modelOrResolver as RouteModelBinding)
+    this.modelBindings.set(param, {
+      model: binding.model,
+      resolve: (value) => resolveModelBinding(binding, value),
+    })
     return this
   }
 
@@ -630,7 +680,6 @@ export class Router<M extends string = never> {
     this.middlewareAliases.clear()
     this.middlewareGroups.clear()
     this.modelBindings.clear()
-    this.modelBindingNames.clear()
   }
 
   definitions(): RouteDefinition[] {
@@ -649,7 +698,7 @@ export class Router<M extends string = never> {
       controller: isControllerAction(handler)
         ? { name: handler[0].name, action: String(handler[1]) }
         : undefined,
-      bindings: serializeBindings(path, bindings, this.modelBindingNames),
+      bindings: serializeBindings(path, bindings, this.modelBindings),
       ...openapi,
     }))
   }
@@ -806,7 +855,9 @@ function applyRouteContract(route: RegisteredRoute, options: RouteContractOption
     deprecated: options.deprecated,
   }
   if (options.bind) {
-    route.bindings = new Map(Object.entries(options.bind))
+    route.bindings = new Map(
+      Object.entries(options.bind).map(([param, binding]) => [param, normalizeModelBinding(binding)]),
+    )
   }
 }
 
@@ -1238,9 +1289,9 @@ function createContractValidationMiddleware(route: RegisteredRoute): MiddlewareH
 
 function resolveHandler(
   action: AnyRouteHandler,
-  modelBindings: Map<string, ModelBindingResolver>,
+  modelBindings: Map<string, RegisteredBinding>,
   container?: Container,
-  routeBindings?: Map<string, BindableModel>,
+  routeBindings?: Map<string, ModelBinding>,
   path?: string,
 ): MiddlewareHandler {
   if (isControllerAction(action)) {
@@ -1261,14 +1312,18 @@ function resolveHandler(
         controller.setContainer(container)
       }
 
-      // Resolve per-route model bindings (from RouteContractOptions.bind)
+      // Resolve per-route model bindings (from RouteContractOptions.bind).
+      // Remembered by param so a router-level bind() on the same name reuses
+      // the record instead of querying again and overwriting this.model().
+      const routeResolved = new Map<string, unknown>()
       if (routeBindings && routeBindings.size > 0) {
         const params = c.req.param() as Record<string, string>
-        for (const [paramName, model] of routeBindings) {
+        for (const [paramName, binding] of routeBindings) {
           const value = params[paramName]
           if (value !== undefined) {
-            const resolved = await model.findOrFail(value)
-            controller.setResolvedModel(model, resolved)
+            const resolved = await resolveModelBinding(binding, value)
+            controller.setResolvedModel(binding.model, resolved)
+            routeResolved.set(paramName, resolved)
           }
         }
       }
@@ -1278,11 +1333,18 @@ function resolveHandler(
         throw new Error(`Controller method ${String(methodName)} is not defined on ${ControllerClass.name}.`)
       }
 
+      // Router-level bindings (bind(param, ...)) travel as positional
+      // arguments after the context, in path-parameter order; the ones bound
+      // to a model are also exposed through `this.model(Model)`.
       const resolvedBindings = modelBindings.size > 0
-        ? await resolveModelBindings(c, modelBindings, path)
+        ? await resolveModelBindings(c, modelBindings, path, routeResolved)
         : []
+      const args: unknown[] = [c]
+      for (const { model, value } of resolvedBindings) {
+        if (model) controller.setResolvedModel(model, value)
+        args.push(value)
+      }
 
-      const args: unknown[] = resolvedBindings.length > 0 ? [c, ...resolvedBindings] : [c]
       const result = await (method as (...a: unknown[]) => unknown).apply(controller, args)
       return ensureResponse(result, c)
     }
@@ -1302,26 +1364,33 @@ function resolveHandler(
 
 async function resolveModelBindings(
   c: Context,
-  modelBindings: Map<string, ModelBindingResolver>,
-  path?: string,
-): Promise<unknown[]> {
+  modelBindings: Map<string, RegisteredBinding>,
+  path: string | undefined,
+  routeResolved: ReadonlyMap<string, unknown>,
+): Promise<Array<{ model?: BindableModel; value: unknown }>> {
   if (modelBindings.size === 0) {
     return []
   }
 
-  const resolved: unknown[] = []
+  const resolved: Array<{ model?: BindableModel; value: unknown }> = []
   const params = c.req.param()
 
   // Get path params in order from the route pattern
   const pathParams = path ? extractPathParamNames(path) : []
 
   for (const param of pathParams) {
-    const resolver = modelBindings.get(param)
-    if (!resolver) continue
+    const binding = modelBindings.get(param)
+    if (!binding) continue
+    // The route's own `bind` entry wins over the router-level one, as it
+    // does for introspection: its record fills the positional slot and is
+    // already the one `this.model()` returns, so no second lookup runs.
+    if (routeResolved.has(param)) {
+      resolved.push({ value: routeResolved.get(param) })
+      continue
+    }
     const value = params[param]
     if (value !== undefined) {
-      const model = await resolver(value)
-      resolved.push(model)
+      resolved.push({ model: binding.model, value: await binding.resolve(value) })
     }
   }
 
@@ -1376,17 +1445,17 @@ function buildResponse(result: unknown): Response {
  */
 function serializeBindings(
   path: string,
-  routeBindings: Map<string, BindableModel> | undefined,
-  routerBindingNames: Map<string, string>,
+  routeBindings: Map<string, ModelBinding> | undefined,
+  routerBindings: Map<string, RegisteredBinding>,
 ): Record<string, string> | undefined {
   const entries = new Map<string, string>()
 
   for (const param of extractPathParamNames(path)) {
-    const name = routerBindingNames.get(param)
+    const name = routerBindings.get(param)?.model?.name
     if (name) entries.set(param, name)
   }
 
-  for (const [param, model] of routeBindings ?? []) {
+  for (const [param, { model }] of routeBindings ?? []) {
     if (model.name) entries.set(param, model.name)
   }
 

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -1313,17 +1313,17 @@ function resolveHandler(
       }
 
       // Resolve per-route model bindings (from RouteContractOptions.bind).
-      // Remembered by param so a router-level bind() on the same name reuses
-      // the record instead of querying again and overwriting this.model().
-      const routeResolved = new Map<string, unknown>()
+      // The model classes they claim are remembered: `this.model()` is keyed
+      // by class, so a router-level bind() must not overwrite a record the
+      // route asked for by name.
+      const routeBoundModels = new Set<unknown>()
       if (routeBindings && routeBindings.size > 0) {
         const params = c.req.param() as Record<string, string>
         for (const [paramName, binding] of routeBindings) {
           const value = params[paramName]
           if (value !== undefined) {
-            const resolved = await resolveModelBinding(binding, value)
-            controller.setResolvedModel(binding.model, resolved)
-            routeResolved.set(paramName, resolved)
+            controller.setResolvedModel(binding.model, await resolveModelBinding(binding, value))
+            routeBoundModels.add(binding.model)
           }
         }
       }
@@ -1337,11 +1337,11 @@ function resolveHandler(
       // arguments after the context, in path-parameter order; the ones bound
       // to a model are also exposed through `this.model(Model)`.
       const resolvedBindings = modelBindings.size > 0
-        ? await resolveModelBindings(c, modelBindings, path, routeResolved)
+        ? await resolveModelBindings(c, modelBindings, path)
         : []
       const args: unknown[] = [c]
       for (const { model, value } of resolvedBindings) {
-        if (model) controller.setResolvedModel(model, value)
+        if (model && !routeBoundModels.has(model)) controller.setResolvedModel(model, value)
         args.push(value)
       }
 
@@ -1365,8 +1365,7 @@ function resolveHandler(
 async function resolveModelBindings(
   c: Context,
   modelBindings: Map<string, RegisteredBinding>,
-  path: string | undefined,
-  routeResolved: ReadonlyMap<string, unknown>,
+  path?: string,
 ): Promise<Array<{ model?: BindableModel; value: unknown }>> {
   if (modelBindings.size === 0) {
     return []
@@ -1381,13 +1380,6 @@ async function resolveModelBindings(
   for (const param of pathParams) {
     const binding = modelBindings.get(param)
     if (!binding) continue
-    // The route's own `bind` entry wins over the router-level one, as it
-    // does for introspection: its record fills the positional slot and is
-    // already the one `this.model()` returns, so no second lookup runs.
-    if (routeResolved.has(param)) {
-      resolved.push({ value: routeResolved.get(param) })
-      continue
-    }
     const value = params[param]
     if (value !== undefined) {
       resolved.push({ model: binding.model, value: await binding.resolve(value) })

--- a/packages/server/tests/mvc/router-model-binding.test.ts
+++ b/packages/server/tests/mvc/router-model-binding.test.ts
@@ -22,7 +22,7 @@ class NotFound extends Error {
  * Mirrors the ORM's static `findOrFail(id, key = 'id')` signature and records
  * every call, so the tests can assert which column the router looked up by.
  */
-function makeModel(name = 'Post') {
+function makeModel(name = 'Post', rows: PostRecord[] = posts) {
   const calls: Array<[unknown, string | undefined]> = []
   return {
     name,
@@ -30,7 +30,7 @@ function makeModel(name = 'Post') {
     async findOrFail(id: unknown, key?: string): Promise<PostRecord> {
       calls.push([id, key])
       const column = (key ?? 'id') as keyof PostRecord
-      const found = posts.find((p) => String(p[column]) === String(id))
+      const found = rows.find((p) => String(p[column]) === String(id))
       if (!found) throw new NotFound(`${name} not found`)
       return found
     },
@@ -184,22 +184,70 @@ describe('Router-level bind(param, ...)', () => {
     expect(await response.text()).toContain('No model binding found for Post')
   })
 
-  it('lets the route-level bind win when the same param is bound at both levels, without a second lookup', async () => {
-    // Fixture rows are arranged so a by-slug and a by-id lookup of the same
-    // raw value disagree: '1' is post 1's id, but no post's slug — and 'second'
-    // is post 2's slug. Route-level `[Post, 'slug']` must be what both
-    // this.model() and the positional argument observe.
-    const Post = makeModel()
+  it('lets the route-level bind win for this.model() when both levels bind the same param', async () => {
+    // Rows arranged so the two lookups of the raw value '1' disagree: it is
+    // row 1's id and row 2's slug. The route asked for the slug, so that is
+    // what this.model() must return; the router-level binding still fills the
+    // positional slot, as it did before route bindings reached this.model().
+    const rows: PostRecord[] = [
+      { id: 1, slug: 'x', title: 'X' },
+      { id: 2, slug: '1', title: 'Y' },
+    ]
+    const Post = makeModel('Post', rows)
     const router = new Router()
     router.bind('post', Post) // by primary key, router-wide
     router.get('/posts/:post', { bind: { post: [Post, 'slug'] } }, [controllerFor(Post), 'showBoth'])
     const app = mount(router)
 
-    const response = await app.request('/posts/second')
+    const response = await app.request('/posts/1')
     expect(response.status).toBe(200)
-    expect(await response.json()).toEqual({ positional: posts[1], model: posts[1] })
-    expect(Post.calls).toEqual([['second', 'slug']])
-    expect(router.definitions()[0]?.bindings).toEqual({ post: 'Post' })
+    expect(await response.json()).toEqual({ positional: rows[0], model: rows[1] })
+    expect(Post.calls).toEqual([['1', 'slug'], ['1', undefined]])
+  })
+
+  it('does not overwrite a route-bound record when another param binds the same model class', async () => {
+    const Post = makeModel()
+    const router = new Router()
+    router.bind('other', Post) // by primary key on a different param
+    router.get('/posts/:id/:other', { bind: { id: [Post, 'slug'] } }, [controllerFor(Post), 'showBoth'])
+    const app = mount(router)
+
+    const response = await app.request('/posts/hello-world/2')
+    expect(response.status).toBe(200)
+    // `this.model(Post)` is keyed by class, so the route's own binding wins;
+    // the router-level record still arrives positionally.
+    expect(await response.json()).toEqual({ positional: posts[1], model: posts[0] })
+  })
+
+  it('still runs a router-level custom resolver when the route binds the same param', async () => {
+    const Post = makeModel()
+    let resolverCalls = 0
+    const router = new Router()
+    router.bind('post', async (value) => {
+      resolverCalls += 1
+      return { resolved: value }
+    })
+    router.get('/posts/:post', { bind: { post: [Post, 'slug'] } }, [controllerFor(Post), 'showBoth'])
+    const app = mount(router)
+
+    const response = await app.request('/posts/hello-world')
+    expect(response.status).toBe(200)
+    // The resolver's value fills the positional slot (it has no model class
+    // to be reached by), while this.model(Post) holds the route's record.
+    expect(await response.json()).toEqual({ positional: { resolved: 'hello-world' }, model: posts[0] })
+    expect(resolverCalls).toBe(1)
+  })
+
+  it('does not resolve bindings for an inline handler, which takes Hono (ctx, next)', async () => {
+    const Post = makeModel()
+    const router = new Router()
+    router.bind('post', Post)
+    router.get('/posts/:post', (c) => c.json({ param: c.req.param('post') }))
+    const app = mount(router)
+
+    const response = await app.request('/posts/1')
+    expect(await response.json()).toEqual({ param: '1' })
+    expect(Post.calls).toEqual([])
   })
 
   it('passes several bound values in path-parameter order', async () => {

--- a/packages/server/tests/mvc/router-model-binding.test.ts
+++ b/packages/server/tests/mvc/router-model-binding.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'bun:test'
+import { Hono, type Context } from 'hono'
+import { Router } from '../../src/mvc/Router'
+import { Controller } from '../../src/mvc/Controller'
+
+interface PostRecord {
+  id: number
+  slug: string
+  title: string
+}
+
+const posts: PostRecord[] = [
+  { id: 1, slug: 'hello-world', title: 'Hello World' },
+  { id: 2, slug: 'second', title: 'Second' },
+]
+
+class NotFound extends Error {
+  statusCode = 404
+}
+
+/**
+ * Mirrors the ORM's static `findOrFail(id, key = 'id')` signature and records
+ * every call, so the tests can assert which column the router looked up by.
+ */
+function makeModel(name = 'Post') {
+  const calls: Array<[unknown, string | undefined]> = []
+  return {
+    name,
+    calls,
+    async findOrFail(id: unknown, key?: string): Promise<PostRecord> {
+      calls.push([id, key])
+      const column = (key ?? 'id') as keyof PostRecord
+      const found = posts.find((p) => String(p[column]) === String(id))
+      if (!found) throw new NotFound(`${name} not found`)
+      return found
+    },
+  }
+}
+type PostModel = ReturnType<typeof makeModel>
+
+/** A controller closed over the model class the route binds, as app code would import it. */
+function controllerFor(Post: PostModel) {
+  return class PostController extends Controller {
+    async show() {
+      return this.json({ via: 'model', post: this.model(Post) })
+    }
+
+    async showPositional(_ctx: Context, post: PostRecord) {
+      return this.json({ via: 'positional', post })
+    }
+
+    async showBoth(_ctx: Context, post: PostRecord) {
+      return this.json({ positional: post, model: this.model(Post) })
+    }
+  }
+}
+
+function mount(router: Router): Hono {
+  const app = new Hono()
+  app.onError((err, c) => c.text(err.message, ((err as Partial<NotFound>).statusCode ?? 500) as 404 | 500))
+  router.mount(app)
+  return app
+}
+
+describe('Route model binding by primary key (bind: { id: Post })', () => {
+  it('resolves through findOrFail without a key and exposes the record via this.model()', async () => {
+    const Post = makeModel()
+    const router = new Router()
+    router.get('/posts/:id', { bind: { id: Post } }, [controllerFor(Post), 'show'])
+    const app = mount(router)
+
+    const response = await app.request('/posts/2')
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ via: 'model', post: posts[1] })
+    expect(Post.calls).toEqual([['2', undefined]])
+  })
+
+  it('surfaces the model not-found exception on a miss', async () => {
+    const Post = makeModel()
+    const router = new Router()
+    router.get('/posts/:id', { bind: { id: Post } }, [controllerFor(Post), 'show'])
+    const app = mount(router)
+
+    const response = await app.request('/posts/999')
+    expect(response.status).toBe(404)
+  })
+})
+
+describe('Route model binding by another column (bind: { slug: [Post, "slug"] })', () => {
+  it('resolves through findOrFail(value, column) and exposes the record via this.model()', async () => {
+    const Post = makeModel()
+    const router = new Router()
+    router.get('/posts/:slug', { bind: { slug: [Post, 'slug'] } }, [controllerFor(Post), 'show'])
+    const app = mount(router)
+
+    const response = await app.request('/posts/hello-world')
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ via: 'model', post: posts[0] })
+    expect(Post.calls).toEqual([['hello-world', 'slug']])
+  })
+
+  it('does not fall back to the primary key when the column has no match', async () => {
+    const Post = makeModel()
+    const router = new Router()
+    router.get('/posts/:slug', { bind: { slug: [Post, 'slug'] } }, [controllerFor(Post), 'show'])
+    const app = mount(router)
+
+    // '1' is a valid id but not a slug — a by-slug route must 404 here.
+    const response = await app.request('/posts/1')
+    expect(response.status).toBe(404)
+    expect(Post.calls).toEqual([['1', 'slug']])
+  })
+
+  it('serializes the bound model name for introspection, same as the class form', () => {
+    const Post = makeModel()
+    const router = new Router()
+    router.get('/posts/:slug', { bind: { slug: [Post, 'slug'] }, name: 'posts.show' }, [controllerFor(Post), 'show'])
+
+    expect(router.definitions()[0]?.bindings).toEqual({ slug: 'Post' })
+  })
+})
+
+describe('Router-level bind(param, ...)', () => {
+  it('passes a model-bound record positionally after the context AND exposes it via this.model()', async () => {
+    const Post = makeModel()
+    const router = new Router()
+    router.bind('post', Post)
+    router.get('/posts/:post', [controllerFor(Post), 'showBoth'])
+    const app = mount(router)
+
+    const response = await app.request('/posts/1')
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ positional: posts[0], model: posts[0] })
+    expect(Post.calls).toEqual([['1', undefined]])
+  })
+
+  it('accepts a [Model, column] tuple and looks up by that column', async () => {
+    const Post = makeModel()
+    const router = new Router()
+    router.bind('post', [Post, 'slug'])
+    router.get('/posts/:post', [controllerFor(Post), 'showBoth'])
+    const app = mount(router)
+
+    const response = await app.request('/posts/second')
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ positional: posts[1], model: posts[1] })
+    expect(Post.calls).toEqual([['second', 'slug']])
+    expect(router.definitions()[0]?.bindings).toEqual({ post: 'Post' })
+  })
+
+  it('passes a custom resolver value as a positional argument, not on the context', async () => {
+    const Post = makeModel()
+    const router = new Router()
+    router.bind('post', async (slug) => posts.find((p) => p.slug === slug) ?? null)
+    router.get('/posts/:post', [controllerFor(Post), 'showPositional'])
+
+    let seenOnContext: unknown = 'unset'
+    const app = new Hono()
+    app.use('*', async (c, next) => {
+      await next()
+      seenOnContext = (c.get as (key: string) => unknown)('post')
+    })
+    router.mount(app)
+
+    const response = await app.request('/posts/hello-world')
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ via: 'positional', post: posts[0] })
+    // The resolver ran on its own — the model was never consulted — and the
+    // value is not published on the Hono context (`this.ctx.get('post')`).
+    expect(Post.calls).toEqual([])
+    expect(seenOnContext).toBeUndefined()
+    expect(router.definitions()[0]?.bindings).toBeUndefined()
+  })
+
+  it('does not expose a custom-resolver value through this.model()', async () => {
+    const Post = makeModel()
+    const router = new Router()
+    router.bind('post', async (slug) => posts.find((p) => p.slug === slug) ?? null)
+    router.get('/posts/:post', [controllerFor(Post), 'show'])
+    const app = mount(router)
+
+    const response = await app.request('/posts/hello-world')
+    expect(response.status).toBe(500)
+    expect(await response.text()).toContain('No model binding found for Post')
+  })
+
+  it('lets the route-level bind win when the same param is bound at both levels, without a second lookup', async () => {
+    // Fixture rows are arranged so a by-slug and a by-id lookup of the same
+    // raw value disagree: '1' is post 1's id, but no post's slug — and 'second'
+    // is post 2's slug. Route-level `[Post, 'slug']` must be what both
+    // this.model() and the positional argument observe.
+    const Post = makeModel()
+    const router = new Router()
+    router.bind('post', Post) // by primary key, router-wide
+    router.get('/posts/:post', { bind: { post: [Post, 'slug'] } }, [controllerFor(Post), 'showBoth'])
+    const app = mount(router)
+
+    const response = await app.request('/posts/second')
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ positional: posts[1], model: posts[1] })
+    expect(Post.calls).toEqual([['second', 'slug']])
+    expect(router.definitions()[0]?.bindings).toEqual({ post: 'Post' })
+  })
+
+  it('passes several bound values in path-parameter order', async () => {
+    class Pair extends Controller {
+      async show(_ctx: Context, a: string, b: string) {
+        return this.json({ a, b })
+      }
+    }
+    const router = new Router()
+    router.bind('a', async (v) => `A:${v}`)
+    router.bind('b', async (v) => `B:${v}`)
+    router.get('/pair/:a/:b', [Pair, 'show'])
+    const app = mount(router)
+
+    const response = await app.request('/pair/one/two')
+    expect(await response.json()).toEqual({ a: 'A:one', b: 'B:two' })
+  })
+})


### PR DESCRIPTION
## Summary

Framework gap found while authoring the Agents on Guren `post-slug-binding` task (a `/posts/:slug` route).

- **`bind: { slug: [Post, 'slug'] }`** — the `bind` option and router-level `router.bind()` now accept a `[Model, column]` tuple. The router calls `Model.findOrFail(value, column)`; the class-only form (`bind: { id: Post }`) keeps resolving by primary key. Both feed `this.model(Post)`.
- **Router-level model bindings feed `this.model()` too.** `router.bind('post', Post | [Post, 'slug'])` records are now available via `this.model(Post)` in addition to the positional argument. Custom resolver values remain positional-only (there is no model class to key them by). When the same param is bound at both levels, the route's own `bind` wins and the record is looked up once.
- **`this.model()` is typed from the model's `recordType` marker** (`BoundModelRecord<T>`) instead of `ReturnType<findOrFail>`, which widened to `Record<string, unknown>` for every real model — the docs claimed `PostRecord` all along. Classes without the marker keep the old fallback.
- **Docs now describe what actually happens.** The routing guide (en + ja) told readers to use `this.ctx.get('post')` for router-level bindings, which has always been `undefined`; the value arrives as a positional argument after the context, in path-parameter order. Same correction in the agent harness rules (`controllers-http.md`, `routes-codegen.md`) and the `guren context` API digest, whose sync test now pins the tuple token.
- `BindableModel` / `RouteModelBinding` types exported from `@guren/core`.

## Tests

`packages/server/tests/mvc/router-model-binding.test.ts` (11 tests) pins, against a `findOrFail(id, key?)` recorder: primary-key vs by-column lookup, no primary-key fallback on a column miss (404), introspection payload for the tuple form, router-level model + tuple bindings reaching both channels, custom resolver reaching only the positional argument (and not `c.get()`), the both-levels precedence, and positional order for several params. Each was mutation-checked (dropping the key → 3 fail; dropping the precedence → 1 fail).

## Checks

- `bun run build`, `bun run typecheck` (root, incl. examples), `bun run test:bun` (4555 pass), `test:testing`, examples/blog vitest — green
- `audit:core-first`, `audit:docs`, `audit:starter-template`, `audit:core-semver` — pass
- Changeset: `@guren/server` minor, `@guren/core` minor, `@guren/cli` patch
