### PR TITLE
fix(server): paginate S3 listings and batch DeleteObjects requests

### DIFF
--- a/.changeset/s3-listing-pagination.md
+++ b/.changeset/s3-listing-pagination.md
@@ -2,4 +2,4 @@
 "@guren/server": patch
 ---
 
-Follow `NextContinuationToken` in `S3Driver.files()`, `directories()`, and `allFiles()`. A single ListObjectsV2 request returns at most 1000 entries, so listings beyond one page were silently truncated — `deleteDirectory()` left objects behind on large directories, and callers treating the listing as complete missed everything past the first page.
+Follow `NextContinuationToken` in `S3Driver.files()`, `directories()`, and `allFiles()`. A single ListObjectsV2 request returns at most 1000 entries, so listings beyond one page were silently truncated — `deleteDirectory()` left objects behind on large directories, and callers treating the listing as complete missed everything past the first page. A truncated page without an advancing token now throws instead of returning an incomplete listing. `deleteMany()` splits deletes into the 1000-key batches DeleteObjects accepts, and root listings on a disk with a `prefix` no longer send a doubled-slash `Prefix` that matches nothing.

--- a/.changeset/s3-listing-pagination.md
+++ b/.changeset/s3-listing-pagination.md
@@ -1,0 +1,5 @@
+---
+"@guren/server": patch
+---
+
+Follow `NextContinuationToken` in `S3Driver.files()`, `directories()`, and `allFiles()`. A single ListObjectsV2 request returns at most 1000 entries, so listings beyond one page were silently truncated — `deleteDirectory()` left objects behind on large directories, and callers treating the listing as complete missed everything past the first page.

