### PR TITLE
test: await every rejects assertion so a missing rejection can fail

### DIFF
--- a/packages/cli/tests/entity-context.test.ts
+++ b/packages/cli/tests/entity-context.test.ts
@@ -351,10 +351,10 @@ verified:
   })
 
   it('throws EntityResolutionError listing available models for unknown entities', async () => {
-    expect(generateEntityContext('Ghost', { cwd: workspace.dir })).rejects.toThrow(
+    await expect(generateEntityContext('Ghost', { cwd: workspace.dir })).rejects.toThrow(
       EntityResolutionError,
     )
-    expect(generateEntityContext('Ghost', { cwd: workspace.dir })).rejects.toThrow(
+    await expect(generateEntityContext('Ghost', { cwd: workspace.dir })).rejects.toThrow(
       'Available models: Post, User',
     )
   })
@@ -447,7 +447,7 @@ describe('entity context (duplicated entity across locations)', () => {
   })
 
   it('requires --module when the same model exists in multiple locations', async () => {
-    expect(generateEntityContext('Post', { cwd: workspace.dir })).rejects.toThrow(
+    await expect(generateEntityContext('Post', { cwd: workspace.dir })).rejects.toThrow(
       'multiple locations: app, crm',
     )
   })

--- a/packages/cli/tests/make-adr.test.ts
+++ b/packages/cli/tests/make-adr.test.ts
@@ -53,10 +53,10 @@ describe('makeAdr', () => {
   it('rejects --by actors that could break out of the frontmatter', async () => {
     const workspace = await createTempWorkspace('guren-cli-make-adr-actor-')
     try {
-      expect(makeAdr('Actor injection', { by: 'x }\nstatus: stable' })).rejects.toThrow(
+      await expect(makeAdr('Actor injection', { by: 'x }\nstatus: stable' })).rejects.toThrow(
         'Invalid actor',
       )
-      expect(makeAdr('Quote injection', { by: 'x", at: y' })).rejects.toThrow('Invalid actor')
+      await expect(makeAdr('Quote injection', { by: 'x", at: y' })).rejects.toThrow('Invalid actor')
     } finally {
       await workspace.cleanup()
     }
@@ -266,10 +266,10 @@ describe('makeAdr', () => {
   it('rejects --entity values that are not plain identifiers', async () => {
     const workspace = await createTempWorkspace('guren-cli-make-adr-inject-')
     try {
-      expect(
+      await expect(
         makeAdr('Injection attempt', { entity: 'Ghost]\nstatus: stable\nentities: [Post' }),
       ).rejects.toThrow('Invalid entity name')
-      expect(makeAdr('Injection attempt', { entity: 'Post # comment' })).rejects.toThrow(
+      await expect(makeAdr('Injection attempt', { entity: 'Post # comment' })).rejects.toThrow(
         'Invalid entity name',
       )
     } finally {
@@ -335,7 +335,7 @@ describe('makeAdr', () => {
         'utf8',
       )
 
-      expect(makeAdr('Ambiguous decision', { entity: 'Post' })).rejects.toThrow(
+      await expect(makeAdr('Ambiguous decision', { entity: 'Post' })).rejects.toThrow(
         'multiple locations: billing, sales',
       )
     } finally {

--- a/packages/cli/tests/make-migration.test.ts
+++ b/packages/cli/tests/make-migration.test.ts
@@ -246,7 +246,7 @@ describe('makeMigration', () => {
   it('refuses, naming the dialect, when no config and no flag declare one', async () => {
     const workspace = await createTempWorkspace('guren-cli-make-migration-no-dialect-')
     try {
-      expect(makeMigration()).rejects.toThrow(/No drizzle config found.*dialect.*--dialect/s)
+      await expect(makeMigration()).rejects.toThrow(/No drizzle config found.*dialect.*--dialect/s)
       // Refused before spawning: drizzle-kit's own `dialect: undefined` names
       // flags the user never typed.
       expect(spawnCalls.length).toBe(0)
@@ -260,7 +260,7 @@ describe('makeMigration', () => {
     try {
       await writeFile(join(workspace.dir, 'drizzle.config.ts'), "export default { out: './db/migrations' }", 'utf8')
 
-      expect(makeMigration({ out: './other' })).rejects.toThrow(
+      await expect(makeMigration({ out: './other' })).rejects.toThrow(
         /drizzle\.config\.ts declares no `dialect`/,
       )
       expect(spawnCalls.length).toBe(0)
@@ -280,7 +280,7 @@ describe('makeMigration', () => {
         'utf8',
       )
 
-      expect(makeMigration({ out: './other' })).rejects.toThrow(/Could not load drizzle\.config\.ts/)
+      await expect(makeMigration({ out: './other' })).rejects.toThrow(/Could not load drizzle\.config\.ts/)
       expect(spawnCalls.length).toBe(0)
     } finally {
       await workspace.cleanup()
@@ -299,7 +299,7 @@ describe('makeMigration', () => {
         'utf8',
       )
 
-      expect(makeMigration({ out: './other' })).rejects.toThrow(/declares `schema` as a list/)
+      await expect(makeMigration({ out: './other' })).rejects.toThrow(/declares `schema` as a list/)
       expect(spawnCalls.length).toBe(0)
     } finally {
       await workspace.cleanup()

--- a/packages/orm/tests/model-enhancements.test.ts
+++ b/packages/orm/tests/model-enhancements.test.ts
@@ -561,7 +561,7 @@ describe('global scopes apply on every query entry point', () => {
   it('refuses when a condition would overwrite the scope on the same field', async () => {
     const User = tenantScopedUser()
 
-    expect(User.where('tenantId', 2).get()).rejects.toThrow('return unfiltered rows')
+    await expect(User.where('tenantId', 2).get()).rejects.toThrow('return unfiltered rows')
   })
 
   it('still collapses a condition that repeats the scope value', async () => {
@@ -588,8 +588,8 @@ describe('global scopes apply on every query entry point', () => {
   it('refuses rather than dropping conditions a basic adapter cannot express', async () => {
     const User = tenantScopedUser()
 
-    expect(User.whereNotIn('id', [99]).get()).rejects.toThrow('return unfiltered rows')
-    expect(User.whereNotNull('name').get()).rejects.toThrow('return unfiltered rows')
+    await expect(User.whereNotIn('id', [99]).get()).rejects.toThrow('return unfiltered rows')
+    await expect(User.whereNotNull('name').get()).rejects.toThrow('return unfiltered rows')
   })
 
   it('applies the scope to select()', async () => {

--- a/packages/orm/tests/soft-deletes.test.ts
+++ b/packages/orm/tests/soft-deletes.test.ts
@@ -301,8 +301,8 @@ describe('SoftDeletes: models with no other scopes', () => {
     }
     Post.useAdapter({ ...createAdapter([]), update: undefined, delete: undefined } as unknown as ORMAdapter)
 
-    expect(Post.delete({ id: 1 })).rejects.toThrow('needed for soft delete')
-    expect(Post.restore({ id: 1 })).rejects.toThrow('needed for restore')
-    expect(Post.forceDelete({ id: 1 })).rejects.toThrow('does not support delete operations')
+    await expect(Post.delete({ id: 1 })).rejects.toThrow('needed for soft delete')
+    await expect(Post.restore({ id: 1 })).rejects.toThrow('needed for restore')
+    await expect(Post.forceDelete({ id: 1 })).rejects.toThrow('does not support delete operations')
   })
 })

--- a/packages/server/tests/auth/session-guard.test.ts
+++ b/packages/server/tests/auth/session-guard.test.ts
@@ -198,7 +198,7 @@ describe('SessionGuard', () => {
 
     test('should throw when session is undefined', async () => {
       const guard = createGuard({ session: undefined })
-      expect(guard.login(user)).rejects.toThrow('session middleware is required')
+      await expect(guard.login(user)).rejects.toThrow('session middleware is required')
     })
 
     test('should regenerate the session ID to prevent session fixation', async () => {

--- a/packages/server/tests/auth/token-guard.test.ts
+++ b/packages/server/tests/auth/token-guard.test.ts
@@ -186,9 +186,9 @@ describe('TokenGuard', () => {
   test('should throw for credential-based flows', async () => {
     const guard = new TokenGuard({ store: new MemoryApiTokenStore(), ctx: fakeContext() })
 
-    expect(guard.login()).rejects.toThrow('does not support login')
-    expect(guard.attempt({})).rejects.toThrow('does not support attempt')
-    expect(guard.validate({})).rejects.toThrow('does not support validate')
+    await expect(guard.login()).rejects.toThrow('does not support login')
+    await expect(guard.attempt({})).rejects.toThrow('does not support attempt')
+    await expect(guard.validate({})).rejects.toThrow('does not support validate')
   })
 
   test('session should be undefined', async () => {

--- a/packages/server/tests/queue/drivers/SqsDriver.test.ts
+++ b/packages/server/tests/queue/drivers/SqsDriver.test.ts
@@ -145,7 +145,7 @@ describe('SqsDriver', () => {
   })
 
   test('should throw when retrying non-existent failed job', async () => {
-    expect(driver.retryFailedJob('nonexistent')).rejects.toThrow('Failed job not found')
+    await expect(driver.retryFailedJob('nonexistent')).rejects.toThrow('Failed job not found')
   })
 
   test('should clear all state', async () => {


### PR DESCRIPTION
## Summary

Twenty-two `expect(promise).rejects.toThrow(...)` assertions across the orm, cli, and server test suites ran without `await`. The matcher returns a promise, so the assertion only runs once that promise settles; written as a bare statement, the test callback returned first, and a promise that resolved (or rejected with a different message) could not fail its test.

This adds the missing `await` to every one of them. Every enclosing callback was already `async`, so no other change was needed.

## Findings

Awaited, all twenty-two still pass. The behaviour they guard is intact today; the change only makes a future regression visible.

Files touched:

- `packages/orm/tests/model-enhancements.test.ts`, `packages/orm/tests/soft-deletes.test.ts`
- `packages/cli/tests/make-migration.test.ts`, `packages/cli/tests/make-adr.test.ts`, `packages/cli/tests/entity-context.test.ts`
- `packages/server/tests/auth/token-guard.test.ts`, `packages/server/tests/auth/session-guard.test.ts`, `packages/server/tests/queue/drivers/SqsDriver.test.ts`

## Verification

- `bun test` on each of the eight files: all green.
- Mutation check: temporarily changing one expected message (`soft-deletes.test.ts`, the `restore` case) turned the test red, confirming the assertions now actually execute.

## Out of scope

Eight `expect(...).resolves.*` assertions in `packages/server/tests` (seeder, password-reset, i18n) are floating in the same way but sit inside synchronous callbacks. Left for the lint-infrastructure work being considered separately.