### PR TITLE
test(docs): verify docs imports name real exports

### DIFF
--- a/scripts/smoke/docs-audit.ts
+++ b/scripts/smoke/docs-audit.ts
@@ -1,5 +1,6 @@
 import { readdir, readFile } from 'node:fs/promises'
 import { join, relative, resolve } from 'node:path'
+import { auditDocsImportSources, formatReport } from './docs-import-sources'
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -396,11 +397,39 @@ async function auditDocLineRules(root: string): Promise<void> {
   }
 }
 
+/**
+ * Every named import in a TypeScript fence must name a symbol its specifier
+ * exports. Reports the whole batch before failing — the assertions above die on
+ * the first miss, which is right for a claim about one file and wrong for a
+ * sweep over every fence in `docs/`. See docs-import-sources.ts for what the
+ * check can and cannot prove.
+ */
+async function auditImportSources(root: string): Promise<void> {
+  const report = await auditDocsImportSources(root)
+
+  if (report.openEntryPoints.length > 0) {
+    console.log(
+      `Docs import audit: no absence verdict for ${report.openEntryPoints.length} entry point(s) that re-export a third-party package wholesale — ${report.openEntryPoints.join('; ')}`,
+    )
+  }
+
+  const failures = report.unresolvable.length + report.unexported.length
+  assert(
+    failures === 0,
+    `${formatReport(report)}\n\n(${report.symbolsChecked} named imports checked across ${report.fencesScanned} TypeScript fences.)`,
+  )
+
+  console.log(
+    `Docs import audit passed: ${report.symbolsChecked} named imports across ${report.importsChecked} first-party import statements in ${report.fencesScanned} TypeScript fences.`,
+  )
+}
+
 async function main(): Promise<void> {
   const root = resolve(process.argv[2] ?? '.')
   await auditEnglishDocs(root)
   await auditJapaneseDocs(root)
   await auditDocLineRules(root)
+  await auditImportSources(root)
   console.log(`Docs audit passed for ${root}`)
 }
 

--- a/scripts/smoke/docs-audit.ts
+++ b/scripts/smoke/docs-audit.ts
@@ -413,6 +413,25 @@ async function auditImportSources(root: string): Promise<void> {
     )
   }
 
