### PR TITLE
feat(cli): comments rule and oxlint step in the agent harness

### DIFF
--- a/.changeset/harness-comments-lint.md
+++ b/.changeset/harness-comments-lint.md
@@ -1,0 +1,5 @@
+---
+"@guren/cli": minor
+---
+
+Agent harness: a `comments.md` rule (what a comment may carry, the 5/8-line limits, the `oxlint-disable-next-line` escape), a Comments section in the `code-review` subagent's checklist, and a `check-after-edit` hook that also runs oxlint on the edited file when the app has an `.oxlintrc.json` (`bunx guren add lint`), reporting warnings as well as errors back to the agent. Refresh an installed harness with `bunx guren agent:sync`.

--- a/packages/cli/templates/agent/core/rules-catalog.md
+++ b/packages/cli/templates/agent/core/rules-catalog.md
@@ -1,6 +1,7 @@
 The rule files: `orm-models.md` (models, queries, relations),
 `controllers-http.md` (validation, Inertia, auth), `routes-codegen.md`
 (route options, schema binding, codegen), `testing.md` (TestApp assertions),
-`docs-and-spec.md` (linked ADRs/docs, generated spec views).
+`docs-and-spec.md` (linked ADRs/docs, generated spec views), `comments.md`
+(what a comment may carry, the size limits, the oxlint rules behind them).
 For framework signatures, check the `guren context` digest first, then the
 matching rule file; only read `node_modules/@guren/*` for APIs neither covers.

--- a/packages/cli/templates/agent/core/rules/comments.md
+++ b/packages/cli/templates/agent/core/rules/comments.md
@@ -5,6 +5,8 @@ globs:
   - "**/*.tsx"
   - "**/*.js"
   - "**/*.jsx"
+  - "**/*.mjs"
+  - "**/*.cjs"
 ---
 
 # Comments

--- a/packages/cli/templates/agent/core/rules/comments.md
+++ b/packages/cli/templates/agent/core/rules/comments.md
@@ -1,0 +1,55 @@
+---
+description: Comments — what a comment may carry, the size limits, and the oxlint rules that enforce the mechanical half
+globs:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+---
+
+# Comments
+
+Code shows *how*; a comment carries only what the code cannot: a non-obvious
+constraint, a deliberate deviation, a pitfall or workaround, a unit or range, a
+cross-file sync obligation, a measured number, an RFC or issue reference.
+
+**Do not write**
+- Narration of the next line or block (`// Check the user`, `// Return early`), a
+  name or type restated, section banners (`// ---- helpers ----`), step labels
+- Change history (`used to`, `previously`, `no longer`, "before this PR"): that is
+  the commit message's job and it rots the day it lands
+- `@param`/`@returns` that only repeat the name and type; `@example` that mirrors
+  the signature
+- JSDoc on a private or internal symbol that restates its name
+
+**Size**: a comment block keeps to 5 lines of body, a module header to 8. If a
+block needs more, it is holding more than one fact per line or explaining what
+the code already says. Every distinct fact gets one line; prose around it goes.
+
+**Keep verbatim**: tool directives (`@ts-expect-error`, `eslint-*`, `@vite-ignore`),
+tags the framework reads (`@docs`, `@deprecated`, `guren-audit-ignore`), comments a
+test reads as source text, and comments inside template literals (they are
+generated output, not commentary).
+
+```typescript
+// Bad: restates the code
+// Loop over the items and validate each one
+for (const item of items) validate(item)
+
+// Good: the one fact the code cannot show
+// The API returns at most 100 rows per call regardless of `limit`.
+for (const page of pages(100)) ...
+```
+
+## Enforcement
+
+With `.oxlintrc.json` present (`bunx guren add lint` writes it), the
+`guren/comment-*` oxlint rules check the mechanical half — block length, banners,
+step labels, change-history wording, `@param` tags that restate the name — as
+warnings, so `bun run lint` stays green on them; run it on the file you edited
+and act on what it reports. A block that genuinely must exceed the limit (a test
+pins its text, or every line is a measured fact) carries, on the line above it,
+`// oxlint-disable-next-line guren/comment-length -- <reason>`.
+
+Whether a comment merely narrates the code is a review judgment: check it on
+every diff you review.

