### PR TITLE
fix(cli): close the issue-reference grammar and make --issue comma-separated (RFC 0018)

### DIFF
--- a/.changeset/docs-issues-grammar.md
+++ b/.changeset/docs-issues-grammar.md
@@ -1,0 +1,20 @@
+---
+'@guren/cli': patch
+---
+
+Tighten the `issues:` reference grammar and make `--issue` comma-separated
+
+A URL reference may no longer contain whitespace, quotes, commas or
+backslashes: the characters that would break the `--issue` list, the quoted
+YAML scalar `make:adr` writes, or the scanner's split of an unquoted
+inline-list entry. Rejecting them in the grammar keeps every consumer safe by
+construction; `guren check --docs` reports such an entry as unreadable, as it
+does any other malformed one. Issue numbers must be positive safe integers.
+
+`make:adr --issue` takes a comma-separated list. Repeating the flag keeps only
+the last value, like every other flag of this CLI, and the help text no longer
+claims otherwise.
+
+`guren context <Entity>` orders Linked issues by repository then number, with
+URL entries last, so the order no longer depends on whether the `origin`
+remote resolved.

--- a/.changeset/docs-issues-link.md
+++ b/.changeset/docs-issues-link.md
@@ -18,10 +18,7 @@ the corpus that describes the system.
   de-duplicated, each naming the docs that declared it. Read from the
   frontmatter alone; a bare number resolves to the `origin` remote's
   repository when there is one.
-- `make:adr --issue <ref>` (comma-separated for several) prefills
-  `issues:`; a malformed reference fails before anything is written. A URL
-  reference may not contain whitespace, quotes, commas or backslashes: the
-  characters that would break the flag's list, the quoted YAML scalar the
-  scaffold writes, or the scanner's inline-list split.
+- `make:adr --issue <ref>` (repeatable, or comma-separated) prefills
+  `issues:`; a malformed reference fails before anything is written.
 - The docs viewer's detail panel shows the issues as outlinks. They are not
   graph nodes and carry no live state.

--- a/.changeset/docs-issues-link.md
+++ b/.changeset/docs-issues-link.md
@@ -18,7 +18,10 @@ the corpus that describes the system.
   de-duplicated, each naming the docs that declared it. Read from the
   frontmatter alone; a bare number resolves to the `origin` remote's
   repository when there is one.
-- `make:adr --issue <ref>` (repeatable, or comma-separated) prefills
-  `issues:`; a malformed reference fails before anything is written.
+- `make:adr --issue <ref>` (comma-separated for several) prefills
+  `issues:`; a malformed reference fails before anything is written. A URL
+  reference may not contain whitespace, quotes, commas or backslashes: the
+  characters that would break the flag's list, the quoted YAML scalar the
+  scaffold writes, or the scanner's inline-list split.
 - The docs viewer's detail panel shows the issues as outlinks. They are not
   graph nodes and carry no live state.

--- a/docs/en/guides/cli.md
+++ b/docs/en/guides/cli.md
@@ -129,7 +129,7 @@ table to.
 | `make:middleware <Name>` | Generates a middleware file in `app/Http/Middleware` | `bunx guren make:middleware Auth` |
 | `make:policy <Name>` | Generates an authorization policy in `app/Policies` with owner-based defaults | `bunx guren make:policy Post` |
 | `make:validator <Name>` | Generates Zod validation schemas (route params, list query, payload) in `app/Http/Validators`; `--fields` uses the same syntax as `make:feature` | `bunx guren make:validator Post --fields "title:string,body:text"` |
-| `make:adr "<Title>"` | Records an architecture decision as a numbered file under `docs/adr/` with linkable frontmatter; `--entity <Model>` prefills the `entities:`/`related:` links, `--issue <ref>` (repeatable) the `issues:` link to a GitHub issue or PR | `bunx guren make:adr "Billing cycle is end-of-month" --entity Invoice --issue 412` |
+| `make:adr "<Title>"` | Records an architecture decision as a numbered file under `docs/adr/` with linkable frontmatter; `--entity <Model>` prefills the `entities:`/`related:` links, `--issue <ref>` (comma-separated for several) the `issues:` link to a GitHub issue or PR | `bunx guren make:adr "Billing cycle is end-of-month" --entity Invoice --issue 412` |
 | `make:seeder <Name>` | Generates a database seeder file | `bunx guren make:seeder UserSeeder` |
 | `make:job <Name>` | Generates a queueable job class | `bunx guren make:job SendEmail` |
 | `make:event <Name>` | Generates an event class | `bunx guren make:event UserRegistered` |

--- a/docs/en/guides/spec-anchored.md
+++ b/docs/en/guides/spec-anchored.md
@@ -124,7 +124,7 @@ bunx guren make:adr "Billing cycle is end-of-month" --entity Invoice --issue 412
 It numbers the file under `docs/adr/`, prefills the frontmatter, and
 `--entity` fills `entities:` and `related:` from what already exists
 (`--by` overrides the `generated.by` actor, which defaults to the git
-author; `--issue`, repeatable, fills `issues:`). Every new Guren app
+author; `--issue`, comma-separated for several, fills `issues:`). Every new Guren app
 ships with a seed ADR explaining the convention.
 
 `bunx guren context Invoice` then ends with a **Linked issues** section

