### PR TITLE
feat(server): stamp authorization capabilities on authorize middlewares

### DIFF
--- a/.changeset/authorization-capabilities.md
+++ b/.changeset/authorization-capabilities.md
@@ -1,0 +1,22 @@
+---
+'@guren/server': minor
+---
+
+Stamp authorization capabilities on the authorize middlewares, so a route's
+required ability is derivable from its middleware chain instead of from
+controller bodies (RFC 0016 §4).
+
+`authorizeMiddleware`, `authorizeAllMiddleware`, and
+`authorizeResourceMiddleware` now carry an RFC 0007 capability stamp, which
+`Router.definitions()` aggregates into `RouteDefinition.capabilities`
+alongside the existing authentication capability. A single ability reports
+`{ abilities: ['update'], mode: 'all' }`; an ability list reports `'any'`;
+`authorizeAllMiddleware` reports `'all'`; the resource variant reports a
+`resource` marker, whose `fromMethodMap` says whether the built-in HTTP verb
+map decides the ability (it does not when an `abilityFor` callback overrides
+it). A chain carrying several checks that do not combine into a single all-of
+reports `mode: 'mixed'` — authorization is present, but no one ability may be
+named for it.
+
+The capability shape stays internal (nothing new is exported from the package
+root) and may change in any release.

--- a/.changeset/authorization-capabilities.md
+++ b/.changeset/authorization-capabilities.md
@@ -10,15 +10,16 @@ controller bodies (RFC 0016 §4).
 `authorizeResourceMiddleware` now carry an RFC 0007 capability stamp, which
 `Router.definitions()` aggregates into `RouteDefinition.capabilities`
 alongside the existing authentication capability. A single ability reports
-`{ abilities: ['update'], mode: 'all' }`; two or more alternatives report
-`'any'`; `authorizeAllMiddleware` reports `'all'`; the resource variant
+`{ abilities: ['update'], mode: 'all' }` however it was written; two or more
+alternatives report `'any'`; `authorizeAllMiddleware` reports `'all'`; the
+resource variant
 reports a `resource` marker, whose `fromMethodMap` says whether the built-in
 HTTP verb map decides the ability (it does not when an `abilityFor` callback
 overrides it). A chain carrying several checks that do not combine into a
 single all-of reports `mode: 'mixed'` — authorization is present, but no one
 ability may be named for it.
 
-Two behaviour changes come with it:
+Three behaviour changes come with it:
 
 - `authorizeAllMiddleware([])` now throws at creation. `Gate.all([])` is
   vacuously true, so an empty list mounted a route that advertised
@@ -26,6 +27,10 @@ Two behaviour changes come with it:
 - All three middlewares now snapshot their arguments at creation
   (the ability array, and `options.abilityFor`), so mutating them afterwards
   can no longer change what is enforced or make the stamp disagree with it.
+- `authorizeMiddleware(['one-ability'])` is now treated exactly like
+  `authorizeMiddleware('one-ability')`, so its denial carries the policy's own
+  message and status instead of the generic any-of message. Two or more
+  alternatives are unchanged.
 
 The capability shape stays internal (nothing new is exported from the package
 root) and may change in any release.

--- a/.changeset/authorization-capabilities.md
+++ b/.changeset/authorization-capabilities.md
@@ -10,13 +10,22 @@ controller bodies (RFC 0016 §4).
 `authorizeResourceMiddleware` now carry an RFC 0007 capability stamp, which
 `Router.definitions()` aggregates into `RouteDefinition.capabilities`
 alongside the existing authentication capability. A single ability reports
-`{ abilities: ['update'], mode: 'all' }`; an ability list reports `'any'`;
-`authorizeAllMiddleware` reports `'all'`; the resource variant reports a
-`resource` marker, whose `fromMethodMap` says whether the built-in HTTP verb
-map decides the ability (it does not when an `abilityFor` callback overrides
-it). A chain carrying several checks that do not combine into a single all-of
-reports `mode: 'mixed'` — authorization is present, but no one ability may be
-named for it.
+`{ abilities: ['update'], mode: 'all' }`; two or more alternatives report
+`'any'`; `authorizeAllMiddleware` reports `'all'`; the resource variant
+reports a `resource` marker, whose `fromMethodMap` says whether the built-in
+HTTP verb map decides the ability (it does not when an `abilityFor` callback
+overrides it). A chain carrying several checks that do not combine into a
+single all-of reports `mode: 'mixed'` — authorization is present, but no one
+ability may be named for it.
+
+Two behaviour changes come with it:
+
+- `authorizeAllMiddleware([])` now throws at creation. `Gate.all([])` is
+  vacuously true, so an empty list mounted a route that advertised
+  authorization and enforced none.
+- All three middlewares now snapshot their arguments at creation
+  (the ability array, and `options.abilityFor`), so mutating them afterwards
+  can no longer change what is enforced or make the stamp disagree with it.
 
 The capability shape stays internal (nothing new is exported from the package
 root) and may change in any release.

