### PR TITLE
ci: cap job runtimes with timeout-minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     # entry, not on a version literal, so promoting a trial version to primary
     # cannot silently flip which lane gates.
     continue-on-error: ${{ matrix.trial == true }}
-    # Measured ceiling for a healthy lane is 5m0s (1.3.14) / 4m7s (1.4.0)
+    # Measured ceiling for a healthy lane is 5m00s (1.3.14) / 4m42s (1.4.0)
     # across 30 runs, cache misses included, so this is an anti-wedge
     # backstop rather than an assertion about how fast the job ought to be.
     # The per-step cap on `Run tests` below is the one that fires first for

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ jobs:
     # entry, not on a version literal, so promoting a trial version to primary
     # cannot silently flip which lane gates.
     continue-on-error: ${{ matrix.trial == true }}
+    # Measured ceiling for a healthy lane is 5m0s (1.3.14) / 4m7s (1.4.0)
+    # across 30 runs, cache misses included, so this is an anti-wedge
+    # backstop rather than an assertion about how fast the job ought to be.
+    # The per-step cap on `Run tests` below is the one that fires first for
+    # the known wedge; this one covers everything else in the job.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -261,7 +267,19 @@ jobs:
       # The harness is invoked directly (not via `bun run test:bun`) so the
       # flag string crosses exactly one `--`-swallowing layer — see the
       # matrix comment above.
+      #
+      # The step is capped as well as the job because this is the step that
+      # hangs: oven-sh/bun#34069 wedged the trial lane here on four runs in
+      # one day (32489029613, 32492123122, 32494964369, 32496297560), each
+      # sitting in_progress for 11-57 minutes until cancelled by hand. A
+      # *step* timeout fails the step, which the job's continue-on-error then
+      # masks on the trial lane — the documented path. Whether a *job*
+      # timeout is reported as a failure (masked) or a cancellation (not) is
+      # not something the documentation settles, so the trial lane's
+      # non-blocking promise deliberately does not rest on it.
+      # Measured 2m16s at worst against a 15m cap.
       - name: Run tests
+        timeout-minutes: 15
         run: |
           bun scripts/test-packages.ts ${{ matrix.test-bun-flags }}
           bun run test:examples
@@ -274,6 +292,9 @@ jobs:
   # themselves and run in parallel with everything else.
   starter-smokes:
     runs-on: ubuntu-latest
+    # Measured max 4m0s: it rebuilds the packages and runs eight scaffold
+    # smokes.
+    timeout-minutes: 20
     services:
       postgres:
         image: postgres:16-alpine
@@ -346,6 +367,8 @@ jobs:
     # No redis service — verifies all tests gracefully skip when Redis is
     # unavailable. Typecheck is deliberately absent: it is environment-
     # independent and already covered by build-and-test.
+    # Measured max 2m54s.
+    timeout-minutes: 15
     env:
       APP_KEY: base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
     steps:
@@ -363,6 +386,8 @@ jobs:
     # VITE_DEV_SERVER_URL must be removed from .env (see setup step) —
     # otherwise autoConfigureInertiaAssets falls back to dev mode.
     # The blog app also disables Secure cookies when CI is set (HTTP, not HTTPS).
+    # Measured max 2m43s; a Playwright browser-cache miss is the variable.
+    timeout-minutes: 20
     services:
       postgres:
         image: postgres:17-alpine
@@ -445,6 +470,8 @@ jobs:
 
   web-app:
     runs-on: ubuntu-latest
+    # Measured max 1m56s.
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,9 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    # Measured max 2m18s over 10 runs. The extra room is for the CodeQL
+    # action itself, whose database build is not this repo's to tune.
+    timeout-minutes: 20
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/metrics-snapshot.yml
+++ b/.github/workflows/metrics-snapshot.yml
@@ -37,6 +37,9 @@ permissions:
 jobs:
   snapshot:
     runs-on: ubuntu-latest
+    # Measured max 18s. The cap is here for a stalled call to the GitHub
+    # traffic API, not for the work.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   canary-validate:
     runs-on: ubuntu-latest
