### PR TITLE
fix(cli): discover schedule kernels that register through the scheduler

### DIFF
--- a/.changeset/schedule-registrar-kernels.md
+++ b/.changeset/schedule-registrar-kernels.md
@@ -1,0 +1,7 @@
+---
+"@guren/cli": patch
+---
+
+**`schedule:list` and `schedule:run` see the schedule kernels apps actually write** — both commands accepted only a kernel *factory* (`scheduleTasksKernel(): Schedule`, and three other export names), while the scheduling guide teaches a `Scheduler` that a provider builds and hands to a registrar. An app following that guide, `examples/blog` and `examples/api` included, got "No scheduled tasks found." for tasks that really run. A kernel may now also export a registrar taking the scheduler, `(scheduler: Scheduler) => void`, named `register…Schedules` or exported as `default` — the same naming convention `route-registrar.ts` applies to route registrars, so a helper that merely takes one argument is not mistaken for an entry point. A kernel may export several, and they share one scheduler.
+
+A kernel that exists is no longer reported as an app that has none. Loading one that threw was swallowed into `consola.debug`; one exporting nothing recognizable, and a `--kernel` path that is not there, printed the same "here is how to create one" hint as a missing file. All three now name the path, say what went wrong, and exit non-zero, and the unrecognized message names the two conventions. `--json` keeps stdout parseable — diagnostics go to stderr. Kernel paths are probed with loader semantics (`isDefinitelyAbsent`), so a kernel whose directory cannot be read reaches the import and is diagnosed rather than reported as absent.

--- a/docs/en/guides/cloudflare.md
+++ b/docs/en/guides/cloudflare.md
@@ -274,7 +274,7 @@ If your app deliberately serves pretty-URL HTML out of `public/`, set `"html_han
 
 The generated worker exports a `scheduled` handler alongside `fetch`, so a Cloudflare cron trigger runs the tasks your app registered with `createScheduler()`. There is no long-lived process on Workers to hold a ticking scheduler, and `scheduler.start()` never runs there — the trigger is what advances the clock.
 
-Two things you supply. First, the tasks and a provider binding the scheduler, exactly as on a Bun server. Declaring them in `app/Console/Kernel.ts` is what also lets `guren schedule:list` and `guren schedule:run` see them:
+Two things you supply. First, the tasks and a provider binding the scheduler, exactly as on a Bun server. Declaring them in `app/Console/Kernel.ts` is what also lets `guren schedule:list` and `guren schedule:run` see them — the file is the requirement, in either shape those commands accept ([Making tasks visible to the CLI](./scheduling.md#making-tasks-visible-to-the-cli)):
 
 ```ts
 // app/Console/Kernel.ts

--- a/docs/en/guides/scheduling.md
+++ b/docs/en/guides/scheduling.md
@@ -292,21 +292,89 @@ await scheduler.runDueTasks()           // Run all due tasks now
 
 ## CLI Integration
 
-Run the scheduler from the command line:
+The ticking scheduler lives inside your application — `scheduler.start()`, above.
+The CLI covers the other half: seeing what is registered, and driving a run from
+outside the process, which is what a system cron or a platform trigger calls.
 
 ```bash
-# Start the scheduler
-bunx guren schedule:work
-
-# Start with custom timezone
-bunx guren schedule:work --timezone=Asia/Tokyo
-
 # List scheduled tasks
 bunx guren schedule:list
+bunx guren schedule:list --json
 
-# Run a specific task immediately
-bunx guren schedule:run cleanup-sessions
+# Run whichever tasks are due now
+bunx guren schedule:run
+
+# Run one task immediately, due or not
+bunx guren schedule:run --task cleanup-sessions --force
 ```
