### PR TITLE
fix(scripts): stop the create-guren-app gate exempting itself on an unreadable version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,12 @@ is `ignoredEdges`: `@guren/cli` and `@guren/core` depend on each other, so core'
 edge on cli is dropped to break the cycle. Any *other* cycle fails the build with
 an explicit error.
 
+The same module also answers "what version did this manifest declare at a git
+rev" (`manifestAtRev` / `versionOf`), which is how the release gates in
+`scripts/` tell a version that moved from one that did not. `versionOf` carries
+the rule that an unreadable manifest is *not* a version — a gate that lets one
+stand in for a number silently stops gating.
+
 **Stale `.d.ts` issue:** If DTS build fails (e.g., `@guren/core` cannot find `@guren/server` types), old `dist/` artifacts are likely interfering. Run:
 ```bash
 bun run build:clean   # remove each package's dist/ then build

--- a/scripts/build-agent-catalog.ts
+++ b/scripts/build-agent-catalog.ts
@@ -37,7 +37,7 @@ import { AGENT_TARGETS } from '../packages/cli/src/agent-targets'
 import { builtinSubCommands } from '../packages/cli/src/commands'
 import { compareVersions } from '../packages/cli/src/codemods'
 import { parseChangeset } from './smoke/core-semver-audit'
-import { repoRoot } from './workspace-packages'
+import { manifestAtRev, repoRoot, versionOf } from './workspace-packages'
 
 const TEMPLATE_DIR = 'packages/cli/templates/agent-catalog'
 /** Exported so the gate's tests name the manifest through the gate, not beside it. */
@@ -394,16 +394,6 @@ export function changesetNames(source: string, pkg: string, file = 'changeset'):
   return parseChangeset(file, source).releases.has(pkg)
 }
 
-/** The `version` field of a `packages/cli/package.json`, or undefined if absent. */
-function versionOf(manifest: string): string | undefined {
-  try {
-    const version = (JSON.parse(manifest) as { version?: unknown }).version
-    return typeof version === 'string' ? version : undefined
-  } catch {
-    return undefined
-  }
-}
-
 /**
  * Sources changed ⇒ a `@guren/cli` changeset is present, unless the CLI
  * version itself moved. Compared against `base` (a ref or SHA). Callers on
@@ -474,9 +464,8 @@ export async function assertChangesetGate(base: string, repo: string = repoRoot)
   // for anything that is not an exact version, and orders `1.0.0+build`
   // equal to `1.0.0` — two spellings that publish as two different payload
   // versions.
-  const show = Bun.spawnSync(['git', 'show', `${diffBase}:${CLI_MANIFEST}`], { cwd: repo })
-  const baseVersion = show.success ? versionOf(show.stdout.toString()) : undefined
-  const headVersion = versionOf(await readFile(join(repo, CLI_MANIFEST), 'utf8').catch(() => ''))
+  const baseVersion = versionOf(manifestAtRev(diffBase, CLI_MANIFEST, repo))
+  const headVersion = versionOf(await readFile(join(repo, CLI_MANIFEST), 'utf8').catch(() => undefined))
   if (baseVersion !== undefined && headVersion !== undefined && baseVersion !== headVersion) return []
   // A side that could not be read is not an exemption — that would be a
   // silent ungating living inside the audit, where the run still prints

--- a/scripts/sync-template-deps.test.ts
+++ b/scripts/sync-template-deps.test.ts
@@ -1,0 +1,147 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { assertCreateAppRepublishes } from './sync-template-deps'
+
+/**
+ * The create-guren-app republish refusal, against throwaway repositories.
+ *
+ * It only says anything against real commits — it compares the version
+ * committed at `HEAD` against the one in the working tree — so each case here
+ * builds a repository and points the refusal at it.
+ *
+ * The fixture carries the one file the refusal reads. Everything else in
+ * `sync-template-deps.ts` runs against the real workspace and is covered by
+ * `bun run audit:template-deps`.
+ */
+describe('assertCreateAppRepublishes', () => {
+  let scratch: string
+  let repoCount = 0
+
+  beforeAll(async () => {
+    scratch = await mkdtemp(join(tmpdir(), 'guren-template-deps-'))
+  })
+  afterAll(async () => {
+    await rm(scratch, { recursive: true, force: true })
+  })
+
+  /**
+   * Every git call is hardened against the machine it runs on: a global
+   * `core.hooksPath` reaches repositories created here, a global
+   * `commit.gpgsign` would make a commit *prompt* — and a hang in bun:test is
+   * charged to the following test, so it would not even look like this one —
+   * and a CI runner has no committer identity to inherit.
+   */
+  const HERMETIC = [
+    '-c', 'core.hooksPath=',
+    '-c', 'commit.gpgsign=false',
+    '-c', 'user.name=Guren template-deps test',
+    '-c', 'user.email=template-deps-test@guren.dev',
+  ]
+
+  function git(repo: string, ...args: string[]): string {
+    const proc = Bun.spawnSync(['git', ...HERMETIC, ...args], { cwd: repo })
+    if (!proc.success) {
+      throw new Error(`git ${args.join(' ')} failed: ${proc.stderr.toString().trim()}`)
+    }
+    return proc.stdout.toString().trim()
+  }
+
+  const MANIFEST = 'packages/create-app/package.json'
+
+  const manifest = (version: string) =>
+    `${JSON.stringify({ name: 'create-guren-app', version }, null, 2)}\n`
+
+  async function put(repo: string, path: string, content: string): Promise<void> {
+    const full = join(repo, path)
+    await mkdir(dirname(full), { recursive: true })
+    await writeFile(full, content, 'utf8')
+  }
+
+  /** A repository whose committed create-app manifest is `committed`. */
+  async function repoAt(committed: string): Promise<string> {
+    const repo = join(scratch, `repo-${++repoCount}`)
+    await mkdir(repo, { recursive: true })
+    git(repo, 'init', '--quiet', '--initial-branch=main')
+    await put(repo, MANIFEST, committed)
+    git(repo, 'add', '-A')
+    git(repo, 'commit', '--quiet', '-m', 'base')
+    return repo
+  }
+
+  it('passes when the working tree moved the version', async () => {
+    const repo = await repoAt(manifest('2.7.1'))
+    await put(repo, MANIFEST, manifest('2.8.0'))
+    expect(await assertCreateAppRepublishes(repo)).toBeUndefined()
+  })
+
+  it('refuses when the version did not move, and names it', async () => {
+    const repo = await repoAt(manifest('2.7.1'))
+    await expect(assertCreateAppRepublishes(repo)).rejects.toThrow(/create-guren-app is still 2\.7\.1/)
+  })
+
+  // The rest is the same fact from both sides: a version nobody could read is
+  // not a version that moved. `undefined !== '2.8.0'` compares unequal, so
+  // every one of these cases used to *pass* the refusal and let a release ship
+  // rewritten template ranges inside no new tarball.
+
+  it('refuses a committed manifest with no version, rather than reading it as a bump', async () => {
+    const repo = await repoAt(`${JSON.stringify({ name: 'create-guren-app' }, null, 2)}\n`)
+    await put(repo, MANIFEST, manifest('2.8.0'))
+    await expect(assertCreateAppRepublishes(repo)).rejects.toThrow(/no readable version committed at HEAD/)
+  })
+
+  it('refuses a committed manifest whose version is not a string', async () => {
+    const repo = await repoAt(`${JSON.stringify({ name: 'create-guren-app', version: 2 }, null, 2)}\n`)
+    await put(repo, MANIFEST, manifest('2.8.0'))
+    await expect(assertCreateAppRepublishes(repo)).rejects.toThrow(/no readable version committed at HEAD/)
+  })
+
+  it('reports malformed committed JSON rather than throwing a raw SyntaxError', async () => {
+    const repo = await repoAt('{ "name": "create-guren-app", oops\n')
+    await put(repo, MANIFEST, manifest('2.8.0'))
+    // The message has to be this refusal's, not the JSON parser's: an
+    // unguarded parse aborts the release with no mention of which manifest or
+    // why the comparison mattered.
+    await expect(assertCreateAppRepublishes(repo)).rejects.toThrow(/no readable version committed at HEAD/)
+  })
+
+  it('refuses a working tree that lost its version', async () => {
+    const repo = await repoAt(manifest('2.7.1'))
+    await put(repo, MANIFEST, `${JSON.stringify({ name: 'create-guren-app' }, null, 2)}\n`)
+    await expect(assertCreateAppRepublishes(repo)).rejects.toThrow(/no readable version in the working tree/)
+  })
+
+  it('names both sides when neither declares a version', async () => {
+    const empty = `${JSON.stringify({ name: 'create-guren-app' }, null, 2)}\n`
+    const repo = await repoAt(empty)
+    await put(repo, MANIFEST, empty)
+    await expect(assertCreateAppRepublishes(repo)).rejects.toThrow(
+      /committed at HEAD and in the working tree/,
+    )
+  })
+
+  it('skips, audibly, when there is no manifest at HEAD to compare against', async () => {
+    // A scaffolder not yet committed leaves nothing to compare — that is an
+    // absent comparison, not a broken one, so it warns and returns rather than
+    // failing a release for a file git never had.
+    const repo = join(scratch, `repo-${++repoCount}`)
+    await mkdir(repo, { recursive: true })
+    git(repo, 'init', '--quiet', '--initial-branch=main')
+    await put(repo, 'README.md', 'no packages yet\n')
+    git(repo, 'add', '-A')
+    git(repo, 'commit', '--quiet', '-m', 'base')
+    await put(repo, MANIFEST, manifest('2.8.0'))
+
+    const warnings: string[] = []
+    const original = console.warn
+    console.warn = (...args: unknown[]) => void warnings.push(args.join(' '))
+    try {
+      expect(await assertCreateAppRepublishes(repo)).toBeUndefined()
+    } finally {
+      console.warn = original
+    }
+    expect(warnings.join('\n')).toContain(MANIFEST)
+  })
+})

--- a/scripts/sync-template-deps.ts
+++ b/scripts/sync-template-deps.ts
@@ -28,7 +28,7 @@ import {
   type DrizzlePinDeclineReason,
   type OrmManifest,
 } from '../packages/cli/src/drizzle-pins'
-import { collectPackages, repoRoot } from './workspace-packages'
+import { collectPackages, manifestAtRev, repoRoot, versionOf } from './workspace-packages'
 
 /**
  * The groups this script rewrites a template's ranges in. Exported because
@@ -245,17 +245,48 @@ async function check(): Promise<void> {
  * following an ORM drizzle pin that moved in an ordinary PR — would be failed
  * for a release that is not theirs to cut. The same fact is printed as a
  * reminder on that path instead.
+ *
+ * The two ways a version can be unreadable are not the same refusal, because
+ * they are not the same fact:
+ *
+ * - no manifest at `HEAD` at all — a scaffolder not yet committed — leaves
+ *   nothing to compare, so this warns and skips, as it always has.
+ * - a manifest that is there and whose version cannot be read is a broken
+ *   comparison, not an absent one, and it fails. Letting it through would be
+ *   worse than a noisy release: `undefined !== '2.8.0'` reads as *the version
+ *   moved*, so the gate would quietly exempt itself and publish `@guren/*`
+ *   ranges inside no new tarball — the exact silent staleness it exists to
+ *   stop. Both sides are checked; a working tree that lost its version
+ *   exempts the release just as effectively as a committed one.
+ *
+ * `repo` is the checkout to run in; it is the function's subject, not a test
+ * hook. The refusal is only observable against real commits, so its tests build
+ * throwaway repositories and point it at those.
  */
