### PR TITLE
fix(cli): stop casting record columns in scaffolded resources

### DIFF
--- a/.changeset/resource-payload-type-parameter.md
+++ b/.changeset/resource-payload-type-parameter.md
@@ -1,0 +1,25 @@
+---
+"@guren/server": minor
+"@guren/core": minor
+---
+
+Let a Resource declare its payload type, so `toJSON()` reports it
+
+`Resource<T>` now takes an optional second type argument for the payload
+`toArray()` builds:
+
+```ts
+export class PostResource extends Resource<PostRecord, PostResourceData> {
+  toArray(): PostResourceData {
+    return { id: this.resource.id, title: this.resource.title }
+  }
+}
+```
+
+`toJSON()` returns `PostResourceData` instead of `Record<string, unknown>`,
+which removes the override every scaffolded resource used to carry — a method
+whose only body was `return super.toJSON() as PostResourceData`, a cast nothing
+checked against the `toArray()` right above it.
+
+The parameter defaults to `ResourceData`, so `Resource<T>` and existing
+overrides keep compiling unchanged. `JsonResource<T>` now reports `T`.

--- a/.changeset/resource-payload-type-parameter.md
+++ b/.changeset/resource-payload-type-parameter.md
@@ -22,4 +22,10 @@ whose only body was `return super.toJSON() as PostResourceData`, a cast nothing
 checked against the `toArray()` right above it.
 
 The parameter defaults to `ResourceData`, so `Resource<T>` and existing
-overrides keep compiling unchanged. `JsonResource<T>` now reports `T`.
+overrides keep compiling unchanged. `JsonResource<T>` deliberately stays on the
+default: narrowing it to `T` would reject a subclass whose `toArray()` returns a
+subset, which is a break no minor should carry.
+
+`TData` describes `toArray()`. `additional()` still takes arbitrary
+`ResourceData` and is spread after the payload, so a colliding key can still
+overwrite a typed field — use it for keys beside the payload, not inside it.

--- a/.changeset/scaffolded-resources-drop-casts.md
+++ b/.changeset/scaffolded-resources-drop-casts.md
@@ -1,0 +1,23 @@
+---
+"@guren/cli": minor
+"create-guren-app": minor
+---
+
+Stop casting record columns in scaffolded resources
+
+`make:feature`, `guren add resource` and `make:resource` wrote
+`id: this.resource.id as number` and `title: this.resource.title as string`
+into every generated resource. The record is `typeof table.$inferSelect`, so
+each column is already typed and the casts only hid mistakes: `as string` on a
+column that is later made nullable swallows the `null` while the resource keeps
+compiling, and `as number` hard-codes a primary key an app with a UUID does not
+have. The key's type is now read off the record (`id: PostRecord['id']`).
+
+`json` columns keep their assertion, in every dialect: `jsonb()`, `json()` and
+`text({ mode: 'json' })` all infer `unknown` unless the schema pins a `$type`.
+
+Generated resources also declare their payload as the `Resource` class's second
+type argument instead of overriding `toJSON()` to cast. That argument arrives in
+the `@guren/core` released alongside this one, so upgrade `@guren/core` and
+`@guren/cli` together — `bunx guren upgrade` does that, and a lone CLI upgrade
+would scaffold a resource the installed core cannot type.

--- a/docs/en/guides/api-resources.md
+++ b/docs/en/guides/api-resources.md
@@ -340,12 +340,14 @@ export interface UserResourceData {
   name: string
 }
 
