### PR TITLE
fix(cli): keep scaffold and harness comments inside the length limit

### DIFF
--- a/.changeset/scaffold-comment-length-create-app.md
+++ b/.changeset/scaffold-comment-length-create-app.md
@@ -1,0 +1,5 @@
+---
+'create-guren-app': patch
+---
+
+Split the over-long comment blocks in the default, api-only, blog, and SQLite templates so a freshly scaffolded app's first `bun run lint` reports no `guren/comment-length` warnings on framework-generated files.

--- a/.changeset/scaffold-comment-length.md
+++ b/.changeset/scaffold-comment-length.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': patch
+---
+
+Split the over-long comment blocks in the scaffold and agent-harness templates so a freshly scaffolded app's first `bun run lint` reports no `guren/comment-length` warnings on framework-generated files. Each block is split by fact and placed on the code it describes; no guidance is dropped.

--- a/packages/cli/templates/agent/core/hooks/gate-on-stop.ts
+++ b/packages/cli/templates/agent/core/hooks/gate-on-stop.ts
@@ -4,12 +4,6 @@
  * turn with uncommitted changes in this app, run `guren gate` (the CI stages:
  * codegen, typecheck, lint, check, audit, test) and block the stop with the
  * findings (exit 2, stderr), so the fix happens in this turn rather than in CI.
- * A clean tree is not gated, so a turn that ends by committing is not gated
- * here: run `guren gate` before committing.
- *
- * The app root is this script's grandparent (`<app>/.claude/hooks/`,
- * `<app>/.codex/hooks/`): Codex runs hooks in the session cwd, which may be a
- * subdirectory, and a monorepo app is not the git root.
  */
 import { resolve } from 'node:path'
 
@@ -40,7 +34,12 @@ try {
   process.exit(2)
 }
 
+// The app root is this script's grandparent (`<app>/.claude/hooks/`,
+// `<app>/.codex/hooks/`): Codex runs hooks in the session cwd, which may be a
+// subdirectory, and a monorepo app is not the git root.
 const findings = await cli.stopGateFindings(resolve(import.meta.dir, '../..'))
+// null when the tree is clean, so a turn that ends by committing is not gated
+// here: run `guren gate` before committing.
 if (findings === null) {
   process.exit(0)
 }

--- a/packages/cli/templates/agent/targets/claude/hooks/check-after-edit.ts
+++ b/packages/cli/templates/agent/targets/claude/hooks/check-after-edit.ts
@@ -4,8 +4,6 @@
  * controllers, models, schema, and pages) and oxlint (for any source file, when
  * the app has an .oxlintrc.json) and feed findings back so they get fixed
  * immediately instead of surfacing later in CI.
- *
- * Exit codes: 0 = ok / not applicable, 2 = findings reported back to the agent.
  */
 import { existsSync, realpathSync } from 'node:fs'
 import { isAbsolute, relative, sep } from 'node:path'
@@ -96,6 +94,7 @@ if (wantsLint && cli.isLintable(relPath)) {
   }
 }
 