+
+### Making tasks visible to the CLI
+
+`schedule:list` and `schedule:run` do not boot your application. They load the
+schedule kernel directly, probing `app/Console/Kernel.ts` (and the lowercase and
+`src/` variants), or the path given to `--kernel`. Tasks declared anywhere else
+are invisible to both commands, however reliably they run under
+`scheduler.start()`.
+
+Two export shapes are recognized, each under its own naming convention.
+
+**A registrar** is the shape most app code already has: a provider builds the
+scheduler and hands it over, and the CLI supplies one of its own.
+
+```ts
+// app/Console/Kernel.ts
+import type { Scheduler } from '@guren/core'
+
+export function registerSchedules(scheduler: Scheduler): void {
+  scheduler.schedule((schedule) => {
+    schedule.call(warmCache).hourly().name('warm-cache')
+  })
+}
+```
+
+Name it `register…Schedules` — `registerSchedules`, `registerBillingSchedules`
+— or make it the default export. A kernel may export several, and they all
+receive the same scheduler. The convention is what keeps the CLI from calling
+every helper the file happens to export; a registrar named anything else is
+reported as unrecognized rather than silently skipped.
+
+**A kernel factory** takes nothing and returns the `Schedule` it built. It is
+recognized as `scheduleTasksKernel`, `schedule`, `defineSchedule`, or the default
+export, and is what `bunx guren add schedule` scaffolds.
+
+```ts
+// app/Console/Kernel.ts
+import { Schedule } from '@guren/core'
+
+export function scheduleTasksKernel(): Schedule {
+  const schedule = new Schedule()
+  schedule.call(warmCache).hourly().name('warm-cache')
+  return schedule
+}
+```
+
+A factory declares the tasks but runs nothing on its own — a provider still has
+to feed them to the scheduler it binds:
+
+```ts
+for (const task of scheduleTasksKernel().buildTasks()) scheduler.addTask(task)
+```
+
+Prefer the registrar in application code: it is the same `Scheduler` API the rest
+of this guide teaches, and the tasks reach the running scheduler without a second
+wiring step.
+
+Either way, resolve services *inside* the task callback rather than while the
+kernel is being built — the CLI reads this file without booting your app, so a
+container lookup at build time has nothing to resolve:
+
+```ts
+schedule.call(() => getContainer().make<SessionManager>('session').pruneExpired()).hourly()
+```
+
+A kernel that exists but matches neither shape, or that throws while loading, is
+reported as such and exits non-zero — it is not the same state as an app that has
+not scheduled anything yet.
 
 ## Testing
 

--- a/docs/ja/guides/cloudflare.md
+++ b/docs/ja/guides/cloudflare.md
@@ -274,7 +274,7 @@ APP_KEY=base64:...
 
 生成されるワーカーは `fetch` と並んで `scheduled` ハンドラを export します。そのため Cloudflare の cron トリガーが、アプリが `createScheduler()` で登録したタスクを実行します。Workers には常駐プロセスがなく、`scheduler.start()` はそこでは動きません。時計を進めるのはトリガーです。
 
