### PR TITLE
fix(create-app): cover tests/ in the api-only template's include

### DIFF
--- a/.changeset/olive-moons-invite.md
+++ b/.changeset/olive-moons-invite.md
@@ -1,0 +1,18 @@
+---
+'create-guren-app': patch
+---
+
+Cover `tests/` in the api-only template's TypeScript `include`.
+
+The api-only starter ships `tests/app.test.ts`, and it was the one file the
+template's own `typecheck` script never read. That was deliberate: the test
+passes `providers: [DatabaseProvider]` to `TestApp.create()`, and
+`@guren/testing` typed that parameter as `new (...args: unknown[]) => ProviderLike`
+— a shape no real `ServiceProvider` subclass satisfies, because constructor
+parameters are contravariant and the inherited constructor takes a concrete
+`Container`. Widening the include before that was fixed would only have made
+the starter smokes red.
+
+`@guren/testing@1.6.1` fixes it, so the include can now cover what it always
+should have. The default template already listed `tests/`; the two templates
+agree again.

--- a/packages/create-app/templates/api-only/tsconfig.json
+++ b/packages/create-app/templates/api-only/tsconfig.json
@@ -15,6 +15,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": [".guren/**/*", "src/**/*", "app/**/*", "routes/**/*", "config/**/*", "db/**/*", "bin/**/*", "*.ts"],
+  "include": [".guren/**/*", "src/**/*", "app/**/*", "routes/**/*", "config/**/*", "db/**/*", "bin/**/*", "tests/**/*", "*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
The api-only starter ships `tests/app.test.ts`, and it was the one file the template's own `typecheck` script never read.

That was deliberate. The test passes `providers: [DatabaseProvider]` to `TestApp.create()`, and `@guren/testing` typed that parameter as `new (...args: unknown[]) => ProviderLike` — a shape no real `ServiceProvider` subclass satisfies, because constructor parameters are contravariant and the inherited constructor takes a concrete `Container`. Widening the include before that was fixed would only have made the starter smokes red.

#522 fixed it and it shipped in `@guren/testing@1.6.1` (v2.10.1), so the include can now cover what it always should have. The default template already listed `tests/`; the two templates agree again.

### Verification

`smoke:starter:api` asserts that tsc read the app's `.guren/*.gen.ts` files — it says nothing about `tests/`. So its green proves nothing broke, not that this change works. The causal evidence is a scaffolded api-only app driven by hand, with both mutations:

| Condition | `tsc` reads `tests/app.test.ts` | `tsc --noEmit` |
|---|---|---|
| this branch + `@guren/testing@1.6.1` | yes | passes |
| `include` reverted | **no** — 0 test files | passes vacuously |
| `@guren/testing` downgraded to 1.6.0 | yes | **`tests/app.test.ts(10,19): error TS2322`** |

The downgrade reproduces the original failure exactly:

```
tests/app.test.ts(10,19): error TS2322: Type 'typeof DatabaseProvider' is not assignable to type 'ProviderConstructor'.
  Types of construct signatures are incompatible.
    Type 'new (container: Container) => DatabaseProvider' is not assignable to type 'new (...args: unknown[]) => ProviderLike'.
      Types of parameters 'container' and 'args' are incompatible.
        Type 'unknown' is not assignable to type 'Container'.
```

Also run against this branch:

- `bun run smoke:starter:api` — passes
- `GUREN_SMOKE_INSTALL_MODE=npm GUREN_SMOKE_BLUEPRINT=api bun run ./scripts/smoke/fresh-app.ts` — passes, resolving `@guren/testing@1.6.1 (declared ^1.6.1)` from the registry
- `bun run audit:starter-template` — passes
- `bun run typecheck` (root + scaffold templates + blog + api), `bun run test:bun create-app` (71 pass), `audit:core-first`, `audit:docs`, `audit:template-deps`, `audit:core-semver`, `audit:plugin-compat`

Neither smoke nor the starter-template audit reads `.changeset/`, so the smoke runs predate the changeset file only.