+  // A *root* entry point going open is not a note, it is the check switching
+  // itself off. The exempt ones are all subpaths — `@guren/orm/drizzle/pg`,
+  // the jsx runtimes — each reached by a handful of snippets. `@guren/core` is
+  // reached by most of them, so one `export *` from a third-party package
+  // added to its barrel drops what this audit verifies from about a thousand
+  // symbols to roughly a hundred, and the only trace is the line above,
+  // printed directly beneath the word "passed". Derived rather than listed:
+  // whichever roots exist, a root is the shape that collapses coverage, while
+  // a new subpath that legitimately re-exports a dependency still costs only
+  // its own snippets.
+  const openRoots = report.openEntryPoints.filter((entry) => entry.split(' ')[0]!.split('/').length === 2)
+  assert(
+    openRoots.length === 0,
+    `Docs import audit cannot verify anything imported from ${openRoots.join('; ')}: a package root that `
+      + 're-exports a third-party package wholesale makes every symbol imported from it unprovable, and '
+      + 'most snippets import from a root. Re-export the names the package means to publish, or move the '
+      + 'wholesale re-export to a subpath.',
+  )
+
   const failures = report.unresolvable.length + report.unexported.length
   assert(
     failures === 0,

--- a/scripts/smoke/docs-import-sources.test.ts
+++ b/scripts/smoke/docs-import-sources.test.ts
@@ -235,6 +235,28 @@ describe('entry points whose surface is open', () => {
     expect(report.unexported).toEqual([])
     expect(report.openEntryPoints).toContain("@guren/orm/drizzle/pg (re-exports 'drizzle-orm/pg-core')")
   })
+
+  test('the set of open entry points is exactly the subpaths that earn it', async () => {
+    // Pinned so it cannot grow unnoticed. Every exempt entry point is one this
+    // gate issues no verdict for, so each addition is a slice of `docs/` that
+    // stops being checked — a decision worth making on purpose. Roots are
+    // covered separately and harder: `docs-audit.ts` fails on one outright.
+    const report = await auditDocsImportSources(repoRoot, join(repoRoot, 'docs'))
+    const open = [...report.openEntryPoints].map((entry) => entry.split(' ')[0]).sort()
+
+    expect(open).toEqual([
+      '@guren/core/jsx-dev-runtime',
+      '@guren/core/jsx-runtime',
+      '@guren/orm/drizzle/mysql',
+      '@guren/orm/drizzle/pg',
+      '@guren/orm/drizzle/sqlite',
+      '@guren/server/jsx-dev-runtime',
+      '@guren/server/jsx-runtime',
+    ])
+    // None of them is a package root, which is the shape that would collapse
+    // coverage rather than trim it.
+    expect(open.filter((entry) => entry!.split('/').length === 2)).toEqual([])
+  })
 })
 
 describe('the docs tree as committed', () => {

--- a/scripts/smoke/docs-import-sources.test.ts
+++ b/scripts/smoke/docs-import-sources.test.ts
@@ -190,6 +190,33 @@ describe('specifiers the gate cannot resolve', () => {
     expect(report.unresolvable[0]?.reason).toContain('static asset')
   })
 
+  // Two import forms name no symbols, which is exactly why they slipped past
+  // the specifier check once: the loop skipped ahead when there was nothing to
+  // look up, and skipped the "does this package even exist" question with it.
+  test('fails a namespace import of a package that does not exist', async () => {
+    const report = await auditSnippet("import * as everything from '@guren/not-a-package'")
+
+    expect(report.unresolvable).toHaveLength(1)
+    expect(report.unresolvable[0]?.reason).toContain('no such first-party package')
+  })
+
+  test('fails a bare side-effect import of a subpath that does not exist', async () => {
+    const report = await auditSnippet("import '@guren/core/not-a-subpath'")
+
+    expect(report.unresolvable).toHaveLength(1)
+    expect(report.unresolvable[0]?.reason).toContain('exports map')
+  })
+
+  test('allows a bare side-effect import of a real asset subpath', async () => {
+    // What a bare import is usually for, and what `docs/{en,ja}/guides/markdown.md`
+    // actually does. A stylesheet having no named exports is not a finding —
+    // the subpath existing is the whole of what can be asked here.
+    const report = await auditSnippet("import '@guren/plugin-markdown/styles.css'")
+
+    expect(report.unresolvable).toEqual([])
+    expect(report.unexported).toEqual([])
+  })
+
   test('leaves a third-party specifier alone', async () => {
     const report = await auditSnippet("import { z } from 'zod'", "import React from 'react'")
 

--- a/scripts/smoke/docs-import-sources.test.ts
+++ b/scripts/smoke/docs-import-sources.test.ts
@@ -1,0 +1,222 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+
+import {
+  auditDocsImportSources,
+  collectEntryPoints,
+  extractImports,
+  formatReport,
+  typescriptFences,
+  type DocsImportReport,
+} from './docs-import-sources'
+
+const repoRoot = join(import.meta.dir, '..', '..')
+
+let scratch: string
+
+beforeAll(async () => {
+  scratch = await mkdtemp(join(tmpdir(), 'guren-docs-imports-'))
+})
+
+afterAll(async () => {
+  await rm(scratch, { recursive: true, force: true })
+})
+
+/**
+ * Run the audit over one synthetic markdown file, resolving specifiers against
+ * this workspace's real `packages/` tree — the surfaces under test are the
+ * actual ones, not a fixture that could drift away from them.
+ */
+let fixtureCount = 0
+async function auditSnippet(...lines: string[]): Promise<DocsImportReport> {
+  const dir = join(scratch, `case-${(fixtureCount += 1)}`)
+  await rm(dir, { recursive: true, force: true })
+  await import('node:fs/promises').then((fs) => fs.mkdir(dir, { recursive: true }))
+  await writeFile(join(dir, 'snippet.md'), `${['```ts', ...lines, '```'].join('\n')}\n`)
+  return auditDocsImportSources(repoRoot, dir)
+}
+
+describe('the premises the gate encodes', () => {
+  test('@guren/core reaches @guren/server wholesale but @guren/orm by allowlist', async () => {
+    // The whole point of deriving the surface from the entry point rather than
+    // from globbed files. If core ever re-exported ORM wholesale, the
+    // interesting half of this check would quietly stop being interesting.
+    const barrel = await readFile(join(repoRoot, 'packages', 'core', 'src', 'index.ts'), 'utf8')
+
+    expect(barrel).toContain("export * from '@guren/server'")
+    expect(barrel).not.toContain("export * from '@guren/orm'")
+  })
+
+  test('every declared @guren/* TypeScript entry point resolves to a source file', async () => {
+    // A subpath whose source cannot be found breaks the derivation rule, so it
+    // fails the gate on its own. That is the intended behaviour, but it must
+    // not be the state of the workspace on an ordinary day.
+    const entryPoints = [...(await collectEntryPoints(repoRoot)).values()]
+
+    expect(entryPoints.filter((entry) => entry.kind === 'unresolved')).toEqual([])
+    // The two known non-modules: a stylesheet and a manifest.
+    expect(
+      entryPoints
+        .filter((entry) => entry.kind === 'asset')
+        .map((entry) => entry.specifier)
+        .sort(),
+    ).toEqual(['@guren/inertia-client/package.json', '@guren/plugin-markdown/styles.css'])
+  })
+})
+
+describe('extraction', () => {
+  test('reads an import out of a fence no parser can read', () => {
+    // The design's central claim. This fragment is what 67 of the repo's 1286
+    // TypeScript fences look like: a class body with no class. @babel/parser
+    // fails on it even with errorRecovery, and an AST-only scanner therefore
+    // reports zero imports for the whole fence.
+    const fragment = ['  async store() {', '    // ...', '  }', "import { Controller } from '@guren/core'"].join('\n')
+
+    expect(extractImports(fragment).map((entry) => entry.specifier)).toEqual(['@guren/core'])
+  })
+
+  test('reads a multi-line named import list and a bare side-effect import', () => {
+    const code = [
+      'import {',
+      '  Controller,',
+      '  Router,',
+      "} from '@guren/core'",
+      "import '@guren/plugin-markdown/styles.css'",
+    ].join('\n')
+
+    expect(extractImports(code).map((entry) => entry.specifier)).toEqual([
+      '@guren/core',
+      '@guren/plugin-markdown/styles.css',
+    ])
+  })
+
+  test('only TypeScript fences are scanned', () => {
+    const markdown = ['```bash', "import { X } from '@guren/core'", '```', '', '```ts', 'const a = 1', '```'].join('\n')
+
+    expect(typescriptFences(markdown)).toHaveLength(1)
+  })
+})
+
+describe('a symbol the specifier does not export', () => {
+  test('passes an import of a symbol the entry point really exports', async () => {
+    const report = await auditSnippet("import { Controller, Router } from '@guren/core'")
+
+    expect(report.unexported).toEqual([])
+    expect(report.unresolvable).toEqual([])
+    expect(report.symbolsChecked).toBe(2)
+  })
+
+  test('fails a symbol imported from the wrong first-party package, and names the right one', async () => {
+    // The exact line that shipped in docs/en/guides/agent-interface.md:
+    // AgentApprovalRequested is genuinely re-exported from core; mcpPlugin
+    // only ever came from @guren/plugin-mcp.
+    const report = await auditSnippet("import { AgentApprovalRequested, mcpPlugin } from '@guren/core'")
+
+    expect(report.unexported).toHaveLength(1)
+    const [finding] = report.unexported
+    expect(finding?.symbol).toBe('mcpPlugin')
+    expect(finding?.specifier).toBe('@guren/core')
+    expect(finding?.exportedBy).toEqual(['@guren/plugin-mcp'])
+    expect(formatReport(report)).toContain('exported by @guren/plugin-mcp')
+  })
+
+  test('says so plainly when no first-party package exports the symbol at all', async () => {
+    const report = await auditSnippet("import { NotARealExport } from '@guren/core'")
+
+    expect(report.unexported).toHaveLength(1)
+    expect(report.unexported[0]?.exportedBy).toEqual([])
+    expect(formatReport(report)).toContain('no first-party entry point exports it')
+  })
+
+  test('reports the file and line of the offending import', async () => {
+    const report = await auditSnippet('const a = 1', '', "import { NotARealExport } from '@guren/core'")
+
+    // fence opens on line 1, so its third content line is line 4.
+    expect(report.unexported[0]?.location).toMatch(/snippet\.md:4$/u)
+  })
+})
+
+describe('type-only imports', () => {
+  // Decision 3: type and value exports share one set and `import type` is not
+  // distinguished. Absent from the merged set means absent from both spaces,
+  // which is a sound compile-error verdict; the finer claim needs a type
+  // checker this gate does not run.
+  test('checks a type-only import exactly like a value import', async () => {
+    const report = await auditSnippet("import type { NotARealType } from '@guren/core'")
+
+    expect(report.unexported).toHaveLength(1)
+    expect(report.unexported[0]?.symbol).toBe('NotARealType')
+  })
+
+  test('accepts a name that core exports only as a type', async () => {
+    // PostgresDatabase reaches core through `export type { … } from '@guren/orm'`.
+    const report = await auditSnippet("import type { PostgresDatabase } from '@guren/core'")
+
+    expect(report.unexported).toEqual([])
+  })
+
+  test('checks both halves of a mixed inline-type import', async () => {
+    const report = await auditSnippet("import { type Controller, NotARealExport } from '@guren/core'")
+
+    expect(report.unexported.map((finding) => finding.symbol)).toEqual(['NotARealExport'])
+    expect(report.symbolsChecked).toBe(2)
+  })
+})
+
+describe('specifiers the gate cannot resolve', () => {
+  // Decision 4: an unavailable check is not a green one.
+  test('fails an unknown first-party package rather than skipping it', async () => {
+    const report = await auditSnippet("import { anything } from '@guren/not-a-package'")
+
+    expect(report.unexported).toEqual([])
+    expect(report.unresolvable).toHaveLength(1)
+    expect(report.unresolvable[0]?.reason).toContain('no such first-party package')
+  })
+
+  test('fails a subpath the exports map does not declare', async () => {
+    const report = await auditSnippet("import { anything } from '@guren/core/not-a-subpath'")
+
+    expect(report.unresolvable).toHaveLength(1)
+    expect(report.unresolvable[0]?.reason).toContain('exports map')
+  })
+
+  test('fails a named import from a non-module asset entry point', async () => {
+    const report = await auditSnippet("import { theme } from '@guren/plugin-markdown/styles.css'")
+
+    expect(report.unresolvable).toHaveLength(1)
+    expect(report.unresolvable[0]?.reason).toContain('static asset')
+  })
+
+  test('leaves a third-party specifier alone', async () => {
+    const report = await auditSnippet("import { z } from 'zod'", "import React from 'react'")
+
+    expect(report.unresolvable).toEqual([])
+    expect(report.importsChecked).toBe(0)
+  })
+})
+
+describe('entry points whose surface is open', () => {
+  test('issues no absence verdict for a wholesale third-party re-export, and names it', async () => {
+    // @guren/orm/drizzle/pg is `export * from 'drizzle-orm/pg-core'`. pgTable
+    // is a drizzle name this gate cannot enumerate, so claiming it absent
+    // would be unsound — and 10 docs snippets import from here.
+    const report = await auditSnippet("import { pgTable, sql } from '@guren/orm/drizzle/pg'")
+
+    expect(report.unexported).toEqual([])
+    expect(report.openEntryPoints).toContain("@guren/orm/drizzle/pg (re-exports 'drizzle-orm/pg-core')")
+  })
+})
+
+describe('the docs tree as committed', () => {
+  test('every named first-party import in docs/ resolves to a real export', async () => {
+    const report = await auditDocsImportSources(repoRoot)
+
+    expect(formatReport(report)).toBe('')
+    // Guard against the sweep going vacuous: a refactor that stopped finding
+    // fences would otherwise report a clean pass over nothing.
+    expect(report.symbolsChecked).toBeGreaterThan(500)
+  })
+})

--- a/scripts/smoke/docs-import-sources.ts
+++ b/scripts/smoke/docs-import-sources.ts
@@ -61,15 +61,20 @@
  *    check is not a green one, the rule `plugin-compat-audit.ts` already
  *    carries.
  *
- *    Three entry points are a genuinely different case. `@guren/orm/drizzle/pg`
+ *    A few *subpaths* are a genuinely different case. `@guren/orm/drizzle/pg`
  *    (and `/mysql`, `/sqlite`) do `export * from 'drizzle-orm/*-core'`, and the
- *    jsx runtimes do the same from `hono`, so their surfaces are *open*:
+ *    four jsx runtimes do the same from `hono`, so their surfaces are *open*:
  *    absence cannot be proven from first-party source, and every "not exported"
  *    verdict there would be unsound. No verdict is issued for an open entry
  *    point — but `openEntryPoints` names each one on every run, so "not
  *    checked" is on the record instead of being inferred from silence. Their
  *    known names still feed the reverse index; being unable to prove absence
- *    does not make presence unknown.
+ *    does not make presence unknown. A package *root* going open is not in
+ *    that category at all — `docs-audit.ts` fails on one, because most
+ *    snippets import from a root and exempting one turns the audit off. The
+ *    set is derived on every run rather than listed here, so this paragraph
+ *    cannot go stale about which entry points are open; the test pins the
+ *    count so it cannot grow unnoticed.
  *
  * A finding names the file, line, symbol, specifier, and which first-party
  * entry points *do* export the symbol — the part that makes it actionable.
@@ -121,7 +126,11 @@ const FIRST_PARTY_SCOPE = '@guren/'
  */
 const FENCE = /^([ \t]*)```([^\n`]*)\n([\s\S]*?)^\1```[ \t]*$/gm
 
-const TYPESCRIPT_FENCE = /^(ts|tsx|typescript)\b/
+// `js`/`jsx` too, though `docs/` has none today. A JavaScript snippet
+// importing from `@guren/*` is exactly as able to name something that is not
+// exported, and a filter that admitted only the tags in use would leave the
+// first such snippet unchecked with nothing to notice it.
+const TYPESCRIPT_FENCE = /^(ts|tsx|typescript|js|jsx|javascript)\b/
 
 /**
  * An import statement, from the leading keyword through the closing quote of

--- a/scripts/smoke/docs-import-sources.ts
+++ b/scripts/smoke/docs-import-sources.ts
@@ -1,0 +1,702 @@
+/**
+ * Prove that every named import in a docs snippet names a symbol its specifier
+ * actually exports.
+ *
+ * The gap this closes shipped: `docs/en/guides/agent-interface.md` and its
+ * Japanese twin carried
+ *
+ *   import { AgentApprovalRequested, mcpPlugin } from '@guren/core'
+ *
+ * `AgentApprovalRequested` is genuinely re-exported from `@guren/core`.
+ * `mcpPlugin` is exported from `@guren/plugin-mcp` and never has been from
+ * core. A reader copy-pasting that line gets a compile error, and `audit:docs`
+ * was green on both sides of the fix because nothing in it read an import.
+ *
+ * Four decisions, each of which had a cheaper wrong answer.
+ *
+ * 1. IMPORT EXTRACTION IS TEXTUAL, AND EACH STATEMENT IS PARSED IN ISOLATION.
+ *    Reading fences with a parser is the obvious design and it silently skips
+ *    the files that need reading most: 67 of the 1286 TypeScript fences under
+ *    `docs/` are deliberate fragments (a class body without its class, `// ...`
+ *    standing in for a method) that @babel/parser cannot parse even with
+ *    `errorRecovery`, and in those the AST reports *zero* imports while real
+ *    `@guren/core` imports sit in the text. An AST-only reader passes those
+ *    files by never having read them.
+ *
+ *    So imports are found textually and each candidate is then parsed alone —
+ *    a lone import statement always parses, whatever surrounds it. The scan is
+ *    kept honest by `crossCheckExtraction()`: on every fence that *does* parse
+ *    cleanly the AST's import list must equal the textual one. That agreement
+ *    holds exactly today (1219/1219), and re-asserting it each run is what
+ *    stops the extractor going quietly blind on an import shape nobody
+ *    anticipated — the failure is a gate error, not a shrug.
+ *
+ * 2. THE EXPORT SURFACE COMES FROM THE ENTRY POINT, TRANSITIVELY — NEVER FROM
+ *    GLOBBED IMPLEMENTATION FILES. A symbol that exists in a file but is not
+ *    re-exported is not exported, and one re-exported under a different name
+ *    would be missed entirely. `packages/core/src/index.ts` is the standing
+ *    proof: ORM names reach core through an explicit allowlist, so `src/`
+ *    membership and export membership differ there *by design*. This repo has
+ *    already been bitten by an allowlist built from implementation files
+ *    rather than from the export surface.
+ *
+ *    A package's `exports` map names the entry point; `./dist/X.js` maps back
+ *    to `src/X.ts` | `src/X.tsx` | `src/X/index.ts`, and `export *` /
+ *    `export { … } from` are followed through relative files and on into
+ *    sibling `@guren/*` entry points.
+ *
+ * 3. TYPE AND VALUE EXPORTS GO IN ONE SET; `import type` IS NOT DISTINGUISHED.
+ *    A name absent from the merged set is absent from both spaces, so the
+ *    snippet cannot compile however it is imported — that verdict is sound
+ *    without a type checker. The converse claim ("this is a value, not a
+ *    type") is not sound without one, and separating the spaces would demand
+ *    resolving whether each `export { X } from './y'` re-exports a type — so
+ *    this gate does not make that claim. It answers "does this name exist on
+ *    this entry point", nothing finer.
+ *
+ * 4. UNRESOLVABLE FAILS. UNKNOWABLE IS REPORTED, NEVER SKIPPED. An unknown
+ *    `@guren/*` package, a subpath absent from the `exports` map (Node blocks
+ *    those at runtime), an entry point whose source cannot be found, or a
+ *    re-export target that does not resolve are all failures: an unavailable
+ *    check is not a green one, the rule `plugin-compat-audit.ts` already
+ *    carries.
+ *
+ *    Three entry points are a genuinely different case. `@guren/orm/drizzle/pg`
+ *    (and `/mysql`, `/sqlite`) do `export * from 'drizzle-orm/*-core'`, and the
+ *    jsx runtimes do the same from `hono`, so their surfaces are *open*:
+ *    absence cannot be proven from first-party source, and every "not exported"
+ *    verdict there would be unsound. No verdict is issued for an open entry
+ *    point — but `openEntryPoints` names each one on every run, so "not
+ *    checked" is on the record instead of being inferred from silence. Their
+ *    known names still feed the reverse index; being unable to prove absence
+ *    does not make presence unknown.
+ *
+ * A finding names the file, line, symbol, specifier, and which first-party
+ * entry points *do* export the symbol — the part that makes it actionable.
+ * When the only exporters are `@guren/server` or one of its subpaths, the
+ * finding says so explicitly: swapping the specifier there would trade this
+ * failure for an `audit:core-first` failure, and the real fix is either
+ * widening core's barrel or documenting a different API.
+ *
+ * No top-level side effects — `docs-audit.ts` drives it, and the tests import
+ * it directly.
+ */
+import { readdir, readFile, stat } from 'node:fs/promises'
+import { join, relative, dirname, resolve } from 'node:path'
+import { parse } from '@babel/parser'
+import type { Statement } from '@babel/types'
+
+/** A docs snippet imports a name its specifier does not export. */
+export interface UnexportedSymbol {
+  readonly location: string
+  readonly symbol: string
+  readonly specifier: string
+  /** First-party entry points that do export this symbol, canonical order. */
+  readonly exportedBy: readonly string[]
+}
+
+/** The gate could not reason about something. Never a silent pass. */
+export interface UnresolvableImport {
+  readonly location: string
+  readonly specifier: string
+  readonly reason: string
+}
+
+export interface DocsImportReport {
+  readonly unexported: readonly UnexportedSymbol[]
+  readonly unresolvable: readonly UnresolvableImport[]
+  /** Entry points whose surface re-exports a third-party package wholesale. */
+  readonly openEntryPoints: readonly string[]
+  readonly fencesScanned: number
+  readonly importsChecked: number
+  readonly symbolsChecked: number
+}
+
+const FIRST_PARTY_SCOPE = '@guren/'
+
+/**
+ * A fenced block and the 1-based line its content starts on. The backreference
+ * pins the closing fence to the opening fence's indentation, so a nested fence
+ * inside an indented block does not close its parent early.
+ */
+const FENCE = /^([ \t]*)```([^\n`]*)\n([\s\S]*?)^\1```[ \t]*$/gm
+
+const TYPESCRIPT_FENCE = /^(ts|tsx|typescript)\b/
+
+/**
+ * An import statement, from the leading keyword through the closing quote of
+ * its specifier. `from` is optional so a side-effect `import 'x'` is seen too —
+ * it carries no named imports, but the cross-check in `crossCheckExtraction()`
+ * compares whole import lists and would otherwise report a phantom mismatch.
+ * Excluding `;` and a backtick from the span keeps a match from running past
+ * the end of its own statement.
+ */
+const IMPORT_STATEMENT = /^[ \t]*import\b(?:[^;`]*?from)?[ \t]*(['"])([^'"\n]+)\1/gm
+
+interface EntryPoint {
+  readonly specifier: string
+  readonly packageDir: string
+  /**
+   * `module` carries a source path. `asset` is a declared non-module target
+   * (a stylesheet, a manifest) — importable for its side effect, never for a
+   * name. `unresolved` is the failure: the exports map declares a `dist/`
+   * target whose source this gate cannot find, which breaks the derivation
+   * rule itself and is reported even when no doc imports it. Collapsing the
+   * last two would report a renamed source as "that's a stylesheet".
+   */
+  readonly kind: 'module' | 'asset' | 'unresolved'
+  readonly sourceFile: string | null
+  readonly target: string
+}
+
+interface Surface {
+  readonly names: ReadonlySet<string>
+  /** Set when the surface re-exports a package this gate cannot enumerate. */
+  readonly openedBy: string | null
+}
+
+async function isFile(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isFile()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * `./dist/X.js` and `./dist/X/index.js` both come from `src/`; tsdown's output
+ * layout mirrors the source tree, so undoing it is a path rewrite rather than a
+ * build-config read.
+ */
+async function sourceForDistTarget(packageDir: string, target: string): Promise<string | null> {
+  if (!target.startsWith('./dist/')) {
+    return null
+  }
+  const stem = target.slice('./dist/'.length).replace(/\.d\.ts$|\.js$/u, '')
+  for (const candidate of [`src/${stem}.ts`, `src/${stem}.tsx`, `src/${stem}/index.ts`]) {
+    const absolute = join(packageDir, candidate)
+    if (await isFile(absolute)) {
+      return absolute
+    }
+  }
+  return null
+}
+
+/**
+ * Every `@guren/*` entry point this workspace publishes, keyed by the
+ * specifier a snippet would write. Derived from the `exports` maps, so a new
+ * subpath is covered the moment it is declared.
+ */
+export async function collectEntryPoints(root: string): Promise<Map<string, EntryPoint>> {
+  const entryPoints = new Map<string, EntryPoint>()
+  const packageDirs = await readdir(join(root, 'packages'), { withFileTypes: true })
+
+  for (const dir of packageDirs) {
+    if (!dir.isDirectory()) {
+      continue
+    }
+    const packageDir = join(root, 'packages', dir.name)
+    const manifestPath = join(packageDir, 'package.json')
+    if (!(await isFile(manifestPath))) {
+      continue
+    }
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as {
+      name?: string
+      exports?: Record<string, string | Record<string, string>>
+    }
+    const name = manifest.name
+    if (!name?.startsWith(FIRST_PARTY_SCOPE) || !manifest.exports) {
+      continue
+    }
+
+    for (const [subpath, target] of Object.entries(manifest.exports)) {
+      const specifier = subpath === '.' ? name : `${name}${subpath.slice(1)}`
+      // `./bin` declares only `default`; every other subpath carries `types`.
+      const resolvedTarget = typeof target === 'string' ? target : (target.types ?? target.default)
+      if (typeof resolvedTarget !== 'string') {
+        entryPoints.set(specifier, { specifier, packageDir, kind: 'unresolved', sourceFile: null, target: JSON.stringify(target) })
+        continue
+      }
+      // `./styles.css` and `./package.json` are assets, not modules. A named
+      // import from one is an error; a side-effect import is fine, and only
+      // named imports are checked.
+      if (!resolvedTarget.startsWith('./dist/')) {
+        entryPoints.set(specifier, { specifier, packageDir, kind: 'asset', sourceFile: null, target: resolvedTarget })
+        continue
+      }
+      const sourceFile = await sourceForDistTarget(packageDir, resolvedTarget)
+      entryPoints.set(specifier, {
+        specifier,
+        packageDir,
+        kind: sourceFile ? 'module' : 'unresolved',
+        sourceFile,
+        target: resolvedTarget,
+      })
+    }
+  }
+
+  return entryPoints
+}
+
+function parseModule(source: string, path: string): Statement[] {
+  try {
+    return parse(source, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx', 'decorators-legacy', 'explicitResourceManagement'],
+    }).program.body
+  } catch (error) {
+    throw new Error(`Cannot parse ${path}: ${(error as Error).message}`)
+  }
+}
+
+/** Names bound by a declaration that carries `export`. */
+function declaredNames(statement: Statement): string[] {
+  if (statement.type !== 'ExportNamedDeclaration' || !statement.declaration) {
+    return []
+  }
+  const declaration = statement.declaration
+  if (declaration.type === 'VariableDeclaration') {
+    return declaration.declarations.flatMap((entry) =>
+      entry.id.type === 'Identifier' ? [entry.id.name] : [],
+    )
+  }
+  if (
+    declaration.type === 'FunctionDeclaration' ||
+    declaration.type === 'ClassDeclaration' ||
+    declaration.type === 'TSDeclareFunction' ||
+    declaration.type === 'TSInterfaceDeclaration' ||
+    declaration.type === 'TSTypeAliasDeclaration' ||
+    declaration.type === 'TSEnumDeclaration' ||
+    declaration.type === 'TSModuleDeclaration'
+  ) {
+    const id = declaration.id
+    return id && id.type === 'Identifier' ? [id.name] : []
+  }
+  return []
+}
+
+/**
+ * Resolve a relative re-export target to a source file. Sources are written
+ * with `.js` extensions (`./attachments/index.js`) that resolve to `.ts`.
+ */
+async function resolveRelative(fromFile: string, specifier: string): Promise<string | null> {
+  const base = resolve(dirname(fromFile), specifier).replace(/\.js$/u, '')
+  for (const candidate of [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts')]) {
+    if (await isFile(candidate)) {
+      return candidate
+    }
+  }
+  return null
+}
+
+class SurfaceResolver {
+  private readonly fileCache = new Map<string, Surface>()
+  private readonly entryCache = new Map<string, Surface>()
+  private readonly visiting = new Set<string>()
+
+  constructor(private readonly entryPoints: Map<string, EntryPoint>) {}
+
+  /**
+   * The export surface of a first-party entry point, or null when the
+   * specifier is not one. Throws when a declared entry point cannot be read —
+   * a surface this gate cannot derive is a gate failure, not an empty set.
+   */
+  async forSpecifier(specifier: string): Promise<Surface | null> {
+    const entryPoint = this.entryPoints.get(specifier)
+    if (!entryPoint) {
+      return null
+    }
+    const cached = this.entryCache.get(specifier)
+    if (cached) {
+      return cached
+    }
+    if (entryPoint.kind === 'asset' || !entryPoint.sourceFile) {
+      throw new Error(
+        entryPoint.kind === 'asset'
+          ? `${specifier} resolves to '${entryPoint.target}', a static asset rather than a TypeScript module — it has no named exports`
+          : `${specifier} declares '${entryPoint.target}' in its exports map, but no matching source exists under src/`,
+      )
+    }
+    const surface = await this.forFile(entryPoint.sourceFile)
+    this.entryCache.set(specifier, surface)
+    return surface
+  }
+
+  private async forFile(file: string): Promise<Surface> {
+    const cached = this.fileCache.get(file)
+    if (cached) {
+      return cached
+    }
+    // A re-export cycle contributes no names of its own; the outer frame that
+    // is still resolving the file will supply them.
+    if (this.visiting.has(file)) {
+      return { names: new Set(), openedBy: null }
+    }
+    this.visiting.add(file)
+    try {
+      const surface = await this.readFile(file)
+      this.fileCache.set(file, surface)
+      return surface
+    } finally {
+      this.visiting.delete(file)
+    }
+  }
+
+  private async readFile(file: string): Promise<Surface> {
+    const body = parseModule(await readFile(file, 'utf8'), file)
+    const names = new Set<string>()
+    let openedBy: string | null = null
+
+    const absorb = async (target: string, statementLabel: string): Promise<void> => {
+      if (target.startsWith('.')) {
+        const resolved = await resolveRelative(file, target)
+        if (!resolved) {
+          throw new Error(`${file}: ${statementLabel} targets '${target}', which does not resolve to a source file`)
+        }
+        const inner = await this.forFile(resolved)
+        for (const name of inner.names) {
+          names.add(name)
+        }
+        openedBy ??= inner.openedBy
+        return
+      }
+      if (target.startsWith(FIRST_PARTY_SCOPE)) {
+        const inner = await this.forSpecifier(target)
+        if (!inner) {
+          throw new Error(`${file}: ${statementLabel} targets '${target}', which is not a declared entry point`)
+        }
+        for (const name of inner.names) {
+          names.add(name)
+        }
+        openedBy ??= inner.openedBy
+        return
+      }
+      // A third-party wholesale re-export. The names cannot be enumerated from
+      // first-party source, so absence stops being provable here.
+      openedBy ??= target
+    }
+
+    for (const statement of body) {
+      if (statement.type === 'ExportDefaultDeclaration') {
+        names.add('default')
+        continue
+      }
+      if (statement.type === 'ExportAllDeclaration') {
+        await absorb(statement.source.value, `export * from '${statement.source.value}'`)
+        continue
+      }
+      if (statement.type !== 'ExportNamedDeclaration') {
+        continue
+      }
+      for (const name of declaredNames(statement)) {
+        names.add(name)
+      }
+      for (const specifier of statement.specifiers) {
+        // `export { a as b }`, `export { a as 'b' }`, `export * as ns from`.
+        if (specifier.type === 'ExportSpecifier' || specifier.type === 'ExportNamespaceSpecifier') {
+          const exported = specifier.exported
+          names.add(exported.type === 'Identifier' ? exported.name : exported.value)
+        } else if (specifier.type === 'ExportDefaultSpecifier') {
+          names.add(specifier.exported.name)
+        }
+      }
+    }
+
+    return { names, openedBy }
+  }
+}
+
+interface ExtractedImport {
+  readonly specifier: string
+  readonly statement: string
+  readonly line: number
+}
+
+function lineOf(source: string, index: number): number {
+  let line = 1
+  for (let i = 0; i < index; i += 1) {
+    if (source[i] === '\n') {
+      line += 1
+    }
+  }
+  return line
+}
+
+/** Every TypeScript fence in a markdown file, with its starting line. */
+export function typescriptFences(markdown: string): { code: string; line: number }[] {
+  const fences: { code: string; line: number }[] = []
+  FENCE.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = FENCE.exec(markdown))) {
+    if (!TYPESCRIPT_FENCE.test((match[2] ?? '').trim())) {
+      continue
+    }
+    // +1: the fence's content begins on the line after the opening ```.
+    fences.push({ code: match[3] ?? '', line: lineOf(markdown, match.index) + 1 })
+  }
+  return fences
+}
+
+export function extractImports(code: string): ExtractedImport[] {
+  const imports: ExtractedImport[] = []
+  IMPORT_STATEMENT.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = IMPORT_STATEMENT.exec(code))) {
+    imports.push({
+      specifier: match[2] ?? '',
+      statement: match[0],
+      line: lineOf(code, match.index),
+    })
+  }
+  return imports
+}
+
+/**
+ * The textual scan is only trustworthy while it agrees with a parser wherever
+ * a parser can run. On a fence that parses with no recovered errors the AST's
+ * import list is authoritative; a disagreement means the extractor is blind to
+ * an import shape, which is a gate failure rather than a missing finding.
+ */
+function crossCheckExtraction(code: string, extracted: readonly ExtractedImport[]): string | null {
+  let body: Statement[]
+  try {
+    const result = parse(code, {
+      sourceType: 'module',
+      errorRecovery: true,
+      plugins: ['typescript', 'jsx', 'decorators-legacy', 'explicitResourceManagement'],
+      allowReturnOutsideFunction: true,
+      allowAwaitOutsideFunction: true,
+      allowSuperOutsideMethod: true,
+      allowUndeclaredExports: true,
+    })
+    // `errors` is nullable in the type; a null one is not evidence of a clean
+    // parse, so treat it the same as a recovered error and stand down.
+    if (result.errors === null || result.errors.length > 0) {
+      return null
+    }
+    body = result.program.body
+  } catch {
+    return null
+  }
+
+  const fromAst = body.flatMap((statement) =>
+    statement.type === 'ImportDeclaration' ? [statement.source.value] : [],
+  )
+  const fromText = extracted.map((entry) => entry.specifier)
+  if (fromAst.join('\n') === fromText.join('\n')) {
+    return null
+  }
+  return `the textual import scan read [${fromText.join(', ')}] where the parser read [${fromAst.join(', ')}]`
+}
+
+/** Named bindings an import statement pulls in. Namespace imports bind none. */
+function importedNames(statement: string): string[] {
+  const body = parseModule(statement, 'an import statement in a docs snippet')
+  const names: string[] = []
+  for (const node of body) {
+    if (node.type !== 'ImportDeclaration') {
+      continue
+    }
+    for (const specifier of node.specifiers) {
+      if (specifier.type === 'ImportSpecifier') {
+        const imported = specifier.imported
+        names.push(imported.type === 'Identifier' ? imported.name : imported.value)
+      } else if (specifier.type === 'ImportDefaultSpecifier') {
+        names.push('default')
+      }
+    }
+  }
+  return names
+}
+
+/**
+ * Canonical order for "which package does export this": `@guren/core` is the
+ * documented path, so it leads when it qualifies; the rest sort by specifier
+ * length then alphabetically, which puts a root entry ahead of its subpaths.
+ */
+function orderExporters(specifiers: string[]): string[] {
+  return [...specifiers].sort((a, b) => {
+    if (a === '@guren/core') return -1
+    if (b === '@guren/core') return 1
+    return a.length - b.length || a.localeCompare(b)
+  })
+}
+
+async function markdownFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { recursive: true, withFileTypes: true })
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+    .map((entry) => join(entry.parentPath, entry.name))
+    .sort()
+}
+
+export async function auditDocsImportSources(root: string, docsDir = 'docs'): Promise<DocsImportReport> {
+  const entryPoints = await collectEntryPoints(root)
+  const resolver = new SurfaceResolver(entryPoints)
+
+  // Reverse index: symbol -> the entry points that export it. Built over every
+  // first-party entry point including the plugins, which is the only reason
+  // `mcpPlugin` can be traced back to `@guren/plugin-mcp`.
+  const exportedFrom = new Map<string, string[]>()
+  const openEntryPoints: string[] = []
+  const unresolvable: UnresolvableImport[] = []
+
+  for (const specifier of [...entryPoints.keys()].sort()) {
+    const entryPoint = entryPoints.get(specifier)
+    if (!entryPoint || entryPoint.kind === 'asset') {
+      continue
+    }
+    // A declared entry point whose source cannot be found breaks the rule this
+    // gate derives every surface with, so it fails on its own account — waiting
+    // for a doc to import it would leave the derivation quietly half-blind.
+    if (entryPoint.kind === 'unresolved') {
+      unresolvable.push({
+        location: relative(root, join(entryPoint.packageDir, 'package.json')),
+        specifier,
+        reason: `exports map declares '${entryPoint.target}', but no matching source exists under src/ — the export surface cannot be derived`,
+      })
+      continue
+    }
+    const surface = await resolver.forSpecifier(specifier)
+    if (!surface) {
+      continue
+    }
+    if (surface.openedBy) {
+      openEntryPoints.push(`${specifier} (re-exports '${surface.openedBy}')`)
+    }
+    for (const name of surface.names) {
+      const owners = exportedFrom.get(name)
+      if (owners) {
+        owners.push(specifier)
+      } else {
+        exportedFrom.set(name, [specifier])
+      }
+    }
+  }
+
+  const unexported: UnexportedSymbol[] = []
+  let fencesScanned = 0
+  let importsChecked = 0
+  let symbolsChecked = 0
+
+  // `resolve` rather than `join` so a caller may hand over an absolute tree.
+  for (const file of await markdownFiles(resolve(root, docsDir))) {
+    const markdown = await readFile(file, 'utf8')
+    // Repo-relative for the real tree; a docs dir outside the root (tests hand
+    // over a temp one) keeps its absolute path rather than a run of `../`.
+    const fromRoot = relative(root, file)
+    const displayPath = fromRoot.startsWith('..') ? file : fromRoot
+
+    for (const fence of typescriptFences(markdown)) {
+      fencesScanned += 1
+      const extracted = extractImports(fence.code)
+
+      const drift = crossCheckExtraction(fence.code, extracted)
+      if (drift) {
+        unresolvable.push({
+          location: `${displayPath}:${fence.line}`,
+          specifier: '(fence)',
+          reason: `import extraction disagrees with the parser — ${drift}`,
+        })
+      }
+
+      for (const entry of extracted) {
+        if (!entry.specifier.startsWith(FIRST_PARTY_SCOPE)) {
+          continue
+        }
+        const location = `${displayPath}:${fence.line + entry.line - 1}`
+        importsChecked += 1
+
+        let names: string[]
+        try {
+          names = importedNames(entry.statement)
+        } catch (error) {
+          unresolvable.push({
+            location,
+            specifier: entry.specifier,
+            reason: `import statement does not parse: ${(error as Error).message}`,
+          })
+          continue
+        }
+        if (names.length === 0) {
+          continue
+        }
+
+        let surface: Surface | null
+        try {
+          surface = await resolver.forSpecifier(entry.specifier)
+        } catch (error) {
+          unresolvable.push({ location, specifier: entry.specifier, reason: (error as Error).message })
+          continue
+        }
+        if (!surface) {
+          unresolvable.push({
+            location,
+            specifier: entry.specifier,
+            reason: entryPoints.has(entry.specifier.split('/').slice(0, 2).join('/'))
+              ? 'no such subpath in the package\'s exports map — Node would refuse this import'
+              : 'no such first-party package in this workspace',
+          })
+          continue
+        }
+        // An open surface cannot prove absence; `openEntryPoints` reports it.
+        if (surface.openedBy) {
+          continue
+        }
+
+        for (const name of names) {
+          symbolsChecked += 1
+          if (surface.names.has(name)) {
+            continue
+          }
+          unexported.push({
+            location,
+            symbol: name,
+            specifier: entry.specifier,
+            exportedBy: orderExporters(exportedFrom.get(name) ?? []),
+          })
+        }
+      }
+    }
+  }
+
+  return {
+    unexported,
+    unresolvable,
+    openEntryPoints,
+    fencesScanned,
+    importsChecked,
+    symbolsChecked,
+  }
+}
+
+export function formatReport(report: DocsImportReport): string {
+  const lines: string[] = []
+
+  if (report.unresolvable.length > 0) {
+    lines.push('Docs import audit could not resolve:')
+    for (const item of report.unresolvable) {
+      lines.push(`- ${item.location}: '${item.specifier}' — ${item.reason}`)
+    }
+    lines.push('')
+  }
+
+  if (report.unexported.length > 0) {
+    lines.push('Docs import audit found imports of symbols their specifier does not export:')
+    for (const item of report.unexported) {
+      const owners = item.exportedBy
+      let hint: string
+      if (owners.length === 0) {
+        hint = 'no first-party entry point exports it — the symbol does not exist yet, or the name is wrong'
+      } else if (owners.every((owner) => owner.startsWith('@guren/server'))) {
+        // Swapping the specifier here trades this failure for a core-first one.
+        hint = `only ${owners.join(', ')} exports it, which docs may not name (audit:core-first) — widen @guren/core's barrel or document a different API`
+      } else {
+        hint = `exported by ${owners.join(', ')}`
+      }
+      lines.push(`- ${item.location}: \`${item.symbol}\` is not exported by '${item.specifier}' — ${hint}`)
+    }
+  }
+
+  return lines.join('\n')
+}

