### PR TITLE
feat(cli): add `guren add lint`

### DIFF
--- a/.changeset/cli-add-lint.md
+++ b/.changeset/cli-add-lint.md
@@ -1,0 +1,5 @@
+---
+"@guren/cli": minor
+---
+
+Add `guren add lint`: writes an `.oxlintrc.json` that loads the Guren rules from `@guren/cli/oxlint` (`guren/await-async-assertion` as an error, the `guren/comment-*` rules as warnings), adds `lint` and `lint:fix` scripts, and pins `oxlint` as a dev dependency. `bunx oxlint` runs under Bun, so an app needs no Node install for it.

--- a/.changeset/cli-add-lint.md
+++ b/.changeset/cli-add-lint.md
@@ -2,4 +2,4 @@
 "@guren/cli": minor
 ---
 
-Add `guren add lint`: writes an `.oxlintrc.json` that loads the Guren rules from `@guren/cli/oxlint` (`guren/await-async-assertion` as an error, the `guren/comment-*` rules as warnings), adds `lint` and `lint:fix` scripts, and pins `oxlint` as a dev dependency. `bunx oxlint` runs under Bun, so an app needs no Node install for it.
+Add `guren add lint`: writes an `.oxlintrc.json` that loads the Guren rules from `@guren/cli/oxlint` (`guren/await-async-assertion` as an error, the `guren/comment-*` rules as warnings), adds `lint` and `lint:fix` scripts, and adds `oxlint` as a dev dependency on a tilde range (oxlint's JS plugin API is alpha, so only patch updates are admitted). `bunx oxlint` runs under Bun, so an app needs no Node install for it.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ bunx guren add storage         # File storage
 bunx guren add events          # Events & listeners
 bunx guren add broadcasting    # Real-time (SSE)
 bunx guren add schedule        # Cron scheduling
+bunx guren add lint            # oxlint with the Guren rules
 ```
 
 Run `bun run codegen` after adding features to regenerate types. When you are ready to ship, `bun run build` creates the production build.

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -31,6 +31,7 @@ bunx guren add storage
 bunx guren add attachments
 bunx guren add broadcasting
 bunx guren add schedule
+bunx guren add lint
 ```
 
 > **Golden path:** Start with `bunx guren add auth` and `bunx guren add resource`, then add more features as your app grows.
@@ -43,6 +44,8 @@ bunx guren plugin @acme/guren-plugin-audit
 
 
 These commands patch `src/app.ts`, create the matching provider/runtime files, and keep the generated app aligned with the reference starter.
+
+`add lint` is the one that touches no application code: it writes `.oxlintrc.json` (oxlint with the Guren rules from `@guren/cli/oxlint`: `guren/await-async-assertion` as an error, the `guren/comment-*` rules as warnings), adds `lint` and `lint:fix` scripts, and pins `oxlint` as a dev dependency; run `bun install` afterwards. `bunx oxlint` runs under Bun, so no Node install is needed.
 
 `bunx guren add admin` scaffolds:
 

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -45,7 +45,7 @@ bunx guren plugin @acme/guren-plugin-audit
 
 These commands patch `src/app.ts`, create the matching provider/runtime files, and keep the generated app aligned with the reference starter.
 
-`add lint` is the one that touches no application code: it writes `.oxlintrc.json` (oxlint with the Guren rules from `@guren/cli/oxlint`: `guren/await-async-assertion` as an error, the `guren/comment-*` rules as warnings), adds `lint` and `lint:fix` scripts, and pins `oxlint` as a dev dependency; run `bun install` afterwards. `bunx oxlint` runs under Bun, so no Node install is needed.
+`add lint` is the one that touches no application code: it writes `.oxlintrc.json` (oxlint with the Guren rules from `@guren/cli/oxlint`: `guren/await-async-assertion` as an error, the `guren/comment-*` rules as warnings), adds `lint` and `lint:fix` scripts, and adds `oxlint` as a dev dependency on a tilde range (patch updates only: oxlint's JS plugin API is alpha); run `bun install` afterwards. `bunx oxlint` runs under Bun, so no Node install is needed.
 
 `bunx guren add admin` scaffolds:
 

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -43,7 +43,7 @@ bunx guren plugin @acme/guren-plugin-audit
 
 これらのコマンドは `src/app.ts` を更新し、対応する provider/runtime ファイルを生成します。
 
-`add lint` だけはアプリのコードに触れません。`.oxlintrc.json`（`@guren/cli/oxlint` の Guren ルール付き oxlint。`guren/await-async-assertion` は error、`guren/comment-*` は warn）を書き、`lint` / `lint:fix` スクリプトを追加し、`oxlint` を devDependency として固定します。実行後に `bun install` してください。`bunx oxlint` は Bun 上で動くので Node は不要です。
+`add lint` だけはアプリのコードに触れません。`.oxlintrc.json`（`@guren/cli/oxlint` の Guren ルール付き oxlint。`guren/await-async-assertion` は error、`guren/comment-*` は warn）を書き、`lint` / `lint:fix` スクリプトを追加し、`oxlint` を devDependency に `~` レンジで追加します（パッチ更新のみ。oxlint の JS プラグイン API は alpha のため）。実行後に `bun install` してください。`bunx oxlint` は Bun 上で動くので Node は不要です。
 
 `bunx guren add admin` は次を生成します:
 

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -31,6 +31,7 @@ bunx guren add storage
 bunx guren add attachments
 bunx guren add broadcasting
 bunx guren add schedule
+bunx guren add lint
 ```
 > **Golden path:** まず `bunx guren add auth` と `bunx guren add resource` から始め、アプリの成長に応じて他の機能を追加してください。
 
@@ -41,6 +42,8 @@ bunx guren plugin @acme/guren-plugin-audit
 `plugin`（`add plugin` としても利用可能）は、依存が未インストールの場合に `bun add` でインストールし（`--no-install` でスキップ可能）、プラグインが宣言するGurenバージョン互換性を検証した上で（`--ignore-compatibility` で無視可能）、Providerを `src/app.ts` に自動登録します。プラグインが `gurenPlugin` マニフェストで宣言した設定スタブや環境変数キーも適用されます。`--force` は公開済みファイルの上書きに使います。
 
 これらのコマンドは `src/app.ts` を更新し、対応する provider/runtime ファイルを生成します。
+
+`add lint` だけはアプリのコードに触れません。`.oxlintrc.json`（`@guren/cli/oxlint` の Guren ルール付き oxlint。`guren/await-async-assertion` は error、`guren/comment-*` は warn）を書き、`lint` / `lint:fix` スクリプトを追加し、`oxlint` を devDependency として固定します。実行後に `bun install` してください。`bunx oxlint` は Bun 上で動くので Node は不要です。
 
 `bunx guren add admin` は次を生成します:
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -62,10 +62,14 @@
   },
   "peerDependencies": {
     "@guren/openapi": ">=1.3.0",
+    "oxlint": "~1.81.0",
     "vite": ">=7.0.0"
   },
   "peerDependenciesMeta": {
     "@guren/openapi": {
+      "optional": true
+    },
+    "oxlint": {
       "optional": true
     }
   },

--- a/packages/cli/src/add-lint.ts
+++ b/packages/cli/src/add-lint.ts
@@ -1,0 +1,63 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { consola } from 'consola'
+import { scaffoldTemplateFile } from './scaffold-templates'
+import { writeRoot, writeScaffoldFiles, type WriterOptions } from './utils'
+
+/**
+ * Tilde, not caret: oxlint's JS plugin API is alpha and outside its semver, so a
+ * caret would let `bun install` float an app onto a minor whose plugin host no
+ * longer loads `@guren/cli/oxlint`. Held to the version this repo lints with by
+ * `tests/add-lint.test.ts`.
+ */
+export const OXLINT_RANGE = '~1.81.0'
+
+/** `bunx oxlint` runs the shim under Bun, so an app needs no Node install for it. */
+export const LINT_SCRIPTS: Readonly<Record<string, string>> = {
+  lint: 'bunx oxlint',
+  'lint:fix': 'bunx oxlint --fix',
+}
+
+interface Manifest {
+  scripts?: Record<string, string>
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  [key: string]: unknown
+}
+
+/**
+ * Install oxlint with the Guren rules: the `.oxlintrc.json` template, the `lint`
+ * scripts, and the `oxlint` dev dependency. Existing scripts and an existing
+ * `oxlint` range are left as they are; only the config file honours `force`.
+ */
+export async function addLint(options: WriterOptions = {}): Promise<string[]> {
+  const created = await writeScaffoldFiles([scaffoldTemplateFile('lint', '.oxlintrc.json')], options)
+  const manifestPath = resolve(writeRoot(options), 'package.json')
+  const raw = await readFile(manifestPath, 'utf8')
+  const manifest = JSON.parse(raw) as Manifest
+
+  let changed = false
+  const scripts = manifest.scripts ?? {}
+  for (const [name, command] of Object.entries(LINT_SCRIPTS)) {
+    if (scripts[name] === undefined) {
+      scripts[name] = command
+      changed = true
+    }
+  }
+  manifest.scripts = scripts
+
+  const installed = manifest.dependencies?.oxlint ?? manifest.devDependencies?.oxlint
+  if (installed === undefined) {
+    manifest.devDependencies = { ...manifest.devDependencies, oxlint: OXLINT_RANGE }
+    changed = true
+  }
+
+  if (!changed) return created
+
+  const indent = /^(\s+)"/mu.exec(raw)?.[1] ?? '  '
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, indent)}\n`, 'utf8')
+  if (installed === undefined) {
+    consola.info('Run: bun install')
+  }
+  return [...created, manifestPath]
+}

