### PR TITLE
fix(cli): honor --name on make:migration

### DIFF
--- a/.changeset/make-migration-honors-name-flag.md
+++ b/.changeset/make-migration-honors-name-flag.md
@@ -1,0 +1,9 @@
+---
+"@guren/cli": patch
+---
+
+Honor `--name` on `make:migration` (`db:make`), and take the last value of a repeated flag.
+
+`guren make:migration --name add_posts_table` — the form the database guide documents — generated a migration under a name drizzle-kit invented (`20260819113244_unusual_triton`) rather than the one given. The argument was declared as a positional, and citty resolves positionals and string flags from different places: `--name <value>` arrived with neither a `name` key nor the value among the positionals, and no unknown-flag error to say so, so drizzle-kit was called with no name at all and fell back to naming the migration itself. Nothing about the run looked like a failure — the migration is generated and correct, only misnamed, which is the kind of thing noticed later when hunting for it by name. Both spellings work now: `--name <name>`, and the bare positional (`guren make:migration add_posts_table`) that the scaffolding skills use.
+
+Repeating any of the command's three flags is also handled. citty types a `string` argument as `string | undefined` and then hands back a `string[]` when the flag appears twice, which each argument failed on differently: `--schema a/schema.ts --schema b/schema.ts` was comma-joined into a path nothing can open and still exited 0, and once `--name` started being read it would have thrown `options.name?.trim is not a function`. The last value wins, as it does everywhere else.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -738,16 +738,48 @@ const makeExceptionCommand = defineCommand({
   },
 })
 
