### PR TITLE
fix(plugin-cloudflare): warn when the database config never calls createD1Database

### DIFF
--- a/.changeset/cloudflare-build-warns-without-d1.md
+++ b/.changeset/cloudflare-build-warns-without-d1.md
@@ -1,0 +1,17 @@
+---
+"@guren/plugin-cloudflare": patch
+---
+
+Warn when the database config never calls `createD1Database()`
+
+The Cloudflare build stubs every SQL client and `bun:sqlite`, since D1 is the
+only database Workers can reach, but it never checked whether the app's
+`config/database.ts` (or `db/config.ts`) actually calls `createD1Database()`. A
+config calling only `createSqliteDatabase()` or `createPostgresDatabase()` built
+clean and threw on the deployed worker's first query.
+
+The build now reads the config the same way the Lambda build does and warns,
+naming the file and the factories it found, when none of them is D1. A config
+naming D1 beside another factory (switching at runtime) passes, and a config the
+scan cannot read stays silent: a name scan cannot see a factory reached
+indirectly, so this is advice rather than a gate.

--- a/packages/plugin-cloudflare/src/build.test.ts
+++ b/packages/plugin-cloudflare/src/build.test.ts
@@ -879,3 +879,55 @@ describe('buildCloudflareOutput deploy-runtime warnings (RFC 0020 Part 0)', () =
     expect(warnings).not.toContain('shares no memory')
   })
 })
+
+describe('buildCloudflareOutput database factory warning', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'guren-cf-db-factory-'))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  function writeDatabaseConfig(source: string): void {
+    mkdirSync(join(root, 'config'), { recursive: true })
+    writeFileSync(join(root, 'config/database.ts'), source)
+  }
+
+  test('should warn when the database config never calls createD1Database', async () => {
+    scaffoldApp(root)
+    writeDatabaseConfig(
+      "import { createSqliteDatabase } from '@guren/core'\nexport const { getDatabase } = createSqliteDatabase({ filename: './data/app.db' })\n",
+    )
+
+    const warnings = await captureWarnings(() => buildCloudflareOutput({ rootDir: root, skipAppBuild: true }))
+
+    expect(warnings).toContain('Cloudflare build: config/database.ts calls createSqliteDatabase() and never createD1Database()')
+    expect(warnings).toContain('throw at its first database call')
+    // Advice, not a gate: the worker is still assembled.
+    expect(existsSync(join(root, '.cloudflare/worker.js'))).toBe(true)
+  })
+
+  test('should stay quiet for a config that switches to createD1Database at runtime', async () => {
+    scaffoldApp(root)
+    writeDatabaseConfig(
+      "import { createD1Database, createSqliteDatabase } from '@guren/core'\n"
+        + "import { isWorkersRuntime } from '@guren/plugin-cloudflare/env'\n"
+        + 'export const { getDatabase } = isWorkersRuntime() ? createD1Database({ binding: () => ({}) }) : createSqliteDatabase({ filename: \'./data/app.db\' })\n',
+    )
+
+    const warnings = await captureWarnings(() => buildCloudflareOutput({ rootDir: root, skipAppBuild: true }))
+
+    expect(warnings).not.toContain('never createD1Database()')
+  })
+
+  test('should stay quiet when there is no database config to read', async () => {
+    scaffoldApp(root)
+
+    const warnings = await captureWarnings(() => buildCloudflareOutput({ rootDir: root, skipAppBuild: true }))
+
+    expect(warnings).not.toContain('never createD1Database()')
+  })
+})