--- a/scripts/smoke/docs-import-sources.ts
+++ b/scripts/smoke/docs-import-sources.ts
@@ -120,6 +120,14 @@ export interface DocsImportReport {
 const FIRST_PARTY_SCOPE = '@guren/'
 
 /**
+ * One plugin list for both parses. `crossCheckExtraction()` compares the
+ * textual scan against a parse of the same fence, so a list that drifted
+ * between the two would report the *parser* disagreeing with itself as
+ * extractor blindness — a gate failure whose message names the wrong cause.
+ */
+const BABEL_PLUGINS = ['typescript', 'jsx', 'decorators-legacy', 'explicitResourceManagement'] as const
+
+/**
  * A fenced block and the 1-based line its content starts on. The backreference
  * pins the closing fence to the opening fence's indentation, so a nested fence
  * inside an indented block does not close its parent early.
@@ -173,6 +181,20 @@ async function isFile(path: string): Promise<boolean> {
 }
 
 /**
+ * The source file an extensionless base path stands for. Both callers below
+ * arrive at a base and then face the same three spellings TypeScript allows
+ * for it.
+ */
+async function firstExistingSource(base: string): Promise<string | null> {
+  for (const candidate of [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts')]) {
+    if (await isFile(candidate)) {
+      return candidate
+    }
+  }
+  return null
+}
+
+/**
  * `./dist/X.js` and `./dist/X/index.js` both come from `src/`; tsdown's output
  * layout mirrors the source tree, so undoing it is a path rewrite rather than a
  * build-config read.
@@ -182,13 +204,7 @@ async function sourceForDistTarget(packageDir: string, target: string): Promise<
     return null
   }
   const stem = target.slice('./dist/'.length).replace(/\.d\.ts$|\.js$/u, '')
-  for (const candidate of [`src/${stem}.ts`, `src/${stem}.tsx`, `src/${stem}/index.ts`]) {
-    const absolute = join(packageDir, candidate)
-    if (await isFile(absolute)) {
-      return absolute
-    }
-  }
-  return null
+  return firstExistingSource(join(packageDir, 'src', stem))
 }
 
 /**
@@ -251,7 +267,7 @@ function parseModule(source: string, path: string): Statement[] {
   try {
     return parse(source, {
       sourceType: 'module',
-      plugins: ['typescript', 'jsx', 'decorators-legacy', 'explicitResourceManagement'],
+      plugins: [...BABEL_PLUGINS],
     }).program.body
   } catch (error) {
     throw new Error(`Cannot parse ${path}: ${(error as Error).message}`)
@@ -289,13 +305,7 @@ function declaredNames(statement: Statement): string[] {
  * with `.js` extensions (`./attachments/index.js`) that resolve to `.ts`.
  */
 async function resolveRelative(fromFile: string, specifier: string): Promise<string | null> {
-  const base = resolve(dirname(fromFile), specifier).replace(/\.js$/u, '')
-  for (const candidate of [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts')]) {
-    if (await isFile(candidate)) {
-      return candidate
-    }
-  }
-  return null
+  return firstExistingSource(resolve(dirname(fromFile), specifier).replace(/\.js$/u, ''))
 }
 
 class SurfaceResolver {
@@ -357,32 +367,30 @@ class SurfaceResolver {
     let openedBy: string | null = null
 
     const absorb = async (target: string, statementLabel: string): Promise<void> => {
+      let inner: Surface
       if (target.startsWith('.')) {
         const resolved = await resolveRelative(file, target)
         if (!resolved) {
           throw new Error(`${file}: ${statementLabel} targets '${target}', which does not resolve to a source file`)
         }
-        const inner = await this.forFile(resolved)
-        for (const name of inner.names) {
-          names.add(name)
-        }
-        openedBy ??= inner.openedBy
-        return
-      }
-      if (target.startsWith(FIRST_PARTY_SCOPE)) {
-        const inner = await this.forSpecifier(target)
-        if (!inner) {
+        inner = await this.forFile(resolved)
+      } else if (target.startsWith(FIRST_PARTY_SCOPE)) {
+        const sibling = await this.forSpecifier(target)
+        if (!sibling) {
           throw new Error(`${file}: ${statementLabel} targets '${target}', which is not a declared entry point`)
         }
-        for (const name of inner.names) {
-          names.add(name)
-        }
-        openedBy ??= inner.openedBy
+        inner = sibling
+      } else {
+        // A third-party wholesale re-export. The names cannot be enumerated from
+        // first-party source, so absence stops being provable here.
+        openedBy ??= target
         return
       }
-      // A third-party wholesale re-export. The names cannot be enumerated from
-      // first-party source, so absence stops being provable here.
-      openedBy ??= target
+
+      for (const name of inner.names) {
+        names.add(name)
+      }
+      openedBy ??= inner.openedBy
     }
 
     for (const statement of body) {
@@ -472,7 +480,7 @@ function crossCheckExtraction(code: string, extracted: readonly ExtractedImport[
     const result = parse(code, {
       sourceType: 'module',
       errorRecovery: true,
-      plugins: ['typescript', 'jsx', 'decorators-legacy', 'explicitResourceManagement'],
+      plugins: [...BABEL_PLUGINS],
       allowReturnOutsideFunction: true,
       allowAwaitOutsideFunction: true,
       allowSuperOutsideMethod: true,

--- a/scripts/smoke/docs-import-sources.ts
+++ b/scripts/smoke/docs-import-sources.ts
@@ -618,7 +618,22 @@ export async function auditDocsImportSources(root: string, docsDir = 'docs'): Pr
           })
           continue
         }
-        if (names.length === 0) {
+        // The *specifier* is resolved for every import; only the per-symbol
+        // loop further down is skipped when nothing is named. An
+        // `import * as x from '@guren/typo'` and a bare `import '@guren/typo'`
+        // name no symbols, and returning here would exempt them from the one
+        // check that still applies — that the package and subpath exist at
+        // all. Decision 4 says an unresolvable specifier fails rather than
+        // being skipped; a short-circuit on the symbol count quietly carved
+        // two import forms out of it.
+        //
+        // With one exception, which is what a bare import is usually *for*:
+        // `import '@guren/plugin-markdown/styles.css'` names a stylesheet, and
+        // a stylesheet having no named exports is not a finding. The subpath
+        // still has to exist in the exports map — a typo in it is refused by
+        // Node exactly as a typo in a module path is — so what is skipped here
+        // is reading a surface out of a file that has none, not the check.
+        if (names.length === 0 && entryPoints.get(entry.specifier)?.kind === 'asset') {
           continue
         }
 


### PR DESCRIPTION
`bun run audit:docs` passed a snippet that imported `mcpPlugin` from `@guren/core`, which has never exported it. A reader copy-pasting that line gets a compile error; the audit was green either way. This adds the check that catches it, and runs it across all of `docs/`.

For every code fence, each named import from a first-party package is checked against that package's real export surface — derived from its `exports` map and followed through `export *` chains, `export { x as y }`, and `export type`, never from globbed files. A finding names the file, line, symbol, specifier, and **which first-party package does export it**, which is what makes it actionable rather than merely correct.

## What it found

Nothing, on the tree as committed — the one known case was already fixed by hand. Since a check that finds nothing is indistinguishable from a broken one, the evidence that it works is separate: reintroducing the historical line produces exactly the expected finding; probes confirm the `@guren/core` / `@guren/orm` allowlist boundary is genuinely enforced (`Attachable` passes from core and fails from orm; `hasMany` fails from both); and three source mutations each turn the intended test red.

Both reviews then found the thing that mattered more than the errors: **two ways the check exempted itself.**

- **Namespace and bare side-effect imports never reached specifier resolution.** The loop skipped ahead when an import named no symbols, taking the "does this package exist at all" question with it. `import * as x from '@guren/typo'` produced no finding while the counter still claimed something had been checked — a direct contradiction of the file's own rule that an unresolvable specifier fails rather than being skipped. Fixing it surfaced a live case: `docs/{en,ja}/guides/markdown.md` imports `@guren/plugin-markdown/styles.css` for its side effect, and had never been verified at all. An asset subpath naming nothing is now allowed; a typo in it still fails, because the subpath existing is the whole of what can be asked there.
- **A package root going open only printed a note.** One `export *` from a third-party package reaching `@guren/core`'s barrel drops what the audit verifies from 1034 symbols to about 129 while still exiting 0 — the only trace a log line directly above the word "passed". That is an audit switching itself off. It now fails, by a derived rule rather than a list: a *root* is the shape that collapses coverage, while a subpath that legitimately re-exports a dependency costs only its own snippets. Measured in both directions.

## Two decisions worth review

**Some entry points cannot be verified, and the check says so out loud.** `@guren/orm/drizzle/{pg,mysql,sqlite}` and the four jsx runtimes `export *` from `drizzle-orm` and `hono`, so absence is unprovable there from first-party source. No verdict is issued for them — but each is named on **every** run, not only on failure, so "not checked" is on the record instead of inferred from silence. A test pins the set of seven, because each addition is a slice of `docs/` that stops being checked, and that should be a decision rather than a side effect.

**`js`/`jsx` fences are scanned**, though `docs/` has none today. A JavaScript snippet can name an unexported symbol exactly as a TypeScript one can, and a filter admitting only the tags currently in use would leave the first such snippet unchecked with nothing to notice it.

## Known limitations, recorded rather than fixed

- A fence containing a template literal whose interpolated content has a line starting with `import` makes the textual scan and the parser disagree, reported as a gate error against a doc that is fine. Zero cases today; it fails loud rather than passing quietly.
- Scope is `docs/` only. `README.md`, `web/`, `examples/` and the scaffold templates carry fences and get `audit:core-first` but not this.
- `scripts/` is outside the root typecheck (`include` covers `packages/**` and `types/**` only), so nothing keeps any `scripts/*.ts` type-correct. Pre-existing and repo-wide; this file was typechecked with a throwaway config during development, which found a real strict-mode error.

## Gates

`typecheck`, `audit:docs` (1034 named imports across 659 first-party import statements in 1286 fences), `audit:core-first`, and the scripts test lane (179 tests) — all green, exit codes captured directly.

`bun run test:bun` cannot be run to completion on the development machine: it dies with a Bun segfault in `packages/cli/tests/tool-dev.test.ts`, at the identical position on clean `main`, in Bun's own dependency-optimizer teardown after that file's tests complete. Pre-existing, environmental, and structurally unrelated — this diff touches only `scripts/smoke/**`. The new tests were run under `--isolate` individually and pass 22/22, closing the one uncertainty flagged about CI being first to run them that way.