--- a/packages/server/src/authorization/middleware.ts
+++ b/packages/server/src/authorization/middleware.ts
@@ -21,9 +21,11 @@ import { stampCapabilities } from '../http/middleware/capabilities'
  * ```
  *
  * An array argument is snapshotted at creation: mutating it afterwards
- * changes neither what the middleware checks nor what it reports. An empty
- * array denies every request (`Gate.any([])` is false) and stamps no ability
- * names — fail-closed, so it is left to run rather than rejected.
+ * changes neither what the middleware checks nor what it reports. A
+ * one-element array is treated exactly like the bare ability, denial message
+ * and status included. An empty array denies every request (`Gate.any([])` is
+ * false) and names no ability — fail-closed, so it is left to run rather than
+ * rejected.
  */
 export function authorizeMiddleware(
   ability: string | string[],
@@ -32,8 +34,8 @@ export function authorizeMiddleware(
 ): Middleware {
   // One snapshot feeds both the handler and the stamp, so a caller mutating
   // the array it passed cannot make the two disagree.
-  const anyOf = Array.isArray(ability)
-  const abilities = anyOf ? [...(ability as string[])] : [ability as string]
+  const abilities = Array.isArray(ability) ? [...ability] : [ability]
+  const anyOf = abilities.length !== 1
 
   return stampCapabilities(async (ctx, next) => {
     const gate = getGate()
@@ -48,8 +50,9 @@ export function authorizeMiddleware(
         throw new AuthorizationException(options.message ?? 'This action is unauthorized.')
       }
     } else {
-      // Single ability: keep the policy's own message and status, so the same
-      // denial reads the same here as through `Controller.authorize()`.
+      // Exactly one ability, however it was written: keep the policy's own
+      // message and status, so the same denial reads the same here as through
+      // `Controller.authorize()`.
       const response = await gateForUser.checkResponse(abilities[0]!, user, model)
       if (!response.allowed) {
         throw denialToException(options.message ? { ...response, message: options.message } : response)
@@ -58,10 +61,9 @@ export function authorizeMiddleware(
 
     await next()
   }, {
-    // Any-of over exactly one ability *is* that ability, so it normalizes to
-    // 'all' — otherwise combining it with another all-of check would report
-    // 'mixed' for a chain whose ability is perfectly derivable.
-    authorization: { abilities, mode: abilities.length === 1 ? 'all' : 'any' },
+    // One ability normalizes to 'all' whichever way it was written; see
+    // `MiddlewareCapabilities.authorization` for why.
+    authorization: { abilities, mode: anyOf ? 'any' : 'all' },
   })
 }
 
@@ -170,7 +172,7 @@ export function authorizeResourceMiddleware(
 
   return stampCapabilities(async (ctx, next) => {
     const method = ctx.req.method.toUpperCase()
-    const ability = abilityFor?.(method) ?? RESOURCE_ABILITY_BY_METHOD[method]
+    const ability = abilityFor?.(method) ?? resourceAbilityForMethod(method)
 
     if (ability === undefined) {
       throw new AuthorizationException(options.message ?? 'This action is unauthorized.')

--- a/packages/server/src/authorization/middleware.ts
+++ b/packages/server/src/authorization/middleware.ts
@@ -3,6 +3,7 @@ import type { Middleware } from '../http/middleware'
 import type { AuthUser, AuthorizeOptions, AuthorizeResourceOptions } from './types'
 import { Gate, getGate, denialToException } from './Gate'
 import { AuthorizationException } from '../errors'
+import { stampCapabilities } from '../http/middleware/capabilities'
 
 /**
  * Middleware to authorize an ability.
@@ -24,7 +25,7 @@ export function authorizeMiddleware(
   modelResolver?: (ctx: Context) => unknown | Promise<unknown>,
   options: AuthorizeOptions = {}
 ): Middleware {
-  return async (ctx, next) => {
+  return stampCapabilities(async (ctx, next) => {
     const gate = getGate()
     const user = await gate.resolveUser(ctx)
     const gateForUser = gate.forUser(user)
@@ -47,7 +48,13 @@ export function authorizeMiddleware(
     }
 
     await next()
-  }
+  }, {
+    // Mirrors the runtime branch above: an array is an any-of check, a
+    // single ability is the one that has to hold.
+    authorization: Array.isArray(ability)
+      ? { abilities: [...ability], mode: 'any' }
+      : { abilities: [ability], mode: 'all' },
+  })
 }
 
 /**
@@ -58,7 +65,7 @@ export function authorizeAllMiddleware(
   modelResolver?: (ctx: Context) => unknown | Promise<unknown>,
   options: AuthorizeOptions = {}
 ): Middleware {
-  return async (ctx, next) => {
+  return stampCapabilities(async (ctx, next) => {
     const gate = getGate()
     const user = await gate.resolveUser(ctx)
     const gateForUser = gate.forUser(user)
@@ -73,7 +80,7 @@ export function authorizeAllMiddleware(
     }
 
     await next()
-  }
+  }, { authorization: { abilities: [...abilities], mode: 'all' } })
 }
 
 // HTTP method → policy ability. QUERY (RFC 10008) is safe like GET, so it
@@ -88,6 +95,21 @@ const RESOURCE_ABILITY_BY_METHOD: Record<string, string> = {
   PUT: 'update',
   PATCH: 'update',
   DELETE: 'delete',
+}
+
+/**
+ * The ability `authorizeResourceMiddleware` checks for an HTTP method, or
+ * `undefined` for a method it refuses to guess at (which the middleware
+ * denies). This is the single source of the verb → ability mapping: a
+ * consumer resolving a route's ability from its stamped
+ * `authorization.resource` capability calls this rather than restating the
+ * table, and may only do so when `resource.fromMethodMap` is true.
+ *
+ * Not re-exported from the package root — like the capability stamp itself
+ * (RFC 0007), this is an internal contract until a public consumer needs it.
+ */
+export function resourceAbilityForMethod(method: string): string | undefined {
+  return RESOURCE_ABILITY_BY_METHOD[method.toUpperCase()]
 }
 
 /**
@@ -116,7 +138,7 @@ export function authorizeResourceMiddleware(
   modelResolver: (ctx: Context) => unknown | Promise<unknown>,
   options: AuthorizeResourceOptions = {}
 ): Middleware {
-  return async (ctx, next) => {
+  return stampCapabilities(async (ctx, next) => {
     const method = ctx.req.method.toUpperCase()
     const ability = options.abilityFor?.(method) ?? RESOURCE_ABILITY_BY_METHOD[method]
 
@@ -136,7 +158,18 @@ export function authorizeResourceMiddleware(
     }
 
     await next()
-  }
+  }, {
+    // The ability is only known once a request arrives. `abilityFor` is
+    // consulted *before* the verb map and wins for standard methods too, so
+    // its presence makes the map non-authoritative for this route — say so
+    // rather than letting a consumer report the mapped ability for a check
+    // that never uses it.
+    authorization: {
+      abilities: [],
+      mode: 'all',
+      resource: { fromMethodMap: options.abilityFor === undefined },
+    },
+  })
 }
 
 /**

--- a/packages/server/src/authorization/middleware.ts
+++ b/packages/server/src/authorization/middleware.ts
@@ -19,21 +19,30 @@ import { stampCapabilities } from '../http/middleware/capabilities'
  * // Multiple abilities (any)
  * app.get('/dashboard', authorizeMiddleware(['admin', 'moderator']), dashboardHandler)
  * ```
