### PR TITLE
refactor(server): let the signer own the one-time-token expiry comparison

### DIFF
--- a/.changeset/one-time-token-expiry-authority.md
+++ b/.changeset/one-time-token-expiry-authority.md
@@ -34,4 +34,6 @@ the token id still exists (single use and revocation). A store may still drop
 expired records for housekeeping — the in-memory and Redis stores do — but
 verification does not rely on it, so a custom store that returns stale rows is
 no longer a way to keep an expired link alive, and one that keeps them is not a
-way to extend it either.
+way to extend it either. The claim is the authority on what verification will
+*accept*; a store that drops a row before that claim expires still ends the
+link early, which is what `MemoryPasswordResetStore.find` does by design.

--- a/packages/server/src/auth/signed-token.ts
+++ b/packages/server/src/auth/signed-token.ts
@@ -21,18 +21,21 @@ export async function readSignedTokenClaims(
   purpose: string,
   store: { delete(tokenId: string): Promise<void> },
 ): Promise<SignedTokenClaims | null> {
-  const payload = signer.verify<{ id?: string; email?: string }>(token, {
-    purpose,
-    allowExpired: true,
-  })
-  if (!payload?.id || !payload.email) {
-    return null
+  const claims = signer.verify<{ id?: string; email?: string }>(token, { purpose })
+  if (claims?.id && claims.email) {
+    return { id: claims.id, email: claims.email }
   }
 
-  if (typeof payload.exp === 'number' && payload.exp < Math.floor(Date.now() / 1000)) {
-    await store.delete(payload.id)
-    return null
+  // Ask again without the expiry check rather than re-deriving the comparison
+  // here. The two calls differ only in that one branch, so a token the strict
+  // call rejected and this one accepts is expired rather than forged. It also
+  // keeps the comparison the signer's: were it to grow clock-skew leeway, the
+  // strict call would accept a token inside the window and this path would
+  // never delete it.
+  const expired = signer.verify<{ id?: string }>(token, { purpose, allowExpired: true })
+  if (expired?.id) {
+    await store.delete(expired.id)
   }
 
-  return { id: payload.id, email: payload.email }
+  return null
 }


### PR DESCRIPTION
Follow-up to #662.

## The seam

`readSignedTokenClaims` verified with `allowExpired: true` and then re-derived the expiry comparison itself:

```ts
if (typeof payload.exp === 'number' && payload.exp < Math.floor(Date.now() / 1000)) {
  await store.delete(payload.id)
  return null
}
```

purely so it could tell an expired token from a badly signed one before deleting the store row. `MessageSigner.verify` already owns that comparison, written in the opposite operand order. The two predicates matched only by coincidence of today's semantics: if `MessageSigner` ever grew clock-skew leeway, which signers usually do, a token inside the leeway window would pass the signer and then be rejected **and deleted** by the helper. Nothing type-checked or tested that seam.

## The change

Ask the signer twice instead — once strict, once permitting expiry. `options.allowExpired` appears in exactly one branch of `verify`, and everything upstream of it (split, signature check, JSON parse, purpose) is deterministic given `(token, purpose, keyring)`. So a token the strict call rejects and the lenient one accepts is expired rather than forged, and the helper holds no clock comparison of its own. Adding leeway to the signer would be picked up by the strict call, and this path would never run.

Cost is one extra HMAC on the failure path only.

## Considered and rejected: `MessageSigner.verifyResult()`

Returning `{ ok: false, reason: 'expired' | 'invalid', payload }` was the obvious alternative. Rejected on two counts:

- It leaves the comparison in two places in source anyway — inside `verifyResult`, plus whatever `verify` keeps for its own return contract. Calling twice removes the comparison from the helper entirely.
- `MessageSigner` is re-exported from `@guren/core`, which makes it Stable under `contributing/api-stability.md`. A new public method there is a separate decision with its own changeset, for what is a single caller: `allowExpired: true` has exactly one use in the repo. `http/middleware/csrf.ts` and `encryption/signed-url.ts` use plain `verify`.

## Changeset correction

#662's changeset said the store "is asked only whether the token id still exists". `MemoryPasswordResetStore.find` drops expired rows by design — covered by its own test at `password-reset.test.ts:40` — so the honest statement is that the claim is the authority on what verification *accepts*, while a store may still end a link early. The changeset is still unconsumed on `main`, so the corrected wording ships with the release.

The store's behaviour is deliberately left alone: it is tested, public, and out of scope here.

## Not changed: `PasswordResetTokenStore.find()`'s required `expiresAt`

No framework code reads it any more, and a required field does invite implementers to conclude it is consulted. But `expiresAt?: Date` tells a third wrong story ("sometimes present — when?"), and the honest change is removing the field, which breaks app code reading it. That is a major-version item. The interface JSDoc #662 added already carries the truth for a minor.

## Verification

The change is behaviour-identical, so a green suite proves little on its own. Two mutants confirm the path is actually covered:

- removing `await store.delete(expired.id)` → 5 failures
- making the strict call lenient (`allowExpired: true`) → 7 failures

`packages/server` + `core` + `orm`: 3037 pass, 0 fail. `packages/cli`: 2081 pass, 0 fail. Root `typecheck`, `audit:core-first`, `audit:docs` all green.