### PR TITLE
fix(examples): make the blog cache provider read CACHE_STORE

### DIFF
--- a/examples/blog/app/Providers/CacheProvider.ts
+++ b/examples/blog/app/Providers/CacheProvider.ts
@@ -1,14 +1,33 @@
-import { ServiceProvider, createCacheManager, type CacheManager } from '@guren/core'
+import {
+  ServiceProvider,
+  createCacheManager,
+  createRedisClient,
+  RedisCacheStore,
+  type CacheManager,
+} from '@guren/core'
 
 let cacheManager: CacheManager | null = null
 
 function createBlogCacheManager(): CacheManager {
-  return createCacheManager({
-    default: 'memory',
+  const cache = createCacheManager({
+    // CACHE_STORE=memory is per-process: correct on one long-lived server,
+    // wrong on Workers, Lambda and Vercel, where two requests can land in
+    // different instances. `redis` needs REDIS_URL.
+    default: process.env.CACHE_STORE ?? 'memory',
     stores: {
       memory: { driver: 'memory' },
     },
   })
+
+  // Registered as a factory rather than a `stores` entry: an entry's options
+  // are evaluated with the config object, and ioredis dials on construction,
+  // so a declared-but-unselected redis store would open a connection on every
+  // boot. This runs only once CACHE_STORE selects it.
+  cache.registerStore('redis', () => new RedisCacheStore({
+    client: createRedisClient({ url: process.env.REDIS_URL }),
+  }))
+
+  return cache
 }
 
 export function getCacheManager(): CacheManager {

--- a/examples/blog/tests/providers/CacheProvider.test.ts
+++ b/examples/blog/tests/providers/CacheProvider.test.ts
@@ -1,44 +1,68 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Container } from '@guren/core'
 
-const { cacheManager, createCacheManager } = vi.hoisted(() => ({
-  cacheManager: { store: vi.fn() },
-  createCacheManager: vi.fn(() => ({ store: vi.fn() })),
+const { createRedisClient } = vi.hoisted(() => ({
+  createRedisClient: vi.fn(() => ({}) as never),
 }))
 
 vi.mock('@guren/core', async () => {
   const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
   return {
     ...actual,
-    createCacheManager,
+    createRedisClient,
   }
 })
 
-import CacheProvider from '../../app/Providers/CacheProvider.js'
+// The provider memoizes its manager at module scope, so every case takes a
+// fresh module instance rather than the one a previous case already built.
+async function loadProvider() {
+  vi.resetModules()
+  return await import('../../app/Providers/CacheProvider.js')
+}
 
 describe('Blog CacheProvider', () => {
+  const originalCacheStore = process.env.CACHE_STORE
+
   beforeEach(() => {
     vi.clearAllMocks()
-    createCacheManager.mockReturnValue(cacheManager)
+    delete process.env.CACHE_STORE
   })
 
-  it('registers a singleton cache manager in the container', () => {
+  afterEach(() => {
+    if (originalCacheStore === undefined) {
+      delete process.env.CACHE_STORE
+    } else {
+      process.env.CACHE_STORE = originalCacheStore
+    }
+  })
+
+  it('registers a singleton cache manager in the container', async () => {
+    const { default: CacheProvider, getCacheManager } = await loadProvider()
     const container = new Container()
-    const provider = new CacheProvider(container)
 
-    provider.register()
+    new CacheProvider(container).register()
 
-    const first = container.make('cache')
-    const second = container.make('cache')
+    expect(container.make('cache')).toBe(container.make('cache'))
+    expect(getCacheManager()).toBe(getCacheManager())
+    expect(container.make('cache')).toBe(getCacheManager())
+  })
 
-    expect(first).toBe(second)
-    expect(first).toBe(cacheManager)
-    expect(createCacheManager).toHaveBeenCalledWith({
-      default: 'memory',
-      stores: {
-        memory: { driver: 'memory' },
-      },
-    })
-    expect(createCacheManager).toHaveBeenCalledTimes(1)
+  it('defaults to the memory store and leaves redis undialed', async () => {
+    const { getCacheManager } = await loadProvider()
+    const cache = getCacheManager()
+
+    expect(cache.getDefaultStoreName()).toBe('memory')
+    expect(cache.hasStore('redis')).toBe(true)
+    // The point of registering redis as a factory rather than a `stores` entry:
+    // the client is only built once something selects the store.
+    expect(createRedisClient).not.toHaveBeenCalled()
+  })
+
+  it('selects the store named by CACHE_STORE', async () => {
+    process.env.CACHE_STORE = 'redis'
+
+    const { getCacheManager } = await loadProvider()
+
+    expect(getCacheManager().getDefaultStoreName()).toBe('redis')
   })
 })


### PR DESCRIPTION
## Summary

`examples/blog` carried the same dead-`CACHE_STORE` defect that #714 fixes for the `guren add cache` scaffold. Its `CacheProvider` hardcoded `default: 'memory'` and registered only a memory store, so the `CACHE_STORE=memory` / `# CACHE_STORE=redis` pair in `examples/blog/.env.example` was read by nothing — setting `CACHE_STORE=redis` changed no behavior.

The provider now selects with `process.env.CACHE_STORE ?? 'memory'` and gains a redis store, matching the scaffold template. The memoized `getCacheManager()` shape the blog already had is unchanged.

The redis store is registered as a **factory** rather than a `stores` entry. An entry's options are evaluated with the config object literal, and ioredis dials on construction, so a declared-but-unselected redis store would open a connection to `REDIS_URL` (or, unset, to localhost) on every boot. `registerStore` defers that until something selects the store.

`.env.example` needed no edit: those lines already existed and simply become live. The dead `SESSION_DRIVER` pair beside them belongs to RFC 0020 (#713) and is deliberately untouched here.

## Scope

- `examples` — `examples/blog/app/Providers/CacheProvider.ts`, `examples/blog/tests/providers/CacheProvider.test.ts`

No published package changes, so no changeset.

## Risk Assessment

Low. Defaults are unchanged for anyone who does not set `CACHE_STORE`: it still resolves to the memory store, and no redis client is constructed.

Ordering was checked rather than assumed. `CacheManager`'s constructor stores `defaultStoreName` as a plain string and resolves the store lazily on the first `store()` call (`packages/server/src/cache/CacheManager.ts:94,140`), so passing `default: 'redis'` before `registerStore('redis', …)` runs is safe.

## Validation

Verified in this branch with captured exit codes:

| Gate | Exit |
|------|------|
| `bun run lint` | 0 |
| `bun run typecheck` | 0 |
| `bun run test:examples` | 0 (24 files, 214 passed; plus 25 bun tests) |
| `bun run audit:core-first` | 0 |
| `bun run audit:agent-catalog` | 0 |

Both gates were checked for the ability to fail, not just for green:

- **lint** — injecting a 7-line comment block and an unused variable produced `error guren(comment-length)` and `warning eslint(no-unused-vars)`, exit 1. A silent oxlint run here really is a clean one.
- **tests** — two mutations of the provider, each caught by a different case:
  - re-hardcoding `default: 'memory'` → `selects the store named by CACHE_STORE` fails
  - moving redis into `stores` (eager client construction) → `defaults to the memory store and leaves redis undialed` fails

## Note for reviewers

The bulk of the test diff is not incidental. The old test mocked `createCacheManager` and asserted on the config object it received, which hid exactly the defect being fixed — a stub can only show which `default` string was passed, never which store resolves, and its return value had no `registerStore` to call. The test now drives the real manager and mocks `createRedisClient` alone, so the assertions are `getDefaultStoreName()`, `hasStore('redis')`, and the absence of a redis client while the store is unselected. Each case takes a fresh module via `vi.resetModules()`, since the provider memoizes at module scope.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation. (n/a — no doc references this provider; the scaffold-side docs change ships in #714.)
