### PR TITLE
fix(server): prefer .vite/manifest.json over a stale flat manifest

### DIFF
--- a/packages/core/src/internal/deploy-build.ts
+++ b/packages/core/src/internal/deploy-build.ts
@@ -74,7 +74,16 @@ export function readManifest(
   return undefined
 }
 
-/** The two layouts `readManifest` accepts, in preference order. */
+/**
+ * The two layouts `readManifest` accepts, in preference order: `.vite/` first,
+ * because Vite >= 5 writes it there and a flat `manifest.json` beside it is
+ * most likely stale output of an older config. `@guren/server`'s runtime
+ * lookup (`clientManifestCandidates` in `http/vite-manifest.ts`) prefers the
+ * same layout — the orders must agree, or an app with both files resolves
+ * different asset versions locally than after a deploy; the server's
+ * `tests/http/vite-manifest.test.ts` pins the agreement (the rule cannot be
+ * shared as code, since this module imports nothing beyond node builtins).
+ */
 function manifestPaths(dir: string): [string, string] {
   return [resolve(dir, '.vite/manifest.json'), resolve(dir, 'manifest.json')]
 }

--- a/packages/server/src/http/inertia-assets.ts
+++ b/packages/server/src/http/inertia-assets.ts
@@ -290,16 +290,19 @@ export function autoConfigureInertiaAssets(app: Application, options: AutoConfig
     return
   }
 
+  // Within each directory, `.vite/manifest.json` outranks the flat layout for
+  // the same reason `clientManifestCandidates` puts it first: Vite >= 5
+  // writes `.vite/`, so a flat file beside it is most likely stale.
   const ssrManifestPaths = [
     options.ssrManifest,
-    resolve(moduleDir, `../${ssrOutDir}/manifest.json`),
     resolve(moduleDir, `../${ssrOutDir}/.vite/manifest.json`),
+    resolve(moduleDir, `../${ssrOutDir}/manifest.json`),
     resolve(moduleDir, `../${ssrOutDir}/ssr-manifest.json`),
-    resolve(moduleDir, '../build/ssr/manifest.json'),
     resolve(moduleDir, '../build/ssr/.vite/manifest.json'),
+    resolve(moduleDir, '../build/ssr/manifest.json'),
     resolve(moduleDir, '../build/ssr/ssr-manifest.json'),
-    resolve(moduleDir, '../public/assets/.ssr/manifest.json'),
     resolve(moduleDir, '../public/assets/.ssr/.vite/manifest.json'),
+    resolve(moduleDir, '../public/assets/.ssr/manifest.json'),
     resolve(moduleDir, '../public/assets/.ssr/ssr-manifest.json'),
     resolve(moduleDir, '../public/assets/.vite/ssr-manifest.json'),
   ].filter((value): value is string => Boolean(value))

