### PR TITLE
fix(orm): load a relation shared by sibling eager-load paths once

### DIFF
--- a/.changeset/quiet-pandas-invite.md
+++ b/.changeset/quiet-pandas-invite.md
@@ -1,0 +1,14 @@
+---
+"@guren/orm": patch
+---
+
+Load a relation shared by several eager-load paths exactly once
+
+`with('posts.comments', 'posts.tags')` walked each path independently, so the
+shared `posts` head was loaded twice and the second pass replaced the very row
+objects the first had attached children to. Only the last-named path survived,
+with no error raised. Eager-load paths are now grouped by their head segment
+and each level is loaded once, so sibling branches all land on the same records
+regardless of the order they are named in. The same fix applies to
+`Model.with()`, `findWith()`, `findWithOrFail()` and `withPaginate()`, which
+had the same defect.

--- a/docs/en/guides/database.md
+++ b/docs/en/guides/database.md
@@ -390,6 +390,16 @@ Nested relations use dot notation:
 const users = await User.with('posts.comments')
 ```
 
+Several paths may branch off the same relation. The shared head is read once,
+so every branch lands on the same records:
+
+```ts
+const users = await User.newQuery().with('posts.comments', 'posts.tags').get()
+
+users[0].posts[0].comments // loaded
+users[0].posts[0].tags     // loaded too
+```
+
 On the QueryBuilder, the object form of `with()` takes a callback per relation
 to constrain the query that loads it. The callback receives that relation's
 query builder with the foreign-key filter already on it, so a `where()` narrows

--- a/docs/ja/guides/database.md
+++ b/docs/ja/guides/database.md
@@ -896,6 +896,16 @@ const page = await Post.newQuery().with('author').orderBy('id', 'desc').paginate
 const users = await User.with('posts.comments')
 ```
 
+同じリレーションから複数のパスを枝分かれさせることもできます。共通する先頭の
+リレーションは一度だけ読み込まれるため、どの枝も同じレコードに載ります。
+
+```ts
+const users = await User.newQuery().with('posts.comments', 'posts.tags').get()
+
+users[0].posts[0].comments // 読み込まれます
+users[0].posts[0].tags     // こちらも読み込まれます
+```
+
 QueryBuilder では、`with()` のオブジェクト形式でリレーションごとにコールバックを
 渡し、読み込みクエリに条件を追加できます。コールバックは外部キーによる絞り込みが
 すでに適用されたクエリビルダを受け取るので、`where()` を呼ぶと読み込む関連レコード

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -912,9 +912,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     }
 
     const copy = { ...record }
-    for (const rel of relationList) {
-      await this.loadRelationInto([copy], rel, queryOptions)
-    }
+    await this.loadRelationsInto([copy], relationList, queryOptions)
     return copy as TRecordFor<T> & RelationTypePick<T, Names>
   }
 
@@ -955,9 +953,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     }
 
     const copy = { ...record }
-    for (const rel of relationList) {
-      await this.loadRelationInto([copy], rel, queryOptions)
-    }
+    await this.loadRelationsInto([copy], relationList, queryOptions)
     return copy as TRecordFor<T> & RelationTypePick<T, Names>
   }
 
@@ -1617,9 +1613,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
 
     const records = result.data.map((record) => ({ ...record }))
 
-    for (const relationName of relationList) {
-      await this.loadRelationInto(records, relationName, queryOptions)
-    }
+    await this.loadRelationsInto(records, relationList, queryOptions)
 
     return {
       data: records as Array<TRecordFor<T> & RelationTypePick<T, Names>>,
@@ -1949,9 +1943,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     }
 
     const copies = records.map((record) => ({ ...record }))
-    for (const relationName of relationList) {
-      await this.loadRelationInto(copies, relationName, queryOptions)
-    }
+    await this.loadRelationsInto(copies, relationList, queryOptions)
 
     return copies as Array<TRecordFor<T> & RelationTypePick<T, Names>>
   }
