### PR TITLE
fix(cli): key the agent-catalog changeset gate on a moved CLI version

### DIFF
--- a/.changeset/agent-catalog-version-exemption.md
+++ b/.changeset/agent-catalog-version-exemption.md
@@ -1,0 +1,5 @@
+---
+"@guren/cli": patch
+---
+
+Exempt the agent-catalog changeset gate on a moved `@guren/cli` version rather than on a manifest-only diff. A push or squash carrying both a catalog change with its changeset and the `changeset version` commit that consumes it no longer fails the gate, and a manifest edit that leaves the version alone is now gated rather than waved through.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,13 +160,18 @@ jobs:
       # unremediable case, and no one can make a collected SHA fetchable again.
       #
       # The release commit stays green. `changeset version` empties .changeset
-      # and bumps versions; the only catalog input it moves is
-      # packages/cli/package.json, since the sync-template-deps pass that
-      # follows writes under packages/create-app/templates and never under
-      # packages/cli/templates. assertChangesetGate exempts a diff whose
-      # touched inputs are the CLI manifest alone, which is that commit — it
-      # reaches main as its own squash merge, so the push diff is that commit
-      # and nothing else.
+      # and bumps versions, so the diff it produces has no changeset left in
+      # the tree to find. assertChangesetGate exempts it on the version
+      # instead: the @guren/cli version moved, and the harm the gate names —
+      # a payload published under an unchanged version — cannot occur when it
+      # did. That is deliberately wider than the "the CLI manifest was the
+      # only file touched" rule it replaces, and subsumes it: the exemption
+      # holds even when a catalog template rides in the same push or squash
+      # as the version commit, which the narrow rule turned into a false red.
+      # Do not re-add the narrow branch beside it. Note the direction, which
+      # is what keeps RFC 0011 §5 satisfied: the version is an *exemption*,
+      # never a demand — a feature PR still satisfies this gate the only way
+      # it can, by adding a changeset.
       - name: Agent catalog audit
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,17 +161,11 @@ jobs:
       #
       # The release commit stays green. `changeset version` empties .changeset
       # and bumps versions, so the diff it produces has no changeset left in
-      # the tree to find. assertChangesetGate exempts it on the version
-      # instead: the @guren/cli version moved, and the harm the gate names —
-      # a payload published under an unchanged version — cannot occur when it
-      # did. That is deliberately wider than the "the CLI manifest was the
-      # only file touched" rule it replaces, and subsumes it: the exemption
-      # holds even when a catalog template rides in the same push or squash
-      # as the version commit, which the narrow rule turned into a false red.
-      # Do not re-add the narrow branch beside it. Note the direction, which
-      # is what keeps RFC 0011 §5 satisfied: the version is an *exemption*,
-      # never a demand — a feature PR still satisfies this gate the only way
-      # it can, by adding a changeset.
+      # the tree to find; assertChangesetGate exempts it on the moved
+      # @guren/cli version instead. Why that is the right key, and why it is
+      # an exemption rather than a demand a feature PR would have to satisfy,
+      # is argued where the branch lives — see the comment on the exemption
+      # in scripts/build-agent-catalog.ts.
       - name: Agent catalog audit
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then

--- a/rfcs/0011-agent-catalog-distribution.md
+++ b/rfcs/0011-agent-catalog-distribution.md
@@ -658,14 +658,16 @@ Automated, in CI on every PR:
    unrecognized top-level field is fatal to conforming clients (§4).
 4. Mutation checks in the implementation PR, proving 1 can fail: name a
    nonexistent target; name an unregistered command. **Amended in
-   implementation:** the two changeset-gate mutations in this list are *not*
-   automated. `assertChangesetGate` needs a git base ref, so the test suite
-   covers its frontmatter parser and its input list rather than the rule
-   itself; the gate was verified by hand on the implementation branch (with
-   the `@guren/cli` changesets hidden it fails with the full changed-input
-   list) and it runs on every PR. Listed here as manual coverage, because a
-   verification list that names checks nobody wrote is worse than a shorter
-   one.
+   implementation:** the changeset gate was first listed here as *manual*
+   coverage — `assertChangesetGate` needs a git base ref, so the suite covered
+   its frontmatter parser and its input list rather than the rule itself. That
+   gap is now closed: the gate's decisions are exercised against throwaway
+   repositories built per case (`scripts/build-agent-catalog.test.ts`,
+   `audit: changeset gate`), including the release commit's exemption, a
+   catalog change without a changeset, a manifest edit that does not move the
+   version, an unreadable base version, and the shallow-fetched base ref CI
+   itself resolves. Each was confirmed to fail against the implementation it
+   is meant to reject.
 
 Manual, once before the first publish and after any payload change:
 

--- a/scripts/build-agent-catalog.test.ts
+++ b/scripts/build-agent-catalog.test.ts
@@ -490,6 +490,29 @@ describe('audit: changeset gate', () => {
     expect(await assertChangesetGate(base, repo)).toEqual([])
   })
 
