### PR TITLE
ci: split the tutorial smoke into its own job and cut its measured waste

### DIFF
--- a/.changeset/audit-deps-scan-timeout.md
+++ b/.changeset/audit-deps-scan-timeout.md
@@ -1,0 +1,5 @@
+---
+"@guren/cli": patch
+---
+
+**`guren audit` stops spending a minute on a dependency scan that cannot finish** — `bun audit --json` spins at 100% CPU indefinitely on some dependency trees (reproduced on a scaffolded app whose `@guren/*` are `file:` links; the same app with those entries removed scans in under a second), and the scan's own cap was 60 s. Every such run therefore cost a minute before reporting the `Dependencies could not be scanned` warning it was always going to report. The cap is now 15 s, still an order of magnitude above the ~1 s a healthy scan takes. Nothing about the verdict changes: an unfinished scan is `unavailable`, never a pass.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,10 +284,8 @@ jobs:
   # themselves and run in parallel with everything else.
   starter-smokes:
     runs-on: ubuntu-latest
-    # Measured max 16m29s at eleven tutorial chapters: it rebuilds the packages,
-    # runs eight scaffold smokes, and executes every chapter of the tutorial in
-    # order. The tutorial grows, so the cap has headroom over the measurement.
-    timeout-minutes: 40
+    # Measured 3m41s without the tutorial, which is its own job below.
+    timeout-minutes: 20
     services:
       postgres:
         image: postgres:16-alpine
@@ -348,17 +346,32 @@ jobs:
       - name: Golden path smoke test
         run: bun run smoke:golden-path
 
-      # docs/en/tutorials/NN-*.md run as a script, chapter by chapter, each
-      # ending in guren gate and a build (RFC 0019).
-      - name: Tutorial smoke
-        run: bun run smoke:tutorial
-
       - name: Golden path smoke test (postgres)
         run: bun run smoke:golden-path:postgres
 
       # The only place a --db mysql scaffold is typechecked and migrated.
       - name: Golden path smoke test (mysql)
         run: bun run smoke:golden-path:mysql
+
+  tutorial-smoke:
+    runs-on: ubuntu-latest
+    # docs/en/tutorials/NN-*.md run as a script, chapter by chapter, each ending
+    # in guren gate and a build (RFC 0019). Its own job, not a starter-smokes
+    # step: at 18m34s (run 34225024536) it is five times the next longest job,
+    # so running it in series set the merge floor at its own length.
+    # No service container: chapter 1 scaffolds --db sqlite and no chapter
+    # reaches for a server.
+    timeout-minutes: 40
+    env:
+      APP_KEY: base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Bun and build packages
+        uses: ./.github/actions/setup-and-build
+
+      - name: Tutorial smoke
+        run: bun run smoke:tutorial
 
   sqlite-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
   # themselves and run in parallel with everything else.
   starter-smokes:
     runs-on: ubuntu-latest
-    # Measured 3m41s without the tutorial, which is its own job below.
+    # Measured 3m26s (run 34229657662); the tutorial is its own job below.
     timeout-minutes: 20
     services:
       postgres:
@@ -356,11 +356,10 @@ jobs:
   tutorial-smoke:
     runs-on: ubuntu-latest
     # docs/en/tutorials/NN-*.md run as a script, chapter by chapter, each ending
-    # in guren gate and a build (RFC 0019). Its own job, not a starter-smokes
-    # step: at 18m34s (run 34225024536) it is five times the next longest job,
-    # so running it in series set the merge floor at its own length.
+    # in guren gate and a build (RFC 0019). Measured 12m51s at fifteen chapters
+    # (run 34229657662); the tutorial grows, so the cap has headroom.
     # No service container: chapter 1 scaffolds --db sqlite and no chapter
-    # reaches for a server.
+    # reaches for a database server.
     timeout-minutes: 40
     env:
       APP_KEY: base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=