--- a/packages/plugin-cloudflare/src/build.ts
+++ b/packages/plugin-cloudflare/src/build.ts
@@ -4,11 +4,13 @@ import { pathToFileURL } from 'node:url'
 import {
   AGENTS_CONFIG_FILE,
   appUsesMcpPlugin,
+  DATABASE_FACTORIES,
   DEV_ONLY_MODULES,
   MCP_PLUGIN_PACKAGE,
   MCP_TRANSPORT_SPECIFIER,
   SQL_CLIENT_MODULES,
   clientManifestJson,
+  detectDatabaseDialects,
   DOCUMENT_ASSET_EXTENSIONS,
   DOCUMENT_ASSET_HEADERS,
   importSpecifier,
@@ -128,6 +130,7 @@ export async function buildCloudflareOutput(options: BuildCloudflareOutputOption
   // drops every login after deploy, and the warning belongs where the
   // developer is still reading (RFC 0020 Part 0).
   await reportDeployRuntimeHazards({ root, label: 'Cloudflare build' })
+  warnDatabaseWithoutD1(root)
 
   if (!options.skipAppBuild) {
     runAppBuild(root, packageJson.scripts ?? {})
@@ -686,6 +689,28 @@ function nextMigrationTag(config: Record<string, unknown>): string {
   }
 
   return `v${highest + 1}`
+}
+
+/**
+ * Every SQL client is stubbed below whether or not the app calls
+ * `createD1Database()`, so a config that never does deploys clean and throws on
+ * its first query. Advice, not a gate, and silent when detection returns no
+ * dialects: a name scan cannot see a factory reached indirectly. A config naming
+ * D1 beside another factory (`web/config/database.ts` switches at runtime) passes.
+ */
+function warnDatabaseWithoutD1(root: string): void {
+  const { dialects, source } = detectDatabaseDialects(root)
+  if (!dialects || !source || dialects.includes('d1')) {
+    return
+  }
+
+  const factories = Object.entries(DATABASE_FACTORIES)
+    .filter(([, dialect]) => dialects.includes(dialect))
+    .map(([factory]) => `${factory}()`)
+    .join(', ')
+  console.warn(
+    `Cloudflare build: ${source} calls ${factories} and never createD1Database(). On Cloudflare Workers only createD1Database() can connect — every other database client is stubbed in this worker — so the deployed worker will throw at its first database call. Switch the config to createD1Database() (keeping the other factory behind an isWorkersRuntime() branch if it serves local development).`,
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary

`buildCloudflareOutput` stubs every SQL client and `bun:sqlite` unconditionally, since D1 is the only database Workers can reach, but it never checked whether the app's `config/database.ts` (or `db/config.ts`) actually calls `createD1Database()`. A config calling only `createSqliteDatabase()` or `createPostgresDatabase()` built clean and threw on the deployed worker's first query.

The build now reads the config through `detectDatabaseDialects()` from `@guren/core/internal/deploy-build`, the same scan the Lambda build uses via `unusedSqlClients`, and prints a `Cloudflare build:` prefixed warning naming the file and the factories it found when none of them is D1. It runs right after the deploy-runtime hazard report, before the app build, so the developer sees it while still reading.

- A config naming D1 beside another factory (the `web/config/database.ts` shape, which switches on `isWorkersRuntime()`) passes.
- When detection returns no dialects (no config, or a config naming no factory), the build stays silent: a name scan cannot see a factory reached indirectly, and the deploy-build header documents the detection as failing open.
- Advice, not a gate: the worker is still assembled.

Independent of RFC 0022 (per-dialect ORM subpath exports); it does not implement the subpath split.

## Scope

- `packages/plugin-cloudflare/src/build.ts`: `warnDatabaseWithoutD1()` and its call site
- `packages/plugin-cloudflare/src/build.test.ts`: three cases (sqlite-only warns, D1 + sqlite does not, missing config does not)
- `.changeset/cloudflare-build-warns-without-d1.md`: `@guren/plugin-cloudflare` patch

## Risk Assessment

Additive: one new `console.warn` on a path that previously said nothing. No change to the generated worker, stubs, aliases, or `wrangler.jsonc`. The message keeps the `Cloudflare build:` prefix that `wrangler-bundle.test.ts` asserts never reaches a deployed bundle.

## Validation

- [x] `bun run build` (`build:clean`)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test:bun plugin-cloudflare` (264 pass, 22 skip, 0 fail)

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [x] I added/updated tests for behavior changes.
- [x] I updated relevant documentation (changeset; no guide describes this check).
