### PR TITLE
feat(web): record a ref tag for outbound links

### DIFF
--- a/web/app/Http/Middleware/site-analytics.ts
+++ b/web/app/Http/Middleware/site-analytics.ts
@@ -3,10 +3,10 @@ import { getWorkersEnv } from '@guren/plugin-cloudflare'
 
 /**
  * Cookie-less, server-side analytics into Workers Analytics Engine: this audience
- * blocks client beacons and AI agents run no JavaScript. No cookies, IPs, full
- * referrers or full user agents are stored, so no consent banner. SQL API: index1 ua
- * class; blob1..9 path, content, ua class, referrer host ('' = direct/same-site),
- * Accept-Language, country, method, initial|inertia, UA token; double1..2 status, ms.
+ * blocks beacons and agents run no JavaScript. No cookies, IPs, full referrers or
+ * full user agents are stored, so no consent banner. SQL API: index1 ua class;
+ * blob1..10 path, content, ua class, referrer host ('' = direct/same-site), language,
+ * country, method, initial|inertia, UA token, ref tag; double1..2 status, ms.
  */
 
 interface AnalyticsEngineDataset {
@@ -70,6 +70,15 @@ export function referrerHost(referrer: string | undefined, ownHost: string): str
   }
 }
 
+// No Zenn, dev.to or Bluesky referrer was recorded in the 30 days to 2026-09-11,
+// so outbound links name their channel instead. Only a short slug is kept.
+const REF_TAG_PATTERN = /^[a-z0-9][a-z0-9-]{0,31}$/
+
+export function refTag(searchParams: URLSearchParams): string {
+  const raw = (searchParams.get('ref') || searchParams.get('utm_source') || '').trim().toLowerCase()
+  return REF_TAG_PATTERN.test(raw) ? raw : ''
+}
+
 export function primaryLanguage(acceptLanguage: string | undefined): string {
   if (!acceptLanguage) return ''
   const first = acceptLanguage.split(',', 1)[0] ?? ''
@@ -115,6 +124,7 @@ export function createSiteAnalyticsMiddleware(
               c.req.method,
               c.req.header('x-inertia') ? 'inertia' : 'initial',
               userAgentToken(userAgent),
+              refTag(url.searchParams),
             ],
             doubles: [c.res?.status ?? 0, Date.now() - startedAt],
           })

--- a/web/app/Http/Middleware/site-analytics.ts
+++ b/web/app/Http/Middleware/site-analytics.ts
@@ -70,8 +70,8 @@ export function referrerHost(referrer: string | undefined, ownHost: string): str
   }
 }
 
