### PR TITLE
fix(examples): correct password verify argument order in API login

### DIFF
--- a/examples/api/app/Http/Controllers/AuthController.ts
+++ b/examples/api/app/Http/Controllers/AuthController.ts
@@ -38,7 +38,7 @@ export default class AuthController extends Controller {
     const { email, password } = await this.validateBody(LoginSchema)
     const user = await User.first({ email })
 
-    if (!user || !(await new ScryptHasher().verify(password, user.passwordHash))) {
+    if (!user || !(await new ScryptHasher().verify(user.passwordHash, password))) {
       return this.json({ error: 'Invalid credentials' }, { status: 401 })
     }
 

--- a/examples/api/tests/auth.test.ts
+++ b/examples/api/tests/auth.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { describe, expect, it, vi, beforeAll, beforeEach } from 'vitest'
 import {
   createControllerContext,
   createControllerModuleMock,
 } from '@guren/testing/controller'
-import type { Context } from '@guren/core'
+import { NodeHasher, type Context } from '@guren/core'
 
 // Mock dependencies
 vi.mock('@guren/core', async () => {
@@ -12,14 +12,12 @@ vi.mock('@guren/core', async () => {
     ...actual,
     ...createControllerModuleMock(),
     ServiceProvider: actual.ServiceProvider,
-    ScryptHasher: class {
-      async hash(password: string) {
-        return `hashed_${password}`
-      }
-      async verify(password: string, hash: string) {
-        return hash === `hashed_${password}`
-      }
-    },
+    // The real Bun-backed hasher cannot run here (vitest runs on Node), so
+    // stand in the Node implementation of the same `PasswordHasher` interface
+    // rather than a hand-rolled fake: a fake's argument order can drift from
+    // `verify(hashed, plain)` without any type error, which is what let a
+    // swapped call site in the controller ship green.
+    ScryptHasher: actual.NodeHasher,
   }
 })
 
@@ -48,14 +46,24 @@ function createController(ctx: Context): AuthController {
   return controller
 }
 
+const hasher = new NodeHasher()
+
 describe('AuthController', () => {
+  let passwordHash: string
+  let correctPasswordHash: string
+
+  beforeAll(async () => {
+    passwordHash = await hasher.hash('password123')
+    correctPasswordHash = await hasher.hash('correctpassword')
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   describe('register()', () => {
     it('creates a new user and returns token', async () => {
-      const newUser = { id: 1, name: 'Test User', email: 'test@example.com', passwordHash: 'hashed_password123', createdAt: new Date() }
+      const newUser = { id: 1, name: 'Test User', email: 'test@example.com', passwordHash, createdAt: new Date() }
       mockUserFirst.mockResolvedValue(null) // No existing user
       mockUserCreate.mockResolvedValue(newUser)
 
@@ -127,7 +135,7 @@ describe('AuthController', () => {
 
   describe('login()', () => {
     it('returns token for valid credentials', async () => {
-      const user = { id: 1, name: 'Test', email: 'test@example.com', passwordHash: 'hashed_password123', createdAt: new Date() }
+      const user = { id: 1, name: 'Test', email: 'test@example.com', passwordHash, createdAt: new Date() }
       mockUserFirst.mockResolvedValue(user)
 
       const ctx = createControllerContext('http://api.test/api/auth/login', {
@@ -173,7 +181,7 @@ describe('AuthController', () => {
     })
 
     it('returns 401 for wrong password', async () => {
-      const user = { id: 1, name: 'Test', email: 'test@example.com', passwordHash: 'hashed_correctpassword', createdAt: new Date() }
+      const user = { id: 1, name: 'Test', email: 'test@example.com', passwordHash: correctPasswordHash, createdAt: new Date() }
       mockUserFirst.mockResolvedValue(user)
 
       const ctx = createControllerContext('http://api.test/api/auth/login', {
@@ -191,6 +199,60 @@ describe('AuthController', () => {
       const response = await controller.login()
 
       expect(response.status).toBe(401)
+    })
+  })
+
+  describe('register() then login()', () => {
+    it('accepts the registered password against the stored hash', async () => {
+      // `AuthenticatableModel` hashes the plain password on create; `User` is
+      // mocked here, so do that step ourselves with the same hasher.
+      const created: Record<string, unknown> = {}
+      mockUserCreate.mockImplementation(async (data: { name: string; email: string; password: string }) => {
+        Object.assign(created, {
+          id: 1,
+          name: data.name,
+          email: data.email,
+          passwordHash: await hasher.hash(data.password),
+          createdAt: new Date(),
+        })
+        return created
+      })
+      mockUserFirst.mockResolvedValueOnce(null) // no existing user at register time
+
+      const registerCtx = createControllerContext('http://api.test/api/auth/register', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'Round Trip',
+          email: 'roundtrip@example.com',
+          password: 'password123',
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      }, {
+        events: { emit: mockEmit },
+      }) as unknown as Context
+
+      const registerResponse = await createController(registerCtx).register()
+      expect(registerResponse.status).toBe(201)
+
+      mockUserFirst.mockResolvedValue(created)
+
+      const loginCtx = createControllerContext('http://api.test/api/auth/login', {
+        method: 'POST',
+        body: JSON.stringify({
+          email: 'roundtrip@example.com',
+          password: 'password123',
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      }, {
+        events: { emit: mockEmit },
+      }) as unknown as Context
+
+      const loginResponse = await createController(loginCtx).login()
+
+      expect(loginResponse.status).toBe(200)
+      const json = await loginResponse.json()
+      expect(json.token).toBeDefined()
+      expect(json.user.email).toBe('roundtrip@example.com')
     })
   })
 


### PR DESCRIPTION
## Summary

`POST /api/auth/login` in the API example returned 500 for every valid credential pair.

`PasswordHasher.verify(hashed, plain)` is the inverse of the `Bun.password.verify(plain, hashed)` that `ScryptHasher` delegates to, and `AuthController.login()` passed its arguments in the wrong order. Bun then tried to parse the plaintext password as a hash and threw `PASSWORD_UNSUPPORTED_ALGORITHM`. Reproduce on a fresh DB: `POST /api/auth/register` succeeds, `POST /api/auth/login` with the same credentials 500s.

The existing unit test never caught it because the hand-rolled `ScryptHasher` mock carried the same swap. Argument *names* do not participate in structural typing, so a fake can disagree with the interface it stands in for and stay green forever.

Changes:

- `AuthController.login()` now calls `verify(user.passwordHash, password)`.
- The test's fake hasher is replaced with `NodeHasher`, the real Node implementation of the same `PasswordHasher` interface. It cannot drift from the interface because it *is* one, and it runs where the Bun-backed `ScryptHasher` cannot (vitest runs on Node, `Bun` is undefined).
- Added a `register()` → `login()` test that goes through the controller over a real scrypt hash. The pre-existing round-trip tests in `packages/server/tests/auth/` were green throughout this bug because the defect lives at the call site, not in the hasher.

## Scope

`examples` (`examples/api` only). No framework package is touched, and the example is `private: true`, so no changeset.

## Risk Assessment

None for published packages. Behavior change is confined to the API example, where login goes from always-500 to working.

Out of scope, filed as follow-ups: `PasswordHasher.verify(hashed, plain)` takes two same-typed strings in an order the type system cannot police, which is what made this shippable in the first place (a named-object parameter or a branded hash type would close it); and `ScryptHasher` is a misnomer since it defaults to argon2id via `Bun.password`. Both are public-API changes on `@guren/server` / `@guren/core`.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck` — exit 0 (needed `bun run build` plus `codegen` in `examples/blog` first; unrelated fresh-worktree state)
- [ ] `bun run test` — `bun run test:examples` passes (blog + api + web, 123 tests in web, 43 in `examples/api`). `bun run test:bun` is **not** green here: it dies with exit 137 (SIGKILL) on `@guren/cli` before reporting, on this machine, both in the full run and when narrowed. That path covers `packages/*` only and cannot be reached by this change; leaving it to CI.

Mutation check on the new coverage: restoring the swapped argument order turns 3 tests red, throwing the same error class as production (`Invalid password hash format.` from `verifyPassword`, matching Bun's `PASSWORD_UNSUPPORTED_ALGORITHM`). Reverted afterwards.

Verification depth: controller-level, with the `User` model mocked. The model's own hash step (`AuthenticatableModel.preparePersistencePayload` → `hasher.hash(plain)`) is simulated in the test with the same hasher rather than exercised. The live-HTTP-against-a-real-DB reproduction was not re-run.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation — no doc references the swapped order (grepped `docs/`, `contributing/`, `rfcs/`, `web/`, `packages/*/README.md`, and all templates; the only other swapped call site was the test mock).
