### PR TITLE
fix(ci): make the published-drift gate cover the feature blueprints

### DIFF
--- a/.changeset/wide-pandas-smell.md
+++ b/.changeset/wide-pandas-smell.md
@@ -1,0 +1,18 @@
+---
+'create-guren-app': patch
+---
+
+Widen the starter template's TypeScript `include` so it covers the files it
+always meant to.
+
+`".guren"` matched nothing: TypeScript expands a bare directory name to a
+wildcard, and its wildcard matcher skips dot-prefixed path segments. Generated
+files that something imports still arrived through the import graph, which is
+what hid the dead entry — the ones nothing imports (`data.gen.ts`,
+`channels.gen.ts`, `translations.gen.ts`) were never checked at all. `config/`,
+`bin/`, `tests/`, `drizzle.config.ts`, and `vite.config.ts` were outside the
+list too.
+
+`bun run typecheck` in a scaffolded app now reads all of them. The api-only
+template already used the explicit-glob form; this brings the default template
+(which blog and worker also build on) into line with it.

--- a/.changeset/wide-pandas-smell.md
+++ b/.changeset/wide-pandas-smell.md
@@ -14,7 +14,13 @@ all. `config/`, `bin/`, `tests/`, `drizzle.config.ts`, and `vite.config.ts`
 were outside the list too.
 
 The api-only template already used the explicit-glob form, so its generated
-files were covered — but its list omitted the `tests/` and `drizzle.config.ts`
-it ships, so those went unchecked there for a different reason. Both templates
-now cover everything they scaffold, and `bun run typecheck` in a scaffolded app
-reads all of it.
+files were covered — but its list omitted the `drizzle.config.ts` it ships, so
+that went unchecked there for a different reason. It now covers that too.
+
+`tests/` is covered in the default template but deliberately not yet in
+api-only: the test file api-only ships passes `providers: [DatabaseProvider]`
+to `TestApp.create()`, and `@guren/testing` types that parameter as
+`new (...args: unknown[]) => ProviderLike`, which no real `ServiceProvider`
+subclass satisfies. That is a defect in the testing package's published type,
+not in the template, and widening the include here before it is fixed would
+only make the starter smokes red.

--- a/.changeset/wide-pandas-smell.md
+++ b/.changeset/wide-pandas-smell.md
@@ -2,17 +2,19 @@
 'create-guren-app': patch
 ---
 
-Widen the starter template's TypeScript `include` so it covers the files it
+Widen both starter templates' TypeScript `include` so they cover the files they
 always meant to.
 
-`".guren"` matched nothing: TypeScript expands a bare directory name to a
-wildcard, and its wildcard matcher skips dot-prefixed path segments. Generated
-files that something imports still arrived through the import graph, which is
-what hid the dead entry — the ones nothing imports (`data.gen.ts`,
-`channels.gen.ts`, `translations.gen.ts`) were never checked at all. `config/`,
-`bin/`, `tests/`, `drizzle.config.ts`, and `vite.config.ts` were outside the
-list too.
+In the default template `".guren"` matched nothing: TypeScript expands a bare
+directory name to a wildcard, and its wildcard matcher skips dot-prefixed path
+segments. Generated files that something imports still arrived through the
+import graph, which is what hid the dead entry — the ones nothing imports
+(`data.gen.ts`, `channels.gen.ts`, `translations.gen.ts`) were never checked at
+all. `config/`, `bin/`, `tests/`, `drizzle.config.ts`, and `vite.config.ts`
+were outside the list too.
 
-`bun run typecheck` in a scaffolded app now reads all of them. The api-only
-template already used the explicit-glob form; this brings the default template
-(which blog and worker also build on) into line with it.
+The api-only template already used the explicit-glob form, so its generated
+files were covered — but its list omitted the `tests/` and `drizzle.config.ts`
+it ships, so those went unchecked there for a different reason. Both templates
+now cover everything they scaffold, and `bun run typecheck` in a scaffolded app
+reads all of it.

--- a/.github/workflows/published-drift.yml
+++ b/.github/workflows/published-drift.yml
@@ -1,10 +1,16 @@
 name: Published Package Drift
 
-# Scaffolds a starter app and installs its @guren/* dependencies from npm
-# instead of from this checkout, then typechecks it. Every other smoke mode
+# Scaffolds a starter app, scaffolds its feature blueprints with this
+# checkout's CLI, installs the app's @guren/* dependencies from npm instead of
+# from this checkout, and typechecks the result. Every other smoke mode
 # (`smoke:starter`, `smoke:starter:packed`) rewrites those dependencies to
 # local builds, so none of them can see a template that has started using an
 # API which only exists in the repository.
+#
+# Templates from here, dependencies from the registry, is the whole mechanism.
+# Both halves matter: scaffolding with the *app's* installed `guren` would emit
+# published templates against published packages — consistent by construction,
+# and a gate that can only pass.
 #
 # This deliberately lives outside ci.yml and nightly-canary.yml. It is expected
 # to be red between a template-facing change and the release that publishes
