### PR TITLE
feat(core): signed attachment delivery route (RFC 0015 Part 2)

### DIFF
--- a/.changeset/rfc0015-part2-delivery-route.md
+++ b/.changeset/rfc0015-part2-delivery-route.md
@@ -1,0 +1,31 @@
+---
+'@guren/core': minor
+---
+
+Signed attachment delivery route (RFC 0015 Part 2).
+
+`configureAttachments()` gains a `delivery` option and a widened `disks`
+map (`'public' | 'private' | { visibility, serve }` with
+`serve: 'auto' | 'redirect' | 'proxy' | 'direct'`). With `delivery`
+configured, `attachmentUrl()` and `AttachmentData` URLs for private disks
+become path-relative signed route URLs (HMAC-signed with a keyring derived
+for the `'attachment-delivery'` purpose, expiring after `urlExpiresIn`,
+with per-call `expiresIn` and `disposition` overrides) instead of
+`disk.temporaryUrl()` — closing the v1 gap where "private on the local
+disk" was not actually private and private R2 required `presign`.
+
+`registerAttachmentRoutes(router)` mounts the route
+(`GET /attachments/:id/:filename`, name `attachments.show`, both
+configurable) from the app's route registrar. It serves by verifying the
+signature (uniform 404 on any failure), loading the row, resolving the
+variant at serve time (not-ready variants fall back to the original), and
+then either 302-redirecting to a per-request presigned URL on disks that
+declare `capabilities.presignedGet` (with `Content-Disposition` /
+`Content-Type` carried via the presign response overrides) or proxying the
+bytes with hardened headers: an inline allowlist (SVG/HTML forced to
+`attachment`), `X-Content-Type-Options: nosniff`,
+`Content-Security-Policy: sandbox`, `Referrer-Policy: no-referrer`,
+signed-lifetime-capped `Cache-Control: private`, and an ETag keyed on the
+resolved object with `If-None-Match`/`HEAD` support.
+
+Additive and opt-in: without `delivery`, nothing changes.

--- a/packages/core/src/attachments/Attachable.ts
+++ b/packages/core/src/attachments/Attachable.ts
@@ -87,17 +87,24 @@ export interface AttachableStatic<TBase extends typeof Model, TDecl extends Decl
   ): Promise<Array<TRecord & AttachedProps<TDecl, K>>>
 
   /**
-   * URL for a collection's attachment: `disk.url()` on public disks,
-   * `disk.temporaryUrl()` on private ones. A declared-but-not-ready variant
-   * falls back to the original's URL; a variant name that was never
-   * declared throws. Returns `null` when nothing is attached.
+   * URL for a collection's attachment: `disk.url()` on public disks; on
+   * private ones a signed delivery-route URL when `delivery` is configured
+   * (RFC 0015), else `disk.temporaryUrl()`. A declared-but-not-ready
+   * variant falls back to the original; a variant name that was never
+   * declared throws. `expiresIn` (ms) overrides the configured
+   * `urlExpiresIn` for this one URL. Returns `null` when nothing is
+   * attached.
    */
   attachmentUrl<K extends keyof TDecl & string>(
     record: PlainObject | AttachableRecordId,
     collection: K,
     // NoInfer: without it, `variant` becomes a second inference site for K
     // and widens it to whichever union of collections admits the name.
-    options?: { variant?: VariantNamesOf<TDecl[NoInfer<K>]> },
+    options?: {
+      variant?: VariantNamesOf<TDecl[NoInfer<K>]>
+      expiresIn?: number
+      disposition?: 'inline' | 'attachment'
+    },
   ): Promise<string | null>
 
   /**
@@ -177,7 +184,7 @@ export function Attachable<
       this: typeof Model,
       record: PlainObject | AttachableRecordId,
       collection: string,
-      options?: { variant?: string },
+      options?: { variant?: string; expiresIn?: number; disposition?: 'inline' | 'attachment' },
     ) {
       const engine = resolveAttachmentEngine(`${this.name}.attachmentUrl()`)
       return engine.attachmentUrl(this, decl, record, collection, options)

--- a/packages/core/src/attachments/Attachable.ts
+++ b/packages/core/src/attachments/Attachable.ts
@@ -1,6 +1,6 @@
 import type { Model, PlainObject } from '@guren/orm'
 import type { AttachmentsDeclaration } from './declaration.js'
-import { resolveAttachmentEngine, type AttachOptions } from './engine.js'
+import { resolveAttachmentEngine, type AttachOptions, type AttachmentUrlOptions } from './engine.js'
 import type { AttachmentData, AttachmentRecord, AttachmentSource } from './types.js'
 
 /** A record id accepted by the attachment statics (int and uuid/text PKs). */
@@ -100,11 +100,7 @@ export interface AttachableStatic<TBase extends typeof Model, TDecl extends Decl
     collection: K,
     // NoInfer: without it, `variant` becomes a second inference site for K
     // and widens it to whichever union of collections admits the name.
-    options?: {
-      variant?: VariantNamesOf<TDecl[NoInfer<K>]>
-      expiresIn?: number
-      disposition?: 'inline' | 'attachment'
-    },
+    options?: AttachmentUrlOptions & { variant?: VariantNamesOf<TDecl[NoInfer<K>]> },
   ): Promise<string | null>
 
   /**
@@ -184,7 +180,7 @@ export function Attachable<
       this: typeof Model,
       record: PlainObject | AttachableRecordId,
       collection: string,
-      options?: { variant?: string; expiresIn?: number; disposition?: 'inline' | 'attachment' },
+      options?: AttachmentUrlOptions & { variant?: string },
     ) {
       const engine = resolveAttachmentEngine(`${this.name}.attachmentUrl()`)
       return engine.attachmentUrl(this, decl, record, collection, options)

--- a/packages/core/src/attachments/delivery.ts
+++ b/packages/core/src/attachments/delivery.ts
@@ -1,37 +1,25 @@
 import { Controller, type Router } from '@guren/server'
-import {
-  DEFAULT_DELIVERY_PREFIX,
-  DEFAULT_DELIVERY_ROUTE_NAME,
-  getActiveAttachmentEngine,
-} from './engine.js'
+import { resolveAttachmentEngine, resolveDeliveryRoute } from './engine.js'
 
 /**
  * The signed attachment delivery route's controller (RFC 0015 §1). Thin on
- * purpose: it parses the request and hands everything to the engine, which
- * owns verification, variant resolution, and the redirect/proxy split —
- * so the serving contract is testable without HTTP.
+ * purpose: it hands the raw `Request` to the engine, which owns
+ * verification, variant resolution, and the redirect/proxy split — so the
+ * serving contract is testable without HTTP.
+ *
+ * Raw on purpose, too: every semantic parameter must be re-read from the
+ * same `URLSearchParams` parse the signature canonicalizes with. Hono's
+ * query decoder disagrees with `URLSearchParams` on malformed
+ * percent-encoding, and a parser mismatch there is a signed-URL rewrite
+ * primitive.
  */
 export class AttachmentDeliveryController extends Controller {
   async show(): Promise<Response> {
-    const engine = getActiveAttachmentEngine()
-    if (!engine) {
-      // A mounted route without a configured engine is a server
-      // misconfiguration, not a client error — say so plainly.
-      return new Response(
-        'Attachments are not configured. Call configureAttachments({ ..., delivery: {} }) at boot.',
-        { status: 500, headers: { 'Content-Type': 'text/plain; charset=utf-8' } },
-      )
-    }
-
-    const params = this.ctx.req.param() as Record<string, string>
-    return engine.handleDeliveryRequest({
-      url: new URL(this.ctx.req.url),
-      id: params.id ?? '',
-      variant: this.query('variant'),
-      disposition: this.query('disposition'),
-      ifNoneMatch: this.ctx.req.header('if-none-match'),
-      method: this.ctx.req.method,
-    })
+    // A mounted route without a configured engine is a server
+    // misconfiguration; the resolver's throw goes through the
+    // ExceptionHandler (reported, 500) like every other attachments API.
+    const engine = resolveAttachmentEngine('The attachments delivery route')
+    return engine.handleDeliveryRequest(this.ctx.req.raw)
   }
 }
 
