### PR TITLE
fix(server): make setDefaultDriver update the queue default; document SyncDriver retry

### DIFF
--- a/.changeset/queue-default-driver-and-sync-release.md
+++ b/.changeset/queue-default-driver-and-sync-release.md
@@ -1,0 +1,19 @@
+---
+'@guren/server': patch
+---
+
+Make `QueueManager.setDefaultDriver()` change the instance default, and
+document that `SyncDriver` retries immediately.
+
+`setDefaultDriver(name)` swapped the global driver `Job.dispatch()` uses but
+never reassigned the manager's own default, so `driver()` with no argument and
+`getDefaultDriverName()` kept answering with the driver from construction. The
+method now updates both, and publishes a driver that was already resolved by
+name as the global rather than leaving it off the global slot.
+
+`SyncDriver.release()` re-runs a released job at once and ignores the retry
+delay. That is deliberate: nothing waits in a sync queue, so honoring the
+default exponential backoff would block the dispatching caller for the full
+delay, and a detached timer would move the failure off the call that surfaces
+it. The driver, the `QueueDriver.release()` contract, the worker's retry path
+and the queue guide now say so.

--- a/docs/en/guides/queue.md
+++ b/docs/en/guides/queue.md
@@ -8,7 +8,7 @@ The standard vNext path is: import queue APIs from `@guren/core`, configure the 
 
 - **Job** – A class that encapsulates a unit of work to be processed asynchronously. Jobs define their own `handle()` method and can specify retry behavior.
 - **Worker** – A long-running process that pulls jobs from queues and executes them. Workers handle retries, failures, and graceful shutdown.
-- **Driver** – The storage backend for jobs. Guren ships with Memory and Redis drivers.
+- **Driver** – The storage backend for jobs. Guren ships with Sync, Memory and Redis drivers.
 - **QueueManager** – Central registry for configuring and accessing multiple queue drivers.
 
 Dispatching and working are separate processes, joined asynchronously through the queue. The request returns as soon as the job is enqueued; it runs later, on the worker's schedule.
@@ -317,6 +317,26 @@ const queue = createQueueManager({
 })
 
 const driver = queue.driver()
+```
+
+### Sync Driver
+
+The sync driver runs each job inline, in the process that dispatched it, so
+nothing needs a worker. It is the development default (`QUEUE_CONNECTION=sync`)
+and a failure surfaces from the `dispatch()` call itself.
+
+Because nothing waits in a sync queue, retry backoff is not honored: a job
+released back to the sync driver runs again immediately, whatever delay its
+`backoff` strategy computes. Use the Memory or Redis driver with a worker when
+you need to observe retry timing.
+
+```ts
+import { createQueueManager, SyncDriver } from '@guren/core'
+
+const queue = createQueueManager({
+  default: 'sync',
+  drivers: { sync: () => new SyncDriver() },
+})
 ```
 
 ## Failed Jobs

--- a/docs/ja/guides/queue.md
+++ b/docs/ja/guides/queue.md
@@ -8,7 +8,7 @@ Guren は、時間のかかるタスクをバックグラウンドで処理す�
 
 - **Job** – 非同期で処理される作業単位をカプセル化したクラス。`handle()`メソッドを定義し、リトライ動作を指定できます。
 - **Worker** – キューからジョブを取得して実行する長時間実行プロセス。リトライ、失敗、グレースフルシャットダウンを処理します。
-- **Driver** – ジョブのストレージバックエンド。GurenにはMemoryとRedisドライバが付属しています。
+- **Driver** – ジョブのストレージバックエンド。GurenにはSync、Memory、Redisドライバが付属しています。
 - **QueueManager** – 複数のキュードライバを設定・アクセスするための中央レジストリ。
 
 ディスパッチとワーカーは別々のプロセスで、キューを挟んで非同期に動きます。リクエストはジョブを積んだ時点で返り、実行はワーカーの都合で後から行われます。
@@ -319,6 +319,21 @@ const queue = createQueueManager({
 })
 
 const driver = queue.driver()
+```
+
+### Syncドライバ
+
+Syncドライバはディスパッチしたプロセス内でジョブをその場で実行するため、ワーカーは不要です。開発環境のデフォルト（`QUEUE_CONNECTION=sync`）で、失敗は`dispatch()`の呼び出しからそのまま送出されます。
+
+Syncキューには待ち行列が無いため、リトライのバックオフは適用されません。Syncドライバへ戻されたジョブは、`backoff`戦略が算出する遅延に関係なく即座に再実行されます。リトライのタイミングを確認したい場合はMemoryまたはRedisドライバとワーカーを使用してください。
+
+```ts
+import { createQueueManager, SyncDriver } from '@guren/core'
+
+const queue = createQueueManager({
+  default: 'sync',
+  drivers: { sync: () => new SyncDriver() },
+})
 ```
 
 ## 失敗したジョブ

