### PR TITLE
fix(cli): honor --no-autofix on guren upgrade

### DIFF
--- a/.changeset/upgrade-no-autofix-flag.md
+++ b/.changeset/upgrade-no-autofix-flag.md
@@ -1,0 +1,19 @@
+---
+'@guren/cli': patch
+---
+
+Honor `--no-autofix` on `guren upgrade`.
+
+The flag was declared as `noAutofix`, but citty's argument parser has a
+dedicated `no-` branch that writes the key with the prefix *stripped*: passing
+`--no-autofix` set `autofix: false` and never set `noAutofix` at all. The
+command read `args.noAutofix`, which the args proxy resolved through `noAutofix`
+then `no-autofix` — neither of which existed — so the flag read as `undefined`
+and `guren upgrade` applied automatic fixes anyway, writing files the user had
+asked it not to touch. Only the `--noAutofix` spelling worked.
+
+The argument is now declared positively as `autofix` (defaulting to `true`), so
+citty's negation lands on the key the command reads and usage advertises
+`--no-autofix`. `--noAutofix` remains supported, because it is the spelling
+`--help` advertised for as long as it was the only one that worked — treat it as
+a documented alias, not as a shim to drop.

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -3027,6 +3027,16 @@ const addCommand = defineCommand({
   },
 })
 
+/**
+ * citty's `--no-` branch writes the key with the prefix *stripped*, so
+ * `--no-autofix` arrives as `autofix: false` and never sets `noAutofix`;
+ * `--noAutofix` is the camel spelling usage printed while only it worked, still
+ * honored so a script written against it keeps suppressing fixes.
+ */
+export function readNoAutofix(args: { autofix?: boolean; noAutofix?: boolean }): boolean {
+  return args.autofix === false || Boolean(args.noAutofix)
+}
+
 const upgradeCommand = defineCommand({
   meta: {
     name: 'upgrade',
@@ -3053,8 +3063,11 @@ const upgradeCommand = defineCommand({
       type: 'boolean',
       description: 'Print the upgrade report as JSON.',
     },
-    noAutofix: {
+    // Positive on purpose, so citty's negation lands on the key `readNoAutofix`
+    // reads. `default: true` is also what makes usage print `--no-autofix`.
+    autofix: {
       type: 'boolean',
+      default: true,
       description: 'Only report fixable issues without applying automatic fixes.',
     },
     checkOnly: {
@@ -3068,7 +3081,7 @@ const upgradeCommand = defineCommand({
     const result = await upgradeCanary({
       install: Boolean(args.install),
       dryRun: Boolean(args.dryRun),
-      noAutofix: Boolean(args.noAutofix),
+      noAutofix: readNoAutofix(args),
       checkOnly: Boolean(args.checkOnly),
       tag,
     })

--- a/packages/cli/tests/upgrade-autofix-flag.test.ts
+++ b/packages/cli/tests/upgrade-autofix-flag.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from 'bun:test'
+import { runCommand } from 'citty'
+
+import { builtinSubCommands, readNoAutofix } from '../src/commands'
+
+/**
+ * Both halves of the defect are driven with the real pieces: citty parses against
+ * the command's own `args`, and the result goes through the same `readNoAutofix`.
+ * `upgradeCommand.run` is not invoked because faking `upgradeCanary` needs
+ * `mock.module`, which is process-wide and would leave `upgrade.test.ts`
+ * asserting against the fake.
+ */
+async function noAutofixFor(rawArgs: string[]): Promise<boolean | undefined> {
+  let captured: boolean | undefined
+  await runCommand(
+    {
+      meta: { name: 'upgrade' },
+      args: builtinSubCommands.upgrade.args,
+      run: ({ args }) => {
+        captured = readNoAutofix(args as { autofix?: boolean; noAutofix?: boolean })
+      },
+    },
+    { rawArgs },
+  )
+  return captured
+}
+
+describe('upgrade --no-autofix', () => {
+  test('leaves autofix on when the flag is absent', async () => {
+    expect(await noAutofixFor([])).toBe(false)
+  })
+
+  test('turns autofix off for the kebab spelling citty negates', async () => {
+    expect(await noAutofixFor(['--no-autofix'])).toBe(true)
+  })
+
+  test('turns autofix off for the camel spelling usage printed', async () => {
+    expect(await noAutofixFor(['--noAutofix'])).toBe(true)
+  })
+
+  test('usage advertises the spelling that works', async () => {
+    const args = builtinSubCommands.upgrade.args as Record<string, { type?: string; default?: unknown }>
+    // citty prints `--no-<name>` only for a boolean defaulting to true.
+    expect(args.autofix).toMatchObject({ type: 'boolean', default: true })
+  })
+})


### PR DESCRIPTION
## Summary

`guren upgrade --no-autofix` was a no-op: upgrade applied automatic fixes anyway, writing files the user had asked it not to touch.

citty's `parseRawArgs` has a dedicated `no-` branch that writes the key with the prefix **stripped**, so `--no-autofix` set `autofix: false` and never set `noAutofix` at all. The command read `args.noAutofix`, which citty's args proxy resolves through `noAutofix` then `no-autofix` — neither of which existed — so the flag read as `undefined`. Only the `--noAutofix` spelling worked, and that was the spelling `--help` printed.

Reproduced against the real bin in a scratch app (`upgrade --dry-run --json`, reporting the `autofixes` keys):

| flag | before | after |
| --- | --- | --- |
| *(none)* | `["scripts"]` | `["scripts"]` |
| `--no-autofix` | `["scripts"]` | `[]` |
| `--noAutofix` | `[]` | `[]` |

The argument is now declared positively as `autofix` (defaulting to `true`), so citty's negation lands on the key the command reads. As a side effect `--help` now advertises `--no-autofix`, because citty prints the negated spelling only for a boolean defaulting to true.

`--noAutofix` remains supported. It is not in `docs/`, `web/`, or the agent templates, but `--help` advertised it for as long as it was the only spelling that worked — dropping it would silently start writing files under any script built against that output, and citty is non-strict so there would be no unknown-flag error either.

The read moved into a named `readNoAutofix` so the test can drive both halves of the defect — the declared key and the expression reading it — without `mock.module`, which is process-wide and would leave `upgrade.test.ts` asserting against a fake `upgradeCanary`. `src/commands.ts` is not in the package's `exports` map and is not re-exported from the index, so this widens no public API.

`UpgradeCanaryOptions.noAutofix` is an internal name and is left alone.

## Scope

- `cli` — `packages/cli/src/commands.ts`, `packages/cli/tests/upgrade-autofix-flag.test.ts`
- changeset: `@guren/cli` patch

## Risk Assessment

- Behavior change is the fix itself: `--no-autofix` now suppresses autofixes instead of being ignored. Anyone who passed it was already getting fixes applied, so this only starts honoring an instruction that was being dropped.
- `--noAutofix` is unchanged, so existing scripts keep working.
- `--autofix` is newly accepted as the positive form (a no-op, since it is the default).
- No migration impact; no public API surface added.

## Validation

- [x] `bun run build` — exit 0
- [x] `bun run typecheck` — exit 0
- [x] `bun run test:bun cli` — 2091 pass, 0 fail (117 files)
- [x] `bun run audit:docs`, `bun run audit:core-first`, `guren check --docs` — all pass
- [x] Mutation-tested: reverting the read expression fails the kebab-spelling case; reverting the declaration fails the usage-shape case
- [ ] `bun run test` (full) — the `test:bun` sweep hit a Bun segfault under `--isolate` in `tool-dev.test.ts` (vite dep optimizer, a known local flake on this machine); re-running. The `cli` package suite that covers this change is green.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
