### PR TITLE
feat(cli): add make:feature --attach for attachment-aware scaffolds

### DIFF
--- a/.changeset/make-feature-attach.md
+++ b/.changeset/make-feature-attach.md
@@ -1,0 +1,13 @@
+---
+'@guren/cli': minor
+---
+
+Add `guren make:feature --attach "cover:one,images:many"` (RFC 0013 Part 4):
+wraps the generated model in the `Attachable` mixin (`hasOneAttached` /
+`hasManyAttached` with `image: 'require'`), wires the store action to read
+uploads via `this.file()` / `this.files()` and `Model.attach()`, and makes
+the destroy action call `Model.purgeAttachments()` before deleting the row —
+deletion is explicit because the polymorphic attachment rows carry no foreign
+key. The flag is refused, with guidance to run `guren add attachments` first,
+when the app has no `configureAttachments()`. `guren add resource` passes
+`--attach` through.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,7 @@ bunx guren make:feature Post --fields "title:string,body:text,published:boolean"
 bunx guren make:feature Post --fields "title:string,body:text" --test  # With test file
 bunx guren make:feature Post --fields "title:string" --public  # Skip auth checks in mutating actions
 bunx guren make:feature Post --fields "title:string" --policy  # Also generate a policy and enforce it in store/update
+bunx guren make:feature Post --fields "title:string" --attach "cover:one,images:many"  # Attachable model + attach-aware store/destroy (requires `guren add attachments` first; RFC 0013 Part 4)
 bunx guren make:policy Post     # Authorization policy scaffold (app/Policies)
 bunx guren make:validator Post --fields "title:string,body:text"  # Zod schemas (route params, list query, payload) in app/Http/Validators
 bunx guren make:adr "Billing cycle is end-of-month"  # Numbered ADR under docs/adr with linkable frontmatter (entities/related)

--- a/docs/en/guides/attachments.md
+++ b/docs/en/guides/attachments.md
@@ -173,8 +173,11 @@ for non-image uploads — the store action reads matching multipart fields via
 action calls `Post.purgeAttachments()` before deleting the row. The command
 refuses to scaffold when the app has no `configureAttachments()`; run
 `bunx guren add attachments` first. Add `<input type="file">` fields to the
-generated New/Edit pages yourself — Inertia's `useForm` switches to a
-multipart POST automatically when the form data contains a `File`.
+generated New page yourself — Inertia's `useForm` switches to a multipart
+POST automatically when the form data contains a `File`. The generated
+`update()` does not touch attachments; to accept uploads from the Edit page
+too, add the same `this.file()` + `Post.attach()` lines there (`hasOne`
+replaces, `hasMany` appends).
 
 ## Working with attachments
 

--- a/docs/en/guides/attachments.md
+++ b/docs/en/guides/attachments.md
@@ -156,6 +156,26 @@ Additional options:
 | `queue` | — | The app's QueueManager, resolved lazily; enables `attach(..., { queued: true })`. |
 | `urlExpiresIn` | 5 minutes | Lifetime of `temporaryUrl()` links for private disks. |
 
+### Scaffolding a feature with attachments
+
+Once the layer is installed, `make:feature` (and `guren add resource`) can
+scaffold a whole attachment-aware feature:
+
+```bash
+bunx guren make:feature Post --fields "title:string,body:text" --attach "cover:one,images:many"
+```
+
+`--attach` takes comma-separated `name:kind` pairs (`one` or `many`; the kind
+defaults to `one`). The generated model is wrapped in the `Attachable` mixin
+with `image: 'require'` on every collection — drop that option per collection
+for non-image uploads — the store action reads matching multipart fields via
+`this.file()` / `this.files()` and calls `Post.attach()`, and the destroy
+action calls `Post.purgeAttachments()` before deleting the row. The command
+refuses to scaffold when the app has no `configureAttachments()`; run
+`bunx guren add attachments` first. Add `<input type="file">` fields to the
+generated New/Edit pages yourself — Inertia's `useForm` switches to a
+multipart POST automatically when the form data contains a `File`.
+
 ## Working with attachments
 
 All statics are typed against the declaration — a typo in a collection name

