### PR TITLE
ci: move the Bun trial lane and bun-types to 1.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         # (scripts/workflow-bun-version.test.ts enforces that); later entries
         # are trial lanes for the next Bun line — promote one to first once it
         # has soaked.
-        bun-version: ['1.3.14', '1.4.0']
+        bun-version: ['1.3.14', '1.4.1']
         include:
           - bun-version: '1.3.14'
             redis: true
@@ -65,7 +65,7 @@ jobs:
           # script is itself `bun run ./scripts/test-packages.ts`), which is
           # how the first version of this lane fed the harness a bare
           # `--parallel` and died on "Unknown flag".
-          - bun-version: '1.4.0'
+          - bun-version: '1.4.1'
             redis: true
             trial: true
             test-bun-flags: '-- -- --parallel --timeout 30000'
@@ -282,7 +282,7 @@ jobs:
       # The flags are applied on pushes only. `--parallel` costs the lane most
       # of its green (numbers on the matrix entry above), and a lane that is
       # red on two runs in three is one everybody learns to scroll past —
-      # which would also cost the 1.4.0 promotion soak, the other thing this
+      # which would also cost the 1.4 promotion soak, the other thing this
       # lane is for and the half that passes. On a pull request it therefore
       # runs plain, and `--parallel` keeps collecting on main at 11-12 runs a
       # day, off everyone's PR checks. The consequence is worth stating: for

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@babel/parser": "^7.24.7",
         "@babel/types": "^7.29.0",
         "@changesets/cli": "^2.31.1",
-        "bun-types": "^1.4.0",
+        "bun-types": "^1.4.1",
         "oxlint": "1.81.0",
         "oxlint-tsgolint": "7.0.2001",
         "typescript": "^7.0.2",
@@ -1168,7 +1168,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+    "bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@babel/parser": "^7.24.7",
     "@babel/types": "^7.29.0",
     "@changesets/cli": "^2.31.1",
-    "bun-types": "^1.4.0",
+    "bun-types": "^1.4.1",
     "oxlint": "1.81.0",
     "oxlint-tsgolint": "7.0.2001",
     "typescript": "^7.0.2",

--- a/packages/server/src/http/Application.ts
+++ b/packages/server/src/http/Application.ts
@@ -285,13 +285,9 @@ function registerProcessTeardown(onSignal: () => void, onExit: () => void): () =
   process.on('exit', onExit)
 
   return () => {
-    // Via the EventEmitter surface: bun-types 1.4.0 declares `off` on Process
-    // with only a "memoryPressure" overload, shadowing the generic `off`, so
-    // signal names stop compiling. `on`/`once` are unaffected.
-    const emitter: NodeJS.EventEmitter = process
-    emitter.off('SIGINT', onSignal)
-    emitter.off('SIGTERM', onSignal)
-    emitter.off('exit', onExit)
+    process.off('SIGINT', onSignal)
+    process.off('SIGTERM', onSignal)
+    process.off('exit', onExit)
   }
 }
 


### PR DESCRIPTION
## Summary

Bun 1.4.1 shipped on 2026-09-04. This moves the CI trial lane from 1.4.0 to 1.4.1 and the root `bun-types` floor to `^1.4.1`. Every other workflow keeps pinning the primary version (1.3.14); `scripts/workflow-bun-version.test.ts` enforces that and stays green. The lockfile was regenerated on 1.3.14, so the primary lane's `--frozen-lockfile` install is unchanged.

The second commit drops the `EventEmitter` cast in `registerProcessTeardown`: bun-types 1.4.1 restores the generic `process.off` signature that 1.4.0 shadowed (oven-sh/bun#40004), and with the floor at `^1.4.1` the workaround had nothing left to cover. No runtime change.

## Why not promote 1.4 to primary yet

On `main`, the 1.4.0 lane is 20 green / 19 red over the last 40 runs. Every red is the same class: 30s timeouts in subprocess-heavy tests (`publish-agent-catalog`, `audit: changeset gate`) under the push-only `--parallel` trial, not a runtime regression. Promotion is a separate decision once that flag's numbers settle; 1.4.1 lands 476 commits including a spawnSync/GC keep-alive fix (oven-sh/bun#40508), so the soak restarts here.

## Verification (Bun 1.4.1, local)

- `bun install --frozen-lockfile`
- `bun run build:clean`
- `bun run typecheck`
- `bun run lint`
- `bun run test:bun` (6495 pass / 0 fail / 98 skip, before the rebase onto #657)
- `bun run test:examples`
- Application lifecycle tests and `scripts/workflow-bun-version.test.ts` after the rebase