### PR TITLE
test(ci): keep an ambient DATABASE_URL out of the fresh-app smoke

### DIFF
--- a/scripts/smoke/fresh-app.ts
+++ b/scripts/smoke/fresh-app.ts
@@ -5,6 +5,7 @@ import process from 'node:process'
 import { FIELD_TYPES } from '../../packages/cli/src/fields'
 import { DATABASE_DRIVERS } from '../../packages/create-app/src/blueprints'
 import { fileExists } from '../../packages/create-app/src/utils'
+import { inheritedEnv } from './inherited-env'
 import { assertSessionDrivers } from './session-drivers'
 import { runPrototypeScaffold } from './prototype-scaffold'
 import { auditBlueprintTemplates, auditConsoleWiring, auditStarterTemplate } from './starter-template-audit'
@@ -127,7 +128,7 @@ async function run(cmd: string[], cwd: string, envOverrides?: Record<string, str
     stdout: 'inherit',
     stderr: 'inherit',
     env: {
-      ...process.env,
+      ...inheritedEnv(),
       ...envOverrides,
     },
   })
@@ -145,7 +146,7 @@ async function runCapture(cmd: string[], cwd: string, envOverrides?: Record<stri
     stdout: 'pipe',
     stderr: 'inherit',
     env: {
-      ...process.env,
+      ...inheritedEnv(),
       ...envOverrides,
     },
   })

--- a/scripts/smoke/inherited-env.ts
+++ b/scripts/smoke/inherited-env.ts
@@ -1,0 +1,14 @@
+import process from 'node:process'
+
+/**
+ * The parent environment a smoke hands a scaffolded app, minus DATABASE_URL.
+ * Bun loads the app's .env without overriding what a parent passes, so a
+ * job-level URL (nightly-canary.yml sets a Postgres one) outranks the scaffold's
+ * SQLite path: drizzle-kit refuses it, no migration is generated, and the app
+ * the smoke boots is not the one the scaffold configured.
+ */
+export function inheritedEnv(): Record<string, string | undefined> {
+  const env = { ...process.env }
+  delete env.DATABASE_URL
+  return env
+}

--- a/scripts/smoke/session-drivers.ts
+++ b/scripts/smoke/session-drivers.ts
@@ -6,9 +6,11 @@
  * store declares has to fail the boot with the message that says so.
  */
 import { Database } from 'bun:sqlite'
+import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import process from 'node:process'
+
+import { inheritedEnv } from './inherited-env'
 
 /** The scaffold's cookie name (`DEFAULT_COOKIE_NAME`) and the CSRF cookie the middleware issues. */
 const SESSION_COOKIE = 'guren.session'
@@ -166,7 +168,7 @@ function startApp(options: SessionDriverProbeOptions, driver: string, port: numb
     stdout: 'pipe',
     stderr: 'pipe',
     env: {
-      ...process.env,
+      ...inheritedEnv(),
       ...options.env,
       SESSION_DRIVER: driver,
       PORT: String(port),
@@ -430,6 +432,12 @@ export async function assertSessionDrivers(options: SessionDriverProbeOptions): 
   // without this migration the `database` driver has no table to write to.
   await run(['bun', cliBin, 'db:migrate'], appDir, { ...env, ...DEVELOPMENT_ENV })
   const databaseFile = await developmentDatabaseFile(appDir)
+  assert(
+    existsSync(databaseFile),
+    `db:migrate left no database at ${databaseFile}, so the scaffold generated no migration to apply `
+      + '(look above for "Could not generate the ... migration automatically"). drizzle-kit reads '
+      + 'DATABASE_URL from the environment before the app\'s .env, so check what the smoke passes it.',
+  )
 
   const refusal = await assertBootRefused(
     options,


### PR DESCRIPTION
## Problem

Nightly Canary has failed four nights running (34196036929, 34321182747, 34447042262, 34571626228), always in `canary-validate` → `Fresh app smoke (default)`:

```
Gate passed: 6 passed, 0 failed, 0 skipped
SQLiteError: unable to open database file   (session-drivers.ts countSessionRows)
```

## Cause

`nightly-canary.yml` sets `DATABASE_URL: postgres://…` for the whole job (it has since #43). `fresh-app.ts` spread `process.env` into every child, and Bun loads the scaffolded app's `.env` without overriding what the parent passes, so the SQLite app ran under the Postgres URL:

1. The sqlite `drizzle.config.ts` refuses a URI, so `guren add session` / `guren add auth` generated no migrations (the `Could not generate the sessions migration automatically` warnings in the log).
2. `db:migrate` found nothing to apply, so `data/guren.db` was never created.
3. The session driver probe added in #729 opens that file read-only and gets `SQLITE_CANTOPEN`.

So the canary has been scaffolding a migration-less app for months. #729 is the first thing that read the development database, which is why it surfaced now. CI's `starter-smokes` job sets no `DATABASE_URL`, so the same smoke stays green there.

This does not depend on the host's SQLite URI handling: the same failure reproduces on macOS with `DATABASE_URL=postgres://… bun run smoke:starter`.

## Fix

- `scripts/smoke/inherited-env.ts`: the parent environment minus `DATABASE_URL`. Both spawn sites use it: `run`/`runCapture` in `fresh-app.ts` (scaffold, migrate, gate) and `startApp` in `session-drivers.ts` (the booted app). Stripping only the first would leave the booted app writing sessions somewhere other than the file the probe counts.
- The probe now asserts the development database exists after `db:migrate` and points at the migration warnings, instead of failing on a bare `SQLiteError`.

The workflow is unchanged. The smoke should hold under any parent environment (release gate, a developer shell with `DATABASE_URL` exported), and moving the variable out of the canary's job env would mean auditing every later step that relies on it.

## Verification

- Local, `DATABASE_URL=postgres://guren:guren@localhost:54322/guren bun run smoke:starter`: before the fix it exits 1 with `SQLITE_CANTOPEN`. After the fix it exits 0, both migrations are generated, and the probe passes (memory 0 rows, database 1 row, cookie 0 rows, cookie 167 chars vs memory 92).
- `bun run lint` passes.
- Nightly Canary dispatched on this branch (Linux) passed all three jobs: https://github.com/gurenjs/guren/actions/runs/34596417847. `Fresh app smoke (default)` generated both migrations and the session driver probe passed. The steps after it, which had not run since 09-08, are green too.