--- a/packages/plugin-cloudflare/src/storage/R2Driver.ts
+++ b/packages/plugin-cloudflare/src/storage/R2Driver.ts
@@ -378,8 +378,8 @@ export class R2Driver implements StorageDriver {
 
   /**
    * Follows `cursor` until `truncated` is false. A single `list()` call is
-   * capped at 1000 keys, so a one-page read (what `S3Driver.allFiles` does)
-   * silently truncates larger directories.
+   * capped at 1000 keys, so a one-page read silently truncates larger
+   * directories.
    */
   private async *pages(options: R2ListOptionsLike): AsyncGenerator<R2ObjectsLike> {
     const bucket = this.bucket()

--- a/packages/server/src/storage/drivers/S3Driver.ts
+++ b/packages/server/src/storage/drivers/S3Driver.ts
@@ -390,7 +390,12 @@ export class S3Driver implements StorageDriver {
    */
   private listingPrefix(directory: string): string {
     const prefix = this.prefixKey(directory)
-    return prefix ? `${prefix.replace(/\/+$/, '')}/` : ''
+    let end = prefix.length
+    while (end > 0 && prefix.charCodeAt(end - 1) === 0x2f /* '/' */) {
+      end--
+    }
+    const trimmed = prefix.slice(0, end)
+    return trimmed ? `${trimmed}/` : ''
   }
 
   async files(directory: string): Promise<string[]> {

--- a/packages/server/src/storage/drivers/S3Driver.ts
+++ b/packages/server/src/storage/drivers/S3Driver.ts
@@ -326,46 +326,64 @@ export class S3Driver implements StorageDriver {
     return metadata
   }
 
-  async files(directory: string): Promise<string[]> {
+  /**
+   * Run ListObjectsV2 to exhaustion, following `NextContinuationToken` —
+   * a single request returns at most 1000 entries, so a one-page read
+   * silently truncates larger listings.
+   */
+  private async listAll(input: Record<string, unknown>): Promise<{
+    contents: Array<{ Key?: string }>
+    commonPrefixes: Array<{ Prefix?: string }>
+  }> {
     const client = await this.getClient()
     const { ListObjectsV2Command } = await importAwsModule('@aws-sdk/client-s3') as {
       ListObjectsV2Command: new (input: unknown) => unknown
     }
 
+    const contents: Array<{ Key?: string }> = []
+    const commonPrefixes: Array<{ Prefix?: string }> = []
+    let continuationToken: string | undefined
+
+    do {
+      const command = new ListObjectsV2Command(
+        continuationToken ? { ...input, ContinuationToken: continuationToken } : input
+      )
+      const response = await client.send(command) as {
+        Contents?: Array<{ Key?: string }>
+        CommonPrefixes?: Array<{ Prefix?: string }>
+        IsTruncated?: boolean
+        NextContinuationToken?: string
+      }
+      contents.push(...(response.Contents ?? []))
+      commonPrefixes.push(...(response.CommonPrefixes ?? []))
+      continuationToken = response.IsTruncated ? response.NextContinuationToken : undefined
+    } while (continuationToken)
+
+    return { contents, commonPrefixes }
+  }
+
+  async files(directory: string): Promise<string[]> {
     const prefix = this.prefixKey(directory)
-    const command = new ListObjectsV2Command({
+    const { contents } = await this.listAll({
       Bucket: this.bucket,
       Prefix: prefix ? `${prefix}/` : '',
       Delimiter: '/',
     })
 
-    const response = await client.send(command) as {
-      Contents?: Array<{ Key?: string }>
-    }
-
-    return (response.Contents ?? [])
+    return contents
       .map((item) => item.Key?.replace(this.prefix ? `${this.prefix}/` : '', '') ?? '')
       .filter((key) => key && !key.endsWith('/'))
   }
 
   async directories(directory: string): Promise<string[]> {
-    const client = await this.getClient()
-    const { ListObjectsV2Command } = await importAwsModule('@aws-sdk/client-s3') as {
-      ListObjectsV2Command: new (input: unknown) => unknown
-    }
-
     const prefix = this.prefixKey(directory)
-    const command = new ListObjectsV2Command({
+    const { commonPrefixes } = await this.listAll({
       Bucket: this.bucket,
       Prefix: prefix ? `${prefix}/` : '',
       Delimiter: '/',
     })
 
-    const response = await client.send(command) as {
-      CommonPrefixes?: Array<{ Prefix?: string }>
-    }
-
-    return (response.CommonPrefixes ?? [])
+    return commonPrefixes
       .map((item) =>
         item.Prefix?.replace(this.prefix ? `${this.prefix}/` : '', '').replace(/\/$/, '') ?? ''
       )
@@ -373,22 +391,13 @@ export class S3Driver implements StorageDriver {
   }
 
   async allFiles(directory: string): Promise<string[]> {
-    const client = await this.getClient()
-    const { ListObjectsV2Command } = await importAwsModule('@aws-sdk/client-s3') as {
-      ListObjectsV2Command: new (input: unknown) => unknown
-    }
-
     const prefix = this.prefixKey(directory)
-    const command = new ListObjectsV2Command({
+    const { contents } = await this.listAll({
       Bucket: this.bucket,
       Prefix: prefix ? `${prefix}/` : '',
     })
 
-    const response = await client.send(command) as {
-      Contents?: Array<{ Key?: string }>
-    }
-
-    return (response.Contents ?? [])
+    return contents
       .map((item) => item.Key?.replace(this.prefix ? `${this.prefix}/` : '', '') ?? '')
       .filter((key) => key && !key.endsWith('/'))
   }

--- a/packages/server/src/storage/drivers/S3Driver.ts
+++ b/packages/server/src/storage/drivers/S3Driver.ts
@@ -208,15 +208,21 @@ export class S3Driver implements StorageDriver {
       DeleteObjectsCommand: new (input: unknown) => unknown
     }
 
-    const command = new DeleteObjectsCommand({
-      Bucket: this.bucket,
-      Delete: {
-        Objects: paths.map((path) => ({ Key: this.prefixKey(path) })),
-      },
-    })
+    // DeleteObjects accepts at most 1000 keys per request; a larger payload
+    // is rejected outright, deleting nothing.
+    let deleted = 0
+    for (let index = 0; index < paths.length; index += 1000) {
+      const command = new DeleteObjectsCommand({
+        Bucket: this.bucket,
+        Delete: {
+          Objects: paths.slice(index, index + 1000).map((path) => ({ Key: this.prefixKey(path) })),
+        },
+      })
 
-    const response = await client.send(command) as { Deleted?: unknown[] }
-    return response.Deleted?.length ?? 0
+      const response = await client.send(command) as { Deleted?: unknown[] }
+      deleted += response.Deleted?.length ?? 0
+    }
+    return deleted
   }
 
   async copy(from: string, to: string): Promise<string> {
@@ -356,17 +362,41 @@ export class S3Driver implements StorageDriver {
       }
       contents.push(...(response.Contents ?? []))
       commonPrefixes.push(...(response.CommonPrefixes ?? []))
-      continuationToken = response.IsTruncated ? response.NextContinuationToken : undefined
+      if (response.IsTruncated) {
+        // A truncated page whose token is missing or repeats the last one
+        // cannot advance: returning what we have would silently truncate,
+        // and re-sending the same token would loop forever. S3-compatible
+        // endpoints are exactly where such malformed pages show up.
+        const next = response.NextContinuationToken
+        if (!next || next === continuationToken) {
+          throw new Error(
+            'S3 listing reported IsTruncated without an advancing NextContinuationToken; refusing to return an incomplete listing.'
+          )
+        }
+        continuationToken = next
+      } else {
+        continuationToken = undefined
+      }
     } while (continuationToken)
 
     return { contents, commonPrefixes }
   }
 
-  async files(directory: string): Promise<string[]> {
+  /**
+   * The ListObjectsV2 `Prefix` for a directory: the prefixed key with exactly
+   * one trailing slash, or empty for the bucket (or disk prefix) root —
+   * naively appending `/` to `prefixKey('')` on a prefixed disk yields
+   * `prefix//`, which matches nothing.
+   */
+  private listingPrefix(directory: string): string {
     const prefix = this.prefixKey(directory)
+    return prefix ? `${prefix.replace(/\/+$/, '')}/` : ''
+  }
+
+  async files(directory: string): Promise<string[]> {
     const { contents } = await this.listAll({
       Bucket: this.bucket,
-      Prefix: prefix ? `${prefix}/` : '',
+      Prefix: this.listingPrefix(directory),
       Delimiter: '/',
     })
 
@@ -376,10 +406,9 @@ export class S3Driver implements StorageDriver {
   }
 
   async directories(directory: string): Promise<string[]> {
-    const prefix = this.prefixKey(directory)
     const { commonPrefixes } = await this.listAll({
       Bucket: this.bucket,
-      Prefix: prefix ? `${prefix}/` : '',
+      Prefix: this.listingPrefix(directory),
       Delimiter: '/',
     })
 
@@ -391,10 +420,9 @@ export class S3Driver implements StorageDriver {
   }
 
   async allFiles(directory: string): Promise<string[]> {
-    const prefix = this.prefixKey(directory)
     const { contents } = await this.listAll({
       Bucket: this.bucket,
-      Prefix: prefix ? `${prefix}/` : '',
+      Prefix: this.listingPrefix(directory),
     })
 
     return contents

--- a/packages/server/tests/storage/S3Driver.test.ts
+++ b/packages/server/tests/storage/S3Driver.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it, mock } from 'bun:test'
 
 // The AWS SDK is an optional peer that is not installed in this workspace.
-// The driver only needs the command class as a carrier for its input, so a
-// bare stand-in is enough — the logic under test (following continuation
-// tokens, mapping keys) is the driver's own, exercised through an injected
-// client that scripts the paged responses.
+// The driver only needs the command classes as carriers for their input, so
+// bare stand-ins are enough — the logic under test (following continuation
+// tokens, batching deletes, mapping keys) is the driver's own, exercised
+// through an injected client that scripts the responses. Note bun never
+// restores mock.module, so this replacement outlives this file; the module
+// is otherwise absent here, so the only behavior it can mask in another
+// test is the missing-optional-dependency error.
 mock.module('@aws-sdk/client-s3', () => ({
   ListObjectsV2Command: class {
+    constructor(readonly input: Record<string, unknown>) {}
+  },
+  DeleteObjectsCommand: class {
     constructor(readonly input: Record<string, unknown>) {}
   },
 }))
@@ -126,12 +132,55 @@ describe('S3Driver listing pagination', () => {
     expect(client.inputs).toHaveLength(1)
   })
 
-  it('stops when a truncated response carries no continuation token', async () => {
-    const { driver, client } = makeDriver([
+  it('lists from the disk prefix root without doubling the slash', async () => {
+    const { driver, client } = makeDriver(
+      [{ Contents: [{ Key: 'app/a.txt' }] }],
+      { prefix: 'app' },
+    )
+
+    expect(await driver.allFiles('')).toEqual(['a.txt'])
+    expect(client.inputs[0]?.Prefix).toBe('app/')
+  })
+
+  it('throws instead of returning an incomplete listing when a truncated response carries no token', async () => {
+    const { driver } = makeDriver([
       { Contents: [{ Key: 'a.txt' }], IsTruncated: true },
     ])
 
-    expect(await driver.allFiles('')).toEqual(['a.txt'])
-    expect(client.inputs).toHaveLength(1)
+    await expect(driver.allFiles('')).rejects.toThrow(/IsTruncated without an advancing/)
+  })
+
+  it('throws instead of looping when a truncated response repeats the previous token', async () => {
+    const { driver, client } = makeDriver([
+      { Contents: [{ Key: 'a.txt' }], IsTruncated: true, NextContinuationToken: 'token-1' },
+      { Contents: [{ Key: 'b.txt' }], IsTruncated: true, NextContinuationToken: 'token-1' },
+    ])
+
+    await expect(driver.allFiles('')).rejects.toThrow(/IsTruncated without an advancing/)
+    expect(client.inputs).toHaveLength(2)
+  })
+})
+
+describe('S3Driver deleteMany batching', () => {
+  it('splits deletes into DeleteObjects requests of at most 1000 keys', async () => {
+    const client = {
+      inputs: [] as Array<Record<string, unknown>>,
+      async send(command: unknown): Promise<unknown> {
+        const input = (command as { input: Record<string, unknown> }).input
+        this.inputs.push(input)
+        const objects = (input.Delete as { Objects: unknown[] }).Objects
+        return { Deleted: objects }
+      },
+    }
+    const driver = new S3Driver({ client, bucket: 'bucket' })
+
+    const paths = Array.from({ length: 1001 }, (_, index) => `file-${index}.txt`)
+    expect(await driver.deleteMany(paths)).toBe(1001)
+
+    expect(client.inputs).toHaveLength(2)
+    const batchSizes = client.inputs.map(
+      (input) => (input.Delete as { Objects: unknown[] }).Objects.length,
+    )
+    expect(batchSizes).toEqual([1000, 1])
   })
 })

--- a/packages/server/tests/storage/S3Driver.test.ts
+++ b/packages/server/tests/storage/S3Driver.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, mock } from 'bun:test'
+
+// The AWS SDK is an optional peer that is not installed in this workspace.
+// The driver only needs the command class as a carrier for its input, so a
+// bare stand-in is enough — the logic under test (following continuation
+// tokens, mapping keys) is the driver's own, exercised through an injected
+// client that scripts the paged responses.
+mock.module('@aws-sdk/client-s3', () => ({
+  ListObjectsV2Command: class {
+    constructor(readonly input: Record<string, unknown>) {}
+  },
+}))
+
+import { S3Driver } from '../../src/storage/drivers/S3Driver'
+
+interface ListPage {
+  Contents?: Array<{ Key?: string }>
+  CommonPrefixes?: Array<{ Prefix?: string }>
+  IsTruncated?: boolean
+  NextContinuationToken?: string
+}
+
+class FakeS3Client {
+  readonly inputs: Array<Record<string, unknown>> = []
+
+  constructor(private readonly pages: ListPage[]) {}
+
+  async send(command: unknown): Promise<unknown> {
+    this.inputs.push((command as { input: Record<string, unknown> }).input)
+    const page = this.pages[this.inputs.length - 1]
+    if (!page) {
+      throw new Error(`Unexpected request #${this.inputs.length}: no page scripted`)
+    }
+    return page
+  }
+}
+
+function makeDriver(pages: ListPage[], options: { prefix?: string } = {}) {
+  const client = new FakeS3Client(pages)
+  const driver = new S3Driver({
+    client,
+    bucket: 'bucket',
+    ...options,
+  })
+  return { driver, client }
+}
+
+describe('S3Driver listing pagination', () => {
+  it('allFiles follows continuation tokens until the listing is exhausted', async () => {
+    const { driver, client } = makeDriver([
+      {
+        Contents: [{ Key: 'dir/a.txt' }, { Key: 'dir/b.txt' }],
+        IsTruncated: true,
+        NextContinuationToken: 'token-1',
+      },
+      {
+        Contents: [{ Key: 'dir/c.txt' }],
+        IsTruncated: true,
+        NextContinuationToken: 'token-2',
+      },
+      {
+        Contents: [{ Key: 'dir/d.txt' }],
+        IsTruncated: false,
+      },
+    ])
+
+    const files = await driver.allFiles('dir')
+
+    expect(files).toEqual(['dir/a.txt', 'dir/b.txt', 'dir/c.txt', 'dir/d.txt'])
+    expect(client.inputs).toHaveLength(3)
+    expect(client.inputs[0]?.ContinuationToken).toBeUndefined()
+    expect(client.inputs[1]?.ContinuationToken).toBe('token-1')
+    expect(client.inputs[2]?.ContinuationToken).toBe('token-2')
+  })
+
+  it('directories aggregates common prefixes across pages', async () => {
+    const { driver, client } = makeDriver([
+      {
+        CommonPrefixes: [{ Prefix: 'a/' }, { Prefix: 'b/' }],
+        IsTruncated: true,
+        NextContinuationToken: 'token-1',
+      },
+      {
+        CommonPrefixes: [{ Prefix: 'c/' }],
+        IsTruncated: false,
+      },
+    ])
+
+    const directories = await driver.directories('')
+
+    expect(directories).toEqual(['a', 'b', 'c'])
+    expect(client.inputs).toHaveLength(2)
+    expect(client.inputs[1]?.ContinuationToken).toBe('token-1')
+    expect(client.inputs[1]?.Delimiter).toBe('/')
+  })
+
+  it('files aggregates keys across pages and strips the disk prefix', async () => {
+    const { driver, client } = makeDriver(
+      [
+        {
+          Contents: [{ Key: 'app/dir/a.txt' }, { Key: 'app/dir/' }],
+          IsTruncated: true,
+          NextContinuationToken: 'token-1',
+        },
+        {
+          Contents: [{ Key: 'app/dir/b.txt' }],
+          IsTruncated: false,
+        },
+      ],
+      { prefix: 'app' },
+    )
+
+    const files = await driver.files('dir')
+
+    expect(files).toEqual(['dir/a.txt', 'dir/b.txt'])
+    expect(client.inputs[0]?.Prefix).toBe('app/dir/')
+    expect(client.inputs[1]?.ContinuationToken).toBe('token-1')
+  })
+
+  it('stops after a single page when the response is not truncated', async () => {
+    const { driver, client } = makeDriver([
+      { Contents: [{ Key: 'a.txt' }] },
+    ])
+
+    expect(await driver.allFiles('')).toEqual(['a.txt'])
+    expect(client.inputs).toHaveLength(1)
+  })
+
+  it('stops when a truncated response carries no continuation token', async () => {
+    const { driver, client } = makeDriver([
+      { Contents: [{ Key: 'a.txt' }], IsTruncated: true },
+    ])
+
+    expect(await driver.allFiles('')).toEqual(['a.txt'])
+    expect(client.inputs).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

`S3Driver.files()`, `directories()`, and `allFiles()` issued a single ListObjectsV2 request and treated the first page as the whole listing. A single request returns at most 1000 entries, so larger listings were silently truncated: callers walking prefixes missed everything past page one, and `deleteDirectory()` left objects behind. All three methods now share a `listAll()` helper that follows `NextContinuationToken` until the listing is exhausted.

Review of the fix surfaced three adjacent defects in the same paths, fixed in the second commit:

- **`deleteMany()` batching** — DeleteObjects accepts at most 1000 keys per request; a larger payload is rejected outright. With pagination fixed, `deleteDirectory()` on a 1000+ object directory would have handed the full key list to one request and deleted nothing. Deletes are now split into 1000-key batches (mirroring `R2Driver`'s existing `DELETE_BATCH_SIZE` handling).
- **Fail-loud pagination** — a truncated page whose continuation token is missing or repeats the previous one now throws instead of silently returning an incomplete listing (or looping forever). Malformed pages like this are exactly what S3-compatible endpoints produce.
- **Root listings on a prefixed disk** — `prefixKey('')` already ends in `/`, so the listing methods sent `Prefix: "prefix//"`, which matches nothing. A shared `listingPrefix()` helper normalizes to exactly one trailing slash.

`R2Driver` already follows its `cursor` to exhaustion; only its stale comment referencing the S3 defect changed.

## Scope

- `packages/server/src/storage/drivers/S3Driver.ts`
- `packages/server/tests/storage/S3Driver.test.ts` (new)
- `packages/plugin-cloudflare/src/storage/R2Driver.ts` (comment only)
- `.changeset/s3-listing-pagination.md` (`@guren/server` patch)

## Risk Assessment

- Listings that previously returned at most 1000 entries now return everything; callers get more data, not different shapes.
- New failure mode: a truncated listing page without an advancing token throws instead of silently truncating. This only fires on malformed responses from S3-compatible endpoints — a well-behaved S3 never produces it.
- `deleteMany()` with >1000 paths now issues multiple requests instead of one oversized request S3 would have rejected.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test`

New unit tests drive the driver through an injected fake client with scripted pages (the AWS SDK is an uninstalled optional peer; `mock.module` supplies bare input-carrier command classes): token forwarding across pages, prefix stripping, root listing on a prefixed disk, throw on missing/repeated tokens, and delete batch splitting (1001 keys → 1000 + 1).

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.