### PR TITLE
docs: replace the non-existent `guren upgrade --apply` in contributing docs

### DIFF
--- a/contributing/deprecation-policy.md
+++ b/contributing/deprecation-policy.md
@@ -8,7 +8,7 @@ This document describes how Guren deprecates APIs and the guarantees users can r
 2. **Warn at runtime** -- On first use, a `console.warn` is emitted with the deprecation ID, replacement guidance, and removal version. Warnings are emitted once per process to avoid log noise.
 3. **Register** -- The deprecation is added to `packages/cli/src/deprecations.ts` so that `bunx guren upgrade --check-only` can detect usage in user projects automatically.
 4. **Document** -- The deprecation is listed in the CHANGELOG under a `### Deprecated` section and in the relevant migration guide.
-5. **Provide codemod** -- When the migration pattern is automatable, a codemod is added to `packages/cli/src/codemods.ts` and made available via `bunx guren upgrade --apply`.
+5. **Provide codemod** -- When the migration pattern is automatable, a codemod is added to `packages/cli/src/codemods.ts` and runs as part of `bunx guren upgrade` (preview with `--dry-run`).
 6. **Remove** -- After the minimum deprecation period, the API is removed in a new major version (or minor version during pre-1.0).
 
 ## Minimum Deprecation Period
@@ -56,12 +56,19 @@ Fields:
 Users can check their projects for deprecated API usage at any time:
 
 ```bash
-# Check only (no changes)
+# Report deprecated API usage (no changes)
 bunx guren upgrade --check-only
 
-# Apply available codemods
-bunx guren upgrade --apply
+# Preview the codemods that would run, without writing
+bunx guren upgrade --dry-run
+
+# Apply codemods -- this also realigns @guren/* dependency ranges and applies
+# doctor autofixes
+bunx guren upgrade
 ```
+
+`--check-only` returns before codemods are considered, so it reports deprecations
+only. Use `--dry-run` to see which codemods would apply.
 
 ## Codemod Requirements
 
@@ -69,7 +76,7 @@ When adding a codemod to `packages/cli/src/codemods.ts`:
 
 - The codemod must be idempotent (safe to run multiple times).
 - It must produce valid TypeScript output.
-- It must include a `--dry-run` mode that shows changes without writing.
+- `detect()` must be side-effect-free, so `bunx guren upgrade --dry-run` can list the affected files without writing.
 - It must be tested against the `examples/blog` reference app.
 
 ## CHANGELOG Format
@@ -79,5 +86,5 @@ Deprecations appear in the CHANGELOG under the version that introduces them:
 ```markdown
 ### Deprecated
 
-- **`Route.get()` / `Route.post()` static methods** -- Use `router.get()` / `router.post()` instance methods instead. Will be removed in 1.0.0. Codemod available via `bunx guren upgrade --apply`. (#123)
+- **`Route.get()` / `Route.post()` static methods** -- Use `router.get()` / `router.post()` instance methods instead. Will be removed in 1.0.0. Codemod available: run `bunx guren upgrade`. (#123)
 ```

--- a/contributing/migration-guide-template.md
+++ b/contributing/migration-guide-template.md
@@ -38,17 +38,17 @@ Brief list of new features (link to docs for details).
 
 ## Upgrade Steps
 
-1. Update dependencies:
+1. Preview the upgrade -- dependency changes and any applicable codemods, without writing:
+   ```bash
+   bunx guren upgrade --canary --dry-run
+   ```
+2. Apply it -- this updates the `@guren/*` dependency ranges and runs the codemods:
    ```bash
    bunx guren upgrade --canary
    ```
-2. Run doctor to check for issues:
+3. Run doctor to check for remaining issues:
    ```bash
    bunx guren doctor
-   ```
-3. Run codemods (if any):
-   ```bash
-   bunx guren upgrade --canary --check-only
    ```
 4. Verify:
    ```bash


### PR DESCRIPTION
## Summary

`contributing/deprecation-policy.md` told contributors to run codemods with `bunx guren upgrade --apply`. That flag is not declared by the `upgrade` command (`packages/cli/src/commands.ts` declares `canary`, `tag`, `install`, `dryRun`, `json`, `noAutofix`, `checkOnly`), and citty's parser is non-strict, so `--apply` was silently dropped rather than erroring. Following the doc therefore ran a plain `guren upgrade` — which does apply codemods, but also realigns `@guren/*` dependency ranges and applies doctor autofixes, none of which the doc was describing.

Codemods actually run inside `upgradeCanary` (`packages/cli/src/upgrade.ts`), unconditionally once the target version resolves, honoring `--dry-run`. The three `--apply` sites now say `bunx guren upgrade` for the applying form and `bunx guren upgrade --dry-run` for the preview form, with the extra effects of the applying form spelled out.

Two adjacent claims about the same mechanism were wrong in the same way, so they are corrected here too:

- **`--check-only` reports deprecations only.** `upgradeCanary` returns early on `checkOnly` with `codemodResults: []`, before `runCodemods` is ever reached. Left alone, the "Automated Detection" block would have read as though check-only previews codemods. `contributing/migration-guide-template.md` had the sharper version of this: its step 3, titled "Run codemods (if any)", was `bunx guren upgrade --canary --check-only`, which runs none. The upgrade steps now preview with `--dry-run` and apply with a plain `--canary` upgrade.
- **A codemod has no dry-run mode.** The `Codemod` interface (`packages/cli/src/codemods.ts`) is `detect()` + `apply()`; `runCodemods` implements dry-run itself by calling `detect()` and reporting the files as `pending`. The requirement "It must include a `--dry-run` mode" is therefore unimplementable as stated, and now reads as a constraint on `detect()` being side-effect-free.

## Scope

- `contributing/` docs only. No source, template, or generated file changes.
- Checked `docs/`, `web/`, `README.md`, `packages/*/src`, and `packages/*/templates` for the same phrasing: `--apply` appeared nowhere else.

## Risk Assessment

None. Documentation-only change under `contributing/`, which no build, typecheck, test, or audit gate scans. No changeset needed.

## Validation

Verified the flag parsing empirically rather than reading it off citty's docs, since the whole defect is a flag being accepted-and-ignored. A probe command declaring the same `dryRun` / `checkOnly` args:

```
--dry-run    -> {"dryRun":true}
--dryRun     -> {"dryRun":true}
--check-only -> {"checkOnly":true}
--apply      -> {}
```

So the kebab-case forms the docs use do bind, and `--apply` is confirmed to be silently discarded.

- [ ] `bun run build` — not run; no source changes.
- [ ] `bun run typecheck` — not run; no source changes.
- [ ] `bun run test` — not run; no source changes.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [ ] I added/updated tests for behavior changes — no behavior changed.
- [x] I updated relevant documentation.
