### PR TITLE
docs: accept RFC 0013 and mark RFC 0010 superseded

### DIFF
--- a/rfcs/0010-model-attachments.md
+++ b/rfcs/0010-model-attachments.md
@@ -2,13 +2,13 @@
 
 **Author:** 7nohe
 **Date:** 2026-08-15
-**Status:** Draft
+**Status:** Superseded by RFC 0013
 
-> **Note (2026-08-21):** Proposed to be superseded by RFC 0013
-> (`0013-attachments-and-image-variants.md`), a deliberately smaller
-> design built on Bun 1.4's native `Bun.Image`. If RFC 0013 is accepted,
-> this document's status becomes `Superseded by RFC 0013` in the same
-> change; it stays in `rfcs/` as design research for the layers RFC 0013
+> **Note (2026-08-21):** Superseded by RFC 0013
+> (`0013-attachments-and-image-variants.md`, accepted 2026-08-21), a
+> deliberately smaller design built on Bun 1.4's native `Bun.Image` that
+> adopts this document's `Attachable` mixin as its model API. This
+> document stays in `rfcs/` as design research for the layers RFC 0013
 > defers (signed proxy delivery, direct upload, blob deduplication), each
 > of which needs a fresh RFC revalidating its assumptions against the
 > one-table schema before implementation.

--- a/rfcs/0013-attachments-and-image-variants.md
+++ b/rfcs/0013-attachments-and-image-variants.md
@@ -2,7 +2,8 @@
 
 **Author:** 7nohe
 **Date:** 2026-08-21
-**Status:** Draft
+**Status:** Accepted (2026-08-21; maintainer decision, standard two-week
+discussion window deliberately compressed — solo-maintainer project)
 
 ## Problem
 


### PR DESCRIPTION
## Summary

Records the acceptance decision for RFC 0013 (attachments and image variants), per `contributing/rfc-process.md` step 3:

- `rfcs/0013-attachments-and-image-variants.md`: `Draft` → `Accepted` (2026-08-21). The standard two-week discussion window is deliberately compressed — maintainer decision on a solo-maintainer project, noted in the status line itself.
- `rfcs/0010-model-attachments.md`: `Draft` → `Superseded by RFC 0013`, in the same change as promised by both documents. It stays in `rfcs/` as design research for the deferred layers (signed delivery, direct upload, blob dedup).

Implementation can now start with Part 1 (`Refs: RFC 0013`).