-export class UserResource extends Resource<User> {
+export class UserResource extends Resource<User, UserResourceData> {
   toArray(): UserResourceData {
     return { id: this.resource.id, name: this.resource.name }
   }
 }
 ```
+
+The second type argument is the payload type, and passing it makes `toJSON()` report the same type. It defaults to `Record<string, unknown>`, so declare it whenever the result of `toJSON()` is handed straight to a page or an API client.
 
 The interface must be declared in the resource's own file — one imported from a shared types module is not read. A Resource codegen cannot extract a type from is named in a `guren codegen` warning rather than dropped in silence, so a missing `Data.*` member always says why.
 

--- a/docs/en/tutorials/authentication.md
+++ b/docs/en/tutorials/authentication.md
@@ -231,20 +231,16 @@ export interface PostResourceData extends Record<string, unknown> {
   author: { id: number; name: string } | null
 }
 
-export class PostResource extends Resource<PostWithAuthor> {
+export class PostResource extends Resource<PostWithAuthor, PostResourceData> {
   toArray(): PostResourceData {
     return {
-      id: this.resource.id as number,
-      title: this.resource.title as string,
-      body: this.resource.body as string,
+      id: this.resource.id,
+      title: this.resource.title,
+      body: this.resource.body,
       author: this.resource.author
         ? { id: this.resource.author.id, name: this.resource.author.name }
         : null,
     }
-  }
-
-  override toJSON(): PostResourceData {
-    return super.toJSON() as PostResourceData
   }
 }
 ```

--- a/docs/en/tutorials/create-blog-post-app.md
+++ b/docs/en/tutorials/create-blog-post-app.md
@@ -197,12 +197,12 @@ export interface PostResourceData extends Record<string, unknown> {
   body: string
 }
 
-export class PostResource extends Resource<PostRecord> {
+export class PostResource extends Resource<PostRecord, PostResourceData> {
   toArray(): PostResourceData {
     return {
-      id: this.resource.id as number,
-      title: this.resource.title as string,
-      body: this.resource.body as string,
+      id: this.resource.id,
+      title: this.resource.title,
+      body: this.resource.body,
     }
   }
   // ...

--- a/docs/en/tutorials/relationships.md
+++ b/docs/en/tutorials/relationships.md
@@ -131,18 +131,14 @@ export interface CommentResourceData extends Record<string, unknown> {
   author: { name: string } | null
 }
 
-export class CommentResource extends Resource<CommentWithAuthor> {
+export class CommentResource extends Resource<CommentWithAuthor, CommentResourceData> {
   toArray(): CommentResourceData {
     return {
-      id: this.resource.id as number,
-      body: this.resource.body as string,
-      createdAt: this.resource.createdAt as string,
+      id: this.resource.id,
+      body: this.resource.body,
+      createdAt: this.resource.createdAt,
       author: this.resource.author ? { name: this.resource.author.name } : null,
     }
-  }
-
-  override toJSON(): CommentResourceData {
-    return super.toJSON() as CommentResourceData
   }
 }
 ```

--- a/docs/ja/guides/api-resources.md
+++ b/docs/ja/guides/api-resources.md
@@ -340,12 +340,14 @@ export interface UserResourceData {
   name: string
 }
 
-export class UserResource extends Resource<User> {
+export class UserResource extends Resource<User, UserResourceData> {
   toArray(): UserResourceData {
     return { id: this.resource.id, name: this.resource.name }
   }
 }
 ```
+
+2 つ目の型引数はペイロードの型で、これを渡すと `toJSON()` も同じ型を返します。省略した場合は `Record<string, unknown>` になるので、`toJSON()` の戻り値をそのままページや API クライアントに渡すなら指定してください。
 
 interface は Resource 自身のファイルで宣言してください。共通の型モジュールから import したものは読み取られません。型を抽出できなかった Resource は黙って捨てられるのではなく `guren codegen` の警告で名指しされるので、`Data.*` が生成されない理由は必ず表示されます。
 

--- a/docs/ja/tutorials/authentication.md
+++ b/docs/ja/tutorials/authentication.md
@@ -231,20 +231,16 @@ export interface PostResourceData extends Record<string, unknown> {
   author: { id: number; name: string } | null
 }
 
-export class PostResource extends Resource<PostWithAuthor> {
+export class PostResource extends Resource<PostWithAuthor, PostResourceData> {
   toArray(): PostResourceData {
     return {
-      id: this.resource.id as number,
-      title: this.resource.title as string,
-      body: this.resource.body as string,
+      id: this.resource.id,
+      title: this.resource.title,
+      body: this.resource.body,
       author: this.resource.author
         ? { id: this.resource.author.id, name: this.resource.author.name }
         : null,
     }
-  }
-
-  override toJSON(): PostResourceData {
-    return super.toJSON() as PostResourceData
   }
 }
 ```

--- a/docs/ja/tutorials/create-blog-post-app.md
+++ b/docs/ja/tutorials/create-blog-post-app.md
@@ -197,12 +197,12 @@ export interface PostResourceData extends Record<string, unknown> {
   body: string
 }
 
-export class PostResource extends Resource<PostRecord> {
+export class PostResource extends Resource<PostRecord, PostResourceData> {
   toArray(): PostResourceData {
     return {
-      id: this.resource.id as number,
-      title: this.resource.title as string,
-      body: this.resource.body as string,
+      id: this.resource.id,
+      title: this.resource.title,
+      body: this.resource.body,
     }
   }
   // ...

--- a/docs/ja/tutorials/relationships.md
+++ b/docs/ja/tutorials/relationships.md
@@ -131,18 +131,14 @@ export interface CommentResourceData extends Record<string, unknown> {
   author: { name: string } | null
 }
 
-export class CommentResource extends Resource<CommentWithAuthor> {
+export class CommentResource extends Resource<CommentWithAuthor, CommentResourceData> {
   toArray(): CommentResourceData {
     return {
-      id: this.resource.id as number,
-      body: this.resource.body as string,
-      createdAt: this.resource.createdAt as string,
+      id: this.resource.id,
+      body: this.resource.body,
+      createdAt: this.resource.createdAt,
       author: this.resource.author ? { name: this.resource.author.name } : null,
     }
-  }
-
-  override toJSON(): CommentResourceData {
-    return super.toJSON() as CommentResourceData
   }
 }
 ```

--- a/examples/api/app/Http/Resources/TaskResource.ts
+++ b/examples/api/app/Http/Resources/TaskResource.ts
@@ -20,7 +20,7 @@ export interface TaskResourceData extends Record<string, unknown> {
   owner?: { id: number | undefined; name: string | undefined }
 }
 
-export class TaskResource extends Resource<TaskRecord | TaskWithOwner> {
+export class TaskResource extends Resource<TaskRecord | TaskWithOwner, TaskResourceData> {
   toArray(): TaskResourceData {
     const task = this.resource
     return {

--- a/examples/api/app/Http/Resources/UserResource.ts
+++ b/examples/api/app/Http/Resources/UserResource.ts
@@ -8,7 +8,7 @@ export interface UserResourceData extends Record<string, unknown> {
   createdAt: string
 }
 
-export class UserResource extends Resource<UserRecord> {
+export class UserResource extends Resource<UserRecord, UserResourceData> {
   toArray(): UserResourceData {
     return {
       id: this.resource.id,

--- a/examples/blog/app/Http/Resources/PostResource.ts
+++ b/examples/blog/app/Http/Resources/PostResource.ts
@@ -18,7 +18,7 @@ export interface PostResourceData extends Record<string, unknown> {
   author?: PostAuthorSummary
 }
 
-export class PostResource extends Resource<PostRecord | PostWithAuthor> {
+export class PostResource extends Resource<PostRecord | PostWithAuthor, PostResourceData> {
   toArray(): PostResourceData {
     const post = this.resource
 
@@ -37,9 +37,5 @@ export class PostResource extends Resource<PostRecord | PostWithAuthor> {
         name: (post as PostWithAuthor).author?.name,
       })) as PostAuthorSummary | undefined,
     }
-  }
-
-  override toJSON(): PostResourceData {
-    return super.toJSON() as PostResourceData
   }
 }

--- a/packages/cli/src/make-feature.ts
+++ b/packages/cli/src/make-feature.ts
@@ -233,19 +233,20 @@ function tsFieldType(field: FieldDefinition): string {
  * The record is `typeof table.$inferSelect`, so every column already carries
  * its own type and reading one needs no cast. Casting anyway is not merely
  * redundant: `as string` on a column the app later makes nullable swallows the
- * `null`, and the resource keeps compiling while it lies to the frontend. A
- * cast on the primary key is worse still, since it hard-codes the `number` an
- * app with a UUID key does not have.
+ * `null`, and the resource keeps compiling while it lies to the frontend.
  *
  * `json` is the one exception, in every dialect: `jsonb()`, `json()` and
  * `text({ mode: 'json' })` all infer `unknown` unless the schema pins a
- * `$type`, so the declared `Record<string, unknown>` has to be asserted.
+ * `$type`, so the declared `Record<string, unknown>` has to be asserted. The
+ * assertion is unconditional, so an author who pinned a `$type` of their own
+ * gets it flattened back to `Record<string, unknown>` in the payload.
  *
  * A `date` column serializes to the ISO string `tsFieldType` declares, so it is
- * converted rather than read. It goes through `new Date()` because the driver
- * decides what it hands back: Postgres `timestamp` yields a `Date`, but SQLite
- * — the default scaffold — stores dates in a `text` column and yields a string.
- * `new Date()` accepts all three, so the conversion needs no cast either.
+ * converted rather than read. It goes through `new Date()` rather than a cast
+ * because this renderer does not own the column: `guren add resource` writes
+ * the table (and gets a `Date` in all three dialects — see `ColumnMapping` in
+ * blueprints.ts), but `make:feature` leaves it to the author, whose `text`
+ * column yields a string. `new Date()` takes either.
  *
  * A nullable column keeps its `?? null`. `$inferSelect` alone makes it a no-op,
  * but the record the author widens later — a `WithRelations` union, a partial

--- a/packages/cli/src/make-feature.ts
+++ b/packages/cli/src/make-feature.ts
@@ -230,20 +230,38 @@ function tsFieldType(field: FieldDefinition): string {
 /**
  * How a resource reads one column off its record.
  *
+ * The record is `typeof table.$inferSelect`, so every column already carries
+ * its own type and reading one needs no cast. Casting anyway is not merely
+ * redundant: `as string` on a column the app later makes nullable swallows the
+ * `null`, and the resource keeps compiling while it lies to the frontend. A
+ * cast on the primary key is worse still, since it hard-codes the `number` an
+ * app with a UUID key does not have.
+ *
+ * `json` is the one exception, in every dialect: `jsonb()`, `json()` and
+ * `text({ mode: 'json' })` all infer `unknown` unless the schema pins a
+ * `$type`, so the declared `Record<string, unknown>` has to be asserted.
+ *
  * A `date` column serializes to the ISO string `tsFieldType` declares, so it is
- * converted rather than cast. It goes through `new Date()` because the driver
+ * converted rather than read. It goes through `new Date()` because the driver
  * decides what it hands back: Postgres `timestamp` yields a `Date`, but SQLite
  * — the default scaffold — stores dates in a `text` column and yields a string.
+ * `new Date()` accepts all three, so the conversion needs no cast either.
+ *
+ * A nullable column keeps its `?? null`. `$inferSelect` alone makes it a no-op,
+ * but the record the author widens later — a `WithRelations` union, a partial
+ * select — can carry `undefined`, which the declared `T | null` would reject.
  */
 function resourceFieldExpression(field: FieldDefinition): string {
   const access = `this.resource.${field.name}`
   if (field.type === 'date') {
-    const iso = `new Date(${access} as string | number | Date).toISOString()`
+    const iso = `new Date(${access}).toISOString()`
     return field.nullable ? `${access} == null ? null : ${iso}` : iso
   }
-  return field.nullable
-    ? `(${access} as ${tsFieldType(field)}) ?? null`
-    : `${access} as ${tsFieldType(field)}`
+  if (field.type === 'json') {
+    const asserted = `${access} as ${tsFieldType(field)}`
+    return field.nullable ? `(${asserted}) ?? null` : asserted
+  }
+  return field.nullable ? `${access} ?? null` : access
 }
 
 /** The empty value a form starts a field at, matching its wire type. */
@@ -269,13 +287,17 @@ function formValue(field: FieldDefinition, formVar: string): string {
 }
 
 function generateResource(singular: string, fields: FieldDefinition[]): string {
+  // The key's type is read off the record rather than declared, the same rule
+  // `make:resource` follows: `guren add resource` writes an auto-increment
+  // `id`, but `make:feature` leaves the table to the author, and a hard-coded
+  // `number` is wrong the moment they reach for a UUID.
   const dataFields = [
-    '  id: number',
+    `  id: ${singular}Record['id']`,
     ...fields.map((f) => `  ${f.name}: ${tsFieldType(f)}`),
   ].join('\n')
 
   const toArrayFields = [
-    '      id: this.resource.id as number,',
+    '      id: this.resource.id,',
     ...fields.map((f) => `      ${f.name}: ${resourceFieldExpression(f)},`),
   ].join('\n')
 
@@ -286,15 +308,11 @@ export interface ${singular}ResourceData extends Record<string, unknown> {
 ${dataFields}
 }
 
-export class ${singular}Resource extends Resource<${singular}Record> {
+export class ${singular}Resource extends Resource<${singular}Record, ${singular}ResourceData> {
   toArray(): ${singular}ResourceData {
     return {
 ${toArrayFields}
     }
-  }
-
-  override toJSON(): ${singular}ResourceData {
-    return super.toJSON() as ${singular}ResourceData
   }
 }
 `

--- a/packages/cli/src/make-resource.ts
+++ b/packages/cli/src/make-resource.ts
@@ -10,17 +10,13 @@ export interface ${className}Data extends Record<string, unknown> {
   id: ${modelName}Record['id']
 }
 
-export class ${className} extends Resource<${modelName}Record> {
+export class ${className} extends Resource<${modelName}Record, ${className}Data> {
   toArray(): ${className}Data {
     return {
       id: this.resource.id,
       // Map the remaining ${modelName}Record columns here. Only call
       // .toISOString() on Date columns — text timestamps are already strings.
     }
-  }
-
-  override toJSON(): ${className}Data {
-    return super.toJSON() as ${className}Data
   }
 }
 `

--- a/packages/cli/templates/agent/core/rules/controllers-http.md
+++ b/packages/cli/templates/agent/core/rules/controllers-http.md
@@ -128,12 +128,19 @@ Use `AuthorizationException.deny(...)` for manual ownership checks that don't go
 ```typescript
 import { Resource } from '@guren/core'
 
-export class PostResource extends Resource<PostRecord> {
-  toArray() {                       // abstract — must implement; typed toArray is exported as Data.Post by codegen
+export interface PostResourceData extends Record<string, unknown> {
+  id: PostRecord['id']
+  title: string
+}
+
+// Resource<TRecord, TPayload> — the second argument makes toJSON() report the
+// payload type too; it defaults to Record<string, unknown> when omitted.
+export class PostResource extends Resource<PostRecord, PostResourceData> {
+  toArray(): PostResourceData {     // abstract — must implement; the annotated type is exported as Data.Post by codegen
     return { id: this.resource.id, title: this.resource.title }
   }
 }
-new PostResource(post).toJSON()          // toArray() + additional() data
+new PostResource(post).toJSON()          // PostResourceData: toArray() + additional() data
 PostResource.collection(posts)           // ResourceData[]
 new PostResource(post).additional({ meta: 1 })
 this.when(cond, value)                   // conditional field inside toArray()

--- a/packages/cli/tests/make-commands.test.ts
+++ b/packages/cli/tests/make-commands.test.ts
@@ -373,7 +373,7 @@ describe('CLI make:* commands', () => {
     it('uses custom model name', async () => {
       const result = await makeResource('UserProfile', { model: 'Profile' })
       const content = fs.readFileSync(result, 'utf-8')
-      expect(content).toContain('Resource<ProfileRecord>')
+      expect(content).toContain('Resource<ProfileRecord, UserProfileResourceData>')
       expect(content).toContain("import type { ProfileRecord } from '../../Models/Profile.js'")
     })
 

--- a/packages/cli/tests/make-feature.test.ts
+++ b/packages/cli/tests/make-feature.test.ts
@@ -172,8 +172,11 @@ describe('makeFeature', () => {
         'utf8',
       )
       expect(resource).toContain('startsAt: string')
+      // No cast on the way in: `new Date()` takes the `Date`, string or number
+      // the three dialects hand back, and casting would only hide a column
+      // that turns out to be none of them.
       expect(resource).toContain(
-        'startsAt: new Date(this.resource.startsAt as string | number | Date).toISOString()',
+        'startsAt: new Date(this.resource.startsAt).toISOString()',
       )
 
       const newPage = await readFile(join(workspace.dir, 'resources/js/pages/events/New.tsx'), 'utf8')
@@ -181,6 +184,45 @@ describe('makeFeature', () => {
       expect(newPage).toContain('value={form.data.startsAt.slice(0, 10)}')
       expect(newPage).toContain("setData('startsAt', event.target.value)")
       expect(newPage).toContain("startsAt: ''")
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  // The record is `typeof table.$inferSelect`, so every column is already
+  // typed and a cast on the way out can only lie: `as string` swallows a
+  // column that turns out to be nullable, and `as number` hard-codes a key an
+  // app with a UUID does not have. `json` is the one column no dialect types
+  // for us — `jsonb()`, `json()` and `text({ mode: 'json' })` all infer
+  // `unknown` — so it is the one that keeps its assertion.
+  it('reads columns off the record without casting, json excepted', async () => {
+    const workspace = await createTempWorkspace('guren-cli-feature-casts-')
+
+    try {
+      await makeFeature('Event', { fields: 'title:string,body:text?,meta:json,seats:number?' })
+
+      const resource = await readFile(
+        join(workspace.dir, 'app/Http/Resources/EventResource.ts'),
+        'utf8',
+      )
+
+      expect(resource).toContain("id: EventRecord['id']")
+      expect(resource).toContain('id: this.resource.id,')
+      expect(resource).toContain('title: this.resource.title,')
+      expect(resource).toContain('body: this.resource.body ?? null,')
+      expect(resource).toContain('seats: this.resource.seats ?? null,')
+      expect(resource).toContain('meta: this.resource.meta as Record<string, unknown>,')
+
+      expect(resource).not.toContain('as number')
+      expect(resource).not.toContain('as string')
+
+      // The payload type is the class's second type argument, so `toJSON()`
+      // reports it without an override whose only body is a cast.
+      expect(resource).toContain(
+        'export class EventResource extends Resource<EventRecord, EventResourceData>',
+      )
+      expect(resource).not.toContain('super.toJSON()')
+      expect(resource).not.toContain('override toJSON')
     } finally {
       await workspace.cleanup()
     }

--- a/packages/cli/tests/make-feature.test.ts
+++ b/packages/cli/tests/make-feature.test.ts
@@ -172,9 +172,8 @@ describe('makeFeature', () => {
         'utf8',
       )
       expect(resource).toContain('startsAt: string')
-      // No cast on the way in: `new Date()` takes the `Date`, string or number
-      // the three dialects hand back, and casting would only hide a column
-      // that turns out to be none of them.
+      // Read without a cast: this renderer does not own the column, so the
+      // conversion has to take whatever the author's schema yields.
       expect(resource).toContain(
         'startsAt: new Date(this.resource.startsAt).toISOString()',
       )
@@ -189,12 +188,8 @@ describe('makeFeature', () => {
     }
   })
 
-  // The record is `typeof table.$inferSelect`, so every column is already
-  // typed and a cast on the way out can only lie: `as string` swallows a
-  // column that turns out to be nullable, and `as number` hard-codes a key an
-  // app with a UUID does not have. `json` is the one column no dialect types
-  // for us — `jsonb()`, `json()` and `text({ mode: 'json' })` all infer
-  // `unknown` — so it is the one that keeps its assertion.
+  // Pins the emitted read per field type; the rule and its exceptions are
+  // stated once, at `resourceFieldExpression()`.
   it('reads columns off the record without casting, json excepted', async () => {
     const workspace = await createTempWorkspace('guren-cli-feature-casts-')
 
@@ -213,15 +208,13 @@ describe('makeFeature', () => {
       expect(resource).toContain('seats: this.resource.seats ?? null,')
       expect(resource).toContain('meta: this.resource.meta as Record<string, unknown>,')
 
+      // The #123 rule for the key, kept as a negative because a regression
+      // would land on a line the positives above do not name.
       expect(resource).not.toContain('as number')
-      expect(resource).not.toContain('as string')
 
-      // The payload type is the class's second type argument, so `toJSON()`
-      // reports it without an override whose only body is a cast.
       expect(resource).toContain(
         'export class EventResource extends Resource<EventRecord, EventResourceData>',
       )
-      expect(resource).not.toContain('super.toJSON()')
       expect(resource).not.toContain('override toJSON')
     } finally {
       await workspace.cleanup()

--- a/packages/cli/tests/make-resource.test.ts
+++ b/packages/cli/tests/make-resource.test.ts
@@ -23,9 +23,6 @@ describe('makeResource', () => {
       expect(content).toContain("id: CommentRecord['id']")
       expect(content).toContain('id: this.resource.id,')
       expect(content).not.toContain('as number')
-      // The payload type is the class's second type argument, so `toJSON()`
-      // reports it without an override whose only body is a cast.
-      expect(content).not.toContain('super.toJSON()')
       expect(content).not.toContain('override toJSON')
       expect(content).not.toContain('this.resource.createdAt?.toISOString()')
     } finally {

--- a/packages/cli/tests/make-resource.test.ts
+++ b/packages/cli/tests/make-resource.test.ts
@@ -14,13 +14,19 @@ describe('makeResource', () => {
       expect(content).toContain(
         "import type { CommentRecord } from '../../Models/Comment.js'",
       )
-      expect(content).toContain('export class CommentResource extends Resource<CommentRecord>')
+      expect(content).toContain(
+        'export class CommentResource extends Resource<CommentRecord, CommentResourceData>',
+      )
       expect(content).toContain('export interface CommentResourceData extends Record<string, unknown>')
       // id type is derived from the record, not hardcoded — a UUID/text primary
       // key must not be forced through an incorrect `number` cast.
       expect(content).toContain("id: CommentRecord['id']")
       expect(content).toContain('id: this.resource.id,')
       expect(content).not.toContain('as number')
+      // The payload type is the class's second type argument, so `toJSON()`
+      // reports it without an override whose only body is a cast.
+      expect(content).not.toContain('super.toJSON()')
+      expect(content).not.toContain('override toJSON')
       expect(content).not.toContain('this.resource.createdAt?.toISOString()')
     } finally {
       await workspace.cleanup()
@@ -34,7 +40,7 @@ describe('makeResource', () => {
 
       const content = await readFile(result, 'utf8')
       expect(content).toContain("import type { PostRecord } from '../../Models/Post.js'")
-      expect(content).toContain('extends Resource<PostRecord>')
+      expect(content).toContain('extends Resource<PostRecord, PostResourceData>')
     } finally {
       await workspace.cleanup()
     }

--- a/packages/create-app/templates/blog/app/Http/Resources/PostResource.ts
+++ b/packages/create-app/templates/blog/app/Http/Resources/PostResource.ts
@@ -16,25 +16,21 @@ export interface PostResourceData extends Record<string, unknown> {
   author?: PostAuthorSummary
 }
 
-export class PostResource extends Resource<PostRecord | PostWithAuthor> {
+export class PostResource extends Resource<PostRecord | PostWithAuthor, PostResourceData> {
   toArray(): PostResourceData {
     const post = this.resource
 
     return {
-      id: post.id as number,
-      title: post.title as string,
-      excerpt: post.excerpt as string,
-      body: post.body as string,
-      authorId: post.authorId as number,
-      createdAt: new Date(post.createdAt as string | Date).toISOString(),
+      id: post.id,
+      title: post.title,
+      excerpt: post.excerpt,
+      body: post.body,
+      authorId: post.authorId,
+      createdAt: new Date(post.createdAt).toISOString(),
       author: this.whenLoaded('author', () => ({
         id: (post as PostWithAuthor).author?.id,
         name: (post as PostWithAuthor).author?.name,
       })) as PostAuthorSummary | undefined,
     }
-  }
-
-  override toJSON(): PostResourceData {
-    return super.toJSON() as PostResourceData
   }
 }

--- a/packages/server/src/http/resources/Resource.ts
+++ b/packages/server/src/http/resources/Resource.ts
@@ -16,6 +16,13 @@ import type { ResourceData, ResourceClass } from './types'
  * base. The polymorphic alternative (`toJSON(): ReturnType<this['toArray']>`)
  * needs no parameter at all but rejects every existing override, which is a
  * breaking change for code the scaffolds have been emitting all along.
+ *
+ * `TData` is a claim about `toArray()`, not about `toJSON()`'s every key:
+ * `additional()` takes arbitrary `ResourceData` and is spread *after* the
+ * payload, so a key that collides overwrites a typed field while the return
+ * type still reads `TData`. That hole is not new — it is what the
+ * `super.toJSON() as PostResourceData` override asserted past — but the type
+ * parameter does not close it. `additional()` is for keys beside the payload.
  */
 export abstract class Resource<T, TData extends ResourceData = ResourceData> {
   /**
@@ -144,8 +151,8 @@ export function collect<T, R extends Resource<T>>(
 /**
  * Simple resource wrapper for objects without transformation.
  */
-export class JsonResource<T extends Record<string, unknown>> extends Resource<T, T> {
-  toArray(): T {
+export class JsonResource<T extends Record<string, unknown>> extends Resource<T> {
+  toArray(): ResourceData {
     return { ...this.resource }
   }
 }

--- a/packages/server/src/http/resources/Resource.ts
+++ b/packages/server/src/http/resources/Resource.ts
@@ -3,8 +3,21 @@ import type { ResourceData, ResourceClass } from './types'
 /**
  * Abstract base class for API resources.
  * Transforms model data into API response format.
+ *
+ * `TData` names the payload `toArray()` builds, so `toJSON()` reports it too:
+ * `class PostResource extends Resource<PostRecord, PostResourceData>`. Without
+ * it every subclass had to restate the payload in an override whose only body
+ * was `return super.toJSON() as PostResourceData` — a cast that says nothing a
+ * type parameter cannot, and one nothing checks against the `toArray()` right
+ * above it.
+ *
+ * It defaults to `ResourceData` so `Resource<T>` and those overrides keep
+ * compiling: an override narrowing the return type stays assignable to the
+ * base. The polymorphic alternative (`toJSON(): ReturnType<this['toArray']>`)
+ * needs no parameter at all but rejects every existing override, which is a
+ * breaking change for code the scaffolds have been emitting all along.
  */
-export abstract class Resource<T> {
+export abstract class Resource<T, TData extends ResourceData = ResourceData> {
   /**
    * The underlying resource.
    */
@@ -23,12 +36,12 @@ export abstract class Resource<T> {
    * Transform the resource into an array/object.
    * Must be implemented by subclasses.
    */
-  abstract toArray(): ResourceData
+  abstract toArray(): TData
 
   /**
    * Transform the resource to JSON.
    */
-  toJSON(): ResourceData {
+  toJSON(): TData {
     return {
       ...this.toArray(),
       ...this.additionalData,
@@ -131,8 +144,8 @@ export function collect<T, R extends Resource<T>>(
 /**
  * Simple resource wrapper for objects without transformation.
  */
-export class JsonResource<T extends Record<string, unknown>> extends Resource<T> {
-  toArray(): ResourceData {
+export class JsonResource<T extends Record<string, unknown>> extends Resource<T, T> {
+  toArray(): T {
     return { ...this.resource }
   }
 }

--- a/packages/testing/src/controller.ts
+++ b/packages/testing/src/controller.ts
@@ -517,7 +517,10 @@ export function createControllerModuleMock() {
     }
   }
 
-  class Resource<T = Record<string, unknown>> {
+  // Second parameter mirrors the real `Resource<T, TData>`: the mock is what a
+  // test file's `extends Resource<PostRecord, PostResourceData>` resolves to,
+  // so a mirror stuck on one parameter rejects the shape the scaffolds emit.
+  class Resource<T = Record<string, unknown>, TData extends Record<string, unknown> = Record<string, unknown>> {
     public resource: T
     public additionalData: Record<string, unknown> = {}
 
@@ -525,11 +528,11 @@ export function createControllerModuleMock() {
       this.resource = resource
     }
 
-    toArray(): Record<string, unknown> {
-      return { ...(this.resource as Record<string, unknown>) }
+    toArray(): TData {
+      return { ...(this.resource as Record<string, unknown>) } as TData
     }
 
-    toJSON(): Record<string, unknown> {
+    toJSON(): TData {
       return {
         ...this.toArray(),
         ...this.additionalData,

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -52,7 +52,13 @@ const DEFAULT_BLUEPRINT_FEATURES: readonly (readonly string[])[] = [
   ['auth'],
   ['admin'],
   ['oauth'],
-  ['resource', 'posts'],
+  // Every field type, and a nullable one, because this is the only gate that
+  // *compiles* what `generateResource()` and the page builders emit per type:
+  // `json` infers `unknown` off the schema, `date` arrives as a Date or a
+  // string depending on the driver, and a nullable column has to survive the
+  // round trip through a form. Bare `add resource` scaffolds two plain
+  // strings, which exercises none of them.
+  ['resource', 'posts', '--fields', 'title:string,body:text?,views:number,published:boolean,publishedAt:date,meta:json'],
   ['queue'],
   ['mail', '--force'],
   ['events'],

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -2,6 +2,7 @@ import { mkdtemp, mkdir, readFile, readdir, realpath, rm } from 'node:fs/promise
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import process from 'node:process'
+import { FIELD_TYPES } from '../../packages/cli/src/fields'
 import { DATABASE_DRIVERS } from '../../packages/create-app/src/blueprints'
 import { fileExists } from '../../packages/create-app/src/utils'
 import { auditBlueprintTemplates, auditConsoleWiring, auditStarterTemplate } from './starter-template-audit'
@@ -29,6 +30,32 @@ type InstallMode = (typeof INSTALL_MODES)[number]
 
 const repoRoot = resolve(import.meta.dir, '../..')
 
+/**
+ * The `--fields` the resource blueprint is scaffolded with.
+ *
+ * Derived from `FIELD_TYPES` rather than written out, because this smoke is
+ * the only gate that *compiles* what `generateResource()` and the page
+ * builders emit per type — everything else about a field type fails at the
+ * type level (`tsFieldType`'s and `ColumnMapping`'s `Record<FieldType, …>`),
+ * but the rendered code is builder output that is otherwise only
+ * parse-checked. A hand-written list would keep passing, and keep claiming
+ * full coverage, the day a seventh type is added.
+ *
+ * `DEFAULT_FIELDS` already covers a plain read and a nullable one, so a bare
+ * `add resource` is not nothing — what it misses is number, boolean, date and
+ * json, and json is the only type drizzle leaves as `unknown`.
+ *
+ * Nullable *and* not, per type, because nullability is a second axis rather
+ * than a seventh type: a nullable `date` is a `== null` ternary and a nullable
+ * `json` a parenthesised assertion, neither of which their non-nullable form
+ * compiles. Twelve fields cost file size, not file count — `makeFeature()`
+ * writes the same seven files whatever it is given.
+ */
+const RESOURCE_FIELDS = FIELD_TYPES.flatMap((type) => [
+  `${type}Field:${type}`,
+  `nullable${type[0].toUpperCase()}${type.slice(1)}Field:${type}?`,
+]).join(',')
+
 // The feature blueprints a default-blueprint app gets, in the order the
 // scaffolders expect. Shared by the vendored and the npm paths so the
 // published-drift gate cannot fall behind the set this smoke otherwise claims
@@ -52,13 +79,7 @@ const DEFAULT_BLUEPRINT_FEATURES: readonly (readonly string[])[] = [
   ['auth'],
   ['admin'],
   ['oauth'],
-  // Every field type, and a nullable one, because this is the only gate that
-  // *compiles* what `generateResource()` and the page builders emit per type:
-  // `json` infers `unknown` off the schema, `date` arrives as a Date or a
-  // string depending on the driver, and a nullable column has to survive the
-  // round trip through a form. Bare `add resource` scaffolds two plain
-  // strings, which exercises none of them.
-  ['resource', 'posts', '--fields', 'title:string,body:text?,views:number,published:boolean,publishedAt:date,meta:json'],
+  ['resource', 'posts', '--fields', RESOURCE_FIELDS],
   ['queue'],
   ['mail', '--force'],
   ['events'],


### PR DESCRIPTION
## What

Two related cleanups to the types in generated API resources.

**1. Drop the casts.** Every generated resource opened with `id: this.resource.id as number` and read each column as `this.resource.title as string`. The record is `typeof table.$inferSelect`, so each column already carries its own type. The casts were not merely redundant:

| expression | nullable column |
|---|---|
| `body: this.resource.body,` | `error TS2322: Type 'string \| null' is not assignable to type 'string'` |
| `body: this.resource.body as string,` | compiles, and the `null` reaches the frontend |

`as number` on the key is the same failure in a different place: it hard-codes a `number` an app with a UUID primary key does not have. `make:resource` was corrected this way in #123 (its test pins `not.toContain('as number')`); `make:feature` and `guren add resource` were left behind.

Two exceptions, both measured:

- **`json` keeps its assertion**, in every dialect. `jsonb()`, `json()` and `text({ mode: 'json' })` all infer `unknown` unless the schema pins a `$type`.
- **`date` loses `as string | number | Date`.** All three dialects infer `Date`, and `new Date()` accepts a `Date`, a string or a number, so a schema that hands back something else should be visible rather than cast away.

**2. Let a Resource declare its payload type.** `Resource<T>` takes an optional second type argument:

```ts
export class PostResource extends Resource<PostRecord, PostResourceData> {
  toArray(): PostResourceData {
    return { id: this.resource.id, title: this.resource.title }
  }
}
```

`toJSON()` now reports `PostResourceData`, which removes the override every scaffolded resource carried — a method whose only body was `return super.toJSON() as PostResourceData`, a cast nothing checked against the `toArray()` directly above it.

The parameter defaults to `ResourceData`, so `Resource<T>` and every existing override keep compiling. The alternative that needs no parameter, `toJSON(): ReturnType<this['toArray']>`, rejects every existing override with `TS2416` — a breaking change for code the scaffolds have been emitting all along.

## New coverage

`generateResource()` is a builder template, so nothing compiled its output per field type: `scaffold-output.test.ts` only parse-gates, and `typecheck:templates` covers the static templates. The default blueprint smoke already ran `guren add resource posts`, but `DEFAULT_FIELDS` is `title:string` plus `body:text?` — a plain read and a nullable one, leaving number, boolean, date and json uncompiled, json being the only type drizzle leaves as `unknown`.

It now derives its `--fields` from `FIELD_TYPES`, nullable variant included per type, so nullability is covered on its own axis (a nullable `date` is a `== null` ternary that its non-nullable form does not compile) and a seventh field type joins without anyone remembering. Verified the gate can fail: removing the `json` assertion makes `smoke:starter` fail with `error TS2322: Type 'unknown' is not assignable to type 'Record<string, unknown>'` in the generated `PostResource.ts`.

`make-feature.test.ts` gains a unit guard for the emitted text, also mutation-checked.

## Release note

`@guren/cli` is a **minor**, not a patch: the code it scaffolds needs the `@guren/core` released alongside it. Upgrading the CLI alone would scaffold a resource the installed core cannot type. `@guren/server` and `@guren/core` are both minor — core re-exports server wholesale and `audit:core-semver` only enforces major-for-major.

`smoke:starter:npm` and `smoke:starter:npm:blog` are **expected to be red until that release ships**: the templates now use a type parameter the published `@guren/core` does not have yet. That is the documented state for a template-facing change, and cutting the release is the fix.

## Verification

- `bun run build:clean`, `bun run typecheck`, `bun run test` (4938 pass, 0 fail)
- `bun run audit:core-first`, `audit:docs`, `audit:starter-template`, `audit:core-semver`
- `bun run smoke:starter`, `smoke:starter:api`, `smoke:starter:blog`

Refs: #123


---

### Review pass

`JsonResource` was briefly narrowed to `Resource<T, T>` and has been put back on `Resource<T>`: it would reject a subclass whose `toArray()` returns a subset of `T`, which is a break a minor cannot carry. `TData` describes `toArray()` only — `additional()` still takes arbitrary `ResourceData` and is spread after the payload, so a colliding key can overwrite a typed field. That hole predates this change (the removed override asserted past it); it is now written down rather than implied.
