### PR TITLE
fix(cli): declare dry-run and check-only with their documented spelling

### DIFF
--- a/.changeset/cli-kebab-flag-declarations.md
+++ b/.changeset/cli-kebab-flag-declarations.md
@@ -1,0 +1,33 @@
+---
+'@guren/cli': patch
+---
+
+Declare nine CLI flags with the kebab-case spelling the docs already use, so
+`--help` and the docs agree and the documented spelling parses natively.
+
+`db:migrate`, `db:seed`, `db:reset`, `db:fresh`, `queue:flush`, `upgrade`,
+`agent:init` and `agent:sync` declared `dryRun`, and `upgrade` declared
+`checkOnly`. citty registers only the *declared* arg name, so `renderUsage`
+advertised `-d, --dryRun` and `--checkOnly` while every guide documents
+`--dry-run` and `--check-only` — and the documented spelling reached the
+command as the truthy string `"false"` rather than a parsed boolean. They are
+now declared `'dry-run'` and `'check-only'`, matching how `token:issue` already
+declares `'read-only'` and `'allow-unmatched'`.
+
+No flag is removed: the camelCase spellings still resolve through citty's
+proxy, and the `-d` alias is unchanged. Aliases are deliberately not used for
+this — `renderUsage` renders an alias single-dashed, so `alias: 'dry-run'` would
+print `-dry-run, --dryRun`.
+
+One user-visible behaviour changes for the better. Mixing two spellings of one
+flag resolves to the declared name rather than to the last one typed, so
+`--dryRun=false --dry-run=true` previously ran a real `db:reset` although the
+user's last word asked for a dry run; the declared name is now the documented
+one, so that invocation dry-runs. The reverse mix is still won by whichever
+spelling is declared, not by argument order.
+
+`upgrade --no-autofix` is untouched and already correct: it is declared as the
+positive `autofix` arg, because citty's `--no-` branch claims `--no-autofix`
+and writes the key `autofix` whatever the arg is called. A `'no-autofix'`
+declaration would advertise a flag that is still ignored, so that flag is not
+part of this rename.

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -828,7 +828,7 @@ const migrateCommand = defineCommand({
     description: 'Run all pending database migrations.',
   },
   args: {
-    dryRun: {
+    'dry-run': {
       type: 'boolean',
       alias: 'd',
       description: 'Show what would happen without executing',
@@ -839,7 +839,7 @@ const migrateCommand = defineCommand({
     },
   },
   async run({ args }) {
-    if (args.dryRun) {
+    if (args['dry-run']) {
       reportDryRun('db:migrate', 'Would run all pending database migrations.', Boolean(args.json))
       return
     }
@@ -866,7 +866,7 @@ const seedCommand = defineCommand({
       description: 'Run in production without confirmation',
       alias: 'f',
     },
-    dryRun: {
+    'dry-run': {
       type: 'boolean',
       alias: 'd',
       description: 'Show what would happen without executing',
@@ -881,7 +881,7 @@ const seedCommand = defineCommand({
       return
     }
 
-    if (args.dryRun) {
+    if (args['dry-run']) {
       reportDryRun('db:seed', 'Would execute database seeders.', Boolean(args.json))
       return
     }
@@ -905,7 +905,7 @@ const seedCommand = defineCommand({
 async function runResetCommand(
   action: 'db:reset' | 'db:fresh',
   doneVerb: 'reset' | 'refreshed',
-  args: { seed?: boolean; force?: boolean; json?: boolean; dryRun?: boolean },
+  args: { seed?: boolean; force?: boolean; json?: boolean; 'dry-run'?: boolean },
 ): Promise<void> {
   if (!ensureDestructiveCommandAllowed(args.force)) {
     return
@@ -914,7 +914,7 @@ async function runResetCommand(
   const seed = Boolean(args.seed)
   const json = Boolean(args.json)
 
-  if (args.dryRun) {
+  if (args['dry-run']) {
     const message = seed
       ? 'Would drop all tables, re-run all migrations, and run seeders.'
       : 'Would drop all tables and re-run all migrations.'
@@ -965,7 +965,7 @@ const resetCommand = defineCommand({
       type: 'boolean',
       description: 'Output result as JSON',
     },
-    dryRun: {
+    'dry-run': {
       type: 'boolean',
       alias: 'd',
       description: 'Show what would happen without executing',
@@ -996,7 +996,7 @@ const freshCommand = defineCommand({
       type: 'boolean',
       description: 'Output result as JSON',
     },
-    dryRun: {
+    'dry-run': {
       type: 'boolean',
       alias: 'd',
       description: 'Show what would happen without executing',
@@ -1421,7 +1421,7 @@ const queueFlushCommand = defineCommand({
       description: 'Run in production without confirmation',
       alias: 'f',
     },
-    dryRun: {
+    'dry-run': {
       type: 'boolean',
       alias: 'd',
       description: 'Show what would happen without executing',
@@ -1432,7 +1432,7 @@ const queueFlushCommand = defineCommand({
       return
     }
 
-    if (args.dryRun) {
+    if (args['dry-run']) {
       const queueFilter = args.queue ? ` on queue "${args.queue}"` : ''
       consola.info(`[dry-run] Would delete all failed jobs${queueFilter}.`)
       return
@@ -2611,7 +2611,7 @@ const AGENT_INIT_ARGS = {
     type: 'string',
     description: `${AGENT_TARGETS_HELP} Default: claude.`,
   },
-  dryRun: {
+  'dry-run': {
     type: 'boolean',
     description:
       'Report what the init would write or replace without changing any file — the preview for --force.',
@@ -2635,7 +2635,7 @@ const agentInitCommand = defineCommand({
       mode: 'init',
       force: Boolean(args.force),
       targets: args.target ? parseTargetArg(args.target) : undefined,
-      dryRun: Boolean(args.dryRun),
+      dryRun: Boolean(args['dry-run']),
     })
     reportAgentHarnessResult(result)
     consola.success(
@@ -2649,7 +2649,9 @@ const agentInitCommand = defineCommand({
 /**
  * The dry run's closing line, whose "run this to apply" hint carries the run's
  * own flags — the applied command must be the previewed one. Derived from the
- * declared arg spec so a future flag cannot fall out of the hint.
+ * declared arg spec so a future flag cannot fall out of the hint, and spelled
+ * verbatim: a declared name is the spelling citty registers, so rewriting its
+ * case here would print a flag the CLI does not parse.
  */
 function agentDryRunClosingLine(
   commandName: 'agent:init' | 'agent:sync',
@@ -2658,8 +2660,8 @@ function agentDryRunClosingLine(
 ): string {
   let suffix = ''
   for (const name of Object.keys(argsSpec)) {
-    if (name === 'dryRun') continue
-    const flag = `--${name.replaceAll(/[A-Z]/gu, (c) => `-${c.toLowerCase()}`)}`
+    if (name === 'dry-run') continue
+    const flag = `--${name}`
     const value = args[name]
     if (argsSpec[name]?.type === 'boolean') {
       if (value) suffix += ` ${flag}`
@@ -2680,7 +2682,7 @@ const AGENT_SYNC_ARGS = {
     description:
       'Delete files in framework-managed directories that are no longer part of the harness. Without this flag they are only reported.',
   },
-  dryRun: {
+  'dry-run': {
     type: 'boolean',
     description: 'Report what the sync would write, replace, or prune without changing any file.',
   },
@@ -2703,7 +2705,7 @@ const agentSyncCommand = defineCommand({
       mode: 'sync',
       targets: args.target ? parseTargetArg(args.target) : undefined,
       prune: Boolean(args.prune),
-      dryRun: Boolean(args.dryRun),
+      dryRun: Boolean(args['dry-run']),
     })
     reportAgentHarnessResult(result)
     consola.success(
@@ -3027,7 +3029,7 @@ const upgradeCommand = defineCommand({
       type: 'boolean',
       description: 'Run bun install after package.json is updated.',
     },
-    dryRun: {
+    'dry-run': {
       type: 'boolean',
       description: 'Print the dependency changes without modifying package.json.',
     },
@@ -3042,7 +3044,7 @@ const upgradeCommand = defineCommand({
       default: true,
       description: 'Only report fixable issues without applying automatic fixes.',
     },
-    checkOnly: {
+    'check-only': {
       type: 'boolean',
       description: 'Run compatibility and deprecation checks without modifying anything.',
     },
@@ -3052,9 +3054,9 @@ const upgradeCommand = defineCommand({
 
     const result = await upgradeCanary({
       install: Boolean(args.install),
-      dryRun: Boolean(args.dryRun),
+      dryRun: Boolean(args['dry-run']),
       noAutofix: readNoAutofix(args),
-      checkOnly: Boolean(args.checkOnly),
+      checkOnly: Boolean(args['check-only']),
       tag,
     })
 
@@ -3085,14 +3087,14 @@ const upgradeCommand = defineCommand({
     }
 
     if (result.codemodResults.length > 0) {
-      consola.box(args.dryRun ? 'Codemod preview' : 'Codemods')
+      consola.box(args['dry-run'] ? 'Codemod preview' : 'Codemods')
       for (const codemod of result.codemodResults) {
         const prefix = codemod.status === 'applied' ? '[applied]' : codemod.status === 'pending' ? '[pending]' : '[skipped]'
         consola.info(`${prefix} ${codemod.description} (${codemod.filesAffected} files)`)
       }
     }
 
-    if (args.checkOnly) {
+    if (args['check-only']) {
       consola.info('Check-only mode. No files were modified.')
       return
     }
@@ -3107,7 +3109,7 @@ const upgradeCommand = defineCommand({
     }
 
     if (result.autofixes.length > 0) {
-      consola.box(args.dryRun ? 'Autofix preview' : 'Autofixes applied')
+      consola.box(args['dry-run'] ? 'Autofix preview' : 'Autofixes applied')
       for (const autofix of result.autofixes) {
         const prefix = autofix.applied ? '[applied]' : '[preview]'
         consola.info(`${prefix} ${autofix.title}: ${autofix.summary}`)
@@ -3135,7 +3137,7 @@ const upgradeCommand = defineCommand({
       }
     }
 
-    if (args.dryRun) {
+    if (args['dry-run']) {
       consola.info('Dry run complete. Files were not modified.')
     } else if (result.updatedDependencies.length > 0 || result.autofixes.some((autofix) => autofix.applied)) {
       consola.info(`Updated ${result.packageJsonPath}`)

--- a/packages/cli/src/define-command.ts
+++ b/packages/cli/src/define-command.ts
@@ -4,9 +4,9 @@
  * citty arrays a repeated flag whatever its declared type, and every array is
  * truthy, so `Boolean(args.json)` reads `--json=false --json=false` as *on*.
  * Only the `=value` spellings can express a false, which is what lets that
- * survive casual testing. citty also registers only the *declared* arg name
- * with its parser, so `--dry-run=false` on an arg declared `dryRun` misses the
- * branch that types it and arrives as the truthy string `"false"`.
+ * survive casual testing. citty also registers only the *declared* arg name,
+ * so any other spelling arrives as the truthy string `"false"` — a backstop
+ * only, since commands declare the spelling they document.
  */
 import { defineCommand as defineCittyCommand } from 'citty'
 import type { ArgsDef, CommandContext, CommandDef } from 'citty'
@@ -16,7 +16,8 @@ import { resolveValue } from './run-cli'
  * Ordering is only recovered within one stored key. citty keys `--dryRun` and
  * `--dry-run` separately and its Proxy reads the declared name first, so mixing
  * two spellings of one flag resolves to that key, not to the last one typed.
- * Positionals live in `_` and are left alone.
+ * The documented spelling therefore wins such a mix only because it is the
+ * declared one. Positionals live in `_` and are left alone.
  */
 export function defineCommand<T extends ArgsDef = ArgsDef>(def: CommandDef<T>): CommandDef<T> {
   const { args, setup, run } = def

--- a/packages/cli/tests/define-command.test.ts
+++ b/packages/cli/tests/define-command.test.ts
@@ -18,8 +18,8 @@ describe('defineCommand', () => {
     const command = defineCommand({
       args: {
         json: { type: 'boolean' },
-        // Declared camelCase and spelled `--dry-run`, which is the spelling this
-        // CLI documents and the one citty never registers as a boolean.
+        // Declared camelCase on purpose: no command declares `dryRun` any more,
+        // and this pins the citty behaviour the coercion still backstops.
         dryRun: { type: 'boolean', alias: 'd' },
         name: { type: 'string' },
       },
@@ -112,6 +112,23 @@ describe('built-in commands', () => {
     }
     return found
   }
+
+  it('declare every arg with the spelling citty registers', async () => {
+    // A camelCase declaration makes `renderUsage` advertise `--dryRun` while the
+    // docs say `--dry-run`, and the documented spelling then arrives as the
+    // truthy string `"false"` instead of parsing. Aliases are exempt:
+    // `renderUsage` renders them single-dashed, so a kebab alias prints worse.
+    const camelCased: string[] = []
+    for (const [path, command] of await everyCommand(builtinSubCommands as Record<string, CommandDef<never>>)) {
+      for (const name of Object.keys((await resolveValue(command.args)) ?? {})) {
+        if (/[A-Z]/u.test(name)) camelCased.push(`${path} --${name}`)
+      }
+    }
+    // Frozen rather than empty so a new camelCase arg fails here. These three are
+    // known and milder than a boolean: citty's Proxy resolves the kebab spelling
+    // of a string either way, so only the usage line contradicts the docs.
+    expect(camelCased).toEqual(['routes:types --pagesOut', 'codegen --pagesOut', 'audit --auditConfig'])
+  })
 
   it('all define themselves through the wrapper, nested ones included', async () => {
     // A command importing `defineCommand` from `citty` instead reads raw arrays


### PR DESCRIPTION
## The defect

citty registers only the *declared* arg name with its parser, and `renderUsage` prints `--${arg.name}`. Nine flags were declared camelCase, so `guren db:migrate --help` advertised `-d, --dryRun` while `docs/en/guides/cli.md`, `docs/ja/guides/cli.md`, the attachments guides and `contributing/deprecation-policy.md` all document `--dry-run`. The documented spelling reached the command as the truthy string `"false"` rather than a parsed boolean.

Renamed to the spelling the docs already use, matching how `token:issue` declares `'read-only'` and `'allow-unmatched'`:

| Command | Was | Now |
|---|---|---|
| `db:migrate`, `db:seed`, `db:reset`, `db:fresh`, `queue:flush`, `upgrade`, `agent:init`, `agent:sync` | `dryRun` | `'dry-run'` |
| `upgrade` | `checkOnly` | `'check-only'` |

```
$ guren db:migrate --help
  -d, --dry-run    Show what would happen without executing
```

No flag is removed: the camelCase spellings still resolve through citty's proxy, and the `-d` alias is unchanged. An alias is not the fix — `renderUsage` renders aliases single-dashed, so `alias: 'dry-run'` would print `-dry-run, --dryRun`.

## One behaviour change, in the safe direction

Mixing two spellings of one flag resolves to the declared name, not to the last one typed (citty's Proxy reads the declared name first). The declared name is now the documented one, so the outcome flips:

| Invocation | Before | After |
|---|---|---|
| `--dryRun=false --dry-run=true` | real run | dry run |

Previously a `db:reset` or `db:fresh` ran for real although the user's last word asked for a dry run. Recovering true argument order would mean consulting `context.rawArgs`; that is a separate change to the parsing added in #672 and is left alone. The limit stays documented in `define-command.ts`, whose docblock is updated to say that the documented spelling now wins such a mix only because it is the declared one.

The `"true"`/`"false"` coercion in `define-command.ts` is kept. After the rename it no longer backstops a documented flag — `--dry-run=false` parses natively — but `--dryRun=false` still relocates to the truthy string and reaches it through citty's camelCase proxy fallback.

## `--no-autofix` is not part of this

Renaming cannot reach it. Measured against citty 0.1.6:

```
decl=noAutofix   ["--no-autofix"] -> {"autofix": false}
decl=no-autofix  ["--no-autofix"] -> {"autofix": false}
```

citty's `--no-` branch strips the prefix and writes the key `autofix` whatever the arg is called, so a `'no-autofix'` declaration would advertise a flag that is still ignored. That is exactly why #676 declares the positive `autofix` arg with `default: true`, which is already on `main` and unaffected here.

## Regression guard

A new test walks every registered command, nested ones included, and fails on any camelCase arg name. Verified by mutation: reverting one declaration makes it fail naming `db:migrate --dryRun`.

Its expectation is frozen rather than empty. Three camelCase declarations remain — `routes:types --pagesOut`, `codegen --pagesOut`, `audit --auditConfig` — and are a milder case: they are string args, where citty's Proxy resolves the kebab spelling either way, so only the usage line contradicts the docs. Left out to keep this to the boolean defect; fixing them also means updating `web/package.json`, which invokes `codegen --pagesOut`.

`agentDryRunClosingLine` now spells its hint `--${name}` verbatim: with declared names being the on-CLI spelling, the old camel-to-kebab rewrite would print a flag citty does not parse. Output confirmed unchanged for the current arg set.

## No docs or template changes

None were needed — every guide and template already documented `--dry-run` and `--check-only`. The docs were right; the declarations were wrong.

## Verification

`lint`, `build:clean`, `typecheck`, `bun test packages/cli/tests` (2064 pass), `audit:agent-catalog`, `audit:docs`, `audit:core-first`, `audit:workspace-scripts` — all exit 0.