### PR TITLE
fix(cli): say a routes file could not be read, instead of reporting none

### DIFF
--- a/.changeset/context-reports-unreadable-routes.md
+++ b/.changeset/context-reports-unreadable-routes.md
@@ -1,7 +1,0 @@
----
-"@guren/cli": patch
----
-
-Report a routes file `guren context <Entity>` could not read, instead of reporting that the entity has no routes.
-
-The entity bundle loads the routes file for real — it imports it to read the definitions off a router — and caught every failure of that import as an empty result. An app whose routes could not be loaded therefore rendered exactly what an app whose entity has no routes renders: `## Routes (0)` and `No routes reference this entity.`, exit 0. Every reader of that bundle, agent or human, had no way to tell a confident answer from a failed one. The reason is now printed in place of that line, with the note that the list is incomplete.

--- a/.changeset/context-reports-unreadable-routes.md
+++ b/.changeset/context-reports-unreadable-routes.md
@@ -1,0 +1,7 @@
+---
+"@guren/cli": patch
+---
+
+Report a routes file `guren context <Entity>` could not read, instead of reporting that the entity has no routes.
+
+The entity bundle loads the routes file for real — it imports it to read the definitions off a router — and caught every failure of that import as an empty result. An app whose routes could not be loaded therefore rendered exactly what an app whose entity has no routes renders: `## Routes (0)` and `No routes reference this entity.`, exit 0. Every reader of that bundle, agent or human, had no way to tell a confident answer from a failed one. The reason is now printed in place of that line, with the note that the list is incomplete.

--- a/examples/api/CHANGELOG.md
+++ b/examples/api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @guren/example-api
 
+## 0.1.21
+
+### Patch Changes
+
+- Updated dependencies [10459aa]
+  - @guren/cli@2.7.1
+
 ## 0.1.20
 
 ### Patch Changes

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/example-api",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @guren/cli
 
+## 2.7.1
+
+### Patch Changes
+
+- 10459aa: Report a routes file `guren context <Entity>` could not read, instead of reporting that the entity has no routes.
+
+  The entity bundle loads the routes file for real — it imports it to read the definitions off a router — and caught every failure of that import as an empty result. An app whose routes could not be loaded therefore rendered exactly what an app whose entity has no routes renders: `## Routes (0)` and `No routes reference this entity.`, exit 0. Every reader of that bundle, agent or human, had no way to tell a confident answer from a failed one. The reason is now printed in place of that line, with the note that the list is incomplete.
+
 ## 2.7.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/cli",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/entity-context.ts
+++ b/packages/cli/src/entity-context.ts
@@ -88,6 +88,8 @@ export interface EntityContext {
   /** Reverse relationship edges: other models whose relationships target this entity. */
   referencedBy: Array<{ model: string; relationship: string; type: string }>
   routes: ContextRoute[]
+  /** Why the routes file could not be loaded, when it could not be. */
+  routesError?: string
   controller?: { className: string; filePath: string; actions: string[] }
   pages: EntityPage[]
   resource?: string
@@ -228,6 +230,7 @@ export async function generateEntityContext(
       .sort()
   }
 
+  let routesError: string | undefined
   const loadEntityRoutes = async (): Promise<ContextRoute[]> => {
     try {
       const provenance: Array<string | null> = []
@@ -246,8 +249,13 @@ export async function generateEntityContext(
           return duplicated ? provenance[index] === match.module : true
         })
         .map(routeDefinitionToContextRoute)
-    } catch {
-      // Routes may not be loadable (missing deps, etc.) — degrade to a route-less bundle.
+    } catch (error) {
+      // A routes file that cannot be loaded is not a routes file with nothing
+      // in it. Reported rather than swallowed: the two used to render the same
+      // "No routes reference this entity.", so an app whose routes failed to
+      // import read as an app whose entity has no routes — and every reader of
+      // this bundle, agent or human, would have believed it.
+      routesError = error instanceof Error ? error.message : String(error)
       return []
     }
   }