--- a/docs/ja/guides/cli.md
+++ b/docs/ja/guides/cli.md
@@ -134,7 +134,7 @@ JSON(`this.json(...)`)を返すため、そのまま型検査を通り、`routes
 | `make:command <Name>` | `app/Console/Commands` にコンソールコマンドを生成。`--command <name>` で呼び出し名を指定。`src/console.ts` への登録が必要（[コンソールコマンドガイド](./console.md)参照） | `bunx guren make:command SendDigest --command reports:digest` |
 | `make:policy <Name>` | 所有者ベースのデフォルトを備えた認可ポリシーを `app/Policies` に生成 | `bunx guren make:policy Post` |
 | `make:validator <Name>` | Zodバリデーションスキーマ(ルートパラメータ・一覧クエリ・ペイロード)を `app/Http/Validators` に生成。`--fields` は `make:feature` と同じ構文 | `bunx guren make:validator Post --fields "title:string,body:text"` |
-| `make:adr "<Title>"` | アーキテクチャ意思決定を採番付きファイルとして `docs/adr/` に記録(リンク可能なfrontmatter付き)。`--entity <Model>` で `entities:`/`related:` を自動補完、`--issue <ref>`(複数可)でGitHubのIssue/PRへの `issues:` リンクを記入 | `bunx guren make:adr "Billing cycle is end-of-month" --entity Invoice --issue 412` |
+| `make:adr "<Title>"` | アーキテクチャ意思決定を採番付きファイルとして `docs/adr/` に記録(リンク可能なfrontmatter付き)。`--entity <Model>` で `entities:`/`related:` を自動補完、`--issue <ref>`(カンマ区切りで複数可)でGitHubのIssue/PRへの `issues:` リンクを記入 | `bunx guren make:adr "Billing cycle is end-of-month" --entity Invoice --issue 412` |
 
 > **Note:** `make:*` は既存ファイルを上書きしません。必要なら `--force` を付けてください。
 

--- a/docs/ja/guides/spec-anchored.md
+++ b/docs/ja/guides/spec-anchored.md
@@ -125,7 +125,7 @@ bunx guren make:adr "Billing cycle is end-of-month" --entity Invoice --issue 412
 `docs/adr/` 配下に採番されたファイルを作り、frontmatterを記入済みに
 します。`--entity` は既存のコードから `entities:` と `related:` を
 自動補完し、`--by` は `generated.by` のactor(既定はgitの作者)を
-上書きします。`--issue`(複数指定可)は `issues:` を埋めます。
+上書きします。`--issue`(カンマ区切りで複数可)は `issues:` を埋めます。
 新規Gurenアプリには、この規約を説明するシードADRが最初から同梱されています。
 
 `bunx guren context Invoice` の末尾には **Linked issues** セクションが付き、

--- a/packages/cli/assets/docs-viewer/index.html
+++ b/packages/cli/assets/docs-viewer/index.html
@@ -633,15 +633,11 @@ button:focus-visible, input:focus-visible { outline: 2px solid var(--accent); ou
     const cell = el('div', 'meta-value')
     issues.forEach((issue, index) => {
       if (index > 0) cell.append(', ')
-      if (!issue.url) {
-        cell.append(issue.label)
-        return
-      }
-      const link = el('a', 'issue-link', issue.label)
-      link.href = issue.url
-      link.target = '_blank'
-      link.rel = 'noopener noreferrer'
-      cell.append(link)
+      cell.append(
+        issue.url
+          ? Object.assign(el('a', 'issue-link', issue.label), { href: issue.url, target: '_blank', rel: 'noopener noreferrer' })
+          : issue.label,
+      )
     })
     grid.append(el('div', 'meta-key', 'issues'), cell)
   }

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -34,6 +34,7 @@ import { makeModule } from './make-module'
 import { makeNotification } from './make-notification'
 import { makeProvider } from './make-provider'
 import { makeAdr } from './make-adr'
+import { splitIssueList } from './issue-refs'
 import { writeSpecArtifacts } from './spec-generate'
 import { buildDocsGraphReport, renderDocsGraphMarkdown } from './docs-graph'
 import { makeResource } from './make-resource'
@@ -94,19 +95,6 @@ function toWriterOptions(args: ForceableArgs): WriterOptions {
     root: args.module,
   }
 }
-
-/**
- * A flag given more than once arrives from citty as an array despite its
- * `string` type; a comma-separated single value is the other spelling.
- */
-function parseRepeatableArg(value: string | string[] | undefined): string[] {
-  if (value === undefined) return []
-  return (Array.isArray(value) ? value : [value])
-    .flatMap((entry) => String(entry).split(','))
-    .map((entry) => entry.trim())
-    .filter((entry) => entry !== '')
-}
-
 const MODULE_ARG = {
   type: 'string' as const,
   description: 'Scaffold inside modules/<name>/ instead of the project root.',
@@ -257,7 +245,7 @@ const makeAdrCommand = defineCommand({
     issue: {
       type: 'string',
       description:
-        'GitHub issue or PR to prefill issues: with (412, owner/repo#412, or a URL). Repeat or comma-separate for several.',
+        'GitHub issues or PRs to prefill issues: with (412, owner/repo#412, or a URL), comma-separated for several.',
     },
     force: { type: 'boolean', description: 'Overwrite existing files', alias: 'f' },
     module: MODULE_ARG,
@@ -267,7 +255,7 @@ const makeAdrCommand = defineCommand({
       ...toWriterOptions(args),
       entity: args.entity,
       by: args.by,
-      issues: parseRepeatableArg(args.issue),
+      issues: splitIssueList(args.issue),
     })
     consola.success(`ADR created at ${file}`)
   },

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -34,7 +34,7 @@ import { makeModule } from './make-module'
 import { makeNotification } from './make-notification'
 import { makeProvider } from './make-provider'
 import { makeAdr } from './make-adr'
-import { splitIssueList } from './issue-refs'
+import { ISSUE_REF_FORMS, splitIssueList } from './issue-refs'
 import { writeSpecArtifacts } from './spec-generate'
 import { buildDocsGraphReport, renderDocsGraphMarkdown } from './docs-graph'
 import { makeResource } from './make-resource'
@@ -95,6 +95,7 @@ function toWriterOptions(args: ForceableArgs): WriterOptions {
     root: args.module,
   }
 }
+
 const MODULE_ARG = {
   type: 'string' as const,
   description: 'Scaffold inside modules/<name>/ instead of the project root.',
@@ -244,8 +245,7 @@ const makeAdrCommand = defineCommand({
     },
     issue: {
       type: 'string',
-      description:
-        'GitHub issues or PRs to prefill issues: with (412, owner/repo#412, or a URL), comma-separated for several.',
+      description: `GitHub issues or PRs to prefill issues: with, comma-separated for several. Each: ${ISSUE_REF_FORMS}.`,
     },
     force: { type: 'boolean', description: 'Overwrite existing files', alias: 'f' },
     module: MODULE_ARG,

--- a/packages/cli/src/docs-index.ts
+++ b/packages/cli/src/docs-index.ts
@@ -127,7 +127,13 @@ export async function scanDocs(cwd: string): Promise<DocRef[]> {
             const parsed = parseDocFrontmatter(source)
             const body = parsed?.body ?? source
             const data = parsed?.data ?? {}
-            const issueEntries = toStringList(data.issues).map((raw) => ({ raw, ref: parseIssueRef(raw) }))
+            const issues: DocIssueRef[] = []
+            const malformedIssues: string[] = []
+            for (const entry of toStringList(data.issues)) {
+              const ref = parseIssueRef(entry)
+              if (ref) issues.push(ref)
+              else malformedIssues.push(entry)
+            }
             return {
               path: toPosixRelative(cwd, file),
               module: root.module,
@@ -145,8 +151,8 @@ export async function scanDocs(cwd: string): Promise<DocRef[]> {
               // rather than read it as absent.
               staleAfter:
                 'stale_after' in data ? (toScalar(data.stale_after) ?? '') : undefined,
-              issues: issueEntries.flatMap(({ ref }) => (ref ? [ref] : [])),
-              malformedIssues: issueEntries.flatMap(({ raw, ref }) => (ref ? [] : [raw])),
+              issues,
+              malformedIssues,
               links: parsed ? extractMarkdownLinks(body) : [],
               hasFrontmatter: parsed !== null,
             }

--- a/packages/cli/src/docs-viewer.ts
+++ b/packages/cli/src/docs-viewer.ts
@@ -11,7 +11,7 @@ import { resolve } from 'node:path'
 import { parseDocFrontmatter } from './docs-frontmatter'
 import { localLinkTarget } from './docs-links'
 import type { DocActorEvent, DocRef } from './docs-index'
-import { issueLabel, issueUrl, resolveOriginRepo } from './issue-refs'
+import { describeIssue, resolveOriginRepo, type IssueLink } from './issue-refs'
 import { resolveDocLink } from './docs-check'
 import { loadDocsGraph, type DocsGraphEdge, type DocsGraphNode } from './docs-graph'
 import { renderDocHtml } from './docs-render'
@@ -47,8 +47,8 @@ export interface DocsViewerDoc {
    */
   stale: boolean
   trustTier: DocTrustTier
-  /** Outlinks for `issues:` (RFC 0018); `url` is absent when the repository cannot be resolved. */
-  issues: Array<{ label: string; url?: string }>
+  /** Outlinks for `issues:` (RFC 0018). */
+  issues: IssueLink[]
   /** Rendered body; the leading H1 is dropped (the panel header carries the title). */
   html: string
 }
@@ -145,7 +145,8 @@ export async function buildDocsViewerData(cwd: string): Promise<DocsViewerData> 
   const staleDocs = new Set(
     checks.filter((check) => check.key.startsWith('docs-stale:')).map((check) => check.filePath),
   )
-  const originRepo = await resolveOriginRepo(cwd)
+  // The git spawn happens only for a bundle that declares something.
+  const originRepo = refs.some((ref) => ref.issues.length > 0) ? await resolveOriginRepo(cwd) : null
 
   const docs = await Promise.all(
     refs.map(async (ref): Promise<DocsViewerDoc> => {
@@ -167,12 +168,7 @@ export async function buildDocsViewerData(cwd: string): Promise<DocsViewerData> 
         staleAfter: ref.staleAfter,
         stale: staleDocs.has(ref.path),
         trustTier: docTrustTier(ref),
-        issues: ref.issues.map((issue) => {
-          const url = issueUrl(issue, originRepo)
-          return url === undefined
-            ? { label: issueLabel(issue, originRepo) }
-            : { label: issueLabel(issue, originRepo), url }
-        }),
+        issues: ref.issues.map((issue) => describeIssue(issue, originRepo)),
         // Links carry the app-root path they resolve to, so the viewer
         // navigates by map lookup instead of re-deriving the rules client-side.
         html: renderDocHtml(body, { resolveLink: (target) => resolveViewerLink(ref.path, target) }),

--- a/packages/cli/src/entity-context.ts
+++ b/packages/cli/src/entity-context.ts
@@ -32,7 +32,7 @@ import {
 } from './context-route'
 import { extractInertiaPageRefs, describeInertiaPage } from './inertia-pages'
 import { scanDocs, extractDocsTags, buildEntityDocIndex, type DocRef } from './docs-index'
-import { issueKey, issueLabel, issueUrl, resolveOriginRepo } from './issue-refs'
+import { describeIssue, resolveOriginRepo, type IssueLink } from './issue-refs'
 import { parseSchemaTableColumns } from './schema-parser'
 
 export interface EntityPage {
@@ -79,13 +79,10 @@ export interface EntityDoc {
  * A GitHub issue/PR the entity's linked docs declare (RFC 0018). Offline by
  * construction: what the frontmatter says, never what GitHub says.
  */
-export interface EntityIssue {
-  /** `owner/repo#412`, `#412` when no repository is known, or the URL. */
-  label: string
-  /** `owner/repo`, declared or resolved from the `origin` remote. */
+export interface EntityIssue extends IssueLink {
+  /** `owner/repo`, declared or resolved from the `origin` remote; absent for a URL entry. */
   repo?: string
   number?: number
-  url?: string
   /** Docs that declared it. */
   docs: string[]
 }
