### PR TITLE
fix(server): make Router contravariant in its alias parameter

### DIFF
--- a/.changeset/router-alias-variance.md
+++ b/.changeset/router-alias-variance.md
@@ -5,7 +5,7 @@
 
 Make `Router<M>`, `RouteBuilder<M>` and the `middleware()` scope builder contravariant in the middleware-alias parameter, with TypeScript's `in` variance annotation.
 
-`M` sat only in method parameters, which TypeScript compares bivariantly, so a router that never registered an alias could be passed where a `Router<'auth'>` was required; the mismatch surfaced at `mount()` as `Middleware "auth" is not registered`. A router carrying more aliases than the parameter names still passes.
+`M`'s only independent occurrence was a method parameter, which TypeScript compares bivariantly, so a router that never registered an alias could be passed where a `Router<'auth'>` was required; the mismatch surfaced at `mount()` as `Middleware "auth" is not registered`. A router carrying more aliases than the parameter names still passes.
 
 The tightening rejects three shapes that used to compile. None is a runtime behaviour change; each was already broken at `mount()` or was never satisfiable.
 

--- a/.changeset/router-alias-variance.md
+++ b/.changeset/router-alias-variance.md
@@ -1,5 +1,16 @@
 ---
-"@guren/server": patch
+"@guren/server": minor
+"@guren/core": minor
 ---
 
-Make `Router<M>` contravariant in its middleware-alias parameter. `M` sat only in method parameters, which TypeScript compares bivariantly, so a `Router` that never registered an alias could be passed where a `Router<'auth'>` was required; the mismatch surfaced at `mount()` as "Middleware "auth" is not registered". A registrar typed `Router<'auth'>` must now actually receive a router on which `aliasMiddleware('auth', …)` was called and its return captured. A router carrying more aliases than the parameter names still passes.
+Make `Router<M>`, `RouteBuilder<M>` and the `middleware()` scope builder contravariant in the middleware-alias parameter, with TypeScript's `in` variance annotation.
+
+`M` sat only in method parameters, which TypeScript compares bivariantly, so a router that never registered an alias could be passed where a `Router<'auth'>` was required; the mismatch surfaced at `mount()` as `Middleware "auth" is not registered`. A router carrying more aliases than the parameter names still passes.
+
+The tightening rejects three shapes that used to compile. None is a runtime behaviour change; each was already broken at `mount()` or was never satisfiable.
+
+- A registrar annotated `Router<'auth'>` is no longer assignable to `RouteRegistration`, the type of `createApp({ routes })`. An entry registrar takes `Router` and registers the aliases itself, capturing what `aliasMiddleware()` returns; a registrar that reads an alias is a function the entry one calls.
+- `Router<string>` is not a valid spelling of "any aliases". It asks for a router carrying every possible alias, which nothing satisfies. Write `Router`, that is `Router<never>`.
+- A `group()` callback cannot annotate aliases the outer router lacks: `router.middleware('auth').group((inner: Router<'auth' | 'guest'>) => …)` on a `Router<'auth'>` is rejected, because the callback reads a name the router never registered.
+
+One hole stays open. An inline `registrarNeedingAuth(new Router())` still compiles, because `M` has nothing to fix it and is inferred from the parameter. Only a router whose `M` is already settled, by a variable annotation or by an `aliasMiddleware()` chain, is checked.

--- a/.changeset/router-alias-variance.md
+++ b/.changeset/router-alias-variance.md
@@ -1,0 +1,5 @@
+---
+"@guren/server": patch
+---
+
+Make `Router<M>` contravariant in its middleware-alias parameter. `M` sat only in method parameters, which TypeScript compares bivariantly, so a `Router` that never registered an alias could be passed where a `Router<'auth'>` was required; the mismatch surfaced at `mount()` as "Middleware "auth" is not registered". A registrar typed `Router<'auth'>` must now actually receive a router on which `aliasMiddleware('auth', …)` was called and its return captured. A router carrying more aliases than the parameter names still passes.