-// No Zenn, dev.to or Bluesky referrer was recorded in the 30 days to 2026-09-11,
-// so outbound links name their channel instead. Only a short slug is kept.
+// The channel an outbound link names itself, for hosts that send no Referer.
+// Only a short slug is kept.
 const REF_TAG_PATTERN = /^[a-z0-9][a-z0-9-]{0,31}$/
 
 export function refTag(searchParams: URLSearchParams): string {

--- a/web/scripts/analytics-report.ts
+++ b/web/scripts/analytics-report.ts
@@ -1,5 +1,6 @@
 // Weekly read-only report over the site's Workers Analytics Engine dataset.
-// The token needs the "Account Analytics: Read" permission.
+// The token needs the "Account Analytics: Read" permission. Tag outbound links
+// with `?ref=<channel>` (a lowercase slug) so their landings show up by channel.
 //
 //   CLOUDFLARE_ACCOUNT_ID=... CLOUDFLARE_API_TOKEN=... bun scripts/analytics-report.ts [--days 7]
 
@@ -62,6 +63,12 @@ const queries: Array<{ title: string; sql: string }> = [
           FROM ${DATASET} WHERE ${WINDOW} AND ${READER}
             AND blob4 != '' AND blob4 != '${FORGED_REFERRER}'
           GROUP BY referrer ORDER BY requests DESC LIMIT 15`,
+  },
+  {
+    title: 'Landings by ref tag (readers)',
+    sql: `SELECT blob10 AS ref, blob1 AS path, SUM(_sample_interval) AS requests
+          FROM ${DATASET} WHERE ${WINDOW} AND ${READER} AND blob10 != ''
+          GROUP BY ref, path ORDER BY requests DESC LIMIT 20`,
   },
   {
     title: 'Languages (readers)',

--- a/web/scripts/analytics-report.ts
+++ b/web/scripts/analytics-report.ts
@@ -25,12 +25,11 @@ if (!Number.isSafeInteger(days) || days < 1 || days > 90) {
 // Data point layout: see web/app/Http/Middleware/site-analytics.ts.
 const WINDOW = `timestamp > NOW() - INTERVAL '${days}' DAY`
 
-// A browser-like user agent is classed `human`, so scanners land there: in the
-// 30 days to 2026-09-11, 63% of `human` requests were 404s. A reader is a
-// successful GET from a client that sends Accept-Language.
+// A browser-like user agent is classed `human`, so scanners land there. A reader
+// is a successful GET from a client that sends Accept-Language.
 const READER = `blob3 = 'human' AND blob7 = 'GET' AND double1 >= 200 AND double1 < 300 AND blob5 != ''`
-// `/` is fetched by clients that never open a page, so it is not reading. Older
-// points class the feed as `blog`, and Analytics Engine keeps them ~90 days.
+// `/` is fetched by clients that never open a page, so it is not reading. The feed
+// is matched by path too, since retained points may predate its class.
 const READING = `blob2 IN ('docs', 'blog', 'markdown') AND blob1 != '/blog/rss.xml'`
 // www.guren.dev 301s to the apex, so no page there can send this referrer; only
 // clients that forge it do.

--- a/web/tests/middleware/site-analytics.test.ts
+++ b/web/tests/middleware/site-analytics.test.ts
@@ -14,6 +14,7 @@ import {
   createSiteAnalyticsMiddleware,
   primaryLanguage,
   referrerHost,
+  refTag,
   userAgentToken,
 } from '../../app/Http/Middleware/site-analytics.js'
 
@@ -130,6 +131,22 @@ describe('primaryLanguage', () => {
   })
 })
 
+describe('refTag', () => {
+  it('should read the channel from ref, falling back to utm_source', () => {
+    expect(refTag(new URLSearchParams('ref=zenn'))).toBe('zenn')
+    expect(refTag(new URLSearchParams('utm_source=Newsletter'))).toBe('newsletter')
+    expect(refTag(new URLSearchParams('ref=x&utm_source=other'))).toBe('x')
+    expect(refTag(new URLSearchParams('ref=&utm_source=devto'))).toBe('devto')
+  })
+
+  it('should drop anything that is not a short slug', () => {
+    expect(refTag(new URLSearchParams(`ref=${encodeURIComponent('<script>')}`))).toBe('')
+    expect(refTag(new URLSearchParams('ref=someone@example.com'))).toBe('')
+    expect(refTag(new URLSearchParams(`ref=${'a'.repeat(33)}`))).toBe('')
+    expect(refTag(new URLSearchParams(''))).toBe('')
+  })
+})
+
 describe('createSiteAnalyticsMiddleware', () => {
   it('should write one data point with the documented layout', async () => {
     const points = await record('https://guren.dev/docs/guides/getting-started', {
@@ -144,7 +161,7 @@ describe('createSiteAnalyticsMiddleware', () => {
     expect(points).toHaveLength(1)
     const point = points[0]!
     expect(point.indexes).toEqual(['human'])
-    expect(point.blobs?.slice(0, 9)).toEqual([
+    expect(point.blobs?.slice(0, 10)).toEqual([
       '/docs/guides/getting-started',
       'docs',
       'human',
@@ -153,6 +170,7 @@ describe('createSiteAnalyticsMiddleware', () => {
       'JP',
       'GET',
       'initial',
+      '',
       '',
     ])
     expect(point.doubles?.[0]).toBe(200)
@@ -171,6 +189,14 @@ describe('createSiteAnalyticsMiddleware', () => {
     expect(agent?.indexes).toEqual(['ai-agent'])
     expect(agent?.blobs?.[1]).toBe('markdown')
     expect(agent?.blobs?.[8]).toBe('claude-user')
+  })
+
+  it('should record the ref tag while keeping the query out of the path', async () => {
+    const [point] = await record('https://guren.dev/docs/guides/cloudflare?ref=zenn', {
+      headers: { 'user-agent': 'Mozilla/5.0' },
+    })
+    expect(point?.blobs?.[0]).toBe('/docs/guides/cloudflare')
+    expect(point?.blobs?.[9]).toBe('zenn')
   })
 
   it('should cap oversized paths so the data point stays writable', async () => {


### PR DESCRIPTION
## Summary

Posts went out on Zenn (08-14), dev.to (08-19) and 7nohe.dev (08-22), yet over the 30 days to 2026-09-11 none of those hosts, Bluesky or Reddit appear among the referrers. External referrals were Google 44, t.co 20, GitHub 4 and DuckDuckGo 3, and there is no way to tell whether the other channels sent nobody or sent visitors without a `Referer`. The middleware keeps the pathname only, so a tagged link was not recorded either.

- Each data point now carries a ref tag (blob10), read from `?ref=` and falling back to `utm_source=`. Only a lowercase slug of up to 32 characters (`[a-z0-9-]`) is kept; anything else is recorded as empty, so the value cannot carry an address or markup.
- The pathname stays query-free, and canonical URLs are built from each page's route path, so a tagged link does not create a duplicate URL.
- The report gains "Landings by ref tag (readers)". Pollers that fetch `/` without reading never carry a tag, so tagged home-page landings are countable even though the untagged `/` count is not.

## Test plan

- [x] `web/tests/middleware/site-analytics.test.ts`: the `refTag` and blob10 cases fail before the middleware change and pass after it
- [x] `bun run typecheck` in `web/`, `bun run lint`
- [ ] After deploy, open a `?ref=` link and confirm the landing appears in `bun web/scripts/analytics-report.ts --days 1`
