### PR TITLE
fix(cli): find a drizzle.config.json instead of overriding it

### DIFF
--- a/.changeset/db-make-finds-json-drizzle-config.md
+++ b/.changeset/db-make-finds-json-drizzle-config.md
@@ -1,0 +1,24 @@
+---
+"@guren/cli": patch
+---
+
+Point `db:make` at a `drizzle.config.json` instead of overriding it with defaults.
+
+`makeMigration()` probed only `drizzle.config.{ts,mts,js,mjs}`, so an app whose
+only drizzle config is the JSON one drizzle-kit names as its own default fell to
+the no-config branch and was handed explicit `--schema db/schema.ts --out
+db/migrations`. drizzle-kit then reported `dialect: undefined` — blaming the user
+for a value they had declared, in a file nothing had read. `drizzle.config.json`
+is now probed last, after the loadable formats, matching drizzle-kit's own
+`.ts` > `.js` > `.json` preference.
+
+This does not make JSON configs work: `bun x drizzle-kit` runs drizzle-kit
+through its `#!/usr/bin/env node` shebang, and under Node its `import()` of the
+config needs a `type: json` import attribute it does not pass, so such an app now
+gets drizzle-kit's own error naming the config file it could not load. That is
+the honest failure — the previous one described a different problem entirely and
+pointed away from the config that caused it. Nothing regresses either: on the
+pinned drizzle-kit, the flags branch those apps leave cannot succeed for anyone,
+since a run passing `--schema`/`--out` without `--dialect` is rejected. Apps with
+a `.ts`, `.mts`, `.js` or `.mjs` config, and any run passing `--schema`/`--out`
+explicitly, are unaffected.

--- a/docs/ja/guides/database.md
+++ b/docs/ja/guides/database.md
@@ -153,7 +153,7 @@ Guren CLI は drizzle-kit をラップしており、Drizzle スキーマから 
 bunx guren make:migration --name add_posts_table
 ```
 
-コマンドはプロジェクトルートの `drizzle.config.ts`（`.mts/.js/.mjs` も可）を参照し、スキーマパス・出力ディレクトリ・DB 方言のデフォルト値を取得します。必要に応じてスキーマや出力先を上書きできます。
+コマンドはプロジェクトルートの `drizzle.config.ts`（`.mts/.js/.mjs` も可）を参照し、スキーマパス・出力ディレクトリ・DB 方言のデフォルト値を取得します。`drizzle.config.json` も検出しますが、drizzle-kit 自身が Node 上で JSON 設定を読み込めないため、drizzle-kit の読み込みエラーになります。JSON 設定を使っている場合は `.ts` など読み込み可能な形式に移してください。必要に応じてスキーマや出力先を上書きできます。
 
 ```bash
 bunx guren make:migration --schema ./custom/schema.ts --out ./custom/migrations

--- a/packages/cli/src/make-migration.ts
+++ b/packages/cli/src/make-migration.ts
@@ -4,11 +4,33 @@ import { runCommand, slugifyProse } from './utils'
 
 const DEFAULT_SCHEMA = 'db/schema.ts'
 const DEFAULT_OUTPUT = 'db/migrations'
+/**
+ * The config filenames we probe for, ordered consistently with drizzle-kit.
+ *
+ * Not a copy of drizzle-kit's own default discovery, which probes only `.ts`,
+ * `.js` and `.json`: we always hand the file over as an explicit `--config`, and
+ * its loader accepts `.mts`/`.mjs` that way even though it never looks for them
+ * itself. Finding nothing is not a no-op — `makeMigration()` then passes
+ * `--schema`/`--out` defaults that ignore whatever the app's config declares.
+ *
+ * `drizzle.config.json` is probed even though drizzle-kit cannot currently load
+ * one: `bun x drizzle-kit` runs it through its `#!/usr/bin/env node` shebang, and
+ * under Node its `import()` of the config needs a `type: json` import attribute
+ * it does not pass. Pointing it at the app's real config still beats overriding
+ * with defaults — the user gets an error naming the file they wrote, instead of
+ * drizzle-kit reporting a missing `dialect` they had in fact declared. Ordering
+ * matters for the same reason drizzle-kit's does: a loadable config alongside a
+ * `.json` must win.
+ *
+ * Verified against drizzle-kit 1.0.0-rc.4 (the version the scaffold templates
+ * pin) via `bun x drizzle-kit generate --config <file>`.
+ */
 const DRIZZLE_CONFIG_CANDIDATES = [
   'drizzle.config.ts',
   'drizzle.config.mts',
   'drizzle.config.js',
   'drizzle.config.mjs',
+  'drizzle.config.json',
 ]
 
 export interface MakeMigrationOptions {

--- a/packages/cli/tests/make-migration.test.ts
+++ b/packages/cli/tests/make-migration.test.ts
@@ -41,6 +41,43 @@ describe('makeMigration', () => {
     }
   })
 
