### PR TITLE
chore: version packages (cli 2.8.0, create-guren-app 1.8.6)

### DIFF
--- a/.changeset/agent-catalog-version-exemption.md
+++ b/.changeset/agent-catalog-version-exemption.md
@@ -1,5 +1,0 @@
----
-"@guren/cli": patch
----
-
-Exempt the agent-catalog changeset gate on a moved `@guren/cli` version rather than on a manifest-only diff. A push or squash carrying both a catalog change with its changeset and the `changeset version` commit that consumes it no longer fails the gate, and a manifest edit that leaves the version alone is now gated rather than waved through.

--- a/.changeset/proud-donuts-cheer.md
+++ b/.changeset/proud-donuts-cheer.md
@@ -1,5 +1,0 @@
----
-"@guren/cli": minor
----
-
-`guren agent:sync` no longer overwrites managed files silently. Files already matching the latest template are skipped and reported as up to date (line-ending-only differences count as up to date, so a CRLF checkout is not warned about forever); a file whose contents differed — an older version or a local edit — is listed as replaced, with a warning that local edits to framework-managed files do not survive a sync. A new `--dry-run` flag on both `agent:sync` and `agent:init` reports what a run would write, replace, or prune without changing any file; combined with `--prune` it says what would be removed, and the closing hint repeats the flags the preview ran with. `AgentHarnessResult` gains `replaced`, `unchanged`, `mode`, `dryRun`, and `pruneRequested` fields, and `written` now reports only the files actually written.

--- a/.changeset/spotty-hoops-shake.md
+++ b/.changeset/spotty-hoops-shake.md
@@ -1,5 +1,0 @@
----
-"@guren/cli": patch
----
-
-`guren check` no longer demands a console registration for files under `app/Console/Commands/` that declare no command. A constants or helper module living next to the commands used to produce a warning that could never be resolved. The registration check now covers only files that could surface a command: a class (declaration or expression) with a superclass or a `signature`/`handle` member, a re-export with a source, or a default-exported identifier or call. Files that fail to parse stay in the check, since they cannot be shown to declare no command — and are no longer double-reported as "skipped" by the coverage summary. `guren context` lists commands through the same predicate, so the two commands agree about what a helper module is.

--- a/.changeset/tall-lions-argue.md
+++ b/.changeset/tall-lions-argue.md
@@ -1,5 +1,0 @@
----
-"@guren/cli": minor
----
-
-`guren check --arch` can now enforce boundaries at the type level. Type-only imports (`import type`, `export type ... from`, and `import('...').X` in a type position) still compile away and are skipped by default, but a rule — or the whole rule set — can opt in with `includeTypeImports: true`, and the `defineArchRules` JSDoc now states the default explicitly. Violations found this way are labeled `(type-only)` in the report.

--- a/examples/api/CHANGELOG.md
+++ b/examples/api/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @guren/example-api
 
+## 0.1.22
+
+### Patch Changes
+
+- Updated dependencies [49b1d04]
+- Updated dependencies [f6f16fd]
+- Updated dependencies [352a76f]
+- Updated dependencies [1e44a1d]
+  - @guren/cli@2.8.0
+
 ## 0.1.21
 
 ### Patch Changes

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/example-api",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @guren/cli
 
