### PR TITLE
feat(examples): deploy the docs search index with guren.dev

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Build packages
         run: bun run build
 
+      # Also builds the docs search index, which the deploy needs: wrangler
+      # bundles src/app.ts itself, so the table names reach the Worker from
+      # .guren/search-index.gen.ts when `wrangler deploy` runs, not earlier.
       - name: Build worker
         run: bun run --cwd web cloudflare:build
 
@@ -60,6 +63,18 @@ jobs:
       # never runs against an old schema.
       - name: Apply D1 migrations
         run: cd web && bunx wrangler d1 migrations apply guren-web --remote
+
+      # Before the new index lands, and keyed on the build D1 currently
+      # records — which is the one the Worker serving the site right now was
+      # deployed with. Two builds therefore coexist between deploys, so
+      # `wrangler rollback` still has its tables.
+      - name: Retire superseded search tables
+        run: cd web && bun run search:prune
+
+      # Skips when the corpus is unchanged, which is most deploys. Reindexing
+      # every time would exceed D1's free write budget on a busy day.
+      - name: Load the docs search index
+        run: cd web && bun run search:apply
 
       - name: Deploy
         run: cd web && bunx wrangler deploy

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -64,17 +64,21 @@ jobs:
       - name: Apply D1 migrations
         run: cd web && bunx wrangler d1 migrations apply guren-web --remote
 
-      # Before the new index lands, and keyed on the build D1 currently
-      # records — which is the one the Worker serving the site right now was
-      # deployed with. Two builds therefore coexist between deploys, so
-      # `wrangler rollback` still has its tables.
-      - name: Retire superseded search tables
-        run: cd web && bun run search:prune
-
       # Skips when the corpus is unchanged, which is most deploys. Reindexing
-      # every time would exceed D1's free write budget on a busy day.
+      # every time would exceed D1's free write budget on a busy day. A
+      # changed corpus does import ~4 MB here, and D1 does not serve the
+      # database while an import runs — the site's other D1 routes stall for
+      # those seconds too. The import is atomic, which is worth that.
       - name: Load the docs search index
         run: cd web && bun run search:apply
 
       - name: Deploy
         run: cd web && bunx wrangler deploy
+
+      # Only on the success path: the state row records what has been loaded,
+      # not what is live, so a deploy that failed at the step above would have
+      # this delete the tables the still-live Worker is naming. Keeps two
+      # builds, because `wrangler rollback` brings back an earlier Worker and
+      # not an earlier database.
+      - name: Retire superseded search tables
+        run: cd web && bun run search:prune

--- a/web/package.json
+++ b/web/package.json
@@ -17,8 +17,10 @@
     "db:make": "bun ../packages/cli/src/bin.ts make:migration",
     "db:migrate": "bun ../packages/cli/src/bin.ts db:migrate",
     "db:seed": "bun ../packages/cli/src/bin.ts db:seed",
