### PR TITLE
Deprecate the class-based seeder API

### DIFF
--- a/.changeset/deprecate-class-seeder-convention.md
+++ b/.changeset/deprecate-class-seeder-convention.md
@@ -1,0 +1,21 @@
+---
+"@guren/server": minor
+"@guren/cli": minor
+"@guren/core": patch
+---
+
+### Deprecated
+
+- **Class-based seeder API (`BaseSeeder` / `Seeder`, `SeederRunner`, `createSeederRunner`, `resetCalledSeeders`, and the `SeederClass` / `SeederInterface` / `SeederRunnerOptions` types)** — Write seeders with `defineSeeder` instead. Deprecated in 2.9.0, will be removed in 3.0.0. Detected by `bunx guren upgrade --check-only` as `seeder-class-convention`.
+
+A seeder class is not itself unsupported. `db:seed` loads seeders through `runSeeders()`, which accepts a `defineSeeder` handler, an exported `seed`/`run`/`Seeder`, or a default export — including an exported class whose prototype has a `run` method, which it constructs and calls as `run({ db })`. That last shape is deliberate: `packages/orm/tests/seeder.test.ts` covers it as "supports class-based seeders with run method".
+
+What `BaseSeeder` gets wrong is the signature it imposes. Its `run()` is declared to take no parameters, so it hides the one argument a seeder needs. A subclass cannot simply correct that: declaring `run(ctx: SeederContext)` fails to compile against the base (`TS2416: Target signature provides too few arguments. Expected 1 or more, but got 0`). Widening it to an optional `run(ctx?: SeederContext)` does compile, but then the subclass must handle a missing context, and that case is real: `call()`, `callOnce()`, `callMany()` and `callParallel()` construct child seeders and invoke `run()` with no arguments at all, so a parent that received a context cannot pass it down. The result is a seeder that is counted as having run while its context handling is left to chance.
+
+`SeederRunner` is the orchestration those classes were written for, and no Guren command reaches it. It runs a single seeder per call — a class passed in, a name registered with `register()`, or a name resolved to `<seedersPath>/<Name>.ts` defaulting to `DatabaseSeeder` — constructing it with `new` and invoking `.run()` with no context. `db:seed` does none of that; it runs every seeder in the folder.
+
+Nothing is removed and no existing call changes its result. This adds `@deprecated` JSDoc naming the replacement, a once-per-process runtime warning from the `BaseSeeder` and `SeederRunner` constructors, and a `seeder-class-convention` entry in the deprecation registry so `bunx guren upgrade --check-only` reports affected files. No codemod ships with it: the migration moves a class body into a handler and has to resolve how each `call()`/`callOnce()` child receives `db`, which is not a mechanical rewrite.
+
+These exports are re-exported from `@guren/core`, which makes them Stable under `contributing/api-stability.md`, so the deprecation policy's minimum of two minor versions applies before removal. Deprecated in 2.9.0, that permits removal from 2.11.0 onward: `removedIn` targets 3.0.0 on the assumption that 3.0.0 follows 2.11.0, which is also what keeps this removal in the same batch as `local-disk-per-object-visibility`. If 3.0.0 is cut earlier than that, this entry moves to the following major rather than being removed early.
+
+The sibling `BaseFactory` / `Factory` / `defineFactory` exports live in the same directory and are deliberately untouched — `make:factory` scaffolds `class …Factory extends Factory<typeof Model>`, `Factory` being the `BaseFactory` alias.

--- a/.claude/skills/guren-api/SKILL.md
+++ b/.claude/skills/guren-api/SKILL.md
@@ -396,8 +396,12 @@ Source: `packages/server/src/http/resources/`
 Source: `packages/server/src/database/`
 
 - `Factory.ts` — Model factory for testing
