### PR TITLE
fix(orm): keep soft deletes inside the caller's transaction

### DIFF
--- a/.changeset/soft-deletes-transaction-handle.md
+++ b/.changeset/soft-deletes-transaction-handle.md
@@ -1,0 +1,9 @@
+---
+"@guren/orm": patch
+---
+
+**`SoftDeletes` runs inside the transaction it was given** — the mixin's `delete()` override was declared `(where)` only and cast to `typeof Model.delete`, so the write options carrying `trx` were dropped where the type system could not see it. A soft delete made inside `Model.transaction()` therefore ran on the default connection: it survived a rollback, and the transaction's own reads could not see it. The override now takes `writeOptions` and threads them into the scoped builder, which is all `Model.transaction()`'s bound scope needed — `txPost.delete({ id })` is correct with no change to the transaction proxy.
+
+`restore()`, `forceDelete()`, `withTrashed()` and `onlyTrashed()` could not be given a transaction at all, since they reach trashed rows through `withoutGlobalScope()`, which took only scope names. Each now accepts write or query options as a trailing argument, and `withoutGlobalScope()` gained an overload taking them *first* — `names` is a rest parameter and cannot be followed by an optional one. The name-only form is unchanged. `withoutGlobalScopes()` takes them trailing, like every other entry point.
+
+`forceDelete()` is the sharp end of the group: a hard delete that escapes the surrounding rollback cannot be undone.

--- a/.changeset/soft-deletes-transaction-handle.md
+++ b/.changeset/soft-deletes-transaction-handle.md
@@ -1,5 +1,5 @@
 ---
-"@guren/orm": patch
+"@guren/orm": minor
 ---
 
 **`SoftDeletes` runs inside the transaction it was given** — the mixin's `delete()` override was declared `(where)` only and cast to `typeof Model.delete`, so the write options carrying `trx` were dropped where the type system could not see it. A soft delete made inside `Model.transaction()` therefore ran on the default connection: it survived a rollback, and the transaction's own reads could not see it. The override now takes `writeOptions` and threads them into the scoped builder, which is all `Model.transaction()`'s bound scope needed — `txPost.delete({ id })` is correct with no change to the transaction proxy.

--- a/docs/en/guides/database.md
+++ b/docs/en/guides/database.md
@@ -673,6 +673,19 @@ the `softDelete` filter so they reach trashed rows, and keep the rest — a
 `tenant` scope still stops a force delete, which cannot be undone, from reaching
 another tenant's row.
 
+Inside a transaction, every one of them takes the handle. The transaction-bound
+scope covers `delete()`; the rest take it as a trailing argument, like any other
+write:
+
+```ts
+await Post.transaction(async (trx, txPost) => {
+  await txPost.delete({ id: 1 })
+  await Post.restore({ id: 2 }, { trx })
+  await Post.forceDelete({ id: 3 }, { trx })
+  const trashed = await Post.onlyTrashed({ trx }).get()
+})
+```
+
 > [!TIP]
 > Your schema must include a `deletedAt` timestamp column for soft deletes to work.
 

--- a/docs/ja/guides/database.md
+++ b/docs/ja/guides/database.md
@@ -596,6 +596,18 @@ await Post.forceDelete({ id: 1 })
 残りのスコープは維持します。したがって `tenant` スコープがあれば、取り消しのきかない
 `forceDelete()` が別テナントの行に届くことはありません。
 
+トランザクション内では、いずれもハンドルを受け取れます。`delete()` はトランザクション
+スコープが担い、残りは他の書き込みと同じく末尾の引数で受け取ります。
+
+```ts
+await Post.transaction(async (trx, txPost) => {
+  await txPost.delete({ id: 1 })
+  await Post.restore({ id: 2 }, { trx })
+  await Post.forceDelete({ id: 3 }, { trx })
+  const trashed = await Post.onlyTrashed({ trx }).get()
+})
+```
+
 ## 属性キャスト
 
 `static casts` を定義すると、データベースから読み取ったカラムの値を自動的に変換できます。