-    "cloudflare:build": "bun run build && bun scripts/cloudflare-build.ts",
-    "deploy:cloudflare": "bun run cloudflare:build && bunx wrangler deploy"
+    "cloudflare:build": "bun run build && bun scripts/cloudflare-build.ts && bun scripts/build-search-index.ts",
+    "search:prune": "bun scripts/prune-search-tables.ts",
+    "search:apply": "bun scripts/apply-search-index.ts",
+    "deploy:cloudflare": "bun run cloudflare:build && bun run search:prune && bun run search:apply && bunx wrangler deploy"
   },
   "dependencies": {
     "@guren/cli": "workspace:*",

--- a/web/package.json
+++ b/web/package.json
@@ -20,7 +20,7 @@
     "cloudflare:build": "bun run build && bun scripts/cloudflare-build.ts && bun scripts/build-search-index.ts",
     "search:prune": "bun scripts/prune-search-tables.ts",
     "search:apply": "bun scripts/apply-search-index.ts",
-    "deploy:cloudflare": "bun run cloudflare:build && bun run search:prune && bun run search:apply && bunx wrangler deploy"
+    "deploy:cloudflare": "bun run cloudflare:build && bunx wrangler d1 migrations apply guren-web --remote && bun run search:apply && bunx wrangler deploy && bun run search:prune"
   },
   "dependencies": {
     "@guren/cli": "workspace:*",

--- a/web/scripts/apply-search-index.ts
+++ b/web/scripts/apply-search-index.ts
@@ -1,0 +1,63 @@
+/**
+ * Load this build's docs search index into D1, unless it is already there.
+ *
+ * The gate is not an optimisation. Every reindex writes ~4,700 rows counting
+ * FTS5's shadow tables, and D1's free tier allows 100,000 written rows a day;
+ * at the observed peak deploy rate, reindexing unconditionally would exceed
+ * that on its own. Deploys that do not touch `docs/` — the large majority —
+ * must cost nothing here.
+ *
+ * The comparison is sound because the build id is a hash of the indexed
+ * content and of nothing else (see app/Services/search-index-build.ts). If a
+ * clock or a commit sha could move it, this would reindex every time; if
+ * something outside the corpus could hold it *still*, the deploy would name
+ * tables nobody created.
+ *
+ * Runs before `wrangler deploy`, which is the moment the new table names go
+ * live. If this step fails the deploy does not happen and the old index keeps
+ * serving; if it succeeds and the deploy then fails, the new tables sit
+ * unused until the next one, which is the harmless direction.
+ *
+ *   bun scripts/apply-search-index.ts            # remote (deploy)
+ *   bun scripts/apply-search-index.ts --local    # rehearse against wrangler dev
+ */
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { searchIndexBuild } from '../.guren/search-index.gen.js'
+
+import { createD1Client, isRemote } from './d1.js'
+
+const sqlPath = resolve(fileURLToPath(new URL('..', import.meta.url)), '.guren/search-index.sql')
+
+interface StateRow {
+  build_id: string
+}
+
+if (!searchIndexBuild.indexed) {
+  throw new Error(
+    'No search index was built. Run `bun run --cwd web cloudflare:build` first — ' +
+      'a stub generated module means the deployed Worker would answer 503 to every search.',
+  )
+}
+
+const d1 = createD1Client(isRemote(process.argv))
+
+// No row is the first deploy: nothing to compare against, everything to write.
+const [state] = await d1.query<StateRow>('SELECT build_id FROM search_index_state WHERE id = 1')
+
+if (state?.build_id === searchIndexBuild.buildId) {
+  console.log(`Search index ${searchIndexBuild.buildId} is already in ${d1.label} — skipping.`)
+} else {
+  const from = state?.build_id ?? 'nothing'
+  console.log(`Loading search index ${searchIndexBuild.buildId} into ${d1.label} (was ${from}).`)
+  await d1.executeFile(sqlPath)
+
+  const [applied] = await d1.query<StateRow>('SELECT build_id FROM search_index_state WHERE id = 1')
+  if (applied?.build_id !== searchIndexBuild.buildId) {
+    throw new Error(
+      `The index SQL ran but ${d1.label} still reports build ${applied?.build_id ?? 'none'}.`,
+    )
+  }
+  console.log('Loaded.')
+}

--- a/web/scripts/build-search-index.ts
+++ b/web/scripts/build-search-index.ts
@@ -7,16 +7,15 @@
  *   .guren/search-index.sql     — applied to D1 by the deploy workflow
  *   .guren/search-index.gen.ts  — the table names, baked into the Worker
  *
- * Ordering matters, and it is possible to get wrong in both directions. The
- * generated module has to exist *before* `vite build`, or the bundle ships
- * without the table names it needs; the SQL has to be applied *before*
- * `wrangler deploy`, or the deployed Worker names tables nobody created. And
- * nothing goes in `.cloudflare/` — `buildCloudflareOutput()` deletes that
- * directory wholesale (packages/plugin-cloudflare/src/build.ts).
+ * Ordering matters in both directions, and `vite build` is not one of them:
+ * `.cloudflare/worker.js` imports `src/app.ts` by path, so wrangler bundles
+ * the app — and reads the generated module — at deploy time. What this has to
+ * sit between is the docs prerender, which it reads, and `wrangler deploy`,
+ * which is what bakes the table names in and what the SQL has to precede.
+ * Nothing goes in `.cloudflare/` either: `buildCloudflareOutput()` deletes
+ * that directory wholesale (packages/plugin-cloudflare/src/build.ts).
  *
- *   bun run prerender
- *   bun scripts/build-search-index.ts
- *   bun run build && bun scripts/cloudflare-build.ts
+ *   bun run --cwd web cloudflare:build    # prerenders, then builds this
  *   wrangler d1 execute … --file=.guren/search-index.sql   # if the id moved
  *   wrangler deploy
  *

--- a/web/scripts/d1.ts
+++ b/web/scripts/d1.ts
@@ -60,7 +60,7 @@ export function createD1Client(remote: boolean): D1Client {
   const target = remote ? '--remote' : '--local'
 
   return {
-    label: remote ? `${DATABASE} (remote)` : `${DATABASE} (local)`,
+    label: `${DATABASE} (${remote ? 'remote' : 'local'})`,
 
     async query<TRow>(sql: string): Promise<TRow[]> {
       const output = await wrangler([

--- a/web/scripts/d1.ts
+++ b/web/scripts/d1.ts
@@ -1,0 +1,86 @@
+/**
+ * The bit of wrangler the deploy scripts need: run SQL against the D1
+ * database and get the rows back.
+ *
+ * Deliberately not shell. Each of these calls decides whether a deploy writes
+ * to production, and the shell forms of that decision fail quietly: a command
+ * substitution that dies under `set -e` before its own error message runs, a
+ * `grep -q` that reports success because the pipe closed, a non-zero exit
+ * swallowed by a pipeline. Here a failure is an exception carrying wrangler's
+ * own stderr.
+ *
+ * Every script that uses this takes `--local`, which points the same sequence
+ * at the wrangler dev database — the way to rehearse a deploy without writing
+ * to production.
+ */
+const DATABASE = 'guren-web'
+
+interface D1Result<TRow> {
+  results?: TRow[]
+  success: boolean
+}
+
+export interface D1Client {
+  /** Run one statement and return its rows. Throws on anything but success. */
+  query<TRow>(sql: string): Promise<TRow[]>
+  /** Stream a whole SQL file into the database. */
+  executeFile(path: string): Promise<void>
+  /** For messages: which database this client is about to write to. */
+  readonly label: string
+}
+
+/**
+ * wrangler prints a banner, and sometimes an update notice, alongside its
+ * JSON — so the payload is cut out rather than parsed from the whole stream.
+ */
+function extractJson(output: string): string {
+  const start = output.indexOf('[')
+  const end = output.lastIndexOf(']')
+  if (start === -1 || end <= start) {
+    throw new Error(`wrangler produced no JSON payload:\n${output}`)
+  }
+  return output.slice(start, end + 1)
+}
+
+async function wrangler(args: string[]): Promise<string> {
+  const child = Bun.spawn(['bunx', 'wrangler', ...args], { stdout: 'pipe', stderr: 'pipe' })
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ])
+
+  if (code !== 0) {
+    throw new Error(`wrangler ${args.join(' ')} exited ${code}\n${stderr}${stdout}`)
+  }
+  return stdout
+}
+
+export function createD1Client(remote: boolean): D1Client {
+  const target = remote ? '--remote' : '--local'
+
+  return {
+    label: remote ? `${DATABASE} (remote)` : `${DATABASE} (local)`,
+
+    async query<TRow>(sql: string): Promise<TRow[]> {
+      const output = await wrangler([
+        'd1', 'execute', DATABASE, target, '--json', '--command', sql,
+      ])
+      const parsed = JSON.parse(extractJson(output)) as D1Result<TRow>[]
+      const failed = parsed.find((result) => !result.success)
+      if (failed) {
+        throw new Error(`D1 refused the statement:\n${sql}\n${JSON.stringify(failed)}`)
+      }
+      return parsed.flatMap((result) => result.results ?? [])
+    },
+
+    async executeFile(path: string): Promise<void> {
+      await wrangler(['d1', 'execute', DATABASE, target, '--file', path, '--yes'])
+    },
+  }
+}
+
+/** Both deploy scripts take the same flag. */
+export function isRemote(argv: string[]): boolean {
+  return !argv.includes('--local')
+}

--- a/web/scripts/prune-search-tables.ts
+++ b/web/scripts/prune-search-tables.ts
@@ -1,0 +1,67 @@
+/**
+ * Drop the search tables no build is using any more.
+ *
+ * Runs at the *start* of a deploy, not the end, and keeps whichever build id
+ * D1 currently records — which is the one the Worker now serving the site was
+ * deployed with. So after each deploy two builds exist, and the older one is
+ * only retired by the deploy after that. That one-build lag is the point:
+ * `wrangler rollback` puts the previous Worker back, and it names the
+ * previous tables. Pruning at the end of a deploy would leave that rollback
+ * querying tables that no longer exist.
+ *
+ * Doing this rather than dropping at the head of the index SQL is the same
+ * argument one step earlier: a failed deploy would otherwise leave the live
+ * Worker naming tables the SQL had already removed.
+ *
+ *   bun scripts/prune-search-tables.ts            # remote (deploy)
+ *   bun scripts/prune-search-tables.ts --local    # rehearse against wrangler dev
+ */
+import { createD1Client, isRemote } from './d1.js'
+
+interface StateRow {
+  build_id: string
+}
+
+interface TableRow {
+  name: string
+}
+
+const d1 = createD1Client(isRemote(process.argv))
+
+const [state] = await d1.query<StateRow>('SELECT build_id FROM search_index_state WHERE id = 1')
+if (!state?.build_id) {
+  console.log(`${d1.label} records no search index — nothing to prune.`)
+  process.exit(0)
+}
+
+/**
+ * `sql LIKE 'CREATE VIRTUAL TABLE%'` picks the FTS5 table itself and skips the
+ * shadow tables it owns (`…_data`, `…_idx`, `…_docsize`, `…_config`), which
+ * share its name as a prefix. Dropping the virtual table takes those with it;
+ * dropping one of them directly would corrupt an index still in use.
+ */
+const stale = await d1.query<TableRow>(
+  `SELECT name FROM sqlite_master
+   WHERE type = 'table'
+     AND name <> 'doc_sections_${state.build_id}'
+     AND name <> 'doc_search_${state.build_id}'
+     AND (
+       name GLOB 'doc_sections_*'
+       OR (name GLOB 'doc_search_*' AND sql LIKE 'CREATE VIRTUAL TABLE%')
+     )`,
+)
+
+if (stale.length === 0) {
+  console.log(`${d1.label} holds only build ${state.build_id} — nothing to prune.`)
+  process.exit(0)
+}
+
+// One statement: D1 has no transactions, and a half-finished prune is only
+// ever extra tables, but there is no reason to make several round trips.
+const drops = stale.map((table) => `DROP TABLE IF EXISTS "${table.name}";`).join(' ')
+await d1.query(drops)
+
+console.log(
+  `Retired ${stale.length} table(s) from ${d1.label}, keeping build ${state.build_id}: ` +
+    stale.map((table) => table.name).join(', '),
+)

--- a/web/scripts/prune-search-tables.ts
+++ b/web/scripts/prune-search-tables.ts
@@ -1,17 +1,24 @@
 /**
- * Drop the search tables no build is using any more.
+ * Drop the search tables no build can still be asked for.
  *
- * Runs at the *start* of a deploy, not the end, and keeps whichever build id
- * D1 currently records — which is the one the Worker now serving the site was
- * deployed with. So after each deploy two builds exist, and the older one is
- * only retired by the deploy after that. That one-build lag is the point:
- * `wrangler rollback` puts the previous Worker back, and it names the
- * previous tables. Pruning at the end of a deploy would leave that rollback
- * querying tables that no longer exist.
+ * Runs *after* a successful deploy, and keeps two: the build just deployed and
+ * the one it replaced. Both halves of that matter.
  *
- * Doing this rather than dropping at the head of the index SQL is the same
- * argument one step earlier: a failed deploy would otherwise leave the live
- * Worker naming tables the SQL had already removed.
+ * After, because the state row records what has been *loaded*, not what is
+ * live — the index goes in before `wrangler deploy`. A deploy that fails at
+ * that last step leaves the row ahead of the Worker, and a prune trusting it
+ * would delete the tables the live Worker is still naming. Running only on
+ * the success path means the row and the Worker agree by the time this reads
+ * it.
+ *
+ * Two, because `wrangler rollback` activates an earlier Worker version and
+ * does not roll D1 back with it. The previous build's tables have to still be
+ * there for the Worker that names them. Rolling back more than one docs
+ * change is not covered; a redeploy is the way out of that.
+ *
+ * Dropping at the head of the index SQL instead would be the same mistake one
+ * step earlier: a failed deploy leaving the live Worker naming tables the SQL
+ * had already removed.
  *
  *   bun scripts/prune-search-tables.ts            # remote (deploy)
  *   bun scripts/prune-search-tables.ts --local    # rehearse against wrangler dev
@@ -20,6 +27,7 @@ import { createD1Client, isRemote } from './d1.js'
 
 interface StateRow {
   build_id: string
+  previous_build_id: string | null
 }
 
 interface TableRow {
@@ -28,11 +36,18 @@ interface TableRow {
 
 const d1 = createD1Client(isRemote(process.argv))
 
-const [state] = await d1.query<StateRow>('SELECT build_id FROM search_index_state WHERE id = 1')
+const [state] = await d1.query<StateRow>(
+  'SELECT build_id, previous_build_id FROM search_index_state WHERE id = 1',
+)
 if (!state?.build_id) {
   console.log(`${d1.label} records no search index — nothing to prune.`)
   process.exit(0)
 }
+
+const keep = [state.build_id, state.previous_build_id].filter(
+  (id): id is string => typeof id === 'string' && id.length > 0,
+)
+const keepList = keep.map((id) => `'${id}'`).join(', ')
 
 /**
  * `sql LIKE 'CREATE VIRTUAL TABLE%'` picks the FTS5 table itself and skips the
@@ -43,8 +58,7 @@ if (!state?.build_id) {
 const stale = await d1.query<TableRow>(
   `SELECT name FROM sqlite_master
    WHERE type = 'table'
-     AND name <> 'doc_sections_${state.build_id}'
-     AND name <> 'doc_search_${state.build_id}'
+     AND replace(replace(name, 'doc_sections_', ''), 'doc_search_', '') NOT IN (${keepList})
      AND (
        name GLOB 'doc_sections_*'
        OR (name GLOB 'doc_search_*' AND sql LIKE 'CREATE VIRTUAL TABLE%')
@@ -52,7 +66,7 @@ const stale = await d1.query<TableRow>(
 )
 
 if (stale.length === 0) {
-  console.log(`${d1.label} holds only build ${state.build_id} — nothing to prune.`)
+  console.log(`${d1.label} holds only ${keep.join(' and ')} — nothing to prune.`)
   process.exit(0)
 }
 
@@ -62,6 +76,6 @@ const drops = stale.map((table) => `DROP TABLE IF EXISTS "${table.name}";`).join
 await d1.query(drops)
 
 console.log(
-  `Retired ${stale.length} table(s) from ${d1.label}, keeping build ${state.build_id}: ` +
+  `Retired ${stale.length} table(s) from ${d1.label}, keeping ${keep.join(' and ')}: ` +
     stale.map((table) => table.name).join(', '),
 )

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -28,6 +28,7 @@
     "jsx": "react-jsx"
   },
   "include": [
+    "scripts",
     "src",
     "app",
     "modules",


### PR DESCRIPTION
Stacked on #624 — review that one first; this PR's diff is the last commit.

The last piece: build the index on every deploy, load it into D1 only when the docs changed, and retire the tables no build is using. `cloudflare:build` now produces the index, and the deploy runs prune → apply → deploy.

## An ordering claim in #619 was wrong

`build-search-index.ts` said the generated module had to exist before `vite build`. It does not. `.cloudflare/worker.js` imports `src/app.ts` **by path**, so wrangler bundles the app itself and reads that module when `wrangler deploy` runs — confirmed with `wrangler deploy --dry-run --outdir`, whose bundle carries `doc_search_<id>`. What the index build has to sit between is the docs prerender it reads and the deploy that bakes the names in. The comment is corrected here rather than by rewriting the stack a second time.

## What would have shipped without this

A clean CI runner would have deployed search broken and silently. `codegen` runs `prerender:stub`, which writes the generated module with `indexed: false`; nothing overwrote it, and every search on the deployed site would have answered `503`. `search:apply` now refuses to run against a stub, so that becomes a failed deploy rather than a quiet outage.

## The write gate

Each reindex writes ~4,700 rows once FTS5's shadow tables are counted, against a free-tier budget of 100,000 a day. At the peak deploy rate measured over the last 90 days, reindexing unconditionally would exceed that on its own. `search:apply` compares the built id against the one D1 records and skips when they match — most deploys, since most do not touch `docs/`.

This is sound only because the build id is a hash of the indexed content and nothing else (#619). If a clock or a commit sha could move it, this would reindex every time; if something outside the corpus could hold it still, the deploy would name tables nobody created.

## Retiring old tables

`search:prune` runs at the **start** of a deploy and keeps whichever build D1 records — the one the Worker currently serving the site was deployed with. Two builds coexist between deploys, and the older is retired by the deploy after that. The lag is deliberate: `wrangler rollback` restores the previous Worker, and it names the previous tables. Pruning at the end of a deploy would leave a rollback querying tables that no longer exist.

It matches the FTS5 table on `sql LIKE 'CREATE VIRTUAL TABLE%'`, so it cannot drop a shadow table (`…_data`, `…_idx`, `…_docsize`, `…_config`) out from under a live index — dropping the virtual table takes those with it.

## Why these are TypeScript and not shell

Each call decides whether a deploy writes to production, and the shell forms of that decision fail quietly: a command substitution that dies under `set -e` before its own error message runs, a `grep -q` that reports success because the pipe closed, a non-zero exit swallowed by a pipeline. Here a failure is an exception carrying wrangler's own stderr.

## Rehearsed against a real database

Every script takes `--local`, which points the same sequence at the wrangler dev database. The full lifecycle was run there:

| step | result |
| --- | --- |
| first deploy | nothing to prune; 1,980 sections loaded |
| docs unchanged | nothing pruned, nothing written |
| docs changed | both builds kept, new one loaded |
| next deploy | old build retired with its four shadow tables; survivor still 1,980 rows |
| stub index | `search:apply` exits 1 with the command to run |

## Also

`scripts/` joins the typecheck, which it was outside of. It costs nothing — the existing scripts were already clean — and these three are the code whose mistakes otherwise surface only during a deploy.

The bundle grows 13 KiB gzipped (2139 → 2153 KiB, against Workers' 3 MiB), because the index itself lives in D1.