+    # Measured max 6m0s. Generous for the same reason as the release gate:
+    # it is a superset of CI, builds from scratch every night, and adds the
+    # deploy-bundle probes and benchmarks on top.
+    timeout-minutes: 45
     services:
       redis:
         image: redis:7-alpine
@@ -157,6 +161,9 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    # Measured max 6m48s — higher than CI's e2e because this one installs
+    # the Playwright browsers unconditionally, with no cache to hit.
+    timeout-minutes: 30
     services:
       postgres:
         image: postgres:17-alpine
@@ -215,6 +222,8 @@ jobs:
 
   web-app:
     runs-on: ubuntu-latest
+    # Measured max 2m36s.
+    timeout-minutes: 20
 
     steps:
       # ----------------------------------------------------------------

--- a/.github/workflows/published-drift.yml
+++ b/.github/workflows/published-drift.yml
@@ -21,6 +21,11 @@ on:
 jobs:
   drift:
     runs-on: ubuntu-latest
+    # Deliberately generous, and not derived from the measured max: these
+    # runs finish in 4-7s and report success, which is too fast for a real
+    # npm install plus typecheck. Until that is looked into, a number based
+    # on them would be a number based on a gate that is not doing its work.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       # `worker` is absent for the same reason fresh-app.ts skips its typecheck:
@@ -57,6 +62,8 @@ jobs:
   # is expected, the same way the npm drift above is.
   agent-catalog:
     runs-on: ubuntu-latest
+    # Measured max 18s; it fetches the published catalog over the network.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Measured max 6m30s over 15 releases. Deliberately looser than CI's
+    # caps: this job legitimately runs the scaffolding smokes, and a
+    # release cut short by a tight cap costs more than a wedged runner.
+    timeout-minutes: 45
     services:
       redis:
         image: redis:7-alpine

