### PR TITLE
refactor(cli): take the skill-claim test hook off the published options

### DIFF
--- a/packages/cli/src/agent-harness.ts
+++ b/packages/cli/src/agent-harness.ts
@@ -54,13 +54,6 @@ export interface AgentHarnessOptions {
    * candidate first, and deletion stays an explicit opt-in.
    */
   prune?: boolean
-  /**
-   * Skill directory names the harness used to ship and no longer plans, which
-   * `sync` still owns for stale reporting and prune. Defaults to the
-   * framework's own `RETIRED_CANONICAL_SKILLS`; exposed so tests can exercise
-   * the retired path while that list is empty.
-   */
-  retiredSkills?: readonly string[]
 }
 
 export interface AgentHarnessResult {
@@ -221,12 +214,17 @@ async function isSameFile(cwd: string, left: string, right: string): Promise<boo
  * planned path exists on disk once the write loop has run (it either wrote the
  * file or skipped it because it was already there), so the identity check has
  * both sides to compare.
+ *
+ * Exported for tests: `retiredSkills` defaults to `RETIRED_CANONICAL_SKILLS`,
+ * which is empty, so the retired-name path has no other way to be exercised.
+ * The seam belongs here rather than on `AgentHarnessOptions`, which is a
+ * published type — a test hook there would outlive the reason for it.
  */
-async function findStaleManagedFiles(
+export async function findStaleManagedFiles(
   cwd: string,
   components: HarnessComponent[],
   plan: readonly PlannedFile[],
-  retiredSkills: readonly string[] | undefined,
+  retiredSkills?: readonly string[],
 ): Promise<string[]> {
   const plannedPaths = new Set(plan.map((file) => file.path))
   const plannedByLowerPath = new Map(plan.map((file) => [file.path.toLowerCase(), file.path]))
@@ -365,7 +363,7 @@ export async function installAgentHarness(options: AgentHarnessOptions = {}): Pr
   // Stale cleanup is a sync concern: init installs into places it has never
   // written, so "not in the plan" carries no leftover signal there.
   const stale =
-    mode === 'sync' ? await findStaleManagedFiles(cwd, components, plan, options.retiredSkills) : []
+    mode === 'sync' ? await findStaleManagedFiles(cwd, components, plan) : []
   const pruned = Boolean(options.prune) && stale.length > 0
   if (pruned) {
     for (const relPath of stale) {

--- a/packages/cli/src/agent-targets.ts
+++ b/packages/cli/src/agent-targets.ts
@@ -1,4 +1,5 @@
 import { parseDocFrontmatter } from './docs-frontmatter'
+import { safePathSegments } from './utils'
 
 /**
  * The one rule for which files each agent target owns and how the canonical
@@ -126,25 +127,33 @@ function nativeRulePath(namespace: PatternNamespace, stem: string): string {
 }
 
 /**
+ * A claimed child must be exactly one plain path segment. The claim is
+ * interpolated into a directory the prune walker will `rm` under, so a name
+ * like `..` would claim outside the app. What counts as a traversal rather
+ * than a name is `safePathSegments`' rule, not a second one written here —
+ * it already rejects `.`, `..`, a backslash (a separator on Windows) and a
+ * NUL (which truncates the path syscall-side). This adds the one constraint
+ * a skill directory has on top of it: exactly one segment, so a legal nested
+ * name like `a/b` is still refused.
+ *
+ * Checked here, where the claim is built, because this is the only place a
+ * `children` claim is ever constructed: `claimFamily` below is the sole
+ * producer, and every name it takes passes through here. A second copy at the
+ * walk that joins the name — closer to the `rm` it protects — would be a
+ * guard no test could make fire.
+ */
+function assertSkillName(name: string): void {
+  if (safePathSegments(name, 'skill claim').length !== 1) {
+    throw new Error(`Agent harness skill claim "${name}" is not a single path segment`)
+  }
+}
+
+/**
  * The skill directory names a `children` claim over `skillsDir` covers: every
  * immediate child the plan writes into, plus the retired names. Derived from
  * the plan rather than listed, so a renamed or added canonical skill cannot
  * leave the claim behind.
  */
-/**
- * A claimed child must be exactly one plain path segment: no separators, no
- * `.`/`..`, not empty. The claim is interpolated into a directory the prune
- * walker will `rm` under, so a name like `..` would claim outside the app.
- * Planned names come from the planner and cannot violate this; the retired
- * list is a constant plus a test hook, and this is the one place both are
- * checked before they reach the walker.
- */
-function assertSkillName(name: string): void {
-  if (name === '' || name === '.' || name === '..' || name.includes('/') || name.includes('\\')) {
-    throw new Error(`Agent harness skill claim "${name}" is not a single path segment`)
-  }
-}
-
 function claimedSkillNames(
   skillsDir: string,
   plan: readonly PlannedFile[],

--- a/packages/cli/tests/agent-harness.test.ts
+++ b/packages/cli/tests/agent-harness.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
 import { mkdtemp, mkdir, rm, readFile, rename, symlink, writeFile, access } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { installAgentHarness } from '../src/agent-harness'
-import { AGENT_TARGETS } from '../src/agent-targets'
+import { findStaleManagedFiles, installAgentHarness, loadAgentTemplates } from '../src/agent-harness'
+import { AGENT_TARGETS, planComponents } from '../src/agent-targets'
 
 /**
  * Whether `dir` lives on a case-insensitive filesystem. Probed rather than
@@ -328,24 +328,23 @@ describe('installAgentHarness', () => {
     )
   })
 
-  it('sync --prune removes a retired canonical skill, directory included', async () => {
+  it('sync claims a retired canonical skill the plan no longer writes', async () => {
     // "retired" is a name the framework used to ship — recorded in
-    // RETIRED_CANONICAL_SKILLS, injected here because that list is empty today
+    // RETIRED_CANONICAL_SKILLS, injected here because that list is empty
+    // today. Driven through findStaleManagedFiles rather than the installer:
+    // the seam for an empty constant belongs on an internal function, not on
+    // the published options type. What prune then does with a stale file is
+    // the shared machinery the retired-rule test above already pins.
     await installAgentHarness({ cwd: tempDir, mode: 'init' })
     await mkdir(join(tempDir, '.claude/skills/retired-skill'), { recursive: true })
     await writeFile(join(tempDir, '.claude/skills/retired-skill/SKILL.md'), 'old skill\n', 'utf8')
 
-    const result = await installAgentHarness({
-      cwd: tempDir,
-      mode: 'sync',
-      prune: true,
-      retiredSkills: ['retired-skill'],
-    })
+    const plan = planComponents(['claude'], await loadAgentTemplates(), 'My App')
+    const stale = await findStaleManagedFiles(tempDir, ['claude'], plan, ['retired-skill'])
 
-    expect(result.stale).toEqual(['.claude/skills/retired-skill/SKILL.md'])
-    expect(result.pruned).toBe(true)
-    await expect(access(join(tempDir, '.claude/skills/retired-skill'))).rejects.toThrow()
-    await access(join(tempDir, '.claude/skills/dev-workflow/SKILL.md'))
+    expect(stale).toEqual(['.claude/skills/retired-skill/SKILL.md'])
+    // and without the tombstone the same directory is not claimed at all
+    expect(await findStaleManagedFiles(tempDir, ['claude'], plan)).toEqual([])
   })
 
   it('sync never claims a skill the framework did not write — the skills roots are shared with external installers', async () => {

--- a/packages/cli/tests/agent-targets.test.ts
+++ b/packages/cli/tests/agent-targets.test.ts
@@ -230,11 +230,17 @@ describe('managedNamespaces', () => {
   })
 
   it('rejects a retired name that is not a single path segment — the claim is rm-adjacent', () => {
-    // backslashes too: they are a separator on Windows, and dropping that
-    // half of the check would otherwise pass every test here
-    for (const bad of ['.', '..', '../x', 'a/b', '', 'a\\b', '..\\x']) {
-      expect(() => managedNamespaces(['claude'], plan(['claude']), [bad])).toThrow('not a single path segment')
+    const claim = (bad: string) => () => managedNamespaces(['claude'], plan(['claude']), [bad])
+    // the traversal half is safePathSegments' rule, reported in its words —
+    // including the backslash (a separator on Windows) and the NUL that
+    // truncates a path syscall-side, neither of which a hand-written
+    // separator check here would have caught
+    for (const bad of ['.', '..', '../x', 'a\\b', '..\\x', 'a\u0000b']) {
+      expect(claim(bad)).toThrow('path traversal')
     }
+    expect(claim('')).toThrow('required')
+    // and the one constraint a skill directory adds on top of it
+    expect(claim('a/b')).toThrow('not a single path segment')
   })
 
   it('the skill claim is derived from the plan, so it tracks the real templates', async () => {


### PR DESCRIPTION
## Summary

Three follow-ups to the `children` skill claim that shipped in #456, all quality rather than behavior. No user-visible change; no changeset.

- **`AgentHarnessOptions.retiredSkills` was a test hook on a published type.** It exists only so a test can exercise the retired-name path while `RETIRED_CANONICAL_SKILLS` is empty; no production caller passes it, and `AgentHarnessOptions` is exported from `packages/cli/src/index.ts`. Nothing would force its removal on the day the constant fills up. The seam moves down to `findStaleManagedFiles`, exported with the same "Exported for tests" comment this package already uses in `audit.ts` and `parse-cache.ts`, and the test drives that. What prune then does with a stale file is shared machinery the retired-rule test already pins.
- **`assertSkillName` restated the package's path-segment rule and got it narrower.** It rejected `''`, `.`, `..`, `/` and `\` by hand, while `safePathSegments` in `utils.ts` — the one place this repo defines "a traversal, not a name" — also rejects the NUL that truncates a path syscall-side. It now calls that and adds only the constraint a skill directory has on top of it: exactly one segment, so a legal nested name like `a/b` is still refused.
- **A JSDoc block sat above the wrong function**, so `assertSkillName` appeared to carry two and `claimedSkillNames` none.

## Scope

`packages/cli/src/agent-harness.ts`, `packages/cli/src/agent-targets.ts` and their tests.

## Risk Assessment

- **Behavior is unchanged for every name the framework can produce.** Planned skill names come from the planner; the retired list is empty. The only inputs whose *rejection message* changes are ones that already threw.
- **The check is still made where the claim is built**, not at the walk that joins the name into a path. A second copy at the walk site was written and then removed: `claimFamily` is the sole producer of a `children` claim, so nothing could reach the walk unvalidated, and a guard no test can make fire is dead code by this repo's own standard.

## Validation

- `bun run test:bun cli` — 1497 pass
- `bun run typecheck` (root) — green
- Mutation checks: relaxing the single-segment test to `< 1` fails the claim test; the NUL case fails against the old hand-written check.
