### PR TITLE
test(server): cover a 404 answer on a route with an output schema

### DIFF
--- a/docs/en/guides/routing.md
+++ b/docs/en/guides/routing.md
@@ -314,7 +314,7 @@ Available contract fields:
 | `params` | Zod schema for path parameters |
 | `query` | Zod schema for query string parameters |
 | `body` | Zod schema for the request body |
-| `output` | Zod schema for the response body |
+| `output` | Zod schema for the response body — validated on 2xx answers only, so error responses and redirects pass through as the application wrote them |
 | `resource` | Resource class response hint — types the API client without a schema |
 | `bind` | Route model binding map — `{ id: Post }` (primary key) or `{ slug: [Post, 'slug'] }` (another column) |
 | `middlewares` | Array of middleware handlers |

--- a/packages/server/tests/route-contract-runtime.test.ts
+++ b/packages/server/tests/route-contract-runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test'
 import { z } from 'zod'
-import { Application, Controller, type Router } from '../src/index'
+import { Application, Controller, NotFoundHttpException, type Router } from '../src/index'
 
 /**
  * The runtime failure modes `guren check`'s route contract check describes in
@@ -185,5 +185,34 @@ describe('output schema scope', () => {
 
     expect(status).toBe(200)
     expect(JSON.parse(body)).toEqual({ id: 1, title: 'hello' })
+  })
+
+  // Not the same path as the 422 above: that one is thrown by `validateBody()`
+  // inside the action, this one stands in for a `Model.findOrFail()` miss. Both
+  // reach the contract middleware the same counterintuitive way — Hono's
+  // `compose` catches at the inner dispatch frame, calls `onError`, assigns the
+  // rendered response to `context.res` and returns normally, so the error body
+  // arrives at `await next()` as an ordinary return rather than as a throw.
+  test('a 404 from the exception handler keeps its status', async () => {
+    class MissingController extends Controller {
+      async show(): Promise<never> {
+        throw new NotFoundHttpException('Post not found')
+      }
+    }
+
+    const app = new Application({
+      routes: (router: Router) => {
+        router.get('/posts/:id', { output: Output }, [MissingController, 'show']).name('posts.show')
+      },
+    })
+    await app.boot()
+    const response = await app.fetch(
+      new Request('http://localhost/posts/1', { headers: { Accept: 'application/json' } }),
+    )
+
+    expect(response.status).toBe(404)
+    // Debug mode adds `exception` and `stack` beside it; the message is the
+    // part that is the app's own answer.
+    expect((await response.json() as { message: string }).message).toBe('Post not found')
   })
 })


### PR DESCRIPTION
## Summary

`#602` limited route `output` validation to successful responses and pinned the 422 from `validateBody()`. This adds the case it left uncovered and states the rule in the docs.

The other way an error body reaches the contract middleware is an exception raised *outside* the action's own validation — what `Model.findOrFail()` throws. It is a different code path from the 422 (which the action raises itself), and both arrive the same counterintuitive way: Hono's `compose` catches at the inner dispatch frame, calls `onError`, assigns the rendered response to `context.res` and returns normally, so the error body reaches `await next()` as an ordinary return rather than as a throw. That is why the block needs an explicit status guard instead of relying on the throw to skip it.

The route contract table still described `output` as covering "the response body" without qualification; it now says what is actually validated.

> Originally opened with its own copy of the runtime fix, before `#602` landed the same change. Reduced to the parts main does not already have.

## Scope

- `server` — one test in `packages/server/tests/route-contract-runtime.test.ts`
- `docs` — the `output` row of the route contract table in `docs/en/guides/routing.md`

## Risk Assessment

None. No runtime code changes, so no changeset.

## Validation

The test is non-vacuous: reverting the `isSuccess` guard in `createContractValidationMiddleware` to `c.res !== undefined` fails it alongside `#602`'s 422 test (2 fail / 8 pass), and it passes with the guard in place.

```
bun run typecheck             ✅
bun run test:bun server       ✅ 2626 pass / 0 fail
bun run audit:docs            ✅
```

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test`

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
