### PR TITLE
test: pin that a Durable Object keeps undeferred side-channel work

### DIFF
--- a/.changeset/durable-agent-side-channels.md
+++ b/.changeset/durable-agent-side-channels.md
@@ -1,0 +1,18 @@
+---
+"@guren/plugin-agents": patch
+---
+
+Record why durable agents hand no side channel to `waitUntil`
+
+The App MCP endpoint hands its audit sink and approval notification to
+`ExecutionContext.waitUntil`, because workerd abandons a promise that a fetch
+handler's request context does not know about. The changes that added this left
+the durable surface alone and named the reason an open question: whether a
+Durable Object drops such a promise too.
+
+It does not. Under Miniflare, an undeferred write started from a Durable
+Object's `fetch`, an RPC method, `alarm`, or `webSocketMessage` landed every
+time, including one still pending 30 seconds after the handler returned, while
+the same write from a plain fetch handler in the same run was lost. The tool
+client keeps building both channels with no deferrer and now says why beside
+the code. Nothing changes at runtime.

--- a/packages/plugin-agents/src/tool-client.ts
+++ b/packages/plugin-agents/src/tool-client.ts
@@ -186,8 +186,9 @@ export interface AgentToolClientOptions {
 }
 
 /**
- * Build the tool client for one agent instance.
- *
+ * Build the tool client for one agent instance, inside a Durable Object: the
+ * audit record and approval notification are not handed to `waitUntil`, so a
+ * Worker's fetch handler would lose both.
  * @throws When `agentName` names no registration — a wiring bug, not a scope
  *   denial, and a denial would send the author to the wrong file.
  */
@@ -230,7 +231,6 @@ export function createAgentToolClient(options: AgentToolClientOptions): AgentToo
   // approval is bound to who asked for it. No deferrer, here or on the audit
   // emitter below: a Durable Object finishes work its handler left running, which
   // a fetch handler drops (@guren/server tests/agent/durable-object.workerd.test.ts).
-  // Called from a Worker's fetch handler instead, both would be lost.
   const approvals = createAgentApprovalContext(runtime.approvals, principal)
 
   // Forwarded per event, not resolved here: the binding behind

--- a/packages/plugin-agents/src/tool-client.ts
+++ b/packages/plugin-agents/src/tool-client.ts
@@ -227,7 +227,10 @@ export function createAgentToolClient(options: AgentToolClientOptions): AgentToo
   )
 
   // Per client, which is per instance, because the principal above is: an
-  // approval is bound to who asked for it.
+  // approval is bound to who asked for it. No deferrer, here or on the audit
+  // emitter below: a Durable Object finishes work its handler left running, which
+  // a fetch handler drops (@guren/server tests/agent/durable-object.workerd.test.ts).
+  // Called from a Worker's fetch handler instead, both would be lost.
   const approvals = createAgentApprovalContext(runtime.approvals, principal)
 
   // Forwarded per event, not resolved here: the binding behind

