### PR TITLE
feat(core): createSessionManager with the database session driver (RFC 0020 Part 2a)

### DIFF
--- a/.changeset/database-session-driver.md
+++ b/.changeset/database-session-driver.md
@@ -1,0 +1,24 @@
+---
+'@guren/core': minor
+'@guren/server': patch
+---
+
+`createSessionManager()`: the `database` session driver (RFC 0020 Part 2a)
+
+`SessionManager` (RFC 0020 Part 1) ships `memory` and `redis`; the
+database-backed store cannot live in `@guren/server`, which must not depend on
+the ORM. `@guren/core` now closes that:
+
+- `createSessionManager(config)` builds a `SessionManager` with the `database`
+  driver registered, and `declare module '@guren/server'` widens
+  `SessionDrivers` so `{ driver: 'database', table: sessions }` type-checks in
+  an app's config. The driver takes the app's own drizzle `sessions` table plus
+  `DatabaseSessionStore`'s options (`dataMode`), and `pruneExpired()` sweeps it.
+- `registerDatabaseSessionDriver(manager)` adds the driver to a manager built
+  elsewhere.
+- Registration is a factory call, never a module side effect, so a bundler that
+  drops an unused import cannot drop the driver with it.
+
+`@guren/server`: an unknown session driver's error now names the drivers that
+*are* registered, which is what tells a `new SessionManager()` caller that
+`database` comes from `@guren/core`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,6 +377,7 @@ export const handler = createLambdaHandler(app)
 | Path | Purpose |
 |------|---------|
 | `packages/server/src/http/Application.ts` | Main server class |
+| `packages/core/src/session-manager.ts` | `createSessionManager()` and the `database` session driver (RFC 0020 §1). The one place `SessionDrivers` gains `database`: the store wraps a drizzle table in an ORM `Model`, which `@guren/server` cannot do. Registered by a factory call rather than a module side effect, so a bundler dropping an unused import cannot drop the driver; `packages/core/tests/session-manager.test.ts` pins the augmentation surviving into the bundled `.d.ts`, which nothing else would notice losing |
 | `packages/server/src/http/middleware/session-manager.ts` | `SessionManager` and the augmentable `SessionDrivers` registry (RFC 0020 §1): named stores, one default, lazy memoized resolution so a plugin's `registerDriver()` and a Workers binding may both arrive after construction. Bound under the container key `session`; `AuthServiceProvider` builds the session middleware on the first request from `manager.options` + `auth.sessionOptions`, and fails the boot when both name a store. Server ships `memory` and `redis`; `database` is core's to add, since server must not depend on the ORM |
 | `packages/server/src/mvc/Controller.ts` | Base controller (validateBody/Query/Params) |
 | `packages/server/src/mvc/Router.ts` | Instance-based route registry |

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -221,28 +221,36 @@ app.use('*', createSessionMiddleware())
 For more than one candidate store, declare them once and pick by environment. Bind a `SessionManager` under the `session` key from a provider's `register()` and `AuthServiceProvider` builds the session middleware around it at boot, resolving the store itself on the first request:
 
 ```ts
-import { ServiceProvider, SessionManager, type SessionConfig } from '@guren/core'
+import { createSessionManager, ServiceProvider, type SessionConfig } from '@guren/core'
 import { createRedisClient } from '@guren/core/redis'
+import { sessions } from '@/db/schema'
 
 const sessionConfig: SessionConfig = {
-  default: process.env.SESSION_DRIVER ?? 'memory',
+  default: process.env.SESSION_DRIVER ?? 'database',
   ttlSeconds: 60 * 60 * 2,
   stores: {
-    memory: { driver: 'memory' },
+    // Survives restarts, isolates and cold starts, over the connection
+    // `configureOrm()` already established — Postgres, MySQL, SQLite or D1.
+    database: { driver: 'database', table: sessions },
     // `client` may be a function: it runs when this store is first used, so a
     // store that is declared but not selected opens no connection.
     redis: { driver: 'redis', client: () => createRedisClient({ url: process.env.REDIS_URL }) },
+    memory: { driver: 'memory' },
   },
 }
 
 export default class SessionProvider extends ServiceProvider {
   register(): void {
-    this.container.instance('session', new SessionManager(sessionConfig))
+    this.container.instance('session', createSessionManager(sessionConfig))
   }
 }
 ```
 
