### PR TITLE
docs(cli): correct the agent-interface skill's shipped/unshipped claims

### DIFF
--- a/packages/cli/templates/agent/core/skills/agent-interface/SKILL.md
+++ b/packages/cli/templates/agent/core/skills/agent-interface/SKILL.md
@@ -53,20 +53,22 @@ Declaring metadata for an action that was not registered (excluded via `only`/`e
 
 ## Metadata fields
 
-Everything below is **declared metadata**. Declaring it is what this release ships: the route records your intent, `guren check` and `guren audit` hold you to it, and `guren context <Entity>` reports it. The runtime that *derives tools from it and serves them* — the protocol surface, the annotation defaults, the approval queue, the audit log — lands with the agent surface itself. Write the metadata now; it is read by the checks today and by that surface when it arrives.
+Everything below is **declared metadata** on the route — there is still no tool definition to write. The metadata is read by `guren check`, `guren audit` and `guren context <Entity>`, and it is honoured at runtime by `@guren/plugin-mcp`, which serves the derived tools at `/mcp`: the annotation defaults are resolved during derivation, `expose.mcp` filters the served catalog, `redact` masks arguments in the audit events, and `approval: 'required'` fails closed. Two things in this table still describe surfaces that have not shipped, and both rows say so: `expose.webMcp` and the approval *queue*.
+
+Serving is a separate, app-level step: the endpoint mounts only when the app installs the plugin and configures a bearer token store. A route carries `.agent()` metadata whether or not it does — declaring it is your job, mounting the endpoint is the app's.
 
 | Field | Meaning |
 |-------|---------|
 | `description` | What the tool does. Falls back to the route's OpenAPI `description` ?? `summary`. Write it for an agent that has never seen your app. |
 | `toolName` | Overrides the route name as the tool name. |
-| `expose` | `{ mcp?, webMcp? }` — which protocol surfaces the tool should appear on. Recorded now; acted on when those surfaces ship. |
+| `expose` | `{ mcp?, webMcp? }` — which protocol surfaces the tool appears on; both default to true. `mcp: false` keeps a tool out of the MCP endpoint's catalog today. `webMcp` is recorded for a browser surface that has not shipped. |
 | `readOnlyHint` | The tool changes nothing. On a mutating verb this is an explicit override — and it exempts the route from the authorization rule below, so `guren check` holds it against the action's body. |
 | `destructiveHint` | `false` is the strong claim "additive updates only" — `guren audit` checks it against the action. Unset keeps the spec default (destructive for a non-read-only tool). |
 | `idempotentHint` | Repeat calls with the same arguments add no effect. The derivation defaults it to true for PUT and DELETE; declaring it records your own claim. |
-| `approval` | `'required'` marks the tool as needing server-side approval before it executes. Recorded now; the approval queue that honours it ships with the agent surface. |
-| `redact` | Argument field names to mask in the agent audit log. Recorded now; the audit log ships with the agent surface. |
+| `approval` | `'required'` marks the tool as needing server-side approval before it executes. There is no approval queue yet, so the MCP endpoint **fails closed** on it: the tool is neither listed nor callable. |
+| `redact` | Argument field names to mask in the `AgentToolInvoked` / `AgentToolDenied` events the endpoint emits. Unioned with a built-in fragment list (`password`, `secret`, `token`, `apikey`, …), so it *adds* to a default rather than being the whole mask. Matching is lowercased, separator-stripped containment — `redact: ['id']` also masks `userId`. |
 
-Annotations are untrusted hints for client UX. **They enforce nothing** — enforcement lives in policies and, later, the approval queue. That is exactly why the two hints that *weaken* a check are held against the controller body.
+Annotations are untrusted hints for client UX. **They enforce nothing** — enforcement lives in your policies (evaluated inside the dispatched request, exactly as for a browser) and in the calling token's tool scopes (evaluated before the request is synthesized); the approval queue is still to come. That is exactly why the two hints that *weaken* a check are held against the controller body.
 
 ## Authentication is not authorization
 


### PR DESCRIPTION
## Summary

`packages/cli/templates/agent/core/skills/agent-interface/SKILL.md` told a coding agent that declaring `.agent()` metadata was all this release shipped, and that the runtime deriving tools from it and serving them — "the protocol surface, the annotation defaults, the approval queue, the audit log" — would land later. That is no longer true: `@guren/plugin-mcp` serves those tools and honours the metadata today.

Verified against this branch's sources:

| Claim | Where it is honoured |
|---|---|
| annotation defaults resolved | `packages/server/src/agent/derive.ts:230-252` |
| `expose.mcp` filters the served catalog | `packages/plugin-mcp/src/plugin.ts:83` |
| `redact` masks arguments in the audit events | `packages/plugin-mcp/src/plugin.ts:156,168` → `packages/server/src/agent/redact.ts` |
| `approval: 'required'` fails closed | `packages/plugin-mcp/src/gate.ts:31-40`, and `server.ts:50-58` keeps such a tool out of `tools/list` |

Four edits, all in that one file:

- **Intro paragraph** — replaced the "lands with the agent surface itself" claim with what the plugin does today, plus a short paragraph noting that mounting the endpoint is a separate app-level step (installing the plugin and configuring a bearer token store), so the correction does not read as "every `.agent()` route is already reachable".
- **`expose` row** — `mcp` is acted on today (both flags default to true; `mcp: false` keeps a tool out of the catalog); only `webMcp` is still recorded-only.
- **`approval` row** — acted on today by refusing, fail-closed, not by queueing: the tool is neither listed nor callable. The approval *queue* remains unshipped and the row says so.
- **`redact` row** — the audit events ship today. Added that the declared entries are unioned with a built-in fragment list rather than being the whole mask, and that matching is lowercased, separator-stripped containment (`redact: ['id']` also masks `userId`).

Also widened one sentence under the table: enforcement lives in policies *and* in the calling token's tool scopes, not in policies alone.

Everything else is unchanged. The skill's reason to exist — the `.agent()` declaration rules, the argument-order trap, `resource()` deny-by-default, "authentication is not authorization", and the schema section — is still accurate and was left alone.

## Scope

`cli` — one harness template file (`packages/cli/templates/agent/core/skills/agent-interface/SKILL.md`). No source, no test, no published docs.

## Risk Assessment

None at runtime: the file is prose shipped into scaffolded apps by `agent:init` / `agent:sync`.

`agent:sync` needs nothing extra. Managed files are replaced by name (`agent-harness.ts:400`, `overwrite = force || (mode === 'sync' && file.managed)`; skills are claimed per name via `claimedSkillNames()` in `agent-targets.ts`), and the file name is unchanged — so no manifest update and no `RETIRED_CANONICAL_SKILLS` entry.

**Not done deliberately:** the user-facing guide this content was checked against, `docs/en/guides/agent-interface.md`, is not on this branch or on `main` — it is on a separate in-flight branch. The skill is not linked at it: the harness has no precedent for linking outside itself (every cross-reference goes through `__RULES_DIR__/*.md`, which resolves inside the scaffolded app), and a scaffolded app has no `docs/en/guides/` tree at all. Once that guide lands, adding a `guren.dev` link here is a one-line follow-up.

## Validation

```
bun run test:bun cli   # 1941 pass, 0 fail, 111 files
bun run audit:docs     # Docs audit passed
```

Both green, but neither actually exercises this change, so I am not presenting them as evidence of correctness: `audit:docs` asserts literal substrings under `docs/**` and `README.md` and never reads `packages/cli/templates/`, and no CLI test references this skill. They were run as the regression guards they are. The correctness evidence is the source-reading in the table above.

`bun run build` / `typecheck` / `test` were not run: the diff is one markdown file with no compiled or generated dependents.

- [ ] `bun run build` — not run (markdown-only change)
- [ ] `bun run typecheck` — not run (markdown-only change)
- [ ] `bun run test` — partial: `test:bun cli` green

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [ ] I added/updated tests for behavior changes — no behavior change; nothing in the suite asserts harness skill prose.
- [x] I updated relevant documentation — this change *is* the documentation fix.