### PR TITLE
feat(cli): reference uncopyable exported payload types in data.gen.ts

### DIFF
--- a/.changeset/data-gen-type-references.md
+++ b/.changeset/data-gen-type-references.md
@@ -1,0 +1,13 @@
+---
+"@guren/cli": minor
+---
+
+Emit payload types data.gen.ts cannot copy as import-type references
+
+A Resource whose payload type is exported but has no copyable object body — a
+`z.infer<typeof Schema>` alias, an intersection, a merged interface — is now
+emitted as `export type X = import('../app/Http/Resources/XResource').XData`
+instead of being omitted with a warning. One zod schema can therefore serve as
+the single source of truth for a route's `output:` contract and its Resource's
+`Data.*` type. Unexported and generic declarations stay refused; the
+unexported warning now says that exporting the declaration fixes it.

--- a/docs/en/guides/api-resources.md
+++ b/docs/en/guides/api-resources.md
@@ -349,6 +349,21 @@ export class UserResource extends Resource<User> {
 
 The interface must be declared in the resource's own file — one imported from a shared types module is not read. A Resource codegen cannot extract a type from is named in a `guren codegen` warning rather than dropped in silence, so a missing `Data.*` member always says why.
 
+The payload type does not have to be a plain interface. An **exported** alias whose shape codegen cannot copy — one derived from a Zod schema, an intersection, a merged interface — is emitted as a reference to the declaration itself, so one schema can be the single source of truth for the runtime contract and the payload type alike:
+
+```ts
+export const UserResourceSchema = z.object({ id: z.number(), name: z.string() })
+export type UserResourceData = z.infer<typeof UserResourceSchema>
+
+export class UserResource extends Resource<User> {
+  toArray(): UserResourceData {
+    return UserResourceSchema.parse(this.resource)
+  }
+}
+```
+
+The declaration must be exported — `data.gen.ts` names it through the resource's module — and a generic type stays unsupported either way, since a reference has no type arguments to pass it.
+
 ### Resources inside modules
 
 Codegen scans `app/Http/Resources` at the project root and inside every `modules/<name>/` directory. A module's Resource is emitted under a name qualified with its module, so `modules/billing/app/Http/Resources/InvoiceResource.ts` becomes `Data.BillingInvoice`. The qualifier is always applied, never only on collision — that way a type's name depends solely on where its class lives, and adding a second `InvoiceResource` elsewhere cannot rename one the frontend already imports.

--- a/docs/ja/guides/api-resources.md
+++ b/docs/ja/guides/api-resources.md
@@ -349,6 +349,21 @@ export class UserResource extends Resource<User> {
 
 interface は Resource 自身のファイルで宣言してください。共通の型モジュールから import したものは読み取られません。型を抽出できなかった Resource は黙って捨てられるのではなく `guren codegen` の警告で名指しされるので、`Data.*` が生成されない理由は必ず表示されます。
 
+ペイロード型はプレーンな interface である必要はありません。本体をコピーできない形の**エクスポート済み**エイリアス、たとえば Zod スキーマ由来の型や交差型、宣言マージされた interface は、宣言そのものへの参照として出力されます。これにより、1 つのスキーマをランタイムのコントラクトとペイロード型の両方の単一の情報源にできます:
+
+```ts
+export const UserResourceSchema = z.object({ id: z.number(), name: z.string() })
+export type UserResourceData = z.infer<typeof UserResourceSchema>
+
+export class UserResource extends Resource<User> {
+  toArray(): UserResourceData {
+    return UserResourceSchema.parse(this.resource)
+  }
+}
+```
+
+`data.gen.ts` は Resource のモジュール越しに宣言を名前で参照するため、宣言はエクスポートされている必要があります。また、参照には渡す型引数がないため、ジェネリック型はどちらの方式でも対象外です。
+
 ### モジュール内の Resource
 
 コード生成はプロジェクトルートの `app/Http/Resources` に加えて、各 `modules/<name>/` の中も走査します。モジュールの Resource はモジュール名を冠した名前で出力され、`modules/billing/app/Http/Resources/InvoiceResource.ts` は `Data.BillingInvoice` になります。この修飾は衝突したときだけでなく常に付きます。そうすることで型名は「クラスがどこにあるか」だけで決まり、別の場所に2つ目の `InvoiceResource` を追加してもフロントエンドが既にインポートしている型名が変わることはありません。

--- a/packages/cli/src/data-types.ts
+++ b/packages/cli/src/data-types.ts
@@ -5,11 +5,19 @@
  * `modules/<name>/` (RFC 0002) — for classes extending `Resource`, extracts
  * the return type of `toArray()` (or an explicit `interface XxxData`), and
  * emits a `data.gen.ts` file that exports a `Data` namespace.
+ *
+ * A payload type whose body cannot be copied — `z.infer<typeof Schema>`, an
+ * intersection, a merged interface — is emitted as an import-type *reference*
+ * to its own declaration instead, provided the file exports it. Copy first,
+ * reference second: a copy works for unexported declarations and keeps
+ * data.gen.ts self-describing, and a pure fallback cannot change any output
+ * that was already being emitted.
  */
 import { readFile } from 'node:fs/promises'
-import { dirname, relative, resolve } from 'node:path'
+import { dirname, join, relative, resolve } from 'node:path'
+import type { File } from '@babel/types'
 import { RESOURCES_DIR, discoverResourceFiles, moduleNameFromRelPath, toPosixRelative } from './discovery'
-import { isIdentifier, pascalCase, resolveAppRoot, writeGeneratedFileIn, type WriterOptions } from './utils'
+import { isIdentifier, pascalCase, relativeImportPath, resolveAppRoot, writeGeneratedFileIn, type WriterOptions } from './utils'
 import { parseSourceFile } from './parse-cache'
 
 export interface ResourceDefinition {
@@ -27,7 +35,11 @@ export interface ResourceDefinition {
    * rename an existing type out from under the frontend importing it.
    */
   dataName: string | null
-  /** Raw TypeScript type body for toArray() return — `null` if none was found. */
+  /**
+   * Right-hand side of the emitted `export type` — a brace body copied from
+   * the source, or an `import('…').Name` reference to a declaration that
+   * could not be copied. `null` if neither was possible.
+   */
   rawType: string | null
   /** Type imports required by this data type */
   imports: string[]
@@ -228,15 +240,17 @@ async function extractResourceType(
   const source = await readFile(filePath, 'utf-8')
 
   // Match class name: `export class PostResource extends Resource<...>`.
-  // Gated ahead of collectTypeImports(), which is a full Babel parse and the
-  // bulk of the per-file cost: every path below discards the imports when this
+  // Gated ahead of parseSourceFile(), which is a full Babel parse and the
+  // bulk of the per-file cost: every path below discards its results when this
   // misses, and the scan now covers modules/*/ too.
   const classMatch = source.match(/export\s+class\s+(\w+Resource)\s+extends\s+Resource/)
   if (!classMatch) return null
 
-  const imports = collectTypeImports(source, filePath).map((statement) =>
+  const ast = parseSourceFile(source, filePath)
+  const imports = collectTypeImports(ast, source).map((statement) =>
     rewriteImportStatement(statement, dirname(filePath), outputDirectory),
   )
+  const declaredTypes = collectTopLevelTypeDeclarations(ast)
 
   const className = classMatch[1]
   const baseName = className.replace(/Resource$/, '')
@@ -245,6 +259,25 @@ async function extractResourceType(
   // class lives — see ResourceDefinition.dataName.
   const dataName = module ? `${pascalCase(module)}${baseName}` : baseName
   const common = { className, dataName, imports, module, filePath: relPath }
+
+  // A declaration that cannot be copied may still be *referencable*: an
+  // import-type reference hands the frontend the declaration itself — unlike
+  // a guessed body, it cannot be wrong. The file's type imports are dropped on
+  // that path: the reference resolves inside the resource's own module, which
+  // resolves its own imports, and two roots' same-named imports must not
+  // collide in the shared import block.
+  const resolveUnreadable = (
+    read: Extract<ObjectTypeRead, { kind: 'unreadable' }>,
+    warningPrefix: string,
+  ): ResourceDefinition => {
+    const reference = readTypeReference(declaredTypes, read.typeName, filePath, outputDirectory)
+    if (reference.rawType !== null) {
+      return { ...common, imports: [], rawType: reference.rawType }
+    }
+    warnings.push(warningPrefix + describeUnreadable(read, reference.exportWouldFix))
+    return { ...common, rawType: null }
+  }
+
   // Comments and string literals are blanked out before anything is matched
   // against the source. Both routinely carry text that looks like a
   // declaration or an unbalanced brace and is neither — a commented-out draft
@@ -267,17 +300,20 @@ async function extractResourceType(
       return { ...common, rawType: annotated.body }
     }
 
-    // The annotation names a type this file does not hand over. Which of the
-    // two reasons it is decides what the author has to change, so say which:
-    // a declaration that is simply elsewhere is a different fix from one that
-    // is right here in a form that cannot be copied.
+    if (annotated.kind === 'unreadable') {
+      return resolveUnreadable(
+        annotated,
+        `Resource ${className} (${relPath}) annotates toArray(): ${typeName} and `,
+      )
+    }
+
+    // The annotation names a type this file does not hand over: a declaration
+    // that is simply elsewhere is a different fix from one that is right here
+    // in a form that cannot be copied, so say which.
     warnings.push(
-      annotated.kind === 'unreadable'
-        ? `Resource ${className} (${relPath}) annotates toArray(): ${typeName} and `
-          + describeUnreadable(annotated)
-        : `Resource ${className} (${relPath}) annotates toArray(): ${typeName}, but no `
-          + `interface or type ${typeName} is declared in that file — omitted from data.gen.ts. `
-          + "Only the resource's own source is read, so move the declaration into it.",
+      `Resource ${className} (${relPath}) annotates toArray(): ${typeName}, but no `
+      + `interface or type ${typeName} is declared in that file — omitted from data.gen.ts. `
+      + "Only the resource's own source is read, so move the declaration into it.",
     )
     return { ...common, rawType: null }
   }
@@ -286,8 +322,7 @@ async function extractResourceType(
   // unreadable is a different sentence again, and the one Strategy 1 alone can
   // reach.
   if (named.kind === 'unreadable') {
-    warnings.push(`Resource ${className} (${relPath}) ${describeUnreadable(named)}`)
-    return { ...common, rawType: null }
+    return resolveUnreadable(named, `Resource ${className} (${relPath}) `)
   }
 
   // Nothing recognised described the payload. Reported anyway, with no type:
@@ -326,6 +361,11 @@ async function extractResourceType(
  * used to yield *some* brace body — the wrong one — which is worse than
  * yielding none: the frontend gets a type that compiles and lies. Refusing
  * costs one `Data` member; guessing costs the trust in all of them.
+ *
+ * An unreadable declaration is not always a lost member: when the file
+ * *exports* it, the caller falls back to an import-type reference
+ * ({@link readTypeReference}), which cannot lie the way a guessed body can —
+ * it names the declaration instead of restating it.
  */
 type ObjectTypeRead =
   | { kind: 'body'; body: string }
@@ -358,7 +398,12 @@ function readObjectType(source: string, masked: string, namePattern: string): Ob
     // `[^{;]*` for the heritage clause, so `extends Record<string, unknown>`
     // is stepped over; `;` bounds it so an aliasless declaration cannot run
     // into a later statement's brace.
-    `^(?:export\\s+)?(?:interface|type)\\s+(${namePattern})\\b\\s*(?:(=)\\s*|(extends[^{;]*))?\\{`,
+    //
+    // `declare` is admitted so this reader and the AST index in
+    // collectTopLevelTypeDeclarations() agree on what counts as declared here
+    // — a modifier only one of them saw would split the verdict between
+    // "copy this" and "no such declaration".
+    `^(?:export\\s+)?(?:declare\\s+)?(?:interface|type)\\s+(${namePattern})\\b\\s*(?:(=)\\s*|(extends[^{;]*))?\\{`,
     'mu',
   )
   const match = declaration.exec(masked)
@@ -367,7 +412,7 @@ function readObjectType(source: string, masked: string, namePattern: string): Ob
     // an intersection, a generic. Distinguishing this from "not declared here"
     // is what lets the caller say which of the two it is.
     const anyDeclaration = new RegExp(
-      `^(?:export\\s+)?(?:interface|type)\\s+(${namePattern})\\b(\\s*<)?`,
+      `^(?:export\\s+)?(?:declare\\s+)?(?:interface|type)\\s+(${namePattern})\\b(\\s*<)?`,
       'mu',
     ).exec(masked)
     if (!anyDeclaration) return { kind: 'none' }
@@ -421,7 +466,7 @@ function readObjectType(source: string, masked: string, namePattern: string): Ob
   // same-named type inside a namespace or a function body is not a second
   // block and must not cost this one its type.
   const declarations = masked.match(
-    new RegExp(`^(?:export\\s+)?(?:interface|type)\\s+${typeName}\\b`, 'gmu'),
+    new RegExp(`^(?:export\\s+)?(?:declare\\s+)?(?:interface|type)\\s+${typeName}\\b`, 'gmu'),
   )
   if (declarations && declarations.length > 1) {
     return {
@@ -455,11 +500,22 @@ function countOccurrences(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1
 }
 
-/** The half of an unreadable-declaration warning that does not name the Resource. */
-function describeUnreadable(read: { typeName: string; reason: string; fix?: string }): string {
+/**
+ * The half of an unreadable-declaration warning that does not name the
+ * Resource. `exportWouldFix` is the caller's knowledge that the declaration
+ * only missed the reference fallback for being unexported — the one-word fix,
+ * which the default advice would otherwise never mention.
+ */
+function describeUnreadable(
+  read: { typeName: string; reason: string; fix?: string },
+  exportWouldFix: boolean,
+): string {
+  const inline = `a single non-generic \`interface ${read.typeName} { … }\` or `
+    + `\`type ${read.typeName} = { … }\` with its members inline.`
   const fix = read.fix
-    ?? `Write ${read.typeName} as a single non-generic \`interface ${read.typeName} { … }\` or `
-      + `\`type ${read.typeName} = { … }\` with its members inline.`
+    ?? (exportWouldFix
+      ? `Export ${read.typeName} so data.gen.ts can reference the declaration itself, or write it as ${inline}`
+      : `Write ${read.typeName} as ${inline}`)
 
   return `declares ${read.typeName} in that file, but it ${read.reason} — omitted from `
     + `data.gen.ts. ${fix}`
@@ -618,8 +674,117 @@ function maskTemplateExpression(
   return source.length
 }
 
-function collectTypeImports(source: string, filePath: string): string[] {
-  const ast = parseSourceFile(source, filePath)
+/**
+ * Outcome of trying to emit a payload type as an import-type reference.
+ *
+ * The gate is *exportedness, proven from the AST*: a reference to an
+ * unexported name is a TS2694 that takes the whole artifact — every other
+ * resource's type with it — out of compilation, and the `export` keyword on
+ * the declaration line is not the test (`export type { X }` exports without
+ * one). `exportWouldFix` is true only when exporting the declaration is all
+ * that stands in the way — what lets the warning say "export it", the
+ * one-word fix, instead of "rewrite the shape".
+ */
+type TypeReferenceRead =
+  | { rawType: string }
+  | { rawType: null; exportWouldFix: boolean }
+
+interface TypeDeclarationInfo {
+  /** Name the declaration is exported under, or `null` when it is not exported. */
+  exportedName: string | null
+  /** Whether any declaration of this name takes type parameters. */
+  generic: boolean
+}
+
+/**
+ * Every top-level `interface`/`type` declaration in the file, keyed by local
+ * name. Local declarations only — an `export … from` re-export forwards a
+ * declaration this file does not hold, whose genericity this parse cannot
+ * see, so it stays out on purpose.
+ */
+function collectTopLevelTypeDeclarations(ast: File | null): Map<string, TypeDeclarationInfo> {
+  const declarations = new Map<string, TypeDeclarationInfo>()
+  if (!ast) return declarations
+
+  for (const node of ast.program.body) {
+    const exported = node.type === 'ExportNamedDeclaration'
+    const declaration = node.type === 'ExportNamedDeclaration' ? node.declaration : node
+    if (declaration?.type !== 'TSTypeAliasDeclaration' && declaration?.type !== 'TSInterfaceDeclaration') {
+      continue
+    }
+    // Declaration merging: one generic block makes the merged type generic,
+    // and one exported block exports it.
+    const info = declarations.get(declaration.id.name) ?? { exportedName: null, generic: false }
+    info.generic ||= declaration.typeParameters != null
+    if (exported) info.exportedName ??= declaration.id.name
+    declarations.set(declaration.id.name, info)
+  }
+
+  // Export lists (`export type { X }`, `export { X as Y }`) in a second pass,
+  // so a list above its declaration still finds it. Only identifier names are
+  // recorded — the dotted reference cannot spell `export { X as 'wire name' }`
+  // — and skipping the rest here is what keeps a plainly-named specifier of
+  // the same declaration in play, whichever order the list spells them in.
+  for (const node of ast.program.body) {
+    if (node.type !== 'ExportNamedDeclaration' || node.declaration || node.source) continue
+    for (const specifier of node.specifiers) {
+      if (specifier.type !== 'ExportSpecifier') continue
+      const info = declarations.get(specifier.local.name)
+      if (!info) continue
+      const exported = specifier.exported.type === 'Identifier'
+        ? specifier.exported.name
+        : specifier.exported.value
+      if (!isIdentifier(exported)) continue
+      info.exportedName ??= exported
+    }
+  }
+
+  return declarations
+}
+
+/**
+ * An `import('…').Name` reference to `typeName`'s own declaration, for a
+ * payload {@link readObjectType} declared unreadable.
+ *
+ * A generic stays refused even when exported: a reference must pass type
+ * arguments a payload reference has nowhere to get — and the existing warning
+ * already names the type parameters as the thing in the way.
+ */
+function readTypeReference(
+  declared: Map<string, TypeDeclarationInfo>,
+  typeName: string,
+  filePath: string,
+  outputDirectory: string,
+): TypeReferenceRead {
+  const info = declared.get(typeName)
+  if (!info || info.generic) return { rawType: null, exportWouldFix: false }
+
+  const specifier = importTypeSpecifier(filePath, outputDirectory)
+  if (specifier === null) return { rawType: null, exportWouldFix: false }
+  if (info.exportedName === null) return { rawType: null, exportWouldFix: true }
+
+  return { rawType: `import('${specifier}').${info.exportedName}` }
+}
+
+/**
+ * Module specifier for an import-type reference from `data.gen.ts` to
+ * `filePath`, or `null` for a file an extensionless specifier does not
+ * resolve to (`.mts`, `.mjs` — and `.js`/`.mjs` cannot declare types anyway).
+ * The `.d.ts` guard looks unreachable — discovery skips those files — but it
+ * sits here because this is the site that slices: stripping only `.ts` from
+ * one would emit a specifier ending in `.d`, silently.
+ * Extensionless because that is the shape this repo's generators *choose*
+ * (api-client.gen.ts's `'./data.gen'`); the `.js` suffixes seen in generated
+ * imports are author-written statements copied verbatim, not a convention.
+ */
+function importTypeSpecifier(filePath: string, outputDirectory: string): string | null {
+  if (!filePath.endsWith('.ts') || filePath.endsWith('.d.ts')) return null
+  // Only data.gen.ts's directory matters here; the basename rides along
+  // because relativeImportPath answers for a file, not a directory.
+  return relativeImportPath(join(outputDirectory, 'data.gen.ts'), filePath.slice(0, -'.ts'.length))
+}
+
+function collectTypeImports(ast: File | null, source: string): string[] {
   if (!ast) return []
 
   const imports: string[] = []

--- a/packages/cli/tests/data-types.test.ts
+++ b/packages/cli/tests/data-types.test.ts
@@ -30,11 +30,11 @@ function resourceFixture(className: string, fields: string): string {
  * `toArray()` annotated as `returnType` when one is given. For the cases where
  * the declaration is the subject and the class around it is only scaffolding.
  */
-function postResourceFile(declarations: string, returnType?: string): string {
+function postResourceFile(declarations: string, returnType?: string, className = 'PostResource'): string {
   return (
     "import { Resource } from '@guren/core'\n\n"
     + `${declarations}\n\n`
-    + 'export class PostResource extends Resource<Record<string, unknown>> {\n'
+    + `export class ${className} extends Resource<Record<string, unknown>> {\n`
     + `  toArray()${returnType ? `: ${returnType}` : ''} {\n`
     + '    return {} as never\n'
     + '  }\n'
@@ -372,111 +372,23 @@ describe('generateDataTypes reports Resource classes it could not extract', () =
     expect(warnings[0]).toContain('move the declaration into it')
   })
 
-  it('says so when the annotated type is here but is not an object type', async () => {
+  it('refuses an uncopyable type that is not exported, and says export fixes it', async () => {
     await writeWorkspaceFiles(appRoot, {
-      // An intersection has no body to copy into the namespace. The
-      // declaration is right here, so telling the author to write one would
-      // send them looking for something they can already see.
+      // A reference to an unexported name is a TS2694 that takes the whole
+      // artifact out of compilation — the failure mode dropping a definition
+      // exists to avoid. But here "export it" is the one-word fix, and the
+      // default rewrite-the-shape advice would never mention it.
       'app/Http/Resources/PostResource.ts': postResourceFile(
-        "import type { PostRecord } from '../../Models/Post.js'\n\n"
-        + 'export type PostPayload = PostRecord & { extra: string }',
+        'type PostPayload = { id: number } & { title: string }',
         'PostPayload',
       ),
     })
 
-    const { warnings } = await generateDataTypes({ appRoot, force: true })
-
-    expect(warnings).toHaveLength(1)
-    expect(warnings[0]).toContain('declares PostPayload in that file')
-    expect(warnings[0]).toContain('is not a plain object type')
-    expect(warnings[0]).not.toContain('move the declaration into it')
-  })
-
-  it('refuses a declaration whose extends clause holds an object type', async () => {
-    await writeWorkspaceFiles(appRoot, {
-      // `extends[^{;]*` stops at the generic argument's brace, so the type
-      // emitted was the argument — a payload the route never sends, with
-      // nothing said about it.
-      'app/Http/Resources/PostResource.ts': postResourceFile(
-        'export interface PostResourceData extends Record<string, { nested: true }> {\n'
-        + '  id: number\n}',
-        'PostResourceData',
-      ),
-    })
-
     const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
 
     expect(definitions.map((d) => d.rawType)).toEqual([null])
     expect(warnings).toHaveLength(1)
-    expect(warnings[0]).toContain('`extends` clause containing an object type')
-  })
-
-  it('refuses a type merged across two declarations', async () => {
-    await writeWorkspaceFiles(appRoot, {
-      'app/Http/Resources/PostResource.ts': postResourceFile(
-        'export interface PostResourceData {\n  id: number\n}\n\n'
-        + 'export interface PostResourceData {\n  title: string\n}',
-        'PostResourceData',
-      ),
-    })
-
-    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
-
-    // Emitting the first block alone drops `title` from a payload that
-    // carries it — a type that compiles and is wrong.
-    expect(definitions.map((d) => d.rawType)).toEqual([null])
-    expect(warnings).toHaveLength(1)
-    expect(warnings[0]).toContain('declared more than once')
-  })
-
-  it('refuses an alias that composes its object body with another type', async () => {
-    await writeWorkspaceFiles(appRoot, {
-      // The shape the "write `type X = { … }`" advice sits next to, so
-      // getting it wrong silently is the likeliest way this misleads.
-      'app/Http/Resources/PostResource.ts': postResourceFile(
-        'export type PostResourceData = { id: number } & { title: string }',
-        'PostResourceData',
-      ),
-    })
-
-    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
-
-    expect(definitions.map((d) => d.rawType)).toEqual([null])
-    expect(warnings).toHaveLength(1)
-    expect(warnings[0]).toContain('one operand of a larger type')
-  })
-
-  it('refuses an alias that uses its body as an operand', async () => {
-    await writeWorkspaceFiles(appRoot, {
-      // `{ … }[]` is an array of the body and `{ … }['k']` is one member of
-      // it. Emitting the body itself describes neither.
-      'app/Http/Resources/PostResource.ts': postResourceFile(
-        'export type PostResourceData = { id: number }[]',
-        'PostResourceData',
-      ),
-    })
-
-    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
-
-    expect(definitions.map((d) => d.rawType)).toEqual([null])
-    expect(warnings).toHaveLength(1)
-    expect(warnings[0]).toContain('one operand of a larger type')
-  })
-
-  it('refuses an alias indexed into, rather than emitting what it indexes', async () => {
-    await writeWorkspaceFiles(appRoot, {
-      'app/Http/Resources/PostResource.ts': postResourceFile(
-        "export type PostResourceData = { payload: { id: number } }['payload']",
-        'PostResourceData',
-      ),
-    })
-
-    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
-
-    // The outer body is the *container*; emitting it types the route with a
-    // wrapper the server never sends.
-    expect(definitions.map((d) => d.rawType)).toEqual([null])
-    expect(warnings[0]).toContain('one operand of a larger type')
+    expect(warnings[0]).toContain('Export PostPayload so data.gen.ts can reference the declaration')
   })
 
   it('tells the author to close an unterminated body instead of rewriting it', async () => {
@@ -564,6 +476,219 @@ describe('generateDataTypes reports Resource classes it could not extract', () =
     expect(warnings).toEqual([])
     expect(definitions.map((d) => d.dataName)).toEqual(['Post'])
   })
+})
+
+describe('generateDataTypes references exported types it cannot copy', () => {
+  let appRoot: string
+
+  beforeEach(async () => {
+    appRoot = await mkdtemp(join(tmpdir(), 'guren-cli-data-types-ref-'))
+  })
+
+  afterEach(async () => {
+    await rm(appRoot, { recursive: true, force: true })
+  })
+
+  const POST_REFERENCE = "import('../app/Http/Resources/PostResource').PostResourceData"
+
+  // One row per uncopyable-but-referencable shape: same fixture scaffolding,
+  // same two assertions, so the list of shapes reads as a list. Each shape
+  // used to be refused; the rationale for why a *copy* would be wrong rides
+  // with its row.
+  const REFERENCED_SHAPES: Array<[title: string, declarations: string]> = [
+    [
+      // `extends[^{;]*` stops at the generic argument's brace, so a copy would
+      // emit the argument — a payload the route never sends. The reference
+      // resolves the interface, heritage and all.
+      'a declaration whose extends clause holds an object type',
+      'export interface PostResourceData extends Record<string, { nested: true }> {\n'
+      + '  id: number\n}',
+    ],
+    [
+      // Copying either block alone drops the other's members — a type that
+      // compiles and is wrong. The reference resolves to the merged type.
+      'a type merged across two declarations',
+      'export interface PostResourceData {\n  id: number\n}\n\n'
+      + 'export interface PostResourceData {\n  title: string\n}',
+    ],
+    [
+      'an alias that composes its object body with another type',
+      'export type PostResourceData = { id: number } & { title: string }',
+    ],
+    [
+      // `{ … }[]` is an array of the body and `{ … }['k']` is one member of
+      // it. Copying the body describes neither; the reference names the alias.
+      'an alias that uses its body as an operand',
+      'export type PostResourceData = { id: number }[]',
+    ],
+    [
+      'an alias indexed into, rather than emitting what it indexes',
+      "export type PostResourceData = { payload: { id: number } }['payload']",
+    ],
+    [
+      // `declare` breaks a reader that expects `interface|type` right after
+      // the optional `export` — and a modifier only one of the two readers
+      // admits would split the verdict between them.
+      'a declare-modified alias',
+      'export declare type PostResourceData = { id: number } & { title: string }',
+    ],
+  ]
+
+  for (const [title, declarations] of REFERENCED_SHAPES) {
+    it(`references ${title}`, async () => {
+      await writeWorkspaceFiles(appRoot, {
+        'app/Http/Resources/PostResource.ts': postResourceFile(declarations, 'PostResourceData'),
+      })
+
+      const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
+
+      expect(warnings).toEqual([])
+      expect(definitions.map((d) => d.rawType)).toEqual([POST_REFERENCE])
+    })
+  }
+
+  it('prefers a plainly-named export specifier over an unspellable alias', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      // The dotted reference cannot spell `'wire-name'`; the second specifier
+      // exports the same declaration under its own name and must win however
+      // the list orders them.
+      'app/Http/Resources/PostResource.ts': postResourceFile(
+        'type PostPayload = { id: number } & { title: string }\n\n'
+        + "export type { PostPayload as 'wire-name', PostPayload }",
+        'PostPayload',
+      ),
+    })
+
+    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
+
+    expect(warnings).toEqual([])
+    expect(definitions.map((d) => d.rawType)).toEqual([
+      "import('../app/Http/Resources/PostResource').PostPayload",
+    ])
+  })
+
+  it(
+    'emits a reference tsc can compile and resolve',
+    async () => {
+      await writeWorkspaceFiles(appRoot, {
+        // Self-contained on purpose (no @guren/core import): tsc follows the
+        // reference into this file, so everything it imports must resolve.
+        'app/Http/Resources/PostResource.ts':
+          'declare class Resource<T> { constructor(resource: T) }\n\n'
+          + 'export type PostResourceData = { id: number } & { title: string }\n\n'
+          + 'export class PostResource extends Resource<Record<string, unknown>> {\n'
+          + '  toArray(): PostResourceData {\n'
+          + '    return {} as never\n'
+          + '  }\n'
+          + '}\n',
+      })
+
+      const { outputPath, definitions, warnings } = await generateDataTypes({ appRoot, force: true })
+
+      expect(warnings).toEqual([])
+      expect(definitions.map((d) => d.rawType)).toEqual([POST_REFERENCE])
+      expect(
+        checkTypes([outputPath], {
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+          target: 'ES2022',
+          types: [],
+        }),
+      ).toEqual([])
+    },
+    TSC_TIMEOUT,
+  )
+
+  it('references an exported annotated type it cannot copy', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      // An intersection has no body to copy into the namespace — but the
+      // declaration is exported, so a reference to it cannot be wrong the way
+      // a guessed body could.
+      'app/Http/Resources/PostResource.ts': postResourceFile(
+        "import type { PostRecord } from '../../Models/Post.js'\n\n"
+        + 'export type PostPayload = PostRecord & { extra: string }',
+        'PostPayload',
+      ),
+    })
+
+    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
+
+    expect(warnings).toEqual([])
+    expect(definitions.map((d) => d.rawType)).toEqual([
+      "import('../app/Http/Resources/PostResource').PostPayload",
+    ])
+    // The file's type imports must not ride along: the reference resolves
+    // inside the resource's own module, and a same-named import from another
+    // root would collide in the shared import block.
+    expect(definitions.map((d) => d.imports)).toEqual([[]])
+    expect(await readFile(join(appRoot, '.guren/data.gen.ts'), 'utf8')).not.toContain('PostRecord')
+  })
+
+  it('references the annotated type when it is an exported z.infer alias', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      // The motivating case: one zod schema as the single source of truth for
+      // the runtime contract (`output:`) and the Resource's payload type.
+      'app/Http/Resources/TaskResource.ts':
+        "import { Resource } from '@guren/core'\n"
+        + "import { z } from 'zod'\n\n"
+        + 'export const TaskResourceSchema = z.object({ id: z.number(), title: z.string() })\n'
+        + 'export type TaskResourceData = z.infer<typeof TaskResourceSchema>\n\n'
+        + 'export class TaskResource extends Resource<Record<string, unknown>> {\n'
+        + '  toArray(): TaskResourceData {\n'
+        + '    return {} as never\n'
+        + '  }\n'
+        + '}\n',
+    })
+
+    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
+
+    expect(warnings).toEqual([])
+    expect(definitions.map((d) => [d.dataName, d.rawType])).toEqual([
+      ['Task', "import('../app/Http/Resources/TaskResource').TaskResourceData"],
+    ])
+  })
+
+  it('references a module resource through its modules/ path', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      'modules/billing/app/Http/Resources/InvoiceResource.ts': postResourceFile(
+        'export type InvoiceResourceData = { total: number } & { currency: string }',
+        'InvoiceResourceData',
+        'InvoiceResource',
+      ),
+    })
+
+    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
+
+    expect(warnings).toEqual([])
+    expect(definitions.map((d) => [d.dataName, d.rawType])).toEqual([
+      [
+        'BillingInvoice',
+        "import('../modules/billing/app/Http/Resources/InvoiceResource').InvoiceResourceData",
+      ],
+    ])
+  })
+
+  it('references a type exported through an export list', async () => {
+    await writeWorkspaceFiles(appRoot, {
+      // `export type { X }` exports without an `export` keyword on the
+      // declaration line — which is why exportedness is read from the AST, not
+      // from the line the declaration sits on.
+      'app/Http/Resources/PostResource.ts': postResourceFile(
+        'type PostPayload = { id: number } & { title: string }\n\n'
+        + 'export type { PostPayload }',
+        'PostPayload',
+      ),
+    })
+
+    const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
+
+    expect(warnings).toEqual([])
+    expect(definitions.map((d) => d.rawType)).toEqual([
+      "import('../app/Http/Resources/PostResource').PostPayload",
+    ])
+  })
+
 })
 
 /**
@@ -730,14 +855,18 @@ describe('generateDataTypes reads a type body by brace depth', () => {
     expect(definitions.map((d) => d.rawType)).toEqual(['{\n  id: number\n}'])
   })
 
-  it('ignores a same-named alias that declares no object type', async () => {
+  it('references a same-named alias that declares no object type', async () => {
     // `type PostResourceData = string` has no body; walking forward to the
-    // next `{` would hand back the class declaration below it.
+    // next `{` would hand back the class declaration below it. Exported, the
+    // alias is referenced instead — the convention says this name *is* the
+    // payload, and the reference takes the author's declaration at its word.
     await writeResource('export type PostResourceData = string')
 
     const { definitions, warnings } = await generateDataTypes({ appRoot, force: true })
 
-    expect(definitions.map((d) => d.rawType)).toEqual([null])
-    expect(warnings).toHaveLength(1)
+    expect(warnings).toEqual([])
+    expect(definitions.map((d) => d.rawType)).toEqual([
+      "import('../app/Http/Resources/PostResource').PostResourceData",
+    ])
   })
 })


### PR DESCRIPTION
## Summary

`generateDataTypes` builds `.guren/data.gen.ts` by copying each Resource payload type's brace body textually. Any declaration without a copyable body — a `z.infer<typeof Schema>` alias, an intersection, a merged interface, an alias used as an operand (`{…}[]`, `{…}['k']`) — was refused with a warning, costing the resource its `Data.*` member and leaving `resource:`-hinted routes untyped.

This PR adds a fallback: when the declaration cannot be copied but the file **exports** it, emit an import-type reference to the declaration itself:

```ts
export namespace Data {
  export type Task = import('../app/Http/Resources/TaskResource').TaskResourceData
}
```

This lets one zod schema be the single source of truth for both the runtime response contract (`output:`) and the Resource's payload type:

```ts
export const TaskResourceSchema = z.object({ id: z.number(), title: z.string() })
export type TaskResourceData = z.infer<typeof TaskResourceSchema>

export class TaskResource extends Resource<TaskRecord> {
  toArray(): TaskResourceData { … }
}
```

**Why fallback, not replacement:** copy stays first — it works for unexported declarations, keeps `data.gen.ts` self-describing, and a pure fallback cannot change any output that was already being emitted, so no existing app's `data.gen.ts` body changes.

**Design decisions:**

- **Exportedness is proven from the AST**, not the declaration line — `export type { X }` exports without touching the line, and a reference to an unexported name is a TS2694 that takes the whole artifact (every other resource's type with it) out of compilation. Verified against tsc with the scaffolded tsconfig, including module resources (`modules/<name>/…`) and declaration merging (the reference resolves the *merged* type, which a single-block copy could not).
- **Non-identifier export aliases** (`export { X as 'wire-name' }`) are skipped when recording, so a plainly-named specifier of the same declaration wins regardless of list order.
- **The reference path drops the file's type imports** — the reference resolves inside the resource's own module, and two roots' same-named imports must not collide in the shared import block.
- **Specifiers are extensionless**, matching the one specifier this repo's generators already choose (`'./data.gen'` in api-client.gen.ts), built with the shared `relativeImportPath` helper.
- **Still refused**: generics (a reference has no type arguments to pass), unexported declarations (the warning now names exporting as the one-word fix), unterminated bodies, and types declared in another file.
- The `readObjectType` regexes now admit a `declare` modifier so the lexical reader and the AST index agree on what counts as declared in the file.

## Scope

- `cli`: `packages/cli/src/data-types.ts` + tests
- `docs`: `docs/{en,ja}/guides/api-resources.md` gain a section on deriving the payload type from a zod schema
- changeset: `@guren/cli` minor

## Risk Assessment

- Pure fallback: every shape that emitted before emits byte-identically; only previously-omitted resources gain a `Data.*` member (and their `resource:`-hinted routes gain response types).
- `Data.X` is no longer guaranteed to be an object type — an exported alias may be an array or union; that is the author's own declaration, but `resource: [X]` hints render `Data.X[]` on top of it.
- Apps on `moduleResolution: NodeNext` would need extensioned specifiers — but the existing generated artifacts (`'./data.gen'`) already assume bundler resolution, so no new constraint is introduced.
- `.mts` resources and `export default interface` stay on the warning path (the latter behaves exactly as before this PR).

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` (`test:bun` all packages green; data-types tests 43 pass)
- [x] `bun run audit:docs` / `bun run audit:core-first`
- Previously-refused shapes now pin the reference output (table-driven), plus new tests for the z.infer case, module paths, `export type { X }` lists, alias-order independence, the unexported warning, dropped imports, and a tsc compile gate that follows the emitted reference.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.