### PR TITLE
fix(examples): resolve @guren/* subpath aliases in the vitest configs

### DIFF
--- a/examples/api/vitest.config.ts
+++ b/examples/api/vitest.config.ts
@@ -17,24 +17,16 @@ export default defineConfig({
         replacement: resolveFromRoot('../../packages/testing/src/index.ts'),
       },
       {
-        find: /^@guren\/testing\//,
-        replacement: resolveFromRoot('../../packages/testing/src/'),
+        find: /^@guren\/testing\/(.+)$/,
+        replacement: `${resolveFromRoot('../../packages/testing/src')}/$1`,
       },
       {
         find: /^@guren\/core$/,
         replacement: resolveFromRoot('../../packages/core/src/index.ts'),
       },
       {
-        find: /^@guren\/core\//,
-        replacement: resolveFromRoot('../../packages/core/src/'),
-      },
-      {
-        find: /^@guren\/core$/,
-        replacement: resolveFromRoot('../../packages/core/src/index.ts'),
-      },
-      {
-        find: /^@guren\/core\//,
-        replacement: resolveFromRoot('../../packages/core/src/'),
+        find: /^@guren\/core\/(.+)$/,
+        replacement: `${resolveFromRoot('../../packages/core/src')}/$1`,
       },
       {
         find: /^@guren\/orm$/,
@@ -49,24 +41,24 @@ export default defineConfig({
         replacement: resolveFromRoot('../../packages/orm/src/drizzle/$1.ts'),
       },
       {
-        find: /^@guren\/orm\//,
-        replacement: resolveFromRoot('../../packages/orm/src/'),
+        find: /^@guren\/orm\/(.+)$/,
+        replacement: `${resolveFromRoot('../../packages/orm/src')}/$1`,
       },
       {
         find: /^@guren\/inertia-client$/,
         replacement: resolveFromRoot('../../packages/inertia-client/src/index.ts'),
       },
       {
-        find: /^@guren\/inertia-client\//,
-        replacement: resolveFromRoot('../../packages/inertia-client/src/'),
+        find: /^@guren\/inertia-client\/(.+)$/,
+        replacement: `${resolveFromRoot('../../packages/inertia-client/src')}/$1`,
       },
       {
         find: /^@guren\/cli$/,
         replacement: resolveFromRoot('../../packages/cli/src/index.ts'),
       },
       {
-        find: /^@guren\/cli\//,
-        replacement: resolveFromRoot('../../packages/cli/src/'),
+        find: /^@guren\/cli\/(.+)$/,
+        replacement: `${resolveFromRoot('../../packages/cli/src')}/$1`,
       },
       {
         find: /^bun:sqlite$/,
@@ -77,8 +69,8 @@ export default defineConfig({
         replacement: resolveFromRoot('../../packages/core/src/index.ts'),
       },
       {
-        find: /^guren\//,
-        replacement: resolveFromRoot('../../packages/core/src/'),
+        find: /^guren\/(.+)$/,
+        replacement: `${resolveFromRoot('../../packages/core/src')}/$1`,
       },
     ],
   },

--- a/examples/blog/vitest.config.ts
+++ b/examples/blog/vitest.config.ts
@@ -48,32 +48,33 @@ export default defineConfig({
         replacement: resolve(rootDir, '../../packages/testing/src/index.ts'),
       },
       {
-        find: /^@guren\/testing\//,
-        replacement: resolve(rootDir, '../../packages/testing/src/'),
+        find: /^@guren\/testing\/(.+)$/,
+        replacement: `${resolve(rootDir, '../../packages/testing/src')}/$1`,
       },
       {
         find: /^@guren\/core$/,
         replacement: resolve(rootDir, '../../packages/core/src/index.ts'),
       },
       {
-        find: /^@guren\/core\//,
-        replacement: resolve(rootDir, '../../packages/core/src/'),
+        find: /^@guren\/core\/(.+)$/,
+        replacement: `${resolve(rootDir, '../../packages/core/src')}/$1`,
       },
       {
         find: /^@guren\/server$/,
         replacement: resolve(rootDir, '../../packages/server/src/index.ts'),
       },
-      // Exact match must precede the prefix rule below, which consumes the
-      // separator without restoring it and would yield 'srcsupport/expiry'
-      // (resolve() normalizes the replacement's trailing slash away). Same
-      // reason the orm's drizzle subpath is listed explicitly.
+      // First match wins, so every explicit subpath entry must precede the
+      // generic `/(.+)$/` rule for its package. The generic form deliberately
+      // does not append '.ts': a subpath may name a file ('internal/route-path')
+      // or a directory resolved by index ('vite'). The orm's drizzle entries
+      // stay explicit because they do append it.
       {
         find: /^@guren\/server\/support\/expiry$/,
         replacement: resolve(rootDir, '../../packages/server/src/support/expiry.ts'),
       },
       {
-        find: /^@guren\/server\//,
-        replacement: resolve(rootDir, '../../packages/server/src/'),
+        find: /^@guren\/server\/(.+)$/,
+        replacement: `${resolve(rootDir, '../../packages/server/src')}/$1`,
       },
       {
         find: /^@guren\/orm$/,
@@ -88,24 +89,24 @@ export default defineConfig({
         replacement: resolve(rootDir, '../../packages/orm/src/drizzle/$1.ts'),
       },
       {
-        find: /^@guren\/orm\//,
-        replacement: resolve(rootDir, '../../packages/orm/src/'),
+        find: /^@guren\/orm\/(.+)$/,
+        replacement: `${resolve(rootDir, '../../packages/orm/src')}/$1`,
       },
       {
         find: /^@guren\/inertia-client$/,
         replacement: resolve(rootDir, '../../packages/inertia-client/src/index.ts'),
       },
       {
-        find: /^@guren\/inertia-client\//,
-        replacement: resolve(rootDir, '../../packages/inertia-client/src/'),
+        find: /^@guren\/inertia-client\/(.+)$/,
+        replacement: `${resolve(rootDir, '../../packages/inertia-client/src')}/$1`,
       },
       {
         find: /^@guren\/cli$/,
         replacement: resolve(rootDir, '../../packages/cli/src/index.ts'),
       },
       {
-        find: /^@guren\/cli\//,
-        replacement: resolve(rootDir, '../../packages/cli/src/'),
+        find: /^@guren\/cli\/(.+)$/,
+        replacement: `${resolve(rootDir, '../../packages/cli/src')}/$1`,
       },
       {
         find: /^bun:sqlite$/,
@@ -116,8 +117,8 @@ export default defineConfig({
         replacement: resolve(rootDir, '../../packages/core/src/index.ts'),
       },
       {
-        find: /^guren\//,
-        replacement: resolve(rootDir, '../../packages/core/src/'),
+        find: /^guren\/(.+)$/,
+        replacement: `${resolve(rootDir, '../../packages/core/src')}/$1`,
       },
     ],
     dedupe: ['react', 'react-dom'],


### PR DESCRIPTION
## Summary

The generic `@guren/*` alias rules in both example apps used a prefix form that mangles every subpath it claims:

```ts
{ find: /^@guren\/core\//, replacement: resolve(rootDir, '../../packages/core/src/') },
```

The regex consumes the path separator and `resolve()` normalizes the replacement's trailing slash away, so `@guren/core/internal/route-path` is rewritten to `.../packages/core/srcinternal/route-path`, which cannot resolve. This affected `@guren/testing/`, `@guren/core/`, `@guren/server/`, `@guren/orm/`, `@guren/inertia-client/`, `@guren/cli/` and the bare `guren/` rule. It was only ever noticed for `@guren/server/support/expiry`, which is why that one has a hand-written exact-match entry sitting above the prefix rule.

Every generic rule now uses the capture-group form already used by `web/vitest.config.ts`:

```ts
{ find: /^@guren\/core\/(.+)$/, replacement: `${resolve(rootDir, '../../packages/core/src')}/$1` },
```

The form deliberately does **not** append `.ts`. A subpath may name a file (`internal/route-path`) or a directory resolved by index (`@guren/cli/vite`), and appending an extension breaks the second. The orm's `drizzle` entries stay explicit precisely because they do append it.

Ordering is preserved: the alias plugin matches first-wins (`entries.find(...)`), so `@guren/testing/vitest`, `@guren/testing/controller`, `@guren/orm/drizzle` and `@guren/orm/drizzle/(.+)` still sit above the generic rule for their package.

This also drops a verbatim duplicate of the `@guren/core` alias pair in `examples/api`, which first-match made unreachable.

## Scope

- `examples/blog/vitest.config.ts`
- `examples/api/vitest.config.ts`

No framework packages, templates, or scaffolds are touched. A repo-wide sweep found no other alias table with this form, and the scaffold templates ship no alias table at all, so nothing reaches generated apps.

## Risk Assessment

**No behavior change for the current test graphs.** Two facts establish this:

1. **Vite does not retry the original specifier after a failed alias replacement.** Measured before the fix with a temporary probe in `examples/blog`:

   ```
   Error: Failed to resolve import "@guren/core/runtime" from "tests/zz-alias-probe.test.ts". Does the file exist?
     Plugin: vite:import-analysis
   ```

   A mangled rewrite is a hard error, not a silent fall back to `node_modules`/`dist`. So no specifier was ever resolving to a built artifact through one of these rules, and the fix cannot flip anything from `dist` to `src`.

2. **The generic rules are unreached by both suites today.** Pointing all of them at a bogus directory leaves `examples/blog` green (29 files / 114 tests) and `examples/api` green (15 files / 42 tests).

Taken together: the rewrite can only turn a would-be resolve error into a correct resolution.

Since the suites cannot go red on this change, they are *not* what validates it. That was done with a temporary probe exercising each rewritten form — nested file subpath, directory-index subpath (`@guren/cli/vite`, the case that would have broken had `.ts` been appended), `@guren/server/*`, bare `guren/*`, and the explicit entries. All resolved. The probe was removed before committing.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck` — green (the first run failed on a stale `dist` for `@guren/plugin-mcp`, unrelated; green after `bun run build`)
- [x] `bun run test` — exit 0; bun suite `0 fail`, blog 29/114, api 15/42, web 16/123

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [ ] I added/updated tests for behavior changes — n/a: this is test-harness configuration with no behavior change, verified by probe and mutation instead (see Risk Assessment).
- [x] I updated relevant documentation — the stale comment above the `expiry` entry, which described the defect being removed, now states the ordering invariant that still holds.

## Notes for the reviewer

Two things found while verifying, deliberately left alone:

- With the generic rules fixed, the explicit `@guren/server/support/expiry` and `@guren/testing/vitest` entries are now redundant (Vite extension-resolves `src/support/expiry` to `expiry.ts`). They are harmless and removing them is out of scope, but the ordering invariant they illustrate now rests only on the orm's `drizzle` entries.
- `examples/api` has no `@guren/server` alias at all. Since core's `src` re-exports `@guren/server`, `@guren/core` resolves to `src` while `@guren/server` resolves through `node_modules` to `dist`. That is pre-existing and unrelated to this change, but it is the shape that leads to two copies in one process. Happy to follow up separately.
