### PR TITLE
feat(web): publish the docs viewer's graph at guren.dev/_guren/docs

### DIFF
--- a/.changeset/docs-render-escaped-table-pipes.md
+++ b/.changeset/docs-render-escaped-table-pipes.md
@@ -2,4 +2,4 @@
 "@guren/cli": patch
 ---
 
-Keep an escaped pipe inside a docs table cell instead of splitting on it. `spec:generate` writes TypeScript unions as `A \| B`, so the docs viewer rendered those rows with one cell too many and a stray backslash — a `screens.md` Props column was the common case.
+Undo the table-cell escaping in the docs viewer's renderer instead of splitting on it. `escapeMarkdownTableCell` doubles a backslash and then escapes every pipe, so a `screens.md` Props column holding a TypeScript union (`A \| B`) rendered as two cells with a stray backslash, pushing the rest of the row one column right. Row splitting now scans for unescaped pipes and reads `\\` as one unit, so a cell that ends in a backslash still lets the delimiter behind it split.

--- a/.changeset/docs-render-escaped-table-pipes.md
+++ b/.changeset/docs-render-escaped-table-pipes.md
@@ -1,0 +1,5 @@
+---
+"@guren/cli": patch
+---
+
+Keep an escaped pipe inside a docs table cell instead of splitting on it. `spec:generate` writes TypeScript unions as `A \| B`, so the docs viewer rendered those rows with one cell too many and a stray backslash — a `screens.md` Props column was the common case.

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,6 +1,10 @@
 # Deploys guren.dev to Cloudflare Workers on every main push that can change
 # the site: the app itself (web/), the docs it serves from the repo root
-# (docs/), and the workspace packages the worker bundle inlines (packages/).
+# (docs/), the workspace packages the worker bundle inlines (packages/), and
+# the blog example, whose docs bundle is published as the static docs-viewer
+# snapshot at /_guren/docs (web/scripts/prerender-docs-viewer.ts). The graph
+# covers the example's source files too, not only its docs/, so the whole
+# directory triggers a rebuild.
 #
 # Safe on a public repo: secrets are never exposed to workflows triggered
 # from fork pull requests, and this only runs on push to main. The API token
@@ -15,6 +19,7 @@ on:
     paths:
       - 'web/**'
       - 'docs/**'
