### PR TITLE
fix(testing): match the runtime on form content types in the controller mock

### DIFF
--- a/.changeset/testing-mock-form-content-type.md
+++ b/.changeset/testing-mock-form-content-type.md
@@ -1,0 +1,19 @@
+---
+"@guren/testing": patch
+---
+
+Fix the controller mock recognizing form `Content-Type`s differently from the runtime.
+
+The mock gated its urlencoded and multipart branches on `contentType.includes(...)`. The runtime has no form branch of its own: everything non-JSON reaches Hono's `parseBody()`, which takes `split(';')[0].trim().toLowerCase()` and compares the media type exactly, answering `{}` for anything else.
+
+A substring test is wrong in both directions, so the mock both missed bodies production parses and parsed bodies production ignores. Measured with body `a=hit`, asking for `this.input('a')`:
+
+| `Content-Type` | runtime | mock (before) |
+| --- | --- | --- |
+| `application/x-www-form-urlencoded; charset=UTF-8` | `"hit"` | `"hit"` |
+| `Application/X-WWW-Form-Urlencoded` | `"hit"` | `null` |
+| `application/x-www-form-urlencoded-evil` | `null` | `"hit"` |
+
+The mock now applies Hono's normalization and exact match. The JSON branch deliberately stays `includes('application/json')`, because the runtime spells that one the same way — tightening it here would introduce a divergence rather than remove one.
+
+`packages/testing/tests/controller.test.ts` pins all four cases by running the same request through the mock and through a real `Application.fetch()` controller, including the parameterized spelling browsers actually send, so the normalization cannot regress into a bare equality check.

--- a/packages/testing/src/controller.ts
+++ b/packages/testing/src/controller.ts
@@ -174,12 +174,25 @@ async function parseRequestBody(ctx: ControllerContext): Promise<unknown> {
       return await request.json().catch(() => ({}))
     }
 
-    if (contentType.includes('application/x-www-form-urlencoded')) {
+    // The form gate is Hono's, not a looser spelling of it. The runtime has no
+    // form branch of its own: everything non-JSON goes to `parseBody()`, which
+    // normalizes the header and matches the media type exactly, answering `{}`
+    // for anything else. A substring test is wrong in both directions —
+    // `Application/X-WWW-Form-Urlencoded` is a body production parses and the
+    // mock would drop, and `application/x-www-form-urlencoded-evil` is one
+    // production ignores and the mock would parse.
+    //
+    // The JSON test above stays a substring test on purpose: the runtime
+    // spells that one `includes('application/json')` too, so tightening it
+    // here would introduce a divergence rather than remove one.
+    const mediaType = contentType.split(';')[0].trim().toLowerCase()
+
+    if (mediaType === 'application/x-www-form-urlencoded') {
       const text = await request.text()
       return collectFormEntries(new URLSearchParams(text))
     }
 
-    if (contentType.includes('multipart/form-data')) {
+    if (mediaType === 'multipart/form-data') {
       return collectFormEntries(await request.formData())
     }
 

--- a/packages/testing/tests/controller.test.ts
+++ b/packages/testing/tests/controller.test.ts
@@ -864,3 +864,88 @@ describe('repeated query parameters', () => {
     expect(ctx.req.query('tag')).toBe('core')
   })
 })