--- a/packages/cli/src/audit-deps.ts
+++ b/packages/cli/src/audit-deps.ts
@@ -119,14 +119,11 @@ export interface DependencyScanOutput {
 }
 
 /**
- * Kick off `bun audit --json` without awaiting it, so the registry
- * round-trip can overlap the local file scanning. `null` means the process
- * could not even start.
- *
- * The cap is 15 s against a measured 1 s for a healthy scan: the only thing a
- * longer wait buys is a slower `unavailable`. `bun audit` spins at 100 % CPU
- * indefinitely on some trees (reproduced on a scaffolded app whose `@guren/*`
- * are `file:` links), so the cap is load-bearing, not a formality.
+ * Kick off `bun audit --json` without awaiting it, so the registry round-trip
+ * can overlap the local file scanning. `null` means it could not even start.
+ * The cap is load-bearing: `bun audit` spins at 100% CPU indefinitely on some
+ * trees (a scaffolded app whose `@guren/*` are `file:` links), and a healthy
+ * scan measures ~1 s, so a longer wait only buys a slower `unavailable`.
  */
 export function startDependencyScan(cwd: string): Promise<DependencyScanOutput | null> {
   let proc: ReturnType<typeof Bun.spawn>

--- a/packages/cli/src/audit-deps.ts
+++ b/packages/cli/src/audit-deps.ts
@@ -20,6 +20,7 @@ interface BunAuditAdvisory {
   vulnerable_versions: string
 }
 
+const DEPENDENCY_SCAN_TIMEOUT_MS = 15_000
 const GHSA_PATTERN = /GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}/i
 const BAD_SHAPE = 'unrecognized bun audit output shape'
 
