### PR TITLE
test(cli): share the compile-gate options in the routes-types tsc probe

### DIFF
--- a/packages/cli/tests/routes-types.test.ts
+++ b/packages/cli/tests/routes-types.test.ts
@@ -212,7 +212,6 @@ describe('buildRouteModuleContent', () => {
   // scaffolded app's typecheck skip this file entirely. Compiling both shapes
   // is what keeps that suppression from coming back as a hidden type error.
   it('type-checks under strict tsc with and without named routes', async () => {
-    const ts = (await import('typescript')).default
     const dir = await mkdtemp(join(tmpdir(), 'guren-routes-types-'))
     try {
       const cases: Record<string, string> = {
@@ -237,13 +236,9 @@ describe('buildRouteModuleContent', () => {
       }
 
       const program = ts.createProgram(files, {
-        strict: true,
+        ...GENERATED_MODULE_COMPILER_OPTIONS,
         noUnusedLocals: true,
         noUnusedParameters: true,
-        target: ts.ScriptTarget.ES2022,
-        module: ts.ModuleKind.ESNext,
-        moduleResolution: ts.ModuleResolutionKind.Bundler,
-        noEmit: true,
       })
       const diagnostics = ts.getPreEmitDiagnostics(program)
 


### PR DESCRIPTION
## Summary

The `type-checks under strict tsc with and without named routes` case in `packages/cli/tests/routes-types.test.ts` hand-rolled its `ts.createProgram()` options instead of spreading `GENERATED_MODULE_COMPILER_OPTIONS`, which the four sibling compile gates in this package all use (`api-client-types`, `data-types`, `i18n-types-compile`, `scaffold-builder-typecheck`). It was the last one out of line, and #500 recorded the reason it was left that way: adopting the shared options can change the diagnostic set a `toEqual([])` assertion is measuring.

The cost of the divergence was `types: []`. Without it, the default type-root walk climbs ancestor directories, so a TMPDIR sitting inside a workspace pulls in and type-checks every `@types` package it finds there — making the probe's runtime a function of where TMPDIR happens to be. That is a plausible contributor to the spread #500 measured (5185ms, 6304ms, 14586ms, 26201ms).

Measured here on a warm cache:

| | before | after |
|---|---|---|
| whole-file user CPU | 14.19s | 5.85s |
| the probe alone (wall, isolated) | 5.34s | ~2.4s |
| the probe's own reported duration | — | 0.5–1.6s |

`noUnusedLocals` / `noUnusedParameters` are kept as explicit extras, since the shared base does not set them. Also drops `const ts = (await import('typescript')).default`, which shadowed the static `ts` import already present at the top of the file.

## Scope

`cli` — one test file, `packages/cli/tests/routes-types.test.ts`. No product code.

## Risk Assessment

The risk #500 named is that the shared options change what the program reports, and a gate asserting `toEqual([])` gets quietly weaker rather than loudly wrong. Verified by mutation rather than by argument — each was appended to the generated module, confirmed to surface, then reverted:

| mutation | diagnostic | proves |
|---|---|---|
| `const unusedLocal = 1` | TS6133 | `noUnusedLocals` survived the spread |
| `export function probe(unusedParam: string): void {}` | TS6133 | `noUnusedParameters` survived the spread |
| `export const bad: string = 1` | TS2322 | `skipLibCheck` did not neuter checking of the emitted `.ts` |

The third is the one that answers #500's concern directly: `skipLibCheck` only suppresses errors *inside* `.d.ts` files, so the generated module itself is still fully checked.

One risk not named in the task: the shared base also pins `lib` (`lib.es2022.d.ts` + `lib.dom.d.ts`), narrower than the `lib.es2022.full.d.ts` that target ES2022 defaults to. It introduced no diagnostics here, and narrowing libs can only add diagnostics, never mask one, so the green run is the stronger evidence.

## Validation

- [x] `bun run build` — exit 0
- [x] `bun run typecheck` — exit 0
- [x] `bun run test` — see below

`bun test tests/routes-types.test.ts`: 35 pass, 0 fail.

`bun run test:bun cli`: 1619 pass, 0 fail across 95 files.

The full `bun run test:bun` reported 4851 pass / 4 fail. All four are 5s-default timeouts under a saturated machine (11 packages built and tested in parallel), and each passes in isolation:

- `scripts/publish-agent-catalog.test.ts` — 16 pass / 0 fail alone
- `packages/plugin-lambda/src/cdk/index.test.ts` — 11 pass / 0 fail alone
- two `packages/cli/tests/context-entity-arg.test.ts` cases, where the second is collateral from the first: the timed-out test's `createTempWorkspace` cleanup chdir'd and removed its temp dir while the next test was running, exactly the global-state hazard that helper's own comment documents

None are in the file this PR touches. They are the same class of problem #500 fixed for this one gate — in-process tsc and CDK-synth tests still on bun:test's 5s default — but they are separate call sites and are left alone here.

`bun run test:examples` was not run (needs a database container).

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.

Follow-up to #500.
