### PR TITLE
fix(server): remove quadratic backtracking from bearer header parsing

### DIFF
--- a/.changeset/bearer-header-redos.md
+++ b/.changeset/bearer-header-redos.md
@@ -1,0 +1,22 @@
+---
+'@guren/server': patch
+---
+
+Fix a quadratic-backtracking regex in `readBearerToken` (CodeQL `js/polynomial-redos`).
+
+`/^Bearer\s+(.+)$/i` let the separator and the token both match a space, so the
+two repetitions overlapped. On `Bearer` followed by a long run of spaces and a
+newline — `.` never matches one, so `$` is unreachable — the engine retried
+every split of that run, quadratic in the header's length: ~1.5s for a 50KB
+header, and the header is parsed *before* any authentication, by
+`hasBearerHeader` on every request that carries one. Anchoring the capture with
+`\S` removes the overlap; the same input now costs ~0.1ms.
+
+The only input whose result changes is an all-whitespace token, which was never
+a token: `Bearer` + spaces used to read as a bearer request carrying a space,
+and now reads as not a bearer request at all. That reclassification is what the
+change is, not just a different token value — `AuthManager.resolveGuardName` no
+longer routes such a request to the token guard, and the CSRF middleware no
+longer skips it. Net stricter: the request falls back to the session guard with
+CSRF enforced, where it previously bypassed CSRF to reach a token lookup that
+could only ever 401.

--- a/packages/server/src/auth/api-token.ts
+++ b/packages/server/src/auth/api-token.ts
@@ -241,10 +241,20 @@ export function parseApiToken(plainTextToken: string): { id: string; token: stri
  * parsing rule shared by `createBearerTokenMiddleware`, `TokenGuard`, and
  * `hasBearerHeader` below — three readers of the same header must not
  * disagree about what a bearer request is.
+ *
+ * The `\S` anchoring the capture is load-bearing, not cosmetic: `\s+(.+)`
+ * lets the separator and the token both match a space, so an attacker-supplied
+ * `Bearer` + many spaces + a newline (`.` never matches one, so `$` is
+ * unreachable) makes the engine retry every split of the whitespace run —
+ * quadratic in the header length, on a header read before any authentication.
+ * Requiring the token to start with a non-space removes the overlap. The only
+ * input whose result changes is an all-whitespace token, which was never a
+ * token: it now reads as "not a bearer request" rather than as a bearer
+ * request carrying a space, so CSRF is no longer skipped for it.
  */
 export function readBearerToken(header: string | undefined | null): string | null {
   if (!header) return null
-  const match = header.match(/^Bearer\s+(.+)$/i)
+  const match = header.match(/^Bearer\s+(\S.*)$/i)
   return match ? match[1] : null
 }
 

--- a/packages/server/tests/auth/api-token.test.ts
+++ b/packages/server/tests/auth/api-token.test.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 import {
   createApiToken,
   parseApiToken,
+  readBearerToken,
   verifyApiToken,
   tokenCan,
   tokenCanAll,
@@ -244,6 +245,42 @@ describe('parseApiToken', () => {
     expect(parseApiToken('|')).toBeNull()
     expect(parseApiToken('abc|')).toBeNull()
     expect(parseApiToken('|def')).toBeNull()
+  })
+})
+
+describe('readBearerToken', () => {
+  it('reads the token after the scheme, case-insensitively', () => {
+    expect(readBearerToken('Bearer abc123')).toBe('abc123')
+    expect(readBearerToken('bearer   abc123')).toBe('abc123')
+    expect(readBearerToken('BEARER\tabc|123')).toBe('abc|123')
+  })
+
+  it('returns null for anything that is not a bearer header', () => {
+    expect(readBearerToken(undefined)).toBeNull()
+    expect(readBearerToken(null)).toBeNull()
+    expect(readBearerToken('')).toBeNull()
+    expect(readBearerToken('Basic abc123')).toBeNull()
+    expect(readBearerToken('Bearer')).toBeNull()
+    expect(readBearerToken('Bearer ')).toBeNull()
+    expect(readBearerToken('Bearer    ')).toBeNull()
+  })
+
+  // The header is parsed before any authentication, so its cost must stay
+  // linear in the length an unauthenticated caller controls. `\\s+(.+)` was
+  // quadratic on this shape: the separator and the token could both match a
+  // space, and the trailing newline made `$` unreachable, so every split of
+  // the whitespace run was retried.
+  it('stays linear on a header built to backtrack', () => {
+    const header = `Bearer${' '.repeat(50_000)}\n`
+
+    const start = performance.now()
+    const result = readBearerToken(header)
+    const elapsed = performance.now() - start
+    expect(result).toBeNull()
+
+    // The budget is deliberately loose: the quadratic form took ~1.5s on this
+    // input and the linear one takes ~0.1ms, so anything in between is noise.
+    expect(elapsed).toBeLessThan(250)
   })
 })
 


### PR DESCRIPTION
Closes CodeQL alert [#76](https://github.com/gurenjs/guren/security/code-scanning/76) (`js/polynomial-redos`, high).

## The defect

`readBearerToken` matched `/^Bearer\s+(.+)$/i`. The separator `\s+` and the capture `(.+)` both match a space, so the two repetitions overlap. Feed it `Bearer` + a long run of spaces + a newline — `.` never matches a newline, so `$` is unreachable and the match must fail — and the engine retries every split of that whitespace run before giving up.

Measured on Bun 1.3.14:

| input | `\s+(.+)` | `\s+(\S.*)` |
|---|---|---|
| `Bearer` + 8K spaces + `\n` | 37ms | 0.01ms |
| `Bearer` + 50K spaces + `\n` | 1495ms | 0.09ms |

Doubling the input quadrupled the time — quadratic, on a header parsed *before* any authentication: `hasBearerHeader` runs on every request carrying an `Authorization` header, from `AuthManager.resolveGuardName` and from the CSRF middleware's bearer skip.

## The fix

Anchor the capture with `\S`. The separator can now only hand the capture one position that succeeds — the boundary where the whitespace run ends — and every other give-back fails in O(1), so the match is linear for any input shape, not just this one.

## The one behavioural change

An all-whitespace token, which was never a token. `Bearer` + spaces used to read as a bearer request carrying a single space; it now reads as not a bearer request at all. So `resolveGuardName` no longer routes it to the token guard and the CSRF middleware no longer skips it: the request falls back to the session guard with CSRF enforced, where it previously bypassed CSRF to reach a token lookup that could only ever 401. Net stricter. `@guren/plugin-mcp`'s bearer path answers with the same 401 either way, now naming the missing token rather than an invalid one.

Every other input — including `Bearer`, `Bearer ` (single trailing space), `Basic …`, a token containing spaces or a `|`, and a lowercase scheme — parses identically; verified by direct comparison of both regexes across those cases.

## Verification

Two tests in `packages/server/tests/auth/api-token.test.ts`, both confirmed to **fail** against the old regex and pass against the new one:

- a deterministic case (`readBearerToken('Bearer    ')` → `null`), and
- a timing budget on the 50K adversarial header (250ms, against ~1.5s before and ~0.1ms after).

`build`, `typecheck`, `test:bun server plugin-mcp core`, `test:examples`, `audit:core-first`, `audit:docs` all green.