--- a/docs/ja/guides/attachments.md
+++ b/docs/ja/guides/attachments.md
@@ -139,6 +139,28 @@ export const { Attachment } = configureAttachments({
 | `queue` | なし | アプリの QueueManager を遅延解決で渡す。`attach(..., { queued: true })` を有効化。 |
 | `urlExpiresIn` | 5分 | private ディスクの `temporaryUrl()` リンクの有効期間。 |
 
+### アタッチメント付きフィーチャーのスキャフォールド
+
+レイヤーの導入後は、`make:feature`（および `guren add resource`）で
+アタッチメント対応のフィーチャー一式をスキャフォールドできます:
+
+```bash
+bunx guren make:feature Post --fields "title:string,body:text" --attach "cover:one,images:many"
+```
+
+`--attach` はカンマ区切りの `name:kind` ペア（`one` または `many`、省略時は
+`one`）を受け取ります。生成されるモデルは各コレクションに
+`image: 'require'` を付けた `Attachable` ミックスインでラップされ（画像以外の
+アップロードにはコレクションごとにこのオプションを外してください）、store
+アクションは同名の multipart フィールドを `this.file()` / `this.files()` で
+読んで `Post.attach()` を呼び、destroy アクションは行の削除前に
+`Post.purgeAttachments()` を呼びます。アプリに `configureAttachments()` が
+ない場合、このコマンドはスキャフォールドを拒否します。先に
+`bunx guren add attachments` を実行してください。生成された New/Edit
+ページへの `<input type="file">` の追加は手動で行います（Inertia の
+`useForm` はフォームデータに `File` が含まれると自動的に multipart POST に
+切り替わります）。
+
 ## アタッチメントの操作
 
 すべての static メソッドは宣言に対して型付けされます。コレクション名やバリアント名の打ち間違いは実行時の事故ではなくコンパイルエラーになります。

--- a/docs/ja/guides/attachments.md
+++ b/docs/ja/guides/attachments.md
@@ -156,10 +156,13 @@ bunx guren make:feature Post --fields "title:string,body:text" --attach "cover:o
 読んで `Post.attach()` を呼び、destroy アクションは行の削除前に
 `Post.purgeAttachments()` を呼びます。アプリに `configureAttachments()` が
 ない場合、このコマンドはスキャフォールドを拒否します。先に
-`bunx guren add attachments` を実行してください。生成された New/Edit
+`bunx guren add attachments` を実行してください。生成された New
 ページへの `<input type="file">` の追加は手動で行います（Inertia の
 `useForm` はフォームデータに `File` が含まれると自動的に multipart POST に
-切り替わります）。
+切り替わります）。生成された `update()` はアタッチメントに触れません。
+Edit ページからのアップロードも受け付けるには、同じ `this.file()` と
+`Post.attach()` の行を `update()` にも追加してください（`hasOne` は置換、
+`hasMany` は追加になります）。
 
 ## アタッチメントの操作
 

--- a/packages/cli/src/attachments-check.ts
+++ b/packages/cli/src/attachments-check.ts
@@ -3,7 +3,7 @@ import type { CallExpression } from '@babel/types'
 import { walk } from './ast-walk'
 import { check, type CheckResult } from './check-result'
 import { collectFiles, listAppRoots } from './discovery'
-import type { ParseCache } from './parse-cache'
+import type { ParseCache, ParsedFile } from './parse-cache'
 import { schemaPathFor, type SchemaTable } from './schema-parser'
 
 /**
@@ -53,6 +53,50 @@ function schemaModuleFor(cwd: string, filePath: string, specifier: string): stri
   return undefined
 }
 
+interface AttachmentsImportScan {
+  /** The local binding `configureAttachments` (from `@guren/core`) is bound to, or null. */
+  configureLocal: string | null
+  /**
+   * Local binding -> { where it came from, the *exported* name it aliases }.
+   * The schema declares exported names, so an `import { attachments as att }`
+   * must be judged by 'attachments', never by 'att'. Default and namespace
+   * imports have no single exported name to judge against; recorded with an
+   * empty `imported` so provenance tests can skip them.
+   */
+  importsByLocal: Map<string, { source: string; imported: string }>
+}
+
+/**
+ * One reading of a file's imports for both consumers in this file. The
+ * scaffolder preflight below and the `guren check` rule underneath judge
+ * "does this file wire the attachments layer" through this single scan —
+ * a second copy is how the two would start disagreeing about the same app
+ * (`guren check` green while `make:feature --attach` refuses, or worse).
+ */
+function scanAttachmentsImports(parsed: ParsedFile): AttachmentsImportScan {
+  let configureLocal: string | null = null
+  const importsByLocal = new Map<string, { source: string; imported: string }>()
+  for (const declaration of parsed.ast.program.body) {
+    if (declaration.type !== 'ImportDeclaration') continue
+    for (const specifier of declaration.specifiers) {
+      if (specifier.type === 'ImportSpecifier') {
+        const imported =
+          specifier.imported.type === 'Identifier' ? specifier.imported.name : specifier.imported.value
+        if (imported === 'configureAttachments' && declaration.source.value === '@guren/core') {
+          configureLocal = specifier.local.name
+        }
+        importsByLocal.set(specifier.local.name, { source: declaration.source.value, imported })
+      } else {
+        importsByLocal.set(specifier.local.name, {
+          source: declaration.source.value,
+          imported: '',
+        })
+      }
+    }
+  }
+  return { configureLocal, importsByLocal }
+}
+
 /**
  * Whether the app (or one of its modules) wires the attachments layer: a
  * `configureAttachments` imported from `@guren/core` that is actually called.
@@ -72,16 +116,7 @@ export async function appConfiguresAttachments(appRoot: string, cache: ParseCach
     const parsed = await cache.get(filePath)
     if (!parsed) continue
 
-    let configureLocal: string | null = null
-    for (const declaration of parsed.ast.program.body) {
-      if (declaration.type !== 'ImportDeclaration' || declaration.source.value !== '@guren/core') continue
-      for (const specifier of declaration.specifiers) {
-        if (specifier.type !== 'ImportSpecifier') continue
-        const imported =
-          specifier.imported.type === 'Identifier' ? specifier.imported.name : specifier.imported.value
-        if (imported === 'configureAttachments') configureLocal = specifier.local.name
-      }
-    }
+    const { configureLocal } = scanAttachmentsImports(parsed)
     if (!configureLocal) continue
 
     let called = false
@@ -131,31 +166,7 @@ export async function checkAttachmentsConfig(options: {
     // The local name configureAttachments is bound to, and where each
     // imported identifier came from — the table's provenance is what makes
     // the check honest.
-    let configureLocal: string | null = null
-    // Local binding -> { where it came from, the *exported* name it aliases }.
-    // The schema declares exported names, so an `import { attachments as att }`
-    // must be judged by 'attachments', never by 'att'.
-    const importsByLocal = new Map<string, { source: string; imported: string }>()
-    for (const declaration of parsed.ast.program.body) {
-      if (declaration.type !== 'ImportDeclaration') continue
-      for (const specifier of declaration.specifiers) {
-        if (specifier.type === 'ImportSpecifier') {
-          const imported =
-            specifier.imported.type === 'Identifier' ? specifier.imported.name : specifier.imported.value
-          if (imported === 'configureAttachments' && declaration.source.value === '@guren/core') {
-            configureLocal = specifier.local.name
-          }
-          importsByLocal.set(specifier.local.name, { source: declaration.source.value, imported })
-        } else {
-          // Default and namespace imports have no single exported name to
-          // judge against; recorded so the provenance test below can skip.
-          importsByLocal.set(specifier.local.name, {
-            source: declaration.source.value,
-            imported: '',
-          })
-        }
-      }
-    }
+    const { configureLocal, importsByLocal } = scanAttachmentsImports(parsed)
     if (!configureLocal) continue
 
     const relPath = relative(cwd, filePath)

--- a/packages/cli/src/attachments-check.ts
+++ b/packages/cli/src/attachments-check.ts
@@ -54,6 +54,48 @@ function schemaModuleFor(cwd: string, filePath: string, specifier: string): stri
 }
 
 /**
+ * Whether the app (or one of its modules) wires the attachments layer: a
+ * `configureAttachments` imported from `@guren/core` that is actually called.
+ *
+ * For scaffolders (`make:feature --attach`) that would otherwise emit models
+ * whose `Attachable` statics all throw at first use — the guidance to run
+ * `guren add attachments` first has to come from the scaffold, not from the
+ * app's first crashed request. Positive evidence only, like the check below:
+ * a file that cannot be read or parsed contributes nothing, so an app this
+ * cannot see into is refused rather than scaffolded broken.
+ */
+export async function appConfiguresAttachments(appRoot: string, cache: ParseCache): Promise<boolean> {
+  for (const filePath of await discoverAttachmentsConfigFiles(appRoot)) {
+    const source = await cache.source(filePath)
+    if (!source || !source.includes('configureAttachments')) continue
+
+    const parsed = await cache.get(filePath)
+    if (!parsed) continue
+
+    let configureLocal: string | null = null
+    for (const declaration of parsed.ast.program.body) {
+      if (declaration.type !== 'ImportDeclaration' || declaration.source.value !== '@guren/core') continue
+      for (const specifier of declaration.specifiers) {
+        if (specifier.type !== 'ImportSpecifier') continue
+        const imported =
+          specifier.imported.type === 'Identifier' ? specifier.imported.name : specifier.imported.value
+        if (imported === 'configureAttachments') configureLocal = specifier.local.name
+      }
+    }
+    if (!configureLocal) continue
+
+    let called = false
+    walk(parsed.ast, (node) => {
+      if (node.type !== 'CallExpression') return
+      const call = node as unknown as CallExpression
+      if (call.callee.type === 'Identifier' && call.callee.name === configureLocal) called = true
+    })
+    if (called) return true
+  }
+  return false
+}
+
+/**
  * Flags a `configureAttachments()` whose `table` is not a table the app's
  * `db/schema.ts` declares (RFC 0013 Part 3). The attachments layer takes the
  * table as `unknown` (the session-store convention), so nothing at typecheck

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -28,6 +28,12 @@ export interface RunBlueprintOptions extends WriterOptions {
   /** Comma-separated field definitions for the resource blueprint, e.g. "title:string,body:text?". */
   fields?: string
   /**
+   * Comma-separated attachment collections for the resource blueprint, e.g.
+   * "cover:one,images:many". Passed through to `makeFeature`, which refuses
+   * it on an app without `configureAttachments()`.
+   */
+  attach?: string
+  /**
    * Skip the scaffold's authentication checks. Defaults to false (auth required).
    *
    * Scope differs per blueprint: the resource blueprint guards its mutating
@@ -673,6 +679,7 @@ export default class BroadcastProvider extends ServiceProvider {
       const created = await makeFeature(singular, {
         force: Boolean(options.force),
         fields: options.fields,
+        attach: options.attach,
         publicAccess: options.publicAccess,
         announce: false,
       })

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -110,6 +110,11 @@ const FIELDS_ARG = {
   description: 'Comma-separated fields, e.g. "title:string,body:text,published:boolean" (append ? for nullable).',
 }
 
+const ATTACH_ARG = {
+  type: 'string' as const,
+  description: 'Comma-separated attachment collections, e.g. "cover:one,images:many" (kind defaults to one). Requires the attachments layer — run `guren add attachments` first.',
+}
+
 function createMakeCommand(spec: MakeCommandSpec) {
   const { name: commandName, description, argDescription, makeFn, resourceName, nextStep } = spec
   return defineCommand({
@@ -2462,6 +2467,7 @@ const makeFeatureCommand = defineCommand({
       description: 'Feature name (singular, e.g., Product).',
     },
     fields: FIELDS_ARG,
+    attach: ATTACH_ARG,
     force: {
       type: 'boolean',
       alias: 'f',
@@ -2484,6 +2490,7 @@ const makeFeatureCommand = defineCommand({
   async run({ args }) {
     await makeFeature(args.name as string, {
       fields: args.fields,
+      attach: typeof args.attach === 'string' ? args.attach : undefined,
       force: Boolean(args.force),
       root: args.module,
       withTest: Boolean(args.test),
@@ -2564,6 +2571,7 @@ const addResourceCommand = defineCommand({
       description: 'Resource name (singular)',
     },
     fields: FIELDS_ARG,
+    attach: ATTACH_ARG,
     public: {
       type: 'boolean',
       description: 'Skip authentication checks in store/update/destroy actions',
@@ -2578,6 +2586,7 @@ const addResourceCommand = defineCommand({
     const createdFiles = await runBlueprint('resource', {
       name: String(args.name),
       fields: typeof args.fields === 'string' ? args.fields : undefined,
+      attach: typeof args.attach === 'string' ? args.attach : undefined,
       publicAccess: Boolean(args.public),
       force: Boolean(args.force),
     })

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -2490,7 +2490,7 @@ const makeFeatureCommand = defineCommand({
   async run({ args }) {
     await makeFeature(args.name as string, {
       fields: args.fields,
-      attach: typeof args.attach === 'string' ? args.attach : undefined,
+      attach: args.attach,
       force: Boolean(args.force),
       root: args.module,
       withTest: Boolean(args.test),

--- a/packages/cli/src/fields.ts
+++ b/packages/cli/src/fields.ts
@@ -1,6 +1,8 @@
 /**
  * The `--fields "name:type,..."` vocabulary shared by the scaffolders that
- * accept one (`make:feature`, `make:validator`, the `resource` blueprint).
+ * accept one (`make:feature`, `make:validator`, the `resource` blueprint),
+ * and its sibling `--attach "name:kind,..."` (`make:feature`, the `resource`
+ * blueprint).
  *
  * It lives here rather than in any one generator so that none of them has to
  * reach into another to parse the same string — `make:feature` composes
@@ -54,5 +56,59 @@ export function parseFieldsString(fieldsStr: string): FieldDefinition[] {
     }
 
     return { name, type: type as FieldType, nullable }
+  })
+}
+
+export const ATTACHMENT_KINDS = ['one', 'many'] as const
+
+export type AttachmentKind = (typeof ATTACHMENT_KINDS)[number]
+
+export interface AttachmentDefinition {
+  name: string
+  kind: AttachmentKind
+}
+
+/**
+ * `--attach "cover:one,images:many"`, mirroring `--fields`' shape: comma
+ * separates collections, colon separates the name from its kind, and an
+ * omitted kind defaults the way an omitted field type does (`cover` reads as
+ * `cover:one` — the common case, like Rails' `has_one_attached`).
+ *
+ * Duplicates are rejected here, unlike in `parseFieldsString`: a repeated
+ * field is a harmless duplicated form input, but a repeated collection is a
+ * duplicate object key in the generated `Attachable` declaration — the second
+ * silently wins and the first kind is discarded.
+ *
+ * The empty string means "no attachments", matching how an omitted `--attach`
+ * reaches the scaffolders.
+ */
+export function parseAttachString(attachStr: string): AttachmentDefinition[] {
+  if (!attachStr.trim()) return []
+
+  const seen = new Set<string>()
+  return attachStr.split(',').map((entry) => {
+    const parts = entry.trim().split(':')
+    const name = parts[0]?.trim()
+    const kind = parts[1]?.trim() || 'one'
+
+    if (!name) throw new Error(`Invalid attachment definition: "${entry}"`)
+
+    // Same rule as field names, for the same reason: the name becomes an
+    // object key in the model declaration, a variable in the generated store
+    // action, and a multipart field name.
+    if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name)) {
+      throw new Error(`Invalid attachment name "${name}". Use a valid identifier, e.g. "coverImage".`)
+    }
+
+    if (!ATTACHMENT_KINDS.includes(kind as AttachmentKind)) {
+      throw new Error(`Invalid attachment kind "${kind}" for "${name}". Valid: ${ATTACHMENT_KINDS.join(', ')}`)
+    }
+
+    if (seen.has(name)) {
+      throw new Error(`Duplicate attachment collection "${name}".`)
+    }
+    seen.add(name)
+
+    return { name, kind: kind as AttachmentKind }
   })
 }

