### PR TITLE
fix(cli): take the last value of a repeated flag on `guren context`

### DIFF
--- a/.changeset/context-repeated-flag-values.md
+++ b/.changeset/context-repeated-flag-values.md
@@ -1,0 +1,16 @@
+---
+'@guren/cli': patch
+---
+
+Fix `guren context` misreading a flag that is passed twice
+
+citty hands an argument back as an array once its flag is repeated, and
+`guren context` read all five of its own straight through.
+`--entity User --entity User` exited 1 on `entityName.toLowerCase is not a
+function`, and `--app . --app .` exited 1 inside `resolve()`. The other three
+never said anything untrue out loud: `--module app --module app` exited 1
+blaming a module named `app,app`; `--routes web.ts --routes web.ts` exited 0
+reporting the entity's routes as none, because the same `resolve()` failure
+lands in the `catch` that exists for a routes file the CLI genuinely cannot
+load; and `--json=true --json=false` printed JSON, because every array is
+truthy. Each of the five now resolves to the value passed last.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -743,15 +743,42 @@ const makeExceptionCommand = defineCommand({
  *
  * citty types every `string` arg as `string | undefined` and then hands back a
  * `string[]` when the flag is passed twice — a lie no compiler catches, and one
- * each of these three arguments fails differently on. `--name a --name b` died
- * inside `makeMigration()` on `options.name?.trim is not a function`; `--schema`
- * and `--out` were quietly comma-joined into a path nothing can open
- * (`--schema a/schema.ts,b/schema.ts`) and still exited 0. Last-wins is what
- * repeating a flag means to whoever typed it.
+ * that surfaces differently at every place the value is then used. Measured on
+ * this bin, three shapes crash: `make:migration --name a --name b` inside
+ * `makeMigration()` on `options.name?.trim is not a function`,
+ * `context --entity User --entity User` on `entityName.toLowerCase is not a
+ * function`, and `context --app . --app .` inside `resolve()` on `The
+ * "paths[0]" property must be of type string, got array`.
+ *
+ * The quiet ones are the reason to narrow a value before reading it rather than
+ * after a crash report: `make:migration --schema a.ts --schema b.ts` comma-joins
+ * them into a path nothing can open and still exits 0;
+ * `context --module app --module app` exits 1 blaming a module named `app,app`;
+ * `context --routes web.ts --routes web.ts` exits 0 reporting the entity's
+ * routes as none, because the same `resolve()` TypeError lands in a `catch` that
+ * exists for a routes file this CLI genuinely cannot load (`entity-context.ts`,
+ * `loadEntityRoutes`) and cannot tell the two apart. Last-wins is what repeating
+ * a flag means to whoever typed it.
  */
 function lastFlagValue(value: unknown): string | undefined {
   const candidate = Array.isArray(value) ? value.at(-1) : value
   return typeof candidate === 'string' ? candidate : undefined
+}
+
+/**
+ * The last value of a repeated citty `boolean` flag.
+ *
+ * `Boolean(args.flag)` reads as safe here and is not: citty arrays a repeated
+ * boolean the same way it arrays a string, and every array is truthy. So
+ * `--json=false --json=false` turns *off* into *on*, and `--json --json=false`
+ * ignores the half the user typed last. Only the `=value` spellings can express
+ * a false, so a bare `--json --json` is unaffected — which is exactly what makes
+ * this the kind of bug that survives casual testing. citty coerces the value
+ * itself (`--json=yes` and `--json=0` both arrive as `true`), so the only work
+ * left is picking the last one.
+ */
+function lastBooleanFlag(value: unknown): boolean {
+  return Boolean(Array.isArray(value) ? value.at(-1) : value)
 }
 
 const makeMigrationCommand = defineCommand({
@@ -2006,22 +2033,28 @@ const contextCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const entity = args.entity ?? args._[0]
+    // Narrowed here rather than at each use so both branches below get the same
+    // treatment: `--app` and `--routes` reach a `resolve()` that throws on an
+    // array whether or not an entity was named.
+    const cwd = lastFlagValue(args.app)
+    const routesFile = lastFlagValue(args.routes)
+    const json = lastBooleanFlag(args.json)
+    const entity = lastFlagValue(args.entity) ?? args._[0]
 
     if (entity) {
       await displayEntityContext(entity, {
-        cwd: args.app,
-        json: Boolean(args.json),
-        routesFile: args.routes,
-        module: args.module,
+        cwd,
+        json,
+        routesFile,
+        module: lastFlagValue(args.module),
       })
       return
     }
 
     await displayContext({
-      cwd: args.app,
-      json: Boolean(args.json),
-      routesFile: args.routes,
+      cwd,
+      json,
+      routesFile,
     })
   },
 })

--- a/packages/cli/tests/context-entity-arg.test.ts
+++ b/packages/cli/tests/context-entity-arg.test.ts
@@ -1,5 +1,5 @@
 import { mkdir, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
 import { CLI_BIN_PATH, SERVER_DIST_ENTRY, assertWorkspaceBuilt, createTempWorkspace } from './helpers'
 
@@ -24,7 +24,11 @@ async function runBin(args: string[], cwd: string): Promise<{ exitCode: number; 
   return { exitCode, stdout }
 }
 
-/** The smallest workspace `guren context` resolves one model from. */
+/**
+ * The smallest workspace `guren context` resolves a model from. Two unrelated
+ * models, not one: a repeated `--entity` can only be shown to resolve to its
+ * *last* value if the other value would have produced visibly different output.
+ */
 async function writeModelFixture(dir: string): Promise<void> {
   await mkdir(join(dir, 'app/Models'), { recursive: true })
   await mkdir(join(dir, 'db'), { recursive: true })
@@ -37,11 +41,95 @@ export const users = pgTable('users', {
   id: serial('id'),
   email: text('email'),
 })
+
+export const posts = pgTable('posts', {
+  id: serial('id'),
+  title: text('title'),
+})
 `,
     'utf8',
   )
   await writeFile(
     join(dir, 'app/Models/User.ts'),
+    `import { defineModel } from '@guren/orm'
+import { users } from '../../db/schema.js'
+
+export class User extends defineModel(users) {}
+`,
+    'utf8',
+  )
+  await writeFile(
+    join(dir, 'app/Models/Post.ts'),
+    `import { defineModel } from '@guren/orm'
+import { posts } from '../../db/schema.js'
+
+export class Post extends defineModel(posts) {}
+`,
+    'utf8',
+  )
+}
+
+/**
+ * One route reaching one of the fixture's models, so the bundle's `## Routes`
+ * section has something to lose. A repeated `--routes` never crashed — its
+ * `resolve()` TypeError landed in the `catch` that degrades an unloadable
+ * routes file to a route-less bundle, and it exited 0 reporting no routes.
+ *
+ * Deliberately not at `routes/web.ts`: that is the path `--routes` defaults to,
+ * so an implementation that dropped the flag entirely would find the same file
+ * anyway and this test would pass without asserting anything.
+ */
+const CUSTOM_ROUTES_FILE = 'routes/custom.ts'
+
+async function writeRoutesFixture(dir: string): Promise<void> {
+  await mkdir(join(dir, 'app/Http/Controllers'), { recursive: true })
+  await mkdir(join(dir, 'routes'), { recursive: true })
+  await writeFile(
+    join(dir, 'app/Http/Controllers/UserController.ts'),
+    `import { Controller } from '@guren/core'
+
+export class UserController extends Controller {
+  async index() {
+    return this.json([])
+  }
+}
+`,
+    'utf8',
+  )
+  await writeFile(
+    join(dir, CUSTOM_ROUTES_FILE),
+    `import type { Router } from '@guren/core'
+import { UserController } from '../app/Http/Controllers/UserController.js'
+
+export function registerWebRoutes(router: Router): void {
+  router.get('/users', [UserController, 'index'])
+}
+`,
+    'utf8',
+  )
+}
+
+/**
+ * A second `User`, inside a module, so `--module` has something to decide. With
+ * one `User` the flag can be dropped entirely and every assertion still holds;
+ * with two, dropping it is an ambiguity error and exit 1.
+ */
+async function writeModuleModelFixture(dir: string): Promise<void> {
+  await mkdir(join(dir, 'modules/billing/app/Models'), { recursive: true })
+  await mkdir(join(dir, 'modules/billing/db'), { recursive: true })
+  await writeFile(
+    join(dir, 'modules/billing/db/schema.ts'),
+    `import { pgTable, serial, text } from 'drizzle-orm/pg-core'
+
+export const users = pgTable('billing_users', {
+  id: serial('id'),
+  plan: text('plan'),
+})
+`,
+    'utf8',
+  )
+  await writeFile(
+    join(dir, 'modules/billing/app/Models/User.ts'),
     `import { defineModel } from '@guren/orm'
 import { users } from '../../db/schema.js'
 
@@ -112,6 +200,126 @@ describe('context entity argument', () => {
       expect(exitCode).toBe(0)
       expect(stdout).toContain('# Project Context')
       expect(stdout).not.toContain('## Model — app/Models/User.ts')
+      expect(stdout).not.toContain('## Model — app/Models/Post.ts')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('takes the last value of a repeated --entity instead of crashing on the array', async () => {
+    const workspace = await createTempWorkspace('guren-cli-context-flag-repeated-')
+    try {
+      await writeModelFixture(workspace.dir)
+
+      // citty hands a twice-passed `string` arg back as `string[]`, which
+      // `generateEntityContext()` reached with `entityName.toLowerCase is not a
+      // function` — exit 1, no bundle. Naming a different entity first pins the
+      // half a same-value repeat cannot see: last wins, not first.
+      const { exitCode, stdout } = await runBin(
+        ['context', '--entity', 'Post', '--entity', 'User'],
+        workspace.dir,
+      )
+
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('## Model — app/Models/User.ts')
+      expect(stdout).not.toContain('app/Models/Post.ts')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('takes the last value of a repeated --module', async () => {
+    const workspace = await createTempWorkspace('guren-cli-context-module-repeated-')
+    try {
+      await writeModelFixture(workspace.dir)
+      await writeModuleModelFixture(workspace.dir)
+
+      // The array shape does not crash here, it compares: `['billing', 'app']`
+      // matches no model's location, so this used to exit 1 reporting `User`
+      // missing from a module named `billing,app`. Two `User`s, and two
+      // different values, so neither dropping the flag (ambiguity, exit 1) nor
+      // taking the first (the module's `User`) can reach this assertion.
+      const { exitCode, stdout } = await runBin(
+        ['context', '--module', 'billing', '--module', 'app', 'User'],
+        workspace.dir,
+      )
+
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('## Model — app/Models/User.ts')
+      expect(stdout).not.toContain('modules/billing/app/Models/User.ts')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('takes the last value of a repeated --routes, which exited 0 reporting no routes', async () => {
+    const workspace = await createTempWorkspace('guren-cli-context-routes-repeated-')
+    try {
+      await writeModelFixture(workspace.dir)
+      await writeRoutesFixture(workspace.dir)
+
+      const single = await runBin(['context', '--routes', CUSTOM_ROUTES_FILE, 'User'], workspace.dir)
+      const repeated = await runBin(
+        ['context', '--routes', CUSTOM_ROUTES_FILE, '--routes', CUSTOM_ROUTES_FILE, 'User'],
+        workspace.dir,
+      )
+
+      // Asserted against the single-flag run rather than a literal: this is the
+      // one shape here that never crashed, so the only evidence it was wrong is
+      // that repeating the flag changed the answer. It used to print
+      // `## Routes (0)` / `No routes reference this entity.` and exit 0.
+      expect(single.exitCode).toBe(0)
+      expect(single.stdout).toContain('## Routes (1)')
+      expect(repeated.exitCode).toBe(0)
+      // Both assertions on purpose: equality alone would also hold if the two
+      // runs regressed together to `## Routes (0)`.
+      expect(repeated.stdout).toContain('## Routes (1)')
+      expect(repeated.stdout).toBe(single.stdout)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('takes the last value of a repeated --app, which threw inside resolve()', async () => {
+    const workspace = await createTempWorkspace('guren-cli-context-app-repeated-')
+    try {
+      await writeModelFixture(workspace.dir)
+
+      // Run from the parent so `--app` is doing the work rather than agreeing
+      // with the cwd, and point the first value somewhere with no models: only
+      // last-wins reaches a bundle at all. Before the fix this exited 1 on
+      // `The "paths[0]" property must be of type string, got array`.
+      const parent = dirname(workspace.dir)
+      const leaf = basename(workspace.dir)
+      const { exitCode, stdout } = await runBin(
+        ['context', '--app', parent, '--app', leaf, 'User'],
+        parent,
+      )
+
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('## Model — app/Models/User.ts')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('takes the last value of a repeated --json, which every array made truthy', async () => {
+    const workspace = await createTempWorkspace('guren-cli-context-json-repeated-')
+    try {
+      await writeModelFixture(workspace.dir)
+
+      // A repeated boolean arrays too, and `Boolean([true, false])` is `true` —
+      // so this printed JSON, ignoring the half typed last. Only the `=value`
+      // spelling can say false, which is why a bare `--json --json` never
+      // exposed it.
+      const { exitCode, stdout } = await runBin(
+        ['context', '--json=true', '--json=false', 'User'],
+        workspace.dir,
+      )
+
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('# User')
+      expect(stdout.trimStart().startsWith('{')).toBe(false)
     } finally {
       await workspace.cleanup()
     }


### PR DESCRIPTION
## Summary

`guren context --entity User --entity User` exited 1 with `entityName.toLowerCase is not a function`.

citty types every argument as a scalar (`string | undefined`, `boolean`) and then hands it back as an **array** once the flag is passed twice. No compiler catches that, and `guren context` read all five of its own arguments straight through. Checking the rest of the command's arguments turned up four more failures, each with a different symptom:

| Repeated flag | Behavior before this PR |
|---|---|
| `--entity User --entity User` | exit 1, `entityName.toLowerCase is not a function` |
| `--app . --app .` | exit 1, `The "paths[0]" property must be of type string, got array` |
| `--module app --module app` | exit 1, blaming a module named `app,app` |
| `--routes web.ts --routes web.ts` | **exit 0**, entity's routes reported as none |
| `--json=true --json=false` | **exit 0**, printed JSON |

Every row was measured by stashing the fix and running the real bin, not inferred.

The two that exit 0 are the point of fixing all five rather than only the reported crash. `--routes` is the worst: the `resolve()` TypeError lands in the `catch` in `loadEntityRoutes` that exists to degrade a routes file the CLI genuinely cannot load, and the two are indistinguishable there. An agent consuming the bundle is simply told the entity has no routes.

`--json` is the one that reads as safe and is not. `Boolean(args.json)` was already there and looked fine, but every array is truthy, so `--json=false --json=false` turns *off* into *on*. Only the `=value` spellings can express a false, which is why a bare `--json --json` never exposed it.

`lastFlagValue()` already existed for `make:migration` (#465); this applies it to the four string arguments and adds `lastBooleanFlag()` for the boolean. Last-wins is what repeating a flag means to whoever typed it.

## Scope

- `cli` — `packages/cli/src/bin.ts` (the `context` command; `lastFlagValue`'s doc comment, plus the new `lastBooleanFlag`)
- `cli` — `packages/cli/tests/context-entity-arg.test.ts`
- changeset (`@guren/cli`, patch)

No behavior change for any single-flag invocation. `make:migration` is untouched.

## Risk Assessment

Low. Each argument is narrowed at the command boundary; nothing downstream changed. Someone relying on `--json=false --json=false` printing JSON would notice, which is the bug.

The remaining ~86 `type: 'string'` arguments elsewhere in `bin.ts` have the same exposure and are deliberately **not** touched here — that is a separate sweep, not a fix to bury in this diff.

## Validation

```
bun run build      exit 0
bun run typecheck  exit 0
bun run test       exit 0   4640 pass / 0 fail (4724 tests, 276 files)
```

Five regression tests added, all driving the real bin through the existing `runBin` helper. Mutation matrix — each column is a deliberately broken implementation, showing which tests go red:

| Mutation | Tests that fail |
|---|---|
| Fix removed entirely | all 5 new tests |
| First-wins (`value.at(0)`) | entity, module, app, json |
| `--module` ignored | module only |
| `--routes` ignored | routes only |
| `--app` ignored | app only |

Two fixture details exist to keep tests from passing vacuously: the routes fixture is written to `routes/custom.ts`, not the default `routes/web.ts` (otherwise dropping `--routes` finds the same file anyway), and the module test adds a second `User` under `modules/billing/` so `--module` has something to decide.

`--routes` is the one case first-wins cannot distinguish — both values name the same file — which is why it asserts the repeated run's output equals the single-flag run's, with a direct `## Routes (1)` assertion on both so a shared regression to `## Routes (0)` cannot pass.

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test`

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation. — no user-facing docs describe repeated flags; the rationale lives in the two helpers' doc comments.
