### PR TITLE
ci: move the Bun trial lane to 1.4.2 and drop the --parallel trial

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         # (scripts/workflow-bun-version.test.ts enforces that); later entries
         # are trial lanes for the next Bun line — promote one to first once it
         # has soaked.
-        bun-version: ['1.3.14', '1.4.1']
+        bun-version: ['1.3.14', '1.4.2']
         include:
           - bun-version: '1.3.14'
             redis: true
@@ -65,7 +65,7 @@ jobs:
           # script is itself `bun run ./scripts/test-packages.ts`), which is
           # how the first version of this lane fed the harness a bare
           # `--parallel` and died on "Unknown flag".
-          - bun-version: '1.4.1'
+          - bun-version: '1.4.2'
             redis: true
             trial: true
             test-bun-flags: '-- -- --parallel --timeout 30000'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,10 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    # Trial lanes report but never block a PR: the parallel runner they trial
-    # can lose a spawnSync child's exit (oven-sh/bun#34069's race, observed on
-    # this suite as a burst of exactly-at-timeout failures in the git-heavy
-    # files, roughly 1 run in 2 on macOS and far rarer here) — data worth
-    # collecting, not worth gating merges on. The flag lives on the matrix
-    # entry, not on a version literal, so promoting a trial version to primary
-    # cannot silently flip which lane gates.
+    # Trial lanes report but never block a PR: they soak the next Bun line, and
+    # a red one is data rather than a merge decision. `trial: true` lives on the
+    # matrix entry, not on a version literal, so promoting a trial version to
+    # primary cannot silently flip which lane gates.
     continue-on-error: ${{ matrix.trial == true }}
     # Measured ceiling for a healthy lane is 5m00s (1.3.14) / 4m42s (1.4.0)
     # across 30 runs, cache misses included, so this is an anti-wedge
@@ -40,35 +37,15 @@ jobs:
         include:
           - bun-version: '1.3.14'
             redis: true
-          # The trial lane also trials `bun test --parallel` (1.4-only flag):
-          # forwarded through test-packages.ts, workers = the runner's 4
-          # cores. The timeout raise absorbs the tests that spawn real
-          # subprocesses (git choreography, tsc gates) running 4-wide on 4
-          # cores, where 5s is only enough for an idle machine.
-          #
-          # The flag was expected to be safe on Linux: macOS ARM64 trips
-          # oven-sh/bun#34069 on this suite (spawnSync loses a child exit; a
-          # worker spins at 100% CPU forever) in ~2 of 5 runs, and that spin
-          # lives in the kqueue path, which epoll does not share. Measured on
-          # this runner, that reasoning does not hold. The lane went from ~91%
-          # green over the 25 runs before the flag (20 success / 2 failure) to
-          # ~36% over the 11 after it (4 success / 4 failure / 3 hangs). Every
-          # failure is the same file, scripts/publish-agent-catalog.test.ts,
-          # at exactly 30000ms; the hangs are the wedge itself. So the flag is
-          # applied on pushes only — see the `Run tests` step, which is where
-          # that condition lives and why.
-          #
-          # Two dashes because `bun <file>` swallows one *leading* `--` before
-          # argv reaches the script; the survivor is the separator
-          # test-packages.ts forwards the rest after. Going through
-          # `bun run test:bun` instead stacks a second swallowing layer (the
-          # script is itself `bun run ./scripts/test-packages.ts`), which is
-          # how the first version of this lane fed the harness a bare
-          # `--parallel` and died on "Unknown flag".
+          # Do not hand this lane `bun test --parallel`: it wedges this suite
+          # on the Linux runners as well as on macOS ARM64 — 2 green in 15
+          # pushes, the reds either publish-agent-catalog.test.ts at exactly
+          # the timeout or `Run tests` hanging to its cap. oven-sh/bun#34069
+          # (spawnSync loses a child exit, a worker then spins at 100% CPU) is
+          # open as of 1.4.2.
           - bun-version: '1.4.2'
             redis: true
             trial: true
-            test-bun-flags: '-- -- --parallel --timeout 30000'
     services:
       redis:
         image: redis:7-alpine
@@ -273,44 +250,16 @@ jobs:
       - name: Bundle budget audit
         run: bun run audit:bundle-budgets
 
