### PR TITLE
refactor(server): centralize the auth-context lookup in auth/

### DIFF
--- a/packages/server/src/auth/context.ts
+++ b/packages/server/src/auth/context.ts
@@ -12,12 +12,15 @@ export const AUTH_CONTEXT_KEY = 'guren:auth'
 /**
  * Read the framework auth context off a request context.
  *
- * Duck-typed on purpose: `ctx.get` returns arbitrary values for unknown keys —
- * test doubles and exotic contexts included — so a bare cast hands out values
- * that are not auth contexts at all. The `user` probe is a cheap sanity check,
- * not validation: an object shaped like an auth context is taken at its word.
+ * The lookup and its cast, in one place — nothing more. `ctx.get` returns
+ * arbitrary values for unknown keys (test doubles and exotic contexts
+ * included), so the cast is a claim, not a check. A caller whose behavior
+ * turns on the value really being an auth context probes the member it is
+ * about to call; `Gate.resolveUser` does exactly that, because a stray value
+ * there decides whether the legacy `ctx.get('user')` fallback runs. Probing
+ * here instead would reject contexts that `requireAuthenticated` and
+ * `requireGuest` can use — they only ever read `check()` / `guest()`.
  */
 export function getAuthContext(ctx: { get: (key: string) => unknown }): AuthContext | undefined {
-  const auth = ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
-  return auth && typeof auth.user === 'function' ? auth : undefined
+  return ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
 }

--- a/packages/server/src/auth/context.ts
+++ b/packages/server/src/auth/context.ts
@@ -1,0 +1,23 @@
+import type { AuthContext } from './types'
+
+/**
+ * Context key the framework auth context is stored under.
+ *
+ * Lives here rather than in `http/middleware/auth` so that `auth/` modules can
+ * import it without reaching back into the middleware layer. The middleware
+ * re-exports it, and it stays a public root export.
+ */
+export const AUTH_CONTEXT_KEY = 'guren:auth'
+
+/**
+ * Read the framework auth context off a request context.
+ *
+ * Duck-typed on purpose: `ctx.get` returns arbitrary values for unknown keys —
+ * test doubles and exotic contexts included — so a bare cast hands out values
+ * that are not auth contexts at all. The `user` probe is a cheap sanity check,
+ * not validation: an object shaped like an auth context is taken at its word.
+ */
+export function getAuthContext(ctx: { get: (key: string) => unknown }): AuthContext | undefined {
+  const auth = ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
+  return auth && typeof auth.user === 'function' ? auth : undefined
+}

--- a/packages/server/src/auth/email-verification.ts
+++ b/packages/server/src/auth/email-verification.ts
@@ -1,3 +1,4 @@
+import { getAuthContext } from './context'
 import { generateId, buildTokenUrl, parseTokenUrl } from './utils'
 import { MessageSigner } from '../encryption/MessageSigner'
 import { deriveAppKeyring, getAppKeyringFromEnv } from '../encryption/app-key'
