### PR TITLE
fix(examples): render the docs search dialog above the page, not under it

### DIFF
--- a/web/resources/js/components/DocSearch.tsx
+++ b/web/resources/js/components/DocSearch.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@inertiajs/react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 
 import {
   createDebouncedDocSearch,
@@ -255,7 +256,13 @@ export function DocSearch({ locale, className = '' }: DocSearchProps) {
         </kbd>
       </button>
 
-      {open && (
+      {open &&
+        // Rendered into the body rather than in place. The trigger sits inside
+        // `.docs-sidebar`, which is `position: sticky` — and sticky creates a
+        // stacking context, so `z-50` here only ordered the dialog *within the
+        // sidebar*. The article's code blocks are `position: relative` and come
+        // later in the document, so they painted over it.
+        createPortal(
         <div
           className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 p-4 pt-[10vh]"
           onMouseDown={(event) => {
@@ -376,8 +383,9 @@ export function DocSearch({ locale, className = '' }: DocSearchProps) {
               <span className="docs-mono ml-auto">esc</span>
             </div>
           </div>
-        </div>
-      )}
+        </div>,
+          document.body,
+        )}
     </>
   )
 }

--- a/web/tests/components/DocSearch.test.ts
+++ b/web/tests/components/DocSearch.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+/**
+ * A source-level check, which is not the kind this repo prefers — but it is
+ * the kind available. `web` has no DOM test harness, and the failure it pins
+ * is invisible to every other gate: the dialog renders, the tests pass, the
+ * typecheck passes, and it is simply painted over on a page that has code
+ * blocks.
+ *
+ * The rule: the dialog cannot render where the trigger sits. That trigger is
+ * inside `.docs-sidebar`, which is `position: sticky`, and sticky creates a
+ * stacking context — so `z-50` there orders the dialog only *within the
+ * sidebar*, and `.docs-content pre` (position: relative, later in the
+ * document) paints over it.
+ */
+const source = readFileSync(
+  resolve(import.meta.dirname, '../../resources/js/components/DocSearch.tsx'),
+  'utf8',
+)
+
+describe('DocSearch', () => {
+  it('renders the dialog into the body rather than in place', () => {
+    expect(source).toContain("import { createPortal } from 'react-dom'")
+    expect(source).toMatch(/createPortal\(/u)
+    expect(source).toContain('document.body,')
+  })
+
+  it('keeps the sidebar reason next to the portal', () => {
+    // The comment is the only thing that stops someone unwinding this as an
+    // unnecessary indirection.
+    expect(source).toMatch(/sticky creates a\s*\n\s*\/\/ stacking context/u)
+  })
+})


### PR DESCRIPTION
Reported from production: on a docs page with code blocks, the search dialog is painted over by them. The blocks above and below cover its edges, and the input row disappears behind one.

## Cause

The trigger sits inside `.docs-sidebar`, which is `position: sticky` — and sticky **creates a stacking context**. So `z-50` on the overlay ordered the dialog only *within the sidebar*. The sidebar itself sits at level 0 in the layout and comes first in the document; `.docs-content pre` is `position: relative`, also level 0, and later. Every code block on the page therefore paints above the entire sidebar subtree, dialog included.

Confirmed on the live site before fixing: the overlay's parent element is `.docs-sidebar`.

## Fix

The dialog renders into `document.body` through a portal, where its z-index means what it says.

Verified on a local production build: the overlay's parent is `BODY`, nothing in the dialog is inside `.docs-sidebar` any more, and hit-testing a grid across the dialog returns elements inside the dialog.

## On the gate

A source-level assertion, which is not this repo's preference. `web` has no DOM test harness, and this failure is invisible to every other gate — the dialog renders, the tests pass, the typecheck passes, and it is simply covered up. The same argument the framework uses for pinning the `process.env.NODE_ENV` form in `packages/server/tests`: nothing at runtime can tell the two apart.

The second assertion pins the comment explaining *why* the portal is there, since that comment is the only thing stopping someone unwinding it as an unnecessary indirection.

## What I could not verify

I could not reproduce the overlap in my browser tooling: the pane it drives reports `visibilityState: hidden` and does not honour scrolling, so I cannot park a code block behind the dialog. The diagnosis rests on the reported screenshot plus the structural check above, not on a reproduction.