--- a/packages/server/src/http/vite-manifest.ts
+++ b/packages/server/src/http/vite-manifest.ts
@@ -44,15 +44,21 @@ export function normalizeDevServerUrl(value: string): string {
 
 /**
  * Candidate client-manifest locations under a project root, in preference
- * order. `baseDir` defaults to the working directory (`viteAsset()`'s
- * anchor); the Inertia wiring passes the root it derives from the app entry
- * module.
+ * order: `.vite/manifest.json` first, because Vite >= 5 writes it there — a
+ * flat `manifest.json` beside it is most likely a stale leftover from an
+ * older Vite config. The deploy plugins locate the same pair through
+ * `@guren/core`'s deploy-build helpers, and the two orders must agree, or an
+ * app with both layouts resolves different asset versions locally than after
+ * a serverless deploy; `tests/http/vite-manifest.test.ts` pins the agreement.
+ *
+ * `baseDir` defaults to the working directory (`viteAsset()`'s anchor); the
+ * Inertia wiring passes the root it derives from the app entry module.
  */
 export function clientManifestCandidates(baseDir?: string): string[] {
   const root = baseDir ?? process.cwd()
   return [
-    resolve(root, 'public/assets/manifest.json'),
     resolve(root, 'public/assets/.vite/manifest.json'),
+    resolve(root, 'public/assets/manifest.json'),
   ]
 }
 

--- a/packages/server/tests/http/vite-manifest.test.ts
+++ b/packages/server/tests/http/vite-manifest.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  clientManifestCandidates,
+  loadViteManifest,
+  getManifestFile,
+} from '../../src/http/vite-manifest'
+// The deploy plugins locate the same manifest through core's build-time
+// helpers, and the preference order lives on both sides: here as
+// `clientManifestCandidates`, there as `manifestPaths` in
+// `packages/core/src/internal/deploy-build.ts`. The rule cannot be shared as
+// code — core depends on server, and deploy-build deliberately imports
+// nothing beyond node builtins — so this test is the coupling: it drives both
+// lookups against one fixture and fails if the orders ever disagree again.
+// Importing the module here is safe for the same reason it is portable: its
+// own test pins that the built artifact imports node builtins only.
+import { resolveClientAssetEnv } from '../../../core/src/internal/deploy-build'
+
+const ENTRY = 'resources/js/app.tsx'
+
+describe('clientManifestCandidates', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'guren-vite-manifest-'))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  /**
+   * Both layouts at once, with different content on purpose: the flat file
+   * plays the stale leftover an older Vite config wrote before the app moved
+   * to the `.vite/` layout Vite >= 5 uses.
+   */
+  function writeBothLayouts(): void {
+    const assets = join(root, 'public/assets')
+    mkdirSync(join(assets, '.vite'), { recursive: true })
+    writeFileSync(
+      join(assets, 'manifest.json'),
+      JSON.stringify({ [ENTRY]: { file: 'app-Stale00.js' } }),
+    )
+    writeFileSync(
+      join(assets, '.vite/manifest.json'),
+      JSON.stringify({ [ENTRY]: { file: 'app-Fresh00.js' } }),
+    )
+  }
+
+  test('should prefer .vite/manifest.json over a stale flat manifest.json', () => {
+    writeBothLayouts()
+
+    const manifest = loadViteManifest(clientManifestCandidates(root), 'client', {
+      warnOnMissing: false,
+    })
+
+    expect(manifest?.__path__).toBe(join(root, 'public/assets/.vite/manifest.json'))
+    expect(getManifestFile(manifest?.[ENTRY])).toBe('app-Fresh00.js')
+  })
+
+  test('should fall back to the flat manifest.json when .vite/ is absent', () => {
+    mkdirSync(join(root, 'public/assets'), { recursive: true })
+    writeFileSync(
+      join(root, 'public/assets/manifest.json'),
+      JSON.stringify({ [ENTRY]: { file: 'app-Flat00.js' } }),
+    )
+
+    const manifest = loadViteManifest(clientManifestCandidates(root), 'client', {
+      warnOnMissing: false,
+    })
+
+    expect(manifest?.__path__).toBe(join(root, 'public/assets/manifest.json'))
+    expect(getManifestFile(manifest?.[ENTRY])).toBe('app-Flat00.js')
+  })
+
+  test('should agree with the deploy-plugin lookup on which layout wins', () => {
+    writeBothLayouts()
+
+    const runtime = loadViteManifest(clientManifestCandidates(root), 'client', {
+      warnOnMissing: false,
+    })
+    const deploy = resolveClientAssetEnv(join(root, 'public'), ENTRY, 'Test build')
+
+    // The same hashed file, addressed by each side's own URL convention. A
+    // disagreement here means an app carrying both layouts serves one asset
+    // version locally and another after a serverless deploy.
+    expect(getManifestFile(runtime?.[ENTRY])).toBe('app-Fresh00.js')
+    expect(deploy.entry).toBe('/assets/app-Fresh00.js')
+  })
+})


### PR DESCRIPTION
## Summary

The two modules that locate the Vite client manifest disagreed on layout preference when both files exist:

- `packages/server/src/http/vite-manifest.ts` `clientManifestCandidates()` preferred the flat `public/assets/manifest.json` over `public/assets/.vite/manifest.json`
- `packages/core/src/internal/deploy-build.ts` `manifestPaths()` (used by `resolveClientAssetEnv` / `ssrRuntimePaths`, so all three deploy plugins) preferred `.vite/manifest.json`

With both layouts present (e.g. a stale flat manifest left over from an older Vite config), the same app resolved different asset versions locally vs. after a serverless deploy.

Vite >= 5 writes `.vite/manifest.json`, so the flat file is the one more likely to be stale. This PR settles on `.vite`-first everywhere:

- Flips `clientManifestCandidates()` to `.vite/manifest.json` before the flat file, with the rationale and the cross-package agreement documented on both sides.
- Aligns the SSR manifest candidate list in `autoConfigureInertiaAssets` the same way: within each candidate directory, `.vite/manifest.json` now outranks the flat layout (directory priority and the `ssr-manifest.json` entries are unchanged).
- Adds `packages/server/tests/http/vite-manifest.test.ts`, which pins the agreement behaviorally: one fixture root holding both layouts with different content is resolved through both the server's `loadViteManifest(clientManifestCandidates(root))` and core's `resolveClientAssetEnv()`, asserting both pick the `.vite` file. The rule cannot be shared as code (core depends on server, and deploy-build deliberately imports nothing beyond node builtins), so the test is the coupling; importing `deploy-build.ts` from a server test is safe because its own test pins that its built artifact imports node builtins only.

## Scope

server (`vite-manifest.ts`, `inertia-assets.ts`, new test), core (comment-only on `deploy-build.ts`).

## Risk Assessment

Behavior changes only for apps that have **both** manifest layouts on disk, where the flat file previously won at runtime. In that state the runtime and the deploy plugins already disagreed, so the flat file winning was the inconsistent half; apps with a single layout (the normal case) are unaffected. Same reasoning for the SSR candidate flip. No API changes.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test:bun` (5126 pass, 0 fail — includes the new test, server/core suites, and the three deploy plugins)

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.