### PR TITLE
test(cli): give the routes-types compile gate the cold-tsc timeout

### DIFF
--- a/packages/cli/tests/routes-types.test.ts
+++ b/packages/cli/tests/routes-types.test.ts
@@ -253,7 +253,7 @@ describe('buildRouteModuleContent', () => {
     } finally {
       await rm(dir, { recursive: true, force: true })
     }
-  })
+  }, COLD_TSC_TIMEOUT)
 })
 
 /**


### PR DESCRIPTION
## Summary

`buildRouteModuleContent > type-checks under strict tsc with and without named routes` is load-sensitive and intermittently fails on bun:test's 5000ms default. Its body is `ts.createProgram()` + `ts.getPreEmitDiagnostics()` over two generated files, which is genuinely slow and has no fixed upper bound relative to machine load.

Measured on a developer machine during an unrelated sweep: it passes in isolation, but under a full `bun run test:bun` it has been observed at 5185ms, 6304ms, 14586ms and 26201ms, i.e. it crosses the budget roughly one run in six. Because a bun:test timeout is charged to the *next* test, a single overrun here presents as several unrelated failures.

This gives that one test an explicit timeout rather than raising the global budget, so the rest of the suite keeps a tight default.

The value is the existing `COLD_TSC_TIMEOUT` (`packages/cli/tests/helpers.ts`), not a new number. Every other in-process tsc call site in the package already uses it: `routes-types.test.ts:332`, `api-client-types.test.ts:352`, `data-types.test.ts:206/614`, `i18n-types-compile.test.ts:111/122`, `scaffold-builder-typecheck.test.ts:160`. The constant is already imported at the top of this file. 180s looks generous against a 26s worst case, and the constant's own comment says why: the limit only needs to sit above the slowest observed cold start, not near it.

### Why this test was the outlier

Not arbitrary, and worth recording even though it is out of scope here. This test hand-rolls its compiler options instead of spreading `GENERATED_MODULE_COMPILER_OPTIONS`, so it omits both `skipLibCheck: true` and `types: []`. The helper's own comment explains the second one: the default type-root walk climbs ancestor directories, so a TMPDIR inside a workspace pulls in and type-checks every `@types` package it finds there — which makes this test's runtime depend on where TMPDIR sits, and is a plausible chunk of the variance. It also re-imports typescript dynamically when `ts` is already statically in scope.

Adopting the shared options could change which diagnostics the program produces, and the test asserts `toEqual([])`, so it does not belong in a timeout fix. Filed as follow-up work.

## Scope

- `cli` — one test file, one line. No product code, no behavior change.

## Risk Assessment

None to shipped code. This is a test-harness timeout only; no source file, template, or public API is touched. The test's assertions are unchanged, so it can still fail for a real reason — it just gets time to reach that verdict instead of being cut off mid-`createProgram()`.

## Validation

Two separate claims, kept separate on purpose.

**1. The timeout argument is actually honored at this call site.** Repeated green runs cannot show this — the failure is ~1-in-6, so N green runs is weak evidence at any realistic N, and it says nothing about whether `it()` reads a third argument here. Mutation-checked instead: temporarily set the timeout to `1`, and the test fails as intended.

```
(fail) buildRouteModuleContent > type-checks under strict tsc with and without named routes [1.66ms]
  ^ this test timed out after 1ms.
```

Then restored to `COLD_TSC_TIMEOUT`.

**2. Nothing else regressed.** `bun run test:bun` x6, all green.

```
 4848 pass
 84 skip
 0 fail
Ran 4932 tests across 285 files. [56.18s]
```

Note what (2) does *not* show: the runs were 56–67s sequential on an otherwise idle machine and the target never surfaced as slow, which is exactly what a run that did not reproduce a load-sensitive 1-in-6 failure looks like. The mutation check is the load-bearing evidence; the repeated runs only cover regression.

**Charged-to-next-test ruled out.** The preceding test (`emits no @ts-nocheck when no routes are named`) is a synchronous string assertion that cannot overrun, and typescript is statically imported at the top of the file, so the file's ~19s module load lands well before this test. The reported durations are this test's own work.

**Survey.** Cross-referenced every `checkTypes(` / `ts.createProgram(` call site under `packages/cli/tests/` against the existing `COLD_TSC_TIMEOUT` usages. All five compile-test files are covered; this test was the sole omission, so there is no sibling carrying the same latent flake.

- [x] `bun run build` (`build:clean`)
- [x] `bun run typecheck`
- [x] `bun run test:bun` (x6)
- [ ] `bun run test` — the `test:examples` half was not run; it needs a live database and this change cannot reach it.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks. (None; test-only.)
- [x] I added/updated tests for behavior changes. (No behavior change; this is the test fix.)
- [x] I updated relevant documentation. (None applicable.)