--- a/packages/server/tests/agent/durable-object.worker.ts
+++ b/packages/server/tests/agent/durable-object.worker.ts
@@ -1,0 +1,145 @@
+// Worker entry for durable-object.workerd.test.ts — bundled with Bun.build at
+// test time and executed inside workerd. Both side channels are built the way
+// @guren/plugin-agents' tool client builds them, with no deferrer, then started
+// from each Durable Object entry point and, as the control, a fetch handler.
+
+// @ts-expect-error -- workerd supplies this module; the root program carries no Workers types.
+import { DurableObject } from 'cloudflare:workers'
+
+import type { AgentApprovalStore } from '../../src/agent/approval'
+import { buildAgentApprovalRequest } from '../../src/agent/approval'
+import { createAuditEmitter } from '../../src/agent/audit-emitter'
+import { AgentToolInvoked } from '../../src/agent/events'
+import { createAgentApprovalContext } from '../../src/agent/pipeline'
+
+interface D1 {
+  prepare: (sql: string) => { bind: (...values: unknown[]) => { run: () => Promise<unknown> } }
+}
+
+/** Bun's `WebSocket` type has no `accept`, which a workerd socket needs before use. */
+interface WorkerdSocket extends WebSocket {
+  accept(): void
+}
+
+declare const WebSocketPair: new () => { 0: WorkerdSocket; 1: WorkerdSocket }
+
+interface ProbeState {
+  storage: {
+    put(key: string, value: string): Promise<void>
+    get(key: string): Promise<string | undefined>
+    setAlarm(at: number): Promise<void>
+  }
+  acceptWebSocket(socket: WorkerdSocket, tags: string[]): void
+  getTags(socket: WorkerdSocket): string[]
+}
+
+interface ProbeStub {
+  fetch(input: string, init?: RequestInit): Promise<Response>
+  enter(via: string): Promise<void>
+  arm(via: string): Promise<void>
+}
+
+interface Env {
+  DB: D1
+  PROBE: { idFromName(name: string): unknown; get(id: unknown): ProbeStub }
+}
+
+const principal = { kind: 'service' as const, id: 'agent:probe:instance', abilities: [] }
+
+/** Neither channel is awaited nor deferred, as in a tool call's handler. */
+function startChannels(db: D1, via: string): void {
+  const land = async (row: string): Promise<void> => {
+    // Still in flight when the handler returns: a D1 write or a webhook round
+    // trip is this, the round trip being the delay.
+    await new Promise((done) => setTimeout(done, 50))
+    await db.prepare('INSERT INTO landed (tool) VALUES (?)').bind(row).run()
+  }
+
+  createAuditEmitter((record) => land(`audit:${record.tool}`), undefined)(
+    new AgentToolInvoked(principal, via, {}, 200, 1, 'durable'),
+  )
+
+  const approvals = createAgentApprovalContext(
+    // Never read: only `notify` runs here.
+    { store: {} as AgentApprovalStore, notify: (request) => land(`notify:${request.tool}`) },
+    principal,
+  )
+  approvals?.notify(
+    buildAgentApprovalRequest({ tool: via, input: {}, fingerprint: 'fp', principal }, new Date()),
+  )
+}
+
+export class ProbeObject extends DurableObject {
+  declare readonly ctx: ProbeState
+  declare readonly env: Env
+
+  async fetch(request: Request): Promise<Response> {
+    const via = new URL(request.url).searchParams.get('tool') ?? 'unknown'
+    if (request.headers.get('Upgrade') === 'websocket') {
+      const pair = new WebSocketPair()
+      this.ctx.acceptWebSocket(pair[1], [via])
+      return new Response(null, { status: 101, webSocket: pair[0] } as ResponseInit)
+    }
+    startChannels(this.env.DB, via)
+    return new Response('ok')
+  }
+
+  async enter(via: string): Promise<void> {
+    startChannels(this.env.DB, via)
+  }
+
+  async arm(via: string): Promise<void> {
+    await this.ctx.storage.put('via', via)
+    await this.ctx.storage.setAlarm(Date.now())
+  }
+
+  async alarm(): Promise<void> {
+    startChannels(this.env.DB, (await this.ctx.storage.get('via')) ?? 'unknown')
+  }
+
+  async webSocketMessage(socket: WorkerdSocket): Promise<void> {
+    startChannels(this.env.DB, this.ctx.getTags(socket)[0] ?? 'unknown')
+    socket.send('started')
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const via = new URL(request.url).searchParams.get('tool') ?? 'unknown'
+    // One instance per case, so no later dispatch is what keeps it alive.
+    const stub = env.PROBE.get(env.PROBE.idFromName(via))
+
+    switch (via) {
+      case 'handler':
+        startChannels(env.DB, via)
+        break
+      case 'fetch':
+        await (await stub.fetch(request.url)).arrayBuffer()
+        break
+      case 'rpc':
+        await stub.enter(via)
+        break
+      case 'alarm':
+        await stub.arm(via)
+        break
+      case 'websocket':
+        await converse(stub, request.url)
+        break
+      default:
+        return new Response(`unknown entry point ${via}`, { status: 400 })
+    }
+    return new Response('ok')
+  },
+}
+
+/** The client half runs in workerd: Bun's `ws` shim cannot complete Miniflare's upgrade. */
+async function converse(stub: ProbeStub, url: string): Promise<void> {
+  const upgraded = await stub.fetch(url, { headers: { Upgrade: 'websocket' } })
+  const socket = (upgraded as Response & { webSocket: WorkerdSocket | null }).webSocket
+  if (!socket) throw new Error(`the Durable Object answered ${upgraded.status} without a socket`)
+  socket.accept()
+  const reply = new Promise((done) => socket.addEventListener('message', done, { once: true }))
+  socket.send('go')
+  await reply
+  socket.close(1000, 'done')
+}

