### PR TITLE
feat(cli): apply Guren UI design tokens to make:auth and make:feature output

### DIFF
--- a/.changeset/guren-ui-scaffolds.md
+++ b/.changeset/guren-ui-scaffolds.md
@@ -1,0 +1,6 @@
+---
+'@guren/cli': minor
+'create-guren-app': patch
+---
+
+Restyle the `make:auth` and `make:feature` scaffold output with the Guren UI design tokens: pages render in the guren.dev light/dark themes via `bg-g-*` / `text-g-*` utilities, flash and error messages become diagnostic rows, and the destructive delete action is an outline + confirm instead of red text. Both commands now ensure the app carries `resources/css/guren.css` and its `app.css` import (idempotent — apps scaffolded by create-guren-app ship them already). The blog blueprint's dashboard page moves in lockstep.

--- a/packages/cli/src/guren-css.ts
+++ b/packages/cli/src/guren-css.ts
@@ -1,0 +1,62 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { consola } from 'consola'
+import { loadScaffoldTemplate } from './scaffold-templates'
+
+const TOKENS_PATH = 'resources/css/guren.css'
+const APP_CSS_PATH = 'resources/css/app.css'
+const IMPORT_LINE = "@import './guren.css';"
+
+/**
+ * Make sure the app carries the Guren UI design tokens the scaffolded pages
+ * style with (`bg-g-page`, `text-g-accent-text`, …): write
+ * `resources/css/guren.css` when the app has none, and add its `@import` to
+ * `resources/css/app.css` when that is missing. Both halves are idempotent.
+ * An existing guren.css is never overwritten — it may carry the user's own
+ * edited tokens, and create-guren-app ships the same file already.
+ */
+export async function ensureGurenUiTokens(cwd: string = process.cwd()): Promise<void> {
+  const tokensPath = resolve(cwd, TOKENS_PATH)
+  await mkdir(dirname(tokensPath), { recursive: true })
+  try {
+    // `wx` makes the exists-check and the write one atomic operation, the
+    // same reasoning as writeFileSafe — but here an existing file is the
+    // fine-and-expected case, not an error.
+    await writeFile(tokensPath, loadScaffoldTemplate('guren-ui/resources/css/guren.css'), {
+      encoding: 'utf8',
+      flag: 'wx',
+    })
+    consola.success(`Created ${TOKENS_PATH}`)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
+  }
+
+  const appCssPath = resolve(cwd, APP_CSS_PATH)
+  let appCss: string
+  try {
+    appCss = await readFile(appCssPath, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    consola.warn(
+      `${APP_CSS_PATH} not found — add ${IMPORT_LINE} to your CSS entry so the Guren UI tokens load.`,
+    )
+    return
+  }
+  if (appCss.includes('./guren.css')) return
+
+  // CSS requires @import to precede other rules, and Tailwind's @theme
+  // mapping inside guren.css has to land after the tailwindcss import — so
+  // slot it right after the last @import when there is one.
+  const lines = appCss.split('\n')
+  let lastImport = -1
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]!.trimStart().startsWith('@import')) lastImport = i
+  }
+  if (lastImport >= 0) {
+    lines.splice(lastImport + 1, 0, IMPORT_LINE)
+  } else {
+    lines.unshift(IMPORT_LINE)
+  }
+  await writeFile(appCssPath, lines.join('\n'), 'utf8')
+  consola.success(`Added ${IMPORT_LINE} to ${APP_CSS_PATH}`)
+}

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -18,6 +18,7 @@ import { readIfExists } from './discovery'
 import { APP_ENTRY_CANDIDATES, resolveAppEntry, wireAppProvider, wireProvider } from './provider-registrar'
 import { wireRouteRegistrar } from './route-registrar'
 import { makeMigration } from './make-migration'
+import { ensureGurenUiTokens } from './guren-css'
 import { loadScaffoldTemplate } from './scaffold-templates'
 
 /** `path` is both the template path under `templates/scaffold/auth/` and the written app path. */
