### PR TITLE
ci: gate agent-catalog inputs on pushes to main, not just PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,22 +133,71 @@ jobs:
       # manifest conforms, and — because the plugin's version is the CLI's — a
       # change to any catalog input carries a @guren/cli changeset.
       #
-      # The changeset gate diffs against the PR's base *SHA* from the event
-      # payload, fetched by SHA into a named ref: on a shallow checkout there
-      # is no refs/remotes/origin/<base>, `git fetch origin <branch>` only
-      # updates FETCH_HEAD, and HEAD on a pull_request run is the synthetic
-      # merge commit, so a deepen loop keyed on either guesses. A two-dot diff
-      # (base..HEAD) needs no merge base. On `push` to main there is no base
-      # to gate against, so only the derived-fact rules run there; the gate
-      # already fired on the PR that merged.
+      # The changeset gate diffs against a base *SHA* from the event payload,
+      # fetched by SHA into a named ref: on a shallow checkout there is no
+      # refs/remotes/origin/<base>, `git fetch origin <branch>` only updates
+      # FETCH_HEAD, and HEAD on a pull_request run is the synthetic merge
+      # commit, so a deepen loop keyed on either guesses. A two-dot diff
+      # (base..HEAD) needs no merge base.
+      #
+      # `push` carries its own base — `github.event.before`, the tip the push
+      # replaced — so it runs the same gate. Without it a commit landing on
+      # main skips the gate outright, and "the gate already fired on the PR
+      # that merged" only holds for commits that arrived through one.
+      #
+      # Two events have no base to gate against. Neither passes as if gated:
+      # the all-zero SHA a branch's first push carries, and a before-SHA the
+      # remote will not serve (force-pushed past, or garbage-collected). The
+      # derived-fact rules still run in each, and the audit's own closing line
+      # says "passed" — so the annotation that the gate did not run is emitted
+      # after it, where it is the last thing in the log rather than a line
+      # scrolled past above a pass.
+      #
+      # Ungating is only ever right for a base the remote genuinely cannot
+      # serve, and on the first attempt that is indistinguishable from a blip
+      # on the network or the ref lock — which would hand a real gap a green
+      # job. Retrying separates them: what survives three tries is the
+      # unremediable case, and no one can make a collected SHA fetchable again.
+      #
+      # The release commit stays green. `changeset version` empties .changeset
+      # and bumps versions; the only catalog input it moves is
+      # packages/cli/package.json, since the sync-template-deps pass that
+      # follows writes under packages/create-app/templates and never under
+      # packages/cli/templates. assertChangesetGate exempts a diff whose
+      # touched inputs are the CLI manifest alone, which is that commit — it
+      # reaches main as its own squash merge, so the push diff is that commit
+      # and nothing else.
       - name: Agent catalog audit
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             base_sha="${{ github.event.pull_request.base.sha }}"
-            git fetch --no-tags --depth=1 origin "$base_sha:refs/audit-base"
-            bun run audit:agent-catalog --base refs/audit-base
+          else
+            base_sha="${{ github.event.before }}"
+          fi
+          gate_ref=
+          skip_kind=
+          skip_reason=
+          if [ -z "$base_sha" ] || [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
+            skip_kind=notice
+            skip_reason="this event reports no previous tip, so there is no base commit to diff against"
+          else
+            for attempt in 1 2 3; do
+              if git fetch --no-tags --depth=1 origin "$base_sha:refs/audit-base"; then
+                gate_ref=refs/audit-base
+                break
+              fi
+              if [ "$attempt" -lt 3 ]; then sleep $((attempt * 5)); fi
+            done
+            if [ -z "$gate_ref" ]; then
+              skip_kind=warning
+              skip_reason="base $base_sha was not fetchable in 3 attempts (force-pushed past, or garbage-collected)"
+            fi
+          fi
+          if [ -n "$gate_ref" ]; then
+            bun run audit:agent-catalog --base "$gate_ref"
           else
             bun run audit:agent-catalog
+            echo "::${skip_kind}::agent-catalog: the derived-fact rules above passed, but THE CHANGESET GATE DID NOT RUN — ${skip_reason}. A catalog input changed without a @guren/cli changeset would not have been caught. This job being green is not that check passing."
           fi
 
       - name: Dependency audit


### PR DESCRIPTION
## Summary

The agent-catalog changeset gate ran only on `pull_request`. A commit reaching `main` any other way — a direct push, or a merge whose PR run predates the rule — skipped it entirely, and a catalog input changed without a `@guren/cli` changeset publishes a payload under a version every installed copy already has.

A push carries a base too: `github.event.before` is the tip it replaced. This fetches it by SHA into `refs/audit-base` exactly as the `pull_request` branch does and runs the same `--base` gate.

Two events have no usable base — the all-zero SHA of a branch's first push, and a before-SHA the remote will not serve after a force-push. Both run the derived-fact rules and skip only the changeset comparison. Failing there would be the worse trade: nobody can make a garbage-collected SHA fetchable again, so a red `main` in that case has no remedy. Neither skip is allowed to read as a pass — see Risk Assessment.

Stacked on #457, which introduces the step being extended.

## Scope

`.github/workflows/ci.yml` only — the `Agent catalog audit` step. No source, no templates, no package manifests. No changeset: `.github/` is not in `CATALOG_INPUTS` and no published package changes.

## Risk Assessment

**The release commit stays green.** This was the reason the change was split out of #457 rather than done there, so it is verified rather than assumed, and from the script side rather than from history — the historical version commits predate `packages/cli/templates/agent-catalog/` and could not have observed it:

- `version-packages` runs `changeset version` then `sync-template-deps --release`.
- `sync-template-deps` writes only the paths `templateManifests()` returns, which is rooted at `packages/create-app/templates` (`packages/create-app/src/blueprints.ts:25`). It cannot write under `packages/cli/templates`.
- So the only `CATALOG_INPUTS` entry a version commit moves is `packages/cli/package.json`, which `assertChangesetGate` already exempts via `touched.every(f => f === CLI_MANIFEST)`.
- That commit reaches `main` as its own squash merge, so the push diff is that commit and nothing else.

**A skipped gate cannot be mistaken for a passing one.** The audit's own closing line reads `agent-catalog audit passed (...)`. An annotation placed before it would scroll past and leave a pass with the last word, making the log indistinguishable from a gated run. The annotation is therefore emitted *after* the ungated audit — last in the log and in the run summary — and states that the gate did not run, why, and that a green job here is not that check passing. `::warning::` for an unfetchable base, `::notice::` for the all-zero case, which is structural rather than anomalous.

**A transient fetch failure does not ungate.** On one attempt, a base the remote genuinely cannot serve is indistinguishable from a blip on the network or the ref lock, and treating both alike would hand a real gap a green job on the strength of a transient error. The fetch is retried three times (5s, 10s) before the fallback is taken.

**`pull_request` behaviour is unchanged**, beyond gaining the same retry.

## Validation

Fetch-by-SHA at `--depth=1` into `refs/audit-base` plus the two-dot diff is not simulated — it is already proven on real CI by the `pull_request` path in run `32261472257`:

```
* [new ref]  685e918f81de8ce1c9d483fa614ae7c55b39ec57 -> refs/audit-base
agent-catalog audit passed the derived-fact rules (10 files rendered, changeset gate vs refs/audit-base)
```

The gate itself, exercised so that it could fail:

| Scenario | Expected | Result |
|---|---|---|
| `packages/cli/templates/agent-catalog/` touched, no `@guren/cli` changeset | red | red |
| `.changeset/*.md` emptied + `packages/cli/package.json` version bumped alone (the release shape) | green | green |

Every branch of the step run under GitHub's `bash -e {0}` against a stubbed `git`/`bun`, with the stub reproducing the audit's real closing line so log ordering is observable:

| Branch | Gate | Exit |
|---|---|---|
| `pull_request`, fetch ok | ran | 0 |
| push, fetch ok first try | ran | 0 |
| push, fails then ok on try 2 | ran | 0 |
| push, ok only on try 3 | ran | 0 |
| push, never fetchable | skipped, `::warning::` last | 0 |
| push, all-zero before | skipped, `::notice::` last | 0 |
| push, before empty | skipped, `::notice::` last | 0 |

Inverse checks: a failing audit exits non-zero on all three paths, and none of them prints the skip line — it would be a false claim about which check failed.

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test:bun` — 4633 pass, 84 skip, 0 fail (276 files)

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [ ] I added/updated tests for behavior changes — the change is workflow YAML, which `scripts/build-agent-catalog.test.ts` cannot reach. Verified by the matrices above instead.
- [x] I updated relevant documentation — the step's comment block, including the removal of the now-false "On `push` to main there is no base to gate against".