@@ -34,16 +40,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: oven-sh/setup-bun@v2
+      # The scaffolder and the `guren add` blueprints run from source, and the
+      # CLI reaches @guren/server through dist/ — so this job needs the
+      # workspace built, and the same action ci.yml uses shares its dist cache.
+      # That does not weaken the gate: what stays off this checkout is what the
+      # *app* resolves, which fresh-app.ts asserts on both sides of scaffolding.
+      # The tools that emit the templates under test are what let it fail.
+      - name: Set up Bun and build packages
+        uses: ./.github/actions/setup-and-build
         with:
           bun-version: '1.3.14'
-
-      # The scaffolder itself runs from source and needs the workspace's own
-      # dependencies. There is no `bun run build` step on purpose: npm mode
-      # touches no build output of this checkout, since the app under test has
-      # to resolve everything from the registry.
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
 
       - name: ${{ matrix.smoke }}
         run: bun run ${{ matrix.smoke }}

--- a/.github/workflows/published-drift.yml
+++ b/.github/workflows/published-drift.yml
@@ -27,11 +27,16 @@ on:
 jobs:
   drift:
     runs-on: ubuntu-latest
-    # Deliberately generous, and not derived from the measured max: these
-    # runs finish in 4-7s and report success, which is too fast for a real
-    # npm install plus typecheck. Until that is looked into, a number based
-    # on them would be a number based on a gate that is not doing its work.
-    timeout-minutes: 30
+    # The 4-7s that made the old cap unusable was real work on a tiny app, not
+    # a skipped install — but it was a *bare* scaffold, with the ten `guren add`
+    # blueprints unchecked. Now that the job scaffolds those too and builds the
+    # workspace, the number is derived like every other cap here. Measured:
+    # setup-and-build 4-11s on a dist-cache hit and 58-78s on a miss (from
+    # ci.yml's build-and-test, which shares the cache); the smoke itself 21s,
+    # 12s and 19s locally for default, api and blog, against 4-7s on CI before
+    # the widening. Worst realistic run is well under 3m, and the npm registry
+    # is the variable.
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       # `worker` is absent for the same reason fresh-app.ts skips its typecheck:
@@ -73,11 +78,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Unlike the npm-mode job above, this one *does* need the workspace
-      # built: rendering imports packages/cli/src/commands.ts to read the
-      # command registry, and that module's dependency graph reaches
-      # @guren/server, whose exports point at untracked dist/. Same action
-      # ci.yml uses, so the dist cache is shared.
+      # Built for its own reason, not the npm-mode job's: rendering imports
+      # packages/cli/src/commands.ts to read the command registry, and that
+      # module's dependency graph reaches @guren/server, whose exports point at
+      # untracked dist/. Same action, so the two share the dist cache.
       - name: Set up Bun and build packages
         uses: ./.github/actions/setup-and-build
         with:

--- a/packages/create-app/templates/api-only/tsconfig.json
+++ b/packages/create-app/templates/api-only/tsconfig.json
@@ -15,6 +15,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": [".guren/**/*", "src/**/*", "app/**/*", "routes/**/*", "config/**/*", "db/**/*", "bin/**/*"],
+  "include": [".guren/**/*", "src/**/*", "app/**/*", "routes/**/*", "config/**/*", "db/**/*", "bin/**/*", "tests/**/*", "*.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/create-app/templates/api-only/tsconfig.json
+++ b/packages/create-app/templates/api-only/tsconfig.json
@@ -15,6 +15,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": [".guren/**/*", "src/**/*", "app/**/*", "routes/**/*", "config/**/*", "db/**/*", "bin/**/*", "tests/**/*", "*.ts"],
+  "include": [".guren/**/*", "src/**/*", "app/**/*", "routes/**/*", "config/**/*", "db/**/*", "bin/**/*", "*.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/create-app/templates/default/tsconfig.json
+++ b/packages/create-app/templates/default/tsconfig.json
@@ -23,12 +23,19 @@
     "jsx": "react-jsx"
   },
   "include": [
-    ".guren",
-    "src",
-    "app",
-    "db",
-    "routes",
-    "resources/js",
-    "types"
+    ".guren/**/*",
+    "src/**/*",
+    "app/**/*",
+    "config/**/*",
+    "db/**/*",
+    "routes/**/*",
+    "resources/js/**/*",
+    "types/**/*",
+    "bin/**/*",
+    "tests/**/*",
+    "*.ts"
+  ],
+  "exclude": [
+    "node_modules"
   ]
 }

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, readdir, rm } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, readdir, realpath, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import process from 'node:process'
@@ -28,6 +28,82 @@ const INSTALL_MODES = ['vendored', 'packed', 'npm'] as const
 type InstallMode = (typeof INSTALL_MODES)[number]
 
 const repoRoot = resolve(import.meta.dir, '../..')
