### PR TITLE
feat: serve the App MCP endpoint on deployed targets (RFC 0016 Phase 4a)

### DIFF
--- a/.changeset/deploy-build-mcp-transport-optin.md
+++ b/.changeset/deploy-build-mcp-transport-optin.md
@@ -1,0 +1,9 @@
+---
+'@guren/core': minor
+---
+
+Add the App MCP build opt-in to `@guren/core/internal/deploy-build`: `appUsesMcpPlugin()` and `stubbableDevOnlyModules()`, plus the `MCP_PLUGIN_PACKAGE` and `MCP_TRANSPORT_SPECIFIER` constants they are stated in terms of.
+
+The deploy plugins stub every entry of `DEV_ONLY_MODULES`, and one of those entries is the transport `@guren/plugin-mcp` dynamically imports — so an app that installed the plugin deployed an App MCP endpoint that could never load (RFC 0016 §7). The new functions are the policy layer: declaring `@guren/plugin-mcp` under `dependencies` is the opt-in, and the transport entry is then the one thing dropped from the stub set. The Dev MCP's `McpServer`, `@guren/cli`, `bun:sqlite` and `vite` stay stubbed for every app.
+
+A minor rather than a patch: `internal/deploy-build` is a published subpath of `@guren/core`, so these are new exports on a shipped surface, and a caret range does not deliver an export the installed package does not have. `DEV_ONLY_MODULES` itself is unchanged.

--- a/.changeset/deploy-plugins-app-mcp-transport.md
+++ b/.changeset/deploy-plugins-app-mcp-transport.md
@@ -1,0 +1,13 @@
+---
+'@guren/plugin-cloudflare': patch
+'@guren/plugin-lambda': patch
+'@guren/plugin-vercel': patch
+---
+
+Stop compiling the App MCP endpoint shut when an app depends on `@guren/plugin-mcp`.
+
+All three deploy plugins stubbed `@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js`, which `@guren/plugin-mcp` dynamically imports to serve the endpoint; Lambda and Vercel additionally routed *every* unlisted `@modelcontextprotocol/sdk/*` subpath to a throwing stub, which also killed the plugin's static imports of `server/index.js` and `types.js`. A deployed endpoint could therefore never load, with no build error to say so.
+
+Each platform now derives its stub set from `stubbableDevOnlyModules()`, and Lambda and Vercel drop the SDK-prefix catch-all, from one read of the app's manifest. The dev-only MCP server (`server/mcp.js`), `@guren/cli`, `bun:sqlite` and `vite` stay stubbed on every platform, for every app.
+
+On Cloudflare the aliases are baked into the app's committed `wrangler.jsonc`, which the scaffold writes once and never overwrites — so an app that adds the plugin after its first deploy would keep the stale alias indefinitely. `cloudflare:build` now fails with the exact alias line to delete when that app depends on `@guren/plugin-mcp`, before it runs the app build.

--- a/packages/core/src/internal/deploy-build.test.ts
+++ b/packages/core/src/internal/deploy-build.test.ts
@@ -4,9 +4,12 @@ import { isBuiltin } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+  appUsesMcpPlugin,
   assertOutputDirOutsideRoot,
   clientManifestJson,
   DATABASE_FACTORIES,
+  MCP_TRANSPORT_SPECIFIER,
+  stubbableDevOnlyModules,
   detectDatabaseDialects,
   DEV_ONLY_MODULES,
   parseDatabaseDialects,
@@ -312,6 +315,87 @@ describe('DEV_ONLY_MODULES', () => {
     for (const entry of sdkEntries) {
       expect(entry.specifier.startsWith(MCP_SDK_SUBPATH_PREFIX)).toBe(true)
     }
+  })
+
+  test('should carry the transport entry the App MCP endpoint needs', () => {
+    // `stubbableDevOnlyModules` drops this entry by specifier; renaming it
+    // upstream would silently drop nothing and leave the endpoint stubbed.
+    expect(DEV_ONLY_MODULES.map((module) => module.specifier)).toContain(MCP_TRANSPORT_SPECIFIER)
+  })
+})
+
+describe('appUsesMcpPlugin', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'guren-mcp-optin-'))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  function writeManifest(manifest: unknown): void {
+    writeFileSync(join(root, 'package.json'), JSON.stringify(manifest))
+  }
+
+  test('should report the opt-in when the plugin is a runtime dependency', () => {
+    writeManifest({ name: 'app', dependencies: { '@guren/core': '^1.12.0', '@guren/plugin-mcp': '^0.2.0' } })
+
+    expect(appUsesMcpPlugin(root)).toBe(true)
+  })
+
+  test('should not report the opt-in for a devDependency', () => {
+    // A devDependency never ships, so there is no endpoint in the deployed
+    // app for the transport to serve — keeping the SDK in the bundle of every
+    // app that merely develops against the plugin is the failure this avoids.
+    writeManifest({ name: 'app', devDependencies: { '@guren/plugin-mcp': '^0.2.0' } })
+
+    expect(appUsesMcpPlugin(root)).toBe(false)
+  })
+
+  test('should not report the opt-in when the manifest declares no dependencies', () => {
+    writeManifest({ name: 'app' })
+
+    expect(appUsesMcpPlugin(root)).toBe(false)
+  })
+
+  test('should not report the opt-in when there is no manifest', () => {
+    // Absent evidence is not evidence of opt-in, and false is the safe
+    // direction: the transport stays stubbed, exactly as before RFC 0016.
+    expect(appUsesMcpPlugin(root)).toBe(false)
+  })
+
+  test('should not report the opt-in when the manifest is malformed', () => {
+    writeFileSync(join(root, 'package.json'), '{ not json')
+
+    expect(appUsesMcpPlugin(root)).toBe(false)
+  })
+})
+
+describe('stubbableDevOnlyModules', () => {
+  test('should stub every dev-only module for an app without the MCP plugin', () => {
+    expect(stubbableDevOnlyModules({ mcpPlugin: false }).map((module) => module.specifier)).toEqual(
+      DEV_ONLY_MODULES.map((module) => module.specifier),
+    )
+  })
+
+  test('should drop only the transport for an app with the MCP plugin', () => {
+    const specifiers = stubbableDevOnlyModules({ mcpPlugin: true }).map((module) => module.specifier)
+
+    expect(specifiers).toEqual(
+      DEV_ONLY_MODULES.map((module) => module.specifier).filter(
+        (specifier) => specifier !== MCP_TRANSPORT_SPECIFIER,
+      ),
+    )
+    // Spelled out as well as derived: the Dev MCP's McpServer generates files
+    // on disk and must stay compiled shut whatever the app depends on, and
+    // `@guren/cli` behind it drags Babel into the bundle.
+    expect(specifiers).toContain('@modelcontextprotocol/sdk/server/mcp.js')
+    expect(specifiers).toContain('@guren/cli')
+    expect(specifiers).toContain('bun:sqlite')
+    expect(specifiers).toContain('vite')
+    expect(specifiers).not.toContain(MCP_TRANSPORT_SPECIFIER)
   })
 })
 

