### PR TITLE
feat(examples): serve docs search from D1 on guren.dev

### DIFF
--- a/web/app/Http/Controllers/DocsSearchController.ts
+++ b/web/app/Http/Controllers/DocsSearchController.ts
@@ -50,8 +50,16 @@ export default class DocsSearchController extends Controller {
       )
     } catch (error) {
       if (error instanceof SearchIndexUnavailableError) {
+        // The error's own text names the build commands and the artifact path
+        // that fix this. That belongs in a log, where whoever deploys will
+        // read it — not in a response to whoever happened to search. Returning
+        // it also walked around the sanitizing the framework's exception
+        // handler does in production.
+        console.error(error.message)
         // Not cached: the next deploy is expected to fix it.
-        return this.json({ error: error.message }, { status: error.statusCode })
+        return this.json({ error: 'Search is not available on this deployment.' }, {
+          status: error.statusCode,
+        })
       }
       throw error
     }

--- a/web/app/Http/Controllers/DocsSearchController.ts
+++ b/web/app/Http/Controllers/DocsSearchController.ts
@@ -1,0 +1,57 @@
+import { Controller } from '@guren/core'
+import { z } from 'zod'
+
+import {
+  docSearchService,
+  SearchIndexUnavailableError,
+  type DocSearchResult,
+} from '../../Services/DocSearchService.js'
+
+/**
+ * Longest query accepted. Every term is ANDed, so a longer one narrows rather
+ * than widens; the cap is there to bound the work a single request can ask of
+ * FTS5, not to constrain the reader.
+ */
+const MAX_QUERY_LENGTH = 64
+
+export const DocSearchQuerySchema = z.object({
+  q: z.string().min(1).max(MAX_QUERY_LENGTH),
+  locale: z.enum(['en', 'ja']).default('en'),
+})
+
+/**
+ * The index only changes when a deploy rebuilds it, so results are safe to
+ * cache at the edge for a short window — the same query from many readers
+ * then costs one D1 read rather than one each.
+ */
+const SEARCH_CACHE_CONTROL = 'public, max-age=60'
+
+export interface DocSearchResponse {
+  query: string
+  locale: 'en' | 'ja'
+  results: DocSearchResult[]
+}
+
+/**
+ * `GET /docs/search` — JSON rather than an Inertia page, so a keystroke costs
+ * a query and not a server-rendered React tree.
+ */
+export default class DocsSearchController extends Controller {
+  async search(): Promise<Response> {
+    const { q, locale } = this.validateQuery(DocSearchQuerySchema)
+
+    try {
+      const results = await docSearchService.search(q, locale)
+      return this.json<DocSearchResponse>(
+        { query: q, locale, results },
+        { headers: { 'Cache-Control': SEARCH_CACHE_CONTROL } },
+      )
+    } catch (error) {
+      if (error instanceof SearchIndexUnavailableError) {
+        // Not cached: the next deploy is expected to fix it.
+        return this.json({ error: error.message }, { status: error.statusCode })
+      }
+      throw error
+    }
+  }
+}

--- a/web/app/Http/Controllers/DocsSearchController.ts
+++ b/web/app/Http/Controllers/DocsSearchController.ts
@@ -20,9 +20,11 @@ export const DocSearchQuerySchema = z.object({
 })
 
 /**
- * The index only changes when a deploy rebuilds it, so results are safe to
- * cache at the edge for a short window — the same query from many readers
- * then costs one D1 read rather than one each.
+ * The index only changes when a deploy rebuilds it, so a repeated query is
+ * safe to serve from cache for a short window. This is the browser's cache
+ * only: the Worker runs on every request, and nothing here or in
+ * wrangler.jsonc puts the response in Cloudflare's cache, so two readers
+ * asking the same thing are still two D1 reads.
  */
 const SEARCH_CACHE_CONTROL = 'public, max-age=60'
 

--- a/web/app/Http/Middleware/docs-search-rate-limit.ts
+++ b/web/app/Http/Middleware/docs-search-rate-limit.ts
@@ -11,7 +11,13 @@ import type { Context, RateLimitEntry, RateLimitStore } from '@guren/core'
  * varies. It stops a loop hammering the endpoint, which is what it is for;
  * Cloudflare's own protections are the perimeter.
  */
