### PR TITLE
fix(cli): declare color-scheme in the Guren UI token sheet

### DIFF
--- a/.changeset/guren-ui-color-scheme.md
+++ b/.changeset/guren-ui-color-scheme.md
@@ -1,0 +1,6 @@
+---
+"create-guren-app": patch
+"@guren/cli": patch
+---
+
+**The Guren UI token sheet declares `color-scheme`** — `resources/css/guren.css` defined a full dark palette behind `@media (prefers-color-scheme: dark)` but never told the user agent about it, so under a dark system preference the scrollbars, native form controls and Chrome's autofill highlight kept rendering light against the dark `--g-page` ground. `:root` now carries `color-scheme: light dark`, which follows the same preference the palette does. Scaffolded apps pick it up from the template; an existing app copies the one declaration into its own `resources/css/guren.css` by hand, since `make:auth` and `make:feature` never overwrite a sheet that is already there.

--- a/packages/cli/templates/scaffold/guren-ui/resources/css/guren.css
+++ b/packages/cli/templates/scaffold/guren-ui/resources/css/guren.css
@@ -9,6 +9,10 @@
    fill moves to them only inside a confirm step. */
 
 :root {
+  /* The dark block below follows the system preference, so the UA chrome
+     (scrollbars, native controls, Chrome's autofill wash) must too. */
+  color-scheme: light dark;
+
   --g-font-sans: system-ui, 'Noto Sans JP', 'Hiragino Sans', sans-serif;
   --g-font-mono: ui-monospace, 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace;
 

--- a/packages/create-app/templates/default/resources/css/guren.css
+++ b/packages/create-app/templates/default/resources/css/guren.css
@@ -9,6 +9,10 @@
    fill moves to them only inside a confirm step. */
 
 :root {
+  /* The dark block below follows the system preference, so the UA chrome
+     (scrollbars, native controls, Chrome's autofill wash) must too. */
+  color-scheme: light dark;
+
   --g-font-sans: system-ui, 'Noto Sans JP', 'Hiragino Sans', sans-serif;
   --g-font-mono: ui-monospace, 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace;
 


### PR DESCRIPTION
## What

`resources/css/guren.css` defines a full dark palette behind `@media (prefers-color-scheme: dark)` but never declared the CSS `color-scheme` property. Under a dark system preference the user-agent-rendered chrome therefore stayed light: scrollbars, native form controls, and Chrome's autofill highlight, all against the dark `--g-page` ground. This affects every app scaffolded by `create-guren-app`, not one example.

`:root` now carries `color-scheme: light dark` — that value rather than a `dark` inside the media block, so the UA follows the same preference the palette does.

Both copies of the sheet move together: `packages/cli/tests/guren-css-sync.test.ts` asserts they are byte-identical.

## Upstream

Landed first in `gurenjs/guren-ui` (`build.ts`, the generator the sheet comes from). That sheet toggles dark on a `.dark` class instead of the media query, so the declaration splits across its two blocks there — `color-scheme: light` on `:root`, `color-scheme: dark` on `:root.dark, .dark`. `light dark` would be wrong for that shape: the chrome would follow the OS while the palette follows the class. Because `color-scheme` inherits, the split also covers a `.dark` class on a subtree, which is how the preview pages render both themes side by side.

## Verification

Served the patched sheet over HTTP with a text input, a checkbox and a select, and emulated a dark `prefers-color-scheme`:

- with the declaration: computed `color-scheme: light dark`, `--g-page: #1a1a2e`, native checkbox renders dark
- with the declaration stripped from the same served file: computed `color-scheme: normal`, same dark ground, native checkbox renders white

Green: `bun run lint`, `bun run typecheck`, `bun test packages/cli/tests/guren-css-sync.test.ts`, `bun run audit:starter-template`. The `smoke:starter*` runs were not needed — no API surface moved.

## Follow-up

`examples/agents/resources/css/guren.css`, added by #718, is a third copy that no test covers. It needs the same one-line edit before or after that PR lands, or the agents demo keeps the bug.