### PR TITLE
refactor(cli): import the delivery route name default from core

### DIFF
--- a/.changeset/attachment-delivery-route-defaults.md
+++ b/.changeset/attachment-delivery-route-defaults.md
@@ -1,0 +1,14 @@
+---
+"@guren/core": minor
+"@guren/cli": patch
+---
+
+Export `DEFAULT_DELIVERY_ROUTE_NAME` from `@guren/core`.
+
+The delivery route's default name is a cross-package contract: `guren check`'s
+attachments rules judge, from another package, whether the name the delivery
+route registers under is claimed by more than one route. That rule kept its own
+copy of `'attachments.show'`, which would not have failed loudly if the
+framework's default moved — it would have stopped matching the route that was
+actually registered and reported a genuine collision as fine. The check now
+imports the constant instead of restating it.

--- a/packages/cli/src/attachments-check.ts
+++ b/packages/cli/src/attachments-check.ts
@@ -1,7 +1,7 @@
 import { readdir, readlink, realpath } from 'node:fs/promises'
 import { basename, dirname, join, relative, resolve, sep } from 'node:path'
 import type { CallExpression, ObjectExpression, ObjectProperty } from '@babel/types'
-import { AttachmentDeliveryController, type RouteDefinition } from '@guren/core'
+import { AttachmentDeliveryController, DEFAULT_DELIVERY_ROUTE_NAME, type RouteDefinition } from '@guren/core'
 import { literalString, memberKeyName, objectLiteral, unwrapTypeAssertion, walk } from './ast-walk'
 import { check, type CheckResult } from './check-result'
 import { collectFiles, fileExists, listAppRoots } from './discovery'
@@ -396,8 +396,6 @@ interface AttachmentsDeliveryScan {
   /** `serve: 'redirect'` disk declarations, deduplicated per config file. */
   redirectDisks: Array<{ relPath: string; disk: string }>
 }