--- a/packages/cli/templates/agent/targets/agents/workflow.md
+++ b/packages/cli/templates/agent/targets/agents/workflow.md
@@ -8,7 +8,9 @@ so make them part of your loop:
    APIs — read it before writing any code. With the MCP server connected, the
    `guren_get_context` tool returns the same map.
 2. **After editing** routes, controllers, models, `db/schema.ts`, or pages,
-   run `bunx guren check` and fix what it reports before moving on.
+   run `bunx guren check` and fix what it reports before moving on. With an
+   `.oxlintrc.json` in the app (`bunx guren add lint`), run `bun run lint` on
+   what you edited as well; its warnings are for you to act on.
 3. Framework-managed files (`.agents/rules/`, `.agents/skills/`) can be
    refreshed anytime with `bunx guren agent:sync`.
 

--- a/packages/cli/templates/agent/targets/claude/agents/code-review.md
+++ b/packages/cli/templates/agent/targets/claude/agents/code-review.md
@@ -92,6 +92,13 @@ Review code changes and provide constructive, actionable feedback.
 - [ ] CSRF protection on state-changing routes
 - [ ] Rate limiting on public endpoints
 
+### Comments
+- [ ] Each comment carries what the code cannot show (a constraint, a pitfall, a unit, a sync obligation, a measured number, a reference) — not a restatement of the next line
+- [ ] No section banners, step labels, or change history (`used to`, `previously`, `no longer`)
+- [ ] No `@param`/`@returns` that only repeat the name and type
+- [ ] A block stays within 5 lines (module header 8), or carries an `oxlint-disable-next-line guren/comment-length -- <reason>`
+- [ ] Rules in `.claude/rules/comments.md`; with `.oxlintrc.json` present, `bun run lint` reports the mechanical half
+
 ### Testing
 - [ ] Tests added for new functionality
 - [ ] Edge cases covered

--- a/packages/cli/templates/agent/targets/claude/hooks/check-after-edit.ts
+++ b/packages/cli/templates/agent/targets/claude/hooks/check-after-edit.ts
@@ -8,7 +8,7 @@
  * Exit codes: 0 = ok / not applicable, 2 = findings reported back to the agent.
  */
 import { existsSync, realpathSync } from 'node:fs'