--- a/packages/cli/src/add-lint.ts
+++ b/packages/cli/src/add-lint.ts
@@ -52,6 +52,9 @@ export async function addLint(options: WriterOptions = {}): Promise<string[]> {
   if (missingScripts.length === 0 && installed !== undefined) return created
 
   manifest.scripts = { ...scripts, ...Object.fromEntries(missingScripts) }
+  if (installed !== undefined && installed !== oxlintRange()) {
+    consola.warn(`package.json already has oxlint ${installed}; @guren/cli/oxlint is tested against ${oxlintRange()}`)
+  }
   if (installed === undefined) {
     manifest.devDependencies = { ...manifest.devDependencies, oxlint: oxlintRange() }
   }

--- a/packages/cli/src/add-lint.ts
+++ b/packages/cli/src/add-lint.ts
@@ -1,16 +1,28 @@
+import { readFileSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { consola } from 'consola'
+import type { DependencyManifest } from './drizzle-pins'
 import { scaffoldTemplateFile } from './scaffold-templates'
 import { writeRoot, writeScaffoldFiles, type WriterOptions } from './utils'
 
 /**
- * Tilde, not caret: oxlint's JS plugin API is alpha and outside its semver, so a
- * caret would let `bun install` float an app onto a minor whose plugin host no
- * longer loads `@guren/cli/oxlint`. Held to the version this repo lints with by
- * `tests/add-lint.test.ts`.
+ * The oxlint range an app gets: this package's own optional peer range, read from
+ * `../package.json` (this package's root from `dist/` and `src/` alike), so the
+ * claim `@guren/cli/oxlint` makes about its host and the range `add lint` writes
+ * cannot drift apart. Tilde on purpose: oxlint's JS plugin API is alpha and
+ * outside its semver, and a caret would float an app past the tested line.
  */
-export const OXLINT_RANGE = '~1.81.0'
+export function oxlintRange(): string {
+  const manifestPath = fileURLToPath(new URL('../package.json', import.meta.url))
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as DependencyManifest
+  const range = manifest.peerDependencies?.oxlint
+  if (range === undefined) {
+    throw new Error('@guren/cli declares no oxlint peer range — add lint has nothing to install')
+  }
+  return range
+}
 
 /** `bunx oxlint` runs the shim under Bun, so an app needs no Node install for it. */
 export const LINT_SCRIPTS: Readonly<Record<string, string>> = {
@@ -18,11 +30,8 @@ export const LINT_SCRIPTS: Readonly<Record<string, string>> = {
   'lint:fix': 'bunx oxlint --fix',
 }
 
-interface Manifest {
+interface Manifest extends DependencyManifest {
   scripts?: Record<string, string>
-  dependencies?: Record<string, string>
-  devDependencies?: Record<string, string>
-  [key: string]: unknown
 }
 
 /**
@@ -31,31 +40,22 @@ interface Manifest {
  * `oxlint` range are left as they are; only the config file honours `force`.
  */
 export async function addLint(options: WriterOptions = {}): Promise<string[]> {
-  const created = await writeScaffoldFiles([scaffoldTemplateFile('lint', '.oxlintrc.json')], options)
+  // Read the manifest before the config write: a missing or malformed package.json
+  // must not leave a half-installed lint setup (or, with --force, a clobbered config).
   const manifestPath = resolve(writeRoot(options), 'package.json')
-  const raw = await readFile(manifestPath, 'utf8')
-  const manifest = JSON.parse(raw) as Manifest
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as Manifest
+  const created = await writeScaffoldFiles([scaffoldTemplateFile('lint', '.oxlintrc.json')], options)
 
-  let changed = false
   const scripts = manifest.scripts ?? {}
-  for (const [name, command] of Object.entries(LINT_SCRIPTS)) {
-    if (scripts[name] === undefined) {
-      scripts[name] = command
-      changed = true
-    }
-  }
-  manifest.scripts = scripts
-
+  const missingScripts = Object.entries(LINT_SCRIPTS).filter(([name]) => scripts[name] === undefined)
   const installed = manifest.dependencies?.oxlint ?? manifest.devDependencies?.oxlint
+  if (missingScripts.length === 0 && installed !== undefined) return created
+
+  manifest.scripts = { ...scripts, ...Object.fromEntries(missingScripts) }
   if (installed === undefined) {
-    manifest.devDependencies = { ...manifest.devDependencies, oxlint: OXLINT_RANGE }
-    changed = true
+    manifest.devDependencies = { ...manifest.devDependencies, oxlint: oxlintRange() }
   }
-
-  if (!changed) return created
-
-  const indent = /^(\s+)"/mu.exec(raw)?.[1] ?? '  '
-  await writeFile(manifestPath, `${JSON.stringify(manifest, null, indent)}\n`, 'utf8')
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
   if (installed === undefined) {
     consola.info('Run: bun install')
   }

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -1,5 +1,6 @@
 import { consola } from 'consola'
 import { addAttachments, appBindsStorage } from './add-attachments'
+import { addLint } from './add-lint'
 import { assertNotApiOnly } from './app-surface'
 import { fileExists, readIfExists } from './discovery'
 import { makeAuth } from './make-auth'
@@ -60,6 +61,10 @@ const blueprintRegistry: Record<string, BlueprintDefinition> = {
       created.push(...(await addAttachments(writerOptions)))
       return created
     },
+  },
+  lint: {
+    description: 'Install oxlint with the Guren rules: .oxlintrc.json, lint scripts, and the oxlint dev dependency.',
+    run: async (options) => addLint({ force: Boolean(options.force) }),
   },
   admin: {
     description: 'Install a starter admin dashboard with dedicated routes and controller.',

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -2983,6 +2983,7 @@ const addCommand = defineCommand({
     broadcasting: createAddBlueprintCommand('broadcasting', 'Install broadcasting scaffolding with sample public and private channels.'),
     cache: createAddBlueprintCommand('cache', 'Install cache scaffolding and an example cache service.'),
     events: createAddBlueprintCommand('events', 'Install event scaffolding with a sample event and listener.'),
+    lint: createAddBlueprintCommand('lint', 'Install oxlint with the Guren rules: .oxlintrc.json, lint scripts, and the oxlint dev dependency.'),
     mail: createAddBlueprintCommand('mail', 'Install mail scaffolding with a sample mailable.'),
     notifications: createAddBlueprintCommand('notifications', 'Install notification scaffolding with sample channels and a sample notification.'),
     queue: createAddBlueprintCommand('queue', 'Install queue scaffolding with a sample job.'),

--- a/packages/cli/templates/scaffold/lint/.oxlintrc.json
+++ b/packages/cli/templates/scaffold/lint/.oxlintrc.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  // The guren rules ship with @guren/cli: await-async-assertion (a bare
+  // `expect(...).rejects` statement can never fail its test) and the comment rules.
+  "jsPlugins": ["@guren/cli/oxlint"],
+  "ignorePatterns": ["node_modules/**", ".guren/**", "dist/**", "public/build/**"],
+  "rules": {
+    "guren/await-async-assertion": "error",
+    // Comment hygiene is advisory: the agent harness feeds these back after every
+    // edit, while `bun run lint` stays green on them.
+    "guren/comment-length": "warn",
+    "guren/comment-banner": "warn",
+    "guren/comment-step-label": "warn",
+    "guren/comment-history": "warn",
+    "guren/comment-param-restates": "warn",
+    "no-unused-vars": ["warn", { "ignoreRestSiblings": true, "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }]
+  }
+  // Type-aware rules (typescript/no-floating-promises and friends) need
+  // `bun add -d oxlint-tsgolint` and `"options": { "typeAware": true }`.
+}

--- a/packages/cli/tests/add-lint.test.ts
+++ b/packages/cli/tests/add-lint.test.ts
@@ -1,9 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
-import { consola } from 'consola'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { existsSync } from 'node:fs'
 import { cp, readFile, rm, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
-import { assertWorkspaceBuilt, createTempWorkspace, linkWorkspacePackage, OXLINT_BIN, type TempWorkspace } from './helpers'
+import { assertWorkspaceBuilt, captureWarnings, createTempWorkspace, linkWorkspacePackage, OXLINT_BIN, type TempWorkspace } from './helpers'
 import { addLint, LINT_SCRIPTS, oxlintRange } from '../src/add-lint'
 import { runBlueprint } from '../src/blueprints'
 
@@ -46,20 +45,15 @@ describe('guren add lint', () => {
 
   it('keeps a lint script and an oxlint range the app already has', async () => {
     await writeFile('package.json', JSON.stringify({ ...MANIFEST, scripts: { lint: 'eslint .' }, devDependencies: { oxlint: '1.0.0' } }))
-    const warn = spyOn(consola, 'warn').mockImplementation(() => {})
 
-    try {
-      const created = await runBlueprint('lint')
+    const { result: created, warnings } = await captureWarnings(() => runBlueprint('lint'))
 
-      const manifest = await readManifest()
-      expect(manifest.scripts).toEqual({ lint: 'eslint .', 'lint:fix': LINT_SCRIPTS['lint:fix'] })
-      expect(manifest.devDependencies).toEqual({ oxlint: '1.0.0' })
-      expect(created).toContain(resolve('package.json'))
-      // A range the plugin was not tested against is kept, but said so.
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining('oxlint 1.0.0'))
-    } finally {
-      warn.mockRestore()
-    }
+    const manifest = await readManifest()
+    expect(manifest.scripts).toEqual({ lint: 'eslint .', 'lint:fix': LINT_SCRIPTS['lint:fix'] })
+    expect(manifest.devDependencies).toEqual({ oxlint: '1.0.0' })
+    expect(created).toContain(resolve('package.json'))
+    // A range the plugin was not tested against is kept, but said so.
+    expect(warnings.join('\n')).toContain('oxlint 1.0.0')
   })
 
   it('refuses to overwrite an existing config without --force', async () => {

--- a/packages/cli/tests/add-lint.test.ts
+++ b/packages/cli/tests/add-lint.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
+import { consola } from 'consola'
 import { existsSync } from 'node:fs'
 import { cp, readFile, rm, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
@@ -45,13 +46,20 @@ describe('guren add lint', () => {
 
   it('keeps a lint script and an oxlint range the app already has', async () => {
     await writeFile('package.json', JSON.stringify({ ...MANIFEST, scripts: { lint: 'eslint .' }, devDependencies: { oxlint: '1.0.0' } }))
+    const warn = spyOn(consola, 'warn').mockImplementation(() => {})
 
-    const created = await runBlueprint('lint')
+    try {
+      const created = await runBlueprint('lint')
 
-    const manifest = await readManifest()
-    expect(manifest.scripts).toEqual({ lint: 'eslint .', 'lint:fix': LINT_SCRIPTS['lint:fix'] })
-    expect(manifest.devDependencies).toEqual({ oxlint: '1.0.0' })
-    expect(created).toContain(resolve('package.json'))
+      const manifest = await readManifest()
+      expect(manifest.scripts).toEqual({ lint: 'eslint .', 'lint:fix': LINT_SCRIPTS['lint:fix'] })
+      expect(manifest.devDependencies).toEqual({ oxlint: '1.0.0' })
+      expect(created).toContain(resolve('package.json'))
+      // A range the plugin was not tested against is kept, but said so.
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('oxlint 1.0.0'))
+    } finally {
+      warn.mockRestore()
+    }
   })
 
   it('refuses to overwrite an existing config without --force', async () => {

--- a/packages/cli/tests/add-lint.test.ts
+++ b/packages/cli/tests/add-lint.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { cp, mkdir, readFile, symlink, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { cp, readFile, rm, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
-import { createTempWorkspace, type TempWorkspace } from './helpers'
-import { addLint, LINT_SCRIPTS, OXLINT_RANGE } from '../src/add-lint'
+import { assertWorkspaceBuilt, createTempWorkspace, linkWorkspacePackage, OXLINT_BIN, type TempWorkspace } from './helpers'
+import { addLint, LINT_SCRIPTS, oxlintRange } from '../src/add-lint'
 import { runBlueprint } from '../src/blueprints'
 
 const repoRoot = resolve(import.meta.dir, '../../..')
+assertWorkspaceBuilt([join(repoRoot, 'packages/cli/dist/oxlint/index.js')])
 
 const MANIFEST = {
   name: 'app',
@@ -13,7 +15,7 @@ const MANIFEST = {
   devDependencies: { typescript: '^5.4.0' },
 }
 
-async function readManifest(): Promise<typeof MANIFEST & { scripts: Record<string, string>; devDependencies: Record<string, string> }> {
+async function readManifest(): Promise<{ scripts: Record<string, string>; devDependencies: Record<string, string> }> {
   return JSON.parse(await readFile('package.json', 'utf8'))
 }
 
@@ -37,7 +39,7 @@ describe('guren add lint', () => {
     expect(await readFile('.oxlintrc.json', 'utf8')).toContain('"jsPlugins": ["@guren/cli/oxlint"]')
     const manifest = await readManifest()
     expect(manifest.scripts).toEqual({ typecheck: 'tsc --noEmit', ...LINT_SCRIPTS })
-    expect(manifest.devDependencies).toEqual({ typescript: '^5.4.0', oxlint: OXLINT_RANGE })
+    expect(manifest.devDependencies).toEqual({ typescript: '^5.4.0', oxlint: oxlintRange() })
     expect(await readFile('package.json', 'utf8')).toEndWith('}\n')
   })
 
@@ -56,15 +58,26 @@ describe('guren add lint', () => {
     await writeFile('.oxlintrc.json', '{}\n')
 
     await expect(runBlueprint('lint')).rejects.toThrow('already exists')
-    expect(await readManifest()).toEqual(MANIFEST as never)
+    expect(await readManifest()).toEqual(MANIFEST)
 
     await runBlueprint('lint', { force: true })
     expect(await readFile('.oxlintrc.json', 'utf8')).toContain('@guren/cli/oxlint')
   })
 
-  it('pins the same oxlint this repo lints with', async () => {
+  it('leaves nothing behind when package.json is missing or malformed', async () => {
+    await rm('package.json')
+    await expect(runBlueprint('lint')).rejects.toThrow('ENOENT')
+    expect(existsSync('.oxlintrc.json')).toBe(false)
+
+    await writeFile('package.json', '{ not json')
+    await expect(runBlueprint('lint')).rejects.toThrow()
+    expect(existsSync('.oxlintrc.json')).toBe(false)
+  })
+
+  it('installs the oxlint this repo lints with: the peer range admits the root pin', async () => {
     const root = JSON.parse(await readFile(join(repoRoot, 'package.json'), 'utf8')) as { devDependencies: Record<string, string> }
-    expect(OXLINT_RANGE).toBe(`~${root.devDependencies.oxlint}`)
+    expect(oxlintRange()).toStartWith('~')
+    expect(Bun.semver.satisfies(root.devDependencies.oxlint!, oxlintRange())).toBe(true)
   })
 
   // Through the real binary, against the built dist: a fresh app must have no
@@ -72,15 +85,10 @@ describe('guren add lint', () => {
   it.each(['default', 'api-only'])('lints the %s starter template with no errors', async (template) => {
     const appDir = join(workspace.dir, template)
     await cp(join(repoRoot, 'packages', 'create-app', 'templates', template), appDir, { recursive: true })
-    await mkdir(join(appDir, 'node_modules', '@guren'), { recursive: true })
-    await symlink(join(repoRoot, 'packages', 'cli'), join(appDir, 'node_modules', '@guren', 'cli'))
+    await linkWorkspacePackage('cli', appDir)
     await addLint({ cwd: appDir })
 
-    const result = Bun.spawnSync([join(repoRoot, 'node_modules', '.bin', 'oxlint'), '--format', 'unix'], {
-      cwd: appDir,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    })
+    const result = Bun.spawnSync([OXLINT_BIN, '--format', 'unix'], { cwd: appDir, stdout: 'pipe', stderr: 'pipe' })
     const output = result.stdout.toString()
 
     expect(result.stderr.toString()).toBe('')

--- a/packages/cli/tests/add-lint.test.ts
+++ b/packages/cli/tests/add-lint.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { cp, mkdir, readFile, symlink, writeFile } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { createTempWorkspace, type TempWorkspace } from './helpers'
+import { addLint, LINT_SCRIPTS, OXLINT_RANGE } from '../src/add-lint'
+import { runBlueprint } from '../src/blueprints'
+
+const repoRoot = resolve(import.meta.dir, '../../..')
+
+const MANIFEST = {
+  name: 'app',
+  scripts: { typecheck: 'tsc --noEmit' },
+  devDependencies: { typescript: '^5.4.0' },
+}
+
+async function readManifest(): Promise<typeof MANIFEST & { scripts: Record<string, string>; devDependencies: Record<string, string> }> {
+  return JSON.parse(await readFile('package.json', 'utf8'))
+}
+
+describe('guren add lint', () => {
+  let workspace: TempWorkspace
+
+  beforeEach(async () => {
+    workspace = await createTempWorkspace('guren-add-lint-')
+    await writeFile('package.json', `${JSON.stringify(MANIFEST, null, 2)}\n`)
+  })
+
+  afterEach(async () => {
+    await workspace.cleanup()
+  })
+
+  it('writes the config, the lint scripts, and the oxlint dev dependency', async () => {
+    const created = await runBlueprint('lint')
+
+    expect(created).toContain(resolve('.oxlintrc.json'))
+    expect(created).toContain(resolve('package.json'))
+    expect(await readFile('.oxlintrc.json', 'utf8')).toContain('"jsPlugins": ["@guren/cli/oxlint"]')
+    const manifest = await readManifest()
+    expect(manifest.scripts).toEqual({ typecheck: 'tsc --noEmit', ...LINT_SCRIPTS })
+    expect(manifest.devDependencies).toEqual({ typescript: '^5.4.0', oxlint: OXLINT_RANGE })
+    expect(await readFile('package.json', 'utf8')).toEndWith('}\n')
+  })
+
+  it('keeps a lint script and an oxlint range the app already has', async () => {
+    await writeFile('package.json', JSON.stringify({ ...MANIFEST, scripts: { lint: 'eslint .' }, devDependencies: { oxlint: '1.0.0' } }))
+
+    const created = await runBlueprint('lint')
+
+    const manifest = await readManifest()
+    expect(manifest.scripts).toEqual({ lint: 'eslint .', 'lint:fix': LINT_SCRIPTS['lint:fix'] })
+    expect(manifest.devDependencies).toEqual({ oxlint: '1.0.0' })
+    expect(created).toContain(resolve('package.json'))
+  })
+
+  it('refuses to overwrite an existing config without --force', async () => {
+    await writeFile('.oxlintrc.json', '{}\n')
+
+    await expect(runBlueprint('lint')).rejects.toThrow('already exists')
+    expect(await readManifest()).toEqual(MANIFEST as never)
+
+    await runBlueprint('lint', { force: true })
+    expect(await readFile('.oxlintrc.json', 'utf8')).toContain('@guren/cli/oxlint')
+  })
+
+  it('pins the same oxlint this repo lints with', async () => {
+    const root = JSON.parse(await readFile(join(repoRoot, 'package.json'), 'utf8')) as { devDependencies: Record<string, string> }
+    expect(OXLINT_RANGE).toBe(`~${root.devDependencies.oxlint}`)
+  })
+
+  // Through the real binary, against the built dist: a fresh app must have no
+  // error-level finding, or the first `bun run lint` a user sees is red.
+  it.each(['default', 'api-only'])('lints the %s starter template with no errors', async (template) => {
+    const appDir = join(workspace.dir, template)
+    await cp(join(repoRoot, 'packages', 'create-app', 'templates', template), appDir, { recursive: true })
+    await mkdir(join(appDir, 'node_modules', '@guren'), { recursive: true })
+    await symlink(join(repoRoot, 'packages', 'cli'), join(appDir, 'node_modules', '@guren', 'cli'))
+    await addLint({ cwd: appDir })
+
+    const result = Bun.spawnSync([join(repoRoot, 'node_modules', '.bin', 'oxlint'), '--format', 'unix'], {
+      cwd: appDir,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const output = result.stdout.toString()
+
+    expect(result.stderr.toString()).toBe('')
+    expect(output).not.toContain('[Error/')
+    expect(output).not.toContain('node_modules/')
+    expect(result.exitCode).toBe(0)
+  })
+})

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -79,6 +79,7 @@ describe('blueprints', () => {
       'broadcasting',
       'cache',
       'events',
+      'lint',
       'mail',
       'notifications',
       'oauth',

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -56,9 +56,51 @@ export async function writeInstalledPackage(
  * the machine rather than the workspace.
  */
 export async function linkWorkspaceCore(baseDir: string): Promise<void> {
-  const linkPath = join(baseDir, 'node_modules', '@guren', 'core')
+  await linkWorkspacePackage('core', baseDir)
+}
+
+/** Symlink `packages/<name>` into `baseDir/node_modules/@guren/<name>`, as a workspace install would. */
+export async function linkWorkspacePackage(name: string, baseDir: string): Promise<void> {
+  const linkPath = join(baseDir, 'node_modules', '@guren', name)
   await mkdir(dirname(linkPath), { recursive: true })
-  await symlink(join(repoRoot, 'packages', 'core'), linkPath, 'dir')
+  await symlink(join(repoRoot, 'packages', name), linkPath, 'dir')
+}
+
+/** The oxlint shim this workspace lints with, for tests that drive the real binary. */
+export const OXLINT_BIN = join(repoRoot, 'node_modules', '.bin', 'oxlint')
+
+/**
+ * Lint one fixture through the real oxlint: `.oxlintrc.json` carries `config`, and
+ * only the `rules` it names are enabled. Returns oxlint's `--format unix` stdout.
+ * Throws on stderr output, and on the message-less `file:0:0:` line oxlint prints
+ * when a plugin throws mid-file — otherwise a broken plugin reads as "no findings".
+ */
+export function lintFixture(options: {
+  config: { jsPlugins: string[]; rules: Record<string, string> }
+  file: string
+  source: string
+  cwd?: string
+}): string {
+  const dir = options.cwd ?? mkdtempSync(join(tmpdir(), 'guren-oxlint-'))
+  try {
+    writeFileSync(join(dir, '.oxlintrc.json'), JSON.stringify(options.config))
+    writeFileSync(join(dir, options.file), options.source)
+    const denies = Object.keys(options.config.rules).flatMap((rule) => ['-D', rule])
+    const result = Bun.spawnSync([OXLINT_BIN, '-c', '.oxlintrc.json', '-A', 'all', ...denies, '--format', 'unix', options.file], {
+      cwd: dir,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const stdout = result.stdout.toString()
+    const stderr = result.stderr.toString()
+    if (stderr.trim() !== '') throw new Error(`oxlint wrote to stderr:\n${stderr}`)
+    if (stdout.split('\n').some((line) => line.startsWith(`${options.file}:0:0:`))) {
+      throw new Error(`the plugin threw while linting the fixture:\n${stdout}`)
+    }
+    return stdout
+  } finally {
+    if (options.cwd === undefined) rmSync(dir, { recursive: true, force: true })
+  }
 }
 
 /**

--- a/packages/cli/tests/oxlint-await-async-assertion.test.ts
+++ b/packages/cli/tests/oxlint-await-async-assertion.test.ts
@@ -1,43 +1,17 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { resolve } from 'node:path'
+import { lintFixture } from './helpers'
 
 // The rule is exercised through the real oxlint binary rather than by calling
 // `create()` with a hand-built AST: what has to hold is that the file the
 // config points at loads as a plugin and reports on the AST oxlint hands it.
 
-const repoRoot = resolve(import.meta.dir, '../../..')
-const oxlint = join(repoRoot, 'node_modules', '.bin', 'oxlint')
-const plugin = join(repoRoot, 'packages', 'cli', 'src', 'oxlint', 'await-async-assertion.js')
+const plugin = resolve(import.meta.dir, '../src/oxlint/await-async-assertion.js')
 
 /** Lines of `source` the rule reports, in the order oxlint prints them. */
 function reportedLines(source: string): number[] {
-  const dir = mkdtempSync(join(tmpdir(), 'guren-await-async-assertion-'))
-  try {
-    writeFileSync(
-      join(dir, '.oxlintrc.json'),
-      JSON.stringify({ jsPlugins: [plugin], rules: { 'guren/await-async-assertion': 'error' } }),
-    )
-    writeFileSync(join(dir, 'case.test.ts'), source)
-    const result = Bun.spawnSync(
-      [oxlint, '-c', '.oxlintrc.json', '-A', 'all', '-D', 'guren/await-async-assertion', '--format', 'unix', 'case.test.ts'],
-      { cwd: dir, stdout: 'pipe', stderr: 'pipe' },
-    )
-    const stdout = result.stdout.toString()
-    const stderr = result.stderr.toString()
-    if (stderr.trim() !== '') {
-      throw new Error(`oxlint wrote to stderr:\n${stderr}`)
-    }
-    // A plugin that throws mid-file is reported by oxlint as a message-less
-    // file-level warning at 0:0, not as a rule finding; surface it as a failure.
-    if (/^case\.test\.ts:0:0:/m.test(stdout)) {
-      throw new Error(`the plugin threw while linting the fixture:\n${stdout}`)
-    }
-    return [...stdout.matchAll(/^case\.test\.ts:(\d+):\d+: .*guren\(await-async-assertion\)/gm)].map((m) => Number(m[1]))
-  } finally {
-    rmSync(dir, { recursive: true, force: true })
-  }
+  const stdout = lintFixture({ config: { jsPlugins: [plugin], rules: { 'guren/await-async-assertion': 'error' } }, file: 'case.test.ts', source })
+  return [...stdout.matchAll(/^case\.test\.ts:(\d+):\d+: .*guren\(await-async-assertion\)/gm)].map((m) => Number(m[1]))
 }
 
 describe('guren/await-async-assertion', () => {

--- a/packages/cli/tests/oxlint-comments.test.ts
+++ b/packages/cli/tests/oxlint-comments.test.ts
@@ -1,36 +1,18 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { resolve } from 'node:path'
+import { lintFixture } from './helpers'
 
 // Exercised through the real oxlint binary, like await-async-assertion: what has
 // to hold is that the plugin loads and reports on the comments oxlint hands it.
 
-const repoRoot = resolve(import.meta.dir, '../../..')
-const oxlint = join(repoRoot, 'node_modules', '.bin', 'oxlint')
-const plugin = join(repoRoot, 'packages', 'cli', 'src', 'oxlint', 'comments.js')
+const plugin = resolve(import.meta.dir, '../src/oxlint/comments.js')
 const RULES = ['comment-length', 'comment-banner', 'comment-step-label', 'comment-history', 'comment-param-restates']
+const rules = Object.fromEntries(RULES.map((r) => [`guren-comments/${r}`, 'error']))
 
 /** `rule@line` for every finding oxlint reports on `source`, in print order. */
 function findings(source: string, file = 'case.ts'): string[] {
-  const dir = mkdtempSync(join(tmpdir(), 'guren-comment-rules-'))
-  try {
-    const rules = Object.fromEntries(RULES.map((r) => [`guren-comments/${r}`, 'error']))
-    writeFileSync(join(dir, '.oxlintrc.json'), JSON.stringify({ jsPlugins: [plugin], rules }))
-    writeFileSync(join(dir, file), source)
-    const result = Bun.spawnSync([oxlint, '-c', '.oxlintrc.json', '-A', 'all', ...RULES.flatMap((r) => ['-D', `guren-comments/${r}`]), '--format', 'unix', file], {
-      cwd: dir,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    })
-    const stdout = result.stdout.toString()
-    const stderr = result.stderr.toString()
-    if (stderr.trim() !== '') throw new Error(`oxlint wrote to stderr:\n${stderr}`)
-    if (new RegExp(`^${file.replace('.', '\\.')}:0:0:`, 'm').test(stdout)) throw new Error(`the plugin threw while linting the fixture:\n${stdout}`)
-    return [...stdout.matchAll(/^case\.\w+:(\d+):\d+: .*guren-comments\((comment-[a-z-]+)\)/gm)].map((m) => `${m[2]}@${m[1]}`)
-  } finally {
-    rmSync(dir, { recursive: true, force: true })
-  }
+  const stdout = lintFixture({ config: { jsPlugins: [plugin], rules }, file, source })
+  return [...stdout.matchAll(/^case\.\w+:(\d+):\d+: .*guren-comments\((comment-[a-z-]+)\)/gm)].map((m) => `${m[2]}@${m[1]}`)
 }
 
 const LONG = '// l\n'.repeat(6)

--- a/packages/cli/tests/oxlint-export.test.ts
+++ b/packages/cli/tests/oxlint-export.test.ts
@@ -1,44 +1,34 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
+import { assertWorkspaceBuilt, lintFixture, linkWorkspacePackage } from './helpers'
 
 // The `@guren/cli/oxlint` subpath is what an app's .oxlintrc.json names, so it is
 // exercised the way oxlint resolves it: a bare specifier through node_modules,
 // against the built dist (the same boundary the cli tests cross for @guren/server).
 
 const repoRoot = resolve(import.meta.dir, '../../..')
-const oxlint = join(repoRoot, 'node_modules', '.bin', 'oxlint')
-
-function lint(source: string, rules: Record<string, string>): string {
-  const dir = mkdtempSync(join(tmpdir(), 'guren-oxlint-export-'))
-  try {
-    mkdirSync(join(dir, 'node_modules', '@guren'), { recursive: true })
-    symlinkSync(join(repoRoot, 'packages', 'cli'), join(dir, 'node_modules', '@guren', 'cli'))
-    writeFileSync(join(dir, '.oxlintrc.json'), JSON.stringify({ jsPlugins: ['@guren/cli/oxlint'], rules }))
-    writeFileSync(join(dir, 'case.ts'), source)
-    const result = Bun.spawnSync([oxlint, '-c', '.oxlintrc.json', '-A', 'all', ...Object.keys(rules).flatMap((r) => ['-D', r]), '--format', 'unix', 'case.ts'], {
-      cwd: dir,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    })
-    const stderr = result.stderr.toString()
-    if (stderr.trim() !== '') throw new Error(`oxlint wrote to stderr:\n${stderr}`)
-    return result.stdout.toString()
-  } finally {
-    rmSync(dir, { recursive: true, force: true })
-  }
-}
+assertWorkspaceBuilt([join(repoRoot, 'packages/cli/dist/oxlint/index.js')])
 
 describe('@guren/cli/oxlint', () => {
-  test('loads as a bare specifier and carries both rule families under the guren name', () => {
-    const output = lint(
-      `import { expect, test } from 'bun:test'\n// ---- banner ----\ntest('x', async () => {\n  expect(Promise.resolve(1)).resolves.toBe(1)\n})\n`,
-      { 'guren/comment-banner': 'error', 'guren/await-async-assertion': 'error' },
-    )
-    expect(output).toContain('case.ts:2:1:')
-    expect(output).toContain('guren(comment-banner)')
-    expect(output).toContain('case.ts:4:3:')
-    expect(output).toContain('guren(await-async-assertion)')
+  test('loads as a bare specifier and carries both rule families under the guren name', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'guren-oxlint-export-'))
+    try {
+      await linkWorkspacePackage('cli', dir)
+      const output = lintFixture({
+        cwd: dir,
+        config: { jsPlugins: ['@guren/cli/oxlint'], rules: { 'guren/comment-banner': 'error', 'guren/await-async-assertion': 'error' } },
+        file: 'case.ts',
+        source: `import { expect, test } from 'bun:test'\n// ---- banner ----\ntest('x', async () => {\n  expect(Promise.resolve(1)).resolves.toBe(1)\n})\n`,
+      })
+
+      expect(output).toContain('case.ts:2:1:')
+      expect(output).toContain('guren(comment-banner)')
+      expect(output).toContain('case.ts:4:3:')
+      expect(output).toContain('guren(await-async-assertion)')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/scripts/smoke/docs-import-sources.ts
+++ b/scripts/smoke/docs-import-sources.ts
@@ -94,13 +94,9 @@ async function isFile(path: string): Promise<boolean> {
   }
 }
 
-/**
- * The source file an extensionless base path stands for. TypeScript first; a
- * plain `.js` source is a module too (the oxlint plugin under packages/cli must
- * be JavaScript, since oxlint hands plugins to a module loader, not a bundler).
- */
+/** TypeScript first; a plain `.js` source is a module too (the oxlint plugin must be JS). */
 async function firstExistingSource(base: string): Promise<string | null> {
-  for (const candidate of [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts'), `${base}.js`, join(base, 'index.js')]) {
+  for (const candidate of [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts'), `${base}.js`]) {
     if (await isFile(candidate)) {
       return candidate
     }
@@ -148,7 +144,7 @@ export async function collectEntryPoints(root: string): Promise<Map<string, Entr
 
     for (const [subpath, target] of Object.entries(manifest.exports)) {
       const specifier = subpath === '.' ? name : `${name}${subpath.slice(1)}`
-      // `./bin` declares only `default`; every other subpath carries `types`.
+      // `./bin` and `./oxlint` declare only `default`; every other subpath carries `types`.
       const resolvedTarget = typeof target === 'string' ? target : (target.types ?? target.default)
       if (typeof resolvedTarget !== 'string') {
         entryPoints.set(specifier, { specifier, packageDir, kind: 'unresolved', sourceFile: null, target: JSON.stringify(target) })

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -241,6 +241,10 @@ async function assertPackedArtifacts(packageTarballs: Map<string, string>, packR
         assert(distContents.includes('defineGeneratedPage'), '@guren/cli tarball is missing the generated page helper implementation.')
         assert(distContents.includes('PaginatedPageProps'), '@guren/cli tarball is missing paginated resource scaffold support.')
         assert(!distContents.includes("import { definePage } from '@guren/inertia-client'"), '@guren/cli tarball still emits definePage() runtime imports for generated pages.')
+        // The `./oxlint` subpath and the config `add lint` writes ship in the tarball; the
+        // workspace symlink the unit tests resolve through never crosses the `files` boundary.
+        assert(entries.includes('package/dist/oxlint/index.js'), '@guren/cli tarball is missing dist/oxlint/index.js, the @guren/cli/oxlint plugin entry.')
+        assert(entries.includes('package/templates/scaffold/lint/.oxlintrc.json'), '@guren/cli tarball is missing templates/scaffold/lint/.oxlintrc.json for guren add lint.')
       }
 
       if (packageName === 'create-guren-app') {

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -65,6 +65,7 @@ const DEFAULT_BLUEPRINT_FEATURES: readonly (readonly string[])[] = [
   ['resource', 'photos', '--fields', 'title:string,caption:text?', '--attach', 'cover:one,images:many'],
   ['broadcasting'],
   ['schedule'],
+  ['lint'],
 ]
 
 /**
@@ -521,6 +522,9 @@ async function runPublishedDependencyDrift(
     await addDefaultBlueprintFeatures(appDir, runtimeEnv)
     await assertPublishedRanges('after scaffolding features')
     await run(['bun', 'install'], appDir, runtimeEnv)
+    // The lint config names @guren/cli/oxlint, which only the release after the
+    // subpath shipped publishes: the drift this mode exists to catch.
+    await run(['bun', 'run', 'lint'], appDir, runtimeEnv)
     // These keep the typecheck below from quietly shrinking back to a bare app.
     await assertCanonicalScaffolds(appDir)
     await assertFeatureScaffolds(appDir)
@@ -668,7 +672,8 @@ async function main(): Promise<void> {
 
     await run(['bun', 'install'], appDir, runtimeEnv)
 
-    if (blueprint === 'default') {
+    const scaffoldsFeatures = blueprint === 'default'
+    if (scaffoldsFeatures) {
       await addDefaultBlueprintFeatures(appDir, runtimeEnv)
       await assertCoreFirstStarter(appDir, { checkDependencies: false })
       await assertCanonicalScaffolds(appDir)
@@ -717,11 +722,15 @@ async function main(): Promise<void> {
     await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'check', '--ci', ...routesArgs], appDir, runtimeEnv)
     await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'audit', '--no-deps', ...routesArgs], appDir, runtimeEnv)
 
-    // `guren add lint` wires oxlint with the @guren/cli/oxlint plugin. A fresh app has
-    // to lint clean under that preset, or the first `bun run lint` a user sees is red.
-    await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'lint'], appDir, runtimeEnv)
-    await run(['bun', 'install'], appDir, runtimeEnv)
-    await run(['bun', 'run', 'lint'], appDir, runtimeEnv)
+    // `guren add lint` wires oxlint with the @guren/cli/oxlint plugin, resolved through
+    // the app's node_modules. A fresh app has to lint clean under that preset, or the
+    // first `bun run lint` a user sees is red. The binary is the checkout's: a second
+    // `bun install` against the vendored file: dependencies spins Bun 1.3.14 at 100%
+    // CPU indefinitely (three runs, 40 min each), and the peer-range test ties the versions.
+    if (!scaffoldsFeatures) {
+      await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'lint'], appDir, runtimeEnv)
+    }
+    await run(['bun', resolve(repoRoot, 'node_modules/oxlint/bin/oxlint')], appDir, runtimeEnv)
 
     console.log(`\nFresh app smoke passed (${blueprint}, ${installMode}): ${appDir}`)
   } finally {

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -717,6 +717,12 @@ async function main(): Promise<void> {
     await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'check', '--ci', ...routesArgs], appDir, runtimeEnv)
     await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'audit', '--no-deps', ...routesArgs], appDir, runtimeEnv)
 
+    // `guren add lint` wires oxlint with the @guren/cli/oxlint plugin. A fresh app has
+    // to lint clean under that preset, or the first `bun run lint` a user sees is red.
+    await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'add', 'lint'], appDir, runtimeEnv)
+    await run(['bun', 'install'], appDir, runtimeEnv)
+    await run(['bun', 'run', 'lint'], appDir, runtimeEnv)
+
     console.log(`\nFresh app smoke passed (${blueprint}, ${installMode}): ${appDir}`)
   } finally {
     if (keepTemp) {


### PR DESCRIPTION
Stacked on #677 (`@guren/cli/oxlint`); merge that first.

## Summary

- `guren add lint` installs oxlint with the Guren rules into an existing app: an `.oxlintrc.json` loading `@guren/cli/oxlint` (`guren/await-async-assertion` as an error, the `guren/comment-*` rules as warnings, type-aware mode off with the opt-in documented in the file), `lint` / `lint:fix` scripts (`bunx oxlint`, which runs under Bun with no Node install), and `oxlint` as a dev dependency.
- The range an app receives is `@guren/cli`'s own optional peer range on `oxlint` (`~1.81.0`, tilde because oxlint's JS plugin API is alpha and outside its semver), read from the package manifest, so the plugin's host claim and the installed range are one value. A test asserts the root pin satisfies it.
- The manifest is read before the config is written (a missing or malformed `package.json` leaves nothing behind) and existing `lint` scripts / an existing `oxlint` range are left alone.
- The fresh-app smoke runs `add lint` and lints every blueprint; the default and api-only starter templates are also linted through the built plugin in a unit test, so a fresh app cannot ship a red first `bun run lint`.
- The four tests that drive the real oxlint binary share one harness in `tests/helpers.ts`.
- Docs: `guren add lint` in the CLI guide (en/ja) and README. Changeset: `@guren/cli` minor.

## Notes

- The smoke lints with the checkout's oxlint binary rather than a second `bun install`: against the vendored `file:` dependencies, Bun 1.3.14's second install spins at 100% CPU indefinitely (three runs, 40 minutes each). In npm mode the existing post-scaffold install is followed by `bun run lint`, which is red until the release that publishes `@guren/cli/oxlint`, the drift that mode exists to measure.
- Verified with no Node on `PATH` that `bun run lint` (`bunx oxlint`) runs, JS plugin included.
- `smoke:starter` and `smoke:starter:api` pass locally; full cli suite, `bun run lint`, root `typecheck`, `audit:docs`, `audit:agent-catalog`, `audit:workspace-scripts`, `audit:core-first`, `audit:plugin-compat` green.
