### PR TITLE
fix(server): force document types served out of public/ to download

### DIFF
--- a/.changeset/olive-jars-attend.md
+++ b/.changeset/olive-jars-attend.md
@@ -1,0 +1,53 @@
+---
+'@guren/server': patch
+---
+
+fix(server): force document types served out of `public/` to download
+
+The `public/` tree is not only build output. The attachments scaffold roots
+its `public` storage disk inside it (`./public/storage`), so a file there can
+be an upload that kept the uploader's own extension and content type. Served
+back as `text/html` or `image/svg+xml` from the app's own origin, that is
+stored XSS: session-riding requests, CSRF-token reads, account takeover.
+
+Two routes reach that directory and neither stopped it. The extension
+allowlist in `registerRootPublicAssets` was declared to be the gate, but
+`configureInertiaAssets` also mounts an unfiltered `serveStatic` at
+`/public/*` (and `registerDevAssets` mounts the same one, so `bun run dev` was
+not exempt); `.svg` is in the allowlist's own default extensions, so it was
+reachable through the declared gate too.
+
+Both mounts, and the `/resources/css/*` one beside them, now answer with
+`Content-Disposition: attachment` and `X-Content-Type-Options: nosniff` for
+the content types a browser renders as a document in the serving origin:
+`text/html`, `text/xml`, `application/xml`, `text/xsl`, and any `*+xml`
+(`application/xhtml+xml`, `image/svg+xml`, `application/xslt+xml`).
+
+`Content-Disposition` is honoured for navigations and ignored for subresource
+loads, so `<img src="/logo.svg">`, `<link rel="icon">` and CSS `url()` are
+unaffected. Scripts, stylesheets, fonts, images, media and PDFs are untouched.
+
+What does change, beyond opening such a URL directly:
+
+- an SVG or HTML page embedded through `<iframe>` or `<object>` no longer
+  renders, because that is a navigation;
+- a directory request resolves to its `index.html` before the guard runs, so
+  `public/site/` now downloads rather than renders. A static microsite under
+  `public/` is the one legitimate flow this stops.
+
+Opt back in per route family: `rootPublicAssets: { inlineDocuments: true }`
+for the root-level allowlist, and `inlineDocuments: true` on
+`configureInertiaAssets` / `registerDevAssets` for `/public/*` and
+`/resources/css/*`. Turn either on only for a directory holding nothing
+user-supplied.
+
+Two scope limits worth stating:
+
+- This covers the app's own static serving, which is what `bun bin/serve.ts`
+  and the Docker image use. A deployment fronting `public/` with platform
+  static assets, a CDN, or nginx serves those files without reaching this
+  middleware and needs the same header policy configured there.
+- Root-level assets are served `public, max-age=31536000, immutable`, so a
+  browser or shared cache holding a pre-upgrade inline response keeps it. An
+  app that has already accepted uploads should rotate those URLs or purge the
+  cache rather than rely on the upgrade alone.

--- a/packages/server/src/http/dev-assets.ts
+++ b/packages/server/src/http/dev-assets.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url'
 import { createRequire } from 'node:module'
 import type { Application } from './Application'
 import { registerRootPublicAssets, type RootPublicAssetsConfig } from './public-assets'
+import { guardStaticDocument } from './static-documents'
 import { isPathWithin, isRealPathWithin } from '../support/contained-path'
 
 declare const Bun: any
@@ -72,6 +73,22 @@ export interface DevAssetsOptions {
   favicon?: boolean
   /** Serve selected files from the public directory without the `/public` prefix. */
   rootPublicAssets?: RootPublicAssetsConfig
+  /**
+   * Serve document types (`.svg`, `.html`, XML) from `/public/*` and
+   * `/resources/css/*` inline instead of forcing them to download. Defaults to
+   * false.
+   *
+   * Off by default because `public/` is also where an app's uploads land, and
+   * a stored `.html` or `.svg` served inline is script in the app's own
+   * origin. Turn it on for a public directory holding nothing user-supplied —
+   * a static microsite under `public/docs/index.html`, say, which Hono resolves
+   * from a directory request and would otherwise hand back as a download.
+   *
+   * The root-level allowlist route has its own switch,
+   * `rootPublicAssets: { inlineDocuments: true }`; an app serving documents
+   * both ways sets both.
+   */
+  inlineDocuments?: boolean
 }
 
 // Resolve the inertia client lazily: @guren/inertia-client is an optional
