### PR TITLE
docs: fix the login error pattern in the build-auth-app guide

### DIFF
--- a/docs/en/guides/build-auth-app.md
+++ b/docs/en/guides/build-auth-app.md
@@ -33,7 +33,7 @@ This scaffolds:
 - Inertia pages under `resources/js/pages/Auth/`
 - `AuthProvider` registered in your application providers
 - Session middleware with development-friendly defaults
-- Auth routes wired into `routes/web.ts`
+- `routes/auth.ts`, wired into your `routes/web.ts` registrar
 
 ## 3. Start the Database
 
@@ -67,56 +67,65 @@ Visit `http://localhost:3333/register` to create an account, then `http://localh
 
 ### LoginController
 
-The generated controller validates credentials with Zod and delegates to the auth guard:
+The generated controller validates credentials with `LoginSchema` (generated alongside it in `app/Http/Validators/LoginValidator.ts`) and delegates to the auth guard:
 
 ```typescript
-import { Controller } from '@guren/core'
-import { z } from 'zod'
+import { Controller, ValidationException } from '@guren/core'
+import { LoginSchema } from '../../Validators/LoginValidator.js'
 import { pages } from '@/.guren/pages.gen'
 
-const LoginSchema = z.object({
-  email: z.email(),
-  password: z.string().min(1),
-  remember: z.boolean().optional(),
-})
-
-export class LoginController extends Controller {
-  async show() {
-    return this.inertia(pages.auth.Login)
+export default class LoginController extends Controller {
+  async show(): Promise<Response> {
+    const email = this.request.query('email') ?? ''
+    return this.inertia(pages.auth.Login, { email }, { title: 'Login' })
   }
 
-  async login() {
+  async store(): Promise<Response> {
     const { email, password, remember } = await this.validateBody(LoginSchema)
-    const ok = await this.auth.attempt({ email, password }, remember)
 
-    if (!ok) {
-      return this.back().withErrors({ email: 'Invalid credentials.' })
+    this.auth.session()?.regenerate()
+
+    const authenticated = await this.auth.attempt({ email, password }, remember)
+
+    if (!authenticated) {
+      throw ValidationException.withMessages({ message: 'Invalid credentials.' })
     }
 
     return this.redirect('/dashboard')
   }
 
-  async logout() {
+  async destroy(): Promise<Response> {
     await this.auth.logout()
-    return this.redirect('/login')
+    this.auth.session()?.invalidate()
+    return this.redirect('/')
   }
 }
 ```
 
+A failed attempt throws `ValidationException.withMessages()`, which the framework renders as a 422 carrying an `errors` payload; the generated login page shows `errors.message`. Use a field name as the key (`{ email: '...' }`) to attach the message to a single input instead.
+
 ### Auth Middleware
 
-Protect any route group with the `auth` alias that the generator registers:
+The generator writes `routes/auth.ts` and calls it from your route registrar. Each route carries its own guard:
 
 ```typescript
-import { Router } from '@guren/core'
+import { Router, requireAuthenticated, requireGuest } from '@guren/core'
 
-export function registerWebRoutes(router: Router): void {
-  // Public routes
-  router.get('/login', [LoginController, 'show']).name('login.show')
-  router.post('/login', [LoginController, 'login']).name('login')
-  router.post('/logout', [LoginController, 'logout']).name('logout')
+export function registerAuthRoutes(router: Router): void {
+  router.get('/login', [LoginController, 'show'], requireGuest({ redirectTo: '/dashboard' })).name('login')
+  router.post('/login', [LoginController, 'store'], requireGuest({ redirectTo: '/dashboard' })).name('login.store')
+  router.post('/logout', [LoginController, 'destroy'], requireAuthenticated({ redirectTo: '/login' })).name('logout')
 
-  // Protected routes
+  router.get('/dashboard', [DashboardController, 'index'], requireAuthenticated({ redirectTo: '/login' })).name('dashboard')
+}
+```
+
+To guard a whole group under a short name instead, register the alias yourself first. `aliasMiddleware()` returns a router carrying the alias in its type, so capture the return value:
+
+```typescript
+export function registerWebRoutes(baseRouter: Router): void {
+  const router = baseRouter.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
+
   router.middleware('auth').group((auth) => {
     auth.get('/dashboard', [DashboardController, 'index']).name('dashboard')
   })
@@ -128,13 +137,22 @@ export function registerWebRoutes(router: Router): void {
 Inside a protected controller, access the current user via `this.auth`:
 
 ```typescript
-export class DashboardController extends Controller {
-  async index() {
-    const user = await this.auth.userOrFail()
-    return this.inertia(pages.dashboard.Index, { user })
+import { Controller } from '@guren/core'
+import type { UserRecord } from '../../Models/User.js'
+import { pages } from '@/.guren/pages.gen'
+
+export default class DashboardController extends Controller {
+  async index(): Promise<Response> {
+    const currentUser = await this.auth.user<UserRecord | null>()
+    const user = currentUser
+      ? { id: currentUser.id, name: currentUser.name, email: currentUser.email }
+      : null
+    return this.inertia(pages.dashboard.Index, { user }, { title: 'Dashboard' })
   }
 }
 ```
+
+`this.auth.user<T>()` returns `null` for a guest. Use `this.auth.userOrFail<T>()` when you want a 401 instead of a null branch.
 
 ## 7. Verify the Flow
 

--- a/docs/ja/guides/build-auth-app.md
+++ b/docs/ja/guides/build-auth-app.md
@@ -33,7 +33,7 @@ bunx guren add auth
 - `resources/js/pages/Auth/` 配下の Inertia ページ
 - アプリケーションプロバイダーに登録済みの `AuthProvider`
 - 開発環境向けのデフォルト設定が適用されたセッションミドルウェア
-- `routes/web.ts` に接続された認証ルート
+- `routes/web.ts` のレジストラに接続された `routes/auth.ts`
 
 ## 3. データベースを起動する
 
@@ -67,56 +67,65 @@ bun run dev
 
 ### LoginController
 
-生成されるコントローラーは Zod でバリデーションを行い、認証ガードに処理を委譲します:
+生成されるコントローラーは `LoginSchema`（同時に生成される `app/Http/Validators/LoginValidator.ts` にあります）でバリデーションを行い、認証ガードに処理を委譲します:
 
 ```typescript
-import { Controller } from '@guren/core'
-import { z } from 'zod'
+import { Controller, ValidationException } from '@guren/core'
+import { LoginSchema } from '../../Validators/LoginValidator.js'
 import { pages } from '@/.guren/pages.gen'
 
-const LoginSchema = z.object({
-  email: z.email(),
-  password: z.string().min(1),
-  remember: z.boolean().optional(),
-})
-
-export class LoginController extends Controller {
-  async show() {
-    return this.inertia(pages.auth.Login)
+export default class LoginController extends Controller {
+  async show(): Promise<Response> {
+    const email = this.request.query('email') ?? ''
+    return this.inertia(pages.auth.Login, { email }, { title: 'Login' })
   }
 
-  async login() {
+  async store(): Promise<Response> {
     const { email, password, remember } = await this.validateBody(LoginSchema)
-    const ok = await this.auth.attempt({ email, password }, remember)
 
-    if (!ok) {
-      return this.back().withErrors({ email: '認証情報が正しくありません。' })
+    this.auth.session()?.regenerate()
+
+    const authenticated = await this.auth.attempt({ email, password }, remember)
+
+    if (!authenticated) {
+      throw ValidationException.withMessages({ message: 'Invalid credentials.' })
     }
 
     return this.redirect('/dashboard')
   }
 
-  async logout() {
+  async destroy(): Promise<Response> {
     await this.auth.logout()
-    return this.redirect('/login')
+    this.auth.session()?.invalidate()
+    return this.redirect('/')
   }
 }
 ```
 
+認証に失敗した場合は `ValidationException.withMessages()` を throw します。フレームワークはこれを `errors` を含む 422 として返し、生成されるログインページは `errors.message` を表示します。特定の入力欄にメッセージを紐付けたい場合は、キーにフィールド名を使ってください（`{ email: '...' }`）。
+
 ### 認証ミドルウェア
 
-ジェネレーターが登録する `auth` エイリアスを使って、ルートグループを保護します:
+ジェネレーターは `routes/auth.ts` を生成し、ルートレジストラから呼び出すよう配線します。各ルートは自分のガードを個別に持ちます:
 
 ```typescript
-import { Router } from '@guren/core'
+import { Router, requireAuthenticated, requireGuest } from '@guren/core'
 
-export function registerWebRoutes(router: Router): void {
-  // 公開ルート
-  router.get('/login', [LoginController, 'show']).name('login.show')
-  router.post('/login', [LoginController, 'login']).name('login')
-  router.post('/logout', [LoginController, 'logout']).name('logout')
+export function registerAuthRoutes(router: Router): void {
+  router.get('/login', [LoginController, 'show'], requireGuest({ redirectTo: '/dashboard' })).name('login')
+  router.post('/login', [LoginController, 'store'], requireGuest({ redirectTo: '/dashboard' })).name('login.store')
+  router.post('/logout', [LoginController, 'destroy'], requireAuthenticated({ redirectTo: '/login' })).name('logout')
 
-  // 保護されたルート
+  router.get('/dashboard', [DashboardController, 'index'], requireAuthenticated({ redirectTo: '/login' })).name('dashboard')
+}
+```
+
+短い名前でグループ全体を保護したい場合は、自分でエイリアスを登録してください。`aliasMiddleware()` はエイリアス名を型に持つ Router を返すので、戻り値を必ず受け取ります:
+
+```typescript
+export function registerWebRoutes(baseRouter: Router): void {
+  const router = baseRouter.aliasMiddleware('auth', requireAuthenticated({ redirectTo: '/login' }))
+
   router.middleware('auth').group((auth) => {
     auth.get('/dashboard', [DashboardController, 'index']).name('dashboard')
   })
@@ -128,13 +137,22 @@ export function registerWebRoutes(router: Router): void {
 保護されたコントローラー内では `this.auth` で現在のユーザーにアクセスできます:
 
 ```typescript
-export class DashboardController extends Controller {
-  async index() {
-    const user = await this.auth.userOrFail()
-    return this.inertia(pages.dashboard.Index, { user })
+import { Controller } from '@guren/core'
+import type { UserRecord } from '../../Models/User.js'
+import { pages } from '@/.guren/pages.gen'
+
+export default class DashboardController extends Controller {
+  async index(): Promise<Response> {
+    const currentUser = await this.auth.user<UserRecord | null>()
+    const user = currentUser
+      ? { id: currentUser.id, name: currentUser.name, email: currentUser.email }
+      : null
+    return this.inertia(pages.dashboard.Index, { user }, { title: 'Dashboard' })
   }
 }
 ```
+
+`this.auth.user<T>()` はゲストの場合 `null` を返します。null 分岐ではなく 401 にしたい場合は `this.auth.userOrFail<T>()` を使ってください。
 
 ## 7. フローを検証する
 


### PR DESCRIPTION
## Problem

`docs/en/guides/build-auth-app.md` showed this on a failed login:

```typescript
return this.back().withErrors({ email: 'Invalid credentials.' })
```

Neither `back()` nor `withErrors()` exists on `Controller` (`packages/server/src/mvc/Controller.ts`). The auth scaffold's real pattern (`packages/cli/src/make-auth.ts`, `LoginController.store`) is:

```typescript
throw ValidationException.withMessages({ message: 'Invalid credentials.' })
```

`message` is also the key the generated login page renders (`{errors.message}`); a field name attaches the message to that input instead.

## Other defects found in the same guide

Checking the rest of the guide against `Controller.ts` / `RequestAuthContext.ts` / `Router.ts` turned up three more:

- **`this.inertia(pages.auth.Login)`** — both `inertia` overloads take `props` as a required positional, so the one-argument call is an arity error.
- **The routes snippet** called `.middleware('auth')` on a bare `Router`, and claimed the generator registers that alias. `Router<M extends string = never>` and `RouteMiddlewareInput<M> = M | MiddlewareHandler`, so `'auth'` is not assignable on a default `Router`; at runtime `Router.ts:850` throws `Middleware "auth" is not registered`. The generator registers no alias — it writes `routes/auth.ts` with per-route `requireGuest` / `requireAuthenticated`. The snippet now shows that, and the alias form is kept as a second example with the `aliasMiddleware()` call it requires.
- **`this.auth.userOrFail()`** returns `Promise<unknown>`, so the result cannot satisfy typed page props. Replaced with the generated `DashboardController`'s own `this.auth.user<UserRecord | null>()` shape.

The `LoginController` snippet is now the file `guren add auth` actually generates (`show` / `store` / `destroy`, validator imported from `app/Http/Validators/LoginValidator.ts`), so the surrounding "the generated controller" prose is true. The bullet claiming "Auth routes wired into `routes/web.ts`" now names `routes/auth.ts`, which is what is generated and wired.

`docs/ja/guides/build-auth-app.md` carried the identical snippets and got the same treatment.

## Verification

- `bun run audit:docs` — passes (1074 named imports across 681 first-party import statements). Note this audit validates *imports*, not member calls, so it would not have caught `back()`/`withErrors()` on its own.
- Every `this.*` helper remaining in both guides (`auth`, `inertia`, `redirect`, `request`, `validateBody`) and every `this.auth.*` member used (`session`, `attempt`, `logout`, `user`, `userOrFail`) verified by reading its declaration in `packages/server/src`.
- `grep` across `docs/`, `web/`, `examples/`, and the templates: no remaining `this.back()` or `withErrors(` outside `ValidationException.withMessages`.

Docs-only change; no source touched.