### PR TITLE
fix(cli): accept `guren context --entity <Model>`, which citty dropped

### DIFF
--- a/.changeset/context-accepts-entity-flag.md
+++ b/.changeset/context-accepts-entity-flag.md
@@ -1,0 +1,13 @@
+---
+"@guren/cli": patch
+---
+
+Accept `guren context --entity <Model>`, which citty silently dropped
+
+`context` declared its `entity` argument `type: 'positional'`. When a value is passed to a positional as a flag, citty 0.1.6 discards it entirely — it reaches neither `args.entity` nor the unconsumed positionals in `args._`, and no unknown-flag error is raised — so `guren context --entity User` ran as if no entity had been named. This command's no-entity branch is the whole-project map, so it printed that and exited 0: the wrong output, with nothing signalling the argument had been ignored.
+
+The flag spelling is one the docs teach rather than an invented one. `--entity <Model>` is a real string flag on both `make:adr` and `docs:graph`, documented in the CLI guides in English and Japanese and in the agent harness template, so `context --entity User` is a natural thing to write after reading them.
+
+`entity` is now `type: 'string'` and falls back to `args._[0]`, which accepts `guren context User`, `--entity User`, and `--entity=User` alike; a string arg still leaves an unconsumed positional in `_`, so the documented positional form is unchanged, including alongside `--module`. `guren context --help` now lists `--entity=<User>` under OPTIONS rather than as an `[ENTITY]` argument, and its description names the positional spelling.
+
+`queue:retry` has the same optional-positional declaration and is deliberately left as it is: its `id`/`--all` guard reports the missing id and exits 1 when the value is dropped, so the wrong spelling is already refused loudly rather than acting on the wrong input.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1311,6 +1311,11 @@ const queueRetryCommand = defineCommand({
     description: 'Retry a failed job or all failed jobs.',
   },
   args: {
+    // Left `positional` on purpose, unlike `context`'s entity arg. citty drops
+    // a value passed to a positional as a flag, so `--id 42` reads as no id at
+    // all — but here that lands in the `else` below, which reports the missing
+    // id and exits 1. The wrong spelling is already loud, so converting it to
+    // `string` would trade the `[ID]` in `--help` for nothing.
     id: {
       type: 'positional',
       required: false,
@@ -1937,10 +1942,19 @@ const contextCommand = defineCommand({
     description: 'Generate a project context map for AI agents. Pass an entity name (e.g. `guren context User`) for an entity-centric bundle.',
   },
   args: {
+    // Declared `string`, not `positional`, so both spellings reach the entity
+    // path. citty drops a value passed as a flag to a positional arg — it lands
+    // in neither `args.entity` nor `args._` and raises no unknown-flag error —
+    // and this command's no-entity branch is the whole-project map, so
+    // `guren context --entity User` would have printed that and exited 0. The
+    // flag spelling is one the docs actively teach: `--entity <Model>` is real
+    // on `make:adr` and `docs:graph`. A `string` arg still leaves an unconsumed
+    // positional in `_`, so `guren context User` is unchanged.
     entity: {
-      type: 'positional',
-      required: false,
-      description: 'Model class name for an entity-centric context bundle (case-insensitive).',
+      type: 'string',
+      valueHint: 'User',
+      description:
+        'Model class name for an entity-centric context bundle (case-insensitive). Also accepted positionally: `guren context User`.',
     },
     json: {
       type: 'boolean',
@@ -1960,8 +1974,10 @@ const contextCommand = defineCommand({
     },
   },
   async run({ args }) {
-    if (args.entity) {
-      await displayEntityContext(args.entity, {
+    const entity = args.entity ?? args._[0]
+
+    if (entity) {
+      await displayEntityContext(entity, {
         cwd: args.app,
         json: Boolean(args.json),
         routesFile: args.routes,

--- a/packages/cli/tests/context-entity-arg.test.ts
+++ b/packages/cli/tests/context-entity-arg.test.ts
@@ -1,0 +1,152 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { describe, expect, it } from 'bun:test'
+import { CLI_BIN_PATH, SERVER_DIST_ENTRY, assertWorkspaceBuilt, createTempWorkspace } from './helpers'
+
+/**
+ * Spawn the real bin: `bin.ts` exports nothing and builds its commands at
+ * module scope, so the citty declaration under test — whether `entity` is a
+ * positional or a string — is only observable through a subprocess.
+ *
+ * Exit code alone cannot tell the two apart here: `context --entity User`
+ * exited 0 before this was fixed too, just having printed the whole-project
+ * map. The assertions read stdout for that reason.
+ */
+async function runBin(args: string[], cwd: string): Promise<{ exitCode: number; stdout: string }> {
+  assertWorkspaceBuilt([SERVER_DIST_ENTRY])
+
+  const proc = Bun.spawn(['bun', CLI_BIN_PATH, ...args], {
+    cwd,
+    stdout: 'pipe',
+    stderr: 'ignore',
+  })
+  const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+  return { exitCode, stdout }
+}
+
+/** The smallest workspace `guren context` resolves one model from. */
+async function writeModelFixture(dir: string): Promise<void> {
+  await mkdir(join(dir, 'app/Models'), { recursive: true })
+  await mkdir(join(dir, 'db'), { recursive: true })
+  await writeFile(join(dir, 'package.json'), '{}', 'utf8')
+  await writeFile(
+    join(dir, 'db/schema.ts'),
+    `import { pgTable, serial, text } from 'drizzle-orm/pg-core'
+
+export const users = pgTable('users', {
+  id: serial('id'),
+  email: text('email'),
+})
+`,
+    'utf8',
+  )
+  await writeFile(
+    join(dir, 'app/Models/User.ts'),
+    `import { defineModel } from '@guren/orm'
+import { users } from '../../db/schema.js'
+
+export class User extends defineModel(users) {}
+`,
+    'utf8',
+  )
+}
+
+describe('context entity argument', () => {
+  it('resolves the entity from a positional argument', async () => {
+    const workspace = await createTempWorkspace('guren-cli-context-positional-')
+    try {
+      await writeModelFixture(workspace.dir)
+
+      const { exitCode, stdout } = await runBin(['context', 'User'], workspace.dir)
+
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('# User')
+      expect(stdout).toContain('## Model — app/Models/User.ts')
+      expect(stdout).not.toContain('# Project Context')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('resolves the entity from --entity, which citty used to drop silently', async () => {
+    const workspace = await createTempWorkspace('guren-cli-context-flag-')
+    try {
+      await writeModelFixture(workspace.dir)
+
+      const { exitCode, stdout } = await runBin(['context', '--entity', 'User'], workspace.dir)
+
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('# User')
+      expect(stdout).toContain('## Model — app/Models/User.ts')
+      // The regression: an `entity` declared `type: 'positional'` swallowed the
+      // flag's value entirely, so this printed the whole-project map instead.
+      expect(stdout).not.toContain('# Project Context')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('resolves the entity from --entity=<name>', async () => {
+    const workspace = await createTempWorkspace('guren-cli-context-flag-eq-')
+    try {
+      await writeModelFixture(workspace.dir)
+
+      const { exitCode, stdout } = await runBin(['context', '--entity=User'], workspace.dir)
+
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('# User')
+      expect(stdout).toContain('## Model — app/Models/User.ts')
+      expect(stdout).not.toContain('# Project Context')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('still prints the project map when no entity is given', async () => {
+    const workspace = await createTempWorkspace('guren-cli-context-none-')
+    try {
+      await writeModelFixture(workspace.dir)
+
+      const { exitCode, stdout } = await runBin(['context'], workspace.dir)
+
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('# Project Context')
+      expect(stdout).not.toContain('## Model — app/Models/User.ts')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('keeps the positional working alongside --module', async () => {
+    const workspace = await createTempWorkspace('guren-cli-context-module-')
+    try {
+      await writeModelFixture(workspace.dir)
+
+      const { exitCode, stdout } = await runBin(['context', '--module', 'app', 'User'], workspace.dir)
+
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('## Model — app/Models/User.ts')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})
+
+describe('queue:retry id argument', () => {
+  // `id` stays positional (see bin.ts). This pins the reason: the flag spelling
+  // is refused loudly rather than silently retrying the wrong thing, so it does
+  // not need `context`'s treatment. If someone converts `id` to a `string`,
+  // this test tells them the behavior it was protecting.
+  it('refuses --id rather than silently retrying nothing', async () => {
+    const workspace = await createTempWorkspace('guren-cli-queue-retry-flag-')
+    try {
+      await writeFile(join(workspace.dir, 'package.json'), '{}', 'utf8')
+
+      const { exitCode } = await runBin(['queue:retry', '--id', '42'], workspace.dir)
+
+      expect(exitCode).toBe(1)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})


### PR DESCRIPTION
## What

`guren context --entity User` now returns the entity bundle. It previously printed the whole-project map and exited 0.

`context` declared its `entity` argument `type: 'positional'`. citty 0.1.6 discards a value passed to a positional as a flag — it reaches neither `args.entity` nor the unconsumed positionals in `args._`, and no unknown-flag error is raised — so the command ran as if no entity had been named. Because this command's no-entity branch is the project map, the result was the wrong output at exit 0, with nothing signalling that the argument had been ignored.

`entity` is now `type: 'string'` with a fallback to `args._[0]`, accepting `context User`, `--entity User`, and `--entity=User` alike.

## Why this spelling matters

`--entity <Model>` is not an invented spelling. It is a real string flag on both `make:adr` and `docs:graph`, documented in the CLI guides in English and Japanese and in the agent harness template, so `context --entity User` is a natural thing to write after reading them. This is the same defect class as the `make:migration --name` bug.

## Why `queue:retry` is left alone

`queue:retry` carries the same optional-positional declaration but is deliberately unchanged, with a comment at the declaration recording why. The failure modes are opposite:

| Invocation | Before | After |
| --- | --- | --- |
| `guren context --entity User` | whole-project map, exit 0 | entity bundle, exit 0 |
| `guren queue:retry --id 42` | `Please provide a job ID or use --all`, exit 1 | unchanged |

`queue:retry`'s `id`/`--all` guard makes the dropped value land in the error branch, so the wrong spelling is already refused loudly rather than acting on the wrong input. Converting it would trade the `[ID]` in `--help` for nothing.

## Reviewer notes

- **Help output changes for `context`.** `--entity=<User>` is now listed under OPTIONS rather than rendered as an `[ENTITY]` argument in USAGE. Since the positional form is the one every doc teaches, the description names it explicitly: `Also accepted positionally: guren context User.`
- **Docs are unchanged on purpose.** `context [Entity]` in `docs/{en,ja}/guides/cli.md` stays accurate. Adding `--entity` to the docs tables would spread a second spelling for a command whose primary spelling is positional, which is the opposite of the reason for this change. `audit:docs` is green.
- **A valueless `--entity` is safe.** citty yields `""` (a string, falsy) rather than `true`, so `--entity` and `--entity --json` both fall through to the project map exactly as before. No boolean can reach `displayEntityContext`.
- **`--module` still composes.** `context --module app User` and `context User --module app` both resolve the entity.
- **`make:migration` is untouched here.** Its identical positional trap is fixed on a separate branch; keeping the two apart avoids a conflict on the same declaration.

## Tests

`packages/cli/tests/context-entity-arg.test.ts` spawns the real bin — `bin.ts` exports nothing and builds its commands at module scope, so nothing importable exercises the citty declaration — and asserts on stdout rather than exit code, because `context --entity User` exited 0 before this change too.

The tests were mutation-tested against the pre-fix declaration: the two flag cases fail and the four spelling-independent ones (positional, no-arg, `--module`, `queue:retry`) stay green. The needle is `## Model — app/Models/User.ts`, not `# User`, since the project map lists models as `### User` and would satisfy the looser assertion.

## Gates

- `bun run typecheck` — exit 0
- `bun run test:bun cli` — 1514 pass, 0 fail
- `bun run audit:docs`, `bun run audit:core-first` — green

Changeset: `@guren/cli` patch.