### PR TITLE
build: take the fixed fast-uri and qs into the lockfile

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1354,7 +1354,7 @@
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -1670,7 +1670,7 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+    "qs": ["qs@6.16.0", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 


### PR DESCRIPTION
Six advisories went active upstream and turned CI red on `main` (`b15c3296`), not on anything in flight:

| severity | package | fixed in |
| --- | --- | --- |
| high ×4 | `fast-uri >=3.0.0 <3.1.6` — host confusion, SSRF via IPv6 normalization, SSRF via repeated percent-decoding, host confusion via percent-encoded scheme | 3.1.6 |
| moderate ×2 | `qs <6.16.0` — array-limit bypass via bracket-key comma parsing, DoS via attacker-controlled `isBuffer` | 6.16.0 |

Both arrive through `@modelcontextprotocol/sdk`: `fast-uri` under `ajv`, `qs` under express's `body-parser`.

## Only two resolutions move

The existing overrides already admit the fixed versions — `^3.1.3` covers 3.1.7, `^6.15.2` covers 6.16.0 — so no declared range needed to change. Worth stating because the reflex here is to bump the override, and an override that crossed a major would be the wrong tool: Bun **replaces** a dependency's declared range rather than intersecting with it, so `fast-uri: ^4` would drag `ajv` (which asks for `^3.0.1`) across a major it never agreed to.

## Why grafted rather than re-resolved

Deleting the two entries and reinstalling was the first attempt. It rewrote 185 lines: bun refreshes the workspace version entries — `main`'s lockfile still records `web@0.1.29` and `@guren/cli@2.13.0` against package.json files that now say `0.1.30` and `2.14.0` — and picks up newer AWS CDK and SDK releases while it is there. A security fix should not carry that, so the two lines are grafted in as bun itself produced them, and `bun install --frozen-lockfile` accepts the result.

The stale workspace entries are worth a separate look; they do not break `--frozen-lockfile`, which is why CI has not noticed.

## Verified

`bun run audit:deps` passes with the one pre-existing esbuild ignore intact and no stale entries.

Past the audit, because a green top-level command does not prove the upgraded copy is on the path that uses it:

- `qs@6.16.0` parses nested and array syntax — `a[b]=1&a[c]=2&d[]=x&d[]=y` → `{"a":{"b":"1","c":"2"},"d":["x","y"]}`
- `ajv` compiles a schema carrying `$id`, which is what reaches `fast-uri`, and validates both ways
- `fast-uri@3.1.7` parses an absolute URI

Tests: `@guren/server` 2,785 pass, `@guren/plugin-mcp` 116 pass, `web` 210 + 25 pass.
