### PR TITLE
refactor(core): promote zod json-schema walker to shared internal module

### DIFF
--- a/.changeset/brave-melons-shout.md
+++ b/.changeset/brave-melons-shout.md
@@ -8,6 +8,13 @@ strings, `minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum`/`multipleOf`
 on numbers, and `minItems`/`maxItems` on arrays. A `z.string().min(1).max(120)`
 body field used to document as a bare `{ "type": "string" }`.
 
+A schema built with `z.int()`, `z.number().int()`, `z.int32()` or `z.uint32()`
+now documents as `{ "type": "integer" }` rather than `{ "type": "number" }` —
+the previous output advertised a contract accepting `3.14` that the route then
+rejected. The same reasoning applies to a schema carrying two patterns or two
+`multipleOf` values: the surplus is now conjoined under `allOf` instead of
+dropped, so the document can no longer accept input the route refuses.
+
 The schema walker itself moved to `@guren/core/internal/zod-json-schema`, so an
 OpenAPI document and anything else derived from the same route cannot disagree
 about a schema. The public API is unchanged.

--- a/.changeset/brave-melons-shout.md
+++ b/.changeset/brave-melons-shout.md
@@ -1,0 +1,13 @@
+---
+"@guren/openapi": minor
+---
+
+Generated documents now carry the constraints a route's Zod schemas declare,
+instead of only their types: `minLength`/`maxLength`/`pattern`/`format` on
+strings, `minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum`/`multipleOf`
+on numbers, and `minItems`/`maxItems` on arrays. A `z.string().min(1).max(120)`
+body field used to document as a bare `{ "type": "string" }`.
+
+The schema walker itself moved to `@guren/core/internal/zod-json-schema`, so an
+OpenAPI document and anything else derived from the same route cannot disagree
+about a schema. The public API is unchanged.

--- a/.changeset/quiet-pugs-repeat.md
+++ b/.changeset/quiet-pugs-repeat.md
@@ -1,0 +1,18 @@
+---
+"@guren/core": minor
+---
+
+Add the `@guren/core/internal/zod-json-schema` entry point: the one Zod 4 → JSON
+Schema 2020-12 walker, promoted out of `@guren/openapi` so every surface that
+describes an application's contracts to something outside the process derives
+the same schema. It now carries Zod's checks into JSON Schema constraints —
+string `minLength`/`maxLength`/`pattern`/`format`, number
+`minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum`/`multipleOf`, and
+array `minItems`/`maxItems` — where before it dropped them.
+
+`internal/zod-compat` gains `schemaChecks()` and `schemaFormat()`, the two reads
+that made this possible: zod stores refinements in a heterogeneous `_def.checks`
+array, and records a format either on the node (`z.email()`) or as a check
+(`z.string().email()`).
+
+Internal by `contributing/api-stability.md` — no stability guarantee.

--- a/.changeset/quiet-pugs-repeat.md
+++ b/.changeset/quiet-pugs-repeat.md
@@ -6,9 +6,13 @@ Add the `@guren/core/internal/zod-json-schema` entry point: the one Zod 4 → JS
 Schema 2020-12 walker, promoted out of `@guren/openapi` so every surface that
 describes an application's contracts to something outside the process derives
 the same schema. It now carries Zod's checks into JSON Schema constraints —
-string `minLength`/`maxLength`/`pattern`/`format`, number
+string `minLength`/`maxLength`/`pattern`/`format` (`email`, `uri`, `uuid`,
+`date-time`, `date`, `duration`, `hostname`, `ipv4`, `ipv6`), number
 `minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum`/`multipleOf`, and
-array `minItems`/`maxItems` — where before it dropped them.
+array `minItems`/`maxItems` — where before it dropped them. An integer-formatted
+number (`z.int()`, `z.int32()`, `z.uint32()`) now renders as `type: "integer"`
+rather than `type: "number"`, and a surplus `pattern` or `multipleOf` that one
+keyword cannot hold is conjoined under `allOf` rather than dropped.
 
 `internal/zod-compat` gains `schemaChecks()` and `schemaFormat()`, the two reads
 that made this possible: zod stores refinements in a heterogeneous `_def.checks`

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,6 +53,10 @@
       "types": "./dist/internal/zod-compat.d.ts",
       "default": "./dist/internal/zod-compat.js"
     },
+    "./internal/zod-json-schema": {
+      "types": "./dist/internal/zod-json-schema.d.ts",
+      "default": "./dist/internal/zod-json-schema.js"
+    },
     "./jsx-runtime": {
       "types": "./dist/jsx-runtime.d.ts",
       "default": "./dist/jsx-runtime.js"

--- a/packages/core/src/internal/zod-compat.test.ts
+++ b/packages/core/src/internal/zod-compat.test.ts
@@ -12,6 +12,8 @@ import {
   pipeSides,
   PRESENCE_WRAPPERS,
   schemaAt,
+  schemaChecks,
+  schemaFormat,
   SINGLE_CHILD_WRAPPERS,
   TRANSPARENT_WRAPPERS,
   typeOf,
@@ -187,5 +189,51 @@ describe('wrapper vocabulary', () => {
     for (const [name, make] of Object.entries(build)) {
       expect(typeOf(make() as never)).toBe(name)
     }
+  })
+})
+
+describe('schemaChecks', () => {
+  // `_def.checks` is heterogeneous: a plain refinement is stored as a bare
+  // check object, while a format method stores the whole format *schema* in the
+  // same array. Both carry the check definition at `_zod.def`, and nothing else
+  // about them is shared — a reader taking the entries at face value sees two
+  // unrelated shapes.
+  test('normalizes both entry shapes to their check definitions', () => {
+    expect(schemaChecks(z.string().min(2).max(5) as never)).toEqual([
+      expect.objectContaining({ check: 'min_length', minimum: 2 }),
+      expect.objectContaining({ check: 'max_length', maximum: 5 }),
+    ])
+
+    const [format] = schemaChecks(z.string().url() as never)
+    expect(format).toMatchObject({ check: 'string_format', format: 'url' })
+  })
+
+  test('returns an empty list for a node with no checks', () => {
+    expect(schemaChecks(z.string() as never)).toEqual([])
+    expect(schemaChecks(z.object({}) as never)).toEqual([])
+  })
+
+  // A caller switches on `check`, so an entry without one can only be misread.
+  test('drops entries that carry no check discriminator', () => {
+    expect(schemaChecks({ _def: { checks: [{ _zod: { def: { minimum: 1 } } }, 'nonsense', null] } })).toEqual([])
+  })
+})
+
+describe('schemaFormat', () => {
+  // The two spellings of a format record it in different places, and a reader
+  // that consults only one silently loses half the formats an app writes.
+  test('reads the format the top-level constructors declare on the node', () => {
+    expect(schemaFormat(z.email() as never)).toBe('email')
+    expect(schemaFormat(z.iso.datetime() as never)).toBe('datetime')
+    expect(schemaFormat(z.int() as never)).toBe('safeint')
+  })
+
+  test('is undefined for the string methods, which record the format as a check', () => {
+    expect(schemaFormat(z.string().email() as never)).toBeUndefined()
+    expect(schemaChecks(z.string().email() as never)[0]).toMatchObject({ format: 'email' })
+  })
+
+  test('is undefined for a node with no format', () => {
+    expect(schemaFormat(z.string() as never)).toBeUndefined()
   })
 })

--- a/packages/core/src/internal/zod-compat.ts
+++ b/packages/core/src/internal/zod-compat.ts
@@ -31,10 +31,24 @@
 
 export interface ZodSchemaLike {
   _def?: Record<string, unknown>
-  /** zod 4's internal container; `values` is its own computed set of accepted literals. */
-  _zod?: { values?: Set<unknown> }
+  /**
+   * zod 4's internal container; `values` is its own computed set of accepted
+   * literals, `def` the definition of whatever the node is (for a check entry,
+   * the check itself — see `schemaChecks`).
+   */
+  _zod?: { values?: Set<unknown>; def?: Record<string, unknown> }
   type?: string
   shape?: Record<string, ZodSchemaLike>
+}
+
+/**
+ * One entry of `_def.checks`, as zod stores it: a `check` discriminator plus
+ * whatever that kind carries (`minimum`, `value`, `inclusive`, `pattern`, …).
+ * Left open rather than modelled as a union — the kinds are zod's to add, and
+ * a reader that does not recognise one must simply ignore it.
+ */
+export interface ZodCheckDef extends Record<string, unknown> {
+  check: string
 }
 
 /**
@@ -158,6 +172,49 @@ export function enumValues(schema: ZodSchemaLike): Array<string | number> {
   }
   const entries = schema._def?.entries as Record<string, string | number> | undefined
   return entries ? Object.values(entries) : []
+}
+
+/**
+ * The refinements attached to a node (`.min()`, `.regex()`, `.multipleOf()`, …),
+ * normalized to the definition objects zod keeps at each entry's `_zod.def`.
+ *
+ * Reading through `_zod.def` rather than the entry itself is what makes the
+ * list uniform: `_def.checks` is heterogeneous by construction. A plain
+ * refinement (`z.string().min(2)`) is stored as a bare check object, while a
+ * format method (`z.string().url()`) stores the *format schema* — a full node
+ * with `parse`, `safeParse` and the rest — in the same array. Both carry the
+ * check definition at `_zod.def`, and nothing else about them is shared.
+ *
+ * Entries without a string `check` are dropped rather than passed through: a
+ * caller switches on that discriminator, so an entry that has none can only be
+ * misread.
+ */
+export function schemaChecks(schema: ZodSchemaLike): ZodCheckDef[] {
+  const checks = schema._def?.checks
+  if (!Array.isArray(checks)) {
+    return []
+  }
+
+  return checks.flatMap((entry) => {
+    const def = entry && typeof entry === 'object' ? (entry as ZodSchemaLike)._zod?.def : undefined
+    return def && typeof def.check === 'string' ? [def as ZodCheckDef] : []
+  })
+}
+
+/**
+ * The node's declared format, if it has one — `'email'` for `z.email()`,
+ * `'safeint'` for `z.int()`.
+ *
+ * This is only *half* of how zod 4 records a format, and the half a caller is
+ * likeliest to forget. The top-level constructors (`z.email()`, `z.iso.datetime()`)
+ * set `_def.format` and attach no check; the equivalent string methods
+ * (`z.string().email()`, `z.string().datetime()`) attach a `string_format`
+ * check and leave `_def.format` undefined. A reader that wants "the format of
+ * this schema" has to consult both this and `schemaChecks`.
+ */
+export function schemaFormat(schema: ZodSchemaLike): string | undefined {
+  const format = schema._def?.format
+  return typeof format === 'string' ? format : undefined
 }
 
 /** A literal's values — always the `_def.values` array in zod 4, which may hold more than one. */

--- a/packages/core/src/internal/zod-json-schema.test.ts
+++ b/packages/core/src/internal/zod-json-schema.test.ts
@@ -107,6 +107,26 @@ describe('toJsonSchema', () => {
       expect(clean(z.string().datetime())).toEqual({ type: 'string', format: 'date-time' })
     })
 
