### PR TITLE
feat(server): add @guren/plugin-mcp, the App MCP endpoint

### DIFF
--- a/.changeset/plugin-mcp-app-endpoint.md
+++ b/.changeset/plugin-mcp-app-endpoint.md
@@ -1,0 +1,8 @@
+---
+'@guren/plugin-mcp': minor
+'@guren/server': minor
+---
+
+Add `@guren/plugin-mcp`: the production App MCP endpoint (RFC 0016 §7). `mcpPlugin()` mounts a bearer-authenticated Model Context Protocol endpoint (default `/mcp`) serving the tools the app's `.agent()` routes derive. Every call re-enters the application through `app.fetch` as a real HTTP request — validation, policies, and middleware run exactly once, in the app — with `env` and execution context forwarded for Workers bindings. The adapter enforces what must precede HTTP: bearer verification against the app's `ApiTokenStore`, token scopes (a token's catalog lists only what it can call; the `ApiToken` default `['*']` grants nothing), fail-closed refusal of `approval: 'required'` tools until the approval queue ships, and per-token rate limits with a stricter write budget. Each refusal emits `AgentToolDenied` and each execution `AgentToolInvoked`, arguments redacted.
+
+`@guren/server` grows the adapter-facing surface: `DerivedAgentTool.inputSources` and `inputBodyNested` record how a flat tool call maps back onto path, query, and body (the merge's inverse, so a POST route's `query` keys land where `validateQuery` reads them), `AuthManager.getApiTokenStore()` exposes the store `useTokens()` configured, and `readBearerToken` joins the root exports.

--- a/bun.lock
+++ b/bun.lock
@@ -76,9 +76,9 @@
       },
       "dependencies": {
         "@babel/parser": "^7.24.7",
-        "@guren/core": "^1.8.0",
-        "@guren/orm": "^2.6.0",
-        "@guren/server": "^2.10.0",
+        "@guren/core": "^1.11.0",
+        "@guren/orm": "^2.6.1",
+        "@guren/server": "^2.13.0",
         "citty": "^0.1.6",
         "consola": "^3.4.2",
       },
@@ -108,9 +108,9 @@
         "guren": "./dist/bin.js",
       },
       "dependencies": {
-        "@guren/cli": "^2.7.0",
-        "@guren/orm": "^2.6.0",
-        "@guren/server": "^2.9.0",
+        "@guren/cli": "^2.12.0",
+        "@guren/orm": "^2.6.1",
+        "@guren/server": "^2.13.0",
       },
       "devDependencies": {
         "@types/node": "^20.14.10",
@@ -250,6 +250,21 @@
       "optionalPeers": [
         "shiki",
       ],
+    },
+    "packages/plugin-mcp": {
+      "name": "@guren/plugin-mcp",
+      "version": "0.1.0",
+      "dependencies": {
+        "@guren/core": "^1.11.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.10",
+        "hono": "^4.11.7",
+        "tsdown": "^0.22.14",
+        "typescript": "^7.0.2",
+        "zod": "^4",
+      },
     },
     "packages/plugin-vercel": {
       "name": "@guren/plugin-vercel",
@@ -575,6 +590,8 @@
     "@guren/plugin-lambda": ["@guren/plugin-lambda@workspace:packages/plugin-lambda"],
 
     "@guren/plugin-markdown": ["@guren/plugin-markdown@workspace:packages/plugin-markdown"],
+
+    "@guren/plugin-mcp": ["@guren/plugin-mcp@workspace:packages/plugin-mcp"],
 
     "@guren/plugin-vercel": ["@guren/plugin-vercel@workspace:packages/plugin-vercel"],
 

--- a/packages/plugin-mcp/package.json
+++ b/packages/plugin-mcp/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@guren/plugin-mcp",
+  "version": "0.1.0",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gurenjs/guren",
+    "directory": "packages/plugin-mcp"
+  },
+  "homepage": "https://github.com/gurenjs/guren#readme",
+  "bugs": {
+    "url": "https://github.com/gurenjs/guren/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gurenPlugin": {
+    "compatibility": ">=1.11.0 <2.0.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "bun --bun tsdown",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@guren/core": "^1.11.0",
+    "@modelcontextprotocol/sdk": "^1.30.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "hono": "^4.11.7",
+    "tsdown": "^0.22.14",
+    "typescript": "^7.0.2",
+    "zod": "^4"
+  }
+}

--- a/packages/plugin-mcp/src/dispatch.test.ts
+++ b/packages/plugin-mcp/src/dispatch.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from 'bun:test'
 import { z } from 'zod'
 import { Router, deriveAgentTools, type DerivedAgentTool } from '@guren/core'
 
-import { buildToolRequest, mapToolResponse } from './dispatch'
+import { advertisesStructuredOutput, buildToolRequest, mapToolResponse } from './dispatch'
 
 function toolFor(register: (router: Router) => void, name: string): DerivedAgentTool {
   const router = new Router()
@@ -196,5 +196,119 @@ describe('mapToolResponse', () => {
     })
     const outcome = await mapToolResponse(plainTool(), response)
     expect(outcome.content[0]!.text).toBe('<html>hi</html>')
+  })
+})
+
+describe('buildToolRequest security and collision fixes', () => {
+  test('should reject a dot-segment path value instead of substituting it', () => {
+    const tool = toolFor((router) => {
+      router.get('/files/:name/meta', handler).name('files.meta').agent({})
+    }, 'files.meta')
+
+    expect(buildToolRequest(tool, { name: '..' })).toEqual({ invalidPath: ['name'] })
+    expect(buildToolRequest(tool, { name: '.' })).toEqual({ invalidPath: ['name'] })
+    // A dot inside a longer value is fine — it is not a whole segment.
+    const ok = buildToolRequest(tool, { name: 'a.b' })
+    expect('request' in ok).toBe(true)
+  })
+
+  test('should forward the inbound origin into the synthesized URL', () => {
+    const tool = toolFor((router) => {
+      router.get('/posts', handler).name('posts.index').agent({})
+    }, 'posts.index')
+
+    const built = buildToolRequest(tool, {}, { origin: 'https://app.example.com' })
+    const request = ('request' in built ? built : undefined)!.request
+    expect(new URL(request.url).origin).toBe('https://app.example.com')
+  })
+
+  test('should keep a body-owned collision key in the body while filling the path', async () => {
+    const tool = toolFor((router) => {
+      router
+        .post(
+          '/posts/:id',
+          { body: z.object({ id: z.coerce.number(), title: z.string() }) },
+          handler,
+        )
+        .name('posts.update')
+        .agent({})
+    }, 'posts.update')
+
+    // The derivation resolves `id` to the body (it merges last), so the value
+    // fills the URL AND rides in the body the route validates.
+    const built = buildToolRequest(tool, { id: 7, title: 'T' })
+    const request = ('request' in built ? built : undefined)!.request
+    expect(new URL(request.url).pathname).toBe('/posts/7')
+    expect(await request.json()).toEqual({ id: 7, title: 'T' })
+  })
+
+  test('should keep a params-owned path key out of the body', async () => {
+    const tool = toolFor((router) => {
+      router
+        .post(
+          '/posts/:id',
+          { params: z.object({ id: z.coerce.number() }), body: z.object({ title: z.string() }) },
+          handler,
+        )
+        .name('posts.update')
+        .agent({})
+    }, 'posts.update')
+
+    const built = buildToolRequest(tool, { id: 7, title: 'T' })
+    const request = ('request' in built ? built : undefined)!.request
+    expect(new URL(request.url).pathname).toBe('/posts/7')
+    expect(await request.json()).toEqual({ title: 'T' })
+  })
+})
+
+describe('mapToolResponse structured-output reconciliation', () => {
+  function structuredTool(): DerivedAgentTool {
+    return toolFor((router) => {
+      router
+        .post('/posts', { output: z.object({ id: z.number() }) }, () => ({ id: 1 }))
+        .name('posts.store')
+        .agent({})
+    }, 'posts.store')
+  }
+
+  function arrayOutputTool(): DerivedAgentTool {
+    return toolFor((router) => {
+      router
+        .get('/nums', { output: z.array(z.number()) }, () => [1, 2])
+        .name('nums.index')
+        .agent({})
+    }, 'nums.index')
+  }
+
+  test('should not advertise a non-object output schema as structured', () => {
+    expect(advertisesStructuredOutput(arrayOutputTool())).toBe(false)
+    expect(advertisesStructuredOutput(structuredTool())).toBe(true)
+  })
+
+  test('should error a 204 for a tool that advertises an object output schema', async () => {
+    const outcome = await mapToolResponse(structuredTool(), new Response(null, { status: 204 }))
+    expect(outcome.isError).toBe(true)
+    expect(outcome.content[0]!.text).toContain('output schema')
+  })
+
+  test('should error a non-object success body for a structured tool', async () => {
+    const response = new Response(JSON.stringify([1, 2]), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const outcome = await mapToolResponse(structuredTool(), response)
+    expect(outcome.isError).toBe(true)
+    expect(outcome.content[0]!.text).toContain('JSON array')
+  })
+
+  test('should pass a non-object output tool result through as text', async () => {
+    const response = new Response(JSON.stringify([1, 2]), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const outcome = await mapToolResponse(arrayOutputTool(), response)
+    expect(outcome.isError).toBeUndefined()
+    expect(outcome.structuredContent).toBeUndefined()
+    expect(JSON.parse(outcome.content[0]!.text)).toEqual([1, 2])
   })
 })

--- a/packages/plugin-mcp/src/dispatch.test.ts
+++ b/packages/plugin-mcp/src/dispatch.test.ts
@@ -1,0 +1,200 @@
+import { describe, test, expect } from 'bun:test'
+import { z } from 'zod'
+import { Router, deriveAgentTools, type DerivedAgentTool } from '@guren/core'
+
+import { buildToolRequest, mapToolResponse } from './dispatch'
+
+function toolFor(register: (router: Router) => void, name: string): DerivedAgentTool {
+  const router = new Router()
+  register(router)
+  const { tools } = deriveAgentTools(router.definitions())
+  const tool = tools.find((candidate) => candidate.toolName === name)
+  expect(tool).toBeDefined()
+  return tool!
+}
+
+const handler = () => new Response('ok')
+
+describe('buildToolRequest', () => {
+  test('should split arguments along their contract sources', async () => {
+    const tool = toolFor((router) => {
+      router
+        .post(
+          '/posts/:id/comments',
+          {
+            params: z.object({ id: z.coerce.number() }),
+            query: z.object({ notify: z.coerce.boolean().optional() }),
+            body: z.object({ text: z.string() }),
+          },
+          handler,
+        )
+        .name('comments.store')
+        .agent({})
+    }, 'comments.store')
+
+    const built = buildToolRequest(tool, { id: 7, notify: true, text: 'hello' })
+    expect('request' in built).toBe(true)
+    const request = ('request' in built ? built : undefined)!.request
+
+    const url = new URL(request.url)
+    expect(url.pathname).toBe('/posts/7/comments')
+    expect(url.searchParams.get('notify')).toBe('true')
+    expect(request.method).toBe('POST')
+    expect(request.headers.get('Content-Type')).toBe('application/json')
+    expect(request.headers.get('Accept')).toBe('application/json')
+    expect(await request.json()).toEqual({ text: 'hello' })
+  })
+
+  test('should send everything as query on a GET', () => {
+    const tool = toolFor((router) => {
+      router
+        .get('/posts', { query: z.object({ page: z.coerce.number().optional() }) }, handler)
+        .name('posts.index')
+        .agent({})
+    }, 'posts.index')
+
+    const built = buildToolRequest(tool, { page: 2, stray: 'x' })
+    const request = ('request' in built ? built : undefined)!.request
+    const url = new URL(request.url)
+    expect(url.searchParams.get('page')).toBe('2')
+    expect(url.searchParams.get('stray')).toBe('x')
+    expect(request.body).toBeNull()
+  })
+
+  test('should forward an undeclared key in the body of a body-carrying method', async () => {
+    const tool = toolFor((router) => {
+      router
+        .post('/posts', { body: z.object({ title: z.string() }) }, handler)
+        .name('posts.store')
+        .agent({})
+    }, 'posts.store')
+
+    const built = buildToolRequest(tool, { title: 'T', unexpected: 1 })
+    const request = ('request' in built ? built : undefined)!.request
+    expect(await request.json()).toEqual({ title: 'T', unexpected: 1 })
+  })
+
+  test('should send a nested body verbatim', async () => {
+    const tool = toolFor((router) => {
+      router.post('/bulk', { body: z.array(z.number()) }, handler).name('bulk.store').agent({})
+    }, 'bulk.store')
+
+    const built = buildToolRequest(tool, { body: [1, 2, 3] })
+    const request = ('request' in built ? built : undefined)!.request
+    expect(await request.json()).toEqual([1, 2, 3])
+  })
+
+  test('should report missing path parameters instead of building a URL', () => {
+    const tool = toolFor((router) => {
+      router.get('/posts/:id', handler).name('posts.show').agent({})
+    }, 'posts.show')
+
+    const built = buildToolRequest(tool, {})
+    expect(built).toEqual({ missing: ['id'] })
+  })
+
+  test('should URL-encode substituted path values', () => {
+    const tool = toolFor((router) => {
+      router.get('/files/:name', handler).name('files.show').agent({})
+    }, 'files.show')
+
+    const built = buildToolRequest(tool, { name: 'a b/c' })
+    const request = ('request' in built ? built : undefined)!.request
+    expect(new URL(request.url).pathname).toBe('/files/a%20b%2Fc')
+  })
+
+  test('should forward the Authorization header verbatim', () => {
+    const tool = toolFor((router) => {
+      router.get('/posts', handler).name('posts.index').agent({})
+    }, 'posts.index')
+
+    const built = buildToolRequest(tool, {}, { authorization: 'Bearer 1|tok' })
+    const request = ('request' in built ? built : undefined)!.request
+    expect(request.headers.get('Authorization')).toBe('Bearer 1|tok')
+  })
+
+  test('should keep a __proto__ argument as an own body property', async () => {
+    const tool = toolFor((router) => {
+      router
+        .post('/odd', { body: z.object({ ok: z.boolean() }) }, handler)
+        .name('odd.store')
+        .agent({})
+    }, 'odd.store')
+
+    const built = buildToolRequest(tool, JSON.parse('{"ok": true, "__proto__": {"x": 1}}'))
+    const request = ('request' in built ? built : undefined)!.request
+    const body = (await request.json()) as Record<string, unknown>
+    expect(body.ok).toBe(true)
+    expect(Object.hasOwn(body, '__proto__')).toBe(true)
+    expect(Object.getPrototypeOf(body)).toBe(Object.prototype)
+  })
+})
+
+describe('mapToolResponse', () => {
+  const jsonResponse = (payload: unknown, init: ResponseInit = {}) =>
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+      ...init,
+    })
+
+  function outputTool(): DerivedAgentTool {
+    return toolFor((router) => {
+      router
+        // An output contract's handler returns the data the schema validates,
+        // not a Response.
+        .get('/posts', { output: z.object({ posts: z.array(z.unknown()) }) }, () => ({ posts: [] }))
+        .name('posts.index')
+        .agent({})
+    }, 'posts.index')
+  }
+
+  function plainTool(): DerivedAgentTool {
+    return toolFor((router) => {
+      router.get('/posts', handler).name('posts.index').agent({})
+    }, 'posts.index')
+  }
+
+  test('should attach structuredContent when the tool advertises an output schema', async () => {
+    const outcome = await mapToolResponse(outputTool(), jsonResponse({ posts: [] }))
+    expect(outcome.structuredContent).toEqual({ posts: [] })
+    expect(outcome.isError).toBeUndefined()
+    expect(outcome.status).toBe(200)
+  })
+
+  test('should unwrap Inertia page props for a tool with no output schema', async () => {
+    const page = { component: 'posts/Index', props: { posts: [1] }, url: '/posts', version: 'v' }
+    const response = new Response(JSON.stringify(page), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', 'X-Inertia': 'true' },
+    })
+
+    const outcome = await mapToolResponse(plainTool(), response)
+    expect(JSON.parse(outcome.content[0]!.text)).toEqual({ posts: [1] })
+  })
+
+  test('should describe a redirect without treating it as an error', async () => {
+    const response = new Response(null, { status: 302, headers: { Location: '/posts/1' } })
+    const outcome = await mapToolResponse(plainTool(), response)
+    expect(outcome.isError).toBeUndefined()
+    expect(outcome.content[0]!.text).toContain('302')
+    expect(outcome.content[0]!.text).toContain('/posts/1')
+  })
+
+  test('should mark a 422 as an error carrying the validation body', async () => {
+    const body = { message: 'Validation failed', errors: { title: ['required'] } }
+    const outcome = await mapToolResponse(plainTool(), jsonResponse(body, { status: 422 }))
+    expect(outcome.isError).toBe(true)
+    expect(outcome.content[0]!.text).toContain('Validation failed')
+    expect(outcome.status).toBe(422)
+  })
+
+  test('should pass through non-JSON as text', async () => {
+    const response = new Response('<html>hi</html>', {
+      status: 200,
+      headers: { 'Content-Type': 'text/html' },
+    })
+    const outcome = await mapToolResponse(plainTool(), response)
+    expect(outcome.content[0]!.text).toBe('<html>hi</html>')
+  })
+})

