### PR TITLE
feat(create-app): enable zod compiled parsing in scaffolded apps

### DIFF
--- a/.changeset/warm-zebras-compile.md
+++ b/.changeset/warm-zebras-compile.md
@@ -1,0 +1,5 @@
+---
+"create-guren-app": minor
+---
+
+Scaffolded apps now enable zod's compiled parsing: the app entry starts with `import 'zod/compile'`, so every schema built after it (validators, route contracts, output schemas) parses through a generated fast path. The template zod range moves to `^4.5.0` accordingly. The shim honors `z.config({ jitless: true })` for CSP-restricted runtimes and falls back to the regular parser for unsupported schemas; note that on invalid input, refinements and transforms can run twice, so keep them free of side effects.

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "examples/api": {
       "name": "@guren/example-api",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -26,7 +26,7 @@
         "@guren/testing": "workspace:*",
         "drizzle-orm": "1.0.0-rc.4",
         "postgres": "^3.4.3",
-        "zod": "^4.4.3",
+        "zod": "^4.5.0",
       },
       "devDependencies": {
         "drizzle-kit": "1.0.0-rc.4",
@@ -50,7 +50,7 @@
         "postgres": "^3.4.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "zod": "^4.4.3",
+        "zod": "^4.5.0",
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
@@ -70,15 +70,15 @@
     },
     "packages/cli": {
       "name": "@guren/cli",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "bin": {
         "guren": "./dist/bin.js",
       },
       "dependencies": {
         "@babel/parser": "^7.24.7",
-        "@guren/core": "^1.11.0",
+        "@guren/core": "^1.12.0",
         "@guren/orm": "^2.6.1",
-        "@guren/server": "^2.13.0",
+        "@guren/server": "^2.14.0",
         "citty": "^0.1.6",
         "consola": "^3.4.2",
       },
@@ -103,14 +103,14 @@
     },
     "packages/core": {
       "name": "@guren/core",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "bin": {
         "guren": "./dist/bin.js",
       },
       "dependencies": {
-        "@guren/cli": "^2.12.0",
+        "@guren/cli": "^2.13.0",
         "@guren/orm": "^2.6.1",
-        "@guren/server": "^2.13.0",
+        "@guren/server": "^2.14.0",
       },
       "devDependencies": {
         "@types/node": "^20.14.10",
@@ -121,7 +121,7 @@
     },
     "packages/create-app": {
       "name": "create-guren-app",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "bin": {
         "create-guren-app": "./dist/cli.js",
       },
@@ -155,9 +155,9 @@
     },
     "packages/openapi": {
       "name": "@guren/openapi",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "dependencies": {
-        "@guren/core": "^1.8.1",
+        "@guren/core": "^1.12.0",
       },
       "devDependencies": {
         "@types/node": "^20.14.10",
@@ -230,7 +230,7 @@
     },
     "packages/plugin-markdown": {
       "name": "@guren/plugin-markdown",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "@guren/core": "^1.8.1",
         "@types/sanitize-html": "^2.16.1",
@@ -253,7 +253,7 @@
     },
     "packages/plugin-mcp": {
       "name": "@guren/plugin-mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@guren/core": "^1.11.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -280,7 +280,7 @@
     },
     "packages/server": {
       "name": "@guren/server",
-      "version": "2.13.0",
+      "version": "2.14.0",
       "dependencies": {
         "@guren/orm": "^2.6.1",
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -315,7 +315,7 @@
     },
     "packages/testing": {
       "name": "@guren/testing",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "devDependencies": {
         "@types/react": "^19.0.0",
         "tsdown": "^0.22.14",
@@ -324,7 +324,7 @@
       },
       "peerDependencies": {
         "@guren/core": ">=1.8.0",
-        "@guren/server": ">=2.2.0",
+        "@guren/server": ">=2.14.0",
         "@inertiajs/react": "^3.6.1",
         "@testing-library/react": "^14.0.0 || ^15.0.0 || ^16.0.0",
         "hono": "^4.13.0",
@@ -341,7 +341,7 @@
     },
     "web": {
       "name": "web",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -20,7 +20,7 @@
     "@guren/testing": "workspace:*",
     "drizzle-orm": "1.0.0-rc.4",
     "postgres": "^3.4.3",
-    "zod": "^4.4.3"
+    "zod": "^4.5.0"
   },
   "devDependencies": {
     "drizzle-kit": "1.0.0-rc.4",

--- a/examples/api/src/app.ts
+++ b/examples/api/src/app.ts
@@ -1,3 +1,10 @@
+// Every zod schema built after this import parses through a compiled fast
+// path. Keep it the first import so it runs before any module that defines
+// schemas. It honors z.config({ jitless: true }) for CSP-restricted runtimes
+// and never throws — unsupported schemas keep the regular parser. One caveat:
+// on invalid input, refinements/transforms can run twice (fast path, then
+// fallback), so keep .refine()/.transform() free of side effects.
+import 'zod/compile'
 import {
   createApp,
   NotificationServiceProvider as CoreNotificationServiceProvider,

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -34,7 +34,7 @@
     "postgres": "^3.4.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "zod": "^4.4.3"
+    "zod": "^4.5.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/examples/blog/src/app.ts
+++ b/examples/blog/src/app.ts
@@ -1,3 +1,10 @@
+// Every zod schema built after this import parses through a compiled fast
+// path. Keep it the first import so it runs before any module that defines
+// schemas. It honors z.config({ jitless: true }) for CSP-restricted runtimes
+// and never throws — unsupported schemas keep the regular parser. One caveat:
+// on invalid input, refinements/transforms can run twice (fast path, then
+// fallback), so keep .refine()/.transform() free of side effects.
+import 'zod/compile'
 import { fileURLToPath } from 'node:url'
 import {
   createApp,

--- a/packages/create-app/templates/blog/src/app.ts
+++ b/packages/create-app/templates/blog/src/app.ts
@@ -1,3 +1,10 @@
+// Every zod schema built after this import parses through a compiled fast
+// path. Keep it the first import so it runs before any module that defines
+// schemas. It honors z.config({ jitless: true }) for CSP-restricted runtimes
+// and never throws — unsupported schemas keep the regular parser. One caveat:
+// on invalid input, refinements/transforms can run twice (fast path, then
+// fallback), so keep .refine()/.transform() free of side effects.
+import 'zod/compile'
 import { createApp, setInertiaDocument } from '@guren/core'
 import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
 import AuthProvider from '../app/Providers/AuthProvider.js'

--- a/packages/create-app/templates/default/package.json
+++ b/packages/create-app/templates/default/package.json
@@ -27,7 +27,7 @@
     "drizzle-orm": "1.0.0-rc.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "zod": "^4.4.3"
+    "zod": "^4.5.0"
   },
   "devDependencies": {
     "@guren/testing": "^1.8.0",

--- a/packages/create-app/templates/default/src/app.ts
+++ b/packages/create-app/templates/default/src/app.ts
@@ -1,3 +1,10 @@
+// Every zod schema built after this import parses through a compiled fast
+// path. Keep it the first import so it runs before any module that defines
+// schemas. It honors z.config({ jitless: true }) for CSP-restricted runtimes
+// and never throws — unsupported schemas keep the regular parser. One caveat:
+// on invalid input, refinements/transforms can run twice (fast path, then
+// fallback), so keep .refine()/.transform() free of side effects.
+import 'zod/compile'
 import { createApp } from '@guren/core'
 import { setInertiaDocument } from '@guren/core'
 import DatabaseProvider from '../app/Providers/DatabaseProvider.js'


### PR DESCRIPTION
## Summary

- The app entry of the **default** and **blog** templates (and the **blog**/**api** examples) now starts with `import 'zod/compile'`: every schema built after it — validators, route contracts, output schemas — parses through zod 4.5's generated fast path, with no framework changes required. `@guren/server` stays zod-free.
- The template zod range moves `^4.4.3` → `^4.5.0` (where the shim first shipped). The api-only template does not depend on zod and is untouched.
- The entry comment documents the three things users must know: keep the import first, `z.config({ jitless: true })` is honored on CSP-restricted runtimes, and refinements/transforms can run twice on invalid input (fast path, then fallback), so they must stay side-effect free.

## Why the shim, not an injection seam

`z.compile()` never throws outside strict mode (unsupported schemas keep the regular parser), the shim compiles lazily (no cold-start cost), and compiled clones keep `_def`/`_zod`/checks so `guren check`, codegen, and agent tool derivation are unaffected. Measured on Bun 1.3.14: 100-item list output validation 19.2µs → 1.2µs (x15.4), 5-field body x3.8.

## Verification

- `bun run test:bun create-app` (108 pass), `bun run audit:starter-template`, `bun run test:examples` (123 pass), `bun run smoke:starter`, `bun run smoke:starter:api` — all green.
- Structural probe: a schema constructed after the shim import carries a different `_zod.run` implementation than one constructed before it, and still parses correctly.