### PR TITLE
fix(server): deny a password login against an account with no password

### DIFF
--- a/.changeset/passwordless-credential-column.md
+++ b/.changeset/passwordless-credential-column.md
@@ -1,0 +1,13 @@
+---
+'@guren/server': minor
+---
+
+Deny a password login against an account that has no password, instead of turning it into a 500.
+
+`ModelUserProvider.validateCredentials()` handed whatever sat in the credential column straight to the hasher. A column holding a sentinel rather than a hash — `passwordHash: 'oauth:...'`, which this repo's own JSDoc, `MassAssignmentException` message, database guide and agent skill all suggest for an OAuth-only account — reached `Bun.password.verify()` and threw. The login came back as a 500 while an unknown address came back as a 401, so the pair of responses told an attacker which addresses belong to OAuth accounts. A null column was already handled; the sentinel was not.
+
+Such a column now means what it says: the account cannot authenticate with a password, so the login is denied. It runs through the same dummy-hash path a null column already took, so the two answers cost the same work and the channel does not reopen as a timing difference. `make:auth --oauth` was never affected — it scaffolds a nullable column — so the reachable population is applications that followed the documented sentinel.
+
+**A value that *claims* a hash format and fails to satisfy it keeps throwing.** That is the other half of the rule and it is deliberate: a truncated or corrupt digest is not a passwordless account, and denying that login in silence would leave nothing to notice the corruption by. `looksLikePasswordHash()` is what separates the two, so the prefixes this check trusts are the same ones the swapped-argument diagnostic trusts.
+
+`DefaultHasher` no longer tells a non-hash value that it "was written by Bun.password". That message is for a genuine Argon2id or bcrypt hash met on a runtime that cannot read it; a sentinel now gets one that says what is actually wrong. `ModelUserProvider` never reaches it, but a direct caller can.

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -308,6 +308,8 @@ Optional means optional: a caller may still pass `passwordHash` and it will type
 
 Leave `requireOnCreate` off when accounts can also arrive without a password — an OAuth-only sign-up, for instance — so `password` stays optional.
 
