### PR TITLE
docs: fix the belongsToMany pivot and withPaginate examples

### DIFF
--- a/.claude/skills/guren-api/SKILL.md
+++ b/.claude/skills/guren-api/SKILL.md
@@ -121,10 +121,10 @@ await User.with('posts.comments')              // nested, dot notation
 await User.where('active', true).with('posts').get()  // QueryBuilder
 await User.findWith(1, 'posts')                // single record + relations
 await User.withCount('posts')                  // users[0].postsCount: number (no rows loaded)
-await Post.withPaginate({ page: 1 }, 'author') // paginated + relations
+await Post.withPaginate('author', { page: 1 }) // paginated + relations
 ```
 
-Also available: `hasOne`, `belongsToMany(pivotTable, ...)`, `hasManyThrough`, `morphMany`/`morphTo`. Full guide: `docs/en/guides/database.md` (Relationships section).
+Also available: `hasOne`, `belongsToMany(name, related, pivotTable, foreignPivotKey, relatedPivotKey, parentKey?, relatedKey?)`, `hasManyThrough`, `morphMany`/`morphTo`. Full guide: `docs/en/guides/database.md` (Relationships section).
 
 ### Routes
 Source: `packages/server/src/mvc/Router.ts`

--- a/docs/en/guides/database.md
+++ b/docs/en/guides/database.md
@@ -316,10 +316,14 @@ Post.belongsTo('author', () => import('./User.js').then((m) => m.User), 'authorI
 ### Other relationship types
 
 ```ts
+import { userRoles } from '@/db/schema'
+
 User.hasOne('profile', Profile, 'userId', 'id')
-User.belongsToMany('roles', Role, 'user_roles', 'userId', 'roleId')
+User.belongsToMany('roles', Role, userRoles, 'userId', 'roleId')
 Country.hasManyThrough('posts', Post, User, 'countryId', 'authorId')
 ```
+
+`belongsToMany(name, RelatedModel, pivotTable, foreignPivotKey, relatedPivotKey, parentKey?, relatedKey?)` takes `pivotTable` as the Drizzle table object exported from `@/db/schema`, not the table's name. `foreignPivotKey` and `relatedPivotKey` are both columns *on the pivot*, referencing this model and the related one; `parentKey` and `relatedKey` are the local keys they point at, and both default to `'id'`.
 
 ### Polymorphic Relationships
 

--- a/docs/ja/guides/database.md
+++ b/docs/ja/guides/database.md
@@ -823,10 +823,14 @@ User.hasOne('profile', Profile, 'userId', 'id')
 ### belongsToMany
 
 ```ts
+import { userRoles, postTags } from '@/db/schema'
+
 // ピボットテーブルを介した多対多
-User.belongsToMany('roles', Role, 'user_roles', 'userId', 'roleId')
-Post.belongsToMany('tags', Tag, 'post_tags', 'postId', 'tagId')
+User.belongsToMany('roles', Role, userRoles, 'userId', 'roleId')
+Post.belongsToMany('tags', Tag, postTags, 'postId', 'tagId')
 ```
+
+`pivotTable` に渡すのは `@/db/schema` からエクスポートした Drizzle のテーブルオブジェクトで、テーブル名の文字列ではありません。
 
 ### hasManyThrough
 
@@ -838,7 +842,7 @@ Country.hasManyThrough('posts', Post, User, 'countryId', 'authorId')
 - `hasMany(name, RelatedModel, foreignKey, localKey)`: 関連モデルの外部キーと親側のローカルキー（通常 `id`）を指定します。
 - `belongsTo(name, RelatedModel, foreignKey, ownerKey)`: 現在のモデルの外部キーと関連モデルの所有キーを結びつけます。
 - `hasOne(name, RelatedModel, foreignKey, localKey)`: `hasMany` と同じように動作しますが、単一のレコードまたは `null` を返します。
-- `belongsToMany(name, RelatedModel, pivotTable, foreignPivotKey, relatedPivotKey)`: ピボットテーブルを通じた多対多を処理します。
+- `belongsToMany(name, RelatedModel, pivotTable, foreignPivotKey, relatedPivotKey, parentKey?, relatedKey?)`: ピボットテーブルを通じた多対多を処理します。`pivotTable` は Drizzle のテーブルオブジェクトです。`foreignPivotKey` と `relatedPivotKey` はどちらもピボット側の列で、それぞれ自モデルと関連モデルを参照します。`parentKey` と `relatedKey` はそれらが指すローカルキーで、既定値はどちらも `'id'` です。
 - `hasManyThrough(name, RelatedModel, ThroughModel, firstKey, secondKey)`: 中間モデルを経由してリモートリレーションにアクセスします。
 - `morphMany(name, RelatedModel, morphName, localKey)`: 1対多のポリモーフィックリレーション。
 - `morphTo(name, morphName)`: ポリモーフィックリレーションの逆方向。


### PR DESCRIPTION
Two documented examples contradicted `packages/orm/src/Model.ts`.

### `belongsToMany` pivot argument

`belongsToMany(name, related, pivotTable, foreignPivotKey, relatedPivotKey, parentKey?, relatedKey?)` (`Model.ts` ~L842) takes the pivot as a Drizzle **table object**, as its JSDoc and `packages/orm/tests/model-relations-sqlite.test.ts` (~L86) both show. The relationship guides passed the table's *name* as a string instead:

```ts
User.belongsToMany('roles', Role, 'user_roles', 'userId', 'roleId')
```

`pivotTable` is typed `unknown`, so the string form compiles and only breaks at query time — which is how this drifted unnoticed. Fixed in `docs/en/guides/database.md` and its Japanese mirror `docs/ja/guides/database.md`, and both sides now state the full signature: the two pivot keys are columns on the pivot, and `parentKey`/`relatedKey` are the local keys they point at (`'id'` by default).

### `withPaginate` argument order

`withPaginate(relations, options?, queryOptions?)` (`Model.ts` ~L1055). `.claude/skills/guren-api/SKILL.md` showed the arguments reversed, and described the relationship helper as `belongsToMany(pivotTable, ...)` — implying the pivot comes first. Both corrected.

Note the harness **template** (`packages/cli/templates/agent/core/skills/guren-api/SKILL.md`, and `core/rules/orm-models.md`) was already correct on both counts; only the repo-root copy had drifted. No template file changed, so no `@guren/cli` changeset is needed — `CATALOG_INPUTS` in `scripts/build-agent-catalog.ts` watches `templates/agent-catalog/`, which does not carry `guren-api`.

### Verification

- `bun run audit:docs` — passed (1066 named imports across 1312 TypeScript fences)
- `bun run audit:agent-catalog` — passed (10 files rendered, `claude plugin validate --strict` ok)

### Follow-up (not in this PR)

`.claude/skills/guren-api/SKILL.md` has drifted from the harness template in about eight other places unrelated to this fix — the `defineModel(table, { fillable })` option form, the `userOrFail<T>` note, `RouteBody<ApiRoutes, ...>`, and the `this.view()` section are all missing. Worth a separate refresh from the template.
