### PR TITLE
fix(server): resolve deferred providers through Container.make()

### DIFF
--- a/.changeset/deferred-provider-make.md
+++ b/.changeset/deferred-provider-make.md
@@ -1,0 +1,22 @@
+---
+'@guren/server': patch
+---
+
+Resolve deferred providers through `Container.make()`.
+
+`make()` handed the key to the deferred-provider loader and then read a flag
+set from the loader's `.then()`, which never runs before the surrounding
+synchronous code finishes — so the flag was always false, the freshly bound
+service was never re-read, and every deferred service failed with
+`Service "..." not found in container` even though its provider had just
+registered it. `ProviderManager.loadDeferredProvider()` worked, but the path
+the plugin guide documents (`deferred: true` + `provides`, loaded on first
+resolution) did not.
+
+The loader now runs the provider's `register()` synchronously and `make()`
+re-reads the bindings after it returns. A synchronous `register()` failure
+surfaces from `make()` instead of becoming an unhandled rejection, and a
+deferred `register()` that binds asynchronously gets an error saying so —
+`make()` cannot await it. `boot()` may still be async; it runs after that
+first resolution, and a later `loadDeferredProvider()` for the same service
+resolves once that boot has finished.

--- a/docs/en/guides/plugins.md
+++ b/docs/en/guides/plugins.md
@@ -87,7 +87,7 @@ export const analyticsPlugin = definePlugin<AnalyticsConfig>({
 })
 ```
 
-Plugins that are expensive to initialize can pass `deferred: true` together with `provides: ['analytics']` so the provider only loads when one of its services is first resolved.
+Plugins that are expensive to initialize can pass `deferred: true` together with `provides: ['analytics']` so the provider only loads when one of its services is first resolved. Because `container.make()` is synchronous, a deferred plugin's `register()` must bind its services synchronously (`make()` throws if it does not); `boot()` may still be async and runs right after that first resolution.
 
 If you need lifecycle behavior beyond what `definePlugin()` covers, you can still export a `ServiceProvider` subclass directly — the class-based contract is unchanged. Avoid storing configuration on a static class property, though: statics are shared, so registering the plugin twice would silently overwrite the first configuration.
 

--- a/docs/ja/guides/plugins.md
+++ b/docs/ja/guides/plugins.md
@@ -87,7 +87,7 @@ export const analyticsPlugin = definePlugin<AnalyticsConfig>({
 })
 ```
 
-初期化コストの高いプラグインは`deferred: true`と`provides: ['analytics']`を併せて指定すると、提供するサービスが最初に解決されるまでプロバイダーの読み込みを遅延できます。
+初期化コストの高いプラグインは`deferred: true`と`provides: ['analytics']`を併せて指定すると、提供するサービスが最初に解決されるまでプロバイダーの読み込みを遅延できます。`container.make()`は同期なので、deferredプラグインの`register()`はサービスを同期的にバインドする必要があります（そうでない場合`make()`は例外を投げます）。`boot()`は非同期でもよく、最初の解決の直後に実行されます。
 
 `definePlugin()`でカバーできないライフサイクル制御が必要な場合は、従来通り`ServiceProvider`のサブクラスを直接エクスポートすることもできます。ただし設定をstaticプロパティに保存するのは避けてください。staticは共有されるため、プラグインを2回登録すると最初の設定が上書きされます。
 