+## 2.8.0
+
+### Minor Changes
+
+- f6f16fd: `guren agent:sync` no longer overwrites managed files silently. Files already matching the latest template are skipped and reported as up to date (line-ending-only differences count as up to date, so a CRLF checkout is not warned about forever); a file whose contents differed — an older version or a local edit — is listed as replaced, with a warning that local edits to framework-managed files do not survive a sync. A new `--dry-run` flag on both `agent:sync` and `agent:init` reports what a run would write, replace, or prune without changing any file; combined with `--prune` it says what would be removed, and the closing hint repeats the flags the preview ran with. `AgentHarnessResult` gains `replaced`, `unchanged`, `mode`, `dryRun`, and `pruneRequested` fields, and `written` now reports only the files actually written.
+- 1e44a1d: `guren check --arch` can now enforce boundaries at the type level. Type-only imports (`import type`, `export type ... from`, and `import('...').X` in a type position) still compile away and are skipped by default, but a rule — or the whole rule set — can opt in with `includeTypeImports: true`, and the `defineArchRules` JSDoc now states the default explicitly. Violations found this way are labeled `(type-only)` in the report.
+
+### Patch Changes
+
+- 49b1d04: Exempt the agent-catalog changeset gate on a moved `@guren/cli` version rather than on a manifest-only diff. A push or squash carrying both a catalog change with its changeset and the `changeset version` commit that consumes it no longer fails the gate, and a manifest edit that leaves the version alone is now gated rather than waved through.
+- 352a76f: `guren check` no longer demands a console registration for files under `app/Console/Commands/` that declare no command. A constants or helper module living next to the commands used to produce a warning that could never be resolved. The registration check now covers only files that could surface a command: a class (declaration or expression) with a superclass or a `signature`/`handle` member, a re-export with a source, or a default-exported identifier or call. Files that fail to parse stay in the check, since they cannot be shown to declare no command — and are no longer double-reported as "skipped" by the coverage summary. `guren context` lists commands through the same predicate, so the two commands agree about what a helper module is.
+
 ## 2.7.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guren/cli",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,20 @@
 # create-guren-app
 
+## 1.8.6
+
+### Patch Changes
+
+- Ship template dependency ranges for this release
+
+  The scaffold's `@guren/*` ranges are generated from the workspace versions,
+  and this release moves `@guren/cli`.
+  `changeset publish` only uploads packages whose own version moved, so
+  without this bump the updated ranges would sit in the repo and never reach
+  anyone running `create-guren-app`.
+
+  No behaviour change; the scaffolded app just resolves the versions released
+  alongside it.
+
 ## 1.8.5
 
 ### Patch Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-guren-app",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/create-app/templates/api-only/package.json
+++ b/packages/create-app/templates/api-only/package.json
@@ -18,7 +18,7 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@guren/cli": "^2.7.1",
+    "@guren/cli": "^2.8.0",
     "@guren/core": "^1.8.0",
     "@guren/orm": "^2.6.0",
     "drizzle-orm": "1.0.0-rc.4"

--- a/packages/create-app/templates/default/package.json
+++ b/packages/create-app/templates/default/package.json
@@ -19,7 +19,7 @@
     "db:seed": "bunx guren db:seed"
   },
   "dependencies": {
-    "@guren/cli": "^2.7.1",
+    "@guren/cli": "^2.8.0",
     "@guren/core": "^1.8.0",
     "@guren/inertia-client": "^1.1.1",
     "@guren/orm": "^2.6.0",

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,15 @@
 # web
 
+## 0.1.22
+
+### Patch Changes
+
+- Updated dependencies [49b1d04]
+- Updated dependencies [f6f16fd]
+- Updated dependencies [352a76f]
+- Updated dependencies [1e44a1d]
+  - @guren/cli@2.8.0
+
 ## 0.1.21
 
 ### Patch Changes

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Consumes 3 pending changesets ahead of the release that first publishes `@guren/plugin-markdown` 0.1.0 (RFC 0012, #489).

- `@guren/cli` 2.7.1 → 2.8.0 (minor)
- `create-guren-app` 1.8.5 → 1.8.6 (template ranges follow `@guren/cli`, written by the release planner)
- `@guren/plugin-markdown` stays 0.1.0 — new package, publishes because the version is not on npm yet
- private `web` / `@guren/example-api` patch bumps

`version-packages` pipeline green: core-semver audit, create-app planner, template-deps sync (`@guren/cli` ^2.8.0 in both templates), plugin-compat audit (4 manifests against core 1.8.0).