### PR TITLE
fix(cli): report a routes or config file that could not be read

### DIFF
--- a/.changeset/lucky-moons-argue.md
+++ b/.changeset/lucky-moons-argue.md
@@ -1,0 +1,73 @@
+---
+"@guren/cli": minor
+---
+
+Report a routes or health file that could not be read, instead of an empty result
+
+`guren context` rendered `## Routes (0)` / `No routes loaded.` and exited 0
+whether the app had no routes or its routes file had thrown on import —
+`loadContextRoutes` caught every failure and returned `[]` with no message.
+The reason is now carried on `ProjectContext.routesError`, printed under the
+Routes heading, and included in `--json`. A routes file that is simply absent
+is still not an error: an api-only or mid-scaffold app legitimately has none.
+`guren context <Entity>` now makes the same distinction, which it did not
+after #482 — it reported a missing routes file as one that could not be read.
+
+Every loader that degrades a missing file to an empty result now shares one
+rule for what "missing" means, `isDefinitelyAbsent()`. `fileExists` rethrows
+anything that is not `ENOENT`, so a `routes` that is a regular file crashed
+`guren context`, `guren context <Entity>` and `spec:generate`/`check --spec`
+outright; `existsSync` does the opposite and answers "no", so a dangling
+`app/health.ts` or `guren.arch.ts` symlink was silently ignored and the
+command reported a clean result from a configuration it never read. Only
+`ENOENT` now means absent; everything else reaches the loader, whose error is
+what gets reported. Adopted by the three routes callers and by health,
+`guren.arch.ts`, and `config/audit.ts` discovery. Absence stays silent only on
+the *default* path: a `--routes` or `--health` the caller named is a typo or a
+wrong app root when it is not there, and is reported like any other unreadable
+file.
+
+`fileExists` keeps the old semantics at its remaining call sites, and two of
+them are worth naming rather than leaving to be rediscovered. Inside
+`guren check`, `route-path-check.ts` skips its scan on a file it reads as
+absent, while `console-check.ts` and `routes-check.ts` already report — but
+report the wrong reason, telling you to create a file you can `ls`; all three
+also still crash outright on a non-ENOENT probe. And `app-surface.ts` reads a
+dangling `routes/web.ts` as the negative evidence that an app cannot render a
+page, which is the expensive direction for a rule its own doc says must run on
+positive evidence only. They are left for one change together, since the
+question of whether a skipped scan belongs in the report is worth settling
+first.
+
+`guren health:check` had the same shape with worse output: a health file that
+existed and failed to import was logged at debug level (invisible by default)
+and reported as "No health manager found", followed by instructions to create
+the file the user already has — while `--json` answered `"status": "healthy"`
+off the built-in memory and uptime checks. It now names the file and the
+reason, carries a failing `health-config` check into the report, and exits 1.
+An explicit `--health <path>` that does not exist, or that imports cleanly and
+exports no recognizable manager, is reported the same way: the user named that
+file, so anything stopping it from yielding a manager is a failure rather than
+a search miss. The default candidate list stays a search, and is now deduped
+by canonical path so a case-insensitive filesystem cannot report one file
+twice — including when that file is a dangling symlink, where `realpath`
+cannot answer and the link's own inode identifies it instead. A file exporting
+both a placeholder `health` and a real `healthManager` now finds the real one:
+the export was picked by truthiness and only then tested for shape, so its
+checks never ran. A load failure is reported even when a *later* candidate
+does yield a manager, so a broken `app/health.ts` beside a working leftover no
+longer answers `"status": "healthy"`. And `--health` with an empty value is
+treated as no flag at all: the mode switch and the path list read it
+differently, so `--health=` applied named-file strictness to the default
+search and failed an app that passes without the flag. `--json` no longer
+prints its console prose to stdout either — that prose was landing in front of
+the document, so the output only parsed when something else had already
+silenced consola. And a report from the app's own manager is normalized before
+it is rendered or added to: nothing type-checks what crosses the `import()`
+boundary, and one without a `checks` array used to kill the command outright.
+
+Test fixtures are written into temp directories with no `node_modules`, where
+Bun's last resort for a bare specifier is to install it — from the global
+cache, and from npm on a miss. Auto-install is now disabled in each fixture,
+so one that needs `@guren/*` links the workspace copy explicitly rather than
+silently binding the published one.

--- a/packages/cli/src/arch-config.ts
+++ b/packages/cli/src/arch-config.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { fileExists } from './discovery'
+import { findFirstLoadable } from './discovery'
 import type { ArchRuleSet } from './arch/index'
 
 export interface LoadedArchConfig {
@@ -48,11 +48,6 @@ export async function loadArchConfig(cwd: string): Promise<LoadedArchConfig> {
 }
 
 async function resolveConfigFile(cwd: string): Promise<string | undefined> {
-  for (const candidate of CANDIDATE_FILES) {
-    if (await fileExists(cwd, candidate)) {
-      return resolve(cwd, candidate)
-    }
-  }
-
-  return undefined
+  const found = await findFirstLoadable(cwd, CANDIDATE_FILES)
+  return found === null ? undefined : resolve(cwd, found)
 }

--- a/packages/cli/src/audit-config.ts
+++ b/packages/cli/src/audit-config.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { fileExists } from './discovery'
+import { findFirstLoadable } from './discovery'
 
 export interface AuditIgnoreEntry {
   /** Must match `AuditFinding.key` exactly (no globs). */
@@ -97,11 +97,6 @@ async function resolveConfigFile(cwd: string, configFile?: string): Promise<stri
     return resolve(cwd, configFile)
   }
 
-  for (const candidate of CANDIDATE_FILES) {
-    if (await fileExists(cwd, candidate)) {
-      return resolve(cwd, candidate)
-    }
-  }
-
-  return undefined
+  const found = await findFirstLoadable(cwd, CANDIDATE_FILES)
+  return found === null ? undefined : resolve(cwd, found)
 }

--- a/packages/cli/src/context-route.ts
+++ b/packages/cli/src/context-route.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path'
 import type { RouteDefinition } from '@guren/core'
-import { loadRouteDefinitions, DEFAULT_ROUTES_FILE } from './load-routes'
+import { loadRouteDefinitions, resolveRoutesFile } from './load-routes'
 import { schemaToTypeString } from './schema-type-extractor'
 
 /**
@@ -74,15 +74,30 @@ export function escapeMarkdownTableCell(value: string): string {
  * Every route as a `ContextRoute`, or `[]` when the routes file can't be
  * loaded (missing deps, mid-scaffold app, etc.) — context commands degrade
  * to a route-less view instead of failing.
+ *
+ * `loadErrors`, when passed, receives the reason the load failed. Pass it
+ * unless the caller has nothing to render it into: an app whose routes file
+ * throws produces the same empty list as an app with no routes at all, so a
+ * caller that drops the reason publishes a confident-looking "no routes"
+ * that nobody can tell apart from a real one — the defect this degradation
+ * had for as long as it swallowed the error outright.
+ *
+ * When there is nothing to load and that is a legitimate shape rather than a
+ * failure, the empty list carries no reason — see `resolveRoutesFile()`.
  */