-async function assertCreateAppRepublishes(): Promise<void> {
+export async function assertCreateAppRepublishes(repo: string = repoRoot): Promise<void> {
   const manifestPath = 'packages/create-app/package.json'
-  const committed = Bun.spawnSync(['git', 'show', `HEAD:${manifestPath}`], { cwd: repoRoot })
-  if (!committed.success) {
+  const committed = manifestAtRev('HEAD', manifestPath, repo)
+  if (committed === undefined) {
     console.warn(`Could not read ${manifestPath} from git; skipping the create-guren-app release check.`)
     return
   }
 
-  const previous = (JSON.parse(committed.stdout.toString()) as { version?: string }).version
-  const current = (await Bun.file(join(repoRoot, manifestPath)).json() as { version?: string }).version
+  const previous = versionOf(committed)
+  const current = versionOf(await readFile(join(repo, manifestPath), 'utf8').catch(() => undefined))
+
+  const unreadable = [
+    ...(previous === undefined ? ['committed at HEAD'] : []),
+    ...(current === undefined ? ['in the working tree'] : []),
+  ]
+  if (unreadable.length > 0) {
+    throw new Error(
+      `${manifestPath} declares no readable version ${unreadable.join(' and ')}.\n` +
+      'This check compares the two to decide whether create-guren-app republishes,\n' +
+      'and a version it could not read is not a version that moved. Repair the\n' +
+      'manifest and re-run; passing here would ship the rewritten template ranges\n' +
+      'inside no new tarball.',
+    )
+  }
 
   if (previous === current) {
     throw new Error(

--- a/scripts/workspace-packages.ts
+++ b/scripts/workspace-packages.ts
@@ -1,8 +1,20 @@
-// Shared discovery for the workspace packages under packages/.
+// Shared reading of the workspace's package manifests.
 //
-// Used by scripts/build-packages.ts and scripts/test-packages.ts so that adding
-// a package (a plugin, for example) never requires editing a hand-maintained
-// list in the root package.json.
+// Two questions, both answered here so that no script answers either one twice:
+//
+// - which packages live under packages/, and in what order they depend on each
+//   other. Used by scripts/build-packages.ts and scripts/test-packages.ts so
+//   that adding a package (a plugin, for example) never requires editing a
+//   hand-maintained list in the root package.json.
+// - what a manifest said at a git rev, which is how the release gates in
+//   scripts/ tell a version that moved from one that did not. `versionOf` is
+//   the rule that a version nobody could read is *not* a version: a gate that
+//   lets an unreadable manifest stand in for a number silently stops gating.
+//   Only one of the two gates had reached that conclusion. The other compared
+//   a bare `.version` against a bare `.version`, so an unreadable side read as
+//   *the version moved* and exempted the release it existed to gate. The rule
+//   lives here because a gate that reimplements it locally is how that
+//   happened, not because two correct copies wanted deduplicating.
 
 import { readdir, readFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
@@ -97,6 +109,50 @@ export async function collectPackages(): Promise<WorkspacePackage[]> {
   }
 
   return packages.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/**
+ * The text of `manifestPath` as of `rev`, or `undefined` when git could not
+ * produce it there — the file did not exist at that commit, or the rev itself
+ * does not resolve.
+ *
+ * Deliberately separate from `versionOf` rather than folded into one
+ * `versionAtRev`: "there is no manifest at that rev" and "there is one and its
+ * version cannot be read" are the same `undefined` to a caller that only wants
+ * a version, and callers that must tell them apart would have no way back.
+ *
+ * `repo` is the checkout to read, not a test hook — a gate is only observable
+ * against real commits, so its tests build throwaway repositories. It must be
+ * the repository *root*: git resolves `<rev>:<path>` against the top of the
+ * working tree whatever the cwd is (from packages/cli, `git show HEAD:package.json`
+ * hands back the root manifest), while every caller pairs this with a
+ * working-tree `join(repo, manifestPath)` that resolves against `repo`. Point
+ * it at a subdirectory and the two sides read different files.
+ */
+export function manifestAtRev(rev: string, manifestPath: string, repo: string = repoRoot): string | undefined {
+  const show = Bun.spawnSync(['git', 'show', `${rev}:${manifestPath}`], { cwd: repo })
+  return show.success ? show.stdout.toString() : undefined
+}
+
+/**
+ * The `version` a package manifest declares, or `undefined` when it declares
+ * none this rule recognizes: unparseable JSON, an absent `version`, a
+ * `version` that is not a string, or no manifest text at all.
+ *
+ * Every one of those collapses to `undefined` on purpose, and callers must
+ * treat `undefined` as "unknown" rather than as a value. Comparing two
+ * unknowns reads as "unchanged"; comparing one against a real version reads as
+ * "moved". Both readings are wrong, and the second is the dangerous one — it
+ * is a release gate exempting itself.
+ */
+export function versionOf(manifest: string | undefined): string | undefined {
+  if (manifest === undefined) return undefined
+  try {
+    const version = (JSON.parse(manifest) as { version?: unknown }).version
+    return typeof version === 'string' ? version : undefined
+  } catch {
+    return undefined
+  }
 }
 
 // @guren/cli and @guren/core depend on each other, so the graph has one real


### PR DESCRIPTION
## Summary

`assertCreateAppRepublishes` in `scripts/sync-template-deps.ts` compared two bare `.version` reads and failed only when they were **equal**, so any side it could not read compared *unequal* and passed:

```
undefined !== '2.8.0'   // read as "the version moved"
```

A committed `packages/create-app/package.json` without a `version` — or a working tree that lost one — therefore waved the release through. The rewritten `@guren/*` template ranges would then ship inside no new `create-guren-app` tarball, which is the exact silent staleness this refusal exists to stop. A malformed committed manifest was worse: an unguarded `JSON.parse` aborted the release with a raw `SyntaxError` naming neither the file nor why the comparison mattered.

`assertChangesetGate` in `scripts/build-agent-catalog.ts` performs the same three steps (`git show <rev>:<manifest>` → parse → `.version`) and had already reached the opposite conclusion, in its own words: *"A side that could not be read is not an exemption."* That reading now lives once, in `scripts/workspace-packages.ts`, and both gates share it.

**What is shared, and what deliberately is not.** Only the *reading* moves:

- `versionOf(text)` — guards `JSON.parse`, requires `typeof === 'string'`
- `manifestAtRev(rev, manifestPath, repo)` — `git show`, or `undefined` when git could not produce the file

The *comparison* stays with each caller, because their policies are opposite — differ ⇒ exempt versus same ⇒ error — and a shared "did it move?" is how the two would come to disagree. They are also two functions rather than one `versionAtRev`, because one caller must tell "no manifest at that rev" from "there is one and its version is unreadable", and a combined reader erases exactly that distinction.

**The two unreadable cases stay distinct refusals**, since they are not the same fact:

- no manifest at `HEAD` at all leaves nothing to compare, so it warns and skips, as it always has;
- a manifest that is there whose version cannot be read is a *broken* comparison, not an absent one, and now fails.

Both sides are checked: a working tree that lost its version exempts the release just as effectively as a committed one did.

## Scope

- `scripts/workspace-packages.ts` — new `manifestAtRev` / `versionOf`; module header updated to carry the rule
- `scripts/sync-template-deps.ts` — the fix; `assertCreateAppRepublishes` exported and given the checkout to run in
- `scripts/build-agent-catalog.ts` — local `versionOf` removed in favour of the shared one (no behaviour change)
- `scripts/sync-template-deps.test.ts` — new
- `CLAUDE.md` — one paragraph on what `workspace-packages.ts` now owns

No published package changed, so there is no changeset.

## Risk Assessment

`sync-template-deps.ts` is a release gate: `bun run audit:template-deps` runs on every PR and `version-packages` runs it with `--release`. The behaviour change is confined to the `--release` path (`--check` never reaches this function).

The new refusal cannot produce a false red on a real release. At `--release` time `changeset version` has just run, so the `HEAD` side is the healthy pre-release manifest and the working-tree side is the one changesets just wrote — both readable by construction. The pre-existing "version did not move" throw already fires after every template write completes, so the new throw does not change when the tree is left rewritten.

`assertChangesetGate` is unchanged in behaviour: `show.success ? versionOf(…) : undefined` and `versionOf(manifestAtRev(…))` are the same expression, and `.catch(() => '')` → `.catch(() => undefined)` both yield `undefined` from `versionOf`.

`assertCreateAppRepublishes` gaining an exported signature with a `repo` parameter follows `assertChangesetGate(base, repo = repoRoot)`; `repo` is the function's subject, not a test hook. Both call sites of `manifestAtRev` must pass a repository **root** — git resolves `<rev>:<path>` against the top of the working tree whatever the cwd is, while the working-tree half resolves against `repo`. That is stated in the docstring.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test`

```
$ bun run audit:template-deps
Template dependency versions match the workspace.

$ bun test --preload scripts/test-cwd-guard.ts --preload scripts/test-global-fetch-guard.ts scripts/
 141 pass / 0 fail

$ bun run test          # exit 0
 test:bun            4740 pass / 0 fail
 examples/blog       29 files passed
 examples/api        15 files passed
 web                 16 files passed
```

Also green: `audit:workspace-scripts`, `audit:agent-catalog`, `audit:core-semver`, `audit:docs`.

**Mutation-checked.** With the old unguarded logic restored, all five new unreadable-version cases go red — and the no-version case reports `Received promise that resolved`, confirming the defect was a silent pass rather than a noisy failure. `scripts/` is outside the root `tsconfig.json`, so the three touched files were type-checked separately under a temporary config; the only errors it reports are the pre-existing ones in `scripts/smoke/fixtures/` and `scripts/benchmarks/`.

The new test file needs no wiring: `scripts/test-packages.ts` collects `scripts/**/*.test.ts` by glob, so `test:bun` picks it up.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
