### PR TITLE
fix(plugin-vercel): drop the dev index.html shell from the static output

### DIFF
--- a/.changeset/vercel-static-index-shadowing.md
+++ b/.changeset/vercel-static-index-shadowing.md
@@ -1,0 +1,21 @@
+---
+"@guren/core": patch
+"@guren/plugin-vercel": patch
+---
+
+Stop the Vercel build from shipping the dev `index.html` shell.
+
+The shell exists so Vite can serve the app in development, and the generated
+`config.json` runs `{ handle: "filesystem" }` ahead of the catch-all to the
+function — so a staged `index.html` answered `/` from the CDN and the app's own
+root route never ran. Cloudflare and Lambda already dropped it, through the
+shared `stageStaticAssets`; this build stages `public/` itself, having no
+`/public/assets` mirror to build (its `config.json` carries a
+`/public/(.*)` rewrite instead), and so never applied the rule.
+
+The removal moves into `removeShadowingIndex` in `@guren/core`'s internal
+deploy-build helpers, which `stageStaticAssets` now calls too. The rule is
+stated once, for the platform whose layout differs as much as for the two that
+share the staging function — the alternative, a second `rmSync` in the plugin
+with a comment pointing back here, is how the two copies drift. The cost is
+that this ships as a two-package release rather than a one-line plugin patch.

