### PR TITLE
fix(cli): print a tool:dev Inspector invocation that runs as printed

### DIFF
--- a/.changeset/tool-dev-inspector-invocation.md
+++ b/.changeset/tool-dev-inspector-invocation.md
@@ -1,0 +1,7 @@
+---
+"@guren/cli": patch
+---
+
+Print an MCP Inspector invocation `tool:dev` users can actually run
+
+The command printed `npx @modelcontextprotocol/inspector --cli <endpoint> --transport http --header "Authorization: Bearer <token>"`, which exits on `Method is required` because `--cli` mode has no default method. It now prints `--method tools/list`, pins the spec with `@latest` so the resolution does not fall to whatever version the npx cache already holds, shows the `tools/call` tail, and mentions that dropping `--cli` opens the browser Inspector UI.

--- a/packages/cli/src/tool-dev.ts
+++ b/packages/cli/src/tool-dev.ts
@@ -203,10 +203,21 @@ export async function runToolDev(options: ToolDevOptions = {}): Promise<ToolDevS
 
   consola.success(`App MCP endpoint is live at ${endpoint}`)
   consola.log('')
-  consola.log('Connect the MCP Inspector:')
+  consola.log('List the tools with the MCP Inspector:')
   consola.log('')
-  consola.log(`  npx @modelcontextprotocol/inspector --cli ${endpoint} \\`)
-  consola.log(`    --transport http --header "Authorization: Bearer ${plainTextToken}"`)
+  // `@latest` pins the resolution rather than accepting whatever the npx cache already holds.
+  // `--cli` mode requires `--method`; without it the Inspector exits on "Method is required".
+  // `--transport http` stays explicit because `--path` can move the endpoint off the `/mcp`
+  // the Inspector would otherwise auto-detect the transport from.
+  consola.log(`  npx @modelcontextprotocol/inspector@latest --cli ${endpoint} \\`)
+  consola.log(`    --transport http --header "Authorization: Bearer ${plainTextToken}" \\`)
+  consola.log('    --method tools/list')
+  consola.log('')
+  consola.log('Call one by swapping that last line, with a name from `guren tool:list`:')
+  consola.log('    --method tools/call --tool-name <name> --tool-arg key=value')
+  consola.log('')
+  consola.log('Or drop --cli for the browser Inspector UI, which takes the URL and token in')
+  consola.log('its own form and needs no --method.')
   consola.log('')
   consola.log('Or paste this into a client that takes a bearer token:')
   consola.log(`  URL:   ${endpoint}`)

