### PR TITLE
fix(testing): accept real ServiceProvider subclasses in TestApp providers

### DIFF
--- a/.changeset/olive-donkeys-tickle.md
+++ b/.changeset/olive-donkeys-tickle.md
@@ -1,0 +1,20 @@
+---
+'@guren/testing': patch
+---
+
+Let `TestApp.create({ providers })` accept a real `ServiceProvider` subclass.
+
+The option was typed `new (...args: unknown[]) => ProviderLike`. Constructor
+parameters are contravariant and `ServiceProvider`'s constructor takes a
+concrete `Container`, so `unknown` was not assignable to it and *no* provider
+class satisfied the type — passing one produced `error TS2322: Type 'typeof
+DatabaseProvider' is not assignable to type 'ProviderConstructor'`. The
+api-only starter template ships a test file that uses the documented API and
+did not typecheck because of it.
+
+The parameters are now `any[]`, which is what a constructor-shape type needs
+in order to be assignable from a constructor that takes anything at all. It
+stays structural rather than reusing `@guren/server`'s
+`ServiceProviderConstructor`, so the published `.d.ts` needs nothing to
+resolve: an app that only depends on `@guren/core` would otherwise widen the
+option to `any` under `skipLibCheck` and check nothing at all.

--- a/packages/testing/src/test-app.providers.test.ts
+++ b/packages/testing/src/test-app.providers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import type { Container, ServiceProviderConstructor } from '@guren/server'
+import type { TestAppOptions } from './test-app'
+
+/**
+ * Mirrors a scaffolded `app/Providers/DatabaseProvider.ts`: an ordinary
+ * `ServiceProvider` subclass, whose inherited constructor takes a concrete
+ * `Container`. That parameter is the whole point of this file — constructor
+ * parameters are contravariant, so an option typed
+ * `new (...args: unknown[]) => ...` rejects it, and the api-only starter's
+ * own test file stopped typechecking.
+ *
+ * Written structurally, against a type-only `Container` import, so the check
+ * is pure `tsc` and needs no built `@guren/server` at runtime.
+ */
+class DatabaseProvider {
+  constructor(protected container: Container) {}
+
+  register(): void {}
+
+  async boot(): Promise<void> {}
+}
+
+describe('TestAppOptions.providers', () => {
+  it('accepts an ordinary ServiceProvider subclass', () => {
+    // The assignability *is* the assertion: this file fails `tsc --noEmit`
+    // if `providers` narrows back to a constructor taking `unknown` args.
+    const options: TestAppOptions = { providers: [DatabaseProvider] }
+
+    expect(options.providers).toEqual([DatabaseProvider])
+  })
+
+  it('accepts the constructor type the framework hands around', () => {
+    // Every plugin factory returns this type (`definePlugin`), so it has to
+    // fit the option too, not just hand-written subclasses.
+    const providers: TestAppOptions['providers'] = [] as ServiceProviderConstructor[]
+
+    expect(providers).toEqual([])
+  })
+})

--- a/packages/testing/src/test-app.ts
+++ b/packages/testing/src/test-app.ts
@@ -4,7 +4,20 @@ import { TestResponse } from './http'
 
 type BootCallback = (app: Hono) => void | Promise<void>
 type ProviderLike = { register?(): unknown; boot?(): unknown }
