### PR TITLE
fix(cli): harden the agent-catalog scripts against a maintainer's global git config

### DIFF
--- a/scripts/build-agent-catalog.ts
+++ b/scripts/build-agent-catalog.ts
@@ -45,6 +45,19 @@ export const CLI_MANIFEST = 'packages/cli/package.json'
 const LICENSE = 'LICENSE'
 
 /**
+ * `core.hooksPath` pointed at nothing, on every git command that creates or
+ * clones a repository. The repository is fresh, but hooks are not: a
+ * maintainer's global `core.hooksPath` (or an `init.templateDir` that installs
+ * into the new clone) applies to it, and the hook runs before this code has
+ * looked at a single file. The rest of the maintainer's configuration is
+ * deliberately left alone — their credential helper and SSH setup are how any
+ * of this reaches a remote at all. Exported because publish-agent-catalog
+ * needs the same rule at more moments, and two copies of it is how one of
+ * them comes to be forgotten.
+ */
+export const NO_HOOKS = ['-c', 'core.hooksPath=']
+
+/**
  * The oldest `@guren/cli` whose `agent:init` accepts `--target`. The skills
  * tell users older CLIs need an upgrade for multi-agent installs. Asserted
  * `<=` the workspace version so it can never claim a future release.
@@ -609,7 +622,9 @@ async function check(base: string | undefined, requireValidate: boolean): Promis
 export async function diffPublished(remote: string): Promise<{ code: 0 | 1 | 2; report: string }> {
   const cloneDir = await mkdtemp(join(tmpdir(), 'guren-agent-catalog-published-'))
   try {
-    const clone = Bun.spawnSync(['git', 'clone', '--quiet', '--depth', '1', remote, cloneDir])
+    // NO_HOOKS: a post-checkout hook writing into the fresh clone would be
+    // read back below as what the public repository publishes
+    const clone = Bun.spawnSync(['git', ...NO_HOOKS, 'clone', '--quiet', '--depth', '1', remote, cloneDir])
     if (!clone.success) {
       return { code: 2, report: `could not clone ${remote}:\n${clone.stderr.toString().trim()}` }
     }

--- a/scripts/publish-agent-catalog.test.ts
+++ b/scripts/publish-agent-catalog.test.ts
@@ -50,7 +50,7 @@ function spawnPublish(remote: string, extraEnv: Record<string, string>, args: st
   // hand the script a PATH that is missing tools without losing its runtime
   const proc = Bun.spawnSync([process.execPath, script, ...args], {
     cwd: repoRoot,
-    env: { ...process.env, ...gitIdentity, GUREN_AGENT_SKILLS_REMOTE: remote, ...extraEnv },
+    env: { ...process.env, GIT_CONFIG_GLOBAL: childGitConfig, ...gitIdentity, GUREN_AGENT_SKILLS_REMOTE: remote, ...extraEnv },
   })
   return {
     code: proc.exitCode,
@@ -83,6 +83,20 @@ function git(cwd: string, ...args: string[]): string {
 
 let bare: string
 let scratch: string
+/**
+ * The global git configuration the *child* runs see, in place of the
+ * maintainer's. `HERMETIC` cannot reach them: the script makes its own
+ * commits, and a global `commit.gpgsign` makes those prompt — a hang, charged
+ * by bun:test to the following test. The script itself is right not to force
+ * signing off (a maintainer may want the publish commit signed), so the
+ * neutral configuration is the test's to supply.
+ *
+ * A file rather than `/dev/null` on purpose: it is where a test that wants to
+ * hand the script a hostile *global* configuration would write one. The three
+ * that do so today (`core.hooksPath`, `core.excludesFile`, `core.attributesFile`)
+ * inject through `GIT_CONFIG_*` in the env, a layer this does not touch.
+ */
+let childGitConfig: string
 
 /** A bare repo with one placeholder commit on main, like the real one had. */
 async function seedRemote(name: string): Promise<string> {
@@ -100,6 +114,8 @@ async function seedRemote(name: string): Promise<string> {
 
 beforeAll(async () => {
   scratch = await mkdtemp(join(tmpdir(), 'guren-publish-test-'))
+  childGitConfig = join(scratch, 'child-gitconfig')
+  await Bun.write(childGitConfig, '[commit]\n\tgpgsign = false\n')
   bare = await seedRemote('agent-skills.git')
 })
 
@@ -329,7 +345,7 @@ describe('publish-agent-catalog', () => {
     expect(run(remote).code).toBe(0)
     const proc = Bun.spawn([process.execPath, script, '--skip-validate'], {
       cwd: repoRoot,
-      env: { ...process.env, ...gitIdentity, GUREN_AGENT_SKILLS_REMOTE: remote, GUREN_CATALOG_VERSION_OVERRIDE: '99.0.0' },
+      env: { ...process.env, GIT_CONFIG_GLOBAL: childGitConfig, ...gitIdentity, GUREN_AGENT_SKILLS_REMOTE: remote, GUREN_CATALOG_VERSION_OVERRIDE: '99.0.0' },
       stdin: 'pipe',
       stdout: 'pipe',
       stderr: 'pipe',

--- a/scripts/publish-agent-catalog.test.ts
+++ b/scripts/publish-agent-catalog.test.ts
@@ -58,8 +58,26 @@ function spawnPublish(remote: string, extraEnv: Record<string, string>, args: st
   }
 }
 
+/**
+ * Every git call this file makes, hardened against the machine it runs on.
+ * A global `core.hooksPath` reaches repositories created here — including
+ * fresh clones, whose `post-checkout` runs before any assertion does — and
+ * publish-agent-catalog disables it the same way, its `NO_HOOKS` comment
+ * carrying the full hazard list. A global `commit.gpgsign` would make a
+ * commit *prompt*, and a hang under bun:test is charged to the following
+ * test, so it would not even look like the call that caused it. A CI runner
+ * has no committer identity to inherit. The same four flags guard
+ * build-agent-catalog.test.ts, which has no module to share them through.
+ */
+const HERMETIC = [
+  '-c', 'core.hooksPath=',
+  '-c', 'commit.gpgsign=false',
+  '-c', 'user.name=Guren publish test',
+  '-c', 'user.email=publish-test@guren.dev',
+]
+
 function git(cwd: string, ...args: string[]): string {
-  const proc = Bun.spawnSync(['git', ...args], { cwd })
+  const proc = Bun.spawnSync(['git', ...HERMETIC, ...args], { cwd })
   return proc.stdout.toString().trim()
 }
 
@@ -69,14 +87,14 @@ let scratch: string
 /** A bare repo with one placeholder commit on main, like the real one had. */
 async function seedRemote(name: string): Promise<string> {
   const remote = join(scratch, name)
-  Bun.spawnSync(['git', 'init', '--quiet', '--bare', '--initial-branch=main', remote])
+  git(scratch, 'init', '--quiet', '--bare', '--initial-branch=main', remote)
   const seed = join(scratch, `${name}-seed`)
-  Bun.spawnSync(['git', 'clone', '--quiet', remote, seed])
+  git(scratch, 'clone', '--quiet', remote, seed)
   await Bun.write(join(seed, 'README.md'), 'placeholder\n')
   await Bun.write(join(seed, 'STALE.md'), 'a file the publish must remove\n')
-  Bun.spawnSync(['git', '-c', 'user.name=t', '-c', 'user.email=t@t', 'add', '-A'], { cwd: seed })
-  Bun.spawnSync(['git', '-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '--quiet', '-m', 'seed'], { cwd: seed })
-  Bun.spawnSync(['git', 'push', '--quiet', 'origin', 'main'], { cwd: seed })
+  git(seed, 'add', '-A')
+  git(seed, 'commit', '--quiet', '-m', 'seed')
+  git(seed, 'push', '--quiet', 'origin', 'main')
   return remote
 }
 
@@ -131,7 +149,7 @@ describe('publish-agent-catalog', () => {
     expect(result.out).toContain('--skip-validate')
     // it refused before cloning: the remote is still just the seed commit
     const check = join(scratch, 'check-refused')
-    Bun.spawnSync(['git', 'clone', '--quiet', bare, check])
+    git(scratch, 'clone', '--quiet', bare, check)
     expect(git(check, 'rev-list', '--count', 'main')).toBe('1')
   })
 
@@ -142,7 +160,7 @@ describe('publish-agent-catalog', () => {
     expect(result.out).toContain('Published:')
 
     const check = join(scratch, 'check1')
-    Bun.spawnSync(['git', 'clone', '--quiet', bare, check])
+    git(scratch, 'clone', '--quiet', bare, check)
     const files = git(check, 'ls-files').split('\n').sort()
     expect(files).toContain('plugins/guren/plugin.json')
     expect(files).toContain('plugins/guren/skills/guren-new-app/SKILL.md')
@@ -160,8 +178,8 @@ describe('publish-agent-catalog', () => {
     expect(fresh.code).toBe(0)
     // and against a remote that only has the seed, every file is missing
     const stale = join(scratch, 'stale.git')
-    Bun.spawnSync(['git', 'clone', '--quiet', '--bare', bare, stale])
-    Bun.spawnSync(['git', 'update-ref', 'refs/heads/main', 'main~1'], { cwd: stale })
+    git(scratch, 'clone', '--quiet', '--bare', bare, stale)
+    git(stale, 'update-ref', 'refs/heads/main', 'main~1')
     const drift = await diffPublished(stale)
     expect(drift.code).toBe(1)
     expect(drift.report).toContain('missing in published: plugins/guren/plugin.json')
@@ -181,7 +199,7 @@ describe('publish-agent-catalog', () => {
     expect(result.out).toContain('Published:')
 
     const check = join(scratch, 'check-v2')
-    Bun.spawnSync(['git', 'clone', '--quiet', bare, check])
+    git(scratch, 'clone', '--quiet', bare, check)
     const files = git(check, 'ls-files').split('\n').sort()
     expect(files.filter((f) => f.startsWith('plugins/plugins/'))).toEqual([])
     expect(files.filter((f) => f.startsWith('.claude-plugin/.claude-plugin/'))).toEqual([])
@@ -200,10 +218,10 @@ describe('publish-agent-catalog', () => {
   it('same version, different content republishes (a LICENSE or wording change), with a warning', async () => {
     // simulate a drifted publish: overwrite one published file, keep the version
     const drift = join(scratch, 'drift')
-    Bun.spawnSync(['git', 'clone', '--quiet', bare, drift])
+    git(scratch, 'clone', '--quiet', bare, drift)
     await Bun.write(join(drift, 'README.md'), 'someone hand-edited this\n')
-    Bun.spawnSync(['git', '-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '--quiet', '-am', 'hand edit'], { cwd: drift })
-    Bun.spawnSync(['git', 'push', '--quiet', 'origin', 'main'], { cwd: drift })
+    git(drift, 'commit', '--quiet', '-am', 'hand edit')
+    git(drift, 'push', '--quiet', 'origin', 'main')
 
     // byte-only drift, the same-version case the drift job exists for: every
     // path is present and one file's contents differ
@@ -217,7 +235,7 @@ describe('publish-agent-catalog', () => {
     expect(result.out).toContain('already published but the tree differs; republishing')
     expect(result.out).toContain('Published:')
     const check = join(scratch, 'check-drift')
-    Bun.spawnSync(['git', 'clone', '--quiet', bare, check])
+    git(scratch, 'clone', '--quiet', bare, check)
     expect(await Bun.file(join(check, 'README.md')).text()).not.toContain('hand-edited')
   })
 
@@ -227,11 +245,11 @@ describe('publish-agent-catalog', () => {
     expect(result.out).toContain('byte-identical to what is published; nothing to do')
     expect(result.out).not.toContain('Published:')
     const check = join(scratch, 'check2')
-    Bun.spawnSync(['git', 'clone', '--quiet', bare, check])
+    git(scratch, 'clone', '--quiet', bare, check)
     const before = git(check, 'rev-list', '--count', 'main')
     run(bare)
     const check2 = join(scratch, 'check2b')
-    Bun.spawnSync(['git', 'clone', '--quiet', bare, check2])
+    git(scratch, 'clone', '--quiet', bare, check2)
     expect(git(check2, 'rev-list', '--count', 'main')).toBe(before)
   })
 
@@ -239,10 +257,10 @@ describe('publish-agent-catalog', () => {
     // rewind the remote all the way to the seed commit so there is a full
     // publish's worth of diff to show
     const rewind = join(scratch, 'rewind')
-    Bun.spawnSync(['git', 'clone', '--quiet', bare, rewind])
+    git(scratch, 'clone', '--quiet', bare, rewind)
     const seedSha = git(rewind, 'rev-list', '--max-parents=0', 'main')
-    Bun.spawnSync(['git', 'reset', '--quiet', '--hard', seedSha], { cwd: rewind })
-    Bun.spawnSync(['git', 'push', '--quiet', '--force', 'origin', 'main'], { cwd: rewind })
+    git(rewind, 'reset', '--quiet', '--hard', seedSha)
+    git(rewind, 'push', '--quiet', '--force', 'origin', 'main')
 
     const result = run(bare, {}, '--dry-run')
     expect(result.code).toBe(0)
@@ -253,7 +271,7 @@ describe('publish-agent-catalog', () => {
     // text of a same-version wording change actually says
     expect(result.out).toMatch(/^\+.*guren/mu)
     const check = join(scratch, 'check3')
-    Bun.spawnSync(['git', 'clone', '--quiet', bare, check])
+    git(scratch, 'clone', '--quiet', bare, check)
     expect(git(check, 'rev-list', '--count', 'main')).toBe('1')
   })
 
@@ -272,7 +290,7 @@ describe('publish-agent-catalog', () => {
 
     expect(result.code).toBe(0)
     const check = join(scratch, 'check-excludes')
-    Bun.spawnSync(['git', 'clone', '--quiet', remote, check])
+    git(scratch, 'clone', '--quiet', remote, check)
     const files = git(check, 'ls-files').split('\n').sort()
     expect(files).toContain('plugins/guren/skills/guren-new-app/SKILL.md')
     expect(files).toContain('README.md')
@@ -297,7 +315,7 @@ describe('publish-agent-catalog', () => {
     expect(result.out).toContain('the staged tree is not the tree that was audited')
     expect(result.out).toContain('staged bytes differ from the rendered bytes')
     const check = join(scratch, 'check-filtered')
-    Bun.spawnSync(['git', 'clone', '--quiet', remote, check])
+    git(scratch, 'clone', '--quiet', remote, check)
     expect(git(check, 'rev-list', '--count', 'main')).toBe('1')
   })
 
@@ -328,10 +346,10 @@ describe('publish-agent-catalog', () => {
 
     // roll the remote back while the run waits for an answer
     const rewind = join(scratch, 'moved-rewind')
-    Bun.spawnSync(['git', 'clone', '--quiet', remote, rewind])
+    git(scratch, 'clone', '--quiet', remote, rewind)
     const seedSha = git(rewind, 'rev-list', '--max-parents=0', 'main')
-    Bun.spawnSync(['git', 'reset', '--quiet', '--hard', seedSha], { cwd: rewind })
-    Bun.spawnSync(['git', 'push', '--quiet', '--force', 'origin', 'main'], { cwd: rewind })
+    git(rewind, 'reset', '--quiet', '--hard', seedSha)
+    git(rewind, 'push', '--quiet', '--force', 'origin', 'main')
 
     proc.stdin.write('y\n')
     proc.stdin.end()
@@ -342,7 +360,7 @@ describe('publish-agent-catalog', () => {
     expect(out).toContain('the remote moved since this run cloned it')
     // the rollback stands: still one commit, not the restored history
     const check = join(scratch, 'check-moved')
-    Bun.spawnSync(['git', 'clone', '--quiet', remote, check])
+    git(scratch, 'clone', '--quiet', remote, check)
     expect(git(check, 'rev-list', '--count', 'main')).toBe('1')
   })
 

--- a/scripts/publish-agent-catalog.ts
+++ b/scripts/publish-agent-catalog.ts
@@ -39,7 +39,7 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import process from 'node:process'
-import { auditRenderedFiles, claudePluginValidate, writeCatalog, type RenderedFile } from './build-agent-catalog'
+import { auditRenderedFiles, claudePluginValidate, NO_HOOKS, writeCatalog, type RenderedFile } from './build-agent-catalog'
 import { repoRoot } from './workspace-packages'
 
 const PUBLISH_REPO = 'gurenjs/agent-skills'
@@ -57,18 +57,6 @@ function remotes(): string[] {
 }
 
 /**
- * `core.hooksPath` pointed at nothing, on every git command this script runs.
- * The clone is fresh, but hooks are not: a maintainer's global `core.hooksPath`
- * (or an `init.templateDir` that installs into the new clone) applies to it,
- * and those hooks run at exactly the moments this script's guarantee depends
- * on — `post-checkout` after the clone, `pre-commit` between the staged-tree
- * check and the tree that gets committed, `post-commit` before the push. The
- * rest of the maintainer's configuration is deliberately left alone: their
- * credential helper and SSH setup are how this pushes at all.
- */
-const NO_HOOKS = ['-c', 'core.hooksPath=']
-
-/**
  * Does this remote name the public repository? A local path is never it, however
  * it is spelled — a bare repo at `/tmp/gurenjs/agent-skills.git` is a test
  * remote, not GitHub — and the owner/repo pair is compared case-insensitively
@@ -84,6 +72,14 @@ export function isPublishRepo(remote: string): boolean {
   return host?.toLowerCase() === 'github.com' && path.toLowerCase() === PUBLISH_REPO.toLowerCase()
 }
 
+/**
+ * `NO_HOOKS` on every git command this script runs, not only the clone: the
+ * moments this script's guarantee depends on are all hook moments —
+ * `post-checkout` after the clone, `pre-commit` between the staged-tree check
+ * and the tree that gets committed, `post-commit` before the push. The rule
+ * itself, and why the rest of the maintainer's configuration is left alone,
+ * lives with the constant in build-agent-catalog.
+ */
 function git(cwd: string, args: string[]): { ok: boolean; out: string; stdout: string } {
   const run = Bun.spawnSync(['git', ...NO_HOOKS, ...args], { cwd })
   return {


### PR DESCRIPTION
## Summary

Three git-configuration settings a maintainer may have set *globally* reached the agent-catalog scripts and their tests. All three have the same shape: the machine the code runs on changes what the code does, and the result does not look like a configuration problem.

**1. The test file's own repositories were unprotected** (`scripts/publish-agent-catalog.test.ts`). It builds throwaway repositories and commits into them, supplying only a committer identity.

- `core.hooksPath` applies to repositories created here, including fresh clones, whose `post-checkout` runs before any assertion does. `scripts/publish-agent-catalog.ts` disables it for exactly this reason, but the test file did not.
- `commit.gpgsign` makes a commit *prompt*. Under `bun:test` a hang is charged to the **following** test, so it does not even look like the call that caused it.

Both now sit in one `HERMETIC` constant, matching what `scripts/build-agent-catalog.test.ts` already does, and every git call in the file goes through the single hardened helper rather than only the two commit sites: a `clone` runs hooks too, and routing them all through one helper removes the question of which call was hardened.

**2. The drift check's clone was unprotected** (`scripts/build-agent-catalog.ts`). `diffPublished` backs the nightly drift job: it clones gurenjs/agent-skills into a temp directory and compares that working tree against this checkout's render. The clone ran without `core.hooksPath=`, so a maintainer's global `post-checkout` hook ran inside it before a single file was read. A hook that writes into the tree makes the gate report drift the public repository does not have, or hide drift it does.

That rule now lives with the constant in `build-agent-catalog.ts` and `publish-agent-catalog.ts` imports it. Two copies is how one of them comes to be forgotten, which is what happened here. It is applied to the clone only: `merge-base`, `diff`, `show` and `ls-files` cannot run a hook, and flagging them would claim a protection they never needed.

**3. The spawned script's own commits were unprotected.** Most commits in the test file are made by the child publish process, which `HERMETIC` cannot reach. The script is right not to force signing off — a maintainer may want the publish commit signed — so the neutral configuration is the test's to supply: `GIT_CONFIG_GLOBAL` pointed at a file the test writes, at both sites that spawn the script. The second matters most: the "remote moved" test reads the child's stdout in a loop until it sees the confirmation prompt, so a signing prompt there blocks forever rather than failing.

## Scope

- `scripts/build-agent-catalog.ts` — one clone hardened, `NO_HOOKS` hoisted here and exported
- `scripts/publish-agent-catalog.ts` — imports the rule instead of restating it (no behavior change)
- `scripts/publish-agent-catalog.test.ts` — `HERMETIC` on every git call, `GIT_CONFIG_GLOBAL` for child runs

## Risk Assessment

One production-code change: the flag added to `diffPublished`'s clone, and the `NO_HOOKS` hoist, which is a move plus an import. `publish-agent-catalog.ts` passes the identical array to the identical calls.

In the test file, the per-call `-c user.name=t -c user.email=t@t` is replaced by the identity in `HERMETIC`; no assertion reads a commit author. The diff was reviewed argument-by-argument, because the file's `git()` helper swallows failures: a mis-transcribed `clone` would fail silently and leave assertions such as `expect(files.filter((f) => f.startsWith('plugins/plugins/'))).toEqual([])` passing vacuously on an empty directory. The `expect()` call count is unchanged at 80.

The three tests that hand the *script* a hostile global configuration (`core.hooksPath`, `core.excludesFile`, `core.attributesFile`) are unaffected: they inject through `GIT_CONFIG_*` in the child's env, a layer `GIT_CONFIG_GLOBAL` does not touch. `GIT_CONFIG_GLOBAL` points at a file rather than `/dev/null` on purpose, so it remains the place a future test would write such a configuration instead of being an erasure someone has to undo first.

## Validation

A green run does not show any of this bites, so all three were mutation-checked. One run does it: a fake `HOME` whose global config sets `core.hooksPath` to marker-writing hooks **and** `commit.gpgsign=true` with `gpg.program=/bin/false`, then `bun test scripts/publish-agent-catalog.test.ts`.

| | before | after |
|---|---|---|
| hooks fired by the test file's own git calls | 32 (16 `post-checkout`, 8 `pre-commit`, 8 `post-commit`) | 0 |
| hooks fired inside `diffPublished`'s clone | 3 (one per call) | 0 |
| tests failing under a global `commit.gpgsign` | 10 of 16 | 0 |

Isolated checks behind those numbers: a commit under a global `commit.gpgsign=true` exits 128 without `-c commit.gpgsign=false` and 0 with it; a single `diffPublished` against a real local remote fired exactly one `post-checkout` before this change.

Checks run:

- [x] `bun run build` (`build:clean`)
- [x] `bun run typecheck` (from the repo root)
- [x] `bun run test:bun` — 4732 pass, 0 fail, 277 files
- [x] `bun test scripts/build-agent-catalog.test.ts` — 47 pass, 0 fail (it imports the edited module, and `test:bun` covers `packages/`, not `scripts/`)
- [x] `bun test scripts/publish-agent-catalog.test.ts` — 16 pass, 0 fail, identical to `main` on this machine

`test:examples` was not run; nothing here touches an example app.

## Known residuals

- `/etc/gitconfig` (system level) is not neutralized for the child runs. `GIT_CONFIG_GLOBAL` replaces `~/.gitconfig` and the XDG path; signing configured system-wide is rare enough not to chase.
- In real use the publish script still inherits the maintainer's signing configuration, deliberately. Only the tests opt out.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.