@@ -121,6 +122,11 @@ export interface DependencyScanOutput {
  * Kick off `bun audit --json` without awaiting it, so the registry
  * round-trip can overlap the local file scanning. `null` means the process
  * could not even start.
+ *
+ * The cap is 15 s against a measured 1 s for a healthy scan: the only thing a
+ * longer wait buys is a slower `unavailable`. `bun audit` spins at 100 % CPU
+ * indefinitely on some trees (reproduced on a scaffolded app whose `@guren/*`
+ * are `file:` links), so the cap is load-bearing, not a formality.
  */
 export function startDependencyScan(cwd: string): Promise<DependencyScanOutput | null> {
   let proc: ReturnType<typeof Bun.spawn>
@@ -129,7 +135,7 @@ export function startDependencyScan(cwd: string): Promise<DependencyScanOutput |
       cwd,
       stdout: 'pipe',
       stderr: 'pipe',
-      timeout: 60_000,
+      timeout: DEPENDENCY_SCAN_TIMEOUT_MS,
     })
   } catch {
     return Promise.resolve(null)

--- a/scripts/smoke/tutorial.ts
+++ b/scripts/smoke/tutorial.ts
@@ -192,18 +192,25 @@ async function startBackground(session: Session, block: RunBlock, chapter: strin
   void pump(proc.stderr as ReadableStream<Uint8Array>)
   session.background.push({ block, proc, logPath, port })
 
+  // The banner and a live /health are raced, not sequenced: a production-mode
+  // server (`bun run preview`) prints no banner at all, so sequencing spent the
+  // whole timeout on every one. GUREN_STRICT_PORT=1 above makes the handed port
+  // the only one this app can hold, so a 200 there is this app answering.
   const deadline = Date.now() + BANNER_TIMEOUT_MS
   let bound: string | null = null
   while (Date.now() < deadline) {
     if (proc.exitCode !== null) break
     bound = boundPort(await readFile(logPath, 'utf8').catch(() => ''))
     if (bound) break
+    if ((await probeHealth(port)).ok) {
+      bound = String(port)
+      break
+    }
     await Bun.sleep(500)
   }
   if (!bound) {
-    // A production-mode server (`NODE_ENV=production bun bin/serve.ts`) prints no
-    // banner, so there is nothing to read. `GUREN_STRICT_PORT=1` above forbids the
-    // walk, which is what makes the port it was handed the only one it can hold.
+    // Alive but silent on both channels: fall back to the handed port and let
+    // the probe loop below decide.
     if (proc.exitCode !== null) {
       console.error(await readFile(logPath, 'utf8').catch(() => ''))
       throw new Error(`background block at line ${block.line} exited before answering (code ${proc.exitCode})`)
@@ -217,24 +224,30 @@ async function startBackground(session: Session, block: RunBlock, chapter: strin
   let lastError = ''
   while (Date.now() < probeDeadline) {
     bound = boundPort(await readFile(logPath, 'utf8').catch(() => '')) ?? bound
-    // `/health`, not `/`: it is the one path the scaffold excludes from host
-    // authorization, and a production-mode server answers every other path with
-    // 403 unless the probe's Host matches APP_URL.
-    const url = `http://127.0.0.1:${bound}/health`
-    try {
-      const response = await fetch(url)
-      if (response.status === 200) {
-        console.log(`background block answered 200 at ${url}`)
-        return
-      }
-      lastError = `answered ${response.status}`
-    } catch (error) {
-      lastError = String(error)
+    const probe = await probeHealth(bound)
+    if (probe.ok) {
+      console.log(`background block answered 200 at http://127.0.0.1:${bound}/health`)
+      return
     }
+    lastError = probe.error
     await Bun.sleep(500)
   }
   console.error(await readFile(logPath, 'utf8').catch(() => ''))
   throw new Error(`background block at line ${block.line} never answered 200 on its reported port (${lastError})`)
+}
+
+/**
+ * `/health`, not `/`: it is the one path the scaffold excludes from host
+ * authorization, and a production-mode server answers every other path with 403
+ * unless the probe's Host matches APP_URL.
+ */
+async function probeHealth(port: string | number): Promise<{ ok: boolean; error: string }> {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/health`)
+    return { ok: response.status === 200, error: `answered ${response.status}` }
+  } catch (error) {
+    return { ok: false, error: String(error) }
+  }
 }
 
 /** Last `:<digits>` on the newest `Bound address` banner line, the same rule as smoke-golden-path.sh. */


### PR DESCRIPTION
`starter-smokes` grew from 3m20s to 22m15s when the tutorial smoke landed in it (#705). Measured on run 34225024536: the `Tutorial smoke` step is 18m34s of that job, and the job is five times the next longest thing in CI.

## Why not a path filter

The obvious fix — run the tutorial smoke only when `docs/en/tutorials/**` or the templates change — does not hold. RFC 0019 §3 states the property the smoke exists for: *"A framework change that breaks a chapter fails CI, the same way `check --spec` fails on a drifted spec view today."* The smoke scaffolds an app against local builds of every `@guren/*`, so any `packages/**` change can move its result. An honest filter would have to include `packages/**`, which fires on nearly every PR.

## What this does instead

**Its own job.** Every other step in `starter-smokes` finishes in under a minute; serialising them behind the tutorial set the merge floor at the tutorial's own length. As a sibling job it runs in parallel and `starter-smokes` returns to ~3m41s. It needs no service container — chapter 1 scaffolds `--db sqlite` and no chapter reaches for a server — which also drops the 33s container init.

**The 90s banner wait.** `bun run preview` (chapter 14) is a production-mode server and prints no banner, so `startBackground` ran the full `BANNER_TIMEOUT_MS` and then got a 200 on the handed port immediately. `GUREN_STRICT_PORT=1` already makes that port the only one the app can hold, so the probe is now raced against the banner rather than sequenced after it.

**The dependency scan.** `bun audit --json` spins at 100% CPU indefinitely on some dependency trees. Reproduced locally on a scaffolded app whose `@guren/*` are `file:` links; the same app with those entries removed scans in under a second. The scan's cap was 60s, so every run spent a minute before reporting the `Dependencies could not be scanned` warning it was always going to report — five times per tutorial run, 10/10 across runs 34173471087 and 34225024536. The cap is now 15s, still an order of magnitude above a healthy scan. The verdict is unchanged: an unfinished scan is `unavailable`, never a pass.

## Measured budget

Measured on this PR's run 34229657662, all jobs green.

| | before (run 34225024536) | after |
|---|---|---|
| `starter-smokes` | 22m15s (1335s) | **3m26s** (206s) |
| `tutorial-smoke` | — | **12m51s** (771s) |
| CI wall clock | 22m15s | **12m51s** |

Inside the tutorial step, 18m34s (1114s) -> 12m25s (745s):

| | before | after |
|---|---|---|
| `bunx guren audit` x5 | 304s | 82s |
| `bun run preview` banner wait | 90s | 0s |

`bun audit` still exits 143 five times a run: the scan genuinely cannot complete on this tree, it now gives up in 15s instead of 60s. The background block that used to sit out the full 90s now logs `answered 200` in the same second it starts.

The residual 12m is the tutorial's actual content: 44 `guren gate` runs (372s), 53 `bun test` runs (212s), and the per-chapter builds. Cutting those cuts coverage.

### On the sync obligation

`audit-deps.ts`'s header says *"Keep in step with `scripts/smoke/dependency-audit.ts`"*. That counterpart spawns `bun audit` with **no timeout of its own**, and the obligation it names is the output-shape contract, which is untouched here — so there is no second number to drift. Worth knowing separately: that smoke runs in the workspace root, where `@guren/*` resolve through `workspace:`, not `file:`, so it does not hit the spin.

## Verification

- `bun run typecheck`, `bun run lint`, `bun run audit:workspace-scripts`, `audit:docs`, `audit:core-first`: pass
- `packages/cli` audit + gate tests: 110 pass
- `GUREN_TUTORIAL_THROUGH=03 bun run smoke:tutorial` locally: pass
- Job timings on this PR's own run, read from `gh run view --json jobs`

## Follow-up, not fixed here

The tutorial app logs `[guren/orm] 2 copies of @guren/orm are loaded in this process` during every chapter-end gate. That is the known two-copies hazard and is out of scope for a CI-time change.

