### PR TITLE
refactor(core): derive attachment object keys from one exported prefix

### DIFF
--- a/.changeset/attachment-object-prefix-constant.md
+++ b/.changeset/attachment-object-prefix-constant.md
@@ -1,0 +1,11 @@
+---
+"@guren/core": minor
+---
+
+Export the attachments object-key prefix as `ATTACHMENT_OBJECT_PREFIX` instead of restating the literal at every site that builds a storage key.
+
+The attachments engine spelled `attachments/` out at six independent sites: the original's key, a variant's key, the HEIC-conversion rewrite, both `deleteDirectory` purges, and the prune sweep's `directories()` listing. That layout is not private to the engine, which is why the duplication matters more than duplication usually does. `guren check`'s attachments rules judge, from `@guren/cli`, whether uploaded bytes land somewhere the app serves statically, and the ones that reach the objects themselves have to name the same `<disk root>/attachments`. Nothing makes the two agree, and the way they come apart is silent: if the layout ever moved (a shard level, a rename), the rule over there would not fail loudly, it would stop matching, answer "not reachable", and report an exposed app as safe. A build-failing security rule failing *open*, with nothing going red anywhere.
+
+`ATTACHMENT_OBJECT_PREFIX` is exported from `@guren/core` so that rule can import the layout rather than restate it, and the engine now builds every key from it. Two tests keep the single source structural: the constant must stay reachable through core's barrel — an allowlist for these names, not `export *`, so a name missing from it is unreachable however it is exported below — and the engine's source may not re-hardcode the prefix. That second one is a source-level check on purpose: nothing at runtime distinguishes a key built from the constant from one built from a re-typed literal.
+
+No behaviour changes; the keys are byte-identical.

--- a/packages/core/src/attachments/engine.ts
+++ b/packages/core/src/attachments/engine.ts
@@ -187,6 +187,24 @@ export interface DeliveryOptions {
   routeName?: string
 }
 
+/**
+ * The single storage key prefix every attachment object lives under:
+ * `attachments/<id>/<name>` for an original, `attachments/<id>/variants/…`
+ * for a derivative, and `attachments/` itself for the prune sweep's
+ * directory listing.
+ *
+ * Exported, and re-exported from `@guren/core`, because the layout is not
+ * private to this file. `guren check`'s attachments rules judge, from
+ * another package, whether uploaded bytes land somewhere the app serves
+ * statically — and the ones that reach the objects themselves have to name
+ * `<disk root>/attachments` to do it. A restated copy of the prefix over
+ * there does not fail loudly when this layout moves (a shard level, a
+ * rename): it stops matching, answers "not reachable", and reports an
+ * exposed app as safe. A build-failing security rule failing *open*, with
+ * nothing going red anywhere. Import this instead of restating it.
+ */
+export const ATTACHMENT_OBJECT_PREFIX = 'attachments'
+
 export const DEFAULT_DELIVERY_PREFIX = '/attachments'
 export const DEFAULT_DELIVERY_ROUTE_NAME = 'attachments.show'
 
