### PR TITLE
docs: add server-rendered views guide (RFC 0014)

### DIFF
--- a/docs/en/guides/controllers.md
+++ b/docs/en/guides/controllers.md
@@ -96,6 +96,7 @@ export default class PostsController extends Controller {
 |--------|--------|-------------|
 | `this.json(data)` | 200 | Return JSON |
 | `this.inertia(component, props)` | 200 | Render an Inertia page |
+| `this.view(component, props)` | 200 | Render a server-rendered HTML page ([Server-Rendered Views](./views.md)) |
 | `this.created(data)` | 201 | JSON with 201 status |
 | `this.accepted(data)` | 202 | JSON with 202 status |
 | `this.redirect(url)` | 302 | HTTP redirect |

--- a/docs/en/guides/views.md
+++ b/docs/en/guides/views.md
@@ -1,0 +1,203 @@
+# Server-Rendered Views
+
+`this.view()` renders a JSX component to a plain server-rendered HTML response — the non-hydrating counterpart to `this.inertia()` for public, read-mostly pages: blog posts, docs, marketing pages. No client framework, no hydration, no Inertia page-payload script in the document. It is what guren.dev uses for its own blog posts.
+
+```ts
+// app/Http/Controllers/BlogController.ts — plain .ts, zero JSX syntax
+import { Controller } from '@guren/core'
+import { z } from 'zod'
+import { ShowPage, PostNotFoundPage } from '../../View/ShowPage.js'
+import { Post } from '../../Models/Post.js'
+
+const SlugParamSchema = z.object({ slug: z.string().min(1) })
+
+export default class BlogController extends Controller {
+  async show() {
+    const { slug } = this.validateParams(SlugParamSchema)
+    const post = await Post.where({ slug }).first()
+
+    if (!post) {
+      return this.view(PostNotFoundPage, {}, { status: 404 })
+    }
+
+    return this.view(ShowPage, { post })
+  }
+}
+```
+
+`view(component, props, options?)` takes a component and its props — not a JSX element — so controllers stay plain `.ts` files. Props are compile-checked at the call site: a wrong prop name is a type error immediately, with no codegen step in between. The optional third argument accepts `status` and `headers` plus a `doctype` flag ([see below](#full-documents-and-fragments)).
+
+## When to use `view()` vs `this.inertia()`
+
+`this.inertia()` is the right choice for interactive, stateful UI — forms, dashboards, anything that navigates client-side. But on an initial document request, Inertia embeds the full page props as a JSON script in `<head>`, and when server-side rendering is enabled the same content is *additionally* rendered as HTML in `<body>`. A large prop — an article body, most obviously — ships twice.
+
+Measured while migrating a real blog off Inertia for its public pages: the same article weighed 443 KB as an Inertia SSR document and 144 KB as plain server-rendered HTML. On guren.dev, the duplicated payload survived compression well enough to be 33.7% of the gzipped response on a docs page.
+
+| Use `this.inertia()` | Use `this.view()` |
+|---|---|
+| Interactive UI: forms, dashboards, admin panels | Public, read-mostly content: blog posts, docs, marketing pages |
+| Client-side navigation between pages | Fresh navigations and crawlers — SEO-critical pages |
+| State that lives in React | Pages that hydrate nothing worth a framework |
+
+The two coexist in one app: guren.dev's blog serves its post page with `view()` while the admin editor stays on Inertia.
+
+## Your first View component
+
+View components live in `app/View/*.tsx` (module-local: `modules/<name>/app/View/`), never under `resources/js/pages/` — codegen claims that directory for Inertia pages. Every View file starts with a JSX pragma pointing at `@guren/core` and imports its types from there — your app never declares `hono` as a dependency; the JSX runtime is re-exported through `@guren/core`, which the app already has:
+
+```tsx
+// app/View/Layout.tsx — the document skeleton every page wraps itself in
+/** @jsxImportSource @guren/core */
+import { viteAsset, type FC, type PropsWithChildren } from '@guren/core'
+
+export const Layout: FC<PropsWithChildren<{ head?: unknown }>> = ({ head, children }) => (
+  <html lang="en">
+    <head>
+      <meta charSet="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <link rel="stylesheet" href={viteAsset('resources/css/app.css')} />
+      {head as never}
+    </head>
+    <body>{children as never}</body>
+  </html>
+)
+```
+
+```tsx
+// app/View/ShowPage.tsx — server-only, never hydrates
+/** @jsxImportSource @guren/core */
+import type { FC } from '@guren/core'
+import { Layout } from './Layout.js'
+
+type PostView = { slug: string; title: string; description: string; bodyHtml: string }
+
+export const ShowPage: FC<{ post: PostView }> = ({ post }) => (
+  <Layout
+    head={
+      <>
+        <title>{post.title} | example.com</title>
+        <meta name="description" content={post.description} />
+        <link rel="canonical" href={`https://example.com/blog/${post.slug}`} />
+      </>
+    }
+  >
+    <article dangerouslySetInnerHTML={{ __html: post.bodyHtml }} />
+  </Layout>
+)
+```
+
+Text children and attribute values are HTML-escaped automatically — `{post.title}` is safe whatever the title contains. The `bodyHtml` injection is safe here because it comes out of a sanitizing renderer; see [the security boundary](#the-security-boundary) for where that responsibility sits.
+
+## The Layout pattern
+
+A Layout is a plain component with an `<html>` root that each page wraps itself in — there is no layout registry or middleware. Two rules keep documents correct and fast:
+
+**The Layout's own `<head>` carries only what pages never restate** — charset, viewport, the stylesheet link, site-wide tags like an RSS discovery link. Per-page metadata (`<title>`, descriptions, canonical URLs) belongs to the page component. This is not just tidiness: metadata rendered by pages is *appended* to `<head>`, never replaced — deduplication skips the Layout's literal children, and browsers use the **first** `<title>` they see. A hard-coded default `<title>` in the Layout silently shadows every page's title.
+
+**Pass page metadata through a Layout `head` slot, not the body.** Tags rendered anywhere in the tree — `<title>`, `<meta>`, `<link>` — are hoisted into `<head>` natively, so a deeply nested component can still contribute metadata. But hoisting rescans the document per hoisted tag, which is quadratic in tag count: a 15-tag SEO block rendered in the body costs about a millisecond per render and grows with page size. The `head` slot in the Layout above renders the same tags directly into `<head>` at flat cost. Hoisting stays as the safety net for tags emitted deep in the tree; the slot is the fast path.
+
+`<script type="application/ld+json">` and `<style>` are *not* hoisted — they render where you put them.
+
+## Resolving assets: `viteAsset()`
+
+A content page needs its stylesheet URL, and that URL is environment-dependent. `viteAsset(entry)` owns both branches:
+
+- **Development** — the Vite dev server serves the source path directly, so `viteAsset('resources/css/app.css')` returns the dev-server URL for that path.
+- **Production** — the entry is looked up in the Vite build manifest and the hashed output file is returned, served with immutable caching.
+
+If neither resolves, `viteAsset()` throws an error naming the paths it tried — never a silent empty string.
+
+One requirement to know about: **a CSS file bundled through a JS entry has no manifest key of its own.** Declare the stylesheet as an explicit build input so Vite emits and records it:
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      input: ['resources/js/app.tsx', 'resources/css/app.css'],
+    },
+  },
+  // ...
+})
+```
+
+### Serverless targets
+
+Serverless bundles ship without the build output directory, so there is no manifest file to read at runtime. The deploy plugins (`@guren/plugin-cloudflare`, `@guren/plugin-vercel`, `@guren/plugin-lambda`) handle this during their build step by injecting the manifest JSON into the `GUREN_VITE_MANIFEST` environment variable; `viteAsset()` prefers it over the filesystem. No configuration on your side — `view()` pages work on targets whose runtime never sees `public/assets/manifest.json`.
+
+## Full documents and fragments
+
+Forgetting to wrap a page in its Layout would fail *softly*: the page still renders a 200, but with no `<head>` to hoist into, every `<title>` and `<meta>` stays inline in the body and no stylesheet is linked. You would notice the missing styles in development; a crawler reading SEO tags out of `<body>` is noticed much later.
+
+So `view()` fails loudly instead: a component that renders a fragment rather than an `<html>`-rooted document throws a descriptive error at first render. When a fragment is what you want — an HTML partial for a widget, say — pass `{ doctype: false }`:
+
+```ts
+return this.view(CommentPartial, { comment }, { doctype: false })
+```
+
+This skips both the document check and the `<!doctype html>` prefix.
+
+## The security boundary
+
+Automatic escaping prevents markup and attribute breakout: a `<script>` tag in a text child renders as text, and a `"` in an attribute value cannot terminate the attribute. Two things remain your responsibility:
+
+**URL schemes are not validated.** `href={userProvidedUrl}` passes a `javascript:` URL through verbatim — escaping is about HTML structure, not link targets. For user-supplied content, sanitize upstream: [`@guren/plugin-markdown`](./markdown.md)'s sanitizer restricts `href`/`src` to `http`, `https`, and `mailto`, and its output is safe to inject with `dangerouslySetInnerHTML`. Rendering sanitized markdown into a View component is exactly the guren.dev blog pipeline.
+
+**JSON-LD needs `dangerouslySetInnerHTML`.** Text children are HTML-escaped, which turns inline JSON into garbage. Emit structured data with the `<` characters escaped as `\u003c` (valid JSON, and inert inside a script element):
+
+```tsx
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c') }}
+/>
+```
+
+## Keeping the two JSX worlds apart
+
+An app using both `view()` and Inertia contains two JSX dialects: React under `resources/js/pages/` (hydrates in the browser) and server-only components under `app/View/`. The compiler already rejects most confusions — a React component passed to `view()`, a View component rendered inside a React page, a missing pragma on an annotated component. Always annotate View components explicitly as `FC<Props>`; an unannotated component is one of the shapes the compiler cannot catch crossing the boundary.
+
+For the rest, add a boundary rule to `guren.arch.ts` and `bunx guren check` enforces it:
+
+```ts
+// guren.arch.ts
+import { defineArchRules } from '@guren/cli/arch'
+
+export default defineArchRules({
+  rules: [
+    // Inertia pages must not import server-only View components.
+    { from: 'resources/js/pages/**', disallow: ['app/View/**', 'modules/*/app/View/**'], includeTypeImports: true },
+  ],
+})
+```
+
+See the [CLI guide](./cli.md) for how architecture rules work in general.
+
+## Gotchas
+
+Lessons from migrating guren.dev's blog, worth knowing before your first page:
+
+- **Inertia `<Link>` to a `view()` route breaks.** The route returns plain HTML, which the Inertia client rejects with its error dialog. Link into `view()` routes with a plain `<a href>` — from Inertia pages too.
+- **Format dates with an explicit `timeZone`.** Date formatting that moves server-side renders in the *server's* time zone — a server in Los Angeles renders "June 30" for a July 1 UTC instant. Pin it: `new Intl.DateTimeFormat('en-US', { dateStyle: 'long', timeZone: 'UTC' })`.
+- **Tailwind must scan `app/View/`.** Tailwind v4's automatic source detection already covers it. On v3-style `content` globs, add `./app/View/**/*.tsx` (and `./modules/*/app/View/**/*.tsx` if you use modules) or your View components' classes are purged from the build.
+- **No HMR.** `view()` pages carry no Vite client, so there is nothing to hot-reload — edit and refresh. That is the deal: zero client JavaScript unless you add some.
+
+## Testing
+
+A `view()` response is plain HTML — assert on the document text:
+
+```ts
+const response = await controller.show()
+const html = await response.text()
+
+expect(response.status).toBe(404)
+expect(html).toContain('Post not found')
+expect(html).toMatch(/<link rel="stylesheet"/)
+```
+
+For isolated controller tests under Vitest, `createControllerModuleMock()` from `@guren/testing` supports `view()` and exports a `viteAsset()` mock (requires `@guren/testing` 1.7.0 or later). Both delegate to the real rendering engine — escaping, the fragment guard, and asset resolution behave exactly as in production, and `viteAsset()` returns deterministic dev-server URLs under test. See the [Testing guide](./testing.md) for the controller-testing helpers in general.
+
+## Next steps
+
+- [Controllers](./controllers.md) — the rest of the response helpers, validation, and route model binding
+- [Frontend](./frontend.md) — the Inertia side: pages, layouts, and type-safe props
+- [Markdown Rendering](./markdown.md) — the sanitizing markdown pipeline that pairs with `view()` for content sites

--- a/docs/ja/guides/controllers.md
+++ b/docs/ja/guides/controllers.md
@@ -153,6 +153,7 @@ if (await this.has('email')) {
 | ヘルパー | 用途 |
 |--------|---------|
 | `this.inertia(component, props, options?)` | `resources/js/pages/<component>.tsx` を使って Inertia ページをレンダリングします。`Promise<Response>` を返すため、コントローラーアクションは `async` にして `return` で直接返してください。 |
+| `this.view(component, props, options?)` | `app/View/` のコンポーネントをサーバーレンダリング HTML として返します。公開・読み取り中心のページ向けです。詳細は[サーバーレンダリングビュー](./views.md)を参照してください。 |
 | `this.json(data, init?)` | ステータス 200 で JSON を返します。 |
 | `this.created(data)` | ステータス 201 で JSON を返します。 |
 | `this.accepted(data)` | ステータス 202 で JSON を返します。 |

--- a/docs/ja/guides/views.md
+++ b/docs/ja/guides/views.md
@@ -1,0 +1,203 @@
+# サーバーレンダリングビュー
+
+`this.view()` は JSX コンポーネントをプレーンなサーバーレンダリング HTML レスポンスとして返します。ブログ記事、ドキュメント、マーケティングページのような公開・読み取り中心のページ向けの、`this.inertia()` のハイドレーションしない対になる存在です。クライアントフレームワークなし、ハイドレーションなし、Inertia のページペイロードスクリプトもドキュメントに含まれません。guren.dev 自身のブログ記事がこの仕組みで配信されています。
+
+```ts
+// app/Http/Controllers/BlogController.ts。プレーンな .ts のままで、JSX 構文はゼロ
+import { Controller } from '@guren/core'
+import { z } from 'zod'
+import { ShowPage, PostNotFoundPage } from '../../View/ShowPage.js'
+import { Post } from '../../Models/Post.js'
+
+const SlugParamSchema = z.object({ slug: z.string().min(1) })
+
+export default class BlogController extends Controller {
+  async show() {
+    const { slug } = this.validateParams(SlugParamSchema)
+    const post = await Post.where({ slug }).first()
+
+    if (!post) {
+      return this.view(PostNotFoundPage, {}, { status: 404 })
+    }
+
+    return this.view(ShowPage, { post })
+  }
+}
+```
+
+`view(component, props, options?)` は JSX 要素ではなく、コンポーネントと props を受け取ります。そのためコントローラーはプレーンな `.ts` ファイルのままです。props は呼び出し箇所でコンパイルチェックされます。間違った prop 名は即座に型エラーになり、間に codegen のステップはありません。省略可能な第 3 引数は `status` と `headers`、そして `doctype` フラグ（[後述](#完全なドキュメントとフラグメント)）を受け付けます。
+
+## `view()` と `this.inertia()` の使い分け
+
+インタラクティブで状態を持つ UI、つまりフォームやダッシュボード、クライアントサイドで遷移する画面には `this.inertia()` が適しています。しかし初回のドキュメントリクエストで Inertia はページ props 全体を JSON スクリプトとして `<head>` に埋め込み、さらにサーバーサイドレンダリングが有効なら同じ内容が HTML としても `<body>` にレンダリングされます。記事本文のような大きな prop は 2 回配信されることになります。
+
+実際のブログの公開ページを Inertia から移行した際の実測では、同じ記事が Inertia SSR ドキュメントとして 443 KB、プレーンなサーバーレンダリング HTML として 144 KB でした。guren.dev では、この重複ペイロードは圧縮後もよく生き残り、docs ページの gzip 後レスポンスの 33.7% を占めていました。
+
+| `this.inertia()` を使う | `this.view()` を使う |
+|---|---|
+| インタラクティブな UI: フォーム、ダッシュボード、管理画面 | 公開・読み取り中心のコンテンツ: ブログ記事、ドキュメント、マーケティングページ |
+| ページ間のクライアントサイドナビゲーション | 新規ナビゲーションとクローラー向けの SEO が重要なページ |
+| React に状態を持つ画面 | フレームワークに値するハイドレーションを何もしないページ |
+
+両者は 1 つのアプリで共存します。guren.dev のブログは記事ページを `view()` で配信しつつ、管理画面のエディタは Inertia のままです。
+
+## 最初の View コンポーネント
+
+View コンポーネントは `app/View/*.tsx`（モジュールローカルなら `modules/<name>/app/View/`）に置きます。`resources/js/pages/` 配下には決して置かないでください。あのディレクトリは codegen が Inertia ページ用として占有しています。すべての View ファイルは `@guren/core` を指す JSX プラグマで始まり、型も `@guren/core` からインポートします。アプリが `hono` を依存に追加することはありません。JSX ランタイムは、アプリがすでに持っている `@guren/core` を通じて再エクスポートされています。
+
+```tsx
+// app/View/Layout.tsx。すべてのページが自分でラップするドキュメントの骨格
+/** @jsxImportSource @guren/core */
+import { viteAsset, type FC, type PropsWithChildren } from '@guren/core'
+
+export const Layout: FC<PropsWithChildren<{ head?: unknown }>> = ({ head, children }) => (
+  <html lang="ja">
+    <head>
+      <meta charSet="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <link rel="stylesheet" href={viteAsset('resources/css/app.css')} />
+      {head as never}
+    </head>
+    <body>{children as never}</body>
+  </html>
+)
+```
+
+```tsx
+// app/View/ShowPage.tsx。サーバー専用で、ハイドレーションされない
+/** @jsxImportSource @guren/core */
+import type { FC } from '@guren/core'
+import { Layout } from './Layout.js'
+
+type PostView = { slug: string; title: string; description: string; bodyHtml: string }
+
+export const ShowPage: FC<{ post: PostView }> = ({ post }) => (
+  <Layout
+    head={
+      <>
+        <title>{post.title} | example.com</title>
+        <meta name="description" content={post.description} />
+        <link rel="canonical" href={`https://example.com/blog/${post.slug}`} />
+      </>
+    }
+  >
+    <article dangerouslySetInnerHTML={{ __html: post.bodyHtml }} />
+  </Layout>
+)
+```
+
+テキストの子要素と属性値は自動的に HTML エスケープされます。タイトルに何が含まれていても `{post.title}` は安全です。この `bodyHtml` の注入が安全なのは、サニタイズするレンダラーの出力だからです。その責任の所在は[セキュリティ境界](#セキュリティ境界)を参照してください。
+
+## Layout パターン
+
+Layout は `<html>` ルートを持つプレーンなコンポーネントで、各ページが自分でラップします。レイアウトのレジストリやミドルウェアはありません。ドキュメントを正しく速く保つルールは 2 つです。
+
+**Layout 自身の `<head>` には、ページが決して上書きしないものだけを置きます**。charset、viewport、スタイルシートのリンク、RSS 発見リンクのようなサイト全体のタグです。ページごとのメタデータ（`<title>`、description、canonical URL）はページコンポーネントに属します。これは単なる整理整頓ではありません。ページがレンダリングしたメタデータは `<head>` に追記されるのであって、置き換えられることはありません。重複排除は Layout のリテラルな子要素を対象にせず、ブラウザは最初に見つけた `<title>` を使います。Layout にハードコードしたデフォルトの `<title>` は、すべてのページのタイトルを静かに覆い隠します。
+
+**ページのメタデータは body ではなく、Layout の `head` スロットで渡します**。ツリーのどこでレンダリングされた `<title>`、`<meta>`、`<link>` もネイティブに `<head>` へ巻き上げ（hoisting）られるので、深くネストしたコンポーネントからでもメタデータを供給できます。ただし hoisting は巻き上げるタグ 1 つごとにドキュメント全体を再走査するため、タグ数に対して二乗のコストがかかります。body に置いた 15 タグの SEO ブロックはレンダリングごとに約 1 ミリ秒を消費し、ページサイズとともに増えます。上の Layout の `head` スロットは同じタグを一定コストで `<head>` に直接レンダリングします。hoisting はツリー深くで出力されるタグのための安全網として残り、スロットが高速経路です。
+
+`<script type="application/ld+json">` と `<style>` は巻き上げられません。書いた場所にそのままレンダリングされます。
+
+## アセット解決: `viteAsset()`
+
+コンテンツページにはスタイルシートの URL が必要で、その URL は環境依存です。`viteAsset(entry)` が両方の分岐を担います。
+
+- **開発時**: Vite 開発サーバーがソースパスを直接配信するため、`viteAsset('resources/css/app.css')` はそのパスの開発サーバー URL を返します。
+- **本番**: エントリを Vite ビルドマニフェストから引き、ハッシュ付き出力ファイルを返します。immutable キャッシュ付きで配信されます。
+
+どちらも解決できない場合、`viteAsset()` は試したパスを列挙するエラーを投げます。空文字列を黙って返すことはありません。
+
+知っておくべき要件が 1 つあります。**JS エントリ経由でバンドルされた CSS ファイルは、自分のマニフェストキーを持ちません**。Vite がファイルを出力しマニフェストに記録するよう、スタイルシートを明示的なビルド入力として宣言してください。
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      input: ['resources/js/app.tsx', 'resources/css/app.css'],
+    },
+  },
+  // ...
+})
+```
+
+### サーバーレスターゲット
+
+サーバーレスのバンドルはビルド出力ディレクトリを伴わずに配備されるため、実行時に読めるマニフェストファイルがありません。デプロイプラグイン（`@guren/plugin-cloudflare`、`@guren/plugin-vercel`、`@guren/plugin-lambda`）はビルドステップでマニフェスト JSON を環境変数 `GUREN_VITE_MANIFEST` に注入し、`viteAsset()` はファイルシステムよりそちらを優先します。アプリ側の設定は不要です。ランタイムが `public/assets/manifest.json` を決して見ないターゲットでも `view()` ページは動作します。
+
+## 完全なドキュメントとフラグメント
+
+ページを Layout でラップし忘れると、失敗は静かに起こります。ページは 200 を返しますが、巻き上げ先の `<head>` がないため、すべての `<title>` と `<meta>` は body 内にインラインのまま残り、スタイルシートもリンクされません。開発中ならスタイルの欠落に気づけますが、クローラーが body から SEO タグを読んでいることに気づくのはずっと後です。
+
+そのため `view()` は大きな音を立てて失敗します。`<html>` をルートとするドキュメントではなくフラグメントをレンダリングしたコンポーネントは、最初のレンダリングで説明的なエラーを投げます。フラグメントを意図している場合（たとえばウィジェット用の HTML 部品）は `{ doctype: false }` を渡してください。
+
+```ts
+return this.view(CommentPartial, { comment }, { doctype: false })
+```
+
+これでドキュメント検査と `<!doctype html>` の付与が両方スキップされます。
+
+## セキュリティ境界
+
+自動エスケープはマークアップと属性の突破を防ぎます。テキストの子要素にある `<script>` タグはテキストとしてレンダリングされ、属性値の中の `"` が属性を打ち切ることはできません。残りの 2 つはあなたの責任です。
+
+**URL スキームは検証されません**。`href={userProvidedUrl}` は `javascript:` URL をそのまま通します。エスケープは HTML の構造の話であって、リンク先の話ではありません。ユーザー投稿コンテンツは上流でサニタイズしてください。[`@guren/plugin-markdown`](./markdown.md) のサニタイザーは `href`/`src` を `http`、`https`、`mailto` に制限し、その出力は `dangerouslySetInnerHTML` で注入して安全です。サニタイズ済み markdown を View コンポーネントにレンダリングする構成は、まさに guren.dev のブログのパイプラインです。
+
+**JSON-LD には `dangerouslySetInnerHTML` が必要です**。テキストの子要素は HTML エスケープされるため、インライン JSON は壊れてしまいます。構造化データは `<` 文字を `\u003c` にエスケープして出力してください（JSON として妥当なまま、script 要素内で無害になります）。
+
+```tsx
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c') }}
+/>
+```
+
+## 2 つの JSX 世界を分離する
+
+`view()` と Inertia の両方を使うアプリは、2 つの JSX 方言を含みます。`resources/js/pages/` 配下の React（ブラウザでハイドレーションされる）と、`app/View/` 配下のサーバー専用コンポーネントです。コンパイラはほとんどの取り違えをすでに拒否します。React コンポーネントを `view()` に渡す、View コンポーネントを React ページ内でレンダリングする、注釈付きコンポーネントのプラグマ忘れ、などです。View コンポーネントには必ず `FC<Props>` の明示的な注釈を付けてください。注釈のないコンポーネントは、境界越えをコンパイラが捕捉できない形の 1 つです。
+
+残りは `guren.arch.ts` に境界ルールを追加すれば `bunx guren check` が強制します。
+
+```ts
+// guren.arch.ts
+import { defineArchRules } from '@guren/cli/arch'
+
+export default defineArchRules({
+  rules: [
+    // Inertia ページはサーバー専用の View コンポーネントをインポートしてはならない。
+    { from: 'resources/js/pages/**', disallow: ['app/View/**', 'modules/*/app/View/**'], includeTypeImports: true },
+  ],
+})
+```
+
+アーキテクチャルール全般については [CLI ガイド](./cli.md)を参照してください。
+
+## 落とし穴
+
+guren.dev のブログ移行で得た教訓です。最初のページを作る前に知っておく価値があります。
+
+- **`view()` ルートへの Inertia `<Link>` は壊れます**。ルートはプレーン HTML を返すため、Inertia クライアントはエラーダイアログを出して拒否します。`view()` ルートへは Inertia ページからでもプレーンな `<a href>` でリンクしてください。
+- **日付フォーマットには明示的な `timeZone` を**。サーバーサイドに移った日付フォーマットは、サーバーのタイムゾーンでレンダリングされます。ロサンゼルスのサーバーは UTC の 7 月 1 日を「6 月 30 日」と表示します。`new Intl.DateTimeFormat('ja-JP', { dateStyle: 'long', timeZone: 'UTC' })` のように固定してください。
+- **Tailwind に `app/View/` を走査させる**。Tailwind v4 の自動ソース検出はすでにカバーしています。v3 スタイルの `content` グロブを使っている場合は `./app/View/**/*.tsx`（モジュールを使うなら `./modules/*/app/View/**/*.tsx` も）を追加しないと、View コンポーネントのクラスがビルドからパージされます。
+- **HMR はありません**。`view()` ページは Vite クライアントを載せないため、ホットリロードの対象がそもそもありません。編集してリロードしてください。これは取引です。自分で足さない限りクライアント JavaScript はゼロです。
+
+## テスト
+
+`view()` レスポンスはプレーン HTML です。ドキュメントのテキストに対してアサートします。
+
+```ts
+const response = await controller.show()
+const html = await response.text()
+
+expect(response.status).toBe(404)
+expect(html).toContain('Post not found')
+expect(html).toMatch(/<link rel="stylesheet"/)
+```
+
+Vitest でのコントローラー単体テストには、`@guren/testing` の `createControllerModuleMock()` が `view()` をサポートし、`viteAsset()` のモックもエクスポートします（`@guren/testing` 1.7.0 以降が必要です）。どちらも実際のレンダリングエンジンに委譲するため、エスケープ、フラグメントガード、アセット解決は本番とまったく同じ挙動になり、テスト中の `viteAsset()` は決定的な開発サーバー URL を返します。コントローラーテストのヘルパー全般は[テストガイド](./testing.md)を参照してください。
+
+## 次のステップ
+
+- [コントローラー](./controllers.md): 残りのレスポンスヘルパー、バリデーション、ルートモデルバインディング
+- [フロントエンド](./frontend.md): Inertia 側。ページ、レイアウト、型安全な props
+- [Markdownレンダリング](./markdown.md): コンテンツサイトで `view()` と組み合わせるサニタイズ付き markdown パイプライン

--- a/web/app/Services/docs-config.ts
+++ b/web/app/Services/docs-config.ts
@@ -44,7 +44,7 @@ const GUIDE_SECTIONS: readonly DocSectionConfig[] = [
   },
   {
     title: { en: 'The Basics', ja: '基本' },
-    slugs: ['routing', 'controllers', 'middleware', 'csrf', 'validation', 'error-handling', 'database', 'frontend'],
+    slugs: ['routing', 'controllers', 'middleware', 'csrf', 'validation', 'error-handling', 'database', 'frontend', 'views'],
   },
   {
     title: { en: 'Security', ja: 'セキュリティ' },


### PR DESCRIPTION
## Summary

User-facing documentation for `Controller.view()` — first-class server-rendered content pages (RFC 0014, shipped in v2.12.0 and dogfooded on guren.dev's own blog in #569).

- New guide **Server-Rendered Views** in English (`docs/en/guides/views.md`) and Japanese (`docs/ja/guides/views.md`), indexed under **The Basics** after Frontend in the docs site nav (`web/app/Services/docs-config.ts`).
- Cross-link from the controllers guide's response-helper table (both locales).

## What the guide covers

- **When to use `view()` vs `this.inertia()`** — public read-mostly pages vs interactive UI, with the measured motivation: the same article shipped 443 KB as an Inertia SSR document vs 144 KB as plain SSR HTML, and guren.dev docs pages carried 33.7% of their gzipped response as duplicated payload.
- **Setup** — View files in `app/View/` (module-local `modules/<name>/app/View/`), the `/** @jsxImportSource @guren/core */` pragma, `FC`/`PropsWithChildren`/`viteAsset` imported from `@guren/core`; apps never declare hono.
- **The Layout pattern** — the head rule (only what pages never restate; a hard-coded Layout `<title>` silently shadows pages), the `head` slot as the fast path with hoisting as the safety net (hoisting is quadratic in tag count).
- **`viteAsset()`** — dev vs production resolution, the explicit Vite build input requirement for CSS entries, and serverless via the deploy plugins' `GUREN_VITE_MANIFEST` injection.
- **The fragment guard** and `{ doctype: false }`.
- **The security boundary** — markup/attribute escaping is automatic; URL schemes are not validated (compose with `@guren/plugin-markdown`'s sanitizer for user content); JSON-LD needs `dangerouslySetInnerHTML` with `<` escaped as `\u003c`.
- **The `guren.arch.ts` boundary rule** keeping React pages from importing View components, using the amended glob from the RFC (`['app/View/**', 'modules/*/app/View/**']`).
- **Gotchas from the dogfooding** — Inertia `<Link>` into a `view()` route breaks (use plain `<a>`), server-side date formatting needs an explicit `timeZone`, Tailwind v3-style content globs need `./app/View/**/*.tsx`, and `view()` pages have no HMR (edit-refresh).
- **Testing** — asserting on `response.text()`, and `createControllerModuleMock()`'s `view()`/`viteAsset()` support (requires `@guren/testing` 1.7.0+, the pending minor).

The conventions agree with the agent-harness rule text (`packages/cli/templates/agent/core/rules/controllers-http.md`), and all technical claims were written from RFC 0014, the `view()`/`viteAsset()` sources, and the #569 reference implementation rather than from memory.

## Verification

- `bun run audit:docs` ✅
- `bun run audit:core-first` ✅ (guides reference `@guren/core` only)
- `bun packages/cli/src/bin.ts check --docs` ✅ (note: the doc-link gate scans OKF-frontmatter docs; these guides have none, verified by mutation — a deliberately broken link is not flagged, so relative links were checked by hand instead)
- `bun run build` + root `bun run typecheck` ✅
- `web`: `bun run typecheck` + `bun run test` (114 tests) ✅ — covers the `docs-config.ts` nav change

Refs: RFC 0014