### PR TITLE
fix(examples): let the IME keep the keys the docs search was taking

### DIFF
--- a/web/resources/js/components/DocSearch.tsx
+++ b/web/resources/js/components/DocSearch.tsx
@@ -69,6 +69,22 @@ function statusMessage(kind: Display['kind'], copy: (typeof COPY)[DocSearchLocal
   }
 }
 
+/**
+ * Whether this key belongs to the IME rather than to the dialog.
+ *
+ * Converting 「にんしょう」to 「認証」ends with Enter, and that Enter reaches
+ * keydown like any other — so without this the dialog took it as "open the
+ * selected result" and navigated away mid-word. The same applies to the arrow
+ * keys, which move through conversion candidates, and to Escape, which
+ * cancels the conversion.
+ *
+ * `keyCode === 229` is the older signal for the same thing, kept because it
+ * costs one comparison and covers browsers that do not set `isComposing`.
+ */
+function isImeKey(event: React.KeyboardEvent): boolean {
+  return event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229
+}
+
 /** Everything inside the dialog that Tab can reach, in document order. */
 const FOCUSABLE = 'a[href], button, input, select, [tabindex]:not([tabindex="-1"])'
 
@@ -98,6 +114,9 @@ export function DocSearch({ locale, className = '' }: DocSearchProps) {
   const [searchLocale, setSearchLocale] = useState<DocSearchLocale>(locale)
   const [display, setDisplay] = useState<Display>({ kind: 'idle' })
   const [selected, setSelected] = useState(0)
+  // True between compositionstart and compositionend — while an IME is
+  // holding a reading the reader has not converted yet.
+  const [composing, setComposing] = useState(false)
   // Resolved after mount: the server has no idea which keyboard this is, and
   // rendering a guess would mismatch during hydration.
   const [isApple, setIsApple] = useState(false)
@@ -166,7 +185,10 @@ export function DocSearch({ locale, className = '' }: DocSearchProps) {
   }, [open])
 
   useEffect(() => {
-    if (!open) {
+    // Nothing is searched while an IME is mid-word: 「認証」is typed as
+    // 「にんしょう」first, and searching that spends a request to tell the
+    // reader there are no matches for something they are still writing.
+    if (!open || composing) {
       return
     }
 
@@ -190,7 +212,7 @@ export function DocSearch({ locale, className = '' }: DocSearchProps) {
         setDisplay(outcome.hits.length > 0 ? { kind: 'results', hits: outcome.hits } : { kind: 'empty' })
       }
     })
-  }, [open, query, searchLocale, search])
+  }, [open, composing, query, searchLocale, search])
 
   useEffect(() => () => search.cancel(), [search])
 
@@ -206,6 +228,9 @@ export function DocSearch({ locale, className = '' }: DocSearchProps) {
    * close button and the locale select too.
    */
   const onDialogKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (isImeKey(event)) {
+      return
+    }
     if (event.key === 'Escape') {
       event.preventDefault()
       close()
@@ -224,7 +249,7 @@ export function DocSearch({ locale, className = '' }: DocSearchProps) {
   }
 
   const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (hits.length === 0) {
+    if (isImeKey(event) || hits.length === 0) {
       return
     }
     if (event.key === 'ArrowDown') {
@@ -287,6 +312,14 @@ export function DocSearch({ locale, className = '' }: DocSearchProps) {
                 value={query}
                 maxLength={MAX_QUERY_LENGTH}
                 onChange={(event) => setQuery(event.target.value)}
+                onCompositionStart={() => setComposing(true)}
+                onCompositionEnd={(event) => {
+                  // The committed text has to be read off the element here:
+                  // in some browsers this fires after the change event that
+                  // carried it, in others before.
+                  setComposing(false)
+                  setQuery(event.currentTarget.value)
+                }}
                 onKeyDown={onInputKeyDown}
                 placeholder={copy.placeholder}
                 aria-label={copy.placeholder}

--- a/web/tests/components/DocSearch.test.ts
+++ b/web/tests/components/DocSearch.test.ts
@@ -28,6 +28,27 @@ describe('DocSearch', () => {
     expect(source).toContain('document.body,')
   })
 
+  it('lets the IME keep the keys it needs', () => {
+    // Converting 「にんしょう」to 「認証」ends with Enter, and that Enter
+    // arrives at keydown like any other — the dialog took it as "open the
+    // selected result" and navigated away mid-word. The arrow keys move
+    // through conversion candidates and Escape cancels the conversion, so
+    // both handlers have to defer, not just the one that reads Enter.
+    expect(source).toMatch(/function isImeKey/u)
+    expect(source).toContain('event.nativeEvent.isComposing')
+    expect(source).toMatch(/const onInputKeyDown[\s\S]{0,120}isImeKey\(event\)/u)
+    expect(source).toMatch(/const onDialogKeyDown[\s\S]{0,120}isImeKey\(event\)/u)
+  })
+
+  it('does not search a reading the reader has not converted yet', () => {
+    // Otherwise 「にんしょう」costs a request to report no matches for
+    // something still being written.
+    // The `={` matters: a substring check passes against `onCompositionEndX`.
+    expect(source).toContain('onCompositionStart={')
+    expect(source).toContain('onCompositionEnd={')
+    expect(source).toMatch(/if \(!open \|\| composing\)/u)
+  })
+
   it('keeps the sidebar reason next to the portal', () => {
     // The comment is the only thing that stops someone unwinding this as an
     // unnecessary indirection.


### PR DESCRIPTION
Reported: pressing Enter to commit a Japanese conversion opens a search result instead of finishing the word.

## What happens

「認証」is typed as 「にんしょう」and converted with Enter. That Enter reaches `keydown` like any other, so the dialog read it as "open the selected result" and navigated away mid-word.

The arrow keys move through conversion candidates and Escape cancels the conversion, so the same applies to them — which is why both handlers defer while a composition is running, not only the one that reads Enter.

`event.nativeEvent.isComposing` is the signal, with `keyCode === 229` alongside it for browsers that do not set the first.

## The same gap, quieter

The search also fired on the unconverted reading: every keystroke of 「にんしょう」spent a request to tell the reader there are no matches for something they were still writing, and flashed 「一致するものがありません」under their hands.

Nothing is searched between `compositionstart` and `compositionend` now. The committed text is read off the element inside the `compositionend` handler, because browsers disagree about whether that event arrives before or after the `change` that carries the same text.

## Verified

On a production build against the real 1,992-row index:

| | |
| --- | --- |
| Enter carrying `isComposing` | dialog stays open, still on `/docs/ja/guides/controllers` |
| ordinary Enter | opens `/docs/ja/guides/authentication#認証ガイド`, dialog closes |
| Escape carrying `isComposing` | dialog stays open |
| composing 「にんしょう」 | **0** requests, prompt unchanged |
| committing 「認証」 | exactly **1** request, `q=認証`, 20 results |

## Gate

Extended the source-level test added with the portal fix, for the same reason: `web` has no DOM test harness, and this failure is invisible to every other gate. Five mutations were tried and all five fail the test — including one that renamed `onCompositionEnd` to `onCompositionEndX`, which the first version of the assertion passed because it was a substring check.
