### PR TITLE
fix(testing): match the runtime's Content-Type rule in the controller mock

### DIFF
--- a/.changeset/mock-content-type-parity.md
+++ b/.changeset/mock-content-type-parity.md
@@ -1,0 +1,9 @@
+---
+"@guren/testing": patch
+---
+
+Match the runtime's `Content-Type` rule in the controller mock's body parsing.
+
+The mock gated its form branches on a case-sensitive `contentType.includes(...)` substring test, while the runtime reaches form bodies through `ctx.req.parseBody()`, which compares the media type — `Content-Type` up to the first `;`, trimmed and lowercased — with `===`. The substring test diverged in both directions: `Application/X-WWW-Form-Urlencoded` and `Multipart/Form-Data; boundary=…` were ignored by the mock and parsed by the runtime, and `application/x-www-form-urlencoded-evil` was parsed by the mock and ignored by the runtime. Either way a controller test could pass on behavior production does not have. The same gate sits in front of `file()`/`files()`, so a mixed-case multipart upload read as `null` in the mock while the runtime delivered the file.
+
+Both gates now apply the media-type rule. The JSON branch deliberately keeps its case-sensitive `includes('application/json')`: the runtime reaches `ctx.req.json()` through exactly that test, so `application/json-evil` is read as JSON and `Application/JSON` is not, in the mock and the runtime alike. All three are now pinned by tests that run one request through the mock and through a real `Application.fetch()` controller and assert both the agreement and the concrete value, alongside tests that pin where a malformed body is swallowed.

--- a/packages/testing/src/controller.ts
+++ b/packages/testing/src/controller.ts
@@ -114,6 +114,23 @@ function loadServer(): Promise<ServerModule> {
 }
 
 /**
+ * Hono's media-type rule, which is what every form body in the runtime is
+ * gated on: `parseBody()` takes `Content-Type` up to the first `;`, trims it,
+ * lowercases it, and compares with `===` (hono/utils/body). A substring test
+ * diverges in *both* directions — it misses `Application/X-WWW-Form-Urlencoded`,
+ * which the runtime parses, and it accepts
+ * `application/x-www-form-urlencoded-evil`, which the runtime does not.
+ *
+ * The JSON branch below deliberately keeps its case-sensitive `includes()`
+ * instead: the runtime reaches `ctx.req.json()` through exactly that test, so
+ * `application/json-evil` is read as JSON and `Application/JSON` falls past it
+ * to the form rule — in the mock and in the runtime alike.
+ */
+function isMediaType(contentType: string, mediaType: string): boolean {
+  return contentType.split(';')[0]?.trim().toLowerCase() === mediaType
+}
+
+/**
  * The mock's counterpart to the runtime's `parseRequestBody`: the parsed body
  * as sent, so an array stays an array for `validateBody()` to judge.
  */
@@ -128,12 +145,12 @@ async function parseRequestBody(ctx: ControllerContext): Promise<unknown> {
     return request.json().catch(() => ({}))
   }
 
