### PR TITLE
refactor(cli): ship attachments blueprint scaffolds as real sources

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,7 @@
     "dev": "bun --watch src/index.ts",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
-    "typecheck:templates": "tsc -p tsconfig.templates.json"
+    "typecheck:templates": "tsc -p tsconfig.templates.json && tsc -p tsconfig.templates-attachments.json"
   },
   "dependencies": {
     "@babel/parser": "^7.24.7",

--- a/packages/cli/src/add-attachments.ts
+++ b/packages/cli/src/add-attachments.ts
@@ -1,7 +1,7 @@
 import { writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { consola } from 'consola'
-import { readIfExists, fileExists } from './discovery'
+import { collectFiles, fileExists, listAppRoots, readIfExists } from './discovery'
 import {
   addImport,
   addToArrayArgument,
@@ -15,7 +15,7 @@ import {
 } from './patch-helpers'
 import { wireProviders } from './provider-registrar'
 import { loadScaffoldTemplate } from './scaffold-templates'
-import { writeScaffoldFiles, type WriterOptions } from './utils'
+import { writeScaffoldFiles, type ScaffoldFileEntry, type WriterOptions } from './utils'
 
 const CONSOLE_ENTRY = 'src/console.ts'
 
@@ -92,7 +92,10 @@ const SCHEMA_IMPORTS: Record<SchemaDialect, (content: string) => string> = {
 
 const VARIANT_RECORD_IMPORT = "import type { AttachmentVariantRecord } from '@guren/core'"
 
-
+/** `path` is both the template path under `templates/scaffold/attachments/` and the written app path. */
+function attachmentsFile(path: string): ScaffoldFileEntry {
+  return { path, contents: loadScaffoldTemplate(`attachments/${path}`) }
+}
 
 /**
  * Any exported `attachments` binding counts as "the app already has one":
@@ -119,14 +122,8 @@ export async function addAttachments(options: WriterOptions): Promise<string[]> 
   // Skipped per file rather than thrown: a re-run (or a run after a partial
   // one) should repair whatever is missing — wire the provider, register the
   // command — not abort on the first file that already exists.
-  // Shipped as real sources under templates/scaffold/attachments so
-  // typecheck:templates compiles them on every run — a string here is a file
-  // no tsconfig covers.
-  const scaffolds = ['config/attachments.ts', 'app/Providers/AttachmentsProvider.ts'].map((path) => ({
-    path,
-    contents: loadScaffoldTemplate(`attachments/${path}`),
-  }))
-  const pending: typeof scaffolds = []
+  const scaffolds = ['config/attachments.ts', 'app/Providers/AttachmentsProvider.ts'].map(attachmentsFile)
+  const pending: ScaffoldFileEntry[] = []
   for (const entry of scaffolds) {
     if (!options.force && (await fileExists(process.cwd(), entry.path))) {
       consola.info(`${entry.path} already exists — left unchanged (use --force to overwrite).`)
@@ -181,11 +178,9 @@ async function patchSchema(): Promise<void> {
  * that file, and installing a second manager over it would shadow it.
  */
 export async function appBindsStorage(): Promise<boolean> {
-  const { collectFiles, listAppRoots } = await import('./discovery')
-  const { resolve: resolvePath } = await import('node:path')
   const roots = await listAppRoots(process.cwd())
   const groups = await Promise.all(
-    roots.flatMap((root) => ['app', 'src'].map((dir) => collectFiles(resolvePath(root.dir, dir)))),
+    roots.flatMap((root) => ['app', 'src'].map((dir) => collectFiles(resolve(root.dir, dir)))),
   )
   const bindingPattern = /\b(?:instance|singleton|bind)\(\s*['"]storage['"]/
   for (const filePath of groups.flat()) {

--- a/packages/cli/src/add-attachments.ts
+++ b/packages/cli/src/add-attachments.ts
@@ -14,6 +14,7 @@ import {
   type SchemaDialect,
 } from './patch-helpers'
 import { wireProviders } from './provider-registrar'
+import { loadScaffoldTemplate } from './scaffold-templates'
 import { writeScaffoldFiles, type WriterOptions } from './utils'
 
 const CONSOLE_ENTRY = 'src/console.ts'
@@ -91,40 +92,7 @@ const SCHEMA_IMPORTS: Record<SchemaDialect, (content: string) => string> = {
 
 const VARIANT_RECORD_IMPORT = "import type { AttachmentVariantRecord } from '@guren/core'"
 
-const CONFIG_FILE = `import { configureAttachments, getContainer } from '@guren/core'
-import { attachments } from '../db/schema'
 
-/**
- * Wires the attachments layer once at boot (AttachmentsProvider imports this
- * module). \`Attachment\` is the app-local model over the attachments table —
- * use it for morph relations and advanced queries; the typed day-to-day API
- * lives on your models via the Attachable mixin.
- *
- * See the attachments guide for declarations, image validation, variants,
- * and queued generation.
- */
-export const { Attachment } = configureAttachments({
-  table: attachments,
-  storage: () => getContainer().make('storage'),
-  // Where new attachments are stored, and how their URLs are built: 'public'
-  // disks serve via disk.url(), 'private' ones via disk.temporaryUrl().
-  disk: 'public',
-  disks: { public: 'public' },
-})
-`
-
-const PROVIDER_FILE = `import { ServiceProvider } from '@guren/core'
-// The import is the wiring: config/attachments.ts calls configureAttachments()
-// at module scope, and loading it from a provider guarantees that happens at
-// boot — before the first attach(), in web and worker processes alike.
-import '@/config/attachments'
-
-export default class AttachmentsProvider extends ServiceProvider {
-  register(): void {
-    // Everything is wired by the config import above.
-  }
-}
-`
 
 /**
  * Any exported `attachments` binding counts as "the app already has one":
@@ -151,10 +119,13 @@ export async function addAttachments(options: WriterOptions): Promise<string[]> 
   // Skipped per file rather than thrown: a re-run (or a run after a partial
   // one) should repair whatever is missing — wire the provider, register the
   // command — not abort on the first file that already exists.
-  const scaffolds = [
-    { path: 'config/attachments.ts', contents: CONFIG_FILE },
-    { path: 'app/Providers/AttachmentsProvider.ts', contents: PROVIDER_FILE },
-  ]
+  // Shipped as real sources under templates/scaffold/attachments so
+  // typecheck:templates compiles them on every run — a string here is a file
+  // no tsconfig covers.
+  const scaffolds = ['config/attachments.ts', 'app/Providers/AttachmentsProvider.ts'].map((path) => ({
+    path,
+    contents: loadScaffoldTemplate(`attachments/${path}`),
+  }))
   const pending: typeof scaffolds = []
   for (const entry of scaffolds) {
     if (!options.force && (await fileExists(process.cwd(), entry.path))) {

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -1,3 +1,4 @@
+import { consola } from 'consola'
 import { addAttachments, appBindsStorage } from './add-attachments'
 import { assertNotApiOnly } from './app-surface'
 import { fileExists, readIfExists } from './discovery'
@@ -62,7 +63,6 @@ const blueprintRegistry: Record<string, BlueprintDefinition> = {
       // a second manager installed over it.
       const hasConventionalProvider = await fileExists(process.cwd(), 'app/Providers/StorageProvider.ts')
       if (!hasConventionalProvider && !(await appBindsStorage())) {
-        const { consola } = await import('consola')
         consola.info("No 'storage' binding found — installing the storage blueprint first.")
         created.push(...(await blueprintRegistry.storage!.run(options)))
       }

--- a/packages/cli/templates/scaffold/attachments/app/Providers/AttachmentsProvider.ts
+++ b/packages/cli/templates/scaffold/attachments/app/Providers/AttachmentsProvider.ts
@@ -2,7 +2,7 @@ import { ServiceProvider } from '@guren/core'
 // The import is the wiring: config/attachments.ts calls configureAttachments()
 // at module scope, and loading it from a provider guarantees that happens at
 // boot — before the first attach(), in web and worker processes alike.
-import '@/config/attachments'
+import '../../config/attachments'
 
 export default class AttachmentsProvider extends ServiceProvider {
   register(): void {

--- a/packages/cli/templates/scaffold/attachments/app/Providers/AttachmentsProvider.ts
+++ b/packages/cli/templates/scaffold/attachments/app/Providers/AttachmentsProvider.ts
@@ -1,0 +1,11 @@
+import { ServiceProvider } from '@guren/core'
+// The import is the wiring: config/attachments.ts calls configureAttachments()
+// at module scope, and loading it from a provider guarantees that happens at
+// boot — before the first attach(), in web and worker processes alike.
+import '@/config/attachments'
+
+export default class AttachmentsProvider extends ServiceProvider {
+  register(): void {
+    // Everything is wired by the config import above.
+  }
+}

--- a/packages/cli/templates/scaffold/attachments/config/attachments.ts
+++ b/packages/cli/templates/scaffold/attachments/config/attachments.ts
@@ -1,5 +1,5 @@
 import { configureAttachments, getContainer } from '@guren/core'
-import { attachments } from '@/db/schema'
+import { attachments } from '../db/schema'
 
 /**
  * Wires the attachments layer once at boot (AttachmentsProvider imports this

--- a/packages/cli/templates/scaffold/attachments/config/attachments.ts
+++ b/packages/cli/templates/scaffold/attachments/config/attachments.ts
@@ -1,0 +1,20 @@
+import { configureAttachments, getContainer } from '@guren/core'
+import { attachments } from '@/db/schema'
+
+/**
+ * Wires the attachments layer once at boot (AttachmentsProvider imports this
+ * module). `Attachment` is the app-local model over the attachments table —
+ * use it for morph relations and advanced queries; the typed day-to-day API
+ * lives on your models via the Attachable mixin.
+ *
+ * See the attachments guide for declarations, image validation, variants,
+ * and queued generation.
+ */
+export const { Attachment } = configureAttachments({
+  table: attachments,
+  storage: () => getContainer().make('storage'),
+  // Where new attachments are stored, and how their URLs are built: 'public'
+  // disks serve via disk.url(), 'private' ones via disk.temporaryUrl().
+  disk: 'public',
+  disks: { public: 'public' },
+})

--- a/packages/cli/tests/add-attachments.test.ts
+++ b/packages/cli/tests/add-attachments.test.ts
@@ -55,7 +55,7 @@ describe('guren add attachments', () => {
 
     const config = await readFile(resolve('config/attachments.ts'), 'utf8')
     expect(config).toContain('configureAttachments({')
-    expect(config).toContain("import { attachments } from '../db/schema'")
+    expect(config).toContain("import { attachments } from '@/db/schema'")
 
     expect(existsSync(resolve('app/Providers/AttachmentsProvider.ts'))).toBe(true)
     const appFile = await readFile(resolve('src/app.ts'), 'utf8')

--- a/packages/cli/tests/add-attachments.test.ts
+++ b/packages/cli/tests/add-attachments.test.ts
@@ -55,7 +55,7 @@ describe('guren add attachments', () => {
 
     const config = await readFile(resolve('config/attachments.ts'), 'utf8')
     expect(config).toContain('configureAttachments({')
-    expect(config).toContain("import { attachments } from '@/db/schema'")
+    expect(config).toContain("import { attachments } from '../db/schema'")
 
     expect(existsSync(resolve('app/Providers/AttachmentsProvider.ts'))).toBe(true)
     const appFile = await readFile(resolve('src/app.ts'), 'utf8')

--- a/packages/cli/tests/fixtures/scaffold-typecheck/attachments/db/schema.ts
+++ b/packages/cli/tests/fixtures/scaffold-typecheck/attachments/db/schema.ts
@@ -1,0 +1,25 @@
+// Companion for typechecking templates/scaffold/attachments: the attachments
+// table the blueprint's Postgres schema patch produces (pinned by
+// scaffold-output.test.ts). config/attachments.ts only ever imports the
+// `attachments` export, so this stays valid for every dialect the patch
+// supports.
+import type { AttachmentVariantRecord } from '@guren/core'
+import { index, integer, jsonb, pgTable, text, timestamp } from '@guren/orm/drizzle/pg'
+
+export const attachments = pgTable('attachments', {
+  id: text('id').primaryKey(),
+  attachableType: text('attachable_type').notNull(),
+  attachableId: text('attachable_id').notNull(),
+  collection: text('collection').notNull().default('default'),
+  disk: text('disk').notNull(),
+  path: text('path').notNull(),
+  name: text('name').notNull(),
+  contentType: text('content_type').notNull(),
+  size: integer('size').notNull(),
+  width: integer('width'),
+  height: integer('height'),
+  variants: jsonb('variants').$type<Record<string, AttachmentVariantRecord>>(),
+  placeholder: text('placeholder'),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [index('attachments_attachable_idx').on(t.attachableType, t.attachableId, t.collection)])

--- a/packages/cli/tests/scaffold-output.test.ts
+++ b/packages/cli/tests/scaffold-output.test.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import {
   CLI_DIST_BIN,
+  PG_SCHEMA_FIXTURE,
   SERVER_DIST_ENTRY,
   assertWorkspaceBuilt,
   createTempWorkspace,
@@ -298,8 +299,8 @@ describe('scaffold-typecheck fixture stays pinned to the builders', () => {
 })
 
 describe('attachments scaffold-typecheck fixture stays pinned to the builder', () => {
-  // tsconfig.templates.json typechecks templates/scaffold/attachments against
-  // tests/fixtures/scaffold-typecheck/attachments/db/schema.ts. That
+  // tsconfig.templates-attachments.json typechecks templates/scaffold/attachments
+  // against tests/fixtures/scaffold-typecheck/attachments/db/schema.ts. That
   // companion is a render of the blueprint's Postgres schema patch, so a
   // change to ATTACHMENTS_TABLE_BLOCKS.pg has to land in the fixture too —
   // otherwise the templates keep typechecking against a table the blueprint
@@ -316,14 +317,16 @@ describe('attachments scaffold-typecheck fixture stays pinned to the builder', (
     const workspace = await createTempWorkspace('guren-attachments-fixture-pin-')
     try {
       await mkdir(join(workspace.dir, 'db'), { recursive: true })
-      await writeFile(
-        join(workspace.dir, 'db/schema.ts'),
-        "import { pgTable, serial, text } from '@guren/orm/drizzle/pg'\n\nexport const posts = pgTable('posts', {\n  id: serial('id').primaryKey(),\n})\n",
-      )
+      await writeFile(join(workspace.dir, 'db/schema.ts'), PG_SCHEMA_FIXTURE)
       await runBlueprint('attachments', {})
 
       const rendered = await readFile(join(workspace.dir, 'db/schema.ts'), 'utf8')
-      expect(rendered).toContain(fixtureTable.trimEnd())
+      // The block is appended at end of file, so the tails must be *equal*:
+      // toContain would keep passing if the builder grew a suffix
+      // (.enableRLS(), a second index) the fixture never learned about.
+      const renderedStart = rendered.indexOf('export const attachments')
+      expect(renderedStart).toBeGreaterThan(-1)
+      expect(rendered.slice(renderedStart).trimEnd()).toBe(fixtureTable.trimEnd())
     } finally {
       await workspace.cleanup()
     }

--- a/packages/cli/tests/scaffold-output.test.ts
+++ b/packages/cli/tests/scaffold-output.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { readFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import {
   CLI_DIST_BIN,
@@ -13,6 +13,7 @@ import { parseSourceFile } from '../src/parse-cache'
 import { collectFiles, IMPORTABLE_EXTENSIONS, NON_SOURCE_DIR_NAMES, toPosixRelative } from '../src/discovery'
 import { builtinSubCommands } from '../src/commands'
 import { makeAuth, type MakeAuthOptions } from '../src/make-auth'
+import { runBlueprint } from '../src/blueprints'
 import { makeFeature } from '../src/make-feature'
 import { makeChannel } from '../src/make-channel'
 import { makeCommand } from '../src/make-command'
@@ -295,3 +296,37 @@ describe('scaffold-typecheck fixture stays pinned to the builders', () => {
     }
   })
 })
+
+describe('attachments scaffold-typecheck fixture stays pinned to the builder', () => {
+  // tsconfig.templates.json typechecks templates/scaffold/attachments against
+  // tests/fixtures/scaffold-typecheck/attachments/db/schema.ts. That
+  // companion is a render of the blueprint's Postgres schema patch, so a
+  // change to ATTACHMENTS_TABLE_BLOCKS.pg has to land in the fixture too —
+  // otherwise the templates keep typechecking against a table the blueprint
+  // no longer writes.
+  it('attachments table matches what the blueprint appends to a pg schema', async () => {
+    const fixtureSchema = await readFile(
+      join(import.meta.dir, 'fixtures/scaffold-typecheck/attachments/db/schema.ts'),
+      'utf8',
+    )
+    const tableStart = fixtureSchema.indexOf('export const attachments')
+    expect(tableStart).toBeGreaterThan(-1)
+    const fixtureTable = fixtureSchema.slice(tableStart)
+
+    const workspace = await createTempWorkspace('guren-attachments-fixture-pin-')
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'db/schema.ts'),
+        "import { pgTable, serial, text } from '@guren/orm/drizzle/pg'\n\nexport const posts = pgTable('posts', {\n  id: serial('id').primaryKey(),\n})\n",
+      )
+      await runBlueprint('attachments', {})
+
+      const rendered = await readFile(join(workspace.dir, 'db/schema.ts'), 'utf8')
+      expect(rendered).toContain(fixtureTable.trimEnd())
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+})
+

--- a/packages/cli/tsconfig.templates-attachments.json
+++ b/packages/cli/tsconfig.templates-attachments.json
@@ -1,0 +1,34 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDirs": [
+      "templates/scaffold/attachments",
+      "tests/fixtures/scaffold-typecheck/attachments"
+    ],
+    "paths": {
+      "@guren/core": [
+        "../core/src/index.ts"
+      ],
+      "@guren/core/*": [
+        "../core/src/*"
+      ],
+      "@guren/server": [
+        "../server/src/index.ts"
+      ],
+      "@guren/server/*": [
+        "../server/src/*"
+      ],
+      "@guren/orm": [
+        "../orm/src/index.ts"
+      ],
+      "@guren/orm/*": [
+        "../orm/src/*"
+      ]
+    }
+  },
+  "include": [
+    "templates/scaffold/attachments/**/*",
+    "tests/fixtures/scaffold-typecheck/attachments/**/*"
+  ],
+  "exclude": []
+}

--- a/packages/cli/tsconfig.templates.json
+++ b/packages/cli/tsconfig.templates.json
@@ -7,8 +7,6 @@
     ],
     "paths": {
       "@/.guren/pages.gen": ["./tests/fixtures/scaffold-typecheck/auth/.guren/pages.gen.ts"],
-      "@/config/attachments": ["./templates/scaffold/attachments/config/attachments.ts"],
-      "@/db/schema": ["./tests/fixtures/scaffold-typecheck/attachments/db/schema.ts"],
       "@guren/core": ["../core/src/index.ts"],
       "@guren/core/*": ["../core/src/*"],
       "@guren/server": ["../server/src/index.ts"],
@@ -23,5 +21,8 @@
     "templates/scaffold/**/*",
     "tests/fixtures/scaffold-typecheck/**/*"
   ],
-  "exclude": []
+  "exclude": [
+    "templates/scaffold/attachments",
+    "tests/fixtures/scaffold-typecheck/attachments"
+  ]
 }

--- a/packages/cli/tsconfig.templates.json
+++ b/packages/cli/tsconfig.templates.json
@@ -7,6 +7,8 @@
     ],
     "paths": {
       "@/.guren/pages.gen": ["./tests/fixtures/scaffold-typecheck/auth/.guren/pages.gen.ts"],
+      "@/config/attachments": ["./templates/scaffold/attachments/config/attachments.ts"],
+      "@/db/schema": ["./tests/fixtures/scaffold-typecheck/attachments/db/schema.ts"],
       "@guren/core": ["../core/src/index.ts"],
       "@guren/core/*": ["../core/src/*"],
       "@guren/server": ["../server/src/index.ts"],


### PR DESCRIPTION
## Summary

Follow-up to [#545](https://github.com/gurenjs/guren/pull/545): the two static files the attachments blueprint writes — `config/attachments.ts` and `AttachmentsProvider.ts` — move from template literals in `add-attachments.ts` to real sources under `templates/scaffold/attachments/`, loaded via `loadScaffoldTemplate()`. A string-emitted file is a file no tsconfig covers; as real sources they are compiled by `typecheck:templates` on every run, per the direction the repo already established for the `make:auth` scaffolds and create-app's `config/database.ts`. The per-dialect schema table blocks stay inline, per the established split (only fully static files live in the template tree).

Two findings from the review passes shaped the mechanics:

- **The scaffolds stay on relative imports.** The obvious `@/db/schema` spelling would have shipped a compatibility break: early create-guren-app templates mapped `@/*` to `./app/*` (verified in git history), so the generated config would resolve to nothing on those apps — while `guren check`, which assumes `@/` means the project root, reported a pass. Relative imports worked on every app vintage.
- **The attachments scaffold gets its own tsconfig project** (`tsconfig.templates-attachments.json`, chained in `typecheck:templates`): `rootDirs` merges every scaffold into one virtual root, so a second `db/schema.ts` companion would collide with auth's.

The fixture companion (`tests/fixtures/scaffold-typecheck/attachments/db/schema.ts`) is pinned against the blueprint's Postgres schema patch in `scaffold-output.test.ts` — comparing tails with `toBe()`, since `toContain` kept passing when the builder grew a suffix the fixture never learned about. A simplifier pass is folded in (make-auth-shaped `attachmentsFile()` helper, hoisted dynamic imports, deduped fixture seeding; mutation-checked that the pin still fails on drift).

No changeset: this rides the same unreleased `@guren/cli` minor as the blueprint itself.

Migrating the remaining blueprint-family inline strings (storage, mail, cache, …) to the same mechanism is a candidate follow-up cleanup, not attempted here.

## Testing

`typecheck:templates` (both projects), cli suite 1695 pass / 0 fail, full `bun run typecheck` / `bun run test` (5149 + 114 pass), `smoke:starter`, `audit:starter-template` — all green.

Refs: RFC 0013