--- a/packages/cli/src/fields.ts
+++ b/packages/cli/src/fields.ts
@@ -9,6 +9,8 @@
  * `make:validator`, so a definition owned by either would be a cycle.
  */
 
+import { isIdentifier } from './utils'
+
 export const FIELD_TYPES = ['string', 'number', 'boolean', 'text', 'date', 'json'] as const
 
 export type FieldType = (typeof FIELD_TYPES)[number]
@@ -47,7 +49,7 @@ export function parseFieldsString(fieldsStr: string): FieldDefinition[] {
     // The name becomes an object key, a property access and a state key in the
     // generated code, so anything that is not an identifier produces a file
     // that cannot be parsed — better to say so than to emit it.
-    if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name)) {
+    if (!isIdentifier(name)) {
       throw new Error(`Invalid field name "${name}". Use a valid identifier, e.g. "publishedAt".`)
     }
 
@@ -67,6 +69,22 @@ export interface AttachmentDefinition {
   name: string
   kind: AttachmentKind
 }
+
+/**
+ * Names `isIdentifier` accepts that still cannot be bound with `const` — a
+ * hasOne collection becomes exactly that in the generated store action
+ * (`const cover = await this.file('cover')`), so a reserved word there is a
+ * file that does not parse. Field names deliberately skip this list: they
+ * only ever appear as object keys and property accesses, where reserved
+ * words are legal.
+ */
+const RESERVED_WORDS = new Set([
+  'await', 'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger', 'default', 'delete',
+  'do', 'else', 'enum', 'export', 'extends', 'false', 'finally', 'for', 'function', 'if',
+  'implements', 'import', 'in', 'instanceof', 'interface', 'let', 'new', 'null', 'package',
+  'private', 'protected', 'public', 'return', 'static', 'super', 'switch', 'this', 'throw',
+  'true', 'try', 'typeof', 'var', 'void', 'while', 'with', 'yield',
+])
 
 /**
  * `--attach "cover:one,images:many"`, mirroring `--fields`' shape: comma
@@ -89,15 +107,25 @@ export function parseAttachString(attachStr: string): AttachmentDefinition[] {
   return attachStr.split(',').map((entry) => {
     const parts = entry.trim().split(':')
     const name = parts[0]?.trim()
-    const kind = parts[1]?.trim() || 'one'
+    // The default applies only to a genuinely omitted kind — an empty or
+    // extra segment (`cover:`, `cover::many`, `cover:many:typo`) is a typo
+    // that silently defaulting would mask.
+    const kind = parts.length > 1 ? parts[1]?.trim() : 'one'
 
-    if (!name) throw new Error(`Invalid attachment definition: "${entry}"`)
+    if (!name || parts.length > 2) throw new Error(`Invalid attachment definition: "${entry}"`)
 
     // Same rule as field names, for the same reason: the name becomes an
     // object key in the model declaration, a variable in the generated store
     // action, and a multipart field name.
-    if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name)) {
+    if (!isIdentifier(name)) {
       throw new Error(`Invalid attachment name "${name}". Use a valid identifier, e.g. "coverImage".`)
+    }
+
+    if (RESERVED_WORDS.has(name)) {
+      throw new Error(
+        `Invalid attachment name "${name}": a reserved word cannot be bound as the variable the `
+        + `generated store action needs. Pick another name.`,
+      )
     }
 
     if (!ATTACHMENT_KINDS.includes(kind as AttachmentKind)) {

--- a/packages/cli/src/make-feature.ts
+++ b/packages/cli/src/make-feature.ts
@@ -1,12 +1,14 @@
 import { consola } from 'consola'
 import { assertNotApiOnly } from './app-surface'
+import { appConfiguresAttachments } from './attachments-check'
 import { camelCase, kebabCase, pagesAccessor, pascalCase, safeModuleName, writeRoot, writeScaffoldFiles, writerOptionsFrom, type WriterOptions } from './utils'
 import { pluralize } from './inflect'
 import { makeModel } from './make-model'
 import { makePolicy } from './make-policy'
 import { makeTest } from './make-test'
 import { makeValidator } from './make-validator'
-import { parseFieldsString, type FieldDefinition, type FieldType } from './fields'
+import { parseAttachString, parseFieldsString, type AttachmentDefinition, type FieldDefinition, type FieldType } from './fields'
+import { ParseCache } from './parse-cache'
 import { schemaPathFor } from './schema-parser'
 
 /**
@@ -22,6 +24,12 @@ export const API_ONLY_FEATURE_ALTERNATIVE = 'Scaffold a JSON controller with gur
 
 export interface MakeFeatureOptions extends WriterOptions {
   fields?: string
+  /**
+   * Comma-separated attachment collections (`"cover:one,images:many"`).
+   * Wraps the generated model in the `Attachable` mixin and wires the store
+   * and destroy actions; refused when the app has no `configureAttachments()`.
+   */
+  attach?: string
   withTest?: boolean
   withFactory?: boolean
   /** Skip authentication checks in mutating actions. Defaults to false (auth required). */
@@ -34,6 +42,7 @@ export interface MakeFeatureOptions extends WriterOptions {
 
 export async function makeFeature(name: string, options: MakeFeatureOptions = {}): Promise<string[]> {
   const fields = parseFieldsString(options.fields ?? '')
+  const attachments = parseAttachString(options.attach ?? '')
   const singular = pascalCase(name)
   const collection = pluralize(singular)
   const routeName = kebabCase(collection)
@@ -42,6 +51,21 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
   const withAuth = !options.publicAccess
   const withPolicy = Boolean(options.withPolicy)
   const writerOptions: WriterOptions = writerOptionsFrom(options)
+
+  // A collection sharing a name with a column is a compile error in the
+  // generated model (the mixin rejects declaration keys that shadow columns),
+  // and one sharing a name with the store action's own locals would generate
+  // a redeclared binding — both are usage errors this can say outright
+  // instead of shipping as a file that does not compile.
+  const reservedAttachmentNames = new Set([...fields.map((field) => field.name), 'id', 'data', variableName])
+  for (const attachment of attachments) {
+    if (reservedAttachmentNames.has(attachment.name)) {
+      throw new Error(
+        `Attachment collection "${attachment.name}" collides with a field, the record's id, or the `
+        + `generated store action's own variables ("data", "${variableName}"). Pick another name.`,
+      )
+    }
+  }
 
   // `--module <name>` moves app/ output under modules/<name>/ (handled by
   // scaffoldFile for makeModel/makePolicy/makeTest below), but pages are
@@ -63,6 +87,18 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
     instead: API_ONLY_FEATURE_ALTERNATIVE,
   })
 
+  // Also before the first write: `--attach` output is only usable on an app
+  // that wired the attachments layer — the mixin's statics throw at first use
+  // otherwise. Refusing here, with the fix named, beats scaffolding a feature
+  // that crashes on its first upload (RFC 0013 Part 4).
+  if (attachments.length > 0 && !(await appConfiguresAttachments(writeRoot(options), new ParseCache()))) {
+    throw new Error(
+      'guren make:feature --attach scaffolds a model wired to the attachments layer, but this app has no '
+      + 'configureAttachments() call. Run `bunx guren add attachments` first, then re-run this command. '
+      + 'Nothing was scaffolded.',
+    )
+  }
+
   // Composed rather than emitted inline — the same way makeModel/makePolicy/
   // makeTest are below — so the schema names the generated controller imports
   // and the ones `make:validator` writes cannot drift apart.
@@ -75,7 +111,7 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
     },
     {
       path: `${appPrefix}app/Http/Controllers/${singular}Controller.ts`,
-      contents: generateController(singular, collection, routeName, routeVar, variableName, fields, withAuth, withPolicy, moduleName),
+      contents: generateController(singular, collection, routeName, routeVar, variableName, fields, withAuth, withPolicy, moduleName, attachments),
     },
     {
       path: `resources/js/pages/${pagePrefix}${routeName}/Index.tsx`,
@@ -98,7 +134,7 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
   created.unshift(validatorPath)
 
   // Create model
-  const modelPath = await makeModel(singular, writerOptions)
+  const modelPath = await makeModel(singular, { ...writerOptions, attachments })
   created.push(modelPath)
 
   // Optionally create policy
@@ -152,6 +188,15 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
     consola.info('')
     consola.info(`  Note: store/update/destroy call this.auth.userOrFail() — unauthenticated requests get 401.`)
     consola.info(`  Use --public to scaffold without authentication checks.`)
+  }
+  if (attachments.length > 0) {
+    const fieldNames = attachments.map((attachment) => `"${attachment.name}"`).join(', ')
+    consola.info('')
+    consola.info(`  Attachments: store() reads the multipart field(s) ${fieldNames} via this.file()/this.files().`)
+    consola.info(`  Add matching <input type="file"> fields to the New/Edit pages (Inertia's useForm posts`)
+    consola.info(`  multipart automatically when the form data contains a File).`)
+    consola.info(`  destroy() calls ${singular}.purgeAttachments() before deleting the row — attachment rows`)
+    consola.info(`  have no foreign key, so deletion stays explicit.`)
   }
   if (moduleName) {
     consola.info('')
@@ -329,6 +374,7 @@ function generateController(
   withAuth: boolean,
   withPolicy: boolean,
   moduleName: string | undefined,
+  attachments: AttachmentDefinition[],
 ): string {
   const authGuard = withAuth ? '    await this.auth.userOrFail()\n' : ''
   const createGuard = withPolicy ? `    await this.authorize('create', ${singular})\n` : ''
@@ -344,6 +390,27 @@ function generateController(
   const redirectPrefix = moduleName ? `/${moduleName}` : ''
   const destroyGuard = withPolicy
     ? `    await this.authorize('delete', [${singular}, ${variableName}])\n`
+    : ''
+  // The RFC 0013 §8 store shape: create first, then one attach per collection
+  // — `this.file()` returns null for an absent multipart field, so a form
+  // that never uploads still stores the record.
+  const storeAttach = attachments
+    .map((attachment) =>
+      attachment.kind === 'one'
+        ? `    const ${attachment.name} = await this.file('${attachment.name}')\n`
+          + `    if (${attachment.name}) {\n`
+          + `      await ${singular}.attach(${variableName}.id, '${attachment.name}', ${attachment.name})\n`
+          + `    }\n`
+        : `    for (const file of await this.files('${attachment.name}')) {\n`
+          + `      await ${singular}.attach(${variableName}.id, '${attachment.name}', file)\n`
+          + `    }\n`)
+    .join('')
+  // Deletion is explicit (RFC 0013 §8): the polymorphic attachment rows carry
+  // no foreign key, and model delete hooks fire on only some delete paths —
+  // so the destroy action purges before deleting the row. After the
+  // authorization guard, deliberately: purging is destructive.
+  const destroyPurge = attachments.length > 0
+    ? `    await ${singular}.purgeAttachments(${variableName}.id)\n`
     : ''
   return `import { Controller, paginate, type PaginatedPageProps } from '@guren/core'
 import { pages } from '@/.guren/pages.gen'
@@ -384,7 +451,7 @@ export default class ${singular}Controller extends Controller {
   async store(): Promise<Response> {
 ${authGuard}${createGuard}    const data = await this.validateBody(${singular}PayloadSchema)
     const ${variableName} = await ${singular}.create(data)
-    return this.redirect('${redirectPrefix}/${routeName}/' + ${variableName}?.id)
+${storeAttach}    return this.redirect('${redirectPrefix}/${routeName}/' + ${variableName}?.id)
   }
 
   async edit(): Promise<Response> {
@@ -406,7 +473,7 @@ ${updateGuard}    const data = await this.validateBody(${singular}PayloadSchema)
   async destroy(): Promise<Response> {
 ${authGuard}    const { id } = this.validateParams(${singular}IdParamSchema)
     const ${variableName} = await ${singular}.findOrFail(id)
-${destroyGuard}    await ${singular}.delete({ id: ${variableName}.id })
+${destroyGuard}${destroyPurge}    await ${singular}.delete({ id: ${variableName}.id })
     return this.redirect('${redirectPrefix}/${routeName}')
   }
 }

--- a/packages/cli/src/make-feature.ts
+++ b/packages/cli/src/make-feature.ts
@@ -54,15 +54,15 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
 
   // A collection sharing a name with a column is a compile error in the
   // generated model (the mixin rejects declaration keys that shadow columns),
-  // and one sharing a name with the store action's own locals would generate
-  // a redeclared binding — both are usage errors this can say outright
-  // instead of shipping as a file that does not compile.
-  const reservedAttachmentNames = new Set([...fields.map((field) => field.name), 'id', 'data', variableName])
+  // and one sharing a name with an identifier the generated store action
+  // already binds or references would shadow it — both are usage errors this
+  // can say outright instead of shipping as a file that does not compile.
+  const reserved = reservedAttachmentNames(fields, singular, variableName)
   for (const attachment of attachments) {
-    if (reservedAttachmentNames.has(attachment.name)) {
+    if (reserved.has(attachment.name)) {
       throw new Error(
-        `Attachment collection "${attachment.name}" collides with a field, the record's id, or the `
-        + `generated store action's own variables ("data", "${variableName}"). Pick another name.`,
+        `Attachment collection "${attachment.name}" collides with a column of the ${singular} table `
+        + `or an identifier the generated controller already uses. Pick another name.`,
       )
     }
   }
