### PR TITLE
fix(server): publish the application container so Job.make() resolves

### DIFF
--- a/.changeset/job-make-container.md
+++ b/.changeset/job-make-container.md
@@ -1,0 +1,21 @@
+---
+"@guren/server": patch
+---
+
+Publish the application container so `Job.make()` works
+
+`Job.make()` and the exported `resolve()` read the process-wide container that
+`setContainer()` fills in, but nothing in the framework ever called it. Every
+job that resolved a service — the `this.make('mail')` pattern the `Job` JSDoc
+advertises, and the mail jobs the auth scaffold generates — therefore threw
+`Container not initialized. Call setContainer() first.` the moment a driver ran
+it, whether that was `SyncDriver` in-process or `guren queue:work`.
+
+`Application` now publishes its own container when it is constructed, so
+anything reaching for the global finds the app's bindings.
+
+Construction rather than `boot()` is deliberate: `guren queue:work` imports the
+app entry to read the queue driver and never calls `boot()`, so a job can run
+against an app that was only constructed. The most recently constructed
+application wins, which is what `bun --hot` needs — a reloaded entry replaces
+the stale container instead of being ignored.

--- a/.changeset/job-make-container.md
+++ b/.changeset/job-make-container.md
@@ -6,16 +6,23 @@ Publish the application container so `Job.make()` works
 
 `Job.make()` and the exported `resolve()` read the process-wide container that
 `setContainer()` fills in, but nothing in the framework ever called it. Every
-job that resolved a service — the `this.make('mail')` pattern the `Job` JSDoc
-advertises, and the mail jobs the auth scaffold generates — therefore threw
-`Container not initialized. Call setContainer() first.` the moment a driver ran
-it, whether that was `SyncDriver` in-process or `guren queue:work`.
+job that resolved a service — `this.make('mail')` inside `handle()`, the way a
+controller resolves one — therefore threw `Container not initialized. Call
+setContainer() first.` the moment a driver ran it, whether that was `SyncDriver`
+in-process or the worker behind `guren queue:work`.
 
-`Application` now publishes its own container when it is constructed, so
-anything reaching for the global finds the app's bindings.
+`Application` now publishes its own container, so anything reaching for the
+global finds the app's bindings.
 
-Construction rather than `boot()` is deliberate: `guren queue:work` imports the
-app entry to read the queue driver and never calls `boot()`, so a job can run
-against an app that was only constructed. The most recently constructed
-application wins, which is what `bun --hot` needs — a reloaded entry replaces
-the stale container instead of being ignored.
+It publishes at construction rather than in `boot()`: `guren queue:work`
+bootstraps the app only far enough to read the queue driver, and an entry that
+merely exports the application — with no `ready` or `bootstrap` export — is
+accepted there and never booted. A job dispatched from module scope is in the
+same position. Bindings a service provider registers still only exist after
+`boot()`, as before; construction publishes the container, not its contents.
+
+Publishing is the constructor's last step, so an application that fails to
+build leaves the previous one's container in place instead of replacing it with
+a half-built one. Otherwise the most recently constructed application wins,
+which is what `bun --hot` needs — a reloaded entry replaces the stale container
+rather than being ignored.

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import type { MiddlewareHandler, ExecutionContext } from 'hono'
 import { Router } from '../mvc/Router'
-import { Container, mountModuleRoutes, type ServiceProvider, type GurenModule } from '../container'
+import { Container, mountModuleRoutes, setContainer, type ServiceProvider, type GurenModule } from '../container'
 import { ProviderManager, type ServiceProviderConstructor } from '../container/ServiceProvider'
 import { AuthManager } from '../auth/AuthManager'
 import { AuthServiceProvider } from '../providers/AuthServiceProvider'
