### PR TITLE
build: drop the last guren/comment-* exemption

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -76,13 +76,6 @@
         "packages/cli/tests/define-command.test.ts"
       ],
       "rules": { "no-restricted-imports": "off" }
-    },
-    {
-      // The one template still exempt: gurenjs/guren#726 (RFC 0020 Part 5)
-      // rewrites this block into three, so trimming it here would only collide.
-      // Delete this entry when #726 lands; lint then proves it is spent.
-      "files": ["packages/cli/templates/scaffold/session/config/session.ts"],
-      "rules": { "guren/comment-length": "off" }
     }
   ]
 }


### PR DESCRIPTION
Follow-up to #731, which narrowed the `guren/comment-*` override down to one file and named the condition for deleting it.

That condition is met: #726 (RFC 0020 Part 5) split the 11-line block in `packages/cli/templates/scaffold/session/config/session.ts` into three, so the exemption is spent. With the entry removed, `bun run lint` exits 0 — the five comment rules now run on the whole repository with no override at all.

The remaining `overrides` entries are the unrelated `no-restricted-imports` pair for citty's `defineCommand`.

No changeset: `.oxlintrc.json` is repo config and ships nothing.

## Verification

`bun run lint` — exit 0.