### PR TITLE
fix(cli): feed the schedule kernel to the scheduler add schedule binds

### DIFF
--- a/.changeset/schedule-blueprint-provider.md
+++ b/.changeset/schedule-blueprint-provider.md
@@ -6,4 +6,4 @@
 
 The blueprint now also scaffolds `app/Providers/SchedulingProvider.ts` — the shape the [Cloudflare Workers guide](https://guren.dev/en/guides/cloudflare#scheduled-tasks) already teaches and `examples/blog` uses — which rebinds `scheduler` with `scheduleTasksKernel().buildTasks()` added to it, and registers it after core's so the binding wins. A scheduler is still not a clock: call `start()` from your bootstrap on a long-lived process, or let a platform cron trigger drive it.
 
-An app that already ran the blueprint installs the provider by re-running it: an existing `app/Console/Kernel.ts` is now left unchanged rather than aborting the command.
+An app that already ran the blueprint installs the provider by re-running it: an existing `app/Console/Kernel.ts` is now left unchanged rather than aborting the command. A kernel that exports no `scheduleTasksKernel` — the registrar shape `schedule:list` also reads — gets no provider and a warning naming the missing step, since that provider's import would fail the app's boot.

--- a/.changeset/schedule-blueprint-provider.md
+++ b/.changeset/schedule-blueprint-provider.md
@@ -1,0 +1,7 @@
+---
+"@guren/cli": patch
+---
+
+**`guren add schedule` now feeds the kernel it writes to the scheduler it binds** — the blueprint wrote `app/Console/Kernel.ts` and wired core's `SchedulingServiceProvider`, whose `register()` only binds `createScheduler()`. Nothing read the kernel, so the container's scheduler held zero tasks and the sample `app-heartbeat` never reached it. `guren schedule:list` hid the gap by loading the kernel file directly.
+
+The blueprint now also scaffolds `app/Providers/SchedulingProvider.ts` — the shape the [Cloudflare Workers guide](https://guren.dev/en/guides/cloudflare#scheduled-tasks) already teaches and `examples/blog` uses — which rebinds `scheduler` with `scheduleTasksKernel().buildTasks()` added to it, and registers it after core's so the binding wins. A scheduler is still not a clock: call `start()` from your bootstrap on a long-lived process, or let a platform cron trigger drive it.

--- a/.changeset/schedule-blueprint-provider.md
+++ b/.changeset/schedule-blueprint-provider.md
@@ -5,3 +5,5 @@
 **`guren add schedule` now feeds the kernel it writes to the scheduler it binds** — the blueprint wrote `app/Console/Kernel.ts` and wired core's `SchedulingServiceProvider`, whose `register()` only binds `createScheduler()`. Nothing read the kernel, so the container's scheduler held zero tasks and the sample `app-heartbeat` never reached it. `guren schedule:list` hid the gap by loading the kernel file directly.
 
 The blueprint now also scaffolds `app/Providers/SchedulingProvider.ts` — the shape the [Cloudflare Workers guide](https://guren.dev/en/guides/cloudflare#scheduled-tasks) already teaches and `examples/blog` uses — which rebinds `scheduler` with `scheduleTasksKernel().buildTasks()` added to it, and registers it after core's so the binding wins. A scheduler is still not a clock: call `start()` from your bootstrap on a long-lived process, or let a platform cron trigger drive it.
+
+An app that already ran the blueprint installs the provider by re-running it: an existing `app/Console/Kernel.ts` is now left unchanged rather than aborting the command.

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -319,9 +319,16 @@ export default registerAdminRoutes
       const writerOptions: WriterOptions = { force: Boolean(options.force) }
       const created = await writeScaffoldFiles([
         scaffoldTemplateFile('schedule', 'app/Console/Kernel.ts'),
+        scaffoldTemplateFile('schedule', 'app/Providers/SchedulingProvider.ts'),
       ], writerOptions)
 
-      await wireProviders([{ name: 'CoreSchedulingServiceProvider', importStatement: "import { SchedulingServiceProvider as CoreSchedulingServiceProvider } from '@guren/core'" }])
+      // Order matters: the app provider registers after core's and rebinds
+      // `scheduler` with the kernel's tasks. Core's binding on its own is an empty
+      // scheduler, which no task from the kernel this just wrote ever reaches.
+      await wireProviders([
+        { name: 'CoreSchedulingServiceProvider', importStatement: "import { SchedulingServiceProvider as CoreSchedulingServiceProvider } from '@guren/core'" },
+        { name: 'SchedulingProvider' },
+      ])
 
       return created
     },

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -46,6 +46,12 @@ export interface BlueprintDefinition {
   run: (options: RunBlueprintOptions) => Promise<string[]>
 }
 
+/** The scaffolded schedule kernel, and the export `SchedulingProvider` imports from it. */
+const SCHEDULE_KERNEL_PATH = 'app/Console/Kernel.ts'
+const SCHEDULE_KERNEL_EXPORT = 'scheduleTasksKernel'
+/** `export` and the name on one line: the function, `const`, and re-export forms. */
+const SCHEDULE_KERNEL_EXPORT_PATTERN = /\bexport\b[^\n]*\bscheduleTasksKernel\b/
+
 const blueprintRegistry: Record<string, BlueprintDefinition> = {
   attachments: {
     description: 'Install the attachments layer: schema table, config, provider, and the prune command.',
@@ -317,20 +323,31 @@ export default registerAdminRoutes
     description: 'Install a schedule kernel with a sample recurring task.',
     run: async (options) => {
       const writerOptions: WriterOptions = { force: Boolean(options.force) }
+      // The provider imports `scheduleTasksKernel`. A kernel already on disk that
+      // exports something else — the registrar shape `schedule:list` also reads —
+      // makes that provider a file the app cannot boot, so it is not written.
+      const existingKernel = writerOptions.force ? null : await readIfExists(process.cwd(), SCHEDULE_KERNEL_PATH)
+      const kernelFeedsProvider = existingKernel === null || SCHEDULE_KERNEL_EXPORT_PATTERN.test(existingKernel)
+
       // `skipExisting`, so an app that ran this before the provider existed can
       // re-run it for the provider alone: without it the present Kernel.ts aborts
       // the command, and --force would overwrite the tasks the app has written.
       const created = await writeScaffoldFiles([
-        scaffoldTemplateFile('schedule', 'app/Console/Kernel.ts'),
-        scaffoldTemplateFile('schedule', 'app/Providers/SchedulingProvider.ts'),
+        scaffoldTemplateFile('schedule', SCHEDULE_KERNEL_PATH),
+        ...(kernelFeedsProvider ? [scaffoldTemplateFile('schedule', 'app/Providers/SchedulingProvider.ts')] : []),
       ], { ...writerOptions, skipExisting: true })
+
+      if (!kernelFeedsProvider) {
+        consola.warn(`${SCHEDULE_KERNEL_PATH} exports no ${SCHEDULE_KERNEL_EXPORT}() — app/Providers/SchedulingProvider.ts was not written.`)
+        consola.info('Feed your own kernel to the scheduler from a provider of your own, or its tasks reach no scheduler: https://guren.dev/en/guides/scheduling')
+      }
 
       // Order matters: the app provider registers after core's and rebinds
       // `scheduler` with the kernel's tasks. Core's binding on its own is an empty
       // scheduler, which no task from the kernel this just wrote ever reaches.
       await wireProviders([
         { name: 'CoreSchedulingServiceProvider', importStatement: "import { SchedulingServiceProvider as CoreSchedulingServiceProvider } from '@guren/core'" },
-        { name: 'SchedulingProvider' },
+        ...(kernelFeedsProvider ? [{ name: 'SchedulingProvider' }] : []),
       ])
 
       return created

--- a/packages/cli/src/blueprints.ts
+++ b/packages/cli/src/blueprints.ts
@@ -317,10 +317,13 @@ export default registerAdminRoutes
     description: 'Install a schedule kernel with a sample recurring task.',
     run: async (options) => {
       const writerOptions: WriterOptions = { force: Boolean(options.force) }
+      // `skipExisting`, so an app that ran this before the provider existed can
+      // re-run it for the provider alone: without it the present Kernel.ts aborts
+      // the command, and --force would overwrite the tasks the app has written.
       const created = await writeScaffoldFiles([
         scaffoldTemplateFile('schedule', 'app/Console/Kernel.ts'),
         scaffoldTemplateFile('schedule', 'app/Providers/SchedulingProvider.ts'),
-      ], writerOptions)
+      ], { ...writerOptions, skipExisting: true })
 
       // Order matters: the app provider registers after core's and rebinds
       // `scheduler` with the kernel's tasks. Core's binding on its own is an empty

--- a/packages/cli/templates/scaffold/schedule/app/Providers/SchedulingProvider.ts
+++ b/packages/cli/templates/scaffold/schedule/app/Providers/SchedulingProvider.ts
@@ -1,0 +1,27 @@
+import { ServiceProvider, createScheduler, type Scheduler } from '@guren/core'
+import { scheduleTasksKernel } from '../Console/Kernel.js'
+
+/**
+ * Feeds the kernel's tasks to the scheduler bound as `scheduler`. A scheduler is
+ * not a clock: on a long-lived Bun process call `start()` on it from your
+ * bootstrap, and on Workers / Lambda the platform's cron trigger supplies the tick.
+ */
+export default class SchedulingProvider extends ServiceProvider {
+  register(): void {
+    this.container.singleton('scheduler', () => {
+      // Without a logger, a task that throws is caught by runDueTasks() and discarded.
+      const scheduler = createScheduler({ logger: console.log })
+
+      for (const task of scheduleTasksKernel().buildTasks()) {
+        scheduler.addTask(task)
+      }
+
+      return scheduler
+    })
+  }
+
+  boot(): void {
+    // Eager, so a kernel that throws fails the boot rather than the first firing.
+    this.container.make<Scheduler>('scheduler')
+  }
+}

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -564,6 +564,15 @@ export const users = pgTable('users', {
     expect(eventFiles.some((file) => file.endsWith('app/Providers/EventProvider.ts'))).toBe(true)
     expect(cacheFiles.some((file) => file.endsWith('app/Providers/CacheProvider.ts'))).toBe(true)
     expect(scheduleFiles.some((file) => file.endsWith('app/Console/Kernel.ts'))).toBe(true)
+    expect(scheduleFiles.some((file) => file.endsWith('app/Providers/SchedulingProvider.ts'))).toBe(true)
+
+    // The kernel declares tasks and runs nothing; core's provider binds a scheduler
+    // with none. Without this feed, `app-heartbeat` never reaches the container's
+    // scheduler even though `schedule:list` reads it straight off the kernel.
+    const schedulingProviderSource = await readFile('app/Providers/SchedulingProvider.ts', 'utf8')
+    expect(schedulingProviderSource).toContain("this.container.singleton('scheduler'")
+    expect(schedulingProviderSource).toContain('scheduleTasksKernel().buildTasks()')
+    expect(schedulingProviderSource).toContain('scheduler.addTask(task)')
     expect(notificationFiles.some((file) => file.endsWith('app/Providers/NotificationProvider.ts'))).toBe(true)
     expect(storageFiles.some((file) => file.endsWith('app/Providers/StorageProvider.ts'))).toBe(true)
 
@@ -601,6 +610,7 @@ export const users = pgTable('users', {
     expect(appSource).toContain('NotificationProvider')
     expect(appSource).toContain('StorageProvider')
     expect(appSource).toContain('BroadcastProvider')
+    expect(appSource).toContain('SchedulingProvider')
     expect(appSource).toContain('OAuthProvider')
 
     const routesSource = await readFile('routes/web.ts', 'utf8')
@@ -609,6 +619,20 @@ export const users = pgTable('users', {
     expect(adminFiles.some((file) => file.endsWith('routes/admin.ts'))).toBe(true)
     expect(routesSource).toContain("import registerAdminRoutes from './admin.js'")
     expect(routesSource).toContain('registerAdminRoutes(router)')
+  })
+
+  // `container.singleton()` overwrites its key, so the app provider only wins by
+  // registering after core's. Reversed, core rebinds a task-less scheduler over it.
+  it('registers the schedule app provider after the core one', async () => {
+    await seedAppFile(APP_FIXTURE)
+
+    await runBlueprint('schedule')
+
+    const providers = (await readFile('src/app.ts', 'utf8')).match(/providers:\s*\[([^\]]*)\]/)?.[1] ?? ''
+    expect(providers.split(',').map((entry) => entry.trim())).toEqual([
+      'CoreSchedulingServiceProvider',
+      'SchedulingProvider',
+    ])
   })
 
   // `addImport`/`addProvider` report an unpatchable app entry by returning a

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -621,6 +621,21 @@ export const users = pgTable('users', {
     expect(routesSource).toContain('registerAdminRoutes(router)')
   })
 
+  // The population that has the bug this provider fixes all have a Kernel.ts
+  // already; aborting on it, or overwriting their tasks under --force, leaves
+  // them no way to install the provider by re-running the blueprint.
+  it('adds the schedule provider to an app whose kernel already exists', async () => {
+    await seedAppFile(APP_FIXTURE)
+    await mkdir('app/Console', { recursive: true })
+    await writeFile('app/Console/Kernel.ts', 'export function scheduleTasksKernel() { return null }\n')
+
+    const created = await runBlueprint('schedule')
+
+    expect(created.some((file) => file.endsWith('app/Providers/SchedulingProvider.ts'))).toBe(true)
+    expect(await readFile('app/Console/Kernel.ts', 'utf8')).not.toContain('app-heartbeat')
+    expect(await readFile('src/app.ts', 'utf8')).toContain('SchedulingProvider')
+  })
+
   // `container.singleton()` overwrites its key, so the app provider only wins by
   // registering after core's. Reversed, core rebinds a task-less scheduler over it.
   it('registers the schedule app provider after the core one', async () => {

--- a/packages/cli/tests/blueprints.test.ts
+++ b/packages/cli/tests/blueprints.test.ts
@@ -636,6 +636,27 @@ export const users = pgTable('users', {
     expect(await readFile('src/app.ts', 'utf8')).toContain('SchedulingProvider')
   })
 
+  // The scaffolded provider imports scheduleTasksKernel; a registrar kernel (the
+  // other shape schedule:list reads) exports no such thing, so writing it anyway
+  // hands the app a provider whose import fails at boot.
+  it('writes no schedule provider against a kernel it cannot import', async () => {
+    await seedAppFile(APP_FIXTURE)
+    await mkdir('app/Console', { recursive: true })
+    await writeFile(
+      'app/Console/Kernel.ts',
+      'import type { Scheduler } from \'@guren/core\'\n\nexport function registerSchedules(scheduler: Scheduler): void {}\n',
+    )
+
+    const { result: created, warnings } = await captureWarnings(() => runBlueprint('schedule'))
+
+    expect(created.some((file) => file.endsWith('app/Providers/SchedulingProvider.ts'))).toBe(false)
+    expect(existsSync('app/Providers/SchedulingProvider.ts')).toBe(false)
+    expect(warnings.join('\n')).toContain('exports no scheduleTasksKernel()')
+    // Registering a provider whose file was not written is the same broken boot.
+    const providers = (await readFile('src/app.ts', 'utf8')).match(/providers:\s*\[([^\]]*)\]/)?.[1] ?? ''
+    expect(providers.split(',').map((entry) => entry.trim())).toEqual(['CoreSchedulingServiceProvider'])
+  })
+
   // `container.singleton()` overwrites its key, so the app provider only wins by
   // registering after core's. Reversed, core rebinds a task-less scheduler over it.
   it('registers the schedule app provider after the core one', async () => {

--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -477,6 +477,16 @@ async function assertFeatureScaffolds(appDir: string): Promise<void> {
   const scheduleKernel = await readFile(join(appDir, 'app/Console/Kernel.ts'), 'utf8')
   assert(scheduleKernel.includes("import { Schedule } from '@guren/core'"), 'Schedule blueprint must import Schedule from @guren/core.')
   assert(scheduleKernel.includes("name('app-heartbeat')"), 'Schedule blueprint must register the sample heartbeat task.')
+
+  // The kernel only declares tasks; without this provider feeding them in, the
+  // scaffolded app boots a scheduler with none of them.
+  const schedulingProvider = await readFile(join(appDir, 'app/Providers/SchedulingProvider.ts'), 'utf8')
+  assert(schedulingProvider.includes('createScheduler'), 'Schedule blueprint provider must create a scheduler.')
+  assert(schedulingProvider.includes("this.container.singleton('scheduler'"), 'Schedule blueprint provider must bind the scheduler in the container.')
+  assert(
+    schedulingProvider.includes('scheduleTasksKernel().buildTasks()') && schedulingProvider.includes('scheduler.addTask(task)'),
+    'Schedule blueprint provider must feed the kernel tasks to the scheduler.',
+  )
 }
 
 /**
@@ -708,6 +718,9 @@ async function main(): Promise<void> {
       assert(appTs.includes('EventServiceProvider'), 'Worker blueprint must scaffold events.')
       assert(appTs.includes('CacheServiceProvider'), 'Worker blueprint must scaffold cache.')
       assert(appTs.includes('SchedulingServiceProvider'), 'Worker blueprint must scaffold schedule.')
+      // Anchored on the providers array: the import line alone would satisfy a
+      // plain substring check while the provider stayed unregistered.
+      assert(/providers:\s*\[[^\]]*\bSchedulingProvider\b/.test(appTs), 'Worker blueprint must register the app scheduling provider.')
       await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'codegen', '--force'], appDir, runtimeEnv)
       await run(['bun', resolve(repoRoot, 'packages/cli/src/bin.ts'), 'codegen', '--routes', 'routes/web.ts', '--out', 'types/generated/routes.d.ts', '--force'], appDir, runtimeEnv)
     }


### PR DESCRIPTION
## Problem

`bunx guren add schedule` produced a schedule kernel that nothing ever ran.

The blueprint wrote `app/Console/Kernel.ts` (exporting `scheduleTasksKernel()`, which declares a sample `app-heartbeat` task) and wired core's `SchedulingServiceProvider`, whose `register()` is only `this.container.singleton('scheduler', () => createScheduler())`. Nothing read the kernel, so the scheduler bound in the container held zero tasks. `guren schedule:list` hid the gap: it loads the kernel file directly and never looks at the container.

Measured on a scaffolded app, booting it and reading `container.make('scheduler').getTasks()`:

| providers | tasks reaching the scheduler |
|---|---|
| before this PR (`CoreSchedulingServiceProvider`) | `[]` |
| after (`CoreSchedulingServiceProvider, SchedulingProvider`) | `["app-heartbeat"]` |
| after, order reversed | `[]` |

## Fix

The blueprint now also scaffolds `app/Providers/SchedulingProvider.ts` — the shape `docs/en/guides/cloudflare.md` teaches under "Scheduled Tasks" and `examples/blog` / `examples/api` already use — which rebinds `scheduler` with `scheduleTasksKernel().buildTasks()` fed in, and registers it *after* core's so `container.singleton()` overwrites the empty binding. This keeps every other blueprint's two-entry shape (`queue`, `mail`, `events`, `storage`, `broadcasting` all pair a core provider with an app one), and needs no change to `@guren/server`.

Two follow-on cases the fix has to cover, since the population that has this bug all have a kernel already:

- **Re-running installs the provider alone.** The scaffold files are written with `skipExisting`, so an existing `app/Console/Kernel.ts` is left unchanged instead of aborting the command — `--force` would have overwritten the tasks the app has written.
- **A kernel the provider cannot import gets no provider.** A registrar-shaped kernel (`export function registerSchedules(scheduler: Scheduler)`, the other shape `schedule:list` reads) exports no `scheduleTasksKernel`, so writing the provider anyway hands the app a boot-time `SyntaxError: Export named 'scheduleTasksKernel' not found`. Verified directly before adding the guard. That case now writes neither the provider nor its registration, and reports the one step the app has to wire itself.

A scheduler is still not a clock — nothing in the framework, the examples, or the scaffold calls `start()`. What changes is that the tasks now reach the scheduler that a bootstrap's `start()`, a Cloudflare cron trigger, or the Lambda schedule handler resolves. The provider's docblock says so.

## `guren check` for hand-written apps

Judged out of scope, as a decision rather than a deferral: "a `SchedulingServiceProvider` bound with no tasks reaching it" is not statically decidable. Tasks can arrive through `addTask` from any provider, through a registrar, or from a module, and no CLI command boots the app. Any rule would either false-positive on the examples' own shape or fail open.

## Overlap

Touches no file that the in-flight schedule-kernel loader work touches (`packages/cli/src/schedule.ts`, `docs/{en,ja}/guides/scheduling.md`). That change's line — "a factory declares the tasks but runs nothing on its own, a provider still has to feed them" — is what this PR makes the scaffold do, so no doc edit is needed here.

## Verification

- `bun run lint`, `bun run typecheck` (incl. `typecheck:scaffold-templates`, which compiles the new provider template), `bun run audit:starter-template`, `bun run audit:core-first`, `bun run audit:docs`, `bun run audit:workspace-scripts` — all green.
- `bun run smoke:starter` and `bun run smoke:starter:worker` — green, with new assertions on the provider's contents and on the providers array itself (anchored on `providers: [...]`, since the import line alone would satisfy a substring check).
- CLI package tests: 2333 pass / 0 fail. Note `bun run test:bun cli` segfaults on macOS at `packages/cli/tests/tool-dev.test.ts` under `--isolate` — the known Bun 1.3.14 crash, reproduced twice at the same file and unrelated to this change; the same suite without `--isolate` is fully green.
- The new registrar test was mutation-checked: forcing the guard to `true` fails it.
