### PR TITLE
feat(plugin-agents): pending-approval ledger and scheduled retry (RFC 0017 Part 3)

### DIFF
--- a/.changeset/agent-approval-status-shared.md
+++ b/.changeset/agent-approval-status-shared.md
@@ -1,0 +1,32 @@
+---
+'@guren/server': minor
+'@guren/core': minor
+---
+
+Share the approval-status rule and the audit recorder across agent surfaces
+
+`toApprovalStatusReport`, `approvalStatusNotFoundMessage` and the
+`ApprovalStatusReport` / `ApprovalStatusOutcome` types move out of
+`@guren/plugin-mcp` and into the framework, so every surface that answers "what
+became of this approval request" answers it the same way — including the part
+that is a *refusal* to distinguish: an unknown request id and another
+principal's request id produce one message, byte for byte, because any
+difference between them turns the check into a way to enumerate other
+principals' pending actions. The found/not-found distinction stays in the audit
+trail, where the operator can see it.
+
+`ApprovalStatusReport` also gains **`consumedAt`**, present once an approval has
+been spent (MCP advertises it as an additive output property). "Approved" alone
+does not say whether the one call it permitted has already run, and a caller that
+repeats a spent approval finds no unconsumed match, files a fresh request, pages
+a human again, and performs the action a second time. The field is what lets a
+caller tell "approved, go ahead" from "approved, and already used".
+
+`createAgentAuditRecorder(options)` is extracted from the invocation pipeline
+and exported alongside it. A surface that reaches the approval store without
+dispatching a tool still has to write a record under the same principal, the
+same `surface`, and the same argument masking; a second copy of that is how one
+surface comes to record a field the other redacts.
+
+No behavior changes for existing callers. `@guren/plugin-mcp` imports the moved
+helpers and keeps its own MCP schema and tool description.

--- a/.changeset/agents-pending-approval-ledger.md
+++ b/.changeset/agents-pending-approval-ledger.md
@@ -1,0 +1,66 @@
+---
+'@guren/plugin-agents': minor
+---
+
+Retry a call automatically once a human approves it (RFC 0017 Part 3)
+
+A tool declaring `approval: 'required'` refuses the first call and files a
+request for a human, and until now an agent got the request id and was on its
+own. The approval queue cannot help: it stores only redacted input and a
+non-reversible fingerprint, so it can neither return the arguments nor repeat
+the call.
+
+`GurenAgent` now owns the retry material. A parked call is checkpointed into a
+private table in the agent's own Durable Object SQLite before the result is
+returned, and a `checkPendingApprovals` schedule is created — 30 seconds,
+doubling per check, capped at the request's expiry. On each wake the agent asks
+the queue about every parked call: `approved` repeats the original call with the
+stored arguments, so the queue's consume-on-use and fingerprint match spend
+exactly the approval that was granted; `rejected` and `expired` rows are pruned.
+
+```ts
+export class Ops extends GurenAgent<Env, OpsState> {
+  async retire(id: number) {
+    const result = await this.tools.call('posts.destroy', { id })
+    if (result.pending) return   // parked; the retry is scheduled for you
+  }
+
+  onToolApprovalSettled(event: AgentToolApprovalSettled) {
+    if (event.status === 'approved') { /* event.result holds the retry's answer */ }
+  }
+}
+```
+
+- **`onToolApprovalSettled(event)`** is overridable and a no-op by default.
+  `status` is the approval's outcome (`approved`, `rejected`, `expired`, or
+  `unknown` for a request the queue no longer has); `result` is the retry's own
+  answer, which can itself be a refusal when another caller spent the approval
+  first.
+- **Nothing is held in memory.** State and schedules are both durable, so an
+  eviction between the request and the approval loses nothing.
+- **No encrypter, no ledger.** Ledger rows are encrypted with the app key at
+  rest, which is what makes holding raw arguments acceptable at all. An
+  application without `EncryptionServiceProvider` and `APP_KEY` is warned at
+  boot and gets no ledger: a parked call is still reported with its `requestId`,
+  it is simply never retried automatically.
+- **The sweep cannot throw.** The Agents SDK retries a failed scheduled callback
+  three times and then drops the schedule, so one bad row would replay the whole
+  sweep and then leave every surviving row with no wake at all. Each row is
+  handled on its own, a hook that throws is reported and swallowed, a row naming
+  a route a deploy removed is kept and counted, and a row no current key can
+  decrypt is pruned and reported as `status: 'unreadable'` rather than taking
+  down the sweep — and with it the record path, which reads the same rows to
+  pick its next wake.
+- **An approval found already spent settles without calling anything.** If a
+  sweep is interrupted after the retry ran but before its row was cleared, the
+  next one settles with `status: 'approved'` and no `result`. Repeating the call
+  there would file a fresh request, page a human again, and perform the action
+  twice.
+- **A retry refused for want of budget keeps its row**, rather than spending a
+  human's approval on a rate-limit refusal.
+- **`AgentToolClient.status(requestId)`** answers what `guren.approval_status`
+  answers an MCP client, derived by the same rule, metered against the same
+  per-instance budget, and audited under the same tool name. It reports "the
+  queue has no such request for you" and "the queue could not be asked" as
+  distinct outcomes, because a caller that purged its retry material on an
+  unanswerable check would drop arguments a later approval needs.

--- a/.changeset/mcp-imports-shared-approval-status.md
+++ b/.changeset/mcp-imports-shared-approval-status.md
@@ -1,0 +1,10 @@
+---
+'@guren/plugin-mcp': patch
+---
+
+Read the approval-status rule from `@guren/core` instead of restating it
+
+`guren.approval_status` keeps its MCP schema, description and audit statuses;
+what it no longer owns is how a stored record becomes an answer. That rule now
+lives in the framework and is shared with the durable agent surface, so a record
+this tool reports as approved cannot be one another surface hides.

--- a/packages/plugin-agents/README.md
+++ b/packages/plugin-agents/README.md
@@ -132,6 +132,58 @@ your own to answer it directly. `routeAgentRequest` is a router, not an auth
 layer — this is the layer. The shape is deliberately thin while RFC 0017's Open
 Question 3 (per-agent policy classes? `Gate` abilities?) is unsettled.
 
+## Human-in-the-loop
+
+A tool declaring `approval: 'required'` refuses the first call and files a
+request for a human. The agent gets the id and stops:
+
+```ts
+export class Ops extends GurenAgent<Env, OpsState> {
+  async retire(id: number) {
+    const result = await this.tools.call('posts.destroy', { id })
+    if (result.pending) return   // parked; the retry is scheduled for you
+  }
+
+  onToolApprovalSettled(event: AgentToolApprovalSettled) {
+    if (event.status === 'approved') { /* event.result holds the retry's answer */ }
+  }
+}
+```
+
+Behind `return`, `this.tools` checkpoints `{ requestId, tool, args }` into a
+private table in the agent's own Durable Object SQLite and schedules
+`checkPendingApprovals` — 30 seconds, doubling per check, capped at the request's
+expiry. On each wake it asks the queue about every parked call. `approved`
+repeats the original call with the stored arguments (the queue's consume-on-use
+and fingerprint match make that spend exactly the approval a human granted);
+`rejected` and `expired` rows are pruned. Every outcome reaches
+`onToolApprovalSettled`, which is a no-op unless you override it.
+
+The sweep is written not to throw. The SDK retries a failed scheduled callback
+three times and then drops the schedule, so one bad row — an approval hook of
+yours that throws, a row naming a route a deploy removed, a row no current key
+can decrypt — would otherwise replay the whole sweep and then leave every
+surviving row with no wake at all. Each row is handled on its own, a throwing
+hook is reported and swallowed, and a retry refused for want of budget keeps its
+row rather than spending a human's approval on a refusal.
+
+One case is worth knowing about because it is the reason `status` and `result`
+are separate. If a sweep is interrupted *after* the retry ran but before the row
+was cleared, the next sweep finds the approval already spent — it settles with
+`status: 'approved'` and **no `result`**, and calls nothing. Repeating the call
+there would find no unconsumed approval, file a fresh request, page a human
+again, and perform the action twice.
+
+Nothing is held in memory: an eviction between the request and the approval
+loses nothing, because the state and the schedule are both durable.
+
+**No encrypter, no ledger.** The approval queue stores only redacted input and a
+non-reversible fingerprint, so the arguments have to live on the agent's side —
+and the bound on that is that they are ciphertext at rest, under the app key. An
+application without `EncryptionServiceProvider` and `APP_KEY` gets a warning at
+boot and no ledger: a parked call is still reported to the agent with its
+`requestId`, it is simply never retried for you.
+
 ## What an agent cannot do
 
 `this.tools.call(name, args)` is the only way an agent reaches the application,

--- a/packages/plugin-agents/src/agent.ts
+++ b/packages/plugin-agents/src/agent.ts
@@ -12,13 +12,38 @@ import { Agent, routeAgentRequest } from 'agents'
 
 import type { AgentsRoutingConfig } from './config'
 import { resolveAgentRuntime, type AgentRuntime } from './latch'
-import { createAgentToolClient, type AgentToolClient } from './tool-client'
+import {
+  firesSooner,
+  PendingCallLedger,
+  type LedgerSql,
+  type PendingToolCall,
+} from './ledger'
+import {
+  createAgentToolClient,
+  type AgentToolApprovalSettled,
+  type AgentToolCallPending,
+  type AgentToolCallResult,
+  type AgentToolClient,
+} from './tool-client'
 
 /**
  * What an agent's `this.tools` offers: the two calls, and nothing that would
  * have to answer synchronously about a runtime that may not have booted yet.
+ *
+ * Deliberately not `status`: RFC 0017 §5 promises the *hook*, and an agent that
+ * polled the queue by hand would be a second retry rule beside the ledger's.
  */
 export type AgentTools = Pick<AgentToolClient, 'call' | 'preflight'>
+
+/** The method the ledger's schedules wake, by the only name the SDK takes. */
+const CHECK_CALLBACK = 'checkPendingApprovals'
+
+/** The client and the ledger, both settled against one published runtime. */
+interface AgentToolContext {
+  client: AgentToolClient
+  /** Absent when no encrypter is bound — see {@link AgentRuntime.cipher}. */
+  ledger?: PendingCallLedger
+}
 
 /**
  * The base class `make:agent` scaffolds.
@@ -32,9 +57,9 @@ export class GurenAgent<
   State = unknown,
   Props extends Record<string, unknown> = Record<string, unknown>,
 > extends Agent<Env, State, Props> {
-  #client?: Promise<AgentToolClient>
+  #context?: Promise<AgentToolContext>
   #tools?: AgentTools
-  /** The runtime the cached client was built against, for the staleness check. */
+  /** The runtime the cached context was built against, for the staleness check. */
   #builtFor?: AgentRuntime
 
   /**
@@ -46,25 +71,246 @@ export class GurenAgent<
    */
   get tools(): AgentTools {
     this.#tools ??= {
-      call: async (name, args) => (await this.#load()).call(name, args),
-      preflight: async (name, args) => (await this.#load()).preflight(name, args),
+      call: async (name, args) => this.#call(name, args ?? {}),
+      preflight: async (name, args) => (await this.#load()).client.preflight(name, args),
     }
     return this.#tools
   }
 
-  async #load(): Promise<AgentToolClient> {
-    // The runtime slot is last-publish-wins, so a client held across a later
+  /**
+   * What became of a call this agent parked for approval (RFC 0017 §5).
+   *
+   * Overridable; a no-op by default. A throw is reported and swallowed, because
+   * this runs inside a schedule the SDK would otherwise replay.
+   */
+  onToolApprovalSettled(event: AgentToolApprovalSettled): void | Promise<void> {
+    void event
+  }
+
+  /**
+   * Ask the queue about every parked call and act on the answers. Public
+   * because the SDK schedules by method name. Nothing here may throw: a failed
+   * delayed callback is retried three times and then dropped, so a throw
+   * replays this body against a half-updated ledger and then leaves every
+   * surviving row with no wake at all.
+   */
+  async checkPendingApprovals(): Promise<void> {
+    const { client, ledger } = await this.#load()
+    if (!ledger) return
+
+    try {
+      for (const call of ledger.pruneUnreadable()) await this.#settle(call, 'unreadable')
+
+      for (const call of ledger.pruneExpired(new Date())) await this.#settle(call, 'expired')
+
+      for (const call of ledger.all()) {
+        // Per row, so one unanswerable request cannot strand the others: a tool
+        // a deploy removed throws out of `client.call`, and without this the
+        // whole sweep would die on it, every wake, until the rows expired.
+        try {
+          await this.#settleOne(client, ledger, call)
+        } catch (error) {
+          console.warn(
+            `[@guren/plugin-agents] Could not settle the approval for "${call.tool}" `
+            + `(request ${call.requestId}): ${describe(error)}. The row is kept and will be `
+            + 'checked again until it expires.',
+          )
+          ledger.bumpChecks(call.requestId)
+        }
+      }
+    } finally {
+      // In `finally` for the same reason the loop catches: whatever happened
+      // above, the rows still waiting need a next wake.
+      await this.#scheduleCheck(ledger, true)
+    }
+  }
+
+  /** One row's verdict. Every ledger write lands before the hook is called. */
+  async #settleOne(
+    client: AgentToolClient,
+    ledger: PendingCallLedger,
+    call: PendingToolCall,
+  ): Promise<void> {
+    const answer = await client.status(call.requestId)
+
+    // Unanswerable, not answered: keeping the row is the whole reason that
+    // variant exists. Purging here would drop the arguments an approval granted
+    // an hour later needs, and nothing would report it. Still counted —
+    // `checks` is the backoff's clock, so a spent budget has to back off rather
+    // than re-ask at the same cadence until the request expires.
+    if (answer.unavailable) {
+      ledger.bumpChecks(call.requestId)
+      return
+    }
+
+    if (!answer.found) {
+      ledger.remove(call.requestId)
+      await this.#settle(call, 'unknown')
+      return
+    }
+
+    const { status, consumedAt } = answer.report
+    if (status === 'pending') {
+      ledger.bumpChecks(call.requestId)
+      return
+    }
+
+    if (status === 'approved') {
+      await this.#settleApproved(client, ledger, call, consumedAt !== undefined)
+      return
+    }
+
+    ledger.remove(call.requestId)
+    await this.#settle(call, status === 'rejected' ? 'rejected' : 'expired')
+  }
+
+  /**
+   * An approved row: repeat the call unless the approval is already spent.
+   * Every ledger write lands before the hook is called.
+   */
+  async #settleApproved(
+    client: AgentToolClient,
+    ledger: PendingCallLedger,
+    call: PendingToolCall,
+    spent: boolean,
+  ): Promise<void> {
+    if (spent) {
+      // Approvals bind to this principal and this exact fingerprint, so nobody
+      // else could have spent it: a previous sweep ran the call and was
+      // interrupted before clearing the row. Re-calling would find no
+      // unconsumed match, file a *new* request, page a human, and run the side
+      // effect a second time on approval.
+      ledger.remove(call.requestId)
+      await this.#settle(call, 'approved')
+      return
+    }
+
+    // The original call, with the stored arguments: the queue's consume-on-use
+    // and fingerprint match make this spend exactly the approval that was
+    // granted, and nothing else.
+    const result = await client.call(call.tool, call.args)
+
+    if (result.pending) {
+      // Spent between the status read and the retry, so the gate filed a fresh
+      // request. Follow the id it reports rather than dropping the arguments
+      // the new request will need.
+      if (result.requestId === call.requestId) {
+        ledger.bumpChecks(call.requestId)
+        return
+      }
+      ledger.remove(call.requestId)
+      this.#park(ledger, result, call.args)
+      return
+    }
+
+    if (result.denied && result.reason === 'rate-limit') {
+      // The budget the status check just spent. Reporting this as the
+      // approval's outcome would drop the row, and a human's approval would be
+      // spent by nobody and never retried.
+      ledger.bumpChecks(call.requestId)
+      return
+    }
+
+    ledger.remove(call.requestId)
+    await this.#settle(call, 'approved', result)
+  }
+
+  /**
+   * Call the hook, which is application code and may throw.
+   *
+   * A throw here would replay the sweep, so it is reported and swallowed: the
+   * ledger write it follows has already happened, and the alternative is
+   * re-running calls that were settled correctly.
+   */
+  async #settle(
+    call: { requestId: string; tool: string },
+    status: AgentToolApprovalSettled['status'],
+    result?: AgentToolCallResult,
+  ): Promise<void> {
+    try {
+      await this.onToolApprovalSettled({
+        requestId: call.requestId,
+        tool: call.tool,
+        status,
+        ...(result ? { result } : {}),
+      })
+    } catch (error) {
+      console.warn(
+        `[@guren/plugin-agents] onToolApprovalSettled threw for request ${call.requestId} `
+        + `(${call.tool}, ${status}): ${describe(error)}`,
+      )
+    }
+  }
+
+  async #call(name: string, args: Record<string, unknown>): Promise<AgentToolCallResult> {
+    const { client, ledger } = await this.#load()
+    const result = await client.call(name, args)
+    // Checkpointed before the result is returned: an agent that parked a call
+    // and was evicted on the next line must still be able to retry it.
+    if (result.pending && ledger && this.#park(ledger, result, args)) {
+      await this.#scheduleCheck(ledger, false)
+    }
+    return result
+  }
+
+  /**
+   * Checkpoint the arguments the queue cannot keep.
+   * @returns whether the call was checkpointed.
+   */
+  #park(
+    ledger: PendingCallLedger,
+    result: AgentToolCallPending,
+    args: Record<string, unknown>,
+  ): boolean {
+    // Both instants come from the queue's own record. Without an expiry the row
+    // could never be pruned, and extending the TTL is not the agent's to do.
+    if (!result.expiresAt) return false
+    ledger.record({
+      requestId: result.requestId,
+      tool: result.tool,
+      args,
+      requestedAt: result.requestedAt ?? new Date().toISOString(),
+      expiresAt: result.expiresAt,
+    })
+    return true
+  }
+
+  /**
+   * Hold the ledger to exactly one pending check.
+   * @param replace Always true after a sweep, so a lengthening backoff takes
+   *   effect. False on the record path, where an existing check is kept only if
+   *   it fires before the one this row needs.
+   */
+  async #scheduleCheck(ledger: PendingCallLedger, replace: boolean): Promise<void> {
+    const now = new Date()
+    const delay = ledger.nextDelaySeconds(now)
+    if (delay === undefined) return
+
+    // `ScheduleCriteria` filters on id, type and time only, so the callback is
+    // matched here rather than by the query.
+    const existing = (await this.listSchedules({ type: 'delayed' })).filter(
+      (schedule) => schedule.callback === CHECK_CALLBACK,
+    )
+    if (!replace && !firesSooner(delay, now, existing.map((schedule) => schedule.time))) return
+
+    for (const schedule of existing) await this.cancelSchedule(schedule.id)
+
+    await this.schedule(delay, CHECK_CALLBACK as keyof this)
+  }
+
+  async #load(): Promise<AgentToolContext> {
+    // The runtime slot is last-publish-wins, so a context held across a later
     // publish would keep dispatching into the application that was replaced.
     // Once the latch is settled this is a slot read: a promise, not a boot.
     const runtime = await resolveAgentRuntime(this.env)
