### PR TITLE
fix(orm): keep global scopes out of a top-level orWhere fold

### DIFF
--- a/.changeset/global-scope-orwhere-fold.md
+++ b/.changeset/global-scope-orwhere-fold.md
@@ -1,0 +1,9 @@
+---
+"@guren/orm": patch
+---
+
+**A top-level `orWhere()` no longer folds a model's global scopes into the OR** — `Model.newQuery()` appended every global scope, `SoftDeletes` included, to the same flat condition list the caller's `where()` and `orWhere()` push onto, and an or-group folds everything before it into its left arm. A documented chain such as `Post.where('status', 'published').orWhere('excerpt', 'like', pattern)` therefore ran as `(scope AND status) OR excerpt`, and any row matching the OR arm came back with the scope dropped: another tenant's records for a `tenant` scope, trashed records for `softDelete`. The folded list reached `count()` (so `paginate()`'s `meta.total` confirmed the leaked rows), `updateAdvanced` and `deleteAdvanced`, so a bulk action behind the same builder shape reached and rewrote those rows too.
+
+Global scopes are now sealed when the query is created and AND-ed around the caller's expression, whatever the caller chains afterwards. `withoutGlobalScope()` and `withoutGlobalScopes()` are unchanged, and a scope registered through `static scopes` stays a caller-level filter as before.
+
+**Unfiltered writes from an all-`undefined` where clause are refused** — a criteria object whose every value was `undefined` produced no `WHERE` clause and the statement reached every row, so `Model.delete({ id: undefined })` emptied the table and `Model.update({ id: undefined }, data)` rewrote it. `update` and `delete` now throw when every filter the caller wrote was dropped; an explicitly empty `{}` and a deliberately unfiltered builder still mean "no filter", and an optional filter set keeps working as long as one value survives. `Model.find(undefined)` returns `null` instead of an arbitrary row, so `findOrFail(undefined)` throws `ModelNotFoundException` as documented (`null` is untouched: it renders `IS NULL`).

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -8,7 +8,7 @@ import type { ModelHooks } from './hooks'
 import { executeObservers } from './ModelObserver'
 import type { ModelObserver, ModelObserverConstructor } from './ModelObserver'
 import { ModelNotFoundException } from './ModelNotFoundException'
-import { QueryBuilder, PREPARED_UPDATE } from './QueryBuilder'
+import { QueryBuilder, PREPARED_UPDATE, SEAL_SCOPES } from './QueryBuilder'
 import type {
   EagerLoadConstraint,
   EagerLoadConstraints,
@@ -326,7 +326,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
       this.defaultScope(builder)
     }
     this.getGlobalScopes().apply(builder, names)
-    return builder
+    return builder[SEAL_SCOPES]()
   }
 
   /** A query with no global scopes applied, `defaultScope` included. */
@@ -535,6 +535,12 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     key: keyof TRecordFor<T> & string = 'id' as keyof TRecordFor<T> & string,
     queryOptions?: ModelQueryOptions,
   ): Promise<TRecordFor<T> | null> {
+    // An undefined identifier renders no WHERE clause at all, which would make
+    // `find` return an arbitrary row and `findOrFail` never throw. `null` is
+    // left alone: it renders `IS NULL`, which is a filter.
+    if (id === undefined) {
+      return null
+    }
     if (this.hasScopes()) {
       return this.newQuery(queryOptions).where(key, id as TRecordFor<T>[typeof key]).first()
     }
@@ -725,7 +731,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     if (registry && registry.size > 0) {
       registry.apply(builder)
     }
-    return builder
+    return builder[SEAL_SCOPES]()
   }
 
   /** No scopes applied — for soft-deleted records or bypassing global filters. */

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -8,6 +8,7 @@ import type { ModelHooks } from './hooks'
 import { executeObservers } from './ModelObserver'
 import type { ModelObserver, ModelObserverConstructor } from './ModelObserver'
 import { ModelNotFoundException } from './ModelNotFoundException'