+// Exit 2 is what carries the findings back to the agent; 0 is ok or not applicable.
 if (findings.length > 0) {
   console.error(`After editing ${relPath}:\n${findings.join('\n')}`)
   process.exit(2)

--- a/packages/cli/templates/agent/targets/cursor/hooks/gate-on-stop.ts
+++ b/packages/cli/templates/agent/targets/cursor/hooks/gate-on-stop.ts
@@ -4,16 +4,14 @@
  * app, run `guren gate` (the CI stages: codegen, typecheck, lint, check, audit,
  * test) and hand the findings back as a `followup_message`, which Cursor submits
  * as the next user message, so the fix happens in this conversation rather than
- * in CI. A clean tree is not gated, so a turn that ends by committing is not
- * gated here: run `guren gate` before committing.
- *
- * Bounded twice: `loop_count` here (Cursor counts this hook's follow-ups per
- * conversation) and `loop_limit` in .cursor/hooks.json, which is user-owned.
- * The app root is this script's grandparent (`<app>/.cursor/hooks/`).
+ * in CI.
  */
 import { resolve } from 'node:path'
 
-/** Follow-ups this hook may trigger per conversation. */
+/**
+ * Follow-ups this hook may trigger per conversation. Bounded twice: here, and by
+ * `loop_limit` in .cursor/hooks.json, which is user-owned.
+ */
 const MAX_FOLLOW_UPS = 3
 
 interface HookInput {
@@ -44,7 +42,10 @@ try {
   followUp('guren gate could not run: @guren/cli is not resolvable from this app (run `bun install`).')
 }
 
+// The app root is this script's grandparent (`<app>/.cursor/hooks/`).
 const findings = await cli.stopGateFindings(resolve(import.meta.dir, '../..'))
+// null when the tree is clean, so a turn that ends by committing is not gated
+// here: run `guren gate` before committing.
 if (findings === null) {
   process.exit(0)
 }

--- a/packages/cli/templates/scaffold/attachments/config/attachments.ts
+++ b/packages/cli/templates/scaffold/attachments/config/attachments.ts
@@ -1,26 +1,27 @@
 import { configureAttachments, getContainer } from '@guren/core'
 import { attachments } from '../db/schema'
 
-/**
- * Wires the attachments layer once at boot (AttachmentsProvider imports this
- * module). `Attachment` is the app-local model over the attachments table —
- * use it for morph relations and advanced queries; the typed day-to-day API
- * lives on your models via the Attachable mixin.
- *
- * See the attachments guide for declarations, image validation, variants,
- * and queued generation.
- */
+// Wires the attachments layer once at boot (AttachmentsProvider imports this
+// module). `Attachment` is the app-local model over the attachments table —
+// use it for morph relations and advanced queries; the typed day-to-day API
+// lives on your models via the Attachable mixin.
+
+// See the attachments guide for declarations, image validation, variants, and
+// queued generation.
 export const { Attachment } = configureAttachments({
   table: attachments,
   storage: () => getContainer().make('storage'),
   // Uploads are bytes a stranger chose, so they are stored on a disk that
   // nothing serves statically — `local` is rooted at ./storage/app, outside
   // public/ — and handed out through the signed delivery route that
-  // registerAttachmentRoutes(router) mounts in your route registrar. That
-  // route serves only an allowlist of types inline, forces a download for the
-  // rest, and adds nosniff plus a sandbox CSP. Rooting this disk inside
-  // public/ instead would bypass all of it; `guren check` fails that shape,
-  // and StorageProvider.ts says why at the disk in question.
+  // registerAttachmentRoutes(router) mounts.
+
+  // That route serves only an allowlist of types inline, forces a download for
+  // the rest, and adds nosniff plus a sandbox CSP.
+
+  // Rooting this disk inside public/ instead would bypass all of it: `guren
+  // check` fails that shape, and StorageProvider.ts says why at the disk in
+  // question.
   disk: 'local',
   // Per-disk visibility. 'public' disks build URLs with disk.url(); 'private'
   // ones go through the delivery route below. Undeclared disks count as

--- a/packages/cli/templates/scaffold/auth/app/Providers/AuthProvider.ts
+++ b/packages/cli/templates/scaffold/auth/app/Providers/AuthProvider.ts
@@ -13,11 +13,10 @@ export default class AuthProvider extends ServiceProvider {
     })
   }
 
+  // Nothing shares the signed-in user with the frontend by default, so every
+  // page would render as a guest. Layout.tsx reads this to choose between
+  // "Sign in" and the Log out control.
   boot(): void {
-    // Nothing shares the signed-in user with the frontend by default, so every
-    // page would render as a guest. Layout.tsx reads this to choose between
-    // "Sign in" and the Log out control.
-    //
     // shareInertiaProps merges over resolvers registered earlier instead of
     // replacing them, so the framework's flashed `errors` still come through.
     // Passing this.container scopes the props to this app.

--- a/packages/cli/templates/scaffold/cache/app/Providers/CacheProvider.ts
+++ b/packages/cli/templates/scaffold/cache/app/Providers/CacheProvider.ts
@@ -3,12 +3,6 @@ import { ServiceProvider, createCacheManager } from '@guren/core'
 // CACHE_STORE picks the store. `memory` is per-process: correct on one
 // long-lived server, wrong on Workers, Lambda and Vercel, where two requests
 // can land in different instances.
-//
-// For Redis, add `createRedisClient` from '@guren/core/redis' and a
-// `redis: { driver: 'redis', client: () => createRedisClient({ url: process.env.REDIS_URL }) }`
-// entry — imported here only when you use it, since that module pulls in
-// ioredis. The function runs when the store is first resolved, so a store
-// declared beside `memory` opens no connection until CACHE_STORE selects it.
 export default class CacheProvider extends ServiceProvider {
   register(): void {
     this.container.singleton('cache', () => createCacheManager({
@@ -16,6 +10,11 @@ export default class CacheProvider extends ServiceProvider {
       default: process.env.CACHE_STORE || 'memory',
       stores: {
         memory: { driver: 'memory' },
+        // For Redis, add `createRedisClient` from '@guren/core/redis' and a
+        // `redis: { driver: 'redis', client: () => createRedisClient({ url: process.env.REDIS_URL }) }`
+        // entry — imported only where you use it, since that module pulls in ioredis.
+        // The function runs when the store is first resolved, so a store declared
+        // beside `memory` opens no connection until CACHE_STORE selects it.
       },
     }))
   }

--- a/packages/cli/templates/scaffold/oauth/app/Http/Controllers/Auth/OAuthController.ts
+++ b/packages/cli/templates/scaffold/oauth/app/Http/Controllers/Auth/OAuthController.ts
@@ -19,9 +19,9 @@ export default class OAuthController extends Controller {
     // attacker could authorize their own account, keep the `code` unconsumed,
     // and walk a visitor through the callback — logging that visitor into the
     // attacker's account.
-    // `?redirectTo=` is user input — the manager only keeps app-relative
-    // paths (or hosts allowlisted via stateConfig.allowedRedirectHosts).
     const { url } = await this.oauth().authorize(provider, {
+      // User input — the manager only keeps app-relative paths (or hosts
+      // allowlisted via stateConfig.allowedRedirectHosts).
       redirectTo: this.request.query('redirectTo'),
       session: this.auth.session(),
     })
@@ -37,17 +37,17 @@ export default class OAuthController extends Controller {
       return this.json({ error: 'Missing OAuth callback parameters.' }, { status: 400 })
     }
 
-    // Replace this with your own account linking: look the user up by
+    // Replace what follows with your own account linking: look the user up by
     // profile.email, create one when missing, then `await this.auth.login(user)`
-    // and finish with `return this.redirect(redirectTo ?? '/')` —
-    // `redirectTo` is already sanitized against open redirects. Refuse to
-    // create an account when `profile.emailVerified === false`: the provider
-    // is saying it never checked that the address belongs to this user.
+    // and finish with `return this.redirect(redirectTo ?? '/')` — `redirectTo`
+    // is already sanitized against open redirects.
     const { profile, redirectTo } = await this.oauth().handleCallback(provider, {
       code,
       state,
       session: this.auth.session(),
     })
+    // Refuse to create an account when `profile.emailVerified === false`: the
+    // provider is saying it never checked that the address belongs to this user.
     return this.json({ provider, profile, redirectTo }, { status: 200 })
   }
 

--- a/packages/cli/templates/scaffold/storage/app/Providers/StorageProvider.ts
+++ b/packages/cli/templates/scaffold/storage/app/Providers/StorageProvider.ts
@@ -7,21 +7,25 @@ import { ServiceProvider, createStorageManager } from '@guren/core'
 // throw (a required-env helper) out of it.
 const disks = {
   local: { driver: 'local', root: './storage/app' },
+
   // Declared public because it is: everything under it is served. A local
   // disk has no per-object visibility, so this is where that is decided.
   // Rooted inside public/ so the root asset server serves these files and
   // disk.url() returns a URL that actually resolves (images and the other
   // allowlisted extensions; add a route for anything else).
-  //
+
   // For assets you ship, then. Never for bytes someone uploaded: anything on
   // this disk is fetchable by URL with no signature, no expiry and no
-  // authorization check. The framework forces a download for document types
-  // served out of public/, so an uploaded .svg will not execute on your
-  // origin — but that is a backstop against one consequence, not access
-  // control, and inlineDocuments: true opts out of it. Uploads belong on
-  // `local` above, handed out through the attachments delivery route — which
-  // is what `guren add attachments` configures, and what `guren check`
-  // verifies.
+  // authorization check.
+
+  // The framework forces a download for document types served out of public/,
+  // so an uploaded .svg will not execute on your origin — but that is a
+  // backstop against one consequence, not access control, and
+  // inlineDocuments: true opts out of it.
+
+  // Uploads belong on `local` above, handed out through the attachments
+  // delivery route — which is what `guren add attachments` configures, and
+  // what `guren check` verifies.
   public: { driver: 'local', root: './public/storage', url: '/storage', visibility: 'public' },
 } as const
 

--- a/packages/create-app/templates/api-only/src/app.ts
+++ b/packages/create-app/templates/api-only/src/app.ts
@@ -3,13 +3,9 @@ import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
 import { registerApiRoutes } from '../routes/api.js'
 
 // The Host header is client-controlled, so production should answer only to the
-// host this app is deployed as, which APP_URL carries.
-//
-// Read at module scope, where not every platform has populated process.env yet
-// (the Cloudflare worker imports this module before wrangler `vars` land). A
-// missing value therefore warns and leaves the check off, rather than throwing
-// and stopping the app from booting at all. Emailed links do not depend on this
-// — app/Auth/AppUrl.ts resolves those per request and fails closed there.
+// host this app is deployed as, which APP_URL carries. Emailed links do not
+// depend on this — app/Auth/AppUrl.ts resolves those per request and fails
+// closed there.
 function hostAuthorization() {
   const exclude = ['/health']
 
@@ -18,6 +14,10 @@ function hostAuthorization() {
   }
 
   const appUrl = process.env.APP_URL?.trim()
+  // Read at module scope, where not every platform has populated process.env yet
+  // (the Cloudflare worker imports this module before wrangler `vars` land), so a
+  // missing value warns and leaves the check off rather than throwing and
+  // stopping the app from booting at all.
   if (!appUrl) {
     console.warn('[app] APP_URL is not set — host authorization is disabled. Set it to the public base URL of this app.')
     return false

--- a/packages/create-app/templates/blog/app/Http/Controllers/PostController.ts
+++ b/packages/create-app/templates/blog/app/Http/Controllers/PostController.ts
@@ -28,15 +28,15 @@ export default class PostController extends Controller {
   // Serves the HTTP QUERY route `posts.search` — a safe read that carries its
   // criteria in a JSON body. Matches posts with any keyword in title or
   // excerpt; `%` and `_` in a keyword act as SQL LIKE wildcards, which this
-  // starter treats as a feature. All keyword OR pairs sit inside one
-  // `where(callback)`, keeping this an any-keyword match while AND filters
-  // added later (a published flag, tenancy) apply to every hit instead of
-  // being OR'd away.
+  // starter treats as a feature.
   async search(): Promise<Response> {
     const { keywords, limit } = await this.validateBody(PostSearchSchema)
 
     const posts = await Post.newQuery()
       .with('author')
+      // All keyword OR pairs sit inside one callback, keeping this an
+      // any-keyword match while AND filters added later (a published flag,
+      // tenancy) apply to every hit instead of being OR'd away.
       .where((q) => {
         for (const keyword of keywords) {
           const pattern = `%${keyword}%`

--- a/packages/create-app/templates/blog/app/Providers/AuthProvider.ts
+++ b/packages/create-app/templates/blog/app/Providers/AuthProvider.ts
@@ -13,11 +13,10 @@ export default class AuthProvider extends ServiceProvider {
     })
   }
 
+  // Nothing shares the signed-in user with the frontend by default, so every
+  // page would render as a guest. Layout.tsx reads this to choose between
+  // "Sign in" and the Write/Dashboard/Log out controls.
   boot(): void {
-    // Nothing shares the signed-in user with the frontend by default, so every
-    // page would render as a guest. Layout.tsx reads this to choose between
-    // "Sign in" and the Write/Dashboard/Log out controls.
-    //
     // shareInertiaProps merges over resolvers registered earlier instead of
     // replacing them, so the framework's flashed `errors` still come through.
     // Passing this.container scopes the props to this app.

--- a/packages/create-app/templates/blog/app/Providers/AuthorizationProvider.ts
+++ b/packages/create-app/templates/blog/app/Providers/AuthorizationProvider.ts
@@ -6,13 +6,12 @@ import { PostPolicy } from '../Policies/PostPolicy.js'
  * Maps models to their policies. `PostController` calls `this.authorize()` in
  * every mutating action, and without a registered policy the gate has nothing
  * to consult and denies them all.
- *
- * The framework's own provider creates the gate during registration, so this
- * runs in boot() — getGate() throws before that.
  */
 export default class AuthorizationProvider extends ServiceProvider {
   register(): void {}
 
+  // The framework's own provider creates the gate during registration, so this
+  // runs in boot() — getGate() throws before that.
   boot(): void {
     getGate().policy(Post, PostPolicy)
   }

--- a/packages/create-app/templates/blog/resources/js/pages/posts/Index.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/posts/Index.tsx
@@ -10,8 +10,9 @@ interface Props extends PaginatedPageProps<PostResourceData> {}
 
 // posts.search is an HTTP QUERY route (RFC 10008): safe like GET, but the
 // criteria travel in a JSON body — HTML forms and Inertia navigation cannot
-// send it, so the page calls it through the generated typed client. The
-// client types the request body from the schema bound to the route, and
+// send it, so the page calls it through the generated typed client.
+
+// The client types the request body from the schema bound to the route, and
 // json() from the `resource` hint the route declares — both come from the
 // route definition, so this file never restates the wire shape.
 const api = createApiClient<ApiRoutes>({ baseUrl: '' })

--- a/packages/create-app/templates/blog/routes/web.ts
+++ b/packages/create-app/templates/blog/routes/web.ts
@@ -34,13 +34,13 @@ export function registerWebRoutes(baseRouter: Router): void {
 
     // HTTP QUERY (RFC 10008): safe and idempotent like GET, but carries its
     // search criteria in a JSON body. Only fetch-based clients can send it —
-    // the posts page calls it through the generated API client. The
-    // `resource` hint declares the response shape the controller builds with
-    // PostResource, so the client's json() comes back typed — no runtime
-    // validation, just the type codegen already extracts from the Resource.
+    // the posts page calls it through the generated API client.
     posts.query('/search', {
       name: 'posts.search',
       body: PostSearchSchema,
+      // Declares the response shape the controller builds with PostResource, so
+      // the client's json() comes back typed — no runtime validation, just the
+      // type codegen already extracts from the Resource.
       resource: { data: [PostResource] },
     }, [PostController, 'search'])
   })

--- a/packages/create-app/templates/blog/src/app.ts
+++ b/packages/create-app/templates/blog/src/app.ts
@@ -18,13 +18,9 @@ setInertiaDocument({
 })
 
 // The Host header is client-controlled, so production should answer only to the
-// host this app is deployed as, which APP_URL carries.
-//
-// Read at module scope, where not every platform has populated process.env yet
-// (the Cloudflare worker imports this module before wrangler `vars` land). A
-// missing value therefore warns and leaves the check off, rather than throwing
-// and stopping the app from booting at all. Emailed links do not depend on this
-// — app/Auth/AppUrl.ts resolves those per request and fails closed there.
+// host this app is deployed as, which APP_URL carries. Emailed links do not
+// depend on this — app/Auth/AppUrl.ts resolves those per request and fails
+// closed there.
 function hostAuthorization() {
   const exclude = ['/health']
 
@@ -33,6 +29,10 @@ function hostAuthorization() {
   }
 
   const appUrl = process.env.APP_URL?.trim()
+  // Read at module scope, where not every platform has populated process.env yet
+  // (the Cloudflare worker imports this module before wrangler `vars` land), so a
+  // missing value warns and leaves the check off rather than throwing and
+  // stopping the app from booting at all.
   if (!appUrl) {
     console.warn('[app] APP_URL is not set — host authorization is disabled. Set it to the public base URL of this app.')
     return false

--- a/packages/create-app/templates/blog/tests/PostController.test.ts
+++ b/packages/create-app/templates/blog/tests/PostController.test.ts
@@ -2,13 +2,14 @@ import { beforeAll, describe, it } from 'bun:test'
 import { TestApp } from '@guren/testing'
 import app from '../src/app.js'
 
-// posts.search is an HTTP QUERY route (RFC 10008). Its controller validates
-// the body with validateBody() before building any query — the schema bound
-// to the route feeds codegen and `guren audit`, while body parsing stays in
-// the controller so the request stream is read once — so an invalid payload
-// gets a 422 without the database ever being touched. That keeps this starter
-// test green without migrations or fixtures; cover the happy path with real
-// feature tests once your test database is set up.
+// posts.search is an HTTP QUERY route (RFC 10008). Its controller validates the
+// body with validateBody() before building any query — the schema bound to the
+// route feeds codegen and `guren audit`, while body parsing stays in the
+// controller so the request stream is read once.
+
+// So an invalid payload gets a 422 without the database ever being touched,
+// which keeps this starter test green without migrations or fixtures. Cover the
+// happy path with real feature tests once your test database is set up.
 describe('posts.search', () => {
   let http: TestApp
 

--- a/packages/create-app/templates/database/sqlite/drizzle.config.ts
+++ b/packages/create-app/templates/database/sqlite/drizzle.config.ts
@@ -1,18 +1,14 @@
 import { defineConfig } from 'drizzle-kit'
 
+// Read by two different SQLite implementations that disagree about URI
+// filenames: the app opens it with `bun:sqlite`, which honours them, while
+// drizzle-kit opens it with `node:sqlite`, which does not. So `file:` is not a
+// shared spelling of anything — `file:local.db` migrates the app into
+// `local.db` and drizzle-kit into a file *named* `file:local.db`.
 const filename = process.env.DATABASE_URL || './data/guren.db'
 
-/**
- * DATABASE_URL is read by two different SQLite implementations that disagree
- * about URI filenames: the app opens it with `bun:sqlite`, which honours them,
- * while drizzle-kit opens it with `node:sqlite`, which does not. So `file:` is
- * not a shared spelling of anything — `file:local.db` migrates the app into
- * `local.db` and drizzle-kit into a file *named* `file:local.db`. The safe set
- * is what both agree on: plain paths, and `:memory:`.
- *
- * The scheme must be two characters or more, since no registered scheme is one
- * letter while `C:/data/app.db` is a Windows drive path.
- */
+// Two characters or more: no registered scheme is one letter, while
+// `C:/data/app.db` is a Windows drive path.
 const uriScheme = /^([a-z][a-z0-9+.-]+):/i.exec(filename)
 
 if (uriScheme) {

--- a/packages/create-app/templates/default/src/app.ts
+++ b/packages/create-app/templates/default/src/app.ts
@@ -17,13 +17,9 @@ setInertiaDocument({
 })
 
 // The Host header is client-controlled, so production should answer only to the
-// host this app is deployed as, which APP_URL carries.
-//
-// Read at module scope, where not every platform has populated process.env yet
-// (the Cloudflare worker imports this module before wrangler `vars` land). A
-// missing value therefore warns and leaves the check off, rather than throwing
-// and stopping the app from booting at all. Emailed links do not depend on this
-// — app/Auth/AppUrl.ts resolves those per request and fails closed there.
+// host this app is deployed as, which APP_URL carries. Emailed links do not
+// depend on this — app/Auth/AppUrl.ts resolves those per request and fails
+// closed there.
 function hostAuthorization() {
   const exclude = ['/health']
 
@@ -32,6 +28,10 @@ function hostAuthorization() {
   }
 
   const appUrl = process.env.APP_URL?.trim()
+  // Read at module scope, where not every platform has populated process.env yet
+  // (the Cloudflare worker imports this module before wrangler `vars` land), so a
+  // missing value warns and leaves the check off rather than throwing and
+  // stopping the app from booting at all.
   if (!appUrl) {
     console.warn('[app] APP_URL is not set — host authorization is disabled. Set it to the public base URL of this app.')
     return false


### PR DESCRIPTION
## Problem

A freshly scaffolded Guren app enables the `guren/comment-*` rules (via `guren add lint`, which is part of the default blueprint). Its very first `bun run lint` reported **twelve** `guren/comment-length` warnings — all on files the framework wrote, not the user.

Measured with `GUREN_KEEP_SMOKE_DIR=1 bun run smoke:starter` on the `default` blueprint. Every one of the eight files involved is byte-identical to its template source (verified with `diff`), so none of these come from a string literal.

| Path in the scaffolded app | Lines | Template source |
| --- | --- | --- |
| `.claude/hooks/check-after-edit.ts:2` | 6 | `cli/templates/agent/targets/claude/hooks/` |
| `.claude/hooks/gate-on-stop.ts:2` | 10 | `cli/templates/agent/core/hooks/` |
| `src/app.ts:39` | 8 | `create-app/templates/default/src/app.ts:19` |
| `drizzle.config.ts:5` | 9 | `create-app/templates/database/sqlite/` |
| `app/Http/Controllers/Auth/OAuthController.ts:17`, `:40` | 7, 6 | `cli/templates/scaffold/oauth/` |
| `app/Providers/AuthProvider.ts:17` | 7 | `cli/templates/scaffold/auth/` |
| `config/attachments.ts:4`, `:16` | 7, 8 | `cli/templates/scaffold/attachments/` |
| `app/Providers/StorageProvider.ts:10` | 15 | `cli/templates/scaffold/storage/` |
| `app/Providers/CacheProvider.ts:3` | 9 | `cli/templates/scaffold/cache/` |
| `config/session.ts:4` | 11 | left to #726 |

## Approach

Each over-long block is split by fact, following the shape #726 used for `config/session.ts`: consecutive `//` runs separated by a real blank line, with each half placed on the code it describes. No guidance is dropped — the facts that moved are the ones that had a better home:

- the app-root derivation in the stop hook, now on the `resolve(import.meta.dir, '../..')` it explains;
- the module-scope `process.env` read in `hostAuthorization()`, now on the `if (!appUrl)` branch that warns;
- the `?redirectTo=` sanitization note, now on the option it guards.

A template-wide scan turned up the same defect in the `api-only` and `blog` blueprints, which are equally user-selectable, so those are fixed here too. Nothing uses `oxlint-disable-next-line`.

`config/session.ts` is deliberately untouched: #726 already rewrites that block.

## Why two warnings still show in the smoke logs

`.claude/hooks/check-after-edit.ts` and `.claude/hooks/gate-on-stop.ts` keep warning in all three smokes, and **no smoke in any install mode can show them cleared**:

- `packages/create-app/src/cli.ts:373` runs `agent:init` through `runAppCli`, which spawns `node_modules/@guren/cli/dist/bin.js` — the **npm-published** copy (2.18.0 in the run above) — and it runs *before* vendoring.
- `vendorLocalPackages()` copies only `dist/` and the manifest, so no vendored `@guren/cli` ever carries `templates/agent`.

Same class as the documented `smoke:starter:npm` behaviour: correctly stale until the release ships. Verified directly instead, by installing the harness from this checkout:

```
bun packages/cli/src/bin.ts agent:init --target claude,cursor
```

The installed hooks lint clean for both targets, and restoring the previous text makes `guren/comment-length` fire again — so the check can fail.

## Verification

| Gate | Result |
| --- | --- |
| `bun run lint` | pass |
| `bun run typecheck` (incl. `typecheck:scaffold-templates`) | pass |
| `bun run audit:starter-template` | pass |
| `bun run audit:agent-catalog` | pass |
| `bun run audit:docs`, `audit:core-first` | pass |
| `packages/cli` + `packages/create-app` tests | 2401 pass, 0 fail |
| `smoke:starter`, `smoke:starter:api`, `smoke:starter:blog` | exit 0; the ten in-scope warnings gone from the gate's lint output |

No gate pins any of these comment texts (grepped `scripts/`, `packages/*/tests`).

`bun run test:bun` under `--isolate` hits the known bun 1.3.14 macOS segfault in `tool-dev.test.ts`; the rerun without `--isolate` is the 2401-pass row above.

## Follow-up

`.oxlintrc.json` turns the `guren/comment-*` rules **off** for `packages/*/templates/**`, which is why this drifted unnoticed while the apps those templates scaffold enable the same rules. That exemption can be narrowed once #726 lands (its `config/session.ts` is the last blocker), which would also bring `templates/agent/**` into the repo's own lint. Tracked separately.

Related: a file starting with `#!/usr/bin/env bun` does not get the 8-line module-header allowance, because oxc reports the hashbang as a comment and `collectBlocks()` hands it the header slot. Worth deciding on with that follow-up.