### PR TITLE
fix(examples): serve blog attachments off a private disk

### DIFF
--- a/examples/blog/app/Providers/StorageProvider.ts
+++ b/examples/blog/app/Providers/StorageProvider.ts
@@ -8,6 +8,16 @@ export default class StorageProvider extends ServiceProvider {
         local: { driver: 'local', root: './storage/app' },
         // Rooted inside public/ so the root asset server serves these files
         // and disk.url() returns a URL that actually resolves.
+        //
+        // For assets this app writes itself, then. Never for bytes someone
+        // uploaded: anything on this disk is fetchable by URL with no
+        // signature, no expiry and no authorization check. The framework
+        // forces a download for document types served out of public/, so an
+        // uploaded .svg will not execute on this origin — but that is a
+        // backstop against one consequence, not access control, and
+        // inlineDocuments: true opts out of it. Attachments go on `local`
+        // above, handed out through the signed delivery route — see
+        // config/attachments.ts.
         public: { driver: 'local', root: './public/storage', url: '/storage', visibility: 'public' },
       },
     }))

--- a/examples/blog/config/attachments.ts
+++ b/examples/blog/config/attachments.ts
@@ -14,10 +14,22 @@ import { Post } from '../app/Models/Post.js'
 export const { Attachment } = configureAttachments({
   table: attachments,
   storage: () => getContainer().make('storage'),
-  // Where new attachments are stored, and how their URLs are built: 'public'
-  // disks serve via disk.url(), 'private' ones via disk.temporaryUrl().
-  disk: 'public',
-  disks: { public: 'public' },
+  // Uploads are bytes a stranger chose, so they are stored on a disk that
+  // nothing serves statically — `local` is rooted at ./storage/app, outside
+  // public/ — and handed out through the signed delivery route that
+  // registerAttachmentRoutes(router) mounts in routes/web.ts. That route
+  // serves only an allowlist of types inline, forces a download for the rest,
+  // and adds nosniff plus a sandbox CSP. Rooting this disk inside public/
+  // instead would bypass all of it; `guren check` fails that shape, and
+  // StorageProvider.ts says why at the disk in question.
+  disk: 'local',
+  // Per-disk visibility. 'public' disks build URLs with disk.url(); 'private'
+  // ones go through the delivery route below. Undeclared disks count as
+  // public, so a private disk has to say so.
+  disks: { local: 'private', public: 'public' },
+  // Presence is the switch: private-disk URLs become signed delivery-route
+  // URLs instead of disk.temporaryUrl(). Accepts `prefix` and `routeName`.
+  delivery: {},
 })
 
 // attachments:prune resolves each row's attachableType through this map to

--- a/examples/blog/e2e/posts-crud.spec.ts
+++ b/examples/blog/e2e/posts-crud.spec.ts
@@ -1,8 +1,19 @@
 import { test, expect, type Page } from '@playwright/test'
