### PR TITLE
fix(web): report readers instead of scanner traffic

### DIFF
--- a/web/app/Http/Middleware/site-analytics.ts
+++ b/web/app/Http/Middleware/site-analytics.ts
@@ -2,11 +2,11 @@ import { defineMiddleware } from '@guren/core'
 import { getWorkersEnv } from '@guren/plugin-cloudflare'
 
 /**
- * Cookie-less, server-side request analytics into Workers Analytics Engine: this
- * audience blocks client beacons and AI agents run no JavaScript. No cookies, IPs
- * or full referrers are stored, so no consent banner. SQL API positions: index1 ua
- * class; blob1..8 pathname, content class, ua class, referrer host ('' = direct or
- * same-site), Accept-Language, country, method, initial|inertia; double1..2 status, ms.
+ * Cookie-less, server-side analytics into Workers Analytics Engine: this audience
+ * blocks client beacons and AI agents run no JavaScript. No cookies, IPs, full
+ * referrers or full user agents are stored, so no consent banner. SQL API: index1 ua
+ * class; blob1..9 path, content, ua class, referrer host ('' = direct/same-site),
+ * Accept-Language, country, method, initial|inertia, UA token; double1..2 status, ms.
  */
 
 interface AnalyticsEngineDataset {
@@ -33,6 +33,14 @@ export function classifyUserAgent(userAgent: string): UserAgentClass {
   if (AI_AGENT_PATTERN.test(userAgent)) return 'ai-agent'
   if (BOT_PATTERN.test(userAgent)) return 'bot'
   return 'human'
+}
+
+// The alternative that matched, so an over-broad one shows up in the data. Every
+// alternative is a literal, which keeps this to a fixed vocabulary rather than
+// arbitrary user-agent text.
+export function userAgentToken(userAgent: string): string {
+  const match = AI_AGENT_PATTERN.exec(userAgent) ?? BOT_PATTERN.exec(userAgent)
+  return match ? match[0].toLowerCase() : ''
 }
 
 export function classifyContent(pathname: string): string {
@@ -92,7 +100,8 @@ export function createSiteAnalyticsMiddleware(
         const dataset = resolveDataset()
         if (dataset) {
           const url = new URL(c.req.url)
-          const uaClass = classifyUserAgent(c.req.header('user-agent') ?? '')
+          const userAgent = c.req.header('user-agent') ?? ''
+          const uaClass = classifyUserAgent(userAgent)
           const cf = (c.req.raw as { cf?: { country?: string } }).cf
           dataset.writeDataPoint({
             indexes: [uaClass],
@@ -105,6 +114,7 @@ export function createSiteAnalyticsMiddleware(
               cf?.country ?? '',
               c.req.method,
               c.req.header('x-inertia') ? 'inertia' : 'initial',
+              userAgentToken(userAgent),
             ],
             doubles: [c.res?.status ?? 0, Date.now() - startedAt],
           })

--- a/web/app/Http/Middleware/site-analytics.ts
+++ b/web/app/Http/Middleware/site-analytics.ts
@@ -37,6 +37,8 @@ export function classifyUserAgent(userAgent: string): UserAgentClass {
 
 export function classifyContent(pathname: string): string {
   if (pathname === '/llms.txt' || pathname === '/llms-full.txt') return 'llms'
+  // Feed clients poll it on a timer; under `blog` it would count as reading.
+  if (pathname === '/blog/rss.xml') return 'feed'
   if (pathname.endsWith('.md')) return 'markdown'
   if (pathname === '/' || pathname === '') return 'home'
   if (pathname === '/docs' || pathname.startsWith('/docs/')) return 'docs'

--- a/web/scripts/analytics-report.ts
+++ b/web/scripts/analytics-report.ts
@@ -24,42 +24,70 @@ if (!Number.isSafeInteger(days) || days < 1 || days > 90) {
 // Data point layout: see web/app/Http/Middleware/site-analytics.ts.
 const WINDOW = `timestamp > NOW() - INTERVAL '${days}' DAY`
 
+// A browser-like user agent is classed `human`, so scanners land there: in the
+// 30 days to 2026-09-11, 63% of `human` requests were 404s. A reader is a
+// successful GET from a client that sends Accept-Language.
+const READER = `blob3 = 'human' AND blob7 = 'GET' AND double1 >= 200 AND double1 < 300 AND blob5 != ''`
+// `/` is fetched by clients that never open a page, so it is not reading. Older
+// points class the feed as `blog`, and Analytics Engine keeps them ~90 days.
+const READING = `blob2 IN ('docs', 'blog', 'markdown') AND blob1 != '/blog/rss.xml'`
+// www.guren.dev 301s to the apex, so no page there can send this referrer; only
+// clients that forge it do.
+const FORGED_REFERRER = 'www.guren.dev'
+const AGENT_OK = `blob3 = 'ai-agent' AND double1 >= 200 AND double1 < 300`
+
 const queries: Array<{ title: string; sql: string }> = [
   {
     title: 'Requests by visitor class',
-    sql: `SELECT blob3 AS visitor, SUM(_sample_interval) AS requests
+    sql: `SELECT blob3 AS visitor, SUM(_sample_interval) AS requests,
+                 SUM(IF(double1 >= 400, _sample_interval, 0)) AS errors
           FROM ${DATASET} WHERE ${WINDOW}
           GROUP BY visitor ORDER BY requests DESC`,
   },
   {
-    title: 'Top pages (humans)',
+    title: 'Readers by content class',
+    sql: `SELECT blob2 AS content, SUM(_sample_interval) AS requests
+          FROM ${DATASET} WHERE ${WINDOW} AND ${READER} AND ${READING}
+          GROUP BY content ORDER BY requests DESC`,
+  },
+  {
+    title: 'Top pages (readers)',
     sql: `SELECT blob1 AS path, SUM(_sample_interval) AS requests
-          FROM ${DATASET} WHERE ${WINDOW} AND blob3 = 'human' AND blob7 = 'GET'
+          FROM ${DATASET} WHERE ${WINDOW} AND ${READER} AND ${READING}
           GROUP BY path ORDER BY requests DESC LIMIT 15`,
   },
   {
-    title: 'Top referrers (humans)',
+    title: 'Top referrers (readers)',
     sql: `SELECT blob4 AS referrer, SUM(_sample_interval) AS requests
-          FROM ${DATASET} WHERE ${WINDOW} AND blob3 = 'human' AND blob4 != ''
+          FROM ${DATASET} WHERE ${WINDOW} AND ${READER}
+            AND blob4 != '' AND blob4 != '${FORGED_REFERRER}'
           GROUP BY referrer ORDER BY requests DESC LIMIT 15`,
+  },
+  {
+    title: 'Languages (readers)',
+    sql: `SELECT blob5 AS language, SUM(_sample_interval) AS requests
+          FROM ${DATASET} WHERE ${WINDOW} AND ${READER} AND ${READING}
+          GROUP BY language ORDER BY requests DESC LIMIT 10`,
+  },
+  {
+    title: 'Feed polls',
+    sql: `SELECT blob3 AS visitor, SUM(_sample_interval) AS requests
+          FROM ${DATASET} WHERE ${WINDOW} AND blob1 = '/blog/rss.xml'
+            AND double1 >= 200 AND double1 < 300
+          GROUP BY visitor ORDER BY requests DESC`,
   },
   {
     title: 'Agent traffic: markdown mirrors and llms.txt',
     sql: `SELECT blob2 AS content, blob3 AS visitor, SUM(_sample_interval) AS requests
           FROM ${DATASET} WHERE ${WINDOW} AND blob2 IN ('markdown', 'llms')
+            AND double1 >= 200 AND double1 < 300
           GROUP BY content, visitor ORDER BY requests DESC LIMIT 15`,
   },
   {
     title: 'Top docs pages fetched by AI agents',
     sql: `SELECT blob1 AS path, SUM(_sample_interval) AS requests
-          FROM ${DATASET} WHERE ${WINDOW} AND blob3 = 'ai-agent'
+          FROM ${DATASET} WHERE ${WINDOW} AND ${AGENT_OK} AND blob2 IN ('docs', 'markdown', 'llms')
           GROUP BY path ORDER BY requests DESC LIMIT 15`,
-  },
-  {
-    title: 'Languages (humans)',
-    sql: `SELECT blob5 AS language, SUM(_sample_interval) AS requests
-          FROM ${DATASET} WHERE ${WINDOW} AND blob3 = 'human' AND blob5 != ''
-          GROUP BY language ORDER BY requests DESC LIMIT 10`,
   },
 ]
 

--- a/web/scripts/analytics-report.ts
+++ b/web/scripts/analytics-report.ts
@@ -89,6 +89,14 @@ const queries: Array<{ title: string; sql: string }> = [
           FROM ${DATASET} WHERE ${WINDOW} AND ${AGENT_OK} AND blob2 IN ('docs', 'markdown', 'llms')
           GROUP BY path ORDER BY requests DESC LIMIT 15`,
   },
+  {
+    // A token whose requests are mostly errors is an alternative scanners match.
+    title: 'AI agent matches by user-agent token',
+    sql: `SELECT blob9 AS token, SUM(_sample_interval) AS requests,
+                 SUM(IF(double1 >= 400, _sample_interval, 0)) AS errors
+          FROM ${DATASET} WHERE ${WINDOW} AND blob3 = 'ai-agent'
+          GROUP BY token ORDER BY requests DESC LIMIT 20`,
+  },
 ]
 
 async function runQuery(sql: string): Promise<Array<Record<string, unknown>>> {

--- a/web/tests/middleware/site-analytics.test.ts
+++ b/web/tests/middleware/site-analytics.test.ts
@@ -14,6 +14,7 @@ import {
   createSiteAnalyticsMiddleware,
   primaryLanguage,
   referrerHost,
+  userAgentToken,
 } from '../../app/Http/Middleware/site-analytics.js'
 
 type Middleware = ReturnType<typeof createSiteAnalyticsMiddleware>
@@ -78,6 +79,21 @@ describe('classifyUserAgent', () => {
   })
 })
 
+describe('userAgentToken', () => {
+  it('should record which pattern alternative matched', () => {
+    expect(userAgentToken('Mozilla/5.0 (compatible; ClaudeBot/1.0)')).toBe('claudebot')
+    expect(userAgentToken('Mozilla/5.0 Chrome/128.0 Cursor/1.4')).toBe('cursor')
+    expect(userAgentToken('curl/8.4.0')).toBe('curl')
+  })
+
+  it('should leave browsers and empty agents without a token', () => {
+    expect(
+      userAgentToken('Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) Safari/604.1'),
+    ).toBe('')
+    expect(userAgentToken('')).toBe('')
+  })
+})
+
 describe('classifyContent', () => {
   it('should bucket the agent-facing mirrors separately from pages', () => {
     expect(classifyContent('/llms.txt')).toBe('llms')
@@ -128,7 +144,7 @@ describe('createSiteAnalyticsMiddleware', () => {
     expect(points).toHaveLength(1)
     const point = points[0]!
     expect(point.indexes).toEqual(['human'])
-    expect(point.blobs?.slice(0, 8)).toEqual([
+    expect(point.blobs?.slice(0, 9)).toEqual([
       '/docs/guides/getting-started',
       'docs',
       'human',
@@ -137,6 +153,7 @@ describe('createSiteAnalyticsMiddleware', () => {
       'JP',
       'GET',
       'initial',
+      '',
     ])
     expect(point.doubles?.[0]).toBe(200)
     expect(point.doubles?.[1]).toBeGreaterThanOrEqual(0)
@@ -153,6 +170,7 @@ describe('createSiteAnalyticsMiddleware', () => {
     })
     expect(agent?.indexes).toEqual(['ai-agent'])
     expect(agent?.blobs?.[1]).toBe('markdown')
+    expect(agent?.blobs?.[8]).toBe('claude-user')
   })
 
   it('should cap oversized paths so the data point stays writable', async () => {

--- a/web/tests/middleware/site-analytics.test.ts
+++ b/web/tests/middleware/site-analytics.test.ts
@@ -87,6 +87,11 @@ describe('classifyContent', () => {
     expect(classifyContent('/')).toBe('home')
     expect(classifyContent('/login')).toBe('other')
   })
+
+  it('should keep the feed out of the blog bucket', () => {
+    expect(classifyContent('/blog/rss.xml')).toBe('feed')
+    expect(classifyContent('/blog/rss')).toBe('blog')
+  })
 })
 
 describe('referrerHost', () => {


### PR DESCRIPTION
## Summary

The analytics report counted scanners as readers. `classifyUserAgent()` falls back to `human` for any browser-like user agent, and over the 30 days to 2026-09-11, 63% of `human` requests (8,004 of 12,756) were 404s from probes such as `/wp-admin/install.php`, `/.git/config` and credential files. No docs page made the human top 15.

- Reader queries now require a 2xx GET with an Accept-Language header, and leave out `/` and the feed. `/` is fetched by clients that never open a page (CN: 590 home requests against 10 docs or blog requests).
- `www.guren.dev` is dropped from referrers. It 301s to the apex, so no page there can send that referrer; 473 of its 501 requests hit `/` and the rest were credential probes.
- `/blog/rss.xml` gets its own `feed` content class. A client polling it roughly every 86 minutes accounted for 501 `human` requests under `blog`.
- Agent queries keep 2xx only, so `/.env` probes stop showing up as "docs pages fetched by AI agents".
- Each data point now stores the `AI_AGENT_PATTERN` / `BOT_PATTERN` alternative that matched (blob9), and the report groups `ai-agent` traffic by it. 55% of `ai-agent` requests were 404s, including `/.env` and `/@fs/root/.aws/config`, and with no user agent stored there was no way to tell which alternative those probes match. Every alternative is a literal, so the stored value comes from a fixed vocabulary, never from arbitrary user-agent text.

The filters apply at query time, so the existing ~90 days of data read correctly without a backfill.

A write-time `scanner` visitor class was considered and left out. Status and path are already stored and the filters above cover all retained data, while classifying at write time would change what `human` means at the deploy date and would permanently misfile a reader who follows a broken link.

## Test plan

- [x] `web/tests/middleware/site-analytics.test.ts`: the new `feed` case fails before the middleware change and passes after it
- [x] The `userAgentToken` and blob9 cases fail before the token change and pass after it
- [x] `bun run typecheck` in `web/`, `bun run lint`
- [ ] Run `bun web/scripts/analytics-report.ts --days 30` with an Account Analytics: Read token. Every SQL construct used here (`SUM(IF(...))`, `IN`, the status ranges) ran against the dataset while diagnosing this, but these exact queries have not.