-    if (this.#client && this.#builtFor === runtime) return this.#client
+    if (this.#context && this.#builtFor === runtime) return this.#context
 
     this.#builtFor = runtime
-    this.#client = this.#buildClient(runtime)
-    return this.#client
+    this.#context = this.#build(runtime)
+    return this.#context
   }
 
-  async #buildClient(runtime: AgentRuntime): Promise<AgentToolClient> {
+  async #build(runtime: AgentRuntime): Promise<AgentToolContext> {
     // Facets reuse `this.name` under a different parent, so a facet and a root
     // agent can carry the same principal id — and approvals are isolated by
     // that id. `selfPath` would disambiguate them but is `@experimental`, and a
@@ -92,7 +338,7 @@ export class GurenAgent<
       )
     }
 
-    return createAgentToolClient({
+    const client = createAgentToolClient({
       runtime,
       agentName: registration.name,
       // The SDK's own instance name (`Agent.name`), which is the `:instance`
@@ -100,6 +346,14 @@ export class GurenAgent<
       // keeps one instance from spending another's approval.
       instanceId: this.name,
     })
+
+    // Bound rather than passed: `this.sql` is a method, and handing the
+    // reference over would call it with the ledger as its receiver.
+    const sql: LedgerSql = (strings, ...values) => this.sql(strings, ...values)
+    return {
+      client,
+      ...(runtime.cipher ? { ledger: new PendingCallLedger(sql, runtime.cipher) } : {}),
+    }
   }
 }
 