@@ -58,8 +46,6 @@ export class AttachmentDeliveryController extends Controller {
  * route name are picked up whenever they exist.
  */
 export function registerAttachmentRoutes(router: Router): void {
-  const delivery = getActiveAttachmentEngine()?.deliveryRoute
-  const prefix = delivery?.prefix ?? DEFAULT_DELIVERY_PREFIX
-  const routeName = delivery?.routeName ?? DEFAULT_DELIVERY_ROUTE_NAME
+  const { prefix, routeName } = resolveDeliveryRoute()
   router.get(`${prefix}/:id/:filename`, [AttachmentDeliveryController, 'show']).name(routeName)
 }

--- a/packages/core/src/attachments/delivery.ts
+++ b/packages/core/src/attachments/delivery.ts
@@ -1,0 +1,65 @@
+import { Controller, type Router } from '@guren/server'
+import {
+  DEFAULT_DELIVERY_PREFIX,
+  DEFAULT_DELIVERY_ROUTE_NAME,
+  getActiveAttachmentEngine,
+} from './engine.js'
+
+/**
+ * The signed attachment delivery route's controller (RFC 0015 §1). Thin on
+ * purpose: it parses the request and hands everything to the engine, which
+ * owns verification, variant resolution, and the redirect/proxy split —
+ * so the serving contract is testable without HTTP.
+ */
+export class AttachmentDeliveryController extends Controller {
+  async show(): Promise<Response> {
+    const engine = getActiveAttachmentEngine()
+    if (!engine) {
+      // A mounted route without a configured engine is a server
+      // misconfiguration, not a client error — say so plainly.
+      return new Response(
+        'Attachments are not configured. Call configureAttachments({ ..., delivery: {} }) at boot.',
+        { status: 500, headers: { 'Content-Type': 'text/plain; charset=utf-8' } },
+      )
+    }
+
+    const params = this.ctx.req.param() as Record<string, string>
+    return engine.handleDeliveryRequest({
+      url: new URL(this.ctx.req.url),
+      id: params.id ?? '',
+      variant: this.query('variant'),
+      disposition: this.query('disposition'),
+      ifNoneMatch: this.ctx.req.header('if-none-match'),
+      method: this.ctx.req.method,
+    })
+  }
+}
+
+/**
+ * Mount the signed delivery route (RFC 0015 §6) — call it from the app's
+ * route registrar:
+ *
+ * ```ts
+ * // routes/web.ts
+ * import { registerAttachmentRoutes } from '@guren/core'
+ *
+ * export function registerWebRoutes(router: Router): void {
+ *   registerAttachmentRoutes(router)
+ *   // …app routes…
+ * }
+ * ```
+ *
+ * Registration never throws and does not require `configureAttachments()`
+ * to have run: route tooling (`routes:types`, `guren check`, audit,
+ * OpenAPI) invokes registrars against a bare `Router` with no providers
+ * booted, so a config-dependent throw here would break every inspection
+ * tool. The controller resolves the engine per request instead; at runtime
+ * providers register before routes mount, so the configured prefix and
+ * route name are picked up whenever they exist.
+ */
+export function registerAttachmentRoutes(router: Router): void {
+  const delivery = getActiveAttachmentEngine()?.deliveryRoute
+  const prefix = delivery?.prefix ?? DEFAULT_DELIVERY_PREFIX
+  const routeName = delivery?.routeName ?? DEFAULT_DELIVERY_ROUTE_NAME
+  router.get(`${prefix}/:id/:filename`, [AttachmentDeliveryController, 'show']).name(routeName)
+}

--- a/packages/core/src/attachments/engine.ts
+++ b/packages/core/src/attachments/engine.ts
@@ -148,6 +148,30 @@ export type DiskDeliveryConfig =
   | 'private'
   | { visibility: 'public' | 'private'; serve?: DeliveryServeMode }
 
+/**
+ * Per-URL options for `attachmentUrl()`. `disposition` accepts only
+ * `'attachment'`: `inline` is already the default outcome for allowlisted
+ * types, and the route's allowlist can never be forced to inline — a
+ * signed `inline` value would change the URL while doing nothing.
+ */
+export interface AttachmentUrlOptions {
+  expiresIn?: number
+  disposition?: 'attachment'
+}
+
+/**
+ * The public union normalized once at the constructor boundary. `'direct'`
+ * splits into its two real axes here — `route: false` (URL minting
+ * bypasses the delivery route) with `serve: 'auto'` (a signed URL that
+ * still arrives, minted before the config change, serves normally) — so
+ * no later branch has to remember that `direct` secretly means `auto`.
+ */
+interface ResolvedDiskDelivery {
+  visibility: 'public' | 'private'
+  route: boolean
+  serve: 'auto' | 'redirect' | 'proxy'
+}
+
 export interface DeliveryOptions {
   /**
    * Route prefix the delivery URLs live under.
@@ -163,20 +187,17 @@ export interface DeliveryOptions {
   routeName?: string
 }
 
-/** What the delivery controller hands the engine per request. */
-export interface DeliveryRequest {
-  /** Full request URL (path + query carry the signature). */
-  url: URL
-  /** The `:id` route parameter. */
-  id: string
-  variant?: string
-  disposition?: string
-  ifNoneMatch?: string
-  method: string
-}
-
 export const DEFAULT_DELIVERY_PREFIX = '/attachments'
 export const DEFAULT_DELIVERY_ROUTE_NAME = 'attachments.show'
+
+/**
+ * The inner (presigned) TTL behind a redirect. Fixed rather than derived
+ * from `urlExpiresIn`: the inner credential is minted per request, so it
+ * never needs to outlive one fetch — and deriving it would let a raised
+ * outer lifetime silently exceed a driver's presign ceiling (R2 rejects
+ * anything over 7 days).
+ */
+const INNER_PRESIGN_TTL_MS = 5 * 60 * 1000
 
 export interface PruneOptions {
   /** Also delete `attachments/` storage prefixes that no row references. */
@@ -282,7 +303,7 @@ export class AttachmentEngine {
   readonly model: typeof Model
   private readonly storage: () => StorageManager
   private readonly defaultDisk: string
-  private readonly diskDelivery: Record<string, { visibility: 'public' | 'private'; serve: DeliveryServeMode }>
+  private readonly diskDelivery: Record<string, ResolvedDiskDelivery>
   private readonly delivery: { prefix: string; routeName: string } | null
   private deliveryKeys: AppKeyring | null = null
   private readonly maxPixels: number
@@ -473,7 +494,7 @@ export class AttachmentEngine {
     declaration: AttachmentsDeclaration,
     recordOrId: PlainObject | string | number,
     collection: string,
-    options: { variant?: string; expiresIn?: number; disposition?: 'inline' | 'attachment' } = {},
+    options: AttachmentUrlOptions & { variant?: string } = {},
   ): Promise<string | null> {
     const spec = this.specFor(model, declaration, collection)
     const variant = options.variant
@@ -1143,11 +1164,16 @@ export class AttachmentEngine {
     return this.diskDelivery[diskName]?.visibility ?? 'public'
   }
 
-  private serveModeFor(diskName: string): DeliveryServeMode {
+  private serveModeFor(diskName: string): 'auto' | 'redirect' | 'proxy' {
     return this.diskDelivery[diskName]?.serve ?? 'auto'
   }
 
-  /** The normalized delivery route config, for `registerAttachmentRoutes`. */
+  /** Whether URL minting for this disk goes through the delivery route (`serve: 'direct'` opts out). */
+  private routeEnabledFor(diskName: string): boolean {
+    return this.diskDelivery[diskName]?.route ?? true
+  }
+
+  /** The normalized delivery route config, for `resolveDeliveryRoute()`. */
   get deliveryRoute(): { prefix: string; routeName: string } | null {
     return this.delivery
   }
@@ -1168,21 +1194,51 @@ export class AttachmentEngine {
    * configured (and the disk did not opt out with `serve: 'direct'`), else
    * the v1 `temporaryUrl()` behaviour with its documented limitations.
    */
+  /** Whether URLs for this row are minted through the delivery route. */
+  private usesDeliveryRoute(row: AttachmentRecord): boolean {
+    return (
+      this.visibilityOf(row.disk) === 'private' && this.delivery !== null && this.routeEnabledFor(row.disk)
+    )
+  }
+
+  /**
+   * The one variant-resolution rule (RFC 0013 §7 / RFC 0015 §1), shared by
+   * URL minting, resource payloads, and the delivery route: a `ready`
+   * entry resolves to the variant's key and format-derived MIME type
+   * (variants are transcoded — serving them under the original's type with
+   * `nosniff` would be self-sabotage); anything else — `pending`,
+   * `failed`, `unavailable`, or an entry missing entirely on a row
+   * attached before the variant was declared — falls back to the original.
+   */
+  private resolveVariantTarget(
+    row: AttachmentRecord,
+    variant?: string,
+  ): { path: string; contentType: string; size: number | null; ready: boolean } {
+    const entry = variant ? row.variants?.[variant] : undefined
+    if (entry?.status === 'ready' && entry.path) {
+      return {
+        path: entry.path,
+        contentType: (entry.format && IMAGE_MIME[entry.format]) || 'application/octet-stream',
+        size: entry.size ?? null,
+        ready: true,
+      }
+    }
+    return { path: row.path, contentType: row.contentType, size: row.size, ready: false }
+  }
+
   private async urlForRow(
     row: AttachmentRecord,
-    options: { variant?: string; expiresIn?: number; disposition?: 'inline' | 'attachment' },
+    options: AttachmentUrlOptions & { variant?: string },
   ): Promise<string> {
-    const isPrivate = this.visibilityOf(row.disk) === 'private'
-    if (isPrivate && this.delivery && this.serveModeFor(row.disk) !== 'direct') {
+    if (this.usesDeliveryRoute(row)) {
       return this.signDeliveryUrl(row, options)
     }
 
     // Generation-time variant fallback, as v1 shipped it: a declared-but-
     // not-ready variant resolves to the original's key.
-    const entry = options.variant ? row.variants?.[options.variant] : undefined
-    const path = entry?.status === 'ready' && entry.path ? entry.path : row.path
+    const { path } = this.resolveVariantTarget(row, options.variant)
     const disk = this.storage().disk(row.disk)
-    if (isPrivate) {
+    if (this.visibilityOf(row.disk) === 'private') {
       return disk.temporaryUrl(path, new Date(Date.now() + (options.expiresIn ?? this.urlExpiresIn)))
     }
     return disk.url(path)
@@ -1197,7 +1253,7 @@ export class AttachmentEngine {
    */
   private signDeliveryUrl(
     row: AttachmentRecord,
-    options: { variant?: string; expiresIn?: number; disposition?: 'inline' | 'attachment' },
+    options: AttachmentUrlOptions & { variant?: string },
   ): string {
     const params = new URLSearchParams()
     if (options.variant) params.set('variant', options.variant)
@@ -1205,7 +1261,9 @@ export class AttachmentEngine {
     // parameter can force `attachment`, never `inline`.
     if (options.disposition) params.set('disposition', options.disposition)
     const query = params.size > 0 ? `?${params}` : ''
-    const path = `${this.delivery!.prefix}/${encodeURIComponent(row.id)}/${encodeURIComponent(row.name)}`
+    // wellFormed: a stored name with a lone surrogate (a legacy row whose
+    // truncation split a pair) must not make encodeURIComponent throw.
+    const path = `${this.delivery!.prefix}/${encodeURIComponent(row.id)}/${encodeURIComponent(wellFormed(row.name))}`
     return signUrl(`${path}${query}`, this.deliveryKeyring(), {
       expiresIn: options.expiresIn ?? this.urlExpiresIn,
     })
@@ -1216,57 +1274,73 @@ export class AttachmentEngine {
    * resolve → redirect or proxy. Everything before the row load is one
    * HMAC per keyring key, and every failure is the same 404 — invalid
    * signature, expired URL, and unknown id must be indistinguishable.
+   *
+   * Takes the raw web `Request`: every semantic parameter (id, variant,
+   * disposition, expires) is re-read from the *same* `URL`/`URLSearchParams`
+   * parse the signature verification canonicalizes with. A route
+   * framework's own query decoder disagrees with `URLSearchParams` on
+   * malformed percent-encoding, and a parser mismatch there is a signed-URL
+   * rewrite primitive.
    */
-  async handleDeliveryRequest(request: DeliveryRequest): Promise<Response> {
+  async handleDeliveryRequest(request: Request): Promise<Response> {
     const notFound = () =>
       new Response('Not Found', { status: 404, headers: { 'X-Content-Type-Options': 'nosniff' } })
 
     // Without delivery config this engine never signed anything; uniform 404.
     if (!this.delivery) return notFound()
 
-    const signedPart = `${request.url.pathname}${request.url.search}`
+    const url = new URL(request.url)
+    const signedPart = `${url.pathname}${url.search}`
     if (!verifySignedUrl(signedPart, this.deliveryKeyring(), { requireExpiration: true })) {
       return notFound()
     }
 
-    const raw = (await this.model.find(request.id)) as PlainObject | null
+    // The id is the first path segment after the prefix. Only URLs this
+    // engine signed reach this point, so the decode cannot throw for real
+    // traffic; the catch is defense in depth, not a code path.
+    let id: string
+    try {
+      id = decodeURIComponent(url.pathname.slice(this.delivery.prefix.length + 1).split('/')[0] ?? '')
+    } catch {
+      return notFound()
+    }
+    const variant = url.searchParams.get('variant') ?? undefined
+    const forceAttachment = url.searchParams.get('disposition') === 'attachment'
+
+    const raw = (await this.model.find(id)) as PlainObject | null
     if (!raw) return notFound()
     const row = this.toRecord(raw)
 
     // The valid signature proves the variant was declared when the URL was
     // minted (attachmentUrl throws on undeclared names before signing), so
-    // variant state never 404s: anything not `ready` — including an entry
-    // missing entirely on a row attached before the variant was declared —
-    // serves the original (RFC 0015 §1).
-    const entry = request.variant ? row.variants?.[request.variant] : undefined
-    const target =
-      entry?.status === 'ready' && entry.path
-        ? {
-            path: entry.path,
-            contentType: (entry.format && IMAGE_MIME[entry.format]) || 'application/octet-stream',
-            size: entry.size ?? null,
-          }
-        : { path: row.path, contentType: row.contentType, size: row.size }
+    // variant state never 404s — resolveVariantTarget falls back to the
+    // original (RFC 0015 §1).
+    const target = this.resolveVariantTarget(row, variant)
 
     // `expires` passed verification, so it is a plain integer in seconds.
-    const remainingMs = Math.max(
-      0,
-      Number(request.url.searchParams.get('expires')) * 1000 - Date.now(),
-    )
+    const remainingMs = Math.max(0, Number(url.searchParams.get('expires')) * 1000 - Date.now())
 
-    const disposition = contentDispositionFor(target.contentType, request.disposition, row.name)
+    const disposition = contentDispositionFor(target.contentType, forceAttachment, wellFormed(row.name))
     const disk = this.storage().disk(row.disk)
     const mode = this.serveModeFor(row.disk)
-    // 'direct' disks never mint route URLs, but a signed URL that reaches
-    // us anyway (minted before the config change) is served like 'auto'.
-    const redirect =
-      mode === 'redirect' || (mode !== 'proxy' && disk.capabilities?.presignedGet === true)
+    // Fail closed at the comparison site: redirecting requires the driver's
+    // *positive* presignedGet declaration, whatever the configured mode —
+    // `serve: 'redirect'` on a disk that cannot presign would 302 to
+    // whatever temporaryUrl() returns (LocalDriver's is the plain public
+    // URL: the exact fail-open this route exists to close). The
+    // misconfiguration downgrades to proxy and says so once.
+    const canPresign = disk.capabilities?.presignedGet === true
+    if (mode === 'redirect' && !canPresign) {
+      warnRedirectDowngradeOnce(row.disk)
+    }
+    const redirect = canPresign && mode !== 'proxy'
 
     if (redirect) {
-      // Minted per request and capped: a long-lived route URL must not
-      // force a long presign (R2 rejects > 7 days) — the inner URL is
-      // always fresh and short.
-      const inner = new Date(Date.now() + Math.min(Math.max(remainingMs, 1_000), this.urlExpiresIn))
+      // Minted per request with a fixed short TTL: the inner credential
+      // only needs to survive one fetch, and a TTL derived from the outer
+      // lifetime would let a raised urlExpiresIn exceed a driver's presign
+      // ceiling (R2 rejects > 7 days).
+      const inner = new Date(Date.now() + Math.min(remainingMs, INNER_PRESIGN_TTL_MS))
       const location = await disk.temporaryUrl(target.path, inner, {
         responseContentDisposition: disposition,
         responseContentType: target.contentType,
@@ -1282,7 +1356,7 @@ export class AttachmentEngine {
       })
     }
 
-    const etag = deliveryEtag(target.path, target.size)
+    const etag = deliveryEtag(target.path, target.size, row.updatedAt)
     const headers: Record<string, string> = {
       'Content-Type': target.contentType,
       'Content-Disposition': disposition,
@@ -1297,16 +1371,20 @@ export class AttachmentEngine {
       ETag: etag,
     }
 
-    if (request.ifNoneMatch === etag) {
+    // A 304 asserts the client's cached copy is still valid — reachable
+    // only when the client already holds the bytes, so no storage check.
+    if (ifNoneMatchSatisfied(request.headers.get('if-none-match'), etag)) {
       return new Response(null, { status: 304, headers })
     }
 
     if (target.size != null) headers['Content-Length'] = String(target.size)
 
     // Hono dispatches HEAD through the GET handler and drops the body;
-    // without this branch every HEAD would pay for the storage read.
+    // without this branch every HEAD would pay for the storage read. A
+    // HEAD 200 still asserts existence, so the object is checked — an
+    // exists() head, not a body read.
     if (request.method === 'HEAD') {
-      return new Response(null, { headers })
+      return (await disk.exists(target.path)) ? new Response(null, { headers }) : notFound()
     }
 
     const body = disk.getStream ? await disk.getStream(target.path) : await disk.get(target.path)
@@ -1317,19 +1395,23 @@ export class AttachmentEngine {
   }
 
   private async toData(row: AttachmentRecord, spec: AttachmentCollectionSpec): Promise<AttachmentData> {
+    const viaRoute = this.usesDeliveryRoute(row)
     const originalUrl = await this.urlForRow(row, {})
     const variants: AttachmentData['variants'] = {}
     for (const name of Object.keys(spec.variants ?? {})) {
+      const target = this.resolveVariantTarget(row, name)
       const entry = row.variants?.[name]
-      const ready = entry?.status === 'ready' && entry.path
       // Not-ready variants fall back to the original so pages keep
-      // rendering (the placeholder LQIP covers the gap): on a public disk
-      // that resolution happens here, on a delivery-route disk the URL
-      // carries the variant and the route resolves at serve time.
+      // rendering (the placeholder LQIP covers the gap). On a delivery-
+      // route disk the URL carries the variant and the route resolves at
+      // serve time; everywhere else the fallback resolves *here*, reusing
+      // `originalUrl` byte for byte — v1 semantics, and one temporaryUrl()
+      // call per row instead of one per pending variant.
       variants[name] = {
-        url: await this.urlForRow(row, { variant: name }),
-        width: ready ? (entry.width ?? null) : null,
-        height: ready ? (entry.height ?? null) : null,
+        url:
+          viaRoute || target.ready ? await this.urlForRow(row, { variant: name }) : originalUrl,
+        width: target.ready ? (entry?.width ?? null) : null,
+        height: target.ready ? (entry?.height ?? null) : null,
       }
     }
     return {
@@ -1389,6 +1471,21 @@ export function getActiveAttachmentEngine(): AttachmentEngine | null {
   return activeEngine
 }
 
+/**
+ * The delivery route's prefix and name: the configured values when an
+ * engine is active, the defaults otherwise (bootless route tooling invokes
+ * registrars with no providers booted). The one place the defaults are
+ * applied outside the engine constructor.
+ */
+export function resolveDeliveryRoute(): { prefix: string; routeName: string } {
+  return (
+    activeEngine?.deliveryRoute ?? {
+      prefix: DEFAULT_DELIVERY_PREFIX,
+      routeName: DEFAULT_DELIVERY_ROUTE_NAME,
+    }
+  )
+}
+
 export function resolveAttachmentEngine(caller: string): AttachmentEngine {
   if (!activeEngine) {
     throw new Error(
@@ -1430,7 +1527,12 @@ async function normalizeSource(source: AttachmentSource, nameOverride?: string):
  */
 export function sanitizeFilename(name: string): string {
   const base = name.split(/[/\\]/).pop() ?? ''
-  const cleaned = base.replace(/[\u0000-\u001f\u007f]/g, '').trim().slice(0, 200)
+  // Truncate by code point, not code unit: a slice() that lands inside a
+  // surrogate pair leaves a lone surrogate that later throws in
+  // encodeURIComponent (delivery URLs, RFC 5987 disposition names).
+  const cleaned = Array.from(base.replace(/[\u0000-\u001f\u007f]/g, '').trim())
+    .slice(0, 200)
+    .join('')
   if (cleaned === '' || /^\.+$/.test(cleaned)) return 'file'
   return cleaned
 }
@@ -1461,21 +1563,39 @@ function sortById(rows: PlainObject[]): PlainObject[] {
 
 function normalizeDiskDelivery(
   disks: Record<string, DiskDeliveryConfig>,
-): Record<string, { visibility: 'public' | 'private'; serve: DeliveryServeMode }> {
-  const normalized: Record<string, { visibility: 'public' | 'private'; serve: DeliveryServeMode }> = {}
+): Record<string, ResolvedDiskDelivery> {
+  const normalized: Record<string, ResolvedDiskDelivery> = {}
   for (const [name, config] of Object.entries(disks)) {
-    normalized[name] =
-      typeof config === 'string'
-        ? { visibility: config, serve: 'auto' }
-        : { visibility: config.visibility, serve: config.serve ?? 'auto' }
+    if (typeof config === 'string') {
+      normalized[name] = { visibility: config, route: true, serve: 'auto' }
+    } else {
+      const serve = config.serve ?? 'auto'
+      normalized[name] = {
+        visibility: config.visibility,
+        route: serve !== 'direct',
+        serve: serve === 'direct' ? 'auto' : serve,
+      }
+    }
   }
   return normalized
 }
 
 function normalizeDeliveryPrefix(prefix: string): string {
-  const trimmed = prefix.replace(/\/+$/, '')
-  if (!trimmed.startsWith('/')) {
-    throw new Error(`configureAttachments: delivery.prefix must start with '/', got '${prefix}'.`)
+  // Loop, not /\/+$/: the regex form backtracks polynomially on
+  // slash-heavy input — the reason trimTrailingSlashes exists in
+  // @guren/server's support module (same loop as S3Driver.listingPrefix).
+  let end = prefix.length
+  while (end > 0 && prefix.charCodeAt(end - 1) === 0x2f /* '/' */) {
+    end--
+  }
+  const trimmed = prefix.slice(0, end)
+  // Anything URL parsing would reinterpret cannot be a route prefix: a
+  // '//' start becomes an authority, '?'/'#' swallow the id and filename
+  // segments, and whitespace never survives a real URL.
+  if (!trimmed.startsWith('/') || trimmed.startsWith('//') || /[?#\s]/.test(trimmed)) {
+    throw new Error(
+      `configureAttachments: delivery.prefix must be a plain absolute path ('/attachments'-shaped), got '${prefix}'.`,
+    )
   }
   return trimmed
 }
@@ -1500,15 +1620,52 @@ const INLINE_CONTENT_TYPES = new Set([
 
 function contentDispositionFor(
   contentType: string,
-  requested: string | undefined,
+  forceAttachment: boolean,
   filename: string,
 ): string {
-  const kind =
-    requested === 'attachment' || !INLINE_CONTENT_TYPES.has(contentType) ? 'attachment' : 'inline'
+  const kind = forceAttachment || !INLINE_CONTENT_TYPES.has(contentType) ? 'attachment' : 'inline'
   // Plain-ASCII fallback plus the RFC 5987 form for everything else; the
   // stored name is already sanitized (no separators, no control chars).
   const fallback = filename.replace(/[^\x20-\x7e]/g, '_').replace(/["\\]/g, '_')
   return `${kind}; filename="${fallback}"; filename*=UTF-8''${encodeRfc5987(filename)}`
+}
+
+/**
+ * `If-None-Match` per RFC 9110: a comma-separated list of entity tags (or
+ * `*`), compared weakly — a `W/` prefix on either side does not break the
+ * match.
+ */
+function ifNoneMatchSatisfied(header: string | null, etag: string): boolean {
+  if (!header) return false
+  const trimmed = header.trim()
+  if (trimmed === '*') return true
+  const strip = (value: string) => (value.startsWith('W/') ? value.slice(2) : value)
+  const target = strip(etag)
+  return trimmed.split(',').some((candidate) => strip(candidate.trim()) === target)
+}
+
+/**
+ * Replace lone surrogates so `encodeURIComponent` cannot throw on a stored
+ * name whose truncation once split a pair. `String#toWellFormed` is
+ * ES2024 (Bun, Node ≥ 20); older runtimes fall through — their names were
+ * produced by the same truncation and are overwhelmingly well-formed.
+ */
+function wellFormed(value: string): string {
+  const candidate = value as string & { toWellFormed?: () => string }
+  return typeof candidate.toWellFormed === 'function' ? candidate.toWellFormed() : value
+}
+
+const warnedRedirectDowngrades = new Set<string>()
+
+function warnRedirectDowngradeOnce(diskName: string): void {
+  if (warnedRedirectDowngrades.has(diskName)) return
+  warnedRedirectDowngrades.add(diskName)
+  console.warn(
+    `[guren] Attachments disk '${diskName}' is configured serve: 'redirect' but its driver does not declare `
+      + `capabilities.presignedGet — redirecting would hand out whatever temporaryUrl() returns, which on a `
+      + `local disk is the plain public URL. Serving via proxy instead; fix the disk's serve mode or use a `
+      + `presign-capable driver.`,
+  )
 }
 
 /** RFC 5987 attr-char escaping: encodeURIComponent leaves !'()* unescaped. */
@@ -1523,10 +1680,15 @@ function encodeRfc5987(value: string): string {
  * A validator over the *resolved object*, not the request: `id + variant`
  * is not a byte identity (a pending variant resolves to original bytes
  * today and variant bytes tomorrow; queued HEIC conversion rewrites the
- * path under the same row id), but the resolved key + size move in both
- * cases, so the validator moves with the bytes.
+ * path under the same row id). Resolved key + size move in both of those
+ * cases; `updatedAt` covers the one they miss — a same-key rewrite with
+ * different bytes of the same length (queued variant regeneration), which
+ * always lands with a row update.
  */
-function deliveryEtag(path: string, size: number | null): string {
-  const digest = createHash('sha256').update(`${path}:${size ?? ''}`).digest('base64url').slice(0, 20)
+function deliveryEtag(path: string, size: number | null, updatedAt: Date): string {
+  const digest = createHash('sha256')
+    .update(`${path}:${size ?? ''}:${updatedAt.getTime()}`)
+    .digest('base64url')
+    .slice(0, 20)
   return `"${digest}"`
 }

--- a/packages/core/src/attachments/engine.ts
+++ b/packages/core/src/attachments/engine.ts
@@ -1,9 +1,15 @@
+import { createHash } from 'node:crypto'
 import { Model, type PlainObject } from '@guren/orm'
 import {
+  deriveAppKeyring,
+  getAppKeyringFromEnv,
   getQueueDriver,
   setQueueDriver,
+  signUrl,
+  verifySignedUrl,
   HttpException,
   ValidationException,
+  type AppKeyring,
   type StorageDriver,
   type StorageManager,
 } from '@guren/server'
@@ -53,12 +59,22 @@ export interface ConfigureAttachmentsOptions {
   /** Default disk name for new attachments. */
   disk: string
   /**
-   * Per-disk visibility: `'public'` disks serve via `disk.url()`, `'private'`
-   * ones via `disk.temporaryUrl()`. Per disk, not per attachment, because at
-   * least one driver (R2) has no per-object visibility. Undeclared disks
-   * default to `'public'`.
+   * Per-disk visibility (and, with the object form, how a private disk's
+   * bytes are served — RFC 0015 §3). `'public'` disks serve via
+   * `disk.url()`; `'private'` ones serve through the signed delivery route
+   * when `delivery` is configured, else via `disk.temporaryUrl()`. Per
+   * disk, not per attachment, because at least one driver (R2) has no
+   * per-object visibility. Undeclared disks default to `'public'`.
    */
-  disks?: Record<string, 'public' | 'private'>
+  disks?: Record<string, DiskDeliveryConfig>
+  /**
+   * Signed delivery route configuration (RFC 0015). Presence switches
+   * private-disk URLs from `disk.temporaryUrl()` to signed route URLs; the
+   * route itself is mounted by `registerAttachmentRoutes(router)` in the
+   * app's route registrar. Without this option nothing changes — v1
+   * behaviour and its documented limitations stand.
+   */
+  delivery?: DeliveryOptions
   /**
    * Decode cap in pixels (decompression-bomb defense). Header-declared and
    * decoded dimensions above this are rejected before a pixel buffer is
@@ -113,6 +129,54 @@ export interface GenerateVariantsPayload {
   heic?: HeicPolicy
   variants?: Record<string, VariantSpec>
 }
+
+/**
+ * How a private disk's bytes are served behind the signed route
+ * (RFC 0015 §3):
+ * - `'auto'` (default): redirect when the driver positively declares
+ *   `capabilities.presignedGet`, else proxy. Declared, never probed —
+ *   `LocalDriver.temporaryUrl()` succeeds with a plain public URL, so a
+ *   probe would misclassify exactly the disk that must not redirect.
+ * - `'redirect'` / `'proxy'`: force one behaviour.
+ * - `'direct'`: bypass the route entirely — v1's raw `temporaryUrl()`
+ *   URLs, for disks that measured the extra hop and want it gone.
+ */
+export type DeliveryServeMode = 'auto' | 'redirect' | 'proxy' | 'direct'
+
+export type DiskDeliveryConfig =
+  | 'public'
+  | 'private'
+  | { visibility: 'public' | 'private'; serve?: DeliveryServeMode }
+
+export interface DeliveryOptions {
+  /**
+   * Route prefix the delivery URLs live under.
+   * @default '/attachments'
+   */
+  prefix?: string
+  /**
+   * Named-route name `registerAttachmentRoutes` registers under.
+   * `Router.name()` silently overwrites duplicates, so the default is
+   * reserved for the framework.
+   * @default 'attachments.show'
+   */
+  routeName?: string
+}
+
+/** What the delivery controller hands the engine per request. */
+export interface DeliveryRequest {
+  /** Full request URL (path + query carry the signature). */
+  url: URL
+  /** The `:id` route parameter. */
+  id: string
+  variant?: string
+  disposition?: string
+  ifNoneMatch?: string
+  method: string
+}
+
+export const DEFAULT_DELIVERY_PREFIX = '/attachments'
+export const DEFAULT_DELIVERY_ROUTE_NAME = 'attachments.show'
 
 export interface PruneOptions {
   /** Also delete `attachments/` storage prefixes that no row references. */
@@ -218,7 +282,9 @@ export class AttachmentEngine {
   readonly model: typeof Model
   private readonly storage: () => StorageManager
   private readonly defaultDisk: string
-  private readonly diskVisibility: Record<string, 'public' | 'private'>
+  private readonly diskDelivery: Record<string, { visibility: 'public' | 'private'; serve: DeliveryServeMode }>
+  private readonly delivery: { prefix: string; routeName: string } | null
+  private deliveryKeys: AppKeyring | null = null
   private readonly maxPixels: number
   private readonly maxImageBytes: number
   private readonly processor: ImageProcessor | null
@@ -235,7 +301,13 @@ export class AttachmentEngine {
 
     this.storage = options.storage
     this.defaultDisk = options.disk
-    this.diskVisibility = options.disks ?? {}
+    this.diskDelivery = normalizeDiskDelivery(options.disks ?? {})
+    this.delivery = options.delivery
+      ? {
+          prefix: normalizeDeliveryPrefix(options.delivery.prefix ?? DEFAULT_DELIVERY_PREFIX),
+          routeName: options.delivery.routeName ?? DEFAULT_DELIVERY_ROUTE_NAME,
+        }
+      : null
     this.maxPixels = options.maxPixels ?? DEFAULT_MAX_PIXELS
     this.maxImageBytes = options.maxImageBytes ?? DEFAULT_MAX_IMAGE_BYTES
     this.processor =
@@ -401,7 +473,7 @@ export class AttachmentEngine {
     declaration: AttachmentsDeclaration,
     recordOrId: PlainObject | string | number,
     collection: string,
-    options: { variant?: string } = {},
+    options: { variant?: string; expiresIn?: number; disposition?: 'inline' | 'attachment' } = {},
   ): Promise<string | null> {
     const spec = this.specFor(model, declaration, collection)
     const variant = options.variant
@@ -425,15 +497,11 @@ export class AttachmentEngine {
     if (!raw) return null
     const row = this.toRecord(raw)
 
-    if (variant !== undefined) {
-      const entry = row.variants?.[variant]
-      if (entry?.status === 'ready' && entry.path) {
-        return this.urlFor(row.disk, entry.path)
-      }
-      // pending / failed / unavailable: serve the original so pages keep
-      // rendering; a later render picks the variant up automatically.
-    }
-    return this.urlFor(row.disk, row.path)
+    return this.urlForRow(row, {
+      variant,
+      expiresIn: options.expiresIn,
+      disposition: options.disposition,
+    })
   }
 
   async purgeAttachments(model: typeof Model, recordId: string | number): Promise<void> {
@@ -1028,7 +1096,7 @@ export class AttachmentEngine {
     const diskNames = new Set<string>([
       ...registered,
       this.defaultDisk,
-      ...Object.keys(this.diskVisibility),
+      ...Object.keys(this.diskDelivery),
       ...rows.map((row) => String(row.disk)),
     ])
 
@@ -1072,32 +1140,196 @@ export class AttachmentEngine {
   }
 
   private visibilityOf(diskName: string): 'public' | 'private' {
-    return this.diskVisibility[diskName] ?? 'public'
+    return this.diskDelivery[diskName]?.visibility ?? 'public'
   }
 
-  private async urlFor(diskName: string, path: string): Promise<string> {
-    const disk = this.storage().disk(diskName)
-    if (this.visibilityOf(diskName) === 'private') {
-      return disk.temporaryUrl(path, new Date(Date.now() + this.urlExpiresIn))
+  private serveModeFor(diskName: string): DeliveryServeMode {
+    return this.diskDelivery[diskName]?.serve ?? 'auto'
+  }
+
+  /** The normalized delivery route config, for `registerAttachmentRoutes`. */
+  get deliveryRoute(): { prefix: string; routeName: string } | null {
+    return this.delivery
+  }
+
+  private deliveryKeyring(): AppKeyring {
+    // Lazy, like the framework's five other purposes: the env is read at
+    // first use, and the derived keyring is scoped so a leaked delivery key
+    // forges delivery URLs and nothing else.
+    if (!this.deliveryKeys) {
+      this.deliveryKeys = deriveAppKeyring(getAppKeyringFromEnv(), 'attachment-delivery')
+    }
+    return this.deliveryKeys
+  }
+
+  /**
+   * The one URL policy (RFC 0015 §7): public disks stay on `disk.url()`
+   * untouched; private disks hand out signed route URLs when `delivery` is
+   * configured (and the disk did not opt out with `serve: 'direct'`), else
+   * the v1 `temporaryUrl()` behaviour with its documented limitations.
+   */
+  private async urlForRow(
+    row: AttachmentRecord,
+    options: { variant?: string; expiresIn?: number; disposition?: 'inline' | 'attachment' },
+  ): Promise<string> {
+    const isPrivate = this.visibilityOf(row.disk) === 'private'
+    if (isPrivate && this.delivery && this.serveModeFor(row.disk) !== 'direct') {
+      return this.signDeliveryUrl(row, options)
+    }
+
+    // Generation-time variant fallback, as v1 shipped it: a declared-but-
+    // not-ready variant resolves to the original's key.
+    const entry = options.variant ? row.variants?.[options.variant] : undefined
+    const path = entry?.status === 'ready' && entry.path ? entry.path : row.path
+    const disk = this.storage().disk(row.disk)
+    if (isPrivate) {
+      return disk.temporaryUrl(path, new Date(Date.now() + (options.expiresIn ?? this.urlExpiresIn)))
     }
     return disk.url(path)
   }
 
+  /**
+   * Path-relative on purpose: the `Host` header never participates in URL
+   * construction (RFC 0015 T6); emails prefix the app's canonical URL
+   * themselves. The variant rides as a signed query parameter and is
+   * resolved at *serve* time, so the same URL starts serving the variant
+   * once generation completes.
+   */
+  private signDeliveryUrl(
+    row: AttachmentRecord,
+    options: { variant?: string; expiresIn?: number; disposition?: 'inline' | 'attachment' },
+  ): string {
+    const params = new URLSearchParams()
+    if (options.variant) params.set('variant', options.variant)
+    // Signed like everything else; §4's allowlist still wins — the
+    // parameter can force `attachment`, never `inline`.
+    if (options.disposition) params.set('disposition', options.disposition)
+    const query = params.size > 0 ? `?${params}` : ''
+    const path = `${this.delivery!.prefix}/${encodeURIComponent(row.id)}/${encodeURIComponent(row.name)}`
+    return signUrl(`${path}${query}`, this.deliveryKeyring(), {
+      expiresIn: options.expiresIn ?? this.urlExpiresIn,
+    })
+  }
+
+  /**
+   * Serve one delivery-route request (RFC 0015 §1): verify → load →
+   * resolve → redirect or proxy. Everything before the row load is one
+   * HMAC per keyring key, and every failure is the same 404 — invalid
+   * signature, expired URL, and unknown id must be indistinguishable.
+   */
+  async handleDeliveryRequest(request: DeliveryRequest): Promise<Response> {
+    const notFound = () =>
+      new Response('Not Found', { status: 404, headers: { 'X-Content-Type-Options': 'nosniff' } })
+
+    // Without delivery config this engine never signed anything; uniform 404.
+    if (!this.delivery) return notFound()
+
+    const signedPart = `${request.url.pathname}${request.url.search}`
+    if (!verifySignedUrl(signedPart, this.deliveryKeyring(), { requireExpiration: true })) {
+      return notFound()
+    }
+
+    const raw = (await this.model.find(request.id)) as PlainObject | null
+    if (!raw) return notFound()
+    const row = this.toRecord(raw)
+
+    // The valid signature proves the variant was declared when the URL was
+    // minted (attachmentUrl throws on undeclared names before signing), so
+    // variant state never 404s: anything not `ready` — including an entry
+    // missing entirely on a row attached before the variant was declared —
+    // serves the original (RFC 0015 §1).
+    const entry = request.variant ? row.variants?.[request.variant] : undefined
+    const target =
+      entry?.status === 'ready' && entry.path
+        ? {
+            path: entry.path,
+            contentType: (entry.format && IMAGE_MIME[entry.format]) || 'application/octet-stream',
+            size: entry.size ?? null,
+          }
+        : { path: row.path, contentType: row.contentType, size: row.size }
+
+    // `expires` passed verification, so it is a plain integer in seconds.
+    const remainingMs = Math.max(
+      0,
+      Number(request.url.searchParams.get('expires')) * 1000 - Date.now(),
+    )
+
+    const disposition = contentDispositionFor(target.contentType, request.disposition, row.name)
+    const disk = this.storage().disk(row.disk)
+    const mode = this.serveModeFor(row.disk)
+    // 'direct' disks never mint route URLs, but a signed URL that reaches
+    // us anyway (minted before the config change) is served like 'auto'.
+    const redirect =
+      mode === 'redirect' || (mode !== 'proxy' && disk.capabilities?.presignedGet === true)
+
+    if (redirect) {
+      // Minted per request and capped: a long-lived route URL must not
+      // force a long presign (R2 rejects > 7 days) — the inner URL is
+      // always fresh and short.
+      const inner = new Date(Date.now() + Math.min(Math.max(remainingMs, 1_000), this.urlExpiresIn))
+      const location = await disk.temporaryUrl(target.path, inner, {
+        responseContentDisposition: disposition,
+        responseContentType: target.contentType,
+      })
+      return new Response(null, {
+        status: 302,
+        headers: {
+          Location: location,
+          // The Location is a bearer credential.
+          'Cache-Control': 'no-store',
+          'Referrer-Policy': 'no-referrer',
+        },
+      })
+    }
+
+    const etag = deliveryEtag(target.path, target.size)
+    const headers: Record<string, string> = {
+      'Content-Type': target.contentType,
+      'Content-Disposition': disposition,
+      'X-Content-Type-Options': 'nosniff',
+      // Belt over the allowlist's braces: even if an inline type turns out
+      // to carry active content in some engine, it executes with no origin.
+      'Content-Security-Policy': 'sandbox',
+      'Referrer-Policy': 'no-referrer',
+      // Browser-cacheable, never in shared caches, never beyond the
+      // signature's own validity.
+      'Cache-Control': `private, max-age=${Math.floor(remainingMs / 1000)}`,
+      ETag: etag,
+    }
+
+    if (request.ifNoneMatch === etag) {
+      return new Response(null, { status: 304, headers })
+    }
+
+    if (target.size != null) headers['Content-Length'] = String(target.size)
+
+    // Hono dispatches HEAD through the GET handler and drops the body;
+    // without this branch every HEAD would pay for the storage read.
+    if (request.method === 'HEAD') {
+      return new Response(null, { headers })
+    }
+
+    const body = disk.getStream ? await disk.getStream(target.path) : await disk.get(target.path)
+    // A row pointing at nothing (crash between object delete and row
+    // delete) surfaces as 404, same as v1's loud url() failure.
+    if (!body) return notFound()
+    return new Response(body as BodyInit, { headers })
+  }
+
   private async toData(row: AttachmentRecord, spec: AttachmentCollectionSpec): Promise<AttachmentData> {
-    const originalUrl = await this.urlFor(row.disk, row.path)
+    const originalUrl = await this.urlForRow(row, {})
     const variants: AttachmentData['variants'] = {}
     for (const name of Object.keys(spec.variants ?? {})) {
       const entry = row.variants?.[name]
-      if (entry?.status === 'ready' && entry.path) {
-        variants[name] = {
-          url: await this.urlFor(row.disk, entry.path),
-          width: entry.width ?? null,
-          height: entry.height ?? null,
-        }
-      } else {
-        // Declared but not (yet) generated: fall back to the original so
-        // pages keep rendering; the placeholder LQIP covers the gap.
-        variants[name] = { url: originalUrl, width: null, height: null }
+      const ready = entry?.status === 'ready' && entry.path
+      // Not-ready variants fall back to the original so pages keep
+      // rendering (the placeholder LQIP covers the gap): on a public disk
+      // that resolution happens here, on a delivery-route disk the URL
+      // carries the variant and the route resolves at serve time.
+      variants[name] = {
+        url: await this.urlForRow(row, { variant: name }),
+        width: ready ? (entry.width ?? null) : null,
+        height: ready ? (entry.height ?? null) : null,
       }
     }
     return {
@@ -1145,6 +1377,16 @@ let activeEngine: AttachmentEngine | null = null
 /** Install the engine `configureAttachments()` built. Last call wins; `null` unconfigures (tests). */
 export function setActiveAttachmentEngine(engine: AttachmentEngine | null): void {
   activeEngine = engine
+}
+
+/**
+ * The active engine, or `null` when `configureAttachments()` has not run —
+ * the delivery route resolves it per request precisely so its registration
+ * stays configuration-independent (bootless route tooling invokes
+ * registrars with no providers booted).
+ */
+export function getActiveAttachmentEngine(): AttachmentEngine | null {
+  return activeEngine
 }
 
 export function resolveAttachmentEngine(caller: string): AttachmentEngine {
@@ -1215,4 +1457,76 @@ function sortById(rows: PlainObject[]): PlainObject[] {
     if (left > right) return 1
     return 0
   })
+}
+
+function normalizeDiskDelivery(
+  disks: Record<string, DiskDeliveryConfig>,
+): Record<string, { visibility: 'public' | 'private'; serve: DeliveryServeMode }> {
+  const normalized: Record<string, { visibility: 'public' | 'private'; serve: DeliveryServeMode }> = {}
+  for (const [name, config] of Object.entries(disks)) {
+    normalized[name] =
+      typeof config === 'string'
+        ? { visibility: config, serve: 'auto' }
+        : { visibility: config.visibility, serve: config.serve ?? 'auto' }
+  }
+  return normalized
+}
+
+function normalizeDeliveryPrefix(prefix: string): string {
+  const trimmed = prefix.replace(/\/+$/, '')
+  if (!trimmed.startsWith('/')) {
+    throw new Error(`configureAttachments: delivery.prefix must start with '/', got '${prefix}'.`)
+  }
+  return trimmed
+}
+
+/**
+ * Content types allowed to render inline (RFC 0015 §4). Everything else —
+ * notably image/svg+xml and text/html — is forced to `attachment`: the
+ * `disposition` parameter can force `attachment` for a listed type, but
+ * nothing can force `inline` for an unlisted one.
+ */
+const INLINE_CONTENT_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'image/avif',
+  'application/pdf',
+  'video/mp4',
+  'audio/mpeg',
+  'text/plain',
+])
+
+function contentDispositionFor(
+  contentType: string,
+  requested: string | undefined,
+  filename: string,
+): string {
+  const kind =
+    requested === 'attachment' || !INLINE_CONTENT_TYPES.has(contentType) ? 'attachment' : 'inline'
+  // Plain-ASCII fallback plus the RFC 5987 form for everything else; the
+  // stored name is already sanitized (no separators, no control chars).
+  const fallback = filename.replace(/[^\x20-\x7e]/g, '_').replace(/["\\]/g, '_')
+  return `${kind}; filename="${fallback}"; filename*=UTF-8''${encodeRfc5987(filename)}`
+}
+
+/** RFC 5987 attr-char escaping: encodeURIComponent leaves !'()* unescaped. */
+function encodeRfc5987(value: string): string {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  )
+}
+
+/**
+ * A validator over the *resolved object*, not the request: `id + variant`
+ * is not a byte identity (a pending variant resolves to original bytes
+ * today and variant bytes tomorrow; queued HEIC conversion rewrites the
+ * path under the same row id), but the resolved key + size move in both
+ * cases, so the validator moves with the bytes.
+ */
+function deliveryEtag(path: string, size: number | null): string {
+  const digest = createHash('sha256').update(`${path}:${size ?? ''}`).digest('base64url').slice(0, 20)
+  return `"${digest}"`
 }

--- a/packages/core/src/attachments/index.ts
+++ b/packages/core/src/attachments/index.ts
@@ -2,7 +2,16 @@ export { Attachable } from './Attachable.js'
 export type { AttachableRecordId, AttachableStatic } from './Attachable.js'
 export { configureAttachments } from './configure.js'
 export type { ConfigureAttachmentsOptions, ConfiguredAttachments } from './configure.js'
-export type { AttachOptions, GenerateVariantsPayload, PruneOptions, PruneReport } from './engine.js'
+export type {
+  AttachOptions,
+  DeliveryOptions,
+  DeliveryServeMode,
+  DiskDeliveryConfig,
+  GenerateVariantsPayload,
+  PruneOptions,
+  PruneReport,
+} from './engine.js'
+export { AttachmentDeliveryController, registerAttachmentRoutes } from './delivery.js'
 export { AttachmentsPruneCommand } from './prune-command.js'
 export { GenerateVariantsJob } from './generate-variants-job.js'
 export { hasManyAttached, hasOneAttached } from './declaration.js'

--- a/packages/core/src/attachments/index.ts
+++ b/packages/core/src/attachments/index.ts
@@ -4,6 +4,7 @@ export { configureAttachments } from './configure.js'
 export type { ConfigureAttachmentsOptions, ConfiguredAttachments } from './configure.js'
 export type {
   AttachOptions,
+  AttachmentUrlOptions,
   DeliveryOptions,
   DeliveryServeMode,
   DiskDeliveryConfig,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -107,6 +107,7 @@ export type {
   AttachmentRecord,
   AttachmentSource,
   AttachmentsDeclaration,
+  AttachmentUrlOptions,
   AttachmentVariantRecord,
   ConfigureAttachmentsOptions,
   ConfiguredAttachments,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,7 +96,7 @@ export type { DatabaseSessionStoreOptions } from './session-store.js'
 export { DatabaseOAuthStateStore } from './oauth-state-store.js'
 // Attachments (RFC 0013) — core-native exports; no bare `Attachment` (it
 // would collide with the mail/notification/Slack attachment vocabulary).
-export { Attachable, AttachmentsPruneCommand, configureAttachments, GenerateVariantsJob, hasManyAttached, hasOneAttached } from './attachments/index.js'
+export { Attachable, AttachmentDeliveryController, AttachmentsPruneCommand, configureAttachments, GenerateVariantsJob, hasManyAttached, hasOneAttached, registerAttachmentRoutes } from './attachments/index.js'
 export type {
   AttachableRecordId,
   AttachableStatic,
@@ -110,6 +110,9 @@ export type {
   AttachmentVariantRecord,
   ConfigureAttachmentsOptions,
   ConfiguredAttachments,
+  DeliveryOptions,
+  DeliveryServeMode,
+  DiskDeliveryConfig,
   GenerateVariantsPayload,
   HeicPolicy,
   ImagePolicy,

--- a/packages/core/tests/attachments-delivery.test.ts
+++ b/packages/core/tests/attachments-delivery.test.ts
@@ -45,17 +45,16 @@ async function serve(
   url: string,
   init: { method?: string; ifNoneMatch?: string } = {},
 ): Promise<Response> {
-  const engine = getActiveAttachmentEngine()!
-  const absolute = new URL(url, 'http://app.test')
-  const id = decodeURIComponent(absolute.pathname.split('/')[2] ?? '')
-  return engine.handleDeliveryRequest({
-    url: absolute,
-    id,
-    variant: absolute.searchParams.get('variant') ?? undefined,
-    disposition: absolute.searchParams.get('disposition') ?? undefined,
-    ifNoneMatch: init.ifNoneMatch,
-    method: init.method ?? 'GET',
-  })
+  const headers = new Headers()
+  if (init.ifNoneMatch) headers.set('if-none-match', init.ifNoneMatch)
+  return getActiveAttachmentEngine()!.handleDeliveryRequest(
+    new Request(new URL(url, 'http://app.test'), { method: init.method ?? 'GET', headers }),
+  )
+}
+
+async function expectServesOriginal(response: Response): Promise<void> {
+  expect(response.status).toBe(200)
+  expect(Buffer.from(await response.arrayBuffer())).toEqual(Buffer.from(PNG_1X1))
 }
 
 describe('attachments signed delivery (RFC 0015)', () => {
@@ -195,7 +194,8 @@ describe('attachments signed delivery (RFC 0015)', () => {
       const response = await serve(url!)
 
       expect(response.status).toBe(200)
-      expect(Buffer.from(await response.arrayBuffer())).toEqual(Buffer.from(PNG_1X1))
+      const body = Buffer.from(await response.clone().arrayBuffer())
+      expect(body).toEqual(Buffer.from(PNG_1X1))
       expect(response.headers.get('Content-Type')).toBe('image/png')
       expect(response.headers.get('Content-Disposition')).toContain('inline')
       expect(response.headers.get('Content-Disposition')).toContain('cover.png')
@@ -228,10 +228,7 @@ describe('attachments signed delivery (RFC 0015)', () => {
       await attachCover()
       // processor: null ⇒ thumb is recorded but never generated.
       const url = await Post.attachmentUrl(1, 'cover', { variant: 'thumb' })
-      const response = await serve(url!)
-
-      expect(response.status).toBe(200)
-      expect(Buffer.from(await response.arrayBuffer())).toEqual(Buffer.from(PNG_1X1))
+      await expectServesOriginal(await serve(url!))
 
       const tampered = url!.replace('variant=thumb', 'variant=og')
       expect((await serve(tampered)).status).toBe(404)
@@ -298,10 +295,63 @@ describe('attachments signed delivery (RFC 0015)', () => {
         disk: 'media',
       })
       const url = await Post.attachmentUrl(3, 'cover')
-      const response = await serve(url!)
+      await expectServesOriginal(await serve(url!))
+    })
 
-      expect(response.status).toBe(200)
-      expect(Buffer.from(await response.arrayBuffer())).toEqual(Buffer.from(PNG_1X1))
+    test("serve: 'redirect' on a disk that cannot presign fails closed into proxy", async () => {
+      configure({ disks: { vault: { visibility: 'private', serve: 'redirect' } } })
+      await attachCover()
+      const url = await Post.attachmentUrl(1, 'cover')
+
+      // LocalDriver declares no presignedGet: a 302 here would hand out its
+      // plain public URL — the exact fail-open the route exists to close.
+      await expectServesOriginal(await serve(url!))
+    })
+
+    test('HEAD checks the object exists; a dangling row 404s', async () => {
+      const record = await attachCover()
+      const url = await Post.attachmentUrl(1, 'cover')
+
+      expect((await serve(url!, { method: 'HEAD' })).status).toBe(200)
+      await storage.disk('vault').delete(record.path)
+      expect((await serve(url!, { method: 'HEAD' })).status).toBe(404)
+      expect((await serve(url!)).status).toBe(404)
+    })
+
+    test('If-None-Match accepts lists, weak validators, and *', async () => {
+      await attachCover()
+      const url = await Post.attachmentUrl(1, 'cover')
+      const etag = (await serve(url!)).headers.get('ETag')!
+
+      expect((await serve(url!, { ifNoneMatch: `"other", ${etag}` })).status).toBe(304)
+      expect((await serve(url!, { ifNoneMatch: `W/${etag}` })).status).toBe(304)
+      expect((await serve(url!, { ifNoneMatch: '*' })).status).toBe(304)
+      expect((await serve(url!, { ifNoneMatch: '"other"' })).status).toBe(200)
+    })
+
+    test('the ETag moves when the row is rewritten, even at the same path and size', async () => {
+      const record = await attachCover()
+      const engine = getActiveAttachmentEngine()!
+      const url = await Post.attachmentUrl(1, 'cover')
+      const before = (await serve(url!)).headers.get('ETag')!
+
+      // Same path, same size — only updatedAt moves (a queued regeneration
+      // rewrites bytes in place and always lands with a row update).
+      await engine.model.forceUpdate({ id: record.id }, { updatedAt: new Date(Date.now() + 5000) })
+      const after = (await serve(url!)).headers.get('ETag')!
+
+      expect(after).not.toBe(before)
+      expect((await serve(url!, { ifNoneMatch: before })).status).toBe(200)
+    })
+
+    test('a filename truncated at a surrogate boundary still mints and serves', async () => {
+      // 199 ASCII chars + an astral emoji: a code-unit slice(0, 200) would
+      // split the surrogate pair and make encodeURIComponent throw.
+      const name = `${'x'.repeat(199)}\u{1F600}.png`
+      await Post.attach(4, 'cover', new File([PNG_1X1], name, { type: 'image/png' }))
+      const url = await Post.attachmentUrl(4, 'cover')
+
+      await expectServesOriginal(await serve(url!))
     })
   })
 
@@ -321,11 +371,11 @@ describe('attachments signed delivery (RFC 0015)', () => {
       return driver
     }
 
-    function withPresigningVault() {
+    function withPresigningVault(overrides: Partial<ConfigureAttachmentsOptions> = {}) {
       const base = storage.disk('vault')
       const driver = presigningDriver(base)
       const manager = { disk: () => driver } as unknown as StorageManager
-      configure({ storage: () => manager })
+      configure({ storage: () => manager, ...overrides })
       return driver as StorageDriver & {
         captured: { expiration?: Date; options?: TemporaryUrlOptions }
       }
@@ -333,7 +383,7 @@ describe('attachments signed delivery (RFC 0015)', () => {
 
     test('presign-capable disks 302 to a per-request presigned URL with response overrides', async () => {
       const driver = withPresigningVault()
-      const record = await Post.attach(1, 'cover', new File([PNG_1X1], 'c.png', { type: 'image/png' }))
+      const record = await attachCover()
       const url = await Post.attachmentUrl(1, 'cover')
       const response = await serve(url!)
 
@@ -348,19 +398,41 @@ describe('attachments signed delivery (RFC 0015)', () => {
     })
 
     test("serve: 'proxy' keeps a presign-capable disk on the proxy path", async () => {
-      const base = storage.disk('vault')
-      const driver = presigningDriver(base)
-      const manager = { disk: () => driver } as unknown as StorageManager
-      configure({
-        storage: () => manager,
-        disks: { vault: { visibility: 'private', serve: 'proxy' } },
-      })
-      await Post.attach(1, 'cover', new File([PNG_1X1], 'c.png', { type: 'image/png' }))
+      withPresigningVault({ disks: { vault: { visibility: 'private', serve: 'proxy' } } })
+      await attachCover()
+      const url = await Post.attachmentUrl(1, 'cover')
+
+      await expectServesOriginal(await serve(url!))
+    })
+
+    test('the inner presign stays short even when the outer lifetime is long', async () => {
+      const driver = withPresigningVault({ urlExpiresIn: 30 * 24 * 60 * 60 * 1000 })
+      await attachCover()
       const url = await Post.attachmentUrl(1, 'cover')
       const response = await serve(url!)
 
-      expect(response.status).toBe(200)
-      expect(Buffer.from(await response.arrayBuffer())).toEqual(Buffer.from(PNG_1X1))
+      expect(response.status).toBe(302)
+      // Fixed 5-minute inner TTL, decoupled from urlExpiresIn: a raised
+      // outer lifetime must never exceed a driver's presign ceiling.
+      expect(driver.captured.expiration!.getTime()).toBeLessThanOrEqual(Date.now() + 5 * 60 * 1000 + 1000)
+    })
+  })
+
+  describe('configuration and payloads', () => {
+    test('delivery.prefix rejects shapes URL parsing would reinterpret', () => {
+      for (const prefix of ['files', '//host', '/files?x=1', '/files#frag', '/fi les']) {
+        expect(() => configure({ delivery: { prefix } })).toThrow(/delivery\.prefix/)
+      }
+    })
+
+    test('without delivery, not-ready variant data URLs are byte-identical to the original URL', async () => {
+      configure({ delivery: undefined, disks: { vault: 'private' } })
+      await attachCover()
+      const [data] = await Post.withAttachments([{ id: 1 }], ['cover'])
+
+      // v1 semantics restored by memoization: the fallback URL is the same
+      // string, not a second temporaryUrl() call that might differ.
+      expect(data!.cover!.variants.thumb!.url).toBe(data!.cover!.url)
     })
   })
 })

--- a/packages/core/tests/attachments-delivery.test.ts
+++ b/packages/core/tests/attachments-delivery.test.ts
@@ -1,0 +1,366 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { drizzle } from 'drizzle-orm/bun-sqlite'
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  Attachable,
+  configureAttachments,
+  defineModel,
+  deriveAppKeyring,
+  DrizzleAdapter,
+  generateAppKey,
+  getAppKeyringFromEnv,
+  hasOneAttached,
+  registerAttachmentRoutes,
+  Router,
+  StorageManager,
+  verifySignedUrl,
+  type ConfigureAttachmentsOptions,
+  type StorageDriver,
+  type TemporaryUrlOptions,
+} from '../src/index'
+import { getActiveAttachmentEngine, setActiveAttachmentEngine } from '../src/attachments/engine'
+import { ATTACHMENTS_DDL, attachmentsTable } from './attachments-table'
+import { PNG_1X1 } from './image-sniff.test'
+
+const posts = sqliteTable('posts', {
+  id: integer('id').primaryKey(),
+  title: text('title').notNull(),
+})
+
+class Post extends Attachable(defineModel(posts), {
+  cover: hasOneAttached({ image: 'require', variants: { thumb: { width: 2, format: 'png' } } }),
+  doc: hasOneAttached(),
+}) {}
+
+function deliveryKeyring() {
+  return deriveAppKeyring(getAppKeyringFromEnv(), 'attachment-delivery')
+}
+
+/** Serve a minted URL through the engine, the way the controller would. */
+async function serve(
+  url: string,
+  init: { method?: string; ifNoneMatch?: string } = {},
+): Promise<Response> {
+  const engine = getActiveAttachmentEngine()!
+  const absolute = new URL(url, 'http://app.test')
+  const id = decodeURIComponent(absolute.pathname.split('/')[2] ?? '')
+  return engine.handleDeliveryRequest({
+    url: absolute,
+    id,
+    variant: absolute.searchParams.get('variant') ?? undefined,
+    disposition: absolute.searchParams.get('disposition') ?? undefined,
+    ifNoneMatch: init.ifNoneMatch,
+    method: init.method ?? 'GET',
+  })
+}
+
+describe('attachments signed delivery (RFC 0015)', () => {
+  let sqlite: Database
+  let storage: StorageManager
+  let tmpDir: string
+  let previousAppKey: string | undefined
+
+  function configure(overrides: Partial<ConfigureAttachmentsOptions> = {}) {
+    return configureAttachments({
+      table: attachmentsTable,
+      storage: () => storage,
+      disk: 'vault',
+      processor: null,
+      disks: { media: 'public', vault: 'private' },
+      delivery: {},
+      ...overrides,
+    })
+  }
+
+  beforeEach(() => {
+    previousAppKey = process.env.APP_KEY
+    process.env.APP_KEY = generateAppKey()
+    sqlite = new Database(':memory:')
+    sqlite.exec(`
+      ${ATTACHMENTS_DDL}
+      CREATE TABLE posts (id integer primary key, title text not null);
+    `)
+    DrizzleAdapter.configure(drizzle({ client: sqlite }) as never)
+    tmpDir = mkdtempSync(join(tmpdir(), 'guren-delivery-'))
+    storage = new StorageManager({
+      default: 'vault',
+      disks: {
+        media: { driver: 'memory', url: 'https://cdn.test' },
+        vault: { driver: 'local', root: tmpDir, url: '/storage' },
+      },
+    })
+    configure()
+  })
+
+  afterEach(() => {
+    sqlite.close()
+    setActiveAttachmentEngine(null)
+    rmSync(tmpDir, { recursive: true, force: true })
+    if (previousAppKey === undefined) delete process.env.APP_KEY
+    else process.env.APP_KEY = previousAppKey
+  })
+
+  function attachCover() {
+    return Post.attach(1, 'cover', new File([PNG_1X1], 'cover.png', { type: 'image/png' }))
+  }
+
+  describe('URL generation', () => {
+    test('private disks mint relative signed route URLs', async () => {
+      await attachCover()
+      const url = await Post.attachmentUrl(1, 'cover')
+
+      expect(url).not.toBeNull()
+      expect(url!.startsWith('/attachments/')).toBe(true)
+      expect(url).toContain('expires=')
+      expect(url).toContain('signature=')
+      expect(verifySignedUrl(url!, deliveryKeyring(), { requireExpiration: true })).toBe(true)
+    })
+
+    test('variant URLs carry the variant as a signed parameter', async () => {
+      await attachCover()
+      const url = await Post.attachmentUrl(1, 'cover', { variant: 'thumb' })
+
+      expect(url).toContain('variant=thumb')
+      expect(verifySignedUrl(url!, deliveryKeyring(), { requireExpiration: true })).toBe(true)
+    })
+
+    test('public disks keep plain disk URLs', async () => {
+      const record = await Post.attach(1, 'cover', new File([PNG_1X1], 'c.png', { type: 'image/png' }), {
+        disk: 'media',
+      })
+      const url = await Post.attachmentUrl(1, 'cover')
+
+      expect(url).toBe(`https://cdn.test/${record.path}`)
+    })
+
+    test('without delivery config, private disks keep the v1 temporaryUrl behaviour', async () => {
+      configure({ delivery: undefined })
+      await attachCover()
+      const url = await Post.attachmentUrl(1, 'cover')
+
+      expect(url!.startsWith('/storage/')).toBe(true)
+      expect(url).not.toContain('signature=')
+    })
+
+    test("serve: 'direct' opts a disk back out of the route", async () => {
+      configure({ disks: { vault: { visibility: 'private', serve: 'direct' } } })
+      await attachCover()
+      const url = await Post.attachmentUrl(1, 'cover')
+
+      expect(url!.startsWith('/storage/')).toBe(true)
+    })
+
+    test('expiresIn overrides the configured lifetime for one URL', async () => {
+      await attachCover()
+      const short = await Post.attachmentUrl(1, 'cover')
+      const long = await Post.attachmentUrl(1, 'cover', { expiresIn: 3_600_000 })
+
+      const expiresOf = (url: string) =>
+        Number(new URL(url, 'http://x.test').searchParams.get('expires'))
+      expect(expiresOf(long!)).toBeGreaterThan(expiresOf(short!))
+    })
+
+    test('a custom prefix flows into minted URLs and the route registration', async () => {
+      configure({ delivery: { prefix: '/files' } })
+      await attachCover()
+      const url = await Post.attachmentUrl(1, 'cover')
+      expect(url!.startsWith('/files/')).toBe(true)
+
+      const router = new Router()
+      registerAttachmentRoutes(router)
+      const definition = router.definitions().find((route) => route.path.startsWith('/files/'))
+      expect(definition?.path).toBe('/files/:id/:filename')
+      expect(definition?.method.toUpperCase()).toBe('GET')
+      expect(definition?.name).toBe('attachments.show')
+    })
+
+    test('registration without any engine registers the default route and does not throw', () => {
+      setActiveAttachmentEngine(null)
+      const router = new Router()
+      registerAttachmentRoutes(router)
+
+      const definition = router.definitions().find((route) => route.path.startsWith('/attachments/'))
+      expect(definition?.path).toBe('/attachments/:id/:filename')
+    })
+  })
+
+  describe('serving (proxy)', () => {
+    test('serves the original bytes with the hardening headers', async () => {
+      await attachCover()
+      const url = await Post.attachmentUrl(1, 'cover')
+      const response = await serve(url!)
+
+      expect(response.status).toBe(200)
+      expect(Buffer.from(await response.arrayBuffer())).toEqual(Buffer.from(PNG_1X1))
+      expect(response.headers.get('Content-Type')).toBe('image/png')
+      expect(response.headers.get('Content-Disposition')).toContain('inline')
+      expect(response.headers.get('Content-Disposition')).toContain('cover.png')
+      expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
+      expect(response.headers.get('Content-Security-Policy')).toBe('sandbox')
+      expect(response.headers.get('Referrer-Policy')).toBe('no-referrer')
+      expect(response.headers.get('Cache-Control')).toMatch(/^private, max-age=\d+$/)
+      expect(response.headers.get('ETag')).toMatch(/^".+"$/)
+      expect(response.headers.get('Content-Length')).toBe(String(PNG_1X1.byteLength))
+    })
+
+    test('disposition=attachment is honoured; non-allowlisted types are forced to attachment', async () => {
+      await attachCover()
+      const forcedUrl = await Post.attachmentUrl(1, 'cover', { disposition: 'attachment' })
+      const forced = await serve(forcedUrl!)
+      expect(forced.status).toBe(200)
+      expect(forced.headers.get('Content-Disposition')).toContain('attachment')
+
+      // An SVG is stored fine but must never render inline same-origin —
+      // even with no disposition parameter at all.
+      await Post.attach(2, 'doc', new File(['<svg onload="alert(1)"/>'], 'evil.svg', { type: 'image/svg+xml' }))
+      const svgUrl = await Post.attachmentUrl(2, 'doc')
+      const svgResponse = await serve(svgUrl!)
+
+      expect(svgResponse.status).toBe(200)
+      expect(svgResponse.headers.get('Content-Disposition')).toContain('attachment')
+    })
+
+    test('a not-ready variant serves the original; tampering with the variant 404s', async () => {
+      await attachCover()
+      // processor: null ⇒ thumb is recorded but never generated.
+      const url = await Post.attachmentUrl(1, 'cover', { variant: 'thumb' })
+      const response = await serve(url!)
+
+      expect(response.status).toBe(200)
+      expect(Buffer.from(await response.arrayBuffer())).toEqual(Buffer.from(PNG_1X1))
+
+      const tampered = url!.replace('variant=thumb', 'variant=og')
+      expect((await serve(tampered)).status).toBe(404)
+    })
+
+    test('a ready variant serves the variant bytes with its own MIME type', async () => {
+      const record = await attachCover()
+      const engine = getActiveAttachmentEngine()!
+      const variantPath = `attachments/${record.id}/variants/thumb.webp`
+      const variantBytes = Buffer.from('variant-bytes')
+      await storage.disk('vault').put(variantPath, variantBytes)
+      await engine.model.forceUpdate(
+        { id: record.id },
+        {
+          variants: {
+            thumb: { status: 'ready', path: variantPath, format: 'webp', size: variantBytes.byteLength },
+          },
+        },
+      )
+
+      const url = await Post.attachmentUrl(1, 'cover', { variant: 'thumb' })
+      const response = await serve(url!)
+
+      expect(response.status).toBe(200)
+      expect(Buffer.from(await response.arrayBuffer())).toEqual(variantBytes)
+      expect(response.headers.get('Content-Type')).toBe('image/webp')
+      expect(response.headers.get('Content-Length')).toBe(String(variantBytes.byteLength))
+    })
+
+    test('404 is uniform: bad signature, expired URL, unknown id', async () => {
+      const record = await attachCover()
+      const url = await Post.attachmentUrl(1, 'cover')
+
+      expect((await serve(`${url}x`)).status).toBe(404)
+
+      const expired = await Post.attachmentUrl(1, 'cover', { expiresIn: -1000 })
+      expect((await serve(expired!)).status).toBe(404)
+
+      await Post.purgeAttachments(1)
+      expect((await serve(url!)).status).toBe(404)
+      // The 404 must not leak whether the id ever existed.
+      expect(record.id).toBeTruthy()
+    })
+
+    test('If-None-Match returns 304 and HEAD skips the body', async () => {
+      await attachCover()
+      const url = await Post.attachmentUrl(1, 'cover')
+
+      const first = await serve(url!)
+      const etag = first.headers.get('ETag')!
+      const cached = await serve(url!, { ifNoneMatch: etag })
+      expect(cached.status).toBe(304)
+      expect(cached.headers.get('Content-Length')).toBeNull()
+
+      const head = await serve(url!, { method: 'HEAD' })
+      expect(head.status).toBe(200)
+      expect(head.body).toBeNull()
+      expect(head.headers.get('Content-Length')).toBe(String(PNG_1X1.byteLength))
+    })
+
+    test('memory disks without getStream fall back to buffered get()', async () => {
+      configure({ disks: { media: 'private' } })
+      await Post.attach(3, 'cover', new File([PNG_1X1], 'm.png', { type: 'image/png' }), {
+        disk: 'media',
+      })
+      const url = await Post.attachmentUrl(3, 'cover')
+      const response = await serve(url!)
+
+      expect(response.status).toBe(200)
+      expect(Buffer.from(await response.arrayBuffer())).toEqual(Buffer.from(PNG_1X1))
+    })
+  })
+
+  describe('serving (redirect)', () => {
+    function presigningDriver(base: StorageDriver): StorageDriver {
+      const captured: { expiration?: Date; options?: TemporaryUrlOptions } = {}
+      const driver = Object.create(base) as StorageDriver & {
+        captured: typeof captured
+      }
+      Object.defineProperty(driver, 'capabilities', { value: { presignedGet: true } })
+      driver.temporaryUrl = async (path, expiration, options) => {
+        captured.expiration = expiration
+        captured.options = options
+        return `https://bucket.test/presigned/${path}`
+      }
+      driver.captured = captured
+      return driver
+    }
+
+    function withPresigningVault() {
+      const base = storage.disk('vault')
+      const driver = presigningDriver(base)
+      const manager = { disk: () => driver } as unknown as StorageManager
+      configure({ storage: () => manager })
+      return driver as StorageDriver & {
+        captured: { expiration?: Date; options?: TemporaryUrlOptions }
+      }
+    }
+
+    test('presign-capable disks 302 to a per-request presigned URL with response overrides', async () => {
+      const driver = withPresigningVault()
+      const record = await Post.attach(1, 'cover', new File([PNG_1X1], 'c.png', { type: 'image/png' }))
+      const url = await Post.attachmentUrl(1, 'cover')
+      const response = await serve(url!)
+
+      expect(response.status).toBe(302)
+      expect(response.headers.get('Location')).toBe(`https://bucket.test/presigned/${record.path}`)
+      expect(response.headers.get('Cache-Control')).toBe('no-store')
+      expect(response.headers.get('Referrer-Policy')).toBe('no-referrer')
+      expect(driver.captured.options?.responseContentType).toBe('image/png')
+      expect(driver.captured.options?.responseContentDisposition).toContain('inline')
+      // The inner presign is minted per request and capped by urlExpiresIn.
+      expect(driver.captured.expiration!.getTime()).toBeLessThanOrEqual(Date.now() + 300_000 + 1000)
+    })
+
+    test("serve: 'proxy' keeps a presign-capable disk on the proxy path", async () => {
+      const base = storage.disk('vault')
+      const driver = presigningDriver(base)
+      const manager = { disk: () => driver } as unknown as StorageManager
+      configure({
+        storage: () => manager,
+        disks: { vault: { visibility: 'private', serve: 'proxy' } },
+      })
+      await Post.attach(1, 'cover', new File([PNG_1X1], 'c.png', { type: 'image/png' }))
+      const url = await Post.attachmentUrl(1, 'cover')
+      const response = await serve(url!)
+
+      expect(response.status).toBe(200)
+      expect(Buffer.from(await response.arrayBuffer())).toEqual(Buffer.from(PNG_1X1))
+    })
+  })
+})

--- a/rfcs/0015-signed-attachment-delivery.md
+++ b/rfcs/0015-signed-attachment-delivery.md
@@ -173,8 +173,12 @@ like:
   row), and it is a single path segment (no `:name*` — see the route
   path pitfall `guren check` guards).
 - Query parameters, all covered by the signature: `variant` (a
-  declared variant name), `disposition` (`inline` | `attachment`),
-  `expires` (unix seconds, written by the signer), `signature`.
+  declared variant name), `disposition` (~~`inline` | `attachment`~~
+  **Amended in Part 2:** `attachment` only — `inline` is already the
+  default outcome for allowlisted types and the allowlist can never be
+  forced to inline, so a signed `inline` value would change the URL
+  while doing nothing), `expires` (unix seconds, written by the
+  signer), `signature`.
 
 Request handling, in order (cheapest first):
 
@@ -270,7 +274,12 @@ per disk:
 - **Redirect** — 302 to a presigned URL **minted per request**:
   `disk.temporaryUrl(key, expiresAt, { responseContentDisposition,
   responseContentType })`, where `expiresAt` is an absolute `Date` at
-  `min(remaining signed lifetime, driver cap)`. Minting per request
+  ~~`min(remaining signed lifetime, driver cap)`~~ **Amended in
+  Part 2:** `min(remaining signed lifetime, a fixed 5-minute inner
+  TTL)` — the inner credential only needs to survive one fetch, no
+  driver exposes its ceiling to compare against, and a TTL derived
+  from `urlExpiresIn` would let a raised outer lifetime silently
+  exceed R2's 7-day limit. Minting per request
   is what lets a long-lived route URL (an emailed link) coexist with
   R2's 7-day presign ceiling — the inner presign is always fresh and
   short. `Cache-Control: no-store` on the redirect itself (the
@@ -334,12 +343,19 @@ disks: {
 ```
 
 `serve`: `'auto'` (default: redirect iff `capabilities.presignedGet`,
-else proxy) | `'redirect'` (boot-time error if the disk does not
-declare `presignedGet` — misconfiguration must not fail open into
-serving) | `'proxy'` (e.g. keep bucket egress behind the app for IP
-allowlisting) | `'direct'` (bypass the route entirely; the v1
-`temporaryUrl()` behaviour, for S3 apps that measured the extra hop
-and want it gone — with the v1 caveats back).
+else proxy) | `'redirect'` (~~boot-time error if the disk does not
+declare `presignedGet`~~ **Amended in Part 2:** a boot-time check has
+nowhere to run — `storage` is resolved lazily and boot never touches
+drivers — so the guard sits at the comparison site instead:
+redirecting always requires the driver's positive `presignedGet`
+declaration, and a `'redirect'` disk without it **downgrades to proxy
+with a warning** rather than 302ing to whatever `temporaryUrl()`
+returns; the static gate is a `guren check` rule in Part 4 —
+misconfiguration must not fail open into serving) | `'proxy'` (e.g.
+keep bucket egress behind the app for IP allowlisting) | `'direct'`
+(bypass the route entirely; the v1 `temporaryUrl()` behaviour, for S3
+apps that measured the extra hop and want it gone — with the v1
+caveats back).
 
 ### 4. Response hardening (proxy mode)
 


### PR DESCRIPTION
## Summary

Part 2 of RFC 0015: the delivery route itself, in `@guren/core`. Builds on Part 1's server surface (#562). This closes v1's one real capability gap — private attachments on the `local` disk and on R2 without `presign`.

### Configuration (additive, opt-in)

- `configureAttachments()` gains `delivery: { prefix?, routeName? }` (defaults `/attachments`, `attachments.show`) and the `disks` map widens to `'public' | 'private' | { visibility, serve }` with `serve: 'auto' | 'redirect' | 'proxy' | 'direct'`.
- With `delivery` configured, `attachmentUrl()` and every `AttachmentData` URL on a private disk becomes a **path-relative signed route URL** — HMAC-signed with `deriveAppKeyring(env, 'attachment-delivery')` (a leaked delivery key forges delivery URLs and nothing else), expiring after `urlExpiresIn`, with per-call `expiresIn` and `disposition` overrides. `serve: 'direct'` opts a disk back to v1's raw `temporaryUrl()`. Without `delivery`, nothing changes.
- Variant URLs carry the variant as a **signed query parameter resolved at serve time**, so the same URL starts serving the variant once generation completes.

### The route

`registerAttachmentRoutes(router)` mounts `GET {prefix}/:id/:filename`. Registration never throws and requires no engine — `routes:types`/`guren check`/audit invoke registrars against a bare `Router` with no providers booted — so the thin controller resolves the engine per request, and the whole serving contract lives in `AttachmentEngine.handleDeliveryRequest()` where it is testable without HTTP.

Serving, in order: verify signature (**uniform 404** — invalid signature, expired URL, and unknown id are indistinguishable) → load row → resolve variant (the valid signature proves declaration at mint time; missing/pending/failed/unavailable entries fall back to the original per RFC 0013 §7 semantics; a ready variant serves its `format`-derived MIME type) → redirect or proxy:

- **Redirect** (disk declares `capabilities.presignedGet`, or `serve: 'redirect'`): 302 to a **per-request** presign capped by `urlExpiresIn` (a long-lived route URL never forces a long presign — R2's 7-day ceiling), carrying `Content-Disposition`/`Content-Type` via Part 1's `temporaryUrl` response-override bag. `Cache-Control: no-store` on the redirect (the Location is a bearer credential).
- **Proxy** (everything else, incl. `local` and R2-binding): streams via `getStream` (buffered `get()` fallback) with the §4 hardening set — inline allowlist (SVG/HTML forced to `attachment`; the signed `disposition` param can force `attachment`, never `inline`), `X-Content-Type-Options: nosniff`, `Content-Security-Policy: sandbox`, `Referrer-Policy: no-referrer`, `Cache-Control: private, max-age=<remaining signed lifetime>`, an ETag keyed on the **resolved object** (path+size — moves when a variant becomes ready or HEIC conversion rewrites the path) with `If-None-Match` → 304, and a HEAD short-circuit (Hono dispatches HEAD through the GET handler; without the branch every HEAD would pay for the storage read).

## Testing

- New `packages/core/tests/attachments-delivery.test.ts`: URL minting (relative signed URLs, public-disk passthrough, v1 fallback without `delivery`, `serve: 'direct'`, custom prefix, `expiresIn` override), route registration (custom prefix + engineless default, no throw), and serving (byte parity + full header set, disposition forcing incl. same-origin SVG, serve-time variant fallback + ready-variant MIME, uniform 404 trio, 304/HEAD, buffered fallback on memory disks, redirect with captured per-request presign + response overrides, `serve: 'proxy'` pinning).
- Regression: full `bun run test:bun` 5265 pass / 0 fail; `bun run build`, `bun run typecheck`, `audit:core-first`, `audit:docs`, `audit:core-semver` all green.

Changeset: `@guren/core` minor. Docs and `guren check` integration are Part 4 per the RFC's plan; R2 `getStream`/`capabilities` are Part 3.

Refs: RFC 0015