@@ -355,6 +363,7 @@ export async function generateEntityContext(
     },
     referencedBy,
     routes,
+    routesError,
     controller: controllerBundle.controller,
     pages: controllerBundle.pages,
     resource,
@@ -406,6 +415,9 @@ export function renderEntityContextMarkdown(ctx: EntityContext): string {
       const cells = [route.method, route.path, route.name ?? '', action, route.params ?? '', route.body ?? '']
       lines.push(`| ${cells.map(escapeMarkdownTableCell).join(' | ')} |`)
     }
+  } else if (ctx.routesError) {
+    lines.push(`Routes could not be read: ${ctx.routesError}`)
+    lines.push('This is not the same as the entity having no routes — the list above is incomplete.')
   } else {
     lines.push('No routes reference this entity.')
   }

--- a/packages/cli/tests/context-entity-arg.test.ts
+++ b/packages/cli/tests/context-entity-arg.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
-import { CLI_BIN_PATH, SERVER_DIST_ENTRY, assertWorkspaceBuilt, createTempWorkspace } from './helpers'
+import { CLI_BIN_PATH, SERVER_DIST_ENTRY, assertWorkspaceBuilt, createTempWorkspace, linkWorkspaceCore } from './helpers'
 
 /**
  * Spawn the real bin: `bin.ts` exports nothing and builds its commands at
@@ -82,6 +82,9 @@ export class Post extends defineModel(posts) {}
 const CUSTOM_ROUTES_FILE = 'routes/custom.ts'
 
 async function writeRoutesFixture(dir: string): Promise<void> {
+  await linkWorkspaceCore(dir)
+  // this fixture is imported, not just parsed: `guren context` loads the
+  // routes file to read its definitions, so its `@guren/core` has to resolve
   await mkdir(join(dir, 'app/Http/Controllers'), { recursive: true })
   await mkdir(join(dir, 'routes'), { recursive: true })
   await writeFile(
@@ -247,6 +250,31 @@ describe('context entity argument', () => {
       expect(exitCode).toBe(0)
       expect(stdout).toContain('## Model — app/Models/User.ts')
       expect(stdout).not.toContain('modules/billing/app/Models/User.ts')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('says the routes file could not be read, rather than reporting no routes', async () => {
+    // the shape that hid a broken environment: an unloadable routes file used
+    // to render exactly what an entity with no routes renders, so a machine
+    // that could not resolve the fixture's imports produced a confident,
+    // wrong answer instead of an error
+    const workspace = await createTempWorkspace('guren-cli-context-routes-broken-')
+    try {
+      await writeModelFixture(workspace.dir)
+      await writeRoutesFixture(workspace.dir)
+      await writeFile(
+        join(workspace.dir, CUSTOM_ROUTES_FILE),
+        "import { nothing } from 'package-that-is-not-installed'\nexport function registerWebRoutes(): void { nothing() }\n",
+        'utf8',
+      )
+
+      const { exitCode, stdout } = await runBin(['context', '--routes', CUSTOM_ROUTES_FILE, 'User'], workspace.dir)
+
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('Routes could not be read:')
+      expect(stdout).not.toContain('No routes reference this entity.')
     } finally {
       await workspace.cleanup()
     }

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -55,6 +55,24 @@ export async function writeInstalledPackage(
 }
 
 /**
+ * Point a fixture app's `@guren/core` at this checkout.
+ *
+ * A fixture that gets imported rather than only parsed — `guren context`
+ * loads `routes/*.ts` for real — needs the import to resolve from a temp
+ * directory that has no node_modules. Bun resolves that by walking up from
+ * the file and then falling back to its global install cache, so on a machine
+ * that has ever installed Guren the fixture silently binds to the *published*
+ * package (verified: `~/.bun/install/cache/@guren/core@1.7.0/dist/index.js`),
+ * and on a machine that has not, the import throws. Either way the test is
+ * measuring the environment. This makes it measure the workspace.
+ */
+export async function linkWorkspaceCore(baseDir: string): Promise<void> {
+  const linkPath = join(baseDir, 'node_modules', '@guren', 'core')
+  await mkdir(dirname(linkPath), { recursive: true })
+  await symlink(join(repoRoot, 'packages', 'core'), linkPath, 'dir')
+}
+
+/**
  * Write a fake locally-installed package the way Bun materializes `file:`,
  * `link:`, and `workspace:` dependencies: node_modules/<name> is a real
  * directory tree whose files are individual symlinks into the source

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,20 @@
 # create-guren-app
 
+## 1.8.5
+
+### Patch Changes
+
+- Ship template dependency ranges for this release
+
+  The scaffold's `@guren/*` ranges are generated from the workspace versions,
+  and this release moves `@guren/cli`.
+  `changeset publish` only uploads packages whose own version moved, so
+  without this bump the updated ranges would sit in the repo and never reach
+  anyone running `create-guren-app`.
+
+  No behaviour change; the scaffolded app just resolves the versions released
+  alongside it.
+
 ## 1.8.4
 
 ### Patch Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-guren-app",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/create-app/templates/api-only/package.json
+++ b/packages/create-app/templates/api-only/package.json
@@ -18,7 +18,7 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@guren/cli": "^2.7.0",
+    "@guren/cli": "^2.7.1",
     "@guren/core": "^1.8.0",
     "@guren/orm": "^2.6.0",
     "drizzle-orm": "1.0.0-rc.4"

--- a/packages/create-app/templates/default/package.json
+++ b/packages/create-app/templates/default/package.json
@@ -19,7 +19,7 @@
     "db:seed": "bunx guren db:seed"
   },
   "dependencies": {
-    "@guren/cli": "^2.7.0",
+    "@guren/cli": "^2.7.1",
     "@guren/core": "^1.8.0",
     "@guren/inertia-client": "^1.1.1",
     "@guren/orm": "^2.6.0",

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,12 @@
 # web
 
+## 0.1.21
+
+### Patch Changes
+
+- Updated dependencies [10459aa]
+  - @guren/cli@2.7.1
+
 ## 0.1.20
 
 ### Patch Changes

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Blocks the v2.9.0 release: `release.yml` failed at `Run tests`, deterministically (reproduced on rerun), on `context entity argument > takes the last value of a repeated --routes`. Nothing was published — the failure is before `changeset publish`.

## What was actually wrong

`guren context <Entity>` loads the routes file for real: it imports the module and reads definitions off a router. Every failure of that import was caught and turned into an empty list, and an empty list renders as `## Routes (0)` / `No routes reference this entity.`, exit 0 — byte for byte what an entity with genuinely no routes renders. A reader cannot tell a confident answer from a failed one, which is exactly how this surfaced: the release gate reported a wrong answer instead of an error, and the test caught it only because the *control* run in the same test changed.

The reason is now printed in place of that line, with a note that the list is incomplete.

## Why the test was environment-dependent

The fixture is written to a temp directory, which has no `node_modules`, so Bun walks up and then falls back to its global install cache. Measured on this machine: it resolved to `~/.bun/install/cache/@guren/core@1.7.0/dist/index.js` — the *published* package, not the workspace. On a runner whose cache lacks it, the import throws instead. The fixture now links `@guren/core` to this checkout, so the test measures the checkout.

**Honest limit:** I could not reproduce the runner's failure locally (an empty `BUN_INSTALL` still resolved). This PR removes the ambient dependence and makes the failure loud; if the release gate still fails, its log will now name the cause instead of printing a wrong answer.

## Validation

- `bun run test:bun cli` — 1552 pass
- `bun run typecheck` (root), `audit:template-deps`, `audit:agent-catalog` — green
- Mutation: restoring the swallow fails the new test

Includes the version bump for the added changeset — `@guren/cli` 2.7.0 → 2.7.1. `@guren/server` stays 2.9.0, so the release tag is still `v2.9.0`.