### PR TITLE
test(server): pin criticalThresholdMb in MemoryCheck threshold tests

### DIFF
--- a/packages/server/tests/health/health.test.ts
+++ b/packages/server/tests/health/health.test.ts
@@ -591,7 +591,10 @@ describe('StorageCheck', () => {
 
 describe('MemoryCheck', () => {
   it('should return healthy when memory is below threshold', async () => {
-    const check = new MemoryCheck({ thresholdMb: 10000 })
+    // Pin criticalThresholdMb too: its 1024MB default sits below thresholdMb
+    // here, and a test process whose heapUsed crosses 1GB would report
+    // "unhealthy" regardless of thresholdMb.
+    const check = new MemoryCheck({ thresholdMb: 10000, criticalThresholdMb: 20000 })
     const result = await check.check()
 
     expect(result.status).toBe('healthy')
@@ -601,7 +604,9 @@ describe('MemoryCheck', () => {
   })
 
   it('should return degraded when memory exceeds threshold', async () => {
-    const check = new MemoryCheck({ thresholdMb: 0 })
+    // criticalThresholdMb must stay above any real heapUsed, or crossing the
+    // 1024MB default turns this "degraded" into "unhealthy".
+    const check = new MemoryCheck({ thresholdMb: 0, criticalThresholdMb: 100000 })
     const result = await check.check()
 
     expect(result.status).toBe('degraded')


### PR DESCRIPTION
## Summary

Fixes a latent flake in `packages/server/tests/health/health.test.ts`: the MemoryCheck "healthy" and "degraded" tests set `thresholdMb` but leave `criticalThresholdMb` at its 1024MB default. `MemoryCheck.check()` evaluates the critical threshold first, so any test process whose `heapUsed` crosses 1GB turns both results into `"unhealthy"` and fails the assertions — regardless of the `thresholdMb` the tests pinned.

This just hit both the `build-and-test (1.4.0)` and `sqlite-smoke` lanes on the docs-only PR #504 (`Expected: "healthy" / Received: "unhealthy"`), and had previously fired 2/5 serial full-suite runs on Bun 1.4.0 during local soak testing.

## Fix

Pin `criticalThresholdMb` explicitly in both tests (20000 / 100000) so the tests assert the threshold logic they name, independent of the suite's heap usage. The existing "unhealthy when memory exceeds critical threshold" test already covers the critical branch.

## Verification

`bun test packages/server/tests/health/health.test.ts` — 53 pass.