@@ -364,7 +382,7 @@ export class AttachmentEngine {
 
     const id = ulid()
     const name = inspection.name
-    const path = `attachments/${id}/${name}`
+    const path = `${ATTACHMENT_OBJECT_PREFIX}/${id}/${name}`
     const diskName = options.disk ?? this.defaultDisk
     const disk = this.storage().disk(diskName)
     const contentType = inspection.contentType ?? normalized.declaredContentType ?? 'application/octet-stream'
@@ -724,7 +742,7 @@ export class AttachmentEngine {
       try {
         const result = await this.processor.process(inspection.bytes, variantSpec)
         const extension = VARIANT_EXTENSION[result.format] ?? result.format
-        const path = `attachments/${id}/variants/${name}.${extension}`
+        const path = `${ATTACHMENT_OBJECT_PREFIX}/${id}/variants/${name}.${extension}`
         await disk.put(path, Buffer.from(result.bytes), {
           contentType: IMAGE_MIME[result.format] ?? 'application/octet-stream',
         })
@@ -807,7 +825,7 @@ export class AttachmentEngine {
     if (sniffed?.format === 'heic' && payload.heic === 'convert') {
       const converted = await this.processor.process(bytes, { format: 'jpeg' })
       const name = replaceExtension(row.name, 'jpg')
-      const path = `attachments/${row.id}/${name}`
+      const path = `${ATTACHMENT_OBJECT_PREFIX}/${row.id}/${name}`
       await disk.put(path, Buffer.from(converted.bytes), { contentType: 'image/jpeg' })
       // The old object is deleted only after the row commit below repoints
       // to the new one: deleting first would leave the row referencing
@@ -843,7 +861,7 @@ export class AttachmentEngine {
     // would find.
     const still = await this.model.where({ id: row.id }).first()
     if (!still) {
-      await disk.deleteDirectory(`attachments/${row.id}`)
+      await disk.deleteDirectory(`${ATTACHMENT_OBJECT_PREFIX}/${row.id}`)
       return
     }
     await this.model.forceUpdate({ id: row.id }, updates)
@@ -982,7 +1000,7 @@ export class AttachmentEngine {
   private async purgeRows(rows: PlainObject[]): Promise<void> {
     for (const row of rows) {
       const disk = this.storage().disk(String(row.disk))
-      await disk.deleteDirectory(`attachments/${String(row.id)}`)
+      await disk.deleteDirectory(`${ATTACHMENT_OBJECT_PREFIX}/${String(row.id)}`)
     }
     const ids = rows.map((row) => String(row.id))
     // Chunked like the prune lookups: a sweep can hand this thousands of
@@ -1126,7 +1144,7 @@ export class AttachmentEngine {
       let disk: StorageDriver
       try {
         disk = this.storage().disk(diskName)
-        prefixes = await disk.directories('attachments')
+        prefixes = await disk.directories(ATTACHMENT_OBJECT_PREFIX)
       } catch (error) {
         report.skippedDisks.push({
           disk: diskName,

--- a/packages/core/src/attachments/index.ts
+++ b/packages/core/src/attachments/index.ts
@@ -2,6 +2,7 @@ export { Attachable } from './Attachable.js'
 export type { AttachableRecordId, AttachableStatic } from './Attachable.js'
 export { configureAttachments } from './configure.js'
 export type { ConfigureAttachmentsOptions, ConfiguredAttachments } from './configure.js'
+export { ATTACHMENT_OBJECT_PREFIX } from './engine.js'
 export type {
   AttachOptions,
   AttachmentUrlOptions,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,7 +96,7 @@ export type { DatabaseSessionStoreOptions } from './session-store.js'
 export { DatabaseOAuthStateStore } from './oauth-state-store.js'
 // Attachments (RFC 0013) — core-native exports; no bare `Attachment` (it
 // would collide with the mail/notification/Slack attachment vocabulary).
-export { Attachable, AttachmentDeliveryController, AttachmentsPruneCommand, configureAttachments, GenerateVariantsJob, hasManyAttached, hasOneAttached, registerAttachmentRoutes } from './attachments/index.js'
+export { Attachable, AttachmentDeliveryController, AttachmentsPruneCommand, ATTACHMENT_OBJECT_PREFIX, configureAttachments, GenerateVariantsJob, hasManyAttached, hasOneAttached, registerAttachmentRoutes } from './attachments/index.js'
 export type {
   AttachableRecordId,
   AttachableStatic,

--- a/packages/core/tests/attachments-object-prefix.test.ts
+++ b/packages/core/tests/attachments-object-prefix.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import * as core from '../src/index'
+import { ATTACHMENT_OBJECT_PREFIX } from '../src/attachments/engine'
+
+/**
+ * The object-key prefix is a cross-package contract, not an engine detail.
+ * `guren check`'s attachments rules judge, from another package, whether
+ * uploaded bytes land somewhere the app serves statically, and the ones that
+ * reach the objects themselves have to name `<disk root>/attachments` to do
+ * it. A restated copy of the prefix over there does not fail loudly when the
+ * layout moves (a shard level, a rename) — it stops matching, answers "not
+ * reachable", and reports an exposed app as safe. A build-failing security
+ * rule failing *open*, with nothing going red anywhere.
+ *
+ * These two tests are what make the single source structural: the engine may
+ * not re-hardcode the prefix, and the constant must stay reachable as
+ * `@guren/core` so a rule over there can import it rather than restate it.
+ */
+describe('attachment object key prefix', () => {
+  it('is reachable from the @guren/core surface', () => {
+    // Core's barrel is an allowlist for these names, not `export *`, so a
+    // name missing from it is unreachable however it is exported below.
+    // The CLI's attachments check already imports AttachmentDeliveryController
+    // through this same channel.
+    expect(core.ATTACHMENT_OBJECT_PREFIX).toBe(ATTACHMENT_OBJECT_PREFIX)
+  })
+
+  it('is the only spelling of the prefix in the engine', async () => {
+    const path = fileURLToPath(new URL('../src/attachments/engine.ts', import.meta.url))
+    // Comments first: the surrounding prose names `attachments/` repeatedly
+    // without building a key, and a scan that reads it would fail on itself.
+    const code = blankComments(await readFile(path, 'utf8'))
+
+    // Nothing at runtime distinguishes a key built from the constant from one
+    // built from a re-typed literal — same reason the MCP endpoint gate pins
+    // the source form of `process.env.NODE_ENV`. So the form is what is
+    // pinned: the key templates, and the bare argument `directories()` takes.
+    expect(code).not.toContain(`\`${ATTACHMENT_OBJECT_PREFIX}/`)
+
+    const declaration = `export const ATTACHMENT_OBJECT_PREFIX = '${ATTACHMENT_OBJECT_PREFIX}'`
+    expect(code).toContain(declaration)
+    // `'attachments.show'` and `'/attachments'` are different strings and stay
+    // out of this deliberately: they are a route name and a URL prefix.
+    for (const quote of ["'", '"']) {
+      expect(code.replace(declaration, '')).not.toContain(
+        `${quote}${ATTACHMENT_OBJECT_PREFIX}${quote}`,
+      )
+    }
+  })
+})
+
+/**
+ * Replace every comment body with spaces, leaving string and template
+ * literals untouched. A scanner rather than a regex sweep because the two
+ * classes nest both ways: `//` inside a string opens no comment, and a quote
+ * inside a comment opens no string.
+ */
+function blankComments(source: string): string {
+  let out = ''
+  let index = 0
+
+  while (index < source.length) {
+    const char = source[index]!
+    const next = source[index + 1]
+
+    if (char === '/' && next === '/') {
+      const end = source.indexOf('\n', index)
+      index = end === -1 ? source.length : end
+      continue
+    }
+    if (char === '/' && next === '*') {
+      const end = source.indexOf('*/', index + 2)
+      index = end === -1 ? source.length : end + 2
+      continue
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      const end = endOfLiteral(source, index, char)
+      out += source.slice(index, end)
+      index = end
+      continue
+    }
+
+    out += char
+    index += 1
+  }
+
+  return out
+}
+
+/**
+ * End index (exclusive) of the literal opening at `start`. Template literals
+ * are taken whole, interpolations included: the key shapes this file looks
+ * for live in exactly that text, and a comment cannot legally sit between a
+ * backtick and its `${`.
+ */
+function endOfLiteral(source: string, start: number, quote: string): number {
+  let index = start + 1
+  while (index < source.length) {
+    const char = source[index]
+    if (char === '\\') {
+      index += 2
+      continue
+    }
+    if (char === quote) return index + 1
+    // An unterminated single- or double-quoted literal cannot span a line;
+    // stopping here keeps a stray apostrophe from swallowing the rest.
+    if (char === '\n' && quote !== '`') return index
+    index += 1
+  }
+  return source.length
+}


### PR DESCRIPTION
## Summary

The attachments engine spelled the object-key prefix `attachments/` out at six independent sites: the original's key, a variant's key, the HEIC-conversion rewrite, both `deleteDirectory` purges, and the prune sweep's `directories()` listing. This replaces all six with one exported constant, `ATTACHMENT_OBJECT_PREFIX`.

That layout is not private to the engine, which is why the duplication matters more than duplication usually does. `guren check`'s attachments rules judge, from `@guren/cli`, whether uploaded bytes land somewhere the app serves statically, and the ones that reach the objects themselves have to name the same `<disk root>/attachments`. Nothing makes the two agree, and the way they come apart is silent: if the layout ever moved (a shard level, a rename), the rule over there would not fail loudly — it would stop matching, answer "not reachable", and report an exposed app as safe. A build-failing security rule failing **open**, with nothing going red anywhere.

Exporting the prefix lets an out-of-package rule import the layout rather than restate it.

### Export path

The constant is surfaced in two places, both required. `packages/core/src/index.ts` cherry-picks the attachments names from `./attachments/index.js` rather than re-exporting the module wholesale, so a name added only to the inner barrel stays unreachable as `@guren/core`. Verified through `dist` and at runtime, including from `packages/cli`'s own resolution context.

### Tests

`packages/core/tests/attachments-object-prefix.test.ts` keeps the single source structural:

- the constant must stay reachable through core's barrel;
- the engine's source may not re-hardcode the prefix.

The second is a source-level check on purpose — nothing at runtime distinguishes a key built from the constant from one built from a re-typed literal, the same reason the MCP endpoint gate pins the source form of `process.env.NODE_ENV`. It blanks comments before scanning (the surrounding prose names `attachments/` repeatedly) and leaves `'attachments.show'` and `'/attachments'` alone — a route name and a URL prefix, different strings.

Both cases were confirmed to fail under mutation: re-literalizing a key template, re-literalizing the `directories()` argument, and dropping the barrel export each turn one red.

## Scope

`core` — `src/attachments/engine.ts`, `src/attachments/index.ts`, `src/index.ts`, one new test, one changeset (`@guren/core: minor`, a new export).

## Risk Assessment

No behaviour changes. The generated keys are byte-identical, and the existing assertions in `attachments.test.ts` still pin the literal wire format (`attachments/<id>/<name>`, `attachments/<id>/variants/<name>.<ext>`) as the independent expected-value side.

Additive export only; nothing is removed or renamed.

## Validation

- [x] `bun run build` (`build:clean`)
- [x] `bun run typecheck`
- [x] `bun run test` — see note below
- [x] `bun run audit:core-first`

`test:examples` is green (blog 114, api 43, web 123). `test:bun` is green per package: core 282, server 2729, orm + openapi + inertia-client 538, plugins + create-app 373, cli 2022 — 0 fail throughout.

The aggregate `test:bun` run did not complete locally: `bun test --isolate packages/cli` from the repo root dies with `panic(main thread): Segmentation fault` inside the vite dev-server child that `tests/tool-dev.test.ts` spawns (Bun 1.3.14). **This reproduces on the base tree with this branch's `packages/core` reverted**, so it is pre-existing and unrelated. That test file passes on its own (7 pass) when run from `packages/cli`.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.

## Follow-up (not in this PR)

- `packages/cli/src/attachments-check.ts` has no object-key prefix literal on `main` — the site that computes `join(realRoot, 'attachments')` lives on the open PR #626 branch. That is a one-line change there once this lands: `join(realRoot, ATTACHMENT_OBJECT_PREFIX)`. The import channel is already proven, since that file imports `AttachmentDeliveryController` from `@guren/core` today.
- `DEFAULT_DELIVERY_ROUTE_NAME = 'attachments.show'` is declared twice — `engine.ts` and `attachments-check.ts:398` — and is the same fail-open class. Actionable on `main` today, tracked separately.