+/**
+ * The last value of a repeated citty flag.
+ *
+ * citty types every `string` arg as `string | undefined` and then hands back a
+ * `string[]` when the flag is passed twice — a lie no compiler catches, and one
+ * each of these three arguments fails differently on. `--name a --name b` died
+ * inside `makeMigration()` on `options.name?.trim is not a function`; `--schema`
+ * and `--out` were quietly comma-joined into a path nothing can open
+ * (`--schema a/schema.ts,b/schema.ts`) and still exited 0. Last-wins is what
+ * repeating a flag means to whoever typed it.
+ */
+function lastFlagValue(value: unknown): string | undefined {
+  const candidate = Array.isArray(value) ? value.at(-1) : value
+  return typeof candidate === 'string' ? candidate : undefined
+}
+
 const makeMigrationCommand = defineCommand({
   meta: {
     name: 'make:migration',
     description: 'Generate a new SQL migration file using drizzle-kit.',
   },
   args: {
+    // A `string`, not a `positional`, because citty resolves the two from
+    // different places and silently drops what the other one reads: declared
+    // positional, `--name add_posts_table` leaves `args` with neither a `name`
+    // key nor the value in `_` — no unknown-flag error either, so the command
+    // ran on to drizzle-kit with no name and drizzle-kit invented its own
+    // (`20260819113244_unusual_triton`). The flag is what docs/*/guides/
+    // database.md documents; the bare positional is what every skill and
+    // templates/agent/** uses, and a `string` arg still leaves unconsumed
+    // positionals in `_` for `run()` below to pick up.
+    //
+    // A second, differently-keyed positional would carry both spellings too,
+    // and would put the bare form back in citty's usage line — but citty
+    // renders a positional by its key, so help would read `[MIGRATIONNAME]`
+    // beside `--name`, and two args for one value raises a which-one-wins
+    // question there is no good answer to. One key, both spellings named in
+    // the description.
     name: {
-      type: 'positional',
-      required: false,
-      description: 'Optional migration name passed to drizzle-kit',
+      type: 'string',
+      description: 'Migration name, as `--name <name>` or a bare positional',
+      valueHint: 'add_posts_table',
     },
     schema: {
       type: 'string',
@@ -762,9 +794,9 @@ const makeMigrationCommand = defineCommand({
   },
   async run({ args }) {
     const result = await makeMigration({
-      name: args.name,
-      schema: args.schema,
-      out: args.out,
+      name: lastFlagValue(args.name) ?? args._[0],
+      schema: lastFlagValue(args.schema),
+      out: lastFlagValue(args.out),
     })
 
     // drizzle-kit exits 0 for "No schema changes, nothing to migrate." too, so

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -397,11 +397,16 @@ export function checkTypes(rootNames: string[], compilerOptions: ts.CompilerOpti
 }
 
 /** Spawn the CLI bin as a subprocess and return its exit code. */
-export async function runCliBin(args: string[], cwd: string): Promise<number> {
+export async function runCliBin(
+  args: string[],
+  cwd: string,
+  options: { env?: Record<string, string> } = {},
+): Promise<number> {
   assertWorkspaceBuilt([SERVER_DIST_ENTRY])
 
   const proc = Bun.spawn(['bun', CLI_BIN_PATH, ...args], {
     cwd,
+    env: options.env ? { ...process.env, ...options.env } : undefined,
     stdout: 'ignore',
     stderr: 'ignore',
   })

--- a/packages/cli/tests/make-migration.test.ts
+++ b/packages/cli/tests/make-migration.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, mock } from 'bun:test'
-import { mkdir, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { createTempWorkspace } from './helpers'
+import { createTempWorkspace, runCliBin } from './helpers'
 import * as realUtils from '../src/utils'
 
 const spawnCalls: Array<{ command: string; args: string[] }> = []
@@ -295,4 +296,111 @@ describe('makeMigration', () => {
       await workspace.cleanup()
     }
   })
+})
+
+/**
+ * A stand-in for the `drizzle-kit` `bun x` would otherwise fetch, written where
+ * `bun x` looks first: `node_modules/.bin` under the invocation cwd. It records
+ * the argv it was handed and exits 0, which is what keeps this test off the
+ * network — a temp workspace has no ancestor `node_modules`, so without the
+ * stub `bun x drizzle-kit` would install the real one.
+ */
+async function seedDrizzleKitStub(dir: string): Promise<void> {
+  const binDir = join(dir, 'node_modules', '.bin')
+  await mkdir(binDir, { recursive: true })
+  const stub = join(binDir, 'drizzle-kit')
+  await writeFile(stub, '#!/bin/sh\nprintf \'%s\\n\' "$@" > "$GUREN_TEST_ARGV_OUT"\n', 'utf8')
+  await chmod(stub, 0o755)
+  await writeFile(join(dir, 'drizzle.config.ts'), 'export default {}', 'utf8')
+}
+
+/**
+ * The argv `make:migration` actually hands drizzle-kit, from a real spawn of
+ * the CLI.
+ *
+ * Spawned rather than imported because what is under test is the citty arg
+ * *declaration* in bin.ts — and bin.ts has no exports, it runs the CLI at
+ * module scope. A test that reached `makeMigration()` directly would keep
+ * passing through exactly the regression this pins: citty resolves positionals
+ * and string flags from different places, so declaring `name` a positional
+ * drops `--name <value>` with neither a `name` key nor an unknown-flag error,
+ * and `makeMigration()` — correct on its own, as the cases above show — is
+ * simply never told the name.
+ *
+ * No `createTempWorkspace`: its `process.chdir()` is there for commands that
+ * read `process.cwd()` in-process, and a subprocess is handed its cwd.
+ */
+async function drizzleKitArgvFor(cliArgs: string[]): Promise<string[]> {
+  const dir = await mkdtemp(join(tmpdir(), 'guren-cli-make-migration-argv-'))
+  try {
+    await seedDrizzleKitStub(dir)
+    const argvOut = join(dir, 'argv.txt')
+
+    const exitCode = await runCliBin(['make:migration', ...cliArgs], dir, {
+      env: { GUREN_TEST_ARGV_OUT: argvOut },
+    })
+    expect(exitCode).toBe(0)
+
+    const recorded = await readFile(argvOut, 'utf8')
+    return recorded.split('\n').filter((line) => line.length > 0)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+describe('make:migration name argument', () => {
+  // The whole argv, not a `toContain` — a containment check passes just as
+  // happily on `--name=add_smoke_probe --name=wrong`, which is the shape a
+  // repeated flag produced before `lastFlagValue()`.
+  const NAMED_ARGV = ['generate', '--name=add_smoke_probe', '--config', 'drizzle.config.ts']
+
+  const forms: Array<[string, string[]]> = [
+    ['--name <value>', ['--name', 'add smoke probe']],
+    ['--name=<value>', ['--name=add smoke probe']],
+    ['a bare positional', ['add smoke probe']],
+    // Last-wins. Unnormalized, citty hands back a `string[]` here and
+    // `makeMigration()` dies on `options.name?.trim is not a function`.
+    ['a repeated --name', ['--name', 'ignored', '--name', 'add smoke probe']],
+  ]
+
+  for (const [label, cliArgs] of forms) {
+    it(`passes the name to drizzle-kit when given as ${label}`, async () => {
+      const argv = await drizzleKitArgvFor(cliArgs)
+
+      expect(argv).toEqual(NAMED_ARGV)
+    })
+  }
+
+  // `--schema` and `--out` take the same citty array, and failed on it more
+  // quietly than `--name` did: comma-joined into `a/schema.ts,b/schema.ts` and
+  // handed to drizzle-kit as a path, with a 0 exit code.
+  it('takes the last value of a repeated --schema or --out', async () => {
+    const argv = await drizzleKitArgvFor([
+      '--schema',
+      'a/schema.ts',
+      '--schema',
+      'b/schema.ts',
+      '--out',
+      'a/migrations',
+      '--out',
+      'b/migrations',
+    ])
+
+    expect(argv).toEqual(['generate', '--schema', 'b/schema.ts', '--out', 'b/migrations'])
+  })
+
+  // A bare `--name` was inert while the argument was a positional — citty
+  // dropped it with everything else. It reaches `makeMigration()` now, so pin
+  // that an empty value falls back to drizzle-kit's own naming rather than
+  // being forwarded as an empty `--name=`.
+  for (const [label, cliArgs] of [
+    ['no name is given', [] as string[]],
+    ['`--name` is given no value', ['--name']],
+  ] as const) {
+    it(`leaves drizzle-kit to name the migration when ${label}`, async () => {
+      const argv = await drizzleKitArgvFor([...cliArgs])
+
+      expect(argv.some((arg) => arg.startsWith('--name'))).toBe(false)
+    })
+  }
 })


### PR DESCRIPTION
## Summary

`guren make:migration --name add_posts_table` — the form `docs/{en,ja}/guides/database.md` documents — generated a migration under a name drizzle-kit invented (`20260819113244_unusual_triton`) rather than the one given.

The cause is not drizzle-kit and not the `--config` branch. `name` was declared `type: 'positional'`, and citty resolves positionals and string flags from different places. Measured against the same citty 0.1.6 definition:

| declaration | invocation | resolved `args` |
|---|---|---|
| `positional` | `--name "add smoke probe"` | `{"_":[]}` — key and value both gone |
| `positional` | `"add smoke probe"` | `{"_":["add smoke probe"],"name":"add smoke probe"}` |
| `string` | `--name "add smoke probe"` | `{"_":[],"name":"add smoke probe"}` |
| `string` | `"add smoke probe"` | `{"_":["add smoke probe"]}` |

So `makeMigration({ name: undefined })` ran, `--name` never reached drizzle-kit, and drizzle-kit named the migration itself. There is no unknown-flag error on that path, so nothing about the run looks like a failure — the migration is generated and correct, only misnamed.

drizzle-kit v1.0.0-rc.4 is innocent: `drizzle-kit generate --name=add_smoke_probe --config drizzle.config.ts` honors the name. `makeMigration()` is innocent too — the existing "applies overrides and slugifies names" test was verifying a function that already worked.

Declaring the argument `type: 'string'` with an `args._[0]` fallback carries both spellings: the documented flag, and the bare positional that every `.claude/skills/**` and `packages/cli/templates/agent/**` uses.

**Repeated flags.** citty types a `string` argument as `string | undefined` and then hands back a `string[]` when the flag appears twice — a lie no compiler catches, and one each of this command's three arguments failed on differently:

- `--name a --name b` → `ERROR options.name?.trim is not a function`, exit 1 (introduced by reading `--name` at all)
- `--schema a/schema.ts --schema b/schema.ts` → comma-joined to `--schema a/schema.ts,b/schema.ts`, **exit 0** (pre-existing)
- `--out a/mig --out b/mig` → same (pre-existing)

`lastFlagValue()` normalizes all three to last-wins. Fixing only `--name` would have meant shipping a normalizer that deliberately skips two arguments with the identical defect.

## Scope

`cli` — `packages/cli/src/bin.ts`, `packages/cli/tests/make-migration.test.ts`, `packages/cli/tests/helpers.ts` (`runCliBin` gains an optional `env`). No docs change: the fix makes the documented `--name` true rather than the docs wrong.

## Risk Assessment

Behavior changes, all in `make:migration`:

- `--name <value>` / `--name=<value>` now reach drizzle-kit. Previously ignored.
- A repeated `--name`/`--schema`/`--out` takes the last value instead of crashing (`--name`) or comma-joining (`--schema`, `--out`).

Unchanged: the bare positional form, a bare `--name` with no value (citty yields `''`, which stays falsy and leaves drizzle-kit to name the migration), and the no-argument form that `scripts/smoke-golden-path.sh:266` uses — it passes no name and asserts nothing about the folder name.

Help output no longer advertises the positional in its usage line (`[OPTIONS]`, no `[NAME]`). A second, differently-keyed positional would restore it, but citty renders a positional by its key, so help would read `[MIGRATIONNAME]` beside `--name`, and two arguments for one value raise a which-one-wins question with no good answer. Both spellings are named in the flag's description instead.

Out of scope, noted while investigating:

- The other two optional positionals have since been settled by #464: `context`'s `entity` was converted the same way, and `queue:retry`'s `id` was deliberately left positional (dropping it lands in the missing-id guard, which already exits 1). `required: true` positionals are safe either way — citty errors on the missing positional rather than dropping it.
- **`context --entity User --entity User` exits 1 with `entityName.toLowerCase is not a function`** — the repeated-flag hazard this PR fixes for `make:migration`, in the command #464 converted, measured on `main` at d7f3034. Left for a follow-up rather than widening this PR; `lastFlagValue()` is the fix.
- `runCli` treats `--help` as a global scan over `rawArgs`, so `make:migration -- --help` prints help rather than naming a migration `help`. Pre-existing, CLI-wide, and untouched here.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` — 4692 tests, 0 fail, exit 0
- [x] `bun run audit:docs`

The regression test spawns the real bin. bin.ts has no exports and runs the CLI at module scope, so nothing importable exercises the citty declaration — a test reaching `makeMigration()` directly passes straight through this bug. A `/bin/sh` stub at `node_modules/.bin/drizzle-kit` records the argv it receives; `bun x` prefers it, which is what keeps the test off the network and away from a real database.

Mutation-checked in both directions:

- Reverting the declaration to `positional` fails exactly the two `--name` cases and leaves the bare-positional case passing (it was never broken).
- Removing `lastFlagValue()` fails exactly the two repeated-flag cases.

Assertions compare the whole argv rather than using `toContain`, which would accept `--name=add_smoke_probe --name=wrong` — the shape a repeated flag produced before normalization.

End-to-end, real CLI against a recording stub:

```
--name "add smoke probe"          → generate --name=add_smoke_probe --config drizzle.config.ts
--name=add_smoke_probe            → generate --name=add_smoke_probe --config drizzle.config.ts
"add smoke probe"                 → generate --name=add_smoke_probe --config drizzle.config.ts
--name first --name second        → generate --name=second --config drizzle.config.ts
--schema a/s.ts --schema b/s.ts   → generate --schema b/s.ts --out db/migrations
--name                            → generate --config drizzle.config.ts
(none)                            → generate --config drizzle.config.ts
```

And against real drizzle-kit in `examples/blog`, the originally reported command now produces `20260819124233_add_smoke_probe`.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation. — no docs change needed; `--name` now behaves as the database guide already describes.