-const REQUESTS_PER_MINUTE = 60
+/**
+ * Above what typing can reach. The client debounces, but a debounce collapses
+ * a burst rather than bounding a minute: 61 pauses longer than 150 ms is 61
+ * requests, which a reader editing a query steadily does reach. This is a
+ * ceiling on abuse, and it should never be the thing a reader runs into.
+ */
+const REQUESTS_PER_MINUTE = 240
 
 interface BunServeEnv {
   server?: { requestIP?: (request: Request) => { address?: string } | null }

--- a/web/app/Http/Middleware/docs-search-rate-limit.ts
+++ b/web/app/Http/Middleware/docs-search-rate-limit.ts
@@ -13,6 +13,10 @@ import type { Context, RateLimitEntry, RateLimitStore } from '@guren/core'
  */
 const REQUESTS_PER_MINUTE = 60
 
+interface BunServeEnv {
+  server?: { requestIP?: (request: Request) => { address?: string } | null }
+}
+
 /**
  * The framework default reads `server.requestIP()`, which only Bun provides —
  * on Workers it would fall back to one shared bucket for every visitor, and
@@ -26,9 +30,8 @@ export function docsSearchRateLimitKey(ctx: Context): string {
     return connectingIp
   }
 
-  const env = ctx.env as { server?: { requestIP?: (request: Request) => { address?: string } | null } } | undefined
-  const address = env?.server?.requestIP?.(ctx.req.raw)?.address
-  return address ?? '__shared__'
+  const env = ctx.env as BunServeEnv | undefined
+  return env?.server?.requestIP?.(ctx.req.raw)?.address ?? '__shared__'
 }
 
 /** Writes between sweeps. Small enough to bound the map, large enough to be rare. */

--- a/web/app/Http/Middleware/docs-search-rate-limit.ts
+++ b/web/app/Http/Middleware/docs-search-rate-limit.ts
@@ -1,0 +1,44 @@
+import { createRateLimitMiddleware, MemoryRateLimitStore } from '@guren/core'
+import type { Context } from '@guren/core'
+
+/**
+ * `/docs/search` is the only public endpoint here that reaches the database,
+ * and it does so per keystroke. This bounds one client's share of D1's daily
+ * read budget.
+ *
+ * Honest about what it is: the store is per-isolate memory, and Workers runs
+ * many isolates, so the effective ceiling is higher than the number below and
+ * varies. It stops a loop hammering the endpoint, which is what it is for;
+ * Cloudflare's own protections are the perimeter.
+ */
+const REQUESTS_PER_MINUTE = 60
+
+/**
+ * The framework default reads `server.requestIP()`, which only Bun provides —
+ * on Workers it would fall back to one shared bucket for every visitor, and
+ * the first burst would lock the endpoint for everyone. Cloudflare puts the
+ * client address in `CF-Connecting-IP`, and it is set by the edge rather than
+ * by the caller.
+ */
+export function docsSearchRateLimitKey(ctx: Context): string {
+  const forwarded = ctx.req.header('cf-connecting-ip')
+  if (forwarded) {
+    return forwarded
+  }
+
+  const env = ctx.env as { server?: { requestIP?: (request: Request) => { address?: string } | null } } | undefined
+  const address = env?.server?.requestIP?.(ctx.req.raw)?.address
+  return address ?? '__shared__'
+}
+
+export const docsSearchRateLimit = createRateLimitMiddleware({
+  limit: REQUESTS_PER_MINUTE,
+  windowMs: 60_000,
+  keyGenerator: docsSearchRateLimitKey,
+  // Zero disables the sweep timer. This module is evaluated while the Worker's
+  // global scope is still running, where Cloudflare disallows timers outright;
+  // expired entries are dropped on read instead.
+  store: new MemoryRateLimitStore(0),
+  keyPrefix: 'docs-search:',
+  message: 'Too many searches. Try again in a moment.',
+})

--- a/web/app/Http/Middleware/docs-search-rate-limit.ts
+++ b/web/app/Http/Middleware/docs-search-rate-limit.ts
@@ -1,5 +1,5 @@
 import { createRateLimitMiddleware, MemoryRateLimitStore } from '@guren/core'
-import type { Context } from '@guren/core'
+import type { Context, RateLimitEntry, RateLimitStore } from '@guren/core'
 
 /**
  * `/docs/search` is the only public endpoint here that reaches the database,
@@ -21,9 +21,9 @@ const REQUESTS_PER_MINUTE = 60
  * by the caller.
  */
 export function docsSearchRateLimitKey(ctx: Context): string {
-  const forwarded = ctx.req.header('cf-connecting-ip')
-  if (forwarded) {
-    return forwarded
+  const connectingIp = ctx.req.header('cf-connecting-ip')
+  if (connectingIp) {
+    return connectingIp
   }
 
   const env = ctx.env as { server?: { requestIP?: (request: Request) => { address?: string } | null } } | undefined
@@ -31,14 +31,53 @@ export function docsSearchRateLimitKey(ctx: Context): string {
   return address ?? '__shared__'
 }
 
+/** Writes between sweeps. Small enough to bound the map, large enough to be rare. */
+const SWEEP_EVERY = 256
+
+/**
+ * The memory store, minus its timer, plus a sweep it drives itself.
+ *
+ * The timer has to go: this module is evaluated while the Worker's global
+ * scope is still running, and Cloudflare disallows timers there. But the
+ * store only drops an expired entry when that same key is seen again, and
+ * the key here is a visitor's address — so an isolate would hold one entry
+ * per address it had ever served, for as long as it lived. Sweeping on write
+ * keeps the map proportional to recent traffic instead of to all of it.
+ */
+export class SweepingRateLimitStore implements RateLimitStore {
+  readonly #entries: MemoryRateLimitStore
+  #writesSinceSweep = 0
+
+  constructor(now: () => number = () => Date.now()) {
+    this.#entries = new MemoryRateLimitStore(0, now)
+  }
+
+  get size(): number {
+    return this.#entries.size
+  }
+
+  async get(key: string): Promise<RateLimitEntry | null> {
+    return this.#entries.get(key)
+  }
+
+  async increment(key: string, windowMs: number): Promise<RateLimitEntry> {
+    if (++this.#writesSinceSweep >= SWEEP_EVERY) {
+      this.#writesSinceSweep = 0
+      this.#entries.cleanup()
+    }
+    return this.#entries.increment(key, windowMs)
+  }
+
+  async reset(key: string): Promise<void> {
+    return this.#entries.reset(key)
+  }
+}
+
 export const docsSearchRateLimit = createRateLimitMiddleware({
   limit: REQUESTS_PER_MINUTE,
   windowMs: 60_000,
   keyGenerator: docsSearchRateLimitKey,
-  // Zero disables the sweep timer. This module is evaluated while the Worker's
-  // global scope is still running, where Cloudflare disallows timers outright;
-  // expired entries are dropped on read instead.
-  store: new MemoryRateLimitStore(0),
+  store: new SweepingRateLimitStore(),
   keyPrefix: 'docs-search:',
   message: 'Too many searches. Try again in a moment.',
 })

--- a/web/app/Services/DocSearchService.ts
+++ b/web/app/Services/DocSearchService.ts
@@ -1,0 +1,180 @@
+// Reads the docs search index that `scripts/build-search-index.ts` puts in D1.
+//
+// The tables are named after the build that produced them, and their names
+// arrive through a generated module baked into the bundle — see that script
+// for why the switch happens at deploy time rather than in SQL.
+import { sql, type SQL } from '@guren/orm/drizzle/sqlite'
+
+import { searchIndexBuild, type SearchIndexBuild } from '@/.guren/search-index.gen.js'
+
+import { getDatabase } from '../../config/database.js'
+import { docPaths } from '../../config/site.js'
+import {
+  BM25_WEIGHTS,
+  buildSearchMatch,
+  queryTerms,
+  type SearchLocale,
+} from './search-tokenize.js'
+
+export interface DocSearchResult {
+  category: string
+  slug: string
+  anchor: string
+  docTitle: string
+  heading: string
+  snippet: string
+  url: string
+}
+
+/**
+ * `getDatabase()` hands back the driver as `unknown` — it is a D1 handle on
+ * Workers and a bun-sqlite one locally. Only `all()` is needed here, and it
+ * is awaited so both the sync and async drivers work.
+ */
+interface QueryableDatabase {
+  all(query: SQL): unknown[] | Promise<unknown[]>
+}
+
+interface SectionRow {
+  category: string
+  slug: string
+  anchor: string
+  doc_title: string
+  heading: string
+  body: string
+}
+
+/** Characters of context, before ellipsis. Fits two lines in a result list. */
+const SNIPPET_LENGTH = 160
+
+/** How far into the snippet the match sits, so the reader sees its lead-in. */
+const SNIPPET_LEAD = 48
+
+/**
+ * Thrown when the app is serving without an index. The generated module is a
+ * stub in any checkout that has not run the build, and returning empty
+ * results there would present a broken deploy as "nothing matched".
+ */
+export class SearchIndexUnavailableError extends Error {
+  readonly statusCode = 503
+
+  constructor() {
+    super(
+      'The docs search index has not been built. Run `bun run prerender && bun scripts/build-search-index.ts`, ' +
+        'then load .guren/search-index.sql into the database this app opens.',
+    )
+    this.name = 'SearchIndexUnavailableError'
+  }
+}
+
+/** Step off a lone surrogate so a slice never splits an astral character. */
+function safeBoundary(text: string, index: number): number {
+  const code = text.charCodeAt(index)
+  return code >= 0xdc00 && code <= 0xdfff ? index - 1 : index
+}
+
+/**
+ * A window of the section body around the first term the reader typed.
+ *
+ * Deliberately not FTS5's `snippet()`: the indexed columns hold bigrams, so
+ * it would hand back 「コン ント トロ」rather than the sentence.
+ */
+export function buildSnippet(body: string, query: string, length = SNIPPET_LENGTH): string {
+  const flat = body.replace(/\s+/gu, ' ').trim()
+  if (flat.length <= length) {
+    return flat
+  }
+
+  const lower = flat.toLowerCase()
+  // Case folding is length-preserving for everything in these docs, but not in
+  // general (İ folds to two code units). Rather than track a shifted index,
+  // fall back to the head of the section when it is not.
+  const at =
+    lower.length === flat.length
+      ? queryTerms(query)
+          .map((term) => lower.indexOf(term))
+          .filter((index) => index >= 0)
+          .reduce<number>((best, index) => (best < 0 ? index : Math.min(best, index)), -1)
+      : -1
+
+  if (at < 0) {
+    return `${flat.slice(0, safeBoundary(flat, length)).trimEnd()}…`
+  }
+
+  const start = safeBoundary(flat, Math.max(0, at - SNIPPET_LEAD))
+  const end = safeBoundary(flat, Math.min(flat.length, start + length))
+  return `${start > 0 ? '…' : ''}${flat.slice(start, end).trim()}${end < flat.length ? '…' : ''}`
+}
+
+export class DocSearchService {
+  readonly #database: () => Promise<unknown>
+  readonly #build: SearchIndexBuild
+
+  constructor(database: () => Promise<unknown>, build: SearchIndexBuild) {
+    this.#database = database
+    this.#build = build
+  }
+
+  get indexed(): boolean {
+    return this.#build.indexed
+  }
+
+  async search(query: string, locale: SearchLocale, limit = 20): Promise<DocSearchResult[]> {
+    if (!this.#build.indexed) {
+      throw new SearchIndexUnavailableError()
+    }
+
+    const match = buildSearchMatch(query, locale)
+    if (match === null) {
+      return []
+    }
+
+    const search = sql.identifier(this.#build.searchTable)
+    const sections = sql.identifier(this.#build.sectionsTable)
+    const [title, heading, body, localeWeight, unigram] = BM25_WEIGHTS[match.mode]
+
+    // FTS5 refuses a table alias on the left of MATCH ("no such column"), so
+    // the search table is named outright and only the sections table is
+    // aliased. Both names come from the generated module rather than from the
+    // request, and everything else is bound — including the bm25 weights.
+    const rows = (await (
+      (await this.#database()) as QueryableDatabase
+    ).all(sql`
+      SELECT s.category AS category, s.slug AS slug, s.anchor AS anchor,
+             s.doc_title AS doc_title, s.heading AS heading, s.body AS body
+      FROM ${search}
+      JOIN ${sections} s ON s.id = ${search}.rowid
+      WHERE ${search} MATCH ${match.match}
+      ORDER BY bm25(${search}, ${title}, ${heading}, ${body}, ${localeWeight}, ${unigram})
+      LIMIT ${limit * 2}
+    `)) as SectionRow[]
+
+    const seen = new Set<string>()
+    const results: DocSearchResult[] = []
+    for (const row of rows) {
+      // A long section is stored as several rows sharing one anchor; the
+      // reader should see the heading once, at its best-ranked occurrence.
+      const key = `${row.slug}#${row.anchor}`
+      if (seen.has(key)) {
+        continue
+      }
+      seen.add(key)
+      results.push({
+        category: row.category,
+        slug: row.slug,
+        anchor: row.anchor,
+        docTitle: row.doc_title,
+        heading: row.heading,
+        snippet: buildSnippet(row.body, query),
+        url: `${docPaths(row.category, row.slug)[locale]}#${encodeURIComponent(row.anchor)}`,
+      })
+      if (results.length === limit) {
+        break
+      }
+    }
+
+    return results
+  }
+}
+
+export const docSearchService = new DocSearchService(getDatabase, searchIndexBuild)

--- a/web/app/Services/DocSearchService.ts
+++ b/web/app/Services/DocSearchService.ts
@@ -129,49 +129,51 @@ export class DocSearchService {
     const sections = sql.identifier(this.#build.sectionsTable)
     const [titleLead, title, heading, body, localeWeight, unigram] = BM25_WEIGHTS[match.mode]
 
-    // FTS5 refuses a table alias on the left of MATCH ("no such column"), so
-    // the search table is named outright and only the sections table is
-    // aliased. Both names come from the generated module rather than from the
-    // request, and everything else is bound — including the bm25 weights.
+    // A long section is stored as several rows sharing one anchor, and the
+    // reader should see that heading once, at its best-ranked chunk. Collapsed
+    // here rather than after the fact: fetching a fixed multiple of the limit
+    // and deduplicating in JS is only right while no section has more chunks
+    // than that multiple. One that did returned a single result for a query
+    // with twenty-six distinct matches. Partitioning by category too, because
+    // a slug is not unique across them — `guides/overview` and
+    // `tutorials/overview` both exist.
+    //
+    // FTS5 refuses a table alias on the left of MATCH ("no such column"), and
+    // bm25() only works in a query directly over the table, so the ranking
+    // subquery is separate from the one that windows over it. Both table names
+    // come from the generated module; everything else is bound, weights
+    // included.
     const database = (await this.#database()) as QueryableDatabase
     const rows = (await database.all(sql`
-      SELECT s.category AS category, s.slug AS slug, s.anchor AS anchor,
-             s.doc_title AS doc_title, s.heading AS heading, s.body AS body
-      FROM ${search}
-      JOIN ${sections} s ON s.id = ${search}.rowid
-      WHERE ${search} MATCH ${match.match}
-      ORDER BY bm25(${search}, ${titleLead}, ${title}, ${heading}, ${body}, ${localeWeight}, ${unigram})
-      LIMIT ${limit * 2}
+      SELECT category, slug, anchor, doc_title, heading, body FROM (
+        SELECT s.category AS category, s.slug AS slug, s.anchor AS anchor,
+               s.doc_title AS doc_title, s.heading AS heading, s.body AS body,
+               ranked.rank AS rank,
+               row_number() OVER (
+                 PARTITION BY s.category, s.slug, s.anchor ORDER BY ranked.rank
+               ) AS chunk
+        FROM (
+          SELECT ${search}.rowid AS id,
+                 bm25(${search}, ${titleLead}, ${title}, ${heading}, ${body}, ${localeWeight}, ${unigram}) AS rank
+          FROM ${search}
+          WHERE ${search} MATCH ${match.match}
+        ) AS ranked
+        JOIN ${sections} s ON s.id = ranked.id
+      )
+      WHERE chunk = 1
+      ORDER BY rank
+      LIMIT ${limit}
     `)) as SectionRow[]
 
-    const seen = new Set<string>()
-    const results: DocSearchResult[] = []
-    for (const row of rows) {
-      // A long section is stored as several rows sharing one anchor; the
-      // reader should see the heading once, at its best-ranked occurrence.
-      // Keyed on the category too, because the slug alone is not unique —
-      // `guides/overview` and `tutorials/overview` both exist, and one would
-      // otherwise suppress the other.
-      const key = `${row.category}/${row.slug}#${row.anchor}`
-      if (seen.has(key)) {
-        continue
-      }
-      seen.add(key)
-      results.push({
-        category: row.category,
-        slug: row.slug,
-        anchor: row.anchor,
-        docTitle: row.doc_title,
-        heading: row.heading,
-        snippet: buildSnippet(row.body, query),
-        url: `${docPaths(row.category, row.slug)[locale]}#${encodeURIComponent(row.anchor)}`,
-      })
-      if (results.length === limit) {
-        break
-      }
-    }
-
-    return results
+    return rows.map((row) => ({
+      category: row.category,
+      slug: row.slug,
+      anchor: row.anchor,
+      docTitle: row.doc_title,
+      heading: row.heading,
+      snippet: buildSnippet(row.body, query),
+      url: `${docPaths(row.category, row.slug)[locale]}#${encodeURIComponent(row.anchor)}`,
+    }))
   }
 }
 

--- a/web/app/Services/DocSearchService.ts
+++ b/web/app/Services/DocSearchService.ts
@@ -89,13 +89,13 @@ export function buildSnippet(body: string, query: string, length = SNIPPET_LENGT
   // Case folding is length-preserving for everything in these docs, but not in
   // general (İ folds to two code units). Rather than track a shifted index,
   // fall back to the head of the section when it is not.
-  const at =
+  const positions =
     lower.length === flat.length
       ? queryTerms(query)
           .map((term) => lower.indexOf(term))
           .filter((index) => index >= 0)
-          .reduce<number>((best, index) => (best < 0 ? index : Math.min(best, index)), -1)
-      : -1
+      : []
+  const at = positions.length > 0 ? Math.min(...positions) : -1
 
   if (at < 0) {
     return `${flat.slice(0, safeBoundary(flat, length)).trimEnd()}…`
@@ -113,10 +113,6 @@ export class DocSearchService {
   constructor(database: () => Promise<unknown>, build: SearchIndexBuild) {
     this.#database = database
     this.#build = build
-  }
-
-  get indexed(): boolean {
-    return this.#build.indexed
   }
 
   async search(query: string, locale: SearchLocale, limit = 20): Promise<DocSearchResult[]> {
@@ -137,9 +133,8 @@ export class DocSearchService {
     // the search table is named outright and only the sections table is
     // aliased. Both names come from the generated module rather than from the
     // request, and everything else is bound — including the bm25 weights.
-    const rows = (await (
-      (await this.#database()) as QueryableDatabase
-    ).all(sql`
+    const database = (await this.#database()) as QueryableDatabase
+    const rows = (await database.all(sql`
       SELECT s.category AS category, s.slug AS slug, s.anchor AS anchor,
              s.doc_title AS doc_title, s.heading AS heading, s.body AS body
       FROM ${search}
@@ -154,7 +149,10 @@ export class DocSearchService {
     for (const row of rows) {
       // A long section is stored as several rows sharing one anchor; the
       // reader should see the heading once, at its best-ranked occurrence.
-      const key = `${row.slug}#${row.anchor}`
+      // Keyed on the category too, because the slug alone is not unique —
+      // `guides/overview` and `tutorials/overview` both exist, and one would
+      // otherwise suppress the other.
+      const key = `${row.category}/${row.slug}#${row.anchor}`
       if (seen.has(key)) {
         continue
       }

--- a/web/app/Services/DocSearchService.ts
+++ b/web/app/Services/DocSearchService.ts
@@ -127,7 +127,7 @@ export class DocSearchService {
 
     const search = sql.identifier(this.#build.searchTable)
     const sections = sql.identifier(this.#build.sectionsTable)
-    const [title, heading, body, localeWeight, unigram] = BM25_WEIGHTS[match.mode]
+    const [titleLead, title, heading, body, localeWeight, unigram] = BM25_WEIGHTS[match.mode]
 
     // FTS5 refuses a table alias on the left of MATCH ("no such column"), so
     // the search table is named outright and only the sections table is
@@ -140,7 +140,7 @@ export class DocSearchService {
       FROM ${search}
       JOIN ${sections} s ON s.id = ${search}.rowid
       WHERE ${search} MATCH ${match.match}
-      ORDER BY bm25(${search}, ${title}, ${heading}, ${body}, ${localeWeight}, ${unigram})
+      ORDER BY bm25(${search}, ${titleLead}, ${title}, ${heading}, ${body}, ${localeWeight}, ${unigram})
       LIMIT ${limit * 2}
     `)) as SectionRow[]
 

--- a/web/routes/web.ts
+++ b/web/routes/web.ts
@@ -1,5 +1,7 @@
 import { Router } from '@guren/core'
+import { docsSearchRateLimit } from '../app/Http/Middleware/docs-search-rate-limit.js'
 import DocsController from '../app/Http/Controllers/DocsController.js'
+import DocsSearchController, { DocSearchQuerySchema } from '../app/Http/Controllers/DocsSearchController.js'
 import HomeController from '../app/Http/Controllers/HomeController.js'
 import MetaController from '../app/Http/Controllers/MetaController.js'
 
@@ -13,6 +15,18 @@ export function registerWebRoutes(router: Router): void {
 
   router.group('/docs', (docs) => {
     docs.get('/', [DocsController, 'index'])
+    // Two segments, so it cannot collide with the three-segment doc pages
+    // below. Locale is a query parameter rather than a path prefix — the
+    // search box is one endpoint serving both /docs and /docs/ja.
+    docs.get(
+      '/search',
+      {
+        name: 'docs.search',
+        query: DocSearchQuerySchema,
+        middlewares: [docsSearchRateLimit],
+      },
+      [DocsSearchController, 'search'],
+    )
     docs.get('/ja', [DocsController, 'indexJa'])
     docs.get('/ja/:category/:slug', [DocsController, 'showJa'])
     docs.get('/:category/:slug', [DocsController, 'show'])

--- a/web/tests/controllers/DocsSearchController.test.ts
+++ b/web/tests/controllers/DocsSearchController.test.ts
@@ -18,7 +18,13 @@ vi.mock('../../app/Services/DocSearchService.js', () => {
   class SearchIndexUnavailableError extends Error {
     readonly statusCode = 503
     constructor() {
-      super('The docs search index has not been built.')
+      // Shaped like the real one, which names the commands and the artifact
+      // path that fix the deployment — otherwise the test below that the
+      // response withholds them would pass on a message with nothing in it.
+      super(
+        'The docs search index has not been built. Run `bun run --cwd web cloudflare:build` ' +
+          'first, then load .guren/search-index.sql into the database this app opens.',
+      )
       this.name = 'SearchIndexUnavailableError'
     }
   }
@@ -100,6 +106,18 @@ describe('DocsSearchController', () => {
     expect(status).toBe(503)
     expect(body).toHaveProperty('error')
     expect(body).not.toHaveProperty('results')
+  })
+
+  it('does not hand the reader the commands that would fix the deployment', async () => {
+    // The error's own text names build commands and a repo path. Useful in a
+    // log; not something this endpoint should return to the public.
+    const detail = new SearchIndexUnavailableError()
+    search.mockRejectedValue(detail)
+    const { body } = await call('http://localhost/docs/search?q=routing')
+
+    expect(detail.message).toContain('.guren/')
+    expect(JSON.stringify(body)).not.toContain('bun ')
+    expect(JSON.stringify(body)).not.toContain('.guren/')
   })
 
   it('does not swallow an unexpected failure', async () => {

--- a/web/tests/controllers/DocsSearchController.test.ts
+++ b/web/tests/controllers/DocsSearchController.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  createControllerContext,
+  createControllerModuleMock,
+} from '../../../packages/testing/src/controller.js'
+import type { Context } from '@guren/core'
+
+vi.mock('@guren/core', () => createControllerModuleMock())
+
+const { search } = vi.hoisted(() => ({ search: vi.fn() }))
+
+// Replaced whole rather than partially: the real module reaches
+// config/database.ts at import time, and that calls a `@guren/core` export the
+// controller mock above does not carry. The controller's `instanceof` check
+// resolves to the class defined here, since both go through this mock.
+vi.mock('../../app/Services/DocSearchService.js', () => {
+  class SearchIndexUnavailableError extends Error {
+    readonly statusCode = 503
+    constructor() {
+      super('The docs search index has not been built.')
+      this.name = 'SearchIndexUnavailableError'
+    }
+  }
+  return { SearchIndexUnavailableError, docSearchService: { search } }
+})
+
+const { SearchIndexUnavailableError } = await import('../../app/Services/DocSearchService.js')
+const { default: DocsSearchController } = await import(
+  '../../app/Http/Controllers/DocsSearchController.js'
+)
+
+async function call(url: string): Promise<{ status: number; body: unknown }> {
+  const controller = new DocsSearchController()
+  controller.setContext(createControllerContext(url) as Context)
+  try {
+    const response = await controller.search()
+    return { status: response.status, body: await response.json() }
+  } catch (error) {
+    // ValidationException carries its own status; the framework's handler turns
+    // it into a response, so read it the way that handler would.
+    const status = (error as { statusCode?: number }).statusCode
+    if (status === undefined) {
+      throw error
+    }
+    return { status, body: error }
+  }
+}
+
+describe('DocsSearchController', () => {
+  beforeEach(() => {
+    search.mockReset()
+    search.mockResolvedValue([])
+  })
+
+  it('passes the query and locale through to the service', async () => {
+    await call('http://localhost/docs/search?q=routing&locale=ja')
+
+    expect(search).toHaveBeenCalledWith('routing', 'ja')
+  })
+
+  it('defaults to English when no locale is given', async () => {
+    await call('http://localhost/docs/search?q=routing')
+
+    expect(search).toHaveBeenCalledWith('routing', 'en')
+  })
+
+  it('echoes the query alongside the results', async () => {
+    search.mockResolvedValue([{ slug: 'routing', anchor: 'groups' }])
+    const { status, body } = await call('http://localhost/docs/search?q=groups')
+
+    expect(status).toBe(200)
+    expect(body).toEqual({
+      query: 'groups',
+      locale: 'en',
+      results: [{ slug: 'routing', anchor: 'groups' }],
+    })
+  })
+
+  it('rejects a missing query', async () => {
+    expect((await call('http://localhost/docs/search')).status).toBe(422)
+    expect(search).not.toHaveBeenCalled()
+  })
+
+  it('rejects a query past the length cap', async () => {
+    const { status } = await call(`http://localhost/docs/search?q=${'a'.repeat(65)}`)
+
+    expect(status).toBe(422)
+    expect(search).not.toHaveBeenCalled()
+  })
+
+  it('rejects a locale outside the two the docs are written in', async () => {
+    expect((await call('http://localhost/docs/search?q=x&locale=fr')).status).toBe(422)
+  })
+
+  it('reports an unbuilt index as unavailable rather than as no results', async () => {
+    search.mockRejectedValue(new SearchIndexUnavailableError())
+    const { status, body } = await call('http://localhost/docs/search?q=routing')
+
+    expect(status).toBe(503)
+    expect(body).toHaveProperty('error')
+    expect(body).not.toHaveProperty('results')
+  })
+
+  it('does not swallow an unexpected failure', async () => {
+    search.mockRejectedValue(new Error('D1 is down'))
+
+    await expect(call('http://localhost/docs/search?q=routing')).rejects.toThrow('D1 is down')
+  })
+})

--- a/web/tests/middleware/docs-search-rate-limit.test.ts
+++ b/web/tests/middleware/docs-search-rate-limit.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import type { Context } from '@guren/core'
-import { docsSearchRateLimitKey } from '../../app/Http/Middleware/docs-search-rate-limit.js'
+import {
+  docsSearchRateLimitKey,
+  SweepingRateLimitStore,
+} from '../../app/Http/Middleware/docs-search-rate-limit.js'
 
 function context(options: { headers?: Record<string, string>; address?: string }): Context {
   const headers = new Headers(options.headers)
@@ -29,5 +32,35 @@ describe('docsSearchRateLimitKey', () => {
     // This is the framework default's behaviour on Workers, and the reason
     // this key generator exists: one visitor's burst would lock out everyone.
     expect(docsSearchRateLimitKey(context({}))).toBe('__shared__')
+  })
+})
+
+describe('SweepingRateLimitStore', () => {
+  const WINDOW = 60_000
+
+  it('counts within the window and starts over after it', async () => {
+    let now = 1_800_000_000_000
+    const store = new SweepingRateLimitStore(() => now)
+
+    expect((await store.increment('a', WINDOW)).count).toBe(1)
+    expect((await store.increment('a', WINDOW)).count).toBe(2)
+
+    now += WINDOW + 1
+    expect((await store.increment('a', WINDOW)).count).toBe(1)
+  })
+
+  it('does not grow without bound as addresses come and go', async () => {
+    // The store only drops an expired entry when its own key is seen again,
+    // and the key is a visitor's address. Without the sweep, an isolate holds
+    // one entry per address it has ever served, for as long as it lives.
+    let now = 1_800_000_000_000
+    const store = new SweepingRateLimitStore(() => now)
+
+    for (let visitor = 0; visitor < 2000; visitor++) {
+      await store.increment(`203.0.113.${visitor}`, WINDOW)
+      now += 100
+    }
+
+    expect(store.size).toBeLessThan(2000)
   })
 })

--- a/web/tests/middleware/docs-search-rate-limit.test.ts
+++ b/web/tests/middleware/docs-search-rate-limit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Context } from '@guren/core'
+import { docsSearchRateLimitKey } from '../../app/Http/Middleware/docs-search-rate-limit.js'
+
+function context(options: { headers?: Record<string, string>; address?: string }): Context {
+  const headers = new Headers(options.headers)
+  return {
+    req: {
+      raw: new Request('http://guren.dev/docs/search?q=x'),
+      header: (name: string) => headers.get(name) ?? undefined,
+    },
+    env: options.address ? { server: { requestIP: () => ({ address: options.address }) } } : undefined,
+  } as unknown as Context
+}
+
+describe('docsSearchRateLimitKey', () => {
+  it('prefers the address Cloudflare puts on the request', () => {
+    expect(docsSearchRateLimitKey(context({ headers: { 'cf-connecting-ip': '203.0.113.7' } }))).toBe(
+      '203.0.113.7',
+    )
+  })
+
+  it('falls back to the socket peer when Bun is serving', () => {
+    expect(docsSearchRateLimitKey(context({ address: '127.0.0.1' }))).toBe('127.0.0.1')
+  })
+
+  it('only shares one bucket when neither is available', () => {
+    // This is the framework default's behaviour on Workers, and the reason
+    // this key generator exists: one visitor's burst would lock out everyone.
+    expect(docsSearchRateLimitKey(context({}))).toBe('__shared__')
+  })
+})

--- a/web/tests/services/doc-search-snippet.test.ts
+++ b/web/tests/services/doc-search-snippet.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildSnippet } from '../../app/Services/DocSearchService.js'
+
+const LONG = 'Lorem ipsum dolor sit amet. '.repeat(20)
+
+describe('buildSnippet', () => {
+  it('returns a short body whole, with no ellipsis', () => {
+    expect(buildSnippet('Deploy the app to Workers.', 'workers')).toBe(
+      'Deploy the app to Workers.',
+    )
+  })
+
+  it('collapses the line breaks the body was stored with', () => {
+    expect(buildSnippet('Deploy\nthe app\n\nto Workers.', 'workers')).toBe(
+      'Deploy the app to Workers.',
+    )
+  })
+
+  it('centres the window on the first term the reader typed', () => {
+    const snippet = buildSnippet(`${LONG} needle here ${LONG}`, 'needle')
+
+    expect(snippet).toContain('needle here')
+    expect(snippet.startsWith('…')).toBe(true)
+    expect(snippet.endsWith('…')).toBe(true)
+  })
+
+  it('matches regardless of the case the body uses', () => {
+    // The stored body keeps its original casing; the query does not.
+    expect(buildSnippet(`${LONG} createD1Database ${LONG}`, 'CreateD1Database')).toContain(
+      'createD1Database',
+    )
+  })
+
+  it('finds a Japanese term as the reader wrote it, not as bigrams', () => {
+    const body = `${LONG}コントローラーはリクエストを受け取る。${LONG}`
+
+    expect(buildSnippet(body, 'コントローラー')).toContain('コントローラーはリクエスト')
+  })
+
+  it('falls back to the head of the body when no term appears', () => {
+    // Can happen: the match may have come from the heading or the doc title.
+    const snippet = buildSnippet(LONG, 'nothingmatcheshere')
+
+    expect(snippet.startsWith('Lorem ipsum')).toBe(true)
+    expect(snippet.endsWith('…')).toBe(true)
+  })
+
+  it('never splits a surrogate pair', () => {
+    const lone = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u
+
+    // The trailing cut: 159 single-unit characters put the first emoji across
+    // indices 159 and 160, so a 160-character window ends inside it.
+    expect(buildSnippet(`${'a'.repeat(159)}${'🎉'.repeat(50)}`, 'a')).not.toMatch(lone)
+
+    // The leading cut: the window opens 48 characters before the hit, and an
+    // odd offset puts that opening inside an emoji.
+    expect(buildSnippet(`${'🎉'.repeat(100)}x needle ${'b'.repeat(300)}`, 'needle')).not.toMatch(
+      lone,
+    )
+  })
+})

--- a/web/tests/services/doc-search-snippet.test.ts
+++ b/web/tests/services/doc-search-snippet.test.ts
@@ -53,9 +53,11 @@ describe('buildSnippet', () => {
     // indices 159 and 160, so a 160-character window ends inside it.
     expect(buildSnippet(`${'a'.repeat(159)}${'🎉'.repeat(50)}`, 'a')).not.toMatch(lone)
 
-    // The leading cut: the window opens 48 characters before the hit, and an
-    // odd offset puts that opening inside an emoji.
-    expect(buildSnippet(`${'🎉'.repeat(100)}x needle ${'b'.repeat(300)}`, 'needle')).not.toMatch(
+    // The leading cut: the window opens 48 characters before the hit, and the
+    // padding is sized so that opening lands on the *second* code unit of an
+    // emoji. One character less and it lands on the first, where an unguarded
+    // slice is accidentally valid and the assertion proves nothing.
+    expect(buildSnippet(`${'🎉'.repeat(100)}xy needle ${'b'.repeat(300)}`, 'needle')).not.toMatch(
       lone,
     )
   })

--- a/web/tests/sqlite/doc-search-service.test.ts
+++ b/web/tests/sqlite/doc-search-service.test.ts
@@ -1,0 +1,155 @@
+/**
+ * DocSearchService against a real FTS5 engine, through the same generated SQL
+ * a deploy applies. Runs under `bun test` for the reason
+ * `tests/sqlite/search-index.test.ts` explains: Node's bundled SQLite has no
+ * FTS5 module, so vitest cannot host any of this.
+ */
+import { Database } from 'bun:sqlite'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { drizzle } from 'drizzle-orm/bun-sqlite'
+
+import { beforeAll, describe, expect, test } from 'bun:test'
+
+import {
+  DocSearchService,
+  SearchIndexUnavailableError,
+} from '../../app/Services/DocSearchService.js'
+import {
+  collectRows,
+  computeBuildId,
+  renderIndexSql,
+  searchTableName,
+  sectionsTableName,
+  type DocsByLocale,
+} from '../../app/Services/search-index-build.js'
+
+const docs: DocsByLocale = {
+  en: {
+    guides: {
+      // Long enough that section splitting stores it as several rows under one
+      // anchor, which is what the deduplication below has to collapse.
+      operations: {
+        title: 'Operations',
+        html: `<h1 id="operations">Operations</h1><p>${'Rotate the paginated ledger. '.repeat(400)}</p>`,
+      },
+      cloudflare: {
+        title: 'Cloudflare',
+        html:
+          '<h1 id="cloudflare">Cloudflare</h1><p>Deploy the app to Workers.</p>' +
+          '<h2 id="database-d1">Database (D1)</h2>' +
+          '<p>Call <code>createD1Database</code> with the binding from wrangler.jsonc.</p>',
+      },
+    },
+  },
+  ja: {
+    guides: {
+      controllers: {
+        title: 'コントローラー',
+        html:
+          '<h1 id="コントローラー">コントローラー</h1>' +
+          '<p>コントローラーはリクエストを受け取り、レスポンスを返す。</p>' +
+          '<h2 id="型安全">型安全</h2><p>型安全なリクエストパースを行う。</p>',
+      },
+    },
+  },
+}
+
+const rows = collectRows(docs)
+const buildId = computeBuildId(rows)
+const build = {
+  indexed: true,
+  buildId,
+  sectionsTable: sectionsTableName(buildId),
+  searchTable: searchTableName(buildId),
+}
+
+let service: DocSearchService
+
+beforeAll(() => {
+  const client = new Database(':memory:')
+  const migrations = join(import.meta.dir, '../../db/migrations')
+  for (const entry of readdirSync(migrations, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => dirent.name)
+    .sort()) {
+    client.exec(readFileSync(join(migrations, entry, 'migration.sql'), 'utf8'))
+  }
+  client.exec(renderIndexSql(rows, buildId))
+  const db = drizzle({ client })
+  service = new DocSearchService(async () => db, build)
+})
+
+describe('DocSearchService', () => {
+  test('finds a Japanese heading and links to its anchor', async () => {
+    const [first] = await service.search('コントローラー', 'ja')
+
+    expect(first).toMatchObject({
+      category: 'guides',
+      slug: 'controllers',
+      docTitle: 'コントローラー',
+      url: `/docs/ja/guides/controllers#${encodeURIComponent('コントローラー')}`,
+    })
+  })
+
+  test('finds an identifier through its camel-case parts', async () => {
+    const results = await service.search('d1 database', 'en')
+
+    expect(results[0]).toMatchObject({ slug: 'cloudflare', anchor: 'database-d1' })
+    expect(results[0].snippet).toContain('createD1Database')
+  })
+
+  test('finds a one-character CJK query', async () => {
+    const results = await service.search('型', 'ja')
+
+    expect(results.map((result) => result.anchor)).toContain('型安全')
+  })
+
+  test('links English results to the English path', async () => {
+    const [first] = await service.search('workers', 'en')
+
+    expect(first.url).toBe('/docs/guides/cloudflare#cloudflare')
+  })
+
+  test('shows a split section once, at its best-ranked row', async () => {
+    // A body over the row cap becomes several rows sharing one anchor. Without
+    // deduplication the same heading fills the whole result list.
+    const results = await service.search('ledger', 'en')
+
+    expect(results.filter((result) => result.anchor === 'operations')).toHaveLength(1)
+  })
+
+  test('scopes results to the requested locale', async () => {
+    // The filter lives inside MATCH rather than in a WHERE after it: filtering
+    // afterwards makes FTS5 read every matching row before discarding half.
+    expect(await service.search('コントローラー', 'en')).toEqual([])
+    expect(await service.search('workers', 'ja')).toEqual([])
+  })
+
+  test('returns nothing for a query with no searchable characters', async () => {
+    expect(await service.search('***', 'en')).toEqual([])
+  })
+
+  test('does not turn FTS5 syntax into a query error', async () => {
+    for (const hostile of ['a OR b', 'NEAR(x, y)', 'body:*', '"']) {
+      expect(await service.search(hostile, 'en')).toBeArray()
+    }
+  })
+
+  test('honours the result limit', async () => {
+    expect((await service.search('the', 'en', 1)).length).toBeLessThanOrEqual(1)
+  })
+
+  test('refuses to answer when the index was never built', async () => {
+    // A checkout that has not run the build carries a stub module. Returning
+    // an empty list there would present a broken deploy as "nothing matched".
+    const unbuilt = new DocSearchService(async () => {
+      throw new Error('should not reach the database')
+    }, { indexed: false, buildId: '', sectionsTable: '', searchTable: '' })
+
+    await expect(unbuilt.search('anything', 'en')).rejects.toBeInstanceOf(
+      SearchIndexUnavailableError,
+    )
+  })
+})

--- a/web/tests/sqlite/doc-search-service.test.ts
+++ b/web/tests/sqlite/doc-search-service.test.ts
@@ -27,12 +27,23 @@ import { applyMigrations } from './migrations.js'
 const docs: DocsByLocale = {
   en: {
     guides: {
-      // Long enough that section splitting stores it as several rows under one
-      // anchor, which is what the deduplication below has to collapse.
+      // Long enough that section splitting stores it as many rows under one
+      // anchor — more than any fixed over-fetch would leave room for.
       operations: {
         title: 'Operations',
-        html: `<h1 id="operations">Operations</h1><p>${'Rotate the paginated ledger. '.repeat(400)}</p>`,
+        html: `<h1 id="operations">Operations</h1><p>${'Rotate the paginated ledger. '.repeat(4000)}</p>`,
       },
+      // Nine more documents mentioning the same word once, so a crowding-out
+      // failure is visible as their absence rather than as a reordering.
+      ...Object.fromEntries(
+        Array.from({ length: 9 }, (_, index) => [
+          `note-${index}`,
+          {
+            title: `Note ${index}`,
+            html: `<h1 id="note-${index}">Note ${index}</h1><p>A paginated note.</p>`,
+          },
+        ]),
+      ),
       overview: {
         title: 'Guide overview',
         html: '<h1 id="overview">Overview</h1><p>Guren at a glance, step by step.</p>',
@@ -152,6 +163,17 @@ describe('DocSearchService', () => {
   test('returns as many distinct sections as the limit allows', async () => {
     expect(await service.search('step by step', 'en', 1)).toHaveLength(1)
     expect(await service.search('step by step', 'en', 2)).toHaveLength(2)
+  })
+
+  test('is not crowded out by one section with many chunks', async () => {
+    // Deduplicating after a fixed over-fetch only works while no section has
+    // more chunks than the multiple. `paginated` appears in one very long
+    // section and in nine short docs; over-fetching 2x the limit returned the
+    // long section alone and dropped the other nine.
+    const results = await service.search('paginated', 'en', 5)
+
+    expect(results.map((result) => result.slug)).toContain('operations')
+    expect(new Set(results.map((result) => result.slug)).size).toBe(5)
   })
 
   test('refuses to answer when the index was never built', async () => {

--- a/web/tests/sqlite/doc-search-service.test.ts
+++ b/web/tests/sqlite/doc-search-service.test.ts
@@ -5,8 +5,6 @@
  * FTS5 module, so vitest cannot host any of this.
  */
 import { Database } from 'bun:sqlite'
-import { readdirSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
 
 import { drizzle } from 'drizzle-orm/bun-sqlite'
 
@@ -24,6 +22,7 @@ import {
   sectionsTableName,
   type DocsByLocale,
 } from '../../app/Services/search-index-build.js'
+import { applyMigrations } from './migrations.js'
 
 const docs: DocsByLocale = {
   en: {
@@ -34,12 +33,22 @@ const docs: DocsByLocale = {
         title: 'Operations',
         html: `<h1 id="operations">Operations</h1><p>${'Rotate the paginated ledger. '.repeat(400)}</p>`,
       },
+      overview: {
+        title: 'Guide overview',
+        html: '<h1 id="overview">Overview</h1><p>Guren at a glance, step by step.</p>',
+      },
       cloudflare: {
         title: 'Cloudflare',
         html:
           '<h1 id="cloudflare">Cloudflare</h1><p>Deploy the app to Workers.</p>' +
           '<h2 id="database-d1">Database (D1)</h2>' +
           '<p>Call <code>createD1Database</code> with the binding from wrangler.jsonc.</p>',
+      },
+    },
+    tutorials: {
+      overview: {
+        title: 'Tutorial overview',
+        html: '<h1 id="overview">Overview</h1><p>Build a blog with Guren, step by step.</p>',
       },
     },
   },
@@ -69,13 +78,7 @@ let service: DocSearchService
 
 beforeAll(() => {
   const client = new Database(':memory:')
-  const migrations = join(import.meta.dir, '../../db/migrations')
-  for (const entry of readdirSync(migrations, { withFileTypes: true })
-    .filter((dirent) => dirent.isDirectory())
-    .map((dirent) => dirent.name)
-    .sort()) {
-    client.exec(readFileSync(join(migrations, entry, 'migration.sql'), 'utf8'))
-  }
+  applyMigrations(client)
   client.exec(renderIndexSql(rows, buildId))
   const db = drizzle({ client })
   service = new DocSearchService(async () => db, build)
@@ -137,8 +140,18 @@ describe('DocSearchService', () => {
     }
   })
 
-  test('honours the result limit', async () => {
-    expect((await service.search('the', 'en', 1)).length).toBeLessThanOrEqual(1)
+  test('keeps two categories that share a slug and an anchor apart', async () => {
+    // `guides/overview` and `tutorials/overview` both exist in the real docs,
+    // and their h1 anchors are identical — a key without the category shows
+    // one of them and silently drops the other.
+    const results = await service.search('step by step', 'en')
+
+    expect(results.map((result) => result.category).sort()).toEqual(['guides', 'tutorials'])
+  })
+
+  test('returns as many distinct sections as the limit allows', async () => {
+    expect(await service.search('step by step', 'en', 1)).toHaveLength(1)
+    expect(await service.search('step by step', 'en', 2)).toHaveLength(2)
   })
 
   test('refuses to answer when the index was never built', async () => {


### PR DESCRIPTION
Stacked on #619 — review that one first; this PR's diff is the second commit.

Adds `GET /docs/search`, the read half of the index #619 builds. JSON rather than an Inertia page: a keystroke should cost a query, not a server-rendered React tree. The UI that calls it is a separate PR.

## Query path

The query goes through the same tokenizer the index was written with, so a bigram phrase lines up with what is stored. A one-character CJK query has no bigram and switches to the unigram column — and that switch also picks the bm25 weight vector.

The two vectors cannot be merged. Weighting the only matched column `0.0` does not merely flatten the ranking, it removes it: every row comes back with the same score and results arrive in rowid order. `tests/sqlite/search-index.test.ts` pins that against the engine.

The locale is scoped inside `MATCH` rather than filtered after it, so FTS5 never reads rows it is about to discard. Table names come from the generated module and everything else is bound, weights included, so `guren audit` stays green without a suppression.

## Snippets

Cut from the stored section body, not from FTS5's `snippet()` — the indexed columns hold bigrams, so that function would return 「コン ント トロ」rather than the sentence. Locating the hit uses the words the reader typed, since the body keeps its original casing while a token stream does not.

A section longer than the row cap is stored as several rows under one anchor; results collapse those to the best-ranked one, or a single long heading would fill the list.

## Failure modes

- **No index** → `503`, not an empty result list. A checkout that has not run the build carries a stub module, and presenting a broken deploy as "nothing matched" is the failure that goes unnoticed.
- **Bad input** → `422` through the route's query schema. `q` is capped at 64 characters; every term is ANDed, so a longer query narrows rather than widens, and the cap only bounds the work one request can ask of FTS5.
- **Anything else** → propagates to the framework handler unchanged.

## Rate limiting

Own key generator, deliberately. The framework default reads `server.requestIP()`, which only Bun provides — on Workers every visitor would fall into one shared bucket and the first burst would lock the endpoint for everyone. `CF-Connecting-IP` is set by the edge rather than by the caller.

The store is per-isolate memory with its sweep timer disabled: Workers disallows timers in global scope, and this module is evaluated there. Honest about the consequence — Workers runs many isolates, so the effective ceiling is higher than 60/min and varies. It stops a loop hammering the endpoint, which is what it is for.

## Verified over HTTP

Against the real index loaded into local SQLite: 「認証」, `d1 database`, and the one-character 「型」each return the expected sections with working `#anchor` URLs; a missing `q` and an unknown locale are `422`; the 61st request in a minute is `429` with `Retry-After`. `guren check` and `guren audit` are clean.