--- a/packages/server/src/queue/QueueManager.ts
+++ b/packages/server/src/queue/QueueManager.ts
@@ -48,7 +48,7 @@ export interface QueueConfig {
  * ```
  */
 export class QueueManager {
-  private readonly defaultDriver: string
+  private defaultDriver: string
   private readonly driverFactories: Map<string, QueueDriverFactory> = new Map()
   private readonly resolvedDrivers: Map<string, QueueDriver> = new Map()
 
@@ -124,14 +124,19 @@ export class QueueManager {
 
   /**
    * Set the default driver and update global driver.
+   *
+   * After this call `driver()` with no argument and `getDefaultDriverName()`
+   * both answer with the new driver, and `Job.dispatch()` goes to it.
    */
   setDefaultDriver(name: string): void {
     if (!this.driverFactories.has(name)) {
       throw new Error(`Queue driver not found: ${name}`)
     }
 
-    const driver = this.driver(name)
-    setQueueDriver(driver)
+    this.defaultDriver = name
+    // driver() only publishes the global on first resolution; a driver that was
+    // already resolved by name would otherwise stay off the global slot.
+    setQueueDriver(this.driver(name))
   }
 }
 

--- a/packages/server/src/queue/Worker.ts
+++ b/packages/server/src/queue/Worker.ts
@@ -195,7 +195,8 @@ export class Worker {
     const willRetry = job.attempts < job.maxAttempts
 
     if (willRetry) {
-      // Calculate retry delay
+      // The driver owns the wait: a queue-backed driver makes the job available
+      // after `delay`, while SyncDriver re-runs it before release() resolves.
       const delay = JobClass.calculateRetryDelay(job.attempts)
       job.lastError = error.message
       await this.driver.release(job, delay)

--- a/packages/server/src/queue/drivers/SyncDriver.ts
+++ b/packages/server/src/queue/drivers/SyncDriver.ts
@@ -7,6 +7,9 @@ import { getJob } from '../Job'
  * semantics stay identical to a real queue, but failures surface right away
  * and nothing needs a second process.
  *
+ * Because nothing waits in a sync queue, retry backoff is not honored:
+ * `release()` re-runs the job immediately whatever `delayMs` it is handed.
+ *
  * @example
  * ```ts
  * const queue = createQueueManager({
@@ -41,8 +44,17 @@ export class SyncDriver implements QueueDriver {
     return null
   }
 
-  async release(job: QueuedJob): Promise<void> {
-    // Re-run immediately: releasing back to a sync queue means retrying now.
+  /**
+   * Re-run the job now, ignoring `delayMs`.
+   *
+   * There is no queue to wait in: the job runs inline in the process that
+   * released it, so honoring a backoff (2s, 4s, 8s under the default
+   * exponential strategy) would block that caller for the full delay, and a
+   * detached timer would move the failure off the call that surfaces it. Sync
+   * mode therefore retries immediately; a failure fails the job and rethrows,
+   * exactly as `push()` does.
+   */
+  async release(job: QueuedJob, _delayMs?: number): Promise<void> {
     await this.push(job)
   }
 

--- a/packages/server/src/queue/types.ts
+++ b/packages/server/src/queue/types.ts
@@ -91,6 +91,11 @@ export interface QueueDriver {
 
   /**
    * Release a job back onto the queue (for retry).
+   *
+   * The driver owns the delay. A driver with nothing to wait in (`SyncDriver`)
+   * may run the job again immediately, so callers must not assume time has
+   * passed once this resolves.
+   *
    * @param job - The job to release
    * @param delayMs - Delay before the job becomes available again
    */

--- a/packages/server/tests/queue/queue.test.ts
+++ b/packages/server/tests/queue/queue.test.ts
@@ -9,6 +9,7 @@ import {
   getRegisteredJobs,
   resolveJobName,
   MemoryDriver,
+  SyncDriver,
   Worker,
   processJob,
   QueueManager,
@@ -772,5 +773,127 @@ describe('QueueManager', () => {
     const globalDriver = getQueueDriver()
 
     expect(globalDriver).toBe(manager.driver('other'))
+  })
+
+  it('resolves the new default from driver() after setDefaultDriver', () => {
+    const memoryDriver = new MemoryDriver()
+    const otherDriver = new MemoryDriver()
+    const manager = new QueueManager({
+      default: 'memory',
+      drivers: {
+        memory: () => memoryDriver,
+        other: () => otherDriver,
+      },
+    })
+
+    // Resolve the old default first so the instance default, not a fresh
+    // cache, is what the assertions below observe.
+    expect(manager.driver()).toBe(memoryDriver)
+
+    manager.setDefaultDriver('other')
+
+    expect(manager.getDefaultDriverName()).toBe('other')
+    expect(manager.driver()).toBe(otherDriver)
+    expect(getQueueDriver()).toBe(otherDriver)
+  })
+
+  it('publishes an already-resolved driver as the global when it becomes the default', () => {
+    const memoryDriver = new MemoryDriver()
+    const otherDriver = new MemoryDriver()
+    const manager = new QueueManager({
+      default: 'memory',
+      drivers: {
+        memory: () => memoryDriver,
+        other: () => otherDriver,
+      },
+    })
+
+    manager.driver()
+    manager.driver('other') // cached under its name, not yet the global
+    expect(getQueueDriver()).toBe(memoryDriver)
+
+    manager.setDefaultDriver('other')
+
+    expect(getQueueDriver()).toBe(otherDriver)
+  })
+
+  it('rejects an unknown driver without changing the default', () => {
+    const manager = new QueueManager({
+      drivers: { memory: () => new MemoryDriver() },
+    })
+
+    expect(() => manager.setDefaultDriver('unknown')).toThrow('Queue driver not found: unknown')
+    expect(manager.getDefaultDriverName()).toBe('memory')
+  })
+})
+
+describe('SyncDriver', () => {
+  let driver: SyncDriver
+
+  beforeEach(() => {
+    driver = new SyncDriver()
+    setQueueDriver(driver)
+    clearJobRegistry()
+  })
+
+  function queuedJob(name: string) {
+    return {
+      id: 'job-1',
+      name,
+      payload: {},
+      queue: 'default',
+      attempts: 1,
+      maxAttempts: 3,
+      availableAt: new Date(),
+      createdAt: new Date(),
+      reservedAt: null,
+    }
+  }
+
+  it('runs the job inline on dispatch and surfaces the failure from dispatch()', async () => {
+    class FailingJob extends Job<void> {
+      async handle() {
+        throw new Error('inline failure')
+      }
+    }
+    registerJob(FailingJob)
+
+    await expect(FailingJob.dispatch(undefined as any)).rejects.toThrow('inline failure')
+
+    const failed = await driver.getFailedJobs()
+    expect(failed).toHaveLength(1)
+    expect(failed[0].attempts).toBe(1)
+  })
+
+  it('release() re-runs the job immediately, ignoring the retry delay', async () => {
+    const ran: number[] = []
+    class RetriedJob extends Job<void> {
+      async handle() {
+        ran.push(Date.now())
+      }
+    }
+    registerJob(RetriedJob)
+
+    const job = queuedJob('RetriedJob')
+    const started = Date.now()
+    await driver.release(job, 5_000)
+
+    expect(ran).toHaveLength(1)
+    expect(ran[0] - started).toBeLessThan(1_000)
+    expect(job.attempts).toBe(2)
+  })
+
+  it('release() rethrows a retry that fails, like push()', async () => {
+    class StillFailingJob extends Job<void> {
+      async handle() {
+        throw new Error('still failing')
+      }
+    }
+    registerJob(StillFailingJob)
+
+    await expect(driver.release(queuedJob('StillFailingJob'), 5_000)).rejects.toThrow(
+      'still failing'
+    )
+    expect(await driver.getFailedJobs()).toHaveLength(1)
   })
 })


### PR DESCRIPTION
## Summary

Two queue fixes in `@guren/server`:

1. **`QueueManager.setDefaultDriver(name)` now changes the instance default.** The method only swapped the global driver that `Job.dispatch()` uses; `defaultDriver` was `readonly` and never reassigned, so `driver()` with no argument and `getDefaultDriverName()` kept answering with the driver named at construction. The field is now mutable and the method assigns it. It also publishes the driver explicitly: `driver()` only sets the global on first resolution, so a driver that had already been resolved by name would otherwise stay off the global slot.

2. **`SyncDriver.release()` keeps retrying immediately, and now says so.** The driver re-enqueues by calling `push()` and ignores `delayMs`. This PR keeps that behavior deliberately rather than honoring the delay: nothing waits in a sync queue, so honoring the default exponential backoff (2s, 4s, 8s) would block the dispatching caller for the full delay, and a detached timer would move the failure off the `dispatch()` call that surfaces it. The rule is now stated on the driver, in the `QueueDriver.release()` contract (callers must not assume time has passed), in the worker's retry path, and in the queue guide (en/ja), which gains a Sync Driver section.

## Tests

- `setDefaultDriver()`: `driver()` and `getDefaultDriverName()` follow the new default; an already-resolved driver becomes the global when it turns default; an unknown name throws and leaves the default untouched.
- `SyncDriver`: a failure surfaces from `dispatch()`; `release(job, 5000)` re-runs the job at once and bumps `attempts`; a failing retry rethrows like `push()`.

## Verification

- `bun test packages/server/tests/queue`: 71 pass, 0 fail
- `bun run typecheck`: green (root tsc, build configs, scaffold templates, blog, api)
- `bun run audit:docs`, `bun run audit:core-first`: pass
- Changeset: `@guren/server` patch

## Notes for reviewers

The alternative for (2) was honoring the delay via a timer. It was rejected because it changes what "sync" means: the failure would no longer propagate from the dispatch call, and tests would leak timers. If you would rather have sync mode honor backoff, that is a behavior change worth its own discussion.
