### PR TITLE
fix(cli): only write a schema aggregate the file identifies

### DIFF
--- a/.changeset/schema-aggregate-writer-confidence.md
+++ b/.changeset/schema-aggregate-writer-confidence.md
@@ -1,0 +1,5 @@
+---
+'@guren/cli': patch
+---
+
+Scaffolders that add a table to `db/schema.ts` now leave an aggregate object alone unless the file itself identifies it as the schema — named `schema`, or read in a `typeof`. On a bare shape match (`export const authTables = { users }`) the new table is appended at end of file with no key added and no declaration moved, the same evidence `guren check` already refuses to gate on.

--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -254,6 +254,12 @@ async function checkSchemaAggregateKeys(cwd: string, cache: ParseCache): Promise
     const missing = [...aggregate.declared].filter((name) => !aggregate.keys.includes(name))
     const complete = missing.length === 0
 
+    // The fix splits on the same evidence the writer does: on a shape match alone no
+    // scaffolder will add the key either, so it names what would make them.
+    const fix = aggregate.confident
+      ? `Add ${missing.join(', ')} to it, keeping each table's own declaration above the object.`
+      : `Nothing identifies this object as the schema, so scaffolders leave it alone: name it \`schema\` or read it in a \`typeof\` to have them keep it current, or add ${missing.join(', ')} by hand.`
+
     results.push({
       ...check(
         `schema-aggregate-keys:${scope}`,
@@ -262,9 +268,7 @@ async function checkSchemaAggregateKeys(cwd: string, cache: ParseCache): Promise
         complete
           ? `The schema object in ${relPath} lists every table the file declares.`
           : `The schema object in ${relPath} does not list ${formatTruncatedList(missing)}.`,
-        complete
-          ? undefined
-          : `Add ${missing.join(', ')} to it, keeping each table's own declaration above the object.`,
+        complete ? undefined : fix,
       ),
       advisory: !aggregate.confident,
     })

--- a/packages/cli/src/patch-helpers.ts
+++ b/packages/cli/src/patch-helpers.ts
@@ -720,13 +720,18 @@ function statementStart(source: string, offset: number): number {
 
 /**
  * Where `name`'s declaration and its aggregate key go, from the one aggregate reading in
- * `schema-parser.ts`. `name` is passed as the extra key so a re-run over a file that already
- * declares the table still recognizes the object listing it.
+ * `schema-parser.ts`, for an aggregate the file itself identifies. `name` is passed as the
+ * extra key so a re-run over a file that already declares the table still recognizes the
+ * object listing it.
  */
 function planAggregateSplice(source: string, name: string): AggregateSplice | null {
   const ast = parseSourceFile(source, 'db/schema.ts')
   const aggregate = ast && findSchemaAggregate(ast, name)
-  if (!aggregate) return null
+  // A shape match the file does not identify is not enough to edit a hand-kept object:
+  // `guren check` grades the same match advisory. Null here also silences
+  // `appendSchemaTable`'s stale-aggregate warning, deliberately — advising by hand the
+  // edit the writer itself declined is that same guess in prose.
+  if (!aggregate?.confident) return null
 
   const { object, statement, keys } = aggregate
   const last = object.properties[object.properties.length - 1]
@@ -764,10 +769,10 @@ function indentOfLine(source: string, offset: number): string {
 
 /**
  * `source` with `block` declaring `name` added — the one rule for writing a table into a
- * `db/schema.ts`, called by every scaffolder that adds one. End of file, unless the app
- * keeps an aggregate object of its tables: then the key goes in and the declaration goes
- * *ahead* of the object, since a `const` naming a table declared further down the file is
- * a use before declaration (TS2448).
+ * `db/schema.ts`, called by every scaffolder that adds one. End of file, unless the file
+ * identifies an aggregate object of its tables: then the key goes in and the declaration
+ * goes *ahead* of the object, since a `const` naming a table declared further down the
+ * file is a use before declaration (TS2448).
  */
 export function appendTableToSchema(
   source: string,

--- a/packages/cli/tests/check.test.ts
+++ b/packages/cli/tests/check.test.ts
@@ -838,6 +838,10 @@ export const authTables = { users }
     const stale = report.checks.find(c => c.key === 'schema-aggregate-keys:app')
     expect(stale!.status).toBe('warn')
     expect(stale!.advisory).toBe(true)
+    // No scaffolder writes to this object either, so the fix names the evidence that
+    // would make one rather than only the edit.
+    expect(stale!.suggestion).toContain('Nothing identifies this object as the schema')
+    expect(stale!.suggestion).toContain('posts')
   })
 
   // parseSchemaTables drops a table whose columns are an identifier; visiting roots

--- a/packages/cli/tests/patch-helpers.test.ts
+++ b/packages/cli/tests/patch-helpers.test.ts
@@ -658,6 +658,33 @@ export const options = { retries, timeout }
     expect(content.trimEnd().endsWith(SESSIONS_BLOCK.trimEnd())).toBe(true)
   })
 