-import { dirname, join, relative } from 'node:path'
+import { dirname, isAbsolute, join, relative, sep } from 'node:path'
 
 interface HookInput {
   tool_input?: {
@@ -44,8 +44,10 @@ function real(path: string): string {
   }
 }
 
-const relPath = relative(real(process.cwd()), real(filePath))
-if (relPath === '' || relPath.startsWith('..')) {
+// POSIX separators so the prefix lists below match on Windows too; `relative()`
+// yields an absolute path across drives there, which is outside the project.
+const relPath = relative(real(process.cwd()), real(filePath)).split(sep).join('/')
+if (relPath === '' || isAbsolute(relPath) || relPath === '..' || relPath.startsWith('../')) {
   process.exit(0)
 }
 
@@ -85,11 +87,14 @@ function resolveOxlint(): string | null {
 // One file, through the shim under Bun (no Node needed). Warnings are reported
 // too: the comment rules are warnings so `bun run lint` stays green, and the
 // agent that just wrote the comment is the one who can fix it.
-const oxlint = LINTABLE.test(relPath) && !UNLINTED_PREFIXES.some((prefix) => relPath.startsWith(prefix)) && existsSync('.oxlintrc.json')
-  ? resolveOxlint()
-  : null
+const lintable = LINTABLE.test(relPath) && !UNLINTED_PREFIXES.some((prefix) => relPath.startsWith(prefix)) && existsSync('.oxlintrc.json')
+const oxlint = lintable ? resolveOxlint() : null
+if (lintable && oxlint === null) {
+  findings.push('.oxlintrc.json is present but oxlint is not installed: run `bun install`')
+}
 if (oxlint !== null) {
-  const result = Bun.spawnSync([process.execPath, oxlint, '--format', 'unix', relPath], { stdout: 'pipe', stderr: 'pipe' })
+  // A file the config ignores is "no files to lint", not a failure.
+  const result = Bun.spawnSync([process.execPath, oxlint, '--no-error-on-unmatched-pattern', '--format', 'unix', relPath], { stdout: 'pipe', stderr: 'pipe' })
   const stdout = result.stdout.toString()
   const lines = stdout.split('\n').filter((line) => line.startsWith(`${relPath}:`))
   if (lines.length > 0) {

--- a/packages/cli/templates/agent/targets/claude/hooks/check-after-edit.ts
+++ b/packages/cli/templates/agent/targets/claude/hooks/check-after-edit.ts
@@ -1,12 +1,14 @@
 #!/usr/bin/env bun
 /**
- * PostToolUse hook: after an agent edits routes, controllers, models, schema,
- * or pages, run `guren check` and feed failures back so they get fixed
+ * PostToolUse hook: after an agent edits a file, run `guren check` (for routes,
+ * controllers, models, schema, and pages) and oxlint (for any source file, when
+ * the app has an .oxlintrc.json) and feed findings back so they get fixed
  * immediately instead of surfacing later in CI.
  *
- * Exit codes: 0 = ok / not applicable, 2 = failures reported back to the agent.
+ * Exit codes: 0 = ok / not applicable, 2 = findings reported back to the agent.
  */
-import { relative } from 'node:path'
+import { existsSync, realpathSync } from 'node:fs'
+import { dirname, join, relative } from 'node:path'
 
 interface HookInput {
   tool_input?: {
@@ -22,6 +24,9 @@ const WATCHED_PATHS = [
   'db/schema.ts',
 ]
 
+const LINTABLE = /\.(?:ts|tsx|js|jsx|mjs|cjs)$/u
+const UNLINTED_PREFIXES = ['.guren/', 'node_modules/', 'dist/', 'public/build/']
+
 let filePath = ''
 try {
   const input = JSON.parse(await Bun.stdin.text()) as HookInput
@@ -30,34 +35,74 @@ try {
   process.exit(0)
 }
 
-const relPath = relative(process.cwd(), filePath)
-if (!WATCHED_PATHS.some((prefix) => relPath.startsWith(prefix))) {
+/** Both sides resolved: on macOS `process.cwd()` is the real `/private/var/...` while the editor hands over `/var/...`. */
+function real(path: string): string {
+  try {
+    return realpathSync(path)
+  } catch {
+    return path
+  }
+}
+
+const relPath = relative(real(process.cwd()), real(filePath))
+if (relPath === '' || relPath.startsWith('..')) {
   process.exit(0)
 }
+
+const findings: string[] = []
 
 // Run the check in-process: this hook fires on every watched edit, and
 // spawning bunx + the CLI would cost a few hundred ms per edit. `changed:
 // true` restricts file-scanning checks (empty methods, architecture
 // boundaries) to what's actually changed, so this stays fast as the app
 // grows — it falls back to checking everything outside a git repo.
-let report
-try {
-  const { runCheck } = await import('@guren/cli')
-  report = await runCheck({ changed: true })
-} catch {
-  process.exit(0)
+if (WATCHED_PATHS.some((prefix) => relPath.startsWith(prefix))) {
+  try {
+    const { runCheck } = await import('@guren/cli')
+    const report = await runCheck({ changed: true })
+    if (report.failCount > 0) {
+      findings.push(`guren check found ${report.failCount} issue(s):`)
+      for (const check of report.checks.filter((check) => check.status === 'fail')) {
+        const location = check.filePath ? ` [${check.filePath}]` : ''
+        const suggestion = check.suggestion ? ` → ${check.suggestion}` : ''
+        findings.push(`- ${check.title}: ${check.message}${location}${suggestion}`)
+      }
+    }
+  } catch {
+    // no @guren/cli resolvable from here: nothing to check with
+  }
 }
 
-if (report.failCount > 0) {
-  const failures = report.checks.filter((check) => check.status === 'fail')
-  const lines = failures.map((check) => {
-    const location = check.filePath ? ` [${check.filePath}]` : ''
-    const suggestion = check.suggestion ? ` → ${check.suggestion}` : ''
-    return `- ${check.title}: ${check.message}${location}${suggestion}`
-  })
-  console.error(
-    `guren check found ${report.failCount} issue(s) after editing ${relPath}:\n${lines.join('\n')}`,
-  )
+/** The oxlint shim, wherever the install put it: a workspace may hoist it to an ancestor. */
+function resolveOxlint(): string | null {
+  for (let dir = process.cwd(); ; dir = dirname(dir)) {
+    const candidate = join(dir, 'node_modules', 'oxlint', 'bin', 'oxlint')
+    if (existsSync(candidate)) return candidate
+    if (dirname(dir) === dir) return null
+  }
+}
+
+// One file, through the shim under Bun (no Node needed). Warnings are reported
+// too: the comment rules are warnings so `bun run lint` stays green, and the
+// agent that just wrote the comment is the one who can fix it.
+const oxlint = LINTABLE.test(relPath) && !UNLINTED_PREFIXES.some((prefix) => relPath.startsWith(prefix)) && existsSync('.oxlintrc.json')
+  ? resolveOxlint()
+  : null
+if (oxlint !== null) {
+  const result = Bun.spawnSync([process.execPath, oxlint, '--format', 'unix', relPath], { stdout: 'pipe', stderr: 'pipe' })
+  const stdout = result.stdout.toString()
+  const lines = stdout.split('\n').filter((line) => line.startsWith(`${relPath}:`))
+  if (lines.length > 0) {
+    findings.push(`oxlint found ${lines.length} issue(s):`)
+    findings.push(...lines.map((line) => `- ${line}`))
+  } else if (result.exitCode !== 0) {
+    // A config or plugin-load failure has no file prefix; it must not read as clean.
+    findings.push(`oxlint exited ${result.exitCode} without linting ${relPath}:\n${stdout}${result.stderr.toString()}`.trimEnd())
+  }
+}
+
+if (findings.length > 0) {
+  console.error(`After editing ${relPath}:\n${findings.join('\n')}`)
   process.exit(2)
 }
 

--- a/packages/cli/templates/agent/targets/claude/settings.json
+++ b/packages/cli/templates/agent/targets/claude/settings.json
@@ -4,6 +4,7 @@
       "Bash(bunx guren:*)",
       "Bash(bun run codegen:*)",
       "Bash(bun run typecheck:*)",
+      "Bash(bun run lint:*)",
       "Bash(bun test:*)"
     ]
   },

--- a/packages/cli/templates/agent/targets/claude/workflow.md
+++ b/packages/cli/templates/agent/targets/claude/workflow.md
@@ -1,8 +1,9 @@
 This project ships with an agent harness wired into `.claude/settings.json`:
 a `SessionStart` hook injects the `guren context` project map, and a
 `PostToolUse` hook (`.claude/hooks/check-after-edit.ts`) re-runs `guren check`
-after edits to routes, controllers, models, schema, or pages and reports
-failures back immediately. The injected map ends with a "Guren API Signatures"
+after edits to routes, controllers, models, schema, or pages, and runs oxlint on
+the edited file when the app has an `.oxlintrc.json` (`bunx guren add lint`
+writes one; warnings are reported too), feeding findings back immediately. The injected map ends with a "Guren API Signatures"
 digest of the ORM, controller, and testing APIs — those signatures are already
 in your context before you write any code. Framework-managed files
 (`.claude/rules`, `skills`, `agents`, `hooks`) can be refreshed anytime with

--- a/packages/cli/tests/agent-hook-lint.test.ts
+++ b/packages/cli/tests/agent-hook-lint.test.ts
@@ -12,11 +12,13 @@ const hook = join(repoRoot, 'packages/cli/templates/agent/targets/claude/hooks/c
 // A built-in rule keeps the test independent of which plugin the app configures.
 const CONFIG = JSON.stringify({ rules: { 'no-debugger': 'warn' } })
 
-function runHook(app: (dir: string) => void, editedFile: string): { exitCode: number; stderr: string } {
+function runHook(app: (dir: string) => void, editedFile: string, options: { installed?: boolean } = {}): { exitCode: number; stderr: string } {
   const dir = mkdtempSync(join(tmpdir(), 'guren-hook-lint-'))
   try {
-    mkdirSync(join(dir, 'node_modules'), { recursive: true })
-    symlinkSync(join(repoRoot, 'node_modules', 'oxlint'), join(dir, 'node_modules', 'oxlint'), 'dir')
+    if (options.installed !== false) {
+      mkdirSync(join(dir, 'node_modules'), { recursive: true })
+      symlinkSync(join(repoRoot, 'node_modules', 'oxlint'), join(dir, 'node_modules', 'oxlint'), 'dir')
+    }
     app(dir)
     const result = Bun.spawnSync([process.execPath, hook], {
       cwd: dir,
@@ -63,6 +65,26 @@ describe('check-after-edit hook: oxlint', () => {
 
     expect(result.exitCode).toBe(2)
     expect(result.stderr).toContain('without linting lib.ts')
+  })
+
+  test('a file the config ignores is not a failure', () => {
+    expect(
+      runHook((dir) => {
+        writeFileSync(join(dir, '.oxlintrc.json'), JSON.stringify({ ignorePatterns: ['gen/**'], rules: { 'no-debugger': 'warn' } }))
+        mkdirSync(join(dir, 'gen'))
+        writeFileSync(join(dir, 'gen', 'x.ts'), FLAGGED_FILE)
+      }, 'gen/x.ts').exitCode,
+    ).toBe(0)
+  })
+
+  test('a config without an installed oxlint asks for bun install', () => {
+    const result = runHook((dir) => {
+      writeFileSync(join(dir, '.oxlintrc.json'), CONFIG)
+      writeFileSync(join(dir, 'lib.ts'), FLAGGED_FILE)
+    }, 'lib.ts', { installed: false })
+
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('run `bun install`')
   })
 
   test('skips generated and non-source paths', () => {

--- a/packages/cli/tests/agent-hook-lint.test.ts
+++ b/packages/cli/tests/agent-hook-lint.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+// The shipped hook, run the way Claude Code runs it: `bun <hook>` with the tool
+// input on stdin, from the app root. The app has no @guren/cli here, so only the
+// oxlint half is exercised; `guren check` is covered by its own tests.
+
+const repoRoot = resolve(import.meta.dir, '../../..')
+const hook = join(repoRoot, 'packages/cli/templates/agent/targets/claude/hooks/check-after-edit.ts')
+// A built-in rule keeps the test independent of which plugin the app configures.
+const CONFIG = JSON.stringify({ rules: { 'no-debugger': 'warn' } })
+
+function runHook(app: (dir: string) => void, editedFile: string): { exitCode: number; stderr: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'guren-hook-lint-'))
+  try {
+    mkdirSync(join(dir, 'node_modules'), { recursive: true })
+    symlinkSync(join(repoRoot, 'node_modules', 'oxlint'), join(dir, 'node_modules', 'oxlint'), 'dir')
+    app(dir)
+    const result = Bun.spawnSync([process.execPath, hook], {
+      cwd: dir,
+      stdin: Buffer.from(JSON.stringify({ tool_input: { file_path: join(dir, editedFile) } })),
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    return { exitCode: result.exitCode, stderr: result.stderr.toString() }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+const FLAGGED_FILE = 'debugger\nexport const a = 1\n'
+
+describe('check-after-edit hook: oxlint', () => {
+  test('reports findings on the edited file, warnings included, and exits 2', () => {
+    const result = runHook((dir) => {
+      writeFileSync(join(dir, '.oxlintrc.json'), CONFIG)
+      writeFileSync(join(dir, 'lib.ts'), FLAGGED_FILE)
+    }, 'lib.ts')
+
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('oxlint found 1 issue(s)')
+    expect(result.stderr).toContain('lib.ts:1:1:')
+    expect(result.stderr).toContain('eslint(no-debugger)')
+  })
+
+  test('stays quiet without an .oxlintrc.json, and on a clean file', () => {
+    expect(runHook((dir) => writeFileSync(join(dir, 'lib.ts'), FLAGGED_FILE), 'lib.ts').exitCode).toBe(0)
+    expect(
+      runHook((dir) => {
+        writeFileSync(join(dir, '.oxlintrc.json'), CONFIG)
+        writeFileSync(join(dir, 'lib.ts'), 'export const a = 1\n')
+      }, 'lib.ts').exitCode,
+    ).toBe(0)
+  })
+
+  test('a config that fails to load is reported, not read as clean', () => {
+    const result = runHook((dir) => {
+      writeFileSync(join(dir, '.oxlintrc.json'), JSON.stringify({ jsPlugins: ['./missing-plugin.js'] }))
+      writeFileSync(join(dir, 'lib.ts'), FLAGGED_FILE)
+    }, 'lib.ts')
+
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('without linting lib.ts')
+  })
+
+  test('skips generated and non-source paths', () => {
+    expect(
+      runHook((dir) => {
+        writeFileSync(join(dir, '.oxlintrc.json'), CONFIG)
+        mkdirSync(join(dir, '.guren'))
+        writeFileSync(join(dir, '.guren', 'routes.gen.ts'), FLAGGED_FILE)
+              }, '.guren/routes.gen.ts').exitCode,
+    ).toBe(0)
+  })
+})


### PR DESCRIPTION
Independent of #677 / #679 (branches from `main`); the hook's oxlint step activates only once an app has an `.oxlintrc.json`, which `guren add lint` (#679) writes.

## Summary

- New harness rule `core/rules/comments.md`: what a comment may carry, the 5/8-line limits, the keep-verbatim list, and the `oxlint-disable-next-line guren/comment-length -- <reason>` escape. Listed in the rules catalog; target-neutral (no hook promises in the shared rule).
- `code-review` subagent checklist gains a Comments section.
- `check-after-edit.ts` (Claude target) also runs oxlint on the edited source file when the app has an `.oxlintrc.json`, through the shim under Bun (no Node needed), reporting warnings as well as errors; a config or plugin that fails to load is reported instead of reading as clean. The shim is found by walking ancestor `node_modules`, so a hoisted workspace install works.
- Fix carried by the same hook change: both the working directory and the edited path are resolved to real paths before the "inside the project" check. On macOS the editor hands over `/var/...` while `process.cwd()` is `/private/var/...`, so the old comparison skipped every edit silently.
- `settings.json` allows `bun run lint`; both workflow texts mention the lint step. Changeset: `@guren/cli` minor. Installed harnesses pick this up with `bunx guren agent:sync`.

## Verification

- New `packages/cli/tests/agent-hook-lint.test.ts` runs the shipped hook as Claude Code does (`bun <hook>`, tool input on stdin, from the app root): findings incl. warnings → exit 2 with the lines; no config or clean file → exit 0; unloadable config → exit 2 with oxlint's output; generated paths skipped. Uses a built-in rule so it does not depend on #677.
- Full cli suite, `bun run lint`, `typecheck:templates`, `audit:agent-catalog`, `audit:docs`, `audit:core-first`, `audit:workspace-scripts` green.
