### PR TITLE
feat(server): signed-delivery groundwork (RFC 0015 Part 1)

### DIFF
--- a/.changeset/rfc0015-part1-server-surface.md
+++ b/.changeset/rfc0015-part1-server-surface.md
@@ -1,0 +1,22 @@
+---
+'@guren/server': minor
+---
+
+Signed-delivery groundwork (RFC 0015 Part 1).
+
+`signUrl`/`verifySignedUrl` now accept app-relative input (`/path?query`)
+and return it relative — previously `signUrl('/path')` threw. Query
+canonicalization sorts by code unit instead of the locale-dependent
+`localeCompare`, the `expires` parameter must be a plain positive integer
+(`NaN`/`Infinity` no longer verify), `signUrl` rejects a non-finite
+`expiresIn`, and `verifySignedUrl` returns `false` on malformed input
+instead of throwing.
+
+`StorageDriver` gains three additive members: an optional
+`getStream?(path, { range? })` streaming read (implemented by
+`LocalDriver` and `S3Driver`; callers fall back to buffered `get()` where
+absent), an optional `capabilities` declaration (`S3Driver` declares
+`{ presignedGet: true }`; absent means none — fail-closed), and an
+optional `TemporaryUrlOptions` bag on `temporaryUrl()` whose
+`responseContentDisposition`/`responseContentType` map onto S3's
+presigned response overrides.

--- a/packages/server/src/encryption/signed-url.ts
+++ b/packages/server/src/encryption/signed-url.ts
@@ -13,33 +13,70 @@ const PURPOSE = 'signed-url'
 const SIGNATURE_PARAM = 'signature'
 const EXPIRES_PARAM = 'expires'
 