--- a/packages/core/src/internal/deploy-build.ts
+++ b/packages/core/src/internal/deploy-build.ts
@@ -353,14 +353,39 @@ export function ssrRuntimePaths(
 }
 
 /**
+ * Delete the dev-mode `index.html` shell from a directory a platform serves
+ * statically.
+ *
+ * Guren-specific knowledge, not platform policy, which is why it is shared:
+ * the shell exists so Vite can serve the app in dev, and every deploy target
+ * answers for its static directory before the function runs — so shipping it
+ * shadows the app's own root route, which then never executes. Exact name
+ * only: the shell is written by the framework's own scaffolding, so there is
+ * no case variant of it to catch, and a platform's asset directory otherwise
+ * belongs to the app.
+ *
+ * Separate from `stageStaticAssets` because a platform whose layout differs
+ * needs this rule without the rest — `@guren/plugin-vercel` stages `public/`
+ * itself, having no `/public/assets` mirror to build (its generated
+ * `config.json` carries a rewrite instead), and shipped the shadowing shell
+ * for exactly as long as the rule lived inside the function it could not call.
+ */
+export function removeShadowingIndex(assetsOut: string): void {
+  const shadowingIndex = resolve(assetsOut, 'index.html')
+  if (existsSync(shadowingIndex)) {
+    rmSync(shadowingIndex)
+  }
+}
+
+/**
  * Copy `public/` into a platform's static-asset staging directory.
  *
- * Two pieces of Guren-specific knowledge, not platform policy, which is why
- * this is shared: the dev-mode `index.html` shell must never ship (it would
- * shadow the app's root route on any host that serves static files first), and
- * built assets self-reference the Vite plugin's derived base `/public/assets/`
- * while HTML references use `/assets/` — so on a host without rewrites the
- * built-assets directory has to appear under both prefixes.
+ * Carries one piece of Guren-specific knowledge of its own, which is why it is
+ * shared rather than per-plugin: built assets self-reference the Vite plugin's
+ * derived base `/public/assets/` while HTML references use `/assets/` — so on
+ * a host without rewrites the built-assets directory has to appear under both
+ * prefixes. The shadowing-shell rule it also applies belongs to
+ * `removeShadowingIndex`, stated there.
  */
 export function stageStaticAssets(publicDir: string, assetsOut: string): void {
   mkdirSync(assetsOut, { recursive: true })
@@ -371,10 +396,7 @@ export function stageStaticAssets(publicDir: string, assetsOut: string): void {
 
   cpSync(publicDir, assetsOut, { recursive: true })
 
-  const shadowingIndex = resolve(assetsOut, 'index.html')
-  if (existsSync(shadowingIndex)) {
-    rmSync(shadowingIndex)
-  }
+  removeShadowingIndex(assetsOut)
 
   const clientAssetsDir = resolve(publicDir, 'assets')
   if (existsSync(clientAssetsDir)) {

--- a/packages/plugin-vercel/src/index.ts
+++ b/packages/plugin-vercel/src/index.ts
@@ -9,6 +9,7 @@ import {
   DOCUMENT_ASSET_EXTENSIONS,
   DOCUMENT_ASSET_HEADERS,
   MCP_SDK_SUBPATH_PREFIX,
+  removeShadowingIndex,
   renderDevOnlyStub,
   stubbableDevOnlyModules,
   resetOutputDir,
@@ -196,7 +197,12 @@ export async function buildVercelOutput(options: BuildVercelOutputOptions = {}):
   }
 
   if (existsSync(publicDir)) {
+    // No `/public/assets` mirror here, unlike `stageStaticAssets`: the
+    // generated `config.json` rewrites `/public/(.*)` onto the output root
+    // instead. The dev shell still has to go — the CDN answers for `static/`
+    // ahead of the function, so `index.html` would shadow the app's root route.
     cpSync(publicDir, resolve(out, 'static'), { recursive: true })
+    removeShadowingIndex(resolve(out, 'static'))
   }
 }
 

--- a/packages/plugin-vercel/tests/index.test.ts
+++ b/packages/plugin-vercel/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
@@ -261,6 +261,24 @@ describe('@guren/plugin-vercel', () => {
       // It has to win before the filesystem handler, which would otherwise
       // miss and fall through to the function.
       expect(routes.findIndex((route) => route.handle === 'filesystem')).toBeGreaterThan(0)
+    })
+
+    it('drops the dev index.html shell so it cannot shadow the app root route', async () => {
+      // `{ handle: 'filesystem' }` runs ahead of the catch-all to the
+      // function, so a staged index.html answers `/` before the app's root
+      // route ever runs. Cloudflare and Lambda already dropped it, through
+      // `stageStaticAssets`; this build stages `public/` itself.
+      const app = scaffoldApp(root, { entrypoint: 'src/vercel.ts' })
+      mkdirSync(join(root, 'public'), { recursive: true })
+      writeFileSync(join(root, 'public/index.html'), '<!doctype html><div id="app"></div>\n')
+      writeFileSync(join(root, 'public/robots.txt'), 'User-agent: *\n')
+
+      await buildVercelOutput(app)
+
+      expect(existsSync(join(app.outputDir, 'static/index.html'))).toBe(false)
+      // The sibling proves the copy ran at all: without it a fixture writing
+      // to the wrong path would pass the assertion above unchanged.
+      expect(existsSync(join(app.outputDir, 'static/robots.txt'))).toBe(true)
     })
 
     it('forces the document types under static/ to download', async () => {


### PR DESCRIPTION
## Summary

`@guren/plugin-vercel` shipped the dev-mode `index.html` shell into
`.vercel/output/static`, where it shadowed the app's own root route.

The generated `config.json` places `{ handle: "filesystem" }` ahead of the
catch-all `{ src: "/(.*)", dest: "/index" }`, so the CDN answered `/` from that
file and the function never ran. `@guren/plugin-cloudflare` and
`@guren/plugin-lambda` already dropped the shell, through the shared
`stageStaticAssets`; the Vercel build stages `public/` itself — it has no
`/public/assets` mirror to build, carrying a `/public/(.*)` rewrite in
`config.json` instead — and so never applied the rule.

The removal moves out of `stageStaticAssets` into a new
`removeShadowingIndex()` in `@guren/core`'s internal deploy-build helpers,
which the staging function now calls. A targeted `rmSync` in the plugin with a
comment pointing back at the shared rule was the alternative; the helper wins
because the rule then has exactly one statement rather than a copy that reads
correct on the day it is written and drifts afterwards. Its price is named in
the commit and the changeset: this ships as a two-package release, since the
plugin now calls a symbol only an unpublished core exports.

Scope is deliberately narrow. The Vercel plugin is *not* switched over to
`stageStaticAssets` — only the index removal transfers. The `stageStaticAssets`
doc comment loses its statement of the shadowing rule so it is not stated
twice.

This is adjacent to the static-document stored-XSS work (#636, #637, #645) but
a separate defect: route shadowing, not response headers.

## Scope

- `packages/core` (`src/internal/deploy-build.ts`)
- `packages/plugin-vercel` (`src/index.ts`, `tests/index.test.ts`)
- changeset: `@guren/core` patch, `@guren/plugin-vercel` patch

## Risk Assessment

- Behavior change is confined to the Vercel build output: a `public/index.html`
  is no longer copied to `.vercel/output/static`. An app that intentionally
  served a static `public/index.html` at `/` on Vercel now gets its own root
  route instead — which is the documented framework behavior and what the other
  two deploy targets already do.
- No public API change. `removeShadowingIndex` is reachable only through the
  deep `@guren/core/internal/deploy-build` import, unstable by
  `contributing/api-stability.md`, exactly like `stageStaticAssets`.
- Version coupling: `@guren/plugin-vercel` calls a symbol that exists only in
  an unreleased `@guren/core`, hence the `@guren/core` patch changeset
  alongside — same shape as the `cdn-static-document-headers` changeset. The
  plugin's `@guren/core` range is left as is; raising the floor to an
  unpublished version would break installs.
- Exact-match `index.html` only, matching what `stageStaticAssets` has always
  removed. The uppercase-extension hole closed in #645 is about extensions a
  platform matches case-sensitively; the shell is written by the framework's
  own scaffolding under one name.

## Validation

- [x] `bun run build` — green.
- [x] `bun run typecheck` — green (needed `bun install` first in this worktree:
      `@guren/plugin-cloudflare` devDeps were absent, unrelated to this change).
- [x] `bun run test` — `bun test --isolate` spun at ~100% CPU with no output on
      this machine (the known local wedge). Re-ran the same package list from
      `scripts/test-packages.ts` without `--isolate`: **6374 pass / 96 skip /
      12 fail**. All 12 are `packages/server/tests/queue/` cross-file
      isolation artifacts — those two files pass 52/52 on their own and are
      untouched here. `bun run test:examples`: 123 pass.
- Failure check: reverting only the Vercel call site (leaving the helper in
  place) turns the new test red and nothing else — 17 pass / 1 fail, the
  failure being `drops the dev index.html shell so it cannot shadow the app
  root route`.

The new test also asserts a sibling `public/robots.txt` **is** staged, so the
absence of `index.html` is evidence of removal rather than of a fixture that
wrote to the wrong path.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [ ] I updated relevant documentation — no doc change needed; the deployment
      guides never documented the shell as deployable, and this brings Vercel
      in line with what they already describe for the other targets.
