### PR TITLE
feat(server): Controller.view() — first-class content rendering (RFC 0014)

### DIFF
--- a/.changeset/controller-view.md
+++ b/.changeset/controller-view.md
@@ -1,0 +1,19 @@
+---
+"@guren/server": minor
+"@guren/core": minor
+---
+
+First-class content rendering (RFC 0014): `Controller.view(component, props)`
+renders a `hono/jsx` component to plain server-rendered HTML — the
+non-hydrating counterpart to `this.inertia()` for public content pages, with
+auto-escaping, native `<title>`/`<meta>`/`<link>` head hoisting, and a loud
+error when a page forgets its Layout (pass `{ doctype: false }` for
+intentional fragments).
+
+Alongside it: `viteAsset(entry)` resolves Vite asset URLs (dev server in
+development, hashed manifest output in production, throws when neither
+resolves), and new `@guren/core/jsx-runtime` / `@guren/core/jsx-dev-runtime`
+subpaths let View files compile with `/** @jsxImportSource @guren/core */` —
+applications never declare hono themselves. `@guren/server`'s hono floor
+moves to `^4.13.0`, where the component result contract `view()` renders was
+introduced.

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "examples/api": {
       "name": "@guren/example-api",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -70,7 +70,7 @@
     },
     "packages/cli": {
       "name": "@guren/cli",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "bin": {
         "guren": "./dist/bin.js",
       },
@@ -103,7 +103,7 @@
     },
     "packages/core": {
       "name": "@guren/core",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "bin": {
         "guren": "./dist/bin.js",
       },
@@ -121,7 +121,7 @@
     },
     "packages/create-app": {
       "name": "create-guren-app",
-      "version": "1.8.8",
+      "version": "1.8.9",
       "bin": {
         "create-guren-app": "./dist/cli.js",
       },
@@ -137,7 +137,7 @@
     },
     "packages/inertia-client": {
       "name": "@guren/inertia-client",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "@inertiajs/core": "^3.6.1",
         "@inertiajs/react": "^3.6.1",
@@ -155,7 +155,7 @@
     },
     "packages/openapi": {
       "name": "@guren/openapi",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@guren/core": "^1.6.0",
       },
@@ -167,7 +167,7 @@
     },
     "packages/orm": {
       "name": "@guren/orm",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "dependencies": {
         "drizzle-orm": "1.0.0-rc.4",
       },
@@ -192,7 +192,7 @@
     },
     "packages/plugin-cloudflare": {
       "name": "@guren/plugin-cloudflare",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@guren/core": "^1.6.2",
         "citty": "^0.1.6",
@@ -207,7 +207,7 @@
     },
     "packages/plugin-lambda": {
       "name": "@guren/plugin-lambda",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@guren/core": "^1.6.2",
         "citty": "^0.1.6",
@@ -230,7 +230,7 @@
     },
     "packages/plugin-markdown": {
       "name": "@guren/plugin-markdown",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@guren/core": "^1.7.0",
         "@types/sanitize-html": "^2.16.1",
@@ -253,7 +253,7 @@
     },
     "packages/plugin-vercel": {
       "name": "@guren/plugin-vercel",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@guren/core": "^1.6.2",
       },
