### PR TITLE
fix(cli): read scanner input through transparent assertions

### DIFF
--- a/.changeset/unwrap-assertions-scanner-sweep.md
+++ b/.changeset/unwrap-assertions-scanner-sweep.md
@@ -1,0 +1,20 @@
+---
+"@guren/cli": patch
+---
+
+Fix the CLI reads that silently misread source wrapped in a transparent TypeScript assertion.
+
+Each tested a node's shape (`ObjectExpression`, `ArrayExpression`) without unwrapping `as const` / `satisfies` / `!` / `<T>x` first, so a wrapper made the declaration invisible. The failure is silent by construction: these scans report "cannot read this" and "nothing to flag" as the same empty result.
+
+- `defineModel(users, { … } satisfies ModelOptions)` dropped every option at once, so `guren audit` reported a model with a `fillable` allowlist as having none, and a wrapped `base: AuthenticatableModel` lost its authentication classification.
+- A string-array config read as unreadable when the array itself carried the wrapper — `static fillable = ['title'] as const`, the idiomatic spelling — with the same consequences plus a skipped denied-credential-column check.
+- A wrapped drizzle column map made the whole table invisible to `parseSchemaTables`, and so to the schema checks, attachments table bindings, `make:feature`, and `guren context`. Wrapped column options read as opaque, so `timestamp('created_at', { withTimezone: false } as const)` skipped the Postgres `timestamptz` warning instead of earning it.
+- `broadcast('c', 'e', { id: 1 } as const)` rendered as `unknown` in `.guren/channels.gen.ts`, typing every listener's argument as unusable rather than as the shape it carries. A wrapped *name* in the same call was worse still — the channel vanished from the generated types entirely — though that half is already fixed on main; a regression test now pins it.
+- `export default { … } as const` was absent from the inert-default-export set, so a shared-constants module was treated as possibly holding a console command and drew a registration warning nothing could resolve.
+- `mcpPlugin({ … } satisfies McpPluginOptions)` read as unreadable, and that scan's positive-evidence-only rule turned it into silence — an agent route requiring approval went unreported despite having nowhere to queue it.
+
+A review sweep of the same files found more of the same class, now fixed too: a `defineModel` `base:` option, a `static passwordHashField = '…' as const`, the entries of a wrapped allowlist array, a relationship name, and the drizzle table and column names — a lost column name made the `timestamptz` warning cite the property instead of the SQL column and drop its `USING` hint.
+
+Two widenings the unwrap could otherwise have caused are closed in the same pass. A `fillable: undefined as string[] | undefined` still reads as the absent option it is, rather than as mass-assignment protection the runtime does not apply. And a drizzle options object carrying a spread now reads as unreadable whether or not it is wrapped — `timestamp('c', { ...SHARED })` may well set `withTimezone`, so concluding "unset" warns about a column that was already right.
+
+All now go through `objectLiteral()` / `literalString()` / `unwrapTypeAssertion()` from `ast-walk`, the one rule for reading through transparent wrapping. That rule also gains its first direct tests: five wrapper spellings were handled but only two were exercised anywhere, and `ParenthesizedExpression` was unreachable through the shared parser's plugin set at all.

--- a/packages/cli/src/agent-route-check.ts
+++ b/packages/cli/src/agent-route-check.ts
@@ -6,7 +6,7 @@ import {
   RESERVED_AGENT_TOOL_NAMES,
 } from '@guren/core'
 import type { AgentRouteMetadata, RouteDefinition } from '@guren/core'
