### PR TITLE
feat(create-app): restyle the blog blueprint with the Guren UI tokens

### DIFF
--- a/.changeset/guren-ui-blog-blueprint.md
+++ b/.changeset/guren-ui-blog-blueprint.md
@@ -1,0 +1,5 @@
+---
+'create-guren-app': patch
+---
+
+Restyle the blog blueprint with the Guren UI design tokens: every page moves from the slate + emerald look to the guren.dev light/dark themes the default template ships, matching the output of the restyled `make:auth` / `make:feature` generators it was originally derived from.

--- a/packages/cli/src/guren-css.ts
+++ b/packages/cli/src/guren-css.ts
@@ -1,11 +1,31 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { consola } from 'consola'
+import { readIfExists } from './discovery'
 import { loadScaffoldTemplate } from './scaffold-templates'
 
 const TOKENS_PATH = 'resources/css/guren.css'
 const APP_CSS_PATH = 'resources/css/app.css'
 const IMPORT_LINE = "@import './guren.css';"
+
+/* The Guren UI class vocabulary shared by every generator that emits styled
+   pages. One definition, or make:auth and make:feature render the same
+   control and silently drift apart. */
+export const FORM_INPUT_CLASS =
+  'w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent'
+export const FIELD_LABEL_CLASS = 'block text-sm font-bold text-g-heading'
+export const PRIMARY_BUTTON_CLASS =
+  'rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down'
+export const PRIMARY_SUBMIT_CLASS = `w-full ${PRIMARY_BUTTON_CLASS} disabled:cursor-not-allowed disabled:opacity-45`
+
+/** Same-length blanking of block comments, so regex indices found on the
+    masked text address the original — a commented-out import is neither an
+    active one nor a place to insert after. */
+function maskCssComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, (match) => ' '.repeat(match.length))
+}
+
+const GUREN_IMPORT_RE = /@import\s+(?:url\(\s*)?['"](?:\.\/)?guren\.css['"]/
 
 /**
  * Make sure the app carries the Guren UI design tokens the scaffolded pages
@@ -31,32 +51,28 @@ export async function ensureGurenUiTokens(cwd: string = process.cwd()): Promise<
     if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
   }
 
-  const appCssPath = resolve(cwd, APP_CSS_PATH)
-  let appCss: string
-  try {
-    appCss = await readFile(appCssPath, 'utf8')
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  const appCss = await readIfExists(cwd, APP_CSS_PATH)
+  if (appCss === null) {
     consola.warn(
       `${APP_CSS_PATH} not found — add ${IMPORT_LINE} to your CSS entry so the Guren UI tokens load.`,
     )
     return
   }
-  if (appCss.includes('./guren.css')) return
 
-  // CSS requires @import to precede other rules, and Tailwind's @theme
-  // mapping inside guren.css has to land after the tailwindcss import — so
-  // slot it right after the last @import when there is one.
-  const lines = appCss.split('\n')
-  let lastImport = -1
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i]!.trimStart().startsWith('@import')) lastImport = i
-  }
-  if (lastImport >= 0) {
-    lines.splice(lastImport + 1, 0, IMPORT_LINE)
-  } else {
-    lines.unshift(IMPORT_LINE)
-  }
-  await writeFile(appCssPath, lines.join('\n'), 'utf8')
+  const masked = maskCssComments(appCss)
+  if (GUREN_IMPORT_RE.test(masked)) return
+
+  // Insert after the last complete @import statement: CSS requires @import
+  // to precede other rules, and the sheet's @theme mapping has to land after
+  // the tailwindcss import. Matching whole statements (not lines) keeps a
+  // multiline `@import url(\n…\n);` intact.
+  const imports = [...masked.matchAll(/@import[^;]*;/g)]
+  const last = imports.at(-1)
+  const updated = last
+    ? appCss.slice(0, last.index + last[0].length)
+      + `\n${IMPORT_LINE}`
+      + appCss.slice(last.index + last[0].length)
+    : `${IMPORT_LINE}\n${appCss}`
+  await writeFile(resolve(cwd, APP_CSS_PATH), updated, 'utf8')
   consola.success(`Added ${IMPORT_LINE} to ${APP_CSS_PATH}`)
 }

--- a/packages/cli/src/make-auth.ts
+++ b/packages/cli/src/make-auth.ts
@@ -18,12 +18,33 @@ import { readIfExists } from './discovery'
 import { APP_ENTRY_CANDIDATES, resolveAppEntry, wireAppProvider, wireProvider } from './provider-registrar'
 import { wireRouteRegistrar } from './route-registrar'
 import { makeMigration } from './make-migration'
-import { ensureGurenUiTokens } from './guren-css'
+import { ensureGurenUiTokens, FIELD_LABEL_CLASS, FORM_INPUT_CLASS, PRIMARY_SUBMIT_CLASS } from './guren-css'
 import { loadScaffoldTemplate } from './scaffold-templates'
 
 /** `path` is both the template path under `templates/scaffold/auth/` and the written app path. */
 function authFile(path: string): ScaffoldFileEntry {
   return { path, contents: loadScaffoldTemplate(`auth/${path}`) }
+}
+
+/** The page heading with the ember tick — the one structural device, once per
+    screen. `indent` is the emitted indentation of the `<h1>` line, so every
+    builder renders the identical block at its own depth. */
+function tickHeading(title: string, indent: string): string {
+  return `<h1 className="flex items-center gap-3 text-2xl font-bold text-g-heading">
+${indent}  <span aria-hidden className="h-6 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+${indent}  ${title}
+${indent}</h1>`
+}
+
+/** A flash/error message as a diagnostic row: mono key in a fixed gutter, a
+    hairline, ordinary body text — the shape of `guren check` output, no
+    tinted box. The tone doubles as the printed key. */
+function calloutRow(tone: 'ok' | 'error', body: string, indent: string, { flush = false } = {}): string {
+  const color = tone === 'ok' ? 'text-g-ok' : 'text-g-danger'
+  return `<p className="${flush ? '' : 'mt-4 '}flex gap-3 border-y border-g-line py-2.5 text-sm">
+${indent}  <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 ${color}">${tone}</span>
+${indent}  <span className="text-g-text">${body}</span>
+${indent}</p>`
 }
 
 // Passwordless apps keep show() (the OAuth button page) and destroy()
@@ -579,19 +600,13 @@ export default function Login({ errors = {} }: Props) {
     <Layout>
       <Head title="Sign in" />
       <section className="rounded-g-card border border-g-line bg-g-panel p-8 shadow-g-card">
-        <h1 className="flex items-center gap-3 text-2xl font-bold text-g-heading">
-          <span aria-hidden className="h-6 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
-          Sign in
-        </h1>
+        ${tickHeading('Sign in', '        ')}
         <p className="mt-2 text-sm text-g-text-2">
           Choose a provider to continue.
         </p>
 
         {errors.message && (
-          <p className="mt-4 flex gap-3 border-y border-g-line py-2.5 text-sm">
-            <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 text-g-danger">error</span>
-            <span className="text-g-text">{errors.message}</span>
-          </p>
+          ${calloutRow('error', '{errors.message}', '          ')}
         )}
 ${buildOAuthButtonsTemplate(providers, { divider: false })}
       </section>
@@ -654,19 +669,13 @@ export default function Login({ email = '', errors = {} }: Props) {
     <Layout>
       <Head title="Sign in" />
       <section className="rounded-g-card border border-g-line bg-g-panel p-8 shadow-g-card">
-        <h1 className="flex items-center gap-3 text-2xl font-bold text-g-heading">
-          <span aria-hidden className="h-6 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
-          Sign in
-        </h1>
+        ${tickHeading('Sign in', '        ')}
         <p className="mt-2 text-sm text-g-text-2">
           Use your account credentials to continue.
         </p>
 
         {errors.message && (
-          <p className="mt-4 flex gap-3 border-y border-g-line py-2.5 text-sm">
-            <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 text-g-danger">error</span>
-            <span className="text-g-text">{errors.message}</span>
-          </p>
+          ${calloutRow('error', '{errors.message}', '          ')}
         )}
 
         <form
@@ -677,7 +686,7 @@ export default function Login({ email = '', errors = {} }: Props) {
           }}
         >
           <div>
-            <label htmlFor={emailId} className="block text-sm font-bold text-g-heading">
+            <label htmlFor={emailId} className="${FIELD_LABEL_CLASS}">
               Email
             </label>
             <input
@@ -686,13 +695,13 @@ export default function Login({ email = '', errors = {} }: Props) {
               value={form.data.email}
               onChange={(event) => form.setData('email', event.target.value)}
               required
-              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
+              className="mt-1 ${FORM_INPUT_CLASS}"
             />
             {errors.email && <p className="mt-1 text-sm text-g-danger">{errors.email}</p>}
           </div>
 
           <div>
-            <label htmlFor={passwordId} className="block text-sm font-bold text-g-heading">
+            <label htmlFor={passwordId} className="${FIELD_LABEL_CLASS}">
               Password
             </label>
             <input
@@ -701,7 +710,7 @@ export default function Login({ email = '', errors = {} }: Props) {
               value={form.data.password}
               onChange={(event) => form.setData('password', event.target.value)}
               required
-              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
+              className="mt-1 ${FORM_INPUT_CLASS}"
             />
             {errors.password && <p className="mt-1 text-sm text-g-danger">{errors.password}</p>}
           </div>
@@ -719,7 +728,7 @@ export default function Login({ email = '', errors = {} }: Props) {
             <button
               type="submit"
               disabled={form.processing}
-              className="w-full rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down disabled:cursor-not-allowed disabled:opacity-45"
+              className="${PRIMARY_SUBMIT_CLASS}"
             >
               Sign in
           </button>
@@ -767,19 +776,13 @@ export default function Register({ errors = {} }: Props) {
     <Layout>
       <Head title="Sign up" />
       <section className="rounded-g-card border border-g-line bg-g-panel p-8 shadow-g-card">
-        <h1 className="flex items-center gap-3 text-2xl font-bold text-g-heading">
-          <span aria-hidden className="h-6 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
-          Create an account
-        </h1>
+        ${tickHeading('Create an account', '        ')}
         <p className="mt-2 text-sm text-g-text-2">
           Sign up to get started.
         </p>
 
         {errors.message && (
-          <p className="mt-4 flex gap-3 border-y border-g-line py-2.5 text-sm">
-            <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 text-g-danger">error</span>
-            <span className="text-g-text">{errors.message}</span>
-          </p>
+          ${calloutRow('error', '{errors.message}', '          ')}
         )}
 
         <form
@@ -790,7 +793,7 @@ export default function Register({ errors = {} }: Props) {
           }}
         >
           <div>
-            <label htmlFor={nameId} className="block text-sm font-bold text-g-heading">
+            <label htmlFor={nameId} className="${FIELD_LABEL_CLASS}">
               Name
             </label>
             <input
@@ -799,13 +802,13 @@ export default function Register({ errors = {} }: Props) {
               value={form.data.name}
               onChange={(event) => form.setData('name', event.target.value)}
               required
-              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
+              className="mt-1 ${FORM_INPUT_CLASS}"
             />
             {errors.name && <p className="mt-1 text-sm text-g-danger">{errors.name}</p>}
           </div>
 
           <div>
-            <label htmlFor={emailId} className="block text-sm font-bold text-g-heading">
+            <label htmlFor={emailId} className="${FIELD_LABEL_CLASS}">
               Email
             </label>
             <input
@@ -814,13 +817,13 @@ export default function Register({ errors = {} }: Props) {
               value={form.data.email}
               onChange={(event) => form.setData('email', event.target.value)}
               required
-              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
+              className="mt-1 ${FORM_INPUT_CLASS}"
             />
             {errors.email && <p className="mt-1 text-sm text-g-danger">{errors.email}</p>}
           </div>
 
           <div>
-            <label htmlFor={passwordId} className="block text-sm font-bold text-g-heading">
+            <label htmlFor={passwordId} className="${FIELD_LABEL_CLASS}">
               Password
             </label>
             <input
@@ -829,13 +832,13 @@ export default function Register({ errors = {} }: Props) {
               value={form.data.password}
               onChange={(event) => form.setData('password', event.target.value)}
               required
-              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
+              className="mt-1 ${FORM_INPUT_CLASS}"
             />
             {errors.password && <p className="mt-1 text-sm text-g-danger">{errors.password}</p>}
           </div>
 
           <div>
-            <label htmlFor={passwordConfirmationId} className="block text-sm font-bold text-g-heading">
+            <label htmlFor={passwordConfirmationId} className="${FIELD_LABEL_CLASS}">
               Confirm password
             </label>
             <input
@@ -844,7 +847,7 @@ export default function Register({ errors = {} }: Props) {
               value={form.data.passwordConfirmation}
               onChange={(event) => form.setData('passwordConfirmation', event.target.value)}
               required
-              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
+              className="mt-1 ${FORM_INPUT_CLASS}"
             />
             {errors.passwordConfirmation && (
               <p className="mt-1 text-sm text-g-danger">{errors.passwordConfirmation}</p>
@@ -854,7 +857,7 @@ export default function Register({ errors = {} }: Props) {
           <button
             type="submit"
             disabled={form.processing}
-            className="w-full rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down disabled:cursor-not-allowed disabled:opacity-45"
+            className="${PRIMARY_SUBMIT_CLASS}"
           >
             Create account
           </button>
@@ -892,7 +895,7 @@ function buildProfileViewTemplate({ includePassword, providerOwnedEmail }: AuthF
   const emailInput = providerOwnedEmail
     ? `
           <div>
-            <label className="block text-sm font-bold text-g-heading">Email</label>
+            <label className="${FIELD_LABEL_CLASS}">Email</label>
             <p className="mt-1 w-full rounded-g-ctl border border-g-line bg-g-raised px-3 py-2 text-g-muted">
               {profile.email}
             </p>
@@ -900,12 +903,12 @@ function buildProfileViewTemplate({ includePassword, providerOwnedEmail }: AuthF
           </div>`
     : `
           <div>
-            <label className="block text-sm font-bold text-g-heading">Email</label>
+            <label className="${FIELD_LABEL_CLASS}">Email</label>
             <input
               type="email"
               value={form.data.email}
               onChange={(event) => form.setData('email', event.target.value)}
-              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
+              className="mt-1 ${FORM_INPUT_CLASS}"
             />
             {form.errors.email ? <p className="mt-1 text-sm text-g-danger">{form.errors.email}</p> : null}
           </div>`
@@ -920,12 +923,12 @@ function buildProfileViewTemplate({ includePassword, providerOwnedEmail }: AuthF
   const passwordInput = includePassword
     ? `
           <div>
-            <label className="block text-sm font-bold text-g-heading">New password</label>
+            <label className="${FIELD_LABEL_CLASS}">New password</label>
             <input
               type="password"
               value={form.data.password}
               onChange={(event) => form.setData('password', event.target.value)}
-              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
+              className="mt-1 ${FORM_INPUT_CLASS}"
             />
             {form.errors.password ? <p className="mt-1 text-sm text-g-danger">{form.errors.password}</p> : null}
           </div>
@@ -965,28 +968,22 @@ export default function ProfileEdit({ profile, status }: Props) {
       <Head title="Profile" />
       <section className="space-y-6 rounded-g-card border border-g-line bg-g-panel p-8 shadow-g-card">
         <header>
-          <h1 className="flex items-center gap-3 text-2xl font-bold text-g-heading">
-            <span aria-hidden className="h-6 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
-            Profile
-          </h1>
+          ${tickHeading('Profile', '          ')}
           <p className="mt-2 text-sm text-g-text-2">${description}</p>
         </header>
 
         {status ? (
-          <p className="flex gap-3 border-y border-g-line py-2.5 text-sm">
-            <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 text-g-ok">ok</span>
-            <span className="text-g-text">{status}</span>
-          </p>
+          ${calloutRow('ok', '{status}', '          ', { flush: true })}
         ) : null}
 
         <form className="space-y-4" onSubmit={handleSubmit}>
           <div>
-            <label className="block text-sm font-bold text-g-heading">Name</label>
+            <label className="${FIELD_LABEL_CLASS}">Name</label>
             <input
               type="text"
               value={form.data.name}
               onChange={(event) => form.setData('name', event.target.value)}
-              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
+              className="mt-1 ${FORM_INPUT_CLASS}"
             />
             {form.errors.name ? <p className="mt-1 text-sm text-g-danger">{form.errors.name}</p> : null}
           </div>
@@ -995,7 +992,7 @@ ${passwordInput}
           <button
             type="submit"
             disabled={form.processing}
-            className="w-full rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down disabled:cursor-not-allowed disabled:opacity-45"
+            className="${PRIMARY_SUBMIT_CLASS}"
           >
             Save changes
           </button>

--- a/packages/cli/src/make-feature.ts
+++ b/packages/cli/src/make-feature.ts
@@ -7,7 +7,7 @@ import { makePolicy } from './make-policy'
 import { makeTest } from './make-test'
 import { makeValidator } from './make-validator'
 import { parseFieldsString, type FieldDefinition, type FieldType } from './fields'
-import { ensureGurenUiTokens } from './guren-css'
+import { ensureGurenUiTokens, FORM_INPUT_CLASS, PRIMARY_BUTTON_CLASS } from './guren-css'
 import { schemaPathFor } from './schema-parser'
 
 /**
@@ -448,7 +448,7 @@ export default function ${collection}Index({ data, pagination }: Props) {
             <span aria-hidden className="h-7 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
             ${collection}
           </h1>
-          <Link href={route('${routeName}.create')} className="rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down">New ${singular}</Link>
+          <Link href={route('${routeName}.create')} className="${PRIMARY_BUTTON_CLASS}">New ${singular}</Link>
         </div>
         <div className="space-y-4">
           {data.map((${variableName}) => (
@@ -549,7 +549,7 @@ ${state.hooks}  return (
       <div className="mx-auto max-w-3xl px-6 py-12">
         <form className="space-y-4" onSubmit={(submitEvent) => { submitEvent.preventDefault(); form.post(route('${routeName}.store')) }}>
 ${formFields}
-          <button type="submit" className="rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down">Create</button>
+          <button type="submit" className="${PRIMARY_BUTTON_CLASS}">Create</button>
         </form>
       </div>
     </main>
@@ -590,7 +590,7 @@ ${state.hooks}  return (
       <div className="mx-auto max-w-3xl px-6 py-12">
         <form className="space-y-4" onSubmit={(submitEvent) => { submitEvent.preventDefault(); form.put(route('${routeName}.update', { id: ${variableName}.id })) }}>
 ${formFields}
-          <button type="submit" className="rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down">Save</button>
+          <button type="submit" className="${PRIMARY_BUTTON_CLASS}">Save</button>
         </form>
       </div>
     </main>
@@ -598,9 +598,6 @@ ${formFields}
 }
 `
 }
-
-const FORM_INPUT_CLASS =
-  'w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent'
 
 function generateFormField(field: FieldDefinition, formVar: string): string {
   const value = formValue(field, formVar)

--- a/packages/cli/tests/guren-css-sync.test.ts
+++ b/packages/cli/tests/guren-css-sync.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'bun:test'
-import { readFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { ensureGurenUiTokens } from '../src/guren-css'
 
 const repoRoot = join(import.meta.dir, '../../..')
 
@@ -26,57 +28,79 @@ it('the scaffold guren.css matches the create-app template copy', async () => {
   expect(scaffold).toBe(blueprint)
 })
 
+async function makeApp(appCss?: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'guren-css-'))
+  await mkdir(join(root, 'resources/css'), { recursive: true })
+  if (appCss !== undefined) {
+    await writeFile(join(root, 'resources/css/app.css'), appCss, 'utf8')
+  }
+  return root
+}
+
 describe('ensureGurenUiTokens', () => {
   it('writes guren.css and adds the app.css import once', async () => {
-    const { mkdtemp, mkdir, readFile: read, writeFile } = await import('node:fs/promises')
-    const { tmpdir } = await import('node:os')
-    const { ensureGurenUiTokens } = await import('../src/guren-css')
-
-    const root = await mkdtemp(join(tmpdir(), 'guren-css-'))
-    await mkdir(join(root, 'resources/css'), { recursive: true })
-    await writeFile(join(root, 'resources/css/app.css'), "@import 'tailwindcss';\n", 'utf8')
+    const root = await makeApp("@import 'tailwindcss';\n")
 
     await ensureGurenUiTokens(root)
 
-    const tokens = await read(join(root, 'resources/css/guren.css'), 'utf8')
+    const tokens = await readFile(join(root, 'resources/css/guren.css'), 'utf8')
     expect(tokens).toContain('--g-accent')
-    const appCss = await read(join(root, 'resources/css/app.css'), 'utf8')
+    const appCss = await readFile(join(root, 'resources/css/app.css'), 'utf8')
     expect(appCss).toBe("@import 'tailwindcss';\n@import './guren.css';\n")
 
     // Second run must not duplicate the import or clobber an edited sheet.
     await writeFile(join(root, 'resources/css/guren.css'), '/* user edited */\n', 'utf8')
     await ensureGurenUiTokens(root)
-    expect(await read(join(root, 'resources/css/guren.css'), 'utf8')).toBe('/* user edited */\n')
-    expect(await read(join(root, 'resources/css/app.css'), 'utf8')).toBe(
+    expect(await readFile(join(root, 'resources/css/guren.css'), 'utf8')).toBe('/* user edited */\n')
+    expect(await readFile(join(root, 'resources/css/app.css'), 'utf8')).toBe(
       "@import 'tailwindcss';\n@import './guren.css';\n",
     )
   })
 
   it('prepends the import when app.css has no @import lines', async () => {
-    const { mkdtemp, mkdir, readFile: read, writeFile } = await import('node:fs/promises')
-    const { tmpdir } = await import('node:os')
-    const { ensureGurenUiTokens } = await import('../src/guren-css')
-
-    const root = await mkdtemp(join(tmpdir(), 'guren-css-'))
-    await mkdir(join(root, 'resources/css'), { recursive: true })
-    await writeFile(join(root, 'resources/css/app.css'), 'body { margin: 0; }\n', 'utf8')
+    const root = await makeApp('body { margin: 0; }\n')
 
     await ensureGurenUiTokens(root)
 
-    expect(await read(join(root, 'resources/css/app.css'), 'utf8')).toBe(
+    expect(await readFile(join(root, 'resources/css/app.css'), 'utf8')).toBe(
       "@import './guren.css';\nbody { margin: 0; }\n",
     )
   })
 
-  it('leaves a missing app.css alone but still writes the tokens', async () => {
-    const { mkdtemp, readFile: read } = await import('node:fs/promises')
-    const { tmpdir } = await import('node:os')
-    const { ensureGurenUiTokens } = await import('../src/guren-css')
-
-    const root = await mkdtemp(join(tmpdir(), 'guren-css-'))
+  it('keeps a multiline @import statement intact', async () => {
+    const root = await makeApp("@import url(\n  'tailwindcss'\n);\nbody { margin: 0; }\n")
 
     await ensureGurenUiTokens(root)
 
-    expect(await read(join(root, 'resources/css/guren.css'), 'utf8')).toContain('--g-accent')
+    expect(await readFile(join(root, 'resources/css/app.css'), 'utf8')).toBe(
+      "@import url(\n  'tailwindcss'\n);\n@import './guren.css';\nbody { margin: 0; }\n",
+    )
+  })
+
+  it('recognizes the import without the ./ prefix and does not duplicate it', async () => {
+    const before = "@import 'tailwindcss';\n@import 'guren.css';\n"
+    const root = await makeApp(before)
+
+    await ensureGurenUiTokens(root)
+
+    expect(await readFile(join(root, 'resources/css/app.css'), 'utf8')).toBe(before)
+  })
+
+  it('treats a commented-out guren.css import as absent', async () => {
+    const root = await makeApp("@import 'tailwindcss';\n/* @import './guren.css'; */\nbody { margin: 0; }\n")
+
+    await ensureGurenUiTokens(root)
+
+    expect(await readFile(join(root, 'resources/css/app.css'), 'utf8')).toBe(
+      "@import 'tailwindcss';\n@import './guren.css';\n/* @import './guren.css'; */\nbody { margin: 0; }\n",
+    )
+  })
+
+  it('leaves a missing app.css alone but still writes the tokens', async () => {
+    const root = await makeApp()
+
+    await ensureGurenUiTokens(root)
+
+    expect(await readFile(join(root, 'resources/css/guren.css'), 'utf8')).toContain('--g-accent')
   })
 })

--- a/packages/create-app/templates/blog/resources/js/components/Layout.tsx
+++ b/packages/create-app/templates/blog/resources/js/components/Layout.tsx
@@ -6,22 +6,22 @@ export default function Layout({ children }: PropsWithChildren) {
   const user = props.auth?.user
 
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100">
-      <header className="border-b border-slate-800 bg-slate-900/60 backdrop-blur">
+    <div className="min-h-screen bg-g-page font-sans text-g-text">
+      <header className="border-b border-g-line bg-g-panel">
         <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
-          <Link href="/" className="text-lg font-semibold text-emerald-300">
+          <Link href="/" className="text-lg font-bold text-g-heading">
             __APP_TITLE__
           </Link>
-          <nav className="flex items-center gap-4 text-sm text-slate-300">
-            <Link href="/posts" className="transition hover:text-emerald-200">
+          <nav className="flex items-center gap-4 text-sm text-g-text-2">
+            <Link href="/posts" className="transition hover:text-g-heading">
               Posts
             </Link>
             {user ? (
               <>
-                <Link href="/posts/create" className="transition hover:text-emerald-200">
+                <Link href="/posts/create" className="transition hover:text-g-heading">
                   Write
                 </Link>
-                <Link href="/dashboard" className="transition hover:text-emerald-200">
+                <Link href="/dashboard" className="transition hover:text-g-heading">
                   Dashboard
                 </Link>
                 {/* Inertia's Link posts through Axios, which copies the
@@ -32,7 +32,7 @@ export default function Layout({ children }: PropsWithChildren) {
                   href="/logout"
                   method="post"
                   as="button"
-                  className="rounded border border-emerald-500 px-3 py-1 text-emerald-200 transition hover:bg-emerald-500 hover:text-slate-950"
+                  className="rounded-g-ctl border border-g-line-strong px-3 py-1 text-g-text transition hover:border-g-muted"
                 >
                   Log out
                 </Link>
@@ -40,7 +40,7 @@ export default function Layout({ children }: PropsWithChildren) {
             ) : (
               <Link
                 href="/login"
-                className="rounded border border-emerald-500 px-3 py-1 text-emerald-200 transition hover:bg-emerald-500 hover:text-slate-950"
+                className="rounded-g-ctl border border-g-line-strong px-3 py-1 text-g-text transition hover:border-g-muted"
               >
                 Sign in
               </Link>

--- a/packages/create-app/templates/blog/resources/js/pages/Home.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/Home.tsx
@@ -12,37 +12,40 @@ export default function Home({ latest }: Props) {
       <Head title="__APP_TITLE__" />
       <section className="space-y-10">
         <header className="space-y-3">
-          <h1 className="text-4xl font-semibold tracking-tight text-emerald-300">__APP_TITLE__</h1>
-          <p className="text-slate-400">
+          <h1 className="flex items-center gap-4 text-4xl font-bold tracking-tight text-g-heading">
+            <span aria-hidden className="h-9 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+            __APP_TITLE__
+          </h1>
+          <p className="text-g-text-2">
             A blog built with Guren — controllers on the server, React pages over Inertia, one
-            codebase. Edit <code className="rounded bg-slate-900 px-1.5 py-0.5 text-sm text-emerald-200">resources/js/pages/Home.tsx</code>{' '}
+            codebase. Edit <code className="rounded bg-g-ink px-1.5 py-0.5 font-mono text-sm text-g-on-ink">resources/js/pages/Home.tsx</code>{' '}
             to make it yours.
           </p>
         </header>
 
         <div className="space-y-4">
           <div className="flex items-baseline justify-between">
-            <h2 className="text-xl font-medium text-slate-100">Latest posts</h2>
-            <Link href="/posts" className="text-sm text-emerald-300 transition hover:text-emerald-200">
+            <h2 className="text-xl font-bold text-g-heading">Latest posts</h2>
+            <Link href="/posts" className="text-sm text-g-accent-text transition hover:underline">
               All posts →
             </Link>
           </div>
 
           {latest.length === 0 ? (
-            <p className="rounded border border-slate-800 bg-slate-900/40 px-4 py-6 text-sm text-slate-400">
-              No posts yet. Run <code className="text-emerald-200">bun run db:seed</code> for sample content,
+            <p className="rounded-g-card border border-g-line bg-g-panel px-4 py-6 text-sm text-g-text-2">
+              No posts yet. Run <code className="font-mono text-g-accent-text">bun run db:seed</code> for sample content,
               or sign in and write the first one.
             </p>
           ) : (
             <ul className="space-y-4">
               {latest.map((post) => (
-                <li key={post.id} className="rounded-lg border border-slate-800 bg-slate-900/40 p-5">
-                  <Link href={`/posts/${post.id}`} className="text-lg font-medium text-slate-100 transition hover:text-emerald-200">
+                <li key={post.id} className="rounded-g-card border border-g-line bg-g-panel p-5 shadow-g-card">
+                  <Link href={`/posts/${post.id}`} className="text-lg font-bold text-g-heading transition hover:text-g-accent-text">
                     {post.title}
                   </Link>
-                  <p className="mt-2 text-sm text-slate-400">{post.excerpt}</p>
+                  <p className="mt-2 text-sm text-g-text-2">{post.excerpt}</p>
                   {post.author ? (
-                    <p className="mt-3 text-xs uppercase tracking-wide text-slate-500">by {post.author.name}</p>
+                    <p className="mt-3 font-mono text-xs uppercase tracking-wide text-g-muted">by {post.author.name}</p>
                   ) : null}
                 </li>
               ))}

--- a/packages/create-app/templates/blog/resources/js/pages/auth/Login.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/auth/Login.tsx
@@ -27,15 +27,19 @@ export default function Login({ email = '', errors = {} }: Props) {
   return (
     <Layout>
       <Head title="Sign in" />
-      <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-8 shadow-xl shadow-emerald-500/5">
-        <h1 className="text-2xl font-semibold text-emerald-300">Sign in</h1>
-        <p className="mt-2 text-sm text-slate-400">
+      <section className="rounded-g-card border border-g-line bg-g-panel p-8 shadow-g-card">
+        <h1 className="flex items-center gap-3 text-2xl font-bold text-g-heading">
+          <span aria-hidden className="h-6 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+          Sign in
+        </h1>
+        <p className="mt-2 text-sm text-g-text-2">
           Use your account credentials to continue.
         </p>
 
         {errors.message && (
-          <p className="mt-4 rounded border border-rose-500/60 bg-rose-500/10 px-4 py-2 text-sm text-rose-200">
-            {errors.message}
+          <p className="mt-4 flex gap-3 border-y border-g-line py-2.5 text-sm">
+            <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 text-g-danger">error</span>
+            <span className="text-g-text">{errors.message}</span>
           </p>
         )}
 
@@ -47,7 +51,7 @@ export default function Login({ email = '', errors = {} }: Props) {
           }}
         >
           <div>
-            <label htmlFor={emailId} className="block text-sm font-medium text-slate-200">
+            <label htmlFor={emailId} className="block text-sm font-bold text-g-heading">
               Email
             </label>
             <input
@@ -56,13 +60,13 @@ export default function Login({ email = '', errors = {} }: Props) {
               value={form.data.email}
               onChange={(event) => form.setData('email', event.target.value)}
               required
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {errors.email && <p className="mt-1 text-sm text-rose-300">{errors.email}</p>}
+            {errors.email && <p className="mt-1 text-sm text-g-danger">{errors.email}</p>}
           </div>
 
           <div>
-            <label htmlFor={passwordId} className="block text-sm font-medium text-slate-200">
+            <label htmlFor={passwordId} className="block text-sm font-bold text-g-heading">
               Password
             </label>
             <input
@@ -71,17 +75,17 @@ export default function Login({ email = '', errors = {} }: Props) {
               value={form.data.password}
               onChange={(event) => form.setData('password', event.target.value)}
               required
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {errors.password && <p className="mt-1 text-sm text-rose-300">{errors.password}</p>}
+            {errors.password && <p className="mt-1 text-sm text-g-danger">{errors.password}</p>}
           </div>
 
-          <label className="flex items-center gap-2 text-sm text-slate-300">
+          <label className="flex items-center gap-2 text-sm text-g-text">
             <input
               type="checkbox"
               checked={form.data.remember}
               onChange={(event) => form.setData('remember', event.target.checked)}
-              className="h-4 w-4 rounded border-slate-700 bg-slate-950 text-emerald-400 focus:ring-emerald-400"
+              className="h-4 w-4 rounded accent-g-accent"
             />
             Remember me
           </label>
@@ -89,16 +93,16 @@ export default function Login({ email = '', errors = {} }: Props) {
             <button
               type="submit"
               disabled={form.processing}
-              className="w-full rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400"
+              className="w-full rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down disabled:cursor-not-allowed disabled:opacity-45"
             >
               Sign in
           </button>
         </form>
 
 
-        <p className="mt-6 text-center text-sm text-slate-400">
+        <p className="mt-6 text-center text-sm text-g-text-2">
           Don&apos;t have an account?{' '}
-          <Link href="/register" className="text-emerald-300 transition hover:text-emerald-200">
+          <Link href="/register" className="text-g-accent-text transition hover:underline">
             Sign up
           </Link>
         </p>

--- a/packages/create-app/templates/blog/resources/js/pages/auth/Register.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/auth/Register.tsx
@@ -30,15 +30,19 @@ export default function Register({ errors = {} }: Props) {
   return (
     <Layout>
       <Head title="Sign up" />
-      <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-8 shadow-xl shadow-emerald-500/5">
-        <h1 className="text-2xl font-semibold text-emerald-300">Create an account</h1>
-        <p className="mt-2 text-sm text-slate-400">
+      <section className="rounded-g-card border border-g-line bg-g-panel p-8 shadow-g-card">
+        <h1 className="flex items-center gap-3 text-2xl font-bold text-g-heading">
+          <span aria-hidden className="h-6 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+          Create an account
+        </h1>
+        <p className="mt-2 text-sm text-g-text-2">
           Sign up to get started.
         </p>
 
         {errors.message && (
-          <p className="mt-4 rounded border border-rose-500/60 bg-rose-500/10 px-4 py-2 text-sm text-rose-200">
-            {errors.message}
+          <p className="mt-4 flex gap-3 border-y border-g-line py-2.5 text-sm">
+            <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 text-g-danger">error</span>
+            <span className="text-g-text">{errors.message}</span>
           </p>
         )}
 
@@ -50,7 +54,7 @@ export default function Register({ errors = {} }: Props) {
           }}
         >
           <div>
-            <label htmlFor={nameId} className="block text-sm font-medium text-slate-200">
+            <label htmlFor={nameId} className="block text-sm font-bold text-g-heading">
               Name
             </label>
             <input
@@ -59,13 +63,13 @@ export default function Register({ errors = {} }: Props) {
               value={form.data.name}
               onChange={(event) => form.setData('name', event.target.value)}
               required
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {errors.name && <p className="mt-1 text-sm text-rose-300">{errors.name}</p>}
+            {errors.name && <p className="mt-1 text-sm text-g-danger">{errors.name}</p>}
           </div>
 
           <div>
-            <label htmlFor={emailId} className="block text-sm font-medium text-slate-200">
+            <label htmlFor={emailId} className="block text-sm font-bold text-g-heading">
               Email
             </label>
             <input
@@ -74,13 +78,13 @@ export default function Register({ errors = {} }: Props) {
               value={form.data.email}
               onChange={(event) => form.setData('email', event.target.value)}
               required
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {errors.email && <p className="mt-1 text-sm text-rose-300">{errors.email}</p>}
+            {errors.email && <p className="mt-1 text-sm text-g-danger">{errors.email}</p>}
           </div>
 
           <div>
-            <label htmlFor={passwordId} className="block text-sm font-medium text-slate-200">
+            <label htmlFor={passwordId} className="block text-sm font-bold text-g-heading">
               Password
             </label>
             <input
@@ -89,13 +93,13 @@ export default function Register({ errors = {} }: Props) {
               value={form.data.password}
               onChange={(event) => form.setData('password', event.target.value)}
               required
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {errors.password && <p className="mt-1 text-sm text-rose-300">{errors.password}</p>}
+            {errors.password && <p className="mt-1 text-sm text-g-danger">{errors.password}</p>}
           </div>
 
           <div>
-            <label htmlFor={passwordConfirmationId} className="block text-sm font-medium text-slate-200">
+            <label htmlFor={passwordConfirmationId} className="block text-sm font-bold text-g-heading">
               Confirm password
             </label>
             <input
@@ -104,25 +108,25 @@ export default function Register({ errors = {} }: Props) {
               value={form.data.passwordConfirmation}
               onChange={(event) => form.setData('passwordConfirmation', event.target.value)}
               required
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
             {errors.passwordConfirmation && (
-              <p className="mt-1 text-sm text-rose-300">{errors.passwordConfirmation}</p>
+              <p className="mt-1 text-sm text-g-danger">{errors.passwordConfirmation}</p>
             )}
           </div>
 
           <button
             type="submit"
             disabled={form.processing}
-            className="w-full rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+            className="w-full rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down disabled:cursor-not-allowed disabled:opacity-45"
           >
             Create account
           </button>
         </form>
 
-        <p className="mt-6 text-center text-sm text-slate-400">
+        <p className="mt-6 text-center text-sm text-g-text-2">
           Already have an account?{' '}
-          <Link href="/login" className="text-emerald-300 transition hover:text-emerald-200">
+          <Link href="/login" className="text-g-accent-text transition hover:underline">
             Sign in
           </Link>
         </p>

--- a/packages/create-app/templates/blog/resources/js/pages/posts/Edit.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/posts/Edit.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 const fieldClass =
-  'mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring'
+  'mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent'
 
 export default function EditPost({ post }: Props) {
   const form = useForm<PostFormData>({
@@ -23,7 +23,10 @@ export default function EditPost({ post }: Props) {
     <Layout>
       <Head title={`Edit ${post.title}`} />
       <section className="space-y-6">
-        <h1 className="text-3xl font-semibold text-emerald-300">Edit post</h1>
+        <h1 className="flex items-center gap-3 text-3xl font-bold text-g-heading">
+          <span aria-hidden className="h-7 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+          Edit post
+        </h1>
 
         <form
           className="space-y-4"
@@ -33,42 +36,42 @@ export default function EditPost({ post }: Props) {
           }}
         >
           <div>
-            <label className="block text-sm font-medium text-slate-200">Title</label>
+            <label className="block text-sm font-bold text-g-heading">Title</label>
             <input
               type="text"
               value={form.data.title}
               onChange={(event) => form.setData('title', event.target.value)}
               className={fieldClass}
             />
-            {form.errors.title ? <p className="mt-1 text-sm text-rose-300">{form.errors.title}</p> : null}
+            {form.errors.title ? <p className="mt-1 text-sm text-g-danger">{form.errors.title}</p> : null}
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-200">Excerpt</label>
+            <label className="block text-sm font-bold text-g-heading">Excerpt</label>
             <input
               type="text"
               value={form.data.excerpt}
               onChange={(event) => form.setData('excerpt', event.target.value)}
               className={fieldClass}
             />
-            {form.errors.excerpt ? <p className="mt-1 text-sm text-rose-300">{form.errors.excerpt}</p> : null}
+            {form.errors.excerpt ? <p className="mt-1 text-sm text-g-danger">{form.errors.excerpt}</p> : null}
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-200">Body</label>
+            <label className="block text-sm font-bold text-g-heading">Body</label>
             <textarea
               rows={10}
               value={form.data.body}
               onChange={(event) => form.setData('body', event.target.value)}
               className={fieldClass}
             />
-            {form.errors.body ? <p className="mt-1 text-sm text-rose-300">{form.errors.body}</p> : null}
+            {form.errors.body ? <p className="mt-1 text-sm text-g-danger">{form.errors.body}</p> : null}
           </div>
 
           <button
             type="submit"
             disabled={form.processing}
-            className="rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+            className="rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down disabled:cursor-not-allowed disabled:opacity-45"
           >
             Save changes
           </button>

--- a/packages/create-app/templates/blog/resources/js/pages/posts/Index.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/posts/Index.tsx
@@ -54,7 +54,10 @@ export default function PostsIndex({ data, pagination }: Props) {
     <Layout>
       <Head title="Posts" />
       <section className="space-y-6">
-        <h1 className="text-3xl font-semibold text-emerald-300">Posts</h1>
+        <h1 className="flex items-center gap-3 text-3xl font-bold text-g-heading">
+          <span aria-hidden className="h-7 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+          Posts
+        </h1>
 
         <form className="flex gap-2" onSubmit={search}>
           <input
@@ -62,21 +65,21 @@ export default function PostsIndex({ data, pagination }: Props) {
             value={keywords}
             onChange={(event) => setKeywords(event.target.value)}
             placeholder="Search posts…"
-            className="w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+            className="w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
           />
           <button
             type="submit"
             disabled={searching}
-            className="rounded border border-emerald-500 px-4 py-2 text-sm text-emerald-200 transition hover:bg-emerald-500/10 disabled:opacity-50"
+            className="rounded-g-ctl border border-g-line-strong bg-g-panel px-4 py-2 text-sm font-bold text-g-text transition hover:border-g-muted disabled:cursor-not-allowed disabled:opacity-45"
           >
             Search
           </button>
         </form>
 
-        {error !== null && <p className="text-sm text-rose-400">{error}</p>}
+        {error !== null && <p className="text-sm text-g-danger">{error}</p>}
 
         {results !== null && (
-          <p className="text-sm text-slate-400">
+          <p className="text-sm text-g-text-2">
             {results.length} {results.length === 1 ? 'result' : 'results'} ·{' '}
             <button
               type="button"
@@ -85,7 +88,7 @@ export default function PostsIndex({ data, pagination }: Props) {
                 setResults(null)
                 setError(null)
               }}
-              className="text-emerald-300 transition hover:text-emerald-200"
+              className="text-g-accent-text transition hover:underline"
             >
               Clear
             </button>
@@ -94,28 +97,28 @@ export default function PostsIndex({ data, pagination }: Props) {
 
         <div className="space-y-4">
           {posts.map((post) => (
-            <article key={post.id} className="rounded-lg border border-slate-800 bg-slate-900/40 p-5">
+            <article key={post.id} className="rounded-g-card border border-g-line bg-g-panel p-5 shadow-g-card">
               <Link
                 href={route('posts.show', { id: post.id })}
-                className="text-lg font-medium text-slate-100 transition hover:text-emerald-200"
+                className="text-lg font-bold text-g-heading transition hover:text-g-accent-text"
               >
                 {post.title}
               </Link>
-              <p className="mt-2 text-sm text-slate-400">{post.excerpt}</p>
+              <p className="mt-2 text-sm text-g-text-2">{post.excerpt}</p>
               {post.author ? (
-                <p className="mt-3 text-xs uppercase tracking-wide text-slate-500">by {post.author.name}</p>
+                <p className="mt-3 font-mono text-xs uppercase tracking-wide text-g-muted">by {post.author.name}</p>
               ) : null}
             </article>
           ))}
         </div>
 
         {results === null && pagination?.links?.pages && (
-          <nav className="flex gap-2">
+          <nav className="flex gap-2 font-mono text-sm">
             {pagination.links.pages.map((page) => (
               <Link
                 key={page.page}
                 href={page.url ?? '#'}
-                className="rounded border border-slate-800 px-3 py-1 text-sm text-slate-300 transition hover:border-emerald-500 hover:text-emerald-200"
+                className="rounded-g-ctl border border-g-line px-3 py-1 text-g-text-2 transition hover:border-g-line-strong hover:text-g-heading"
               >
                 {page.page}
               </Link>

--- a/packages/create-app/templates/blog/resources/js/pages/posts/New.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/posts/New.tsx
@@ -6,7 +6,7 @@ import Layout from '../../components/Layout.js'
 type PostFormData = ApiRoutes['posts.store']['body']
 
 const fieldClass =
-  'mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring'
+  'mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent'
 
 export default function NewPost() {
   const form = useForm<PostFormData>({ title: '', excerpt: '', body: '' })
@@ -15,7 +15,10 @@ export default function NewPost() {
     <Layout>
       <Head title="New post" />
       <section className="space-y-6">
-        <h1 className="text-3xl font-semibold text-emerald-300">New post</h1>
+        <h1 className="flex items-center gap-3 text-3xl font-bold text-g-heading">
+          <span aria-hidden className="h-7 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+          New post
+        </h1>
 
         <form
           className="space-y-4"
@@ -25,42 +28,42 @@ export default function NewPost() {
           }}
         >
           <div>
-            <label className="block text-sm font-medium text-slate-200">Title</label>
+            <label className="block text-sm font-bold text-g-heading">Title</label>
             <input
               type="text"
               value={form.data.title}
               onChange={(event) => form.setData('title', event.target.value)}
               className={fieldClass}
             />
-            {form.errors.title ? <p className="mt-1 text-sm text-rose-300">{form.errors.title}</p> : null}
+            {form.errors.title ? <p className="mt-1 text-sm text-g-danger">{form.errors.title}</p> : null}
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-200">Excerpt</label>
+            <label className="block text-sm font-bold text-g-heading">Excerpt</label>
             <input
               type="text"
               value={form.data.excerpt}
               onChange={(event) => form.setData('excerpt', event.target.value)}
               className={fieldClass}
             />
-            {form.errors.excerpt ? <p className="mt-1 text-sm text-rose-300">{form.errors.excerpt}</p> : null}
+            {form.errors.excerpt ? <p className="mt-1 text-sm text-g-danger">{form.errors.excerpt}</p> : null}
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-200">Body</label>
+            <label className="block text-sm font-bold text-g-heading">Body</label>
             <textarea
               rows={10}
               value={form.data.body}
               onChange={(event) => form.setData('body', event.target.value)}
               className={fieldClass}
             />
-            {form.errors.body ? <p className="mt-1 text-sm text-rose-300">{form.errors.body}</p> : null}
+            {form.errors.body ? <p className="mt-1 text-sm text-g-danger">{form.errors.body}</p> : null}
           </div>
 
           <button
             type="submit"
             disabled={form.processing}
-            className="rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+            className="rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down disabled:cursor-not-allowed disabled:opacity-45"
           >
             Publish
           </button>

--- a/packages/create-app/templates/blog/resources/js/pages/posts/Show.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/posts/Show.tsx
@@ -18,23 +18,26 @@ export default function PostShow({ post }: Props) {
       <Head title={post.title} />
       <article className="space-y-6">
         <header className="space-y-2">
-          <h1 className="text-3xl font-semibold text-emerald-300">{post.title}</h1>
-          <p className="text-sm text-slate-500">
+          <h1 className="flex items-center gap-3 text-3xl font-bold text-g-heading">
+            <span aria-hidden className="h-7 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+            {post.title}
+          </h1>
+          <p className="text-sm text-g-muted">
             {post.author ? `by ${post.author.name} · ` : ''}
             {new Date(post.createdAt).toLocaleDateString()}
           </p>
-          <p className="text-slate-400">{post.excerpt}</p>
+          <p className="text-g-text-2">{post.excerpt}</p>
         </header>
 
-        <div className="whitespace-pre-wrap text-slate-200">{post.body}</div>
+        <div className="whitespace-pre-wrap text-g-text">{post.body}</div>
 
-        <footer className="flex gap-4 border-t border-slate-800 pt-6 text-sm">
-          <Link href={route('posts.index')} className="text-slate-300 transition hover:text-emerald-200">
+        <footer className="flex items-center gap-4 border-t border-g-line pt-6 text-sm">
+          <Link href={route('posts.index')} className="text-g-text-2 transition hover:text-g-heading">
             ← All posts
           </Link>
           {canManage ? (
             <>
-              <Link href={route('posts.edit', { id: post.id })} className="text-emerald-300 transition hover:text-emerald-200">
+              <Link href={route('posts.edit', { id: post.id })} className="text-g-accent-text transition hover:underline">
                 Edit
               </Link>
               <Link
@@ -42,7 +45,7 @@ export default function PostShow({ post }: Props) {
                 method="delete"
                 as="button"
                 onBefore={() => window.confirm('Delete this post?')}
-                className="text-rose-400 transition hover:text-rose-300"
+                className="rounded-g-ctl border border-g-danger-chip px-3 py-1 font-bold text-g-danger transition hover:bg-g-danger-tint"
               >
                 Delete
               </Link>

--- a/packages/create-app/templates/blog/resources/js/pages/profile/Edit.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/profile/Edit.tsx
@@ -30,56 +30,60 @@ export default function ProfileEdit({ profile, status }: Props) {
   return (
     <Layout>
       <Head title="Profile" />
-      <section className="space-y-6 rounded-lg border border-slate-800 bg-slate-900/40 p-8 shadow-xl shadow-emerald-500/5">
+      <section className="space-y-6 rounded-g-card border border-g-line bg-g-panel p-8 shadow-g-card">
         <header>
-          <h1 className="text-2xl font-semibold text-emerald-300">Profile</h1>
-          <p className="mt-2 text-sm text-slate-400">Update your account details and password.</p>
+          <h1 className="flex items-center gap-3 text-2xl font-bold text-g-heading">
+            <span aria-hidden className="h-6 w-[3px] shrink-0 rounded-full bg-[image:var(--g-tick)]" />
+            Profile
+          </h1>
+          <p className="mt-2 text-sm text-g-text-2">Update your account details and password.</p>
         </header>
 
         {status ? (
-          <p className="rounded border border-emerald-500/40 bg-emerald-500/10 px-4 py-2 text-sm text-emerald-200">
-            {status}
+          <p className="flex gap-3 border-y border-g-line py-2.5 text-sm">
+            <span className="w-10 shrink-0 text-right font-mono text-xs font-bold leading-5 text-g-ok">ok</span>
+            <span className="text-g-text">{status}</span>
           </p>
         ) : null}
 
         <form className="space-y-4" onSubmit={handleSubmit}>
           <div>
-            <label className="block text-sm font-medium text-slate-200">Name</label>
+            <label className="block text-sm font-bold text-g-heading">Name</label>
             <input
               type="text"
               value={form.data.name}
               onChange={(event) => form.setData('name', event.target.value)}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {form.errors.name ? <p className="mt-1 text-sm text-rose-300">{form.errors.name}</p> : null}
+            {form.errors.name ? <p className="mt-1 text-sm text-g-danger">{form.errors.name}</p> : null}
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-200">Email</label>
+            <label className="block text-sm font-bold text-g-heading">Email</label>
             <input
               type="email"
               value={form.data.email}
               onChange={(event) => form.setData('email', event.target.value)}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {form.errors.email ? <p className="mt-1 text-sm text-rose-300">{form.errors.email}</p> : null}
+            {form.errors.email ? <p className="mt-1 text-sm text-g-danger">{form.errors.email}</p> : null}
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-200">New password</label>
+            <label className="block text-sm font-bold text-g-heading">New password</label>
             <input
               type="password"
               value={form.data.password}
               onChange={(event) => form.setData('password', event.target.value)}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 outline-none ring-emerald-400 transition focus:border-emerald-400 focus:ring"
+              className="mt-1 w-full rounded-g-ctl border border-g-line-strong bg-g-panel px-3 py-2 text-g-text transition outline-none placeholder:text-g-muted focus:border-transparent focus:outline-2 focus:-outline-offset-1 focus:outline-g-accent"
             />
-            {form.errors.password ? <p className="mt-1 text-sm text-rose-300">{form.errors.password}</p> : null}
+            {form.errors.password ? <p className="mt-1 text-sm text-g-danger">{form.errors.password}</p> : null}
           </div>
 
           <button
             type="submit"
             disabled={form.processing}
-            className="w-full rounded bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+            className="w-full rounded-g-ctl bg-g-accent px-4 py-2 text-sm font-bold text-g-on-accent transition hover:bg-g-accent-down disabled:cursor-not-allowed disabled:opacity-45"
           >
             Save changes
           </button>

--- a/packages/create-app/tests/template-tsx-parse.test.ts
+++ b/packages/create-app/tests/template-tsx-parse.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, test } from 'bun:test'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+/**
+ * Every blueprint .tsx must at least parse. The templates are excluded from
+ * all typecheck projects (they resolve `@guren/*` from npm — see
+ * common-pitfalls), and the blueprint tests assert selected strings, so
+ * before this gate a syntax error in a template page only surfaced in the
+ * multi-minute starter smokes.
+ */
+const templatesRoot = join(import.meta.dir, '../templates')
+
+function collectTsx(dir: string): string[] {
+  const found: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) found.push(...collectTsx(path))
+    else if (entry.name.endsWith('.tsx')) found.push(path)
+  }
+  return found
+}
+
+const transpiler = new Bun.Transpiler({ loader: 'tsx' })
+
+test('the parser actually rejects broken TSX', () => {
+  expect(() => transpiler.transformSync('const <nonsense')).toThrow()
+})
+
+describe('blueprint template pages parse as TSX', () => {
+  const files = collectTsx(templatesRoot)
+
+  test('finds template TSX files', () => {
+    expect(files.length).toBeGreaterThan(10)
+  })
+
+  it.each(files.map((file) => [relative(templatesRoot, file)] as const))('%s', (rel) => {
+    const source = readFileSync(join(templatesRoot, rel), 'utf8')
+    expect(() => transpiler.transformSync(source)).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

Third and final step of adopting the Guren UI design system in scaffolded apps (stacked on #549; #547 shipped the tokens, #549 restyled the generators).

Every page of the blog blueprint moves from the slate + emerald look to the token language the restyled `make:auth` / `make:feature` generators now emit — the blueprint was originally derived from their output and moves with them:

- guren.dev light/dark themes through the tokens alone (the blueprint inherits `guren.css` from the default template layer; no `dark:` variants in markup)
- one crimson fill per screen (Sign in / Publish / Save — the primary action), the ember tick on page titles
- flash and error messages as diagnostic rows, mono uppercase kickers for bylines
- the destructive post delete becomes an outline + explicit verb behind the existing `window.confirm`
- `dashboard/Index.tsx` was already moved in #549 as the pinned lockstep pair

`examples/blog` (the dogfood app) is deliberately out of scope, per the sync test's policy.

## Verification

- `bun run test:bun create-app cli` — 1760 pass (includes the scaffold-blog-sync lockstep pins)
- `bun run smoke:starter:blog` — exit 0 (real scaffold: install, typecheck, build)
- `audit:starter-template`, `audit:core-first` — pass
- Rendered Home, posts Index, and Login in a Vite + Tailwind v4 sandbox and verified light/dark visually

## Merge order

#549 first, then retarget this PR to `main` **before** deleting `claude/guren-ui-scaffolds` (a deleted base auto-closes the stacked PR, as happened to #548).