### PR TITLE
refactor(cli): make the catalog audit reuse the rules it was rewriting

### DIFF
--- a/scripts/build-agent-catalog.test.ts
+++ b/scripts/build-agent-catalog.test.ts
@@ -17,6 +17,7 @@ import {
   validateAgainstSchema,
   writeCatalog,
 } from './build-agent-catalog.ts'
+import { repoRoot } from './workspace-packages.ts'
 
 /**
  * The audit exists to fail. Every rule below is pinned in both directions: it
@@ -27,9 +28,16 @@ import {
 
 const md = (path: string, content: string) => [{ path, content }]
 
+/**
+ * One render, shared. Nothing here mutates the array, and re-rendering per
+ * test only re-reads the same ten template files.
+ */
+let rendered: Promise<Awaited<ReturnType<typeof renderCatalog>>>
+const catalog = () => (rendered ??= renderCatalog())
+
 describe('renderCatalog', () => {
   it('renders the full published tree with no token left behind', async () => {
-    const files = await renderCatalog()
+    const files = await catalog()
     const paths = files.map((f) => f.path).sort()
     expect(paths).toEqual(
       [
@@ -51,7 +59,7 @@ describe('renderCatalog', () => {
   })
 
   it('renders one manifest template into both locations, differing only by $schema', async () => {
-    const files = await renderCatalog()
+    const files = await catalog()
     const root = JSON.parse(files.find((f) => f.path === 'plugins/guren/plugin.json')!.content)
     const claude = JSON.parse(files.find((f) => f.path === 'plugins/guren/.claude-plugin/plugin.json')!.content)
     expect(root.$schema).toBe('https://agent-plugins.org/schemas/1.0.0/plugin.schema.json')
@@ -61,7 +69,7 @@ describe('renderCatalog', () => {
   })
 
   it('the plugin version is the workspace @guren/cli version', async () => {
-    const files = await renderCatalog()
+    const files = await catalog()
     const cli = (await Bun.file(new URL('../packages/cli/package.json', import.meta.url)).json()) as { version: string }
     const root = JSON.parse(files.find((f) => f.path === 'plugins/guren/plugin.json')!.content)
     const market = JSON.parse(files.find((f) => f.path === '.claude-plugin/marketplace.json')!.content)
@@ -72,7 +80,7 @@ describe('renderCatalog', () => {
   it('the pre-app skill never invokes bunx guren before an app exists', async () => {
     // the whole point of guren-new-app: `guren` is not on npm, so every
     // `bunx guren` line must come after the scaffold + postcondition section
-    const files = await renderCatalog()
+    const files = await catalog()
     const skill = files.find((f) => f.path.endsWith('guren-new-app/SKILL.md'))!.content
     const handoff = skill.indexOf('## Check the postcondition')
     expect(handoff).toBeGreaterThan(0)
@@ -83,9 +91,34 @@ describe('renderCatalog', () => {
   })
 })
 
+describe('the command registry is importable', () => {
+  it('builds on import without running the CLI or touching the filesystem', () => {
+    // the audit imports `commands.ts` to read what the CLI registers. That is
+    // only safe while importing it stays inert: a stray console line, a
+    // prompt, or a warning in any of the ~50 command modules it pulls in
+    // would run on every audit and every publish. The module says so in
+    // prose; this is what makes the claim fail when it stops being true.
+    //
+    // What it pins is output, not every possible side effect — a top-level
+    // `await` that merely waits would still pass. GUREN_QUIET_DUPLICATE_ORM
+    // silences the one line this workspace prints by design: `src` and
+    // `dist` copies of @guren/orm coexist here, which is not a property of
+    // the registry.
+    const probe = Bun.spawnSync([
+      process.execPath,
+      '-e',
+      "import('./packages/cli/src/commands.ts').then((m) => { if (Object.keys(m.builtinSubCommands).length === 0) process.exit(3) })",
+    ], { cwd: repoRoot, env: { ...process.env, GUREN_QUIET_DUPLICATE_ORM: '1' } })
+
+    expect(probe.exitCode).toBe(0)
+    expect(probe.stdout.toString()).toBe('')
+    expect(probe.stderr.toString()).toBe('')
+  })
+})
+
 describe('audit: commands and flags', () => {
   it('passes on the real payload', async () => {
-    expect(await assertCommandsAndFlags(await renderCatalog())).toEqual([])
+    expect(await assertCommandsAndFlags(await catalog())).toEqual([])
   })
 
   it('fails on a command the CLI does not register', async () => {
@@ -163,7 +196,7 @@ describe('audit: changeset gate parser', () => {
 
 describe('audit: targets', () => {
   it('passes on the real payload', async () => {
-    expect(assertTargets(await renderCatalog())).toEqual([])
+    expect(assertTargets(await catalog())).toEqual([])
   })
   it('fails on a target outside AGENT_TARGETS', () => {
     const problems = assertTargets(md('x.md', '`bunx guren agent:init --target codex,windsurf`'))
@@ -194,7 +227,7 @@ describe('audit: Agent Plugins v1 manifest', () => {
   }
 
   it('passes on the real payload', async () => {
-    expect(await assertPortableManifest(await renderCatalog())).toEqual([])
+    expect(await assertPortableManifest(await catalog())).toEqual([])
   })
   it('fails when $schema is missing (required by the spec)', async () => {
     const { $schema: _s, ...noSchema } = valid

--- a/scripts/build-agent-catalog.ts
+++ b/scripts/build-agent-catalog.ts
@@ -33,6 +33,8 @@ import { dirname, join, relative } from 'node:path'
 import process from 'node:process'
 import { AGENT_TARGETS } from '../packages/cli/src/agent-targets'
 import { builtinSubCommands } from '../packages/cli/src/commands'
+import { compareVersions } from '../packages/cli/src/codemods'
+import { parseChangeset } from './smoke/core-semver-audit'
 import { repoRoot } from './workspace-packages'
 
 const TEMPLATE_DIR = 'packages/cli/templates/agent-catalog'
@@ -88,7 +90,7 @@ async function readContext(): Promise<RenderContext> {
   return { cliVersion, minCli: MIN_CLI_FOR_TARGETS, targets: AGENT_TARGETS }
 }
 
-function substitute(template: string, ctx: RenderContext, portableSchema: boolean): string {
+function substitute(template: string, ctx: RenderContext, portableSchema = false): string {
   return template
     .replaceAll('__CLI_VERSION__', ctx.cliVersion)
     .replaceAll('__MIN_CLI__', ctx.minCli)
@@ -115,21 +117,21 @@ export async function renderCatalog(): Promise<RenderedFile[]> {
   }
 
   const pluginRoot = 'plugins/guren'
-  add('.claude-plugin/marketplace.json', substitute(await loadTemplate('marketplace.json.tpl'), ctx, false))
-  add('README.md', substitute(await loadTemplate('README.md.tpl'), ctx, false))
-  add('CONTRIBUTING.md', substitute(await loadTemplate('CONTRIBUTING.md.tpl'), ctx, false))
-  add(`${pluginRoot}/README.md`, substitute(await loadTemplate('plugin-README.md.tpl'), ctx, false))
+  add('.claude-plugin/marketplace.json', substitute(await loadTemplate('marketplace.json.tpl'), ctx))
+  add('README.md', substitute(await loadTemplate('README.md.tpl'), ctx))
+  add('CONTRIBUTING.md', substitute(await loadTemplate('CONTRIBUTING.md.tpl'), ctx))
+  add(`${pluginRoot}/README.md`, substitute(await loadTemplate('plugin-README.md.tpl'), ctx))
   // one manifest template, rendered twice: the portable Agent Plugins v1
   // manifest at the plugin root, and Claude Code's location without $schema
   const pluginTpl = await loadTemplate('plugin.json.tpl')
   add(`${pluginRoot}/plugin.json`, substitute(pluginTpl, ctx, true))
-  add(`${pluginRoot}/.claude-plugin/plugin.json`, substitute(pluginTpl, ctx, false))
+  add(`${pluginRoot}/.claude-plugin/plugin.json`, substitute(pluginTpl, ctx))
 
   const skillsDir = join(repoRoot, TEMPLATE_DIR, 'skills')
   for (const entry of await readdir(skillsDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue
     const skillFile = join(skillsDir, entry.name, 'SKILL.md')
-    add(`${pluginRoot}/skills/${entry.name}/SKILL.md`, substitute(await readFile(skillFile, 'utf8'), ctx, false))
+    add(`${pluginRoot}/skills/${entry.name}/SKILL.md`, substitute(await readFile(skillFile, 'utf8'), ctx))
   }
 
   // LICENSE is copied, not templated: the published license can never
@@ -141,8 +143,13 @@ export async function renderCatalog(): Promise<RenderedFile[]> {
   return files.sort((a, b) => a.path.localeCompare(b.path))
 }
 
-export async function writeCatalog(outDir: string): Promise<RenderedFile[]> {
-  const files = await renderCatalog()
+/**
+ * `files` lets a caller that has already rendered — `--check`, which audits
+ * the payload before writing it for the validator — write that same array
+ * instead of rendering a second one. Same tree either way; one render.
+ */
+export async function writeCatalog(outDir: string, files?: readonly RenderedFile[]): Promise<readonly RenderedFile[]> {
+  files ??= await renderCatalog()
   for (const file of files) {
     const dest = join(outDir, file.path)
     await mkdir(dirname(dest), { recursive: true })
@@ -234,19 +241,17 @@ export function assertTargets(files: readonly RenderedFile[]): string[] {
   return problems
 }
 
-function compareSemver(a: string, b: string): number {
-  const pa = a.split('.').map(Number)
-  const pb = b.split('.').map(Number)
-  for (let i = 0; i < 3; i++) {
-    const d = (pa[i] ?? 0) - (pb[i] ?? 0)
-    if (d !== 0) return d
-  }
-  return 0
-}
-
 export async function assertMinCli(): Promise<string[]> {
   const ctx = await readContext()
-  return compareSemver(ctx.minCli, ctx.cliVersion) > 0
+  // `compareVersions` returns NaN when either side is not an exact version —
+  // a prerelease workspace version, a partial pin. `NaN > 0` is false, so a
+  // comparison that could not be made would otherwise read as "not ahead"
+  // and pass the gate it exists to be.
+  const order = compareVersions(ctx.minCli, ctx.cliVersion)
+  if (Number.isNaN(order)) {
+    return [`Cannot order MIN_CLI_FOR_TARGETS ${ctx.minCli} against the workspace @guren/cli ${ctx.cliVersion}`]
+  }
+  return order > 0
     ? [`MIN_CLI_FOR_TARGETS ${ctx.minCli} is ahead of the workspace @guren/cli ${ctx.cliVersion}`]
     : []
 }
@@ -369,19 +374,21 @@ export async function assertPortableManifest(files: readonly RenderedFile[]): Pr
 /**
  * Does this changeset's frontmatter release `pkg`? Only the `---`-delimited
  * block is read, so a package-looking line in the Markdown body does not
- * count; keys may be quoted or bare, as changesets accepts both. (The OKF
- * frontmatter parser in packages/cli is a fixed-field subset and does not
- * see package names, so this is the one place a tiny local parser is right.)
+ * count; keys may be quoted or bare, as changesets accepts both.
+ *
+ * The reading is `core-semver-audit.ts`'s, not a second one written here:
+ * that gate already had to be as permissive as `@changesets/parse` about
+ * comments, quoting and bump values, and two regexes for one file format is
+ * how the two gates come to disagree about what a release plan says.
+ * (The OKF frontmatter parser in packages/cli is a fixed-field subset that
+ * never sees package names, which is why it is not the one to reuse.)
+ *
+ * Throws on a changeset it cannot read, rather than reporting "no release
+ * for pkg" — the caller turns that into a reported problem, because a
+ * changeset nobody can parse is not evidence that a release was not planned.
  */
-export function changesetNames(source: string, pkg: string): boolean {
-  const block = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/u.exec(source)
-  if (!block) return false
-  for (const line of (block[1] ?? '').split(/\r?\n/u)) {
-    const m = /^\s*(?:"([^"]+)"|'([^']+)'|([^\s:"']+))\s*:/u.exec(line)
-    const key = m?.[1] ?? m?.[2] ?? m?.[3]
-    if (key === pkg) return true
-  }
-  return false
+export function changesetNames(source: string, pkg: string, file = 'changeset'): boolean {
+  return parseChangeset(file, source).releases.has(pkg)
 }
 
 /**
@@ -416,7 +423,12 @@ export async function assertChangesetGate(base: string): Promise<string[]> {
     // no .changeset dir — fall through to the failure below
   }
   for (const name of names) {
-    if (changesetNames(await readFile(join(changesetDir, name), 'utf8'), '@guren/cli')) return []
+    try {
+      if (changesetNames(await readFile(join(changesetDir, name), 'utf8'), '@guren/cli', name)) return []
+    } catch (error) {
+      // an unreadable changeset is not evidence that no release was planned
+      return [`could not read .changeset/${name}: ${error instanceof Error ? error.message : String(error)}`]
+    }
   }
   return [
     `catalog inputs changed (${touched.join(', ')}) but no .changeset/*.md names "@guren/cli". ` +
@@ -483,11 +495,12 @@ async function check(base: string | undefined, requireValidate: boolean): Promis
     return 1
   }
 
-  // render once and validate that same tree, then discard it
+  // write the tree that was just audited — not a second render of it — and
+  // validate that, then discard it. Provenance, and one render per run.
   const dir = await mkdtemp(join(tmpdir(), 'guren-agent-catalog-'))
   let outcome: ValidateOutcome
   try {
-    await writeCatalog(dir)
+    await writeCatalog(dir, files)
     outcome = await claudePluginValidate(dir)
   } finally {
     await rm(dir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary

Quality follow-up to #457, which merged before this pass finished. Three things in the catalog audit that could not fail on the input they exist to judge, plus two cleanups.

- **The version gate failed open on the input it is about.** `assertMinCli` compared `MIN_CLI_FOR_TARGETS` against the workspace version with a hand-written `compareSemver` that mapped each dotted part through `Number`. A partial pin or a prerelease produced `NaN`, and `NaN > 0` is `false` — a comparison that *could not be made* read as "not ahead" and passed. It now uses `compareVersions` from `codemods.ts` (built on `Bun.semver.order`, and documented as returning `NaN` deliberately) and reports that `NaN` as its own problem. `MIN_CLI_FOR_TARGETS = '2.5'` now fails the audit; before, it passed.
- **Two readings of changeset frontmatter.** `changesetNames` was a second parser beside `scripts/smoke/core-semver-audit.ts`'s `parseChangeset`, which had already had to be as permissive as `@changesets/parse` about comments, quoting and bump values. Two regexes for one file format is how two release gates come to disagree about what a release plan says. It now calls that parser, and a changeset it cannot read is reported as a problem rather than as "no release planned".
- **`--check` rendered the payload twice** — once to audit, once to write for `claude plugin validate` — so the tree that was validated was not the tree that was audited, only an identical one. It writes the array it audited.
- `substitute`'s portable-schema flag defaults to `false`; seven of its eight call sites passed the literal.
- The test file renders once instead of seven times.
- **`commands.ts` claims that importing it is inert. That claim now has a test**, run in a subprocess, which fails on a stray console line at import. Writing it turned up that the import is *not* silent in this workspace — it prints the ORM's duplicate-copy warning, because `src` and `dist` copies coexist here by design. The test silences that one known line explicitly rather than asserting around it, and says what it does and does not pin (output, not a top-level `await` that merely waits).

## Validation

- `bun test scripts/` — 116 pass
- `bun run typecheck` (root), `bun run audit:agent-catalog` — green
- Mutation checks: `MIN_CLI_FOR_TARGETS = '2.5'` fails the audit; a `console.warn` at the top of `commands.ts` fails the new test.