+  it('uses a drizzle.config.json, the format drizzle-kit names as its own default', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-migration-json-')
+    try {
+      await writeFile(
+        join(workspace.dir, 'drizzle.config.json'),
+        '{ "dialect": "postgresql", "schema": "db/schema.ts", "out": "db/migrations" }',
+        'utf8',
+      )
+
+      await makeMigration()
+
+      const call = spawnCalls.pop()
+      expect(call?.args).toContain('--config')
+      expect(call?.args).toContain('drizzle.config.json')
+      expect(call?.args?.includes('--schema')).toBe(false)
+      expect(call?.args?.includes('--out')).toBe(false)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('prefers a loadable config over the json drizzle-kit cannot import', async () => {
+    const workspace = await createTempWorkspace('guren-cli-make-migration-order-')
+    try {
+      await writeFile(join(workspace.dir, 'drizzle.config.js'), 'export default {}', 'utf8')
+      await writeFile(join(workspace.dir, 'drizzle.config.json'), '{}', 'utf8')
+
+      await makeMigration()
+
+      const call = spawnCalls.pop()
+      expect(call?.args).toContain('drizzle.config.js')
+      expect(call?.args?.includes('drizzle.config.json')).toBe(false)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('applies overrides and slugifies names', async () => {
     const workspace = await createTempWorkspace('guren-cli-make-migration-override-')
     try {


### PR DESCRIPTION
## Summary

`makeMigration()` probed only `drizzle.config.{ts,mts,js,mjs}`, so an app whose only drizzle config is the JSON one drizzle-kit names as its own default fell to the no-config branch and was handed explicit `--schema db/schema.ts --out db/migrations`. drizzle-kit then reported `dialect: undefined` — blaming the user for a value they had declared, in a file nothing had read.

`drizzle.config.json` is now probed last, after the loadable formats, matching drizzle-kit's own `.ts` > `.js` > `.json` preference.

**This does not make JSON configs work, and the change is not sold as if it does.** `bun x drizzle-kit` runs drizzle-kit through its `#!/usr/bin/env node` shebang, and under Node its `import()` of the config needs a `type: json` import attribute it does not pass. The value here is an honest error: such an app now gets drizzle-kit's own message naming the config it could not load, instead of one describing a different problem and pointing away from the cause.

## Scope

`cli`, `docs`

- `packages/cli/src/make-migration.ts` — one candidate added, plus a comment recording the measurements below
- `packages/cli/tests/make-migration.test.ts` — two tests
- `docs/ja/guides/database.md` — the one passage that enumerated the discoverable formats
- changeset (`@guren/cli` patch)

## Risk Assessment

No regression path. Every affected population was walked:

| App | Before | After |
|---|---|---|
| only `.json` | error (`dialect: undefined`) | error (`needs an import attribute`) |
| `.ts`/`.mts`/`.js`/`.mjs` present | config used | unchanged, loadable formats still win |
| `.json` + explicit `--schema`/`--out` | `hasOverrides` short-circuits the config | unchanged |

The branch JSON-config apps leave cannot succeed for *anyone* on the pinned drizzle-kit, which rejects a run passing `--schema`/`--out` without `--dialect`. So the only behavior change is one error message becoming the accurate one.

### Measurements

The premise was checked rather than assumed. Against drizzle-kit **1.0.0-rc.4** (what `packages/create-app/templates/*` pin), via `bun x drizzle-kit generate --config <file>` — the exact invocation `makeMigration()` spawns:

| config | result |
|---|---|
| `.ts` / `.mts` / `.js` / `.mjs` | migration generated |
| `.json` | fails: `needs an import attribute of "type: json"` |

Cause isolated by running the same bundle under both runtimes: `node bin.cjs` fails, `bun bin.cjs` succeeds. The `drizzle.config.json` string in drizzle-kit's bundle only builds its *default filename* expression (`… ? "drizzle.config.ts" : defaultJsConfigExists ? "drizzle.config.js" : "drizzle.config.json"`); it is not evidence the loader can read one.

This also confirms the existing `.mts`/`.mjs` entries are correct: drizzle-kit's own default discovery never probes them, but its loader accepts them via an explicit `--config`, which is always how Guren passes the file.

### Follow-up (not in this PR)

The same probing surfaced a wider latent defect, left untouched here deliberately: `makeMigration()` never passes `--dialect`, so both the no-config fallback *and* the documented `--schema`/`--out` override flow fail on the pinned drizzle-kit even for an app with a valid `drizzle.config.ts`. Filed separately.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck` — clean (needs `guren codegen` in a fresh worktree first)
- [x] `bun run test` — exit 0; `4603 pass / 0 fail` (framework) plus 29/15/16 example+web files
- [x] `bun run audit:docs` — passed
- [x] `bunx guren check --docs` — 0 failures

Both new tests were confirmed able to fail: the `.json` test is red on the unmodified array (`Received: [..., "--schema", "db/schema.ts", "--out", "db/migrations"]`), and the ordering test was mutation-checked by moving `.json` to the front of the list.

An end-to-end run of the real `makeMigration()` against a JSON-config app confirms it now spawns `--config drizzle.config.json` and surfaces drizzle-kit's error, rather than writing to the overridden default.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.