### PR TITLE
fix(cli): read module and app config through transparent assertions

### DIFF
--- a/.changeset/unwrap-assertions-module-and-app-scans.md
+++ b/.changeset/unwrap-assertions-module-and-app-scans.md
@@ -1,0 +1,12 @@
+---
+"@guren/cli": patch
+---
+
+Fix two `guren check` scans that silently misread config wrapped in a transparent TypeScript assertion.
+
+Both read a call argument positionally and tested it for `ObjectExpression` without unwrapping first, so `satisfies` or `as const` around the object made the whole declaration invisible. That failure is silent by construction: these scans report "cannot read this" and "nothing to flag" as the same empty result.
+
+- Route registrar wiring read `defineModule({ … })` bare, so `defineModule({ … } satisfies ModuleDefinition)` looked like a module with no descriptor at all. The scope then fell back to the conventional `modules/<name>/routes.ts`, and a module whose registrar lives anywhere else — `routes/index.ts`, say — had its whole routes directory reported as unmounted.
+- The deploy-runtime scan read `createApp({ … })` the same way, so `createApp({ auth: {} } satisfies AppOptions)` dropped the session signal and the app passed the backed-session-store check instead of being warned. The file's generic identifier scan already walked through these wrappers; only this positional read did not.
+
+Both now go through `objectLiteral()` from `ast-walk`, the one rule for reading an object literal through transparent wrapping.

--- a/packages/cli/src/deploy-runtime.ts
+++ b/packages/cli/src/deploy-runtime.ts
@@ -1,7 +1,7 @@
 import { readFile, readdir } from 'node:fs/promises'
 import { extname, join, resolve } from 'node:path'
