### PR TITLE
feat(create-app): run the scaffolded CI as one guren gate step

### DIFF
--- a/.changeset/create-app-ci-gate.md
+++ b/.changeset/create-app-ci-gate.md
@@ -1,0 +1,12 @@
+---
+'create-guren-app': minor
+---
+
+The scaffolded CI workflow is one `bunx guren gate --deps` step
+
+`.github/workflows/ci.yml` in the default and API-only templates ran codegen,
+typecheck, lint, `check --ci`, `audit`, and the tests as six steps. It now runs
+`bunx guren gate --deps`, the same stages in the same order, so a change that
+passes `bunx guren gate` locally passes CI, and the API-only template no longer
+needs `--routes routes/api.ts` (the gate finds the entry itself). Needs the
+`@guren/cli` that ships `guren gate`.

--- a/.changeset/harness-guren-gate-tool.md
+++ b/.changeset/harness-guren-gate-tool.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': patch
+---
+
+The harness entry document lists the `guren_gate` MCP tool.

--- a/.changeset/mcp-guren-gate.md
+++ b/.changeset/mcp-guren-gate.md
@@ -1,0 +1,10 @@
+---
+'@guren/server': minor
+---
+
+`guren_gate` MCP tool
+
+The development MCP endpoint exposes `guren gate` as `guren_gate`, with
+`changed` and `deps` arguments and the per-stage report as its result; `ok`
+is the verdict, and the result is marked as an error when a stage fails. On a
+`@guren/cli` older than `guren gate` the tool says so instead of throwing.

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -155,8 +155,9 @@ Validate your app before shipping — these commands are also designed for AI co
 | `spec:generate` | Regenerates the derived spec views in `docs/spec/` (ER diagram, domain model, screens, module map) — see [Spec-Anchored Development](./spec-anchored.md) | `bunx guren spec:generate` |
 
 `audit` exits with a non-zero status when it finds failures. Plain
-`check` is informational — its suite flags are the CI gates, each
-exiting non-zero on failures in that suite:
+`check` is informational — its suite flags each exit non-zero on
+failures in that suite, and `gate` (below) is what the scaffolded CI
+workflow runs:
 
 ```bash
 bunx guren audit
@@ -185,8 +186,10 @@ bunx guren gate --deps     # add the dependency scan to the audit stage
 bunx guren gate --json     # the per-stage report, for tools
 ```
 