--- a/packages/server/tests/agent/durable-object.worker.ts
+++ b/packages/server/tests/agent/durable-object.worker.ts
@@ -24,19 +24,14 @@ interface WorkerdSocket extends WebSocket {
 declare const WebSocketPair: new () => { 0: WorkerdSocket; 1: WorkerdSocket }
 
 interface ProbeState {
-  storage: {
-    put(key: string, value: string): Promise<void>
-    get(key: string): Promise<string | undefined>
-    setAlarm(at: number): Promise<void>
-  }
-  acceptWebSocket(socket: WorkerdSocket, tags: string[]): void
-  getTags(socket: WorkerdSocket): string[]
+  storage: { setAlarm(at: number): Promise<void> }
+  acceptWebSocket(socket: WorkerdSocket): void
 }
 
 interface ProbeStub {
   fetch(input: string, init?: RequestInit): Promise<Response>
-  enter(via: string): Promise<void>
-  arm(via: string): Promise<void>
+  enter(): Promise<void>
+  arm(): Promise<void>
 }
 
 interface Env {
@@ -74,31 +69,29 @@ export class ProbeObject extends DurableObject {
   declare readonly env: Env
 
   async fetch(request: Request): Promise<Response> {
-    const via = new URL(request.url).searchParams.get('tool') ?? 'unknown'
     if (request.headers.get('Upgrade') === 'websocket') {
       const pair = new WebSocketPair()
-      this.ctx.acceptWebSocket(pair[1], [via])
+      this.ctx.acceptWebSocket(pair[1])
       return new Response(null, { status: 101, webSocket: pair[0] } as ResponseInit)
     }
-    startChannels(this.env.DB, via)
+    startChannels(this.env.DB, 'fetch')
     return new Response('ok')
   }
 
-  async enter(via: string): Promise<void> {
-    startChannels(this.env.DB, via)
+  async enter(): Promise<void> {
+    startChannels(this.env.DB, 'rpc')
   }
 
-  async arm(via: string): Promise<void> {
-    await this.ctx.storage.put('via', via)
+  async arm(): Promise<void> {
     await this.ctx.storage.setAlarm(Date.now())
   }
 
   async alarm(): Promise<void> {
-    startChannels(this.env.DB, (await this.ctx.storage.get('via')) ?? 'unknown')
+    startChannels(this.env.DB, 'alarm')
   }
 
   async webSocketMessage(socket: WorkerdSocket): Promise<void> {
-    startChannels(this.env.DB, this.ctx.getTags(socket)[0] ?? 'unknown')
+    startChannels(this.env.DB, 'websocket')
     socket.send('started')
   }
 }
@@ -117,10 +110,10 @@ export default {
         await (await stub.fetch(request.url)).arrayBuffer()
         break
       case 'rpc':
-        await stub.enter(via)
+        await stub.enter()
         break
       case 'alarm':
-        await stub.arm(via)
+        await stub.arm()
         break
       case 'websocket':
         await converse(stub, request.url)

--- a/packages/server/tests/agent/durable-object.workerd.test.ts
+++ b/packages/server/tests/agent/durable-object.workerd.test.ts
@@ -1,0 +1,30 @@
+/**
+ * The question #775 and #778 left open: does a Durable Object abandon a side
+ * channel its handler left running, the way a fetch handler does? It does not,
+ * from any of the four ways an agent's code runs there. That is why
+ * `@guren/plugin-agents` builds its audit emitter and approval context with no
+ * deferrer, where the App MCP endpoint must pass `waitUntil`.
+ */
+import { describe, expect, test } from 'bun:test'
+
+import { runDeferralCase, workerdEnabled, type DeferralCase } from './workerd-deferral'
+
+const ENTRY_POINTS = ['fetch', 'rpc', 'alarm', 'websocket'] as const
+
+describe.skipIf(!workerdEnabled)('an undeferred side channel inside a Durable Object', () => {
+  test('should land from every Durable Object entry point while a fetch handler loses it', async () => {
+    const entry = new URL('./durable-object.worker.ts', import.meta.url).pathname
+    const cases: DeferralCase[] = [['handler', '0'], ...ENTRY_POINTS.map((via) => [via, '0'] as const)]
+
+    const landed = await runDeferralCase(entry, 'landed', {
+      cases,
+      durableObjects: { PROBE: 'ProbeObject' },
+    })
+
+    // `handler` is absent from both halves: the control that shows this run
+    // can see a write being dropped at all.
+    expect(landed).toEqual(
+      ENTRY_POINTS.flatMap((via) => [`audit:${via}`, `notify:${via}`]).sort(),
+    )
+  }, 60_000)
+})

--- a/packages/server/tests/agent/durable-object.workerd.test.ts
+++ b/packages/server/tests/agent/durable-object.workerd.test.ts
@@ -7,17 +7,16 @@
  */
 import { describe, expect, test } from 'bun:test'
 
-import { runDeferralCase, workerdEnabled, type DeferralCase } from './workerd-deferral'
+import { runDeferralCase, workerdEnabled } from './workerd-deferral'
 
 const ENTRY_POINTS = ['fetch', 'rpc', 'alarm', 'websocket'] as const
 
 describe.skipIf(!workerdEnabled)('an undeferred side channel inside a Durable Object', () => {
   test('should land from every Durable Object entry point while a fetch handler loses it', async () => {
     const entry = new URL('./durable-object.worker.ts', import.meta.url).pathname
-    const cases: DeferralCase[] = [['handler', '0'], ...ENTRY_POINTS.map((via) => [via, '0'] as const)]
 
     const landed = await runDeferralCase(entry, 'landed', {
-      cases,
+      cases: ['handler', ...ENTRY_POINTS].map((via) => `tool=${via}`),
       durableObjects: { PROBE: 'ProbeObject' },
     })
 

--- a/packages/server/tests/agent/workerd-deferral.ts
+++ b/packages/server/tests/agent/workerd-deferral.ts
@@ -1,19 +1,41 @@
 /**
- * The Miniflare harness both deferral suites run on. Shared because it encodes
+ * The Miniflare harness the deferral suites run on. Shared because it encodes
  * runtime knowledge that has to move in lockstep — the compat date, the flags,
- * the explicit module list, the settle window — and both suites are gated behind
+ * the explicit module list, the settle window — and every suite is gated behind
  * GUREN_TEST_WRANGLER=1 and skipped in CI, so a copy left behind when Miniflare
  * moves fails nowhere and is found by whoever next runs the suite locally.
  */
 
+/** One dispatch, sent as `?tool=<tool>&defer=<defer>`. */
+export type DeferralCase = readonly [tool: string, defer: '0' | '1']
+
+export interface DeferralOptions {
+  cases?: readonly DeferralCase[]
+  /** Binding name → the Durable Object class the fixture exports. */
+  durableObjects?: Record<string, string>
+}
+
+const UNDEFERRED_THEN_DEFERRED: readonly DeferralCase[] = [['undeferred', '0'], ['deferred', '1']]
+
 /**
- * Bundle `entry`, dispatch it twice inside workerd — once undeferred, once
- * deferred — and answer which of the two writes reached D1. Only the deferred
- * one may: green in both directions is the answer that proves nothing, which is
- * why the caller asserts the pair rather than a single row.
+ * Bundle `entry`, dispatch each case once inside workerd, and answer which
+ * writes reached D1, sorted. The cases must include one expected to be dropped:
+ * all-landed is the answer that proves nothing, which is why the caller asserts
+ * the whole set rather than a single row.
  */
-export async function runDeferralCase(entry: string, table: string): Promise<string[]> {
-  const build = await Bun.build({ entrypoints: [entry], target: 'browser', format: 'esm', minify: false })
+export async function runDeferralCase(
+  entry: string,
+  table: string,
+  options: DeferralOptions = {},
+): Promise<string[]> {
+  const build = await Bun.build({
+    entrypoints: [entry],
+    target: 'browser',
+    format: 'esm',
+    minify: false,
+    // Supplied by workerd at run time; there is nothing on disk to bundle.
+    external: ['cloudflare:workers'],
+  })
   if (!build.success) {
     throw new Error(build.logs.map((log) => String(log)).join('\n'))
   }
@@ -24,6 +46,7 @@ export async function runDeferralCase(entry: string, table: string): Promise<str
     // import graph itself, which is stricter than what wrangler ships to workerd.
     modules: [{ type: 'ESModule', path: 'worker.js', contents: await build.outputs[0]!.text() }],
     d1Databases: ['DB'],
+    ...(options.durableObjects ? { durableObjects: options.durableObjects } : {}),
     compatibilityDate: '2026-07-01',
     compatibilityFlags: ['nodejs_compat'],
   })
@@ -32,9 +55,9 @@ export async function runDeferralCase(entry: string, table: string): Promise<str
     const db = await mf.getD1Database('DB')
     await db.prepare(`CREATE TABLE ${table} (tool TEXT)`).run()
 
-    for (const [tool, defer] of [['undeferred', '0'], ['deferred', '1']] as const) {
+    for (const [tool, defer] of options.cases ?? UNDEFERRED_THEN_DEFERRED) {
       const response = await mf.dispatchFetch(`http://localhost/?tool=${tool}&defer=${defer}`)
-      if (response.status !== 200) throw new Error(`worker answered ${response.status}`)
+      if (response.status !== 200) throw new Error(`worker answered ${response.status} for ${tool}`)
       await response.arrayBuffer()
     }
 
@@ -43,11 +66,12 @@ export async function runDeferralCase(entry: string, table: string): Promise<str
     await new Promise((done) => setTimeout(done, 1500))
 
     const rows = (await db.prepare(`SELECT tool FROM ${table}`).all()) as { results: { tool: string }[] }
-    return rows.results.map((row) => row.tool)
+    // Sorted because an alarm or a socket message lands in no dispatch order.
+    return rows.results.map((row) => row.tool).sort()
   } finally {
     await mf.dispose()
   }
 }
 
-/** Miniflare spawns workerd, a native binary, so both suites opt in explicitly. */
+/** Miniflare spawns workerd, a native binary, so the suites opt in explicitly. */
 export const workerdEnabled = process.env.GUREN_TEST_WRANGLER === '1'

--- a/packages/server/tests/agent/workerd-deferral.ts
+++ b/packages/server/tests/agent/workerd-deferral.ts
@@ -6,16 +6,14 @@
  * moves fails nowhere and is found by whoever next runs the suite locally.
  */
 
-/** One dispatch, sent as `?tool=<tool>&defer=<defer>`. */
-export type DeferralCase = readonly [tool: string, defer: '0' | '1']
-
 export interface DeferralOptions {
-  cases?: readonly DeferralCase[]
+  /** Query strings, each dispatched once as `/?<case>`. */
+  cases?: readonly string[]
   /** Binding name → the Durable Object class the fixture exports. */
   durableObjects?: Record<string, string>
 }
 
-const UNDEFERRED_THEN_DEFERRED: readonly DeferralCase[] = [['undeferred', '0'], ['deferred', '1']]
+const UNDEFERRED_THEN_DEFERRED = ['tool=undeferred&defer=0', 'tool=deferred&defer=1']
 
 /**
  * Bundle `entry`, dispatch each case once inside workerd, and answer which
@@ -46,7 +44,7 @@ export async function runDeferralCase(
     // import graph itself, which is stricter than what wrangler ships to workerd.
     modules: [{ type: 'ESModule', path: 'worker.js', contents: await build.outputs[0]!.text() }],
     d1Databases: ['DB'],
-    ...(options.durableObjects ? { durableObjects: options.durableObjects } : {}),
+    durableObjects: options.durableObjects,
     compatibilityDate: '2026-07-01',
     compatibilityFlags: ['nodejs_compat'],
   })
@@ -55,9 +53,9 @@ export async function runDeferralCase(
     const db = await mf.getD1Database('DB')
     await db.prepare(`CREATE TABLE ${table} (tool TEXT)`).run()
 
-    for (const [tool, defer] of options.cases ?? UNDEFERRED_THEN_DEFERRED) {
-      const response = await mf.dispatchFetch(`http://localhost/?tool=${tool}&defer=${defer}`)
-      if (response.status !== 200) throw new Error(`worker answered ${response.status} for ${tool}`)
+    for (const query of options.cases ?? UNDEFERRED_THEN_DEFERRED) {
+      const response = await mf.dispatchFetch(`http://localhost/?${query}`)
+      if (response.status !== 200) throw new Error(`worker answered ${response.status} for ?${query}`)
       await response.arrayBuffer()
     }
 


### PR DESCRIPTION
Follow-up to #775 and #778. Those two PRs deferred the App MCP endpoint's audit sink and approval notification through `ExecutionContext.waitUntil`. They left `@guren/plugin-agents` alone because nobody knew whether a Durable Object drops an undeferred promise the way a fetch handler does.

## Answer: it does not

Measured under Miniflare (workerd 1.20260801.1, compat date 2026-07-01). Each write was started without being awaited or deferred, and delayed before it reached D1:

| Where the write starts | 50 ms | 5 s | 30 s |
| --- | --- | --- | --- |
| plain fetch handler (control) | lost | lost | lost |
| Durable Object `fetch` | landed | landed | landed |
| Durable Object RPC method | landed | landed | landed |
| Durable Object `alarm` | landed | landed | landed |
| Durable Object `webSocketMessage` | landed | landed | landed |

Each case gets its own Durable Object instance, so no later dispatch is what keeps it alive. D1 is read only after the outer fetch has returned. The 5 s and 30 s columns come from a throwaway probe. The committed test runs the 50 ms column.

That rules out a runtime change. This PR adds a test and a comment, and nothing changes at runtime.

## Changes

- **New suite** (`packages/server/tests/agent/durable-object.workerd.test.ts` and `durable-object.worker.ts`). The fixture builds both side channels the way `tool-client.ts` does: `createAuditEmitter(sink)` and `createAgentApprovalContext(config, principal)`, neither given a deferrer. It starts them from the four Durable Object entry points, with the fetch-handler control in the same run. Like the other two workerd suites, it only runs when `GUREN_TEST_WRANGLER=1`.
- **Shared harness** (`packages/server/tests/agent/workerd-deferral.ts`). It now takes optional `cases` (whole query strings) and `durableObjects`, marks `cloudflare:workers` external, and returns rows sorted, because an alarm does not land in dispatch order. The two existing suites send the same query strings as before and still pass.
- **`packages/plugin-agents/src/tool-client.ts`**, comments only:
  - Beside the approval context: why neither it nor the audit emitter gets a deferrer, with a pointer to the test.
  - On `createAgentToolClient`'s JSDoc: the function is meant to run inside a Durable Object. It is exported from `@guren/plugin-agents/runtime`, and a caller in a Worker's fetch handler would lose both channels. This PR adds no API for that case.
- **Changeset:** `@guren/plugin-agents` patch.

## Not measured

- Miniflare does not reproduce production eviction of an idle Durable Object (tens of seconds without events).
- I did not test whether a Durable Object's own `waitUntil` has any effect.

The comments claim only what was measured.

## Possible follow-up

The new suite runs locally only; it is opt-in like its two siblings. It also exercises a copy of the tool client's wiring, not `createAgentToolClient` itself. A positive check in plugin-agents' CI lane (`tests/workers/approvals.workers.ts`) would catch drift if the real call path changes: assert that a delayed `notify` from a real agent tool call lands. That lane cannot show a write being dropped, so the control stays here.

## Out of scope

`packages/server/src/logging/Logger.ts` fires async `LogChannel` writes the same way. No shipped channel is affected, since all of them are local. `Logger` is a long-lived singleton with no request context, so deferring its writes needs its own design (a per-request logger or AsyncLocalStorage). That work is in a separate change.

## Gates

- `bun run build`: green
- `bun run typecheck`: green (after `bun run build:routes` for the example apps' codegen)
- `bun run lint`: green
- `GUREN_TEST_WRANGLER=1 bun test` on all three workerd suites: 3 pass
- plugin-agents `bun test`: 111 pass
- `audit:core-semver` and `audit:plugin-compat`: pass
- `bun run test`: the full run was stopped before it finished, with no failures in its output up to that point.