-Cookie and TTL settings on the manager are the base; `auth.sessionOptions` overrides them field by field. Setting `auth.sessionOptions.store` *and* binding a manager fails the boot rather than picking one silently, as does a `default` store whose driver nobody registered; an unknown `default` name fails at construction. Either way a typo in `SESSION_DRIVER` stops the boot instead of the first login. `memory` is always declared, so `SESSION_DRIVER=memory` works without an entry. Bind the manager in `register()`, not `boot()`: `AuthServiceProvider` boots before your providers do (a deferred provider is the exception; it is activated on the first request). A plugin adds a driver by augmenting the `SessionDrivers` interface and calling `manager.registerDriver(name, factory)`; resolution is lazy, so the plugin's `register()` may run after the config was declared. The `database` driver over your ORM tables and the `guren add session` scaffold that writes this file for you are the next parts of RFC 0020.
+`createSessionManager()` is `new SessionManager()` plus the `database` driver, which only `@guren/core` can supply: the store wraps your table in an ORM model, and the HTTP layer underneath does not depend on the ORM. Use it whenever a `database` store is declared; `registerDatabaseSessionDriver(manager)` adds the driver to a manager you built some other way.
+
+The `database` driver needs a `sessions` table in `db/schema.ts` and a migration. It has three columns — `id` (text primary key), `data`, and `expiresAt` — and the dialect-specific shape is in the [Cloudflare guide](./cloudflare.md#sessions-and-oauth-state-must-be-database-backed). Sweep expired rows on a schedule with `manager.pruneExpired()`; `read()` already treats them as missing.
+
+Cookie and TTL settings on the manager are the base; `auth.sessionOptions` overrides them field by field. Setting `auth.sessionOptions.store` *and* binding a manager fails the boot rather than picking one silently, as does a `default` store whose driver nobody registered; an unknown `default` name fails at construction. Either way a typo in `SESSION_DRIVER` stops the boot instead of the first login. `memory` is always declared, so `SESSION_DRIVER=memory` works without an entry. Bind the manager in `register()`, not `boot()`: `AuthServiceProvider` boots before your providers do (a deferred provider is the exception; it is activated on the first request). A plugin adds a driver by augmenting the `SessionDrivers` interface and calling `manager.registerDriver(name, factory)`; resolution is lazy, so the plugin's `register()` may run after the config was declared.
 
 > [!WARNING]
 > On Cloudflare Workers, AWS Lambda, or Vercel, requests share no memory, so the default `MemorySessionStore` loses a login on the very next request. The middleware warns once per process when it finds itself in that position; `guren check` and the deploy builds warn ahead of time.

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -221,28 +221,36 @@ app.use('*', createSessionMiddleware())
 候補となるストアが複数あるなら、一度宣言して環境ごとに選びます。プロバイダの `register()` で `session` キーに `SessionManager` を bind すると、`AuthServiceProvider` は起動時にそれを組み込んだセッションミドルウェアを構築し、ストア自体は最初のリクエストで解決します:
 
 ```ts
-import { ServiceProvider, SessionManager, type SessionConfig } from '@guren/core'
+import { createSessionManager, ServiceProvider, type SessionConfig } from '@guren/core'
 import { createRedisClient } from '@guren/core/redis'
+import { sessions } from '@/db/schema'
 
 const sessionConfig: SessionConfig = {
-  default: process.env.SESSION_DRIVER ?? 'memory',
+  default: process.env.SESSION_DRIVER ?? 'database',
   ttlSeconds: 60 * 60 * 2,
   stores: {
-    memory: { driver: 'memory' },
+    // 再起動・isolate・コールドスタートをまたいで残ります。接続は
+    // `configureOrm()` が確立済みのもの(Postgres / MySQL / SQLite / D1)を使います。
+    database: { driver: 'database', table: sessions },
     // `client` は関数でも構いません。このストアが最初に使われたときに実行されるので、
     // 宣言しただけで選ばれていないストアは接続を開きません。
     redis: { driver: 'redis', client: () => createRedisClient({ url: process.env.REDIS_URL }) },
+    memory: { driver: 'memory' },
   },
 }
 
 export default class SessionProvider extends ServiceProvider {
   register(): void {
-    this.container.instance('session', new SessionManager(sessionConfig))
+    this.container.instance('session', createSessionManager(sessionConfig))
   }
 }
 ```
 
-マネージャ側の cookie と TTL 設定が基本で、`auth.sessionOptions` がフィールド単位で上書きします。`auth.sessionOptions.store` とマネージャの両方を設定すると、どちらかを黙って選ぶのではなく起動時にエラーになります。`default` ストアのドライバが未登録の場合も同様に起動で失敗し、未宣言の `default` 名は構築時に失敗します。いずれの場合も `SESSION_DRIVER` の typo は最初のログインではなく起動で止まります。`memory` は常に宣言済みなので、`SESSION_DRIVER=memory` はエントリなしで動きます。マネージャは `boot()` ではなく `register()` で bind してください。`AuthServiceProvider` はアプリのプロバイダより先に boot します(deferred provider は例外で、最初のリクエストで起動されます)。プラグインは `SessionDrivers` インターフェースを augmentation で拡張し、`manager.registerDriver(name, factory)` を呼ぶことでドライバを追加できます。解決は遅延なので、プラグインの `register()` が設定の宣言より後に走っても構いません。ORM のテーブルを使う `database` ドライバと、このファイルを生成する `guren add session` は RFC 0020 の次のパートです。
+`createSessionManager()` は `new SessionManager()` に `database` ドライバを登録したものです。このドライバはテーブルを ORM のモデルで包むので、ORM に依存しない HTTP 層ではなく `@guren/core` だけが提供できます。`database` ストアを宣言するなら常にこちらを使ってください。別の方法で組み立てたマネージャには `registerDatabaseSessionDriver(manager)` でドライバを足せます。
+
+`database` ドライバは `db/schema.ts` の `sessions` テーブルとマイグレーションを必要とします。列は `id`(text 主キー)・`data`・`expiresAt` の3つで、方言ごとの定義は [Cloudflare ガイド](./cloudflare.md#sessions-and-oauth-state-must-be-database-backed) にあります。期限切れ行は `manager.pruneExpired()` をスケジュール実行して掃除してください(`read()` は既に期限切れを不在として扱います)。
+
+マネージャ側の cookie と TTL 設定が基本で、`auth.sessionOptions` がフィールド単位で上書きします。`auth.sessionOptions.store` とマネージャの両方を設定すると、どちらかを黙って選ぶのではなく起動時にエラーになります。`default` ストアのドライバが未登録の場合も同様に起動で失敗し、未宣言の `default` 名は構築時に失敗します。いずれの場合も `SESSION_DRIVER` の typo は最初のログインではなく起動で止まります。`memory` は常に宣言済みなので、`SESSION_DRIVER=memory` はエントリなしで動きます。マネージャは `boot()` ではなく `register()` で bind してください。`AuthServiceProvider` はアプリのプロバイダより先に boot します(deferred provider は例外で、最初のリクエストで起動されます)。プラグインは `SessionDrivers` インターフェースを augmentation で拡張し、`manager.registerDriver(name, factory)` を呼ぶことでドライバを追加できます。解決は遅延なので、プラグインの `register()` が設定の宣言より後に走っても構いません。
 
 > [!WARNING]
 > Cloudflare Workers、AWS Lambda、Vercel ではリクエスト間でメモリを共有しないため、デフォルトの `MemorySessionStore` はログイン直後のリクエストでセッションを失います。ミドルウェアはその状況を検出するとプロセスごとに一度警告し、`guren check` とデプロイビルドは事前に警告します。

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -92,6 +92,9 @@ export { DatabaseApiTokenStore } from './api-token-store.js'
 export type { DatabaseApiTokenStoreOptions } from './api-token-store.js'
 export { DatabaseSessionStore } from './session-store.js'
 export type { DatabaseSessionStoreOptions } from './session-store.js'
+// Importing this module is what augments `SessionDrivers` with `database`.
+export { createSessionManager, registerDatabaseSessionDriver } from './session-manager.js'
+export type { DatabaseSessionDriverOptions } from './session-manager.js'
 export { DatabaseOAuthStateStore } from './oauth-state-store.js'
 // Attachments (RFC 0013) — core-native exports; no bare `Attachment` (it
 // would collide with the mail/notification/Slack attachment vocabulary).

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1,0 +1,36 @@
+import { SessionManager, type SessionConfig } from '@guren/server'
+import { DatabaseSessionStore, type DatabaseSessionStoreOptions } from './session-store.js'
+
+/**
+ * The `database` driver's config. `table` is the app's own drizzle `sessions`
+ * table: core cannot name one for it, since a table drizzle-kit does not see
+ * in `db/schema.ts` gets no migration (RFC 0020 §1).
+ */
+export interface DatabaseSessionDriverOptions extends DatabaseSessionStoreOptions {
+  /** The `sessions` table, with `id`, `data` and `expiresAt` columns. */
+  table: unknown
+}
+
+declare module '@guren/server' {
+  interface SessionDrivers {
+    database: DatabaseSessionDriverOptions
+  }
+}
+
+/**
+ * A `SessionManager` that knows the `database` driver, which `@guren/server`
+ * cannot register itself: the store wraps the table in an ORM model, and
+ * server must not depend on `@guren/orm` (RFC 0003, Alternatives). Registered
+ * here rather than by importing this module for its side effect, so a bundler
+ * that drops an unused import cannot drop the driver with it.
+ */
+export function createSessionManager(config: SessionConfig = {}): SessionManager {
+  const manager = new SessionManager(config)
+  registerDatabaseSessionDriver(manager)
+  return manager
+}
+
+/** Adds the `database` driver to a manager built elsewhere (a plugin's, or a subclass). */
+export function registerDatabaseSessionDriver(manager: SessionManager): void {
+  manager.registerDriver('database', ({ table, ...options }) => new DatabaseSessionStore(table, options))
+}

--- a/packages/core/tests/session-manager.test.ts
+++ b/packages/core/tests/session-manager.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { Database } from 'bun:sqlite'
+import { drizzle } from 'drizzle-orm/bun-sqlite'
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { SessionManager } from '@guren/server'
+import { DrizzleAdapter } from '../src/index'
+import { createSessionManager, registerDatabaseSessionDriver } from '../src/session-manager'
+import { DatabaseSessionStore } from '../src/session-store'
+
+const sessions = sqliteTable('sessions', {
+  id: text('id').primaryKey(),
+  data: text('data', { mode: 'json' }).$type<Record<string, unknown>>().notNull(),
+  expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
+})
+
+// The same table with a plain text column, which is what `dataMode: 'text'` is for.
+const sessionsText = sqliteTable('sessions_text', {
+  id: text('id').primaryKey(),
+  data: text('data').notNull(),
+  expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
+})
+
+describe('createSessionManager', () => {
+  let sqlite: Database
+
+  beforeEach(() => {
+    sqlite = new Database(':memory:')
+    for (const table of ['sessions', 'sessions_text']) {
+      sqlite.exec(`CREATE TABLE ${table} (id text primary key, data text not null, expires_at integer not null);`)
+    }
+    DrizzleAdapter.configure(drizzle({ client: sqlite }) as never)
+  })
+
+  afterEach(() => {
+    sqlite.close()
+  })
+
+  test('should resolve a database store that round-trips through the table', async () => {
+    const manager = createSessionManager({
+      default: 'database',
+      stores: { database: { driver: 'database', table: sessions } },
+    })
+
+    const store = manager.store()
+    expect(store).toBeInstanceOf(DatabaseSessionStore)
+
+    await store.write('abc', { user: 1 }, 60)
+    expect(await store.read('abc')).toEqual({ user: 1 })
+    expect(sqlite.query('select count(*) as n from sessions').get()).toEqual({ n: 1 })
+  })
+
+  test('should pass driver options other than `table` to the store', async () => {
+    const manager = createSessionManager({
+      default: 'database',
+      stores: { database: { driver: 'database', table: sessionsText, dataMode: 'text' } },
+    })
+
+    await manager.store().write('abc', { user: 1 }, 60)
+
+    // `dataMode: 'text'` serializes for a column drizzle does not encode.
+    expect(sqlite.query('select data from sessions_text').get()).toEqual({ data: '{"user":1}' })
+    expect(await manager.store().read('abc')).toEqual({ user: 1 })
+  })
+
+  test('should keep the built-in drivers alongside database', () => {
+    const manager = createSessionManager({ stores: { redis: { driver: 'redis', client: {} } } })
+
+    expect(manager.getStoreNames()).toEqual(['memory', 'redis'])
+    expect(manager.store('memory')).toBeDefined()
+  })
+
+  test('should sweep expired rows through pruneExpired', async () => {
+    const manager = createSessionManager({
+      default: 'database',
+      stores: { database: { driver: 'database', table: sessions } },
+    })
+    await manager.store().write('live', {}, 60)
+    sqlite.exec("INSERT INTO sessions (id, data, expires_at) VALUES ('dead', '{}', 1)")
+
+    await manager.pruneExpired()
+
+    expect(sqlite.query('select id from sessions').all()).toEqual([{ id: 'live' }])
+  })
+
+  test('should let a manager built elsewhere opt into the driver', () => {
+    const manager = new SessionManager({
+      default: 'database',
+      stores: { database: { driver: 'database', table: sessions } },
+    })
+
+    expect(() => manager.store()).toThrow('Unknown session driver: database')
+    registerDatabaseSessionDriver(manager)
+    expect(manager.store()).toBeInstanceOf(DatabaseSessionStore)
+  })
+})
+
+describe('the built declaration', () => {
+  // The `database` driver type-checks in an app only if this augmentation
+  // survives into core's bundled .d.ts; nothing else would notice its loss,
+  // since core's own sources see the source file.
+  test('should carry the SessionDrivers augmentation', () => {
+    const declaration = join(import.meta.dir, '../dist/index.d.ts')
+    if (!existsSync(declaration)) {
+      throw new Error(`Expected ${declaration}; run \`bun run build core\` before this test.`)
+    }
+
+    const source = readFileSync(declaration, 'utf8')
+    expect(source).toContain("declare module '@guren/server'")
+    expect(source).toMatch(/interface SessionDrivers\s*\{\s*database:/)
+  })
+})

--- a/packages/core/tests/session-manager.types.ts
+++ b/packages/core/tests/session-manager.types.ts
@@ -1,0 +1,29 @@
+/**
+ * Type-level tests for the `database` driver's `SessionDrivers` augmentation
+ * (RFC 0020 §1). Compiled by the root `tsc --noEmit`; never executed.
+ */
+import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core'
+import type { SessionConfig } from '@guren/server'
+import { createSessionManager } from '../src/session-manager'
+
+const sessions = sqliteTable('sessions', {
+  id: text('id').primaryKey(),
+  data: text('data', { mode: 'json' }).$type<Record<string, unknown>>().notNull(),
+  expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
+})
+
+export const config: SessionConfig = {
+  default: 'database',
+  stores: {
+    database: { driver: 'database', table: sessions, dataMode: 'text' },
+    memory: { driver: 'memory' },
+  },
+}
+
+export const manager = createSessionManager(config)
+
+// @ts-expect-error `table` is required by the database driver.
+export const missingTable: SessionConfig = { stores: { database: { driver: 'database' } } }
+
+// @ts-expect-error An undeclared driver name is not assignable.
+export const unknownDriver: SessionConfig = { stores: { x: { driver: 'dynamodb', table: 'sessions' } } }

--- a/packages/server/src/http/middleware/session-manager.ts
+++ b/packages/server/src/http/middleware/session-manager.ts
@@ -157,7 +157,8 @@ export class SessionManager {
     const factory = this.driverFactories.get(driver)
     if (!factory) {
       throw new Error(
-        `Unknown session driver: ${driver} (session store "${storeName}"). Register it with registerDriver(), or install the plugin that provides it.`,
+        `Unknown session driver: ${driver} (session store "${storeName}"). Registered: ${[...this.driverFactories.keys()].join(', ')}. `
+        + 'Register it with registerDriver(), or build the manager with the factory that provides it.',
       )
     }
     return { factory, options }


### PR DESCRIPTION
## Summary

RFC 0020 Part 2a: the `database` session driver, in `@guren/core`.

Part 1 shipped `SessionManager` with `memory` and `redis`. The database-backed store cannot live beside them — it wraps a drizzle table in an ORM model, and the HTTP layer must not depend on the ORM (RFC 0003, Alternatives). Core is the established home for that glue (`DatabaseApiTokenStore`, `DatabaseSessionStore`).

- **`createSessionManager(config)`** builds a `SessionManager` with the `database` driver registered, and `declare module '@guren/server'` widens `SessionDrivers`, so `{ driver: 'database', table: sessions }` type-checks in an app's `SessionConfig`. The driver takes the app's own `sessions` table plus `DatabaseSessionStore`'s options (`dataMode`); `pruneExpired()` sweeps it.
- **`registerDatabaseSessionDriver(manager)`** adds the driver to a manager built elsewhere (a plugin's, a subclass).
- Registration is a **factory call, never a module side effect** — a bundler that drops an unused import cannot drop the driver with it, and the deploy plugins' stub sets do not expect one (RFC 0003/0009 avoided the same shape).
- `@guren/server`: an unknown driver's error now names the drivers that *are* registered, which is what tells a `new SessionManager()` caller that `database` comes from core.

The scaffold that writes this config, the `sessions` table, and its migration is Part 2b.

## Verification

- A test pins the augmentation surviving into core's bundled `.d.ts`: nothing else would notice its loss, since core's own sources see the source file.
- `packages/core/tests/session-manager.types.ts` asserts at compile time that `table` is required and an undeclared driver name is rejected.
- Runtime tests round-trip a session through sqlite, check `dataMode: 'text'` reaches the store, and check `pruneExpired()`.
- `bun run typecheck`, `lint`, `audit:docs`, `audit:core-first`, `audit:core-semver` green; `test:bun server core`: 3263 pass, 0 fail.

Refs: RFC 0020
