### PR TITLE
refactor: declare Post fillable via the typed defineModel option

### DIFF
--- a/.changeset/blog-template-typed-fillable.md
+++ b/.changeset/blog-template-typed-fillable.md
@@ -1,0 +1,12 @@
+---
+'create-guren-app': patch
+---
+
+Declare the blog template's Post allowlist as the typed `defineModel` option
+
+`app/Models/Post.ts` scaffolded a `static fillable = [...]`, the untyped form.
+The `defineModel(posts, { fillable: [...] })` option is the documented,
+preferred one because TypeScript checks every name against the table's columns,
+and the template's own `User.ts` already used it. The field list is unchanged,
+and the comment recording that `authorId` is set from the signed-in user rather
+than from request input now sits directly above the list it explains.

--- a/examples/api/app/Models/Task.ts
+++ b/examples/api/app/Models/Task.ts
@@ -6,9 +6,9 @@ export type TaskRecord = typeof tasks.$inferSelect
 export type NewTaskRecord = typeof tasks.$inferInsert
 export type TaskOwnerSummary = Pick<UserRecord, 'id' | 'name'>
 
-export class Task extends defineModel(tasks) {
-  static fillable = ['title', 'description', 'completed', 'userId']
-
+export class Task extends defineModel(tasks, {
+  fillable: ['title', 'description', 'completed', 'userId'],
+}) {
   static override relationTypes: { owner: BelongsToRecord<TaskOwnerSummary> } = {
     owner: null,
   }

--- a/examples/blog/app/Models/Post.ts
+++ b/examples/blog/app/Models/Post.ts
@@ -7,14 +7,17 @@ export type PostRecord = typeof posts.$inferSelect
 export type NewPostRecord = typeof posts.$inferInsert
 export type PostAuthorSummary = Pick<UserRecord, 'id' | 'name'>
 
-export class Post extends Attachable(defineModel(posts), {
-  cover: hasOneAttached({
-    image: 'require',
-    variants: { thumb: { width: 320 } },
+export class Post extends Attachable(
+  defineModel(posts, {
+    fillable: ['title', 'excerpt', 'body', 'authorId'],
   }),
-}) {
-  static fillable = ['title', 'excerpt', 'body', 'authorId']
-
+  {
+    cover: hasOneAttached({
+      image: 'require',
+      variants: { thumb: { width: 320 } },
+    }),
+  },
+) {
   static override relationTypes: { author: BelongsToRecord<PostAuthorSummary> } = {
     author: null,
   }

--- a/packages/create-app/templates/blog/app/Models/Post.ts
+++ b/packages/create-app/templates/blog/app/Models/Post.ts
@@ -6,10 +6,10 @@ export type PostRecord = typeof posts.$inferSelect
 export type NewPostRecord = typeof posts.$inferInsert
 export type PostAuthorSummary = Pick<UserRecord, 'id' | 'name'>
 
-export class Post extends defineModel(posts) {
+export class Post extends defineModel(posts, {
   // `authorId` is set from the signed-in user, never from request input.
-  static fillable = ['title', 'excerpt', 'body']
-
+  fillable: ['title', 'excerpt', 'body'],
+}) {
   static override relationTypes: { author: BelongsToRecord<PostAuthorSummary> } = {
     author: null,
   }

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -369,8 +369,9 @@ async function assertBlogScaffold(appDir: string): Promise<void> {
   assert(/<Link[^>]*method="post"/su.test(layout), 'Blog blueprint must log out through an Inertia Link.')
 
   const post = await readFile(join(appDir, 'app/Models/Post.ts'), 'utf8')
-  assert(post.includes('static fillable'), 'Blog Post model must declare fillable fields.')
-  assert(!/fillable\s*=\s*\[[^\]]*authorId/su.test(post), 'Blog Post model must not accept authorId as mass-assignable input.')
+  // Both spellings: the typed `defineModel` option and a `static` on the class.
+  assert(/fillable\s*[:=]\s*\[/su.test(post), 'Blog Post model must declare fillable fields.')
+  assert(!/fillable\s*[:=]\s*\[[^\]]*authorId/su.test(post), 'Blog Post model must not accept authorId as mass-assignable input.')
 
   const postController = await readFile(join(appDir, 'app/Http/Controllers/PostController.ts'), 'utf8')
   for (const ability of ["'create'", "'update'", "'delete'"]) {

--- a/web/modules/blog/app/Models/Post.ts
+++ b/web/modules/blog/app/Models/Post.ts
@@ -4,6 +4,6 @@ import { posts } from '../../../../db/schema.js'
 export type PostRecord = typeof posts.$inferSelect
 export type NewPostRecord = typeof posts.$inferInsert
 
-export class Post extends defineModel(posts) {
-  static fillable = ['slug', 'title', 'description', 'bodyMarkdown', 'bodyHtml', 'publishedAt', 'updatedAt']
-}
+export class Post extends defineModel(posts, {
+  fillable: ['slug', 'title', 'description', 'bodyMarkdown', 'bodyHtml', 'publishedAt', 'updatedAt'],
+}) {}


### PR DESCRIPTION
Four models still declared their mass-assignment allowlist with the older untyped `static fillable = [...]`. The documented, preferred form is the `defineModel(table, { fillable: [...] })` option, which TypeScript checks against the table's columns, so a column typo is a compile error rather than a silently dead allowlist entry.

Converted, with the field lists unchanged:

- `examples/blog/app/Models/Post.ts` — the option goes into the `defineModel` call that `Attachable(...)` wraps.
- `web/modules/blog/app/Models/Post.ts`
- `packages/create-app/templates/blog/app/Models/Post.ts` — the comment recording that `authorId` comes from the signed-in user rather than request input now sits directly above the list it explains, matching that template's own `User.ts`.
- `examples/api/app/Models/Task.ts`

### The smoke assertion this would have quietly disarmed

`scripts/smoke/fresh-app.ts` pinned the literal text `static fillable` for the scaffolded blog `Post` model, so the first assertion fails loudly after the conversion. Its companion is the interesting one:

```
assert(!/fillable\s*=\s*\[[^\]]*authorId/su.test(post), '…must not accept authorId as mass-assignable input.')
```

That regex can never match `fillable: [...]`. Left alone it would still read as a live guard while matching nothing. Both assertions now accept either spelling (`[:=]`), and the negative one was verified against a mutated copy of the template that adds `authorId` to the list: it trips. The legacy `static` spelling still satisfies the positive assertion, so the check covers apps that use either form.

### Verification

All run locally, judged by exit code.

| Gate | Result |
|---|---|
| `bun run build` | pass |
| `bun run typecheck` (after `codegen` in `examples/blog`) | pass |
| `bun run --cwd web typecheck` | pass |
| `bun run lint` | pass |
| `bun run --cwd examples/blog test` | 114 pass |
| `bun run --cwd web test` | 214 + 25 pass |
| `bun run audit:starter-template` | pass |
| `bun run test:bun create-app` | 112 pass |
| `bun run smoke:starter` | pass |
| `bun run smoke:starter:blog` | pass |

`smoke:starter:blog` is the only gate that executes the edited assertion, and it also typechecks the template's field names inside a real scaffold, which the root typecheck cannot do because `packages/create-app/tsconfig.json` excludes `templates`.

`guren audit` was run in both `examples/blog` and `web` to confirm the CLI still reads the allowlist: no mass-assignment warning appears. That check was proven live by temporarily removing the option, which produces `API3 Post mass assignment: Post declares no fillable`.

A `create-guren-app` patch changeset is included since the template output changes. No changeset for `examples/` or `web/`, which are private.

### Notes

- `bun run test:bun cli` segfaults under `--isolate` on this machine. It is pre-existing: the same crash reproduces with the pre-change template restored, and the suite passes 2219/0 when run without `--isolate`.

The `examples/api` conversion is verified by `bun run typecheck:api`, `bun run lint`, `bun run --cwd examples/api test` (43 pass), and `guren check` / `guren audit` in that app: no new warnings, and removing the option reproduces `API3 Task mass assignment: Task declares no fillable`.
