### PR TITLE
fix(plugin-cloudflare): default the offered scope when an OAuth client sends none

### DIFF
--- a/.changeset/mcp-oauth-default-scope.md
+++ b/.changeset/mcp-oauth-default-scope.md
@@ -1,0 +1,39 @@
+---
+"@guren/plugin-cloudflare": patch
+---
+
+Offer a default scope when an OAuth client sends none, and advertise the scopes it could ask for
+
+An `--mcp-oauth` worker's consent screen offered exactly what the authorize
+request asked for, so a client sending no `scope` was offered nothing: the page
+said there was nothing to approve, the user had no button to press, and the MCP
+connection could not be established at all. Both clients measured against a
+deployed app (Claude's connector and MCP Inspector) omit `scope` and expose no
+field to add one, so there was no way round it from the client. RFC 6749 §3.3
+requires a server receiving no scope to apply a default or fail the request.
+
+The scaffolded `McpOAuthController` now substitutes `DEFAULT_SCOPE`, a named
+constant set to `tools:*`, when the request carries no scope at all. That widens
+the offer, not the grant: the screen renders write tools unticked, so approving
+it untouched still grants only the read-only set, and the intersection against
+the client's request is unchanged. A scope that is present but expands to
+nothing still offers nothing, so a client naming one unknown tool is not handed
+every tool.
+
+The generated `OAuthProvider` also declares `scopesSupported: ['tools:*',
+'tools:read']`, which the authorization server metadata advertises, so a client
+that reads it has something to request. Only the set-level scopes are listed:
+the build has no route graph, so the `tool:<name>` scopes an app exposes are not
+known at build time.
+
+An app that already ran `--mcp-oauth` gets the metadata half from a rebuild, since
+the worker is regenerated every build, but not the default: the scaffold never
+overwrites a controller the developer already has. Apply it by hand in
+`app/Http/Controllers/McpOAuthController.ts`:
+
+```ts
+const DEFAULT_SCOPE = 'tools:*'
+
+// in offeredTools(), where `requested` was passed straight to expandToolScopes:
+requested.length > 0 ? requested : [DEFAULT_SCOPE],
+```

--- a/packages/plugin-cloudflare/src/build.ts
+++ b/packages/plugin-cloudflare/src/build.ts
@@ -1310,6 +1310,12 @@ function renderOAuthProvider(mcpPath: string, defaultEntry: string): string {
   // 2026-07-28 line in favour of Client ID Metadata Documents, but it is
   // what shipping MCP SDK 1.x clients use to register themselves today.
   clientRegistrationEndpoint: ${JSON.stringify(OAUTH_ENDPOINTS.register)},
+  // Advertised in the authorization server metadata, so a client has something to
+  // discover and request rather than sending no scope at all. Set-level only: the
+  // build has no route graph to name \`tool:<name>\` scopes from. A grant records
+  // those \`tool:<name>\` entries, so a refresh must echo the token response's own
+  // scope and never this list, which the provider downscopes to nothing.
+  scopesSupported: ['tools:*', 'tools:read'],
 })`
 }
 

--- a/packages/plugin-cloudflare/src/mcp-oauth.test.ts
+++ b/packages/plugin-cloudflare/src/mcp-oauth.test.ts
@@ -199,6 +199,16 @@ describe('cloudflare:build --mcp-oauth', () => {
       expect(worker).not.toContain('handler.fetch(request, env, ctx)')
     })
 
+    /**
+     * Without `scopes_supported` a well-behaved client has nothing to discover
+     * and sends no scope, which the consent screen then has to default.
+     */
+    test('should advertise the set-level scopes in the server metadata', async () => {
+      const worker = await build()
+
+      expect(worker).toContain("scopesSupported: ['tools:*', 'tools:read']")
+    })
+
     test('should import the seam from the plugin-mcp oauth subpath', async () => {
       const worker = await build()
 
@@ -499,6 +509,13 @@ describe('mcp-oauth templates', () => {
   test('should intersect the submission with what the client requested', () => {
     expect(controller).toContain('expandToolScopes(')
     expect(controller).toContain('offeredScopes.has(scope)')
+  })
+
+  test('should offer a default rather than nothing when the client sends no scope', () => {
+    expect(controller).toContain("const DEFAULT_SCOPE = 'tools:*'")
+    // In `offeredTools`, so the POST path defaults identically; and keyed on the
+    // request being empty, not on its expansion, which must stay empty.
+    expect(controller).toContain('requested.length > 0 ? requested : [DEFAULT_SCOPE]')
   })
 
   test('should carry the CSRF field into the consent form', () => {

--- a/packages/plugin-cloudflare/templates/mcp-oauth/app/Http/Controllers/McpOAuthController.ts
+++ b/packages/plugin-cloudflare/templates/mcp-oauth/app/Http/Controllers/McpOAuthController.ts
@@ -39,6 +39,15 @@ import {
  */
 const LOGIN_PATH = '/login'
 
+/**
+ * What a client that sent no `scope` is offered. RFC 6749 §3.3 requires a default
+ * or a refusal, and the MCP clients measured (Claude's connector, MCP Inspector)
+ * send none with no field to add one. It widens the *offer*, not the grant: the
+ * screen leaves write tools unticked, so approving it untouched still grants only
+ * the read-only set. Narrow it to `tools:read` to offer reads alone.
+ */
+const DEFAULT_SCOPE = 'tools:*'
+
 interface WorkerEnvWithProvider {
   OAUTH_PROVIDER: OAuthHelpers
 }
@@ -181,14 +190,20 @@ export default class McpOAuthController extends Controller {
     return env.OAUTH_PROVIDER
   }
 
-  /** Every MCP-exposed tool the requested scopes expand to, in router order. */
+  /**
+   * Every MCP-exposed tool the requested scopes expand to, in router order; a
+   * request carrying no scope at all is offered {@link DEFAULT_SCOPE}. Only an
+   * *absent* scope defaults — a scope that expands to nothing stays empty, or a
+   * client naming one tool this app does not have would be offered every tool.
+   * Both callers go through here, so `approve()` intersects against the same set.
+   */
   private offeredTools(requested: string[]): DerivedAgentTool[] {
     const { tools } = deriveAgentTools(this.make<Application>('app').router.definitions())
     const exposed = tools.filter((tool) => tool.expose.mcp)
 
     const allowed = new Set(
       expandToolScopes(
-        requested,
+        requested.length > 0 ? requested : [DEFAULT_SCOPE],
         exposed.map((tool) => ({ name: tool.toolName, readOnly: tool.annotations.readOnlyHint })),
       ),
     )

--- a/packages/plugin-cloudflare/tests/mcp-oauth-controller.test.ts
+++ b/packages/plugin-cloudflare/tests/mcp-oauth-controller.test.ts
@@ -84,6 +84,10 @@ const AUTHORIZE_QUERY =
   'client_id=cli_1&redirect_uri=https%3A%2F%2Fclient.test%2Fcb&response_type=code&state=s1'
     + '&scope=tool%3Aposts.index+tool%3Aposts.store'
 
+/** The same request with no `scope` parameter, which is what MCP clients send. */
+const SCOPELESS_QUERY =
+  'client_id=cli_1&redirect_uri=https%3A%2F%2Fclient.test%2Fcb&response_type=code&state=s2'
+
 let app: Application
 let previousTesting: string | undefined
 let previousAppKey: string | undefined
@@ -101,8 +105,8 @@ async function get(query: string, headers: Record<string, string> = {}): Promise
 }
 
 /** The `_token` value and session cookie a real browser would carry back. */
-async function consentSession(): Promise<{ token: string; cookie: string }> {
-  const response = await get(AUTHORIZE_QUERY, asUser(7))
+async function consentSession(query = AUTHORIZE_QUERY): Promise<{ token: string; cookie: string }> {
+  const response = await get(query, asUser(7))
   const html = await response.text()
   const token = /name="_token" value="([^"]+)"/.exec(html)?.[1]
   if (!token) {
@@ -229,6 +233,23 @@ describe('scaffolded McpOAuthController', () => {
       expect(html).toContain('no tools it can be granted')
       expect(html).not.toContain('type="checkbox"')
     })
+
+    /**
+     * The clients measured against a deployed app (Claude's connector, MCP
+     * Inspector) omit `scope` and expose no field to add one, so an offer of
+     * nothing leaves the user no button and the connection unestablishable
+     * (RFC 6749 §3.3). The test above is the other half of the rule: a scope
+     * that *expands* to nothing must stay empty rather than widen to everything.
+     */
+    test('should offer every tool when the request carries no scope at all', async () => {
+      const html = await (await get(SCOPELESS_QUERY, asUser(7))).text()
+
+      expect(html).not.toContain('no tools it can be granted')
+      expect(html).toContain('value="tool:posts.index" checked')
+      // Offered, and still unticked: the default widens the offer, not the grant.
+      expect(html).toContain('value="tool:posts.destroy"')
+      expect(html).not.toContain('value="tool:posts.destroy" checked')
+    })
   })
 
   describe('granting', () => {
@@ -291,6 +312,23 @@ describe('scaffolded McpOAuthController', () => {
       // The provider's own identifier is a string; props keeps the app's type.
       expect(options.userId).toBe('7')
       expect(options.metadata).toHaveProperty('grantedAt')
+    })
+
+    /**
+     * The default has to reach `approve()` too, which is why it lives in
+     * `offeredTools`: defaulting on the GET alone renders checkboxes whose scopes
+     * the intersection then drops, completing the authorization with an empty
+     * grant and no visible failure.
+     */
+    test('should grant a ticked write from a request that carried no scope', async () => {
+      const { token, cookie } = await consentSession(SCOPELESS_QUERY)
+
+      await post(
+        [['_token', token], ['authorize_query', SCOPELESS_QUERY], ['scope', 'tool:posts.store']],
+        { cookie },
+      )
+
+      expect(calls.completeAuthorization[0]?.scope).toEqual(['tool:posts.store'])
     })
 
     test('should grant nothing when nothing was ticked', async () => {


### PR DESCRIPTION
## Problem

The scaffolded `McpOAuthController` offered exactly the scopes the authorize request asked for. A client sending no `scope` therefore reached the consent screen with nothing to approve:

> This application requested no tools it can be granted. Nothing here would give it access, so there is nothing to approve.

There is no button to press, so the MCP connection cannot be established at all. Measured against a deployed app: Claude's connector and MCP Inspector both omit `scope`, and neither exposes a field to type one into. Inspector lets you hand-edit the authorize URL; Claude does not, so there is no client-side workaround.

RFC 6749 §3.3 requires a server receiving no `scope` to either process the request using a predefined default or fail it. The template did neither: it proceeded and offered nothing.

## Fix

Two complementary halves. Metadata lets a client ask; the default makes a client that does not ask still work.

**1. A default scope in the consent controller.** `DEFAULT_SCOPE` (`tools:*`) is substituted when the request carries no scope at all.

- `tools:*` rather than `tools:read`, because the screen already pre-ticks read-only tools and leaves writes unticked. Approving the screen untouched grants the same read-only set either way, but the write tools are visible and one click away instead of absent with no explanation. It widens the *offer*, not the grant.
- The substitution lives in `offeredTools`, which both `show()` and `approve()` call. Defaulting only in `show()` would render checkboxes while `approve()` computed its offered set from an empty request, completing the authorization with `scope: []` and no visible failure.
- Keyed on `requested.length === 0`, never on an empty *expansion*: a client naming one tool this app does not have must still be offered nothing, and the existing `tool:nope` test guards that distinction.
- A named constant with the reason in its comment, so an app author can narrow it to `tools:read`.

**2. `scopesSupported` in the generated provider.** `renderOAuthProvider` now declares `scopesSupported: ['tools:*', 'tools:read']`, which `@cloudflare/workers-oauth-provider` advertises as `scopes_supported` in the authorization server metadata. Set-level scopes only: the build has no route graph, so the `tool:<name>` scopes an app exposes are not known at build time. Read out of the published `oauth-provider.js`, the option is metadata only — the provider never filters a request against it.

## Upgrading an existing app

The metadata half arrives with a rebuild — the worker is regenerated every build. The default does not: the scaffold never overwrites a controller the developer already has (`src/mcp-oauth.test.ts:367`), so an existing `app/Http/Controllers/McpOAuthController.ts` needs the two lines applied by hand. The changeset carries them, since that text is what an upgrading user reads in the CHANGELOG.

## Verification

- `expandToolScopes` grammar re-measured: `[]` → `[]`, `['tools:*']` → every exposed tool, `['tools:read']` → read-only tools only. `offeredTools` filters `expose.mcp` before expanding, so `tools:*` cannot reach a non-MCP tool.
- `AuthRequest.scope` is `string[]`, non-optional, and the provider builds it as `(url.searchParams.get("scope") || "").split(" ").filter(Boolean)` — `[]` for a missing parameter, so `requested.length` is safe.
- Both advertised scopes satisfy the provider's `OAUTH_SCOPE_TOKEN_PATTERN`, which `validateAuthorizationServerScopes` throws on.
- Two new cases in `tests/mcp-oauth-controller.test.ts`, which drives the template as a running application: a scope-less GET offers every tool with writes unticked, and a scope-less POST grants a ticked write. Mutation-checked — reverting the substitution fails both.
- Template substring assertions in `src/mcp-oauth.test.ts` for the constant, the empty-request keying, and the generated `scopesSupported`.

## Gates

`build`, `typecheck`, `lint`, `test:bun` (per package), `test:examples`, `audit:core-first`, `audit:docs`, `audit:agent-catalog`, `audit:plugin-compat`, `audit:core-semver` all green. `packages/cli/tests/make-migration.test.ts` showed two 5s timeout failures under load and passes on its own; it is untouched here.

No docs change: the Cloudflare guide does not describe the consent screen's scope handling.
