### PR TITLE
fix(orm): report a missing seeders folder instead of a database failure

### DIFF
--- a/.changeset/db-seed-reports-empty-seeders.md
+++ b/.changeset/db-seed-reports-empty-seeders.md
@@ -11,4 +11,4 @@ Report an empty seeders folder from `db:seed` instead of "Database seeders execu
 
 `db:reset --seed` and `db:fresh --seed` also refuse up front, before dropping anything, when the app's `config/database.ts` exports no seed function at all: they previously emptied the database and then reported it seeded. `db:seed` already refused the same config.
 
-The commands still exit 0 on the empty-folder diagnostic — it is not a failure — and a `config/database.ts` whose seed function reports nothing keeps the previous message. A missing seeders folder still throws as before, rather than being softened into this warning.
+The commands still exit 0 on the empty-folder diagnostic — it is not a failure — and a `config/database.ts` whose seed function reports nothing keeps the previous message.

--- a/.changeset/db-seed-reports-missing-seeders-folder.md
+++ b/.changeset/db-seed-reports-missing-seeders-folder.md
@@ -1,0 +1,13 @@
+---
+"@guren/orm": minor
+---
+
+Report a missing `db/seeders/` from `db:seed` as "no seeders found" instead of a database failure
+
+`collectSeeders()` read the folder with no handling for its absence, so an app that never created `db/seeders/` had the ENOENT propagate out of `runSeeders()` into the driver's `seedDatabase()`. In `createPostgresDatabase()`, `createMySqlDatabase()` and `createSqliteDatabase()` that means `seedFailure()` wrapped it as `Failed to seed the database: ENOENT: no such file or directory, scandir '/…/db/seeders'` — a filesystem error dressed as a database failure; `createAwsDataApiDatabase()` does not wrap, so the raw ENOENT surfaced. Either way the report blamed the database for a folder that simply holds no seeders.
+
+**Behavior change to a Stable API:** `runSeeders()` (and `loadSeeders()`) no longer reject when the directory does not exist. `runSeeders()` now resolves a `SeederRunSummary` with `seedersRan: 0` and `filesWithoutSeeder: 0`, and `loadSeeders()` returns `[]`. `db:seed` therefore reports the missing folder with the warning it already prints for an empty one — `No seeders found in db/seeders — nothing was seeded.`, pointing at `bunx guren make:seeder` — and exits 0. This matches `inspectMigrationsFolder()`, which has always reported a missing `db/migrations` as `migrationsFound: 0` rather than throwing. Callers that relied on the rejection to detect an absent folder must now check the folder themselves: the summary cannot tell them apart, since `seedersRan: 0` describes an empty folder just as well.
+
+Only absence is softened. A path that exists but is not a directory (`ENOTDIR`), or one the process may not read (`EACCES`), still throws — both are misconfigurations, not folders holding no seeders. A folder that was never *configured* stays an error too: every driver's `seedDatabase()` still throws `No seeders folder configured. Provide "seedersFolder" when calling create<Driver>Database().` when the app passed no `seedersFolder` at all.
+
+`examples/api` drops the workaround this cost it — it probed the folder with `existsSync` and passed `seedersFolder: undefined`, then guarded on the same flag again at boot.

--- a/examples/api/config/app.ts
+++ b/examples/api/config/app.ts
@@ -1,4 +1,4 @@
-import { configureOrm, hasSeeders, seedDatabase } from './database.js'
+import { configureOrm, seedDatabase } from './database.js'
 
 let bootstrapped = false
 
