### PR TITLE
fix(web): declare utf-8 on the static markdown and llms-full.txt

### DIFF
--- a/web/public/_headers
+++ b/web/public/_headers
@@ -8,8 +8,13 @@
   X-Robots-Tag: noindex
   Cache-Control: public, max-age=3600
 
+# The charset is explicit: the platform serves these as bare `text/markdown`
+# and `text/plain` (measured on guren.dev), and a browser opening the Japanese
+# markdown directly then guesses the encoding. DOCS_CACHE_CONTROL's routes set it.
 /docs/*.md
+  Content-Type: text/markdown; charset=utf-8
   Cache-Control: public, max-age=3600
 
 /llms-full.txt
+  Content-Type: text/plain; charset=utf-8
   Cache-Control: public, max-age=3600

--- a/web/tests/services/docs-headers.test.ts
+++ b/web/tests/services/docs-headers.test.ts
@@ -24,6 +24,13 @@ describe('public/_headers', () => {
     expect(headers).toContain(`  Cache-Control: ${DOCS_CACHE_CONTROL}\n`)
   })
 
+  // Workers Static Assets serve a bare `text/markdown`; without an explicit
+  // charset a browser guesses the encoding of the Japanese source.
+  it('should declare utf-8 on the text files it serves', () => {
+    expect(headers).toContain(`\n${docsBasePath('en')}/*.md\n  Content-Type: text/markdown; charset=utf-8\n`)
+    expect(headers).toContain(`\n${LLMS_FULL_PATH}\n  Content-Type: text/plain; charset=utf-8\n`)
+  })
+
   it('should cover the generated paths with those rules', () => {
     expect(docFragmentPath('ja', 'guides', 'routing').startsWith(`${DOC_FRAGMENT_ROOT}/`)).toBe(true)
     // The Japanese markdown lives under the English prefix, so one rule covers both.


### PR DESCRIPTION
Follow-up to #758. On guren.dev the asset layer serves `/docs/**/*.md` as a bare `text/markdown` and `/llms-full.txt` as `text/plain` (measured after the deploy), while the Worker responses they replaced carried `charset=utf-8`. A browser opening the Japanese markdown directly guesses the encoding. The `_headers` rules now set the Content-Type with the charset explicitly; `tests/services/docs-headers.test.ts` pins both lines, and the Miniflare-gated `tests/cloudflare` suite still passes.