+      - 'examples/blog/**'
       - 'packages/**'
       - '.github/workflows/deploy-web.yml'
   workflow_dispatch:

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "examples/api": {
       "name": "@guren/example-api",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -68,13 +68,13 @@
     },
     "packages/cli": {
       "name": "@guren/cli",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "bin": {
         "guren": "./dist/bin.js",
       },
       "dependencies": {
         "@babel/parser": "^7.24.7",
-        "@guren/core": "^1.6.1",
+        "@guren/core": "^1.6.2",
         "@guren/orm": "^2.4.0",
         "citty": "^0.1.6",
         "consola": "^3.4.2",
@@ -92,12 +92,12 @@
     },
     "packages/core": {
       "name": "@guren/core",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "bin": {
         "guren": "./dist/bin.js",
       },
       "dependencies": {
-        "@guren/cli": "^2.5.0",
+        "@guren/cli": "^2.6.1",
         "@guren/orm": "^2.4.0",
         "@guren/server": "^2.6.0",
       },
@@ -110,7 +110,7 @@
     },
     "packages/create-app": {
       "name": "create-guren-app",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "bin": {
         "create-guren-app": "./dist/cli.js",
       },
@@ -181,9 +181,9 @@
     },
     "packages/plugin-cloudflare": {
       "name": "@guren/plugin-cloudflare",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
-        "@guren/core": "^1.5.2",
+        "@guren/core": "^1.6.2",
         "citty": "^0.1.6",
       },
       "devDependencies": {
@@ -196,7 +196,7 @@
     },
     "packages/plugin-lambda": {
       "name": "@guren/plugin-lambda",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@guren/core": "^1.4.0",
         "citty": "^0.1.6",
@@ -219,7 +219,7 @@
     },
     "packages/plugin-vercel": {
       "name": "@guren/plugin-vercel",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "@guren/core": "^1.4.0",
       },
@@ -290,7 +290,7 @@
     },
     "web": {
       "name": "web",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -315,6 +315,7 @@
         "drizzle-kit": "1.0.0-rc.4",
         "marked": "^15.0.11",
         "marked-highlight": "^2.2.3",
+        "mermaid": "^11.16.1",
         "shiki": "^3.15.0",
         "tailwindcss": "^4.2.2",
         "typescript": "^5.4.0",

--- a/examples/blog/docs/adr/0003-post-pages-are-cached-writes-invalidate.md
+++ b/examples/blog/docs/adr/0003-post-pages-are-cached-writes-invalidate.md
@@ -12,9 +12,9 @@ generated: { by: "human:7nohe", at: 2026-08-11T11:19:26.406Z }
 
 ## Context
 
-Post lists and detail pages are read far more often than they change,
-and they are public ([[0001-posts-are-public-by-default]]), so caching
-them is safe.
+Post lists and detail pages are read far more often than they change, and
+they are public ([Posts are public by default](0001-posts-are-public-by-default.md)),
+so caching them is safe.
 
 ## Decision
 

--- a/packages/cli/src/docs-render.ts
+++ b/packages/cli/src/docs-render.ts
@@ -113,19 +113,23 @@ function emphasis(escaped: string): string {
 }
 
 /**
- * Splits a table row on its unescaped pipes, unescaping `\|` back to a literal
- * pipe. `spec:generate` writes TypeScript unions that way, so splitting on
- * every pipe pushes each later cell one column right and leaves a stray
- * backslash behind — the row renders with more cells than the table has
- * headers.
+ * Splits a table row on its unescaped pipes, undoing the escaping
+ * `escapeMarkdownTableCell` applies: a backslash doubled, then every pipe
+ * escaped. Reading `\\` as one unit is what keeps the parity right — `\\|`
+ * is a literal backslash followed by a cell delimiter, not an escaped pipe.
+ *
+ * Splitting on every pipe instead pushes each later cell one column right and
+ * leaves a stray backslash behind, so a `screens.md` Props column holding a
+ * TypeScript union rendered with more cells than the table had headers.
  */
 function splitCells(row: string): string[] {
   const cells: string[] = []
   let cell = ''
 
   for (let cursor = 0; cursor < row.length; cursor += 1) {
-    if (row[cursor] === '\\' && row[cursor + 1] === '|') {
-      cell += '|'
+    const escaped = row[cursor] === '\\' && (row[cursor + 1] === '|' || row[cursor + 1] === '\\')
+    if (escaped) {
+      cell += row[cursor + 1]
       cursor += 1
     } else if (row[cursor] === '|') {
       cells.push(cell)
@@ -140,11 +144,15 @@ function splitCells(row: string): string[] {
 }
 
 function renderTable(rows: string[], resolveLink?: (target: string) => string): string {
+  // The outer pipes are optional and produce an empty cell on each side. Which
+  // trailing pipe is a delimiter is a question only the scan can answer, so the
+  // empties are dropped from its result rather than sliced off the row first.
   const cells = (row: string): string[] => {
-    let text = row.trim()
-    if (text.startsWith('|')) text = text.slice(1)
-    if (text.endsWith('|') && !text.endsWith('\\|')) text = text.slice(0, -1)
-    return splitCells(text).map((cell) => inline(cell.trim(), resolveLink))
+    const text = row.trim()
+    const parts = splitCells(text)
+    if (text.startsWith('|')) parts.shift()
+    if (parts.length > 1 && parts[parts.length - 1] === '') parts.pop()
+    return parts.map((cell) => inline(cell.trim(), resolveLink))
   }
 
   const [head, , ...body] = rows

--- a/packages/cli/src/docs-render.ts
+++ b/packages/cli/src/docs-render.ts
@@ -112,14 +112,40 @@ function emphasis(escaped: string): string {
     .replace(/(^|[^*])\*([^*]+)\*/g, '$1<em>$2</em>')
 }
 
+/**
+ * Splits a table row on its unescaped pipes, unescaping `\|` back to a literal
+ * pipe. `spec:generate` writes TypeScript unions that way, so splitting on
+ * every pipe pushes each later cell one column right and leaves a stray
+ * backslash behind — the row renders with more cells than the table has
+ * headers.
+ */
+function splitCells(row: string): string[] {
+  const cells: string[] = []
+  let cell = ''
+
+  for (let cursor = 0; cursor < row.length; cursor += 1) {
+    if (row[cursor] === '\\' && row[cursor + 1] === '|') {
+      cell += '|'
+      cursor += 1
+    } else if (row[cursor] === '|') {
+      cells.push(cell)
+      cell = ''
+    } else {
+      cell += row[cursor]
+    }
+  }
+  cells.push(cell)
+
+  return cells
+}
+
 function renderTable(rows: string[], resolveLink?: (target: string) => string): string {
-  const cells = (row: string): string[] =>
-    row
-      .trim()
-      .replace(/^\|/, '')
-      .replace(/\|$/, '')
-      .split('|')
-      .map((cell) => inline(cell.trim(), resolveLink))
+  const cells = (row: string): string[] => {
+    let text = row.trim()
+    if (text.startsWith('|')) text = text.slice(1)
+    if (text.endsWith('|') && !text.endsWith('\\|')) text = text.slice(0, -1)
+    return splitCells(text).map((cell) => inline(cell.trim(), resolveLink))
+  }
 
   const [head, , ...body] = rows
   const thead = `<thead><tr>${cells(head).map((c) => `<th>${c}</th>`).join('')}</tr></thead>`

--- a/packages/cli/tests/docs-render.test.ts
+++ b/packages/cli/tests/docs-render.test.ts
@@ -49,6 +49,18 @@ We keep **bold** choices and \`code\` spans, *emphasised*.
     expect(html).toContain('<td>serial</td>')
   })
 
+  it('keeps an escaped pipe inside a cell instead of splitting on it', () => {
+    // What `spec:generate` writes for a TypeScript union in a Props column.
+    const html = renderDocHtml(`| Page | Props |
+|------|-------|
+| posts/Edit | { post: PostFormValues \\| null } |
+`)
+
+    const row = html.match(/<tbody><tr>.*?<\/tr>/)?.[0] ?? ''
+    expect(row.match(/<td>/g)).toHaveLength(2)
+    expect(row).toContain('<td>{ post: PostFormValues | null }</td>')
+  })
+
   it('passes mermaid fences through and escapes other code fences', () => {
     const html = renderDocHtml(`\`\`\`mermaid
 erDiagram

--- a/packages/cli/tests/docs-render.test.ts
+++ b/packages/cli/tests/docs-render.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { renderDocHtml } from '../src/docs-render'
+import { escapeMarkdownTableCell } from '../src/context-route'
 
 describe('renderDocHtml', () => {
   it('renders headings one level down, paragraphs, and inline spans', () => {
@@ -59,6 +60,35 @@ We keep **bold** choices and \`code\` spans, *emphasised*.
     const row = html.match(/<tbody><tr>.*?<\/tr>/)?.[0] ?? ''
     expect(row.match(/<td>/g)).toHaveLength(2)
     expect(row).toContain('<td>{ post: PostFormValues | null }</td>')
+  })
+
+  it('reads a doubled backslash as one, so the pipe behind it still splits', () => {
+    // `escapeMarkdownTableCell` doubles backslashes before escaping pipes, so
+    // `\\|` is a cell that ends in a backslash, not an escaped pipe.
+    const html = renderDocHtml(`| Path | Note |
+|------|------|
+| C:\\\\ | root |
+`)
+
+    const row = html.match(/<tbody><tr>.*?<\/tr>/)?.[0] ?? ''
+    expect(row.match(/<td>/g)).toHaveLength(2)
+    expect(row).toContain('<td>C:\\</td>')
+    expect(row).toContain('<td>root</td>')
+  })
+
+  it('round-trips every cell value the table escaper produces', () => {
+    const values = ['A | B', 'A \\| B', 'Post \\ Draft', '{ post: PostFormValues | null }']
+    const html = renderDocHtml(`| Value |
+|-------|
+${values.map((value) => `| ${escapeMarkdownTableCell(value)} |`).join('\n')}
+`)
+
+    const rows = html.match(/<tr><td>.*?<\/tr>/g) ?? []
+    expect(rows).toHaveLength(values.length)
+    rows.forEach((row, index) => {
+      expect(row.match(/<td>/g)).toHaveLength(1)
+      expect(row).toBe(`<tr><td>${values[index]}</td></tr>`)
+    })
   })
 
   it('passes mermaid fences through and escapes other code fences', () => {

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -7,3 +7,4 @@ public/assets
 .dev.vars
 .cloudflare
 data/
+public/_guren

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "codegen": "bun run prerender:stub && cd .. && bun packages/cli/src/bin.ts codegen --app web --routes routes/web.ts --out types/generated/routes.d.ts --pages resources/js/pages --pagesOut .guren/pages.gen.ts --force",
     "routes:types": "bun run codegen",
-    "prerender": "bun scripts/prerender-docs.ts",
+    "prerender": "bun scripts/prerender-docs.ts && bun scripts/prerender-docs-viewer.ts",
     "prerender:stub": "bun scripts/prerender-docs.ts --stub",
     "dev": "bun run codegen && bun run prerender:stub && bun run dev:server",
     "dev:server": "bun run --watch bin/serve.ts",
@@ -43,6 +43,7 @@
     "@vitejs/plugin-react": "^6.0.0",
     "drizzle-kit": "1.0.0-rc.4",
     "marked": "^15.0.11",
+    "mermaid": "^11.16.1",
     "marked-highlight": "^2.2.3",
     "shiki": "^3.15.0",
     "tailwindcss": "^4.2.2",

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
+Disallow: /_guren/
 
 Sitemap: https://guren.dev/sitemap.xml

--- a/web/resources/js/pages/Home.tsx
+++ b/web/resources/js/pages/Home.tsx
@@ -306,9 +306,10 @@ export default function Home({ codeExamples }: Props) {
             </div>
             <figure>
               <a
-                href="/docs-graph.png"
+                href="/_guren/docs"
                 target="_blank"
                 rel="noreferrer"
+                aria-label="Open the blog example's docs graph in the Guren docs viewer"
                 className="block overflow-hidden rounded-xl border border-white/10 bg-white/[0.03] p-2 transition hover:border-crimson-400/40"
               >
                 <img
@@ -322,9 +323,12 @@ export default function Home({ codeExamples }: Props) {
               </a>
               <figcaption className="mt-3 text-sm leading-relaxed text-white/50">
                 Your app&apos;s knowledge graph, drawn from the blog example&apos;s real docs —
-                plain markdown ADRs that declare the entities they govern and link to each
-                other with <code className="text-white/70">[[wiki-links]]</code>. Rendered live
-                at <code className="text-crimson-300/90">/_guren/docs</code>; broken links fail{' '}
+                plain markdown ADRs that declare the entities they govern in{' '}
+                <code className="text-white/70">frontmatter</code>, and link to the code and
+                to each other in the body.{' '}
+                <span className="text-white/70">Open the example&apos;s graph</span> — the same
+                screen your own docs get at <code className="text-crimson-300/90">/_guren/docs</code>{' '}
+                while you develop; broken links fail{' '}
                 <code className="text-white/70">guren check --docs</code> in CI.
               </figcaption>
             </figure>

--- a/web/scripts/prerender-docs-viewer.ts
+++ b/web/scripts/prerender-docs-viewer.ts
@@ -1,0 +1,134 @@
+/**
+ * Publish a static snapshot of the docs viewer (RFC 0005) under
+ * web/public/_guren/docs/, so guren.dev can serve the real screen the
+ * homepage advertises instead of only a screenshot of it.
+ *
+ * The viewer itself never runs here. `DocsViewerServiceProvider` reads the
+ * bundle off disk through @guren/cli on every request, and this app deploys
+ * to Workers — no filesystem, and wrangler.jsonc aliases @guren/cli to a
+ * stub. So the payload is built once at build time and the shipped shell is
+ * copied beside it; both are plain static assets after that.
+ *
+ * The framework gate is deliberately untouched: `isDocsViewerEnabled()`
+ * still refuses to mount anything in production. What this publishes is a
+ * snapshot of the *blog example's* public docs, which is why exposing it
+ * costs nothing — see the injected banner, which says so on the page.
+ *
+ * Usage: bun scripts/prerender-docs-viewer.ts
+ */
+import { createRequire } from 'node:module'
+import { copyFileSync, mkdirSync, statSync, writeFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { gzipSync } from 'node:zlib'
+import { buildDocsViewerData, docsViewerAssetPath } from '@guren/cli'
+
+const webRoot = fileURLToPath(new URL('..', import.meta.url))
+
+/**
+ * The bundle to publish. The framework's own docs/ carries no OKF relations
+ * (109 documents, zero edges), so the blog example is the only bundle whose
+ * graph shows what the viewer is for — and it is the one the homepage
+ * screenshot already describes.
+ */
+const bundleRoot = resolve(webRoot, '../examples/blog')
+const outDir = resolve(webRoot, 'public/_guren/docs')
+
+/** Injected once each; every replacement is asserted, so a reshaped shell fails the build. */
+const BANNER = `
+<style>
+.demo-banner {
+  position: fixed; top: 1.5rem; right: 1.75rem; z-index: 5;
+  max-width: 22rem; text-align: right;
+  font-family: var(--mono); font-size: 0.72rem; line-height: 1.6;
+  color: var(--text-muted);
+}
+.demo-banner code { color: var(--text-secondary); }
+.demo-banner a { color: var(--accent); text-decoration: none; }
+.demo-banner a:hover { text-decoration: underline; }
+@media (max-width: 900px) { .demo-banner { display: none; } }
+</style>
+<meta name="robots" content="noindex" />
+`
+
+const BANNER_BODY = `
+<p class="demo-banner">
+  A static snapshot of the blog example's docs. In your own app the viewer
+  runs on your machine: <code>GUREN_DOCS=1 bun run dev</code>, then
+  <code>/_guren/docs</code>.
+  <a href="https://guren.dev/docs/guides/spec-anchored">how this works ↗</a>
+</p>
+`
+
+function inject(html: string, anchor: string, replacement: string): string {
+  const occurrences = html.split(anchor).length - 1
+  if (occurrences !== 1) {
+    throw new Error(
+      `docs viewer shell: expected exactly one ${JSON.stringify(anchor)}, found ${occurrences}. ` +
+        'The shipped asset changed shape — update this script rather than the asset.',
+    )
+  }
+  return html.replace(anchor, replacement)
+}
+
+function write(path: string, content: string): void {
+  writeFileSync(path, content, 'utf8')
+  report(path)
+}
+
+function report(path: string): void {
+  const bytes = statSync(path).size
+  console.log(`  ${path.replace(webRoot, 'web/')} — ${formatBytes(bytes)}`)
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+const data = await buildDocsViewerData(bundleRoot)
+
+// A bundle that resolved to the wrong directory still builds — it just comes
+// back empty, and an empty graph is indistinguishable from a working one that
+// happens to render nothing. Fail here instead of publishing a blank screen.
+if (data.nodes.length === 0 || data.edges.length === 0) {
+  console.error(
+    `No docs graph at ${bundleRoot} (${data.nodes.length} nodes, ${data.edges.length} edges). ` +
+      'Nothing worth publishing — refusing to write an empty viewer.',
+  )
+  process.exit(1)
+}
+
+mkdirSync(resolve(outDir, 'assets'), { recursive: true })
+
+const json = JSON.stringify(data)
+write(resolve(outDir, 'data.json'), json)
+console.log(
+  `    ${data.nodes.length} nodes, ${data.edges.length} edges, ${data.docs.length} docs` +
+    ` — ${formatBytes(gzipSync(Buffer.from(json, 'utf8')).length)} gzipped`,
+)
+
+const shell = await readFile(docsViewerAssetPath(), 'utf-8')
+write(
+  resolve(outDir, 'index.html'),
+  inject(
+    inject(
+      inject(shell, '<title>Guren docs</title>', '<title>Guren docs graph — blog example</title>'),
+      '</head>',
+      `${BANNER}</head>`,
+    ),
+    '<body>',
+    `<body>${BANNER_BODY}`,
+  ),
+)
+
+// The shell loads mermaid from a fixed path and degrades to "bun add -d
+// mermaid" hints without it — three of the example's spec views are mermaid
+// diagrams, so a snapshot without it reads as broken.
+copyFileSync(
+  createRequire(import.meta.url).resolve('mermaid/dist/mermaid.min.js'),
+  resolve(outDir, 'assets/mermaid.js'),
+)
+report(resolve(outDir, 'assets/mermaid.js'))


### PR DESCRIPTION
## Summary

The homepage advertises the docs viewer with a screenshot, which shows that the screen exists but not that it renders a real bundle. This publishes the live screen at `guren.dev/_guren/docs`, built from the blog example's own docs, and links the homepage figure to it.

The viewer itself cannot run there. `DocsViewerServiceProvider` reads the bundle off disk through `@guren/cli` on every request, and the site deploys to Workers, where there is no filesystem and `@guren/cli` is aliased to a stub. So `web/scripts/prerender-docs-viewer.ts` builds the payload at build time, copies the shell that `@guren/cli` ships, and writes both into `public/_guren/docs/` to be served as static assets.

**The framework gate is untouched.** `isDocsViewerEnabled()` still refuses to mount anything in production, and `packages/server` has no diff. What is published is a snapshot of the example's already-public docs, and an injected banner says so on the page so a reader does not conclude the endpoint is safe to expose in their own app.

The bundle is the blog example's rather than this repo's `docs/`: the latter carries no OKF relations (109 documents, zero edges), so its graph is a cloud of unconnected dots.

Two defects surfaced while checking what would actually be published:

- **`[[wiki-links]]` are not a thing.** The syntax appeared exactly once in the repository, in the homepage caption. Nothing parses it, so the example's ADR 0003 pointed at ADR 0001 with dead text and the graph had no document-to-document edge at all. It is a markdown link now, which `guren check --docs` validates (3 links → 4) and the graph draws (17 edges → 18). The caption describes what the bundle actually declares.
- **Escaped pipes broke every generated table** (first commit, `@guren/cli` patch). The renderer split rows on every literal pipe, so `A \| B` in a `screens.md` Props column produced one cell too many and a stray backslash. This affected any user opening the viewer locally, not just this snapshot.

## Scope

`cli` (renderer fix + test + changeset), `web` (build script, homepage, robots), `examples` (one ADR link), CI (deploy triggers).

## Risk Assessment

- No runtime code runs on the site for this: three static files under `public/_guren/docs/`, generated during `bun run prerender` and gitignored.
- `mermaid` becomes a `web` devDependency and ships as a 3.4 MB static asset. Without it the three spec diagrams degrade to "bun add -d mermaid" hints, which reads as broken on a public page.
- `examples/blog/**` joins the deploy triggers, because the snapshot is built from it. Without that, editing the example's docs would leave a stale graph published. Side effect: unrelated changes to the example now redeploy the site.
- Workers Static Assets answer before the worker, so these requests never reach the site analytics middleware. The page's usage is structurally unmeasurable.
- `/_guren/` is disallowed in robots.txt and the shell carries `noindex`.
- The generator fails the build if the bundle comes back with no nodes or edges, rather than publishing a blank screen.
- Open question for the reviewer: the figure links to the live viewer, which is unusable at 375 px (verified: the graph collapses behind the HUD). The previous link target, the full-size PNG, reads fine on a phone. Keeping the PNG on the image and adding a separate text link to the live graph is the alternative.

## Validation

- `bun run typecheck` (root), `bun run test:bun cli` (1490 pass), `web` tests (112 pass), `bun run build`, `bun run --cwd web cloudflare:build`
- `examples/blog`: `guren check --docs` and `guren check --spec` both pass
- Asset routing verified against `wrangler dev`: `/_guren/docs` → 307 → `/_guren/docs/` 200, `data.json` 200, `mermaid.js` 200
- Rendered in a real browser: graph draws, node panel opens, the mermaid spec diagrams render (no fallback hints, no console errors)
- The renderer fix is mutation-checked: the new test fails against the old `split('|')` and passes with the scan

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