@@ -95,6 +95,8 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
     throw new Error(
       'guren make:feature --attach scaffolds a model wired to the attachments layer, but this app has no '
       + 'configureAttachments() call. Run `bunx guren add attachments` first, then re-run this command. '
+      + 'If your app wires attachments in a shape this cannot detect (a namespace import, a wrapper), '
+      + 'scaffold without --attach and add the Attachable mixin to the model by hand. '
       + 'Nothing was scaffolded.',
     )
   }
@@ -193,8 +195,11 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
     const fieldNames = attachments.map((attachment) => `"${attachment.name}"`).join(', ')
     consola.info('')
     consola.info(`  Attachments: store() reads the multipart field(s) ${fieldNames} via this.file()/this.files().`)
-    consola.info(`  Add matching <input type="file"> fields to the New/Edit pages (Inertia's useForm posts`)
-    consola.info(`  multipart automatically when the form data contains a File).`)
+    consola.info(`  Add matching <input type="file"> fields to the New page (Inertia's useForm posts multipart`)
+    consola.info(`  automatically when the form data contains a File). Uploads are validated as images and 422`)
+    consola.info(`  on anything else — drop image: 'require' in the model for opaque bytes like PDFs.`)
+    consola.info(`  update() does not touch attachments; to accept uploads from the Edit page, add the same`)
+    consola.info(`  this.file() + ${singular}.attach() lines there (hasOne replaces, hasMany appends).`)
     consola.info(`  destroy() calls ${singular}.purgeAttachments() before deleting the row — attachment rows`)
     consola.info(`  have no foreign key, so deletion stays explicit.`)
   }