--- a/scripts/workflow-timeout.test.ts
+++ b/scripts/workflow-timeout.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { repoRoot } from './workspace-packages.ts'
+
+/**
+ * A job with no `timeout-minutes` inherits GitHub's 6-hour default, which is
+ * not a cap on anything this repo does — it is a cap on how long a *hang* can
+ * hold a runner. That bill came due on 2026-08-21: the Bun 1.4.0 trial lane hit
+ * oven-sh/bun#34069 on four runs in one day and sat `in_progress` for 11 to 57
+ * minutes each, until someone noticed and cancelled by hand. Nothing but a
+ * human was standing between those runs and six hours apiece.
+ *
+ * So the property is totality, not any particular number: *every* job declares
+ * one. A per-job cap that a new job silently opts out of is the same gap again,
+ * which is why this reads the workflows off disk rather than from a list.
+ *
+ * The numbers themselves are measured (see the comment on each cap) and set
+ * well above the observed ceiling on purpose. A cap tight enough to turn a slow
+ * runner red is a cap someone deletes, and then there is no cap.
+ */
+const WORKFLOW_DIR = join(repoRoot, '.github/workflows')
+
+/**
+ * Above every cap in the tree, below GitHub's 6-hour default. Totality alone
+ * would be satisfied by `timeout-minutes: 350`, which caps nothing.
+ */
+const MAX_REASONABLE_MINUTES = 60
+
+function workflowFiles(): string[] {
+  return [...new Bun.Glob('*.{yml,yaml}').scanSync({ cwd: WORKFLOW_DIR })].sort()
+}
+
+/**
+ * Job id -> the lines of its block, for the one top-level `jobs:` mapping.
+ *
+ * Indentation is the whole point: `timeout-minutes` on a *step* sits deeper and
+ * caps that step only, so a line-level search would read a workflow whose jobs
+ * are all uncapped as covered. Job ids are the keys at exactly two spaces
+ * inside `jobs:` — the `on:` block has two-space keys too (`push:`,
+ * `schedule:`), hence scoping to the section rather than to the file.
+ */
+export function jobBlocks(source: string): Map<string, string[]> {
+  const lines = source.split('\n')
+  const blocks = new Map<string, string[]>()
+  let inJobs = false
+  let current: string[] | undefined
+
+  for (const line of lines) {
+    if (/^jobs:\s*$/.test(line)) {
+      inJobs = true
+      continue
+    }
+    if (!inJobs) continue
+
+    // A key back at column 0 ends the jobs mapping.
+    if (/^\S/.test(line)) break
+
+    const job = /^ {2}([A-Za-z_][\w-]*):\s*(?:#.*)?$/.exec(line)
+    if (job) {
+      current = []
+      blocks.set(job[1]!, current)
+      continue
+    }
+    current?.push(line)
+  }
+
+  return blocks
+}
+
+/** The job-level `timeout-minutes` of a job block, if it declares one. */
+export function jobTimeout(block: string[]): number | undefined {
+  for (const line of block) {
+    const match = /^ {4}timeout-minutes:\s*(\d+)\s*(?:#.*)?$/.exec(line)
+    if (match) return Number(match[1])
+  }
+  return undefined
+}
+
+describe('workflow job timeouts', () => {
+  const workflows = workflowFiles().map((file) => ({
+    file,
+    jobs: jobBlocks(readFileSync(join(WORKFLOW_DIR, file), 'utf8')),
+  }))
+
+  it('finds jobs in every workflow', () => {
+    // Everything below is measured against this, so a workflow whose jobs this
+    // stops recognising has to fail loudly rather than vacuously pass.
+    for (const { file, jobs } of workflows) {
+      expect([file, jobs.size > 0]).toEqual([file, true])
+    }
+  })
+
+  it.each(workflows.flatMap(({ file, jobs }) => [...jobs.keys()].map((job) => [file, job] as const)))(
+    '%s: %s caps its runtime',
+    (file, job) => {
+      const minutes = jobTimeout(workflows.find((w) => w.file === file)!.jobs.get(job)!)
+      expect(minutes).toBeDefined()
+      expect(minutes!).toBeGreaterThan(0)
+      expect(minutes!).toBeLessThanOrEqual(MAX_REASONABLE_MINUTES)
+    },
+  )
+})
+
+describe("CI's trial lane", () => {
+  const ci = readFileSync(join(WORKFLOW_DIR, 'ci.yml'), 'utf8')
+
+  it('caps the test step, not only the job', () => {
+    /*
+     * The trial lane is non-blocking through `continue-on-error`, which is
+     * documented to cover a job that *fails*. A job-level timeout is not
+     * documented to report as a failure rather than a cancellation, and a
+     * cancellation is not masked — so resting the lane's non-blocking promise
+     * on the job cap would be resting it on undocumented behaviour. A *step*
+     * timeout fails the step, and a failed step fails the job, which
+     * `continue-on-error` then masks by the documented path.
+     *
+     * `Run tests` is also where the wedge actually happens, so this cap is the
+     * one that fires first; the job cap stays as the backstop for a hang
+     * anywhere else.
+     */
+    const step = /^ {6}- name: Run tests\n {8}timeout-minutes: (\d+)$/m.exec(ci)
+    expect(step).not.toBeNull()
+    expect(Number(step![1])).toBeGreaterThan(0)
+  })
+})

--- a/scripts/workflow-timeout.test.ts
+++ b/scripts/workflow-timeout.test.ts
@@ -19,6 +19,12 @@ import { repoRoot } from './workspace-packages.ts'
  * The numbers themselves are measured (see the comment on each cap) and set
  * well above the observed ceiling on purpose. A cap tight enough to turn a slow
  * runner red is a cap someone deletes, and then there is no cap.
+ *
+ * Parsed rather than pattern-matched, because the distinction the whole gate
+ * rests on is structural: `timeout-minutes` on a *step* caps that step only,
+ * and a line-level search would read a workflow whose jobs are all uncapped as
+ * covered. Two steps in ci.yml are even named `Run tests`, so "the cap near the
+ * step with this name" is not a question text matching can answer either.
  */
 const WORKFLOW_DIR = join(repoRoot, '.github/workflows')
 
@@ -28,84 +34,44 @@ const WORKFLOW_DIR = join(repoRoot, '.github/workflows')
  */
 const MAX_REASONABLE_MINUTES = 60
 
+type Step = { name?: string; 'timeout-minutes'?: unknown }
+type Job = { 'timeout-minutes'?: unknown; steps?: Step[] }
+
 function workflowFiles(): string[] {
   return [...new Bun.Glob('*.{yml,yaml}').scanSync({ cwd: WORKFLOW_DIR })].sort()
 }
 
-/**
- * Job id -> the lines of its block, for the one top-level `jobs:` mapping.
- *
- * Indentation is the whole point: `timeout-minutes` on a *step* sits deeper and
- * caps that step only, so a line-level search would read a workflow whose jobs
- * are all uncapped as covered. Job ids are the keys at exactly two spaces
- * inside `jobs:` — the `on:` block has two-space keys too (`push:`,
- * `schedule:`), hence scoping to the section rather than to the file.
- */
-export function jobBlocks(source: string): Map<string, string[]> {
-  const lines = source.split('\n')
-  const blocks = new Map<string, string[]>()
-  let inJobs = false
-  let current: string[] | undefined
-
-  for (const line of lines) {
-    if (/^jobs:\s*$/.test(line)) {
-      inJobs = true
-      continue
-    }
-    if (!inJobs) continue
-
-    // A key back at column 0 ends the jobs mapping.
-    if (/^\S/.test(line)) break
-
-    const job = /^ {2}([A-Za-z_][\w-]*):\s*(?:#.*)?$/.exec(line)
-    if (job) {
-      current = []
-      blocks.set(job[1]!, current)
-      continue
-    }
-    current?.push(line)
+function jobsOf(file: string): Record<string, Job> {
+  const parsed = Bun.YAML.parse(readFileSync(join(WORKFLOW_DIR, file), 'utf8')) as {
+    jobs?: Record<string, Job>
   }
-
-  return blocks
-}
-
-/** The job-level `timeout-minutes` of a job block, if it declares one. */
-export function jobTimeout(block: string[]): number | undefined {
-  for (const line of block) {
-    const match = /^ {4}timeout-minutes:\s*(\d+)\s*(?:#.*)?$/.exec(line)
-    if (match) return Number(match[1])
-  }
-  return undefined
+  return parsed.jobs ?? {}
 }
 
 describe('workflow job timeouts', () => {
-  const workflows = workflowFiles().map((file) => ({
-    file,
-    jobs: jobBlocks(readFileSync(join(WORKFLOW_DIR, file), 'utf8')),
-  }))
+  const workflows = workflowFiles().map((file) => ({ file, jobs: jobsOf(file) }))
 
   it('finds jobs in every workflow', () => {
     // Everything below is measured against this, so a workflow whose jobs this
     // stops recognising has to fail loudly rather than vacuously pass.
     for (const { file, jobs } of workflows) {
-      expect([file, jobs.size > 0]).toEqual([file, true])
+      expect([file, Object.keys(jobs).length > 0]).toEqual([file, true])
     }
   })
 
-  it.each(workflows.flatMap(({ file, jobs }) => [...jobs.keys()].map((job) => [file, job] as const)))(
-    '%s: %s caps its runtime',
-    (file, job) => {
-      const minutes = jobTimeout(workflows.find((w) => w.file === file)!.jobs.get(job)!)
-      expect(minutes).toBeDefined()
-      expect(minutes!).toBeGreaterThan(0)
-      expect(minutes!).toBeLessThanOrEqual(MAX_REASONABLE_MINUTES)
-    },
-  )
+  it.each(
+    workflows.flatMap(({ file, jobs }) =>
+      Object.keys(jobs).map((job) => [file, job] as const),
+    ),
+  )('%s: %s caps its runtime', (file, job) => {
+    const minutes = workflows.find((w) => w.file === file)!.jobs[job]!['timeout-minutes']
+    expect(typeof minutes).toBe('number')
+    expect(minutes as number).toBeGreaterThan(0)
+    expect(minutes as number).toBeLessThanOrEqual(MAX_REASONABLE_MINUTES)
+  })
 })
 
 describe("CI's trial lane", () => {
-  const ci = readFileSync(join(WORKFLOW_DIR, 'ci.yml'), 'utf8')
-
   it('caps the test step, not only the job', () => {
     /*
      * The trial lane is non-blocking through `continue-on-error`, which is
@@ -116,12 +82,17 @@ describe("CI's trial lane", () => {
      * timeout fails the step, and a failed step fails the job, which
      * `continue-on-error` then masks by the documented path.
      *
-     * `Run tests` is also where the wedge actually happens, so this cap is the
-     * one that fires first; the job cap stays as the backstop for a hang
-     * anywhere else.
+     * `Run tests` in build-and-test is also where the wedge actually happens,
+     * so this cap is the one that fires first; the job cap stays as the
+     * backstop for a hang anywhere else. It has to be *that* step: web-app has
+     * a step by the same name, and a cap landing there would leave the one
+     * that wedges uncapped.
      */
-    const step = /^ {6}- name: Run tests\n {8}timeout-minutes: (\d+)$/m.exec(ci)
-    expect(step).not.toBeNull()
-    expect(Number(step![1])).toBeGreaterThan(0)
+    const steps = jobsOf('ci.yml')['build-and-test']?.steps ?? []
+    const runTests = steps.filter((step) => step.name === 'Run tests')
+
+    expect(runTests).toHaveLength(1)
+    expect(typeof runTests[0]!['timeout-minutes']).toBe('number')
+    expect(runTests[0]!['timeout-minutes'] as number).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## Why

No job in `.github/workflows` declared `timeout-minutes`, so every one inherited GitHub's 6-hour default.

On 2026-08-21 the Bun 1.4.0 trial lane added in #511 hit the known upstream wedge [oven-sh/bun#34069](https://github.com/oven-sh/bun/issues/34069) on four runs, each sitting `in_progress` until cancelled by hand:

| run | wedged for |
|---|---|
| [32489029613](https://github.com/gurenjs/guren/actions/runs/32489029613) | 17m |
| [32492123122](https://github.com/gurenjs/guren/actions/runs/32492123122) | 57m |
| [32494964369](https://github.com/gurenjs/guren/actions/runs/32494964369) | 26m |
| [32496297560](https://github.com/gurenjs/guren/actions/runs/32496297560) | 11m |

This is upstream behaviour, not a repo defect — but a `continue-on-error` lane that can hang should not be able to hold a runner for six hours per commit, and the only thing that stopped it was a person noticing.

## Caps

Measured over the last 30 CI runs, 15 nightly runs and 15 releases. Caps sit well above the observed ceiling on purpose: a cap tight enough to turn a slow runner red is a cap that gets deleted, and then there is no cap.

| workflow | job | measured max | cap |
|---|---|---|---|
| ci | `build-and-test` | 5m00s | 25 |
| ci | `starter-smokes` | 4m00s | 20 |
| ci | `sqlite-smoke` | 2m54s | 15 |
| ci | `e2e` | 2m43s | 20 |
| ci | `web-app` | 1m56s | 15 |
| release | `publish` | 6m30s | 45 |
| nightly-canary | `canary-validate` | 6m00s | 45 |
| nightly-canary | `e2e` | 6m48s | 30 |
| nightly-canary | `web-app` | 2m36s | 20 |
| codeql | `analyze` | 2m18s | 20 |
| metrics-snapshot | `snapshot` | 18s | 15 |
| published-drift | `drift` | see below | 30 |
| published-drift | `agent-catalog` | 18s | 20 |

`deploy-web`'s `deploy` job already declared `timeout-minutes: 30` and is unchanged.

Release and nightly are looser than CI deliberately: both legitimately run the scaffolding smokes, nightly builds from scratch with no dist cache, and nightly `e2e` installs the Playwright browsers unconditionally — which is where its 6m48s outlier came from.

## Why the test step is capped as well as the job

`continue-on-error` is documented as preventing a run from failing "when a job **fails**". A job-level timeout is not documented to report as a *failure* rather than a *cancellation*, and a cancellation is not masked. Resting the trial lane's non-blocking promise on that would be resting it on undocumented behaviour.

So `Run tests` — the step that actually wedges — carries its own `timeout-minutes: 15` (measured 2m16s at worst). A step timeout fails the step, a failed step fails the job, and `continue-on-error` masks that by the documented path. The job cap stays as the backstop for a hang anywhere else in the job.

Two things already in the lane's favour, unchanged here: `strategy.fail-fast: false` means a timed-out trial lane cannot cancel the primary lane, and the `main-protection` ruleset declares no `required_status_checks` rule at all, so no check blocks a merge today regardless.

## Test

`scripts/workflow-timeout.test.ts` (auto-discovered by `test-packages.ts`, no wiring needed) asserts the property that matters — totality, not any particular number: every job in every workflow declares a cap, and it is a positive integer no greater than 60, since totality alone would be satisfied by `timeout-minutes: 350`.

It **parses** each workflow rather than pattern-matching it, because the distinction the whole gate rests on is structural. A line-level search cannot tell a job key from a step key, so a workflow with a cap on a step and none on its job would pass vacuously. Nor can it identify a step by name: `ci.yml` has *two* steps called `Run tests` — `build-and-test`'s and `web-app`'s — so the step assertion names the job and the step, not a line adjacency.

That totality is also why this PR touches `codeql.yml`, `metrics-snapshot.yml` and `published-drift.yml`, which were outside the reported scope: a totality test with three exemptions is not a totality test.

Mutation-checked, per the repo's rule that a check which cannot fail is not a check. Each of these turns it red, and the tree was restored after every one:

| mutation | result |
|---|---|
| job cap deleted | red |
| job cap raised to 350 | red |
| job cap moved to step-level indentation only | red |
| `build-and-test`'s `Run tests` step cap deleted | red |
| that step cap moved to `web-app`'s identically-named `Run tests` | red |

The last one is why the second commit exists. The first version of the step assertion was a regex on `- name: Run tests` plus the following line, taking the first match in file order — and it **passes** that mutation, leaving the one step that actually wedges uncapped while reporting green. Verified directly before replacing it.

`scripts/workflow-bun-version.test.ts` needs no change: `timeout-minutes` does not match its `bun-version` pattern, and it still passes.

### Not mirrored into nightly-canary

`nightly-canary.yml` opens with a "SUPERSET of CI — when adding a new step to ci.yml, mirror it here" block, and the `Run tests` step cap is not mirrored. That invariant is about *which checks run*, not step configuration, and nightly's `Run tests` is 1.3.14 without `--parallel`, so it cannot reach bun#34069. Its job-level cap of 45 covers it.

## Separate finding, not fixed here

`published-drift`'s three `drift` matrix jobs complete in **4–7 seconds** and report success. That is far too fast for a scaffold plus an npm install plus a typecheck, so that gate looks vacuous. Its cap is therefore deliberately generous and explicitly *not* derived from those durations — a number based on them would be a number based on a gate that is not doing its work. Worth a separate look.

## CI on this PR

The run is green at the run level ([32499341967](https://github.com/gurenjs/guren/actions/runs/32499341967), conclusion `success`), and it happens to exercise the exact question this PR is about.

`build-and-test (1.4.0)` failed — the ordinary way, not by timing out. Four tests in `publish-agent-catalog` died at `[30000.11ms]`, exactly the per-test timeout, which is bun#34069's signature on the git-heavy files; the whole test run took 75.91s against a 15-minute step cap. So nothing here is evidence about the caps firing. It *is* evidence that a failed trial lane still leaves the run `success`: `continue-on-error` masked it, the same as on runs 32493695386, 32494422344 and 32494903664 before this change.

Note the individual check still reads `fail` in the PR checks list while the run reads `success`. That is pre-existing and unchanged by this PR.

## Verification

- `bun run build:clean`, `bun run build:routes`, `bun run typecheck` — clean
- `bun test scripts/` — 157 pass, 0 fail
- All seven workflows parse as valid YAML, and every job resolves a `timeout-minutes` value

