### PR TITLE
chore: note bun test --changed under-selection in the test harness

### DIFF
--- a/scripts/test-packages.ts
+++ b/scripts/test-packages.ts
@@ -15,6 +15,13 @@
 //
 // Positional arguments select packages by directory name or package name.
 // Everything after a bare `--` is forwarded to `bun test` verbatim.
+//
+// One forwarded flag to distrust: `--changed` selects test files by git diff,
+// but packages/cli's tests load @guren/server through the workspace symlink's
+// dist/ (see .claude/rules/common-pitfalls.md, "Stale Build Artifacts"), a
+// dependency git cannot see — so a change under packages/server/src selects
+// the server tests and silently skips the cli tests that would exercise it.
+// For server-touching changes, run the full sweep or name the packages.
 
 import { closeSync, mkdtempSync, openSync, readSync, rmSync, writeSync } from 'node:fs'
 import { tmpdir } from 'node:os'


### PR DESCRIPTION
## Summary

Documents a known limitation of forwarding `--changed` through `scripts/test-packages.ts`: `bun test --changed` selects test files by git diff, but `packages/cli`'s tests load `@guren/server` through the workspace symlink's `dist/` — a dependency edge git cannot see. A change under `packages/server/src` therefore selects the server tests and silently skips the cli tests that would exercise it (under-selection, not over-selection — the dangerous direction).

Comment-only change in the harness header, next to the flag-forwarding usage notes.

## Testing

- `bun scripts/test-packages.ts --list` still resolves the package set