### PR TITLE
feat(examples): add the docs search dialog to guren.dev

### DIFF
--- a/web/resources/js/components/DocSearch.tsx
+++ b/web/resources/js/components/DocSearch.tsx
@@ -47,6 +47,22 @@ type Display =
   | { kind: 'error' }
   | { kind: 'unavailable' }
 
+/** The line shown in place of a result list, for every state that has none. */
+function statusMessage(kind: Display['kind'], copy: (typeof COPY)[DocSearchLocale]): string {
+  switch (kind) {
+    case 'empty':
+      return copy.empty
+    case 'error':
+      return copy.error
+    case 'unavailable':
+      return copy.unavailable
+    case 'loading':
+      return '…'
+    default:
+      return copy.idle
+  }
+}
+
 /** A text field the reader is already typing in should keep the `/` key. */
 function isTypingTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
@@ -294,15 +310,7 @@ export function DocSearch({ locale, className = '' }: DocSearchProps) {
                 ))
               ) : (
                 <p className="px-4 py-8 text-center text-sm text-docs-text-muted">
-                  {display.kind === 'empty'
-                    ? copy.empty
-                    : display.kind === 'error'
-                      ? copy.error
-                      : display.kind === 'unavailable'
-                        ? copy.unavailable
-                        : display.kind === 'loading'
-                          ? '…'
-                          : copy.idle}
+                  {statusMessage(display.kind, copy)}
                 </p>
               )}
             </div>

