### PR TITLE
feat(server): add agent exposure metadata to routes

### DIFF
--- a/.changeset/agent-route-metadata.md
+++ b/.changeset/agent-route-metadata.md
@@ -1,0 +1,9 @@
+---
+"@guren/server": minor
+---
+
+Add agent exposure metadata to routes (RFC 0016 Phase 1).
+
+- `RouteBuilder.agent(metadata)` and the `agent` key on `RouteContractOptions` mark a route as an agent tool. The metadata (`AgentRouteMetadata`: description, toolName, expose, MCP annotation hint overrides, approval, redact) is storage-only — input/output schemas, authorization, and annotation defaults derive from the contracts the route already carries.
+- `resource()` accepts per-action metadata via `ResourceRouteOptions.agent`; an action not listed is not exposed (deny by default), and metadata for an action the call does not register (excluded via `only`/`except`, or missing from the controller) throws.
+- `RouteDefinition.agent` carries the declared metadata through `definitions()`. Metadata is snapshotted on attach and on read, so neither side can mutate the router's copy.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -28,6 +28,7 @@ export type {
   RouteMiddlewareInput,
   RouteModelBinding,
   RouteOpenApiMetadata,
+  AgentRouteMetadata,
   ResourceAction as RouteResourceAction,
   ResourceResponseHint,
   ResourceResponseShape,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -22,13 +22,13 @@ export type { ViteAssetOptions } from './http/vite-assets'
 export { Router } from './mvc/Router'
 export type {
   BindableModel,
+  AgentRouteMetadata,
   RouteBuilder,
   RouteContractOptions,
   RouteDefinition,
   RouteMiddlewareInput,
   RouteModelBinding,
   RouteOpenApiMetadata,
-  AgentRouteMetadata,
   ResourceAction as RouteResourceAction,
   ResourceResponseHint,
   ResourceResponseShape,

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -206,24 +206,24 @@ export interface RouteOpenApiMetadata {
  * output schema, authorization — is derived from the contracts the route
  * already carries, never restated here.
  *
- * Storage only: no defaults are applied at registration. Derivation
- * (`deriveAgentTools`) resolves the tool description from this metadata or
- * the route's OpenAPI metadata, the tool name from `toolName` or the route
- * name, and the MCP annotation defaults from the HTTP method. A route needs
- * a `.name()` to become a tool — the name is the tool's identity — but that
- * is enforced by `guren check`, not here, because `.agent()` may legally be
- * chained before `.name()`.
+ * Storage only: no defaults are applied at registration, and the router does
+ * not require a route name here — `.agent()` may legally be chained before
+ * `.name()`, so name-requirement enforcement is deliberately left to static
+ * checks over `definitions()` (a route without a name cannot become a tool;
+ * the name is the tool's identity).
  */
 export interface AgentRouteMetadata {
-  /** Tool description. Falls back to OpenAPI `description` ?? `summary` at derivation. */
+  /** Tool description. Absent, the route's OpenAPI `description` ?? `summary` stands in. */
   description?: string
   /** Tool name override. Defaults to the route name, used verbatim. */
   toolName?: string
-  /** Protocol surfaces this tool appears on. Both default true at derivation. */
+  /** Protocol surfaces this tool appears on. Unset surfaces count as exposed. */
   expose?: { mcp?: boolean; webMcp?: boolean }
-  /** MCP ToolAnnotations overrides; defaults derive from the HTTP method. */
+  /** MCP ToolAnnotations override: the tool does not modify its environment. Unset: GET/QUERY routes read-only. */
   readOnlyHint?: boolean
+  /** MCP ToolAnnotations override. `false` is the strong claim "additive updates only"; unset keeps the spec default (true for non-read-only tools). */
   destructiveHint?: boolean
+  /** MCP ToolAnnotations override: repeat calls with the same arguments have no additional effect. Unset: PUT/DELETE routes idempotent. */
   idempotentHint?: boolean
   /** Route invocations through an agent surface require server-side approval. */
   approval?: 'required'
@@ -232,17 +232,17 @@ export interface AgentRouteMetadata {
 }
 
 /**
- * One immutable snapshot of agent metadata. Taken when the metadata is
- * attached and again when `definitions()` hands it out, so neither a caller
+ * One immutable snapshot of agent metadata, taken when the metadata is
+ * attached and again when `definitions()` hands it out — so neither a caller
  * mutating its options object after registration nor a consumer mutating a
- * definition can change what the router actually holds (the same rule the
- * authorization stamps follow).
+ * definition can change the agent metadata the router actually holds. The
+ * claim is scoped to this field: other definition fields (`schemas`, the
+ * spread OpenAPI metadata) alias the registry. Plain data end to end, so
+ * `structuredClone` keeps future nested fields covered without a
+ * hand-maintained field list.
  */
 function cloneAgentMetadata(metadata: AgentRouteMetadata): AgentRouteMetadata {
-  const clone: AgentRouteMetadata = { ...metadata }
-  if (metadata.expose) clone.expose = { ...metadata.expose }
-  if (metadata.redact) clone.redact = [...metadata.redact]
-  return clone
+  return structuredClone(metadata)
 }
 
 interface RegisteredRoute {
@@ -703,28 +703,25 @@ export class Router<M extends string = never> {
     const baseName = options.name ?? path.replace(/^\//u, '').replace(/\//gu, '.')
     const paramName = options.param ?? 'id'
     const { only, except, agent } = options
-    const registered = new Set<ResourceAction>()
 
-    for (const { method, suffix, httpMethod } of RESOURCE_ACTIONS) {
+    // The registration predicate is pure, so it runs once up front. That
+    // keeps the orphan check *before* any mutation: a rejected resource()
+    // leaves the router exactly as it was, never holding half its routes.
+    const registrable = new Set<ResourceAction>()
+    for (const { method } of RESOURCE_ACTIONS) {
       if (only && !only.includes(method)) continue
       if (except?.includes(method)) continue
-
-      const actualSuffix = suffix.replace(':param', `:${paramName}`)
-      const routePath = path + actualSuffix
-
       if (typeof (controller.prototype as Record<string, unknown>)[method] === 'function') {
-        const builder = this[httpMethod](routePath, [controller, method as ControllerMethodFor<C>]).name(`${baseName}.${method}`)
-        registered.add(method)
-
-        const agentMetadata = agent?.[method]
-        if (agentMetadata) {
-          builder.agent(agentMetadata)
-        }
+        registrable.add(method)
       }
     }
 
     if (agent) {
-      const orphaned = Object.keys(agent).filter((action) => !registered.has(action as ResourceAction))
+      // An explicitly-undefined value (`destroy: enabled ? meta : undefined`)
+      // is not a declaration — only real metadata for an unregistrable action
+      // is a wiring mistake.
+      const orphaned = (Object.keys(agent) as ResourceAction[])
+        .filter((action) => agent[action] !== undefined && !registrable.has(action))
       if (orphaned.length > 0) {
         throw new Error(
           `Router.resource('${path}'): agent metadata declared for ${orphaned.map((a) => `"${a}"`).join(', ')}, `
@@ -732,6 +729,17 @@ export class Router<M extends string = never> {
             + 'Agent metadata for a tool that cannot exist is a wiring mistake.',
         )
       }
+    }
+
+    for (const { method, suffix, httpMethod } of RESOURCE_ACTIONS) {
+      if (!registrable.has(method)) continue
+
+      const actualSuffix = suffix.replace(':param', `:${paramName}`)
+      const routePath = path + actualSuffix
+
+      const builder = this[httpMethod](routePath, [controller, method as ControllerMethodFor<C>]).name(`${baseName}.${method}`)
+      const agentMetadata = agent?.[method]
+      if (agentMetadata) builder.agent(agentMetadata)
     }
 
     return this
@@ -1167,6 +1175,16 @@ function createRouteBuilder<M extends string = never>(route: RegisteredRoute, na
       return this
     },
     agent(metadata: AgentRouteMetadata): RouteBuilder<M> {
+      // Refuse a second declaration rather than replacing or merging: a
+      // wholesale replace silently drops security-relevant fields the first
+      // declaration carried (approval, redact), and merge semantics would be
+      // just as easy to weaken by accident. One route, one declaration.
+      if (route.agent) {
+        throw new Error(
+          `Route ${route.method} ${route.path} already carries agent metadata `
+            + '(declared via route options or an earlier .agent() call). Declare it once.',
+        )
+      }
       route.agent = cloneAgentMetadata(metadata)
       return this
     },

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -188,6 +188,8 @@ export interface RouteContractOptions<
    * and expose the record to the controller via `this.model(Post)`.
    */
   bind?: Record<string, RouteModelBinding>
+  /** Agent exposure metadata (RFC 0016). See {@link AgentRouteMetadata}. */
+  agent?: AgentRouteMetadata
 }
 
 export interface RouteOpenApiMetadata {
@@ -196,6 +198,51 @@ export interface RouteOpenApiMetadata {
   tags?: string[]
   operationId?: string
   deprecated?: boolean
+}
+
+/**
+ * Agent exposure metadata for a route (RFC 0016). Declaring it marks the
+ * route as an agent tool; everything else about the tool — its input schema,
+ * output schema, authorization — is derived from the contracts the route
+ * already carries, never restated here.
+ *
+ * Storage only: no defaults are applied at registration. Derivation
+ * (`deriveAgentTools`) resolves the tool description from this metadata or
+ * the route's OpenAPI metadata, the tool name from `toolName` or the route
+ * name, and the MCP annotation defaults from the HTTP method. A route needs
+ * a `.name()` to become a tool — the name is the tool's identity — but that
+ * is enforced by `guren check`, not here, because `.agent()` may legally be
+ * chained before `.name()`.
+ */
+export interface AgentRouteMetadata {
+  /** Tool description. Falls back to OpenAPI `description` ?? `summary` at derivation. */
+  description?: string
+  /** Tool name override. Defaults to the route name, used verbatim. */
+  toolName?: string
+  /** Protocol surfaces this tool appears on. Both default true at derivation. */
+  expose?: { mcp?: boolean; webMcp?: boolean }
+  /** MCP ToolAnnotations overrides; defaults derive from the HTTP method. */
+  readOnlyHint?: boolean
+  destructiveHint?: boolean
+  idempotentHint?: boolean
+  /** Route invocations through an agent surface require server-side approval. */
+  approval?: 'required'
+  /** Argument fields masked in agent audit logs. */
+  redact?: string[]
+}
+
+/**
+ * One immutable snapshot of agent metadata. Taken when the metadata is
+ * attached and again when `definitions()` hands it out, so neither a caller
+ * mutating its options object after registration nor a consumer mutating a
+ * definition can change what the router actually holds (the same rule the
+ * authorization stamps follow).
+ */
+function cloneAgentMetadata(metadata: AgentRouteMetadata): AgentRouteMetadata {
+  const clone: AgentRouteMetadata = { ...metadata }
+  if (metadata.expose) clone.expose = { ...metadata.expose }
+  if (metadata.redact) clone.redact = [...metadata.redact]
+  return clone
 }
 
 interface RegisteredRoute {
@@ -217,6 +264,7 @@ interface RegisteredRoute {
   resource?: ResourceResponseHint
   openapi?: RouteOpenApiMetadata
   bindings?: Map<string, ModelBinding>
+  agent?: AgentRouteMetadata
 }
 
 /**
@@ -263,6 +311,11 @@ export interface RouteDefinition {
   }
   /** Route model bindings: param name → bound model class name (from `bind`) */
   bindings?: Record<string, string>
+  /**
+   * Agent exposure metadata as declared (RFC 0016) — raw, no defaults
+   * applied. Absence means the route is not an agent tool.
+   */
+  agent?: AgentRouteMetadata
   summary?: string
   description?: string
   tags?: string[]
@@ -279,6 +332,8 @@ export interface RouteBuilder<M extends string = never> {
   name(routeName: string): RouteBuilder<M>
   /** Attach middleware to this specific route. See {@link RouteMiddlewareInput}. */
   middleware(...items: RouteMiddlewareInput<M>[]): RouteBuilder<M>
+  /** Expose this route as an agent tool (RFC 0016). See {@link AgentRouteMetadata}. */
+  agent(metadata: AgentRouteMetadata): RouteBuilder<M>
 }
 
 /**
@@ -357,6 +412,14 @@ export interface ResourceRouteOptions {
   param?: string
   only?: ResourceAction[]
   except?: ResourceAction[]
+  /**
+   * Per-action agent exposure (RFC 0016). An action not listed here is not
+   * exposed as a tool — deny by default, no `destroy: false` spelling needed.
+   * Listing an action this call does not register (excluded via `only`/
+   * `except`, or missing from the controller) throws: metadata for a tool
+   * that cannot exist is a wiring mistake, not a no-op.
+   */
+  agent?: Partial<Record<ResourceAction, AgentRouteMetadata>>
 }
 
 /**
@@ -639,7 +702,8 @@ export class Router<M extends string = never> {
   ): this {
     const baseName = options.name ?? path.replace(/^\//u, '').replace(/\//gu, '.')
     const paramName = options.param ?? 'id'
-    const { only, except } = options
+    const { only, except, agent } = options
+    const registered = new Set<ResourceAction>()
 
     for (const { method, suffix, httpMethod } of RESOURCE_ACTIONS) {
       if (only && !only.includes(method)) continue
@@ -649,7 +713,24 @@ export class Router<M extends string = never> {
       const routePath = path + actualSuffix
 
       if (typeof (controller.prototype as Record<string, unknown>)[method] === 'function') {
-        this[httpMethod](routePath, [controller, method as ControllerMethodFor<C>]).name(`${baseName}.${method}`)
+        const builder = this[httpMethod](routePath, [controller, method as ControllerMethodFor<C>]).name(`${baseName}.${method}`)
+        registered.add(method)
+
+        const agentMetadata = agent?.[method]
+        if (agentMetadata) {
+          builder.agent(agentMetadata)
+        }
+      }
+    }
+
+    if (agent) {
+      const orphaned = Object.keys(agent).filter((action) => !registered.has(action as ResourceAction))
+      if (orphaned.length > 0) {
+        throw new Error(
+          `Router.resource('${path}'): agent metadata declared for ${orphaned.map((a) => `"${a}"`).join(', ')}, `
+            + 'but no such route was registered (excluded via only/except, or missing from the controller). '
+            + 'Agent metadata for a tool that cannot exist is a wiring mistake.',
+        )
       }
     }
 
@@ -683,12 +764,13 @@ export class Router<M extends string = never> {
   }
 
   definitions(): RouteDefinition[] {
-    return this.registry.map(({ method, path, name, schemas, resource, openapi, routeMiddlewareNames, middlewares, scopedMiddlewares, handler, bindings }) => ({
+    return this.registry.map(({ method, path, name, schemas, resource, openapi, routeMiddlewareNames, middlewares, scopedMiddlewares, handler, bindings, agent }) => ({
       method,
       path,
       name,
       schemas,
       resource: serializeResourceHint(resource),
+      agent: agent ? cloneAgentMetadata(agent) : undefined,
       middlewareNames: [...routeMiddlewareNames],
       // Route-local only, so a group-scoped handler does not make every route
       // in the group report middleware it never attached (`guren audit` warns
@@ -867,6 +949,9 @@ function applyRouteContract(route: RegisteredRoute, options: RouteContractOption
     route.bindings = new Map(
       Object.entries(options.bind).map(([param, binding]) => [param, normalizeModelBinding(binding)]),
     )
+  }
+  if (options.agent) {
+    route.agent = cloneAgentMetadata(options.agent)
   }
 }
 
@@ -1079,6 +1164,10 @@ function createRouteBuilder<M extends string = never>(route: RegisteredRoute, na
       const { names, handlers } = partitionMiddleware(items)
       route.routeMiddlewareNames.push(...names)
       route.middlewares.push(...handlers)
+      return this
+    },
+    agent(metadata: AgentRouteMetadata): RouteBuilder<M> {
+      route.agent = cloneAgentMetadata(metadata)
       return this
     },
   }
@@ -1520,6 +1609,7 @@ function isRouteContractOptions(value: unknown): value is RouteContractOptions<S
     || 'bind' in value
     || 'name' in value
     || 'middlewares' in value
+    || 'agent' in value
     || 'summary' in value
     || 'description' in value
     || 'tags' in value

--- a/packages/server/tests/mvc/agent-metadata.test.ts
+++ b/packages/server/tests/mvc/agent-metadata.test.ts
@@ -1,0 +1,165 @@
+import { describe, test, expect } from 'bun:test'
+import { z } from 'zod'
+import { Router, type AgentRouteMetadata } from '../../src/mvc/Router'
+import { Controller } from '../../src/mvc/Controller'
+
+class PostController extends Controller {
+  async index() {
+    return this.json({ posts: [] })
+  }
+
+  async store() {
+    return this.created({})
+  }
+
+  async destroy() {
+    return this.noContent()
+  }
+}
+
+function definitionByName(router: Router, name: string) {
+  const definition = router.definitions().find((d) => d.name === name)
+  expect(definition).toBeDefined()
+  return definition!
+}
+
+describe('AgentRouteMetadata (RFC 0016)', () => {
+  describe('fluent .agent()', () => {
+    test('should store metadata and carry it through definitions()', () => {
+      const router = new Router()
+      router
+        .post('/posts', { body: z.object({ title: z.string() }) }, [PostController, 'store'])
+        .name('posts.store')
+        .agent({ description: 'Create a blog post' })
+
+      const definition = definitionByName(router, 'posts.store')
+      expect(definition.agent).toEqual({ description: 'Create a blog post' })
+    })
+
+    test('should chain in either order with name()', () => {
+      const router = new Router()
+      router.get('/posts', [PostController, 'index']).agent({ description: 'List posts' }).name('posts.index')
+
+      const definition = definitionByName(router, 'posts.index')
+      expect(definition.agent).toEqual({ description: 'List posts' })
+    })
+
+    test('routes without metadata report no agent field', () => {
+      const router = new Router()
+      router.get('/posts', [PostController, 'index']).name('posts.index')
+
+      expect(definitionByName(router, 'posts.index').agent).toBeUndefined()
+    })
+  })
+
+  describe('route-contract options key', () => {
+    test('should accept agent metadata alongside a contract', () => {
+      const router = new Router()
+      router.post('/posts', {
+        name: 'posts.store',
+        body: z.object({ title: z.string() }),
+        agent: { description: 'Create a blog post', destructiveHint: false },
+      }, [PostController, 'store'])
+
+      const definition = definitionByName(router, 'posts.store')
+      expect(definition.agent).toEqual({ description: 'Create a blog post', destructiveHint: false })
+    })
+
+    test('an options object whose ONLY key is agent must not be mistaken for a handler', () => {
+      // Regression guard for the isRouteContractOptions key-sniff list: without
+      // 'agent' in it, this registration treats the options object as the
+      // handler and the tuple as middleware.
+      const router = new Router()
+      router.get('/posts', { agent: { description: 'List posts' } }, [PostController, 'index']).name('posts.index')
+
+      const definition = definitionByName(router, 'posts.index')
+      expect(definition.agent).toEqual({ description: 'List posts' })
+      expect(definition.controller).toEqual({ name: 'PostController', action: 'index' })
+    })
+  })
+
+  describe('snapshot semantics', () => {
+    test('mutating the caller metadata object after registration changes nothing', () => {
+      const router = new Router()
+      const metadata: AgentRouteMetadata = {
+        description: 'List posts',
+        expose: { webMcp: false },
+        redact: ['secret'],
+      }
+      router.get('/posts', [PostController, 'index']).name('posts.index').agent(metadata)
+
+      metadata.description = 'CHANGED'
+      metadata.expose!.webMcp = true
+      metadata.redact!.push('another')
+
+      expect(definitionByName(router, 'posts.index').agent).toEqual({
+        description: 'List posts',
+        expose: { webMcp: false },
+        redact: ['secret'],
+      })
+    })
+
+    test('mutating a returned definition does not leak back into the registry', () => {
+      const router = new Router()
+      router.get('/posts', [PostController, 'index']).name('posts.index').agent({ description: 'List posts' })
+
+      const first = definitionByName(router, 'posts.index')
+      first.agent!.description = 'CHANGED'
+
+      expect(definitionByName(router, 'posts.index').agent).toEqual({ description: 'List posts' })
+    })
+  })
+
+  describe('resource() per-action metadata', () => {
+    test('listed actions are exposed, unlisted actions are not', () => {
+      const router = new Router()
+      router.resource('posts', PostController, {
+        agent: {
+          index: { description: 'List posts' },
+          store: { description: 'Create a post' },
+          // destroy is not listed: deny by default.
+        },
+      })
+
+      expect(definitionByName(router, 'posts.index').agent).toEqual({ description: 'List posts' })
+      expect(definitionByName(router, 'posts.store').agent).toEqual({ description: 'Create a post' })
+      expect(definitionByName(router, 'posts.destroy').agent).toBeUndefined()
+    })
+
+    test('metadata for an action excluded via except throws', () => {
+      const router = new Router()
+      expect(() =>
+        router.resource('posts', PostController, {
+          except: ['destroy'],
+          agent: { destroy: { description: 'Delete a post' } },
+        }),
+      ).toThrow('agent metadata declared for "destroy"')
+    })
+
+    test('metadata for an action the controller does not implement throws', () => {
+      const router = new Router()
+      // PostController has no update()
+      expect(() =>
+        router.resource('posts', PostController, {
+          agent: { update: { description: 'Update a post' } },
+        }),
+      ).toThrow('agent metadata declared for "update"')
+    })
+  })
+
+  describe('scoped registration', () => {
+    test('agent metadata works on routes registered inside a middleware group', () => {
+      const router = new Router().aliasMiddleware('auth', async (_ctx, next) => {
+        await next()
+      })
+
+      router.middleware('auth').group((auth) => {
+        auth.post('/posts', [PostController, 'store']).name('posts.store').agent({ description: 'Create a post' })
+      })
+
+      const definition = definitionByName(router, 'posts.store')
+      expect(definition.agent).toEqual({ description: 'Create a post' })
+      expect(definition.middlewareNames).toEqual(['auth'])
+    })
+  })
+})

--- a/packages/server/tests/mvc/router-agent-metadata.test.ts
+++ b/packages/server/tests/mvc/router-agent-metadata.test.ts
@@ -78,6 +78,32 @@ describe('AgentRouteMetadata (RFC 0016)', () => {
     })
   })
 
+  describe('double declaration', () => {
+    test('a chained .agent() after an options-level declaration throws instead of replacing', () => {
+      // A wholesale replace would silently drop security-relevant fields the
+      // first declaration carried (approval, redact).
+      const router = new Router()
+      expect(() =>
+        router
+          .post('/transfers', {
+            name: 'transfers.store',
+            agent: { approval: 'required', redact: ['ssn'] },
+          }, [PostController, 'store'])
+          .agent({ description: 'Transfer funds' }),
+      ).toThrow('already carries agent metadata')
+
+      // The first declaration survives intact.
+      const definition = definitionByName(router, 'transfers.store')
+      expect(definition.agent).toEqual({ approval: 'required', redact: ['ssn'] })
+    })
+
+    test('calling .agent() twice on the builder throws', () => {
+      const router = new Router()
+      const builder = router.get('/posts', [PostController, 'index']).name('posts.index').agent({ description: 'a' })
+      expect(() => builder.agent({ description: 'b' })).toThrow('already carries agent metadata')
+    })
+  })
+
   describe('snapshot semantics', () => {
     test('mutating the caller metadata object after registration changes nothing', () => {
       const router = new Router()
@@ -134,6 +160,36 @@ describe('AgentRouteMetadata (RFC 0016)', () => {
           agent: { destroy: { description: 'Delete a post' } },
         }),
       ).toThrow('agent metadata declared for "destroy"')
+    })
+
+    test('a rejected resource() call leaves the router untouched', () => {
+      const router = new Router()
+      expect(() =>
+        router.resource('posts', PostController, {
+          except: ['destroy'],
+          agent: { destroy: { description: 'Delete a post' } },
+        }),
+      ).toThrow()
+
+      // Validation runs before any registration: no phantom half-resource.
+      expect(router.definitions()).toHaveLength(0)
+      expect(router.hasRoute('posts.index')).toBe(false)
+    })
+
+    test('an explicitly-undefined metadata value is not a declaration', () => {
+      // The natural conditional spelling must not throw when the action is
+      // excluded — nothing was declared for it.
+      const router = new Router()
+      router.resource('posts', PostController, {
+        except: ['destroy'],
+        agent: {
+          index: { description: 'List posts' },
+          destroy: undefined,
+        },
+      })
+
+      expect(definitionByName(router, 'posts.index').agent).toEqual({ description: 'List posts' })
+      expect(router.hasRoute('posts.destroy')).toBe(false)
     })
 
     test('metadata for an action the controller does not implement throws', () => {


### PR DESCRIPTION
## Summary

RFC 0016 Phase 1, PR-1a: the Agent Contract's storage layer. `RouteBuilder.agent(metadata)` and the `agent` key on `RouteContractOptions` mark a route as an agent tool; `RouteDefinition.agent` carries the declaration through `definitions()` to every consumer. Everything else about a tool — input schema, output schema, authorization, annotation defaults — derives from the contracts the route already carries, so nothing is restated.

- **Storage only**: no defaults applied at registration. The name-requirement (`.agent()` needs a `.name()` to become a tool) is deliberately left to static checks over `definitions()`, because `.agent()` may legally be chained before `.name()`.
- **`resource()` per-action metadata** via `ResourceRouteOptions.agent`: an action not listed is not exposed (deny by default). Metadata for an action the call does not register (excluded via `only`/`except`, or missing from the controller) throws — **before any registration**, so a rejected call leaves the router untouched. An explicitly-undefined value is not a declaration.
- **One declaration per route**: a second `.agent()` throws instead of replacing the first wholesale, because a replace silently drops security-relevant fields (`approval`, `redact`).
- **Snapshot semantics**: metadata is `structuredClone`d on attach and on `definitions()` read, so neither the caller's options object nor a returned definition aliases the router's copy.
- The `isRouteContractOptions` key-sniff gains `'agent'` (with a regression test: an options object whose only key is `agent` must not be mistaken for a handler).

## Notes for reviewers

- Second commit addresses an 8-angle review pass: the double-declaration replace, pre-validation atomicity, the explicit-undefined edge, structuredClone, and doc/convention fixes (no references to unshipped symbols).
- Verified `RouteBuilder` has exactly one implementor, so the new required interface method breaks nothing; `RouteDefinition` consumers (CLI, openapi) pass the field through structurally.
- `guren context` intentionally does not surface `agent` yet — that lands with the checks and entity-context section in PR-1c (RFC 0016 §13–14).
- Gates: `bun run build`, root `bun run typecheck`, full `bun run test:bun` (5431 pass / 0 fail), 15 new tests.

Refs: RFC 0016