### PR TITLE
fix(cli): settle a differently-cased managed file by identity, not by name

### DIFF
--- a/.changeset/agent-sync-prune-case-sensitive-fs.md
+++ b/.changeset/agent-sync-prune-case-sensitive-fs.md
@@ -1,0 +1,9 @@
+---
+"@guren/cli": patch
+---
+
+Let `agent:sync --prune` remove a stale managed file whose name differs from a planned one only by case.
+
+The stale scan compared paths case-insensitively, so that a case-preserving filesystem — where the write loop refreshes a planned file through a differently-cased directory entry it found on disk — would not classify the file it had just written as stale. On a case-sensitive filesystem those two names are two separate files: after a rename, `.claude/rules/ORM-MODELS.md` and `.claude/rules/orm-models.md` both exist, and the lowercased comparison hid the genuinely stale one from prune permanently.
+
+The scan now matches exact paths first, and for a case-only mismatch spares the entry only when it and the planned path are the same file on disk (same device and inode). A filesystem that cannot answer that question leaves the entry alone — neither reported nor deleted — rather than spending an irreversible delete on a claim it could not establish.

--- a/packages/cli/src/agent-harness.ts
+++ b/packages/cli/src/agent-harness.ts
@@ -186,13 +186,41 @@ async function detectInstalledComponents(
 }
 
 /**
+ * Do two app-relative paths name the same file on disk? Only ever asked about
+ * a pair that differs by case alone, where the path strings cannot answer it:
+ * on a case-insensitive filesystem the two are one directory entry the write
+ * loop has just refreshed through the casing it found, on a case-sensitive one
+ * they are two files and the unplanned casing is a genuine leftover. `bigint`
+ * because a Windows file ID is 64 bits and would not survive a `number` — two
+ * distinct NTFS files could compare equal and spare a real leftover.
+ *
+ * A failed `lstat` leaves the two indistinguishable, so it answers "same": the
+ * entry is left alone rather than deleted on a claim that could not be
+ * established. Nothing is lost by that on the one plausible path — a directory
+ * readable but not searchable lists its names and refuses to stat them, and
+ * `rm` would be refused there too.
+ */
+async function isSameFile(cwd: string, left: string, right: string): Promise<boolean> {
+  try {
+    const [leftStat, rightStat] = await Promise.all([
+      lstat(join(cwd, left), { bigint: true }),
+      lstat(join(cwd, right), { bigint: true }),
+    ])
+    return leftStat.dev === rightStat.dev && leftStat.ino === rightStat.ino
+  } catch {
+    return true
+  }
+}
+
+/**
  * Files inside the active components' managed namespaces that the current
  * plan does not write. Planned files (managed or user-owned) are excluded
  * via the full planned path set, so a future planner change cannot turn its
- * own output into a prune candidate. The comparison is case-insensitive: on
- * a case-preserving filesystem the write loop can refresh a planned file
- * through a differently-cased directory entry, and an exact match would then
- * classify the file it just wrote as stale.
+ * own output into a prune candidate. A scanned entry that matches a planned
+ * path by case alone is settled by `isSameFile` rather than by string — every
+ * planned path exists on disk once the write loop has run (it either wrote the
+ * file or skipped it because it was already there), so the identity check has
+ * both sides to compare.
  */
 async function findStaleManagedFiles(
   cwd: string,
@@ -200,7 +228,8 @@ async function findStaleManagedFiles(
   plan: readonly PlannedFile[],
   retiredSkills: readonly string[] | undefined,
 ): Promise<string[]> {
-  const plannedPathsLower = new Set(plan.map((file) => file.path.toLowerCase()))
+  const plannedPaths = new Set(plan.map((file) => file.path))
+  const plannedByLowerPath = new Map(plan.map((file) => [file.path.toLowerCase(), file.path]))
   const stale: string[] = []
 
   /**
@@ -254,9 +283,14 @@ async function findStaleManagedFiles(
         continue
       }
       const relPath = toPosixRelative(cwd, join(entry.parentPath, entry.name))
-      if (!plannedPathsLower.has(relPath.toLowerCase())) {
-        stale.push(relPath)
+      if (plannedPaths.has(relPath)) {
+        continue
       }
+      const caseAlias = plannedByLowerPath.get(relPath.toLowerCase())
+      if (caseAlias && (await isSameFile(cwd, relPath, caseAlias))) {
+        continue
+      }
+      stale.push(relPath)
     }
   }
 

--- a/packages/cli/tests/agent-harness.test.ts
+++ b/packages/cli/tests/agent-harness.test.ts
@@ -5,6 +5,25 @@ import { tmpdir } from 'node:os'
 import { installAgentHarness } from '../src/agent-harness'
 import { AGENT_TARGETS } from '../src/agent-targets'
 
+/**
+ * Whether `dir` lives on a case-insensitive filesystem. Probed rather than
+ * inferred from `process.platform`: macOS mounts case-sensitive volumes and
+ * Linux case-insensitive ones, and the behavior under test follows the
+ * filesystem the app was scaffolded on, not the OS running the test.
+ */
+async function filesystemIsCaseInsensitive(dir: string): Promise<boolean> {
+  const probe = join(dir, 'case-probe.tmp')
+  await writeFile(probe, '', 'utf8')
+  try {
+    await access(join(dir, 'CASE-PROBE.TMP'))
+    return true
+  } catch {
+    return false
+  } finally {
+    await rm(probe, { force: true })
+  }
+}
+
 describe('installAgentHarness', () => {
   let tempDir: string
 
@@ -505,10 +524,12 @@ describe('installAgentHarness', () => {
     expect(await readFile(join(tempDir, 'shared-rules/legacy.md'), 'utf8')).toBe('external\n')
   })
 
-  it('sync --prune spares a planned file reached through a differently-cased entry', async () => {
+  it('sync --prune settles a differently-cased entry by identity, not by name', async () => {
     await installAgentHarness({ cwd: tempDir, mode: 'init' })
-    // case-preserving filesystems keep this entry name while the write loop
-    // refreshes the planned lowercase path through it
+    const caseInsensitive = await filesystemIsCaseInsensitive(tempDir)
+    // what a case-only rename of a managed rule leaves behind: one directory
+    // entry on a case-insensitive filesystem, two distinct files on a
+    // case-sensitive one, so the two branches assert opposite outcomes
     await rename(
       join(tempDir, '.claude/rules/orm-models.md'),
       join(tempDir, '.claude/rules/ORM-MODELS.md'),
@@ -516,8 +537,15 @@ describe('installAgentHarness', () => {
 
     const result = await installAgentHarness({ cwd: tempDir, mode: 'sync', prune: true })
 
-    expect(result.stale).not.toContain('.claude/rules/ORM-MODELS.md')
+    // either way the planned path holds the current template
     expect(await readFile(join(tempDir, '.claude/rules/orm-models.md'), 'utf8')).toContain('defineModel')
+    if (caseInsensitive) {
+      // the entry the write loop just refreshed — pruning it would delete the plan's own output
+      expect(result.stale).not.toContain('.claude/rules/ORM-MODELS.md')
+    } else {
+      expect(result.stale).toContain('.claude/rules/ORM-MODELS.md')
+      await expect(access(join(tempDir, '.claude/rules/ORM-MODELS.md'))).rejects.toThrow()
+    }
   })
 
   it('sync --prune scans only the namespaces of the components being synced', async () => {


### PR DESCRIPTION
Stacked on #456 — please review that one first. Based on `feat/prune-children-namespace` rather than `main` because #456 rewrites the exact function this changes; a `main`-based diff would carry its two commits.

## Summary

`agent:sync --prune` compared scanned filesystem paths against planned ones case-insensitively. The reason is real: on a case-preserving filesystem the write loop refreshes a planned file through whatever casing the directory entry already has, so an exact match would classify the file it had just written as stale.

The cost landed on case-sensitive filesystems (Linux, and every CI runner here). After a case-only rename, `.claude/rules/ORM-MODELS.md` and `.claude/rules/orm-models.md` are two distinct files that both exist, and the lowercased comparison made the genuinely stale one invisible to prune permanently.

The scan now matches exact paths first, and settles a case-only mismatch by asking the filesystem whether the two paths are the same object (device + inode) rather than by comparing strings. `lstat` is read with `{ bigint: true }` so a 64-bit Windows file ID survives the comparison — as a `number` two distinct NTFS files could compare equal and spare a real leftover (NTFS supports per-directory case sensitivity).

A failed `lstat` answers "same", leaving the entry alone rather than spending an irreversible `rm` on a claim that could not be established. The one plausible trigger, a directory readable but not searchable, is also a directory where the deletion would be refused, so nothing is lost.

## Scope

`cli` — `packages/cli/src/agent-harness.ts`, `packages/cli/tests/agent-harness.test.ts`, changeset.

## Risk Assessment

Behavior change is confined to `agent:sync --prune` and to entries whose path differs from a planned one by case alone:

- Case-insensitive filesystem (macOS, default Windows): unchanged. The alias resolves to the same object and is still spared.
- Case-sensitive filesystem: a distinct leftover copy is now reported in `stale` and deleted under `--prune`. That is the fix, and it is a deletion that did not happen before, so it is the line worth scrutinising in review.

No API change; `@guren/cli` patch.

## Validation

The test that covered this asserted different things on macOS (one file, spared) and on Linux (two files, one silently unpruned) while passing on both. It now probes the filesystem's case sensitivity — not `process.platform`, since macOS mounts case-sensitive volumes and Linux case-insensitive ones — and asserts the opposite outcome on each kind.

Mutation-tested in both directions, on a real case-sensitive APFS volume (`hdiutil`) as well as the default one:

| implementation | macOS (case-insensitive) | case-sensitive volume |
| --- | --- | --- |
| this PR | pass | pass |
| lowercase-only compare (before) | pass | **fail** |
| exact-only compare | **fail** | pass |

Not covered by the above: the `bigint` widening is unverifiable here (macOS inodes fit in a `number`), and rests on the documented Windows file-ID width. The `catch` branch in `isSameFile` has no test; its only reachable trigger is a directory where `rm` would fail too.

Also checked: the planner emits no two paths differing only by case (44 planned files across all targets), so the lowercase map has no ambiguous winner.

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run audit:docs`, `bun run audit:core-first`

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation. (No doc change needed: the `--prune` line in `CLAUDE.md` and `docs/*/guides/cli.md` describes the intended behavior, which this restores.)
