### PR TITLE
test(cli): derive the guren.css copies the sync test compares

### DIFF
--- a/packages/cli/tests/guren-css-sync.test.ts
+++ b/packages/cli/tests/guren-css-sync.test.ts
@@ -6,25 +6,43 @@ import { ensureGurenUiTokens } from '../src/guren-css'
 
 const repoRoot = join(import.meta.dir, '../../..')
 
+const BLUEPRINT = 'packages/create-app/templates/default/resources/css/guren.css'
+
+const TOKEN_SHEETS = [
+  'examples/agents/resources/css/guren.css',
+  'packages/cli/templates/scaffold/guren-ui/resources/css/guren.css',
+  BLUEPRINT,
+]
+
+/** Tracked, so an untracked scratch copy is not a failure and node_modules is
+    never walked. */
+function trackedTokenSheets(): string[] {
+  const git = Bun.spawnSync(['git', 'ls-files', '-z', '--', '*resources/css/guren.css'], {
+    cwd: repoRoot,
+  })
+  if (git.exitCode !== 0) {
+    throw new Error(`git ls-files exited ${git.exitCode}: ${git.stderr.toString().trim()}`)
+  }
+  return git.stdout.toString().split('\0').filter(Boolean).sort()
+}
+
 /**
  * The token sheet ships in the create-app template, is written into older apps
- * by ensureGurenUiTokens, and is vendored into examples/agents; the three
- * copies must stay byte-identical, or an app's tokens depend on which command
- * wrote the file. Upstream is gurenjs/guren-ui, and lands here by hand.
+ * by ensureGurenUiTokens, and is vendored into examples/agents — which no
+ * command maintains, so it drifts silently. The copies must stay
+ * byte-identical, or an app's tokens depend on which command wrote the file.
+ * Upstream is gurenjs/guren-ui, and lands here by hand.
  */
 it('every guren.css copy matches the create-app template copy', async () => {
-  const blueprint = await readFile(
-    join(repoRoot, 'packages/create-app/templates/default/resources/css/guren.css'),
-    'utf8',
-  )
-  const scaffold = await readFile(
-    join(repoRoot, 'packages/cli/templates/scaffold/guren-ui/resources/css/guren.css'),
-    'utf8',
-  )
-  const example = await readFile(join(repoRoot, 'examples/agents/resources/css/guren.css'), 'utf8')
+  // Derived, then pinned: a fourth copy has to be added here deliberately, and
+  // a listing that came back empty cannot pass the comparison below vacuously.
+  const paths = trackedTokenSheets()
+  expect(paths).toEqual(TOKEN_SHEETS)
 
-  expect(scaffold).toBe(blueprint)
-  expect(example).toBe(blueprint)
+  const blueprint = await readFile(join(repoRoot, BLUEPRINT), 'utf8')
+  for (const path of paths) {
+    expect(await readFile(join(repoRoot, path), 'utf8')).toBe(blueprint)
+  }
 })
 
 async function makeApp(appCss?: string): Promise<string> {


### PR DESCRIPTION
## What

`packages/cli/tests/guren-css-sync.test.ts` listed the token sheet's copies by path. That is how `examples/agents/resources/css/guren.css` arrived covered by nothing in #718, and the same is true of any fourth copy a later PR adds.

The paths are now derived with `git ls-files -z -- '*resources/css/guren.css'` — tracked, so an untracked scratch copy is not a failure and `node_modules` is never walked. The known three stay in the file as a floor: a listing that came back empty or short would otherwise pass the identity comparison vacuously, and a genuinely new copy has to be added deliberately rather than absorbed in silence.

No behaviour change; test-only, so no changeset.

## Verification

Three mutations, each of which reddens the test:

| mutation | assertion that fires |
| --- | --- |
| append a byte to `examples/agents/resources/css/guren.css` | identity |
| `git add` a fourth copy under `examples/blog` | floor |
| `git rm --cached` one of the three | floor |

Green: `bun run lint`, `bun run typecheck`, `bun test packages/cli` (2325 pass).

Note for anyone reproducing: `bun run test:bun cli` spins at 100% CPU without printing on this Bun (1.3.14) — the known `--isolate` failure mode, unrelated to this change. `bun test packages/cli` runs the same files in 38s. The file also passes on its own under `--isolate`.