@@ -188,4 +442,8 @@ function lowerFirst(value: string): string {
 function isFacet(agent: { parentPath?: unknown }): boolean {
   const path = agent.parentPath
   return Array.isArray(path) && path.length > 0
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }

--- a/packages/plugin-agents/src/index.ts
+++ b/packages/plugin-agents/src/index.ts
@@ -23,6 +23,25 @@ export { agentsPlugin } from './plugin'
 export type { AgentsPluginConfig } from './plugin'
 
 /**
+ * The human-in-the-loop vocabulary (RFC 0017 §5). Types only, so an agent class
+ * types its `onToolApprovalSettled` override without importing `agents` — the
+ * root stays Bun-safe.
+ */
+export type {
+  AgentApprovalStatusFound,
+  AgentApprovalStatusMissing,
+  AgentApprovalStatusResult,
+  AgentApprovalStatusUnavailable,
+  AgentToolApprovalSettled,
+  AgentToolCallDenied,
+  AgentToolCallFailed,
+  AgentToolCallOk,
+  AgentToolCallPending,
+  AgentToolCallResult,
+} from './tool-client'
+export type { LedgerCipher, PendingToolCall } from './ledger'
+
+/**
  * The runtime seam — `configureAgentRuntime`, `resolveAgentRuntime`,
  * `createAgentToolClient` and their types — is **not** re-exported here. It
  * lives at `@guren/plugin-agents/runtime`, so that agent code reaching for it

--- a/packages/plugin-agents/src/latch.ts
+++ b/packages/plugin-agents/src/latch.ts
@@ -15,6 +15,7 @@ import type {
 } from '@guren/core'
 
 import type { AgentBudgetConfig, AgentsApprovalsConfig } from './config'
+import type { LedgerCipher } from './ledger'
 
 /** What the plugin resolved for one registered agent at boot. */
 export interface AgentRegistration {
@@ -52,6 +53,14 @@ export interface AgentRuntime {
    */
   audit?: () => AgentAuditEmitter
   approvals?: AgentsApprovalsConfig
+  /**
+   * The app key's encryption, for the ledger's arguments (RFC 0017 §5).
+   *
+   * Absent, there is no ledger: a parked call is still returned with its
+   * `requestId`, but nothing is checkpointed, because the one bound on storing
+   * raw arguments is that they are ciphertext at rest.
+   */
+  cipher?: LedgerCipher
 }
 
 /**

--- a/packages/plugin-agents/src/ledger.test.ts
+++ b/packages/plugin-agents/src/ledger.test.ts
@@ -1,0 +1,262 @@
+import { Database } from 'bun:sqlite'
+import { describe, test, expect, beforeEach } from 'bun:test'
+
+import { firesSooner, PendingCallLedger, type LedgerCipher, type LedgerSql } from './ledger'
+
+/**
+ * The ledger against real SQLite (RFC 0017 §5).
+ *
+ * `bun:sqlite` rather than a fake store: a stand-in accepting any SQL would let
+ * a statement workerd rejects pass here. The cipher is reversible and obvious,
+ * so encryption at rest is asserted on the raw column rather than trusted.
+ */
+
+/** `Agent.sql`'s shape over `bun:sqlite`: synchronous, tagged, rows out. */
+function sqlOver(db: Database): LedgerSql {
+  return (strings, ...values) => {
+    const statement = strings.join('?')
+    const params = values as Array<string | number | null>
+    return db.query(statement).all(...params) as Array<Record<string, never>>
+  }
+}
+
+/** Reversible and inspectable: a test asserts the raw column is not plaintext. */
+const cipher: LedgerCipher = {
+  encrypt: (text) => `sealed:${Buffer.from(text, 'utf8').toString('base64')}`,
+  decrypt: (text) => Buffer.from(text.slice('sealed:'.length), 'base64').toString('utf8'),
+}
+
+const NOW = new Date('2026-09-05T12:00:00.000Z')
+
+function at(offsetMs: number): string {
+  return new Date(NOW.getTime() + offsetMs).toISOString()
+}
+
+let db: Database
+let ledger: PendingCallLedger
+
+beforeEach(() => {
+  db = new Database(':memory:')
+  ledger = new PendingCallLedger(sqlOver(db), cipher)
+})
+
+function park(requestId: string, overrides: Partial<Parameters<PendingCallLedger['record']>[0]> = {}): void {
+  ledger.record({
+    requestId,
+    tool: 'posts.destroy',
+    args: { id: 7 },
+    requestedAt: NOW.toISOString(),
+    expiresAt: at(60 * 60 * 1000),
+    ...overrides,
+  })
+}
+
+describe('PendingCallLedger: rows', () => {
+  test('should create its table on first use', () => {
+    expect(ledger.all()).toEqual([])
+  })
+
+  test('should round-trip a parked call with its arguments', () => {
+    park('req-1', { args: { id: 7, reason: 'stale' } })
+
+    expect(ledger.all()).toEqual([
+      {
+        requestId: 'req-1',
+        tool: 'posts.destroy',
+        args: { id: 7, reason: 'stale' },
+        requestedAt: NOW.toISOString(),
+        expiresAt: at(60 * 60 * 1000),
+        checks: 0,
+      },
+    ])
+  })
+
+  test('should store the arguments encrypted at rest', () => {
+    park('req-1', { args: { secret: 'hunter2-distinctive' } })
+
+    const [row] = db.query('SELECT args FROM guren_pending_tool_calls').all() as Array<{ args: string }>
+    expect(row!.args).not.toContain('hunter2-distinctive')
+    expect(row!.args).not.toContain('secret')
+    // Reversible for the retry — the point is the column, not a one-way hash.
+    expect(JSON.parse(cipher.decrypt(row!.args))).toEqual({ secret: 'hunter2-distinctive' })
+  })
+
+  test('should replace a row recorded twice under one request id', () => {
+    park('req-1', { args: { id: 1 } })
+    park('req-1', { args: { id: 2 } })
+
+    expect(ledger.all()).toHaveLength(1)
+    expect(ledger.all()[0]!.args).toEqual({ id: 2 })
+  })
+
+  test('should remove a row by request id', () => {
+    park('req-1')
+    park('req-2')
+
+    ledger.remove('req-1')
+
+    expect(ledger.all().map((call) => call.requestId)).toEqual(['req-2'])
+  })
+
+  test('should count checks per row', () => {
+    park('req-1')
+    ledger.bumpChecks('req-1')
+    ledger.bumpChecks('req-1')
+
+    expect(ledger.all()[0]!.checks).toBe(2)
+  })
+})
+
+describe('PendingCallLedger: pruning', () => {
+  test('should drop and report rows past their expiry', () => {
+    park('gone', { expiresAt: at(-1) })
+    park('alive', { expiresAt: at(60_000) })
+
+    const pruned = ledger.pruneExpired(NOW)
+
+    expect(pruned.map((call) => call.requestId)).toEqual(['gone'])
+    expect(ledger.all().map((call) => call.requestId)).toEqual(['alive'])
+  })
+
+  test('should drop a row whose expiry cannot be read', () => {
+    // The direction `agentApprovalExpiredAt` fails in: a date the framework
+    // cannot parse is expired, never "not expired yet".
+    park('unreadable', { expiresAt: 'not a date' })
+
+    expect(ledger.pruneExpired(NOW).map((call) => call.requestId)).toEqual(['unreadable'])
+    expect(ledger.all()).toEqual([])
+  })
+
+  test('should keep a row expiring exactly at now out of the future', () => {
+    park('boundary', { expiresAt: NOW.toISOString() })
+
+    expect(ledger.pruneExpired(NOW)).toHaveLength(1)
+  })
+})
+
+describe('PendingCallLedger: the next wake', () => {
+  test('should answer nothing when no row is waiting', () => {
+    expect(ledger.nextDelaySeconds(NOW)).toBeUndefined()
+  })
+
+  test('should start at 30 seconds and double per check', () => {
+    park('req-1')
+    expect(ledger.nextDelaySeconds(NOW)).toBe(30)
+
+    ledger.bumpChecks('req-1')
+    expect(ledger.nextDelaySeconds(NOW)).toBe(60)
+
+    ledger.bumpChecks('req-1')
+    expect(ledger.nextDelaySeconds(NOW)).toBe(120)
+  })
+
+  test('should follow the least-checked row, not the most', () => {
+    // One wake asks about every row, so the cadence serves the newest parked
+    // call rather than inheriting the oldest row's stretched backoff.
+    park('old')
+    for (let check = 0; check < 5; check++) ledger.bumpChecks('old')
+    park('new')
+
+    expect(ledger.nextDelaySeconds(NOW)).toBe(30)
+  })
+
+  test('should cap the wake at the earliest expiry plus a grace', () => {
+    park('soon', { expiresAt: at(10_000) })
+
+    // 30s of backoff would land past the request's life, and the row would
+    // never be reported as expired.
+    expect(ledger.nextDelaySeconds(NOW)).toBe(15)
+  })
+
+  test('should cap the backoff at the approval TTL', () => {
+    park('req-1', { expiresAt: at(10 * 60 * 60 * 1000) })
+    for (let check = 0; check < 12; check++) ledger.bumpChecks('req-1')
+
+    expect(ledger.nextDelaySeconds(NOW)).toBe(3600)
+  })
+
+  test('should never answer a delay a schedule cannot honour', () => {
+    // A row can cross its expiry between the prune and this call.
+    park('lapsed', { expiresAt: at(-60_000) })
+
+    expect(ledger.nextDelaySeconds(NOW)).toBe(1)
+  })
+})
+
+describe('PendingCallLedger: rows no key can open', () => {
+  /** One row's ciphertext is rejected, as a rotated app key would reject it. */
+  function ledgerRefusing(marker: string): PendingCallLedger {
+    return new PendingCallLedger(sqlOver(db), {
+      encrypt: cipher.encrypt,
+      decrypt: (text) => {
+        const opened = cipher.decrypt(text)
+        if (opened.includes(marker)) throw new Error('no key opens this row')
+        return opened
+      },
+    })
+  }
+
+  test('should skip an unreadable row rather than throw', () => {
+    park('readable', { args: { id: 1 } })
+    park('rotated', { args: { id: 'ROTATED' } })
+
+    // `all()` backs the record path too, so a throw here would deny a caller the
+    // `pending` result of a call that was parked perfectly well.
+    const rows = ledgerRefusing('ROTATED').all()
+
+    expect(rows.map((call) => call.requestId)).toEqual(['readable'])
+  })
+
+  test('should drop and report unreadable rows', () => {
+    park('readable', { args: { id: 1 } })
+    park('rotated', { args: { id: 'ROTATED' } })
+    const ledgerWithRotation = ledgerRefusing('ROTATED')
+
+    const unreadable = ledgerWithRotation.pruneUnreadable()
+
+    expect(unreadable).toEqual([{ requestId: 'rotated', tool: 'posts.destroy' }])
+    expect(ledgerWithRotation.all().map((call) => call.requestId)).toEqual(['readable'])
+    // Gone from the table, not merely filtered out of the read.
+    expect(db.query('SELECT request_id FROM guren_pending_tool_calls').all()).toEqual([
+      { request_id: 'readable' },
+    ])
+  })
+
+  test('should still answer a delay when one row is unreadable', () => {
+    park('rotated', { args: { id: 'ROTATED' } })
+    park('readable', { args: { id: 1 } })
+
+    expect(ledgerRefusing('ROTATED').nextDelaySeconds(NOW)).toBe(30)
+  })
+})
+
+describe('firesSooner', () => {
+  /** `Schedule.time` is Unix seconds for every schedule type. */
+  const nowSeconds = Math.floor(NOW.getTime() / 1000)
+
+  test('should schedule when nothing is pending', () => {
+    expect(firesSooner(30, NOW, [])).toBe(true)
+  })
+
+  test('should replace a check that fires after the one this row needs', () => {
+    // A row expiring in five minutes, against a check twenty minutes out.
+    expect(firesSooner(300, NOW, [nowSeconds + 1200])).toBe(true)
+  })
+
+  test('should keep a check that already fires sooner', () => {
+    expect(firesSooner(300, NOW, [nowSeconds + 60])).toBe(false)
+  })
+
+  test('should keep a check equal to the one it would create', () => {
+    expect(firesSooner(300, NOW, [nowSeconds + 300])).toBe(false)
+  })
+
+  test('should compare against the earliest of several', () => {
+    expect(firesSooner(300, NOW, [nowSeconds + 1200, nowSeconds + 60])).toBe(false)
+  })
+
+  test('should schedule past a time it cannot read', () => {
+    // The opposite would let one unreadable row suppress every later check.
+    expect(firesSooner(300, NOW, [Number.NaN])).toBe(true)
+  })
+})

--- a/packages/plugin-agents/src/ledger.ts
+++ b/packages/plugin-agents/src/ledger.ts
@@ -1,0 +1,223 @@
+/**
+ * The pending-approval ledger (RFC 0017 §5): the retry material for a call a
+ * human has not answered yet.
+ *
+ * The approval queue stores only redacted input and a non-reversible
+ * fingerprint, so it can never repeat the call — the agent side owns the
+ * arguments. A deliberate, bounded exception to RFC 0016's "no reversible copy
+ * of arguments": per-instance storage no API surfaces, rows purged when their
+ * approval settles or expires, ciphertext at rest.
+ */
+import { DEFAULT_AGENT_APPROVAL_TTL_MS } from '@guren/core'
+
+/** What the SDK's `sql` tagged template accepts and returns. */
+export type LedgerSqlValue = string | number | boolean | null
+
+/**
+ * A synchronous tagged-template SQL executor — `Agent.sql`'s exact shape, so
+ * the Durable Object passes its own method and a Bun test passes `bun:sqlite`.
+ */
+export type LedgerSql = (
+  strings: TemplateStringsArray,
+  ...values: LedgerSqlValue[]
+) => Array<Record<string, LedgerSqlValue>>
+
+/** Reversible encryption for the arguments column. `Encrypter`'s string half. */
+export interface LedgerCipher {
+  encrypt(text: string): string
+  decrypt(text: string): string
+}
+
+/** A row whose arguments no key on hand can open. */
+export interface UnreadablePendingCall {
+  requestId: string
+  tool: string
+}
+
+/** One parked call, as the agent checkpointed it. */
+export interface PendingToolCall {
+  requestId: string
+  tool: string
+  args: Record<string, unknown>
+  requestedAt: string
+  /** ISO 8601 — the *queue's* expiry, never extended by the ledger. */
+  expiresAt: string
+  /** How many times {@link PendingCallLedger.bumpChecks} has counted this row. */
+  checks: number
+}
+
+/** First backoff step, doubling per check. */
+const BASE_DELAY_SECONDS = 30
+
+/**
+ * Added past the earliest expiry so the final wake sees an expired record and
+ * prunes it, rather than landing on the instant it lapses and rescheduling.
+ */
+const EXPIRY_GRACE_SECONDS = 5
+
+/** A schedule must be in the future: a delay of zero is a hot alarm loop. */
+const MIN_DELAY_SECONDS = 1
+
+/**
+ * A backstop only: the *default* TTL, not any row's own. What actually bounds a
+ * wake by a request's life is the earliest `expires_at` each call computes.
+ */
+const MAX_DELAY_SECONDS = Math.floor(DEFAULT_AGENT_APPROVAL_TTL_MS / 1000)
+
+/**
+ * The rows one agent instance is waiting on.
+ *
+ * Lazily creates its table: `CREATE TABLE IF NOT EXISTS` is the framework's own
+ * bookkeeping, not an application table — RFC 0017 Open Question 5 (how *app*
+ * schemas migrate across deploys) is untouched by it.
+ */
+export class PendingCallLedger {
+  #created = false
+
+  constructor(
+    private readonly sql: LedgerSql,
+    private readonly cipher: LedgerCipher,
+  ) {}
+
+  /**
+   * Checkpoint a call the queue parked.
+   *
+   * Replacing a row under the same id resets its `checks`, which is what an
+   * agent re-calling a parked tool produces: a fresh call is fresh interest,
+   * and the backoff restarts with it.
+   */
+  record(call: Omit<PendingToolCall, 'checks'>): void {
+    this.#ensureTable()
+    const args = this.cipher.encrypt(JSON.stringify(call.args))
+    void this.sql`INSERT OR REPLACE INTO guren_pending_tool_calls
+      (request_id, tool, args, requested_at, expires_at, checks)
+      VALUES (${call.requestId}, ${call.tool}, ${args}, ${call.requestedAt}, ${call.expiresAt}, 0)`
+  }
+
+  /**
+   * Every row whose arguments can still be read, oldest request first.
+   *
+   * An undecryptable row is skipped, not thrown over: one would otherwise take
+   * down the sweep *and* the record path, which reads this to pick its next
+   * wake. {@link pruneUnreadable} reports and clears them.
+   */
+  all(): PendingToolCall[] {
+    const readable: PendingToolCall[] = []
+    for (const row of this.#rows()) {
+      const args = this.#decrypt(row)
+      if (!args) continue
+      readable.push({
+        requestId: String(row.request_id),
+        tool: String(row.tool),
+        args,
+        requestedAt: String(row.requested_at),
+        expiresAt: String(row.expires_at),
+        checks: Number(row.checks),
+      })
+    }
+    return readable
+  }
+
+  /**
+   * Drop every row whose arguments cannot be decrypted, returning what was
+   * dropped. An app key rotated past its `previousKeys`, or a corrupt column:
+   * the queue may still hold the request, but nothing here can retry it.
+   */
+  pruneUnreadable(): UnreadablePendingCall[] {
+    const unreadable: UnreadablePendingCall[] = []
+    for (const row of this.#rows()) {
+      if (this.#decrypt(row)) continue
+      unreadable.push({ requestId: String(row.request_id), tool: String(row.tool) })
+    }
+    for (const call of unreadable) this.remove(call.requestId)
+    return unreadable
+  }
+
+  remove(requestId: string): void {
+    this.#ensureTable()
+    void this.sql`DELETE FROM guren_pending_tool_calls WHERE request_id = ${requestId}`
+  }
+
+  bumpChecks(requestId: string): void {
+    this.#ensureTable()
+    void this.sql`UPDATE guren_pending_tool_calls SET checks = checks + 1 WHERE request_id = ${requestId}`
+  }
+
+  /**
+   * Drop every row past its expiry, returning them so the caller can report
+   * each one. An unparseable `expires_at` counts as expired, the direction
+   * `agentApprovalExpiredAt` fails in.
+   */
+  pruneExpired(now: Date): PendingToolCall[] {
+    const expired = this.all().filter((call) => {
+      const at = Date.parse(call.expiresAt)
+      return Number.isNaN(at) || at <= now.getTime()
+    })
+    for (const call of expired) this.remove(call.requestId)
+    return expired
+  }
+
+  /**
+   * When to wake next, in seconds, or `undefined` when nothing is waiting.
+   *
+   * Exponential from the **least-checked** row: one wake asks about every row,
+   * so the cadence serves the newest parked call rather than inheriting the
+   * oldest row's stretched backoff. Capped by the earliest expiry.
+   */
+  nextDelaySeconds(now: Date): number | undefined {
+    const calls = this.all()
+    if (calls.length === 0) return undefined
+
+    const checks = Math.min(...calls.map((call) => call.checks))
+    const backoff = BASE_DELAY_SECONDS * 2 ** Math.min(checks, 20)
+
+    const earliest = Math.min(...calls.map((call) => Date.parse(call.expiresAt) || 0))
+    const untilExpiry = Math.ceil((earliest - now.getTime()) / 1000) + EXPIRY_GRACE_SECONDS
+
+    return Math.max(MIN_DELAY_SECONDS, Math.min(backoff, untilExpiry, MAX_DELAY_SECONDS))
+  }
+
+  #rows(): Array<Record<string, LedgerSqlValue>> {
+    this.#ensureTable()
+    return this.sql`SELECT * FROM guren_pending_tool_calls ORDER BY requested_at ASC, request_id ASC`
+  }
+
+  /** @returns the arguments, or `undefined` when the row cannot be read. */
+  #decrypt(row: Record<string, LedgerSqlValue>): Record<string, unknown> | undefined {
+    try {
+      return JSON.parse(this.cipher.decrypt(String(row.args))) as Record<string, unknown>
+    } catch {
+      return undefined
+    }
+  }
+
+  #ensureTable(): void {
+    if (this.#created) return
+    void this.sql`CREATE TABLE IF NOT EXISTS guren_pending_tool_calls (
+      request_id TEXT PRIMARY KEY,
+      tool TEXT NOT NULL,
+      args TEXT NOT NULL,
+      requested_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      checks INTEGER NOT NULL DEFAULT 0
+    )`
+    this.#created = true
+  }
+}
+
+/**
+ * Whether a check at `now + delaySeconds` fires sooner than every pending one.
+ *
+ * A row expiring in five minutes must not be left to a check twenty minutes
+ * out. `times` are Unix **seconds**, the unit `Schedule.time` carries.
+ */
+export function firesSooner(
+  delaySeconds: number,
+  now: Date,
+  times: readonly number[],
+): boolean {
+  const at = Math.floor(now.getTime() / 1000) + delaySeconds
+  // An unreadable time is treated as "no useful schedule", so the new one wins:
+  // the opposite would let one bad row suppress every later check.
+  return times.every((existing) => !Number.isFinite(existing) || at < existing)
+}

--- a/packages/plugin-agents/src/plugin.test.ts
+++ b/packages/plugin-agents/src/plugin.test.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import {
   AGENT_AUDIT_BINDING,
   AgentToolInvoked,
+  EncryptionServiceProvider,
   EventServiceProvider,
   createApp,
   definePlugin,
@@ -263,5 +264,33 @@ describe('agentsPlugin', () => {
       .call('posts.index', {})
 
     expect(recorded).toEqual([`${AgentToolInvoked.name}:posts.index`])
+  })
+})
+
+describe('agentsPlugin: the ledger cipher', () => {
+  test('should publish the app key cipher when the encryption provider is registered', async () => {
+    process.env.APP_KEY = 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+    await boot({ agents: TRIAGER }, [EncryptionServiceProvider])
+
+    const cipher = (await resolveAgentRuntime()).cipher
+    expect(cipher).toBeDefined()
+    // The binding is the container's `encrypter`, so the round trip is the
+    // whole claim: a ledger row is ciphertext the same key opens.
+    const sealed = cipher!.encrypt('the-arguments')
+    expect(sealed).not.toContain('the-arguments')
+    expect(cipher!.decrypt(sealed)).toBe('the-arguments')
+  })
+
+  test('should disable the ledger and say so when nothing is bound', async () => {
+    const warnings = await captureWarnings(async () => {
+      await boot({ agents: TRIAGER })
+    })
+
+    expect((await resolveAgentRuntime()).cipher).toBeUndefined()
+    // Named in the warning because there is no other signal: a pending call is
+    // still reported, it is simply never retried.
+    const warning = warnings.find((line) => line.includes('pending-approval ledger is disabled'))
+    expect(warning).toContain('EncryptionServiceProvider')
+    expect(warning).toContain('APP_KEY')
   })
 })

