### PR TITLE
feat(server): cache hashed public assets immutably in production

### DIFF
--- a/.changeset/public-assets-immutable-cache.md
+++ b/.changeset/public-assets-immutable-cache.md
@@ -1,0 +1,5 @@
+---
+"@guren/server": minor
+---
+
+Serve Vite's content-hashed build assets (`/public/assets/*` in production) with `Cache-Control: public, max-age=31536000, immutable`. Their filenames change on every content change, so browsers can cache them forever instead of re-downloading on each visit. Files elsewhere under `public/` keep stable names and are served without a caching header, unchanged; the dev-mode route stays uncached so HMR keeps working. The prefix follows a custom `publicRoute` (e.g. `/static/*` → `/static/assets/*`).

--- a/packages/server/src/http/inertia-assets.ts
+++ b/packages/server/src/http/inertia-assets.ts
@@ -85,12 +85,21 @@ export function configureInertiaAssets(app: Application, options: InertiaAssetsO
 
   const publicRoute = options.publicRoute ?? '/public/*'
   const rewriteRequestPath = createStaticRewrite(publicRoute)
+  const hashedAssetsPrefix = `${publicRouteBase(publicRoute)}/assets/`
 
   app.use(
     publicRoute,
     serveStatic({
       root: publicDir,
       rewriteRequestPath,
+      // Vite writes content-hashed filenames under `assets/`, so those
+      // responses can be cached forever. Files elsewhere in public/ keep
+      // stable names and must stay revalidatable.
+      onFound: (_path, ctx) => {
+        if (ctx.req.path.startsWith(hashedAssetsPrefix)) {
+          ctx.header('Cache-Control', 'public, max-age=31536000, immutable')
+        }
+      },
     }),
   )
 
@@ -111,6 +120,13 @@ export function configureInertiaAssets(app: Application, options: InertiaAssetsO
       console.warn('Unable to resolve @guren/inertia-client for production serving.', error)
     }
   }
+}
+
+/** The route base ahead of the wildcard, as {@link createStaticRewrite} sees it. */
+function publicRouteBase(route: string): string {
+  const wildcardIndex = route.indexOf('*')
+  const base = wildcardIndex >= 0 ? route.slice(0, wildcardIndex) : route
+  return trimTrailingSlashes(base)
 }
 
 /**

--- a/packages/server/tests/http/public-cache-headers.test.ts
+++ b/packages/server/tests/http/public-cache-headers.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { Application } from '../../src'
+import { configureInertiaAssets } from '../../src/http/inertia-assets'
+import { registerDevAssets } from '../../src/runtime'
+import { useAssetFixture } from './asset-fixture'
+
+const IMMUTABLE_CACHE_CONTROL = 'public, max-age=31536000, immutable'
+
+/**
+ * Cache-Control on the `/public/*` static route.
+ *
+ * Vite writes content-hashed filenames under `public/assets/`, so in
+ * production those responses are safe to cache forever. Everything else in
+ * public/ keeps stable names, and the dev server must never cache at all —
+ * both of those are pinned here so the immutable header cannot creep onto
+ * them.
+ */
+describe('public asset cache headers', () => {
+  const fixture = useAssetFixture('guren-public-cache-')
+  const originalEnv = { ...process.env }
+
+  beforeEach(async () => {
+    process.env = { ...originalEnv }
+
+    await fixture.write('public/assets/app-4f2b1c8d.js', 'console.log("hashed")\n')
+    await fixture.write('public/assets/app-4f2b1c8d.css', 'body {}\n')
+    await fixture.write('public/robots.txt', 'User-agent: *\n')
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  function createProductionApp(publicRoute?: string): Application {
+    process.env.NODE_ENV = 'production'
+
+    const app = new Application()
+    configureInertiaAssets(app, {
+      publicDir: fixture.path('public'),
+      publicRoute,
+      inertiaClient: false,
+    })
+
+    return app
+  }
+
+  it('serves hashed build assets with an immutable Cache-Control in production', async () => {
+    const app = createProductionApp()
+
+    const response = await app.fetch(new Request('http://example.com/public/assets/app-4f2b1c8d.js'))
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('hashed')
+    expect(response.headers.get('Cache-Control')).toBe(IMMUTABLE_CACHE_CONTROL)
+  })
+
+  it('covers stylesheets under the hashed assets directory', async () => {
+    const app = createProductionApp()
+
+    const response = await app.fetch(new Request('http://example.com/public/assets/app-4f2b1c8d.css'))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Cache-Control')).toBe(IMMUTABLE_CACHE_CONTROL)
+  })
+
+  it('leaves files outside assets/ without a Cache-Control header in production', async () => {
+    const app = createProductionApp()
+
+    const response = await app.fetch(new Request('http://example.com/public/robots.txt'))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Cache-Control')).toBeNull()
+  })
+
+  it('derives the hashed assets prefix from a custom public route', async () => {
+    const app = createProductionApp('/static/*')
+
+    const hashed = await app.fetch(new Request('http://example.com/static/assets/app-4f2b1c8d.js'))
+    const stable = await app.fetch(new Request('http://example.com/static/robots.txt'))
+
+    expect(hashed.status).toBe(200)
+    expect(hashed.headers.get('Cache-Control')).toBe(IMMUTABLE_CACHE_CONTROL)
+    expect(stable.status).toBe(200)
+    expect(stable.headers.get('Cache-Control')).toBeNull()
+  })
+
+  it('never caches public assets on the dev route', async () => {
+    await fixture.mkdir('resources')
+
+    const app = new Application()
+    registerDevAssets(app, {
+      resourcesDir: fixture.path('resources'),
+      publicDir: fixture.path('public'),
+      inertiaClient: false,
+    })
+
+    const response = await app.fetch(new Request('http://example.com/public/assets/app-4f2b1c8d.js'))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Cache-Control')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

The production `/public/*` static route (Hono `serveStatic`) sent Vite's content-hashed build assets with no caching header at all, so browsers re-downloaded every JS/CSS chunk on each visit. Meanwhile the root-level public assets and the built `/vendor/*` Inertia client already ship long-lived `Cache-Control` headers.

This PR attaches `Cache-Control: public, max-age=31536000, immutable` to the hashed assets via `serveStatic`'s `onFound` hook, scoped by path:

- `<publicRoute base>/assets/*` (Vite's output, content hash in the filename) → immutable, cache forever
- everything else under `public/` (user files with stable names) → unchanged, no caching header
- the prefix follows a custom `publicRoute` (e.g. `/static/*` → `/static/assets/*`)

The dev-mode route (`dev-assets.ts`) is deliberately untouched: HMR needs fresh assets, and a test now pins that no `Cache-Control` appears there.

## Changes

- `packages/server/src/http/inertia-assets.ts`: add `onFound` to the production `serveStatic` mount + a small `publicRouteBase()` helper mirroring `createStaticRewrite`'s base derivation
- `packages/server/tests/http/public-cache-headers.test.ts`: new tests for the hashed/immutable case (JS + CSS), the stable-file case, a custom `publicRoute`, and the dev route staying uncached
- changeset: `@guren/server` minor (behavior addition)

## Verification

- `bun run build` ✅
- `bun run test:bun server` — 2205 pass / 0 fail ✅
- `bun run typecheck` ✅
- `bun run test:examples` — 114 pass ✅