### PR TITLE
feat(create-app): apply Guren UI design tokens to the default template

### DIFF
--- a/.changeset/guren-ui-default-template.md
+++ b/.changeset/guren-ui-default-template.md
@@ -1,0 +1,5 @@
+---
+'create-guren-app': minor
+---
+
+Restyle the default template with the Guren UI design tokens: `resources/css/guren.css` ships the guren.dev light/dark themes (white + crimson, rose-pine ground + rose accent) as CSS variables with a Tailwind `@theme inline` mapping, and the welcome page now renders in both themes following the system preference.

--- a/packages/create-app/templates/default/resources/css/app.css
+++ b/packages/create-app/templates/default/resources/css/app.css
@@ -1,1 +1,2 @@
 @import 'tailwindcss';
+@import './guren.css';

--- a/packages/create-app/templates/default/resources/css/guren.css
+++ b/packages/create-app/templates/default/resources/css/guren.css
@@ -1,0 +1,135 @@
+/* Guren UI — design tokens (https://github.com/gurenjs/guren-ui)
+   Light is the guren.dev docs light theme (white + crimson); dark is its
+   docs dark theme (rose-pine-moon ground, rose accent text). The dark block
+   follows the system preference — restructure it behind a class if the app
+   grows a theme toggle.
+
+   The red budget: --g-accent (crimson) fills one element per screen — the
+   primary action. Destructive actions are outline + explicit verb; the red
+   fill moves to them only inside a confirm step. */
+
+:root {
+  --g-font-sans: system-ui, 'Noto Sans JP', 'Hiragino Sans', sans-serif;
+  --g-font-mono: ui-monospace, 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace;
+
+  /* surfaces */
+  --g-page: #ffffff;
+  --g-panel: #ffffff;
+  --g-raised: #fffafa;
+  --g-ink: #1a1212; /* terminal surface — dark in both themes */
+  --g-line: #e5e7eb;
+  --g-line-strong: #d1d5db;
+
+  /* text */
+  --g-heading: #111827;
+  --g-text: #1f2937;
+  --g-text-2: #4b5563;
+  --g-muted: #9ca3af;
+
+  /* text printed on the ink surface */
+  --g-on-ink: #fff5f5;
+  --g-on-ink-muted: #c9a9a9;
+
+  /* the red budget */
+  --g-accent: #db1b1b; /* crimson-600 — primary fills only */
+  --g-accent-down: #b91c1c;
+  --g-accent-text: #991b1b; /* crimson-800 — links, accent text */
+  --g-accent-tint: #fff1f2;
+  --g-on-accent: #fff5f5;
+
+  /* signals — text-safe value + chip value + wash */
+  --g-ok: #286983;
+  --g-ok-chip: #56949f;
+  --g-ok-tint: rgba(86, 148, 159, 0.12);
+  --g-warn: #b45309;
+  --g-warn-chip: #ea9d34;
+  --g-warn-tint: rgba(234, 157, 52, 0.14);
+  --g-danger: #b91c1c;
+  --g-danger-chip: #f23a3a;
+  --g-danger-tint: #fff1f2;
+
+  /* the one structural device — marks the current place, once per screen */
+  --g-tick: linear-gradient(180deg, #ff3c28, #8b0000);
+
+  /* geometry */
+  --g-r-ctl: 8px;
+  --g-r-card: 12px;
+  --g-shadow-card: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
+  --g-shadow-float: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.04);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --g-page: #1a1a2e;
+    --g-panel: #1e1e34;
+    --g-raised: #232340;
+    --g-line: #2e2e4a;
+    --g-line-strong: #3d3d5c;
+
+    --g-heading: #e0def4;
+    --g-text: #e0def4;
+    --g-text-2: #908caa;
+    --g-muted: #6e6a86;
+
+    /* fills stay crimson in both themes; accent TEXT moves to rose —
+       crimson measures 4.42:1 on this ground */
+    --g-accent-text: #eb6f92;
+    --g-accent-tint: rgba(235, 111, 146, 0.12);
+
+    --g-ok: #9ccfd8;
+    --g-ok-chip: #9ccfd8;
+    --g-ok-tint: rgba(156, 207, 216, 0.1);
+    --g-warn: #f6c177;
+    --g-warn-chip: #f6c177;
+    --g-warn-tint: rgba(246, 193, 119, 0.1);
+    --g-danger: #ffa5a5;
+    --g-danger-chip: #f23a3a;
+    --g-danger-tint: rgba(242, 58, 58, 0.12);
+
+    --g-shadow-card: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
+    --g-shadow-float: 0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -2px rgba(0, 0, 0, 0.25);
+  }
+}
+
+/* Tailwind utilities over the tokens: bg-g-page, text-g-accent-text,
+   border-g-line, rounded-g-card, shadow-g-card, font-sans, font-mono … */
+@theme inline {
+  --font-sans: var(--g-font-sans);
+  --font-mono: var(--g-font-mono);
+
+  --color-g-page: var(--g-page);
+  --color-g-panel: var(--g-panel);
+  --color-g-raised: var(--g-raised);
+  --color-g-ink: var(--g-ink);
+  --color-g-line: var(--g-line);
+  --color-g-line-strong: var(--g-line-strong);
+
+  --color-g-heading: var(--g-heading);
+  --color-g-text: var(--g-text);
+  --color-g-text-2: var(--g-text-2);
+  --color-g-muted: var(--g-muted);
+
+  --color-g-on-ink: var(--g-on-ink);
+  --color-g-on-ink-muted: var(--g-on-ink-muted);
+
+  --color-g-accent: var(--g-accent);
+  --color-g-accent-down: var(--g-accent-down);
+  --color-g-accent-text: var(--g-accent-text);
+  --color-g-accent-tint: var(--g-accent-tint);
+  --color-g-on-accent: var(--g-on-accent);
+
+  --color-g-ok: var(--g-ok);
+  --color-g-ok-chip: var(--g-ok-chip);
+  --color-g-ok-tint: var(--g-ok-tint);
+  --color-g-warn: var(--g-warn);
+  --color-g-warn-chip: var(--g-warn-chip);
+  --color-g-warn-tint: var(--g-warn-tint);
+  --color-g-danger: var(--g-danger);
+  --color-g-danger-chip: var(--g-danger-chip);
+  --color-g-danger-tint: var(--g-danger-tint);
+
+  --radius-g-ctl: var(--g-r-ctl);
+  --radius-g-card: var(--g-r-card);
+  --shadow-g-card: var(--g-shadow-card);
+  --shadow-g-float: var(--g-shadow-float);
+}