-- `Seeder.ts` — Database seeder
-- `SeederRunner.ts` — Seeder execution
+- `Seeder.ts` — `BaseSeeder`/`Seeder`, deprecated in 2.9.0 (removed in 3.0.0)
+- `SeederRunner.ts` — deprecated in 2.9.0 (removed in 3.0.0), wired to no command
+
+Seeding itself does not live here. `db:seed` runs every seeder in the folder
+through `runSeeders()` in `packages/orm/src/seeder.ts`, and seeders are written
+with `defineSeeder`.
 
 ### Logging
 Source: `packages/server/src/logging/`

--- a/docs/en/guides/upgrading.md
+++ b/docs/en/guides/upgrading.md
@@ -13,7 +13,15 @@ bun install
 bunx guren codegen
 ```
 
-4. Run validations:
+4. Check the project for deprecated API usage:
+
+```bash
+bunx guren upgrade --check-only
+```
+
+Each finding names the version the API was deprecated in, the version it is removed in, the replacement to move to, and the files that use it. Nothing is written to disk.
+
+5. Run validations:
 
 ```bash
 bun run build
@@ -21,7 +29,7 @@ bun run typecheck
 bun run test
 ```
 
-5. Apply migration notes for your source/target versions.
+6. Apply migration notes for your source/target versions.
 
 ## Migration Notes
 

--- a/docs/ja/guides/upgrading.md
+++ b/docs/ja/guides/upgrading.md
@@ -13,7 +13,15 @@ bun install
 bunx guren codegen
 ```
 
-4. 検証実行
+4. 非推奨APIの使用箇所を確認
+
+```bash
+bunx guren upgrade --check-only
+```
+
+非推奨化されたバージョン、削除予定バージョン、置き換え先、使用しているファイルが項目ごとに表示されます。ファイルへの書き込みは行いません。
+
+5. 検証実行
 
 ```bash
 bun run build
@@ -21,7 +29,7 @@ bun run typecheck
 bun run test
 ```
 
-5. 対象バージョンの移行メモを適用
+6. 対象バージョンの移行メモを適用
 
 ## 移行メモ
 

--- a/packages/cli/src/deprecations.ts
+++ b/packages/cli/src/deprecations.ts
@@ -6,7 +6,7 @@
  */
 import { readFile } from 'node:fs/promises'
 import { relative } from 'node:path'
-import { discoverAppSourceFiles, discoverModelFiles } from './discovery'
+import { discoverAppSourceFiles, discoverDbArtifactFiles, discoverModelFiles } from './discovery'
 import { extractClassDeclaration, findStaticClassProperty } from './model-parser'
 import { parseSourceFile } from './parse-cache'
 
@@ -69,6 +69,45 @@ async function detectLocalVisibilityCalls(cwd: string): Promise<string[]> {
   return affected.filter((file): file is string => file !== null)
 }
 
