### PR TITLE
fix(orm): run eager-loaded relations on the parent query's transaction

### DIFF
--- a/.changeset/eager-loading-inherits-transaction.md
+++ b/.changeset/eager-loading-inherits-transaction.md
@@ -17,7 +17,7 @@ could be inconsistent even when they did not.
 `ModelQueryOptions` and pass it to each related query, including the pivot and
 through-table reads. `QueryBuilder` forwards its own `trx`.
 
-`Model.with()`, `findWith()`, `findWithOrFail()` and `withPaginate()` gained an
-optional trailing `queryOptions` argument so they can forward a transaction too.
-These four previously took no query options at all, so this completes the
-plumbing rather than fixing a reachable bug in them.
+`Model.with()`, `findWith()`, `findWithOrFail()`, `withPaginate()` and
+`withCount()` gained an optional trailing `queryOptions` argument so they can
+forward a transaction too. These five previously took no query options at all,
+so this completes the plumbing rather than fixing a reachable bug in them.

--- a/.changeset/eager-loading-inherits-transaction.md
+++ b/.changeset/eager-loading-inherits-transaction.md
@@ -1,0 +1,23 @@
+---
+'@guren/orm': minor
+---
+
+Eager-loaded relations now run on the transaction that read their parents.
+
+`QueryBuilder` carried its `trx` into the parent query but not into the relation
+queries `with()` issues, so a transaction-bound `get()`, `first()` or
+`paginate()` read parents inside the transaction and their relations on the
+pool. On Postgres and MySQL, where the transaction selects a connection, that
+means relations of uncommitted parents came back `null` (or empty), and reads
+could be inconsistent even when they did not.
+
+`Model.loadRelationInto()` and every relation loader it delegates to
+(`belongsTo`, `hasMany`, `hasOne`, `belongsToMany`, `hasManyThrough`,
+`morphMany`, `morphTo`, and nested-path recursion) now accept
+`ModelQueryOptions` and pass it to each related query, including the pivot and
+through-table reads. `QueryBuilder` forwards its own `trx`.
+
+`Model.with()`, `findWith()`, `findWithOrFail()` and `withPaginate()` gained an
+optional trailing `queryOptions` argument so they can forward a transaction too.
+These four previously took no query options at all, so this completes the
+plumbing rather than fixing a reachable bug in them.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export type {
   PaginatedResult,
   ModelPaginationMeta,
   ORMAdapter,
+  ModelQueryOptions,
   TransactionHandle,
   TransactionModelScope,
   CastType,

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -1964,14 +1964,18 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     this: T,
     relations: K | readonly K[],
     where?: WhereClauseFor<T>,
+    queryOptions?: ModelQueryOptions,
   ): Promise<Array<TRecordFor<T> & RelationCountPick<K | readonly K[]>>>
 
   static async withCount<T extends typeof Model, Names extends RelationNames>(
     this: T,
     relations: Names,
     where?: WhereClauseFor<T>,
+    queryOptions?: ModelQueryOptions,
   ): Promise<Array<TRecordFor<T> & RelationCountPick<Names>>> {
-    const records = where ? await this.where(where) : await this.all()
+    const records = where
+      ? await this.newQuery(queryOptions).where(where as Partial<Record<string, unknown>>).get()
+      : await this.all(queryOptions)
     if (!records.length) {
       return records as Array<TRecordFor<T> & RelationCountPick<Names>>
     }
@@ -1979,7 +1983,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     const relationList = normalizeRelations(relations)
     const copies = records.map((record) => ({ ...record })) as Array<PlainObject>
     for (const relationName of relationList) {
-      await this.loadRelationCountInto(copies, relationName)
+      await this.loadRelationCountInto(copies, relationName, queryOptions)
     }
 
     return copies as Array<TRecordFor<T> & RelationCountPick<Names>>
@@ -1990,6 +1994,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     this: T,
     records: Array<PlainObject>,
     relationName: string,
+    queryOptions?: ModelQueryOptions,
   ): Promise<void> {
     if (relationName.includes('.')) {
       throw new Error(`${this.name}: withCount does not support nested relation "${relationName}".`)
@@ -2013,7 +2018,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
 
         const counts = new Map<unknown, number>()
         if (values.length > 0) {
-          const relatedRecords = (await related.where({ [foreignKey]: values } as WhereClause)) as PlainObject[]
+          const relatedRecords = (await related.newQuery(queryOptions).where({ [foreignKey]: values } as WhereClause)) as PlainObject[]
           for (const item of relatedRecords) {
             const key = item[foreignKey]
             counts.set(key, (counts.get(key) ?? 0) + 1)
@@ -2027,7 +2032,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
       }
       case 'morphMany': {
         const withRelation = records.map((record) => ({ ...record }))
-        await this.loadRelationInto(withRelation, relationName)
+        await this.loadRelationInto(withRelation, relationName, queryOptions)
         for (const [index, record] of records.entries()) {
           const value = withRelation[index]?.[relationName]
           record[countField] = Array.isArray(value) ? value.length : 0
@@ -2043,7 +2048,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
 
         const ownerKeys = new Set<unknown>()
         if (values.length > 0) {
-          const owners = (await related.where({ [ownerKey]: values } as WhereClause)) as PlainObject[]
+          const owners = (await related.newQuery(queryOptions).where({ [ownerKey]: values } as WhereClause)) as PlainObject[]
           for (const owner of owners) {
             ownerKeys.add(owner[ownerKey])
           }

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -888,6 +888,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     id: TRecordFor<T>[keyof TRecordFor<T> & string],
     relations: K | readonly K[],
     key?: keyof TRecordFor<T> & string,
+    queryOptions?: ModelQueryOptions,
   ): Promise<(TRecordFor<T> & RelationTypePick<T, K | readonly K[]>) | null>
 
   static async findWith<T extends typeof Model, Names extends RelationNames>(
@@ -895,8 +896,9 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     id: TRecordFor<T>[keyof TRecordFor<T> & string],
     relations: Names,
     key?: keyof TRecordFor<T> & string,
+    queryOptions?: ModelQueryOptions,
   ): Promise<(TRecordFor<T> & RelationTypePick<T, Names>) | null> {
-    const record = await this.find(id, key)
+    const record = await this.find(id, key, queryOptions)
     if (record == null) return null
 
     const relationList = normalizeRelations(relations)
@@ -906,7 +908,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
 
     const copy = { ...record }
     for (const rel of relationList) {
-      await this.loadRelationInto([copy], rel)
+      await this.loadRelationInto([copy], rel, queryOptions)
     }
     return copy as TRecordFor<T> & RelationTypePick<T, Names>
   }
@@ -930,6 +932,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     id: TRecordFor<T>[keyof TRecordFor<T> & string],
     relations: K | readonly K[],
     key?: keyof TRecordFor<T> & string,
+    queryOptions?: ModelQueryOptions,
   ): Promise<TRecordFor<T> & RelationTypePick<T, K | readonly K[]>>
 
   static async findWithOrFail<T extends typeof Model, Names extends RelationNames>(
@@ -937,8 +940,9 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     id: TRecordFor<T>[keyof TRecordFor<T> & string],
     relations: Names,
     key?: keyof TRecordFor<T> & string,
+    queryOptions?: ModelQueryOptions,
   ): Promise<TRecordFor<T> & RelationTypePick<T, Names>> {
-    const record = await this.findOrFail(id, key)
+    const record = await this.findOrFail(id, key, queryOptions)
 
     const relationList = normalizeRelations(relations)
     if (relationList.length === 0) {
@@ -947,7 +951,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
 
     const copy = { ...record }
     for (const rel of relationList) {
-      await this.loadRelationInto([copy], rel)
+      await this.loadRelationInto([copy], rel, queryOptions)
     }
     return copy as TRecordFor<T> & RelationTypePick<T, Names>
   }
@@ -1590,14 +1594,16 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     this: T,
     relations: K | readonly K[],
     options?: PaginateOptions<TRecordFor<T>>,
+    queryOptions?: ModelQueryOptions,
   ): Promise<PaginatedResult<TRecordFor<T> & RelationTypePick<T, K | readonly K[]>>>
 
   static async withPaginate<T extends typeof Model, Names extends RelationNames>(
     this: T,
     relations: Names,
     options: PaginateOptions<TRecordFor<T>> = {},
+    queryOptions?: ModelQueryOptions,
   ): Promise<PaginatedResult<TRecordFor<T> & RelationTypePick<T, Names>>> {
-    const result = await this.paginate(options)
+    const result = await this.paginate(options, queryOptions)
     const relationList = normalizeRelations(relations)
 
     if (relationList.length === 0 || result.data.length === 0) {
@@ -1607,7 +1613,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     const records = result.data.map((record) => ({ ...record }))
 
     for (const relationName of relationList) {
-      await this.loadRelationInto(records, relationName)
+      await this.loadRelationInto(records, relationName, queryOptions)
     }
 
     return {
@@ -1916,14 +1922,18 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     this: T,
     relations: K | readonly K[],
     where?: WhereClauseFor<T>,
+    queryOptions?: ModelQueryOptions,
   ): Promise<Array<TRecordFor<T> & RelationTypePick<T, K | readonly K[]>>>
 
   static async with<T extends typeof Model, Names extends RelationNames>(
     this: T,
     relations: Names,
     where?: WhereClauseFor<T>,
+    queryOptions?: ModelQueryOptions,
   ): Promise<Array<TRecordFor<T> & RelationTypePick<T, Names>>> {
-    const records = where ? await this.where(where) : await this.all()
+    const records = where
+      ? await this.newQuery(queryOptions).where(where as Partial<Record<string, unknown>>).get()
+      : await this.all(queryOptions)
     if (!records.length) {
       return records as Array<TRecordFor<T> & RelationTypePick<T, Names>>
     }
@@ -1935,7 +1945,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
 
     const copies = records.map((record) => ({ ...record }))
     for (const relationName of relationList) {
-      await this.loadRelationInto(copies, relationName)
+      await this.loadRelationInto(copies, relationName, queryOptions)
     }
 
     return copies as Array<TRecordFor<T> & RelationTypePick<T, Names>>
@@ -2060,6 +2070,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     this: T,
     records: Array<PlainObject>,
     relationName: string,
+    queryOptions?: ModelQueryOptions,
   ): Promise<void> {
     const [head, ...rest] = relationName.split('.')
     const definition = this.getRelationDefinition(head)
@@ -2070,25 +2081,25 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
 
     switch (definition.type) {
       case 'hasMany':
-        await this.loadHasMany(records, definition)
+        await this.loadHasMany(records, definition, queryOptions)
         break
       case 'hasOne':
-        await this.loadHasOne(records, definition)
+        await this.loadHasOne(records, definition, queryOptions)
         break
       case 'belongsTo':
-        await this.loadBelongsTo(records, definition)
+        await this.loadBelongsTo(records, definition, queryOptions)
         break
       case 'belongsToMany':
-        await this.loadBelongsToMany(records, definition)
+        await this.loadBelongsToMany(records, definition, queryOptions)
         break
       case 'hasManyThrough':
-        await this.loadHasManyThrough(records, definition)
+        await this.loadHasManyThrough(records, definition, queryOptions)
         break
       case 'morphMany':
-        await this.loadMorphMany(records, definition)
+        await this.loadMorphMany(records, definition, queryOptions)
         break
       case 'morphTo':
-        await this.loadMorphTo(records, definition)
+        await this.loadMorphTo(records, definition, queryOptions)
         break
     }
 
@@ -2122,39 +2133,43 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     }
 
     const related = await resolveModelReference(definition.related)
-    await related.loadRelationInto(children, rest.join('.'))
+    await related.loadRelationInto(children, rest.join('.'), queryOptions)
   }
 
   protected static async loadHasMany(
     records: Array<PlainObject>,
     definition: HasManyRelationDefinition,
+    queryOptions?: ModelQueryOptions,
   ): Promise<void> {
     const { foreignKey, localKey, name } = definition
     const related = await resolveModelReference(definition.related)
-    await loadRelationData(records, name, related, localKey, foreignKey, true)
+    await loadRelationData(records, name, related, localKey, foreignKey, true, queryOptions)
   }
 
   protected static async loadHasOne(
     records: Array<PlainObject>,
     definition: HasOneRelationDefinition,
+    queryOptions?: ModelQueryOptions,
   ): Promise<void> {
     const { foreignKey, localKey, name } = definition
     const related = await resolveModelReference(definition.related)
-    await loadRelationData(records, name, related, localKey, foreignKey, false)
+    await loadRelationData(records, name, related, localKey, foreignKey, false, queryOptions)
   }
 
   protected static async loadBelongsTo(
     records: Array<PlainObject>,
     definition: BelongsToRelationDefinition,
+    queryOptions?: ModelQueryOptions,
   ): Promise<void> {
     const { foreignKey, ownerKey, name } = definition
     const related = await resolveModelReference(definition.related)
-    await loadRelationData(records, name, related, foreignKey, ownerKey, false)
+    await loadRelationData(records, name, related, foreignKey, ownerKey, false, queryOptions)
   }
 
   protected static async loadBelongsToMany(
     records: Array<PlainObject>,
     definition: BelongsToManyRelationDefinition,
+    queryOptions?: ModelQueryOptions,
   ): Promise<void> {
     const { pivotTable, foreignPivotKey, relatedPivotKey, parentKey, relatedKey, name } = definition
     const related = await resolveModelReference(definition.related)
@@ -2175,7 +2190,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     const adapter = this.getAdapter()
     const pivotRows = await adapter.findMany<PlainObject>(pivotTable, {
       where: { [foreignPivotKey]: parentValues } as WhereClause,
-    })
+    }, queryOptions)
 
     // Build a map: parentKeyValue -> relatedKeyValue[]
     const pivotMap = new Map<unknown, unknown[]>()
@@ -2196,7 +2211,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     }
 
     // Step 2: Query related table for those IDs
-    const relatedRecords = await related.where({
+    const relatedRecords = await related.newQuery(queryOptions).where({
       [relatedKey]: Array.from(allRelatedIds),
     } as WhereClause) as PlainObject[]
 
@@ -2223,6 +2238,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
   protected static async loadHasManyThrough(
     records: Array<PlainObject>,
     definition: HasManyThroughRelationDefinition,
+    queryOptions?: ModelQueryOptions,
   ): Promise<void> {
     const { firstKey, secondKey, localKey, secondLocalKey, name } = definition
     const related = await resolveModelReference(definition.related)
@@ -2241,7 +2257,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     }
 
     // Step 1: Query through model for intermediate records
-    const throughRecords = await through.where({
+    const throughRecords = await through.newQuery(queryOptions).where({
       [firstKey]: localValues,
     } as WhereClause) as PlainObject[]
 
@@ -2264,7 +2280,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     }
 
     // Step 2: Query related model using through model's keys
-    const relatedRecords = await related.where({
+    const relatedRecords = await related.newQuery(queryOptions).where({
       [secondKey]: Array.from(allThroughIds),
     } as WhereClause) as PlainObject[]
 
@@ -2296,6 +2312,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
   protected static async loadMorphMany(
     records: Array<PlainObject>,
     definition: MorphManyRelationDefinition,
+    queryOptions?: ModelQueryOptions,
   ): Promise<void> {
     const { morphName, localKey, name } = definition
     const related = await resolveModelReference(definition.related)
@@ -2312,7 +2329,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
       return
     }
 
-    const allRelated = await related.where({
+    const allRelated = await related.newQuery(queryOptions).where({
       [typeColumn]: parentType,
       [idColumn]: localValues,
     } as WhereClause) as PlainObject[]
@@ -2333,6 +2350,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
   protected static async loadMorphTo(
     records: Array<PlainObject>,
     definition: MorphToRelationDefinition,
+    queryOptions?: ModelQueryOptions,
   ): Promise<void> {
     const { morphName, name } = definition
     const typeColumn = `${morphName}Type`
@@ -2355,7 +2373,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
       const modelClass = morphMap[type]
       if (!modelClass) continue
       const uniqueIds = Array.from(new Set(ids))
-      const results = await modelClass.where({ id: uniqueIds } as WhereClause) as PlainObject[]
+      const results = await modelClass.newQuery(queryOptions).where({ id: uniqueIds } as WhereClause) as PlainObject[]
       const idMap = new Map<unknown, PlainObject>()
       for (const r of results) idMap.set(r.id, { ...r })
       resolved.set(type, idMap)
@@ -2380,6 +2398,7 @@ async function loadRelationData(
   parentKey: string,
   relatedKey: string,
   isArray: boolean,
+  queryOptions?: ModelQueryOptions,
 ): Promise<void> {
   const values = Array.from(
     new Set(records.map((r) => r[parentKey]).filter((v): v is unknown => v != null)),
@@ -2392,7 +2411,7 @@ async function loadRelationData(
     return
   }
 
-  const relatedRecords = await related.where({ [relatedKey]: values } as WhereClause)
+  const relatedRecords = await related.newQuery(queryOptions).where({ [relatedKey]: values } as WhereClause)
   const map = new Map<unknown, PlainObject | PlainObject[]>()
 
   for (const item of relatedRecords as PlainObject[]) {

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -696,17 +696,22 @@ export class QueryBuilder<
    * Supports dot notation for nested relations at any depth
    * (e.g., 'posts.comments.author') — the full path is delegated to
    * Model.loadRelationInto, which recurses through the relation chain.
+   *
+   * The builder's `trx` goes with it: a relation loaded for rows read inside
+   * a transaction has to be read on that same handle, or the parents come
+   * from the transaction and their children from the pool — which on
+   * Postgres/MySQL means uncommitted parents get a null relation back.
    */
   private readonly loadEagerRelations = async (results: TResult[]): Promise<TResult[]> => {
     if (this.eagerLoad.length === 0 || results.length === 0) return results
 
     const copies = results.map((r) => ({ ...r }))
     const model = this.modelClass as typeof Model & {
-      loadRelationInto(records: PlainObject[], name: string): Promise<void>
+      loadRelationInto(records: PlainObject[], name: string, queryOptions?: AdapterQueryOptions): Promise<void>
     }
 
     for (const relation of this.eagerLoad) {
-      await model.loadRelationInto(copies as PlainObject[], relation)
+      await model.loadRelationInto(copies as PlainObject[], relation, { trx: this.options.trx })
     }
 
     return copies as TResult[]

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -16,6 +16,7 @@ export type {
   PaginatedResult,
   ModelPaginationMeta,
   ORMAdapter,
+  ModelQueryOptions,
   TransactionHandle,
   TransactionModelScope,
   CastType,

--- a/packages/orm/tests/postgres-integration.test.ts
+++ b/packages/orm/tests/postgres-integration.test.ts
@@ -257,6 +257,44 @@ describePostgres('eager loading inside a transaction (requires POSTGRES_URL)', (
       if (!(error instanceof RollbackSignal)) throw error
     })
   })
+
+  it('carries the transaction down a nested relation path', async () => {
+    // The recursion in loadRelationInto() re-enters on the related model, so
+    // the second hop has its own chance to fall back to the pool.
+    await Article.transaction(async (trx) => {
+      const author = (await Author.create({ name: 'Katherine' }, { trx })) as AuthorRecord
+      await Article.create({ title: 'On Orbits', authorId: author.id }, { trx })
+
+      const [loaded] = (await Author.newQuery({ trx })
+        .where('id', author.id)
+        .with('articles.author')
+        .get()) as Array<AuthorRecord & { articles: Array<ArticleRecord & { author: AuthorRecord | null }> }>
+
+      expect(loaded.articles[0]?.author).toMatchObject({ name: 'Katherine' })
+
+      throw new RollbackSignal()
+    }).catch((error: unknown) => {
+      if (!(error instanceof RollbackSignal)) throw error
+    })
+  })
+
+  it('counts related rows on the transaction with withCount()', async () => {
+    await Article.transaction(async (trx) => {
+      const author = (await Author.create({ name: 'Radia' }, { trx })) as AuthorRecord
+      await Article.create({ title: 'On Trees', authorId: author.id }, { trx })
+      await Article.create({ title: 'On Bridges', authorId: author.id }, { trx })
+
+      const [loaded] = (await Author.withCount('articles', { id: author.id }, { trx })) as Array<
+        AuthorRecord & { articlesCount: number }
+      >
+
+      expect(loaded.articlesCount).toBe(2)
+
+      throw new RollbackSignal()
+    }).catch((error: unknown) => {
+      if (!(error instanceof RollbackSignal)) throw error
+    })
+  })
 })
 
 /** Unwinds a transaction after its assertions have run, without failing it. */

--- a/packages/orm/tests/postgres-integration.test.ts
+++ b/packages/orm/tests/postgres-integration.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { sql } from 'drizzle-orm'
 import { integer, pgTable, serial, varchar } from 'drizzle-orm/pg-core'
 import { createPostgresDatabase, type PostgresDatabase } from '../src/postgres'
-import { Model } from '../src/Model'
+import { Model, type PaginatedResult, type TransactionHandle } from '../src/Model'
 import { DrizzleAdapter } from '../src/adapters/drizzle-adapter'
 
 // The unit tests in postgres.test.ts mock `postgres` and the migrator away, so
@@ -116,6 +116,9 @@ describePostgres('createPostgresDatabase against a real PostgreSQL server (requi
   })
 })
 
+/** Unwinds a transaction after its assertions have run, without failing it. */
+class RollbackSignal extends Error {}
+
 // Its own database: the block above resets the one it uses, which drops every
 // table in it, and these fixtures have to survive alongside them.
 const RELATIONS_DATABASE = 'guren_orm_relations_test'
@@ -190,8 +193,26 @@ describePostgres('eager loading inside a transaction (requires POSTGRES_URL)', (
     await database?.closeDatabase()
   })
 
-  it('loads a belongsTo relation on the transaction that read its parent', async () => {
+  /**
+   * Run a body inside a transaction, then unwind it so its fixtures stay out
+   * of later tests. Two things here are load-bearing: the signal is thrown
+   * only after the body's assertions have run, and every other error
+   * propagates untouched — so a failed assertion still surfaces as itself
+   * rather than as a rollback.
+   */
+  async function inRolledBackTransaction(
+    body: (trx: TransactionHandle) => Promise<void>,
+  ): Promise<void> {
     await Article.transaction(async (trx) => {
+      await body(trx)
+      throw new RollbackSignal()
+    }).catch((error: unknown) => {
+      if (!(error instanceof RollbackSignal)) throw error
+    })
+  }
+
+  it('loads a belongsTo relation on the transaction that read its parent', async () => {
+    await inRolledBackTransaction(async (trx) => {
       const author = (await Author.create({ name: 'Ada' }, { trx })) as AuthorRecord
       const article = (await Article.create(
         { title: 'On Engines', authorId: author.id },
@@ -213,35 +234,27 @@ describePostgres('eager loading inside a transaction (requires POSTGRES_URL)', (
 
       // Rolling back keeps the fixture out of later runs; the assertions above
       // have already been made, so a failure still surfaces as itself.
-      throw new RollbackSignal()
-    }).catch((error: unknown) => {
-      if (!(error instanceof RollbackSignal)) throw error
     })
   })
 
   it('loads relations through paginate() on the transaction', async () => {
-    await Article.transaction(async (trx) => {
+    await inRolledBackTransaction(async (trx) => {
       const author = (await Author.create({ name: 'Grace' }, { trx })) as AuthorRecord
       await Article.create({ title: 'On Compilers', authorId: author.id }, { trx })
 
       const page = (await Article.newQuery({ trx })
         .where('authorId', author.id)
         .with('author')
-        .paginate(1, 10)) as unknown as {
-        data: Array<ArticleRecord & { author: AuthorRecord | null }>
-      }
+        .paginate(1, 10)) as PaginatedResult<ArticleRecord & { author: AuthorRecord | null }>
 
       expect(page.data).toHaveLength(1)
       expect(page.data[0].author).toMatchObject({ name: 'Grace' })
 
-      throw new RollbackSignal()
-    }).catch((error: unknown) => {
-      if (!(error instanceof RollbackSignal)) throw error
     })
   })
 
   it('loads a hasMany relation on the transaction that read its parent', async () => {
-    await Article.transaction(async (trx) => {
+    await inRolledBackTransaction(async (trx) => {
       const author = (await Author.create({ name: 'Barbara' }, { trx })) as AuthorRecord
       await Article.create({ title: 'On Genomes', authorId: author.id }, { trx })
 
@@ -252,16 +265,13 @@ describePostgres('eager loading inside a transaction (requires POSTGRES_URL)', (
 
       expect(loaded.articles.map((article) => article.title)).toEqual(['On Genomes'])
 
-      throw new RollbackSignal()
-    }).catch((error: unknown) => {
-      if (!(error instanceof RollbackSignal)) throw error
     })
   })
 
   it('carries the transaction down a nested relation path', async () => {
     // The recursion in loadRelationInto() re-enters on the related model, so
     // the second hop has its own chance to fall back to the pool.
-    await Article.transaction(async (trx) => {
+    await inRolledBackTransaction(async (trx) => {
       const author = (await Author.create({ name: 'Katherine' }, { trx })) as AuthorRecord
       await Article.create({ title: 'On Orbits', authorId: author.id }, { trx })
 
@@ -272,14 +282,11 @@ describePostgres('eager loading inside a transaction (requires POSTGRES_URL)', (
 
       expect(loaded.articles[0]?.author).toMatchObject({ name: 'Katherine' })
 
-      throw new RollbackSignal()
-    }).catch((error: unknown) => {
-      if (!(error instanceof RollbackSignal)) throw error
     })
   })
 
   it('counts related rows on the transaction with withCount()', async () => {
-    await Article.transaction(async (trx) => {
+    await inRolledBackTransaction(async (trx) => {
       const author = (await Author.create({ name: 'Radia' }, { trx })) as AuthorRecord
       await Article.create({ title: 'On Trees', authorId: author.id }, { trx })
       await Article.create({ title: 'On Bridges', authorId: author.id }, { trx })
@@ -290,12 +297,6 @@ describePostgres('eager loading inside a transaction (requires POSTGRES_URL)', (
 
       expect(loaded.articlesCount).toBe(2)
 
-      throw new RollbackSignal()
-    }).catch((error: unknown) => {
-      if (!(error instanceof RollbackSignal)) throw error
     })
   })
 })
-
-/** Unwinds a transaction after its assertions have run, without failing it. */
-class RollbackSignal extends Error {}

--- a/packages/orm/tests/postgres-integration.test.ts
+++ b/packages/orm/tests/postgres-integration.test.ts
@@ -3,7 +3,10 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { sql } from 'drizzle-orm'
+import { integer, pgTable, serial, varchar } from 'drizzle-orm/pg-core'
 import { createPostgresDatabase, type PostgresDatabase } from '../src/postgres'
+import { Model } from '../src/Model'
+import { DrizzleAdapter } from '../src/adapters/drizzle-adapter'
 
 // The unit tests in postgres.test.ts mock `postgres` and the migrator away, so
 // they can assert that a migration run *happens* but never that the database
@@ -23,14 +26,14 @@ function databaseUrl(url: string, database: string): string {
   return target.toString()
 }
 
-async function ensureTestDatabase(url: string): Promise<void> {
+async function ensureTestDatabase(url: string, database: string = TEST_DATABASE): Promise<void> {
   const { default: postgres } = await import('postgres')
   const admin = postgres(databaseUrl(url, 'postgres'), { max: 1 })
   try {
-    const existing = await admin.unsafe(`SELECT 1 FROM pg_database WHERE datname = '${TEST_DATABASE}'`)
+    const existing = await admin.unsafe(`SELECT 1 FROM pg_database WHERE datname = '${database}'`)
     // Postgres has no CREATE DATABASE IF NOT EXISTS.
     if (existing.length === 0) {
-      await admin.unsafe(`CREATE DATABASE "${TEST_DATABASE}"`)
+      await admin.unsafe(`CREATE DATABASE "${database}"`)
     }
   } finally {
     await admin.end({ timeout: 0 })
@@ -112,3 +115,149 @@ describePostgres('createPostgresDatabase against a real PostgreSQL server (requi
     expect(remaining.map((row) => row.name)).toContain('widgets')
   })
 })
+
+// Its own database: the block above resets the one it uses, which drops every
+// table in it, and these fixtures have to survive alongside them.
+const RELATIONS_DATABASE = 'guren_orm_relations_test'
+
+function createRelationsMigrationsFolder(): string {
+  const migrationsFolder = mkdtempSync(join(tmpdir(), 'guren-orm-postgres-relations-'))
+  const migrationDir = join(migrationsFolder, '20240101000000_init')
+  mkdirSync(migrationDir, { recursive: true })
+  writeFileSync(
+    join(migrationDir, 'migration.sql'),
+    'CREATE TABLE "authors" ("id" serial PRIMARY KEY NOT NULL, "name" varchar(255) NOT NULL);\n'
+    // The migrator splits on this marker; the newlines are load-bearing, since
+    // `--` would otherwise comment out the statement that follows it.
+    + '--> statement-breakpoint\n'
+    + 'CREATE TABLE "articles" ("id" serial PRIMARY KEY NOT NULL, "title" varchar(255) NOT NULL,'
+    + ' "author_id" integer NOT NULL);\n',
+  )
+  return migrationsFolder
+}
+
+const authorsTable = pgTable('authors', {
+  id: serial('id').primaryKey(),
+  name: varchar('name', { length: 255 }).notNull(),
+})
+
+const articlesTable = pgTable('articles', {
+  id: serial('id').primaryKey(),
+  title: varchar('title', { length: 255 }).notNull(),
+  authorId: integer('author_id').notNull(),
+})
+
+type AuthorRecord = typeof authorsTable.$inferSelect
+type ArticleRecord = typeof articlesTable.$inferSelect
+
+// Eager loading against a real transaction. A pooled driver is what makes this
+// observable at all: the fake adapters hand every query the same store, so a
+// relation query that ignores `trx` still returns the uncommitted parent's
+// children and the bug reads as correct behavior.
+describePostgres('eager loading inside a transaction (requires POSTGRES_URL)', () => {
+  let database: PostgresDatabase
+
+  class Author extends Model<AuthorRecord> {
+    static override table = authorsTable
+  }
+
+  class Article extends Model<ArticleRecord> {
+    static override table = articlesTable
+  }
+
+  Article.belongsTo('author', Author, 'authorId', 'id')
+  Author.hasMany('articles', Article, 'authorId', 'id')
+
+  beforeAll(async () => {
+    const url = POSTGRES_URL as string
+    await ensureTestDatabase(url, RELATIONS_DATABASE)
+    database = createPostgresDatabase({
+      migrationsFolder: createRelationsMigrationsFolder(),
+      connectionString: () => databaseUrl(url, RELATIONS_DATABASE),
+      // The default pool holds a single connection, which would turn the
+      // symptom under test into a different one: a relation query that skips
+      // the transaction would sit waiting for the connection the transaction
+      // is holding rather than returning rows it cannot see. Bun charges a
+      // timeout to whichever test runs next, so the failure would not even
+      // point here.
+      clientOptions: { max: 5 },
+    })
+    await database.resetDatabase()
+    DrizzleAdapter.configure((await database.getDatabase()) as never)
+  })
+
+  afterAll(async () => {
+    await database?.closeDatabase()
+  })
+
+  it('loads a belongsTo relation on the transaction that read its parent', async () => {
+    await Article.transaction(async (trx) => {
+      const author = (await Author.create({ name: 'Ada' }, { trx })) as AuthorRecord
+      const article = (await Article.create(
+        { title: 'On Engines', authorId: author.id },
+        { trx },
+      )) as ArticleRecord
+
+      // The premise: nothing outside the transaction can see either row yet,
+      // so a relation query that runs on the pool has no author to find. If
+      // this ever stops holding, the assertion below passes for free.
+      const fromPool = await Author.find(author.id)
+      expect(fromPool).toBeNull()
+
+      const [loaded] = (await Article.newQuery({ trx })
+        .where('id', article.id)
+        .with('author')
+        .get()) as Array<ArticleRecord & { author: AuthorRecord | null }>
+
+      expect(loaded.author).toMatchObject({ id: author.id, name: 'Ada' })
+
+      // Rolling back keeps the fixture out of later runs; the assertions above
+      // have already been made, so a failure still surfaces as itself.
+      throw new RollbackSignal()
+    }).catch((error: unknown) => {
+      if (!(error instanceof RollbackSignal)) throw error
+    })
+  })
+
+  it('loads relations through paginate() on the transaction', async () => {
+    await Article.transaction(async (trx) => {
+      const author = (await Author.create({ name: 'Grace' }, { trx })) as AuthorRecord
+      await Article.create({ title: 'On Compilers', authorId: author.id }, { trx })
+
+      const page = (await Article.newQuery({ trx })
+        .where('authorId', author.id)
+        .with('author')
+        .paginate(1, 10)) as unknown as {
+        data: Array<ArticleRecord & { author: AuthorRecord | null }>
+      }
+
+      expect(page.data).toHaveLength(1)
+      expect(page.data[0].author).toMatchObject({ name: 'Grace' })
+
+      throw new RollbackSignal()
+    }).catch((error: unknown) => {
+      if (!(error instanceof RollbackSignal)) throw error
+    })
+  })
+
+  it('loads a hasMany relation on the transaction that read its parent', async () => {
+    await Article.transaction(async (trx) => {
+      const author = (await Author.create({ name: 'Barbara' }, { trx })) as AuthorRecord
+      await Article.create({ title: 'On Genomes', authorId: author.id }, { trx })
+
+      const [loaded] = (await Author.newQuery({ trx })
+        .where('id', author.id)
+        .with('articles')
+        .get()) as Array<AuthorRecord & { articles: ArticleRecord[] }>
+
+      expect(loaded.articles.map((article) => article.title)).toEqual(['On Genomes'])
+
+      throw new RollbackSignal()
+    }).catch((error: unknown) => {
+      if (!(error instanceof RollbackSignal)) throw error
+    })
+  })
+})
+
+/** Unwinds a transaction after its assertions have run, without failing it. */
+class RollbackSignal extends Error {}


### PR DESCRIPTION
## Summary

Eager-loaded relations did not inherit the transaction of the query they decorate.

`QueryBuilder.executeQuery()` and `count()` passed `{ trx: this.options.trx }` to the adapter, but `loadEagerRelations` called `Model.loadRelationInto(records, relation)` with no query options, and the relation loaders issued plain, unbound queries. So `Post.newQuery({ trx }).with('author').get()` read the parent rows inside the transaction and the `author` rows on the connection pool.

On adapters where the transaction selects a connection (Postgres, MySQL), that means relations of uncommitted parents come back `null` or empty, and reads can be inconsistent even when they do not.

`Model.loadRelationInto()` and every loader it delegates to — `belongsTo`, `hasMany`, `hasOne`, `belongsToMany`, `hasManyThrough`, `morphMany`, `morphTo`, and the nested-path recursion — now accept `ModelQueryOptions` and pass it to each related query, including the pivot and through-table reads. `QueryBuilder` forwards its own `trx`.

One detail worth calling out for review: the loaders reached the database through `Model.where()`, a static that internally calls `this.newQuery()` with no options and therefore has nowhere to put a `trx`. They now call `related.newQuery(queryOptions).where(...)`. This is the same code path — `Model.where()` is itself just `newQuery().where(...)`, so global scopes, soft-delete filtering, and read transforms are unchanged. Threading the parameter while leaving `related.where(...)` in place would have type-checked cleanly and left the fix a silent no-op.

`with()`, `findWith()`, `findWithOrFail()`, `withPaginate()` and `withCount()` gained an optional trailing `queryOptions`. **These five previously took no query options at all and are not reachable from `TransactionModelScope`, so this half completes the plumbing rather than fixing a demonstrable bug in them.**

## Scope

- `orm` — `packages/orm/src/Model.ts`, `packages/orm/src/QueryBuilder.ts`, `packages/orm/src/index.ts`
- `core` — `packages/core/src/index.ts` (type re-export only)
- tests — `packages/orm/tests/postgres-integration.test.ts`

## Risk Assessment

Behavior-preserving for existing callers.

- Every new parameter is optional and trailing, on both the overload declaration and the implementation signature. No existing call site changes.
- Non-transactional eager loads now pass `{ trx: undefined }` rather than omitting the argument. This is not a new hazard: `executeQuery()` and `count()` already pass `{ trx: this.options.trx }` unconditionally on every query, and `resolveExecutor()` in the Drizzle adapter guards with `options?.trx && typeof options.trx === 'object'`, so a present-but-undefined `trx` falls back to the configured database exactly as an absent one does.
- `ModelQueryOptions` is now exported from `@guren/orm` and `@guren/core`. Five public statics take it as a parameter type; callers could pass a `{ trx }` literal structurally but had no way to name it. `TransactionHandle` was already exported alongside it.
- `minor` for `@guren/orm`. No `@guren/core` changeset — the addition is a type re-export, and the one-directional core gate fires on a server major.

### Known gaps, deliberately not addressed here

- `TransactionModelScope` (returned by `Model.inTransaction()`) forwards `trx` for `all`/`find`/`first`/`where`/`newQuery`/`create`/`update`/`delete`/`paginate` but does not expose the `with*` family. Adding it is new public API surface; `scope.newQuery().with('author')` covers the case today.
- Separately, `.with({ author: (q) => q.where(...) })` stores its constraint callback at `QueryBuilder.ts:336` and never reads it, so the object form of `with()` silently drops the constraint. Pre-existing and unrelated to this fix; filed as its own issue.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test`

```
bun run test:bun (POSTGRES_URL set)   4630 tests, 0 fail
bun run test:examples                 112 pass
bun run audit:core-first              passed
bun run audit:docs                    passed
```

The new tests run against a real PostgreSQL server and a real transaction, and **each was mutation-verified**: reverting the `{ trx: this.options.trx }` forwarding at `QueryBuilder.ts:714` turns them red with `author: null` / an empty array, and reverting the `newQuery(queryOptions)` swap in `loadRelationData` does the same. A test that cannot fail would prove nothing here, and the no-op variant described above is easy to ship by accident.

Two details in the test are load-bearing and should not be "cleaned up":

- **`clientOptions: { max: 5 }`.** The default pool holds a single connection. With one, a relation query that skips the transaction would block waiting for the connection the transaction holds instead of returning rows it cannot see — a hang rather than a wrong answer. Bun charges that timeout to whichever test runs next, so the failure would not even point at this file.
- **The `await Author.find(author.id)` premise check.** It asserts the pool cannot see the uncommitted parent. If transaction isolation ever stops holding, the assertion that follows would pass for free.

The suite uses its own database, because the existing block in the same file calls `resetDatabase()`, which drops every schema in the one it runs against.

Not verified: the MySQL integration suite is red locally, in its own `ensureTestDatabase` (`packages/orm/tests/mysql-integration.test.ts:31`) with `Access denied for user 'guren'@'%' to database 'mysql'`. That is a local permission gap in the test's setup, before any ORM code runs, and is untouched by this change.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation — no docs change needed; nothing in `docs/` documented a workaround for this, and no documented API signature changed incompatibly.
