### PR TITLE
test(server): pin MemoryCheck critical threshold in health tests

### DIFF
--- a/packages/server/tests/health/health.test.ts
+++ b/packages/server/tests/health/health.test.ts
@@ -590,8 +590,11 @@ describe('StorageCheck', () => {
 // ============================================================
 
 describe('MemoryCheck', () => {
+  // Both thresholds pinned: the defaults (512/1024) compare against this test
+  // process's own heap, which crosses 1 GB mid-suite under `--isolate` on a
+  // single process — the unhealthy branch would fire and flip the verdict.
   it('should return healthy when memory is below threshold', async () => {
-    const check = new MemoryCheck({ thresholdMb: 10000 })
+    const check = new MemoryCheck({ thresholdMb: 10000, criticalThresholdMb: 20000 })
     const result = await check.check()
 
     expect(result.status).toBe('healthy')
@@ -601,7 +604,7 @@ describe('MemoryCheck', () => {
   })
 
   it('should return degraded when memory exceeds threshold', async () => {
-    const check = new MemoryCheck({ thresholdMb: 0 })
+    const check = new MemoryCheck({ thresholdMb: 0, criticalThresholdMb: 20000 })
     const result = await check.check()
 
     expect(result.status).toBe('degraded')


### PR DESCRIPTION
## Summary

The MemoryCheck health tests for the `healthy` and `degraded` verdicts pin `thresholdMb` but leave `criticalThresholdMb` at its default (1024 MB). `MemoryCheck.check()` compares those thresholds against the **test process's own** `process.memoryUsage().heapUsed`, so the moment the suite's heap crosses 1 GB, both tests receive `"unhealthy"` and fail — a latent flake that depends on ambient heap, not on the code under test.

This fires in practice: on Bun 1.4.0, a single-process `bun test --isolate` run of the full suite crosses 1 GB of heap before this file executes, and the two tests failed in 2 of 5 back-to-back runs (they pass under `--parallel`, where each worker's heap stays small, and on Bun 1.3.14 — which is why CI has not seen it yet).

## Change

Pin `criticalThresholdMb` in both tests so the expected verdict is unreachable-by-accident:

- `healthy` expectation: `{ thresholdMb: 10000, criticalThresholdMb: 20000 }`
- `degraded` expectation: `{ thresholdMb: 0, criticalThresholdMb: 20000 }`

The `unhealthy` expectation test already pins both (`{ thresholdMb: 0, criticalThresholdMb: 0 }`) and is unchanged.

## Testing

- `bun test packages/server/tests/health/health.test.ts` — 53 pass, 0 fail