@@ -265,14 +265,14 @@
     },
     "packages/server": {
       "name": "@guren/server",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "dependencies": {
-        "@guren/orm": "^2.6.0",
+        "@guren/orm": "^2.6.1",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "chalk": "^5.3.0",
         "consola": "^3.4.2",
         "figlet": "^1.7.0",
-        "hono": "^4.12.29",
+        "hono": "^4.13.0",
         "ioredis": "^5.11.1",
         "nodemailer": "^9.0.1",
       },
@@ -300,7 +300,7 @@
     },
     "packages/testing": {
       "name": "@guren/testing",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "devDependencies": {
         "@types/react": "^19.0.0",
         "tsdown": "^0.22.14",
@@ -326,7 +326,7 @@
     },
     "web": {
       "name": "web",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -224,6 +224,7 @@ export const CONTROLLER_MEMBER_KINDS: Readonly<Record<string, ControllerMemberKi
   authorize: 'non-body',
   can: 'non-body',
   inertia: 'non-body',
+  view: 'non-body',
   locale: 'non-body',
   t: 'non-body',
   tc: 'non-body',

--- a/packages/cli/src/guidelines.ts
+++ b/packages/cli/src/guidelines.ts
@@ -38,7 +38,8 @@ export async function generateGuidelines(options: GuidelinesOptions = {}): Promi
     lines.push(`- Controllers: ${allSingular ? 'singular' : 'plural'} resource name (e.g., ${controllers[0]})`)
   }
   lines.push(`- Models: PascalCase, singular (e.g., Post, User)`)
-  lines.push(`- Views: nested folders under resources/js/pages/ (e.g., Posts/Index.tsx)`)
+  lines.push(`- Inertia pages: nested folders under resources/js/pages/ (e.g., Posts/Index.tsx)`)
+  lines.push(`- Server-rendered content Views (Controller.view()): app/View/ with the @jsxImportSource @guren/core pragma — never under resources/js/pages/`)
   lines.push('')
 
   // Auth setup
@@ -139,7 +140,7 @@ export async function generateGuidelines(options: GuidelinesOptions = {}): Promi
   lines.push('## When Creating New Features')
   lines.push('1. Create model in `app/Models/`')
   lines.push('2. Create controller in `app/Http/Controllers/`')
-  lines.push('3. Create views in `resources/js/pages/{Feature}/`')
+  lines.push('3. Create Inertia pages in `resources/js/pages/{Feature}/` (server-rendered content Views go in `app/View/`)')
   lines.push('4. Create validator in `app/Http/Validators/` (`bunx guren make:validator <Name> --fields "..."`)')
   lines.push('5. Create resource in `app/Http/Resources/`')
   lines.push('6. Register routes in `routes/web.ts`')

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,14 @@
     "./internal/zod-compat": {
       "types": "./dist/internal/zod-compat.d.ts",
       "default": "./dist/internal/zod-compat.js"
+    },
+    "./jsx-runtime": {
+      "types": "./dist/jsx-runtime.d.ts",
+      "default": "./dist/jsx-runtime.js"
+    },
+    "./jsx-dev-runtime": {
+      "types": "./dist/jsx-dev-runtime.d.ts",
+      "default": "./dist/jsx-dev-runtime.js"
     }
   },
   "bin": {

--- a/packages/core/src/jsx-dev-runtime.ts
+++ b/packages/core/src/jsx-dev-runtime.ts
@@ -1,0 +1,5 @@
+/**
+ * Development twin of `jsx-runtime.ts` — compilers emit imports from the
+ * `/jsx-dev-runtime` subpath in dev transforms.
+ */
+export * from '@guren/server/jsx-dev-runtime'

--- a/packages/core/src/jsx-runtime.ts
+++ b/packages/core/src/jsx-runtime.ts
@@ -1,0 +1,12 @@
+/**
+ * The JSX runtime application View files compile against (RFC 0014):
+ *
+ * ```tsx
+ * /** @jsxImportSource @guren/core *​/
+ * ```
+ *
+ * A pure re-export of `@guren/server/jsx-runtime` (itself hono's), so the
+ * pragma, `Controller.view()`'s renderer, and the framework all share one
+ * hono copy. Apps never declare hono.
+ */
+export * from '@guren/server/jsx-runtime'

--- a/packages/core/src/jsx-runtime.ts
+++ b/packages/core/src/jsx-runtime.ts
@@ -1,12 +1,8 @@
 /**
- * The JSX runtime application View files compile against (RFC 0014):
- *
- * ```tsx
- * /** @jsxImportSource @guren/core *​/
- * ```
- *
- * A pure re-export of `@guren/server/jsx-runtime` (itself hono's), so the
- * pragma, `Controller.view()`'s renderer, and the framework all share one
- * hono copy. Apps never declare hono.
+ * The JSX runtime application View files compile against (RFC 0014), via a
+ * per-file `@jsxImportSource` pragma pointing at `@guren/core`. A pure
+ * re-export of `@guren/server/jsx-runtime` (itself hono's), so the pragma,
+ * `Controller.view()`'s renderer, and the framework all share one hono copy.
+ * Apps never declare hono.
  */
 export * from '@guren/server/jsx-runtime'

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
   ...tsdownPreset,
   entry: [
     'src/index.ts',
+    'src/jsx-runtime.ts',
+    'src/jsx-dev-runtime.ts',
     'src/bin.ts',
     'src/runtime.ts',
     'src/vite.ts',

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -105,6 +105,14 @@
     "./support/expiry": {
       "types": "./dist/support/expiry.d.ts",
       "default": "./dist/support/expiry.js"
+    },
+    "./jsx-runtime": {
+      "types": "./dist/jsx-runtime.d.ts",
+      "default": "./dist/jsx-runtime.js"
+    },
+    "./jsx-dev-runtime": {
+      "types": "./dist/jsx-dev-runtime.d.ts",
+      "default": "./dist/jsx-dev-runtime.js"
     }
   },
   "scripts": {
@@ -119,7 +127,7 @@
     "chalk": "^5.3.0",
     "consola": "^3.4.2",
     "figlet": "^1.7.0",
-    "hono": "^4.12.29",
+    "hono": "^4.13.0",
     "ioredis": "^5.11.1",
     "nodemailer": "^9.0.1"
   },

--- a/packages/server/src/http/inertia-assets.ts
+++ b/packages/server/src/http/inertia-assets.ts
@@ -15,7 +15,17 @@ import { parseImportMap } from '../support/import-map'
 import { DEFAULT_DEV_STYLES_ENTRY } from '../support/inertia-defaults'
 import { trimTrailingSlashes } from '../support/trim-slashes'
 import { hash } from '../encryption/Hash'
-import { loadViteManifest, getManifestFile, getManifestCss, type ViteManifest } from './vite-manifest'
+import {
+  loadViteManifest,
+  getManifestFile,
+  getManifestCss,
+  clientManifestCandidates,
+  isViteProduction,
+  normalizeDevServerUrl,
+  DEFAULT_DEV_SERVER_URL,
+  PUBLIC_ASSETS_URL_PREFIX,
+  type ViteManifest,
+} from './vite-manifest'
 
 export interface InertiaAssetsOptions extends DevAssetsOptions {
   /** Default stylesheet entry embedded into Inertia responses. */
@@ -213,11 +223,10 @@ export function autoConfigureInertiaAssets(app: Application, options: AutoConfig
     return
   }
 
-  const isProduction =
-    (process.env.NODE_ENV ?? 'development') === 'production' && typeof process.env.VITE_DEV_SERVER_URL !== 'string'
+  const isProduction = isViteProduction()
 
   if (!isProduction) {
-    const devServerUrl = options.devServerUrl ?? process.env.VITE_DEV_SERVER_URL ?? 'http://localhost:5173'
+    const devServerUrl = options.devServerUrl ?? process.env.VITE_DEV_SERVER_URL ?? DEFAULT_DEV_SERVER_URL
     const normalizedDevServerUrl = normalizeDevServerUrl(devServerUrl)
     setEnvIfUserDidNotProvide('GUREN_INERTIA_ENTRY', `${normalizedDevServerUrl}/resources/js/dev-entry.ts`)
     setEnvIfUserDidNotProvide('GUREN_INERTIA_STYLES', options.stylesEntry ?? DEFAULT_DEV_STYLES_ENTRY)
@@ -241,11 +250,10 @@ export function autoConfigureInertiaAssets(app: Application, options: AutoConfig
   }
 
   const clientManifest = loadViteManifest(
-    [
-      resolve(moduleDir, '../public/assets/manifest.json'),
-      resolve(moduleDir, '../public/assets/.vite/manifest.json'),
-    ],
+    clientManifestCandidates(resolve(moduleDir, '..')),
     'client',
+    // The build-id hash below reads the raw text; nothing else does.
+    { includeRaw: true },
   )
 
   const clientEntry = clientManifest?.['resources/js/app.tsx']
@@ -260,13 +268,13 @@ export function autoConfigureInertiaAssets(app: Application, options: AutoConfig
   }
 
   if (clientEntryFile) {
-    setEnvIfUserDidNotProvide('GUREN_INERTIA_ENTRY', `/public/assets/${clientEntryFile.replace(/^\//u, '')}`)
+    setEnvIfUserDidNotProvide('GUREN_INERTIA_ENTRY', `${PUBLIC_ASSETS_URL_PREFIX}${clientEntryFile.replace(/^\//u, '')}`)
   }
 
   if (clientCssFiles?.length) {
     setEnvIfUserDidNotProvide(
       'GUREN_INERTIA_STYLES',
-      clientCssFiles.map((href) => `/public/assets/${href.replace(/^\//u, '')}`).join(','),
+      clientCssFiles.map((href) => `${PUBLIC_ASSETS_URL_PREFIX}${href.replace(/^\//u, '')}`).join(','),
     )
   }
 
@@ -355,21 +363,6 @@ function resolveDevSsrEntry(options: InertiaAssetsOptions): string | undefined {
 
   return resolve(resourcesDir, 'js/ssr.tsx')
 }
-
-function normalizeDevServerUrl(value: string): string {
-  if (!value) {
-    return value
-  }
-
-  const trimmed = value.trim()
-  if (!trimmed) {
-    return trimmed
-  }
-
-  const stripped = trimTrailingSlashes(trimmed)
-  return stripped.length > 0 ? stripped : '/'
-}
-
 
 function deriveAssetRoot(manifest: ViteManifest | undefined, fallback: string): string | undefined {
   if (!manifest?.__path__) {

--- a/packages/server/src/http/inertia-assets.ts
+++ b/packages/server/src/http/inertia-assets.ts
@@ -1,7 +1,6 @@
 import { serveStatic } from 'hono/bun'
 import { dirname, resolve, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { readFileSync } from 'node:fs'
 import type { Application } from './Application'
 import {
   createStaticRewrite,
@@ -16,6 +15,7 @@ import { parseImportMap } from '../support/import-map'
 import { DEFAULT_DEV_STYLES_ENTRY } from '../support/inertia-defaults'
 import { trimTrailingSlashes } from '../support/trim-slashes'
 import { hash } from '../encryption/Hash'
+import { loadViteManifest, getManifestFile, getManifestCss, type ViteManifest } from './vite-manifest'
 
 export interface InertiaAssetsOptions extends DevAssetsOptions {
   /** Default stylesheet entry embedded into Inertia responses. */
@@ -370,52 +370,6 @@ function normalizeDevServerUrl(value: string): string {
   return stripped.length > 0 ? stripped : '/'
 }
 
-type ViteManifestEntryObject = {
-  file: string
-  css?: string[]
-  assets?: string[]
-  imports?: string[]
-  dynamicImports?: string[]
-}
-
-type ViteManifestValue = ViteManifestEntryObject | string[]
-
-type ViteManifest = Record<string, ViteManifestValue> & { __path__?: string; __raw__?: string }
-
-function loadViteManifest(candidatePaths: string[], label: 'client' | 'SSR'): ViteManifest | undefined {
-  const command = label === 'SSR' ? 'bunx vite build --ssr' : 'bunx vite build'
-
-  for (const manifestPath of candidatePaths) {
-    try {
-      const raw = readFileSync(manifestPath, 'utf8')
-      const manifest = JSON.parse(raw) as ViteManifest
-      Object.defineProperty(manifest, '__path__', {
-        value: manifestPath,
-        enumerable: false,
-      })
-      Object.defineProperty(manifest, '__raw__', {
-        value: raw,
-        enumerable: false,
-      })
-      return manifest
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        console.warn(`Unable to load ${label} Vite manifest at ${manifestPath}.`, error)
-        return undefined
-      }
-    }
-  }
-
-  if (candidatePaths.length) {
-    console.warn(
-      `Unable to load ${label} Vite manifest. Checked paths:\n${candidatePaths
-        .map((p) => `  - ${p}`)
-        .join('\n')}\nRun \`${command}\` before starting in production.`,
-    )
-  }
-
-  return undefined
-}
 
 function deriveAssetRoot(manifest: ViteManifest | undefined, fallback: string): string | undefined {
   if (!manifest?.__path__) {
@@ -423,38 +377,6 @@ function deriveAssetRoot(manifest: ViteManifest | undefined, fallback: string): 
   }
 
   return resolve(dirname(manifest.__path__), '..')
-}
-
-function getManifestFile(
-  entry: ViteManifestValue | string | undefined,
-): string | undefined {
-  if (!entry) {
-    return undefined
-  }
-
-  if (Array.isArray(entry)) {
-    return entry[0]
-  }
-
-  if (typeof entry === 'string') {
-    return entry
-  }
-
-  if ('file' in entry && typeof entry.file === 'string') {
-    return entry.file
-  }
-
-  return undefined
-}
-
-function getManifestCss(
-  entry: ViteManifestValue | string | undefined,
-): string[] | undefined {
-  if (!entry || Array.isArray(entry) || typeof entry === 'string') {
-    return undefined
-  }
-
-  return entry.css
 }
 
 function resolveResourcesDir(options: InertiaAssetsOptions, moduleDir?: string): string | undefined {

--- a/packages/server/src/http/vite-assets.test.ts
+++ b/packages/server/src/http/vite-assets.test.ts
@@ -9,9 +9,11 @@ describe('viteAsset', () => {
   const savedNodeEnv = process.env.NODE_ENV
   const savedDevServerUrl = process.env.VITE_DEV_SERVER_URL
 
+  // No cache reset in the lifecycle hooks: every test's manifestPaths point
+  // into a fresh temp dir, so cache keys never collide across tests. The one
+  // test that needs a reset (cache semantics) calls it inline.
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'guren-vite-assets-'))
-    __resetViteAssetCache()
   })
 
   afterEach(() => {
@@ -22,7 +24,6 @@ describe('viteAsset', () => {
     } else {
       process.env.VITE_DEV_SERVER_URL = savedDevServerUrl
     }
-    __resetViteAssetCache()
   })
 
   const productionEnv = () => {

--- a/packages/server/src/http/vite-assets.test.ts
+++ b/packages/server/src/http/vite-assets.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { viteAsset, __resetViteAssetCache } from './vite-assets'
+
+describe('viteAsset', () => {
+  let tempDir: string
+  const savedNodeEnv = process.env.NODE_ENV
+  const savedDevServerUrl = process.env.VITE_DEV_SERVER_URL
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'guren-vite-assets-'))
+    __resetViteAssetCache()
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+    process.env.NODE_ENV = savedNodeEnv
+    if (savedDevServerUrl === undefined) {
+      delete process.env.VITE_DEV_SERVER_URL
+    } else {
+      process.env.VITE_DEV_SERVER_URL = savedDevServerUrl
+    }
+    __resetViteAssetCache()
+  })
+
+  const productionEnv = () => {
+    process.env.NODE_ENV = 'production'
+    delete process.env.VITE_DEV_SERVER_URL
+  }
+
+  const writeManifest = (entries: Record<string, unknown>): string => {
+    const path = join(tempDir, 'manifest.json')
+    writeFileSync(path, JSON.stringify(entries))
+    return path
+  }
+
+  describe('development', () => {
+    test('should point at the dev server when VITE_DEV_SERVER_URL is set', () => {
+      process.env.NODE_ENV = 'production'
+      process.env.VITE_DEV_SERVER_URL = 'http://localhost:5199/'
+
+      expect(viteAsset('resources/css/app.css')).toBe(
+        'http://localhost:5199/resources/css/app.css',
+      )
+    })
+
+    test('should default to localhost:5173 outside production', () => {
+      process.env.NODE_ENV = 'development'
+      delete process.env.VITE_DEV_SERVER_URL
+
+      expect(viteAsset('/resources/css/app.css')).toBe(
+        'http://localhost:5173/resources/css/app.css',
+      )
+    })
+  })
+
+  describe('production', () => {
+    test('should resolve a manifest entry to its hashed public URL', () => {
+      productionEnv()
+      const manifestPath = writeManifest({
+        'resources/css/app.css': { file: 'app-a1b2c3.css' },
+      })
+
+      expect(viteAsset('resources/css/app.css', { manifestPaths: [manifestPath] })).toBe(
+        '/public/assets/app-a1b2c3.css',
+      )
+    })
+
+    test('should throw naming the checked paths when no manifest exists', () => {
+      productionEnv()
+      const missing = join(tempDir, 'nope', 'manifest.json')
+
+      expect(() => viteAsset('resources/css/app.css', { manifestPaths: [missing] })).toThrow(
+        /no Vite manifest found[\s\S]*nope/,
+      )
+    })
+
+    test('should throw naming the entry when the manifest does not record it', () => {
+      productionEnv()
+      const manifestPath = writeManifest({
+        'resources/js/app.tsx': { file: 'app-ffffff.js' },
+      })
+
+      expect(() => viteAsset('resources/css/app.css', { manifestPaths: [manifestPath] })).toThrow(
+        /"resources\/css\/app\.css" is not in the Vite manifest/,
+      )
+    })
+
+    test('should cache the manifest read per path set', () => {
+      productionEnv()
+      const manifestPath = writeManifest({
+        'resources/css/app.css': { file: 'app-a1b2c3.css' },
+      })
+      expect(viteAsset('resources/css/app.css', { manifestPaths: [manifestPath] })).toBe(
+        '/public/assets/app-a1b2c3.css',
+      )
+
+      // Rewrite on disk; the cached copy must keep answering until reset.
+      writeFileSync(manifestPath, JSON.stringify({ 'resources/css/app.css': { file: 'app-zzz.css' } }))
+      expect(viteAsset('resources/css/app.css', { manifestPaths: [manifestPath] })).toBe(
+        '/public/assets/app-a1b2c3.css',
+      )
+
+      __resetViteAssetCache()
+      expect(viteAsset('resources/css/app.css', { manifestPaths: [manifestPath] })).toBe(
+        '/public/assets/app-zzz.css',
+      )
+    })
+  })
+})

--- a/packages/server/src/http/vite-assets.ts
+++ b/packages/server/src/http/vite-assets.ts
@@ -1,10 +1,20 @@
 import { resolve } from 'node:path'
-import { loadViteManifest, getManifestFile, type ViteManifest } from './vite-manifest'
-import { trimTrailingSlashes } from '../support/trim-slashes'
+import {
+  loadViteManifest,
+  getManifestFile,
+  clientManifestCandidates,
+  isViteProduction,
+  normalizeDevServerUrl,
+  DEFAULT_DEV_SERVER_URL,
+  PUBLIC_ASSETS_URL_PREFIX,
+  type ViteManifest,
+} from './vite-manifest'
+import { trimSlashes } from '../support/trim-slashes'
 
 /**
- * Options for {@link viteAsset}. Both fields exist for tests and unusual
- * layouts; ordinary applications call `viteAsset(entry)` with no options.
+ * Options for {@link viteAsset}. Ordinary applications call
+ * `viteAsset(entry)` with no options; `manifestPaths` exists for tests and
+ * unusual layouts.
  */
 export interface ViteAssetOptions {
   /**
@@ -12,19 +22,14 @@ export interface ViteAssetOptions {
    * directory). Defaults to the standard build output locations.
    */
   manifestPaths?: string[]
-  /** Dev-server URL override. Defaults to `VITE_DEV_SERVER_URL`. */
-  devServerUrl?: string
 }
 
-const DEFAULT_MANIFEST_PATHS = [
-  'public/assets/manifest.json',
-  'public/assets/.vite/manifest.json',
-]
-
+let defaultCandidates: string[] | undefined
 const manifestCache = new Map<string, ViteManifest | null>()
 
 /** @internal Test seam — clears the memoized manifest reads. */
 export function __resetViteAssetCache(): void {
+  defaultCandidates = undefined
   manifestCache.clear()
 }
 
@@ -53,21 +58,26 @@ export function __resetViteAssetCache(): void {
  * no manifest key of its own — declare it as an explicit build input in
  * `vite.config.ts` (`build.rollupOptions.input`) so Vite emits and records
  * it.
+ *
+ * **Serverless caveat:** production resolution reads the manifest from the
+ * filesystem, which bundled deploy targets (Cloudflare Workers, Vercel,
+ * Lambda) do not ship — their deploy plugins resolve assets at build time
+ * for Inertia and do not yet feed this helper. On those targets `viteAsset`
+ * throws at first render until the deploy plugins gain a build-time manifest
+ * injection; track that as the follow-up before using `view()` there.
  */
 export function viteAsset(entry: string, options: ViteAssetOptions = {}): string {
-  const normalizedEntry = entry.replace(/^\/+/u, '')
-  const devServerUrl = options.devServerUrl ?? process.env.VITE_DEV_SERVER_URL
-  // Mirrors autoConfigureInertiaAssets: a configured dev server means dev
-  // asset serving even when NODE_ENV says production.
-  const isProduction =
-    (process.env.NODE_ENV ?? 'development') === 'production' && typeof devServerUrl !== 'string'
+  const normalizedEntry = trimSlashes(entry)
+  const devServerUrl = process.env.VITE_DEV_SERVER_URL
 
-  if (!isProduction) {
-    const base = trimTrailingSlashes((devServerUrl ?? 'http://localhost:5173').trim())
+  if (!isViteProduction(devServerUrl)) {
+    const base = normalizeDevServerUrl(devServerUrl ?? DEFAULT_DEV_SERVER_URL)
     return `${base}/${normalizedEntry}`
   }
 
-  const candidates = (options.manifestPaths ?? DEFAULT_MANIFEST_PATHS).map((path) => resolve(path))
+  const candidates = options.manifestPaths
+    ? options.manifestPaths.map((path) => resolve(path))
+    : (defaultCandidates ??= clientManifestCandidates())
   const cacheKey = candidates.join('\n')
   let manifest = manifestCache.get(cacheKey)
   if (manifest === undefined) {
@@ -92,5 +102,5 @@ export function viteAsset(entry: string, options: ViteAssetOptions = {}): string
     )
   }
 
-  return `/public/assets/${file.replace(/^\/+/u, '')}`
+  return `${PUBLIC_ASSETS_URL_PREFIX}${trimSlashes(file)}`
 }

--- a/packages/server/src/http/vite-assets.ts
+++ b/packages/server/src/http/vite-assets.ts
@@ -1,0 +1,96 @@
+import { resolve } from 'node:path'
+import { loadViteManifest, getManifestFile, type ViteManifest } from './vite-manifest'
+import { trimTrailingSlashes } from '../support/trim-slashes'
+
+/**
+ * Options for {@link viteAsset}. Both fields exist for tests and unusual
+ * layouts; ordinary applications call `viteAsset(entry)` with no options.
+ */
+export interface ViteAssetOptions {
+  /**
+   * Vite manifest candidate paths (absolute, or relative to the working
+   * directory). Defaults to the standard build output locations.
+   */
+  manifestPaths?: string[]
+  /** Dev-server URL override. Defaults to `VITE_DEV_SERVER_URL`. */
+  devServerUrl?: string
+}
+
+const DEFAULT_MANIFEST_PATHS = [
+  'public/assets/manifest.json',
+  'public/assets/.vite/manifest.json',
+]
+
+const manifestCache = new Map<string, ViteManifest | null>()
+
+/** @internal Test seam — clears the memoized manifest reads. */
+export function __resetViteAssetCache(): void {
+  manifestCache.clear()
+}
+
+/**
+ * Resolve the public URL of a Vite build input, for server-rendered content
+ * pages (RFC 0014). The URL is environment-dependent and this helper owns
+ * both branches:
+ *
+ * - **Development** (a dev server is configured, or `NODE_ENV` is not
+ *   `production`): the Vite dev server serves the source path directly, so
+ *   this returns `${devServerUrl}/${entry}`.
+ * - **Production**: the entry is looked up in the Vite build manifest and the
+ *   hashed output file is returned under the `/public/assets/` route that
+ *   `configureInertiaAssets` serves with immutable caching.
+ *
+ * Fails loudly: an unresolvable manifest or an entry the manifest does not
+ * record throws with the paths tried and the likely fix — never a silent
+ * empty string.
+ *
+ * @example
+ * ```tsx
+ * <link rel="stylesheet" href={viteAsset('resources/css/app.css')} />
+ * ```
+ *
+ * Note a CSS file bundled *through* a JS entry (imported from `app.tsx`) has
+ * no manifest key of its own — declare it as an explicit build input in
+ * `vite.config.ts` (`build.rollupOptions.input`) so Vite emits and records
+ * it.
+ */
+export function viteAsset(entry: string, options: ViteAssetOptions = {}): string {
+  const normalizedEntry = entry.replace(/^\/+/u, '')
+  const devServerUrl = options.devServerUrl ?? process.env.VITE_DEV_SERVER_URL
+  // Mirrors autoConfigureInertiaAssets: a configured dev server means dev
+  // asset serving even when NODE_ENV says production.
+  const isProduction =
+    (process.env.NODE_ENV ?? 'development') === 'production' && typeof devServerUrl !== 'string'
+
+  if (!isProduction) {
+    const base = trimTrailingSlashes((devServerUrl ?? 'http://localhost:5173').trim())
+    return `${base}/${normalizedEntry}`
+  }
+
+  const candidates = (options.manifestPaths ?? DEFAULT_MANIFEST_PATHS).map((path) => resolve(path))
+  const cacheKey = candidates.join('\n')
+  let manifest = manifestCache.get(cacheKey)
+  if (manifest === undefined) {
+    manifest = loadViteManifest(candidates, 'client', { warnOnMissing: false }) ?? null
+    manifestCache.set(cacheKey, manifest)
+  }
+
+  if (!manifest) {
+    throw new Error(
+      `viteAsset(): no Vite manifest found. Checked:\n${candidates
+        .map((path) => `  - ${path}`)
+        .join('\n')}\n` +
+        'Run `bunx vite build` before starting in production, or pass { manifestPaths } pointing at the build output.',
+    )
+  }
+
+  const file = getManifestFile(manifest[normalizedEntry])
+  if (!file) {
+    throw new Error(
+      `viteAsset(): "${normalizedEntry}" is not in the Vite manifest at ${manifest.__path__ ?? 'an unknown path'}. ` +
+        'Declare it as a build input in vite.config.ts (build.rollupOptions.input) so Vite emits and records it.',
+    )
+  }
+
+  return `/public/assets/${file.replace(/^\/+/u, '')}`
+}

--- a/packages/server/src/http/vite-manifest.ts
+++ b/packages/server/src/http/vite-manifest.ts
@@ -1,11 +1,60 @@
 import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { trimTrailingSlashes } from '../support/trim-slashes'
 
 /**
- * Vite manifest reading, shared between the Inertia asset wiring
- * (`inertia-assets.ts`) and the content-page `viteAsset()` helper
- * (`vite-assets.ts`, RFC 0014). Factored out so the two cannot drift on
- * what counts as a manifest or where one may live.
+ * The one rule for how Vite build output is found and addressed, shared
+ * between the Inertia asset wiring (`inertia-assets.ts`) and the content-page
+ * `viteAsset()` helper (`vite-assets.ts`, RFC 0014): what counts as a
+ * manifest, where one may live, which URL prefix serves the hashed files,
+ * and what "the dev server is on" means. Factored out so the two consumers
+ * cannot drift on any of it.
  */
+
+/** Where `configureInertiaAssets` serves hashed build output from. */
+export const PUBLIC_ASSETS_URL_PREFIX = '/public/assets/'
+
+/** The Vite default the framework assumes when no dev-server URL is set. */
+export const DEFAULT_DEV_SERVER_URL = 'http://localhost:5173'
+
+/**
+ * Production for *asset* purposes: `NODE_ENV` says so and no dev server is
+ * configured — a configured dev server means dev asset serving even when
+ * `NODE_ENV` is `production` (E2E runs do exactly this).
+ */
+export function isViteProduction(
+  devServerUrl: string | undefined = process.env.VITE_DEV_SERVER_URL,
+): boolean {
+  return (process.env.NODE_ENV ?? 'development') === 'production' && typeof devServerUrl !== 'string'
+}
+
+export function normalizeDevServerUrl(value: string): string {
+  if (!value) {
+    return value
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return trimmed
+  }
+
+  const stripped = trimTrailingSlashes(trimmed)
+  return stripped.length > 0 ? stripped : '/'
+}
+
+/**
+ * Candidate client-manifest locations under a project root, in preference
+ * order. `baseDir` defaults to the working directory (`viteAsset()`'s
+ * anchor); the Inertia wiring passes the root it derives from the app entry
+ * module.
+ */
+export function clientManifestCandidates(baseDir?: string): string[] {
+  const root = baseDir ?? process.cwd()
+  return [
+    resolve(root, 'public/assets/manifest.json'),
+    resolve(root, 'public/assets/.vite/manifest.json'),
+  ]
+}
 
 export type ViteManifestEntryObject = {
   file: string
@@ -26,6 +75,12 @@ export interface LoadViteManifestOptions {
    * — a warning can scroll past, a missing stylesheet URL cannot.
    */
   warnOnMissing?: boolean
+  /**
+   * Retain the raw manifest text as `__raw__` on the result. Off by default:
+   * only the Inertia wiring hashes it (for the build id), and long-lived
+   * caches should not pin hundreds of KB of JSON text nothing reads.
+   */
+  includeRaw?: boolean
 }
 
 export function loadViteManifest(
@@ -44,10 +99,12 @@ export function loadViteManifest(
         value: manifestPath,
         enumerable: false,
       })
-      Object.defineProperty(manifest, '__raw__', {
-        value: raw,
-        enumerable: false,
-      })
+      if (options.includeRaw) {
+        Object.defineProperty(manifest, '__raw__', {
+          value: raw,
+          enumerable: false,
+        })
+      }
       return manifest
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {

--- a/packages/server/src/http/vite-manifest.ts
+++ b/packages/server/src/http/vite-manifest.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs'
+
+/**
+ * Vite manifest reading, shared between the Inertia asset wiring
+ * (`inertia-assets.ts`) and the content-page `viteAsset()` helper
+ * (`vite-assets.ts`, RFC 0014). Factored out so the two cannot drift on
+ * what counts as a manifest or where one may live.
+ */
+
+export type ViteManifestEntryObject = {
+  file: string
+  css?: string[]
+  assets?: string[]
+  imports?: string[]
+  dynamicImports?: string[]
+}
+
+export type ViteManifestValue = ViteManifestEntryObject | string[]
+
+export type ViteManifest = Record<string, ViteManifestValue> & { __path__?: string; __raw__?: string }
+
+export interface LoadViteManifestOptions {
+  /**
+   * Emit console warnings when no manifest is found (the Inertia wiring's
+   * behavior). `viteAsset()` passes `false` and throws its own error instead
+   * — a warning can scroll past, a missing stylesheet URL cannot.
+   */
+  warnOnMissing?: boolean
+}
+
+export function loadViteManifest(
+  candidatePaths: string[],
+  label: 'client' | 'SSR',
+  options: LoadViteManifestOptions = {},
+): ViteManifest | undefined {
+  const warnOnMissing = options.warnOnMissing ?? true
+  const command = label === 'SSR' ? 'bunx vite build --ssr' : 'bunx vite build'
+
+  for (const manifestPath of candidatePaths) {
+    try {
+      const raw = readFileSync(manifestPath, 'utf8')
+      const manifest = JSON.parse(raw) as ViteManifest
+      Object.defineProperty(manifest, '__path__', {
+        value: manifestPath,
+        enumerable: false,
+      })
+      Object.defineProperty(manifest, '__raw__', {
+        value: raw,
+        enumerable: false,
+      })
+      return manifest
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        console.warn(`Unable to load ${label} Vite manifest at ${manifestPath}.`, error)
+        return undefined
+      }
+    }
+  }
+
+  if (warnOnMissing && candidatePaths.length) {
+    console.warn(
+      `Unable to load ${label} Vite manifest. Checked paths:\n${candidatePaths
+        .map((p) => `  - ${p}`)
+        .join('\n')}\nRun \`${command}\` before starting in production.`,
+    )
+  }
+
+  return undefined
+}
+
+export function getManifestFile(
+  entry: ViteManifestValue | string | undefined,
+): string | undefined {
+  if (!entry) {
+    return undefined
+  }
+
+  if (Array.isArray(entry)) {
+    return entry[0]
+  }
+
+  if (typeof entry === 'string') {
+    return entry
+  }
+
+  if ('file' in entry && typeof entry.file === 'string') {
+    return entry.file
+  }
+
+  return undefined
+}
+
+export function getManifestCss(
+  entry: ViteManifestValue | string | undefined,
+): string[] | undefined {
+  if (!entry || Array.isArray(entry) || typeof entry === 'string') {
+    return undefined
+  }
+
+  return entry.css
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -11,7 +11,9 @@ export type {
 } from './http/Application'
 export { parseRequestPayload, formatValidationErrors } from './http/request'
 export { Controller } from './mvc/Controller'
-export type { InertiaResponse, InferInertiaProps, ControllerInertiaProps, AuthPayload, ViewOptions } from './mvc/Controller'
+export type { InertiaResponse, InferInertiaProps, ControllerInertiaProps, AuthPayload } from './mvc/Controller'
+export { renderDocument } from './mvc/view'
+export type { ViewOptions } from './mvc/view'
 // Content rendering (RFC 0014): the component types app View files annotate
 // with, and the asset resolver their Layouts link stylesheets through.
 export type { FC, PropsWithChildren } from 'hono/jsx'

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -11,7 +11,12 @@ export type {
 } from './http/Application'
 export { parseRequestPayload, formatValidationErrors } from './http/request'
 export { Controller } from './mvc/Controller'
-export type { InertiaResponse, InferInertiaProps, ControllerInertiaProps, AuthPayload } from './mvc/Controller'
+export type { InertiaResponse, InferInertiaProps, ControllerInertiaProps, AuthPayload, ViewOptions } from './mvc/Controller'
+// Content rendering (RFC 0014): the component types app View files annotate
+// with, and the asset resolver their Layouts link stylesheets through.
+export type { FC, PropsWithChildren } from 'hono/jsx'
+export { viteAsset } from './http/vite-assets'
+export type { ViteAssetOptions } from './http/vite-assets'
 export { Router } from './mvc/Router'
 export type {
   BindableModel,

--- a/packages/server/src/jsx-dev-runtime.ts
+++ b/packages/server/src/jsx-dev-runtime.ts
@@ -1,0 +1,6 @@
+/**
+ * Development twin of `jsx-runtime.ts` — compilers emit imports from the
+ * `/jsx-dev-runtime` subpath in dev transforms. See `jsx-runtime.ts` for why
+ * the pragma routes through the framework.
+ */
+export * from 'hono/jsx/jsx-dev-runtime'

--- a/packages/server/src/jsx-runtime.test.ts
+++ b/packages/server/src/jsx-runtime.test.ts
@@ -1,0 +1,17 @@
+import { describe, test, expect } from 'bun:test'
+import { jsx, jsxs, Fragment } from './jsx-runtime'
+import { jsxDEV } from './jsx-dev-runtime'
+
+describe('jsx runtime subpaths (RFC 0014)', () => {
+  test('should re-export hono\'s automatic-runtime surface', () => {
+    expect(typeof jsx).toBe('function')
+    expect(typeof jsxs).toBe('function')
+    expect(typeof jsxDEV).toBe('function')
+    expect(typeof Fragment).toBe('function')
+  })
+
+  test('should render an escaped element through the re-export', async () => {
+    const node = jsx('p', { children: '<x>' }, undefined)
+    expect(String(await node.toString())).toBe('<p>&lt;x&gt;</p>')
+  })
+})

--- a/packages/server/src/jsx-runtime.ts
+++ b/packages/server/src/jsx-runtime.ts
@@ -1,14 +1,9 @@
 /**
  * The app-facing JSX runtime for server-rendered content views (RFC 0014).
  *
- * Application View files opt in with a per-file pragma:
- *
- * ```tsx
- * /** @jsxImportSource @guren/core *​/
- * ```
- *
- * which the compiler resolves to `@guren/core/jsx-runtime` →
- * `@guren/server/jsx-runtime` → here. Routing the pragma through the
+ * Application View files opt in with a per-file `@jsxImportSource` pragma
+ * pointing at `@guren/core`, which the compiler resolves to
+ * `@guren/core/jsx-runtime` → here → hono. Routing the pragma through the
  * framework rather than at `hono/jsx` directly means applications never
  * declare hono themselves, and the runtime that compiles their JSX is the
  * same hono copy `Controller.view()` renders with — by construction, not by

--- a/packages/server/src/jsx-runtime.ts
+++ b/packages/server/src/jsx-runtime.ts
@@ -1,0 +1,17 @@
+/**
+ * The app-facing JSX runtime for server-rendered content views (RFC 0014).
+ *
+ * Application View files opt in with a per-file pragma:
+ *
+ * ```tsx
+ * /** @jsxImportSource @guren/core *​/
+ * ```
+ *
+ * which the compiler resolves to `@guren/core/jsx-runtime` →
+ * `@guren/server/jsx-runtime` → here. Routing the pragma through the
+ * framework rather than at `hono/jsx` directly means applications never
+ * declare hono themselves, and the runtime that compiles their JSX is the
+ * same hono copy `Controller.view()` renders with — by construction, not by
+ * install-layout luck.
+ */
+export * from 'hono/jsx/jsx-runtime'

--- a/packages/server/src/mvc/Controller.ts
+++ b/packages/server/src/mvc/Controller.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'hono'
-import { createElement, type FC } from 'hono/jsx'
+import type { FC } from 'hono/jsx'
+import { renderDocument, type ViewOptions } from './view'
 import { inertia, type InertiaOptions } from './inertia/InertiaEngine'
 import { resolveSharedInertiaProps, type ResolvedSharedInertiaProps } from './inertia/shared'
 import { AUTH_CONTEXT_KEY } from '../http/middleware/auth'
@@ -91,17 +92,6 @@ export type ControllerInertiaProps<TController extends Controller, TAction exten
 export interface RedirectOptions {
   status?: number
   headers?: HeadersInit
-}
-
-/** Options for {@link Controller.view} (RFC 0014). */
-export interface ViewOptions {
-  status?: number
-  headers?: HeadersInit
-  /**
-   * Prepend `<!doctype html>` and require a full document (an `<html>` root).
-   * Pass `false` for an intentional fragment response — no doctype, no check.
-   */
-  doctype?: boolean
 }
 
 type InertiaResponseOptions = Omit<InertiaOptions, 'url' | 'request'> & { url?: string }
@@ -330,6 +320,12 @@ export class Controller {
    * (RFC 0014). Takes the component and its props separately so controllers
    * stay plain `.ts` and the props are type-checked at the call site.
    *
+   * Escaping covers markup: text children and attribute values are escaped,
+   * so tag and attribute breakout cannot occur. It does **not** validate URL
+   * schemes — a `javascript:` href built from user data is emitted verbatim.
+   * Sanitize user-supplied URLs upstream (e.g. `@guren/plugin-markdown`'s
+   * allowlist) before they reach a View.
+   *
    * @example
    * ```typescript
    * async show() {
@@ -338,32 +334,8 @@ export class Controller {
    * }
    * ```
    */
-  protected async view<P>(component: FC<P>, props: P, options: ViewOptions = {}): Promise<Response> {
-    // Build a real hono element and let hono reduce it. Invoking the
-    // component directly and reducing the result by hand looks equivalent
-    // and is not: it skips hono's escaping of raw strings inside a `Child[]`
-    // (a stored-XSS hole caught in the RFC 0014 review).
-    const body = String(await createElement(component as never, props as never).toString())
-
-    if (options.doctype !== false && !/^\s*<html[\s>]/iu.test(body)) {
-      const name = component.displayName ?? (component as { name?: string }).name ?? 'component'
-      throw new Error(
-        `view(): ${name} rendered a fragment, not a document. ` +
-          'Wrap the page in your Layout (an <html> root), or pass { doctype: false } ' +
-          'for an intentional fragment response. Without <html>/<head>, <title> and ' +
-          '<meta> tags are not hoisted and the page ships unstyled.',
-      )
-    }
-
-    const headers = new Headers(options.headers)
-    if (!headers.has('content-type')) {
-      headers.set('content-type', 'text/html; charset=utf-8')
-    }
-
-    return new Response((options.doctype === false ? '' : '<!doctype html>') + body, {
-      status: options.status ?? 200,
-      headers,
-    })
+  protected view<P>(component: FC<P>, props: P, options?: ViewOptions): Promise<Response> {
+    return renderDocument(component, props, options)
   }
 
   protected async inertia<TPage extends InertiaPageContractLike>(

--- a/packages/server/src/mvc/Controller.ts
+++ b/packages/server/src/mvc/Controller.ts
@@ -1,4 +1,5 @@
 import type { Context } from 'hono'
+import { createElement, type FC } from 'hono/jsx'
 import { inertia, type InertiaOptions } from './inertia/InertiaEngine'
 import { resolveSharedInertiaProps, type ResolvedSharedInertiaProps } from './inertia/shared'
 import { AUTH_CONTEXT_KEY } from '../http/middleware/auth'
@@ -90,6 +91,17 @@ export type ControllerInertiaProps<TController extends Controller, TAction exten
 export interface RedirectOptions {
   status?: number
   headers?: HeadersInit
+}
+
+/** Options for {@link Controller.view} (RFC 0014). */
+export interface ViewOptions {
+  status?: number
+  headers?: HeadersInit
+  /**
+   * Prepend `<!doctype html>` and require a full document (an `<html>` root).
+   * Pass `false` for an intentional fragment response — no doctype, no check.
+   */
+  doctype?: boolean
 }
 
 type InertiaResponseOptions = Omit<InertiaOptions, 'url' | 'request'> & { url?: string }
@@ -311,6 +323,48 @@ export class Controller {
   }
 
   // ─── Response Helpers ───────────────────────────────────────────
+
+  /**
+   * Render a `hono/jsx` component to a plain server-rendered HTML response —
+   * the non-hydrating counterpart to {@link inertia} for public content pages
+   * (RFC 0014). Takes the component and its props separately so controllers
+   * stay plain `.ts` and the props are type-checked at the call site.
+   *
+   * @example
+   * ```typescript
+   * async show() {
+   *   const post = await Post.findOrFail(id)
+   *   return this.view(PostPage, { post })
+   * }
+   * ```
+   */
+  protected async view<P>(component: FC<P>, props: P, options: ViewOptions = {}): Promise<Response> {
+    // Build a real hono element and let hono reduce it. Invoking the
+    // component directly and reducing the result by hand looks equivalent
+    // and is not: it skips hono's escaping of raw strings inside a `Child[]`
+    // (a stored-XSS hole caught in the RFC 0014 review).
+    const body = String(await createElement(component as never, props as never).toString())
+
+    if (options.doctype !== false && !/^\s*<html[\s>]/iu.test(body)) {
+      const name = component.displayName ?? (component as { name?: string }).name ?? 'component'
+      throw new Error(
+        `view(): ${name} rendered a fragment, not a document. ` +
+          'Wrap the page in your Layout (an <html> root), or pass { doctype: false } ' +
+          'for an intentional fragment response. Without <html>/<head>, <title> and ' +
+          '<meta> tags are not hoisted and the page ships unstyled.',
+      )
+    }
+
+    const headers = new Headers(options.headers)
+    if (!headers.has('content-type')) {
+      headers.set('content-type', 'text/html; charset=utf-8')
+    }
+
+    return new Response((options.doctype === false ? '' : '<!doctype html>') + body, {
+      status: options.status ?? 200,
+      headers,
+    })
+  }
 
   protected async inertia<TPage extends InertiaPageContractLike>(
     page: TPage,

--- a/packages/server/src/mvc/view.test.ts
+++ b/packages/server/src/mvc/view.test.ts
@@ -1,0 +1,168 @@
+import { describe, test, expect } from 'bun:test'
+import type { FC } from 'hono/jsx'
+import { jsx } from '../jsx-runtime'
+import { Controller, type ViewOptions } from './Controller'
+
+// Plain-TS element builders (no .tsx: the workspace-root typecheck program
+// carries no `jsx` compiler option). Going through `../jsx-runtime` also
+// exercises the RFC 0014 subpath source directly.
+// Returns `never`: a JSXNode is renderable but FC's declared result union
+// names it only inside `Child[]`, so the loosest honest type keeps every
+// hand-built component assignable to FC without per-site casts.
+const h = (tag: string, props: Record<string, unknown> = {}, children?: unknown): never =>
+  jsx(tag, children === undefined ? props : { ...props, children }, undefined) as never
+
+class TestController extends Controller {
+  render<P>(component: FC<P>, props: P, options?: ViewOptions): Promise<Response> {
+    return this.view(component, props, options)
+  }
+}
+
+const controller = () => new TestController()
+
+const DocPage: FC<{ title: string; body: string }> = ({ title, body }) =>
+  h('html', { lang: 'en' }, [
+    h('head'),
+    h('body', {}, h('article', {}, [h('title', {}, title), h('h1', {}, body)])),
+  ]) as never
+
+describe('Controller.view', () => {
+  describe('response contract', () => {
+    test('should return an html document with doctype and content-type', async () => {
+      const res = await controller().render(DocPage, { title: 'T', body: 'B' })
+      const html = await res.text()
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toBe('text/html; charset=utf-8')
+      expect(html.startsWith('<!doctype html><html lang="en">')).toBe(true)
+      expect(html).not.toContain('__INERTIA_PAGE__')
+    })
+
+    test('should honour status, headers, and doctype: false', async () => {
+      const Fragment: FC<{ t: string }> = ({ t }) => h('article', {}, t) as never
+      const res = await controller().render(Fragment, { t: 'x' }, {
+        doctype: false,
+        status: 404,
+        headers: { 'x-robots-tag': 'noindex' },
+      })
+
+      expect(res.status).toBe(404)
+      expect(res.headers.get('x-robots-tag')).toBe('noindex')
+      expect(await res.text()).toBe('<article>x</article>')
+    })
+
+    test('should let a caller-provided content-type win', async () => {
+      const Frag: FC<Record<string, never>> = () => h('p', {}, 'x') as never
+      const res = await controller().render(Frag, {}, {
+        doctype: false,
+        headers: { 'content-type': 'text/plain' },
+      })
+      expect(res.headers.get('content-type')).toBe('text/plain')
+    })
+
+    test('should hoist title and meta from the body into head', async () => {
+      const res = await controller().render(DocPage, { title: 'Deep', body: 'b' })
+      const html = await res.text()
+      expect(html).toMatch(/<head>[\s\S]*<title>Deep<\/title>[\s\S]*<\/head>/)
+    })
+  })
+
+  describe('forgotten-Layout guard', () => {
+    test('should throw a descriptive error for a fragment without doctype: false', async () => {
+      const Orphan: FC<{ t: string }> = ({ t }) => h('article', {}, t) as never
+      await expect(controller().render(Orphan, { t: 'x' })).rejects.toThrow(
+        /view\(\): Orphan rendered a fragment, not a document/,
+      )
+    })
+
+    test('should accept the same fragment when doctype: false marks it intentional', async () => {
+      const Orphan: FC<{ t: string }> = ({ t }) => h('article', {}, t) as never
+      const res = await controller().render(Orphan, { t: 'x' }, { doctype: false })
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('rendering shapes', () => {
+    const shapes: Array<[string, FC<{ t: string }>]> = [
+      ['sync root', (({ t }) => h('p', {}, t)) as FC<{ t: string }>],
+      [
+        'async root',
+        (async ({ t }) => {
+          await new Promise((resolve) => setTimeout(resolve, 1))
+          return h('p', {}, t)
+        }) as FC<{ t: string }>,
+      ],
+      [
+        'nested async child',
+        (({ t }) => {
+          const Slow: FC<{ t: string }> = async ({ t: inner }) => {
+            await new Promise((resolve) => setTimeout(resolve, 1))
+            return h('em', {}, inner) as never
+          }
+          return h('div', {}, jsx(Slow as never, { t }, undefined)) as never
+        }) as FC<{ t: string }>,
+      ],
+    ]
+
+    for (const [name, component] of shapes) {
+      test(`should render and escape a ${name}`, async () => {
+        const res = await controller().render(component, { t: '<x>' }, { doctype: false })
+        const html = await res.text()
+        expect(html).toContain('&lt;x&gt;')
+        expect(html).not.toContain('<x>')
+      })
+    }
+
+    test('should render a null-returning component as an empty body', async () => {
+      const Empty: FC<Record<string, never>> = () => null
+      const res = await controller().render(Empty, {}, { doctype: false })
+      expect(await res.text()).toBe('')
+    })
+  })
+
+  describe('escaping boundary (security regressions)', () => {
+    test('should escape a raw string inside a Child[] (the RFC 0014 XSS regression)', async () => {
+      const RawArray: FC<Record<string, never>> = () =>
+        ['<script>alert(1)</script>', h('p', {}, 'ok')] as never
+      const res = await controller().render(RawArray, {}, { doctype: false })
+      const html = await res.text()
+
+      expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+      expect(html).not.toContain('<script>')
+    })
+
+    test('should escape a Promise<string> inside a Child[]', async () => {
+      const PromiseArray: FC<Record<string, never>> = () =>
+        [Promise.resolve('<b>raw</b>'), h('p', {}, 'ok')] as never
+      const res = await controller().render(PromiseArray, {}, { doctype: false })
+      const html = await res.text()
+
+      expect(html).toContain('&lt;b&gt;raw&lt;/b&gt;')
+      expect(html).not.toContain('<b>raw</b>')
+    })
+
+    test('should escape attribute breakout attempts', async () => {
+      const Link: FC<{ href: string }> = ({ href }) => h('a', { href }, 'x') as never
+      const res = await controller().render(Link, { href: '" onmouseover="alert(1)' }, { doctype: false })
+      expect(await res.text()).toBe('<a href="&quot; onmouseover=&quot;alert(1)">x</a>')
+    })
+
+    test('should pass a javascript: URL through verbatim (scheme validation is the caller\'s job)', async () => {
+      // Pins the documented boundary: view() escapes markup, not URL schemes.
+      // Content that carries user-supplied URLs must be sanitized upstream
+      // (e.g. @guren/plugin-markdown's allowlist).
+      const Link: FC<{ href: string }> = ({ href }) => h('a', { href }, 'x') as never
+      const res = await controller().render(Link, { href: 'javascript:alert(1)' }, { doctype: false })
+      expect(await res.text()).toBe('<a href="javascript:alert(1)">x</a>')
+    })
+  })
+
+  describe('error propagation', () => {
+    test('should propagate a throwing component like any throwing action', async () => {
+      const Boom: FC<Record<string, never>> = () => {
+        throw new Error('kaboom')
+      }
+      await expect(controller().render(Boom, {})).rejects.toThrow('kaboom')
+    })
+  })
+})

--- a/packages/server/src/mvc/view.test.ts
+++ b/packages/server/src/mvc/view.test.ts
@@ -79,6 +79,17 @@ describe('renderDocument', () => {
       expect(res.status).toBe(200)
       expect((await res.text()).startsWith('<!doctype html><!--banner--><html>')).toBe(true)
     })
+
+    test('should scan adversarial comment runs in linear time (CodeQL js/redos regression)', async () => {
+      // The regex form of this guard backtracked exponentially on
+      // '<!--' + '--><!--' * n with no closing root. ~30k repetitions hung
+      // for minutes; the linear scanner must reject it instantly.
+      const Adversarial: FC<Record<string, never>> = () =>
+        [raw('<!--' + '--><!--'.repeat(30_000))] as never
+      const started = performance.now()
+      await expect(renderDocument(Adversarial, {})).rejects.toThrow(/rendered a fragment/)
+      expect(performance.now() - started).toBeLessThan(1_000)
+    })
   })
 
   describe('rendering shapes', () => {

--- a/packages/server/src/mvc/view.test.ts
+++ b/packages/server/src/mvc/view.test.ts
@@ -1,35 +1,28 @@
 import { describe, test, expect } from 'bun:test'
 import type { FC } from 'hono/jsx'
+import { raw } from 'hono/html'
 import { jsx } from '../jsx-runtime'
-import { Controller, type ViewOptions } from './Controller'
+import { renderDocument } from './view'
+import { Controller } from './Controller'
 
-// Plain-TS element builders (no .tsx: the workspace-root typecheck program
-// carries no `jsx` compiler option). Going through `../jsx-runtime` also
-// exercises the RFC 0014 subpath source directly.
-// Returns `never`: a JSXNode is renderable but FC's declared result union
-// names it only inside `Child[]`, so the loosest honest type keeps every
-// hand-built component assignable to FC without per-site casts.
+// Plain-TS element builder (no .tsx: the workspace-root typecheck program
+// carries no `jsx` compiler option). Returns `never` so hand-built
+// components are assignable to FC.
 const h = (tag: string, props: Record<string, unknown> = {}, children?: unknown): never =>
   jsx(tag, children === undefined ? props : { ...props, children }, undefined) as never
-
-class TestController extends Controller {
-  render<P>(component: FC<P>, props: P, options?: ViewOptions): Promise<Response> {
-    return this.view(component, props, options)
-  }
-}
-
-const controller = () => new TestController()
 
 const DocPage: FC<{ title: string; body: string }> = ({ title, body }) =>
   h('html', { lang: 'en' }, [
     h('head'),
     h('body', {}, h('article', {}, [h('title', {}, title), h('h1', {}, body)])),
-  ]) as never
+  ])
 
-describe('Controller.view', () => {
+const Orphan: FC<{ t: string }> = ({ t }) => h('article', {}, t)
+
+describe('renderDocument', () => {
   describe('response contract', () => {
     test('should return an html document with doctype and content-type', async () => {
-      const res = await controller().render(DocPage, { title: 'T', body: 'B' })
+      const res = await renderDocument(DocPage, { title: 'T', body: 'B' })
       const html = await res.text()
 
       expect(res.status).toBe(200)
@@ -39,8 +32,7 @@ describe('Controller.view', () => {
     })
 
     test('should honour status, headers, and doctype: false', async () => {
-      const Fragment: FC<{ t: string }> = ({ t }) => h('article', {}, t) as never
-      const res = await controller().render(Fragment, { t: 'x' }, {
+      const res = await renderDocument(Orphan, { t: 'x' }, {
         doctype: false,
         status: 404,
         headers: { 'x-robots-tag': 'noindex' },
@@ -52,8 +44,7 @@ describe('Controller.view', () => {
     })
 
     test('should let a caller-provided content-type win', async () => {
-      const Frag: FC<Record<string, never>> = () => h('p', {}, 'x') as never
-      const res = await controller().render(Frag, {}, {
+      const res = await renderDocument(Orphan, { t: 'x' }, {
         doctype: false,
         headers: { 'content-type': 'text/plain' },
       })
@@ -61,7 +52,7 @@ describe('Controller.view', () => {
     })
 
     test('should hoist title and meta from the body into head', async () => {
-      const res = await controller().render(DocPage, { title: 'Deep', body: 'b' })
+      const res = await renderDocument(DocPage, { title: 'Deep', body: 'b' })
       const html = await res.text()
       expect(html).toMatch(/<head>[\s\S]*<title>Deep<\/title>[\s\S]*<\/head>/)
     })
@@ -69,44 +60,52 @@ describe('Controller.view', () => {
 
   describe('forgotten-Layout guard', () => {
     test('should throw a descriptive error for a fragment without doctype: false', async () => {
-      const Orphan: FC<{ t: string }> = ({ t }) => h('article', {}, t) as never
-      await expect(controller().render(Orphan, { t: 'x' })).rejects.toThrow(
+      await expect(renderDocument(Orphan, { t: 'x' })).rejects.toThrow(
         /view\(\): Orphan rendered a fragment, not a document/,
       )
     })
 
     test('should accept the same fragment when doctype: false marks it intentional', async () => {
-      const Orphan: FC<{ t: string }> = ({ t }) => h('article', {}, t) as never
-      const res = await controller().render(Orphan, { t: 'x' }, { doctype: false })
+      const res = await renderDocument(Orphan, { t: 'x' }, { doctype: false })
       expect(res.status).toBe(200)
+    })
+
+    test('should accept a document behind a leading comment', async () => {
+      // A plain string child would be escaped; a genuine leading comment
+      // reaches the output only as raw markup (e.g. a build banner).
+      const WithComment: FC<Record<string, never>> = () =>
+        [raw('<!--banner-->'), h('html', {}, h('body', {}, 'x'))] as never
+      const res = await renderDocument(WithComment, {})
+      expect(res.status).toBe(200)
+      expect((await res.text()).startsWith('<!doctype html><!--banner--><html>')).toBe(true)
     })
   })
 
   describe('rendering shapes', () => {
     const shapes: Array<[string, FC<{ t: string }>]> = [
-      ['sync root', (({ t }) => h('p', {}, t)) as FC<{ t: string }>],
+      ['sync root', ({ t }) => h('p', {}, t)],
       [
         'async root',
-        (async ({ t }) => {
+        async ({ t }) => {
           await new Promise((resolve) => setTimeout(resolve, 1))
           return h('p', {}, t)
-        }) as FC<{ t: string }>,
+        },
       ],
       [
         'nested async child',
-        (({ t }) => {
+        ({ t }) => {
           const Slow: FC<{ t: string }> = async ({ t: inner }) => {
             await new Promise((resolve) => setTimeout(resolve, 1))
-            return h('em', {}, inner) as never
+            return h('em', {}, inner)
           }
-          return h('div', {}, jsx(Slow as never, { t }, undefined)) as never
-        }) as FC<{ t: string }>,
+          return h('div', {}, jsx(Slow as never, { t }, undefined))
+        },
       ],
     ]
 
     for (const [name, component] of shapes) {
       test(`should render and escape a ${name}`, async () => {
-        const res = await controller().render(component, { t: '<x>' }, { doctype: false })
+        const res = await renderDocument(component, { t: '<x>' }, { doctype: false })
         const html = await res.text()
         expect(html).toContain('&lt;x&gt;')
         expect(html).not.toContain('<x>')
@@ -115,7 +114,7 @@ describe('Controller.view', () => {
 
     test('should render a null-returning component as an empty body', async () => {
       const Empty: FC<Record<string, never>> = () => null
-      const res = await controller().render(Empty, {}, { doctype: false })
+      const res = await renderDocument(Empty, {}, { doctype: false })
       expect(await res.text()).toBe('')
     })
   })
@@ -124,7 +123,7 @@ describe('Controller.view', () => {
     test('should escape a raw string inside a Child[] (the RFC 0014 XSS regression)', async () => {
       const RawArray: FC<Record<string, never>> = () =>
         ['<script>alert(1)</script>', h('p', {}, 'ok')] as never
-      const res = await controller().render(RawArray, {}, { doctype: false })
+      const res = await renderDocument(RawArray, {}, { doctype: false })
       const html = await res.text()
 
       expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
@@ -134,7 +133,7 @@ describe('Controller.view', () => {
     test('should escape a Promise<string> inside a Child[]', async () => {
       const PromiseArray: FC<Record<string, never>> = () =>
         [Promise.resolve('<b>raw</b>'), h('p', {}, 'ok')] as never
-      const res = await controller().render(PromiseArray, {}, { doctype: false })
+      const res = await renderDocument(PromiseArray, {}, { doctype: false })
       const html = await res.text()
 
       expect(html).toContain('&lt;b&gt;raw&lt;/b&gt;')
@@ -142,17 +141,17 @@ describe('Controller.view', () => {
     })
 
     test('should escape attribute breakout attempts', async () => {
-      const Link: FC<{ href: string }> = ({ href }) => h('a', { href }, 'x') as never
-      const res = await controller().render(Link, { href: '" onmouseover="alert(1)' }, { doctype: false })
+      const Link: FC<{ href: string }> = ({ href }) => h('a', { href }, 'x')
+      const res = await renderDocument(Link, { href: '" onmouseover="alert(1)' }, { doctype: false })
       expect(await res.text()).toBe('<a href="&quot; onmouseover=&quot;alert(1)">x</a>')
     })
 
     test('should pass a javascript: URL through verbatim (scheme validation is the caller\'s job)', async () => {
-      // Pins the documented boundary: view() escapes markup, not URL schemes.
-      // Content that carries user-supplied URLs must be sanitized upstream
-      // (e.g. @guren/plugin-markdown's allowlist).
-      const Link: FC<{ href: string }> = ({ href }) => h('a', { href }, 'x') as never
-      const res = await controller().render(Link, { href: 'javascript:alert(1)' }, { doctype: false })
+      // Pins the documented boundary: rendering escapes markup, not URL
+      // schemes. Content carrying user-supplied URLs must be sanitized
+      // upstream (e.g. @guren/plugin-markdown's allowlist).
+      const Link: FC<{ href: string }> = ({ href }) => h('a', { href }, 'x')
+      const res = await renderDocument(Link, { href: 'javascript:alert(1)' }, { doctype: false })
       expect(await res.text()).toBe('<a href="javascript:alert(1)">x</a>')
     })
   })
@@ -162,7 +161,20 @@ describe('Controller.view', () => {
       const Boom: FC<Record<string, never>> = () => {
         throw new Error('kaboom')
       }
-      await expect(controller().render(Boom, {})).rejects.toThrow('kaboom')
+      await expect(renderDocument(Boom, {})).rejects.toThrow('kaboom')
     })
+  })
+})
+
+describe('Controller.view', () => {
+  test('should delegate to renderDocument with options intact', async () => {
+    class TestController extends Controller {
+      run() {
+        return this.view(Orphan, { t: '<x>' }, { doctype: false, status: 201 })
+      }
+    }
+    const res = await new TestController().run()
+    expect(res.status).toBe(201)
+    expect(await res.text()).toBe('<article>&lt;x&gt;</article>')
   })
 })

--- a/packages/server/src/mvc/view.ts
+++ b/packages/server/src/mvc/view.ts
@@ -1,0 +1,51 @@
+import type { FC } from 'hono/jsx'
+// The narrow runtime entry, deliberately: the `hono/jsx` barrel drags the
+// client-side DOM renderer and streaming modules (+8 modules, ~53 KB) onto
+// every app's cold-start path, and `jsx()` bottoms out in the same element
+// construction `createElement()` does for this call shape.
+import { jsx } from '../jsx-runtime'
+
+/** Options for {@link renderDocument} / `Controller.view()` (RFC 0014). */
+export type ViewOptions = ResponseInit & {
+  /**
+   * Prepend `<!doctype html>` and require a full document (an `<html>` root).
+   * Pass `false` for an intentional fragment response — no doctype, no check.
+   */
+  doctype?: boolean
+}
+
+/**
+ * Render a `hono/jsx` component to a plain server-rendered HTML `Response` —
+ * the engine behind `Controller.view()` (RFC 0014), separated the way
+ * `inertia()` is from `Controller.inertia()`.
+ */
+export async function renderDocument<P>(
+  component: FC<P>,
+  props: P,
+  options: ViewOptions = {},
+): Promise<Response> {
+  // Build a real hono element and let hono own the reduction. Invoking the
+  // component directly and reducing the result by hand looks equivalent and
+  // is not: it skips hono's escaping of raw strings inside a `Child[]` (a
+  // stored-XSS hole caught in the RFC 0014 review).
+  const body = String(await jsx(component as never, props as never, undefined).toString())
+
+  // Leading whitespace and comments are legal ahead of the root element.
+  if (options.doctype !== false && !/^(?:\s|<!--[\s\S]*?-->)*<html[\s>]/iu.test(body)) {
+    const name = component.displayName ?? (component as { name?: string }).name ?? 'component'
+    throw new Error(
+      `view(): ${name} rendered a fragment, not a document. ` +
+        'Wrap the page in your Layout (an <html> root), or pass { doctype: false } ' +
+        'for an intentional fragment response. Without <html>/<head>, <title> and ' +
+        '<meta> tags are not hoisted and the page ships unstyled.',
+    )
+  }
+
+  const { doctype, headers: headersInit, ...init } = options
+  const headers = new Headers(headersInit)
+  if (!headers.has('content-type')) {
+    headers.set('content-type', 'text/html; charset=utf-8')
+  }
+
+  return new Response((doctype === false ? '' : '<!doctype html>') + body, { ...init, headers })
+}

--- a/packages/server/src/mvc/view.ts
+++ b/packages/server/src/mvc/view.ts
@@ -15,6 +15,35 @@ export type ViewOptions = ResponseInit & {
 }
 
 /**
+ * Does the rendered output begin with an `<html>` root, allowing leading
+ * whitespace and complete comments? A hand-rolled linear scan rather than a
+ * regex: the equivalent pattern (`(?:\s|<!--.*?-->)*<html`) backtracks
+ * exponentially on adversarial comment runs (CodeQL js/redos), and the body
+ * being scanned can embed user-influenced raw markup.
+ */
+function startsWithHtmlRoot(body: string): boolean {
+  let i = 0
+  while (i < body.length) {
+    const ch = body.charCodeAt(i)
+    // \t \n \v \f \r or space
+    if (ch === 32 || (ch >= 9 && ch <= 13)) {
+      i++
+      continue
+    }
+    if (body.startsWith('<!--', i)) {
+      const end = body.indexOf('-->', i + 4)
+      if (end === -1) return false
+      i = end + 3
+      continue
+    }
+    break
+  }
+  if (body.slice(i, i + 5).toLowerCase() !== '<html') return false
+  const next = body.charCodeAt(i + 5)
+  return next === 62 /* > */ || next === 32 || (next >= 9 && next <= 13)
+}
+
+/**
  * Render a `hono/jsx` component to a plain server-rendered HTML `Response` —
  * the engine behind `Controller.view()` (RFC 0014), separated the way
  * `inertia()` is from `Controller.inertia()`.
@@ -30,8 +59,7 @@ export async function renderDocument<P>(
   // stored-XSS hole caught in the RFC 0014 review).
   const body = String(await jsx(component as never, props as never, undefined).toString())
 
-  // Leading whitespace and comments are legal ahead of the root element.
-  if (options.doctype !== false && !/^(?:\s|<!--[\s\S]*?-->)*<html[\s>]/iu.test(body)) {
+  if (options.doctype !== false && !startsWithHtmlRoot(body)) {
     const name = component.displayName ?? (component as { name?: string }).name ?? 'component'
     throw new Error(
       `view(): ${name} rendered a fragment, not a document. ` +

--- a/packages/server/tsdown.config.ts
+++ b/packages/server/tsdown.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
   ...tsdownPreset,
   entry: [
     'src/index.ts',
+    'src/jsx-runtime.ts',
+    'src/jsx-dev-runtime.ts',
     'src/auth/index.ts',
     'src/authorization/index.ts',
     'src/broadcasting/index.ts',


### PR DESCRIPTION
Implements [RFC 0014](https://github.com/gurenjs/guren/blob/main/rfcs/0014-controller-view.md) (Accepted 2026-08-25): first-class non-Inertia content rendering.

## What ships

- **`Controller.view(component, props, options)`** — renders a `hono/jsx` component to plain server-rendered HTML, the non-hydrating counterpart to `this.inertia()` for public content pages. Renders through `createElement` so hono owns escaping (the hand-reduction alternative had a measured stored-XSS hole with raw strings in a `Child[]` — pinned as a regression test). Prepends the doctype and **throws a descriptive error when a page renders a fragment without an `<html>` root**: the soft failure ships an unstyled page with hoisted SEO tags stranded in `<body>`. `{ doctype: false }` marks intentional fragments.
- **`viteAsset(entry)`** — asset URL resolution for content Layouts: dev-server URL in development, hashed manifest output under `/public/assets/` in production, a loud error naming every path tried when neither resolves. The manifest reading is factored into `vite-manifest.ts`, shared with the Inertia wiring (behavior unchanged).
- **`@guren/core/jsx-runtime` + `/jsx-dev-runtime`** — View files compile with `/** @jsxImportSource @guren/core */`; apps never declare hono, and the pragma resolves to the same hono copy `view()` renders with by construction. `FC` / `PropsWithChildren` re-exported from the barrel for annotations.
- hono floor `^4.12.29` → `^4.13.0` (`FunctionComponentResult` was introduced there — verified by unpacking both versions).

## Gates

- `bun run build` — green (subpath dist artifacts verified present and resolving)
- `bun run typecheck` — green (blog/api examples included)
- `bun run test:bun` — 5045 pass / 0 fail; the 23 new tests cover the render-shape matrix, the XSS regressions (asserted escaped), the fragment guard, the escaping boundary in both directions (a `javascript:` href is pinned as *passed through* — scheme validation is the caller's job), `viteAsset`'s three branches with caching, and the runtime subpaths
- `audit:core-first`, `audit:docs` — green
- Changesets: `@guren/server` minor + `@guren/core` minor (the core release is required for the subpaths to reach npm)

## Not in this PR

- guren.dev blog-page dogfooding migration (next PR, per the RFC's ordering)
- `make:content-page` scaffolding, sitemap/RSS helpers, `viewStream()` — follow-ups
- Templates/docs referencing `view()` — gated on the release (`smoke:starter:npm` would be correctly red until then)
