### PR TITLE
fix(examples): resolve the server package from src in the api vitest config

### DIFF
--- a/examples/api/vitest.config.ts
+++ b/examples/api/vitest.config.ts
@@ -28,6 +28,19 @@ export default defineConfig({
         find: /^@guren\/core\/(.+)$/,
         replacement: `${resolveFromRoot('../../packages/core/src')}/$1`,
       },
+      // `@guren/core`'s index re-exports the server package wholesale, so
+      // without these two the suite runs core from src while the server it
+      // re-exports comes from dist. The generic form deliberately does not
+      // append '.ts': a subpath may name a file ('internal/route-path') or a
+      // directory resolved by index ('vite').
+      {
+        find: /^@guren\/server$/,
+        replacement: resolveFromRoot('../../packages/server/src/index.ts'),
+      },
+      {
+        find: /^@guren\/server\/(.+)$/,
+        replacement: `${resolveFromRoot('../../packages/server/src')}/$1`,
+      },
       {
         find: /^@guren\/orm$/,
         replacement: resolveFromRoot('../../packages/orm/src/index.ts'),
@@ -81,7 +94,7 @@ export default defineConfig({
     setupFiles: ['./tests/setup.ts'],
     server: {
       deps: {
-        inline: ['@guren/core', '@guren/orm', '@guren/core', '@guren/testing'],
+        inline: ['@guren/core', '@guren/orm', '@guren/testing'],
       },
     },
   },


### PR DESCRIPTION
## Problem

`examples/api/vitest.config.ts` aliased every other workspace package to its `src` entrypoint but had no `@guren/server` entry at all, unlike `examples/blog/vitest.config.ts` and `web/vitest.config.ts`.

`packages/core/src/index.ts` is `export * from '@guren/server'`. So in the api test graph, `@guren/core` resolved to source while the `@guren/server` it re-exports resolved through `packages/core/node_modules/@guren/server` to `packages/server/dist/index.js`. The api suite therefore exercised core, orm, testing and cli from source while validating **built output** for server.

Today that is *one uniformly stale copy*, not two: `@guren/server` was the only unaliased specifier, so every path reaching server landed on the same `dist`. Two copies in one process is the **latent** hazard the split creates, which is what the probe below deliberately triggered.

`examples/api/tsconfig.json` already maps `@guren/server` to src, so this brings runtime resolution into agreement with what typecheck already asserts.

## Confirming the diagnosis

A temporary probe under `examples/api/tests/` compared class identity across the two resolutions (removed before committing):

```ts
import { HttpException as ViaCore } from '@guren/core'
import { HttpException as ViaServerSrc } from '../../../packages/server/src/index.ts'
expect(ViaCore).toBe(ViaServerSrc)
```

Before the fix it failed with `Compared values have no visual difference` — the dual-copy signature. After the fix it passes.

Worth noting: a test file in `examples/api` cannot import `@guren/server` directly at all (`Cannot find package`) — it isn't a declared dependency, so there is no symlink. The re-export inside `packages/core/src` is the only path that reaches it.

## Verifying the rules can actually fail

Each rule was mutated **separately**:

| Mutation | Result | Path that fired |
|---|---|---|
| exact-match → bogus file | 9 of 15 test files fail | `packages/core/src/index.ts` — `export * from '@guren/server'` |
| generic → bogus directory | 9 of 15 test files fail | `packages/core/src/store-utils.ts:17` — `@guren/server/support/expiry` |

Neither rule is inert. (The counts match but set membership was not compared.)

The generic rule's extensionless form is validated live, not just by convention: `@guren/server/support/expiry` resolves through it to a `.ts` **file** and the suite is green. That is why api needs no explicit entry for that subpath where `examples/blog` still carries one. Per #603 the generic form must not append `.ts`, since a subpath may name a file (`internal/route-path`) or a directory resolved by index (`vite`).

## Also

`server.deps.inline` listed `@guren/core` twice; dropped the duplicate.

The server package is deliberately **not** added to that list. Once the specifier is aliased to an absolute in-workspace `.ts` path it is rewritten before externalization is decided, so the entry would be a no-op — and spelling it unescaped outside a regex trips `audit:core-first`, which does a blunt substring scan over `examples/` and `web/`. That is why the neighbouring configs name it only inside `find:` patterns, where the escaped form does not match the audit's needle. The comment in this diff is worded around the literal for the same reason.

## Gates

- `bun run typecheck` — green (full chain, including `typecheck:api` and `typecheck:blog`)
- `bun run test:examples` — green, 16 files / 123 tests; `examples/api` alone is 15 files / 42 tests. Switching the api suite from `dist` to `src` surfaced no real failures.

`bun run test:bun` crashes on this machine with a Bun 1.3.14 segfault in `packages/cli/tests/tool-dev.test.ts` (which spawns a real Vite dev server). **This is pre-existing and unrelated** — `test:bun` runs `bun test` over `packages/*` and never reads `examples/api/vitest.config.ts`. Verified by running it on a pristine tree with the change stashed: identical crash point and identical crash fingerprint.

```
bun.report/1.3.14/Mt10d9b296inkgEusooC_2078iB2078iB___ug9sC_mimjlDmy5ilD...
```

The file passes in isolation (7 pass), so the crash needs the full-suite context.