-The Claude Code harness runs it from a `Stop` hook (see
-[AI Agent Harness](#ai-agent-harness)); `AGENTS.md` tells other agents
+The scaffolded `.github/workflows/ci.yml` is one `bunx guren gate --deps`
+step, so a change that passes the gate locally passes CI. The Claude Code
+harness runs it from a `Stop` hook (see [AI Agent Harness](#ai-agent-harness)),
+the MCP server exposes it as `guren_gate`, and `AGENTS.md` tells other agents
 to run it before declaring a change done.
 
 Routes wrapped in named middleware (for example `router.middleware('auth').group(...)`) are recognized as protected. Guest flows such as `/login` and `/register` are excluded from authentication checks.

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -153,8 +153,8 @@ JSON(`this.json(...)`)を返すため、そのまま型検査を通り、`routes
 | `spec:generate` | `docs/spec/` の導出スペックビュー(ER図・ドメインモデル・画面一覧・モジュールマップ)を再生成 — 詳細は[スペックアンカード開発](./spec-anchored.md) | `bunx guren spec:generate` |
 
 `audit` は失敗(fail)を検出すると非ゼロの終了コードを返します。
-プレーンな `check` は情報提供で、CIをゲートするのは各スイートフラグです
-(それぞれのスイートの失敗で非ゼロexit):
+プレーンな `check` は情報提供で、各スイートフラグはそのスイートの失敗で
+非ゼロ exit します。scaffold された CI ワークフローが回すのは後述の `gate` です:
 
 ```bash
 bunx guren audit
@@ -182,9 +182,11 @@ bunx guren gate --deps     # audit ステージに依存関係スキャンを追
 bunx guren gate --json     # ステージごとのレポート(ツール向け)
 ```
 
-Claude Code のハーネスはこれを `Stop` hook から実行します
-([AIエージェントハーネス](#aiエージェントハーネス)参照)。その他のエージェントには
-変更完了を宣言する前に実行するよう `AGENTS.md` が指示します。
+scaffold される `.github/workflows/ci.yml` は `bunx guren gate --deps` の 1 step
+なので、ローカルで gate を通した変更は CI も通ります。Claude Code のハーネスはこれを
+`Stop` hook から実行し([AIエージェントハーネス](#aiエージェントハーネス)参照)、MCP
+サーバは `guren_gate` ツールとして公開し、その他のエージェントには変更完了を宣言する
+前に実行するよう `AGENTS.md` が指示します。
 
 名前付きミドルウェアで保護されたルート(例: `router.middleware('auth').group(...)`)は保護済みと認識されます。`/login` や `/register` などのゲストフローは認証チェックの対象外です。
 

--- a/packages/cli/templates/agent/core/entry-body.md
+++ b/packages/cli/templates/agent/core/entry-body.md
@@ -98,6 +98,7 @@ are rejected with 403.
 | `guren_get_context` | Project structure map (models, routes, pages, controllers, …) |
 | `guren_entity_context` | Entity-centric context bundle (model, routes, pages, linked docs) |
 | `guren_check` | Validate route ↔ controller ↔ page consistency, doc links, spec freshness |
+| `guren_gate` | Every CI stage (codegen, typecheck, lint, check, audit, test) in one verdict; `ok` = the change is done |
 | `guren_docs_graph` | OKF docs relation graph (narrow with entity/path) — impact query before renames |
 | `guren_list_models` | List models (relations, soft deletes, auth trait) |
 | `guren_generate_guidelines` | Generate project-specific coding guidelines |

--- a/packages/create-app/templates/api-only/.github/workflows/ci.yml
+++ b/packages/create-app/templates/api-only/.github/workflows/ci.yml
@@ -17,22 +17,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Generate types
-        run: bun run codegen
-
-      - name: Type check
-        run: bun run typecheck
-
-      - name: Lint
-        run: bun run lint
-
-      - name: Integrity check
-        run: bunx guren check --ci --routes routes/api.ts
-
-      # Exits non-zero on failing findings. Scans dependencies too; pass
-      # --no-deps if this runner cannot reach the npm registry.
-      - name: Security audit
-        run: bunx guren audit --json --routes routes/api.ts
-
-      - name: Tests
-        run: bun test
+      # Every verification stage in one exit code: codegen, typecheck, lint,
+      # check, audit, test. --deps scans dependencies too; drop it if this
+      # runner cannot reach the npm registry. `bunx guren gate` runs the same
+      # stages locally.
+      - name: Gate
+        run: bunx guren gate --deps

--- a/packages/create-app/templates/default/.github/workflows/ci.yml
+++ b/packages/create-app/templates/default/.github/workflows/ci.yml
@@ -17,22 +17,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Generate types
-        run: bun run codegen
-
-      - name: Type check
-        run: bun run typecheck
-
-      - name: Lint
-        run: bun run lint
-
-      - name: Integrity check
-        run: bunx guren check --ci
-
-      # Exits non-zero on failing findings. Scans dependencies too; pass
-      # --no-deps if this runner cannot reach the npm registry.
-      - name: Security audit
-        run: bunx guren audit --json
-
-      - name: Tests
-        run: bun test
+      # Every verification stage in one exit code: codegen, typecheck, lint,
+      # check, audit, test. --deps scans dependencies too; drop it if this
+      # runner cannot reach the npm registry. `bunx guren gate` runs the same
+      # stages locally.
+      - name: Gate
+        run: bunx guren gate --deps

--- a/packages/create-app/tests/lint-template.test.ts
+++ b/packages/create-app/tests/lint-template.test.ts
@@ -22,7 +22,8 @@ describe('template lint setup', () => {
     expect(manifest.scripts['lint:fix']).toBe('bunx oxlint --fix')
     // The range itself is audit:template-deps' business (it follows @guren/cli's peer).
     expect(manifest.devDependencies.oxlint).toMatch(/^~\d/)
+    // CI lints through the gate, whose lint stage runs the same oxlint config.
     const ci = await readFile(join(repoRoot, 'packages/create-app/templates', template, '.github/workflows/ci.yml'), 'utf8')
-    expect(ci).toContain('run: bun run lint')
+    expect(ci).toContain('run: bunx guren gate --deps')
   })
 })

--- a/packages/server/src/mcp/create-mcp-server.ts
+++ b/packages/server/src/mcp/create-mcp-server.ts
@@ -61,6 +61,13 @@ export interface GurenCliApi {
     warnCount: number
     failCount: number
   }>
+  /** Absent on a @guren/cli older than `guren gate`; the tool says so instead of throwing. */
+  runGate?(opts: { cwd: string; changed?: boolean; deps?: boolean }): Promise<{
+    cwd: string
+    ok: boolean
+    changed: boolean
+    stages: Array<{ name: string; status: string; durationMs: number; findings: string[]; reason?: string }>
+  }>
   listModels(opts: { appRoot: string }): Promise<
     Array<{
       className: string
@@ -340,6 +347,25 @@ export function createMcpServer(options: CreateMcpServerOptions): McpServer {
     async () => {
       const report = await cli.runCheck({ cwd })
       return { content: [{ type: 'text', text: JSON.stringify(report, null, 2) }] }
+    },
+  )
+
+  server.tool(
+    'guren_gate',
+    'Run every verification stage the scaffolded CI runs (codegen, typecheck, lint, check, audit, test) and report each; `ok` is the one verdict on whether the change is done. A stage that cannot run fails rather than skips.',
+    {
+      changed: z.boolean().default(false).describe('Narrow check and lint to files changed vs. the merge base with main'),
+      deps: z.boolean().default(false).describe('Scan dependencies in the audit stage (needs registry access)'),
+    },
+    async ({ changed, deps }) => {
+      if (!cli.runGate) {
+        return {
+          content: [{ type: 'text', text: 'guren_gate needs a @guren/cli that ships `guren gate`; upgrade the app (bunx guren upgrade).' }],
+          isError: true,
+        }
+      }
+      const report = await cli.runGate({ cwd, changed, deps })
+      return { content: [{ type: 'text', text: JSON.stringify(report, null, 2) }], isError: !report.ok }
     },
   )
 

--- a/packages/server/tests/mcp/mcp-server.test.ts
+++ b/packages/server/tests/mcp/mcp-server.test.ts
@@ -59,6 +59,15 @@ function createMockCli(overrides: Partial<GurenCliApi> = {}, calls?: CodegenCall
       warnCount: 1,
       failCount: 0,
     }),
+    runGate: async (opts) => ({
+      cwd: opts.cwd,
+      ok: !opts.deps,
+      changed: opts.changed ?? false,
+      stages: [
+        { name: 'codegen', status: 'pass', durationMs: 1, findings: [] },
+        { name: 'audit', status: opts.deps ? 'fail' : 'pass', durationMs: 1, findings: opts.deps ? ['Dependency: lodash <4.17.21'] : [] },
+      ],
+    }),
     listModels: async () => [
       {
         className: 'Post',
@@ -142,6 +151,7 @@ describe('Guren MCP Server', () => {
     expect(names).toContain('guren_get_context')
     expect(names).toContain('guren_entity_context')
     expect(names).toContain('guren_check')
+    expect(names).toContain('guren_gate')
     expect(names).toContain('guren_list_models')
     expect(names).toContain('guren_generate_guidelines')
     expect(names).toContain('guren_doctor')
@@ -149,7 +159,7 @@ describe('Guren MCP Server', () => {
     expect(names).toContain('guren_make_component')
     expect(names).toContain('guren_codegen')
     expect(names).toContain('guren_agent_surface')
-    expect(tools).toHaveLength(10)
+    expect(tools).toHaveLength(11)
   })
 
   test('guren_docs_graph registers only when the CLI provides it', async () => {
@@ -438,6 +448,29 @@ describe('Guren MCP Server', () => {
     expect(report.warnCount).toBe(1)
     expect(report.failCount).toBe(0)
     expect(report.checks).toHaveLength(2)
+  })
+
+  test('guren_gate returns the per-stage report and flags a failed gate as an error', async () => {
+    const client = await createTestClient()
+    const passed = await client.callTool({ name: 'guren_gate', arguments: { changed: true } })
+    const passedReport = JSON.parse((passed.content as Array<{ type: string; text: string }>)[0].text)
+    expect(passed.isError).toBeFalsy()
+    expect(passedReport.ok).toBe(true)
+    expect(passedReport.changed).toBe(true)
+    expect(passedReport.stages.map((s: { name: string }) => s.name)).toEqual(['codegen', 'audit'])
+
+    const failed = await client.callTool({ name: 'guren_gate', arguments: { deps: true } })
+    const failedReport = JSON.parse((failed.content as Array<{ type: string; text: string }>)[0].text)
+    expect(failed.isError).toBe(true)
+    expect(failedReport.ok).toBe(false)
+    expect(failedReport.stages[1].findings).toEqual(['Dependency: lodash <4.17.21'])
+  })
+
+  test('guren_gate on a CLI without runGate says so instead of throwing', async () => {
+    const client = await createTestClient({ runGate: undefined })
+    const result = await client.callTool({ name: 'guren_gate', arguments: {} })
+    expect(result.isError).toBe(true)
+    expect((result.content as Array<{ type: string; text: string }>)[0].text).toContain('guren gate')
   })
 
   test('guren_list_models returns model info', async () => {

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -715,24 +715,12 @@ async function main(): Promise<void> {
       await run(['bun', resolve(repoRoot, 'scripts/smoke/build-budget.ts'), '--max-kb', '600', appDir], repoRoot, runtimeEnv)
     }
 
-    // Templates advertise a starter test suite and a CI workflow gating on
-    // `check --ci` and `guren audit`; exercise all three so they cannot drift
-    // from the framework. The api blueprint needs its codegen manifests first.
-    // --no-deps keeps the audit off the network; older CLI releases ignore it.
-    if (blueprint === 'api') {
-      await run(['bun', 'run', 'codegen'], appDir, runtimeEnv)
-    }
-    const routesArgs = blueprint === 'api' ? ['--routes', 'routes/api.ts'] : []
-    await run(['bun', 'test'], appDir, runtimeEnv)
-    await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'check', '--ci', ...routesArgs], appDir, runtimeEnv)
-    await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'audit', '--no-deps', ...routesArgs], appDir, runtimeEnv)
-
-    // The templates ship .oxlintrc.json with the @guren/cli/oxlint plugin, resolved through
-    // the app's node_modules. A fresh app has to lint clean under that preset, or the
-    // first `bun run lint` a user sees is red. The binary is the checkout's: a second
-    // `bun install` against the vendored file: dependencies spins Bun 1.3.14 at 100%
-    // CPU indefinitely (three runs, 40 min each), and audit:template-deps ties the versions.
-    await run(['bun', resolve(repoRoot, 'node_modules/oxlint/bin/oxlint')], appDir, runtimeEnv)
+    // The templates' CI workflow is one `guren gate --deps` step; run the same gate
+    // (without the dependency scan, which needs the registry) so the starter test
+    // suite, `check --ci`, `audit`, and the shipped .oxlintrc.json preset cannot
+    // drift from the framework. A fresh app has to pass every stage, or the first
+    // CI run a user sees is red. The gate finds the app's routes entry itself.
+    await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'gate'], appDir, runtimeEnv)
 
     console.log(`\nFresh app smoke passed (${blueprint}, ${installMode}): ${appDir}`)
   } finally {

--- a/scripts/smoke/starter-template-audit.ts
+++ b/scripts/smoke/starter-template-audit.ts
@@ -43,8 +43,8 @@ export async function auditBlueprintTemplates(root: string): Promise<void> {
   for (const template of ['default', 'api-only']) {
     const contents = await read(root, `templates/${template}/.github/workflows/ci.yml`).catch(() => '')
     assert(
-      contents.includes('guren check --ci'),
-      `templates/${template}/.github/workflows/ci.yml is missing from the create-guren-app tarball (or lost its check gate).`,
+      contents.includes('guren gate --deps'),
+      `templates/${template}/.github/workflows/ci.yml is missing from the create-guren-app tarball (or lost its gate step).`,
     )
   }
 }


### PR DESCRIPTION
## Summary

- The default and API-only `.github/workflows/ci.yml` ran codegen, typecheck, lint, `check --ci`, `audit`, and the tests as six steps. They now run one `bunx guren gate --deps` step: the same stages in the same order, so a change that passes `bunx guren gate` locally passes CI. The API-only workflow drops its `--routes routes/api.ts` flags (the gate finds the entry itself, since #690).
- `scripts/smoke/fresh-app.ts` runs the gate in place of its separate `bun test` / `check --ci` / `audit` / oxlint steps, and `starter-template-audit` asserts the gate step.
- The development MCP endpoint exposes `guren_gate` (`changed`, `deps`), returning the per-stage report with `isError` set when a stage fails. On a `@guren/cli` older than `guren gate` the tool says so instead of throwing. The harness entry document lists it.

Follow-up from #690. `smoke:starter:npm` is expected red until the release that publishes `guren gate` ships (the template now uses it).

## Test plan

- [x] `packages/server/tests/mcp`: 64 pass (new: `guren_gate` report / error flag / missing-`runGate` case; tool count 11)
- [x] `bun run typecheck`, `bun run lint`
- [x] `audit:starter-template`, `audit:docs`, `audit:core-first`, `audit:agent-catalog`, `audit:workspace-scripts`
- [x] `smoke:starter` and `smoke:starter:api`: both pass, the gate reports 6 passed / 0 failed / 0 skipped on each fresh app (lint ran on the app's own oxlint)
