### PR TITLE
fix(server): report only server failures as unhandled exceptions

### DIFF
--- a/.changeset/exception-fallback-server-errors-only.md
+++ b/.changeset/exception-fallback-server-errors-only.md
@@ -1,0 +1,11 @@
+---
+'@guren/server': patch
+---
+
+Stop reporting handled client errors as `Unhandled exception:`.
+
+`ExceptionHandler.reportException()` falls back to `console.error('Unhandled exception:', error)` when an app registers no reporter, so that a hosted runtime — where stdout is the only channel back to the operator — does not turn a 500 into a rendered page and nothing else. That fallback fired for *every* exception reaching the handler, including the 4xx an application throws on purpose: a `ValidationException` from `validateBody()`, an `AuthorizationException` from an authorization middleware, an `HttpException.notFound()`. A route rejecting invalid input as designed printed a full stack trace per request, labelled as though nothing had handled it.
+
+The label was the misleading part. Nothing escapes: the exception is caught by the handler's own middleware, `reportException()` is awaited inside `handle()`, and the correct 4xx is returned. Confirmed on Node 22 under `--unhandled-rejections=strict` against the built `dist` — no `unhandledRejection`, no `uncaughtException`, exit 0 — so this was never a crash risk on `@guren/plugin-lambda` or `@guren/plugin-vercel`, only noise loud enough to read as one.
+
+The gate is on the console fallback alone, **not** on `shouldNotReport()`: a registered reporter still receives 4xx, because an app tracking auth failures or validation churn through one is asking for exactly those. The status it reads comes from a single `resolveExceptionStatus()`, which `renderDefaultException` now also takes its status from rather than from `toResponse()` — what an exception is delivered as and whether it counts as a server failure must be the same number, or an exception could be sent as a 422 and reported as a crash. An error carrying no status is still a 500, so a bare `throw new Error(...)` logs exactly as before.