--- a/packages/cli/tests/tool-dev.test.ts
+++ b/packages/cli/tests/tool-dev.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test'
 import { mkdir, symlink, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
+import { consola } from 'consola'
 import { createTempWorkspace, linkWorkspaceCore, type TempWorkspace } from './helpers'
 import { runToolDev } from '../src/tool-dev'
 
@@ -106,6 +107,7 @@ describe('tool:dev', () => {
   let workspace: TempWorkspace
   let appDir: string
   let logSpy: ReturnType<typeof spyOn>
+  let consolaSpy: ReturnType<typeof spyOn>
   const originalNodeEnv = process.env.NODE_ENV
 
   beforeEach(async () => {
@@ -116,10 +118,14 @@ describe('tool:dev', () => {
     await mkdir(join(appDir, 'src'), { recursive: true })
     await writeFile(join(appDir, 'routes/web.ts'), ROUTES)
     logSpy = spyOn(console, 'log').mockImplementation(() => {})
+    // consola.log bypasses console.log here, so the command's own output needs
+    // its own spy. LogFn carries a `raw` sibling, so a bare arrow is not one.
+    consolaSpy = spyOn(consola, 'log').mockImplementation(Object.assign(() => {}, { raw: () => {} }))
   })
 
   afterEach(async () => {
     logSpy.mockRestore()
+    consolaSpy.mockRestore()
     if (originalNodeEnv === undefined) delete process.env.NODE_ENV
     else process.env.NODE_ENV = originalNodeEnv
     await workspace.cleanup()
@@ -217,6 +223,25 @@ describe('tool:dev', () => {
       appStore: { size: number }
     }
     expect(module.appStore.size).toBe(0)
+  })
+
+  it('prints an Inspector invocation that works as printed', async () => {
+    await writeFile(join(appDir, 'src/main.ts'), MAIN_WITH_PLUGIN)
+    const session = await runToolDev({ appRoot: appDir, port: ANY_PORT })
+
+    // Line continuations rejoined: what has to be complete is the command, not
+    // any single printed line of it.
+    const printed = consolaSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join('\n')
+      .replace(/\s*\\\n\s*/gu, ' ')
+
+    // `--cli` exits on "Method is required" without `--method`, and an unpinned
+    // spec runs whatever version the npx cache already happens to hold.
+    expect(printed).toContain(
+      `npx @modelcontextprotocol/inspector@latest --cli ${session.endpoint} --transport http `
+        + `--header "Authorization: Bearer ${session.token}" --method tools/list`,
+    )
   })
 
   it('says which user tool calls authenticate as', async () => {


### PR DESCRIPTION
## Summary

`guren tool:dev` printed an MCP Inspector invocation that does not work when copy-pasted:

```
npx @modelcontextprotocol/inspector --cli <endpoint> \
  --transport http --header "Authorization: Bearer <token>"
```

Two defects, both verified against a real scaffolded app on `@guren/cli` 2.15.0:

1. **No `--method`.** The Inspector's `--cli` mode has no default method, so running the command exactly as printed exits with `{"error":{"code":"error","message":"Method is required. Use --method to specify the method to invoke."}}`. The whole point of printing an invocation is that it runs.
2. **Unpinned spec.** `npx` treats a bare package name as `*`, so any version already in the npx cache satisfies it — a machine holding a stale v1 silently runs the deprecated v1 rather than the current release. (The registry default is not the problem: `dist-tags.latest` is 2.5.0. `@latest` pins the resolution instead of accepting the cache.)

The command now prints:

```
List the tools with the MCP Inspector:

  npx @modelcontextprotocol/inspector@latest --cli http://127.0.0.1:3333/mcp \
    --transport http --header "Authorization: Bearer <token>" \
    --method tools/list

Call one by swapping that last line, with a name from `guren tool:list`:
    --method tools/call --tool-name <name> --tool-arg key=value

Or drop --cli for the browser Inspector UI, which takes the URL and token in
its own form and needs no --method.
```

`--transport http` stays explicit even though the Inspector auto-detects it from a `/mcp` URL: `--path` can move the endpoint off `/mcp`.

Every flag was checked against `npx @modelcontextprotocol/inspector@latest --cli --help` rather than from memory.

## Scope

- `cli` — `packages/cli/src/tool-dev.ts` (printed output only), `packages/cli/tests/tool-dev.test.ts`
- changeset: `@guren/cli` patch

No docs change: neither `docs/en/guides/cli.md` nor `docs/ja/guides/cli.md` prints the invocation, and RFC 0016 §6 only says the command "prints the official MCP Inspector invocation" — both remain accurate.

## Risk Assessment

Output text only. No behavior change to the endpoint, the token, or `runToolDev`'s return value, so nothing programmatic depends on what changed. No test asserted the printed text before this PR, which is why the defect shipped; one now does.

## Validation

No test covered the printed command, so this adds one. It rejoins the line continuations and asserts the invocation as a single command, because what has to be complete is the command rather than any one printed line. Mutation-checked: deleting the `--method tools/list` line turns it red.

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test:bun cli` — `tool-dev.test.ts` 8 pass, 0 fail
- [x] `bun run lint`

Starter smokes and `audit:starter-template` were skipped locally: no template under `packages/create-app/templates/**` or `packages/cli/templates/**` is touched. CI runs them anyway and they are green.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation. (None needed — see Scope.)