@@ -632,6 +632,18 @@ export class Application {
     // scope to register the asset routes before bootstrap() awaits boot().
     // Registering first here is the only ordering an app cannot get in front of.
     this.mountSecurityDefaults()
+
+    // Publish this container as the process-wide one. Code that runs outside a
+    // request has no context to reach it through — Job.make() and the exported
+    // resolve() both read the global — so without this every job that resolves
+    // a service throws "Container not initialized".
+    //
+    // Set here rather than in boot() because a job can run against an app that
+    // was never booted: `guren queue:work` imports the app entry (which builds
+    // the Application at module scope) and reads the queue driver without
+    // calling boot(). Last construction wins, which is what `bun --hot` wants —
+    // a reloaded entry replaces the stale container instead of being ignored.
+    setContainer(this.container)
 
     // Bind core instances
     this.container.instance('app', this as Application)

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -633,18 +633,6 @@ export class Application {
     // Registering first here is the only ordering an app cannot get in front of.
     this.mountSecurityDefaults()
 
-    // Publish this container as the process-wide one. Code that runs outside a
-    // request has no context to reach it through — Job.make() and the exported
-    // resolve() both read the global — so without this every job that resolves
-    // a service throws "Container not initialized".
-    //
-    // Set here rather than in boot() because a job can run against an app that
-    // was never booted: `guren queue:work` imports the app entry (which builds
-    // the Application at module scope) and reads the queue driver without
-    // calling boot(). Last construction wins, which is what `bun --hot` wants —
-    // a reloaded entry replaces the stale container instead of being ignored.
-    setContainer(this.container)
-
     // Bind core instances
     this.container.instance('app', this as Application)
     this.container.instance('hono', this.hono)
@@ -726,6 +714,24 @@ export class Application {
     if (!hasUserProviderOf(InertiaServiceProvider)) {
       this.providerManager.register(InertiaServiceProvider)
     }
+
+    // Publish this container as the process-wide one. Code that runs outside a
+    // request has no context to reach it through — Job.make() and the exported
+    // resolve() both read the global — so without this every job that resolves
+    // a service throws "Container not initialized".
+    //
+    // Construction rather than boot(): `guren queue:work` bootstraps the app
+    // only far enough to read the queue driver, and an entry that just exports
+    // the application (no `ready`/`bootstrap`) is accepted there and never
+    // booted. A job dispatched from module scope is in the same position.
+    //
+    // Last statement of the constructor, so an application that fails to build
+    // — provider registration below instantiates providers, and that can throw
+    // — leaves the previous application's container in place rather than
+    // publishing its own half-built one. Otherwise last construction wins,
+    // which is what `bun --hot` wants: a reloaded entry replaces the stale
+    // container instead of being ignored.
+    setContainer(this.container)
   }
 
   get auth(): AuthManager {

--- a/packages/server/tests/queue/job-container.test.ts
+++ b/packages/server/tests/queue/job-container.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { Application } from '../../src/http/Application'
+import { Job, SyncDriver, createQueueManager, registerJob, clearJobRegistry } from '../../src/queue'
+
+interface Mailer {
+  send: (subject: string) => void
+}
+
+class ResolvingJob extends Job<{ subject: string }> {
+  async handle(payload: { subject: string }): Promise<void> {
+    this.make<Mailer>('mail').send(payload.subject)
+  }
+}
+
+function useSyncDriver(): void {
+  createQueueManager({
+    default: 'sync',
+    drivers: { sync: () => new SyncDriver() },
+  }).driver()
+}
+
+describe('Job.make() against an Application container', () => {
+  beforeEach(() => {
+    clearJobRegistry()
+    useSyncDriver()
+    registerJob(ResolvingJob)
+  })
+
+  it('resolves bindings when a job runs on the sync driver', async () => {
+    const app = new Application()
+    const sent: string[] = []
+    app.container.instance('mail', { send: (subject: string) => sent.push(subject) } satisfies Mailer)
+    await app.boot()
+
+    await ResolvingJob.dispatch({ subject: 'Welcome' })
+
+    expect(sent).toEqual(['Welcome'])
+  })
+
+  it('resolves bindings before the application is booted', async () => {
+    // `guren queue:work` imports the app entry and reads the queue driver
+    // without calling boot(), so a job can run against a constructed-only app.
+    // Moving the setContainer() call into boot() fails this test and not the
+    // one above.
+    const app = new Application()
+    const sent: string[] = []
+    app.container.instance('mail', { send: (subject: string) => sent.push(subject) } satisfies Mailer)
+
+    await ResolvingJob.dispatch({ subject: 'Unbooted' })
+
+    expect(sent).toEqual(['Unbooted'])
+  })
+})

--- a/packages/server/tests/queue/job-container.test.ts
+++ b/packages/server/tests/queue/job-container.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, beforeEach } from 'bun:test'
 import { Application } from '../../src/http/Application'
-import { Job, SyncDriver, createQueueManager, registerJob, clearJobRegistry } from '../../src/queue'
+import { resolve } from '../../src/container'
+import {
+  Job,
+  MemoryDriver,
+  SyncDriver,
+  Worker,
+  createQueueManager,
+  registerJob,
+  clearJobRegistry,
+} from '../../src/queue'
 
 interface Mailer {
   send: (subject: string) => void
@@ -12,24 +21,22 @@ class ResolvingJob extends Job<{ subject: string }> {
   }
 }
 
-function useSyncDriver(): void {
-  createQueueManager({
-    default: 'sync',
-    drivers: { sync: () => new SyncDriver() },
-  }).driver()
+function appWithMailer(): { app: Application; sent: string[] } {
+  const app = new Application()
+  const sent: string[] = []
+  app.container.instance('mail', { send: (subject: string) => sent.push(subject) } satisfies Mailer)
+  return { app, sent }
 }
 
-describe('Job.make() against an Application container', () => {
+describe('the container an Application publishes', () => {
   beforeEach(() => {
     clearJobRegistry()
-    useSyncDriver()
     registerJob(ResolvingJob)
   })
 
-  it('resolves bindings when a job runs on the sync driver', async () => {
-    const app = new Application()
-    const sent: string[] = []
-    app.container.instance('mail', { send: (subject: string) => sent.push(subject) } satisfies Mailer)
+  it('lets a job resolve bindings on the sync driver', async () => {
+    createQueueManager({ default: 'sync', drivers: { sync: () => new SyncDriver() } }).driver()
+    const { app, sent } = appWithMailer()
     await app.boot()
 
     await ResolvingJob.dispatch({ subject: 'Welcome' })
@@ -37,17 +44,54 @@ describe('Job.make() against an Application container', () => {
     expect(sent).toEqual(['Welcome'])
   })
 
-  it('resolves bindings before the application is booted', async () => {
-    // `guren queue:work` imports the app entry and reads the queue driver
-    // without calling boot(), so a job can run against a constructed-only app.
-    // Moving the setContainer() call into boot() fails this test and not the
-    // one above.
-    const app = new Application()
-    const sent: string[] = []
-    app.container.instance('mail', { send: (subject: string) => sent.push(subject) } satisfies Mailer)
+  it('lets a job resolve bindings before the application is booted', async () => {
+    // `guren queue:work` bootstraps the app only far enough to read the queue
+    // driver, so a job can run against an app that was never booted. Moving the
+    // setContainer() call into boot() fails this test and not the one above.
+    createQueueManager({ default: 'sync', drivers: { sync: () => new SyncDriver() } }).driver()
+    const { sent } = appWithMailer()
 
     await ResolvingJob.dispatch({ subject: 'Unbooted' })
 
     expect(sent).toEqual(['Unbooted'])
+  })
+
+  it('lets a job resolve bindings when a worker drains the queue', async () => {
+    // The shape `queue:work` actually runs: dispatch only enqueues, and the job
+    // is constructed and handled later by the Worker.
+    const driver = new MemoryDriver()
+    createQueueManager({ default: 'memory', drivers: { memory: () => driver } }).driver()
+    const { app, sent } = appWithMailer()
+    await app.boot()
+
+    await ResolvingJob.dispatch({ subject: 'Deferred' })
+    expect(sent).toEqual([])
+
+    await new Worker(driver, { queues: ['default'], sleep: 0, stopWhenEmpty: true }).start()
+
+    expect(sent).toEqual(['Deferred'])
+  })
+
+  it('backs the exported resolve() helper', () => {
+    const { app } = appWithMailer()
+    app.container.instance('probe', { value: 42 })
+
+    expect(resolve<{ value: number }>('probe')).toEqual({ value: 42 })
+  })
+
+  it('keeps the previous container when an application fails to construct', () => {
+    const { app } = appWithMailer()
+    app.container.instance('probe', { value: 'first' })
+
+    class ExplodingProvider {
+      constructor() {
+        throw new Error('provider blew up')
+      }
+    }
+
+    expect(
+      () => new Application({ providers: [ExplodingProvider as never] }),
+    ).toThrow('provider blew up')
+    expect(resolve<{ value: string }>('probe')).toEqual({ value: 'first' })
   })
 })


### PR DESCRIPTION
## Summary

`Job.make()` never worked. It delegates to `getContainer()` (`packages/server/src/queue/Job.ts:93-97`), and nothing in the framework ever called `setContainer()` — the only writes were the export itself and `controller.setContainer()` in `Router.ts`, which fills a different, per-request slot. So any job resolving a service inside `handle()` threw `Container not initialized. Call setContainer() first.` the moment a driver ran it, whether that was `SyncDriver` in-process or the worker behind `guren queue:work`. The exported `resolve()` helper was dead for the same reason.

`Application` now publishes its own container, so anything reaching for the global finds the app's bindings.

Two placement decisions, both pinned by tests:

- **Construction, not `boot()`.** `guren queue:work` bootstraps the app only far enough to read the queue driver (`packages/cli/src/queue.ts:getConfiguredDriver`, which never calls `ensureApplicationBooted`), and an entry that merely exports the application — no `ready`/`bootstrap` export — is accepted there and never booted. A job dispatched from module scope is in the same position. Bindings a service provider registers still only exist after `boot()`, as before: construction publishes the container, not its contents.
- **Last statement of the constructor.** `ProviderManager.register()` instantiates providers (`new providerOrClass(container)`) during construction and can throw. Publishing earlier meant an application that failed to build replaced a working application's container with its own half-built one. Otherwise the most recently constructed application wins, which is what `bun --hot` needs — a reloaded entry replaces the stale container rather than being ignored.

Nothing in `docs/` or `packages/cli/templates/` claimed this API in a job, so there is no documentation to correct. The example apps did use it: `examples/blog/app/Jobs/*` and `examples/api/app/Jobs/*` both resolve the mailer this way.

## Scope

server (`Application` constructor), plus a server test file and a changeset. No public API or type changes.

## Risk Assessment

- Patch-level, additive: a code path that always threw now succeeds. No caller can have depended on the throw.
- Known trade-off — the global is a single slot, so with several `Application` instances alive in one process (e.g. `TestApp.create()` beside an app under test) the most recently constructed one wins for `Job.make()`/`resolve()`. No call site in this repo combines multi-app construction with job execution. Removing the trade-off means giving jobs an explicit container, which the public `new ()` contract on `Job` and the three independent instantiation sites (SyncDriver, Worker, Lambda handler) put out of reach of a patch.
- Deliberately no clearing on teardown: `stop()` is listener lifecycle, and `application-stop.test.ts` already requires an old app's `stop()` not to clear newer global state; hot reload depends on replacement.
- `@guren/server` patch only. `@guren/core` re-exports it, so the caret follows; `audit:core-semver` passes.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` — 4569 pass / 0 fail (framework), 112 pass (examples)

Also run: `packages/testing` vitest suite (171 pass — `test:bun` does not cover it) and `bun run audit:core-semver` (pass).

Evidence beyond the suite passing, since the suite passing is not itself evidence here — nothing exercised the broken path before: `examples/blog` uses `MemoryDriver`, and its job tests `vi.mock('@guren/core')` the `Job` base class wholesale, stubbing `this.make`.

- Reproduced the failure on `main` before fixing, then mutation-tested the guard both ways: removing the call fails the new tests; moving it into `boot()` fails only the unbooted test; moving it back before provider registration fails only the failed-construction test. Each new test also passes in isolation, so none of them rely on module state left by a sibling.
- Verified through the built `dist/` from inside `examples/blog` (the resolution path a real app takes, not the monorepo's `src` aliases) with a throwaway script — a job resolving `'mail'` ran and returned the bound value. Not committed; the committed guard is the server test.
- Not covered: a real `guren queue:work` subprocess. It depends on the CLI and the app entry resolving the same `@guren/server` copy — an invariant `getQueueDriver()` already relies on, and one that fails loudly ("Queue driver not configured") rather than silently.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation. — n/a: no doc or template claimed this API.
