### PR TITLE
fix(cli): splice into the providers array instead of rebuilding it

### DIFF
--- a/.changeset/provider-array-splice.md
+++ b/.changeset/provider-array-splice.md
@@ -1,0 +1,7 @@
+---
+"@guren/cli": patch
+---
+
+**Provider registration no longer rewrites the rest of the `providers` array** — every command that registers a provider (`guren add session`, `add cache`, `add attachments`, `make:auth`, `guren plugin`, and the `guren add` blueprints) rebuilt the array by re-joining parsed entries. Those entries come from a *masked* copy of the source, where string contents are blanked character for character so a name mentioned in a comment cannot read as a registration. Joining them back therefore wrote the mask to disk: `mcpPlugin({ path: '/mcp' })` became `mcpPlugin({ path: '    ' })`, mounting the endpoint at a four-space path on an app that still boots, typechecks and passes `guren check`. The array was also flattened onto one line, and matching to the first `]` truncated an array holding a nested one — `providers: [plugin({ hosts: ['a'] })]` had the new provider spliced inside the plugin's own argument.
+
+The insert now splices into the array's own span, the way `addToArrayOption` and `addToArrayArgument` already did: existing text is preserved verbatim, the span is found by depth-counting rather than by the first `]`, and a `providers: [` appearing only in a comment is no longer mistaken for the real one.

