### PR TITLE
docs: add markdown rendering guide

### DIFF
--- a/docs/en/guides/markdown.md
+++ b/docs/en/guides/markdown.md
@@ -1,0 +1,174 @@
+# Markdown Rendering
+
+`@guren/plugin-markdown` renders markdown to HTML with hardened defaults: GitHub Flavored Markdown, sanitized output safe for `dangerouslySetInnerHTML`, GitHub-style alerts, heading anchors, and optional shiki code highlighting. It is the pipeline guren.dev itself uses for its docs and blog.
+
+## Install
+
+```bash
+bunx guren plugin @guren/plugin-markdown
+bun add @guren/plugin-markdown
+```
+
+## Rendering
+
+```ts
+import { createMarkdownRenderer } from '@guren/plugin-markdown'
+
+const renderer = createMarkdownRenderer()
+const html = await renderer.render('# Hello\n\n> [!NOTE]\n> Sanitized by default.')
+```
+
+`render()` is a pure async function of its input: one renderer instance is safe under concurrent requests, and the package keeps no cache. Render at save time and store the HTML (the blog pattern), or render per request — that choice belongs to your app.
+
+All options with their defaults:
+
+```ts
+createMarkdownRenderer({
+  gfm: true,        // tables, strikethrough, autolinks
+  sanitize: true,   // allowlist-sanitize the output (see below)
+  alerts: true,     // GitHub-style > [!NOTE] blockquote alerts
+  anchors: true,    // heading id attributes
+  rewriteLink: undefined,   // (href: string) => string
+  highlight: undefined,     // code-fence highlighter (see below)
+})
+```
+
+## Sanitization
+
+Markdown syntax alone can carry `javascript:` and `data:` URLs into `href` and `src`, so escaping raw HTML is not enough on its own. With the default `sanitize: true`, the rendered HTML passes a `sanitize-html` allowlist before it is returned:
+
+- structural tags only; raw HTML like `<script>` is escaped, not silently dropped
+- `href`/`src` restricted to `http`, `https`, and `mailto`; protocol-relative URLs (`//host/path`) are rejected
+- inline styles limited to the declarations shiki emits (colors and the `--shiki-dark` custom properties), so highlighted code survives sanitization intact
+- heading `id`s and the alert markup are admitted by exact value
+
+The result is safe to inject with `dangerouslySetInnerHTML`.
+
+Extend the allowlist without replacing it by passing a callback — it receives the defaults and returns the options to use:
+
+```ts
+createMarkdownRenderer({
+  sanitize: (defaults) => ({
+    ...defaults,
+    allowedTags: [...(defaults.allowedTags as string[]), 'video'],
+  }),
+})
+```
+
+For trusted content — your own docs rendered at build time — opt out explicitly with `sanitize: false`.
+
+## Alerts
+
+GitHub's five blockquote directives render as labeled alert blocks:
+
+```markdown
+> [!NOTE]
+> Something worth knowing.
+
+> [!WARNING]
+> Something worth checking.
+```
+
+The markup uses framework-neutral class names (`guren-markdown-alert`, `guren-markdown-alert--note` … `--caution`, `__label`, `__body`) and the package applies no styling itself — see [Styling](#styling).
+
+`alertLabels` overrides the rendered label text per type (requires `@guren/plugin-markdown` 0.2.0 or later), for i18n or a different vocabulary — several types may share one label, class names stay keyed to the directive that was written, and labels render as escaped text:
+
+```ts
+createMarkdownRenderer({
+  alertLabels: { note: 'note', tip: 'ok', important: 'rule', warning: 'rule', caution: 'never' },
+})
+```
+
+An explicit empty string suppresses the label text; omitted types keep their default (`Note`, `Tip`, `Important`, `Warning`, `Caution`).
+
+## Heading anchors
+
+With `anchors: true` every heading gets a slug `id` — unicode-aware, duplicate-safe within a render (`Setup`, `Setup-1`, `Setup` yields `setup`, `setup-1`, `setup-2`), and hardened against HTML smuggled into heading text.
+
+## Link rewriting
+
+`rewriteLink` runs over every link `href` before rendering — for example, turning GitHub-compatible relative `.md` links into site routes:
+
+```ts
+createMarkdownRenderer({
+  rewriteLink: (href) => (href.endsWith('.md') ? `/docs/${href.slice(0, -3)}` : href),
+})
+```
+
+## Code highlighting with shiki
+
+`shiki` is an optional peer dependency behind its own subpath — install it only if you use it:
+
+```bash
+bun add shiki
+```
+
+```ts
+import { createMarkdownRenderer } from '@guren/plugin-markdown'
+import { createShikiHighlight } from '@guren/plugin-markdown/shiki'
+
+const renderer = createMarkdownRenderer({
+  highlight: createShikiHighlight({
+    themes: { light: 'github-light', dark: 'github-dark' },
+    langs: ['typescript', 'tsx', 'bash', 'json'],
+  }),
+})
+```
+
+This builds a fine-grained `shiki/core` highlighter — only the listed grammars, with the JavaScript regex engine instead of the oniguruma WASM blob — and emits dual-theme output: the light palette inline, the dark palette in `--shiki-dark` custom properties. Fences in unloaded languages fall back to plain text instead of throwing.
+
+### On Cloudflare Workers
+
+Bundlers that must see every import statically cannot resolve grammar names at runtime. Pass explicit module thunks instead — the thunks also keep loading lazy, so importing the module costs nothing until the first render:
+
+```ts
+createShikiHighlight({
+  themes: { light: 'github-light', dark: 'github-dark' },
+  themeModules: [
+    () => import('shiki/dist/themes/github-light.mjs'),
+    () => import('shiki/dist/themes/github-dark.mjs'),
+  ],
+  langModules: [() => import('shiki/dist/langs/typescript.mjs')],
+})
+```
+
+Never import the full `shiki` entry in code that ends up in a Workers bundle — it pulls every grammar plus the oniguruma WASM. The full entry is fine in build-time code (prerendering docs, for example), where arbitrary languages matter more than bundle size.
+
+### Custom highlighters
+
+`highlight` is just a function `(code, lang) => string | Promise<string>`. A result that begins with `<pre` is treated as a complete code block and emitted as-is (shiki's shape); anything else is wrapped in the default `<pre><code>`.
+
+## Styling
+
+The renderer emits class names but no styles. A small reference stylesheet covers alerts and the dark-mode shiki toggle:
+
+```ts
+import '@guren/plugin-markdown/styles.css'
+```
+
+Alert accent colors are CSS custom properties, so overriding just the variables restyles them:
+
+```css
+.guren-markdown-alert--note { --guren-markdown-alert-accent: #e11d48; }
+```
+
+## As a container service
+
+`markdownPlugin()` registers a configured renderer as the `markdown` container service:
+
+```ts
+import { createApp } from '@guren/core'
+import { markdownPlugin } from '@guren/plugin-markdown'
+
+createApp({
+  providers: [markdownPlugin({ /* renderer options */ })],
+})
+```
+
+```ts
+import type { MarkdownRenderer } from '@guren/plugin-markdown'
+
+const renderer = container.make<MarkdownRenderer>('markdown')
+```
+
+The plugin form is optional — `createMarkdownRenderer` works without `createApp` at all.

--- a/docs/ja/guides/markdown.md
+++ b/docs/ja/guides/markdown.md
@@ -1,0 +1,174 @@
+# Markdownレンダリング
+
+`@guren/plugin-markdown`は、堅牢なデフォルト設定でmarkdownをHTMLにレンダリングします。GitHub Flavored Markdown、`dangerouslySetInnerHTML`に安全なサニタイズ済み出力、GitHubスタイルのアラート、見出しアンカー、そしてオプションのshikiコードハイライトを備えています。guren.dev自身のdocsとブログが使っているパイプラインです。
+
+## インストール
+
+```bash
+bunx guren plugin @guren/plugin-markdown
+bun add @guren/plugin-markdown
+```
+
+## レンダリング
+
+```ts
+import { createMarkdownRenderer } from '@guren/plugin-markdown'
+
+const renderer = createMarkdownRenderer()
+const html = await renderer.render('# Hello\n\n> [!NOTE]\n> デフォルトでサニタイズされます。')
+```
+
+`render()`は入力に対する純粋な非同期関数です。1つのレンダラインスタンスは並行リクエスト下でも安全で、パッケージはキャッシュを持ちません。保存時にレンダリングしてHTMLを格納する（ブログのパターン）か、リクエストごとにレンダリングするかはアプリ側の選択です。
+
+全オプションとデフォルト値:
+
+```ts
+createMarkdownRenderer({
+  gfm: true,        // テーブル、取り消し線、オートリンク
+  sanitize: true,   // 出力をallowlistでサニタイズ（後述）
+  alerts: true,     // GitHubスタイルの > [!NOTE] blockquoteアラート
+  anchors: true,    // 見出しのid属性
+  rewriteLink: undefined,   // (href: string) => string
+  highlight: undefined,     // コードフェンスのハイライタ（後述）
+})
+```
+
+## サニタイズ
+
+markdown記法だけでも`javascript:`や`data:`のURLは`href`や`src`に入り込めるため、生HTMLのエスケープだけでは不十分です。デフォルトの`sanitize: true`では、レンダリング結果は返される前に`sanitize-html`のallowlistを通過します。
+
+- 構造タグのみ許可。`<script>`のような生HTMLは黙って消えるのではなくエスケープされます
+- `href`/`src`は`http`、`https`、`mailto`に限定。プロトコル相対URL（`//host/path`）は拒否されます
+- インラインstyleはshikiが出力する宣言（色と`--shiki-dark`カスタムプロパティ）だけに限定されるため、ハイライト済みコードはサニタイズを無傷で通過します
+- 見出しの`id`とアラートのマークアップは、値の完全一致で許可されます
+
+結果は`dangerouslySetInnerHTML`で安全に注入できます。
+
+allowlistの拡張はコールバックで行います。デフォルト値を受け取り、使用するオプションを返します:
+
+```ts
+createMarkdownRenderer({
+  sanitize: (defaults) => ({
+    ...defaults,
+    allowedTags: [...(defaults.allowedTags as string[]), 'video'],
+  }),
+})
+```
+
+信頼済みコンテンツ（ビルド時にレンダリングする自分のdocsなど）には、`sanitize: false`で明示的にオプトアウトします。
+
+## アラート
+
+GitHubの5つのblockquoteディレクティブは、ラベル付きのアラートブロックとしてレンダリングされます:
+
+```markdown
+> [!NOTE]
+> 知っておくべきこと。
+
+> [!WARNING]
+> 確認すべきこと。
+```
+
+マークアップにはフレームワーク中立なクラス名（`guren-markdown-alert`、`guren-markdown-alert--note`〜`--caution`、`__label`、`__body`）が付き、パッケージ自体はスタイルを適用しません。[スタイリング](#スタイリング)を参照してください。
+
+`alertLabels`はタイプごとのラベル文字列を上書きします（`@guren/plugin-markdown` 0.2.0以降）。i18nや別の語彙のために使え、複数タイプで1つのラベルを共有できます。クラス名は書かれたディレクティブに紐づいたまま変わらず、ラベルはエスケープ済みテキストとしてレンダリングされます:
+
+```ts
+createMarkdownRenderer({
+  alertLabels: { note: 'note', tip: 'ok', important: 'rule', warning: 'rule', caution: 'never' },
+})
+```
+
+明示的な空文字列はラベル文字列を抑止します。省略したタイプはデフォルトのラベル（`Note`、`Tip`、`Important`、`Warning`、`Caution`）を保ちます。
+
+## 見出しアンカー
+
+`anchors: true`ではすべての見出しにslugの`id`が付きます。unicode対応で、1レンダリング内の重複にも安全です（`Setup`、`Setup-1`、`Setup`は`setup`、`setup-1`、`setup-2`になります）。見出しテキストに紛れ込ませたHTMLに対しても堅牢化されています。
+
+## リンクの書き換え
+
+`rewriteLink`はレンダリング前にすべてのリンクの`href`に対して実行されます。たとえば、GitHub互換の相対`.md`リンクをサイトのルートに変換できます:
+
+```ts
+createMarkdownRenderer({
+  rewriteLink: (href) => (href.endsWith('.md') ? `/docs/${href.slice(0, -3)}` : href),
+})
+```
+
+## shikiによるコードハイライト
+
+`shiki`は専用サブパスの背後にあるoptional peer dependencyです。使う場合だけインストールします:
+
+```bash
+bun add shiki
+```
+
+```ts
+import { createMarkdownRenderer } from '@guren/plugin-markdown'
+import { createShikiHighlight } from '@guren/plugin-markdown/shiki'
+
+const renderer = createMarkdownRenderer({
+  highlight: createShikiHighlight({
+    themes: { light: 'github-light', dark: 'github-dark' },
+    langs: ['typescript', 'tsx', 'bash', 'json'],
+  }),
+})
+```
+
+これはfine-grainedな`shiki/core`ハイライタを構築します。列挙した文法だけを読み込み、oniguruma WASMの代わりにJavaScript正規表現エンジンを使います。出力はデュアルテーマで、ライトパレットはインライン、ダークパレットは`--shiki-dark`カスタムプロパティに載ります。未ロード言語のフェンスは例外を投げずプレーンテキストにフォールバックします。
+
+### Cloudflare Workersでは
+
+すべてのimportを静的に解決する必要があるバンドラは、実行時の文法名解決ができません。代わりに明示的なモジュールthunkを渡します。thunkはロードを遅延させる効果もあり、モジュールのimport自体は初回レンダリングまでコストゼロです:
+
+```ts
+createShikiHighlight({
+  themes: { light: 'github-light', dark: 'github-dark' },
+  themeModules: [
+    () => import('shiki/dist/themes/github-light.mjs'),
+    () => import('shiki/dist/themes/github-dark.mjs'),
+  ],
+  langModules: [() => import('shiki/dist/langs/typescript.mjs')],
+})
+```
+
+Workersバンドルに入るコードでフルの`shiki`エントリをimportしてはいけません。全文法とoniguruma WASMを引き込みます。ビルド時コード（docsのプリレンダリングなど）では、バンドルサイズより任意言語対応が重要なのでフルエントリで問題ありません。
+
+### カスタムハイライタ
+
+`highlight`は単なる関数`(code, lang) => string | Promise<string>`です。`<pre`で始まる結果は完全なコードブロックとしてそのまま出力され（shikiの形）、それ以外はデフォルトの`<pre><code>`でラップされます。
+
+## スタイリング
+
+レンダラはクラス名だけを出力し、スタイルは適用しません。アラートとダークモードのshiki切替をカバーする小さな参照スタイルシートが同梱されています:
+
+```ts
+import '@guren/plugin-markdown/styles.css'
+```
+
+アラートのアクセント色はCSSカスタムプロパティなので、変数の上書きだけで再スタイルできます:
+
+```css
+.guren-markdown-alert--note { --guren-markdown-alert-accent: #e11d48; }
+```
+
+## コンテナサービスとして
+
+`markdownPlugin()`は設定済みレンダラを`markdown`コンテナサービスとして登録します:
+
+```ts
+import { createApp } from '@guren/core'
+import { markdownPlugin } from '@guren/plugin-markdown'
+
+createApp({
+  providers: [markdownPlugin({ /* レンダラのオプション */ })],
+})
+```
+
+```ts
+import type { MarkdownRenderer } from '@guren/plugin-markdown'
+
+const renderer = container.make<MarkdownRenderer>('markdown')
+```
+
+プラグイン形態はオプションです。`createMarkdownRenderer`は`createApp`なしでも動作します。

--- a/web/app/Services/docs-config.ts
+++ b/web/app/Services/docs-config.ts
@@ -67,6 +67,7 @@ const GUIDE_SECTIONS: readonly DocSectionConfig[] = [
       'health-checks',
       'i18n',
       'api-resources',
+      'markdown',
     ],
   },
   {


### PR DESCRIPTION
Adds the `@guren/plugin-markdown` guide (RFC 0012) in both locales — `docs/en/guides/markdown.md` and `docs/ja/guides/markdown.md` — and wires the `markdown` slug into the docs nav (Digging Deeper section in `web/app/Services/docs-config.ts`).

Covers: install via `guren plugin`, the pure-`render()` contract and save-time vs request-time choice, the sanitization allowlist and its extension callback, alerts (with `alertLabels` noted as requiring 0.2.0+, which the pending changeset ships), heading anchors, `rewriteLink`, shiki integration including the Workers `langModules`/`themeModules` thunk guidance, the reference stylesheet, and the `markdownPlugin()` container form.

Verified: `guren check --docs` and `audit:docs` green; web prerender picks up both locale pages (titles present in `docs.gen.ts`); web test suite 114 pass; root typecheck green.

Refs: RFC 0012