### PR TITLE
fix(cli): compare an array entry on its unmasked source

### DIFF
--- a/.changeset/array-entry-source-comparison.md
+++ b/.changeset/array-entry-source-comparison.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': patch
+---
+
+Compare an array entry against a caller's value on its unmasked source. Entries came back with string contents blanked, so a value holding a string literal — `mcpPlugin({ path: '/mcp' })` — never equalled an existing entry and the registration was appended a second time.

--- a/packages/cli/src/patch-helpers.ts
+++ b/packages/cli/src/patch-helpers.ts
@@ -102,17 +102,29 @@ export function findClosingDelimiter(content: string, openIndex: number, open: s
 const ARRAY_ENTRY_CLOSERS: Record<string, string> = { '(': ')', '[': ']', '{': '}' }
 
 /**
+ * One entry of an array literal, in both the forms its readers need. Masking
+ * preserves length, so one pair of offsets indexes the masked copy and `inner`
+ * alike. Two entries can share a `code` and differ in `source`: `'/mcp'` and
+ * `'/api'` blank to the same run, so only `source` may answer "is this the
+ * value the caller asked for".
+ */
+interface ArrayEntry {
+  /** Masked and trimmed: string and comment contents blanked. */
+  code: string
+  /** The same span, verbatim out of `inner`. */
+  source: string
+}
+
+/**
  * Entries of an array literal's interior, split at depth 0 only. Masked first,
- * so a name in a comment is not mistaken for an entry — which is also why the
- * result answers membership only: string contents come out blanked, so
- * re-joining these entries into the file writes `'/mcp'` back as `'    '`.
+ * so a name in a comment is not mistaken for an entry, and so an entry's own
+ * trailing comment trims away with its whitespace.
  * Regex literals are not masked; an unmatched closer stops the split there.
  */
-function parseArrayEntries(inner: string): string[] {
+function parseArrayEntries(inner: string): ArrayEntry[] {
   const masked = maskNonCode(inner)
   const closers: string[] = []
-  const entries: string[] = []
-  let start = 0
+  const bounds: number[] = [0]
 
   for (let i = 0; i < masked.length; i++) {
     const char = masked[i]
@@ -123,13 +135,22 @@ function parseArrayEntries(inner: string): string[] {
     } else if (char === ')' || char === ']' || char === '}') {
       if (closers.pop() !== char) break
     } else if (char === ',' && closers.length === 0) {
-      entries.push(masked.slice(start, i))
-      start = i + 1
+      bounds.push(i, i + 1)
     }
   }
 
-  entries.push(masked.slice(start))
-  return entries.map((entry) => entry.trim()).filter((entry) => entry.length > 0)
+  bounds.push(masked.length)
+
+  const entries: ArrayEntry[] = []
+  for (let i = 0; i < bounds.length; i += 2) {
+    const span = masked.slice(bounds[i], bounds[i + 1])
+    const code = span.trim()
+    if (code.length === 0) continue
+    const from = bounds[i] + (span.length - span.trimStart().length)
+    entries.push({ code, source: inner.slice(from, from + code.length) })
+  }
+
+  return entries
 }
 
 /**
@@ -306,7 +327,8 @@ export function insertProvider(
   providerName: string,
   /**
    * Defaults to exact-match against `providerName`; factory registrations pass
-   * a prefix check so `vercelPlugin({ ... })` counts as registered.
+   * a prefix check so `vercelPlugin({ ... })` counts as registered. Entries
+   * arrive masked, so a predicate must not test text holding a string literal.
    */
   isRegistered?: (entries: string[]) => boolean,
 ): InsertResult {
@@ -329,8 +351,8 @@ export function insertProvider(
   const providers = parseArrayEntries(interior)
 
   const alreadyRegistered = isRegistered
-    ? isRegistered(providers)
-    : providers.some(p => p === providerName)
+    ? isRegistered(providers.map((entry) => entry.code))
+    : providers.some((entry) => entry.source === providerName)
   if (alreadyRegistered) {
     return { reason: PATCH_REASONS.providerAlreadyRegistered }
   }
@@ -427,7 +449,7 @@ export async function addToArrayOption(
 
   const interior = content.slice(open + 1, close)
 
-  if (parseArrayEntries(interior).some((entry) => entry === valueSource)) {
+  if (parseArrayEntries(interior).some((entry) => entry.source === valueSource)) {
     return { modified: false, reason: PATCH_REASONS.alreadyPresent }
   }
 
@@ -494,7 +516,7 @@ export function insertArrayArgument(content: string, methodName: string, valueSo
   }
 
   const interior = content.slice(open + 1, close)
-  if (parseArrayEntries(interior).some((entry) => entry === valueSource)) {
+  if (parseArrayEntries(interior).some((entry) => entry.source === valueSource)) {
     return content
   }
 

--- a/packages/cli/tests/patch-helpers.test.ts
+++ b/packages/cli/tests/patch-helpers.test.ts
@@ -728,18 +728,19 @@ export const schema = { users }
   })
 })
 
-describe('array entries — depth-0 splitting', () => {
-  async function withFile(name: string, contents: string, run: () => Promise<void>): Promise<string> {
-    const workspace = await createTempWorkspace('guren-cli-array-depth-')
-    try {
-      await writeWorkspaceFiles(workspace.dir, { [name]: contents })
-      await run()
-      return await readFile(join(workspace.dir, name), 'utf8')
-    } finally {
-      await workspace.cleanup()
-    }
+/** Runs `run()` against a workspace holding `name`, and returns what it left there. */
+async function withArrayFile(name: string, contents: string, run: () => Promise<void>): Promise<string> {
+  const workspace = await createTempWorkspace('guren-cli-array-entries-')
+  try {
+    await writeWorkspaceFiles(workspace.dir, { [name]: contents })
+    await run()
+    return await readFile(join(workspace.dir, name), 'utf8')
+  } finally {
+    await workspace.cleanup()
   }
+}
 
+describe('array entries — depth-0 splitting', () => {
   it('reads an entry whose object argument holds a comma as one entry', () => {
     const app = 'createApp({ providers: [mcpPlugin({ path: mcpPath, prefix: mcpPrefix })] })'
 
@@ -762,7 +763,7 @@ describe('array entries — depth-0 splitting', () => {
 
   it('reads an entry holding a nested array as one entry', async () => {
     const source = 'kernel.registerMany([group([alpha, beta])])\n'
-    const result = await withFile('src/console.ts', source, async () => {
+    const result = await withArrayFile('src/console.ts', source, async () => {
       const patch = await addToArrayArgument('src/console.ts', 'registerMany', 'group([alpha, beta])')
       expect(patch.reason).toBe(PATCH_REASONS.alreadyPresent)
     })
@@ -770,7 +771,7 @@ describe('array entries — depth-0 splitting', () => {
   })
 
   it('detects a valueSource that itself contains a comma on a second run', async () => {
-    const result = await withFile('src/app.ts', 'const app = createApp({ modules: [] })\n', async () => {
+    const result = await withArrayFile('src/app.ts', 'const app = createApp({ modules: [] })\n', async () => {
       expect((await addToArrayOption('src/app.ts', 'modules', 'billingModule(extra, more)')).modified).toBe(true)
       const second = await addToArrayOption('src/app.ts', 'modules', 'billingModule(extra, more)')
       expect(second.reason).toBe(PATCH_REASONS.alreadyPresent)
@@ -783,8 +784,85 @@ describe('array entries — depth-0 splitting', () => {
   // split there — `Basic`, already split off before it, stands.
   it('stops splitting at an unbalanced closer instead of cutting a fragment', async () => {
     const source = 'kernel.registerMany([Basic, match(/a,}b/)])\n'
-    const result = await withFile('src/console.ts', source, async () => {
+    const result = await withArrayFile('src/console.ts', source, async () => {
       const patch = await addToArrayArgument('src/console.ts', 'registerMany', 'match(/a,}b/)')
+      expect(patch.reason).toBe(PATCH_REASONS.alreadyPresent)
+    })
+    expect(result).toBe(source)
+  })
+})
+
+describe('array entries — masked entries vs. an unmasked value', () => {
+  it('matches an existing entry whose argument holds a string literal', () => {
+    const app = "createApp({ providers: [mcpPlugin({ path: '/mcp' })] })"
+
+    const result = insertProvider(app, "mcpPlugin({ path: '/mcp' })")
+
+    expect(result.reason).toBe(PATCH_REASONS.providerAlreadyRegistered)
+  })
+
+  // Masking is length-preserving, so `'/mcp'` and `'/api'` are the same blanked
+  // run: comparing two masked sides would read this as registered and drop it.
+  it('separates two entries whose string literals are the same length', () => {
+    const app = "createApp({ providers: [mcpPlugin({ path: '/mcp' })] })"
+
+    const result = insertProvider(app, "mcpPlugin({ path: '/api' })")
+
+    expect(result.content).toBe(
+      "createApp({ providers: [mcpPlugin({ path: '/mcp' }), mcpPlugin({ path: '/api' })] })",
+    )
+  })
+
+  it('does not read a value that appears only in a comment inside the array', () => {
+    const app = "createApp({ providers: [DatabaseProvider /* , mcpPlugin({ path: '/mcp' }) */] })"
+
+    const result = insertProvider(app, "mcpPlugin({ path: '/mcp' })")
+
+    expect(result.content).toBe(
+      "createApp({ providers: [DatabaseProvider, mcpPlugin({ path: '/mcp' })"
+      + " /* , mcpPlugin({ path: '/mcp' }) */] })",
+    )
+  })
+
+  // The predicate reads the masked form, which is why `plugin.ts` tests a
+  // prefix that holds no string literal.
+  it('hands a membership predicate the masked entry', () => {
+    const app = "createApp({ providers: [mcpPlugin({ path: '/mcp' })] })"
+    const seen: string[] = []
+
+    insertProvider(app, 'mcpPlugin()', (entries) => {
+      seen.push(...entries)
+      return false
+    })
+
+    expect(seen).toEqual(["mcpPlugin({ path: '    ' })"])
+  })
+
+  it('detects an option value holding a string literal on a second run', async () => {
+    const value = "billingModule({ prefix: '/billing' })"
+    const result = await withArrayFile('src/app.ts', 'const app = createApp({ modules: [] })\n', async () => {
+      expect((await addToArrayOption('src/app.ts', 'modules', value)).modified).toBe(true)
+      expect((await addToArrayOption('src/app.ts', 'modules', value)).reason).toBe(PATCH_REASONS.alreadyPresent)
+    })
+    expect(result).toBe(`const app = createApp({ modules: [${value}] })\n`)
+  })
+
+  it('detects an array argument holding a string literal', async () => {
+    const source = "kernel.registerMany([namespaced('billing')])\n"
+    const result = await withArrayFile('src/console.ts', source, async () => {
+      const patch = await addToArrayArgument('src/console.ts', 'registerMany', "namespaced('billing')")
+      expect(patch.reason).toBe(PATCH_REASONS.alreadyPresent)
+    })
+    expect(result).toBe(source)
+  })
+
+  // An escape blanks to two characters like the pair it stands for, so the
+  // offsets a masked entry hands back still index the source.
+  it('keeps its offsets across an escape inside the literal', async () => {
+    const value = "namespaced('a\\'b')"
+    const source = `kernel.registerMany([${value}])\n`
+    const result = await withArrayFile('src/console.ts', source, async () => {
+      const patch = await addToArrayArgument('src/console.ts', 'registerMany', value)
       expect(patch.reason).toBe(PATCH_REASONS.alreadyPresent)
     })
     expect(result).toBe(source)


### PR DESCRIPTION
## Problem

`parseArrayEntries()` returns entries taken from a **masked** copy of the source: `maskNonCode()` blanks string and comment contents character for character while keeping the quotes, so `mcpPlugin({ path: '/mcp' })` comes back as `mcpPlugin({ path: '    ' })`.

Three call sites then compared those masked entries against an **unmasked** value:

- `insertProvider()` — `providers.some(p => p === providerName)` (the default, non-predicate path)
- `addToArrayOption()` — `entry === valueSource`
- `insertArrayArgument()` — the same test

So any `providerName` / `valueSource` holding a string literal could never equal an existing entry, however correctly the array was parsed. The registration read as absent and the command appended a duplicate.

The factory-prefix predicate in `plugin.ts` (`entry.startsWith(`${factoryName}(`)`) is unaffected — the prefix it tests holds no string literal, which is why this stayed latent.

## Change

Each entry now carries both forms of the same span:

```ts
interface ArrayEntry {
  code: string    // masked and trimmed
  source: string  // the same span, verbatim out of `inner`
}
```

`maskNonCode` preserves length, so one pair of offsets indexes the masked copy and the source alike. Exact matches compare `source`; `isRegistered` keeps receiving `code`, so `plugin.ts` and `provider-registrar.ts` need no change and the masking that stops a name written only in a comment from reading as a registration is intact.

**Masking the caller's value instead would not have worked.** Masking is length-preserving, so `'/mcp'` and `'/api'` blank to the same run: comparing two masked sides trades the duplicate append for a *silently dropped* registration. `separates two entries whose string literals are the same length` pins that.

## Tests

Seven new cases. **Four were verified red against the unfixed source**, each on its own assertion with `reason: undefined` — i.e. a duplicate was appended — rather than on a file-level error:

- an existing entry whose argument holds a string literal (`insertProvider`)
- an option value holding one, asserted as idempotency across two runs (`addToArrayOption`)
- an array argument holding one (`addToArrayArgument`)
- an escape inside the literal, which pins that the masked entry's offsets still index the source

The other three pass before and after and are regression guards, not fixed failures:

- the same-length collision above — confirmed discriminating by mutating the comparison back to masked-vs-masked, which reds exactly that one case
- a value that appears only in a comment *inside* the array, which is the comment-blindness property this must not lose
- a membership predicate receiving the masked entry, the contract `plugin.ts` depends on

#739's `withFile` and this PR's were identical but for their temp prefix, so the two are one module-scope `withArrayFile` — the only line this touches inside #739's block.

## Relation to #739

This builds on #739, which has since merged; the branch was rebased onto it and now carries its own commit only.

## Gates

`build`, `typecheck`, `lint` green, and the cli suite is 2386 pass / 0 fail across 137 files. `audit:starter-template` was run on an earlier revision of the same change, since these patchers are what the scaffolders write through.

`bun run test:bun cli` exits 144 under Bun 1.3.14 on macOS (the known `--isolate` crash); the count above is the same suite run without `--isolate`.
