### PR TITLE
fix(cli): split array entries at depth 0 instead of on every comma

### DIFF
--- a/.changeset/array-entries-depth-split.md
+++ b/.changeset/array-entries-depth-split.md
@@ -1,0 +1,7 @@
+---
+"@guren/cli": patch
+---
+
+**Array-entry parsing now splits at depth 0**, so an entry holding a comma is one entry. Every patcher that answers "is this already registered" — `guren plugin`, `guren add`'s provider wiring, `make:module`, `make:command` — split an array literal's interior on *every* comma, with no awareness of nesting: `providers: [mcpPlugin({ path: '/mcp', prefix: '/x' })]` parsed as the two fragments `mcpPlugin({ path: '/mcp'` and `prefix: '/x' })`, and a nested array split the same way. A fragment matches neither the exact value a caller looks for nor, once the entry does not begin with the factory call, its prefix — so an existing registration read as absent and the command appended a duplicate.
+
+Nesting is tracked with a stack over `()`, `[]` and `{}` on the same masked copy as before, so a name mentioned only in a comment still does not read as a registration. Regex literals are not masked; an unmatched closer stops the split there rather than cutting a fragment out of an entry, and the splits made before it stand.

--- a/packages/cli/src/patch-helpers.ts
+++ b/packages/cli/src/patch-helpers.ts
@@ -99,17 +99,38 @@ export function findClosingDelimiter(content: string, openIndex: number, open: s
   return -1
 }
 
