### PR TITLE
feat(web): apply the Guren UI design system to the docs site

### DIFF
--- a/web/app/Services/MarkdownRenderer.ts
+++ b/web/app/Services/MarkdownRenderer.ts
@@ -15,6 +15,10 @@ import {
   type DocLocale,
 } from './docs-config.js'
 
+// The code surface is themeless ink (Guren UI): app.css always applies the
+// dark palette from the `--shiki-dark` custom properties and pins the
+// background to the ink token. The output stays dual-theme so it is
+// interchangeable with the blog pipeline's stored HTML (PostRenderer.ts).
 const DOCS_THEMES = {
   light: 'rose-pine-dawn',
   dark: 'rose-pine-moon',
@@ -24,15 +28,17 @@ const ALERT_DIRECTIVE_PATTERN = /^\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s
 
 type AlertType = 'note' | 'tip' | 'important' | 'warning' | 'caution'
 
+// Callouts render as diagnostic rows (Guren UI): GitHub's five directives
+// map onto the note / ok / rule / never key vocabulary of `guren check`.
 const ALERT_METADATA: Record<
   AlertType,
   { label: string; classSuffix: string }
 > = {
-  note: { label: 'Note', classSuffix: 'note' },
-  tip: { label: 'Tip', classSuffix: 'tip' },
-  important: { label: 'Important', classSuffix: 'important' },
-  warning: { label: 'Warning', classSuffix: 'warning' },
-  caution: { label: 'Caution', classSuffix: 'caution' },
+  note: { label: 'note', classSuffix: 'note' },
+  tip: { label: 'ok', classSuffix: 'tip' },
+  important: { label: 'rule', classSuffix: 'important' },
+  warning: { label: 'rule', classSuffix: 'warning' },
+  caution: { label: 'never', classSuffix: 'caution' },
 }
 
 export interface DocLinkContext {

--- a/web/resources/css/app.css
+++ b/web/resources/css/app.css
@@ -53,38 +53,105 @@ html {
   scroll-behavior: smooth;
 }
 
+/* ─── Guren UI tokens (gurenjs/guren-ui dist/tokens.css) ───
+   The design system was derived from these docs themes, so the values match
+   what the site already shipped; --docs-* below are aliases kept for the
+   existing markup. Fonts stay on the site's own policy (no self-hosted
+   family is introduced here). */
 :root {
-  --docs-surface-page: #ffffff;
-  --docs-surface-panel: #ffffff;
-  --docs-surface-raised: #fffafa;
-  --docs-border-soft: #e5e7eb;
-  --docs-border-strong: #d1d5db;
-  --docs-text-primary: #1f2937;
-  --docs-text-secondary: #4b5563;
-  --docs-text-muted: #9ca3af;
-  --docs-heading: #111827;
-  --docs-accent: #db1b1b;
-  --docs-accent-strong: #991b1b;
-  --docs-accent-tint: #fff1f2;
-  --docs-shadow-card: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
-  --docs-shadow-floating: 0 10px 15px -3px rgba(0, 0, 0, 0.05), 0 4px 6px -2px rgba(0, 0, 0, 0.025);
+  --g-font-mono: 'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace;
+
+  /* surfaces */
+  --g-page: #ffffff;
+  --g-panel: #ffffff;
+  --g-raised: #fffafa;
+  --g-ink: #1a1212;             /* terminal surface — dark in both themes */
+  --g-line: #e5e7eb;
+  --g-line-strong: #d1d5db;
+
+  /* text */
+  --g-heading: #111827;
+  --g-text: #1f2937;
+  --g-text-2: #4b5563;
+  --g-muted: #9ca3af;
+
+  /* the red budget */
+  --g-accent: #db1b1b;          /* crimson-600 — primary fills only */
+  --g-accent-down: #b91c1c;
+  --g-accent-text: #991b1b;     /* crimson-800 — links, accent text */
+  --g-accent-tint: #fff1f2;
+  --g-on-accent: #fff5f5;       /* crimson-50 on accent fills */
+
+  /* signals — text-safe value + chip value + wash */
+  --g-ok: #286983;
+  --g-ok-chip: #56949f;
+  --g-ok-tint: rgba(86, 148, 159, 0.12);
+  --g-warn: #b45309;
+  --g-warn-chip: #ea9d34;
+  --g-warn-tint: rgba(234, 157, 52, 0.14);
+  --g-danger: #b91c1c;
+  --g-danger-chip: #f23a3a;
+  --g-danger-tint: #fff1f2;
+
+  /* the one structural device */
+  --g-tick: linear-gradient(180deg, #ff3c28, #8b0000);
+
+  /* geometry */
+  --g-r-ctl: 8px;
+  --g-r-card: 12px;
+  --g-shadow-card: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
+  --g-shadow-float: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.04);
+
+  /* legacy aliases — the pre-Guren-UI names the markup still reads */
+  --docs-surface-page: var(--g-page);
+  --docs-surface-panel: var(--g-panel);
+  --docs-surface-raised: var(--g-raised);
+  --docs-border-soft: var(--g-line);
+  --docs-border-strong: var(--g-line-strong);
+  --docs-text-primary: var(--g-text);
+  --docs-text-secondary: var(--g-text-2);
+  --docs-text-muted: var(--g-muted);
+  --docs-heading: var(--g-heading);
+  --docs-accent: var(--g-accent);
+  --docs-accent-strong: var(--g-accent-text);
+  --docs-accent-tint: var(--g-accent-tint);
+  --docs-shadow-card: var(--g-shadow-card);
+  --docs-shadow-floating: var(--g-shadow-float);
 }
 
 :root.dark {
-  --docs-surface-page: #1a1a2e;
-  --docs-surface-panel: #1e1e34;
-  --docs-surface-raised: #232340;
-  --docs-border-soft: #2e2e4a;
-  --docs-border-strong: #3d3d5c;
-  --docs-text-primary: #e0def4;
-  --docs-text-secondary: #908caa;
-  --docs-text-muted: #6e6a86;
-  --docs-heading: #e0def4;
-  --docs-accent: #eb6f92;
-  --docs-accent-strong: #eb6f92;
-  --docs-accent-tint: rgba(235, 111, 146, 0.12);
-  --docs-shadow-card: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
-  --docs-shadow-floating: 0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -2px rgba(0, 0, 0, 0.25);
+  --g-page: #1a1a2e;
+  --g-panel: #1e1e34;
+  --g-raised: #232340;
+  --g-line: #2e2e4a;
+  --g-line-strong: #3d3d5c;
+
+  --g-heading: #e0def4;
+  --g-text: #e0def4;
+  --g-text-2: #908caa;
+  --g-muted: #6e6a86;
+
+  /* fills stay crimson in both themes; accent TEXT moves to rose, the docs'
+     own dark accent — crimson measures 4.42:1 on this ground. */
+  --g-accent-text: #eb6f92;
+  --g-accent-tint: rgba(235, 111, 146, 0.12);
+
+  --g-ok: #9ccfd8;
+  --g-ok-chip: #9ccfd8;
+  --g-ok-tint: rgba(156, 207, 216, 0.10);
+  --g-warn: #f6c177;
+  --g-warn-chip: #f6c177;
+  --g-warn-tint: rgba(246, 193, 119, 0.10);
+  --g-danger: #ffa5a5;
+  --g-danger-chip: #f23a3a;
+  --g-danger-tint: rgba(242, 58, 58, 0.12);
+
+  --g-shadow-card: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
+  --g-shadow-float: 0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -2px rgba(0, 0, 0, 0.25);
+
+  /* accent as text is rose in the dark theme (the fill alias stays crimson
+     via --g-accent; markup that paints fills was moved to .docs-btn-primary) */
+  --docs-accent: var(--g-accent-text);
 }
 
 body {
@@ -100,6 +167,14 @@ body.docs-theme {
 
 /* ─── Docs nav links ─── */
 .docs-nav-link {
+  position: relative;
+  display: block;
+  padding: 0.4rem 0.6rem;
+  border-radius: var(--g-r-ctl);
+  font-size: 0.925rem;
+  font-weight: 400;
+  color: var(--docs-text-secondary);
+  text-decoration: none;
   outline: 2px solid transparent;
   outline-offset: 2px;
   transition: background-color 150ms ease, color 150ms ease, outline-color 150ms ease;
@@ -107,8 +182,8 @@ body.docs-theme {
 
 .docs-nav-link:hover,
 .docs-nav-link:focus-visible {
-  color: var(--docs-accent-strong) !important;
-  background-color: var(--docs-accent-tint) !important;
+  color: var(--docs-heading);
+  background-color: var(--docs-accent-tint);
 }
 
 .docs-nav-link:focus-visible {
@@ -116,9 +191,84 @@ body.docs-theme {
 }
 
 .docs-nav-link--active {
-  font-weight: 700 !important;
-  color: var(--docs-accent-strong) !important;
-  background-color: var(--docs-accent-tint) !important;
+  font-weight: 700;
+  color: var(--docs-heading);
+  background-color: var(--docs-accent-tint);
+}
+
+/* the ember tick — one per screen, and the nav current place wins it */
+.docs-nav-link--active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 7px;
+  bottom: 7px;
+  width: 3px;
+  border-radius: 2px;
+  background: var(--g-tick);
+}
+
+/* the same 3px logo-gradient fragment, standalone — for a page title when no
+   nav current place is on screen */
+.docs-tick {
+  display: inline-block;
+  width: 3px;
+  height: 0.9em;
+  border-radius: 2px;
+  background: var(--g-tick);
+}
+
+/* ─── Machine-issued text: mono labels and values ─── */
+.docs-kicker {
+  font-family: var(--g-font-mono);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.docs-mono {
+  font-family: var(--g-font-mono);
+}
+
+/* ─── Buttons — the red budget: one crimson fill per screen, in both themes.
+   Destructive is outline + explicit verb, never a second red fill. ─── */
+.docs-btn-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: var(--g-r-ctl);
+  background: var(--g-accent);
+  color: var(--g-on-accent);
+  font-weight: 700;
+  text-decoration: none;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.docs-btn-primary:hover {
+  background: var(--g-accent-down);
+}
+
+.docs-btn-primary:focus-visible {
+  outline: 2px solid var(--g-accent);
+  outline-offset: 2px;
+}
+
+.docs-btn-danger {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--g-r-ctl);
+  background: transparent;
+  border: 1px solid var(--g-danger-chip);
+  color: var(--g-danger);
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.docs-btn-danger:hover {
+  background: var(--g-danger-tint);
 }
 
 .docs-primary-link {
@@ -313,18 +463,32 @@ body.docs-theme {
   border-bottom-color: var(--docs-accent-strong);
 }
 
+/* The code surface has no theme: ink in light and dark alike (the same
+   terminal surface CodeBlock.tsx paints), syntax from rose-pine-moon.
+   !important beats the theme background shiki inlines on the element. */
 .shiki {
-  border-radius: 0.75rem;
-  border: 1px solid var(--docs-border-soft);
+  border-radius: var(--g-r-card);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   padding: 1rem 1.25rem;
   overflow-x: auto;
-  background: var(--docs-surface-raised);
+  background-color: var(--g-ink) !important;
   font-size: 0.9rem;
   line-height: 1.5;
 }
 
 .shiki code {
-  font-family: "JetBrains Mono", "SFMono-Regular", ui-monospace, "SFMono", monospace;
+  font-family: var(--g-font-mono);
+}
+
+/* Both markdown pipelines emit dual-theme shiki HTML with the dark palette
+   in `--shiki-dark` custom properties (the blog stores that HTML at save
+   time, so the shape cannot change per theme). The themeless ink surface
+   always shows the dark palette — in light mode too. Scoped to
+   .docs-content: the landing page highlights with a single dark theme that
+   carries no `--shiki-dark` vars. */
+.docs-content .shiki,
+.docs-content .shiki span {
+  color: var(--shiki-dark) !important;
 }
 
 .docs-content :not(pre) > code {
@@ -337,96 +501,80 @@ body.docs-theme {
   font-weight: 500;
 }
 
-/* ─── Alerts ─── */
+/* ─── Callouts — the diagnostic row, not a box. Same anatomy as guren check
+   output: a mono key in a fixed gutter, a hairline, ordinary body text.
+   Keys: note / ok / rule / never (the renderer maps GitHub's five
+   directives onto them). ─── */
 .docs-alert {
-  border-radius: 0.75rem;
-  padding: 1rem 1.25rem;
-  border-left: 4px solid;
-  background: var(--docs-surface-raised);
+  display: grid;
+  grid-template-columns: 84px 1fr;
+  gap: 14px;
+  padding: 10px 2px;
   margin: 1.25rem 0;
+  border-top: 1px solid var(--docs-border-soft);
+  border-bottom: 1px solid var(--docs-border-soft);
+}
+
+/* stacked rows share one hairline */
+.docs-alert + .docs-alert {
+  border-top: 0;
+  margin-top: -1.25rem;
 }
 
 .docs-alert__label {
-  margin: 0 0 0.5rem;
-  font-size: 0.85rem;
+  margin: 0;
+  font-family: var(--g-font-mono);
+  font-size: 0.8rem;
   font-weight: 700;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+  line-height: 1.9;
+  text-align: right;
 }
 
 .docs-alert__body {
   font-size: 0.95rem;
+  color: var(--docs-text-primary);
 }
 
 .docs-alert__body > :first-child { margin-top: 0; }
 .docs-alert__body > :last-child { margin-bottom: 0; }
 
-.docs-alert--note { border-color: #3b82f6; background: #eff6ff; }
-.docs-alert--note .docs-alert__label { color: #1d4ed8; }
+.docs-alert--note .docs-alert__label,
+.docs-alert--tip .docs-alert__label { color: var(--g-ok); }
 
-.docs-alert--tip { border-color: #10b981; background: #ecfdf5; }
-.docs-alert--tip .docs-alert__label { color: #047857; }
+.docs-alert--important .docs-alert__label,
+.docs-alert--warning .docs-alert__label { color: var(--g-warn); }
 
-.docs-alert--important { border-color: #f59e0b; background: #fffbeb; }
-.docs-alert--important .docs-alert__label { color: #b45309; }
+.docs-alert--caution .docs-alert__label { color: var(--g-danger); }
 
-.docs-alert--warning { border-color: #f97316; background: #fff7ed; }
-.docs-alert--warning .docs-alert__label { color: #c2410c; }
-
-.docs-alert--caution { border-color: #ef4444; background: #fef2f2; }
-.docs-alert--caution .docs-alert__label { color: #b91c1c; }
-
-:root.dark .docs-alert--note { border-color: #60a5fa; background: rgba(59, 130, 246, 0.1); }
-:root.dark .docs-alert--note .docs-alert__label { color: #93bbfd; }
-
-:root.dark .docs-alert--tip { border-color: #34d399; background: rgba(16, 185, 129, 0.1); }
-:root.dark .docs-alert--tip .docs-alert__label { color: #6ee7b7; }
-
-:root.dark .docs-alert--important { border-color: #fbbf24; background: rgba(245, 158, 11, 0.1); }
-:root.dark .docs-alert--important .docs-alert__label { color: #fcd34d; }
-
-:root.dark .docs-alert--warning { border-color: #fb923c; background: rgba(249, 115, 22, 0.1); }
-:root.dark .docs-alert--warning .docs-alert__label { color: #fdba74; }
-
-:root.dark .docs-alert--caution { border-color: #f87171; background: rgba(239, 68, 68, 0.1); }
-:root.dark .docs-alert--caution .docs-alert__label { color: #fca5a5; }
-
-/* Shiki dual-theme: show dark colors in dark mode */
-:root.dark .shiki,
-:root.dark .shiki span {
-  color: var(--shiki-dark) !important;
-  background-color: var(--shiki-dark-bg) !important;
-}
-
-/* ─── Copy button ─── */
+/* ─── Copy button — sits on the themeless ink surface, so it is themeless
+   too ─── */
 .docs-copy-btn {
   position: absolute;
   top: 0.35rem;
   right: 0.35rem;
-  border: 1px solid var(--docs-border-soft);
-  background: var(--docs-surface-page);
-  color: var(--docs-text-secondary);
-  border-radius: 0.375rem;
+  border: 1px solid rgba(255, 245, 245, 0.25);
+  background: rgba(255, 245, 245, 0.08);
+  color: rgba(255, 245, 245, 0.75);
+  border-radius: var(--g-r-ctl);
   padding: 0.2rem 0.4rem;
+  font-family: var(--g-font-mono);
   font-size: 0.7rem;
-  font-weight: 600;
+  font-weight: 500;
   cursor: pointer;
   transition: all 0.2s;
   opacity: 0;
   z-index: 10;
 }
 
-pre:hover .docs-copy-btn {
+pre:hover .docs-copy-btn,
+.docs-copy-btn:focus-visible {
   opacity: 1;
 }
 
 .docs-copy-btn:hover {
-  background: var(--docs-surface-raised);
-  color: var(--docs-text-primary);
-  border-color: var(--docs-border-strong);
+  background: rgba(255, 245, 245, 0.16);
+  color: #fff5f5;
+  border-color: rgba(255, 245, 245, 0.4);
 }
 
 /* ─── Media in docs ─── */
@@ -450,14 +598,21 @@ pre:hover .docs-copy-btn {
 }
 
 .docs-content table thead tr {
-  border-bottom: 2px solid var(--docs-border-soft);
+  border-bottom: 1px solid var(--docs-border-strong);
 }
 
+/* table headers are machine-issued values: mono, small, uppercase.
+   text-2 rather than the g-table muted: docs tables sit on the page ground,
+   where muted measures 2.5:1 — below text duty. */
 .docs-content table th {
-  font-weight: 600;
+  font-family: var(--g-font-mono);
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
   text-align: left;
   padding: 0.75rem 1rem;
-  color: var(--docs-heading);
+  color: var(--docs-text-secondary);
 }
 
 .docs-content table td {
@@ -499,7 +654,7 @@ pre:hover .docs-copy-btn {
 /* ─── Prev/Next pagination ─── */
 .docs-pagination-link {
   transition: all 0.2s ease;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  box-shadow: var(--g-shadow-card);
 }
 
 .docs-pagination-link:hover {

--- a/web/resources/js/pages/Docs/Index.tsx
+++ b/web/resources/js/pages/Docs/Index.tsx
@@ -71,8 +71,10 @@ export default function DocsIndex({ categories, locale, locales = [], basePath }
       <main className="min-h-[calc(100vh-70px)] bg-docs-page text-docs-text" style={{ fontFamily: 'system-ui, sans-serif' }}>
         <div className="mx-auto max-w-[1200px] px-6 pt-16 pb-24">
           <header className="mb-20 max-w-[800px]">
-            <p className="mb-4 flex items-center gap-2 text-sm font-semibold uppercase tracking-widest text-docs-accent">
-              <span className="inline-block h-px w-5 bg-docs-accent" />
+            {/* the ember tick — this screen has no current-place nav, so the
+                page title block carries the one tick */}
+            <p className="docs-kicker mb-4 flex items-center gap-2.5 text-sm text-docs-accent">
+              <span className="docs-tick" aria-hidden="true" />
               {copy.eyebrow}
             </p>
             <h1 className="mb-6 text-[3.5rem] font-extrabold leading-[1.1] tracking-tight text-docs-heading">
@@ -107,7 +109,7 @@ export default function DocsIndex({ categories, locale, locales = [], basePath }
                   <div className="grid gap-12">
                     {group.sections.map((section) => (
                       <div key={`${group.category}-${section.title}`}>
-                        <h3 className="mb-5 text-sm font-bold uppercase tracking-widest text-docs-text-muted">
+                        <h3 className="docs-kicker mb-5 text-sm text-docs-text-secondary">
                           {section.title}
                         </h3>
                         <div className="grid gap-6" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))' }}>

--- a/web/resources/js/pages/Docs/Show.tsx
+++ b/web/resources/js/pages/Docs/Show.tsx
@@ -5,7 +5,6 @@ import { Footer } from '../../components/Footer.js'
 import { Header } from '../../components/Header.js'
 import { Seo } from '../../components/Seo.js'
 import { breadcrumbJsonLd, techArticleJsonLd } from '../../lib/structured-data.js'
-import { docsTheme } from './theme.js'
 
 type DocSummary = {
   slug: string
@@ -242,12 +241,12 @@ export default function DocsShow({ categories, doc, active, locale, locales = []
         <aside className="docs-sidebar">
           {categories.map((group) => (
             <section key={group.category} className="mb-8">
-              <h2 className="mb-4 pl-2 text-xs font-bold uppercase tracking-widest text-docs-heading">
+              <h2 className="docs-kicker mb-4 pl-2 text-xs text-docs-heading">
                 {group.title}
               </h2>
               {group.sections.map((section) => (
                 <div key={`${group.category}-${section.title}`} className="mb-5">
-                  <h3 className="mb-2 pl-2 text-[0.7rem] font-semibold uppercase tracking-widest text-docs-text-muted">
+                  <h3 className="docs-kicker mb-2 pl-2 text-[0.7rem] text-docs-text-secondary">
                     {section.title}
                   </h3>
                   <nav className="flex flex-col gap-0.5">
@@ -258,16 +257,6 @@ export default function DocsShow({ categories, doc, active, locale, locales = []
                           key={`${group.category}-${entry.slug}`}
                           href={`${basePath}/${group.category}/${entry.slug}`}
                           className={`docs-nav-link ${isActive ? 'docs-nav-link--active' : ''}`}
-                          style={{
-                            padding: '0.4rem 0.6rem',
-                            borderRadius: '6px',
-                            textDecoration: 'none',
-                            color: isActive ? docsTheme.accent.strong : docsTheme.text.secondary,
-                            backgroundColor: isActive ? docsTheme.accent.tint : 'transparent',
-                            fontWeight: isActive ? 600 : 400,
-                            fontSize: '0.925rem',
-                            borderLeft: isActive ? `2px solid ${docsTheme.accent.strong}` : '2px solid transparent',
-                          }}
                         >
                           {entry.title}
                         </Link>
@@ -286,11 +275,11 @@ export default function DocsShow({ categories, doc, active, locale, locales = []
             <>
               <header className="mb-12">
                 <div className="mb-4 flex items-center gap-3">
-                  <span className="rounded bg-docs-accent-tint px-2 py-1 text-xs font-bold uppercase tracking-widest text-docs-accent">
+                  <span className="docs-kicker rounded-full bg-docs-accent-tint px-2.5 py-1 text-xs text-docs-accent">
                     {docLabel}
                   </span>
                   <span className="text-sm text-docs-text-muted">/</span>
-                  <span className="text-sm font-medium text-docs-text-muted">{doc.category}</span>
+                  <span className="docs-mono text-sm text-docs-text-secondary">{doc.category}</span>
                 </div>
                 <h1 className="mb-4 text-[2.75rem] font-extrabold leading-[1.1] tracking-tight text-docs-heading">
                   {doc.title}
@@ -339,10 +328,7 @@ export default function DocsShow({ categories, doc, active, locale, locales = []
               <p className="mb-10 text-lg leading-relaxed text-docs-text-secondary">
                 The page you are looking for doesn't exist or has been moved.
               </p>
-              <Link
-                href={basePath}
-                className="inline-flex items-center gap-2 rounded-full bg-docs-accent px-6 py-3 font-semibold text-white no-underline transition hover:scale-105"
-              >
+              <Link href={basePath} className="docs-btn-primary px-6 py-3">
                 Back to Documentation
               </Link>
             </section>
@@ -352,7 +338,7 @@ export default function DocsShow({ categories, doc, active, locale, locales = []
         {/* Table of Contents */}
         {toc.items.length > 0 && (
           <aside className="docs-toc">
-            <p className="mb-3 text-xs font-bold uppercase tracking-widest text-docs-text-muted">
+            <p className="docs-kicker mb-3 text-xs text-docs-text-secondary">
               On this page
             </p>
             <nav className="flex flex-col gap-1">

--- a/web/resources/js/pages/admin/PostForm.tsx
+++ b/web/resources/js/pages/admin/PostForm.tsx
@@ -52,7 +52,7 @@ export default function AdminPostForm({ post }: Props) {
               onChange={(event) => form.setData('title', event.target.value)}
               className={fieldClass}
             />
-            {form.errors.title && <span className="text-sm text-red-600">{form.errors.title}</span>}
+            {form.errors.title && <span className="text-sm text-(--g-danger)">{form.errors.title}</span>}
           </label>
 
           <label className="flex flex-col gap-2">
@@ -64,7 +64,7 @@ export default function AdminPostForm({ post }: Props) {
               className={fieldClass}
             />
             {form.errors.description && (
-              <span className="text-sm text-red-600">{form.errors.description}</span>
+              <span className="text-sm text-(--g-danger)">{form.errors.description}</span>
             )}
           </label>
 
@@ -77,7 +77,7 @@ export default function AdminPostForm({ post }: Props) {
               className={`${fieldClass} font-mono text-sm`}
             />
             {form.errors.bodyMarkdown && (
-              <span className="text-sm text-red-600">{form.errors.bodyMarkdown}</span>
+              <span className="text-sm text-(--g-danger)">{form.errors.bodyMarkdown}</span>
             )}
           </label>
 
@@ -85,7 +85,7 @@ export default function AdminPostForm({ post }: Props) {
             <button
               type="submit"
               disabled={form.processing}
-              className="rounded-full bg-docs-accent px-6 py-2.5 font-semibold text-white disabled:opacity-60"
+              className="docs-btn-primary px-6 py-2.5 disabled:opacity-60"
             >
               {post ? 'Save changes' : 'Create post'}
             </button>

--- a/web/resources/js/pages/admin/Posts.tsx
+++ b/web/resources/js/pages/admin/Posts.tsx
@@ -42,14 +42,14 @@ export default function AdminPosts({ posts }: Props) {
           <div className="flex items-center gap-3">
             <Link
               href="/admin/posts/new"
-              className="rounded-full bg-docs-accent px-5 py-2 font-semibold text-white no-underline"
+              className="docs-btn-primary px-5 py-2 no-underline"
             >
               New post
             </Link>
             <button
               type="button"
               onClick={() => router.post('/logout')}
-              className="rounded-full border border-docs-border px-5 py-2 font-semibold text-docs-text-secondary"
+              className="rounded-lg border border-docs-border px-5 py-2 font-semibold text-docs-text-secondary"
             >
               Log out
             </button>
@@ -62,7 +62,7 @@ export default function AdminPosts({ posts }: Props) {
           <div style={{ overflowX: 'auto' }}>
             <table className="w-full border-collapse text-left">
               <thead>
-                <tr className="border-b border-docs-border text-xs font-bold uppercase tracking-widest text-docs-text-muted">
+                <tr className="docs-kicker border-b border-docs-border text-xs text-docs-text-secondary">
                   <th className="px-3 py-2">Title</th>
                   <th className="px-3 py-2">Status</th>
                   <th className="px-3 py-2">Updated</th>
@@ -89,7 +89,7 @@ export default function AdminPosts({ posts }: Props) {
                         <span className="text-sm text-docs-text-muted">Draft</span>
                       )}
                     </td>
-                    <td className="px-3 py-3 text-sm text-docs-text-muted">{formatDate(post.updatedAt)}</td>
+                    <td className="docs-mono px-3 py-3 text-sm text-docs-text-secondary">{formatDate(post.updatedAt)}</td>
                     <td className="px-3 py-3">
                       <div className="flex items-center gap-3 text-sm">
                         <Link href={`/admin/posts/${post.id}/edit`} className="font-semibold text-docs-accent no-underline">
@@ -98,7 +98,7 @@ export default function AdminPosts({ posts }: Props) {
                         <button type="button" onClick={() => togglePublish(post)} className="font-semibold text-docs-text-secondary">
                           {post.publishedAt ? 'Unpublish' : 'Publish'}
                         </button>
-                        <button type="button" onClick={() => destroy(post)} className="font-semibold text-red-600">
+                        <button type="button" onClick={() => destroy(post)} className="docs-btn-danger px-2.5 py-1 text-sm">
                           Delete
                         </button>
                       </div>

--- a/web/resources/js/pages/blog/Index.tsx
+++ b/web/resources/js/pages/blog/Index.tsx
@@ -64,7 +64,7 @@ export default function BlogIndex({ posts }: Props) {
           <div className="flex flex-col gap-8">
             {posts.map((post) => (
               <article key={post.slug} className="border-b border-docs-border pb-8">
-                <p className="mb-2 text-sm text-docs-text-muted">{formatDate(post.publishedAt)}</p>
+                <p className="docs-mono mb-2 text-sm text-docs-text-secondary">{formatDate(post.publishedAt)}</p>
                 <h2 className="mb-2 text-2xl font-bold text-docs-heading">
                   <Link href={`/blog/${post.slug}`} className="no-underline hover:underline">
                     {post.title}

--- a/web/resources/js/pages/blog/Show.tsx
+++ b/web/resources/js/pages/blog/Show.tsx
@@ -46,7 +46,7 @@ export default function BlogShow({ post }: Props) {
           <article className="docs-article">
             <header className="mb-12">
               {post.publishedAt && (
-                <p className="mb-3 text-sm text-docs-text-muted">{formatDate(post.publishedAt)}</p>
+                <p className="docs-mono mb-3 text-sm text-docs-text-secondary">{formatDate(post.publishedAt)}</p>
               )}
               <h1 className="mb-4 text-[2.75rem] font-extrabold leading-[1.1] tracking-tight text-docs-heading">
                 {post.title}
@@ -69,10 +69,7 @@ export default function BlogShow({ post }: Props) {
             <p className="mb-10 text-lg leading-relaxed text-docs-text-secondary">
               The post you are looking for doesn't exist or has been unpublished.
             </p>
-            <Link
-              href="/blog"
-              className="inline-flex items-center gap-2 rounded-full bg-docs-accent px-6 py-3 font-semibold text-white no-underline transition hover:scale-105"
-            >
+            <Link href="/blog" className="docs-btn-primary px-6 py-3">
               Back to the blog
             </Link>
           </section>

--- a/web/tests/services/MarkdownRenderer.test.ts
+++ b/web/tests/services/MarkdownRenderer.test.ts
@@ -8,10 +8,16 @@ const { renderMarkdownToHtml, rewriteDocLink } = await import(
 )
 
 describe('renderMarkdownToHtml', () => {
-  it('renders alert blocks', async () => {
+  it('renders alert blocks as diagnostic rows', async () => {
     const html = await renderMarkdownToHtml('> [!NOTE]\n> Hello there')
     expect(html).toContain('docs-alert--note')
-    expect(html).toContain('Note')
+    expect(html).toContain('<p class="docs-alert__label">note</p>')
+  })
+
+  it('maps warning directives onto the rule key', async () => {
+    const html = await renderMarkdownToHtml('> [!WARNING]\n> Careful')
+    expect(html).toContain('docs-alert--warning')
+    expect(html).toContain('<p class="docs-alert__label">rule</p>')
   })
 
   it('renders code blocks with shiki', async () => {


### PR DESCRIPTION
## Summary

Applies the [gurenjs/guren-ui](https://github.com/gurenjs/guren-ui) application design system to the guren.dev docs site. The system's tokens were originally derived from these docs themes, so this is not a recolor — it unifies the component language.

**Tokens** — `app.css` now carries the `--g-*` tokens from `guren-ui` `dist/tokens.css` as the source of truth; the existing `--docs-*` variables become aliases with unchanged values, so all current markup and the Tailwind theme keep working. Fonts stay on the site's existing policy (no self-hosted family is introduced).

**Component language**

- **Ember tick**: the 3px logo-gradient fragment marks one place per screen — the active sidebar item on doc pages (replacing the flat 2px border), the title block on the docs index (replacing the eyebrow dash).
- **Diagnostic-row callouts**: admonitions lose the colored boxes and render in the `guren check` output shape — a right-aligned mono key in a fixed gutter, a hairline, ordinary body text. GitHub's five directives map onto the system's key vocabulary: NOTE→`note`, TIP→`ok`, IMPORTANT/WARNING→`rule`, CAUTION→`never`.
- **Themeless ink code surface**: code blocks sit on ink `#1a1212` (the surface `CodeBlock.tsx` already paints) in both themes, with the rose-pine-moon palette. Both markdown pipelines keep emitting dual-theme shiki HTML — the blog stores rendered HTML at save time, so the stored shape cannot change — and `app.css` now applies the dark palette unconditionally (scoped to `.docs-content`; the landing page already single-themes). The copy button is restyled for the ink surface and is themeless too.
- **The red budget**: crimson fills stay crimson in both themes via `.docs-btn-primary`. Previously `bg-docs-accent` fills flipped to the rose accent in dark mode, putting white text on `#eb6f92` (~2.5:1). Destructive actions (admin Delete) become outline + explicit verb (`.docs-btn-danger`) instead of red text.
- **Mono for machine-issued values**: table headers, nav section labels, TOC/eyebrow kickers, category slugs, badge labels, and dates.
- **Geometry**: radii settle on 8px (controls) / 12px (cards); the stray third shadow on pagination links joins the two-shadow system.

**Contrast** — measured in both themes with computed styles: rule key 5.02:1 / note key 6.11:1 on white, 10+:1 on the dark ground; labels that previously used the muted color (2.5:1 on white) move to the secondary text color.

## Testing

- `bun run test` (web) — 113 passed, including new assertions for the diagnostic-row keys
- `bun run typecheck` (web) — clean
- `bun run build` (web) — codegen + prerender + vite + SSR build clean
- `bun run audit:core-first`, `bun run audit:docs` — pass
- Verified light and dark themes in the browser: index, guide page, sidebar tick, diagnostic rows, ink code blocks