-type ProviderConstructor = new (...args: unknown[]) => ProviderLike
+/**
+ * Constructor shape for a provider class passed to `TestApp.create()`.
+ *
+ * The parameters are `any[]`, not `unknown[]`: constructor parameters are
+ * contravariant, so `unknown[]` rejects every real `ServiceProvider`
+ * subclass — their inherited constructor takes a concrete `Container`.
+ *
+ * It stays structural rather than reusing `@guren/server`'s
+ * `ServiceProviderConstructor` so the published `.d.ts` needs nothing to
+ * resolve: an app that only depends on `@guren/core` would otherwise widen
+ * this to `any` under `skipLibCheck` and check nothing at all.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ProviderConstructor = new (...args: any[]) => ProviderLike
 type RouteRegistration = (router: Router) => void | Promise<void>
 type ApplicationLike = {
   boot(): Promise<void>


### PR DESCRIPTION
## Summary

`TestApp.create({ providers })` typed its option as `new (...args: unknown[]) => ProviderLike`. Constructor parameters are contravariant and `ServiceProvider`'s constructor takes a concrete `Container`, so `unknown` was not assignable to it and **no** provider class satisfied the type. Passing one produced:

```
error TS2322: Type 'typeof DatabaseProvider' is not assignable to type 'ProviderConstructor'.
  Types of construct signatures are incompatible.
    Type 'new (container: Container) => DatabaseProvider' is not assignable to type 'new (...args: unknown[]) => ProviderLike'.
```

This was not hypothetical: the api-only starter template ships `tests/app.test.ts`, which uses the documented API, and it is why that template's `tsconfig.json` still omits `tests/**/*` (see the note in `.changeset/wide-pandas-smell.md`, added by #520).

The parameters are now `any[]` — what a constructor-shape type needs in order to accept a constructor that takes anything at all.

### Why it stays structural rather than importing `ServiceProviderConstructor`

`@guren/server` already exports exactly this type, and `test-app.ts` already type-imports from that package, so reusing it looks like the tidier fix. It is not, and the failure mode is silent.

TypeScript resolves the *realpath* of a `.d.ts` before looking up its imports. A scaffolded api-only app depends on `@guren/core` only — `@guren/server` arrives through hoisting — so from the resolved location of the published declaration file the lookup can fail. Measured directly against a scaffolded app: when `@guren/server` does not resolve from there, `@guren/core`'s `export * from '@guren/server'` collapses and even `ServiceProvider` stops being an exported member. With `skipLibCheck: true` (both templates set it) the nearer failure mode is quieter still — the option widens toward `any` and checks nothing, so the api-only typecheck would pass for the wrong reason.

The structural form needs nothing to resolve and cannot degrade. The reasoning is recorded at the declaration site.

## Scope

- `testing` — `packages/testing/src/test-app.ts`, plus a new `packages/testing/src/test-app.providers.test.ts`
- changeset for `@guren/testing` (patch)

No template or CI changes.

## Risk Assessment

Type-level only; no runtime behavior changes. Strictly widening — every call that compiled before still compiles.

`@guren/testing` is a `devDependency` of the starter templates, and `smoke:starter:npm:api` resolves it from the npm registry. **Re-adding `"tests/**/*"` to the api-only template's tsconfig therefore has to wait for the release that publishes this patch**, and is deliberately not part of this PR — doing it early would make the Published Package Drift gate red for a reason that gate is not meant to report. It is tracked as a follow-up.

## Validation

Verified end-to-end at the published-`.d.ts` level, not just in-repo: scaffolded an api-only app, vendored the local builds through `scripts/smoke/local-packages.ts`, and added `"tests/**/*"` to *that scratch app's* tsconfig.

- With `unknown[]`: **red**, reproducing both reported errors verbatim at `tests/app.test.ts` lines 10 and 19.
- With `any[]`: **green**.

The same mutation was run against the in-repo regression test, which fails on both of its assertions when the alias is reverted — the test can fail.

- [x] `bun run build`
- [x] `bun run typecheck` — clean (examples need `bun run codegen` first in a fresh worktree)
- [x] `bun run test:testing` — 13 files, 173 passed
- [x] `bun run smoke:starter:api` — passed. Note this smoke does **not** verify the fix: the template's `include` still omits `tests/`, so `tests/app.test.ts` is never typechecked, and the app's own `bun test` exercises `providers` at runtime, where the bug never existed. It is a no-regression guard on the `@guren/testing` build.

`bun run test:bun` is red on the authoring machine with `Storage directory not found: packages/cli/tests/.test-storage-link/storage/app/public`. It is unrelated and cannot be caused by this change — `@guren/testing` is not in `test:bun`'s package list at all, and `bun run test:bun cli` alone is 1659 pass / 0 fail. It looks like the parallel runner racing that shared fixture path.

## Notes for the reviewer

The regression test deliberately gives its fixture a **required** `Container` constructor parameter. A no-argument fake is assignable to the broken type too, so it would have passed before and after and proved nothing. The test also asserts that `ServiceProviderConstructor[]` itself fits the option, so plugin factories (`definePlugin`) stay covered. Both imports are type-only, so the file needs no built `@guren/server` at runtime.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