+ *
+ * An array argument is snapshotted at creation: mutating it afterwards
+ * changes neither what the middleware checks nor what it reports. An empty
+ * array denies every request (`Gate.any([])` is false) and stamps no ability
+ * names — fail-closed, so it is left to run rather than rejected.
  */
 export function authorizeMiddleware(
   ability: string | string[],
   modelResolver?: (ctx: Context) => unknown | Promise<unknown>,
   options: AuthorizeOptions = {}
 ): Middleware {
+  // One snapshot feeds both the handler and the stamp, so a caller mutating
+  // the array it passed cannot make the two disagree.
+  const anyOf = Array.isArray(ability)
+  const abilities = anyOf ? [...(ability as string[])] : [ability as string]
+
   return stampCapabilities(async (ctx, next) => {
     const gate = getGate()
     const user = await gate.resolveUser(ctx)
     const gateForUser = gate.forUser(user)
 
-    const abilities = Array.isArray(ability) ? ability : [ability]
     const model = modelResolver ? await modelResolver(ctx) : undefined
 
-    if (Array.isArray(ability)) {
+    if (anyOf) {
       // Any-of has no single response to carry, so a denial can only be generic.
       if (!(await gateForUser.any(abilities, model))) {
         throw new AuthorizationException(options.message ?? 'This action is unauthorized.')
@@ -41,7 +50,7 @@ export function authorizeMiddleware(
     } else {
       // Single ability: keep the policy's own message and status, so the same
       // denial reads the same here as through `Controller.authorize()`.
-      const response = await gateForUser.checkResponse(ability, user, model)
+      const response = await gateForUser.checkResponse(abilities[0]!, user, model)
       if (!response.allowed) {
         throw denialToException(options.message ? { ...response, message: options.message } : response)
       }
@@ -49,22 +58,37 @@ export function authorizeMiddleware(
 
     await next()
   }, {
-    // Mirrors the runtime branch above: an array is an any-of check, a
-    // single ability is the one that has to hold.
-    authorization: Array.isArray(ability)
-      ? { abilities: [...ability], mode: 'any' }
-      : { abilities: [ability], mode: 'all' },
+    // Any-of over exactly one ability *is* that ability, so it normalizes to
+    // 'all' — otherwise combining it with another all-of check would report
+    // 'mixed' for a chain whose ability is perfectly derivable.
+    authorization: { abilities, mode: abilities.length === 1 ? 'all' : 'any' },
   })
 }
 
 /**
  * Middleware to authorize all given abilities.
+ *
+ * The array is snapshotted at creation, so mutating it afterwards changes
+ * neither what the middleware checks nor what it reports.
+ *
+ * @throws if no ability is given. `Gate.all([])` is vacuously true, so an
+ * empty list would mount a route that advertises authorization and enforces
+ * none — the fail-open shape RFC 0016's "authn is not authz" rule exists to
+ * catch. Refusing at creation surfaces it at boot rather than per request.
  */
 export function authorizeAllMiddleware(
-  abilities: string[],
+  input: string[],
   modelResolver?: (ctx: Context) => unknown | Promise<unknown>,
   options: AuthorizeOptions = {}
 ): Middleware {
+  const abilities = [...input]
+
+  if (abilities.length === 0) {
+    throw new Error(
+      'authorizeAllMiddleware() requires at least one ability: an empty list authorizes every request while claiming to authorize.'
+    )
+  }
+
   return stampCapabilities(async (ctx, next) => {
     const gate = getGate()
     const user = await gate.resolveUser(ctx)
@@ -80,7 +104,7 @@ export function authorizeAllMiddleware(
     }
 
     await next()
-  }, { authorization: { abilities: [...abilities], mode: 'all' } })
+  }, { authorization: { abilities, mode: 'all' } })
 }
 
 // HTTP method → policy ability. QUERY (RFC 10008) is safe like GET, so it
@@ -138,9 +162,15 @@ export function authorizeResourceMiddleware(
   modelResolver: (ctx: Context) => unknown | Promise<unknown>,
   options: AuthorizeResourceOptions = {}
 ): Middleware {
+  // Captured once: the stamp's `fromMethodMap` is fixed at creation, so the
+  // handler must not read `options.abilityFor` again per request — a caller
+  // assigning it later would otherwise override the map the stamp still
+  // reports as authoritative.
+  const abilityFor = options.abilityFor
+
   return stampCapabilities(async (ctx, next) => {
     const method = ctx.req.method.toUpperCase()
-    const ability = options.abilityFor?.(method) ?? RESOURCE_ABILITY_BY_METHOD[method]
+    const ability = abilityFor?.(method) ?? RESOURCE_ABILITY_BY_METHOD[method]
 
     if (ability === undefined) {
       throw new AuthorizationException(options.message ?? 'This action is unauthorized.')
@@ -167,7 +197,7 @@ export function authorizeResourceMiddleware(
     authorization: {
       abilities: [],
       mode: 'all',
-      resource: { fromMethodMap: options.abilityFor === undefined },
+      resource: { fromMethodMap: abilityFor === undefined },
     },
   })
 }

--- a/packages/server/src/http/middleware/capabilities.ts
+++ b/packages/server/src/http/middleware/capabilities.ts
@@ -17,6 +17,37 @@ export const CAPABILITIES = Symbol.for('guren.capabilities')
 
 export interface MiddlewareCapabilities {
   authentication?: { mode: 'required' | 'guest-only' }
+  /**
+   * Authorization enforced by the chain (RFC 0016 §4): what makes
+   * route → ability derivable without reading controller bodies.
+   *
+   * - `abilities` — the ability names checked, in the order the chain
+   *   checks them. Empty when every check derives its ability at request
+   *   time (see `resource`).
+   * - `mode` — how they combine. `'all'` every listed ability must pass,
+   *   `'any'` at least one must. `'mixed'` means the chain carries more
+   *   than one check and the conjunction of them is not expressible as
+   *   either: authorization is present, but the ability is *not* cleanly
+   *   derivable, and a consumer must treat it as undetermined rather than
+   *   picking a name out of `abilities`. Note `mode` alone does not say
+   *   whether one ability is derivable: `authorizeMiddleware('update')`
+   *   reports `'all'` and `authorizeMiddleware(['update'])` reports
+   *   `'any'`, and both are equally derivable — key on
+   *   `abilities.length === 1`, not on the mode.
+   * - `resource` — present when a check resolves its ability from the
+   *   request method (`authorizeResourceMiddleware`). `fromMethodMap: true`
+   *   means the built-in verb map decides, so a consumer holding the
+   *   route's method resolves the ability through
+   *   `resourceAbilityForMethod()` in `../../authorization/middleware`.
+   *   `false` means an `abilityFor` callback overrides that map and the
+   *   real ability is unknowable statically — fail closed, do not fall
+   *   back to the verb map.
+   */
+  authorization?: {
+    abilities: string[]
+    mode: 'all' | 'any' | 'mixed'
+    resource?: { fromMethodMap: boolean }
+  }
 }
 
 export function stampCapabilities(

--- a/packages/server/src/http/middleware/capabilities.ts
+++ b/packages/server/src/http/middleware/capabilities.ts
@@ -23,17 +23,17 @@ export interface MiddlewareCapabilities {
    *
    * - `abilities` — the ability names checked, in the order the chain
    *   checks them. Empty when every check derives its ability at request
-   *   time (see `resource`).
+   *   time (see `resource`), and also for the degenerate
+   *   `authorizeMiddleware([])`, which denies every request.
    * - `mode` — how they combine. `'all'` every listed ability must pass,
-   *   `'any'` at least one must. `'mixed'` means the chain carries more
-   *   than one check and the conjunction of them is not expressible as
-   *   either: authorization is present, but the ability is *not* cleanly
-   *   derivable, and a consumer must treat it as undetermined rather than
-   *   picking a name out of `abilities`. Note `mode` alone does not say
-   *   whether one ability is derivable: `authorizeMiddleware('update')`
-   *   reports `'all'` and `authorizeMiddleware(['update'])` reports
-   *   `'any'`, and both are equally derivable — key on
-   *   `abilities.length === 1`, not on the mode.
+   *   `'any'` at least one must (so `'any'` only ever appears with two or
+   *   more — an any-of over one ability normalizes to `'all'`). `'mixed'`
+   *   means the chain carries more than one check and the conjunction of
+   *   them is not expressible as either: authorization is present, but the
+   *   ability is *not* cleanly derivable, and a consumer must treat it as
+   *   undetermined rather than picking a name out of `abilities`. A single
+   *   derivable ability is `abilities.length === 1` with `mode: 'all'` and
+   *   no `resource`.
    * - `resource` — present when a check resolves its ability from the
    *   request method (`authorizeResourceMiddleware`). `fromMethodMap: true`
    *   means the built-in verb map decides, so a consumer holding the

--- a/packages/server/src/http/middleware/capabilities.ts
+++ b/packages/server/src/http/middleware/capabilities.ts
@@ -16,6 +16,10 @@ import type { MiddlewareHandler } from 'hono'
 export const CAPABILITIES = Symbol.for('guren.capabilities')
 
 export interface MiddlewareCapabilities {
+  /**
+   * Authentication enforced by the chain. `'required'` beats `'guest-only'`
+   * when a chain somehow carries both.
+   */
   authentication?: { mode: 'required' | 'guest-only' }
   /**
    * Authorization enforced by the chain (RFC 0016 §4): what makes
@@ -26,14 +30,17 @@ export interface MiddlewareCapabilities {
    *   time (see `resource`), and also for the degenerate
    *   `authorizeMiddleware([])`, which denies every request.
    * - `mode` — how they combine. `'all'` every listed ability must pass,
-   *   `'any'` at least one must (so `'any'` only ever appears with two or
-   *   more — an any-of over one ability normalizes to `'all'`). `'mixed'`
-   *   means the chain carries more than one check and the conjunction of
-   *   them is not expressible as either: authorization is present, but the
-   *   ability is *not* cleanly derivable, and a consumer must treat it as
-   *   undetermined rather than picking a name out of `abilities`. A single
-   *   derivable ability is `abilities.length === 1` with `mode: 'all'` and
-   *   no `resource`.
+   *   `'any'` at least one must. A list of exactly one normalizes to
+   *   `'all'`, because any-of one ability *is* that ability — and the
+   *   middleware treats it that way at runtime too, down to the denial
+   *   message. So `'any'` means either two or more alternatives, or the
+   *   degenerate empty list that denies every request. `'mixed'` means the
+   *   chain carries more than one check and the conjunction of them is not
+   *   expressible as either: authorization is present, but the ability is
+   *   *not* cleanly derivable, and a consumer must treat it as undetermined
+   *   rather than picking a name out of `abilities`. A single derivable
+   *   ability is `abilities.length === 1` with `mode: 'all'` and no
+   *   `resource`.
    * - `resource` — present when a check resolves its ability from the
    *   request method (`authorizeResourceMiddleware`). `fromMethodMap: true`
    *   means the built-in verb map decides, so a consumer holding the
@@ -47,6 +54,57 @@ export interface MiddlewareCapabilities {
     abilities: string[]
     mode: 'all' | 'any' | 'mixed'
     resource?: { fromMethodMap: boolean }
+  }
+}
+
+/**
+ * Fold one middleware's stamp into an accumulating aggregate, applying the
+ * rules the type above states: `'required'` beats `'guest-only'`; abilities
+ * union; two checks are a conjunction, so all-of + all-of stays `'all'` and
+ * anything else becomes `'mixed'`; `fromMethodMap` ANDs, since one
+ * non-authoritative check makes the verb map unusable for the whole chain.
+ *
+ * Mutates `into` and never `stamp` — nested objects and arrays are copied
+ * the first time they are taken, so a later merge cannot write back through
+ * the aggregate into a handler's stamp.
+ *
+ * Every call counts as an independent check. Folding the *same* stamp twice
+ * would read as two of them and degrade an `'any'` to `'mixed'`, so
+ * de-duplicating handlers that appear more than once in a chain is the
+ * caller's job.
+ */
+export function mergeCapabilities(
+  into: MiddlewareCapabilities,
+  stamp: MiddlewareCapabilities,
+): void {
+  const auth = stamp.authentication
+  if (auth && (!into.authentication || auth.mode === 'required')) {
+    into.authentication = { ...auth }
+  }
+
+  const authz = stamp.authorization
+  if (!authz) return
+
+  const current = into.authorization
+  if (!current) {
+    into.authorization = {
+      abilities: [...authz.abilities],
+      mode: authz.mode,
+      ...(authz.resource ? { resource: { ...authz.resource } } : {}),
+    }
+    return
+  }
+
+  for (const ability of authz.abilities) {
+    if (!current.abilities.includes(ability)) current.abilities.push(ability)
+  }
+
+  current.mode = current.mode === 'all' && authz.mode === 'all' ? 'all' : 'mixed'
+
+  if (authz.resource) {
+    current.resource = {
+      fromMethodMap: (current.resource?.fromMethodMap ?? true) && authz.resource.fromMethodMap,
+    }
   }
 }
 

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -5,7 +5,7 @@ import { mountRoute } from './mount-route'
 import { flattenRequestQueries, formatValidationErrors, parseRequestPayload, type ValidationErrorLike } from '../http/request'
 import { ValidationException } from '../errors/exceptions/ValidationException'
 import type { ValidationSchema } from '../http/middleware/validation'
-import { capabilitiesOf, type MiddlewareCapabilities } from '../http/middleware/capabilities'
+import { capabilitiesOf, mergeCapabilities, type MiddlewareCapabilities } from '../http/middleware/capabilities'
 import { trimSlashes } from '../support/trim-slashes'
 
 /**
@@ -777,6 +777,9 @@ export class Router<M extends string = never> {
    * thrown: `definitions()` must stay side-effect-free for introspection of
    * routers that never mount (audit, codegen), and an unresolvable alias
    * simply contributes no capabilities.
+   *
+   * This walks the chain; the rules for combining what it finds live with the
+   * capability type, in `mergeCapabilities`.
    */
   private aggregateCapabilities(
     names: string[],
@@ -787,50 +790,17 @@ export class Router<M extends string = never> {
     const aggregated: MiddlewareCapabilities = {}
     const visited = seen ?? new Set<string>()
     // The same handler can legitimately appear twice in one chain — passed
-    // inline as well as reached through an alias or a group. Absorbing its
-    // stamp twice would read as two independent checks and degrade an 'any'
-    // to 'mixed', so each stamp object contributes once. Threaded through
-    // the group recursion alongside `visited`, or a stamp reached inside a
-    // group would not be recognized as the one seen inline.
-    const absorbed = seenStamps ?? new Set<MiddlewareCapabilities>()
+    // inline as well as reached through an alias or a group. `mergeCapabilities`
+    // counts every call as an independent check, which would degrade an 'any'
+    // to 'mixed', so each stamp is merged once. Threaded through the group
+    // recursion alongside `visited`, or a stamp reached inside a group would
+    // not be recognized as the one seen inline.
+    const merged = seenStamps ?? new Set<MiddlewareCapabilities>()
 
-    const absorb = (capabilities: MiddlewareCapabilities | undefined): void => {
-      if (!capabilities || absorbed.has(capabilities)) return
-      absorbed.add(capabilities)
-
-      const auth = capabilities.authentication
-      if (auth) {
-        // 'required' wins: a route that both requires auth and (oddly)
-        // requires guest is reported as requiring auth.
-        if (!aggregated.authentication || auth.mode === 'required') {
-          aggregated.authentication = auth
-        }
-      }
-
-      const authz = capabilities.authorization
-      if (authz) {
-        const current = aggregated.authorization
-        if (!current) {
-          aggregated.authorization = {
-            abilities: [...authz.abilities],
-            mode: authz.mode,
-            ...(authz.resource ? { resource: { ...authz.resource } } : {}),
-          }
-        } else {
-          // Two checks on one chain are a conjunction. Only all-of + all-of
-          // stays expressible; anything else is 'mixed' — present, but with
-          // no single ability a consumer may name.
-          for (const ability of authz.abilities) {
-            if (!current.abilities.includes(ability)) current.abilities.push(ability)
-          }
-          current.mode = current.mode === 'all' && authz.mode === 'all' ? 'all' : 'mixed'
-          if (authz.resource) {
-            current.resource = {
-              fromMethodMap: (current.resource?.fromMethodMap ?? true) && authz.resource.fromMethodMap,
-            }
-          }
-        }
-      }
+    const absorbStamp = (stamp: MiddlewareCapabilities | undefined): void => {
+      if (!stamp || merged.has(stamp)) return
+      merged.add(stamp)
+      mergeCapabilities(aggregated, stamp)
     }
 
     for (const name of names) {
@@ -839,14 +809,16 @@ export class Router<M extends string = never> {
 
       const groupNames = this.middlewareGroups.get(name)
       if (groupNames) {
-        absorb(this.aggregateCapabilities(groupNames, [], visited, absorbed))
+        // The group's own aggregate is freshly built from stamps already
+        // recorded in `merged`, so it needs no de-duplication of its own.
+        mergeCapabilities(aggregated, this.aggregateCapabilities(groupNames, [], visited, merged))
         continue
       }
 
-      absorb(capabilitiesOf(this.middlewareAliases.get(name)))
+      absorbStamp(capabilitiesOf(this.middlewareAliases.get(name)))
     }
 
-    for (const handler of inline) absorb(capabilitiesOf(handler))
+    for (const handler of inline) absorbStamp(capabilitiesOf(handler))
 
     return aggregated
   }

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -782,14 +782,17 @@ export class Router<M extends string = never> {
     names: string[],
     inline: MiddlewareHandler[],
     seen?: Set<string>,
+    seenStamps?: Set<MiddlewareCapabilities>,
   ): MiddlewareCapabilities {
     const aggregated: MiddlewareCapabilities = {}
     const visited = seen ?? new Set<string>()
-    // The same handler can legitimately appear twice in one chain (a scoped
-    // middleware also passed inline). Absorbing its stamp twice would read
-    // as two independent checks and degrade an 'any' to 'mixed', so each
-    // stamp object contributes once.
-    const absorbed = new Set<MiddlewareCapabilities>()
+    // The same handler can legitimately appear twice in one chain — passed
+    // inline as well as reached through an alias or a group. Absorbing its
+    // stamp twice would read as two independent checks and degrade an 'any'
+    // to 'mixed', so each stamp object contributes once. Threaded through
+    // the group recursion alongside `visited`, or a stamp reached inside a
+    // group would not be recognized as the one seen inline.
+    const absorbed = seenStamps ?? new Set<MiddlewareCapabilities>()
 
     const absorb = (capabilities: MiddlewareCapabilities | undefined): void => {
       if (!capabilities || absorbed.has(capabilities)) return
@@ -836,7 +839,7 @@ export class Router<M extends string = never> {
 
       const groupNames = this.middlewareGroups.get(name)
       if (groupNames) {
-        absorb(this.aggregateCapabilities(groupNames, [], visited))
+        absorb(this.aggregateCapabilities(groupNames, [], visited, absorbed))
         continue
       }
 

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -785,14 +785,48 @@ export class Router<M extends string = never> {
   ): MiddlewareCapabilities {
     const aggregated: MiddlewareCapabilities = {}
     const visited = seen ?? new Set<string>()
+    // The same handler can legitimately appear twice in one chain (a scoped
+    // middleware also passed inline). Absorbing its stamp twice would read
+    // as two independent checks and degrade an 'any' to 'mixed', so each
+    // stamp object contributes once.
+    const absorbed = new Set<MiddlewareCapabilities>()
 
     const absorb = (capabilities: MiddlewareCapabilities | undefined): void => {
-      const auth = capabilities?.authentication
-      if (!auth) return
-      // 'required' wins: a route that both requires auth and (oddly)
-      // requires guest is reported as requiring auth.
-      if (!aggregated.authentication || auth.mode === 'required') {
-        aggregated.authentication = auth
+      if (!capabilities || absorbed.has(capabilities)) return
+      absorbed.add(capabilities)
+
+      const auth = capabilities.authentication
+      if (auth) {
+        // 'required' wins: a route that both requires auth and (oddly)
+        // requires guest is reported as requiring auth.
+        if (!aggregated.authentication || auth.mode === 'required') {
+          aggregated.authentication = auth
+        }
+      }
+
+      const authz = capabilities.authorization
+      if (authz) {
+        const current = aggregated.authorization
+        if (!current) {
+          aggregated.authorization = {
+            abilities: [...authz.abilities],
+            mode: authz.mode,
+            ...(authz.resource ? { resource: { ...authz.resource } } : {}),
+          }
+        } else {
+          // Two checks on one chain are a conjunction. Only all-of + all-of
+          // stays expressible; anything else is 'mixed' — present, but with
+          // no single ability a consumer may name.
+          for (const ability of authz.abilities) {
+            if (!current.abilities.includes(ability)) current.abilities.push(ability)
+          }
+          current.mode = current.mode === 'all' && authz.mode === 'all' ? 'all' : 'mixed'
+          if (authz.resource) {
+            current.resource = {
+              fromMethodMap: (current.resource?.fromMethodMap ?? true) && authz.resource.fromMethodMap,
+            }
+          }
+        }
       }
     }
 

--- a/packages/server/tests/authorization/authorization.test.ts
+++ b/packages/server/tests/authorization/authorization.test.ts
@@ -17,6 +17,7 @@ import {
 import type { AuthorizeResourceOptions } from '../../src/authorization'
 import { AuthorizationException } from '../../src/errors'
 import type { Context } from '../../src/http/Application'
+import type { Middleware } from '../../src/http/middleware'
 
 // Test models
 class Post {
@@ -707,6 +708,16 @@ describe('Authorization Integration', () => {
 // authorizeResourceMiddleware Tests
 // ===================
 
+/** Drive one authorization middleware against a fake request context. */
+const drive = async (middleware: Middleware, method = 'GET') => {
+  const ctx = { req: { method }, get: () => ({ id: 1 }) } as unknown as Context
+  let nextCalled = false
+  await middleware(ctx, async () => {
+    nextCalled = true
+  })
+  return nextCalled
+}
+
 describe('authorizeResourceMiddleware', () => {
   let checkedAbilities: string[]
 
@@ -722,18 +733,8 @@ describe('authorizeResourceMiddleware', () => {
     setGate(gate)
   })
 
-  const run = async (method: string, options?: AuthorizeResourceOptions) => {
-    const middleware = authorizeResourceMiddleware(() => ({ id: 1 }), options)
-    const ctx = {
-      req: { method },
-      get: () => ({ id: 1 }),
-    } as unknown as Context
-    let nextCalled = false
-    await middleware(ctx, async () => {
-      nextCalled = true
-    })
-    return nextCalled
-  }
+  const run = (method: string, options?: AuthorizeResourceOptions) =>
+    drive(authorizeResourceMiddleware(() => ({ id: 1 }), options), method)
 
   test('maps known methods to resource abilities', async () => {
     const expected: Array<[string, string]> = [
@@ -790,13 +791,7 @@ describe('authorizeResourceMiddleware', () => {
     const middleware = authorizeResourceMiddleware(() => ({ id: 1 }), options)
     options.abilityFor = () => 'purge'
 
-    const ctx = { req: { method: 'DELETE' }, get: () => ({ id: 1 }) } as unknown as Context
-    let nextCalled = false
-    await middleware(ctx, async () => {
-      nextCalled = true
-    })
-
-    expect(nextCalled).toBe(true)
+    expect(await drive(middleware, 'DELETE')).toBe(true)
     expect(checkedAbilities).toEqual(['delete'])
   })
 })
@@ -816,15 +811,6 @@ describe('authorize middleware ability snapshots', () => {
     setGate(gate)
   })
 
-  const drive = async (middleware: ReturnType<typeof authorizeMiddleware>) => {
-    const ctx = { req: { method: 'POST' }, get: () => ({ id: 1 }) } as unknown as Context
-    let nextCalled = false
-    await middleware(ctx, async () => {
-      nextCalled = true
-    })
-    return nextCalled
-  }
-
   test('authorizeMiddleware checks the array as it was at creation', async () => {
     const abilities = ['admin', 'moderator']
     const middleware = authorizeMiddleware(abilities)
@@ -843,6 +829,27 @@ describe('authorize middleware ability snapshots', () => {
     expect(await drive(middleware)).toBe(true)
     // Not [] — Gate.all([]) is vacuously true and would authorize anyone.
     expect(checkedAbilities).toEqual(['admin', 'billing'])
+  })
+
+  test('a one-element array keeps the policy denial, like the bare ability', async () => {
+    const gate = new Gate()
+    gate.define('publish', () => Response.denyWithStatus(404, 'No such post.'))
+    setGate(gate)
+
+    // Any-of over one ability is that ability, so it must not fall back to
+    // the generic any-of denial — the stamp reports it as all-of-one.
+    await expect(drive(authorizeMiddleware(['publish']))).rejects.toThrow('No such post.')
+    await expect(drive(authorizeMiddleware('publish'))).rejects.toThrow('No such post.')
+
+    // Two alternatives have no single response to carry, so that denial is
+    // generic — the boundary the normalization stops at.
+    await expect(drive(authorizeMiddleware(['publish', 'admin']))).rejects.toThrow(
+      'This action is unauthorized.'
+    )
+  })
+
+  test('an empty ability list still denies every request', async () => {
+    await expect(drive(authorizeMiddleware([]))).rejects.toThrow(AuthorizationException)
   })
 
   test('authorizeAllMiddleware refuses an empty ability list at creation', () => {

--- a/packages/server/tests/authorization/authorization.test.ts
+++ b/packages/server/tests/authorization/authorization.test.ts
@@ -10,6 +10,8 @@ import {
   authorize,
   Policy,
   definePolicy,
+  authorizeMiddleware,
+  authorizeAllMiddleware,
   authorizeResourceMiddleware,
 } from '../../src/authorization'
 import type { AuthorizeResourceOptions } from '../../src/authorization'
@@ -778,5 +780,72 @@ describe('authorizeResourceMiddleware', () => {
     const abilityFor = (method: string) => (method === 'POST' ? 'update' : undefined)
     expect(await run('POST', { abilityFor })).toBe(true)
     expect(checkedAbilities).toEqual(['update'])
+  })
+
+  test('captures abilityFor at creation, so a later assignment cannot apply', async () => {
+    // The capability stamp fixes `fromMethodMap` at creation. If the handler
+    // re-read options per request, an assignment made afterwards would change
+    // the ability checked while the stamp still named the verb map.
+    const options: AuthorizeResourceOptions = {}
+    const middleware = authorizeResourceMiddleware(() => ({ id: 1 }), options)
+    options.abilityFor = () => 'purge'
+
+    const ctx = { req: { method: 'DELETE' }, get: () => ({ id: 1 }) } as unknown as Context
+    let nextCalled = false
+    await middleware(ctx, async () => {
+      nextCalled = true
+    })
+
+    expect(nextCalled).toBe(true)
+    expect(checkedAbilities).toEqual(['delete'])
+  })
+})
+
+describe('authorize middleware ability snapshots', () => {
+  let checkedAbilities: string[]
+
+  beforeEach(() => {
+    checkedAbilities = []
+    const gate = new Gate()
+    for (const ability of ['admin', 'moderator', 'billing']) {
+      gate.define(ability, () => {
+        checkedAbilities.push(ability)
+        return true
+      })
+    }
+    setGate(gate)
+  })
+
+  const drive = async (middleware: ReturnType<typeof authorizeMiddleware>) => {
+    const ctx = { req: { method: 'POST' }, get: () => ({ id: 1 }) } as unknown as Context
+    let nextCalled = false
+    await middleware(ctx, async () => {
+      nextCalled = true
+    })
+    return nextCalled
+  }
+
+  test('authorizeMiddleware checks the array as it was at creation', async () => {
+    const abilities = ['admin', 'moderator']
+    const middleware = authorizeMiddleware(abilities)
+    abilities.length = 0
+
+    expect(await drive(middleware)).toBe(true)
+    // Not [] — an emptied array would make Gate.any([]) deny everything.
+    expect(checkedAbilities).toEqual(['admin'])
+  })
+
+  test('authorizeAllMiddleware checks the array as it was at creation', async () => {
+    const abilities = ['admin', 'billing']
+    const middleware = authorizeAllMiddleware(abilities)
+    abilities.length = 0
+
+    expect(await drive(middleware)).toBe(true)
+    // Not [] — Gate.all([]) is vacuously true and would authorize anyone.
+    expect(checkedAbilities).toEqual(['admin', 'billing'])
+  })
+
+  test('authorizeAllMiddleware refuses an empty ability list at creation', () => {
+    expect(() => authorizeAllMiddleware([])).toThrow('at least one ability')
   })
 })

--- a/packages/server/tests/mvc/router.test.ts
+++ b/packages/server/tests/mvc/router.test.ts
@@ -997,6 +997,77 @@ describe('Router authorization capabilities (RFC 0016)', () => {
     })
   })
 
+  it('absorbs a handler once across the group boundary too', async () => {
+    const { authorizeMiddleware } = await import('../../src/authorization/middleware')
+
+    // The same handler reached through a group *and* passed inline is still
+    // one check, so the dedup has to survive the recursive aggregation.
+    const anyOf = authorizeMiddleware(['admin', 'moderator'])
+    const router = new Router<'can-admin' | 'staff'>()
+    router.aliasMiddleware('can-admin', anyOf)
+    router.groupMiddleware('staff', ['can-admin'])
+    router.post('/both', () => 'ok', anyOf).middleware('staff')
+
+    expect(router.definitions()[0]!.capabilities?.authorization).toEqual({
+      abilities: ['admin', 'moderator'],
+      mode: 'any',
+    })
+  })
+
+  it('normalizes a single-element any-of so merging with all-of stays all', async () => {
+    const { authorizeMiddleware, authorizeAllMiddleware } = await import('../../src/authorization/middleware')
+
+    const router = new Router()
+    router.get('/one', () => 'ok', authorizeMiddleware(['read']))
+    router.post('/merged', () => 'ok', authorizeMiddleware(['read']), authorizeAllMiddleware(['write']))
+
+    const defs = router.definitions()
+    expect(defs[0]!.capabilities?.authorization).toEqual({ abilities: ['read'], mode: 'all' })
+    expect(defs[1]!.capabilities?.authorization).toEqual({
+      abilities: ['read', 'write'],
+      mode: 'all',
+    })
+  })
+
+  it('snapshots the ability array so a later mutation cannot make the stamp lie', async () => {
+    const { authorizeMiddleware, authorizeAllMiddleware } = await import('../../src/authorization/middleware')
+    const { capabilitiesOf } = await import('../../src/http/middleware/capabilities')
+
+    const anyOf = ['admin', 'moderator']
+    const allOf = ['admin']
+    const anyHandler = authorizeMiddleware(anyOf)
+    const allHandler = authorizeAllMiddleware(allOf)
+
+    // Emptying `allOf` would make Gate.all([]) pass unconditionally while the
+    // stamp still claimed 'admin' — the stamp must describe the snapshot.
+    anyOf.length = 0
+    allOf.length = 0
+
+    expect(capabilitiesOf(anyHandler)?.authorization?.abilities).toEqual(['admin', 'moderator'])
+    expect(capabilitiesOf(allHandler)?.authorization?.abilities).toEqual(['admin'])
+  })
+
+  it('refuses authorizeAllMiddleware with no abilities', async () => {
+    const { authorizeAllMiddleware } = await import('../../src/authorization/middleware')
+
+    // Gate.all([]) is vacuously true, so this would advertise authorization
+    // and enforce none.
+    expect(() => authorizeAllMiddleware([])).toThrow('at least one ability')
+  })
+
+  it('keeps the stamp in step with a late abilityFor assignment', async () => {
+    const { authorizeResourceMiddleware } = await import('../../src/authorization/middleware')
+    const { capabilitiesOf } = await import('../../src/http/middleware/capabilities')
+
+    const options: { abilityFor?: (method: string) => string | undefined } = {}
+    const handler = authorizeResourceMiddleware(resolver, options)
+    options.abilityFor = () => 'archive'
+
+    // The handler captured `abilityFor` at creation, so the assignment above
+    // changes neither the check nor the stamp that describes it.
+    expect(capabilitiesOf(handler)?.authorization?.resource).toEqual({ fromMethodMap: true })
+  })
+
   it('does not leak the aggregate back into the stamp', async () => {
     const { authorizeMiddleware } = await import('../../src/authorization/middleware')
     const { capabilitiesOf } = await import('../../src/http/middleware/capabilities')

--- a/packages/server/tests/mvc/router.test.ts
+++ b/packages/server/tests/mvc/router.test.ts
@@ -872,6 +872,148 @@ describe('Router capability aggregation', () => {
   })
 })
 
+describe('Router authorization capabilities (RFC 0016)', () => {
+  const resolver = () => ({ id: 1 })
+
+  it('reports a single ability from authorizeMiddleware', async () => {
+    const { authorizeMiddleware } = await import('../../src/authorization/middleware')
+
+    const router = new Router()
+    router.put('/posts/:id', () => 'ok', authorizeMiddleware('update', resolver))
+
+    expect(router.definitions()[0]!.capabilities).toEqual({
+      authorization: { abilities: ['update'], mode: 'all' },
+    })
+  })
+
+  it('reports an ability list as any-of, and authorizeAll as all-of', async () => {
+    const { authorizeMiddleware, authorizeAllMiddleware } = await import('../../src/authorization/middleware')
+
+    const router = new Router()
+    router.get('/dashboard', () => 'ok', authorizeMiddleware(['admin', 'moderator']))
+    router.post('/reports', () => 'ok', authorizeAllMiddleware(['admin', 'billing']))
+
+    const defs = router.definitions()
+    expect(defs[0]!.capabilities?.authorization).toEqual({
+      abilities: ['admin', 'moderator'],
+      mode: 'any',
+    })
+    expect(defs[1]!.capabilities?.authorization).toEqual({
+      abilities: ['admin', 'billing'],
+      mode: 'all',
+    })
+  })
+
+  it('marks the resource variant as method-derived and resolves through the one verb map', async () => {
+    const { authorizeResourceMiddleware, resourceAbilityForMethod } = await import(
+      '../../src/authorization/middleware'
+    )
+
+    const router = new Router()
+    router.put('/posts/:id', () => 'ok', authorizeResourceMiddleware(resolver))
+
+    const [def] = router.definitions()
+    expect(def!.capabilities?.authorization).toEqual({
+      abilities: [],
+      mode: 'all',
+      resource: { fromMethodMap: true },
+    })
+
+    // A consumer holding the route's method derives the ability from the
+    // exported map rather than restating it.
+    expect(resourceAbilityForMethod(def!.method)).toBe('update')
+    expect(resourceAbilityForMethod('get')).toBe('view')
+    expect(resourceAbilityForMethod('PURGE')).toBeUndefined()
+  })
+
+  it('clears fromMethodMap when abilityFor overrides the verb map', async () => {
+    const { authorizeResourceMiddleware } = await import('../../src/authorization/middleware')
+
+    const router = new Router()
+    router.delete(
+      '/posts/:id',
+      () => 'ok',
+      // Legal and consulted *before* the map, so the mapped 'delete' would
+      // be a lie about what this route checks.
+      authorizeResourceMiddleware(resolver, {
+        abilityFor: (method) => (method === 'DELETE' ? 'archive' : undefined),
+      }),
+    )
+
+    expect(router.definitions()[0]!.capabilities?.authorization?.resource).toEqual({
+      fromMethodMap: false,
+    })
+  })
+
+  it('carries authorization stamps through aliases and groups alongside authentication', async () => {
+    const { authorizeMiddleware } = await import('../../src/authorization/middleware')
+    const { requireAuthenticated } = await import('../../src/http/middleware/auth')
+
+    const router = new Router<'auth' | 'can-update' | 'editor'>()
+    router.aliasMiddleware('auth', requireAuthenticated())
+    router.aliasMiddleware('can-update', authorizeMiddleware('update', resolver))
+    router.groupMiddleware('editor', ['auth', 'can-update'])
+    router.patch('/posts/:id', () => 'ok').middleware('editor')
+
+    expect(router.definitions()[0]!.capabilities).toEqual({
+      authentication: { mode: 'required' },
+      authorization: { abilities: ['update'], mode: 'all' },
+    })
+  })
+
+  it('reports two combined checks as mixed when they are not both all-of', async () => {
+    const { authorizeMiddleware, authorizeAllMiddleware } = await import('../../src/authorization/middleware')
+
+    const router = new Router()
+    router.post(
+      '/mixed',
+      () => 'ok',
+      authorizeMiddleware(['admin', 'moderator']),
+      authorizeAllMiddleware(['billing']),
+    )
+    router.post('/all', () => 'ok', authorizeMiddleware('update'), authorizeAllMiddleware(['billing']))
+
+    const defs = router.definitions()
+    expect(defs[0]!.capabilities?.authorization).toEqual({
+      abilities: ['admin', 'moderator', 'billing'],
+      mode: 'mixed',
+    })
+    expect(defs[1]!.capabilities?.authorization).toEqual({
+      abilities: ['update', 'billing'],
+      mode: 'all',
+    })
+  })
+
+  it('absorbs a repeated handler once instead of degrading its mode', async () => {
+    const { authorizeMiddleware } = await import('../../src/authorization/middleware')
+
+    const anyOf = authorizeMiddleware(['admin', 'moderator'])
+    const router = new Router()
+    router.post('/twice', () => 'ok', anyOf, anyOf)
+
+    expect(router.definitions()[0]!.capabilities?.authorization).toEqual({
+      abilities: ['admin', 'moderator'],
+      mode: 'any',
+    })
+  })
+
+  it('does not leak the aggregate back into the stamp', async () => {
+    const { authorizeMiddleware } = await import('../../src/authorization/middleware')
+    const { capabilitiesOf } = await import('../../src/http/middleware/capabilities')
+
+    const handler = authorizeMiddleware('update', resolver)
+    const router = new Router()
+    router.post('/a', () => 'ok', handler, authorizeMiddleware('publish'))
+
+    expect(router.definitions()[0]!.capabilities?.authorization?.abilities).toEqual([
+      'update',
+      'publish',
+    ])
+    // The handler's own stamp is untouched by aggregation.
+    expect(capabilitiesOf(handler)?.authorization?.abilities).toEqual(['update'])
+  })
+})
+
 describe('Router QUERY method (RFC 10008)', () => {
   it('query() registers a QUERY route with contract metadata', () => {
     const body = z.object({ q: z.string().min(1) })

--- a/packages/server/tests/mvc/router.test.ts
+++ b/packages/server/tests/mvc/router.test.ts
@@ -4,6 +4,18 @@ import { z } from 'zod'
 import { Router } from '../../src/mvc/Router'
 import { Controller } from '../../src/mvc/Controller'
 import { Resource } from '../../src/http/resources/Resource'
+import {
+  authorizeAllMiddleware,
+  authorizeMiddleware,
+  authorizeResourceMiddleware,
+  resourceAbilityForMethod,
+} from '../../src/authorization/middleware'
+import { requireAuthenticated } from '../../src/http/middleware/auth'
+import {
+  capabilitiesOf,
+  mergeCapabilities,
+  type MiddlewareCapabilities,
+} from '../../src/http/middleware/capabilities'
 
 class StubController extends Controller {
   async index() { return new Response('index') }
@@ -875,9 +887,7 @@ describe('Router capability aggregation', () => {
 describe('Router authorization capabilities (RFC 0016)', () => {
   const resolver = () => ({ id: 1 })
 
-  it('reports a single ability from authorizeMiddleware', async () => {
-    const { authorizeMiddleware } = await import('../../src/authorization/middleware')
-
+  it('reports a single ability from authorizeMiddleware', () => {
     const router = new Router()
     router.put('/posts/:id', () => 'ok', authorizeMiddleware('update', resolver))
 
@@ -886,9 +896,7 @@ describe('Router authorization capabilities (RFC 0016)', () => {
     })
   })
 
-  it('reports an ability list as any-of, and authorizeAll as all-of', async () => {
-    const { authorizeMiddleware, authorizeAllMiddleware } = await import('../../src/authorization/middleware')
-
+  it('reports an ability list as any-of, and authorizeAll as all-of', () => {
     const router = new Router()
     router.get('/dashboard', () => 'ok', authorizeMiddleware(['admin', 'moderator']))
     router.post('/reports', () => 'ok', authorizeAllMiddleware(['admin', 'billing']))
@@ -904,11 +912,20 @@ describe('Router authorization capabilities (RFC 0016)', () => {
     })
   })
 
-  it('marks the resource variant as method-derived and resolves through the one verb map', async () => {
-    const { authorizeResourceMiddleware, resourceAbilityForMethod } = await import(
-      '../../src/authorization/middleware'
-    )
+  it('normalizes a single-element any-of so merging with all-of stays all', () => {
+    const router = new Router()
+    router.get('/one', () => 'ok', authorizeMiddleware(['read']))
+    router.post('/merged', () => 'ok', authorizeMiddleware(['read']), authorizeAllMiddleware(['write']))
 
+    const defs = router.definitions()
+    expect(defs[0]!.capabilities?.authorization).toEqual({ abilities: ['read'], mode: 'all' })
+    expect(defs[1]!.capabilities?.authorization).toEqual({
+      abilities: ['read', 'write'],
+      mode: 'all',
+    })
+  })
+
+  it('marks the resource variant as method-derived and resolves through the one verb map', () => {
     const router = new Router()
     router.put('/posts/:id', () => 'ok', authorizeResourceMiddleware(resolver))
 
@@ -926,9 +943,7 @@ describe('Router authorization capabilities (RFC 0016)', () => {
     expect(resourceAbilityForMethod('PURGE')).toBeUndefined()
   })
 
-  it('clears fromMethodMap when abilityFor overrides the verb map', async () => {
-    const { authorizeResourceMiddleware } = await import('../../src/authorization/middleware')
-
+  it('clears fromMethodMap when abilityFor overrides the verb map', () => {
     const router = new Router()
     router.delete(
       '/posts/:id',
@@ -945,10 +960,21 @@ describe('Router authorization capabilities (RFC 0016)', () => {
     })
   })
 
-  it('carries authorization stamps through aliases and groups alongside authentication', async () => {
-    const { authorizeMiddleware } = await import('../../src/authorization/middleware')
-    const { requireAuthenticated } = await import('../../src/http/middleware/auth')
+  it('clears fromMethodMap for the whole chain when one resource check overrides', () => {
+    const router = new Router()
+    router.delete(
+      '/posts/:id',
+      () => 'ok',
+      authorizeResourceMiddleware(resolver),
+      authorizeResourceMiddleware(resolver, { abilityFor: () => 'archive' }),
+    )
 
+    expect(router.definitions()[0]!.capabilities?.authorization?.resource).toEqual({
+      fromMethodMap: false,
+    })
+  })
+
+  it('carries authorization stamps through aliases and groups alongside authentication', () => {
     const router = new Router<'auth' | 'can-update' | 'editor'>()
     router.aliasMiddleware('auth', requireAuthenticated())
     router.aliasMiddleware('can-update', authorizeMiddleware('update', resolver))
@@ -961,9 +987,7 @@ describe('Router authorization capabilities (RFC 0016)', () => {
     })
   })
 
-  it('reports two combined checks as mixed when they are not both all-of', async () => {
-    const { authorizeMiddleware, authorizeAllMiddleware } = await import('../../src/authorization/middleware')
-
+  it('reports two combined checks as mixed when they are not both all-of', () => {
     const router = new Router()
     router.post(
       '/mixed',
@@ -984,9 +1008,7 @@ describe('Router authorization capabilities (RFC 0016)', () => {
     })
   })
 
-  it('absorbs a repeated handler once instead of degrading its mode', async () => {
-    const { authorizeMiddleware } = await import('../../src/authorization/middleware')
-
+  it('absorbs a repeated handler once instead of degrading its mode', () => {
     const anyOf = authorizeMiddleware(['admin', 'moderator'])
     const router = new Router()
     router.post('/twice', () => 'ok', anyOf, anyOf)
@@ -997,9 +1019,7 @@ describe('Router authorization capabilities (RFC 0016)', () => {
     })
   })
 
-  it('absorbs a handler once across the group boundary too', async () => {
-    const { authorizeMiddleware } = await import('../../src/authorization/middleware')
-
+  it('absorbs a handler once across the group boundary too', () => {
     // The same handler reached through a group *and* passed inline is still
     // one check, so the dedup has to survive the recursive aggregation.
     const anyOf = authorizeMiddleware(['admin', 'moderator'])
@@ -1014,25 +1034,7 @@ describe('Router authorization capabilities (RFC 0016)', () => {
     })
   })
 
-  it('normalizes a single-element any-of so merging with all-of stays all', async () => {
-    const { authorizeMiddleware, authorizeAllMiddleware } = await import('../../src/authorization/middleware')
-
-    const router = new Router()
-    router.get('/one', () => 'ok', authorizeMiddleware(['read']))
-    router.post('/merged', () => 'ok', authorizeMiddleware(['read']), authorizeAllMiddleware(['write']))
-
-    const defs = router.definitions()
-    expect(defs[0]!.capabilities?.authorization).toEqual({ abilities: ['read'], mode: 'all' })
-    expect(defs[1]!.capabilities?.authorization).toEqual({
-      abilities: ['read', 'write'],
-      mode: 'all',
-    })
-  })
-
-  it('snapshots the ability array so a later mutation cannot make the stamp lie', async () => {
-    const { authorizeMiddleware, authorizeAllMiddleware } = await import('../../src/authorization/middleware')
-    const { capabilitiesOf } = await import('../../src/http/middleware/capabilities')
-
+  it('snapshots the ability array so a later mutation cannot make the stamp lie', () => {
     const anyOf = ['admin', 'moderator']
     const allOf = ['admin']
     const anyHandler = authorizeMiddleware(anyOf)
@@ -1047,18 +1049,7 @@ describe('Router authorization capabilities (RFC 0016)', () => {
     expect(capabilitiesOf(allHandler)?.authorization?.abilities).toEqual(['admin'])
   })
 
-  it('refuses authorizeAllMiddleware with no abilities', async () => {
-    const { authorizeAllMiddleware } = await import('../../src/authorization/middleware')
-
-    // Gate.all([]) is vacuously true, so this would advertise authorization
-    // and enforce none.
-    expect(() => authorizeAllMiddleware([])).toThrow('at least one ability')
-  })
-
-  it('keeps the stamp in step with a late abilityFor assignment', async () => {
-    const { authorizeResourceMiddleware } = await import('../../src/authorization/middleware')
-    const { capabilitiesOf } = await import('../../src/http/middleware/capabilities')
-
+  it('keeps the stamp in step with a late abilityFor assignment', () => {
     const options: { abilityFor?: (method: string) => string | undefined } = {}
     const handler = authorizeResourceMiddleware(resolver, options)
     options.abilityFor = () => 'archive'
@@ -1068,10 +1059,7 @@ describe('Router authorization capabilities (RFC 0016)', () => {
     expect(capabilitiesOf(handler)?.authorization?.resource).toEqual({ fromMethodMap: true })
   })
 
-  it('does not leak the aggregate back into the stamp', async () => {
-    const { authorizeMiddleware } = await import('../../src/authorization/middleware')
-    const { capabilitiesOf } = await import('../../src/http/middleware/capabilities')
-
+  it('does not leak the aggregate back into the stamp', () => {
     const handler = authorizeMiddleware('update', resolver)
     const router = new Router()
     router.post('/a', () => 'ok', handler, authorizeMiddleware('publish'))
@@ -1082,6 +1070,85 @@ describe('Router authorization capabilities (RFC 0016)', () => {
     ])
     // The handler's own stamp is untouched by aggregation.
     expect(capabilitiesOf(handler)?.authorization?.abilities).toEqual(['update'])
+  })
+})
+
+describe('mergeCapabilities', () => {
+  const fold = (...stamps: MiddlewareCapabilities[]): MiddlewareCapabilities => {
+    const into: MiddlewareCapabilities = {}
+    for (const stamp of stamps) mergeCapabilities(into, stamp)
+    return into
+  }
+
+  const authz = (
+    abilities: string[],
+    mode: 'all' | 'any' | 'mixed',
+    resource?: { fromMethodMap: boolean },
+  ): MiddlewareCapabilities => ({
+    authorization: { abilities, mode, ...(resource ? { resource } : {}) },
+  })
+
+  it('lets required beat guest-only in either order', () => {
+    const required: MiddlewareCapabilities = { authentication: { mode: 'required' } }
+    const guest: MiddlewareCapabilities = { authentication: { mode: 'guest-only' } }
+
+    expect(fold(guest, required).authentication).toEqual({ mode: 'required' })
+    expect(fold(required, guest).authentication).toEqual({ mode: 'required' })
+  })
+
+  it('unions abilities without repeating one both checks name', () => {
+    expect(fold(authz(['a', 'b'], 'all'), authz(['b', 'c'], 'all')).authorization).toEqual({
+      abilities: ['a', 'b', 'c'],
+      mode: 'all',
+    })
+  })
+
+  it('keeps all-of only when both sides are all-of', () => {
+    const modeOf = (left: 'all' | 'any', right: 'all' | 'any') =>
+      fold(authz(['x'], left), authz(['y'], right)).authorization?.mode
+
+    expect(modeOf('all', 'all')).toBe('all')
+    expect(modeOf('all', 'any')).toBe('mixed')
+    expect(modeOf('any', 'all')).toBe('mixed')
+    // Two independent any-of groups are still a conjunction of two groups,
+    // which is not itself an any-of.
+    expect(modeOf('any', 'any')).toBe('mixed')
+  })
+
+  it('ANDs fromMethodMap and keeps a resource marker the second stamp lacks', () => {
+    const authoritative = authz([], 'all', { fromMethodMap: true })
+    const overridden = authz([], 'all', { fromMethodMap: false })
+
+    expect(fold(authoritative, authoritative).authorization?.resource).toEqual({ fromMethodMap: true })
+    expect(fold(authoritative, overridden).authorization?.resource).toEqual({ fromMethodMap: false })
+    expect(fold(overridden, authoritative).authorization?.resource).toEqual({ fromMethodMap: false })
+    expect(fold(authoritative, authz(['x'], 'all')).authorization?.resource).toEqual({
+      fromMethodMap: true,
+    })
+  })
+
+  it('copies on first take, so a later merge cannot write into a stamp', () => {
+    const stamp = authz(['read'], 'all', { fromMethodMap: true })
+    const into = fold(stamp, authz(['write'], 'any', { fromMethodMap: false }))
+
+    expect(into.authorization).toEqual({
+      abilities: ['read', 'write'],
+      mode: 'mixed',
+      resource: { fromMethodMap: false },
+    })
+    expect(stamp.authorization).toEqual({
+      abilities: ['read'],
+      mode: 'all',
+      resource: { fromMethodMap: true },
+    })
+  })
+
+  it('leaves the aggregate alone for a stamp carrying neither field', () => {
+    expect(fold(authz(['read'], 'all'), {}).authorization).toEqual({
+      abilities: ['read'],
+      mode: 'all',
+    })
+    expect(fold({})).toEqual({})
   })
 })
 


### PR DESCRIPTION
## Summary

Phase 0 prerequisite work for RFC 0016 (PR-0b): make route → authorization ability declaratively derivable from the middleware chain, extending RFC 0007's capability stamps beyond authentication.

- `MiddlewareCapabilities` gains `authorization?: { abilities: string[]; mode: 'all' | 'any' | 'mixed'; resource?: { fromMethodMap: boolean } }`.
- `authorizeMiddleware`, `authorizeAllMiddleware`, and `authorizeResourceMiddleware` now stamp it. A single ability (or a one-element list, normalized) reports `mode: 'all'`; a multi-ability list reports `'any'` (mirroring the runtime any-of branch); combining checks on one chain is a conjunction, so only all-of + all-of stays `'all'` — anything else reports `'mixed'`, meaning authorization is present but no single ability may be named (fail closed).
- The resource variant stamps `resource.fromMethodMap`: `true` only when no `abilityFor` override exists, because `abilityFor` wins over the verb map even for standard verbs. Consumers resolve the ability via the new `resourceAbilityForMethod()` (exported from `authorization/middleware`, deliberately not from the package root) rather than restating the table.
- `Router.aggregateCapabilities` absorbs `authentication` and `authorization` independently (the old guard bailed on stamps without `authentication`), and dedupes each stamp object across the whole recursion, group boundaries included.

## Notes for reviewers

- Second commit addresses an external review: ability arrays and `abilityFor` are snapshotted at creation so the stamp and the runtime check cannot diverge under later mutation; `authorizeAllMiddleware([])` now throws (it authorized every request while claiming to authorize — fail open), while `authorizeMiddleware([])` stays legal because its runtime is fail-closed (denies everything) and is documented as such.
- Tests pin both halves: the stamp shape in `router.test.ts` and the runtime behavior in `authorization.test.ts` (snapshot survives caller mutation; late `abilityFor` assignment cannot move a DELETE off `delete`). The group-boundary dedup fix was mutation-checked.
- Nothing new reaches the package root (verified against the built `dist/index.d.ts`); the stamp shape remains internal per RFC 0007.
- Gates: `bun run build`, root `bun run typecheck`, full `bun run test:bun` (5337 pass / 0 fail).

Refs: RFC 0016