--- a/packages/server/src/container/Container.ts
+++ b/packages/server/src/container/Container.ts
@@ -34,8 +34,16 @@ export class Container {
   protected scopedInstances: Map<string, unknown>[] = []
   protected fakes: Map<string, unknown> = new Map()
 
-  /** @internal Used by ProviderManager to resolve deferred providers on demand */
-  deferredProviderLoader: ((service: string) => Promise<void>) | null = null
+  /**
+   * @internal Installed by ProviderManager once every eager provider has booted.
+   *
+   * Called from `make()` for a key with no binding. The loader must run the
+   * deferred provider's `register()` *synchronously* before it returns, so the
+   * bindings it adds are visible to the same `make()` call; `boot()` may be
+   * asynchronous and is what the returned promise settles on. `undefined`
+   * means no deferred provider claims the service.
+   */
+  deferredProviderLoader: ((service: string) => Promise<void> | undefined) | null = null
 
   /**
    * Bind a service to the container.
@@ -103,17 +111,21 @@ export class Container {
       return this.fakes.get(resolvedKey)
     }
 
-    // Check binding exists — try deferred providers if not found
+    // Check binding exists — try deferred providers if not found.
+    // make() is synchronous, so it can only see what the provider's register()
+    // bound before the loader returned; the loader contract guarantees that
+    // for a synchronous register(). An async register() binds too late for
+    // this call, which is reported rather than left as a bare "not found".
     let binding = this.bindings.get(resolvedKey)
     if (!binding && this.deferredProviderLoader) {
-      // Synchronously trigger deferred provider loading.
-      // The loader registers the provider which adds bindings to this container.
-      // We use a micro-optimization: call the loader and let it resolve synchronously
-      // if the provider's register() is synchronous (which is the common case).
-      let resolved = false
-      this.deferredProviderLoader(resolvedKey).then(() => { resolved = true })
-      if (resolved) {
-        binding = this.bindings.get(resolvedKey)
+      const loading = this.deferredProviderLoader(resolvedKey)
+      binding = this.bindings.get(resolvedKey)
+      if (loading && !binding) {
+        throw new Error(
+          `Deferred provider for "${key}" did not bind "${resolvedKey}" synchronously in register(). ` +
+          'Container.make() cannot await an async register(); bind the service synchronously, ' +
+          'or await ProviderManager.loadDeferredProvider() before resolving it.',
+        )
       }
     }
     if (!binding) {

--- a/packages/server/src/container/ServiceProvider.ts
+++ b/packages/server/src/container/ServiceProvider.ts
@@ -77,6 +77,8 @@ export class ProviderManager {
   protected registered: Set<ServiceProvider> = new Set()
   protected booted: Set<ServiceProvider> = new Set()
   protected deferredProviders: Map<string, ServiceProvider> = new Map()
+  /** Per service, the boot of an already-activated deferred provider, so a later loadDeferredProvider() awaits that boot */
+  private deferredActivations: Map<string, Promise<void>> = new Map()
   private allBooted = false
 
   constructor(protected container: Container) {}
@@ -157,32 +159,48 @@ export class ProviderManager {
     // Wire deferred provider resolution into Container.make()
     if (this.deferredProviders.size > 0) {
       this.container.deferredProviderLoader = (service: string) =>
-        this.loadDeferredProvider(service)
+        this.activateDeferredProvider(service)
     }
   }
 
   /**
-   * Load a deferred provider for a service.
+   * Load a deferred provider for a service: register it, boot it, and drop
+   * its services from the deferred set. Resolves once boot() has finished,
+   * also when the provider was already activated by Container.make().
    */
   async loadDeferredProvider(service: string): Promise<void> {
+    await (this.activateDeferredProvider(service) ?? this.deferredActivations.get(service))
+  }
+
+  /**
+   * The synchronous half of deferred loading, which is what lets a
+   * synchronous `Container.make()` resolve a deferred service: `register()`
+   * runs before this returns, so its bindings are in the container by the
+   * time the caller reads them, and a synchronous throw reaches the caller.
+   * `boot()` follows on the returned promise, which make() does not await: a
+   * boot failure surfaces as an unhandled rejection rather than silently.
+   * Services are unclaimed from the deferred set up front so a re-entrant
+   * make() for a sibling service does not register the provider twice.
+   */
+  private activateDeferredProvider(service: string): Promise<void> | undefined {
     const provider = this.deferredProviders.get(service)
-    if (!provider) return
+    if (!provider) return undefined
 
-    if (!this.registered.has(provider)) {
-      await provider.register()
-      this.registered.add(provider)
-      this.providers.push(provider)
-    }
-
-    if (!this.booted.has(provider)) {
-      await provider.boot?.()
-      this.booted.add(provider)
-    }
-
-    // Remove from deferred
+    const registering = provider.register()
+    this.registered.add(provider)
+    this.providers.push(provider)
     for (const providedService of provider.provides()) {
       this.deferredProviders.delete(providedService)
     }
+
+    const activation = Promise.resolve(registering).then(async () => {
+      await provider.boot?.()
+      this.booted.add(provider)
+    })
+    for (const providedService of provider.provides()) {
+      this.deferredActivations.set(providedService, activation)
+    }
+    return activation
   }
 
   /**

--- a/packages/server/tests/container/container.test.ts
+++ b/packages/server/tests/container/container.test.ts
@@ -486,6 +486,133 @@ describe('ProviderManager', () => {
     expect(manager.isDeferredService('deferred.service')).toBe(false)
   })
 
+  describe('deferred providers through Container.make()', () => {
+    it('should resolve a deferred service on first make() after boot', async () => {
+      let registered = 0
+      class LazyProvider extends ServiceProvider {
+        static deferred = true
+        static provides = ['lazy.service']
+
+        register(): void {
+          registered++
+          this.container.singleton('lazy.service', () => ({ ready: true }))
+        }
+      }
+
+      manager.register(LazyProvider)
+      await manager.registerAll()
+      await manager.bootAll()
+
+      expect(registered).toBe(0)
+      expect(container.make<{ ready: boolean }>('lazy.service')).toEqual({ ready: true })
+      expect(registered).toBe(1)
+      expect(manager.isDeferredService('lazy.service')).toBe(false)
+    })
+
+    it('should register the provider once when make() is called repeatedly', async () => {
+      let registered = 0
+      class LazyProvider extends ServiceProvider {
+        static deferred = true
+        static provides = ['lazy.a', 'lazy.b']
+
+        register(): void {
+          registered++
+          this.container.instance('lazy.a', 'a')
+          this.container.instance('lazy.b', 'b')
+        }
+      }
+
+      manager.register(LazyProvider)
+      await manager.bootAll()
+
+      expect(container.make<string>('lazy.a')).toBe('a')
+      expect(container.make<string>('lazy.b')).toBe('b')
+      expect(container.make<string>('lazy.a')).toBe('a')
+      expect(registered).toBe(1)
+      expect(manager.getProviders()).toHaveLength(1)
+    })
+
+    it('should boot the provider after make() and settle loadDeferredProvider() on that boot', async () => {
+      const order: string[] = []
+      class LazyProvider extends ServiceProvider {
+        static deferred = true
+        static provides = ['lazy.service']
+
+        register(): void {
+          order.push('register')
+          this.container.instance('lazy.service', 'value')
+        }
+
+        async boot(): Promise<void> {
+          await Promise.resolve()
+          order.push('boot')
+        }
+      }
+
+      manager.register(LazyProvider)
+      await manager.bootAll()
+
+      expect(container.make<string>('lazy.service')).toBe('value')
+      expect(order).toEqual(['register'])
+
+      await manager.loadDeferredProvider('lazy.service')
+      expect(order).toEqual(['register', 'boot'])
+    })
+
+    it('should surface a synchronous register() failure from make()', async () => {
+      class BrokenProvider extends ServiceProvider {
+        static deferred = true
+        static provides = ['broken.service']
+
+        register(): void {
+          throw new Error('register exploded')
+        }
+      }
+
+      manager.register(BrokenProvider)
+      await manager.bootAll()
+
+      expect(() => container.make('broken.service')).toThrow('register exploded')
+    })
+
+    it('should explain when a deferred register() binds asynchronously', async () => {
+      class AsyncProvider extends ServiceProvider {
+        static deferred = true
+        static provides = ['async.service']
+
+        async register(): Promise<void> {
+          await Promise.resolve()
+          this.container.instance('async.service', 'late')
+        }
+      }
+
+      manager.register(AsyncProvider)
+      await manager.bootAll()
+
+      expect(() => container.make('async.service')).toThrow(
+        /did not bind "async.service" synchronously/,
+      )
+    })
+
+    it('should still throw not-found for a service no deferred provider claims', async () => {
+      class LazyProvider extends ServiceProvider {
+        static deferred = true
+        static provides = ['lazy.service']
+
+        register(): void {
+          this.container.instance('lazy.service', 'value')
+        }
+      }
+
+      manager.register(LazyProvider)
+      await manager.bootAll()
+
+      expect(() => container.make('other.service')).toThrow(
+        'Service "other.service" not found in container',
+      )
+    })
+  })
+
   it('should only register providers once', async () => {
     let registerCount = 0
 


### PR DESCRIPTION
## Summary

`Container.make()` never resolved a deferred provider. It handed the key to the deferred-provider loader and then read a flag set from the loader's `.then()`, which cannot run before the surrounding synchronous code finishes, so the flag was always `false`, the freshly bound service was never re-read, and every deferred service failed with `Service "..." not found in container` even though its provider had just registered it. `ProviderManager.loadDeferredProvider()` worked, but the path the plugin guide documents (`deferred: true` + `provides`, loaded on first resolution) did not.

## What changed

- **`Container.make()`** re-reads the bindings after calling the loader instead of checking a flag that never flips. If the loader found a provider but no binding appeared, it throws an error explaining that a deferred `register()` must bind synchronously (`make()` cannot await an async `register()`), with the workaround of awaiting `loadDeferredProvider()` first. The comment now describes the loader contract rather than a "synchronous promise" that does not exist.
- **`ProviderManager`** splits the synchronous half of deferred loading into `activateDeferredProvider()`, which the container's loader now calls. `register()` runs before it returns, so a synchronous throw reaches the caller of `make()` instead of becoming an unhandled rejection; the provider's services are unclaimed from the deferred set up front so a re-entrant `make()` for a sibling service does not register the provider twice. `boot()` follows on the returned promise, and a later `loadDeferredProvider()` for the same service awaits that boot rather than resolving early.
- **Tests** (`packages/server/tests/container/container.test.ts`): six new cases covering first-`make()` resolution, no double registration, register/boot ordering, synchronous `register()` failures surfacing from `make()`, the async-`register()` error, and unclaimed services still reporting not-found. Five of them fail on `main`.
- **Docs**: the plugin guide (en/ja) states the constraint: `register()` must bind synchronously; `boot()` may be async.
- **Changeset**: `@guren/server` patch.

## Notes for review

- `make()` stays synchronous; that is the public contract and what the docs promise, so an async resolution path was not introduced.
- A `boot()` failure triggered via `make()` surfaces as an unhandled rejection, as before. It is not swallowed.
- An async `register()` on a deferred provider was never resolvable through `make()`; the difference is that it now says so instead of reporting a bare not-found.

## Verification

- `bun test packages/server/tests/container` (46 pass)
- `bun run test:bun server` (2791 pass)
- `bun run typecheck` (exit 0)