@@ -397,42 +394,36 @@ export async function generateEntityContext(
     seeders,
     tests,
     docs,
-    issues: await collectEntityIssues(cwd, docs.map((doc) => docRefByPath.get(doc.path))),
+    issues: await collectEntityIssues(cwd, docs.flatMap((doc) => docRefByPath.get(doc.path) ?? [])),
   }
 }
 
 /** One entry per distinct issue, each naming every doc that declared it. */
-async function collectEntityIssues(
-  cwd: string,
-  refs: Array<DocRef | undefined>,
-): Promise<EntityIssue[]> {
-  const declared = refs.filter((ref): ref is DocRef => ref !== undefined && ref.issues.length > 0)
-  if (declared.length === 0) return []
+async function collectEntityIssues(cwd: string, refs: DocRef[]): Promise<EntityIssue[]> {
+  // The git spawn happens only for an entity whose docs declare something.
+  if (!refs.some((ref) => ref.issues.length > 0)) return []
 
   const originRepo = await resolveOriginRepo(cwd)
-  const byKey = new Map<string, EntityIssue>()
-  for (const ref of declared) {
+  const byLabel = new Map<string, EntityIssue>()
+  for (const ref of refs) {
     for (const issue of ref.issues) {
-      const key = issueKey(issue, originRepo)
-      const existing = byKey.get(key)
+      const link = describeIssue(issue, originRepo)
+      const existing = byLabel.get(link.label)
       if (existing) {
         if (!existing.docs.includes(ref.path)) existing.docs.push(ref.path)
         continue
       }
-      const url = issueUrl(issue, originRepo)
-      const repo = issue.kind === 'github' ? (issue.repo ?? originRepo ?? undefined) : undefined
-      byKey.set(key, {
-        label: issueLabel(issue, originRepo),
-        ...(repo === undefined ? {} : { repo }),
-        ...(issue.kind === 'github' ? { number: issue.number } : {}),
-        ...(url === undefined ? {} : { url }),
+      byLabel.set(link.label, {
+        ...link,
+        repo: issue.kind === 'github' ? (issue.repo ?? originRepo ?? undefined) : undefined,
+        number: issue.kind === 'github' ? issue.number : undefined,
         docs: [ref.path],
       })
     }
   }
   // By repository then number, so the order does not change with whether
   // `origin` resolved, and #7 precedes #412; URL entries follow, by label.
-  return [...byKey.values()].sort(
+  return [...byLabel.values()].sort(
     (a, b) =>
       Number(a.number === undefined) - Number(b.number === undefined)
       || (a.repo ?? '').localeCompare(b.repo ?? '')

--- a/packages/cli/src/entity-context.ts
+++ b/packages/cli/src/entity-context.ts
@@ -430,7 +430,15 @@ async function collectEntityIssues(
       })
     }
   }
-  return [...byKey.values()].sort((a, b) => a.label.localeCompare(b.label))
+  // By repository then number, so the order does not change with whether
+  // `origin` resolved, and #7 precedes #412; URL entries follow, by label.
+  return [...byKey.values()].sort(
+    (a, b) =>
+      Number(a.number === undefined) - Number(b.number === undefined)
+      || (a.repo ?? '').localeCompare(b.repo ?? '')
+      || (a.number ?? 0) - (b.number ?? 0)
+      || a.label.localeCompare(b.label),
+  )
 }
 
 /**

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -58,13 +58,7 @@ export {
   type EntityContextOptions,
   type EntityIssue,
 } from './entity-context'
-export {
-  parseIssueRef,
-  splitIssueList,
-  resolveOriginRepo,
-  ISSUE_REF_FORMS,
-  type DocIssueRef,
-} from './issue-refs'
+export type { DocIssueRef, IssueLink } from './issue-refs'
 export {
   routeDefinitionToContextRoute,
   loadContextRoutes,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -60,6 +60,7 @@ export {
 } from './entity-context'
 export {
   parseIssueRef,
+  splitIssueList,
   resolveOriginRepo,
   ISSUE_REF_FORMS,
   type DocIssueRef,

--- a/packages/cli/src/issue-refs.ts
+++ b/packages/cli/src/issue-refs.ts
@@ -23,32 +23,50 @@ export type DocIssueRef =
     }
 
 /** The accepted spellings, in the order the fix text lists them. */
-export const ISSUE_REF_FORMS = '412, "#412", owner/repo#412, or an issue/PR URL'
+export const ISSUE_REF_FORMS =
+  '412, "#412", owner/repo#412, or an issue/PR URL (no spaces, quotes, commas or backslashes)'
 
 const NUMBER_RE = /^#?(\d+)$/
 const REPO_SEGMENT = '[A-Za-z0-9_.-]+'
 const REPO_NUMBER_RE = new RegExp(`^(${REPO_SEGMENT}/${REPO_SEGMENT})#(\\d+)$`)
+// A URL character set that survives every place a reference travels: the
+// comma-split `--issue` list, the double-quoted YAML scalar make:adr writes,
+// and the inline-list frontmatter the scanner splits on unquoted commas.
+const URL_CHARS = '[^\\s",\\\\]'
 const GITHUB_URL_RE = new RegExp(
-  `^https?://(?:www\\.)?github\\.com/(${REPO_SEGMENT}/${REPO_SEGMENT})/(?:issues|pull)/(\\d+)(?:[/?#].*)?$`,
+  `^https?://(?:www\\.)?github\\.com/(${REPO_SEGMENT}/${REPO_SEGMENT})/(?:issues|pull)/(\\d+)(?:[/?#]${URL_CHARS}*)?$`,
 )
+const URL_RE = new RegExp(`^https?://${URL_CHARS}+$`)
+
+function issueNumber(digits: string): number | null {
+  const value = Number(digits)
+  return Number.isSafeInteger(value) && value > 0 ? value : null
+}
 
 /** Parse one `issues:` entry, or null when it matches no accepted form. */
 export function parseIssueRef(raw: string): DocIssueRef | null {
   const entry = raw.trim()
   if (entry === '') return null
 
-  const bare = NUMBER_RE.exec(entry)
-  if (bare) return { kind: 'github', raw: entry, repo: null, number: Number(bare[1]) }
+  const github = NUMBER_RE.exec(entry) ?? REPO_NUMBER_RE.exec(entry) ?? GITHUB_URL_RE.exec(entry)
+  if (github) {
+    const [repo, digits] = github.length === 2 ? [null, github[1]] : [github[1], github[2]]
+    const number = issueNumber(digits)
+    return number === null ? null : { kind: 'github', raw: entry, repo, number }
+  }
 
-  const scoped = REPO_NUMBER_RE.exec(entry)
-  if (scoped) return { kind: 'github', raw: entry, repo: scoped[1], number: Number(scoped[2]) }
-
-  const github = GITHUB_URL_RE.exec(entry)
-  if (github) return { kind: 'github', raw: entry, repo: github[1], number: Number(github[2]) }
-
-  if (/^https?:\/\/\S+$/.test(entry)) return { kind: 'url', raw: entry, url: entry }
+  if (URL_RE.test(entry)) return { kind: 'url', raw: entry, url: entry }
 
   return null
+}
+
+/** The `--issue` flag's value as entries: comma-separated, blanks dropped. */
+export function splitIssueList(value: string | undefined): string[] {
+  if (value === undefined) return []
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry !== '')
 }
 
 const REMOTE_RE = new RegExp(

--- a/packages/cli/src/issue-refs.ts
+++ b/packages/cli/src/issue-refs.ts
@@ -5,12 +5,11 @@
  * never is, so `guren check` stays a deterministic gate.
  */
 import { runGit } from './changed-files'
+import { splitCommaList } from './utils'
 
 export type DocIssueRef =
   | {
       kind: 'github'
-      /** The entry as written, for messages. */
-      raw: string
       /** `owner/repo`, or null when the entry names the app's own repository. */
       repo: string | null
       number: number
@@ -18,55 +17,53 @@ export type DocIssueRef =
   | {
       /** An http(s) URL on some other host: an outlink the viewer can render, nothing more. */
       kind: 'url'
-      raw: string
       url: string
     }
+
+/** What a consumer shows for one reference; `url` is absent when no repository is known. */
+export interface IssueLink {
+  /** `owner/repo#412`, `#412` when no repository is known, or the URL. */
+  label: string
+  url?: string
+}
 
 /** The accepted spellings, in the order the fix text lists them. */
 export const ISSUE_REF_FORMS =
   '412, "#412", owner/repo#412, or an issue/PR URL (no spaces, quotes, commas or backslashes)'
 
-const NUMBER_RE = /^#?(\d+)$/
 const REPO_SEGMENT = '[A-Za-z0-9_.-]+'
-const REPO_NUMBER_RE = new RegExp(`^(${REPO_SEGMENT}/${REPO_SEGMENT})#(\\d+)$`)
 // A URL character set that survives every place a reference travels: the
 // comma-split `--issue` list, the double-quoted YAML scalar make:adr writes,
 // and the inline-list frontmatter the scanner splits on unquoted commas.
 const URL_CHARS = '[^\\s",\\\\]'
-const GITHUB_URL_RE = new RegExp(
-  `^https?://(?:www\\.)?github\\.com/(${REPO_SEGMENT}/${REPO_SEGMENT})/(?:issues|pull)/(\\d+)(?:[/?#]${URL_CHARS}*)?$`,
-)
+const GITHUB_FORMS = [
+  /^#?(?<number>\d+)$/,
+  new RegExp(`^(?<repo>${REPO_SEGMENT}/${REPO_SEGMENT})#(?<number>\\d+)$`),
+  new RegExp(
+    `^https?://(?:www\\.)?github\\.com/(?<repo>${REPO_SEGMENT}/${REPO_SEGMENT})/(?:issues|pull)/(?<number>\\d+)(?:[/?#]${URL_CHARS}*)?$`,
+  ),
+]
 const URL_RE = new RegExp(`^https?://${URL_CHARS}+$`)
-
-function issueNumber(digits: string): number | null {
-  const value = Number(digits)
-  return Number.isSafeInteger(value) && value > 0 ? value : null
-}
 
 /** Parse one `issues:` entry, or null when it matches no accepted form. */
 export function parseIssueRef(raw: string): DocIssueRef | null {
   const entry = raw.trim()
-  if (entry === '') return null
 
-  const github = NUMBER_RE.exec(entry) ?? REPO_NUMBER_RE.exec(entry) ?? GITHUB_URL_RE.exec(entry)
-  if (github) {
-    const [repo, digits] = github.length === 2 ? [null, github[1]] : [github[1], github[2]]
-    const number = issueNumber(digits)
-    return number === null ? null : { kind: 'github', raw: entry, repo, number }
+  for (const form of GITHUB_FORMS) {
+    const groups = form.exec(entry)?.groups
+    if (!groups) continue
+    const number = Number(groups.number)
+    return Number.isSafeInteger(number) && number > 0
+      ? { kind: 'github', repo: groups.repo ?? null, number }
+      : null
   }
 
-  if (URL_RE.test(entry)) return { kind: 'url', raw: entry, url: entry }
-
-  return null
+  return URL_RE.test(entry) ? { kind: 'url', url: entry } : null
 }
 
 /** The `--issue` flag's value as entries: comma-separated, blanks dropped. */
 export function splitIssueList(value: string | undefined): string[] {
-  if (value === undefined) return []
-  return value
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter((entry) => entry !== '')
+  return value === undefined ? [] : splitCommaList(value)
 }
 
 const REMOTE_RE = new RegExp(
@@ -89,22 +86,15 @@ export async function resolveOriginRepo(cwd: string): Promise<string | null> {
   return url === undefined ? null : repoFromRemoteUrl(url)
 }
 
-/** `owner/repo#412`, or `#412` when no repository is known. */
-export function issueLabel(ref: DocIssueRef, defaultRepo: string | null): string {
-  if (ref.kind === 'url') return ref.url
+/**
+ * Label and URL for one reference. The label doubles as the identity across
+ * docs: `412` and `acme/shop#412` in a checkout whose origin is acme/shop
+ * describe one issue and get one label.
+ */
+export function describeIssue(ref: DocIssueRef, defaultRepo: string | null): IssueLink {
+  if (ref.kind === 'url') return { label: ref.url, url: ref.url }
   const repo = ref.repo ?? defaultRepo
-  return repo ? `${repo}#${ref.number}` : `#${ref.number}`
-}
-
-/** The issue's URL, or undefined when the repository cannot be resolved. */
-export function issueUrl(ref: DocIssueRef, defaultRepo: string | null): string | undefined {
-  if (ref.kind === 'url') return ref.url
-  const repo = ref.repo ?? defaultRepo
-  return repo ? `https://github.com/${repo}/issues/${ref.number}` : undefined
-}
-
-/** Identity for de-duplication across docs: the same issue named two ways is one issue. */
-export function issueKey(ref: DocIssueRef, defaultRepo: string | null): string {
-  if (ref.kind === 'url') return ref.url
-  return `${ref.repo ?? defaultRepo ?? ''}#${ref.number}`
+  return repo
+    ? { label: `${repo}#${ref.number}`, url: `https://github.com/${repo}/issues/${ref.number}` }
+    : { label: `#${ref.number}` }
 }

--- a/packages/cli/src/make-adr.ts
+++ b/packages/cli/src/make-adr.ts
@@ -15,7 +15,7 @@ import {
 } from './discovery'
 import { discoverParsedModels } from './model-parser'
 import { runGit } from './changed-files'
-import { ISSUE_REF_FORMS, parseIssueRef, type DocIssueRef } from './issue-refs'
+import { ISSUE_REF_FORMS, parseIssueRef } from './issue-refs'
 
 const ADR_DIR = 'docs/adr'
 
@@ -41,13 +41,18 @@ export interface MakeAdrOptions extends WriterOptions {
   issues?: string[]
 }
 
-function resolveIssueRefs(entries: string[]): DocIssueRef[] {
+/**
+ * Each entry as the YAML list item make:adr writes. Bare numbers stay bare;
+ * every other form is quoted, since `#` opens a YAML comment. The quoting
+ * needs no escaping because the grammar admits neither `"` nor `\`.
+ */
+function issueYamlEntries(entries: string[]): string[] {
   return entries.map((entry) => {
     const ref = parseIssueRef(entry)
     if (ref === null) {
       throw new Error(`Invalid issue reference "${entry}" — write it as one of: ${ISSUE_REF_FORMS}.`)
     }
-    return ref
+    return ref.kind === 'github' && ref.repo === null ? String(ref.number) : `"${entry.trim()}"`
   })
 }
 
@@ -156,7 +161,7 @@ function adrTemplate(
   actor: string | null,
   generatedAt: string,
   prefill: AdrPrefill,
-  issueRefs: DocIssueRef[],
+  issueEntries: string[],
 ): string {
   const entities =
     prefill.entities.length > 0 ? `entities: [${prefill.entities.join(', ')}]` : 'entities: []'
@@ -169,12 +174,7 @@ function adrTemplate(
   // YAML. ACTOR_RE already excludes quotes, so no escaping is needed.
   const generated = actor === null ? '' : `\ngenerated: { by: "${actor}", at: ${generatedAt} }`
 
-  // Bare numbers stay bare; every other form is quoted, since `#` opens a
-  // YAML comment and `owner/repo#412` would be cut at the `#`.
-  const issues =
-    issueRefs.length > 0
-      ? `\nissues: [${issueRefs.map((ref) => (ref.kind === 'github' && ref.repo === null ? String(ref.number) : `"${ref.raw}"`)).join(', ')}]`
-      : ''
+  const issues = issueEntries.length > 0 ? `\nissues: [${issueEntries.join(', ')}]` : ''
 
   return `---
 type: adr
@@ -229,7 +229,7 @@ export async function makeAdr(title: string, options: MakeAdrOptions = {}): Prom
   const moduleName = options.root ? safeModuleName(options.root) : undefined
   const dir = moduleName ? `modules/${moduleName}/${ADR_DIR}` : ADR_DIR
   // Validated before any discovery: a bad reference fails fast, not after a scan.
-  const issueRefs = resolveIssueRefs(options.issues ?? [])
+  const issueEntries = issueYamlEntries(options.issues ?? [])
   const [prefill, actor] = await Promise.all([
     options.entity ? resolveAdrPrefill(options.entity, moduleName) : EMPTY_PREFILL,
     resolveActor(options.by),
@@ -238,7 +238,7 @@ export async function makeAdr(title: string, options: MakeAdrOptions = {}): Prom
 
   return writeScaffoldFile(
     `${dir}/${sequence}-${adrSlug(title)}.md`,
-    adrTemplate(title.trim(), actor, new Date().toISOString(), prefill, issueRefs),
+    adrTemplate(title.trim(), actor, new Date().toISOString(), prefill, issueEntries),
     options,
   )
 }

--- a/packages/cli/src/token-issue.ts
+++ b/packages/cli/src/token-issue.ts
@@ -18,6 +18,7 @@ import {
   type ScopedTool,
 } from '@guren/core'
 import { listTools } from './tool-list'
+import { splitCommaList } from './utils'
 import { loadBootedApplication } from './runtime'
 
 /** `tool:` scope prefix, including the separator. */
@@ -115,13 +116,6 @@ export interface TokenIssuePlan {
   warnings: string[]
 }
 
-/** Split, trim, and drop empties — `--tools 'a, b,'` names two scopes. */
-function splitToolEntries(raw: string): string[] {
-  return raw
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0)
-}
 
 /**
  * Decide what a token would carry, without minting anything. Throws on every refusal in a
@@ -130,7 +124,7 @@ function splitToolEntries(raw: string): string[] {
  * `tools` is injected rather than derived so the rules stay testable with no route graph.
  */
 export function planTokenIssue(input: TokenIssueInput, tools: readonly ScopedTool[]): TokenIssuePlan {
-  const entries = splitToolEntries(input.tools)
+  const entries = splitCommaList(input.tools)
   if (entries.length === 0) {
     throw new Error('--tools requires at least one scope (for example: tools:read, posts.*, posts.store).')
   }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -243,6 +243,14 @@ export function pascalCase(value: string): string {
  * adversarial input). A twin lives in `@guren/server` (`src/support/trim-slashes.ts`);
  * the packages share no dependency edge, so the six lines are duplicated by convention.
  */
+/** Split, trim, and drop empties: `'a, b,'` names two entries. */
+export function splitCommaList(value: string): string[] {
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry !== '')
+}
+
 export function trimSlashes(value: string): string {
   let start = 0
   let end = value.length

--- a/packages/cli/tests/docs-issues.test.ts
+++ b/packages/cli/tests/docs-issues.test.ts
@@ -3,7 +3,7 @@
 // offline; a network call from any of these paths is a bug these tests cannot
 // see, which is why the fetch guard is preloaded on the suite.
 import { existsSync, readFileSync } from 'node:fs'
-import { mkdir, writeFile } from 'node:fs/promises'
+import { writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { describe, expect, it } from 'bun:test'
@@ -13,7 +13,7 @@ import { generateEntityContext, renderEntityContextMarkdown } from '../src/entit
 import { buildDocsViewerData } from '../src/docs-viewer'
 import { makeAdr } from '../src/make-adr'
 import { resolveOriginRepo } from '../src/issue-refs'
-import { createTempWorkspace } from './helpers'
+import { createTempWorkspace, writeWorkspaceFiles } from './helpers'
 
 const ADR_WITH_ISSUES = `---
 type: adr
@@ -25,17 +25,23 @@ issues: [412, "#398", "acme/shop#7", https://github.com/acme/shop/pull/9, next-s
 # Posts need moderation
 `
 
-async function writeApp(dir: string): Promise<void> {
-  await mkdir(join(dir, 'docs/adr'), { recursive: true })
-  await mkdir(join(dir, 'app/Models'), { recursive: true })
-  await writeFile(join(dir, 'package.json'), '{}', 'utf8')
-  await writeFile(join(dir, 'app/Models/Post.ts'), 'export class Post {}\n', 'utf8')
+/** A one-model app whose docs are `docs`, the moderation ADR by default. */
+async function writeApp(
+  dir: string,
+  docs: Record<string, string> = { 'docs/adr/0001-moderation.md': ADR_WITH_ISSUES },
+): Promise<void> {
+  await writeWorkspaceFiles(dir, {
+    'package.json': '{}',
+    'app/Models/Post.ts': 'export class Post {}\n',
+    ...docs,
+  })
 }
 
-function gitWithOrigin(dir: string, remote: string): boolean {
-  const init = spawnSync('git', ['init', '-q'], { cwd: dir, stdio: 'ignore' })
-  if (init.status !== 0) return false
-  return spawnSync('git', ['remote', 'add', 'origin', remote], { cwd: dir, stdio: 'ignore' }).status === 0
+function gitWithOrigin(dir: string, remote: string): void {
+  for (const args of [['init', '-q'], ['remote', 'add', 'origin', remote]]) {
+    const result = spawnSync('git', args, { cwd: dir, stdio: 'ignore' })
+    if (result.status !== 0) throw new Error(`git ${args[0]} failed with status ${result.status}`)
+  }
 }
 
 describe('issues: frontmatter', () => {
@@ -43,15 +49,14 @@ describe('issues: frontmatter', () => {
     const workspace = await createTempWorkspace('guren-cli-docs-issues-scan-')
     try {
       await writeApp(workspace.dir)
-      await writeFile(join(workspace.dir, 'docs/adr/0001-moderation.md'), ADR_WITH_ISSUES, 'utf8')
 
       const [ref] = await scanDocs(workspace.dir)
 
       expect(ref.issues).toEqual([
-        { kind: 'github', raw: '412', repo: null, number: 412 },
-        { kind: 'github', raw: '#398', repo: null, number: 398 },
-        { kind: 'github', raw: 'acme/shop#7', repo: 'acme/shop', number: 7 },
-        { kind: 'github', raw: 'https://github.com/acme/shop/pull/9', repo: 'acme/shop', number: 9 },
+        { kind: 'github', repo: null, number: 412 },
+        { kind: 'github', repo: null, number: 398 },
+        { kind: 'github', repo: 'acme/shop', number: 7 },
+        { kind: 'github', repo: 'acme/shop', number: 9 },
       ])
       expect(ref.malformedIssues).toEqual(['next-sprint'])
     } finally {
@@ -62,12 +67,7 @@ describe('issues: frontmatter', () => {
   it('loses the list to an unquoted #number, which YAML reads as a comment, and warns on the remainder', async () => {
     const workspace = await createTempWorkspace('guren-cli-docs-issues-comment-')
     try {
-      await writeApp(workspace.dir)
-      await writeFile(
-        join(workspace.dir, 'docs/adr/0001-x.md'),
-        '---\ntype: adr\nissues: [412, #398]\n---\n# X\n',
-        'utf8',
-      )
+      await writeApp(workspace.dir, { 'docs/adr/0001-x.md': '---\ntype: adr\nissues: [412, #398]\n---\n# X\n' })
 
       const [ref] = await scanDocs(workspace.dir)
 
@@ -84,7 +84,6 @@ describe('issues: frontmatter', () => {
     const workspace = await createTempWorkspace('guren-cli-docs-issues-check-')
     try {
       await writeApp(workspace.dir)
-      await writeFile(join(workspace.dir, 'docs/adr/0001-moderation.md'), ADR_WITH_ISSUES, 'utf8')
 
       const results = await runDocsCheck({ cwd: workspace.dir })
       const issueResults = results.filter((r) => r.key.startsWith('docs-issues:'))
@@ -103,14 +102,11 @@ describe('guren context <Entity> linked issues', () => {
   it('lists each distinct issue once, naming every doc that declared it', async () => {
     const workspace = await createTempWorkspace('guren-cli-docs-issues-context-')
     try {
-      await writeApp(workspace.dir)
-      await mkdir(join(workspace.dir, 'docs/context'), { recursive: true })
-      await writeFile(join(workspace.dir, 'docs/adr/0001-moderation.md'), ADR_WITH_ISSUES, 'utf8')
-      await writeFile(
-        join(workspace.dir, 'docs/context/posts.md'),
-        '---\ntype: context\nentities: [Post]\nissues: ["#412", https://gitlab.example.com/i/5]\n---\n# Posts\n',
-        'utf8',
-      )
+      await writeApp(workspace.dir, {
+        'docs/adr/0001-moderation.md': ADR_WITH_ISSUES,
+        'docs/context/posts.md':
+          '---\ntype: context\nentities: [Post]\nissues: ["#412", https://gitlab.example.com/i/5]\n---\n# Posts\n',
+      })
 
       const ctx = await generateEntityContext('Post', { cwd: workspace.dir })
 
@@ -147,8 +143,7 @@ describe('guren context <Entity> linked issues', () => {
   it('omits the section when no linked doc declares issues', async () => {
     const workspace = await createTempWorkspace('guren-cli-docs-issues-none-')
     try {
-      await writeApp(workspace.dir)
-      await writeFile(join(workspace.dir, 'docs/adr/0001-x.md'), '---\ntype: adr\nentities: [Post]\n---\n# X\n', 'utf8')
+      await writeApp(workspace.dir, { 'docs/adr/0001-x.md': '---\ntype: adr\nentities: [Post]\n---\n# X\n' })
 
       const ctx = await generateEntityContext('Post', { cwd: workspace.dir })
 
@@ -162,9 +157,8 @@ describe('guren context <Entity> linked issues', () => {
   it('resolves bare numbers against the origin remote when the app is a GitHub checkout', async () => {
     const workspace = await createTempWorkspace('guren-cli-docs-issues-origin-')
     try {
-      await writeApp(workspace.dir)
-      if (!gitWithOrigin(workspace.dir, 'git@github.com:acme/shop.git')) return
-      await writeFile(join(workspace.dir, 'docs/adr/0001-x.md'), '---\ntype: adr\nentities: [Post]\nissues: [412]\n---\n# X\n', 'utf8')
+      await writeApp(workspace.dir, { 'docs/adr/0001-x.md': '---\ntype: adr\nentities: [Post]\nissues: [412]\n---\n# X\n' })
+      gitWithOrigin(workspace.dir, 'git@github.com:acme/shop.git')
 
       expect(await resolveOriginRepo(workspace.dir)).toBe('acme/shop')
       const ctx = await generateEntityContext('Post', { cwd: workspace.dir })
@@ -183,10 +177,8 @@ describe('docs viewer issue outlinks', () => {
     const workspace = await createTempWorkspace('guren-cli-docs-issues-viewer-')
     try {
       await writeApp(workspace.dir)
-      await writeFile(join(workspace.dir, 'docs/adr/0001-moderation.md'), ADR_WITH_ISSUES, 'utf8')
 
-      const data = await buildDocsViewerData(workspace.dir)
-      const [doc] = data.docs
+      const [doc] = (await buildDocsViewerData(workspace.dir)).docs
 
       expect(doc.issues).toEqual([
         { label: '#412' },
@@ -194,7 +186,6 @@ describe('docs viewer issue outlinks', () => {
         { label: 'acme/shop#7', url: 'https://github.com/acme/shop/issues/7' },
         { label: 'acme/shop#9', url: 'https://github.com/acme/shop/issues/9' },
       ])
-      expect(data.nodes.some((node) => node.id.includes('412'))).toBe(false)
     } finally {
       await workspace.cleanup()
     }
@@ -214,7 +205,11 @@ describe('make:adr --issue', () => {
       // The written file round-trips through the scanner without warnings.
       await writeFile(join(workspace.dir, 'package.json'), '{}', 'utf8')
       const [ref] = await scanDocs(workspace.dir)
-      expect(ref.issues.map((issue) => issue.raw)).toEqual(['412', 'acme/shop#7', 'https://github.com/acme/shop/pull/9'])
+      expect(ref.issues).toEqual([
+        { kind: 'github', repo: null, number: 412 },
+        { kind: 'github', repo: 'acme/shop', number: 7 },
+        { kind: 'github', repo: 'acme/shop', number: 9 },
+      ])
       expect(ref.malformedIssues).toEqual([])
     } finally {
       await workspace.cleanup()

--- a/packages/cli/tests/docs-issues.test.ts
+++ b/packages/cli/tests/docs-issues.test.ts
@@ -237,6 +237,11 @@ describe('make:adr --issue', () => {
       await expect(makeAdr('Bad reference', { issues: ['412', 'next-sprint'] })).rejects.toThrow(
         'Invalid issue reference "next-sprint"',
       )
+      // A quote would end the scalar the scaffold writes early; the grammar
+      // refuses it, so nothing reaches the file.
+      await expect(
+        makeAdr('Quote injection', { issues: ['https://github.com/acme/shop/issues/412?", evil: true'] }),
+      ).rejects.toThrow('Invalid issue reference')
       expect(existsSync(join(workspace.dir, 'docs/adr'))).toBe(false)
     } finally {
       await workspace.cleanup()

--- a/packages/cli/tests/issue-refs.test.ts
+++ b/packages/cli/tests/issue-refs.test.ts
@@ -1,38 +1,25 @@
 import { describe, expect, it } from 'bun:test'
-import {
-  issueKey,
-  issueLabel,
-  issueUrl,
-  parseIssueRef,
-  repoFromRemoteUrl,
-  splitIssueList,
-} from '../src/issue-refs'
+import { describeIssue, parseIssueRef, repoFromRemoteUrl, splitIssueList } from '../src/issue-refs'
 
 describe('parseIssueRef', () => {
   it('accepts a bare number as the app-repository form', () => {
-    expect(parseIssueRef('412')).toEqual({ kind: 'github', raw: '412', repo: null, number: 412 })
-    expect(parseIssueRef('#412')).toEqual({ kind: 'github', raw: '#412', repo: null, number: 412 })
-    expect(parseIssueRef('  412 ')).toEqual({ kind: 'github', raw: '412', repo: null, number: 412 })
+    expect(parseIssueRef('412')).toEqual({ kind: 'github', repo: null, number: 412 })
+    expect(parseIssueRef('#412')).toEqual({ kind: 'github', repo: null, number: 412 })
+    expect(parseIssueRef('  412 ')).toEqual({ kind: 'github', repo: null, number: 412 })
   })
 
   it('accepts owner/repo#number', () => {
-    expect(parseIssueRef('acme/shop#398')).toEqual({
-      kind: 'github',
-      raw: 'acme/shop#398',
-      repo: 'acme/shop',
-      number: 398,
-    })
-    expect(parseIssueRef('acme-inc/shop.web#1')).toMatchObject({ repo: 'acme-inc/shop.web', number: 1 })
+    expect(parseIssueRef('acme/shop#398')).toEqual({ kind: 'github', repo: 'acme/shop', number: 398 })
+    expect(parseIssueRef('acme-inc/shop.web#1')).toEqual({ kind: 'github', repo: 'acme-inc/shop.web', number: 1 })
   })
 
   it('parses GitHub issue and pull request URLs, ignoring fragments', () => {
     expect(parseIssueRef('https://github.com/acme/shop/issues/412')).toEqual({
       kind: 'github',
-      raw: 'https://github.com/acme/shop/issues/412',
       repo: 'acme/shop',
       number: 412,
     })
-    expect(parseIssueRef('https://github.com/acme/shop/pull/9#issuecomment-1')).toMatchObject({
+    expect(parseIssueRef('https://github.com/acme/shop/pull/9#issuecomment-1')).toEqual({
       kind: 'github',
       repo: 'acme/shop',
       number: 9,
@@ -43,7 +30,6 @@ describe('parseIssueRef', () => {
   it('keeps a non-GitHub URL as an outlink', () => {
     expect(parseIssueRef('https://gitlab.example.com/acme/shop/-/issues/5')).toEqual({
       kind: 'url',
-      raw: 'https://gitlab.example.com/acme/shop/-/issues/5',
       url: 'https://gitlab.example.com/acme/shop/-/issues/5',
     })
   })
@@ -104,26 +90,27 @@ describe('repoFromRemoteUrl', () => {
   })
 })
 
-describe('issue labels, URLs and keys', () => {
+describe('describeIssue', () => {
   const bare = parseIssueRef('412')!
   const scoped = parseIssueRef('acme/shop#412')!
   const url = parseIssueRef('https://gitlab.example.com/i/5')!
 
-  it('fills the app repository in from the default when the entry names none', () => {
-    expect(issueLabel(bare, 'acme/shop')).toBe('acme/shop#412')
-    expect(issueUrl(bare, 'acme/shop')).toBe('https://github.com/acme/shop/issues/412')
-    expect(issueKey(bare, 'acme/shop')).toBe(issueKey(scoped, null))
+  it('fills the app repository in from the default, so two spellings of one issue share a label', () => {
+    expect(describeIssue(bare, 'acme/shop')).toEqual({
+      label: 'acme/shop#412',
+      url: 'https://github.com/acme/shop/issues/412',
+    })
+    expect(describeIssue(bare, 'acme/shop')).toEqual(describeIssue(scoped, null))
   })
 
   it('degrades to a bare label with no URL when no repository is known', () => {
-    expect(issueLabel(bare, null)).toBe('#412')
-    expect(issueUrl(bare, null)).toBeUndefined()
-    expect(issueKey(bare, null)).toBe('#412')
+    expect(describeIssue(bare, null)).toEqual({ label: '#412' })
   })
 
   it('passes URL entries through unchanged', () => {
-    expect(issueLabel(url, 'acme/shop')).toBe('https://gitlab.example.com/i/5')
-    expect(issueUrl(url, null)).toBe('https://gitlab.example.com/i/5')
-    expect(issueKey(url, 'acme/shop')).toBe('https://gitlab.example.com/i/5')
+    expect(describeIssue(url, 'acme/shop')).toEqual({
+      label: 'https://gitlab.example.com/i/5',
+      url: 'https://gitlab.example.com/i/5',
+    })
   })
 })

--- a/packages/cli/tests/issue-refs.test.ts
+++ b/packages/cli/tests/issue-refs.test.ts
@@ -5,6 +5,7 @@ import {
   issueUrl,
   parseIssueRef,
   repoFromRemoteUrl,
+  splitIssueList,
 } from '../src/issue-refs'
 
 describe('parseIssueRef', () => {
@@ -51,6 +52,39 @@ describe('parseIssueRef', () => {
     for (const raw of ['', 'next-sprint', 'shop#12', 'acme/shop#', 'acme/shop/12', '12a', 'ftp://x/1', 'https://x y']) {
       expect(parseIssueRef(raw)).toBeNull()
     }
+  })
+
+  it('rejects the characters that would break a quoted YAML scalar or a comma list', () => {
+    for (const raw of [
+      'https://github.com/acme/shop/issues/412?", evil: true',
+      'https://github.com/acme/shop/issues/412?a=1,2',
+      'https://github.com/acme/shop/issues/412#\\x',
+      'https://gitlab.example.com/i/5?q="x"',
+      'https://gitlab.example.com/i/5,6',
+    ]) {
+      expect(parseIssueRef(raw)).toBeNull()
+    }
+  })
+
+  it('never yields a non-http(s) URL, which is what keeps viewer hrefs safe', () => {
+    expect(parseIssueRef('javascript:alert(1)')).toBeNull()
+    expect(parseIssueRef('data:text/html,x')).toBeNull()
+  })
+
+  it('rejects zero and numbers beyond the safe-integer range', () => {
+    expect(parseIssueRef('0')).toBeNull()
+    expect(parseIssueRef('#0')).toBeNull()
+    expect(parseIssueRef('acme/shop#0')).toBeNull()
+    expect(parseIssueRef('99999999999999999999')).toBeNull()
+    expect(parseIssueRef('0412')).toMatchObject({ number: 412 })
+  })
+})
+
+describe('splitIssueList', () => {
+  it('splits the --issue value on commas and drops blanks', () => {
+    expect(splitIssueList(undefined)).toEqual([])
+    expect(splitIssueList('412')).toEqual(['412'])
+    expect(splitIssueList(' 412, acme/shop#7 ,, ')).toEqual(['412', 'acme/shop#7'])
   })
 })
 

--- a/rfcs/0018-github-issues-as-task-ledger.md
+++ b/rfcs/0018-github-issues-as-task-ledger.md
@@ -89,6 +89,13 @@ Accepted forms, each one list entry:
 Pull requests share the number space and are accepted in every form; the
 field keeps the name `issues`, and the guide says so (Open Question 3).
 
+A URL form may not contain whitespace, `"`, `,` or `\`. Those are the
+characters that would break one of the places a reference travels: the
+comma-separated `--issue` list, the double-quoted YAML scalar `make:adr`
+writes, and the scanner's inline-list split on unquoted commas. Rejecting
+them in the grammar keeps every consumer safe by construction rather than
+by escaping at each sink.
+
 "The app's own repository" is resolved from the `origin` remote
 (`git remote get-url origin`, through the existing `runGit` helper in
 `changed-files.ts`) only when a consumer needs a full URL. Validation never
@@ -113,6 +120,10 @@ export interface DocRef {
   malformedIssues: string[]
 }
 ```
+
+**Amended in implementation:** `DocIssueRef` shipped as a discriminated union,
+`{ kind: 'github', raw, repo, number } | { kind: 'url', raw, url }`, because
+the non-GitHub URL form §6 admits has no `repo`/`number` to carry.
 
 `docs-check.ts` adds one rule, `docs-issues:<path>`: a **warn** per malformed
 entry (`issues: [next-sprint]`, an unparsable URL), with the accepted forms in
@@ -154,6 +165,13 @@ export interface EntityContext {
   issuesLiveError?: string
 }
 ```
+
+**Amended in implementation:** `EntityIssue` shipped with a required `label`
+(`owner/repo#412`, `#412` when no repository is known, or the URL) and
+optional `repo`, `number` and `url`, so a URL-form entry and a bare number in
+a checkout with no `origin` both have a shape; entries sort by repository then
+number, with URL entries last, so the order does not depend on whether
+`origin` resolved. `live` is unchanged and lands in Part 2.
 
 Markdown output adds a section after Linked docs:
 
@@ -201,7 +219,10 @@ bunx guren make:adr "Users verify email before posting" --entity User --issue 41
 bunx guren make:adr "Rename billing plans" --issue acme/shop#398 --issue 401
 ```
 
-`--issue` is repeatable and accepts the same forms as the field. It prefills
+`--issue` is ~~repeatable~~ **Amended in implementation:** comma-separated
+for several; the CLI collapses a repeated flag to its last value by design
+(`packages/cli/src/define-command.ts`), and a comma cannot appear in a
+reference (§1). It accepts the same forms as the field and prefills
 `issues:` and nothing else: no title fetch, no network. `MakeAdrOptions` gains
 `issues?: string[]`, validated by the same parser the index uses, so a
 malformed value fails the command with the accepted forms rather than writing


### PR DESCRIPTION
## Summary

Follow-up to #694 (RFC 0018 Part 1), carrying the review findings that were still in flight when it merged, plus a simplify pass. Worth landing before v2.17.0 (#695) ships the field: the first two items change what `make:adr --issue` accepts and writes.

**Review fixes**

- **Grammar closed against delimiters.** A URL reference may no longer contain whitespace, `"`, `,` or `\`. Before, `--issue 'https://github.com/acme/shop/issues/412?", evil: true'` wrote a frontmatter line the scanner then misread as three entries, and a URL with a comma was split into two references that both parsed. Rejecting the characters in the grammar keeps the `--issue` list, the quoted YAML scalar the scaffold writes, and the scanner's unquoted inline-list split safe by construction.
- **`--issue` is comma-separated, not repeatable.** The CLI collapses a repeated flag to its last value by design (`define-command.ts`), so `--issue a --issue b` never reached the command as two values; the help text and docs claimed otherwise.
- Issue numbers must be positive safe integers; Linked issues sort by repository then number with URL entries last, so the order does not depend on whether `origin` resolved.
- The RFC records each deviation in place.

**Simplify pass**

- `DocIssueRef` drops `raw` (make:adr quotes the entry it was given); the three GitHub forms parse through named groups.
- One `describeIssue()` replaces the label/url/key trio and doubles as the identity across docs; `EntityIssue` extends the same `IssueLink` the viewer ships.
- The comma-list split is shared with `token:issue` through `splitCommaList()` in utils.
- The docs viewer spawns `git remote get-url` only for a bundle that declares issues; the package barrel exports the types only.
- Tests use the workspace helper and fail rather than pass vacuously when `git init` fails.

**Skipped on purpose:** a per-arg "repeatable" opt-out in `define-command.ts` (proposed as the deeper fix for the flag) would add a second mode to shared infrastructure for one flag; the comma spelling is the repo's existing convention (`--target`, `--tools`).

## Verification

- `bun run typecheck`, `bun run lint`: green
- `packages/cli` suite with the cwd and fetch guards preloaded: 2243 pass

Refs: RFC 0018