@@ -364,8 +365,8 @@ export function requireVerifiedEmail(options: {
 
   return async (ctx: { get: <T = unknown>(key: string) => T; redirect: (url: string) => Response }, next: () => Promise<void>) => {
     const getUser = options.getUser ?? (async (c: { get: <T = unknown>(key: string) => T }) => {
-      const auth = c.get<{ user?: () => Promise<{ emailVerifiedAt?: Date | null } | null> } | undefined>('guren:auth')
-      return auth?.user?.() ?? null
+      const auth = getAuthContext(c)
+      return (await auth?.user<{ emailVerifiedAt?: Date | null }>()) ?? null
     })
 
     const user = await getUser(ctx)

--- a/packages/server/src/authorization/Gate.ts
+++ b/packages/server/src/authorization/Gate.ts
@@ -205,8 +205,11 @@ export class Gate {
     // carries a manually-set user), letting authorizeMiddleware pass where
     // requireAuthenticated denies (RFC 0016). The legacy fallback survives
     // only for requests with no auth context at all.
+    // Duck-typed on purpose: ctx.get returns arbitrary values for unknown
+    // keys, and here that answer decides whether the fallback below runs at
+    // all. getAuthContext deliberately does not probe — see its contract.
     const auth = getAuthContext(ctx)
-    if (auth) {
+    if (auth && typeof auth.user === 'function') {
       return ((await auth.user()) as AuthUser | null) ?? null
     }
 

--- a/packages/server/src/authorization/Gate.ts
+++ b/packages/server/src/authorization/Gate.ts
@@ -11,8 +11,7 @@ import type {
   ResponseBuilder,
 } from './types'
 import { AuthorizationException, HttpException } from '../errors'
-import { AUTH_CONTEXT_KEY } from '../http/middleware/auth'
-import type { AuthContext } from '../auth/types'
+import { getAuthContext } from '../auth/context'
 
 /**
  * Response builder for authorization checks.
@@ -206,10 +205,8 @@ export class Gate {
     // carries a manually-set user), letting authorizeMiddleware pass where
     // requireAuthenticated denies (RFC 0016). The legacy fallback survives
     // only for requests with no auth context at all.
-    // Duck-typed on purpose: test doubles and exotic contexts may return
-    // arbitrary values for unknown keys.
-    const auth = ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
-    if (auth && typeof auth.user === 'function') {
+    const auth = getAuthContext(ctx)
+    if (auth) {
       return ((await auth.user()) as AuthUser | null) ?? null
     }
 

--- a/packages/server/src/http/FormRequest.ts
+++ b/packages/server/src/http/FormRequest.ts
@@ -2,9 +2,8 @@ import type { Context } from 'hono'
 import type { ValidationRule } from './validation/types'
 import { Validator } from './validation/Validator'
 import { AuthorizationException } from '../errors/exceptions/AuthorizationException'
-import { AUTH_CONTEXT_KEY } from './middleware/auth'
+import { getAuthContext } from '../auth/context'
 import { parseRequestPayload } from './request'
-import type { AuthContext } from '../auth'
 
 /**
  * Base class for form request validation.
@@ -83,7 +82,7 @@ export abstract class FormRequest<T = Record<string, unknown>> {
    * true, because an unawaited call is a pending promise.
    */
   protected async user<TUser = unknown>(): Promise<TUser | null> {
-    const auth = this.ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
+    const auth = getAuthContext(this.ctx)
     return (await auth?.user<TUser>()) ?? null
   }
 

--- a/packages/server/src/http/middleware/auth.ts
+++ b/packages/server/src/http/middleware/auth.ts
@@ -1,5 +1,6 @@
 import type { Context, MiddlewareHandler } from 'hono'
 import type { Authenticatable, AuthContext } from '../../auth/types'
+import { AUTH_CONTEXT_KEY, getAuthContext } from '../../auth/context'
 import { jsonResponse } from './index'
 import { stampCapabilities } from './capabilities'
 export type { AuthContext } from '../../auth/types'
@@ -10,7 +11,6 @@ export interface RequireAuthOptions {
   responseFactory?: () => Response
 }
 
-const AUTH_CONTEXT_KEY = 'guren:auth'
 const TESTING_USER_HEADER = 'x-testing-user'
 
 function resolveTestingUser(ctx: Context): Authenticatable | null {
@@ -70,15 +70,11 @@ export function attachAuthContext(contextFactory: (ctx: Context) => AuthContext)
   }
 }
 
-function resolveAuth(ctx: { get: (key: string) => unknown }): AuthContext | undefined {
-  return ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
-}
-
 export function requireAuthenticated(options: RequireAuthOptions = {}): MiddlewareHandler {
   const { redirectTo, status = 401, responseFactory } = options
 
   return stampCapabilities(async (ctx, next) => {
-    const auth = resolveAuth(ctx)
+    const auth = getAuthContext(ctx)
 
     if (!auth) {
       throw new Error('Auth context has not been attached. Did you register the auth middleware?')
@@ -104,7 +100,7 @@ export function requireGuest(options: RequireAuthOptions = {}): MiddlewareHandle
   const { redirectTo, status = 403, responseFactory } = options
 
   return stampCapabilities(async (ctx, next) => {
-    const auth = resolveAuth(ctx)
+    const auth = getAuthContext(ctx)
 
     if (!auth) {
       throw new Error('Auth context has not been attached. Did you register the auth middleware?')
@@ -126,4 +122,4 @@ export function requireGuest(options: RequireAuthOptions = {}): MiddlewareHandle
   }, { authentication: { mode: 'guest-only' } })
 }
 
-export { AUTH_CONTEXT_KEY }
+export { AUTH_CONTEXT_KEY, getAuthContext }

--- a/packages/server/src/mvc/Controller.ts
+++ b/packages/server/src/mvc/Controller.ts
@@ -3,10 +3,10 @@ import type { FC } from 'hono/jsx'
 import { renderDocument, type ViewOptions } from './view'
 import { inertia, type InertiaOptions } from './inertia/InertiaEngine'
 import { resolveSharedInertiaProps, type ResolvedSharedInertiaProps } from './inertia/shared'
-import { AUTH_CONTEXT_KEY } from '../http/middleware/auth'
 import { getRequestLocale, getRequestTranslator, type TranslatorBinding } from '../http/middleware/detect-locale'
 import { tryGetI18n, type I18nManager, type RegisteredTranslationKey, type ReplacementValues } from '../i18n'
 import { flattenRequestQueries, parseRequestPayload } from '../http/request'
+import { getAuthContext } from '../auth/context'
 import type { AuthContext } from '../auth/types'
 import type { ServiceBindings } from '../container/bindings'
 import type { ContainerLike } from '../container/types'
@@ -229,7 +229,7 @@ export class Controller {
   }
 
   protected get auth(): AuthContext {
-    const auth = this.ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
+    const auth = getAuthContext(this.ctx)
     if (!auth) {
       throw new Error('Controller auth helper requires the auth middleware. Make sure AuthServiceProvider is registered.')
     }
@@ -305,7 +305,7 @@ export class Controller {
   }
 
   private async gateUser(): Promise<AuthUser | null> {
-    const auth = this.ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
+    const auth = getAuthContext(this.ctx)
     if (!auth) {
       return null
     }

--- a/packages/server/tests/http/middleware/auth.test.ts
+++ b/packages/server/tests/http/middleware/auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import { Hono } from 'hono'
 import {
+  AUTH_CONTEXT_KEY,
   attachAuthContext,
   requireAuthenticated,
   requireGuest,
@@ -15,7 +16,7 @@ describe('attachAuthContext', () => {
 
     app.use(attachAuthContext(() => mockAuth))
     app.get('/test', async (c) => {
-      const auth = (c as unknown as { get: (key: string) => AuthContext }).get('guren:auth')
+      const auth = (c as unknown as { get: (key: string) => AuthContext }).get(AUTH_CONTEXT_KEY)
       const user = await auth.user()
       return c.json({ user })
     })

--- a/packages/server/tests/http/middleware/auth.test.ts
+++ b/packages/server/tests/http/middleware/auth.test.ts
@@ -30,6 +30,25 @@ describe('attachAuthContext', () => {
 })
 
 describe('requireAuthenticated', () => {
+  it('accepts a context that implements only the method it calls', async () => {
+    // The guards read check()/guest() and nothing else, so a hand-rolled
+    // minimal context has to keep working. This pins getAuthContext's
+    // contract: it does not probe for members its callers never touch —
+    // Gate does that at its own call site, where a stray value decides
+    // whether the legacy fallback runs.
+    const app = new Hono()
+    const partialAuth = { check: async () => true } as unknown as AuthContext
+
+    app.use(attachAuthContext(() => partialAuth))
+    app.use('/protected/*', requireAuthenticated())
+    app.get('/protected/resource', (c) => c.text('secret data'))
+
+    const res = await app.request('/protected/resource')
+
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('secret data')
+  })
+
   it('allows authenticated users to proceed', async () => {
     const app = new Hono()
     const mockAuth = createMockAuthContext({ isAuthenticated: true })


### PR DESCRIPTION
## Summary

The `guren:auth` context key was shared but the lookup was not. Six sites each repeated `ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined`, and `auth/email-verification.ts` could not import the constant at all — it lived in `http/middleware/auth`, which `auth/` modules should not reach back into — so it read the raw string `'guren:auth'` with its own structural type.

`AUTH_CONTEXT_KEY` and a new `getAuthContext()` accessor now live in `auth/context.ts`, the concept's home. Every site goes through the accessor. The middleware re-exports both, so `AUTH_CONTEXT_KEY` stays a public root export and `getAuthContext` stays internal.

The duck-type probe (`typeof auth.user === 'function'`) stays at **Gate's call site**, not in the accessor. Only Gate's behavior turns on telling an auth context from an arbitrary value: a stray value there decides whether the legacy `ctx.get('user')` fallback runs. `requireAuthenticated` and `requireGuest` read `check()` / `guest()` and nothing else, so probing for `user` in the accessor would reject a hand-rolled minimal context those guards can use — turning a working request into a 500 whose message ("Auth context has not been attached") misdescribes the cause. The accessor's contract documents this: the cast is a claim, not a check, and a caller whose behavior depends on the value really being an auth context probes the member it is about to call.

The second commit is that correction; the first commit had the probe centralized.

## Scope

`server` only.

- New: `packages/server/src/auth/context.ts`
- Converted: `mvc/Controller.ts` (×2), `http/FormRequest.ts`, `http/middleware/auth.ts` (private `resolveAuth` folded in), `authorization/Gate.ts`, `auth/email-verification.ts` (the raw-string site)
- Tests: `tests/http/middleware/auth.test.ts`

Deliberately **not** touched: the two `AuthProvider` templates (`packages/cli/templates/scaffold/auth/`, `packages/create-app/templates/blog/`), `examples/blog/config/inertia.ts`, and the docs samples. Those resolve `@guren/*` from npm, so they stay on the already-published `AUTH_CONTEXT_KEY`; pointing them at an unreleased `getAuthContext` would ship templates that only build after the next release and turn `smoke:starter:npm` red.

## Risk Assessment

No public API moved. `AUTH_CONTEXT_KEY` is still exported from the root (`dist/index.d.ts` verified), and `getAuthContext` appears in no public export path — not the root, not the `./auth` subpath, and `./http/middleware/auth` is not in the `exports` map. No changeset: nothing users can reach changed, and CI has no `changeset status` gate.

Behavior is unchanged at every site. `email-verification`'s old `auth?.user?.() ?? null` and the new `(await auth?.user<…>()) ?? null` are equivalent — the caller already awaited. `requireVerifiedEmail`'s public `options.getUser` signature is untouched; only the default implementation's body changed.

No new module cycle: `auth/context.ts` imports `./types` type-only, so it is a leaf at runtime. `FormRequest` and `Gate` in fact lose their edge to `http/middleware/auth`.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` — exit 0; `5417 pass / 0 fail` (bun) plus 29/15/16 vitest files green

Both halves of the probe decision are pinned, and each pin was checked by mutation:

- moving the probe back into the accessor fails the new `requireAuthenticated > accepts a context that implements only the method it calls`
- dropping it from Gate fails the existing `Gate.resolveUser > should ignore a non-auth-context value stored under the auth key`

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation. (No user-facing docs affected — the accessor is internal, and the docs samples correctly stay on the published `AUTH_CONTEXT_KEY`.)