--- a/packages/plugin-agents/src/plugin.ts
+++ b/packages/plugin-agents/src/plugin.ts
@@ -19,6 +19,7 @@ import {
 import type {
   AgentAuditEmitter,
   Application,
+  Encrypter,
   EventManager,
   ScopedTool,
   ServiceProviderConstructor,
@@ -30,6 +31,10 @@ import {
   type AgentsConfig,
 } from './config'
 import { configureAgentRuntime, freezeAgentRegistrations, type AgentRegistration } from './latch'
+import type { LedgerCipher } from './ledger'
+
+/** The container key `EncryptionServiceProvider` binds the app-key cipher under. */
+const ENCRYPTER_BINDING = 'encrypter'
 
 export type AgentsPluginConfig = AgentsConfig
 
@@ -117,6 +122,28 @@ const factory = definePlugin<AgentsPluginConfig>({
       )
     }
 
+    // Read here rather than at first use, unlike the audit emitter: the
+    // encrypter is bound by `register()`, which every provider has run before
+    // any `boot` does, and the warning is only useful while an author is
+    // reading boot output. The string half, not the `Encrypter` itself: its
+    // `encrypt` JSON-serialises, and the ledger hands it a JSON string already.
+    const encrypter = container.has(ENCRYPTER_BINDING)
+      ? container.make<Encrypter>(ENCRYPTER_BINDING)
+      : undefined
+    if (!encrypter) {
+      console.warn(
+        '[@guren/plugin-agents] No encrypter is bound, so the pending-approval ledger is disabled: '
+        + 'a call awaiting approval is reported to the agent but never retried automatically. '
+        + 'Add EncryptionServiceProvider to `providers` and set APP_KEY to enable it.',
+      )
+    }
+    const cipher: LedgerCipher | undefined = encrypter
+      ? {
+          encrypt: (text) => encrypter.encryptString(text),
+          decrypt: (text) => encrypter.decryptString(text),
+        }
+      : undefined
+
     configureAgentRuntime({
       // Not `app` itself: this hook runs inside `bootAll()`, so every provider
       // after it is still unbooted. `boot()` rather than `booted()`: after a boot
@@ -135,6 +162,7 @@ const factory = definePlugin<AgentsPluginConfig>({
       registrations: freezeAgentRegistrations(registrations),
       audit,
       ...(config.approvals ? { approvals: config.approvals } : {}),
+      ...(cipher ? { cipher } : {}),
     })
   },
 })

--- a/packages/plugin-agents/src/runtime.ts
+++ b/packages/plugin-agents/src/runtime.ts
@@ -18,7 +18,14 @@ export {
 export type { AgentRegistration, AgentRuntime, AgentRuntimeResolver } from './latch'
 
 export { createAgentToolClient } from './tool-client'
+export { PendingCallLedger } from './ledger'
+export type { LedgerCipher, LedgerSql, LedgerSqlValue, PendingToolCall } from './ledger'
 export type {
+  AgentApprovalStatusFound,
+  AgentApprovalStatusMissing,
+  AgentApprovalStatusResult,
+  AgentApprovalStatusUnavailable,
+  AgentToolApprovalSettled,
   AgentToolCallDenied,
   AgentToolCallFailed,
   AgentToolCallOk,

--- a/packages/plugin-agents/src/tool-client.test.ts
+++ b/packages/plugin-agents/src/tool-client.test.ts
@@ -9,6 +9,7 @@ import {
   AgentToolDenied,
   AgentToolInvoked,
   EventServiceProvider,
+  approvalStatusNotFoundMessage,
   createApp,
   createCsrfMiddleware,
   requireAuthenticated,
@@ -384,6 +385,144 @@ describe('createAgentToolClient: the per-instance budget', () => {
       expect((await triager.call('posts.index', {})).ok).toBe(true)
     }
     expect((await triager.call('posts.index', {})).denied).toBe(true)
+  })
+})
+
+describe('createAgentToolClient: the approval status check', () => {
+  /** Park a call so there is a record, and answer with its id. */
+  async function park(instanceId: string, id: number): Promise<string> {
+    const result = await client('triager', instanceId).call('posts.publish', { id })
+    if (!result.pending) throw new Error('the fixture tool did not park')
+    return result.requestId
+  }
+
+  test('should report a request this instance created', async () => {
+    const requestId = await park('status-1', 101)
+
+    const answer = await client('triager', 'status-1').status(requestId)
+
+    expect(answer.found).toBe(true)
+    if (!answer.found) return
+    expect(answer.report).toMatchObject({
+      requestId,
+      status: 'pending',
+      tool: 'posts.publish',
+      executed: false,
+    })
+  })
+
+  test('should audit a report under the meta-tool name and the durable surface', async () => {
+    const requestId = await park('status-2', 102)
+    records.length = 0
+
+    await client('triager', 'status-2').status(requestId)
+    await drainEvents()
+
+    const invoked = records.filter((event): event is AgentToolInvoked => event instanceof AgentToolInvoked)
+    expect(invoked).toHaveLength(1)
+    expect(invoked[0]!.tool).toBe('guren.approval_status')
+    expect(invoked[0]!.status).toBe(200)
+    expect(invoked[0]!.surface).toBe('durable')
+    expect(invoked[0]!.principal?.id).toBe('agent:triager:status-2')
+  })
+
+  test('should answer not found for an id no request carries, audited as a 404', async () => {
+    records.length = 0
+
+    const answer = await client('triager', 'status-3').status('no-such-request')
+    await drainEvents()
+
+    expect(answer.found).toBe(false)
+    expect(answer.unavailable).toBeUndefined()
+    const invoked = records.filter((event): event is AgentToolInvoked => event instanceof AgentToolInvoked)
+    expect(invoked[0]!.status).toBe(404)
+  })
+
+  test('should hide another instance request behind the same answer, audited as a 403', async () => {
+    const requestId = await park('status-owner', 104)
+    records.length = 0
+
+    // Two instances of one agent are two principals, and approvals are isolated
+    // by that id: a caller must not be able to enumerate another's pending
+    // actions by walking ids.
+    const answer = await client('triager', 'status-stranger').status(requestId)
+    await drainEvents()
+
+    expect(answer.found).toBe(false)
+    const invoked = records.filter((event): event is AgentToolInvoked => event instanceof AgentToolInvoked)
+    expect(invoked[0]!.status).toBe(403)
+  })
+
+  test('should answer an unknown id and a foreign one identically', async () => {
+    const requestId = await park('status-owner-2', 105)
+    const stranger = client('triager', 'status-stranger-2')
+
+    const foreign = await stranger.status(requestId)
+    const unknown = await stranger.status('no-such-request')
+
+    // One message for both branches, echoing only the id the caller supplied.
+    // Any difference beyond that is the enumeration the 403/404 split in the
+    // trail exists to keep out of the caller's reach.
+    expect(foreign.message).toBe(approvalStatusNotFoundMessage(requestId))
+    expect(unknown.message).toBe(approvalStatusNotFoundMessage('no-such-request'))
+  })
+
+  test('should spend the per-instance budget', async () => {
+    // A status check reaches the application's storage, so an unmetered one is
+    // a hole in the budget an agent can poll through.
+    let clock = 6_000_000
+    const thrifty = client('thrifty', 't-status', () => clock)
+
+    expect((await thrifty.status('a')).found).toBe(false)
+    expect((await thrifty.status('b')).found).toBe(false)
+
+    const spent = await thrifty.status('c')
+    expect(spent.unavailable).toBe(true)
+    expect(spent.message).toContain('callsPerMinute')
+  })
+
+  test('should keep the check unavailable rather than missing with no queue', async () => {
+    // The two are handled oppositely by the ledger: a row is purged on a
+    // missing record and kept on an unanswerable check.
+    const unqueued: AgentRuntime = { ...runtime }
+    delete unqueued.approvals
+
+    const answer = await createAgentToolClient({
+      runtime: unqueued,
+      agentName: 'triager',
+      instanceId: 'status-4',
+    }).status('any')
+
+    expect(answer.unavailable).toBe(true)
+    expect(answer.message).toContain('agentsPlugin({ approvals: { store, notify } })')
+  })
+
+  test('should report a store that threw as unavailable, audited as a 500', async () => {
+    const broken: AgentRuntime = {
+      ...runtime,
+      approvals: {
+        store: {
+          create: () => Promise.resolve(),
+          find: () => Promise.reject(new Error('the queue is down')),
+          findMatch: () => Promise.resolve(null),
+          consume: () => Promise.resolve(false),
+        },
+        notify: () => {},
+      },
+    }
+    records.length = 0
+
+    const answer = await createAgentToolClient({
+      runtime: broken,
+      agentName: 'triager',
+      instanceId: 'status-5',
+    }).status('any')
+    await drainEvents()
+
+    expect(answer.unavailable).toBe(true)
+    expect(answer.message).toContain('the queue is down')
+    const invoked = records.filter((event): event is AgentToolInvoked => event instanceof AgentToolInvoked)
+    expect(invoked[0]!.status).toBe(500)
   })
 })
 

--- a/packages/plugin-agents/src/tool-client.ts
+++ b/packages/plugin-agents/src/tool-client.ts
@@ -8,13 +8,20 @@
  * Nothing here imports `agents`: this half runs on Bun, and the Durable Object
  * shell lives in `./agent`.
  */
-import { createAgentApprovalContext, createAgentInvocationPipeline } from '@guren/core'
+import {
+  APPROVAL_STATUS_TOOL_NAME,
+  createAgentApprovalContext,
+  createAgentAuditRecorder,
+  createAgentInvocationPipeline,
+  toApprovalStatusReport,
+} from '@guren/core'
 import type {
   AgentAuditEmitter,
   AgentInvocationDenial,
   AgentInvocationPipeline,
   AgentPrincipal,
   AgentToolDenialReason,
+  ApprovalStatusReport,
   ToolCallOutcome,
 } from '@guren/core'
 
@@ -33,14 +40,17 @@ export interface AgentToolCallOk {
 /**
  * The tool needs a human, and one has been asked.
  *
- * Nothing executed. Part 3 adds the ledger that checkpoints
- * `{ requestId, tool, args }` and retries once the approval settles; in this
- * part the agent gets the id and decides for itself what to do with it.
+ * Nothing executed. A `GurenAgent` checkpoints `{ requestId, tool, args }` into
+ * its ledger and retries once the approval settles; a client driven directly
+ * gets the id and decides for itself what to do with it.
  */
 export interface AgentToolCallPending {
   pending: true
   requestId: string
   tool: string
+  /** ISO 8601, from the queue's record. */
+  requestedAt?: string
+  /** ISO 8601, from the queue's record — the ledger never extends it. */
   expiresAt?: string
   message: string
   ok?: undefined
@@ -80,9 +90,72 @@ export type AgentToolCallResult =
   | AgentToolCallDenied
   | AgentToolCallFailed
 
+/** The queue answered with this caller's record. */
+export interface AgentApprovalStatusFound {
+  found: true
+  report: ApprovalStatusReport
+  message?: undefined
+  unavailable?: undefined
+}
+
+/** The queue answered: no such request, or not this caller's. */
+export interface AgentApprovalStatusMissing {
+  found: false
+  message: string
+  report?: undefined
+  unavailable?: undefined
+}
+
+/**
+ * The question could not be put to the queue — budget spent, no queue, or a
+ * store that threw. Its own variant because "unknown" and "unasked" have
+ * opposite correct handling: a caller purging its retry material on an
+ * unanswerable check would drop arguments a later approval needs.
+ */
+export interface AgentApprovalStatusUnavailable {
+  unavailable: true
+  message: string
+  found?: undefined
+  report?: undefined
+}
+
+/** One status check's answer. */
+export type AgentApprovalStatusResult =
+  | AgentApprovalStatusFound
+  | AgentApprovalStatusMissing
+  | AgentApprovalStatusUnavailable
+
+/** What became of one parked call, as `onToolApprovalSettled` receives it. */
+export interface AgentToolApprovalSettled {
+  requestId: string
+  /** The tool the parked call addressed. */
+  tool: string
+  /**
+   * `'unknown'`: the queue holds no record of this request. `'unreadable'`: the
+   * ledger row could not be decrypted, so the request may still be pending in
+   * the queue but its arguments are gone and nothing can retry it.
+   */
+  status: 'approved' | 'rejected' | 'expired' | 'unknown' | 'unreadable'
+  /**
+   * The retry's own answer, which can itself be a refusal. Present only for
+   * `'approved'`, and **absent even then** when the approval was found already
+   * spent — an earlier sweep ran the call and was interrupted before it could
+   * clear the row, so nothing was called this time.
+   */
+  result?: AgentToolCallResult
+}
+
 export interface AgentToolClient {
   /** Call a tool by name. */
   call(name: string, args?: Record<string, unknown>): Promise<AgentToolCallResult>
+  /**
+   * What became of an approval request this agent created (RFC 0016 §5.4).
+   *
+   * The same answer `guren.approval_status` gives an MCP client, derived by the
+   * same rule and audited under the same tool name: a status check reaches the
+   * application's storage, so it spends the budget and leaves a record.
+   */
+  status(requestId: string): Promise<AgentApprovalStatusResult>
   /**
    * Ask the route for a verdict instead of an execution (RFC 0016 §5.4).
    *
@@ -207,11 +280,78 @@ export function createAgentToolClient(options: AgentToolClientOptions): AgentToo
     return fromDenial(result.denial, tool.toolName)
   }
 
+  // The same recorder the pipeline writes through, so a status check and a tool
+  // call cannot come to describe their principal, surface or masking differently.
+  const record = createAgentAuditRecorder({
+    ...(audit ? { audit } : {}),
+    principal,
+    surface: 'durable',
+  })
+
+  const status = async (requestId: string): Promise<AgentApprovalStatusResult> => {
+    if (!approvals) {
+      return {
+        unavailable: true,
+        message:
+          'This application has no approval queue, so no request can be looked up. Configure one '
+          + 'with agentsPlugin({ approvals: { store, notify } }).',
+      }
+    }
+
+    const audited = { toolName: APPROVAL_STATUS_TOOL_NAME }
+    const args = { requestId }
+
+    // Metered as a read, the way `guren.approval_status` is: a status check
+    // reaches the application's storage, so an unmetered one is a hole in the
+    // per-instance budget an agent can poll through.
+    const overBudget = budget.consume()
+    if (overBudget) {
+      record.denied(audited, args, overBudget.reason)
+      return { unavailable: true, message: overBudget.message }
+    }
+
+    const startedAt = performance.now()
+    try {
+      const outcome = toApprovalStatusReport(
+        requestId,
+        await approvals.store.find(requestId),
+        principal,
+        approvals.now(),
+      )
+
+      if ('notFound' in outcome) {
+        // 404 to the caller either way; 403 in the trail when the record exists
+        // and belongs to someone else. The caller must not be able to tell the
+        // two apart, and the operator must.
+        record.invoked(audited, args, outcome.foreign ? 403 : 404, elapsed(startedAt))
+        return { found: false, message: outcome.notFound }
+      }
+
+      record.invoked(audited, args, 200, elapsed(startedAt))
+      return { found: true, report: outcome.report }
+    } catch (error) {
+      record.invoked(audited, args, 500, elapsed(startedAt))
+      return {
+        unavailable: true,
+        message: `The approval queue could not be reached: ${describe(error)}`,
+      }
+    }
+  }
+
   return {
     call: (name, args = {}) => invoke(name, args, false),
     preflight: (name, args = {}) => invoke(name, args, true),
+    status,
     allowed: abilities.map((ability) => ability.slice('tool:'.length)),
   }
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function elapsed(startedAt: number): number {
+  return Math.round(performance.now() - startedAt)
 }
 
 /**
@@ -228,6 +368,7 @@ function fromDenial(denial: AgentInvocationDenial, toolName: string): AgentToolC
       pending: true,
       requestId: body.requestId,
       tool: typeof body.tool === 'string' ? body.tool : toolName,
+      ...(typeof body.requestedAt === 'string' ? { requestedAt: body.requestedAt } : {}),
       ...(typeof body.expiresAt === 'string' ? { expiresAt: body.expiresAt } : {}),
       message: denial.message,
     }

--- a/packages/plugin-agents/tests/workers/agent.workers.ts
+++ b/packages/plugin-agents/tests/workers/agent.workers.ts
@@ -103,6 +103,7 @@ describe('a scheduled callback that calls a tool', () => {
     expect(await runInDurableObject(stub, (agent) => agent.state)).toEqual({
       lastTitle: null,
       sweeps: 0,
+      settled: [],
     })
 
     // `runDurableObjectAlarm` fires the alarm *now*, and the SDK's handler then
@@ -118,7 +119,7 @@ describe('a scheduled callback that calls a tool', () => {
 
     // Checkpointed into state, not into a local: the call happened inside an
     // alarm, and nothing else survives the wake.
-    expect(state).toEqual({ lastTitle: 'Hello', sweeps: 1 })
+    expect(state).toEqual({ lastTitle: 'Hello', sweeps: 1, settled: [] })
   })
 })
 

--- a/packages/plugin-agents/tests/workers/app/app/Agents/TestAgent.ts
+++ b/packages/plugin-agents/tests/workers/app/app/Agents/TestAgent.ts
@@ -1,12 +1,24 @@
 import { GurenAgent } from '../../../../../src/agent'
+import type { AgentToolApprovalSettled, AgentToolCallResult } from '../../../../../src/index'
+import { hookThrows } from '../../config/hook-switch'
+
+/** What `onToolApprovalSettled` saw, flattened into state so a wake can report it. */
+interface SettledRecord {
+  requestId: string
+  tool: string
+  status: string
+  /** The retry's own answer: `true` executed, `false` refused, `null` no retry. */
+  retried: boolean | null
+}
 
 interface TestAgentState {
   lastTitle: string | null
   sweeps: number
+  settled: SettledRecord[]
 }
 
 export class TestAgent extends GurenAgent<Cloudflare.Env, TestAgentState> {
-  initialState: TestAgentState = { lastTitle: null, sweeps: 0 }
+  initialState: TestAgentState = { lastTitle: null, sweeps: 0, settled: [] }
 
   /** Reached only when the route authorizer let the request through. */
   async onRequest(): Promise<Response> {
@@ -19,7 +31,29 @@ export class TestAgent extends GurenAgent<Cloudflare.Env, TestAgentState> {
     const title = result.ok
       ? (JSON.parse(textOf(result.outcome)) as { posts: Array<{ title: string }> }).posts[0]!.title
       : null
-    this.setState({ lastTitle: title, sweeps: this.state.sweeps + 1 })
+    this.setState({ ...this.state, lastTitle: title, sweeps: this.state.sweeps + 1 })
+  }
+
+  /** The approval-gated tool, called the way an agent would call it. */
+  async destroyPost(id: number): Promise<AgentToolCallResult> {
+    return this.tools.call('posts.destroy', { id })
+  }
+
+  /** State, because a hook's locals do not survive the wake that fired it. */
+  onToolApprovalSettled(event: AgentToolApprovalSettled): void {
+    if (hookThrows()) throw new Error('the application hook failed')
+    this.setState({
+      ...this.state,
+      settled: [
+        ...this.state.settled,
+        {
+          requestId: event.requestId,
+          tool: event.tool,
+          status: event.status,
+          retried: event.result ? event.result.ok === true : null,
+        },
+      ],
+    })
   }
 }
 

--- a/packages/plugin-agents/tests/workers/app/app/Agents/ThriftyAgent.ts
+++ b/packages/plugin-agents/tests/workers/app/app/Agents/ThriftyAgent.ts
@@ -1,0 +1,11 @@
+import { GurenAgent } from '../../../../../src/agent'
+import type { AgentToolCallResult } from '../../../../../src/index'
+
+/** Registered with a budget small enough that a retry runs out of it. */
+export class ThriftyAgent extends GurenAgent<Cloudflare.Env, Record<string, never>> {
+  initialState: Record<string, never> = {}
+
+  async destroyPost(id: number): Promise<AgentToolCallResult> {
+    return this.tools.call('posts.destroy', { id })
+  }
+}

--- a/packages/plugin-agents/tests/workers/app/config/agents.ts
+++ b/packages/plugin-agents/tests/workers/app/config/agents.ts
@@ -1,5 +1,6 @@
 import { defineAgentsConfig } from '../../../../src/index'
 
+import { approvalQueue } from './approval-queue'
 import { agentRouting } from './routing-switch'
 
 export default defineAgentsConfig({
@@ -7,10 +8,20 @@ export default defineAgentsConfig({
     triager: {
       module: 'app/Agents/TestAgent.ts',
       export: 'TestAgent',
-      // Read only, so the write tool is a scope denial rather than a missing route.
-      scopes: ['tool:posts.index'],
+      // `posts.store` is left out, so the write tool is a scope denial rather
+      // than a missing route; `posts.destroy` is in, and gated on approval.
+      scopes: ['tool:posts.index', 'tool:posts.destroy'],
+    },
+    thrifty: {
+      module: 'app/Agents/ThriftyAgent.ts',
+      export: 'ThriftyAgent',
+      scopes: ['tool:posts.destroy'],
+      // Two calls buys a park and a status check; the retry is the third, so
+      // the rate-limited-retry path is reachable without waiting out a window.
+      budget: { callsPerMinute: 2 },
     },
   },
+  approvals: { store: approvalQueue, notify: () => {} },
   // A getter, not a value: the generated worker reads `routing` per request, so
   // one deploy can serve both the unconfigured deny-all and a configured
   // authorizer as the suite moves the switch.

--- a/packages/plugin-agents/tests/workers/app/config/approval-queue.ts
+++ b/packages/plugin-agents/tests/workers/app/config/approval-queue.ts
@@ -1,0 +1,53 @@
+/**
+ * The approval queue the workerd suite plays a human against.
+ *
+ * Its own module for the reason `routing-switch.ts` is one: `config/agents.ts`
+ * and `src/app.ts` both need it, and the app imports the config. In the
+ * isolate's memory, which is enough here because a Durable Object and the
+ * Worker entrypoint share one module instance — a deployed app needs a store
+ * its next isolate can read.
+ */
+import type {
+  AgentApprovalMatch,
+  AgentApprovalRequest,
+  AgentApprovalStore,
+} from '@guren/core'
+
+class MemoryApprovalStore implements AgentApprovalStore {
+  readonly records: AgentApprovalRequest[] = []
+  /** Lookups left to fail, so a test can drive the unanswerable-check path. */
+  failLookups = 0
+
+  async create(request: AgentApprovalRequest): Promise<void> {
+    this.records.push(request)
+  }
+
+  async find(id: string): Promise<AgentApprovalRequest | null> {
+    if (this.failLookups > 0) {
+      this.failLookups -= 1
+      throw new Error('the queue is unreachable')
+    }
+    return this.records.find((record) => record.id === id) ?? null
+  }
+
+  async findMatch(match: AgentApprovalMatch): Promise<AgentApprovalRequest | null> {
+    const matched = this.records.filter(
+      (record) =>
+        record.tool === match.tool
+        && record.fingerprint === match.fingerprint
+        && record.principalKey === match.principalKey
+        && record.consumedAt === undefined,
+    )
+    return matched[matched.length - 1] ?? null
+  }
+
+  /** Compare-and-set, so two concurrent calls cannot both win one approval. */
+  async consume(id: string): Promise<boolean> {
+    const record = this.records.find((candidate) => candidate.id === id)
+    if (!record || record.consumedAt !== undefined) return false
+    record.consumedAt = new Date().toISOString()
+    return true
+  }
+}
+
+export const approvalQueue = new MemoryApprovalStore()

--- a/packages/plugin-agents/tests/workers/app/config/hook-switch.ts
+++ b/packages/plugin-agents/tests/workers/app/config/hook-switch.ts
@@ -1,0 +1,17 @@
+/**
+ * Whether the fixture agents' `onToolApprovalSettled` throws.
+ *
+ * The hook is application code running inside a schedule the SDK would replay,
+ * so "a throwing hook does not strand the other rows" is a real invariant. Its
+ * own module for the reason `routing-switch.ts` is one: the suite moves it over
+ * HTTP rather than by importing the worker.
+ */
+let throwing = false
+
+export function setHookThrows(value: boolean): void {
+  throwing = value
+}
+
+export function hookThrows(): boolean {
+  return throwing
+}

--- a/packages/plugin-agents/tests/workers/app/src/app.ts
+++ b/packages/plugin-agents/tests/workers/app/src/app.ts
@@ -2,12 +2,17 @@
  * The fixture application `guren cloudflare:build` assembles the workerd
  * suite's worker from.
  *
- * A real Guren app: two agent tools and a probe surface the tests drive over
- * HTTP rather than by importing this module, so no assertion depends on the
- * test and the worker sharing a module instance.
+ * A real Guren app: three agent tools — one behind the approval queue — and a
+ * probe surface the tests drive over HTTP rather than by importing this module,
+ * so no assertion depends on the test and the worker sharing a module instance.
  */
+// Assigned before `createApp` runs: `EncryptionServiceProvider.register()` reads
+// `process.env.APP_KEY` at registration, and this module registers at evaluation.
+process.env.APP_KEY = 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+
 import {
   AgentToolInvoked,
+  EncryptionServiceProvider,
   EventServiceProvider,
   createApp,
   type EventManager,
@@ -17,7 +22,12 @@ import { z } from 'zod'
 
 import { agentsPlugin } from '../../../../src/plugin'
 import agents from '../config/agents'
+import { approvalQueue } from '../config/approval-queue'
+import { setHookThrows } from '../config/hook-switch'
 import { lastRoutedTarget, setRoutingMode, type RoutingMode } from '../config/routing-switch'
+
+/** Post ids the gated tool actually deleted, so a retry cannot run twice unseen. */
+const destroyed: number[] = []
 
 /** Principal ids the audit trail recorded, reported by `GET /__probe`. */
 const auditedPrincipals: string[] = []
@@ -33,6 +43,15 @@ let boots = 0
 
 const RoutingQuery = z.object({ mode: z.enum(['absent', 'allow', 'deny', 'response', 'throw']) })
 
+const HookQuery = z.object({ throws: z.enum(['yes', 'no']) })
+
+const BreakQuery = z.object({ times: z.coerce.number().int().nonnegative() })
+
+const ResolveQuery = z.object({
+  id: z.string(),
+  verdict: z.enum(['approved', 'rejected', 'expire']),
+})
+
 function registerRoutes(router: Router): void {
   router
     .get('/posts', () => Response.json({ posts: [{ id: 1, title: 'Hello' }] }))
@@ -45,8 +64,64 @@ function registerRoutes(router: Router): void {
     .name('posts.store')
     .agent({ description: 'Create a post' })
 
+  router
+    .delete('/posts/:id', { params: z.object({ id: z.coerce.number() }) }, ({ params }) => {
+      destroyed.push(params.id)
+      return Response.json({ destroyed: params.id })
+    })
+    .name('posts.destroy')
+    .agent({ description: 'Delete a post', approval: 'required' })
+
   router.get('/__probe', () =>
-    Response.json({ boots, principals: auditedPrincipals, target: lastRoutedTarget() ?? null }))
+    Response.json({
+      boots,
+      principals: auditedPrincipals,
+      target: lastRoutedTarget() ?? null,
+      destroyed,
+      approvals: approvalQueue.records.map((record) => ({
+        id: record.id,
+        tool: record.tool,
+        status: record.status,
+        expiresAt: record.expiresAt,
+        consumed: record.consumedAt !== undefined,
+      })),
+    }))
+
+  // The human's half of the loop, as the suite plays it. `expire` rewrites the
+  // record's own expiry rather than a clock: `agentApprovalStatusAt` derives
+  // expiry from that field, so this is the one thing a test can move.
+  router.get('/__probe/approvals', { query: ResolveQuery }, ({ query }) => {
+    const record = approvalQueue.records.find((candidate) => candidate.id === query.id)
+    if (!record) return Response.json({ error: 'no such request' }, { status: 404 })
+
+    if (query.verdict === 'expire') {
+      record.expiresAt = new Date(Date.now() - 1000).toISOString()
+    } else {
+      record.status = query.verdict
+      record.resolvedAt = new Date().toISOString()
+      record.resolvedBy = 'the-suite'
+    }
+    return Response.json({ id: record.id, status: record.status })
+  })
+
+  router.get('/__probe/break', { query: BreakQuery }, ({ query }) => {
+    approvalQueue.failLookups = query.times
+    return Response.json({ failLookups: query.times })
+  })
+
+  router.get('/__probe/hook', { query: HookQuery }, ({ query }) => {
+    setHookThrows(query.throws === 'yes')
+    return Response.json({ throws: query.throws })
+  })
+
+  router.get('/__probe/reset', () => {
+    setHookThrows(false)
+    approvalQueue.failLookups = 0
+    approvalQueue.records.length = 0
+    destroyed.length = 0
+    auditedPrincipals.length = 0
+    return Response.json({ reset: true })
+  })
 
   // GET rather than POST: a direct request from the suite carries no session
   // and no XSRF token, and this switch is fixture plumbing, not a tool.
@@ -59,7 +134,7 @@ function registerRoutes(router: Router): void {
 
 const application = createApp({
   routes: registerRoutes,
-  providers: [EventServiceProvider, agentsPlugin(agents)],
+  providers: [EventServiceProvider, EncryptionServiceProvider, agentsPlugin(agents)],
 })
 
 // A counting wrapper rather than the Application itself: `bootWorkersApp`

--- a/packages/plugin-agents/tests/workers/app/wrangler.jsonc
+++ b/packages/plugin-agents/tests/workers/app/wrangler.jsonc
@@ -28,11 +28,12 @@
   "durable_objects": {
     "bindings": [
       { "name": "TEST_AGENT", "class_name": "TestAgent" },
-      { "name": "STRAY_AGENT", "class_name": "StrayAgent" }
+      { "name": "STRAY_AGENT", "class_name": "StrayAgent" },
+      { "name": "THRIFTY_AGENT", "class_name": "ThriftyAgent" }
     ]
   },
   // `new_sqlite_classes`, not `new_classes`: the SDK stores state and all its
   // bookkeeping in Durable Object SQLite, so the legacy KV storage backend
   // cannot host an Agent. This is the form the scaffold emits.
-  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["TestAgent", "StrayAgent"] }]
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["TestAgent", "StrayAgent", "ThriftyAgent"] }]
 }

--- a/packages/plugin-agents/tests/workers/approvals.workers.ts
+++ b/packages/plugin-agents/tests/workers/approvals.workers.ts
@@ -1,0 +1,386 @@
+/// <reference types="@cloudflare/vitest-plugin/types" />
+import { env } from 'cloudflare:workers'
+import { SELF, evictDurableObject, runDurableObjectAlarm, runInDurableObject } from 'cloudflare:test'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { TestAgent } from './app/app/Agents/TestAgent'
+import type { ThriftyAgent } from './app/app/Agents/ThriftyAgent'
+
+/**
+ * The pending-approval ledger inside a real Durable Object (RFC 0017 §5).
+ *
+ * What Bun cannot reach: DO SQLite, the SDK's schedules, and eviction. The
+ * queue's own side is read over HTTP so no assertion rests on the suite and the
+ * worker sharing a module instance.
+ */
+
+interface TestEnv {
+  TEST_AGENT: DurableObjectNamespace<TestAgent>
+  THRIFTY_AGENT: DurableObjectNamespace<ThriftyAgent>
+}
+
+const bindings = env as unknown as TestEnv
+
+interface ApprovalRecord {
+  id: string
+  tool: string
+  status: string
+  expiresAt: string
+  consumed: boolean
+}
+
+interface Probe {
+  destroyed: number[]
+  approvals: ApprovalRecord[]
+}
+
+let instance = 0
+
+function freshAgent(): DurableObjectStub<TestAgent> {
+  instance += 1
+  const name = `approver-${instance}`
+  return bindings.TEST_AGENT.get(bindings.TEST_AGENT.idFromName(name))
+}
+
+async function probe(): Promise<Probe> {
+  const response = await SELF.fetch('https://fixture.test/__probe')
+  expect(response.status).toBe(200)
+  return (await response.json()) as Probe
+}
+
+async function resolve(id: string, verdict: 'approved' | 'rejected' | 'expire'): Promise<void> {
+  const response = await SELF.fetch(
+    `https://fixture.test/__probe/approvals?id=${id}&verdict=${verdict}`,
+  )
+  expect(response.status).toBe(200)
+}
+
+/** Either fixture class: both are `GurenAgent`s with a ledger behind them. */
+type LedgerAgent = TestAgent | ThriftyAgent
+
+/** The ledger's own rows, straight out of the agent's SQLite. */
+function ledgerRows<A extends LedgerAgent>(
+  stub: DurableObjectStub<A>,
+): Promise<Array<Record<string, string | number | boolean | null>>> {
+  return runInDurableObject(stub, (agent) =>
+    agent.sql`SELECT * FROM guren_pending_tool_calls`)
+}
+
+function checkSchedules<A extends LedgerAgent>(stub: DurableObjectStub<A>): Promise<string[]> {
+  return runInDurableObject(stub, async (agent) =>
+    (await agent.listSchedules({ type: 'delayed' }))
+      .filter((schedule) => schedule.callback === 'checkPendingApprovals')
+      .map((schedule) => schedule.id))
+}
+
+/**
+ * Bring the SDK's own schedule rows forward so an alarm has something due.
+ *
+ * `runDurableObjectAlarm` fires now, but the SDK's handler runs only schedules
+ * whose `time` has passed, and the ledger's first backoff is 30s. Reaching into
+ * `cf_agents_schedules` is what tests the alarm path in under a second.
+ */
+async function makeDue(stub: DurableObjectStub<TestAgent>): Promise<void> {
+  await runInDurableObject(stub, (agent) => {
+    void agent.sql`UPDATE cf_agents_schedules SET time = ${Math.floor(Date.now() / 1000) - 1}`
+  })
+}
+
+function thriftyAgent(): DurableObjectStub<ThriftyAgent> {
+  instance += 1
+  const name = `thrifty-${instance}`
+  return bindings.THRIFTY_AGENT.get(bindings.THRIFTY_AGENT.idFromName(name))
+}
+
+async function setHookThrows(throws: boolean): Promise<void> {
+  const response = await SELF.fetch(
+    `https://fixture.test/__probe/hook?throws=${throws ? 'yes' : 'no'}`,
+  )
+  expect(response.status).toBe(200)
+}
+
+async function breakQueue(times: number): Promise<void> {
+  const response = await SELF.fetch(`https://fixture.test/__probe/break?times=${times}`)
+  expect(response.status).toBe(200)
+}
+
+async function park(stub: DurableObjectStub<TestAgent>, id: number): Promise<string> {
+  const result = await runInDurableObject(stub, (agent) => agent.destroyPost(id))
+  expect(result.pending).toBe(true)
+  if (!result.pending) throw new Error('unreachable')
+  return result.requestId
+}
+
+function settled(stub: DurableObjectStub<TestAgent>): Promise<TestAgent['state']['settled']> {
+  return runInDurableObject(stub, (agent) => agent.state.settled)
+}
+
+beforeEach(async () => {
+  const response = await SELF.fetch('https://fixture.test/__probe/reset')
+  expect(response.status).toBe(200)
+})
+
+describe('a call the approval queue parks', () => {
+  it('should checkpoint the arguments and schedule exactly one check', async () => {
+    const stub = freshAgent()
+
+    const requestId = await park(stub, 41)
+
+    const rows = await ledgerRows(stub)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.request_id).toBe(requestId)
+    expect(rows[0]!.tool).toBe('posts.destroy')
+    expect(rows[0]!.checks).toBe(0)
+    expect(await checkSchedules(stub)).toHaveLength(1)
+    // Nothing ran: the whole point of a parked call.
+    expect((await probe()).destroyed).toEqual([])
+  })
+
+  it('should store the arguments encrypted at rest', async () => {
+    const stub = freshAgent()
+
+    await park(stub, 987654)
+
+    const [row] = await ledgerRows(stub)
+    // A leaked snapshot of this Durable Object must not disclose what the agent
+    // asked for — the queue's own record is redacted for the same reason.
+    expect(String(row!.args)).not.toContain('987654')
+    expect(String(row!.args)).not.toContain('"id"')
+  })
+
+  it('should not schedule a second check for a second parked call', async () => {
+    const stub = freshAgent()
+
+    await park(stub, 1)
+    await park(stub, 2)
+
+    expect(await ledgerRows(stub)).toHaveLength(2)
+    expect(await checkSchedules(stub)).toHaveLength(1)
+  })
+})
+
+describe('the scheduled check', () => {
+  it('should repeat the call once on the alarm when a human approved it', async () => {
+    const stub = freshAgent()
+    const requestId = await park(stub, 7)
+
+    await resolve(requestId, 'approved')
+    await makeDue(stub)
+    expect(await runDurableObjectAlarm(stub)).toBe(true)
+
+    // Executed exactly once, and the approval is spent: the retry carries the
+    // stored arguments, so the queue's fingerprint match binds it to this call.
+    const report = await probe()
+    expect(report.destroyed).toEqual([7])
+    expect(report.approvals[0]!.consumed).toBe(true)
+
+    expect(await ledgerRows(stub)).toEqual([])
+    expect(await settled(stub)).toEqual([
+      { requestId, tool: 'posts.destroy', status: 'approved', retried: true },
+    ])
+    // Nothing left to wait for, so nothing is scheduled.
+    expect(await checkSchedules(stub)).toEqual([])
+  })
+
+  it('should drop the row and report a rejection without calling the tool', async () => {
+    const stub = freshAgent()
+    const requestId = await park(stub, 8)
+
+    await resolve(requestId, 'rejected')
+    await runInDurableObject(stub, (agent) => agent.checkPendingApprovals())
+
+    expect((await probe()).destroyed).toEqual([])
+    expect(await ledgerRows(stub)).toEqual([])
+    expect(await settled(stub)).toEqual([
+      { requestId, tool: 'posts.destroy', status: 'rejected', retried: null },
+    ])
+  })
+
+  it('should prune a request whose window closed unanswered', async () => {
+    const stub = freshAgent()
+    const requestId = await park(stub, 9)
+
+    await resolve(requestId, 'expire')
+    await runInDurableObject(stub, (agent) => agent.checkPendingApprovals())
+
+    expect((await probe()).destroyed).toEqual([])
+    expect(await ledgerRows(stub)).toEqual([])
+    expect(await settled(stub)).toEqual([
+      { requestId, tool: 'posts.destroy', status: 'expired', retried: null },
+    ])
+  })
+
+  it('should keep a still-pending row, count the check, and reschedule once', async () => {
+    const stub = freshAgent()
+    const requestId = await park(stub, 10)
+
+    await runInDurableObject(stub, (agent) => agent.checkPendingApprovals())
+
+    const rows = await ledgerRows(stub)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.request_id).toBe(requestId)
+    // The count is what lengthens the backoff; one schedule is what keeps a
+    // sweep from multiplying its own wakes.
+    expect(rows[0]!.checks).toBe(1)
+    expect(await checkSchedules(stub)).toHaveLength(1)
+    expect(await settled(stub)).toEqual([])
+  })
+})
+
+describe('a check the queue cannot answer', () => {
+  it('should keep the row, count the check, and reschedule', async () => {
+    const stub = freshAgent()
+    const requestId = await park(stub, 12)
+
+    await breakQueue(1)
+    await runInDurableObject(stub, (agent) => agent.checkPendingApprovals())
+
+    // Unanswerable is not "no such request": purging here would drop the
+    // arguments an approval granted an hour later needs. The count still
+    // advances, so a queue that stays down backs off instead of re-asking at
+    // one cadence until the request expires.
+    const rows = await ledgerRows(stub)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.request_id).toBe(requestId)
+    expect(rows[0]!.checks).toBe(1)
+    expect(await checkSchedules(stub)).toHaveLength(1)
+    expect(await settled(stub)).toEqual([])
+  })
+
+  it('should still retry once the queue comes back', async () => {
+    const stub = freshAgent()
+    const requestId = await park(stub, 13)
+
+    await breakQueue(1)
+    await runInDurableObject(stub, (agent) => agent.checkPendingApprovals())
+    await resolve(requestId, 'approved')
+    await runInDurableObject(stub, (agent) => agent.checkPendingApprovals())
+
+    expect((await probe()).destroyed).toEqual([13])
+    expect(await ledgerRows(stub)).toEqual([])
+  })
+})
+
+describe('a sweep interrupted after the call already ran', () => {
+  it('should not call the tool or page a human a second time', async () => {
+    const stub = freshAgent()
+    const requestId = await park(stub, 30)
+    await resolve(requestId, 'approved')
+
+    // Stands in for the interruption the SDK's retry creates: the approval is
+    // spent and the tool has run, but the ledger row is still there. Same
+    // instance, so this is the same principal and the same fingerprint — the
+    // gate consumes exactly the approval the sweep was going to spend.
+    await runInDurableObject(stub, (agent) => agent.tools.call('posts.destroy', { id: 30 }))
+    await runInDurableObject(stub, (agent) => agent.checkPendingApprovals())
+
+    const report = await probe()
+    // Once. Re-calling would find no unconsumed match, file a second request,
+    // page a human again, and delete the post twice on approval.
+    expect(report.destroyed).toEqual([30])
+    expect(report.approvals).toHaveLength(1)
+    expect(report.approvals[0]!.consumed).toBe(true)
+
+    expect(await ledgerRows(stub)).toEqual([])
+    // No `result`: nothing was called this time round.
+    expect(await settled(stub)).toEqual([
+      { requestId, tool: 'posts.destroy', status: 'approved', retried: null },
+    ])
+  })
+})
+
+describe('a hook that throws', () => {
+  it('should not fail the sweep when it throws outside a row handler', async () => {
+    const stub = freshAgent()
+    const lapsing = await park(stub, 20)
+    await park(stub, 21)
+    // The row's own expiry, not the queue record's: `pruneExpired` reads what
+    // was copied at park time, and resolving the queue side never writes back.
+    await runInDurableObject(stub, (agent) => {
+      void agent.sql`UPDATE guren_pending_tool_calls SET expires_at = '2020-01-01T00:00:00.000Z'
+        WHERE request_id = ${lapsing}`
+    })
+
+    await setHookThrows(true)
+    // Pruning runs before the per-row handlers, so nothing else would catch
+    // this. A throw escaping here is retried three times by the SDK and then
+    // leaves every surviving row with no schedule at all.
+    await runInDurableObject(stub, (agent) => agent.checkPendingApprovals())
+
+    const rows = await ledgerRows(stub)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.checks).toBe(1)
+    expect(await checkSchedules(stub)).toHaveLength(1)
+  })
+})
+
+describe('a row naming a tool the application no longer has', () => {
+  it('should keep the row and settle the others', async () => {
+    const stub = freshAgent()
+    const requestId = await park(stub, 60)
+    await park(stub, 61)
+    await resolve(requestId, 'approved')
+
+    // What a deploy that dropped a route leaves behind: `client.call` throws
+    // rather than answering, and without a per-row catch the whole sweep would
+    // die on it at every wake until both rows expired.
+    await runInDurableObject(stub, (agent) => {
+      void agent.sql`UPDATE guren_pending_tool_calls SET tool = 'posts.gone'
+        WHERE request_id = ${requestId}`
+    })
+    await runInDurableObject(stub, (agent) => agent.checkPendingApprovals())
+
+    const rows = await ledgerRows(stub)
+    expect(rows).toHaveLength(2)
+    // Both counted: the broken one by its catch, the healthy one as pending.
+    expect(rows.map((row) => row.checks)).toEqual([1, 1])
+    expect(await checkSchedules(stub)).toHaveLength(1)
+  })
+})
+
+describe('a retry that runs out of budget', () => {
+  it('should keep the approval rather than spend it on a refusal', async () => {
+    const stub = thriftyAgent()
+
+    const parked = await runInDurableObject(stub, (agent) => agent.destroyPost(50))
+    expect(parked.pending).toBe(true)
+    if (!parked.pending) return
+    await resolve(parked.requestId, 'approved')
+
+    // The status check is the second of two calls a minute, so the retry is the
+    // third and comes back rate-limited.
+    await runInDurableObject(stub, (agent) => agent.checkPendingApprovals())
+
+    const report = await probe()
+    expect(report.destroyed).toEqual([])
+    // Reporting the refusal as the approval's outcome would drop the row, and a
+    // human's approval would be spent by nobody and never retried.
+    expect(report.approvals[0]!.consumed).toBe(false)
+
+    const rows = await ledgerRows(stub)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.checks).toBe(1)
+  })
+})
+
+describe('the retry across an eviction', () => {
+  it('should repeat the call from durable state alone', async () => {
+    const stub = freshAgent()
+    const requestId = await park(stub, 11)
+
+    // Everything in memory is gone: the client, its budget, the ledger object.
+    // Only DO SQLite and the SDK's schedules survive, which is the rule the
+    // design follows rather than parking an awaited promise.
+    await evictDurableObject(stub)
+
+    await resolve(requestId, 'approved')
+    await makeDue(stub)
+    expect(await runDurableObjectAlarm(stub)).toBe(true)
+
+    expect((await probe()).destroyed).toEqual([11])
+    expect(await ledgerRows(stub)).toEqual([])
+    expect(await settled(stub)).toEqual([
+      { requestId, tool: 'posts.destroy', status: 'approved', retried: true },
+    ])
+  })
+})

--- a/packages/plugin-mcp/src/approval-status.ts
+++ b/packages/plugin-mcp/src/approval-status.ts
@@ -4,17 +4,11 @@
  * a request id; this is what the id is for. A meta-tool for the same protocol
  * reason `guren.preflight` is one: a status is not the gated route's output, and
  * MCP forbids a schema-declaring tool from answering with a different shape of
- * success. It owns no rule — expiry is `agentApprovalStatusAt` and visibility
- * `agentApprovalVisibleTo`, the same two the gate reads, so a record this tool
- * calls "approved" cannot be one the gate refuses.
+ * success. It owns no rule — the answer itself is `toApprovalStatusReport` in
+ * `@guren/core`, shared with the durable surface, so a record this tool calls
+ * "approved" cannot be one the gate refuses.
  */
-import {
-  agentApprovalStatusAt,
-  agentApprovalVisibleTo,
-  APPROVAL_STATUS_TOOL_NAME,
-  type AgentApprovalRequest,
-  type AgentPrincipal,
-} from '@guren/core'
+import { APPROVAL_STATUS_TOOL_NAME } from '@guren/core'
 
 /** A JSON Schema object as MCP advertises it. */
 type McpObjectSchema = { type: 'object'; [key: string]: unknown }
@@ -68,6 +62,13 @@ const APPROVAL_STATUS_OUTPUT_SCHEMA: McpObjectSchema = {
         'Always false. Reading a status never performs the call — an approved request still has to '
         + 'be called again.',
     },
+    consumedAt: {
+      type: 'string',
+      description:
+        'ISO 8601 instant the approval was spent. Approved and already spent: the one call it '
+        + 'permitted has run — do not repeat the call. Absent while an approval is still available '
+        + 'to use.',
+    },
   },
   required: ['requestId', 'status', 'tool', 'requestedAt', 'expiresAt', 'executed'],
 }
