### PR TITLE
ci(web): fail the deploy when the worker bundle outgrows its budget

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Build worker
         run: bun run --cwd web cloudflare:build
 
+      # wrangler's dry run on the assembled output, judged against the budget
+      # in web/scripts/lib/bundle-size.ts. Before the D1 steps: a bundle that
+      # will not be deployed must not have loaded a search index first.
+      - name: Check worker bundle size
+        run: cd web && bun run bundle:check
+
       # Idempotent: only unapplied migrations run. Before deploy so new code
       # never runs against an old schema.
       - name: Apply D1 migrations

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     "db:migrate": "bun ../packages/cli/src/bin.ts db:migrate",
     "db:seed": "bun ../packages/cli/src/bin.ts db:seed",
     "cloudflare:build": "bun run build && bun scripts/cloudflare-build.ts && bun scripts/build-search-index.ts",
+    "bundle:check": "bun scripts/check-bundle-size.ts",
     "search:prune": "bun scripts/prune-search-tables.ts",
     "search:apply": "bun scripts/apply-search-index.ts",
     "deploy:cloudflare": "bun run cloudflare:build && bunx wrangler d1 migrations apply guren-web --remote && bun run search:apply && bunx wrangler deploy && bun run search:prune"

--- a/web/scripts/check-bundle-size.ts
+++ b/web/scripts/check-bundle-size.ts
@@ -1,0 +1,43 @@
+/**
+ * Fail the deploy when the worker bundle outgrows its budget. Runs wrangler's
+ * dry run on the assembled .cloudflare/ (so after `cloudflare:build`, before
+ * anything touches D1) and reads the size it reports. Needs no credentials.
+ *   bun scripts/check-bundle-size.ts
+ */
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { judgeBundleSize, parseWranglerSize } from './lib/bundle-size.js'
+
+const outDir = mkdtempSync(join(tmpdir(), 'guren-web-bundle-'))
+let exitCode = 1
+
+try {
+  const child = Bun.spawn(['bunx', 'wrangler', 'deploy', '--dry-run', '--outdir', outDir], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ])
+
+  if (code !== 0) {
+    console.error(`wrangler deploy --dry-run exited ${code}\n${stderr}${stdout}`)
+  } else {
+    const size = parseWranglerSize(`${stdout}\n${stderr}`)
+    if (!size) {
+      console.error(`wrangler printed no "Total Upload" line to read the size from:\n${stderr}${stdout}`)
+    } else {
+      const verdict = judgeBundleSize(size)
+      console.log(verdict.message)
+      exitCode = verdict.ok ? 0 : 1
+    }
+  }
+} finally {
+  rmSync(outDir, { recursive: true, force: true })
+}
+
+process.exit(exitCode)

--- a/web/scripts/lib/bundle-size.ts
+++ b/web/scripts/lib/bundle-size.ts
@@ -1,0 +1,52 @@
+// The worker bundle budget the deploy enforces (scripts/check-bundle-size.ts).
+// A regression budget, not the platform's number: Cloudflare checks 64 MiB
+// uncompressed on every plan (developers.cloudflare.com/workers/platform/limits,
+// confirmed 2026-09-09; the compressed limits went away on 2026-09-04). The
+// worker measured 4,935 KiB after #758, and 28,622 KiB with the docs bundled
+// in, which nothing reported. Raise the budget deliberately, with the number
+// that justified it.
+
+export const BUNDLE_BUDGET_KIB = 12_288
+
+export interface BundleSize {
+  totalKiB: number
+  gzipKiB: number | null
+}
+
+const UNIT_KIB: Record<string, number> = { B: 1 / 1024, KiB: 1, MiB: 1024 }
+
+function toKiB(value: string, unit: string): number {
+  return Number.parseFloat(value) * UNIT_KIB[unit]!
+}
+
+/** wrangler prints `Total Upload: 4935.14 KiB / gzip: 900.47 KiB`; the unit can move. */
+export function parseWranglerSize(output: string): BundleSize | null {
+  const total = output.match(/Total Upload:\s*([\d.]+)\s*(B|KiB|MiB)/u)
+  if (!total) {
+    return null
+  }
+  const gzip = output.match(/gzip:\s*([\d.]+)\s*(B|KiB|MiB)/u)
+
+  return {
+    totalKiB: toKiB(total[1]!, total[2]!),
+    gzipKiB: gzip ? toKiB(gzip[1]!, gzip[2]!) : null,
+  }
+}
+
+export function judgeBundleSize(
+  size: BundleSize,
+  budgetKiB = BUNDLE_BUDGET_KIB,
+): { ok: boolean; message: string } {
+  const percent = ((size.totalKiB / budgetKiB) * 100).toFixed(0)
+  const gzip = size.gzipKiB === null ? '' : ` (gzip ${size.gzipKiB.toFixed(0)} KiB)`
+  const ok = size.totalKiB <= budgetKiB
+  const line = `Worker bundle: ${size.totalKiB.toFixed(0)} KiB uncompressed${gzip}, ${percent}% of the ${budgetKiB} KiB budget.`
+
+  return {
+    ok,
+    message: ok
+      ? line
+      : `${line}\nOver budget. Find what grew with \`wrangler deploy --dry-run --outdir <dir>\` and the source map, ` +
+        'or raise BUNDLE_BUDGET_KIB in web/scripts/lib/bundle-size.ts with the number that justifies it.',
+  }
+}