--- a/packages/server/src/errors/ExceptionHandler.ts
+++ b/packages/server/src/errors/ExceptionHandler.ts
@@ -129,7 +129,15 @@ export class ExceptionHandler {
     // rendered page and nothing else — on a hosted runtime, where stdout is
     // the only channel back to the operator, that leaves the failure
     // undiagnosable. Anything registering a reporter owns the reporting.
-    if (this.reporters.length === 0) {
+    //
+    // Server failures only. A 4xx is already delivered to the caller in full —
+    // a `ValidationException`'s field errors are the response body — so
+    // logging it adds nothing an operator can act on, while a route that
+    // rejects invalid input as designed prints a stack trace per request.
+    // This gate is deliberately *not* `shouldNotReport()`: a registered
+    // reporter still receives 4xx, because an app tracking auth failures or
+    // validation churn through one is asking for exactly those.
+    if (this.reporters.length === 0 && resolveExceptionStatus(error) >= 500) {
       console.error('Unhandled exception:', error)
     }
 
@@ -183,22 +191,20 @@ export class ExceptionHandler {
    */
   protected renderDefaultException(error: Error, ctx: Context): Response {
     const debug = this.shouldShowDetails()
+    // Resolved before the branch, so the status this renders with is the same
+    // number `reportException` judged it by. `toResponse()` supplies the body;
+    // the status comes from the one rule either way.
+    const statusCode = resolveExceptionStatus(error)
 
     if (HttpException.isHttpException(error)) {
-      const { status, body } = error.toResponse(debug)
+      const { body } = error.toResponse(debug)
 
       if (this.wantsHtmlResponse(ctx) && !debug) {
-        return ctx.html(renderErrorPage(status, body.message), status as ContentfulStatusCode)
+        return ctx.html(renderErrorPage(statusCode, body.message), statusCode as ContentfulStatusCode)
       }
 
-      return ctx.json(body, status as ContentfulStatusCode)
+      return ctx.json(body, statusCode as ContentfulStatusCode)
     }
-
-    // Use duck-typed statusCode if present (e.g. ModelNotFoundException → 404)
-    const statusCode =
-      'statusCode' in error && typeof (error as Record<string, unknown>).statusCode === 'number'
-        ? (error as Record<string, unknown>).statusCode as number
-        : 500
 
     const body: ErrorResponse = {
       message: statusCode < 500 || debug ? error.message : 'Internal Server Error',
@@ -250,6 +256,27 @@ export class ExceptionHandler {
       }
     }
   }
+}
+
+/**
+ * The HTTP status an exception carries, or 500 when it names none.
+ *
+ * Duck-typed on `statusCode` rather than on `instanceof HttpException`, which
+ * is what lets a foreign exception (`ModelNotFoundException` from
+ * `@guren/orm`, crossing a package boundary) render as its own 404 rather than
+ * a 500. `HttpException.isHttpException()` treats the same property as the
+ * authority, so this reads what that check already required.
+ *
+ * One rule, read by both halves of the handler: what an exception is delivered
+ * as and whether the fallback logger treats it as a server failure must be the
+ * same number, or an exception could be sent as a 422 and reported as a crash.
+ * That is why `renderDefaultException` takes the status from here rather than
+ * from `toResponse()`, whose `status` a duck-typed implementation could spell
+ * differently from its own `statusCode`.
+ */
+function resolveExceptionStatus(error: unknown): number {
+  const statusCode = (error as { statusCode?: unknown } | null | undefined)?.statusCode
+  return typeof statusCode === 'number' ? statusCode : 500
 }
 
 /**

--- a/packages/server/tests/errors/errors.test.ts
+++ b/packages/server/tests/errors/errors.test.ts
@@ -446,6 +446,79 @@ describe('ExceptionHandler', () => {
     })
   })
 
+  /**
+   * The console fallback exists so an app with no reporter still surfaces a
+   * *server* failure on stdout. A 4xx is not one: it is delivered to the
+   * caller in full, so logging it turns a route rejecting invalid input as
+   * designed into a stack trace per request — which is how a correct 422 came
+   * to be printed as `Unhandled exception:`.
+   */
+  describe('fallback console reporting', () => {
+    const captureConsoleError = () => {
+      const calls: unknown[][] = []
+      const original = console.error
+      console.error = (...args: unknown[]) => {
+        calls.push(args)
+      }
+      return {
+        calls,
+        restore: () => {
+          console.error = original
+        },
+      }
+    }
+
+    it('should not log client errors when no reporter is registered', async () => {
+      const captured = captureConsoleError()
+      try {
+        await handler.handle(
+          new ValidationException({ title: ['Too short'] }),
+          createMockContext() as any
+        )
+        await handler.handle(new AuthorizationException(), createMockContext() as any)
+        await handler.handle(new NotFoundHttpException(), createMockContext() as any)
+      } finally {
+        captured.restore()
+      }
+
+      expect(captured.calls).toEqual([])
+    })
+
+    it('should log server errors when no reporter is registered', async () => {
+      const captured = captureConsoleError()
+      const httpFailure = new HttpException(500, 'Boom')
+      const bare = new Error('Bare failure')
+      try {
+        await handler.handle(httpFailure, createMockContext() as any)
+        await handler.handle(bare, createMockContext() as any)
+      } finally {
+        captured.restore()
+      }
+
+      expect(captured.calls).toHaveLength(2)
+      expect(captured.calls[0]).toEqual(['Unhandled exception:', httpFailure])
+      expect(captured.calls[1]).toEqual(['Unhandled exception:', bare])
+    })
+
+    it('should still hand client errors to a registered reporter', async () => {
+      const reported: Error[] = []
+      handler.report((error) => {
+        reported.push(error)
+      })
+
+      const error = new ValidationException({ title: ['Too short'] })
+      const captured = captureConsoleError()
+      try {
+        await handler.handle(error, createMockContext() as any)
+      } finally {
+        captured.restore()
+      }
+
+      expect(reported).toEqual([error])
+      expect(captured.calls).toEqual([])
+    })
+  })
+
   describe('dontReport', () => {
     it('should not report excluded exceptions', async () => {
       const reported: Error[] = []


### PR DESCRIPTION
## What this is

The agent preflight seam prints `Unhandled exception: ... ValidationException` while correctly returning a 422. This PR establishes what that message actually is, and stops it.

**It is not an unhandled promise rejection, and it cannot crash a Node process.** It is `console.error('Unhandled exception:', error)` — the fallback in `ExceptionHandler.reportException()` that exists so an app with no reporter still surfaces a server failure on stdout. That fallback fired for *every* exception reaching the handler, including the 4xx an application throws on purpose.

### Evidence

- `grep "Unhandled exception"` over the repo returns exactly one hit: `packages/server/src/errors/ExceptionHandler.ts:133`. Not Bun, not Hono.
- A standalone script (no test runner) registering both `unhandledRejection` and `uncaughtException` reproduces the message; **neither handler fires**, and the process exits 0.
- The same app driven from **Node 22 under `--unhandled-rejections=strict`**, against the built `dist`: the message prints, the response is 422, `unhandled seen: false`, exit 0. Repeated with the pre-fix build to confirm the pre-fix behaviour is identical there.

Structurally there is nothing to escape: the exception is caught by the handler's own middleware, `reportException()` is awaited inside `handle()`, and the correct response is returned. **Not release-blocking.**

### The reported contrast does not exist

The report contrasts this with "an ordinary validation failure on the same route prints nothing." That path prints nothing because it **validates nothing** — with no preflight header the request returned **200** with an invalid body. A route contract's `body` schema is not enforced for controller routes; the controller's own `validateBody()` owns it, which is exactly what the seam's comment says and why preflight validates the body itself. An ordinary `this.validateBody()` failure prints the identical block. Nothing differs between the two paths in the way the report assumed.

**The preflight seam is unchanged.** It throws correctly and the handler renders correctly; the defect is the fallback logger's breadth.

## The change

The console fallback now runs only for exceptions resolving to a 5xx. A 4xx is already delivered to the caller in full — a `ValidationException`'s field errors *are* the response body — so logging it adds nothing an operator can act on, while a route rejecting invalid input as designed printed a stack trace per request.

The gate sits on the console branch alone and deliberately **not** on `shouldNotReport()`: a registered reporter still receives 4xx, because an app tracking auth failures or validation churn through one is asking for exactly those.

Status comes from a single `resolveExceptionStatus()`, which `renderDefaultException` now also reads instead of `toResponse().status`. What an exception is delivered as and whether it counts as a server failure must be the same number, or an exception could be sent as a 422 and reported as a crash. An error carrying no status is still a 500, so a bare `throw new Error(...)` logs as before.

## Tests

Three in `packages/server/tests/errors/errors.test.ts`, capturing `console.error` rather than asserting on process output:

- 4xx (`ValidationException`, `AuthorizationException`, `NotFoundHttpException`) with no reporter logs nothing — **fails on unmodified source**, verified by reverting the fix.
- 5xx (`HttpException(500)`) and a bare `Error` with no reporter still log. This is the half that fails if the gate is later widened.
- A registered reporter still receives a 4xx, pinning the `shouldNotReport()` boundary that was deliberately not moved.

## Verification

- `bun run build` — exit 0
- `bun run typecheck` — exit 0
- `bun run test:bun server` — 2689 pass, 0 fail (exit 0)
- The preflight suite that surfaced this now runs clean: 12 pass, 0 fail, no output. The four `Unhandled exception:` lines left in the full server log are all bare `Error`s with no status — exactly what the fallback is for.