@@ -256,6 +261,32 @@ export function buildRouteRegistrationHint(options: {
 }
 
 // --- Template generators ---
+
+/**
+ * Names an attachment collection may not take, derived from what the
+ * generated code binds where the attach lines land — kept beside the
+ * templates so a renamed store local moves this set in the same edit.
+ *
+ * `createdAt`/`updatedAt` are reserved even though `make:feature` never sees
+ * the table: the resource blueprint always appends both columns, most
+ * hand-written tables carry them too, and a declaration key that shadows a
+ * column is a compile error in the mixin. `data`, the record variable, the
+ * model class, and its payload schema are all in scope before the attach
+ * lines in the generated store action, so a collection reusing one of them
+ * would shadow a binding the earlier lines already used.
+ */
+function reservedAttachmentNames(fields: FieldDefinition[], singular: string, variableName: string): Set<string> {
+  return new Set([
+    ...fields.map((field) => field.name),
+    'id',
+    'createdAt',
+    'updatedAt',
+    'data',
+    variableName,
+    singular,
+    `${singular}PayloadSchema`,
+  ])
+}
 
 // Keyed by `FieldType` rather than `string`, so adding a field type fails to
 // compile here instead of silently falling through to a string default.

--- a/packages/cli/src/make-model.ts
+++ b/packages/cli/src/make-model.ts
@@ -22,26 +22,22 @@ function attachableFactory(kind: AttachmentDefinition['kind']): string {
 function modelTemplate(className: string, attachments: AttachmentDefinition[]): string {
   const schemaIdentifier = schemaIdentifierFor(className)
 
-  if (attachments.length === 0) {
-    return `import { defineModel } from '@guren/core'
-import { ${schemaIdentifier} } from '../../db/schema.js'
-
-export type ${className}Record = typeof ${schemaIdentifier}.$inferSelect
-export type New${className}Record = typeof ${schemaIdentifier}.$inferInsert
-
-export class ${className} extends defineModel(${schemaIdentifier}) {
-}
-`
-  }
-
+  // This scaffold's own default, not the framework's: every collection gets
+  // `image: 'require'` (full-decode validation, 422 on non-image) because
+  // safe-by-default matches the rest of the CLI's posture, and the option
+  // sits in the generated file for the author to delete. Drop it per
+  // collection for opaque bytes (PDFs, archives) — `hasOneAttached()` with
+  // no options.
   const factories = [...new Set(attachments.map((attachment) => attachableFactory(attachment.kind)))]
-  const imports = ['Attachable', 'defineModel', ...factories].sort().join(', ')
-  // `image: 'require'` is the RFC 0013 default for scaffolds: uploads are
-  // full-decode validated as images (422 otherwise). Drop it per collection
-  // for opaque bytes (PDFs, archives) — `hasOneAttached()` with no options.
+  const imports = attachments.length === 0
+    ? 'defineModel'
+    : ['Attachable', 'defineModel', ...factories].sort().join(', ')
   const declaration = attachments
     .map((attachment) => `  ${attachment.name}: ${attachableFactory(attachment.kind)}({ image: 'require' }),`)
     .join('\n')
+  const heritage = attachments.length === 0
+    ? `defineModel(${schemaIdentifier})`
+    : `Attachable(defineModel(${schemaIdentifier}), {\n${declaration}\n})`
 
   return `import { ${imports} } from '@guren/core'
 import { ${schemaIdentifier} } from '../../db/schema.js'
@@ -49,9 +45,7 @@ import { ${schemaIdentifier} } from '../../db/schema.js'
 export type ${className}Record = typeof ${schemaIdentifier}.$inferSelect
 export type New${className}Record = typeof ${schemaIdentifier}.$inferInsert
 
-export class ${className} extends Attachable(defineModel(${schemaIdentifier}), {
-${declaration}
-}) {
+export class ${className} extends ${heritage} {
 }
 `
 }

--- a/packages/cli/src/make-model.ts
+++ b/packages/cli/src/make-model.ts
@@ -1,13 +1,29 @@
 import type { WriterOptions } from './utils'
 import { scaffoldFile } from './utils'
 import { schemaIdentifierFor } from './inflect'
+import type { AttachmentDefinition } from './fields'
 
 const MODELS_DIR = 'app/Models'
 
-function modelTemplate(className: string): string {
+export interface MakeModelOptions extends WriterOptions {
+  /**
+   * Attachment collections to declare through the `Attachable` mixin
+   * (`make:feature --attach`). The caller is responsible for having verified
+   * that the app wires `configureAttachments()` — the mixin's statics throw
+   * at first use otherwise.
+   */
+  attachments?: AttachmentDefinition[]
+}
+
+function attachableFactory(kind: AttachmentDefinition['kind']): string {
+  return kind === 'one' ? 'hasOneAttached' : 'hasManyAttached'
+}
+
+function modelTemplate(className: string, attachments: AttachmentDefinition[]): string {
   const schemaIdentifier = schemaIdentifierFor(className)
 
-  return `import { defineModel } from '@guren/core'
+  if (attachments.length === 0) {
+    return `import { defineModel } from '@guren/core'
 import { ${schemaIdentifier} } from '../../db/schema.js'
 
 export type ${className}Record = typeof ${schemaIdentifier}.$inferSelect
@@ -16,11 +32,33 @@ export type New${className}Record = typeof ${schemaIdentifier}.$inferInsert
 export class ${className} extends defineModel(${schemaIdentifier}) {
 }
 `
+  }
+
+  const factories = [...new Set(attachments.map((attachment) => attachableFactory(attachment.kind)))]
+  const imports = ['Attachable', 'defineModel', ...factories].sort().join(', ')
+  // `image: 'require'` is the RFC 0013 default for scaffolds: uploads are
+  // full-decode validated as images (422 otherwise). Drop it per collection
+  // for opaque bytes (PDFs, archives) — `hasOneAttached()` with no options.
+  const declaration = attachments
+    .map((attachment) => `  ${attachment.name}: ${attachableFactory(attachment.kind)}({ image: 'require' }),`)
+    .join('\n')
+
+  return `import { ${imports} } from '@guren/core'
+import { ${schemaIdentifier} } from '../../db/schema.js'
+
+export type ${className}Record = typeof ${schemaIdentifier}.$inferSelect
+export type New${className}Record = typeof ${schemaIdentifier}.$inferInsert
+
+export class ${className} extends Attachable(defineModel(${schemaIdentifier}), {
+${declaration}
+}) {
+}
+`
 }
 
-export async function makeModel(name: string, options: WriterOptions = {}): Promise<string> {
+export async function makeModel(name: string, options: MakeModelOptions = {}): Promise<string> {
   return scaffoldFile(name, {
     dir: MODELS_DIR,
-    template: ({ className }) => modelTemplate(className),
+    template: ({ className }) => modelTemplate(className, options.attachments ?? []),
   }, options)
 }

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -260,6 +260,27 @@ export async function seedInertiaApp(dir: string): Promise<void> {
   await writeWorkspaceFiles(dir, INERTIA_APP_FILES)
 }
 
+/**
+ * The shape `guren add attachments` leaves behind, reduced to what the
+ * `make:feature --attach` preflight reads: a `configureAttachments` imported
+ * from `@guren/core` and actually called. Parsed only, never executed — the
+ * storage thunk throwing is what keeps that honest.
+ */
+export async function seedAttachmentsConfig(dir: string): Promise<void> {
+  await writeWorkspaceFiles(dir, {
+    'config/attachments.ts': `import { configureAttachments } from '@guren/core'
+import { attachments } from '../db/schema.js'
+
+export const { Attachment } = configureAttachments({
+  table: attachments,
+  storage: () => {
+    throw new Error('unused in tests')
+  },
+})
+`,
+  })
+}
+
 /** One page component, for tests about an app that acquired one it cannot render. */
 export const PAGE_COMPONENT_FIXTURE = 'export default function Home() { return null }\n'
 

--- a/packages/cli/tests/make-feature.test.ts
+++ b/packages/cli/tests/make-feature.test.ts
@@ -3,8 +3,8 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
 import { makeFeature, buildRouteRegistrationHint } from '../src/make-feature'
-import { parseFieldsString } from '../src/fields'
-import { API_ONLY_REFUSAL, API_ROUTES_FIXTURE, createTempWorkspace, DEFAULT_ROUTES_FIXTURE, seedApiOnlyApp } from './helpers'
+import { parseAttachString, parseFieldsString } from '../src/fields'
+import { API_ONLY_REFUSAL, API_ROUTES_FIXTURE, createTempWorkspace, DEFAULT_ROUTES_FIXTURE, seedApiOnlyApp, seedAttachmentsConfig } from './helpers'
 
 describe('parseFieldsString', () => {
   it('parses simple fields', () => {
@@ -59,6 +59,135 @@ describe('parseFieldsString', () => {
   it('defaults type to string when omitted', () => {
     const fields = parseFieldsString('title')
     expect(fields[0].type).toBe('string')
+  })
+})
+
+describe('parseAttachString', () => {
+  it('parses collections with kinds', () => {
+    expect(parseAttachString('cover:one,images:many')).toEqual([
+      { name: 'cover', kind: 'one' },
+      { name: 'images', kind: 'many' },
+    ])
+  })
+
+  it('defaults the kind to one when omitted', () => {
+    expect(parseAttachString('cover')).toEqual([{ name: 'cover', kind: 'one' }])
+  })
+
+  it('returns no collections for an empty string', () => {
+    expect(parseAttachString('')).toEqual([])
+    expect(parseAttachString('  ')).toEqual([])
+  })
+
+  it('handles whitespace', () => {
+    expect(parseAttachString(' cover : one , images : many ')).toEqual([
+      { name: 'cover', kind: 'one' },
+      { name: 'images', kind: 'many' },
+    ])
+  })
+
+  it('throws for an invalid kind', () => {
+    expect(() => parseAttachString('cover:two')).toThrow('Invalid attachment kind')
+  })
+
+  it('throws for an empty or non-identifier name', () => {
+    expect(() => parseAttachString(':one')).toThrow('Invalid attachment definition')
+    expect(() => parseAttachString('cover-image:one')).toThrow('Invalid attachment name')
+  })
+
+  // A repeated collection is a duplicate object key in the generated
+  // Attachable declaration — the second silently wins, so it is refused.
+  it('throws for a duplicate collection', () => {
+    expect(() => parseAttachString('cover:one,cover:many')).toThrow('Duplicate attachment collection')
+  })
+})
+
+describe('makeFeature --attach', () => {
+  it('wraps the model in Attachable and wires store/destroy', async () => {
+    const workspace = await createTempWorkspace('guren-cli-feature-attach-')
+
+    try {
+      await seedAttachmentsConfig(workspace.dir)
+      await makeFeature('Post', { fields: 'title:string', attach: 'cover:one,images:many' })
+
+      const model = await readFile(join(workspace.dir, 'app/Models/Post.ts'), 'utf8')
+      expect(model).toContain("import { Attachable, defineModel, hasManyAttached, hasOneAttached } from '@guren/core'")
+      expect(model).toContain('export class Post extends Attachable(defineModel(posts), {')
+      expect(model).toContain("  cover: hasOneAttached({ image: 'require' }),")
+      expect(model).toContain("  images: hasManyAttached({ image: 'require' }),")
+
+      const controller = await readFile(
+        join(workspace.dir, 'app/Http/Controllers/PostController.ts'),
+        'utf8',
+      )
+      const storeBody = controller.slice(controller.indexOf('async store'), controller.indexOf('async edit'))
+      expect(storeBody).toContain("const cover = await this.file('cover')")
+      expect(storeBody).toContain("await Post.attach(post.id, 'cover', cover)")
+      expect(storeBody).toContain("for (const file of await this.files('images'))")
+      expect(storeBody).toContain("await Post.attach(post.id, 'images', file)")
+      // Attach runs after create (it needs the id) and before the redirect.
+      expect(storeBody.indexOf('Post.create(data)')).toBeLessThan(storeBody.indexOf("this.file('cover')"))
+      expect(storeBody.indexOf("Post.attach(post.id, 'images'")).toBeLessThan(storeBody.indexOf('this.redirect'))
+
+      // Deletion is explicit (RFC 0013 §8): purge before the row goes away.
+      const destroyBody = controller.slice(controller.indexOf('async destroy'))
+      expect(destroyBody).toContain('await Post.purgeAttachments(post.id)')
+      expect(destroyBody.indexOf('Post.purgeAttachments')).toBeLessThan(destroyBody.indexOf('Post.delete'))
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('refuses --attach when the app has no configureAttachments()', async () => {
+    const workspace = await createTempWorkspace('guren-cli-feature-attach-missing-')
+
+    try {
+      await expect(
+        makeFeature('Post', { fields: 'title:string', attach: 'cover:one' }),
+      ).rejects.toThrow(/guren add attachments/)
+
+      // Refused before the first write — no half-scaffolded feature.
+      expect(existsSync(join(workspace.dir, 'app/Http/Validators/PostValidator.ts'))).toBe(false)
+      expect(existsSync(join(workspace.dir, 'app/Models/Post.ts'))).toBe(false)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('refuses a collection name that collides with a field', async () => {
+    const workspace = await createTempWorkspace('guren-cli-feature-attach-collision-')
+
+    try {
+      await seedAttachmentsConfig(workspace.dir)
+      await expect(
+        makeFeature('Post', { fields: 'cover:string', attach: 'cover:one' }),
+      ).rejects.toThrow(/collides/)
+      await expect(
+        makeFeature('Post', { fields: 'title:string', attach: 'post:one' }),
+      ).rejects.toThrow(/collides/)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('leaves the model and controller unchanged without --attach', async () => {
+    const workspace = await createTempWorkspace('guren-cli-feature-no-attach-')
+
+    try {
+      await makeFeature('Post', { fields: 'title:string' })
+
+      const model = await readFile(join(workspace.dir, 'app/Models/Post.ts'), 'utf8')
+      expect(model).not.toContain('Attachable')
+
+      const controller = await readFile(
+        join(workspace.dir, 'app/Http/Controllers/PostController.ts'),
+        'utf8',
+      )
+      expect(controller).not.toContain('attach')
+      expect(controller).not.toContain('purgeAttachments')
+    } finally {
+      await workspace.cleanup()
+    }
   })
 })
 

--- a/packages/cli/tests/make-feature.test.ts
+++ b/packages/cli/tests/make-feature.test.ts
@@ -95,6 +95,20 @@ describe('parseAttachString', () => {
     expect(() => parseAttachString('cover-image:one')).toThrow('Invalid attachment name')
   })
 
+  // A hasOne collection becomes `const <name>` in the generated store action,
+  // so a reserved word is a file that does not parse.
+  it('throws for a reserved-word name', () => {
+    expect(() => parseAttachString('await:one')).toThrow('reserved word')
+    expect(() => parseAttachString('class:many')).toThrow('reserved word')
+  })
+
+  // Extra or empty segments are typos that a silent default would mask.
+  it('throws for malformed kind segments', () => {
+    expect(() => parseAttachString('cover:many:typo')).toThrow('Invalid attachment definition')
+    expect(() => parseAttachString('cover::many')).toThrow('Invalid attachment definition')
+    expect(() => parseAttachString('cover:')).toThrow('Invalid attachment kind')
+  })
+
   // A repeated collection is a duplicate object key in the generated
   // Attachable declaration — the second silently wins, so it is refused.
   it('throws for a duplicate collection', () => {
@@ -164,6 +178,15 @@ describe('makeFeature --attach', () => {
       ).rejects.toThrow(/collides/)
       await expect(
         makeFeature('Post', { fields: 'title:string', attach: 'post:one' }),
+      ).rejects.toThrow(/collides/)
+      // Shadowing the model class puts the store action's own `Post.create`
+      // in a temporal dead zone; createdAt is a column every resource
+      // blueprint table (and most hand-written ones) carries.
+      await expect(
+        makeFeature('Post', { fields: 'title:string', attach: 'Post:one' }),
+      ).rejects.toThrow(/collides/)
+      await expect(
+        makeFeature('Post', { fields: 'title:string', attach: 'createdAt:one' }),
       ).rejects.toThrow(/collides/)
     } finally {
       await workspace.cleanup()

--- a/packages/cli/tests/scaffold-output.test.ts
+++ b/packages/cli/tests/scaffold-output.test.ts
@@ -7,6 +7,7 @@ import {
   assertWorkspaceBuilt,
   createTempWorkspace,
   seedApiOnlyApp,
+  seedAttachmentsConfig,
   seedInertiaApp,
 } from './helpers'
 import { parseSourceFile } from '../src/parse-cache'
@@ -192,6 +193,16 @@ describe('generated sources parse', () => {
   it('make:feature public, in a module', async () => {
     await expectAllOutputsParse('guren-parse-feature-module-', () =>
       makeFeature('Invoice', { fields: 'title:string,paidAt:date?', publicAccess: true, root: 'billing' }))
+  })
+
+  // Seeded with a configureAttachments() config because the flag refuses an
+  // app without one — the seed itself is parsed by the gate too.
+  it('make:feature with attachments', async () => {
+    await expectAllOutputsParse(
+      'guren-parse-feature-attach-',
+      () => makeFeature('Post', { fields: 'title:string', attach: 'cover:one,images:many' }),
+      seedAttachmentsConfig,
+    )
   })
 
   it('make:controller (Inertia dialect)', async () => {

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -90,6 +90,12 @@ const DEFAULT_BLUEPRINT_FEATURES: readonly (readonly string[])[] = [
   // attachments exercises its own scaffolds rather than re-running the
   // storage prerequisite.
   ['attachments'],
+  // After attachments, deliberately: `--attach` refuses an app without
+  // configureAttachments(). This second resource is the one gate that
+  // *typechecks* the attach-aware model (Attachable + has*Attached from
+  // @guren/core) and controller (attach/purgeAttachments) an app installs —
+  // in the repo they are only parse-checked builder output.
+  ['resource', 'photos', '--fields', 'title:string,caption:text?', '--attach', 'cover:one,images:many'],
   ['broadcasting'],
   ['schedule'],
 ]


### PR DESCRIPTION
## Summary

Implements RFC 0013 Part 4 / RFC 0010 Open Question 4: `guren make:feature <Entity> --attach "cover:one,images:many"`.

- **`--attach` spec** mirrors `--fields`: comma-separated `name:kind` pairs, kind `one` | `many` (defaults to `one`), parsed by `parseAttachString` in `fields.ts`. Duplicate collections are rejected (a repeated key in the `Attachable` declaration silently discards the first kind), and names colliding with a field, `id`, or the store action's own locals are refused at scaffold time instead of shipping a file that does not compile.
- **Model**: wrapped in the `Attachable` mixin — `class Post extends Attachable(defineModel(posts), { cover: hasOneAttached({ image: 'require' }), images: hasManyAttached({ image: 'require' }) }) {}`, imports from `@guren/core`.
- **Store action**: reads uploads via `this.file()` (hasOne) / `this.files()` (hasMany) and calls `Post.attach(post.id, ...)` after create — the RFC §8 shape; an absent multipart field still stores the record.
- **Destroy action**: calls `Post.purgeAttachments(post.id)` after the authorization guard and before deleting the row (RFC 0013 §8: attachment rows are polymorphic, no FK cascade is possible, and model delete hooks are unreliable — deletion stays explicit).
- **Preflight**: refuses the flag when the app has no `configureAttachments()` call — detected the way `guren check`'s attachments check does (`appConfiguresAttachments` in `attachments-check.ts`: an import from `@guren/core` that is actually called, positive evidence only) — and names `guren add attachments` as the fix, before the first write.
- **`guren add resource`** passes `--attach` through to `makeFeature`.

## Coverage

- Unit tests beside the existing make-feature tests: parser, generated model/store/destroy shape, the refusal (nothing written), and collision errors.
- `scaffold-output.test.ts` gains an `--attach` matrix entry (parse gate), seeded with a shared `seedAttachmentsConfig` helper.
- The fresh-app smoke scaffolds a second resource with `--attach` after the `attachments` blueprint, so the attach-aware model/controller are typechecked against the packages an app installs (in-repo they are parse-checked builder output only).
- Docs: `docs/{en,ja}/guides/attachments.md` gain a scaffolding subsection; root CLAUDE.md lists the flag.
- Changeset: `@guren/cli` minor.

## Gates

- `bun run build` / `typecheck` / `test` — green
- `bun run audit:core-first` / `audit:docs` — green
- `bun run smoke:starter` — green (exercises the new flag end to end)

Refs: RFC 0013