+/** The closer each opener `parseArrayEntries` tracks expects to see. */
+const ARRAY_ENTRY_CLOSERS: Record<string, string> = { '(': ')', '[': ']', '{': '}' }
+
 /**
- * Entries of an array literal's interior. Masked first, so a name appearing
- * only in a comment is not mistaken for an existing entry — which is also why
- * the result answers membership only: string contents come out blanked, so
+ * Entries of an array literal's interior, split at depth 0 only. Masked first,
+ * so a name in a comment is not mistaken for an entry — which is also why the
+ * result answers membership only: string contents come out blanked, so
  * re-joining these entries into the file writes `'/mcp'` back as `'    '`.
+ * Regex literals are not masked; an unmatched closer stops the split there.
  */
 function parseArrayEntries(inner: string): string[] {
-  return maskNonCode(inner)
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0)
+  const masked = maskNonCode(inner)
+  const closers: string[] = []
+  const entries: string[] = []
+  let start = 0
+
+  for (let i = 0; i < masked.length; i++) {
+    const char = masked[i]
+    const closer = ARRAY_ENTRY_CLOSERS[char]
+
+    if (closer !== undefined) {
+      closers.push(closer)
+    } else if (char === ')' || char === ']' || char === '}') {
+      if (closers.pop() !== char) break
+    } else if (char === ',' && closers.length === 0) {
+      entries.push(masked.slice(start, i))
+      start = i + 1
+    }
+  }
+
+  entries.push(masked.slice(start))
+  return entries.map((entry) => entry.trim()).filter((entry) => entry.length > 0)
 }
 
 /**

--- a/packages/cli/tests/patch-helpers.test.ts
+++ b/packages/cli/tests/patch-helpers.test.ts
@@ -727,3 +727,66 @@ export const schema = { users }
     expect(warned).not.toContain('moving `export const sessions`')
   })
 })
+
+describe('array entries — depth-0 splitting', () => {
+  async function withFile(name: string, contents: string, run: () => Promise<void>): Promise<string> {
+    const workspace = await createTempWorkspace('guren-cli-array-depth-')
+    try {
+      await writeWorkspaceFiles(workspace.dir, { [name]: contents })
+      await run()
+      return await readFile(join(workspace.dir, name), 'utf8')
+    } finally {
+      await workspace.cleanup()
+    }
+  }
+
+  it('reads an entry whose object argument holds a comma as one entry', () => {
+    const app = 'createApp({ providers: [mcpPlugin({ path: mcpPath, prefix: mcpPrefix })] })'
+
+    const result = insertProvider(app, 'mcpPlugin({ path: mcpPath, prefix: mcpPrefix })')
+
+    expect(result.reason).toBe(PATCH_REASONS.providerAlreadyRegistered)
+  })
+
+  // The prefix predicate matched the leading fragment either way, so it is the
+  // half of `guren plugin` that never broke — pinned so the split cannot lose it.
+  it('still recognizes a factory prefix across that comma', () => {
+    const app = "createApp({ providers: [mcpPlugin({ path: '/mcp', prefix: '/x' })] })"
+
+    const result = insertProvider(app, 'mcpPlugin()', (entries) =>
+      entries.some((entry) => entry.startsWith('mcpPlugin(')),
+    )
+
+    expect(result.reason).toBe(PATCH_REASONS.providerAlreadyRegistered)
+  })
+
+  it('reads an entry holding a nested array as one entry', async () => {
+    const source = 'kernel.registerMany([group([alpha, beta])])\n'
+    const result = await withFile('src/console.ts', source, async () => {
+      const patch = await addToArrayArgument('src/console.ts', 'registerMany', 'group([alpha, beta])')
+      expect(patch.reason).toBe(PATCH_REASONS.alreadyPresent)
+    })
+    expect(result).toBe(source)
+  })
+
+  it('detects a valueSource that itself contains a comma on a second run', async () => {
+    const result = await withFile('src/app.ts', 'const app = createApp({ modules: [] })\n', async () => {
+      expect((await addToArrayOption('src/app.ts', 'modules', 'billingModule(extra, more)')).modified).toBe(true)
+      const second = await addToArrayOption('src/app.ts', 'modules', 'billingModule(extra, more)')
+      expect(second.reason).toBe(PATCH_REASONS.alreadyPresent)
+    })
+    expect(result).toBe('const app = createApp({ modules: [billingModule(extra, more)] })\n')
+  })
+
+  // Regex literals are not masked: the comma inside one sits at depth 1 and is
+  // no separator, and the `}` closes a brace never opened, which stops the
+  // split there — `Basic`, already split off before it, stands.
+  it('stops splitting at an unbalanced closer instead of cutting a fragment', async () => {
+    const source = 'kernel.registerMany([Basic, match(/a,}b/)])\n'
+    const result = await withFile('src/console.ts', source, async () => {
+      const patch = await addToArrayArgument('src/console.ts', 'registerMany', 'match(/a,}b/)')
+      expect(patch.reason).toBe(PATCH_REASONS.alreadyPresent)
+    })
+    expect(result).toBe(source)
+  })
+})


### PR DESCRIPTION
## Problem

`parseArrayEntries()` in `packages/cli/src/patch-helpers.ts` split an array literal's interior on **every** comma, with no awareness of nesting:

```ts
providers: [mcpPlugin({ path: '/mcp', prefix: '/x' })]
```

parsed as the two fragments `mcpPlugin({ path: '/mcp'` and `prefix: '/x' })`. A nested array split the same way.

A fragment matches neither the exact value a caller looks for, nor — once the entry does not begin with the factory call — its prefix. So an existing registration reads as absent and the command appends a duplicate. This reaches every patcher that answers "is this already registered": `guren plugin`, `guren add`'s provider wiring, `make:module`, `make:command`.

## Change

Nesting is tracked with a stack over `()`, `[]` and `{}`, on the same masked copy as before — masking is deliberate and stays, since it is what stops a name mentioned only in a comment from reading as a registration.

Regex literals are *not* masked, so an unmatched closer means the depth from there on cannot be trusted. The split stops at that point rather than cutting a fragment out of an entry, and splits already made stand — the stack was consistent up to there. Resetting instead would regress an input the old code handled (`[Basic, match(/a}b/)]`, registering `Basic`).

## Tests

Five cases in `packages/cli/tests/patch-helpers.test.ts`. **Four were verified to fail against the previous implementation**, each on its own assertion with `reason: undefined` — i.e. it appended a duplicate — rather than on a file-level error:

- an entry whose object argument holds a comma
- an entry holding a nested array
- a `valueSource` that itself contains a comma, asserted as idempotency across two runs
- an unbalanced closer from a regex literal

The fifth pins that the factory-prefix predicate in `plugin.ts` still matches across a nested comma. That one passed before and after: it matched the leading fragment either way, and is included so the change cannot lose it.

## Note for the reviewer

This was written against `main` before #733 merged, and has since been rebased onto #733 and #737, both of which touch the same file.

Against #733: the two overlap only in `parseArrayEntries`'s doc comment, whose facts are now merged into one block. `insertProvider` itself is untouched here — #733 owns that.

Against #737: git interleaved the two end-of-file test blocks, so the resolution took #737's file wholesale and re-appended this block, which now uses its `writeWorkspaceFiles` helper rather than its own `mkdir`/`writeFile` pair. Both resolutions were checked by diffing the result against `main` — `patch-helpers.ts` and the test file each come out as this change alone.

## Follow-up, not in this PR

A second, independent duplicate-producer lives in the same function's contract: entries come back **masked**, but all three call sites compare them against an **unmasked** `providerName` / `valueSource`. Any value containing a string literal therefore never matches, however correctly the array is parsed. Fixtures here use identifier arguments to isolate the nesting defect from that one.

## Gates

`build`, `typecheck`, `lint`, and the cli suite (2354 pass / 0 fail across 137 files) are green on the rebased tree; `audit:starter-template` was run as well, since this changes what a patcher writes when an existing entry contains a comma.

Note that `bun run test:bun cli` segfaults under Bun 1.3.14 on macOS with `--isolate` — a known local crash unrelated to this change. The run above is the same suite without `--isolate`.