-function canonicalizeUrl(value: string): { canonical: string; url: URL } {
-  const url = new URL(value)
-  url.searchParams.delete(SIGNATURE_PARAM)
-  const params = Array.from(url.searchParams.entries()).sort(([left], [right]) => left.localeCompare(right))
-  url.search = ''
+// App-relative input ('/path?query') is parsed against this base; the origin
+// must never reach the signature (the canonical form is path + query) or the
+// return value (relative in, relative out) — RFC 0015 §2.
+const RELATIVE_BASE = 'https://relative.invalid'
+
+// `expires` must be a plain positive decimal integer in unix seconds. The
+// bound matters: `Number(expires) < now` alone lets `NaN` and `Infinity`
+// verify forever. 15 digits stays inside Number.MAX_SAFE_INTEGER.
+const EXPIRES_SHAPE = /^[0-9]{1,15}$/
+
+function parseUrl(value: string): { url: URL; relative: boolean } {
+  const relative = value.startsWith('/')
+  return { url: relative ? new URL(value, RELATIVE_BASE) : new URL(value), relative }
+}
+
+function serializeUrl(url: URL, relative: boolean): string {
+  return relative ? `${url.pathname}${url.search}` : url.toString()
+}
+
+function canonicalizeUrl(url: URL): string {
+  const canonical = new URL(url.toString())
+  canonical.searchParams.delete(SIGNATURE_PARAM)
+  // Code-unit comparison, not localeCompare: canonicalization must be
+  // deterministic across runtimes and locales or signer and verifier can
+  // disagree on the same URL.
+  const params = Array.from(canonical.searchParams.entries()).sort(([left], [right]) =>
+    left < right ? -1 : left > right ? 1 : 0,
+  )
+  canonical.search = ''
   for (const [key, paramValue] of params) {
-    url.searchParams.append(key, paramValue)
+    canonical.searchParams.append(key, paramValue)
   }
 
-  return { canonical: `${url.pathname}${url.search}`, url }
+  return `${canonical.pathname}${canonical.search}`
 }
 
 export function signUrl(value: string, keyring: AppKeyring, options: SignedUrlOptions = {}): string {
-  const url = new URL(value)
+  const { url, relative } = parseUrl(value)
   if (typeof options.expiresIn === 'number') {
+    if (!Number.isFinite(options.expiresIn)) {
+      throw new TypeError(
+        `signUrl: expiresIn must be a finite number of milliseconds, got ${options.expiresIn}`,
+      )
+    }
     url.searchParams.set(EXPIRES_PARAM, String(Math.floor((Date.now() + options.expiresIn) / 1000)))
   }
 
-  const { canonical } = canonicalizeUrl(url.toString())
+  const canonical = canonicalizeUrl(url)
   const signer = new MessageSigner(keyring)
   const signature = signer.sign({ url: canonical }, { purpose: PURPOSE })
   url.searchParams.set(SIGNATURE_PARAM, signature)
-  return url.toString()
+  return serializeUrl(url, relative)
 }
 
 export function verifySignedUrl(value: string, keyring: AppKeyring, options: VerifySignedUrlOptions = {}): boolean {
-  const url = new URL(value)
+  // A verifier is handed attacker-controlled input; malformed input is a
+  // failed verification, not an exception for the caller to remember.
+  let url: URL
+  try {
+    url = parseUrl(value).url
+  } catch {
+    return false
+  }
+
   const signature = url.searchParams.get(SIGNATURE_PARAM)
   if (!signature) {
     return false
@@ -50,11 +87,16 @@ export function verifySignedUrl(value: string, keyring: AppKeyring, options: Ver
     return false
   }
 
-  if (expires && Number(expires) < Math.floor(Date.now() / 1000)) {
-    return false
+  if (expires !== null) {
+    if (!EXPIRES_SHAPE.test(expires)) {
+      return false
+    }
+    if (Number(expires) < Math.floor(Date.now() / 1000)) {
+      return false
+    }
   }
 
-  const { canonical } = canonicalizeUrl(value)
+  const canonical = canonicalizeUrl(url)
   const signer = new MessageSigner(keyring)
   const payload = signer.verify<{ url: string }>(signature, { purpose: PURPOSE })
   return payload?.url === canonical

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -439,6 +439,9 @@ export type {
   StorageDriverFactory,
   PutOptions,
   FileMetadata,
+  TemporaryUrlOptions,
+  GetStreamOptions,
+  StorageDriverCapabilities,
 } from './storage'
 // Scheduling
 export {

--- a/packages/server/src/storage/drivers/LocalDriver.ts
+++ b/packages/server/src/storage/drivers/LocalDriver.ts
@@ -8,10 +8,12 @@ import {
   rm,
   copyFile,
   rename,
+  open,
 } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
+import { Readable } from 'node:stream'
 import { join, dirname, relative, resolve, sep } from 'node:path'
-import type { StorageDriver, LocalDriverOptions, PutOptions, FileMetadata } from '../types'
+import type { StorageDriver, LocalDriverOptions, PutOptions, FileMetadata, GetStreamOptions } from '../types'
 import { warnOnce } from '../../support/warn-once'
 
 /**
@@ -93,6 +95,34 @@ export class LocalDriver implements StorageDriver {
   async getAsString(path: string): Promise<string | null> {
     const content = await this.get(path)
     return content ? content.toString('utf-8') : null
+  }
+
+  async getStream(path: string, options?: GetStreamOptions): Promise<ReadableStream<Uint8Array> | null> {
+    const fullPath = this.fullPath(path)
+
+    // Open before returning: a bare createReadStream() hands back a stream
+    // whose open fails asynchronously, which cannot honour the contract's
+    // `null` for a missing file.
+    let handle: Awaited<ReturnType<typeof open>>
+    try {
+      handle = await open(fullPath, 'r')
+    } catch {
+      return null
+    }
+
+    const stats = await handle.stat()
+    if (!stats.isFile()) {
+      await handle.close()
+      return null
+    }
+
+    // autoClose (default) closes the handle when the stream ends or errors.
+    const nodeStream = handle.createReadStream(
+      options?.range ? { start: options.range.start, end: options.range.end } : undefined,
+    )
+    // node:stream/web's ReadableStream is a distinct type from the global
+    // one; the runtime object is the same — normalize at this boundary.
+    return Readable.toWeb(nodeStream) as unknown as ReadableStream<Uint8Array>
   }
 
   async exists(path: string): Promise<boolean> {

--- a/packages/server/src/storage/drivers/S3Driver.ts
+++ b/packages/server/src/storage/drivers/S3Driver.ts
@@ -1,4 +1,12 @@
-import type { StorageDriver, S3DriverOptions, PutOptions, FileMetadata } from '../types'
+import type {
+  StorageDriver,
+  S3DriverOptions,
+  PutOptions,
+  FileMetadata,
+  GetStreamOptions,
+  TemporaryUrlOptions,
+  StorageDriverCapabilities,
+} from '../types'
 import { assertVisibilitySupported, cannedAcl, putAclFields } from './s3-acl'
 
 /**
@@ -26,6 +34,10 @@ interface S3Client {
  * ```
  */
 export class S3Driver implements StorageDriver {
+  // S3's temporaryUrl() is a real SigV4 presign the bucket enforces —
+  // declared, not probed (RFC 0015 §3).
+  readonly capabilities: StorageDriverCapabilities = { presignedGet: true }
+
   private client: S3Client | null = null
   private readonly bucket: string
   private readonly region: string
@@ -157,6 +169,36 @@ export class S3Driver implements StorageDriver {
     return content ? content.toString('utf-8') : null
   }
 
+  async getStream(path: string, options?: GetStreamOptions): Promise<ReadableStream<Uint8Array> | null> {
+    const client = await this.getClient()
+    const { GetObjectCommand } = await importAwsModule('@aws-sdk/client-s3') as {
+      GetObjectCommand: new (input: unknown) => unknown
+    }
+
+    try {
+      const command = new GetObjectCommand({
+        Bucket: this.bucket,
+        Key: this.prefixKey(path),
+        ...(options?.range
+          ? { Range: `bytes=${options.range.start}-${options.range.end ?? ''}` }
+          : {}),
+      })
+
+      const response = await client.send(command) as {
+        Body?: { transformToWebStream(): ReadableStream<Uint8Array> }
+      }
+
+      // The SDK body is not itself a web stream on Node; the contract is a
+      // global web ReadableStream, so normalize at the driver boundary.
+      return response.Body ? response.Body.transformToWebStream() : null
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'name' in error && error.name === 'NoSuchKey') {
+        return null
+      }
+      throw error
+    }
+  }
+
   async exists(path: string): Promise<boolean> {
     const client = await this.getClient()
     const { HeadObjectCommand } = await importAwsModule('@aws-sdk/client-s3') as {
@@ -251,7 +293,7 @@ export class S3Driver implements StorageDriver {
     return `${this.baseUrl}/${this.prefixKey(path)}`
   }
 
-  async temporaryUrl(path: string, expiration: Date): Promise<string> {
+  async temporaryUrl(path: string, expiration: Date, options?: TemporaryUrlOptions): Promise<string> {
     const client = await this.getClient()
     const { GetObjectCommand } = await importAwsModule('@aws-sdk/client-s3') as {
       GetObjectCommand: new (input: unknown) => unknown
@@ -263,6 +305,12 @@ export class S3Driver implements StorageDriver {
     const command = new GetObjectCommand({
       Bucket: this.bucket,
       Key: this.prefixKey(path),
+      ...(options?.responseContentDisposition
+        ? { ResponseContentDisposition: options.responseContentDisposition }
+        : {}),
+      ...(options?.responseContentType
+        ? { ResponseContentType: options.responseContentType }
+        : {}),
     })
 
     const expiresIn = Math.max(1, Math.floor((expiration.getTime() - Date.now()) / 1000))

--- a/packages/server/src/storage/index.ts
+++ b/packages/server/src/storage/index.ts
@@ -9,6 +9,9 @@ export type {
   S3DriverOptions,
   MemoryDriverOptions,
   DriverConfig,
+  TemporaryUrlOptions,
+  GetStreamOptions,
+  StorageDriverCapabilities,
 } from './types'
 
 export { LocalDriver } from './drivers/LocalDriver'

--- a/packages/server/src/storage/types.ts
+++ b/packages/server/src/storage/types.ts
@@ -54,9 +54,53 @@ export interface FileMetadata {
 }
 
 /**
+ * Response-override options for temporary (presigned) URLs — RFC 0015 §3.
+ *
+ * Drivers that presign map these onto the backend's `response-*` overrides
+ * (S3: `ResponseContentDisposition` / `ResponseContentType` on the presigned
+ * `GetObjectCommand`) so Content-Disposition and Content-Type policy
+ * survives a redirect to the bucket. A driver that cannot honour them
+ * ignores them and serves its own object metadata — a caller that needs the
+ * guarantee must proxy the bytes instead.
+ */
+export interface TemporaryUrlOptions {
+  responseContentDisposition?: string
+  responseContentType?: string
+}
+
+/**
+ * Streaming-read options. `range` is byte-inclusive (`start`..`end`, `end`
+ * omitted = to end of file), matching HTTP Range semantics.
+ */
+export interface GetStreamOptions {
+  range?: { start: number; end?: number }
+}
+
+/**
+ * Capabilities a driver positively declares — RFC 0015 §3. Absent means
+ * none: a capability not declared is treated as unavailable (fail-closed),
+ * never probed. Probing cannot work here: `LocalDriver.temporaryUrl()`
+ * succeeds and returns a plain public URL, so a try/catch probe would
+ * misclassify exactly the disk that must not redirect.
+ */
+export interface StorageDriverCapabilities {
+  /**
+   * `temporaryUrl()` returns a URL whose bearer-signature the backend
+   * itself enforces (S3-style presign) — not merely a URL. `LocalDriver`
+   * must NOT declare this: its `temporaryUrl()` is the plain public URL.
+   */
+  presignedGet?: boolean
+}
+
+/**
  * Storage driver interface.
  */
 export interface StorageDriver {
+  /**
+   * Capabilities the delivery layer may rely on. Absent ⇒ none declared.
+   */
+  readonly capabilities?: StorageDriverCapabilities
+
   /**
    * Put a file into storage.
    * @param path File path
@@ -135,8 +179,26 @@ export interface StorageDriver {
    * Get a temporary (signed) URL for a file.
    * @param path File path
    * @param expiration Expiration date
+   * @param options Response overrides for presigning drivers (ignored by
+   *                drivers that cannot honour them — see TemporaryUrlOptions)
    */
-  temporaryUrl(path: string, expiration: Date): Promise<string>
+  temporaryUrl(path: string, expiration: Date, options?: TemporaryUrlOptions): Promise<string>
+
+  /**
+   * Read a file as a stream. Optional — callers fall back to buffered
+   * `get()` where absent.
+   *
+   * Contract: resolves `null` for a missing file, verified *before* the
+   * stream is returned (a stream whose open fails after return cannot
+   * honour that), and the result is normalized to the global web
+   * `ReadableStream` at the driver's own boundary (`Readable.toWeb`,
+   * `Body.transformToWebStream()`, or a cast where the runtime's stream
+   * type is structurally compatible).
+   *
+   * @param path File path
+   * @param options Optional byte range
+   */
+  getStream?(path: string, options?: GetStreamOptions): Promise<ReadableStream<Uint8Array> | null>
 
   /**
    * Get the file size in bytes.

--- a/packages/server/tests/encryption/signed-url.test.ts
+++ b/packages/server/tests/encryption/signed-url.test.ts
@@ -1,0 +1,120 @@
+import { describe, test, expect } from 'bun:test'
+import {
+  generateKey,
+  parseAppKey,
+  deriveAppKeyring,
+  MessageSigner,
+  signUrl,
+  verifySignedUrl,
+} from '../../src/encryption'
+
+function makeKeyring() {
+  return deriveAppKeyring({ current: parseAppKey(generateKey()), previous: [] }, 'signed-url-test')
+}
+
+describe('signUrl / verifySignedUrl', () => {
+  describe('relative input (RFC 0015 §2)', () => {
+    test('signs an app-relative path and returns a relative URL', () => {
+      const keyring = makeKeyring()
+      const signed = signUrl('/attachments/01J8ZK/report.pdf?variant=thumb', keyring, {
+        expiresIn: 60_000,
+      })
+
+      expect(signed.startsWith('/attachments/01J8ZK/report.pdf?')).toBe(true)
+      // The placeholder base must leak into neither the signature nor the output.
+      expect(signed).not.toContain('relative.invalid')
+      expect(signed).toContain('signature=')
+      expect(signed).toContain('expires=')
+      expect(verifySignedUrl(signed, keyring, { requireExpiration: true })).toBe(true)
+    })
+
+    test('a relative-signed URL verifies when presented on any origin (host-portable by design)', () => {
+      const keyring = makeKeyring()
+      const signed = signUrl('/files/a.png', keyring, { expiresIn: 60_000 })
+
+      expect(verifySignedUrl(`https://app.example${signed}`, keyring)).toBe(true)
+      expect(verifySignedUrl(`https://other.example${signed}`, keyring)).toBe(true)
+    })
+
+    test('tampering with path or query invalidates the signature', () => {
+      const keyring = makeKeyring()
+      const signed = signUrl('/files/a.png?variant=thumb', keyring, { expiresIn: 60_000 })
+
+      expect(verifySignedUrl(signed.replace('/a.png', '/b.png'), keyring)).toBe(false)
+      expect(verifySignedUrl(signed.replace('variant=thumb', 'variant=og'), keyring)).toBe(false)
+    })
+
+    test('absolute URLs keep working unchanged', () => {
+      const keyring = makeKeyring()
+      const signed = signUrl('https://example.com/invite?b=2&a=1', keyring, { expiresIn: 60_000 })
+
+      expect(signed.startsWith('https://example.com/invite?')).toBe(true)
+      expect(verifySignedUrl(signed, keyring)).toBe(true)
+    })
+  })
+
+  describe('canonicalization', () => {
+    test('query order does not affect verification', () => {
+      const keyring = makeKeyring()
+      const signed = signUrl('/p?a=1&B=2', keyring)
+      const signature = new URL(signed, 'https://x.invalid').searchParams.get('signature')
+
+      // The same signature verifies with the parameters reordered.
+      expect(verifySignedUrl(`/p?B=2&a=1&signature=${signature}`, keyring)).toBe(true)
+    })
+
+    test('parameters sort by code unit, not by locale', () => {
+      const keyring = makeKeyring()
+      const signer = new MessageSigner(keyring)
+
+      // Code-unit order puts 'B' (0x42) before 'a' (0x61); locale-aware
+      // collation would reverse them. Pin the direction by verifying
+      // against independently built tokens over each canonical form.
+      const codeUnit = signer.sign({ url: '/p?B=2&a=1' }, { purpose: 'signed-url' })
+      const localeish = signer.sign({ url: '/p?a=1&B=2' }, { purpose: 'signed-url' })
+
+      expect(verifySignedUrl(`/p?a=1&B=2&signature=${codeUnit}`, keyring)).toBe(true)
+      expect(verifySignedUrl(`/p?a=1&B=2&signature=${localeish}`, keyring)).toBe(false)
+    })
+  })
+
+  describe('expiry', () => {
+    test('rejects expired URLs and honours requireExpiration', () => {
+      const keyring = makeKeyring()
+      const expired = signUrl('/p', keyring, { expiresIn: -1000 })
+      const unexpiring = signUrl('/p', keyring)
+
+      expect(verifySignedUrl(expired, keyring)).toBe(false)
+      expect(verifySignedUrl(unexpiring, keyring)).toBe(true)
+      expect(verifySignedUrl(unexpiring, keyring, { requireExpiration: true })).toBe(false)
+    })
+
+    test('non-integer expires values fail closed even when validly signed', () => {
+      const keyring = makeKeyring()
+
+      // Sign URLs that already carry a malformed expires param: the
+      // signature over them is genuine, so only the shape gate can reject.
+      for (const expires of ['NaN', 'Infinity', '-1', '1e10', '9'.repeat(16)]) {
+        const signed = signUrl(`/p?expires=${encodeURIComponent(expires)}`, keyring)
+        expect(verifySignedUrl(signed, keyring)).toBe(false)
+      }
+    })
+
+    test('signUrl rejects a non-finite expiresIn', () => {
+      const keyring = makeKeyring()
+
+      expect(() => signUrl('/p', keyring, { expiresIn: Number.NaN })).toThrow(TypeError)
+      expect(() => signUrl('/p', keyring, { expiresIn: Number.POSITIVE_INFINITY })).toThrow(TypeError)
+    })
+  })
+
+  describe('malformed input', () => {
+    test('verifySignedUrl returns false instead of throwing', () => {
+      const keyring = makeKeyring()
+
+      expect(verifySignedUrl('not a url', keyring)).toBe(false)
+      expect(verifySignedUrl('relative/without/slash', keyring)).toBe(false)
+      expect(verifySignedUrl('/no-signature-param', keyring)).toBe(false)
+    })
+  })
+})

--- a/packages/server/tests/storage/S3Driver.test.ts
+++ b/packages/server/tests/storage/S3Driver.test.ts
@@ -15,6 +15,16 @@ mock.module('@aws-sdk/client-s3', () => ({
   DeleteObjectsCommand: class {
     constructor(readonly input: Record<string, unknown>) {}
   },
+  GetObjectCommand: class {
+    constructor(readonly input: Record<string, unknown>) {}
+  },
+}))
+
+// The presigner is only ever handed the command; echoing its input back as
+// the "URL" lets tests assert what would have been signed.
+mock.module('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: async (_client: unknown, command: { input: Record<string, unknown> }) =>
+    `https://presigned.example/?input=${encodeURIComponent(JSON.stringify(command.input))}`,
 }))
 
 import { S3Driver } from '../../src/storage/drivers/S3Driver'
@@ -182,5 +192,91 @@ describe('S3Driver deleteMany batching', () => {
       (input) => (input.Delete as { Objects: unknown[] }).Objects.length,
     )
     expect(batchSizes).toEqual([1000, 1])
+  })
+})
+
+describe('S3Driver streaming and delivery capabilities (RFC 0015)', () => {
+  it('declares presignedGet — temporaryUrl is a real presign', () => {
+    const driver = new S3Driver({ client: { send: async () => ({}) }, bucket: 'bucket' })
+    expect(driver.capabilities).toEqual({ presignedGet: true })
+  })
+
+  it('getStream normalizes the SDK body via transformToWebStream', async () => {
+    const bytes = new TextEncoder().encode('streamed')
+    const client = {
+      inputs: [] as Array<Record<string, unknown>>,
+      async send(command: unknown): Promise<unknown> {
+        this.inputs.push((command as { input: Record<string, unknown> }).input)
+        return {
+          Body: {
+            transformToWebStream: () => new Blob([bytes]).stream(),
+          },
+        }
+      },
+    }
+    const driver = new S3Driver({ client, bucket: 'bucket', prefix: 'media' })
+
+    const stream = await driver.getStream('dir/a.bin')
+    expect(stream).not.toBeNull()
+    expect(Buffer.from(await new Response(stream!).arrayBuffer())).toEqual(Buffer.from(bytes))
+    expect(client.inputs[0]?.Key).toBe('media/dir/a.bin')
+    expect(client.inputs[0]?.Range).toBeUndefined()
+  })
+
+  it('getStream maps the range option onto an HTTP Range header', async () => {
+    const client = {
+      inputs: [] as Array<Record<string, unknown>>,
+      async send(command: unknown): Promise<unknown> {
+        this.inputs.push((command as { input: Record<string, unknown> }).input)
+        return { Body: { transformToWebStream: () => new Blob([]).stream() } }
+      },
+    }
+    const driver = new S3Driver({ client, bucket: 'bucket' })
+
+    await driver.getStream('a.bin', { range: { start: 5, end: 9 } })
+    await driver.getStream('a.bin', { range: { start: 7 } })
+
+    expect(client.inputs[0]?.Range).toBe('bytes=5-9')
+    expect(client.inputs[1]?.Range).toBe('bytes=7-')
+  })
+
+  it('getStream resolves null for a missing key', async () => {
+    const client = {
+      async send(): Promise<unknown> {
+        const error = new Error('no such key')
+        error.name = 'NoSuchKey'
+        throw error
+      },
+    }
+    const driver = new S3Driver({ client, bucket: 'bucket' })
+
+    expect(await driver.getStream('missing.bin')).toBeNull()
+  })
+
+  it('temporaryUrl forwards response overrides into the presigned command', async () => {
+    const driver = new S3Driver({ client: { send: async () => ({}) }, bucket: 'bucket' })
+
+    const url = await driver.temporaryUrl('doc.pdf', new Date(Date.now() + 60_000), {
+      responseContentDisposition: 'attachment; filename="doc.pdf"',
+      responseContentType: 'application/pdf',
+    })
+
+    const input = JSON.parse(
+      decodeURIComponent(new URL(url).searchParams.get('input') ?? '{}'),
+    ) as Record<string, unknown>
+    expect(input.ResponseContentDisposition).toBe('attachment; filename="doc.pdf"')
+    expect(input.ResponseContentType).toBe('application/pdf')
+    expect(input.Key).toBe('doc.pdf')
+  })
+
+  it('temporaryUrl omits response overrides when none are given', async () => {
+    const driver = new S3Driver({ client: { send: async () => ({}) }, bucket: 'bucket' })
+
+    const url = await driver.temporaryUrl('doc.pdf', new Date(Date.now() + 60_000))
+    const input = JSON.parse(
+      decodeURIComponent(new URL(url).searchParams.get('input') ?? '{}'),
+    ) as Record<string, unknown>
+    expect('ResponseContentDisposition' in input).toBe(false)
+    expect('ResponseContentType' in input).toBe(false)
   })
 })

--- a/packages/server/tests/storage/local-stream.test.ts
+++ b/packages/server/tests/storage/local-stream.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtemp, rm, mkdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { LocalDriver } from '../../src/storage'
+import type { StorageDriver } from '../../src/storage'
+
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
+  return Buffer.from(await new Response(stream).arrayBuffer())
+}
+
+describe('LocalDriver.getStream', () => {
+  let driver: LocalDriver
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'guren-storage-stream-'))
+    driver = new LocalDriver({ root: tmpDir, url: '/storage' })
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('streams the same bytes get() returns', async () => {
+    const content = Buffer.from('streaming works, byte for byte')
+    await driver.put('files/a.bin', content)
+
+    const stream = await driver.getStream('files/a.bin')
+    expect(stream).not.toBeNull()
+    expect(await readAll(stream!)).toEqual(content)
+  })
+
+  it('resolves null for a missing file (verified before the stream is returned)', async () => {
+    expect(await driver.getStream('missing.bin')).toBeNull()
+  })
+
+  it('resolves null for a directory', async () => {
+    await mkdir(join(tmpDir, 'a-directory'))
+    expect(await driver.getStream('a-directory')).toBeNull()
+  })
+
+  it('honours an inclusive byte range', async () => {
+    await driver.put('range.bin', Buffer.from('0123456789'))
+
+    const middle = await driver.getStream('range.bin', { range: { start: 2, end: 5 } })
+    expect((await readAll(middle!)).toString()).toBe('2345')
+
+    const tail = await driver.getStream('range.bin', { range: { start: 7 } })
+    expect((await readAll(tail!)).toString()).toBe('789')
+  })
+
+  it('declares no capabilities (temporaryUrl is not a presign)', () => {
+    expect((driver as StorageDriver).capabilities).toBeUndefined()
+  })
+})

--- a/rfcs/0015-signed-attachment-delivery.md
+++ b/rfcs/0015-signed-attachment-delivery.md
@@ -548,7 +548,7 @@ attachment shown to a user is a private attachment that user can save.
 
 | Package | Adds |
 |---|---|
-| `@guren/server` | `signUrl`/`verifySignedUrl` relative-input support + canonicalization fix; `StorageDriver.getStream?` + `capabilities?`; `LocalDriver.getStream`, `S3Driver.getStream`, `S3Driver.capabilities` |
+| `@guren/server` | the three §2 signer fixes (relative input/output, code-unit canonicalization, strict `expires`); `StorageDriver.getStream?` + `capabilities?` + the §3 `temporaryUrl` response-override options; `LocalDriver.getStream`, `S3Driver.getStream`, `S3Driver.capabilities`, S3 response overrides *(row amended in Part 1: the original omitted the strict-`expires` fix and the `temporaryUrl` bag that §2/§3 already specified)* |
 | `@guren/core` | `delivery` option on `configureAttachments`; `registerAttachmentRoutes` + the delivery controller; `urlFor` switch; **core-native export** → explicit `packages/core/src/index.ts` wiring + a core changeset (allowlist rule) |
 | `@guren/plugin-cloudflare` | `R2Driver.getStream`, `R2Driver.capabilities` (from `presign` presence); Cloudflare guide: "private attachments on the binding, no `presign` needed" |
 | `@guren/cli` | `guren check` rule (§6); scaffold template comment update (`packages/cli/templates/scaffold/attachments/config/attachments.ts`) |
@@ -568,11 +568,14 @@ an app wants to keep.
 
 ### Implementation plan
 
-1. **Part 1 — server:** signer fixes (relative input, code-unit sort)
-   + `getStream?`/`capabilities?` on the interface + Local/S3
-   implementations. Tests: sign/verify round-trips relative and
-   absolute, cross-locale canonicalization, stream vs. buffered
-   parity per driver.
+1. **Part 1 — server:** the §2 signer fixes (relative input/output,
+   code-unit sort, strict `expires`) + `getStream?`/`capabilities?`
+   and the §3 `temporaryUrl` response-override options on the
+   interface + Local/S3 implementations. Tests: sign/verify
+   round-trips relative and absolute, output shape (no placeholder
+   origin), canonicalization order pins, malformed-`expires`
+   rejection, stream vs. buffered parity per driver, response
+   overrides reaching the presigned command.
 2. **Part 2 — core:** `delivery` config + `registerAttachmentRoutes`
    + the controller (verify → load → resolve variant → redirect/proxy
    with §4 headers) + `urlFor` switch + `AttachmentData` passthrough.


### PR DESCRIPTION
## Summary

Part 1 of RFC 0015 (signed attachment delivery): the additive `@guren/server` surface the delivery route builds on. No route yet — that is Part 2 in `@guren/core`.

### Signer fixes (`signUrl` / `verifySignedUrl`)

- **Relative input, relative output.** `signUrl('/attachments/…')` previously threw (`new URL` with no base). App-relative input now parses against a fixed placeholder base and serializes back as `pathname + search` — the placeholder origin reaches neither the signature (canonical form was already path+query) nor the return value. Tests assert the output shape, not just a round-trip, since a leaked placeholder URL still round-trips.
- **Deterministic canonicalization.** Query sorting switches from locale/ICU-dependent `localeCompare` to code-unit comparison; a test pins the direction with independently built tokens over each canonical form. Zero production callers existed, so the fix is compatibility-free.
- **Strict `expires`.** The verifier now requires a plain positive decimal integer (≤15 digits). Previously `Number(expires) < now` let `expires=NaN` and `expires=Infinity` verify forever — and `signUrl(..., { expiresIn: NaN })` happily produced the former; it now throws `TypeError`. Malformed URLs handed to `verifySignedUrl` return `false` instead of throwing.

### Storage surface (all additive)

- `StorageDriver.getStream?(path, { range? })` — optional streaming read. Contract: `null` for a missing file verified **before** the stream is returned, result normalized to the global web `ReadableStream` at the driver's own boundary, byte range inclusive.
  - `LocalDriver`: `fsPromises.open()` first (a bare `createReadStream()` fails asynchronously after return, which cannot honour the `null` contract), then `Readable.toWeb`.
  - `S3Driver`: `Body.transformToWebStream()`, `range` mapped onto the HTTP `Range` header.
- `StorageDriver.capabilities?` — positive self-declaration, absent = none (fail-closed). `S3Driver` declares `{ presignedGet: true }`; `LocalDriver` deliberately declares nothing (its `temporaryUrl()` is the plain public URL — the reason RFC 0015 rejected probing).
- `temporaryUrl(path, expiration, options?)` — optional `TemporaryUrlOptions` bag (`responseContentDisposition` / `responseContentType`); `S3Driver` maps it onto the presigned `GetObjectCommand`'s response overrides so disposition policy survives redirect mode.

### RFC amendment

`rfcs/0015-signed-attachment-delivery.md` §9 table and the Part 1 plan line are amended to name the strict-`expires` fix and the `temporaryUrl` response-override bag, which §2/§3 already specified but the plan rows omitted.

## Testing

- `bun run build`, `bun run typecheck`, `bun run test:bun` (5214 pass / 0 fail), `audit:core-first`, `audit:docs`, `audit:core-semver` all green.
- New tests: relative sign/verify round-trips + output shape, host-portability, tamper cases, canonicalization order pins, malformed-`expires` rejection (signed-but-malformed values), `TypeError` on non-finite `expiresIn`; `LocalDriver.getStream` byte parity/missing/directory/range; `S3Driver` capabilities, `transformToWebStream` normalization, `Range` mapping, `NoSuchKey → null`, response overrides reaching the presigned command.

Changeset: `@guren/server` minor.

Refs: RFC 0015