-import type { File } from '@babel/types'
-import { memberKeyName, walk, type BabelNode } from './ast-walk'
+import type { File, Node } from '@babel/types'
+import { memberKeyName, objectLiteral, walk, type BabelNode } from './ast-walk'
 import {
   collectFiles,
   toPosixRelative,
@@ -364,9 +364,12 @@ function extractSignals(ast: File): ExtractedSignal[] {
           // object) keeps SMTP-style `auth: { user, pass }` mailer config
           // from reading as a session.
           if (name === 'createApp') {
-            const first = (node.arguments as BabelNode[])[0]
-            if (first?.type === 'ObjectExpression') {
-              for (const property of first.properties as BabelNode[]) {
+            // Unlike the generic identifier scan, which walks through
+            // `satisfies`/`as const` (see TYPE_ONLY_NODES above), this
+            // positional read has to unwrap them itself.
+            const options = objectLiteral((node.arguments as Node[])[0])
+            if (options) {
+              for (const property of options.properties as unknown as BabelNode[]) {
                 if (property.type === 'ObjectProperty' && propertyKeyName(property) === 'auth') {
                   emit('session', 'auth', lineOf(property))
                 }

--- a/packages/cli/src/routes-check.ts
+++ b/packages/cli/src/routes-check.ts
@@ -1,7 +1,7 @@
 import { stat } from 'node:fs/promises'
 import { dirname, extname, isAbsolute, join, relative, resolve } from 'node:path'
-import type { Statement } from '@babel/types'
-import { walk } from './ast-walk'
+import type { CallExpression, Statement } from '@babel/types'
+import { memberKeyName, objectLiteral, walk } from './ast-walk'
 import {
   discoverModuleRoutesFiles,
   discoverRoutesFiles,
@@ -425,29 +425,24 @@ async function resolveModuleEntry(
 
   walk(parsed.ast.program, (node) => {
     if (sawDefineModule || node.type !== 'CallExpression') return
-    const callee = node.callee as { type?: string; name?: string } | undefined
-    if (callee?.type !== 'Identifier' || callee.name !== 'defineModule') return
-    const [argument] = (node.arguments ?? []) as Array<{
-      type?: string
-      properties?: Array<{
-        type?: string
-        computed?: boolean
-        key?: { type?: string; name?: string; value?: unknown }
-        value?: { type?: string; name?: string }
-      }>
-    }>
-    if (argument?.type !== 'ObjectExpression') return
+    const call = node as unknown as CallExpression
+    if (call.callee.type !== 'Identifier' || call.callee.name !== 'defineModule') return
+    // `defineModule({ … } satisfies ModuleDefinition)` describes the same
+    // module, so unwrap before judging the argument's shape. Reading it bare
+    // made the descriptor invisible and dropped the scope back to the
+    // conventional `routes.ts` — a wired module reported as unmounted, with
+    // nothing to distinguish that from a descriptor naming no routes.
+    const argument = objectLiteral(call.arguments[0])
+    if (!argument) return
     sawDefineModule = true
 
-    for (const property of argument.properties ?? []) {
+    for (const property of argument.properties) {
       if (property.type === 'SpreadElement') {
         hasSpread = true
         continue
       }
-      if (property.computed) continue
-      const key = property.key
-      const name = key?.type === 'Identifier' ? key.name : key?.type === 'StringLiteral' ? String(key.value) : undefined
-      if (name !== 'routes') continue
+      // Computed keys answer `undefined` here, which is the skip this wants.
+      if (memberKeyName(property) !== 'routes') continue
       // A method shorthand (`routes(router) {...}`) is an inline registrar,
       // same as an arrow value.
       routesValue = property.type === 'ObjectMethod' ? { type: 'FunctionExpression' } : (property.value ?? null)

--- a/packages/cli/tests/check.test.ts
+++ b/packages/cli/tests/check.test.ts
@@ -1455,6 +1455,15 @@ export function registerBillingRoutes(router: Router): void {
 }
 `
 
+  /** A registrar at `routes/index.ts`, mounting `routes/invoice.ts`. */
+  const BILLING_ROUTES_INDEX = `import { Router } from '@guren/core'
+import { registerRoutes } from './invoice.js'
+
+export function registerBillingRoutes(router: Router): void {
+  registerRoutes(router)
+}
+`
+
   /** `make:route Invoice --module billing` output, wired to nothing. */
   const MODULE_ROUTE = `import { Router } from '@guren/core'
 import InvoiceController from '../app/Http/Controllers/InvoiceController.js'
@@ -1526,19 +1535,39 @@ import { registerBillingRoutes } from './routes/index.js'
 
 export const billingModule = defineModule({ name: 'billing', routes: registerBillingRoutes })
 `,
-      'modules/billing/routes/index.ts': `import { Router } from '@guren/core'
-import { registerRoutes } from './invoice.js'
-
-export function registerBillingRoutes(router: Router): void {
-  registerRoutes(router)
-}
-`,
+      'modules/billing/routes/index.ts': BILLING_ROUTES_INDEX,
       'modules/billing/routes/invoice.ts': MODULE_ROUTE,
     })
 
     expect(statusOf(report, 'modules/billing/routes/invoice.ts')).toBe('pass')
     expect(wiring(report).has('modules/billing/routes/index.ts')).toBe(false)
   })
+
+  // `defineModule({ … } satisfies ModuleDefinition)` is still a module
+  // descriptor: the assertion changes nothing the runtime sees. Reading the
+  // call's argument without unwrapping it made the descriptor invisible, and
+  // the module then fell back to the conventional `routes.ts` — the stale
+  // registrar this fixture keeps in place — so a wired directory reported as
+  // unmounted. Silent by construction: "cannot read the descriptor" and
+  // "the descriptor names nothing" are the same absence.
+  it.each([' satisfies Record<string, unknown>', ' as const'])(
+    'reads a defineModule descriptor written with %s',
+    async (suffix) => {
+      const report = await withWorkspace({
+        'routes/web.ts': PLAIN_ENTRY,
+        'modules/billing/routes.ts': BILLING_ENTRY,
+        'modules/billing/index.ts': `import { defineModule } from '@guren/core'
+import { registerBillingRoutes } from './routes/index.js'
+
+export const billingModule = defineModule({ name: 'billing', routes: registerBillingRoutes }${suffix})
+`,
+        'modules/billing/routes/index.ts': BILLING_ROUTES_INDEX,
+        'modules/billing/routes/invoice.ts': MODULE_ROUTE,
+      })
+
+      expect(statusOf(report, 'modules/billing/routes/invoice.ts')).toBe('pass')
+    },
+  )
 
   // The runtime mounts only what `defineModule({ routes })` names — a
   // descriptor without `routes` mounts nothing, however well-wired the

--- a/packages/cli/tests/deploy-runtime.test.ts
+++ b/packages/cli/tests/deploy-runtime.test.ts
@@ -375,6 +375,27 @@ export const app = createApp({ auth: { autoSession: false } })
     })
   })
 
+  // The `auth` key is read off createApp's first argument positionally, and a
+  // transparent assertion around the options object is not the object — the
+  // generic identifier scan walks through `satisfies`/`as const`, but this
+  // positional read did not, so an app written this way lost the session
+  // signal entirely and passed a check it should fail.
+  it.each([' satisfies Record<string, unknown>', ' as const'])(
+    'reads createApp options written with %s',
+    async (suffix) => {
+      const files = {
+        'src/app.ts': `import { createApp } from '@guren/core'\nexport const app = createApp({ auth: {} }${suffix})\n`,
+      }
+
+      await withApp('guren-stores-wrapped-auth-', files, { '@guren/plugin-cloudflare': '^0.2.0' }, async (dir) => {
+        const check = (await deployChecks(dir))['deploy-runtime-stores']
+
+        expect(check.status).toBe('warn')
+        expect(check.message).toContain('sessions are enabled')
+      })
+    },
+  )
+
   // The `auth: {` match alone can't see what's inside the object it opens, so
   // suppression must come from a whole-app check for `autoSession: false`,
   // not from excluding it within the same regex pass (that reintroduces the


### PR DESCRIPTION
## Summary

Two `guren check` scans silently misread config wrapped in a transparent TypeScript assertion. Both read a call argument positionally and tested it for `ObjectExpression` without unwrapping first, so `satisfies` or `as const` around the object made the whole declaration invisible.

That failure is silent by construction: these scans report "cannot read this" and "nothing to flag" as the same empty result, so the app looks clean rather than unreadable.

- **Route registrar wiring** read `defineModule({ … })` bare, so `defineModule({ … } satisfies ModuleDefinition)` looked like a module with no descriptor at all. The scope then fell back to the conventional `modules/<name>/routes.ts`, and a module whose registrar lives anywhere else — `routes/index.ts`, say — had its whole routes directory reported as unmounted. That is the inverse of what the check advertises ("every `routes/*.ts` reached from the registrar that would mount it").
- **The deploy-runtime scan** read `createApp({ … })` the same way, so `createApp({ auth: {} } satisfies AppOptions)` dropped the session signal and the app passed the backed-session-store check instead of being warned. That file's own comment already says these wrappers "still ha[ve] to be walked"; its generic identifier scan does, this positional read did not.

Both now go through `objectLiteral()` from `ast-walk`, the one rule for reading an object literal through transparent wrapping, added in #614.

## Scope

- `cli` — `packages/cli/src/routes-check.ts`, `packages/cli/src/deploy-runtime.ts`, and their tests.

## Risk Assessment

Low. Strictly widens what the two scans can read; no verdict that previously fired stops firing.

The `routes-check` hunk also replaces a hand-rolled inline structural type and a hand-rolled key-name ternary with the shared `CallExpression` cast plus `memberKeyName()`, matching `attachments-check.ts`. The computed-key, `ObjectMethod`, `SpreadElement` and missing-argument paths were each checked to behave identically to before — a computed key now answers `undefined` from `memberKeyName()`, which is the same skip the explicit `property.computed` test performed.

An app already written with `satisfies` will start seeing verdicts it was never shown before. That is the point of the fix, but it means a previously "clean" app can go warn on upgrade.

## Validation

Each new test was confirmed to fail before its fix, on the assertion it targets rather than on a parse error — necessary here, since a fixture that fails to parse produces the identical symptom.

The tests are parameterized over `satisfies` and `as const`, and each variant was shown to be independently live by mutation: dropping the `TSAsExpression` arm of `unwrapTypeAssertion` reddens exactly the two `as const` cases; dropping the `TSSatisfiesExpression` arm reddens exactly the two `satisfies` cases. Reverting either call-site swap alone reddens only its own test.

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` — `packages/cli` green (2026 pass / 0 fail), `test:examples` green (123 pass). See the note below on the full-suite runner.

Note on the full suite: on this machine `bun run test` has been ending in a Bun segfault (`panic(main thread): Segmentation fault`, Bun 1.3.14) inside `packages/cli/tests/tool-dev.test.ts`, which starts a Vite dev server — a Bun crash, not a test failure, and unrelated to these scans. An earlier complete run of the same suite reported 5990 pass / 1 fail, that one failure being `scripts/publish-agent-catalog.test.ts` timing out at its 5s budget under load; it passes in isolation. Worth a look in CI, which is the clean-machine reference.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation — no doc change needed; this restores documented behavior rather than changing it.
