### PR TITLE
docs: draft RFCs 0023-0026 from the 2026-09 design review

### DIFF
--- a/rfcs/0023-container-only-service-resolution.md
+++ b/rfcs/0023-container-only-service-resolution.md
@@ -1,0 +1,400 @@
+# RFC: Container-Only Service Resolution
+
+**Author:** 7nohe
+**Date:** 2026-09-11
+**Status:** Draft
+
+## Problem
+
+Every `Application` owns a DI container: the constructor creates one
+(`packages/server/src/http/Application.ts:506`), binds `app`, `hono`, `auth`
+and `router` into it (`:517-520`), and hands it to the router at mount time
+(`:658`, `RouterMountOptions.container`, `mvc/Router.ts:336`). Providers bind
+their managers under the keys `ServiceBindings` names
+(`container/bindings.ts:25-57`). Then the constructor's last statement
+publishes that container into a module-level slot (`setContainer`, `:585`),
+and beside it thirteen more module-level slots hold the services the
+container already binds. The consumers read the slots.
+
+What exists today (verified at `30a26e94`):
+
+| Slot | Declared at | Setter / getter | Who sets it | Who reads it | Container key |
+|---|---|---|---|---|---|
+| `globalContainer` | `container/Container.ts:336` | `setContainer` `:338` / `getContainer` `:342` | `Application` constructor `:585` | `Job.make()` (`queue/Job.ts:45`), `resolve()` (`Container.ts:349`), scaffold `config/attachments.ts` (`getContainer().make('storage')`) | (is the container) |
+| `globalGate` | `authorization/Gate.ts:334` | `setGate` `:340` / `getGate` `:344` | `AuthorizationServiceProvider.ts:11` | `Controller.authorize/can` (`mvc/Controller.ts:215,220`), `authorization/middleware.ts:24,71,134`, `defineGate`/`can`/`cannot`/`authorize` (`Gate.ts:353-365`), blog template `AuthorizationProvider.boot()` | `gate` (`AuthorizationServiceProvider.ts:12`); no reader in `packages/*/src` |
+| `globalEncrypter` | `encryption/Encrypter.ts:207` | `setEncrypter` `:213` / `getEncrypter` `:217` | nobody in `packages/` | `encrypt()` `:225`, `decrypt()` `:230` | `encrypter` (`EncryptionServiceProvider.ts:12`) |
+| `globalMailManager` | `mail/Mail.ts:211` | `setMailManager` `:214` / `getMailManager` `:218` | scaffold `MailProvider.boot()` (`cli/templates/scaffold/mail/.../MailProvider.ts:21`), `examples/blog` `EventServiceProvider.ts:52` | `SendMailJob.handle()` `:229` | `mail` (`MailServiceProvider.ts:7`) |
+| `globalDriver` (queue) | `queue/Job.ts:6` | `setQueueDriver` `:8` / `getQueueDriver` `:12` | `QueueManager.driver()` on the *first* resolution of the default driver only (`queue/QueueManager.ts:48-50`), `setDefaultDriver()` `:84`, `@guren/core` attachments engine on every queued attach (`core/src/attachments/engine.ts:871`) | `Job.dispatch()` `:58`, `Mail.queue()` `:187`, `guren queue:work` (`cli/src/queue.ts:172`), attachments engine `:874` | `queue` (`QueueServiceProvider.ts:7`); nothing in `packages/*/src` calls `make('queue')` |
+| `globalI18n` | `i18n/I18nManager.ts:143` | `setI18n` `:151` / `getI18n` `:156` / `tryGetI18n` `:164` | nobody in `packages/` | `t()`/`tc()` `:169-175`, `Controller.#resolveI18n` after the container (`Controller.ts:334-340`), `detectLocaleMiddleware` default (`http/middleware/detect-locale.ts:145`) | `i18n` (`I18nServiceProvider.ts:40`) |
+| `globalLogManager` | `logging/LogManager.ts:192` | `setLogManager` `:194` / `getLogManager` `:198` | nobody in `packages/` | nobody in `packages/*/src` | `log` (`LogServiceProvider.ts:7`) |
+| `globalNotificationManager` | `notifications/NotificationManager.ts:322` | `setNotificationManager` `:324` / `getNotificationManager` `:328` | nobody in `packages/` | nobody in `packages/*/src` | `notifications` (`NotificationServiceProvider.ts:7`) |
+| `SendNotificationJob.notificationManager` (static) | `NotificationManager.ts:253` | `registerQueueJob()` `:223` | `NotificationServiceProvider.boot()` `:13-15` | `SendNotificationJob.handle()` `:256` | same |
+| `globalBroadcastManager` | `broadcasting/BroadcastManager.ts:521` | `setBroadcastManager` `:523` / `getBroadcastManager` `:527` | nobody in `packages/` | nobody in `packages/*/src` | `broadcast` (`BroadcastServiceProvider.ts:7`) |
+| `globalExceptionHandler` | `errors/ExceptionHandler.ts:195` | `setExceptionHandler` `:197` / `getExceptionHandler` `:201` | nobody in `packages/` | nobody in `packages/*/src` (`ErrorServiceProvider.boot()` wires `hono.onError` from the binding, `:13-15`) | `exception.handler` |
+| `documentOptions`, `defaultSsrRenderer` | `mvc/inertia/InertiaEngine.ts:96,111` | `setInertiaDocument` `:105` / `setInertiaSsrRenderer` `:119` (no getters) | templates' `src/app.ts` at module scope, `web/src/app.ts:23`, the Workers entry `plugin-cloudflare` generates (`build.ts:1130`) | the engine, `:478` and `:335` | none |
+| `globalRegistry` (shared props) | `mvc/inertia/shared.ts:115` | `setInertiaSharedProps` `:140` / `getInertiaSharedPropsResolver` `:151` | `examples/blog/config/inertia.ts:15` | `resolveSharedInertiaProps` | `inertia.sharedProps`, container-scoped registry with the global as fallback (`:111-134`) |
+| `defaultStore` (rate limit) | `http/middleware/rate-limit.ts:232` | `getDefaultStore()` `:234`, no setter | lazily, first middleware without `store` | `createRateLimitMiddleware` `:257` | none |
+| `defaultCandidates`, `manifestCache` | `http/vite-assets.ts:29-30` | `__resetViteAssetCache` `:33` | first render | manifest resolution | none |
+| `activeEngine` (attachments, `@guren/core`) | `core/src/attachments/engine.ts:1358` | `setActiveAttachmentEngine` `:1361` / `getActiveAttachmentEngine` `:1370` | `configureAttachments()` | the delivery route | none |
+
+The `global*` variables are module-private; only the `set*`/`get*` pairs and
+the functional helpers built on them are public, all through
+`packages/server/src/index.ts` (`:181-182`, `:525-526`, `:558-559`,
+`:646-647`, `:674-678`, `:778-779`, `:811-812`, `:842-844`, `:872-874`,
+`:919-924`, `:960-963`) and from there `@guren/core` (`core/src/index.ts:1`).
+
+Five of the slots (log, notifications, broadcast, exception handler, and the
+`gate` *binding*) have a setter or a getter nobody in the framework calls.
+The rest are load-bearing, and that is where the defects live.
+
+### What it costs today
+
+- **Two `Application`s in one process are last-writer-wins.**
+  `TestApp.create()` constructs `new Application(...)` and boots it
+  (`packages/testing/src/test-app.ts:427-437`). Boot runs
+  `AuthorizationServiceProvider.register()`, which is `setGate()`. Two
+  `TestApp`s alive in one `bun test` process share one `globalGate`: the
+  policies the first app registered are consulted by nobody once the second
+  boots, because `Controller.authorize()` reads `getGate()` (`Controller.ts:215`),
+  not the `gate` its own container binds, and not `this.make('gate')`, a
+  helper the same class already has (`Controller.ts:189-195`).
+  `registerQueueJob()` does the same to the notification job's static field,
+  and `Application.ts:585` to the container itself.
+- **The same service has two resolution paths, so a half-configured state is
+  the normal state.** `EncryptionServiceProvider` binds `encrypter` and never
+  calls `setEncrypter()`, so `encrypt()`/`decrypt()` throw
+  `Encrypter not initialized` in every app that did not wire the global by
+  hand. `I18nServiceProvider` binds `i18n` and passes the manager to
+  `detectLocaleMiddleware` explicitly (`:60`) without calling `setI18n()`, so
+  `t()` throws in a `createApp({ i18n })` app while `this.t()` in a controller
+  works (container first, `Controller.ts:335`). `QueueServiceProvider` binds a
+  manager; `Job.dispatch()` reads a driver that only exists once *something*
+  resolved the default driver, which is why the attachments engine reasserts
+  the global on every dispatch (`engine.ts:867-871`) and why the scaffold's
+  `MailProvider` needs a `boot()` whose only job is `setMailManager()`.
+- **Tests need reset seams.** `clearJobRegistry`, `clearNotificationRegistry`,
+  `resetWarnOnce`, `__resetViteAssetCache` and the documented
+  `setInertiaSsrRenderer(undefined)` ("test isolation", `InertiaEngine.ts:117`)
+  exist because state outlives its app. Across `packages/*/{src,tests}`,
+  `setQueueDriver(` appears 16 times and `clearJobRegistry(` 14.
+- **Workers and Lambda are fine per isolate, and the design still cannot
+  express a request scope.** `Container.scoped()`/`scopedAsync()`
+  (`Container.ts:225,235`) push a `Map` onto `scopedInstances` (`:20`), a
+  stack; two overlapping async requests would interleave pushes and pops.
+  Their only callers are `packages/server/tests/container/container.test.ts`.
+  Everything request-scoped today rides the Hono context instead
+  (`AUTH_CONTEXT_KEY`, `http/middleware/auth.ts:67`; `LOCALE_CONTEXT_KEY`,
+  `detect-locale.ts:143`; the agent principal, keyed on the `Request` object,
+  `internal/agent-principal.ts:1-8`).
+
+### What already points the right way
+
+Cache, events, storage, scheduler, health, OAuth and sessions (RFC 0020) have
+no global slot at all: they are container-only and no harder to use.
+`Command` receives its container in the constructor (`console/Command.ts:21-23`)
+and the scaffolded `src/console.ts` passes `app.container`. Shared Inertia
+props keep a container-scoped registry with the global as a fallback for
+bare-Hono apps (`shared.ts:111-134`). `Controller.#resolveI18n` reads the
+container before the global (`Controller.ts:334-340`). `createFacade(container,
+key)` re-resolves on every access (`facades/index.ts:8-21`); five guides
+document `createFacades(app.container)` and nothing under `packages/`,
+`examples/` or `web/src` calls it. This RFC applies the established pattern
+to the rest.
+
+## Proposed Solution
+
+One rule: a service is resolved from the container of the `Application` that
+owns the request, the job, or the command. No consumer inside `packages/`
+reads a module-level slot. The public `set*`/`get*` functions and the
+functional helpers built on them stay for the deprecation window as shims
+over the *default application's* container, then go at the next major.
+
+### 1. Keys
+
+`ServiceBindings` (`container/bindings.ts`) already names every service in
+the table: `gate`, `encrypter`, `mail`, `queue`, `log`, `i18n`,
+`notifications`, `broadcast`, `exception.handler`, `inertia.sharedProps`.
+Three keys are added, all bound by `Application` from `createApp()` options:
+
+```ts
+// packages/server/src/container/bindings.ts
+export interface ServiceBindings {
+  // ...existing keys unchanged
+  /** `createApp({ inertia: { document } })`; read by InertiaEngine instead of the module slot. */
+  'inertia.document': InertiaDocumentOptions
+  /** `createApp({ inertia: { ssrRenderer } })`; per-call `ssr.render` still wins. */
+  'inertia.ssrRenderer': InertiaSsrRenderer
+  /** Bound by `configureAttachments()` on the app it is given (see §4). */
+  attachments: AttachmentEngine
+}
+```
+
+The rate-limit default store becomes one `MemoryRateLimitStore` per
+middleware instance (constructed inside `createRateLimitMiddleware`), which is
+what the `store` option already does; a process-wide bucket shared by every
+limiter that omitted `store` was never intended. `vite-assets` memoizes
+filesystem reads, not a service, and stays as is.
+
+### 2. How a consumer gets its container
+
+| Consumer | Today | After |
+|---|---|---|
+| Controller | `_container` set by `Router.ts:1410`; `authorize()` ignores it | `authorize()`/`can()` use `this.make('gate')`; `this.t()` drops the `tryGetI18n()` fallback |
+| Middleware (`can()`, `authorize()` in `authorization/middleware.ts`, `detectLocaleMiddleware`, rate limit) | `getGate()`, `tryGetI18n()` | `getRequestContainer(ctx)` (below) |
+| Job | `new JobClass()` in `Worker.ts:115`; `Job.make()` reads `getContainer()` | `Worker` takes `{ container }`, calls `instance.setContainer()` before `handle()`; `Job.make()` reads it |
+| Console command | `this.container` (`Command.ts:21`) | unchanged |
+| Provider | `this.container` | unchanged; providers stop calling `set*()` |
+| Module-scope and provider-`boot()` helpers (`encrypt()`, `t()`, `can()`, `defineGate()`, `Job.dispatch()`, `resolve()`) | the module slot | the default application's container (§3) |
+
+The request accessor:
+
+```ts
+// packages/server/src/http/request-container.ts
+export const CONTAINER_CONTEXT_KEY = 'guren.container'
+
+declare module 'hono' {
+  interface ContextVariableMap {
+    [CONTAINER_CONTEXT_KEY]: Container
+  }
+}
+
+/** The container of the Application serving `ctx`; throws off an Application (bare Hono). */
+export function getRequestContainer(ctx: { get: (key: string) => unknown }): Container
+export function tryGetRequestContainer(ctx: { get: (key: string) => unknown }): Container | undefined
+```
+
+`Application.mountSecurityDefaults()` (`Application.ts:763`) already installs
+the one middleware an app cannot get in front of; `ctx.set(CONTAINER_CONTEXT_KEY,
+this.container)` goes first in that chain. Same shape as the auth context
+and the locale: the context is the request scope Guren already has.
+
+### 3. Functional helpers resolve the default application, not `AsyncLocalStorage`
+
+`encrypt()`, `t()`, `can()`, `defineGate()`, `Job.dispatch()` and `resolve()`
+have no handle to pass. Two designs were weighed: `AsyncLocalStorage`
+(`app.fetch()` runs the request inside `store.run(container, ...)`, helpers
+read `store.getStore()`), or a default application (the container the
+constructor publishes today, `Application.ts:585`, given a name and a
+contract). The default application is chosen:
+
+1. The helpers are called where no request is running. `setInertiaDocument`
+   runs at module scope in every template; `defineGate()` runs in a
+   provider's `boot()` (`examples/agents/app/Providers/AuthProvider.ts:38`);
+   `guren queue:work` dispatches with no HTTP context at all. An async store
+   has nothing to return there, so the fallback to a default application is
+   needed anyway, and then it is the mechanism.
+2. The repo already avoids the dependency where it can. The agent principal
+   seam keys on the `Request` object precisely so it "needs no
+   `AsyncLocalStorage` (identical on workerd and Bun)"
+   (`internal/agent-principal.ts:6`); the ORM imports `node:async_hooks` on
+   demand so it "stays off the module graph of a Workers or Lambda bundle"
+   (`orm/src/adapters/drizzle-adapter.ts:233`). Workers need `nodejs_compat`
+   for it (`plugin-cloudflare/src/build.ts:1345` sets it; a user-written
+   `wrangler.jsonc` may not).
+3. Anything inside a request has a better handle, the context (§2); the
+   ambient path is for the residue, and a plain default covers it.
+
+Contract:
+
+```ts
+// packages/server/src/http/default-application.ts
+/** The most recently constructed Application, as today; `null` before any exists. */
+export function defaultApplication(): Application | null
+/** Opt-in override for a process that constructs several and wants the ambient one chosen, not last. */
+export function useAsDefaultApplication(app: Application): void
+/** @internal test seam; replaces every `set*(undefined)` and `clear*()` reset. */
+export function resetDefaultApplication(): void
+/** The default application's container; throws the same "not initialized" error the getters throw today. */
+export function defaultContainer(): Container
+```
+
+Last-constructed stays the rule because that is what a sequential
+`bun test` process needs: each file's `TestApp` is the live one. The hazard
+is two *live* apps plus an ambient call, so constructing a second
+`Application` while a first exists sets a flag, and the first ambient call
+after that warns once (`warnOnce('ambient-application-ambiguous', ...)`),
+naming `useAsDefaultApplication()` and the explicit forms.
+
+The explicit forms are what exists: `container.make(key)`, `this.make(key)`
+in controllers, jobs and commands, `createFacades(container)`. `t()` keeps
+its signature; a request-aware translation already exists as
+`getRequestTranslator(ctx)` (`detect-locale.ts:20`). `Job.dispatch()` gains
+its explicit twin on the manager, which is where the driver lives:
+
+```ts
+// packages/server/src/queue/QueueManager.ts
+class QueueManager {
+  /** Explicit form of `JobClass.dispatch(payload, options)`. */
+  dispatch<T>(JobClass: JobClass<T>, payload: T, options?: JobOptions): Promise<string>
+}
+// Job.dispatch(payload, options) === defaultContainer().make('queue').dispatch(this, payload, options)
+```
+
+`QueueManager.driver()` stops publishing a global (`QueueManager.ts:48-50`,
+`:84`); `guren queue:work` resolves `container.make('queue').driver()` from the
+app it boots (`cli/src/queue.ts:155-176`) and passes that container to the
+`Worker`.
+
+### 4. Providers own the binding; nothing else writes
+
+- `AuthorizationServiceProvider.register()` binds `gate` and drops `setGate()`.
+- `SendMailJob.handle()` uses `this.make('mail')`; the scaffold `MailProvider`
+  loses its `boot()`; `Mail.queue()` resolves `queue` through the manager it
+  was built from (`Mail.ts:244`), so `MailManager` gains the container it is
+  bound with.
+- `SendNotificationJob` uses `this.make('notifications')`; the static field
+  and `registerQueueJob()`'s assignment go.
+- `encrypt()`/`decrypt()` read `defaultContainer().make('encrypter')`. This
+  is the one change that turns a throw into a working call for every
+  scaffolded app.
+- `t()`/`tc()` read `defaultContainer().make('i18n')`; `detectLocaleMiddleware`
+  defaults `i18n` to `tryGetRequestContainer(c)?.makeOptional('i18n')`.
+- `InertiaEngine` reads `inertia.document` and `inertia.ssrRenderer` from
+  `getRequestContainer(ctx)`; `setInertiaDocument()`/`setInertiaSsrRenderer()`
+  become shims that bind on the default application. The Workers entry
+  `plugin-cloudflare` generates switches to the option in the same PR.
+- `configureAttachments({ app })` binds `attachments` on that app; the
+  delivery route resolves it from the request container. The scaffold's
+  `storage: () => getContainer().make('storage')` becomes
+  `storage: (container) => container.make('storage')`: the factory receives
+  the container it is bound on.
+- `Container.scoped()`/`scopedAsync()` are left alone in Part 1 (Open
+  Question 2).
+
+### 5. The shims
+
+Every exported setter and getter keeps its signature and forwards:
+
+```ts
+// packages/server/src/authorization/Gate.ts (pattern for all nine pairs)
+/** @deprecated since 2.23.0, removed in 3.0.0. Bind `gate` on the app's container; providers already do. */
+export function setGate(gate: Gate): void {
+  warnDeprecated('global-service-setters', 'setGate')
+  defaultContainer().instance('gate', gate)
+}
+/** @deprecated since 2.23.0, removed in 3.0.0. Use `this.make('gate')`, `getRequestContainer(ctx)`, or `defaultContainer()`. */
+export function getGate(): Gate {
+  warnDeprecated('global-service-getters', 'getGate')
+  return defaultContainer().make('gate')
+}
+```
+
+`warnDeprecated(id, symbol)` is `warnOnce` keyed per symbol in the policy's
+message format (`Seeder.ts:27-33` is the existing shape). The module-private
+`let global*` declarations go in Part 2; only the exported functions are
+under the policy's window.
+
+| Deprecation id | Symbols | Replacement |
+|---|---|---|
+| `global-service-setters` | `setGate`, `setEncrypter`, `setMailManager`, `setQueueDriver`, `setI18n`, `setLogManager`, `setNotificationManager`, `setBroadcastManager`, `setExceptionHandler`, `setContainer`, `setInertiaDocument`, `setInertiaSsrRenderer`, `setInertiaSharedProps` | `container.instance(key, value)` in a provider; `createApp({ inertia })` for the two Inertia options; `shareInertiaProps(fn, container)` |
+| `global-service-getters` | `getGate`, `getEncrypter`, `getMailManager`, `getQueueDriver`, `getI18n`, `tryGetI18n`, `getLogManager`, `getNotificationManager`, `getBroadcastManager`, `getExceptionHandler`, `getContainer`, `getInertiaSharedPropsResolver` | `this.make(key)`, `getRequestContainer(ctx).make(key)`, `defaultContainer().make(key)` |
+| `attachments-active-engine` (`@guren/core`) | `setActiveAttachmentEngine`, `getActiveAttachmentEngine` | `configureAttachments({ app })`, `container.make('attachments')` |
+
+Not deprecated: `encrypt`, `decrypt`, `t`, `tc`, `can`, `cannot`,
+`defineGate`, `authorizeAbility`, `resolve`, `Job.dispatch`, `Job.make`. Same
+signatures, resolving from the default container (`resolve(key)` becomes
+`defaultContainer().make(key)` outright).
+
+### Implementation plan
+
+Referencing `RFC 0023` in each PR:
+
+0. **Seams, no behaviour change** (`@guren/server`, minor): `getRequestContainer`
+   and the context stamp; `Worker` `{ container }` option and
+   `Job.setContainer()`; `QueueManager.dispatch()`; `defaultApplication()`
+   family over the slot `Application.ts:585` already writes; the three
+   bindings and `createApp({ inertia })`. Additive.
+1. **Consumers read the container, global as fallback** (server + core + cli
+   scaffolds, minor): every row of §4, each reading its container first and
+   the old slot second, so an app that still calls `setX()` by hand keeps
+   working. Providers stop calling setters. The scaffold `MailProvider` and
+   `config/attachments.ts` change; `guren queue:work` resolves through the
+   container. Test: two `Application`s booted in one process, each with a
+   different policy for the same model, each authorizes by its own. Core
+   gets a changeset (the allowlist rule in `.claude/rules/common-pitfalls.md`).
+2. **Deprecate** (server + cli, minor, target `2.23.0`): stages 1 to 5 of
+   `contributing/deprecation-policy.md`. JSDoc `@deprecated` on the 25
+   symbols; `warnDeprecated` on first call; the three
+   `packages/cli/src/deprecations.ts` entries above, `detect()` scanning
+   import specifiers from `@guren/core` and `@guren/server`; CHANGELOG
+   `### Deprecated`; the codemod (Migration Path). Part 1's fallback reads
+   go here: the shims now write to the container, so no slot is left to read.
+3. **Remove** (server `3.0.0` and core `2.0.0`, same release): delete the
+   shims, `let global*`, `SendNotificationJob.notificationManager`, and the
+   `clear*`/`reset*` seams that existed only for them. Core majors with
+   server because `core/src/index.ts:1` re-exports every removed symbol;
+   `audit:core-semver` fails a plan that majors `@guren/server` alone
+   (`.claude/rules/common-pitfalls.md`: "The version core sits on is
+   independent; the bump type is not"). Two minors at least separate Part 2
+   from Part 3 (stable-API rule).
+
+## Alternatives Considered
+
+- **Keep the singletons and delete the container bindings.** Honest about
+  what runs today, and five bindings would go unnoticed. It forecloses a
+  second `Application` per process (the testing package's model) and any
+  request scope, and contradicts `Command`, `Controller.make()`,
+  `createFacades()` and five guides, all of which hand out a container.
+- **Facades as the resolution rule.** `createFacades()` exists
+  (`facades/index.ts:74-87`) with no caller outside docs. A facade is a
+  consumer style over a container, not a way to find one; it needs the
+  container this RFC supplies, and it stays as the explicit form.
+- **`AsyncLocalStorage` as the only ambient.** Rejected as the sole
+  mechanism in §3: module-scope and `boot()` callers have no async context,
+  and the repo has twice chosen not to depend on it for the serverless
+  bundles. It remains the candidate for a real request scope (Open Question 1).
+- **A container parameter on every functional helper.**
+  `t(key, replacements, container)` in a template, `encrypt(value, options,
+  container)` in a model hook: a second explicit form beside
+  `container.make(key)` and the facades.
+- **Keep the setters, make them per-app (a `WeakMap<Application, Gate>`).**
+  Still a slot a provider must remember to write, still two paths. And the
+  symbols are documented (`getGate` in four guides, `getContainer` in three,
+  `setInertiaDocument` in four), so the deprecation policy applies either way.
+
+## Migration Path
+
+Per `contributing/deprecation-policy.md`, Part 2 registers the three
+deprecations (`bunx guren upgrade --check-only` lists affected files) and
+`bunx guren upgrade` applies the codemod below. What an app changes:
+
+| App code today | After | Codemod |
+|---|---|---|
+| `getGate().policy(Post, PostPolicy)` in a provider `boot()` (blog template) | `this.container.make('gate').policy(Post, PostPolicy)` | Yes: inside a class extending `ServiceProvider`, `getGate()` → `this.container.make('gate')`; same for the other getters by key |
+| `setMailManager(manager)` in a provider that also binds `mail` (scaffold) | delete the call | Yes, when the same class binds the key; otherwise reported |
+| `setMailManager(m)` in a provider that binds nothing (`examples/blog`) | `this.container.instance('mail', m)` | Yes |
+| `setInertiaDocument({...})` at module scope with an inline literal | `createApp({ inertia: { document: {...} } })` | Yes, when `createApp(` is in the same file; otherwise reported |
+| `getContainer().make('storage')` in `config/attachments.ts` | `(container) => container.make('storage')` | Yes, inside a `configureAttachments()` factory; elsewhere reported |
+| A custom `Job` reading `getContainer()` in `handle()` | `this.make(key)` | Yes, inside a class extending `Job` |
+| Tests calling `setGate`/`setQueueDriver` to inject a fake | `app.container.instance('gate', fake)` or `container.fake(key, fake)` | Reported only |
+
+The codemod is idempotent, AST-based (`@babel/parser`, as `deprecations.ts`
+already uses) and tested against `examples/blog`. Timeline: deprecated in the
+Part 2 minor, removed at server `3.0.0` / core `2.0.0`, two minors later at
+the earliest.
+
+## Open Questions
+
+1. **Request scope semantics.** With the container on the context, the next
+   step is a per-request child container (`container.createChild()` under
+   `CONTAINER_CONTEXT_KEY`) so a request translator or the auth context can
+   be bindings rather than context keys. Leaning: this RFC defines only the
+   stamp; the scope is its own RFC once one service needs it.
+2. **`Container.scoped()` / `scopedAsync()`.** Stack-based, unsafe under
+   concurrent requests, zero callers outside their test. Remove in Part 3, or
+   reimplement over question 1's child container? Leaning: remove.
+3. **Default application: last-constructed or first?** Last matches
+   sequential tests and today's `:585`; first would protect a long-lived
+   server from a stray `new Application()` in a plugin. Is the warn-once on
+   a second construction enough?
+4. **`inertia.document` as a `createApp()` option versus a provider
+   binding.** The option reads well in a scaffold; the generated Workers entry
+   (`build.ts:1130`) calls the setter after importing the app, which the
+   option cannot express. Keep both, or have the plugin bind directly?
+5. **The class registries.** `jobRegistry` (`Job.ts:129`) and
+   `notificationRegistry` (`notifications/registry.ts:13`) map wire names to
+   classes and are per process by design. Out of scope unless two apps in one
+   process need conflicting `jobName`s.
+6. **`getContainer()` after removal.** `defaultContainer()` is the successor.
+   Keep `getContainer` as an alias for the three guides and the attachments
+   scaffold, or remove it? Leaning: remove; the codemod covers the scaffold.

--- a/rfcs/0024-single-runtime-package.md
+++ b/rfcs/0024-single-runtime-package.md
@@ -1,0 +1,362 @@
+# RFC: One Runtime Package
+
+**Author:** 7nohe
+**Date:** 2026-09-11
+**Status:** Draft
+
+## Problem
+
+Guren publishes its runtime under two names. `@guren/server` holds the source;
+`@guren/core` is the name every doc, template and plugin imports. The split was
+meant to give application code one stable entry point while the server package
+kept its own release line. What it produces instead is two version numbers for
+one API, a dependency cycle, and a growing set of gates whose only job is to
+keep the two names from contradicting each other.
+
+What exists today (verified at `30a26e94`):
+
+- **`@guren/core` is a re-export barrel plus the database-backed stores.**
+  `packages/core/src/index.ts:1` is `export * from '@guren/server'`; lines
+  2-90 are an explicit allowlist from `@guren/orm`; lines 91-127 export the
+  stores and attachment engine that need the ORM (`session-store.ts`,
+  `api-token-store.ts`, `oauth-state-store.ts`, `session-manager.ts`,
+  `attachments/engine.ts`, all importing `Model` from `@guren/orm`). Every
+  subpath is a shim over the matching server subpath: `runtime.ts`,
+  `agent.ts`, `jsx-runtime.ts` are `export *`; `lambda.ts` and `redis.ts`
+  restate server's names as allowlists; `vite.ts` re-exports the default.
+- **The two versions are independent.** `packages/core/package.json:3` says
+  `1.16.0`; `packages/server/package.json` says `2.21.0`. Core depends on
+  server through a caret (`"@guren/server": "^2.21.0"`, `core/package.json:93`),
+  so `changeset version` rewrites the range on a server major and leaves
+  core's bump type alone. That is how server 2.0.0 (2026-08-05, RFC 0006
+  removals) reached users as core 1.5.0, a minor, through every `^1.4.0`
+  (`scripts/smoke/core-semver-audit.ts:5-8`, and the "core-semver" paragraph
+  of `.claude/rules/common-pitfalls.md`). `audit:core-semver` exists to
+  refuse that plan; the "fixed group is not the fix" paragraph exists to
+  explain why the obvious changesets setting makes it worse. Release tags
+  follow server (`v2.21.0`), so "the v2.21 release" names a core 1.16.0.
+- **The cycle.** `packages/core/src/bin.ts:2` is `import '@guren/cli/bin'`,
+  which makes `@guren/cli` a runtime dependency of core (`core/package.json:91`),
+  while cli depends on core (`cli/package.json`, `"@guren/core": "^1.16.0"`).
+  `packages/core/src/internal/deploy-check.ts:37` reaches cli a second time
+  by lazy `import('@guren/cli')`. The build breaks the cycle by hand:
+  `ignoredEdges` in `scripts/workspace-packages.ts:136-138` drops core's
+  edge on cli, with a stale-entry warning at lines 200-207. Server has its
+  own lazy `import('@guren/cli')` under `@ts-ignore`
+  (`packages/server/src/mcp/McpServiceProvider.ts:27-31`), covered by
+  `deps: { neverBundle: ['@guren/cli', 'zod'] }` in
+  `packages/server/tsdown.config.ts:54`.
+- **The rule that puts the database stores in core is already broken.** The
+  stated reason is that server must not depend on the ORM: RFC 0003
+  (`rfcs/0003-cloudflare-workers-plugin.md:563-567`), restated in
+  `packages/core/src/session-manager.ts:23` and `CLAUDE.md:387`. But
+  `packages/server/src/auth/AuthenticatableModel.ts:1` imports `Model` at
+  runtime and extends it at line 5, and `packages/server/package.json`
+  declares `"@guren/orm": "^2.7.1"` under `dependencies`. The boundary the
+  stores were moved across does not exist; only the stores moved.
+- **The core-first rule is enforced at the repo's edge and nowhere else.**
+  `scripts/smoke/core-first-audit.ts:5-11` scans `README.md`, `docs`,
+  `examples`, `web` and `packages/create-app/templates/default` (not
+  `api-only`) for the string `@guren/server`. Inside `packages/`, the name is
+  load-bearing: `@guren/testing` peer-depends on `"@guren/server": ">=2.14.0"`
+  (required) beside an *optional* `"@guren/core": ">=1.8.0"`, and its
+  `test-app.ts:409-413` and `agent.ts:50-53` try core, then server, then a
+  bare Hono app. `@guren/plugin-lambda` declares an optional peer
+  `"@guren/server": ">=2.20.0"` because `src/session/index.ts:12` must write
+  `declare module '@guren/server'` to augment `SessionDrivers`; augmenting
+  the name users import would not merge. `packages/cli/src/key-generate.ts:3`
+  imports from server directly; `deprecations.ts:59` and
+  `deploy-runtime.ts:228` scan for both names because either may appear.
+- **Subpaths diverge.** Server's `exports` map has 28 entries (`.` plus 27
+  subpaths); core's has 13 (`.` plus 12). Ten subpaths exist on both, two
+  only on core (`/internal/deploy-build`, `/internal/deploy-check`), and 17
+  only on server. Of those 17, the 13 per-subsystem entries (`/auth`,
+  `/cache`, `/mail`, `/queue`, ...) have no first-party consumer outside
+  `packages/server` and appear in no doc, because the core-first audit makes
+  them unnameable; the root barrel (`packages/server/src/index.ts`, 1037
+  lines, 102 export statements) already exports the same names, and
+  `packages/server/tsdown.config.ts:5-8` explains that the per-entry chunks
+  must share module state or `registerJob` through the root would be
+  invisible to `./queue`.
+- **The docs define stability by the name, not the package.**
+  `contributing/api-stability.md` says a symbol is Stable when it is
+  "re-exported from `@guren/core`", and `contributing/plugin-contract.md:159`
+  lists three public entry points (`@guren/server`, `@guren/orm`,
+  `@guren/core`). Two of the three are the same API under different version
+  numbers.
+
+### What it costs to keep the two names consistent
+
+Everything below exists only because the runtime has two names. None of it
+guards a behaviour a user can observe.
+
+| Kind | Where (at `30a26e94`) | Why it exists |
+|---|---|---|
+| Gate | `scripts/smoke/core-semver-audit.ts` + test; `package.json:40`; `ci.yml:148`; head of `version-packages` (`package.json:61`) | a server major must become a core major |
+| Gate | `scripts/smoke/core-first-audit.ts`; `package.json:29`; `ci.yml:116`, `release.yml:79`, `nightly-canary.yml:76` | docs must not name the package the code lives in |
+| Gate (half) | `scripts/smoke/plugin-compat-audit.ts`: `rangeAtRelease` / `plannedVersions` | a plugin's `@guren/core` range moves when *server* crosses a major, while `compatibility` does not |
+| Assertion | `starter-template-audit.ts:71`; `fresh-app.ts:284-285, 304-305, 432, 438, 445` | five restatements of the same "no `@guren/server`" rule |
+| Build config | `ignoredEdges` + stale-entry warning, `workspace-packages.ts:136-138, 200-207` | the core↔cli cycle |
+| Build config | `neverBundle: ['@guren/cli']`, `server/tsdown.config.ts:54` | the server⇢cli lazy import |
+| Source | `packages/core/src/{bin,runtime,vite,lambda,redis,agent,jsx-runtime,jsx-dev-runtime}.ts`, `internal/{route-path,zod-compat,zod-json-schema}.ts` | eleven files whose only content is a re-export |
+| Source | `core/package.json:5-8` `sideEffects` naming `bin`; `core/tests/core.test.ts:25-29` pinning the proxy | the bin lives in the wrong package |
+| Test | `packages/core/tests/session-manager.test.ts` | a `declare module` augmentation must survive core's *bundled* `.d.ts` (server emits unbundled ones, `server/tsdown.config.ts:46-48`) |
+| Fallback | `testing/src/test-app.ts:409-413`, `testing/src/agent.ts:50-53` | either name may be the one installed |
+| Scanner | `cli/src/deprecations.ts:59`, `cli/src/deploy-runtime.ts:228` | either name may appear in app source |
+| Peer | `plugin-lambda/package.json` optional `@guren/server` | module augmentation targets the declaring package |
+| Prose | four paragraphs of `common-pitfalls.md` (core-first, core-semver, fixed group, "core is not on the release train") | explaining the above to the next contributor |
+
+Fourteen mechanisms, two of them running on every CI job and one at the head
+of every release.
+
+## Proposed Solution
+
+Publish one runtime package, **`@guren/core`**, containing what
+`packages/server/src` and `packages/core/src` contain today. `@guren/server`
+becomes a re-export shim for one major and is then retired.
+
+### Direction: core is the package (A), not server (B)
+
+Both directions end with one name. The migration cost decides it.
+
+| | (A) `@guren/core` is real, `@guren/server` shims | (B) `@guren/server` is real, `@guren/core` retired |
+|---|---|---|
+| Root import lines to rewrite in-repo | 0 in docs/examples/templates | 401 (`docs/en`), 390 (`docs/ja`), 138 (`examples`), 38 + 44 (create-app and cli templates), 2 (`web/src`) |
+| Manifests to repoint | `@guren/testing` (peer), `@guren/plugin-lambda` (peer), `@guren/cli` (drops server) | both templates, `@guren/openapi`, all 7 plugins, `web`, 3 examples, every user app since v1.0-alpha |
+| Gates to invert | none (the "no `@guren/server`" grep keeps its meaning through the shim window) | `core-first-audit` and five smoke assertions flip sign |
+| Name accuracy | `core` already carries the ORM allowlist, the Vite plugin, the JSX runtime | `server` would carry `Model`, `defineModel`, `createPostgresDatabase` |
+| Users who wrote the discouraged name | codemod `@guren/server` → `@guren/core` | codemod in the other direction, for every user |
+
+The only argument for (B) is that server holds the source and the git
+history. `git mv packages/server/src packages/core/src` keeps both. (A) it is.
+
+### Package graph after
+
+| Package | Depends on (runtime) | Change |
+|---|---|---|
+| `@guren/core` | `@guren/orm`; lazy, undeclared `@guren/cli` (MCP provider, deploy-check) | absorbs server's source; loses `@guren/cli` and `@guren/server` from `dependencies` |
+| `@guren/orm` | drizzle | unchanged |
+| `@guren/cli` | `@guren/core`, `@guren/orm` | drops `@guren/server`; `key-generate.ts:3` imports from core |
+| `@guren/testing` | peer `@guren/core` (required) | drops the server peer and the two fallback chains |
+| `@guren/openapi` | `@guren/core` | range bump only |
+| `@guren/inertia-client`, `create-guren-app` | none | unchanged |
+| 7 plugins | `@guren/core` | range bump; `plugin-lambda` drops its server peer and augments `@guren/core` |
+| `@guren/server` (shim, one major) | `@guren/core` | `export *` of the root and of every surviving subpath |
+
+The declared graph becomes acyclic: `ignoredEdges` empties and the
+stale-entry loop goes with it. The lazy core⇢cli imports stay as they are in
+server today, so `neverBundle: ['@guren/cli', 'zod']` moves from
+`server/tsdown.config.ts` to core's; it is not deleted.
+
+### Source layout and the bin
+
+- `packages/server/src/**` moves under `packages/core/src/` with `git mv`;
+  core's eleven re-export files and `bin.ts` are deleted. Core adopts
+  server's declaration strategy (`tsc -p tsconfig.build.json`, unbundled
+  `.d.ts`), which retires the bundled-augmentation test.
+- The `guren` bin is `@guren/cli`'s (`cli/package.json` already declares
+  `"bin": { "guren": "./dist/bin.js" }`), and both scaffold templates
+  already depend on `@guren/cli` (`templates/default/package.json:24`,
+  `templates/api-only/package.json:23`). Core stops declaring a bin and
+  drops its `sideEffects` entries; server's `"sideEffects": false` carries
+  over.
+- The module-level state the tsdown comment warns about (job registry, mail
+  manager, queue driver) keeps sharing chunks exactly as it does now, since
+  the entry set is the same package's.
+
+### Subpaths: the rule, and which of the 29 survive
+
+A subpath earns its place by one of three things; anything else lives on the
+root, which is where the docs already import it from.
+
+1. **It isolates a dependency the root must not pull.** `/redis` (ioredis),
+   `/mcp` (`@modelcontextprotocol/sdk`, deliberately kept off the barrel at
+   `server/src/index.ts:1031-1033`), `/lambda`, `/vite`.
+2. **It targets a different runtime than the app graph.** `/agent`
+   (browser-safe dispatch, RFC 0016 §3), `/jsx-runtime` and
+   `/jsx-dev-runtime` (the `@jsxImportSource` target), `/runtime` (Bun
+   helpers), `/encryption` (loaded lazily from a vitest setup file,
+   `testing/src/vitest.ts:25`, where the root graph is not wanted).
+3. **It is a contract shared with sibling packages but not app API:**
+   `/internal/*`.
+
+| Outcome | Subpaths | Count |
+|---|---|---|
+| Survive, already on core | `/runtime`, `/vite`, `/lambda`, `/redis`, `/agent`, `/jsx-runtime`, `/jsx-dev-runtime`, `/internal/deploy-build`, `/internal/deploy-check`, `/internal/route-path`, `/internal/zod-compat`, `/internal/zod-json-schema` | 12 |
+| Survive, promoted from server | `/mcp`, `/encryption`, `/internal/request` | 3 |
+| Dropped: root exports the same names (`server/src/index.ts:505-1008`) | `/auth`, `/authorization`, `/broadcasting`, `/cache`, `/events`, `/health`, `/i18n`, `/logging`, `/mail`, `/notifications`, `/queue`, `/scheduling`, `/storage` | 13 |
+| Dropped: cross-package sharing is now intra-package | `/support/expiry` | 1 |
+
+So `@guren/core` ends with 16 `exports` entries; the shim mirrors all 29 old
+paths for one major (the dropped 14 pointing at the root) so that an import
+that worked on server 2.x resolves on the shim and the codemod, not a 404,
+tells the user where it went. The `core.test.ts:17-23` rule (expiry helpers
+never public) survives as a test of the root barrel rather than of a
+subpath.
+
+### `@guren/core/internal/*`
+
+Unchanged in name and in stability tier. The six internal subpaths exist so
+`@guren/cli`, `@guren/openapi` and `@guren/testing` share one Zod → JSON
+Schema rule and one request-body rule; after the move they are the package's
+own modules published under the same paths, and `api-stability.md`'s
+"Internal" tier keeps describing them.
+
+### Versioning and the release sequence
+
+This is a major for both names.
+
+- **`@guren/core` goes to 3.0.0**, not 2.0.0: it continues the number the
+  runtime is on (server 2.21.0), the release tag `v3.0.0` follows it
+  (today's tags follow server), and the shim publishes as
+  `@guren/server@3.0.0`, so the two names carry the same number for the
+  whole shim window and "which version is installed" has one answer.
+- Sequence, one release: (1) the source move and shim; (2) cli, testing,
+  openapi and the seven plugins repoint (cli, testing, openapi as minors;
+  plugins are 0.x, minors) with `compatibility: ">=3.0.0 <4.0.0"`; (3) gates
+  and prose deleted (table below); (4) the codemod and `guren upgrade`
+  changes (Migration Path); (5) `sync:template-deps` writes `^3.0.0` into
+  the templates. `smoke:starter:npm` is red until the release ships, the
+  documented state for a template using an unreleased API.
+- **4.0.0** (or the next major, whichever is later): the shim's last version
+  is published with an `npm deprecate` notice naming `@guren/core`, the
+  package leaves the workspace, and the "no `@guren/server`" grep is deleted.
+
+### Changesets
+
+`.changeset/config.json` does not change. `fixed` stays `[]` (the measured
+reasons in `core-semver-audit.ts:14-20` still hold: a fixed group snaps to
+its highest member in both directions). The shim needs no changeset of its
+own: `updateInternalDependencies: "patch"` bumps it on every core release,
+which is the behaviour a shim wants. At retirement it moves into `ignore`.
+
+### Plugin `compatibility`
+
+All seven plugins declare a range against `@guren/core` and stop below 2.0.0
+(`>=1.0.0 <2.0.0` for cloudflare, lambda, markdown, vercel; `>=1.14.0 <2.0.0`
+for agents and mcp; `>=1.13.0 <2.0.0` for webmcp). Every one is rewritten in
+the merge release, which is exactly the drift `audit:plugin-compat` catches
+after `changeset version`. After the merge the field claims against the
+package whose API the plugin actually calls, so the range and the field
+describe one thing. `checkPluginCompatibility` (`plugin-manifest.ts:218-230`)
+and `readCoreVersion` (`:201-206`) need no change: they already read
+`node_modules/@guren/core/package.json`.
+
+### What gets deleted
+
+| Item | Fate |
+|---|---|
+| `audit:core-semver` (script, test, CI step, `version-packages` head) | deleted: no dependent bump to promote |
+| `audit:core-first` | reduced to the single "no `@guren/server`" grep already in `starter-template-audit.ts:71`; deleted with the shim |
+| `plugin-compat-audit.ts` `rangeAtRelease` and the dependency-driven `plannedVersions` | deleted: core's version moves only when core has a changeset. The range-subset probe stays |
+| `ignoredEdges` and its stale-entry warning | deleted |
+| `neverBundle` in `server/tsdown.config.ts` | moves to core's config |
+| `packages/core/src/bin.ts`, 11 re-export files, `sideEffects`, `core.test.ts:25-29` | deleted |
+| `session-manager.test.ts` bundled-`.d.ts` pin | deleted with the bundled declarations |
+| `testing` fallback chains, `plugin-lambda` server peer | deleted |
+| `deprecations.ts:59` and `deploy-runtime.ts:228` dual names | kept through the shim window (they are what finds the old name), then narrowed |
+| `common-pitfalls.md` core-first, core-semver, fixed-group and release-train paragraphs; `api-stability.md` decision tree step 1; `plugin-contract.md:159` | rewritten to describe one package |
+
+## Alternatives Considered
+
+- **`fixed: [["@guren/server", "@guren/core"]]`.** Rejected for the reason
+  `core-semver-audit.ts:14-20` measured against `changeset version`: the
+  group is bidirectional and snaps to its highest member, so a server-only
+  patch moved core 1.6.2 → 2.7.1 in the trial, crossing core's major line
+  inside a release whose changelog reads "Patch Changes" and tripping every
+  plugin's `<2.0.0`. Only one direction of the coupling is true, and
+  changesets cannot express one direction.
+- **Keep two packages; pin core to server exactly.** `"@guren/server": "2.21.0"`
+  and a core release for every server release. It removes the silent-major
+  case and nothing else: two version numbers to explain, the cycle, the
+  eleven shims, the diverging subpaths, and augmentation still targeting the
+  name users are told not to import. It also makes `updateInternalDependencies`
+  publish a core patch for every server patch, which is a shim with extra
+  steps.
+- **Merge `@guren/orm` too.** Rejected. The ORM is a real boundary: it pins
+  `drizzle-orm` exactly and `drizzle-pins.ts` propagates that pin to
+  templates and to `guren upgrade`; it has its own release line (2.7.1) and
+  its own open design question on per-dialect entry points (RFC 0022); and
+  the cli's schema tooling consumes it without the HTTP stack. Folding it in
+  would put drizzle's release cadence on the framework's.
+- **Move the database stores back into server and keep core as a pure
+  barrel.** Fixes the broken RFC 0003 rule honestly, but leaves everything in
+  the cost table in place; it is the first half of this RFC without the
+  second.
+- **Retire `@guren/server` immediately, no shim.** Saves one major of
+  maintenance for a package that costs nothing to maintain
+  (`updateInternalDependencies` does the work), at the price of a hard break
+  for the two first-party packages and every user who wrote the discouraged
+  name. The deprecation policy asks for two minors of warning; a shim is how
+  a package name gets them.
+
+## Migration Path
+
+**Apps importing `@guren/core`** (every scaffold since v1.0-alpha): nothing
+to edit. `guren upgrade` already rewrites `@guren/*` ranges across the four
+manifest fields (`upgrade.ts:17-18`) and aligns the drizzle pins; it will
+write `^3.0.0`.
+
+**Apps importing `@guren/server`:** a codemod, the first entry in the
+currently empty registry (`packages/cli/src/codemods.ts:21`,
+`codemods: Codemod[] = []`), selected by `findApplicableCodemods` for the
+2.x → 3.x range:
+
+- `'@guren/server'` → `'@guren/core'`;
+- `'@guren/server/<sub>'` → `'@guren/core/<sub>'` for the 15 surviving
+  subpaths, and → `'@guren/core'` for the 14 dropped ones;
+- `declare module '@guren/server'` → `declare module '@guren/core'`;
+- the `package.json` dependency `@guren/server` → `@guren/core` (the manifest
+  rewrite `guren upgrade` already performs, extended to rename).
+
+The detector reuses `GUREN_IMPORT` at `deprecations.ts:59`, which already
+matches both names. The policy's "tested against `examples/blog`" rule cannot
+apply literally (the blog imports core), so the codemod test uses a synthetic
+fixture that imports every old path once.
+
+**Plugin authors:** bump the `@guren/core` range, rewrite `compatibility`,
+and rename any `declare module`. `guren plugin` refuses a stale range with
+its existing message (`plugin.ts:119-125`), so a plugin left on `<2.0.0`
+fails at install, not at runtime.
+
+**Deprecation stages** (per `contributing/deprecation-policy.md`):
+
+| Stage | Release | What |
+|---|---|---|
+| Announce + register | next 2.x minor | `Deprecation` entry `guren-server-import` (`since` that minor, `removedIn` 4.0.0) in `deprecations.ts`; `guren upgrade --check-only` and `guren doctor` list the files; CHANGELOG `### Deprecated` |
+| Provide codemod + shim | 3.0.0 | the merge release above; `guren upgrade` runs the rename |
+| Warn at runtime | 3.0.0 | the shim's root entry emits the once-per-process `[guren] Deprecation (guren-server-import)` warning on import |
+| Remove | 4.0.0 | shim retired; `npm deprecate` on its last version |
+
+The 3.x line is at least two minors long before 4.0.0, which satisfies the
+minimum period for a stable API.
+
+## Open Questions
+
+1. **3.0.0 or 2.0.0 for `@guren/core`?** 3.0.0 keeps the tag line and the
+   shim on one number. 2.0.0 is the smaller semantic step and matches the
+   plugins' existing `<2.0.0` ceilings, but ships a `@guren/core@2.x` that
+   is older-looking than the `@guren/server@2.x` it replaces.
+2. **Does `declare module '@guren/server'` merge through the shim?** The
+   shim is `export * from '@guren/core'`. If TypeScript does not merge an
+   augmentation through a star re-export, a third-party plugin on the old
+   name fails to type-check against 3.x with no runtime symptom. To be
+   answered by a test in the shim package before 3.0.0; if the answer is no,
+   the codemod's `declare module` rename becomes mandatory rather than
+   cosmetic.
+3. **Directory name.** `git mv packages/server/src packages/core/src` keeps
+   blame but leaves `packages/server` as a three-file shim for a major; the
+   alternative (`packages/server` → `packages/core`, then fold in core's
+   stores) keeps the larger history intact and moves the smaller tree.
+4. **Do the 13 per-subsystem subpaths deserve a stay?** No first-party
+   consumer, no doc; but a third-party plugin may import `@guren/server/queue`
+   today. The shim answers it for one major. Whether `@guren/core/queue` and
+   friends are ever published is a question for the first user who asks.
+5. **Should the shim be retired at all?** A permanent shim costs one
+   automatic patch per release. Against that: a second name is what every
+   mechanism in the cost table grew around, and `deprecations.ts` and the
+   two smoke assertions exist only while it does.
+6. **Where does the "stable = re-exported from core" definition go?** With
+   one package, `api-stability.md`'s first decision-tree step is a tautology;
+   the honest replacement is "exported from the root or a non-`internal`
+   subpath", which should be written down in the same PR.

--- a/rfcs/0025-orm-single-read-pipeline.md
+++ b/rfcs/0025-orm-single-read-pipeline.md
@@ -1,0 +1,400 @@
+# RFC: One Read Pipeline for Models
+
+**Author:** 7nohe
+**Date:** 2026-09-11
+**Status:** Draft
+
+## Problem
+
+`@guren/orm` reads a row through two pipelines, chosen by whether the model
+carries a global scope, and only one of them applies the model's read-time
+transforms. Everything below is verified at `30a26e94`.
+
+**The fork.** Five static reads on `Model` branch on `hasScopes()`
+(`packages/orm/src/Model.ts:550`, `:572`, `:667`, `:1013`, `:1045`). Without a
+scope they call the adapter directly and run `applyReadTransforms` (casts,
+then accessors; `:435-440`) on the result (`:556`, `:579`, `:679`; the write
+paths do the same at `:1201`, `:1286`). With a scope they build a
+`QueryBuilder` and return whatever `get()` hands back, and `QueryBuilder.ts`
+does not contain the string `applyReadTransforms`. These calls return raw rows:
+
+| Call | Path taken | Transforms |
+|---|---|---|
+| `Post.all()`, no scope | adapter `findMany` | yes |
+| `Post.all()`, model mixes in `SoftDeletes` | `newQuery().get()` (`:551`) | **no** |
+| `Post.where(...).get()` / `await Post.where(...)` | builder (`:701`) | **no** |
+| `Post.orderBy(...)`, no scope | adapter (`:1031`) | **no**, even on the fast arm |
+| `Post.paginate()`, either arm | adapter (`:1089`) or builder (`:1055`) | **no** |
+| `Post.with('author')`, with `where` | builder (`:1383`) | **no** |
+| every eager-loaded child row | `related.newQuery(...)` (`:1462`, `:1723`, `:1942`) | **no** |
+
+A model declaring `casts = { meta: 'json' }` therefore gets `meta` back as an
+object from `Post.find(1)` and as a string from `Post.where('id', 1).first()`.
+`docs/en/guides/database.md:696-757` documents casts and accessors with no such
+caveat, and the tutorial's own `Post` (`docs/en/tutorials/09-relationships.md`)
+walks straight into the builder path the moment chapter 9 adds `with()`.
+
+**The escape hatch drops the scopes.** `Model.query()` (`Model.ts:1336-1361`)
+is documented as carrying "no model scopes, casts or accessors", and it is the
+only way to join or to aggregate anything but a count: `WhereOperator`
+(`QueryBuilder.ts:30`) has eleven operators and the builder's terminals are
+`get`, `first`, `firstOrFail`, `count`, `paginate`, `update`, `delete`. The
+first query that outgrows the builder is the first query that silently reads
+soft-deleted rows and other tenants' rows; `docs/en/guides/api-resources.md:229`
+ships that shape as the cursor-pagination example.
+
+**Pagination exists twice.** `Model.paginate()` sanitises page and size,
+counts, computes the offset and builds `meta` (`Model.ts:1061-1104`);
+`QueryBuilder.paginate()` does it again (`QueryBuilder.ts:307-344`). They agree
+by inspection, not by construction.
+
+**Relations are declared three times with nothing linking them.** The blog's
+`Post` (`examples/blog/app/Models/Post.ts`) says `authorId` references
+`users.id` in `db/schema.ts:26`, then `static override relationTypes: { author:
+BelongsToRecord<PostAuthorSummary> } = { author: null }` for the type side, then
+`Post.belongsTo('author', () => import('./User.js').then(...), 'authorId',
+'id')` after the class for the runtime side. The dummy value exists because a
+`static` needs an initializer. Nothing checks that the three agree: the two
+names can differ and the foreign key is a `string` at the call. Without
+`relationTypes`, `RelationKeyOrString` collapses to `string` (`Model.ts:2011`)
+and every relation name type-checks; with it, only the head of a dot path is
+checked (`:1994-1999`), which `database.md:489` has to explain.
+`packages/cli/src/model-parser.ts:374-503` reads both and prefers
+`relationTypes`: the lazy `import()` thunk hides the related model's name.
+
+**What is already in flight.** A bug-fix branch (`fix/review-orm-read-pipeline`)
+is applying `applyReadTransforms` inside the builder paths as a patch, which
+turns the table above all-yes with no API change. This RFC takes that as Part
+0. The patch closes the symptom; the fork stays, and the next transform added
+to one arm will be missing from the other. The rest is about removing the fork.
+
+## Proposed Solution
+
+One read pipeline: every static read on `Model` is a thin call into
+`QueryBuilder`, which owns scopes, eager loading, pagination and the one point
+where rows become records. `QueryBuilder` keeps its name: it is a public export
+and the type of every `static scopes` entry, and a rename buys nothing here.
+
+### 1. `QueryBuilder` owns materialisation
+
+Every terminal that returns rows funnels through one method:
+
+```ts
+class QueryBuilder<TRecord, TResult = TRecord> {
+  /** The one place a row becomes a record: casts, accessors, then eager loads. */
+  private async materialize(rows: PlainObject[]): Promise<TResult[]> {
+    const records = rows.map((row) => this.modelClass.applyReadTransforms(row))  // public @internal from Part 0
+    return this.loadEagerRelations(records)
+  }
+
+  async get(): Promise<TResult[]>                 // executeQuery -> materialize
+  async first(): Promise<TResult | null>          // limit 1 -> get
+  async paginate(...): Promise<PaginatedResult<TResult>>  // count + get
+}
+```
+
+Eager loaders already fetch children through `related.newQuery(...)`
+(`Model.ts:1942`), so a child row is materialised by *its* model's builder.
+Dropping the fast arm costs one builder allocation per call and no extra round
+trip: `find()` issues one `findUnique` today, one `findManyAdvanced` with
+`limit 1` through the builder.
+
+Additions the statics need in order to delegate, and the ones `Model.query()`
+users need in order to leave it:
+
+```ts
+// Ordering in every shape Model.orderBy() accepts today (Model.ts:61-68)
+orderBy(field: FieldKey<TRecord>, direction?: OrderDirection): this
+orderBy(input: OrderByInput<TRecord>): this
+
+// Relation counts move over from Model.withCount(); with() and select() already exist
+withCount(...relations: RelationKey[]): QueryBuilder<TRecord, TResult & RelationCountPick<...>>
+
+// Aggregates. count() exists; the rest are one adapter method away.
+sum(field: FieldKey<TRecord>): Promise<number>
+avg(field: FieldKey<TRecord>): Promise<number>
+min<K extends FieldKey<TRecord>>(field: K): Promise<TRecord[K] | null>
+max<K extends FieldKey<TRecord>>(field: K): Promise<TRecord[K] | null>
+exists(): Promise<boolean>        // select <pk> ... limit 1; never materialises
+
+// The scoped escape to Drizzle (replaces Model.query(); see §6)
+toSql(): SQL | undefined
+toDrizzle<S extends SelectedFields>(selection?: S): DrizzleSelect<S>
+```
+
+The adapter side is one optional method shaped like `countAdvanced`:
+`aggregateAdvanced?(table, conditions: WhereCondition[], { fn: 'sum' | 'avg' |
+'min' | 'max', column }, queryOptions): Promise<unknown>`. `DrizzleAdapter`
+implements it with `sql\`sum(${column})\`` and friends; without it, `sum()`
+throws the "conditions the configured adapter cannot express" error
+`executeQuery` throws today (`QueryBuilder.ts:535`), never a wrong number.
+
+### 2. The statics that become delegations
+
+Each becomes a one-line call into a scoped builder; signatures do not change.
+
+| Static | Delegation |
+|---|---|
+| `all(opts)` | `newQuery(opts).get()` |
+| `find(id, key, opts)` | `id === undefined ? null : newQuery(opts).where(key, id).first()` |
+| `findOrFail` | `find` then throw, as today |
+| `findWith(id, rels, key, opts)` / `findWithOrFail` | `newQuery(opts).with(rels).where(key, id).first()` |
+| `first(where, opts)` | `newQuery(opts).where(where ?? {}).first()` |
+| `where`, `whereNull`, `whereNotNull`, `whereIn`, `whereNotIn`, `select`, `scope` | already delegations, unchanged |
+| `orderBy(order, where, opts)` | `newQuery(opts).where(where ?? {}).orderBy(order).get()` |
+| `paginate(options, opts)` | `newQuery(opts).where(...).orderBy(...).paginate({ page, perPage })` |
+| `withPaginate(rels, options, opts)` | same, with `.with(rels)` |
+| `with(rels, where, opts)` | `newQuery(opts).where(where ?? {}).with(rels).get()` |
+| `withCount(rels, where, opts)` | `newQuery(opts).where(where ?? {}).withCount(rels).get()` |
+
+`Model.paginate()`'s own count-and-slice body (`:1058-1104`) goes; the builder's
+is the one implementation. `TransactionModelScope` (`:271-283`) is a third copy
+of the same list and becomes the same delegations with `{ trx }` bound.
+`findUnique` and the where-clause form of `count` stop being called by `Model`
+but stay on the public `ORMAdapter` interface; the builder's basic-adapter
+fallback still uses `findMany` and `count`. `hasScopes()` is `protected static`
+and reachable from subclasses, so it is kept and `@deprecated` until Part 3.
+
+### 3. Scopes: one registry, applied once per builder instance
+
+Nothing structural changes; the invariant is stated so Part 1 can test it.
+`buildScopedQuery` (`Model.ts:767-781`) is the only place a scoped builder is
+born: `defaultScope`, then the `GlobalScopeRegistry` entries minus `except`,
+then `SEAL_SCOPES` so a later top-level `orWhere()` cannot fold the scopes into
+its left arm (#732). Every delegation in §2 goes through it. The registry stays
+per class, cloned on first write so a subclass inherits (`:304-310`);
+`SoftDeletes` keeps registering only the named scope `softDelete`
+(`SoftDeletes.ts:58-64`), so `withTrashed()` can drop it while a tenant scope
+stays on. With the fast arm gone, "every read applies the scopes" holds by
+construction rather than by five `if` statements.
+
+### 4. One relation declaration
+
+```ts
+import { defineModel, belongsTo, hasMany, type WithRelations } from '@guren/orm'
+import { User } from './User'                      // static import; the thunk below defers the cycle
+
+export class Post extends defineModel(posts, { fillable: ['title', 'body', 'authorId'] }) {
+  static relations = {
+    author: belongsTo(() => User, 'authorId'),          // ownerKey defaults to 'id'
+  }
+}
+
+export class User extends defineModel(users) {
+  static relations = {
+    posts: hasMany(() => Post, 'authorId'),             // localKey defaults to 'id'
+  }
+}
+```
+
+The descriptors are branded objects: the type carries the related model and
+the key names, the value carries what `getRelationDefinitions()` needs:
+
+```ts
+export function belongsTo<Related extends typeof Model, FK extends string>(
+  related: () => Related, foreignKey: FK, ownerKey?: keyof TRecordFor<Related> & string,
+): BelongsTo<Related, FK>
+export function hasMany<Related extends typeof Model>(
+  related: () => Related, foreignKey: keyof TRecordFor<Related> & string, localKey?: string,
+): HasMany<Related>
+// hasOne, belongsToMany, hasManyThrough, morphMany, morphTo: same shape, the statics' parameters minus `name`
+```
+
+The thunk is what the current API already takes (`Model.ts:820`): two models
+that point at each other cannot evaluate each other's class at module load. A
+static `import { User }` plus `() => User` is enough; the examples' dynamic
+`import()` existed because the call ran at module bottom, where the cycle
+bites. The identifier staying in source is what lets `model-parser.ts` read
+the related model's name from the runtime declaration.
+
+The result type is inferred from the declaration. `BelongsTo` reads the
+foreign key's nullability off the parent's own record, so
+`BelongsToRequiredRecord` and the hand-written `| null` go away:
+
+```ts
+type RelationResult<T extends typeof Model, R> =
+  R extends BelongsTo<infer Related, infer FK>
+    ? null extends TRecordFor<T>[FK & keyof TRecordFor<T>] ? TRecordFor<Related> | null : TRecordFor<Related>
+  : R extends HasOne<infer Related> ? TRecordFor<Related> | null
+  : R extends HasMany<infer Related> | BelongsToMany<infer Related> | HasManyThrough<infer Related> | MorphMany<infer Related>
+    ? TRecordFor<Related>[]
+  : R extends MorphTo ? PlainObject | null
+  : never
+
+type RelationsOf<T extends typeof Model> = T extends { relations: infer R extends Record<string, RelationDescriptor> } ? R : {}
+
+// Every segment of a dot path is checked, not only its head (depth-capped in the implementation).
+type RelationPath<T extends typeof Model> = {
+  [K in keyof RelationsOf<T> & string]: K | `${K}.${RelationPath<RelatedOf<RelationsOf<T>[K]>>}`
+}[keyof RelationsOf<T> & string]
+
+export type WithRelations<T extends typeof Model, P extends RelationPath<T>> =
+  TRecordFor<T> & { [K in RelationHead<P>]: RelationResult<T, RelationsOf<T>[K]> /* tails recurse */ }
+
+type PostWithAuthor = WithRelations<typeof Post, 'author'>
+//   ^? PostRecord & { author: UserRecord }        (authorId is NOT NULL in the schema)
+type UserWithPosts = WithRelations<typeof User, 'posts.author'>
+//   ^? UserRecord & { posts: Array<PostRecord & { author: UserRecord }> }
+```
+
+`RelationTypesFor<T>` (`:2003-2007`) becomes "`relations` if declared, else
+`relationTypes`", so Part 2 is additive: a model may carry either, and the
+static `hasMany()`/`belongsTo()` methods keep working until Part 3. At runtime
+`getRelationDefinitions()` reads `this.relations` (own property only, the
+guard at `:529`) and converts each descriptor into today's `RelationDefinition`
+on first use, so every loader in `Model.ts:1569-1903` is untouched; a foreign
+key naming no column throws there with the model and relation name, where
+today the adapter throws "unknown column" on the first query. `model-parser.ts`
+gains a third source and prefers it; `guren model:list`, `spec:generate` and
+the ER view need no other change. The relation name is the object key, so
+there is no name to mismatch and no dummy value.
+
+### 5. Transactions, as far as reads go
+
+`newQuery({ trx })` is the only way a `trx` enters a read, and the builder
+forwards it to every eager load (`QueryBuilder.ts:586-606`), which #744 needed.
+With §2 every read passes through one constructor, and that is where an
+ambient transaction handle belongs: `options.trx ?? currentTransaction()`. The
+handle itself (an `AsyncLocalStorage` the adapter enters on `transaction()`)
+is a separate bug fix and is not specified here. The one constraint added: it
+must use the on-demand `import('node:async_hooks')` the adapter's nesting guard
+already uses (`drizzle-adapter.ts:232-245`), or the Workers and Lambda bundles
+gain an edge they cannot resolve.
+
+### 6. Retiring `Model.query()`
+
+```ts
+// Today: raw and unscoped
+const rows = await Post.query().where(gt(posts.id, cursor)).orderBy(asc(posts.id)).limit(21)
+
+// Proposed: the model's conditions and scopes travel as a Drizzle fragment
+const rows = await Post.where('id', '>', cursor)
+  .toDrizzle({ id: posts.id, title: posts.title, author: users.name })
+  .leftJoin(users, eq(posts.authorId, users.id))
+  .orderBy(asc(posts.id))
+  .limit(21)
+
+const scoped = Post.newQuery().toSql()          // SQL | undefined, for a hand-built select
+await db.select().from(posts).where(and(scoped, gt(posts.views, 100)))
+```
+
+`toSql()` renders `effectiveConditions()` through `buildDrizzleConditions`,
+exactly what `findManyAdvanced` renders (`drizzle-adapter.ts:491`), so a scope
+is applied the same way whether the query stays in the builder or leaves it.
+`toDrizzle(selection?)` returns `db.select(selection).from(table).$dynamic()`
+with that fragment applied as `.where()`. Two rules for the docs: rows out of
+`toDrizzle()` are Drizzle's, not the model's (no casts, no accessors; after a
+join they may not be model rows at all), and a further `.where()` on the
+Drizzle side *replaces* the fragment (Drizzle keeps one `config.where`), so
+conditions go on the model side or through `toSql()` and `and()`. Like
+`Model.query()` it needs a Drizzle handle (`:2301-2307`).
+
+### Part plan
+
+- **Part 0 (patch, in flight):** `applyReadTransforms` runs inside the
+  builder's terminals. Fixes the Problem table; changes no API.
+- **Part 1 (minor, non-breaking):** §1 additions, §2 delegations, `hasScopes()`
+  deprecated, `Model.paginate()`'s duplicate body removed. Tests: each §2
+  static on a scoped and an unscoped model, asserting a `json` cast came back
+  parsed and the scope reached the SQL.
+- **Part 2 (minor, additive):** §4 descriptors, `WithRelations` inference,
+  parser support, scaffold and docs on the new form; `relationTypes` and the
+  static relation methods deprecated per the Migration Path.
+- **Part 3 (next `@guren/orm` major, and `@guren/core` with it, since core
+  re-exports the ORM by allowlist):** remove `Model.query()`, `relationTypes`,
+  the static relation methods and `hasScopes()`; `findUnique` becomes optional
+  on `ORMAdapter`. No major is planned (RFC 0022 says the same); Parts 0 to 2
+  stand without it.
+
+## Alternatives Considered
+
+**Keep both paths and document them.** Rejected. The fork *is* the bug class:
+the transforms were missing from one arm because there were two, and the next
+read-time feature would have to be added twice again. Documenting "casts apply
+to `find` but not to `where().get()`" is documenting a defect.
+
+**Drop the Active Record statics and expose only the builder.** Rejected.
+`.find(` / `.findOrFail(` appear in 49 files across `docs/en`, the scaffold
+templates and the examples, the tutorial teaches them first, and every
+`make:feature` controller calls them. Delegation keeps the surface and removes
+the duplication, which is the point of §2.
+
+**Use Drizzle's relational queries (`db.query.posts.findMany({ with })`) as
+the pipeline.** `drizzle-orm` is pinned at `1.0.0-rc.4`, so RQB v2 is the
+current API, and the factories already accept a `relations` option
+(`postgres.ts:43-47`, `sqlite.ts:192`, `d1.ts:73`). What it gives for free is
+real: one declaration against the schema (`defineRelations(schema, r => ({
+posts: { author: r.one.users({ from: r.posts.authorId, to: r.users.id }) } }))`)
+and nested `with` typed at every level with no phantom types of Guren's own.
+What it costs: there is no hook for a global scope. RQB's `where` is per call
+and per nesting level, so `SoftDeletes` and a tenant scope would have to be
+restated at every `with` by every caller, the failure §6 exists to prevent.
+Its rows are plain rows, so casts and accessors would run afterwards per level
+by finding the model behind each nested table; `morphMany`/`morphTo` have no
+RQB equivalent; and a declaration beside the schema needs a second parser for
+`model:list` and the spec views. RQB is the right *loader* for typed nested
+paths and the wrong *pipeline*: a later part can compile §4's `static
+relations` into a `defineRelations` object and let the builder call RQB for
+the eager-load step with scopes still applied by the builder. Not proposed
+here because it makes eager loading Drizzle-only, and `ORMAdapter` is the one
+seam that is not.
+
+**A join DSL on `QueryBuilder`.** Not proposed: it would re-implement a third
+of Drizzle's select builder; `toDrizzle()` reaches the real one, scope intact.
+
+## Migration Path
+
+Parts 0 and 1 change no signatures. Part 2 deprecates, Part 3 removes, in the
+order `contributing/deprecation-policy.md` sets (announce, warn once per
+process, register, CHANGELOG `### Deprecated`, codemod, remove after at least
+two minors). Two entries in `packages/cli/src/deprecations.ts`:
+`model-relation-types` (the `relationTypes` marker and the static
+`hasMany()`/`belongsTo()`/... calls; `detect` is `detectModelStatic(cwd,
+'relationTypes')`, the predicate `model-guarded` uses) and `model-query-raw`
+(`Model.query()`; a text scan for `.query(` on a model class name, reported as
+candidates for a human to read, since the receiver is only known at runtime).
+
+Codemod `model-relations` in `codemods.ts`, scope for `guren upgrade`: a class
+with `static (override|declare) relationTypes: { name: XRecord<...> }` plus
+module-level `Class.hasMany|belongsTo|...(name, related, ...keys)` calls in the
+same file, where `related` is an identifier, a `() => Ident` thunk, or the
+`() => import('./X.js').then((m) => m.X)` shape the docs teach, becomes
+`static relations = { name: fn(() => X, ...keys) }` with the member and the
+calls deleted, a static `import { X }` added where the dynamic form was used,
+and unreferenced `XRecord` type imports dropped. Reported for a human instead:
+a `relationTypes` entry with no runtime call (the blog's `PostAuthorSummary`
+narrowing), any other `related` shape, and `BelongsToRequiredRecord` on a
+nullable column (the inferred type would widen). `Model.query()` is not
+codemodded: the replacement selection is a decision per call site.
+
+Docs and templates switch in Part 2: `database.md` §Relationships, tutorial
+chapters 9 and 10, `packages/create-app/templates/blog/app/Models/*`,
+`make-feature.ts` output, and the harness rule `orm-models.md`. The
+`api-resources.md:229` example moves to `toDrizzle()` in Part 1, since it is
+the shape that drops scopes today.
+
+## Open Questions
+
+1. **`select()` narrowing versus casts and accessors.** A cast on an omitted
+   column is skipped. An accessor reading an omitted column (`fullName` from
+   `firstName` + `lastName`, selecting only `id`) gets `undefined` inputs.
+   Options: run accessors only when their columns are present (needs a
+   declared dependency list), skip all accessors on a narrowed query, or type
+   the result as the bare `Pick` and document that accessors do not apply to
+   narrowed rows. Leaning to the last.
+2. **Does `Model.query()` keep a scoped variant name?** `Post.query()` reads
+   well. Part 3 could re-point it at `newQuery().toDrizzle()` rather than
+   remove it, at the cost of a name that meant "raw" for two majors meaning
+   "scoped" in the third. The alternative is deletion.
+3. **Foreign-key names in `static relations`.** The static form cannot check
+   the parent's foreign key against the parent's own columns (no `this` in a
+   static initializer); a `defineModel(posts, { relations })` option could, as
+   `fillable` is checked today. Ship both, or only the option?
+4. **Inference across a cycle.** `Post.relations` mentions `typeof User` and
+   `User.relations` mentions `typeof Post`. Inference only walks `recordType`,
+   never the other side's `relations`, so it should resolve; TS7022 on a
+   mutually inferred static is still the first thing Part 2 proves, with a
+   type test in `packages/orm/tests/model.query.types.ts` on the blog pair.
+5. **The write fork.** `update()`/`delete()` fork the same way for their where
+   clause (`:1267`, `:1320`). Folding them into the builder is the same change
+   as §2 and could ride in Part 1.

--- a/rfcs/0026-introspection-boot.md
+++ b/rfcs/0026-introspection-boot.md
@@ -1,0 +1,400 @@
+# RFC: Introspection Boot
+
+**Author:** 7nohe
+**Date:** 2026-09-11
+**Status:** Draft
+
+## Problem
+
+`CLAUDE.md` says the CLI never boots an app (`packages/cli/src/csrf-exemption-audit.ts`
+row: "no CLI command can see it, because nothing in the CLI boots an app"). That is
+half true, and the half that is true is the half that hurts.
+
+What the CLI executes today (verified at `30a26e94`):
+
+| Step | Where | Runs user code? |
+|---|---|---|
+| `import()` of `routes/web.ts` | `packages/cli/src/load-routes.ts:141` | Yes: the routes file, every controller it imports, every model, validator and resource those import, and `@guren/core` |
+| `new Router()` + the registrar | `load-routes.ts:150-151` | Yes: the registrar body |
+| `import()` of every `modules/*/index.ts` | `load-routes.ts:109`, `:160` | Yes: each module's providers are *imported* (`defineModule({ providers })`), never constructed |
+| `createApp()`, `registerAll()` | nowhere | No |
+| `boot()`, `listen()` | only `guren dev` (`commands.ts:2248-2289`) | Not for any check |
+
+So `guren check`, `audit`, `doctor`, `context`, `codegen`, `spec:generate` and
+`openapi:generate` already pay for evaluating the app's module graph, and stop
+one call short of the object that knows the answers: the `Application` whose
+constructor registers the providers (`packages/server/src/http/Application.ts:504-590`)
+and whose `bootOnce()` runs `registerAll()`, `mountRoutes()`, `bootAll()`
+(`Application.ts:741-760`). Everything a provider binds in `register()`, by
+contract side-effect free until `boot()` or a request asks
+(`packages/server/src/container/ServiceProvider.ts:24-27`), is rebuilt from
+source text instead.
+
+### What the gap costs
+
+1. **Controllers are re-found by name.** `Router.definitions()` serialises a
+   controller as `{ name: handler[0].name, action }` (`packages/server/src/mvc/Router.ts:723-724`),
+   so `parseControllerMethods()` keys bodies on `ClassName.method`, scans
+   `app/Http/Controllers` and `modules/*/`, and records a collision when two
+   files declare one class name; "last file scanned wins"
+   (`packages/cli/src/controller-methods.ts:40`, `:258-265`, `:293-301`). The
+   Router held the class object the whole time.
+2. **Runtime facts are re-derived from syntax.** `deploy-runtime.ts` (835 lines)
+   walks every source file for `new ScryptHasher(...)`, store constructions and a
+   `SessionConfig`-annotated object's `driver:` (`:156-192`, `:240-467`) to answer
+   three questions a registered app answers by inspection: which hasher the user
+   provider holds (`ModelUserProvider.ts:33`, `:56`), which session store is the
+   default (`session-manager.ts:93-103`), whether providers were listed or
+   discovered (`Application.ts:547-572`). `session-config.ts` (125 lines) and
+   `sessions-check.ts` (163) read the same config again; the "is the binding
+   provider registered" rule is a `\bClassName\b` regex over `src/app.ts`
+   (`sessions-check.ts:23-34`) and `appBindsService()` is a regex for
+   `singleton('session'` over every file (`discovery.ts:535-547`).
+   `attachments-check.ts` (734 lines) reads `configureAttachments({...})` call
+   arguments by AST, while the engine it configures is one
+   `setActiveAttachmentEngine()` away (`packages/core/src/attachments/configure.ts:29-40`).
+   The scan "reads constructions, not intent" (its own header), which is why
+   every verdict there is advisory (`check.ts:580-594`).
+3. **Security verdicts come from regexes over blanked bodies.** `guren audit`
+   decides "reads the body without validating" and "mutates without auth" with
+   `BODY_ACCESS_PATTERN` (`audit.ts:136`), `AUTH_CALL_PATTERN` (`:555`),
+   `mutatesRecords()` (`:633`, `controller-methods.ts:213-219`) over source with
+   comments and strings blanked (`controller-methods.ts:228`). The middleware half
+   already reads the registered definition (`authMiddlewareVerdict`, `audit.ts:115-127`),
+   but alias names are opaque strings there: `middlewareNames` carries `'auth'`,
+   not what `'auth'` resolves to (`Router.ts:296-301`).
+4. **The higher altitude is already proven reachable.** `route-contract-check.ts`,
+   `agent-route-check.ts`, `agents-types.ts` and `routes-types.ts` read registered
+   definitions (`check.ts:459-466`, `agents-types.ts:12`, `routes-types.ts:34`) and
+   the agent-tool derivation is one function shared by runtime and codegen
+   (RFC 0016 §2, "Two derivation layers, one core rule"). None of them carries a
+   "must match the rule over there" comment, because there is no second rule.
+
+### Numbers
+
+Measured at `30a26e94`, commits since 2026-06-01 touching `packages/cli`:
+
+| Population | Commits | `fix` | `feat` |
+|---|---|---|---|
+| all of `packages/cli` | 448 | 54 | 128 |
+| the six source-scanning modules (`deploy-runtime`, `session-config`, `sessions-check`, `attachments-check`, `audit`, `controller-methods`) | 63 | 5 | |
+| the four definition-reading modules (`route-contract-check`, `agent-route-check`, `agents-types`, `routes-types`) | 21 | 2, neither about drift (#515 is a server 422 change, #265 a CodeQL sweep) | |
+
+Other measures of the same tax:
+
+- The CLAUDE.md Key Files table has 12 rows whose description is "the one
+  rule / scan / reading / derivation for X". 10 are in `packages/cli`, and 7 of
+  those restate a fact the runtime holds (`route-registrar` mirrors what
+  `load-routes` resolves; `controller-methods` mirrors how `Router` dispatches;
+  `http-methods`; `deploy-runtime`; `session-config` mirrors `SessionManager`;
+  `schema-binding` mirrors a drizzle table object; `app-surface`). Each row was
+  written after a second copy of the rule drifted.
+- Tests pinning the static readings: `tests/check.test.ts` 2,332 lines,
+  `tests/audit.test.ts` 2,465, `tests/deploy-runtime.test.ts` 1,496.
+
+## Proposed Solution
+
+An introspection mode on `Application`: register providers, mount routes, never
+boot, never listen, never open a socket, and emit one serialisable manifest. The
+CLI reads the manifest where it reads source today, and keeps the source scan
+only for facts that exist nowhere but in a method body.
+
+### 1. `Application.introspect()` and `AppManifest`
+
+```ts
+// @guren/server, Application.ts
+async introspect(): Promise<AppManifest>
+
+// @guren/core (re-exported), for providers and app code
+export function isIntrospecting(): boolean   // process.env.GUREN_INTROSPECT === '1'
+```
+
+`introspect()` runs, in order: `providerManager.registerAll()` (with the
+per-provider outcome capture of §2), `mountRoutes()` (`Application.ts:643-660`;
+the registrar, `mountModuleRoutes()`, the prototype fixture import), then the
+manifest builders. It does not run `options.boot` (`Application.ts:744`: an
+arbitrary callback over Hono), does not run `bootAll()`, and never calls
+`listen()`. A second call returns the memoised manifest.
+
+```ts
+export interface AppManifest {
+  schemaVersion: 1
+  generatedAt: string
+  entry: { file: string; root: string; stage: 'register' }
+  runtime: { bun: string | null; node: string | null; platform: string }
+  providers: ProviderEntry[]
+  modules: ModuleEntry[]
+  routes: RouteEntry[]
+  middlewareAliases: Record<string, MiddlewareEntry>
+  bindings: string[]                      // container keys present after register()
+  session?: SessionEntry
+  auth?: AuthEntry
+  cache?: DriverMapEntry
+  storage?: DriverMapEntry
+  queue?: DriverMapEntry
+  attachments?: AttachmentsEntry
+  agentTools: DerivedAgentTool[]          // deriveAgentTools(routes), unchanged
+  warnings: ManifestWarning[]
+}
+
+export interface ProviderEntry {
+  name: string                            // constructor.name (durable: Guren forbids identifier mangling)
+  source: 'framework' | 'options.providers' | 'module' | 'discovered'
+  module?: string
+  deferred: boolean
+  provides: string[]
+  register: 'ran' | 'introspect-hook' | 'threw' | 'skipped'
+  error?: string
+}
+
+export interface ModuleEntry {
+  name: string; prefix?: string; providers: string[]; commands: string[]; routeCount: number
+}
+
+export interface ControllerRef {
+  name: string; action: string
+  file: string | null                     // project-relative; null when identity matching failed
+  exportName: string | null               // 'default' or the named export
+  resolved: 'identity' | 'name-only'
+}
+
+export interface MiddlewareEntry {
+  kind: 'alias' | 'group' | 'inline'
+  name: string | null
+  members?: string[]                      // for 'group'
+  capabilities: MiddlewareCapabilities    // the existing RFC 0007 shape
+  ability?: string                        // when the middleware declares one (see §3)
+}
+
+export type RouteEntry = Omit<RouteDefinition, 'schemas' | 'controller' | 'middlewareNames'> & {
+  module: string | null
+  controller?: ControllerRef
+  middleware: MiddlewareEntry[]           // scoped, then route-local; aliases resolved
+  schemas: Partial<Record<'params' | 'query' | 'body' | 'output', JsonSchema | { unreadable: string }>>
+}
+
+export interface SessionEntry {
+  source: 'manager' | 'auth.sessionOptions.store' | 'none'
+  default: string
+  stores: Record<string, { driver: string; table?: string; perProcess: boolean }>
+}
+
+export interface AuthEntry {
+  guards: string[]; defaultGuard: string | null
+  providers: Record<string, { kind: string; model?: string; hasher: string }>   // hasher: constructor.name
+}
+
+export interface DriverMapEntry { default: string; entries: Record<string, { driver: string }> }
+
+export interface AttachmentsEntry {
+  configured: boolean
+  table?: string; disk?: string
+  delivery?: { mode: 'stream' | 'redirect'; routeName: string; mounted: boolean }
+}
+
+export interface ManifestWarning { code: string; message: string; provider?: string; route?: string }
+```
+
+Each optional section is present exactly when its container key exists after
+`registerAll()` (`Container.has()`, `Container.ts:134`). The managers gain one
+read-only method each so the manifest never resolves a store:
+`SessionManager.describe()` (over the private `configs` map,
+`session-manager.ts:96`; the `database` driver's `table` reported through
+drizzle's `getTableName()`), `CacheManager.describe()`, `StorageManager.describe()`,
+`QueueManager.describe()`, `AuthManager.describe()`, and
+`describeActiveAttachmentEngine()` in `@guren/core`. `perProcess` comes from the
+same `PER_PROCESS_SESSION_DRIVERS` set the runtime warning uses.
+
+### 2. What introspection must not do
+
+Introspection runs user code, exactly as `load-routes.ts:141` does today; the
+new exposure is `src/app.ts` and the providers' `register()` bodies. The guards:
+
+| Guard | Mechanism |
+|---|---|
+| The flag | The CLI spawns a child with `GUREN_INTROSPECT=1` set before the entry's module graph evaluates. `isIntrospecting()` is the one reader. |
+| No boot, no listen | Under the flag, `Application.boot()` itself degrades to `introspect()` and `listen()` throws `Cannot listen under GUREN_INTROSPECT`. This covers an entry that boots at module scope (`bootstrapApplication()` already accepts a `ready` promise, `runtime.ts:90-100`), which `introspect()` alone could not intercept. |
+| No database | Every ORM factory defers the connection to `getDatabase()`: `createPostgresDatabase` (`packages/orm/src/postgres.ts:153-173`), `createMysqlDatabase` (`mysql.ts:165-169`), `createSqliteDatabase` (`sqlite.ts:186`), `createD1Database` (`d1.ts:59`), `createAwsDataApiDatabase` (`aws-data-api.ts:63`). Construction is free. The eager step is `configureOrm()`, which awaits migrations and opens a client (`postgres.ts:195-198`, `mysql.ts:202`, `aws-data-api.ts:200`), and the scaffold calls it from `DatabaseProvider.boot()`, never `register()` (`templates/default/app/Providers/DatabaseProvider.ts:7-16`). Stopping before `bootAll()` is the guard. An app that calls `configureOrm()` in `register()` connects; §5's reader reports it as a warning (`provider-connected-in-register`) by watching `@guren/orm`'s active-connection registry, and the verdict for that app stays advisory. |
+| Providers with eager side effects | `ServiceProvider` gains `introspect?(): void \| Promise<void>`. When present it runs *instead of* `register()` under the flag and should bind only what `describe()` needs. When absent, `register()` runs unchanged. The scaffolded providers already register thunks (`templates/scaffold/cache/.../CacheProvider.ts:8-20`, `session/config/session.ts`), and `SessionManager`, `CacheManager`, `QueueManager` resolve lazily, so none of them needs the hook. An ioredis client constructed inside `register()` without `lazyConnect` is the shape that does. |
+| A `register()` that throws | Recorded as `register: 'threw'` with the message; registration continues so the manifest still describes the rest. Every reader treats a section behind a thrown provider as unverified (§5), never as absent. |
+| A `register()` that hangs | The child has a wall-clock cap (default 30 s, `--timeout`). A timeout is a failed introspection, and Part 2's fallback applies. The child loads `.env` the way `guren dev` does and writes nothing. |
+
+### 3. Controller references and middleware resolution
+
+The Router keeps the handler tuple in its registry (`Router.ts:222`, the class
+object in `handler[0]`) and drops it at `definitions()`. Part 1 adds
+`Router.registeredHandlers(): ReadonlyArray<{ index: number; controller?: ControllerConstructor; action?: string }>`,
+index-aligned with `definitions()`. The manifest builder resolves each class to a
+file by identity: it `import()`s every discovered controller file (a cache hit,
+since the routes import already evaluated them) and compares exports with `===`.
+Two `PostController` classes in two modules are then two `ControllerRef`s with
+different `file`s, and `ControllerNameCollision` has nothing to report for routed
+controllers. A class whose file the walk does not find (declared inline in the
+routes file, say) is `resolved: 'name-only'` with `file: null`, and a body scan
+keyed on it stays on the collision-reporting path it has today.
+
+Middleware aliases resolve through the Router's own `middlewareAliases` and
+`middlewareGroups` maps (`Router.ts:373-374`), which `definitions()` never
+exposes. `MiddlewareEntry.capabilities` reuses `capabilitiesOf()` per handler.
+`ability` is filled only when the handler carries it in its capabilities; the
+framework's own authorization middleware gains that declaration in Part 1, a
+user's middleware may add it, and an absent value means "not determinable", which
+`guren audit` reports as it reports an unresolved alias today.
+
+### 4. `guren introspect --json`
+
+A new command, additive. Reads the app the way `dev` does (`resolveMainEntry()`,
+`runtime.ts:68`; `bootstrapApplication()`, `:90`), runs the child, prints the
+manifest. `--json` is the machine form; the default prints the sections as
+tables. The CLI-side reader lives in `packages/cli/src/introspect.ts`:
+
+```ts
+export type Introspection =
+  | { status: 'ok'; manifest: AppManifest }
+  | { status: 'failed'; reason: 'no-entry' | 'import' | 'timeout' | 'crashed' | 'old-server'; message: string }
+
+export async function introspectApp(cwd: string, options?: { timeoutMs?: number }): Promise<Introspection>
+```
+
+`old-server` is the app resolving a `@guren/server` without `introspect()`; the
+reader detects it structurally, as `MaybeApplication` does for `listen()`
+(`runtime.ts:15-24`). One introspection per CLI process, memoised, shared by
+every check that asks: the same shape as `check.ts`'s `loadRouteGraph()`
+(`:168-185`) and `doctor.ts`'s `createManifestPlans()` (`:1248-1256`).
+
+### 5. Who reads the manifest, who stays static
+
+| Module | Today | After Part 2 | Part 3 |
+|---|---|---|---|
+| `deploy-runtime.ts` | AST scan (`:156-467`) feeding `judgePasswordHashing`, `judgeRuntimeStores`, `judgeProviderDiscovery` (`:661-822`) | `DeployRuntimeAnalysis` built from `auth.providers[*].hasher`, `session`, `cache`, `queue`, `providers[*].source` | Extractor deleted; `checkDeployRuntime(cwd)` keeps its signature, so `@guren/core/internal/deploy-check` (`deploy-check.ts:33-58`) is untouched |
+| `session-config.ts`, `sessions-check.ts` | AST for `SessionConfig`, regex for the binding provider | `session.source === 'none'` while a `SessionConfig` file exists is the inert-config finding; `stores[*].table` against the schema export list (the schema half stays AST, §5 last row) | `session-config.ts` reduced to the schema-binding lookup |
+| `attachments-check.ts` | AST over `configureAttachments()` arguments, route lookup | `attachments.{table,disk,delivery}`; `delivery.mounted` from the routes | Argument parsing deleted; `Attachable(...)` model detection stays AST (a model file is not executed by registration) |
+| `controller-methods.ts` | key `ClassName.method`, collisions | key `file#export.method` from `ControllerRef`; the body scan itself stays | `ControllerNameCollision` reported only for `name-only` refs |
+| `audit.ts` auth/validation | middleware names + body regex | resolved `middleware[]` with capabilities and `ability`; contract `schemas.body` presence; body regex only for the in-action `userOrFail()` / `validateBody()` case | unchanged scope |
+| `audit.ts` raw SQL, secrets, mass assignment, CSRF exemptions | source and `node_modules` scans (`:656-660`, `csrf-exemption-audit.ts`) | unchanged: body-level and dependency-level facts | unchanged |
+| `route-contract-check`, `agent-route-check`, `agents-types`, `routes-types`, `prototype-check` | `loadRouteDefinitions()` | the manifest's `routes` (a `RouteDefinition` superset) plus `module` provenance; no rule changes | `load-routes.ts` becomes the static fallback only |
+| `doctor.ts` deploy section, `context.ts`, `spec-generate.ts` | `analyzeDeployRuntime`, `loadContextRoutes` | manifest | |
+| `docs-check`, `docs-index`, `i18n-check`, `spec-check`, `arch-check`, `audit:prose` | static | static by nature: prose, links, import graphs | |
+| `schema-parser`, `schema-check`, `schema-binding` | Drizzle AST | static: the database is never opened, and `db/schema.ts` is data, not behaviour | |
+| all `make:*` / `add` scaffolders, `route-registrar` patching, `inflect`, `drizzle-pins` | static | static: they write source, and must run on an app that does not compile yet | |
+
+Fallback rule for Part 2: when `introspectApp()` returns `failed`, every check in
+the first five rows runs its current static path and marks the result
+`evidence: 'static'`; a check that has no static path reports
+`status: 'warn'` with `unverified` in the key; a section behind a provider whose
+`register` is `'threw'` is treated the same way. No verdict is ever `pass` on
+absent evidence: `CheckResult` gains `evidence: 'manifest' | 'static' | 'none'`.
+
+### 6. Enabling refactor: one module per command
+
+`commands.ts` becomes `packages/cli/src/commands/<name>.ts`, one `defineCommand()`
+each, plus `commands/index.ts` holding a registry:
+
+```ts
+export const COMMANDS: Record<string, () => Promise<{ default: CommandDef }>> = {
+  'check': () => import('./check'),
+  'introspect': () => import('./introspect'),
+  // ...67 entries
+}
+```
+
+`bin.ts` passes the loaders to citty as lazy `subCommands`, so one invocation
+imports one command. Non-breaking: names, flags and output are byte-identical.
+It lands before Part 1 so the new command has somewhere to go that is not line 3,421.
+
+### Implementation plan
+
+Referencing `RFC 0026` in each PR:
+
+0. **Split** (§6). `@guren/cli` only; no behaviour change. Its own PR.
+1. **Manifest** (§1-§4). `@guren/server`: `introspect()`, the `boot()`/`listen()`
+   flag behaviour, `ServiceProvider.introspect?`, `Router.registeredHandlers()`,
+   the `describe()` methods, `AppManifest` types, the `ability` capability.
+   `@guren/core`: `isIntrospecting()`, `describeActiveAttachmentEngine()`,
+   `createSessionManager` unchanged. `@guren/cli`: `introspect.ts`, `guren
+   introspect`. Additive; minor releases for server, core (the allowlist rule)
+   and cli; `examples/blog` and `web/` produce a manifest in CI.
+2. **Consumers** (§5 rows 1-8) with the static fallback and `evidence`. Verdicts
+   may change for an app where the source scan guessed wrong; each such change is
+   a changeset entry naming the check key.
+3. **Retire** the source scans the table marks. `tests/deploy-runtime.test.ts`
+   shrinks to the judge functions over manifest fixtures; the CLAUDE.md rows for
+   `deploy-runtime`, `session-config` and the collision half of
+   `controller-methods` are rewritten to point at the manifest.
+
+## Alternatives Considered
+
+**Keep static-only.** The drift tax is the numbers above: 5 fixes in 63 commits
+on six modules, 3,246 lines of source and 6,293 of tests whose job is to agree
+with a runtime they cannot see, and 12 "the one rule" rows written after a
+disagreement. Every advisory verdict in `guren check` is advisory because the
+scan "never reads intent". The cost also compounds per feature: RFC 0020 Part 0
+had to add a `SessionConfig` reader before the driver existed, and
+`attachments-check.ts` grew to 734 lines across RFC 0013 and RFC 0015. A
+manifest makes the next feature's check a field lookup.
+
+**Full boot, including `listen()`.** Rejected. `bootAll()` runs
+`configureOrm()` through the scaffolded `DatabaseProvider`, which migrates and
+connects; a check that needs a database is not a check that runs in CI on a
+fresh clone. `listen()` needs Bun and a port.
+
+**A build-time manifest from the Vite plugin.** The route-types plugin already
+spawns the CLI on changes to `routes/web.ts`, pages and resources
+(`packages/cli/src/vite/route-types.ts:14-22`, `:47`) and is off under `CI`
+(`:40`). It could write `.guren/manifest.json` on every regeneration. A cache
+of Part 1 at most, not a replacement: an API-only app has no Vite, CI skips the
+plugin, and a manifest on disk is the stale-artifact class `common-pitfalls.md`
+warns about. If it ships, `introspectApp()` prefers a live run.
+
+**Reuse the MCP endpoint.** `/_guren/mcp` runs inside a booted app, but its
+tools (`create-mcp-server.ts:212-510`) call the CLI's static scans, and it needs
+`GUREN_MCP=1` plus a listening server. A transport, not a source of facts.
+
+## Migration Path
+
+Internal for the most part:
+
+- `Application.introspect()`, `isIntrospecting()`, `ServiceProvider.introspect?`,
+  `Router.registeredHandlers()` and the `describe()` methods are additive. A
+  provider written before this RFC introspects through its `register()`
+  unchanged.
+- `boot()` under `GUREN_INTROSPECT=1` stops before `bootAll()`. Nothing sets that
+  variable today; a user who exports it in a shell and runs `guren dev` sees the
+  `listen()` refusal name the variable.
+- User-visible changes are limited to a check whose verdict moves because the
+  manifest contradicts the scan (a `SessionStore` passed as `store:` that the
+  scan read as unbacked becomes `pass`; a `configureOrm()` in `register()`
+  becomes a warning). Each is listed in the Part 2 changeset under the check key.
+- `loadRouteDefinitions()` is not deprecated: it is the static fallback and the
+  path for a scaffold mid-generation whose `src/app.ts` does not import yet.
+- No deprecation is introduced, so `deprecations.ts` and `codemods.ts` are
+  untouched. Changesets: `@guren/server` minor, `@guren/core` minor,
+  `@guren/cli` minor for Part 1; `@guren/cli` minor for Parts 0, 2, 3.
+
+## Open Questions
+
+1. **Workers-only providers that touch bindings at `register()`.**
+   `getWorkersEnv()` throws before the first request captures `env`
+   (`packages/plugin-cloudflare/src/env.ts:27-34`), and `bootWorkersApp()` runs
+   `boot()` only after `captureWorkersEnv(env)` (`boot.ts:46-58`). A provider
+   that reads `env.DB` in `register()` therefore throws under introspection and
+   lands as `register: 'threw'`. Is a `ServiceProvider.introspect?` on the
+   plugin's own providers enough, or should `@guren/plugin-cloudflare` ship a
+   `captureWorkersEnv(stubFromWranglerConfig())` for the introspection child,
+   reading `wrangler.jsonc` the way `build.ts:521-532` already does?
+2. **Side effects at import.** `modules/*/index.ts` is imported today
+   (`load-routes.ts:109`); `src/app.ts` is the new exposure. Should `guren
+   introspect` refuse an entry whose module scope calls `listen()` (detected by
+   the throw) with a pointer to the `bin/serve.ts` shape, or report silently?
+3. **`options.boot` callback.** Skipped in §1 because it is arbitrary code over
+   Hono. An app that registers routes inside it (the pre-registrar shape) then
+   shows fewer routes under introspection than at runtime. Report a warning when
+   the callback is present, or run it and accept the exposure?
+4. **`getCookielessAuthPaths()`.** Declared in `boot()` after `mountRoutes()`
+   (`Application.ts:617-618`), so a register-stage manifest cannot list them
+   and `csrf-exemption-audit.ts` keeps its `node_modules` scan. Is a
+   `declareCookielessAuthPath()` moved to `register()` worth the ordering
+   change it would need?
+5. **Schema JSON.** `RouteEntry.schemas` is JSON Schema through the `zod-compat`
+   walker `@guren/openapi` uses. Should `route-contract-check` keep the live Zod
+   object instead, at the price of never running from a manifest file?


### PR DESCRIPTION
## Summary

Four Draft RFCs from a whole-framework design review (2026-09). Each cites the code at 30a26e94 and follows `contributing/rfc-process.md`.

- **0023 Container-Only Service Resolution.** Sixteen module-level service slots sit beside the DI container and consumers read the slots, not the container. Proposes container-first resolution with a deprecation path for the `set*`/`get*` pairs.
- **0024 One Runtime Package.** `@guren/core` re-exports all of `@guren/server` yet versions independently; the core/cli cycle and several gates exist only to keep the two names consistent. Proposes folding server into core (3.0.0) with a one-major shim and a codemod.
- **0025 One Read Pipeline for Models.** Reads fork on `hasScopes()` and `Model.query()` drops scopes; relations are declared three times. Proposes one `QueryBuilder` materialisation and a single relation declaration. The fix branch for casts is acknowledged as Part 0.
- **0026 Introspection Boot.** The CLI already executes the user's module graph to read the router but stops before providers, then re-derives their facts from source. Proposes `Application.introspect()` and a manifest the checks consume.

All four are `Status: Draft`; nothing is decided here.