--- a/web/tests/lib/bundle-size.test.ts
+++ b/web/tests/lib/bundle-size.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { BUNDLE_BUDGET_KIB, judgeBundleSize, parseWranglerSize } from '../../scripts/lib/bundle-size.js'
+
+const WRANGLER_OUTPUT = `
+ ⛅️ wrangler 4.129.0
+───────────────────
+Total Upload: 4935.14 KiB / gzip: 900.47 KiB
+--dry-run: exiting now.
+`
+
+describe('parseWranglerSize', () => {
+  it('should read the uncompressed and gzip sizes wrangler prints', () => {
+    expect(parseWranglerSize(WRANGLER_OUTPUT)).toEqual({ totalKiB: 4935.14, gzipKiB: 900.47 })
+  })
+
+  it('should normalise the unit to KiB when wrangler picks another', () => {
+    expect(parseWranglerSize('Total Upload: 1.5 MiB / gzip: 512 B')).toEqual({
+      totalKiB: 1536,
+      gzipKiB: 0.5,
+    })
+  })
+
+  it('should return null rather than a size when the line is missing', () => {
+    expect(parseWranglerSize('Something else entirely')).toBeNull()
+  })
+})
+
+describe('judgeBundleSize', () => {
+  it('should pass a bundle within the budget and say how much of it is used', () => {
+    const verdict = judgeBundleSize({ totalKiB: 4935, gzipKiB: 900 })
+
+    expect(verdict.ok).toBe(true)
+    expect(verdict.message).toContain('4935 KiB uncompressed (gzip 900 KiB)')
+    expect(verdict.message).toContain(`40% of the ${BUNDLE_BUDGET_KIB} KiB budget`)
+  })
+
+  it('should fail a bundle over the budget and name the file that holds it', () => {
+    const verdict = judgeBundleSize({ totalKiB: 28_622, gzipKiB: null }, 12_288)
+
+    expect(verdict.ok).toBe(false)
+    expect(verdict.message).toContain('233% of the 12288 KiB budget')
+    expect(verdict.message).toContain('Over budget')
+    expect(verdict.message).toContain('web/scripts/lib/bundle-size.ts')
+  })
+
+  it('should treat the budget itself as within budget', () => {
+    expect(judgeBundleSize({ totalKiB: 12_288, gzipKiB: null }, 12_288).ok).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #760.

Adds a `Check worker bundle size` step to `deploy-web.yml` right after `Build worker` and before the D1 steps. `web/scripts/check-bundle-size.ts` runs `wrangler deploy --dry-run --outdir <tmp>` on the assembled output (no credentials needed), parses the `Total Upload` line and fails above `BUNDLE_BUDGET_KIB` (12,288 KiB) in `web/scripts/lib/bundle-size.ts`, whose header records where the number comes from and the platform limit it is not (64 MiB uncompressed since 2026-09-04). The parser and the verdict are unit-tested; the real run on the current build prints:

```
Worker bundle: 4931 KiB uncompressed (gzip 900 KiB), 40% of the 12288 KiB budget.
```

The failure message names the file holding the budget and how to attribute the growth, so raising it is a deliberate edit with a number attached.