### PR TITLE
feat: publish the agent catalog by a maintainer-run script, with a nightly drift check

### DIFF
--- a/.changeset/agent-catalog-user-scope.md
+++ b/.changeset/agent-catalog-user-scope.md
@@ -1,0 +1,7 @@
+---
+"@guren/cli": patch
+---
+
+Install the catalog plugin at user scope in the published README.
+
+The two skills it ships are for the step before a project exists, and they are the same two whatever you are building. `--scope project` wrote them into whichever repository the user happened to be standing in — which at that moment is either nothing or something unrelated — and shared an on-ramp with the collaborators of an app that already has the harness installed. It is also not the scope the plugin CLI defaults to.

--- a/.github/workflows/published-drift.yml
+++ b/.github/workflows/published-drift.yml
@@ -47,3 +47,25 @@ jobs:
 
       - name: ${{ matrix.smoke }}
         run: bun run ${{ matrix.smoke }}
+
+  # gurenjs/agent-skills is published by a maintainer running
+  # `bun run publish:agent-catalog` after a release (RFC 0011). The one thing
+  # a manual step lacks is a reminder that it was skipped; this is it. Renders
+  # the catalog from this checkout and diffs it against what the public repo
+  # currently serves. Read-only, no token. Red means "run publish:agent-catalog"
+  # — or, between a catalog-source change and the release that carries it, red
+  # is expected, the same way the npm drift above is.
+  agent-catalog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.14'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Diff the rendered catalog against gurenjs/agent-skills
+        run: bun run ./scripts/build-agent-catalog.ts --diff-published

--- a/.github/workflows/published-drift.yml
+++ b/.github/workflows/published-drift.yml
@@ -60,12 +60,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: oven-sh/setup-bun@v2
+      # Unlike the npm-mode job above, this one *does* need the workspace
+      # built: rendering imports packages/cli/src/commands.ts to read the
+      # command registry, and that module's dependency graph reaches
+      # @guren/server, whose exports point at untracked dist/. Same action
+      # ci.yml uses, so the dist cache is shared.
+      - name: Set up Bun and build packages
+        uses: ./.github/actions/setup-and-build
         with:
           bun-version: '1.3.14'
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
 
       - name: Diff the rendered catalog against gurenjs/agent-skills
         run: bun run ./scripts/build-agent-catalog.ts --diff-published

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Run `bun run codegen` after adding features to regenerate types. When you are re
 
 ## What you get
 
