### PR TITLE
fix(cli): keep Data.<Entity> after promoting a prototype feature

### DIFF
--- a/.changeset/hip-pumas-shout.md
+++ b/.changeset/hip-pumas-shout.md
@@ -1,0 +1,5 @@
+---
+"@guren/cli": patch
+---
+
+Promotion now leaves `Data.<Entity>` in `data.gen.ts`. The Resource `make:feature` writes when promoting a prototype feature annotated `toArray()` with the `<Entity>Data` it imports from `resources/js/types/`, and codegen reads only the Resource's own source, so it warned and omitted the type. The annotation now names the `<Entity>ResourceData` alias the same file declares.

--- a/docs/en/tutorials/15-prototype-first.md
+++ b/docs/en/tutorials/15-prototype-first.md
@@ -433,7 +433,7 @@ Hand the backend to the agent:
 The rubric:
 
 - **`db/schema.ts`** gained an `announcements` table with the four columns and nothing else changed. A migration under `db/migrations/` was generated and applied.
-- **`app/Models/Announcement.ts`**, **`app/Http/Resources/AnnouncementResource.ts`** and **`app/Http/Controllers/AnnouncementController.ts`** exist. The Resource's `toArray()` returns `AnnouncementData`, the type the pages were built against, so the shape the customer saw is now the serializer's contract.
+- **`app/Models/Announcement.ts`**, **`app/Http/Resources/AnnouncementResource.ts`** and **`app/Http/Controllers/AnnouncementController.ts`** exist. The Resource's `toArray()` returns `AnnouncementResourceData`, its own alias for the `AnnouncementData` the pages were built against, so the shape the customer saw is now the serializer's contract and `codegen` emits it as `Data.Announcement`.
 - **`routes/web.ts`** has no `prototype` handler left for `announcements.*`, `index` and `show` are still public, the rest still in the `auth` group, and the `params` and `body` schemas are unchanged.
 - **`resources/js/pages/announcements/`**, **`app/Http/Validators/AnnouncementValidator.ts`** and **`resources/js/prototype/index.ts`** are untouched. `git diff --stat` is the check; the pages are the point of the exercise, and the fixture keeps serving `build:prototype`.
 - **`docs/spec/`** was regenerated, so `check --spec` is green.

--- a/docs/ja/tutorials/15-prototype-first.md
+++ b/docs/ja/tutorials/15-prototype-first.md
@@ -433,7 +433,7 @@ bun test tests/AnnouncementController.test.ts
 rubric:
 
 - **`db/schema.ts`** に 4 つの列を持つ `announcements` テーブルが増え、それ以外は変わっていない。`db/migrations/` の下にマイグレーションが生成され、適用されている。
-- **`app/Models/Announcement.ts`**、**`app/Http/Resources/AnnouncementResource.ts`**、**`app/Http/Controllers/AnnouncementController.ts`** が存在する。Resource の `toArray()` は、ページが組み立てられた型 `AnnouncementData` を返す。顧客が見た形が、そのままシリアライザーの契約になっている。
+- **`app/Models/Announcement.ts`**、**`app/Http/Resources/AnnouncementResource.ts`**、**`app/Http/Controllers/AnnouncementController.ts`** が存在する。Resource の `toArray()` は、ページが組み立てられた型 `AnnouncementData` の別名 `AnnouncementResourceData` を返す。顧客が見た形が、そのままシリアライザーの契約になり、`codegen` はそれを `Data.Announcement` として書き出す。
 - **`routes/web.ts`** に `announcements.*` の `prototype` ハンドラーが残っておらず、`index` と `show` は公開のまま、残りは `auth` グループのまま、`params` と `body` のスキーマは変わっていない。
 - **`resources/js/pages/announcements/`**、**`app/Http/Validators/AnnouncementValidator.ts`**、**`resources/js/prototype/index.ts`** に触れていない。`git diff --stat` で確認する。ページこそがこの演習の要点で、fixture は `build:prototype` に答え続ける。
 - **`docs/spec/`** が再生成され、`check --spec` が緑。