+
+/**
+ * The mock and the runtime must agree on which `Content-Type` carries a form
+ * body, or a controller test reads a body production never parsed — or misses
+ * one it did.
+ *
+ * The runtime has no form branch of its own: everything non-JSON reaches
+ * Hono's `parseBody()`, which takes `split(';')[0].trim().toLowerCase()` and
+ * compares the media type exactly, answering `{}` otherwise. The mock used a
+ * substring test, which is wrong in BOTH directions — too strict on a legal
+ * uppercase spelling, too loose on a media type that merely starts the same
+ * way. Both directions are asserted for that reason: a case-insensitive
+ * substring test still passes the uppercase case while leaving the bogus one
+ * broken.
+ *
+ * The parameterized `; charset=UTF-8` spelling is the one browsers actually
+ * send and already agreed; it is pinned so the normalization cannot regress
+ * into a bare equality check.
+ */
+describe('form content types', () => {
+  const CASES = [
+    { name: 'the parameterized spelling browsers send', contentType: 'application/x-www-form-urlencoded; charset=UTF-8', expected: 'hit' },
+    { name: 'a legal uppercase spelling', contentType: 'Application/X-WWW-Form-Urlencoded', expected: 'hit' },
+    { name: 'a media type that only starts the same way', contentType: 'application/x-www-form-urlencoded-evil', expected: null },
+    { name: 'multipart with its boundary parameter', contentType: null, expected: 'hit' },
+  ] as const
+
+  function build(contentType: string | null): RequestInit {
+    if (contentType === null) {
+      const form = new FormData()
+      form.append('a', 'hit')
+      return { method: 'POST', body: form }
+    }
+    return { method: 'POST', headers: { 'Content-Type': contentType }, body: 'a=hit' }
+  }
+
+  async function readThroughMock(init: RequestInit): Promise<unknown> {
+    const { Controller } = createControllerModuleMock()
+
+    class ReadController extends Controller {
+      async read() {
+        return (await this.input<string>('a')) ?? null
+      }
+    }
+
+    const controller = new ReadController()
+    controller.setContext(
+      createControllerContext('http://example.com/posts', init) as unknown as ControllerContext
+    )
+
+    return controller.read()
+  }
+
+  async function readThroughRuntime(init: RequestInit): Promise<unknown> {
+    const { Controller, createApp } = await import('@guren/core')
+
+    class ReadController extends Controller {
+      async read() {
+        return this.json({ value: (await this.input<string>('a')) ?? null })
+      }
+    }
+
+    const app = createApp({
+      routes: (router) => {
+        router.post('/posts', [ReadController, 'read'])
+      },
+    })
+    await app.boot()
+
+    const response = await app.fetch(new Request('http://example.com/posts', init))
+    expect(response.status).toBe(200)
+
+    return ((await response.json()) as { value: unknown }).value
+  }
+
+  for (const { name, contentType, expected } of CASES) {
+    it(`${name} reads the same in the mock and the runtime`, async () => {
+      const fromMock = await readThroughMock(build(contentType))
+      const fromRuntime = await readThroughRuntime(build(contentType))
+
+      expect(fromRuntime).toBe(expected)
+      expect(fromMock).toBe(expected)
+    })
+  }
+})


### PR DESCRIPTION
## Summary

Closes the last known divergence between `@guren/testing`'s controller mock and the `@guren/server` runtime, following #594 (repeated form fields), #593 (repeated query parameters) and #595 (undecodable bodies).

The mock gated its urlencoded and multipart branches on `contentType.includes(...)`. The runtime has **no form branch of its own** — everything non-JSON reaches Hono's `parseBody()`, which takes `split(';')[0].trim().toLowerCase()` and compares the media type exactly, answering `{}` for anything else.

So this was never a casing bug: a substring test is wrong in *both* directions. Measured with body `a=hit`, asking for `this.input('a')`:

| `Content-Type` | runtime | mock (before) | |
| --- | --- | --- | --- |
| `application/x-www-form-urlencoded; charset=UTF-8` | `"hit"` | `"hit"` | agreed |
| `Application/X-WWW-Form-Urlencoded` | `"hit"` | `null` | mock missed a body production parses |
| `application/x-www-form-urlencoded-evil` | `null` | `"hit"` | mock parsed a body production ignores |

The mock now applies Hono's normalization and exact match.

**The JSON branch deliberately stays `includes('application/json')`.** The runtime spells that one the same way (`packages/server/src/http/request.ts`), so tightening it here would introduce a divergence rather than remove one. Worth knowing separately: `Application/JSON` yields `{}` on **both** sides today. That is a shared looseness rather than a mock bug — media types are case-insensitive per RFC 7231 — but changing it is a production behavior change, so it is deliberately out of scope here.

## Scope

- `testing` — `packages/testing/src/controller.ts`, `packages/testing/tests/controller.test.ts`
- changeset: `@guren/testing` patch

No runtime change.

## Risk Assessment

Confined to the test-time mock, in the direction of matching production. A downstream test sending an uppercase form `Content-Type` previously saw an empty body and now sees the parsed one — which is what its controller receives in production. A test relying on the mock parsing a media type that merely *starts* like a form type was asserting a fiction.

The parameterized spelling browsers actually send (`; charset=UTF-8`) already agreed and is unchanged.

## Validation

- `bun run build:clean` — exit 0
- `bun run typecheck` — exit 0
- `bun run test` — exit 0 (5847 pass, 0 fail)
- `bun run test:testing` — exit 0 (197 pass)

The four new cases run the same request through the mock **and** through a real `Application.fetch()` controller, so the pair cannot drift again.

Each was verified to be able to fail, by mutation:

| mutation | result |
| --- | --- |
| revert to the original substring test | uppercase **and** bogus-suffix cases go red |
| case-insensitive substring (the tempting half-fix) | only the bogus-suffix case goes red |
| equality without normalization | the `; charset=UTF-8` and multipart-boundary cases go red, plus 5 pre-existing multipart tests |

The middle row is why the bogus-suffix case is in the suite: a fix that only addressed casing would pass a uppercase-only test while leaving the other direction broken. The last row is why the parameterized spelling is pinned.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