-import { memberKeyName, walk } from './ast-walk'
+import { memberKeyName, objectLiteral, walk } from './ast-walk'
 import { check, type CheckResult } from './check-result'
 import {
   mutatesRecords,
@@ -496,14 +496,20 @@ function readMcpPluginCalls(parsed: ParsedFile): 'configured' | 'absent' | undef
     const callee = call.callee
     if (callee.type !== 'Identifier' || !locals.has(callee.name)) return
 
-    const options = call.arguments[0]
+    const argument = call.arguments[0]
     // `mcpPlugin()` with no argument is a readable call with no queue: the
     // default is the unconfigured one.
-    if (!options) {
+    if (!argument) {
       answer ??= 'absent'
       return
     }
-    if (options.type !== 'ObjectExpression') return
+    // Read through transparent wrapping: `mcpPlugin({ … } satisfies
+    // McpPluginOptions)` is the same options object at runtime, and the bare
+    // shape test read it as unreadable — which this scan's positive-evidence
+    // rule then turns into silence, so a gated route with nowhere to queue
+    // its approvals went unreported.
+    const options = objectLiteral(argument)
+    if (!options) return
 
     const properties = options.properties
     const carriesQueue = properties.some(

--- a/packages/cli/src/ast-walk.ts
+++ b/packages/cli/src/ast-walk.ts
@@ -72,8 +72,10 @@ export function memberKeyName(member: {
  * turning that option on stays a one-line change rather than a silent
  * regression in every scanner at once.
  */
-export function unwrapTypeAssertion(node: Node): Node {
-  let current = node
+export function unwrapTypeAssertion(node: Node): Node
+export function unwrapTypeAssertion(node: BabelNode): BabelNode
+export function unwrapTypeAssertion(node: Node | BabelNode): Node | BabelNode {
+  let current = node as Node
   if (!current || typeof current !== 'object') return current
   while (
     current.type === 'TSAsExpression' ||
@@ -82,6 +84,11 @@ export function unwrapTypeAssertion(node: Node): Node {
     current.type === 'TSTypeAssertion' ||
     current.type === 'ParenthesizedExpression'
   ) {
+    // A wrapper always carries an expression when Babel built it, but
+    // `literalString` accepts `unknown` and hands whatever it was given
+    // straight here. Stopping on a missing one keeps a malformed node
+    // answering "not a wrapper" rather than throwing out of a scan.
+    if (!current.expression) return current
     current = current.expression
   }
   return current
@@ -95,6 +102,22 @@ export function unwrapTypeAssertion(node: Node): Node {
  * bare test reads `{ … } as const` — the shape the storage and module
  * scaffolds actually emit — as "not an object", and the scan then skips the
  * one config it most needed to read.
+ *
+ * A source-level guard over quoted `'ObjectExpression'`, in the style of
+ * `class-member-walk-guard.test.ts`, was considered for this rule and
+ * deliberately rejected: the invariant is a dataflow property, not a lexical
+ * one. `model-parser.ts` spells the bare test in several places and each is
+ * *correct*, because the node was unwrapped by its caller; `findDefineModelOption`
+ * in that same file spelled the identical test and was a bug. A grep cannot
+ * separate the two, so the allowlist would have had to name the whole file and
+ * would have blinded the guard to the one site it was meant to catch. The
+ * class-member rule that a guard here does pin has no "already handled
+ * upstream" spelling, which is why it works there and not this rule.
+ *
+ * The rule also deliberately stops short of the shape tests on other node
+ * types: a drizzle table factory call, a route registrar's arrow function and
+ * a `.references(() => …)` callback have no idiomatic wrapped spelling, so
+ * unwrapping there would widen the rule without widening what it can read.
  */
 export function objectLiteral(node: Node | null | undefined): ObjectExpression | null {
   if (!node) return null
@@ -110,6 +133,10 @@ export function objectLiteral(node: Node | null | undefined): ObjectExpression |
  * knows only `StringLiteral` reads the first as no route at all. Anything with
  * an interpolation, or a reference to a constant declared elsewhere, is `null`:
  * these scanners miss rather than invent.
+ *
+ * Reading `null` for a wrapped literal is not always a mere gap: it took
+ * `broadcast.channel('announcements' as const, …)` out of the generated
+ * channel types entirely, rather than degrading what it generated for it.
  */
 export function literalString(value: unknown): string | null {
   if (!value || typeof value !== 'object') return null

--- a/packages/cli/src/channel-types.ts
+++ b/packages/cli/src/channel-types.ts
@@ -1,6 +1,6 @@
 import { readdir, readFile } from 'node:fs/promises'
 import { relative, resolve } from 'node:path'
-import { literalString, walk, type BabelNode } from './ast-walk'
+import { literalString, unwrapTypeAssertion, walk, type BabelNode } from './ast-walk'
 import { parseSourceFile } from './parse-cache'
 import { escapeSingleQuoted as esc, escapeTemplateLiteral as escapeTemplatePart, resolveAppRoot, writeGeneratedFileIn, type WriterOptions } from './utils'
 
@@ -289,7 +289,13 @@ function renderPayloadType(value: unknown): string {
   return normalizePayloadType(node)
 }
 
-function normalizePayloadType(node: BabelNode): string {
+function normalizePayloadType(input: BabelNode): string {
+  // Unwrapped here rather than at the caller so the recursive descent below
+  // covers nested values too: `{ tags: ['a'] as const } as const` wraps at
+  // two levels, and a payload read as "not an object" renders as `unknown`,
+  // which types every listener's argument as unusable.
+  const node = unwrapTypeAssertion(input)
+
   switch (node.type) {
     case 'StringLiteral':
       return 'string'

--- a/packages/cli/src/console-check.ts
+++ b/packages/cli/src/console-check.ts
@@ -8,7 +8,7 @@ import {
   toPosixRelative,
   moduleNameFor,
 } from './discovery'
-import { memberKeyName, walk } from './ast-walk'
+import { memberKeyName, unwrapTypeAssertion, walk } from './ast-walk'
 import { camelCase, escapeRegExp, referencesIdentifier } from './utils'
 import { ParseCache } from './parse-cache'
 import { check, type CheckResult } from './check-result'
@@ -90,12 +90,15 @@ function declaresCommand(ast: File): boolean {
     // surface a command — the same evidence-of-absence direction as the class
     // branch below, so `export default new SendDigestCommand()` stays in while
     // `export default TABLES` in an object-literal helper does not
-    if (
-      node.type === 'ExportDefaultDeclaration' &&
-      node.declaration.type !== 'ClassDeclaration' &&
-      !INERT_DEFAULT_EXPORTS.has(node.declaration.type)
-    ) {
-      return true
+    if (node.type === 'ExportDefaultDeclaration') {
+      // Judged on the unwrapped node: `export default { … } as const` is a
+      // TSAsExpression, absent from the inert set, so the bare test read the
+      // module as possibly holding a command and asked for a registration
+      // that could never exist.
+      const declaration = unwrapTypeAssertion(node.declaration)
+      if (declaration.type !== 'ClassDeclaration' && !INERT_DEFAULT_EXPORTS.has(declaration.type)) {
+        return true
+      }
     }
   }
 

--- a/packages/cli/src/model-parser.ts
+++ b/packages/cli/src/model-parser.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises'
 import type { Statement, Expression, ClassDeclaration, ClassBody, ClassProperty, CallExpression, Node, ObjectProperty } from '@babel/types'
-import { memberKeyName, unwrapTypeAssertion } from './ast-walk'
+import { literalString, memberKeyName, objectLiteral, unwrapTypeAssertion } from './ast-walk'
 import { extractDocsTags } from './docs-index'
 import { discoverModelFiles, toPosixRelative, moduleNameFromRelPath } from './discovery'
 import { parseSourceFile } from './parse-cache'
@@ -141,7 +141,8 @@ export function firstClassDeclaration(body: Statement[]): ClassDeclaration | nul
  * here. Matching is by name only — an aliased import is not resolved.
  */
 function isAuthenticatableBase(node: Node): boolean {
-  const target = node.type === 'TSInstantiationExpression' ? node.expression : node
+  const unwrapped = unwrapTypeAssertion(node)
+  const target = unwrapped.type === 'TSInstantiationExpression' ? unwrapped.expression : unwrapped
   return target.type === 'Identifier' && target.name === 'AuthenticatableModel'
 }
 
@@ -223,7 +224,7 @@ export function findStaticClassProperty(classDecl: ClassDeclaration, name: strin
 /** Value of `static <name> = '<literal>'`, or undefined when absent or not a string literal. */
 export function staticStringProperty(classDecl: ClassDeclaration, name: string): string | undefined {
   const property = findStaticClassProperty(classDecl, name)
-  return property?.value?.type === 'StringLiteral' ? property.value.value : undefined
+  return literalString(property?.value) ?? undefined
 }
 
 /**
@@ -234,11 +235,18 @@ export function staticStringProperty(classDecl: ClassDeclaration, name: string):
  * runtime exposes.
  */
 function stringArrayEntries(node: Node | null | undefined): string[] | undefined {
-  if (node?.type !== 'ArrayExpression') return undefined
+  // `static fillable = ['title'] as const` is the idiomatic spelling of a
+  // read-only allowlist, and reads as a non-array without this: the config
+  // then resolves to undefined and every check that consults it — the
+  // mass-assignment audit, the denied-credential-column check — reports the
+  // model as having no allowlist at all rather than one it could not read.
+  const array = node ? unwrapTypeAssertion(node) : null
+  if (array?.type !== 'ArrayExpression') return undefined
   const entries: string[] = []
-  for (const element of node.elements) {
-    if (element?.type !== 'StringLiteral') return undefined
-    entries.push(element.value)
+  for (const element of array.elements) {
+    const entry = literalString(element)
+    if (entry === null) return undefined
+    entries.push(entry)
   }
   return entries
 }
@@ -278,8 +286,8 @@ export function extractModelAttachments(
   const call = classDecl.superClass ? findMixinCall(classDecl.superClass, 'Attachable') : null
   if (!call) return null
 
-  const declaration = call.arguments[1] === undefined ? undefined : unwrapTypeAssertion(call.arguments[1])
-  if (declaration?.type !== 'ObjectExpression') return 'unreadable'
+  const declaration = objectLiteral(call.arguments[1])
+  if (!declaration) return 'unreadable'
 
   const collections: ModelAttachmentCollection[] = []
   for (const property of declaration.properties) {
@@ -317,7 +325,7 @@ function parseAttachmentSpec(node: Node): { kind: 'one' | 'many'; variants: stri
     const key = memberKeyName(property)
     if (!key) return null
     if (key !== 'variants') continue
-    const names = attachmentVariantNames(unwrapTypeAssertion(property.value))
+    const names = attachmentVariantNames(property.value)
     if (!names) return null
     variants = names
   }
@@ -326,9 +334,10 @@ function parseAttachmentSpec(node: Node): { kind: 'one' | 'many'; variants: stri
 
 /** Keys of a `variants: { thumb: {...}, og: {...} }` object literal, or null when not fully readable. */
 function attachmentVariantNames(node: Node): string[] | null {
-  if (node.type !== 'ObjectExpression') return null
+  const variants = objectLiteral(node)
+  if (!variants) return null
   const names: string[] = []
-  for (const property of node.properties) {
+  for (const property of variants.properties) {
     if (property.type !== 'ObjectProperty') return null
     const name = memberKeyName(property)
     if (!name) return null
@@ -346,11 +355,15 @@ function attachmentVariantNames(node: Node): string[] | null {
 export function findDefineModelOption(classDecl: ClassDeclaration, name: string): ObjectProperty | null {
   if (!classDecl.superClass) return null
   const call = findMixinCall(classDecl.superClass, 'defineModel')
-  const options = call?.arguments[1]
-  if (options?.type !== 'ObjectExpression') return null
+  const options = objectLiteral(call?.arguments[1])
+  if (!options) return null
   for (const property of options.properties) {
     if (property.type !== 'ObjectProperty' || propertyKeyName(property) !== name) continue
-    if (property.value.type === 'Identifier' && property.value.name === 'undefined') return null
+    // Through a wrapper too: `fillable: undefined as string[] | undefined` is
+    // the same skipped assignment, and reading it as a declared option
+    // reports mass-assignment protection the runtime does not have.
+    const value = unwrapTypeAssertion(property.value)
+    if (value.type === 'Identifier' && value.name === 'undefined') return null
     return property
   }
   return null
@@ -500,10 +513,10 @@ function extractRelationshipsFromCalls(
               prop.type === 'Identifier' &&
               relMethods.has(prop.name)
             ) {
-              const relName = call.arguments[0]
-              if (relName?.type === 'StringLiteral') {
+              const relName = literalString(call.arguments[0])
+              if (relName !== null) {
                 relationships.push({
-                  name: relName.value,
+                  name: relName,
                   type: prop.name as ModelRelationship['type'],
                 })
               }
@@ -521,10 +534,10 @@ function extractRelationshipsFromCalls(
       expr.callee.property.type === 'Identifier' &&
       relMethods.has(expr.callee.property.name)
     ) {
-      const relName = expr.arguments[0]
-      if (relName?.type === 'StringLiteral') {
+      const relName = literalString(expr.arguments[0])
+      if (relName !== null) {
         relationships.push({
-          name: relName.value,
+          name: relName,
           type: expr.callee.property.name as ModelRelationship['type'],
         })
       }

--- a/packages/cli/src/schema-parser.ts
+++ b/packages/cli/src/schema-parser.ts
@@ -7,7 +7,7 @@ import type {
   ObjectProperty,
   Statement,
 } from '@babel/types'
-import { memberKeyName, unwrapTypeAssertion } from './ast-walk'
+import { literalString, memberKeyName, objectLiteral, unwrapTypeAssertion } from './ast-walk'
 import { listAppRoots } from './discovery'
 import { parseSourceFile } from './parse-cache'
 
@@ -149,7 +149,11 @@ function propertyKeyName(property: ObjectProperty): string | undefined {
  * name-less `timestamp({ … })`.
  */
 function firstObjectArgument(call: CallExpression | undefined): ObjectExpression | undefined {
-  return call?.arguments.find((arg): arg is ObjectExpression => arg.type === 'ObjectExpression')
+  for (const argument of call?.arguments ?? []) {
+    const literal = objectLiteral(argument)
+    if (literal) return literal
+  }
+  return undefined
 }
 
 /**
@@ -161,18 +165,30 @@ function firstObjectArgument(call: CallExpression | undefined): ObjectExpression
  */
 function hasOpaqueOptions(call: CallExpression | undefined): boolean {
   if (!call) return false
-  return call.arguments.some(
-    (arg) => arg.type !== 'ObjectExpression' && arg.type !== 'StringLiteral',
-  )
+  return call.arguments.some((arg) => {
+    // Both tests apply to the unwrapped node: `{ … } as const` is the same
+    // object drizzle receives, and `timestamp('x' as const)` is the same
+    // name — reading either as opaque turns a fully static declaration into
+    // an unknown, which is how a written option stops being checked.
+    const argument = unwrapTypeAssertion(arg)
+    if (argument.type === 'StringLiteral') return false
+    if (argument.type !== 'ObjectExpression') return true
+    // A spread hides every option it carries, so an inline object holding one
+    // proves no more than an identifier does: `timestamp('c', { ...SHARED })`
+    // has to read as unknown, not as "withTimezone absent", or the check
+    // warns about a column the runtime already got right.
+    return argument.properties.some((property) => property.type === 'SpreadElement')
+  })
 }
 
 /**
  * A boolean option off the builder's own options object, e.g. the
  * `withTimezone` in `timestamp('created_at', { withTimezone: true })`.
  * Undefined when absent or not written as a boolean literal. A `satisfies`
- * or `as const` wrapper is unwrapped first — `withTimezone: true as const`
- * is the same `true` to Postgres, and reading it as "unset" would be a
- * false alarm.
+ * or `as const` wrapper is unwrapped on both sides — the options object via
+ * {@link firstObjectArgument} and the value here — because
+ * `{ withTimezone: true } as const` is the same `true` to Postgres either
+ * way, and reading it as "unset" would be a false alarm.
  */
 function booleanOption(builder: CallExpression | undefined, option: string): boolean | undefined {
   const options = firstObjectArgument(builder)
@@ -235,9 +251,10 @@ function columnsFromObject(columnsArg: ObjectExpression): SchemaColumn[] {
 
     const { type, builder, methods } = unwrapColumnChain(prop.value)
     const nameArg = builder?.arguments[0]
+
     columns.push({
       name,
-      columnName: nameArg?.type === 'StringLiteral' ? nameArg.value : undefined,
+      columnName: literalString(nameArg) ?? undefined,
       type: type && methods.has('array') ? `${type}[]` : type,
       notNull: methods.has('notNull'),
       primaryKey: methods.has('primaryKey'),
@@ -292,8 +309,7 @@ async function parseSchemaFile(schemaPath: string, module: string | null): Promi
       const dialect = tableFactoryDialect(declarator.init, aliases)
       if (!dialect) continue
 
-      const nameArg = declarator.init.arguments[0]
-      const tableName = nameArg?.type === 'StringLiteral' ? nameArg.value : undefined
+      const tableName = literalString(declarator.init.arguments[0]) ?? undefined
 
       const columnsArg = firstObjectArgument(declarator.init)
       if (!columnsArg) continue

--- a/packages/cli/tests/agent-route-check.test.ts
+++ b/packages/cli/tests/agent-route-check.test.ts
@@ -815,6 +815,40 @@ export const providers = [mcpPlugin({ approvals: { store, notify: () => {} } })]
       expect(keys(results)).not.toContain('agent-route-approval-store')
     })
 
+    it('reads plugin options written behind a transparent wrapper', async () => {
+      await writeAppFile(`
+import { mcpPlugin, type McpPluginOptions } from '@guren/plugin-mcp'
+
+export const providers = [mcpPlugin({ path: '/mcp' } satisfies McpPluginOptions)]
+`)
+
+      const results = await checkAgentRoutes({ cwd: tempDir, definitions: [gated()] })
+      // Wrapped options used to read as unreadable, and the scan's
+      // positive-evidence-only rule then turned that into silence — a gated
+      // route with nowhere to queue its approvals went unreported.
+      expect(keys(results)).toContain('agent-route-approval-store')
+    })
+
+    it('reads an approvals queue written behind a transparent wrapper', async () => {
+      // The unwrapped call is what makes this test able to fail: on its own, a
+      // wrapped configured call is indistinguishable from an unreadable one —
+      // both produce no finding. Pairing it with a readable call that has no
+      // queue means the wrapped one has to be understood as *configured* to
+      // keep the finding away.
+      await writeAppFile(`
+import { mcpPlugin } from '@guren/plugin-mcp'
+import { store } from './approvals'
+
+export const providers = [
+  mcpPlugin({ path: '/mcp' }),
+  mcpPlugin({ approvals: { store, notify: () => {} } } as const),
+]
+`)
+
+      const results = await checkAgentRoutes({ cwd: tempDir, definitions: [gated()] })
+      expect(keys(results)).not.toContain('agent-route-approval-store')
+    })
+
     it('follows a local alias of the factory', async () => {
       await writeAppFile(`
 import { mcpPlugin as mcp } from '@guren/plugin-mcp'

--- a/packages/cli/tests/ast-walk.test.ts
+++ b/packages/cli/tests/ast-walk.test.ts
@@ -1,0 +1,113 @@
+import { parse } from '@babel/parser'
+import type { Expression, File, Node } from '@babel/types'
+import { describe, expect, it } from 'bun:test'
+import { literalString, objectLiteral, unwrapTypeAssertion } from '../src/ast-walk'
+
+/**
+ * Parses `source` and returns the initializer of its first `const x = …`.
+ *
+ * Deliberately calls `@babel/parser` directly rather than going through
+ * `parseSourceFile`: one of the five wrapper spellings
+ * (`ParenthesizedExpression`) is unreachable under the plugin set that parser
+ * uses, so a test routed through it could not distinguish a live branch from a
+ * dead one. `createParenthesizedExpressions` is opt-in here for that reason.
+ *
+ * No JSX plugin, on purpose — `<T>x` (`TSTypeAssertion`) does not parse when
+ * JSX is enabled, since the two grammars claim the same syntax.
+ */
+function firstInitializer(source: string, options: { parenthesized?: boolean } = {}): Expression {
+  const ast: File = parse(source, {
+    sourceType: 'module',
+    plugins: ['typescript'],
+    createParenthesizedExpressions: options.parenthesized ?? false,
+  })
+  const [statement] = ast.program.body
+  if (statement?.type !== 'VariableDeclaration') throw new Error('expected a variable declaration')
+  const init = statement.declarations[0]?.init
+  if (!init) throw new Error('expected an initializer')
+  return init
+}
+
+describe('unwrapTypeAssertion', () => {
+  it('sees through every transparent wrapper spelling', () => {
+    const cases: Array<[string, string]> = [
+      ['as const', 'const x = { a: 1 } as const'],
+      ['as T', 'const x = { a: 1 } as Options'],
+      ['satisfies T', 'const x = { a: 1 } satisfies Options'],
+      ['non-null assertion', 'const x = { a: 1 }!'],
+      ['angle-bracket assertion', 'const x = <Options>{ a: 1 }'],
+    ]
+
+    for (const [label, source] of cases) {
+      const unwrapped = unwrapTypeAssertion(firstInitializer(source))
+      expect(unwrapped.type, label).toBe('ObjectExpression')
+    }
+  })
+
+  it('sees through a parenthesized expression when the parser produces one', () => {
+    const wrapped = firstInitializer('const x = ({ a: 1 })', { parenthesized: true })
+
+    // Guards the fixture rather than the rule: without this the assertion
+    // below would pass on a parser that dropped the node, and the branch
+    // would look covered while never being entered.
+    expect(wrapped.type).toBe('ParenthesizedExpression')
+    expect(unwrapTypeAssertion(wrapped).type).toBe('ObjectExpression')
+  })
+
+  it('unwraps repeatedly, not once', () => {
+    const wrapped = firstInitializer('const x = (({ a: 1 } as const) satisfies Options)!', {
+      parenthesized: true,
+    })
+
+    expect(unwrapTypeAssertion(wrapped).type).toBe('ObjectExpression')
+  })
+
+  it('returns anything else untouched', () => {
+    const call = firstInitializer('const x = makeOptions()')
+
+    expect(unwrapTypeAssertion(call)).toBe(call)
+  })
+})
+
+describe('objectLiteral', () => {
+  it('answers the literal under a wrapper', () => {
+    const literal = objectLiteral(firstInitializer('const x = { a: 1 } satisfies Options'))
+
+    expect(literal?.type).toBe('ObjectExpression')
+    expect(literal?.properties).toHaveLength(1)
+  })
+
+  it('answers null for a node that denotes no literal, wrapped or not', () => {
+    expect(objectLiteral(firstInitializer('const x = SHARED_OPTIONS as Options'))).toBeNull()
+    expect(objectLiteral(firstInitializer('const x = [1] as const'))).toBeNull()
+  })
+
+  it('answers null for an absent node', () => {
+    expect(objectLiteral(null)).toBeNull()
+    expect(objectLiteral(undefined)).toBeNull()
+  })
+})
+
+describe('unwrapTypeAssertion on a malformed node', () => {
+  it('answers the node rather than throwing when a wrapper carries no expression', () => {
+    // `literalString` takes `unknown` and forwards it here unvalidated, so a
+    // wrapper-shaped object that Babel did not build must not take a scan down
+    // with it.
+    const malformed = { type: 'TSAsExpression' } as unknown as Node
+
+    expect(unwrapTypeAssertion(malformed)).toBe(malformed)
+    expect(literalString(malformed)).toBeNull()
+  })
+})
+
+describe('literalString', () => {
+  it('reads a string through a wrapper, in either spelling', () => {
+    expect(literalString(firstInitializer("const x = 'redirect' as const"))).toBe('redirect')
+    expect(literalString(firstInitializer('const x = `/posts` satisfies string'))).toBe('/posts')
+  })
+
+  it('still misses rather than invents', () => {
+    expect(literalString(firstInitializer('const x = ROUTE as string'))).toBeNull()
+    expect(literalString(firstInitializer('const x = `/posts/${id}` as const'))).toBeNull()
+  })
+})

--- a/packages/cli/tests/audit.test.ts
+++ b/packages/cli/tests/audit.test.ts
@@ -1005,6 +1005,32 @@ export class Post extends defineModel(posts, {
     }
   })
 
+  it('counts a fillable option written behind a satisfies wrapper', async () => {
+    const workspace = await createTempWorkspace('guren-cli-audit-mass-option-satisfies-')
+
+    try {
+      await mkdir(join(workspace.dir, 'app/Models'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Models/Post.ts'),
+        `import { defineModel, type ModelOptions } from '@guren/core'
+import { posts } from '../../db/schema.js'
+
+export class Post extends defineModel(posts, {
+  fillable: ['title', 'body'],
+} satisfies ModelOptions) {}`,
+        'utf8',
+      )
+
+      const report = await runAudit({ cwd: workspace.dir })
+
+      const post = report.findings.find(f => f.key === 'mass-assignment:Post')
+      expect(post).toBeDefined()
+      expect(post!.status).toBe('pass')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('counts hidden passed as a defineModel option, with static shadowing it', async () => {
     const workspace = await createTempWorkspace('guren-cli-audit-hidden-option-')
 

--- a/packages/cli/tests/channel-types.test.ts
+++ b/packages/cli/tests/channel-types.test.ts
@@ -65,6 +65,58 @@ describe('generateChannelTypes', () => {
     }
   })
 
+  it('reads a channel and event name written behind a transparent wrapper', async () => {
+    const workspace = await createTempWorkspace('guren-cli-channel-types-wrapped-name-')
+    try {
+      await mkdir(join(workspace.dir, 'app/Providers'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Providers/BroadcastProvider.ts'),
+        `export function setup(broadcast: any) {
+  broadcast.channel('announcements' as const, () => true)
+  broadcast.broadcast('announcements' as const, 'NewPost' as const, { id: 1 })
+}
+`,
+        'utf8',
+      )
+
+      const { channels, outputPath } = await generateChannelTypes({ appRoot: workspace.dir, force: true })
+
+      // A wrapped name used to read as no name at all, which drops the whole
+      // channel rather than degrading its payload to `unknown`.
+      expect(channels).toContain('announcements')
+      expect(await readFile(outputPath, 'utf8')).toContain("'NewPost': { id: number }")
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reads a payload written behind a transparent wrapper', async () => {
+    const workspace = await createTempWorkspace('guren-cli-channel-types-wrapped-')
+    try {
+      await mkdir(join(workspace.dir, 'app/Providers'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'app/Providers/BroadcastProvider.ts'),
+        `export function setup(broadcast: any) {
+  broadcast.channel('announcements', () => true)
+  broadcast.broadcast('announcements', 'NewPost', { id: 1, tags: ['a'] as const } as const)
+  broadcast.broadcast('announcements', 'Summary', 'hello' satisfies string)
+}
+`,
+        'utf8',
+      )
+
+      const { outputPath } = await generateChannelTypes({ appRoot: workspace.dir, force: true })
+      const content = await readFile(outputPath, 'utf8')
+
+      // Wrapped payloads used to render as `unknown`, which types every
+      // listener's argument as unusable rather than as the shape it carries.
+      expect(content).toContain("'NewPost': { id: number; tags: (string)[] }")
+      expect(content).toContain("'Summary': string")
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   // Plugins used to be a fixed typescript+jsx pair for every extension. In a
   // `.ts` file that makes `<Type>value` cast syntax parse as an unterminated
   // JSX element, so the file silently contributed no channels at all.

--- a/packages/cli/tests/console-check.test.ts
+++ b/packages/cli/tests/console-check.test.ts
@@ -191,6 +191,29 @@ kernel.registerMany([SendDigestCommand])`,
     }
   })
 
+  it('ignores a default-exported object literal written behind an as-const wrapper', async () => {
+    const workspace = await createTempWorkspace('guren-cli-check-console-inert-as-const-')
+
+    try {
+      await mkdir(join(workspace.dir, 'app/Console/Commands'), { recursive: true })
+      // `export default { … } as const` is a TSAsExpression, so the inert-shape
+      // test used to miss it and the module was treated as possibly holding a
+      // command — a registration warning nothing could ever resolve.
+      await writeFile(
+        join(workspace.dir, 'app/Console/Commands/table-config.ts'),
+        `export default { users: 'users', posts: 'posts' } as const`,
+        'utf8',
+      )
+
+      const report = await runCheck({ cwd: workspace.dir })
+
+      expect(report.checks.some(c => c.key.startsWith('console-command:'))).toBe(false)
+      expect(report.checks.some(c => c.key.startsWith('console-entry:'))).toBe(false)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('keeps a re-export shim in the check', async () => {
     const workspace = await createTempWorkspace('guren-cli-check-console-shim-')
 

--- a/packages/cli/tests/model-parser.test.ts
+++ b/packages/cli/tests/model-parser.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'bun:test'
-import { parseModelSource } from '../src/model-parser'
+import {
+  classUsesAuthenticatableBase,
+  firstClassDeclaration,
+  hasModelConfig,
+  parseModelSource,
+  resolveModelStringArrayConfig,
+  staticStringProperty,
+} from '../src/model-parser'
+import { parseSourceFile } from '../src/parse-cache'
 
 describe('parseModelSource', () => {
   it('parses defineModel pattern with belongsTo', () => {
@@ -88,6 +96,104 @@ if (typeof User.hasMany === 'function') {
     expect(result!.usesAuth).toBe(true)
     expect(result!.relationships).toHaveLength(1)
     expect(result!.relationships[0].name).toBe('posts')
+  })
+
+  it('parses a defineModel options object written behind an as-const wrapper', () => {
+    const source = `
+import { AuthenticatableModel, defineModel } from '@guren/core'
+import { users } from '../../db/schema.js'
+
+export class User extends defineModel(users, {
+  base: AuthenticatableModel,
+  name: 'Account',
+} as const) {}
+`
+    const result = parseModelSource(source, '/app/Models/User.ts')
+
+    expect(result).not.toBeNull()
+    expect(result!.usesAuth).toBe(true)
+  })
+
+  it('reads a string-array config written behind an as-const wrapper', () => {
+    const source = `
+import { defineModel } from '@guren/orm'
+import { posts } from '../../db/schema.js'
+
+export class Post extends defineModel(posts) {
+  static override fillable = ['title', 'body'] as const
+}
+`
+    const ast = parseSourceFile(source, '/app/Models/Post.ts')
+    const classDecl = firstClassDeclaration(ast!.program.body)!
+
+    expect(resolveModelStringArrayConfig(classDecl, 'fillable')).toEqual(['title', 'body'])
+  })
+
+  it('reads a string-array defineModel option written behind an as-const wrapper', () => {
+    // The composed path `guren audit` walks: findDefineModelOption reaches the
+    // property, stringArrayEntries has to see through the array's own wrapper.
+    const source = `
+import { defineModel } from '@guren/orm'
+import { posts } from '../../db/schema.js'
+
+export class Post extends defineModel(posts, { fillable: ['title'] as const }) {}
+`
+    const ast = parseSourceFile(source, '/app/Models/Post.ts')
+    const classDecl = firstClassDeclaration(ast!.program.body)!
+
+    expect(resolveModelStringArrayConfig(classDecl, 'fillable')).toEqual(['title'])
+  })
+
+  it('reads a defineModel base, a static string and array entries through wrappers', () => {
+    const source = `
+import { AuthenticatableModel, defineModel } from '@guren/core'
+import { users } from '../../db/schema.js'
+
+export class User extends defineModel(users, {
+  base: AuthenticatableModel satisfies typeof AuthenticatableModel,
+}) {
+  static override passwordHashField = 'secretHash' as const
+  static override fillable = [('name' satisfies keyof UserRecord)]
+}
+`
+    const ast = parseSourceFile(source, '/app/Models/User.ts')
+    const classDecl = firstClassDeclaration(ast!.program.body)!
+
+    expect(classUsesAuthenticatableBase(classDecl)).toBe(true)
+    expect(staticStringProperty(classDecl, 'passwordHashField')).toBe('secretHash')
+    expect(resolveModelStringArrayConfig(classDecl, 'fillable')).toEqual(['name'])
+  })
+
+  it('still treats a wrapped `undefined` option as the absent option it is', () => {
+    // `defineModel` skips the assignment either way, so reading this as a
+    // declared allowlist would report mass-assignment protection the runtime
+    // does not have — the widening the unwrap could otherwise cause.
+    const source = `
+import { defineModel } from '@guren/orm'
+import { posts } from '../../db/schema.js'
+
+export class Post extends defineModel(posts, {
+  fillable: undefined as string[] | undefined,
+} as const) {}
+`
+    const ast = parseSourceFile(source, '/app/Models/Post.ts')
+    const classDecl = firstClassDeclaration(ast!.program.body)!
+
+    expect(hasModelConfig(classDecl, 'fillable')).toBe(false)
+  })
+
+  it('reads a relationship name written behind a wrapper', () => {
+    const source = `
+import { defineModel } from '@guren/orm'
+import { posts } from '../../db/schema.js'
+
+export class Post extends defineModel(posts) {}
+
+Post.belongsTo('author' as const, (() => null) as any, 'authorId', 'id')
+`
+    const result = parseModelSource(source, '/app/Models/Post.ts')
+
+    expect(result!.relationships.map((r) => r.name)).toEqual(['author'])
   })
 
   it('does not flag a plain defineModel model as authenticatable', () => {

--- a/packages/cli/tests/schema-parser.test.ts
+++ b/packages/cli/tests/schema-parser.test.ts
@@ -222,6 +222,117 @@ export const posts = pgTable('posts', {
     }
   })
 
+  it('reads a column map written behind a transparent wrapper', async () => {
+    const workspace = await createTempWorkspace('guren-cli-schema-wrapped-')
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'db/schema.ts'),
+        `import { pgTable, serial, timestamp } from 'drizzle-orm/pg-core'
+
+export const posts = pgTable('posts', {
+  id: serial('id').primaryKey(),
+  createdAt: timestamp('created_at', { withTimezone: false } as const),
+} satisfies Record<string, unknown>)
+`,
+        'utf8',
+      )
+
+      const tables = await parseSchemaTables(workspace.dir)
+
+      // The wrapped column map used to make the whole table invisible.
+      expect(tables.map((t) => t.identifier)).toEqual(['posts'])
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reads column options written behind a transparent wrapper', async () => {
+    const workspace = await createTempWorkspace('guren-cli-schema-wrapped-options-')
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'db/schema.ts'),
+        `import { pgTable, timestamp } from 'drizzle-orm/pg-core'
+
+export const posts = pgTable('posts', {
+  createdAt: timestamp('created_at', { withTimezone: false } as const),
+})
+`,
+        'utf8',
+      )
+
+      const [posts] = await parseSchemaTables(workspace.dir)
+      const createdAt = posts.columns.find((c) => c.name === 'createdAt')!
+
+      // Wrapped options used to read as opaque, so a written `false` looked
+      // like an unknown and the timestamptz check skipped the column.
+      expect(createdAt.opaqueOptions).toBeUndefined()
+      expect(createdAt.withTimezone).toBe(false)
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('reads a table and column name written behind a transparent wrapper', async () => {
+    const workspace = await createTempWorkspace('guren-cli-schema-wrapped-names-')
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'db/schema.ts'),
+        `import { pgTable, timestamp } from 'drizzle-orm/pg-core'
+
+export const posts = pgTable('blog_posts' as const, {
+  createdAt: timestamp('created_at' as const),
+})
+`,
+        'utf8',
+      )
+
+      const [posts] = await parseSchemaTables(workspace.dir)
+
+      // A lost name is not a lost column: the timestamptz warning names the
+      // property, suggests the name-less builder form, and drops the SQL hint.
+      expect(posts.tableName).toBe('blog_posts')
+      expect(posts.columns.find((c) => c.name === 'createdAt')?.columnName).toBe('created_at')
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
+  it('treats an options object carrying a spread as unreadable, wrapped or not', async () => {
+    const workspace = await createTempWorkspace('guren-cli-schema-spread-')
+    try {
+      await mkdir(join(workspace.dir, 'db'), { recursive: true })
+      await writeFile(
+        join(workspace.dir, 'db/schema.ts'),
+        `import { pgTable, timestamp } from 'drizzle-orm/pg-core'
+
+const SHARED = { withTimezone: true }
+
+export const posts = pgTable('posts', {
+  spread: timestamp('spread', { ...SHARED }),
+  wrappedSpread: timestamp('wrapped_spread', { ...SHARED } as const),
+  absent: timestamp('absent'),
+})
+`,
+        'utf8',
+      )
+
+      const [posts] = await parseSchemaTables(workspace.dir)
+      const columns = new Map(posts.columns.map((c) => [c.name, c]))
+
+      // The spread may carry `withTimezone`, so its absence proves nothing —
+      // concluding "unset" here warns about a column the runtime got right.
+      expect(columns.get('spread')?.opaqueOptions).toBe(true)
+      expect(columns.get('wrappedSpread')?.opaqueOptions).toBe(true)
+      // Control: a genuinely option-less builder stays readable and warnable.
+      expect(columns.get('absent')?.opaqueOptions).toBeUndefined()
+    } finally {
+      await workspace.cleanup()
+    }
+  })
+
   it('ignores a computed option key rather than reading the identifier as its name', async () => {
     const workspace = await createTempWorkspace('guren-cli-schema-computed-key-')
     try {


### PR DESCRIPTION
## Summary

CLI AST scanners tested a Babel node's shape without first unwrapping transparent TypeScript wrapping (`as const`, `satisfies T`, `x!`, `<T>x`), so a wrapper made the declaration invisible. This is the same class as #628, in the files that PR did not reach.

The failure mode is silent by construction: these scans report "cannot read this" and "nothing to flag" as the same empty result, so a fully static declaration reads as unreadable and the scan says nothing.

- `defineModel(users, { … } satisfies ModelOptions)` dropped every option at once — `guren audit` reported a model with a `fillable` allowlist as having none, and a wrapped `base: AuthenticatableModel` lost its authentication classification (as did a `base:` wrapped on its own). The string-array reader also missed a wrapper on the array and on its entries, and `static passwordHashField = '…' as const` read as absent, taking the denied-credential-column check with it.
- A wrapped drizzle column map made the whole table invisible to `parseSchemaTables` — and so to the schema checks, attachments table bindings, `make:feature`, and `guren context`. Wrapped column options read as opaque, so `timestamp('created_at', { withTimezone: false } as const)` skipped the Postgres `timestamptz` warning instead of earning it. A wrapped table or column *name* was lost outright, which made that warning cite the property rather than the SQL column and drop its `USING` hint.
- `broadcast('c', 'e', { id: 1 } as const)` rendered as `unknown` in `.guren/channels.gen.ts`, typing every listener's argument as unusable rather than as the shape it carries.
- `export default { … } as const` was absent from the inert-default-export set, so a shared-constants module was treated as possibly holding a console command and drew a registration warning nothing could resolve.
- `mcpPlugin({ … } satisfies McpPluginOptions)` read as unreadable, and that scan's positive-evidence-only rule turned that into silence — an agent route requiring approval went unreported despite having nowhere to queue it.
- A relationship name written `Post.belongsTo('author' as const, …)` was dropped from model listings, `guren context`, and the ER spec.

### Two widenings closed in the same pass

Unwrapping can turn "unreadable" into a confidently wrong reading. Both cases found here are closed:

- `fillable: undefined as string[] | undefined` still reads as the absent option it is. `defineModel` skips the assignment, so reading it as a declared allowlist would report mass-assignment protection the runtime does not apply.
- A drizzle options object carrying a spread now reads as unreadable whether or not it is wrapped. `timestamp('c', { ...SHARED })` may well set `withTimezone`, so concluding "unset" warns about a column that was already right. (This half was a pre-existing gap for the unwrapped spelling; unwrapping merely stopped the wrapper from accidentally hiding it.)

### Why no source-level guard

A grep guard over quoted `'ObjectExpression'`, in the style of `packages/cli/tests/class-member-walk-guard.test.ts`, was considered and deliberately rejected: this invariant is a dataflow property, not a lexical one. `model-parser.ts` still spells the bare shape test in several places and each is correct, because the caller unwraps — a grep cannot separate those from `findDefineModelOption`, which spelled the identical test in the same file and was a bug. The allowlist would have had to name the whole file and would have blinded the guard to the one site it was meant to catch. The reasoning is recorded on `objectLiteral()` so the next sweep does not re-derive it.

(The existing `ClassMethod` guard did fire once during this work — on prose in a docstring. That is the clearest available argument for the rejection.)

## Scope

`cli` — `ast-walk.ts`, `model-parser.ts`, `schema-parser.ts`, `channel-types.ts`, `console-check.ts`, `agent-route-check.ts`, plus tests. No other package touched.

`unwrapTypeAssertion` gains a `BabelNode` overload so the walk-based scanners can reach the shared rule without a cast per call; those are the scanners holding loosely typed nodes precisely *because* they walk, and making them pay a double cast is what pushes the next one into spelling the unwrap loop itself. It also now stops rather than throwing on a wrapper carrying no `expression`, since `literalString` accepts `unknown` and forwards it unvalidated.

`packages/cli/tests/ast-walk.test.ts` is new — the shared rule had no direct tests. It handles five wrapper spellings but only two were exercised anywhere, and `ParenthesizedExpression` is unreachable through `parseSourceFile`'s plugin set, so that branch is covered by parsing with `createParenthesizedExpressions` on.

## Risk Assessment

Low. Every change converts a silent "cannot read" into a verdict; no check's *rule* changed, only what it can see.

- Ran `guren check` and `guren audit` against `examples/blog`, `examples/api`, and `web` on this branch and on `main`, and diffed: **no difference**. Neither new findings nor suppressed ones on real code.
- The two widening cases above are the failure mode this could have introduced; both are fixed and pinned by tests.
- No public API change. The `unwrapTypeAssertion` overload is additive.

One test (`reads a channel and event name written behind a transparent wrapper`) passes on `main` already — #628's `literalString` unwrap fixed that half. It is kept as a pin rather than removed.

## Validation

- [x] `bun run build` (`build:clean`)
- [x] `bun run typecheck`
- [x] `bun run test`

```
packages/cli                    2077 pass   0 fail
all other packages              3922 pass   0 fail  (84 skip)
test:examples                    280 pass   0 fail  (29+15+16 files)
audit:core-first / audit:docs   passed
```

Each of the 16 added tests was confirmed to **fail before its fix** — 15 of them still fail against `main`'s `packages/cli/src`, and the 16th is the guard against the `undefined`-widening described above. A test that does not actually wrap its fixture proves nothing here, so this was checked per site rather than in a batch.

One earlier version of the `mcpPlugin` approvals test did **not** pin its behaviour (both the fixed and unfixed code produce "no finding"); it now pairs the wrapped call with a readable one that has no queue, so the wrapped call has to be understood as *configured* for the test to pass.

`bun run test:bun` as a single invocation intermittently dies with a Bun `Segmentation fault` in `tool-dev.test.ts`'s Vite optimizer. That reproduces on `main` with the same command and is unrelated to this diff; per-package runs (above) are green.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.

Changeset: `@guren/cli` patch.