--- a/packages/core/src/internal/deploy-build.ts
+++ b/packages/core/src/internal/deploy-build.ts
@@ -786,17 +786,6 @@ export function unusedSqlClients(input: {
 export type DevOnlySpecifier = (typeof DEV_ONLY_MODULES)[number]['specifier']
 
 /**
- * Source for a stub replacing one dev-only module. Shared because what it
- * encodes is a bundler constraint, not a platform choice: every name the
- * importer destructures must be present or the bundle fails with "no matching
- * export", and each is emitted as a throwing *function* because the stubbed
- * names mix constructors (`new Database()`) with plain calls
- * (`createServer()`) — a class invoked without `new` reports "Class
- * constructor cannot be invoked without 'new'" instead of the real reason.
- *
- * @param message Platform-specific explanation, including the replacement API.
- */
-/**
  * A JavaScript string literal for `value`.
  *
  * `JSON.stringify` alone is not one: JSON and JavaScript disagree about
@@ -808,6 +797,17 @@ function toJsStringLiteral(value: string): string {
   return JSON.stringify(value).replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029')
 }
 
+/**
+ * Source for a stub replacing one dev-only module. Shared because what it
+ * encodes is a bundler constraint, not a platform choice: every name the
+ * importer destructures must be present or the bundle fails with "no matching
+ * export", and each is emitted as a throwing *function* because the stubbed
+ * names mix constructors (`new Database()`) with plain calls
+ * (`createServer()`) — a class invoked without `new` reports "Class
+ * constructor cannot be invoked without 'new'" instead of the real reason.
+ *
+ * @param message Platform-specific explanation, including the replacement API.
+ */
 export function renderDevOnlyStub(module: DevOnlyModule, message: string): string {
   // The message reaches the file twice and needs different escaping each
   // time: as a string literal in the thrown error, and as text in a comment

--- a/packages/core/src/internal/deploy-build.ts
+++ b/packages/core/src/internal/deploy-build.ts
@@ -436,6 +436,95 @@ export const DEV_ONLY_MODULES = [
   },
 ] as const satisfies readonly DevOnlyModule[]
 
+/** One entry of `DEV_ONLY_MODULES`, with its `kind` still narrowed. */
+export type DevOnlyModuleEntry = (typeof DEV_ONLY_MODULES)[number]
+
+/**
+ * The specifier `@guren/plugin-mcp` dynamically imports to serve the App MCP
+ * endpoint (RFC 0016 §7). Named here rather than inline in three plugins
+ * because it is the one entry of `DEV_ONLY_MODULES` whose stubbing is
+ * conditional, and each platform has to recognise it.
+ */
+export const MCP_TRANSPORT_SPECIFIER =
+  '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+
+/** The package an app declares to opt into the App MCP endpoint. */
+export const MCP_PLUGIN_PACKAGE = '@guren/plugin-mcp'
+
+/**
+ * Whether the app has opted into the App MCP endpoint (RFC 0016 §7).
+ *
+ * Resolves the RFC's Open Question 5 — how a build learns that an app wants
+ * the MCP transport — as **dependency sniffing**: declaring
+ * `@guren/plugin-mcp` in `dependencies` *is* the opt-in. Nothing else is
+ * asked of the developer, because there is nothing else to ask: an app that
+ * installed the plugin and mounted it wants the endpoint to work, and a build
+ * flag it must also remember to pass is a way for the endpoint to be silently
+ * compiled shut on a platform. The build does not *enable* anything here — it
+ * stops sabotaging what the app already configured.
+ *
+ * `dependencies` only, never `devDependencies`: a devDependency does not ship,
+ * so an app that has one has no MCP endpoint at runtime to protect. Reading
+ * both would keep the transport in the bundle of every app that merely
+ * develops against the plugin.
+ *
+ * Absent, unreadable, or malformed manifest answers `false` — no opt-in
+ * evidence is not the same as opt-in, and the false direction is the safe
+ * one: the transport stays stubbed, which is exactly today's behaviour.
+ */
+export function appUsesMcpPlugin(root: string): boolean {
+  try {
+    const manifest = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>
+    }
+    const dependencies = manifest.dependencies
+    return (
+      typeof dependencies === 'object'
+      && dependencies !== null
+      && MCP_PLUGIN_PACKAGE in dependencies
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * The dev-only modules that must stay stubbed for this app.
+ *
+ * The policy layer over `DEV_ONLY_MODULES`, which stays exported and
+ * unchanged: it is the full inventory, and other consumers (the wrangler
+ * bundle probe, the stub-filename table) read it as such. What varies per app
+ * is only whether the *transport* entry is in force.
+ *
+ * `@guren/plugin-mcp` reaches the App MCP endpoint through exactly one lazy
+ * import — `MCP_TRANSPORT_SPECIFIER` — plus static imports of the SDK's
+ * `server/index.js` and `types.js`, which no entry here names. Stubbing the
+ * transport therefore compiles the endpoint shut on every platform, which is
+ * what the three deploy plugins did until RFC 0016 Phase 4a. Dropping the
+ * entry for an app that declared the plugin is the whole of the fix.
+ *
+ * `@modelcontextprotocol/sdk/server/mcp.js` stays stubbed regardless, and the
+ * distinction matters: that is the **Dev** MCP's `McpServer`, reached from
+ * `@guren/server`'s `McpServiceProvider`, which drives the CLI's code
+ * generators against the filesystem. It is compiled shut by the `NODE_ENV`
+ * define anyway; the stub is the second guard, and a deployed app has no use
+ * for it either way. Same for `@guren/cli` behind it, and for `bun:sqlite`
+ * and `vite`, none of which the App MCP endpoint touches.
+ *
+ * The return type keeps the entries' narrow `kind` union, so a platform's
+ * `Record<kind, message>` table stays exhaustively keyed on the three kinds
+ * this list actually contains rather than widening to `DevOnlyModuleKind`.
+ */
+export function stubbableDevOnlyModules(options: {
+  mcpPlugin: boolean
+}): readonly DevOnlyModuleEntry[] {
+  if (!options.mcpPlugin) {
+    return DEV_ONLY_MODULES
+  }
+
+  return DEV_ONLY_MODULES.filter((module) => module.specifier !== MCP_TRANSPORT_SPECIFIER)
+}
+
 /**
  * A database `@guren/orm` can connect through, named after the factory an
  * app's database config calls to declare it.

--- a/packages/core/src/internal/deploy-build.ts
+++ b/packages/core/src/internal/deploy-build.ts
@@ -511,9 +511,16 @@ export function appUsesMcpPlugin(root: string): boolean {
  * for it either way. Same for `@guren/cli` behind it, and for `bun:sqlite`
  * and `vite`, none of which the App MCP endpoint touches.
  *
- * The return type keeps the entries' narrow `kind` union, so a platform's
- * `Record<kind, message>` table stays exhaustively keyed on the three kinds
- * this list actually contains rather than widening to `DevOnlyModuleKind`.
+ * The return type keeps each entry's narrow `kind` so that a platform can
+ * index its `Record<kind, message>` table with `module.kind` at all. What
+ * makes those tables exhaustive is not this function — each is keyed off
+ * `DEV_ONLY_MODULES` directly (on Workers, that list plus
+ * `SQL_CLIENT_MODULES`), which is what turns a new kind there into a compile
+ * error there. Widening the return to `readonly DevOnlyModule[]` would leave
+ * that exhaustiveness untouched and instead break every one of the lookups,
+ * since `DevOnlyModuleKind` includes `'sql-driver'` — a kind Lambda's and
+ * Vercel's tables deliberately omit, because those two platforms decide the
+ * SQL clients per app rather than per platform.
  */
 export function stubbableDevOnlyModules(options: {
   mcpPlugin: boolean

--- a/packages/plugin-cloudflare/src/build.test.ts
+++ b/packages/plugin-cloudflare/src/build.test.ts
@@ -644,15 +644,19 @@ describe('buildCloudflareOutput with a stale committed wrangler.jsonc', () => {
     expect(existsSync(join(root, '.cloudflare/worker.js'))).toBe(true)
   })
 
-  test('should not fail on a comment mentioning the transport specifier', async () => {
+  test('should not fail on the alias line commented out rather than deleted', async () => {
     scaffoldApp(root, { mcpPlugin: true })
-    // Exactly what a developer following the failure message leaves behind.
+    // What a developer following the failure message actually leaves behind:
+    // the line commented out, not deleted. Both the specifier and the stub
+    // filename are still in the file, so a guard that matched the text rather
+    // than the parsed keys would fail this build permanently, with the
+    // instruction it prints already carried out.
     writeFileSync(
       join(root, 'wrangler.jsonc'),
-      `{\n  // Deleted the ${MCP_TRANSPORT_SPECIFIER} alias so the App MCP\n`
-        + `  // endpoint works on Workers.\n`
-        + `  "name": "legacy",\n  "main": ".cloudflare/worker.js",\n  "alias": {\n`
+      `{\n  "name": "legacy",\n  "main": ".cloudflare/worker.js",\n  "alias": {\n`
         + `    "bun:sqlite": "./.cloudflare/stub-bun-sqlite.js",\n`
+        + `    // Removed for the App MCP endpoint (RFC 0016):\n`
+        + `    // ${JSON.stringify(MCP_TRANSPORT_SPECIFIER)}: "./.cloudflare/stub-mcp-transport.js"\n`
         + `  }\n}\n`,
     )
 

--- a/packages/plugin-cloudflare/src/build.test.ts
+++ b/packages/plugin-cloudflare/src/build.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { MCP_TRANSPORT_SPECIFIER } from '@guren/core/internal/deploy-build'
 import { buildCloudflareOutput } from './build'
 
 function writeJson(path: string, value: unknown): void {
@@ -25,12 +26,24 @@ const CLIENT_MANIFEST = {
   'resources/js/app.tsx': { file: 'app-Abc123.js', css: ['app-Def456.css'] },
 }
 
-function scaffoldApp(root: string, options: { ssr?: boolean; renderExport?: string } = {}): void {
-  const { ssr = true, renderExport = 'export const render = () => ({ body: "", head: [] })' } = options
+function scaffoldApp(
+  root: string,
+  options: { ssr?: boolean; renderExport?: string; mcpPlugin?: boolean } = {},
+): void {
+  const {
+    ssr = true,
+    renderExport = 'export const render = () => ({ body: "", head: [] })',
+    mcpPlugin = false,
+  } = options
 
   mkdirSync(join(root, 'src'), { recursive: true })
   writeFileSync(join(root, 'src/app.ts'), 'export default { boot: async () => {}, fetch: async () => new Response("ok") }\n')
-  writeJson(join(root, 'package.json'), { name: '@acme/demo-app' })
+  // Declaring `@guren/plugin-mcp` under `dependencies` is the App MCP opt-in
+  // the build reads (RFC 0016 §7).
+  writeJson(join(root, 'package.json'), {
+    name: '@acme/demo-app',
+    ...(mcpPlugin ? { dependencies: { '@guren/plugin-mcp': '^0.2.0' } } : {}),
+  })
 
   mkdirSync(join(root, 'public/assets/.vite'), { recursive: true })
   writeFileSync(join(root, 'public/robots.txt'), 'User-agent: *\n')
@@ -326,8 +339,49 @@ describe('workers runtime configuration', () => {
 
     expect(readFileSync(join(root, '.cloudflare/stub-bun-sqlite.js'), 'utf8')).toContain('throw new Error')
     expect(existsSync(join(root, '.cloudflare/stub-vite.js'))).toBe(true)
+
+    // The regression hold for the App MCP change: an app that did not ask for
+    // the endpoint keeps every stub it had.
+    expect(config.alias[MCP_TRANSPORT_SPECIFIER]).toBe('./.cloudflare/stub-mcp-transport.js')
   })
 
+  test('should leave the App MCP transport unaliased for an app depending on the plugin', async () => {
+    scaffoldApp(root, { mcpPlugin: true })
+
+    await buildCloudflareOutput({ rootDir: root, skipAppBuild: true })
+
+    const config = JSON.parse(readFileSync(join(root, 'wrangler.jsonc'), 'utf8'))
+    // The alias was the only thing killing the endpoint on Workers; the
+    // adapter itself is workerd-compatible (RFC 0016 §7).
+    expect(config.alias[MCP_TRANSPORT_SPECIFIER]).toBeUndefined()
+    // Everything else is unchanged — the Dev MCP's McpServer generates files
+    // on disk and must stay compiled shut whatever the app depends on.
+    expect(config.alias['@modelcontextprotocol/sdk/server/mcp.js']).toBe('./.cloudflare/stub-mcp-server.js')
+    expect(config.alias['@guren/cli']).toBe('./.cloudflare/stub-guren-cli.js')
+    expect(config.alias['bun:sqlite']).toBe('./.cloudflare/stub-bun-sqlite.js')
+    expect(config.alias.vite).toBe('./.cloudflare/stub-vite.js')
+    expect(config.alias.postgres).toBe('./.cloudflare/stub-postgres.js')
+
+    // The stub file is still written: an app whose committed config predates
+    // this version keeps pointing at it.
+    expect(existsSync(join(root, '.cloudflare/stub-mcp-transport.js'))).toBe(true)
+  })
+
+  test('should not suggest the transport alias when warning an MCP app about a stale config', async () => {
+    scaffoldApp(root, { mcpPlugin: true })
+    // A config predating the build-owned keys entirely, with no alias at all —
+    // so the warning names every entry it is missing.
+    writeFileSync(join(root, 'wrangler.jsonc'), '{ "name": "legacy" }\n')
+
+    const warning = await captureWarnings(() =>
+      buildCloudflareOutput({ rootDir: root, skipAppBuild: true }),
+    )
+
+    expect(warning).toContain('@modelcontextprotocol/sdk/server/mcp.js')
+    // Suggesting the transport alias would talk this app into the very stub
+    // the guard below fails on.
+    expect(warning).not.toContain(MCP_TRANSPORT_SPECIFIER)
+  })
   test('should define import.meta.url so module-scope URL resolution survives', async () => {
     scaffoldApp(root)
 
@@ -482,5 +536,92 @@ describe('workers runtime configuration', () => {
     await expect(buildCloudflareOutput({ rootDir: root, skipAppBuild: true })).rejects.toThrow(
       /both flatten to/,
     )
+  })
+})
+
+describe('buildCloudflareOutput with a stale committed wrangler.jsonc', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'guren-cf-mcp-'))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  /** A config carrying the alias set as scaffolded before the app added the plugin. */
+  function writeStaleConfig(root: string, extra = ''): void {
+    writeFileSync(
+      join(root, 'wrangler.jsonc'),
+      `{\n${extra}  "name": "legacy",\n  "main": ".cloudflare/worker.js",\n  "alias": {\n`
+        + `    "bun:sqlite": "./.cloudflare/stub-bun-sqlite.js",\n`
+        + `    ${JSON.stringify(MCP_TRANSPORT_SPECIFIER)}: "./.cloudflare/stub-mcp-transport.js"\n`
+        + `  }\n}\n`,
+    )
+  }
+
+  test('should fail and name the alias line to delete', async () => {
+    scaffoldApp(root, { mcpPlugin: true })
+    writeStaleConfig(root)
+
+    // The scaffold never overwrites an existing config, so this alias would
+    // otherwise survive every build and deploy the endpoint compiled shut,
+    // with nothing red anywhere.
+    const error = await buildCloudflareOutput({ rootDir: root, skipAppBuild: true }).catch(
+      (thrown: Error) => thrown,
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    const message = (error as Error).message
+    expect(message).toContain('@guren/plugin-mcp')
+    // The exact line, so the fix is an edit rather than a search.
+    expect(message).toContain(
+      `${JSON.stringify(MCP_TRANSPORT_SPECIFIER)}: "./.cloudflare/stub-mcp-transport.js"`,
+    )
+    // And the one entry that must survive the edit.
+    expect(message).toContain('@modelcontextprotocol/sdk/server/mcp.js')
+  })
+
+  test('should build normally when the app does not depend on the plugin', async () => {
+    scaffoldApp(root)
+    writeStaleConfig(root)
+
+    // Without the plugin the alias is correct, not stale — a guard that fired
+    // here would break every app that has ever deployed to Workers.
+    await captureWarnings(() => buildCloudflareOutput({ rootDir: root, skipAppBuild: true }))
+
+    expect(existsSync(join(root, '.cloudflare/worker.js'))).toBe(true)
+  })
+
+  test('should not fail on a comment mentioning the transport specifier', async () => {
+    scaffoldApp(root, { mcpPlugin: true })
+    // Exactly what a developer following the failure message leaves behind.
+    writeFileSync(
+      join(root, 'wrangler.jsonc'),
+      `{\n  // Deleted the ${MCP_TRANSPORT_SPECIFIER} alias so the App MCP\n`
+        + `  // endpoint works on Workers.\n`
+        + `  "name": "legacy",\n  "main": ".cloudflare/worker.js",\n  "alias": {\n`
+        + `    "bun:sqlite": "./.cloudflare/stub-bun-sqlite.js",\n`
+        + `  }\n}\n`,
+    )
+
+    await captureWarnings(() => buildCloudflareOutput({ rootDir: root, skipAppBuild: true }))
+
+    expect(existsSync(join(root, '.cloudflare/worker.js'))).toBe(true)
+  })
+
+  test('should build rather than fail when the config cannot be parsed', async () => {
+    scaffoldApp(root, { mcpPlugin: true })
+    writeFileSync(join(root, 'wrangler.jsonc'), '{ "name": "legacy", "alias": ')
+
+    // Unreadable is not evidence of a stale alias, and the existing
+    // build-owned-keys warning already reports the file.
+    const warning = await captureWarnings(() =>
+      buildCloudflareOutput({ rootDir: root, skipAppBuild: true }),
+    )
+
+    expect(existsSync(join(root, '.cloudflare/worker.js'))).toBe(true)
+    expect(warning).toContain('could not parse')
   })
 })

--- a/packages/plugin-cloudflare/src/build.test.ts
+++ b/packages/plugin-cloudflare/src/build.test.ts
@@ -583,6 +583,56 @@ describe('buildCloudflareOutput with a stale committed wrangler.jsonc', () => {
     expect(message).toContain('@modelcontextprotocol/sdk/server/mcp.js')
   })
 
+  test('should fail on generated residue under a custom output directory', async () => {
+    scaffoldApp(root, { mcpPlugin: true })
+    // Same residue, different outputDir — the alias target is a path this
+    // build chose, so matching the whole of it would miss every app that
+    // moved its output.
+    writeFileSync(
+      join(root, 'wrangler.jsonc'),
+      `{\n  "name": "legacy",\n  "alias": {\n`
+        + `    ${JSON.stringify(MCP_TRANSPORT_SPECIFIER)}: "./dist/cf/stub-mcp-transport.js"\n`
+        + `  }\n}\n`,
+    )
+
+    await expect(buildCloudflareOutput({ rootDir: root, skipAppBuild: true })).rejects.toThrow(
+      /@guren\/plugin-mcp/,
+    )
+  })
+
+  test('should leave an alias pointing at the developer own shim alone', async () => {
+    scaffoldApp(root, { mcpPlugin: true })
+    // An alias on this specifier is only *build residue* when it names the
+    // stub file this build writes. Pointing it somewhere else is a deliberate
+    // override — an alternative transport, an instrumented wrapper — and
+    // failing on it would refuse a config with nothing wrong with it, while
+    // claiming in the message that a stub is there when it is not.
+    writeFileSync(
+      join(root, 'wrangler.jsonc'),
+      `{\n  "name": "legacy",\n  "alias": {\n`
+        + `    ${JSON.stringify(MCP_TRANSPORT_SPECIFIER)}: "./shims/my-transport.js"\n`
+        + `  }\n}\n`,
+    )
+
+    await captureWarnings(() => buildCloudflareOutput({ rootDir: root, skipAppBuild: true }))
+
+    expect(existsSync(join(root, '.cloudflare/worker.js'))).toBe(true)
+  })
+
+  test('should leave a non-string alias target alone', async () => {
+    scaffoldApp(root, { mcpPlugin: true })
+    // Malformed rather than stale, and this guard exists to name one editable
+    // line — it cannot name one in a value that is not a path.
+    writeFileSync(
+      join(root, 'wrangler.jsonc'),
+      `{\n  "name": "legacy",\n  "alias": { ${JSON.stringify(MCP_TRANSPORT_SPECIFIER)}: 42 }\n}\n`,
+    )
+
+    await captureWarnings(() => buildCloudflareOutput({ rootDir: root, skipAppBuild: true }))
+
+    expect(existsSync(join(root, '.cloudflare/worker.js'))).toBe(true)
+  })
+
   test('should build normally when the app does not depend on the plugin', async () => {
     scaffoldApp(root)
     writeStaleConfig(root)

--- a/packages/plugin-cloudflare/src/build.test.ts
+++ b/packages/plugin-cloudflare/src/build.test.ts
@@ -382,6 +382,7 @@ describe('workers runtime configuration', () => {
     // the guard below fails on.
     expect(warning).not.toContain(MCP_TRANSPORT_SPECIFIER)
   })
+
   test('should define import.meta.url so module-scope URL resolution survives', async () => {
     scaffoldApp(root)
 

--- a/packages/plugin-cloudflare/src/build.ts
+++ b/packages/plugin-cloudflare/src/build.ts
@@ -69,11 +69,16 @@ export async function buildCloudflareOutput(options: BuildCloudflareOutputOption
   assertOutputDirOutsideRoot(out, root, 'Cloudflare build')
 
   const packageJson = readPackageJson(root)
+  // One read of the app's App MCP opt-in, threaded to both halves of the
+  // decision below — the guard on the committed config, and the alias set the
+  // scaffold writes. Two independent reads would be two places for them to
+  // disagree, silently; the other two deploy plugins thread it the same way.
+  const mcpPlugin = appUsesMcpPlugin(root)
 
   // Checked here, before the app build: this is a one-line edit to a file the
   // developer owns, and reporting it after several minutes of Vite output is
   // reporting it where nobody reads.
-  assertMcpTransportNotAliased(root)
+  assertMcpTransportNotAliased(root, mcpPlugin)
 
   if (!options.skipAppBuild) {
     runAppBuild(root, packageJson.scripts ?? {})
@@ -107,7 +112,7 @@ export async function buildCloudflareOutput(options: BuildCloudflareOutputOption
 
   writeDevOnlyStubs(out)
 
-  scaffoldWranglerConfig(root, out, packageJson.name, appUsesMcpPlugin(root))
+  scaffoldWranglerConfig(root, out, packageJson.name, mcpPlugin)
 }
 
 const MCP_UNAVAILABLE = 'The MCP endpoint is unavailable on Cloudflare Workers — it generates files on disk.'
@@ -202,6 +207,10 @@ function devOnlyAliases(outRelative: string, mcpPlugin: boolean): Record<string,
  * A warning would be the wrong instrument: this is one line to delete, in a
  * file the developer owns, and the build can name it exactly.
  *
+ * `mcpPlugin` arrives as an argument rather than being read here, so this and
+ * the alias set the scaffold writes cannot end up disagreeing about the same
+ * manifest.
+ *
  * Read through `parseJsonc` rather than as text, for the same reason
  * `warnMissingBuildOwnedKeys` does: a config carries comments, and a comment
  * mentioning the specifier — including the one the failure message itself
@@ -209,9 +218,9 @@ function devOnlyAliases(outRelative: string, mcpPlugin: boolean): Record<string,
  * left to that function's warning; failing a deploy on a file this build
  * could not read would be worse than the defect.
  */
-function assertMcpTransportNotAliased(root: string): void {
+function assertMcpTransportNotAliased(root: string, mcpPlugin: boolean): void {
   const configPath = resolve(root, 'wrangler.jsonc')
-  if (!existsSync(configPath) || !appUsesMcpPlugin(root)) {
+  if (!mcpPlugin || !existsSync(configPath)) {
     return
   }
 

--- a/packages/plugin-cloudflare/src/build.ts
+++ b/packages/plugin-cloudflare/src/build.ts
@@ -121,15 +121,15 @@ export async function buildCloudflareOutput(options: BuildCloudflareOutputOption
 const MCP_UNAVAILABLE = 'The MCP endpoint is unavailable on Cloudflare Workers — it generates files on disk.'
 
 /**
- * Why the dev-only modules in `DEV_ONLY_MODULES` cannot run here, worded for
- * this platform: each names the Workers-appropriate replacement.
- */
-/**
  * Both lists: on Workers the SQL clients are as unreachable as the dev-only
  * modules, because D1 is the only database the platform has.
  */
 const STUBBED_MODULES = [...DEV_ONLY_MODULES, ...SQL_CLIENT_MODULES]
 
+/**
+ * Why the stubbed modules cannot run here, worded for this platform: each
+ * names the Workers-appropriate replacement.
+ */
 const UNAVAILABLE_ON_WORKERS: Record<(typeof STUBBED_MODULES)[number]['kind'], string> = {
   sqlite: 'bun:sqlite is unavailable on Cloudflare Workers — use createD1Database().',
   vite: 'The Vite dev server is unavailable on Cloudflare Workers — assets are served by Workers Static Assets.',
@@ -161,28 +161,6 @@ const STUB_FILES: Record<DevOnlySpecifier | SqlClientSpecifier, string> = {
   mysql2: 'stub-mysql2.js',
   'mysql2/promise': 'stub-mysql2-promise.js',
   '@aws-sdk/client-rds-data': 'stub-rds-data.js',
-}
-
-/**
- * Does this alias target name the stub file *this build generates* for
- * `specifier`, rather than something of the app's own?
- *
- * Answered from `STUB_FILES` rather than a re-spelled literal: the filename
- * has exactly one definition, and a rename there must not leave a second
- * spelling behind that silently stops matching.
- *
- * The comparison is on the last path segment, because the directory the alias
- * points into is `outputDir`, an option — the same generated stub is
- * `./.cloudflare/stub-mcp-transport.js` in one app and `./dist/cf/…` in the
- * next. Both separators are split on: the value is a specifier wrangler
- * resolves, so it is written with forward slashes, but a config hand-edited
- * on Windows need not be.
- */
-function isGeneratedStubPath(
-  target: string,
-  specifier: DevOnlySpecifier | SqlClientSpecifier,
-): boolean {
-  return target.split(/[\\/]/).pop() === STUB_FILES[specifier]
 }
 
 function writeDevOnlyStubs(out: string): void {
@@ -239,11 +217,16 @@ function devOnlyAliases(outRelative: string, mcpPlugin: boolean): Record<string,
  * Failing on the key alone would refuse a config that has nothing wrong with
  * it, while asserting in the message that a stub is there when it is not.
  *
- * The test is on the filename from `STUB_FILES`, not on the whole path: the
- * output directory the alias points into is an option, so the same residue
- * reads as `./.cloudflare/…` or `./dist/cf/…`. A developer shim that happens
- * to be named `stub-mcp-transport.js` would be misread, which is the one
- * false positive left and is a name this build generates.
+ * The test is on the last path segment, not on the whole path: the output
+ * directory the alias points into is an option, so the same residue reads as
+ * `./.cloudflare/…` in one app and `./dist/cf/…` in the next. The filename
+ * comes from `STUB_FILES` rather than a re-spelled literal — it has exactly
+ * one definition, and a rename there must not leave a second spelling behind
+ * that silently stops matching. Both separators are split on: the value is a
+ * specifier wrangler resolves, so it is written with forward slashes, but a
+ * config hand-edited on Windows need not be. A developer shim that happens to
+ * be named `stub-mcp-transport.js` would be misread, which is the one false
+ * positive left and is a name this build generates.
  *
  * `mcpPlugin` arrives as an argument rather than being read here, so this and
  * the alias set the scaffold writes cannot end up disagreeing about the same
@@ -275,7 +258,7 @@ function assertMcpTransportNotAliased(root: string, mcpPlugin: boolean): void {
   }
 
   const target = (alias as Record<string, unknown>)[MCP_TRANSPORT_SPECIFIER]
-  if (typeof target !== 'string' || !isGeneratedStubPath(target, MCP_TRANSPORT_SPECIFIER)) {
+  if (typeof target !== 'string' || target.split(/[\\/]/).pop() !== STUB_FILES[MCP_TRANSPORT_SPECIFIER]) {
     return
   }
 

--- a/packages/plugin-cloudflare/src/build.ts
+++ b/packages/plugin-cloudflare/src/build.ts
@@ -2,11 +2,15 @@ import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, write
 import { relative, resolve, sep } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import {
+  appUsesMcpPlugin,
   DEV_ONLY_MODULES,
+  MCP_PLUGIN_PACKAGE,
+  MCP_TRANSPORT_SPECIFIER,
   SQL_CLIENT_MODULES,
   clientManifestJson,
   importSpecifier,
   renderDevOnlyStub,
+  stubbableDevOnlyModules,
   assertOutputDirOutsideRoot,
   resetOutputDir,
   resolveClientAssetEnv,
@@ -66,6 +70,11 @@ export async function buildCloudflareOutput(options: BuildCloudflareOutputOption
 
   const packageJson = readPackageJson(root)
 
+  // Checked here, before the app build: this is a one-line edit to a file the
+  // developer owns, and reporting it after several minutes of Vite output is
+  // reporting it where nobody reads.
+  assertMcpTransportNotAliased(root)
+
   if (!options.skipAppBuild) {
     runAppBuild(root, packageJson.scripts ?? {})
   }
@@ -98,7 +107,7 @@ export async function buildCloudflareOutput(options: BuildCloudflareOutputOption
 
   writeDevOnlyStubs(out)
 
-  scaffoldWranglerConfig(root, out, packageJson.name)
+  scaffoldWranglerConfig(root, out, packageJson.name, appUsesMcpPlugin(root))
 }
 
 const MCP_UNAVAILABLE = 'The MCP endpoint is unavailable on Cloudflare Workers — it generates files on disk.'
@@ -160,13 +169,69 @@ function writeDevOnlyStubs(out: string): void {
  * including each MCP SDK subpath — needs its own entry. Unlike the Lambda
  * plugin's bundler hook, wrangler cannot match a prefix, so an SDK subpath
  * added upstream needs a new `DEV_ONLY_MODULES` entry to stay stubbed here.
+ *
+ * `mcpPlugin` drops the App MCP transport's entry (RFC 0016 §7): an app that
+ * declares `@guren/plugin-mcp` serves the endpoint from the worker, and the
+ * adapter is workerd-compatible by construction — the alias was the only
+ * thing killing it. The Dev MCP's `McpServer` keeps its alias either way.
+ *
+ * The *files* are written unconditionally by `writeDevOnlyStubs`; only the
+ * alias set varies. A stub file costs nothing, and an app whose committed
+ * `wrangler.jsonc` still points at one must keep finding it.
  */
-function devOnlyAliases(outRelative: string): Record<string, string> {
+function devOnlyAliases(outRelative: string, mcpPlugin: boolean): Record<string, string> {
+  const stubbed = [...stubbableDevOnlyModules({ mcpPlugin }), ...SQL_CLIENT_MODULES]
+
   return Object.fromEntries(
-    STUBBED_MODULES.map((module) => [
+    stubbed.map((module) => [
       module.specifier,
       `./${outRelative}/${STUB_FILES[module.specifier]}`,
     ]),
+  )
+}
+
+/**
+ * Fail rather than deploy an app whose committed `wrangler.jsonc` still
+ * aliases the App MCP transport to a stub while its manifest declares
+ * `@guren/plugin-mcp`.
+ *
+ * The scaffold writes `wrangler.jsonc` once and never overwrites it, so an
+ * app that adds the plugin later keeps an alias nothing in the build controls
+ * — and the endpoint stays compiled shut with every gate green, the failure
+ * appearing only as `tools/list` returning nothing against a deployed worker.
+ * A warning would be the wrong instrument: this is one line to delete, in a
+ * file the developer owns, and the build can name it exactly.
+ *
+ * Read through `parseJsonc` rather than as text, for the same reason
+ * `warnMissingBuildOwnedKeys` does: a config carries comments, and a comment
+ * mentioning the specifier — including the one the failure message itself
+ * suggests writing — must not fail the build. A file that does not parse is
+ * left to that function's warning; failing a deploy on a file this build
+ * could not read would be worse than the defect.
+ */
+function assertMcpTransportNotAliased(root: string): void {
+  const configPath = resolve(root, 'wrangler.jsonc')
+  if (!existsSync(configPath) || !appUsesMcpPlugin(root)) {
+    return
+  }
+
+  let config: Record<string, unknown>
+  try {
+    config = parseJsonc(readFileSync(configPath, 'utf8')) as Record<string, unknown>
+  } catch {
+    return
+  }
+
+  const alias = config.alias
+  if (typeof alias !== 'object' || alias === null || !(MCP_TRANSPORT_SPECIFIER in alias)) {
+    return
+  }
+
+  const target = (alias as Record<string, unknown>)[MCP_TRANSPORT_SPECIFIER]
+  throw new Error(
+    `Cloudflare build: ${configPath} aliases the App MCP transport to a stub, but this app depends on ${MCP_PLUGIN_PACKAGE} — the endpoint would deploy compiled shut. Delete this one line from "alias":\n`
+    + `  ${JSON.stringify(MCP_TRANSPORT_SPECIFIER)}: ${JSON.stringify(target)}\n`
+    + `Leave every other alias entry in place; ${JSON.stringify('@modelcontextprotocol/sdk/server/mcp.js')} in particular must stay stubbed — that is the dev-only MCP server, which generates files on disk.`,
   )
 }
 
@@ -366,7 +431,12 @@ function renderWorkerModule(input: {
   return lines.join('\n')
 }
 
-function scaffoldWranglerConfig(root: string, out: string, packageName: string | undefined): void {
+function scaffoldWranglerConfig(
+  root: string,
+  out: string,
+  packageName: string | undefined,
+  mcpPlugin: boolean,
+): void {
   const configPath = resolve(root, 'wrangler.jsonc')
   const appName = (packageName ?? 'guren-app').replace(/^@[^/]+\//, '')
   const outRelative = relative(root, out).split(sep).join('/')
@@ -376,7 +446,7 @@ function scaffoldWranglerConfig(root: string, out: string, packageName: string |
     main: `${outRelative}/worker.js`,
     compatibility_date: new Date().toISOString().slice(0, 10),
     compatibility_flags: ['nodejs_compat'],
-    alias: devOnlyAliases(outRelative),
+    alias: devOnlyAliases(outRelative, mcpPlugin),
     define: {
       // Statements in the generated worker cannot beat ESM import hoisting,
       // and wrangler `vars` are not guaranteed to reach `process.env` before
@@ -410,7 +480,7 @@ function scaffoldWranglerConfig(root: string, out: string, packageName: string |
     writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, { flag: 'wx' })
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
-      warnMissingBuildOwnedKeys(configPath, outRelative)
+      warnMissingBuildOwnedKeys(configPath, outRelative, mcpPlugin)
       return
     }
     throw error
@@ -501,7 +571,11 @@ function parseJsonc(text: string): unknown {
  * an extra `define` — and a suggestion shaped like a complete object reads as
  * one to paste over what is there, which would drop them.
  */
-function warnMissingBuildOwnedKeys(configPath: string, outRelative: string): void {
+function warnMissingBuildOwnedKeys(
+  configPath: string,
+  outRelative: string,
+  mcpPlugin: boolean,
+): void {
   let config: Record<string, unknown>
   try {
     config = parseJsonc(readFileSync(configPath, 'utf8')) as Record<string, unknown>
@@ -523,7 +597,7 @@ function warnMissingBuildOwnedKeys(configPath: string, outRelative: string): voi
   const alias = (
     typeof configAlias === 'object' && configAlias !== null ? configAlias : {}
   ) as Record<string, string>
-  for (const [specifier, target] of Object.entries(devOnlyAliases(outRelative))) {
+  for (const [specifier, target] of Object.entries(devOnlyAliases(outRelative, mcpPlugin))) {
     if (!(specifier in alias)) {
       missing.push(`${JSON.stringify(specifier)}: ${JSON.stringify(target)} (inside "alias")`)
     }

--- a/packages/plugin-cloudflare/src/build.ts
+++ b/packages/plugin-cloudflare/src/build.ts
@@ -69,10 +69,13 @@ export async function buildCloudflareOutput(options: BuildCloudflareOutputOption
   assertOutputDirOutsideRoot(out, root, 'Cloudflare build')
 
   const packageJson = readPackageJson(root)
-  // One read of the app's App MCP opt-in, threaded to both halves of the
+  // The App MCP opt-in is decided once and threaded to both halves of the
   // decision below — the guard on the committed config, and the alias set the
-  // scaffold writes. Two independent reads would be two places for them to
+  // scaffold writes. Deciding it twice would be two places for one answer to
   // disagree, silently; the other two deploy plugins thread it the same way.
+  // This does parse package.json a second time, after `readPackageJson` above
+  // answered a different question (scripts, name): a second parse is cheap and
+  // cannot disagree with anything, a second *decision* is neither.
   const mcpPlugin = appUsesMcpPlugin(root)
 
   // Checked here, before the app build: this is a one-line edit to a file the
@@ -160,6 +163,28 @@ const STUB_FILES: Record<DevOnlySpecifier | SqlClientSpecifier, string> = {
   '@aws-sdk/client-rds-data': 'stub-rds-data.js',
 }
 
+/**
+ * Does this alias target name the stub file *this build generates* for
+ * `specifier`, rather than something of the app's own?
+ *
+ * Answered from `STUB_FILES` rather than a re-spelled literal: the filename
+ * has exactly one definition, and a rename there must not leave a second
+ * spelling behind that silently stops matching.
+ *
+ * The comparison is on the last path segment, because the directory the alias
+ * points into is `outputDir`, an option — the same generated stub is
+ * `./.cloudflare/stub-mcp-transport.js` in one app and `./dist/cf/…` in the
+ * next. Both separators are split on: the value is a specifier wrangler
+ * resolves, so it is written with forward slashes, but a config hand-edited
+ * on Windows need not be.
+ */
+function isGeneratedStubPath(
+  target: string,
+  specifier: DevOnlySpecifier | SqlClientSpecifier,
+): boolean {
+  return target.split(/[\\/]/).pop() === STUB_FILES[specifier]
+}
+
 function writeDevOnlyStubs(out: string): void {
   for (const module of STUBBED_MODULES) {
     writeFileSync(
@@ -196,9 +221,9 @@ function devOnlyAliases(outRelative: string, mcpPlugin: boolean): Record<string,
 }
 
 /**
- * Fail rather than deploy an app whose committed `wrangler.jsonc` still
- * aliases the App MCP transport to a stub while its manifest declares
- * `@guren/plugin-mcp`.
+ * Fail rather than deploy an app whose committed `wrangler.jsonc` still points
+ * the App MCP transport at a stub *this build generated*, while its manifest
+ * declares `@guren/plugin-mcp`.
  *
  * The scaffold writes `wrangler.jsonc` once and never overwrites it, so an
  * app that adds the plugin later keeps an alias nothing in the build controls
@@ -206,6 +231,19 @@ function devOnlyAliases(outRelative: string, mcpPlugin: boolean): Record<string,
  * appearing only as `tools/list` returning nothing against a deployed worker.
  * A warning would be the wrong instrument: this is one line to delete, in a
  * file the developer owns, and the build can name it exactly.
+ *
+ * The *value* is what decides, not the key. An alias on this specifier is only
+ * build residue when it names the stub file this build writes; pointing it at
+ * a shim of the developer's own is a deliberate override — an alternative
+ * transport, an instrumented wrapper — and none of this build's business.
+ * Failing on the key alone would refuse a config that has nothing wrong with
+ * it, while asserting in the message that a stub is there when it is not.
+ *
+ * The test is on the filename from `STUB_FILES`, not on the whole path: the
+ * output directory the alias points into is an option, so the same residue
+ * reads as `./.cloudflare/…` or `./dist/cf/…`. A developer shim that happens
+ * to be named `stub-mcp-transport.js` would be misread, which is the one
+ * false positive left and is a name this build generates.
  *
  * `mcpPlugin` arrives as an argument rather than being read here, so this and
  * the alias set the scaffold writes cannot end up disagreeing about the same
@@ -232,11 +270,15 @@ function assertMcpTransportNotAliased(root: string, mcpPlugin: boolean): void {
   }
 
   const alias = config.alias
-  if (typeof alias !== 'object' || alias === null || !(MCP_TRANSPORT_SPECIFIER in alias)) {
+  if (typeof alias !== 'object' || alias === null) {
     return
   }
 
   const target = (alias as Record<string, unknown>)[MCP_TRANSPORT_SPECIFIER]
+  if (typeof target !== 'string' || !isGeneratedStubPath(target, MCP_TRANSPORT_SPECIFIER)) {
+    return
+  }
+
   throw new Error(
     `Cloudflare build: ${configPath} aliases the App MCP transport to a stub, but this app depends on ${MCP_PLUGIN_PACKAGE} — the endpoint would deploy compiled shut. Delete this one line from "alias":\n`
     + `  ${JSON.stringify(MCP_TRANSPORT_SPECIFIER)}: ${JSON.stringify(target)}\n`

--- a/packages/plugin-cloudflare/src/wrangler-bundle.test.ts
+++ b/packages/plugin-cloudflare/src/wrangler-bundle.test.ts
@@ -1,8 +1,12 @@
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
-import { existsSync, mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { DEV_ONLY_MODULES, SQL_CLIENT_MODULES } from '@guren/core/internal/deploy-build'
+import {
+  DEV_ONLY_MODULES,
+  SQL_CLIENT_MODULES,
+  stubbableDevOnlyModules,
+} from '@guren/core/internal/deploy-build'
 
 // Opt-in end-to-end contract test: proves wrangler can actually bundle a
 // worker that imports `@guren/orm`, with only the stubs `cloudflare:build`
@@ -28,6 +32,48 @@ const DRIVER_PACKAGES = ['postgres', 'mysql2', '@aws-sdk']
 function wrangler(cwd: string, args: string[]): { exitCode: number; output: string } {
   const result = Bun.spawnSync({ cmd: ['bunx', 'wrangler', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
   return { exitCode: result.exitCode, output: `${result.stdout.toString()}${result.stderr.toString()}` }
+}
+
+/**
+ * Write the stub files and the `wrangler.jsonc` aliasing `modules` to them —
+ * what `cloudflare:build` scaffolds, written directly so a probe pins the
+ * contract rather than the command that emits it.
+ *
+ * Which modules a probe passes is the whole variable: the ORM probe below
+ * stubs everything, and the App MCP probe stubs everything *except* the
+ * transport, which is the configuration RFC 0016 Phase 4a produces.
+ */
+function writeWranglerConfig(
+  root: string,
+  name: string,
+  modules: readonly { specifier: string; exportNames: readonly string[] }[],
+): void {
+  mkdirSync(join(root, 'stubs'), { recursive: true })
+
+  const alias: Record<string, string> = {}
+  for (const module of modules) {
+    const file = `${module.specifier.replace(/[^a-zA-Z0-9]+/g, '-')}.js`
+    const throwing = module.exportNames
+      .map((exportName) => `export function ${exportName}() { throw new Error('stubbed') }`)
+      .join('\n')
+    const named = module.exportNames.length > 0 ? `, { ${module.exportNames.join(', ')} }` : ''
+    writeFileSync(
+      join(root, 'stubs', file),
+      `${throwing}\nfunction unavailable() { throw new Error('stubbed') }\nexport default Object.assign(unavailable${named})\n`,
+    )
+    alias[module.specifier] = `./stubs/${file}`
+  }
+
+  writeFileSync(
+    join(root, 'wrangler.jsonc'),
+    JSON.stringify({
+      name,
+      main: 'worker.ts',
+      compatibility_date: '2026-07-01',
+      compatibility_flags: ['nodejs_compat'],
+      alias,
+    }),
+  )
 }
 
 describe.skipIf(!enabled)('wrangler bundles a worker importing @guren/orm', () => {
@@ -97,31 +143,7 @@ describe.skipIf(!enabled)('wrangler bundles a worker importing @guren/orm', () =
 
     // The stubs and aliases `cloudflare:build` scaffolds, written directly so
     // the test pins the contract rather than the command that emits it.
-    const stubbed = [...DEV_ONLY_MODULES, ...SQL_CLIENT_MODULES]
-    const alias: Record<string, string> = {}
-    for (const module of stubbed) {
-      const file = `${module.specifier.replace(/[^a-zA-Z0-9]+/g, '-')}.js`
-      const throwing = module.exportNames
-        .map((name) => `export function ${name}() { throw new Error('stubbed') }`)
-        .join('\n')
-      const named = module.exportNames.length > 0 ? `, { ${module.exportNames.join(', ')} }` : ''
-      writeFileSync(
-        join(root, 'stubs', file),
-        `${throwing}\nfunction unavailable() { throw new Error('stubbed') }\nexport default Object.assign(unavailable${named})\n`,
-      )
-      alias[module.specifier] = `./stubs/${file}`
-    }
-
-    writeFileSync(
-      join(root, 'wrangler.jsonc'),
-      JSON.stringify({
-        name: 'bundle-probe',
-        main: 'worker.ts',
-        compatibility_date: '2026-07-01',
-        compatibility_flags: ['nodejs_compat'],
-        alias,
-      }),
-    )
+    writeWranglerConfig(root, 'bundle-probe', [...DEV_ONLY_MODULES, ...SQL_CLIENT_MODULES])
   })
 
   afterAll(() => {
@@ -139,5 +161,208 @@ describe.skipIf(!enabled)('wrangler bundles a worker importing @guren/orm', () =
       expect(result.exitCode).toBe(0)
     },
     180_000,
+  )
+})
+
+/**
+ * The free plan's compressed worker limit. Written as a byte count rather than
+ * copied from the RFC's prose "3 MB", which is loose about MB vs MiB — the
+ * platform's limit is 3 MiB of gzipped upload.
+ */
+const FREE_PLAN_GZIP_BUDGET = 3 * 1024 * 1024
+
+/** Extensions that count toward the upload; sourcemaps do not, and dwarf it. */
+const UPLOADED_EXTENSIONS = ['.js', '.mjs', '.wasm']
+
+/**
+ * The `@guren/*` packages a probe must resolve from this checkout, derived
+ * rather than listed: seed with the one the worker imports and close over the
+ * workspace `dependencies`. A package added to `@guren/plugin-mcp`'s graph
+ * enters the probe by itself — a hand-kept list is how a package comes to be
+ * installed from npm and silently verified in its *published* form instead
+ * (see `scripts/smoke/local-packages.ts`, which owns the same rule for the
+ * smokes).
+ */
+function workspaceClosure(seed: string): Map<string, { dir: string; manifest: Record<string, unknown> }> {
+  const packagesDir = new URL('../../', import.meta.url).pathname
+  const byName = new Map<string, { dir: string; manifest: Record<string, unknown> }>()
+  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const manifestPath = join(packagesDir, entry.name, 'package.json')
+    if (!existsSync(manifestPath)) continue
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<string, unknown>
+    byName.set(manifest.name as string, { dir: join(packagesDir, entry.name), manifest })
+  }
+
+  const closure = new Map<string, { dir: string; manifest: Record<string, unknown> }>()
+  const queue = [seed]
+  while (queue.length > 0) {
+    const name = queue.shift() as string
+    if (closure.has(name)) continue
+    const found = byName.get(name)
+    if (!found) {
+      throw new Error(`bundle probe: ${name} is not a package in this workspace`)
+    }
+    closure.set(name, found)
+    for (const dep of Object.keys((found.manifest.dependencies ?? {}) as Record<string, string>)) {
+      if (dep.startsWith('@guren/')) queue.push(dep)
+    }
+  }
+
+  return closure
+}
+
+describe.skipIf(!enabled)('wrangler bundles a worker importing @guren/plugin-mcp', () => {
+  let root: string
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'guren-wrangler-mcp-'))
+
+    const closure = workspaceClosure('@guren/plugin-mcp')
+
+    // Every third-party dependency of the closure, flattened to the probe's
+    // top level. Vendoring the workspace packages by *copy* rather than by
+    // tarball is not a shortcut: `bun add` of a tarball leaves the packages'
+    // own `@guren/*` ranges to resolve, which npm satisfies with published
+    // copies nested under each vendored package — measured directly, and the
+    // published `@guren/core` predates RFC 0016, so the bundle failed on
+    // exports the checkout has.
+    const thirdParty: Record<string, string> = {}
+    for (const { manifest } of closure.values()) {
+      for (const [name, range] of Object.entries((manifest.dependencies ?? {}) as Record<string, string>)) {
+        if (!name.startsWith('@guren/')) thirdParty[name] = range
+      }
+    }
+    // The real SDK, from npm: what the transport actually costs is the number
+    // this probe exists to report.
+    if (!thirdParty['@modelcontextprotocol/sdk']) {
+      throw new Error('bundle probe: no @modelcontextprotocol/sdk in the closure; the probe would measure nothing')
+    }
+
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'mcp-bundle-probe', type: 'module', private: true, dependencies: thirdParty }),
+    )
+    const install = Bun.spawnSync({ cmd: ['bun', 'install'], cwd: root, stdout: 'pipe', stderr: 'pipe' })
+    if (install.exitCode !== 0) {
+      throw new Error(`bundle probe setup failed to install dependencies:\n${install.stderr.toString()}`)
+    }
+
+    for (const [name, { dir, manifest }] of closure) {
+      const dist = join(dir, 'dist')
+      if (!existsSync(dist)) {
+        throw new Error(`bundle probe: ${name} has no dist/; run \`bun run build\` first`)
+      }
+      const target = join(root, 'node_modules', name)
+      mkdirSync(target, { recursive: true })
+      cpSync(dist, join(target, 'dist'), { recursive: true })
+      // Dependencies stripped from the copied manifest: everything is
+      // flattened at the probe's top level already, and leaving the ranges in
+      // is what would invite a resolver to fetch a second copy.
+      const { dependencies, devDependencies, peerDependencies, ...rest } = manifest
+      writeFileSync(join(target, 'package.json'), JSON.stringify(rest))
+    }
+
+    // Asserted rather than assumed, and this is the assertion the whole probe
+    // rests on: a package resolving *out* of the probe measures this monorepo
+    // rather than an installed app, which has reported a real bundle change
+    // as no change at all before.
+    for (const name of [...closure.keys(), '@modelcontextprotocol/sdk']) {
+      if (!existsSync(join(root, 'node_modules', name))) {
+        throw new Error(`bundle probe: ${name} did not land in the probe's node_modules`)
+      }
+    }
+    for (const name of closure.keys()) {
+      if (existsSync(join(root, 'node_modules', name, 'node_modules'))) {
+        throw new Error(`bundle probe: ${name} has nested node_modules; it would resolve a second copy`)
+      }
+    }
+
+    writeFileSync(
+      join(root, 'worker.ts'),
+      `import { mcpPlugin } from '@guren/plugin-mcp'\n`
+        + `export default {\n`
+        + `  async fetch(): Promise<Response> {\n`
+        + `    return new Response(typeof mcpPlugin)\n`
+        + `  },\n`
+        + `}\n`,
+    )
+
+  })
+
+  afterAll(() => {
+    if (root) rmSync(root, { recursive: true, force: true })
+  })
+
+  /**
+   * Bundle the probe with `modules` stubbed and report the gzipped bytes
+   * wrangler would upload.
+   *
+   * Gzipped here rather than parsed out of wrangler's own "Total Upload /
+   * gzip" line — that line is prose and can be reworded — but printed beside
+   * it so a human can reconcile the two. Sourcemaps are excluded: the `.map`
+   * beside the bundle is several times its size and the limit does not count
+   * it, so a whole-directory sum would fail for a file that never ships.
+   */
+  function bundleSize(
+    label: string,
+    modules: readonly { specifier: string; exportNames: readonly string[] }[],
+  ): number {
+    writeWranglerConfig(root, 'mcp-bundle-probe', modules)
+    const out = join(root, `out-${label}`)
+    const result = wrangler(root, ['deploy', '--dry-run', '--outdir', out])
+
+    // Name what is missing rather than only that something is: with the
+    // transport unstubbed, a bundle that cannot resolve reports the SDK
+    // subpath by name.
+    expect(result.output).not.toMatch(/Could not resolve/)
+    expect(result.exitCode).toBe(0)
+
+    let gzipped = 0
+    let files = 0
+    for (const file of readdirSync(out)) {
+      if (!UPLOADED_EXTENSIONS.some((extension) => file.endsWith(extension))) continue
+      gzipped += Bun.gzipSync(readFileSync(join(out, file))).byteLength
+      files += 1
+    }
+
+    // A worker with nothing measured passes any budget.
+    expect(files).toBeGreaterThan(0)
+
+    console.log(
+      `App MCP probe [${label}]: ${(gzipped / 1024).toFixed(1)} KiB gzipped over ${files} file(s) — `
+        + result.output.split('\n').find((line) => line.includes('Total Upload'))?.trim(),
+    )
+
+    return gzipped
+  }
+
+  test(
+    'bundles the App MCP transport and stays inside the free-plan budget',
+    () => {
+      // Everything `cloudflare:build` stubs for an app that declares
+      // `@guren/plugin-mcp` — which is everything except the transport.
+      const served = bundleSize('transport-served', [
+        ...stubbableDevOnlyModules({ mcpPlugin: true }),
+        ...SQL_CLIENT_MODULES,
+      ])
+      // And the same worker as every deploy plugin built it before RFC 0016
+      // Phase 4a. Both are measured because "the bundle resolves" cannot tell
+      // them apart: the stub declares the transport's export name, so the
+      // stubbed configuration bundles perfectly well — it just deploys an
+      // endpoint that throws. The size difference is the only observable
+      // proof that the real transport reached the bundle, and it is also the
+      // number the RFC asks this probe to report.
+      const stubbed = bundleSize('transport-stubbed', [...DEV_ONLY_MODULES, ...SQL_CLIENT_MODULES])
+
+      console.log(
+        `App MCP transport costs ${((served - stubbed) / 1024).toFixed(1)} KiB gzipped `
+          + `(${((served / FREE_PLAN_GZIP_BUDGET) * 100).toFixed(1)}% of the ${FREE_PLAN_GZIP_BUDGET / 1024 / 1024} MiB free-plan budget used in total)`,
+      )
+
+      expect(served).toBeGreaterThan(stubbed)
+      expect(served).toBeLessThan(FREE_PLAN_GZIP_BUDGET)
+    },
+    300_000,
   )
 })

--- a/packages/plugin-cloudflare/src/wrangler-bundle.test.ts
+++ b/packages/plugin-cloudflare/src/wrangler-bundle.test.ts
@@ -34,6 +34,9 @@ function wrangler(cwd: string, args: string[]): { exitCode: number; output: stri
   return { exitCode: result.exitCode, output: `${result.stdout.toString()}${result.stderr.toString()}` }
 }
 
+/** As much of a `DEV_ONLY_MODULES` / `SQL_CLIENT_MODULES` entry as a stub needs. */
+type StubbedModule = { specifier: string; exportNames: readonly string[] }
+
 /**
  * Write the stub files and the `wrangler.jsonc` aliasing `modules` to them —
  * what `cloudflare:build` scaffolds, written directly so a probe pins the
@@ -43,11 +46,7 @@ function wrangler(cwd: string, args: string[]): { exitCode: number; output: stri
  * stubs everything, and the App MCP probe stubs everything *except* the
  * transport, which is the configuration RFC 0016 Phase 4a produces.
  */
-function writeWranglerConfig(
-  root: string,
-  name: string,
-  modules: readonly { specifier: string; exportNames: readonly string[] }[],
-): void {
+function writeWranglerConfig(root: string, name: string, modules: readonly StubbedModule[]): void {
   mkdirSync(join(root, 'stubs'), { recursive: true })
 
   const alias: Record<string, string> = {}
@@ -174,6 +173,9 @@ const FREE_PLAN_GZIP_BUDGET = 3 * 1024 * 1024
 /** Extensions that count toward the upload; sourcemaps do not, and dwarf it. */
 const UPLOADED_EXTENSIONS = ['.js', '.mjs', '.wasm']
 
+/** A package of this workspace, as the probe vendors it: its directory and manifest. */
+type WorkspacePackage = { dir: string; manifest: Record<string, unknown> }
+
 /**
  * The `@guren/*` packages a probe must resolve from this checkout, derived
  * rather than listed: seed with the one the worker imports and close over the
@@ -183,9 +185,9 @@ const UPLOADED_EXTENSIONS = ['.js', '.mjs', '.wasm']
  * (see `scripts/smoke/local-packages.ts`, which owns the same rule for the
  * smokes).
  */
-function workspaceClosure(seed: string): Map<string, { dir: string; manifest: Record<string, unknown> }> {
+function workspaceClosure(seed: string): Map<string, WorkspacePackage> {
   const packagesDir = new URL('../../', import.meta.url).pathname
-  const byName = new Map<string, { dir: string; manifest: Record<string, unknown> }>()
+  const byName = new Map<string, WorkspacePackage>()
   for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue
     const manifestPath = join(packagesDir, entry.name, 'package.json')
@@ -194,7 +196,7 @@ function workspaceClosure(seed: string): Map<string, { dir: string; manifest: Re
     byName.set(manifest.name as string, { dir: join(packagesDir, entry.name), manifest })
   }
 
-  const closure = new Map<string, { dir: string; manifest: Record<string, unknown> }>()
+  const closure = new Map<string, WorkspacePackage>()
   const queue = [seed]
   while (queue.length > 0) {
     const name = queue.shift() as string
@@ -287,7 +289,6 @@ describe.skipIf(!enabled)('wrangler bundles a worker importing @guren/plugin-mcp
         + `  },\n`
         + `}\n`,
     )
-
   })
 
   afterAll(() => {
@@ -304,10 +305,7 @@ describe.skipIf(!enabled)('wrangler bundles a worker importing @guren/plugin-mcp
    * beside the bundle is several times its size and the limit does not count
    * it, so a whole-directory sum would fail for a file that never ships.
    */
-  function bundleSize(
-    label: string,
-    modules: readonly { specifier: string; exportNames: readonly string[] }[],
-  ): number {
+  function bundleSize(label: string, modules: readonly StubbedModule[]): number {
     writeWranglerConfig(root, 'mcp-bundle-probe', modules)
     const out = join(root, `out-${label}`)
     const result = wrangler(root, ['deploy', '--dry-run', '--outdir', out])

--- a/packages/plugin-lambda/src/build.test.ts
+++ b/packages/plugin-lambda/src/build.test.ts
@@ -472,7 +472,6 @@ describe('buildLambdaOutput', () => {
     // @guren/plugin-mcp imports it *statically*, so a catch-all still in
     // force would leave the endpoint just as compiled shut.
     expect(probeHttpExport(root)).toBe(`${SDK_SERVER_INDEX_MARKER}|${SDK_TRANSPORT_MARKER}`)
-
   })
 
   test('should keep the Dev MCP server stubbed even for an app depending on the plugin', async () => {

--- a/packages/plugin-lambda/src/build.test.ts
+++ b/packages/plugin-lambda/src/build.test.ts
@@ -39,6 +39,56 @@ interface ScaffoldOptions {
   renderExport?: string
   /** Lines placed above the handler exports, plus the body of the `http` export. */
   entry?: { preamble?: string[]; http: string }
+  /** Declare `@guren/plugin-mcp` under `dependencies` — the App MCP opt-in (RFC 0016 §7). */
+  mcpPlugin?: boolean
+}
+
+/** Markers the fake SDK exports, so a test can tell "resolved" from "stubbed". */
+const SDK_SERVER_INDEX_MARKER = 'fake-sdk-server-index'
+const SDK_TRANSPORT_MARKER = 'fake-sdk-transport'
+
+/**
+ * A stand-in for `@modelcontextprotocol/sdk` inside the scaffolded app.
+ *
+ * Deliberately without an `exports` map: a subpath under one that is slightly
+ * wrong fails to resolve and reads exactly like the stub still intercepting,
+ * which is the verdict these tests exist to distinguish. Legacy path
+ * resolution has no such failure mode.
+ *
+ * Both subpaths matter and for different reasons — `webStandardStreamableHttp.js`
+ * is the entry `stubbableDevOnlyModules` releases, and `server/index.js` is one
+ * `DEV_ONLY_MODULES` never named, so only the SDK-prefix catch-all can stub it.
+ */
+function installFakeMcpSdk(root: string): void {
+  const pkg = join(root, 'node_modules/@modelcontextprotocol/sdk')
+  mkdirSync(join(pkg, 'server'), { recursive: true })
+  writeJson(join(pkg, 'package.json'), {
+    name: '@modelcontextprotocol/sdk',
+    version: '1.30.0',
+    type: 'module',
+  })
+  writeFileSync(join(pkg, 'server/index.js'), `export const MARKER = '${SDK_SERVER_INDEX_MARKER}'\n`)
+  writeFileSync(
+    join(pkg, 'server/webStandardStreamableHttp.js'),
+    `export const WebStandardStreamableHTTPServerTransport = '${SDK_TRANSPORT_MARKER}'\n`,
+  )
+}
+
+/**
+ * An entry importing both SDK subpaths and reporting what it got.
+ *
+ * `server/index.js` comes in as a *namespace*: the catch-all stub for an
+ * unlisted subpath is a bare `throw` with no exports at all, so a named import
+ * of it fails the bundle rather than the bundled module — which would make the
+ * stubbed and unstubbed cases fail at different stages and need different
+ * assertions. A namespace import bundles either way and throws on evaluation.
+ */
+const SDK_ENTRY: ScaffoldOptions['entry'] = {
+  preamble: [
+    "import * as serverIndex from '@modelcontextprotocol/sdk/server/index.js'",
+    "import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'",
+  ],
+  http: '`${serverIndex.MARKER}|${WebStandardStreamableHTTPServerTransport}`',
 }
 
 function scaffoldApp(root: string, options: ScaffoldOptions = {}): void {
@@ -46,6 +96,7 @@ function scaffoldApp(root: string, options: ScaffoldOptions = {}): void {
     ssr = true,
     renderExport = 'export const render = () => ({ body: "", head: [] })',
     entry = { http: 'process.env.NODE_ENV' },
+    mcpPlugin = false,
   } = options
 
   mkdirSync(join(root, 'src'), { recursive: true })
@@ -61,7 +112,10 @@ function scaffoldApp(root: string, options: ScaffoldOptions = {}): void {
       '',
     ].join('\n'),
   )
-  writeJson(join(root, 'package.json'), { name: '@acme/demo-app' })
+  writeJson(join(root, 'package.json'), {
+    name: '@acme/demo-app',
+    ...(mcpPlugin ? { dependencies: { '@guren/plugin-mcp': '^0.2.0' } } : {}),
+  })
 
   mkdirSync(join(root, 'public/assets/.vite'), { recursive: true })
   writeFileSync(join(root, 'public/robots.txt'), 'User-agent: *\n')
@@ -380,5 +434,70 @@ describe('buildLambdaOutput', () => {
 
     expect(result.exitCode).not.toBe(0)
     expect(result.stderr.toString()).toContain('The MCP endpoint is unavailable on AWS Lambda')
+  })
+
+  test('should stub both MCP SDK subpaths for an app that does not depend on the plugin', async () => {
+    // The regression hold: nothing about RFC 0016 Phase 4a may reach an app
+    // that never asked for the App MCP endpoint.
+    scaffoldApp(root, { entry: SDK_ENTRY })
+    installFakeMcpSdk(root)
+
+    await buildLambdaOutput({ rootDir: root, skipAppBuild: true })
+
+    const result = Bun.spawnSync({
+      cmd: [process.execPath, '-e', 'await import(process.argv[1])', join(root, '.lambda/function/handler.js')],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr.toString()).toContain('The MCP endpoint is unavailable on AWS Lambda')
+    // Not merely "something threw": the SDK sits installed beside the app, so
+    // its markers reaching the bundle is what "resolved for real" looks like.
+    const bundle = readFileSync(join(root, '.lambda/function/handler.js'), 'utf8')
+    expect(bundle).not.toContain(SDK_TRANSPORT_MARKER)
+    expect(bundle).not.toContain(SDK_SERVER_INDEX_MARKER)
+  })
+
+  test('should bundle the real MCP SDK for an app depending on @guren/plugin-mcp', async () => {
+    scaffoldApp(root, { entry: SDK_ENTRY, mcpPlugin: true })
+    installFakeMcpSdk(root)
+
+    await buildLambdaOutput({ rootDir: root, skipAppBuild: true })
+
+    // Two separate mechanisms had to stop firing, and the markers tell them
+    // apart from "resolved nothing": `webStandardStreamableHttp.js` is the
+    // entry the stub map releases, and `server/index.js` is one no entry ever
+    // named — only the SDK-prefix catch-all could have stubbed it, and
+    // @guren/plugin-mcp imports it *statically*, so a catch-all still in
+    // force would leave the endpoint just as compiled shut.
+    expect(probeHttpExport(root)).toBe(`${SDK_SERVER_INDEX_MARKER}|${SDK_TRANSPORT_MARKER}`)
+
+  })
+
+  test('should keep the Dev MCP server stubbed even for an app depending on the plugin', async () => {
+    // Its McpServer drives the CLI's code generators against a filesystem the
+    // function does not have, and the App MCP endpoint never touches it.
+    scaffoldApp(root, {
+      mcpPlugin: true,
+      entry: {
+        preamble: ["import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'"],
+        http: 'String(McpServer)',
+      },
+    })
+    installFakeMcpSdk(root)
+    writeFileSync(
+      join(root, 'node_modules/@modelcontextprotocol/sdk/server/mcp.js'),
+      "export const McpServer = 'fake-sdk-mcp-server'\n",
+    )
+
+    await buildLambdaOutput({ rootDir: root, skipAppBuild: true })
+
+    // The stub's throw is a *function body*, so importing succeeds and
+    // calling is what fails — assert on the bundle text rather than on a
+    // process exit code, which would pass for the wrong reason.
+    const bundle = readFileSync(join(root, '.lambda/function/handler.js'), 'utf8')
+    expect(bundle).toContain('The MCP endpoint is unavailable on AWS Lambda')
+    expect(bundle).not.toContain('fake-sdk-mcp-server')
   })
 })

--- a/packages/plugin-lambda/src/build.ts
+++ b/packages/plugin-lambda/src/build.ts
@@ -1,11 +1,13 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import {
+  appUsesMcpPlugin,
   DEV_ONLY_MODULES,
   clientManifestJson,
   importSpecifier,
   MCP_SDK_SUBPATH_PREFIX,
   renderDevOnlyStub,
+  stubbableDevOnlyModules,
   assertOutputDirOutsideRoot,
   resetOutputDir,
   resolveClientAssetEnv,
@@ -75,20 +77,26 @@ const UNAVAILABLE_ON_LAMBDA: Record<(typeof DEV_ONLY_MODULES)[number]['kind'], s
  * would fail at import time on Lambda even though no code path ever runs it.
  * Stubbing also keeps megabytes of dev tooling out of the bundle.
  *
- * Unconditional, unlike the database clients: nothing an app can declare makes
- * the Vite dev server or the MCP endpoint's generators run on Lambda.
+ * Which of them are in force is per app, and for one reason only: an app that
+ * declares `@guren/plugin-mcp` serves the App MCP endpoint here, so its
+ * transport must reach the bundle rather than a stub (RFC 0016 §7). The rest
+ * are unconditional — nothing an app can declare makes the Vite dev server or
+ * the *Dev* MCP's generators run on Lambda. `stubbableDevOnlyModules` owns
+ * that distinction; this function only renders what it is handed.
  */
-const DEV_ONLY_STUBS: Record<string, string> = Object.fromEntries(
-  DEV_ONLY_MODULES.map((module) => [
-    module.specifier,
-    renderDevOnlyStub(module, UNAVAILABLE_ON_LAMBDA[module.kind]),
-  ]),
-)
+function devOnlyStubs(mcpPlugin: boolean): Record<string, string> {
+  return Object.fromEntries(
+    stubbableDevOnlyModules({ mcpPlugin }).map((module) => [
+      module.specifier,
+      renderDevOnlyStub(module, UNAVAILABLE_ON_LAMBDA[module.kind]),
+    ]),
+  )
+}
 
 /**
  * The dev-only stubs plus one per database client this app does not connect
- * through. Unlike the dev-only set this depends on the app, so it is built
- * per build rather than at module scope.
+ * through. Both halves depend on the app, so it is built per build rather
+ * than at module scope.
  *
  * A stub here also *overrides* `external`, verified against Bun 1.3.14: the
  * bundler consults plugins before it consults the external list, so stubbing
@@ -96,11 +104,15 @@ const DEV_ONLY_STUBS: Record<string, string> = Object.fromEntries(
  * than leaving `external: ['@aws-sdk/*']` to keep drizzle's hoisted top-level
  * import of a package the runtime may not provide.
  */
-function stubsFor(root: string, dialects: readonly DatabaseDialect[] | undefined): Record<string, string> {
+function stubsFor(
+  root: string,
+  dialects: readonly DatabaseDialect[] | undefined,
+  mcpPlugin: boolean,
+): Record<string, string> {
   const unused = unusedSqlClients({ root, label: 'Lambda build', dialects })
 
   return {
-    ...DEV_ONLY_STUBS,
+    ...devOnlyStubs(mcpPlugin),
     ...Object.fromEntries(
       unused.map(({ module, message }) => [module.specifier, renderDevOnlyStub(module, message)]),
     ),
@@ -113,6 +125,12 @@ function stubsFor(root: string, dialects: readonly DatabaseDialect[] | undefined
  * rather than resolving to an empty module: a subpath reached from app code
  * (not Guren's disabled MCP endpoint) must fail loudly at build or cold start,
  * never silently hand back missing exports.
+ *
+ * Reachable only for an app that does *not* declare `@guren/plugin-mcp`. For
+ * one that does, the SDK is a dependency it deliberately ships, and this
+ * fallback would stub `server/index.js` and `types.js` — which
+ * `@guren/plugin-mcp` imports statically — leaving the endpoint just as
+ * compiled shut as the transport stub did. See `stubFilter`.
  */
 const unlistedMcpStub = `throw new Error(${JSON.stringify(MCP_UNAVAILABLE)})\n`
 
@@ -124,13 +142,22 @@ function escapeRegExp(value: string): string {
 // of stubbed specifiers — a hand-maintained regex could silently fall out of
 // sync, and a client that is filtered but has no stub loads as an empty
 // module instead of failing.
-function stubFilter(stubs: Record<string, string>): RegExp {
-  return new RegExp(
-    `^(?:${[
-      ...Object.keys(stubs).map(escapeRegExp),
-      `${escapeRegExp(MCP_SDK_SUBPATH_PREFIX)}.+`,
-    ].join('|')})$`,
-  )
+//
+// The catch-all is the one term that cannot be derived from the stubs, and
+// the tempting derivation is actively wrong: "include it while any MCP SDK
+// subpath is still stubbed" reads well and holds always, because
+// `@modelcontextprotocol/sdk/server/mcp.js` stays stubbed for every app —
+// which would leave the catch-all swallowing `server/index.js` and `types.js`
+// and undo the whole of RFC 0016 Phase 4a silently. So it is gated on the
+// same `mcpPlugin` decision that produced the stubs, threaded from one read
+// of the app's manifest rather than re-derived here.
+function stubFilter(stubs: Record<string, string>, mcpPlugin: boolean): RegExp {
+  const terms = Object.keys(stubs).map(escapeRegExp)
+  if (!mcpPlugin) {
+    terms.push(`${escapeRegExp(MCP_SDK_SUBPATH_PREFIX)}.+`)
+  }
+
+  return new RegExp(`^(?:${terms.join('|')})$`)
 }
 
 /**
@@ -187,7 +214,19 @@ export async function buildLambdaOutput(options: BuildLambdaOutputOptions = {}):
   const wrapperPath = resolve(out, `${LAMBDA_HANDLER_MODULE}.ts`)
   writeFileSync(wrapperPath, renderHandlerModule({ out, entrypoint, env: bakedEnv }))
 
-  await bundleHandler(wrapperPath, funcDir, stubsFor(root, options.databaseDialects))
+  // One read of the app's manifest, threaded to both halves of the stub
+  // decision: which modules are rendered, and whether unlisted MCP SDK
+  // subpaths are swallowed by the catch-all. Two independent reads would be
+  // two places for them to disagree, and the disagreement is silent — the
+  // catch-all would stub what the stub map deliberately released.
+  const mcpPlugin = appUsesMcpPlugin(root)
+
+  await bundleHandler(
+    wrapperPath,
+    funcDir,
+    stubsFor(root, options.databaseDialects, mcpPlugin),
+    mcpPlugin,
+  )
 
   // Lambda's Node.js runtime treats `.js` as CommonJS unless the package is
   // marked as a module; the bundle and the SSR chunks are both ESM.
@@ -282,8 +321,9 @@ async function bundleHandler(
   handlerEntry: string,
   funcDir: string,
   stubs: Record<string, string>,
+  mcpPlugin: boolean,
 ): Promise<void> {
-  const filter = stubFilter(stubs)
+  const filter = stubFilter(stubs, mcpPlugin)
 
   const result = await Bun.build({
     entrypoints: [handlerEntry],

--- a/packages/plugin-vercel/src/index.ts
+++ b/packages/plugin-vercel/src/index.ts
@@ -256,6 +256,32 @@ function stubbedModules(
  */
 const unlistedMcpStub = `throw new Error(${JSON.stringify(MCP_UNAVAILABLE)})\n`
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// Derived from the stubs actually rendered so it stays the only enumeration
+// of stubbed specifiers — a hand-maintained regex could silently fall out of
+// sync, and a specifier that is filtered but has no stub would load as an
+// empty module instead of failing.
+//
+// The catch-all is the one term that cannot be derived from the stubs, and
+// the tempting derivation is actively wrong: "include it while any MCP SDK
+// subpath is still stubbed" holds always, because
+// `@modelcontextprotocol/sdk/server/mcp.js` stays stubbed for every app —
+// so the catch-all would keep swallowing `server/index.js` and `types.js`
+// and undo RFC 0016 Phase 4a silently. So it is gated on the same `mcpPlugin`
+// decision that produced the stubs, threaded from one read of the app's
+// manifest rather than re-derived here.
+function stubFilter(stubs: Record<string, string>, mcpPlugin: boolean): RegExp {
+  const terms = Object.keys(stubs).map(escapeRegExp)
+  if (!mcpPlugin) {
+    terms.push(`${escapeRegExp(MCP_SDK_SUBPATH_PREFIX)}.+`)
+  }
+
+  return new RegExp(`^(?:${terms.join('|')})$`)
+}
+
 /**
  * Bundle the function with Bun's JS API rather than by spawning `bun build`.
  *
@@ -271,26 +297,12 @@ async function bundleFunction(input: {
   viteManifest: string | undefined
 }): Promise<void> {
   // One read of the app's manifest, threaded to both halves of the stub
-  // decision below: two independent reads would be two places for them to
-  // disagree, silently.
+  // decision: which modules are rendered, and whether unlisted MCP SDK
+  // subpaths are swallowed by the catch-all. Two independent reads would be
+  // two places for them to disagree, silently.
   const mcpPlugin = appUsesMcpPlugin(input.root)
   const stubs = stubbedModules(input.root, input.dialects, mcpPlugin)
-  // Derived from the stubs actually rendered so it stays the only enumeration
-  // of stubbed specifiers — a hand-maintained regex could silently fall out of
-  // sync, and a specifier that is filtered but has no stub would load as an
-  // empty module instead of failing.
-  //
-  // The catch-all is the one term that cannot be derived from the stubs, and
-  // the tempting derivation is actively wrong: "include it while any MCP SDK
-  // subpath is still stubbed" holds always, because
-  // `@modelcontextprotocol/sdk/server/mcp.js` stays stubbed for every app —
-  // so the catch-all would keep swallowing `server/index.js` and `types.js`
-  // and undo RFC 0016 Phase 4a silently. Gate it on `mcpPlugin` instead.
-  const terms = Object.keys(stubs).map(escapeRegExp)
-  if (!mcpPlugin) {
-    terms.push(`${escapeRegExp(MCP_SDK_SUBPATH_PREFIX)}.+`)
-  }
-  const filter = new RegExp(`^(?:${terms.join('|')})$`)
+  const filter = stubFilter(stubs, mcpPlugin)
 
   const result = await Bun.build({
     entrypoints: [input.entrypoint],
@@ -342,10 +354,6 @@ async function bundleFunction(input: {
   if (!result.success) {
     throw new Error(`${LABEL}: bun build failed.\n${result.logs.map((log) => String(log)).join('\n')}`)
   }
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 function buildVercelEnvironment(publicDir: string, ssrDir: string): Record<string, string> {

--- a/packages/plugin-vercel/src/index.ts
+++ b/packages/plugin-vercel/src/index.ts
@@ -2,11 +2,13 @@ import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node
 import { basename, extname, resolve } from 'node:path'
 import { definePlugin, type ServiceProviderConstructor } from '@guren/core'
 import {
+  appUsesMcpPlugin,
   assertOutputDirOutsideRoot,
   clientManifestJson,
   DEV_ONLY_MODULES,
   MCP_SDK_SUBPATH_PREFIX,
   renderDevOnlyStub,
+  stubbableDevOnlyModules,
   resetOutputDir,
   resolveClientAssetEnv,
   resolvePathLike,
@@ -214,9 +216,19 @@ const UNAVAILABLE_ON_VERCEL: Record<(typeof DEV_ONLY_MODULES)[number]['kind'], s
  * - The database clients for dialects the app does not use, decided per app
  *   rather than per platform — the ones it *does* use are load-bearing here,
  *   unlike on Workers where D1 is the only database.
+ *
+ * The dev-only set is per app in one respect too: an app declaring
+ * `@guren/plugin-mcp` serves the App MCP endpoint from this function, so its
+ * transport must reach the bundle (RFC 0016 §7). The *Dev* MCP's `McpServer`
+ * and the CLI behind it stay stubbed regardless — see
+ * `stubbableDevOnlyModules`.
  */
-function stubbedModules(root: string, dialects: readonly DatabaseDialect[] | undefined): Record<string, string> {
-  const devOnly = DEV_ONLY_MODULES.flatMap((module) => {
+function stubbedModules(
+  root: string,
+  dialects: readonly DatabaseDialect[] | undefined,
+  mcpPlugin: boolean,
+): Record<string, string> {
+  const devOnly = stubbableDevOnlyModules({ mcpPlugin }).flatMap((module) => {
     const message = UNAVAILABLE_ON_VERCEL[module.kind]
     return message === null ? [] : [[module.specifier, renderDevOnlyStub(module, message)]]
   })
@@ -235,6 +247,12 @@ function stubbedModules(root: string, dialects: readonly DatabaseDialect[] | und
  * rather than resolving to an empty module: a subpath reached from app code
  * (not Guren's disabled MCP endpoint) must fail loudly at build or cold start,
  * never silently hand back missing exports.
+ *
+ * Reachable only for an app that does *not* declare `@guren/plugin-mcp`. For
+ * one that does, the SDK is a dependency it deliberately ships, and this
+ * fallback would stub `server/index.js` and `types.js` — which
+ * `@guren/plugin-mcp` imports statically — leaving the endpoint just as
+ * compiled shut as the transport stub did.
  */
 const unlistedMcpStub = `throw new Error(${JSON.stringify(MCP_UNAVAILABLE)})\n`
 
@@ -252,14 +270,27 @@ async function bundleFunction(input: {
   dialects: readonly DatabaseDialect[] | undefined
   viteManifest: string | undefined
 }): Promise<void> {
-  const stubs = stubbedModules(input.root, input.dialects)
+  // One read of the app's manifest, threaded to both halves of the stub
+  // decision below: two independent reads would be two places for them to
+  // disagree, silently.
+  const mcpPlugin = appUsesMcpPlugin(input.root)
+  const stubs = stubbedModules(input.root, input.dialects, mcpPlugin)
   // Derived from the stubs actually rendered so it stays the only enumeration
   // of stubbed specifiers — a hand-maintained regex could silently fall out of
   // sync, and a specifier that is filtered but has no stub would load as an
   // empty module instead of failing.
-  const filter = new RegExp(
-    `^(?:${[...Object.keys(stubs).map(escapeRegExp), `${escapeRegExp(MCP_SDK_SUBPATH_PREFIX)}.+`].join('|')})$`,
-  )
+  //
+  // The catch-all is the one term that cannot be derived from the stubs, and
+  // the tempting derivation is actively wrong: "include it while any MCP SDK
+  // subpath is still stubbed" holds always, because
+  // `@modelcontextprotocol/sdk/server/mcp.js` stays stubbed for every app —
+  // so the catch-all would keep swallowing `server/index.js` and `types.js`
+  // and undo RFC 0016 Phase 4a silently. Gate it on `mcpPlugin` instead.
+  const terms = Object.keys(stubs).map(escapeRegExp)
+  if (!mcpPlugin) {
+    terms.push(`${escapeRegExp(MCP_SDK_SUBPATH_PREFIX)}.+`)
+  }
+  const filter = new RegExp(`^(?:${terms.join('|')})$`)
 
   const result = await Bun.build({
     entrypoints: [input.entrypoint],

--- a/packages/plugin-vercel/tests/index.test.ts
+++ b/packages/plugin-vercel/tests/index.test.ts
@@ -6,19 +6,69 @@ import { buildVercelOutput, createVercelHandler, vercelPlugin } from '../src/ind
 
 const DEFAULT_ENTRYPOINT_SOURCE = "export default { fetch() { return new Response('ok') } }\n"
 
+/** Markers the fake SDK exports, so a test can tell "resolved" from "stubbed". */
+const SDK_SERVER_INDEX_MARKER = 'fake-sdk-server-index'
+const SDK_TRANSPORT_MARKER = 'fake-sdk-transport'
+
+/**
+ * An entrypoint importing both SDK subpaths and reporting what it got.
+ *
+ * `server/index.js` comes in as a *namespace*: the catch-all stub for an
+ * unlisted subpath is a bare `throw` with no exports at all, so a named import
+ * of it fails the bundle rather than the bundled module, and the stubbed and
+ * unstubbed cases would then fail at different stages.
+ */
+const SDK_ENTRY_SOURCE =
+  "import * as serverIndex from '@modelcontextprotocol/sdk/server/index.js'\n"
+  + "import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'\n"
+  + 'export default { fetch() { return new Response(`${serverIndex.MARKER}|${WebStandardStreamableHTTPServerTransport}`) } }\n'
+
+/**
+ * A stand-in for `@modelcontextprotocol/sdk` inside the scaffolded app.
+ *
+ * Deliberately without an `exports` map: a subpath under one that is slightly
+ * wrong fails to resolve and reads exactly like the stub still intercepting,
+ * which is the verdict these tests exist to distinguish.
+ */
+function installFakeMcpSdk(root: string): void {
+  const pkg = join(root, 'node_modules/@modelcontextprotocol/sdk')
+  mkdirSync(join(pkg, 'server'), { recursive: true })
+  writeFileSync(
+    join(pkg, 'package.json'),
+    JSON.stringify({ name: '@modelcontextprotocol/sdk', version: '1.30.0', type: 'module' }),
+    'utf8',
+  )
+  writeFileSync(join(pkg, 'server/index.js'), `export const MARKER = '${SDK_SERVER_INDEX_MARKER}'\n`, 'utf8')
+  writeFileSync(
+    join(pkg, 'server/webStandardStreamableHttp.js'),
+    `export const WebStandardStreamableHTTPServerTransport = '${SDK_TRANSPORT_MARKER}'\n`,
+    'utf8',
+  )
+}
+
 /**
  * Writes a minimal buildable app under `root` and returns it as
  * `buildVercelOutput` options, so a test can just `await buildVercelOutput(app)`.
  */
 function scaffoldApp(
   root: string,
-  options: { entrypoint?: string; source?: string } = {},
+  options: { entrypoint?: string; source?: string; mcpPlugin?: boolean } = {},
 ): { rootDir: string; entrypoint: string; outputDir: string } {
-  const { entrypoint = 'src/index.ts', source = DEFAULT_ENTRYPOINT_SOURCE } = options
+  const { entrypoint = 'src/index.ts', source = DEFAULT_ENTRYPOINT_SOURCE, mcpPlugin = false } = options
   const entrypointPath = join(root, entrypoint)
 
   mkdirSync(dirname(entrypointPath), { recursive: true })
   writeFileSync(entrypointPath, source, 'utf8')
+
+  if (mcpPlugin) {
+    // Declaring the plugin under `dependencies` is the App MCP opt-in the
+    // build reads (RFC 0016 §7).
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'demo-app', dependencies: { '@guren/plugin-mcp': '^0.2.0' } }),
+      'utf8',
+    )
+  }
 
   return { rootDir: root, entrypoint: entrypointPath, outputDir: join(root, '.vercel/output') }
 }
@@ -259,6 +309,62 @@ describe('@guren/plugin-vercel', () => {
       )
 
       expect(copied).toContain('Parent docs.')
+    })
+
+    it('stubs both MCP SDK subpaths for an app that does not depend on the plugin', async () => {
+      // The regression hold: nothing about RFC 0016 Phase 4a reaches an app
+      // that never asked for the App MCP endpoint.
+      const app = scaffoldApp(root, { source: SDK_ENTRY_SOURCE })
+      installFakeMcpSdk(root)
+
+      await buildVercelOutput(app)
+
+      const bundle = readFileSync(join(app.outputDir, 'functions/index.func/index.js'), 'utf8')
+      expect(bundle).toContain('The MCP endpoint is unavailable on Vercel')
+      // The SDK sits installed beside the app, so its markers reaching the
+      // bundle is what "resolved for real" would look like.
+      expect(bundle).not.toContain(SDK_TRANSPORT_MARKER)
+      expect(bundle).not.toContain(SDK_SERVER_INDEX_MARKER)
+    })
+
+    it('bundles the real MCP SDK for an app depending on @guren/plugin-mcp', async () => {
+      const app = scaffoldApp(root, { source: SDK_ENTRY_SOURCE, mcpPlugin: true })
+      installFakeMcpSdk(root)
+
+      await buildVercelOutput(app)
+
+      // Two mechanisms had to stop firing, and the markers tell them apart
+      // from "resolved nothing": `webStandardStreamableHttp.js` is the entry
+      // the stub map releases, and `server/index.js` is one no entry ever
+      // named — only the SDK-prefix catch-all could have stubbed it, and
+      // @guren/plugin-mcp imports it *statically*, so a catch-all still in
+      // force would leave the endpoint just as compiled shut.
+      const bundle = readFileSync(join(app.outputDir, 'functions/index.func/index.js'), 'utf8')
+      expect(bundle).toContain(SDK_TRANSPORT_MARKER)
+      expect(bundle).toContain(SDK_SERVER_INDEX_MARKER)
+      expect(bundle).not.toContain('The MCP endpoint is unavailable on Vercel')
+    })
+
+    it('keeps the Dev MCP server stubbed even for an app depending on the plugin', async () => {
+      // Its McpServer drives the CLI's code generators against a filesystem
+      // the function does not have, and the App MCP endpoint never touches it.
+      const app = scaffoldApp(root, {
+        source:
+          "import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'\n"
+          + 'export default { fetch() { return new Response(String(McpServer)) } }\n',
+        mcpPlugin: true,
+      })
+      installFakeMcpSdk(root)
+      writeFileSync(
+        join(root, 'node_modules/@modelcontextprotocol/sdk/server/mcp.js'),
+        "export const McpServer = 'fake-sdk-mcp-server'\n",
+      )
+
+      await buildVercelOutput(app)
+
+      const bundle = readFileSync(join(app.outputDir, 'functions/index.func/index.js'), 'utf8')
+      expect(bundle).toContain('The MCP endpoint is unavailable on Vercel')
+      expect(bundle).not.toContain('fake-sdk-mcp-server')
     })
   })
 })

--- a/rfcs/0016-agent-interface.md
+++ b/rfcs/0016-agent-interface.md
@@ -626,7 +626,7 @@ workerd-compatible by construction; the build must stop killing it:
   render the manifest-derived consent screen. `props` map to `AgentPrincipal`.
 
 **Amended in implementation (first two bullets; `--mcp-oauth` is a later PR).**
-Two corrections, both widening what the bullets described:
+Corrections, each widening what the bullets above described:
 
 - **Open Question 5 resolved: dependency sniffing.** `@guren/plugin-mcp` under the
   app's `dependencies` *is* the opt-in — nothing else is asked, because there is

--- a/rfcs/0016-agent-interface.md
+++ b/rfcs/0016-agent-interface.md
@@ -625,6 +625,31 @@ workerd-compatible by construction; the build must stop killing it:
   and DCR; Guren scaffolds the session-authenticated authorize/consent routes, which
   render the manifest-derived consent screen. `props` map to `AgentPrincipal`.
 
+**Amended in implementation (first two bullets; `--mcp-oauth` is a later PR).**
+Two corrections, both widening what the bullets described:
+
+- **Open Question 5 resolved: dependency sniffing.** `@guren/plugin-mcp` under the
+  app's `dependencies` *is* the opt-in — nothing else is asked, because there is
+  nothing else to ask. An app that installed the plugin and mounted it wants the
+  endpoint to work, and a build flag it must also remember to pass is one more way
+  for the endpoint to be silently compiled shut on a platform. `devDependencies` do
+  not count: they never ship, so there is no deployed endpoint to protect.
+  `appUsesMcpPlugin()` answers `false` for an absent or unreadable manifest — no
+  opt-in evidence is not opt-in, and that direction preserves today's behaviour.
+- **The fix is not Cloudflare-only.** Lambda and Vercel read the same
+  `DEV_ONLY_MODULES` list and carried the same defect; both additionally routed
+  *every* unlisted `@modelcontextprotocol/sdk/*` subpath to a throwing stub, which
+  also killed the plugin's static imports of `server/index.js` and `types.js`. So
+  the rule lives in `@guren/core/internal/deploy-build`
+  (`appUsesMcpPlugin` + `stubbableDevOnlyModules`) and all three platforms read it.
+- Exactly **one** entry is dropped: the transport. `server/mcp.js` (the Dev MCP's
+  `McpServer`), `@guren/cli`, `bun:sqlite` and `vite` stay stubbed for every app —
+  "the two MCP SDK stubs" in the bullet above overstated it.
+- Cloudflare's aliases are baked into the app's *committed* `wrangler.jsonc`, which
+  the scaffold writes once and never overwrites. An app that adds the plugin later
+  would keep the stale alias forever, so the build **fails** and names the one line
+  to delete rather than warning.
+
 **Phase 4b (separate RFC).** Durable agent runtime on the Cloudflare Agents SDK
 (`make:agent`). `McpAgent` is deprecated/frozen and is not used; MCP serving needs no
 Durable Objects. Known prerequisites recorded now: named-export injection into the
@@ -735,8 +760,10 @@ Purely additive; no existing API changes shape or behavior. Two soft edges:
    signal. See the §7 amendment.
 4. `listChanged` / tool pagination for large catalogs, and whether `tags` should
    drive filtered exposure.
-5. How the Workers build detects `@guren/plugin-mcp` (dependency sniffing vs. an
-   explicit `BuildCloudflareOutputOptions` flag).
+5. ~~How the Workers build detects `@guren/plugin-mcp` (dependency sniffing vs. an
+   explicit `BuildCloudflareOutputOptions` flag).~~ **Resolved in implementation:**
+   dependency sniffing, shared by all three deploy plugins rather than Workers
+   alone. See the §7 amendment.
 6. `loadRouteDefinitions()` scans `modules/*` on disk regardless of
    `createApp({ modules })`; an unmounted module's `.agent()` routes would appear in
    generated manifests but not the live registry. Whether routes-check should warn on


### PR DESCRIPTION
## Summary

RFC 0016 Phase 4a (first PR): the deploy builds stop compiling the App MCP endpoint shut. `@guren/plugin-mcp` is workerd-compatible by construction, but every deploy target stubbed the MCP SDK out from under it: all three platforms stub `@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js` (which the plugin dynamically imports), and Lambda/Vercel additionally stub every SDK subpath through a prefix catch-all — killing the plugin's static `server/index.js` / `types.js` imports too. The RFC names Cloudflare; the defect lives in the shared module lists, so the fix does as well. Scope extension to Lambda/Vercel is recorded in the RFC amendment.

### One shared policy (`@guren/core/internal/deploy-build`)
- `appUsesMcpPlugin(root)` — **Open Question 5 resolved as dependency sniffing**: `@guren/plugin-mcp` under the app's `dependencies` *is* the opt-in (installing the plugin is the explicit act; the build merely stops sabotaging it). `devDependencies` don't count (they never ship); an absent or unreadable manifest is not opt-in evidence — fail-closed, preserving today's behavior exactly.
- `stubbableDevOnlyModules({ mcpPlugin })` — drops exactly one entry: the transport. `mcp.js` (`McpServer`, the Dev MCP) stays stubbed on every platform forever — it generates files on disk and is compiled shut by the `NODE_ENV` define regardless.
- The opt-in is decided once per build and threaded to every consumer, so the per-platform decisions (stub map, catch-all, aliases, guard) cannot drift apart.

### Per platform
- **Lambda / Vercel**: stub maps derive from the policy, and the SDK-prefix catch-all is conditional on the same boolean. The tempting derivation — "keep the catch-all while any SDK subpath is still stubbed" — is *always true* (`mcp.js` never unstubs) and would have silently swallowed `server/index.js`; a tombstone comment at both sites records why.
- **Cloudflare**: aliases and the scaffold derive from the policy. The aliases live in the app's *committed* `wrangler.jsonc`, which the scaffold never overwrites — so an app that adds the plugin later would keep a stale stub alias and ship an endpoint whose `tools/list` returns nothing, with every gate green. `cloudflare:build` now **fails** in that state, naming the exact alias line to delete. The guard judges the alias by its *value* (the generated stub filename, last path segment, read from `STUB_FILES`): an alias pointing at a developer's own shim is a deliberate override and builds untouched; JSONC comments can't trip it; an unparseable config falls back to the existing warning path. Stub *files* are still written unconditionally — older committed configs reference them.

### Measured (differential wrangler probe, `GUREN_TEST_WRANGLER=1`, nightly)
A bare "bundle resolves" check cannot fail for this defect — the stub declares the transport's export name, so the broken configuration bundles fine and merely throws at request time. The new probe bundles the same worker twice (transport served vs stubbed) against identical vendored workspace packages and asserts the difference:

| Configuration | gzipped |
|---|---|
| transport served (post-fix) | **157.7 KiB** |
| transport stubbed (pre-fix) | 150.4 KiB |

The transport costs **7.3 KiB gzipped**; the whole worker sits at **5.1 % of the free-plan 3 MiB budget**. Vendoring is by directory copy with a no-nested-`node_modules` assertion — tarball installs let npm satisfy `@guren/*` ranges with published (pre-RFC-0016) copies, which is the probe measuring the wrong thing.

### RFC §7 amendment
Records the sniffing resolution of Open Question 5, the Lambda/Vercel scope extension, that exactly one stub entry is dropped (the original bullet's "the two MCP SDK stubs" overstated it), and that the stale-alias case fails rather than warns.

Changesets: `@guren/core` minor (new exports on a published subpath), the three deploy plugins patch.

Known follow-up (tracked separately, pre-existing): the Cloudflare config checks are `wrangler.jsonc`-only; an app on `wrangler.toml` skips them and gets a second config scaffolded beside it.

## Test plan

- [x] `bun install --frozen-lockfile`, `bun run build:clean`, blog codegen, root `bun run typecheck`
- [x] `test:bun server core plugin-cloudflare plugin-lambda plugin-vercel plugin-mcp` (3324 tests), `test:testing`
- [x] `audit:core-first`, `audit:docs`, `audit:plugin-compat`, `audit:core-semver`
- [x] `GUREN_TEST_WRANGLER=1` probe run locally (numbers above); wired into the nightly canary
- [x] 13 mutations run across the two passes, each caught by exactly the intended test — including one rerun that exposed a hollowed-out JSONC-comment test after the guard rewrite, now replaced with the commented-out-alias case
- [x] Independent review pass re-ran 4 of the mutations from a clean read and confirmed they bite
