### PR TITLE
fix(cli): recognize every spelling of a root baseUrl in doctor

### DIFF
--- a/.changeset/wise-eels-smile.md
+++ b/.changeset/wise-eels-smile.md
@@ -1,0 +1,12 @@
+---
+'@guren/cli': patch
+---
+
+Recognize every spelling of a project-root `baseUrl` in `guren doctor`
+
+The tsconfig alias check compared `baseUrl` against the literals `"."` and
+`"./"`, so a root `baseUrl` written any other way — an absolute path equal to
+the project root, `"./."`, or `""` — fell into the "repoints the alias" branch.
+That reported the wrong cause and turned the autofix off, leaving behind a
+`baseUrl` TypeScript 7 rejects (TS5102). The comparison now resolves both paths
+instead of enumerating spellings.

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -439,7 +439,15 @@ async function detectTsconfig(context: DoctorRuleContext): Promise<DoctorCheck> 
 // `baseUrl` is reported as something to remove, never written.
 const TSCONFIG_ALIAS_FIX = 'Set `"paths": { "@/*": ["./*"] }` in compilerOptions and remove `baseUrl` so `@/.guren/*` and `@/app/*` imports resolve on every TypeScript version.'
 
-const isRootBaseUrl = (baseUrl: string | undefined): boolean => baseUrl === '.' || baseUrl === './'
+// Compares resolved paths rather than enumerating spellings: `.`, `./`, `./.`,
+// `''`, and an absolute path equal to the project root all name the same
+// directory, and a literal list silently drops the ones it forgot into the
+// "repoints the alias" branch — a wrong message plus a `baseUrl` TypeScript 7
+// rejects, left in place because the autofix declined to touch it. The
+// `typeof` guard keeps a malformed tsconfig (`"baseUrl": 1`) a warn instead of
+// a `resolve()` TypeError, and covers the omitted case in the same expression.
+const isRootBaseUrl = (cwd: string, baseUrl: unknown): boolean =>
+  typeof baseUrl === 'string' && resolve(cwd, baseUrl) === resolve(cwd)
 
 async function detectTsconfigAlias(context: DoctorRuleContext): Promise<DoctorCheck> {
   const tsconfig = await readJsonIfExists<TsconfigShape>(context.cwd, 'tsconfig.json')
@@ -453,7 +461,7 @@ async function detectTsconfigAlias(context: DoctorRuleContext): Promise<DoctorCh
   const baseUrl = compilerOptions?.baseUrl
   // Path mappings resolve relative to baseUrl (or the tsconfig directory when
   // baseUrl is omitted), so `./*` only means "project root" for a root baseUrl.
-  const baseUrlIsRoot = baseUrl === undefined || isRootBaseUrl(baseUrl)
+  const baseUrlIsRoot = baseUrl === undefined || isRootBaseUrl(context.cwd, baseUrl)
   const targetsRoot = aliasTargets.some((target) => target === './*' || target === '*')
   const mapsToRoot = targetsRoot && baseUrlIsRoot
   const ok = mapsToRoot && baseUrl === undefined
@@ -496,7 +504,7 @@ async function createTsconfigAliasAutofix(_context: DoctorRuleContext, check: Do
 
       const nextConfig = { ...current.value }
       const compilerOptions = { ...nextConfig.compilerOptions }
-      if (isRootBaseUrl(compilerOptions.baseUrl)) {
+      if (isRootBaseUrl(cwd, compilerOptions.baseUrl)) {
         delete compilerOptions.baseUrl
       }
       compilerOptions.paths = { ...compilerOptions.paths }

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -761,6 +761,88 @@ describe('runDoctor', () => {
     }
   })
 
+  // A root `baseUrl` has more than one spelling. These reach the same
+  // `mapsToRoot` branch as `"."` above, so they must warn with the TS5102
+  // message and autofix; a literal comparison drops them into the "repoints
+  // the alias" branch, which reports the wrong cause and refuses to fix it.
+  it.each([
+    ['an absolute path equal to the project root', (dir: string) => dir],
+    ['a redundant `./.`', () => './.'],
+    // Whatever an older TypeScript made of `""`, TS7 rejects `baseUrl` for
+    // any value, so warn-and-remove is the outcome either way.
+    ['an empty string', () => ''],
+  ])('warns on a root baseUrl written as %s and the autofix removes it', async (_label, buildBaseUrl) => {
+    const workspace = await createTempWorkspace('guren-cli-doctor-alias-root-baseurl-alt-')
+
+    try {
+      await writeFile(
+        join(workspace.dir, 'package.json'),
+        JSON.stringify({ name: 'doctor-alias-root-baseurl-alt' }, null, 2),
+        'utf8',
+      )
+      await writeFile(
+        join(workspace.dir, 'tsconfig.json'),
+        JSON.stringify({
+          // Derived from `workspace.dir` — the same string passed as `cwd`
+          // below. A realpath would add macOS's `/private` prefix to one side
+          // of the comparison only.
+          compilerOptions: { baseUrl: buildBaseUrl(workspace.dir), paths: { '@/*': ['./*'] } },
+          include: ['.guren/**/*'],
+        }, null, 2),
+        'utf8',
+      )
+
+      const report = await runDoctor({ cwd: workspace.dir, json: true })
+      const aliasCheck = report.checks.find((check) => check.key === 'tsconfig-alias')
+
+      expect(aliasCheck?.status).toBe('warn')
+      expect(aliasCheck?.message).toContain('TS5102')
+      expect(aliasCheck?.canAutofix).toBe(true)
+
+      const { evaluations } = await getDoctorRuleEvaluations({ cwd: workspace.dir })
+      const aliasEval = evaluations.find((evaluation) => evaluation.check.key === 'tsconfig-alias')
+      await aliasEval!.autofix!.apply(workspace.dir)
+
+      const tsconfig = JSON.parse(await Bun.file(join(workspace.dir, 'tsconfig.json')).text()) as {
+        compilerOptions: { baseUrl?: string; paths?: Record<string, string[]> }
+      }
+
+      expect(tsconfig.compilerOptions.baseUrl).toBeUndefined()
+      expect(tsconfig.compilerOptions.paths?.['@/*']).toEqual(['./*'])
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+  it('warns instead of crashing on a non-string baseUrl', async () => {
+    // The root-baseUrl comparison resolves paths, and `resolve()` throws on a
+    // non-string. A hand-edited tsconfig has to stay a warn, not take down the
+    // whole doctor run.
+    const workspace = await createTempWorkspace('guren-cli-doctor-alias-baseurl-nonstring-')
+
+    try {
+      await writeFile(
+        join(workspace.dir, 'package.json'),
+        JSON.stringify({ name: 'doctor-alias-baseurl-nonstring' }, null, 2),
+        'utf8',
+      )
+      await writeFile(
+        join(workspace.dir, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: { baseUrl: 1, paths: { '@/*': ['./*'] } },
+          include: ['.guren/**/*'],
+        }, null, 2),
+        'utf8',
+      )
+
+      const report = await runDoctor({ cwd: workspace.dir, json: true })
+      const aliasCheck = report.checks.find((check) => check.key === 'tsconfig-alias')
+
+      expect(aliasCheck?.status).toBe('warn')
+      expect(aliasCheck?.canAutofix).toBe(false)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
   it('warns when a custom baseUrl repoints a root @/* mapping', async () => {
     const workspace = await createTempWorkspace('guren-cli-doctor-alias-baseurl-')
 


### PR DESCRIPTION
## Summary

Follow-up to #521 (TypeScript 7 migration).

`guren doctor` warns when a tsconfig sets `baseUrl`, because TypeScript 7 rejects the option outright (TS5102), and offers an autofix that removes it when the `@/*` mapping already points at the project root. The check decided "this `baseUrl` names the project root" by comparing against two literals:

```ts
const isRootBaseUrl = (baseUrl: string | undefined): boolean => baseUrl === '.' || baseUrl === './'
```

A root `baseUrl` written any other way — an absolute path equal to the project root, `"./."`, or `""` — fell through to the "a custom `baseUrl` repoints the alias" branch instead. Two consequences, both wrong:

1. The message claims the alias resolves under some other directory, when it resolves exactly where the user wanted.
2. `canAutofix` goes false, so `guren doctor --fix` / `guren upgrade` leave behind a `baseUrl` that TypeScript 7 refuses to load.

Resolve both paths instead of enumerating spellings:

```ts
const isRootBaseUrl = (cwd: string, baseUrl: unknown): boolean =>
  typeof baseUrl === 'string' && resolve(cwd, baseUrl) === resolve(cwd)
```

Two details worth flagging for review:

- **The parameter is `unknown`, not `string | undefined`.** tsconfig is JSON, so `"baseUrl": 1` is reachable from a hand-edited file. Under the old literal comparison that was a harmless `false`; `resolve()` would throw a `TypeError` and take the whole doctor run down with it. The `typeof` guard also covers the omitted case in the same expression, which matters because the autofix calls this predicate directly, without the caller-side `baseUrl === undefined` short-circuit that the detection path has.
- **The `baseUrl === undefined` comparisons stay strict.** Loosening either one to `!baseUrl` would classify `""` as "no baseUrl set" and silently pass it. That strictness is what makes `""` a warn.

The three states the check distinguishes are unchanged: `baseUrl` absent = pass, `baseUrl` naming the project root = warn + autofix, `baseUrl` naming another directory = warn without autofix.

## Scope

`cli` — `packages/cli/src/doctor.ts` and its tests. Changeset: `@guren/cli` patch.

`isRootBaseUrl` is the only home for this rule; `grep -rn baseUrl packages/cli/src packages/create-app/src` turns up no second implementation, and `guren upgrade` reaches the same predicate through `getDoctorRuleEvaluations` rather than carrying its own copy. The scaffold tsconfig templates emit no `baseUrl`, so freshly created apps were never affected — this only reaches apps scaffolded before the option was dropped from the template, plus anyone who set it by hand.

## Risk Assessment

Strictly widens what the existing warn and autofix recognize. No tsconfig that passed before now warns, and no `baseUrl` that was previously left alone is now removed unless it genuinely resolves to the project root — in which case removing it is a no-op for resolution, since `paths` resolves from the tsconfig directory either way.

New coupling worth noting: detection computes `canAutofix` from `context.cwd` while the autofix re-derives the same judgment from its own `apply(cwd)` argument. If those two ever disagreed, the check would advertise an autofix that then declined to remove the `baseUrl`, silently. They cannot: `packages/cli/src/upgrade.ts:407-418` feeds one `cwd` local to both `getDoctorRuleEvaluations({ cwd })` and `autofix.apply(cwd)`.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck` — green (root, incl. `check-build-configs`, scaffold templates, `examples/blog`, `examples/api`)
- [x] `bun run test` — `5021 pass / 0 fail` across 293 files

Each new test was mutation-checked rather than just observed passing:

- Reverting `isRootBaseUrl` to the literal comparison (keeping the two-arg signature, so only the comparison changes) turns the three new root-spelling cases red and nothing else.
- Dropping the `typeof` guard turns three cases red: the new non-string case plus two pre-existing autofix tests, which is the direct evidence that the guard is what protects the autofix path for a tsconfig with no `baseUrl` at all.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation — no user-facing docs describe this predicate; the reasoning is a comment at the call site.