--- a/packages/plugin-mcp/src/dispatch.ts
+++ b/packages/plugin-mcp/src/dispatch.ts
@@ -35,6 +35,16 @@ export type BuiltToolRequest =
   | { request: Request }
   /** Path parameters the call did not supply — the URL cannot be built. */
   | { missing: string[] }
+  /**
+   * Path parameter values that are URL dot-segments (`.` / `..`). Rejected,
+   * never substituted: `encodeURIComponent` leaves a dot untouched, and the
+   * `Request` URL parser then collapses the segment — so `{ name: '..' }` on
+   * `/files/:name/meta` would reach `/meta`, a route the scope check never
+   * saw. The only ASCII segments the WHATWG parser normalizes are `.` and
+   * `..`; every other separator (`/`, `\`) survives `encodeURIComponent`
+   * percent-encoded, so this is the complete set.
+   */
+  | { invalidPath: string[] }
 
 /**
  * Rebuild the HTTP request a tool call describes.
@@ -58,7 +68,12 @@ export function buildToolRequest(
 ): BuiltToolRequest {
   const origin = options.origin ?? 'http://localhost'
   const missing: string[] = []
-  const consumed = new Set<string>()
+  const invalidPath: string[] = []
+  // Path parameters consumed *exclusively* by the URL. A name the merge
+  // resolved to `query`/`body` (a collision the derivation warns about) fills
+  // the path — the URL needs it — and still flows to its declared sink below,
+  // so it is not added here.
+  const pathOnly = new Set<string>()
 
   // The one path lexer (PATH_PARAM_PATTERN) does the substitution, so the
   // names replaced here are exactly the names the derivation advertised —
@@ -71,12 +86,26 @@ export function buildToolRequest(
         missing.push(name)
         return `${lead}:${name}`
       }
-      consumed.add(name)
-      return `${lead}${encodeURIComponent(String(value))}`
+      const encoded = String(value)
+      if (encoded === '.' || encoded === '..') {
+        invalidPath.push(name)
+        return `${lead}:${name}`
+      }
+      // A name the merge assigned to query/body still substitutes into the
+      // URL, but keeps flowing to that sink — so a collision does not drop
+      // the argument from the body the route validates.
+      const source = Object.hasOwn(tool.inputSources, name) ? tool.inputSources[name] : undefined
+      if (source === undefined || source === 'params' || source === 'path') {
+        pathOnly.add(name)
+      }
+      return `${lead}${encodeURIComponent(encoded)}`
     },
   )
   if (missing.length > 0) {
     return { missing }
+  }
+  if (invalidPath.length > 0) {
+    return { invalidPath }
   }
 
   const method = tool.method
@@ -85,7 +114,7 @@ export function buildToolRequest(
   const query = new URLSearchParams()
   const bodyEntries: Array<[string, unknown]> = []
   for (const [key, value] of Object.entries(args)) {
-    if (consumed.has(key) || value === undefined) continue
+    if (pathOnly.has(key) || value === undefined) continue
     const source = Object.hasOwn(tool.inputSources, key) ? tool.inputSources[key] : undefined
     // Query-bound: everything on a bodyless method; declared `query` keys; a
     // `params`/`path` key the path never declared (a contract defect
@@ -180,10 +209,22 @@ export interface ToolCallOutcome {
 }
 
 /**
+ * Whether the tool advertises an object output schema — the only kind MCP
+ * lists, and therefore the only kind that obliges a success result to carry
+ * `structuredContent`. A route whose `output` is an array or primitive is not
+ * advertised as structured (MCP `outputSchema` must be an object), so its
+ * results ride as text. `describeTool` and `mapToolResponse` must agree on
+ * this exact predicate, or one advertises a schema the other cannot satisfy.
+ */
+export function advertisesStructuredOutput(tool: DerivedAgentTool): boolean {
+  return tool.outputSchema?.type === 'object'
+}
+
+/**
  * Map the application's response onto an MCP tool result (RFC 0016 §3.4).
  *
- * - 2xx JSON → serialized text, plus `structuredContent` when the tool
- *   advertises an `outputSchema` (the one shape the route validated).
+ * - 2xx JSON object → serialized text, plus `structuredContent` when the tool
+ *   advertises an object `outputSchema` (the one shape the route validated).
  * - 2xx Inertia page JSON → unwrapped to `page.props`, only for a tool with
  *   no `outputSchema` — unwrap and schema are mutually exclusive by
  *   derivation, so the advertised shape can never disagree with the result.
@@ -192,16 +233,26 @@ export interface ToolCallOutcome {
  *   a 422's `{ message, errors }` is an application-level failure the agent
  *   should read, not a protocol error.
  * - non-JSON → capped text.
+ *
+ * One MCP invariant overrides the table: a *non-error* result for a tool that
+ * advertises an object `outputSchema` must carry `structuredContent`, or the
+ * SDK client rejects it after the route has already run. A success response
+ * that yields no object to put there (204, 3xx, non-JSON, a non-object body)
+ * contradicts the route's own declared output, so it becomes an `isError`
+ * result naming the mismatch — which the SDK exempts from the rule — rather
+ * than a protocol fault the agent cannot interpret.
  */
 export async function mapToolResponse(
   tool: DerivedAgentTool,
   response: Response,
 ): Promise<ToolCallOutcome> {
   const status = response.status
+  const structured = advertisesStructuredOutput(tool)
 
   if (status === 204 || (status >= 300 && status < 400)) {
     const location = response.headers.get('Location')
     const text = location ? `HTTP ${status} (Location: ${location})` : `HTTP ${status}`
+    if (structured) return inconsistentOutput(tool, text, status)
     return { content: [{ type: 'text', text }], status }
   }
 
@@ -220,18 +271,45 @@ export async function mapToolResponse(
     const text = raw.length > TEXT_RESPONSE_CAP
       ? `${raw.slice(0, TEXT_RESPONSE_CAP)}… [truncated ${raw.length - TEXT_RESPONSE_CAP} characters]`
       : raw
+    if (structured) return inconsistentOutput(tool, `a non-JSON body (${text.slice(0, 200)})`, status)
     return { content: [{ type: 'text', text }], status }
   }
 
   const payload = unwrapInertiaProps(tool, response, parsed)
+
+  if (structured && !isRecord(payload)) {
+    return inconsistentOutput(tool, `a ${Array.isArray(payload) ? 'JSON array' : typeof payload} body`, status)
+  }
+
   const outcome: ToolCallOutcome = {
     content: [{ type: 'text', text: JSON.stringify(payload) }],
     status,
   }
-  if (tool.outputSchema && isRecord(payload)) {
+  if (structured && isRecord(payload)) {
     outcome.structuredContent = payload
   }
   return outcome
+}
+
+/**
+ * A success response that cannot satisfy the tool's advertised object output
+ * schema. Returned as an error result — the honest signal that the route and
+ * its declared `output` disagree — which also sidesteps the SDK's
+ * structuredContent requirement (errors are exempt).
+ */
+function inconsistentOutput(tool: DerivedAgentTool, detail: string, status: number): ToolCallOutcome {
+  return {
+    content: [
+      {
+        type: 'text',
+        text:
+          `The tool "${tool.toolName}" advertises an output schema, but the route returned ${detail} `
+          + `(HTTP ${status}) — no structured result could be produced.`,
+      },
+    ],
+    isError: true,
+    status,
+  }
 }
 
 function parseJsonBody(response: Response, raw: string): unknown | undefined {

--- a/packages/plugin-mcp/src/dispatch.ts
+++ b/packages/plugin-mcp/src/dispatch.ts
@@ -1,0 +1,256 @@
+/**
+ * The dispatch contract (RFC 0016 §3): a tool call re-enters the application
+ * as a real HTTP request, so validation, policies, and middleware run exactly
+ * once, in the app — never re-implemented here.
+ *
+ * This module is pure request/response plumbing: it rebuilds an HTTP request
+ * from a flat tool call and maps the app's response onto an MCP tool result.
+ * It never validates arguments (the route does, and the MCP client already
+ * saw the JSON Schema) and never decides authorization (the gate and the
+ * app's policies do).
+ */
+import type { DerivedAgentTool } from '@guren/core'
+import { PATH_PARAM_PATTERN } from '@guren/core/internal/route-path'
+
+/** How many characters of a non-JSON response body survive into the result. */
+const TEXT_RESPONSE_CAP = 50_000
+
+export interface BuildToolRequestOptions {
+  /**
+   * Origin the synthesized URL is built on. Never leaves the process — the
+   * request goes straight into `app.fetch` — but host-authorization
+   * middleware still reads its `Host`, so the default stays on the one name
+   * every dev allowlist admits.
+   */
+  origin?: string
+  /**
+   * `Authorization` header to forward verbatim, so the app's own token guard
+   * authenticates the same principal the adapter verified. Absent for a
+   * surface that authenticates some other way.
+   */
+  authorization?: string
+}
+
+export type BuiltToolRequest =
+  | { request: Request }
+  /** Path parameters the call did not supply — the URL cannot be built. */
+  | { missing: string[] }
+
+/**
+ * Rebuild the HTTP request a tool call describes.
+ *
+ * The flat argument object is taken apart along `tool.inputSources` — the
+ * derivation's own record of which contract each property came from — so a
+ * POST route's `query` keys land in the query string where `validateQuery`
+ * reads them, not in the body. Keys the derivation never advertised are
+ * forwarded anyway (body for body-carrying methods, query otherwise): the
+ * route's validator is the one place that rejects them, and dropping them
+ * here would make this a second, quieter validator.
+ *
+ * GET and HEAD force everything into the query string whatever its source —
+ * `Request` refuses a body on those methods, and a `body` schema on a GET
+ * route is a contract defect this adapter cannot repair.
+ */
+export function buildToolRequest(
+  tool: DerivedAgentTool,
+  args: Record<string, unknown>,
+  options: BuildToolRequestOptions = {},
+): BuiltToolRequest {
+  const origin = options.origin ?? 'http://localhost'
+  const missing: string[] = []
+  const consumed = new Set<string>()
+
+  // The one path lexer (PATH_PARAM_PATTERN) does the substitution, so the
+  // names replaced here are exactly the names the derivation advertised —
+  // `:name*` is a parameter literally named `name*` on both sides.
+  const path = tool.path.replace(
+    PATH_PARAM_PATTERN,
+    (_match, lead: string, name: string) => {
+      const value = args[name]
+      if (value === undefined) {
+        missing.push(name)
+        return `${lead}:${name}`
+      }
+      consumed.add(name)
+      return `${lead}${encodeURIComponent(String(value))}`
+    },
+  )
+  if (missing.length > 0) {
+    return { missing }
+  }
+
+  const method = tool.method
+  const bodyless = method === 'GET' || method === 'HEAD'
+
+  const query = new URLSearchParams()
+  const bodyEntries: Array<[string, unknown]> = []
+  for (const [key, value] of Object.entries(args)) {
+    if (consumed.has(key) || value === undefined) continue
+    const source = Object.hasOwn(tool.inputSources, key) ? tool.inputSources[key] : undefined
+    // Query-bound: everything on a bodyless method; declared `query` keys; a
+    // `params`/`path` key the path never declared (a contract defect
+    // `guren check` fails — forwarded so the route's validation reports it
+    // rather than it vanishing here); and, on a nested-body route, any key
+    // that is not the body itself, since that body is `args.body` verbatim
+    // and has no object to absorb strays.
+    const toQuery = bodyless
+      || source === 'query'
+      || source === 'params'
+      || source === 'path'
+      || (tool.inputBodyNested && key !== 'body')
+
+    if (toQuery) {
+      appendQueryValue(query, key, value)
+    } else {
+      bodyEntries.push([key, value])
+    }
+  }
+
+  const headers = new Headers({
+    // What turns an Inertia route into page JSON instead of an HTML document
+    // — without engaging the `X-Inertia` visit protocol and its 409 version
+    // negotiation, which a stateless tool call has no version to answer.
+    Accept: 'application/json',
+    'X-Guren-Agent-Surface': 'mcp',
+  })
+  if (options.authorization) {
+    headers.set('Authorization', options.authorization)
+  }
+
+  let body: string | undefined
+  if (!bodyless) {
+    if (tool.inputBodyNested) {
+      // The route validates a non-object body (an array, a primitive), which
+      // the derivation nested under `body` to give the tool an object root.
+      // Unwrapped here: posting `{ body: [...] }` would hand the validator an
+      // object where it expects the array.
+      if (Object.hasOwn(args, 'body')) {
+        body = JSON.stringify(args.body)
+      }
+    } else if (bodyEntries.length > 0) {
+      body = JSON.stringify(accumulate(bodyEntries))
+    }
+  }
+  if (body !== undefined) {
+    headers.set('Content-Type', 'application/json')
+  }
+
+  const qs = query.toString()
+  const url = `${origin}${path}${qs ? `?${qs}` : ''}`
+  return { request: new Request(url, { method, headers, body }) }
+}
+
+/** Primitives stringify; anything structured rides as JSON text. */
+function appendQueryValue(query: URLSearchParams, key: string, value: unknown): void {
+  if (Array.isArray(value)) {
+    for (const element of value) {
+      query.append(key, serializeQueryScalar(element))
+    }
+    return
+  }
+  query.append(key, serializeQueryScalar(value))
+}
+
+function serializeQueryScalar(value: unknown): string {
+  if (value === null || typeof value !== 'object') return String(value)
+  return JSON.stringify(value)
+}
+
+/**
+ * Null-prototype accumulator, spread back to plain: a JSON argument may
+ * legally be named `__proto__`, and assigning that key on `{}` invokes the
+ * prototype setter instead of defining the property — the same rule the
+ * derivation and the redaction walk apply.
+ */
+function accumulate(entries: Array<[string, unknown]>): Record<string, unknown> {
+  const record = Object.create(null) as Record<string, unknown>
+  for (const [key, value] of entries) {
+    record[key] = value
+  }
+  return { ...record }
+}
+
+/** An MCP tool result, shaped for the SDK's CallToolResult. */
+export interface ToolCallOutcome {
+  content: Array<{ type: 'text'; text: string }>
+  structuredContent?: Record<string, unknown>
+  isError?: boolean
+  /** The HTTP status the dispatch resolved to, for the audit event. */
+  status: number
+}
+
+/**
+ * Map the application's response onto an MCP tool result (RFC 0016 §3.4).
+ *
+ * - 2xx JSON → serialized text, plus `structuredContent` when the tool
+ *   advertises an `outputSchema` (the one shape the route validated).
+ * - 2xx Inertia page JSON → unwrapped to `page.props`, only for a tool with
+ *   no `outputSchema` — unwrap and schema are mutually exclusive by
+ *   derivation, so the advertised shape can never disagree with the result.
+ * - 204 / 3xx → a status line naming the Location; not an error.
+ * - 4xx / 5xx → `isError: true` carrying the exception handler's JSON body:
+ *   a 422's `{ message, errors }` is an application-level failure the agent
+ *   should read, not a protocol error.
+ * - non-JSON → capped text.
+ */
+export async function mapToolResponse(
+  tool: DerivedAgentTool,
+  response: Response,
+): Promise<ToolCallOutcome> {
+  const status = response.status
+
+  if (status === 204 || (status >= 300 && status < 400)) {
+    const location = response.headers.get('Location')
+    const text = location ? `HTTP ${status} (Location: ${location})` : `HTTP ${status}`
+    return { content: [{ type: 'text', text }], status }
+  }
+
+  const raw = await response.text()
+  const parsed = parseJsonBody(response, raw)
+
+  if (status >= 400) {
+    return {
+      content: [{ type: 'text', text: raw || `HTTP ${status}` }],
+      isError: true,
+      status,
+    }
+  }
+
+  if (parsed === undefined) {
+    const text = raw.length > TEXT_RESPONSE_CAP
+      ? `${raw.slice(0, TEXT_RESPONSE_CAP)}… [truncated ${raw.length - TEXT_RESPONSE_CAP} characters]`
+      : raw
+    return { content: [{ type: 'text', text }], status }
+  }
+
+  const payload = unwrapInertiaProps(tool, response, parsed)
+  const outcome: ToolCallOutcome = {
+    content: [{ type: 'text', text: JSON.stringify(payload) }],
+    status,
+  }
+  if (tool.outputSchema && isRecord(payload)) {
+    outcome.structuredContent = payload
+  }
+  return outcome
+}
+
+function parseJsonBody(response: Response, raw: string): unknown | undefined {
+  const contentType = response.headers.get('Content-Type') ?? ''
+  if (!contentType.includes('json') || raw === '') return undefined
+  try {
+    return JSON.parse(raw) as unknown
+  } catch {
+    return undefined
+  }
+}
+
+function unwrapInertiaProps(tool: DerivedAgentTool, response: Response, parsed: unknown): unknown {
+  if (tool.outputSchema) return parsed
+  if (response.headers.get('X-Inertia') !== 'true') return parsed
+  if (!isRecord(parsed) || !('props' in parsed)) return parsed
+  return parsed.props
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/packages/plugin-mcp/src/dispatch.ts
+++ b/packages/plugin-mcp/src/dispatch.ts
@@ -9,7 +9,7 @@
  * saw the JSON Schema) and never decides authorization (the gate and the
  * app's policies do).
  */
-import type { DerivedAgentTool } from '@guren/core'
+import type { AgentToolInputSource, DerivedAgentTool } from '@guren/core'
 import { PATH_PARAM_PATTERN } from '@guren/core/internal/route-path'
 
 /** How many characters of a non-JSON response body survive into the result. */
@@ -86,19 +86,21 @@ export function buildToolRequest(
         missing.push(name)
         return `${lead}:${name}`
       }
-      const encoded = String(value)
-      if (encoded === '.' || encoded === '..') {
+      // The raw stringified value — the dot-segment check runs before
+      // encoding, because `encodeURIComponent` leaves `.`/`..` untouched.
+      const stringified = String(value)
+      if (stringified === '.' || stringified === '..') {
         invalidPath.push(name)
         return `${lead}:${name}`
       }
       // A name the merge assigned to query/body still substitutes into the
       // URL, but keeps flowing to that sink — so a collision does not drop
       // the argument from the body the route validates.
-      const source = Object.hasOwn(tool.inputSources, name) ? tool.inputSources[name] : undefined
+      const source = sourceOf(tool, name)
       if (source === undefined || source === 'params' || source === 'path') {
         pathOnly.add(name)
       }
-      return `${lead}${encodeURIComponent(encoded)}`
+      return `${lead}${encodeURIComponent(stringified)}`
     },
   )
   if (missing.length > 0) {
@@ -115,7 +117,7 @@ export function buildToolRequest(
   const bodyEntries: Array<[string, unknown]> = []
   for (const [key, value] of Object.entries(args)) {
     if (pathOnly.has(key) || value === undefined) continue
-    const source = Object.hasOwn(tool.inputSources, key) ? tool.inputSources[key] : undefined
+    const source = sourceOf(tool, key)
     // Query-bound: everything on a bodyless method; declared `query` keys; a
     // `params`/`path` key the path never declared (a contract defect
     // `guren check` fails — forwarded so the route's validation reports it
@@ -167,6 +169,16 @@ export function buildToolRequest(
   const qs = query.toString()
   const url = `${origin}${path}${qs ? `?${qs}` : ''}`
   return { request: new Request(url, { method, headers, body }) }
+}
+
+/**
+ * The contract a property was declared under, or undefined if the derivation
+ * never advertised it. `Object.hasOwn` rather than a plain read: a JSON
+ * argument may legally be named `__proto__`, and `inputSources['__proto__']`
+ * would otherwise resolve to `Object.prototype`, not undefined.
+ */
+function sourceOf(tool: DerivedAgentTool, name: string): AgentToolInputSource | undefined {
+  return Object.hasOwn(tool.inputSources, name) ? tool.inputSources[name] : undefined
 }
 
 /** Primitives stringify; anything structured rides as JSON text. */
@@ -257,7 +269,6 @@ export async function mapToolResponse(
   }
 
   const raw = await response.text()
-  const parsed = parseJsonBody(response, raw)
 
   if (status >= 400) {
     return {
@@ -266,6 +277,9 @@ export async function mapToolResponse(
       status,
     }
   }
+
+  // Parsed only past the error branch, which reads the raw body verbatim.
+  const parsed = parseJsonBody(response, raw)
 
   if (parsed === undefined) {
     const text = raw.length > TEXT_RESPONSE_CAP

--- a/packages/plugin-mcp/src/gate.test.ts
+++ b/packages/plugin-mcp/src/gate.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from 'bun:test'
+import { Router, deriveAgentTools, type DerivedAgentTool } from '@guren/core'
+
+import { gateToolCall } from './gate'
+
+function tools(): { read: DerivedAgentTool; write: DerivedAgentTool; approval: DerivedAgentTool } {
+  const router = new Router()
+  const handler = () => new Response('ok')
+  router.get('/posts', handler).name('posts.index').agent({})
+  router.post('/posts', handler).name('posts.store').agent({})
+  router.delete('/posts/:id', handler).name('posts.destroy').agent({ approval: 'required' })
+  const derived = deriveAgentTools(router.definitions()).tools
+  const byName = new Map(derived.map((tool) => [tool.toolName, tool]))
+  return {
+    read: byName.get('posts.index')!,
+    write: byName.get('posts.store')!,
+    approval: byName.get('posts.destroy')!,
+  }
+}
+
+describe('gateToolCall', () => {
+  test('should allow a tool the scopes grant', () => {
+    expect(gateToolCall(tools().write, ['tool:posts.store'])).toEqual({ allowed: true })
+  })
+
+  test('should deny with reason scope when no entry grants the tool', () => {
+    const verdict = gateToolCall(tools().write, ['tools:read', '*'])
+    expect(verdict.allowed).toBe(false)
+    if (!verdict.allowed) expect(verdict.reason).toBe('scope')
+  })
+
+  test('should judge tools:read by the resolved read-only annotation', () => {
+    const { read, write } = tools()
+    expect(gateToolCall(read, ['tools:read']).allowed).toBe(true)
+    expect(gateToolCall(write, ['tools:read']).allowed).toBe(false)
+  })
+
+  test('should deny an approval-required tool even when scopes grant it', () => {
+    const verdict = gateToolCall(tools().approval, ['tools:*'])
+    expect(verdict.allowed).toBe(false)
+    if (!verdict.allowed) expect(verdict.reason).toBe('approval')
+  })
+
+  test('should report scope before approval, so probes cannot map approval gates', () => {
+    const verdict = gateToolCall(tools().approval, [])
+    expect(verdict.allowed).toBe(false)
+    if (!verdict.allowed) expect(verdict.reason).toBe('scope')
+  })
+})

--- a/packages/plugin-mcp/src/gate.ts
+++ b/packages/plugin-mcp/src/gate.ts
@@ -1,0 +1,50 @@
+/**
+ * The adapter-level checks a tool call passes before any HTTP request is
+ * synthesized (RFC 0016 §5). Everything here maps onto one
+ * `AgentToolDenialReason` — what happens *inside* the dispatched request
+ * (validation, `Gate` policies) is the application's verdict, reported as an
+ * invocation with its HTTP status, never re-judged here.
+ */
+import { scopesAllowTool, type AgentToolDenialReason, type DerivedAgentTool } from '@guren/core'
+
+export type GateVerdict =
+  | { allowed: true }
+  | { allowed: false; reason: AgentToolDenialReason; message: string }
+
+/**
+ * Scope and approval, in that order — a caller learns a tool needs approval
+ * only once its token could invoke it at all, so an unauthorized probe cannot
+ * map which tools are approval-gated.
+ *
+ * `tools:read`-style scopes judge the tool by its *resolved* read-only
+ * annotation, the same value the catalog advertises.
+ */
+export function gateToolCall(tool: DerivedAgentTool, abilities: readonly string[]): GateVerdict {
+  if (!scopesAllowTool(abilities, scopedShape(tool))) {
+    return {
+      allowed: false,
+      reason: 'scope',
+      message: `The token's scopes do not grant the tool "${tool.toolName}".`,
+    }
+  }
+
+  if (tool.approval === 'required') {
+    // Fail-closed until the approval queue ships (RFC 0016 Phase 2.5): a
+    // tool that declares it must not execute without server-side approval
+    // is refused, never quietly executed.
+    return {
+      allowed: false,
+      reason: 'approval',
+      message:
+        `The tool "${tool.toolName}" requires server-side approval, and this server has no `
+        + 'approval queue configured. Approval support ships in a later release.',
+    }
+  }
+
+  return { allowed: true }
+}
+
+/** The two fields the scope grammar judges a tool by. */
+export function scopedShape(tool: DerivedAgentTool): { name: string; readOnly: boolean } {
+  return { name: tool.toolName, readOnly: tool.annotations.readOnlyHint }
+}

--- a/packages/plugin-mcp/src/index.ts
+++ b/packages/plugin-mcp/src/index.ts
@@ -1,0 +1,6 @@
+export { mcpPlugin, type McpPluginConfig } from './plugin'
+export { buildToolRequest, mapToolResponse } from './dispatch'
+export type { BuildToolRequestOptions, BuiltToolRequest, ToolCallOutcome } from './dispatch'
+export { gateToolCall, type GateVerdict } from './gate'
+export { AgentRateLimiter, type RateLimitConfig } from './rate-limit'
+export { createAppMcpServer, type AppMcpServerOptions } from './server'

--- a/packages/plugin-mcp/src/plugin.test.ts
+++ b/packages/plugin-mcp/src/plugin.test.ts
@@ -1,0 +1,141 @@
+import { describe, test, expect, beforeAll } from 'bun:test'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { z } from 'zod'
+import {
+  AgentToolInvoked,
+  EventServiceProvider,
+  MemoryApiTokenStore,
+  createApiToken,
+  createApp,
+  type Application,
+  type EventManager,
+  type Router,
+} from '@guren/core'
+
+import { mcpPlugin } from './plugin'
+
+/**
+ * The endpoint end to end: a real Application with token auth and agent
+ * routes, driven by the SDK's own client over streamable HTTP — the fetch is
+ * bridged straight into `app.fetch`, so this covers the transport, the
+ * bearer boundary, the scope gate, the dispatch re-entry, and the audit
+ * emission in one pass.
+ */
+describe('mcpPlugin (integration)', () => {
+  const store = new MemoryApiTokenStore()
+  let app: Application
+  let events: EventManager
+  let token: string
+
+  function registerRoutes(router: Router): void {
+    router
+      .get('/posts', () => Response.json({ posts: [{ id: 1, title: 'Hello' }] }))
+      .name('posts.index')
+      .agent({ description: 'List posts' })
+    router
+      .post('/posts', { body: z.object({ title: z.string(), password: z.string() }) }, ({ body }) =>
+        Response.json({ created: body.title }, { status: 201 }))
+      .name('posts.store')
+      .agent({})
+  }
+
+  beforeAll(async () => {
+    app = createApp({
+      routes: registerRoutes,
+      providers: [EventServiceProvider, mcpPlugin()],
+    })
+    app.auth.useTokens(store)
+    await app.boot()
+    events = app.container.make<EventManager>('events')
+
+    const issued = await createApiToken(store, {
+      name: 'test',
+      userId: 42,
+      abilities: ['tools:*'],
+    })
+    token = issued.plainTextToken
+  })
+
+  async function connectClient(bearer: string): Promise<Client> {
+    const transport = new StreamableHTTPClientTransport(new URL('http://localhost/mcp'), {
+      fetch: (input, init) => app.fetch(new Request(input, init)),
+      requestInit: { headers: { Authorization: `Bearer ${bearer}` } },
+    })
+    const client = new Client({ name: 'integration', version: '1.0.0' })
+    await client.connect(transport)
+    return client
+  }
+
+  test('should refuse a request without a bearer token', async () => {
+    const response = await app.fetch(
+      new Request('http://localhost/mcp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      }),
+    )
+    expect(response.status).toBe(401)
+    expect(response.headers.get('WWW-Authenticate')).toBe('Bearer')
+  })
+
+  test('should list the app tools to a granted token', async () => {
+    const client = await connectClient(token)
+    const { tools } = await client.listTools()
+    expect(tools.map((tool) => tool.name).sort()).toEqual(['posts.index', 'posts.store'])
+  })
+
+  test('should execute a read tool through the app and return its JSON', async () => {
+    const client = await connectClient(token)
+    const result = await client.callTool({ name: 'posts.index', arguments: {} })
+    expect(result.isError).toBeUndefined()
+    const content = result.content as Array<{ type: string; text: string }>
+    expect(JSON.parse(content[0]!.text)).toEqual({ posts: [{ id: 1, title: 'Hello' }] })
+  })
+
+  test('should execute a write tool and emit a redacted AgentToolInvoked', async () => {
+    const seen: AgentToolInvoked[] = []
+    events.on(AgentToolInvoked, (event) => {
+      seen.push(event)
+    })
+
+    const client = await connectClient(token)
+    const result = await client.callTool({
+      name: 'posts.store',
+      arguments: { title: 'New', password: 'hunter2' },
+    })
+    expect(result.isError).toBeUndefined()
+
+    // Emission is fire-and-forget; give the microtask a beat.
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    const invoked = seen.find((event) => event.tool === 'posts.store')
+    expect(invoked).toBeDefined()
+    expect(invoked!.principal).toEqual({ kind: 'user', id: 42, abilities: ['tools:*'] })
+    expect(invoked!.arguments.title).toBe('New')
+    expect(invoked!.arguments.password).toBe('[REDACTED]')
+    expect(invoked!.status).toBe(201)
+    expect(invoked!.surface).toBe('mcp')
+  })
+
+  test('should hide and deny tools outside the token scopes', async () => {
+    const readOnly = await createApiToken(store, {
+      name: 'ro',
+      userId: 42,
+      abilities: ['tools:read'],
+    })
+    const client = await connectClient(readOnly.plainTextToken)
+
+    const { tools } = await client.listTools()
+    expect(tools.map((tool) => tool.name)).toEqual(['posts.index'])
+
+    const result = await client.callTool({ name: 'posts.store', arguments: { title: 'x', password: 'y' } })
+    expect(result.isError).toBe(true)
+  })
+
+  test('should treat the ApiToken default abilities as granting no tools', async () => {
+    const legacy = await createApiToken(store, { name: 'legacy', userId: 42 })
+    const client = await connectClient(legacy.plainTextToken)
+    const { tools } = await client.listTools()
+    expect(tools).toEqual([])
+  })
+})

--- a/packages/plugin-mcp/src/plugin.ts
+++ b/packages/plugin-mcp/src/plugin.ts
@@ -87,6 +87,12 @@ const factory = definePlugin<McpPluginConfig>({
       name: config.serverInfo?.name ?? 'guren-app',
       version: config.serverInfo?.version ?? '1.0.0',
     }
+    // Per-token, in this process. An app's *own* rate-limit middleware on an
+    // agent route keys on `server.requestIP()`, which is null for the
+    // synthesized re-entrant request (it never arrived over a socket) and so
+    // collapses to that route's shared bucket for every MCP caller. This
+    // limiter is the per-caller floor the app's cannot be on this surface; a
+    // global budget across instances still needs a shared store.
     const limiter = config.rateLimit === false ? undefined : new AgentRateLimiter(config.rateLimit)
 
     // Dynamic import, mirroring the Dev MCP provider: the SDK stays out of
@@ -183,26 +189,34 @@ async function dispatchThroughApp(
   args: Record<string, unknown>,
 ): Promise<ToolCallOutcome> {
   const built = buildToolRequest(tool, args, {
+    // The inbound request's own origin, so the re-entrant request carries the
+    // real Host the MCP client reached `/mcp` on. Defaulting to localhost
+    // (dispatch's fallback) makes host-authorization middleware — which RFC
+    // 0016's "in production" apps are encouraged to enable — reject every
+    // tool call with 403.
+    origin: new URL(c.req.url).origin,
     authorization: c.req.header('Authorization'),
   })
   if ('missing' in built) {
     // No HTTP happened, but the call did — recorded by the caller as an
     // invocation with the status the app would have answered.
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Missing required path parameter(s): ${built.missing.join(', ')}.`,
-        },
-      ],
-      isError: true,
-      status: 400,
-    }
+    return badRequest(`Missing required path parameter(s): ${built.missing.join(', ')}.`)
+  }
+  if ('invalidPath' in built) {
+    return badRequest(
+      `Path parameter(s) ${built.invalidPath.join(', ')} may not be "." or ".." — `
+      + 'a dot-segment would resolve to a different route than the one authorized.',
+    )
   }
 
   // env and execution context are forwarded explicitly — omitting them
   // silently loses D1/R2 bindings and waitUntil on Workers (RFC 0016 §3.1).
   return mapToolResponse(tool, await app.fetch(built.request, c.env, executionContext(c)))
+}
+
+/** A tool call the adapter rejected before HTTP — recorded as a 400 invocation. */
+function badRequest(text: string): ToolCallOutcome {
+  return { content: [{ type: 'text', text }], isError: true, status: 400 }
 }
 
 /** Hono throws on `executionCtx` outside Workers; absent is a normal answer here. */

--- a/packages/plugin-mcp/src/plugin.ts
+++ b/packages/plugin-mcp/src/plugin.ts
@@ -1,0 +1,236 @@
+import {
+  AgentToolDenied,
+  AgentToolInvoked,
+  definePlugin,
+  deriveAgentTools,
+  readBearerToken,
+  redactAgentArguments,
+  verifyApiToken,
+  type AgentPrincipal,
+  type AgentToolDenialReason,
+  type Application,
+  type AuthManager,
+  type DerivedAgentTool,
+  type EventManager,
+  type ServiceProviderConstructor,
+} from '@guren/core'
+import type { Context } from 'hono'
+
+import { buildToolRequest, mapToolResponse, type ToolCallOutcome } from './dispatch'
+import { AgentRateLimiter, type RateLimitConfig } from './rate-limit'
+import { createAppMcpServer } from './server'
+
+export interface McpPluginConfig {
+  /**
+   * Where the App MCP endpoint mounts.
+   * @default '/mcp'
+   */
+  path?: string
+  /** MCP server identity advertised to clients. Defaults to the package name. */
+  serverInfo?: { name?: string; version?: string }
+  /**
+   * Per-token rate limits, on by default (`false` disables). Enforced in
+   * process memory: exact on one long-running server, per-instance on a
+   * fleet or serverless — a global budget needs the app's own rate-limit
+   * middleware over a shared store.
+   */
+  rateLimit?: RateLimitConfig | false
+  /**
+   * Whether verifying a bearer writes the token's `lastUsedAt`.
+   * @default true
+   */
+  updateLastUsed?: boolean
+}
+
+/**
+ * The App MCP endpoint (RFC 0016 §7): the application's own agent tools —
+ * routes declaring `.agent()` — served over the Model Context Protocol, in
+ * production, behind bearer tokens.
+ *
+ * Every tool call re-enters the application through `app.fetch` as a real
+ * HTTP request (§3): validation, policies, and middleware run exactly once,
+ * in the app. The adapter's own checks are the ones that must precede HTTP —
+ * bearer verification, token scopes, approval, rate limits — and each
+ * refusal is an `AgentToolDenied` event; each execution an
+ * `AgentToolInvoked`, arguments redacted (§5.2).
+ *
+ * Requires token auth: the app must call `auth.useTokens(store)` (or
+ * configure it via its auth options), because the endpoint verifies bearers
+ * against the same store the token guard uses. The check is per request, not
+ * at boot — provider order does not guarantee the app's auth configuration
+ * has run before this plugin boots.
+ */
+const factory = definePlugin<McpPluginConfig>({
+  name: 'mcp',
+  register(): void {
+    // Everything binds per request; there is no container service to offer.
+  },
+  async boot(container, config): Promise<void> {
+    const app = container.make<Application>('app')
+    const auth = container.make<AuthManager>('auth')
+    const events = container.has('events') ? container.make<EventManager>('events') : undefined
+    if (!events) {
+      console.warn(
+        '[@guren/plugin-mcp] No event manager is bound (register EventServiceProvider); '
+        + 'agent audit events (AgentToolInvoked / AgentToolDenied) will not be emitted.',
+      )
+    }
+
+    const { tools, warnings } = deriveAgentTools(app.router.definitions())
+    for (const warning of warnings) {
+      console.warn(`[@guren/plugin-mcp] ${warning}`)
+    }
+    const exposed = tools.filter((tool) => tool.expose.mcp)
+
+    const path = config.path ?? '/mcp'
+    const serverInfo = {
+      name: config.serverInfo?.name ?? 'guren-app',
+      version: config.serverInfo?.version ?? '1.0.0',
+    }
+    const limiter = config.rateLimit === false ? undefined : new AgentRateLimiter(config.rateLimit)
+
+    // Dynamic import, mirroring the Dev MCP provider: the SDK stays out of
+    // module graphs that never mount the endpoint.
+    const { WebStandardStreamableHTTPServerTransport } = await import(
+      '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+    )
+
+    const emit = (event: AgentToolInvoked | AgentToolDenied): void => {
+      // Fire-and-forget: a listener's failure must not fail the tool call it
+      // records. EventManager already isolates listener errors; the catch
+      // covers emit itself.
+      void events?.emit(event).catch((error) => {
+        console.warn(`[@guren/plugin-mcp] audit event listener failed: ${String(error)}`)
+      })
+    }
+
+    app.hono.all(path, async (c) => {
+      const store = auth.getApiTokenStore()
+      if (!store) {
+        return c.json(
+          {
+            error: 'misconfigured',
+            message:
+              'The MCP endpoint requires token auth: call auth.useTokens(store) in your '
+              + 'application so bearer tokens can be verified.',
+          },
+          500,
+        )
+      }
+
+      const bearer = readBearerToken(c.req.header('Authorization'))
+      if (!bearer) {
+        return unauthorized(c, 'A bearer token is required.')
+      }
+      const verified = await verifyApiToken(bearer, store, {
+        updateLastUsed: config.updateLastUsed ?? true,
+      })
+      if (!verified) {
+        return unauthorized(c, 'The bearer token is invalid, expired, or revoked.')
+      }
+
+      const principal: AgentPrincipal = {
+        kind: 'user',
+        id: verified.userId,
+        abilities: verified.abilities,
+      }
+
+      const server = createAppMcpServer({
+        tools: exposed,
+        abilities: verified.abilities,
+        serverInfo,
+        limiter,
+        rateKey: verified.token.id,
+        dispatch: (tool, args) => dispatchThroughApp(app, c, tool, args),
+        onInvoked: (tool, args, status, durationMs) => {
+          emit(
+            new AgentToolInvoked(
+              principal,
+              tool.toolName,
+              redactAgentArguments(args, tool.redact),
+              status,
+              durationMs,
+              'mcp',
+            ),
+          )
+        },
+        onDenied: (tool, args, reason: AgentToolDenialReason) => {
+          emit(
+            new AgentToolDenied(
+              principal,
+              tool.toolName,
+              redactAgentArguments(args, tool.redact),
+              reason,
+              'mcp',
+            ),
+          )
+        },
+      })
+
+      const transport = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+      })
+      await server.connect(transport)
+      return transport.handleRequest(c.req.raw)
+    })
+  },
+})
+
+async function dispatchThroughApp(
+  app: Application,
+  c: Context,
+  tool: DerivedAgentTool,
+  args: Record<string, unknown>,
+): Promise<ToolCallOutcome> {
+  const built = buildToolRequest(tool, args, {
+    authorization: c.req.header('Authorization'),
+  })
+  if ('missing' in built) {
+    // No HTTP happened, but the call did — recorded by the caller as an
+    // invocation with the status the app would have answered.
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Missing required path parameter(s): ${built.missing.join(', ')}.`,
+        },
+      ],
+      isError: true,
+      status: 400,
+    }
+  }
+
+  // env and execution context are forwarded explicitly — omitting them
+  // silently loses D1/R2 bindings and waitUntil on Workers (RFC 0016 §3.1).
+  return mapToolResponse(tool, await app.fetch(built.request, c.env, executionContext(c)))
+}
+
+/** Hono throws on `executionCtx` outside Workers; absent is a normal answer here. */
+function executionContext(c: Context): ExecutionContext | undefined {
+  try {
+    return c.executionCtx as ExecutionContext
+  } catch {
+    return undefined
+  }
+}
+
+type ExecutionContext = Parameters<Application['fetch']>[2]
+
+function unauthorized(c: Context, message: string): Response {
+  c.header('WWW-Authenticate', 'Bearer')
+  return c.json({ error: 'unauthorized', message }, 401)
+}
+
+/**
+ * Register the App MCP plugin.
+ *
+ * @example
+ * ```typescript
+ * import { mcpPlugin } from '@guren/plugin-mcp'
+ *
+ * createApp({ providers: [mcpPlugin({ path: '/mcp' })] })
+ * ```
+ */
+export function mcpPlugin(config: McpPluginConfig = {}): ServiceProviderConstructor {
+  return factory(config)
+}

--- a/packages/plugin-mcp/src/rate-limit.test.ts
+++ b/packages/plugin-mcp/src/rate-limit.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from 'bun:test'
+
+import { AgentRateLimiter } from './rate-limit'
+
+describe('AgentRateLimiter', () => {
+  test('should exhaust the overall budget within one window', () => {
+    const limiter = new AgentRateLimiter({ max: 2, writeMax: 2, windowMs: 1_000 })
+    expect(limiter.take('t', { write: false, now: 0 })).toBe(true)
+    expect(limiter.take('t', { write: false, now: 1 })).toBe(true)
+    expect(limiter.take('t', { write: false, now: 2 })).toBe(false)
+  })
+
+  test('should exhaust the write budget before the overall one', () => {
+    const limiter = new AgentRateLimiter({ max: 10, writeMax: 1, windowMs: 1_000 })
+    expect(limiter.take('t', { write: true, now: 0 })).toBe(true)
+    expect(limiter.take('t', { write: true, now: 1 })).toBe(false)
+    // Reads still fit in the overall budget.
+    expect(limiter.take('t', { write: false, now: 2 })).toBe(true)
+  })
+
+  test('should reset when the window rolls over', () => {
+    const limiter = new AgentRateLimiter({ max: 1, windowMs: 1_000 })
+    expect(limiter.take('t', { write: false, now: 0 })).toBe(true)
+    expect(limiter.take('t', { write: false, now: 999 })).toBe(false)
+    expect(limiter.take('t', { write: false, now: 1_000 })).toBe(true)
+  })
+
+  test('should keep budgets independent per key', () => {
+    const limiter = new AgentRateLimiter({ max: 1, windowMs: 1_000 })
+    expect(limiter.take('a', { write: false, now: 0 })).toBe(true)
+    expect(limiter.take('b', { write: false, now: 0 })).toBe(true)
+  })
+
+  test('a refused call should not consume budget', () => {
+    const limiter = new AgentRateLimiter({ max: 2, writeMax: 1, windowMs: 1_000 })
+    expect(limiter.take('t', { write: true, now: 0 })).toBe(true)
+    // Write budget exhausted; this refusal must not eat the overall budget.
+    expect(limiter.take('t', { write: true, now: 1 })).toBe(false)
+    expect(limiter.take('t', { write: false, now: 2 })).toBe(true)
+  })
+})

--- a/packages/plugin-mcp/src/rate-limit.ts
+++ b/packages/plugin-mcp/src/rate-limit.ts
@@ -1,0 +1,69 @@
+/**
+ * Per-token rate limiting for the App MCP endpoint (RFC 0016 §5.3), on by
+ * default with a stricter budget for non-read-only tools.
+ *
+ * A fixed window per key, in process memory. That is the honest scope of
+ * this limiter: one long-running server enforces it exactly; a fleet or a
+ * serverless deployment enforces it per instance, which still bounds abuse
+ * per instance but is not a global budget. The config doc says so rather
+ * than pretending otherwise — a distributed limiter needs a shared store and
+ * belongs to the app's own rate-limit middleware.
+ */
+
+export interface RateLimitConfig {
+  /** Calls allowed per window, per token. @default 60 */
+  max?: number
+  /** Of which, calls to non-read-only tools. @default 20 */
+  writeMax?: number
+  /** Window length in milliseconds. @default 60_000 */
+  windowMs?: number
+}
+
+interface WindowState {
+  startedAt: number
+  total: number
+  writes: number
+}
+
+export class AgentRateLimiter {
+  private readonly max: number
+  private readonly writeMax: number
+  private readonly windowMs: number
+  private readonly windows = new Map<string, WindowState>()
+
+  constructor(config: RateLimitConfig = {}) {
+    this.max = config.max ?? 60
+    this.writeMax = config.writeMax ?? 20
+    this.windowMs = config.windowMs ?? 60_000
+  }
+
+  /**
+   * Take one call from `key`'s current window. Returns false — without
+   * consuming anything — when the budget is exhausted.
+   */
+  take(key: string, options: { write: boolean; now?: number }): boolean {
+    const now = options.now ?? Date.now()
+    const current = this.windows.get(key)
+    const window = current && now - current.startedAt < this.windowMs
+      ? current
+      : { startedAt: now, total: 0, writes: 0 }
+
+    if (window.total >= this.max) return false
+    if (options.write && window.writes >= this.writeMax) return false
+
+    window.total += 1
+    if (options.write) window.writes += 1
+    this.windows.set(key, window)
+
+    // An abandoned key's window is replaced on its next use and never read
+    // otherwise; sweep opportunistically so a token churn cannot grow the
+    // map without bound.
+    if (this.windows.size > 10_000) {
+      for (const [candidate, state] of this.windows) {
+        if (now - state.startedAt >= this.windowMs) this.windows.delete(candidate)
+      }
+    }
+
+    return true
+  }
+}

--- a/packages/plugin-mcp/src/server.test.ts
+++ b/packages/plugin-mcp/src/server.test.ts
@@ -1,0 +1,117 @@
+import { describe, test, expect } from 'bun:test'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { Router, deriveAgentTools, type AgentToolDenialReason, type DerivedAgentTool } from '@guren/core'
+
+import { AgentRateLimiter } from './rate-limit'
+import { createAppMcpServer, type AppMcpServerOptions } from './server'
+import type { ToolCallOutcome } from './dispatch'
+
+function deriveFixtureTools(): DerivedAgentTool[] {
+  const router = new Router()
+  const handler = () => new Response('ok')
+  router.get('/posts', handler).name('posts.index').agent({ description: 'List posts' })
+  router.post('/posts', handler).name('posts.store').agent({})
+  router.get('/hidden', handler).name('hidden.index').agent({ expose: { mcp: false } })
+  return deriveAgentTools(router.definitions()).tools.filter((tool) => tool.expose.mcp)
+}
+
+interface Recorded {
+  invoked: Array<{ tool: string; status: number }>
+  denied: Array<{ tool: string; reason: AgentToolDenialReason }>
+}
+
+async function connect(overrides: Partial<AppMcpServerOptions> = {}): Promise<{ client: Client; recorded: Recorded }> {
+  const recorded: Recorded = { invoked: [], denied: [] }
+  const server = createAppMcpServer({
+    tools: deriveFixtureTools(),
+    abilities: ['tools:*'],
+    serverInfo: { name: 'test-app', version: '0.0.0' },
+    rateKey: 'token-1',
+    dispatch: async (): Promise<ToolCallOutcome> => ({
+      content: [{ type: 'text', text: '{"ok":true}' }],
+      status: 200,
+    }),
+    onInvoked: (tool, _args, status) => recorded.invoked.push({ tool: tool.toolName, status }),
+    onDenied: (tool, _args, reason) => recorded.denied.push({ tool: tool.toolName, reason }),
+    ...overrides,
+  })
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  const client = new Client({ name: 'test-client', version: '1.0.0' })
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+  return { client, recorded }
+}
+
+describe('createAppMcpServer', () => {
+  test('should list only the tools the abilities grant', async () => {
+    const { client } = await connect({ abilities: ['tools:read'] })
+    const { tools } = await client.listTools()
+    expect(tools.map((tool) => tool.name)).toEqual(['posts.index'])
+  })
+
+  test('should advertise schema and annotations on listed tools', async () => {
+    const { client } = await connect()
+    const { tools } = await client.listTools()
+    const index = tools.find((tool) => tool.name === 'posts.index')!
+    expect(index.description).toBe('List posts')
+    expect(index.inputSchema).toEqual({ type: 'object', properties: {} })
+    expect(index.annotations).toEqual({
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    })
+  })
+
+  test('should dispatch a granted call and record the invocation', async () => {
+    const { client, recorded } = await connect()
+    const result = await client.callTool({ name: 'posts.store', arguments: {} })
+    expect(result.isError).toBeUndefined()
+    expect(recorded.invoked).toEqual([{ tool: 'posts.store', status: 200 }])
+    expect(recorded.denied).toEqual([])
+  })
+
+  test('should deny an out-of-scope call as an error result and record it', async () => {
+    const { client, recorded } = await connect({ abilities: ['tools:read'] })
+    const result = await client.callTool({ name: 'posts.store', arguments: {} })
+    expect(result.isError).toBe(true)
+    expect(recorded.denied).toEqual([{ tool: 'posts.store', reason: 'scope' }])
+    expect(recorded.invoked).toEqual([])
+  })
+
+  test('should refuse an unknown tool without recording anything', async () => {
+    const { client, recorded } = await connect()
+    const result = await client.callTool({ name: 'nope', arguments: {} })
+    expect(result.isError).toBe(true)
+    expect(recorded.invoked).toEqual([])
+    expect(recorded.denied).toEqual([])
+  })
+
+  test('should not serve a tool excluded from the mcp surface', async () => {
+    const { client } = await connect()
+    const { tools } = await client.listTools()
+    expect(tools.map((tool) => tool.name)).not.toContain('hidden.index')
+    const result = await client.callTool({ name: 'hidden.index', arguments: {} })
+    expect(result.isError).toBe(true)
+  })
+
+  test('should enforce the write budget through the limiter and record the denial', async () => {
+    const limiter = new AgentRateLimiter({ max: 10, writeMax: 1, windowMs: 60_000 })
+    const { client, recorded } = await connect({ limiter })
+    await client.callTool({ name: 'posts.store', arguments: {} })
+    const second = await client.callTool({ name: 'posts.store', arguments: {} })
+    expect(second.isError).toBe(true)
+    expect(recorded.denied).toEqual([{ tool: 'posts.store', reason: 'rate-limit' }])
+  })
+
+  test('should convert a dispatch throw into an error result recorded as a 500', async () => {
+    const { client, recorded } = await connect({
+      dispatch: async () => {
+        throw new Error('boom')
+      },
+    })
+    const result = await client.callTool({ name: 'posts.index', arguments: {} })
+    expect(result.isError).toBe(true)
+    expect(recorded.invoked).toEqual([{ tool: 'posts.index', status: 500 }])
+  })
+})

--- a/packages/plugin-mcp/src/server.ts
+++ b/packages/plugin-mcp/src/server.ts
@@ -14,10 +14,10 @@ import {
   ListToolsRequestSchema,
   type CallToolResult,
 } from '@modelcontextprotocol/sdk/types.js'
-import { scopesAllowTool, type AgentToolDenialReason, type DerivedAgentTool } from '@guren/core'
+import type { AgentToolDenialReason, DerivedAgentTool } from '@guren/core'
 
-import { gateToolCall, scopedShape } from './gate'
-import type { ToolCallOutcome } from './dispatch'
+import { gateToolCall } from './gate'
+import { advertisesStructuredOutput, type ToolCallOutcome } from './dispatch'
 import type { AgentRateLimiter } from './rate-limit'
 
 export interface AppMcpServerOptions {
@@ -45,12 +45,17 @@ export interface AppMcpServerOptions {
 export function createAppMcpServer(options: AppMcpServerOptions): Server {
   const server = new Server(options.serverInfo, { capabilities: { tools: {} } })
 
-  // The catalog a token sees is the catalog it can call: listing ungranted
-  // tools would map the app's write surface for a read-only token, and MCP
-  // clients treat the list as an invitation.
+  // The catalog a token sees is the catalog it can call: a tool is listed
+  // only if `gateToolCall` would admit it, so scope *and* the current
+  // approval verdict decide both. Listing a tool a call then refuses (an
+  // ungranted one maps the write surface for a read-only token; an
+  // approval-required one with no queue is categorically uncallable today)
+  // makes the list lie, and MCP clients treat it as an invitation. Rate
+  // limits are deliberately not consulted — a budget is a runtime state, not
+  // a capability, and a temporarily-throttled tool is still in the catalog.
   server.setRequestHandler(ListToolsRequestSchema, () => ({
     tools: options.tools
-      .filter((tool) => scopesAllowTool(options.abilities, scopedShape(tool)))
+      .filter((tool) => gateToolCall(tool, options.abilities).allowed)
       .map((tool) => describeTool(tool)),
   }))
 
@@ -101,7 +106,15 @@ function describeTool(tool: DerivedAgentTool) {
     name: tool.toolName,
     ...(tool.description ? { description: tool.description } : {}),
     inputSchema: tool.inputSchema as { type: 'object'; [key: string]: unknown },
-    ...(tool.outputSchema ? { outputSchema: tool.outputSchema as { type: 'object'; [key: string]: unknown } } : {}),
+    // Only an object output schema is advertised: MCP requires
+    // `outputSchema.type === 'object'`, and a single array/primitive one
+    // would make the SDK client reject the *entire* tools/list. A route
+    // whose `output` is non-object still works — its results ride as text,
+    // the same branch `advertisesStructuredOutput` gates on the response
+    // side, so list and call stay in agreement.
+    ...(advertisesStructuredOutput(tool)
+      ? { outputSchema: tool.outputSchema as { type: 'object'; [key: string]: unknown } }
+      : {}),
     annotations: {
       readOnlyHint: tool.annotations.readOnlyHint,
       destructiveHint: tool.annotations.destructiveHint,

--- a/packages/plugin-mcp/src/server.ts
+++ b/packages/plugin-mcp/src/server.ts
@@ -1,0 +1,119 @@
+/**
+ * Assembly of the per-request MCP server for the App MCP endpoint.
+ *
+ * The low-level `Server` is deliberate: the tools already carry JSON Schema
+ * from `deriveAgentTools`, and the high-level `McpServer` API wants live Zod
+ * — which would validate (and `coerce`/`transform`) a second time on top of
+ * the route's own validation (RFC 0016 §3.2). Structural validation is the
+ * client's job against the advertised schema; semantic validation is the
+ * route's.
+ */
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type CallToolResult,
+} from '@modelcontextprotocol/sdk/types.js'
+import { scopesAllowTool, type AgentToolDenialReason, type DerivedAgentTool } from '@guren/core'
+
+import { gateToolCall, scopedShape } from './gate'
+import type { ToolCallOutcome } from './dispatch'
+import type { AgentRateLimiter } from './rate-limit'
+
+export interface AppMcpServerOptions {
+  /** Tools already filtered to `expose.mcp`. */
+  tools: readonly DerivedAgentTool[]
+  /** The verified token's abilities — the scope grammar's input. */
+  abilities: readonly string[]
+  serverInfo: { name: string; version: string }
+  /** Undefined disables rate limiting (config `rateLimit: false`). */
+  limiter?: AgentRateLimiter
+  /** Rate-limit key — the token id, so budgets follow credentials, not IPs. */
+  rateKey: string
+  /** Execute one granted call. Errors it throws become error results, not protocol faults. */
+  dispatch(tool: DerivedAgentTool, args: Record<string, unknown>): Promise<ToolCallOutcome>
+  /** Audit hooks — the emitter owns redaction and event construction. */
+  onInvoked(tool: DerivedAgentTool, args: Record<string, unknown>, status: number, durationMs: number): void
+  onDenied(tool: DerivedAgentTool, args: Record<string, unknown>, reason: AgentToolDenialReason): void
+}
+
+/**
+ * One server per request, stateless — `Server.connect()` binds a transport
+ * once, so the endpoint constructs a fresh pair each time (the same pattern
+ * as the Dev MCP endpoint).
+ */
+export function createAppMcpServer(options: AppMcpServerOptions): Server {
+  const server = new Server(options.serverInfo, { capabilities: { tools: {} } })
+
+  // The catalog a token sees is the catalog it can call: listing ungranted
+  // tools would map the app's write surface for a read-only token, and MCP
+  // clients treat the list as an invitation.
+  server.setRequestHandler(ListToolsRequestSchema, () => ({
+    tools: options.tools
+      .filter((tool) => scopesAllowTool(options.abilities, scopedShape(tool)))
+      .map((tool) => describeTool(tool)),
+  }))
+
+  server.setRequestHandler(CallToolRequestSchema, async (request): Promise<CallToolResult> => {
+    const name = request.params.name
+    const args = (request.params.arguments ?? {}) as Record<string, unknown>
+
+    const tool = options.tools.find((candidate) => candidate.toolName === name)
+    if (!tool) {
+      return errorResult(`Unknown tool "${name}".`)
+    }
+
+    const verdict = gateToolCall(tool, options.abilities)
+    if (!verdict.allowed) {
+      options.onDenied(tool, args, verdict.reason)
+      return errorResult(verdict.message)
+    }
+
+    if (options.limiter && !options.limiter.take(options.rateKey, { write: !tool.annotations.readOnlyHint })) {
+      options.onDenied(tool, args, 'rate-limit')
+      return errorResult(
+        `Rate limit exceeded for this token${tool.annotations.readOnlyHint ? '' : ' (write budget)'}. Retry later.`,
+      )
+    }
+
+    const startedAt = performance.now()
+    try {
+      const outcome = await options.dispatch(tool, args)
+      options.onInvoked(tool, args, outcome.status, elapsed(startedAt))
+      const result: CallToolResult = { content: outcome.content }
+      if (outcome.structuredContent) result.structuredContent = outcome.structuredContent
+      if (outcome.isError) result.isError = true
+      return result
+    } catch (error) {
+      // The route's own failures came back as responses; reaching here means
+      // the dispatch itself broke. Still an invocation — it ran — recorded
+      // with the status the app would have reported for an unhandled throw.
+      options.onInvoked(tool, args, 500, elapsed(startedAt))
+      return errorResult(error instanceof Error ? error.message : String(error))
+    }
+  })
+
+  return server
+}
+
+function describeTool(tool: DerivedAgentTool) {
+  return {
+    name: tool.toolName,
+    ...(tool.description ? { description: tool.description } : {}),
+    inputSchema: tool.inputSchema as { type: 'object'; [key: string]: unknown },
+    ...(tool.outputSchema ? { outputSchema: tool.outputSchema as { type: 'object'; [key: string]: unknown } } : {}),
+    annotations: {
+      readOnlyHint: tool.annotations.readOnlyHint,
+      destructiveHint: tool.annotations.destructiveHint,
+      idempotentHint: tool.annotations.idempotentHint,
+    },
+  }
+}
+
+function errorResult(text: string): CallToolResult {
+  return { content: [{ type: 'text', text }], isError: true }
+}
+
+function elapsed(startedAt: number): number {
+  return Math.round(performance.now() - startedAt)
+}

--- a/packages/plugin-mcp/tsconfig.build.json
+++ b/packages/plugin-mcp/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build-base.json"]
+}

--- a/packages/plugin-mcp/tsconfig.json
+++ b/packages/plugin-mcp/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/plugin-mcp/tsdown.config.ts
+++ b/packages/plugin-mcp/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsdown'
+
+import { tsdownPreset } from '../../scripts/tsdown-preset'
+
+export default defineConfig({
+  ...tsdownPreset,
+  entry: ['src/index.ts'],
+  tsconfig: 'tsconfig.build.json',
+})

--- a/packages/server/src/agent/derive.ts
+++ b/packages/server/src/agent/derive.ts
@@ -79,6 +79,24 @@ export interface DerivedAgentTool {
   description?: string
   /** Merged `params` + `query` + `body`, object root (MCP requires one). */
   inputSchema: AgentToolSchema
+  /**
+   * Which contract each advertised input property came from — the inverse of
+   * the merge, for the adapter that has to take a flat tool call apart again
+   * and rebuild the HTTP request: `params`/`path` substitute into the URL
+   * path, `query` joins the query string, `body` lands in the JSON body. The
+   * schema alone cannot answer this (the merge is flat by design), and an
+   * adapter guessing by method would put a POST route's `query` keys in the
+   * body, where `validateQuery` never looks.
+   */
+  inputSources: Record<string, AgentToolInputSource>
+  /**
+   * True when the route's `body` schema was not an object and therefore nests
+   * under a single `body` property (see {@link buildInputSchema}). The
+   * dispatching adapter must then send `arguments.body` *as* the HTTP body,
+   * not an object wrapping it — the flat reconstruction would post
+   * `{ body: [...] }` to a route that validates an array.
+   */
+  inputBodyNested: boolean
   /** Present only when the route binds an `output` schema — the one shape validated at runtime. */
   outputSchema?: AgentToolSchema
   /**
@@ -138,8 +156,15 @@ const READ_ONLY_METHODS: ReadonlySet<string> = new Set(['GET', 'QUERY'])
 /** HTTP methods that are idempotent whether or not they are read-only. */
 const IDEMPOTENT_METHODS: ReadonlySet<string> = new Set(['GET', 'QUERY', 'PUT', 'DELETE'])
 
-/** Where a merged input property came from, for collision reporting. */
-type InputSource = 'params' | 'path' | 'query' | 'body'
+/**
+ * Where a merged input property came from — collision reporting inside the
+ * merge, request reconstruction outside it ({@link DerivedAgentTool.inputSources}).
+ * `params` and `path` both mean URL substitution to an adapter; they stay
+ * distinct because a warning should name the schema the author actually wrote.
+ */
+export type AgentToolInputSource = 'params' | 'path' | 'query' | 'body'
+
+type InputSource = AgentToolInputSource
 
 interface MergedInput {
   properties: Record<string, AgentToolSchema>
@@ -203,13 +228,16 @@ export function deriveAgentTools(definitions: RouteDefinition[]): DeriveAgentToo
 
     const toolWarnings: string[] = []
     const readOnlyHint = agent.readOnlyHint ?? READ_ONLY_METHODS.has(method)
+    const input = buildInputSchema(definition, method, toolWarnings)
     const tool: DerivedAgentTool = {
       toolName,
       routeName,
       method,
       path: definition.path,
       description: agent.description ?? definition.description ?? definition.summary,
-      inputSchema: buildInputSchema(definition, method, toolWarnings),
+      inputSchema: input.schema,
+      inputSources: input.sources,
+      inputBodyNested: input.nestedBody,
       outputSchema: buildOutputSchema(definition, method, toolWarnings),
       // Declared, not derived — see the field's own doc for why an
       // unrepresentable `output` must still suppress the hint.
@@ -257,11 +285,17 @@ export function deriveAgentTools(definitions: RouteDefinition[]): DeriveAgentToo
  * URL cannot be built without it. That is applied after the merge, so it holds
  * however the parameter came to be described.
  */
+interface BuiltInput {
+  schema: AgentToolSchema
+  sources: Record<string, AgentToolInputSource>
+  nestedBody: boolean
+}
+
 function buildInputSchema(
   definition: RouteDefinition,
   method: string,
   warnings: string[],
-): AgentToolSchema {
+): BuiltInput {
   const label = `${method} ${definition.path}`
   // Null-prototype: a path parameter may legally be named `__proto__`
   // (`/posts/:__proto__` — the lexer accepts `[A-Za-z0-9_-]+`), and assigning
@@ -313,6 +347,7 @@ function buildInputSchema(
     mergeProperties(merged, queryDetails.properties, queryDetails.required, 'query', warnings)
   }
 
+  let nestedBody = false
   const body = definition.schemas?.body
     ? toJsonSchema(definition.schemas.body, warnings, `${label} body`, 'input')
     : undefined
@@ -331,6 +366,7 @@ function buildInputSchema(
       // through `.optional()` — and claiming it optional would advertise a call
       // the route rejects.)
       mergeProperties(merged, { body }, new Set(['body']), 'body', warnings)
+      nestedBody = true
     }
   }
 
@@ -345,13 +381,24 @@ function buildInputSchema(
   }
 
   const required = Array.from(merged.required)
+  // Accumulated on a null prototype for the same `__proto__` reason as
+  // `merged.properties`, then spread onto a normal object on the way out.
+  const sources = Object.create(null) as Record<string, AgentToolInputSource>
+  for (const [name, source] of merged.owner) {
+    sources[name] = source
+  }
+
   return {
-    type: 'object',
-    // Copied onto a normal object: `merged.properties` has a null prototype
-    // (see above), which JSON.stringify handles but a consumer calling
-    // `hasOwnProperty` on the returned schema would not.
-    properties: { ...merged.properties },
-    ...(required.length > 0 ? { required } : {}),
+    schema: {
+      type: 'object',
+      // Copied onto a normal object: `merged.properties` has a null prototype
+      // (see above), which JSON.stringify handles but a consumer calling
+      // `hasOwnProperty` on the returned schema would not.
+      properties: { ...merged.properties },
+      ...(required.length > 0 ? { required } : {}),
+    },
+    sources: { ...sources },
+    nestedBody,
   }
 }
 

--- a/packages/server/src/auth/AuthManager.ts
+++ b/packages/server/src/auth/AuthManager.ts
@@ -36,6 +36,7 @@ export class AuthManager implements AuthManagerContract {
   private readonly providers = new Map<string, ProviderRegistryEntry<any>>()
   private defaultGuard: string
   private tokenGuard: string | null = null
+  private apiTokenStore: ApiTokenStore | null = null
 
   constructor(options: AuthManagerOptions = {}) {
     this.defaultGuard = options.defaultGuard ?? DEFAULT_GUARD
@@ -208,6 +209,20 @@ export class AuthManager implements AuthManagerContract {
     })
 
     this.tokenGuard = guardName
+    this.apiTokenStore = store
+  }
+
+  /**
+   * The `ApiTokenStore` the last `useTokens()` call configured, or undefined
+   * for an app that never opted into token auth. The store is otherwise
+   * closed over by the guard factory, so this accessor is the one way
+   * out-of-request machinery — `guren token:issue`, the App MCP adapter's
+   * principal lookup — reaches the same store the guard verifies against.
+   * Handing them a *different* store is how an issued token comes to fail
+   * verification.
+   */
+  getApiTokenStore(): ApiTokenStore | undefined {
+    return this.apiTokenStore ?? undefined
   }
 }
 

--- a/packages/server/src/auth/index.ts
+++ b/packages/server/src/auth/index.ts
@@ -40,6 +40,7 @@ export type {
 export {
   createApiToken,
   parseApiToken,
+  readBearerToken,
   verifyApiToken,
   tokenCan,
   tokenCanAll,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -39,6 +39,7 @@ export type {
 // `.guren/agents.gen.ts` and by protocol adapters, which must not derive twice.
 export { deriveAgentTools } from './agent/derive'
 export type {
+  AgentToolInputSource,
   AgentToolSchema,
   DeriveAgentToolsResult,
   DerivedAgentTool,
@@ -129,6 +130,7 @@ export {
   // API tokens
   createApiToken,
   parseApiToken,
+  readBearerToken,
   verifyApiToken,
   tokenCan,
   tokenCanAll,

--- a/packages/server/tests/agent/derive.test.ts
+++ b/packages/server/tests/agent/derive.test.ts
@@ -626,3 +626,57 @@ describe('deriveAgentTools (RFC 0016)', () => {
     })
   })
 })
+
+describe('input sources (request reconstruction)', () => {
+  test('records which contract each merged property came from', () => {
+    const router = new Router()
+    router.post(
+      '/posts/:id/comments',
+      {
+        params: z.object({ id: z.coerce.number() }),
+        query: z.object({ notify: z.coerce.boolean().optional() }),
+        body: z.object({ text: z.string() }),
+      },
+      [PostController, 'store'],
+    ).name('comments.store').agent({})
+
+    const tool = toolNamed(router, 'comments.store')
+    expect(tool.inputSources).toEqual({ id: 'params', notify: 'query', text: 'body' })
+    expect(tool.inputBodyNested).toBe(false)
+  })
+
+  test('marks an undeclared path parameter as path-sourced', () => {
+    const router = new Router()
+    router.get('/posts/:slug', [PostController, 'show']).name('posts.show').agent({})
+
+    const tool = toolNamed(router, 'posts.show')
+    expect(tool.inputSources).toEqual({ slug: 'path' })
+  })
+
+  test('a collision winner owns the property source', () => {
+    const router = new Router()
+    router.post(
+      '/posts/:id',
+      {
+        query: z.object({ id: z.string() }),
+        body: z.object({ id: z.coerce.number() }),
+      },
+      [PostController, 'update'],
+    ).name('posts.update').agent({})
+
+    const tool = toolNamed(router, 'posts.update')
+    // body merges last and wins; the path token keeps id required either way.
+    expect(tool.inputSources.id).toBe('body')
+  })
+
+  test('flags a non-object body as nested under the body property', () => {
+    const router = new Router()
+    router.post('/bulk', { body: z.array(z.number()) }, [PostController, 'store'])
+      .name('bulk.store')
+      .agent({})
+
+    const tool = toolNamed(router, 'bulk.store')
+    expect(tool.inputBodyNested).toBe(true)
+    expect(tool.inputSources).toEqual({ body: 'body' })
+  })
+})

--- a/rfcs/0016-agent-interface.md
+++ b/rfcs/0016-agent-interface.md
@@ -320,8 +320,20 @@ Each feature maps to a measured failure mode of the MCP ecosystem.
 ### 7. Protocol adapters
 
 **`@guren/plugin-mcp` (Phase 2).** Installed via `guren plugin @guren/plugin-mcp`;
-configured in `config/agent.ts` (`defineAgentConfig({ mcp: { path: '/mcp', auth } })`).
-Mounts per-request stateless `McpServer` + `WebStandardStreamableHTTPServerTransport`
+~~configured in `config/agent.ts` (`defineAgentConfig({ mcp: { path: '/mcp', auth } })`)~~.
+**Amended in implementation:** configured directly on the factory
+(`mcpPlugin({ path: '/mcp' })`), like every other Guren plugin; a
+`defineAgentConfig` wrapper can layer on later without changing the plugin's
+contract. The per-request server is the SDK's *low-level* `Server`, not
+`McpServer` — the tools already carry JSON Schema and the high-level API wants
+live Zod, which §3.2 forbids handing over. Further shipped judgments:
+tools/list is filtered to the token's scopes (an ungranted catalog would map
+the write surface for a read-only token); an `approval: 'required'` tool is
+refused fail-closed until the 2.5 queue exists; `_preflight` is deferred to a
+follow-up (it needs a server-side seam to stop the chain before the
+controller); and bearer auth answers 401 + `WWW-Authenticate: Bearer` at the
+transport boundary, before any MCP framing. Mounts per-request stateless
+server + `WebStandardStreamableHTTPServerTransport`
 (the Dev MCP pattern), derives from the live router at boot, dispatches per §3.
 Ships with bearer auth; acting as an OAuth authorization server is out of scope
 (separate RFC), except on Cloudflare below. Auto-generated MCP prompts ("how to use


### PR DESCRIPTION
## Summary

RFC 0016 Phase 2 (PR-2c): the production App MCP endpoint. `mcpPlugin()` mounts a bearer-authenticated Model Context Protocol endpoint (default `/mcp`) serving the tools the app's `.agent()` routes derive.

Every call re-enters the application through `app.fetch` as a real HTTP request (§3), so validation, policies, and middleware run exactly once — in the app — with `env` and execution context forwarded for Workers bindings. The adapter enforces only what must precede HTTP:

- **Bearer verification** against the app's own `ApiTokenStore` (401 + `WWW-Authenticate` at the transport boundary, before any MCP framing)
- **Token scopes** — a token's catalog is exactly the set it can call, and the `ApiToken` default `['*']` grants nothing
- **Approval** — `approval: 'required'` tools are refused fail-closed until the 2.5 queue ships, and are not listed
- **Per-token rate limits** with a stricter write budget

Refusals emit `AgentToolDenied`, executions `AgentToolInvoked`, arguments redacted.

`@guren/server` grows the adapter-facing surface: `DerivedAgentTool.inputSources` / `inputBodyNested` (the merge's inverse, so a POST route's `query` keys land where `validateQuery` reads them), `AuthManager.getApiTokenStore()`, and `readBearerToken` on the barrel.

## Review findings fixed

Two review passes; six real defects found and closed, each with a regression test:

- **Dot-segment path smuggling** — `encodeURIComponent` leaves `.`/`..` untouched and the URL parser then collapses the segment, so `{ name: '..' }` on `/files/:name/meta` reached `/meta`, a route the scope check never saw. Now rejected.
- **Host authorization 403** — the synthesized request was pinned to `localhost`, so any app enabling host authorization (which the framework encourages in production) rejected every tool call. The inbound origin is forwarded.
- **Non-object output schema broke `tools/list` entirely** — MCP requires `outputSchema.type === 'object'`; one `output: z.array()` route made the SDK reject the whole catalog. Only object schemas are advertised; others ride as text, gated by one shared predicate.
- **`structuredContent` invariant** — a success result for a tool advertising an object schema must carry it, or the SDK throws `-32600` *after* the route ran. 204/3xx/non-JSON/non-object bodies now return an error result naming the mismatch (which the SDK exempts).
- **Catalog/callable divergence** — approval-required tools were listed but always refused.
- **Collision winner dropped** — a path-named key the merge assigned to the body filled the URL and vanished from the body the route validates.

## Testing

45 tests: unit coverage of dispatch splitting/mapping, the scope+approval gate, and the limiter, plus an integration suite driving a real `Application` with the MCP SDK's own client over streamable HTTP — auth boundary, scope-filtered listing, dispatch re-entry, and redacted audit emission end to end. Full `packages/server` suite (2601), root typecheck, and `build` all green.

One pre-existing limitation surfaced and filed separately: `parseRequestPayload` discards non-object JSON bodies, so a route with `body: z.array()` cannot receive its payload from any HTTP caller.

Refs: RFC 0016 §3, §5, §7