### PR TITLE
refactor(server): give the buildToolRequest failure wording one definition

### DIFF
--- a/.changeset/agent-dispatch-browser-subpath.md
+++ b/.changeset/agent-dispatch-browser-subpath.md
@@ -8,4 +8,6 @@ Add `@guren/server/agent`, the browser-safe half of the agent dispatch surface (
 
 The entry deliberately re-exports **no value** from `agent/derive`. `dispatch.ts` imports `DerivedAgentTool` with `import type`, which is what keeps the derivation — and through it `Router` and the authorization middleware — out of the graph; a value re-export would undo that with nothing failing.
 
+The entry also exports `describeBuildFailure` (with its `ToolRequestBuildFailure` input type): the one wording for the two ways `buildToolRequest` refuses to build — a missing path parameter, a `.`/`..` path value. One function rather than a string per adapter, because the same tool is reachable from several surfaces and an agent that reads a different diagnosis depending on which one it reached would be debugging the client instead of its own call. `@guren/plugin-mcp` and the WebMCP client both read it.
+
 `BuildToolRequestOptions` gains `surface`, which sets the `X-Guren-Agent-Surface` header the builder previously hardcoded to `'mcp'`. It defaults to `'mcp'`, so every existing caller sends exactly what it sent before, and `'webmcp'` is what an in-browser call announces. The header is informational and write-only inside the framework — it is there for an application that wants to tell the surfaces apart, and no check may ever rest on it, since any client sets any header it likes.

--- a/.changeset/plugin-mcp-shared-build-failure.md
+++ b/.changeset/plugin-mcp-shared-build-failure.md
@@ -1,0 +1,9 @@
+---
+'@guren/plugin-mcp': patch
+---
+
+Read the `buildToolRequest` failure messages from the shared `describeBuildFailure` instead of restating them.
+
+No message changes. The wording used to be duplicated byte-for-byte in the WebMCP client, held in sync by a comment; it now has one definition in `@guren/core/agent`, so the two surfaces cannot drift apart.
+
+`gurenPlugin.compatibility` rises to `">=1.13.0 <2.0.0"` — the plugin now imports a core export that first ships in 1.13.0, and the claim is what makes `guren plugin` refuse a core that lacks it. The `@guren/core` dependency range stays at the workspace version on purpose; `changeset version` raises the published floor.

--- a/packages/plugin-mcp/package.json
+++ b/packages/plugin-mcp/package.json
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "gurenPlugin": {
-    "compatibility": ">=1.11.0 <2.0.0"
+    "compatibility": ">=1.13.0 <2.0.0"
   },
   "files": [
     "dist"

--- a/packages/plugin-mcp/src/plugin.ts
+++ b/packages/plugin-mcp/src/plugin.ts
@@ -7,6 +7,7 @@ import {
   buildToolRequest,
   createAuditEmitter,
   definePlugin,
+  describeBuildFailure,
   deriveAgentTools,
   isReservedAgentToolName,
   mapToolResponse,
@@ -421,16 +422,10 @@ async function dispatchThroughApp(
     authorization: c.req.header('Authorization'),
     preflight,
   })
-  if ('missing' in built) {
+  if (!('request' in built)) {
     // No HTTP happened, but the call did — recorded by the caller as an
     // invocation with the status the app would have answered.
-    return badRequest(`Missing required path parameter(s): ${built.missing.join(', ')}.`)
-  }
-  if ('invalidPath' in built) {
-    return badRequest(
-      `Path parameter(s) ${built.invalidPath.join(', ')} may not be "." or ".." — `
-      + 'a dot-segment would resolve to a different route than the one authorized.',
-    )
+    return badRequest(describeBuildFailure(built))
   }
 
   // env and execution context are forwarded explicitly — omitting them

--- a/packages/plugin-webmcp/src/client.ts
+++ b/packages/plugin-webmcp/src/client.ts
@@ -22,6 +22,7 @@
  */
 import {
   buildToolRequest,
+  describeBuildFailure,
   mapToolResponse,
   type AgentToolInputSource,
   type DerivedAgentTool,
@@ -349,17 +350,8 @@ async function executeTool(
     surface: 'webmcp',
   })
 
-  // Wording matched to @guren/plugin-mcp's dispatch: one tool, two surfaces,
-  // and an agent that reads a different diagnosis depending on which one it
-  // reached would be debugging the client instead of its own call.
-  if ('missing' in built) {
-    return errorResult(`Missing required path parameter(s): ${built.missing.join(', ')}.`)
-  }
-  if ('invalidPath' in built) {
-    return errorResult(
-      `Path parameter(s) ${built.invalidPath.join(', ')} may not be "." or ".." — `
-      + 'a dot-segment would resolve to a different route than the one authorized.',
-    )
+  if (!('request' in built)) {
+    return errorResult(describeBuildFailure(built))
   }
 
   applyCsrfToken(built.request)

--- a/packages/server/src/agent/dispatch.ts
+++ b/packages/server/src/agent/dispatch.ts
@@ -72,6 +72,10 @@ export const PREFLIGHT_ARGUMENT = '_preflight'
 
 export type BuiltToolRequest =
   | { request: Request }
+  | ToolRequestBuildFailure
+
+/** The ways `buildToolRequest` refuses to build — no HTTP has happened. */
+export type ToolRequestBuildFailure =
   /** Path parameters the call did not supply — the URL cannot be built. */
   | { missing: string[] }
   /**
@@ -84,6 +88,24 @@ export type BuiltToolRequest =
    * percent-encoded, so this is the complete set.
    */
   | { invalidPath: string[] }
+
+/**
+ * The agent-facing diagnosis of a {@link ToolRequestBuildFailure}.
+ *
+ * One function rather than a string per adapter: the same tool is reachable
+ * from several surfaces (App MCP, WebMCP, `guren tool:call`), and an agent
+ * that reads a different diagnosis depending on which one it reached would
+ * be debugging the client instead of its own call.
+ */
+export function describeBuildFailure(failure: ToolRequestBuildFailure): string {
+  if ('missing' in failure) {
+    return `Missing required path parameter(s): ${failure.missing.join(', ')}.`
+  }
+  return (
+    `Path parameter(s) ${failure.invalidPath.join(', ')} may not be "." or ".." — `
+    + 'a dot-segment would resolve to a different route than the one authorized.'
+  )
+}
 
 /**
  * Rebuild the HTTP request a tool call describes.

--- a/packages/server/src/agent/public.ts
+++ b/packages/server/src/agent/public.ts
@@ -30,6 +30,7 @@
 export {
   advertisesStructuredOutput,
   buildToolRequest,
+  describeBuildFailure,
   mapToolResponse,
   PREFLIGHT_ARGUMENT,
 } from './dispatch'
@@ -37,6 +38,7 @@ export type {
   BuildToolRequestOptions,
   BuiltToolRequest,
   ToolCallOutcome,
+  ToolRequestBuildFailure,
 } from './dispatch'
 export type {
   AgentToolInputSource,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -55,6 +55,7 @@ export type {
 export {
   advertisesStructuredOutput,
   buildToolRequest,
+  describeBuildFailure,
   mapToolResponse,
   PREFLIGHT_ARGUMENT,
 } from './agent/dispatch'
@@ -62,6 +63,7 @@ export type {
   BuildToolRequestOptions,
   BuiltToolRequest,
   ToolCallOutcome,
+  ToolRequestBuildFailure,
 } from './agent/dispatch'
 // Meta-tool names an adapter adds to the catalogue and an application route
 // may not claim (RFC 0016 §5.4). Exported so `@guren/plugin-mcp` and

--- a/packages/server/tests/agent/public-entry.test.ts
+++ b/packages/server/tests/agent/public-entry.test.ts
@@ -15,6 +15,7 @@ import { deriveAgentTools, type DerivedAgentTool } from '../../src/agent/derive'
 import {
   advertisesStructuredOutput,
   buildToolRequest,
+  describeBuildFailure,
   mapToolResponse,
   PREFLIGHT_ARGUMENT,
 } from '../../src/agent/public'
@@ -37,9 +38,17 @@ describe('@guren/server/agent entry', () => {
     // can be asserted at runtime. The type exports are held by the consumers
     // that import them (packages/plugin-webmcp) and by `bun run typecheck`.
     expect(typeof buildToolRequest).toBe('function')
+    expect(typeof describeBuildFailure).toBe('function')
     expect(typeof mapToolResponse).toBe('function')
     expect(typeof advertisesStructuredOutput).toBe('function')
     expect(PREFLIGHT_ARGUMENT).toBe('_preflight')
+  })
+
+  test('should diagnose both failure shapes', () => {
+    expect(describeBuildFailure({ missing: ['id'] })).toBe(
+      'Missing required path parameter(s): id.',
+    )
+    expect(describeBuildFailure({ invalidPath: ['name'] })).toContain('may not be "." or ".."')
   })
 })
 


### PR DESCRIPTION
## What changed

`buildToolRequest`'s two refusals — a missing path parameter and a `.`/`..` path value — were diagnosed by byte-identical strings duplicated in `@guren/plugin-mcp` (`src/plugin.ts`) and the WebMCP client (`@guren/plugin-webmcp/src/client.ts`), held in sync only by a comment.

- `describeBuildFailure(failure): string` now lives on the dispatch seam (`packages/server/src/agent/dispatch.ts`), together with a `ToolRequestBuildFailure` type split out of `BuiltToolRequest`. The "one tool, two surfaces" invariant the client comment used to carry moved into the function's doc.
- Exported from the package index and from the browser-safe `@guren/server/agent` entry. The entry's header rules hold: the value comes from `./dispatch` (pure Web API), nothing new from `./derive`.
- Both call sites collapse to a single `if (!('request' in built))` branch reading the shared builder. **No message changes** — the wording assertions in `client.test.ts` pass unmodified.
- `packages/server/tests/agent/public-entry.test.ts` asserts the new re-export and both failure shapes' diagnoses.

## Why

The invariant was enforced by a comment, not by code: an edit to either copy would silently hand an agent a different diagnosis depending on which surface it reached — debugging the client instead of its own call.

## Release notes

- `.changeset/agent-dispatch-browser-subpath.md` (the `/agent` subpath is merged but unreleased) gains a paragraph for the new export, so the surface ships as one coherent entry.
- New patch changeset for `@guren/plugin-mcp`. Its `gurenPlugin.compatibility` rises to `>=1.13.0 <2.0.0` — it now imports a core export that first ships in 1.13.0. The `@guren/core` dependency range stays at the workspace version on purpose; `changeset version` raises the published floor (same convention as `@guren/plugin-webmcp`).

## Verification

- `bun run build:clean`, `bun run typecheck` — green
- `bun run test:bun plugin-mcp plugin-webmcp server` — 2846 pass / 0 fail
- `bun run audit:plugin-compat`, `audit:core-first`, `audit:docs` — green