+    // The network formats JSON Schema 2020-12 registers, in both spellings.
+    test('maps the registered network and duration formats', () => {
+      expect(clean(z.ipv4())).toEqual({ type: 'string', format: 'ipv4' })
+      expect(clean(z.ipv6())).toEqual({ type: 'string', format: 'ipv6' })
+      expect(clean(z.hostname())).toEqual({ type: 'string', format: 'hostname' })
+      expect(clean(z.iso.duration())).toEqual({ type: 'string', format: 'duration' })
+
+      expect(clean(z.string().ipv4())).toEqual({ type: 'string', format: 'ipv4' })
+      expect(clean(z.string().ipv6())).toEqual({ type: 'string', format: 'ipv6' })
+      expect(clean(z.string().duration())).toEqual({ type: 'string', format: 'duration' })
+    })
+
+    // JSON Schema's `time` is an RFC 3339 `full-time` and requires an offset;
+    // `z.iso.time()` accepts a local wall-clock time, so claiming the format
+    // would assert something the schema does not enforce. zod's own emitter
+    // omits it for the same reason.
+    test('does not claim the time format for a schema that accepts a local time', () => {
+      expect(clean(z.iso.time())).toEqual({ type: 'string' })
+    })
+
     test('combines a format with the length bounds beside it', () => {
       expect(clean(z.email().max(254))).toEqual({ type: 'string', format: 'email', maxLength: 254 })
     })
@@ -118,9 +138,24 @@ describe('toJsonSchema', () => {
       expect(clean(z.iso.datetime())?.pattern).toBeUndefined()
     })
 
