### PR TITLE
build: apply the guren/comment-* rules to the framework's own templates

### DIFF
--- a/.changeset/hashbang-module-header.md
+++ b/.changeset/hashbang-module-header.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': patch
+---
+
+`guren/comment-length` now gives the module-header allowance (8 lines) to the JSDoc under a `#!/usr/bin/env bun` line. oxc reports the hashbang as a comment, so it was taking the header slot and leaving the real header on the 5-line body limit — which is what the hook scripts an app scaffolds are written against.

--- a/.changeset/scaffold-comment-length-create-app.md
+++ b/.changeset/scaffold-comment-length-create-app.md
@@ -1,0 +1,5 @@
+---
+'create-guren-app': patch
+---
+
+Split the over-long comment blocks in the default, api-only, blog, and SQLite templates so a freshly scaffolded app's first `bun run lint` reports no `guren/comment-length` warnings on framework-generated files.

--- a/.changeset/scaffold-comment-length.md
+++ b/.changeset/scaffold-comment-length.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': patch
+---
+
+Split the over-long comment blocks in the scaffold and agent-harness templates so a freshly scaffolded app's first `bun run lint` reports no `guren/comment-length` warnings on framework-generated files. Each block is split by fact and placed on the code it describes; no guidance is dropped.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -78,17 +78,11 @@
       "rules": { "no-restricted-imports": "off" }
     },
     {
-      // Scaffold templates are user-facing starter code whose comments guide the
-      // reader, and audit:starter-template asserts their text literally; test
-      // fixtures and stubs are inputs, not commentary.
-      "files": ["packages/*/templates/**", "**/tests/fixtures/**", "**/stubs/**"],
-      "rules": {
-        "guren/comment-length": "off",
-        "guren/comment-banner": "off",
-        "guren/comment-step-label": "off",
-        "guren/comment-history": "off",
-        "guren/comment-param-restates": "off"
-      }
+      // The one template still exempt: gurenjs/guren#726 (RFC 0020 Part 5)
+      // rewrites this block into three, so trimming it here would only collide.
+      // Delete this entry when #726 lands; lint then proves it is spent.
+      "files": ["packages/cli/templates/scaffold/session/config/session.ts"],
+      "rules": { "guren/comment-length": "off" }
     }
   ]
 }