+A credential column holding something that is not a password hash means the account cannot authenticate with one. `ModelUserProvider` treats a null column, an empty string, and a sentinel such as `'oauth:...'` alike: the login is denied, and the same hashing work is spent as on a real verification so the response is not distinguishable by time. A value that *claims* a hash format and fails to satisfy it still throws — that is a corrupt or truncated column, and denying it in silence would leave nothing to notice it by. A nullable column is the clearer choice for a passwordless account; `make:auth --oauth` scaffolds one.
+
 The default `AuthServiceProvider` automatically registers a `web` guard that uses the `users` provider. If you need additional guards (e.g. token-based APIs), call `auth.registerGuard('api', factory)` inside the provider and set it as default via `auth.setDefaultGuard('api')` when appropriate.
 
 ## Controllers & Routes

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -306,6 +306,8 @@ export class User extends defineModel(users, {
 
 OAuth 専用のサインアップなどパスワードなしでアカウントが作られる場合は `requireOnCreate` を付けず、`password` を任意のままにします。
 
+資格情報カラムにパスワードハッシュ以外の値が入っている場合、そのアカウントはパスワードで認証できないという意味になります。`ModelUserProvider` は null、空文字列、`'oauth:...'` のような番兵を同じ扱いにします: ログインを拒否し、実際の検証と同じだけのハッシュ計算を行うので応答時間からも判別できません。一方、ハッシュ形式を名乗っていて内容がそれを満たさない値はこれまでどおりスローします。カラムの破損や切り詰めであり、黙って拒否すると気付く手がかりが無くなるためです。パスワードを持たないアカウントには nullable なカラムの方が明快で、`make:auth --oauth` はそちらを生成します。
+
 既定の `AuthServiceProvider` は `users` プロバイダーを使う `web` ガードを自動登録します。追加のガード（例: トークンベース API）が必要なら、`context.auth.registerGuard('api', factory)` を呼び、必要に応じて `context.auth.setDefaultGuard('api')` で既定を差し替えます。
 
 ## コントローラーとルート

--- a/packages/server/src/auth/password/DefaultHasher.ts
+++ b/packages/server/src/auth/password/DefaultHasher.ts
@@ -1,7 +1,7 @@
 import type { PasswordHasher } from './PasswordHasher'
 import { ScryptHasher } from './ScryptHasher'
 import { NodeHasher } from './NodeHasher'
-import { NODE_SCRYPT_PREFIX } from './hash-format'
+import { NODE_SCRYPT_PREFIX, looksLikePasswordHash } from './hash-format'
 
 /**
  * Runtime-detecting password hasher: hashes with `Bun.password` when running
@@ -55,6 +55,17 @@ export class DefaultHasher implements PasswordHasher {
     }
 
     if (!this.bun) {
+      if (!looksLikePasswordHash(hashed)) {
+        // Saying "written by Bun.password" about an `oauth:...` sentinel would
+        // be a confident wrong answer. `ModelUserProvider` never gets here;
+        // a direct caller might.
+        throw new Error(
+          'This value is not a password hash in any format the built-in hashers ' +
+            'produce, so it cannot be verified. A credential column holding a ' +
+            'sentinel for a passwordless account should not reach verify().',
+        )
+      }
+
       throw new Error(
         'This password hash was written by Bun.password (Argon2id or bcrypt) and ' +
           'cannot be verified on a runtime without Bun. Hash formats follow the ' +

--- a/packages/server/src/auth/password/hash-format.ts
+++ b/packages/server/src/auth/password/hash-format.ts
@@ -24,7 +24,7 @@ const HASH_PREFIXES = [
   NODE_SCRYPT_PREFIX,
 ]
 
-function looksLikePasswordHash(value: string): boolean {
+export function looksLikePasswordHash(value: string): boolean {
   return HASH_PREFIXES.some((prefix) => value.startsWith(prefix))
 }
 

--- a/packages/server/src/auth/providers/ModelUserProvider.ts
+++ b/packages/server/src/auth/providers/ModelUserProvider.ts
@@ -1,6 +1,7 @@
 import type { Model, PlainObject } from '@guren/orm'
 import type { PasswordHasher } from '../password/PasswordHasher'
 import { DefaultHasher } from '../password/DefaultHasher'
+import { looksLikePasswordHash } from '../password/hash-format'
 import type { AuthCredentials, Authenticatable } from '../types'
 import { BaseUserProvider } from './UserProvider'
 
@@ -96,7 +97,17 @@ export class ModelUserProvider<User extends Authenticatable = Authenticatable> e
     }
 
     const hashed = (user as PlainObject)[this.passwordColumn]
-    if (typeof hashed !== 'string') {
+    // A column holding something that is not a password hash means the account
+    // cannot authenticate with one: a null or empty column, or a sentinel such
+    // as the `passwordHash: 'oauth:...'` this repo documents for OAuth-only
+    // accounts. That is a failed login, not a server error - handing it to the
+    // hasher throws, which surfaces as a 500 and tells an attacker that the
+    // address belongs to an OAuth account while an unknown address gets a 401.
+    //
+    // A value that *claims* a hash format and fails to satisfy it keeps
+    // throwing. That is a corrupt or truncated column, and denying the login in
+    // silence would leave nothing to notice it by.
+    if (typeof hashed !== 'string' || !looksLikePasswordHash(hashed)) {
       // Run a dummy hash to prevent timing-based user enumeration.
       // This ensures requests take the same time whether or not the user exists.
       await this.hasher.hash('dummy-timing-equalization')

--- a/packages/server/tests/auth/passwordless-credentials.test.ts
+++ b/packages/server/tests/auth/passwordless-credentials.test.ts
@@ -1,0 +1,91 @@
+import { describe, test, expect } from 'bun:test'
+import { ModelUserProvider } from '../../src/auth/providers/ModelUserProvider'
+import { NodeHasher } from '../../src/auth/password/NodeHasher'
+import type { PasswordHasher } from '../../src/auth/password/PasswordHasher'
+
+type Row = { id: number; email: string; passwordHash: unknown }
+
+function providerFor(rows: Row[], hasher?: PasswordHasher) {
+  const model = {
+    where: async (clause: Record<string, unknown>) =>
+      rows.filter((row) => row.email === clause.email),
+  }
+
+  return new ModelUserProvider(model as never, {
+    usernameColumn: 'email',
+    passwordColumn: 'passwordHash',
+    credentialsPasswordField: 'password',
+    ...(hasher ? { hasher } : {}),
+  })
+}
+
+// A password login against an account that has no password used to reach the
+// hasher, which throws. The 500 that produced told an attacker the address
+// belonged to an OAuth account, while an unknown address answered 401.
+describe('a credential column that is not a password hash', () => {
+  const PASSWORDLESS = {
+    'the sentinel this repo documents': 'oauth:github:12345',
+    'a bare provider name': 'oauth',
+    'an empty string': '',
+    'null': null,
+    'undefined': undefined,
+    'a number left by a bad migration': 12345,
+  }
+
+  test.each(Object.entries(PASSWORDLESS))('denies the login for %s', async (_label, passwordHash) => {
+    const provider = providerFor([{ id: 1, email: 'a@example.com', passwordHash }])
+    const user = { id: 1, email: 'a@example.com', passwordHash }
+
+    expect(await provider.validateCredentials(user as never, { password: 'guess' })).toBe(false)
+  })
+
+  test('spends the same hashing work as a real verification', async () => {
+    // Without the dummy hash the sentinel would return in microseconds while a
+    // real account pays for scrypt, which is the same enumeration channel
+    // measured with a stopwatch instead of read off a status code.
+    const calls: string[] = []
+    const counting: PasswordHasher = {
+      async hash(plain) {
+        calls.push(plain)
+        return new NodeHasher({ cost: 1024 }).hash(plain)
+      },
+      verify: (hashed, plain) => new NodeHasher({ cost: 1024 }).verify(hashed, plain),
+    }
+
+    const provider = providerFor([], counting)
+    const user = { id: 1, email: 'a@example.com', passwordHash: 'oauth:github:12345' }
+
+    expect(await provider.validateCredentials(user as never, { password: 'guess' })).toBe(false)
+    expect(calls).toHaveLength(1)
+  })
+})
+
+// The other half of the rule: a value that claims a hash format and does not
+// satisfy it is a corrupt column, and denying it in silence would leave nothing
+// to notice it by.
+describe('a credential column that claims a hash format', () => {
+  const CORRUPT = {
+    'a truncated digest': '$scrypt$N=1024,r=8,p=1$c2FsdA==$',
+    'unparseable parameters': '$scrypt$N=x,r=y,p=z$c2FsdA==$c2FsdA==',
+    'a bcrypt prefix with no body': '$2b$',
+  }
+
+  test.each(Object.entries(CORRUPT))('still throws for %s', async (_label, passwordHash) => {
+    const provider = providerFor([{ id: 1, email: 'a@example.com', passwordHash }])
+    const user = { id: 1, email: 'a@example.com', passwordHash }
+
+    await expect(provider.validateCredentials(user as never, { password: 'guess' })).rejects.toThrow()
+  })
+})
+
+describe('a real password hash', () => {
+  test('is unaffected', async () => {
+    const hasher = new NodeHasher({ cost: 1024 })
+    const passwordHash = await hasher.hash('password123')
+    const provider = providerFor([{ id: 1, email: 'a@example.com', passwordHash }], hasher)
+    const user = { id: 1, email: 'a@example.com', passwordHash }
+
+    expect(await provider.validateCredentials(user as never, { password: 'password123' })).toBe(true)
+    expect(await provider.validateCredentials(user as never, { password: 'wrong' })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to #638, which flagged this and left it out on purpose.

`ModelUserProvider.validateCredentials()` handed whatever sat in the credential column straight to the hasher. A column holding a *sentinel* rather than a hash reached `Bun.password.verify()` and threw, so the login answered **500** while an unknown address answered **401**. That pair of responses tells an attacker which addresses belong to OAuth-only accounts.

The sentinel is not a hypothetical: `passwordHash: 'oauth:...'` is what `AuthenticatableModel`'s JSDoc, `Model.ts`'s JSDoc, the `MassAssignmentException` message, the database guide, the authentication guide, and the agent harness skill all suggest for an account created through OAuth. A **null** column was already handled correctly; the sentinel was not.

Verified before and after:

```
oauth:github:123           -> THREW: Password verification failed with error "UnsupportedAlgorithm"   (before)
oauth:github:123           -> false                                                                    (after)
null                       -> false                                                                    (unchanged)
$scrypt$N=1024,r=8,p=1$c…$ -> THREW: Invalid password hash format.                                     (unchanged)
```

## Scope

`server`, `docs`

- `ModelUserProvider.validateCredentials()` — a credential value that is not a password hash denies the login.
- `hash-format.ts` — `looksLikePasswordHash()` is exported; it now has a second caller.
- `DefaultHasher` — the runtime-mismatch message is no longer told to a value that is not a hash.
- `docs/{en,ja}/guides/authentication.md` — the contract, and a pointer to a nullable column as the clearer choice.

## Risk Assessment

**The fix is in the provider, not in the hashers, and that placement is the substance of the change.** The enumeration channel has two halves: the status code and the response time. `validateCredentials()` already spends a dummy hash for a null column so that a missing account and a real one cost the same. Returning `false` from inside `verify()` would close the status-code half and open a timing half in the same commit — the hasher has no timing budget to spend. Putting it where the dummy hash already lives closes both.

**The rule has two sides, and only one of them changed.** A value that does not claim to be a hash (`oauth:...`, `''`, `null`, a number left by a bad migration) is a passwordless account: deny. A value that *claims* a format and fails to satisfy it (`$scrypt$…$` with a truncated digest) is a corrupt column: still throws. Denying that one in silence would leave nothing to notice the corruption by — which is the same reasoning that made #638 reject a malformed digest rather than accept it.

**Reachable population.** `make:auth --oauth` scaffolds a *nullable* column and creates passwordless accounts, so the framework's own OAuth path was never affected. This reaches applications that followed the documented sentinel.

**Not covered:** an application calling `hasher.verify()` directly still throws on a sentinel, because a hasher asked to verify a non-hash is a programming error and has no dummy hash to spend. `examples/api` is such a caller. The deeper fix there is to register a `ModelUserProvider` rather than hand-roll the comparison, which is a larger change than this PR.

**Bump type.** `minor`, `@guren/server` only. Worth a second opinion: `contributing/semver-guidance.md` lists "changes to Stable API … default behavior" under Major, and `ModelUserProvider` is re-exported from `@guren/core`, so it is Stable. Read strictly, that argues for a major. Read as `rfc-process.md` does — "Bug fixes (even complex ones)" need no RFC — a 500 becoming the correct 401 for an account that can never authenticate by password is a fix, no signature changes, and nobody has working code depending on the throw. #638 shipped a comparable security behaviour change as a minor and `audit:core-semver` passed, so this follows that precedent. Say the word and I will re-cut it as a major.

## Validation

- [x] `bun run build` — exit 0
- [x] `bun run typecheck` — exit 0
- [x] `bun run test` — see below

Per package: server 2781, cli 2081, core 242, orm 416, remaining packages + scripts 742. Examples: blog 114, api 43, web 123. `packages/testing` 250. Audits `audit:docs`, `audit:core-first`, `audit:core-semver`, `audit:template-deps` all pass.

`packages/server/tests/auth/passwordless-credentials.test.ts` covers the boundary in both directions — six passwordless shapes deny, three format-claiming shapes still throw, a real hash is unaffected — plus an assertion that the deny path spends the dummy hash, which is the timing half. **Mutation-checked:** dropping the `looksLikePasswordHash` guard turns 3 of them red.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