+/**
+ * Files that import the class-based seeder API rather than `defineSeeder`.
+ *
+ * Text search over the import statement, not the AST: what identifies the
+ * deprecation is the specifier list on an import from `@guren/core`, and a
+ * subclass of it can sit in any file the app puts code in. `@guren/server` is
+ * matched too — the core-first rule says not to import from it, but an app
+ * that already does is exactly the one this needs to reach.
+ *
+ * `defineSeeder` ends in the same six letters as `Seeder`, so the specifier is
+ * matched on its own word boundaries; a file that imports only `defineSeeder`
+ * is the supported case and must not be reported.
+ */
+const SEEDER_CLASS_SPECIFIERS = /\b(?:BaseSeeder|SeederRunner|createSeederRunner|resetCalledSeeders|Seeder|SeederClass|SeederInterface|SeederRunnerOptions)\b/
+const GUREN_IMPORT = /import\s+(?:type\s+)?\{([^}]*)\}\s*from\s*['"]@guren\/(?:core|server)['"]/g
+
+async function detectSeederClassImports(cwd: string): Promise<string[]> {
+  const files = [
+    ...(await discoverAppSourceFiles(cwd)),
+    ...(await discoverDbArtifactFiles(cwd, 'Seeder')),
+  ]
+  const affected = await Promise.all(
+    files.map(async (filePath) => {
+      const source = await readFile(filePath, 'utf-8')
+      for (const match of source.matchAll(GUREN_IMPORT)) {
+        const specifiers = match[1]
+          .split(',')
+          .map((part) => part.split(/\bas\b/)[0].replace(/^\s*type\s+/, '').trim())
+          .filter(Boolean)
+        if (specifiers.some((name) => SEEDER_CLASS_SPECIFIERS.test(name))) {
+          return relative(cwd, filePath)
+        }
+      }
+      return null
+    }),
+  )
+  return affected.filter((file): file is string => file !== null)
+}
+
 export const deprecations: Deprecation[] = [
   {
     id: 'model-guarded',
@@ -100,6 +139,17 @@ export const deprecations: Deprecation[] = [
       + 'serves it, so these calls have never done anything. Declare the disk\'s "visibility" option to match '
       + 'what it is, and keep restricted files on a disk that is not served.',
     detect: detectLocalVisibilityCalls,
+  },
+  {
+    id: 'seeder-class-convention',
+    what: 'Class-based seeder API (BaseSeeder/Seeder, SeederRunner, createSeederRunner)',
+    since: '2.9.0',
+    removedIn: '3.0.0',
+    replacement:
+      "Write seeders with defineSeeder from '@guren/core' — its handler receives the { db } context "
+      + 'that BaseSeeder.run() is declared not to take, and `db:seed` runs every seeder in the folder, '
+      + 'so the SeederRunner orchestration (which no Guren command reaches) is not needed.',
+    detect: detectSeederClassImports,
   },
 ]
 

--- a/packages/cli/templates/agent/core/skills/guren-api/SKILL.md
+++ b/packages/cli/templates/agent/core/skills/guren-api/SKILL.md
@@ -454,8 +454,11 @@ Source: `packages/server/src/http/resources/`
 Source: `packages/server/src/database/`
 
 - `Factory.ts` — Model factory for testing
-- `Seeder.ts` — Database seeder
-- `SeederRunner.ts` — Seeder execution
+- `Seeder.ts` — `BaseSeeder`/`Seeder`, deprecated in 2.9.0 (removed in 3.0.0)
+- `SeederRunner.ts` — deprecated in 2.9.0 (removed in 3.0.0), wired to no command
+
+Seeding itself does not live here. `db:seed` runs every seeder in `db/seeders/`,
+and seeders are written with `defineSeeder` from `@guren/core`.
 
 ### Logging
 Source: `packages/server/src/logging/`

--- a/packages/cli/tests/upgrade.test.ts
+++ b/packages/cli/tests/upgrade.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, afterEach, describe, expect, it, mock, spyOn } from 'bun:test'
-import { readFile, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 import { createTempWorkspace, type TempWorkspace } from './helpers'
 import { upgradeCanary, checkVersionCompatibility } from '../src/upgrade'
 import { findApplicableCodemods, compareVersions, codemods, type Codemod } from '../src/codemods'
@@ -568,5 +568,52 @@ describe('checkDeprecations', () => {
   it('returns empty array when no deprecations are registered', async () => {
     const result = await checkDeprecations(workspace.dir)
     expect(result).toHaveLength(0)
+  })
+
+  describe('seeder-class-convention', () => {
+    async function writeFileIn(relativePath: string, contents: string): Promise<void> {
+      const target = join(workspace.dir, relativePath)
+      await mkdir(dirname(target), { recursive: true })
+      await writeFile(target, contents)
+    }
+
+    function seederWarning(warnings: Awaited<ReturnType<typeof checkDeprecations>>) {
+      return warnings.find((warning) => warning.id === 'seeder-class-convention')
+    }
+
+    it('reports files importing the class-based seeder API', async () => {
+      await writeFileIn(
+        'db/seeders/LegacyUserSeeder.ts',
+        "import { Seeder } from '@guren/core'\nexport default class LegacyUserSeeder extends Seeder {\n  async run(): Promise<void> {}\n}\n",
+      )
+      await writeFileIn(
+        'app/Services/Runner.ts',
+        "import { createSeederRunner } from '@guren/core'\nexport const runner = createSeederRunner()\n",
+      )
+
+      const warning = seederWarning(await checkDeprecations(workspace.dir))
+
+      expect(warning).toBeDefined()
+      expect(warning?.affectedFiles.sort()).toEqual([
+        join('app', 'Services', 'Runner.ts'),
+        join('db', 'seeders', 'LegacyUserSeeder.ts'),
+      ])
+    })
+
+    // The negative case is the one that rots silently: `defineSeeder` ends in
+    // the same six letters as `Seeder`, so a detector matching the specifier
+    // as a substring would report every correctly written seeder in the app.
+    it('does not report a seeder written with defineSeeder', async () => {
+      await writeFileIn(
+        'db/seeders/001_users.ts',
+        "import { defineSeeder } from '@guren/core'\nexport default defineSeeder(async ({ db }) => { void db })\n",
+      )
+      await writeFileIn(
+        'app/Services/Seeding.ts',
+        "import { defineSeeder, runSeeders } from '@guren/core'\nexport const helpers = [defineSeeder, runSeeders]\n",
+      )
+
+      expect(seederWarning(await checkDeprecations(workspace.dir))).toBeUndefined()
+    })
   })
 })

--- a/packages/server/src/database/Seeder.ts
+++ b/packages/server/src/database/Seeder.ts
@@ -1,4 +1,5 @@
 import type { SeederClass } from './types'
+import { warnOnce } from '../support/warn-once'
 
 /**
  * Track which seeders have been called with callOnce.
@@ -7,6 +8,10 @@ const calledSeeders = new Set<string>()
 
 /**
  * Reset called seeders tracking (for testing).
+ *
+ * @deprecated Bookkeeping for {@link BaseSeeder}'s `callOnce`. Write seeders
+ * with `defineSeeder` from `@guren/core` instead, which needs no such
+ * tracking. Deprecated in 2.9.0, removed in 3.0.0.
  */
 export function resetCalledSeeders(): void {
   calledSeeders.clear()
@@ -14,15 +19,55 @@ export function resetCalledSeeders(): void {
 
 /**
  * Abstract base class for database seeders.
+ *
+ * @deprecated Write seeders with `defineSeeder` from `@guren/core` instead.
+ * Deprecated in 2.9.0, removed in 3.0.0.
+ *
+ * A seeder class is not itself the problem: `db:seed` loads every seeder
+ * through `runSeeders()`, which does accept an exported class whose prototype
+ * has a `run` method, constructs it, and calls `run({ db })`. What this base
+ * class gets wrong is the signature it imposes on that method. `run()` is
+ * declared to take no parameters, so it hides the one argument a seeder
+ * needs.
+ *
+ * A subclass cannot simply correct that: declaring `run(ctx: SeederContext)`
+ * fails to compile against the base (`TS2416: Target signature provides too
+ * few arguments. Expected 1 or more, but got 0`). Widening it to an optional
+ * `run(ctx?: SeederContext)` does compile, but then the subclass has to handle
+ * a missing context — and that case is real, because
+ * {@link BaseSeeder.call}, {@link BaseSeeder.callOnce},
+ * {@link BaseSeeder.callMany} and {@link BaseSeeder.callParallel} construct
+ * child seeders and invoke `run()` with no arguments at all. A parent that
+ * received a context cannot pass it down.
+ *
+ * The orchestration these classes were written for, `SeederRunner`, is
+ * reached by no Guren command.
  */
 export abstract class BaseSeeder {
+  constructor() {
+    warnOnce(
+      'seeder-class-convention:base-seeder',
+      '[guren] Deprecation (seeder-class-convention): BaseSeeder/Seeder is deprecated\n'
+        + '  since 2.9.0, will be removed in 3.0.0.\n'
+        + "  Write seeders with defineSeeder from '@guren/core': its handler receives { db }, "
+        + 'which BaseSeeder.run() is declared not to take.',
+    )
+  }
+
   /**
    * Run the seeder.
+   *
+   * Declared without parameters, which is what makes this class the wrong
+   * base: `runSeeders()` calls it with a `{ db }` context that this signature
+   * cannot name.
    */
   abstract run(): Promise<void>
 
   /**
    * Call another seeder.
+   *
+   * No context is forwarded: the child's `run()` is invoked with no
+   * arguments, whatever the caller itself received.
    */
   protected async call(SeederClass: SeederClass): Promise<void> {
     const seeder = new SeederClass()
@@ -65,5 +110,8 @@ export abstract class BaseSeeder {
 
 /**
  * Alias for BaseSeeder.
+ *
+ * @deprecated Write seeders with `defineSeeder` from `@guren/core` instead.
+ * Deprecated in 2.9.0, removed in 3.0.0. See {@link BaseSeeder}.
  */
 export { BaseSeeder as Seeder }

--- a/packages/server/src/database/SeederRunner.ts
+++ b/packages/server/src/database/SeederRunner.ts
@@ -1,16 +1,38 @@
 import { join } from 'node:path'
 import { existsSync } from 'node:fs'
 import type { SeederClass, SeederRunnerOptions } from './types'
+// Deprecated alongside this runner: the two halves of the same convention.
 import { resetCalledSeeders } from './Seeder'
+import { warnOnce } from '../support/warn-once'
 
 /**
  * Seeder runner for executing database seeders.
+ *
+ * @deprecated No Guren command reaches this runner. Write seeders with
+ * `defineSeeder` from `@guren/core` and run them with `db:seed`. Deprecated
+ * in 2.9.0, removed in 3.0.0.
+ *
+ * `db:seed` seeds by loading the seeders folder through `runSeeders()`, which
+ * runs every seeder it finds there and hands each one a `{ db }` context. This
+ * runner orchestrates differently: it runs a single seeder per call, taken
+ * from a class passed in, a name registered with {@link SeederRunner.register},
+ * or a name resolved to `<seedersPath>/<Name>.ts` and defaulting to
+ * `DatabaseSeeder`; it constructs it with `new` and invokes `.run()` with no
+ * context. Nothing in the framework calls any of it. See {@link BaseSeeder}
+ * for what the no-context `run()` costs a seeder written against it.
  */
 export class SeederRunner {
   private options: Required<SeederRunnerOptions>
   private seeders: Map<string, SeederClass> = new Map()
 
   constructor(options: SeederRunnerOptions = {}) {
+    warnOnce(
+      'seeder-class-convention:seeder-runner',
+      '[guren] Deprecation (seeder-class-convention): SeederRunner is deprecated\n'
+        + '  since 2.9.0, will be removed in 3.0.0.\n'
+        + "  No Guren command runs it. Write seeders with defineSeeder from '@guren/core' "
+        + 'and run them with `guren db:seed`.',
+    )
     this.options = {
       seedersPath: options.seedersPath ?? 'db/seeders',
       defaultSeeder: options.defaultSeeder ?? 'DatabaseSeeder',
@@ -146,6 +168,10 @@ export class SeederRunner {
 
 /**
  * Create a seeder runner.
+ *
+ * @deprecated No Guren command reaches this runner. Write seeders with
+ * `defineSeeder` from `@guren/core` instead. Deprecated in 2.9.0, removed in
+ * 3.0.0. See {@link SeederRunner}.
  */
 export function createSeederRunner(options?: SeederRunnerOptions): SeederRunner {
   return new SeederRunner(options)

--- a/packages/server/src/database/types.ts
+++ b/packages/server/src/database/types.ts
@@ -1,5 +1,9 @@
 /**
  * Seeder class interface.
+ *
+ * @deprecated The constructor shape `BaseSeeder` and `SeederRunner` expect.
+ * Write seeders with `defineSeeder` from `@guren/core` instead. Deprecated in
+ * 2.9.0, removed in 3.0.0.
  */
 export interface SeederClass {
   new (): Seeder
@@ -7,6 +11,12 @@ export interface SeederClass {
 
 /**
  * Abstract seeder interface.
+ *
+ * Exported from the package root as `SeederInterface`.
+ *
+ * @deprecated The no-context `run()` shape `BaseSeeder` imposes. Write seeders
+ * with `defineSeeder` from `@guren/core` instead, whose handler is typed to
+ * receive `{ db }`. Deprecated in 2.9.0, removed in 3.0.0.
  */
 export interface Seeder {
   run(): Promise<void>
@@ -32,6 +42,10 @@ export interface Factory<T> {
 
 /**
  * Seeder runner options.
+ *
+ * @deprecated Options for `SeederRunner`, which no Guren command reaches.
+ * Write seeders with `defineSeeder` from `@guren/core` and run them with
+ * `db:seed`. Deprecated in 2.9.0, removed in 3.0.0.
  */
 export interface SeederRunnerOptions {
   /**

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -511,6 +511,15 @@ export type {
   RegisteredTranslationKey,
 } from './i18n'
 // Database (Seeder & Factory)
+// The seeder half is deprecated (`seeder-class-convention`, registered in
+// `packages/cli/src/deprecations.ts`): `BaseSeeder`/`Seeder`/
+// `resetCalledSeeders`/`SeederRunner`/`createSeederRunner`, and the
+// `SeederClass`/`SeederInterface`/`SeederRunnerOptions` types below. Seeding
+// goes through `runSeeders()`/`defineSeeder`; `runSeeders()` does accept a
+// seeder class, but not one whose `run()` is declared to take no context, and
+// no command reaches `SeederRunner` at all. Removal is 3.0.0, which
+// `audit:core-semver` will hold until a `@guren/core` major is declared
+// alongside it. The factory half is live: `make:factory` scaffolds against it.
 export {
   BaseSeeder,
   Seeder,


### PR DESCRIPTION
## Summary

`BaseSeeder`/`Seeder`, `SeederRunner`, `createSeederRunner`, `resetCalledSeeders` and the `SeederClass`/`SeederInterface`/`SeederRunnerOptions` types carry a seeder convention the framework does not use. They were added in the v1.0-alpha commit, are wired to no command, and are reachable only as published exports of `@guren/server` (re-exported by `@guren/core`) and from their own test.

A seeder class is not itself unsupported. `db:seed` loads seeders through `runSeeders()`, which accepts an exported class whose prototype has a `run` method, constructs it, and calls `run({ db })` — `packages/orm/tests/seeder.test.ts` covers that shape deliberately, as "supports class-based seeders with run method".

What `BaseSeeder` gets wrong is the signature it imposes. Its `run()` is declared to take no parameters, so a subclass cannot name the one argument a seeder needs:

- `run(ctx: SeederContext)` fails to compile against the base — `TS2416: Target signature provides too few arguments. Expected 1 or more, but got 0`.
- `run(ctx?: SeederContext)` does compile, but then the subclass has to handle a missing context, and that case is real: `call()`, `callOnce()`, `callMany()` and `callParallel()` construct child seeders and invoke `run()` with no arguments at all, so a parent that received a context cannot pass it down.

`SeederRunner`, the orchestration those classes were written for, is reached by nothing. It runs a single seeder per call — a class passed in, a name registered with `register()`, or a name resolved to `<seedersPath>/<Name>.ts` defaulting to `DatabaseSeeder` — and invokes `.run()` with no context. `db:seed` does none of that; it runs every seeder in the folder.

Removing the exports would major `@guren/server` and, through `audit:core-semver`, `@guren/core` — a release decision rather than a consistency fix. This PR follows `contributing/deprecation-policy.md` instead:

1. `@deprecated` JSDoc on all eight symbols, naming `defineSeeder` as the replacement.
2. A once-per-process `warnOnce` from the `BaseSeeder` and `SeederRunner` constructors.
3. A `seeder-class-convention` entry in `packages/cli/src/deprecations.ts`, so `bunx guren upgrade --check-only` reports affected files.
4. A changeset written as a `### Deprecated` section.

No codemod ships with it: the migration moves a class body into a handler and has to resolve how each `call()`/`callOnce()` child receives `db`, which is not a mechanical rewrite.

A second commit fixes the references that still pointed readers at the deprecated API:

- **Both `guren-api` skill copies** listed `SeederRunner.ts` as "Seeder execution". That was already wrong before this deprecation — seeding runs through `runSeeders()`, not through a file no command reaches — and an agent asked how to write a seeder was sent to the class API with `defineSeeder` mentioned nowhere. Both files are now marked, and the section says where seeding happens. The template copy names `db/seeders/` instead of a `packages/` path, since it ships into apps where the framework tree does not exist.
- **`docs/{en,ja}/guides/upgrading.md`** never mentioned `guren upgrade --check-only` in its required workflow, so the deprecation registry — the mechanism by which any registered deprecation reaches an existing app — was invisible to anyone following the documented steps. It is now its own step in both languages.

`docs/{en,ja}/guides/database.md` needed no change: both already teach `defineSeeder` and never mention the class API. No `## Migration Notes` entry either — that section documents migrations at the version boundary where they bite, and 3.0.0 does not exist yet, so it belongs to the removal.

## Scope

- `server` — JSDoc and runtime warnings in `src/database/{Seeder,SeederRunner,types}.ts`, plus a maintainer note at the export site.
- `cli` — deprecation registry entry, detector, tests, and the agent-harness `guren-api` skill template.
- `docs` — upgrade guides (en/ja) and the workspace `guren-api` skill.
- Changeset: `@guren/server` minor, `@guren/cli` minor, `@guren/core` patch.

## Risk Assessment

Nothing is removed and no existing call changes its result. The only behavioral change is the once-per-process `console.warn` emitted when a `BaseSeeder` subclass or a `SeederRunner` is constructed.

Version planning: these exports reach `@guren/core`, which makes them Stable under `contributing/api-stability.md`, so the policy's minimum of two minor versions applies before removal. Deprecated in 2.9.0, that permits removal from 2.11.0 onward. `removedIn` targets 3.0.0 on the assumption that 3.0.0 follows 2.11.0, which also keeps this removal in the same batch as `local-disk-per-object-visibility`. **If 3.0.0 is cut earlier than 2.11.0, this entry moves to the following major rather than being removed early.**

`BaseFactory`/`Factory`/`defineFactory` live in the same directory but are deliberately untouched — they are live API, and `make:factory` scaffolds `class …Factory extends Factory<typeof Model>`, `Factory` being the `BaseFactory` alias.

The detector matches import specifiers on word boundaries because `defineSeeder` ends in the same six letters as `Seeder`; a substring match would report every correctly written seeder in an app. Both the positive and the negative case are tested, and the negative test was confirmed to fail when the word boundaries are removed.

## Validation

- `bun run build` — succeeded; `@deprecated` and the removal version are present in `packages/server/dist/database/{Seeder,SeederRunner,types}.d.ts`, and reach `@guren/core` consumers through its `export * from '@guren/server'`.
- `bun run typecheck` — clean.
- `bun run test:bun` — 4628 pass, 0 fail (4712 across 276 files).
- `bun run test:examples` — all pass.
- `bun run audit:core-semver` / `audit:core-first` / `audit:docs` / `audit:contracts` / `audit:starter-template` — all pass.
- `bun run smoke:starter` — 18 passed, 0 failures. `bun run smoke:starter:api` — 4 passed, 0 failures. (Obliged by the `packages/cli/templates/**` change.)
- `bunx guren upgrade --check-only` against a fixture app reports the entry with its affected files, and reports nothing for an app whose seeders use `defineSeeder`.

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test`

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
