### PR TITLE
ci: trial Bun 1.4.0 in the CI matrix

### DIFF
--- a/.changeset/bun-1-4-signal-teardown-types.md
+++ b/.changeset/bun-1-4-signal-teardown-types.md
@@ -1,0 +1,5 @@
+---
+'@guren/server': patch
+---
+
+Keep the SIGINT/SIGTERM/exit teardown compiling under bun-types 1.4.0, which declares `process.off` with only a `"memoryPressure"` overload and thereby shadows the generic `EventEmitter.off` the signal names relied on. Runtime behavior is unchanged.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bun-version: ['1.3.14']
+        # The first entry is the supported version every other workflow pins
+        # (scripts/workflow-bun-version.test.ts enforces that); later entries
+        # are trial lanes for the next Bun line — promote one to first once it
+        # has soaked.
+        bun-version: ['1.3.14', '1.4.0']
         include:
           - bun-version: '1.3.14'
             redis: true
-          # When a new Bun version is supported, add it here:
-          # - bun-version: '1.4.x'
-          #   redis: true
+          - bun-version: '1.4.0'
+            redis: true
     services:
       redis:
         image: redis:7-alpine

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "guren-monorepo",
       "devDependencies": {
         "@changesets/cli": "^2.31.1",
-        "bun-types": "^1.3.14",
+        "bun-types": "^1.4.0",
         "typescript": "^5.9.3",
         "vite": "^8.2.0",
         "vitest": "^3.2.7",
@@ -15,7 +15,7 @@
     },
     "examples/api": {
       "name": "@guren/example-api",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -68,7 +68,7 @@
     },
     "packages/cli": {
       "name": "@guren/cli",
-      "version": "2.7.1",
+      "version": "2.8.0",
       "bin": {
         "guren": "./dist/bin.js",
       },
@@ -114,7 +114,7 @@
     },
     "packages/create-app": {
       "name": "create-guren-app",
-      "version": "1.8.5",
+      "version": "1.8.6",
       "bin": {
         "create-guren-app": "./dist/cli.js",
       },
@@ -317,7 +317,7 @@
     },
     "web": {
       "name": "web",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -984,7 +984,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   ],
   "devDependencies": {
     "@changesets/cli": "^2.31.1",
-    "bun-types": "^1.3.14",
+    "bun-types": "^1.4.0",
     "typescript": "^5.9.3",
     "vitest": "^3.2.7",
     "vite": "^8.2.0",

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -329,9 +329,15 @@ function registerProcessTeardown(onSignal: () => void, onExit: () => void): () =
   process.on('exit', onExit)
 
   return () => {
-    process.off('SIGINT', onSignal)
-    process.off('SIGTERM', onSignal)
-    process.off('exit', onExit)
+    // Detach via the EventEmitter surface: bun-types 1.4.0 declares `off` on
+    // Process with only a "memoryPressure" overload, which shadows the generic
+    // `off` Process used to inherit — so signal names stop compiling there.
+    // (`on`/`once` are unaffected: @types/node declares those per event, and
+    // interface merging keeps every overload.)
+    const emitter: NodeJS.EventEmitter = process
+    emitter.off('SIGINT', onSignal)
+    emitter.off('SIGTERM', onSignal)
+    emitter.off('exit', onExit)
   }
 }
 


### PR DESCRIPTION
## Summary

Bun 1.4.0 shipped ([release notes](https://bun.sh/blog/bun-v1.4)). This PR starts Guren's support for it along the path `ci.yml` already prepared:

- Add **Bun 1.4.0 as a trial lane** in the CI matrix (with the Redis-backed suite), keeping 1.3.14 as the first entry that every other workflow pins — `scripts/workflow-bun-version.test.ts` keeps enforcing that, so the release gate stays on the supported version until the trial lane has soaked.
- Bump **bun-types to ^1.4.0** (lockfile updated with Bun 1.3.14, so the frozen-lockfile install on the primary lane is untouched).
- Fix the one thing bun-types 1.4.0 broke: it declares `process.off` with only a `"memoryPressure"` overload, which shadows the generic `EventEmitter.off` the SIGINT/SIGTERM/exit teardown relied on. The teardown now detaches through the `EventEmitter` surface; runtime behavior is unchanged (patch changeset for `@guren/server`).

## Verification (local, Bun 1.4.0)

- `bun install --frozen-lockfile`, `bun run build:clean`, codegen, `bun run typecheck`: green
- `bun run test:bun`: 4932 tests across 285 files, green on clean runs
- `bun run test:examples`: blog 108 / api 42 / web 113, all green
- `audit:core-first`, `audit:docs`, `audit:template-deps`: green

The only recurring failures were the subprocess-heavy agent-catalog tests hitting their 5s timeout under machine load; an interleaved A/B (3× each) showed them flaking at the same rate on 1.3.14 and 1.4.0, so that is pre-existing load sensitivity, not a 1.4 regression (and the `claude plugin validate` half is skipped on CI runners anyway).

## Follow-up (separate PRs, once the trial lane has soaked)

- Promote 1.4.0 to the matrix's first entry and move every workflow pin to it
- The `process.off` overload gap looks like a bun-types bug worth reporting upstream