--- a/packages/cli/src/make-feature-prototype.ts
+++ b/packages/cli/src/make-feature-prototype.ts
@@ -187,11 +187,15 @@ export function generatePromotedResource(singular: string, fields: FieldDefiniti
 import type { ${singular}Record } from '../../Models/${singular}.js'
 import type { ${singular}Data } from '${prototypeTypesSpecifier(singular)}'
 
-/** The shape the prototype pages were built against, now the serializer's contract. */
+/**
+ * The shape the prototype pages were built against, now the serializer's contract.
+ * Annotate toArray() with this alias, not the imported ${singular}Data: data.gen.ts
+ * reads only this file, and an imported annotation drops Data.${singular}.
+ */
 export type ${singular}ResourceData = ${singular}Data
 
-export class ${singular}Resource extends Resource<${singular}Record, ${singular}Data> {
-  toArray(): ${singular}Data {
+export class ${singular}Resource extends Resource<${singular}Record, ${singular}ResourceData> {
+  toArray(): ${singular}ResourceData {
     return {
 ${toArrayFields}
     }

--- a/packages/cli/tests/make-feature.test.ts
+++ b/packages/cli/tests/make-feature.test.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
 import { makeFeature, buildRouteRegistrationHint } from '../src/make-feature'
+import { generateDataTypes } from '../src/data-types'
 import { parseAttachString, parseFieldsString } from '../src/fields'
 import { API_ONLY_REFUSAL, API_ROUTES_FIXTURE, createTempWorkspace, DEFAULT_ROUTES_FIXTURE, seedApiOnlyApp, seedAttachmentsConfig } from './helpers'
 
@@ -724,7 +725,15 @@ describe('makeFeature --prototype (RFC 0021 Part 3)', () => {
       const resource = await readFile(join(workspace.dir, 'app/Http/Resources/NoteResource.ts'), 'utf8')
       expect(resource).toContain("import type { NoteData } from '@/resources/js/types/Note'")
       expect(resource).toContain('export type NoteResourceData = NoteData')
-      expect(resource).toContain('toArray(): NoteData {')
+      expect(resource).toContain('toArray(): NoteResourceData {')
+
+      // The annotation names the local alias so codegen still emits Data.Note:
+      // data.gen.ts reads only the resource's own source.
+      const generated = await generateDataTypes({ appRoot: workspace.dir })
+      expect(generated.warnings).toEqual([])
+      expect(generated.definitions.find((d) => d.className === 'NoteResource')?.rawType)
+        .toContain('.NoteResourceData')
+      expect(await readFile(join(workspace.dir, '.guren/data.gen.ts'), 'utf8')).toContain('Note =')
     } finally {
       await workspace.cleanup()
     }

--- a/scripts/smoke/prototype-scaffold.ts
+++ b/scripts/smoke/prototype-scaffold.ts
@@ -121,5 +121,11 @@ export async function runPrototypeScaffold(options: PrototypeScaffoldOptions): P
   )
   const promotedFixture = await readFile(join(appDir, 'resources/js/prototype/index.ts'), 'utf8')
   assert(promotedFixture === fixture, 'promotion must leave the fixture as it was')
-  console.log('[smoke:prototype-scaffold] promoted: backend written, pages and fixture kept')
+
+  // The promoted Resource must still yield a `Data` member. codegen only warns
+  // when it cannot read one, so nothing downstream fails on a silent omission.
+  await cli('codegen', '--force')
+  const dataTypes = await readFile(join(appDir, '.guren/data.gen.ts'), 'utf8')
+  assert(/^\s*export type Note = /mu.test(dataTypes), 'promotion left Data.Note out of data.gen.ts')
+  console.log('[smoke:prototype-scaffold] promoted: backend written, pages and fixture kept, Data.Note emitted')
 }


### PR DESCRIPTION
## Summary

Promoting a prototype feature to a real backend silently dropped its `Data.<Entity>` type from `data.gen.ts`.

The Resource that `make:feature` writes when promoting annotates `toArray()` with the `<Entity>Data` it imports from `resources/js/types/`. `data.gen.ts` reads only the Resource's own source — a deliberate constraint, since the import-type fallback added in #538 gates on exportedness proven from the AST of that one file, and following an import would reintroduce the blindness `collectTopLevelTypeDeclarations()` explicitly refuses for re-exports. So codegen warned and emitted nothing:

```
WARN  Resource AnnouncementResource (app/Http/Resources/AnnouncementResource.ts) annotates
      toArray(): AnnouncementData, but no interface or type AnnouncementData is declared in
      that file — omitted from data.gen.ts.
```

Nothing downstream failed: the codegen stage only warns, so `guren gate` stayed green and the type just wasn't there.

The extractor is not the problem. The promoted Resource already declares a type that satisfies the fallback's three conditions (top-level, exported, non-generic):

```ts
export type AnnouncementResourceData = AnnouncementData
```

`toArray()` now names that alias instead of the imported one, so the existing "copy first, reference second" path emits the member:

```ts
export type Announcement = import('../app/Http/Resources/AnnouncementResource').AnnouncementResourceData
```

Since the alias *is* `AnnouncementData`, the type the prototype pages were built against remains the serializer's contract, with no shape duplicated.

The scaffold smoke now runs `codegen` after promotion and asserts the `Data` member. That check's absence is what let this ship: the smoke stopped at promotion, and a warning fails nothing.

Found while running the v2.21.0 tutorial end to end from `create-guren-app`.

## Scope

- `cli` — `make-feature-prototype.ts` (the promoted-Resource template), its test
- `scripts` — `smoke/prototype-scaffold.ts` (new post-promotion codegen assertion)
- `docs` — tutorial 15 success criteria, en + ja (the returned type's name changed)

## Risk Assessment

No API change and no migration. Only newly scaffolded promotions differ; an app already promoted keeps compiling — `<Entity>ResourceData` and `<Entity>Data` are the same type, so changing the annotation by hand is optional and purely to regain `Data.<Entity>`.

One visible output difference: a promoted feature's `Data` member is an `import(...)` reference rather than a copied brace body. That is the documented fallback shape from #538, not a new mechanism.

The ja doc change was rebased onto #767's prose rewrite, keeping that PR's wording and correcting only the type name.

## Validation

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` — see note

`bun run smoke:starter` (the real end-to-end proof: fresh app, `add prototype` → `make:feature --prototype` → promote → `codegen`):

```
✔ Data types generated at .../.guren/data.gen.ts        (no warning)
[smoke:prototype-scaffold] promoted: backend written, pages and fixture kept, Data.Note emitted
...
Gate passed: 6 passed, 0 failed, 0 skipped
```

Emitted output, confirmed directly:

```
warnings: []
export type Note = import('../app/Http/Resources/NoteResource').NoteResourceData
```

Also green: `bun run typecheck`, `bun run lint`, `bun run audit:docs`, `bun run audit:core-first`, `bun run audit:starter-template`, `bun test packages/cli` (2421 pass).

Note on `bun run test`: the full `test:bun` run wedged locally at 99% CPU with no output for 10 minutes (the known `spawnSync` spin), with a sibling worktree running the same suite concurrently. It was killed and replaced with `bun test packages/cli` plus the relevant `scripts/` tests, which cover every file this PR touches. CI runs the full suite.

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation.
