### PR TITLE
fix(cli): report what db:make actually generated

### DIFF
--- a/.changeset/db-make-reports-generated-migration.md
+++ b/.changeset/db-make-reports-generated-migration.md
@@ -1,0 +1,13 @@
+---
+"@guren/cli": minor
+---
+
+Report what `db:make` actually generated instead of an unconditional "Migration generated."
+
+`drizzle-kit generate` exits 0 whether it wrote a migration or printed "No schema changes, nothing to migrate.", and the CLI reported ✔ off that exit code. Paired with the empty-folder warning `db:migrate` now prints, a user whose `db/schema.ts` has no pending changes got a loop with nothing in it explaining why: warning → `db:make` → ✔ → `db:migrate` → the same warning.
+
+`makeMigration()` now diffs the migrations folder around the child process and resolves that folder the same three ways it decides drizzle-kit's arguments — an explicit `--out`, the `out` the drizzle config declares, or the default. `db:make` names the migration it generated, and warns `No migration generated in db/migrations — db/schema.ts has no changes since the last one.` when there was none, pointing at the schema rather than back at `db:make`. The command still exits 0.
+
+The folder is reported only when it was positively resolved: a drizzle config that declares no `out`, or one that throws on import, leaves the previous message rather than naming a folder drizzle-kit may not have written to.
+
+`makeMigration()` now resolves to a `MakeMigrationResult` rather than `void`, and that type is exported alongside `MakeMigrationOptions` so a caller can name what it receives.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -293,14 +293,19 @@ function reportDryRun(action: string, message: string, json: boolean, extra?: Re
   }
 }
 
