### PR TITLE
fix(server): repair five service-wiring defects found in the design review

### DIFF
--- a/.changeset/bearer-user-reaches-gate.md
+++ b/.changeset/bearer-user-reaches-gate.md
@@ -7,7 +7,22 @@ Make the user `createBearerTokenMiddleware({ loadUser })` loads visible to the G
 The middleware stored the loaded user under `guren:user`, a key nothing in
 authorization reads: `Gate.resolveUser` consults the attached auth context
 first and then `ctx.get('user')`, so a policy check on a bearer-authenticated
-request saw no user at all. The middleware now also attaches an auth context
-answering with the loaded user, which is what `Gate`, `requireAuthenticated()`
-and `Controller.auth` read. `ctx.get('guren:user')` keeps working. A
-`loadUser` that returns `null` leaves the request unauthenticated.
+request saw no user at all. Wrapping the attached context instead would only
+have moved the problem, since `AuthServiceProvider` attaches its own context
+during `boot()` and overwrites whatever the middleware left.
+
+The middleware now records the principal it resolved on the request, under
+`RESOLVED_PRINCIPAL_KEY`, and the framework auth context answers `check()`,
+`user()`, `id()` and `logout()` from it before reaching a guard. The user
+therefore reaches `Gate`, `requireAuthenticated()` and `Controller.auth`
+whether the middleware is mounted before or after `boot()`. `logout()` revokes
+the presented token and leaves a co-present session alone, as `TokenGuard`
+does; a successful `login()` or `attempt()` replaces the principal, so the
+request's identity follows the login. `user()` is sanitized through the
+provider `useTokens({ provider })` configured, so a password hash cannot leave
+the auth layer. An identity the invocation pipeline installed still wins
+(RFC 0017 §2). `ctx.get('guren:user')` keeps working.
+
+A `loadUser` that returns `null` leaves the request unauthenticated even beside
+a logged-in session: the token verified, so that request is the token's.
+A request the middleware never ran for is untouched.

--- a/.changeset/bearer-user-reaches-gate.md
+++ b/.changeset/bearer-user-reaches-gate.md
@@ -1,0 +1,13 @@
+---
+"@guren/server": patch
+---
+
+Make the user `createBearerTokenMiddleware({ loadUser })` loads visible to the Gate
+
+The middleware stored the loaded user under `guren:user`, a key nothing in
+authorization reads: `Gate.resolveUser` consults the attached auth context
+first and then `ctx.get('user')`, so a policy check on a bearer-authenticated
+request saw no user at all. The middleware now also attaches an auth context
+answering with the loaded user, which is what `Gate`, `requireAuthenticated()`
+and `Controller.auth` read. `ctx.get('guren:user')` keeps working. A
+`loadUser` that returns `null` leaves the request unauthenticated.

--- a/.changeset/cache-check-takes-cache-store.md
+++ b/.changeset/cache-check-takes-cache-store.md
@@ -1,12 +1,16 @@
 ---
-"@guren/server": patch
+"@guren/server": minor
 ---
 
 Let `CacheCheck` take the framework's own `CacheStore`
 
 The health check expected a store with `put` / `forget`, methods no Guren
-cache store has (`CacheStore` exposes `set` / `delete`), so the built-in
-check could not be handed the built-in store without a cast that then failed
-at runtime. `CacheStoreInterface` is now `Pick<CacheStore, 'get' | 'set' |
-'delete'>`, which `cache.store()` and every shipped store satisfy; a custom
-object passed to the check must expose those three methods.
+cache store has (`CacheStore` exposes `set` / `delete`), so the built-in check
+could not be handed the built-in store without a cast that then failed at
+runtime. `CacheStoreInterface` is now `Pick<CacheStore, 'get' | 'set' |
+'delete'>`, which `cache.store()` and every shipped store satisfy.
+
+This is a source break for an object written against the old shape: a store
+exposing `get` / `put` / `forget` no longer compiles against the constructor,
+and the check reports it unhealthy at runtime, since the methods it calls are
+not there. Rename those members to `set` and `delete`, or pass a `CacheStore`.

--- a/.changeset/cache-check-takes-cache-store.md
+++ b/.changeset/cache-check-takes-cache-store.md
@@ -1,0 +1,12 @@
+---
+"@guren/server": patch
+---
+
+Let `CacheCheck` take the framework's own `CacheStore`
+
+The health check expected a store with `put` / `forget`, methods no Guren
+cache store has (`CacheStore` exposes `set` / `delete`), so the built-in
+check could not be handed the built-in store without a cast that then failed
+at runtime. `CacheStoreInterface` is now `Pick<CacheStore, 'get' | 'set' |
+'delete'>`, which `cache.store()` and every shipped store satisfy; a custom
+object passed to the check must expose those three methods.

--- a/.changeset/encryption-provider-sets-global.md
+++ b/.changeset/encryption-provider-sets-global.md
@@ -1,0 +1,11 @@
+---
+"@guren/server": patch
+---
+
+Register the container's Encrypter as the global one at boot
+
+`EncryptionServiceProvider` bound an `encrypter` singleton but never called
+`setEncrypter()`, so the exported `encrypt()` / `decrypt()` / `getEncrypter()`
+threw "Encrypter not initialized" in every app that registered the provider.
+The provider now sets the global from the bound instance in `boot()`, so the
+functional API and `container.make('encrypter')` share one encrypter.

--- a/.changeset/encryption-provider-sets-global.md
+++ b/.changeset/encryption-provider-sets-global.md
@@ -9,3 +9,6 @@ Register the container's Encrypter as the global one at boot
 threw "Encrypter not initialized" in every app that registered the provider.
 The provider now sets the global from the bound instance in `boot()`, so the
 functional API and `container.make('encrypter')` share one encrypter.
+
+The container's encrypter becomes the global one at boot, replacing an encrypter
+the app set with `setEncrypter()` itself before booting.

--- a/.changeset/log-provider-default-channel.md
+++ b/.changeset/log-provider-default-channel.md
@@ -1,0 +1,10 @@
+---
+"@guren/server": patch
+---
+
+Give `LogServiceProvider` a usable default channel
+
+The provider bound a `LogManager` whose `default` named `console` while
+`channels` declared nothing, so the first `log.info()` or `log.channel()`
+through the container threw `Log channel [console] is not defined`. The
+default is now a declared console channel.

--- a/.changeset/log-provider-default-channel.md
+++ b/.changeset/log-provider-default-channel.md
@@ -8,3 +8,10 @@ The provider bound a `LogManager` whose `default` named `console` while
 `channels` declared nothing, so the first `log.info()` or `log.channel()`
 through the container threw `Log channel [console] is not defined`. The
 default is now a declared console channel.
+
+The provider also publishes the bound manager as the global one in `boot()`, so
+`getLogManager()` works in an app that registers it instead of throwing "Log
+manager has not been initialized". `BroadcastServiceProvider` and
+`NotificationServiceProvider` do the same for `getBroadcastManager()` and
+`getNotificationManager()`, which had the same gap. Each replaces a manager the
+app set itself, as `EncryptionServiceProvider` does.

--- a/.changeset/oauth-dropped-binding-fails-closed.md
+++ b/.changeset/oauth-dropped-binding-fails-closed.md
@@ -1,0 +1,13 @@
+---
+"@guren/server": patch
+---
+
+Reject an OAuth callback whose stored state lost its browser binding
+
+`verifyOAuthState` accepted a state that came back from the store with no
+`binding` even when the caller presented one, so an `OAuthStateStore` that
+drops the field (a `oauth_states` table with no `binding` column) silently
+turned a bound flow back into a transferable one, with only a one-shot
+`console.warn` to say so. A bound flow now fails on a missing binding on
+either side, the same as on a mismatch. The warning stays, so a store author
+sees why the callback was rejected. Flows bound on neither side still verify.

--- a/.changeset/oauth-dropped-binding-fails-closed.md
+++ b/.changeset/oauth-dropped-binding-fails-closed.md
@@ -1,13 +1,28 @@
 ---
-"@guren/server": patch
+"@guren/server": minor
 ---
 
 Reject an OAuth callback whose stored state lost its browser binding
 
-`verifyOAuthState` accepted a state that came back from the store with no
-`binding` even when the caller presented one, so an `OAuthStateStore` that
-drops the field (a `oauth_states` table with no `binding` column) silently
-turned a bound flow back into a transferable one, with only a one-shot
-`console.warn` to say so. A bound flow now fails on a missing binding on
-either side, the same as on a mismatch. The warning stays, so a store author
-sees why the callback was rejected. Flows bound on neither side still verify.
+`verifyOAuthState` read boundness only from the payload the store returned, so
+an `OAuthStateStore` that drops `binding` (an `oauth_states` table with no
+`binding` column) inverted the protection: the honest callback, which presents
+a binding the store cannot match, was rejected, while the session-fixation
+callback was accepted, because a victim's browser presents no binding either
+and a stored `undefined` beside a presented `undefined` read as an unbound
+flow. Only a one-shot `console.warn` marked the difference.
+
+A bound state now carries a marker in the state value itself, minted by
+`createOAuthState` before the state is hashed into the store key. Boundness
+therefore survives a store that keeps nothing, and cannot be edited off a state:
+changing any byte changes the key the store was written under, so the lookup
+misses. A bound flow whose payload comes back without its binding fails, and
+warns per occurrence rather than once per process.
+
+**Before upgrading, give the `oauth_states` table its `binding` column.** A
+store that drops the column now fails every bound callback instead of silently
+downgrading it. States minted before the upgrade keep verifying: they carry no
+marker, and a store that keeps `binding` compares the two sides as before.
+
+Bound flows that pass their own `state` to `authorize()` get it back carrying
+the marker. Send the `state` `authorize()` returns, not the one passed in.

--- a/.changeset/storage-check-takes-storage-driver.md
+++ b/.changeset/storage-check-takes-storage-driver.md
@@ -1,0 +1,20 @@
+---
+"@guren/server": minor
+---
+
+Let `StorageCheck` take the framework's own `StorageDriver`
+
+The check hand-wrote a `StorageDriverInterface` whose `put` returned
+`Promise<void>`, while `StorageDriver.put` resolves the stored path, so
+`new StorageCheck(storage.disk())` did not compile — the built-in check could
+not be handed a built-in disk. `StorageDriverInterface` is now
+`Pick<StorageDriver, 'put' | 'get' | 'delete'>`, which every shipped driver
+satisfies.
+
+This is a source break for an object written against the old shape: a `put`
+returning `Promise<void>` no longer compiles against the constructor. Return
+the path, or pass a `StorageDriver`.
+
+The guide showed a `disk` option the check has never had, and a `.health`
+default `testPath` against the code's `__health_check__.txt`. Both now match
+the code.

--- a/docs/en/guides/api-tokens.md
+++ b/docs/en/guides/api-tokens.md
@@ -136,11 +136,19 @@ router.get('/api/me', (ctx) => {
 })
 ```
 
-The loaded user also becomes the request's auth context, so `this.auth.user()`
-in a controller, `requireAuthenticated()`, and the Gate (policies,
-`this.authorize()`, `authorizeMiddleware()`) all see it. A `loadUser` that
-returns `null` leaves the request unauthenticated rather than falling back to
-a session user.
+The loaded user becomes the request's principal, so `this.auth.user()` in a
+controller, `requireAuthenticated()`, and the Gate (policies,
+`this.authorize()`, `authorizeMiddleware()`) all answer with it. The principal
+is recorded on the request rather than on the auth context, so it is read
+whether the middleware is mounted before or after `boot()`.
+
+`auth.logout()` on such a request revokes the token it presented and leaves a
+co-present session alone. A `loadUser` that returns `null` leaves the request
+unauthenticated: the token verified, so that request belongs to the token, and
+a logged-in session does not stand in for the user it names. A request the
+middleware never ran for keeps its session user. Where `useTokens({ provider })`
+is configured, the loaded user is sanitized through that provider, so password
+hashes and the model's `hidden` fields never leave the auth layer.
 
 ### Custom Error Handlers
 

--- a/docs/en/guides/api-tokens.md
+++ b/docs/en/guides/api-tokens.md
@@ -136,6 +136,12 @@ router.get('/api/me', (ctx) => {
 })
 ```
 
+The loaded user also becomes the request's auth context, so `this.auth.user()`
+in a controller, `requireAuthenticated()`, and the Gate (policies,
+`this.authorize()`, `authorizeMiddleware()`) all see it. A `loadUser` that
+returns `null` leaves the request unauthenticated rather than falling back to
+a session user.
+
 ### Custom Error Handlers
 
 ```ts

--- a/docs/en/guides/health-checks.md
+++ b/docs/en/guides/health-checks.md
@@ -91,17 +91,25 @@ health.register(new CacheCheck(cache.store(), {
 }))
 ```
 
+An object written against the old `get` / `put` / `forget` shape no longer
+compiles against the constructor, and the check reports it unhealthy: the
+methods it calls are not there. `StorageCheck` takes a `StorageDriver` the same
+way, and its `put` must resolve the stored path.
+
 ### Storage Check
 
-Verifies storage driver connectivity:
+Writes, reads back, and deletes one file on a `StorageDriver`. Pass the disk
+itself (`storage.disk()` from the `StorageManager`, or any driver you built),
+not the manager:
 
 ```typescript
 import { StorageCheck } from '@guren/core'
 
-health.register(new StorageCheck(storage, {
-  name: 'storage',        // Custom name (default: 'storage')
-  disk: 'local',          // Disk to check (default: default disk)
-  testPath: '.health',    // Test file path (default: '.health')
+const storage = app.container.make('storage') // StorageManager
+
+health.register(new StorageCheck(storage.disk(), {
+  name: 'storage',                    // Custom name (default: 'storage')
+  testPath: '__health_check__.txt',   // Test file path (default: '__health_check__.txt')
 }))
 ```
 

--- a/docs/en/guides/health-checks.md
+++ b/docs/en/guides/health-checks.md
@@ -77,12 +77,16 @@ Memory check returns status based on heap usage:
 
 ### Cache Check
 
-Verifies cache store connectivity:
+Writes, reads back, and deletes one key on a `CacheStore`. Pass the store
+itself (`cache.store()` from the `CacheManager`, or any store you built), not
+the manager:
 
 ```typescript
 import { CacheCheck } from '@guren/core'
 
-health.register(new CacheCheck(cache, {
+const cache = app.container.make('cache') // CacheManager
+
+health.register(new CacheCheck(cache.store(), {
   name: 'cache',   // Custom name (default: 'cache')
 }))
 ```