@@ -116,66 +117,4 @@ export function readApprovalStatusArguments(
     }
   }
   return { requestId }
-}
-
-/** One answer, as it rides in `structuredContent`. */
-export interface ApprovalStatusReport {
-  [key: string]: unknown
-  requestId: string
-  status: string
-  tool: string
-  requestedAt: string
-  expiresAt: string
-  executed: false
-  resolvedAt?: string
-  resolvedBy?: string
-}
-
-/**
- * The one message for "there is no such request *for you*". One function for
- * both branches because an unknown id and another principal's id must be the
- * same answer byte for byte: any difference turns the tool into a way to
- * enumerate other principals' pending actions. The audit trail is where the
- * distinction is kept, for the operator.
- */
-export function approvalStatusNotFoundMessage(requestId: string): string {
-  return `No approval request with id "${requestId}" was made by this caller.`
-}
-
-export type ApprovalStatusOutcome =
-  | { report: ApprovalStatusReport }
-  /**
-   * Unknown, or not this caller's — one answer to the caller. `foreign` is the
-   * half the *operator* gets: it rides beside the message, for the audit event,
-   * and must never reach the result.
-   */
-  | { notFound: string; foreign: boolean }
-
-/**
- * Read a stored record as an answer for `principal` at `now`. `record === null`
- * and "not visible to this principal" converge here rather than at two call
- * sites, so their sameness is structural.
- */
-export function toApprovalStatusReport(
-  requestId: string,
-  record: AgentApprovalRequest | null,
-  principal: AgentPrincipal | null,
-  now: Date,
-): ApprovalStatusOutcome {
-  if (!record || !agentApprovalVisibleTo(record, principal)) {
-    return { notFound: approvalStatusNotFoundMessage(requestId), foreign: record !== null }
-  }
-
-  return {
-    report: {
-      requestId: record.id,
-      status: agentApprovalStatusAt(record, now),
-      tool: record.tool,
-      requestedAt: record.requestedAt,
-      expiresAt: record.expiresAt,
-      executed: false,
-      ...(record.resolvedAt ? { resolvedAt: record.resolvedAt } : {}),
-      ...(record.resolvedBy ? { resolvedBy: record.resolvedBy } : {}),
-    },
-  }
 }