--- a/packages/create-app/templates/default/resources/js/pages/Home.tsx
+++ b/packages/create-app/templates/default/resources/js/pages/Home.tsx
@@ -16,47 +16,60 @@ export default function Home({ message }: Props) {
   return (
     <>
       <Head title="__APP_TITLE__" />
-      <main className="min-h-screen bg-gradient-to-b from-gray-950 to-gray-900 text-gray-100">
+      <main className="min-h-screen bg-g-page font-sans text-g-text">
         <div className="mx-auto max-w-3xl px-6 py-20">
-          <div className="mb-4 inline-block rounded-full bg-indigo-500/10 px-3 py-1 text-sm text-indigo-400">
+          <p className="mb-5 font-mono text-xs tracking-[0.18em] uppercase text-g-text-2">
             Powered by Bun + Hono
-          </div>
-          <h1 className="mb-4 text-5xl font-bold tracking-tight">{message}</h1>
-          <p className="mb-12 text-lg text-gray-400">
+          </p>
+          <h1 className="mb-4 flex items-center gap-4 text-5xl font-bold tracking-tight text-g-heading">
+            <span aria-hidden className="h-10 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+            {message}
+          </h1>
+          <p className="mb-8 text-lg text-g-text-2">
             The Laravel of TypeScript. Edit{' '}
-            <code className="rounded bg-gray-800 px-1.5 py-0.5 text-sm text-indigo-300">
+            <code className="rounded bg-g-ink px-1.5 py-0.5 font-mono text-sm text-g-on-ink">
               resources/js/pages/Home.tsx
             </code>{' '}
             to get started.
           </p>
 
+          <div className="mb-12 flex flex-wrap gap-3">
+            <a
+              href="https://guren.dev/docs"
+              className="inline-flex items-center rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down"
+            >
+              Documentation
+            </a>
+            <a
+              href="https://github.com/gurenjs/guren"
+              className="inline-flex items-center rounded-g-ctl border border-g-line-strong bg-g-panel px-4 py-2 text-sm font-bold text-g-text transition hover:border-g-muted"
+            >
+              GitHub
+            </a>
+          </div>
+
           <div className="grid gap-4 sm:grid-cols-2">
             {features.map((f) => (
-              <div key={f.title} className="rounded-lg border border-gray-800 bg-gray-900/50 p-5">
-                <h3 className="mb-1 font-semibold text-gray-100">{f.title}</h3>
-                <p className="text-sm text-gray-400">{f.desc}</p>
+              <div
+                key={f.title}
+                className="rounded-g-card border border-g-line bg-g-panel p-5 shadow-g-card"
+              >
+                <h3 className="mb-1 font-bold text-g-heading">{f.title}</h3>
+                <p className="text-sm text-g-text-2">{f.desc}</p>
               </div>
             ))}
           </div>
 
-          <div className="mt-12 rounded-lg border border-gray-800 bg-gray-900/50 p-6">
-            <h2 className="mb-3 text-lg font-semibold">Next steps</h2>
-            <div className="space-y-2 font-mono text-sm text-gray-400">
-              <p><span className="text-gray-500">$</span> bunx guren add auth</p>
-              <p><span className="text-gray-500">$</span> bunx guren add resource posts</p>
-              <p><span className="text-gray-500">$</span> bunx guren make:model Post</p>
+          <div className="mt-12 rounded-g-card bg-g-ink p-6">
+            <h2 className="mb-3 font-mono text-xs tracking-[0.18em] uppercase text-g-on-ink-muted">
+              Next steps
+            </h2>
+            <div className="space-y-2 font-mono text-sm text-g-on-ink">
+              <p><span className="text-g-on-ink-muted">$</span> bunx guren add auth</p>
+              <p><span className="text-g-on-ink-muted">$</span> bunx guren add resource posts</p>
+              <p><span className="text-g-on-ink-muted">$</span> bunx guren make:model Post</p>
             </div>
           </div>
-
-          <p className="mt-8 text-center text-sm text-gray-600">
-            <a href="https://guren.dev/docs" className="text-indigo-400 hover:text-indigo-300">
-              Documentation
-            </a>
-            {' · '}
-            <a href="https://github.com/user/guren" className="text-indigo-400 hover:text-indigo-300">
-              GitHub
-            </a>
-          </p>
         </div>
       </main>
     </>


### PR DESCRIPTION
## Summary

First step of adopting the Guren UI design system ([gurenjs/guren-ui](https://github.com/gurenjs/guren-ui)) in scaffolded apps. The default template now ships the design tokens and renders its welcome page in the Guren look instead of the generic gray + indigo Tailwind styling.

- `resources/css/guren.css` (new): the guren.dev docs themes as CSS variables — light = white + crimson, dark = rose-pine ground with the rose accent text — plus a Tailwind v4 `@theme inline` mapping so template code styles with plain utilities (`bg-g-page`, `text-g-accent-text`, `rounded-g-card`, …).
- `Home.tsx`: rewritten in that language. Dark mode follows the system preference through the tokens alone (no `dark:` variants in markup); one crimson fill per screen (the primary action); the ember tick marks the page title; the next-steps block prints on the ink terminal surface (`#1a1212`, themeless in both modes).
- Fonts are system stacks — no webfont payload is added to scaffolded apps.

Design decisions (the red budget, accent text moving per theme, the single structural tick) follow gurenjs/guren-ui, which traces every value back to surfaces guren.dev already ships. Token values are stable; the copy is synced manually.

Follow-ups (separate PRs): the `make:auth` / `make:feature` scaffold output in `@guren/cli`, then regenerating the blog template from the restyled generators.

## Verification

- `bun run test:bun create-app` — 71 pass
- `bun run audit:starter-template`, `audit:core-first`, `audit:docs` — pass
- `bun run smoke:starter` — exit 0 (real scaffold: install, typecheck, build)
- Rendered both themes in a Vite + Tailwind v4 sandbox and verified light/dark visually (crimson fill, tick gradient, ink block, card surfaces).