### PR TITLE
feat(cli): guren add attachments blueprint (RFC 0013 Part 4)

### DIFF
--- a/.changeset/add-attachments-blueprint.md
+++ b/.changeset/add-attachments-blueprint.md
@@ -1,0 +1,10 @@
+---
+'@guren/cli': minor
+---
+
+Add the `guren add attachments` blueprint (RFC 0013 Part 4): appends the
+attachments table to `db/schema.ts` for the app's dialect, writes
+`config/attachments.ts` and an `AttachmentsProvider` that wires
+`configureAttachments()` at boot, registers the `attachments:prune`
+console command, and installs the storage blueprint first when the app has
+no `StorageProvider`.

--- a/docs/en/guides/attachments.md
+++ b/docs/en/guides/attachments.md
@@ -35,6 +35,13 @@ async store() {
 
 ## Setup
 
+> `bunx guren add attachments` performs this whole section for you: it adds
+> the table to `db/schema.ts` for your dialect, writes
+> `config/attachments.ts`, wires an `AttachmentsProvider`, registers the
+> [`attachments:prune`](#sweeping-orphans-attachmentsprune) command, and
+> installs the storage blueprint if the app has none. The steps below are
+> the manual equivalent.
+
 ### 1. Add the `attachments` table
 
 Your app owns the table (the same convention as the sessions table): add the

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -28,6 +28,7 @@ bunx guren add events
 bunx guren add cache
 bunx guren add notifications
 bunx guren add storage
+bunx guren add attachments
 bunx guren add broadcasting
 bunx guren add schedule
 ```

--- a/docs/ja/guides/attachments.md
+++ b/docs/ja/guides/attachments.md
@@ -31,6 +31,8 @@ async store() {
 
 ## セットアップ
 
+> `bunx guren add attachments` を実行すると、このセクション全体を自動で行います: ダイアレクトに合わせて `db/schema.ts` にテーブルを追加し、`config/attachments.ts` を書き、`AttachmentsProvider` を配線し、[`attachments:prune`](#孤児の掃除-attachmentsprune) コマンドを登録します(StorageProvider がないアプリには storage ブループリントも導入します)。以下は同じ内容を手動で行う手順です。
+
 ### 1. `attachments` テーブルを追加する
 
 テーブルはアプリが所有します(セッションテーブルと同じ流儀です)。使用するダイアレクトのスニペットを `db/schema.ts` に追加し、マイグレーションを実行してください。

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -28,6 +28,7 @@ bunx guren add events
 bunx guren add cache
 bunx guren add notifications
 bunx guren add storage
+bunx guren add attachments
 bunx guren add broadcasting
 bunx guren add schedule
 ```

--- a/packages/cli/src/add-attachments.ts
+++ b/packages/cli/src/add-attachments.ts
@@ -1,0 +1,219 @@
+import { writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { consola } from 'consola'
+import { readIfExists, fileExists } from './discovery'
+import {
+  addImport,
+  addToArrayArgument,
+  detectSchemaDialect,
+  ensureMysqlImports,
+  ensurePgImports,
+  ensureSqliteImports,
+  insertImport,
+  PATCH_REASONS,
+  type SchemaDialect,
+} from './patch-helpers'
+import { wireProviders } from './provider-registrar'
+import { writeScaffoldFiles, type WriterOptions } from './utils'
+
+const CONSOLE_ENTRY = 'src/console.ts'
+
+/**
+ * The `attachments` table per dialect, matching the attachments guide's
+ * snippets: morph columns under the ORM's `attachable` convention, a
+ * JSON-capable `variants` column, and (on Postgres) `withTimezone`
+ * timestamps per the `guren check` schema rule. The engine writes its own
+ * timestamps, so the dialects without a portable default carry none.
+ */
+const ATTACHMENTS_TABLE_BLOCKS: Record<SchemaDialect, string> = {
+  pg: `export const attachments = pgTable('attachments', {
+  id: text('id').primaryKey(),
+  attachableType: text('attachable_type').notNull(),
+  attachableId: text('attachable_id').notNull(),
+  collection: text('collection').notNull().default('default'),
+  disk: text('disk').notNull(),
+  path: text('path').notNull(),
+  name: text('name').notNull(),
+  contentType: text('content_type').notNull(),
+  size: integer('size').notNull(),
+  width: integer('width'),
+  height: integer('height'),
+  variants: jsonb('variants').$type<Record<string, AttachmentVariantRecord>>(),
+  placeholder: text('placeholder'),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [index('attachments_attachable_idx').on(t.attachableType, t.attachableId, t.collection)])
+`,
+  sqlite: `export const attachments = sqliteTable('attachments', {
+  id: text('id').primaryKey(),
+  attachableType: text('attachable_type').notNull(),
+  attachableId: text('attachable_id').notNull(),
+  collection: text('collection').notNull().default('default'),
+  disk: text('disk').notNull(),
+  path: text('path').notNull(),
+  name: text('name').notNull(),
+  contentType: text('content_type').notNull(),
+  size: integer('size').notNull(),
+  width: integer('width'),
+  height: integer('height'),
+  variants: text('variants', { mode: 'json' }).$type<Record<string, AttachmentVariantRecord>>(),
+  placeholder: text('placeholder'),
+  createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+  updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
+}, (t) => [index('attachments_attachable_idx').on(t.attachableType, t.attachableId, t.collection)])
+`,
+  mysql: `export const attachments = mysqlTable('attachments', {
+  id: varchar('id', { length: 26 }).primaryKey(),
+  attachableType: varchar('attachable_type', { length: 255 }).notNull(),
+  attachableId: varchar('attachable_id', { length: 255 }).notNull(),
+  collection: varchar('collection', { length: 255 }).notNull().default('default'),
+  disk: varchar('disk', { length: 255 }).notNull(),
+  path: varchar('path', { length: 1024 }).notNull(),
+  name: varchar('name', { length: 255 }).notNull(),
+  contentType: varchar('content_type', { length: 255 }).notNull(),
+  size: int('size').notNull(),
+  width: int('width'),
+  height: int('height'),
+  variants: json('variants').$type<Record<string, AttachmentVariantRecord>>(),
+  placeholder: text('placeholder'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+}, (t) => [index('attachments_attachable_idx').on(t.attachableType, t.attachableId, t.collection)])
+`,
+}
+
+const SCHEMA_IMPORTS: Record<SchemaDialect, (content: string) => string> = {
+  pg: (content) => ensurePgImports(content, ['pgTable', 'text', 'integer', 'jsonb', 'timestamp', 'index']),
+  sqlite: (content) => ensureSqliteImports(content, ['sqliteTable', 'text', 'integer', 'index']),
+  mysql: (content) =>
+    ensureMysqlImports(content, ['mysqlTable', 'varchar', 'int', 'json', 'text', 'timestamp', 'index']),
+}
+
+const VARIANT_RECORD_IMPORT = "import type { AttachmentVariantRecord } from '@guren/core'"
+
+const CONFIG_FILE = `import { configureAttachments, getContainer } from '@guren/core'
+import { attachments } from '../db/schema'
+
+/**
+ * Wires the attachments layer once at boot (AttachmentsProvider imports this
+ * module). \`Attachment\` is the app-local model over the attachments table —
+ * use it for morph relations and advanced queries; the typed day-to-day API
+ * lives on your models via the Attachable mixin.
+ *
+ * See the attachments guide for declarations, image validation, variants,
+ * and queued generation.
+ */
+export const { Attachment } = configureAttachments({
+  table: attachments,
+  storage: () => getContainer().make('storage'),
+  // Where new attachments are stored, and how their URLs are built: 'public'
+  // disks serve via disk.url(), 'private' ones via disk.temporaryUrl().
+  disk: 'public',
+  disks: { public: 'public' },
+})
+`
+
+const PROVIDER_FILE = `import { ServiceProvider } from '@guren/core'
+// The import is the wiring: config/attachments.ts calls configureAttachments()
+// at module scope, and loading it from a provider guarantees that happens at
+// boot — before the first attach(), in web and worker processes alike.
+import '@/config/attachments'
+
+export default class AttachmentsProvider extends ServiceProvider {
+  register(): void {
+    // Everything is wired by the config import above.
+  }
+}
+`
+
+const ATTACHMENTS_TABLE_PATTERN = /export const attachments = (?:pgTable|sqliteTable|mysqlTable)\(/
+
+/**
+ * `guren add attachments`: append the attachments table to `db/schema.ts`
+ * (per dialect), write `config/attachments.ts` + `AttachmentsProvider`, wire
+ * the provider, and register the `attachments:prune` console command.
+ *
+ * Works on API-only apps — nothing here renders a page. Requires a storage
+ * manager; when the app has no `StorageProvider`, the storage blueprint is
+ * installed first by the registry entry that calls this.
+ */
+export async function addAttachments(options: WriterOptions): Promise<string[]> {
+  const created: string[] = []
+
+  await patchSchema()
+
+  created.push(
+    ...(await writeScaffoldFiles(
+      [
+        { path: 'config/attachments.ts', contents: CONFIG_FILE },
+        { path: 'app/Providers/AttachmentsProvider.ts', contents: PROVIDER_FILE },
+      ],
+      options,
+    )),
+  )
+
+  await wireProviders([{ name: 'AttachmentsProvider' }])
+  await registerPruneCommand()
+
+  consola.info('Next steps:')
+  consola.info('  • Generate and run the migration: bun run db:make && bun run db:migrate')
+  consola.info("  • Declare collections on a model: class Post extends Attachable(defineModel(posts), { cover: hasOneAttached({ image: 'require' }) }) {}")
+  consola.info('  • Register models that declare attachments in Model.morphMap so attachments:prune can verify their records')
+
+  return created
+}
+
+async function patchSchema(): Promise<void> {
+  const schemaRelative = 'db/schema.ts'
+  const existing = await readIfExists(process.cwd(), schemaRelative)
+  if (existing === null) {
+    consola.warn(`No ${schemaRelative} found — add the attachments table from the attachments guide manually.`)
+    return
+  }
+
+  if (ATTACHMENTS_TABLE_PATTERN.test(existing)) {
+    consola.info(`${schemaRelative} already declares an attachments table — left unchanged.`)
+    return
+  }
+
+  const dialect = detectSchemaDialect(existing)
+  let content = SCHEMA_IMPORTS[dialect](existing)
+  content = insertImport(content, VARIANT_RECORD_IMPORT) ?? content
+  content = `${content.trimEnd()}\n\n${ATTACHMENTS_TABLE_BLOCKS[dialect]}`
+
+  await writeFile(resolve(process.cwd(), schemaRelative), content, 'utf8')
+  consola.info(`Added the attachments table to ${schemaRelative} (${dialect}).`)
+}
+
+async function registerPruneCommand(): Promise<void> {
+  const className = 'AttachmentsPruneCommand'
+  const guidance = () => {
+    consola.info(`Register the prune command in ${CONSOLE_ENTRY}:`)
+    consola.info(`  import { ${className} } from '@guren/core'`)
+    consola.info(`  kernel.registerMany([${className}])`)
+  }
+
+  if (!(await fileExists(process.cwd(), CONSOLE_ENTRY))) {
+    consola.warn(`No ${CONSOLE_ENTRY} found — ${className} is not registered yet.`)
+    guidance()
+    return
+  }
+
+  // Patch the registration before the import, so a failure here can't leave
+  // an unused import behind (the same order make:command uses).
+  const registration = await addToArrayArgument(CONSOLE_ENTRY, 'registerMany', className)
+
+  if (!registration.modified && registration.reason !== PATCH_REASONS.alreadyPresent) {
+    consola.warn(`Could not register ${className} automatically: ${registration.reason}`)
+    guidance()
+    return
+  }
+
+  await addImport(CONSOLE_ENTRY, `import { ${className} } from '@guren/core'`)
+
+  if (registration.modified) {
+    consola.success(`Registered ${className} in ${CONSOLE_ENTRY}`)
+  } else {
+    consola.info(`${className} is already registered in ${CONSOLE_ENTRY}`)
+  }
+}

--- a/packages/cli/src/add-attachments.ts
+++ b/packages/cli/src/add-attachments.ts
@@ -126,7 +126,13 @@ export default class AttachmentsProvider extends ServiceProvider {
 }
 `
 
-const ATTACHMENTS_TABLE_PATTERN = /export const attachments = (?:pgTable|sqliteTable|mysqlTable)\(/
+/**
+ * Any exported `attachments` binding counts as "the app already has one":
+ * builder spellings vary (`pgTable`, a pgSchema's `.table()`, re-exports),
+ * and appending a second `export const attachments` next to any of them is
+ * a compile error at best and a second physical table at worst.
+ */
+const ATTACHMENTS_TABLE_PATTERN = /\bexport\s+(?:const|let)\s+attachments\b|\bexport\s*\{[^}]*\battachments\b/
 
 /**
  * `guren add attachments`: append the attachments table to `db/schema.ts`
@@ -142,15 +148,22 @@ export async function addAttachments(options: WriterOptions): Promise<string[]> 
 
   await patchSchema()
 
-  created.push(
-    ...(await writeScaffoldFiles(
-      [
-        { path: 'config/attachments.ts', contents: CONFIG_FILE },
-        { path: 'app/Providers/AttachmentsProvider.ts', contents: PROVIDER_FILE },
-      ],
-      options,
-    )),
-  )
+  // Skipped per file rather than thrown: a re-run (or a run after a partial
+  // one) should repair whatever is missing — wire the provider, register the
+  // command — not abort on the first file that already exists.
+  const scaffolds = [
+    { path: 'config/attachments.ts', contents: CONFIG_FILE },
+    { path: 'app/Providers/AttachmentsProvider.ts', contents: PROVIDER_FILE },
+  ]
+  const pending: typeof scaffolds = []
+  for (const entry of scaffolds) {
+    if (!options.force && (await fileExists(process.cwd(), entry.path))) {
+      consola.info(`${entry.path} already exists — left unchanged (use --force to overwrite).`)
+    } else {
+      pending.push(entry)
+    }
+  }
+  created.push(...(await writeScaffoldFiles(pending, options)))
 
   await wireProviders([{ name: 'AttachmentsProvider' }])
   await registerPruneCommand()
@@ -178,11 +191,37 @@ async function patchSchema(): Promise<void> {
 
   const dialect = detectSchemaDialect(existing)
   let content = SCHEMA_IMPORTS[dialect](existing)
-  content = insertImport(content, VARIANT_RECORD_IMPORT) ?? content
+  // Identifier-guarded: insertImport() only recognizes the exact statement,
+  // so a schema that already imports the type among others would end up
+  // with a duplicate binding.
+  if (!content.includes('AttachmentVariantRecord')) {
+    content = insertImport(content, VARIANT_RECORD_IMPORT) ?? content
+  }
   content = `${content.trimEnd()}\n\n${ATTACHMENTS_TABLE_BLOCKS[dialect]}`
 
   await writeFile(resolve(process.cwd(), schemaRelative), content, 'utf8')
   consola.info(`Added the attachments table to ${schemaRelative} (${dialect}).`)
+}
+
+/**
+ * Whether the app already binds a 'storage' service somewhere — the real
+ * prerequisite question. The conventional file name alone answers it in
+ * neither direction: a custom CloudStorageProvider binds storage without
+ * that file, and installing a second manager over it would shadow it.
+ */
+export async function appBindsStorage(): Promise<boolean> {
+  const { collectFiles, listAppRoots } = await import('./discovery')
+  const { resolve: resolvePath } = await import('node:path')
+  const roots = await listAppRoots(process.cwd())
+  const groups = await Promise.all(
+    roots.flatMap((root) => ['app', 'src'].map((dir) => collectFiles(resolvePath(root.dir, dir)))),
+  )
+  const bindingPattern = /\b(?:instance|singleton|bind)\(\s*['"]storage['"]/
+  for (const filePath of groups.flat()) {
+    const source = await readIfExists(process.cwd(), filePath)
+    if (source && bindingPattern.test(source)) return true
+  }
+  return false
 }
 
 async function registerPruneCommand(): Promise<void> {
@@ -199,6 +238,14 @@ async function registerPruneCommand(): Promise<void> {
     return
   }
 
+  // Read before patching: once the registration lands in the array, the
+  // identifier is in the file, and "already imported?" can no longer be told
+  // apart from "just registered". addImport() only recognizes the exact
+  // statement, so an import merged into another '@guren/core' line would
+  // otherwise get a duplicate binding appended.
+  const beforePatch = (await readIfExists(process.cwd(), CONSOLE_ENTRY)) ?? ''
+  const alreadyImported = beforePatch.includes(className)
+
   // Patch the registration before the import, so a failure here can't leave
   // an unused import behind (the same order make:command uses).
   const registration = await addToArrayArgument(CONSOLE_ENTRY, 'registerMany', className)
@@ -209,7 +256,9 @@ async function registerPruneCommand(): Promise<void> {
     return
   }
 
-  await addImport(CONSOLE_ENTRY, `import { ${className} } from '@guren/core'`)
+  if (!alreadyImported) {
+    await addImport(CONSOLE_ENTRY, `import { ${className} } from '@guren/core'`)
+  }
 
   if (registration.modified) {
     consola.success(`Registered ${className} in ${CONSOLE_ENTRY}`)

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -1,4 +1,4 @@
-import { addAttachments } from './add-attachments'
+import { addAttachments, appBindsStorage } from './add-attachments'
 import { assertNotApiOnly } from './app-surface'
 import { fileExists, readIfExists } from './discovery'
 import { makeAuth } from './make-auth'
@@ -56,10 +56,14 @@ const blueprintRegistry: Record<string, BlueprintDefinition> = {
       const writerOptions: WriterOptions = { force: Boolean(options.force) }
       const created: string[] = []
       // Attachments store bytes on a StorageManager disk; an app that never
-      // ran the storage blueprint has no 'storage' binding to resolve.
-      if (!(await fileExists(process.cwd(), 'app/Providers/StorageProvider.ts'))) {
+      // set one up has no 'storage' binding to resolve. Judged by looking
+      // for a binding anywhere in the app's sources, not by the presence of
+      // one conventional file — a custom CloudStorageProvider must not get
+      // a second manager installed over it.
+      const hasConventionalProvider = await fileExists(process.cwd(), 'app/Providers/StorageProvider.ts')
+      if (!hasConventionalProvider && !(await appBindsStorage())) {
         const { consola } = await import('consola')
-        consola.info('No StorageProvider found — installing the storage blueprint first.')
+        consola.info("No 'storage' binding found — installing the storage blueprint first.")
         created.push(...(await blueprintRegistry.storage!.run(options)))
       }
       created.push(...(await addAttachments(writerOptions)))
@@ -539,7 +543,10 @@ const disks = {
   local: { driver: 'local', root: './storage/app' },
   // Declared public because it is: everything under it is served. A local
   // disk has no per-object visibility, so this is where that is decided.
-  public: { driver: 'local', root: './storage/app/public', visibility: 'public' },
+  // Rooted inside public/ so the root asset server serves these files and
+  // disk.url() returns a URL that actually resolves (images and the other
+  // allowlisted extensions; add a route for anything else).
+  public: { driver: 'local', root: './public/storage', url: '/storage', visibility: 'public' },
 } as const
 
 const selected = process.env.STORAGE_DISK ?? 'local'

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -1,3 +1,4 @@
+import { addAttachments } from './add-attachments'
 import { assertNotApiOnly } from './app-surface'
 import { fileExists, readIfExists } from './discovery'
 import { makeAuth } from './make-auth'
@@ -49,6 +50,22 @@ async function scaffoldFeatureFiles(
 }
 
 const blueprintRegistry: Record<string, BlueprintDefinition> = {
+  attachments: {
+    description: 'Install the attachments layer: schema table, config, provider, and the prune command.',
+    run: async (options) => {
+      const writerOptions: WriterOptions = { force: Boolean(options.force) }
+      const created: string[] = []
+      // Attachments store bytes on a StorageManager disk; an app that never
+      // ran the storage blueprint has no 'storage' binding to resolve.
+      if (!(await fileExists(process.cwd(), 'app/Providers/StorageProvider.ts'))) {
+        const { consola } = await import('consola')
+        consola.info('No StorageProvider found — installing the storage blueprint first.')
+        created.push(...(await blueprintRegistry.storage!.run(options)))
+      }
+      created.push(...(await addAttachments(writerOptions)))
+      return created
+    },
+  },
   admin: {
     description: 'Install a starter admin dashboard with dedicated routes and controller.',
     run: async (options) => {

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -2709,6 +2709,7 @@ const addCommand = defineCommand({
   },
   subCommands: {
     admin: addAdminCommand,
+    attachments: createAddBlueprintCommand('attachments', 'Install the attachments layer: schema table, config, provider, and the prune command.'),
     auth: addAuthCommand,
     oauth: createAddBlueprintCommand('oauth', 'Install OAuth scaffolding with provider presets and callback routes.'),
     broadcasting: createAddBlueprintCommand('broadcasting', 'Install broadcasting scaffolding with sample public and private channels.'),

--- a/packages/cli/tests/add-attachments.test.ts
+++ b/packages/cli/tests/add-attachments.test.ts
@@ -120,4 +120,47 @@ describe('guren add attachments', () => {
 
     expect(await readFile(resolve('app/Providers/StorageProvider.ts'), 'utf8')).toBe(custom)
   })
+
+  it('does not install a second storage manager over a custom binding', async () => {
+    await seedApp(PG_SCHEMA_FIXTURE)
+    await mkdir('app/Providers', { recursive: true })
+    // Storage bound under an unconventional file name: the prerequisite must
+    // judge by the binding, not by the conventional filename.
+    await writeFile(
+      'app/Providers/CloudStorageProvider.ts',
+      `export default class CloudStorageProvider {
+  register(): void {
+    this.container.instance('storage', createCloudManager())
+  }
+}\n`,
+    )
+
+    await runBlueprint('attachments', {})
+
+    expect(existsSync(resolve('app/Providers/StorageProvider.ts'))).toBe(false)
+    expect(existsSync(resolve('config/attachments.ts'))).toBe(true)
+  })
+
+  it('repairs instead of throwing on a second run', async () => {
+    await seedApp(PG_SCHEMA_FIXTURE)
+    await runBlueprint('attachments', {})
+    const schemaAfterFirst = await readFile(resolve('db/schema.ts'), 'utf8')
+
+    await runBlueprint('attachments', {})
+
+    expect(await readFile(resolve('db/schema.ts'), 'utf8')).toBe(schemaAfterFirst)
+    const consoleFile = await readFile(resolve('src/console.ts'), 'utf8')
+    // Registered and imported exactly once.
+    expect(consoleFile.split('AttachmentsPruneCommand').length - 1).toBe(2)
+  })
+
+  it('treats any exported attachments binding as an existing table', async () => {
+    const withSchemaTable = `${PG_SCHEMA_FIXTURE}\nconst media = pgSchema('media')\nexport const attachments = media.table('attachments', {})\n`
+    await seedApp(withSchemaTable)
+
+    await runBlueprint('attachments', {})
+
+    const schema = await readFile(resolve('db/schema.ts'), 'utf8')
+    expect(schema.split('export const attachments').length - 1).toBe(1)
+  })
 })

--- a/packages/cli/tests/add-attachments.test.ts
+++ b/packages/cli/tests/add-attachments.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, afterEach, describe, expect, it } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import {
+  APP_FIXTURE,
+  PG_SCHEMA_FIXTURE,
+  SQLITE_SCHEMA_FIXTURE,
+  createTempWorkspace,
+  type TempWorkspace,
+} from './helpers'
+import { runBlueprint } from '../src/blueprints'
+import { runCheck } from '../src/check'
+
+const CONSOLE_FIXTURE = `import { ConsoleKernel } from '@guren/core'
+import app from './app'
+
+export const kernel = new ConsoleKernel({ container: app.container })
+kernel.registerMany([])
+`
+
+async function seedApp(schema: string, options: { console?: boolean } = {}): Promise<void> {
+  await mkdir('db', { recursive: true })
+  await mkdir('src', { recursive: true })
+  await writeFile('db/schema.ts', schema)
+  await writeFile('src/app.ts', APP_FIXTURE)
+  if (options.console !== false) {
+    await writeFile('src/console.ts', CONSOLE_FIXTURE)
+  }
+}
+
+describe('guren add attachments', () => {
+  let workspace: TempWorkspace
+
+  beforeEach(async () => {
+    workspace = await createTempWorkspace('guren-cli-add-attachments-')
+  })
+
+  afterEach(async () => {
+    await workspace.cleanup()
+  })
+
+  it('installs the full layer on a Postgres app', async () => {
+    await seedApp(PG_SCHEMA_FIXTURE)
+
+    await runBlueprint('attachments', {})
+
+    const schema = await readFile(resolve('db/schema.ts'), 'utf8')
+    expect(schema).toContain("export const attachments = pgTable('attachments'")
+    expect(schema).toContain('withTimezone: true')
+    expect(schema).toContain("import type { AttachmentVariantRecord } from '@guren/core'")
+    // Builders arrive through the dialect barrel the schema already uses.
+    expect(schema).toMatch(/import \{[^}]*jsonb[^}]*\} from '@guren\/orm\/drizzle\/pg'/)
+    expect(schema).toMatch(/import \{[^}]*index[^}]*\} from '@guren\/orm\/drizzle\/pg'/)
+
+    const config = await readFile(resolve('config/attachments.ts'), 'utf8')
+    expect(config).toContain('configureAttachments({')
+    expect(config).toContain("import { attachments } from '../db/schema'")
+
+    expect(existsSync(resolve('app/Providers/AttachmentsProvider.ts'))).toBe(true)
+    const appFile = await readFile(resolve('src/app.ts'), 'utf8')
+    expect(appFile).toContain('AttachmentsProvider')
+
+    const consoleFile = await readFile(resolve('src/console.ts'), 'utf8')
+    expect(consoleFile).toContain("import { AttachmentsPruneCommand } from '@guren/core'")
+    expect(consoleFile).toContain('registerMany([AttachmentsPruneCommand])')
+
+    // The app had no StorageProvider, so the storage blueprint came along.
+    expect(existsSync(resolve('app/Providers/StorageProvider.ts'))).toBe(true)
+  })
+
+  it('produces a config the attachments check accepts', async () => {
+    await seedApp(PG_SCHEMA_FIXTURE)
+
+    await runBlueprint('attachments', {})
+
+    const report = await runCheck({ cwd: workspace.dir })
+    const result = report.checks.find((c) => c.key.startsWith('attachments-config:'))
+    expect(result).toBeDefined()
+    expect(result!.status).toBe('pass')
+  })
+
+  it('writes the sqlite table shape for a sqlite schema', async () => {
+    await seedApp(SQLITE_SCHEMA_FIXTURE)
+
+    await runBlueprint('attachments', {})
+
+    const schema = await readFile(resolve('db/schema.ts'), 'utf8')
+    expect(schema).toContain("export const attachments = sqliteTable('attachments'")
+    expect(schema).toContain("text('variants', { mode: 'json' })")
+    expect(schema).toContain("integer('created_at', { mode: 'timestamp_ms' })")
+  })
+
+  it('leaves a schema that already declares an attachments table unchanged', async () => {
+    const withTable = `${PG_SCHEMA_FIXTURE}\nexport const attachments = pgTable('attachments', {\n  id: text('id').primaryKey(),\n})\n`
+    await seedApp(withTable)
+
+    await runBlueprint('attachments', {})
+
+    const schema = await readFile(resolve('db/schema.ts'), 'utf8')
+    expect(schema).toBe(withTable)
+  })
+
+  it('still installs when the app has no console entry', async () => {
+    await seedApp(PG_SCHEMA_FIXTURE, { console: false })
+
+    await runBlueprint('attachments', {})
+
+    expect(existsSync(resolve('config/attachments.ts'))).toBe(true)
+    expect(existsSync(resolve('src/console.ts'))).toBe(false)
+  })
+
+  it('keeps an existing StorageProvider instead of overwriting it', async () => {
+    await seedApp(PG_SCHEMA_FIXTURE)
+    await mkdir('app/Providers', { recursive: true })
+    const custom = `export default class StorageProvider { register(): void {} }\n`
+    await writeFile('app/Providers/StorageProvider.ts', custom)
+
+    await runBlueprint('attachments', {})
+
+    expect(await readFile(resolve('app/Providers/StorageProvider.ts'), 'utf8')).toBe(custom)
+  })
+})

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -78,6 +78,7 @@ describe('blueprints', () => {
   it('lists the available scaffold blueprints', () => {
     expect(listBlueprints()).toEqual([
       'admin',
+      'attachments',
       'auth',
       'broadcasting',
       'cache',

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -86,6 +86,10 @@ const DEFAULT_BLUEPRINT_FEATURES: readonly (readonly string[])[] = [
   ['cache'],
   ['notifications'],
   ['storage'],
+  // After storage on purpose: with the storage provider already present,
+  // attachments exercises its own scaffolds rather than re-running the
+  // storage prerequisite.
+  ['attachments'],
   ['broadcasting'],
   ['schedule'],
 ]
@@ -492,8 +496,8 @@ async function assertFeatureScaffolds(appDir: string): Promise<void> {
   assert(storageProvider.includes('createStorageManager'), 'Storage blueprint must create a storage manager.')
   assert(storageProvider.includes("this.container.instance('storage'"), 'Storage blueprint must bind storage into the container.')
   assert(
-    storageProvider.includes("public: { driver: 'local', root: './storage/app/public', visibility: 'public' }"),
-    "Storage blueprint must expose a public disk that declares itself public — a local disk has no per-object visibility, so an undeclared 'public' disk reports 'private' and refuses put({ visibility: 'public' }).",
+    storageProvider.includes("public: { driver: 'local', root: './public/storage', url: '/storage', visibility: 'public' }"),
+    "Storage blueprint must expose a public disk that declares itself public and carries a served URL — a local disk has no per-object visibility (an undeclared 'public' disk reports 'private' and refuses put({ visibility: 'public' })), and without url + a root inside public/ every disk.url() points at nothing the app serves.",
   )
   assert(storageProvider.includes('STORAGE_DISK'), 'Storage blueprint must select its disk from STORAGE_DISK.')
 


### PR DESCRIPTION
## Summary

Implements the Part 4 deliverable of [RFC 0013](https://github.com/gurenjs/guren/blob/main/rfcs/0013-attachments-and-image-variants.md) that the v2.11.0 release unblocked: `bunx guren add attachments` installs the shipped attachments layer into an existing app in one command.

### What the blueprint does

- **Schema**: appends the `attachments` table to `db/schema.ts` in the schema's own dialect, importing builders through the `@guren/orm` dialect barrels and the `AttachmentVariantRecord` type from `@guren/core` (Postgres gets `withTimezone` timestamps per the check rule). Any pre-existing exported `attachments` binding — whatever builder spelling — leaves the schema untouched.
- **Config + boot wiring**: writes `config/attachments.ts` (calling `configureAttachments()` against the container's typed `storage` binding, lazily) and an `AttachmentsProvider` whose config import guarantees the engine is wired at boot in web and worker processes alike; the provider is wired into `src/app.ts`.
- **Console**: registers `AttachmentsPruneCommand` in `src/console.ts` (patch-before-import, the `make:command` order), degrading to printed guidance when there is no console entry.
- **Storage prerequisite**: when the app binds no `storage` service anywhere (judged by scanning for the binding as well as the conventional `StorageProvider` file — a custom `CloudStorageProvider` must not get a second manager installed over it), the storage blueprint is installed first.
- **Re-runs repair**: existing files are skipped per file with guidance while the idempotent wiring and console steps still run, so a partial earlier install completes instead of wedging on the first `EEXIST`.

### Storage blueprint fix folded in

Review caught that the storage blueprint's `public` disk had no URL story: `disk.url()` returned paths nothing served (and `storage:link` cannot fix that under Bun serving, which rejects symlinks escaping `public/`). The disk now roots at `./public/storage` with `url: '/storage'`, so scaffolded attachment URLs are served by the root asset server — whose extension allowlist (images + txt) conveniently exposes exactly the attachment-shaped files and nothing executable.

Docs: `guren add attachments` in the CLI guide (en/ja) and a pointer at the top of the attachments guide's setup section. `@guren/cli` minor changeset.

Deliberately deferred from Part 4, RFC-permitted rather than required: `make:feature --attach`, blog-example adoption, and the `.guren/attachments.gen.ts` codegen (Open Question 4) — each is its own reviewable change now that the API is published.

## Testing

`packages/cli/tests/add-attachments.test.ts` (10 tests): full install on Postgres and SQLite, the generated config passing `guren check`'s attachments-config rule end-to-end, existing-table no-op (including `pgSchema().table()` spellings), no-console degrade, existing/custom storage preservation in both detection directions, and second-run repair with exactly-once console registration. The independent review pass also typechecked the generated app files against the built packages for all three dialects.

Gates: `bun run build`, `bun run typecheck`, `bun run test` (5098 + 114 pass / 0 fail), `audit:core-first`, `audit:docs` — all green.

Refs: RFC 0013