### PR TITLE
fix(cli): survive blanked env values in the scaffolded configs

### DIFF
--- a/.changeset/blank-env-values.md
+++ b/.changeset/blank-env-values.md
@@ -1,0 +1,7 @@
+---
+"@guren/cli": patch
+---
+
+**Scaffolded configs survive a blanked environment variable** — the generated configs selected a store, disk, transport, host or port with `process.env.FOO ?? 'default'`, which passes an empty string straight through. Blanking a key rather than deleting the line, or a hosting dashboard supplying a cleared variable, therefore named something that does not exist: `config/session.ts` failed the boot with `Session store not found:  (declared: memory)`, `CacheProvider` threw `Cache store not found:` on first use, `config/mail.ts` picked a transport called `''`, `StorageProvider` a disk called `''`, and `Number(process.env.SMTP_PORT ?? 587)` produced port **0** rather than 587. Each now uses `||`, which is what the fallback was written to mean.
+
+`MAIL_FROM_NAME` and the credential variables keep `??`, where an empty value is a real choice rather than a missing one. `appendEnvEntry()` additionally refuses an entry that does not assign the key it is probed by, which would otherwise be re-appended on every run.

--- a/docs/en/guides/authentication.md
+++ b/docs/en/guides/authentication.md
@@ -228,7 +228,7 @@ import { createRedisClient } from '@guren/core/redis'
 import { sessions } from '@/db/schema'
 
 const sessionConfig: SessionConfig = {
-  default: process.env.SESSION_DRIVER ?? 'database',
+  default: process.env.SESSION_DRIVER || 'database',
   ttlSeconds: 60 * 60 * 2,
   stores: {
     // Survives restarts, isolates and cold starts, over the connection

--- a/docs/en/guides/storage.md
+++ b/docs/en/guides/storage.md
@@ -324,7 +324,7 @@ Declare every disk once and pick one with an environment variable, the way `bunx
 
 ```ts
 const storage = createStorageManager({
-  default: process.env.STORAGE_DISK ?? 'local',
+  default: process.env.STORAGE_DISK || 'local',
   disks: {
     // Not served by anything. Uploads belong here — see the note below.
     local: { driver: 'local', root: './storage/app' },

--- a/docs/ja/guides/authentication.md
+++ b/docs/ja/guides/authentication.md
@@ -228,7 +228,7 @@ import { createRedisClient } from '@guren/core/redis'
 import { sessions } from '@/db/schema'
 
 const sessionConfig: SessionConfig = {
-  default: process.env.SESSION_DRIVER ?? 'database',
+  default: process.env.SESSION_DRIVER || 'database',
   ttlSeconds: 60 * 60 * 2,
   stores: {
     // 再起動・isolate・コールドスタートをまたいで残ります。接続は

--- a/docs/ja/guides/storage.md
+++ b/docs/ja/guides/storage.md
@@ -324,7 +324,7 @@ const url = await disk.temporaryUrl('private/document.pdf', expiration)
 
 ```ts
 const storage = createStorageManager({
-  default: process.env.STORAGE_DISK ?? 'local',
+  default: process.env.STORAGE_DISK || 'local',
   disks: {
     // 何からも配信されません。アップロードはこちらへ（下の注記を参照）。
     local: { driver: 'local', root: './storage/app' },

--- a/examples/blog/app/Providers/CacheProvider.ts
+++ b/examples/blog/app/Providers/CacheProvider.ts
@@ -12,7 +12,7 @@ function createBlogCacheManager(): CacheManager {
     // CACHE_STORE=memory is per-process: correct on one long-lived server,
     // wrong on Workers, Lambda and Vercel, where two requests can land in
     // different instances. `redis` needs REDIS_URL.
-    default: process.env.CACHE_STORE ?? 'memory',
+    default: process.env.CACHE_STORE || 'memory',
     stores: {
       memory: { driver: 'memory' },
       // `client` is a function so the client is constructed only when

--- a/examples/blog/app/Providers/EventServiceProvider.ts
+++ b/examples/blog/app/Providers/EventServiceProvider.ts
@@ -37,9 +37,9 @@ export function initializeEventSystem(): EventManager {
   mailManager = mailManager ?? createMailManager({
     // Defaults to `log`, not `memory`: development needs the verification and
     // password-reset links printed, and `memory` discards them silently.
-    default: process.env.MAIL_MAILER ?? 'log',
+    default: process.env.MAIL_MAILER || 'log',
     from: {
-      email: process.env.MAIL_FROM_ADDRESS ?? 'noreply@blog.example.com',
+      email: process.env.MAIL_FROM_ADDRESS || 'noreply@blog.example.com',
       name: process.env.MAIL_FROM_NAME ?? 'Guren Blog',
     },
     transports: {

--- a/packages/cli/src/env-registrar.ts
+++ b/packages/cli/src/env-registrar.ts
@@ -13,6 +13,12 @@ const ENV_FILES = ['.env.example', '.env'] as const
  * file is left uncreated, since the app reads neither by a blueprint's doing.
  */
 export async function appendEnvEntry(key: string, entry: string): Promise<void> {
+  // An entry not assigning `key` never satisfies the probe, so every run would
+  // append it again; `key` reaches a regex, so callers pass a literal name.
+  if (!new RegExp(`^\\s*${key}=`, 'm').test(entry)) {
+    throw new Error(`The env entry for ${key} does not assign ${key}=.`)
+  }
+
   const declared = new RegExp(`^\\s*#?\\s*${key}=`, 'm')
 
   for (const file of ENV_FILES) {

--- a/packages/cli/templates/scaffold/auth/config/mail.ts
+++ b/packages/cli/templates/scaffold/auth/config/mail.ts
@@ -4,18 +4,21 @@ import type { MailConfig } from '@guren/core'
 // console instead of sending them — nothing to configure for local
 // development. Set MAIL_DRIVER=smtp (and the SMTP_* variables below)
 // once you're ready to send real email.
+// `||`, not `??`: a blanked `FOO=` is '', which none of these accept.
 export const mailConfig: MailConfig = {
-  default: process.env.MAIL_DRIVER ?? 'log',
+  default: process.env.MAIL_DRIVER || 'log',
   from: {
-    email: process.env.MAIL_FROM_ADDRESS ?? 'noreply@example.com',
+    email: process.env.MAIL_FROM_ADDRESS || 'noreply@example.com',
+    // `??` here: an empty display name is a choice, not a missing value.
     name: process.env.MAIL_FROM_NAME ?? 'Guren',
   },
   transports: {
     log: { driver: 'log' },
     smtp: {
       driver: 'smtp',
-      host: process.env.SMTP_HOST ?? 'localhost',
-      port: Number(process.env.SMTP_PORT ?? 587),
+      host: process.env.SMTP_HOST || 'localhost',
+      // `Number('')` is 0, so a blank port would silently win over 587.
+      port: Number(process.env.SMTP_PORT || 587),
       auth: {
         user: process.env.SMTP_USER ?? '',
         pass: process.env.SMTP_PASS ?? '',

--- a/packages/cli/templates/scaffold/cache/app/Providers/CacheProvider.ts
+++ b/packages/cli/templates/scaffold/cache/app/Providers/CacheProvider.ts
@@ -12,7 +12,8 @@ import { ServiceProvider, createCacheManager } from '@guren/core'
 export default class CacheProvider extends ServiceProvider {
   register(): void {
     this.container.singleton('cache', () => createCacheManager({
-      default: process.env.CACHE_STORE ?? 'memory',
+      // `||`, not `??`: a blanked `CACHE_STORE=` is '', which names no store.
+      default: process.env.CACHE_STORE || 'memory',
       stores: {
         memory: { driver: 'memory' },
       },

--- a/packages/cli/templates/scaffold/session/config/session.ts
+++ b/packages/cli/templates/scaffold/session/config/session.ts
@@ -13,7 +13,8 @@ import { sessions } from '../db/schema'
 // `redis: { driver: 'redis', client: () => createRedisClient({ url: process.env.REDIS_URL }) }`
 // entry — imported here only when you use it, since that module pulls in ioredis.
 export const sessionConfig: SessionConfig = {
-  default: process.env.SESSION_DRIVER ?? 'database',
+  // `||`, not `??`: a blanked `SESSION_DRIVER=` is '', which names no store.
+  default: process.env.SESSION_DRIVER || 'database',
   ttlSeconds: 60 * 60 * 2,
   stores: {
     // Over the connection configureOrm() already established. The `sessions`

--- a/packages/cli/templates/scaffold/storage/app/Providers/StorageProvider.ts
+++ b/packages/cli/templates/scaffold/storage/app/Providers/StorageProvider.ts
@@ -25,7 +25,8 @@ const disks = {
   public: { driver: 'local', root: './public/storage', url: '/storage', visibility: 'public' },
 } as const
 
-const selected = process.env.STORAGE_DISK ?? 'local'
+// `||`, not `??`: a blanked `STORAGE_DISK=` is '', which names no disk.
+const selected = process.env.STORAGE_DISK || 'local'
 
 export default class StorageProvider extends ServiceProvider {
   register(): void {

--- a/packages/cli/tests/add-cache.test.ts
+++ b/packages/cli/tests/add-cache.test.ts
@@ -31,7 +31,9 @@ describe('guren add cache', () => {
     await runBlueprint('cache', {})
 
     const provider = await readFile(resolve('app/Providers/CacheProvider.ts'), 'utf8')
-    expect(provider).toContain("default: process.env.CACHE_STORE ?? 'memory'")
+    // `||`, not `??`: a blanked `CACHE_STORE=` is '', which names no store.
+    expect(provider).toContain("default: process.env.CACHE_STORE || 'memory'")
+    expect(provider).not.toContain('process.env.CACHE_STORE ??')
     expect(provider).toContain("memory: { driver: 'memory' }")
     // The redis store is documented in a comment rather than declared:
     // importing createRedisClient pulls ioredis into every bundle, on a runtime

--- a/packages/cli/tests/add-session.test.ts
+++ b/packages/cli/tests/add-session.test.ts
@@ -60,7 +60,9 @@ describe('guren add session', () => {
     // Only as a comment: a real import puts ioredis in every bundle, including
     // one whose SESSION_DRIVER is `database`.
     expect(config).not.toMatch(/^import .*@guren\/core\/redis/m)
-    expect(config).toContain("default: process.env.SESSION_DRIVER ?? 'database'")
+    // `||`, not `??`: a blanked `SESSION_DRIVER=` is '', which names no store.
+    expect(config).toContain("default: process.env.SESSION_DRIVER || 'database'")
+    expect(config).not.toContain('process.env.SESSION_DRIVER ??')
     expect(config).toContain("database: { driver: 'database', table: sessions }")
 
     const provider = await readFile(resolve('app/Providers/SessionProvider.ts'), 'utf8')

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -566,6 +566,12 @@ export const users = pgTable('users', {
     expect(scheduleFiles.some((file) => file.endsWith('app/Console/Kernel.ts'))).toBe(true)
     expect(notificationFiles.some((file) => file.endsWith('app/Providers/NotificationProvider.ts'))).toBe(true)
     expect(storageFiles.some((file) => file.endsWith('app/Providers/StorageProvider.ts'))).toBe(true)
+
+    // `||`, not `??`: a blanked `STORAGE_DISK=` is '', which names no disk and
+    // trips the provider's own guard at boot instead of falling back to local.
+    const storageProviderSource = await readFile('app/Providers/StorageProvider.ts', 'utf8')
+    expect(storageProviderSource).toContain("process.env.STORAGE_DISK || 'local'")
+    expect(storageProviderSource).not.toContain('process.env.STORAGE_DISK ??')
     expect(broadcastingFiles.some((file) => file.endsWith('app/Providers/BroadcastProvider.ts'))).toBe(true)
 
     // Registered with the channel's own check, not an allow-all: otherwise

--- a/packages/cli/tests/env-registrar.test.ts
+++ b/packages/cli/tests/env-registrar.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { createTempWorkspace, type TempWorkspace } from './helpers'
+import { appendEnvEntry } from '../src/env-registrar'
+
+const ENTRY = `
+# Which store CacheProvider uses.
+CACHE_STORE=memory
+`
+
+describe('appendEnvEntry', () => {
+  let workspace: TempWorkspace
+
+  beforeEach(async () => {
+    workspace = await createTempWorkspace('guren-cli-env-registrar-')
+  })
+
+  afterEach(async () => {
+    await workspace.cleanup()
+  })
+
+  it('appends to both env files, separated from what is already there', async () => {
+    await writeFile('.env.example', 'APP_KEY=\n')
+    await writeFile('.env', 'APP_KEY=generated')
+
+    await appendEnvEntry('CACHE_STORE', ENTRY)
+
+    for (const file of ['.env.example', '.env']) {
+      const content = await readFile(resolve(file), 'utf8')
+      expect(content).toContain('APP_KEY=')
+      expect(content).toContain('\n\n# Which store CacheProvider uses.\nCACHE_STORE=memory\n')
+    }
+  })
+
+  it('creates neither file', async () => {
+    await appendEnvEntry('CACHE_STORE', ENTRY)
+
+    expect(existsSync(resolve('.env.example'))).toBe(false)
+    expect(existsSync(resolve('.env'))).toBe(false)
+  })
+
+  it('treats a commented mention as a choice already made', async () => {
+    await writeFile('.env.example', 'APP_KEY=\n# CACHE_STORE=redis\n')
+
+    await appendEnvEntry('CACHE_STORE', ENTRY)
+
+    const content = await readFile(resolve('.env.example'), 'utf8')
+    expect(content.match(/CACHE_STORE/g)).toHaveLength(1)
+  })
+
+  it('is idempotent over the entry it wrote itself', async () => {
+    await writeFile('.env.example', 'APP_KEY=\n')
+
+    await appendEnvEntry('CACHE_STORE', ENTRY)
+    const once = await readFile(resolve('.env.example'), 'utf8')
+    await appendEnvEntry('CACHE_STORE', ENTRY)
+
+    expect(await readFile(resolve('.env.example'), 'utf8')).toBe(once)
+  })
+
+  it('refuses an entry that does not assign the key it is probed by', async () => {
+    await writeFile('.env.example', 'APP_KEY=\n')
+
+    // Without the guard the probe never matches what was written, so every
+    // re-run appends the entry again.
+    await expect(appendEnvEntry('CACHE_STORE', '\n# CACHE_STORE is a thing\n'))
+      .rejects.toThrow('does not assign CACHE_STORE=')
+  })
+})

--- a/packages/cli/tests/helpers.ts
+++ b/packages/cli/tests/helpers.ts
@@ -714,7 +714,7 @@ export default class SessionProvider extends ServiceProvider {
 `
 
 /** A `config/session.ts` in the shape `guren add session` writes. */
-export function sessionConfigSource(stores: string, selected = "process.env.SESSION_DRIVER ?? 'database'"): string {
+export function sessionConfigSource(stores: string, selected = "process.env.SESSION_DRIVER || 'database'"): string {
   return `import { type SessionConfig } from '@guren/core'
 import { sessions } from '../db/schema'
 

--- a/packages/cli/tests/make-auth.test.ts
+++ b/packages/cli/tests/make-auth.test.ts
@@ -199,7 +199,9 @@ export function registerWebRoutes(router: Router): void {
       expect(resetController).toContain('User.update(')
 
       const mailConfig = await readFile(join(workspace.dir, 'config/mail.ts'), 'utf8')
-      expect(mailConfig).toContain("process.env.MAIL_DRIVER ?? 'log'")
+      // `||`, not `??`: a blank value names no transport, and `Number('')` is 0.
+      expect(mailConfig).toContain("process.env.MAIL_DRIVER || 'log'")
+      expect(mailConfig).toContain('Number(process.env.SMTP_PORT || 587)')
 
       const mailProvider = await readFile(join(workspace.dir, 'app/Providers/MailProvider.ts'), 'utf8')
       expect(mailProvider).toContain("this.container.singleton('mail'")


### PR DESCRIPTION
## The defect

Every generated config selected a store, disk, transport, host or port with
`process.env.FOO ?? 'default'`. `??` only falls back on `undefined`, so a
**blanked** key passes an empty string straight through and names something that
does not exist. Blanking rather than deleting is idiomatic here — the same
`.env.example` ships `REDIS_URL=` blank — and it is also what a hosting
dashboard produces for a cleared variable.

Measured on the shipped templates, with `FOO=` blank:

| Site | Before | After |
|---|---|---|
| `session/config/session.ts` `SESSION_DRIVER` | `Session store not found:  (declared: memory)` — **at boot** | `database` |
| `cache/…/CacheProvider.ts` `CACHE_STORE` | `Cache store not found:` on first use | `memory` |
| `auth/config/mail.ts` `SMTP_PORT` | **port `0`** — `Number('')` | `587` |
| `auth/config/mail.ts` `MAIL_DRIVER` | transport `''` | `log` |
| `auth/config/mail.ts` `SMTP_HOST` / `MAIL_FROM_ADDRESS` | `''` | the default |
| `storage/…/StorageProvider.ts` `STORAGE_DISK` | disk `''`, caught by its own boot guard | `local` |

`examples/blog`'s `CacheProvider` and `EventServiceProvider` carried the same
shape and move with them.

`SMTP_PORT` is the one that fails quietly: the others name a thing that is
missing and say so, while port `0` is a number the config accepts.

## What is not changed

`MAIL_FROM_NAME` keeps `??` — an empty display name is a choice, not a missing
value. So do `SMTP_USER`, `SMTP_PASS` and `RESEND_API_KEY`, whose fallback is
already `''`, making the two operators identical.

`DATABASE_URL` in `create-app`'s database templates has the same shape. It is
left alone here: that is a separate template tree with its own gates, and its
`.env.example` always ships a value.

## Also

`appendEnvEntry()` (`env-registrar.ts`) gains the invariant it lacked: an entry
that does not assign the key it is probed by would never satisfy the presence
check, so it would be re-appended on every run. That now throws.

## Verification

- `build`, `lint`, `typecheck`, and `audit:docs` / `audit:core-first` /
  `audit:starter-template` / `audit:template-deps` — all exit 0.
- `@guren/cli`: **2325 pass / 0 fail**. `test:examples`: 214 + 25 pass / 0 fail.
- Every fix is pinned by an assertion that fails when the operator is reverted;
  `env-registrar.test.ts` is new (5 tests) since that module had no test file.
- The `docs/{en,ja}` session and storage guides show the configs the scaffold
  generates, so they move with the templates. The mail guide already wrote
  `Number(process.env.SMTP_PORT) || 587` — the scaffold was the outlier.

## History

This PR originally also made `CACHE_STORE` real (the provider reading it, the
blueprint writing the env entry, the dead line removed from the templates) and
deduplicated the blueprint env patcher. All of that landed independently on
main as #715, #716 and #717 while this was open — #717 is the framework-level
`client` thunk this PR had filed as a follow-up, which is the better fix and
removes the need for the imperative `registerStore` workaround it used. The
branch was rebuilt on that work; what survives is the operator family above,
which none of those PRs touched.