### PR TITLE
fix(server): drop the inert ApplicationOptions.discover

### DIFF
--- a/.changeset/plenty-taxis-shout.md
+++ b/.changeset/plenty-taxis-shout.md
@@ -1,0 +1,5 @@
+---
+"@guren/server": minor
+---
+
+Remove `ApplicationOptions.discover`. The option was accepted and silently ignored since it was introduced — nothing in `Application` ever read it, so no discovery ran and no behavior exists to migrate. This ships as a minor deliberately: it is a type-surface bug fix, not an API removal. JavaScript apps are unaffected either way, and TypeScript code passing `discover: true` now gets a compile error naming the truth instead of a silent no-op. The `AutoDiscovery` class remains available as a standalone scanner; its docs now state that registration in Guren is explicit and show how to feed scan results into the registries yourself.

--- a/packages/cli/src/deploy-runtime.ts
+++ b/packages/cli/src/deploy-runtime.ts
@@ -165,9 +165,9 @@ interface ExtractedSignal {
  *
  * ScryptHasher counts as password authentication because constructing one is
  * only ever done to hash a password (seeders do this). AutoDiscovery maps to
- * `discovery`; `ApplicationOptions.discover` is deliberately not a signal —
- * it is declared but never read anywhere in @guren/server, so warning about
- * it would flag a config key that has no effect.
+ * `discovery`; a `discover: true` option in `createApp()` is deliberately not
+ * a signal — the option never had an effect (`ApplicationOptions` no longer
+ * declares it), so a leftover in an older app is inert, not discovery.
  */
 const CONSTRUCTED_SIGNALS: Record<string, SignalKind> = {
   ScryptHasher: 'passwordAuth',

--- a/packages/cli/tests/deploy-runtime.test.ts
+++ b/packages/cli/tests/deploy-runtime.test.ts
@@ -630,9 +630,9 @@ const discovery = new AutoDiscovery({ basePath: 'app' })
     })
   })
 
-  // ApplicationOptions.discover is declared but never read anywhere in
-  // @guren/server, so it has no runtime effect — writing `discover: true`
-  // does not activate filesystem provider discovery and must not warn.
+  // ApplicationOptions no longer declares `discover` (it was accepted and
+  // silently ignored, then removed), but an older app may still carry the
+  // key — inert then and now, so it must not read as discovery.
   it('does not warn on the inert discover: true option', async () => {
     const files = {
       'src/app.ts': `import { createApp } from '@guren/core'\nexport const app = createApp({ discover: true })\n`,

--- a/packages/server/src/discovery/AutoDiscovery.ts
+++ b/packages/server/src/discovery/AutoDiscovery.ts
@@ -40,6 +40,14 @@ export interface DiscoveryResult {
  * Auto-discovery engine that scans application directories and discovers
  * framework components (providers, listeners, jobs, events).
  *
+ * Standalone by design: nothing in `Application` runs this scan, so
+ * registration stays explicit — `createApp({ providers: [...] })`, and
+ * `defineModule` lists for modules — which is what `guren check` verifies
+ * and what bundle-deploy targets (Workers, Vercel, Lambda) require, since a
+ * runtime directory scan finds nothing in a bundle. A caller that wants
+ * discovery runs the scan itself and feeds each result into the matching
+ * registry, as the example below does.
+ *
  * Uses `Bun.Glob` to scan directories and dynamic `import()` to load modules.
  *
  * @example

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -465,7 +465,6 @@ export interface ApplicationOptions {
    * is registered automatically.
    */
   readonly i18n?: I18nPluginOptions
-  readonly discover?: boolean
   readonly routes?: RouteRegistration
   /**
    * Application modules (RFC 0002) — each module's providers are appended


### PR DESCRIPTION
## Summary

`ApplicationOptions.discover` was part of the public type but nothing in `Application` ever read it — `createApp({ discover: true })` type-checked, ran, and silently did nothing (#478).

This removes the option. **Shipping as a minor deliberately**: this is a type-surface bug fix, not an API removal —

- the option was accepted and silently ignored since it was introduced, so there is **no behavior to migrate**; an app that passed it behaves identically after the upgrade
- JavaScript apps are unaffected entirely
- TypeScript code passing `discover: true` now gets a **loud compile error at build time naming the truth**, instead of the silent no-op — the opposite shape of the silently-delivered breakage our semver gates exist to prevent
- nothing in docs, templates, or examples ever mentioned the option (verified by grep)

`AutoDiscovery` remains exported as a standalone scanner. Its class doc now states the design intent explicitly — registration in Guren is explicit (`providers: [...]`, `defineModule` lists), which is what `guren check` verifies and what bundle-deploy targets (Workers/Vercel/Lambda) require — and shows how to feed scan results into the registries yourself, answering the issue's question about which registry each discovery result was meant to reach.

The deploy check's `discover: true` handling is untouched (a leftover key in an older app is inert, not discovery); its comments and test are updated to the new reality.

Fixes #478