### PR TITLE
feat(server): skip CSRF for cookie-less bearer requests

### DIFF
--- a/.changeset/csrf-bearer-skip.md
+++ b/.changeset/csrf-bearer-skip.md
@@ -1,0 +1,5 @@
+---
+'@guren/server': minor
+---
+
+Skip CSRF verification for `Authorization: Bearer` requests that carry no `Cookie` header (RFC 0016). CSRF defends cookie ambient authority, and a cookie-less bearer request has none to attach — the token is the client's own deliberately presented credential. A request carrying any cookie verifies exactly as before, so a forged Bearer header on a victim-browser request skips nothing, regardless of middleware mount order. Token issuance is unchanged.

--- a/packages/server/src/auth/AuthManager.ts
+++ b/packages/server/src/auth/AuthManager.ts
@@ -5,7 +5,7 @@ import { RequestAuthContext } from './RequestAuthContext'
 import { ModelUserProvider, type ModelUserProviderOptions } from './providers/ModelUserProvider'
 import { SessionGuard } from './SessionGuard'
 import { TokenGuard } from './TokenGuard'
-import { readBearerToken, type ApiTokenStore } from './api-token'
+import { hasBearerHeader, type ApiTokenStore } from './api-token'
 import { ScryptHasher } from './password/ScryptHasher'
 import type {
   AttachContextOptions,
@@ -209,10 +209,6 @@ export class AuthManager implements AuthManagerContract {
 
     this.tokenGuard = guardName
   }
-}
-
-function hasBearerHeader(ctx: Context): boolean {
-  return readBearerToken(ctx.req.header('Authorization')) !== null
 }
 
 export type { AuthCredentials } from './types'

