### PR TITLE
refactor(examples): drop redundant subpath aliases from the vitest configs

### DIFF
--- a/examples/api/vitest.config.ts
+++ b/examples/api/vitest.config.ts
@@ -9,10 +9,6 @@ export default defineConfig({
   resolve: {
     alias: [
       {
-        find: /^@guren\/testing\/controller$/,
-        replacement: resolveFromRoot('../../packages/testing/src/controller.ts'),
-      },
-      {
         find: /^@guren\/testing$/,
         replacement: resolveFromRoot('../../packages/testing/src/index.ts'),
       },
@@ -32,6 +28,12 @@ export default defineConfig({
         find: /^@guren\/orm$/,
         replacement: resolveFromRoot('../../packages/orm/src/index.ts'),
       },
+      // The only explicit subpath entries here, and first match wins, so both
+      // must stay above the generic orm rule. Every other subpath is served by
+      // a generic `/(.+)$/` rule, whose replacement is extensionless on purpose
+      // so that vite's resolver completes it. The drizzle mapping is pinned
+      // anyway because 'src/drizzle.ts' and the 'src/drizzle/' directory
+      // coexist.
       {
         find: /^@guren\/orm\/drizzle$/,
         replacement: resolveFromRoot('../../packages/orm/src/drizzle.ts'),

--- a/examples/blog/vitest.config.ts
+++ b/examples/blog/vitest.config.ts
@@ -40,10 +40,6 @@ export default defineConfig({
         replacement: reactDomClientEntry,
       },
       {
-        find: /^@guren\/testing\/vitest$/,
-        replacement: resolve(rootDir, '../../packages/testing/src/vitest.ts'),
-      },
-      {
         find: /^@guren\/testing$/,
         replacement: resolve(rootDir, '../../packages/testing/src/index.ts'),
       },
@@ -63,15 +59,6 @@ export default defineConfig({
         find: /^@guren\/server$/,
         replacement: resolve(rootDir, '../../packages/server/src/index.ts'),
       },
-      // First match wins, so every explicit subpath entry must precede the
-      // generic `/(.+)$/` rule for its package. The generic form deliberately
-      // does not append '.ts': a subpath may name a file ('internal/route-path')
-      // or a directory resolved by index ('vite'). The orm's drizzle entries
-      // stay explicit because they do append it.
-      {
-        find: /^@guren\/server\/support\/expiry$/,
-        replacement: resolve(rootDir, '../../packages/server/src/support/expiry.ts'),
-      },
       {
         find: /^@guren\/server\/(.+)$/,
         replacement: `${resolve(rootDir, '../../packages/server/src')}/$1`,
@@ -80,6 +67,12 @@ export default defineConfig({
         find: /^@guren\/orm$/,
         replacement: resolve(rootDir, '../../packages/orm/src/index.ts'),
       },
+      // The only explicit subpath entries left, and first match wins, so both
+      // must stay above the generic orm rule. Every other subpath is served by
+      // a generic `/(.+)$/` rule, whose replacement is extensionless on purpose
+      // so that vite's resolver completes it ('src/support/expiry' -> the
+      // neighbouring expiry.ts). The drizzle mapping is pinned anyway because
+      // 'src/drizzle.ts' and the 'src/drizzle/' directory coexist.
       {
         find: /^@guren\/orm\/drizzle$/,
         replacement: resolve(rootDir, '../../packages/orm/src/drizzle.ts'),


### PR DESCRIPTION
## Summary

Follow-up cleanup to #603.

#603 rewrote the generic `@guren/*` alias rules in both example vitest configs
from a broken trailing-slash prefix form to the capture-group form. That made
three explicit subpath entries redundant: each existed only to dodge the prefix
defect, where the generic rule rewrote a subpath to an unresolvable path.

Removed:

| config | entry |
| --- | --- |
| `examples/blog` | `/^@guren\/server\/support\/expiry$/` |
| `examples/blog` | `/^@guren\/testing\/vitest$/` |
| `examples/api` | `/^@guren\/testing\/controller$/` |

**What this buys.** The generic `testing`, `server` and `orm` rules are now on the
path both suites exercise on every run. A reintroduction of the #603 prefix
defect currently passes both example suites unnoticed; after this change it
fails them.

### The drizzle pair is kept, but the stated reason was wrong

`/^@guren\/orm\/drizzle$/` and `/^@guren\/orm\/drizzle\/(.+)$/` stay. The comment
#603 left behind justified them by claiming they append `.ts` and the generic
form does not, so they are load-bearing. **That is empirically false** — removing
them leaves the blog suite green (29 files / 114 tests), because
`src/drizzle/pg` extension-resolves to `pg.ts` exactly as `src/support/expiry`
resolves to `expiry.ts`. Measured, not assumed.

They are kept as belt-and-braces for a different, checkable reason, which the
rewritten comment now states: `packages/orm/src/drizzle.ts` and the
`packages/orm/src/drizzle/` directory coexist, so that one mapping is pinned
rather than left to extension resolution. `examples/api` had no comment at all
and now carries the same note.

The comment also no longer asserts the `src/foo/index.ts` half of extension
resolution. Nothing in either example suite imports a directory-index subpath,
so that clause was inherited from `web/vitest.config.ts` rather than measured.

## Scope

`examples` only — `examples/blog/vitest.config.ts` and
`examples/api/vitest.config.ts`. No package source, no templates, no docs.

## Risk Assessment

Test-configuration only; nothing ships to users and no runtime behavior changes.

The one real risk is that a removed entry was load-bearing and the generic rule
does not cover it. That is what the mutation pairs below rule out. Note that a
green suite is **not** evidence here: before this change the generic rules were
dead code in both example suites, which #603 established by pointing them at
bogus paths and watching both suites stay green.

Each removal was proven by a mutation pair instead, run manually and reverted:

| entry | pointed at a bogus path | entry removed |
| --- | --- | --- |
| blog `server/support/expiry` | **18 of 29 files red** | 29 files / 114 tests green |
| blog `testing/vitest` | **29 of 29 files red** | 29 files / 114 tests green |
| api `testing/controller` | **5 of 15 files red** | 15 files / 42 tests green |

The red half proves the specifier is actually reached; the green half proves the
generic rule resolves it. A temporary probe test importing each specifier
directly was also added, run, and deleted.

## Validation

- [x] `bun run build` (`build:clean`) — green.
- [x] `bun run typecheck` — green, including the `blog` and `api` typechecks.
- [ ] `bun run test` — **did not complete on the machine used; see below.**

Also green: `bun run audit:core-first`, `bun run audit:docs`, and
`bun run test:examples` (blog 29 files / 114 tests, api 15 files / 42 tests),
which is the half of the suite this diff can affect.

`bun run test:bun` could not be completed locally. The repo's runner
(`bun test --isolate`) segfaults under Bun 1.3.14 and then spins at 100% CPU
producing no summary. This reproduced concurrently and identically in three
independent worktrees, including ones unrelated to this change. Re-run without
`--isolate` it reports 5794 pass / 12 fail; all 12 are queue/`Worker` tests that
share global state, and they pass under `--isolate` (65 pass, 0 fail), so they
are artifacts of dropping the flag rather than regressions. Structurally the gate
is discharged anyway: `test:bun` runs `packages/` plus `scripts/`, and this diff
is entirely under `examples/`, so the two sets share no file. CI should be
treated as the authority for this checkbox.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes. (No behavior change. The
      removals were verified by mutation pairs and by throwaway probe tests,
      which were deleted; nothing here warrants a permanent test.)
- [x] I updated relevant documentation. (The in-file comment explaining the
      ordering rule was rewritten in both configs, and its previous claim
      corrected.)