--- a/docs/en/guides/oauth.md
+++ b/docs/en/guides/oauth.md
@@ -299,9 +299,10 @@ export const oauthStates = sqliteTable('oauth_states', {
 
 The `binding` column holds the hashed browser binding from
 [Binding State to the Browser](#binding-state-to-the-browser). Without it the
-store cannot persist a binding, and every bound state comes back unbound, which
-silently reverts the protection. Add the column before binding flows via
-`session` or `bindTo`.
+store cannot persist a binding, so every bound state comes back unbound and
+`handleCallback` rejects it with "Invalid or expired OAuth state" (a warning on
+the console names the store as the cause). Add the column before binding flows
+via `session` or `bindTo`.
 
 Expired state rows are removed as they are encountered; call `store.deleteExpired()` from a scheduled job for bulk cleanup. Redis remains available for apps that already run it:
 

--- a/docs/en/guides/oauth.md
+++ b/docs/en/guides/oauth.md
@@ -144,6 +144,11 @@ a native app's secure storage), manage the value yourself with `bindTo`: pass a
 value only this browser can present back to `authorize()`, and hand the same
 value to `handleCallback()`. `bindTo` wins when both options are given.
 
+A bound state carries a short marker, so boundness travels with the state rather
+than only in the store: a store that cannot keep `binding` then rejects the
+callback instead of quietly accepting a transferable state. Send the `state` that
+`authorize()` returns, including when you supplied one of your own.
+
 > [!WARNING]
 > `authorize()` without `session` or `bindTo` still works, so apps written
 > against the earlier API keep running, and it logs a warning once per process.

--- a/docs/ja/guides/api-tokens.md
+++ b/docs/ja/guides/api-tokens.md
@@ -136,7 +136,9 @@ router.get('/api/me', (ctx) => {
 })
 ```
 
-読み込んだユーザーはそのリクエストの auth context にもなります。コントローラの `this.auth.user()`、`requireAuthenticated()`、Gate（Policy、`this.authorize()`、`authorizeMiddleware()`）はすべてこのユーザーを見ます。`loadUser` が `null` を返した場合、リクエストは未認証のままです。セッションのユーザーへは戻りません。
+読み込んだユーザーはそのリクエストの principal になります。コントローラの `this.auth.user()`、`requireAuthenticated()`、Gate（Policy、`this.authorize()`、`authorizeMiddleware()`）はいずれもこのユーザーを参照します。principal は auth context ではなくリクエスト側に記録されるため、ミドルウェアを `boot()` の前にマウントしても後にマウントしても読まれます。
+
+このリクエストで `auth.logout()` を呼ぶと、提示されたトークンを失効させ、同時に存在するセッションはそのまま残します。`loadUser` が `null` を返した場合、そのリクエストは未認証になります。トークンの検証自体は成功しており、そのリクエストはトークンのものなので、ログイン済みセッションが代わりに使われることはありません。ミドルウェアが実行されなかったリクエストは、セッションのユーザーをそのまま保ちます。`useTokens({ provider })` を設定している場合、読み込んだユーザーはその provider で sanitize されるため、パスワードハッシュやモデルの `hidden` フィールドが auth 層の外に出ることはありません。
 
 ### カスタムエラーハンドラー
 

--- a/docs/ja/guides/api-tokens.md
+++ b/docs/ja/guides/api-tokens.md
@@ -136,6 +136,8 @@ router.get('/api/me', (ctx) => {
 })
 ```
 
+読み込んだユーザーはそのリクエストの auth context にもなります。コントローラの `this.auth.user()`、`requireAuthenticated()`、Gate（Policy、`this.authorize()`、`authorizeMiddleware()`）はすべてこのユーザーを見ます。`loadUser` が `null` を返した場合、リクエストは未認証のままです。セッションのユーザーへは戻りません。
+
 ### カスタムエラーハンドラー
 
 ```ts

--- a/docs/ja/guides/health-checks.md
+++ b/docs/ja/guides/health-checks.md
@@ -77,12 +77,14 @@ health.register(new MemoryCheck({
 
 ### キャッシュチェック
 
-キャッシュストアへの接続を確かめます。
+`CacheStore` にキーをひとつ書き込み、読み戻して削除します。渡すのはマネージャではなくストア本体です（`CacheManager` の `cache.store()`、または自作のストア）。
 
 ```typescript
 import { CacheCheck } from '@guren/core'
 
-health.register(new CacheCheck(cache, {
+const cache = app.container.make('cache') // CacheManager
+
+health.register(new CacheCheck(cache.store(), {
   name: 'cache',   // カスタム名（デフォルト: 'cache'）
 }))
 ```

--- a/docs/ja/guides/health-checks.md
+++ b/docs/ja/guides/health-checks.md
@@ -89,17 +89,20 @@ health.register(new CacheCheck(cache.store(), {
 }))
 ```
 
+旧来の `get` / `put` / `forget` を持つオブジェクトはコンストラクタの型に合わなくなり、実行時にはチェックが unhealthy を返します。呼び出すメソッドがそこに無いためです。`StorageCheck` も同様に `StorageDriver` を受け取り、その `put` は保存先のパスを返す必要があります。
+
 ### ストレージチェック
 
-ストレージドライバーへの接続を確かめます。
+`StorageDriver` にファイルをひとつ書き込み、読み戻して削除します。渡すのはマネージャではなくディスク本体です（`StorageManager` の `storage.disk()`、または自作のドライバ）。
 
 ```typescript
 import { StorageCheck } from '@guren/core'
 
-health.register(new StorageCheck(storage, {
-  name: 'storage',        // カスタム名（デフォルト: 'storage'）
-  disk: 'local',          // チェックするディスク（デフォルト: デフォルトディスク）
-  testPath: '.health',    // テストファイルパス（デフォルト: '.health'）
+const storage = app.container.make('storage') // StorageManager
+
+health.register(new StorageCheck(storage.disk(), {
+  name: 'storage',                    // カスタム名（デフォルト: 'storage'）
+  testPath: '__health_check__.txt',   // テストファイルパス（デフォルト: '__health_check__.txt'）
 }))
 ```
 

--- a/docs/ja/guides/oauth.md
+++ b/docs/ja/guides/oauth.md
@@ -283,7 +283,7 @@ export const oauthStates = sqliteTable('oauth_states', {
 })
 ```
 
-`binding` 列は[stateをブラウザに束縛する](#stateをブラウザに束縛する)で使うハッシュを保持します。この列が無いとストアは束縛を保存できません。束縛済みのstateがすべて未束縛で戻ってくるため、保護が黙って無効になります。`session` / `bindTo` を使う前に列を追加してください。
+`binding` 列は[stateをブラウザに束縛する](#stateをブラウザに束縛する)で使うハッシュを保持します。この列が無いとストアは束縛を保存できません。束縛済みのstateがすべて未束縛で戻ってくるため、`handleCallback` は「Invalid or expired OAuth state」として拒否します。原因のストアはコンソールの警告が示します。`session` / `bindTo` を使う前に列を追加してください。
 
 期限切れのstate行は参照時に削除されます。まとめて掃除したい場合は、スケジュールジョブから `store.deleteExpired()` を呼んでください。既にRedisを運用しているアプリなら、Redisも引き続き使えます:
 

--- a/docs/ja/guides/oauth.md
+++ b/docs/ja/guides/oauth.md
@@ -133,6 +133,8 @@ await oauth.handleCallback('github', { code, state, session: this.auth.session()
 
 束縛をセッション以外の場所に置きたい場合（暗号化Cookie、ネイティブアプリのセキュアストレージなど）は、`bindTo` で自分で管理します。そのブラウザだけが提示できる値を `authorize()` に渡し、同じ値を `handleCallback()` にも渡してください。両方指定した場合は `bindTo` が優先されます。
 
+束縛済みのstateには短いマーカーが付きます。束縛されているという事実がストアだけでなくstate自体にも乗るため、`binding` を保存できないストアでは、転送可能なstateを黙って受け入れるのではなくコールバックを拒否します。自分でstateを指定した場合も含めて、`authorize()` が返した `state` をそのまま使ってください。
+
 > [!WARNING]
 > `session` も `bindTo` も渡さない `authorize()` は従来どおり動くので、以前のAPIで書かれたアプリは壊れません。ただしプロセスごとに一度警告を出しますし、束縛を使い始めるまでは上記の攻撃に晒されたままです。`make:auth` と `oauth` ブループリントは束縛版を生成します。
 

--- a/packages/server/src/auth/AuthManager.ts
+++ b/packages/server/src/auth/AuthManager.ts
@@ -98,17 +98,10 @@ export class AuthManager implements AuthManagerContract {
       // the ordinary "has not been registered" error.
       const installed = readAgentPrincipal(context.ctx.req.raw)
       if (installed) {
-        return new AgentPrincipalGuard<User>({
-          installed,
-          // The same provider rule `useTokens({ provider })` configures for
-          // the token guard: with one, the principal's id resolves to the real
-          // user record; without one, a minimal `{ id }`. Two rules here would
-          // mean a policy reading a user field behaved differently depending
-          // on which surface the call arrived on.
-          ...(this.apiTokenOptions.provider
-            ? { provider: this.getProvider<User>(this.apiTokenOptions.provider) }
-            : {}),
-        })
+        const provider = this.tokenUserProvider<User>()
+        // With a provider the principal's id resolves to the real user record;
+        // without one, a minimal `{ id }`.
+        return new AgentPrincipalGuard<User>({ installed, ...(provider ? { provider } : {}) })
       }
     }
 
@@ -176,6 +169,17 @@ export class AuthManager implements AuthManagerContract {
   }
 
   /**
+   * The user provider `useTokens({ provider })` configured, and no other.
+   * Every surface that turns a token's or a principal's id into a user record
+   * reads this one: a second rule would mean a policy reading a user field
+   * behaved differently depending on which surface the call arrived on.
+   */
+  private tokenUserProvider<User>(): UserProvider<User> | undefined {
+    const name = this.apiTokenOptions.provider
+    return name ? this.getProvider<User>(name) : undefined
+  }
+
+  /**
    * The principal a middleware resolved for this request, sanitized the way the
    * token guard sanitizes its own. Read at call time, so a context built before
    * the authenticating middleware ran still answers with it.
@@ -188,13 +192,9 @@ export class AuthManager implements AuthManagerContract {
     const principal = getResolvedPrincipal(ctx)
     if (!principal || principal.user == null) return principal
 
-    // The provider `useTokens({ provider })` configured, and no other: a second
-    // rule here would sanitize a user differently depending on which surface
-    // the call arrived on.
-    const providerName = this.apiTokenOptions.provider
-    if (!providerName) return principal
+    const provider = this.tokenUserProvider<unknown>()
+    if (!provider) return principal
 
-    const provider = this.getProvider<unknown>(providerName)
     return { ...principal, user: sanitizeUser(provider, principal.user) }
   }
 

--- a/packages/server/src/auth/AuthManager.ts
+++ b/packages/server/src/auth/AuthManager.ts
@@ -4,7 +4,9 @@ import { getSessionFromContext } from '../http/middleware/session'
 import { readAgentPrincipal } from '../internal/agent-principal'
 import { AgentPrincipalGuard } from './AgentPrincipalGuard'
 import { RequestAuthContext } from './RequestAuthContext'
+import { getResolvedPrincipal, type ResolvedPrincipal } from './context'
 import { ModelUserProvider, type ModelUserProviderOptions } from './providers/ModelUserProvider'
+import { sanitizeUser } from './providers/UserProvider'
 import { SessionGuard } from './SessionGuard'
 import { TokenGuard } from './TokenGuard'
 import { hasBearerHeader, type ApiTokenStore } from './api-token'
@@ -168,7 +170,32 @@ export class AuthManager implements AuthManagerContract {
       })
     }
 
-    return new RequestAuthContext(resolveName, ctx, resolveSession, guardFactory)
+    return new RequestAuthContext(resolveName, ctx, resolveSession, guardFactory, () =>
+      this.resolvePrincipal(ctx),
+    )
+  }
+
+  /**
+   * The principal a middleware resolved for this request, sanitized the way the
+   * token guard sanitizes its own. Read at call time, so a context built before
+   * the authenticating middleware ran still answers with it.
+   */
+  private resolvePrincipal(ctx: Context): ResolvedPrincipal | undefined {
+    // An identity the pipeline installed outranks one a header produced
+    // (RFC 0017 §2), so the principal guard answers this request instead.
+    if (readAgentPrincipal(ctx.req.raw)) return undefined
+
+    const principal = getResolvedPrincipal(ctx)
+    if (!principal || principal.user == null) return principal
+
+    // The provider `useTokens({ provider })` configured, and no other: a second
+    // rule here would sanitize a user differently depending on which surface
+    // the call arrived on.
+    const providerName = this.apiTokenOptions.provider
+    if (!providerName) return principal
+
+    const provider = this.getProvider<unknown>(providerName)
+    return { ...principal, user: sanitizeUser(provider, principal.user) }
   }
 
   async attempt(name: string, ctx: Context, credentials: AuthCredentials, remember?: boolean): Promise<boolean> {

--- a/packages/server/src/auth/RequestAuthContext.ts
+++ b/packages/server/src/auth/RequestAuthContext.ts
@@ -96,7 +96,6 @@ export class RequestAuthContext implements AuthContext {
    * new session rather than revoking the credential the request arrived with.
    */
   private forgetPrincipal(): void {
-    if (!this.resolvePrincipal()) return
     setResolvedPrincipal(this.ctx, undefined)
   }
 }

--- a/packages/server/src/auth/RequestAuthContext.ts
+++ b/packages/server/src/auth/RequestAuthContext.ts
@@ -1,9 +1,12 @@
 import type { Context } from 'hono'
 import type { Session } from '../http/middleware'
 import type { AuthContext, AuthCredentials, Guard } from './types'
+import { setResolvedPrincipal, type ResolvedPrincipal } from './context'
 import { AuthenticationException } from '../errors/exceptions/AuthenticationException'
 
 export type GuardResolver = (resolvedName: string) => Guard<unknown>
+
+export type PrincipalResolver = () => ResolvedPrincipal | undefined
 
 export class RequestAuthContext implements AuthContext {
   private readonly guardCache = new Map<string, Guard<unknown>>()
@@ -13,6 +16,7 @@ export class RequestAuthContext implements AuthContext {
     private readonly ctx: Context,
     private readonly resolveSession: () => Session | undefined,
     private readonly resolveGuard: GuardResolver,
+    private readonly resolvePrincipal: PrincipalResolver = () => undefined,
   ) {}
 
   guard<T = unknown>(name?: string): Guard<T> {
@@ -34,14 +38,20 @@ export class RequestAuthContext implements AuthContext {
   }
 
   async check(): Promise<boolean> {
+    const principal = this.resolvePrincipal()
+    if (principal) return principal.user != null
     return this.guard().check()
   }
 
   async guest(): Promise<boolean> {
+    const principal = this.resolvePrincipal()
+    if (principal) return principal.user == null
     return this.guard().guest()
   }
 
   async user<T = unknown>(): Promise<T | null> {
+    const principal = this.resolvePrincipal()
+    if (principal) return (principal.user ?? null) as T | null
     return this.guard<T>().user()
   }
 
@@ -52,18 +62,41 @@ export class RequestAuthContext implements AuthContext {
   }
 
   async id(): Promise<unknown> {
+    const principal = this.resolvePrincipal()
+    if (principal) return principal.user == null ? null : principal.id
     return this.guard().id()
   }
 
   async login<T = unknown>(user: T, remember?: boolean): Promise<void> {
     await this.guard<T>().login(user, remember)
+    this.forgetPrincipal()
   }
 
   async attempt(credentials: AuthCredentials, remember?: boolean): Promise<boolean> {
-    return this.guard().attempt(credentials, remember)
+    const succeeded = await this.guard().attempt(credentials, remember)
+    if (succeeded) this.forgetPrincipal()
+    return succeeded
   }
 
   async logout(): Promise<void> {
+    const principal = this.resolvePrincipal()
+    if (principal) {
+      // Revoking only the presented credential, and leaving a co-present
+      // session alone, is `TokenGuard.logout`'s rule.
+      await principal.revoke?.()
+      this.forgetPrincipal()
+      return
+    }
     await this.guard().logout()
+  }
+
+  /**
+   * The request's identity is whatever just logged in, so a principal a
+   * middleware resolved stops answering. A later `logout()` therefore ends the
+   * new session rather than revoking the credential the request arrived with.
+   */
+  private forgetPrincipal(): void {
+    if (!this.resolvePrincipal()) return
+    setResolvedPrincipal(this.ctx, undefined)
   }
 }

--- a/packages/server/src/auth/TokenGuard.ts
+++ b/packages/server/src/auth/TokenGuard.ts
@@ -5,7 +5,7 @@ import {
   API_TOKEN_KEY,
   parseApiToken,
   readBearerToken,
-  revokeApiToken,
+  revokePresentedToken,
   verifyApiToken,
   type ApiTokenStore,
   type VerifiedApiToken,
@@ -118,14 +118,9 @@ export class TokenGuard<User = unknown> implements Guard<User> {
   /** Revokes the presented token. Subsequent requests with it fail verification. */
   async logout(): Promise<void> {
     const result = await this.verify()
-    if (result) {
-      await revokeApiToken(result.token.id, this.store)
-    }
+    await revokePresentedToken(this.ctx, result?.token.id, this.store)
     this.verification = Promise.resolve(null)
     this.resolvedUser = Promise.resolve(null)
-    // So getApiToken()/getApiTokenOrFail() cannot succeed after logout on the
-    // same request.
-    this.ctx.set(API_TOKEN_KEY, undefined)
   }
 
   session<T extends Session = Session>(): T | undefined {

--- a/packages/server/src/auth/api-token.ts
+++ b/packages/server/src/auth/api-token.ts
@@ -330,6 +330,20 @@ export async function getUserApiTokens(
 export const API_TOKEN_KEY = 'guren:api-token'
 
 /**
+ * Revoke the token a request presented, and clear it from the request context
+ * so `getApiToken()` / `getApiTokenOrFail()` cannot succeed after a logout on
+ * the same request. The slot is cleared whether or not a token still verified.
+ */
+export async function revokePresentedToken(
+  ctx: Context,
+  tokenId: string | undefined,
+  store: ApiTokenStore,
+): Promise<void> {
+  if (tokenId) await revokeApiToken(tokenId, store)
+  ctx.set(API_TOKEN_KEY, undefined)
+}
+
+/**
  * Options for the bearer token middleware.
  */
 export interface BearerTokenMiddlewareOptions {
@@ -413,13 +427,7 @@ export function createBearerTokenMiddleware(
       setResolvedPrincipal(ctx, {
         user,
         id: result.userId,
-        source: 'bearer',
-        revoke: async () => {
-          await revokeApiToken(result.token.id, store)
-          // So getApiToken()/getApiTokenOrFail() cannot succeed after logout
-          // on the same request, as with TokenGuard.
-          ctx.set(API_TOKEN_KEY, undefined)
-        },
+        revoke: () => revokePresentedToken(ctx, result.token.id, store),
       })
 
       if (!getAuthContext(ctx)) {

--- a/packages/server/src/auth/api-token.ts
+++ b/packages/server/src/auth/api-token.ts
@@ -1,5 +1,7 @@
 import type { MiddlewareHandler, Context } from 'hono'
 import { hashToken, generateToken, generateId, secureCompare } from './utils'
+import { AUTH_CONTEXT_KEY, getAuthContext } from './context'
+import type { AuthContext } from './types'
 import { isOptionalExpiryPast } from '../support/expiry'
 import { AuthenticationException } from '../errors/exceptions/AuthenticationException'
 
@@ -399,9 +401,42 @@ export function createBearerTokenMiddleware(
     if (loadUser) {
       const user = await loadUser(result.userId)
       ctx.set('guren:user', user)
+      ctx.set(AUTH_CONTEXT_KEY, withBearerUser(getAuthContext(ctx), user, result.userId))
     }
 
     return next()
+  }
+}
+
+/**
+ * The auth context a bearer request carries once `loadUser` resolved. Its
+ * answer under `AUTH_CONTEXT_KEY` is what `Gate.resolveUser` reads, and that
+ * answer is final: a user stored under any other key is invisible to
+ * authorization. Identity comes from the loaded user; session and guard
+ * lookups go to the context the app attached, when there is one.
+ */
+function withBearerUser(base: AuthContext | undefined, user: unknown, userId: string | number): AuthContext {
+  const attached = base && typeof base.user === 'function' ? base : undefined
+  const unsupported = (method: string) => async (): Promise<never> => {
+    throw new Error(`${method}() is not available on a bearer-token request with no auth context attached.`)
+  }
+
+  return {
+    check: async () => user != null,
+    guest: async () => user == null,
+    user: async <T>() => (user ?? null) as T | null,
+    userOrFail: async <T>() => {
+      if (user == null) throw new AuthenticationException()
+      return user as T
+    },
+    id: async () => (user == null ? null : userId),
+    login: attached ? attached.login.bind(attached) : unsupported('login'),
+    attempt: attached ? attached.attempt.bind(attached) : unsupported('attempt'),
+    logout: attached ? attached.logout.bind(attached) : async () => {},
+    guard: attached ? attached.guard.bind(attached) : () => {
+      throw new Error('guard() is not available on a bearer-token request with no auth context attached.')
+    },
+    session: attached ? attached.session.bind(attached) : () => undefined,
   }
 }
 

--- a/packages/server/src/auth/api-token.ts
+++ b/packages/server/src/auth/api-token.ts
@@ -1,7 +1,11 @@
 import type { MiddlewareHandler, Context } from 'hono'
 import { hashToken, generateToken, generateId, secureCompare } from './utils'
-import { AUTH_CONTEXT_KEY, getAuthContext } from './context'
-import type { AuthContext } from './types'
+import {
+  AUTH_CONTEXT_KEY,
+  createPrincipalAuthContext,
+  getAuthContext,
+  setResolvedPrincipal,
+} from './context'
 import { isOptionalExpiryPast } from '../support/expiry'
 import { AuthenticationException } from '../errors/exceptions/AuthenticationException'
 
@@ -401,42 +405,29 @@ export function createBearerTokenMiddleware(
     if (loadUser) {
       const user = await loadUser(result.userId)
       ctx.set('guren:user', user)
-      ctx.set(AUTH_CONTEXT_KEY, withBearerUser(getAuthContext(ctx), user, result.userId))
+      // The framework auth context reads this slot before it reaches a guard,
+      // so the loaded user reaches the Gate whether this middleware runs
+      // before or after the one that attaches the context. A verified token
+      // whose user does not load stores `null`, which makes the request
+      // unauthenticated rather than falling back to a session user.
+      setResolvedPrincipal(ctx, {
+        user,
+        id: result.userId,
+        source: 'bearer',
+        revoke: async () => {
+          await revokeApiToken(result.token.id, store)
+          // So getApiToken()/getApiTokenOrFail() cannot succeed after logout
+          // on the same request, as with TokenGuard.
+          ctx.set(API_TOKEN_KEY, undefined)
+        },
+      })
+
+      if (!getAuthContext(ctx)) {
+        ctx.set(AUTH_CONTEXT_KEY, createPrincipalAuthContext(ctx))
+      }
     }
 
     return next()
-  }
-}
-
-/**
- * The auth context a bearer request carries once `loadUser` resolved. Its
- * answer under `AUTH_CONTEXT_KEY` is what `Gate.resolveUser` reads, and that
- * answer is final: a user stored under any other key is invisible to
- * authorization. Identity comes from the loaded user; session and guard
- * lookups go to the context the app attached, when there is one.
- */
-function withBearerUser(base: AuthContext | undefined, user: unknown, userId: string | number): AuthContext {
-  const attached = base && typeof base.user === 'function' ? base : undefined
-  const unsupported = (method: string) => async (): Promise<never> => {
-    throw new Error(`${method}() is not available on a bearer-token request with no auth context attached.`)
-  }
-
-  return {
-    check: async () => user != null,
-    guest: async () => user == null,
-    user: async <T>() => (user ?? null) as T | null,
-    userOrFail: async <T>() => {
-      if (user == null) throw new AuthenticationException()
-      return user as T
-    },
-    id: async () => (user == null ? null : userId),
-    login: attached ? attached.login.bind(attached) : unsupported('login'),
-    attempt: attached ? attached.attempt.bind(attached) : unsupported('attempt'),
-    logout: attached ? attached.logout.bind(attached) : async () => {},
-    guard: attached ? attached.guard.bind(attached) : () => {
-      throw new Error('guard() is not available on a bearer-token request with no auth context attached.')
-    },
-    session: attached ? attached.session.bind(attached) : () => undefined,
   }
 }
 

--- a/packages/server/src/auth/context.ts
+++ b/packages/server/src/auth/context.ts
@@ -29,7 +29,6 @@ export const RESOLVED_PRINCIPAL_KEY = 'guren:resolved-principal'
 export interface ResolvedPrincipal {
   user: unknown
   id: unknown
-  source: string
   /** Invalidate the presented credential. `logout()` calls it. */
   revoke?: () => Promise<void>
 }
@@ -64,15 +63,16 @@ export function createPrincipalAuthContext(ctx: Context): AuthContext {
     throw new Error(`${method}() is not available on a request with no auth context attached.`)
   }
   const principal = () => getResolvedPrincipal(ctx)
+  const user = async <T>(): Promise<T | null> => (principal()?.user ?? null) as T | null
 
   return {
     check: async () => principal()?.user != null,
     guest: async () => principal()?.user == null,
-    user: async <T>() => (principal()?.user ?? null) as T | null,
+    user,
     userOrFail: async <T>() => {
-      const user = principal()?.user
-      if (user == null) throw new AuthenticationException()
-      return user as T
+      const resolved = await user<T>()
+      if (resolved == null) throw new AuthenticationException()
+      return resolved
     },
     id: async () => {
       const resolved = principal()

--- a/packages/server/src/auth/context.ts
+++ b/packages/server/src/auth/context.ts
@@ -1,4 +1,6 @@
+import type { Context } from 'hono'
 import type { AuthContext } from './types'
+import { AuthenticationException } from '../errors/exceptions/AuthenticationException'
 
 /**
  * Context key the framework auth context is stored under.
@@ -10,6 +12,29 @@ import type { AuthContext } from './types'
 export const AUTH_CONTEXT_KEY = 'guren:auth'
 
 /**
+ * Context key the principal a middleware already resolved is stored under.
+ *
+ * The framework auth context answers from this slot before it reaches a guard,
+ * so a middleware that authenticates a request (the bearer-token middleware,
+ * or an app's own) reaches the Gate whatever order it is mounted in.
+ */
+export const RESOLVED_PRINCIPAL_KEY = 'guren:resolved-principal'
+
+/**
+ * An identity a middleware established for this one request.
+ *
+ * `user` is null when the credential verified but its user cannot be loaded:
+ * the request is then unauthenticated, not merely unresolved.
+ */
+export interface ResolvedPrincipal {
+  user: unknown
+  id: unknown
+  source: string
+  /** Invalidate the presented credential. `logout()` calls it. */
+  revoke?: () => Promise<void>
+}
+
+/**
  * Read the framework auth context off a request context. `ctx.get` returns
  * arbitrary values for unknown keys, so the cast is a claim, not a check. A
  * caller whose behavior turns on a real auth context probes the member it is
@@ -18,4 +43,48 @@ export const AUTH_CONTEXT_KEY = 'guren:auth'
  */
 export function getAuthContext(ctx: { get: (key: string) => unknown }): AuthContext | undefined {
   return ctx.get(AUTH_CONTEXT_KEY) as AuthContext | undefined
+}
+
+export function getResolvedPrincipal(ctx: { get: (key: string) => unknown }): ResolvedPrincipal | undefined {
+  return ctx.get(RESOLVED_PRINCIPAL_KEY) as ResolvedPrincipal | undefined
+}
+
+export function setResolvedPrincipal(ctx: Context, principal: ResolvedPrincipal | undefined): void {
+  ctx.set(RESOLVED_PRINCIPAL_KEY, principal)
+}
+
+/**
+ * The auth context a request carries when a middleware resolved a principal and
+ * nothing attached a framework context — a bearer-authenticated route on a
+ * plain Hono app. Credential flows throw rather than pretending to succeed;
+ * `logout()` revokes the presented credential.
+ */
+export function createPrincipalAuthContext(ctx: Context): AuthContext {
+  const unsupported = (method: string): never => {
+    throw new Error(`${method}() is not available on a request with no auth context attached.`)
+  }
+  const principal = () => getResolvedPrincipal(ctx)
+
+  return {
+    check: async () => principal()?.user != null,
+    guest: async () => principal()?.user == null,
+    user: async <T>() => (principal()?.user ?? null) as T | null,
+    userOrFail: async <T>() => {
+      const user = principal()?.user
+      if (user == null) throw new AuthenticationException()
+      return user as T
+    },
+    id: async () => {
+      const resolved = principal()
+      return resolved?.user == null ? null : resolved.id
+    },
+    login: async () => unsupported('login'),
+    attempt: async () => unsupported('attempt'),
+    logout: async () => {
+      await principal()?.revoke?.()
+      setResolvedPrincipal(ctx, undefined)
+    },
+    guard: () => unsupported('guard'),
+    session: () => undefined,
+  }
 }

--- a/packages/server/src/auth/oauth/index.ts
+++ b/packages/server/src/auth/oauth/index.ts
@@ -196,18 +196,19 @@ let warnedAboutDroppedBinding = false
 
 /**
  * The flow was bound at authorize time but the state came back without one,
- * so the configured `OAuthStateStore` is not persisting `binding` — which
- * silently reverts the protection to the transferable state it replaced.
+ * so the configured `OAuthStateStore` is not persisting `binding`. The
+ * callback is rejected; this names the cause, since "Invalid or expired OAuth
+ * state" alone reads as a user problem.
  */
 function warnOnceAboutDroppedBinding(): void {
   if (warnedAboutDroppedBinding) return
   warnedAboutDroppedBinding = true
   console.warn(
     '[guren] An OAuth state was created with `bindTo` but came back from the state store '
-    + 'without its binding, so the callback could not be tied to the browser that started the '
-    + 'flow. The configured OAuthStateStore is dropping `OAuthStatePayload.binding` — for '
-    + 'DatabaseOAuthStateStore this usually means the `oauth_states` table has no `binding` '
-    + 'column. See: https://guren.dev/docs/guides/oauth',
+    + 'without its binding, so the callback was rejected: it cannot be tied to the browser '
+    + 'that started the flow. The configured OAuthStateStore is dropping '
+    + '`OAuthStatePayload.binding` — for DatabaseOAuthStateStore this usually means the '
+    + '`oauth_states` table has no `binding` column. See: https://guren.dev/docs/guides/oauth',
   )
 }
 
@@ -499,9 +500,9 @@ export async function verifyOAuthState(
 
 /**
  * Whether the presented value matches the binding recorded at authorize time.
- * A state created without a binding still verifies, so an app that has not
- * adopted `bindTo` keeps working; a state created *with* one is useless to a
- * browser that cannot present it, so a missing or wrong value fails.
+ * A flow bound on neither side verifies, so an app that has not adopted
+ * `bindTo` keeps working. A bound flow fails on a missing value on either side:
+ * a browser that cannot present the binding, or a store that did not keep it.
  */
 function bindingMatches(
   stored: string | undefined,
@@ -509,13 +510,13 @@ function bindingMatches(
   hashAlgorithm: 'sha256' | 'sha512',
 ): boolean {
   if (!stored) {
-    // The caller bound this flow, so a payload coming back without one means
-    // the store dropped the field rather than that the state was never bound.
-    // Verification cannot tell the two apart, so it stays permissive — but a
-    // store that silently discards the binding turns the protection off, and
-    // nothing else would say so.
-    if (presented) warnOnceAboutDroppedBinding()
-    return true
+    if (!presented) return true
+    // The caller bound this flow, so a payload coming back unbound means the
+    // store dropped the field. Accepting it would hand the protection back to
+    // the transferable state it replaced, so the callback fails; the warning
+    // is what tells the store author why.
+    warnOnceAboutDroppedBinding()
+    return false
   }
   if (!presented) return false
   // Both sides are hex digests, so this takes the hex-decoding comparator —

--- a/packages/server/src/auth/oauth/index.ts
+++ b/packages/server/src/auth/oauth/index.ts
@@ -132,6 +132,11 @@ const MAX_PENDING_SESSION_BINDINGS = 5
 export interface OAuthAuthorizeOptions {
   scope?: string[]
   redirectTo?: string
+  /**
+   * Use this value rather than a minted one. A bound flow returns it carrying
+   * the boundness marker, so send the `state` `authorize()` returns, not the
+   * one passed in.
+   */
   state?: string
   extraParams?: Record<string, string>
   /**
@@ -192,23 +197,21 @@ function warnOnceAboutUnboundState(): void {
   )
 }
 
-let warnedAboutDroppedBinding = false
-
 /**
  * The flow was bound at authorize time but the state came back without one,
  * so the configured `OAuthStateStore` is not persisting `binding`. The
  * callback is rejected; this names the cause, since "Invalid or expired OAuth
- * state" alone reads as a user problem.
+ * state" alone reads as a user problem. Printed per occurrence: each rejected
+ * login is one a store author has to be able to trace, and reaching this
+ * branch costs a caller a state the store has already consumed.
  */
-function warnOnceAboutDroppedBinding(): void {
-  if (warnedAboutDroppedBinding) return
-  warnedAboutDroppedBinding = true
+function warnAboutDroppedBinding(): void {
   console.warn(
-    '[guren] An OAuth state was created with `bindTo` but came back from the state store '
-    + 'without its binding, so the callback was rejected: it cannot be tied to the browser '
-    + 'that started the flow. The configured OAuthStateStore is dropping '
-    + '`OAuthStatePayload.binding` — for DatabaseOAuthStateStore this usually means the '
-    + '`oauth_states` table has no `binding` column. See: https://guren.dev/docs/guides/oauth',
+    '[guren] A bound OAuth state came back from the state store without its binding, so the '
+    + 'callback was rejected: it cannot be tied to the browser that started the flow. The '
+    + 'configured OAuthStateStore is dropping `OAuthStatePayload.binding` — for '
+    + 'DatabaseOAuthStateStore this usually means the `oauth_states` table has no `binding` '
+    + 'column. See: https://guren.dev/docs/guides/oauth',
   )
 }
 
@@ -282,6 +285,15 @@ function consumeSessionBinding(
   session.set(OAUTH_SESSION_BINDING_KEY, pending.filter((entry) => entry.stateHash !== stateHash))
   return match?.binding
 }
+
+/**
+ * Prefix a bound state carries. `verifyOAuthState` reads boundness off the
+ * state itself, so a store that drops `binding` cannot turn a bound flow back
+ * into a transferable one. The store key is the hash of the whole state, so
+ * adding or stripping the prefix changes the key and the lookup misses: the
+ * marker needs no signature of its own.
+ */
+const BOUND_STATE_PREFIX = 'gb1~'
 
 const DEFAULT_STATE_EXPIRES_IN = 10 * 60 * 1000
 const DEFAULT_STATE_LENGTH = 24
@@ -463,7 +475,9 @@ export async function createOAuthState(
   fixedState?: string,
   bindTo?: string,
 ): Promise<{ state: string; expiresAt: Date }> {
-  const state = fixedState ?? generateToken(config.stateLength ?? DEFAULT_STATE_LENGTH)
+  const minted = fixedState ?? generateToken(config.stateLength ?? DEFAULT_STATE_LENGTH)
+  // Marked before hashing, so the mark is part of what the store is keyed on.
+  const state = bindTo ? `${BOUND_STATE_PREFIX}${minted}` : minted
   const hashAlgorithm = config.hashAlgorithm ?? DEFAULT_STATE_HASH_ALGORITHM
   const expiresAt = new Date(Date.now() + (config.expiresIn ?? DEFAULT_STATE_EXPIRES_IN))
   const stateHash = hashToken(state, hashAlgorithm)
@@ -492,7 +506,9 @@ export async function verifyOAuthState(
     : await findAndDeleteState(store, stateHash)
   if (!payload) return null
   if (payload.provider !== provider) return null
-  if (!bindingMatches(payload.binding, bindTo, hashAlgorithm)) return null
+  if (!bindingMatches(payload.binding, bindTo, hashAlgorithm, state.startsWith(BOUND_STATE_PREFIX))) {
+    return null
+  }
   // Re-sanitize on the way out so custom stores and states persisted before
   // an allowlist change cannot smuggle an unsafe target through.
   return { ...payload, redirectTo: sanitizeOAuthRedirect(payload.redirectTo, config.allowedRedirectHosts) }
@@ -508,14 +524,16 @@ function bindingMatches(
   stored: string | undefined,
   presented: string | undefined,
   hashAlgorithm: 'sha256' | 'sha512',
+  stateWasBound: boolean,
 ): boolean {
   if (!stored) {
-    if (!presented) return true
-    // The caller bound this flow, so a payload coming back unbound means the
-    // store dropped the field. Accepting it would hand the protection back to
-    // the transferable state it replaced, so the callback fails; the warning
-    // is what tells the store author why.
-    warnOnceAboutDroppedBinding()
+    if (!stateWasBound && !presented) return true
+    // The flow was bound but the payload came back unbound, so the store
+    // dropped the field. Accepting it would hand the protection back to the
+    // transferable state it replaced — and a victim's browser presents nothing
+    // either, so trusting the store alone accepts exactly the fixation the
+    // binding exists to stop. The callback fails; the warning says why.
+    warnAboutDroppedBinding()
     return false
   }
   if (!presented) return false

--- a/packages/server/src/auth/oauth/index.ts
+++ b/packages/server/src/auth/oauth/index.ts
@@ -198,12 +198,11 @@ function warnOnceAboutUnboundState(): void {
 }
 
 /**
- * The flow was bound at authorize time but the state came back without one,
- * so the configured `OAuthStateStore` is not persisting `binding`. The
- * callback is rejected; this names the cause, since "Invalid or expired OAuth
- * state" alone reads as a user problem. Printed per occurrence: each rejected
- * login is one a store author has to be able to trace, and reaching this
- * branch costs a caller a state the store has already consumed.
+ * The state came back without the binding the flow was created with, so the
+ * configured `OAuthStateStore` is not persisting `binding`. This names the
+ * cause, since "Invalid or expired OAuth state" reads as a user problem.
+ * Printed per rejected login, each of which a store author has to trace;
+ * reaching the branch costs a caller a state the store already consumed.
  */
 function warnAboutDroppedBinding(): void {
   console.warn(

--- a/packages/server/src/health/checks/CacheCheck.ts
+++ b/packages/server/src/health/checks/CacheCheck.ts
@@ -1,11 +1,9 @@
 import type { CheckResult } from '../types'
+import type { CacheStore } from '../../cache/types'
 import { HealthCheck } from '../HealthCheck'
 
-export interface CacheStoreInterface {
-  get<T>(key: string): Promise<T | null>
-  put<T>(key: string, value: T, ttl?: number): Promise<void>
-  forget(key: string): Promise<boolean>
-}
+/** The slice of `CacheStore` the check exercises; `cache.store()` satisfies it. */
+export type CacheStoreInterface = Pick<CacheStore, 'get' | 'set' | 'delete'>
 
 export interface CacheCheckOptions {
   /** @default 'cache' */
@@ -32,11 +30,11 @@ export class CacheCheck extends HealthCheck {
     const testValue = `health_check_${Date.now()}`
 
     try {
-      await this.cache.put(this.testKey, testValue, 60)
+      await this.cache.set(this.testKey, testValue, 60)
 
       const retrieved = await this.cache.get<string>(this.testKey)
 
-      await this.cache.forget(this.testKey)
+      await this.cache.delete(this.testKey)
 
       if (retrieved === testValue) {
         return this.healthy('Cache is functioning correctly')

--- a/packages/server/src/health/checks/StorageCheck.ts
+++ b/packages/server/src/health/checks/StorageCheck.ts
@@ -1,11 +1,9 @@
 import type { CheckResult } from '../types'
+import type { StorageDriver } from '../../storage/types'
 import { HealthCheck } from '../HealthCheck'
 
-export interface StorageDriverInterface {
-  put(path: string, contents: string | Buffer): Promise<void>
-  get(path: string): Promise<Buffer | null>
-  delete(path: string): Promise<boolean>
-}
+/** The slice of `StorageDriver` the check exercises; `storage.disk()` satisfies it. */
+export type StorageDriverInterface = Pick<StorageDriver, 'put' | 'get' | 'delete'>
 
 export interface StorageCheckOptions {
   /** @default 'storage' */

--- a/packages/server/src/providers/BroadcastServiceProvider.ts
+++ b/packages/server/src/providers/BroadcastServiceProvider.ts
@@ -1,9 +1,16 @@
 import { ServiceProvider } from '../container/ServiceProvider'
-import { createBroadcastManager } from '../broadcasting'
+import { createBroadcastManager, setBroadcastManager, type BroadcastManager } from '../broadcasting'
 
-/** Binds the BroadcastManager as a singleton in the container. */
+/**
+ * Binds the BroadcastManager as a singleton in the container and, at boot,
+ * makes it the global one behind `getBroadcastManager()`.
+ */
 export class BroadcastServiceProvider extends ServiceProvider {
   register(): void {
     this.container.singleton('broadcast', () => createBroadcastManager())
+  }
+
+  boot(): void {
+    setBroadcastManager(this.container.make<BroadcastManager>('broadcast'))
   }
 }

--- a/packages/server/src/providers/BroadcastServiceProvider.ts
+++ b/packages/server/src/providers/BroadcastServiceProvider.ts
@@ -1,10 +1,7 @@
 import { ServiceProvider } from '../container/ServiceProvider'
 import { createBroadcastManager, setBroadcastManager, type BroadcastManager } from '../broadcasting'
 
-/**
- * Binds the BroadcastManager as a singleton in the container and, at boot,
- * makes it the global one behind `getBroadcastManager()`.
- */
+/** Binds the BroadcastManager as a singleton in the container. */
 export class BroadcastServiceProvider extends ServiceProvider {
   register(): void {
     this.container.singleton('broadcast', () => createBroadcastManager())

--- a/packages/server/src/providers/EncryptionServiceProvider.ts
+++ b/packages/server/src/providers/EncryptionServiceProvider.ts
@@ -1,8 +1,13 @@
 import { ServiceProvider } from '../container/ServiceProvider'
-import { createEncrypter } from '../encryption'
+import { createEncrypter, setEncrypter, type Encrypter } from '../encryption'
 import { deriveAppKeyring, encodeDerivedKey, getAppKeyringFromEnv } from '../encryption/app-key'
 
-/** Binds the Encrypter as a singleton in the container. */
+/**
+ * Binds the Encrypter as a singleton in the container and, at boot, makes it
+ * the global one behind `encrypt()` / `decrypt()` / `getEncrypter()`. The
+ * global is set in `boot()` rather than `register()` so a provider registering
+ * later can still replace `app.keyring` before the encrypter is built.
+ */
 export class EncryptionServiceProvider extends ServiceProvider {
   register(): void {
     if (!this.container.has('app.keyring')) {
@@ -16,5 +21,9 @@ export class EncryptionServiceProvider extends ServiceProvider {
         previousKeys: keyring.previous.map((key) => encodeDerivedKey(key)),
       })
     })
+  }
+
+  boot(): void {
+    setEncrypter(this.container.make<Encrypter>('encrypter'))
   }
 }

--- a/packages/server/src/providers/LogServiceProvider.ts
+++ b/packages/server/src/providers/LogServiceProvider.ts
@@ -2,10 +2,9 @@ import { ServiceProvider } from '../container/ServiceProvider'
 import { createLogManager, setLogManager, type LogManager } from '../logging'
 
 /**
- * Binds the LogManager as a singleton in the container and, at boot, makes it
- * the global one behind `getLogManager()`. The default channel is declared,
- * not merely named: `LogManager` resolves channels from `channels` alone, so a
- * `default` with no matching entry throws on the first write.
+ * Binds the LogManager as a singleton in the container. The default channel is
+ * declared, not merely named: `LogManager` resolves channels from `channels`
+ * alone, so a `default` with no matching entry throws on the first write.
  */
 export class LogServiceProvider extends ServiceProvider {
   register(): void {

--- a/packages/server/src/providers/LogServiceProvider.ts
+++ b/packages/server/src/providers/LogServiceProvider.ts
@@ -1,10 +1,11 @@
 import { ServiceProvider } from '../container/ServiceProvider'
-import { createLogManager } from '../logging'
+import { createLogManager, setLogManager, type LogManager } from '../logging'
 
 /**
- * Binds the LogManager as a singleton in the container. The default channel is
- * declared, not merely named: `LogManager` resolves channels from `channels`
- * alone, so a `default` with no matching entry throws on the first write.
+ * Binds the LogManager as a singleton in the container and, at boot, makes it
+ * the global one behind `getLogManager()`. The default channel is declared,
+ * not merely named: `LogManager` resolves channels from `channels` alone, so a
+ * `default` with no matching entry throws on the first write.
  */
 export class LogServiceProvider extends ServiceProvider {
   register(): void {
@@ -12,5 +13,9 @@ export class LogServiceProvider extends ServiceProvider {
       default: 'console',
       channels: { console: { driver: 'console' } },
     }))
+  }
+
+  boot(): void {
+    setLogManager(this.container.make<LogManager>('log'))
   }
 }

--- a/packages/server/src/providers/LogServiceProvider.ts
+++ b/packages/server/src/providers/LogServiceProvider.ts
@@ -1,9 +1,16 @@
 import { ServiceProvider } from '../container/ServiceProvider'
 import { createLogManager } from '../logging'
 
-/** Binds the LogManager as a singleton in the container. */
+/**
+ * Binds the LogManager as a singleton in the container. The default channel is
+ * declared, not merely named: `LogManager` resolves channels from `channels`
+ * alone, so a `default` with no matching entry throws on the first write.
+ */
 export class LogServiceProvider extends ServiceProvider {
   register(): void {
-    this.container.singleton('log', () => createLogManager({ default: 'console', channels: {} }))
+    this.container.singleton('log', () => createLogManager({
+      default: 'console',
+      channels: { console: { driver: 'console' } },
+    }))
   }
 }

--- a/packages/server/src/providers/NotificationServiceProvider.ts
+++ b/packages/server/src/providers/NotificationServiceProvider.ts
@@ -1,17 +1,24 @@
 import { ServiceProvider } from '../container/ServiceProvider'
-import { createNotificationManager, type NotificationManager } from '../notifications'
+import {
+  createNotificationManager,
+  setNotificationManager,
+  type NotificationManager,
+} from '../notifications'
 
-/** Binds the NotificationManager as a singleton in the container. */
+/**
+ * Binds the NotificationManager as a singleton in the container and, at boot,
+ * makes it the global one behind `getNotificationManager()`.
+ */
 export class NotificationServiceProvider extends ServiceProvider {
   register(): void {
     this.container.singleton('notifications', () => createNotificationManager())
   }
 
   boot(): void {
-    // Register the queued-notification job in every booted process, including
-    // a worker that never sends a notification itself.
-    this.container
-      .make<NotificationManager>('notifications')
-      .registerQueueJob()
+    const manager = this.container.make<NotificationManager>('notifications')
+    setNotificationManager(manager)
+    // Registered in every booted process, including a worker that never sends
+    // a notification itself.
+    manager.registerQueueJob()
   }
 }

--- a/packages/server/src/providers/NotificationServiceProvider.ts
+++ b/packages/server/src/providers/NotificationServiceProvider.ts
@@ -5,10 +5,7 @@ import {
   type NotificationManager,
 } from '../notifications'
 
-/**
- * Binds the NotificationManager as a singleton in the container and, at boot,
- * makes it the global one behind `getNotificationManager()`.
- */
+/** Binds the NotificationManager as a singleton in the container. */
 export class NotificationServiceProvider extends ServiceProvider {
   register(): void {
     this.container.singleton('notifications', () => createNotificationManager())

--- a/packages/server/tests/auth/auth-manager.test.ts
+++ b/packages/server/tests/auth/auth-manager.test.ts
@@ -4,28 +4,14 @@ import type { Guard, GuardContext, UserProvider } from '../../src/auth/types'
 import { createApiToken, MemoryApiTokenStore } from '../../src/auth/api-token'
 import { TokenGuard } from '../../src/auth/TokenGuard'
 import { fakeContext } from '../support/fake-context'
+import { fakeGuard, fakeUserProvider } from '../support/fake-auth'
 
 function createMockGuardFactory(): (ctx: GuardContext) => Guard {
-  return () => ({
-    async check() { return false },
-    async guest() { return true },
-    async user() { return null },
-    async id() { return null },
-    async login() {},
-    async logout() {},
-    async attempt() { return false },
-    async validate() { return null },
-    session() { return undefined },
-  })
+  return () => fakeGuard()
 }
 
-function createMockProviderFactory(): (manager: any) => UserProvider {
-  return () => ({
-    async retrieveById() { return null },
-    async retrieveByCredentials() { return null },
-    async validateCredentials() { return false },
-    getId() { return null },
-  })
+function createMockProviderFactory(): (manager: unknown) => UserProvider {
+  return () => fakeUserProvider()
 }
 
 describe('AuthManager', () => {
@@ -204,12 +190,10 @@ describe('AuthManager.useTokens', () => {
     const manager = new AuthManager()
     manager.registerGuard('web', createMockGuardFactory())
     manager.setDefaultGuard('web')
-    manager.registerProvider('users', () => ({
+    manager.registerProvider('users', () => fakeUserProvider({
       async retrieveById(id: unknown) { return { id, name: 'Alice' } as never },
-      async retrieveByCredentials() { return null },
-      async validateCredentials() { return false },
-      getId(user: { id: unknown }) { return user.id },
-    }) as never)
+      getId(user: unknown) { return (user as { id: unknown }).id },
+    }))
     manager.useTokens(store, { provider: 'users' })
 
     const { plainTextToken } = await createApiToken(store, { name: 't', userId: 42 })

--- a/packages/server/tests/auth/bearer-gate-resolution.test.ts
+++ b/packages/server/tests/auth/bearer-gate-resolution.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'bun:test'
+import { Hono } from 'hono'
+import { createApiToken, createBearerTokenMiddleware, MemoryApiTokenStore } from '../../src/auth/api-token'
+import { getAuthContext } from '../../src/auth/context'
+import type { AuthContext } from '../../src/auth/types'
+import { Gate } from '../../src/authorization'
+import { attachAuthContext } from '../../src/http/middleware/auth'
+
+interface ProfileUser {
+  id: number
+  name: string
+}
+
+/** The context an app with cookie sessions attaches: no session, so no user. */
+function sessionlessContext(): AuthContext {
+  return {
+    check: async () => false,
+    guest: async () => true,
+    user: async () => null,
+    userOrFail: async () => { throw new Error('unauthenticated') },
+    id: async () => null,
+    login: async () => {},
+    attempt: async () => false,
+    logout: async () => {},
+    guard: () => { throw new Error('no guard') },
+    session: () => undefined,
+  }
+}
+
+async function bearerFor(store: MemoryApiTokenStore): Promise<string> {
+  const { plainTextToken } = await createApiToken(store, { name: 'cli', userId: 1 })
+  return `Bearer ${plainTextToken}`
+}
+
+function profileRoute(app: Hono, gate: Gate): void {
+  app.get('/me', async (c) => {
+    const user = await gate.resolveUser(c)
+    await gate.forUser(user).authorize('read-profile')
+    return c.json({ id: (user as ProfileUser).id, viaContext: await getAuthContext(c)?.user<ProfileUser>() })
+  })
+}
+
+describe('createBearerTokenMiddleware with the Gate', () => {
+  const loadUser = async (userId: string | number): Promise<ProfileUser> => ({ id: Number(userId), name: 'John' })
+
+  it('should resolve the loaded user through Gate.resolveUser when no auth context is attached', async () => {
+    const store = new MemoryApiTokenStore()
+    const gate = new Gate().define('read-profile', (user) => (user as ProfileUser | null)?.id === 1)
+    const app = new Hono()
+    app.use('*', createBearerTokenMiddleware({ store, loadUser }))
+    profileRoute(app, gate)
+
+    const res = await app.request('/me', { headers: { Authorization: await bearerFor(store) } })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ id: 1, viaContext: { id: 1, name: 'John' } })
+  })
+
+  it('should let the bearer user win over an attached context that has no session user', async () => {
+    const store = new MemoryApiTokenStore()
+    const gate = new Gate().define('read-profile', (user) => (user as ProfileUser | null)?.id === 1)
+    const app = new Hono()
+    app.use('*', attachAuthContext(() => sessionlessContext()))
+    app.use('*', createBearerTokenMiddleware({ store, loadUser }))
+    profileRoute(app, gate)
+
+    const res = await app.request('/me', { headers: { Authorization: await bearerFor(store) } })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ id: 1, viaContext: { id: 1, name: 'John' } })
+  })
+
+  it('should report an unresolvable user as unauthenticated rather than falling back', async () => {
+    const store = new MemoryApiTokenStore()
+    const app = new Hono()
+    app.use('*', attachAuthContext(() => sessionlessContext()))
+    app.use('*', createBearerTokenMiddleware({ store, loadUser: async () => null }))
+    app.get('/me', async (c) => {
+      const auth = getAuthContext(c)!
+      return c.json({ check: await auth.check(), user: await auth.user(), id: await auth.id() })
+    })
+
+    const res = await app.request('/me', { headers: { Authorization: await bearerFor(store) } })
+
+    expect(await res.json()).toEqual({ check: false, user: null, id: null })
+  })
+})

--- a/packages/server/tests/auth/bearer-gate-resolution.test.ts
+++ b/packages/server/tests/auth/bearer-gate-resolution.test.ts
@@ -1,54 +1,130 @@
+/**
+ * The bearer middleware's user has to reach authorization at every mounting
+ * order the docs allow, so the cases that can drive a real `Application` do,
+ * rather than asserting against a context built here.
+ */
+process.env.APP_KEY = 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+
 import { describe, expect, it } from 'bun:test'
 import { Hono } from 'hono'
-import { createApiToken, createBearerTokenMiddleware, MemoryApiTokenStore } from '../../src/auth/api-token'
+import {
+  createApiToken,
+  createBearerTokenMiddleware,
+  getApiToken,
+  MemoryApiTokenStore,
+  verifyApiToken,
+} from '../../src/auth/api-token'
+import { AuthManager } from '../../src/auth/AuthManager'
 import { getAuthContext } from '../../src/auth/context'
-import type { AuthContext } from '../../src/auth/types'
+import type { AuthContext, Guard, UserProvider } from '../../src/auth/types'
 import { Gate } from '../../src/authorization'
+import { Application } from '../../src/http/Application'
 import { attachAuthContext } from '../../src/http/middleware/auth'
+import { installAgentPrincipal } from '../../src/internal/agent-principal'
 
 interface ProfileUser {
   id: number
   name: string
 }
 
-/** The context an app with cookie sessions attaches: no session, so no user. */
-function sessionlessContext(): AuthContext {
-  return {
-    check: async () => false,
-    guest: async () => true,
-    user: async () => null,
-    userOrFail: async () => { throw new Error('unauthenticated') },
-    id: async () => null,
-    login: async () => {},
-    attempt: async () => false,
-    logout: async () => {},
-    guard: () => { throw new Error('no guard') },
-    session: () => undefined,
-  }
-}
+const SESSION_USER = { id: 7, name: 'Session' }
+
+const loadUser = async (userId: string | number): Promise<ProfileUser> => ({
+  id: Number(userId),
+  name: 'John',
+})
 
 async function bearerFor(store: MemoryApiTokenStore): Promise<string> {
   const { plainTextToken } = await createApiToken(store, { name: 'cli', userId: 1 })
   return `Bearer ${plainTextToken}`
 }
 
-function profileRoute(app: Hono, gate: Gate): void {
-  app.get('/me', async (c) => {
+/** The Gate's answer beside the context's, so a divergence between them shows. */
+function profileHandler(): (c: any) => Promise<Response> {
+  const gate = new Gate().define('read-profile', (user) => (user as ProfileUser | null)?.id === 1)
+  return async (c) => {
     const user = await gate.resolveUser(c)
     await gate.forUser(user).authorize('read-profile')
     return c.json({ id: (user as ProfileUser).id, viaContext: await getAuthContext(c)?.user<ProfileUser>() })
-  })
+  }
+}
+
+/** A guard that answers the way a logged-in session guard does. */
+function guardFor(user: unknown): Guard<unknown> {
+  return {
+    check: async () => user !== null,
+    guest: async () => user === null,
+    user: async <T>() => user as T,
+    id: async () => (user as { id: unknown } | null)?.id ?? null,
+    login: async () => {},
+    logout: async () => {},
+    attempt: async () => true,
+    validate: async () => null,
+    session: () => undefined,
+  }
+}
+
+/** The framework context an app with a logged-in session carries. */
+function sessionUserContext(ctx: Parameters<AuthManager['createAuthContext']>[0]): AuthContext {
+  const auth = new AuthManager()
+  auth.registerGuard('web', () => guardFor(SESSION_USER))
+  auth.setDefaultGuard('web')
+  return auth.createAuthContext(ctx)
 }
 
 describe('createBearerTokenMiddleware with the Gate', () => {
-  const loadUser = async (userId: string | number): Promise<ProfileUser> => ({ id: Number(userId), name: 'John' })
-
-  it('should resolve the loaded user through Gate.resolveUser when no auth context is attached', async () => {
+  // The documented mounting order: the middleware goes on before boot(), and
+  // AuthServiceProvider then attaches its own context behind it.
+  it('should resolve the loaded user when the middleware is mounted before boot', async () => {
     const store = new MemoryApiTokenStore()
-    const gate = new Gate().define('read-profile', (user) => (user as ProfileUser | null)?.id === 1)
+    const app = new Application({ auth: {} })
+    app.use('/api/*', createBearerTokenMiddleware({ store, loadUser }))
+    await app.boot()
+    app.hono.get('/api/me', profileHandler())
+
+    const res = await app.fetch(
+      new Request('http://example.com/api/me', { headers: { Authorization: await bearerFor(store) } }),
+    )
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ id: 1, viaContext: { id: 1, name: 'John' } })
+  })
+
+  it('should resolve the loaded user when the middleware is mounted after boot', async () => {
+    const store = new MemoryApiTokenStore()
+    const app = new Application({ auth: {} })
+    await app.boot()
+    app.hono.use('/api/*', createBearerTokenMiddleware({ store, loadUser }))
+    app.hono.get('/api/me', profileHandler())
+
+    const res = await app.fetch(
+      new Request('http://example.com/api/me', { headers: { Authorization: await bearerFor(store) } }),
+    )
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ id: 1, viaContext: { id: 1, name: 'John' } })
+  })
+
+  it('should resolve the loaded user in an app configured without auth options', async () => {
+    const store = new MemoryApiTokenStore()
+    const app = new Application()
+    app.use('/api/*', createBearerTokenMiddleware({ store, loadUser }))
+    await app.boot()
+    app.hono.get('/api/me', profileHandler())
+
+    const res = await app.fetch(
+      new Request('http://example.com/api/me', { headers: { Authorization: await bearerFor(store) } }),
+    )
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ id: 1, viaContext: { id: 1, name: 'John' } })
+  })
+
+  it('should resolve the loaded user on a plain Hono app with no auth context', async () => {
+    const store = new MemoryApiTokenStore()
     const app = new Hono()
     app.use('*', createBearerTokenMiddleware({ store, loadUser }))
-    profileRoute(app, gate)
+    app.get('/me', profileHandler())
 
     const res = await app.request('/me', { headers: { Authorization: await bearerFor(store) } })
 
@@ -56,24 +132,31 @@ describe('createBearerTokenMiddleware with the Gate', () => {
     expect(await res.json()).toEqual({ id: 1, viaContext: { id: 1, name: 'John' } })
   })
 
-  it('should let the bearer user win over an attached context that has no session user', async () => {
+  it('should revoke the presented token on logout', async () => {
     const store = new MemoryApiTokenStore()
-    const gate = new Gate().define('read-profile', (user) => (user as ProfileUser | null)?.id === 1)
     const app = new Hono()
-    app.use('*', attachAuthContext(() => sessionlessContext()))
     app.use('*', createBearerTokenMiddleware({ store, loadUser }))
-    profileRoute(app, gate)
+    app.post('/logout', async (c) => {
+      await getAuthContext(c)!.logout()
+      return c.json({ tokenAfter: getApiToken(c) ?? null })
+    })
 
-    const res = await app.request('/me', { headers: { Authorization: await bearerFor(store) } })
+    const { plainTextToken } = await createApiToken(store, { name: 'cli', userId: 1 })
+    const res = await app.request('/logout', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${plainTextToken}` },
+    })
 
-    expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({ id: 1, viaContext: { id: 1, name: 'John' } })
+    expect(await res.json()).toEqual({ tokenAfter: null })
+    expect(await verifyApiToken(plainTextToken, store)).toBeNull()
   })
 
-  it('should report an unresolvable user as unauthenticated rather than falling back', async () => {
+  // The token verified, so the request is bearer-authenticated and the session
+  // user does not stand in for the user the token names.
+  it('should report a verified token whose user does not load as unauthenticated', async () => {
     const store = new MemoryApiTokenStore()
     const app = new Hono()
-    app.use('*', attachAuthContext(() => sessionlessContext()))
+    app.use('*', attachAuthContext(sessionUserContext))
     app.use('*', createBearerTokenMiddleware({ store, loadUser: async () => null }))
     app.get('/me', async (c) => {
       const auth = getAuthContext(c)!
@@ -83,5 +166,79 @@ describe('createBearerTokenMiddleware with the Gate', () => {
     const res = await app.request('/me', { headers: { Authorization: await bearerFor(store) } })
 
     expect(await res.json()).toEqual({ check: false, user: null, id: null })
+  })
+
+  it('should leave the session user alone on a request the middleware never ran for', async () => {
+    const store = new MemoryApiTokenStore()
+    const app = new Hono()
+    app.use('*', attachAuthContext(sessionUserContext))
+    app.use('/api/*', createBearerTokenMiddleware({ store, loadUser: async () => null }))
+    app.get('/me', async (c) => c.json({ user: await getAuthContext(c)!.user() }))
+
+    const res = await app.request('/me')
+
+    expect(await res.json()).toEqual({ user: SESSION_USER })
+  })
+
+  it('should sanitize the loaded user through the provider useTokens configured', async () => {
+    const store = new MemoryApiTokenStore()
+    const provider = {
+      retrieveById: async () => null,
+      retrieveByCredentials: async () => null,
+      validateCredentials: async () => false,
+      getId: (user: unknown) => (user as ProfileUser).id,
+      sanitize: (user: unknown) => {
+        const { password: _password, ...rest } = user as ProfileUser & { password: string }
+        return rest
+      },
+    } as unknown as UserProvider<unknown>
+
+    const auth = new AuthManager()
+    auth.registerProvider('users', () => provider)
+    auth.registerGuard('web', () => guardFor(null))
+    auth.setDefaultGuard('web')
+    auth.useTokens(store, { provider: 'users' })
+
+    const app = new Hono()
+    app.use('*', attachAuthContext((ctx) => auth.createAuthContext(ctx)))
+    app.use('*', createBearerTokenMiddleware({
+      store,
+      loadUser: async (userId) => ({ id: Number(userId), name: 'John', password: 'hash' }),
+    }))
+    app.get('/me', async (c) => c.json({ user: await getAuthContext(c)!.user() }))
+
+    const res = await app.request('/me', { headers: { Authorization: await bearerFor(store) } })
+
+    expect(await res.json()).toEqual({ user: { id: 1, name: 'John' } })
+  })
+
+  // RFC 0017 §2: a header must not win over an identity the pipeline itself
+  // established, and the slot is written from a header.
+  it('should let an installed agent principal outrank the bearer token', async () => {
+    const store = new MemoryApiTokenStore()
+    const app = new Application()
+    app.use('/api/*', createBearerTokenMiddleware({ store, loadUser }))
+    await app.boot()
+    app.hono.get('/api/me', async (c) => c.json({ user: await getAuthContext(c)!.user() }))
+
+    const request = installAgentPrincipal(new Request('http://example.com/api/me', {
+      headers: { Authorization: await bearerFor(store) },
+    }), { principal: { kind: 'service', id: 'agent:triager:1' }, abilities: ['tools:*'] })
+    const res = await app.fetch(request)
+
+    expect(await res.json()).toEqual({ user: { id: 'agent:triager:1' } })
+  })
+
+  it('should not throw when the attached context implements only part of AuthContext', async () => {
+    const store = new MemoryApiTokenStore()
+    const app = new Hono()
+    const partial = { check: async () => false, user: async () => null } as unknown as AuthContext
+    app.use('*', attachAuthContext(() => partial))
+    app.use('*', createBearerTokenMiddleware({ store, loadUser }))
+    app.get('/me', async (c) => c.json({ user: await getAuthContext(c)!.user() }))
+
+    const res = await app.request('/me', { headers: { Authorization: await bearerFor(store) } })
+
+    expect(res.status).toBe(200)
   })
 })

--- a/packages/server/tests/auth/bearer-gate-resolution.test.ts
+++ b/packages/server/tests/auth/bearer-gate-resolution.test.ts
@@ -6,7 +6,7 @@
 process.env.APP_KEY = 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
 
 import { describe, expect, it } from 'bun:test'
-import { Hono } from 'hono'
+import { Hono, type Context } from 'hono'
 import {
   createApiToken,
   createBearerTokenMiddleware,
@@ -16,11 +16,12 @@ import {
 } from '../../src/auth/api-token'
 import { AuthManager } from '../../src/auth/AuthManager'
 import { getAuthContext } from '../../src/auth/context'
-import type { AuthContext, Guard, UserProvider } from '../../src/auth/types'
+import type { AuthContext, Guard } from '../../src/auth/types'
 import { Gate } from '../../src/authorization'
 import { Application } from '../../src/http/Application'
 import { attachAuthContext } from '../../src/http/middleware/auth'
 import { installAgentPrincipal } from '../../src/internal/agent-principal'
+import { fakeGuard, fakeUserProvider } from '../support/fake-auth'
 
 interface ProfileUser {
   id: number
@@ -40,7 +41,7 @@ async function bearerFor(store: MemoryApiTokenStore): Promise<string> {
 }
 
 /** The Gate's answer beside the context's, so a divergence between them shows. */
-function profileHandler(): (c: any) => Promise<Response> {
+function profileHandler(): (c: Context) => Promise<Response> {
   const gate = new Gate().define('read-profile', (user) => (user as ProfileUser | null)?.id === 1)
   return async (c) => {
     const user = await gate.resolveUser(c)
@@ -51,17 +52,13 @@ function profileHandler(): (c: any) => Promise<Response> {
 
 /** A guard that answers the way a logged-in session guard does. */
 function guardFor(user: unknown): Guard<unknown> {
-  return {
+  return fakeGuard({
     check: async () => user !== null,
     guest: async () => user === null,
     user: async <T>() => user as T,
     id: async () => (user as { id: unknown } | null)?.id ?? null,
-    login: async () => {},
-    logout: async () => {},
     attempt: async () => true,
-    validate: async () => null,
-    session: () => undefined,
-  }
+  })
 }
 
 /** The framework context an app with a logged-in session carries. */
@@ -72,61 +69,48 @@ function sessionUserContext(ctx: Parameters<AuthManager['createAuthContext']>[0]
   return auth.createAuthContext(ctx)
 }
 
-describe('createBearerTokenMiddleware with the Gate', () => {
-  // The documented mounting order: the middleware goes on before boot(), and
-  // AuthServiceProvider then attaches its own context behind it.
-  it('should resolve the loaded user when the middleware is mounted before boot', async () => {
-    const store = new MemoryApiTokenStore()
+/** Mounts the middleware, and answers a request for the protected route. */
+type Wiring = (store: MemoryApiTokenStore) => Promise<(headers: Record<string, string>) => Promise<Response> | Response>
+
+// The documented order is the middleware before boot(), with AuthServiceProvider
+// attaching its own context behind it; the rest are orders an app may mount them
+// in, and the plain Hono app has no framework context to attach at all.
+const WIRINGS: Array<[name: string, mount: Wiring]> = [
+  ['a Guren app with auth options, mounted before boot', async (store) => {
     const app = new Application({ auth: {} })
     app.use('/api/*', createBearerTokenMiddleware({ store, loadUser }))
     await app.boot()
     app.hono.get('/api/me', profileHandler())
-
-    const res = await app.fetch(
-      new Request('http://example.com/api/me', { headers: { Authorization: await bearerFor(store) } }),
-    )
-
-    expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({ id: 1, viaContext: { id: 1, name: 'John' } })
-  })
-
-  it('should resolve the loaded user when the middleware is mounted after boot', async () => {
-    const store = new MemoryApiTokenStore()
+    return (headers) => app.fetch(new Request('http://example.com/api/me', { headers }))
+  }],
+  ['a Guren app with auth options, mounted after boot', async (store) => {
     const app = new Application({ auth: {} })
     await app.boot()
     app.hono.use('/api/*', createBearerTokenMiddleware({ store, loadUser }))
     app.hono.get('/api/me', profileHandler())
-
-    const res = await app.fetch(
-      new Request('http://example.com/api/me', { headers: { Authorization: await bearerFor(store) } }),
-    )
-
-    expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({ id: 1, viaContext: { id: 1, name: 'John' } })
-  })
-
-  it('should resolve the loaded user in an app configured without auth options', async () => {
-    const store = new MemoryApiTokenStore()
+    return (headers) => app.fetch(new Request('http://example.com/api/me', { headers }))
+  }],
+  ['a Guren app configured without auth options', async (store) => {
     const app = new Application()
     app.use('/api/*', createBearerTokenMiddleware({ store, loadUser }))
     await app.boot()
     app.hono.get('/api/me', profileHandler())
-
-    const res = await app.fetch(
-      new Request('http://example.com/api/me', { headers: { Authorization: await bearerFor(store) } }),
-    )
-
-    expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({ id: 1, viaContext: { id: 1, name: 'John' } })
-  })
-
-  it('should resolve the loaded user on a plain Hono app with no auth context', async () => {
-    const store = new MemoryApiTokenStore()
+    return (headers) => app.fetch(new Request('http://example.com/api/me', { headers }))
+  }],
+  ['a plain Hono app with no auth context', async (store) => {
     const app = new Hono()
     app.use('*', createBearerTokenMiddleware({ store, loadUser }))
     app.get('/me', profileHandler())
+    return (headers) => app.request('/me', { headers })
+  }],
+]
 
-    const res = await app.request('/me', { headers: { Authorization: await bearerFor(store) } })
+describe('createBearerTokenMiddleware with the Gate', () => {
+  it.each(WIRINGS)('should resolve the loaded user on %s', async (_name, mount) => {
+    const store = new MemoryApiTokenStore()
+    const request = await mount(store)
+
+    const res = await request({ Authorization: await bearerFor(store) })
 
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ id: 1, viaContext: { id: 1, name: 'John' } })
@@ -182,16 +166,13 @@ describe('createBearerTokenMiddleware with the Gate', () => {
 
   it('should sanitize the loaded user through the provider useTokens configured', async () => {
     const store = new MemoryApiTokenStore()
-    const provider = {
-      retrieveById: async () => null,
-      retrieveByCredentials: async () => null,
-      validateCredentials: async () => false,
+    const provider = fakeUserProvider({
       getId: (user: unknown) => (user as ProfileUser).id,
       sanitize: (user: unknown) => {
         const { password: _password, ...rest } = user as ProfileUser & { password: string }
         return rest
       },
-    } as unknown as UserProvider<unknown>
+    })
 
     const auth = new AuthManager()
     auth.registerProvider('users', () => provider)

--- a/packages/server/tests/auth/oauth.test.ts
+++ b/packages/server/tests/auth/oauth.test.ts
@@ -20,6 +20,14 @@ import { hashToken } from '../../src/auth/utils'
 // unrestored replacement answers other files' `fetch()` calls: restore it here explicitly.
 const realFetch = globalThis.fetch
 
+/** An `oauth_states` table with no `binding` column: the payload comes back stripped. */
+function bindingDroppingStore(): MemoryOAuthStateStore {
+  const store = new MemoryOAuthStateStore()
+  const inner = store.store.bind(store)
+  store.store = async (stateHash, payload) => inner(stateHash, { ...payload, binding: undefined })
+  return store
+}
+
 afterEach(() => {
   globalThis.fetch = realFetch
 })
@@ -86,10 +94,27 @@ describe('oauth helpers', () => {
     const store = new MemoryOAuthStateStore()
     const { state } = await createOAuthState('github', store, {}, undefined, 'fixed-state', 'session-abc')
 
-    const stored = await store.find(hashToken('fixed-state'))
+    // A bound state carries the boundness marker, and is keyed on all of it.
+    expect(state).toBe('gb1~fixed-state')
+    const stored = await store.find(hashToken(state))
     expect(stored?.binding).toBe(hashToken('session-abc'))
     expect(stored?.binding).not.toBe('session-abc')
+  })
+
+  it('leaves an unbound state unmarked', async () => {
+    const store = new MemoryOAuthStateStore()
+    const { state } = await createOAuthState('github', store, {}, undefined, 'fixed-state')
+
     expect(state).toBe('fixed-state')
+  })
+
+  // Stripping the marker to make a bound flow read as unbound changes the key
+  // the store was written under, so the lookup misses.
+  it('does not find a state whose boundness marker was tampered with', async () => {
+    const store = new MemoryOAuthStateStore()
+    const { state } = await createOAuthState('github', store, {}, undefined, 'fixed-state', 'session-abc')
+
+    expect(await verifyOAuthState(state.replace('gb1~', ''), 'github', store, {})).toBeNull()
   })
 
   // A store that drops `binding` would otherwise revert the protection to the
@@ -110,6 +135,59 @@ describe('oauth helpers', () => {
     }
 
     expect(warnings.some((line) => line.includes('without its binding'))).toBe(true)
+  })
+
+  // The fixation the binding exists to stop: the attacker's own flow, walked
+  // through a victim's browser, which holds no binding to present. Nothing in
+  // the stored payload distinguishes it from an unbound flow, so the state
+  // itself is what has to say the flow was bound.
+  it('rejects, and warns, when a dropping store loses the binding on both sides', async () => {
+    const droppingStore = bindingDroppingStore()
+    const original = console.warn
+    const warnings: string[] = []
+    console.warn = (message: unknown) => { warnings.push(String(message)) }
+
+    try {
+      const { state } = await createOAuthState('github', droppingStore, {}, undefined, undefined, 'attacker-session')
+      expect(await verifyOAuthState(state, 'github', droppingStore, {})).toBeNull()
+    } finally {
+      console.warn = original
+    }
+
+    expect(warnings.some((line) => line.includes('without its binding'))).toBe(true)
+  })
+
+  it('warns on every dropped binding, not only the first', async () => {
+    const droppingStore = bindingDroppingStore()
+    const original = console.warn
+    const warnings: string[] = []
+    console.warn = (message: unknown) => { warnings.push(String(message)) }
+
+    try {
+      for (const session of ['one', 'two']) {
+        const { state } = await createOAuthState('github', droppingStore, {}, undefined, undefined, session)
+        await verifyOAuthState(state, 'github', droppingStore, {}, session)
+      }
+    } finally {
+      console.warn = original
+    }
+
+    expect(warnings.filter((line) => line.includes('without its binding'))).toHaveLength(2)
+  })
+
+  // States minted before the marker existed keep verifying: an unmarked state
+  // whose store kept the binding compares stored against presented as before.
+  it('verifies a bound state minted before the marker existed', async () => {
+    const store = new MemoryOAuthStateStore()
+    await store.store(hashToken('legacy-state'), {
+      provider: 'github',
+      redirectTo: '/dashboard',
+      expiresAt: new Date(Date.now() + 60_000),
+      binding: hashToken('starting-session'),
+    })
+
+    const payload = await verifyOAuthState('legacy-state', 'github', store, {}, 'starting-session')
+    expect(payload?.redirectTo).toBe('/dashboard')
   })
 
   it('still verifies a state created without a binding', async () => {

--- a/packages/server/tests/auth/oauth.test.ts
+++ b/packages/server/tests/auth/oauth.test.ts
@@ -92,9 +92,10 @@ describe('oauth helpers', () => {
     expect(state).toBe('fixed-state')
   })
 
-  // A store that drops `binding` reverts the protection with no other signal, so the
-  // mismatch between "bound at authorize" and "unbound at callback" must be reported.
-  it('warns when a bound flow comes back from the store unbound', async () => {
+  // A store that drops `binding` would otherwise revert the protection to the
+  // transferable state it replaced, with no other signal. So the callback fails,
+  // and the warning is what names the store as the cause.
+  it('rejects, and warns, when a bound flow comes back from the store unbound', async () => {
     const store = new MemoryOAuthStateStore()
     const original = console.warn
     const warnings: string[] = []
@@ -103,7 +104,7 @@ describe('oauth helpers', () => {
     try {
       const { state } = await createOAuthState('github', store, {}, undefined, 'dropped-state')
       // Minted unbound but presented with a binding: the shape a dropping store produces.
-      expect(await verifyOAuthState(state, 'github', store, {}, 'session-abc')).not.toBeNull()
+      expect(await verifyOAuthState(state, 'github', store, {}, 'session-abc')).toBeNull()
     } finally {
       console.warn = original
     }

--- a/packages/server/tests/auth/request-auth-context.test.ts
+++ b/packages/server/tests/auth/request-auth-context.test.ts
@@ -3,30 +3,17 @@ import { RequestAuthContext } from '../../src/auth/RequestAuthContext'
 import { AuthenticationException } from '../../src/errors/exceptions/AuthenticationException'
 import type { Guard } from '../../src/auth/types'
 import type { Session } from '../../src/http/middleware'
-
-function createMockGuard(overrides: Partial<Guard> = {}): Guard {
-  return {
-    async check() { return false },
-    async guest() { return true },
-    async user() { return null },
-    async id() { return null },
-    async login() {},
-    async logout() {},
-    async attempt() { return false },
-    async validate() { return null },
-    session() { return undefined },
-    ...overrides,
-  } as Guard
-}
+import { fakeContext } from '../support/fake-context'
+import { fakeGuard } from '../support/fake-auth'
 
 function createContext(
   guardOverrides: Partial<Guard> = {},
   session?: Session,
 ) {
-  const guard = createMockGuard(guardOverrides)
+  const guard = fakeGuard(guardOverrides)
   const resolveName = (name?: string) => name ?? 'web'
   const resolveGuard = () => guard
-  return new RequestAuthContext(resolveName, {} as any, () => session, resolveGuard)
+  return new RequestAuthContext(resolveName, fakeContext(), () => session, resolveGuard)
 }
 
 describe('RequestAuthContext', () => {

--- a/packages/server/tests/health/health.test.ts
+++ b/packages/server/tests/health/health.test.ts
@@ -13,6 +13,7 @@ import {
   customCheck,
 } from '../../src/health'
 import type { CacheStoreInterface, CheckResult, HealthStatus } from '../../src/health'
+import { MemoryStore } from '../../src/cache'
 
 describe('HealthCheck', () => {
   class TestCheck extends HealthCheck {
@@ -439,34 +440,44 @@ describe('RedisCheck', () => {
 })
 
 describe('CacheCheck', () => {
-  it('should return healthy when cache operations succeed', async () => {
-    let stored: unknown = null
-    const cache = {
-      get: mock(() => Promise.resolve(stored)),
-      put: mock((key: string, value: unknown) => {
-        stored = value
-        return Promise.resolve()
-      }),
-      forget: mock(() => Promise.resolve(true)),
-    }
-
-    const check = new CacheCheck(cache as unknown as CacheStoreInterface)
+  it('should accept the built-in cache store and leave no key behind', async () => {
+    const store = new MemoryStore()
+    const check = new CacheCheck(store)
     const result = await check.check()
 
     expect(result.status).toBe('healthy')
-    expect(cache.put).toHaveBeenCalled()
-    expect(cache.get).toHaveBeenCalled()
-    expect(cache.forget).toHaveBeenCalled()
+    expect(await store.has('__health_check__')).toBe(false)
+  })
+
+  it('should return healthy when cache operations succeed', async () => {
+    let stored: unknown = null
+    const get = mock((_key: string) => Promise.resolve(stored))
+    const cache: CacheStoreInterface = {
+      get: <T>(key: string) => get(key) as Promise<T | null>,
+      set: mock((key: string, value: unknown) => {
+        stored = value
+        return Promise.resolve()
+      }),
+      delete: mock(() => Promise.resolve(true)),
+    }
+
+    const check = new CacheCheck(cache)
+    const result = await check.check()
+
+    expect(result.status).toBe('healthy')
+    expect(cache.set).toHaveBeenCalled()
+    expect(get).toHaveBeenCalled()
+    expect(cache.delete).toHaveBeenCalled()
   })
 
   it('should return degraded when read/write mismatch', async () => {
-    const cache = {
-      get: mock(() => Promise.resolve('wrong_value')),
-      put: mock(() => Promise.resolve()),
-      forget: mock(() => Promise.resolve(true)),
+    const cache: CacheStoreInterface = {
+      get: <T>() => Promise.resolve('wrong_value' as T | null),
+      set: mock(() => Promise.resolve()),
+      delete: mock(() => Promise.resolve(true)),
     }
 
-    const check = new CacheCheck(cache as unknown as CacheStoreInterface)
+    const check = new CacheCheck(cache)
     const result = await check.check()
 
     expect(result.status).toBe('degraded')
@@ -474,13 +485,13 @@ describe('CacheCheck', () => {
   })
 
   it('should return unhealthy when operation fails', async () => {
-    const cache = {
+    const cache: CacheStoreInterface = {
       get: mock(() => Promise.reject(new Error('Cache error'))),
-      put: mock(() => Promise.resolve()),
-      forget: mock(() => Promise.resolve(true)),
+      set: mock(() => Promise.resolve()),
+      delete: mock(() => Promise.resolve(true)),
     }
 
-    const check = new CacheCheck(cache as unknown as CacheStoreInterface)
+    const check = new CacheCheck(cache)
     const result = await check.check()
 
     expect(result.status).toBe('unhealthy')
@@ -489,19 +500,19 @@ describe('CacheCheck', () => {
 
   it('should use custom test key', async () => {
     let usedKey: string | null = null
-    const cache = {
-      get: mock((key: string) => {
+    const cache: CacheStoreInterface = {
+      get: <T>(key: string) => {
         usedKey = key
-        return Promise.resolve('test')
-      }),
-      put: mock((key: string, _value: unknown) => {
+        return Promise.resolve('test' as T | null)
+      },
+      set: mock((key: string, _value: unknown) => {
         usedKey = key
         return Promise.resolve()
       }),
-      forget: mock(() => Promise.resolve(true)),
+      delete: mock(() => Promise.resolve(true)),
     }
 
-    const check = new CacheCheck(cache as unknown as CacheStoreInterface, { testKey: 'custom_key' })
+    const check = new CacheCheck(cache, { testKey: 'custom_key' })
     await check.check()
 
     expect(usedKey ?? '').toBe('custom_key')

--- a/packages/server/tests/health/health.test.ts
+++ b/packages/server/tests/health/health.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../../src/health'
 import type { CacheStoreInterface, CheckResult, HealthStatus } from '../../src/health'
 import { MemoryStore } from '../../src/cache'
+import { MemoryDriver } from '../../src/storage'
 
 describe('HealthCheck', () => {
   class TestCheck extends HealthCheck {
@@ -520,12 +521,21 @@ describe('CacheCheck', () => {
 })
 
 describe('StorageCheck', () => {
+  it('should accept the built-in storage driver and leave no file behind', async () => {
+    const disk = new MemoryDriver()
+    const check = new StorageCheck(disk)
+    const result = await check.check()
+
+    expect(result.status).toBe('healthy')
+    expect(await disk.exists('__health_check__.txt')).toBe(false)
+  })
+
   it('should return healthy when storage operations succeed', async () => {
     let stored: string | null = null
     const storage = {
       put: mock((path: string, contents: string) => {
         stored = contents
-        return Promise.resolve()
+        return Promise.resolve(path)
       }),
       get: mock(() => Promise.resolve(stored ? Buffer.from(stored) : null)),
       delete: mock(() => Promise.resolve(true)),
@@ -542,7 +552,7 @@ describe('StorageCheck', () => {
 
   it('should return degraded when read/write mismatch', async () => {
     const storage = {
-      put: mock(() => Promise.resolve()),
+      put: mock(() => Promise.resolve('path')),
       get: mock(() => Promise.resolve(Buffer.from('wrong'))),
       delete: mock(() => Promise.resolve(true)),
     }

--- a/packages/server/tests/health/health.test.ts
+++ b/packages/server/tests/health/health.test.ts
@@ -450,27 +450,6 @@ describe('CacheCheck', () => {
     expect(await store.has('__health_check__')).toBe(false)
   })
 
-  it('should return healthy when cache operations succeed', async () => {
-    let stored: unknown = null
-    const get = mock((_key: string) => Promise.resolve(stored))
-    const cache: CacheStoreInterface = {
-      get: <T>(key: string) => get(key) as Promise<T | null>,
-      set: mock((key: string, value: unknown) => {
-        stored = value
-        return Promise.resolve()
-      }),
-      delete: mock(() => Promise.resolve(true)),
-    }
-
-    const check = new CacheCheck(cache)
-    const result = await check.check()
-
-    expect(result.status).toBe('healthy')
-    expect(cache.set).toHaveBeenCalled()
-    expect(get).toHaveBeenCalled()
-    expect(cache.delete).toHaveBeenCalled()
-  })
-
   it('should return degraded when read/write mismatch', async () => {
     const cache: CacheStoreInterface = {
       get: <T>() => Promise.resolve('wrong_value' as T | null),

--- a/packages/server/tests/logging/logging.test.ts
+++ b/packages/server/tests/logging/logging.test.ts
@@ -690,6 +690,10 @@ describe('createLogManager', () => {
 
 describe('Global log manager', () => {
   it('throws when not initialized', () => {
+    // The global is per process and every test file shares it, so this clears
+    // it rather than assuming no other file booted a LogServiceProvider.
+    setLogManager(undefined as unknown as LogManager)
+
     expect(() => getLogManager()).toThrow(
       'Log manager has not been initialized. Call setLogManager() first.'
     )

--- a/packages/server/tests/logging/logging.test.ts
+++ b/packages/server/tests/logging/logging.test.ts
@@ -13,6 +13,7 @@ import {
   setLogManager,
   getLogManager,
 } from '../../src/logging'
+import { clearGlobalManager } from '../support/globals'
 
 describe('LOG_LEVEL_PRIORITY', () => {
   it('has correct priority order', () => {
@@ -690,9 +691,7 @@ describe('createLogManager', () => {
 
 describe('Global log manager', () => {
   it('throws when not initialized', () => {
-    // The global is per process and every test file shares it, so this clears
-    // it rather than assuming no other file booted a LogServiceProvider.
-    setLogManager(undefined as unknown as LogManager)
+    clearGlobalManager(setLogManager)
 
     expect(() => getLogManager()).toThrow(
       'Log manager has not been initialized. Call setLogManager() first.'

--- a/packages/server/tests/providers/EncryptionServiceProvider.test.ts
+++ b/packages/server/tests/providers/EncryptionServiceProvider.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'bun:test'
+import { createApp } from '../../src/http/Application'
+import { EncryptionServiceProvider } from '../../src/providers/EncryptionServiceProvider'
+import { decrypt, encrypt, getEncrypter, type Encrypter } from '../../src/encryption'
+
+process.env.APP_KEY ??= 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+
+describe('EncryptionServiceProvider', () => {
+  it('should make the bound encrypter the one behind encrypt() and decrypt() once the app boots', async () => {
+    const app = createApp({ providers: [EncryptionServiceProvider] })
+    await app.boot()
+
+    const payload = encrypt({ userId: 7 })
+
+    expect(decrypt<{ userId: number }>(payload)).toEqual({ userId: 7 })
+    expect(getEncrypter()).toBe(app.container.make<Encrypter>('encrypter'))
+  })
+})

--- a/packages/server/tests/providers/LogServiceProvider.test.ts
+++ b/packages/server/tests/providers/LogServiceProvider.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, spyOn } from 'bun:test'
+import { Container } from '../../src/container/Container'
+import { LogServiceProvider } from '../../src/providers/LogServiceProvider'
+import type { LogManager } from '../../src/logging'
+
+describe('LogServiceProvider', () => {
+  it('should bind a log manager whose default channel writes to the console', () => {
+    const container = new Container()
+    new LogServiceProvider(container).register()
+    const log = container.make<LogManager>('log')
+
+    const info = spyOn(console, 'info').mockImplementation(() => {})
+    try {
+      expect(() => log.channel()).not.toThrow()
+      log.info('booted')
+      expect(info).toHaveBeenCalledTimes(1)
+      expect(String(info.mock.calls[0]?.[0])).toContain('booted')
+    } finally {
+      info.mockRestore()
+    }
+  })
+})

--- a/packages/server/tests/providers/LogServiceProvider.test.ts
+++ b/packages/server/tests/providers/LogServiceProvider.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, spyOn } from 'bun:test'
 import { Container } from '../../src/container/Container'
 import { LogServiceProvider } from '../../src/providers/LogServiceProvider'
-import { getLogManager, type LogManager } from '../../src/logging'
+import type { LogManager } from '../../src/logging'
 
 describe('LogServiceProvider', () => {
   it('should bind a log manager whose default channel writes to the console', () => {
@@ -18,14 +18,5 @@ describe('LogServiceProvider', () => {
     } finally {
       info.mockRestore()
     }
-  })
-
-  it('should publish the bound manager as the global one at boot', () => {
-    const container = new Container()
-    const provider = new LogServiceProvider(container)
-    provider.register()
-    provider.boot()
-
-    expect(getLogManager()).toBe(container.make<LogManager>('log'))
   })
 })

--- a/packages/server/tests/providers/LogServiceProvider.test.ts
+++ b/packages/server/tests/providers/LogServiceProvider.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, spyOn } from 'bun:test'
 import { Container } from '../../src/container/Container'
 import { LogServiceProvider } from '../../src/providers/LogServiceProvider'
-import type { LogManager } from '../../src/logging'
+import { getLogManager, type LogManager } from '../../src/logging'
 
 describe('LogServiceProvider', () => {
   it('should bind a log manager whose default channel writes to the console', () => {
@@ -18,5 +18,14 @@ describe('LogServiceProvider', () => {
     } finally {
       info.mockRestore()
     }
+  })
+
+  it('should publish the bound manager as the global one at boot', () => {
+    const container = new Container()
+    const provider = new LogServiceProvider(container)
+    provider.register()
+    provider.boot()
+
+    expect(getLogManager()).toBe(container.make<LogManager>('log'))
   })
 })

--- a/packages/server/tests/providers/global-managers.test.ts
+++ b/packages/server/tests/providers/global-managers.test.ts
@@ -1,0 +1,33 @@
+/**
+ * The functional APIs (`getBroadcastManager()`, `getNotificationManager()`)
+ * throw until something calls their setter, so a provider that only binds into
+ * the container leaves them unusable in every app that registers it.
+ */
+import { describe, expect, it } from 'bun:test'
+import { Container } from '../../src/container/Container'
+import { BroadcastServiceProvider } from '../../src/providers/BroadcastServiceProvider'
+import { NotificationServiceProvider } from '../../src/providers/NotificationServiceProvider'
+import { getBroadcastManager, type BroadcastManager } from '../../src/broadcasting'
+import { getNotificationManager, type NotificationManager } from '../../src/notifications'
+
+describe('BroadcastServiceProvider', () => {
+  it('should publish the bound manager as the global one at boot', () => {
+    const container = new Container()
+    const provider = new BroadcastServiceProvider(container)
+    provider.register()
+    provider.boot()
+
+    expect(getBroadcastManager()).toBe(container.make<BroadcastManager>('broadcast'))
+  })
+})
+
+describe('NotificationServiceProvider', () => {
+  it('should publish the bound manager as the global one at boot', () => {
+    const container = new Container()
+    const provider = new NotificationServiceProvider(container)
+    provider.register()
+    provider.boot()
+
+    expect(getNotificationManager()).toBe(container.make<NotificationManager>('notifications'))
+  })
+})

--- a/packages/server/tests/providers/global-managers.test.ts
+++ b/packages/server/tests/providers/global-managers.test.ts
@@ -1,33 +1,63 @@
 /**
- * The functional APIs (`getBroadcastManager()`, `getNotificationManager()`)
- * throw until something calls their setter, so a provider that only binds into
- * the container leaves them unusable in every app that registers it.
+ * The functional APIs (`getBroadcastManager()`, `getLogManager()`,
+ * `getNotificationManager()`) throw until something calls their setter, so a
+ * provider that only binds into the container leaves them unusable in every app
+ * that registers it.
  */
 import { describe, expect, it } from 'bun:test'
 import { Container } from '../../src/container/Container'
+import type { ServiceProviderConstructor } from '../../src/container/ServiceProvider'
 import { BroadcastServiceProvider } from '../../src/providers/BroadcastServiceProvider'
+import { LogServiceProvider } from '../../src/providers/LogServiceProvider'
 import { NotificationServiceProvider } from '../../src/providers/NotificationServiceProvider'
-import { getBroadcastManager, type BroadcastManager } from '../../src/broadcasting'
-import { getNotificationManager, type NotificationManager } from '../../src/notifications'
+import { getBroadcastManager, setBroadcastManager } from '../../src/broadcasting'
+import { getLogManager, setLogManager } from '../../src/logging'
+import { getNotificationManager, setNotificationManager } from '../../src/notifications'
+import { clearGlobalManager } from '../support/globals'
 
-describe('BroadcastServiceProvider', () => {
-  it('should publish the bound manager as the global one at boot', () => {
-    const container = new Container()
-    const provider = new BroadcastServiceProvider(container)
-    provider.register()
-    provider.boot()
+type GlobalManagerCase = [
+  name: string,
+  Provider: ServiceProviderConstructor,
+  binding: string,
+  read: () => unknown,
+  clear: () => void,
+]
 
-    expect(getBroadcastManager()).toBe(container.make<BroadcastManager>('broadcast'))
-  })
-})
+const CASES: GlobalManagerCase[] = [
+  [
+    'BroadcastServiceProvider',
+    BroadcastServiceProvider,
+    'broadcast',
+    getBroadcastManager,
+    () => clearGlobalManager(setBroadcastManager),
+  ],
+  [
+    'LogServiceProvider',
+    LogServiceProvider,
+    'log',
+    getLogManager,
+    () => clearGlobalManager(setLogManager),
+  ],
+  [
+    'NotificationServiceProvider',
+    NotificationServiceProvider,
+    'notifications',
+    getNotificationManager,
+    () => clearGlobalManager(setNotificationManager),
+  ],
+]
 
-describe('NotificationServiceProvider', () => {
-  it('should publish the bound manager as the global one at boot', () => {
-    const container = new Container()
-    const provider = new NotificationServiceProvider(container)
-    provider.register()
-    provider.boot()
+describe('service provider globals', () => {
+  it.each(CASES)(
+    '%s should publish the bound manager as the global one at boot',
+    async (_name, Provider, binding, read, clear) => {
+      clear()
+      const container = new Container()
+      const provider = new Provider(container)
+      await provider.register()
+      await provider.boot?.()
 
-    expect(getNotificationManager()).toBe(container.make<NotificationManager>('notifications'))
-  })
+      expect(read()).toBe(container.make(binding))
+    },
+  )
 })

--- a/packages/server/tests/support/fake-auth.ts
+++ b/packages/server/tests/support/fake-auth.ts
@@ -1,0 +1,30 @@
+import type { Guard, UserProvider } from '../../src/auth/types'
+
+/** A guard that answers unauthenticated, for a case that overrides what it asks. */
+export function fakeGuard<User = unknown>(overrides: Partial<Guard<User>> = {}): Guard<User> {
+  return {
+    async check() { return false },
+    async guest() { return true },
+    async user() { return null },
+    async id() { return null },
+    async login() {},
+    async logout() {},
+    async attempt() { return false },
+    async validate() { return null },
+    session() { return undefined },
+    ...overrides,
+  } as Guard<User>
+}
+
+/** A user provider that resolves nothing, for a case that overrides what it asks. */
+export function fakeUserProvider<User = unknown>(
+  overrides: Partial<UserProvider<User>> = {},
+): UserProvider<User> {
+  return {
+    async retrieveById() { return null },
+    async retrieveByCredentials() { return null },
+    async validateCredentials() { return false },
+    getId() { return null },
+    ...overrides,
+  } as UserProvider<User>
+}

--- a/packages/server/tests/support/globals.ts
+++ b/packages/server/tests/support/globals.ts
@@ -1,0 +1,9 @@
+/**
+ * Unset a per-process global manager. The setters take a manager, so clearing
+ * one is a cast; every test file in the process shares these globals, so a case
+ * that asserts the unset state has to clear rather than assume no other file
+ * booted a provider.
+ */
+export function clearGlobalManager<T>(set: (manager: T) => void): void {
+  set(undefined as unknown as T)
+}


### PR DESCRIPTION
## Summary

Five defects in `@guren/server` service wiring, found by a whole-framework design review. Each commit carries its own failing-then-passing test and a patch changeset.

- **LogServiceProvider** bound `channels: {}` with `default: 'console'`, so the first `log.channel()` threw `Log channel [console] is not defined`. It now declares the console channel it defaults to.
- **Bearer token middleware** wrote the loaded user to `guren:user` while `Gate.resolveUser` read a different key, so a `loadUser` result never reached authorization. The middleware now also exposes the user through the auth context every other consumer reads. No third key was added.
- **EncryptionServiceProvider** never called `setEncrypter`, so the exported `encrypt()`/`decrypt()` always threw "not initialized". The provider now registers the container's encrypter as the functional API's instance.
- **OAuth `bindingMatches`** returned true when the stored state had no browser binding, silently downgrading to transferable state when a custom store dropped the column. It now fails closed and keeps the warning.
- **CacheCheck** expected `put`/`forget` while `CacheStore` exposes `set`/`delete`, so the built-in health check could not take the built-in cache store. It now accepts a `CacheStore`.

Docs touched: api-tokens, oauth, health-checks (en + ja).

## Test plan

- `bun run typecheck`, `bun run lint`: green
- `bun test packages/server`: 3037 pass / 47 skip / 0 fail
- `bun run audit:prose`, `audit:docs`, `audit:core-first`: green
- Integration tree with the sibling review branches: `bun run test:bun` 7465 pass / 1 fail (`upgradeCanary` 5s timeout under load; passes alone and on main), `bun run test:examples` green

## Notes

`MailServiceProvider` has the same empty-config shape (default transport `smtp`, none registered). Left for a follow-up since it needs a decision on the default transport.

## Review follow-ups (code-review + simplify passes)

- The bearer wrapper is gone. The middleware writes a per-request resolved principal that `RequestAuthContext` reads before any guard, so mounting order no longer matters; `logout()` revokes the presented token; `user()` is sanitized through the `useTokens({ provider })` provider.
- OAuth boundness travels in the state value (`gb1~` marker), so a store that drops the binding column fails closed for both the honest and the fixation shape; warning per occurrence; legacy states keep verifying.
- StorageCheck narrowed like CacheCheck; Log, Broadcast and Notification providers publish their globals at boot; health/cache changesets raised to minor.
- Cleanup: principal rules single-sourced, shared auth test doubles, provider table test.