+import { existsSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { gotoHydrated, waitForHydrated } from './helpers.js'
 
 const coverFixture = fileURLToPath(new URL('./fixtures/cover.png', import.meta.url))
+
+/**
+ * Where the `local` disk (StorageProvider's ./storage/app, relative to the app
+ * root the E2E server runs from) holds one attachment's objects, given the
+ * signed delivery URL its id came from.
+ */
+function storageDirFor(deliveryUrl: string): string {
+  const id = decodeURIComponent(new URL(deliveryUrl, 'http://localhost').pathname.split('/')[2] ?? '')
+  return fileURLToPath(new URL(`../storage/app/attachments/${id}`, import.meta.url))
+}
 
 /** Creates a post and returns its show-page URL. */
 async function createPost(page: Page, title: string, options: { cover?: boolean } = {}): Promise<string> {
@@ -71,10 +82,11 @@ test.describe('Posts — authenticated CRUD', () => {
     const title = `E2E Cover Post ${Date.now()}`
     const postUrl = await createPost(page, title, { cover: true })
 
-    // The show page renders the stored attachment from the public disk.
+    // The cover lives on the private disk, so the show page renders it through
+    // the signed delivery route rather than as a static asset.
     const cover = page.getByTestId('post-cover')
     await expect(cover).toBeVisible()
-    await expect(cover).toHaveAttribute('src', /\/storage\/attachments\//)
+    await expect(cover).toHaveAttribute('src', /^\/attachments\/[^/]+\/.*[?&]signature=/)
 
     // The bytes must actually come back over HTTP — a broken image keeps
     // naturalWidth at 0 even though the element is "visible".
@@ -93,7 +105,12 @@ test.describe('Posts — authenticated CRUD', () => {
     const postUrl = await createPost(page, title, { cover: true })
 
     const coverSrc = await page.getByTestId('post-cover').getAttribute('src')
-    expect(coverSrc).toMatch(/\/storage\/attachments\//)
+    expect(coverSrc).toMatch(/^\/attachments\/[^/]+\/.*[?&]signature=/)
+
+    // Assert the bytes are on disk *before* deleting, so the "gone afterwards"
+    // check below cannot pass by pointing at a path that never existed.
+    const storedObjects = storageDirFor(coverSrc!)
+    expect(existsSync(storedObjects)).toBe(true)
 
     // The Delete button's confirm dialog only exists once React has hydrated.
     await gotoHydrated(page, `${postUrl}/edit`)
@@ -107,9 +124,14 @@ test.describe('Posts — authenticated CRUD', () => {
     const showResponse = await page.request.get(postUrl)
     expect(showResponse.status()).toBe(404)
 
-    // …and purgeAttachments removed the stored object too.
+    // …its signed URL stops resolving…
     const coverResponse = await page.request.get(coverSrc!)
     expect(coverResponse.status()).toBe(404)
+
+    // …and purgeAttachments removed the stored object too. Worth asserting
+    // separately: the delivery route 404s on the missing row before it ever
+    // touches storage, so the status above says nothing about the bytes.
+    expect(existsSync(storedObjects)).toBe(false)
   })
 
   test('edit an existing post', async ({ page }) => {

--- a/examples/blog/routes/web.ts
+++ b/examples/blog/routes/web.ts
@@ -1,4 +1,4 @@
-import { Router, requireAuthenticated, requireGuest } from '@guren/core'
+import { Router, registerAttachmentRoutes, requireAuthenticated, requireGuest } from '@guren/core'
 import PostController from '../app/Http/Controllers/PostController.js'
 import { Post } from '../app/Models/Post.js'
 import { PostPayloadSchema } from '../app/Http/Validators/PostValidator.js'
@@ -8,6 +8,11 @@ export function registerWebRoutes(baseRouter: Router): void {
   const router = baseRouter
     .aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
     .aliasMiddleware('guest', requireGuest({ redirectTo: '/dashboard' }))
+
+  // Attachments live on the private `local` disk, so their URLs point at this
+  // signed delivery route. Unmounted, every cover image 404s — and the 404 is
+  // the route's own uniform failure, so nothing at runtime names the cause.
+  registerAttachmentRoutes(router)
 
   router.get('/', [PostController, 'index']).name('home')
 

--- a/examples/blog/types/generated/routes.d.ts
+++ b/examples/blog/types/generated/routes.d.ts
@@ -10,6 +10,7 @@ declare namespace Guren {
 
   export type RoutePath =
     '/'
+    | `/attachments/${string}/${string}`
     | `/auth/${string}`
     | `/auth/${string}/callback`
     | '/dashboard'


### PR DESCRIPTION
Stacked on #614 — review that first; this PR's base is its branch, so the diff here is the blog example alone.

## Why

`examples/blog` stored uploads on the `public` disk, which `StorageProvider` roots at `./public/storage` — inside the tree the root asset server serves. Uploaded bytes came back as static assets with the content type their extension implies: an uploaded `.svg` was returned as `image/svg+xml`, inline, and its script ran on the app's own origin. The reference app was demonstrating exactly the shape #614's new `attachments-public-disk` rule fails.

Reproduced before fixing, on this branch's base:

```
FAIL attachments-public-disk:config/attachments.ts:public
```

CI would not have caught it: `ci.yml` runs only `check --spec` on the blog, and the new rule is in the plain suite.

## What

The shape #614's scaffold now emits:

- `config/attachments.ts` — `disk: 'local'` (`./storage/app`, outside `public/`), `disks: { local: 'private', public: 'public' }`, `delivery: {}`.
- `routes/web.ts` — `registerAttachmentRoutes(router)`, so the signed delivery route the config points URLs at is actually mounted.
- `StorageProvider.ts` — comments only. The `public` disk stays, and now says what it is not for. The disks map itself is unchanged, so `tests/providers/StorageProvider.test.ts` keeps asserting it literally.

Verified after the change that new uploads land in `storage/app/attachments/…` and nothing new appears under `public/storage/`.

## E2E

Cover URLs move from `/storage/attachments/…` to the signed route, so the assertions follow. The delete test needed more than a new regex: it proved `purgeAttachments` removed the bytes by fetching a static URL, and the delivery route 404s on the missing row *before* it touches storage. That assertion would now pass with the object still on disk. It checks the stored objects directly instead — present before the delete, gone after — and the "present before" half is what keeps the "gone after" half from passing against a path that never existed. Confirmed the check bites by pointing it at a bogus directory and watching the test fail.

## Deliberately unchanged

- **Existing rows.** `attachments` rows carry `disk` per row and `public: 'public'` stays declared, so rows written before this keep resolving through `disk.url()`. No data migration; CI reseeds from scratch.
- **`SendNewPostNotification`** still writes its JSON artifact to the `public` disk. Those are app-authored bytes, not an upload, and `PostResource.notificationArtifactPath` publishes the path.

## No changeset

`@guren/example-blog` is `private` and listed in `.changeset/config.json`'s `ignore`. The framework-side changeset ships with #614.

## Gates

`build:clean`, `typecheck`, `test` (all packages), `audit:core-first`, `audit:docs`, blog `smoke`, `guren check` (32 passed / 0 failures), `guren audit` (one pre-existing esbuild advisory), and the blog E2E suite — **30 passed** — all run against this branch as it stands, rebased onto #614's current tip.

`smoke:starter:blog` and `audit:starter-template` cover the scaffold templates #614 changes; they are that PR's exposure, not this one's.