@@ -15,7 +15,7 @@ export async function bootModels(): Promise<void> {
   if (bootstrapped) return
 
   await configureOrm()
-  if (shouldSeedOnBoot() && hasSeeders) {
+  if (shouldSeedOnBoot()) {
     await seedDatabase()
   }
   bootstrapped = true

--- a/examples/api/config/database.ts
+++ b/examples/api/config/database.ts
@@ -1,13 +1,8 @@
-import { existsSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
 import { createPostgresDatabase } from '@guren/orm'
-
-const seedersFolder = new URL('../db/seeders', import.meta.url)
-export const hasSeeders = existsSync(fileURLToPath(seedersFolder))
 
 const database = createPostgresDatabase({
   migrationsFolder: new URL('../db/migrations', import.meta.url),
-  seedersFolder: hasSeeders ? seedersFolder : undefined,
+  seedersFolder: new URL('../db/seeders', import.meta.url),
   connectionString: () => process.env.DATABASE_URL ?? 'postgres://guren:guren@localhost:54322/guren_api',
 })
 

--- a/packages/orm/src/seeder.ts
+++ b/packages/orm/src/seeder.ts
@@ -1,3 +1,4 @@
+import type { Dirent } from 'node:fs'
 import { readdir } from 'node:fs/promises'
 import { extname, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
@@ -127,7 +128,32 @@ async function collectSeeders<TDatabase>(
   directory: string | URL,
 ): Promise<{ root: string; seeders: Array<SeederHandler<TDatabase>>; filesWithoutSeeder: number }> {
   const root = directory instanceof URL ? fileURLToPath(directory) : resolve(directory)
-  const entries = await readdir(root, { withFileTypes: true })
+
+  // A folder that was never created holds no seeders — the same nothing-to-run
+  // an empty one reports, and what `db:seed` already has the right message for.
+  // Letting the ENOENT out instead reached the user through `seedFailure()` as
+  // "Failed to seed the database: ENOENT ... scandir", a filesystem error
+  // dressed as a database failure; `inspectMigrationsFolder()` has always
+  // answered `migrationsFound: 0` for a missing migrations folder.
+  //
+  // Only ENOENT is absence, and it is read off the listing itself rather than
+  // from a preceding existsSync: that check answers false for a folder whose
+  // *parent* is unreadable, which would turn a permission problem into a silent
+  // "no seeders found". ENOTDIR (a file sitting where the folder should be) and
+  // EACCES both still throw — both are misconfigurations a user has to see, and
+  // neither is a folder holding no seeders. A folder that was never
+  // *configured* is different again, and each driver's `seedDatabase()` still
+  // throws for it before reaching here.
+  let entries: Dirent[]
+  try {
+    entries = await readdir(root, { withFileTypes: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+      throw error
+    }
+    return { root, seeders: [], filesWithoutSeeder: 0 }
+  }
+
   const files = entries
     .filter((entry) => entry.isFile() && isSeederCandidate(entry.name))
     .map((entry) => resolve(root, entry.name))

--- a/packages/orm/tests/seeder.test.ts
+++ b/packages/orm/tests/seeder.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { defineSeeder, loadSeeders, runSeeders, type SeederContext } from '../src/seeder'
@@ -154,6 +154,11 @@ describe('loadSeeders', () => {
     const seeders = await loadSeeders(tempDir)
     expect(seeders).toEqual([])
   })
+
+  it('returns empty array for a directory that does not exist', async () => {
+    const seeders = await loadSeeders(join(tempDir, 'never-created'))
+    expect(seeders).toEqual([])
+  })
 })
 
 describe('runSeeders', () => {
@@ -268,6 +273,56 @@ describe('runSeeders run summary', () => {
     expect(await runSeeders({}, tempDir)).toEqual({
       seedersFolder: tempDir,
       seedersRan: 1,
+      filesWithoutSeeder: 0,
+    })
+  })
+
+  // An app that never created db/seeders/ used to have the readdir ENOENT
+  // surface through seedFailure() as "Failed to seed the database: ENOENT ...
+  // scandir" — a filesystem error dressed as a database failure. It holds no
+  // seeders, which is the nothing-to-run db:seed already reports, and is what
+  // `inspectMigrationsFolder()` has always answered for a missing db/migrations.
+  it('should report nothing ran for a folder that does not exist', async () => {
+    const missing = join(tempDir, 'never-created')
+
+    expect(await runSeeders({}, missing)).toEqual({
+      seedersFolder: missing,
+      seedersRan: 0,
+      filesWithoutSeeder: 0,
+    })
+  })
+
+  // A symlink pointing at nothing resolves to nothing, and the OS reports that
+  // as the same ENOENT a folder that was never created gives — so it reads as
+  // absent rather than as an error of its own.
+  it('should report nothing ran for a dangling symlink', async () => {
+    const link = join(tempDir, 'seeders')
+    await symlink(join(tempDir, 'never-created'), link)
+
+    expect(await runSeeders({}, link)).toEqual({
+      seedersFolder: link,
+      seedersRan: 0,
+      filesWithoutSeeder: 0,
+    })
+  })
+
+  // Absence is ENOENT and nothing else: a file sitting where the folder belongs
+  // is a misconfiguration, and reporting it as an empty folder would send the
+  // user to `make:seeder` to write a seeder into a path that cannot hold one.
+  it('should not report nothing ran for a file where the folder belongs', async () => {
+    const notAFolder = join(tempDir, 'seeders')
+    await writeFile(notAFolder, '')
+
+    await expect(runSeeders({}, notAFolder)).rejects.toThrow(/ENOTDIR/)
+  })
+
+  // Configs pass the folder as a URL, so the guard has to hold on that path too.
+  it('should report nothing ran for a missing folder given as a URL', async () => {
+    const missing = join(tempDir, 'never-created')
+
+    expect(await runSeeders({}, new URL(`file://${missing}`))).toEqual({
+      seedersFolder: missing,
+      seedersRan: 0,
       filesWithoutSeeder: 0,
     })
   })


### PR DESCRIPTION
## Summary

`db:seed` treated a *missing* `db/seeders/` differently from an *empty* one, and the missing case produced a diagnostic that named the wrong subsystem.

`collectSeeders()` in `packages/orm/src/seeder.ts` listed the folder with no handling for its absence, so an app that never created it had the ENOENT propagate out of `runSeeders()` into the driver's `seedDatabase()`. Postgres, MySQL and SQLite wrap it with `seedFailure()` as `Failed to seed the database: ENOENT: no such file or directory, scandir '/…/db/seeders'`; the AWS Data API driver returns `runSeeders()` directly and does not wrap at all. Either way the report blamed the database for a folder that simply holds no seeders.

The migration sibling already made the opposite call for the identical situation: `inspectMigrationsFolder()` guards its folder and answers `migrationsFound: 0`, so `db:migrate` reports "nothing found" rather than throwing. This brings seeding in line. `runSeeders()` now resolves a `SeederRunSummary` with `seedersRan: 0` and `loadSeeders()` returns `[]`, which routes `db:seed` into the message it already prints for an empty folder — `No seeders found in db/seeders — nothing was seeded.`, pointing at `bunx guren make:seeder` — and exits 0.

The evidence that the split cost something was in the repo. `examples/api/config/database.ts` probed the folder with `existsSync` and passed `seedersFolder: undefined`, and `config/app.ts` guarded on the same flag again at boot; `examples/api/db/` genuinely has no `seeders/`. One first-party example carried the workaround twice, which is the usual sign that the fix belongs deeper. Both copies are removed here.

### Absence is ENOENT and nothing else

The guard reads absence off the listing itself rather than from a preceding `existsSync`. Measured behaviour of the two on macOS:

| case | `existsSync` | `readdir` |
|---|---|---|
| folder absent | `false` | `ENOENT` |
| dangling symlink | `false` | `ENOENT` |
| a file at the path | `true` | `ENOTDIR` |
| folder mode `000` | `true` | `EACCES` |
| **parent unreadable** | **`false`** | **`EACCES`** |

That last row is why an `existsSync` pre-check is the wrong instrument: it answers "absent" for a folder whose *parent* cannot be read, turning a permission problem into a silent "no seeders found". Catching only `ENOENT` from `readdir` keeps `ENOTDIR` and `EACCES` throwing — both are misconfigurations a user has to see — and removes the TOCTOU window a separate existence check opens. A dangling symlink resolves to nothing and the OS reports `ENOENT` for it under either approach, so it reads as absent; distinguishing it would need `lstat`, which is not worth the machinery. Both decisions are pinned by tests.

A folder that was never *configured* is a different case and still throws: every driver's `seedDatabase()` keeps raising `No seeders folder configured. Provide "seedersFolder" when calling create<Driver>Database().`

## Scope

`orm`, `examples`

## Risk Assessment

**Behaviour change to a Stable API.** `runSeeders()` and `loadSeeders()` are listed as Stable in `contributing/api-stability.md`, and they no longer reject when the directory does not exist. Callers that relied on the rejection to detect an absent folder must now check the folder themselves — the summary cannot tell them apart, since `seedersRan: 0` describes an empty folder just as well. The changeset states this explicitly.

The changeset is a **minor**, matching the precedent set by the migration-side fix for the identical situation. Note that a strict reading of `contributing/semver-guidance.md:35` ("Changes to Stable API signatures, return types, or default behavior") would call for a major instead; this is a deliberate call, flagged here so a reviewer can overrule it. `runSeeders` is on `@guren/core`'s named allowlist, so a major would also raise the question of core's bump — the judgment `scripts/smoke/core-semver-audit.ts` deliberately leaves out of scope for orm.

No documentation asserted the old throwing behaviour, so no docs change was needed.

Two things worth a reviewer's attention beyond the diff:

- **`.changeset/db-seed-reports-empty-seeders.md` is edited here.** That pending changeset (from #462) ended with "A missing seeders folder still throws as before, rather than being softened into this warning." Both changesets ship in the same release, so leaving it would put a direct contradiction inside one CHANGELOG entry. Only that sentence is removed. Revert it if you would rather keep the file untouched.
- **The `api-only` template has the same shape and is left alone.** `packages/create-app/templates/api-only/db/` ships no `seeders/`, while `packages/create-app/src/blueprints.ts:276,281` passes `seedersFolder` unconditionally — so every scaffolded API app was hitting exactly this ENOENT, and this fix resolves it for them. No template carries a copy of the `hasSeeders` workaround, so nothing is routed into the "not configured" error. Adding a `.gitkeep` was left out of scope because `audit:starter-template` asserts scaffold contents literally.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck` (root, plus `examples/blog` and `examples/api`)
- [x] `bun run test` — `test:bun` 4625 pass / 0 fail; `examples/blog`, `examples/api` (42), `web` (112) all green

The new tests were mutation-checked in both directions: swallowing every `readdir` error fails the `ENOTDIR` case, and rethrowing everything (the pre-fix behaviour) fails the four absence cases.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation. (None asserted the old behaviour; the changeset carries the change.)