-    // JSON Schema has one `pattern` keyword, so the second is unrepresentable.
-    test('keeps the first pattern when a schema carries two', () => {
-      expect(clean(z.string().regex(/^a/).startsWith('b'))?.pattern).toBe('^a')
+    // One `pattern` keyword per schema object, so a second has to be conjoined.
+    // Dropping it would emit a schema that ACCEPTS strings the route rejects —
+    // the one direction a derived contract must never be wrong in.
+    test('conjoins a surplus pattern rather than dropping it', () => {
+      expect(clean(z.string().regex(/^a/).startsWith('b'))).toEqual({
+        type: 'string',
+        pattern: '^a',
+        allOf: [{ pattern: '^b.*' }],
+      })
+
+      expect(clean(z.string().regex(/^a/).startsWith('b').endsWith('c'))?.allOf).toEqual([
+        { pattern: '^b.*' },
+        { pattern: '.*c$' },
+      ])
+    })
+
+    test('leaves a lone pattern flat', () => {
+      expect(clean(z.string().regex(/^a/))).toEqual({ type: 'string', pattern: '^a' })
     })
 
     // Dropping an unmapped format leaves `type: 'string'`, which is still true.
@@ -154,6 +189,41 @@ describe('toJsonSchema', () => {
 
     test('carries multipleOf', () => {
       expect(clean(z.number().multipleOf(0.5))).toEqual({ type: 'number', multipleOf: 0.5 })
+    })
+
+    // Two multiples compose to their least common multiple, which one keyword
+    // cannot spell. zod's own emitter drops the second outright, which widens
+    // the schema past what the route accepts.
+    test('conjoins a surplus multipleOf rather than dropping it', () => {
+      expect(clean(z.number().multipleOf(2).multipleOf(3))).toEqual({
+        type: 'number',
+        multipleOf: 2,
+        allOf: [{ multipleOf: 3 }],
+      })
+    })
+
+    // `z.int()` documented as `number` advertises a contract admitting 3.14,
+    // which the route then rejects. JSON Schema says "whole" with a type.
+    test('renders an integer-formatted number as type integer', () => {
+      expect(clean(z.int())).toEqual({ type: 'integer' })
+      expect(clean(z.number().int())).toEqual({ type: 'integer' })
+      expect(clean(z.int32())).toEqual({ type: 'integer' })
+      expect(clean(z.uint32())).toEqual({ type: 'integer' })
+      expect(clean(z.int().min(1).max(9))).toEqual({ type: 'integer', minimum: 1, maximum: 9 })
+    })
+
+    // The other half of the same zod vocabulary; these really are reals.
+    test('leaves the float formats as plain numbers', () => {
+      expect(clean(z.float32())).toEqual({ type: 'number' })
+      expect(clean(z.float64())).toEqual({ type: 'number' })
+    })
+
+    // Zod's own emitter adds `minimum: -2147483648` for int32 and the
+    // safe-integer range for `z.int()`. Those are the representation's limits,
+    // not the application's contract, and they bury the bounds an author wrote.
+    test('does not emit the bounds a numeric format implies', () => {
+      expect(clean(z.int32())).not.toHaveProperty('minimum')
+      expect(clean(z.int())).not.toHaveProperty('maximum')
     })
 
     test('keeps the tighter of two bounds of the same kind', () => {

--- a/packages/core/src/internal/zod-json-schema.test.ts
+++ b/packages/core/src/internal/zod-json-schema.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, test } from 'bun:test'
+import { z } from 'zod'
+import * as z3 from 'zod/v3'
+import { isZodSchema, type JsonSchemaObject, readObjectSchema, toJsonSchema } from './zod-json-schema'
+
+/** The walk with its warnings, since almost every assertion cares about both. */
+function walk(schema: unknown, io: 'input' | 'output' = 'input') {
+  const warnings: string[] = []
+  const result = toJsonSchema(schema, warnings, 'schema', io)
+  return { result, warnings }
+}
+
+/** The rendered schema, asserting the walk had nothing to complain about. */
+function clean(schema: unknown, io: 'input' | 'output' = 'input'): JsonSchemaObject | undefined {
+  const { result, warnings } = walk(schema, io)
+  expect(warnings).toEqual([])
+  return result
+}
+
+describe('toJsonSchema', () => {
+  describe('types', () => {
+    test('renders the primitive types', () => {
+      expect(clean(z.string())).toEqual({ type: 'string' })
+      expect(clean(z.number())).toEqual({ type: 'number' })
+      expect(clean(z.boolean())).toEqual({ type: 'boolean' })
+      expect(clean(z.bigint())).toEqual({ type: 'integer' })
+      expect(clean(z.date())).toEqual({ type: 'string', format: 'date-time' })
+      expect(clean(z.null())).toEqual({ type: 'null' })
+    })
+
+    test('renders an object with only its non-omissible keys required', () => {
+      expect(clean(z.object({ a: z.string(), b: z.number().optional() }))).toEqual({
+        type: 'object',
+        properties: { a: { type: 'string' }, b: { type: 'number' } },
+        required: ['a'],
+      })
+    })
+
+    test('renders a nullable as a union with null rather than unwrapping it', () => {
+      expect(clean(z.string().nullable())).toEqual({ anyOf: [{ type: 'string' }, { type: 'null' }] })
+    })
+
+    test('reads the side of a pipe that matches the direction being described', () => {
+      const piped = z.string().pipe(z.coerce.number())
+
+      expect(clean(piped, 'input')).toEqual({ type: 'string' })
+      expect(clean(piped, 'output')).toEqual({ type: 'number' })
+    })
+
+    test('warns rather than quietly dropping a schema it cannot read', () => {
+      const { result, warnings } = walk(z.lazy(() => z.string()))
+
+      expect(result).toBeUndefined()
+      expect(warnings).toEqual(['schema: the contents of a "lazy" schema could not be read, so it is omitted.'])
+    })
+
+    test('refuses a zod 3 node with a warning naming the v3 API', () => {
+      const { result, warnings } = walk(z3.string())
+
+      expect(result).toBeUndefined()
+      expect(warnings[0]).toContain('zod v3 API')
+    })
+  })
+
+  // The walker used to drop every check, so `z.string().min(1)` and
+  // `z.string()` produced the same schema — an agent handed the second learns
+  // nothing about what the endpoint will actually accept.
+  describe('string constraints', () => {
+    test('carries min and max length', () => {
+      expect(clean(z.string().min(2).max(5))).toEqual({ type: 'string', minLength: 2, maxLength: 5 })
+    })
+
+    test('pins both ends of an exact length', () => {
+      expect(clean(z.string().length(4))).toEqual({ type: 'string', minLength: 4, maxLength: 4 })
+    })
+
+    test('keeps the tighter of two bounds of the same kind', () => {
+      expect(clean(z.string().min(2).min(5))).toEqual({ type: 'string', minLength: 5 })
+      expect(clean(z.string().max(9).max(3))).toEqual({ type: 'string', maxLength: 3 })
+    })
+
+    test('carries a regex as the pattern source, not the /…/ literal', () => {
+      expect(clean(z.string().regex(/^[a-z]+$/))).toEqual({ type: 'string', pattern: '^[a-z]+$' })
+    })
+
+    test('carries the patterns zod compiles for prefix, suffix and substring tests', () => {
+      expect(clean(z.string().startsWith('draft-'))?.pattern).toBe('^draft-.*')
+      expect(clean(z.string().endsWith('.md'))?.pattern).toBe('.*\\.md$')
+      expect(clean(z.string().includes('x'))?.pattern).toBe('x')
+    })
+
+    // zod 4 records a format two different ways depending on which spelling was
+    // used, and only one of them is a check — a reader that consults a single
+    // source silently loses half the formats an app writes.
+    test('reads a format declared on the node (z.email())', () => {
+      expect(clean(z.email())).toEqual({ type: 'string', format: 'email' })
+      expect(clean(z.uuid())).toEqual({ type: 'string', format: 'uuid' })
+      expect(clean(z.url())).toEqual({ type: 'string', format: 'uri' })
+      expect(clean(z.iso.datetime())).toEqual({ type: 'string', format: 'date-time' })
+      expect(clean(z.iso.date())).toEqual({ type: 'string', format: 'date' })
+    })
+
+    test('reads a format attached as a check (z.string().email())', () => {
+      expect(clean(z.string().email())).toEqual({ type: 'string', format: 'email' })
+      expect(clean(z.string().uuid())).toEqual({ type: 'string', format: 'uuid' })
+      expect(clean(z.string().url())).toEqual({ type: 'string', format: 'uri' })
+      expect(clean(z.string().datetime())).toEqual({ type: 'string', format: 'date-time' })
+    })
+
+    test('combines a format with the length bounds beside it', () => {
+      expect(clean(z.email().max(254))).toEqual({ type: 'string', format: 'email', maxLength: 254 })
+    })
+
+    // A registered format says the same thing in a word; zod's own regex for it
+    // runs to hundreds of characters and is its parser, not the contract.
+    test('does not emit the internal regex of a registered format', () => {
+      expect(clean(z.string().uuid())?.pattern).toBeUndefined()
+      expect(clean(z.iso.datetime())?.pattern).toBeUndefined()
+    })
+
+    // JSON Schema has one `pattern` keyword, so the second is unrepresentable.
+    test('keeps the first pattern when a schema carries two', () => {
+      expect(clean(z.string().regex(/^a/).startsWith('b'))?.pattern).toBe('^a')
+    })
+
+    // Dropping an unmapped format leaves `type: 'string'`, which is still true.
+    test('drops a format JSON Schema has not registered', () => {
+      expect(clean(z.cuid())).toEqual({ type: 'string' })
+      expect(clean(z.emoji())).toEqual({ type: 'string' })
+    })
+
+    // `.trim()` and `.toLowerCase()` are stored as `overwrite` checks — they
+    // transform rather than constrain, and have no JSON Schema keyword.
+    test('ignores checks that rewrite a value instead of constraining it', () => {
+      expect(clean(z.string().trim().toLowerCase())).toEqual({ type: 'string' })
+    })
+  })
+
+  describe('number constraints', () => {
+    test('carries inclusive bounds as minimum and maximum', () => {
+      expect(clean(z.number().min(1).max(10))).toEqual({ type: 'number', minimum: 1, maximum: 10 })
+    })
+
+    // `.min()` and `.gt()` are one zod check kind separated by `inclusive`;
+    // collapsing them onto one keyword would widen or narrow the contract by one.
+    test('separates exclusive bounds into their own keywords', () => {
+      expect(clean(z.number().gt(1).lt(10))).toEqual({
+        type: 'number',
+        exclusiveMinimum: 1,
+        exclusiveMaximum: 10,
+      })
+      expect(clean(z.number().positive())).toEqual({ type: 'number', exclusiveMinimum: 0 })
+    })
+
+    test('carries multipleOf', () => {
+      expect(clean(z.number().multipleOf(0.5))).toEqual({ type: 'number', multipleOf: 0.5 })
+    })
+
+    test('keeps the tighter of two bounds of the same kind', () => {
+      expect(clean(z.number().min(1).min(4))).toEqual({ type: 'number', minimum: 4 })
+    })
+
+    // `z.date().min()` and `z.bigint().min()` reuse the same check kinds with a
+    // `Date` / `bigint` bound. Emitting either produces a keyword that is not a
+    // JSON number — and a bigint one that `JSON.stringify` throws on outright.
+    test('does not emit bounds whose value is not a JSON number', () => {
+      expect(clean(z.date().min(new Date('2020-01-01')))).toEqual({ type: 'string', format: 'date-time' })
+      expect(clean(z.bigint().min(1n))).toEqual({ type: 'integer' })
+      expect(() => JSON.stringify(clean(z.bigint().min(1n)))).not.toThrow()
+    })
+  })
+
+  describe('array constraints', () => {
+    test('carries min and max items alongside the element type', () => {
+      expect(clean(z.array(z.string()).min(1).max(3))).toEqual({
+        type: 'array',
+        items: { type: 'string' },
+        minItems: 1,
+        maxItems: 3,
+      })
+    })
+
+    test('pins both ends of an exact length', () => {
+      expect(clean(z.array(z.number()).length(2))).toEqual({
+        type: 'array',
+        items: { type: 'number' },
+        minItems: 2,
+        maxItems: 2,
+      })
+    })
+  })
+
+  // Constraints must survive the wrappers a real schema is written with, or
+  // they would only ever appear on bare top-level types.
+  test('carries constraints through wrappers and into object properties', () => {
+    expect(clean(z.string().min(3).optional())).toEqual({ type: 'string', minLength: 3 })
+    expect(clean(z.object({ title: z.string().min(1).max(80) }))).toEqual({
+      type: 'object',
+      properties: { title: { type: 'string', minLength: 1, maxLength: 80 } },
+      required: ['title'],
+    })
+  })
+})
+
+describe('readObjectSchema', () => {
+  test('reports the properties and the keys a caller must supply', () => {
+    const warnings: string[] = []
+    const details = readObjectSchema(
+      z.object({ page: z.number().min(1), q: z.string().optional() }),
+      warnings,
+      'query',
+      'input',
+    )
+
+    expect(warnings).toEqual([])
+    expect(details?.properties).toEqual({
+      page: { type: 'number', minimum: 1 },
+      q: { type: 'string' },
+    })
+    expect([...(details?.required ?? [])]).toEqual(['page'])
+  })
+
+  test('looks through a wrapper around the object', () => {
+    const warnings: string[] = []
+    const details = readObjectSchema(z.object({ page: z.number() }).optional(), warnings, 'query', 'input')
+
+    expect(warnings).toEqual([])
+    expect(Object.keys(details?.properties ?? {})).toEqual(['page'])
+  })
+
+  test('warns when the schema is not an object once unwrapped', () => {
+    const warnings: string[] = []
+
+    expect(readObjectSchema(z.string(), warnings, 'query', 'input')).toBeUndefined()
+    expect(warnings).toEqual(['query: expected an object schema for parameter expansion.'])
+  })
+
+  test('returns undefined without warning when there is no schema at all', () => {
+    const warnings: string[] = []
+
+    expect(readObjectSchema(undefined, warnings, 'query', 'input')).toBeUndefined()
+    expect(warnings).toEqual([])
+  })
+})
+
+describe('isZodSchema', () => {
+  test('accepts a zod node and rejects a look-alike validator', () => {
+    expect(isZodSchema(z.string())).toBe(true)
+    expect(isZodSchema({ safeParse: () => ({ success: true }) })).toBe(false)
+    expect(isZodSchema(null)).toBe(false)
+    expect(isZodSchema('string')).toBe(false)
+  })
+})

--- a/packages/core/src/internal/zod-json-schema.ts
+++ b/packages/core/src/internal/zod-json-schema.ts
@@ -98,12 +98,19 @@ type ZodLike = ZodSchemaLike
  * same thing, matched against zod's own `z.toJSONSchema()` output so the two
  * cannot disagree about, say, whether `z.url()` is `"url"` or `"uri"`.
  *
- * Deliberately short. Zod carries plenty of formats that JSON Schema has never
- * registered (`cuid`, `nanoid`, `emoji`, `ulid`, `jwt`, `base64`…), and
- * emitting those verbatim advertises a constraint no consumer can interpret —
- * an agent reading `format: "cuid"` learns nothing it can act on, while the
- * `type: "string"` it already had stays true. Unmapped formats are dropped, not
- * warned about: the schema is still correct, just less specific.
+ * The line is "registered by JSON Schema 2020-12", not "short". Zod carries
+ * plenty of formats the spec has never registered (`cuid`, `nanoid`, `emoji`,
+ * `ulid`, `jwt`, `base64`…), and emitting those verbatim advertises a
+ * constraint no consumer can interpret — an agent reading `format: "cuid"`
+ * learns nothing it can act on, while the `type: "string"` it already had stays
+ * true. Unmapped formats are dropped, not warned about: the schema is still
+ * correct, just less specific.
+ *
+ * `time` is the one registered format deliberately left out, and zod omits it
+ * from its own output for the same reason: JSON Schema's `time` is an RFC 3339
+ * `full-time`, which requires an offset, while `z.iso.time()` accepts a local
+ * wall-clock time. Claiming the format would assert an offset the schema does
+ * not require.
  */
 const JSON_SCHEMA_STRING_FORMATS: Readonly<Record<string, string>> = {
   email: 'email',
@@ -111,7 +118,27 @@ const JSON_SCHEMA_STRING_FORMATS: Readonly<Record<string, string>> = {
   uuid: 'uuid',
   datetime: 'date-time',
   date: 'date',
+  duration: 'duration',
+  hostname: 'hostname',
+  ipv4: 'ipv4',
+  ipv6: 'ipv6',
 }
+
+/**
+ * The `number_format` values that describe an integer. JSON Schema says this
+ * with a *type*, not a format, so these change `type: "number"` to
+ * `type: "integer"` — a `z.int()` that documents as `number` advertises a
+ * contract admitting `3.14`, which the route then rejects.
+ *
+ * `float32` / `float64` are the other half of the same zod vocabulary and stay
+ * plain numbers. The bounds each of these formats implies (zod's own emitter
+ * adds `minimum: -2147483648` for `int32`, and the safe-integer range for
+ * `safeint`) are deliberately not emitted: they are the representation's
+ * limits rather than the application's contract, and they bury the constraints
+ * an author actually wrote. `int64` / `uint64` need no entry — they sit on
+ * `bigint` nodes, which this walker already renders as `integer`.
+ */
+const INTEGER_NUMBER_FORMATS: ReadonlySet<string> = new Set(['safeint', 'int32', 'uint32'])
 
 /**
  * The string formats whose zod-supplied regex is worth carrying as `pattern` —
@@ -175,7 +202,10 @@ export function toJsonSchema(
     case 'string':
       return { type: 'string', ...stringConstraints(schema) }
     case 'number':
-      return { type: 'number', ...numericConstraints(schema) }
+      return {
+        type: isIntegerNumber(schema) ? 'integer' : 'number',
+        ...numericConstraints(schema),
+      }
     case 'boolean':
       return { type: 'boolean' }
     case 'bigint':
@@ -513,40 +543,82 @@ function lengthConstraints(
   return constraints
 }
 
+/**
+ * Every format this node declares, in the order a reader should prefer them.
+ *
+ * Two sources, because zod has two spellings: the top-level constructors
+ * (`z.email()`, `z.int()`) record the format on the node, while the equivalent
+ * methods (`z.string().email()`, `z.number().int()`) attach it as a check and
+ * leave the node's own field empty. Reading one source loses half the formats
+ * an app writes, so both are collected here once rather than in each caller.
+ */
+function declaredFormats(schema: ZodSchemaLike): string[] {
+  const onNode = schemaFormat(schema)
+  const onChecks = schemaChecks(schema).flatMap((check) =>
+    typeof check.format === 'string' ? [check.format] : [],
+  )
+  return onNode ? [onNode, ...onChecks] : onChecks
+}
+
+/** Whether a `number` node is constrained to whole values, and so is a JSON Schema `integer`. */
+function isIntegerNumber(schema: ZodSchemaLike): boolean {
+  return declaredFormats(schema).some((format) => INTEGER_NUMBER_FORMATS.has(format))
+}
+
 function stringConstraints(schema: ZodSchemaLike): JsonSchemaObject {
   const constraints: JsonSchemaObject = lengthConstraints(schema, 'minLength', 'maxLength')
 
-  // `z.email()` records the format on the node; `z.string().email()` records it
-  // as a check. Both spellings have to be read or half of them lose the format.
-  const declared = JSON_SCHEMA_STRING_FORMATS[schemaFormat(schema) ?? '']
-  if (declared) {
-    constraints.format = declared
-  }
-
-  for (const check of schemaChecks(schema)) {
-    if (check.check !== 'string_format') continue
-    const format = typeof check.format === 'string' ? check.format : undefined
-    if (!format) continue
-
+  for (const format of declaredFormats(schema)) {
     const mapped = JSON_SCHEMA_STRING_FORMATS[format]
     if (mapped && constraints.format === undefined) {
       constraints.format = mapped
-      continue
-    }
-
-    // JSON Schema has one `pattern` keyword, so a schema carrying two
-    // pattern-bearing checks (`.regex(...).startsWith(...)`) can only keep the
-    // first. The alternative — an `allOf` of single-keyword schemas — buys
-    // exactness for a rare shape at the cost of a schema no consumer renders
-    // as well; the first pattern is still a true constraint, just not the
-    // only one.
-    if (PATTERN_BEARING_FORMATS.has(format) && constraints.pattern === undefined) {
-      const pattern = patternSource(check)
-      if (pattern) constraints.pattern = pattern
     }
   }
 
+  const patterns = schemaChecks(schema).flatMap((check) => {
+    if (check.check !== 'string_format') return []
+    const format = typeof check.format === 'string' ? check.format : undefined
+    if (!format || !PATTERN_BEARING_FORMATS.has(format)) return []
+    const pattern = patternSource(check)
+    return pattern ? [pattern] : []
+  })
+
+  assignWithSurplus(constraints, 'pattern', patterns)
+
   return constraints
+}
+
+/**
+ * Put the first value under `keyword` and fold any remainder into `allOf`.
+ *
+ * JSON Schema allows one `pattern` and one `multipleOf` per schema object, so a
+ * node carrying two of either (`z.string().regex(/^a/).startsWith('b')`,
+ * `z.number().multipleOf(2).multipleOf(3)`) cannot state both in place. Keeping
+ * only the first is not a lesser answer, it is a wrong one: the emitted schema
+ * then *accepts values the route rejects*, which is the one direction a derived
+ * contract must never be wrong in — an agent handed it will send input that
+ * fails validation. `allOf` conjoins, so the surplus stays enforceable.
+ *
+ * The first value stays on the node rather than going into `allOf` with the
+ * rest, so the overwhelmingly common single-constraint case emits flat.
+ * (zod's own emitter drops the surplus `multipleOf` outright here.)
+ */
+function assignWithSurplus(
+  constraints: JsonSchemaObject,
+  keyword: 'pattern' | 'multipleOf',
+  values: Array<string | number>,
+): void {
+  const [first, ...surplus] = values
+  if (first === undefined) {
+    return
+  }
+
+  // The keyword's value type is narrowed per keyword by the caller's input,
+  // which is why the assignment needs the cast the union of both cannot express.
+  ;(constraints[keyword] as string | number) = first
+  if (surplus.length > 0) {
+    constraints.allOf = surplus.map((value) => ({ [keyword]: value }) as JsonSchemaObject)
+  }
 }
 
 /** A check's regex as a JSON Schema `pattern` — the source, never the `/…/` literal form. */
@@ -583,19 +655,18 @@ function numericConstraints(schema: ZodSchemaLike): JsonSchemaObject {
         }
         break
       }
-      // Two `multipleOf` checks would compose to their least common multiple,
-      // which JSON Schema cannot spell in one keyword; the first is kept.
-      case 'multiple_of': {
-        const value = numeric(check.value)
-        if (value !== undefined && constraints.multipleOf === undefined) {
-          constraints.multipleOf = value
-        }
-        break
-      }
       default:
         break
     }
   }
+
+  // Two `multipleOf` checks compose to their least common multiple, which one
+  // keyword cannot spell — so the surplus is conjoined rather than dropped.
+  assignWithSurplus(constraints, 'multipleOf', schemaChecks(schema).flatMap((check) => {
+    if (check.check !== 'multiple_of') return []
+    const value = numeric(check.value)
+    return value === undefined ? [] : [value]
+  }))
 
   return constraints
 }

--- a/packages/core/src/internal/zod-json-schema.ts
+++ b/packages/core/src/internal/zod-json-schema.ts
@@ -91,8 +91,6 @@ export interface ObjectSchemaDetails {
   required: Set<string>
 }
 
-type ZodLike = ZodSchemaLike
-
 /**
  * Zod's string formats mapped to the JSON Schema `format` names that mean the
  * same thing, matched against zod's own `z.toJSONSchema()` output so the two
@@ -202,10 +200,7 @@ export function toJsonSchema(
     case 'string':
       return { type: 'string', ...stringConstraints(schema) }
     case 'number':
-      return {
-        type: isIntegerNumber(schema) ? 'integer' : 'number',
-        ...numericConstraints(schema),
-      }
+      return numberSchema(schema)
     case 'boolean':
       return { type: 'boolean' }
     case 'bigint':
@@ -226,7 +221,7 @@ export function toJsonSchema(
       return {
         type: 'array',
         items: toJsonSchema(item, warnings, `${label}[]`, io) ?? {},
-        ...lengthConstraints(schema, 'minItems', 'maxItems'),
+        ...lengthConstraints(schemaChecks(schema), 'minItems', 'maxItems'),
       }
     }
     case 'object': {
@@ -354,7 +349,7 @@ export function isZodSchema(schema: unknown): schema is ZodSchemaLike {
  * ungated recursion would document it wrong instead of refusing it.
  */
 function warnIfZod3(schema: unknown, warnings: string[], label: string): boolean {
-  if (schema && typeof schema === 'object' && isZod3Schema(schema as ZodLike)) {
+  if (schema && typeof schema === 'object' && isZod3Schema(schema as ZodSchemaLike)) {
     warnings.push(`${label}: skipped — ${ZOD3_UNSUPPORTED_MESSAGE}`)
     return true
   }
@@ -362,7 +357,7 @@ function warnIfZod3(schema: unknown, warnings: string[], label: string): boolean
 }
 
 function readObjectSchemaDetails(
-  schema: ZodLike,
+  schema: ZodSchemaLike,
   warnings: string[],
   label: string,
   io: SchemaIo,
@@ -412,7 +407,7 @@ function readObjectSchemaDetails(
  * from `SINGLE_CHILD_WRAPPERS` rather than a local list. See `pipeSides` for
  * why a pipe resolves per direction.
  */
-function unwrap(schema: ZodLike, io: SchemaIo): ZodLike | undefined {
+function unwrap(schema: ZodSchemaLike, io: SchemaIo): ZodSchemaLike | undefined {
   const def = schema._def ?? {}
   const typeName = typeOf(schema)
 
@@ -423,7 +418,7 @@ function unwrap(schema: ZodLike, io: SchemaIo): ZodLike | undefined {
   return SINGLE_CHILD_WRAPPERS.has(typeName) ? innerSchema(def) : undefined
 }
 
-function isOptional(schema: ZodLike, io: SchemaIo): boolean {
+function isOptional(schema: ZodSchemaLike, io: SchemaIo): boolean {
   switch (typeOf(schema)) {
     case 'optional':
       return true
@@ -508,13 +503,13 @@ function tightenUpper(current: number | undefined, candidate: number): number {
  * count elements (`minItems`). Zod uses the same three check kinds for both.
  */
 function lengthConstraints(
-  schema: ZodSchemaLike,
+  checks: readonly ZodCheckDef[],
   minKey: 'minLength' | 'minItems',
   maxKey: 'maxLength' | 'maxItems',
 ): JsonSchemaObject {
   const constraints: JsonSchemaObject = {}
 
-  for (const check of schemaChecks(schema)) {
+  for (const check of checks) {
     switch (check.check) {
       case 'min_length': {
         const minimum = numeric(check.minimum)
@@ -551,39 +546,47 @@ function lengthConstraints(
  * methods (`z.string().email()`, `z.number().int()`) attach it as a check and
  * leave the node's own field empty. Reading one source loses half the formats
  * an app writes, so both are collected here once rather than in each caller.
+ *
+ * Takes the node's checks rather than re-reading them: every caller has already
+ * walked `_def.checks` for something else, and this walker is on RFC 0016's
+ * tool-derivation path as well as the document one.
  */
-function declaredFormats(schema: ZodSchemaLike): string[] {
+function declaredFormats(schema: ZodSchemaLike, checks: readonly ZodCheckDef[]): string[] {
   const onNode = schemaFormat(schema)
-  const onChecks = schemaChecks(schema).flatMap((check) =>
-    typeof check.format === 'string' ? [check.format] : [],
-  )
+  const onChecks = checks.flatMap((check) => typeof check.format === 'string' ? [check.format] : [])
   return onNode ? [onNode, ...onChecks] : onChecks
 }
 
-/** Whether a `number` node is constrained to whole values, and so is a JSON Schema `integer`. */
-function isIntegerNumber(schema: ZodSchemaLike): boolean {
-  return declaredFormats(schema).some((format) => INTEGER_NUMBER_FORMATS.has(format))
+/**
+ * The whole rendering of a `number` node, because its *type* and its
+ * constraints are read from the same check list — `z.int()` is a format, and
+ * splitting the two would walk `_def.checks` twice per node.
+ */
+function numberSchema(schema: ZodSchemaLike): JsonSchemaObject {
+  const checks = schemaChecks(schema)
+  const isInteger = declaredFormats(schema, checks).some((format) => INTEGER_NUMBER_FORMATS.has(format))
+
+  return { type: isInteger ? 'integer' : 'number', ...numericConstraints(checks) }
 }
 
 function stringConstraints(schema: ZodSchemaLike): JsonSchemaObject {
-  const constraints: JsonSchemaObject = lengthConstraints(schema, 'minLength', 'maxLength')
+  const checks = schemaChecks(schema)
+  const constraints: JsonSchemaObject = lengthConstraints(checks, 'minLength', 'maxLength')
 
-  for (const format of declaredFormats(schema)) {
-    const mapped = JSON_SCHEMA_STRING_FORMATS[format]
-    if (mapped && constraints.format === undefined) {
-      constraints.format = mapped
-    }
+  // First mapped format wins, which is why the node's own format leads the list.
+  const format = declaredFormats(schema, checks)
+    .map((declared) => JSON_SCHEMA_STRING_FORMATS[declared])
+    .find(Boolean)
+  if (format) {
+    constraints.format = format
   }
 
-  const patterns = schemaChecks(schema).flatMap((check) => {
+  assignWithSurplus(constraints, 'pattern', checks.flatMap((check) => {
     if (check.check !== 'string_format') return []
-    const format = typeof check.format === 'string' ? check.format : undefined
-    if (!format || !PATTERN_BEARING_FORMATS.has(format)) return []
+    if (typeof check.format !== 'string' || !PATTERN_BEARING_FORMATS.has(check.format)) return []
     const pattern = patternSource(check)
     return pattern ? [pattern] : []
-  })
-
-  assignWithSurplus(constraints, 'pattern', patterns)
+  }))
 
   return constraints
 }
@@ -626,10 +629,10 @@ function patternSource(check: ZodCheckDef): string | undefined {
   return check.pattern instanceof RegExp ? check.pattern.source : undefined
 }
 
-function numericConstraints(schema: ZodSchemaLike): JsonSchemaObject {
+function numericConstraints(checks: readonly ZodCheckDef[]): JsonSchemaObject {
   const constraints: JsonSchemaObject = {}
 
-  for (const check of schemaChecks(schema)) {
+  for (const check of checks) {
     switch (check.check) {
       // `.min()`/`.gte()` and `.gt()` are one check kind separated by
       // `inclusive`; JSON Schema 2020-12 separates them into two keywords whose
@@ -662,7 +665,7 @@ function numericConstraints(schema: ZodSchemaLike): JsonSchemaObject {
 
   // Two `multipleOf` checks compose to their least common multiple, which one
   // keyword cannot spell — so the surplus is conjoined rather than dropped.
-  assignWithSurplus(constraints, 'multipleOf', schemaChecks(schema).flatMap((check) => {
+  assignWithSurplus(constraints, 'multipleOf', checks.flatMap((check) => {
     if (check.check !== 'multiple_of') return []
     const value = numeric(check.value)
     return value === undefined ? [] : [value]

--- a/packages/core/src/internal/zod-json-schema.ts
+++ b/packages/core/src/internal/zod-json-schema.ts
@@ -1,0 +1,601 @@
+/**
+ * The one Zod → JSON Schema rule, shared by every surface that has to describe
+ * an application's contracts to something outside the process: `@guren/openapi`
+ * renders it as OpenAPI 3.1 schema objects (which *are* JSON Schema 2020-12),
+ * and RFC 0016's agent tools advertise it as MCP input/output schemas.
+ *
+ * Internal by the rules in `contributing/api-stability.md`: reachable only
+ * through a deep import under `internal/`, never re-exported from
+ * `@guren/core`'s index. No stability guarantee — it exists so two derivations
+ * of the same schema cannot disagree, not as a public extension point. That is
+ * the whole reason it moved here from `@guren/openapi`: a second walker is how
+ * an agent tool comes to advertise a schema the documented API contradicts.
+ *
+ * Every `_def` read goes through `zod-compat.ts`, including the check reads
+ * this module added. Reaching into `_def` here would put zod-layout knowledge
+ * in two places, which is exactly the split `zod-compat` exists to prevent.
+ *
+ * Zod 4 only, and a v3 node is *refused* rather than walked — on v3 `_def.type`
+ * holds a nested schema where v4 keeps the type name, so every read below would
+ * misfire and produce a confidently wrong document. The refusal is re-checked
+ * at each recursion, because a v3 node can hide inside a v4 wrapper.
+ *
+ * What this module does not decide: what a caller does with the warnings, and
+ * how the result is embedded (a `requestBody` content map, an MCP `inputSchema`).
+ * Warnings are appended to a caller-owned array so a document generator can
+ * surface them per request and a codegen step can fail on them.
+ */
+import {
+  arrayElement,
+  enumValues,
+  getTypeName,
+  innerSchema,
+  isZod3Schema,
+  literalValues,
+  objectShape,
+  pipeSide,
+  pipeSides,
+  recordValueType,
+  type SchemaIo,
+  schemaChecks,
+  schemaFormat,
+  SINGLE_CHILD_WRAPPERS,
+  typeOf,
+  ZOD3_UNSUPPORTED_MESSAGE,
+  type ZodCheckDef,
+  type ZodSchemaLike,
+} from './zod-compat'
+
+export type JsonSchemaPrimitiveType
+  = 'string' | 'number' | 'integer' | 'boolean' | 'array' | 'object' | 'null'
+
+/**
+ * A JSON Schema 2020-12 object, restricted to the keywords this walker emits.
+ * OpenAPI 3.1's Schema Object is the same dialect, so `@guren/openapi` uses
+ * this type verbatim.
+ */
+export interface JsonSchemaObject {
+  type?: JsonSchemaPrimitiveType | JsonSchemaPrimitiveType[]
+  format?: string
+  description?: string
+  enum?: Array<string | number>
+  const?: string | number | boolean | null
+  properties?: Record<string, JsonSchemaObject>
+  required?: string[]
+  items?: JsonSchemaObject
+  prefixItems?: JsonSchemaObject[]
+  minItems?: number
+  maxItems?: number
+  minLength?: number
+  maxLength?: number
+  pattern?: string
+  minimum?: number
+  maximum?: number
+  exclusiveMinimum?: number
+  exclusiveMaximum?: number
+  multipleOf?: number
+  additionalProperties?: boolean | JsonSchemaObject
+  anyOf?: JsonSchemaObject[]
+  oneOf?: JsonSchemaObject[]
+  allOf?: JsonSchemaObject[]
+}
+
+/**
+ * An object schema taken apart rather than rendered — the shape a caller needs
+ * when the properties do not stay together in one schema object (OpenAPI
+ * expands a `query` schema into one parameter per property, and RFC 0016 merges
+ * `params` + `query` + `body` into a single tool input).
+ */
+export interface ObjectSchemaDetails {
+  properties: Record<string, JsonSchemaObject>
+  required: Set<string>
+}
+
+type ZodLike = ZodSchemaLike
+
+/**
+ * Zod's string formats mapped to the JSON Schema `format` names that mean the
+ * same thing, matched against zod's own `z.toJSONSchema()` output so the two
+ * cannot disagree about, say, whether `z.url()` is `"url"` or `"uri"`.
+ *
+ * Deliberately short. Zod carries plenty of formats that JSON Schema has never
+ * registered (`cuid`, `nanoid`, `emoji`, `ulid`, `jwt`, `base64`…), and
+ * emitting those verbatim advertises a constraint no consumer can interpret —
+ * an agent reading `format: "cuid"` learns nothing it can act on, while the
+ * `type: "string"` it already had stays true. Unmapped formats are dropped, not
+ * warned about: the schema is still correct, just less specific.
+ */
+const JSON_SCHEMA_STRING_FORMATS: Readonly<Record<string, string>> = {
+  email: 'email',
+  url: 'uri',
+  uuid: 'uuid',
+  datetime: 'date-time',
+  date: 'date',
+}
+
+/**
+ * The string formats whose zod-supplied regex is worth carrying as `pattern` —
+ * the ones a user *wrote as a pattern* (`.regex()`) or as a prefix/suffix/
+ * substring test, which zod stores only as a compiled regex.
+ *
+ * The registered formats above are excluded on purpose even though zod exposes
+ * a pattern for them too: their regexes run to hundreds of characters (the
+ * `datetime` one alone is ~300), they are zod's parsing implementation rather
+ * than the contract, and `format` already says the same thing in a word.
+ */
+const PATTERN_BEARING_FORMATS: ReadonlySet<string> = new Set([
+  'regex', 'starts_with', 'ends_with', 'includes',
+])
+
+/**
+ * Turn a Zod schema into a JSON Schema object, appending a line to `warnings`
+ * for anything it cannot express. `label` names the schema in those warnings
+ * (`"POST /posts body.title"`); `io` picks the side of coercing and piped
+ * schemas to describe — `input` is what a caller sends, `output` what a parse
+ * produces.
+ *
+ * Returns `undefined` when the node contributes nothing (a bare `z.undefined()`)
+ * or could not be read; a caller treats that as "omit this property".
+ */
+export function toJsonSchema(
+  schema: unknown,
+  warnings: string[],
+  label: string,
+  io: SchemaIo,
+): JsonSchemaObject | undefined {
+  if (warnIfZod3(schema, warnings, label)) {
+    return undefined
+  }
+
+  if (!isZodSchema(schema)) {
+    warnings.push(`${label}: skipped because schema is not a supported Zod schema.`)
+    return undefined
+  }
+
+  const typeName = typeOf(schema)
+  const def = schema._def ?? {}
+
+  // Wrappers add nothing to the rendered type, so they are looked through
+  // uniformly. `nullable` is the exception — it renders as a union with null —
+  // and so keeps its own case below.
+  if (typeName !== 'nullable' && SINGLE_CHILD_WRAPPERS.has(typeName)) {
+    const nested = unwrap(schema, io)
+    if (!nested) {
+      // Reaching a wrapper whose contents cannot be read drops the property,
+      // so say so — `z.lazy()` hides its schema behind a getter this walker
+      // does not call, and a silently missing property reads as a schema that
+      // never declared one.
+      warnings.push(`${label}: the contents of a "${typeName}" schema could not be read, so it is omitted.`)
+      return undefined
+    }
+    return toJsonSchema(nested, warnings, label, io)
+  }
+
+  switch (typeName) {
+    case 'string':
+      return { type: 'string', ...stringConstraints(schema) }
+    case 'number':
+      return { type: 'number', ...numericConstraints(schema) }
+    case 'boolean':
+      return { type: 'boolean' }
+    case 'bigint':
+      // Constraints are skipped: a bigint's bounds are `bigint` values, and
+      // JSON Schema's numeric keywords are JSON numbers.
+      return { type: 'integer' }
+    case 'date':
+      // Same reason as bigint — `z.date().min()` carries a `Date`.
+      return { type: 'string', format: 'date-time' }
+    case 'undefined':
+      return undefined
+    case 'null':
+      return { type: 'null' }
+    case 'literal':
+      return literalSchema(def)
+    case 'array': {
+      const item = arrayElement(def)
+      return {
+        type: 'array',
+        items: toJsonSchema(item, warnings, `${label}[]`, io) ?? {},
+        ...lengthConstraints(schema, 'minItems', 'maxItems'),
+      }
+    }
+    case 'object': {
+      const details = readObjectSchemaDetails(schema, warnings, label, io)
+      if (!details) {
+        return { type: 'object' }
+      }
+      return {
+        type: 'object',
+        properties: details.properties,
+        required: details.required.size > 0 ? Array.from(details.required) : undefined,
+      }
+    }
+    case 'nullable': {
+      const nested = unwrap(schema, io)
+      const nestedSchema = nested ? toJsonSchema(nested, warnings, label, io) : undefined
+      return nestedSchema ? { anyOf: [nestedSchema, { type: 'null' }] } : { type: ['null'] }
+    }
+    case 'transform':
+      warnings.push(`${label}: transform schemas are documented as generic objects.`)
+      return { type: 'object' }
+    // `z.discriminatedUnion()` produces this same node.
+    case 'union': {
+      const options = (def.options as unknown[]) ?? []
+      const oneOf = options
+        .map((option, index) => toJsonSchema(option, warnings, `${label}.option${index}`, io))
+        .filter((option): option is JsonSchemaObject => Boolean(option))
+      return oneOf.length > 0 ? { oneOf } : undefined
+    }
+    case 'intersection': {
+      const left = toJsonSchema(def.left, warnings, `${label}.left`, io)
+      const right = toJsonSchema(def.right, warnings, `${label}.right`, io)
+      const allOf = [left, right].filter((value): value is JsonSchemaObject => Boolean(value))
+      return allOf.length > 0 ? { allOf } : undefined
+    }
+    case 'record': {
+      const valueType = recordValueType(def)
+      return {
+        type: 'object',
+        additionalProperties: toJsonSchema(valueType, warnings, `${label}.value`, io) ?? true,
+      }
+    }
+    // `z.nativeEnum()` produces this same node, so the values may be numbers.
+    case 'enum': {
+      const values = enumValues(schema)
+      if (values.length === 0) {
+        // An empty enum accepts nothing; JSON Schema has no `never`, so a bare
+        // string is the least-wrong fallback (the CLI renders `never`).
+        return { type: 'string' }
+      }
+      const hasNumber = values.some((value) => typeof value === 'number')
+      const hasString = values.some((value) => typeof value === 'string')
+      if (hasNumber && hasString) {
+        return { type: ['string', 'number'], enum: values }
+      }
+      return { type: hasNumber ? 'number' : 'string', enum: values }
+    }
+    case 'tuple': {
+      const items = ((def.items as unknown[]) ?? [])
+        .map((item, index) => toJsonSchema(item, warnings, `${label}[${index}]`, io))
+        .filter((item): item is JsonSchemaObject => Boolean(item))
+      return {
+        type: 'array',
+        prefixItems: items,
+        minItems: items.length,
+        maxItems: items.length,
+      }
+    }
+    case 'promise': {
+      const nested = innerSchema(def)
+      return nested ? toJsonSchema(nested, warnings, label, io) : undefined
+    }
+    default:
+      warnings.push(`${label}: unsupported Zod type "${typeName}".`)
+      return undefined
+  }
+}
+
+/**
+ * Take an object schema apart into its properties and the set of keys a caller
+ * must supply, looking through any wrappers around it. Warns and returns
+ * `undefined` when the schema is absent, not Zod, or not an object once
+ * unwrapped — a caller that expands properties into something else (query
+ * parameters, merged tool input) has nothing to expand otherwise.
+ */
+export function readObjectSchema(
+  schema: unknown,
+  warnings: string[],
+  label: string,
+  io: SchemaIo,
+): ObjectSchemaDetails | undefined {
+  if (!schema) {
+    return undefined
+  }
+
+  if (warnIfZod3(schema, warnings, label)) {
+    return undefined
+  }
+
+  if (!isZodSchema(schema)) {
+    warnings.push(`${label}: skipped because schema is not a supported Zod schema.`)
+    return undefined
+  }
+
+  const details = readObjectSchemaDetails(schema, warnings, label, io)
+  if (!details) {
+    warnings.push(`${label}: expected an object schema for parameter expansion.`)
+  }
+  return details
+}
+
+/** Whether this value looks like a Zod schema at all — the gate every walk opens with. */
+export function isZodSchema(schema: unknown): schema is ZodSchemaLike {
+  if (!schema || typeof schema !== 'object') {
+    return false
+  }
+
+  return Boolean(getTypeName(schema as ZodSchemaLike))
+}
+
+/**
+ * Push the v3 refusal warning and report whether it fired. One helper so the
+ * composed message cannot drift between the entry points, and so the recursive
+ * walks re-check nested nodes — a v3 schema can sit inside a v4 object, and an
+ * ungated recursion would document it wrong instead of refusing it.
+ */
+function warnIfZod3(schema: unknown, warnings: string[], label: string): boolean {
+  if (schema && typeof schema === 'object' && isZod3Schema(schema as ZodLike)) {
+    warnings.push(`${label}: skipped — ${ZOD3_UNSUPPORTED_MESSAGE}`)
+    return true
+  }
+  return false
+}
+
+function readObjectSchemaDetails(
+  schema: ZodLike,
+  warnings: string[],
+  label: string,
+  io: SchemaIo,
+): ObjectSchemaDetails | undefined {
+  // Recursion can surface a v3 node a wrapper was hiding (`z.optional(v3Obj)`
+  // passes the entry gate — the wrapper is v4).
+  if (warnIfZod3(schema, warnings, label)) {
+    return undefined
+  }
+
+  if (typeOf(schema) !== 'object') {
+    const nested = unwrap(schema, io)
+    return nested ? readObjectSchemaDetails(nested, warnings, label, io) : undefined
+  }
+
+  const shape = objectShape(schema)
+  if (!shape) {
+    warnings.push(`${label}: object schema shape could not be read.`)
+    return undefined
+  }
+
+  const properties: Record<string, JsonSchemaObject> = {}
+  const required = new Set<string>()
+
+  for (const [key, value] of Object.entries(shape)) {
+    const propertySchema = toJsonSchema(value, warnings, `${label}.${key}`, io)
+    if (!propertySchema) {
+      continue
+    }
+
+    properties[key] = propertySchema
+    if (!isOptional(value, io)) {
+      required.add(key)
+    }
+  }
+
+  return { properties, required }
+}
+
+/**
+ * The schema a wrapper wraps, in the direction being described. Three walks
+ * look through wrappers for different reasons — finding the object behind a
+ * parameter schema, rendering a type, deciding whether a property may be
+ * omitted — and each layers its own handling on top (`nullable` renders as a
+ * union; `optional` and friends decide presence). What none of them may do is
+ * disagree about which names *are* wrappers, which is why the membership comes
+ * from `SINGLE_CHILD_WRAPPERS` rather than a local list. See `pipeSides` for
+ * why a pipe resolves per direction.
+ */
+function unwrap(schema: ZodLike, io: SchemaIo): ZodLike | undefined {
+  const def = schema._def ?? {}
+  const typeName = typeOf(schema)
+
+  if (typeName === 'pipe') {
+    return pipeSide(def, io)
+  }
+
+  return SINGLE_CHILD_WRAPPERS.has(typeName) ? innerSchema(def) : undefined
+}
+
+function isOptional(schema: ZodLike, io: SchemaIo): boolean {
+  switch (typeOf(schema)) {
+    case 'optional':
+      return true
+    // Both fill a missing value in, so the field may be left out of a request
+    // but is always present in a response.
+    case 'default':
+    case 'prefault':
+      return io === 'input'
+    // Swallows any failure, a missing value included, and substitutes its
+    // fallback — so nothing is required of a caller, and a response always
+    // carries the field.
+    case 'catch':
+      return io === 'input'
+    // Re-requires a field an inner wrapper made optional, so the walk stops
+    // here rather than reading what it wraps.
+    case 'nonoptional':
+      return false
+    // A pipeline runs both stages, so a field may be omitted only if neither
+    // stage rejects a missing value. Reading just the side being rendered
+    // would document an omission the other stage refuses. Still an
+    // approximation in the other direction: a transforming stage can supply a
+    // value the next stage accepts, which this reports as required.
+    case 'pipe': {
+      const { from, to } = pipeSides(schema._def ?? {})
+      if (!from) {
+        return false
+      }
+      return to ? isOptional(from, io) && isOptional(to, io) : isOptional(from, io)
+    }
+    default: {
+      const nested = unwrap(schema, io)
+      return nested ? isOptional(nested, io) : false
+    }
+  }
+}
+
+function literalSchema(def: Record<string, unknown>): JsonSchemaObject {
+  // v4 literals can hold more than one value; only the first is documented
+  // here (unlike the CLI's type renderer, which unions all of them).
+  const value = literalValues(def)[0]
+
+  if (typeof value === 'string') {
+    return { type: 'string', const: value }
+  }
+  if (typeof value === 'number') {
+    return { type: 'number', const: value }
+  }
+  if (typeof value === 'boolean') {
+    return { type: 'boolean', const: value }
+  }
+  if (value === null) {
+    return { type: 'null', const: null }
+  }
+
+  return {}
+}
+
+/**
+ * A check value that JSON Schema can carry. The guard is not ceremonial: the
+ * same `greater_than` / `min_length` check kinds are attached to `z.date()` and
+ * `z.bigint()`, where the bound is a `Date` or a `bigint` — emitting either
+ * would produce a keyword whose value is not a JSON number (and, for bigint,
+ * one that `JSON.stringify` throws on).
+ */
+function numeric(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+/** The tighter of two lower bounds — a schema may carry `.min(2).min(5)`. */
+function tightenLower(current: number | undefined, candidate: number): number {
+  return current === undefined ? candidate : Math.max(current, candidate)
+}
+
+/** The tighter of two upper bounds. */
+function tightenUpper(current: number | undefined, candidate: number): number {
+  return current === undefined ? candidate : Math.min(current, candidate)
+}
+
+/**
+ * `min_length` / `max_length` / `length_equals` under whichever pair of
+ * keywords the type spells them: strings count characters (`minLength`), arrays
+ * count elements (`minItems`). Zod uses the same three check kinds for both.
+ */
+function lengthConstraints(
+  schema: ZodSchemaLike,
+  minKey: 'minLength' | 'minItems',
+  maxKey: 'maxLength' | 'maxItems',
+): JsonSchemaObject {
+  const constraints: JsonSchemaObject = {}
+
+  for (const check of schemaChecks(schema)) {
+    switch (check.check) {
+      case 'min_length': {
+        const minimum = numeric(check.minimum)
+        if (minimum !== undefined) constraints[minKey] = tightenLower(constraints[minKey], minimum)
+        break
+      }
+      case 'max_length': {
+        const maximum = numeric(check.maximum)
+        if (maximum !== undefined) constraints[maxKey] = tightenUpper(constraints[maxKey], maximum)
+        break
+      }
+      // `.length(n)` is one check that pins both ends.
+      case 'length_equals': {
+        const length = numeric(check.length)
+        if (length !== undefined) {
+          constraints[minKey] = tightenLower(constraints[minKey], length)
+          constraints[maxKey] = tightenUpper(constraints[maxKey], length)
+        }
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  return constraints
+}
+
+function stringConstraints(schema: ZodSchemaLike): JsonSchemaObject {
+  const constraints: JsonSchemaObject = lengthConstraints(schema, 'minLength', 'maxLength')
+
+  // `z.email()` records the format on the node; `z.string().email()` records it
+  // as a check. Both spellings have to be read or half of them lose the format.
+  const declared = JSON_SCHEMA_STRING_FORMATS[schemaFormat(schema) ?? '']
+  if (declared) {
+    constraints.format = declared
+  }
+
+  for (const check of schemaChecks(schema)) {
+    if (check.check !== 'string_format') continue
+    const format = typeof check.format === 'string' ? check.format : undefined
+    if (!format) continue
+
+    const mapped = JSON_SCHEMA_STRING_FORMATS[format]
+    if (mapped && constraints.format === undefined) {
+      constraints.format = mapped
+      continue
+    }
+
+    // JSON Schema has one `pattern` keyword, so a schema carrying two
+    // pattern-bearing checks (`.regex(...).startsWith(...)`) can only keep the
+    // first. The alternative — an `allOf` of single-keyword schemas — buys
+    // exactness for a rare shape at the cost of a schema no consumer renders
+    // as well; the first pattern is still a true constraint, just not the
+    // only one.
+    if (PATTERN_BEARING_FORMATS.has(format) && constraints.pattern === undefined) {
+      const pattern = patternSource(check)
+      if (pattern) constraints.pattern = pattern
+    }
+  }
+
+  return constraints
+}
+
+/** A check's regex as a JSON Schema `pattern` — the source, never the `/…/` literal form. */
+function patternSource(check: ZodCheckDef): string | undefined {
+  return check.pattern instanceof RegExp ? check.pattern.source : undefined
+}
+
+function numericConstraints(schema: ZodSchemaLike): JsonSchemaObject {
+  const constraints: JsonSchemaObject = {}
+
+  for (const check of schemaChecks(schema)) {
+    switch (check.check) {
+      // `.min()`/`.gte()` and `.gt()` are one check kind separated by
+      // `inclusive`; JSON Schema 2020-12 separates them into two keywords whose
+      // values are both numbers (in draft-04 `exclusiveMinimum` was a boolean —
+      // that dialect is not what OpenAPI 3.1 or MCP speak).
+      case 'greater_than': {
+        const value = numeric(check.value)
+        if (value === undefined) break
+        if (check.inclusive === true) {
+          constraints.minimum = tightenLower(constraints.minimum, value)
+        } else {
+          constraints.exclusiveMinimum = tightenLower(constraints.exclusiveMinimum, value)
+        }
+        break
+      }
+      case 'less_than': {
+        const value = numeric(check.value)
+        if (value === undefined) break
+        if (check.inclusive === true) {
+          constraints.maximum = tightenUpper(constraints.maximum, value)
+        } else {
+          constraints.exclusiveMaximum = tightenUpper(constraints.exclusiveMaximum, value)
+        }
+        break
+      }
+      // Two `multipleOf` checks would compose to their least common multiple,
+      // which JSON Schema cannot spell in one keyword; the first is kept.
+      case 'multiple_of': {
+        const value = numeric(check.value)
+        if (value !== undefined && constraints.multipleOf === undefined) {
+          constraints.multipleOf = value
+        }
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  return constraints
+}

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -21,5 +21,6 @@ export default defineConfig({
     'src/redis.ts',
     'src/internal/deploy-build.ts',
     'src/internal/zod-compat.ts',
+    'src/internal/zod-json-schema.ts',
   ],
 })

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -1,23 +1,13 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, relative, resolve } from 'node:path'
 import type { Application, RouteDefinition } from '@guren/core'
+import type { ZodSchemaLike } from '@guren/core/internal/zod-compat'
 import {
-  arrayElement,
-  enumValues,
-  getTypeName,
-  innerSchema,
-  isZod3Schema,
-  literalValues,
-  objectShape,
-  pipeSide,
-  pipeSides,
-  recordValueType,
-  type SchemaIo,
-  SINGLE_CHILD_WRAPPERS,
-  typeOf,
-  ZOD3_UNSUPPORTED_MESSAGE,
-  type ZodSchemaLike,
-} from '@guren/core/internal/zod-compat'
+  isZodSchema,
+  type JsonSchemaObject,
+  readObjectSchema,
+  toJsonSchema,
+} from '@guren/core/internal/zod-json-schema'
 
 type WriterOptions = {
   force?: boolean
@@ -26,8 +16,6 @@ type WriterOptions = {
 type ZodLike = ZodSchemaLike & {
   safeParse?: (data: unknown) => { success: boolean }
 }
-
-type OpenApiPrimitiveType = 'string' | 'number' | 'integer' | 'boolean' | 'array' | 'object' | 'null'
 
 export interface OpenApiServer {
   url: string
@@ -71,23 +59,14 @@ export interface OpenApiInfoObject {
   description?: string
 }
 
-export interface OpenApiSchemaObject {
-  type?: OpenApiPrimitiveType | OpenApiPrimitiveType[]
-  format?: string
-  description?: string
-  enum?: Array<string | number>
-  const?: string | number | boolean | null
-  properties?: Record<string, OpenApiSchemaObject>
-  required?: string[]
-  items?: OpenApiSchemaObject
-  prefixItems?: OpenApiSchemaObject[]
-  minItems?: number
-  maxItems?: number
-  additionalProperties?: boolean | OpenApiSchemaObject
-  anyOf?: OpenApiSchemaObject[]
-  oneOf?: OpenApiSchemaObject[]
-  allOf?: OpenApiSchemaObject[]
-}
+/**
+ * OpenAPI 3.1's Schema Object *is* JSON Schema 2020-12, so this is the shared
+ * walker's own type under the name this package has always exported. Keeping
+ * one definition is the point of the promotion: a second copy here is how the
+ * document and an agent tool derived from the same route come to advertise
+ * different constraints.
+ */
+export type OpenApiSchemaObject = JsonSchemaObject
 
 export interface OpenApiParameterObject {
   name: string
@@ -258,11 +237,6 @@ interface HonoLike {
   get(path: string, handler: (context: HonoLikeContext) => Response | Promise<Response>): unknown
 }
 
-type ObjectSchemaDetails = {
-  properties: Record<string, OpenApiSchemaObject>
-  required: Set<string>
-}
-
 function isApplicationLike(target: Application | HonoLike): target is Application & { hono: HonoLike; router: { definitions(): RouteDefinition[] } } {
   return typeof target === 'object'
     && target !== null
@@ -341,7 +315,7 @@ function buildRequestBody(definition: RouteDefinition, warnings: string[]): Open
     return undefined
   }
 
-  const bodySchema = toOpenApiSchema(schema, warnings, `${definition.method} ${definition.path} body`, 'input')
+  const bodySchema = toJsonSchema(schema, warnings, `${definition.method} ${definition.path} body`, 'input')
   if (!bodySchema) {
     return undefined
   }
@@ -358,7 +332,7 @@ function buildResponses(definition: RouteDefinition, warnings: string[]): Record
   const responses: Record<string, OpenApiResponseObject> = {}
   const successStatus = definition.method === 'POST' ? '201' : '200'
   const successSchema = definition.schemas?.output
-    ? toOpenApiSchema(definition.schemas.output, warnings, `${definition.method} ${definition.path} response`, 'output')
+    ? toJsonSchema(definition.schemas.output, warnings, `${definition.method} ${definition.path} response`, 'output')
     : undefined
 
   responses[successStatus] = {
@@ -380,203 +354,6 @@ function buildResponses(definition: RouteDefinition, warnings: string[]): Record
   }
 
   return responses
-}
-
-/**
- * Push the v3 refusal warning and report whether it fired. One helper so the
- * composed message cannot drift between the entry points, and so the recursive
- * walks re-check nested nodes — a v3 schema can sit inside a v4 object, and an
- * ungated recursion would document it wrong instead of refusing it.
- */
-function warnIfZod3(schema: unknown, warnings: string[], label: string): boolean {
-  if (schema && typeof schema === 'object' && isZod3Schema(schema as ZodLike)) {
-    warnings.push(`${label}: skipped — ${ZOD3_UNSUPPORTED_MESSAGE}`)
-    return true
-  }
-  return false
-}
-
-function readObjectSchema(schema: unknown, warnings: string[], label: string, io: SchemaIo): ObjectSchemaDetails | undefined {
-  if (!schema) {
-    return undefined
-  }
-
-  if (warnIfZod3(schema, warnings, label)) {
-    return undefined
-  }
-
-  if (!isZodSchema(schema)) {
-    warnings.push(`${label}: skipped because schema is not a supported Zod schema.`)
-    return undefined
-  }
-
-  const details = readObjectSchemaDetails(schema, warnings, label, io)
-  if (!details) {
-    warnings.push(`${label}: expected an object schema for parameter expansion.`)
-  }
-  return details
-}
-
-function readObjectSchemaDetails(schema: ZodLike, warnings: string[], label: string, io: SchemaIo): ObjectSchemaDetails | undefined {
-  // Recursion can surface a v3 node a wrapper was hiding (`z.optional(v3Obj)`
-  // passes the entry gate — the wrapper is v4).
-  if (warnIfZod3(schema, warnings, label)) {
-    return undefined
-  }
-
-  if (typeOf(schema) !== 'object') {
-    const nested = unwrap(schema, io)
-    return nested ? readObjectSchemaDetails(nested, warnings, label, io) : undefined
-  }
-
-  const shape = objectShape(schema)
-  if (!shape) {
-    warnings.push(`${label}: object schema shape could not be read.`)
-    return undefined
-  }
-
-  const properties: Record<string, OpenApiSchemaObject> = {}
-  const required = new Set<string>()
-
-  for (const [key, value] of Object.entries(shape)) {
-    const propertySchema = toOpenApiSchema(value, warnings, `${label}.${key}`, io)
-    if (!propertySchema) {
-      continue
-    }
-
-    properties[key] = propertySchema
-    if (!isOptional(value, io)) {
-      required.add(key)
-    }
-  }
-
-  return { properties, required }
-}
-
-function toOpenApiSchema(schema: unknown, warnings: string[], label: string, io: SchemaIo): OpenApiSchemaObject | undefined {
-  if (warnIfZod3(schema, warnings, label)) {
-    return undefined
-  }
-
-  if (!isZodSchema(schema)) {
-    warnings.push(`${label}: skipped because schema is not a supported Zod schema.`)
-    return undefined
-  }
-
-  const typeName = typeOf(schema)
-  const def = schema._def ?? {}
-
-  // Wrappers add nothing to the rendered type, so they are looked through
-  // uniformly. `nullable` is the exception — it renders as a union with null —
-  // and so keeps its own case below.
-  if (typeName !== 'nullable' && SINGLE_CHILD_WRAPPERS.has(typeName)) {
-    const nested = unwrap(schema, io)
-    if (!nested) {
-      // Reaching a wrapper whose contents cannot be read drops the property,
-      // so say so — `z.lazy()` hides its schema behind a getter this walker
-      // does not call, and a silently missing property reads as a schema that
-      // never declared one.
-      warnings.push(`${label}: the contents of a "${typeName}" schema could not be read, so it is omitted.`)
-      return undefined
-    }
-    return toOpenApiSchema(nested, warnings, label, io)
-  }
-
-  switch (typeName) {
-    case 'string':
-      return { type: 'string' }
-    case 'number':
-      return { type: 'number' }
-    case 'boolean':
-      return { type: 'boolean' }
-    case 'bigint':
-      return { type: 'integer' }
-    case 'date':
-      return { type: 'string', format: 'date-time' }
-    case 'undefined':
-      return undefined
-    case 'null':
-      return { type: 'null' }
-    case 'literal':
-      return literalSchema(def)
-    case 'array': {
-      const item = arrayElement(def)
-      return { type: 'array', items: toOpenApiSchema(item, warnings, `${label}[]`, io) ?? {} }
-    }
-    case 'object': {
-      const details = readObjectSchemaDetails(schema, warnings, label, io)
-      if (!details) {
-        return { type: 'object' }
-      }
-      return {
-        type: 'object',
-        properties: details.properties,
-        required: details.required.size > 0 ? Array.from(details.required) : undefined,
-      }
-    }
-    case 'nullable': {
-      const nested = unwrap(schema, io)
-      const nestedSchema = nested ? toOpenApiSchema(nested, warnings, label, io) : undefined
-      return nestedSchema ? { anyOf: [nestedSchema, { type: 'null' }] } : { type: ['null'] }
-    }
-    case 'transform':
-      warnings.push(`${label}: transform schemas are documented as generic objects.`)
-      return { type: 'object' }
-    // `z.discriminatedUnion()` produces this same node.
-    case 'union': {
-      const options = (def.options as unknown[]) ?? []
-      const oneOf = options
-        .map((option, index) => toOpenApiSchema(option, warnings, `${label}.option${index}`, io))
-        .filter((option): option is OpenApiSchemaObject => Boolean(option))
-      return oneOf.length > 0 ? { oneOf } : undefined
-    }
-    case 'intersection': {
-      const left = toOpenApiSchema(def.left, warnings, `${label}.left`, io)
-      const right = toOpenApiSchema(def.right, warnings, `${label}.right`, io)
-      const allOf = [left, right].filter((value): value is OpenApiSchemaObject => Boolean(value))
-      return allOf.length > 0 ? { allOf } : undefined
-    }
-    case 'record': {
-      const valueType = recordValueType(def)
-      return {
-        type: 'object',
-        additionalProperties: toOpenApiSchema(valueType, warnings, `${label}.value`, io) ?? true,
-      }
-    }
-    // `z.nativeEnum()` produces this same node, so the values may be numbers.
-    case 'enum': {
-      const values = enumValues(schema)
-      if (values.length === 0) {
-        // An empty enum accepts nothing; OpenAPI has no `never`, so a bare
-        // string is the least-wrong fallback (the CLI renders `never`).
-        return { type: 'string' }
-      }
-      const hasNumber = values.some((value) => typeof value === 'number')
-      const hasString = values.some((value) => typeof value === 'string')
-      if (hasNumber && hasString) {
-        return { type: ['string', 'number'], enum: values }
-      }
-      return { type: hasNumber ? 'number' : 'string', enum: values }
-    }
-    case 'tuple': {
-      const items = ((def.items as unknown[]) ?? [])
-        .map((item, index) => toOpenApiSchema(item, warnings, `${label}[${index}]`, io))
-        .filter((item): item is OpenApiSchemaObject => Boolean(item))
-      return {
-        type: 'array',
-        prefixItems: items,
-        minItems: items.length,
-        maxItems: items.length,
-      }
-    }
-    case 'promise': {
-      const nested = innerSchema(def)
-      return nested ? toOpenApiSchema(nested, warnings, label, io) : undefined
-    }
-    default:
-      warnings.push(`${label}: unsupported Zod type "${typeName}".`)
-      return undefined
-  }
 }
 
 function normalizeServers(servers?: OpenApiDocumentOptions['servers']): OpenApiServer[] | undefined {
@@ -679,93 +456,6 @@ function escapeHtml(value: string): string {
     .replace(/'/gu, '&#39;')
 }
 
-function isZodSchema(schema: unknown): schema is ZodLike {
-  if (!schema || typeof schema !== 'object') {
-    return false
-  }
-
-  return Boolean(getTypeName(schema as ZodLike))
-}
-
-/**
- * The schema a wrapper wraps, in the direction being documented. Three walks
- * look through wrappers for different reasons — finding the object behind a
- * parameter schema, rendering a type, deciding whether a property may be
- * omitted — and each layers its own handling on top (`nullable` renders as a
- * union; `optional` and friends decide presence). What none of them may do is
- * disagree about which names *are* wrappers, which is why the membership comes
- * from `SINGLE_CHILD_WRAPPERS` rather than a local list. See `pipeSides` for
- * why a pipe resolves per direction.
- */
-function unwrap(schema: ZodLike, io: SchemaIo): ZodLike | undefined {
-  const def = schema._def ?? {}
-  const typeName = typeOf(schema)
-
-  if (typeName === 'pipe') {
-    return pipeSide(def, io)
-  }
-
-  return SINGLE_CHILD_WRAPPERS.has(typeName) ? innerSchema(def) : undefined
-}
-
-function isOptional(schema: ZodLike, io: SchemaIo): boolean {
-  switch (typeOf(schema)) {
-    case 'optional':
-      return true
-    // Both fill a missing value in, so the field may be left out of a request
-    // but is always present in a response.
-    case 'default':
-    case 'prefault':
-      return io === 'input'
-    // Swallows any failure, a missing value included, and substitutes its
-    // fallback — so nothing is required of a caller, and a response always
-    // carries the field.
-    case 'catch':
-      return io === 'input'
-    // Re-requires a field an inner wrapper made optional, so the walk stops
-    // here rather than reading what it wraps.
-    case 'nonoptional':
-      return false
-    // A pipeline runs both stages, so a field may be omitted only if neither
-    // stage rejects a missing value. Reading just the side being rendered
-    // would document an omission the other stage refuses. Still an
-    // approximation in the other direction: a transforming stage can supply a
-    // value the next stage accepts, which this reports as required.
-    case 'pipe': {
-      const { from, to } = pipeSides(schema._def ?? {})
-      if (!from) {
-        return false
-      }
-      return to ? isOptional(from, io) && isOptional(to, io) : isOptional(from, io)
-    }
-    default: {
-      const nested = unwrap(schema, io)
-      return nested ? isOptional(nested, io) : false
-    }
-  }
-}
-
-function literalSchema(def: Record<string, unknown>): OpenApiSchemaObject {
-  // v4 literals can hold more than one value; only the first is documented
-  // here (unlike the CLI's type renderer, which unions all of them).
-  const value = literalValues(def)[0]
-
-  if (typeof value === 'string') {
-    return { type: 'string', const: value }
-  }
-  if (typeof value === 'number') {
-    return { type: 'number', const: value }
-  }
-  if (typeof value === 'boolean') {
-    return { type: 'boolean', const: value }
-  }
-  if (value === null) {
-    return { type: 'null', const: null }
-  }
-
-  return {}
-}
-
 function isRequestBodyRequired(schema: unknown): boolean {
   if (!isZodSchema(schema)) {
     return true
@@ -774,9 +464,13 @@ function isRequestBodyRequired(schema: unknown): boolean {
   // `safeParse` is supposed to return failures, but a malformed schema can
   // still throw — zod 4 throws outright when an object's property is not a
   // schema it recognizes (a nested v3 node, for one). A body whose schema
-  // cannot even run against `{}` is best documented as required.
+  // cannot even run against `{}` is best documented as required. Running the
+  // schema is this package's own business, which is why `ZodLike` (the reading
+  // surface plus `safeParse`) stays here rather than in the shared walker: the
+  // walker only ever *reads* a schema.
+  const parseable = schema as ZodLike
   try {
-    return !schema.safeParse!({}).success
+    return !parseable.safeParse?.({}).success
   } catch {
     return true
   }

--- a/packages/openapi/tests/openapi.test.ts
+++ b/packages/openapi/tests/openapi.test.ts
@@ -24,9 +24,9 @@ describe('@guren/openapi', () => {
         operationId: 'postsStore',
         deprecated: true,
         schemas: {
-          params: z.object({ id: z.coerce.number() }),
+          params: z.object({ id: z.coerce.number().positive() }),
           query: z.object({ preview: z.boolean().optional() }),
-          body: z.object({ title: z.string(), body: z.string() }),
+          body: z.object({ title: z.string().min(1).max(120), body: z.string() }),
           output: z.object({ id: z.number(), title: z.string(), body: z.string() }),
         },
       },
@@ -43,14 +43,17 @@ describe('@guren/openapi', () => {
     expect(document.info.title).toBe('Blog API')
     expect(document.paths['/posts/{id}']?.post?.summary).toBe('Create a post')
     expect(document.paths['/posts/{id}']?.post?.deprecated).toBe(true)
+    // The bounds a route validates with reach the document: a client (or an
+    // agent) reading `{ type: 'string' }` where the endpoint requires a
+    // non-empty string under 120 characters is told less than the app knows.
     expect(document.paths['/posts/{id}']?.post?.parameters).toEqual([
-      { name: 'id', in: 'path', required: true, schema: { type: 'number' } },
+      { name: 'id', in: 'path', required: true, schema: { type: 'number', exclusiveMinimum: 0 } },
       { name: 'preview', in: 'query', required: false, schema: { type: 'boolean' } },
     ])
     expect(document.paths['/posts/{id}']?.post?.requestBody?.content['application/json']?.schema).toEqual({
       type: 'object',
       properties: {
-        title: { type: 'string' },
+        title: { type: 'string', minLength: 1, maxLength: 120 },
         body: { type: 'string' },
       },
       required: ['title', 'body'],
@@ -342,6 +345,33 @@ describe('@guren/openapi', () => {
       const { operation, warnings } = operationFor({ query })
       return { parameters: operation?.parameters, warnings }
     }
+
+    // The walk itself is unit-tested in `@guren/core`'s own
+    // `zod-json-schema.test.ts`; what matters here is that the constraints
+    // survive the trip into every place a document carries a schema —
+    // request body, query parameter, and response — rather than only the one
+    // that happened to be exercised.
+    it('carries zod checks into every schema the document emits', () => {
+      const body = bodyDocument(z.object({
+        slug: z.string().regex(/^[a-z-]+$/),
+        contact: z.email(),
+        tags: z.array(z.string()).min(1).max(5),
+      }))
+      expect(body.warnings).toEqual([])
+      expect(body.schema?.properties).toEqual({
+        slug: { type: 'string', pattern: '^[a-z-]+$' },
+        contact: { type: 'string', format: 'email' },
+        tags: { type: 'array', items: { type: 'string' }, minItems: 1, maxItems: 5 },
+      })
+
+      const { parameters } = queryParameters(z.object({ page: z.number().min(1).max(100) }))
+      expect(parameters).toEqual([
+        { name: 'page', in: 'query', required: true, schema: { type: 'number', minimum: 1, maximum: 100 } },
+      ])
+
+      const response = responseDocument(z.object({ id: z.uuid() }))
+      expect(response.schema?.properties?.id).toEqual({ type: 'string', format: 'uuid' })
+    })
 
     it('keeps the element type of a zod 4 array', () => {
       const { schema, warnings } = bodyDocument(z.object({ tags: z.array(z.string()) }))

--- a/packages/openapi/tests/openapi.test.ts
+++ b/packages/openapi/tests/openapi.test.ts
@@ -24,7 +24,7 @@ describe('@guren/openapi', () => {
         operationId: 'postsStore',
         deprecated: true,
         schemas: {
-          params: z.object({ id: z.coerce.number().positive() }),
+          params: z.object({ id: z.coerce.number().int().positive() }),
           query: z.object({ preview: z.boolean().optional() }),
           body: z.object({ title: z.string().min(1).max(120), body: z.string() }),
           output: z.object({ id: z.number(), title: z.string(), body: z.string() }),
@@ -47,7 +47,7 @@ describe('@guren/openapi', () => {
     // agent) reading `{ type: 'string' }` where the endpoint requires a
     // non-empty string under 120 characters is told less than the app knows.
     expect(document.paths['/posts/{id}']?.post?.parameters).toEqual([
-      { name: 'id', in: 'path', required: true, schema: { type: 'number', exclusiveMinimum: 0 } },
+      { name: 'id', in: 'path', required: true, schema: { type: 'integer', exclusiveMinimum: 0 } },
       { name: 'preview', in: 'query', required: false, schema: { type: 'boolean' } },
     ])
     expect(document.paths['/posts/{id}']?.post?.requestBody?.content['application/json']?.schema).toEqual({

--- a/rfcs/0016-agent-interface.md
+++ b/rfcs/0016-agent-interface.md
@@ -120,7 +120,13 @@ Implementation notes (the non-obvious parts):
 **One Zod → JSON Schema rule.** The existing walker in `@guren/openapi`
 (`toOpenApiSchema`, OpenAPI 3.1 = JSON Schema 2020-12) is promoted to a shared
 internal module (`packages/core/src/internal/zod-json-schema.ts`, beside
-`zod-compat.ts`); `@guren/openapi` re-exports it. As part of the promotion it learns
+`zod-compat.ts`); ~~`@guren/openapi` re-exports it~~ **Amended in implementation:**
+`@guren/openapi` *imports* it and re-exports nothing. Re-exporting would publish an
+internal module through a package's stable index, which is exactly the tier
+`contributing/api-stability.md` says it must not reach — the walker stays behind one
+deep import, and the only name `@guren/openapi` still exposes is its own
+`OpenApiSchemaObject`, now an alias of the walker's `JsonSchemaObject` (OpenAPI 3.1's
+Schema Object *is* that dialect, so one definition serves both). As part of the promotion it learns
 to carry Zod checks (`min`/`max`/`regex`/`format`) into JSON Schema constraints —
 today it drops them.
 


### PR DESCRIPTION
## Summary

Phase 0 prerequisite work for RFC 0016 (PR-0c): one Zod → JSON Schema rule, shared by every surface that describes application contracts externally.

- The Zod 4 → JSON Schema 2020-12 walker moves from `@guren/openapi` into `@guren/core/internal/zod-json-schema` (internal per `contributing/api-stability.md`, beside `zod-compat`/`deploy-build`); `@guren/openapi` imports it and its public API keeps its names (`OpenApiSchemaObject` is now an alias of the walker's `JsonSchemaObject` — OpenAPI 3.1's Schema Object is that dialect). Two walkers is how an agent tool would come to advertise a schema the documented API contradicts.
- The walker now carries Zod checks it previously dropped: `minLength`/`maxLength`/`pattern`/`format` on strings, `minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum` (2020-12 numeric form)/`multipleOf` on numbers, `minItems`/`maxItems` on arrays. Repeated bounds of one kind collapse to the tighter value; both zod spellings of a format (`z.email()` and `z.string().email()`) are read through one helper.
- Registered JSON Schema formats emitted: `email`, `uri`, `uuid`, `date-time`, `date`, `duration`, `hostname`, `ipv4`, `ipv6`. Unregistered zod formats (`cuid`, `emoji`, `nanoid`, …) are skipped on purpose, as is `time` (zod's accepts local wall-clock times, JSON Schema's requires an offset — zod's own emitter omits it too).
- `z.int()`/`z.number().int()`/`int32`/`uint32` render `type: "integer"` (their implied representation bounds are not emitted); floats stay `number`.
- A surplus `pattern` or `multipleOf` folds into `allOf` instead of being dropped — dropping made the derived schema accept values the route rejects, the one direction a derived contract must never be wrong in.

## Notes for reviewers

- `@guren/openapi`'s `@guren/core` range is deliberately untouched: `changeset version` rewrites it when the release is cut (verified empirically by running it and resetting), and pre-bumping breaks workspace linking.
- The `allOf` fold and the constraint layer are mutation-checked (stubbing them fails the corresponding tests).
- Gates: `bun run build` (no stray `src/**/*.d.ts` from the TS7 declaration emitter), `bun run build:list` (core before openapi), root `bun run typecheck` incl. `typecheck:build-configs`, `bun run test:bun core openapi cli` (2133 pass / 0 fail), `audit:core-first`, `audit:docs`.

Refs: RFC 0016