@@ -2076,10 +2068,53 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
    * @internal Used by QueryBuilder for eager loading.
    * Supports nested paths with dot notation, e.g. `posts.comments`.
    *
+   * Paths are grouped by their head segment so a relation shared by several
+   * paths is loaded exactly once. Walking `posts.comments` and `posts.tags`
+   * independently would load `posts` twice, and the loaders assign fresh
+   * spread copies — so the second pass would replace the very row objects the
+   * first had already attached children to, and only the last path would
+   * survive.
+   *
    * `constraints` are keyed by the full path of the level each one constrains,
    * so `pathPrefix` accumulates the path walked so far as the recursion
    * descends: at `posts.comments` the leaf looks itself up under that whole
    * key, not under `comments`.
+   */
+  static async loadRelationsInto<T extends typeof Model>(
+    this: T,
+    records: Array<PlainObject>,
+    relationNames: readonly string[],
+    queryOptions?: ModelQueryOptions,
+    constraints?: EagerLoadConstraints,
+    pathPrefix = '',
+  ): Promise<void> {
+    if (records.length === 0 || relationNames.length === 0) return
+
+    // head -> the distinct tails to walk beneath it, in first-seen order. A
+    // bare path contributes no tail, so `posts` alongside `posts.comments`
+    // loads `posts` once and still descends into the comments.
+    const groups = new Map<string, string[]>()
+    for (const path of relationNames) {
+      const separator = path.indexOf('.')
+      const head = separator === -1 ? path : path.slice(0, separator)
+      const tail = separator === -1 ? '' : path.slice(separator + 1)
+      let tails = groups.get(head)
+      if (!tails) {
+        tails = []
+        groups.set(head, tails)
+      }
+      if (tail && !tails.includes(tail)) {
+        tails.push(tail)
+      }
+    }
+
+    for (const [head, tails] of groups) {
+      await this.loadRelationLevel(records, head, tails, queryOptions, constraints, pathPrefix)
+    }
+  }
+
+  /**
+   * @internal Kept as the single-path entry point onto {@link loadRelationsInto}.
    */
   static async loadRelationInto<T extends typeof Model>(
     this: T,
@@ -2089,7 +2124,21 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     constraints?: EagerLoadConstraints,
     pathPrefix = '',
   ): Promise<void> {
-    const [head, ...rest] = relationName.split('.')
+    await this.loadRelationsInto(records, [relationName], queryOptions, constraints, pathPrefix)
+  }
+
+  /**
+   * Load one relation level and recurse into the tails beneath it.
+   */
+  protected static async loadRelationLevel<T extends typeof Model>(
+    this: T,
+    records: Array<PlainObject>,
+    head: string,
+    tails: readonly string[],
+    queryOptions?: ModelQueryOptions,
+    constraints?: EagerLoadConstraints,
+    pathPrefix = '',
+  ): Promise<void> {
     const definition = this.getRelationDefinition(head)
 
     if (!definition) {
@@ -2126,7 +2175,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
         break
     }
 
-    if (rest.length === 0) {
+    if (tails.length === 0) {
       return
     }
 
@@ -2156,7 +2205,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     }
 
     const related = await resolveModelReference(definition.related)
-    await related.loadRelationInto(children, rest.join('.'), queryOptions, constraints, currentPath)
+    await related.loadRelationsInto(children, tails, queryOptions, constraints, currentPath)
   }
 
   protected static async loadHasMany(

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -2074,11 +2074,6 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
    * spread copies — so the second pass would replace the very row objects the
    * first had already attached children to, and only the last path would
    * survive.
-   *
-   * `constraints` are keyed by the full path of the level each one constrains,
-   * so `pathPrefix` accumulates the path walked so far as the recursion
-   * descends: at `posts.comments` the leaf looks itself up under that whole
-   * key, not under `comments`.
    */
   static async loadRelationsInto<T extends typeof Model>(
     this: T,
@@ -2088,23 +2083,25 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     constraints?: EagerLoadConstraints,
     pathPrefix = '',
   ): Promise<void> {
-    if (records.length === 0 || relationNames.length === 0) return
+    if (relationNames.length === 0) return
 
-    // head -> the distinct tails to walk beneath it, in first-seen order. A
-    // bare path contributes no tail, so `posts` alongside `posts.comments`
-    // loads `posts` once and still descends into the comments.
+    // head -> the distinct tails to walk beneath it, in first-seen order.
     const groups = new Map<string, string[]>()
     for (const path of relationNames) {
-      const separator = path.indexOf('.')
-      const head = separator === -1 ? path : path.slice(0, separator)
-      const tail = separator === -1 ? '' : path.slice(separator + 1)
-      let tails = groups.get(head)
-      if (!tails) {
-        tails = []
-        groups.set(head, tails)
-      }
-      if (tail && !tails.includes(tail)) {
-        tails.push(tail)
+      const [head, ...rest] = path.split('.')
+      const tails = groups.get(head) ?? []
+      groups.set(head, tails)
+
+      // A bare path contributes no tail, so `posts` alongside `posts.comments`
+      // loads `posts` once and still descends into the comments. A trailing
+      // dot does contribute one — an empty tail — so a malformed `posts.`
+      // still reaches the unknown-relation throw rather than being read as
+      // the bare `posts`.
+      if (rest.length > 0) {
+        const tail = rest.join('.')
+        if (!tails.includes(tail)) {
+          tails.push(tail)
+        }
       }
     }
 
@@ -2114,7 +2111,9 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
   }
 
   /**
-   * @internal Kept as the single-path entry point onto {@link loadRelationsInto}.
+   * @internal Public since it is reachable from generated code; kept for
+   * backwards compatibility now that the eager loader walks whole path lists.
+   * Internal callers should use {@link loadRelationsInto} instead.
    */
   static async loadRelationInto<T extends typeof Model>(
     this: T,
@@ -2129,6 +2128,11 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
 
   /**
    * Load one relation level and recurse into the tails beneath it.
+   *
+   * `constraints` are keyed by the full path of the level each one constrains,
+   * so `pathPrefix` accumulates the path walked so far as the recursion
+   * descends: at `posts.comments` the leaf looks itself up under that whole
+   * key, not under `comments`.
    */
   protected static async loadRelationLevel<T extends typeof Model>(
     this: T,
@@ -2578,7 +2582,7 @@ type RelationNames = string | readonly string[]
 // ('comments.author'). Only the head segment is checked against
 // relationTypes — the tail is an unvalidated string, so a malformed path
 // ('comments.', 'comments..author') or a typo'd nested segment still
-// type-checks. loadRelationInto() throws "unknown relation" for a bad tail
+// type-checks. loadRelationLevel() throws "unknown relation" for a bad tail
 // segment at runtime, but only once it actually recurses into at least one
 // loaded child row — if every record's head relation loads zero rows, the
 // tail is never inspected and the call silently no-ops. Declare the nested

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -744,10 +744,7 @@ export class QueryBuilder<
 
     const copies = results.map((r) => ({ ...r }))
 
-    // Every path goes in at once: the loader groups them by head so a relation
-    // several paths share is read once. Loading it per path would replace the
-    // row objects an earlier path had already attached children to, leaving
-    // only the last path's children in the result.
+    // Every path goes in at once so the loader can group them by head.
     await this.modelClass.loadRelationsInto(
       copies as PlainObject[],
       this.eagerLoad,

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -729,8 +729,8 @@ export class QueryBuilder<
   /**
    * Load eager relations onto fetched results.
    * Supports dot notation for nested relations at any depth
-   * (e.g., 'posts.comments.author') — the full path is delegated to
-   * Model.loadRelationInto, which recurses through the relation chain.
+   * (e.g., 'posts.comments.author') — the paths are delegated to
+   * Model.loadRelationsInto, which recurses through the relation chain.
    * Constraint callbacks registered by the object form of `with()` travel
    * alongside, keyed by the path segment each one constrains.
    *
@@ -744,23 +744,16 @@ export class QueryBuilder<
 
     const copies = results.map((r) => ({ ...r }))
 
-    // A path whose head another path also walks is skipped: loading `posts`
-    // and then `posts.comments` reloads `posts` and replaces the very objects
-    // the first pass attached children to. Walking only the longest path is
-    // result-equivalent because constraints are keyed by full path, so each
-    // level still gets its own callback.
-    const paths = this.eagerLoad.filter(
-      (name) => !this.eagerLoad.some((other) => other.startsWith(`${name}.`)),
+    // Every path goes in at once: the loader groups them by head so a relation
+    // several paths share is read once. Loading it per path would replace the
+    // row objects an earlier path had already attached children to, leaving
+    // only the last path's children in the result.
+    await this.modelClass.loadRelationsInto(
+      copies as PlainObject[],
+      this.eagerLoad,
+      { trx: this.options.trx },
+      this.eagerLoadConstraints,
     )
-
-    for (const relation of paths) {
-      await this.modelClass.loadRelationInto(
-        copies as PlainObject[],
-        relation,
-        { trx: this.options.trx },
-        this.eagerLoadConstraints,
-      )
-    }
 
     return copies as TResult[]
   }

--- a/packages/orm/tests/model-relations-sqlite.test.ts
+++ b/packages/orm/tests/model-relations-sqlite.test.ts
@@ -436,4 +436,25 @@ describe('relations on real bun:sqlite driver', () => {
       Model.morphMap = undefined
     }
   })
+
+  it('should reject a nested morphTo path even when there are no records to load', async () => {
+    // the throw has to stay ahead of any children inspection, so an empty
+    // result set still reports the unsupported path instead of resolving
+    Model.morphMap = { Post, User }
+    try {
+      await expect(Image.loadRelationInto([], 'imageable.author')).rejects.toThrow(
+        /nested eager loading through morphTo relation "imageable"/,
+      )
+    } finally {
+      Model.morphMap = undefined
+    }
+  })
+
+  it('should reject a path with a trailing dot instead of reading it as bare', async () => {
+    // `posts.` names an empty tail segment; silently treating it as `posts`
+    // would swallow a typo that used to be reported
+    await expect(User.newQuery().with('posts.' as never).get()).rejects.toThrow(
+      /unknown relation ""/,
+    )
+  })
 })

--- a/packages/orm/tests/model-relations-sqlite.test.ts
+++ b/packages/orm/tests/model-relations-sqlite.test.ts
@@ -54,6 +54,9 @@ type UserWithPosts = UserRecord & { posts: PostRecord[] }
 type UserWithPostComments = UserRecord & {
   posts: Array<PostRecord & { comments: CommentRecord[] }>
 }
+type UserWithPostCommentsAndTags = UserRecord & {
+  posts: Array<PostRecord & { comments: CommentRecord[]; tags: TagRecord[] }>
+}
 type PostWithAuthor = PostRecord & { author: UserRecord | null }
 type UserWithPostAuthors = UserRecord & { posts: PostWithAuthor[] }
 
@@ -365,5 +368,72 @@ describe('relations on real bun:sqlite driver', () => {
       'keep',
       'keep',
     ])
+  })
+
+  it('should load both sibling nested paths under a shared head', async () => {
+    const users = (await User.newQuery()
+      .with('posts.comments', 'posts.tags')
+      .get()) as UserWithPostCommentsAndTags[]
+
+    const a1 = users.find((u) => u.name === 'Alice')?.posts.find((p) => p.title === 'A1')
+    // the shared head `posts` is loaded once, so neither sibling replaces the
+    // row objects the other already attached children to
+    expect(a1?.comments.map((c) => c.body).sort()).toEqual(['drop', 'keep'])
+    expect(a1?.tags.map((t) => t.name).sort()).toEqual(['draft', 'news'])
+  })
+
+  it('should load both sibling nested paths regardless of their order', async () => {
+    const users = (await User.newQuery()
+      .with('posts.tags', 'posts.comments')
+      .get()) as UserWithPostCommentsAndTags[]
+
+    const a1 = users.find((u) => u.name === 'Alice')?.posts.find((p) => p.title === 'A1')
+    expect(a1?.comments.map((c) => c.body).sort()).toEqual(['drop', 'keep'])
+    expect(a1?.tags.map((t) => t.name).sort()).toEqual(['draft', 'news'])
+  })
+
+  it('should keep sibling nested paths when each carries its own constraint', async () => {
+    const users = (await User.newQuery()
+      .with({
+        'posts.tags': (q) => q.where('name', 'news'),
+        'posts.comments': (q) => q.where('body', 'keep'),
+      })
+      .get()) as UserWithPostCommentsAndTags[]
+
+    const a1 = users.find((u) => u.name === 'Alice')?.posts.find((p) => p.title === 'A1')
+    expect(a1?.comments.map((c) => c.body)).toEqual(['keep'])
+    expect(a1?.tags.map((t) => t.name)).toEqual(['news'])
+  })
+
+  it('should load a bare path and a nested path that share a head', async () => {
+    const users = (await User.newQuery()
+      .with('posts', 'posts.comments')
+      .get()) as UserWithPostComments[]
+
+    const alice = users.find((u) => u.name === 'Alice')
+    expect(alice?.posts.map((p) => p.title).sort()).toEqual(['A1', 'A2'])
+    expect(alice?.posts.find((p) => p.title === 'A1')?.comments.map((c) => c.body).sort()).toEqual([
+      'drop',
+      'keep',
+    ])
+  })
+
+  it('should load sibling nested paths through Model.with()', async () => {
+    const users = (await User.with(['posts.comments', 'posts.tags'])) as UserWithPostCommentsAndTags[]
+
+    const a1 = users.find((u) => u.name === 'Alice')?.posts.find((p) => p.title === 'A1')
+    expect(a1?.comments.map((c) => c.body).sort()).toEqual(['drop', 'keep'])
+    expect(a1?.tags.map((t) => t.name).sort()).toEqual(['draft', 'news'])
+  })
+
+  it('should reject a nested path that walks through a morphTo relation', async () => {
+    Model.morphMap = { Post, User }
+    try {
+      await expect(Image.newQuery().with('imageable.author').get()).rejects.toThrow(
+        /nested eager loading through morphTo relation "imageable"/,
+      )
+    } finally {
+      Model.morphMap = undefined
+    }
   })
 })


### PR DESCRIPTION
## Summary

Sibling nested eager-load paths silently clobbered each other — only the last-named path survived, with no error raised:

```ts
await User.newQuery().with('posts.comments', 'posts.tags').get()
// posts[0] -> { id, title, authorId, tags: [...] }      comments MISSING

await User.newQuery().with('posts.tags', 'posts.comments').get()
// posts[0] -> { id, title, authorId, comments: [...] }  tags MISSING
```

`QueryBuilder.loadEagerRelations` walked each eager-load path independently, calling `Model.loadRelationInto` once per full path. Each call re-loaded the shared `posts` head, and the loaders assign fresh spread copies (`record[name] = ...`) — so the second pass replaced the very row objects the first had already attached children to.

Eager-load paths are now grouped by their head segment: each level is loaded exactly once, then the recursion descends with the union of that head's tails. A bare path contributes no tail, so `with('posts', 'posts.comments')` loads `posts` once and still descends into the comments.

This subsumes the prefix filter added in #448, which only covered the case where one path extended another (`posts` + `posts.comments`) and could not help siblings, since neither `posts.comments` nor `posts.tags` is a prefix of the other. That filter is removed.

The same defect was present in `Model.with()`, `findWith()`, `findWithOrFail()` and `withPaginate()`, which looped over their relation list one path at a time and never had #448's filter at all. They now hand the whole list in at once.

`loadRelationInto` is kept as a thin single-path wrapper, so no public signature changes.

## Scope

- `orm` — `Model.ts` (new `loadRelationsInto` / `loadRelationLevel`, four updated call sites), `QueryBuilder.ts`
- `docs` — `docs/en/guides/database.md`, `docs/ja/guides/database.md`

## Risk Assessment

Behaviour change is strictly corrective: paths that previously vanished now load. No public signature changes, no migration impact.

Invariants deliberately preserved and covered by tests:

- Constraints stay keyed by the **full path** of the level they constrain (`posts` the head, `posts.comments` the leaf), and key order does not affect the result.
- The transaction from #447 still reaches every relation query — loaders continue to build with `related.newQuery(queryOptions)`.
- `morphTo` still throws on nested paths, and the throw stays **ahead** of children collection, so it fires even when the result set is empty. Nothing pinned this before; a test now does.
- `morphMany` still groups on the morph type as well as the id.

One consequence worth noting for reviewers: a head shared by N paths now issues one query instead of N. That is the point of the fix, but it does change query counts.

## Validation

- [x] `bun run build` (via `build:clean`)
- [x] `bun run typecheck` — clean at root, blog and api
- [x] `bun run test` — exit 0, no failures

Also run: `bun run audit:core-first` and `bun run audit:docs`, both pass.

Regression tests are in `packages/orm/tests/model-relations-sqlite.test.ts` against the real `bun:sqlite` driver — six cases: both key orders, per-branch constraints, `Model.with()`, a bare path sharing a head with a dotted one, and the `morphTo` nested throw. Four were red before the fix.

Mutation-tested twice, both mutations killed:

- Reverting the grouping to a per-path walk fails 5 tests — the four new sibling cases **plus** #448's existing constrained-prefix test, which is the direct evidence that the grouping genuinely subsumes the filter this PR removes.
- Removing the empty-tail guard fails 23 tests.

No `@guren/core` changeset: `packages/core` has an empty diff, so no name was added to its export allowlist. `changeset status --verbose` confirms core is already in the release plan at 1.7.0 from an unrelated changeset, and its caret on `@guren/orm` carries this fix.

## Review follow-up

A second commit fixes two behaviour changes the first one introduced, both found by review and both verified against `main` before being treated as real:

- **Trailing-dot paths.** `with('posts.')` names an empty tail segment. The grouping dropped it, so the path was silently read as the bare `posts`; pre-fix it threw `unknown relation ""`. The tail is now decided by whether the path had a separator at all, not by whether the tail is non-empty — a bare path still contributes nothing, and `posts.` still reports.
- **Empty record lists.** The entry guard returned early on an empty record list, which skipped the nested-`morphTo` rejection entirely: `loadRelationInto([], 'imageable.author')` resolved instead of throwing. Only the record list was removed from that guard; every caller already checks it, and the loaders are no-ops on an empty list.

Both are pinned by tests that fail against the mutated guard.

Two review points deliberately **not** acted on:

- Sibling heads are still loaded sequentially rather than concurrently. `queryOptions.trx` is passed straight through as the drizzle db handle, so a `Promise.all` would issue concurrent statements on a single transaction connection. The pre-fix code was sequential too, so nothing regressed.
- A subclass overriding the `@internal` static `loadRelationInto` is no longer invoked from the eager-load path. It is not a documented extension point, and treating it as one would block routing internal callers to the grouped entry point.

Also worth flagging: only the `Model.with()` call site has a test, while the fix covers four. The other three are the identical one-liner, but the test evidence is narrower than the claim.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