--- a/packages/orm/src/Model.ts
+++ b/packages/orm/src/Model.ts
@@ -321,13 +321,33 @@ export abstract class Model<TRecord extends PlainObject = PlainObject> {
    * this is asked to drop, so a mixin whose filter must be opt-out-able has to
    * register a named scope and nothing else.
    */
-  static withoutGlobalScope<T extends typeof Model>(this: T, ...names: string[]): QueryBuilder<TRecordFor<T>> {
-    return this.buildScopedQuery(undefined, names)
+  static withoutGlobalScope<T extends typeof Model>(this: T, ...names: string[]): QueryBuilder<TRecordFor<T>>
+  /**
+   * Query options lead here because `names` is a rest parameter and cannot be
+   * followed by an optional one; every other entry point takes them trailing.
+   */
+  static withoutGlobalScope<T extends typeof Model>(
+    this: T,
+    queryOptions: ModelQueryOptions,
+    ...names: string[]
+  ): QueryBuilder<TRecordFor<T>>
+  static withoutGlobalScope<T extends typeof Model>(
+    this: T,
+    ...args: Array<string | ModelQueryOptions>
+  ): QueryBuilder<TRecordFor<T>> {
+    const [first, ...rest] = args
+    if (typeof first === 'string' || first === undefined) {
+      return this.buildScopedQuery(undefined, args as string[])
+    }
+    return this.buildScopedQuery(first, rest as string[])
   }
 
   /** A query with no global scopes applied, `defaultScope` included. */
-  static withoutGlobalScopes<T extends typeof Model>(this: T): QueryBuilder<TRecordFor<T>> {
-    return new QueryBuilder<TRecordFor<T>>(this)
+  static withoutGlobalScopes<T extends typeof Model>(
+    this: T,
+    queryOptions?: ModelQueryOptions,
+  ): QueryBuilder<TRecordFor<T>> {
+    return new QueryBuilder<TRecordFor<T>>(this, queryOptions)
   }
 
   /**

--- a/packages/orm/src/SoftDeletes.ts
+++ b/packages/orm/src/SoftDeletes.ts
@@ -1,31 +1,46 @@
-import type { Model, PlainObject } from './Model'
+import type { Model, ModelQueryOptions, ModelWriteOptions, PlainObject } from './Model'
 import { PREPARED_UPDATE, type QueryBuilder } from './QueryBuilder'
 
 /** The static methods the SoftDeletes mixin adds. */
 export interface SoftDeletesStatic {
   deletedAtColumn: string
   /** Start a query that includes soft-deleted records. */
-  withTrashed(): QueryBuilder<PlainObject>
+  withTrashed(queryOptions?: ModelQueryOptions): QueryBuilder<PlainObject>
   /** Start a query that returns only soft-deleted records. */
-  onlyTrashed(): QueryBuilder<PlainObject>
+  onlyTrashed(queryOptions?: ModelQueryOptions): QueryBuilder<PlainObject>
   /** Restore soft-deleted records by setting deletedAt back to null. */
-  restore(where: Partial<Record<string, unknown>>): Promise<PlainObject>
+  restore(where: Partial<Record<string, unknown>>, writeOptions?: ModelWriteOptions): Promise<PlainObject>
   /** Permanently delete records from the database, bypassing soft delete. */
-  forceDelete(where: Partial<Record<string, unknown>>): Promise<number | PlainObject | void>
+  forceDelete(
+    where: Partial<Record<string, unknown>>,
+    writeOptions?: ModelWriteOptions,
+  ): Promise<number | PlainObject | void>
 }
 
-/** A query carrying every global scope this model has, including softDelete. */
-function scopedQuery(model: typeof Model, where: Partial<Record<string, unknown>>): QueryBuilder<PlainObject> {
-  return (model.newQuery() as QueryBuilder<PlainObject>).where(where)
+/**
+ * A query carrying every global scope this model has, including softDelete.
+ * `queryOptions` carries the caller's `trx`; dropping it here sends the write to
+ * the default connection, outside the transaction meant to own it.
+ */
+function scopedQuery(
+  model: typeof Model,
+  where: Partial<Record<string, unknown>>,
+  queryOptions?: ModelQueryOptions,
+): QueryBuilder<PlainObject> {
+  return (model.newQuery(queryOptions) as QueryBuilder<PlainObject>).where(where)
 }
 
 /** A query carrying every global scope *except* softDelete, so it sees trashed rows. */
-function withoutSoftDeleteScope(model: typeof Model): QueryBuilder<PlainObject> {
-  return model.withoutGlobalScope('softDelete') as QueryBuilder<PlainObject>
+function withoutSoftDeleteScope(model: typeof Model, queryOptions?: ModelQueryOptions): QueryBuilder<PlainObject> {
+  return model.withoutGlobalScope(queryOptions ?? {}, 'softDelete') as QueryBuilder<PlainObject>
 }
 
-function trashedScopedQuery(model: typeof Model, where: Partial<Record<string, unknown>>): QueryBuilder<PlainObject> {
-  return withoutSoftDeleteScope(model).where(where)
+function trashedScopedQuery(
+  model: typeof Model,
+  where: Partial<Record<string, unknown>>,
+  queryOptions?: ModelQueryOptions,
+): QueryBuilder<PlainObject> {
+  return withoutSoftDeleteScope(model, queryOptions).where(where)
 }
 
 /**
@@ -51,6 +66,7 @@ export function SoftDeletes<TBase extends typeof Model>(Base: TBase): TBase & So
   ;(SoftDeleteModel as unknown as typeof Model).delete = async function (
     this: typeof Model,
     where: Partial<Record<string, unknown>>,
+    writeOptions?: ModelWriteOptions,
   ): Promise<number | PlainObject | void> {
     const adapter = this.getAdapter()
     if (!adapter.update) {
@@ -60,21 +76,28 @@ export function SoftDeletes<TBase extends typeof Model>(Base: TBase): TBase & So
     // Through the scoped builder, not straight to the adapter: the caller's
     // `where` alone ignores every global scope, so one tenant could
     // soft-delete another tenant's row. PREPARED_UPDATE skips mutators/casts.
-    return scopedQuery(this, where)[PREPARED_UPDATE]({ [column]: new Date() })
+    return scopedQuery(this, where, writeOptions)[PREPARED_UPDATE]({ [column]: new Date() })
   } as typeof Model.delete
 
-  SoftDeleteModel.withTrashed = function (this: typeof Model): QueryBuilder<PlainObject> {
-    return withoutSoftDeleteScope(this)
+  SoftDeleteModel.withTrashed = function (
+    this: typeof Model,
+    queryOptions?: ModelQueryOptions,
+  ): QueryBuilder<PlainObject> {
+    return withoutSoftDeleteScope(this, queryOptions)
   }
 
-  SoftDeleteModel.onlyTrashed = function (this: typeof Model): QueryBuilder<PlainObject> {
+  SoftDeleteModel.onlyTrashed = function (
+    this: typeof Model,
+    queryOptions?: ModelQueryOptions,
+  ): QueryBuilder<PlainObject> {
     const column = (this as unknown as SoftDeletesStatic).deletedAtColumn
-    return withoutSoftDeleteScope(this).whereNotNull(column)
+    return withoutSoftDeleteScope(this, queryOptions).whereNotNull(column)
   }
 
   SoftDeleteModel.restore = async function (
     this: typeof Model,
     where: Partial<Record<string, unknown>>,
+    writeOptions?: ModelWriteOptions,
   ): Promise<PlainObject> {
     const adapter = this.getAdapter()
     if (!adapter.update) {
@@ -83,12 +106,13 @@ export function SoftDeletes<TBase extends typeof Model>(Base: TBase): TBase & So
     const column = (this as unknown as SoftDeletesStatic).deletedAtColumn
     // Drops only the softDelete filter, so this reaches a trashed row while a
     // tenant scope still stops it from un-deleting somebody else's.
-    return trashedScopedQuery(this, where)[PREPARED_UPDATE]({ [column]: null })
+    return trashedScopedQuery(this, where, writeOptions)[PREPARED_UPDATE]({ [column]: null })
   }
 
   SoftDeleteModel.forceDelete = async function (
     this: typeof Model,
     where: Partial<Record<string, unknown>>,
+    writeOptions?: ModelWriteOptions,
   ): Promise<number | PlainObject | void> {
     const adapter = this.getAdapter()
     if (!adapter.delete) {
@@ -96,7 +120,7 @@ export function SoftDeletes<TBase extends typeof Model>(Base: TBase): TBase & So
     }
     // An unscoped hard delete is unrecoverable, so every scope but softDelete
     // has to survive; dropping that one is what reaches trashed rows too.
-    return trashedScopedQuery(this, where).delete()
+    return trashedScopedQuery(this, where, writeOptions).delete()
   }
 
   return SoftDeleteModel

--- a/packages/orm/tests/postgres-integration.test.ts
+++ b/packages/orm/tests/postgres-integration.test.ts
@@ -3,9 +3,10 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { sql } from 'drizzle-orm'
-import { integer, pgTable, serial, varchar } from 'drizzle-orm/pg-core'
+import { integer, pgTable, serial, timestamp, varchar } from 'drizzle-orm/pg-core'
 import { createPostgresDatabase, type PostgresDatabase } from '../src/postgres'
 import { Model, type PaginatedResult, type TransactionHandle } from '../src/Model'
+import { SoftDeletes } from '../src/SoftDeletes'
 import { DrizzleAdapter } from '../src/adapters/drizzle-adapter'
 
 // postgres.test.ts mocks `postgres` and the migrator away, so it can assert a
@@ -305,6 +306,148 @@ describePostgres('eager loading inside a transaction (requires POSTGRES_URL)', (
 
       expect(loaded.articlesCount).toBe(2)
 
+    })
+  })
+})
+
+// Its own database, for the same reason the relations block has one.
+const SOFT_DELETE_DATABASE = 'guren_orm_soft_delete_test'
+
+function createSoftDeleteMigrationsFolder(): string {
+  const migrationsFolder = mkdtempSync(join(tmpdir(), 'guren-orm-postgres-soft-delete-'))
+  const migrationDir = join(migrationsFolder, '20240101000000_init')
+  mkdirSync(migrationDir, { recursive: true })
+  writeFileSync(
+    join(migrationDir, 'migration.sql'),
+    'CREATE TABLE "notes" ("id" serial PRIMARY KEY NOT NULL, "title" varchar(255) NOT NULL,'
+    + ' "deleted_at" timestamp with time zone);\n',
+  )
+  return migrationsFolder
+}
+
+const notesTable = pgTable('notes', {
+  id: serial('id').primaryKey(),
+  title: varchar('title', { length: 255 }).notNull(),
+  deletedAt: timestamp('deleted_at', { withTimezone: true }),
+})
+
+type NoteRecord = typeof notesTable.$inferSelect
+
+// The SoftDeletes mixin builds its own scoped query for every write, so each one
+// is a place the caller's `trx` can be dropped. The fake adapters cannot see that
+// happen — they hand the pool and the transaction the same store — so only a
+// pooled driver makes an escaped write observable.
+describePostgres('SoftDeletes inside a transaction (requires POSTGRES_URL)', () => {
+  let database: PostgresDatabase
+
+  class Note extends SoftDeletes(Model<NoteRecord>) {
+    static override table = notesTable
+  }
+
+  beforeAll(async () => {
+    const url = POSTGRES_URL as string
+    await ensureTestDatabase(url, SOFT_DELETE_DATABASE)
+    database = createPostgresDatabase({
+      migrationsFolder: createSoftDeleteMigrationsFolder(),
+      connectionString: () => databaseUrl(url, SOFT_DELETE_DATABASE),
+      // Same reason as the relations block: on a single-connection pool the reads
+      // below would block on the connection the transaction holds.
+      clientOptions: { max: 5 },
+    })
+    await database.resetDatabase()
+    DrizzleAdapter.configure((await database.getDatabase()) as never)
+  })
+
+  afterAll(async () => {
+    await database?.closeDatabase()
+  })
+
+  /**
+   * Committed before the transaction opens. A row created *inside* it is invisible
+   * to the pool whatever the write did, which would pass every assertion for free.
+   */
+  async function seedNote(title: string, deletedAt: Date | null = null): Promise<NoteRecord> {
+    return (await Note.create({ title, deletedAt })) as NoteRecord
+  }
+
+  /** Runs the body in a transaction, then unwinds it without failing the test. */
+  async function rolledBack(body: (trx: TransactionHandle) => Promise<void>): Promise<void> {
+    await Note.transaction(async (trx) => {
+      await body(trx)
+      throw new RollbackSignal()
+    }).catch((error: unknown) => {
+      if (!(error instanceof RollbackSignal)) throw error
+    })
+  }
+
+  /** Reads on the pool, past the softDelete scope that would otherwise hide the row. */
+  async function fromPool(id: number): Promise<NoteRecord | null> {
+    const [row] = (await Note.withoutGlobalScopes().where('id', id).get()) as NoteRecord[]
+    return row ?? null
+  }
+
+  it('unwinds a soft delete made through the transaction-bound scope', async () => {
+    const note = await seedNote('scoped-delete')
+
+    await Note.transaction(async (_trx, txNote) => {
+      await txNote.delete({ id: note.id })
+
+      // The premise: the write is invisible outside the transaction that made it.
+      expect((await fromPool(note.id))?.deletedAt).toBeNull()
+
+      throw new RollbackSignal()
+    }).catch((error: unknown) => {
+      if (!(error instanceof RollbackSignal)) throw error
+    })
+
+    // With the handle dropped, the UPDATE ran on the pool and outlived the rollback.
+    expect((await fromPool(note.id))?.deletedAt).toBeNull()
+  })
+
+  it('unwinds a soft delete made through the static form', async () => {
+    const note = await seedNote('static-delete')
+
+    await rolledBack(async (trx) => {
+      await Note.delete({ id: note.id }, { trx })
+      expect((await fromPool(note.id))?.deletedAt).toBeNull()
+    })
+
+    expect((await fromPool(note.id))?.deletedAt).toBeNull()
+  })
+
+  it('unwinds a restore()', async () => {
+    const note = await seedNote('trashed-restore', new Date('2020-01-01T00:00:00Z'))
+
+    await rolledBack(async (trx) => {
+      await Note.restore({ id: note.id }, { trx })
+      expect((await fromPool(note.id))?.deletedAt).not.toBeNull()
+    })
+
+    expect((await fromPool(note.id))?.deletedAt).not.toBeNull()
+  })
+
+  it('unwinds a forceDelete()', async () => {
+    const note = await seedNote('trashed-force', new Date('2020-01-01T00:00:00Z'))
+
+    await rolledBack(async (trx) => {
+      await Note.forceDelete({ id: note.id }, { trx })
+      expect(await fromPool(note.id)).not.toBeNull()
+    })
+
+    // A hard delete that escapes the rollback cannot be undone.
+    expect(await fromPool(note.id)).not.toBeNull()
+  })
+
+  it('reads rows the transaction trashed with withTrashed() and onlyTrashed()', async () => {
+    await rolledBack(async (trx) => {
+      const note = (await Note.create({ title: 'tx-trashed', deletedAt: null }, { trx })) as NoteRecord
+      await Note.delete({ id: note.id }, { trx })
+
+      expect(await Note.onlyTrashed({ trx }).where('id', note.id).get()).toHaveLength(1)
+      expect(await Note.withTrashed({ trx }).where('id', note.id).get()).toHaveLength(1)
+
+      // Without the handle these read the pool, where the row does not exist yet.
+      expect(await Note.onlyTrashed().where('id', note.id).get()).toHaveLength(0)
     })
   })
 })

--- a/packages/orm/tests/soft-deletes.test.ts
+++ b/packages/orm/tests/soft-deletes.test.ts
@@ -297,3 +297,123 @@ describe('SoftDeletes: models with no other scopes', () => {
     await expect(Post.forceDelete({ id: 1 })).rejects.toThrow('does not support delete operations')
   })
 })
+
+/**
+ * Every SoftDeletes entry point builds its own scoped query, so each is a place
+ * the caller's `trx` can be dropped on the floor — the write then runs on the
+ * default connection, outside the transaction that was supposed to own it.
+ * `queryOptions` sits in a different argument position per adapter method, so
+ * the recorder reads each one where that method actually carries it.
+ */
+function recordingPost() {
+  const store = SEED.map((r) => ({ ...r }))
+  const base = createAdapter(store) as unknown as Record<string, (...args: unknown[]) => unknown>
+  const seen: Array<{ method: string; trx: unknown }> = []
+
+  const record = (method: string, position: number) =>
+    (...args: unknown[]) => {
+      seen.push({ method, trx: (args[position] as { trx?: unknown } | undefined)?.trx })
+      return base[method]?.(...args)
+    }
+
+  const adapter = {
+    ...base,
+    findManyAdvanced: record('findManyAdvanced', 3),
+    update: record('update', 3),
+    delete: record('delete', 2),
+  } as unknown as ORMAdapter
+
+  class Post extends SoftDeletes(Model<PostRecord>) {
+    static table = 'posts'
+  }
+  Post.useAdapter(adapter)
+  ;(Post as unknown as typeof Model).addGlobalScope('tenant', (q) => q.where('tenantId', 1))
+
+  return { Post, store, seen }
+}
+
+const TRX = { sentinel: 'transaction-handle' }
+
+describe('SoftDeletes: transaction handles', () => {
+  it('delete() runs the soft-delete UPDATE on the caller\'s transaction', async () => {
+    const { Post, seen } = recordingPost()
+
+    await Post.delete({ id: 1 }, { trx: TRX })
+
+    expect(seen).toEqual([{ method: 'update', trx: TRX }])
+  })
+
+  it('delete() through the transaction-bound scope carries the handle', async () => {
+    const { Post, seen } = recordingPost()
+
+    // `Model.transaction()` builds this scope, and its `delete` resolves through
+    // the prototype chain to the mixin's override, which builds its own query.
+    await (Post as unknown as typeof Model).inTransaction(TRX).delete({ id: 1 })
+
+    expect(seen).toEqual([{ method: 'update', trx: TRX }])
+  })
+
+  it('restore() runs on the caller\'s transaction', async () => {
+    const { Post, seen } = recordingPost()
+
+    await Post.restore({ id: 2 }, { trx: TRX })
+
+    expect(seen).toEqual([{ method: 'update', trx: TRX }])
+  })
+
+  it('forceDelete() runs on the caller\'s transaction', async () => {
+    const { Post, seen } = recordingPost()
+
+    await Post.forceDelete({ id: 2 }, { trx: TRX })
+
+    expect(seen).toEqual([{ method: 'delete', trx: TRX }])
+  })
+
+  it('withTrashed() and onlyTrashed() read on the caller\'s transaction', async () => {
+    const { Post, seen } = recordingPost()
+
+    expect(titles(await Post.withTrashed({ trx: TRX }).get())).toEqual(['ours-live', 'ours-trashed'])
+    expect(titles(await Post.onlyTrashed({ trx: TRX }).get())).toEqual(['ours-trashed'])
+
+    expect(seen).toEqual([
+      { method: 'findManyAdvanced', trx: TRX },
+      { method: 'findManyAdvanced', trx: TRX },
+    ])
+  })
+
+  it('keeps every other global scope while carrying the handle', async () => {
+    const { Post, store, seen } = recordingPost()
+
+    // The tenant scope is what stops a transaction-bound force delete from
+    // reaching another tenant's trashed row.
+    await Post.forceDelete({ id: 4 }, { trx: TRX })
+
+    expect(store.find((r) => r.id === 4)).toBeDefined()
+    expect(seen).toEqual([{ method: 'delete', trx: TRX }])
+  })
+
+  it('withoutGlobalScope() takes leading query options without disturbing the name-only form', async () => {
+    const { Post, seen } = recordingPost()
+    const model = Post as unknown as typeof Model
+
+    expect(titles(await model.withoutGlobalScope({ trx: TRX }, 'softDelete').get())).toEqual([
+      'ours-live',
+      'ours-trashed',
+    ])
+    expect(titles(await model.withoutGlobalScope('softDelete').get())).toEqual(['ours-live', 'ours-trashed'])
+
+    expect(seen).toEqual([
+      { method: 'findManyAdvanced', trx: TRX },
+      { method: 'findManyAdvanced', trx: undefined },
+    ])
+  })
+
+  it('withoutGlobalScopes() takes query options too', async () => {
+    const { Post, seen } = recordingPost()
+    const model = Post as unknown as typeof Model
+
+    expect(await model.withoutGlobalScopes({ trx: TRX }).get()).toHaveLength(4)
+
+    expect(seen).toEqual([{ method: 'findManyAdvanced', trx: TRX }])
+  })
+})


### PR DESCRIPTION
## Problem

`SoftDeletes` silently drops the transaction handle.

**1. `delete()` accepts write options and ignores them.** `Model.delete(where, writeOptions)` takes `{ trx }`, and the transaction proxy relies on it (`Model.ts`: `delete: (where) => this.delete(where, { trx })`). The mixin overrode `delete` with a function declared `(where)` only and cast the result `as typeof Model.delete`, so the mismatch type-checked. The soft-delete `UPDATE` therefore ran on the default connection: it was not rolled back with the rest of the transaction, and the transaction's own reads could not see it.

**2. Nothing else in the surface could be given a transaction at all.** `restore()`, `forceDelete()`, `withTrashed()` and `onlyTrashed()` reach trashed rows through `withoutGlobalScope()`, which took only scope names. `forceDelete()` is the sharp end: a hard delete that escapes the surrounding rollback cannot be undone.

## Fix

Every entry point now threads write/query options into the scoped builder introduced by #732 (`buildScopedQuery`), so no new scope-applying site is added.

`withoutGlobalScope()` gained an overload taking the options **first**. The report proposed appending an optional `queryOptions`, but `names` is a rest parameter and cannot be followed by an optional one, so that form is not available. The name-only call is unchanged; `withoutGlobalScopes()` takes them trailing like every other entry point.

The transaction proxy needed no change. Its `delete` resolves through the prototype chain to the mixin's override, so fixing the signature makes `txPost.delete({ id })` correct on its own. `TransactionModelScope` stays free of SoftDeletes, and the docs show the static form for the rest:

```ts
await Post.transaction(async (trx, txPost) => {
  await txPost.delete({ id: 1 })
  await Post.restore({ id: 2 }, { trx })
  await Post.forceDelete({ id: 3 }, { trx })
  const trashed = await Post.onlyTrashed({ trx }).get()
})
```

## Verification

Both suites were confirmed red before the fix and green after.

- `packages/orm/tests/soft-deletes.test.ts` — the adapter records the query options each call receives, per method, and asserts the handle arrives for `delete()` (static and through the transaction-bound scope), `restore()`, `forceDelete()`, `withTrashed()`, `onlyTrashed()` and both `withoutGlobalScope` forms. 8 new tests; all 8 fail on `main`.
- `packages/orm/tests/postgres-integration.test.ts` — the real consequence, against the pooled driver. A row is committed *before* the transaction opens, written inside it, then the transaction is unwound; the row is read back past the `softDelete` scope. 5 new tests; all 5 fail on `main`. Gated on `POSTGRES_URL`, which CI supplies.

The premise is asserted inline rather than assumed: while the transaction is open, a pool read must not see the write. Without that check the assertions would pass for free on a row created inside the transaction.

## Not fixed here: `Model.transaction()` on bun-sqlite

The report asked for the regression test to be a bun:sqlite rollback in the style of `where-group-sqlite.test.ts`. That test cannot work, and the reason is a separate defect worth its own issue.

drizzle's bun-sqlite `transaction()` is **synchronous**. An async callback returns a pending promise, so drizzle runs `BEGIN`, gets a promise, and `COMMIT`s before any awaited work inside it has run. Measured directly:

```
db.transaction((tx) => (async () => { await tx.update(...); throw new Error('boom') })())
→ returned: Promise { <pending> }
→ caught boom
→ rows after: [ { id: 1, name: "b" } ]     // the write survived the throw
```

So on bun-sqlite `Model.transaction()` provides no atomicity at all, and a rollback test there would fail both before *and* after this fix. That is why the real-driver coverage is on Postgres, where a rollback is actually observable. The bun-sqlite gap is out of scope for this PR.