@@ -523,7 +524,7 @@ function buildOAuthButtonLinks(providers: string[]): string {
     .map(
       (provider) => `          <a
             href="/auth/${provider}"
-            className="flex w-full items-center justify-center rounded border border-slate-700 bg-slate-950 px-4 py-2 text-sm font-medium text-slate-100 transition hover:border-emerald-400 hover:text-emerald-200"
+            className="flex w-full items-center justify-center rounded-g-ctl border border-g-line-strong bg-g-panel px-4 py-2 text-sm font-bold text-g-text transition hover:border-g-muted"
           >
             Continue with ${OAUTH_PROVIDER_LABELS[provider]}
           </a>`,
@@ -543,10 +544,10 @@ function buildOAuthButtonsTemplate(providers: string[], { divider = true } = {})
 
   const dividerBlock = divider
     ? `
-          <div className="flex items-center gap-3 text-xs uppercase tracking-wide text-slate-500">
-            <span className="h-px flex-1 bg-slate-800" />
+          <div className="flex items-center gap-3 text-xs uppercase tracking-wide text-g-muted">
+            <span className="h-px flex-1 bg-g-line" />
             Or continue with
-            <span className="h-px flex-1 bg-slate-800" />
+            <span className="h-px flex-1 bg-g-line" />
           </div>`
     : ''
 
@@ -577,15 +578,19 @@ export default function Login({ errors = {} }: Props) {
   return (
     <Layout>
       <Head title="Sign in" />
-      <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-8 shadow-xl shadow-emerald-500/5">
-        <h1 className="text-2xl font-semibold text-emerald-300">Sign in</h1>
-        <p className="mt-2 text-sm text-slate-400">
+      <section className="rounded-g-card border border-g-line bg-g-panel p-8 shadow-g-card">
+        <h1 className="flex items-center gap-3 text-2xl font-bold text-g-heading">
+          <span aria-hidden className="h-6 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+          Sign in
+        </h1>
+        <p className="mt-2 text-sm text-g-text-2">
           Choose a provider to continue.
         </p>
 
         {errors.message && (
-          <p className="mt-4 rounded border border-rose-500/60 bg-rose-500/10 px-4 py-2 text-sm text-rose-200">
-            {errors.message}
+          <p className="mt-4 flex gap-3 border-y border-g-line py-2.5 text-sm">
+            <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 text-g-danger">error</span>
+            <span className="text-g-text">{errors.message}</span>
           </p>
         )}
 ${buildOAuthButtonsTemplate(providers, { divider: false })}
@@ -599,9 +604,9 @@ ${buildOAuthButtonsTemplate(providers, { divider: false })}
 function buildLoginViewTemplate(includeRegister: boolean, includeReset: boolean, oauthProviders: string[] = []): string {
   const signUpLink = includeRegister
     ? `
-        <p className="mt-2 text-center text-sm text-slate-400">
+        <p className="mt-2 text-center text-sm text-g-text-2">
           Don&apos;t have an account?{' '}
-          <Link href="/register" className="text-emerald-300 transition hover:text-emerald-200">
+          <Link href="/register" className="text-g-accent-text transition hover:underline">
             Sign up
           </Link>
         </p>`
@@ -609,13 +614,13 @@ function buildLoginViewTemplate(includeRegister: boolean, includeReset: boolean,
 
   const forgotPasswordText = includeReset
     ? `
-        <p className="mt-6 text-center text-sm text-slate-400">
-          <Link href="/forgot-password" className="text-emerald-300 transition hover:text-emerald-200">
+        <p className="mt-6 text-center text-sm text-g-text-2">
+          <Link href="/forgot-password" className="text-g-accent-text transition hover:underline">
             Forgot your password?
           </Link>
         </p>`
     : `
-        <p className="mt-6 text-center text-sm text-slate-400">
+        <p className="mt-6 text-center text-sm text-g-text-2">
           Forgot your password? Contact your administrator.
         </p>`
 
@@ -648,15 +653,19 @@ export default function Login({ email = '', errors = {} }: Props) {
   return (
     <Layout>
       <Head title="Sign in" />
-      <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-8 shadow-xl shadow-emerald-500/5">
-        <h1 className="text-2xl font-semibold text-emerald-300">Sign in</h1>
-        <p className="mt-2 text-sm text-slate-400">
+      <section className="rounded-g-card border border-g-line bg-g-panel p-8 shadow-g-card">
+        <h1 className="flex items-center gap-3 text-2xl font-bold text-g-heading">
+          <span aria-hidden className="h-6 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+          Sign in
+        </h1>
+        <p className="mt-2 text-sm text-g-text-2">
           Use your account credentials to continue.
         </p>
 
         {errors.message && (
-          <p className="mt-4 rounded border border-rose-500/60 bg-rose-500/10 px-4 py-2 text-sm text-rose-200">
-            {errors.message}
+          <p className="mt-4 flex gap-3 border-y border-g-line py-2.5 text-sm">
+            <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 text-g-danger">error</span>
+            <span className="text-g-text">{errors.message}</span>
           </p>
         )}
 
@@ -668,7 +677,7 @@ export default function Login({ email = '', errors = {} }: Props) {
           }}
         >
           <div>
-            <label htmlFor={emailId} className="block text-sm font-medium text-slate-200">
+            <label htmlFor={emailId} className="block text-sm font-bold text-g-heading">
               Email
             </label>
             <input
@@ -677,13 +686,13 @@ export default function Login({ email = '', errors = {} }: Props) {
               value={form.data.email}
               onChange={(event) => form.setData('email', event.target.value)}
               required
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {errors.email && <p className="mt-1 text-sm text-rose-300">{errors.email}</p>}
+            {errors.email && <p className="mt-1 text-sm text-g-danger">{errors.email}</p>}
           </div>
 
           <div>
-            <label htmlFor={passwordId} className="block text-sm font-medium text-slate-200">
+            <label htmlFor={passwordId} className="block text-sm font-bold text-g-heading">
               Password
             </label>
             <input
@@ -692,17 +701,17 @@ export default function Login({ email = '', errors = {} }: Props) {
               value={form.data.password}
               onChange={(event) => form.setData('password', event.target.value)}
               required
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {errors.password && <p className="mt-1 text-sm text-rose-300">{errors.password}</p>}
+            {errors.password && <p className="mt-1 text-sm text-g-danger">{errors.password}</p>}
           </div>
 
-          <label className="flex items-center gap-2 text-sm text-slate-300">
+          <label className="flex items-center gap-2 text-sm text-g-text">
             <input
               type="checkbox"
               checked={form.data.remember}
               onChange={(event) => form.setData('remember', event.target.checked)}
-              className="h-4 w-4 rounded border-slate-700 bg-slate-950 text-emerald-400 focus:ring-emerald-400"
+              className="h-4 w-4 rounded accent-g-accent"
             />
             Remember me
           </label>
@@ -710,7 +719,7 @@ export default function Login({ email = '', errors = {} }: Props) {
             <button
               type="submit"
               disabled={form.processing}
-              className="w-full rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400"
+              className="w-full rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down disabled:cursor-not-allowed disabled:opacity-45"
             >
               Sign in
           </button>
@@ -757,15 +766,19 @@ export default function Register({ errors = {} }: Props) {
   return (
     <Layout>
       <Head title="Sign up" />
-      <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-8 shadow-xl shadow-emerald-500/5">
-        <h1 className="text-2xl font-semibold text-emerald-300">Create an account</h1>
-        <p className="mt-2 text-sm text-slate-400">
+      <section className="rounded-g-card border border-g-line bg-g-panel p-8 shadow-g-card">
+        <h1 className="flex items-center gap-3 text-2xl font-bold text-g-heading">
+          <span aria-hidden className="h-6 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+          Create an account
+        </h1>
+        <p className="mt-2 text-sm text-g-text-2">
           Sign up to get started.
         </p>
 
         {errors.message && (
-          <p className="mt-4 rounded border border-rose-500/60 bg-rose-500/10 px-4 py-2 text-sm text-rose-200">
-            {errors.message}
+          <p className="mt-4 flex gap-3 border-y border-g-line py-2.5 text-sm">
+            <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 text-g-danger">error</span>
+            <span className="text-g-text">{errors.message}</span>
           </p>
         )}
 
@@ -777,7 +790,7 @@ export default function Register({ errors = {} }: Props) {
           }}
         >
           <div>
-            <label htmlFor={nameId} className="block text-sm font-medium text-slate-200">
+            <label htmlFor={nameId} className="block text-sm font-bold text-g-heading">
               Name
             </label>
             <input
@@ -786,13 +799,13 @@ export default function Register({ errors = {} }: Props) {
               value={form.data.name}
               onChange={(event) => form.setData('name', event.target.value)}
               required
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {errors.name && <p className="mt-1 text-sm text-rose-300">{errors.name}</p>}
+            {errors.name && <p className="mt-1 text-sm text-g-danger">{errors.name}</p>}
           </div>
 
           <div>
-            <label htmlFor={emailId} className="block text-sm font-medium text-slate-200">
+            <label htmlFor={emailId} className="block text-sm font-bold text-g-heading">
               Email
             </label>
             <input
@@ -801,13 +814,13 @@ export default function Register({ errors = {} }: Props) {
               value={form.data.email}
               onChange={(event) => form.setData('email', event.target.value)}
               required
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {errors.email && <p className="mt-1 text-sm text-rose-300">{errors.email}</p>}
+            {errors.email && <p className="mt-1 text-sm text-g-danger">{errors.email}</p>}
           </div>
 
           <div>
-            <label htmlFor={passwordId} className="block text-sm font-medium text-slate-200">
+            <label htmlFor={passwordId} className="block text-sm font-bold text-g-heading">
               Password
             </label>
             <input
@@ -816,13 +829,13 @@ export default function Register({ errors = {} }: Props) {
               value={form.data.password}
               onChange={(event) => form.setData('password', event.target.value)}
               required
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {errors.password && <p className="mt-1 text-sm text-rose-300">{errors.password}</p>}
+            {errors.password && <p className="mt-1 text-sm text-g-danger">{errors.password}</p>}
           </div>
 
           <div>
-            <label htmlFor={passwordConfirmationId} className="block text-sm font-medium text-slate-200">
+            <label htmlFor={passwordConfirmationId} className="block text-sm font-bold text-g-heading">
               Confirm password
             </label>
             <input
@@ -831,25 +844,25 @@ export default function Register({ errors = {} }: Props) {
               value={form.data.passwordConfirmation}
               onChange={(event) => form.setData('passwordConfirmation', event.target.value)}
               required
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
             {errors.passwordConfirmation && (
-              <p className="mt-1 text-sm text-rose-300">{errors.passwordConfirmation}</p>
+              <p className="mt-1 text-sm text-g-danger">{errors.passwordConfirmation}</p>
             )}
           </div>
 
           <button
             type="submit"
             disabled={form.processing}
-            className="w-full rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+            className="w-full rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down disabled:cursor-not-allowed disabled:opacity-45"
           >
             Create account
           </button>
         </form>
 ${buildOAuthButtonsTemplate(oauthProviders)}
-        <p className="mt-6 text-center text-sm text-slate-400">
+        <p className="mt-6 text-center text-sm text-g-text-2">
           Already have an account?{' '}
-          <Link href="/login" className="text-emerald-300 transition hover:text-emerald-200">
+          <Link href="/login" className="text-g-accent-text transition hover:underline">
             Sign in
           </Link>
         </p>
@@ -879,22 +892,22 @@ function buildProfileViewTemplate({ includePassword, providerOwnedEmail }: AuthF
   const emailInput = providerOwnedEmail
     ? `
           <div>
-            <label className="block text-sm font-medium text-slate-200">Email</label>
-            <p className="mt-1 w-full rounded border border-slate-800 bg-slate-900 px-3 py-2 text-slate-400">
+            <label className="block text-sm font-bold text-g-heading">Email</label>
+            <p className="mt-1 w-full rounded-g-ctl border border-g-line bg-g-raised px-3 py-2 text-g-muted">
               {profile.email}
             </p>
-            <p className="mt-1 text-xs text-slate-500">Managed by your sign-in provider.</p>
+            <p className="mt-1 text-xs text-g-muted">Managed by your sign-in provider.</p>
           </div>`
     : `
           <div>
-            <label className="block text-sm font-medium text-slate-200">Email</label>
+            <label className="block text-sm font-bold text-g-heading">Email</label>
             <input
               type="email"
               value={form.data.email}
               onChange={(event) => form.setData('email', event.target.value)}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {form.errors.email ? <p className="mt-1 text-sm text-rose-300">{form.errors.email}</p> : null}
+            {form.errors.email ? <p className="mt-1 text-sm text-g-danger">{form.errors.email}</p> : null}
           </div>`
   const passwordFormField = includePassword
     ? `
@@ -907,14 +920,14 @@ function buildProfileViewTemplate({ includePassword, providerOwnedEmail }: AuthF
   const passwordInput = includePassword
     ? `
           <div>
-            <label className="block text-sm font-medium text-slate-200">New password</label>
+            <label className="block text-sm font-bold text-g-heading">New password</label>
             <input
               type="password"
               value={form.data.password}
               onChange={(event) => form.setData('password', event.target.value)}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {form.errors.password ? <p className="mt-1 text-sm text-rose-300">{form.errors.password}</p> : null}
+            {form.errors.password ? <p className="mt-1 text-sm text-g-danger">{form.errors.password}</p> : null}
           </div>
 `
     : ''
@@ -950,35 +963,39 @@ export default function ProfileEdit({ profile, status }: Props) {
   return (
     <Layout>
       <Head title="Profile" />
-      <section className="space-y-6 rounded-lg border border-slate-800 bg-slate-900/40 p-8 shadow-xl shadow-emerald-500/5">
+      <section className="space-y-6 rounded-g-card border border-g-line bg-g-panel p-8 shadow-g-card">
         <header>
-          <h1 className="text-2xl font-semibold text-emerald-300">Profile</h1>
-          <p className="mt-2 text-sm text-slate-400">${description}</p>
+          <h1 className="flex items-center gap-3 text-2xl font-bold text-g-heading">
+            <span aria-hidden className="h-6 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+            Profile
+          </h1>
+          <p className="mt-2 text-sm text-g-text-2">${description}</p>
         </header>
 
         {status ? (
-          <p className="rounded border border-emerald-500/40 bg-emerald-500/10 px-4 py-2 text-sm text-emerald-200">
-            {status}
+          <p className="flex gap-3 border-y border-g-line py-2.5 text-sm">
+            <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 text-g-ok">ok</span>
+            <span className="text-g-text">{status}</span>
           </p>
         ) : null}
 
         <form className="space-y-4" onSubmit={handleSubmit}>
           <div>
-            <label className="block text-sm font-medium text-slate-200">Name</label>
+            <label className="block text-sm font-bold text-g-heading">Name</label>
             <input
               type="text"
               value={form.data.name}
               onChange={(event) => form.setData('name', event.target.value)}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {form.errors.name ? <p className="mt-1 text-sm text-rose-300">{form.errors.name}</p> : null}
+            {form.errors.name ? <p className="mt-1 text-sm text-g-danger">{form.errors.name}</p> : null}
           </div>
 ${emailInput}
 ${passwordInput}
           <button
             type="submit"
             disabled={form.processing}
-            className="w-full rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+            className="w-full rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down disabled:cursor-not-allowed disabled:opacity-45"
           >
             Save changes
           </button>
@@ -1584,6 +1601,10 @@ export async function makeAuth(options: MakeAuthOptions = {}): Promise<string[]>
   }
 
   const created = await writeScaffoldFiles(files, options)
+
+  // The pages above style with the Guren UI tokens (bg-g-page, …) — make
+  // sure the app actually loads them.
+  await ensureGurenUiTokens()
 
   await updateSchema(features)
   await updatePageContracts()

--- a/packages/cli/src/make-feature.ts
+++ b/packages/cli/src/make-feature.ts
@@ -7,6 +7,7 @@ import { makePolicy } from './make-policy'
 import { makeTest } from './make-test'
 import { makeValidator } from './make-validator'
 import { parseFieldsString, type FieldDefinition, type FieldType } from './fields'
+import { ensureGurenUiTokens } from './guren-css'
 import { schemaPathFor } from './schema-parser'
 
 /**
@@ -94,6 +95,10 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
       contents: generateEditPage(singular, routeName, variableName, fields),
     },
   ], writerOptions)
+
+  // The pages above style with the Guren UI tokens (bg-g-page, …) — make
+  // sure the app actually loads them.
+  await ensureGurenUiTokens(writeRoot(writerOptions))
 
   created.unshift(validatorPath)
 
@@ -436,28 +441,33 @@ interface Props extends PaginatedPageProps<${singular}ResourceData> {}
 
 export default function ${collection}Index({ data, pagination }: Props) {
   return (
-    <main className="mx-auto max-w-3xl space-y-6 px-6 py-12">
-      <div className="flex items-center justify-between">
-        <h1 className="text-3xl font-semibold">${collection}</h1>
-        <Link href={route('${routeName}.create')} className="rounded bg-black px-4 py-2 text-white">New ${singular}</Link>
-      </div>
-      <div className="space-y-4">
-        {data.map((${variableName}) => (
-          <article key={${variableName}.id} className="rounded border p-4">
-            <Link href={route('${routeName}.show', { id: ${variableName}.id })} className="text-xl font-medium">{${variableName}.${titleField}}</Link>
-${summaryField ? `            <p className="mt-2 text-sm text-zinc-600">{${variableName}.${summaryField} ?? ''}</p>` : ''}
-          </article>
-        ))}
-      </div>
-      {pagination?.links?.pages && (
-        <nav className="flex gap-2">
-          {pagination.links.pages.map((page) => (
-            <Link key={page.page} href={page.url ?? '#'} className="rounded border px-3 py-1">
-              {page.page}
-            </Link>
+    <main className="min-h-screen bg-g-page font-sans text-g-text">
+      <div className="mx-auto max-w-3xl space-y-6 px-6 py-12">
+        <div className="flex items-center justify-between">
+          <h1 className="flex items-center gap-3 text-3xl font-bold text-g-heading">
+            <span aria-hidden className="h-7 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+            ${collection}
+          </h1>
+          <Link href={route('${routeName}.create')} className="rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down">New ${singular}</Link>
+        </div>
+        <div className="space-y-4">
+          {data.map((${variableName}) => (
+            <article key={${variableName}.id} className="rounded-g-card border border-g-line bg-g-panel p-4 shadow-g-card">
+              <Link href={route('${routeName}.show', { id: ${variableName}.id })} className="text-xl font-bold text-g-heading transition hover:text-g-accent-text">{${variableName}.${titleField}}</Link>
+${summaryField ? `              <p className="mt-2 text-sm text-g-text-2">{${variableName}.${summaryField} ?? ''}</p>` : ''}
+            </article>
           ))}
-        </nav>
-      )}
+        </div>
+        {pagination?.links?.pages && (
+          <nav className="flex gap-2 font-mono text-sm">
+            {pagination.links.pages.map((page) => (
+              <Link key={page.page} href={page.url ?? '#'} className="rounded-g-ctl border border-g-line px-3 py-1 text-g-text-2 transition hover:border-g-line-strong hover:text-g-heading">
+                {page.page}
+              </Link>
+            ))}
+          </nav>
+        )}
+      </div>
     </main>
   )
 }
@@ -473,13 +483,13 @@ function generateShowPage(
 ): string {
   const fieldRenders = fields.map((f) => {
     if (f.type === 'boolean') {
-      return `      <p><strong>${f.name}:</strong> {${variableName}.${f.name} ? 'Yes' : 'No'}</p>`
+      return `        <p><strong>${f.name}:</strong> {${variableName}.${f.name} ? 'Yes' : 'No'}</p>`
     }
     if (f.type === 'json') {
       // An object is not renderable as a React child.
-      return `      <p><strong>${f.name}:</strong> {JSON.stringify(${variableName}.${f.name})}</p>`
+      return `        <p><strong>${f.name}:</strong> {JSON.stringify(${variableName}.${f.name})}</p>`
     }
-    return `      <p><strong>${f.name}:</strong> {${variableName}.${f.name}${f.nullable ? " ?? ''" : ''}}</p>`
+    return `        <p><strong>${f.name}:</strong> {${variableName}.${f.name}${f.nullable ? " ?? ''" : ''}}</p>`
   }).join('\n')
 
   return `import { Link } from '@inertiajs/react'
@@ -492,20 +502,22 @@ interface Props {
 
 export default function ${singular}Show({ ${variableName} }: Props) {
   return (
-    <main className="mx-auto max-w-3xl space-y-6 px-6 py-12">
-      <Link href={route('${routeName}.index')}>Back</Link>
+    <main className="min-h-screen bg-g-page font-sans text-g-text">
+      <div className="mx-auto max-w-3xl space-y-6 px-6 py-12">
+        <Link href={route('${routeName}.index')} className="text-sm text-g-accent-text transition hover:underline">Back</Link>
 ${fieldRenders}
-      <div className="flex gap-4">
-        <Link href={route('${routeName}.edit', { id: ${variableName}.id })}>Edit</Link>
-        <Link
-          href={route('${routeName}.destroy', { id: ${variableName}.id })}
-          method="delete"
-          as="button"
-          onBefore={() => window.confirm('Delete this ${variableName}?')}
-          className="text-red-600"
-        >
-          Delete
-        </Link>
+        <div className="flex items-center gap-4">
+          <Link href={route('${routeName}.edit', { id: ${variableName}.id })} className="text-g-accent-text transition hover:underline">Edit</Link>
+          <Link
+            href={route('${routeName}.destroy', { id: ${variableName}.id })}
+            method="delete"
+            as="button"
+            onBefore={() => window.confirm('Delete this ${variableName}?')}
+            className="rounded-g-ctl border border-g-danger-chip px-3 py-1 text-sm font-bold text-g-danger transition hover:bg-g-danger-tint"
+          >
+            Delete
+          </Link>
+        </div>
       </div>
     </main>
   )
@@ -533,11 +545,13 @@ type ${singular}FormData = RouteBody<ApiRoutes, '${routeName}.store'>
 export default function New${singular}() {
   const form = useForm<${singular}FormData>({ ${defaults} })
 ${state.hooks}  return (
-    <main className="mx-auto max-w-3xl px-6 py-12">
-      <form className="space-y-4" onSubmit={(submitEvent) => { submitEvent.preventDefault(); form.post(route('${routeName}.store')) }}>
+    <main className="min-h-screen bg-g-page font-sans text-g-text">
+      <div className="mx-auto max-w-3xl px-6 py-12">
+        <form className="space-y-4" onSubmit={(submitEvent) => { submitEvent.preventDefault(); form.post(route('${routeName}.store')) }}>
 ${formFields}
-        <button type="submit" className="rounded bg-black px-4 py-2 text-white">Create</button>
-      </form>
+          <button type="submit" className="rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down">Create</button>
+        </form>
+      </div>
     </main>
   )
 }
@@ -572,59 +586,64 @@ interface Props {
 export default function Edit${singular}({ ${variableName} }: Props) {
   const form = useForm<${singular}FormData>({ ${defaults} })
 ${state.hooks}  return (
-    <main className="mx-auto max-w-3xl px-6 py-12">
-      <form className="space-y-4" onSubmit={(submitEvent) => { submitEvent.preventDefault(); form.put(route('${routeName}.update', { id: ${variableName}.id })) }}>
+    <main className="min-h-screen bg-g-page font-sans text-g-text">
+      <div className="mx-auto max-w-3xl px-6 py-12">
+        <form className="space-y-4" onSubmit={(submitEvent) => { submitEvent.preventDefault(); form.put(route('${routeName}.update', { id: ${variableName}.id })) }}>
 ${formFields}
-        <button type="submit" className="rounded bg-black px-4 py-2 text-white">Save</button>
-      </form>
+          <button type="submit" className="rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down">Save</button>
+        </form>
+      </div>
     </main>
   )
 }
 `
 }
 
+const FORM_INPUT_CLASS =
+  'w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent'
+
 function generateFormField(field: FieldDefinition, formVar: string): string {
   const value = formValue(field, formVar)
   if (field.type === 'boolean') {
-    return `        <label className="flex items-center gap-2">
-          <input type="checkbox" checked={${value}} onChange={(event) => ${formVar}.setData('${field.name}', event.target.checked)} />
-          ${field.name}
-        </label>`
+    return `          <label className="flex items-center gap-2">
+            <input type="checkbox" checked={${value}} onChange={(event) => ${formVar}.setData('${field.name}', event.target.checked)} className="h-4 w-4 rounded accent-g-accent" />
+            ${field.name}
+          </label>`
   }
   if (field.type === 'text') {
-    return `        <textarea value={${value}} onChange={(event) => ${formVar}.setData('${field.name}', event.target.value)} placeholder="${field.name}" className="w-full rounded border px-3 py-2" />`
+    return `          <textarea value={${value}} onChange={(event) => ${formVar}.setData('${field.name}', event.target.value)} placeholder="${field.name}" className="${FORM_INPUT_CLASS}" />`
   }
   if (field.type === 'number') {
-    return `        <input type="number" value={${value}} onChange={(event) => ${formVar}.setData('${field.name}', Number(event.target.value))} placeholder="${field.name}" className="w-full rounded border px-3 py-2" />`
+    return `          <input type="number" value={${value}} onChange={(event) => ${formVar}.setData('${field.name}', Number(event.target.value))} placeholder="${field.name}" className="${FORM_INPUT_CLASS}" />`
   }
   if (field.type === 'date') {
     // The value arrives as an ISO timestamp but `type="date"` only renders a
     // bare `YYYY-MM-DD`, and shows nothing at all for anything longer.
-    return `        <input type="date" value={${value}.slice(0, 10)} onChange={(event) => ${formVar}.setData('${field.name}', event.target.value)} className="w-full rounded border px-3 py-2" />`
+    return `          <input type="date" value={${value}.slice(0, 10)} onChange={(event) => ${formVar}.setData('${field.name}', event.target.value)} className="${FORM_INPUT_CLASS}" />`
   }
   if (field.type === 'json') {
     // Uncontrolled: a controlled textarea driven by the parsed object would
     // reject every keystroke that leaves the JSON temporarily invalid. The
     // flag is what keeps that from being silent — without it, submitting
     // half-typed JSON would quietly send the last value that parsed.
-    return `        <textarea
-          defaultValue={jsonText.${field.name}}
-          onChange={(event) => {
-            try {
-              ${formVar}.setData('${field.name}', JSON.parse(event.target.value))
-              setJsonErrors((prev) => ({ ...prev, ${field.name}: false }))
-            } catch {
-              setJsonErrors((prev) => ({ ...prev, ${field.name}: true }))
-            }
-          }}
-          placeholder="${field.name}"
-          className="w-full rounded border px-3 py-2 font-mono text-sm"
-        />
-        {jsonErrors.${field.name} && (
-          <p className="text-sm text-red-600">${field.name} is not valid JSON — fix it or the last valid value is submitted.</p>
-        )}`
+    return `          <textarea
+            defaultValue={jsonText.${field.name}}
+            onChange={(event) => {
+              try {
+                ${formVar}.setData('${field.name}', JSON.parse(event.target.value))
+                setJsonErrors((prev) => ({ ...prev, ${field.name}: false }))
+              } catch {
+                setJsonErrors((prev) => ({ ...prev, ${field.name}: true }))
+              }
+            }}
+            placeholder="${field.name}"
+            className="${FORM_INPUT_CLASS} font-mono text-sm"
+          />
+          {jsonErrors.${field.name} && (
+            <p className="text-sm text-g-danger">${field.name} is not valid JSON — fix it or the last valid value is submitted.</p>
+          )}`
   }
-  return `        <input value={${value}} onChange={(event) => ${formVar}.setData('${field.name}', event.target.value)} placeholder="${field.name}" className="w-full rounded border px-3 py-2" />`
+  return `          <input value={${value}} onChange={(event) => ${formVar}.setData('${field.name}', event.target.value)} placeholder="${field.name}" className="${FORM_INPUT_CLASS}" />`
 }
 
 /**

--- a/packages/cli/templates/scaffold/auth/resources/js/components/Layout.tsx
+++ b/packages/cli/templates/scaffold/auth/resources/js/components/Layout.tsx
@@ -5,20 +5,20 @@ export default function Layout({ children }: PropsWithChildren) {
   const { props } = usePage<{ auth?: { user?: { name?: string } } }>()
   const user = props.auth?.user
   const navButtonClass =
-    'rounded border border-emerald-500 px-3 py-1 text-emerald-200 transition hover:bg-emerald-500 hover:text-slate-950'
+    'rounded-g-ctl border border-g-line-strong px-3 py-1 text-g-text transition hover:border-g-muted'
 
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100">
-      <header className="border-b border-slate-800 bg-slate-900/60 backdrop-blur">
+    <div className="min-h-screen bg-g-page font-sans text-g-text">
+      <header className="border-b border-g-line bg-g-panel">
         <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
-          <Link href="/" className="text-lg font-semibold text-emerald-300">
+          <Link href="/" className="text-lg font-bold text-g-heading">
             Guren
           </Link>
-          <nav className="flex items-center gap-4 text-sm text-slate-300">
-            <Link href="/" className="transition hover:text-emerald-200">
+          <nav className="flex items-center gap-4 text-sm text-g-text-2">
+            <Link href="/" className="transition hover:text-g-heading">
               Home
             </Link>
-            <Link href="/dashboard" className="transition hover:text-emerald-200">
+            <Link href="/dashboard" className="transition hover:text-g-heading">
               Dashboard
             </Link>
             {user ? (

--- a/packages/cli/templates/scaffold/auth/resources/js/pages/auth/ForgotPassword.tsx
+++ b/packages/cli/templates/scaffold/auth/resources/js/pages/auth/ForgotPassword.tsx
@@ -20,21 +20,26 @@ export default function ForgotPassword({ errors = {}, status }: Props) {
   return (
     <Layout>
       <Head title="Forgot password" />
-      <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-8 shadow-xl shadow-emerald-500/5">
-        <h1 className="text-2xl font-semibold text-emerald-300">Forgot your password?</h1>
-        <p className="mt-2 text-sm text-slate-400">
+      <section className="rounded-g-card border border-g-line bg-g-panel p-8 shadow-g-card">
+        <h1 className="flex items-center gap-3 text-2xl font-bold text-g-heading">
+          <span aria-hidden className="h-6 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+          Forgot your password?
+        </h1>
+        <p className="mt-2 text-sm text-g-text-2">
           Enter your email and we&apos;ll send you a link to reset your password.
         </p>
 
         {status ? (
-          <p className="mt-4 rounded border border-emerald-500/40 bg-emerald-500/10 px-4 py-2 text-sm text-emerald-200">
-            {status}
+          <p className="mt-4 flex gap-3 border-y border-g-line py-2.5 text-sm">
+            <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 text-g-ok">ok</span>
+            <span className="text-g-text">{status}</span>
           </p>
         ) : null}
 
         {errors.message && (
-          <p className="mt-4 rounded border border-rose-500/60 bg-rose-500/10 px-4 py-2 text-sm text-rose-200">
-            {errors.message}
+          <p className="mt-4 flex gap-3 border-y border-g-line py-2.5 text-sm">
+            <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 text-g-danger">error</span>
+            <span className="text-g-text">{errors.message}</span>
           </p>
         )}
 
@@ -46,7 +51,7 @@ export default function ForgotPassword({ errors = {}, status }: Props) {
           }}
         >
           <div>
-            <label htmlFor={emailId} className="block text-sm font-medium text-slate-200">
+            <label htmlFor={emailId} className="block text-sm font-bold text-g-heading">
               Email
             </label>
             <input
@@ -55,15 +60,15 @@ export default function ForgotPassword({ errors = {}, status }: Props) {
               value={form.data.email}
               onChange={(event) => form.setData('email', event.target.value)}
               required
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {errors.email && <p className="mt-1 text-sm text-rose-300">{errors.email}</p>}
+            {errors.email && <p className="mt-1 text-sm text-g-danger">{errors.email}</p>}
           </div>
 
           <button
             type="submit"
             disabled={form.processing}
-            className="w-full rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+            className="w-full rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down disabled:cursor-not-allowed disabled:opacity-45"
           >
             Send reset link
           </button>

--- a/packages/cli/templates/scaffold/auth/resources/js/pages/auth/ResetPassword.tsx
+++ b/packages/cli/templates/scaffold/auth/resources/js/pages/auth/ResetPassword.tsx
@@ -28,17 +28,21 @@ export default function ResetPassword({ token, email, errors = {} }: Props) {
   return (
     <Layout>
       <Head title="Reset password" />
-      <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-8 shadow-xl shadow-emerald-500/5">
-        <h1 className="text-2xl font-semibold text-emerald-300">Reset your password</h1>
+      <section className="rounded-g-card border border-g-line bg-g-panel p-8 shadow-g-card">
+        <h1 className="flex items-center gap-3 text-2xl font-bold text-g-heading">
+          <span aria-hidden className="h-6 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+          Reset your password
+        </h1>
         {email ? (
-          <p className="mt-2 text-sm text-slate-400">
+          <p className="mt-2 text-sm text-g-text-2">
             Choose a new password for {email}.
           </p>
         ) : null}
 
         {errors.token && (
-          <p className="mt-4 rounded border border-rose-500/60 bg-rose-500/10 px-4 py-2 text-sm text-rose-200">
-            {errors.token}
+          <p className="mt-4 flex gap-3 border-y border-g-line py-2.5 text-sm">
+            <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 text-g-danger">error</span>
+            <span className="text-g-text">{errors.token}</span>
           </p>
         )}
 
@@ -50,7 +54,7 @@ export default function ResetPassword({ token, email, errors = {} }: Props) {
           }}
         >
           <div>
-            <label htmlFor={passwordId} className="block text-sm font-medium text-slate-200">
+            <label htmlFor={passwordId} className="block text-sm font-bold text-g-heading">
               New password
             </label>
             <input
@@ -59,13 +63,13 @@ export default function ResetPassword({ token, email, errors = {} }: Props) {
               value={form.data.password}
               onChange={(event) => form.setData('password', event.target.value)}
               required
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {errors.password && <p className="mt-1 text-sm text-rose-300">{errors.password}</p>}
+            {errors.password && <p className="mt-1 text-sm text-g-danger">{errors.password}</p>}
           </div>
 
           <div>
-            <label htmlFor={passwordConfirmationId} className="block text-sm font-medium text-slate-200">
+            <label htmlFor={passwordConfirmationId} className="block text-sm font-bold text-g-heading">
               Confirm new password
             </label>
             <input
@@ -74,17 +78,17 @@ export default function ResetPassword({ token, email, errors = {} }: Props) {
               value={form.data.passwordConfirmation}
               onChange={(event) => form.setData('passwordConfirmation', event.target.value)}
               required
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
             {errors.passwordConfirmation && (
-              <p className="mt-1 text-sm text-rose-300">{errors.passwordConfirmation}</p>
+              <p className="mt-1 text-sm text-g-danger">{errors.passwordConfirmation}</p>
             )}
           </div>
 
           <button
             type="submit"
             disabled={form.processing}
-            className="w-full rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+            className="w-full rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down disabled:cursor-not-allowed disabled:opacity-45"
           >
             Reset password
           </button>

--- a/packages/cli/templates/scaffold/auth/resources/js/pages/auth/VerifyEmail.tsx
+++ b/packages/cli/templates/scaffold/auth/resources/js/pages/auth/VerifyEmail.tsx
@@ -11,15 +11,19 @@ export default function VerifyEmail({ status }: Props) {
   return (
     <Layout>
       <Head title="Verify email" />
-      <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-8 shadow-xl shadow-emerald-500/5">
-        <h1 className="text-2xl font-semibold text-emerald-300">Verify your email</h1>
-        <p className="mt-2 text-sm text-slate-400">
+      <section className="rounded-g-card border border-g-line bg-g-panel p-8 shadow-g-card">
+        <h1 className="flex items-center gap-3 text-2xl font-bold text-g-heading">
+          <span aria-hidden className="h-6 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+          Verify your email
+        </h1>
+        <p className="mt-2 text-sm text-g-text-2">
           We sent a verification link to your email address. Click it to activate your account.
         </p>
 
         {status ? (
-          <p className="mt-4 rounded border border-emerald-500/40 bg-emerald-500/10 px-4 py-2 text-sm text-emerald-200">
-            {status}
+          <p className="mt-4 flex gap-3 border-y border-g-line py-2.5 text-sm">
+            <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 text-g-ok">ok</span>
+            <span className="text-g-text">{status}</span>
           </p>
         ) : null}
 
@@ -33,7 +37,7 @@ export default function VerifyEmail({ status }: Props) {
           <button
             type="submit"
             disabled={form.processing}
-            className="w-full rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+            className="w-full rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down disabled:cursor-not-allowed disabled:opacity-45"
           >
             Resend verification email
           </button>

--- a/packages/cli/templates/scaffold/auth/resources/js/pages/dashboard/Index.tsx
+++ b/packages/cli/templates/scaffold/auth/resources/js/pages/dashboard/Index.tsx
@@ -9,19 +9,23 @@ export default function Dashboard({ user }: Props) {
     <Layout>
       <section className="space-y-6">
         <header>
-          <h1 className="text-3xl font-semibold text-emerald-300">Dashboard</h1>
-          <p className="mt-2 text-sm text-slate-400">This page is protected by the auth middleware.</p>
+          <h1 className="flex items-center gap-3 text-3xl font-bold text-g-heading">
+            <span aria-hidden className="h-7 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+            Dashboard
+          </h1>
+          <p className="mt-2 text-sm text-g-text-2">This page is protected by the auth middleware.</p>
         </header>
 
         {user ? (
-          <div className="rounded-lg border border-slate-800 bg-slate-900/40 p-6 shadow-lg shadow-emerald-500/10">
-            <h2 className="text-xl font-medium text-slate-100">Signed in as {user.name}</h2>
-            <p className="mt-2 text-sm text-slate-300">Email: {user.email}</p>
+          <div className="rounded-g-card border border-g-line bg-g-panel p-6 shadow-g-card">
+            <h2 className="text-xl font-bold text-g-heading">Signed in as {user.name}</h2>
+            <p className="mt-2 text-sm text-g-text-2">Email: {user.email}</p>
           </div>
         ) : (
-          <div className="rounded border border-rose-500/60 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
-            You are not signed in.
-          </div>
+          <p className="flex gap-3 border-y border-g-line py-2.5 text-sm">
+            <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 text-g-danger">error</span>
+            <span className="text-g-text">You are not signed in.</span>
+          </p>
         )}
       </section>
     </Layout>

--- a/packages/cli/templates/scaffold/guren-ui/resources/css/guren.css
+++ b/packages/cli/templates/scaffold/guren-ui/resources/css/guren.css
@@ -1,0 +1,135 @@
+/* Guren UI — design tokens (https://github.com/gurenjs/guren-ui)
+   Light is the guren.dev docs light theme (white + crimson); dark is its
+   docs dark theme (rose-pine-moon ground, rose accent text). The dark block
+   follows the system preference — restructure it behind a class if the app
+   grows a theme toggle.
+
+   The red budget: --g-accent (crimson) fills one element per screen — the
+   primary action. Destructive actions are outline + explicit verb; the red
+   fill moves to them only inside a confirm step. */
+
+:root {
+  --g-font-sans: system-ui, 'Noto Sans JP', 'Hiragino Sans', sans-serif;
+  --g-font-mono: ui-monospace, 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace;
+
+  /* surfaces */
+  --g-page: #ffffff;
+  --g-panel: #ffffff;
+  --g-raised: #fffafa;
+  --g-ink: #1a1212; /* terminal surface — dark in both themes */
+  --g-line: #e5e7eb;
+  --g-line-strong: #d1d5db;
+
+  /* text */
+  --g-heading: #111827;
+  --g-text: #1f2937;
+  --g-text-2: #4b5563;
+  --g-muted: #9ca3af;
+
+  /* text printed on the ink surface */
+  --g-on-ink: #fff5f5;
+  --g-on-ink-muted: #c9a9a9;
+
+  /* the red budget */
+  --g-accent: #db1b1b; /* crimson-600 — primary fills only */
+  --g-accent-down: #b91c1c;
+  --g-accent-text: #991b1b; /* crimson-800 — links, accent text */
+  --g-accent-tint: #fff1f2;
+  --g-on-accent: #fff5f5;
+
+  /* signals — text-safe value + chip value + wash */
+  --g-ok: #286983;
+  --g-ok-chip: #56949f;
+  --g-ok-tint: rgba(86, 148, 159, 0.12);
+  --g-warn: #b45309;
+  --g-warn-chip: #ea9d34;
+  --g-warn-tint: rgba(234, 157, 52, 0.14);
+  --g-danger: #b91c1c;
+  --g-danger-chip: #f23a3a;
+  --g-danger-tint: #fff1f2;
+
+  /* the one structural device — marks the current place, once per screen */
+  --g-tick: linear-gradient(180deg, #ff3c28, #8b0000);
+
+  /* geometry */
+  --g-r-ctl: 8px;
+  --g-r-card: 12px;
+  --g-shadow-card: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
+  --g-shadow-float: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.04);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --g-page: #1a1a2e;
+    --g-panel: #1e1e34;
+    --g-raised: #232340;
+    --g-line: #2e2e4a;
+    --g-line-strong: #3d3d5c;
+
+    --g-heading: #e0def4;
+    --g-text: #e0def4;
+    --g-text-2: #908caa;
+    --g-muted: #6e6a86;
+
+    /* fills stay crimson in both themes; accent TEXT moves to rose —
+       crimson measures 4.42:1 on this ground */
+    --g-accent-text: #eb6f92;
+    --g-accent-tint: rgba(235, 111, 146, 0.12);
+
+    --g-ok: #9ccfd8;
+    --g-ok-chip: #9ccfd8;
+    --g-ok-tint: rgba(156, 207, 216, 0.1);
+    --g-warn: #f6c177;
+    --g-warn-chip: #f6c177;
+    --g-warn-tint: rgba(246, 193, 119, 0.1);
+    --g-danger: #ffa5a5;
+    --g-danger-chip: #f23a3a;
+    --g-danger-tint: rgba(242, 58, 58, 0.12);
+
+    --g-shadow-card: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
+    --g-shadow-float: 0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -2px rgba(0, 0, 0, 0.25);
+  }
+}
+
+/* Tailwind utilities over the tokens: bg-g-page, text-g-accent-text,
+   border-g-line, rounded-g-card, shadow-g-card, font-sans, font-mono … */
+@theme inline {
+  --font-sans: var(--g-font-sans);
+  --font-mono: var(--g-font-mono);
+
+  --color-g-page: var(--g-page);
+  --color-g-panel: var(--g-panel);
+  --color-g-raised: var(--g-raised);
+  --color-g-ink: var(--g-ink);
+  --color-g-line: var(--g-line);
+  --color-g-line-strong: var(--g-line-strong);
+
+  --color-g-heading: var(--g-heading);
+  --color-g-text: var(--g-text);
+  --color-g-text-2: var(--g-text-2);
+  --color-g-muted: var(--g-muted);
+
+  --color-g-on-ink: var(--g-on-ink);
+  --color-g-on-ink-muted: var(--g-on-ink-muted);
+
+  --color-g-accent: var(--g-accent);
+  --color-g-accent-down: var(--g-accent-down);
+  --color-g-accent-text: var(--g-accent-text);
+  --color-g-accent-tint: var(--g-accent-tint);
+  --color-g-on-accent: var(--g-on-accent);
+
+  --color-g-ok: var(--g-ok);
+  --color-g-ok-chip: var(--g-ok-chip);
+  --color-g-ok-tint: var(--g-ok-tint);
+  --color-g-warn: var(--g-warn);
+  --color-g-warn-chip: var(--g-warn-chip);
+  --color-g-warn-tint: var(--g-warn-tint);
+  --color-g-danger: var(--g-danger);
+  --color-g-danger-chip: var(--g-danger-chip);
+  --color-g-danger-tint: var(--g-danger-tint);
+
+  --radius-g-ctl: var(--g-r-ctl);
+  --radius-g-card: var(--g-r-card);
+  --shadow-g-card: var(--g-shadow-card);
+  --shadow-g-float: var(--g-shadow-float);
+}

--- a/packages/cli/tests/guren-css-sync.test.ts
+++ b/packages/cli/tests/guren-css-sync.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const repoRoot = join(import.meta.dir, '../../..')
+
+/**
+ * The Guren UI token sheet exists in two places: create-guren-app ships it in
+ * the default template, and `guren add auth` / `guren make:feature` write the
+ * scaffold copy into apps that predate it (ensureGurenUiTokens). The two must
+ * stay byte-identical — a drifted copy means an app gets different tokens
+ * depending on which command created the file. Same policy as
+ * scaffold-blog-sync.test.ts; upstream design decisions live in
+ * gurenjs/guren-ui and land here by hand.
+ */
+it('the scaffold guren.css matches the create-app template copy', async () => {
+  const scaffold = await readFile(
+    join(repoRoot, 'packages/cli/templates/scaffold/guren-ui/resources/css/guren.css'),
+    'utf8',
+  )
+  const blueprint = await readFile(
+    join(repoRoot, 'packages/create-app/templates/default/resources/css/guren.css'),
+    'utf8',
+  )
+
+  expect(scaffold).toBe(blueprint)
+})
+
+describe('ensureGurenUiTokens', () => {
+  it('writes guren.css and adds the app.css import once', async () => {
+    const { mkdtemp, mkdir, readFile: read, writeFile } = await import('node:fs/promises')
+    const { tmpdir } = await import('node:os')
+    const { ensureGurenUiTokens } = await import('../src/guren-css')
+
+    const root = await mkdtemp(join(tmpdir(), 'guren-css-'))
+    await mkdir(join(root, 'resources/css'), { recursive: true })
+    await writeFile(join(root, 'resources/css/app.css'), "@import 'tailwindcss';\n", 'utf8')
+
+    await ensureGurenUiTokens(root)
+
+    const tokens = await read(join(root, 'resources/css/guren.css'), 'utf8')
+    expect(tokens).toContain('--g-accent')
+    const appCss = await read(join(root, 'resources/css/app.css'), 'utf8')
+    expect(appCss).toBe("@import 'tailwindcss';\n@import './guren.css';\n")
+
+    // Second run must not duplicate the import or clobber an edited sheet.
+    await writeFile(join(root, 'resources/css/guren.css'), '/* user edited */\n', 'utf8')
+    await ensureGurenUiTokens(root)
+    expect(await read(join(root, 'resources/css/guren.css'), 'utf8')).toBe('/* user edited */\n')
+    expect(await read(join(root, 'resources/css/app.css'), 'utf8')).toBe(
+      "@import 'tailwindcss';\n@import './guren.css';\n",
+    )
+  })
+
+  it('prepends the import when app.css has no @import lines', async () => {
+    const { mkdtemp, mkdir, readFile: read, writeFile } = await import('node:fs/promises')
+    const { tmpdir } = await import('node:os')
+    const { ensureGurenUiTokens } = await import('../src/guren-css')
+
+    const root = await mkdtemp(join(tmpdir(), 'guren-css-'))
+    await mkdir(join(root, 'resources/css'), { recursive: true })
+    await writeFile(join(root, 'resources/css/app.css'), 'body { margin: 0; }\n', 'utf8')
+
+    await ensureGurenUiTokens(root)
+
+    expect(await read(join(root, 'resources/css/app.css'), 'utf8')).toBe(
+      "@import './guren.css';\nbody { margin: 0; }\n",
+    )
+  })
+
+  it('leaves a missing app.css alone but still writes the tokens', async () => {
+    const { mkdtemp, readFile: read } = await import('node:fs/promises')
+    const { tmpdir } = await import('node:os')
+    const { ensureGurenUiTokens } = await import('../src/guren-css')
+
+    const root = await mkdtemp(join(tmpdir(), 'guren-css-'))
+
+    await ensureGurenUiTokens(root)
+
+    expect(await read(join(root, 'resources/css/guren.css'), 'utf8')).toContain('--g-accent')
+  })
+})

--- a/packages/create-app/templates/blog/resources/js/pages/dashboard/Index.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/dashboard/Index.tsx
@@ -9,19 +9,23 @@ export default function Dashboard({ user }: Props) {
     <Layout>
       <section className="space-y-6">
         <header>
-          <h1 className="text-3xl font-semibold text-emerald-300">Dashboard</h1>
-          <p className="mt-2 text-sm text-slate-400">This page is protected by the auth middleware.</p>
+          <h1 className="flex items-center gap-3 text-3xl font-bold text-g-heading">
+            <span aria-hidden className="h-7 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+            Dashboard
+          </h1>
+          <p className="mt-2 text-sm text-g-text-2">This page is protected by the auth middleware.</p>
         </header>
 
         {user ? (
-          <div className="rounded-lg border border-slate-800 bg-slate-900/40 p-6 shadow-lg shadow-emerald-500/10">
-            <h2 className="text-xl font-medium text-slate-100">Signed in as {user.name}</h2>
-            <p className="mt-2 text-sm text-slate-300">Email: {user.email}</p>
+          <div className="rounded-g-card border border-g-line bg-g-panel p-6 shadow-g-card">
+            <h2 className="text-xl font-bold text-g-heading">Signed in as {user.name}</h2>
+            <p className="mt-2 text-sm text-g-text-2">Email: {user.email}</p>
           </div>
         ) : (
-          <div className="rounded border border-rose-500/60 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
-            You are not signed in.
-          </div>
+          <p className="flex gap-3 border-y border-g-line py-2.5 text-sm">
+            <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 text-g-danger">error</span>
+            <span className="text-g-text">You are not signed in.</span>
+          </p>
         )}
       </section>
     </Layout>


### PR DESCRIPTION
## Summary

Second step of adopting the Guren UI design system in scaffolded apps (stacked on #547, which ships the tokens in the default template).

- **make:auth**: the five static templates (Layout, ForgotPassword, ResetPassword, VerifyEmail, dashboard) and the four view builders (Login, OAuth-only Login, Register, Profile) restyled from the slate + emerald look to the Guren UI token language (`bg-g-page`, `text-g-accent-text`, `rounded-g-card`, …). One crimson fill per screen (the primary action), the ember tick on page titles, flash/error messages as diagnostic rows (mono key in a gutter, no tinted boxes).
- **make:feature**: the Index/Show/New/Edit builders restyled the same way. The destructive delete is now an outline + explicit verb behind the existing `window.confirm` step instead of bare red text.
- **`ensureGurenUiTokens()`** (new, run by both commands after scaffolding): writes `resources/css/guren.css` when the app has none and inserts its `@import` into `app.css` when missing — so `guren add auth` into an app scaffolded before the tokens still renders styled. Idempotent; an existing guren.css is never overwritten.
- The token sheet ships as a second copy under `packages/cli/templates/scaffold/guren-ui/`; `tests/guren-css-sync.test.ts` pins it byte-identical to the create-app template copy (same policy as `scaffold-blog-sync.test.ts`).
- The blog blueprint's `dashboard/Index.tsx` moves in lockstep with its scaffold twin, per the pinned pair. The rest of the blog blueprint keeps its old look until the follow-up PR regenerates it from these generators.

## Verification

- `bun run test:bun cli` — 1689 pass (parse gates, builder typecheck, blog-sync, new sync + ensure tests)
- `bun run test:bun create-app` — 71 pass
- `bun run typecheck` (incl. `typecheck:scaffold-templates`) — green
- `bun run smoke:starter` and `bun run smoke:starter:blog` — exit 0
- `audit:starter-template`, `audit:core-first`, `audit:docs` — pass
- Rendered ForgotPassword and Dashboard in a Vite + Tailwind v4 sandbox and verified light/dark visually.