### PR TITLE
fix(testing): match the runtime on repeated query parameters

### DIFF
--- a/.changeset/testing-mock-repeated-query-params.md
+++ b/.changeset/testing-mock-repeated-query-params.md
@@ -1,0 +1,13 @@
+---
+"@guren/testing": patch
+---
+
+Fix the controller mock reading repeated query parameters differently from the runtime.
+
+The mock's `validateQuery()` / `validateQuerySafe()` validated against `this.ctx.req.query()`, which is one value per key. The runtime validates against `flattenRequestQueries`, which reads `ctx.req.queries()` and returns `values.length === 1 ? values[0] : values` — so a repeated key arrives as an **array** and a single occurrence as a string. For `?tag=a&tag=b`, a `z.array(...)` schema saw `['a', 'b']` in production and `'b'` in the mock, letting a controller test pass on behavior production does not have (or fail on behavior it does).
+
+Both surfaces now flatten through one shared rule that mirrors `flattenRequestQueries` exactly. `queries()` is optional on `ControllerContext`, so a context that lacks one re-derives the same grouping from the required `req.url`; the one thing it must not fall back to is `query()`, which is single-valued by construction and is the divergence being closed.
+
+The mock's no-arg `ctx.req.query()` was built with `Object.fromEntries(searchParams.entries())`, keeping the **last** occurrence of a repeated key, while Hono's keeps the **first** (`?tag=a&tag=b` reads back as `a`). That second divergence is fixed too.
+
+`packages/testing/tests/controller.test.ts` pins the parity by running the same URL through the mock and through a real `Application.fetch()` controller, covering a repeated key and a single-occurrence key in one comparison, so the two cannot drift apart again.

--- a/packages/testing/src/controller.ts
+++ b/packages/testing/src/controller.ts
@@ -58,20 +58,22 @@ export function createControllerContext(
     method: request.method,
     query: (key?: string) => {
       if (!key) {
-        return Object.fromEntries(searchParams.entries())
+        // Hono's no-arg `query()` keeps the FIRST occurrence of a repeated
+        // key, so `?tag=a&tag=b` reads back as `a`. `Object.fromEntries` over
+        // the entries keeps the last one, which is how the mock came to
+        // disagree with the runtime here.
+        const first: Record<string, string> = {}
+        for (const [name, value] of searchParams.entries()) {
+          if (!(name in first)) {
+            first[name] = value
+          }
+        }
+        return first
       }
 
       return searchParams.get(key) ?? undefined
     },
-    queries: () => {
-      const values = new Map<string, string[]>()
-      for (const [key, value] of searchParams.entries()) {
-        const existing = values.get(key) ?? []
-        existing.push(value)
-        values.set(key, existing)
-      }
-      return Object.fromEntries(values)
-    },
+    queries: () => groupSearchParams(searchParams),
     param: () => undefined,
     header: (name: string) => request.headers.get(name) ?? undefined,
   }
