### PR TITLE
fix(cli): declare pages-out and audit-config with their documented spelling

### DIFF
--- a/.changeset/cli-kebab-string-flag-declarations.md
+++ b/.changeset/cli-kebab-string-flag-declarations.md
@@ -1,0 +1,21 @@
+---
+'@guren/cli': patch
+---
+
+Declare the three remaining camelCase CLI flags with the kebab-case spelling the
+docs already use, so `--help` and the docs agree.
+
+`routes:types` and `codegen` declared `pagesOut`, and `audit` declared
+`auditConfig`. citty registers only the *declared* arg name, so `renderUsage`
+advertised `--pagesOut` and `--auditConfig` while the comments and docs refer to
+`--pages-out` and `--audit-config`. They are now declared `'pages-out'` and
+`'audit-config'`, matching how `token:issue` declares `'read-only'` and
+`'allow-unmatched'`.
+
+Unlike the boolean rename this fixes no parsing bug: these are string args, and
+citty's args proxy resolves either spelling to the other in both directions, so
+`--pagesOut` and `--pages-out` reach the command identically before and after.
+Only the usage line changes.
+
+Aliases are deliberately not used for this — `renderUsage` renders an alias
+single-dashed, so `alias: 'pages-out'` would print `-pages-out, --pagesOut`.

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -1046,7 +1046,7 @@ const routeTypesCommand = defineCommand({
       description: 'Frontend pages directory to scan for page contracts',
       valueHint: 'resources/js/pages',
     },
-    pagesOut: {
+    'pages-out': {
       type: 'string',
       description: 'Runtime page manifest module to write',
       valueHint: '.guren/pages.gen.ts',
@@ -1062,7 +1062,7 @@ const routeTypesCommand = defineCommand({
     const { outputPath: pagesOutputPath, plan: pagesPlan } = await generatePageTypes({
       appRoot: args.app,
       pagesDir: args.pages,
-      outputFile: args.pagesOut,
+      outputFile: args['pages-out'],
       ...writerOptions,
     })
     const { outputPath, runtimeOutputPath } = await generateRouteTypes({
@@ -1100,7 +1100,7 @@ const codegenCommand = defineCommand({
       generatePageTypes({
         appRoot: args.app,
         pagesDir: args.pages,
-        outputFile: args.pagesOut,
+        outputFile: args['pages-out'],
         extractProps: true,
         ...writerOptions,
       }),
@@ -2480,7 +2480,7 @@ const auditCommand = defineCommand({
       type: 'string',
       description: 'Application root directory.',
     },
-    auditConfig: {
+    'audit-config': {
       type: 'string',
       description: 'Path to the ignore config (defaults to config/audit.{ts,js,mjs}).',
     },
@@ -2494,7 +2494,7 @@ const auditCommand = defineCommand({
     const report = await runAudit({
       cwd: args.app,
       routesFile: args.routes,
-      auditConfigFile: args.auditConfig,
+      auditConfigFile: args['audit-config'],
       deps: args.deps,
     })
 

--- a/packages/cli/tests/define-command.test.ts
+++ b/packages/cli/tests/define-command.test.ts
@@ -115,8 +115,9 @@ describe('built-in commands', () => {
 
   it('declare every arg with the spelling citty registers', async () => {
     // A camelCase declaration makes `renderUsage` advertise `--dryRun` while the
-    // docs say `--dry-run`, and the documented spelling then arrives as the
-    // truthy string `"false"` instead of parsing. Aliases are exempt:
+    // docs say `--dry-run`. For a boolean the documented spelling then arrives as
+    // the truthy string `"false"` instead of parsing; for a string citty's proxy
+    // resolves either way and only the usage line is wrong. Aliases are exempt:
     // `renderUsage` renders them single-dashed, so a kebab alias prints worse.
     const camelCased: string[] = []
     for (const [path, command] of await everyCommand(builtinSubCommands as Record<string, CommandDef<never>>)) {
@@ -124,10 +125,7 @@ describe('built-in commands', () => {
         if (/[A-Z]/u.test(name)) camelCased.push(`${path} --${name}`)
       }
     }
-    // Frozen rather than empty so a new camelCase arg fails here. These three are
-    // known and milder than a boolean: citty's Proxy resolves the kebab spelling
-    // of a string either way, so only the usage line contradicts the docs.
-    expect(camelCased).toEqual(['routes:types --pagesOut', 'codegen --pagesOut', 'audit --auditConfig'])
+    expect(camelCased).toEqual([])
   })
 
   it('all define themselves through the wrapper, nested ones included', async () => {

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "codegen": "bun run prerender:stub && cd .. && bun packages/cli/src/bin.ts codegen --app web --routes routes/web.ts --out types/generated/routes.d.ts --pages resources/js/pages --pagesOut .guren/pages.gen.ts --force",
+    "codegen": "bun run prerender:stub && cd .. && bun packages/cli/src/bin.ts codegen --app web --routes routes/web.ts --out types/generated/routes.d.ts --pages resources/js/pages --pages-out .guren/pages.gen.ts --force",
     "routes:types": "bun run codegen",
     "prerender": "bun scripts/copy-docs-images.ts && bun scripts/prerender-docs.ts && bun scripts/prerender-docs-viewer.ts",
     "prerender:stub": "bun scripts/copy-docs-images.ts && bun scripts/prerender-docs.ts --stub && bun scripts/build-search-index.ts --stub",


### PR DESCRIPTION
Follow-up to #678: that PR renamed the camelCase **boolean** flags, this one closes out the three remaining **string** args.

citty registers only the *declared* arg name, so `renderUsage` advertised `--pagesOut` (on `routes:types`, and on `codegen`, which reuses its `args`) and `--auditConfig`, while the comments and docs refer to `--pages-out` and `--audit-config`.

They are now declared `'pages-out'` and `'audit-config'`, matching how `token:issue` declares `'read-only'` and `'allow-unmatched'`, and read under those keys. An alias is not the fix: `renderUsage` renders aliases single-dashed, so `alias: 'pages-out'` would print `-pages-out, --pagesOut`.

### No parsing bug here, unlike the boolean case

These are string args, and citty's args proxy resolves one spelling to the other **in both directions**. Verified by driving `routes:types` end to end with each spelling against a kebab declaration — both write the destination they name:

```
custom/camel.gen.ts   # written by --pagesOut
custom/kebab.gen.ts   # written by --pages-out
```

So no caller regresses, and only the usage line moves:

```
--pages-out=<.guren/pages.gen.ts>    Runtime page manifest module to write
--audit-config                       Path to the ignore config (defaults to config/audit.{ts,js,mjs}).
```

### Also in this PR

- `web/package.json`'s `codegen` script passed `--pagesOut` and now passes `--pages-out`. It kept working either way — consistency, not a fix.
- The frozen list in `define-command.test.ts` held these three as known exceptions. It is now `[]`, so any new camelCase arg fails there.

### Gates

`lint`, `build:clean`, `typecheck`, `bun test packages/cli/tests` (2077 pass / 0 fail), `audit:agent-catalog` — all green, re-run after rebasing onto main. No template or scaffold file is touched, so the starter-template audits are not in scope.

Changeset: `@guren/cli` patch.