-      # `bun run test` inlined so the trial lane's flags reach the package
-      # suites only; the example apps keep their own per-app runs either way.
-      # The harness is invoked directly (not via `bun run test:bun`) so the
-      # flag string crosses exactly one `--`-swallowing layer — see the
-      # matrix comment above.
-      #
-      # The flags are applied on pushes only. `--parallel` costs the lane most
-      # of its green (numbers on the matrix entry above), and a lane that is
-      # red on two runs in three is one everybody learns to scroll past —
-      # which would also cost the 1.4 promotion soak, the other thing this
-      # lane is for and the half that passes. On a pull request it therefore
-      # runs plain, and `--parallel` keeps collecting on main at 11-12 runs a
-      # day, off everyone's PR checks. The consequence is worth stating: for
-      # this lane a green PR no longer predicts a green push. It gates neither.
-      #
-      # The condition lives here rather than on the matrix entry because
-      # `matrix` is not available in a job-level `if`, so the lane cannot be
-      # skipped per entry; and while the context tables say `github` is
-      # available inside `strategy`, a `run:` is somewhere both are
-      # unambiguously available, which is worth more than the tidier spelling.
-      # Delete the condition and keep `matrix.test-bun-flags` once bun#34069
-      # closes.
-      #
-      # The step is capped as well as the job because this is the step that
-      # hangs: oven-sh/bun#34069 wedged the trial lane here on four runs in
-      # one day (32489029613, 32492123122, 32494964369, 32496297560), each
-      # sitting in_progress for 11-57 minutes until cancelled by hand. A
-      # *step* timeout fails the step, which the job's continue-on-error then
-      # masks on the trial lane — the documented path. Whether a *job*
-      # timeout is reported as a failure (masked) or a cancellation (not) is
-      # not something the documentation settles, so the trial lane's
-      # non-blocking promise deliberately does not rest on it.
+      # Capped as well as the job because this is the step a wedged runner
+      # hangs in: oven-sh/bun#34069 held it in_progress for 11-57 minutes on
+      # four runs in one day. A *step* timeout fails the step, which the job's
+      # continue-on-error then masks on a trial lane — the documented path;
+      # whether a *job* timeout is reported as a failure or a cancellation is
+      # not something the documentation settles.
       # Measured 2m16s at worst against a 15m cap.
       - name: Run tests
         timeout-minutes: 15
-        run: |
-          bun scripts/test-packages.ts ${{ github.event_name == 'push' && matrix.test-bun-flags || '' }}
-          bun run test:examples
+        run: bun run test
 
       - name: Testing package tests (vitest)
         run: bun run test:testing

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@babel/parser": "^7.24.7",
         "@babel/types": "^7.29.0",
         "@changesets/cli": "^2.31.1",
-        "bun-types": "^1.4.1",
+        "bun-types": "^1.4.2",
         "oxlint": "1.81.0",
         "oxlint-tsgolint": "7.0.2001",
         "typescript": "^7.0.2",