@@ -150,6 +152,39 @@ function asRecord(body: unknown): Record<string, unknown> {
   return typeof body === 'object' && body !== null && !Array.isArray(body)
     ? (body as Record<string, unknown>)
     : {}
+}
+
+/**
+ * The mock's counterpart to the runtime's `flattenRequestQueries`: query data
+ * as a validation schema sees it, keeping a repeated key as an array and a
+ * single occurrence as a plain string (`?tag=a&tag=b` → `{ tag: ['a', 'b'] }`,
+ * `?page=2` → `{ page: '2' }`).
+ *
+ * The runtime calls `ctx.req.queries()` unconditionally, so a context without
+ * one throws there. `queries()` is optional on {@link ControllerContext}, and
+ * the fallback re-derives the same grouping from `req.url` — which is required,
+ * and is what `createControllerContext` parses internally anyway. It must not
+ * fall back to `query()`: that surface is one value per key by construction,
+ * which is the divergence this function exists to close.
+ */
+function flattenContextQueries(ctx: ControllerContext): Record<string, unknown> {
+  const queries = ctx.req.queries?.() ?? groupSearchParams(new URL(ctx.req.url).searchParams)
+  const flat: Record<string, unknown> = {}
+  for (const [key, values] of Object.entries(queries)) {
+    flat[key] = values.length === 1 ? values[0] : values
+  }
+  return flat
+}
+
+/** Groups repeated search params into `queries()`' `Record<string, string[]>`. */
+function groupSearchParams(searchParams: URLSearchParams): Record<string, string[]> {
+  const values = new Map<string, string[]>()
+  for (const [key, value] of searchParams.entries()) {
+    const existing = values.get(key) ?? []
+    existing.push(value)
+    values.set(key, existing)
+  }
+  return Object.fromEntries(values)
 }
 
 export function createGurenControllerModule() {
@@ -455,7 +490,7 @@ export function createControllerModuleMock() {
         | { success: true; data: T }
         | { success: false; error: { issues?: Array<{ path: (string | number)[]; message: string }> } }
     }): T {
-      return this.runValidation(schema, this.ctx.req.query(), 422)
+      return this.runValidation(schema, flattenContextQueries(this.ctx), 422)
     }
 
     public validateQuerySafe<T>(schema: {
@@ -463,7 +498,7 @@ export function createControllerModuleMock() {
         | { success: true; data: T }
         | { success: false; error: { issues?: Array<{ path: (string | number)[]; message: string }> } }
     }): { success: true; data: T } | { success: false; errors: Record<string, string> } {
-      return this.runValidationSafe(schema, this.ctx.req.query())
+      return this.runValidationSafe(schema, flattenContextQueries(this.ctx))
     }
 
     public validateParams<T>(schema: {

--- a/packages/testing/src/controller.ts
+++ b/packages/testing/src/controller.ts
@@ -63,10 +63,8 @@ export function createControllerContext(
         // the entries keeps the last one, which is how the mock came to
         // disagree with the runtime here.
         const first: Record<string, string> = {}
-        for (const [name, value] of searchParams.entries()) {
-          if (!(name in first)) {
-            first[name] = value
-          }
+        for (const [name, value] of searchParams) {
+          first[name] ??= value
         }
         return first
       }
@@ -178,13 +176,7 @@ function flattenContextQueries(ctx: ControllerContext): Record<string, unknown> 
 
 /** Groups repeated search params into `queries()`' `Record<string, string[]>`. */
 function groupSearchParams(searchParams: URLSearchParams): Record<string, string[]> {
-  const values = new Map<string, string[]>()
-  for (const [key, value] of searchParams.entries()) {
-    const existing = values.get(key) ?? []
-    existing.push(value)
-    values.set(key, existing)
-  }
-  return Object.fromEntries(values)
+  return Object.fromEntries([...searchParams.keys()].map((key) => [key, searchParams.getAll(key)]))
 }
 
 export function createGurenControllerModule() {

--- a/packages/testing/tests/controller.test.ts
+++ b/packages/testing/tests/controller.test.ts
@@ -579,3 +579,123 @@ describe('readInertiaResponse', () => {
     expect(result.payload.props.html).toBe('<div>&</div>')
   })
 })
+
+/**
+ * The mock and the runtime must hand a validation schema the same query data,
+ * or a controller test passes on behavior production does not have.
+ *
+ * The runtime validates against `flattenRequestQueries`, which reads
+ * `ctx.req.queries()` and returns `values.length === 1 ? values[0] : values` —
+ * so a repeated key arrives as an ARRAY and a single occurrence as a string.
+ * The mock validated against `ctx.req.query()`, one value per key, so
+ * `?tag=a&tag=b` reached a `z.array(...)` schema as `'b'`.
+ *
+ * The probe is `validateQuery`/`validateQuerySafe` specifically: `input()`
+ * takes the keyed `query(key)` form on both sides and already agreed, so an
+ * `input()`-based test here could never fail. The schema is an identity one so
+ * the buggy mock returns a wrong shape instead of throwing 422, which is what
+ * lets the two sides be compared directly. Both keys are asserted on purpose:
+ * a repeated-only case also passes under a mock that wraps every value in an
+ * array, which would agree on `tag` while newly disagreeing on `page`.
+ */
+describe('repeated query parameters', () => {
+  const URL_UNDER_TEST = 'http://example.com/posts?tag=core&tag=framework&page=2'
+  const EXPECTED = { tag: ['core', 'framework'], page: '2' }
+
+  const identitySchema = {
+    safeParse: (data: unknown) => ({ success: true as const, data }),
+  }
+
+  function readThroughMock(surface: 'validateQuery' | 'validateQuerySafe'): unknown {
+    const { Controller } = createControllerModuleMock()
+
+    class ReadController extends Controller {
+      read() {
+        if (surface === 'validateQuery') {
+          return this.validateQuery(identitySchema)
+        }
+        const result = this.validateQuerySafe(identitySchema)
+        return result.success ? result.data : result.errors
+      }
+    }
+
+    const controller = new ReadController()
+    controller.setContext(
+      createControllerContext(URL_UNDER_TEST) as unknown as ControllerContext
+    )
+
+    return controller.read()
+  }
+
+  async function readThroughRuntime(
+    surface: 'validateQuery' | 'validateQuerySafe',
+  ): Promise<unknown> {
+    // Lazy, like the rest of this package: the mock resolves @guren/server on
+    // demand so a suite that mocks it still gets the real module here.
+    const { Controller, createApp } = await import('@guren/core')
+
+    class ReadController extends Controller {
+      read() {
+        if (surface === 'validateQuery') {
+          return this.json({ value: this.validateQuery(identitySchema) })
+        }
+        const result = this.validateQuerySafe(identitySchema)
+        return this.json({ value: result.success ? result.data : result.errors })
+      }
+    }
+
+    const app = createApp({
+      routes: (router) => {
+        router.get('/posts', [ReadController, 'read'])
+      },
+    })
+    await app.boot()
+
+    const response = await app.fetch(new Request(URL_UNDER_TEST))
+    expect(response.status).toBe(200)
+
+    return ((await response.json()) as { value: unknown }).value
+  }
+
+  for (const surface of ['validateQuery', 'validateQuerySafe'] as const) {
+    it(`${surface}() sees repeated keys as arrays in the mock and the runtime`, async () => {
+      const fromMock = readThroughMock(surface)
+      const fromRuntime = await readThroughRuntime(surface)
+
+      expect(fromRuntime).toEqual(EXPECTED)
+      expect(fromMock).toEqual(EXPECTED)
+      expect(fromMock).toEqual(fromRuntime)
+    })
+  }
+
+  it('flattens from req.url when the context has no queries()', () => {
+    // The fallback branch of flattenContextQueries: `queries()` is optional on
+    // ControllerContext, and a hand-rolled context without one must still see
+    // the array — falling back to `query()` would quietly restore the bug.
+    const { Controller } = createControllerModuleMock()
+
+    class ReadController extends Controller {
+      read() {
+        return this.validateQuery(identitySchema)
+      }
+    }
+
+    const full = createControllerContext(URL_UNDER_TEST)
+    const withoutQueries = {
+      ...full,
+      req: { ...full.req, queries: undefined },
+    } as unknown as ControllerContext
+
+    const controller = new ReadController()
+    controller.setContext(withoutQueries)
+
+    expect(controller.read()).toEqual(EXPECTED)
+  })
+
+  it('reads back the first occurrence from the mock context, as Hono does', () => {
+    const ctx = createControllerContext(URL_UNDER_TEST)
+
+    expect(ctx.req.query()).toEqual({ tag: 'core', page: '2' })
+    expect(ctx.req.query('tag')).toBe('core')
+  })
+})

--- a/packages/testing/tests/controller.test.ts
+++ b/packages/testing/tests/controller.test.ts
@@ -606,41 +606,43 @@ describe('repeated query parameters', () => {
     safeParse: (data: unknown) => ({ success: true as const, data }),
   }
 
-  function readThroughMock(surface: 'validateQuery' | 'validateQuerySafe'): unknown {
+  /** Both surfaces read the same context, so one pass answers for both. */
+  interface BothSurfaces {
+    validateQuery: unknown
+    validateQuerySafe: unknown
+  }
+
+  function readThroughMock(ctx: ControllerContext): BothSurfaces {
     const { Controller } = createControllerModuleMock()
 
     class ReadController extends Controller {
-      read() {
-        if (surface === 'validateQuery') {
-          return this.validateQuery(identitySchema)
+      read(): BothSurfaces {
+        const safe = this.validateQuerySafe(identitySchema)
+        return {
+          validateQuery: this.validateQuery(identitySchema),
+          validateQuerySafe: safe.success ? safe.data : safe.errors,
         }
-        const result = this.validateQuerySafe(identitySchema)
-        return result.success ? result.data : result.errors
       }
     }
 
     const controller = new ReadController()
-    controller.setContext(
-      createControllerContext(URL_UNDER_TEST) as unknown as ControllerContext
-    )
+    controller.setContext(ctx)
 
     return controller.read()
   }
 
-  async function readThroughRuntime(
-    surface: 'validateQuery' | 'validateQuerySafe',
-  ): Promise<unknown> {
+  async function readThroughRuntime(): Promise<BothSurfaces> {
     // Lazy, like the rest of this package: the mock resolves @guren/server on
     // demand so a suite that mocks it still gets the real module here.
     const { Controller, createApp } = await import('@guren/core')
 
     class ReadController extends Controller {
       read() {
-        if (surface === 'validateQuery') {
-          return this.json({ value: this.validateQuery(identitySchema) })
-        }
-        const result = this.validateQuerySafe(identitySchema)
-        return this.json({ value: result.success ? result.data : result.errors })
+        const safe = this.validateQuerySafe(identitySchema)
+        return this.json({
+          validateQuery: this.validateQuery(identitySchema),
+          validateQuerySafe: safe.success ? safe.data : safe.errors,
+        })
       }
     }
 
@@ -654,42 +656,30 @@ describe('repeated query parameters', () => {
     const response = await app.fetch(new Request(URL_UNDER_TEST))
     expect(response.status).toBe(200)
 
-    return ((await response.json()) as { value: unknown }).value
+    return (await response.json()) as BothSurfaces
   }
 
-  for (const surface of ['validateQuery', 'validateQuerySafe'] as const) {
-    it(`${surface}() sees repeated keys as arrays in the mock and the runtime`, async () => {
-      const fromMock = readThroughMock(surface)
-      const fromRuntime = await readThroughRuntime(surface)
+  it('validateQuery()/validateQuerySafe() see repeated keys as arrays in the mock and the runtime', async () => {
+    const fromRuntime = await readThroughRuntime()
+    const fromMock = readThroughMock(
+      createControllerContext(URL_UNDER_TEST) as unknown as ControllerContext
+    )
 
-      expect(fromRuntime).toEqual(EXPECTED)
-      expect(fromMock).toEqual(EXPECTED)
-      expect(fromMock).toEqual(fromRuntime)
-    })
-  }
+    expect(fromRuntime).toEqual({ validateQuery: EXPECTED, validateQuerySafe: EXPECTED })
+    expect(fromMock).toEqual(fromRuntime)
+  })
 
   it('flattens from req.url when the context has no queries()', () => {
     // The fallback branch of flattenContextQueries: `queries()` is optional on
     // ControllerContext, and a hand-rolled context without one must still see
     // the array — falling back to `query()` would quietly restore the bug.
-    const { Controller } = createControllerModuleMock()
-
-    class ReadController extends Controller {
-      read() {
-        return this.validateQuery(identitySchema)
-      }
-    }
-
     const full = createControllerContext(URL_UNDER_TEST)
     const withoutQueries = {
       ...full,
       req: { ...full.req, queries: undefined },
     } as unknown as ControllerContext
 
-    const controller = new ReadController()
-    controller.setContext(withoutQueries)
-
-    expect(controller.read()).toEqual(EXPECTED)
+    expect(readThroughMock(withoutQueries).validateQuery).toEqual(EXPECTED)
   })
 
   it('reads back the first occurrence from the mock context, as Hono does', () => {


### PR DESCRIPTION
## Summary

`@guren/testing`'s controller mock disagreed with the `@guren/server` runtime on repeated query parameters, so a controller test could pass on behavior production does not have.

The mock's `validateQuery()` / `validateQuerySafe()` validated against `this.ctx.req.query()`, which is one value per key. The runtime validates against `flattenRequestQueries` (`packages/server/src/http/request.ts`), which reads `ctx.req.queries()` and returns `values.length === 1 ? values[0] : values` — so a repeated key arrives as an **array** and a single occurrence as a string. For `?tag=a&tag=b`, a `z.array(...)` schema saw `['a', 'b']` in production and `'b'` in the mock.

Both surfaces now flatten through one shared rule that mirrors `flattenRequestQueries` exactly. `queries()` is optional on the published `ControllerContext` type, so a context that lacks one re-derives the same grouping from the required `req.url`. What it must **not** fall back to is `query()`: that surface is single-valued by construction and is the divergence being closed.

A second divergence in the same file is fixed too. The mock context's no-arg `ctx.req.query()` was `Object.fromEntries(searchParams.entries())`, keeping the **last** occurrence of a repeated key, while Hono keeps the **first** (`?tag=a&tag=b` reads back as `a`). Verified directly against Hono rather than assumed.

`input()` needed no change: both sides take the keyed `query(key)` form, which is first-wins on Hono and on `searchParams.get()` alike. That is why the new test probes `validateQuery`/`validateQuerySafe` specifically — an `input()`-based test here could not fail.

This is the same bug class as the repeated-form-fields fix on `claude/elegant-pike-27977d` (`ca500398`), which is not in this branch's history. See Risk Assessment.

## Scope

- `testing` — `packages/testing/src/controller.ts`, `packages/testing/tests/controller.test.ts`
- changeset: `@guren/testing` patch

## Risk Assessment

- **Behavior change, intended:** a controller test that asserted the mock's old single-valued query shape will now see an array for a repeated key. That is the point — the old shape was not what production produces.
- **No runtime change.** `@guren/server` is untouched; only the test double moved.
- **No type break.** `queries` stays optional on `ControllerContext`, which is a published type. Making it required would delete the fallback branch and its test, but it is a structural break for anyone hand-rolling a context — worth a follow-up in the next minor, not a patch.
- **Merge order matters:** `ca500398` (repeated form fields) sits on the sibling branch `claude/elegant-pike-27977d` and is not an ancestor of this branch. Both append a `describe(...)` block at the tail of `packages/testing/tests/controller.test.ts`, so whichever lands second will conflict there. The fixes themselves do not overlap (form body vs query string) and the changeset filenames differ.

## Validation

- [x] `bun run build` (`build:clean`)
- [x] `bun run typecheck`
- [x] `bun run test` — exit 0
- [x] `bun run test:testing` — 13 files, 184 tests passed

**Mutation-verified** — the test was confirmed able to fail, one call site at a time:

| Mutation | Result |
|---|---|
| `validateQuery` reverted to `query()` | red |
| `validateQuerySafe` reverted to `query()` | red |
| no-arg `query()` back to last-wins | red |
| `flattenContextQueries` fallback branch stubbed | red |
| `groupSearchParams` truncated to first value | red |

The parity test runs the same URL through the mock and through a real `Application.fetch()` controller built with `createApp` from `@guren/core`, comparing a repeated key and a single-occurrence key in one assertion. Both are asserted on purpose: a repeated-only case also passes under a mock that wraps every value in an array.

The second commit is a `/simplify` pass over the same diff (`??=` for the first-wins scan, `getAll()` for the grouping, and one parity helper answering both surfaces instead of a `surface` string branching in two places). All five mutations were re-run against the simplified code.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation — no user-facing docs describe the mock's query shape; the changeset carries the note.

## Follow-ups (not in this PR)

- `formatValidationErrors` is a fourth runtime mirror in the same file and **has already diverged**: the runtime keys on `issue.path?.[0]` (string only) with a fallback `message` key, the mock keys on `issue.path.join('.')` with none — and `packages/testing/tests/controller.test.ts:316` pins the divergence in. Same bug class, pre-existing.
- Make `queries` required on `ControllerContext` in the next minor, which deletes the fallback branch and its test.