-  if (contentType.includes('application/x-www-form-urlencoded')) {
+  if (isMediaType(contentType, 'application/x-www-form-urlencoded')) {
     const text = await request.text()
     return Object.fromEntries(new URLSearchParams(text))
   }
 
-  if (contentType.includes('multipart/form-data')) {
+  if (isMediaType(contentType, 'multipart/form-data')) {
     const formData = await request.formData()
     const result: Record<string, unknown> = {}
     formData.forEach((value, key) => {
@@ -402,7 +419,9 @@ export function createControllerModuleMock() {
         // Clone for the same reason as parseRequestPayload: both may read the
         // body of the same request, mirroring Hono's parse cache — and the
         // memo keeps repeated file()/files() calls to one parse.
-        this.multipartBody = contentType.includes('multipart/form-data')
+        // The runtime's file()/files() read ctx.req.parseBody(), so they are
+        // gated on Hono's media-type rule too — see isMediaType.
+        this.multipartBody = isMediaType(contentType, 'multipart/form-data')
           ? request.clone().formData()
           : Promise.resolve(null)
       }

--- a/packages/testing/tests/controller.test.ts
+++ b/packages/testing/tests/controller.test.ts
@@ -724,6 +724,43 @@ describe('body content-type recognition', () => {
   }
 
   /**
+   * The same rule has to hold on the module's `parseRequestPayload`, not just
+   * on the class: a route contract's `body` and `validateRequest()` reach the
+   * body through that export and never touch a Controller instance, so an app
+   * that mocks `@guren/core` gets its contract validation from here.
+   */
+  it('parseRequestPayload applies the media-type rule in the mock and the runtime', async () => {
+    const init = urlencoded('Application/X-WWW-Form-Urlencoded')
+
+    const fromMock = await createGurenControllerModule().parseRequestPayload(
+      createControllerContext('http://example.com/posts', init) as unknown as ControllerContext
+    )
+
+    const { Controller, createApp } = await import('@guren/core')
+    const { parseRequestPayload } = await import('@guren/server')
+
+    class ReadController extends Controller {
+      async read() {
+        return this.json({ value: await parseRequestPayload(this.ctx) })
+      }
+    }
+
+    const app = createApp({
+      routes: (router) => {
+        router.post('/posts', [ReadController, 'read'])
+      },
+    })
+    await app.boot()
+
+    const response = await app.fetch(new Request('http://example.com/posts', init))
+    expect(response.status).toBe(200)
+    const fromRuntime = ((await response.json()) as { value: unknown }).value
+
+    expect(fromRuntime).toEqual({ [FIELD]: VALUE })
+    expect(fromMock).toEqual({ [FIELD]: VALUE })
+  })
+
+  /**
    * `file()` reads the multipart body through a separate gate in both — the
    * mock's `readMultipart()`, the runtime's `ctx.req.parseBody({ all: true })`
    * — so the media-type rule has to hold there too, or an upload test passes

--- a/packages/testing/tests/controller.test.ts
+++ b/packages/testing/tests/controller.test.ts
@@ -579,3 +579,242 @@ describe('readInertiaResponse', () => {
     expect(result.payload.props.html).toBe('<div>&</div>')
   })
 })
+
+/**
+ * The mock and the runtime must agree on *which* bodies they read, or a
+ * controller test passes on behavior production does not have.
+ *
+ * The runtime's rule has two halves, and they are not the same rule:
+ *
+ * - JSON is a case-sensitive substring test. `parseRequestBody()` reaches
+ *   `ctx.req.json()` through `contentType.includes('application/json')`, so
+ *   `application/json-evil` is read as JSON while `Application/JSON` is not.
+ * - Everything else falls through to `ctx.req.parseBody()`, which compares
+ *   the media type — `Content-Type` up to the first `;`, trimmed and
+ *   lowercased — with `===`. So `Application/X-WWW-Form-Urlencoded` parses
+ *   and `application/x-www-form-urlencoded-evil` does not.
+ *
+ * A substring test on the form branches diverges in both directions at once,
+ * which is why both directions are asserted here. Each case runs the same
+ * request through the mock and through a real `Application.fetch()`, and
+ * asserts the concrete value as well, so the pair cannot agree on the wrong
+ * answer.
+ */
+describe('body content-type recognition', () => {
+  const FIELD = 'a'
+  const VALUE = 'hit'
+  const BOUNDARY = '----gurenparity'
+
+  const urlencoded = (contentType: string): RequestInit => ({
+    method: 'POST',
+    headers: { 'Content-Type': contentType },
+    body: new URLSearchParams({ [FIELD]: VALUE }).toString(),
+  })
+
+  const json = (contentType: string): RequestInit => ({
+    method: 'POST',
+    headers: { 'Content-Type': contentType },
+    body: JSON.stringify({ [FIELD]: VALUE }),
+  })
+
+  // Hand-built rather than via FormData: passing a FormData body lets the
+  // runtime pick the Content-Type, and the header is exactly what is under
+  // test here.
+  const multipart = (contentType: string): RequestInit => ({
+    method: 'POST',
+    headers: { 'Content-Type': contentType },
+    body:
+      `--${BOUNDARY}\r\n` +
+      `Content-Disposition: form-data; name="${FIELD}"\r\n\r\n` +
+      `${VALUE}\r\n` +
+      `--${BOUNDARY}--\r\n`,
+  })
+
+  async function readThroughControllerMock(init: RequestInit): Promise<unknown> {
+    const { Controller } = createControllerModuleMock()
+
+    class ReadController extends Controller {
+      async read() {
+        return (await this.input<string>(FIELD)) ?? null
+      }
+    }
+
+    const controller = new ReadController()
+    controller.setContext(
+      createControllerContext('http://example.com/posts', init) as unknown as ControllerContext
+    )
+
+    return controller.read()
+  }
+
+  async function readThroughApplication(init: RequestInit): Promise<unknown> {
+    // Lazy, like the rest of this package: the mock resolves @guren/server on
+    // demand so a suite that mocks it still gets the real module here.
+    const { Controller, createApp } = await import('@guren/core')
+
+    class ReadController extends Controller {
+      async read() {
+        return this.json({ value: (await this.input<string>(FIELD)) ?? null })
+      }
+    }
+
+    const app = createApp({
+      routes: (router) => {
+        router.post('/posts', [ReadController, 'read'])
+      },
+    })
+    await app.boot()
+
+    const response = await app.fetch(new Request('http://example.com/posts', init))
+    expect(response.status).toBe(200)
+
+    return ((await response.json()) as { value: unknown }).value
+  }
+
+  const CASES = [
+    {
+      name: 'a mixed-case urlencoded media type is read',
+      init: () => urlencoded('Application/X-WWW-Form-Urlencoded'),
+      expected: VALUE,
+    },
+    {
+      name: 'a urlencoded media type with parameters is read',
+      init: () => urlencoded('application/x-www-form-urlencoded; charset=UTF-8'),
+      expected: VALUE,
+    },
+    {
+      name: 'a media type that merely starts with the urlencoded one is ignored',
+      init: () => urlencoded('application/x-www-form-urlencoded-evil'),
+      expected: null,
+    },
+    {
+      name: 'a mixed-case multipart media type is read',
+      init: () => multipart(`Multipart/Form-Data; boundary=${BOUNDARY}`),
+      expected: VALUE,
+    },
+    {
+      name: 'a media type that merely starts with the multipart one is ignored',
+      init: () => multipart(`multipart/form-data-evil; boundary=${BOUNDARY}`),
+      expected: null,
+    },
+    // The JSON branch is asserted, not assumed: the runtime gates it on a
+    // case-sensitive substring, so these two are the shape a media-type rule
+    // applied there would break.
+    {
+      name: 'a mixed-case JSON media type is not read as JSON',
+      init: () => json('Application/JSON'),
+      expected: null,
+    },
+    {
+      name: 'a media type that merely starts with the JSON one is read as JSON',
+      init: () => json('application/json-evil'),
+      expected: VALUE,
+    },
+  ] as const
+
+  for (const { name, init, expected } of CASES) {
+    it(`${name}, in the mock and the runtime`, async () => {
+      const fromMock = await readThroughControllerMock(init())
+      const fromRuntime = await readThroughApplication(init())
+
+      expect(fromRuntime).toBe(expected)
+      expect(fromMock).toBe(expected)
+      expect(fromMock).toBe(fromRuntime)
+    })
+  }
+
+  /**
+   * `file()` reads the multipart body through a separate gate in both — the
+   * mock's `readMultipart()`, the runtime's `ctx.req.parseBody({ all: true })`
+   * — so the media-type rule has to hold there too, or an upload test passes
+   * against a file the runtime would have delivered (or missed).
+   */
+  it('file() sees a mixed-case multipart media type in the mock and the runtime', async () => {
+    const init: RequestInit = {
+      method: 'POST',
+      headers: { 'Content-Type': `Multipart/Form-Data; boundary=${BOUNDARY}` },
+      body:
+        `--${BOUNDARY}\r\n` +
+        `Content-Disposition: form-data; name="avatar"; filename="a.txt"\r\n` +
+        'Content-Type: text/plain\r\n\r\n' +
+        'hello\r\n' +
+        `--${BOUNDARY}--\r\n`,
+    }
+
+    const { Controller: MockController } = createControllerModuleMock()
+
+    class MockUploadController extends MockController {
+      async upload() {
+        return (await this.file('avatar'))?.name ?? null
+      }
+    }
+
+    const mockController = new MockUploadController()
+    mockController.setContext(
+      createControllerContext('http://example.com/uploads', init) as unknown as ControllerContext
+    )
+    const fromMock = await mockController.upload()
+
+    const { Controller, createApp } = await import('@guren/core')
+
+    class UploadController extends Controller {
+      async upload() {
+        return this.json({ value: (await this.file('avatar'))?.name ?? null })
+      }
+    }
+
+    const app = createApp({
+      routes: (router) => {
+        router.post('/uploads', [UploadController, 'upload'])
+      },
+    })
+    await app.boot()
+
+    const response = await app.fetch(new Request('http://example.com/uploads', init))
+    expect(response.status).toBe(200)
+    const fromRuntime = ((await response.json()) as { value: unknown }).value
+
+    expect(fromRuntime).toBe('a.txt')
+    expect(fromMock).toBe('a.txt')
+  })
+
+  /**
+   * A body the parser cannot read must reach the field helpers as `{}`, not
+   * as a throw. The runtime swallows it in exactly one place — the private
+   * `getRawBody()` in `Controller` — while the exported `parseRequestPayload`
+   * lets it out; the mock mirrors that split, so these pin the class layer.
+   *
+   * Both encodings are here because they fail differently: malformed JSON is
+   * caught inside the parser (`.catch(() => ({}))`), while a multipart body
+   * with no boundary rejects out of `formData()` and is only caught one level
+   * up.
+   */
+  const MALFORMED = [
+    {
+      name: 'malformed JSON',
+      init: (): RequestInit => ({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{not json',
+      }),
+    },
+    {
+      name: 'a multipart body with no boundary',
+      init: (): RequestInit => ({
+        method: 'POST',
+        headers: { 'Content-Type': 'multipart/form-data' },
+        body: 'not a multipart body',
+      }),
+    },
+  ] as const
+
+  for (const { name, init } of MALFORMED) {
+    it(`${name} reads as an empty body in the mock and the runtime`, async () => {
+      const fromMock = await readThroughControllerMock(init())
+      const fromRuntime = await readThroughApplication(init())
+
+      expect(fromRuntime).toBe(null)
+      expect(fromMock).toBe(null)
+    })
+  }
+})


### PR DESCRIPTION
## Summary

`@guren/testing`'s controller mock gated its form-body branches on a case-sensitive `contentType.includes(...)` substring test. The runtime does not: it reaches form bodies through `ctx.req.parseBody()`, which compares the *media type* — `Content-Type` up to the first `;`, trimmed and lowercased — with `===` (`hono/utils/body`). A substring test diverges in both directions at once, so a controller test could pass on behavior production does not have.

Found by a Codex review, then measured directly: every case below was run through the mock and through a real `createApp(...)` + `Application.fetch()` controller.

| `Content-Type` (body `a=hit`) | mock `input('a')` | runtime `input('a')` |
|---|---|---|
| `Application/X-WWW-Form-Urlencoded` | `undefined` | `"hit"` |
| `application/x-www-form-urlencoded-evil` | `"hit"` | `null` |
| `Multipart/Form-Data; boundary=…` | `undefined` | `"hit"` |

The third row was not in the original report; it falls out of the same rule (`bufferToFormData` lowercases the media type before handing the body to `Response.formData()`). The same gate also sits in front of `readMultipart()`, so a mixed-case multipart upload read as `null` from `file()` in the mock while the runtime delivered the `File`.

### The fix

One new helper, `isMediaType()`, applied to the three gates that the runtime routes through Hono: the two form branches in the mock's `parseRequestBody`, and `readMultipart()`. Only the `if` conditions changed — the branch bodies are untouched.

**The JSON branch deliberately keeps its case-sensitive `includes('application/json')`.** The task suggested it might have the same problem; measurement says otherwise. The runtime reaches `ctx.req.json()` through exactly that test, so `application/json-evil` *is* read as JSON and `Application/JSON` is *not*, in the mock and the runtime alike. Both directions are now pinned by tests rather than left to the next reader's judgement.

### Malformed bodies: measured, no code change here

The original report also named malformed bodies (`{not json` under `application/json`; `multipart/form-data` with no boundary) as a divergence where the mock throws and the runtime does not. **That was true of the base the report was written against, not of `main`.** Measured on this branch's base, the two already agreed in both directions, so no `catch` was added — adding one would have created a divergence in the name of fixing one. What this branch adds is tests pinning the agreement.

Since then #595 has landed on `main` and moved *where* the swallow happens: it is now inside `parseRequestBody` itself on both sides, so the exported `parseRequestPayload` no longer lets the throw out either. Re-measured after merging `main`, and the doc comment on those tests was corrected — it described the pre-merge split. The tests themselves assert observable behavior and did not need to change.

## Scope

- `packages/testing` — `src/controller.ts` (3 gates), `tests/controller.test.ts` (+11 tests)
- `.changeset/mock-content-type-parity.md` — `@guren/testing` patch

No runtime package changed; `@guren/server` was read, not edited.

## Risk Assessment

Behavior change is confined to the test-time mock, and in every direction it moves the mock *toward* the runtime. A suite that was relying on the old behavior was relying on a body the runtime would not have parsed (or would have), so a break here is the bug surfacing, not a regression.

`main` has been merged into this branch (merge commit, no rebase). Two conflicts in `@guren/testing`, both resolved keeping each side whole:

- `src/controller.ts` — #595 wrapped the mock's entire `parseRequestBody` in a `try`/`catch` returning `{}`; this branch re-gated the two form branches. Resolved to #595's structure with the media-type gates re-applied inside it.
- `tests/controller.test.ts` — both sides appended a `describe` at file end and git interleaved them. Kept both, sequentially: `repeated query parameters` (#593) and `body content-type recognition` (this branch).

## Validation

All gates green on the committed tree:

- [x] `bun run build` — ran as `bun run build:clean`, exit 0
- [x] `bun run typecheck` — exit 0 (a fresh worktree needs `bun run --cwd examples/blog codegen` first)
- [x] `bun run test` — exit 0
- [x] `bun run test:testing` — 198 passed (13 files)

**Every one of the 11 new tests was verified to actually fail**, via six mutations of the fix:

| Mutation | Red |
|---|---|
| form gates back to `includes()` | 4 |
| `readMultipart()` gate back to `includes()` | 1 (`file()`) |
| JSON branch switched to the media-type rule | 2 |
| every malformed-body fallback removed | 2 (malformed JSON, malformed multipart) |
| substring gate + Hono-style header normalization | 1 (`multipart/form-data-evil`) |

The last one was added after noticing the first mutation left `multipart/form-data-evil` green: it survives a naive substring gate because `formData()` rejects it anyway. Rather than delete a case that looked vacuous, it was checked against a mutation that can actually reach it. All six were re-run after merging `main`.

Each test runs the same request through the mock and through a real `Application.fetch()` controller and asserts the concrete expected value *as well as* the agreement, so the pair cannot agree on the wrong answer.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