@@ -19,7 +19,7 @@
     },
     "examples/agents": {
       "name": "@guren/example-agents",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -39,7 +39,7 @@
     },
     "examples/api": {
       "name": "@guren/example-api",
-      "version": "0.1.32",
+      "version": "0.1.35",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -92,7 +92,7 @@
     },
     "packages/cli": {
       "name": "@guren/cli",
-      "version": "2.15.1",
+      "version": "2.18.0",
       "bin": {
         "guren": "./dist/bin.js",
       },
@@ -127,7 +127,7 @@
     },
     "packages/core": {
       "name": "@guren/core",
-      "version": "1.13.1",
+      "version": "1.15.0",
       "bin": {
         "guren": "./dist/bin.js",
       },
@@ -145,7 +145,7 @@
     },
     "packages/create-app": {
       "name": "create-guren-app",
-      "version": "1.12.0",
+      "version": "1.13.2",
       "bin": {
         "create-guren-app": "./dist/cli.js",
       },
@@ -216,7 +216,7 @@
     },
     "packages/plugin-agents": {
       "name": "@guren/plugin-agents",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "@guren/core": "^1.13.0",
         "agents": "^0.22.0",
@@ -236,7 +236,7 @@
     },
     "packages/plugin-cloudflare": {
       "name": "@guren/plugin-cloudflare",
-      "version": "0.6.0",
+      "version": "0.8.0",
       "dependencies": {
         "@guren/core": "^1.13.0",
         "citty": "^0.1.6",
@@ -253,7 +253,7 @@
     },
     "packages/plugin-lambda": {
       "name": "@guren/plugin-lambda",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@guren/core": "^1.6.2",
         "citty": "^0.1.6",
@@ -299,7 +299,7 @@
     },
     "packages/plugin-mcp": {
       "name": "@guren/plugin-mcp",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@guren/core": "^1.13.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -314,7 +314,7 @@
     },
     "packages/plugin-vercel": {
       "name": "@guren/plugin-vercel",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "dependencies": {
         "@guren/core": "^1.6.2",
       },
@@ -339,7 +339,7 @@
     },
     "packages/server": {
       "name": "@guren/server",
-      "version": "2.16.0",
+      "version": "2.19.0",
       "dependencies": {
         "@guren/orm": "^2.6.3",
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -400,7 +400,7 @@
     },
     "web": {
       "name": "web",
-      "version": "0.1.32",
+      "version": "0.1.35",
       "dependencies": {
         "@guren/cli": "workspace:*",
         "@guren/core": "workspace:*",
@@ -1276,7 +1276,7 @@
 
     "browserslist": ["browserslist@4.28.9", "", { "dependencies": { "baseline-browser-mapping": "^2.11.20", "caniuse-lite": "^1.0.30001810", "electron-to-chromium": "^1.5.420", "node-releases": "^2.0.54", "update-browserslist-db": "^1.3.2" }, "bin": { "browserslist": "cli.js" } }, "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg=="],
 
-    "bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
+    "bun-types": ["bun-types@1.4.2", "", { "dependencies": { "@types/node": "*" } }, "sha512-bxV1FgK7yBIzjRe5zBozIM4Bem11ZJcCXSrjWRG3YWLt8yFDePu4cLjpebO8OvPeIE9trbyPF4fuj3Cia4Fj3w=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@babel/parser": "^7.24.7",
     "@babel/types": "^7.29.0",
     "@changesets/cli": "^2.31.1",
-    "bun-types": "^1.4.1",
+    "bun-types": "^1.4.2",
     "oxlint": "1.81.0",
     "oxlint-tsgolint": "7.0.2001",
     "typescript": "^7.0.2",

--- a/scripts/test-packages.ts
+++ b/scripts/test-packages.ts
@@ -17,6 +17,8 @@ import { collectPackages, parseArgs, repoRoot, selectPackages } from './workspac
 // survives a `test` script being reworded; a regex over it would not.
 const nonBunTestPackages = new Set(['@guren/testing'])
 
+// `bun <file>` (unlike `bun run`) swallows one *leading* `--` before argv, so a
+// direct invocation needs two: `bun scripts/test-packages.ts -- -- --parallel`.
 const { flags, positionals: selectors, forwarded } = parseArgs(
   process.argv.slice(2),
   ['list'],


### PR DESCRIPTION
Bun 1.4.2 is out (12 commits on 1.4.1: a WebKit upgrade plus small fixes). This
moves the trial lane onto it and retires the `--parallel` experiment the lane
has been carrying since August.

## Trial lane 1.4.1 → 1.4.2

`bun-types` follows to `^1.4.2`. The lockfile is written by 1.3.14 — the primary
lane's version, whose `--frozen-lockfile` must keep passing — and 1.4.2 reads it
back with no changes. The workspace versions in `bun.lock` also catch up with the
2.19.0 release, which bumped the manifests without re-running install.

The primary pin stays 1.3.14; this is not a promotion.

## `bun test --parallel` comes off

The flag was applied on pushes only, on the theory that oven-sh/bun#34069
(spawnSync loses a child exit, then a worker spins at 100% CPU) was confined to
the macOS kqueue path. The Linux numbers say otherwise, and they have got worse
rather than settled:

| lane | green |
|---|---|
| PR runs, no flag | 12 / 12 |
| main pushes, with the flag | 2 / 15 |

Every red is one of two shapes: `scripts/publish-agent-catalog.test.ts` failing
at exactly the 30000ms timeout, or `Run tests` hanging until its 15-minute cap.
The upstream bug is still open and none of 1.4.2's 12 commits touch it, so the
flag goes and the measurement stays in the matrix comment as the reason not to
put it back. `Run tests` is `bun run test` again; the step keeps its cap as an
anti-wedge backstop.

The consequence is that this lane's green on a pull request predicts its green on
a push once more.

## Verification

Under 1.4.2 (installed to a scratch prefix, not the default toolchain):
`bun install --frozen-lockfile` (no changes) → `build:clean` → `build:routes` →
`typecheck` → `lint` → `test:bun` (7077 pass, 98 skip, 0 fail) → `test:examples`
→ `test:testing`, all green.

Under 1.3.14: `typecheck`, `lint`, `scripts/workflow-bun-version.test.ts` and
`audit:agent-catalog --base origin/main` green — the catalog gate confirms no
changeset is owed. `test:bun` cannot complete on this macOS machine: Bun 1.3.14
segfaults in `packages/cli/tests/tool-dev.test.ts` under `--isolate`. That
reproduces identically on a tree without these commits and does not happen under
1.4.2, and CI's own 1.3.14 lane is green, so it is a local macOS issue rather
than something this change introduces.