+import { everyFilterDropped } from './where-conditions'
 import { QueryBuilder, PREPARED_UPDATE, SEAL_SCOPES } from './QueryBuilder'
 import type {
   EagerLoadConstraint,
@@ -321,17 +322,24 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
    * register a named scope and nothing else.
    */
   static withoutGlobalScope<T extends typeof Model>(this: T, ...names: string[]): QueryBuilder<TRecordFor<T>> {
-    const builder = new QueryBuilder<TRecordFor<T>>(this)
-    if (this.defaultScope) {
-      this.defaultScope(builder)
-    }
-    this.getGlobalScopes().apply(builder, names)
-    return builder[SEAL_SCOPES]()
+    return this.buildScopedQuery(undefined, names)
   }
 
   /** A query with no global scopes applied, `defaultScope` included. */
   static withoutGlobalScopes<T extends typeof Model>(this: T): QueryBuilder<TRecordFor<T>> {
     return new QueryBuilder<TRecordFor<T>>(this)
+  }
+
+  /**
+   * Both write entry points fork on `hasScopes()`, and only one arm reaches a
+   * builder — so the refusal belongs above the fork, where every adapter is
+   * still in scope.
+   */
+  private static assertFiltersSurvived(where: unknown, operation: 'update' | 'delete'): void {
+    if (!everyFilterDropped(where)) return
+    throw new Error(
+      `${this.name}: refusing to ${operation} unfiltered — every value in the where clause was undefined.`,
+    )
   }
 
   /** Applies hidden/visible filtering, accessors and appends. */
@@ -535,9 +543,8 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     key: keyof TRecordFor<T> & string = 'id' as keyof TRecordFor<T> & string,
     queryOptions?: ModelQueryOptions,
   ): Promise<TRecordFor<T> | null> {
-    // An undefined identifier renders no WHERE clause at all, which would make
-    // `find` return an arbitrary row and `findOrFail` never throw. `null` is
-    // left alone: it renders `IS NULL`, which is a filter.
+    // An undefined identifier renders no WHERE clause at all, so `find` would
+    // return an arbitrary row. `null` is left alone: it renders `IS NULL`.
     if (id === undefined) {
       return null
     }
@@ -631,6 +638,11 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     where?: WhereClauseFor<T>,
     queryOptions?: ModelQueryOptions,
   ): Promise<TRecordFor<T> | null> {
+    // Same contract as find(); the scoped arm below never reaches
+    // QueryBuilder.first(), which carries this rule for builder chains.
+    if (everyFilterDropped(where)) {
+      return null
+    }
     if (this.hasScopes()) {
       const builder = this.newQuery(queryOptions).limit(1)
       if (where) {
@@ -723,13 +735,26 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
   }
 
   static newQuery<T extends typeof Model>(this: T, queryOptions?: ModelQueryOptions): QueryBuilder<TRecordFor<T>> {
+    return this.buildScopedQuery(queryOptions)
+  }
+
+  /**
+   * The one place a scoped builder is born: applying scopes without sealing
+   * them leaves them foldable by a later `orWhere()`, and nothing else would
+   * report it. `except` names the global scopes to leave off.
+   */
+  private static buildScopedQuery<T extends typeof Model>(
+    this: T,
+    queryOptions?: ModelQueryOptions,
+    except?: string[],
+  ): QueryBuilder<TRecordFor<T>> {
     const builder = new QueryBuilder<TRecordFor<T>>(this, queryOptions)
     if (this.defaultScope) {
       this.defaultScope(builder)
     }
     const registry = this.globalScopeRegistry
     if (registry && registry.size > 0) {
-      registry.apply(builder)
+      registry.apply(builder, except)
     }
     return builder[SEAL_SCOPES]()
   }
@@ -1191,6 +1216,7 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     if (!adapter.update) {
       throw new Error('Configured adapter does not support update operations.')
     }
+    this.assertFiltersSurvived(where, 'update')
 
     const filtered = applyFillable ? this.filterFillable(data) : { ...(data as PlainObject) }
     const payload = await this.preparePersistencePayload(filtered)
@@ -1251,6 +1277,8 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
     if (!adapter.delete) {
       throw new Error('Configured adapter does not support delete operations.')
     }
+
+    this.assertFiltersSurvived(where, 'delete')
 
     const hooks = this.hooks
     const observers = this.observers

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -21,6 +21,12 @@ type FieldKey<TRecord extends PlainObject> = keyof TRecord & string
  */
 export const PREPARED_UPDATE = Symbol('guren.orm.preparedUpdate')
 
+/**
+ * Key for the global-scope seal. Exported for `Model` across the module
+ * boundary, but kept out of the package entry point.
+ */
+export const SEAL_SCOPES = Symbol('guren.orm.sealScopes')
+
 export type WhereOperator = '=' | '!=' | '>' | '<' | '>=' | '<=' | 'like' | 'in' | 'not in' | 'is null' | 'is not null'
 
 export interface SimpleCondition {
@@ -79,6 +85,8 @@ export class QueryBuilder<
   TResult extends PlainObject = TRecord,
 > {
   private conditions: WhereCondition[] = []
+  private scopeConditions: WhereCondition[] = []
+  private droppedUndefinedFilters = false
   private options: QueryBuilderOptions = { orderBy: [] }
   private modelClass: typeof Model
   private table: unknown
@@ -114,10 +122,12 @@ export class QueryBuilder<
 
     if (typeof fieldOrConditions === 'object' && fieldOrConditions !== null) {
       for (const [key, val] of Object.entries(fieldOrConditions)) {
-        if (val !== undefined) {
-          // Array values mean IN — mirrors the adapter's object-where contract
-          this.addSimpleCondition(key, Array.isArray(val) ? 'in' : '=', val)
+        if (val === undefined) {
+          this.droppedUndefinedFilters = true
+          continue
         }
+        // Array values mean IN — mirrors the adapter's object-where contract
+        this.addSimpleCondition(key, Array.isArray(val) ? 'in' : '=', val)
       }
       return this
     }
@@ -155,9 +165,11 @@ export class QueryBuilder<
 
     if (typeof fieldOrConditions === 'object' && fieldOrConditions !== null) {
       for (const [key, val] of Object.entries(fieldOrConditions)) {
-        if (val !== undefined) {
-          orConditions.push({ type: 'simple', field: key, operator: Array.isArray(val) ? 'in' : '=', value: val })
+        if (val === undefined) {
+          this.droppedUndefinedFilters = true
+          continue
         }
+        orConditions.push({ type: 'simple', field: key, operator: Array.isArray(val) ? 'in' : '=', value: val })
       }
     } else {
       const field = fieldOrConditions as string
@@ -278,13 +290,13 @@ export class QueryBuilder<
   }
 
   async count(): Promise<number> {
-    if (typeof this.adapter.count === 'function' && this.conditions.length === 0) {
+    if (typeof this.adapter.count === 'function' && this.allConditions().length === 0) {
       return this.adapter.count(this.table, undefined, { trx: this.options.trx })
     }
 
     const advancedAdapter = this.adapter as ORMAdapterAdvanced
     if (typeof advancedAdapter.countAdvanced === 'function') {
-      return advancedAdapter.countAdvanced(this.table, this.conditions, { trx: this.options.trx })
+      return advancedAdapter.countAdvanced(this.table, this.effectiveConditions(), { trx: this.options.trx })
     }
 
     const results = await this.executeQuery()
@@ -376,10 +388,11 @@ export class QueryBuilder<
     if (!this.adapter.update) {
       throw new Error('Configured adapter does not support update operations.')
     }
+    this.assertFiltersSurvived('update')
 
     const advancedAdapter = this.adapter as ORMAdapterAdvanced
     if (typeof advancedAdapter.updateAdvanced === 'function') {
-      return advancedAdapter.updateAdvanced(this.table, this.conditions, payload, { trx: this.options.trx }) as Promise<TRecord>
+      return advancedAdapter.updateAdvanced(this.table, this.effectiveConditions(), payload, { trx: this.options.trx }) as Promise<TRecord>
     }
 
     const simpleWhere = this.toSimpleWhereClause()
@@ -394,10 +407,11 @@ export class QueryBuilder<
     if (!this.adapter.delete) {
       throw new Error('Configured adapter does not support delete operations.')
     }
+    this.assertFiltersSurvived('delete')
 
     const advancedAdapter = this.adapter as ORMAdapterAdvanced
     if (typeof advancedAdapter.deleteAdvanced === 'function') {
-      return advancedAdapter.deleteAdvanced(this.table, this.conditions, { trx: this.options.trx })
+      return advancedAdapter.deleteAdvanced(this.table, this.effectiveConditions(), { trx: this.options.trx })
     }
 
     const simpleWhere = this.toSimpleWhereClause()
@@ -423,7 +437,22 @@ export class QueryBuilder<
   }
 
   getConditions(): WhereCondition[] {
-    return this.conditions
+    return this.effectiveConditions()
+  }
+
+  /**
+   * Freezes the conditions applied so far as this model's global scopes.
+   * They are AND-ed around the caller's expression from here on: left in the
+   * same list, a top-level `orWhere()` folds everything before it into the
+   * OR's left arm (see `normalizeConditionSequence`) and the query loses
+   * tenant isolation and soft-delete filtering.
+   */
+  [SEAL_SCOPES](): this {
+    if (this.conditions.length > 0) {
+      this.scopeConditions.push(...this.conditions)
+      this.conditions = []
+    }
+    return this
   }
 
   getOptions(): QueryBuilderOptions {
@@ -448,6 +477,38 @@ export class QueryBuilder<
     this.conditions.push(needsWrap ? { type: 'group', boolean, conditions: [grouped] } : grouped)
   }
 
+  /** Every condition on the builder, scopes first, as one flat list. */
+  private allConditions(): WhereCondition[] {
+    return this.scopeConditions.length === 0 ? this.conditions : [...this.scopeConditions, ...this.conditions]
+  }
+
+  /** Global scopes AND the caller's expression, never folded into it. */
+  private effectiveConditions(): WhereCondition[] {
+    if (this.scopeConditions.length === 0) return this.conditions
+    const caller = normalizeConditionSequence(this.conditions)
+    if (!caller) return [...this.scopeConditions]
+    // An or-group node means two things by position (see pushCallbackGroup):
+    // at the head of a list it reads as an orWhere continuation and would fold
+    // the scopes back in. Wrapping selects the parenthesized reading.
+    const guarded: WhereCondition = caller.type === 'group' && caller.boolean === 'or'
+      ? { type: 'group', boolean: 'and', conditions: [caller] }
+      : caller
+    return [...this.scopeConditions, guarded]
+  }
+
+  /**
+   * A criteria object whose every value was `undefined` leaves no caller
+   * condition at all, and the write then rewrites every row the scopes admit.
+   * `where({})` and a deliberately unfiltered builder are untouched: only a
+   * filter the caller wrote and lost counts.
+   */
+  private assertFiltersSurvived(operation: 'update' | 'delete'): void {
+    if (!this.droppedUndefinedFilters || this.conditions.length > 0) return
+    throw new Error(
+      `${this.modelClass.name}: refusing to ${operation} unfiltered — every value in the where clause was undefined.`,
+    )
+  }
+
   private addSimpleCondition(field: string, operator: WhereOperator, value: unknown): void {
     this.conditions.push({
       type: 'simple',
@@ -461,7 +522,7 @@ export class QueryBuilder<
     const advancedAdapter = this.adapter as ORMAdapterAdvanced
 
     if (typeof advancedAdapter.findManyAdvanced === 'function') {
-      return advancedAdapter.findManyAdvanced<TResult>(this.table, this.conditions, {
+      return advancedAdapter.findManyAdvanced<TResult>(this.table, this.effectiveConditions(), {
         orderBy: this.options.orderBy.length > 0 ? (this.options.orderBy as OrderByClause) : undefined,
         limit: this.options.limitValue,
         offset: this.options.offsetValue,
@@ -472,7 +533,7 @@ export class QueryBuilder<
     // Passing a null conversion on as `where: undefined` would drop every
     // condition — global scopes included — and return the whole table.
     const simpleWhere = this.toSimpleWhereClause()
-    if (simpleWhere === null && this.conditions.length > 0) {
+    if (simpleWhere === null && this.allConditions().length > 0) {
       throw new Error(
         `${this.modelClass.name}: this query uses conditions the configured adapter cannot express `
         + `(it implements neither findManyAdvanced nor countAdvanced). Running it would drop every `
@@ -489,13 +550,14 @@ export class QueryBuilder<
 
   /** Null when the conditions are too complex for a basic adapter's WhereClause. */
   private toSimpleWhereClause(): Record<string, unknown> | null {
-    if (this.conditions.length === 0) {
+    const conditions = this.allConditions()
+    if (conditions.length === 0) {
       return null
     }
 
     const result: Record<string, unknown> = {}
 
-    for (const condition of this.conditions) {
+    for (const condition of conditions) {
       if (condition.type !== 'simple') {
         return null // Cannot convert OR groups to simple where
       }

--- a/packages/orm/src/QueryBuilder.ts
+++ b/packages/orm/src/QueryBuilder.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_PAGINATION_SIZE } from './Model'
 import { ModelNotFoundException } from './ModelNotFoundException'
-import { normalizeConditionSequence } from './where-conditions'
+import { groupConditionSequence } from './where-conditions'
 import type {
   AdapterQueryOptions,
   FindManyOptions,
@@ -86,6 +86,7 @@ export class QueryBuilder<
 > {
   private conditions: WhereCondition[] = []
   private scopeConditions: WhereCondition[] = []
+  /** Fold this up wherever a nested builder's conditions are (pushCallbackGroup). */
   private droppedUndefinedFilters = false
   private options: QueryBuilderOptions = { orderBy: [] }
   private modelClass: typeof Model
@@ -121,14 +122,7 @@ export class QueryBuilder<
     }
 
     if (typeof fieldOrConditions === 'object' && fieldOrConditions !== null) {
-      for (const [key, val] of Object.entries(fieldOrConditions)) {
-        if (val === undefined) {
-          this.droppedUndefinedFilters = true
-          continue
-        }
-        // Array values mean IN — mirrors the adapter's object-where contract
-        this.addSimpleCondition(key, Array.isArray(val) ? 'in' : '=', val)
-      }
+      this.conditions.push(...this.simpleConditionsFrom(fieldOrConditions))
       return this
     }
 
@@ -164,13 +158,7 @@ export class QueryBuilder<
     const orConditions: SimpleCondition[] = []
 
     if (typeof fieldOrConditions === 'object' && fieldOrConditions !== null) {
-      for (const [key, val] of Object.entries(fieldOrConditions)) {
-        if (val === undefined) {
-          this.droppedUndefinedFilters = true
-          continue
-        }
-        orConditions.push({ type: 'simple', field: key, operator: Array.isArray(val) ? 'in' : '=', value: val })
-      }
+      orConditions.push(...this.simpleConditionsFrom(fieldOrConditions))
     } else {
       const field = fieldOrConditions as string
 
@@ -270,6 +258,9 @@ export class QueryBuilder<
   }
 
   async first(): Promise<TResult | null> {
+    // Same contract as Model.find(): an evaporated filter would hand back an
+    // arbitrary row rather than the "no match" the caller asked about.
+    if (this.filtersEvaporated()) return null
     const prev = this.options.limitValue
     this.options.limitValue = 1
     try {
@@ -290,7 +281,7 @@ export class QueryBuilder<
   }
 
   async count(): Promise<number> {
-    if (typeof this.adapter.count === 'function' && this.allConditions().length === 0) {
+    if (typeof this.adapter.count === 'function' && !this.hasConditions()) {
       return this.adapter.count(this.table, undefined, { trx: this.options.trx })
     }
 
@@ -441,17 +432,15 @@ export class QueryBuilder<
   }
 
   /**
-   * Freezes the conditions applied so far as this model's global scopes.
-   * They are AND-ed around the caller's expression from here on: left in the
-   * same list, a top-level `orWhere()` folds everything before it into the
-   * OR's left arm (see `normalizeConditionSequence`) and the query loses
-   * tenant isolation and soft-delete filtering.
+   * Freezes the conditions applied so far as this model's global scopes, to be
+   * AND-ed around the caller's expression from here on. Left in the same list,
+   * a top-level `orWhere()` folds them into its left arm (see
+   * `normalizeConditionSequence`) and the query loses tenant isolation and
+   * soft-delete filtering.
    */
   [SEAL_SCOPES](): this {
-    if (this.conditions.length > 0) {
-      this.scopeConditions.push(...this.conditions)
-      this.conditions = []
-    }
+    this.scopeConditions.push(...this.conditions)
+    this.conditions = []
     return this
   }
 
@@ -467,17 +456,31 @@ export class QueryBuilder<
   private pushCallbackGroup(callback: WhereGroupCallback<TRecord>, boolean: 'and' | 'or'): void {
     const nested = new QueryBuilder<TRecord>(this.modelClass, { trx: this.options.trx })
     callback(nested)
-    const grouped = normalizeConditionSequence(nested.conditions)
-    if (!grouped) return
-
-    // An or-group node means two things by position: in member position a
-    // parenthesized disjunction, at the top level an orWhere continuation that
-    // folds the preceding conditions in. Wrapping selects the first reading.
-    const needsWrap = boolean === 'or' || (grouped.type === 'group' && grouped.boolean === 'or')
-    this.conditions.push(needsWrap ? { type: 'group', boolean, conditions: [grouped] } : grouped)
+    // The flag has to outlive the nested builder: a group whose every filter
+    // evaporated pushes no node at all, and the write guard would see nothing.
+    this.droppedUndefinedFilters ||= nested.droppedUndefinedFilters
+    const grouped = groupConditionSequence(nested.conditions, boolean)
+    if (grouped) this.conditions.push(grouped)
   }
 
-  /** Every condition on the builder, scopes first, as one flat list. */
+  private simpleConditionsFrom(criteria: Record<string, unknown>): SimpleCondition[] {
+    const conditions: SimpleCondition[] = []
+    for (const [field, value] of Object.entries(criteria)) {
+      if (value === undefined) {
+        this.droppedUndefinedFilters = true
+        continue
+      }
+      // Array values mean IN — mirrors the adapter's object-where contract
+      conditions.push({ type: 'simple', field, operator: Array.isArray(value) ? 'in' : '=', value })
+    }
+    return conditions
+  }
+
+  private hasConditions(): boolean {
+    return this.scopeConditions.length > 0 || this.conditions.length > 0
+  }
+
+  /** Flat list, for the basic-adapter conversion that cannot read group nodes. */
   private allConditions(): WhereCondition[] {
     return this.scopeConditions.length === 0 ? this.conditions : [...this.scopeConditions, ...this.conditions]
   }
@@ -485,25 +488,20 @@ export class QueryBuilder<
   /** Global scopes AND the caller's expression, never folded into it. */
   private effectiveConditions(): WhereCondition[] {
     if (this.scopeConditions.length === 0) return this.conditions
-    const caller = normalizeConditionSequence(this.conditions)
-    if (!caller) return [...this.scopeConditions]
-    // An or-group node means two things by position (see pushCallbackGroup):
-    // at the head of a list it reads as an orWhere continuation and would fold
-    // the scopes back in. Wrapping selects the parenthesized reading.
-    const guarded: WhereCondition = caller.type === 'group' && caller.boolean === 'or'
-      ? { type: 'group', boolean: 'and', conditions: [caller] }
-      : caller
-    return [...this.scopeConditions, guarded]
+    const caller = groupConditionSequence(this.conditions)
+    return caller ? [...this.scopeConditions, caller] : [...this.scopeConditions]
   }
 
   /**
-   * A criteria object whose every value was `undefined` leaves no caller
-   * condition at all, and the write then rewrites every row the scopes admit.
    * `where({})` and a deliberately unfiltered builder are untouched: only a
-   * filter the caller wrote and lost counts.
+   * filter the caller wrote and then lost counts.
    */
+  private filtersEvaporated(): boolean {
+    return this.droppedUndefinedFilters && this.conditions.length === 0
+  }
+
   private assertFiltersSurvived(operation: 'update' | 'delete'): void {
-    if (!this.droppedUndefinedFilters || this.conditions.length > 0) return
+    if (!this.filtersEvaporated()) return
     throw new Error(
       `${this.modelClass.name}: refusing to ${operation} unfiltered — every value in the where clause was undefined.`,
     )
@@ -533,7 +531,7 @@ export class QueryBuilder<
     // Passing a null conversion on as `where: undefined` would drop every
     // condition — global scopes included — and return the whole table.
     const simpleWhere = this.toSimpleWhereClause()
-    if (simpleWhere === null && this.allConditions().length > 0) {
+    if (simpleWhere === null && this.hasConditions()) {
       throw new Error(
         `${this.modelClass.name}: this query uses conditions the configured adapter cannot express `
         + `(it implements neither findManyAdvanced nor countAdvanced). Running it would drop every `

--- a/packages/orm/src/adapters/drizzle-adapter.ts
+++ b/packages/orm/src/adapters/drizzle-adapter.ts
@@ -81,20 +81,6 @@ async function resolveList(result: DrizzleLikeSelect): Promise<unknown[]> {
 
 type DrizzleTableLike = Record<string, unknown>
 
-/**
- * An all-undefined criteria object renders no WHERE clause, and the write then
- * reaches every row. An explicitly empty `{}` still means "no filter", so only
- * a criteria object that carried keys is refused.
- */
-function assertFiltersSurvived(where: WhereClause | undefined, operation: 'update' | 'delete'): void {
-  if (!where || typeof where !== 'object') return
-  const values = Object.values(where)
-  if (values.length === 0 || values.some((value) => value !== undefined)) return
-  throw new Error(
-    `DrizzleAdapter: refusing to ${operation} unfiltered — every value in the where clause was undefined.`,
-  )
-}
-
 function resolveWhere(table: unknown, where?: WhereClause): unknown {
   if (!where || typeof where !== 'object') {
     return where
@@ -321,7 +307,6 @@ export const DrizzleAdapter: ORMAdapterAdvanced & {
     if (!db.update) {
       throw new Error('DrizzleAdapter: configured database does not support updates.')
     }
-    assertFiltersSurvived(where, 'update')
 
     const clause = resolveWhere(table, where)
     const finalQuery = clause ? db.update(table).set(data).where(clause) : db.update(table).set(data)
@@ -340,7 +325,6 @@ export const DrizzleAdapter: ORMAdapterAdvanced & {
     if (!db.delete) {
       throw new Error('DrizzleAdapter: configured database does not support deletes.')
     }
-    assertFiltersSurvived(where, 'delete')
 
     const clause = resolveWhere(table, where)
     const finalQuery = clause ? db.delete(table).where(clause) : db.delete(table)

--- a/packages/orm/src/adapters/drizzle-adapter.ts
+++ b/packages/orm/src/adapters/drizzle-adapter.ts
@@ -81,6 +81,20 @@ async function resolveList(result: DrizzleLikeSelect): Promise<unknown[]> {
 
 type DrizzleTableLike = Record<string, unknown>
 
+/**
+ * An all-undefined criteria object renders no WHERE clause, and the write then
+ * reaches every row. An explicitly empty `{}` still means "no filter", so only
+ * a criteria object that carried keys is refused.
+ */
+function assertFiltersSurvived(where: WhereClause | undefined, operation: 'update' | 'delete'): void {
+  if (!where || typeof where !== 'object') return
+  const values = Object.values(where)
+  if (values.length === 0 || values.some((value) => value !== undefined)) return
+  throw new Error(
+    `DrizzleAdapter: refusing to ${operation} unfiltered — every value in the where clause was undefined.`,
+  )
+}
+
 function resolveWhere(table: unknown, where?: WhereClause): unknown {
   if (!where || typeof where !== 'object') {
     return where
@@ -307,6 +321,7 @@ export const DrizzleAdapter: ORMAdapterAdvanced & {
     if (!db.update) {
       throw new Error('DrizzleAdapter: configured database does not support updates.')
     }
+    assertFiltersSurvived(where, 'update')
 
     const clause = resolveWhere(table, where)
     const finalQuery = clause ? db.update(table).set(data).where(clause) : db.update(table).set(data)
@@ -325,6 +340,7 @@ export const DrizzleAdapter: ORMAdapterAdvanced & {
     if (!db.delete) {
       throw new Error('DrizzleAdapter: configured database does not support deletes.')
     }
+    assertFiltersSurvived(where, 'delete')
 
     const clause = resolveWhere(table, where)
     const finalQuery = clause ? db.delete(table).where(clause) : db.delete(table)

--- a/packages/orm/src/where-conditions.ts
+++ b/packages/orm/src/where-conditions.ts
@@ -1,6 +1,17 @@
 import type { WhereCondition } from './QueryBuilder'
 
 /**
+ * True when the caller wrote filters and every one of them was `undefined`.
+ * Such a criteria object renders no WHERE clause at all, so the query reaches
+ * every row; an explicitly empty `{}` still means "no filter" and is false.
+ */
+export function everyFilterDropped(where: unknown): boolean {
+  if (!where || typeof where !== 'object') return false
+  const values = Object.values(where as Record<string, unknown>)
+  return values.length > 0 && values.every((value) => value === undefined)
+}
+
+/**
  * Folds a builder's condition list into one node, or null when it holds
  * nothing renderable. An OR group folds everything before it into the OR, so
  * `.where(a).where(b).orWhere(c)` reads `(a AND b) OR c`. The one
@@ -21,6 +32,21 @@ export function normalizeConditionSequence(conditions: WhereCondition[]): WhereC
   }
 
   return combine('and', pending)
+}
+
+/**
+ * Folds a list and makes the result safe to splice into another list. An
+ * or-group means two things by position: a parenthesized disjunction in member
+ * position, an orWhere continuation at the head. Wrapping selects the first.
+ */
+export function groupConditionSequence(
+  conditions: WhereCondition[],
+  boolean: 'and' | 'or' = 'and',
+): WhereCondition | null {
+  const folded = normalizeConditionSequence(conditions)
+  if (!folded) return null
+  const needsWrap = boolean === 'or' || (folded.type === 'group' && folded.boolean === 'or')
+  return needsWrap ? { type: 'group', boolean, conditions: [folded] } : folded
 }
 
 function combine(boolean: 'and' | 'or', parts: WhereCondition[]): WhereCondition | null {

--- a/packages/orm/tests/unfiltered-write-sqlite.test.ts
+++ b/packages/orm/tests/unfiltered-write-sqlite.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { drizzle } from 'drizzle-orm/bun-sqlite'
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { Model } from '../src/Model'
+import { ModelNotFoundException } from '../src/ModelNotFoundException'
+import { DrizzleAdapter } from '../src/adapters/drizzle-adapter'
+
+// A criteria object whose every value is `undefined` renders no WHERE clause,
+// so the query reaches every row. Verified against the real driver because the
+// fallthrough only exists once Drizzle has built the statement.
+
+const postsTable = sqliteTable('posts', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  title: text('title').notNull(),
+  published: integer('published', { mode: 'boolean' }).notNull(),
+})
+
+type PostRecord = typeof postsTable.$inferSelect
+
+describe('unfiltered write guard on real bun:sqlite driver', () => {
+  let sqlite: Database
+
+  class Post extends Model<PostRecord> {
+    static override table = postsTable
+  }
+
+  class ScopedPost extends Model<PostRecord> {
+    static override table = postsTable
+    static {
+      this.addGlobalScope('publishedOnly', (q) => q.where('published', true))
+    }
+  }
+
+  const rowCount = (): number =>
+    sqlite.query<{ n: number }, []>('SELECT count(*) AS n FROM posts').get()?.n ?? -1
+
+  beforeEach(() => {
+    sqlite = new Database(':memory:')
+    sqlite.exec(`
+      CREATE TABLE posts (
+        id integer primary key autoincrement,
+        title text not null,
+        published integer not null
+      );
+      INSERT INTO posts (title, published) VALUES ('First', 1), ('Second', 1), ('Draft', 0);
+    `)
+    DrizzleAdapter.configure(drizzle({ client: sqlite }) as never)
+  })
+
+  afterEach(() => {
+    sqlite.close()
+  })
+
+  it('should return null from find() for an undefined identifier', async () => {
+    expect(await Post.find(undefined as never)).toBeNull()
+  })
+
+  it('should throw ModelNotFoundException from findOrFail() for an undefined identifier', async () => {
+    await expect(Post.findOrFail(undefined as never)).rejects.toThrow(ModelNotFoundException)
+  })
+
+  it('should refuse a delete whose only filter was undefined', async () => {
+    await expect(Post.delete({ id: undefined })).rejects.toThrow(/refusing to delete unfiltered/)
+    expect(rowCount()).toBe(3)
+  })
+
+  it('should refuse an update whose only filter was undefined', async () => {
+    await expect(Post.update({ id: undefined }, { title: 'pwned' })).rejects.toThrow(/refusing to update unfiltered/)
+    const renamed = sqlite.query<{ n: number }, []>("SELECT count(*) AS n FROM posts WHERE title = 'pwned'").get()
+    expect(renamed?.n).toBe(0)
+  })
+
+  it('should refuse a scoped builder delete whose only filter was undefined', async () => {
+    await expect(ScopedPost.newQuery().where({ id: undefined }).delete()).rejects.toThrow(
+      /refusing to delete unfiltered/,
+    )
+    expect(rowCount()).toBe(3)
+  })
+
+  it('should still run when one filter of an optional set survives', async () => {
+    await Post.newQuery().where({ published: true, title: undefined }).delete()
+
+    const rows = sqlite.query<{ title: string }, []>('SELECT title FROM posts').all()
+    expect(rows.map((r) => r.title)).toEqual(['Draft'])
+  })
+
+  it('should still allow a deliberately unfiltered builder delete', async () => {
+    await Post.newQuery().delete()
+    expect(rowCount()).toBe(0)
+  })
+})

--- a/packages/orm/tests/unfiltered-write-sqlite.test.ts
+++ b/packages/orm/tests/unfiltered-write-sqlite.test.ts
@@ -78,6 +78,25 @@ describe('unfiltered write guard on real bun:sqlite driver', () => {
     expect(rowCount()).toBe(3)
   })
 
+  it('should refuse a delete whose only filter was undefined inside a group', async () => {
+    await expect(
+      Post.newQuery().where((q) => q.where({ id: undefined })).delete(),
+    ).rejects.toThrow(/refusing to delete unfiltered/)
+    expect(rowCount()).toBe(3)
+  })
+
+  it('should return null from first() when every filter was undefined', async () => {
+    expect(await Post.first({ title: undefined })).toBeNull()
+    expect(await ScopedPost.first({ title: undefined })).toBeNull()
+  })
+
+  it('should agree with Model.first() when the same query is spelled on a builder', async () => {
+    expect(await Post.newQuery().where({ title: undefined }).first()).toBeNull()
+    await expect(Post.newQuery().where({ title: undefined }).firstOrFail()).rejects.toThrow(
+      ModelNotFoundException,
+    )
+  })
+
   it('should still run when one filter of an optional set survives', async () => {
     await Post.newQuery().where({ published: true, title: undefined }).delete()
 

--- a/packages/orm/tests/where-group-sqlite.test.ts
+++ b/packages/orm/tests/where-group-sqlite.test.ts
@@ -130,6 +130,64 @@ describe('callback where groups on real bun:sqlite driver', () => {
     expect(titles).toEqual(['Bun speed', 'Deleted bun', 'Hono routing'])
   })
 
+  // A top-level orWhere folds every preceding condition into the OR's left arm.
+  // Global scopes live outside that fold, or a documented `.where().orWhere()`
+  // chain silently drops tenant isolation and soft-delete filtering.
+  describe('global scopes against a top-level orWhere', () => {
+    class ScopedPost extends Model<PostRecord> {
+      static override table = postsTable
+      static {
+        this.addGlobalScope('publishedOnly', (q) => q.where('published', true))
+      }
+    }
+
+    it('should not let a top-level orWhere escape a global scope', async () => {
+      const posts = await ScopedPost.where('title', 'like', '%bun%')
+        .orWhere('excerpt', 'like', '%unfinished%')
+        .get()
+
+      // 'Draft on bun' matches the OR arm but is unpublished.
+      expect(posts.map((p) => p.title).sort()).toEqual(['Bun speed', 'Deleted bun'])
+    })
+
+    it('should not let a top-level orWhere escape the scope in count()', async () => {
+      const total = await ScopedPost.where('title', 'like', '%bun%')
+        .orWhere('excerpt', 'like', '%unfinished%')
+        .count()
+
+      expect(total).toBe(2)
+    })
+
+    it('should not let a top-level orWhere escape the soft-delete scope', async () => {
+      const posts = await SoftPost.where('title', 'like', '%speed%')
+        .orWhere('excerpt', 'like', '%gone%')
+        .get()
+
+      // 'Deleted bun' carries excerpt 'gone' and is trashed.
+      expect(posts.map((p) => p.title)).toEqual(['Bun speed'])
+    })
+
+    it('should not let a top-level orWhere escape the scope on delete', async () => {
+      await ScopedPost.newQuery()
+        .where('title', 'like', '%speed%')
+        .orWhere('excerpt', 'like', '%unfinished%')
+        .delete()
+
+      const rows = sqlite.query<{ title: string }, []>('SELECT title FROM posts ORDER BY id').all()
+      expect(rows.map((r) => r.title)).toEqual(['Draft on bun', 'Hono routing', 'Deleted bun', 'Unrelated'])
+    })
+
+    it('should not let a top-level orWhere escape the scope on forceUpdate', async () => {
+      await ScopedPost.newQuery()
+        .where('title', 'like', '%speed%')
+        .orWhere('excerpt', 'like', '%unfinished%')
+        .forceUpdate({ excerpt: 'touched' })
+
+      const touched = sqlite.query<{ title: string }, []>("SELECT title FROM posts WHERE excerpt = 'touched'").all()
+      expect(touched.map((r) => r.title)).toEqual(['Bun speed'])
+    })
+  })
+
   it('should apply grouped conditions to bulk update and delete', async () => {
     await Post.newQuery()
       .where((q) => q.where('title', 'like', '%bun%').orWhere('excerpt', 'like', '%bun%'))


### PR DESCRIPTION
## Summary

A security review of the ORM found that a model's global scopes were folded away by a top-level `orWhere()`.

`Model.newQuery()` appended every global scope — `SoftDeletes` included — to the same flat condition list the caller's `where()`/`orWhere()` push onto, and `normalizeConditionSequence` folds everything preceding an or-group into that group's left arm. So a chain the docs teach verbatim:

```ts
Post.where('status', 'published').orWhere('excerpt', 'like', pattern)
```

ran as `(scope AND status) OR excerpt`. Any row matching the OR arm came back with the scope dropped: another tenant's records under a `tenant` scope, trashed records under `softDelete`. The folded list also reached `countAdvanced`, `updateAdvanced` and `deleteAdvanced`, so `paginate()`'s `meta.total` confirmed the leaked rows, and a bulk moderation or cleanup action written with the same builder shape reached and rewrote them.

Global scopes are now sealed at query creation and AND-ed around the caller's expression, whatever gets chained afterwards.

The reason this went unnoticed is worth flagging for review: `packages/orm/tests/where-group-sqlite.test.ts` already had a test named `'should not let orWhere groups escape the soft-delete scope'`, but its body puts the `orWhere` inside a `where(callback)` — the already-safe form. The hazard class was identified and the test aimed at the wrong shape. New tests pin the top-level shape on read, `count()`, `softDelete`, `delete()` and `forceUpdate()`.

A second, adjacent defect is fixed in the same change: a criteria object whose every value was `undefined` produced no `WHERE` clause and the statement reached every row, so `Model.delete({ id: undefined })` emptied the table and `Model.update({ id: undefined }, data)` rewrote it. `update` and `delete` now refuse when every filter the caller wrote was dropped, and `Model.find(undefined)` returns `null` so `findOrFail` throws `ModelNotFoundException` as its doc comment promises.

## Scope

- `orm` — `QueryBuilder`, `Model`, `adapters/drizzle-adapter`
- tests: `packages/orm/tests/where-group-sqlite.test.ts`, new `packages/orm/tests/unfiltered-write-sqlite.test.ts`
- changeset: `@guren/orm` patch

No docs change: the examples in `docs/en/guides/database.md` and the scaffolded `orm-models.md` rules are correct once the engine is.

## Risk Assessment

Three intentional behavior changes:

1. **A scoped query with a top-level `orWhere` returns fewer rows than before.** That is the fix. Anyone who was relying on the old output was relying on the scope being dropped.
2. **`update`/`delete` throw when every filter the caller passed was `undefined`.** An explicitly empty `{}` and a deliberately unfiltered builder still mean "no filter", and an optional-filter set keeps working as long as one value survives — there is a test pinning each.
3. **`Model.find(undefined)` returns `null`.** `null` is deliberately left alone: it renders `IS NULL`, which is a real filter, so `Post.find(null, 'deletedAt')` behaves as before.

`withoutGlobalScope()` / `withoutGlobalScopes()` are unchanged, and a scope registered through `static scopes` stays a caller-level filter as before. Basic (non-advanced) adapters still receive scopes: `toSimpleWhereClause()` reads the flat concatenation.

`SEAL_SCOPES` follows the existing `PREPARED_UPDATE` pattern — symbol-keyed, exported for `Model` across the module boundary, kept out of the package entry point.

## Validation

- [x] `bun run build` (`build:clean`)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test:bun orm server` — 3411 pass, 0 fail
- [x] `bun run test:bun cli core` — 2630 pass, 0 fail

Mutation-checked: reverting the seal in `Model.newQuery()` fails all five new scope tests, so they can actually fail.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