@@ -151,6 +168,7 @@ export function registerDevAssets(app: Application, options: DevAssetsOptions): 
       serveStatic({
         root: cssDir,
         rewriteRequestPath: cssRewrite,
+        onFound: options.inlineDocuments ? undefined : guardStaticDocument,
       }),
     )
   }
@@ -195,6 +213,7 @@ export function registerDevAssets(app: Application, options: DevAssetsOptions): 
       serveStatic({
         root: publicDir,
         rewriteRequestPath,
+        onFound: options.inlineDocuments ? undefined : guardStaticDocument,
       }),
     )
 

--- a/packages/server/src/http/inertia-assets.ts
+++ b/packages/server/src/http/inertia-assets.ts
@@ -10,6 +10,7 @@ import {
   type DevAssetsOptions,
 } from './dev-assets'
 import { registerRootPublicAssets } from './public-assets'
+import { guardStaticDocument } from './static-documents'
 import { isPathWithin, isRealPathWithin } from '../support/contained-path'
 import { parseImportMap } from '../support/import-map'
 import { DEFAULT_DEV_STYLES_ENTRY } from '../support/inertia-defaults'
@@ -105,7 +106,11 @@ export function configureInertiaAssets(app: Application, options: InertiaAssetsO
       // Vite writes content-hashed filenames under `assets/`, so those
       // responses can be cached forever. Files elsewhere in public/ keep
       // stable names and must stay revalidatable.
-      onFound: (_path, ctx) => {
+      onFound: (path, ctx) => {
+        if (!options.inlineDocuments) {
+          guardStaticDocument(path, ctx)
+        }
+
         if (ctx.req.path.startsWith(hashedAssetsPrefix)) {
           ctx.header('Cache-Control', 'public, max-age=31536000, immutable')
         }

--- a/packages/server/src/http/public-assets.ts
+++ b/packages/server/src/http/public-assets.ts
@@ -2,6 +2,7 @@ import { extname, resolve } from 'node:path'
 import type { Application } from './Application'
 import { trimTrailingSlashes } from '../support/trim-slashes'
 import { isPathWithin, isRealPathWithin } from '../support/contained-path'
+import { applyDocumentDisposition } from './static-documents'
 
 declare const Bun: any
 
@@ -39,6 +40,16 @@ export interface RootPublicAssetsOptions {
   routePrefix?: string
   /** Override content types per extension. */
   contentTypeMap?: Record<string, string>
+  /**
+   * Serve document types (`.svg`, `.html`, XML) inline instead of forcing them
+   * to download. Defaults to false.
+   *
+   * The default exists because this directory is also where an app's uploads
+   * land — `.svg` is in the default extension list, and an SVG navigated to
+   * directly is script in the app's own origin. Turn it on only for a
+   * directory holding nothing user-supplied.
+   */
+  inlineDocuments?: boolean
 }
 
 type NormalizedConfig = {
@@ -46,6 +57,7 @@ type NormalizedConfig = {
   cacheControlHeader: string
   routePrefix?: string
   contentTypeMap?: Record<string, string>
+  inlineDocuments: boolean
 }
 
 export function registerRootPublicAssets(app: Application, publicDir: string, config?: RootPublicAssetsConfig): void {
@@ -60,7 +72,7 @@ export function registerRootPublicAssets(app: Application, publicDir: string, co
     return
   }
 
-  const { extensions, cacheControlHeader, routePrefix, contentTypeMap } = normalized
+  const { extensions, cacheControlHeader, routePrefix, contentTypeMap, inlineDocuments } = normalized
   const normalizedPrefix = routePrefix ? trimTrailingSlashes(routePrefix) || '/' : undefined
 
   app.hono.use(async (ctx, next) => {
@@ -103,10 +115,15 @@ export function registerRootPublicAssets(app: Application, publicDir: string, co
       return next()
     }
 
+    const contentType = contentTypeMap?.[extension] ?? DEFAULT_CONTENT_TYPES[extension] ?? 'application/octet-stream'
     const headers = new Headers({
       'Cache-Control': cacheControlHeader,
-      'Content-Type': contentTypeMap?.[extension] ?? DEFAULT_CONTENT_TYPES[extension] ?? 'application/octet-stream',
+      'Content-Type': contentType,
     })
+
+    if (!inlineDocuments) {
+      applyDocumentDisposition(headers, contentType)
+    }
 
     return new Response(file, { headers })
   })
@@ -121,6 +138,7 @@ function normalizeConfig(config?: RootPublicAssetsConfig): NormalizedConfig | un
     return {
       extensions: new Set(DEFAULT_EXTENSIONS),
       cacheControlHeader: DEFAULT_CACHE_CONTROL,
+      inlineDocuments: false,
     }
   }
 
@@ -141,6 +159,7 @@ function normalizeConfig(config?: RootPublicAssetsConfig): NormalizedConfig | un
     cacheControlHeader: config.cacheControlHeader ?? DEFAULT_CACHE_CONTROL,
     routePrefix: config.routePrefix,
     contentTypeMap: config.contentTypeMap,
+    inlineDocuments: config.inlineDocuments ?? false,
   }
 }
 

--- a/packages/server/src/http/static-documents.ts
+++ b/packages/server/src/http/static-documents.ts
@@ -1,0 +1,82 @@
+import type { Context } from 'hono'
+import { getMimeType } from 'hono/utils/mime'
+
+/**
+ * The one rule for "a browser would render this as a document in the serving
+ * origin". A file the app merely *stores* under `public/` — an upload keeping
+ * its original extension, most of all — otherwise becomes script running as
+ * the app: same cookies, same session, same CSRF token.
+ *
+ * A denylist rather than the attachments engine's `INLINE_CONTENT_TYPES`
+ * allowlist, because these mounts also serve the app's own build output. An
+ * allowlist here would have to enumerate every asset type a project can ship,
+ * and would break a deployment the first time it shipped one that was missed.
+ * Everything absent from this set — scripts, stylesheets, fonts, images,
+ * media, PDFs — is inert when navigated to, and stays inline.
+ */
+const DOCUMENT_CONTENT_TYPES = new Set([
+  'text/html',
+  'text/xml',
+  'application/xml',
+  'text/xsl',
+])
+
+/**
+ * Judged on the media type alone. Both inputs this module reads are
+ * parameterised — Hono's `getMimeType` returns `text/html; charset=utf-8`, and
+ * so does a hand-written `contentTypeMap` entry — so comparing the header
+ * verbatim is precisely how the check stops matching while still looking
+ * present.
+ */
+export function rendersAsDocument(contentType: string | undefined | null): boolean {
+  if (!contentType) {
+    return false
+  }
+
+  const mediaType = contentType.split(';', 1)[0]!.trim().toLowerCase()
+
+  // The `+xml` suffix rather than the three names that reach this through
+  // Hono's own table (`application/xhtml+xml`, `image/svg+xml`,
+  // `application/xslt+xml`): every structured XML type parses as XML, an XML
+  // document carries script through an `<?xml-stylesheet?>` PI, and a
+  // `contentTypeMap` can name one the table never would.
+  return DOCUMENT_CONTENT_TYPES.has(mediaType) || mediaType.endsWith('+xml')
+}
+
+/**
+ * Neutralizes a served document by turning it into a download.
+ *
+ * `Content-Disposition: attachment` is honoured for navigations and ignored
+ * for subresource loads, which is what makes it usable on a general asset
+ * route: `<img src="/logo.svg">`, `<link rel="icon">` and CSS `url()` keep
+ * working unchanged, while `/logo.svg` opened directly is downloaded instead
+ * of rendered. An `<iframe>` or `<object>` *is* a navigation, so an SVG or
+ * HTML page embedded that way stops rendering — which is the same mechanism
+ * as the fix, not an exception to it. `nosniff` rides along for the types a
+ * browser would otherwise promote on its own.
+ */
+export function applyDocumentDisposition(headers: Headers, contentType: string | undefined | null): void {
+  if (!rendersAsDocument(contentType)) {
+    return
+  }
+
+  headers.set('Content-Disposition', 'attachment')
+  headers.set('X-Content-Type-Options', 'nosniff')
+}
+
+/**
+ * The {@link import('hono/bun').serveStatic} form of
+ * {@link applyDocumentDisposition}, for use as its `onFound` hook.
+ *
+ * Keyed on the same `getMimeType(path)` the middleware itself used a line
+ * earlier to set `Content-Type`, rather than on the extension: the two agree
+ * by construction only while they read the same function.
+ */
+export function guardStaticDocument(path: string, ctx: Context): void {
+  if (!rendersAsDocument(getMimeType(path))) {
+    return
+  }
+
+  ctx.header('Content-Disposition', 'attachment')
+  ctx.header('X-Content-Type-Options', 'nosniff')
+}

--- a/packages/server/tests/http/static-documents.test.ts
+++ b/packages/server/tests/http/static-documents.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import { Application } from '../../src'
+import { configureInertiaAssets, registerDevAssets } from '../../src/runtime'
+import { registerRootPublicAssets } from '../../src/http/public-assets'
+import { rendersAsDocument } from '../../src/http/static-documents'
+import { useAssetFixture } from './asset-fixture'
+
+describe('rendersAsDocument', () => {
+  const documents = [
+    'text/html',
+    'text/html; charset=utf-8',
+    'TEXT/HTML',
+    ' text/html ',
+    'image/svg+xml',
+    'application/xhtml+xml',
+    'application/xslt+xml',
+    'text/xml',
+    'application/xml',
+    'text/xsl',
+  ]
+
+  const inert = [
+    'text/javascript; charset=utf-8',
+    'text/css; charset=utf-8',
+    'text/plain; charset=utf-8',
+    'image/png',
+    'application/pdf',
+    'application/octet-stream',
+    'application/json',
+    'font/woff2',
+  ]
+
+  for (const contentType of documents) {
+    it(`treats ${JSON.stringify(contentType)} as a document`, () => {
+      expect(rendersAsDocument(contentType)).toBe(true)
+    })
+  }
+
+  for (const contentType of inert) {
+    it(`leaves ${JSON.stringify(contentType)} inline`, () => {
+      expect(rendersAsDocument(contentType)).toBe(false)
+    })
+  }
+
+  it('treats an absent content type as inline', () => {
+    expect(rendersAsDocument(undefined)).toBe(false)
+    expect(rendersAsDocument(null)).toBe(false)
+    expect(rendersAsDocument('')).toBe(false)
+  })
+})
+
+/**
+ * The `public/` tree is not only the app's build output: the attachments
+ * scaffold roots its `public` storage disk inside it, so a file there can be
+ * an upload that kept the uploader's own extension. Served as `text/html` or
+ * `image/svg+xml` from the app's origin, that is stored XSS.
+ *
+ * Both routes over the directory are asserted, in both modes, because the
+ * two are complementary and a patch to one leaves the other live: the
+ * extension allowlist skips `/public/` paths and serves `.svg` at the root,
+ * while the `/public/*` mount has no allowlist and serves everything.
+ *
+ * Written to fail before `guardStaticDocument` / `applyDocumentDisposition`
+ * existed: without them every assertion below reads a null header.
+ */
+describe('document types served out of public/', () => {
+  const fixture = useAssetFixture('guren-static-documents-')
+
+  async function seedUploads(): Promise<void> {
+    await fixture.write('public/storage/attachments/01ABC/evil.html', '<script>alert(1)</script>\n')
+    await fixture.write('public/storage/attachments/01ABC/evil.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>\n')
+    await fixture.write('public/assets/app.js', 'export const app = 1\n')
+    await fixture.write('public/assets/app.css', 'body { color: red }\n')
+  }
+
+  describe('the dev /public/* mount', () => {
+    let app: Application
+
+    beforeEach(async () => {
+      await seedUploads()
+      app = new Application()
+      registerDevAssets(app, {
+        resourcesDir: fixture.path('resources'),
+        publicDir: fixture.path('public'),
+        inertiaClient: false,
+      })
+    })
+
+    it('forces an uploaded HTML file to download', async () => {
+      const response = await app.fetch(
+        new Request('http://example.com/public/storage/attachments/01ABC/evil.html'),
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Disposition')).toBe('attachment')
+      expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
+    })
+
+    it('forces an uploaded SVG to download', async () => {
+      const response = await app.fetch(
+        new Request('http://example.com/public/storage/attachments/01ABC/evil.svg'),
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Disposition')).toBe('attachment')
+    })
+
+    // Hono's Bun adapter supplies `isDir`, so a directory request resolves to
+    // `index.html` *before* onFound runs — which is why the guard is keyed on
+    // the path the middleware resolved rather than on `ctx.req.path`. Keying it
+    // on the request path would pass every other case in this file and let a
+    // directory request through.
+    it('forces a directory index to download', async () => {
+      await fixture.write('public/site/index.html', '<script>alert(1)</script>\n')
+
+      const response = await app.fetch(new Request('http://example.com/public/site/'))
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Disposition')).toBe('attachment')
+    })
+
+    it('forces a document under /resources/css/* to download', async () => {
+      await fixture.write('resources/css/evil.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>\n')
+
+      const response = await app.fetch(new Request('http://example.com/resources/css/evil.svg'))
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Disposition')).toBe('attachment')
+    })
+
+    it('leaves scripts and stylesheets inline', async () => {
+      const script = await app.fetch(new Request('http://example.com/public/assets/app.js'))
+      const styles = await app.fetch(new Request('http://example.com/public/assets/app.css'))
+
+      expect(script.status).toBe(200)
+      expect(script.headers.get('Content-Disposition')).toBeNull()
+      expect(styles.status).toBe(200)
+      expect(styles.headers.get('Content-Disposition')).toBeNull()
+    })
+
+    // The escape hatch for a public directory holding no uploads — a static
+    // microsite under `public/site/index.html` is the case that needs it.
+    it('serves documents inline when the app opts in', async () => {
+      const inline = new Application()
+      registerDevAssets(inline, {
+        resourcesDir: fixture.path('resources'),
+        publicDir: fixture.path('public'),
+        inertiaClient: false,
+        inlineDocuments: true,
+      })
+
+      const response = await inline.fetch(
+        new Request('http://example.com/public/storage/attachments/01ABC/evil.html'),
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Disposition')).toBeNull()
+    })
+  })
+
+  describe('the production /public/* mount', () => {
+    const originalNodeEnv = process.env.NODE_ENV
+    let app: Application
+
+    beforeEach(async () => {
+      await seedUploads()
+      process.env.NODE_ENV = 'production'
+      app = new Application()
+      configureInertiaAssets(app, {
+        publicDir: fixture.path('public'),
+        inertiaClient: false,
+      })
+      process.env.NODE_ENV = originalNodeEnv
+    })
+
+    it('forces an uploaded HTML file to download', async () => {
+      const response = await app.fetch(
+        new Request('http://example.com/public/storage/attachments/01ABC/evil.html'),
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Disposition')).toBe('attachment')
+      expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
+    })
+
+    it('keeps the immutable cache header on hashed assets it does not guard', async () => {
+      const response = await app.fetch(new Request('http://example.com/public/assets/app.js'))
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Cache-Control')).toContain('immutable')
+      expect(response.headers.get('Content-Disposition')).toBeNull()
+    })
+  })
+
+  describe('the root extension allowlist', () => {
+    let app: Application
+
+    beforeEach(async () => {
+      await seedUploads()
+      app = new Application()
+      registerRootPublicAssets(app, fixture.path('public'))
+    })
+
+    // The allowlist route is reachable for `.svg` even though `.html` is not,
+    // so a fix confined to the `/public/*` mount would leave this one serving
+    // active content.
+    it('forces an uploaded SVG to download', async () => {
+      const response = await app.fetch(
+        new Request('http://example.com/storage/attachments/01ABC/evil.svg'),
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Type')).toContain('image/svg+xml')
+      expect(response.headers.get('Content-Disposition')).toBe('attachment')
+      expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
+    })
+
+    it('honours a contentTypeMap that renames an extension into a document type', async () => {
+      await fixture.write('public/notes.txt', '<script>alert(1)</script>\n')
+
+      const mapped = new Application()
+      registerRootPublicAssets(mapped, fixture.path('public'), {
+        extensions: ['txt'],
+        contentTypeMap: { '.txt': 'text/html; charset=utf-8' },
+      })
+
+      const response = await mapped.fetch(new Request('http://example.com/notes.txt'))
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Disposition')).toBe('attachment')
+    })
+
+    it('leaves non-document assets inline', async () => {
+      await fixture.write('public/logo.png', 'not really a png')
+
+      const response = await app.fetch(new Request('http://example.com/logo.png'))
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Disposition')).toBeNull()
+    })
+
+    it('serves documents inline when the app opts in', async () => {
+      const inline = new Application()
+      registerRootPublicAssets(inline, fixture.path('public'), { inlineDocuments: true })
+
+      const response = await inline.fetch(
+        new Request('http://example.com/storage/attachments/01ABC/evil.svg'),
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Disposition')).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Files served out of `public/` were handed back with an extension-derived
`Content-Type` and no `Content-Disposition`, on every route over that
directory. `public/` is not only build output: the attachments scaffold roots
its `public` storage disk at `./public/storage` and `guren add attachments`
defaults `disk: 'public'`, so a file there can be an upload that kept the
uploader's own extension and content type. `sanitizeFilename` preserves the
extension, the storage key is `attachments/${id}/${name}`, and a collection
declared without `image: 'require'` accepts arbitrary bytes, which the
`make:model` comment and the `hasOneAttached()` JSDoc both invite for PDFs and
archives. Served back as `text/html` or `image/svg+xml` from the app's own
origin, that is stored XSS: session-riding requests, CSRF-token reads, account
takeover.

Two routes reach the directory and neither stopped it:

- `registerRootPublicAssets` applies an extension allowlist, which the storage
  template's own comment declares to be the gate. But `.svg` is in that
  allowlist's default extensions and was served as `image/svg+xml`, so the
  declared gate served active content.
- `configureInertiaAssets` also mounts an unfiltered `serveStatic` at
  `/public/*`, and `registerDevAssets` mounts the same one, so `bun run dev`
  was not exempt.

`static-documents.ts` is now the single rule for which content types render as
a document in the serving origin, and all four serving paths apply
`Content-Disposition: attachment` + `X-Content-Type-Options: nosniff` to them.

Two keying decisions are load-bearing and are commented as such:

- On the **media type**, not the header verbatim. Both inputs are
  parameterised (`text/html; charset=utf-8`), and comparing the whole header is
  precisely how such a check stops matching while still looking present.
- For the `serveStatic` mounts, on the **path the middleware resolved**, not
  `ctx.req.path`. Hono's Bun adapter supplies `isDir`, so a directory request
  becomes `index.html` before `onFound` runs.

## Scope

`server` — `http/static-documents.ts` (new), `http/public-assets.ts`,
`http/inertia-assets.ts`, `http/dev-assets.ts`.

No template or scaffold file is touched, so the starter-template audits and the
scaffold smokes are out of scope for this change.

## Risk Assessment

Behavior change in a patch release, deliberate. Guarded types are `text/html`,
`text/xml`, `application/xml`, `text/xsl`, and any `*+xml` (which covers
`application/xhtml+xml`, `image/svg+xml`, `application/xslt+xml`, and a
`contentTypeMap` naming a structured XML type Hono's table never would).
Scripts, stylesheets, fonts, images, media and PDFs are untouched.

`Content-Disposition` is honoured for navigations and ignored for subresource
loads, so `<img src="/logo.svg">`, `<link rel="icon">` and CSS `url()` keep
working — verified against the only in-repo consumer, `web/`, whose six
`/logo.svg` references are all `<img>`. What does change beyond opening such a
URL directly:

- an SVG or HTML page embedded through `<iframe>`/`<object>` no longer renders,
  because that is a navigation;
- a directory request resolves to its `index.html` before the guard runs, so
  `public/site/` downloads rather than renders. A static microsite under
  `public/` is the one legitimate flow this stops.

Both route families therefore carry an escape hatch for a public directory
holding nothing user-supplied: `rootPublicAssets: { inlineDocuments: true }`
for the root-level allowlist, and `inlineDocuments: true` on
`configureInertiaAssets` / `registerDevAssets` for `/public/*` and
`/resources/css/*`.

Two scope limits, both stated in the changeset so they are not read as closed:

- This covers the app's own static serving (`bun bin/serve.ts`, the Docker
  image). A deployment fronting `public/` with platform static assets, a CDN or
  nginx serves those files without reaching this middleware and needs the same
  header policy configured there.
- Root-level assets are served `immutable` for a year, so a cache holding a
  pre-upgrade inline response keeps it. An app that has already accepted
  uploads should rotate those URLs or purge rather than rely on the upgrade.

Follow-up, deliberately not in this PR because it touches `templates/**` and
has its own review surface: move the attachments scaffold off the `public`
disk onto a non-served disk delivered through `registerAttachmentRoutes()`
(RFC 0015 already enforces an inline-type allowlist there), and add a
`guren check` rule for a `configureAttachments` disk rooted inside `public/`.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [ ] `bun run test` — not run to completion. `bun run test:bun server`
  (2657 pass / 0 fail) and `bun run test:bun core cli` (2244 pass / 0 fail,
  the packages that reach `@guren/server` through `dist/`) were run instead;
  a full-suite run wedged at 98% CPU with no output, unrelated to this change.
  Also green: `bun run audit:core-first`, `bun run audit:docs`.

The new tests are mutation-checked rather than merely green, since a passing
suite proves nothing on its own here:

- stubbing `rendersAsDocument` to `false` reddens every positive assertion and
  leaves the negative and opt-out ones alone, which is the correct signature;
- re-keying the guard on `ctx.req.path` reddens the directory-index case alone.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation. (Changeset covers the behavior change
      and both opt-outs; the option JSDoc carries the rest. No guide currently
      documents these mounts' headers.)