+
+// The feature blueprints a default-blueprint app gets, in the order the
+// scaffolders expect. Shared by the vendored and the npm paths so the
+// published-drift gate cannot fall behind the set this smoke otherwise claims
+// to cover: every one of these emits template code importing @guren/core, and
+// a bare scaffold contains none of it.
+//
+// --force on mail: `add auth` also scaffolds app/Providers/MailProvider.ts
+// (password reset needs a mail manager) — the mail blueprint's own, more
+// complete MailProvider (memory transport, setMailManager wiring)
+// intentionally supersedes it, so the assertions can verify its shape.
+const DEFAULT_BLUEPRINT_FEATURES: readonly (readonly string[])[] = [
+  ['auth'],
+  ['resource', 'posts'],
+  ['queue'],
+  ['mail', '--force'],
+  ['events'],
+  ['cache'],
+  ['notifications'],
+  ['storage'],
+  ['broadcasting'],
+  ['schedule'],
+]
+
+/**
+ * Run the feature blueprints through *this checkout's* CLI.
+ *
+ * Which CLI is not an implementation detail, and npm mode is where it decides
+ * whether the gate can fail at all: the app's own installed `guren` ships the
+ * published blueprints, so using it would emit published templates against
+ * published packages — consistent by construction, and a gate that can only
+ * pass. Templates from here, dependencies from the registry, is the mismatch
+ * the drift check exists to measure.
+ */
+async function addDefaultBlueprintFeatures(
+  appDir: string,
+  runtimeEnv: Record<string, string>,
+): Promise<void> {
+  for (const feature of DEFAULT_BLUEPRINT_FEATURES) {
+    await run(
+      ['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', ...feature],
+      appDir,
+      // The CLI runs from source while the app resolves @guren/orm from its own
+      // node_modules, so two copies legitimately coexist in *this* process. The
+      // warning describes the scaffolder, not the app under test; scoped to
+      // these calls so a genuine duplicate in the app stays loud.
+      { ...runtimeEnv, GUREN_QUIET_DUPLICATE_ORM: '1' },
+    )
+  }
+}
+
+/**
+ * A tsconfig `include` entry naming a dot-prefixed directory on its own
+ * (`".guren"`) matches no files: TypeScript expands the bare name to a
+ * wildcard, and its wildcard matcher skips dot-prefixed path segments. The app
+ * still typechecks, because every generated file something imports arrives
+ * through the import graph anyway — which is exactly what hides the dead entry.
+ * What goes unchecked is the generated files nothing imports (`data.gen.ts`,
+ * `channels.gen.ts`, `translations.gen.ts`). Nothing at runtime tells the two
+ * forms apart, so the form is pinned here.
+ */
+async function assertGeneratedDirsAreTypechecked(appDir: string): Promise<void> {
+  const include = (JSON.parse(await readFile(join(appDir, 'tsconfig.json'), 'utf8')) as {
+    include?: string[]
+  }).include ?? []
+  assert(include.length > 0, 'Scaffolded app tsconfig declares no include list.')
+  for (const entry of include) {
+    const segments = entry.split('/')
+    const named = segments[0] === '.' ? segments[1] : segments[0]
+    assert(
+      !named?.startsWith('.') || entry.includes('*'),
+      `Scaffolded app tsconfig includes "${entry}", which matches no files: ` +
+        `a bare dot-prefixed directory needs an explicit glob (e.g. "${named}/**/*").`,
+    )
+  }
+}
 
 async function run(cmd: string[], cwd: string, envOverrides?: Record<string, string>): Promise<void> {
   console.log(`\n$ (${cwd}) ${cmd.join(' ')}`)
@@ -393,39 +469,63 @@ async function assertFeatureScaffolds(appDir: string): Promise<void> {
 }
 
 /**
- * Install the scaffolded app from the registry and typecheck it.
+ * Install the scaffolded app from the registry, scaffold its features with this
+ * checkout's CLI, and typecheck the result.
  *
  * Resolving the template's own ranges is the whole point, so this fails
  * whenever a template has started using an API that exists only in this
  * repository — invisible to the other install modes and to the root
  * `typecheck`, which excludes `templates` (that now covers `config/database.ts`
  * too, shipped as per-driver sources under `templates/database/`).
+ *
+ * "Template" here means every template, not just the base scaffold. The
+ * feature blueprints in `packages/cli/src/blueprints.ts` and `make-auth.ts`
+ * emit far more `@guren/core` imports than the bare app does, and they are
+ * ordinary source in this checkout, so they drift ahead of the registry the
+ * same way. They are scaffolded with the checkout's CLI for the reason spelled
+ * out on addDefaultBlueprintFeatures().
+ *
+ * What this deliberately does not run: `bun run build` (Vite), `bun test`,
+ * `guren check`, `guren audit`. The claim being gated is "an app scaffolded
+ * from the current templates builds against what is on npm right now" — the
+ * vendored mode owns the rest, and the closing summary names every skip so a
+ * green run says what it proved.
  */
 async function runPublishedDependencyDrift(
   appDir: string,
   blueprint: string,
   runtimeEnv: Record<string, string>,
 ): Promise<void> {
-  const packageJson = JSON.parse(await readFile(join(appDir, 'package.json'), 'utf8')) as DependencyManifest
-  const gurenDependencies = Object.entries(declaredDependencies(packageJson))
-    .filter(([name]) => name.startsWith('@guren/'))
+  // The mirror of what the vendored modes assert, through the same predicate:
+  // if this mode ever degraded into one of them it would keep passing while
+  // checking nothing, so the local specs are asserted away rather than assumed
+  // absent. Re-run after scaffolding, since a blueprint is free to add a
+  // dependency and a local one would silently take the app off the registry.
+  const assertPublishedRanges = async (stage: string): Promise<[string, string][]> => {
+    const packageJson = JSON.parse(await readFile(join(appDir, 'package.json'), 'utf8')) as DependencyManifest
+    const gurenDependencies = Object.entries(declaredDependencies(packageJson))
+      .filter(([name]) => name.startsWith('@guren/'))
 
-  assert(gurenDependencies.length > 0, 'Scaffolded app declares no @guren/* dependencies to resolve from npm.')
-  for (const [name, range] of gurenDependencies) {
-    // The mirror of what the vendored modes assert, through the same predicate:
-    // if this mode ever degraded into one of them it would keep passing while
-    // checking nothing, so the local specs are asserted away rather than
-    // assumed absent.
     assert(
-      !isLocalSpecifier(range),
-      `npm install mode requires ${name} to keep its published range, got "${range}".`,
+      gurenDependencies.length > 0,
+      `Scaffolded app declares no @guren/* dependencies to resolve from npm (${stage}).`,
     )
+    for (const [name, range] of gurenDependencies) {
+      assert(
+        !isLocalSpecifier(range),
+        `npm install mode requires ${name} to keep its published range, got "${range}" (${stage}).`,
+      )
+    }
+    return gurenDependencies
   }
+
+  await assertPublishedRanges('as scaffolded')
 
   // The scaffolder already installed, but it only warns on failure — this is
   // the install whose exit code can fail the job.
   await run(['bun', 'install'], appDir, runtimeEnv)
 
+  const gurenDependencies = await assertPublishedRanges('after install')
   const resolved: string[] = []
   for (const [name, range] of gurenDependencies) {
     const installed = JSON.parse(
@@ -435,18 +535,85 @@ async function runPublishedDependencyDrift(
   }
   console.log(`\nResolved from npm:\n  ${resolved.join('\n  ')}`)
 
+  const scaffoldsFeatures = blueprint === 'default'
+  if (scaffoldsFeatures) {
+    await addDefaultBlueprintFeatures(appDir, runtimeEnv)
+    await assertPublishedRanges('after scaffolding features')
+    await run(['bun', 'install'], appDir, runtimeEnv)
+    // Reused from the vendored path rather than reinvented: these fail loudly
+    // if a blueprint stopped emitting what it claims to, which is what keeps
+    // the widened typecheck below from quietly shrinking back to a bare app.
+    await assertCanonicalScaffolds(appDir)
+    await assertFeatureScaffolds(appDir)
+  }
+
+  // Skipped for blog for the reason spelled out in its vendored branch below.
+  const runsCodegen = blueprint !== 'blog'
+
+  let checkedFiles: string[]
   try {
-    // Skipped for blog for the reason spelled out in its vendored branch below.
-    if (blueprint !== 'blog') {
+    if (runsCodegen) {
       await run(['bun', 'run', 'codegen'], appDir, runtimeEnv)
     }
-    await run(['bun', 'run', 'typecheck'], appDir, runtimeEnv)
+    checkedFiles = await typecheckApp(appDir, runtimeEnv)
   } catch (error) {
     console.error('\nThe scaffolded app does not build against the published packages listed above.')
     throw error
   }
 
-  console.log(`\nPublished dependency drift check passed (${blueprint}): ${appDir}`)
+  console.log([
+    '',
+    `Published dependency drift check passed (${blueprint}): ${appDir}`,
+    'What this run covered:',
+    `  blueprint            ${blueprint}`,
+    `  feature blueprints   ${scaffoldsFeatures
+      ? DEFAULT_BLUEPRINT_FEATURES.map((feature) => feature[0]).join(', ')
+      : `none — the ${blueprint} blueprint ships its own and adds no features`}`,
+    `  codegen              ${runsCodegen ? 'ran' : 'skipped — blog typechecks the .guren stubs it ships'}`,
+    `  typechecked          ${checkedFiles.length} app files (tsc --noEmit)`,
+    '  not covered          bun run build, bun test, guren check, guren audit — the vendored smoke owns those',
+  ].join('\n'))
+}
+
+/**
+ * Typecheck the app through its own `typecheck` script, and report which of its
+ * files tsc actually read.
+ *
+ * `--listFiles` rides along on the one compile rather than costing a second:
+ * the count is what tells a reader whether a green run proved anything, and a
+ * tsconfig that narrows — or an `include` entry that matches nothing, see
+ * assertGeneratedDirsAreTypechecked() — shrinks it visibly instead of silently.
+ * runCapture() is not reusable here because it discards stdout on failure, and
+ * stdout is where tsc writes its diagnostics.
+ */
+async function typecheckApp(appDir: string, runtimeEnv: Record<string, string>): Promise<string[]> {
+  const cmd = ['bun', 'run', 'typecheck', '--listFiles']
+  console.log(`\n$ (${appDir}) ${cmd.join(' ')}`)
+  const proc = Bun.spawn({
+    cmd,
+    cwd: appDir,
+    stdout: 'pipe',
+    stderr: 'inherit',
+    env: { ...process.env, ...runtimeEnv },
+  })
+  const output = await new Response(proc.stdout).text()
+  const exitCode = await proc.exited
+  if (exitCode !== 0) {
+    console.error(output)
+    throw new Error(`Command failed with exit code ${exitCode}: ${cmd.join(' ')}`)
+  }
+
+  const appPrefixes = [appDir, await realpath(appDir)]
+  const checkedFiles = output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => appPrefixes.some((prefix) => line.startsWith(`${prefix}/`)))
+    .filter((line) => !line.includes('/node_modules/'))
+  assert(
+    checkedFiles.length > 0,
+    'tsc read none of the app\'s own files — the scaffolded tsconfig covers nothing.',
+  )
+  return checkedFiles
 }
 
 function resolveInstallMode(): InstallMode {
@@ -463,11 +630,13 @@ function resolveInstallMode(): InstallMode {
 async function main(): Promise<void> {
   const installMode = resolveInstallMode()
 
-  // npm mode deliberately touches no build output of this checkout — the app
-  // it scaffolds is meant to be the one a user gets from the registry.
-  if (installMode !== 'npm') {
-    await ensureBuiltPackages()
-  }
+  // Every mode needs the workspace built. What npm mode keeps off this checkout
+  // is what the *app* resolves — its @guren/* come from the registry, and
+  // runPublishedDependencyDrift() asserts that on both sides of scaffolding.
+  // The scaffolder and the `guren add` blueprints are tools that emit the
+  // templates under test, and the CLI reaches @guren/server through dist/, so
+  // building them is what lets the gate fail rather than what weakens it.
+  await ensureBuiltPackages()
 
   const blueprint = process.env.GUREN_SMOKE_BLUEPRINT ?? 'default'
   const tempRoot = await mkdtemp(join(tmpdir(), `guren-fresh-app-${blueprint}-`))
@@ -494,6 +663,7 @@ async function main(): Promise<void> {
     await run(createArgs, repoRoot, runtimeEnv)
 
     await assertCoreFirstStarter(appDir)
+    await assertGeneratedDirsAreTypechecked(appDir)
 
     if (installMode === 'npm') {
       await runPublishedDependencyDrift(appDir, blueprint, runtimeEnv)
@@ -531,21 +701,7 @@ async function main(): Promise<void> {
 
     if (blueprint === 'default') {
       // Default blueprint: add all features
-      await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'auth'], appDir, runtimeEnv)
-      await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'resource', 'posts'], appDir, runtimeEnv)
-      await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'queue'], appDir, runtimeEnv)
-      // --force: `add auth` now also scaffolds app/Providers/MailProvider.ts
-      // (password reset needs a mail manager) — the mail blueprint's own,
-      // more complete MailProvider (memory transport, setMailManager wiring)
-      // intentionally supersedes it here so the assertions below can verify
-      // its shape.
-      await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'mail', '--force'], appDir, runtimeEnv)
-      await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'events'], appDir, runtimeEnv)
-      await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'cache'], appDir, runtimeEnv)
-      await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'notifications'], appDir, runtimeEnv)
-      await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'storage'], appDir, runtimeEnv)
-      await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'broadcasting'], appDir, runtimeEnv)
-      await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'schedule'], appDir, runtimeEnv)
+      await addDefaultBlueprintFeatures(appDir, runtimeEnv)
       await assertCoreFirstStarter(appDir, { checkDependencies: false })
       await assertCanonicalScaffolds(appDir)
       await assertFeatureScaffolds(appDir)

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -88,6 +88,13 @@ async function addDefaultBlueprintFeatures(
  * What goes unchecked is the generated files nothing imports (`data.gen.ts`,
  * `channels.gen.ts`, `translations.gen.ts`). Nothing at runtime tells the two
  * forms apart, so the form is pinned here.
+ *
+ * Scope, measured rather than assumed: naming the dot segment in the pattern is
+ * what rescues it, at any depth — `".guren/**\/*"` and `"types/.gen/**\/*"`
+ * both match. So this only has to reject the leading bare form. The case it
+ * cannot see is a dot-directory a *wildcard* would have to discover
+ * (`"types/**\/*"` silently skips `types/.gen/`); that is invisible in the
+ * tsconfig alone, and no template does it today.
  */
 async function assertGeneratedDirsAreTypechecked(appDir: string): Promise<void> {
   const include = (JSON.parse(await readFile(join(appDir, 'tsconfig.json'), 'utf8')) as {

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -35,12 +35,23 @@ const repoRoot = resolve(import.meta.dir, '../..')
 // to cover: every one of these emits template code importing @guren/core, and
 // a bare scaffold contains none of it.
 //
+// It cannot be *derived* from the CLI's registry — `resource` needs a name and
+// `mail` needs a flag, which a list of names cannot carry — so it is checked
+// against it instead, by assertCoversEveryBlueprint(). That every blueprint
+// appears here is not this list happening to be long: `admin` and `oauth` were
+// absent from every smoke in the tree until that check was written.
+//
+// admin and oauth after auth: `add admin` guards /admin and redirects to the
+// sign-in page `add auth` scaffolds.
+//
 // --force on mail: `add auth` also scaffolds app/Providers/MailProvider.ts
 // (password reset needs a mail manager) — the mail blueprint's own, more
 // complete MailProvider (memory transport, setMailManager wiring)
 // intentionally supersedes it, so the assertions can verify its shape.
 const DEFAULT_BLUEPRINT_FEATURES: readonly (readonly string[])[] = [
   ['auth'],
+  ['admin'],
+  ['oauth'],
   ['resource', 'posts'],
   ['queue'],
   ['mail', '--force'],
@@ -51,6 +62,31 @@ const DEFAULT_BLUEPRINT_FEATURES: readonly (readonly string[])[] = [
   ['broadcasting'],
   ['schedule'],
 ]
+
+/**
+ * Fail when the CLI grows a blueprint this smoke does not scaffold.
+ *
+ * The registry has a tripwire of its own — packages/cli/tests/blueprints.test.ts
+ * pins it to an exact list — which is precisely why this drift was silent:
+ * whoever adds a blueprint is routed there, updates that array, and nothing
+ * points back here. This is the pointer back.
+ *
+ * Imported dynamically because packages/cli/src/blueprints reaches
+ * @guren/server through untracked dist/. A top-level import would evaluate
+ * before main() runs ensureBuiltPackages(), turning a missing build into a
+ * module-resolution error instead of the message that names the fix.
+ */
+async function assertCoversEveryBlueprint(): Promise<void> {
+  const { listBlueprints } = await import('../../packages/cli/src/blueprints')
+  const covered = new Set(DEFAULT_BLUEPRINT_FEATURES.map(([name]) => name))
+  const missing = listBlueprints().filter((name) => !covered.has(name))
+  assert(
+    missing.length === 0,
+    `The default blueprint smoke does not scaffold: ${missing.join(', ')}. ` +
+      'Add them to DEFAULT_BLUEPRINT_FEATURES — a blueprint no smoke scaffolds ' +
+      'is template code no gate typechecks against the published packages.',
+  )
+}
 
 /**
  * Run the feature blueprints through *this checkout's* CLI.
@@ -75,39 +111,6 @@ async function addDefaultBlueprintFeatures(
       // warning describes the scaffolder, not the app under test; scoped to
       // these calls so a genuine duplicate in the app stays loud.
       { ...runtimeEnv, GUREN_QUIET_DUPLICATE_ORM: '1' },
-    )
-  }
-}
-
-/**
- * A tsconfig `include` entry naming a dot-prefixed directory on its own
- * (`".guren"`) matches no files: TypeScript expands the bare name to a
- * wildcard, and its wildcard matcher skips dot-prefixed path segments. The app
- * still typechecks, because every generated file something imports arrives
- * through the import graph anyway — which is exactly what hides the dead entry.
- * What goes unchecked is the generated files nothing imports (`data.gen.ts`,
- * `channels.gen.ts`, `translations.gen.ts`). Nothing at runtime tells the two
- * forms apart, so the form is pinned here.
- *
- * Scope, measured rather than assumed: naming the dot segment in the pattern is
- * what rescues it, at any depth — `".guren/**\/*"` and `"types/.gen/**\/*"`
- * both match. So this only has to reject the leading bare form. The case it
- * cannot see is a dot-directory a *wildcard* would have to discover
- * (`"types/**\/*"` silently skips `types/.gen/`); that is invisible in the
- * tsconfig alone, and no template does it today.
- */
-async function assertGeneratedDirsAreTypechecked(appDir: string): Promise<void> {
-  const include = (JSON.parse(await readFile(join(appDir, 'tsconfig.json'), 'utf8')) as {
-    include?: string[]
-  }).include ?? []
-  assert(include.length > 0, 'Scaffolded app tsconfig declares no include list.')
-  for (const entry of include) {
-    const segments = entry.split('/')
-    const named = segments[0] === '.' ? segments[1] : segments[0]
-    assert(
-      !named?.startsWith('.') || entry.includes('*'),
-      `Scaffolded app tsconfig includes "${entry}", which matches no files: ` +
-        `a bare dot-prefixed directory needs an explicit glob (e.g. "${named}/**/*").`,
     )
   }
 }
@@ -145,6 +148,10 @@ async function runCapture(cmd: string[], cwd: string, envOverrides?: Record<stri
   const output = await new Response(proc.stdout).text()
   const exitCode = await proc.exited
   if (exitCode !== 0) {
+    // Piped stdout is the diagnostic for anything that reports there rather
+    // than on stderr — `tsc` writes every error to stdout — so a failure has
+    // to hand it back before throwing, or the log shows only the exit code.
+    console.error(output)
     throw new Error(`Command failed with exit code ${exitCode}: ${cmd.join(' ')}`)
   }
   return output
@@ -583,43 +590,45 @@ async function runPublishedDependencyDrift(
 }
 
 /**
- * Typecheck the app through its own `typecheck` script, and report which of its
- * files tsc actually read.
+ * Typecheck the app through its own `typecheck` script, and assert tsc actually
+ * read the files it was supposed to.
  *
- * `--listFiles` rides along on the one compile rather than costing a second:
- * the count is what tells a reader whether a green run proved anything, and a
- * tsconfig that narrows — or an `include` entry that matches nothing, see
- * assertGeneratedDirsAreTypechecked() — shrinks it visibly instead of silently.
- * runCapture() is not reusable here because it discards stdout on failure, and
- * stdout is where tsc writes its diagnostics.
+ * `--listFiles` rides along on the one compile rather than costing a second,
+ * and it is what makes this an *outcome* check rather than a claim about
+ * tsconfig syntax. The bug it exists for: `"include": [".guren"]` matches no
+ * files, because TypeScript expands a bare directory name to a wildcard and its
+ * wildcard matcher skips dot-prefixed segments. Generated files something
+ * imports still arrive through the import graph — which is exactly what hides
+ * it — so the ones nothing imports are the tell. Asking tsc which files it read
+ * catches every reformulation of that mistake, not just the one spelling a
+ * syntax check could reject.
  */
 async function typecheckApp(appDir: string, runtimeEnv: Record<string, string>): Promise<string[]> {
-  const cmd = ['bun', 'run', 'typecheck', '--listFiles']
-  console.log(`\n$ (${appDir}) ${cmd.join(' ')}`)
-  const proc = Bun.spawn({
-    cmd,
-    cwd: appDir,
-    stdout: 'pipe',
-    stderr: 'inherit',
-    env: { ...process.env, ...runtimeEnv },
-  })
-  const output = await new Response(proc.stdout).text()
-  const exitCode = await proc.exited
-  if (exitCode !== 0) {
-    console.error(output)
-    throw new Error(`Command failed with exit code ${exitCode}: ${cmd.join(' ')}`)
-  }
+  const output = await runCapture(['bun', 'run', 'typecheck', '--listFiles'], appDir, runtimeEnv)
 
-  const appPrefixes = [appDir, await realpath(appDir)]
+  // tsc reports realpaths, and macOS hands out a /var -> /private/var symlink
+  // for the temp dir, so compare against the resolved prefix.
+  const appRoot = await realpath(appDir)
   const checkedFiles = output
     .split('\n')
     .map((line) => line.trim())
-    .filter((line) => appPrefixes.some((prefix) => line.startsWith(`${prefix}/`)))
-    .filter((line) => !line.includes('/node_modules/'))
+    .filter((line) => line.startsWith(`${appRoot}/`) && !line.includes('/node_modules/'))
+    .map((line) => line.slice(appRoot.length + 1))
   assert(
     checkedFiles.length > 0,
-    'tsc read none of the app\'s own files — the scaffolded tsconfig covers nothing.',
+    "tsc read none of the app's own files — the scaffolded tsconfig covers nothing.",
   )
+
+  const generated = (await readdir(join(appDir, '.guren')).catch(() => [] as string[]))
+    .filter((name) => name.endsWith('.gen.ts'))
+  const unchecked = generated.filter((name) => !checkedFiles.includes(join('.guren', name)))
+  assert(
+    unchecked.length === 0,
+    `tsc never read ${unchecked.map((name) => `.guren/${name}`).join(', ')} — ` +
+      "the app's tsconfig does not cover its own generated files. A bare " +
+      '".guren" include entry is the usual cause; it needs an explicit glob.',
+  )
+
   return checkedFiles
 }
 
@@ -644,6 +653,7 @@ async function main(): Promise<void> {
   // templates under test, and the CLI reaches @guren/server through dist/, so
   // building them is what lets the gate fail rather than what weakens it.
   await ensureBuiltPackages()
+  await assertCoversEveryBlueprint()
 
   const blueprint = process.env.GUREN_SMOKE_BLUEPRINT ?? 'default'
   const tempRoot = await mkdtemp(join(tmpdir(), `guren-fresh-app-${blueprint}-`))
@@ -670,7 +680,6 @@ async function main(): Promise<void> {
     await run(createArgs, repoRoot, runtimeEnv)
 
     await assertCoreFirstStarter(appDir)
-    await assertGeneratedDirsAreTypechecked(appDir)
 
     if (installMode === 'npm') {
       await runPublishedDependencyDrift(appDir, blueprint, runtimeEnv)
@@ -742,7 +751,7 @@ async function main(): Promise<void> {
     // Worker blueprint has a known scaffold export mismatch (named vs default).
     // TODO: fix blueprint templates to use consistent exports, then remove this skip.
     if (blueprint !== 'worker') {
-      await run(['bun', 'run', 'typecheck'], appDir, runtimeEnv)
+      await typecheckApp(appDir, runtimeEnv)
     }
 
     // Worker blueprint: skip Vite build (scaffold-only validation is sufficient)


### PR DESCRIPTION
## Summary

The `Published Package Drift` workflow was doing real work, but on a much
smaller app than it appeared to. `runPublishedDependencyDrift()` typechecked a
bare scaffold — 15 files — and returned before the `guren add` feature
blueprints. Those blueprints live in `packages/cli/src/blueprints.ts` and
`make-auth.ts`, are ordinary source in this checkout, and emit most of an app's
`@guren/core` imports, so they drift ahead of the registry exactly like the base
template with nothing watching.

A paired mutation test is what settled it. Before this change:

| Mutation | Result |
| --- | --- |
| Bogus `@guren/core` import in `templates/default` | 🔴 red |
| The same import in a `blueprints.ts` feature | 🟢 **green** |

Both are red now.

Worth stating plainly, because it shaped the fix: the gate was **not**
short-circuiting. Run `32447832064` installed 285 packages from npm in 2.1s and
ran `tsc` for 2.2s, and it resolved `@guren/cli@2.8.0` / `@guren/core@1.8.0` —
both behind the workspace, which only the registry can produce. The 4-7s
durations were a fast runner on a tiny app. The gate was narrow, not vacuous.

### What changed

- **npm mode scaffolds the feature blueprints**, through *this checkout's* CLI.
  Which CLI decides whether the gate can fail at all: the app's own installed
  `guren` ships the published blueprints, so using it would emit published
  templates against published packages — consistent by construction. Templates
  from here, dependencies from the registry, is the mismatch being measured.
  The feature list is shared with the vendored path so the two cannot drift.
- **The list is cross-checked against `listBlueprints()`.** It cannot be
  derived (`resource` needs a name, `mail` a flag), and it was already two
  behind: `admin` and `oauth` appeared in no smoke in the tree. `blueprints.ts`
  has its own tripwire in `packages/cli/tests/blueprints.test.ts`, which is
  exactly why this was silent — whoever adds a blueprint is routed there and
  nothing pointed back at the smoke. This is the pointer back.
- **`typecheckApp()` asserts an outcome, not a config shape.** `--listFiles`
  rides along on the one compile, and the check is that tsc actually read every
  `.guren/*.gen.ts`. The vendored path calls it too, so it runs per PR — and
  that is the lane whose codegen actually produces those files.
- **Each run prints what it covered**: blueprint, features, whether codegen ran,
  files typechecked, and what it deliberately does not run.
- **`runCapture()` no longer swallows stdout on failure.** That was wrong for
  every caller — a failing `npm pack` lost its output too — and fixing it let
  `typecheckApp()` drop a hand-rolled capturing spawn.
- **Workflow** switched to `./.github/actions/setup-and-build`: the CLI reaches
  `@guren/server` through `dist/`. What stays off this checkout is what the
  *app* resolves, asserted on both sides of scaffolding.
- **`timeout-minutes` 30 → 15**, now that the measurement means something.
  #518 set 30 deliberately underived for this exact reason.

### Template tsconfig bug found on the way

`"include": [".guren"]` in the default template matched **no files**: TypeScript
expands a bare directory name to a wildcard and its matcher skips dot-prefixed
segments. Generated files something imports still arrived through the import
graph — which is what hid it — so `data.gen.ts`, `channels.gen.ts` and
`translations.gen.ts` were never typechecked, in every scaffolded app rather
than only here. `config/`, `bin/`, `tests/`, `drizzle.config.ts` and
`vite.config.ts` were outside the list too. The api-only template already used
the explicit-glob form; the default template now matches it.

Coverage went from 15 files to 82 for the default blueprint.

## Scope

`cli` (smoke scripts), `create-app` (template tsconfig), CI workflow. No
framework runtime code.

## Risk Assessment

- **User-visible:** `bun run typecheck` in a newly scaffolded app now reads more
  files. Verified clean against the published packages for default, blog and
  api. Carries a `create-guren-app` changeset.
- **CI cost:** the drift job now builds the workspace. Measured on
  `build-and-test`, which shares the dist cache: 4-11s on a hit, 58-78s on a
  miss.
- **Known gap left open:** `tests/**/*` is covered in the default template but
  not api-only. Covering it surfaced a real defect that this branch cannot fix —
  `@guren/testing` types `TestApp.create`'s `providers` option as
  `new (...args: unknown[]) => ProviderLike`, which is contravariant, so no
  actual `ServiceProvider` subclass satisfies it, and the api-only starter's own
  test uses that documented API. npm mode resolves that type from the registry,
  so widening before the fix ships would only make the starter smokes red. The
  changeset records the reason.
- **Pre-existing, untouched:** `worker` remains absent from the drift matrix
  (named-vs-default export mismatch).

## Validation

Mutation-tested — both new guards fail when they should:

```
error: The default blueprint smoke does not scaffold: oauth. ...
error: tsc never read .guren/translations.gen.ts, .guren/data.gen.ts, .guren/channels.gen.ts ...
```

Smokes, all green: `smoke:starter:npm` 21s / `:npm:api` 13s / `:npm:blog` 17s,
`smoke:starter` 30s, `:api` 21s, `:blog` 25s, `:worker` 21s, `:packed` 20s.

Audits, all green: `audit:starter-template`, `core-first`, `docs`,
`template-deps`, `workspace-scripts`, `contracts`, `deps`, `core-semver`,
`plugin-compat`. `scripts/workflow-timeout.test.ts` passes.

- [x] `bun run build`
- [x] `bun run typecheck`
- [ ] `bun run test` — `test:bun` is red on this machine, identically at
      `origin/main`: `Storage directory not found: packages/cli/tests/.test-storage-link/...`.
      Pre-existing and unrelated; `create-guren-app` passes 71/0 in isolation.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