--- a/packages/cli/src/patch-helpers.ts
+++ b/packages/cli/src/patch-helpers.ts
@@ -100,7 +100,9 @@ export function findClosingDelimiter(content: string, openIndex: number, open: s
 
 /**
  * Entries of an array literal's interior. Masked first, so a name appearing
- * only in a comment is not mistaken for an existing entry.
+ * only in a comment is not mistaken for an existing entry — which is also why
+ * the result answers membership only: string contents come out blanked, so
+ * re-joining these entries into the file writes `'/mcp'` back as `'    '`.
  */
 function parseArrayEntries(inner: string): string[] {
   return maskNonCode(inner)
@@ -274,9 +276,9 @@ export type InsertResult = { content: string; reason?: undefined } | { content?:
 /**
  * Pure, and split out for the same reason as `insertImport`: a caller adding
  * the provider's import too applies both here and writes once, so a failure
- * cannot leave half the pair on disk. Re-joins from parsed entries rather than
- * appending in place, collapsing a multi-line array onto one line — long-
- * standing output that every provider-wiring test pins.
+ * cannot leave half the pair on disk. Splices into the array's own span rather
+ * than re-joining `parseArrayEntries` output, which writes the mask back and
+ * blanked an unrelated `mcpPlugin({ path: '/mcp' })` to `'    '`.
  */
 export function insertProvider(
   content: string,
@@ -287,14 +289,23 @@ export function insertProvider(
    */
   isRegistered?: (entries: string[]) => boolean,
 ): InsertResult {
-  const providersArrayPattern = /providers:\s*\[([\s\S]*?)\]/
-  const match = content.match(providersArrayPattern)
+  const match = matchInCode(content, /providers:\s*\[/)
 
   if (!match) {
     return { reason: PATCH_REASONS.providersArrayNotFound }
   }
 
-  const providers = parseArrayEntries(match[1])
+  // Depth-counted rather than matched to the first `]`, which a nested array
+  // or an object argument holding one ends early.
+  const open = match.index + match[0].length - 1
+  const close = findClosingDelimiter(content, open, '[', ']')
+
+  if (close === -1) {
+    return { reason: PATCH_REASONS.providersArrayNotFound }
+  }
+
+  const interior = content.slice(open + 1, close)
+  const providers = parseArrayEntries(interior)
 
   const alreadyRegistered = isRegistered
     ? isRegistered(providers)
@@ -303,10 +314,8 @@ export function insertProvider(
     return { reason: PATCH_REASONS.providerAlreadyRegistered }
   }
 
-  providers.push(providerName)
-
   return {
-    content: content.replace(providersArrayPattern, `providers: [${providers.join(', ')}]`),
+    content: content.slice(0, open + 1) + appendArrayEntry(interior, providerName) + content.slice(close),
   }
 }
 

--- a/packages/cli/tests/patch-helpers.test.ts
+++ b/packages/cli/tests/patch-helpers.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
-import { addImport, addToArrayArgument, addToArrayOption, insertImport } from '../src/patch-helpers'
+import { addImport, addToArrayArgument, addToArrayOption, insertImport, insertProvider, PATCH_REASONS } from '../src/patch-helpers'
 import { createTempWorkspace } from './helpers'
 
 describe('addImport', () => {
@@ -473,5 +473,78 @@ describe('insertImport — already-imported detection', () => {
   it('sees a binding through a comment between the braces', () => {
     const commented = "import {\n  Router,\n  /* delivery helper */ registerAttachmentRoutes,\n} from '@guren/core'\n"
     expect(insertImport(commented, STATEMENT)).toBeNull()
+  })
+})
+
+describe('insertProvider', () => {
+  // The array a scaffolded worker app actually has: several lines, and a
+  // plugin argument whose string literal is unrelated to the registration.
+  const MULTILINE_APP = `const app = createApp({
+  routes: registerWebRoutes,
+  providers: [
+    DatabaseProvider,
+    AuthProvider,
+    cloudflarePlugin(),
+    mcpPlugin({ path: '/mcp' }),
+  ],
+})
+`
+
+  it('appends without rewriting an unrelated string literal', () => {
+    const result = insertProvider(MULTILINE_APP, 'SessionProvider')
+
+    expect(result.content).toBeDefined()
+    expect(result.content).toContain('SessionProvider')
+    // The defect wrote the mask back, leaving `path: '    '` — a four-space
+    // route that boots, typechecks and passes `guren check`.
+    expect(result.content).toContain("mcpPlugin({ path: '/mcp' })")
+  })
+
+  it('leaves the array spanning the lines it already spanned', () => {
+    const result = insertProvider(MULTILINE_APP, 'SessionProvider')
+
+    // Asserted separately from the literal: re-joining entries collapses the
+    // array and blanks the literal, and either alone can regress.
+    expect(result.content).toContain('\n    DatabaseProvider,\n')
+    expect(result.content).toContain('  ],\n')
+  })
+
+  it('keeps a single-line array on one line', () => {
+    const result = insertProvider('createApp({ providers: [DatabaseProvider] })', 'AuthProvider')
+
+    expect(result.content).toBe('createApp({ providers: [DatabaseProvider, AuthProvider] })')
+  })
+
+  it('spans an array holding a nested one', () => {
+    const nested = "createApp({ providers: [plugin({ hosts: ['a'] })] })"
+
+    const result = insertProvider(nested, 'SessionProvider')
+
+    // Matching to the first `]` ended the array inside `hosts`, splicing the
+    // new entry into the middle of the plugin's own argument.
+    expect(result.content).toBe("createApp({ providers: [plugin({ hosts: ['a'] }), SessionProvider] })")
+  })
+
+  it('does not treat a `$` in an existing entry as a replacement pattern', () => {
+    const result = insertProvider('createApp({ providers: [$1, $$legacy] })', 'SessionProvider')
+
+    expect(result.content).toBe('createApp({ providers: [$1, $$legacy, SessionProvider] })')
+  })
+
+  it('ignores a providers array that exists only in a comment', () => {
+    const commented = `// providers: [OldProvider],
+createApp({ providers: [DatabaseProvider] })`
+
+    const result = insertProvider(commented, 'SessionProvider')
+
+    expect(result.content).toContain('// providers: [OldProvider],')
+    expect(result.content).toContain('providers: [DatabaseProvider, SessionProvider]')
+  })
+
+  it('reports an app with no providers array rather than inventing one', () => {
+    const result = insertProvider('createApp({ routes: registerWebRoutes })', 'SessionProvider')
+
+    expect(result.content).toBeUndefined()
+    expect(result.reason).toBe(PATCH_REASONS.providersArrayNotFound)
   })
 })


### PR DESCRIPTION
`guren add session` corrupted an unrelated string literal in `src/app.ts` when registering `SessionProvider`. On an app carrying `mcpPlugin({ path: '/mcp' })`, the argument came back as `mcpPlugin({ path: '    ' })` — four spaces. The MCP endpoint mounts at a four-space path on an app that still boots, typechecks and passes `guren check`; it surfaces only as a 404 at `/mcp`.

## Cause

`insertProvider()` rebuilt the whole array by re-joining the entries `parseArrayEntries()` returns:

```ts
content.replace(providersArrayPattern, `providers: [${providers.join(', ')}]`)
```

`parseArrayEntries()` masks its input first, blanking string and comment *contents* character for character so a name mentioned in a comment cannot read as an existing registration. That is correct for membership testing and wrong to write back — joining those entries put the mask on disk, which is why `'/mcp'` became four spaces and not something arbitrary.

Three further defects came from the same line, each verified against the pre-fix code:

| Input | Before | After |
|---|---|---|
| multi-line array | flattened onto one line | line structure kept |
| `providers: [plugin({ hosts: ['a'] })]` | `[plugin({ hosts: [' ', SessionProvider] })]` | `[plugin({ hosts: ['a'] }), SessionProvider]` |
| `providers: [$1, $$legacy]` | `[$1, $$legacy, $legacy, ...]` | unchanged entries |
| `providers: [` in a comment | comment patched, real array missed | comment untouched |

The `$` row is `String.replace`'s replacement-pattern expansion; the nested-array row is the non-greedy `[\s\S]*?\]` ending at the first `]`.

On formatting: existing lines are now preserved verbatim, and the new entry joins the last entry's line (`mcpPlugin({ path: '/mcp' }), SessionProvider,`) rather than opening a line of its own. That is `appendArrayEntry()`'s existing behaviour, shared with the `make:module` and `make:command` registrars, and is deliberately left alone here.

## Fix

The insert now works the way `addToArrayOption()` and `addToArrayArgument()` in the same file already did: locate the span with `matchInCode()` + `findClosingDelimiter()`, then splice with `appendArrayEntry()`, leaving existing text verbatim. `parseArrayEntries()` output is kept for membership testing only.

The report suggested an AST edit. `patch-helpers.ts` already has the precise-patch seam and two callers using it, so reusing it is a smaller change than introducing a second mechanism, and it brings provider registration in line with the module and command registrars. `parseArrayEntries()` is deliberately left masked — its masking is what stops a commented-out name reading as registered, and changing it would alter duplicate detection for every caller.

Behaviour intentionally preserved: `providersArrayNotFound` is still returned when there is no array (rather than creating one, as `addToArrayOption` does) — `plugin.ts` and the existing tests branch on that reason.

## Scope

`insertProvider()` is the single write site behind every provider-wiring command, so one fix covers `guren add session`, `add cache`, `add attachments`, `make:auth`, `guren plugin`, and the `guren add` blueprints. No command was touched individually.

## Tests

Seven cases in `packages/cli/tests/patch-helpers.test.ts`. The main fixture is a multi-line array containing a string-literal argument, asserting the append, the literal byte-identical, **and** that the array still spans its lines — the last separately, so a re-join regression cannot pass on the first two.

Restoring the pre-fix `patch-helpers.ts` and re-running names exactly five failures:

```
(fail) insertProvider > appends without rewriting an unrelated string literal
(fail) insertProvider > leaves the array spanning the lines it already spanned
(fail) insertProvider > spans an array holding a nested one
(fail) insertProvider > does not treat a `$` in an existing entry as a replacement pattern
(fail) insertProvider > ignores a providers array that exists only in a comment
```

The remaining two pin behaviour that must not change (a single-line array stays on one line; an app with no providers array still reports `providersArrayNotFound`), and pass against both implementations by design.

## Verification

`bun run build`, `typecheck`, `lint`, `test:bun cli` (2336 pass / 0 fail) — all green, re-run after rebasing onto current `main`. No templates touched, so the starter smokes do not apply.

## Follow-up (not in this PR)

`parseArrayEntries()` splits on every comma with no nesting awareness, so `mcpPlugin({ path: '/mcp', prefix: '/x' })` parses as two fragments. That can no longer corrupt output now that nothing re-joins it, and it only affects duplicate detection, so it is left for a separate change rather than altering membership semantics here.