--- a/packages/cli/src/oxlint/comments.js
+++ b/packages/cli/src/oxlint/comments.js
@@ -29,8 +29,13 @@ function stripLine(text) {
 export function collectBlocks(comments, sourceLines, firstStatementLine) {
   const blocks = []
   let run = null
+  const hashbang = (sourceLines[0] ?? '').startsWith('#!')
   for (const c of comments) {
     const startLine = c.loc.start.line
+    // oxc reports `#!` as a comment (type 'Shebang'), so left in it takes the
+    // module-header slot from the real header below it. Keyed on the source
+    // text rather than the type, which is oxc's name to change.
+    if (hashbang && startLine === 1) continue
     const prefix = (sourceLines[startLine - 1] ?? '').slice(0, c.loc.start.column)
     const trailing = prefix.trim().length > 0
     if (c.type === 'Line') {

--- a/packages/cli/templates/agent/core/hooks/gate-on-stop.ts
+++ b/packages/cli/templates/agent/core/hooks/gate-on-stop.ts
@@ -4,12 +4,6 @@
  * turn with uncommitted changes in this app, run `guren gate` (the CI stages:
  * codegen, typecheck, lint, check, audit, test) and block the stop with the
  * findings (exit 2, stderr), so the fix happens in this turn rather than in CI.
- * A clean tree is not gated, so a turn that ends by committing is not gated
- * here: run `guren gate` before committing.
- *
- * The app root is this script's grandparent (`<app>/.claude/hooks/`,
- * `<app>/.codex/hooks/`): Codex runs hooks in the session cwd, which may be a
- * subdirectory, and a monorepo app is not the git root.
  */
 import { resolve } from 'node:path'
 
@@ -40,7 +34,12 @@ try {
   process.exit(2)
 }
 
+// The app root is this script's grandparent (`<app>/.claude/hooks/`,
+// `<app>/.codex/hooks/`): Codex runs hooks in the session cwd, which may be a
+// subdirectory, and a monorepo app is not the git root.
 const findings = await cli.stopGateFindings(resolve(import.meta.dir, '../..'))
+// null when the tree is clean, so a turn that ends by committing is not gated
+// here: run `guren gate` before committing.
 if (findings === null) {
   process.exit(0)
 }

--- a/packages/cli/templates/agent/targets/claude/hooks/check-after-edit.ts
+++ b/packages/cli/templates/agent/targets/claude/hooks/check-after-edit.ts
@@ -4,8 +4,6 @@
  * controllers, models, schema, and pages) and oxlint (for any source file, when
  * the app has an .oxlintrc.json) and feed findings back so they get fixed
  * immediately instead of surfacing later in CI.
- *
- * Exit codes: 0 = ok / not applicable, 2 = findings reported back to the agent.
  */
 import { existsSync, realpathSync } from 'node:fs'
 import { isAbsolute, relative, sep } from 'node:path'
@@ -96,6 +94,7 @@ if (wantsLint && cli.isLintable(relPath)) {
   }
 }
 
+// Exit 2 is what carries the findings back to the agent; 0 is ok or not applicable.
 if (findings.length > 0) {
   console.error(`After editing ${relPath}:\n${findings.join('\n')}`)
   process.exit(2)

--- a/packages/cli/templates/agent/targets/cursor/hooks/gate-on-stop.ts
+++ b/packages/cli/templates/agent/targets/cursor/hooks/gate-on-stop.ts
@@ -4,16 +4,14 @@
  * app, run `guren gate` (the CI stages: codegen, typecheck, lint, check, audit,
  * test) and hand the findings back as a `followup_message`, which Cursor submits
  * as the next user message, so the fix happens in this conversation rather than
- * in CI. A clean tree is not gated, so a turn that ends by committing is not
- * gated here: run `guren gate` before committing.
- *
- * Bounded twice: `loop_count` here (Cursor counts this hook's follow-ups per
- * conversation) and `loop_limit` in .cursor/hooks.json, which is user-owned.
- * The app root is this script's grandparent (`<app>/.cursor/hooks/`).
+ * in CI.
  */
 import { resolve } from 'node:path'
 
-/** Follow-ups this hook may trigger per conversation. */
+/**
+ * Follow-ups this hook may trigger per conversation. Bounded twice: here, and by
+ * `loop_limit` in .cursor/hooks.json, which is user-owned.
+ */
 const MAX_FOLLOW_UPS = 3
 
 interface HookInput {
@@ -44,7 +42,10 @@ try {
   followUp('guren gate could not run: @guren/cli is not resolvable from this app (run `bun install`).')
 }
 
+// The app root is this script's grandparent (`<app>/.cursor/hooks/`).
 const findings = await cli.stopGateFindings(resolve(import.meta.dir, '../..'))
+// null when the tree is clean, so a turn that ends by committing is not gated
+// here: run `guren gate` before committing.
 if (findings === null) {
   process.exit(0)
 }

--- a/packages/cli/templates/scaffold/attachments/config/attachments.ts
+++ b/packages/cli/templates/scaffold/attachments/config/attachments.ts
@@ -1,26 +1,27 @@
 import { configureAttachments, getContainer } from '@guren/core'
 import { attachments } from '../db/schema'
 
-/**
- * Wires the attachments layer once at boot (AttachmentsProvider imports this
- * module). `Attachment` is the app-local model over the attachments table —
- * use it for morph relations and advanced queries; the typed day-to-day API
- * lives on your models via the Attachable mixin.
- *
- * See the attachments guide for declarations, image validation, variants,
- * and queued generation.
- */
+// Wires the attachments layer once at boot (AttachmentsProvider imports this
+// module). `Attachment` is the app-local model over the attachments table —
+// use it for morph relations and advanced queries; the typed day-to-day API
+// lives on your models via the Attachable mixin.
+
+// See the attachments guide for declarations, image validation, variants, and
+// queued generation.
 export const { Attachment } = configureAttachments({
   table: attachments,
   storage: () => getContainer().make('storage'),
   // Uploads are bytes a stranger chose, so they are stored on a disk that
   // nothing serves statically — `local` is rooted at ./storage/app, outside
   // public/ — and handed out through the signed delivery route that
-  // registerAttachmentRoutes(router) mounts in your route registrar. That
-  // route serves only an allowlist of types inline, forces a download for the
-  // rest, and adds nosniff plus a sandbox CSP. Rooting this disk inside
-  // public/ instead would bypass all of it; `guren check` fails that shape,
-  // and StorageProvider.ts says why at the disk in question.
+  // registerAttachmentRoutes(router) mounts.
+
+  // That route serves only an allowlist of types inline, forces a download for
+  // the rest, and adds nosniff plus a sandbox CSP.
+
+  // Rooting this disk inside public/ instead would bypass all of it: `guren
+  // check` fails that shape, and StorageProvider.ts says why at the disk in
+  // question.
   disk: 'local',
   // Per-disk visibility. 'public' disks build URLs with disk.url(); 'private'
   // ones go through the delivery route below. Undeclared disks count as

--- a/packages/cli/templates/scaffold/auth/app/Providers/AuthProvider.ts
+++ b/packages/cli/templates/scaffold/auth/app/Providers/AuthProvider.ts
@@ -13,11 +13,10 @@ export default class AuthProvider extends ServiceProvider {
     })
   }
 
+  // Nothing shares the signed-in user with the frontend by default, so every
+  // page would render as a guest. Layout.tsx reads this to choose between
+  // "Sign in" and the Log out control.
   boot(): void {
-    // Nothing shares the signed-in user with the frontend by default, so every
-    // page would render as a guest. Layout.tsx reads this to choose between
-    // "Sign in" and the Log out control.
-    //
     // shareInertiaProps merges over resolvers registered earlier instead of
     // replacing them, so the framework's flashed `errors` still come through.
     // Passing this.container scopes the props to this app.

--- a/packages/cli/templates/scaffold/cache/app/Providers/CacheProvider.ts
+++ b/packages/cli/templates/scaffold/cache/app/Providers/CacheProvider.ts
@@ -3,12 +3,6 @@ import { ServiceProvider, createCacheManager } from '@guren/core'
 // CACHE_STORE picks the store. `memory` is per-process: correct on one
 // long-lived server, wrong on Workers, Lambda and Vercel, where two requests
 // can land in different instances.
-//
-// For Redis, add `createRedisClient` from '@guren/core/redis' and a
-// `redis: { driver: 'redis', client: () => createRedisClient({ url: process.env.REDIS_URL }) }`
-// entry — imported here only when you use it, since that module pulls in
-// ioredis. The function runs when the store is first resolved, so a store
-// declared beside `memory` opens no connection until CACHE_STORE selects it.
 export default class CacheProvider extends ServiceProvider {
   register(): void {
     this.container.singleton('cache', () => createCacheManager({
@@ -16,6 +10,11 @@ export default class CacheProvider extends ServiceProvider {
       default: process.env.CACHE_STORE || 'memory',
       stores: {
         memory: { driver: 'memory' },
+        // For Redis, add `createRedisClient` from '@guren/core/redis' and a
+        // `redis: { driver: 'redis', client: () => createRedisClient({ url: process.env.REDIS_URL }) }`
+        // entry — imported only where you use it, since that module pulls in ioredis.
+        // The function runs when the store is first resolved, so a store declared
+        // beside `memory` opens no connection until CACHE_STORE selects it.
       },
     }))
   }

--- a/packages/cli/templates/scaffold/oauth/app/Http/Controllers/Auth/OAuthController.ts
+++ b/packages/cli/templates/scaffold/oauth/app/Http/Controllers/Auth/OAuthController.ts
@@ -19,9 +19,9 @@ export default class OAuthController extends Controller {
     // attacker could authorize their own account, keep the `code` unconsumed,
     // and walk a visitor through the callback — logging that visitor into the
     // attacker's account.
-    // `?redirectTo=` is user input — the manager only keeps app-relative
-    // paths (or hosts allowlisted via stateConfig.allowedRedirectHosts).
     const { url } = await this.oauth().authorize(provider, {
+      // User input — the manager only keeps app-relative paths (or hosts
+      // allowlisted via stateConfig.allowedRedirectHosts).
       redirectTo: this.request.query('redirectTo'),
       session: this.auth.session(),
     })
@@ -37,17 +37,17 @@ export default class OAuthController extends Controller {
       return this.json({ error: 'Missing OAuth callback parameters.' }, { status: 400 })
     }
 
-    // Replace this with your own account linking: look the user up by
+    // Replace what follows with your own account linking: look the user up by
     // profile.email, create one when missing, then `await this.auth.login(user)`
-    // and finish with `return this.redirect(redirectTo ?? '/')` —
-    // `redirectTo` is already sanitized against open redirects. Refuse to
-    // create an account when `profile.emailVerified === false`: the provider
-    // is saying it never checked that the address belongs to this user.
+    // and finish with `return this.redirect(redirectTo ?? '/')` — `redirectTo`
+    // is already sanitized against open redirects.
     const { profile, redirectTo } = await this.oauth().handleCallback(provider, {
       code,
       state,
       session: this.auth.session(),
     })
+    // Refuse to create an account when `profile.emailVerified === false`: the
+    // provider is saying it never checked that the address belongs to this user.
     return this.json({ provider, profile, redirectTo }, { status: 200 })
   }
 

--- a/packages/cli/templates/scaffold/storage/app/Providers/StorageProvider.ts
+++ b/packages/cli/templates/scaffold/storage/app/Providers/StorageProvider.ts
@@ -7,21 +7,25 @@ import { ServiceProvider, createStorageManager } from '@guren/core'
 // throw (a required-env helper) out of it.
 const disks = {
   local: { driver: 'local', root: './storage/app' },
+
   // Declared public because it is: everything under it is served. A local
   // disk has no per-object visibility, so this is where that is decided.
   // Rooted inside public/ so the root asset server serves these files and
   // disk.url() returns a URL that actually resolves (images and the other
   // allowlisted extensions; add a route for anything else).
-  //
+
   // For assets you ship, then. Never for bytes someone uploaded: anything on
   // this disk is fetchable by URL with no signature, no expiry and no
-  // authorization check. The framework forces a download for document types
-  // served out of public/, so an uploaded .svg will not execute on your
-  // origin — but that is a backstop against one consequence, not access
-  // control, and inlineDocuments: true opts out of it. Uploads belong on
-  // `local` above, handed out through the attachments delivery route — which
-  // is what `guren add attachments` configures, and what `guren check`
-  // verifies.
+  // authorization check.
+
+  // The framework forces a download for document types served out of public/,
+  // so an uploaded .svg will not execute on your origin — but that is a
+  // backstop against one consequence, not access control, and
+  // inlineDocuments: true opts out of it.
+
+  // Uploads belong on `local` above, handed out through the attachments
+  // delivery route — which is what `guren add attachments` configures, and
+  // what `guren check` verifies.
   public: { driver: 'local', root: './public/storage', url: '/storage', visibility: 'public' },
 } as const
 

--- a/packages/cli/tests/oxlint-comments.test.ts
+++ b/packages/cli/tests/oxlint-comments.test.ts
@@ -24,6 +24,12 @@ describe('guren/comment-*', () => {
     expect(findings(`/**\n${' * l\n'.repeat(9)} */\nexport const a = 1\n`)).toEqual(['comment-length@1'])
   })
 
+  test('a hashbang does not take the module-header slot from the header under it', () => {
+    expect(findings(`#!/usr/bin/env bun\n/**\n${' * l\n'.repeat(8)} */\nexport const a = 1\n`)).toEqual([])
+    expect(findings(`#!/usr/bin/env bun\n${'// l\n'.repeat(8)}export const a = 1\n`)).toEqual([])
+    expect(findings(`#!/usr/bin/env bun\n/**\n${' * l\n'.repeat(9)} */\nexport const a = 1\n`)).toEqual(['comment-length@2'])
+  })
+
   test('adjacent line comments form one block; trailing comments never do', () => {
     expect(findings(`const z = 0\n${LONG}const a = 1\n`)).toEqual(['comment-length@2'])
     expect(findings(`const a = 1 // one\nconst b = 2 // two\nconst c = 3 // three\nconst d = 4 // four\nconst e = 5 // five\nconst f = 6 // six\n`)).toEqual([])

--- a/packages/create-app/templates/api-only/src/app.ts
+++ b/packages/create-app/templates/api-only/src/app.ts
@@ -3,13 +3,9 @@ import DatabaseProvider from '../app/Providers/DatabaseProvider.js'
 import { registerApiRoutes } from '../routes/api.js'
 
 // The Host header is client-controlled, so production should answer only to the
-// host this app is deployed as, which APP_URL carries.
-//
-// Read at module scope, where not every platform has populated process.env yet
-// (the Cloudflare worker imports this module before wrangler `vars` land). A
-// missing value therefore warns and leaves the check off, rather than throwing
-// and stopping the app from booting at all. Emailed links do not depend on this
-// — app/Auth/AppUrl.ts resolves those per request and fails closed there.
+// host this app is deployed as, which APP_URL carries. Emailed links do not
+// depend on this — app/Auth/AppUrl.ts resolves those per request and fails
+// closed there.
 function hostAuthorization() {
   const exclude = ['/health']
 
@@ -18,6 +14,10 @@ function hostAuthorization() {
   }
 
   const appUrl = process.env.APP_URL?.trim()
+  // Read at module scope, where not every platform has populated process.env yet
+  // (the Cloudflare worker imports this module before wrangler `vars` land), so a
+  // missing value warns and leaves the check off rather than throwing and
+  // stopping the app from booting at all.
   if (!appUrl) {
     console.warn('[app] APP_URL is not set — host authorization is disabled. Set it to the public base URL of this app.')
     return false

--- a/packages/create-app/templates/blog/app/Http/Controllers/PostController.ts
+++ b/packages/create-app/templates/blog/app/Http/Controllers/PostController.ts
@@ -28,15 +28,15 @@ export default class PostController extends Controller {
   // Serves the HTTP QUERY route `posts.search` — a safe read that carries its
   // criteria in a JSON body. Matches posts with any keyword in title or
   // excerpt; `%` and `_` in a keyword act as SQL LIKE wildcards, which this
-  // starter treats as a feature. All keyword OR pairs sit inside one
-  // `where(callback)`, keeping this an any-keyword match while AND filters
-  // added later (a published flag, tenancy) apply to every hit instead of
-  // being OR'd away.
+  // starter treats as a feature.
   async search(): Promise<Response> {
     const { keywords, limit } = await this.validateBody(PostSearchSchema)
 
     const posts = await Post.newQuery()
       .with('author')
+      // All keyword OR pairs sit inside one callback, keeping this an
+      // any-keyword match while AND filters added later (a published flag,
+      // tenancy) apply to every hit instead of being OR'd away.
       .where((q) => {
         for (const keyword of keywords) {
           const pattern = `%${keyword}%`

--- a/packages/create-app/templates/blog/app/Providers/AuthProvider.ts
+++ b/packages/create-app/templates/blog/app/Providers/AuthProvider.ts
@@ -13,11 +13,10 @@ export default class AuthProvider extends ServiceProvider {
     })
   }
 
+  // Nothing shares the signed-in user with the frontend by default, so every
+  // page would render as a guest. Layout.tsx reads this to choose between
+  // "Sign in" and the Write/Dashboard/Log out controls.
   boot(): void {
-    // Nothing shares the signed-in user with the frontend by default, so every
-    // page would render as a guest. Layout.tsx reads this to choose between
-    // "Sign in" and the Write/Dashboard/Log out controls.
-    //
     // shareInertiaProps merges over resolvers registered earlier instead of
     // replacing them, so the framework's flashed `errors` still come through.
     // Passing this.container scopes the props to this app.

--- a/packages/create-app/templates/blog/app/Providers/AuthorizationProvider.ts
+++ b/packages/create-app/templates/blog/app/Providers/AuthorizationProvider.ts
@@ -6,13 +6,12 @@ import { PostPolicy } from '../Policies/PostPolicy.js'
  * Maps models to their policies. `PostController` calls `this.authorize()` in
  * every mutating action, and without a registered policy the gate has nothing
  * to consult and denies them all.
- *
- * The framework's own provider creates the gate during registration, so this
- * runs in boot() — getGate() throws before that.
  */
 export default class AuthorizationProvider extends ServiceProvider {
   register(): void {}
 
+  // The framework's own provider creates the gate during registration, so this
+  // runs in boot() — getGate() throws before that.
   boot(): void {
     getGate().policy(Post, PostPolicy)
   }

--- a/packages/create-app/templates/blog/resources/js/pages/posts/Index.tsx
+++ b/packages/create-app/templates/blog/resources/js/pages/posts/Index.tsx
@@ -10,8 +10,9 @@ interface Props extends PaginatedPageProps<PostResourceData> {}
 
 // posts.search is an HTTP QUERY route (RFC 10008): safe like GET, but the
 // criteria travel in a JSON body — HTML forms and Inertia navigation cannot
-// send it, so the page calls it through the generated typed client. The
-// client types the request body from the schema bound to the route, and
+// send it, so the page calls it through the generated typed client.
+
+// The client types the request body from the schema bound to the route, and
 // json() from the `resource` hint the route declares — both come from the
 // route definition, so this file never restates the wire shape.
 const api = createApiClient<ApiRoutes>({ baseUrl: '' })

--- a/packages/create-app/templates/blog/routes/web.ts
+++ b/packages/create-app/templates/blog/routes/web.ts
@@ -34,13 +34,13 @@ export function registerWebRoutes(baseRouter: Router): void {
 
     // HTTP QUERY (RFC 10008): safe and idempotent like GET, but carries its
     // search criteria in a JSON body. Only fetch-based clients can send it —
-    // the posts page calls it through the generated API client. The
-    // `resource` hint declares the response shape the controller builds with
-    // PostResource, so the client's json() comes back typed — no runtime
-    // validation, just the type codegen already extracts from the Resource.
+    // the posts page calls it through the generated API client.
     posts.query('/search', {
       name: 'posts.search',
       body: PostSearchSchema,
+      // Declares the response shape the controller builds with PostResource, so
+      // the client's json() comes back typed — no runtime validation, just the
+      // type codegen already extracts from the Resource.
       resource: { data: [PostResource] },
     }, [PostController, 'search'])
   })

--- a/packages/create-app/templates/blog/src/app.ts
+++ b/packages/create-app/templates/blog/src/app.ts
@@ -18,13 +18,9 @@ setInertiaDocument({
 })
 
 // The Host header is client-controlled, so production should answer only to the
-// host this app is deployed as, which APP_URL carries.
-//
-// Read at module scope, where not every platform has populated process.env yet
-// (the Cloudflare worker imports this module before wrangler `vars` land). A
-// missing value therefore warns and leaves the check off, rather than throwing
-// and stopping the app from booting at all. Emailed links do not depend on this
-// — app/Auth/AppUrl.ts resolves those per request and fails closed there.
+// host this app is deployed as, which APP_URL carries. Emailed links do not
+// depend on this — app/Auth/AppUrl.ts resolves those per request and fails
+// closed there.
 function hostAuthorization() {
   const exclude = ['/health']
 
@@ -33,6 +29,10 @@ function hostAuthorization() {
   }
 
   const appUrl = process.env.APP_URL?.trim()
+  // Read at module scope, where not every platform has populated process.env yet
+  // (the Cloudflare worker imports this module before wrangler `vars` land), so a
+  // missing value warns and leaves the check off rather than throwing and
+  // stopping the app from booting at all.
   if (!appUrl) {
     console.warn('[app] APP_URL is not set — host authorization is disabled. Set it to the public base URL of this app.')
     return false

--- a/packages/create-app/templates/blog/tests/PostController.test.ts
+++ b/packages/create-app/templates/blog/tests/PostController.test.ts
@@ -2,13 +2,14 @@ import { beforeAll, describe, it } from 'bun:test'
 import { TestApp } from '@guren/testing'
 import app from '../src/app.js'
 
-// posts.search is an HTTP QUERY route (RFC 10008). Its controller validates
-// the body with validateBody() before building any query — the schema bound
-// to the route feeds codegen and `guren audit`, while body parsing stays in
-// the controller so the request stream is read once — so an invalid payload
-// gets a 422 without the database ever being touched. That keeps this starter
-// test green without migrations or fixtures; cover the happy path with real
-// feature tests once your test database is set up.
+// posts.search is an HTTP QUERY route (RFC 10008). Its controller validates the
+// body with validateBody() before building any query — the schema bound to the
+// route feeds codegen and `guren audit`, while body parsing stays in the
+// controller so the request stream is read once.
+
+// So an invalid payload gets a 422 without the database ever being touched,
+// which keeps this starter test green without migrations or fixtures. Cover the
+// happy path with real feature tests once your test database is set up.
 describe('posts.search', () => {
   let http: TestApp
 

--- a/packages/create-app/templates/database/sqlite/drizzle.config.ts
+++ b/packages/create-app/templates/database/sqlite/drizzle.config.ts
@@ -1,18 +1,14 @@
 import { defineConfig } from 'drizzle-kit'
 
+// Read by two different SQLite implementations that disagree about URI
+// filenames: the app opens it with `bun:sqlite`, which honours them, while
+// drizzle-kit opens it with `node:sqlite`, which does not. So `file:` is not a
+// shared spelling of anything — `file:local.db` migrates the app into
+// `local.db` and drizzle-kit into a file *named* `file:local.db`.
 const filename = process.env.DATABASE_URL || './data/guren.db'
 
-/**
- * DATABASE_URL is read by two different SQLite implementations that disagree
- * about URI filenames: the app opens it with `bun:sqlite`, which honours them,
- * while drizzle-kit opens it with `node:sqlite`, which does not. So `file:` is
- * not a shared spelling of anything — `file:local.db` migrates the app into
- * `local.db` and drizzle-kit into a file *named* `file:local.db`. The safe set
- * is what both agree on: plain paths, and `:memory:`.
- *
- * The scheme must be two characters or more, since no registered scheme is one
- * letter while `C:/data/app.db` is a Windows drive path.
- */
+// Two characters or more: no registered scheme is one letter, while
+// `C:/data/app.db` is a Windows drive path.
 const uriScheme = /^([a-z][a-z0-9+.-]+):/i.exec(filename)
 
 if (uriScheme) {

--- a/packages/create-app/templates/default/src/app.ts
+++ b/packages/create-app/templates/default/src/app.ts
@@ -17,13 +17,9 @@ setInertiaDocument({
 })
 
 // The Host header is client-controlled, so production should answer only to the
-// host this app is deployed as, which APP_URL carries.
-//
-// Read at module scope, where not every platform has populated process.env yet
-// (the Cloudflare worker imports this module before wrangler `vars` land). A
-// missing value therefore warns and leaves the check off, rather than throwing
-// and stopping the app from booting at all. Emailed links do not depend on this
-// — app/Auth/AppUrl.ts resolves those per request and fails closed there.
+// host this app is deployed as, which APP_URL carries. Emailed links do not
+// depend on this — app/Auth/AppUrl.ts resolves those per request and fails
+// closed there.
 function hostAuthorization() {
   const exclude = ['/health']
 
@@ -32,6 +28,10 @@ function hostAuthorization() {
   }
 
   const appUrl = process.env.APP_URL?.trim()
+  // Read at module scope, where not every platform has populated process.env yet
+  // (the Cloudflare worker imports this module before wrangler `vars` land), so a
+  // missing value warns and leaves the check off rather than throwing and
+  // stopping the app from booting at all.
   if (!appUrl) {
     console.warn('[app] APP_URL is not set — host authorization is disabled. Set it to the public base URL of this app.')
     return false


### PR DESCRIPTION
`.oxlintrc.json` turned all five `guren/comment-*` rules off for `packages/*/templates/**`, on the grounds that "audit:starter-template asserts their text literally". It does not — its eighteen assertions name `package.json` scripts, `@guren/core` imports and `interface Props`, never a comment. Meanwhile every app scaffolded from those templates enables the same five rules on itself, so the framework held its starter code to a looser standard than the code it generates: a freshly scaffolded app's first `bun run lint` reported twelve `guren/comment-length` warnings, all on framework-written files.

## What changed

- **The override is now one file wide.** `packages/*/templates/**` is gone, and with it `**/tests/fixtures/**` and `**/stubs/**`: those report nothing under any of the five rules, the comment-rule tests write their inputs to a temp dir rather than to a fixture, and the glob never covered `scripts/smoke/fixtures` anyway, so it was not the rule it read as.
- **`collectBlocks()` no longer hands the module-header slot to a hashbang.** oxc reports `#!/usr/bin/env bun` as a comment (`type: 'Shebang'`), so the JSDoc below it was held to the 5-line body limit while `.claude/rules/coding-standards.md` gives a module header 8. The three hook scripts `guren agent:init` installs are written that way. Keyed on the source text rather than on oxc's type name, since a scaffolded app pins `@guren/cli`, not the oxlint the plugin runs under.

## The one remaining hole, and it is user-visible

`packages/cli/templates/scaffold/session/config/session.ts` keeps a `guren/comment-length` exemption. #726 (RFC 0020 Part 5) rewrites that 11-line block into three, so trimming it here would only collide. **Until #726 lands, a user who runs `guren add session` gets one `guren/comment-length` warning on their own `bun run lint`** — this PR does not close that, it only stops the repo from hiding it. Deleting that entry is the follow-up, and lint proves when it is spent.

## Base

Stacked on `ff4fdfb0` — `fix(cli): keep scaffold and harness comments inside the length limit`, which fixes the 19 template files. **That commit is not on origin and has no PR of its own**, so the diff below includes work that belongs to that branch. If it is pushed and merged first, this branch fast-forwards cleanly; the SHA is identical.

## Verification

Baseline on a pristine tree (after `bun install` in this worktree): `bun run lint` exits 0.

| check | result |
|---|---|
| `bun run lint` | exit 0 |
| `bun run typecheck` | exit 0 (after codegen in `examples/blog` and `examples/agents`) |
| `bun run build:clean` | exit 0 |
| `bun run test:bun` | 7109 pass, 0 fail |
| `bun run audit:starter-template` | exit 0 |
| `bun run audit:docs` / `audit:core-first` | exit 0 |

Two things were checked by mutation rather than by a passing run:

- Lifting the session.ts entry too yields **exactly one** finding, `session.ts:4:1`, and nothing else — so the templates really are clean, not merely unlinted.
- Appending a banner, a step label, a 9-line block and "used to" to `templates/default/src/app.ts` fires `comment-length`, `comment-step-label` and `comment-history` on it. Before this PR that file was exempt.
- The new test case fails against the pre-fix `comments.js` (`comment-length@2` where `[]` is expected), and a shebang file whose first comment sits *below* the first import fires identically before and after — the hashbang change is a pure relaxation.

`bun run test:bun`: 7109 pass, 0 fail across 416 files, exit 0. (Its first run hit the known Bun 1.3.14 macOS segfault before printing summaries; a re-run went through.)