--- a/docs/en/guides/middleware.md
+++ b/docs/en/guides/middleware.md
@@ -83,6 +83,8 @@ export function registerWebRoutes(baseRouter: Router): void {
 
 > [!IMPORTANT]
 > `aliasMiddleware()` returns a **new `Router` type** carrying the alias name it just registered. Call it without capturing the result and the name never reaches the type, so a later `.middleware('auth')` fails to compile. Always chain and assign, as above.
+>
+> The type travels across functions too. A registrar typed `Router<'auth' | 'guest'>` only accepts a router on which both names were aliased and the result captured, so hand it the captured `router` rather than the `baseRouter` it came from. The entry registrar itself takes plain `Router`: it is the one that registers the aliases, and `createApp({ routes })` hands it a router carrying none.
 
 Once registered, use the alias string anywhere middleware is accepted:
 

--- a/docs/en/guides/middleware.md
+++ b/docs/en/guides/middleware.md
@@ -84,7 +84,7 @@ export function registerWebRoutes(baseRouter: Router): void {
 > [!IMPORTANT]
 > `aliasMiddleware()` returns a **new `Router` type** carrying the alias name it just registered. Call it without capturing the result and the name never reaches the type, so a later `.middleware('auth')` fails to compile. Always chain and assign, as above.
 >
-> The type travels across functions too. A registrar typed `Router<'auth' | 'guest'>` only accepts a router on which both names were aliased and the result captured, so hand it the captured `router` rather than the `baseRouter` it came from. The entry registrar itself takes plain `Router`: it is the one that registers the aliases, and `createApp({ routes })` hands it a router carrying none.
+> The type also travels across functions. See [Registering Aliases](./routing.md#registering-aliases).
 
 Once registered, use the alias string anywhere middleware is accepted:
 

--- a/docs/en/guides/routing.md
+++ b/docs/en/guides/routing.md
@@ -117,6 +117,8 @@ export function registerWebRoutes(baseRouter: Router): void {
 
 > [!IMPORTANT]
 > `aliasMiddleware()` returns a **new `Router` type** carrying the alias name it just registered. Call it without capturing the result and the name never reaches the type, so a later `.middleware('auth')` fails to compile. Always chain and assign, as above.
+>
+> The type travels across functions too. A registrar typed `Router<'auth' | 'guest'>` only accepts a router on which both names were aliased and the result captured, so hand it the captured `router` rather than the `baseRouter` it came from. The entry registrar itself takes plain `Router`: it is the one that registers the aliases, and `createApp({ routes })` hands it a router carrying none.
 
 ### Middleware Groups
 

--- a/docs/ja/guides/routing.md
+++ b/docs/ja/guides/routing.md
@@ -90,6 +90,8 @@ export function registerWebRoutes(baseRouter: Router): void {
 
 > [!IMPORTANT]
 > `aliasMiddleware()` は登録済みのエイリアス名を型に載せた**新しい `Router` 型**を返します。戻り値を受け取らずに呼び出すと登録名が型に伝わらず、後続の `.middleware('auth')` が型エラーになります。上記のように必ずチェーンして受け取ってください。
+>
+> この型は関数をまたいでも効きます。`Router<'auth' | 'guest'>` と書いた登録関数には、その2つをエイリアス登録して戻り値を受け取った `router` を渡してください。`baseRouter` のままでは型が合いません。エントリの登録関数は素の `Router` を受け取ります。エイリアスを登録するのはその関数自身で、`createApp({ routes })` が渡すルーターにはまだ何も載っていないからです。
 
 エイリアスを登録すれば、ミドルウェアが受け入れられる場所ならどこでも文字列名で使えます。
 

--- a/examples/api/vitest.config.ts
+++ b/examples/api/vitest.config.ts
@@ -73,14 +73,6 @@ export default defineConfig({
         find: /^bun:sqlite$/,
         replacement: resolveFromRoot('./tests/support/bun-sqlite.ts'),
       },
-      {
-        find: /^guren$/,
-        replacement: resolveFromRoot('../../packages/core/src/index.ts'),
-      },
-      {
-        find: /^guren\/(.+)$/,
-        replacement: `${resolveFromRoot('../../packages/core/src')}/$1`,
-      },
     ],
   },
   test: {

--- a/examples/blog/tests/controllers/DashboardController.test.ts
+++ b/examples/blog/tests/controllers/DashboardController.test.ts
@@ -6,10 +6,6 @@ import {
 } from '@guren/testing'
 import type { Context } from '@guren/core'
 
-vi.mock('guren', async (importOriginal) => ({
-  ...((await importOriginal()) as object),
-  ...createControllerModuleMock(),
-}))
 vi.mock('@guren/core', async () => {
   const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
   return {

--- a/examples/blog/tests/controllers/ForgotPasswordController.test.ts
+++ b/examples/blog/tests/controllers/ForgotPasswordController.test.ts
@@ -19,10 +19,6 @@ vi.mock('../../app/Jobs/SendPasswordResetEmailJob.js', () => ({
   SendPasswordResetEmailJob: { dispatch: mockDispatch },
 }))
 
-vi.mock('guren', async (importOriginal) => ({
-  ...((await importOriginal()) as object),
-  ...createControllerModuleMock(),
-}))
 vi.mock('@guren/core', async () => {
   const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
   return {

--- a/examples/blog/tests/controllers/LoginController.test.ts
+++ b/examples/blog/tests/controllers/LoginController.test.ts
@@ -10,10 +10,6 @@ const { mockEmit } = vi.hoisted(() => ({
   mockEmit: vi.fn(),
 }))
 
-vi.mock('guren', async (importOriginal) => ({
-  ...((await importOriginal()) as object),
-  ...createControllerModuleMock(),
-}))
 vi.mock('@guren/core', async () => {
   const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
   return {

--- a/examples/blog/tests/controllers/OAuthController.test.ts
+++ b/examples/blog/tests/controllers/OAuthController.test.ts
@@ -17,10 +17,6 @@ vi.mock('../../app/Models/User.js', () => ({
   },
 }))
 
-vi.mock('guren', async (importOriginal) => ({
-  ...((await importOriginal()) as object),
-  ...createControllerModuleMock(),
-}))
 vi.mock('@guren/core', async () => {
   const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
   return {

--- a/examples/blog/tests/controllers/PostController.test.ts
+++ b/examples/blog/tests/controllers/PostController.test.ts
@@ -61,10 +61,6 @@ vi.mock('../../app/Services/PostCacheService.js', () => ({
   PostCacheService: MockPostCacheService,
 }))
 
-vi.mock('guren', async (importOriginal) => ({
-  ...((await importOriginal()) as object),
-  ...createControllerModuleMock(),
-}))
 vi.mock('@guren/core', async () => {
   const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
   return {

--- a/examples/blog/tests/controllers/ProfileController.test.ts
+++ b/examples/blog/tests/controllers/ProfileController.test.ts
@@ -25,10 +25,6 @@ vi.mock('../../app/Mail/EmailVerificationMail.js', () => ({
   sendEmailVerificationMail: mockSendEmailVerificationMail,
 }))
 
-vi.mock('guren', async (importOriginal) => ({
-  ...((await importOriginal()) as object),
-  ...createControllerModuleMock(),
-}))
 vi.mock('@guren/core', async () => {
   const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
   return {

--- a/examples/blog/tests/controllers/RegisterController.test.ts
+++ b/examples/blog/tests/controllers/RegisterController.test.ts
@@ -28,10 +28,6 @@ vi.mock('../../app/Mail/EmailVerificationMail.js', () => ({
   sendEmailVerificationMail: mockSendEmailVerificationMail,
 }))
 
-vi.mock('guren', async (importOriginal) => ({
-  ...((await importOriginal()) as object),
-  ...createControllerModuleMock(),
-}))
 vi.mock('@guren/core', async () => {
   const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
   return {

--- a/examples/blog/tests/controllers/ResetPasswordController.test.ts
+++ b/examples/blog/tests/controllers/ResetPasswordController.test.ts
@@ -18,10 +18,6 @@ vi.mock('../../app/Models/User.js', () => ({
   },
 }))
 
-vi.mock('guren', async (importOriginal) => ({
-  ...((await importOriginal()) as object),
-  ...createControllerModuleMock(),
-}))
 vi.mock('@guren/core', async () => {
   const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
   return {

--- a/examples/blog/tests/controllers/VerifyEmailController.test.ts
+++ b/examples/blog/tests/controllers/VerifyEmailController.test.ts
@@ -19,10 +19,6 @@ vi.mock('../../app/Mail/EmailVerificationMail.js', () => ({
   sendEmailVerificationMail: mockSendEmailVerificationMail,
 }))
 
-vi.mock('guren', async (importOriginal) => ({
-  ...((await importOriginal()) as object),
-  ...createControllerModuleMock(),
-}))
 vi.mock('@guren/core', async () => {
   const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
   return {

--- a/examples/blog/tests/controllers/auth.test.ts
+++ b/examples/blog/tests/controllers/auth.test.ts
@@ -9,10 +9,6 @@ import type { Context } from '@guren/core'
 
 
 
-vi.mock('guren', async (importOriginal) => ({
-  ...((await importOriginal()) as object),
-  ...createControllerModuleMock(),
-}))
 vi.mock('@guren/core', async () => {
   const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
   return {

--- a/examples/blog/tests/controllers/inertia.test.ts
+++ b/examples/blog/tests/controllers/inertia.test.ts
@@ -28,10 +28,6 @@ function createGurenCoreMock() {
   }
 }
 
-vi.mock('guren', async (importOriginal) => ({
-  ...((await importOriginal()) as object),
-  ...createControllerModuleMock(),
-}))
 vi.mock('@guren/core', async () => {
   const actual = await vi.importActual<typeof import('@guren/core')>('@guren/core')
   return {

--- a/examples/blog/vitest.config.ts
+++ b/examples/blog/vitest.config.ts
@@ -102,14 +102,6 @@ export default defineConfig({
         find: /^bun:sqlite$/,
         replacement: resolve(rootDir, './tests/support/bun-sqlite.ts'),
       },
-      {
-        find: /^guren$/,
-        replacement: resolve(rootDir, '../../packages/core/src/index.ts'),
-      },
-      {
-        find: /^guren\/(.+)$/,
-        replacement: `${resolve(rootDir, '../../packages/core/src')}/$1`,
-      },
     ],
     dedupe: ['react', 'react-dom'],
   },

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -284,7 +284,7 @@ export interface RouteDefinition {
 }
 
 /** Chainable builder for configuring a registered route. */
-export interface RouteBuilder<M extends string = never> {
+export interface RouteBuilder<in M extends string = never> {
   name(routeName: string): RouteBuilder<M>
   /** Attach middleware to this specific route. See {@link RouteMiddlewareInput}. */
   middleware(...items: RouteMiddlewareInput<M>[]): RouteBuilder<M>
@@ -364,15 +364,14 @@ export interface ResourceRouteOptions {
   agent?: Partial<Record<ResourceAction, AgentRouteMetadata>>
 }
 
-/** Instance-based router for app-local route registration and mounting. */
-export class Router<M extends string = never> {
-  /**
-   * Without this, `M` appears only in method parameters, which TypeScript
-   * compares bivariantly, so a `Router<never>` passes as a `Router<'auth'>` and
-   * fails at `mount()`. A function-typed property is checked contravariantly:
-   * a router carrying more aliases still substitutes for one needing fewer.
-   */
-  declare readonly __middlewareAliases?: (name: M) => void
+/**
+ * Instance-based router for app-local route registration and mounting.
+ *
+ * `in M`: `M` appears only in method parameters, which TypeScript compares
+ * bivariantly, so without the annotation a `Router<never>` passes as a
+ * `Router<'auth'>` and the missing alias only surfaces at `mount()`.
+ */
+export class Router<in M extends string = never> {
   private readonly registry: RegisteredRoute[] = []
   private readonly prefixStack: string[] = []
   private readonly namedRoutes: Map<string, RegisteredRoute> = new Map()
@@ -907,7 +906,7 @@ function applyRouteContract(route: RegisteredRoute, options: RouteContractOption
   }
 }
 
-class RouterMiddlewareGroupBuilder<M extends string = never> {
+class RouterMiddlewareGroupBuilder<in M extends string = never> {
   constructor(
     private readonly router: Router<M>,
     private readonly items: readonly MiddlewareScopeEntry[],

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -374,8 +374,7 @@ export interface ResourceRouteOptions {
  * Instance-based router for app-local route registration and mounting.
  *
  * `in M` is an explicit pin, not the source of the contravariance: the
- * `RouteBuilder<M>` return positions already force it (measured). TypeScript
- * checks the annotation against the inferred variance, so it cannot go stale.
+ * `RouteBuilder<M>` return positions already force it (measured).
  */
 export class Router<in M extends string = never> {
   private readonly registry: RegisteredRoute[] = []

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -283,7 +283,13 @@ export interface RouteDefinition {
   deprecated?: boolean
 }
 
-/** Chainable builder for configuring a registered route. */
+/**
+ * Chainable builder for configuring a registered route.
+ *
+ * `in M`: `M`'s only independent occurrence is a method parameter (the
+ * `RouteBuilder<M>` returns restate it), compared bivariantly. Without the
+ * annotation a `Router<never>` passes as a `Router<'auth'>`, failing at `mount()`.
+ */
 export interface RouteBuilder<in M extends string = never> {
   name(routeName: string): RouteBuilder<M>
   /** Attach middleware to this specific route. See {@link RouteMiddlewareInput}. */
@@ -367,9 +373,9 @@ export interface ResourceRouteOptions {
 /**
  * Instance-based router for app-local route registration and mounting.
  *
- * `in M`: `M` appears only in method parameters, which TypeScript compares
- * bivariantly, so without the annotation a `Router<never>` passes as a
- * `Router<'auth'>` and the missing alias only surfaces at `mount()`.
+ * `in M` is an explicit pin, not the source of the contravariance: the
+ * `RouteBuilder<M>` return positions already force it (measured). TypeScript
+ * checks the annotation against the inferred variance, so it cannot go stale.
  */
 export class Router<in M extends string = never> {
   private readonly registry: RegisteredRoute[] = []

--- a/packages/server/src/mvc/Router.ts
+++ b/packages/server/src/mvc/Router.ts
@@ -366,6 +366,13 @@ export interface ResourceRouteOptions {
 
 /** Instance-based router for app-local route registration and mounting. */
 export class Router<M extends string = never> {
+  /**
+   * Without this, `M` appears only in method parameters, which TypeScript
+   * compares bivariantly, so a `Router<never>` passes as a `Router<'auth'>` and
+   * fails at `mount()`. A function-typed property is checked contravariantly:
+   * a router carrying more aliases still substitutes for one needing fewer.
+   */
+  declare readonly __middlewareAliases?: (name: M) => void
   private readonly registry: RegisteredRoute[] = []
   private readonly prefixStack: string[] = []
   private readonly namedRoutes: Map<string, RegisteredRoute> = new Map()

--- a/packages/server/tests/mvc/router-declaration.test.ts
+++ b/packages/server/tests/mvc/router-declaration.test.ts
@@ -3,9 +3,10 @@ import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 describe('the built declaration', () => {
-  // `in M` is what rejects a router missing an alias a registrar reads, and an
-  // app only ever reads the built .d.ts. tsc emits these declarations unbundled
-  // today and preserves it; this guards a future switch to bundled dts.
+  // `RouteBuilder`'s `in M` is what rejects a router missing an alias a
+  // registrar reads, and an app only ever reads the built .d.ts. tsc emits
+  // these declarations unbundled today and preserves it; this guards a future
+  // switch to bundled dts.
   test('should carry the contravariance annotation on Router and RouteBuilder', () => {
     const declaration = join(import.meta.dir, '../../dist/mvc/Router.d.ts')
     if (!existsSync(declaration)) {

--- a/packages/server/tests/mvc/router-declaration.test.ts
+++ b/packages/server/tests/mvc/router-declaration.test.ts
@@ -3,9 +3,9 @@ import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 describe('the built declaration', () => {
-  // `in M` is what rejects a router missing an alias a registrar reads. The
-  // source fixture cannot see it lost in emit, and an app only ever reads the
-  // built .d.ts, so a bundler dropping the annotation would go unnoticed.
+  // `in M` is what rejects a router missing an alias a registrar reads, and an
+  // app only ever reads the built .d.ts. tsc emits these declarations unbundled
+  // today and preserves it; this guards a future switch to bundled dts.
   test('should carry the contravariance annotation on Router and RouteBuilder', () => {
     const declaration = join(import.meta.dir, '../../dist/mvc/Router.d.ts')
     if (!existsSync(declaration)) {

--- a/packages/server/tests/mvc/router-declaration.test.ts
+++ b/packages/server/tests/mvc/router-declaration.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('the built declaration', () => {
+  // `in M` is what rejects a router missing an alias a registrar reads. The
+  // source fixture cannot see it lost in emit, and an app only ever reads the
+  // built .d.ts, so a bundler dropping the annotation would go unnoticed.
+  test('should carry the contravariance annotation on Router and RouteBuilder', () => {
+    const declaration = join(import.meta.dir, '../../dist/mvc/Router.d.ts')
+    if (!existsSync(declaration)) {
+      throw new Error(`Expected ${declaration}; run \`bun run build server\` before this test.`)
+    }
+
+    const source = readFileSync(declaration, 'utf8')
+    expect(source).toMatch(/declare class Router<in M extends string = never>/)
+    expect(source).toMatch(/interface RouteBuilder<in M extends string = never>/)
+  })
+})

--- a/packages/server/tests/mvc/router-middleware.types.ts
+++ b/packages/server/tests/mvc/router-middleware.types.ts
@@ -76,3 +76,55 @@ export const verifiedEmailLegacyCallback = requireVerifiedEmail({ getUser: legac
 export const unregisteredAliasRejected = new Router().aliasMiddleware('auth', auditLogger)
 // @ts-expect-error 'nope' is not a registered alias on this router
 unregisteredAliasRejected.middleware('nope')
+
+/**
+ * Method parameters are compared bivariantly, so without `Router`'s phantom
+ * property a `Router<never>` flows into a `Router<'auth'>` slot and fails at
+ * `mount()`. With it the parameter is contravariant: a router needing the
+ * alias rejects one that never registered it, and one carrying extra aliases
+ * still passes.
+ */
+export function registrarNeedingAuth(router: Router<'auth'>): void {
+  router.middleware('auth').get('/dashboard', [DemoController, 'index'])
+}
+
+// A bare `new Router()` in argument position would infer `M` from the parameter, so hold it first.
+const plainRouter = new Router()
+// @ts-expect-error a router that never aliased 'auth' cannot satisfy a registrar that reads it
+registrarNeedingAuth(plainRouter)
+
+// @ts-expect-error nor can one that registered a different alias
+registrarNeedingAuth(new Router().aliasMiddleware('guest', auditLogger))
+
+registrarNeedingAuth(new Router().aliasMiddleware('auth', auditLogger))
+registrarNeedingAuth(new Router().aliasMiddleware('auth', auditLogger).aliasMiddleware('guest', rateLimiter))
+
+/** The documented flow: capture the return, which carries the alias in its type. */
+export function documentedFlow(baseRouter: Router): void {
+  const router = baseRouter.aliasMiddleware('auth', auditLogger)
+  registrarNeedingAuth(router)
+  router.middleware('auth').group((authed) => {
+    authed.get('/dashboard', [DemoController, 'index'])
+  })
+}
+
+/** Discarding the return keeps the parameter at `Router<never>`, which the registrar rejects. */
+export function discardedReturn(baseRouter: Router): void {
+  baseRouter.aliasMiddleware('auth', auditLogger)
+  // @ts-expect-error the alias is registered at runtime but absent from `baseRouter`'s type
+  registrarNeedingAuth(baseRouter)
+}
+
+/** A registrar that needs no alias accepts any router, the direction `registerAttachmentRoutes(router)` relies on. */
+export function registrarNeedingNone(router: Router): void {
+  router.get('/health', [DemoController, 'index'])
+}
+registrarNeedingNone(new Router().aliasMiddleware('auth', auditLogger))
+
+/** The scope builder inherits the variance through the router it wraps. */
+export function scopeNeedingAuth(scope: ReturnType<Router<'auth'>['middleware']>): void {
+  scope.get('/dashboard', [DemoController, 'index'])
+}
+// @ts-expect-error a scope opened on a router without 'auth' cannot stand in for one that has it
+scopeNeedingAuth(new Router().middleware(rateLimiter))
+scopeNeedingAuth(new Router().aliasMiddleware('auth', auditLogger).middleware('auth'))

--- a/packages/server/tests/mvc/router-middleware.types.ts
+++ b/packages/server/tests/mvc/router-middleware.types.ts
@@ -1,7 +1,8 @@
 import type { MiddlewareHandler } from 'hono'
 import { requireVerifiedEmail } from '../../src/auth/email-verification'
+import type { RouteRegistration } from '../../src/http/Application'
 import { Controller } from '../../src/mvc/Controller'
-import { Router } from '../../src/mvc/Router'
+import { Router, type RouteBuilder } from '../../src/mvc/Router'
 
 /**
  * A type-only fixture: nothing here is mounted and `bun run typecheck` is the
@@ -78,9 +79,9 @@ export const unregisteredAliasRejected = new Router().aliasMiddleware('auth', au
 unregisteredAliasRejected.middleware('nope')
 
 /**
- * Method parameters are compared bivariantly, so without `Router`'s phantom
- * property a `Router<never>` flows into a `Router<'auth'>` slot and fails at
- * `mount()`. With it the parameter is contravariant: a router needing the
+ * Method parameters are compared bivariantly, so without `Router`'s `in M`
+ * annotation a `Router<never>` flows into a `Router<'auth'>` slot and fails at
+ * `mount()`. Annotated, the parameter is contravariant: a router needing the
  * alias rejects one that never registered it, and one carrying extra aliases
  * still passes.
  */
@@ -93,11 +94,51 @@ const plainRouter = new Router()
 // @ts-expect-error a router that never aliased 'auth' cannot satisfy a registrar that reads it
 registrarNeedingAuth(plainRouter)
 
-// @ts-expect-error nor can one that registered a different alias
+/**
+ * The residual hole, pinned as compiling: an inline `new Router()` has no
+ * annotation to fix `M`, so it is inferred from the parameter and the missing
+ * alias still reaches `mount()`. Contravariance cannot close this; only a
+ * router whose `M` is already fixed is checked.
+ */
+registrarNeedingAuth(new Router())
+
+// @ts-expect-error 'guest' and 'auth' are disjoint literals, rejected either way round — not a variance case
 registrarNeedingAuth(new Router().aliasMiddleware('guest', auditLogger))
 
 registrarNeedingAuth(new Router().aliasMiddleware('auth', auditLogger))
 registrarNeedingAuth(new Router().aliasMiddleware('auth', auditLogger).aliasMiddleware('guest', rateLimiter))
+
+/** A `RouteBuilder` carries the same alias set, and the same annotation. */
+export function builderNeedingAuth(builder: RouteBuilder<'auth'>): void {
+  builder.middleware('auth')
+}
+const plainBuilder = new Router().get('/health', [DemoController, 'index'])
+// @ts-expect-error a builder from a router without 'auth' cannot satisfy one that reads it
+builderNeedingAuth(plainBuilder)
+builderNeedingAuth(new Router().aliasMiddleware('auth', auditLogger).get('/dashboard', [DemoController, 'index']))
+
+/**
+ * `RouteRegistration` names `Router`: an entry registrar is handed a bare one
+ * and registers the aliases itself, so a registrar that annotates aliases does
+ * not fit that slot. `createApp({ routes })` takes the outer one.
+ */
+// @ts-expect-error a registrar reading 'auth' cannot be the app's entry registrar
+export const authRegistrarAsEntry: RouteRegistration = registrarNeedingAuth
+
+/** `Router<string>` asks for every possible alias, so nothing satisfies it. Spell "any aliases" `Router`. */
+export function registrarNeedingEveryAlias(router: Router<string>): void {
+  router.get('/health', [DemoController, 'index'])
+}
+// @ts-expect-error a router carrying one alias does not carry all of them
+registrarNeedingEveryAlias(new Router().aliasMiddleware('auth', auditLogger))
+
+/** A `group()` callback cannot annotate aliases the router it is opened on lacks. */
+export function groupCallbackWideningAliases(router: Router<'auth'>): void {
+  // @ts-expect-error the callback reads 'guest', which this router never registered
+  router.middleware('auth').group((inner: Router<'auth' | 'guest'>) => {
+    inner.get('/dashboard', [DemoController, 'index'])
+  })
+}
 
 /** The documented flow: capture the return, which carries the alias in its type. */
 export function documentedFlow(baseRouter: Router): void {
@@ -121,7 +162,7 @@ export function registrarNeedingNone(router: Router): void {
 }
 registrarNeedingNone(new Router().aliasMiddleware('auth', auditLogger))
 
-/** The scope builder inherits the variance through the router it wraps. */
+/** The scope builder carries the same annotation, and the router it wraps would give it anyway. */
 export function scopeNeedingAuth(scope: ReturnType<Router<'auth'>['middleware']>): void {
   scope.get('/dashboard', [DemoController, 'index'])
 }

--- a/packages/server/tests/mvc/router-middleware.types.ts
+++ b/packages/server/tests/mvc/router-middleware.types.ts
@@ -79,11 +79,10 @@ export const unregisteredAliasRejected = new Router().aliasMiddleware('auth', au
 unregisteredAliasRejected.middleware('nope')
 
 /**
- * Method parameters are compared bivariantly, so without `Router`'s `in M`
- * annotation a `Router<never>` flows into a `Router<'auth'>` slot and fails at
+ * Method parameters are compared bivariantly, so without `RouteBuilder`'s
+ * `in M` a `Router<never>` flows into a `Router<'auth'>` slot and fails at
  * `mount()`. Annotated, the parameter is contravariant: a router needing the
- * alias rejects one that never registered it, and one carrying extra aliases
- * still passes.
+ * alias rejects one that never registered it, one with extra aliases passes.
  */
 export function registrarNeedingAuth(router: Router<'auth'>): void {
   router.middleware('auth').get('/dashboard', [DemoController, 'index'])
@@ -149,20 +148,13 @@ export function documentedFlow(baseRouter: Router): void {
   })
 }
 
-/** Discarding the return keeps the parameter at `Router<never>`, which the registrar rejects. */
-export function discardedReturn(baseRouter: Router): void {
-  baseRouter.aliasMiddleware('auth', auditLogger)
-  // @ts-expect-error the alias is registered at runtime but absent from `baseRouter`'s type
-  registrarNeedingAuth(baseRouter)
-}
-
 /** A registrar that needs no alias accepts any router, the direction `registerAttachmentRoutes(router)` relies on. */
 export function registrarNeedingNone(router: Router): void {
   router.get('/health', [DemoController, 'index'])
 }
 registrarNeedingNone(new Router().aliasMiddleware('auth', auditLogger))
 
-/** The scope builder carries the same annotation, and the router it wraps would give it anyway. */
+/** Exercises the scope-builder path; its contravariance comes from the private `Router<M>` field. */
 export function scopeNeedingAuth(scope: ReturnType<Router<'auth'>['middleware']>): void {
   scope.get('/dashboard', [DemoController, 'index'])
 }

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -21,8 +21,6 @@ export default defineConfig({
       { find: /^@guren\/orm$/, replacement: resolveFromRoot('../packages/orm/src/index.ts') },
       { find: /^@guren\/orm\/(.+)$/, replacement: resolveFromRoot('../packages/orm/src') + '/$1' },
       { find: /^@guren\/plugin-cloudflare$/, replacement: resolveFromRoot('../packages/plugin-cloudflare/src/index.ts') },
-      { find: /^guren$/, replacement: resolveFromRoot('../packages/core/src/index.ts') },
-      { find: /^guren\/(.+)$/, replacement: resolveFromRoot('../packages/core/src') + '/$1' },
     ],
   },
   test: {


### PR DESCRIPTION
## Summary

- **`Router<M>` did not check its alias parameter.** `M` appeared only in method parameter positions, so method bivariance let `Router<never>` flow into a `Router<'auth'>` parameter and the registrar failed at `mount()` instead of at compile time. A phantom `declare readonly` function-typed member makes `Router` contravariant in `M`: `Router<never>` and `Router<'guest'>` are now rejected where `Router<'auth'>` is required, while a router with more aliases is still accepted. Proven by `@ts-expect-error` cases in the existing type-level fixture; the phantom emits no JS and lands in `dist/mvc/Router.d.ts`.
- **Eleven blog controller tests mocked a `guren` package that no longer exists.** Removed the dead mocks; the suite is 116/116 before and after.

## Test plan

- `bun run typecheck` (full chain including templates and examples): green
- `bun run lint`: green
- `bun test packages/server/tests/mvc`: 190 pass
- `bun run test:examples`: green

## Review follow-ups (code-review + simplify passes)

- The phantom member is replaced by TypeScript's `in M` variance annotation on `Router`, `RouteBuilder` and the group builder; `RouteBuilder` is the load-bearing one and had the same hole.
- A test pins the emitted `dist` declaration; the fixture documents the residual inference hole (`new Router()` inline) and the `RouteRegistration` rejection.
- Changeset raised to minor for server and core; docs callouts cover the cross-registrar case; retired `guren` vitest aliases removed from blog, web and api.
