### PR TITLE
fix(server): void a resource hint that is not a class, array or object

### DIFF
--- a/.changeset/resource-hint-non-object.md
+++ b/.changeset/resource-hint-non-object.md
@@ -1,0 +1,13 @@
+---
+'@guren/server': patch
+---
+
+Stop `Router.definitions()` from recursing forever on a route `resource` hint
+that is neither a Resource class, a single-element array, nor a plain object.
+
+The hint is purely declarative and nothing validates it at runtime, so a value
+outside `ResourceResponseHint` reaches the serializer. A string recursed until
+the stack overflowed (every character is itself a one-character string), `null`
+threw out of `Object.entries`, and a class instance serialized to `{}` — a
+response shape the server never sends. All three now void the whole hint, the
+same all-or-nothing rule an unnamed Resource class already followed.

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -1590,6 +1590,15 @@ function serializeResourceHint(hint: ResourceResponseHint | undefined): Resource
     return hint.name || undefined
   }
 
+  // Nothing validates the hint at runtime, so a value outside the type is
+  // reachable and voids the hint like an unnamed class does. A primitive has to
+  // be rejected before `Object.entries`, which turns a string into an infinite
+  // recursion (every character is itself a one-character string) and throws on
+  // `null`.
+  if (typeof hint !== 'object' || hint === null) {
+    return undefined
+  }
+
   // Array.isArray does not narrow the readonly tuple member of the union
   // (it is not assignable to `any[]`), so without the assertion the tuple
   // would fall through to the Object.entries path and serialize as
@@ -1597,6 +1606,14 @@ function serializeResourceHint(hint: ResourceResponseHint | undefined): Resource
   if (Array.isArray(hint)) {
     const inner = serializeResourceHint((hint as readonly ResourceResponseHint[])[0])
     return inner === undefined ? undefined : [inner]
+  }
+
+  // Only an envelope literal is left. A class instance enumerates to nothing
+  // through `Object.entries`, so without this it would serialize to `{}` — a
+  // response shape the server never sends.
+  const proto = Object.getPrototypeOf(hint)
+  if (proto !== Object.prototype && proto !== null) {
+    return undefined
   }
 
   const entries: Array<[string, ResourceResponseShape]> = []

--- a/packages/server/tests/mvc/router.test.ts
+++ b/packages/server/tests/mvc/router.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import { Hono, type MiddlewareHandler } from 'hono'
 import { z } from 'zod'
-import { Router } from '../../src/mvc/Router'
+import { Router, type ResourceResponseHint } from '../../src/mvc/Router'
 import { Controller } from '../../src/mvc/Controller'
 import { Resource } from '../../src/http/resources/Resource'
 import {
@@ -203,6 +203,27 @@ describe('Router resource response hint', () => {
     router.get('/posts', {
       name: 'posts.index',
       resource: { data: [Anonymous], author: AuthorResource },
+    }, [StubController, 'index'])
+
+    expect(router.definitions()[0]?.resource).toBeUndefined()
+  })
+
+  // The hint type admits only classes, single-element arrays and plain objects,
+  // but nothing validates it at runtime: a string used to recurse forever (every
+  // character is itself a one-character string) and `null` threw out of
+  // `Object.entries`. Anything unusable follows the same all-or-nothing rule as
+  // an unnamed class.
+  it.each([
+    ['a bare string', 'PostResource'],
+    ['null', null],
+    ['a string nested in an envelope', { data: 'PostResource' }],
+    ['a string nested in a collection', { data: ['PostResource'] }],
+    ['a class instance', new Date()],
+  ])('omits the whole hint for %s', (_label, hint) => {
+    const router = new Router()
+    router.get('/posts', {
+      name: 'posts.index',
+      resource: hint as unknown as ResourceResponseHint,
     }, [StubController, 'index'])
 
     expect(router.definitions()[0]?.resource).toBeUndefined()


### PR DESCRIPTION
## Problem

`serializeResourceHint` in `packages/server/src/mvc/Router.ts` recursed infinitely when handed a string. The route `resource` option is purely declarative and nothing validates it at runtime, so a value outside `ResourceResponseHint` does reach the serializer — and every character of a string is itself a one-character string, which `Object.entries` walks again, forever. Two neighbouring cases were wrong the same way: `null` threw out of `Object.entries`, and a class instance enumerated to nothing and serialized to `{}` — a response shape the server never sends.

Found while reviewing the RFC 0016 route metadata work; the defect predates it.

## Fix

Reject anything that is not a Resource class, a single-element array, or a plain object, following the all-or-nothing rule an unnamed Resource class already used: the whole hint becomes `undefined` rather than being narrowed. Two guards, each next to what it protects — a primitive/`null` check before the array branch, and a plain-object prototype check before `Object.entries`.

A hint holding a reference cycle still overflows; that is out of scope here, since it needs a deliberately self-referential value rather than the natural `resource: 'PostResource'` mistake.

## Tests

A table case in `Router resource response hint` covering a bare string, `null`, a class instance, and a string nested in both an envelope and a collection (propagation through each recursive branch). Before the fix, the string cases fail with `RangeError: Maximum call stack size exceeded`, `null` with a `TypeError`, and the instance with `Received: {}`.

## Gates

- `bun run build` — green
- `bun run typecheck` (root) — green
- `bun run test:bun` — 5436 pass, 0 fail (the CLI tests reach the server through `dist/`, so they are run against the rebuilt package)