### PR TITLE
fix(inertia): make useChannel(name) subscribe to its channel

### DIFF
--- a/.changeset/use-channel-subscribes-its-channel.md
+++ b/.changeset/use-channel-subscribes-its-channel.md
@@ -1,0 +1,19 @@
+---
+'@guren/inertia-client': patch
+---
+
+Make `useChannel(name)` actually subscribe to `name`.
+
+The hook opened an EventSource on the bare SSE endpoint and attached
+listeners by event name, but never told the server which channel it wanted.
+`sseMiddleware()` subscribes only what `?channels=` names when the stream
+opens, so `useChannel('orders')` received `connected` and `ping` and nothing
+else — the channel argument was a type carrier and the documented
+`feed.on('NewPost', …)` never fired.
+
+Each subscription now opens `endpoint?channels=<name>` (`&channels=` when the
+endpoint already carries a query string, the name URL-encoded). The server
+authorizes the channel against the user its SSE route resolves, so private
+and presence channels work through the same call when that route is given
+`getUser`. `channelStreamUrl()` is exported for anyone building the URL by
+hand.

--- a/docs/en/guides/broadcasting.md
+++ b/docs/en/guides/broadcasting.md
@@ -219,6 +219,8 @@ const off = feed.on('NewPost', (payload) => {
 
 This gives you typed channel/event names and inferred payload shapes in the frontend.
 
+Each `useChannel(name)` call opens its own `EventSource` on `endpoint?channels=name` (default endpoint `/broadcasting/events`; an endpoint that already has a query string gets `&channels=`). The channel argument is what the server subscribes, not just a type — the stream is authorized and subscribed up front exactly like the `?channels=` example below, so a private or presence channel works through the same call when the SSE route resolves the user with `getUser`. A channel the server refuses is left out of the `connected` event's `channels` list and delivers nothing. One stream per channel is deliberate: events are dispatched by event name, so keeping each channel on its own stream is what lets `feed.on('NewPost', …)` mean "`NewPost` on `announcements`". `channelStreamUrl(endpoint, channel)` is exported for building that URL by hand.
+
 ### End-to-end typed realtime flow
 
 Use the generated `ChannelEvents` on the server too, so emit-side payloads are checked at compile time.

--- a/docs/ja/guides/broadcasting.md
+++ b/docs/ja/guides/broadcasting.md
@@ -209,6 +209,8 @@ const off = feed.on('NewPost', (payload) => {
 
 これにより、フロント側で channel/event 名だけでなく payload 形状も型安全に扱えます。
 
+`useChannel(name)` は呼び出しごとに `endpoint?channels=name` へ専用の `EventSource` を開きます（デフォルトの endpoint は `/broadcasting/events`。endpoint に既にクエリ文字列がある場合は `&channels=` で連結します）。チャンネル引数は型のためだけのものではなく、サーバーが実際に購読するチャンネルです。後述の `?channels=` の例と同じくストリーム開始時に認可・購読されるため、SSE ルートが `getUser` でユーザーを解決していればプライベート・プレゼンスチャンネルも同じ呼び出しで動作します。サーバーが拒否したチャンネルは `connected` イベントの `channels` 一覧に含まれず、何も届きません。チャンネルごとに 1 ストリームなのは意図的です。イベントはイベント名で振り分けられるため、チャンネルをストリーム単位で分けることで `feed.on('NewPost', …)` が「`announcements` の `NewPost`」を意味できます。URL を自前で組み立てる場合は `channelStreamUrl(endpoint, channel)` を使えます。
+
 ### E2E 型安全リアルタイム
 
 生成された `ChannelEvents` をサーバー側 emit にも適用すると、送信時 payload もコンパイル時に検証できます。

--- a/packages/inertia-client/src/channel.ts
+++ b/packages/inertia-client/src/channel.ts
@@ -10,9 +10,27 @@ type EventPayloadFor<
 > = TChannelEvents[TChannel][TEvent]
 
 export interface UseChannelOptions {
+  /**
+   * The SSE route mounted with `broadcast.sseMiddleware()`. The channel a
+   * subscription asks for is appended as `?channels=<name>`; an endpoint that
+   * already carries a query string gets `&channels=`.
+   */
   endpoint?: string
   withCredentials?: boolean
   eventSourceFactory?: (url: string, init: EventSourceInit) => EventSource
+}
+
+/**
+ * The URL a subscription opens: the SSE endpoint plus the channel it wants.
+ *
+ * The server subscribes nothing on its own — `sseMiddleware()` reads
+ * `?channels=` when the stream opens and delivers only what that names. A
+ * stream opened without it receives `connected` and `ping` and nothing else,
+ * which is exactly what `useChannel('orders')` used to open.
+ */
+export function channelStreamUrl(endpoint: string, channel: string): string {
+  const separator = endpoint.includes('?') ? '&' : '?'
+  return `${endpoint}${separator}channels=${encodeURIComponent(channel)}`
 }
 
 export type ChannelSubscription<
@@ -28,6 +46,15 @@ export type ChannelSubscription<
 
 /**
  * Create a typed channel subscription factory backed by EventSource.
+ *
+ * Each `useChannel(name)` call opens its own EventSource on
+ * `endpoint?channels=name`. One stream per channel is deliberate: the server
+ * dispatches by *event* name, not channel name, so two channels sharing an
+ * event name on one stream would be indistinguishable to `on()`. The server
+ * authorizes the requested channel against the user its SSE route resolves
+ * (`sseMiddleware({ getUser })`), so a private or presence channel works here
+ * too when that route knows who is connecting; a channel it refuses is simply
+ * left out of the `connected` event's `channels` list and delivers nothing.
  */
 export function createUseChannel<TChannelEvents extends UnknownChannelEvents>(
   options: UseChannelOptions = {},
@@ -39,7 +66,7 @@ export function createUseChannel<TChannelEvents extends UnknownChannelEvents>(
   return function useChannel<TChannel extends keyof TChannelEvents & string>(
     channel: TChannel,
   ): ChannelSubscription<TChannelEvents, TChannel> {
-    const eventSource = eventSourceFactory(endpoint, { withCredentials })
+    const eventSource = eventSourceFactory(channelStreamUrl(endpoint, channel), { withCredentials })
     const listeners = new Map<string, Set<EventListener>>()
 
     const attach = (event: string, listener: EventListener): void => {

--- a/packages/inertia-client/src/index.ts
+++ b/packages/inertia-client/src/index.ts
@@ -1,6 +1,6 @@
 export { startInertiaClient } from './app'
 export type { StartInertiaClientOptions } from './app'
-export { createUseChannel } from './channel'
+export { createUseChannel, channelStreamUrl } from './channel'
 export type { UseChannelOptions, ChannelSubscription } from './channel'
 export { renderInertiaServer } from './server'
 export type { RenderInertiaServerOptions, RenderInertiaServerResult } from './server'

--- a/packages/inertia-client/tests/channel.test.ts
+++ b/packages/inertia-client/tests/channel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { createUseChannel } from '../src/channel'
+import { channelStreamUrl, createUseChannel } from '../src/channel'
 
 type ListenerMap = Map<string, Set<EventListener>>
 
@@ -38,7 +38,73 @@ class MockEventSource {
   }
 }
 
+describe('channelStreamUrl', () => {
+  it('appends the channel as ?channels= to a bare endpoint', () => {
+    expect(channelStreamUrl('/broadcasting/events', 'notifications')).toBe(
+      '/broadcasting/events?channels=notifications',
+    )
+  })
+
+  it('joins with & when the endpoint already has a query string', () => {
+    expect(channelStreamUrl('/broadcasting/events?token=abc', 'notifications')).toBe(
+      '/broadcasting/events?token=abc&channels=notifications',
+    )
+  })
+
+  it('encodes characters that would split or terminate the query', () => {
+    expect(channelStreamUrl('/broadcasting/events', 'chat room&1#x')).toBe(
+      '/broadcasting/events?channels=chat%20room%261%23x',
+    )
+  })
+})
+
 describe('createUseChannel', () => {
+  // The server subscribes only what `?channels=` names when the stream opens,
+  // so a hook that opened the bare endpoint received nothing channel-specific.
+  it('opens the EventSource with the requested channel in ?channels=', () => {
+    type Events = {
+      notifications: { NewMessage: { content: string } }
+      'private-orders.123': { OrderUpdated: { status: string } }
+    }
+
+    const opened: Array<{ url: string; init: EventSourceInit }> = []
+    const useChannel = createUseChannel<Events>({
+      eventSourceFactory: (url, init) => {
+        opened.push({ url, init })
+        return new MockEventSource() as unknown as EventSource
+      },
+    })
+
+    useChannel('notifications')
+    useChannel('private-orders.123')
+
+    expect(opened.map((entry) => entry.url)).toEqual([
+      '/broadcasting/events?channels=notifications',
+      '/broadcasting/events?channels=private-orders.123',
+    ])
+    expect(opened[0].init).toEqual({ withCredentials: true })
+  })
+
+  it('keeps a custom endpoint and its query string ahead of the channel', () => {
+    type Events = {
+      notifications: { NewMessage: { content: string } }
+    }
+
+    let openedUrl = ''
+    const useChannel = createUseChannel<Events>({
+      endpoint: '/realtime/stream?token=abc',
+      withCredentials: false,
+      eventSourceFactory: (url) => {
+        openedUrl = url
+        return new MockEventSource() as unknown as EventSource
+      },
+    })
+
+    useChannel('notifications')
+
+    expect(openedUrl).toBe('/realtime/stream?token=abc&channels=notifications')
+  })
+
   it('subscribes to typed events and parses payload', () => {
     type Events = {
       notifications: {


### PR DESCRIPTION
## Summary

`createUseChannel()`'s `useChannel(channel)` never used its `channel` argument at runtime. It opened an `EventSource` on the bare SSE endpoint and attached listeners by event name, but `sseMiddleware()` subscribes only what `?channels=` names when the stream opens. So `useChannel('orders')` received `connected` and `ping` and nothing else, and the documented `feed.on('NewPost', …)` never fired. The argument was effectively a type carrier.

This is a real bug, not a type-only parameter, so the hook now drives the server's up-front subscription path:

- Each `useChannel(name)` opens `endpoint?channels=<name>` (`&channels=` when the endpoint already carries a query string; the name is URL-encoded).
- The `POST /broadcasting/auth` path is not needed here: the SSE route already authorizes requested channels against the user `getUser` resolves, so private and presence channels work through the same call. A refused channel is left out of the `connected` event's `channels` list.
- One `EventSource` per channel is kept on purpose and documented: the server dispatches by event name, so a shared stream could not tell `NewPost` on two channels apart.
- `channelStreamUrl(endpoint, channel)` is exported from `@guren/inertia-client` for building the URL by hand.

Docs (en/ja broadcasting guide) explain the contract, and a patch changeset is included for `@guren/inertia-client`.

## Tests

- Three `channelStreamUrl` cases (bare endpoint, existing query string, encoding of `&`, `#`, space).
- Two `createUseChannel` cases asserting the URL the factory receives, including a private channel and a custom endpoint. Reverting only the URL construction makes both fail.

## Verification

- `packages/inertia-client`: 99 tests pass.
- Root `typecheck` (tsc, build-configs, scaffold-templates, blog, api) green after `bun run build` and blog codegen.
- `audit:docs` and `audit:core-first` pass.