+  it('adds the identifier to an aggregate the file reads in a `typeof`', async () => {
+    // The other half of the evidence `findSchemaAggregate` accepts: not named `schema`,
+    // but the file itself says what the object is.
+    const content = await appendSessions(`${PG_TABLES}
+export const appSchema = { users, posts }
+
+export type AppSchema = typeof appSchema
+`)
+
+    expect(content).toContain('export const appSchema = { users, posts, sessions }')
+    expect(content.indexOf('export const sessions =')).toBeLessThan(content.indexOf('export const appSchema ='))
+  })
+
+  it('leaves a table-shaped object the file does not identify alone', async () => {
+    // A deliberate grouping of some tables is indistinguishable from the aggregate on
+    // shape, so the writer falls all the way back: no key, and no declaration moved
+    // ahead of the object — the reordering exists only to make the key legal.
+    const content = await appendSessions(`${PG_TABLES}
+export const authTables = { users }
+`)
+
+    expect(content).toContain('export const authTables = { users }')
+    expect(content).not.toContain('sessions }')
+    expect(content.trimEnd().endsWith(SESSIONS_BLOCK.trimEnd())).toBe(true)
+    expect(content.indexOf('export const sessions =')).toBeGreaterThan(content.indexOf('export const authTables ='))
+  })
+
   it('leaves an aggregate ambiguous between two candidates alone', async () => {
     const content = await appendSessions(`${PG_TABLES}
 export const schema = { users, posts }
@@ -725,6 +752,17 @@ export const schema = { users }
 
     expect(warned).toContain('stays out of `typeof schema`')
     expect(warned).not.toContain('moving `export const sessions`')
+  })
+
+  it('says nothing about a table-shaped object the file does not identify', async () => {
+    // The writer declines to add the key here, so advising the same edit by hand would
+    // be the guess it just refused. `guren check` still reports it, advisory.
+    const warned = await warningsFor(`${PG_TABLES}
+export const authTables = { users }
+
+${DECLARED}`)
+
+    expect(warned).toBe('')
   })
 })
 


### PR DESCRIPTION
`findSchemaAggregate()` returns `confident: boolean` — the file's own evidence that the object it matched is the schema drizzle is handed, rather than an object that merely has the shape of one. `guren check`'s `checkSchemaAggregateKeys` already acts on it (`advisory: !aggregate.confident`), so a bare shape match does not fail `--ci` or `guren gate`.

`planAggregateSplice()` in `patch-helpers.ts` called the same detection and ignored the flag. For a correct schema that keeps no aggregate at all:

```ts
export const users = pgTable('users', { … })
export const posts = pgTable('posts', { … })
export const authTables = { users }
```

`appendTableToSchema()` would splice `sessions,` into `authTables` and move the new table's declaration above it — editing a hand-kept file on exactly the guess the checker refuses to gate on. All four writers reach it: `guren add session`, `guren add attachments`, `guren make:auth`, and the resource blueprint behind `make:feature`.

## Change

`planAggregateSplice()` now returns null on a non-confident match, so the writer falls all the way back: end-of-file append, no key, no declaration reordering. The reordering exists only because the key references the table (TS2448), so the two go together.

The gate reads `aggregate.confident` at the one place both callers pass through; no second answer to "which object is the aggregate" or "which identifiers are tables" was added.

## The stale-aggregate warning: silenced

`appendSchemaTable()`'s `already-declared` branch warns `The schema object in db/schema.ts does not list <name> — …`. It shares `planAggregateSplice()`, so it is now silent on a non-confident object. **This is deliberate, not incidental.** Advising the user by hand to make the edit the writer itself just declined is the same guess in prose, and the advice names a specific object that may be a deliberate narrow grouping. Nothing is lost: `guren check` still reports the omission, advisory, which is where a shape-match-grade finding belongs. The comment at the gate says so, so a future reader restoring the warning cannot silently restore the write with it.

## `guren check`'s message (the optional item)

Taken, for the same consistency reason. On a non-confident match the fix no longer only says "add them to it" — the edit no scaffolder will make either. It now names the evidence:

> Nothing identifies this object as the schema, so scaffolders leave it alone: name it `schema` or read it in a `typeof` to have them keep it current, or add posts by hand.

The `message` is unchanged, so existing assertions against it still hold.

## Scaffolded apps are unaffected

`packages/create-app/templates/database/{postgres,mysql,sqlite}/db/schema.ts` keep no aggregate object at all, so `findSchemaAggregate` already returned null there. `examples/blog/db/schema.ts` uses `export const schema` *and* `export type BlogSchema = typeof schema` — confident on both counts. No smoke or template surface changes behaviour.

## Tests

Three added to `packages/cli/tests/patch-helpers.test.ts` / `check.test.ts`:

- an aggregate named something else but read in a `typeof` still gets the key and the reordering — the only defence against a future "simplification" of the rule to `name === 'schema'`;
- a non-confident object gets neither the key **nor** the declaration move (both asserted, so a half-fallback cannot pass);
- a non-confident stale aggregate produces no warning.

Each was mutation-checked: reverting the gate fails the last two, dropping the `typeof` half of `confident` fails the first. `blueprints.test.ts`, `make-auth.test.ts`, `add-session.test.ts` and `add-attachments.test.ts` pass unchanged — their fixtures name the aggregate `schema`.

## Verification

| gate | exit |
|---|---|
| `bun run lint` | 0 |
| `bun run typecheck` | 0 |
| `cd packages/cli && bun test --preload ../../scripts/test-cwd-guard.ts` | 0 — 2389 pass, 0 fail (baseline on the merge base: 2386 pass, 0 fail) |