-/** The migrations folder as the user would type it: cwd-relative when it is under cwd. */
-function describeMigrationsFolder(folder: string | undefined): string {
-  if (!folder) {
-    return 'the migrations folder'
-  }
+/**
+ * A path as the user would type it: cwd-relative when it is under cwd, and
+ * verbatim otherwise. `relative()` resolves a relative input against cwd on its
+ * own, so a config's './db/schema.ts' and an absolute folder both land here.
+ */
+function describePath(path: string): string {
+  const relativePath = relative(process.cwd(), path)
+  return relativePath === '' || relativePath.startsWith('..') ? path : relativePath
+}
 
-  const relativePath = relative(process.cwd(), folder)
-  return relativePath === '' || relativePath.startsWith('..') ? folder : relativePath
+/** The migrations folder as the user would type it, or a stand-in when unknown. */
+function describeMigrationsFolder(folder: string | undefined): string {
+  return folder ? describePath(folder) : 'the migrations folder'
 }
 
 function reportSuccess(action: string, message: string, json: boolean, extra?: Record<string, unknown>): void {
@@ -711,12 +716,31 @@ const makeMigrationCommand = defineCommand({
     },
   },
   async run({ args }) {
-    await makeMigration({
+    const result = await makeMigration({
       name: args.name,
       schema: args.schema,
       out: args.out,
     })
-    consola.success('Migration generated.')
+
+    // drizzle-kit exits 0 for "No schema changes, nothing to migrate." too, so
+    // the ✔ below is reported off what it wrote, not off the exit code. An
+    // unresolvable out dir leaves `migrationsFolder` unset and keeps the old
+    // message rather than describing a folder we did not watch.
+    if (result.migrationsFolder && result.created.length === 0) {
+      // The config states its paths as './db/schema.ts'; render it the same way
+      // as the folder above so one message does not mix two spellings.
+      const schema = result.schemaPath ? describePath(result.schemaPath) : 'your schema'
+      consola.warn(
+        `No migration generated in ${describeMigrationsFolder(result.migrationsFolder)} — ` +
+          `${schema} has no changes since the last one.`,
+      )
+      consola.info(`Edit \`${schema}\` to change your tables, then re-run \`bun run db:make\`.`)
+      return
+    }
+
+    consola.success(
+      result.created.length > 0 ? `Migration generated: ${result.created.join(', ')}.` : 'Migration generated.',
+    )
   },
 })
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 export { makeController } from './make-controller'
 export { makeMigration } from './make-migration'
+export type { MakeMigrationOptions, MakeMigrationResult } from './make-migration'
 export { makeModel } from './make-model'
 export { makeView } from './make-view'
 export { makeRoute } from './make-route'

--- a/packages/cli/src/make-migration.ts
+++ b/packages/cli/src/make-migration.ts
@@ -1,5 +1,7 @@
-import { access } from 'node:fs/promises'
+import { existsSync, readdirSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { findFirstExisting } from './discovery'
 import { runCommand, slugifyProse } from './utils'
 
 const DEFAULT_SCHEMA = 'db/schema.ts'
@@ -17,31 +19,94 @@ export interface MakeMigrationOptions {
   out?: string
 }
 
+/**
+ * What `drizzle-kit generate` actually produced. The command exits 0 whether it
+ * wrote a migration or printed "No schema changes, nothing to migrate.", so a ✔
+ * off the exit code alone reports a migration that does not exist — and sends
+ * the user back to `db:migrate`, which then repeats its own empty-folder
+ * warning with nothing in between explaining why.
+ */
+export interface MakeMigrationResult {
+  /**
+   * The folder drizzle-kit wrote to, absolute. **Present only when it was
+   * resolved from positive evidence** — an explicit `--out`, or the `out` the
+   * drizzle config declares. Absent means `created` observed nothing and says
+   * nothing: naming a folder drizzle-kit may not have written to is worse than
+   * staying quiet, so the caller falls back to reporting the exit code.
+   */
+  migrationsFolder?: string
+  /**
+   * Migration folders that appeared during this run, by name. Empty alongside a
+   * `migrationsFolder` is the "nothing to migrate" case, positively observed.
+   */
+  created: string[]
+  /** The schema file drizzle-kit read, when known, for the caller's message. */
+  schemaPath?: string
+}
+
+interface DrizzleConfig {
+  out?: string
+  schema?: string
+}
+
 function toSlug(value: string): string {
   return slugifyProse(value, '_', 'migration')
 }
 
 async function resolveDrizzleConfig(): Promise<string | undefined> {
-  const cwd = process.cwd()
-
-  for (const candidate of DRIZZLE_CONFIG_CANDIDATES) {
-    const absolute = resolve(cwd, candidate)
-    try {
-      await access(absolute)
-      return candidate
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        continue
-      }
-
-      throw error
-    }
-  }
-
-  return undefined
+  return (await findFirstExisting(process.cwd(), DRIZZLE_CONFIG_CANDIDATES)) ?? undefined
 }
 
-export async function makeMigration(options: MakeMigrationOptions = {}): Promise<void> {
+/**
+ * One path from the config, or nothing when it names no single file. drizzle-kit
+ * also accepts globs and arrays for `schema`, and a message telling the user to
+ * edit a glob names a file that does not exist.
+ */
+function readPath(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' && !value.includes('*') ? value : undefined
+}
+
+/**
+ * Reads the paths out of the drizzle config, which is the authority on them
+ * whenever we hand drizzle-kit `--config` instead of explicit flags.
+ *
+ * Importing it runs the file, so every failure — a config that throws on a
+ * missing env var, a `drizzle-kit` that will not resolve — reports "unknown"
+ * rather than propagating: this is a reporting nicety layered over a command
+ * that already did its job. `schema` is read only when it is a single path;
+ * drizzle-kit also accepts globs and arrays, which name no one file to point a
+ * user at.
+ */
+async function readDrizzleConfig(configPath: string): Promise<DrizzleConfig> {
+  try {
+    const module = await import(pathToFileURL(resolve(process.cwd(), configPath)).href)
+    // drizzle-kit's loader adopts a promise-exporting config, so awaiting is
+    // what keeps this reader looking at the same object the child process does.
+    const config = ((await module.default) ?? module) as DrizzleConfig
+
+    return { out: readPath(config?.out), schema: readPath(config?.schema) }
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * drizzle-kit migration folder names in `folder` — one directory each, holding
+ * a migration.sql. `@guren/orm` reads the same shape for the migrator, but
+ * publishes only the summary types, so the CLI reads it here rather than
+ * growing the ORM's public surface for one caller.
+ */
+function listMigrationNames(folder: string): string[] {
+  if (!existsSync(folder)) {
+    return []
+  }
+
+  return readdirSync(folder, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && existsSync(resolve(folder, entry.name, 'migration.sql')))
+    .map((entry) => entry.name)
+}
+
+export async function makeMigration(options: MakeMigrationOptions = {}): Promise<MakeMigrationResult> {
   const name = options.name?.trim() ? toSlug(options.name) : undefined
   const configPath = await resolveDrizzleConfig()
   const hasOverrides = options.schema != null || options.out != null
@@ -68,6 +133,25 @@ export async function makeMigration(options: MakeMigrationOptions = {}): Promise
     args.push('--config', configPath)
   }
 
+  // Only the config branch leaves the paths unstated on the command line. Note
+  // an app passing just `--schema` takes the DEFAULT_OUTPUT branch above, so
+  // reading the config for `out` there would describe a folder drizzle-kit is
+  // not writing to.
+  const configured = useConfig && configPath ? await readDrizzleConfig(configPath) : {}
+  const outDir = out ?? configured.out
+  const migrationsFolder = outDir ? resolve(process.cwd(), outDir) : undefined
+  const before = migrationsFolder ? new Set(listMigrationNames(migrationsFolder)) : new Set<string>()
+
   const bunExecutable = process.execPath || 'bun'
   await runCommand(bunExecutable, args)
+
+  if (!migrationsFolder) {
+    return { created: [] }
+  }
+
+  return {
+    migrationsFolder,
+    created: listMigrationNames(migrationsFolder).filter((entry) => !before.has(entry)),
+    schemaPath: schema ?? configured.schema,
+  }
 }

--- a/packages/cli/tests/make-migration.test.ts
+++ b/packages/cli/tests/make-migration.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it, mock } from 'bun:test'
-import { writeFile } from 'node:fs/promises'
+import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { createTempWorkspace } from './helpers'
 import * as realUtils from '../src/utils'
 
 const spawnCalls: Array<{ command: string; args: string[] }> = []
+
+/**
+ * What the faked `drizzle-kit generate` writes for the next call, or undefined
+ * for the run that finds no schema changes. Without this the mock would create
+ * nothing on every path, so a test asserting "nothing was generated" would pass
+ * against a `makeMigration` that never looks at the folder at all.
+ */
+let nextGeneratedMigration: { folder: string; name: string } | undefined
 
 // Mock `./utils`'s `runCommand` rather than `node:child_process` directly:
 // `mock.module()` replaces a module in the process-wide registry for the
@@ -18,10 +26,22 @@ await mock.module('../src/utils', () => ({
   ...realUtils,
   runCommand: async (command: string, args: string[]) => {
     spawnCalls.push({ command, args })
+
+    if (nextGeneratedMigration) {
+      const { folder, name } = nextGeneratedMigration
+      nextGeneratedMigration = undefined
+      await mkdir(join(folder, name), { recursive: true })
+      await writeFile(join(folder, name, 'migration.sql'), 'CREATE TABLE users ();', 'utf8')
+    }
   },
 }))
 
 const { makeMigration } = await import('../src/make-migration')
+
+/** Queues one generated migration for the next `makeMigration()` call. */
+function generateOnNextRun(folder: string, name: string): void {
+  nextGeneratedMigration = { folder, name }
+}
 
 describe('makeMigration', () => {
   it('uses the drizzle config when available', async () => {
@@ -56,6 +76,184 @@ describe('makeMigration', () => {
       expect(call?.args).toContain('--out')
       expect(call?.args).toContain('db/migrations')
       expect(call?.args).toContain('--name=add_users')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('names the migration drizzle-kit generated', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-migration-created-')
+    try {
+      const root = process.cwd()
+      generateOnNextRun(join(root, 'db/migrations'), '0000_add_users')
+
+      const result = await makeMigration({ out: 'db/migrations' })
+
+      expect(result.created).toEqual(['0000_add_users'])
+      expect(result.migrationsFolder).toBe(join(root, 'db/migrations'))
+      spawnCalls.pop()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reports no migration when drizzle-kit found no schema changes', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-migration-unchanged-')
+    try {
+      // drizzle-kit prints "No schema changes, nothing to migrate." and exits 0,
+      // so the folder is the only evidence that nothing was written.
+      const result = await makeMigration({ out: 'db/migrations' })
+
+      expect(result.created).toEqual([])
+      // Set, so the caller can tell "watched, nothing appeared" from "not watched".
+      expect(result.migrationsFolder).toBe(join(process.cwd(), 'db/migrations'))
+      spawnCalls.pop()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('ignores migrations that were already there', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-migration-existing-')
+    try {
+      const folder = join(workspace.dir, 'db/migrations')
+      await mkdir(join(folder, '0000_create_users'), { recursive: true })
+      await writeFile(join(folder, '0000_create_users', 'migration.sql'), '', 'utf8')
+      generateOnNextRun(folder, '0001_add_posts')
+
+      const result = await makeMigration({ out: 'db/migrations' })
+
+      expect(result.created).toEqual(['0001_add_posts'])
+      spawnCalls.pop()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('resolves the output folder from the drizzle config', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-migration-config-out-')
+    try {
+      await writeFile(
+        join(workspace.dir, 'drizzle.config.ts'),
+        "export default { schema: './db/schema.ts', out: './custom/migrations' }",
+        'utf8',
+      )
+      generateOnNextRun(join(process.cwd(), 'custom/migrations'), '0000_from_config')
+
+      const result = await makeMigration()
+
+      expect(result.migrationsFolder).toBe(join(process.cwd(), 'custom/migrations'))
+      expect(result.created).toEqual(['0000_from_config'])
+      expect(result.schemaPath).toBe('./db/schema.ts')
+      spawnCalls.pop()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('watches the default folder when only --schema is overridden', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-migration-schema-only-')
+    try {
+      // A --schema override alone stops the config being passed to drizzle-kit,
+      // so `out` falls to the default and the config's own out is not what gets
+      // written to.
+      await writeFile(
+        join(workspace.dir, 'drizzle.config.ts'),
+        "export default { out: './custom/migrations' }",
+        'utf8',
+      )
+      generateOnNextRun(join(process.cwd(), 'db/migrations'), '0000_add_users')
+
+      const result = await makeMigration({ schema: 'db/other-schema.ts' })
+
+      expect(result.migrationsFolder).toBe(join(process.cwd(), 'db/migrations'))
+      expect(result.created).toEqual(['0000_add_users'])
+      expect(result.schemaPath).toBe('db/other-schema.ts')
+      const call = spawnCalls.pop()
+      expect(call?.args?.includes('--config')).toBe(false)
+      expect(call?.args).toContain('db/migrations')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reports nothing when the config declares no out directory', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-migration-no-out-')
+    try {
+      // drizzle-kit falls back to its own default here, which this reader has no
+      // way to know. Naming a folder we did not watch would be worse than the
+      // plain success message, so the folder stays unset.
+      await writeFile(join(workspace.dir, 'drizzle.config.ts'), "export default { dialect: 'sqlite' }", 'utf8')
+
+      const result = await makeMigration()
+
+      expect(result.migrationsFolder).toBeUndefined()
+      expect(result.created).toEqual([])
+      spawnCalls.pop()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('does not fail db:make when the config cannot be read', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-migration-bad-config-')
+    try {
+      // Reading the config is a reporting nicety over a command that already
+      // ran, so a config this reader chokes on must not turn into a thrown
+      // `db:make`. drizzle-kit loads configs with its own bundler, so the two
+      // do not always agree on what is loadable — this pins that the
+      // disagreement costs a message, never the command.
+      await writeFile(
+        join(workspace.dir, 'drizzle.config.ts'),
+        "import 'a-package-that-is-not-installed'\nexport default { out: './db/migrations' }",
+        'utf8',
+      )
+
+      const result = await makeMigration()
+
+      expect(result.migrationsFolder).toBeUndefined()
+      expect(result.created).toEqual([])
+      spawnCalls.pop()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reads a promise-exporting config, which drizzle-kit accepts', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-migration-promise-config-')
+    try {
+      await writeFile(
+        join(workspace.dir, 'drizzle.config.ts'),
+        "export default Promise.resolve({ out: './custom/migrations' })",
+        'utf8',
+      )
+      generateOnNextRun(join(process.cwd(), 'custom/migrations'), '0000_from_promise')
+
+      const result = await makeMigration()
+
+      expect(result.migrationsFolder).toBe(join(process.cwd(), 'custom/migrations'))
+      expect(result.created).toEqual(['0000_from_promise'])
+      spawnCalls.pop()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('does not name a glob schema as the file to edit', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-migration-glob-schema-')
+    try {
+      await writeFile(
+        join(workspace.dir, 'drizzle.config.ts'),
+        "export default { schema: './modules/*/db/schema.ts', out: './db/migrations' }",
+        'utf8',
+      )
+
+      const result = await makeMigration()
+
+      // The folder is still watched; only the schema is unnameable.
+      expect(result.migrationsFolder).toBe(join(process.cwd(), 'db/migrations'))
+      expect(result.schemaPath).toBeUndefined()
+      spawnCalls.pop()
     } finally {
       await workspace.cleanup()
     }


### PR DESCRIPTION
## Summary

`bunx guren db:make` reported `✔ Migration generated.` even when drizzle-kit generated nothing.

`drizzle-kit generate` exits 0 whether it wrote a migration or printed `No schema changes, nothing to migrate.`, and `makeMigration()` returned `void`, so the command reported success off the exit code alone.

Paired with #460, which just changed `db:migrate` to warn on an empty migrations folder and point at `db:make`, a user whose `db/schema.ts` has no pending changes was left in a loop with nothing in it naming the cause:

```
db:migrate → "No migrations found in db/migrations — nothing was applied."
db:make    → "✔ Migration generated."
db:migrate → the same warning, forever
```

`makeMigration()` now diffs the migrations folder around the child process and resolves that folder the same three ways it decides drizzle-kit's arguments: an explicit `--out`, the `out` the drizzle config declares, or the default. A lone `--schema` override stops the config being passed at all, so `out` falls to the default there rather than to what the config says.

After (verified against `examples/blog`):

```
No schema changes, nothing to migrate 😴
 WARN  No migration generated in db/migrations — db/schema.ts has no changes since the last one.
ℹ Edit db/schema.ts to change your tables, then re-run bun run db:make.
```

and on the positive path, `✔ Migration generated: 20260819113244_unusual_triton.`

The warning borrows the `db:migrate` message's shape but deliberately not its follow-up: pointing back at `bun run db:make` is what closes the loop this PR exists to open, so it points at the schema instead.

## Scope

`cli` — `packages/cli/src/make-migration.ts`, `packages/cli/src/bin.ts`, `packages/cli/src/index.ts`, tests, changeset.

No `packages/orm` changes. `inspectMigrationsFolder()` / `listLocalMigrations()` are not exported from `@guren/orm`'s barrel (only the `MigrationRunSummary` / `MigrationStatusEntry` types are), so the CLI reads the folder locally rather than growing the ORM's public surface for one caller — the same way `db-status.ts` already declares the summary shape locally.

## Risk Assessment

**The folder is reported only on positive evidence.** A drizzle config declaring no `out`, or one this reader chokes on, leaves `migrationsFolder` unset and keeps the previous `✔ Migration generated.` — naming a folder drizzle-kit may not have written to is worse than saying nothing. Reading the config is a reporting nicety over a command that already did its job, so every failure of it reports "unknown" instead of propagating.

**Why the out dir is resolved twice.** `makeMigration()` decides drizzle-kit's arguments, then separately resolves which folder to watch. That is forced by drizzle-kit's CLI, verified against the installed `drizzle-kit` (`drizzle-orm` pin `1.0.0-rc.4`):

```
$ node node_modules/drizzle-kit/bin.cjs generate --config drizzle.config.ts --out ./b
 Invalid input  You can't use both --config and other cli options for generate command
```

Passing `--out` alongside `--config` to unify the two derivations is rejected by the tool. Scraping the path out of drizzle-kit's stdout was the alternative and is worse: `runCommand` uses `stdio: 'inherit'`, and it would trade a documented config schema for undocumented console text.

**Behavior/compat:** `makeMigration()` now resolves to `MakeMigrationResult` rather than `void` (additive for callers that ignore it); `MakeMigrationOptions`/`MakeMigrationResult` are exported so a caller can name what it receives. `db:make` still exits 0 in every case. `describeMigrationsFolder` was split into a general `describePath`, and the folder rendering `db:migrate`/`db:reset`/`db:fresh` already ship is byte-identical (`relative()` already resolves a relative input against cwd, so no extra `resolve()` is involved).

**Known gap, not fixed here:** `DRIZZLE_CONFIG_CANDIDATES` omits `drizzle.config.json`, which drizzle-kit supports as a first-class format (its own discovery order is `.ts` → `.js` → `.json`). An app whose only config is `drizzle.config.json` gets explicit `--schema`/`--out` passed instead, silently overriding what it declares. Pre-existing in argument construction and separable, so it is left for its own change.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` — 4610 pass / 0 fail, plus 108 + 42 + 112 example/web tests, exit 0

Both branches exercised end-to-end against `examples/blog`, not just in tests.

The new tests are mutation-verified rather than assumed: reverting the folder diff fails 5 of them, hardcoding `created: []` fails 4, dropping the `await` on the config's default export fails the promise-config test, and dropping the glob guard fails the glob test. The existing `runCommand` mock creates nothing, so a "no migration generated" test would otherwise have passed vacuously — the mock can now write a migration on demand.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation — no user-facing docs describe `db:make`'s output; the changeset carries the behavior change.
