### PR TITLE
chore(create-app): regenerate stale data.gen headers in templates

### DIFF
--- a/packages/create-app/templates/blog/.guren/data.gen.ts
+++ b/packages/create-app/templates/blog/.guren/data.gen.ts
@@ -1,4 +1,4 @@
-// Generated from app/Http/Resources — DO NOT EDIT
+// Generated from app/Http/Resources (and modules/*/app/Http/Resources) — DO NOT EDIT
 // Run `guren codegen` to regenerate.
 
 import type { PostRecord, PostAuthorSummary } from '../app/Models/Post.js'

--- a/packages/create-app/templates/default/.guren/data.gen.ts
+++ b/packages/create-app/templates/default/.guren/data.gen.ts
@@ -1,4 +1,4 @@
-// Generated from app/Http/Resources — DO NOT EDIT
+// Generated from app/Http/Resources (and modules/*/app/Http/Resources) — DO NOT EDIT
 // Run `guren codegen` to regenerate.
 
 /**


### PR DESCRIPTION
## Summary
- The committed `data.gen.ts` in the `blog` and `default` starter templates still had the pre-module-fan-out header comment (`// Generated from app/Http/Resources — DO NOT EDIT`), while `generateDataTypes` (packages/cli/src/data-types.ts) has stamped the module-aware header (`// Generated from app/Http/Resources (and modules/*/app/Http/Resources) — DO NOT EDIT`) since module support was added.
- Regenerated both files via `generateDataTypes({ appRoot: <template>, force: true })`; the body was already byte-identical, so only line 1 changed in each file.
- Nothing in CI asserts these generated files against their generator, so the drift stayed green — this closes that gap for these two files.

## Test plan
- [x] `git diff` confirms only line 1 changed in each `data.gen.ts`
- [x] `bun run audit:starter-template` passes
- [x] `bun run test:bun create-app` — 71 pass / 0 fail