-export async function loadContextRoutes(cwd: string, routesFile?: string): Promise<ContextRoute[]> {
+export async function loadContextRoutes(
+  cwd: string,
+  routesFile?: string,
+  loadErrors?: string[],
+): Promise<ContextRoute[]> {
+  const target = await resolveRoutesFile(cwd, routesFile)
+  if (target.silentlyAbsent) return []
+
   try {
-    const definitions = await loadRouteDefinitions(
-      resolve(cwd, routesFile ?? DEFAULT_ROUTES_FILE),
-      cwd,
-    )
+    const definitions = await loadRouteDefinitions(resolve(cwd, target.path), cwd)
     return definitions.map(routeDefinitionToContextRoute)
-  } catch {
+  } catch (error) {
+    loadErrors?.push(error instanceof Error ? error.message : String(error))
     return []
   }
 }

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -26,6 +26,8 @@ export interface ProjectContext {
   framework: { name: string; version: string }
   models: ModelInfo[]
   routes: ContextRoute[]
+  /** Why `routes` is empty, when it is empty because the load failed. */
+  routesError?: string
   pages: string[]
   controllers: string[]
   resources: string[]
@@ -73,6 +75,8 @@ export async function generateContext(options: ContextOptions = {}): Promise<Pro
 
   // Every source below is independent — one barrier instead of a dozen
   // serialized directory walks (plus the route-graph import).
+  const routeLoadErrors: string[] = []
+
   const [
     models,
     routes,
@@ -88,7 +92,7 @@ export async function generateContext(options: ContextOptions = {}): Promise<Pro
     commands,
   ] = await Promise.all([
     collectModels(),
-    loadContextRoutes(cwd, options.routesFile),
+    loadContextRoutes(cwd, options.routesFile, routeLoadErrors),
     listInertiaPageIds(cwd),
     toNames(discoverControllerFiles),
     toNames(discoverResourceFiles),
@@ -109,6 +113,7 @@ export async function generateContext(options: ContextOptions = {}): Promise<Pro
     framework: { name: 'Guren', version },
     models,
     routes,
+    routesError: routeLoadErrors[0],
     pages,
     controllers,
     resources,
@@ -167,6 +172,13 @@ export function renderContextMarkdown(ctx: ProjectContext): string {
       const cells = [route.method, route.path, route.name ?? '', controller]
       lines.push(`| ${cells.map(escapeMarkdownTableCell).join(' | ')} |`)
     }
+  } else if (ctx.routesError) {
+    // An unreadable routes file is not an app with no routes. Both used to
+    // render `## Routes (0)` / `No routes loaded.` and exit 0, so the reader
+    // of a context map — an agent, most often — had no way to tell a real
+    // answer from a failed one.
+    lines.push(`Routes could not be read: ${ctx.routesError}`)
+    lines.push('This is not the same as the app having no routes — the list above is incomplete.')
   } else {
     lines.push('No routes loaded.')
   }

--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -1,4 +1,4 @@
-import { readdir, access, readFile, stat } from 'node:fs/promises'
+import { readdir, access, lstat, readFile, stat } from 'node:fs/promises'
 import { resolve, join, extname, relative, sep, posix } from 'node:path'
 import { collectionName } from './inflect'
 import { escapeRegExp } from './utils'
@@ -84,6 +84,35 @@ export function moduleNameFor(cwd: string, filePath: string): string | null {
   return moduleNameFromRelPath(toPosixRelative(cwd, filePath))
 }
 
+/**
+ * Whether the path is *definitely* not there.
+ *
+ * The question {@link fileExists} answers is "can I read this", and it is the
+ * right one for a scaffolder deciding whether to write. It is the wrong one
+ * for a loader that degrades a missing file to an empty result: `access()`
+ * reports a dangling symlink as `ENOENT`, and `existsSync` reports `EACCES`
+ * and `ENOTDIR` as "no" — so a real, broken configuration reads as "you have
+ * none", which is the confident wrong answer these loaders exist to avoid.
+ * Non-ENOENT outcomes therefore answer `false` here: the caller attempts the
+ * load, and the loader's own error is what gets reported.
+ *
+ * `lstat`, not `access`: a dangling symlink is something the user put there,
+ * so it belongs in the loader's hands too.
+ */
+export async function isDefinitelyAbsent(cwd: string, relativePath: string): Promise<boolean> {
+  try {
+    await lstat(resolve(cwd, relativePath))
+    return false
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ENOENT'
+  }
+}
+
+/**
+ * Whether the path can be read: follows symlinks, throws on anything but
+ * ENOENT. A loader that must not crash on a broken filesystem wants
+ * {@link isDefinitelyAbsent} instead.
+ */
 export async function fileExists(cwd: string, relativePath: string): Promise<boolean> {
   try {
     await access(resolve(cwd, relativePath))
@@ -108,6 +137,20 @@ export async function fileExists(cwd: string, relativePath: string): Promise<boo
 export async function findFirstExisting(cwd: string, candidates: readonly string[]): Promise<string | null> {
   const results = await Promise.all(candidates.map((candidate) => fileExists(cwd, candidate)))
   const index = results.indexOf(true)
+  return index === -1 ? null : candidates[index]
+}
+
+/**
+ * {@link findFirstExisting} for a *loader*: the first candidate that is not
+ * {@link isDefinitelyAbsent}, so a broken-but-present config reaches the
+ * import and is diagnosed rather than skipped.
+ *
+ * Preference order lives here for the same reason it does there: it decides
+ * which file the whole command then reads.
+ */
+export async function findFirstLoadable(cwd: string, candidates: readonly string[]): Promise<string | null> {
+  const results = await Promise.all(candidates.map((candidate) => isDefinitelyAbsent(cwd, candidate)))
+  const index = results.indexOf(false)
   return index === -1 ? null : candidates[index]
 }
 

--- a/packages/cli/src/entity-context.ts
+++ b/packages/cli/src/entity-context.ts
@@ -21,7 +21,7 @@ import {
   type DiscoveredModel,
   type ModelRelationship,
 } from './model-parser'
-import { loadRouteDefinitions, DEFAULT_ROUTES_FILE } from './load-routes'
+import { loadRouteDefinitions, resolveRoutesFile } from './load-routes'
 import { parseSourceFile } from './parse-cache'
 import {
   routeDefinitionToContextRoute,
@@ -232,10 +232,13 @@ export async function generateEntityContext(
 
   let routesError: string | undefined
   const loadEntityRoutes = async (): Promise<ContextRoute[]> => {
+    const target = await resolveRoutesFile(cwd, options.routesFile)
+    if (target.silentlyAbsent) return []
+
     try {
       const provenance: Array<string | null> = []
       const definitions = await loadRouteDefinitions(
-        resolve(cwd, options.routesFile ?? DEFAULT_ROUTES_FILE),
+        resolve(cwd, target.path),
         cwd,
         undefined,
         provenance,

--- a/packages/cli/src/health-check.ts
+++ b/packages/cli/src/health-check.ts
@@ -1,7 +1,8 @@
 import { consola } from 'consola'
 import { resolve } from 'node:path'
-import { existsSync } from 'node:fs'
+import { lstat, stat } from 'node:fs/promises'
 import { pathToFileURL } from 'node:url'
+import { isDefinitelyAbsent } from './discovery'
 
 export interface HealthCheckOptions {
   /**
@@ -48,14 +49,88 @@ interface HealthManager {
 }
 
 /**
+ * The load failures, as report entries.
+ *
+ * Carried as checks rather than only logged, so they reach `--json` — the
+ * shape CI and agents read. Without them the payload is indistinguishable
+ * from an app whose health checks all passed.
+ */
+function configChecks(loadErrors: string[]): CheckResult[] {
+  return loadErrors.map((message) => ({
+    name: 'health-config',
+    status: 'unhealthy' as const,
+    message: `Could not load health checks — ${message}`,
+  }))
+}
+
+/**
+ * A key that is equal for two paths naming the same file, and different
+ * otherwise.
+ *
+ * `stat` first, so a symlink and its target dedupe to one candidate. It
+ * throws for a *dangling* symlink, and falling back to the literal path there
+ * defeated the dedupe in exactly the case the loader was taught to notice:
+ * `app/health.ts` and `app/Health.ts` pointing nowhere are one file on a
+ * case-insensitive filesystem, and were reported twice. The link itself is a
+ * real inode, so `lstat` answers for it — and keeps two genuinely different
+ * broken links apart, which a path-shaped fallback could not.
+ *
+ * `bigint` because a Windows file ID is 64 bits and would not survive a
+ * `number` — two distinct files could compare equal and one of their failures
+ * go unreported. Same reason `isSameFile()` in `agent-harness.ts` uses it.
+ *
+ * `undefined` means neither probe could answer; the caller keeps the
+ * candidate rather than guessing, since a duplicate report is a smaller
+ * failure than a dropped one.
+ */
+async function fileIdentity(path: string): Promise<string | undefined> {
+  for (const probe of [stat, lstat]) {
+    try {
+      const stats = await probe(path, { bigint: true })
+      return `${stats.dev}:${stats.ino}`
+    } catch {
+      // the next probe answers, or nothing does
+    }
+  }
+  return undefined
+}
+
+/**
  * Try to load the health manager from common locations.
  */
-async function loadHealthManager(options: HealthCheckOptions = {}): Promise<HealthManager | null> {
+async function loadHealthManager(
+  options: HealthCheckOptions = {},
+  loadErrors: string[] = [],
+): Promise<HealthManager | null> {
   const appRoot = options.appRoot ? resolve(options.appRoot) : process.cwd()
 
-  // Common health setup file locations
-  const healthPaths = options.health
-    ? [resolve(appRoot, options.health)]
+  const fail = (path: string, reason: string): void => {
+    loadErrors.push(`${path}: ${reason}`)
+    consola.warn(`Failed to load health checks from ${path}: ${reason}`)
+  }
+
+  // A `--health <path>` is the user naming the file; anything that stops it
+  // from yielding a manager is a failure to report, including the file not
+  // being there and the file exporting nothing recognizable. Without one, the
+  // list below is a *search*, so a candidate that loads without exporting a
+  // manager is just a miss — some other `health.ts` — and stays silent.
+  //
+  // One value carries that distinction rather than a mode flag beside the
+  // list, because a flag and a list derived from the same option disagreed:
+  // `--health=` (citty's result for a valued flag given no value) turned on
+  // named-file strictness while the paths fell back to the default search,
+  // and exited 1 on an app that exits 0 without the flag. An empty value
+  // names no file.
+  //
+  // `resolveRoutesFile()` derives namedness the same way and for the same
+  // reason, but is not shared with this: there, absence when unnamed is a
+  // silent shape and the whole answer; here it is one candidate of five, and
+  // the named case additionally has to report a file that imports but exports
+  // nothing. The atom the two have in common is `Boolean(option)` — the
+  // consequences are what differ, and those do not factor.
+  const namedPath = options.health ? resolve(appRoot, options.health) : undefined
+  const healthPaths = namedPath
+    ? [namedPath]
     : [
         resolve(appRoot, 'app/health.ts'),
         resolve(appRoot, 'app/Health.ts'),
@@ -64,23 +139,64 @@ async function loadHealthManager(options: HealthCheckOptions = {}): Promise<Heal
         resolve(appRoot, 'config/health.ts'),
       ]
 
+  // Probing and importing in one pass, so the usual app — a manager at the
+  // first candidate — stops there instead of stat'ing all five first. Dedupe
+  // is incremental for the same reason: a candidate is only ever compared
+  // against ones already reached, which is what a two-phase pass computed
+  // anyway.
+  const seen = new Set<string>()
+
   for (const healthPath of healthPaths) {
-    if (existsSync(healthPath)) {
-      try {
-        const mod = await import(pathToFileURL(healthPath).href)
+    // `isDefinitelyAbsent`, not `existsSync`: the latter answers "no" for a
+    // dangling symlink, an untraversable parent, and an `app` that is a
+    // regular file — so a health file the user really put there would be
+    // skipped, and the command would report a clean bill of health for a
+    // configuration it never managed to look at.
+    if (await isDefinitelyAbsent(appRoot, healthPath)) {
+      if (namedPath !== undefined) fail(namedPath, 'no such file')
+      continue
+    }
 
-        // Look for common export patterns
-        const health =
-          mod.health ||
-          mod.healthManager ||
-          mod.default
+    // Deduped by identity, not by name: on a case-insensitive filesystem
+    // `app/health.ts` and `app/Health.ts` are one file, and the loop would
+    // otherwise import it twice and report the same failure twice. Deduping
+    // on the *error text* instead would collapse two genuinely different
+    // files whose failures happen to read alike (a `throw new Error('boom')`
+    // in each carries no path), under-reporting a real second problem.
+    const identity = await fileIdentity(healthPath)
+    if (identity !== undefined) {
+      if (seen.has(identity)) continue
+      seen.add(identity)
+    }
 
-        if (health && typeof health.check === 'function') {
-          return health as HealthManager
-        }
-      } catch (error) {
-        consola.debug(`Failed to load health from ${healthPath}:`, error)
+    try {
+      const mod = await import(pathToFileURL(healthPath).href)
+
+      // Each candidate export is tested for the shape, not just for being
+      // truthy: a file that exports both a placeholder `health` and a real
+      // `healthManager` would otherwise be judged on the placeholder alone and
+      // reported as exporting no manager.
+      const health = [mod.health, mod.healthManager, mod.default].find(
+        (candidate) => candidate && typeof candidate.check === 'function',
+      )
+
+      if (health) return health as HealthManager
+
+      if (namedPath !== undefined) {
+        fail(
+          healthPath,
+          'imported, but exports no health manager '
+          + '(expected `health`, `healthManager`, or a default export with a check() method)',
+        )
       }
+    } catch (error) {
+      // `consola.debug` is invisible at the default log level, so a health
+      // file that exists and throws on import used to arrive at the caller as
+      // `null` — rendered as "No health manager found", followed by
+      // instructions to create the file the user already has. Reported as a
+      // warning, and remembered so the caller can say which file failed
+      // instead of claiming there is none.
+      fail(healthPath, error instanceof Error ? error.message : String(error))
     }
   }
 
@@ -121,60 +237,132 @@ const RESET = '\x1b[0m'
  * Run health checks from CLI.
  */
 export async function runHealthCheck(options: HealthCheckOptions = {}): Promise<void> {
-  const health = await loadHealthManager(options)
+  const loadErrors: string[] = []
+  const health = await loadHealthManager(options, loadErrors)
 
-  if (!health) {
-    consola.info('No health manager found.')
-    consola.info('')
-    consola.info('To configure health checks, create a health file at:')
-    consola.info('  app/health.ts')
-    consola.info('')
-    consola.info('Example:')
-    consola.info('  import { createHealthManager, DatabaseCheck, MemoryCheck } from "@guren/core"')
-    consola.info('')
-    consola.info('  export const health = createHealthManager()')
-    consola.info('  health.register(new DatabaseCheck(db))')
-    consola.info('  health.register(new MemoryCheck())')
-
-    // Run basic built-in checks even without config
-    await runBasicChecks(options)
-    return
+  // A health file that exists and cannot be imported is not an app with no
+  // health checks. Both used to reach the built-in checks, which report
+  // `status: "healthy"` off memory/uptime/runtime alone — so `guren
+  // health:check --json` answered a question it had not been able to ask.
+  // Printed once, because `loadErrors` is complete the moment the loader
+  // returns; `consola.error` goes to stderr, so it never reaches the JSON.
+  if (loadErrors.length > 0) {
+    consola.error('Health checks could not be read:')
+    for (const message of loadErrors) {
+      consola.error(`  ${message}`)
+    }
+  } else if (!health) {
+    sayer(options)([
+      'No health manager found.',
+      '',
+      'To configure health checks, create a health file at:',
+      '  app/health.ts',
+      '',
+      'Example:',
+      '  import { createHealthManager, DatabaseCheck, MemoryCheck } from "@guren/core"',
+      '',
+      '  export const health = createHealthManager()',
+      '  health.register(new DatabaseCheck(db))',
+      '  health.register(new MemoryCheck())',
+    ])
   }
 
-  // Get checks to run
-  let report: HealthReport
+  const report = withLoadErrors(
+    health ? await runManagerChecks(health, options) : await runBasicChecks(options),
+    loadErrors,
+  )
 
-  if (options.checks) {
-    const checkNames = options.checks.split(',').map((s) => s.trim())
-    report = await health.checkOnly(checkNames)
-  } else {
-    report = await health.check()
-  }
+  emit(report, options)
 
-  // Output
-  if (options.json) {
-    console.log(JSON.stringify({
-      status: report.status,
-      timestamp: report.timestamp.toISOString(),
-      checks: report.checks,
-    }, null, 2))
-  } else {
-    printReport(report)
-  }
-
-  // Exit with appropriate code
   if (report.status === 'unhealthy') {
     process.exit(1)
   }
 }
 
 /**
- * Run basic health checks without configuration.
+ * Info-level prose, dropped under `--json`.
+ *
+ * consola's info reporter writes to stdout, so under `--json` prose lands in
+ * front of the document and nothing downstream can parse it. One gate for
+ * every prose block in this command, so a later message cannot forget it —
+ * which is the bug this exists to fix. (It looked fine from the test suite
+ * only because `NODE_ENV=test` puts consola at warn level: the assertion was
+ * reading the environment.)
  */
-async function runBasicChecks(options: HealthCheckOptions): Promise<void> {
-  consola.info('')
-  consola.info('Running basic health checks...')
-  consola.info('')
+function sayer(options: HealthCheckOptions): (lines: string[]) => void {
+  return (lines) => {
+    if (options.json) return
+    for (const line of lines) consola.info(line)
+  }
+}
+
+/** The configured manager's report, normalized. */
+async function runManagerChecks(
+  health: HealthManager,
+  options: HealthCheckOptions,
+): Promise<HealthReport> {
+  const report = options.checks
+    ? await health.checkOnly(options.checks.split(',').map((name) => name.trim()))
+    : await health.check()
+
+  // The manager is app-authored and arrives through `import()`, so nothing
+  // type-checks the report it returns. A missing `checks` reached
+  // `printReport` as "undefined is not an object" and the splice below as a
+  // spread of undefined; a missing `timestamp` is the same crash one field
+  // over, at every `toISOString()`. Normalized where the value crosses the
+  // boundary, so no consumer downstream has to defend. `status` is left as
+  // given: coercing an unrecognized one would decide the exit code on the
+  // command's behalf.
+  return {
+    ...report,
+    checks: Array.isArray(report.checks) ? report.checks : [],
+    timestamp: report.timestamp instanceof Date ? report.timestamp : new Date(),
+  }
+}
+
+/**
+ * The report with any load failures folded in.
+ *
+ * One place, because the two paths into it used to disagree: the built-in
+ * checks derived `unhealthy` from a spliced entry while the manager path
+ * forced it, and only one of them reported at all — so a broken
+ * `app/health.ts` beside a working leftover answered `"status": "healthy"`,
+ * exit 0, with the failure's only trace a stderr warning a CI step reading
+ * stdout never sees.
+ */
+function withLoadErrors(report: HealthReport, loadErrors: string[]): HealthReport {
+  if (loadErrors.length === 0) return report
+
+  return {
+    ...report,
+    status: 'unhealthy',
+    checks: [...configChecks(loadErrors), ...report.checks],
+  }
+}
+
+/** The one place a report reaches the user. */
+function emit(report: HealthReport, options: HealthCheckOptions): void {
+  if (options.json) {
+    console.log(JSON.stringify({
+      status: report.status,
+      timestamp: report.timestamp.toISOString(),
+      checks: report.checks,
+    }, null, 2))
+    return
+  }
+
+  printReport(report)
+}
+
+/**
+ * The built-in checks, for an app that configured none of its own.
+ *
+ * Returns rather than emits: the caller folds load failures in and does the
+ * one emit, so the two ways into a report cannot disagree about how a failure
+ * is marked or which exit code follows.
+ */
+async function runBasicChecks(options: HealthCheckOptions): Promise<HealthReport> {
+  sayer(options)(['', 'Running basic health checks...', ''])
 
   const checks: CheckResult[] = []
 
@@ -213,21 +401,7 @@ async function runBasicChecks(options: HealthCheckOptions): Promise<void> {
       ? 'degraded'
       : 'healthy'
 
-  const report: HealthReport = {
-    status: overallStatus,
-    timestamp: new Date(),
-    checks,
-  }
-
-  if (options.json) {
-    console.log(JSON.stringify({
-      status: report.status,
-      timestamp: report.timestamp.toISOString(),
-      checks: report.checks,
-    }, null, 2))
-  } else {
-    printReport(report)
-  }
+  return { status: overallStatus, timestamp: new Date(), checks }
 }
 
 /**

--- a/packages/cli/src/load-routes.ts
+++ b/packages/cli/src/load-routes.ts
@@ -2,8 +2,8 @@ import { resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { consola } from 'consola'
 import { Router, mountModuleRoutes, type GurenModule, type RouteDefinition } from '@guren/core'
-import { listModuleNames } from './discovery'
-import { REGISTRAR_EXPORT_NAMES, REGISTRAR_PATTERN } from './route-registrar'
+import { isDefinitelyAbsent, listModuleNames } from './discovery'
+import { DEFAULT_ROUTES_FILE, REGISTRAR_EXPORT_NAMES, REGISTRAR_PATTERN } from './route-registrar'
 
 type RouteRegistrar = (router: Router) => void | Promise<void>
 
@@ -11,6 +11,48 @@ type RouteRegistrar = (router: Router) => void | Promise<void>
 // importing it from here; the constant lives beside the registrar name
 // contract, which the scaffolders need without pulling in `@guren/core`.
 export { DEFAULT_ROUTES_FILE } from './route-registrar'
+
+export interface RoutesFileTarget {
+  /** The path to load, as given or as defaulted. */
+  path: string
+  /**
+   * Nothing to load, and that is a legitimate shape rather than a failure —
+   * so the caller degrades to a route-less view in silence.
+   */
+  silentlyAbsent: boolean
+}
+
+/**
+ * Which routes file to load, and whether its absence is an answer or a
+ * failure.
+ *
+ * Two rules in one place because they only make sense together. An app with
+ * no routes file at all is legitimate — api-only, mid-scaffold — and reports
+ * nothing; `guren check` is where a missing entry file is diagnosed. But a
+ * caller that *named* the file is a different question: a path that is not
+ * there is a typo or a wrong app root, and reporting "no routes" for it is
+ * the confident wrong answer #482 exists to prevent.
+ *
+ * An empty value names nothing, so `--routes=` is the default path, not a
+ * file called "". Left to each call site, that distinction went wrong the
+ * same way twice: `--health=` applied named-file strictness to the default
+ * *search*, and `--routes=` resolved to the app root and reported
+ * `Cannot find module '<app root>'` — a diagnostic naming a directory the
+ * user never typed.
+ *
+ * Every caller that degrades a missing routes file asks through here, because
+ * `guren context`, `guren context <Entity>` and `spec:generate` must not
+ * disagree about the same app — and have: #482 fixed the entity bundle's
+ * half of this rule and left the other two spelling it themselves.
+ */
+export async function resolveRoutesFile(
+  cwd: string,
+  routesFile?: string,
+): Promise<RoutesFileTarget> {
+  const path = routesFile || DEFAULT_ROUTES_FILE
+
+  return { path, silentlyAbsent: !routesFile && (await isDefinitelyAbsent(cwd, path)) }
+}
 
 function resolveRegistrar(moduleExports: Record<string, unknown>): RouteRegistrar | undefined {
   for (const name of REGISTRAR_EXPORT_NAMES) {

--- a/packages/cli/src/spec-screens.ts
+++ b/packages/cli/src/spec-screens.ts
@@ -1,13 +1,13 @@
 import { resolve } from 'node:path'
 import { readFile } from 'node:fs/promises'
 import type { ClassDeclaration } from '@babel/types'
-import { discoverControllerFiles, classNameFromPath, toPosixRelative, fileExists } from './discovery'
+import { discoverControllerFiles, classNameFromPath, toPosixRelative } from './discovery'
 import {
   routeDefinitionToContextRoute,
   escapeMarkdownTableCell,
   type ContextRoute,
 } from './context-route'
-import { loadRouteDefinitions, DEFAULT_ROUTES_FILE } from './load-routes'
+import { loadRouteDefinitions, resolveRoutesFile, type RoutesFileTarget } from './load-routes'
 import { extractClassDeclaration } from './model-parser'
 import { parseSourceFile } from './parse-cache'
 import {
@@ -140,12 +140,17 @@ interface RouteGraph {
  * throws is not: the resulting document would look identical to one for an
  * app that genuinely has no routes, so it is flagged degraded and must
  * never be written or byte-compared.
+ *
+ * A named `--routes` that is not there is degraded too, not silent: it would
+ * otherwise regenerate a routeless document and the drift gate would compare
+ * it, reporting drift that regenerating could only "fix" by deleting real
+ * content. `resolveRoutesFile()` owns that distinction.
  */
-async function loadRouteGraph(cwd: string, relRoutesFile: string): Promise<RouteGraph> {
-  if (!(await fileExists(cwd, relRoutesFile))) return { routes: [] }
+async function loadRouteGraph(cwd: string, target: RoutesFileTarget): Promise<RouteGraph> {
+  if (target.silentlyAbsent) return { routes: [] }
 
   try {
-    const definitions = await loadRouteDefinitions(resolve(cwd, relRoutesFile), cwd)
+    const definitions = await loadRouteDefinitions(resolve(cwd, target.path), cwd)
     return { routes: definitions.map(routeDefinitionToContextRoute) }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
@@ -171,12 +176,13 @@ function renderRoute(route: ContextRoute): string {
  * cell instead of being misfiled as unrouted.
  */
 export async function generateScreensSpec(cwd: string, routesFile?: string): Promise<SpecArtifact> {
+  const target = await resolveRoutesFile(cwd, routesFile)
   // Rendered into the document, so it has to be app-root-relative and POSIX —
   // an absolute path would differ per machine and break the drift gate.
-  const relRoutesFile = toPosixRelative(cwd, resolve(cwd, routesFile ?? DEFAULT_ROUTES_FILE))
+  const relRoutesFile = toPosixRelative(cwd, resolve(cwd, target.path))
 
   const [graph, pagesByController, pageIdsOnDisk] = await Promise.all([
-    loadRouteGraph(cwd, relRoutesFile),
+    loadRouteGraph(cwd, target),
     collectPagesByController(cwd),
     listInertiaPageIds(cwd),
   ])

--- a/packages/cli/tests/arch-check.test.ts
+++ b/packages/cli/tests/arch-check.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, symlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
 import { runArchCheck } from '../src/arch-check'
@@ -572,6 +572,27 @@ export default {
       })
       // OrderService.ts (the violating file) wasn't in the changed set, so it's never scanned.
       expect(results.some((r) => r.filePath === 'app/Domain/OrderService.ts')).toBe(false)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})
+
+describe('runArchCheck config discovery', () => {
+  it('reports a guren.arch.ts that exists only as a dangling symlink', async () => {
+    // Discovery used `fileExists`, which reads a dangling symlink as absent —
+    // so a rules file the user really put there was skipped and the gate
+    // returned no results, which reads exactly like "no violations". An
+    // architecture check that could not load its rules is not a passing one.
+    const workspace = await createTempWorkspace('guren-cli-arch-dangling-')
+
+    try {
+      await symlink(join(workspace.dir, 'nowhere.ts'), join(workspace.dir, 'guren.arch.ts'))
+
+      const results = await runArchCheck({ cwd: workspace.dir, cache: new ParseCache() })
+
+      expect(results).not.toEqual([])
+      expect(results.some((result) => /failed to load/i.test(result.message))).toBe(true)
     } finally {
       await workspace.cleanup()
     }

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, symlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
 import { authMiddlewareVerdict, describeMethod, runAudit, LINK_BUILDER_PATTERN, type AuditReport } from '../src/audit'
@@ -2288,6 +2288,27 @@ export default function registerRoutes(router: any) {
       const authz = report.findings.find(f => f.key === 'authz:DELETE /posts/:id')
       expect(authz).toBeDefined()
       expect(authz!.status).toBe('warn')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})
+
+describe('audit ignore config discovery', () => {
+  it('reports a config/audit.ts that exists only as a dangling symlink', async () => {
+    // Discovery used `fileExists`, which reads a dangling symlink as absent,
+    // so an ignore config the user really put there was skipped without a
+    // word — and the audit ran with none of the entries it was told about,
+    // reporting a result shaped by rules it never read.
+    const workspace = await createTempWorkspace('guren-cli-audit-config-dangling-')
+
+    try {
+      await mkdir(join(workspace.dir, 'config'), { recursive: true })
+      await symlink(join(workspace.dir, 'config/nowhere.ts'), join(workspace.dir, 'config/audit.ts'))
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      expect(report.findings.some((f) => f.key === 'audit-config:load')).toBe(true)
     } finally {
       await workspace.cleanup()
     }

--- a/packages/cli/tests/context-entity-arg.test.ts
+++ b/packages/cli/tests/context-entity-arg.test.ts
@@ -280,6 +280,47 @@ describe('context entity argument', () => {
     }
   })
 
+  it('reports a --routes path that is not there, rather than reporting no routes', async () => {
+    // The other side of the absent-file split. A named file that is not there
+    // is a typo or a wrong --app, not the shape an api-only app has, and #482
+    // exists precisely so that reads as an error rather than as an entity
+    // with no routes.
+    const workspace = await createTempWorkspace('guren-cli-entity-routes-typo-')
+    try {
+      await writeModelFixture(workspace.dir)
+
+      const { exitCode, stdout } = await runBin(
+        ['context', '--routes', 'routes/nope.ts', 'User'],
+        workspace.dir,
+      )
+
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('Routes could not be read:')
+      expect(stdout).not.toContain('No routes reference this entity.')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reports nothing when the app simply has no routes file', async () => {
+    // The other half of the split: "could not be read" has to stay rare
+    // enough to mean something. An api-only or mid-scaffold app has no routes
+    // file at all, and `guren context` (whole-project) says so plainly — the
+    // two commands must not disagree about the same app.
+    const workspace = await createTempWorkspace('guren-cli-entity-routes-absent-')
+    try {
+      await writeModelFixture(workspace.dir)
+
+      const { exitCode, stdout } = await runBin(['context', 'User'], workspace.dir)
+
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('No routes reference this entity.')
+      expect(stdout).not.toContain('Routes could not be read:')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('takes the last value of a repeated --routes, which exited 0 reporting no routes', async () => {
     const workspace = await createTempWorkspace('guren-cli-context-routes-repeated-')
     try {

--- a/packages/cli/tests/context.test.ts
+++ b/packages/cli/tests/context.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
 import { GUREN_API_DIGEST } from '../src/api-digest'
 import { generateContext, renderContextMarkdown } from '../src/context'
-import { createTempWorkspace } from './helpers'
+import { CORE_RESOLVING_ROUTES_FIXTURE, createTempWorkspace, linkWorkspaceCore } from './helpers'
 
 describe('generateContext', () => {
   it('discovers models from app/Models', async () => {
@@ -89,6 +89,117 @@ export class Post extends defineModel(posts) {}`,
       expect(ctx.jobs).toContain('SendEmail')
       expect(ctx.commands).toContain('SendDigestCommand')
       expect(ctx.commands).not.toContain('SharedConfig')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('says the routes file could not be read, rather than reporting none', async () => {
+    // The shape #482 fixed for `guren context <Entity>`, in the project-wide
+    // map: an unloadable routes file used to render exactly what an app with
+    // no routes renders — `## Routes (0)` / `No routes loaded.`, exit 0 — so
+    // a reader could not tell a real answer from a failed one.
+    const workspace = await createTempWorkspace('guren-cli-context-routes-broken-')
+
+    try {
+      await mkdir(join(workspace.dir, 'routes'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'routes/web.ts'),
+        "import { nothing } from 'package-that-is-not-installed'\nexport function registerWebRoutes(): void { nothing() }\n",
+        'utf8',
+      )
+      await writeFile(join(workspace.dir, 'package.json'), '{}', 'utf8')
+
+      const ctx = await generateContext({ cwd: workspace.dir })
+
+      expect(ctx.routes).toEqual([])
+      expect(ctx.routesError).toContain('package-that-is-not-installed')
+      // The renderer's three branches are mutually exclusive, so covering the
+      // `routesError` one here is enough — the other two are covered by the
+      // absent-file and named-typo cases below.
+      expect(renderContextMarkdown(ctx)).toContain('Routes could not be read:')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reports a routes path that cannot even be probed, rather than crashing', async () => {
+    // The absent-vs-unreadable split is a filesystem probe, and only ENOENT
+    // answers "absent". A `routes` that is a regular file makes the probe
+    // throw ENOTDIR (an unreadable parent throws EACCES); a probe that let
+    // that escape would crash `guren context --json` with a stack trace
+    // instead of the diagnostic, and one that read it as "absent" would print
+    // the confident "No routes loaded." the split exists to prevent.
+    const workspace = await createTempWorkspace('guren-cli-context-routes-notdir-')
+
+    try {
+      await writeFile(join(workspace.dir, 'package.json'), '{}', 'utf8')
+      await writeFile(join(workspace.dir, 'routes'), 'not a directory', 'utf8')
+
+      const ctx = await generateContext({ cwd: workspace.dir })
+
+      expect(ctx.routes).toEqual([])
+      expect(ctx.routesError).toBeDefined()
+      expect(renderContextMarkdown(ctx)).toContain('Routes could not be read:')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reports a routesFile that was named but is not there', async () => {
+    // Absence is only a legitimate shape on the default path. A caller that
+    // named the file gets the same diagnostic as any other unreadable one.
+    const workspace = await createTempWorkspace('guren-cli-context-routes-typo-')
+
+    try {
+      await writeFile(join(workspace.dir, 'package.json'), '{}', 'utf8')
+
+      const ctx = await generateContext({ cwd: workspace.dir, routesFile: 'routes/nope.ts' })
+
+      expect(ctx.routes).toEqual([])
+      expect(ctx.routesError).toContain('nope.ts')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('keeps reporting no routes for an app that genuinely has none', async () => {
+    const workspace = await createTempWorkspace('guren-cli-context-routes-absent-')
+
+    try {
+      await writeFile(join(workspace.dir, 'package.json'), '{}', 'utf8')
+
+      const ctx = await generateContext({ cwd: workspace.dir })
+
+      expect(ctx.routes).toEqual([])
+      expect(ctx.routesError).toBeUndefined()
+      expect(renderContextMarkdown(ctx)).toContain('No routes loaded.')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('loads a routes file that imports @guren/core from this checkout', async () => {
+    // The positive control for the above: proving the error path works is
+    // worth nothing unless the success path is reached through the workspace.
+    // A fixture with no node_modules otherwise resolves `@guren/core` by
+    // Bun's auto-install fallback — the global cache, then npm — which is how
+    // a green test comes to be measuring the published package, or the
+    // registry, instead of this checkout.
+    const workspace = await createTempWorkspace('guren-cli-context-routes-linked-')
+
+    try {
+      await linkWorkspaceCore(workspace.dir)
+      await mkdir(join(workspace.dir, 'routes'), { recursive: true })
+      // The same fixture the resolution guard runs unlinked — the two are
+      // each other's control, so they have to be one fixture.
+      await writeFile(join(workspace.dir, 'routes/web.ts'), CORE_RESOLVING_ROUTES_FIXTURE, 'utf8')
+      await writeFile(join(workspace.dir, 'package.json'), '{}', 'utf8')
+
+      const ctx = await generateContext({ cwd: workspace.dir })
+
+      expect(ctx.routesError).toBeUndefined()
+      expect(ctx.routes.map((route) => route.name)).toEqual(['posts.index'])
     } finally {
       await workspace.cleanup()
     }

--- a/packages/cli/tests/fixture-resolution-guard.test.ts
+++ b/packages/cli/tests/fixture-resolution-guard.test.ts
@@ -1,0 +1,99 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'bun:test'
+import {
+  CLI_BIN_PATH,
+  CORE_RESOLVING_ROUTES_FIXTURE,
+  SERVER_DIST_ENTRY,
+  assertWorkspaceBuilt,
+  createTempWorkspace,
+} from './helpers'
+
+/**
+ * The guard that keeps this package's fixtures measuring the checkout instead
+ * of the machine, under test itself.
+ *
+ * `createTempWorkspace` writes a bunfig disabling Bun's auto-install fallback
+ * into every fixture; its own comment records why, and what the fallback was
+ * measured to resolve to. These are the two tests that go red when that stops
+ * happening. The shared fixture they run
+ * ({@link CORE_RESOLVING_ROUTES_FIXTURE}) is what makes them able to tell.
+ */
+describe('temp-directory fixtures cannot reach an ambient @guren/core', () => {
+  it('gives a spawned CLI no way to resolve an unlinked fixture', async () => {
+    assertWorkspaceBuilt([SERVER_DIST_ENTRY])
+    const workspace = await createTempWorkspace('guren-cli-resolution-guard-')
+
+    try {
+      await writeFile(join(workspace.dir, 'package.json'), '{}', 'utf8')
+      await mkdir(join(workspace.dir, 'routes'), { recursive: true })
+      await writeFile(join(workspace.dir, 'routes/web.ts'), CORE_RESOLVING_ROUTES_FIXTURE, 'utf8')
+
+      const proc = Bun.spawn(['bun', CLI_BIN_PATH, 'context'], {
+        cwd: workspace.dir,
+        stdout: 'pipe',
+        stderr: 'ignore',
+      })
+      const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+
+      expect(exitCode).toBe(0)
+      // The *reason* is the assertion, not the failure. Drop the bunfig
+      // `createTempWorkspace` writes and this fixture still fails to produce
+      // routes — but with "resolved a different @guren/core", because it
+      // bound the published package (verified by removing it). Only a
+      // resolution failure proves nothing ambient was reachable.
+      //
+      // Matched loosely because the wording is Bun's, not ours, and it has
+      // already moved once: 1.3.14 says `Cannot find module '@guren/core'
+      // from …`, 1.4.0 says `Cannot find package '@guren/core' imported from
+      // …`. Pinning the sentence made this fail on a runtime where the
+      // behaviour under test was correct.
+      expect(stdout).toMatch(/Cannot find (module|package) '@guren\/core'/u)
+      expect(stdout).not.toContain('resolved a different @guren/core')
+      expect(stdout).not.toContain('posts.index')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('carries the setting that disables auto-install, on any machine', async () => {
+    // The behavioural test above only separates "guard present" from "guard
+    // removed" where an ambient copy is actually reachable: on a runner with
+    // an empty Bun cache and no registry, the fixture fails to resolve either
+    // way and the assertion passes with the fix reverted. This one does not
+    // depend on the machine at all — it fails the moment the setting stops
+    // being written, which is the regression that would let the other test go
+    // quietly blind.
+    const workspace = await createTempWorkspace('guren-cli-resolution-guard-config-')
+
+    try {
+      const bunfig = await readFile(join(workspace.dir, 'bunfig.toml'), 'utf8')
+      expect(bunfig).toContain('[install]')
+      expect(bunfig).toMatch(/auto\s*=\s*"disable"/u)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('needs no equivalent in this process: an unlinked fixture is not importable', async () => {
+    // A canary, not a guard. `bun run` auto-installs and `bun test` does not
+    // (Bun 1.3.14, verified with no bunfig present anywhere), which is why
+    // only the processes these tests *spawn* need the fixture bunfig, and why
+    // no `[install]` setting is carried in the repo's own bunfig files. This
+    // asserts the conclusion — an in-process fixture cannot reach an ambient
+    // copy — rather than the mechanism, which it cannot distinguish from
+    // "tried and failed". A future Bun that auto-installs under the test
+    // runner would resolve here, and that is what this exists to catch.
+    const dir = await mkdtemp(join(tmpdir(), 'guren-cli-resolution-canary-'))
+
+    try {
+      await writeFile(join(dir, 'fixture.ts'), CORE_RESOLVING_ROUTES_FIXTURE, 'utf8')
+
+      const outcome = await import(join(dir, 'fixture.ts')).then(() => 'resolved', () => 'blocked')
+      expect(outcome).toBe('blocked')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/tests/health-check.test.ts
+++ b/packages/cli/tests/health-check.test.ts
@@ -1,7 +1,71 @@
 import { describe, expect, it, mock } from 'bun:test'
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, symlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { createTempWorkspace, createConsolaStub } from './helpers'
+import {
+  createTempWorkspace,
+  createConsolaStub,
+  runCliBinCaptured,
+  writeWorkspaceFiles,
+} from './helpers'
+
+interface HealthReportJson {
+  status: string
+  checks: Array<{ name: string; message?: string }>
+}
+
+interface HealthCliRun {
+  stderr: string
+  exitCode: number
+  /** Parsed stdout — the helper always passes `--json`. */
+  report: HealthReportJson
+}
+
+/**
+ * Run `health:check --json` and return its parsed report.
+ *
+ * A subprocess and not an in-process call because the paths under test end in
+ * `process.exit(1)`, and the exit code is half of what they assert.
+ * {@link runCliBinCaptured} owns the environment the child needs — without it
+ * `JSON.parse` would succeed here while a user's own `--json` run returned a
+ * document with three lines of English in front of it.
+ */
+async function runHealthCli(cwd: string, args: string[] = []): Promise<HealthCliRun> {
+  const { stdout, stderr, exitCode } = await runCliBinCaptured(
+    ['health:check', ...args, '--json'],
+    cwd,
+  )
+  return { stderr, exitCode, report: JSON.parse(stdout) as HealthReportJson }
+}
+
+/**
+ * A health file exporting `exportName`, for the loader to find or reject.
+ *
+ * One builder rather than a literal per test: the shape the loader recognizes
+ * (`check` / `checkOnly` / `getCheckNames`) is what several of these tests are
+ * about, and a copy that missed a new member would fail as "exports no health
+ * manager" — a message pointing at the loader rather than at the stale fixture.
+ */
+function managerSource(
+  exportName: string,
+  options: { checkName?: string; omitChecks?: boolean } = {},
+): string {
+  const { checkName = 'ok', omitChecks = false } = options
+  const reported = omitChecks ? '' : `, checks: [{ name: '${checkName}', status: 'healthy' }]`
+  const empty = omitChecks ? '' : ', checks: []'
+
+  return `export const ${exportName} = {
+  async check() {
+    return { status: 'healthy', timestamp: new Date()${reported} }
+  },
+  async checkOnly() {
+    return { status: 'healthy', timestamp: new Date()${empty} }
+  },
+  getCheckNames() {
+    return ['${checkName}']
+  },
+}
+`
+}
 
 const consolaStub = createConsolaStub({ debug: mock(() => {}) })
 
@@ -26,6 +90,197 @@ describe('runHealthCheck', () => {
       expect(logSpy).toHaveBeenCalled()
     } finally {
       console.log = originalLog
+      await workspace.cleanup()
+    }
+  })
+
+  it('says the health file could not be read, rather than reporting none', async () => {
+    // Spawned rather than called in-process: this path exits non-zero, which
+    // is half of what is under test. A health file that exists and throws on
+    // import used to arrive here as `null` — printed as "No health manager
+    // found" with instructions to create the file the user already has, and
+    // `--json` answered `"status": "healthy"` off the built-in memory/uptime
+    // checks alone. An unreadable config is not a clean bill of health.
+    const workspace = await createTempWorkspace('guren-cli-health-unreadable-')
+
+    try {
+      await mkdir(join(workspace.dir, 'app'), { recursive: true })
+      await mkdir(join(workspace.dir, 'src'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/health.ts'),
+        "import 'a-package-that-is-not-installed'\nexport const health = {}\n",
+        'utf8',
+      )
+      // Two candidate paths, one file. A case-insensitive filesystem produces
+      // this on its own (`app/health.ts` and `app/Health.ts` are both probed),
+      // but only a symlink reproduces it on ext4 — without one, the dedupe
+      // could be deleted and this assertion would still see a single finding
+      // everywhere CI runs.
+      await symlink(join(workspace.dir, 'app/health.ts'), join(workspace.dir, 'src/health.ts'))
+
+      const { stderr, exitCode, report } = await runHealthCli(workspace.dir)
+
+      expect(exitCode).toBe(1)
+      expect(stderr).toContain('Health checks could not be read')
+      expect(stderr).not.toContain('No health manager found')
+
+      expect(report.status).toBe('unhealthy')
+
+      // One finding, not one per candidate path — see `fileIdentity`.
+      const configChecks = report.checks.filter((check) => check.name === 'health-config')
+      expect(configChecks).toHaveLength(1)
+      // Which file, and why — the two things "No health manager found" never said.
+      expect(configChecks[0]?.message).toContain('app/health.ts')
+      expect(configChecks[0]?.message).toContain('a-package-that-is-not-installed')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reports an explicit --health file that exports no manager', async () => {
+    // `--health <path>` is the user naming the file, so anything that stops it
+    // from yielding a manager is a failure — including a file that imports
+    // cleanly and exports the wrong shape. It used to fall through to "No
+    // health manager found" and answer `"status": "healthy"` off the built-in
+    // memory and uptime checks, exit 0. The default candidate list is a
+    // *search*, so a miss there is still silent.
+    const workspace = await createTempWorkspace('guren-cli-health-wrong-shape-')
+
+    try {
+      await mkdir(join(workspace.dir, 'config'), { recursive: true })
+      await writeFile(join(workspace.dir, 'config/health.ts'), 'export const health = {}\n', 'utf8')
+
+      const { exitCode, report } = await runHealthCli(workspace.dir, ['--health', 'config/health.ts'])
+
+      expect(exitCode).toBe(1)
+      expect(report.status).toBe('unhealthy')
+      expect(report.checks.find((check) => check.name === 'health-config')?.message)
+        .toContain('exports no health manager')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reports a health file that exists only as a dangling symlink', async () => {
+    // `existsSync` answers "no" for a dangling symlink, an untraversable
+    // parent, and an `app` that is a regular file. Skipping the candidate on
+    // any of those left `loadErrors` empty and the command answered
+    // `"status": "healthy"` off the built-in checks — a clean bill of health
+    // for a configuration it never managed to look at.
+    const workspace = await createTempWorkspace('guren-cli-health-dangling-')
+
+    try {
+      await mkdir(join(workspace.dir, 'app'), { recursive: true })
+      await symlink(join(workspace.dir, 'app/nowhere.ts'), join(workspace.dir, 'app/health.ts'))
+
+      const { exitCode, report } = await runHealthCli(workspace.dir)
+
+      expect(exitCode).toBe(1)
+      expect(report.status).toBe('unhealthy')
+      // One finding, not one per candidate path: `realpath` cannot answer for
+      // a dangling link, so this is the case `fileIdentity`'s inode fallback
+      // exists for.
+      expect(report.checks.filter((check) => check.name === 'health-config')).toHaveLength(1)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('finds a manager that a placeholder export would have shadowed', async () => {
+    // The export was picked by truthiness and only then tested for shape, so a
+    // file carrying both a placeholder `health` and a real `healthManager` was
+    // judged on the placeholder — reported as exporting no manager, and its
+    // actual checks never ran.
+    const workspace = await createTempWorkspace('guren-cli-health-shadowed-')
+
+    try {
+      await writeWorkspaceFiles(workspace.dir, {
+        'app/health.ts': `export const health = {}\n${managerSource('healthManager', { checkName: 'real' })}`,
+      })
+
+      const { exitCode, report } = await runHealthCli(workspace.dir)
+
+      expect(exitCode).toBe(0)
+      // The configured check ran; the built-in fallbacks did not.
+      expect(report.checks.map((check) => check.name)).toEqual(['real'])
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('treats --health with an empty value as no flag at all', async () => {
+    // The mode switch and the path list read `options.health` differently —
+    // `!== undefined` versus truthiness — so citty's `''` for a valued flag
+    // given no value turned on named-file strictness while leaving the
+    // default *search* in place. A candidate that merely exports no manager
+    // then failed the command, on an app that passes without the flag.
+    const workspace = await createTempWorkspace('guren-cli-health-empty-flag-')
+
+    try {
+      await mkdir(join(workspace.dir, 'app'), { recursive: true })
+      await writeFile(join(workspace.dir, 'app/health.ts'), 'export const health = {}\n', 'utf8')
+
+      const run = async (args: string[]) => {
+        const { exitCode, report } = await runHealthCli(workspace.dir, args)
+        // Timestamps and uptime differ between two runs by construction, so
+        // the comparison is over what the flag could actually change.
+        return { exitCode, status: report.status, checks: report.checks.map((c) => c.name) }
+      }
+
+      // Asserted against the no-flag run rather than a literal: the point is
+      // that an empty value names no file, so it cannot change the answer.
+      // Concurrent because both are read-only against the same fixture.
+      const [withEmptyFlag, withoutFlag] = await Promise.all([run(['--health=']), run([])])
+      expect(withEmptyFlag).toEqual(withoutFlag)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('keeps an earlier load failure in the report when a later file works', async () => {
+    // Only the "no manager at all" branch used to report `loadErrors`, so a
+    // broken `app/health.ts` beside a working `src/health.ts` left over from
+    // an older layout answered `"status": "healthy"` and exit 0 — the file the
+    // operator configured never ran, and `--json` said nothing about it.
+    const workspace = await createTempWorkspace('guren-cli-health-partial-')
+
+    try {
+      await writeWorkspaceFiles(workspace.dir, {
+        'app/health.ts': "import 'a-package-that-is-not-installed'\nexport const health = {}\n",
+        'src/health.ts': managerSource('health', { checkName: 'src-one' }),
+      })
+
+      const { exitCode, report } = await runHealthCli(workspace.dir)
+
+      expect(exitCode).toBe(1)
+      expect(report.status).toBe('unhealthy')
+      // The working manager's checks still run and are still reported.
+      expect(report.checks.map((check) => check.name)).toEqual(['health-config', 'src-one'])
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('survives a manager whose report omits checks', async () => {
+    // The manager is app-authored and arrives through `import()`, so nothing
+    // type-checks its report. Splicing the load failures into one that has no
+    // `checks` spread `undefined` and killed the command — on exactly the path
+    // that had a diagnostic to print, so the output was empty where it mattered
+    // most. (`printReport` had the same hole for longer, on the non-json path.)
+    const workspace = await createTempWorkspace('guren-cli-health-checkless-')
+
+    try {
+      await writeWorkspaceFiles(workspace.dir, {
+        'app/health.ts': "import 'a-package-that-is-not-installed'\n",
+        'src/health.ts': managerSource('health', { omitChecks: true }),
+      })
+
+      const { exitCode, report } = await runHealthCli(workspace.dir)
+
+      expect(exitCode).toBe(1)
+      expect(report.status).toBe('unhealthy')
+      expect(report.checks.map((check) => check.name)).toEqual(['health-config'])
+    } finally {
       await workspace.cleanup()
     }
   })

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -140,6 +140,28 @@ export const users = sqliteTable('users', {
 `
 
 /**
+ * A routes file that genuinely resolves `@guren/core` at runtime.
+ *
+ * `Router` is used as a *value*, twice over on purpose. An import used only
+ * in type position is erased by the transpiler, so such a fixture never
+ * resolves the package at all and cannot detect anything about how it
+ * resolved — and the `instanceof` holds only if the fixture got the same
+ * class the loading process passed in, which a separately-resolved copy
+ * would not be.
+ *
+ * One copy because two tests are each other's control: linked via
+ * {@link linkWorkspaceCore} it must load, unlinked it must fail to resolve.
+ * The pair proves nothing unless both run the same fixture.
+ */
+export const CORE_RESOLVING_ROUTES_FIXTURE = `import { Router } from '@guren/core'
+
+export function registerWebRoutes(router: Router): void {
+  if (!(router instanceof Router)) throw new Error('resolved a different @guren/core')
+  router.get('/posts', () => new Response('ok')).name('posts.index')
+}
+`
+
+/**
  * The `routes/web.ts` the two app templates scaffold.
  *
  * The blog one is the shape that broke every route-wiring patch: it names the
@@ -366,6 +388,38 @@ export async function writeWorkspaceFiles(
  */
 export async function createTempWorkspace(prefix: string): Promise<TempWorkspace> {
   const dir = await mkdtemp(join(tmpdir(), prefix))
+
+  // Bun's last resort for a bare specifier it cannot resolve is to *install*
+  // it — from the global cache, and from npm when the cache misses. A fixture
+  // here has no node_modules, so every `@guren/*` import in a file a CLI
+  // process actually loads resolves to whatever the machine happens to have
+  // installed, or to whatever npm serves today (measured: `@guren/core@1.7.0`
+  // from ~/.bun/install/cache on one machine, a fresh 1.8.0 download on a
+  // cache miss, and a hard failure on a runner that cannot reach the
+  // registry). Disabling it makes an unlinked fixture fail loudly instead of
+  // silently binding the *published* package and calling that a test of this
+  // checkout. Use `linkWorkspaceCore()` for fixtures that need the real thing.
+  //
+  // Here rather than in a bunfig of our own, because bunfig lookup is cwd-only
+  // (it does not walk up — verified from examples/blog and web/) and this is
+  // the cwd the tests spawn CLI processes with. The test *runner* needs no
+  // such setting: `bun run` auto-installs and `bun test` does not, so an
+  // in-process fixture import cannot reach an ambient copy either way — a
+  // canary in tests/fixture-resolution-guard.test.ts pins that, since a Bun
+  // that changed it would expose every in-process fixture at once.
+  //
+  // Written *before* the chdir, deliberately: an await between chdir and the
+  // return is a suspension point where a timed-out test abandons the helper
+  // with cwd moved and no `cleanup()` to move it back — which the cwd guard
+  // then reports against whichever file happened to be running.
+  //
+  // One consequence to know about: the workspace is therefore never *empty*.
+  // `create-app` refuses to scaffold into a non-empty directory (its check is
+  // `readdir(dir).length === 0`), so a test pointing `guren new` at one of
+  // these needs `--force` — the error it gets otherwise names the directory
+  // and nothing about this file.
+  await writeFile(join(dir, 'bunfig.toml'), '[install]\nauto = "disable"\n')
+
   const originalCwd = process.cwd()
   process.chdir(dir)
 
@@ -465,6 +519,37 @@ export async function runCliBin(
     stderr: 'ignore',
   })
   return proc.exited
+}
+
+/**
+ * {@link runCliBin}, capturing both streams instead of discarding them.
+ *
+ * `NODE_ENV` is dropped rather than inherited: Bun's test runner sets it to
+ * `test`, which drops consola to the warn level in the child and hides the
+ * info-level output these assertions inspect — so a test would read the
+ * environment rather than the command. Deleting it is what a plain terminal
+ * invocation looks like; setting it to `production` would also unhide the
+ * output but flips every gate in the framework that keys on production.
+ */
+export async function runCliBinCaptured(
+  args: string[],
+  cwd: string,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  assertWorkspaceBuilt([SERVER_DIST_ENTRY])
+
+  const { NODE_ENV: _testEnv, ...env } = process.env
+  const proc = Bun.spawn(['bun', CLI_BIN_PATH, ...args], {
+    cwd,
+    env,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { stdout, stderr, exitCode }
 }
 
 /**

--- a/packages/cli/tests/spec-check.test.ts
+++ b/packages/cli/tests/spec-check.test.ts
@@ -144,4 +144,32 @@ export class Post extends defineModel(posts) {}
 
     expect(results.map((r) => r.key)).toEqual(['spec-drift:screens.md'])
   })
+
+  it('degrades the screens view when the routes path cannot even be probed', async () => {
+    // Its own workspace: this one is deliberately broken, and the shared
+    // fixture above is restored between tests rather than rebuilt.
+    //
+    // The drift gate reads a routes file it cannot load as `degraded` and
+    // skips the byte comparison — diffing hollow content would report drift
+    // that regenerating could only "fix" by destroying the committed view.
+    // That only holds if the existence probe reaches the loader: a `routes`
+    // that is a regular file makes the probe throw ENOTDIR, which used to
+    // escape `runSpecCheck` as a stack trace instead of this warning.
+    const broken = await createTempWorkspace('guren-cli-spec-check-notdir-')
+
+    try {
+      await writeFile(join(broken.dir, 'package.json'), '{}', 'utf8')
+      await writeFile(join(broken.dir, 'routes'), 'not a directory', 'utf8')
+      await mkdir(join(broken.dir, 'docs/spec'), { recursive: true })
+      await writeFile(join(broken.dir, 'docs/spec/screens.md'), '# stale\n', 'utf8')
+
+      const results = await runSpecCheck({ cwd: broken.dir })
+      const screens = results.find((r) => r.key === 'spec-drift:screens.md')
+
+      expect(screens?.status).toBe('warn')
+      expect(screens?.message).toContain('route graph failed to load')
+    } finally {
+      await broken.cleanup()
+    }
+  })
 })


### PR DESCRIPTION
## Summary

The v2.9.0 release gate failed on a CLI test that was measuring the machine
rather than the checkout, and #482 fixed that one test and the one swallowed
error behind it. This is the sweep for the same two shapes elsewhere.

**Swallowed load failures.** `guren context` rendered `## Routes (0)` /
`No routes loaded.` and exited 0 whether the app had no routes or its routes
file threw on import — `loadContextRoutes` caught every failure and returned
`[]` with no message, the same defect #482 fixed one function over. The reason
now reaches `ProjectContext.routesError`, the rendered Routes section, and
`--json`. `guren health:check` had it worse: a health file that existed and
failed to import was logged at debug level (invisible by default), reported as
"No health manager found" with instructions to create the file the user
already has, while `--json` answered `"status": "healthy"` off the built-in
memory and uptime checks. It now names the file and the reason, carries a
failing `health-config` check into the report, and exits 1.

**One rule for what "missing" means.** The two probes in use disagreed, and
both were wrong for a loader. `fileExists` rethrows anything but `ENOENT`, so a
`routes` that is a regular file crashed `guren context`, `guren context
<Entity>` and `spec:generate`/`check --spec` outright. `existsSync` answers
"no" instead, so a dangling `app/health.ts` or `guren.arch.ts` symlink was
skipped and the command reported a clean result from a configuration it never
read. `isDefinitelyAbsent()` is now the one rule: only `ENOENT` is absent,
everything else reaches the loader and the loader's error is what gets
reported. `resolveRoutesFile()` owns the companion rule — absence is silent
only on the *default* path, since a `--routes` or `--health` the caller named
is a typo or a wrong app root when it is not there.

**Fixtures that measured the machine.** A test fixture in a temp directory has
no `node_modules`, and Bun's last resort for a bare specifier is to *install*
it — from the global cache, and from the npm registry on a miss. So a fixture a
CLI process loads binds whatever `@guren/*` the machine has (measured:
`@guren/core@1.7.0` out of `~/.bun/install/cache`) or whatever npm serves today
(measured: a fresh 1.8.0 download into an empty cache), and on a runner that
can reach neither, it throws. `createTempWorkspace` now disables auto-install
in each fixture, and two tests fail if that stops happening.

### Two findings worth keeping, from the sweep itself

- **`bun run` auto-installs; `bun test` does not** (Bun 1.3.14, verified with no
  bunfig present anywhere). That is why the exposure is confined to processes
  the tests *spawn*, and why the test runner needs no setting of its own.
- **A `@guren/core` import used only in type position is erased by the
  transpiler**, so such a fixture never resolves the package and cannot detect
  anything about how it resolved. That is why the sweep came back nearly empty
  — and what stops being true at the first `extends Controller`.

**Negative result, stated plainly:** no test other than the one #482 fixed was
binding an ambient copy. The instrument could have found one — with the fixture
linked and auto-install on it passes, unlinked and auto-install on it *still*
passes (binding the published package), unlinked and auto-install off it fails.
Only the third combination is a real answer, which is why the guard test
asserts the failure's *reason* rather than the failure.

## Scope

`cli` — `context`, `context <Entity>`, `spec:generate` / `check --spec`,
`health:check`, and `guren.arch.ts` / `config/audit.ts` discovery. No changes
to `server`, `orm`, `core`, templates, or docs.

## Risk Assessment

Behavior changes, all in the "report instead of stay quiet" direction:

- `guren health:check` **exits 1** where it exited 0, when a health file exists
  and cannot yield a manager. This is the intended fix and can turn a green CI
  step red — for a step that was reporting a clean bill of health for a
  configuration it never read. Changeset is `minor` for this reason.
- `guren health:check --json` no longer prints its console prose to stdout. The
  output only parsed before when something else had already silenced consola.
- `--routes=` and `--health=` (empty value) now mean "no flag" rather than
  naming a file. Previously `--routes=` resolved to the app root and reported
  `Cannot find module '<app root>'`.
- `guren context --json` gains an optional `routesError` field; `loadContextRoutes`
  gains an optional third parameter. Both additive.

Deliberately **not** changed, and named in the changeset so it is not
rediscovered: `fileExists` keeps the old semantics at its remaining call sites,
including three scans inside `guren check` and `app-surface.ts`. Those want one
change together, after settling whether a skipped scan belongs in the report.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` — `packages/cli` 1659 pass / 0 fail; all other packages
      3193 pass / 0 fail; `test:examples` 264 pass
- [x] `audit:core-first`, `audit:docs`, `audit:template-deps`,
      `audit:plugin-compat`, `audit:core-semver` — all pass

Every fix is mutation-verified: reverting it makes the corresponding test fail.
Behavior was also checked directly against the CLI across 10 scenarios (health
file absent / present-without-manager / empty flag / import throws / dangling
symlink / named-without-manager / named-missing, and routes none / empty flag /
typo'd path).

> **Note on `bun run test:bun`:** the monorepo-wide run intermittently dies with
> no summary and no failing test. That is [oven-sh/bun#34069](https://github.com/oven-sh/bun/issues/34069)
> — a lost child exit in `spawnSync` on macOS ARM64 — whose incidence tracks
> total `spawnSync` volume at full-suite scale. Per-package runs, which do not
> hit it, are the numbers above.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation (changeset).
