### PR TITLE
test: await the real @guren/core inside the controller module mocks

### DIFF
--- a/examples/api/tests/resources/UserResource.test.ts
+++ b/examples/api/tests/resources/UserResource.test.ts
@@ -3,7 +3,7 @@ import { createControllerModuleMock } from '@guren/testing/controller'
 
 // Async like every other mock in this suite: awaiting the real module settles
 // the server/hono graph inside the factory, rather than leaving it to load
-// while vitest is tearing the environment down.
+// while vitest is tearing the environment down (seen on bun 1.4.2 only).
 vi.mock('@guren/core', async () => {
   const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
   return { ...actual, ...createControllerModuleMock() }

--- a/web/modules/blog/app/Http/Controllers/Admin/PostsController.test.ts
+++ b/web/modules/blog/app/Http/Controllers/Admin/PostsController.test.ts
@@ -6,6 +6,9 @@ import {
 } from '@guren/testing'
 import type { Context } from '@guren/core'
 
+// Async like every other mock in this suite: awaiting the real module settles
+// the server/hono graph inside the factory, rather than leaving it to load
+// while vitest is tearing the environment down (seen on bun 1.4.2 only).
 vi.mock('@guren/core', async () => {
   const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
   return { ...actual, ...createControllerModuleMock() }

--- a/web/modules/blog/app/Http/Controllers/Auth/OAuthController.test.ts
+++ b/web/modules/blog/app/Http/Controllers/Auth/OAuthController.test.ts
@@ -6,14 +6,12 @@ import {
 } from '@guren/testing'
 import type { Context } from '@guren/core'
 
-vi.mock('@guren/core', () => {
-  const mock = createControllerModuleMock()
-  // The module mock has no AuthorizationException; a 403-carrying stand-in
-  // keeps admin-allowlist working under it.
-  class AuthorizationException extends Error {
-    statusCode = 403
-  }
-  return { ...mock, AuthorizationException }
+// Async like every other mock in this suite: awaiting the real module settles
+// the server/hono graph inside the factory, rather than leaving it to load
+// while vitest is tearing the environment down (seen on bun 1.4.2 only).
+vi.mock('@guren/core', async () => {
+  const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
+  return { ...actual, ...createControllerModuleMock() }
 })
 
 import OAuthController from './OAuthController.js'

--- a/web/modules/blog/app/Http/Controllers/BlogController.test.ts
+++ b/web/modules/blog/app/Http/Controllers/BlogController.test.ts
@@ -7,6 +7,9 @@ import {
 } from '@guren/testing'
 import type { Context } from '@guren/core'
 
+// Async like every other mock in this suite: awaiting the real module settles
+// the server/hono graph inside the factory, rather than leaving it to load
+// while vitest is tearing the environment down (seen on bun 1.4.2 only).
 vi.mock('@guren/core', async () => {
   const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
   return { ...actual, ...createControllerModuleMock() }


### PR DESCRIPTION
## Summary

A synchronous `vi.mock('@guren/core', () => createControllerModuleMock())` leaves the server/hono module graph loading while vitest tears the environment down. On bun 1.4.2 that surfaces as:

```
EnvironmentTeardownError: Cannot load '.../hono/dist/index.js' imported from packages/server/src/http/Application.ts after the environment was torn down
```

#752 moved `examples/api/tests/resources/TaskResource.test.ts` to an async factory that awaits `vi.importActual` before spreading the mock over it. The same failure then hit `UserResource.test.ts` on #743's CI (run 34291895000, build-and-test (1.4.2)) while main's run of the identical code passed, so the cause is latent in every remaining sync mock of this shape.

#743 has since converted `UserResource.test.ts` and the two blog controller tests. Rebased on top of it, this PR is what remains:

- `web/modules/blog/app/Http/Controllers/Auth/OAuthController.test.ts` — the last mock still going through `createControllerModuleMock()` synchronously, and it imports `@guren/testing`'s root, which reaches `@guren/server`. With the real module spread first, its hand-written 403 `AuthorizationException` stand-in is replaced by the real one (`HttpException` with `statusCode: 403`), so the stand-in is gone.
- The #752 comment on the three mocks #743 converted, so all five async factories carry the same one (the two web controller tests had none; `UserResource.test.ts` lacked the "seen on bun 1.4.2 only" tail).

Left alone: the job and mail tests (`examples/blog/tests/jobs/*`, `examples/blog/tests/mail/Mail.test.ts`, `examples/api/tests/jobs/SendRegistrationEmailJob.test.ts`). Their `@guren/core` mocks are hand-built objects, and every other import they make (`Job`, `Event`, models, mail modules) is either mocked or type-only, so nothing in them reaches `@guren/server`.

Test-only change; no changeset.

## Verification

- `bun run test:examples` (blog, api, agents, web): all green before the rebase
- After the rebase: `cd web && bun run test` (24 files / 220 tests + 25 `bun test` cases) and `examples/api` `tests/resources`, all green
- `bun run lint`: clean

Note for anyone reproducing locally: `web/tests/services/MarkdownRenderer.test.ts` fails in a fresh worktree until `bun run build plugin-markdown` runs. `@guren/plugin-markdown` is not aliased to `src` in the web vitest config, so a `dist/` built before #705 lacks the `info` argument the tutorial-listing captions read. Unrelated to this PR; main's CI is green on the same code.