--- a/packages/server/src/auth/api-token.ts
+++ b/packages/server/src/auth/api-token.ts
@@ -239,13 +239,24 @@ export function parseApiToken(plainTextToken: string): { id: string; token: stri
 /**
  * Extract the bearer token from an Authorization header value. The one
  * parsing rule shared by `createBearerTokenMiddleware`, `TokenGuard`, and
- * the guard selection in `AuthManager` — three readers of the same header
- * must not disagree about what a bearer request is.
+ * `hasBearerHeader` below — three readers of the same header must not
+ * disagree about what a bearer request is.
  */
 export function readBearerToken(header: string | undefined | null): string | null {
   if (!header) return null
   const match = header.match(/^Bearer\s+(.+)$/i)
   return match ? match[1] : null
+}
+
+/**
+ * The one answer to "is this request bearer-authenticated?" — the parsing
+ * rule above applied to the header it is read from. Shared by guard selection
+ * (`AuthManager.resolveGuardName`) and the CSRF skip for cookie-less bearer
+ * requests: both must classify a request identically, and a second copy of
+ * the header name is how they would drift apart.
+ */
+export function hasBearerHeader(ctx: Context): boolean {
+  return readBearerToken(ctx.req.header('Authorization')) !== null
 }
 
 /**

--- a/packages/server/src/http/middleware/csrf.ts
+++ b/packages/server/src/http/middleware/csrf.ts
@@ -6,7 +6,7 @@ import { deriveAppKeyring, getAppKeyringFromEnv } from '../../encryption/app-key
 import { MessageSigner } from '../../encryption/MessageSigner'
 import { secureCompare } from '../../encryption/Hash'
 import { isMcpEndpointEnabled, MCP_ENDPOINT_PATH } from '../../mcp/endpoint'
-import { readBearerToken } from '../../auth/api-token'
+import { hasBearerHeader } from '../../auth/api-token'
 
 export const CSRF_TOKEN_KEY = '_csrf_token'
 export const CSRF_HEADER_NAME = 'X-CSRF-TOKEN'
@@ -176,12 +176,13 @@ function isMcpEndpointRequest(path: string): boolean {
  * never reads — therefore keeps verification on; a bearer client that wants
  * the skip sends none, which is what every non-browser client does.
  *
- * Bearer detection is `readBearerToken`, shared with `TokenGuard` and
- * `AuthManager.resolveGuardName`, so this rule and token authentication
- * cannot disagree about what a bearer request is.
+ * Bearer detection is `hasBearerHeader`, the same predicate
+ * `AuthManager.resolveGuardName` routes a request to the token guard by, so
+ * this rule and token authentication cannot disagree about what a bearer
+ * request is.
  */
 function isBearerRequestWithoutCookies(ctx: Context): boolean {
-  if (readBearerToken(ctx.req.header('Authorization')) === null) {
+  if (!hasBearerHeader(ctx)) {
     return false
   }
 

--- a/packages/server/src/http/middleware/csrf.ts
+++ b/packages/server/src/http/middleware/csrf.ts
@@ -6,6 +6,7 @@ import { deriveAppKeyring, getAppKeyringFromEnv } from '../../encryption/app-key
 import { MessageSigner } from '../../encryption/MessageSigner'
 import { secureCompare } from '../../encryption/Hash'
 import { isMcpEndpointEnabled, MCP_ENDPOINT_PATH } from '../../mcp/endpoint'
+import { readBearerToken } from '../../auth/api-token'
 
 export const CSRF_TOKEN_KEY = '_csrf_token'
 export const CSRF_HEADER_NAME = 'X-CSRF-TOKEN'
@@ -152,6 +153,41 @@ function isExcluded(path: string, excludePatterns: string[]): boolean {
  */
 function isMcpEndpointRequest(path: string): boolean {
   return path === MCP_ENDPOINT_PATH && isMcpEndpointEnabled()
+}
+
+/**
+ * A bearer-authenticated request that carries no cookies at all (RFC 0016
+ * §3). CSRF defends cookie ambient authority — a browser attaching the
+ * victim's cookies to a request the victim never made. A request that
+ * authenticates by `Authorization: Bearer` and sends no `Cookie` header has
+ * none to attach: the token is the client's own credential, deliberately
+ * presented, and a browser cannot strip its cookies from a cross-site
+ * request. Agent tool dispatch is the intended caller — it synthesizes
+ * cookie-less bearer requests by construction.
+ *
+ * The predicate is the raw `Cookie` header, deliberately not the loaded
+ * session. Ambient authority *requires a cookie*, so the header's absence is
+ * proof by itself — independent of where this middleware sits relative to
+ * the session mount. A session-based predicate reads as more precise and is
+ * weaker on both edges: mounted before the session middleware it sees no
+ * session and fails open for a cookie-carrying victim browser, and an
+ * intermediate middleware that writes one value into a fresh session turns a
+ * genuinely cookie-less client into a 403. Any cookie — even one this app
+ * never reads — therefore keeps verification on; a bearer client that wants
+ * the skip sends none, which is what every non-browser client does.
+ *
+ * Bearer detection is `readBearerToken`, shared with `TokenGuard` and
+ * `AuthManager.resolveGuardName`, so this rule and token authentication
+ * cannot disagree about what a bearer request is.
+ */
+function isBearerRequestWithoutCookies(ctx: Context): boolean {
+  if (readBearerToken(ctx.req.header('Authorization')) === null) {
+    return false
+  }
+
+  // Only true absence skips: an empty `Cookie:` header is malformed enough
+  // to stay on the verifying path.
+  return ctx.req.header('Cookie') === undefined
 }
 
 /** The token issued so far this request, and the mode it was issued for. */
@@ -321,6 +357,9 @@ async function getTokenFromRequest(ctx: Context): Promise<string | undefined> {
  *   those sessions expire
  * - Exempts the dev-only MCP endpoint while it is mounted, since agent
  *   clients cannot fetch a token first (it guards local-only access instead)
+ * - Skips verification for `Authorization: Bearer` requests that carry no
+ *   cookies (RFC 0016) — token clients authenticate per request and hold no
+ *   cookie ambient authority for CSRF to defend
  *
  * `cookie: false` disables the `XSRF-TOKEN` cookie for apps that deliver the
  * token themselves (meta tag / form field). Session-bound tokens still
@@ -379,7 +418,9 @@ export function createCsrfMiddleware(options: CsrfOptions = {}): MiddlewareHandl
     // Excluded and MCP paths skip *verification*, not issuance: an exempt
     // endpoint that logs a user in (an OAuth callback is the usual one) still
     // has to hand back a bound token, or every later mutation is rejected.
-    if (isExcluded(path, exclude) || isMcpEndpointRequest(path)) {
+    // Cookie-less bearer requests skip on the same terms — see
+    // isBearerRequestWithoutCookies for why that is sound.
+    if (isExcluded(path, exclude) || isMcpEndpointRequest(path) || isBearerRequestWithoutCookies(ctx)) {
       await next()
       settleCookie(ctx)
       return

--- a/packages/server/tests/http/middleware/csrf.test.ts
+++ b/packages/server/tests/http/middleware/csrf.test.ts
@@ -941,3 +941,135 @@ describe('mode enforcement between minting and verification', () => {
     expect(post.status).toBe(200)
   })
 })
+
+describe('cookie-less bearer requests (RFC 0016)', () => {
+  function createBearerApp() {
+    const store = new MemorySessionStore()
+    const app = new Hono()
+    app.use(createSessionMiddleware({ store }))
+    app.use(createCsrfMiddleware())
+    app.get('/login', (c) => {
+      getSessionFromContext(c)?.set('userId', 1)
+      return c.text('ok')
+    })
+    app.post('/submit', (c) => c.text('ok'))
+    return app
+  }
+
+  it('skips verification for a Bearer request carrying no cookies', async () => {
+    const app = createBearerApp()
+
+    const post = await app.request('/submit', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer 1|sometoken' },
+    })
+
+    expect(post.status).toBe(200)
+  })
+
+  it('still issues the XSRF cookie on the skipped request', async () => {
+    const app = createBearerApp()
+
+    const post = await app.request('/submit', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer 1|sometoken' },
+    })
+
+    expect(pickCookie(post, 'XSRF-TOKEN')).not.toBe('')
+  })
+
+  it('verifies as usual when the Bearer request carries the session cookie', async () => {
+    const app = createBearerApp()
+    const session = extractCookie(await app.request('/login'))
+
+    // A forged Authorization header on a victim-browser request: the cookies
+    // are what CSRF defends, so the bearer skip must not apply.
+    const post = await app.request('/submit', {
+      method: 'POST',
+      headers: { Cookie: session, Authorization: 'Bearer forged' },
+    })
+
+    expect(post.status).toBe(403)
+  })
+
+  it('verifies as usual when the Bearer request carries any cookie at all', async () => {
+    const app = createBearerApp()
+
+    // Even a cookie this app never reads keeps verification on: the
+    // predicate is the Cookie header, not what loaded from it.
+    const post = await app.request('/submit', {
+      method: 'POST',
+      headers: { Cookie: 'unrelated=1', Authorization: 'Bearer 1|sometoken' },
+    })
+
+    expect(post.status).toBe(403)
+  })
+
+  it('does not fail open when CSRF is mounted before the session middleware', async () => {
+    // A hand-composed chain in the wrong order: the skip decision must not
+    // depend on whether the session has loaded yet.
+    const store = new MemorySessionStore()
+    const setup = new Hono()
+    setup.use(createSessionMiddleware({ store }))
+    setup.use(createCsrfMiddleware())
+    setup.get('/login', (c) => {
+      getSessionFromContext(c)?.set('userId', 1)
+      return c.text('ok')
+    })
+    const session = extractCookie(await setup.request('/login'))
+
+    const app = new Hono()
+    app.use(createCsrfMiddleware())
+    app.use(createSessionMiddleware({ store }))
+    app.post('/submit', (c) => c.text('ok'))
+
+    const post = await app.request('/submit', {
+      method: 'POST',
+      headers: { Cookie: session, Authorization: 'Bearer forged' },
+    })
+
+    expect(post.status).toBe(403)
+  })
+
+  it('skips even when an intermediate middleware writes to the fresh session', async () => {
+    // A locale write between session and CSRF makes the new session persist,
+    // but a client that sent no cookies still holds no ambient authority.
+    const app = new Hono()
+    app.use(createSessionMiddleware({ store: new MemorySessionStore() }))
+    app.use(async (c, next) => {
+      getSessionFromContext(c)?.set('locale', 'en')
+      await next()
+    })
+    app.use(createCsrfMiddleware())
+    app.post('/submit', (c) => c.text('ok'))
+
+    const post = await app.request('/submit', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer 1|sometoken' },
+    })
+
+    expect(post.status).toBe(200)
+  })
+
+  it('does not skip for non-Bearer Authorization schemes', async () => {
+    const app = createBearerApp()
+
+    const post = await app.request('/submit', {
+      method: 'POST',
+      headers: { Authorization: 'Basic dXNlcjpwYXNz' },
+    })
+
+    expect(post.status).toBe(403)
+  })
+
+  it('does not skip for an empty Bearer credential', async () => {
+    const app = createBearerApp()
+
+    const post = await app.request('/submit', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer ' },
+    })
+
+    expect(post.status).toBe(403)
+  })
+})

--- a/rfcs/0016-agent-interface.md
+++ b/rfcs/0016-agent-interface.md
@@ -185,11 +185,21 @@ Tool execution re-enters the application as a real HTTP request:
    body and validated by the route/controller as usual. Passing live Zod to the SDK
    would apply `coerce`/`default`/`transform` twice.
 3. **CSRF**: verification is skipped for requests that carry `Authorization: Bearer`
-   **and no session cookie**. CSRF defends cookie ambient authority; a cookie-less
-   request has none. The cookie condition matters because CSRF middleware runs before
-   auth context and cannot verify the bearer token — with it, a forged Bearer header
-   on a cookie-carrying (victim-browser) request is still verified. Cookie issuance
-   (`settleCookie`) is unchanged. No endpoint-specific CSRF exemption is needed.
+   **and ~~no session cookie~~ no `Cookie` header at all**. **Amended in
+   implementation:** the predicate is the raw `Cookie` header's absence, which is
+   both stricter and more robust than "no session cookie". The session cookie's
+   name is configuration owned by the session middleware mount and invisible to the
+   CSRF middleware, and the tempting refinement — keying on the *loaded* session —
+   is weaker on both edges: mounted before the session middleware it sees no
+   session and fails open for a cookie-carrying victim browser, and an intermediate
+   middleware writing one value into a fresh session turns a genuinely cookie-less
+   client into a 403. Ambient authority requires a cookie, so the header's absence
+   is proof by itself, independent of mount order; dispatch synthesizes cookie-less
+   bearer requests by construction, and a bearer request carrying any cookie simply
+   verifies as before. Bearer detection is the shared `readBearerToken()`, so this
+   rule and token authentication cannot disagree about what a bearer request is.
+   Cookie issuance (`settleCookie`) is unchanged. No endpoint-specific CSRF
+   exemption is needed.
 4. **Response mapping** to MCP results:
    - 2xx JSON → `structuredContent` (when an outputSchema is advertised) + serialized text content
    - 2xx Inertia page JSON → unwrapped to `page.props`, **only** for routes with no


### PR DESCRIPTION
## Summary

RFC 0016 Phase 2 groundwork (PR-2a). Tool execution over App MCP re-enters the application as a real HTTP request authenticated by `Authorization: Bearer` and carrying no cookies — CSRF has no ambient authority to defend there, and without this rule every mutating tool call would 403.

- `createCsrfMiddleware` skips **verification** (never issuance) for requests that carry a Bearer credential and no `Cookie` header at all
- Bearer detection reuses the shared `readBearerToken()`, so this rule and token authentication cannot disagree about what a bearer request is
- The RFC's "no session cookie" is amended in place to "no `Cookie` header": the raw header's absence proves the absence of ambient authority independent of middleware mount order, where a session-based predicate fails open when CSRF is mounted before the session middleware and 403s a cookie-less client as soon as an intermediate middleware writes into the fresh session

## Testing

- 8 new cases in `csrf.test.ts`: skip on cookie-less bearer, issuance unchanged, forged Bearer with session cookie still 403, any unrelated cookie still 403, CSRF-before-session mount order stays closed, intermediate session write keeps the skip, non-Bearer schemes and empty credentials never skip
- Full `packages/server` suite green (2528 tests), root typecheck green

Refs: RFC 0016 §3