--- a/web/resources/js/components/DocSearch.tsx
+++ b/web/resources/js/components/DocSearch.tsx
@@ -18,6 +18,7 @@ const COPY = {
     idle: 'Type to search the guides and tutorials.',
     empty: 'No matches.',
     error: 'Search is unavailable right now. Try again in a moment.',
+    throttled: 'Too many searches. Give it a moment.',
     unavailable: 'The search index has not been built for this deployment yet.',
     close: 'Close search',
     hint: 'to select',
@@ -30,6 +31,7 @@ const COPY = {
     idle: '入力するとガイドとチュートリアルを検索します。',
     empty: '一致するものがありません。',
     error: '検索を利用できません。しばらくしてからお試しください。',
+    throttled: '検索の回数が多すぎます。少し待ってからお試しください。',
     unavailable: 'このデプロイでは検索インデックスがまだ作られていません。',
     close: '検索を閉じる',
     hint: 'で移動',
@@ -45,6 +47,7 @@ type Display =
   | { kind: 'results'; hits: DocSearchHit[] }
   | { kind: 'empty' }
   | { kind: 'error' }
+  | { kind: 'throttled' }
   | { kind: 'unavailable' }
 
 /** The line shown in place of a result list, for every state that has none. */
@@ -56,12 +59,17 @@ function statusMessage(kind: Display['kind'], copy: (typeof COPY)[DocSearchLocal
       return copy.error
     case 'unavailable':
       return copy.unavailable
+    case 'throttled':
+      return copy.throttled
     case 'loading':
       return '…'
     default:
       return copy.idle
   }
 }
+
+/** Everything inside the dialog that Tab can reach, in document order. */
+const FOCUSABLE = 'a[href], button, input, select, [tabindex]:not([tabindex="-1"])'
 
 /** A text field the reader is already typing in should keep the `/` key. */
 function isTypingTarget(target: EventTarget | null): boolean {
@@ -93,6 +101,7 @@ export function DocSearch({ locale, className = '' }: DocSearchProps) {
   // rendering a guess would mismatch during hydration.
   const [isApple, setIsApple] = useState(false)
 
+  const dialogRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const optionRefs = useRef<Array<HTMLAnchorElement | null>>([])
@@ -115,11 +124,18 @@ export function DocSearch({ locale, className = '' }: DocSearchProps) {
     triggerRef.current?.focus()
   }, [search])
 
+  // Re-subscribed whenever the dialog opens or closes, so the shortcut can
+  // route through close() — which retires the queued search and returns focus
+  // — rather than flipping the flag and leaving both behind.
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
         event.preventDefault()
-        setOpen((wasOpen) => !wasOpen)
+        if (open) {
+          close()
+        } else {
+          setOpen(true)
+        }
         return
       }
       if (event.key === '/' && !isTypingTarget(event.target) && !event.metaKey && !event.ctrlKey) {
@@ -130,7 +146,7 @@ export function DocSearch({ locale, className = '' }: DocSearchProps) {
 
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
-  }, [])
+  }, [open, close])
 
   useEffect(() => {
     if (!open) {
@@ -165,6 +181,8 @@ export function DocSearch({ locale, className = '' }: DocSearchProps) {
     search.schedule(trimmed, searchLocale, (outcome: DocSearchOutcome) => {
       if (outcome.status === 'unavailable') {
         setDisplay({ kind: 'unavailable' })
+      } else if (outcome.status === 'throttled') {
+        setDisplay({ kind: 'throttled' })
       } else if (outcome.status === 'error') {
         setDisplay({ kind: 'error' })
       } else {
@@ -181,12 +199,30 @@ export function DocSearch({ locale, className = '' }: DocSearchProps) {
     optionRefs.current[selected]?.scrollIntoView({ block: 'nearest' })
   }, [selected])
 
-  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+  /**
+   * Escape and Tab belong to the dialog rather than to the input: `aria-modal`
+   * promises that the keyboard cannot leave, and Escape has to work from the
+   * close button and the locale select too.
+   */
+  const onDialogKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Escape') {
       event.preventDefault()
       close()
       return
     }
+    if (event.key !== 'Tab') {
+      return
+    }
+
+    const focusable = [...(dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? [])]
+    const edge = event.shiftKey ? focusable[0] : focusable.at(-1)
+    if (focusable.length > 0 && document.activeElement === edge) {
+      event.preventDefault()
+      ;(event.shiftKey ? focusable.at(-1) : focusable[0])?.focus()
+    }
+  }
+
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (hits.length === 0) {
       return
     }
@@ -229,9 +265,11 @@ export function DocSearch({ locale, className = '' }: DocSearchProps) {
           }}
         >
           <div
+            ref={dialogRef}
             role="dialog"
             aria-modal="true"
             aria-label={copy.dialogLabel}
+            onKeyDown={onDialogKeyDown}
             className="flex max-h-[70vh] w-full max-w-[640px] flex-col overflow-hidden rounded-xl border border-docs-border bg-docs-page shadow-2xl"
           >
             <div className="flex items-center gap-2 border-b border-docs-border px-4 py-3">
@@ -287,7 +325,19 @@ export function DocSearch({ locale, className = '' }: DocSearchProps) {
                     role="option"
                     aria-selected={index === selected}
                     href={result.url}
-                    onClick={() => setOpen(false)}
+                    onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
+                      setOpen(false)
+                      // A result inside the document already open is a
+                      // same-URL visit, which Inertia treats as a replacement:
+                      // it remounts the page, skips the navigate event, and
+                      // resets scroll afterwards — so the page's own fragment
+                      // effect cannot put the reader on the heading. Let the
+                      // browser do it instead.
+                      if (result.url.split('#')[0] === window.location.pathname) {
+                        event.preventDefault()
+                        window.location.hash = result.url.slice(result.url.indexOf('#') + 1)
+                      }
+                    }}
                     onMouseEnter={() => setSelected(index)}
                     className={`block border-b border-docs-border px-4 py-3 no-underline last:border-b-0 ${
                       index === selected ? 'bg-docs-accent-tint' : ''
@@ -309,7 +359,12 @@ export function DocSearch({ locale, className = '' }: DocSearchProps) {
                   </Link>
                 ))
               ) : (
-                <p className="px-4 py-8 text-center text-sm text-docs-text-muted">
+                <p
+                  // Announced when it changes: every one of these states
+                  // arrives after an await, with no other cue that it did.
+                  aria-live="polite"
+                  className="px-4 py-8 text-center text-sm text-docs-text-muted"
+                >
                   {statusMessage(display.kind, copy)}
                 </p>
               )}

--- a/web/resources/js/components/DocSearch.tsx
+++ b/web/resources/js/components/DocSearch.tsx
@@ -1,0 +1,320 @@
+import { Link } from '@inertiajs/react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import {
+  createDebouncedDocSearch,
+  MAX_QUERY_LENGTH,
+  type DocSearchHit,
+  type DocSearchLocale,
+  type DocSearchOutcome,
+} from '../lib/docs-search.js'
+import { SearchIcon, XIcon } from './icons.js'
+
+const COPY = {
+  en: {
+    trigger: 'Search docs',
+    placeholder: 'Search the documentation',
+    dialogLabel: 'Search the documentation',
+    idle: 'Type to search the guides and tutorials.',
+    empty: 'No matches.',
+    error: 'Search is unavailable right now. Try again in a moment.',
+    unavailable: 'The search index has not been built for this deployment yet.',
+    close: 'Close search',
+    hint: 'to select',
+    localeLabel: 'Search language',
+  },
+  ja: {
+    trigger: 'ドキュメントを検索',
+    placeholder: 'ドキュメントを検索',
+    dialogLabel: 'ドキュメントを検索',
+    idle: '入力するとガイドとチュートリアルを検索します。',
+    empty: '一致するものがありません。',
+    error: '検索を利用できません。しばらくしてからお試しください。',
+    unavailable: 'このデプロイでは検索インデックスがまだ作られていません。',
+    close: '検索を閉じる',
+    hint: 'で移動',
+    localeLabel: '検索する言語',
+  },
+} as const
+
+const LOCALE_LABELS: Record<DocSearchLocale, string> = { en: 'English', ja: '日本語' }
+
+type Display =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'results'; hits: DocSearchHit[] }
+  | { kind: 'empty' }
+  | { kind: 'error' }
+  | { kind: 'unavailable' }
+
+/** A text field the reader is already typing in should keep the `/` key. */
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+  return (
+    target.isContentEditable ||
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement
+  )
+}
+
+interface DocSearchProps {
+  /** The locale of the page this sits on; the reader can change it in the dialog. */
+  locale: DocSearchLocale
+  className?: string
+}
+
+export function DocSearch({ locale, className = '' }: DocSearchProps) {
+  const copy = COPY[locale]
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [searchLocale, setSearchLocale] = useState<DocSearchLocale>(locale)
+  const [display, setDisplay] = useState<Display>({ kind: 'idle' })
+  const [selected, setSelected] = useState(0)
+  // Resolved after mount: the server has no idea which keyboard this is, and
+  // rendering a guess would mismatch during hydration.
+  const [isApple, setIsApple] = useState(false)
+
+  const inputRef = useRef<HTMLInputElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const optionRefs = useRef<Array<HTMLAnchorElement | null>>([])
+
+  const search = useMemo(() => createDebouncedDocSearch(), [])
+
+  useEffect(() => {
+    setIsApple(/Mac|iPhone|iPad/u.test(navigator.platform || navigator.userAgent))
+  }, [])
+
+  // The dialog opens on the page's own language; a later page in the other
+  // language should open on that one.
+  useEffect(() => {
+    setSearchLocale(locale)
+  }, [locale])
+
+  const close = useCallback(() => {
+    setOpen(false)
+    search.cancel()
+    triggerRef.current?.focus()
+  }, [search])
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault()
+        setOpen((wasOpen) => !wasOpen)
+        return
+      }
+      if (event.key === '/' && !isTypingTarget(event.target) && !event.metaKey && !event.ctrlKey) {
+        event.preventDefault()
+        setOpen(true)
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [])
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    inputRef.current?.focus()
+    // Selected, not cleared: reopening keeps the last query visible so it can
+    // be refined, while typing still replaces it instead of appending.
+    inputRef.current?.select()
+    // The page behind the dialog must not scroll under it.
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = previousOverflow
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const trimmed = query.trim()
+    if (trimmed.length === 0) {
+      search.cancel()
+      setDisplay({ kind: 'idle' })
+      return
+    }
+
+    setDisplay({ kind: 'loading' })
+    setSelected(0)
+    search.schedule(trimmed, searchLocale, (outcome: DocSearchOutcome) => {
+      if (outcome.status === 'unavailable') {
+        setDisplay({ kind: 'unavailable' })
+      } else if (outcome.status === 'error') {
+        setDisplay({ kind: 'error' })
+      } else {
+        setDisplay(outcome.hits.length > 0 ? { kind: 'results', hits: outcome.hits } : { kind: 'empty' })
+      }
+    })
+  }, [open, query, searchLocale, search])
+
+  useEffect(() => () => search.cancel(), [search])
+
+  const hits = display.kind === 'results' ? display.hits : []
+
+  useEffect(() => {
+    optionRefs.current[selected]?.scrollIntoView({ block: 'nearest' })
+  }, [selected])
+
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      close()
+      return
+    }
+    if (hits.length === 0) {
+      return
+    }
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setSelected((index) => (index + 1) % hits.length)
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setSelected((index) => (index - 1 + hits.length) % hits.length)
+    } else if (event.key === 'Enter') {
+      event.preventDefault()
+      // Click the link rather than navigating by hand, so Enter and a mouse
+      // click take exactly the same path through Inertia.
+      optionRefs.current[selected]?.click()
+    }
+  }
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen(true)}
+        className={`flex w-full items-center gap-2 rounded-lg border border-docs-border bg-docs-panel px-3 py-2 text-left text-sm text-docs-text-muted transition hover:border-docs-border-strong hover:text-docs-text ${className}`}
+      >
+        <SearchIcon className="size-4 shrink-0" />
+        <span className="flex-1 truncate">{copy.trigger}</span>
+        <kbd className="docs-mono hidden shrink-0 rounded border border-docs-border px-1.5 py-0.5 text-[0.7rem] text-docs-text-muted sm:block">
+          {isApple ? '⌘K' : 'Ctrl K'}
+        </kbd>
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 p-4 pt-[10vh]"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) {
+              close()
+            }
+          }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={copy.dialogLabel}
+            className="flex max-h-[70vh] w-full max-w-[640px] flex-col overflow-hidden rounded-xl border border-docs-border bg-docs-page shadow-2xl"
+          >
+            <div className="flex items-center gap-2 border-b border-docs-border px-4 py-3">
+              <SearchIcon className="size-5 shrink-0 text-docs-text-muted" />
+              <input
+                ref={inputRef}
+                type="search"
+                value={query}
+                maxLength={MAX_QUERY_LENGTH}
+                onChange={(event) => setQuery(event.target.value)}
+                onKeyDown={onInputKeyDown}
+                placeholder={copy.placeholder}
+                aria-label={copy.placeholder}
+                aria-autocomplete="list"
+                aria-controls="docs-search-results"
+                aria-activedescendant={hits.length > 0 ? `docs-search-hit-${selected}` : undefined}
+                className="min-w-0 flex-1 bg-transparent text-base text-docs-text outline-none placeholder:text-docs-text-muted"
+              />
+              <label className="sr-only" htmlFor="docs-search-locale">
+                {copy.localeLabel}
+              </label>
+              <select
+                id="docs-search-locale"
+                value={searchLocale}
+                onChange={(event) => setSearchLocale(event.target.value as DocSearchLocale)}
+                className="docs-mono shrink-0 rounded border border-docs-border bg-docs-panel px-2 py-1 text-xs text-docs-text-secondary"
+              >
+                {(Object.keys(LOCALE_LABELS) as DocSearchLocale[]).map((code) => (
+                  <option key={code} value={code}>
+                    {LOCALE_LABELS[code]}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={close}
+                aria-label={copy.close}
+                className="shrink-0 rounded p-1 text-docs-text-muted transition hover:text-docs-text"
+              >
+                <XIcon className="size-4" />
+              </button>
+            </div>
+
+            <div id="docs-search-results" role="listbox" aria-label={copy.dialogLabel} className="overflow-y-auto">
+              {display.kind === 'results' ? (
+                hits.map((result, index) => (
+                  <Link
+                    key={`${result.slug}${result.anchor}`}
+                    ref={(node: HTMLAnchorElement | null) => {
+                      optionRefs.current[index] = node
+                    }}
+                    id={`docs-search-hit-${index}`}
+                    role="option"
+                    aria-selected={index === selected}
+                    href={result.url}
+                    onClick={() => setOpen(false)}
+                    onMouseEnter={() => setSelected(index)}
+                    className={`block border-b border-docs-border px-4 py-3 no-underline last:border-b-0 ${
+                      index === selected ? 'bg-docs-accent-tint' : ''
+                    }`}
+                  >
+                    <div className="flex items-baseline gap-2">
+                      <span className="truncate text-sm font-semibold text-docs-heading">
+                        {result.heading}
+                      </span>
+                      <span className="docs-mono shrink-0 text-[0.7rem] text-docs-text-muted">
+                        {result.docTitle}
+                      </span>
+                    </div>
+                    {result.snippet && (
+                      <p className="mt-1 line-clamp-2 text-[0.8rem] leading-relaxed text-docs-text-secondary">
+                        {result.snippet}
+                      </p>
+                    )}
+                  </Link>
+                ))
+              ) : (
+                <p className="px-4 py-8 text-center text-sm text-docs-text-muted">
+                  {display.kind === 'empty'
+                    ? copy.empty
+                    : display.kind === 'error'
+                      ? copy.error
+                      : display.kind === 'unavailable'
+                        ? copy.unavailable
+                        : display.kind === 'loading'
+                          ? '…'
+                          : copy.idle}
+                </p>
+              )}
+            </div>
+
+            <div className="flex items-center gap-3 border-t border-docs-border px-4 py-2 text-[0.7rem] text-docs-text-muted">
+              <span className="docs-mono">↑↓ ⏎</span>
+              <span>{copy.hint}</span>
+              <span className="docs-mono ml-auto">esc</span>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/web/resources/js/components/icons.tsx
+++ b/web/resources/js/components/icons.tsx
@@ -65,6 +65,14 @@ export function XIcon(props: IconProps) {
   )
 }
 
+export function SearchIcon(props: IconProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" {...props}>
+      <path fillRule="evenodd" d="M10.5 3.75a6.75 6.75 0 1 0 4.28 11.97l4.25 4.25a.75.75 0 1 0 1.06-1.06l-4.25-4.25A6.75 6.75 0 0 0 10.5 3.75Zm-5.25 6.75a5.25 5.25 0 1 1 10.5 0 5.25 5.25 0 0 1-10.5 0Z" clipRule="evenodd" />
+    </svg>
+  )
+}
+
 export function ChevronRightIcon(props: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" {...props}>

--- a/web/resources/js/lib/docs-search.ts
+++ b/web/resources/js/lib/docs-search.ts
@@ -49,6 +49,11 @@ export function createDocSearchRunner(options: RunnerOptions = {}): DocSearchRun
   let inFlight: AbortController | null = null
 
   const cancel = (): void => {
+    // The token moves too, not just the abort. Aborting a request whose
+    // response is already buffered does not necessarily reject it, so without
+    // this a cancelled search still resolves and delivers — repainting
+    // results under an input the reader has just cleared.
+    latest++
     inFlight?.abort()
     inFlight = null
   }
@@ -57,8 +62,10 @@ export function createDocSearchRunner(options: RunnerOptions = {}): DocSearchRun
     cancel,
 
     async run(query, locale) {
-      const token = ++latest
+      // Cancel first: it advances the token to retire the previous run, so
+      // this one has to claim its own afterwards.
       cancel()
+      const token = ++latest
 
       const controller = new AbortController()
       inFlight = controller
@@ -136,11 +143,10 @@ export function createDebouncedDocSearch(
   const delayMs = options.delayMs ?? SEARCH_DEBOUNCE_MS
   let timer: ReturnType<typeof setTimeout> | undefined
 
+  // clearTimeout ignores an undefined id, so neither call needs a guard.
   const cancel = (): void => {
-    if (timer !== undefined) {
-      clearTimeout(timer)
-      timer = undefined
-    }
+    clearTimeout(timer)
+    timer = undefined
     runner.cancel()
   }
 
@@ -148,9 +154,7 @@ export function createDebouncedDocSearch(
     cancel,
 
     schedule(query, locale, deliver) {
-      if (timer !== undefined) {
-        clearTimeout(timer)
-      }
+      clearTimeout(timer)
       timer = setTimeout(() => {
         timer = undefined
         void runner.run(query, locale).then((outcome) => {

--- a/web/resources/js/lib/docs-search.ts
+++ b/web/resources/js/lib/docs-search.ts
@@ -19,6 +19,7 @@ export interface DocSearchHit {
 export type DocSearchOutcome =
   | { status: 'ok'; hits: DocSearchHit[] }
   | { status: 'unavailable' }
+  | { status: 'throttled' }
   | { status: 'error' }
 
 export type DocSearchLocale = 'en' | 'ja'
@@ -98,6 +99,13 @@ export function createDocSearchRunner(options: RunnerOptions = {}): DocSearchRun
         return { status: 'unavailable' }
       }
 
+      // A debounce collapses a burst; it is not a rate bound, and sustained
+      // editing can still reach the endpoint's limit. Saying so beats the
+      // generic failure message, which invites the reader to keep typing.
+      if (response.status === 429) {
+        return { status: 'throttled' }
+      }
+
       if (!response.ok) {
         return { status: 'error' }
       }
@@ -118,7 +126,12 @@ export function createDocSearchRunner(options: RunnerOptions = {}): DocSearchRun
   }
 }
 
-/** Long enough that a burst of typing is one request, short enough to feel live. */
+/**
+ * Long enough that a burst of typing is one request, short enough to feel
+ * live. Note what it is not: every pause longer than this sends a request, so
+ * this bounds a burst and not a minute. The endpoint's own limit is what
+ * bounds the minute, and the UI has to say so when it is reached.
+ */
 export const SEARCH_DEBOUNCE_MS = 150
 
 export interface DebouncedDocSearch {
@@ -154,7 +167,11 @@ export function createDebouncedDocSearch(
     cancel,
 
     schedule(query, locale, deliver) {
-      clearTimeout(timer)
+      // Cancel rather than only clearing the timer: a request already in
+      // flight still held the current token, so for the 150 ms until the new
+      // one starts it could deliver its results into the new query's loading
+      // state — stale rows, clickable, under something else the reader typed.
+      cancel()
       timer = setTimeout(() => {
         timer = undefined
         void runner.run(query, locale).then((outcome) => {

--- a/web/resources/js/lib/docs-search.ts
+++ b/web/resources/js/lib/docs-search.ts
@@ -1,0 +1,164 @@
+// The request half of the docs search box, kept out of the component so the
+// one rule that matters here can be tested without a DOM.
+//
+// That rule: a search box issues a request per keystroke, and the responses do
+// not come back in the order they were sent. Without a guard, a slow request
+// for 「認」lands after a fast one for 「認証」and the reader watches their
+// results revert to a stale query as they type.
+
+export interface DocSearchHit {
+  category: string
+  slug: string
+  anchor: string
+  docTitle: string
+  heading: string
+  snippet: string
+  url: string
+}
+
+export type DocSearchOutcome =
+  | { status: 'ok'; hits: DocSearchHit[] }
+  | { status: 'unavailable' }
+  | { status: 'error' }
+
+export type DocSearchLocale = 'en' | 'ja'
+
+/** Matches the cap the route's query schema enforces; a longer one is a 422. */
+export const MAX_QUERY_LENGTH = 64
+
+export interface DocSearchRunner {
+  /**
+   * Resolves with the outcome for this query, or `null` when a newer call
+   * superseded it. A `null` must leave the display alone rather than clear it.
+   */
+  run(query: string, locale: DocSearchLocale): Promise<DocSearchOutcome | null>
+  /** Drop the in-flight request and stop its result from being delivered. */
+  cancel(): void
+}
+
+interface RunnerOptions {
+  fetch?: typeof globalThis.fetch
+  endpoint?: string
+}
+
+export function createDocSearchRunner(options: RunnerOptions = {}): DocSearchRunner {
+  const request = options.fetch ?? ((...args: Parameters<typeof fetch>) => fetch(...args))
+  const endpoint = options.endpoint ?? '/docs/search'
+
+  let latest = 0
+  let inFlight: AbortController | null = null
+
+  const cancel = (): void => {
+    inFlight?.abort()
+    inFlight = null
+  }
+
+  return {
+    cancel,
+
+    async run(query, locale) {
+      const token = ++latest
+      cancel()
+
+      const controller = new AbortController()
+      inFlight = controller
+
+      const url = `${endpoint}?q=${encodeURIComponent(query.slice(0, MAX_QUERY_LENGTH))}&locale=${locale}`
+
+      let response: Response
+      try {
+        response = await request(url, {
+          signal: controller.signal,
+          headers: { Accept: 'application/json' },
+        })
+      } catch {
+        // An abort is not a failure the reader should see — neither the one a
+        // newer keystroke causes nor the one closing the modal causes, and the
+        // second is why the signal is checked rather than only the token.
+        return controller.signal.aborted || token !== latest ? null : { status: 'error' }
+      }
+
+      // Aborting a request whose response is already buffered does not
+      // necessarily reject it, so a superseded call can arrive here intact.
+      // Checked before the status is read as well as after the body is: a
+      // stale 503 would otherwise paint "the index is not built" over a
+      // perfectly good current query.
+      if (token !== latest) {
+        return null
+      }
+
+      if (response.status === 503) {
+        return { status: 'unavailable' }
+      }
+
+      if (!response.ok) {
+        return { status: 'error' }
+      }
+
+      let payload: { results?: DocSearchHit[] }
+      try {
+        payload = (await response.json()) as { results?: DocSearchHit[] }
+      } catch {
+        return controller.signal.aborted || token !== latest ? null : { status: 'error' }
+      }
+
+      if (token !== latest) {
+        return null
+      }
+
+      return { status: 'ok', hits: payload.results ?? [] }
+    },
+  }
+}
+
+/** Long enough that a burst of typing is one request, short enough to feel live. */
+export const SEARCH_DEBOUNCE_MS = 150
+
+export interface DebouncedDocSearch {
+  /**
+   * Queue a search. Only the last query in a burst is sent, and only outcomes
+   * that were not superseded reach `deliver`.
+   */
+  schedule(query: string, locale: DocSearchLocale, deliver: (outcome: DocSearchOutcome) => void): void
+  /** Drop a queued search and any request already in flight. */
+  cancel(): void
+}
+
+/**
+ * Debouncing here rather than in the component so the property that matters
+ * can be tested: `/docs/search` is rate limited, and one request per keystroke
+ * would have the UI trip a limit meant for abuse.
+ */
+export function createDebouncedDocSearch(
+  options: { runner?: DocSearchRunner; delayMs?: number } = {},
+): DebouncedDocSearch {
+  const runner = options.runner ?? createDocSearchRunner()
+  const delayMs = options.delayMs ?? SEARCH_DEBOUNCE_MS
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  const cancel = (): void => {
+    if (timer !== undefined) {
+      clearTimeout(timer)
+      timer = undefined
+    }
+    runner.cancel()
+  }
+
+  return {
+    cancel,
+
+    schedule(query, locale, deliver) {
+      if (timer !== undefined) {
+        clearTimeout(timer)
+      }
+      timer = setTimeout(() => {
+        timer = undefined
+        void runner.run(query, locale).then((outcome) => {
+          if (outcome !== null) {
+            deliver(outcome)
+          }
+        })
+      }, delayMs)
+    },
+  }
+}

--- a/web/resources/js/pages/Docs/Index.tsx
+++ b/web/resources/js/pages/Docs/Index.tsx
@@ -32,6 +32,7 @@ interface Props {
   basePath: string
 }
 import { SITE_DESCRIPTION, pageTitle } from '../../../../config/site.js'
+import { DocSearch } from '../../components/DocSearch.js'
 import { Footer } from '../../components/Footer.js'
 import { Header } from '../../components/Header.js'
 import { Seo } from '../../components/Seo.js'
@@ -86,6 +87,7 @@ export default function DocsIndex({ categories, locale, locales = [], basePath }
             <p className="max-w-[640px] text-xl leading-relaxed text-docs-text-secondary">
               {copy.lead}
             </p>
+            <DocSearch locale={locale} className="mt-8 max-w-[420px]" />
           </header>
 
           <div className="grid gap-16">

--- a/web/resources/js/pages/Docs/Show.tsx
+++ b/web/resources/js/pages/Docs/Show.tsx
@@ -1,6 +1,7 @@
-import { Head, Link } from '@inertiajs/react'
+import { Head, Link, router } from '@inertiajs/react'
 import { useEffect, useMemo, useState } from 'react'
 import { SITE_DESCRIPTION, pageTitle } from '../../../../config/site.js'
+import { DocSearch } from '../../components/DocSearch.js'
 import { Footer } from '../../components/Footer.js'
 import { Header } from '../../components/Header.js'
 import { Seo } from '../../components/Seo.js'
@@ -221,6 +222,45 @@ export default function DocsShow({ categories, doc, active, locale, locales = []
     setSidebarOpen(false)
   }, [active?.category, active?.slug])
 
+  // A browser scrolls to the fragment on a full page load; Inertia does not
+  // after a client-side visit, so a search result deep-linking to a heading
+  // would land at the top of the page instead. Keyed on the router event
+  // rather than on the doc, because two results in the same document differ
+  // only by their fragment.
+  useEffect(() => {
+    let pending: ReturnType<typeof setTimeout> | undefined
+
+    const scrollToFragment = () => {
+      const id = decodeURIComponent(window.location.hash.slice(1))
+      if (!id) return
+
+      // Inertia announces the navigation before React has necessarily
+      // committed the new document, so the heading may not exist yet. Retried
+      // on the macrotask queue rather than on an animation frame: a tab that
+      // is not visible never runs one, and a docs link opened in a background
+      // tab should still be at its heading when the reader gets there.
+      let attempts = 0
+      const attempt = () => {
+        const target = document.getElementById(id)
+        if (target) {
+          target.scrollIntoView({ block: 'start' })
+          return
+        }
+        if (attempts++ < 10) {
+          pending = setTimeout(attempt, 16)
+        }
+      }
+      attempt()
+    }
+
+    scrollToFragment()
+    const stop = router.on('navigate', scrollToFragment)
+    return () => {
+      clearTimeout(pending)
+      stop()
+    }
+  }, [])
+
   // Mermaid diagrams: the build-time renderer leaves ```mermaid fences as
   // <pre class="mermaid"> (shiki has no grammar for them), and the library
   // is loaded here — lazily, client-only, and only on pages that have one.
@@ -375,6 +415,7 @@ export default function DocsShow({ categories, doc, active, locale, locales = []
       <main className={`docs-layout ${toc.items.length > 0 ? 'docs-layout--toc' : ''}`}>
         {/* Sidebar */}
         <aside className="docs-sidebar">
+          <DocSearch locale={locale} className="mb-6" />
           <button
             type="button"
             onClick={() => setSidebarOpen((open) => !open)}

--- a/web/resources/js/pages/Docs/Show.tsx
+++ b/web/resources/js/pages/Docs/Show.tsx
@@ -111,6 +111,19 @@ function loadMermaid(): Promise<MermaidApi> {
   return mermaidLoader
 }
 
+/**
+ * A hash is whatever is in the address bar, not necessarily something this
+ * page wrote: `#%` makes decodeURIComponent throw, and an exception here
+ * would take the whole effect — and with it the router subscription — down.
+ */
+function decodeFragment(hash: string): string {
+  try {
+    return decodeURIComponent(hash)
+  } catch {
+    return hash
+  }
+}
+
 interface TocItem {
   id: string
   text: string
@@ -231,7 +244,7 @@ export default function DocsShow({ categories, doc, active, locale, locales = []
     let pending: ReturnType<typeof setTimeout> | undefined
 
     const scrollToFragment = () => {
-      const id = decodeURIComponent(window.location.hash.slice(1))
+      const id = decodeFragment(window.location.hash.slice(1))
       if (!id) return
 
       // Inertia announces the navigation before React has necessarily

--- a/web/tests/lib/docs-search.test.ts
+++ b/web/tests/lib/docs-search.test.ts
@@ -108,6 +108,20 @@ describe('createDocSearchRunner', () => {
     expect(await pending).toBeNull()
   })
 
+  it('discards a cancelled response the abort did not reject', async () => {
+    // Clearing the input cancels without starting a newer search. If the
+    // response was already buffered the abort does not reject it, and the
+    // results would repaint under an input the reader has just emptied.
+    const deferred = deferredFetch({ ignoreAbort: true })
+    const runner = createDocSearchRunner({ fetch: deferred.fetch })
+
+    const pending = runner.run('routing', 'en')
+    runner.cancel()
+    deferred.releases[0](jsonResponse([hit('routing')]))
+
+    expect(await pending).toBeNull()
+  })
+
   it('distinguishes an unbuilt index from a failure', async () => {
     const deferred = deferredFetch()
     const runner = createDocSearchRunner({ fetch: deferred.fetch })

--- a/web/tests/lib/docs-search.test.ts
+++ b/web/tests/lib/docs-search.test.ts
@@ -188,6 +188,18 @@ describe('createDocSearchRunner', () => {
     expect(await fresh).toEqual({ status: 'ok', hits: [hit('routing')] })
   })
 
+  it('distinguishes being rate limited from a failure', async () => {
+    // The reader is told to wait rather than to try again, which is what the
+    // generic failure message invites.
+    const deferred = deferredFetch()
+    const runner = createDocSearchRunner({ fetch: deferred.fetch })
+
+    const pending = runner.run('routing', 'en')
+    deferred.releases[0](new Response('{}', { status: 429 }))
+
+    expect(await pending).toEqual({ status: 'throttled' })
+  })
+
   it('reports a server failure', async () => {
     const deferred = deferredFetch()
     const runner = createDocSearchRunner({ fetch: deferred.fetch })
@@ -275,6 +287,23 @@ describe('createDebouncedDocSearch', () => {
     await vi.advanceTimersByTimeAsync(200)
 
     expect(deliver).not.toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
+  it('retires a running request when a newer query is scheduled', async () => {
+    // Only the timer used to be cleared, so for the debounce interval the
+    // in-flight request still held the current token — long enough to deliver
+    // its rows into the loading state of a query the reader had moved on from.
+    vi.useFakeTimers()
+    const spy = runnerSpy()
+    const search = createDebouncedDocSearch({ runner: spy.runner, delayMs: 150 })
+
+    search.schedule('old', 'en', () => {})
+    await vi.advanceTimersByTimeAsync(200)
+    expect(spy.run).toHaveBeenCalledTimes(1)
+
+    search.schedule('new', 'en', () => {})
+    expect(spy.cancel).toHaveBeenCalled()
     vi.useRealTimers()
   })
 

--- a/web/tests/lib/docs-search.test.ts
+++ b/web/tests/lib/docs-search.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createDebouncedDocSearch,
+  createDocSearchRunner,
+  MAX_QUERY_LENGTH,
+  type DocSearchHit,
+  type DocSearchOutcome,
+} from '../../resources/js/lib/docs-search.js'
+
+function hit(slug: string): DocSearchHit {
+  return {
+    category: 'guides',
+    slug,
+    anchor: 'a',
+    docTitle: slug,
+    heading: 'Heading',
+    snippet: 'Snippet',
+    url: `/docs/guides/${slug}`,
+  }
+}
+
+function jsonResponse(hits: DocSearchHit[], status = 200): Response {
+  return new Response(JSON.stringify({ results: hits }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+/**
+ * A fetch whose responses are released by hand, so a test can make the first
+ * request resolve *after* the second — the ordering the network actually
+ * produces and the reason this module exists.
+ */
+function deferredFetch(options: { ignoreAbort?: boolean } = {}) {
+  const releases: Array<(response: Response) => void> = []
+  const urls: string[] = []
+
+  const fetchMock = vi.fn((url: string | URL | Request, init?: RequestInit) => {
+    urls.push(String(url))
+    return new Promise<Response>((resolve, reject) => {
+      releases.push(resolve)
+      // `ignoreAbort` models a response that was already buffered when the
+      // abort landed: aborting does not reject it, so a superseded call
+      // arrives intact and only the token comparison can discard it.
+      if (!options.ignoreAbort) {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'))
+        })
+      }
+    })
+  })
+
+  return { fetch: fetchMock as unknown as typeof globalThis.fetch, releases, urls, calls: fetchMock }
+}
+
+describe('createDocSearchRunner', () => {
+  it('sends the query and locale to the search endpoint', async () => {
+    const deferred = deferredFetch()
+    const runner = createDocSearchRunner({ fetch: deferred.fetch })
+
+    const pending = runner.run('コントローラー', 'ja')
+    deferred.releases[0](jsonResponse([hit('controllers')]))
+
+    expect(await pending).toEqual({ status: 'ok', hits: [hit('controllers')] })
+    expect(deferred.urls[0]).toBe(
+      `/docs/search?q=${encodeURIComponent('コントローラー')}&locale=ja`,
+    )
+  })
+
+  it('discards a response that arrives after a newer query', async () => {
+    // The failure this guards: 「認」is slow, 「認証」is fast, and without the
+    // check the reader watches their results revert as they type.
+    const deferred = deferredFetch()
+    const runner = createDocSearchRunner({ fetch: deferred.fetch })
+
+    const stale = runner.run('認', 'ja')
+    const fresh = runner.run('認証', 'ja')
+
+    deferred.releases[1](jsonResponse([hit('authentication')]))
+    deferred.releases[0](jsonResponse([hit('stale')]))
+
+    expect(await fresh).toEqual({ status: 'ok', hits: [hit('authentication')] })
+    expect(await stale).toBeNull()
+  })
+
+  it('reports a superseded request as nothing rather than as a failure', async () => {
+    // Superseding aborts the previous fetch, so it rejects. Surfacing that as
+    // an error would flash a failure message on every keystroke.
+    const deferred = deferredFetch()
+    const runner = createDocSearchRunner({ fetch: deferred.fetch })
+
+    const stale = runner.run('rou', 'en')
+    const fresh = runner.run('routing', 'en')
+    deferred.releases[1](jsonResponse([hit('routing')]))
+
+    expect(await stale).toBeNull()
+    expect(await fresh).toMatchObject({ status: 'ok' })
+  })
+
+  it('reports an explicit cancel as nothing rather than as a failure', async () => {
+    const deferred = deferredFetch()
+    const runner = createDocSearchRunner({ fetch: deferred.fetch })
+
+    const pending = runner.run('routing', 'en')
+    runner.cancel()
+
+    expect(await pending).toBeNull()
+  })
+
+  it('distinguishes an unbuilt index from a failure', async () => {
+    const deferred = deferredFetch()
+    const runner = createDocSearchRunner({ fetch: deferred.fetch })
+
+    const pending = runner.run('routing', 'en')
+    deferred.releases[0](new Response('{}', { status: 503 }))
+
+    expect(await pending).toEqual({ status: 'unavailable' })
+  })
+
+  it('discards a superseded response the abort did not reject', async () => {
+    const deferred = deferredFetch({ ignoreAbort: true })
+    const runner = createDocSearchRunner({ fetch: deferred.fetch })
+
+    const stale = runner.run('rou', 'en')
+    const fresh = runner.run('routing', 'en')
+
+    deferred.releases[1](jsonResponse([hit('routing')]))
+    deferred.releases[0](jsonResponse([hit('stale')]))
+
+    expect(await stale).toBeNull()
+    expect(await fresh).toEqual({ status: 'ok', hits: [hit('routing')] })
+  })
+
+  it('does not let a superseded failure paint over the current query', async () => {
+    // A stale 503 reaching the display would tell the reader the index is not
+    // built while their actual query is answering fine.
+    const deferred = deferredFetch({ ignoreAbort: true })
+    const runner = createDocSearchRunner({ fetch: deferred.fetch })
+
+    const stale = runner.run('rou', 'en')
+    const fresh = runner.run('routing', 'en')
+
+    deferred.releases[1](jsonResponse([hit('routing')]))
+    deferred.releases[0](new Response('{}', { status: 503 }))
+
+    expect(await stale).toBeNull()
+    expect(await fresh).toMatchObject({ status: 'ok' })
+  })
+
+  it('discards a response superseded while its body was being read', async () => {
+    // The narrow window the second comparison covers: the status was current
+    // when it was checked, and the reader typed again while json() ran.
+    let resolveBody: (value: unknown) => void = () => {}
+    const body = new Promise((resolve) => {
+      resolveBody = resolve
+    })
+    const deferred = deferredFetch({ ignoreAbort: true })
+    const runner = createDocSearchRunner({ fetch: deferred.fetch })
+
+    const stale = runner.run('rou', 'en')
+    deferred.releases[0]({
+      ok: true,
+      status: 200,
+      json: () => body,
+    } as unknown as Response)
+    await Promise.resolve()
+
+    const fresh = runner.run('routing', 'en')
+    resolveBody({ results: [hit('stale')] })
+    deferred.releases[1](jsonResponse([hit('routing')]))
+
+    expect(await stale).toBeNull()
+    expect(await fresh).toEqual({ status: 'ok', hits: [hit('routing')] })
+  })
+
+  it('reports a server failure', async () => {
+    const deferred = deferredFetch()
+    const runner = createDocSearchRunner({ fetch: deferred.fetch })
+
+    const pending = runner.run('routing', 'en')
+    deferred.releases[0](new Response('{}', { status: 500 }))
+
+    expect(await pending).toEqual({ status: 'error' })
+  })
+
+  it('reports a network failure', async () => {
+    const runner = createDocSearchRunner({
+      fetch: (() => Promise.reject(new TypeError('offline'))) as unknown as typeof globalThis.fetch,
+    })
+
+    expect(await runner.run('routing', 'en')).toEqual({ status: 'error' })
+  })
+
+  it('truncates rather than sending a query the route would reject', async () => {
+    const deferred = deferredFetch()
+    const runner = createDocSearchRunner({ fetch: deferred.fetch })
+
+    void runner.run('a'.repeat(MAX_QUERY_LENGTH + 20), 'en')
+
+    expect(deferred.urls[0]).toBe(`/docs/search?q=${'a'.repeat(MAX_QUERY_LENGTH)}&locale=en`)
+  })
+
+  it('treats a response with no results array as empty', async () => {
+    const deferred = deferredFetch()
+    const runner = createDocSearchRunner({ fetch: deferred.fetch })
+
+    const pending = runner.run('routing', 'en')
+    deferred.releases[0](new Response('{}', { status: 200 }))
+
+    expect(await pending).toEqual({ status: 'ok', hits: [] })
+  })
+})
+
+describe('createDebouncedDocSearch', () => {
+  function runnerSpy(outcome: DocSearchOutcome = { status: 'ok', hits: [] }) {
+    const run = vi.fn(async () => outcome)
+    const cancel = vi.fn()
+    return { runner: { run, cancel }, run, cancel }
+  }
+
+  it('collapses a burst of typing into one request', async () => {
+    // `/docs/search` is rate limited; one request per keystroke would have the
+    // UI trip a limit that exists to stop abuse.
+    vi.useFakeTimers()
+    const spy = runnerSpy()
+    const search = createDebouncedDocSearch({ runner: spy.runner, delayMs: 150 })
+
+    for (const query of ['r', 'ro', 'rou', 'rout', 'routing']) {
+      search.schedule(query, 'en', () => {})
+    }
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(spy.run).toHaveBeenCalledTimes(1)
+    expect(spy.run).toHaveBeenCalledWith('routing', 'en')
+    vi.useRealTimers()
+  })
+
+  it('delivers the outcome once the delay elapses', async () => {
+    vi.useFakeTimers()
+    const spy = runnerSpy({ status: 'ok', hits: [hit('routing')] })
+    const search = createDebouncedDocSearch({ runner: spy.runner, delayMs: 150 })
+    const deliver = vi.fn()
+
+    search.schedule('routing', 'en', deliver)
+    expect(deliver).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(200)
+    expect(deliver).toHaveBeenCalledWith({ status: 'ok', hits: [hit('routing')] })
+    vi.useRealTimers()
+  })
+
+  it('never delivers a superseded outcome', async () => {
+    vi.useFakeTimers()
+    const spy = runnerSpy()
+    spy.run.mockResolvedValue(null as unknown as DocSearchOutcome)
+    const search = createDebouncedDocSearch({ runner: spy.runner, delayMs: 150 })
+    const deliver = vi.fn()
+
+    search.schedule('routing', 'en', deliver)
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(deliver).not.toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
+  it('cancels a queued search and the request behind it', async () => {
+    vi.useFakeTimers()
+    const spy = runnerSpy()
+    const search = createDebouncedDocSearch({ runner: spy.runner, delayMs: 150 })
+
+    search.schedule('routing', 'en', () => {})
+    search.cancel()
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(spy.run).not.toHaveBeenCalled()
+    expect(spy.cancel).toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
Stacked on #620 — review that one first; this PR's diff is the third commit.

The reader-facing half of docs search: a ⌘K / Ctrl+K / `/` dialog in the docs sidebar and under the docs index hero, calling the endpoint #620 added.

## Why the request logic is not in the component

The rule that matters here is not a rendering one. A search box issues a request per keystroke and the responses do not come back in the order they were sent: a slow 「認」lands after a fast 「認証」 and the reader watches their results revert as they type. `resources/js/lib/docs-search.ts` owns that, and the ordering guarantee is unit-tested with a fetch whose two calls resolve out of order — which is not something a component test could express without pulling jsdom and Testing Library into `web`.

Both token comparisons in there are load bearing, and each has a test that fails without it:

- Aborting a request whose response is already buffered does not necessarily reject it, so a superseded call can arrive intact. A stale `503` reaching the display would tell the reader the index is not built while their actual query answers fine.
- The second covers the window where the status was current when checked and the reader typed again while `json()` ran.

An abort — from a newer keystroke or from closing the dialog — is never surfaced as an error, or the modal would flash a failure on every keystroke.

Debouncing sits in the same module for the same reason: `/docs/search` is rate limited at 60/min, and one request per keystroke would have the UI trip a limit that exists to stop abuse. The test asserts a five-keystroke burst is one request.

## A bug this surfaced

Inertia does not scroll to a fragment after a client-side visit the way a browser does on a full page load, so **every search result landed at the top of its page**. `Docs/Show` now scrolls to the heading on the router's `navigate` event.

It retries on the macrotask queue rather than on an animation frame, for two reasons: React has not necessarily committed the new document when Inertia announces the navigation, and a tab that is not visible never runs a frame at all — a docs link opened in a background tab should still be at its heading when the reader gets there.

## Details

- Enter activates the selected result by clicking its link, so the keyboard and the mouse take exactly the same path through Inertia.
- Reopening keeps the last query and selects it, so it can be refined but typing still replaces it.
- Sections with no body of their own — 8% of them, a heading sitting directly above a subheading — render without an empty snippet line.
- The ⌘ / Ctrl label resolves after mount; rendering a guess would mismatch during hydration.
- Locale defaults to the page's own and is switchable in the dialog.

## Verified in a browser against the real index

Both locales, both themes, keyboard and pointer selection, deep links landing on their heading, and outside-click and Escape closing the dialog and returning focus to the trigger. The empty and idle states were checked directly; the `unavailable` state is unit-tested only, since a local checkout with the index loaded cannot produce a 503.