--- a/packages/plugin-mcp/src/approval.test.ts
+++ b/packages/plugin-mcp/src/approval.test.ts
@@ -546,6 +546,38 @@ describe('guren.approval_status', () => {
     })
   })
 
+  test('should report a spent approval as consumed, so a caller does not repeat it', async () => {
+    const store = new MemoryApprovalStore()
+    const spent = await seedApproved(store, { id: 5 }, { consumedAt: NOW.toISOString() })
+    const { client } = await connect({ store })
+
+    const result = await client.callTool({
+      name: 'guren.approval_status',
+      arguments: { requestId: spent.id },
+    })
+
+    // Still "approved" — the human said yes — but the one call it permitted has
+    // run. A caller that repeated it would file a fresh request and, on
+    // approval, perform the action a second time.
+    expect(result.structuredContent).toMatchObject({
+      status: 'approved',
+      consumedAt: NOW.toISOString(),
+    })
+  })
+
+  test('should omit consumedAt while an approval is still available', async () => {
+    const store = new MemoryApprovalStore()
+    const approved = await seedApproved(store, { id: 5 })
+    const { client } = await connect({ store })
+
+    const result = await client.callTool({
+      name: 'guren.approval_status',
+      arguments: { requestId: approved.id },
+    })
+
+    expect(result.structuredContent).not.toHaveProperty('consumedAt')
+  })
+
   test('should report an approved request with its resolution', async () => {
     const store = new MemoryApprovalStore()
     const approved = await seedApproved(store, { id: 5 })

--- a/packages/plugin-mcp/src/server.ts
+++ b/packages/plugin-mcp/src/server.ts
@@ -19,6 +19,7 @@ import {
   gateToolCall,
   isReservedAgentToolName,
   PREFLIGHT_TOOL_NAME,
+  toApprovalStatusReport,
   type AgentApprovalStore,
   type AgentInvocationDenial,
   type AgentInvocationPipeline,
@@ -28,11 +29,7 @@ import {
   type DerivedAgentTool,
 } from '@guren/core'
 
-import {
-  describeApprovalStatusTool,
-  readApprovalStatusArguments,
-  toApprovalStatusReport,
-} from './approval-status'
+import { describeApprovalStatusTool, readApprovalStatusArguments } from './approval-status'
 import { describePreflightTool, readPreflightArguments, toPreflightVerdict } from './preflight'
 import type { AgentRateLimiter } from './rate-limit'
 

--- a/packages/server/src/agent/approval-status.test.ts
+++ b/packages/server/src/agent/approval-status.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect } from 'bun:test'
+
+import { approvalStatusNotFoundMessage, toApprovalStatusReport } from './approval-status'
+import { agentApprovalPrincipalKey, type AgentApprovalRequest } from './approval'
+import type { AgentPrincipal } from './events'
+
+/**
+ * The rule two surfaces share (RFC 0016 §5.4): `guren.approval_status` over MCP
+ * and a durable agent's own check. Its own file because the answer is read by
+ * both, and one of its branches is a deliberate refusal to distinguish.
+ */
+
+const NOW = new Date('2026-09-06T12:00:00.000Z')
+
+const CALLER: AgentPrincipal = { kind: 'service', id: 'agent:triager:inbox-1', abilities: [] }
+const STRANGER: AgentPrincipal = { kind: 'service', id: 'agent:triager:inbox-2', abilities: [] }
+
+function record(overrides: Partial<AgentApprovalRequest> = {}): AgentApprovalRequest {
+  return {
+    id: 'req-1',
+    tool: 'posts.destroy',
+    input: { id: 5 },
+    fingerprint: 'fp',
+    principal: CALLER,
+    principalKey: agentApprovalPrincipalKey(CALLER),
+    requestedAt: NOW.toISOString(),
+    expiresAt: new Date(NOW.getTime() + 60_000).toISOString(),
+    status: 'pending',
+    ...overrides,
+  }
+}
+
+describe('toApprovalStatusReport', () => {
+  test('should report a pending request to the caller that created it', () => {
+    const outcome = toApprovalStatusReport('req-1', record(), CALLER, NOW)
+
+    expect(outcome).toEqual({
+      report: {
+        requestId: 'req-1',
+        status: 'pending',
+        tool: 'posts.destroy',
+        requestedAt: NOW.toISOString(),
+        expiresAt: new Date(NOW.getTime() + 60_000).toISOString(),
+        executed: false,
+      },
+    })
+  })
+
+  test('should derive expiry from the clock rather than the stored status', () => {
+    const lapsed = record({ expiresAt: new Date(NOW.getTime() - 1).toISOString() })
+
+    expect(toApprovalStatusReport('req-1', lapsed, CALLER, NOW)).toMatchObject({
+      report: { status: 'expired' },
+    })
+  })
+
+  test('should report a spent approval as consumed', () => {
+    // Still approved — a human said yes — but the one call it permitted has run.
+    // A caller repeating it files a fresh request and acts a second time.
+    const spent = record({ status: 'approved', consumedAt: NOW.toISOString() })
+
+    expect(toApprovalStatusReport('req-1', spent, CALLER, NOW)).toMatchObject({
+      report: { status: 'approved', consumedAt: NOW.toISOString() },
+    })
+  })
+
+  test('should omit consumedAt while the approval is still available', () => {
+    const approved = record({ status: 'approved' })
+    const outcome = toApprovalStatusReport('req-1', approved, CALLER, NOW)
+
+    expect('report' in outcome && 'consumedAt' in outcome.report).toBe(false)
+  })
+
+  test('should answer an unknown id and another principal id identically', () => {
+    // Any difference here turns the check into a way to enumerate other
+    // principals' pending actions.
+    const foreign = toApprovalStatusReport('req-1', record(), STRANGER, NOW)
+    const unknown = toApprovalStatusReport('req-1', null, CALLER, NOW)
+
+    expect(foreign).toEqual({ notFound: approvalStatusNotFoundMessage('req-1'), foreign: true })
+    expect(unknown).toEqual({ notFound: approvalStatusNotFoundMessage('req-1'), foreign: false })
+  })
+
+  test('should keep the found/not-found distinction for the operator only', () => {
+    // `foreign` rides beside the message for the audit event; the message the
+    // caller sees is the same either way.
+    const foreign = toApprovalStatusReport('req-1', record(), STRANGER, NOW)
+    const unknown = toApprovalStatusReport('req-1', null, CALLER, NOW)
+
+    expect('notFound' in foreign && 'notFound' in unknown
+      && foreign.notFound === unknown.notFound).toBe(true)
+    expect('foreign' in foreign && foreign.foreign).toBe(true)
+  })
+})

--- a/packages/server/src/agent/approval-status.ts
+++ b/packages/server/src/agent/approval-status.ts
@@ -1,0 +1,85 @@
+/**
+ * Reading one approval record as an answer for the caller that asked
+ * (RFC 0016 §5.4 item 4). Pure derivation, like `approval.ts`: no store, no
+ * clock, no protocol.
+ *
+ * Here rather than in an adapter because two surfaces answer this question —
+ * `guren.approval_status` over MCP and a durable agent's own status check
+ * (RFC 0017 §5) — and a record one of them calls "approved" must not be one
+ * the other hides.
+ */
+import {
+  agentApprovalStatusAt,
+  agentApprovalVisibleTo,
+  type AgentApprovalRequest,
+} from './approval'
+import type { AgentPrincipal } from './events'
+
+/** One answer about one request. */
+export interface ApprovalStatusReport {
+  [key: string]: unknown
+  requestId: string
+  status: string
+  tool: string
+  requestedAt: string
+  expiresAt: string
+  executed: false
+  resolvedAt?: string
+  resolvedBy?: string
+  /**
+   * When the approval was spent, if it has been. An approved record carrying
+   * this authorizes nothing further — the one call it permitted has run, and
+   * repeating that call files a fresh request rather than reusing this one.
+   */
+  consumedAt?: string
+}
+
+/**
+ * The one message for "there is no such request *for you*". One function for
+ * both branches because an unknown id and another principal's id must be the
+ * same answer byte for byte: any difference turns the check into a way to
+ * enumerate other principals' pending actions. The audit trail is where the
+ * distinction is kept, for the operator.
+ */
+export function approvalStatusNotFoundMessage(requestId: string): string {
+  return `No approval request with id "${requestId}" was made by this caller.`
+}
+
+export type ApprovalStatusOutcome =
+  | { report: ApprovalStatusReport }
+  /**
+   * Unknown, or not this caller's — one answer to the caller. `foreign` is the
+   * half the *operator* gets: it rides beside the message, for the audit event,
+   * and must never reach the result.
+   */
+  | { notFound: string; foreign: boolean }
+
+/**
+ * Read a stored record as an answer for `principal` at `now`. `record === null`
+ * and "not visible to this principal" converge here rather than at two call
+ * sites, so their sameness is structural.
+ */
+export function toApprovalStatusReport(
+  requestId: string,
+  record: AgentApprovalRequest | null,
+  principal: AgentPrincipal | null,
+  now: Date,
+): ApprovalStatusOutcome {
+  if (!record || !agentApprovalVisibleTo(record, principal)) {
+    return { notFound: approvalStatusNotFoundMessage(requestId), foreign: record !== null }
+  }
+
+  return {
+    report: {
+      requestId: record.id,
+      status: agentApprovalStatusAt(record, now),
+      tool: record.tool,
+      requestedAt: record.requestedAt,
+      expiresAt: record.expiresAt,
+      executed: false,
+      ...(record.resolvedAt ? { resolvedAt: record.resolvedAt } : {}),
+      ...(record.resolvedBy ? { resolvedBy: record.resolvedBy } : {}),
+      ...(record.consumedAt ? { consumedAt: record.consumedAt } : {}),
+    },
+  }
+}

--- a/packages/server/src/agent/pipeline.ts
+++ b/packages/server/src/agent/pipeline.ts
@@ -220,6 +220,63 @@ export function createAgentApprovalContext(
   }
 }
 
+/** What {@link createAgentAuditRecorder} needs, settled once per caller. */
+export interface AgentAuditRecorderOptions {
+  audit?: AgentAuditEmitter
+  principal: AgentPrincipal | null
+  surface: AgentSurface
+}
+
+/** The two records a surface writes. See {@link createAgentAuditRecorder}. */
+export interface AgentAuditRecorder {
+  invoked(
+    audited: AuditedTool,
+    args: Record<string, unknown>,
+    status: number,
+    durationMs: number,
+  ): void
+  denied(
+    audited: AuditedTool,
+    args: Record<string, unknown>,
+    reason: AgentToolDenialReason,
+  ): void
+}
+
+/**
+ * How a call is written down: principal, surface, and argument masking.
+ *
+ * Exported because a durable agent's approval-status check reaches the store
+ * without dispatching a tool (RFC 0017 §5), and a second copy of this rule is
+ * how one surface records an argument the other masks.
+ */
+export function createAgentAuditRecorder(options: AgentAuditRecorderOptions): AgentAuditRecorder {
+  return {
+    invoked(audited, args, status, durationMs): void {
+      options.audit?.(
+        new AgentToolInvoked(
+          options.principal,
+          audited.toolName,
+          redactAgentArguments(args, audited.redact),
+          status,
+          durationMs,
+          options.surface,
+        ),
+      )
+    },
+    denied(audited, args, reason): void {
+      options.audit?.(
+        new AgentToolDenied(
+          options.principal,
+          audited.toolName,
+          redactAgentArguments(args, audited.redact),
+          reason,
+          options.surface,
+        ),
+      )
+    },
+  }
+}
+
 /** One call, as the pipeline is asked to run it. */
 export interface AgentInvocation {
   /** The tool the request is built from. */
@@ -288,31 +345,11 @@ export function createAgentInvocationPipeline(
     ...(options.scopeSubject !== undefined ? { scopeSubject: options.scopeSubject } : {}),
   }
 
-  const record = {
-    invoked(audited: AuditedTool, args: Record<string, unknown>, status: number, durationMs: number): void {
-      options.audit?.(
-        new AgentToolInvoked(
-          options.principal,
-          audited.toolName,
-          redactAgentArguments(args, audited.redact),
-          status,
-          durationMs,
-          options.surface,
-        ),
-      )
-    },
-    denied(audited: AuditedTool, args: Record<string, unknown>, reason: AgentToolDenialReason): void {
-      options.audit?.(
-        new AgentToolDenied(
-          options.principal,
-          audited.toolName,
-          redactAgentArguments(args, audited.redact),
-          reason,
-          options.surface,
-        ),
-      )
-    },
-  }
+  const record = createAgentAuditRecorder({
+    ...(options.audit ? { audit: options.audit } : {}),
+    principal: options.principal,
+    surface: options.surface,
+  })
 
   return {
     async invoke(call: AgentInvocation): Promise<AgentInvocationResult> {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -144,8 +144,14 @@ export {
   scopedShape,
 } from './agent/gate'
 export type { ApprovalGateContext, GateVerdict, ScopeGateOptions } from './agent/gate'
-export { createAgentApprovalContext, createAgentInvocationPipeline } from './agent/pipeline'
+export {
+  createAgentApprovalContext,
+  createAgentAuditRecorder,
+  createAgentInvocationPipeline,
+} from './agent/pipeline'
 export type {
+  AgentAuditRecorder,
+  AgentAuditRecorderOptions,
   AgentDispatchTarget,
   AgentInterposition,
   AgentInvocation,
@@ -156,6 +162,11 @@ export type {
   AuditedTool,
   InterposedAgentCall,
 } from './agent/pipeline'
+// Reading one approval record as an answer for the caller that asked. Shared by
+// `guren.approval_status` over MCP and the durable surface's own status check
+// (RFC 0017 §5): two readers, one rule for what a caller may be told.
+export { approvalStatusNotFoundMessage, toApprovalStatusReport } from './agent/approval-status'
+export type { ApprovalStatusOutcome, ApprovalStatusReport } from './agent/approval-status'
 export { ViewEngine } from './mvc/ViewEngine'
 export { inertia, setInertiaSsrRenderer, setInertiaDocument } from './mvc/inertia/InertiaEngine'
 export { setInertiaSharedProps, getInertiaSharedPropsResolver, shareInertiaProps } from './mvc/inertia/shared'

--- a/rfcs/0017-durable-agent-runtime.md
+++ b/rfcs/0017-durable-agent-runtime.md
@@ -374,7 +374,7 @@ would be the mocked-driver trap. Instead:
   integration (named exports, `bootAndFetch`, bindings verification,
   default-deny routing). First end-to-end agent on Workers, tested per PR via
   the Workers Vitest integration.
-- **Part 3**: pending-approval ledger + retry + `onToolApprovalSettled`.
+- **Part 3**: pending-approval ledger + retry + `onToolApprovalSettled`. *(shipped)*
 - **Part 4**: email entry points, docs, guren.dev dogfooding, and the
   service-binding split topology if demand materializes.
 
@@ -597,6 +597,116 @@ stand-in (§7). Decisions, in the order §6 lists them:
   `boot`.
 - **Deferred**: the service-binding split, `cloudflare:build --watch`, email
   entry points, and the bundle-probe budget line for the agent entry.
+
+**Part 3 shipped.** The pending-approval ledger, the retry, and
+`onToolApprovalSettled` (§5). Decisions worth recording:
+
+- **The status rule moved down to `@guren/server` before it gained a second
+  reader.** `toApprovalStatusReport` / `approvalStatusNotFoundMessage` were
+  `@guren/plugin-mcp`'s; they are now `@guren/core`'s, and the plugin imports
+  them while keeping its MCP schema and description. A durable agent asking
+  "what became of this request" must get the answer `guren.approval_status`
+  gives, including the part that is a *refusal to distinguish*: an unknown id
+  and another principal's id are one message, and a second copy of that rule is
+  how one surface comes to leak what the other hides. `createAgentAuditRecorder`
+  moved out of the pipeline for the same reason — the status check reaches the
+  store without dispatching a tool, so it audits *beside* the pipeline, and the
+  principal, surface and redaction it records under are now one function's.
+- **The ledger's answer has three outcomes, not two.** `found: true`,
+  `found: false`, and `unavailable`. The third is not a nicety: with two, a
+  budget exhausted mid-sweep reads as "the queue has no such request", every
+  remaining row is purged, and the arguments an approval granted an hour later
+  needs are gone with nothing failing anywhere. "Unknown" and "unasked" have
+  opposite correct handling — purge and keep — so the discriminator has to
+  exist. A store that throws and an unconfigured queue answer `unavailable` too.
+- **`guren_pending_tool_calls` is the framework's own table**, created with
+  `CREATE TABLE IF NOT EXISTS` in the agent's Durable Object SQLite. Open
+  Question 5 asks how *application* schemas migrate across deploys and stays
+  open; a six-column bookkeeping table the framework owns end to end is not the
+  case that question is about.
+- **The backoff follows the least-checked row.** 30 seconds doubling per check,
+  floored at 1 second and capped three ways: by the earliest `expires_at` plus a
+  small grace (so the final wake sees the expiry and prunes it rather than
+  landing on the instant it lapses), and by the approval TTL. One wake asks
+  about every row, so the cadence has to serve the newest parked call rather
+  than inherit the oldest row's stretched backoff.
+- **Exactly one check schedule, held two different ways.** `ScheduleCriteria`
+  filters on id, type and time — not on the callback — so the callback name is
+  matched over `listSchedules({ type: 'delayed' })`. On the record path a
+  schedule is created only if none exists; at the end of a sweep the existing
+  ones are *cancelled* and one is created, because that is the only way a
+  lengthening backoff takes effect, and cancel-then-create is correct whether or
+  not the SDK has already retired the row that just fired.
+- **`checks` is the backoff's clock, not a count of answers.** An unanswerable
+  check — a spent budget, a store that threw — keeps the row *and* counts it, or
+  a queue that stays down is re-asked at one fixed cadence until the request
+  expires, and a low `callsPerMinute` never gets past its first rows. The
+  converse: re-parking a call under an id the gate returned again resets the
+  count, so an agent re-calling a parked tool restarts its own backoff. That is
+  deliberate — a fresh call is fresh interest — and stated because "doubling per
+  check" alone does not imply it.
+- **The sweep may not throw, and that shaped its structure.** The SDK retries a
+  failed delayed callback three times (`DEFAULT_RETRY.maxAttempts`) and then
+  deletes the one-shot row and logs — verified in `scheduler-*.js`, where only
+  code-update, transient-platform and memory-limit errors preserve the row. So a
+  throw replays the whole method against a half-updated ledger *and* strands
+  every surviving row with no schedule. Each row is therefore handled inside its
+  own `try`, every ledger write lands before the hook is called, the hook (app
+  code) is called through a wrapper that reports and swallows, and the
+  end-of-sweep reschedule sits in a `finally`.
+- **An approval found already spent is settled, never retried.** This is the
+  sharpest consequence of the replay rule. `consume` sets only `consumedAt`, so
+  a sweep interrupted between the executed retry and `ledger.remove` would, on
+  replay, read the record as approved, find no *unconsumed* match, file a **new**
+  request, page a human again, and perform the side effect twice on approval.
+  `ApprovalStatusReport` therefore carries `consumedAt` (and MCP advertises it),
+  and the sweep treats approved-and-spent as "a previous wake ran this": remove
+  the row, settle with `status: 'approved'` and **no `result`**. Approvals bind
+  to this principal and this exact fingerprint, so nobody else could have spent
+  it.
+- **A retry refused for want of budget keeps its row.** The retry spends the same
+  per-instance budget the status check just spent, so an exhausted window comes
+  back `denied` with `reason: 'rate-limit'`. Reporting that as the approval's
+  outcome would drop the row, and a human's approval would be spent by nobody
+  and never retried — it is treated like an unanswerable check instead.
+- **A row nothing can decrypt is pruned, not thrown over.** An app key rotated
+  past its `previousKeys` used to take down `all()`, which backs the *record*
+  path too — so one bad row denied a caller the `pending` result of a call that
+  parked perfectly well. `all()` now skips such rows and `pruneUnreadable()`
+  clears and reports them as `status: 'unreadable'`, following the precedent
+  `agentApprovalExpiredAt` set for an unparseable date.
+- **A stale schedule is replaced when the new row needs an earlier one.** The
+  record path used to keep any existing check, so a row expiring in five minutes
+  could be left to a check twenty minutes out. `Schedule.time` is Unix seconds
+  for every schedule type; `firesSooner` is the pure comparison, unit-tested on
+  Bun rather than inferred from a Durable Object's behaviour.
+- **A retry that comes back pending replaces its row rather than dropping it.**
+  Another caller can spend the approval between the status read and the retry,
+  and the gate then files a fresh request; following the id it reports keeps the
+  arguments the new request will need. A retry pending under the *same* id is a
+  race, not a new request, and only counts a check.
+- **`onToolApprovalSettled` receives the approval's outcome and the retry's
+  answer separately.** `status` is what the queue said; `result` is what the
+  repeated call returned, and it can itself be a refusal — an approval spent by
+  someone else arrives as `approved` carrying a denial. `'unknown'` is the
+  status for a request the queue no longer has a record of.
+- **No encrypter, no ledger, and the warning is at boot.** §5 makes ciphertext
+  at rest the bound on holding raw arguments at all, so `agentsPlugin` publishes
+  a cipher from the container's `encrypter` binding or publishes none and says
+  so. Without one a parked call is still returned with its `requestId`; nothing
+  is checkpointed and nothing is retried. Read at boot rather than at first use,
+  unlike the audit emitter: the binding comes from `register()`, which has run
+  for every provider before any `boot` does, and a warning is only useful while
+  an author is reading boot output.
+- **The workerd lane covers the alarm path, and eviction.**
+  `@cloudflare/vitest-plugin` ships `evictDurableObject`, so "the retry survives
+  eviction" is a real assertion rather than a claim. `APP_KEY` reaches
+  `getAppKeyringFromEnv` under workerd by assigning `process.env.APP_KEY` at the
+  top of the fixture's app module — the same trick the Bun suite uses, and it
+  does not depend on how a compatibility date maps wrangler `vars` into
+  `process.env`. One reach into SDK internals: the ledger's first backoff is 30
+  seconds, so a test that wants a due alarm pulls `cf_agents_schedules.time`
+  back rather than waiting.
 
 ## Alternatives Considered
 


### PR DESCRIPTION
## Summary

RFC 0017 Part 3: the pending-approval ledger, the scheduled retry, and `onToolApprovalSettled` (RFC §5). A durable call to an `approval: 'required'` tool comes back `pending`; the agent now checkpoints the retry material in its own Durable Object SQLite and repeats the call once a human approves it, with nothing held in memory between the two.

### `@guren/server` / `@guren/core`

- `toApprovalStatusReport`, `approvalStatusNotFoundMessage` and the `ApprovalStatusReport` / `ApprovalStatusOutcome` types move from `@guren/plugin-mcp` into `@guren/server` (`agent/approval-status.ts`), so `guren.approval_status` and the durable client answer a status by one rule — including the refusal to distinguish an unknown id from another principal's.
- `ApprovalStatusReport.consumedAt` (additive): an approval that is `approved` and already spent says so. MCP's output schema gains the property with the instruction not to repeat the call.
- `createAgentAuditRecorder` is extracted from the invocation pipeline: a status check reaches the store without dispatching a tool, and a second copy of the principal/surface/redaction triple is how one surface records what the other masks.

### `@guren/plugin-agents`

- **Ledger** (`src/ledger.ts`): `guren_pending_tool_calls` in the agent's DO SQLite, arguments as ciphertext under the app key (`AgentRuntime.cipher`, published from the container's `encrypter`). No encrypter → no ledger: a parked call is still returned with its `requestId`, nothing is checkpointed, and `agentsPlugin` says so once at boot. Rows are purged when their approval settles or expires; the queue's expiry is never extended. Unreadable rows (key rotated past retention, corrupted column) are pruned and reported, never thrown on.
- **`AgentToolClient.status(requestId)`**: found / not found / **unavailable** (budget spent, no queue, store threw). The third outcome exists because "unknown" and "unasked" need opposite handling: purging retry material on an unanswerable check would drop the arguments a later approval needs. Audited under `guren.approval_status` with 200 / 404 / 403 exactly as plugin-mcp does; spends the per-instance budget as a read.
- **`GurenAgent.checkPendingApprovals()`** (the schedule callback): prune expired and unreadable rows; per row ask the queue; `approved` → repeat the original call with the stored arguments, so the gate's consume-on-use and fingerprint match spend exactly that approval; `approved` with `consumedAt` → an earlier wake already ran it, remove the row and never re-call; `rejected` / `expired` / `unknown` → remove and settle; `pending` / `unavailable` / a rate-limited or throwing retry → keep the row and count the check. Each row is isolated in its own `try`, every ledger write happens before the hook, the app-authored hook is wrapped, and the reschedule sits in a `finally` — the agents SDK replays a thrown callback up to three times and then drops the one-shot schedule, so a throw must neither replay an executed call nor strand the remaining rows.
- **Backoff**: 30s doubling per check from the least-checked row, capped by the earliest expiry (+ grace) and the default TTL. Exactly one delayed `checkPendingApprovals` schedule at a time; a stale one is replaced when a newly parked row needs an earlier wake (`firesSooner`).
- **`onToolApprovalSettled(event)`**: overridable, default no-op. `status` ∈ `approved | rejected | expired | unknown | unreadable`; `result` carries the retry's own answer and is absent when the approval was found already spent.

### Tests

- Bun: ledger (real `bun:sqlite`, encryption at rest, backoff boundaries, unreadable rows), `status()` (identical answer for unknown and foreign ids, 200/404/403 in the trail, budget, no queue), `firesSooner`, plugin cipher publish/warn, server `approval-status`, MCP `consumedAt`.
- workerd (`tests/workers/approvals.workers.ts`, 14 new): checkpoint + one schedule, ciphertext at rest, approve → alarm → executed once and consumed, reject, expire, still-pending reschedule, queue unavailable then recovered, retry across `evictDurableObject`, replay after an executed retry files no second request, a throwing hook does not stop the sweep, a tool a deploy removed, a rate-limited retry keeps the row. Every new guard was mutation-checked (disabling it fails the matching test).

### Changesets

`@guren/server` minor, `@guren/core` minor, `@guren/plugin-mcp` patch, `@guren/plugin-agents` minor. The RFC's Implementation notes gain a "Part 3 shipped" block.

## Verification

`bun run build:clean`, `bun run typecheck`, `bun run lint`, `bun run test:bun plugin-agents plugin-mcp server core`, the cli suite (without `--isolate`: Bun 1.3.14's isolate lane segfaults in `packages/cli` on this machine), `bun run test:agents` (32 workerd tests), and the eight `audit:*` scripts CI runs.