-用意するものは 2 つです。1 つめは、Bun サーバーのときとまったく同じ、タスクと scheduler をバインドするプロバイダです。タスクを `app/Console/Kernel.ts` に宣言しておくと、`guren schedule:list` と `guren schedule:run` からも見えるようになります。
+用意するものは 2 つです。1 つめは、Bun サーバーのときとまったく同じ、タスクと scheduler をバインドするプロバイダです。タスクを `app/Console/Kernel.ts` に宣言しておくと、`guren schedule:list` と `guren schedule:run` からも見えるようになります。条件はこのファイルであることで、形はこれらのコマンドが受け入れるどちらでもかまいません（[CLIから見えるようにする](./scheduling.md#cliから見えるようにする)）。
 
 ```ts
 // app/Console/Kernel.ts

--- a/docs/ja/guides/scheduling.md
+++ b/docs/ja/guides/scheduling.md
@@ -292,21 +292,88 @@ await scheduler.runDueTasks()           // 実行予定の全タスクを今す�
 
 ## CLI統合
 
-コマンドラインからスケジューラーを実行します。
+常駐するスケジューラーはアプリケーションの中で動きます(前述の`scheduler.start()`)。
+CLIが担うのはもう半分、つまり登録内容の確認と、プロセスの外からの実行です。後者は
+システムのcronやプラットフォームのトリガーが呼ぶものです。
 
 ```bash
-# スケジューラーを開始
-bunx guren schedule:work
-
-# カスタムタイムゾーンで開始
-bunx guren schedule:work --timezone=Asia/Tokyo
-
 # スケジュールされたタスクを一覧
 bunx guren schedule:list
+bunx guren schedule:list --json
 
-# 特定のタスクを即座に実行
-bunx guren schedule:run cleanup-sessions
+# 実行時刻を迎えたタスクを実行
+bunx guren schedule:run
+
+# 特定のタスクを時刻に関係なく即座に実行
+bunx guren schedule:run --task cleanup-sessions --force
 ```
+
+### CLIから見えるようにする
+
+`schedule:list`と`schedule:run`はアプリケーションをbootしません。スケジュール
+カーネルを直接読み込み、`app/Console/Kernel.ts`(小文字版と`src/`版も含む)、
+あるいは`--kernel`で渡したパスを探索します。それ以外の場所で宣言されたタスクは、
+`scheduler.start()`の下でどれだけ確実に動いていても、両コマンドからは見えません。
+
+認識されるエクスポートの形は2つで、それぞれに命名規約があります。
+
+**レジストラ**は多くのアプリケーションコードが既に持っている形です。プロバイダー
+がスケジューラーを構築して渡し、CLIは自前のスケジューラーを渡します。
+
+```ts
+// app/Console/Kernel.ts
+import type { Scheduler } from '@guren/core'
+
+export function registerSchedules(scheduler: Scheduler): void {
+  scheduler.schedule((schedule) => {
+    schedule.call(warmCache).hourly().name('warm-cache')
+  })
+}
+```
+
+名前は`register…Schedules`(`registerSchedules`、`registerBillingSchedules`など)
+にするか、デフォルトエクスポートにします。1つのカーネルが複数エクスポートしても
+よく、その全部が同じスケジューラーを受け取ります。この規約があるおかげで、CLIは
+ファイルが偶然エクスポートしているヘルパーまで呼ばずに済みます。規約から外れた名前
+のレジストラは、黙って無視されるのではなく「認識できない」として報告されます。
+
+**カーネルファクトリ**は引数を取らず、構築した`Schedule`を返します。
+`scheduleTasksKernel`、`schedule`、`defineSchedule`、またはデフォルトエクスポート
+として認識され、`bunx guren add schedule`が生成するのはこの形です。
+
+```ts
+// app/Console/Kernel.ts
+import { Schedule } from '@guren/core'
+
+export function scheduleTasksKernel(): Schedule {
+  const schedule = new Schedule()
+  schedule.call(warmCache).hourly().name('warm-cache')
+  return schedule
+}
+```
+
+ファクトリはタスクを宣言するだけで、それ自体は何も実行しません。プロバイダーが
+バインドするスケジューラーへ渡す必要があります。
+
+```ts
+for (const task of scheduleTasksKernel().buildTasks()) scheduler.addTask(task)
+```
+
+アプリケーションコードではレジストラを推奨します。このガイドの他の箇所が教える
+`Scheduler` APIそのままであり、2度目の配線なしにタスクが実行中のスケジューラーへ
+届きます。
+
+どちらの形でも、サービスの解決はカーネル構築時ではなくタスクのコールバック内で
+行ってください。CLIはアプリをbootせずにこのファイルを読むため、構築時のコンテナ
+参照には解決先がありません。
+
+```ts
+schedule.call(() => getContainer().make<SessionManager>('session').pruneExpired()).hourly()
+```
+
+カーネルが存在するのにどちらの形にも一致しない場合、あるいは読み込み中に例外を
+投げた場合は、その旨を報告して非ゼロで終了します。まだ何もスケジュールしていない
+アプリとは別の状態として扱われます。
 
 ## テスト
 

--- a/packages/cli/src/schedule.ts
+++ b/packages/cli/src/schedule.ts
@@ -1,8 +1,8 @@
 import { consola } from 'consola'
 import { resolve } from 'node:path'
-import { existsSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
-import { matchesCron, parseCron, toTimezone, type ParsedCron } from '@guren/core'
+import { isDefinitelyAbsent } from './discovery'
+import { createScheduler, matchesCron, parseCron, toTimezone, type ParsedCron, type Scheduler } from '@guren/core'
 
 export interface ScheduleOptions {
   appRoot?: string
@@ -64,8 +64,108 @@ function normalizeTask(raw: ScheduledTaskLike): TaskInfo {
   }
 }
 
+/** Why a listing has no tasks; see {@link reportEmptyKernel} for what each state means. */
+type KernelLoad =
+  | { kind: 'loaded'; path: string; tasks: TaskInfo[]; warnings: string[] }
+  | { kind: 'missing' }
+  | { kind: 'not-found'; path: string }
+  | { kind: 'failed'; path: string; reasons: string[] }
+  | { kind: 'unrecognized'; path: string; exports: string[] }
+
+/** Export names carrying a kernel factory: called with no scheduler, returns the schedule. */
+const KERNEL_FACTORY_EXPORTS = ['scheduleTasksKernel', 'schedule', 'defineSchedule', 'default']
+
+/**
+ * Export names carrying a registrar: handed the scheduler, returns nothing. Named
+ * rather than shape-matched, for the reason `route-registrar.ts` gives about routes
+ * — a helper that merely takes one argument is not the entry point, and a loader
+ * that calls every such export runs app code nobody pointed it at.
+ */
+const REGISTRAR_PATTERN = /^register\w*Schedules$/u
+
+function isRegistrarExportName(name: string): boolean {
+  return name === 'default' || REGISTRAR_PATTERN.test(name)
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function tasksFromSchedule(value: unknown): TaskInfo[] | null {
+  const schedule = value as { buildTasks?: () => unknown[]; getTasks?: () => unknown[] } | null
+  const raw =
+    typeof schedule?.buildTasks === 'function'
+      ? schedule.buildTasks()
+      : typeof schedule?.getTasks === 'function'
+        ? schedule.getTasks()
+        : null
+
+  return raw ? raw.map((task) => normalizeTask(task as ScheduledTaskLike)) : null
+}
+
+/**
+ * Reads one kernel module in both shapes the docs teach: a factory returning a
+ * `Schedule` (`scheduleTasksKernel()`), and a registrar taking the `Scheduler`
+ * the app binds in a provider. Arity is what tells them apart — a registrar's
+ * export name belongs to the app, so no name list can find it.
+ */
+async function readKernelModule(kernelPath: string): Promise<KernelLoad> {
+  let mod: Record<string, unknown>
+  try {
+    mod = (await import(pathToFileURL(kernelPath).href)) as Record<string, unknown>
+  } catch (error) {
+    return { kind: 'failed', path: kernelPath, reasons: [describeError(error)] }
+  }
+
+  const reasons: string[] = []
+
+  for (const name of KERNEL_FACTORY_EXPORTS) {
+    const exported = mod[name]
+    if (typeof exported !== 'function' || exported.length > 0) continue
+
+    try {
+      const tasks = tasksFromSchedule(await (exported as () => unknown)())
+      if (tasks) return { kind: 'loaded', path: kernelPath, tasks, warnings: [] }
+    } catch (error) {
+      reasons.push(`${name}() threw: ${describeError(error)}`)
+    }
+  }
+
+  // One scheduler across every registrar, so an app may split its tasks over
+  // several. Deduplicated by identity: `export default registerSchedules` beside
+  // the named export is the same function twice, not two sets of tasks.
+  const registrars = new Map<(scheduler: Scheduler) => unknown, string>()
+  for (const [name, exported] of Object.entries(mod)) {
+    if (typeof exported === 'function' && exported.length === 1 && isRegistrarExportName(name)) {
+      const registrar = exported as (scheduler: Scheduler) => unknown
+      if (!registrars.has(registrar)) registrars.set(registrar, name)
+    }
+  }
+
+  if (registrars.size > 0) {
+    const scheduler = createScheduler()
+    for (const [registrar, name] of registrars) {
+      try {
+        await registrar(scheduler)
+      } catch (error) {
+        reasons.push(`${name}(scheduler) threw: ${describeError(error)}`)
+      }
+    }
+
+    // The `await` above is what keeps an async registrar's rejection reportable
+    // rather than escaping as an unhandled one.
+    const tasks = scheduler.getTasks().map((task) => normalizeTask(task as ScheduledTaskLike))
+    if (tasks.length > 0 || reasons.length === 0) {
+      return { kind: 'loaded', path: kernelPath, tasks, warnings: reasons }
+    }
+  }
+
+  if (reasons.length > 0) return { kind: 'failed', path: kernelPath, reasons }
+  return { kind: 'unrecognized', path: kernelPath, exports: Object.keys(mod) }
+}
+
 /** Loads the schedule kernel from `--kernel`, or from the conventional locations. */
-async function loadScheduleKernel(options: ScheduleOptions = {}): Promise<{ tasks: TaskInfo[]; scheduler?: unknown } | null> {
+async function loadScheduleKernel(options: ScheduleOptions = {}): Promise<KernelLoad> {
   const appRoot = options.appRoot ? resolve(options.appRoot) : process.cwd()
 
   const kernelPaths = options.kernel
@@ -79,37 +179,20 @@ async function loadScheduleKernel(options: ScheduleOptions = {}): Promise<{ task
         resolve(appRoot, 'src/console/Kernel.ts'),
       ]
 
+  let firstProblem: KernelLoad | null = null
+
   for (const kernelPath of kernelPaths) {
-    if (existsSync(kernelPath)) {
-      try {
-        const mod = await import(pathToFileURL(kernelPath).href)
+    // Loader semantics: a kernel whose directory cannot be read must reach the
+    // import and be diagnosed, not be reported as an app that has no kernel.
+    if (await isDefinitelyAbsent(appRoot, kernelPath)) continue
 
-        const scheduleFunction =
-          mod.scheduleTasksKernel ||
-          mod.schedule ||
-          mod.defineSchedule ||
-          mod.default
-
-        if (typeof scheduleFunction === 'function') {
-          const schedule = scheduleFunction()
-
-          if (schedule && typeof schedule.buildTasks === 'function') {
-            const tasks = schedule.buildTasks()
-            return { tasks: tasks.map((t: unknown) => normalizeTask(t as ScheduledTaskLike)) }
-          }
-
-          if (schedule && typeof schedule.getTasks === 'function') {
-            const tasks = schedule.getTasks()
-            return { tasks: tasks.map((t: unknown) => normalizeTask(t as ScheduledTaskLike)) }
-          }
-        }
-      } catch (error) {
-        consola.debug(`Failed to load kernel from ${kernelPath}:`, error)
-      }
-    }
+    const load = await readKernelModule(kernelPath)
+    if (load.kind === 'loaded') return load
+    firstProblem ??= load
   }
 
-  return null
+  if (firstProblem) return firstProblem
+  return options.kernel ? { kind: 'not-found', path: kernelPaths[0] } : { kind: 'missing' }
 }
 
 /**
@@ -184,31 +267,86 @@ function formatTimeUntil(date: Date): string {
   return 'in < 1 min'
 }
 
-export async function listScheduledTasks(options: ScheduleOptions = {}): Promise<void> {
+/**
+ * Says why there are no tasks to show. `missing` is the only state the "create a
+ * kernel" hint fits: a kernel that exists but threw, exported nothing usable, or
+ * was named by a `--kernel` that is not there, is a wiring bug, and the hint would
+ * answer a question nobody asked. Diagnostics go through consola's error/warn
+ * (stderr), leaving `--json` stdout machine-readable.
+ */
+function reportEmptyKernel(kernel: KernelLoad, json: boolean): void {
+  switch (kernel.kind) {
+    case 'not-found':
+      consola.error(`No schedule kernel at ${kernel.path}.`)
+      process.exitCode = 1
+      return
+
+    case 'failed':
+      consola.error(
+        [`Failed to load the schedule kernel at ${kernel.path}:`, ...kernel.reasons.map((reason) => `  ${reason}`)].join('\n'),
+      )
+      process.exitCode = 1
+      return
+
+    case 'unrecognized':
+      consola.error(
+        [
+          `${kernel.path} exports nothing the scheduler recognizes.`,
+          `  Found: ${kernel.exports.join(', ') || '(no exports)'}`,
+          '  Export a kernel factory `scheduleTasksKernel(): Schedule`, or a registrar',
+          '  named `register…Schedules(scheduler: Scheduler)`. Either may be the default export.',
+        ].join('\n'),
+      )
+      process.exitCode = 1
+      return
+
+    case 'loaded':
+      consola.warn(`${kernel.path} loaded, but registered no tasks.`)
+      return
+
+    case 'missing':
+      if (json) return
+      consola.info('No scheduled tasks found.')
+      consola.info('')
+      consola.info('To define scheduled tasks, create a kernel file at:')
+      consola.info('  app/Console/Kernel.ts')
+      consola.info('')
+      consola.info('Example:')
+      consola.info('  export function scheduleTasksKernel() {')
+      consola.info('    const schedule = new Schedule()')
+      consola.info('    schedule.call(myTask).daily().name("my-task")')
+      consola.info('    return schedule')
+      consola.info('  }')
+  }
+}
+
+/**
+ * The kernel's tasks, or `null` once the reason there are none has been reported.
+ * `reportEmptyKernel`'s `loaded` case relies on the emptiness test here, so the two
+ * stay in one place.
+ */
+async function resolveTasks(options: ScheduleOptions): Promise<TaskInfo[] | null> {
   const kernel = await loadScheduleKernel(options)
 
-  if (!kernel || kernel.tasks.length === 0) {
-    if (options.json) {
-      console.log(JSON.stringify([], null, 2))
-      return
-    }
+  if (kernel.kind !== 'loaded' || kernel.tasks.length === 0) {
+    reportEmptyKernel(kernel, Boolean(options.json))
+    return null
+  }
 
-    consola.info('No scheduled tasks found.')
-    consola.info('')
-    consola.info('To define scheduled tasks, create a kernel file at:')
-    consola.info('  app/Console/Kernel.ts')
-    consola.info('')
-    consola.info('Example:')
-    consola.info('  export function scheduleTasksKernel() {')
-    consola.info('    const schedule = new Schedule()')
-    consola.info('    schedule.call(myTask).daily().name("my-task")')
-    consola.info('    return schedule')
-    consola.info('  }')
+  for (const warning of kernel.warnings) consola.warn(warning)
+  return kernel.tasks
+}
+
+export async function listScheduledTasks(options: ScheduleOptions = {}): Promise<void> {
+  const tasks = await resolveTasks(options)
+
+  if (!tasks) {
+    if (options.json) console.log(JSON.stringify([], null, 2))
     return
   }
 
   if (options.json) {
-    const data = kernel.tasks.map((task) => {
+    const data = tasks.map((task) => {
       const nextRun = getNextRunTime(task.expression, task.timezone)
       return {
         name: task.name,
@@ -223,7 +361,7 @@ export async function listScheduledTasks(options: ScheduleOptions = {}): Promise
 
   const rows: string[][] = []
 
-  for (const task of kernel.tasks) {
+  for (const task of tasks) {
     const nextRun = getNextRunTime(task.expression, task.timezone)
     rows.push([
       task.name,
@@ -251,20 +389,14 @@ export async function listScheduledTasks(options: ScheduleOptions = {}): Promise
   }
 
   console.log('')
-  console.log(`Total: ${kernel.tasks.length} task${kernel.tasks.length === 1 ? '' : 's'}`)
+  console.log(`Total: ${tasks.length} task${tasks.length === 1 ? '' : 's'}`)
 }
 
 export async function runScheduledTasks(options: ScheduleRunOptions = {}): Promise<void> {
-  const kernel = await loadScheduleKernel(options)
+  const tasks = await resolveTasks(options)
+  if (!tasks) return
 
-  if (!kernel || kernel.tasks.length === 0) {
-    consola.error('No scheduled tasks found.')
-    return
-  }
-
-  const tasksToRun = options.task
-    ? kernel.tasks.filter((t) => t.name === options.task)
-    : kernel.tasks
+  const tasksToRun = options.task ? tasks.filter((t) => t.name === options.task) : tasks
 
   if (tasksToRun.length === 0) {
     consola.error(`Task "${options.task}" not found.`)
@@ -300,8 +432,7 @@ export async function runScheduledTasks(options: ScheduleRunOptions = {}): Promi
       consola.success(`  Ran: ${task.name} (${Date.now() - startedAt}ms)`)
     } catch (error) {
       failures += 1
-      const reason = error instanceof Error ? error.message : String(error)
-      consola.error(`  Failed: ${task.name} — ${reason}`)
+      consola.error(`  Failed: ${task.name} — ${describeError(error)}`)
     }
   }
 

--- a/packages/cli/tests/schedule.test.ts
+++ b/packages/cli/tests/schedule.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve, join } from 'node:path'
+import { consola } from 'consola'
 import { getNextRunTime, listScheduledTasks, runScheduledTasks } from '../src/schedule'
 
 describe('schedule', () => {
@@ -219,5 +220,213 @@ describe('getNextRunTime', () => {
   test('returns null for an expression that cannot match', () => {
     expect(getNextRunTime('0 25 * * *', undefined, new Date(2026, 5, 10))).toBeNull()
     expect(getNextRunTime('not a cron', undefined, new Date(2026, 5, 10))).toBeNull()
+  })
+})
+
+describe('schedule kernel discovery', () => {
+  const root = resolve(import.meta.dir, '.test-schedule-discovery')
+
+  // A fresh directory per test: `import()` caches by URL, so a second kernel
+  // written to a path already loaded in this process is never read.
+  let fixtures = 0
+  let testDir: string
+  let kernelPath: string
+
+  // Kept apart so the `--json` test can assert on stdout alone; every other
+  // assertion reads both.
+  let stdout: string[] = []
+  let stderr: string[] = []
+
+  const original = {
+    info: consola.info, warn: consola.warn, error: consola.error, success: consola.success,
+    log: console.log,
+  }
+
+  beforeEach(() => {
+    fixtures += 1
+    testDir = join(root, `app-${fixtures}`)
+    kernelPath = join(testDir, 'app/Console/Kernel.ts')
+    mkdirSync(join(testDir, 'app/Console'), { recursive: true })
+    stdout = []
+    stderr = []
+    const record = (into: string[]) => (...args: unknown[]) => { into.push(args.map(String).join(' ')) }
+    Object.assign(consola, {
+      info: record(stderr), warn: record(stderr), error: record(stderr), success: record(stderr),
+    })
+    console.log = record(stdout) as typeof console.log
+    // Bun ignores `process.exitCode = undefined`, and a leaked 1 here would
+    // fail the whole test run, not just the assertion.
+    process.exitCode = 0
+  })
+
+  afterEach(() => {
+    Object.assign(consola, original)
+    console.log = original.log
+    process.exitCode = 0
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  const listed = (): string => [...stdout, ...stderr].join('\n')
+
+  test('discovers a registrar taking the scheduler, the shape apps bind in a provider', async () => {
+    writeFileSync(kernelPath, `
+export function registerAppSchedules(scheduler) {
+  scheduler.schedule((schedule) => {
+    schedule.call(() => {}).hourly().name('app:warm-cache')
+  })
+}
+`)
+
+    await listScheduledTasks({ appRoot: testDir })
+
+    expect(listed()).toContain('app:warm-cache')
+    expect(listed()).toContain('Total: 1 task')
+    expect(process.exitCode).toBe(0)
+  })
+
+  test('counts a registrar exported twice once', async () => {
+    writeFileSync(kernelPath, `
+export function registerAppSchedules(scheduler) {
+  scheduler.schedule((schedule) => {
+    schedule.call(() => {}).hourly().name('app:warm-cache')
+  })
+}
+export default registerAppSchedules
+`)
+
+    await listScheduledTasks({ appRoot: testDir })
+
+    expect(listed()).toContain('Total: 1 task')
+  })
+
+  test('leaves a one-argument export alone unless its name says it is a registrar', async () => {
+    writeFileSync(kernelPath, `
+export function registerAppSchedules(scheduler) {
+  scheduler.schedule((schedule) => {
+    schedule.call(() => {}).hourly().name('app:warm-cache')
+  })
+}
+export function summarize(row) {
+  return row.missing.field
+}
+`)
+
+    await listScheduledTasks({ appRoot: testDir })
+
+    expect(listed()).not.toContain('summarize')
+    expect(listed()).toContain('app:warm-cache')
+  })
+
+  test('reports a registrar the naming convention misses rather than staying silent', async () => {
+    writeFileSync(kernelPath, `
+export function scheduleTasks(scheduler) {
+  scheduler.schedule((schedule) => {
+    schedule.call(() => {}).hourly().name('app:warm-cache')
+  })
+}
+`)
+
+    await listScheduledTasks({ appRoot: testDir })
+
+    expect(listed()).toContain('exports nothing the scheduler recognizes')
+    expect(listed()).toContain('Found: scheduleTasks')
+    expect(listed()).toContain('register…Schedules')
+    expect(process.exitCode).toBe(1)
+  })
+
+  test('awaits an async registrar, so tasks added after an await are seen', async () => {
+    writeFileSync(kernelPath, `
+export async function registerAppSchedules(scheduler) {
+  await Promise.resolve()
+  scheduler.schedule((schedule) => {
+    schedule.call(() => {}).hourly().name('app:late-task')
+  })
+}
+`)
+
+    await listScheduledTasks({ appRoot: testDir })
+
+    expect(listed()).toContain('app:late-task')
+  })
+
+  test('reports an async registrar that rejects rather than leaving it unhandled', async () => {
+    writeFileSync(kernelPath, `
+export async function registerAppSchedules(scheduler) {
+  await Promise.resolve()
+  throw new Error('async registrar failed')
+}
+`)
+
+    await listScheduledTasks({ appRoot: testDir })
+
+    expect(listed()).toContain('registerAppSchedules(scheduler) threw')
+    expect(listed()).toContain('async registrar failed')
+    expect(process.exitCode).toBe(1)
+  })
+
+  test('runs a registrar-declared task', async () => {
+    const marker = join(testDir, 'ran.txt')
+    writeFileSync(kernelPath, `
+import { writeFileSync } from 'node:fs'
+
+export function registerAppSchedules(scheduler) {
+  scheduler.schedule((schedule) => {
+    schedule.call(() => { writeFileSync(${JSON.stringify(marker)}, 'ran') }).hourly().name('app:warm-cache')
+  })
+}
+`)
+
+    await runScheduledTasks({ appRoot: testDir, force: true })
+
+    expect(existsSync(marker)).toBe(true)
+  })
+
+  test('names the kernel that exports nothing it recognizes, rather than the missing-kernel hint', async () => {
+    writeFileSync(kernelPath, 'export const commands = []\n')
+
+    await listScheduledTasks({ appRoot: testDir })
+
+    expect(listed()).toContain('exports nothing the scheduler recognizes')
+    expect(listed()).toContain('Kernel.ts')
+    expect(listed()).toContain('Found: commands')
+    expect(listed()).not.toContain('create a kernel file at')
+    expect(process.exitCode).toBe(1)
+  })
+
+  test('reports a kernel that throws instead of swallowing it into debug output', async () => {
+    writeFileSync(kernelPath, "throw new Error('kernel exploded')\n")
+
+    await listScheduledTasks({ appRoot: testDir })
+
+    expect(listed()).toContain('Failed to load the schedule kernel')
+    expect(listed()).toContain('kernel exploded')
+    expect(process.exitCode).toBe(1)
+  })
+
+  test('keeps the create-a-kernel hint for an app with no kernel file', async () => {
+    rmSync(kernelPath, { force: true })
+
+    await listScheduledTasks({ appRoot: testDir })
+
+    expect(listed()).toContain('To define scheduled tasks, create a kernel file at:')
+    expect(process.exitCode).toBe(0)
+  })
+
+  test('names an explicit --kernel path that does not exist', async () => {
+    await listScheduledTasks({ appRoot: testDir, kernel: 'app/Console/Missing.ts' })
+
+    expect(listed()).toContain('No schedule kernel at')
+    expect(listed()).toContain('Missing.ts')
+    expect(listed()).not.toContain('create a kernel file at')
+    expect(process.exitCode).toBe(1)
+  })
+
+  test('keeps --json stdout parseable when the kernel is unusable', async () => {
+    writeFileSync(kernelPath, 'export const commands = []\n')
+
+    await listScheduledTasks({ appRoot: testDir, json: true })
+
+    expect(JSON.parse(stdout.join('\n'))).toEqual([])
+    expect(stderr.join('\n')).toContain('exports nothing the scheduler recognizes')
   })
 })


### PR DESCRIPTION
## Summary

`schedule:list` and `schedule:run` accepted only a kernel *factory* — `scheduleTasksKernel(): Schedule`, plus three other export names — while `docs/{en,ja}/guides/scheduling.md` teaches a `Scheduler` that a provider builds and hands to a registrar. An app following the main guide therefore got `No scheduled tasks found.` for tasks that really run, `examples/blog` and `examples/api` included:

```
$ cd examples/blog && bun ../../packages/cli/src/bin.ts schedule:list
ℹ No scheduled tasks found.
ℹ To define scheduled tasks, create a kernel file at:
ℹ   app/Console/Kernel.ts
```

`examples/blog/app/Console/Kernel.ts` exists and declares `blog:warm-post-cache`, which `SchedulingProvider` really registers.

That framing matters for the fix. The guide teaching the kernel shape is `cloudflare.md` (added in #728) and nothing else; the reference apps are not deviant, they are following the main guide. So this is a **loader too narrow** defect, not a reference app in the wrong shape — the examples are untouched.

**A kernel may now also export a registrar** taking the scheduler, named `register…Schedules` or exported as `default`. That convention mirrors `packages/cli/src/route-registrar.ts`, which rejects shape-matching for the structurally identical problem in writing — "a helper that merely takes a router is not the entry point" — and all four registrars in this repo already match it. An earlier revision of this PR discriminated by *arity* instead; that was wrong, and the reason is worth stating: "any one-argument export is called with a Scheduler" is a public convention that cannot be narrowed later, while a name pattern can always be widened. It also meant the loader invoked app code nobody pointed it at, which needed a class-detection carve-out to contain. Several registrars share one scheduler, each is awaited, and a function exported twice (`export default registerSchedules` beside the named export) is counted once.

**A kernel that exists is no longer reported as an app that has none.** Three states were collapsed into one hint:

| State | Before | After |
|---|---|---|
| No kernel at any probed path | "here is how to create one" | unchanged |
| Kernel threw while loading | swallowed into `consola.debug` | names the path and the error, exit 1 |
| Kernel exports nothing recognized | same "create one" hint | names the path, lists what it found and what is accepted, exit 1 |
| `--kernel <missing path>` | same "create one" hint | names the path, exit 1 |

`--json` keeps stdout parseable: diagnostics go to stderr, `[]` to stdout.

**Docs** gain a *Making tasks visible to the CLI* section in both locales — the commands do not boot the app, which paths they probe, both accepted shapes, the registrar as canonical for application code, and the reminder to resolve services inside the callback. Two other broken promises in that same block are fixed while here: `schedule:run` takes `--task`, not a positional name, and `schedule:work` does not exist at all (`commands.ts` registers only `schedule:list` and `schedule:run`). `cloudflare.md` gets a cross-reference so its factory example reads as one valid shape rather than the requirement.

## Scope

`cli`, `docs`. No example, template, or scaffold sources changed.

## Risk Assessment

Purely widening: every kernel the loader accepted before is still accepted on the same path, and the factory pass runs first. The one behavioral narrowing is that the factory pass skips exports with arity ≥ 1, which no doc or template teaches — that is what keeps a registrar named `schedule` from being called with `undefined` before the registrar pass sees it.

Kernel paths are now probed with `isDefinitelyAbsent` from `discovery.ts` rather than `existsSync`, which answers "absent" for a path whose directory cannot be read — the same illegibility this PR removes, one layer down.

New non-zero exits on `schedule:list` / `schedule:run` for a kernel that exists but cannot be used. A missing kernel keeps today's exit code, so a cron entry in an app with no kernel is unaffected.

A registrar whose name misses the convention (`scheduleTasks(scheduler)`) is not called. It reports as unrecognized, naming what it found and both accepted conventions, and exits non-zero — a near-miss is actionable rather than silent.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run lint` — clean, and mutation-checked (an injected unused variable made it exit 1, so the green run is real)
- [x] `bun run test:bun cli` — 2338 pass, 0 fail
- [x] `bun run audit:docs`, `bun run audit:core-first`

`bun run test:examples` was not run: no example source changed (`git status` clean there; codegen output is gitignored).

Twelve new tests in `packages/cli/tests/schedule.test.ts` cover registrar discovery, double-export dedupe, an async registrar (its tasks, and its rejection), a one-argument export the convention excludes, a near-miss name, and each of the reporting states. The existing tests in that file asserted nothing (`await listScheduledTasks(...)` with no expectation), so they would have passed either way. Each test gets a fresh fixture directory — `import()` caches by URL, so a second kernel written to an already-loaded path is never read.

Both new doc anchors were checked against the site's own slugger (`packages/plugin-markdown/src/slugger.ts`), not assumed.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.

## Adjacent finding, deliberately not fixed here

`bunx guren add schedule` (`packages/cli/src/blueprints.ts`) writes the factory-shape kernel and wires core's `SchedulingServiceProvider`, which is only `singleton('scheduler', () => createScheduler())` and never reads the kernel. So `add schedule` produces a kernel that `schedule:list` now sees and that `scheduler.start()` runs nothing from — the mirror image of this defect. The new docs state the missing step honestly ("a factory declares the tasks but runs nothing on its own"); wiring the scaffold's two halves together belongs in its own PR.