-
-const DEFAULT_DELIVERY_ROUTE_NAME = 'attachments.show'
 
 async function scanAttachmentsDelivery(
   cwd: string,

--- a/packages/core/src/attachments/index.ts
+++ b/packages/core/src/attachments/index.ts
@@ -2,7 +2,7 @@ export { Attachable } from './Attachable.js'
 export type { AttachableRecordId, AttachableStatic } from './Attachable.js'
 export { configureAttachments } from './configure.js'
 export type { ConfigureAttachmentsOptions, ConfiguredAttachments } from './configure.js'
-export { ATTACHMENT_OBJECT_PREFIX } from './engine.js'
+export { ATTACHMENT_OBJECT_PREFIX, DEFAULT_DELIVERY_ROUTE_NAME } from './engine.js'
 export type {
   AttachOptions,
   AttachmentUrlOptions,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,7 +96,7 @@ export type { DatabaseSessionStoreOptions } from './session-store.js'
 export { DatabaseOAuthStateStore } from './oauth-state-store.js'
 // Attachments (RFC 0013) — core-native exports; no bare `Attachment` (it
 // would collide with the mail/notification/Slack attachment vocabulary).
-export { Attachable, AttachmentDeliveryController, AttachmentsPruneCommand, ATTACHMENT_OBJECT_PREFIX, configureAttachments, GenerateVariantsJob, hasManyAttached, hasOneAttached, registerAttachmentRoutes } from './attachments/index.js'
+export { Attachable, AttachmentDeliveryController, AttachmentsPruneCommand, ATTACHMENT_OBJECT_PREFIX, configureAttachments, DEFAULT_DELIVERY_ROUTE_NAME, GenerateVariantsJob, hasManyAttached, hasOneAttached, registerAttachmentRoutes } from './attachments/index.js'
 export type {
   AttachableRecordId,
   AttachableStatic,

--- a/packages/core/tests/attachments-delivery-route-name.test.ts
+++ b/packages/core/tests/attachments-delivery-route-name.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import * as core from '../src/index'
+import { DEFAULT_DELIVERY_ROUTE_NAME } from '../src/attachments/engine'
+import { blankComments } from './source-scan'
+
+/**
+ * The delivery route's default name is a cross-package contract, not an engine
+ * detail. `guren check`'s attachments rules judge, from @guren/cli, whether
+ * the name the delivery route registers under collides with an app route —
+ * `Router.name()` silently overwrites duplicates, so a collision resolves
+ * route() lookups and typed links to whichever registered last. To ask that
+ * question the rule has to name the same route name the engine applies.
+ *
+ * A restated copy over there does not fail loudly when the default moves: it
+ * stops matching the route that was actually registered, finds one claim
+ * instead of two, and reports a genuine collision as fine. A warning failing
+ * *open*, with nothing going red anywhere.
+ *
+ * These two tests are what make the single source structural: the constant
+ * must stay reachable as `@guren/core` so a rule over there can import it
+ * rather than restate it, and the engine may not re-hardcode it.
+ *
+ * `DEFAULT_DELIVERY_PREFIX` is deliberately not exported alongside it. It is
+ * the other value `resolveDeliveryRoute()` defaults, but no rule outside this
+ * package names a delivery URL today, and a name in core's allowlist is a
+ * semver commitment — it goes out when something over there needs it.
+ */
+describe('attachment delivery route name default', () => {
+  it('is reachable from the @guren/core surface', () => {
+    // Core's barrel is an allowlist for these names, not `export *`, so a
+    // name missing from it is unreachable however it is exported below.
+    // The CLI's attachments check already imports AttachmentDeliveryController
+    // through this same channel.
+    expect(core.DEFAULT_DELIVERY_ROUTE_NAME).toBe(DEFAULT_DELIVERY_ROUTE_NAME)
+  })
+
+  it('is the only spelling of the route name in the engine', async () => {
+    const path = fileURLToPath(new URL('../src/attachments/engine.ts', import.meta.url))
+    // Comments first: the surrounding prose quotes `'attachments.show'` while
+    // documenting the default, and a scan that read it would fail on itself.
+    const code = blankComments(await readFile(path, 'utf8'))
+
+    // Nothing at runtime distinguishes a name read from the constant from one
+    // re-typed as a literal — same reason the MCP endpoint gate pins the
+    // source form of `process.env.NODE_ENV`. So the form is what is pinned.
+    const declaration = `export const DEFAULT_DELIVERY_ROUTE_NAME = '${DEFAULT_DELIVERY_ROUTE_NAME}'`
+    expect(code).toContain(declaration)
+    for (const quote of ["'", '"']) {
+      expect(code.replace(declaration, '')).not.toContain(
+        `${quote}${DEFAULT_DELIVERY_ROUTE_NAME}${quote}`,
+      )
+    }
+  })
+})

--- a/packages/core/tests/attachments-object-prefix.test.ts
+++ b/packages/core/tests/attachments-object-prefix.test.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import * as core from '../src/index'
 import { ATTACHMENT_OBJECT_PREFIX } from '../src/attachments/engine'
+import { blankComments } from './source-scan'
 
 /**
  * The object-key prefix is a cross-package contract, not an engine detail.
@@ -50,64 +51,3 @@ describe('attachment object key prefix', () => {
     }
   })
 })
-
-/**
- * Replace every comment body with spaces, leaving string and template
- * literals untouched. A scanner rather than a regex sweep because the two
- * classes nest both ways: `//` inside a string opens no comment, and a quote
- * inside a comment opens no string.
- */
-function blankComments(source: string): string {
-  let out = ''
-  let index = 0
-
-  while (index < source.length) {
-    const char = source[index]!
-    const next = source[index + 1]
-
-    if (char === '/' && next === '/') {
-      const end = source.indexOf('\n', index)
-      index = end === -1 ? source.length : end
-      continue
-    }
-    if (char === '/' && next === '*') {
-      const end = source.indexOf('*/', index + 2)
-      index = end === -1 ? source.length : end + 2
-      continue
-    }
-    if (char === "'" || char === '"' || char === '`') {
-      const end = endOfLiteral(source, index, char)
-      out += source.slice(index, end)
-      index = end
-      continue
-    }
-
-    out += char
-    index += 1
-  }
-
-  return out
-}
-
-/**
- * End index (exclusive) of the literal opening at `start`. Template literals
- * are taken whole, interpolations included: the key shapes this file looks
- * for live in exactly that text, and a comment cannot legally sit between a
- * backtick and its `${`.
- */
-function endOfLiteral(source: string, start: number, quote: string): number {
-  let index = start + 1
-  while (index < source.length) {
-    const char = source[index]
-    if (char === '\\') {
-      index += 2
-      continue
-    }
-    if (char === quote) return index + 1
-    // An unterminated single- or double-quoted literal cannot span a line;
-    // stopping here keeps a stray apostrophe from swallowing the rest.
-    if (char === '\n' && quote !== '`') return index
-    index += 1
-  }
-  return source.length
-}

--- a/packages/core/tests/source-scan.ts
+++ b/packages/core/tests/source-scan.ts
@@ -1,0 +1,69 @@
+/**
+ * Source-form scanning for the tests that keep a cross-package constant a
+ * single source. Nothing at runtime distinguishes a value read from a
+ * constant from one re-typed as a literal, so those tests read the engine's
+ * own text — the same reason the MCP endpoint gate pins the source form of
+ * `process.env.NODE_ENV`. Shared rather than copied per test file: a second
+ * copy of a scanner is the bug those tests exist to prevent.
+ */
+
+/**
+ * Replace every comment body with spaces, leaving string and template
+ * literals untouched. A scanner rather than a regex sweep because the two
+ * classes nest both ways: `//` inside a string opens no comment, and a quote
+ * inside a comment opens no string.
+ */
+export function blankComments(source: string): string {
+  let out = ''
+  let index = 0
+
+  while (index < source.length) {
+    const char = source[index]!
+    const next = source[index + 1]
+
+    if (char === '/' && next === '/') {
+      const end = source.indexOf('\n', index)
+      index = end === -1 ? source.length : end
+      continue
+    }
+    if (char === '/' && next === '*') {
+      const end = source.indexOf('*/', index + 2)
+      index = end === -1 ? source.length : end + 2
+      continue
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      const end = endOfLiteral(source, index, char)
+      out += source.slice(index, end)
+      index = end
+      continue
+    }
+
+    out += char
+    index += 1
+  }
+
+  return out
+}
+
+/**
+ * End index (exclusive) of the literal opening at `start`. Template literals
+ * are taken whole, interpolations included: the shapes these scans look for
+ * live in exactly that text, and a comment cannot legally sit between a
+ * backtick and its `${`.
+ */
+function endOfLiteral(source: string, start: number, quote: string): number {
+  let index = start + 1
+  while (index < source.length) {
+    const char = source[index]
+    if (char === '\\') {
+      index += 2
+      continue
+    }
+    if (char === quote) return index + 1
+    // An unterminated single- or double-quoted literal cannot span a line;
+    // stopping here keeps a stray apostrophe from swallowing the rest.
+    if (char === '\n' && quote !== '`') return index
+    index += 1
+  }
+  return source.length
+}


### PR DESCRIPTION
## Summary

`DEFAULT_DELIVERY_ROUTE_NAME` was declared twice: in `packages/core/src/attachments/engine.ts`, and again in `packages/cli/src/attachments-check.ts` as an independent const with the same name and value.

The default is not private to the engine. `guren check`'s attachments rules ask, from `@guren/cli`, whether the name the delivery route registers under is claimed by more than one route — `Router.name()` silently overwrites duplicates, so a collision resolves `route()` lookups and typed links to whichever registered last. To ask that question the rule has to name the same route name the engine applies. Nothing made the two agree, and the way they come apart is silent: if the framework's default moved, the rule would not fail loudly — it would stop matching the route that was actually registered, find one claim instead of two, and report a genuine collision as fine.

(The neighbouring "is the delivery route mounted at all" rule reads the controller class, not the name, so it was never exposed to this drift.)

Same failure class as the object-key prefix consolidated in #633.

## Changes

- Re-export `DEFAULT_DELIVERY_ROUTE_NAME` through `packages/core/src/attachments/index.ts` and name it in core's barrel — an allowlist for these names, not `export *`, so a name missing from it is unreachable as `@guren/core` however it is exported below.
- Delete the CLI re-declaration; import from `@guren/core` (the file already imports `AttachmentDeliveryController` through that channel).
- Two tests keep the single source structural: the constant must stay reachable from `@guren/core`, and the engine's source may not re-hardcode the name. The second is source-level on purpose — nothing at runtime distinguishes a name read from the constant from one re-typed as a literal, the same reason the MCP endpoint gate pins the source form of `process.env.NODE_ENV`. Both were confirmed to fail under mutation.
- The second test needs the same comment-blanking scanner #633 wrote for the object-key prefix, so that scanner moves to `packages/core/tests/source-scan.ts` rather than being copied. Two copies of a scanner in one package is the bug these tests exist to prevent, and the copies had already begun to differ in their prose.
- Changeset: `@guren/core` minor, `@guren/cli` patch.

No behaviour changes.

## `DEFAULT_DELIVERY_PREFIX` stays unexported

It is the other value `resolveDeliveryRoute()` defaults, but nothing outside `@guren/core` names a delivery URL today, and a name in that allowlist is a semver commitment. It also cannot carry the same structural test: the shape worth catching there is an interpolated restatement, and seeing inside template literals also reads the prefix-validation error message, which quotes `'/attachments'` as prose. It goes out when a rule over there needs it. The reasoning is recorded in the test's docblock.

## Side effect worth noting

The CLI's existing duplicate-name test builds its fixture from the literal `'attachments.show'` against a `delivery: {}` config, so it agreed with the local copy no matter what the framework did. With the import in place, renaming core's default turns that test red — verified by mutation.

## Release note

The `@guren/core` minor means the release that ships this also needs a `create-guren-app` bump.

## Verification

Rebased onto `main` after #633 landed; the one-line conflict in core's attachments export list is resolved as a union.

- `bun run build:clean`, `bun run typecheck`, `bun run audit:core-first`, `bun run audit:docs` — all green.
- Tests: the aggregate `bun run test` hit a Bun segfault twice on the dev machine (known local instability), so coverage was taken per package instead — all `test:bun` packages individually plus `test:examples` (exit 0), 0 failures throughout (core 234, cli 2080, server 2735, orm 416, …).