-- **Agent-ready by default** — `guren context` hands an agent the project map with API signatures, `guren check` and `guren audit` verify its work mechanically, and every new app ships an agent harness. In a [public, blind-scored evaluation](https://github.com/gurenjs/framework-comparison/tree/main/agent-eval), every agent trial shipped a working feature
+- **Agent-ready by default** — `guren context` hands an agent the project map with API signatures, `guren check` and `guren audit` verify its work mechanically, and every new app ships an agent harness — and before you have an app, the Guren skills are one `npx skills add gurenjs/agent-skills` (or `claude plugin marketplace add gurenjs/agent-skills`) away. In a [public, blind-scored evaluation](https://github.com/gurenjs/framework-comparison/tree/main/agent-eval), every agent trial shipped a working feature
 - **Laravel-style MVC** — routes, controllers, and an Eloquent-inspired Model API
 - **Inertia.js + React** — SPA-like UX without a separate frontend app
 - **Drizzle ORM** — swap database backends through an adapter (PostgreSQL / MySQL / SQLite)

--- a/contributing/release-checklist.md
+++ b/contributing/release-checklist.md
@@ -42,7 +42,7 @@ only on the PR's CI and here. Start the databases first: `bun run db:up` and
 - [ ] Create a git tag following semver
 - [ ] Create GitHub release with changelog excerpt
 - [ ] Verify npm publish succeeds for all packages
-- [ ] If `@guren/cli` moved: `bun run publish:agent-catalog` (renders the agent catalog, audits it, and pushes it to `gurenjs/agent-skills` over your own git credentials — no token; a no-op when the published version already matches). The nightly `Published Package Drift` workflow turns red if this is forgotten.
+- [ ] If `@guren/cli` moved: `bun run publish:agent-catalog` (renders the agent catalog, audits it, and pushes it to `gurenjs/agent-skills` over your own git credentials — no token; a no-op when the published tree is already byte-identical). The same version with different bytes is *not* a no-op: it publishes a corrective commit, which copies already installed under that version do not pick up until `@guren/cli` moves again. The command needs the Claude Code CLI on your PATH to validate the manifests, and refuses to publish without it; `--skip-validate` is the override once you have validated by hand. The nightly `Published Package Drift` workflow turns red if this is forgotten.
 - [ ] Verify `bunx create-guren-app` works with the new version
 - [ ] Run `bunx guren upgrade --canary` on an older app to verify upgrade path
 

--- a/contributing/release-checklist.md
+++ b/contributing/release-checklist.md
@@ -42,6 +42,7 @@ only on the PR's CI and here. Start the databases first: `bun run db:up` and
 - [ ] Create a git tag following semver
 - [ ] Create GitHub release with changelog excerpt
 - [ ] Verify npm publish succeeds for all packages
+- [ ] If `@guren/cli` moved: `bun run publish:agent-catalog` (renders the agent catalog, audits it, and pushes it to `gurenjs/agent-skills` over your own git credentials — no token; a no-op when the published version already matches). The nightly `Published Package Drift` workflow turns red if this is forgotten.
 - [ ] Verify `bunx create-guren-app` works with the new version
 - [ ] Run `bunx guren upgrade --canary` on an older app to verify upgrade path
 

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -266,6 +266,21 @@ What each selection writes:
 - **Claude Code**: a `CLAUDE.md` project guide, verified API rules, skills, and subagents under `.claude/`, an `.mcp.json` pointing at the dev server's MCP endpoint (the scaffolded `dev` script enables it via `GUREN_MCP=1`), and hooks that close the feedback loop — the `guren context` project map loads at session start, and `guren check` re-runs automatically after edits to routes, controllers, models, schema, or pages, reporting failures straight back to the coding agent.
 - **Codex, Cursor, GitHub Copilot, OpenCode**: an `AGENTS.md` project guide plus the same rules and skills under `.agents/rules/` and `.agents/skills/` (skills follow the cross-agent SKILL.md standard). Cursor additionally gets the rules in its native format (`.cursor/rules/guren-*.mdc`), Copilot as path-scoped instructions (`.github/instructions/guren-*.instructions.md`), and Codex a command-approval allowlist for the harness's own commands (`.codex/rules/guren.rules`). MCP client configs land where each tool looks: `.codex/config.toml`, `.cursor/mcp.json`, `.vscode/mcp.json`, or the `mcp` entry in `opencode.json`. These agents do not run the harness's hooks, so `AGENTS.md` instructs them to run `guren context` at session start and `guren check` after edits.
 
+### Before you have an app: install the Guren skills from a catalog
+
+The harness above lives inside an app's `@guren/cli`, so it only exists once an app does. For the step before that — an agent that has never seen Guren, in a directory with nothing in it — Guren publishes two on-ramp skills to the agent catalogs from [`gurenjs/agent-skills`](https://github.com/gurenjs/agent-skills):
+
+```bash
+# Claude Code
+claude plugin marketplace add gurenjs/agent-skills
+claude plugin install guren@gurenjs --scope project
+
+# Cursor, Codex, Copilot, OpenCode, Gemini CLI and others (Agent Skills CLI)
+npx skills add gurenjs/agent-skills
+```
+
+The plugin also conforms to [Agent Plugins v1](https://agent-plugins.org), so any client that reads a root `plugin.json` can install it from that repository directly. It ships `guren-new-app` (explains Guren, scaffolds an app with `bunx create-guren-app`, hands off) and `guren-harness` (runs `bunx guren agent:init --target <agents>` and explains the `guren context` → edit → `guren check` → `guren audit` loop). It deliberately does **not** copy the harness's rules or skills: those are installed by the app's own CLI and stay version-matched to it. The repository is generated from `packages/cli/templates/agent-catalog/` on each release; send changes there, not to `gurenjs/agent-skills`.
+
 | Command | Description | Example |
 |---------|-------------|---------|
 | `agent:init` | Install the agent harness for the selected agents into an existing app (skips files that already exist; `--force` overwrites) | `bunx guren agent:init --target codex,cursor` |

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -273,13 +273,13 @@ The harness above lives inside an app's `@guren/cli`, so it only exists once an 
 ```bash
 # Claude Code
 claude plugin marketplace add gurenjs/agent-skills
-claude plugin install guren@gurenjs --scope project
+claude plugin install guren@gurenjs --scope user
 
 # Cursor, Codex, Copilot, OpenCode, Gemini CLI and others (Agent Skills CLI)
 npx skills add gurenjs/agent-skills
 ```
 
-The plugin also conforms to [Agent Plugins v1](https://agent-plugins.org), so any client that reads a root `plugin.json` can install it from that repository directly. It ships `guren-new-app` (explains Guren, scaffolds an app with `bunx create-guren-app`, hands off) and `guren-harness` (runs `bunx guren agent:init --target <agents>` and explains the `guren context` → edit → `guren check` → `guren audit` loop). It deliberately does **not** copy the harness's rules or skills: those are installed by the app's own CLI and stay version-matched to it. The repository is generated from `packages/cli/templates/agent-catalog/` on each release; send changes there, not to `gurenjs/agent-skills`.
+Install it at user scope: these skills are for the step *before* a project exists, and they are the same two skills whatever you are building — project scope would write them into whichever repository you happened to be standing in, and share an on-ramp with collaborators of an app that already has the harness. The plugin also conforms to [Agent Plugins v1](https://agent-plugins.org), so any client that reads a root `plugin.json` can install it from that repository directly. It ships `guren-new-app` (explains Guren, scaffolds an app with `bunx create-guren-app`, hands off) and `guren-harness` (runs `bunx guren agent:init --target <agents>` and explains the `guren context` → edit → `guren check` → `guren audit` loop). It deliberately does **not** copy the harness's rules or skills: those are installed by the app's own CLI and stay version-matched to it. The repository is generated from `packages/cli/templates/agent-catalog/` on each release; send changes there, not to `gurenjs/agent-skills`.
 
 | Command | Description | Example |
 |---------|-------------|---------|

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -264,6 +264,21 @@ Inertiaのページは `modules/<name>/` 配下にコロケーションされま
 - **Claude Code**: プロジェクトガイドの `CLAUDE.md`、`.claude/` 配下の検証済みAPIルール・スキル・サブエージェント、開発サーバーの MCP エンドポイントを指す `.mcp.json`（エンドポイント自体は scaffold された `dev` スクリプトの `GUREN_MCP=1` で有効になります）、そしてフィードバックループを構成する hooks です。セッション開始時に `guren context` のプロジェクトマップが読み込まれ、ルート・コントローラ・モデル・スキーマ・ページの編集後には `guren check` が自動で再実行され、失敗があればその場でコーディングエージェントに報告されます。
 - **Codex・Cursor・GitHub Copilot・OpenCode**: プロジェクトガイドの `AGENTS.md` と、`.agents/rules/`・`.agents/skills/` 配下の同じルール・スキル(スキルはエージェント横断の SKILL.md 標準形式)。加えて、Cursor にはネイティブ形式のルール(`.cursor/rules/guren-*.mdc`)、Copilot にはパススコープ付き instructions(`.github/instructions/guren-*.instructions.md`)、Codex にはハーネス自身のコマンドを承認不要にする許可リスト(`.codex/rules/guren.rules`)が生成されます。MCP クライアント設定は各ツールが参照する場所(`.codex/config.toml`・`.cursor/mcp.json`・`.vscode/mcp.json`・`opencode.json` の `mcp` エントリ)に書き出されます。これらのエージェントはハーネスの hooks を実行しないため、セッション開始時の `guren context` 実行と編集後の `guren check` 実行を `AGENTS.md` が指示します。
 
+### アプリを作る前に: カタログから Guren のスキルを入れる
+
+上のハーネスはアプリの `@guren/cli` の中にあるので、アプリができて初めて存在します。その手前、Guren を見たことのないエージェントが空のディレクトリにいる段階のために、Guren は導入用のスキル2本を [`gurenjs/agent-skills`](https://github.com/gurenjs/agent-skills) からエージェントカタログに公開しています。
+
+```bash
+# Claude Code
+claude plugin marketplace add gurenjs/agent-skills
+claude plugin install guren@gurenjs --scope project
+
+# Cursor・Codex・Copilot・OpenCode・Gemini CLI など(Agent Skills CLI)
+npx skills add gurenjs/agent-skills
+```
+
+このプラグインは [Agent Plugins v1](https://agent-plugins.org) にも準拠しているので、ルートの `plugin.json` を読むクライアントならそのリポジトリから直接インストールできます。中身は `guren-new-app`(Guren を説明し、`bunx create-guren-app` で雛形を作り、引き渡す)と `guren-harness`(`bunx guren agent:init --target <agents>` を実行し、`guren context` → 編集 → `guren check` → `guren audit` のループを説明する)の2本です。ハーネスの rules や skills は意図的にコピーしていません。それらはアプリ自身の CLI が入れるもので、アプリの版数と揃い続けます。リポジトリは各リリース時に `packages/cli/templates/agent-catalog/` から生成されるので、変更はそちらへ送ってください(`gurenjs/agent-skills` へは送らないでください)。
+
 | コマンド | 説明 | 例 |
 |---------|------|-----|
 | `agent:init` | 選択したエージェント向けのハーネスを既存アプリに導入(既存ファイルはスキップ、`--force` で上書き) | `bunx guren agent:init --target codex,cursor` |

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -271,13 +271,13 @@ Inertiaのページは `modules/<name>/` 配下にコロケーションされま
 ```bash
 # Claude Code
 claude plugin marketplace add gurenjs/agent-skills
-claude plugin install guren@gurenjs --scope project
+claude plugin install guren@gurenjs --scope user
 
 # Cursor・Codex・Copilot・OpenCode・Gemini CLI など(Agent Skills CLI)
 npx skills add gurenjs/agent-skills
 ```
 
-このプラグインは [Agent Plugins v1](https://agent-plugins.org) にも準拠しているので、ルートの `plugin.json` を読むクライアントならそのリポジトリから直接インストールできます。中身は `guren-new-app`(Guren を説明し、`bunx create-guren-app` で雛形を作り、引き渡す)と `guren-harness`(`bunx guren agent:init --target <agents>` を実行し、`guren context` → 編集 → `guren check` → `guren audit` のループを説明する)の2本です。ハーネスの rules や skills は意図的にコピーしていません。それらはアプリ自身の CLI が入れるもので、アプリの版数と揃い続けます。リポジトリは各リリース時に `packages/cli/templates/agent-catalog/` から生成されるので、変更はそちらへ送ってください(`gurenjs/agent-skills` へは送らないでください)。
+インストールは user scope です。これらのスキルはプロジェクトが存在する*前*の段階のためのもので、何を作る場合でも同じ2本だからです。project scope にすると、たまたま居たリポジトリの設定に書き込まれ、すでにハーネスが入っているアプリの共同作業者にまで on-ramp を配ることになります。このプラグインは [Agent Plugins v1](https://agent-plugins.org) にも準拠しているので、ルートの `plugin.json` を読むクライアントならそのリポジトリから直接インストールできます。中身は `guren-new-app`(Guren を説明し、`bunx create-guren-app` で雛形を作り、引き渡す)と `guren-harness`(`bunx guren agent:init --target <agents>` を実行し、`guren context` → 編集 → `guren check` → `guren audit` のループを説明する)の2本です。ハーネスの rules や skills は意図的にコピーしていません。それらはアプリ自身の CLI が入れるもので、アプリの版数と揃い続けます。リポジトリは各リリース時に `packages/cli/templates/agent-catalog/` から生成されるので、変更はそちらへ送ってください(`gurenjs/agent-skills` へは送らないでください)。
 
 | コマンド | 説明 | 例 |
 |---------|------|-----|

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "audit:template-deps": "bun run ./scripts/sync-template-deps.ts --check",
     "build:agent-catalog": "bun run ./scripts/build-agent-catalog.ts --out",
     "audit:agent-catalog": "bun run ./scripts/build-agent-catalog.ts --check",
+    "publish:agent-catalog": "bun run ./scripts/publish-agent-catalog.ts",
     "version-packages": "bun run audit:core-semver && bun run ./scripts/plan-create-app-bump.ts && changeset version && bun run ./scripts/sync-template-deps.ts --release && bun run audit:plugin-compat && bun install",
     "release": "bun run build && changeset publish",
     "test:bun": "bun run ./scripts/test-packages.ts",

--- a/packages/cli/templates/agent-catalog/README.md.tpl
+++ b/packages/cli/templates/agent-catalog/README.md.tpl
@@ -10,8 +10,14 @@ Cursor, Codex, GitHub Copilot, OpenCode and other coding agents.
 
 ```bash
 claude plugin marketplace add gurenjs/agent-skills
-claude plugin install guren@gurenjs --scope project
+claude plugin install guren@gurenjs --scope user
 ```
+
+User scope on purpose: these skills are for the step *before* a project
+exists, and they are the same two skills whatever you are building. Project
+scope would write them into whichever repository you happened to be standing
+in, and share an on-ramp with collaborators of an app that already has the
+harness installed.
 
 **Cursor, Codex, Copilot, OpenCode, Gemini CLI and others** (Agent Skills CLI)
 

--- a/scripts/publish-agent-catalog.test.ts
+++ b/scripts/publish-agent-catalog.test.ts
@@ -69,18 +69,23 @@ function git(cwd: string, ...args: string[]): string {
 let bare: string
 let scratch: string
 
-beforeAll(async () => {
-  scratch = await mkdtemp(join(tmpdir(), 'guren-publish-test-'))
-  bare = join(scratch, 'agent-skills.git')
-  // a bare repo with one placeholder commit on main, like the real one had
-  Bun.spawnSync(['git', 'init', '--quiet', '--bare', '--initial-branch=main', bare])
-  const seed = join(scratch, 'seed')
-  Bun.spawnSync(['git', 'clone', '--quiet', bare, seed])
+/** A bare repo with one placeholder commit on main, like the real one had. */
+async function seedRemote(name: string): Promise<string> {
+  const remote = join(scratch, name)
+  Bun.spawnSync(['git', 'init', '--quiet', '--bare', '--initial-branch=main', remote])
+  const seed = join(scratch, `${name}-seed`)
+  Bun.spawnSync(['git', 'clone', '--quiet', remote, seed])
   await Bun.write(join(seed, 'README.md'), 'placeholder\n')
   await Bun.write(join(seed, 'STALE.md'), 'a file the publish must remove\n')
   Bun.spawnSync(['git', '-c', 'user.name=t', '-c', 'user.email=t@t', 'add', '-A'], { cwd: seed })
   Bun.spawnSync(['git', '-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '--quiet', '-m', 'seed'], { cwd: seed })
   Bun.spawnSync(['git', 'push', '--quiet', 'origin', 'main'], { cwd: seed })
+  return remote
+}
+
+beforeAll(async () => {
+  scratch = await mkdtemp(join(tmpdir(), 'guren-publish-test-'))
+  bare = await seedRemote('agent-skills.git')
 })
 
 afterAll(async () => {
@@ -174,6 +179,13 @@ describe('publish-agent-catalog', () => {
     Bun.spawnSync(['git', '-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '--quiet', '-am', 'hand edit'], { cwd: drift })
     Bun.spawnSync(['git', 'push', '--quiet', 'origin', 'main'], { cwd: drift })
 
+    // byte-only drift, the same-version case the drift job exists for: every
+    // path is present and one file's contents differ
+    const byteDrift = await diffPublished(bare)
+    expect(byteDrift.code).toBe(1)
+    expect(byteDrift.report).toContain('differs: README.md')
+    expect(byteDrift.report).not.toContain('missing in published')
+
     const result = run(bare)
     expect(result.code).toBe(0)
     expect(result.out).toContain('already published but the tree differs; republishing')
@@ -211,8 +223,111 @@ describe('publish-agent-catalog', () => {
     expect(result.out).toContain('--dry-run: not committing or pushing.')
     expect(result.out).toMatch(/\d+ files? changed/u)
     expect(result.out).toContain('plugins/guren/plugin.json')
+    // the patch, not only the stat: a stat cannot show what the replacement
+    // text of a same-version wording change actually says
+    expect(result.out).toMatch(/^\+.*guren/mu)
     const check = join(scratch, 'check3')
     Bun.spawnSync(['git', 'clone', '--quiet', bare, check])
     expect(git(check, 'rev-list', '--count', 'main')).toBe('1')
+  })
+
+  it('a global gitignore cannot thin the published tree', async () => {
+    // core.excludesFile applies inside the clone too, so a plain `git add -A`
+    // stages whatever the maintainer's global ignores leave behind — a tree
+    // that passed the audit as ten files and reaches users as six
+    const remote = await seedRemote('excludes.git')
+    const excludes = join(scratch, 'global-excludes')
+    await Bun.write(excludes, '*.md\n')
+    const result = runWithEnv(remote, {
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'core.excludesFile',
+      GIT_CONFIG_VALUE_0: excludes,
+    })
+
+    expect(result.code).toBe(0)
+    const check = join(scratch, 'check-excludes')
+    Bun.spawnSync(['git', 'clone', '--quiet', remote, check])
+    const files = git(check, 'ls-files').split('\n').sort()
+    expect(files).toContain('plugins/guren/skills/guren-new-app/SKILL.md')
+    expect(files).toContain('README.md')
+    expect(files.length).toBe(10)
+  })
+
+  it('refuses to publish a tree a clean filter rewrote on its way into the index', async () => {
+    // core.attributesFile is global too, and a clean filter rewrites bytes
+    // between the tree that passed the audit and the tree that gets pushed
+    const remote = await seedRemote('filtered.git')
+    const attributes = join(scratch, 'global-attributes')
+    await Bun.write(attributes, '*.md filter=upcase\n')
+    const result = runWithEnv(remote, {
+      GIT_CONFIG_COUNT: '2',
+      GIT_CONFIG_KEY_0: 'core.attributesFile',
+      GIT_CONFIG_VALUE_0: attributes,
+      GIT_CONFIG_KEY_1: 'filter.upcase.clean',
+      GIT_CONFIG_VALUE_1: 'tr a-z A-Z',
+    })
+
+    expect(result.code).toBe(1)
+    expect(result.out).toContain('the staged tree is not the tree that was audited')
+    expect(result.out).toContain('staged bytes differ from the rendered bytes')
+    const check = join(scratch, 'check-filtered')
+    Bun.spawnSync(['git', 'clone', '--quiet', remote, check])
+    expect(git(check, 'rev-list', '--count', 'main')).toBe('1')
+  })
+
+  it('refuses to push onto a remote that moved after this run cloned it', async () => {
+    // the confirmation prompt is the one moment a test can move the remote
+    // out from under a run that has already cloned it. A rollback is the
+    // dangerous shape: the new commit is still a fast-forward from the
+    // remote's rewound tip, so a plain push would restore exactly the history
+    // somebody had just removed.
+    const remote = await seedRemote('moved.git')
+    expect(run(remote).code).toBe(0)
+    const proc = Bun.spawn([process.execPath, script, '--skip-validate'], {
+      cwd: repoRoot,
+      env: { ...process.env, ...gitIdentity, GUREN_AGENT_SKILLS_REMOTE: remote, GUREN_CATALOG_VERSION_OVERRIDE: '99.0.0' },
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const reader = proc.stdout.getReader()
+    let seen = ''
+    while (!seen.includes('Push this to')) {
+      const { value, done } = await reader.read()
+      if (done) break
+      seen += new TextDecoder().decode(value)
+    }
+    reader.releaseLock()
+    expect(seen).toContain('Push this to')
+
+    // roll the remote back while the run waits for an answer
+    const rewind = join(scratch, 'moved-rewind')
+    Bun.spawnSync(['git', 'clone', '--quiet', remote, rewind])
+    const seedSha = git(rewind, 'rev-list', '--max-parents=0', 'main')
+    Bun.spawnSync(['git', 'reset', '--quiet', '--hard', seedSha], { cwd: rewind })
+    Bun.spawnSync(['git', 'push', '--quiet', '--force', 'origin', 'main'], { cwd: rewind })
+
+    proc.stdin.write('y\n')
+    proc.stdin.end()
+    const code = await proc.exited
+    const out = seen + (await new Response(proc.stderr).text())
+
+    expect(code).toBe(1)
+    expect(out).toContain('the remote moved since this run cloned it')
+    // the rollback stands: still one commit, not the restored history
+    const check = join(scratch, 'check-moved')
+    Bun.spawnSync(['git', 'clone', '--quiet', remote, check])
+    expect(git(check, 'rev-list', '--count', 'main')).toBe('1')
+  })
+
+  it('refuses the generator version override against the real remote', () => {
+    // the override is a test hook. Left in a maintainer's environment it
+    // would publish a version @guren/cli does not have, under the real name
+    const result = spawnPublish('', { GUREN_CATALOG_VERSION_OVERRIDE: '99.0.0' }, ['--yes', '--skip-validate'])
+
+    expect(result.code).toBe(1)
+    expect(result.out).toContain('GUREN_CATALOG_VERSION_OVERRIDE=99.0.0')
+    // refused before it could reach the network at all
+    expect(result.out).not.toContain('Could not clone')
   })
 })

--- a/scripts/publish-agent-catalog.test.ts
+++ b/scripts/publish-agent-catalog.test.ts
@@ -34,17 +34,13 @@ const gitIdentity = {
   GIT_COMMITTER_EMAIL: 'publish-test@guren.dev',
 }
 
-function run(remote: string, ...args: string[]) {
-  return runWithEnv(remote, {}, ...args)
-}
-
 /**
  * The git choreography these tests are about, with the validator gate stood
  * down: `claude` is not on a CI runner's PATH and the script refuses to
  * publish when the validator cannot run. That refusal has its own test below,
  * so it is not a condition on all the others.
  */
-function runWithEnv(remote: string, extraEnv: Record<string, string>, ...args: string[]) {
+function run(remote: string, extraEnv: Record<string, string> = {}, ...args: string[]) {
   return spawnPublish(remote, extraEnv, ['--yes', '--skip-validate', ...args])
 }
 
@@ -149,7 +145,7 @@ describe('publish-agent-catalog', () => {
     // the bug this pins: `cp -R plugins clone/plugins` nests into
     // clone/plugins/plugins/ when the destination already exists — which it
     // does on every publish after the first
-    const result = runWithEnv(bare, { GUREN_CATALOG_VERSION_OVERRIDE: '99.0.0' })
+    const result = run(bare, { GUREN_CATALOG_VERSION_OVERRIDE: '99.0.0' })
     expect(result.code).toBe(0)
     expect(result.out).toContain('Publishing @guren/cli 99.0.0')
     expect(result.out).toContain('Published:')
@@ -218,7 +214,7 @@ describe('publish-agent-catalog', () => {
     Bun.spawnSync(['git', 'reset', '--quiet', '--hard', seedSha], { cwd: rewind })
     Bun.spawnSync(['git', 'push', '--quiet', '--force', 'origin', 'main'], { cwd: rewind })
 
-    const result = run(bare, '--dry-run')
+    const result = run(bare, {}, '--dry-run')
     expect(result.code).toBe(0)
     expect(result.out).toContain('--dry-run: not committing or pushing.')
     expect(result.out).toMatch(/\d+ files? changed/u)
@@ -238,7 +234,7 @@ describe('publish-agent-catalog', () => {
     const remote = await seedRemote('excludes.git')
     const excludes = join(scratch, 'global-excludes')
     await Bun.write(excludes, '*.md\n')
-    const result = runWithEnv(remote, {
+    const result = run(remote, {
       GIT_CONFIG_COUNT: '1',
       GIT_CONFIG_KEY_0: 'core.excludesFile',
       GIT_CONFIG_VALUE_0: excludes,
@@ -259,7 +255,7 @@ describe('publish-agent-catalog', () => {
     const remote = await seedRemote('filtered.git')
     const attributes = join(scratch, 'global-attributes')
     await Bun.write(attributes, '*.md filter=upcase\n')
-    const result = runWithEnv(remote, {
+    const result = run(remote, {
       GIT_CONFIG_COUNT: '2',
       GIT_CONFIG_KEY_0: 'core.attributesFile',
       GIT_CONFIG_VALUE_0: attributes,

--- a/scripts/publish-agent-catalog.test.ts
+++ b/scripts/publish-agent-catalog.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { diffPublished } from './build-agent-catalog.ts'
+import { repoRoot } from './workspace-packages.ts'
+
+/**
+ * The publish script end to end, against a local bare repository standing in
+ * for gurenjs/agent-skills. Three runs, three distinct outcomes the script
+ * must tell apart: a first publish that writes the whole tree, a re-run on
+ * the same version that is a no-op success (not a failure — most releases do
+ * not move @guren/cli), and a re-run whose tree differs only in content
+ * (same version) that still refuses to push a byte-identical tree.
+ *
+ * Kept as a scripts-level guard rather than a unit test because the script's
+ * value is the git choreography — clone, replace tracked files, fast-forward
+ * push — and that is not meaningfully testable without a real repository.
+ */
+
+const script = join(repoRoot, 'scripts', 'publish-agent-catalog.ts')
+
+function run(remote: string, ...args: string[]) {
+  const proc = Bun.spawnSync(['bun', script, '--yes', ...args], {
+    cwd: repoRoot,
+    env: { ...process.env, GUREN_AGENT_SKILLS_REMOTE: remote },
+  })
+  return {
+    code: proc.exitCode,
+    out: (proc.stdout.toString() + proc.stderr.toString()).replace(/\[guren\/orm\][^\n]*\n/gu, ''),
+  }
+}
+
+function git(cwd: string, ...args: string[]): string {
+  const proc = Bun.spawnSync(['git', ...args], { cwd })
+  return proc.stdout.toString().trim()
+}
+
+let bare: string
+let scratch: string
+
+beforeAll(async () => {
+  scratch = await mkdtemp(join(tmpdir(), 'guren-publish-test-'))
+  bare = join(scratch, 'agent-skills.git')
+  // a bare repo with one placeholder commit on main, like the real one had
+  Bun.spawnSync(['git', 'init', '--quiet', '--bare', '--initial-branch=main', bare])
+  const seed = join(scratch, 'seed')
+  Bun.spawnSync(['git', 'clone', '--quiet', bare, seed])
+  await Bun.write(join(seed, 'README.md'), 'placeholder\n')
+  await Bun.write(join(seed, 'STALE.md'), 'a file the publish must remove\n')
+  Bun.spawnSync(['git', '-c', 'user.name=t', '-c', 'user.email=t@t', 'add', '-A'], { cwd: seed })
+  Bun.spawnSync(['git', '-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '--quiet', '-m', 'seed'], { cwd: seed })
+  Bun.spawnSync(['git', 'push', '--quiet', 'origin', 'main'], { cwd: seed })
+})
+
+afterAll(async () => {
+  await rm(scratch, { recursive: true, force: true })
+})
+
+describe('publish-agent-catalog', () => {
+  it('first publish replaces the tracked tree and pushes a fast-forward commit', async () => {
+    const result = run(bare)
+    expect(result.code).toBe(0)
+    expect(result.out).toContain('Publishing @guren/cli')
+    expect(result.out).toContain('Published:')
+
+    const check = join(scratch, 'check1')
+    Bun.spawnSync(['git', 'clone', '--quiet', bare, check])
+    const files = git(check, 'ls-files').split('\n').sort()
+    expect(files).toContain('plugins/guren/plugin.json')
+    expect(files).toContain('plugins/guren/skills/guren-new-app/SKILL.md')
+    expect(files).toContain('.claude-plugin/marketplace.json')
+    // the placeholder-era file the publish does not render is gone
+    expect(files).not.toContain('STALE.md')
+    // history is linear: seed + publish, no force
+    expect(git(check, 'rev-list', '--count', 'main')).toBe('2')
+    expect(git(check, 'log', '-1', '--format=%s')).toMatch(/^Publish @guren\/cli \d/u)
+  })
+
+  it('the drift check is green right after a publish and reports drift against a stale remote', async () => {
+    // right after the first publish above, published == rendered
+    const fresh = await diffPublished(bare)
+    expect(fresh.code).toBe(0)
+    // and against a remote that only has the seed, every file is missing
+    const stale = join(scratch, 'stale.git')
+    Bun.spawnSync(['git', 'clone', '--quiet', '--bare', bare, stale])
+    Bun.spawnSync(['git', 'update-ref', 'refs/heads/main', 'main~1'], { cwd: stale })
+    const drift = await diffPublished(stale)
+    expect(drift.code).toBe(1)
+    expect(drift.report).toContain('missing in published: plugins/guren/plugin.json')
+    expect(drift.report).toContain('extra in published: STALE.md')
+    // an unreachable remote is neither pass nor fail
+    const gone = await diffPublished(join(scratch, 'does-not-exist.git'))
+    expect(gone.code).toBe(2)
+  })
+
+  it('a re-run on the same version is a no-op success, not a failure', () => {
+    const result = run(bare)
+    expect(result.code).toBe(0)
+    expect(result.out).toContain('already publishes')
+    expect(result.out).not.toContain('Published:')
+    const check = join(scratch, 'check2')
+    Bun.spawnSync(['git', 'clone', '--quiet', bare, check])
+    expect(git(check, 'rev-list', '--count', 'main')).toBe('2')
+  })
+
+  it('--dry-run against a stale remote shows the diff and pushes nothing', async () => {
+    // rewind the remote to the seed commit so there is something to publish
+    const rewind = join(scratch, 'rewind')
+    Bun.spawnSync(['git', 'clone', '--quiet', bare, rewind])
+    Bun.spawnSync(['git', 'reset', '--quiet', '--hard', 'HEAD~1'], { cwd: rewind })
+    Bun.spawnSync(['git', 'push', '--quiet', '--force', 'origin', 'main'], { cwd: rewind })
+
+    const result = run(bare, '--dry-run')
+    expect(result.code).toBe(0)
+    expect(result.out).toContain('--dry-run: not committing or pushing.')
+    expect(result.out).toContain('files changed')
+    const check = join(scratch, 'check3')
+    Bun.spawnSync(['git', 'clone', '--quiet', bare, check])
+    expect(git(check, 'rev-list', '--count', 'main')).toBe('1')
+  })
+})

--- a/scripts/publish-agent-catalog.test.ts
+++ b/scripts/publish-agent-catalog.test.ts
@@ -22,9 +22,13 @@ import { repoRoot } from './workspace-packages.ts'
 const script = join(repoRoot, 'scripts', 'publish-agent-catalog.ts')
 
 function run(remote: string, ...args: string[]) {
+  return runWithEnv(remote, {}, ...args)
+}
+
+function runWithEnv(remote: string, extraEnv: Record<string, string>, ...args: string[]) {
   const proc = Bun.spawnSync(['bun', script, '--yes', ...args], {
     cwd: repoRoot,
-    env: { ...process.env, GUREN_AGENT_SKILLS_REMOTE: remote },
+    env: { ...process.env, GUREN_AGENT_SKILLS_REMOTE: remote, ...extraEnv },
   })
   return {
     code: proc.exitCode,
@@ -95,27 +99,77 @@ describe('publish-agent-catalog', () => {
     expect(gone.code).toBe(2)
   })
 
+  it('a second, higher version publishes over the populated tree without nesting directories', async () => {
+    // the bug this pins: `cp -R plugins clone/plugins` nests into
+    // clone/plugins/plugins/ when the destination already exists — which it
+    // does on every publish after the first
+    const result = runWithEnv(bare, { GUREN_CATALOG_VERSION_OVERRIDE: '99.0.0' })
+    expect(result.code).toBe(0)
+    expect(result.out).toContain('Publishing @guren/cli 99.0.0')
+    expect(result.out).toContain('Published:')
+
+    const check = join(scratch, 'check-v2')
+    Bun.spawnSync(['git', 'clone', '--quiet', bare, check])
+    const files = git(check, 'ls-files').split('\n').sort()
+    expect(files.filter((f) => f.startsWith('plugins/plugins/'))).toEqual([])
+    expect(files.filter((f) => f.startsWith('.claude-plugin/.claude-plugin/'))).toEqual([])
+    expect(files).toContain('plugins/guren/plugin.json')
+    const manifest = JSON.parse(await Bun.file(join(check, 'plugins/guren/plugin.json')).text())
+    expect(manifest.version).toBe('99.0.0')
+    // exactly the rendered set, nothing extra
+    expect(files.length).toBe(10)
+    expect(git(check, 'rev-list', '--count', 'main')).toBe('3')
+
+    // and publish the real version back on top so later tests see it
+    const back = run(bare)
+    expect(back.code).toBe(0)
+  })
+
+  it('same version, different content republishes (a LICENSE or wording change), with a warning', async () => {
+    // simulate a drifted publish: overwrite one published file, keep the version
+    const drift = join(scratch, 'drift')
+    Bun.spawnSync(['git', 'clone', '--quiet', bare, drift])
+    await Bun.write(join(drift, 'README.md'), 'someone hand-edited this\n')
+    Bun.spawnSync(['git', '-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '--quiet', '-am', 'hand edit'], { cwd: drift })
+    Bun.spawnSync(['git', 'push', '--quiet', 'origin', 'main'], { cwd: drift })
+
+    const result = run(bare)
+    expect(result.code).toBe(0)
+    expect(result.out).toContain('already published but the tree differs; republishing')
+    expect(result.out).toContain('Published:')
+    const check = join(scratch, 'check-drift')
+    Bun.spawnSync(['git', 'clone', '--quiet', bare, check])
+    expect(await Bun.file(join(check, 'README.md')).text()).not.toContain('hand-edited')
+  })
+
   it('a re-run on the same version is a no-op success, not a failure', () => {
     const result = run(bare)
     expect(result.code).toBe(0)
-    expect(result.out).toContain('already publishes')
+    expect(result.out).toContain('byte-identical to what is published; nothing to do')
     expect(result.out).not.toContain('Published:')
     const check = join(scratch, 'check2')
     Bun.spawnSync(['git', 'clone', '--quiet', bare, check])
-    expect(git(check, 'rev-list', '--count', 'main')).toBe('2')
+    const before = git(check, 'rev-list', '--count', 'main')
+    run(bare)
+    const check2 = join(scratch, 'check2b')
+    Bun.spawnSync(['git', 'clone', '--quiet', bare, check2])
+    expect(git(check2, 'rev-list', '--count', 'main')).toBe(before)
   })
 
   it('--dry-run against a stale remote shows the diff and pushes nothing', async () => {
-    // rewind the remote to the seed commit so there is something to publish
+    // rewind the remote all the way to the seed commit so there is a full
+    // publish's worth of diff to show
     const rewind = join(scratch, 'rewind')
     Bun.spawnSync(['git', 'clone', '--quiet', bare, rewind])
-    Bun.spawnSync(['git', 'reset', '--quiet', '--hard', 'HEAD~1'], { cwd: rewind })
+    const seedSha = git(rewind, 'rev-list', '--max-parents=0', 'main')
+    Bun.spawnSync(['git', 'reset', '--quiet', '--hard', seedSha], { cwd: rewind })
     Bun.spawnSync(['git', 'push', '--quiet', '--force', 'origin', 'main'], { cwd: rewind })
 
     const result = run(bare, '--dry-run')
     expect(result.code).toBe(0)
     expect(result.out).toContain('--dry-run: not committing or pushing.')
-    expect(result.out).toContain('files changed')
+    expect(result.out).toMatch(/\d+ files? changed/u)
+    expect(result.out).toContain('plugins/guren/plugin.json')
     const check = join(scratch, 'check3')
     Bun.spawnSync(['git', 'clone', '--quiet', bare, check])
     expect(git(check, 'rev-list', '--count', 'main')).toBe('1')

--- a/scripts/publish-agent-catalog.test.ts
+++ b/scripts/publish-agent-catalog.test.ts
@@ -21,14 +21,39 @@ import { repoRoot } from './workspace-packages.ts'
 
 const script = join(repoRoot, 'scripts', 'publish-agent-catalog.ts')
 
+/**
+ * A commit identity supplied by the test rather than by the machine. A CI
+ * runner has no `user.email` and a hostname of `(none)`, so git cannot
+ * auto-detect one and every commit the script makes would fail there while
+ * passing on a maintainer's laptop.
+ */
+const gitIdentity = {
+  GIT_AUTHOR_NAME: 'Guren publish test',
+  GIT_AUTHOR_EMAIL: 'publish-test@guren.dev',
+  GIT_COMMITTER_NAME: 'Guren publish test',
+  GIT_COMMITTER_EMAIL: 'publish-test@guren.dev',
+}
+
 function run(remote: string, ...args: string[]) {
   return runWithEnv(remote, {}, ...args)
 }
 
+/**
+ * The git choreography these tests are about, with the validator gate stood
+ * down: `claude` is not on a CI runner's PATH and the script refuses to
+ * publish when the validator cannot run. That refusal has its own test below,
+ * so it is not a condition on all the others.
+ */
 function runWithEnv(remote: string, extraEnv: Record<string, string>, ...args: string[]) {
-  const proc = Bun.spawnSync(['bun', script, '--yes', ...args], {
+  return spawnPublish(remote, extraEnv, ['--yes', '--skip-validate', ...args])
+}
+
+function spawnPublish(remote: string, extraEnv: Record<string, string>, args: string[]) {
+  // argv[0] is this bun, not whatever `bun` PATH resolves to, so a test may
+  // hand the script a PATH that is missing tools without losing its runtime
+  const proc = Bun.spawnSync([process.execPath, script, ...args], {
     cwd: repoRoot,
-    env: { ...process.env, GUREN_AGENT_SKILLS_REMOTE: remote, ...extraEnv },
+    env: { ...process.env, ...gitIdentity, GUREN_AGENT_SKILLS_REMOTE: remote, ...extraEnv },
   })
   return {
     code: proc.exitCode,
@@ -63,6 +88,22 @@ afterAll(async () => {
 })
 
 describe('publish-agent-catalog', () => {
+  it('refuses to publish when claude plugin validate could not run', () => {
+    // a PATH with no `claude` on it: a CI runner, or a maintainer who has not
+    // installed the CLI. Publish is the last gate before users, so an
+    // unavailable validator refuses rather than warns — only --skip-validate
+    // (which every other test here passes) overrides that. Runs before any
+    // publish because it must not reach the remote at all.
+    const result = spawnPublish(bare, { PATH: '/usr/bin:/bin' }, ['--yes'])
+    expect(result.code).toBe(1)
+    expect(result.out).toContain('claude plugin validate could not run')
+    expect(result.out).toContain('--skip-validate')
+    // it refused before cloning: the remote is still just the seed commit
+    const check = join(scratch, 'check-refused')
+    Bun.spawnSync(['git', 'clone', '--quiet', bare, check])
+    expect(git(check, 'rev-list', '--count', 'main')).toBe('1')
+  })
+
   it('first publish replaces the tracked tree and pushes a fast-forward commit', async () => {
     const result = run(bare)
     expect(result.code).toBe(0)

--- a/scripts/publish-agent-catalog.test.ts
+++ b/scripts/publish-agent-catalog.test.ts
@@ -1,9 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { diffPublished } from './build-agent-catalog.ts'
+import { isPublishRepo } from './publish-agent-catalog.ts'
 import { repoRoot } from './workspace-packages.ts'
 
 /**
@@ -86,6 +87,35 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await rm(scratch, { recursive: true, force: true })
+})
+
+describe('isPublishRepo', () => {
+  // what decides whether a run is pointed at the public repository. Unit
+  // tested because the guard that uses it cannot be mutation tested: making
+  // it answer wrongly, with the override set, is a run that clones and
+  // pushes to the real gurenjs/agent-skills.
+  it('recognizes the real repository however it is addressed', () => {
+    for (const remote of [
+      'git@github.com:gurenjs/agent-skills.git',
+      'https://github.com/gurenjs/agent-skills.git',
+      'https://github.com/gurenjs/agent-skills',
+      'ssh://git@github.com/GurenJS/Agent-Skills.git',
+    ]) {
+      expect(isPublishRepo(remote)).toBe(true)
+    }
+  })
+
+  it('never mistakes a local path for it, however the path is spelled', () => {
+    for (const remote of [
+      '/tmp/gurenjs/agent-skills.git',
+      './gurenjs/agent-skills.git',
+      'file:///tmp/gurenjs/agent-skills.git',
+      'git@github.com:gurenjs/agent-skills-fork.git',
+      'https://example.com/gurenjs/agent-skills.git',
+    ]) {
+      expect(isPublishRepo(remote)).toBe(false)
+    }
+  })
 })
 
 describe('publish-agent-catalog', () => {
@@ -316,14 +346,79 @@ describe('publish-agent-catalog', () => {
     expect(git(check, 'rev-list', '--count', 'main')).toBe('1')
   })
 
+  it('runs no hook the maintainer has configured globally', async () => {
+    // core.hooksPath is global, so it applies to this fresh clone too, and
+    // its hooks run at the moments the provenance guarantee depends on:
+    // post-checkout after the clone, pre-commit between the staged-tree check
+    // and the tree that gets committed, post-commit before the push
+    const hooks = join(scratch, 'global-hooks')
+    await mkdir(hooks, { recursive: true })
+    const marker = join(scratch, 'hook-ran')
+    for (const hook of ['post-checkout', 'pre-commit', 'post-commit']) {
+      await Bun.write(join(hooks, hook), `#!/bin/sh\necho ${hook} >> ${marker}\n`)
+      await chmod(join(hooks, hook), 0o755)
+    }
+    const remote = await seedRemote('hooked.git')
+
+    const result = run(remote, {
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'core.hooksPath',
+      GIT_CONFIG_VALUE_0: hooks,
+    })
+
+    expect(result.code).toBe(0)
+    expect(result.out).toContain('Published:')
+    expect(await Bun.file(marker).exists()).toBe(false)
+  })
+
   it('refuses the generator version override against the real remote', () => {
     // the override is a test hook. Left in a maintainer's environment it
-    // would publish a version @guren/cli does not have, under the real name
-    const result = spawnPublish('', { GUREN_CATALOG_VERSION_OVERRIDE: '99.0.0' }, ['--yes', '--skip-validate'])
+    // would publish a version @guren/cli does not have, under the real name.
+    // The remote is named rather than left empty: an empty one is falsy, so
+    // it would also refuse under the older guard that only asked whether the
+    // variable was set, and the test could not tell the two apart.
+    const result = spawnPublish('https://github.com/gurenjs/agent-skills.git', { GUREN_CATALOG_VERSION_OVERRIDE: '99.0.0' }, [
+      '--yes',
+      '--skip-validate',
+    ])
 
     expect(result.code).toBe(1)
     expect(result.out).toContain('GUREN_CATALOG_VERSION_OVERRIDE=99.0.0')
     // refused before it could reach the network at all
     expect(result.out).not.toContain('Could not clone')
+  })
+
+  it('allows the override against a local remote whose path merely reads like the real one', async () => {
+    // the destination is decided by what the remote is, not by whether its
+    // spelling contains the repository name: a bare repo under a directory
+    // called gurenjs/agent-skills is a test remote
+    await mkdir(join(scratch, 'gurenjs'), { recursive: true })
+    const remote = await seedRemote(join('gurenjs', 'agent-skills.git'))
+    const result = run(remote, { GUREN_CATALOG_VERSION_OVERRIDE: '99.0.0' })
+
+    expect(result.code).toBe(0)
+    expect(result.out).toContain('Publishing @guren/cli 99.0.0')
+  })
+
+  it('--skip-validate does not run the validator, rather than forgiving its verdict', async () => {
+    // a `claude` on PATH that fails loudly if it is ever invoked. Without
+    // --skip-validate the script would run it and refuse; with it, the
+    // publish must not touch it at all.
+    const bin = join(scratch, 'fake-bin')
+    await mkdir(bin, { recursive: true })
+    const marker = join(scratch, 'validator-was-run')
+    await Bun.write(join(bin, 'claude'), `#!/bin/sh\ntouch ${marker}\necho 'validation failed' >&2\nexit 1\n`)
+    await chmod(join(bin, 'claude'), 0o755)
+    const remote = await seedRemote('skip-validate.git')
+
+    const skipped = spawnPublish(remote, { PATH: `${bin}:${process.env.PATH ?? ''}` }, ['--yes', '--skip-validate'])
+    expect(skipped.code).toBe(0)
+    expect(await Bun.file(marker).exists()).toBe(false)
+
+    // and without the flag the same fake validator refuses the publish
+    const validated = spawnPublish(remote, { PATH: `${bin}:${process.env.PATH ?? ''}` }, ['--yes'])
+    expect(validated.code).toBe(1)
+    expect(validated.out).toContain('claude plugin validate --strict failed')
+    expect(await Bun.file(marker).exists()).toBe(true)
   })
 })

--- a/scripts/publish-agent-catalog.ts
+++ b/scripts/publish-agent-catalog.ts
@@ -56,8 +56,36 @@ function remotes(): string[] {
   return [`git@github.com:${PUBLISH_REPO}.git`, `https://github.com/${PUBLISH_REPO}.git`]
 }
 
+/**
+ * `core.hooksPath` pointed at nothing, on every git command this script runs.
+ * The clone is fresh, but hooks are not: a maintainer's global `core.hooksPath`
+ * (or an `init.templateDir` that installs into the new clone) applies to it,
+ * and those hooks run at exactly the moments this script's guarantee depends
+ * on — `post-checkout` after the clone, `pre-commit` between the staged-tree
+ * check and the tree that gets committed, `post-commit` before the push. The
+ * rest of the maintainer's configuration is deliberately left alone: their
+ * credential helper and SSH setup are how this pushes at all.
+ */
+const NO_HOOKS = ['-c', 'core.hooksPath=']
+
+/**
+ * Does this remote name the public repository? A local path is never it, however
+ * it is spelled — a bare repo at `/tmp/gurenjs/agent-skills.git` is a test
+ * remote, not GitHub — and the owner/repo pair is compared case-insensitively
+ * because GitHub treats it that way while a substring check would not.
+ */
+export function isPublishRepo(remote: string): boolean {
+  if (remote.startsWith('/') || remote.startsWith('.') || remote.startsWith('file:')) return false
+  const address = remote.replace(/^[a-z+]+:\/\//iu, '').replace(/^[^@/]+@/u, '')
+  const [host, ...rest] = address.split(/[:/]/u)
+  const path = rest.join('/').replace(/\.git$/u, '')
+  // the host too: a different server offering a path of the same name is
+  // somebody's mirror, not the repository this script may not publish to
+  return host?.toLowerCase() === 'github.com' && path.toLowerCase() === PUBLISH_REPO.toLowerCase()
+}
+
 function git(cwd: string, args: string[]): { ok: boolean; out: string; stdout: string } {
-  const run = Bun.spawnSync(['git', ...args], { cwd })
+  const run = Bun.spawnSync(['git', ...NO_HOOKS, ...args], { cwd })
   return {
     ok: run.success,
     out: (run.stdout.toString() + run.stderr.toString()).trim(),
@@ -86,9 +114,18 @@ class PublishRefusal extends Error {}
  * path set and then blob by blob.
  */
 async function stagedTreeProblems(cloneDir: string, files: readonly RenderedFile[]): Promise<string[]> {
-  const listed = git(cloneDir, ['ls-files', '--cached', '-z'])
+  // --stage, so the mode comes with the path: a tree records `100755` and
+  // `120000` as surely as it records bytes, and a publish that turned a
+  // rendered file into an executable or a symlink would pass a comparison
+  // that only read its content.
+  const listed = git(cloneDir, ['ls-files', '--stage', '-z'])
   if (!listed.ok) return [`git ls-files failed after staging: ${listed.out}`]
-  const stagedPaths = listed.stdout.split('\0').filter(Boolean)
+  const entries = listed.stdout.split('\0').filter(Boolean).map((line) => {
+    const [meta = '', path = ''] = line.split('\t')
+    const [mode = '', , stage = ''] = meta.split(' ')
+    return { mode, stage, path }
+  })
+  const stagedPaths = entries.map((entry) => entry.path)
   const staged = new Set(stagedPaths)
   const rendered = new Set(files.map((file) => file.path))
   const problems = [
@@ -96,6 +133,10 @@ async function stagedTreeProblems(cloneDir: string, files: readonly RenderedFile
     ...[...rendered].filter((p) => !staged.has(p)).map((p) => `rendered but not staged: ${p}`),
   ].sort()
   if (problems.length > 0) return problems
+  for (const entry of entries) {
+    if (entry.mode !== '100644') problems.push(`staged as ${entry.mode}, not a plain file: ${entry.path}`)
+    if (entry.stage !== '0') problems.push(`staged unmerged (stage ${entry.stage}): ${entry.path}`)
+  }
   for (const file of files) {
     const blob = git(cloneDir, ['show', `:${file.path}`])
     if (!blob.ok) {
@@ -130,7 +171,7 @@ async function main(): Promise<void> {
   // that happens to redirect it today: a second way to point somewhere else
   // would leave a proxy check green while the hole it closes reopened
   const override = process.env.GUREN_CATALOG_VERSION_OVERRIDE
-  if (override && remotes().some((remote) => remote.includes(PUBLISH_REPO))) {
+  if (override && remotes().some(isPublishRepo)) {
     fail(
       `Refusing to publish: GUREN_CATALOG_VERSION_OVERRIDE=${override} is set. It is a test hook for a local remote, not a way to publish a version @guren/cli does not have.`,
     )
@@ -186,6 +227,16 @@ async function main(): Promise<void> {
     // the tip this run is allowed to move: the push leases it, so a remote
     // that changed under us — including one somebody force-rolled backwards,
     // which an ordinary fast-forward would happily restore — is refused
+    // asked again of the clone, because the URL this run resolved is not
+    // necessarily the one git will push to: a global `remote.origin.pushurl`
+    // applies to any repository whose remote is named origin, including this
+    // fresh one.
+    const pushUrl = git(cloneDir, ['remote', 'get-url', '--push', 'origin']).stdout.trim()
+    if (override && isPublishRepo(pushUrl)) {
+      fail(
+        `Refusing to publish: GUREN_CATALOG_VERSION_OVERRIDE=${override} is set and this clone pushes to ${pushUrl}.`,
+      )
+    }
     const baseOid = git(cloneDir, ['rev-parse', 'HEAD']).stdout.trim()
     const publishedVersion = await pluginVersionIn(cloneDir)
     console.log(
@@ -222,6 +273,12 @@ async function main(): Promise<void> {
         `Refusing to publish: the staged tree is not the tree that was audited.\n${staged.map((p) => `  ${p}`).join('\n')}`,
       )
     }
+    // the index just verified, named. Everything after this point — the
+    // prompt, the commit — is checked against this OID rather than trusted to
+    // have left it alone.
+    const verifiedTree = git(cloneDir, ['write-tree'])
+    if (!verifiedTree.ok) fail(`git write-tree failed in the clone:\n${verifiedTree.out}`)
+    const verifiedTreeOid = verifiedTree.stdout.trim()
     const status = git(cloneDir, ['status', '--porcelain'])
     if (status.out === '') {
       // the same-version no-op: most releases do not move @guren/cli, and a
@@ -258,11 +315,33 @@ async function main(): Promise<void> {
     const message = `Publish @guren/cli ${nextVersion}`
     const commit = git(cloneDir, ['commit', '--quiet', '-m', message])
     if (!commit.ok) fail(`git commit failed:\n${commit.out}`)
-    // leased to the tip that was cloned: any other value means the remote
-    // moved while this ran, and the answer is always to re-run rather than to
-    // overwrite. A plain push would reject a divergent remote but would
-    // happily fast-forward a deliberate rollback back into place.
-    const push = git(cloneDir, ['push', '--quiet', `--force-with-lease=${PUBLISH_BRANCH}:${baseOid}`, 'origin', PUBLISH_BRANCH])
+
+    // what actually got committed, checked rather than assumed: the tree must
+    // be the one verified above, and its one parent the tip that was cloned.
+    const head = git(cloneDir, ['rev-parse', 'HEAD'])
+    if (!head.ok) fail(`git rev-parse HEAD failed in the clone:\n${head.out}`)
+    const commitOid = head.stdout.trim()
+    const tree = git(cloneDir, ['rev-parse', `${commitOid}^{tree}`]).stdout.trim()
+    const parents = git(cloneDir, ['rev-list', '--parents', '-n', '1', commitOid]).stdout.trim().split(' ').slice(1)
+    if (tree !== verifiedTreeOid || parents.length !== 1 || parents[0] !== baseOid) {
+      fail(
+        `Refusing to publish: the commit is not the one this run built (tree ${tree}, parents ${parents.join(' ') || 'none'}; expected tree ${verifiedTreeOid} on ${baseOid}).`,
+      )
+    }
+
+    // that commit by OID, not a branch name that something could have moved,
+    // onto a remote leased to the tip that was cloned: any other value there
+    // means the remote changed while this ran, and the answer is always to
+    // re-run rather than to overwrite. A plain push would reject a divergent
+    // remote but would happily fast-forward a deliberate rollback back into
+    // place.
+    const push = git(cloneDir, [
+      'push',
+      '--quiet',
+      `--force-with-lease=${PUBLISH_BRANCH}:${baseOid}`,
+      'origin',
+      `${commitOid}:refs/heads/${PUBLISH_BRANCH}`,
+    ])
     if (!push.ok) fail(`git push failed (the remote moved since this run cloned it; re-run to publish onto its new tip):\n${push.out}`)
     console.log(`Published: ${message}`)
   } finally {

--- a/scripts/publish-agent-catalog.ts
+++ b/scripts/publish-agent-catalog.ts
@@ -1,0 +1,177 @@
+/**
+ * Publish the rendered agent-catalog payload to gurenjs/agent-skills
+ * (RFC 0011 §5).
+ *
+ * This is a maintainer-run script, not a CI job — the same shape Remotion
+ * uses to publish `packages/skills/` from its monorepo to `remotion-dev/skills`.
+ * It runs over the maintainer's own git credentials; there is no repository
+ * token or secret anywhere. It belongs at the end of the release procedure,
+ * after the npm publish the maintainer can see succeeded.
+ *
+ * What it does, in order, and why each step is where it is:
+ *
+ * 1. Render the payload into a temporary directory and run the same
+ *    derived-fact assertions `audit:agent-catalog` runs, over that same tree.
+ *    Provenance: the tree that is audited is the tree that is pushed, never
+ *    a second render.
+ * 2. Clone gurenjs/agent-skills shallow. Compare the plugin `version` already
+ *    published with the one just rendered. Equal → nothing to do, exit 0.
+ *    Most releases do not move @guren/cli, and failing here would make a
+ *    routine step red for a reason that has nothing to do with the catalog.
+ * 3. Delete every tracked file in the clone, copy the rendered tree in, and
+ *    commit. Ordinary fast-forward push — never --force. Claude Code keeps a
+ *    local clone of a registered marketplace and refreshes it; a rewritten
+ *    history risks non-fast-forward failures for every registered user, and
+ *    the payload is deterministic anyway.
+ *
+ * `--dry-run` does everything except commit and push, and prints the diff.
+ * `--yes` skips the confirmation prompt (for the release checklist).
+ */
+import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { auditRenderedFiles, claudePluginValidate, writeCatalog } from './build-agent-catalog'
+import { repoRoot } from './workspace-packages'
+
+const PUBLISH_REPO = 'gurenjs/agent-skills'
+const PUBLISH_BRANCH = 'main'
+
+/**
+ * Where to clone from and push to. The real remote by default; a test points
+ * this at a local bare repository via `GUREN_AGENT_SKILLS_REMOTE` so the
+ * no-op and fast-forward paths can be exercised without touching GitHub.
+ */
+function remotes(): string[] {
+  const override = process.env.GUREN_AGENT_SKILLS_REMOTE
+  if (override) return [override]
+  return [`git@github.com:${PUBLISH_REPO}.git`, `https://github.com/${PUBLISH_REPO}.git`]
+}
+
+function git(cwd: string, args: string[]): { ok: boolean; out: string } {
+  const run = Bun.spawnSync(['git', ...args], { cwd })
+  return { ok: run.success, out: (run.stdout.toString() + run.stderr.toString()).trim() }
+}
+
+function fail(message: string): never {
+  console.error(message)
+  process.exit(1)
+}
+
+/** The plugin version a rendered or cloned tree declares, or null if unreadable. */
+async function pluginVersionIn(dir: string): Promise<string | null> {
+  try {
+    const manifest = (await Bun.file(join(dir, 'plugins', 'guren', 'plugin.json')).json()) as { version?: unknown }
+    return typeof manifest.version === 'string' ? manifest.version : null
+  } catch {
+    return null
+  }
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2)
+  const dryRun = args.includes('--dry-run')
+  const yes = args.includes('--yes')
+
+  // 1. render + audit the tree we are about to push
+  const renderDir = await mkdtemp(join(tmpdir(), 'guren-catalog-publish-'))
+  const cloneDir = await mkdtemp(join(tmpdir(), 'guren-catalog-clone-'))
+  const cleanup = async (): Promise<void> => {
+    await rm(renderDir, { recursive: true, force: true })
+    await rm(cloneDir, { recursive: true, force: true })
+  }
+
+  try {
+    const files = await writeCatalog(renderDir)
+    const problems = await auditRenderedFiles(files)
+    if (problems.length > 0) {
+      fail(`Refusing to publish: the rendered payload fails its own audit.\n${problems.map((p) => `  ${p}`).join('\n')}`)
+    }
+    const validated = await claudePluginValidate(renderDir)
+    if (validated.kind === 'fail') {
+      fail(`Refusing to publish: claude plugin validate --strict failed.\n${validated.output}`)
+    }
+    if (validated.kind === 'unavailable') {
+      // publishing without the validator is a maintainer decision, made
+      // visibly; the audit in CI already ran on the same sources
+      console.warn(`Note: claude plugin validate could not run here (${validated.reason}); publishing on the derived-fact audit alone.`)
+    }
+    const nextVersion = (await pluginVersionIn(renderDir)) ?? fail('Rendered payload has no plugin version — refusing to publish.')
+
+    // 2. clone and compare
+    // try each remote form in turn: SSH first, HTTPS for maintainers who
+    // authenticate that way
+    let cloned = false
+    const errors: string[] = []
+    for (const remote of remotes()) {
+      await rm(cloneDir, { recursive: true, force: true })
+      const clone = git(repoRoot, ['clone', '--quiet', '--depth', '1', '--branch', PUBLISH_BRANCH, remote, cloneDir])
+      if (clone.ok) {
+        cloned = true
+        break
+      }
+      errors.push(clone.out)
+    }
+    if (!cloned) fail(`Could not clone ${PUBLISH_REPO}:\n${errors.join('\n')}`)
+    const publishedVersion = await pluginVersionIn(cloneDir)
+    if (publishedVersion === nextVersion) {
+      console.log(`${PUBLISH_REPO} already publishes @guren/cli ${nextVersion}; nothing to do.`)
+      return
+    }
+    console.log(`Publishing @guren/cli ${nextVersion} to ${PUBLISH_REPO} (currently ${publishedVersion ?? 'unpublished'}).`)
+
+    // 3. replace tracked contents with the rendered tree
+    const tracked = git(cloneDir, ['ls-files'])
+    if (!tracked.ok) fail(`git ls-files failed in the clone:\n${tracked.out}`)
+    for (const path of tracked.out.split('\n').filter(Boolean)) {
+      await rm(join(cloneDir, path), { force: true })
+    }
+    // copy rendered files in (recursive dir copy via cp -R keeps this dependency-free)
+    for (const entry of await readdir(renderDir)) {
+      const cp = Bun.spawnSync(['cp', '-R', join(renderDir, entry), join(cloneDir, entry)])
+      if (!cp.success) fail(`Failed to copy ${entry} into the clone.`)
+    }
+    // sweep empty directories left behind by removed files
+    Bun.spawnSync(['find', cloneDir, '-type', 'd', '-empty', '-not', '-path', '*/.git*', '-delete'])
+
+    git(cloneDir, ['add', '-A'])
+    const status = git(cloneDir, ['status', '--porcelain'])
+    if (status.out === '') {
+      console.log('Rendered payload is byte-identical to what is published; nothing to commit.')
+      return
+    }
+    const diffStat = git(cloneDir, ['diff', '--cached', '--stat'])
+    console.log(diffStat.out)
+
+    if (dryRun) {
+      console.log('\n--dry-run: not committing or pushing.')
+      return
+    }
+    if (!yes) {
+      process.stdout.write(`\nPush this to ${PUBLISH_REPO}/${PUBLISH_BRANCH}? [y/N] `)
+      const answer = await new Promise<string>((resolve) => {
+        process.stdin.once('data', (d) => resolve(d.toString().trim()))
+      })
+      if (!/^y(es)?$/iu.test(answer)) {
+        console.log('Aborted.')
+        return
+      }
+    }
+    const message = `Publish @guren/cli ${nextVersion}`
+    const commit = git(cloneDir, ['commit', '--quiet', '-m', message])
+    if (!commit.ok) fail(`git commit failed:\n${commit.out}`)
+    // ordinary push: fast-forward only, never --force
+    const push = git(cloneDir, ['push', '--quiet', 'origin', PUBLISH_BRANCH])
+    if (!push.ok) fail(`git push failed (a non-fast-forward means someone else pushed; re-run to rebase onto their tip):\n${push.out}`)
+    console.log(`Published: ${message}`)
+  } finally {
+    await cleanup()
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })
+}

--- a/scripts/publish-agent-catalog.ts
+++ b/scripts/publish-agent-catalog.ts
@@ -27,9 +27,9 @@
  * `--dry-run` does everything except commit and push, and prints the diff.
  * `--yes` skips the confirmation prompt (for the release checklist).
  */
-import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import process from 'node:process'
 import { auditRenderedFiles, claudePluginValidate, writeCatalog } from './build-agent-catalog'
 import { repoRoot } from './workspace-packages'
@@ -48,9 +48,13 @@ function remotes(): string[] {
   return [`git@github.com:${PUBLISH_REPO}.git`, `https://github.com/${PUBLISH_REPO}.git`]
 }
 
-function git(cwd: string, args: string[]): { ok: boolean; out: string } {
+function git(cwd: string, args: string[]): { ok: boolean; out: string; stdout: string } {
   const run = Bun.spawnSync(['git', ...args], { cwd })
-  return { ok: run.success, out: (run.stdout.toString() + run.stderr.toString()).trim() }
+  return {
+    ok: run.success,
+    out: (run.stdout.toString() + run.stderr.toString()).trim(),
+    stdout: run.stdout.toString(),
+  }
 }
 
 function fail(message: string): never {
@@ -92,9 +96,15 @@ async function main(): Promise<void> {
       fail(`Refusing to publish: claude plugin validate --strict failed.\n${validated.output}`)
     }
     if (validated.kind === 'unavailable') {
-      // publishing without the validator is a maintainer decision, made
-      // visibly; the audit in CI already ran on the same sources
-      console.warn(`Note: claude plugin validate could not run here (${validated.reason}); publishing on the derived-fact audit alone.`)
+      // CI cannot run the validator (no `claude` on the ubuntu runner), so
+      // publish is where it must run — this is the last gate before users.
+      // Refuse rather than warn: an unavailable check is not a green one.
+      // --skip-validate is the explicit override, for a maintainer who has
+      // run it by hand.
+      if (!args.includes('--skip-validate')) {
+        fail(`Refusing to publish: claude plugin validate could not run (${validated.reason}). Install the Claude Code CLI, or pass --skip-validate after validating by hand.`)
+      }
+      console.warn(`Note: --skip-validate given; publishing without claude plugin validate (${validated.reason}).`)
     }
     const nextVersion = (await pluginVersionIn(renderDir)) ?? fail('Rendered payload has no plugin version — refusing to publish.')
 
@@ -114,31 +124,43 @@ async function main(): Promise<void> {
     }
     if (!cloned) fail(`Could not clone ${PUBLISH_REPO}:\n${errors.join('\n')}`)
     const publishedVersion = await pluginVersionIn(cloneDir)
-    if (publishedVersion === nextVersion) {
-      console.log(`${PUBLISH_REPO} already publishes @guren/cli ${nextVersion}; nothing to do.`)
-      return
-    }
-    console.log(`Publishing @guren/cli ${nextVersion} to ${PUBLISH_REPO} (currently ${publishedVersion ?? 'unpublished'}).`)
+    console.log(
+      publishedVersion === nextVersion
+        ? `${PUBLISH_REPO} already publishes @guren/cli ${nextVersion}; checking the tree is byte-identical.`
+        : `Publishing @guren/cli ${nextVersion} to ${PUBLISH_REPO} (currently ${publishedVersion ?? 'unpublished'}).`,
+    )
 
-    // 3. replace tracked contents with the rendered tree
-    const tracked = git(cloneDir, ['ls-files'])
+    // 3. replace tracked contents with the rendered tree. Every tracked file
+    // is removed, then every rendered file is written at its exact path with
+    // mkdir -p — never `cp -R` of a directory, which nests (`plugins/plugins/`)
+    // when the destination already exists, i.e. on every publish after the
+    // first. Directories emptied by the removals are swept last.
+    const tracked = git(cloneDir, ['ls-files', '-z'])
     if (!tracked.ok) fail(`git ls-files failed in the clone:\n${tracked.out}`)
-    for (const path of tracked.out.split('\n').filter(Boolean)) {
+    for (const path of tracked.stdout.split('\0').filter(Boolean)) {
       await rm(join(cloneDir, path), { force: true })
     }
-    // copy rendered files in (recursive dir copy via cp -R keeps this dependency-free)
-    for (const entry of await readdir(renderDir)) {
-      const cp = Bun.spawnSync(['cp', '-R', join(renderDir, entry), join(cloneDir, entry)])
-      if (!cp.success) fail(`Failed to copy ${entry} into the clone.`)
+    for (const file of files) {
+      const dest = join(cloneDir, file.path)
+      await mkdir(dirname(dest), { recursive: true })
+      await writeFile(dest, file.content, 'utf8')
     }
-    // sweep empty directories left behind by removed files
     Bun.spawnSync(['find', cloneDir, '-type', 'd', '-empty', '-not', '-path', '*/.git*', '-delete'])
 
     git(cloneDir, ['add', '-A'])
     const status = git(cloneDir, ['status', '--porcelain'])
     if (status.out === '') {
-      console.log('Rendered payload is byte-identical to what is published; nothing to commit.')
+      // the same-version no-op: most releases do not move @guren/cli, and a
+      // publish that finds nothing to write is a success, not a failure
+      console.log('Rendered payload is byte-identical to what is published; nothing to do.')
       return
+    }
+    if (publishedVersion === nextVersion) {
+      // same version, different bytes: a LICENSE change, a wording fix that
+      // rode a CLI release, or a corrupted earlier publish. Republish — but
+      // note that plugin.json's version is Claude Code's cache key, so
+      // already-installed copies will not pick this up until the next bump.
+      console.warn(`Note: version ${nextVersion} is already published but the tree differs; republishing. Installed plugins keyed on this version will not refresh until @guren/cli moves.`)
     }
     const diffStat = git(cloneDir, ['diff', '--cached', '--stat'])
     console.log(diffStat.out)

--- a/scripts/publish-agent-catalog.ts
+++ b/scripts/publish-agent-catalog.ts
@@ -88,12 +88,13 @@ class PublishRefusal extends Error {}
 async function stagedTreeProblems(cloneDir: string, files: readonly RenderedFile[]): Promise<string[]> {
   const listed = git(cloneDir, ['ls-files', '--cached', '-z'])
   if (!listed.ok) return [`git ls-files failed after staging: ${listed.out}`]
-  const stagedPaths = listed.stdout.split('\0').filter(Boolean).sort()
-  const renderedPaths = files.map((file) => file.path).sort()
+  const stagedPaths = listed.stdout.split('\0').filter(Boolean)
+  const staged = new Set(stagedPaths)
+  const rendered = new Set(files.map((file) => file.path))
   const problems = [
-    ...stagedPaths.filter((p) => !renderedPaths.includes(p)).map((p) => `staged but not rendered: ${p}`),
-    ...renderedPaths.filter((p) => !stagedPaths.includes(p)).map((p) => `rendered but not staged: ${p}`),
-  ]
+    ...stagedPaths.filter((p) => !rendered.has(p)).map((p) => `staged but not rendered: ${p}`),
+    ...[...rendered].filter((p) => !staged.has(p)).map((p) => `rendered but not staged: ${p}`),
+  ].sort()
   if (problems.length > 0) return problems
   for (const file of files) {
     const blob = git(cloneDir, ['show', `:${file.path}`])
@@ -125,9 +126,13 @@ async function main(): Promise<void> {
   // render a second version without editing packages/cli/package.json. Left
   // in a maintainer's environment it would otherwise publish that synthetic
   // version to the real repository under the real plugin name.
-  if (process.env.GUREN_CATALOG_VERSION_OVERRIDE && !process.env.GUREN_AGENT_SKILLS_REMOTE) {
+  // asked of the destination this run actually resolved, not of the env var
+  // that happens to redirect it today: a second way to point somewhere else
+  // would leave a proxy check green while the hole it closes reopened
+  const override = process.env.GUREN_CATALOG_VERSION_OVERRIDE
+  if (override && remotes().some((remote) => remote.includes(PUBLISH_REPO))) {
     fail(
-      `Refusing to publish: GUREN_CATALOG_VERSION_OVERRIDE=${process.env.GUREN_CATALOG_VERSION_OVERRIDE} is set. It is a test hook for a local remote, not a way to publish a version @guren/cli does not have.`,
+      `Refusing to publish: GUREN_CATALOG_VERSION_OVERRIDE=${override} is set. It is a test hook for a local remote, not a way to publish a version @guren/cli does not have.`,
     )
   }
 
@@ -267,7 +272,11 @@ async function main(): Promise<void> {
 
 if (import.meta.main) {
   main().catch((error: unknown) => {
-    console.error(error instanceof Error ? error.message : String(error))
+    // a refusal is a sentence written for the maintainer and its stack says
+    // nothing; anything else is a crash, and reducing that to one line is how
+    // a real bug in this script looks like a considered decision not to
+    // publish
+    console.error(error instanceof PublishRefusal ? error.message : error)
     process.exit(1)
   })
 }

--- a/scripts/publish-agent-catalog.ts
+++ b/scripts/publish-agent-catalog.ts
@@ -18,20 +18,28 @@
  *    published with the one just rendered. Equal → nothing to do, exit 0.
  *    Most releases do not move @guren/cli, and failing here would make a
  *    routine step red for a reason that has nothing to do with the catalog.
- * 3. Delete every tracked file in the clone, copy the rendered tree in, and
- *    commit. Ordinary fast-forward push — never --force. Claude Code keeps a
- *    local clone of a registered marketplace and refreshes it; a rewritten
- *    history risks non-fast-forward failures for every registered user, and
- *    the payload is deterministic anyway.
+ * 3. Delete every tracked file in the clone, write the rendered tree in, and
+ *    check that what git staged is that same tree, path set and bytes — a
+ *    global excludesFile or clean filter sits between the two. Then commit
+ *    and push, appending to history rather than rewriting it: Claude Code
+ *    keeps a local clone of a registered marketplace and refreshes it, so a
+ *    rewritten history risks non-fast-forward failures for every registered
+ *    user, and the payload is deterministic anyway. The push is leased to the
+ *    tip that was cloned, so a remote that moved in the meantime — including
+ *    one somebody deliberately rolled back, which a plain fast-forward would
+ *    restore — is refused rather than overwritten.
  *
  * `--dry-run` does everything except commit and push, and prints the diff.
  * `--yes` skips the confirmation prompt (for the release checklist).
+ * `--skip-validate` publishes without `claude plugin validate`, for a
+ * maintainer who has run it by hand; without it, a validator that cannot run
+ * refuses the publish.
  */
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import process from 'node:process'
-import { auditRenderedFiles, claudePluginValidate, writeCatalog } from './build-agent-catalog'
+import { auditRenderedFiles, claudePluginValidate, writeCatalog, type RenderedFile } from './build-agent-catalog'
 import { repoRoot } from './workspace-packages'
 
 const PUBLISH_REPO = 'gurenjs/agent-skills'
@@ -57,9 +65,45 @@ function git(cwd: string, args: string[]): { ok: boolean; out: string; stdout: s
   }
 }
 
+/**
+ * Throws rather than exits: every refusal here happens inside the `try` that
+ * owns two temp directories, and `process.exit` would skip the `finally` that
+ * removes them. The top-level catch prints the message and exits 1, which is
+ * what a refusal looked like before.
+ */
 function fail(message: string): never {
-  console.error(message)
-  process.exit(1)
+  throw new PublishRefusal(message)
+}
+
+class PublishRefusal extends Error {}
+
+/**
+ * Is what git has staged exactly the tree that was rendered and audited? The
+ * script's whole claim is that those two are the same tree, and between them
+ * sit a maintainer's global git configuration and any hook or filter it
+ * installs — an excludesFile that drops `*.md`, an attributes filter that
+ * rewrites bytes. Compared here, at the point the two can still differ, by
+ * path set and then blob by blob.
+ */
+async function stagedTreeProblems(cloneDir: string, files: readonly RenderedFile[]): Promise<string[]> {
+  const listed = git(cloneDir, ['ls-files', '--cached', '-z'])
+  if (!listed.ok) return [`git ls-files failed after staging: ${listed.out}`]
+  const stagedPaths = listed.stdout.split('\0').filter(Boolean).sort()
+  const renderedPaths = files.map((file) => file.path).sort()
+  const problems = [
+    ...stagedPaths.filter((p) => !renderedPaths.includes(p)).map((p) => `staged but not rendered: ${p}`),
+    ...renderedPaths.filter((p) => !stagedPaths.includes(p)).map((p) => `rendered but not staged: ${p}`),
+  ]
+  if (problems.length > 0) return problems
+  for (const file of files) {
+    const blob = git(cloneDir, ['show', `:${file.path}`])
+    if (!blob.ok) {
+      problems.push(`could not read the staged copy of ${file.path}: ${blob.out}`)
+    } else if (blob.stdout !== file.content) {
+      problems.push(`staged bytes differ from the rendered bytes: ${file.path}`)
+    }
+  }
+  return problems
 }
 
 /** The plugin version a rendered or cloned tree declares, or null if unreadable. */
@@ -77,6 +121,16 @@ async function main(): Promise<void> {
   const dryRun = args.includes('--dry-run')
   const yes = args.includes('--yes')
 
+  // the generator's version override exists so this script's own test can
+  // render a second version without editing packages/cli/package.json. Left
+  // in a maintainer's environment it would otherwise publish that synthetic
+  // version to the real repository under the real plugin name.
+  if (process.env.GUREN_CATALOG_VERSION_OVERRIDE && !process.env.GUREN_AGENT_SKILLS_REMOTE) {
+    fail(
+      `Refusing to publish: GUREN_CATALOG_VERSION_OVERRIDE=${process.env.GUREN_CATALOG_VERSION_OVERRIDE} is set. It is a test hook for a local remote, not a way to publish a version @guren/cli does not have.`,
+    )
+  }
+
   // 1. render + audit the tree we are about to push
   const renderDir = await mkdtemp(join(tmpdir(), 'guren-catalog-publish-'))
   const cloneDir = await mkdtemp(join(tmpdir(), 'guren-catalog-clone-'))
@@ -91,20 +145,21 @@ async function main(): Promise<void> {
     if (problems.length > 0) {
       fail(`Refusing to publish: the rendered payload fails its own audit.\n${problems.map((p) => `  ${p}`).join('\n')}`)
     }
-    const validated = await claudePluginValidate(renderDir)
-    if (validated.kind === 'fail') {
-      fail(`Refusing to publish: claude plugin validate --strict failed.\n${validated.output}`)
-    }
-    if (validated.kind === 'unavailable') {
-      // CI cannot run the validator (no `claude` on the ubuntu runner), so
-      // publish is where it must run — this is the last gate before users.
-      // Refuse rather than warn: an unavailable check is not a green one.
-      // --skip-validate is the explicit override, for a maintainer who has
-      // run it by hand.
-      if (!args.includes('--skip-validate')) {
+    // CI cannot run the validator (no `claude` on the ubuntu runner), so
+    // publish is where it must run — this is the last gate before users.
+    // An unavailable check is not a green one, so it refuses; --skip-validate
+    // is the explicit override, for a maintainer who has run it by hand, and
+    // it skips the run itself rather than only forgiving the outcome.
+    if (args.includes('--skip-validate')) {
+      console.warn('Note: --skip-validate given; publishing without claude plugin validate.')
+    } else {
+      const validated = await claudePluginValidate(renderDir)
+      if (validated.kind === 'fail') {
+        fail(`Refusing to publish: claude plugin validate --strict failed.\n${validated.output}`)
+      }
+      if (validated.kind === 'unavailable') {
         fail(`Refusing to publish: claude plugin validate could not run (${validated.reason}). Install the Claude Code CLI, or pass --skip-validate after validating by hand.`)
       }
-      console.warn(`Note: --skip-validate given; publishing without claude plugin validate (${validated.reason}).`)
     }
     const nextVersion = (await pluginVersionIn(renderDir)) ?? fail('Rendered payload has no plugin version — refusing to publish.')
 
@@ -123,6 +178,10 @@ async function main(): Promise<void> {
       errors.push(clone.out)
     }
     if (!cloned) fail(`Could not clone ${PUBLISH_REPO}:\n${errors.join('\n')}`)
+    // the tip this run is allowed to move: the push leases it, so a remote
+    // that changed under us — including one somebody force-rolled backwards,
+    // which an ordinary fast-forward would happily restore — is refused
+    const baseOid = git(cloneDir, ['rev-parse', 'HEAD']).stdout.trim()
     const publishedVersion = await pluginVersionIn(cloneDir)
     console.log(
       publishedVersion === nextVersion
@@ -147,7 +206,17 @@ async function main(): Promise<void> {
     }
     Bun.spawnSync(['find', cloneDir, '-type', 'd', '-empty', '-not', '-path', '*/.git*', '-delete'])
 
-    git(cloneDir, ['add', '-A'])
+    // --force: a maintainer's global excludesFile applies inside the clone,
+    // and a publish that quietly stages nine of ten rendered files would be
+    // indistinguishable from a correct one
+    const add = git(cloneDir, ['add', '--force', '-A'])
+    if (!add.ok) fail(`git add failed in the clone:\n${add.out}`)
+    const staged = await stagedTreeProblems(cloneDir, files)
+    if (staged.length > 0) {
+      fail(
+        `Refusing to publish: the staged tree is not the tree that was audited.\n${staged.map((p) => `  ${p}`).join('\n')}`,
+      )
+    }
     const status = git(cloneDir, ['status', '--porcelain'])
     if (status.out === '') {
       // the same-version no-op: most releases do not move @guren/cli, and a
@@ -162,8 +231,10 @@ async function main(): Promise<void> {
       // already-installed copies will not pick this up until the next bump.
       console.warn(`Note: version ${nextVersion} is already published but the tree differs; republishing. Installed plugins keyed on this version will not refresh until @guren/cli moves.`)
     }
-    const diffStat = git(cloneDir, ['diff', '--cached', '--stat'])
-    console.log(diffStat.out)
+    // the stat says which files move; the patch is what a maintainer is
+    // actually authorizing, and the next step is a public push
+    console.log(git(cloneDir, ['diff', '--cached', '--stat']).out)
+    console.log(git(cloneDir, ['diff', '--cached', '--no-ext-diff']).out)
 
     if (dryRun) {
       console.log('\n--dry-run: not committing or pushing.')
@@ -182,9 +253,12 @@ async function main(): Promise<void> {
     const message = `Publish @guren/cli ${nextVersion}`
     const commit = git(cloneDir, ['commit', '--quiet', '-m', message])
     if (!commit.ok) fail(`git commit failed:\n${commit.out}`)
-    // ordinary push: fast-forward only, never --force
-    const push = git(cloneDir, ['push', '--quiet', 'origin', PUBLISH_BRANCH])
-    if (!push.ok) fail(`git push failed (a non-fast-forward means someone else pushed; re-run to rebase onto their tip):\n${push.out}`)
+    // leased to the tip that was cloned: any other value means the remote
+    // moved while this ran, and the answer is always to re-run rather than to
+    // overwrite. A plain push would reject a divergent remote but would
+    // happily fast-forward a deliberate rollback back into place.
+    const push = git(cloneDir, ['push', '--quiet', `--force-with-lease=${PUBLISH_BRANCH}:${baseOid}`, 'origin', PUBLISH_BRANCH])
+    if (!push.ok) fail(`git push failed (the remote moved since this run cloned it; re-run to publish onto its new tip):\n${push.out}`)
     console.log(`Published: ${message}`)
   } finally {
     await cleanup()


### PR DESCRIPTION
## Summary

PR C of three for RFC 0011 (stacked on #457 → #456). The publish path and the reminder that guards it.

- **`bun run publish:agent-catalog`** — maintainer-run, not CI. Renders the catalog into a temp dir, runs the *same* derived-fact assertions `audit:agent-catalog` runs on that same tree (provenance: the tree audited is the tree pushed), clones `gurenjs/agent-skills` shallow, compares plugin versions, replaces the tracked files, checks that what git staged is byte-for-byte the tree that was audited, commits `Publish @guren/cli <version>`, and pushes over the maintainer's own git credentials, leased to the tip it cloned. **No token, no secret.** This is the shape Remotion uses to publish `packages/skills/` → `remotion-dev/skills`. A re-run on the same version is a no-op success (most releases don't move `@guren/cli`). `--dry-run` shows the diff and pushes nothing; `--yes` skips the prompt.
- **Nightly drift job** in `published-drift.yml` — a read-only `agent-catalog` job renders from `main` and diffs against what `gurenjs/agent-skills` serves (`--diff-published`). Exit 1 with the file list on drift; exit 2 if the repo can't be cloned (unavailable ≠ green). Same doctrine as the npm drift job beside it: outside `ci.yml`, cannot block a PR, expected-red between a catalog-source change and the release that carries it. This is the one place the design improves on Remotion's, which has no such check.
- **Docs**: "Before you have an app: install the Guren skills from a catalog" in en/ja `cli.md`, a README pointer, and the publish step in `contributing/release-checklist.md`.
- **Refactor**: `check()` now calls a shared `auditRenderedFiles()` so audit and publish run one implementation, not two lists.

## Scope

`scripts/` (new `publish-agent-catalog.ts` + test, `build-agent-catalog.ts` extended), `.github/workflows/published-drift.yml`, `package.json` scripts, `docs/{en,ja}/guides/cli.md`, `README.md`, `contributing/release-checklist.md`. No `packages/*` source change.

## Risk Assessment

- **Push safety**: the commit is appended, never a rewrite. Claude Code keeps a local clone of a registered marketplace and refreshes it; a rewritten history risks non-fast-forward failures for every registered user. The push is leased to the tip the run cloned (`--force-with-lease=main:<oid>`), which is what makes that true: a plain fast-forward would also accept a remote somebody had deliberately rolled back and would restore the history they removed. Any other value at the remote fails with a message to re-run.
- **Refuses to publish** if its own audit fails, if `claude plugin validate --strict` fails, or if the validator cannot run at all — CI has no `claude`, so this is the one place it blocks, and an unavailable check is not a green one. `--skip-validate` is the explicit override for a maintainer who validated by hand. It also refuses if the staged tree is not the tree that was audited (a global `excludesFile` or attributes filter can thin or rewrite it), and refuses the generator's `GUREN_CATALOG_VERSION_OVERRIDE` test hook against the real remote.
- **No changeset for C** — it adds no `packages/*` code. The branch carries B's `@guren/cli` changeset, and C's `build-agent-catalog.ts` edits change no rendered output (`--diff-published` reports identical trees before/after; the audit's changeset gate passes).
- **First publish is not done here.** `gurenjs/agent-skills` still has the placeholder README. Publishing waits for the release that ships this `@guren/cli` — the payload's version is the CLI's, and the CLI on npm today is 2.6.1 without the registry export the skills' audit assumes. Dry-run against the real repo confirms the exact 9-file diff and stops.

## Validation

- `bun run typecheck` (root) — green
- `bun test scripts/` — 116 pass
- `bun run audit:docs`, `audit:core-first` — pass
- `bun run audit:agent-catalog --base origin/main --require-validate` — pass
- **Live dry-run** against the real `gurenjs/agent-skills`: clones, reports "currently unpublished", prints the 9-file diffstat, stops without pushing.
- **`--diff-published`** against the real repo: exit 1 with 8 missing + 1 differing (correct — only the placeholder is there).

**Publish integration test** (against a local bare repo standing in for `gurenjs/agent-skills`, seeded with a placeholder + a stale file): first publish removes the stale file, leaves linear history (2 commits, no rewrite), commit subject `Publish @guren/cli <v>`; re-run on the same version is a no-op success (still 2 commits); `--dry-run` against a rewound remote prints the diff and leaves it at 1 commit. Each guard has a test that fails when the guard is removed: a global `*.md` excludesFile must not thin the published tree, a global clean filter must be caught before the commit, the version override must be refused, and a remote rolled back while the run waits at its confirmation prompt must be refused rather than restored. Drift check pinned 0/1/2: fresh remote → 0; stale remote → 1 with `missing in published: plugins/guren/plugin.json` and `extra in published: STALE.md`; unreachable → 2.

- [x] `bun run build` (unchanged packages)
- [x] `bun run typecheck`
- [x] `bun run test` (scripts guards)

## Checklist

- [x] I followed existing project conventions. (`published-drift.yml` doctrine; exit-2 = could-not-run; scripts tests auto-collected by `test:bun`; the RFC's remotion survey is cited in the script header.)
- [x] I considered backward compatibility and documented intentional breaks. (None.)
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.

## After merge

Once #456 → #457 → this land and a release ships `@guren/cli`, run `bun run publish:agent-catalog` (it's now in the release checklist). Until then the nightly drift job will be red by design, exactly like the npm drift job is between a template change and its release.