+  it('falls back to a two-dot diff when there is no merge base', async () => {
+    // What a shallow CI checkout looks like: the base was fetched by SHA to
+    // depth 1, so it shares no history with HEAD and `git merge-base` has no
+    // answer. The fallback must be the base tip — an empty left side would
+    // make the diff `HEAD..HEAD`, which reports no files and passes this gate
+    // on every such run.
+    const { repo, base } = await baseRepo()
+    git(repo, 'checkout', '--quiet', '--orphan', 'unrelated')
+    await commit(repo, 'unrelated root', {
+      [CLI_MANIFEST]: manifest('2.7.1'),
+      'packages/cli/templates/agent-catalog/README.md.tpl': 'after\n',
+    })
+    // the two premises, pinned: git really has no merge base to offer here,
+    // and an empty rev would not be a loud failure but a silent pass
+    expect(Bun.spawnSync(['git', 'merge-base', base, 'HEAD'], { cwd: repo }).success).toBe(false)
+    const emptyLeftSide = Bun.spawnSync(['git', 'diff', '--name-only', '..HEAD'], { cwd: repo })
+    expect(emptyLeftSide.success).toBe(true)
+    expect(emptyLeftSide.stdout.toString().trim()).toBe('')
+    const problems = await assertChangesetGate(base, repo)
+    expect(problems).toHaveLength(1)
+    expect(problems[0]).toContain('README.md.tpl')
+  })
+
   it('reports a base ref it cannot resolve rather than passing', async () => {
     const { repo } = await baseRepo()
     const problems = await assertChangesetGate('refs/does-not-exist', repo)

--- a/scripts/build-agent-catalog.test.ts
+++ b/scripts/build-agent-catalog.test.ts
@@ -347,29 +347,29 @@ describe('audit: changeset gate', () => {
 
   /**
    * Every git call is hardened against the machine it runs on: a global
-   * `core.hooksPath` reaches repositories created here (the publish script
-   * disables it for the same reason), a global `commit.gpgsign` would make a
-   * commit *prompt* — and a hang in bun:test is charged to the following
-   * test, so it would not even look like this one — and a CI runner has no
-   * committer identity to inherit.
+   * `core.hooksPath` reaches repositories created here (publish-agent-catalog
+   * disables it the same way, and its comment has the full hazard list), a
+   * global `commit.gpgsign` would make a commit *prompt* — and a hang in
+   * bun:test is charged to the following test, so it would not even look
+   * like this one — and a CI runner has no committer identity to inherit.
    */
+  const HERMETIC = [
+    '-c', 'core.hooksPath=',
+    '-c', 'commit.gpgsign=false',
+    '-c', 'user.name=Guren gate test',
+    '-c', 'user.email=gate-test@guren.dev',
+  ]
+
   function git(repo: string, ...args: string[]): string {
-    const proc = Bun.spawnSync(
-      [
-        'git',
-        '-c', 'core.hooksPath=/dev/null',
-        '-c', 'commit.gpgsign=false',
-        '-c', 'user.name=Guren gate test',
-        '-c', 'user.email=gate-test@guren.dev',
-        ...args,
-      ],
-      { cwd: repo },
-    )
+    const proc = Bun.spawnSync(['git', ...HERMETIC, ...args], { cwd: repo })
     if (!proc.success) {
       throw new Error(`git ${args.join(' ')} failed: ${proc.stderr.toString().trim()}`)
     }
     return proc.stdout.toString().trim()
   }
+
+  /** A path under `scratch` no other case has used. */
+  const newRepoDir = (suffix = '') => join(scratch, `repo-${++repoCount}${suffix}`)
 
   const manifest = (version: string, extra: Record<string, unknown> = {}) =>
     `${JSON.stringify({ name: '@guren/cli', version, ...extra }, null, 2)}\n`
@@ -396,7 +396,7 @@ describe('audit: changeset gate', () => {
    * the sha to use as the gate's base.
    */
   async function baseRepo(version = '2.7.1'): Promise<{ repo: string; base: string }> {
-    const repo = join(scratch, `repo-${++repoCount}`)
+    const repo = newRepoDir()
     await mkdir(repo, { recursive: true })
     git(repo, 'init', '--quiet', '--initial-branch=main')
     const base = await commit(repo, 'base', {
@@ -408,6 +408,22 @@ describe('audit: changeset gate', () => {
   }
 
   const CHANGESET = '---\n"@guren/cli": patch\n---\n\ncatalog wording\n'
+  const CHANGESET_FILE = '.changeset/tidy-pandas-shout.md'
+  const TEMPLATE = 'packages/cli/templates/agent-catalog/README.md.tpl'
+
+  /** The feature PR: a catalog template edit, with or without its changeset. */
+  const rewordCatalog = (repo: string, withChangeset: boolean) =>
+    commit(repo, 'reword the catalog', {
+      [TEMPLATE]: 'after\n',
+      ...(withChangeset ? { [CHANGESET_FILE]: CHANGESET } : {}),
+    })
+
+  /** What `changeset version` commits: the bump, and the changeset consumed. */
+  const versionPackages = (repo: string, version: string) =>
+    commit(repo, `chore: version packages to ${version}`, {
+      [CLI_MANIFEST]: manifest(version),
+      [CHANGESET_FILE]: null,
+    })
 
   it('passes when nothing it watches changed', async () => {
     const { repo, base } = await baseRepo()
@@ -417,9 +433,7 @@ describe('audit: changeset gate', () => {
 
   it('fails on a catalog change with no @guren/cli changeset', async () => {
     const { repo, base } = await baseRepo()
-    await commit(repo, 'reword the catalog', {
-      'packages/cli/templates/agent-catalog/README.md.tpl': 'after\n',
-    })
+    await rewordCatalog(repo, false)
     const problems = await assertChangesetGate(base, repo)
     expect(problems).toHaveLength(1)
     expect(problems[0]).toContain('README.md.tpl')
@@ -428,10 +442,7 @@ describe('audit: changeset gate', () => {
 
   it('passes on a catalog change that carries one — the rule a feature PR can satisfy', async () => {
     const { repo, base } = await baseRepo()
-    await commit(repo, 'reword the catalog', {
-      'packages/cli/templates/agent-catalog/README.md.tpl': 'after\n',
-      '.changeset/tidy-pandas-shout.md': CHANGESET,
-    })
+    await rewordCatalog(repo, true)
     expect(await assertChangesetGate(base, repo)).toEqual([])
   })
 
@@ -442,15 +453,39 @@ describe('audit: changeset gate', () => {
     // in the tree to be found, so this range was a false red. Nothing here
     // can publish under an unchanged version: 2.7.1 → 2.8.0.
     const { repo, base } = await baseRepo('2.7.1')
-    await commit(repo, 'reword the catalog', {
-      'packages/cli/templates/agent-catalog/README.md.tpl': 'after\n',
-      '.changeset/tidy-pandas-shout.md': CHANGESET,
-    })
-    await commit(repo, 'chore: version packages to 2.8.0', {
-      [CLI_MANIFEST]: manifest('2.8.0'),
-      '.changeset/tidy-pandas-shout.md': null,
-    })
+    await rewordCatalog(repo, true)
+    await versionPackages(repo, '2.8.0')
     expect(await assertChangesetGate(base, repo)).toEqual([])
+  })
+
+  it('passes on the release commit whose only touched input is the manifest', async () => {
+    // The ordinary `changeset version` push, where no catalog template rides
+    // along: one input touched, and the version moved. Without this case a
+    // rule reading `touched.length > 1 && baseVersion !== headVersion` would
+    // satisfy every other test here and turn every plain release commit red.
+    const { repo, base } = await baseRepo('2.7.1')
+    await versionPackages(repo, '2.8.0')
+    expect(await assertChangesetGate(base, repo)).toEqual([])
+  })
+
+  it('reads the base version from the merge base, not from a base that moved on', async () => {
+    // A branch that forked before a release: its own range moves nothing, but
+    // the base ref it is compared against has since advanced to 2.8.0.
+    // Reading the base *tip* would see 2.7.1 vs 2.8.0 and exempt a catalog
+    // change that publishes under an unchanged version.
+    const { repo, base } = await baseRepo('2.7.1')
+    git(repo, 'checkout', '--quiet', '-b', 'feature')
+    await rewordCatalog(repo, false)
+    git(repo, 'checkout', '--quiet', 'main')
+    await versionPackages(repo, '2.8.0')
+    git(repo, 'checkout', '--quiet', 'feature')
+    // the premise: the base ref's tip and the merge base disagree about the version
+    expect(git(repo, 'show', `main:${CLI_MANIFEST}`)).toContain('2.8.0')
+    expect(git(repo, 'merge-base', 'main', 'HEAD')).toBe(base)
+
+    const problems = await assertChangesetGate('main', repo)
+    expect(problems).toHaveLength(1)
+    expect(problems[0]).toContain('README.md.tpl')
   })
 
   it('fails on a manifest edit that does not move the version', async () => {
@@ -472,13 +507,13 @@ describe('audit: changeset gate', () => {
     // exemption is not granted. An unavailable check is not a green one —
     // and a silent pass here would be worse than CI's ungated fallback,
     // which at least annotates itself.
-    const repo = join(scratch, `repo-${++repoCount}`)
+    const repo = newRepoDir()
     await mkdir(repo, { recursive: true })
     git(repo, 'init', '--quiet', '--initial-branch=main')
     const base = await commit(repo, 'base without a CLI package', { 'web/index.md': 'docs\n' })
     await commit(repo, 'add the CLI and a catalog template', {
       [CLI_MANIFEST]: manifest('2.7.1'),
-      'packages/cli/templates/agent-catalog/README.md.tpl': 'after\n',
+      [TEMPLATE]: 'after\n',
     })
     const problems = await assertChangesetGate(base, repo)
     expect(problems).toHaveLength(1)
@@ -486,7 +521,7 @@ describe('audit: changeset gate', () => {
 
     // …but it is not a red on its own: a changeset still satisfies the gate,
     // so an unreadable version cannot fail a PR that did the right thing.
-    await commit(repo, 'add the changeset', { '.changeset/tidy-pandas-shout.md': CHANGESET })
+    await commit(repo, 'add the changeset', { [CHANGESET_FILE]: CHANGESET })
     expect(await assertChangesetGate(base, repo)).toEqual([])
   })
 
@@ -500,10 +535,8 @@ describe('audit: changeset gate', () => {
     git(repo, 'checkout', '--quiet', '--orphan', 'unrelated')
     await commit(repo, 'unrelated root', {
       [CLI_MANIFEST]: manifest('2.7.1'),
-      'packages/cli/templates/agent-catalog/README.md.tpl': 'after\n',
+      [TEMPLATE]: 'after\n',
     })
-    // the two premises, pinned: git really has no merge base to offer here,
-    // and an empty rev would not be a loud failure but a silent pass
     expect(Bun.spawnSync(['git', 'merge-base', base, 'HEAD'], { cwd: repo }).success).toBe(false)
     const emptyLeftSide = Bun.spawnSync(['git', 'diff', '--name-only', '..HEAD'], { cwd: repo })
     expect(emptyLeftSide.success).toBe(true)
@@ -521,18 +554,12 @@ describe('audit: changeset gate', () => {
     // `git show <shallow-ref>:<path>`, and if that could not resolve, every
     // release commit would be red for the reason this change removed.
     const { repo: origin, base } = await baseRepo('2.7.1')
-    await commit(origin, 'reword the catalog', {
-      'packages/cli/templates/agent-catalog/README.md.tpl': 'after\n',
-      '.changeset/tidy-pandas-shout.md': CHANGESET,
-    })
-    await commit(origin, 'chore: version packages to 2.8.0', {
-      [CLI_MANIFEST]: manifest('2.8.0'),
-      '.changeset/tidy-pandas-shout.md': null,
-    })
+    await rewordCatalog(origin, true)
+    await versionPackages(origin, '2.8.0')
     // servers refuse a by-SHA want unless they allow it; GitHub does
     git(origin, 'config', 'uploadpack.allowAnySHA1InWant', 'true')
 
-    const shallow = join(scratch, `repo-${++repoCount}-shallow`)
+    const shallow = newRepoDir('-shallow')
     git(scratch, 'clone', '--quiet', '--depth', '1', `file://${origin}`, shallow)
     git(shallow, 'fetch', '--no-tags', '--depth=1', 'origin', `${base}:refs/audit-base`)
     expect(Bun.spawnSync(['git', 'merge-base', 'refs/audit-base', 'HEAD'], { cwd: shallow }).success).toBe(false)

--- a/scripts/build-agent-catalog.test.ts
+++ b/scripts/build-agent-catalog.test.ts
@@ -1,11 +1,13 @@
-import { describe, expect, it } from 'bun:test'
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
 
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
 import {
   CATALOG_INPUTS,
+  CLI_MANIFEST,
+  assertChangesetGate,
   assertCommandsAndFlags,
   assertMinCli,
   assertPortableManifest,
@@ -317,5 +319,181 @@ describe('claude plugin validate', () => {
     } finally {
       await rm(dir, { recursive: true, force: true })
     }
+  })
+})
+
+/**
+ * The changeset gate, against throwaway repositories.
+ *
+ * Everything above tests the gate's *parser*; none of it ran the gate, which
+ * needs real commits to diff. That left its actual decisions — including the
+ * exemption, the one branch a release commit depends on — pinned by nothing.
+ * These build a repository per case and point `assertChangesetGate` at it.
+ *
+ * The fixture only has to carry what the gate reads: the paths in
+ * `CATALOG_INPUTS`, the CLI manifest's `version`, and `.changeset/`. Content
+ * is irrelevant to it, so the templates here are one line each.
+ */
+describe('audit: changeset gate', () => {
+  let scratch: string
+  let repoCount = 0
+
+  beforeAll(async () => {
+    scratch = await mkdtemp(join(tmpdir(), 'guren-catalog-gate-'))
+  })
+  afterAll(async () => {
+    await rm(scratch, { recursive: true, force: true })
+  })
+
+  /**
+   * Every git call is hardened against the machine it runs on: a global
+   * `core.hooksPath` reaches repositories created here (the publish script
+   * disables it for the same reason), a global `commit.gpgsign` would make a
+   * commit *prompt* — and a hang in bun:test is charged to the following
+   * test, so it would not even look like this one — and a CI runner has no
+   * committer identity to inherit.
+   */
+  function git(repo: string, ...args: string[]): string {
+    const proc = Bun.spawnSync(
+      [
+        'git',
+        '-c', 'core.hooksPath=/dev/null',
+        '-c', 'commit.gpgsign=false',
+        '-c', 'user.name=Guren gate test',
+        '-c', 'user.email=gate-test@guren.dev',
+        ...args,
+      ],
+      { cwd: repo },
+    )
+    if (!proc.success) {
+      throw new Error(`git ${args.join(' ')} failed: ${proc.stderr.toString().trim()}`)
+    }
+    return proc.stdout.toString().trim()
+  }
+
+  const manifest = (version: string, extra: Record<string, unknown> = {}) =>
+    `${JSON.stringify({ name: '@guren/cli', version, ...extra }, null, 2)}\n`
+
+  /** Write files (null deletes), then commit. Returns the new HEAD sha. */
+  async function commit(repo: string, message: string, changes: Record<string, string | null>): Promise<string> {
+    for (const [path, content] of Object.entries(changes)) {
+      const full = join(repo, path)
+      if (content === null) {
+        await rm(full, { force: true })
+        continue
+      }
+      await mkdir(dirname(full), { recursive: true })
+      await writeFile(full, content, 'utf8')
+    }
+    git(repo, 'add', '-A')
+    git(repo, 'commit', '--quiet', '-m', message)
+    return git(repo, 'rev-parse', 'HEAD')
+  }
+
+  /**
+   * A repository at the state before the change under test: a CLI manifest, a
+   * catalog template, and an empty `.changeset/`. Returns the repo path and
+   * the sha to use as the gate's base.
+   */
+  async function baseRepo(version = '2.7.1'): Promise<{ repo: string; base: string }> {
+    const repo = join(scratch, `repo-${++repoCount}`)
+    await mkdir(repo, { recursive: true })
+    git(repo, 'init', '--quiet', '--initial-branch=main')
+    const base = await commit(repo, 'base', {
+      [CLI_MANIFEST]: manifest(version),
+      'packages/cli/templates/agent-catalog/README.md.tpl': 'before\n',
+      '.changeset/README.md': 'changesets live here\n',
+    })
+    return { repo, base }
+  }
+
+  const CHANGESET = '---\n"@guren/cli": patch\n---\n\ncatalog wording\n'
+
+  it('passes when nothing it watches changed', async () => {
+    const { repo, base } = await baseRepo()
+    await commit(repo, 'unrelated', { 'web/index.md': 'docs\n' })
+    expect(await assertChangesetGate(base, repo)).toEqual([])
+  })
+
+  it('fails on a catalog change with no @guren/cli changeset', async () => {
+    const { repo, base } = await baseRepo()
+    await commit(repo, 'reword the catalog', {
+      'packages/cli/templates/agent-catalog/README.md.tpl': 'after\n',
+    })
+    const problems = await assertChangesetGate(base, repo)
+    expect(problems).toHaveLength(1)
+    expect(problems[0]).toContain('README.md.tpl')
+    expect(problems[0]).toContain('@guren/cli')
+  })
+
+  it('passes on a catalog change that carries one — the rule a feature PR can satisfy', async () => {
+    const { repo, base } = await baseRepo()
+    await commit(repo, 'reword the catalog', {
+      'packages/cli/templates/agent-catalog/README.md.tpl': 'after\n',
+      '.changeset/tidy-pandas-shout.md': CHANGESET,
+    })
+    expect(await assertChangesetGate(base, repo)).toEqual([])
+  })
+
+  it('passes when the CLI version moved, even with a catalog change in the same range', async () => {
+    // The A-then-B push: a catalog change with its changeset, and then the
+    // `changeset version` commit that consumes it. The old manifest-only
+    // exemption did not match (two inputs touched) and no changeset survives
+    // in the tree to be found, so this range was a false red. Nothing here
+    // can publish under an unchanged version: 2.7.1 → 2.8.0.
+    const { repo, base } = await baseRepo('2.7.1')
+    await commit(repo, 'reword the catalog', {
+      'packages/cli/templates/agent-catalog/README.md.tpl': 'after\n',
+      '.changeset/tidy-pandas-shout.md': CHANGESET,
+    })
+    await commit(repo, 'chore: version packages to 2.8.0', {
+      [CLI_MANIFEST]: manifest('2.8.0'),
+      '.changeset/tidy-pandas-shout.md': null,
+    })
+    expect(await assertChangesetGate(base, repo)).toEqual([])
+  })
+
+  it('fails on a manifest edit that does not move the version', async () => {
+    // The branch the version rule replaces. The old exemption was "the CLI
+    // manifest was the only file touched", which waved this through — a
+    // manifest change is not a version change, and this one publishes the
+    // payload under 2.7.1 all over again.
+    const { repo, base } = await baseRepo('2.7.1')
+    await commit(repo, 'add a keyword', {
+      [CLI_MANIFEST]: manifest('2.7.1', { keywords: ['guren'] }),
+    })
+    const problems = await assertChangesetGate(base, repo)
+    expect(problems).toHaveLength(1)
+    expect(problems[0]).toContain(CLI_MANIFEST)
+  })
+
+  it('does not exempt a version it could not read, and says so', async () => {
+    // No manifest on the base side: the comparison cannot be made, so the
+    // exemption is not granted. An unavailable check is not a green one —
+    // and a silent pass here would be worse than CI's ungated fallback,
+    // which at least annotates itself.
+    const repo = join(scratch, `repo-${++repoCount}`)
+    await mkdir(repo, { recursive: true })
+    git(repo, 'init', '--quiet', '--initial-branch=main')
+    const base = await commit(repo, 'base without a CLI package', { 'web/index.md': 'docs\n' })
+    await commit(repo, 'add the CLI and a catalog template', {
+      [CLI_MANIFEST]: manifest('2.7.1'),
+      'packages/cli/templates/agent-catalog/README.md.tpl': 'after\n',
+    })
+    const problems = await assertChangesetGate(base, repo)
+    expect(problems).toHaveLength(1)
+    expect(problems[0]).toContain('could not be read')
+
+    // …but it is not a red on its own: a changeset still satisfies the gate,
+    // so an unreadable version cannot fail a PR that did the right thing.
+    await commit(repo, 'add the changeset', { '.changeset/tidy-pandas-shout.md': CHANGESET })
+    expect(await assertChangesetGate(base, repo)).toEqual([])
+  })
+
+  it('reports a base ref it cannot resolve rather than passing', async () => {
+    const { repo } = await baseRepo()
+    const problems = await assertChangesetGate('refs/does-not-exist', repo)
+    expect(problems).toHaveLength(1)
+    expect(problems[0]).toContain('could not diff against refs/does-not-exist')
   })
 })

--- a/scripts/build-agent-catalog.test.ts
+++ b/scripts/build-agent-catalog.test.ts
@@ -513,6 +513,33 @@ describe('audit: changeset gate', () => {
     expect(problems[0]).toContain('README.md.tpl')
   })
 
+  it('exempts the release commit through a shallow-fetched base ref — the shape CI runs', async () => {
+    // The push event, reproduced: a depth-1 checkout of the tip, and the
+    // previous tip fetched by SHA into refs/audit-base at depth 1. There is
+    // no merge base, so the gate diffs against the ref name — and then has to
+    // read `packages/cli/package.json` out of it. Nothing else here exercises
+    // `git show <shallow-ref>:<path>`, and if that could not resolve, every
+    // release commit would be red for the reason this change removed.
+    const { repo: origin, base } = await baseRepo('2.7.1')
+    await commit(origin, 'reword the catalog', {
+      'packages/cli/templates/agent-catalog/README.md.tpl': 'after\n',
+      '.changeset/tidy-pandas-shout.md': CHANGESET,
+    })
+    await commit(origin, 'chore: version packages to 2.8.0', {
+      [CLI_MANIFEST]: manifest('2.8.0'),
+      '.changeset/tidy-pandas-shout.md': null,
+    })
+    // servers refuse a by-SHA want unless they allow it; GitHub does
+    git(origin, 'config', 'uploadpack.allowAnySHA1InWant', 'true')
+
+    const shallow = join(scratch, `repo-${++repoCount}-shallow`)
+    git(scratch, 'clone', '--quiet', '--depth', '1', `file://${origin}`, shallow)
+    git(shallow, 'fetch', '--no-tags', '--depth=1', 'origin', `${base}:refs/audit-base`)
+    expect(Bun.spawnSync(['git', 'merge-base', 'refs/audit-base', 'HEAD'], { cwd: shallow }).success).toBe(false)
+
+    expect(await assertChangesetGate('refs/audit-base', shallow)).toEqual([])
+  })
+
   it('reports a base ref it cannot resolve rather than passing', async () => {
     const { repo } = await baseRepo()
     const problems = await assertChangesetGate('refs/does-not-exist', repo)

--- a/scripts/build-agent-catalog.ts
+++ b/scripts/build-agent-catalog.ts
@@ -247,9 +247,9 @@ export function assertTargets(files: readonly RenderedFile[]): string[] {
 export async function assertMinCli(): Promise<string[]> {
   const ctx = await readContext()
   // `compareVersions` returns NaN when either side is not an exact version —
-  // a prerelease workspace version, a partial pin. `NaN > 0` is false, so a
-  // comparison that could not be made would otherwise read as "not ahead"
-  // and pass the gate it exists to be.
+  // a range, a partial pin (a prerelease *is* exact, and orders normally).
+  // `NaN > 0` is false, so a comparison that could not be made would
+  // otherwise read as "not ahead" and pass the gate it exists to be.
   const order = compareVersions(ctx.minCli, ctx.cliVersion)
   if (Number.isNaN(order)) {
     return [`Cannot order MIN_CLI_FOR_TARGETS ${ctx.minCli} against the workspace @guren/cli ${ctx.cliVersion}`]
@@ -405,17 +405,6 @@ function versionOf(manifest: string): string | undefined {
 }
 
 /**
- * The CLI version at `rev`, read from git rather than from the working tree.
- * `undefined` means it could not be read — a missing manifest, unparseable
- * JSON, no `version` field — which callers must not treat as "the version
- * moved".
- */
-function cliVersionAt(rev: string, repo: string): string | undefined {
-  const show = Bun.spawnSync(['git', 'show', `${rev}:${CLI_MANIFEST}`], { cwd: repo })
-  return show.success ? versionOf(show.stdout.toString()) : undefined
-}
-
-/**
  * Sources changed ⇒ a `@guren/cli` changeset is present, unless the CLI
  * version itself moved. Compared against `base` (a ref or SHA). Callers on
  * shallow checkouts must fetch it first.
@@ -461,26 +450,39 @@ export async function assertChangesetGate(base: string, repo: string = repoRoot)
   // not bump versions in this repo, and a gate that asked them to would be
   // asking for a number `changeset version` writes (RFC 0011 §5).
   //
+  // This replaced an exemption for a diff whose touched inputs were the CLI
+  // manifest alone. The two are not nested: this one is wider where it
+  // matters (a catalog template may ride in the same push or squash as the
+  // version commit, which the old rule turned into a false red) and narrower
+  // where the old one was too loose (a manifest edit that leaves the version
+  // alone is gated, because it republishes the payload under the version it
+  // already had). Do not re-add the old branch beside this one.
+  //
   // The head side is the working tree, matching how `.changeset/` is read
-  // below and how `renderCatalog` reads the version it publishes. Read off
-  // disk rather than through `readContext()`, which applies
-  // GUREN_CATALOG_VERSION_OVERRIDE — a stray env var must not be able to
-  // manufacture an exemption. Compared as strings, because the claim is
-  // literally "the same version string": `compareVersions` returns NaN on a
-  // prerelease or a partial pin, and `NaN !== 0` would exempt every one of
-  // them.
-  const baseVersion = cliVersionAt(diffBase, repo)
+  // below and how `renderCatalog` reads the version it publishes — so a
+  // maintainer running `--check` part-way through `changeset version`, files
+  // written and not yet committed, is judged on what a publish from that
+  // checkout would carry. The cost is that this half of the comparison is
+  // only as trustworthy as the tree is clean: a step that rewrote the
+  // manifest without committing it could manufacture an exemption. CI has no
+  // such step, and its checkout is clean. Read off disk rather than through
+  // `readContext()`, which applies GUREN_CATALOG_VERSION_OVERRIDE — a stray
+  // env var must not be able to manufacture one either.
+  //
+  // Compared as strings, because the claim is literally "the same version
+  // string". `compareVersions` answers a different question: it returns NaN
+  // for anything that is not an exact version, and orders `1.0.0+build`
+  // equal to `1.0.0` — two spellings that publish as two different payload
+  // versions.
+  const show = Bun.spawnSync(['git', 'show', `${diffBase}:${CLI_MANIFEST}`], { cwd: repo })
+  const baseVersion = show.success ? versionOf(show.stdout.toString()) : undefined
   const headVersion = versionOf(await readFile(join(repo, CLI_MANIFEST), 'utf8').catch(() => ''))
   if (baseVersion !== undefined && headVersion !== undefined && baseVersion !== headVersion) return []
   // A side that could not be read is not an exemption — that would be a
   // silent ungating living inside the audit, where the run still prints
   // "passed" and no CI annotation covers it. It falls through to the
   // changeset check instead, so a PR that has a changeset still passes, and
-  // says so in the failure below when one is missing.
-  const unreadable =
-    baseVersion === undefined || headVersion === undefined
-      ? ` The @guren/cli version could not be read on ${baseVersion === undefined ? `the base side (${diffBase})` : 'the working tree'}, so the version-moved exemption could not be evaluated.`
-      : ''
+  // the reason is reported only when one is missing.
 
   const changesetDir = join(repo, '.changeset')
   let names: string[] = []
@@ -497,10 +499,16 @@ export async function assertChangesetGate(base: string, repo: string = repoRoot)
       return [`could not read .changeset/${name}: ${error instanceof Error ? error.message : String(error)}`]
     }
   }
+  const unreadable = [
+    baseVersion === undefined ? `the base side (${diffBase})` : undefined,
+    headVersion === undefined ? 'the working tree' : undefined,
+  ].filter(Boolean)
   return [
     `catalog inputs changed (${touched.join(', ')}) but no .changeset/*.md names "@guren/cli". ` +
       'The plugin version is the CLI version and a payload published under an unchanged version is one every installed copy skips forever; add a @guren/cli changeset.' +
-      unreadable,
+      (unreadable.length > 0
+        ? ` The @guren/cli version could not be read on ${unreadable.join(' or ')}, so the version-moved exemption could not be evaluated.`
+        : ''),
   ]
 }
 

--- a/scripts/build-agent-catalog.ts
+++ b/scripts/build-agent-catalog.ts
@@ -25,7 +25,9 @@
  * `--check` also enforces the changeset gate: if any input this script reads
  * changed relative to the base ref, a changeset naming `@guren/cli` must be
  * present, because the plugin's version is the CLI's and a payload published
- * under an unchanged version is one every installed copy skips forever.
+ * under an unchanged version is one every installed copy skips forever. A
+ * diff that moves the CLI version itself is exempt — that is the release
+ * commit, and the harm the gate names cannot occur when the version moved.
  */
 import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -38,7 +40,8 @@ import { parseChangeset } from './smoke/core-semver-audit'
 import { repoRoot } from './workspace-packages'
 
 const TEMPLATE_DIR = 'packages/cli/templates/agent-catalog'
-const CLI_MANIFEST = 'packages/cli/package.json'
+/** Exported so the gate's tests name the manifest through the gate, not beside it. */
+export const CLI_MANIFEST = 'packages/cli/package.json'
 const LICENSE = 'LICENSE'
 
 /**
@@ -391,31 +394,87 @@ export function changesetNames(source: string, pkg: string, file = 'changeset'):
   return parseChangeset(file, source).releases.has(pkg)
 }
 
+/** The `version` field of a `packages/cli/package.json`, or undefined if absent. */
+function versionOf(manifest: string): string | undefined {
+  try {
+    const version = (JSON.parse(manifest) as { version?: unknown }).version
+    return typeof version === 'string' ? version : undefined
+  } catch {
+    return undefined
+  }
+}
+
 /**
- * Sources changed ⇒ a `@guren/cli` changeset is present. Compared against
- * `base` (a ref or SHA). Callers on shallow checkouts must fetch it first.
+ * The CLI version at `rev`, read from git rather than from the working tree.
+ * `undefined` means it could not be read — a missing manifest, unparseable
+ * JSON, no `version` field — which callers must not treat as "the version
+ * moved".
  */
-export async function assertChangesetGate(base: string): Promise<string[]> {
+function cliVersionAt(rev: string, repo: string): string | undefined {
+  const show = Bun.spawnSync(['git', 'show', `${rev}:${CLI_MANIFEST}`], { cwd: repo })
+  return show.success ? versionOf(show.stdout.toString()) : undefined
+}
+
+/**
+ * Sources changed ⇒ a `@guren/cli` changeset is present, unless the CLI
+ * version itself moved. Compared against `base` (a ref or SHA). Callers on
+ * shallow checkouts must fetch it first.
+ *
+ * `repo` is the checkout to run in; it is the function's subject, not a test
+ * hook. The gate is only observable against real commits, so its own tests
+ * build throwaway repositories and point it at those.
+ */
+export async function assertChangesetGate(base: string, repo: string = repoRoot): Promise<string[]> {
   // three-dot (merge-base..HEAD) is the precise diff on a full clone; it
   // needs a merge base, which a shallow CI checkout that fetched only the
   // base SHA does not have. Two-dot (base tip..HEAD) needs none and can only
   // over-report on a stale branch, never under-report — so try precise, then
-  // safe.
-  let diff = Bun.spawnSync(['git', 'diff', '--name-only', `${base}...HEAD`], { cwd: repoRoot })
-  if (!diff.success) {
-    diff = Bun.spawnSync(['git', 'diff', '--name-only', `${base}..HEAD`], { cwd: repoRoot })
-  }
+  // safe. Resolved to one rev rather than written as two diff spellings,
+  // because the version comparison below has to read the same side of the
+  // diff the file list came from: on a stale branch `base`'s tip can carry a
+  // *newer* version than HEAD, which would exempt a run the merge base would
+  // have gated.
+  const mergeBase = Bun.spawnSync(['git', 'merge-base', base, 'HEAD'], { cwd: repo })
+  const diffBase = mergeBase.success ? mergeBase.stdout.toString().trim() : base
+  const diff = Bun.spawnSync(['git', 'diff', '--name-only', `${diffBase}..HEAD`], { cwd: repo })
   if (!diff.success) {
     return [`could not diff against ${base}: ${diff.stderr.toString().trim()} — fetch the base ref before running --check`]
   }
   const changed = diff.stdout.toString().split('\n').filter(Boolean)
   const touched = changed.filter((f) => CATALOG_INPUTS.some((input) => (input.endsWith('/') ? f.startsWith(input) : f === input)))
   if (touched.length === 0) return []
-  // the CLI manifest only moves in the release PR, which is the version bump
-  // itself — no changeset expected there
-  if (touched.every((f) => f === CLI_MANIFEST)) return []
 
-  const changesetDir = join(repoRoot, '.changeset')
+  // The version moved ⇒ exempt. The harm this gate names is a payload
+  // published under an *unchanged* version, and that cannot happen once the
+  // version string differs — so `changeset version`'s own commit is green
+  // whatever else rides with it, including a catalog template and the
+  // changeset that commit just consumed. Note the direction: an exemption
+  // keyed on the version, never a demand that a PR move one. Feature PRs do
+  // not bump versions in this repo, and a gate that asked them to would be
+  // asking for a number `changeset version` writes (RFC 0011 §5).
+  //
+  // The head side is the working tree, matching how `.changeset/` is read
+  // below and how `renderCatalog` reads the version it publishes. Read off
+  // disk rather than through `readContext()`, which applies
+  // GUREN_CATALOG_VERSION_OVERRIDE — a stray env var must not be able to
+  // manufacture an exemption. Compared as strings, because the claim is
+  // literally "the same version string": `compareVersions` returns NaN on a
+  // prerelease or a partial pin, and `NaN !== 0` would exempt every one of
+  // them.
+  const baseVersion = cliVersionAt(diffBase, repo)
+  const headVersion = versionOf(await readFile(join(repo, CLI_MANIFEST), 'utf8').catch(() => ''))
+  if (baseVersion !== undefined && headVersion !== undefined && baseVersion !== headVersion) return []
+  // A side that could not be read is not an exemption — that would be a
+  // silent ungating living inside the audit, where the run still prints
+  // "passed" and no CI annotation covers it. It falls through to the
+  // changeset check instead, so a PR that has a changeset still passes, and
+  // says so in the failure below when one is missing.
+  const unreadable =
+    baseVersion === undefined || headVersion === undefined
+      ? ` The @guren/cli version could not be read on ${baseVersion === undefined ? `the base side (${diffBase})` : 'the working tree'}, so the version-moved exemption could not be evaluated.`
+      : ''
+
+  const changesetDir = join(repo, '.changeset')
   let names: string[] = []
   try {
     names = (await readdir(changesetDir)).filter((n) => n.endsWith('.md') && n !== 'README.md')
@@ -432,7 +491,8 @@ export async function assertChangesetGate(base: string): Promise<string[]> {
   }
   return [
     `catalog inputs changed (${touched.join(', ')}) but no .changeset/*.md names "@guren/cli". ` +
-      'The plugin version is the CLI version and a payload published under an unchanged version is one every installed copy skips forever; add a @guren/cli changeset.',
+      'The plugin version is the CLI version and a payload published under an unchanged version is one every installed copy skips forever; add a @guren/cli changeset.' +
+      unreadable,
   ]
 }
 

--- a/scripts/build-agent-catalog.ts
+++ b/scripts/build-agent-catalog.ts
@@ -433,7 +433,10 @@ export async function assertChangesetGate(base: string, repo: string = repoRoot)
   // because the version comparison below has to read the same side of the
   // diff the file list came from: on a stale branch `base`'s tip can carry a
   // *newer* version than HEAD, which would exempt a run the merge base would
-  // have gated.
+  // have gated. The shallow fallback gives that precision up — it reads the
+  // base tip — which is safe for the two events CI passes a base for, because
+  // both name a specific commit rather than a moving branch: `push` sends the
+  // tip its own push replaced, and `pull_request` sends `base.sha`.
   // Empty output counts as a failure, not as a rev. Today's git exits
   // non-zero when there is no merge base, so this is belt-and-braces — but
   // the failure it prevents is silent rather than loud: an empty left side

--- a/scripts/build-agent-catalog.ts
+++ b/scripts/build-agent-catalog.ts
@@ -434,8 +434,13 @@ export async function assertChangesetGate(base: string, repo: string = repoRoot)
   // diff the file list came from: on a stale branch `base`'s tip can carry a
   // *newer* version than HEAD, which would exempt a run the merge base would
   // have gated.
+  // Empty output counts as a failure, not as a rev. Today's git exits
+  // non-zero when there is no merge base, so this is belt-and-braces — but
+  // the failure it prevents is silent rather than loud: an empty left side
+  // makes `git diff ..HEAD` a diff of HEAD against itself, which reports no
+  // files and passes this gate rather than reporting that it could not run.
   const mergeBase = Bun.spawnSync(['git', 'merge-base', base, 'HEAD'], { cwd: repo })
-  const diffBase = mergeBase.success ? mergeBase.stdout.toString().trim() : base
+  const diffBase = (mergeBase.success && mergeBase.stdout.toString().trim()) || base
   const diff = Bun.spawnSync(['git', 'diff', '--name-only', `${diffBase}..HEAD`], { cwd: repo })
   if (!diff.success) {
     return [`could not diff against ${base}: ${diff.stderr.toString().trim()} — fetch the base ref before running --check`]


### PR DESCRIPTION
## Summary

`assertChangesetGate` in `scripts/build-agent-catalog.ts` enforces: if any file under `CATALOG_INPUTS` changed relative to the base ref, a changeset naming `@guren/cli` must be present. The published plugin's version *is* the CLI's version, so a payload published under an unchanged version is one every installed copy skips forever (RFC 0011 §5).

The gate diffs an aggregate commit range but reads `.changeset/` only at the final tree. A single push or squash containing **both** a catalog change with its changeset **and** the `changeset version` commit that consumes it went red: the touched inputs are a catalog template plus `packages/cli/package.json`, so the manifest-only exemption did not match, and no changeset survived in the tree to be found. It is unreachable in this repository's current flow — the version commit always lands as its own squash merge — which is why it was left out of #457, but the exemption was keyed on the wrong thing.

This keys the exemption on the **`version` field of `packages/cli/package.json` having moved**, read from both sides of the diff. The harm the gate names cannot occur once the version differs. The old branch is deleted rather than kept beside the new one.

The two rules are not nested, and that is deliberate:

- **wider** where it matters — a catalog template may ride in the same push or squash as the version commit;
- **narrower** where the old rule was too loose — a manifest edit that leaves the version alone is now gated, because it republishes the payload under the version it already had.

Note the direction, which is what keeps RFC 0011 §5's objection satisfied: this is an *exemption* keyed on the version, never a *demand* that a PR move one. Feature PRs still satisfy the gate the only way they can, by adding a changeset.

Supporting changes in the same function:

- The diff base is resolved once via `git merge-base` and used for both the file list and the base-side version read. On a stale branch the base *tip* can carry a newer version than HEAD, which would exempt a run the merge base would have gated. Empty `merge-base` output counts as unresolved, because an empty left side makes `git diff ..HEAD` a diff of HEAD against itself — a silent pass rather than a loud failure.
- A version side that cannot be read is **not** an exemption. It falls through to the changeset check, so a PR that has a changeset still passes, and the reason is reported in the failure when one is missing. A silent ungating inside the audit would be worse than CI's ungated fallback, which at least annotates itself.

`assertChangesetGate` now takes the checkout to run in (`repo`, defaulting to `repoRoot`). That is the function's subject, not a test hook: it replaces a module-level constant at every use site and introduces no branch the production path does not take.

## Scope

`cli` (the `scripts/` gate that guards the agent-catalog payload), `ci`, `docs` (RFC 0011 §6).

- `scripts/build-agent-catalog.ts` — the gate
- `scripts/build-agent-catalog.test.ts` — new `audit: changeset gate` block
- `.github/workflows/ci.yml` — comment only, no step changes
- `rfcs/0011-agent-catalog-distribution.md` — §6 verification record
- `.changeset/agent-catalog-version-exemption.md`

## Risk Assessment

- **No behavior change outside the audit.** Nothing here ships in a package; the gate runs in CI and from `bun run audit:agent-catalog`.
- **The one intentional tightening**: a diff whose only catalog input is `packages/cli/package.json` with an *unchanged* version now requires a changeset. Previously exempt. The release commit is unaffected — it moves the version by definition.
- **CI interaction, checked**: the push-side gate added in #472 fetches the base SHA into `refs/audit-base` with `--depth=1`, retries 3×, and falls back to an ungated run with a `::warning::` annotation. The shell is untouched and no new silent ungating is introduced, so that fallback is exactly as loud as before. The shallow shape is now covered by a test — `git show <shallow-ref>:<path>` is what every release commit's exemption depends on, and if it could not resolve, the false red would simply have relocated.
- **Known limit, stated in the code**: the head-side version comes from the working tree, matching how `.changeset/` and `renderCatalog`'s published version are read. It is therefore only as trustworthy as the tree is clean. CI's checkout is clean and no step rewrites that manifest.

## Validation

`assertChangesetGate` had no test at all before this — the suite covered its frontmatter parser and its input list, never the rule. The new block builds a throwaway git repository per case, and **every case was confirmed to fail against the implementation it rejects**:

| Case | Mutation that makes it fail |
|---|---|
| A+B in one range (the false red) | restore the manifest-only exemption |
| manifest edit, version unchanged | restore the manifest-only exemption |
| release commit, manifest the only input | `touched.length > 1 && …` |
| base ref moved on past the merge base | read the version from `base` instead of `diffBase` |
| unreadable base version is not exempt | drop the `!== undefined` guards |
| shallow-fetched base ref (CI's shape) | break the `git show <ref>:<path>` read |

Also covered: nothing watched changed; a catalog change with a changeset; an unresolvable base ref; and the no-merge-base two-dot fallback.

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` — `test:bun` 4732 pass / 0 fail (includes the `scripts/` sweep), `test:examples` 112 pass / 0 fail
- [x] `bun run audit:agent-catalog --base main` — passes with the changeset present, and was confirmed to fail with it temporarily moved aside
- [x] `bun run audit:docs`

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.

## Review notes

Reviewed by Codex plus a four-angle cleanup pass before opening. Three findings were applied rather than argued with:

- the comment claiming `compareVersions` returns `NaN` for a prerelease was wrong — it orders one normally. `NaN` is for a non-exact specifier, and `1.0.0+build` orders *equal* to `1.0.0`, which is the actual reason the comparison is a string compare. Corrected here and in `assertMinCli`'s neighbouring claim.
- two shapes no test discriminated (the plain release commit; a base that moved on) are now covered — both rows in the table above.
- RFC 0011 §6 recorded the changeset gate as *manually* verified. That is no longer true, and the RFC's own rule is that a verification list must be accurate in both directions.

Two follow-ups were spun out rather than widened into this PR: `scripts/sync-template-deps.ts` hand-rolls the same "version at a rev vs. working tree" read with an unguarded `JSON.parse`, and `scripts/publish-agent-catalog.test.ts` commits without disabling global git hooks or commit signing.
