### PR TITLE
Deprecate the module-level service slots (RFC 0023 Part 2)

### DIFF
--- a/.changeset/rfc0023-part2-cli.md
+++ b/.changeset/rfc0023-part2-cli.md
@@ -1,0 +1,31 @@
+---
+"@guren/cli": minor
+---
+
+Register RFC 0023's deprecations and ship the codemod that migrates them
+
+`bunx guren upgrade --check-only` reports `global-service-setters` and
+`global-service-getters`, naming every file that imports one of the module-level
+service accessors deprecated in `@guren/server` 2.23.0. Detection reads a wider
+file set than the other entries: `config/`, `src/` and `app/` of the app and its
+modules, plus test files, because the setters live in `src/app.ts` and
+`config/*.ts` and the test-injection row of the migration table is reported
+rather than rewritten.
+
+`bunx guren upgrade` applies the `container-only-service-resolution` codemod,
+the first entry in the codemod registry. It is AST-based, idempotent, and
+covers the Migration Path table:
+
+- a deprecated getter inside a `ServiceProvider` becomes `this.container.make(key)`, and `getContainer()` there becomes `this.container`
+- a deprecated setter whose key a provider in the same file binds is deleted; one in a provider that binds nothing becomes `this.container.instance(key, value)`
+- `setInertiaDocument({ … })` with an inline literal moves into `createApp({ inertia: { document } })` when `createApp` is in the same file, comment included
+- the attachments `storage` factory becomes `(container) => container.make('storage')`
+- `getContainer().make(key)` inside a `Job` becomes `this.make(key)`
+- unused `@guren/core` / `@guren/server` import specifiers left behind are removed
+
+Test injections through `setGate()` or `setQueueDriver()` are reported only:
+the replacement depends on which application the fake belongs to.
+
+`guren queue:work` resolves its fallback driver through the new internal
+`resolveQueueDriver()`, so booting an app for the worker no longer prints a
+deprecation warning for a call the CLI made itself.

--- a/.changeset/rfc0023-part2-server.md
+++ b/.changeset/rfc0023-part2-server.md
@@ -1,0 +1,50 @@
+---
+"@guren/server": minor
+"@guren/core": minor
+---
+
+### Deprecated
+
+- **Module-level service setters and getters** — `setGate`/`getGate`, `setEncrypter`/`getEncrypter`, `setMailManager`/`getMailManager`, `setQueueDriver`/`getQueueDriver`, `setI18n`/`getI18n`/`tryGetI18n`, `setLogManager`/`getLogManager`, `setNotificationManager`/`getNotificationManager`, `setBroadcastManager`/`getBroadcastManager`, `setExceptionHandler`/`getExceptionHandler`, `setContainer`/`getContainer`, `setInertiaDocument`, `setInertiaSsrRenderer`, `setInertiaSharedProps`/`getInertiaSharedPropsResolver`, and the `SendNotificationJob.notificationManager` static. Resolve services from the container of the application that owns the call instead. Deprecated in 2.23.0, will be removed in 3.0.0. Detected by `bunx guren upgrade --check-only` as `global-service-setters` and `global-service-getters`; codemod available: run `bunx guren upgrade`. (RFC 0023 Part 2)
+
+Nothing is removed and every call still works. Each accessor now carries
+`@deprecated` JSDoc naming its replacement and warns once per symbol in the
+format `contributing/deprecation-policy.md` defines.
+
+**A setter now writes the live application's container.** Part 1 made every
+consumer read the container first and the module slot second, which left a
+hand-written `setMailManager(m)` silently shadowed by the binding a provider
+had already made. The shim binds the key on the ambient container instead, and
+clears its own slot so no value outlives the app that received it. Two
+applications in one process therefore no longer inherit each other's
+hand-installed services. Where no `Application` has been constructed yet — both
+scaffold templates call `setInertiaDocument()` at module scope above
+`createApp()` — the slot is still where the value lands, and the getters keep
+reading it second.
+
+`setInertiaDocument` and `setInertiaSsrRenderer` are tagged and reported but do
+not warn at runtime. RFC 0023 Open Question 4 has not settled whether
+`createApp({ inertia })` or the setter is the endpoint, the Workers entry
+`@guren/plugin-cloudflare` generates still calls `setInertiaSsrRenderer()`, and
+both scaffold templates still write `setInertiaDocument()`; a warning naming
+code the framework itself emits is not something an app author can act on. The
+codemod rewrites both for an app that wants to move now.
+
+`setQueueDriver()` keeps its override: through this release the pin still wins
+over the bound `queue` manager, because `@guren/testing`'s `fakeQueue()` and the
+tutorial's queue chapter inject through it and nothing else expresses that. The
+pin goes with the setter in Part 3.
+
+The functional helpers are not deprecated and do not warn: `encrypt`, `decrypt`,
+`t`, `tc`, `can`, `cannot`, `defineGate`, `authorizeAbility`, `resolve`,
+`Job.dispatch` and `Job.make` resolve through internal seams, so an app that
+never calls an accessor by hand sees no warning at all.
+
+One new export, `@internal`: `resolveQueueDriver()` is `getQueueDriver()`
+without the warning, for the framework's own dispatch paths in `@guren/core` and
+`@guren/cli`.
+
+These symbols are re-exported from `@guren/core`, which makes them Stable under
+`contributing/api-stability.md`, so the policy's minimum of two minor versions
+applies before removal. Deprecated in 2.23.0, that permits removal from 2.25.0
+onward; `removedIn` targets 3.0.0.

--- a/docs/en/guides/upgrading.md
+++ b/docs/en/guides/upgrading.md
@@ -33,6 +33,32 @@ bun run test
 
 ## Migration Notes
 
+### 2.22.x → 2.23.0
+
+#### Module-level service setters and getters are deprecated
+
+- **What changed**: `setGate`/`getGate`, `setEncrypter`/`getEncrypter`, `setMailManager`/`getMailManager`, `setQueueDriver`/`getQueueDriver`, `setI18n`/`getI18n`/`tryGetI18n`, `setLogManager`/`getLogManager`, `setNotificationManager`/`getNotificationManager`, `setBroadcastManager`/`getBroadcastManager`, `setExceptionHandler`/`getExceptionHandler`, `setContainer`/`getContainer`, `setInertiaDocument`, `setInertiaSsrRenderer`, and `setInertiaSharedProps`/`getInertiaSharedPropsResolver` carry `@deprecated` and warn once per symbol. They keep working until 3.0.0. A setter now binds the value on the container of the application that is live, so two applications in one process no longer overwrite each other's services.
+- **Who is affected**: Providers that call a setter after binding the same key, code that reads a service through a getter, and tests that inject a fake through `setGate()` or `setQueueDriver()`.
+- **How to migrate**: Run `bunx guren upgrade --check-only` for the list of files, then `bunx guren upgrade` to apply the rewrites. The codemod turns a getter inside a provider into `this.container.make(key)`, binds a setter's value with `this.container.instance(key, value)` (or deletes the call when the same file already binds that key), moves an inline `setInertiaDocument({ ... })` into `createApp({ inertia: { document } })`, gives the attachments `storage` factory the container it is bound with, and rewrites `getContainer().make(key)` inside a `Job` to `this.make(key)`. Test injections are reported, not rewritten: bind the fake with `app.container.fake(key, fake)` instead. `setQueueDriver()` is the exception, because its pin still overrides the bound manager through 2.23.0.
+
+```ts
+// Before
+export default class AuthorizationProvider extends ServiceProvider {
+  boot(): void {
+    getGate().policy(Post, PostPolicy)
+  }
+}
+
+// After
+export default class AuthorizationProvider extends ServiceProvider {
+  boot(): void {
+    this.container.make('gate').policy(Post, PostPolicy)
+  }
+}
+```
+
+The functional helpers built on these accessors are not deprecated and keep their signatures: `encrypt`, `decrypt`, `t`, `tc`, `can`, `cannot`, `defineGate`, `authorizeAbility`, `resolve`, `Job.dispatch` and `Job.make` all resolve from the container of the application they run under.
+
 ### 1.x → 2.0.0
 
 #### Structural mass assignment

--- a/docs/ja/guides/upgrading.md
+++ b/docs/ja/guides/upgrading.md
@@ -33,6 +33,32 @@ bun run test
 
 ## 移行メモ
 
+### 2.22.x → 2.23.0
+
+#### モジュールレベルのサービス setter / getter が非推奨に
+
+- **変更点**: `setGate`/`getGate`、`setEncrypter`/`getEncrypter`、`setMailManager`/`getMailManager`、`setQueueDriver`/`getQueueDriver`、`setI18n`/`getI18n`/`tryGetI18n`、`setLogManager`/`getLogManager`、`setNotificationManager`/`getNotificationManager`、`setBroadcastManager`/`getBroadcastManager`、`setExceptionHandler`/`getExceptionHandler`、`setContainer`/`getContainer`、`setInertiaDocument`、`setInertiaSsrRenderer`、`setInertiaSharedProps`/`getInertiaSharedPropsResolver` に `@deprecated` が付き、シンボルごとに一度だけ警告します。3.0.0 までは従来どおり動きます。setter は起動中のアプリケーションのコンテナに値をバインドするようになったので、1 プロセスに 2 つのアプリケーションがあってもサービスを上書きし合いません。
+- **影響範囲**: 同じキーをバインドしたうえで setter も呼んでいる provider、getter 経由でサービスを読むコード、`setGate()` や `setQueueDriver()` でフェイクを注入しているテストです。
+- **移行方法**: まず `bunx guren upgrade --check-only` で対象ファイルを確認し、`bunx guren upgrade` で書き換えを適用します。codemod は provider 内の getter を `this.container.make(key)` にし、setter の値を `this.container.instance(key, value)` でバインドし（同じファイルがそのキーをすでにバインドしている場合は呼び出しを削除）、インラインの `setInertiaDocument({ ... })` を `createApp({ inertia: { document } })` へ移し、attachments の `storage` ファクトリにバインド元のコンテナを渡し、`Job` 内の `getContainer().make(key)` を `this.make(key)` に書き換えます。テストの注入は報告のみで書き換えません。`app.container.fake(key, fake)` でフェイクをバインドしてください。`setQueueDriver()` だけは例外で、2.23.0 の時点ではピンがバインド済みマネージャーより優先されます。
+
+```ts
+// Before
+export default class AuthorizationProvider extends ServiceProvider {
+  boot(): void {
+    getGate().policy(Post, PostPolicy)
+  }
+}
+
+// After
+export default class AuthorizationProvider extends ServiceProvider {
+  boot(): void {
+    this.container.make('gate').policy(Post, PostPolicy)
+  }
+}
+```
+
+これらのアクセサの上に作られた関数ヘルパーは非推奨ではなく、シグネチャも変わりません。`encrypt`、`decrypt`、`t`、`tc`、`can`、`cannot`、`defineGate`、`authorizeAbility`、`resolve`、`Job.dispatch`、`Job.make` はいずれも、実行中のアプリケーションのコンテナから解決します。
+
 ### 1.x → 2.0.0
 
 #### 構造的マスアサインメント保護

--- a/packages/cli/src/codemod-container-resolution.ts
+++ b/packages/cli/src/codemod-container-resolution.ts
@@ -163,6 +163,8 @@ export function transformSource(source: string, filePath: string): string | null
 
   const providers: Range[] = []
   const jobs: Range[] = []
+  /** Service keys a provider in this file binds on a container of its own. */
+  const bound = new Set<string>()
   // Where a getter must not be rewritten: `this` is not the instance there, or
   // another rule has already claimed the call.
   const skip: Range[] = []
@@ -175,12 +177,13 @@ export function transformSource(source: string, filePath: string): string | null
     else if (parent === 'Job') jobs.push(range)
     else return
     skip.push(...reboundRanges(node))
+    if (parent === 'ServiceProvider') collectBoundKeys(node, bound)
   })
 
   const edits: Edit[] = [
     ...storageFactoryEdits(ast.program, source, guren, skip),
     ...getterEdits(ast.program, guren, providers, jobs, skip),
-    ...setterEdits(ast.program, source, guren, providers, skip),
+    ...setterEdits(ast.program, source, guren, providers, skip, bound),
     ...inertiaDocumentEdits(ast.program, source, guren),
   ]
   if (edits.length === 0) return null
@@ -242,7 +245,14 @@ function getterEdits(program: unknown, guren: Set<string>, providers: Range[], j
 }
 
 /** Rows 2 and 3: a deprecated setter inside a provider. */
-function setterEdits(program: unknown, source: string, guren: Set<string>, providers: Range[], skip: Range[]): Edit[] {
+function setterEdits(
+  program: unknown,
+  source: string,
+  guren: Set<string>,
+  providers: Range[],
+  skip: Range[],
+  bound: Set<string>,
+): Edit[] {
   const edits: Edit[] = []
   walk(program, (node) => {
     if (node.type !== 'ExpressionStatement') return
@@ -263,7 +273,7 @@ function setterEdits(program: unknown, source: string, guren: Set<string>, provi
     // same value twice and the container half is the one that survives. Judged
     // per file rather than per class: the blog example's call sits in a
     // module-scope helper its provider invokes, which is the common shape.
-    if (providers.some((provider) => classBinds(program, provider, key))) {
+    if (bound.has(key)) {
       edits.push({ ...statementSpan(source, statement), text: '', consumes: calleeRange })
       return
     }
@@ -279,16 +289,12 @@ function setterEdits(program: unknown, source: string, guren: Set<string>, provi
   return edits
 }
 
-/** Whether the class at `range` binds `key` on a container of its own. */
-function classBinds(program: unknown, range: Range, key: string): boolean {
-  let found = false
-  walk(program, (node) => {
-    if (found) return false
-    const nodeAt = nodeRange(node)
-    if (!nodeAt || !contains(range, nodeAt)) return
-    if (boundKey(node) === key) found = true
+/** Every service key this provider class binds on a container of its own. */
+function collectBoundKeys(classNode: BabelNode, into: Set<string>): void {
+  walk(classNode.body, (node) => {
+    const key = boundKey(node)
+    if (key) into.add(key)
   })
-  return found
 }
 
 /** Row 5: `configureAttachments({ storage: () => getContainer().make('storage') })`. */

--- a/packages/cli/src/codemod-container-resolution.ts
+++ b/packages/cli/src/codemod-container-resolution.ts
@@ -1,0 +1,466 @@
+/**
+ * RFC 0023 Part 2's codemod: the module-level service slots become container
+ * resolution. Each rule is one row of the RFC's Migration Path table, applied
+ * to the whole accessor family, since the shape is what it recognises.
+ * Anything the table marks "reported" is left alone and reaches the author
+ * through `deprecations.ts` instead.
+ *
+ * Rewrites are offset splices applied back to front, so one rule never
+ * invalidates another's positions.
+ */
+import { readFile, writeFile } from 'node:fs/promises'
+import { relative } from 'node:path'
+import type { Node } from '@babel/types'
+import { type BabelNode, memberKeyName, unwrapTypeAssertion, walk } from './ast-walk'
+import { discoverAppConfigFiles } from './discovery'
+import { parseSourceFile } from './parse-cache'
+
+/** Deprecated getter → the container key it resolved. */
+const GETTER_KEYS: Record<string, string> = {
+  getGate: 'gate',
+  getEncrypter: 'encrypter',
+  getMailManager: 'mail',
+  getI18n: 'i18n',
+  getLogManager: 'log',
+  getNotificationManager: 'notifications',
+  getBroadcastManager: 'broadcast',
+  getExceptionHandler: 'exception.handler',
+}
+
+/**
+ * Deprecated setter → the container key it wrote. `setQueueDriver` is absent on
+ * purpose: through Part 2 the pin still overrides the bound manager, so binding
+ * the key is not the same instruction.
+ */
+const SETTER_KEYS: Record<string, string> = {
+  setGate: 'gate',
+  setEncrypter: 'encrypter',
+  setMailManager: 'mail',
+  setI18n: 'i18n',
+  setLogManager: 'log',
+  setNotificationManager: 'notifications',
+  setBroadcastManager: 'broadcast',
+  setExceptionHandler: 'exception.handler',
+}
+
+const BINDING_METHODS = new Set(['instance', 'bind', 'singleton'])
+
+/** Cheap pre-filter: parsing every app source to find nothing is the common case. */
+const MENTIONS = new RegExp(
+  `\\b(?:getContainer|setInertiaDocument|${Object.keys(GETTER_KEYS).join('|')}|${Object.keys(SETTER_KEYS).join('|')})\\b`,
+)
+
+interface Range {
+  start: number
+  end: number
+}
+
+interface Edit extends Range {
+  text: string
+  /** An identifier this edit consumes, so an import specifier can be judged unused. */
+  consumes?: Range
+}
+
+function nodeRange(node: BabelNode | Node | undefined | null): Range | null {
+  if (!node) return null
+  const start = (node as { start?: number | null }).start
+  const end = (node as { end?: number | null }).end
+  return typeof start === 'number' && typeof end === 'number' ? { start, end } : null
+}
+
+function contains(outer: Range, inner: Range): boolean {
+  return inner.start >= outer.start && inner.end <= outer.end
+}
+
+function enclosing(ranges: Range[], node: Range): Range | undefined {
+  return ranges.find((range) => contains(range, node))
+}
+
+function superClassName(node: BabelNode): string | undefined {
+  const superClass = node.superClass as BabelNode | undefined
+  return superClass?.type === 'Identifier' ? (superClass.name as string) : undefined
+}
+
+/** A call of `name` with no arguments. */
+function isPlainCall(node: BabelNode, name: string): boolean {
+  const callee = node.callee as BabelNode | undefined
+  return (
+    node.type === 'CallExpression'
+    && callee?.type === 'Identifier'
+    && callee.name === name
+    && (node.arguments as unknown[]).length === 0
+  )
+}
+
+/** The key a `container.instance('key', …)`-shaped call binds, if any. */
+function boundKey(node: BabelNode): string | undefined {
+  if (node.type !== 'CallExpression') return undefined
+  const callee = node.callee as BabelNode | undefined
+  if (callee?.type !== 'MemberExpression') return undefined
+  const property = callee.property as BabelNode | undefined
+  if (property?.type !== 'Identifier' || !BINDING_METHODS.has(property.name as string)) return undefined
+  const first = (node.arguments as BabelNode[])[0]
+  return first?.type === 'StringLiteral' ? (first.value as string) : undefined
+}
+
+function lineStartAt(source: string, offset: number): number {
+  return source.lastIndexOf('\n', Math.max(0, offset - 1)) + 1
+}
+
+/**
+ * A statement's span widened to whole lines and to the `//` comment lines
+ * written directly above it: a deleted statement must not leave the comment
+ * that explained it pointing at the next one.
+ */
+function statementSpan(source: string, range: Range): Range {
+  let start = lineStartAt(source, range.start)
+  while (start > 0) {
+    const previous = lineStartAt(source, start - 1)
+    if (!source.slice(previous, start - 1).trim().startsWith('//')) break
+    start = previous
+  }
+  const lineEnd = source.indexOf('\n', range.end)
+  let end = lineEnd < 0 ? source.length : lineEnd + 1
+  // A statement between two blank lines leaves one behind, not two.
+  if (source[end] === '\n' && source.slice(Math.max(0, start - 2), start) === '\n\n') end += 1
+  return { start, end }
+}
+
+function applyEdits(source: string, edits: Edit[]): string {
+  let result = source
+  for (const edit of [...edits].sort((a, b) => b.start - a.start)) {
+    result = result.slice(0, edit.start) + edit.text + result.slice(edit.end)
+  }
+  return result
+}
+
+/**
+ * `source` with every Migration Path rewrite applied, or null when the file
+ * needs none. `detect()` and `apply()` both answer from this, so a file
+ * `--dry-run` lists is exactly a file `guren upgrade` writes.
+ */
+export function transformSource(source: string, filePath: string): string | null {
+  if (!MENTIONS.test(source)) return null
+  const ast = parseSourceFile(source, filePath)
+  if (!ast) return null
+
+  const providers: Range[] = []
+  const jobs: Range[] = []
+  walk(ast.program, (node) => {
+    if (node.type !== 'ClassDeclaration' && node.type !== 'ClassExpression') return
+    const range = nodeRange(node)
+    if (!range) return
+    const parent = superClassName(node)
+    if (parent === 'ServiceProvider') providers.push(range)
+    else if (parent === 'Job') jobs.push(range)
+  })
+
+  const edits: Edit[] = [
+    ...getterEdits(ast.program, providers, jobs),
+    ...setterEdits(ast.program, source, providers),
+    ...storageFactoryEdits(ast.program, source),
+    ...inertiaDocumentEdits(ast.program, source),
+  ]
+  if (edits.length === 0) return null
+
+  edits.push(...unusedImportEdits(ast.program, source, edits))
+  return applyEdits(source, edits)
+}
+
+/** Rows 1 and 6: a deprecated getter inside a provider or a job. */
+function getterEdits(program: unknown, providers: Range[], jobs: Range[]): Edit[] {
+  const edits: Edit[] = []
+  walk(program, (node) => {
+    if (node.type !== 'CallExpression') return
+    const range = nodeRange(node)
+    const callee = nodeRange(node.callee as BabelNode)
+    if (!range || !callee) return
+
+    for (const [name, key] of Object.entries(GETTER_KEYS)) {
+      if (!isPlainCall(node, name)) continue
+      if (enclosing(providers, range)) {
+        edits.push({ ...range, text: `this.container.make('${key}')`, consumes: callee })
+      }
+      return
+    }
+
+    if (!isPlainCall(node, 'getContainer')) return
+    if (enclosing(providers, range)) {
+      edits.push({ ...range, text: 'this.container', consumes: callee })
+      return
+    }
+    // A job holds its container privately, so only the resolution wrapped
+    // around the call can be rewritten: `getContainer().make(k)` is
+    // `this.make(k)`. A bare `getContainer()` in a job is reported instead.
+    if (enclosing(jobs, range)) {
+      edits.push({ ...range, text: 'this', consumes: callee })
+    }
+  })
+  return edits
+}
+
+/** Rows 2 and 3: a deprecated setter inside a provider. */
+function setterEdits(program: unknown, source: string, providers: Range[]): Edit[] {
+  const edits: Edit[] = []
+  walk(program, (node) => {
+    if (node.type !== 'ExpressionStatement') return
+    const call = unwrapTypeAssertion(node.expression as Node) as BabelNode
+    const callee = call?.type === 'CallExpression' ? (call.callee as BabelNode) : undefined
+    if (callee?.type !== 'Identifier') return
+    const key = SETTER_KEYS[callee.name as string]
+    if (!key) return
+
+    const statement = nodeRange(node)
+    const callRange = nodeRange(call)
+    const calleeRange = nodeRange(callee)
+    const args = call.arguments as BabelNode[]
+    const argument = nodeRange(args[0])
+    if (!statement || !callRange || !calleeRange || args.length !== 1 || !argument) return
+
+    // A provider in this file already binds the key, so the call was writing the
+    // same value twice and the container half is the one that survives. Judged
+    // per file rather than per class: the blog example's call sits in a
+    // module-scope helper its provider invokes, which is the common shape.
+    if (providers.some((provider) => classBinds(program, provider, key))) {
+      edits.push({ ...statementSpan(source, statement), text: '', consumes: calleeRange })
+      return
+    }
+
+    if (!enclosing(providers, callRange)) return
+
+    edits.push({
+      ...callRange,
+      text: `this.container.instance('${key}', ${source.slice(argument.start, argument.end)})`,
+      consumes: calleeRange,
+    })
+  })
+  return edits
+}
+
+/** Whether the class at `range` binds `key` on a container of its own. */
+function classBinds(program: unknown, range: Range, key: string): boolean {
+  let found = false
+  walk(program, (node) => {
+    if (found) return false
+    const nodeAt = nodeRange(node)
+    if (!nodeAt || !contains(range, nodeAt)) return
+    if (boundKey(node) === key) found = true
+  })
+  return found
+}
+
+/** Row 5: `configureAttachments({ storage: () => getContainer().make('storage') })`. */
+function storageFactoryEdits(program: unknown, source: string): Edit[] {
+  const edits: Edit[] = []
+  walk(program, (node) => {
+    if (node.type !== 'CallExpression') return
+    const callee = node.callee as BabelNode | undefined
+    if (callee?.type !== 'Identifier' || callee.name !== 'configureAttachments') return
+    const options = unwrapTypeAssertion((node.arguments as Node[])[0]) as BabelNode | undefined
+    if (options?.type !== 'ObjectExpression') return
+
+    for (const property of options.properties as BabelNode[]) {
+      if (property.type !== 'ObjectProperty' || memberKeyName(property as never) !== 'storage') continue
+      const arrow = unwrapTypeAssertion(property.value as Node) as BabelNode
+      const arrowRange = nodeRange(arrow)
+      if (arrow?.type !== 'ArrowFunctionExpression' || !arrowRange) continue
+      if ((arrow.params as unknown[]).length !== 0) continue
+
+      const inner: Edit[] = []
+      walk(arrow.body, (child) => {
+        if (!isPlainCall(child, 'getContainer')) return
+        const range = nodeRange(child)
+        if (range) inner.push({ ...range, text: 'container', consumes: nodeRange(child.callee as BabelNode) ?? undefined })
+      })
+      if (inner.length === 0) continue
+
+      // The parameter list is the arrow's own `()`, which `async` can precede.
+      const open = source.indexOf('(', arrowRange.start)
+      if (open < 0 || open >= arrowRange.end || source.slice(open, open + 2) !== '()') continue
+      edits.push({ start: open, end: open + 2, text: '(container)' }, ...inner)
+    }
+  })
+  return edits
+}
+
+/** Row 4: `setInertiaDocument({…})` at module scope beside a `createApp({…})`. */
+function inertiaDocumentEdits(program: unknown, source: string): Edit[] {
+  const body = (program as { body?: BabelNode[] }).body ?? []
+
+  const options = createAppOptions(program)
+  if (!options) return []
+
+  for (const statement of body) {
+    if (statement.type !== 'ExpressionStatement') continue
+    const call = unwrapTypeAssertion(statement.expression as Node) as BabelNode
+    if (!call || call.type !== 'CallExpression') continue
+    const callee = call.callee as BabelNode | undefined
+    if (callee?.type !== 'Identifier' || callee.name !== 'setInertiaDocument') continue
+
+    const literal = unwrapTypeAssertion((call.arguments as Node[])[0]) as BabelNode | undefined
+    const literalRange = nodeRange(literal)
+    const statementRange = nodeRange(statement)
+    if (literal?.type !== 'ObjectExpression' || !literalRange || !statementRange) continue
+
+    const span = statementSpan(source, statementRange)
+    const comment = source
+      .slice(span.start, lineStartAt(source, statementRange.start))
+      .split('\n')
+      .filter((line) => line.trim().length > 0)
+      .map((line) => `  ${line.trim()}\n`)
+      .join('')
+
+    return [
+      { ...span, text: '', consumes: nodeRange(callee) ?? undefined },
+      {
+        start: options.start + 1,
+        end: options.start + 1,
+        text: `\n${comment}  inertia: {\n    document: ${indentLiteral(source.slice(literalRange.start, literalRange.end))},\n  },`,
+      },
+    ]
+  }
+  return []
+}
+
+/**
+ * The `createApp({…})` options object this module passes, when it has no
+ * `inertia` key yet. A call that already carries one is reported rather than
+ * merged: the two values would have to be reconciled by a reader.
+ */
+function createAppOptions(program: unknown): Range | null {
+  let found: Range | null = null
+  walk(program, (node) => {
+    if (found || node.type !== 'CallExpression') return
+    const callee = node.callee as BabelNode | undefined
+    if (callee?.type !== 'Identifier' || callee.name !== 'createApp') return
+    const options = unwrapTypeAssertion((node.arguments as Node[])[0]) as BabelNode | undefined
+    if (options?.type !== 'ObjectExpression') return
+    const keys = (options.properties as BabelNode[])
+      .map((property) => (property.type === 'ObjectProperty' ? memberKeyName(property as never) : undefined))
+    if (keys.includes('inertia')) return
+    found = nodeRange(options)
+  })
+  return found
+}
+
+/**
+ * A literal moved two levels deeper keeps its own line breaks and gains four
+ * columns. Skipped where a backtick appears: indentation inside a template
+ * literal is content, not layout.
+ */
+function indentLiteral(literal: string): string {
+  if (!literal.includes('\n') || literal.includes('`')) return literal
+  const [first, ...rest] = literal.split('\n')
+  return [first, ...rest.map((line) => (line.trim().length === 0 ? line : `    ${line}`))].join('\n')
+}
+
+/**
+ * Import specifiers whose every reference this pass removed. Judged on the
+ * offsets the edits consume rather than on the rewritten text, so a name the
+ * file still uses elsewhere keeps its import.
+ */
+function unusedImportEdits(program: unknown, source: string, edits: Edit[]): Edit[] {
+  const consumed = edits.map((edit) => edit.consumes).filter((range): range is Range => Boolean(range))
+  if (consumed.length === 0) return []
+
+  const references = new Map<string, Range[]>()
+  const declarations: { range: Range; specifiers: { name: string; range: Range }[] }[] = []
+
+  for (const statement of (program as { body?: BabelNode[] }).body ?? []) {
+    if (statement.type !== 'ImportDeclaration') continue
+    const sourceValue = (statement.source as BabelNode).value
+    if (sourceValue !== '@guren/core' && sourceValue !== '@guren/server') continue
+    const range = nodeRange(statement)
+    if (!range) continue
+    const specifiers = (statement.specifiers as BabelNode[])
+      .filter((specifier) => specifier.type === 'ImportSpecifier')
+      .map((specifier) => ({
+        name: ((specifier.local as BabelNode).name as string),
+        range: nodeRange(specifier) as Range,
+      }))
+      .filter((specifier) => specifier.range)
+    if (specifiers.length > 0) declarations.push({ range, specifiers })
+  }
+  if (declarations.length === 0) return []
+
+  const importRanges = declarations.map((declaration) => declaration.range)
+  walk(program, (node) => {
+    if (node.type !== 'Identifier') return
+    const range = nodeRange(node)
+    if (!range || enclosing(importRanges, range)) return
+    const name = node.name as string
+    references.set(name, [...(references.get(name) ?? []), range])
+  })
+
+  const removals: Edit[] = []
+  for (const declaration of declarations) {
+    const dropped = declaration.specifiers.filter((specifier) =>
+      (references.get(specifier.name) ?? []).every((reference) =>
+        consumed.some((range) => contains(range, reference)),
+      ),
+    )
+    if (dropped.length === 0) continue
+
+    if (dropped.length === declaration.specifiers.length) {
+      removals.push({ ...statementSpan(source, declaration.range), text: '' })
+      continue
+    }
+    for (const specifier of dropped) {
+      removals.push({ ...widenSpecifier(source, specifier.range), text: '' })
+    }
+  }
+  return removals
+}
+
+/** A specifier's span plus the separator that joined it to its neighbour. */
+function widenSpecifier(source: string, range: Range): Range {
+  const lineStart = lineStartAt(source, range.start)
+  const lineEnd = source.indexOf('\n', range.end)
+  const rest = source.slice(range.end, lineEnd < 0 ? source.length : lineEnd)
+  // One specifier per line takes its whole line; anything else on the line
+  // means the comma, not the newline, is what joined it to its neighbour.
+  if (source.slice(lineStart, range.start).trim() === '' && rest.trim().replace(',', '') === '') {
+    return { start: lineStart, end: lineEnd < 0 ? source.length : lineEnd + 1 }
+  }
+
+  let end = range.end
+  while (/[ \t]/.test(source[end] ?? '')) end += 1
+  if (source[end] === ',') {
+    end += 1
+    while (/[ \t]/.test(source[end] ?? '')) end += 1
+    return { start: range.start, end }
+  }
+
+  let start = range.start
+  while (start > 0 && /[ \t]/.test(source[start - 1])) start -= 1
+  if (source[start - 1] === ',') start -= 1
+  return { start, end: range.end }
+}
+
+/** Files the codemod would rewrite, relative to `cwd`. */
+export async function detectContainerResolution(cwd: string): Promise<string[]> {
+  const files = await discoverAppConfigFiles(cwd)
+  const affected = await Promise.all(
+    files.map(async (filePath) => {
+      const source = await readFile(filePath, 'utf-8').catch(() => null)
+      if (source === null) return null
+      return transformSource(source, filePath) === null ? null : relative(cwd, filePath)
+    }),
+  )
+  return affected.filter((file): file is string => file !== null)
+}
+
+/** Applies the rewrites; answers how many files changed. */
+export async function applyContainerResolution(cwd: string): Promise<number> {
+  const files = await discoverAppConfigFiles(cwd)
+  let changed = 0
+  for (const filePath of files) {
+    const source = await readFile(filePath, 'utf-8').catch(() => null)
+    if (source === null) continue
+    const next = transformSource(source, filePath)
+    if (next === null) continue
+    await writeFile(filePath, next, 'utf-8')
+    changed += 1
+  }
+  return changed
+}

--- a/packages/cli/src/codemod-container-resolution.ts
+++ b/packages/cli/src/codemod-container-resolution.ts
@@ -81,13 +81,14 @@ function superClassName(node: BabelNode): string | undefined {
   return superClass?.type === 'Identifier' ? (superClass.name as string) : undefined
 }
 
-/** A call of `name` with no arguments. */
-function isPlainCall(node: BabelNode, name: string): boolean {
+/** A call of `name`, imported from Guren, with no arguments. */
+function isPlainCall(node: BabelNode, name: string, guren: Set<string>): boolean {
   const callee = node.callee as BabelNode | undefined
   return (
     node.type === 'CallExpression'
     && callee?.type === 'Identifier'
     && callee.name === name
+    && guren.has(name)
     && (node.arguments as unknown[]).length === 0
   )
 }
@@ -126,9 +127,18 @@ function statementSpan(source: string, range: Range): Range {
   return { start, end }
 }
 
-function applyEdits(source: string, edits: Edit[]): string {
+/**
+ * Back to front, so one splice never invalidates another's offsets. Two spans
+ * that overlap cannot both be applied that way — the second would write into
+ * the middle of the first's replacement — and this file is a user's source, so
+ * the answer there is to change nothing.
+ */
+function applyEdits(source: string, edits: Edit[]): string | null {
   let result = source
+  let lowest = source.length
   for (const edit of [...edits].sort((a, b) => b.start - a.start)) {
+    if (edit.end > lowest) return null
+    lowest = edit.start
     result = result.slice(0, edit.start) + edit.text + result.slice(edit.end)
   }
   return result
@@ -144,9 +154,18 @@ export function transformSource(source: string, filePath: string): string | null
   const ast = parseSourceFile(source, filePath)
   if (!ast) return null
 
+  // Every rule is keyed on a name, and the name means what this codemod thinks
+  // only when the file imported it from Guren: an app's own `getContainer`
+  // helper is a different object.
+  const imports = gurenImports(ast.program)
+  const guren = new Set(imports.flatMap((declaration) => declaration.specifiers.map((s) => s.name)))
+  if (guren.size === 0) return null
+
   const providers: Range[] = []
   const jobs: Range[] = []
-  const rebound: Range[] = []
+  // Where a getter must not be rewritten: `this` is not the instance there, or
+  // another rule has already claimed the call.
+  const skip: Range[] = []
   walk(ast.program, (node) => {
     if (node.type !== 'ClassDeclaration' && node.type !== 'ClassExpression') return
     const range = nodeRange(node)
@@ -155,18 +174,18 @@ export function transformSource(source: string, filePath: string): string | null
     if (parent === 'ServiceProvider') providers.push(range)
     else if (parent === 'Job') jobs.push(range)
     else return
-    rebound.push(...reboundRanges(node))
+    skip.push(...reboundRanges(node))
   })
 
   const edits: Edit[] = [
-    ...getterEdits(ast.program, providers, jobs, rebound),
-    ...setterEdits(ast.program, source, providers, rebound),
-    ...storageFactoryEdits(ast.program, source),
-    ...inertiaDocumentEdits(ast.program, source),
+    ...storageFactoryEdits(ast.program, source, guren, skip),
+    ...getterEdits(ast.program, guren, providers, jobs, skip),
+    ...setterEdits(ast.program, source, guren, providers, skip),
+    ...inertiaDocumentEdits(ast.program, source, guren),
   ]
   if (edits.length === 0) return null
 
-  edits.push(...unusedImportEdits(ast.program, source, edits))
+  edits.push(...unusedImportEdits(imports, ast.program, source, edits))
   return applyEdits(source, edits)
 }
 
@@ -191,23 +210,23 @@ function reboundRanges(classNode: BabelNode): Range[] {
 }
 
 /** Rows 1 and 6: a deprecated getter inside a provider or a job. */
-function getterEdits(program: unknown, providers: Range[], jobs: Range[], rebound: Range[]): Edit[] {
+function getterEdits(program: unknown, guren: Set<string>, providers: Range[], jobs: Range[], skip: Range[]): Edit[] {
   const edits: Edit[] = []
   walk(program, (node) => {
     if (node.type !== 'CallExpression') return
     const range = nodeRange(node)
     const callee = nodeRange(node.callee as BabelNode)
-    if (!range || !callee || enclosing(rebound, range)) return
+    if (!range || !callee || enclosing(skip, range)) return
 
     for (const [name, key] of Object.entries(GETTER_KEYS)) {
-      if (!isPlainCall(node, name)) continue
+      if (!isPlainCall(node, name, guren)) continue
       if (enclosing(providers, range)) {
         edits.push({ ...range, text: `this.container.make('${key}')`, consumes: callee })
       }
       return
     }
 
-    if (!isPlainCall(node, 'getContainer')) return
+    if (!isPlainCall(node, 'getContainer', guren)) return
     if (enclosing(providers, range)) {
       edits.push({ ...range, text: 'this.container', consumes: callee })
       return
@@ -223,7 +242,7 @@ function getterEdits(program: unknown, providers: Range[], jobs: Range[], reboun
 }
 
 /** Rows 2 and 3: a deprecated setter inside a provider. */
-function setterEdits(program: unknown, source: string, providers: Range[], rebound: Range[]): Edit[] {
+function setterEdits(program: unknown, source: string, guren: Set<string>, providers: Range[], skip: Range[]): Edit[] {
   const edits: Edit[] = []
   walk(program, (node) => {
     if (node.type !== 'ExpressionStatement') return
@@ -231,7 +250,7 @@ function setterEdits(program: unknown, source: string, providers: Range[], rebou
     const callee = call?.type === 'CallExpression' ? (call.callee as BabelNode) : undefined
     if (callee?.type !== 'Identifier') return
     const key = SETTER_KEYS[callee.name as string]
-    if (!key) return
+    if (!key || !guren.has(callee.name as string)) return
 
     const statement = nodeRange(node)
     const callRange = nodeRange(call)
@@ -249,7 +268,7 @@ function setterEdits(program: unknown, source: string, providers: Range[], rebou
       return
     }
 
-    if (!enclosing(providers, callRange) || enclosing(rebound, callRange)) return
+    if (!enclosing(providers, callRange) || enclosing(skip, callRange)) return
 
     edits.push({
       ...callRange,
@@ -273,12 +292,12 @@ function classBinds(program: unknown, range: Range, key: string): boolean {
 }
 
 /** Row 5: `configureAttachments({ storage: () => getContainer().make('storage') })`. */
-function storageFactoryEdits(program: unknown, source: string): Edit[] {
+function storageFactoryEdits(program: unknown, source: string, guren: Set<string>, claimed: Range[]): Edit[] {
   const edits: Edit[] = []
   walk(program, (node) => {
     if (node.type !== 'CallExpression') return
     const callee = node.callee as BabelNode | undefined
-    if (callee?.type !== 'Identifier' || callee.name !== 'configureAttachments') return
+    if (callee?.type !== 'Identifier' || callee.name !== 'configureAttachments' || !guren.has(callee.name)) return
     const options = unwrapTypeAssertion((node.arguments as Node[])[0]) as BabelNode | undefined
     if (options?.type !== 'ObjectExpression') return
 
@@ -291,7 +310,7 @@ function storageFactoryEdits(program: unknown, source: string): Edit[] {
 
       const inner: Edit[] = []
       walk(arrow.body, (child) => {
-        if (!isPlainCall(child, 'getContainer')) return
+        if (!isPlainCall(child, 'getContainer', guren)) return
         const range = nodeRange(child)
         if (range) inner.push({ ...range, text: 'container', consumes: nodeRange(child.callee as BabelNode) ?? undefined })
       })
@@ -301,13 +320,17 @@ function storageFactoryEdits(program: unknown, source: string): Edit[] {
       const open = source.indexOf('(', arrowRange.start)
       if (open < 0 || open >= arrowRange.end || source.slice(open, open + 2) !== '()') continue
       edits.push({ start: open, end: open + 2, text: '(container)' }, ...inner)
+      // The getter rule would otherwise claim the same call and emit a second
+      // edit over the span this one just rewrote.
+      claimed.push(arrowRange)
     }
   })
   return edits
 }
 
 /** Row 4: `setInertiaDocument({…})` at module scope beside a `createApp({…})`. */
-function inertiaDocumentEdits(program: unknown, source: string): Edit[] {
+function inertiaDocumentEdits(program: unknown, source: string, guren: Set<string>): Edit[] {
+  if (!guren.has('setInertiaDocument') || !guren.has('createApp')) return []
   const body = (program as { body?: BabelNode[] }).body ?? []
 
   const options = createAppOptions(program)
@@ -377,36 +400,53 @@ function indentLiteral(literal: string): string {
   return [first, ...rest.map((line) => (line.trim().length === 0 ? line : `    ${line}`))].join('\n')
 }
 
+interface ImportedName {
+  name: string
+  range: Range
+}
+
+interface GurenImport {
+  range: Range
+  specifiers: ImportedName[]
+}
+
 /**
- * Import specifiers whose every reference this pass removed. Judged on the
- * offsets the edits consume rather than on the rewritten text, so a name the
- * file still uses elsewhere keeps its import.
+ * The file's `@guren/core` / `@guren/server` named imports. A declaration
+ * carrying anything else (a default or namespace specifier) is skipped: nothing
+ * in an app writes one, and rebuilding its specifier list is the one way this
+ * codemod could delete an import it does not understand.
  */
-function unusedImportEdits(program: unknown, source: string, edits: Edit[]): Edit[] {
+function gurenImports(program: unknown): GurenImport[] {
+  const declarations: GurenImport[] = []
+  for (const statement of (program as { body?: BabelNode[] }).body ?? []) {
+    if (statement.type !== 'ImportDeclaration') continue
+    const from = (statement.source as BabelNode).value
+    if (from !== '@guren/core' && from !== '@guren/server') continue
+    const range = nodeRange(statement)
+    const nodes = statement.specifiers as BabelNode[]
+    if (!range || nodes.length === 0 || nodes.some((node) => node.type !== 'ImportSpecifier')) continue
+
+    const specifiers = nodes
+      .map((node) => ({ name: (node.local as BabelNode).name as string, range: nodeRange(node) }))
+      .filter((specifier): specifier is ImportedName => specifier.range !== null)
+    if (specifiers.length === nodes.length) declarations.push({ range, specifiers })
+  }
+  return declarations
+}
+
+/**
+ * Import specifiers this pass left with no reference. A name is dropped only
+ * when it had references and every one of them sits inside an edit: a name with
+ * no reference at all is an import the codemod never touched, and one whose
+ * references it cannot see (a JSX tag is a `JSXIdentifier`, not an `Identifier`)
+ * has to read the same way.
+ */
+function unusedImportEdits(imports: GurenImport[], program: unknown, source: string, edits: Edit[]): Edit[] {
   const consumed = edits.map((edit) => edit.consumes).filter((range): range is Range => Boolean(range))
   if (consumed.length === 0) return []
 
   const references = new Map<string, Range[]>()
-  const declarations: { range: Range; specifiers: { name: string; range: Range }[] }[] = []
-
-  for (const statement of (program as { body?: BabelNode[] }).body ?? []) {
-    if (statement.type !== 'ImportDeclaration') continue
-    const sourceValue = (statement.source as BabelNode).value
-    if (sourceValue !== '@guren/core' && sourceValue !== '@guren/server') continue
-    const range = nodeRange(statement)
-    if (!range) continue
-    const specifiers = (statement.specifiers as BabelNode[])
-      .filter((specifier) => specifier.type === 'ImportSpecifier')
-      .map((specifier) => ({
-        name: ((specifier.local as BabelNode).name as string),
-        range: nodeRange(specifier) as Range,
-      }))
-      .filter((specifier) => specifier.range)
-    if (specifiers.length > 0) declarations.push({ range, specifiers })
-  }
-  if (declarations.length === 0) return []
-
-  const importRanges = declarations.map((declaration) => declaration.range)
+  const importRanges = imports.map((declaration) => declaration.range)
   walk(program, (node) => {
     if (node.type !== 'Identifier') return
     const range = nodeRange(node)
@@ -416,48 +456,39 @@ function unusedImportEdits(program: unknown, source: string, edits: Edit[]): Edi
   })
 
   const removals: Edit[] = []
-  for (const declaration of declarations) {
-    const dropped = declaration.specifiers.filter((specifier) =>
-      (references.get(specifier.name) ?? []).every((reference) =>
-        consumed.some((range) => contains(range, reference)),
-      ),
-    )
-    if (dropped.length === 0) continue
+  for (const declaration of imports) {
+    const kept = declaration.specifiers.filter((specifier) => {
+      const found = references.get(specifier.name) ?? []
+      return found.length === 0 || !found.every((reference) => consumed.some((range) => contains(range, reference)))
+    })
+    if (kept.length === declaration.specifiers.length) continue
 
-    if (dropped.length === declaration.specifiers.length) {
-      removals.push({ ...statementSpan(source, declaration.range), text: '' })
-      continue
-    }
-    for (const specifier of dropped) {
-      removals.push({ ...widenSpecifier(source, specifier.range), text: '' })
-    }
+    removals.push(
+      kept.length === 0
+        ? { ...statementSpan(source, declaration.range), text: '' }
+        : specifierListEdit(source, declaration, kept),
+    )
   }
   return removals
 }
 
-/** A specifier's span plus the separator that joined it to its neighbour. */
-function widenSpecifier(source: string, range: Range): Range {
-  const lineStart = lineStartAt(source, range.start)
-  const lineEnd = source.indexOf('\n', range.end)
-  const rest = source.slice(range.end, lineEnd < 0 ? source.length : lineEnd)
-  // One specifier per line takes its whole line; anything else on the line
-  // means the comma, not the newline, is what joined it to its neighbour.
-  if (source.slice(lineStart, range.start).trim() === '' && rest.trim().replace(',', '') === '') {
-    return { start: lineStart, end: lineEnd < 0 ? source.length : lineEnd + 1 }
-  }
+/**
+ * The whole `{ … }` rewritten from the specifiers that stay. One edit rather
+ * than one per dropped name, because two removals in a single-line list share
+ * the comma between them and splicing both leaves the import unparseable.
+ */
+function specifierListEdit(source: string, declaration: GurenImport, kept: ImportedName[]): Edit {
+  const { specifiers } = declaration
+  const open = source.lastIndexOf('{', specifiers[0].range.start)
+  const close = source.indexOf('}', specifiers[specifiers.length - 1].range.end)
+  const names = kept.map((specifier) => source.slice(specifier.range.start, specifier.range.end))
+  const multiline = source.slice(open, close).includes('\n')
 
-  let end = range.end
-  while (/[ \t]/.test(source[end] ?? '')) end += 1
-  if (source[end] === ',') {
-    end += 1
-    while (/[ \t]/.test(source[end] ?? '')) end += 1
-    return { start: range.start, end }
+  return {
+    start: open + 1,
+    end: close,
+    text: multiline ? `\n  ${names.join(',\n  ')},\n` : ` ${names.join(', ')} `,
   }
-
-  let start = range.start
-  while (start > 0 && /[ \t]/.test(source[start - 1])) start -= 1
-  if (source[start - 1] === ',') start -= 1
-  return { start, end: range.end }
 }
 
 /** Files the codemod would rewrite, relative to `cwd`. */

--- a/packages/cli/src/codemod-container-resolution.ts
+++ b/packages/cli/src/codemod-container-resolution.ts
@@ -146,6 +146,7 @@ export function transformSource(source: string, filePath: string): string | null
 
   const providers: Range[] = []
   const jobs: Range[] = []
+  const rebound: Range[] = []
   walk(ast.program, (node) => {
     if (node.type !== 'ClassDeclaration' && node.type !== 'ClassExpression') return
     const range = nodeRange(node)
@@ -153,11 +154,13 @@ export function transformSource(source: string, filePath: string): string | null
     const parent = superClassName(node)
     if (parent === 'ServiceProvider') providers.push(range)
     else if (parent === 'Job') jobs.push(range)
+    else return
+    rebound.push(...reboundRanges(node))
   })
 
   const edits: Edit[] = [
-    ...getterEdits(ast.program, providers, jobs),
-    ...setterEdits(ast.program, source, providers),
+    ...getterEdits(ast.program, providers, jobs, rebound),
+    ...setterEdits(ast.program, source, providers, rebound),
     ...storageFactoryEdits(ast.program, source),
     ...inertiaDocumentEdits(ast.program, source),
   ]
@@ -167,14 +170,34 @@ export function transformSource(source: string, filePath: string): string | null
   return applyEdits(source, edits)
 }
 
+/**
+ * Spans inside a class where `this` is not the instance: a static member, and
+ * any non-arrow function body. A rewrite to `this.…` there compiles and then
+ * throws at runtime, which is strictly worse than the warning it replaces.
+ */
+function reboundRanges(classNode: BabelNode): Range[] {
+  const ranges: Range[] = []
+  const body = (classNode.body as BabelNode | undefined)?.body as BabelNode[] | undefined
+  for (const member of body ?? []) {
+    const range = nodeRange(member)
+    if (range && member.static === true) ranges.push(range)
+  }
+  walk(classNode.body, (node) => {
+    if (node.type !== 'FunctionExpression' && node.type !== 'FunctionDeclaration' && node.type !== 'ObjectMethod') return
+    const range = nodeRange(node)
+    if (range) ranges.push(range)
+  })
+  return ranges
+}
+
 /** Rows 1 and 6: a deprecated getter inside a provider or a job. */
-function getterEdits(program: unknown, providers: Range[], jobs: Range[]): Edit[] {
+function getterEdits(program: unknown, providers: Range[], jobs: Range[], rebound: Range[]): Edit[] {
   const edits: Edit[] = []
   walk(program, (node) => {
     if (node.type !== 'CallExpression') return
     const range = nodeRange(node)
     const callee = nodeRange(node.callee as BabelNode)
-    if (!range || !callee) return
+    if (!range || !callee || enclosing(rebound, range)) return
 
     for (const [name, key] of Object.entries(GETTER_KEYS)) {
       if (!isPlainCall(node, name)) continue
@@ -200,7 +223,7 @@ function getterEdits(program: unknown, providers: Range[], jobs: Range[]): Edit[
 }
 
 /** Rows 2 and 3: a deprecated setter inside a provider. */
-function setterEdits(program: unknown, source: string, providers: Range[]): Edit[] {
+function setterEdits(program: unknown, source: string, providers: Range[], rebound: Range[]): Edit[] {
   const edits: Edit[] = []
   walk(program, (node) => {
     if (node.type !== 'ExpressionStatement') return
@@ -226,7 +249,7 @@ function setterEdits(program: unknown, source: string, providers: Range[]): Edit
       return
     }
 
-    if (!enclosing(providers, callRange)) return
+    if (!enclosing(providers, callRange) || enclosing(rebound, callRange)) return
 
     edits.push({
       ...callRange,

--- a/packages/cli/src/codemods.ts
+++ b/packages/cli/src/codemods.ts
@@ -3,6 +3,8 @@
  * transforms user code to adapt to breaking changes.
  */
 
+import { applyContainerResolution, detectContainerResolution } from './codemod-container-resolution'
+
 export interface Codemod {
   /** Unique identifier, e.g. 'rename-static-route' */
   id: string
@@ -17,8 +19,25 @@ export interface Codemod {
   apply(cwd: string): Promise<number>
 }
 
-/** Registry of all available codemods, ordered by version. */
-export const codemods: Codemod[] = []
+/**
+ * Registry of all available codemods, ordered by version.
+ *
+ * Ranges name the line of the `@guren/*` pin `checkVersionCompatibility()`
+ * anchors on: the first dependency naming an exact release, `@guren/cli` in
+ * every scaffold. A range on another package's line selects for nobody.
+ */
+export const codemods: Codemod[] = [
+  {
+    id: 'container-only-service-resolution',
+    description:
+      'RFC 0023: resolve gate, encrypter, mail, i18n, log, notifications, broadcast and the exception '
+      + 'handler from the container instead of the module-level setters and getters',
+    fromVersion: '2.21.0',
+    toVersion: '2.22.0',
+    detect: detectContainerResolution,
+    apply: applyContainerResolution,
+  },
+]
 
 /** Codemods applicable for upgrading between two versions. */
 export function findApplicableCodemods(from: string, to: string): Codemod[] {

--- a/packages/cli/src/deprecations.ts
+++ b/packages/cli/src/deprecations.ts
@@ -1,7 +1,13 @@
 /** Framework-level deprecation warnings. */
 import { readFile } from 'node:fs/promises'
 import { relative } from 'node:path'
-import { discoverAppSourceFiles, discoverDbArtifactFiles, discoverModelFiles } from './discovery'
+import {
+  discoverAppConfigFiles,
+  discoverAppSourceFiles,
+  discoverDbArtifactFiles,
+  discoverModelFiles,
+  discoverTestFiles,
+} from './discovery'
 import { extractClassDeclaration, findStaticClassProperty } from './model-parser'
 import { parseSourceFile } from './parse-cache'
 
@@ -60,8 +66,12 @@ const GUREN_IMPORT = /import\s+(?:type\s+)?\{([^}]*)\}\s*from\s*['"]@guren\/(?:c
  * `@guren/server` is matched alongside `@guren/core`: an app importing from it
  * despite the core-first rule is exactly the one this needs to reach.
  */
-async function detectGurenImports(cwd: string, matches: (specifier: string) => boolean): Promise<string[]> {
-  const files = [
+async function detectGurenImports(
+  cwd: string,
+  matches: (specifier: string) => boolean,
+  files?: string[],
+): Promise<string[]> {
+  files ??= [
     ...(await discoverAppSourceFiles(cwd)),
     ...(await discoverDbArtifactFiles(cwd, 'Seeder')),
   ]
@@ -93,6 +103,50 @@ const detectSeederClassImports = (cwd: string): Promise<string[]> =>
 /** Files importing the `ScryptHasher` name for the class now exported as `Argon2Hasher`. */
 const detectScryptHasherImports = (cwd: string): Promise<string[]> =>
   detectGurenImports(cwd, (specifier) => specifier === 'ScryptHasher')
+
+const GLOBAL_SERVICE_SETTERS = new Set([
+  'setGate',
+  'setEncrypter',
+  'setMailManager',
+  'setQueueDriver',
+  'setI18n',
+  'setLogManager',
+  'setNotificationManager',
+  'setBroadcastManager',
+  'setExceptionHandler',
+  'setContainer',
+  'setInertiaDocument',
+  'setInertiaSsrRenderer',
+  'setInertiaSharedProps',
+])
+
+const GLOBAL_SERVICE_GETTERS = new Set([
+  'getGate',
+  'getEncrypter',
+  'getMailManager',
+  'getQueueDriver',
+  'getI18n',
+  'tryGetI18n',
+  'getLogManager',
+  'getNotificationManager',
+  'getBroadcastManager',
+  'getExceptionHandler',
+  'getContainer',
+  'getInertiaSharedPropsResolver',
+])
+
+/**
+ * Every source an app can call these from, which is wider than the `app/` scan
+ * the other entries use: the setters live in `src/app.ts` and `config/*.ts`,
+ * and the test-injection row of RFC 0023's Migration Path is reported rather
+ * than rewritten, so a test file has to be reachable too.
+ */
+async function globalServiceFiles(cwd: string): Promise<string[]> {
+  return [...(await discoverAppConfigFiles(cwd)), ...(await discoverTestFiles(cwd))]
+}
+
+const detectGlobalServiceImports = (names: Set<string>) => async (cwd: string): Promise<string[]> =>
+  detectGurenImports(cwd, (specifier) => names.has(specifier), await globalServiceFiles(cwd))
 
 export const deprecations: Deprecation[] = [
   {
@@ -147,6 +201,36 @@ export const deprecations: Deprecation[] = [
       + "(Bun.password's Argon2id, never scrypt). For a hash every runtime can verify, use 'Hash', "
       + 'whose default is node:crypto scrypt.',
     detect: detectScryptHasherImports,
+  },
+  {
+    id: 'global-service-setters',
+    what:
+      'Module-level service setters (setGate, setEncrypter, setMailManager, setQueueDriver, setI18n, '
+      + 'setLogManager, setNotificationManager, setBroadcastManager, setExceptionHandler, setContainer, '
+      + 'setInertiaDocument, setInertiaSsrRenderer, setInertiaSharedProps)',
+    since: '2.23.0',
+    removedIn: '3.0.0',
+    replacement:
+      "Bind the service on the owning app's container instead — container.instance(key, value) from a "
+      + 'service provider. createApp({ inertia }) covers the document and SSR renderer, '
+      + 'shareInertiaProps(fn, container) the shared props, and useAsDefaultApplication(app) the ambient '
+      + 'application setContainer() chose. Run `bunx guren upgrade` for the rewrites that are mechanical.',
+    detect: detectGlobalServiceImports(GLOBAL_SERVICE_SETTERS),
+  },
+  {
+    id: 'global-service-getters',
+    what:
+      'Module-level service getters (getGate, getEncrypter, getMailManager, getQueueDriver, getI18n, '
+      + 'tryGetI18n, getLogManager, getNotificationManager, getBroadcastManager, getExceptionHandler, '
+      + 'getContainer, getInertiaSharedPropsResolver)',
+    since: '2.23.0',
+    removedIn: '3.0.0',
+    replacement:
+      'Resolve from the container that owns the call — this.make(key) in a controller, job or command, '
+      + 'this.container.make(key) in a provider, getRequestContainer(ctx).make(key) in middleware, '
+      + 'defaultContainer().make(key) elsewhere. The functional helpers (encrypt, decrypt, t, tc, can, '
+      + 'cannot, defineGate, resolve, Job.dispatch) are unaffected.',
+    detect: detectGlobalServiceImports(GLOBAL_SERVICE_GETTERS),
   },
 ]
 

--- a/packages/cli/src/guidelines.ts
+++ b/packages/cli/src/guidelines.ts
@@ -90,7 +90,7 @@ export async function generateGuidelines(options: GuidelinesOptions = {}): Promi
     lines.push('- Policies in app/Policies/ — enforce with `await this.authorize(ability, [Model, record])` in controllers')
     lines.push(`- Available: ${policies.join(', ')}`)
   } else {
-    lines.push('- No policies found. Scaffold with `bunx guren make:policy <Model>` and register via `getGate().policy(Model, ModelPolicy)`')
+    lines.push("- No policies found. Scaffold with `bunx guren make:policy <Model>` and register from a provider's boot() via `this.container.make('gate').policy(Model, ModelPolicy)`")
   }
   lines.push('')
 

--- a/packages/cli/src/make-feature.ts
+++ b/packages/cli/src/make-feature.ts
@@ -238,11 +238,10 @@ export async function makeFeature(name: string, options: MakeFeatureOptions = {}
   consola.info(`  4. Run: bunx guren codegen`)
   if (withPolicy) {
     const modelsBase = moduleName ? `../modules/${moduleName}` : '../app'
-    consola.info(`  5. Register the policy in src/app.ts (inside the boot callback):`)
-    consola.info(`     import { getGate } from '@guren/core'`)
+    consola.info(`  5. Register the policy from a service provider's boot():`)
     consola.info(`     import { ${singular} } from '${modelsBase}/Models/${singular}.js'`)
     consola.info(`     import { ${singular}Policy } from '${modelsBase}/Policies/${singular}Policy.js'`)
-    consola.info(`     getGate().policy(${singular}, ${singular}Policy)`)
+    consola.info(`     this.container.make('gate').policy(${singular}, ${singular}Policy)`)
   }
   if (withAuth) {
     consola.info('')

--- a/packages/cli/src/queue-deps.ts
+++ b/packages/cli/src/queue-deps.ts
@@ -1,5 +1,5 @@
 import type { ContainerLike, QueueDriver, QueueManager, WorkerEvents } from '@guren/core'
-import { Worker, getQueueDriver } from '@guren/core'
+import { Worker, resolveQueueDriver } from '@guren/core'
 
-export { Worker, getQueueDriver }
+export { Worker, resolveQueueDriver }
 export type { ContainerLike, QueueDriver, QueueManager, WorkerEvents }

--- a/packages/cli/src/queue.ts
+++ b/packages/cli/src/queue.ts
@@ -2,7 +2,7 @@ import { pathToFileURL } from 'node:url'
 import { consola } from 'consola'
 import {
   Worker,
-  getQueueDriver,
+  resolveQueueDriver,
   type ContainerLike,
   type QueueDriver,
   type QueueManager,
@@ -158,7 +158,7 @@ type BoundQueueManager = Pick<QueueManager, 'driver' | 'hasDriver' | 'getDefault
 
 /**
  * Boots the app and resolves its queue driver: the `queue` manager its own
- * container binds (RFC 0023 §3), else the driver `getQueueDriver()` reads
+ * container binds (RFC 0023 §3), else the driver `resolveQueueDriver()` reads
  * from the default application. The container rides along so the worker can
  * hand it to each job.
  */
@@ -182,7 +182,7 @@ async function getConfiguredQueue(): Promise<{ driver: QueueDriver; container: C
 
   const container = appContainer(app)
   const manager = container?.has?.('queue') ? (container.make('queue') as BoundQueueManager) : undefined
-  const driver = manager?.hasDriver(manager.getDefaultDriverName()) ? manager.driver() : getQueueDriver()
+  const driver = manager?.hasDriver(manager.getDefaultDriverName()) ? manager.driver() : resolveQueueDriver()
   if (!driver) {
     consola.error('Queue driver not configured. Make sure your application boots a queue manager and activates a driver.')
     process.exit(1)

--- a/packages/cli/tests/codemod-container-resolution.test.ts
+++ b/packages/cli/tests/codemod-container-resolution.test.ts
@@ -275,6 +275,27 @@ describe('the RFC 0023 codemod', () => {
     expect(output).not.toContain('this.container')
   })
 
+  test('changes nothing when two rules claim overlapping spans', () => {
+    // The setter statement is deleted whole and the getter inside it rewritten;
+    // splicing both would write into the middle of the other's replacement.
+    const source = [
+      "import { ServiceProvider, setMailManager, getMailManager } from '@guren/core'",
+      '',
+      'export default class MailProvider extends ServiceProvider {',
+      '  register(): void {',
+      "    this.container.singleton('mail', () => manager)",
+      '  }',
+      '',
+      '  boot(): void {',
+      '    setMailManager(getMailManager() ?? manager)',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    expect(transformSource(source, 'app/Providers/MailProvider.ts')).toBeNull()
+  })
+
   test('reports rather than rewrites a test injecting a fake', () => {
     const source = [
       "import { setGate, setQueueDriver } from '@guren/core'",

--- a/packages/cli/tests/codemod-container-resolution.test.ts
+++ b/packages/cli/tests/codemod-container-resolution.test.ts
@@ -8,6 +8,7 @@ import {
   transformSource,
 } from '../src/codemod-container-resolution'
 import { codemods, findApplicableCodemods, runCodemods } from '../src/codemods'
+import { parseSourceFile } from '../src/parse-cache'
 import { writeWorkspaceFiles } from './helpers'
 
 const REPO_ROOT = join(import.meta.dir, '../../..')
@@ -200,6 +201,78 @@ describe('the RFC 0023 codemod', () => {
     ].join('\n')
 
     expect(transformSource(source, 'app/Jobs/ReportJob.ts')).toBeNull()
+  })
+
+  test('keeps a single-line import parseable when two specifiers go', () => {
+    const source = [
+      "import { ServiceProvider, getGate, getContainer } from '@guren/core'",
+      '',
+      'export default class P extends ServiceProvider {',
+      '  boot(): void {',
+      '    getGate().policy(A, B)',
+      "    getContainer().make('x')",
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    const output = transformSource(source, 'app/Providers/P.ts')
+
+    expect(output).toContain("import { ServiceProvider } from '@guren/core'")
+    // The two removals share the comma between them, so a per-specifier splice
+    // leaves `import { ServiceProvider,  from …`.
+    expect(parseSourceFile(output ?? '', 'app/Providers/P.ts')).not.toBeNull()
+  })
+
+  test('keeps an import specifier it did not rewrite', () => {
+    const source = [
+      "import { ServiceProvider, getGate, createEventManager } from '@guren/core'",
+      '',
+      'export default class P extends ServiceProvider {',
+      '  boot(): void {',
+      '    getGate().policy(A, B)',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    expect(transformSource(source, 'app/Providers/P.ts')).toContain(
+      "import { ServiceProvider, createEventManager } from '@guren/core'",
+    )
+  })
+
+  test('leaves a same-named symbol imported from elsewhere alone', () => {
+    const source = [
+      "import { ServiceProvider } from '@guren/core'",
+      "import { getContainer } from '../support/di.js'",
+      '',
+      'export default class P extends ServiceProvider {',
+      '  register(): void {',
+      "    getContainer().make('thing')",
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    expect(transformSource(source, 'app/Providers/P.ts')).toBeNull()
+  })
+
+  test('lets one rule claim a call the other would also rewrite', () => {
+    const source = [
+      "import { ServiceProvider, configureAttachments, getContainer } from '@guren/core'",
+      '',
+      'export default class AttachmentsProvider extends ServiceProvider {',
+      '  register(): void {',
+      "    configureAttachments({ table, storage: () => getContainer().make('storage'), disk: 'media' })",
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    const output = transformSource(source, 'app/Providers/AttachmentsProvider.ts')
+
+    expect(output).toContain("storage: (container) => container.make('storage')")
+    expect(output).not.toContain('this.container')
   })
 
   test('reports rather than rewrites a test injecting a fake', () => {

--- a/packages/cli/tests/codemod-container-resolution.test.ts
+++ b/packages/cli/tests/codemod-container-resolution.test.ts
@@ -156,6 +156,52 @@ describe('the RFC 0023 codemod', () => {
     expect(output).toContain("import { Job, type StorageManager } from '@guren/core'")
   })
 
+  test('leaves a getter alone where `this` is not the instance', () => {
+    const nested = [
+      "import { ServiceProvider, getGate } from '@guren/core'",
+      '',
+      'export default class AuthorizationProvider extends ServiceProvider {',
+      '  register(): void {',
+      "    this.container.singleton('policies', function () {",
+      '      return getGate()',
+      '    })',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    const staticMember = [
+      "import { ServiceProvider, getContainer } from '@guren/core'",
+      '',
+      'export default class AuthorizationProvider extends ServiceProvider {',
+      '  static boot(): void {',
+      "    getContainer().make('gate')",
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    expect(transformSource(nested, 'app/Providers/AuthorizationProvider.ts')).toBeNull()
+    expect(transformSource(staticMember, 'app/Providers/AuthorizationProvider.ts')).toBeNull()
+  })
+
+  test('leaves a job getter alone inside a non-arrow callback', () => {
+    const source = [
+      "import { Job, getContainer } from '@guren/core'",
+      '',
+      'export class ReportJob extends Job<{ id: number }> {',
+      '  async handle(): Promise<void> {',
+      '    run(function () {',
+      "      return getContainer().make('storage')",
+      '    })',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    expect(transformSource(source, 'app/Jobs/ReportJob.ts')).toBeNull()
+  })
+
   test('reports rather than rewrites a test injecting a fake', () => {
     const source = [
       "import { setGate, setQueueDriver } from '@guren/core'",

--- a/packages/cli/tests/codemod-container-resolution.test.ts
+++ b/packages/cli/tests/codemod-container-resolution.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test } from 'bun:test'
+import { cp, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  applyContainerResolution,
+  detectContainerResolution,
+  transformSource,
+} from '../src/codemod-container-resolution'
+import { codemods, findApplicableCodemods, runCodemods } from '../src/codemods'
+import { writeWorkspaceFiles } from './helpers'
+
+const REPO_ROOT = join(import.meta.dir, '../../..')
+
+async function scratchApp(files: Record<string, string>): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'guren-codemod-'))
+  await writeWorkspaceFiles(dir, files)
+  return dir
+}
+
+/** Applying twice must leave the second run with nothing to do. */
+async function applyTwice(dir: string): Promise<{ first: number; second: number; detected: string[] }> {
+  const detected = await detectContainerResolution(dir)
+  const first = await applyContainerResolution(dir)
+  const second = await applyContainerResolution(dir)
+  return { first, second, detected }
+}
+
+describe('the RFC 0023 codemod', () => {
+  test('rewrites a getter inside a service provider to the container it holds', () => {
+    const source = [
+      "import { ServiceProvider, getGate } from '@guren/core'",
+      "import { Post } from '../Models/Post.js'",
+      '',
+      'export default class AuthorizationProvider extends ServiceProvider {',
+      '  boot(): void {',
+      '    getGate().policy(Post, Post)',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    const output = transformSource(source, 'app/Providers/AuthorizationProvider.ts')
+
+    expect(output).toContain("this.container.make('gate').policy(Post, Post)")
+    expect(output).toContain("import { ServiceProvider } from '@guren/core'")
+    expect(output).not.toContain('getGate')
+  })
+
+  test('deletes a setter whose key a provider in the same file already binds', () => {
+    const source = [
+      "import { ServiceProvider, setMailManager } from '@guren/core'",
+      '',
+      'function boot(manager: never): void {',
+      '  setMailManager(manager)',
+      '}',
+      '',
+      'export default class MailProvider extends ServiceProvider {',
+      '  register(): void {',
+      "    this.container.singleton('mail', () => manager)",
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    const output = transformSource(source, 'app/Providers/MailProvider.ts')
+
+    expect(output).not.toContain('setMailManager')
+    expect(output).toContain("this.container.singleton('mail'")
+  })
+
+  test('binds the value on the container when the provider binds nothing', () => {
+    const source = [
+      "import { ServiceProvider, setMailManager } from '@guren/core'",
+      '',
+      'export default class MailProvider extends ServiceProvider {',
+      '  boot(): void {',
+      '    setMailManager(manager)',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    expect(transformSource(source, 'app/Providers/MailProvider.ts')).toContain(
+      "this.container.instance('mail', manager)",
+    )
+  })
+
+  test('moves an inline setInertiaDocument literal into createApp options', () => {
+    const source = [
+      "import { createApp, setInertiaDocument } from '@guren/core'",
+      '',
+      '// Rendered into every server-rendered document.',
+      'setInertiaDocument({',
+      "  head: '<link rel=\"icon\" href=\"/favicon.svg\" />',",
+      '})',
+      '',
+      'const app = createApp({',
+      '  routes: registerWebRoutes,',
+      '})',
+      '',
+    ].join('\n')
+
+    const output = transformSource(source, 'src/app.ts')
+
+    expect(output).toContain('  inertia: {\n    document: {')
+    expect(output).toContain('// Rendered into every server-rendered document.')
+    expect(output).not.toContain('setInertiaDocument')
+    expect(output).toContain("import { createApp } from '@guren/core'")
+  })
+
+  test('leaves setInertiaDocument alone when createApp is in another file', () => {
+    const source = [
+      "import { setInertiaDocument } from '@guren/core'",
+      '',
+      "setInertiaDocument({ head: '' })",
+      '',
+    ].join('\n')
+
+    expect(transformSource(source, 'config/inertia.ts')).toBeNull()
+  })
+
+  test('gives the attachments storage factory the container it is bound with', () => {
+    const source = [
+      "import { configureAttachments, getContainer } from '@guren/core'",
+      '',
+      'export const { Attachment } = configureAttachments({',
+      '  table: attachments,',
+      "  storage: () => getContainer().make('storage'),",
+      "  disk: 'media',",
+      '})',
+      '',
+    ].join('\n')
+
+    const output = transformSource(source, 'config/attachments.ts')
+
+    expect(output).toContain("storage: (container) => container.make('storage')")
+    expect(output).toContain("import { configureAttachments } from '@guren/core'")
+  })
+
+  test('rewrites getContainer().make() inside a Job to this.make()', () => {
+    const source = [
+      "import { Job, getContainer, type StorageManager } from '@guren/core'",
+      '',
+      'export class ReportJob extends Job<{ id: number }> {',
+      '  async handle(): Promise<void> {',
+      "    const storage = getContainer().make<StorageManager>('storage')",
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    const output = transformSource(source, 'app/Jobs/ReportJob.ts')
+
+    expect(output).toContain("this.make<StorageManager>('storage')")
+    expect(output).toContain("import { Job, type StorageManager } from '@guren/core'")
+  })
+
+  test('reports rather than rewrites a test injecting a fake', () => {
+    const source = [
+      "import { setGate, setQueueDriver } from '@guren/core'",
+      '',
+      'setQueueDriver(fake)',
+      'setGate(gate)',
+      '',
+    ].join('\n')
+
+    expect(transformSource(source, 'app/support/inject.ts')).toBeNull()
+  })
+
+  test('is selected for the versions a scaffolded app upgrades between', () => {
+    const codemod = codemods.find((entry) => entry.id === 'container-only-service-resolution')
+    expect(codemod).toBeDefined()
+    // `checkVersionCompatibility()` anchors on the first @guren/* pin naming an
+    // exact release, which every template orders as @guren/cli.
+    expect(findApplicableCodemods('2.21.0', '2.22.0').map((entry) => entry.id)).toContain(
+      'container-only-service-resolution',
+    )
+  })
+
+  test('runs through the codemod registry and is idempotent', async () => {
+    const dir = await scratchApp({
+      'app/Providers/AuthorizationProvider.ts': [
+        "import { ServiceProvider, getGate } from '@guren/core'",
+        '',
+        'export default class AuthorizationProvider extends ServiceProvider {',
+        '  boot(): void {',
+        '    getGate().policy(Post, PostPolicy)',
+        '  }',
+        '}',
+        '',
+      ].join('\n'),
+    })
+
+    try {
+      const applied = await runCodemods(dir, '2.21.0', '2.22.0')
+      expect(applied).toEqual([
+        expect.objectContaining({ id: 'container-only-service-resolution', status: 'applied', filesAffected: 1 }),
+      ])
+
+      const again = await runCodemods(dir, '2.21.0', '2.22.0')
+      expect(again).toEqual([
+        expect.objectContaining({ id: 'container-only-service-resolution', status: 'skipped', filesAffected: 0 }),
+      ])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('migrates the blog example and changes nothing on a second run', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'guren-codemod-blog-'))
+    try {
+      for (const directory of ['app', 'config', 'src', 'routes', 'db']) {
+        await cp(join(REPO_ROOT, 'examples/blog', directory), join(dir, directory), { recursive: true })
+      }
+
+      const { first, second, detected } = await applyTwice(dir)
+
+      expect(detected).toContain('app/Providers/EventServiceProvider.ts')
+      expect(first).toBe(detected.length)
+      expect(second).toBe(0)
+
+      const provider = await readFile(join(dir, 'app/Providers/EventServiceProvider.ts'), 'utf8')
+      expect(provider).not.toContain('setMailManager')
+      expect(provider).toContain("this.container.singleton('mail'")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/tests/queue.test.ts
+++ b/packages/cli/tests/queue.test.ts
@@ -31,7 +31,7 @@ await mock.module('../src/queue-deps', () => ({
       this.events.workerStopped?.()
     }
   },
-  getQueueDriver: () => fakeDriver,
+  resolveQueueDriver: () => fakeDriver,
 }))
 
 const {

--- a/packages/cli/tests/upgrade.test.ts
+++ b/packages/cli/tests/upgrade.test.ts
@@ -699,4 +699,61 @@ describe('checkDeprecations', () => {
       expect(seederWarning(await checkDeprecations(workspace.dir))).toBeUndefined()
     })
   })
+
+  describe('the RFC 0023 service accessors', () => {
+    async function writeFileIn(relativePath: string, contents: string): Promise<void> {
+      const target = join(workspace.dir, relativePath)
+      await mkdir(dirname(target), { recursive: true })
+      await writeFile(target, contents)
+    }
+
+    function filesFor(warnings: Awaited<ReturnType<typeof checkDeprecations>>, id: string) {
+      return (warnings.find((warning) => warning.id === id)?.affectedFiles ?? []).sort()
+    }
+
+    // The setters live outside `app/`, the only directory the other entries
+    // scan, and the test-injection row of the migration table is reported
+    // rather than rewritten, so a test file has to be reached too.
+    it('reports setters and getters across config, src, app and tests', async () => {
+      await writeFileIn(
+        'src/app.ts',
+        "import { createApp, setInertiaDocument } from '@guren/core'\nsetInertiaDocument({ head: '' })\nexport default createApp({})\n",
+      )
+      await writeFileIn(
+        'config/inertia.ts',
+        "import { setInertiaSharedProps } from '@guren/core'\nsetInertiaSharedProps(null)\n",
+      )
+      await writeFileIn(
+        'app/Providers/AuthorizationProvider.ts',
+        "import { getGate } from '@guren/server'\nexport const gate = () => getGate()\n",
+      )
+      await writeFileIn(
+        'tests/posts.test.ts',
+        "import { setQueueDriver } from '@guren/core'\nsetQueueDriver(fake)\n",
+      )
+
+      const warnings = await checkDeprecations(workspace.dir)
+
+      expect(filesFor(warnings, 'global-service-setters')).toEqual([
+        join('config', 'inertia.ts'),
+        join('src', 'app.ts'),
+        join('tests', 'posts.test.ts'),
+      ])
+      expect(filesFor(warnings, 'global-service-getters')).toEqual([
+        join('app', 'Providers', 'AuthorizationProvider.ts'),
+      ])
+    })
+
+    it('does not report an app that resolves from its container', async () => {
+      await writeFileIn(
+        'app/Providers/AuthorizationProvider.ts',
+        "import { ServiceProvider } from '@guren/core'\nexport default class P extends ServiceProvider {\n  boot(): void {\n    this.container.make('gate')\n  }\n}\n",
+      )
+
+      const warnings = await checkDeprecations(workspace.dir)
+
+      expect(filesFor(warnings, 'global-service-setters')).toEqual([])
+      expect(filesFor(warnings, 'global-service-getters')).toEqual([])
+    })
+  })
 })

--- a/packages/core/src/attachments/engine.ts
+++ b/packages/core/src/attachments/engine.ts
@@ -5,7 +5,7 @@ import {
   getAppKeyringFromEnv,
   ambientBinding,
   ambientContainer,
-  getQueueDriver,
+  resolveQueueDriver,
   signUrl,
   verifySignedUrl,
   HttpException,
@@ -923,7 +923,7 @@ export class AttachmentEngine {
       }
       return manager as QueueDispatcher
     }
-    if (!getQueueDriver()) {
+    if (!resolveQueueDriver()) {
       throw new Error(
         "attach() with queued: true requires a queue. Pass configureAttachments({ queue: () => queueManager }) or boot the app's queue before attaching.",
       )
@@ -1410,7 +1410,12 @@ export class AttachmentEngine {
 
 let activeEngine: AttachmentEngine | null = null
 
-/** Install the engine `configureAttachments()` built. Last call wins; `null` unconfigures (tests). */
+/**
+ * Install the engine `configureAttachments()` built. Last call wins; `null`
+ * unconfigures (tests). Neither this nor its getter is exported from
+ * `@guren/core`, so RFC 0023's deprecation window does not reach them: they go
+ * with the slot in Part 3.
+ */
 export function setActiveAttachmentEngine(engine: AttachmentEngine | null): void {
   activeEngine = engine
 }

--- a/packages/server/src/authorization/Gate.ts
+++ b/packages/server/src/authorization/Gate.ts
@@ -12,7 +12,8 @@ import type {
 } from './types'
 import { AuthorizationException, HttpException } from '../errors'
 import { getAuthContext } from '../auth/context'
-import { ambientBinding } from '../http/default-application'
+import { ambientBinding, bindAmbient } from '../http/default-application'
+import { warnDeprecatedGetter, warnDeprecatedSetter } from '../support/deprecate'
 
 /** Response builder for authorization checks. */
 export const Response: ResponseBuilder = {
@@ -338,12 +339,28 @@ export function createGate(options?: GateOptions): Gate {
   return new Gate(options)
 }
 
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Bind the gate on the
+ * app's container instead — `AuthorizationServiceProvider` already does, and a
+ * provider of your own reaches it as `this.container.instance('gate', gate)`.
+ */
 export function setGate(gate: Gate): void {
-  globalGate = gate
+  warnDeprecatedSetter('setGate')
+  globalGate = bindAmbient('gate', gate) ? null : gate
 }
 
-/** The default application's `gate`, else the one `setGate()` installed. */
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Use `this.make('gate')`
+ * in a controller, `getRequestContainer(ctx).make('gate')` in middleware, or
+ * `defaultContainer().make('gate')`.
+ */
 export function getGate(): Gate {
+  warnDeprecatedGetter('getGate')
+  return resolveGate()
+}
+
+/** @internal The default application's `gate`, else the one `setGate()` installed, without the warning. */
+export function resolveGate(): Gate {
   const gate = ambientBinding('gate') ?? globalGate
   if (!gate) {
     throw new Error('Gate not initialized. Construct the app with createApp(), or call setGate() first.')
@@ -353,17 +370,17 @@ export function getGate(): Gate {
 
 /** Define a gate on the global instance. */
 export function defineGate(ability: string, callback: GateCallback): void {
-  getGate().define(ability, callback)
+  resolveGate().define(ability, callback)
 }
 
 export async function can(ability: string, ...args: unknown[]): Promise<boolean> {
-  return getGate().allows(ability, ...args)
+  return resolveGate().allows(ability, ...args)
 }
 
 export async function cannot(ability: string, ...args: unknown[]): Promise<boolean> {
-  return getGate().denies(ability, ...args)
+  return resolveGate().denies(ability, ...args)
 }
 
 export async function authorize(ability: string, ...args: unknown[]): Promise<void> {
-  return getGate().authorize(ability, ...args)
+  return resolveGate().authorize(ability, ...args)
 }

--- a/packages/server/src/authorization/middleware.ts
+++ b/packages/server/src/authorization/middleware.ts
@@ -1,14 +1,14 @@
 import type { Context } from '../http/Application'
 import type { Middleware } from '../http/middleware'
 import type { AuthorizeOptions, AuthorizeResourceOptions } from './types'
-import { Gate, getGate, denialToException } from './Gate'
+import { Gate, resolveGate, denialToException } from './Gate'
 import { tryGetRequestContainer } from '../http/request-container'
 import { AuthorizationException } from '../errors'
 import { stampCapabilities } from '../http/middleware/capabilities'
 
 /** The gate of the app serving `ctx` (RFC 0023 §2); the ambient one on a bare Hono app. */
 function gateFor(ctx: Context): Gate {
-  return tryGetRequestContainer(ctx)?.makeOptional('gate') ?? getGate()
+  return tryGetRequestContainer(ctx)?.makeOptional('gate') ?? resolveGate()
 }
 
 /**

--- a/packages/server/src/broadcasting/BroadcastManager.ts
+++ b/packages/server/src/broadcasting/BroadcastManager.ts
@@ -18,7 +18,8 @@ import type { Context } from '../http/Application'
 import type { Middleware } from '../http/middleware'
 import { parseRequestPayload } from '../http/request'
 import { randomHex } from '../encryption/Random'
-import { ambientBinding } from '../http/default-application'
+import { ambientBinding, bindAmbient } from '../http/default-application'
+import { warnDeprecatedGetter, warnDeprecatedSetter } from '../support/deprecate'
 
 /**
  * Best-effort identity for the user behind a connection: `getUser` is
@@ -521,12 +522,23 @@ export class BroadcastManager {
 
 let globalBroadcastManager: BroadcastManager | null = null
 
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Bind the manager on the
+ * app's container instead — `BroadcastServiceProvider` already does, and a
+ * provider of your own reaches it as `this.container.instance('broadcast', m)`.
+ */
 export function setBroadcastManager(manager: BroadcastManager): void {
-  globalBroadcastManager = manager
+  warnDeprecatedSetter('setBroadcastManager')
+  globalBroadcastManager = bindAmbient('broadcast', manager) ? null : manager
 }
 
-/** The default application's `broadcast`, else the one `setBroadcastManager()` installed. */
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Use
+ * `this.make('broadcast')` in a controller, job or command, or
+ * `defaultContainer().make('broadcast')`.
+ */
 export function getBroadcastManager(): BroadcastManager {
+  warnDeprecatedGetter('getBroadcastManager')
   const manager = ambientBinding('broadcast') ?? globalBroadcastManager
   if (!manager) {
     throw new Error('BroadcastManager not initialized. Register BroadcastServiceProvider, or call setBroadcastManager() first.')

--- a/packages/server/src/container/Container.ts
+++ b/packages/server/src/container/Container.ts
@@ -6,6 +6,7 @@ import type {
   ContextualBinding,
 } from './types'
 import type { ServiceBindings } from './bindings'
+import { warnDeprecatedGetter, warnDeprecatedSetter } from '../support/deprecate'
 
 /**
  * Dependency injection container. Keys from `ServiceBindings` type `make()`
@@ -335,7 +336,8 @@ export function createContainer(): Container {
 
 let globalContainer: Container | null = null
 
-export function setContainer(container: Container): void {
+/** @internal The ambient slot's write, without the deprecation warning `setContainer()` carries. */
+export function installContainer(container: Container): void {
   globalContainer = container
 }
 
@@ -349,10 +351,31 @@ export function clearContainer(): void {
   globalContainer = null
 }
 
-export function getContainer(): Container {
+/** @internal The ambient container or the throw, without the deprecation warning `getContainer()` carries. */
+export function requireContainer(): Container {
   if (!globalContainer) {
     throw new Error('Container not initialized. Call setContainer() first.')
   }
   return globalContainer
+}
+
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Choose the ambient
+ * application with `useAsDefaultApplication(app)`; every `Application`
+ * constructor already publishes its own container.
+ */
+export function setContainer(container: Container): void {
+  warnDeprecatedSetter('setContainer')
+  installContainer(container)
+}
+
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Use `defaultContainer()`
+ * for the ambient one, `this.make(key)` in a controller, job or command, or
+ * `getRequestContainer(ctx)` in middleware.
+ */
+export function getContainer(): Container {
+  warnDeprecatedGetter('getContainer')
+  return requireContainer()
 }
 

--- a/packages/server/src/encryption/Encrypter.ts
+++ b/packages/server/src/encryption/Encrypter.ts
@@ -1,7 +1,8 @@
 import { createCipheriv, createDecipheriv, randomBytes, createHmac } from 'crypto'
 import type { EncrypterConfig, EncryptOptions, DecryptOptions, EncryptedPayload } from './types'
 import { generateAppKey, normalizeAppKey } from './app-key'
-import { ambientBinding } from '../http/default-application'
+import { ambientBinding, bindAmbient } from '../http/default-application'
+import { warnDeprecatedGetter, warnDeprecatedSetter } from '../support/deprecate'
 
 /**
  * GCM authentication tag length, in bytes, pinned on both sides: Node and Bun
@@ -211,12 +212,28 @@ export function createEncrypter(config: EncrypterConfig): Encrypter {
   return new Encrypter(config)
 }
 
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Bind the encrypter on
+ * the app's container instead — `EncryptionServiceProvider` already does, and a
+ * provider of your own reaches it as `this.container.instance('encrypter', e)`.
+ */
 export function setEncrypter(encrypter: Encrypter): void {
-  globalEncrypter = encrypter
+  warnDeprecatedSetter('setEncrypter')
+  globalEncrypter = bindAmbient('encrypter', encrypter) ? null : encrypter
 }
 
-/** The default application's `encrypter`, else the one `setEncrypter()` installed. */
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Use
+ * `this.make('encrypter')` in a controller, job or command, or
+ * `defaultContainer().make('encrypter')`. `encrypt()` / `decrypt()` are unaffected.
+ */
 export function getEncrypter(): Encrypter {
+  warnDeprecatedGetter('getEncrypter')
+  return resolveEncrypter()
+}
+
+/** @internal The default application's `encrypter`, else the one `setEncrypter()` installed. */
+function resolveEncrypter(): Encrypter {
   const encrypter = ambientBinding('encrypter') ?? globalEncrypter
   if (!encrypter) {
     throw new Error('Encrypter not initialized. Register EncryptionServiceProvider, or call setEncrypter() first.')
@@ -226,10 +243,10 @@ export function getEncrypter(): Encrypter {
 
 /** Encrypt with the global encrypter. */
 export function encrypt(value: unknown, options?: EncryptOptions): string {
-  return getEncrypter().encrypt(value, options)
+  return resolveEncrypter().encrypt(value, options)
 }
 
 /** Decrypt with the global encrypter. */
 export function decrypt<T = unknown>(payload: string, options?: DecryptOptions): T {
-  return getEncrypter().decrypt<T>(payload, options)
+  return resolveEncrypter().decrypt<T>(payload, options)
 }

--- a/packages/server/src/errors/ExceptionHandler.ts
+++ b/packages/server/src/errors/ExceptionHandler.ts
@@ -11,7 +11,8 @@ import type {
 } from './types'
 import { HttpException } from './HttpException'
 import { renderErrorPage } from './error-page'
-import { ambientBinding } from '../http/default-application'
+import { ambientBinding, bindAmbient } from '../http/default-application'
+import { warnDeprecatedGetter, warnDeprecatedSetter } from '../support/deprecate'
 
 /** Centralized error handling: reporting, per-class renderers, middleware. */
 export class ExceptionHandler {
@@ -195,12 +196,23 @@ export function createExceptionHandler(
 
 let globalExceptionHandler: ExceptionHandler | null = null
 
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Bind the handler on the
+ * app's container instead — `ErrorServiceProvider` already does, and a provider
+ * of your own reaches it as `this.container.instance('exception.handler', h)`.
+ */
 export function setExceptionHandler(handler: ExceptionHandler): void {
-  globalExceptionHandler = handler
+  warnDeprecatedSetter('setExceptionHandler')
+  globalExceptionHandler = bindAmbient('exception.handler', handler) ? null : handler
 }
 
-/** The default application's `exception.handler`, else the one `setExceptionHandler()` installed. */
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Use
+ * `this.make('exception.handler')` in a controller, job or command, or
+ * `defaultContainer().make('exception.handler')`.
+ */
 export function getExceptionHandler(): ExceptionHandler {
+  warnDeprecatedGetter('getExceptionHandler')
   const handler = ambientBinding('exception.handler') ?? globalExceptionHandler
   if (!handler) {
     throw new Error(

--- a/packages/server/src/events/queued.ts
+++ b/packages/server/src/events/queued.ts
@@ -1,4 +1,4 @@
-import { Job, getQueueDriver, registerJob } from '../queue/Job'
+import { Job, registerJob, resolveQueueDriver } from '../queue/Job'
 import { encodeEventData } from './serialize'
 import type { QueueEventDispatcher } from './types'
 
@@ -48,7 +48,7 @@ class QueuedEventJob extends Job<QueuedEventPayload> {
 export function createQueueEventDispatcher(): QueueEventDispatcher {
   registerJob(QueuedEventJob)
   return async (queue, eventName, event, listenerSeq) => {
-    if (getQueueDriver() === null) return false
+    if (resolveQueueDriver() === null) return false
     await QueuedEventJob.dispatch(
       { queue, eventName, event: encodeEventData(event), listenerSeq },
       { queue },

--- a/packages/server/src/http/default-application.ts
+++ b/packages/server/src/http/default-application.ts
@@ -1,6 +1,6 @@
 import type { Application } from './Application'
 import type { ServiceBindings } from '../container/bindings'
-import { type Container, clearContainer, getContainer, peekContainer, setContainer } from '../container/Container'
+import { type Container, clearContainer, installContainer, peekContainer, requireContainer } from '../container/Container'
 import { warnOnce } from '../support/warn-once'
 
 /**
@@ -39,7 +39,7 @@ export function resetDefaultApplication(): void {
 function setDefault(app: Application, nextAmbiguous: boolean): void {
   current = app
   ambiguous = nextAmbiguous
-  setContainer(app.container)
+  installContainer(app.container)
 }
 
 /**
@@ -58,7 +58,7 @@ export function defaultApplication(): Application | null {
 /** The default application's container; throws the same "not initialized" error the getters throw. */
 export function defaultContainer(): Container {
   warnIfAmbiguous()
-  return getContainer()
+  return requireContainer()
 }
 
 /** `defaultContainer()` for a caller with a fallback of its own: null instead of the throw. */
@@ -74,6 +74,17 @@ export function ambientContainer(): Container | null {
  */
 export function ambientBinding<K extends keyof ServiceBindings>(key: K): ServiceBindings[K] | undefined {
   return ambientContainer()?.makeOptional(key)
+}
+
+/**
+ * @internal A deprecated setter's write (RFC 0023 §5): the ambient container
+ * when one exists, else nothing. Answers whether it landed, so the caller can
+ * drop its module slot rather than leave a copy that outlives the app.
+ */
+export function bindAmbient<K extends keyof ServiceBindings>(key: K, value: ServiceBindings[K]): boolean {
+  const container = ambientContainer()
+  container?.instance(key, value)
+  return container !== null
 }
 
 /** Resolve `key` from the default application's container. */

--- a/packages/server/src/http/middleware/detect-locale.ts
+++ b/packages/server/src/http/middleware/detect-locale.ts
@@ -2,7 +2,7 @@ import type { Context } from 'hono'
 import { createMiddleware } from 'hono/factory'
 import { getCookie } from 'hono/cookie'
 import { parseAccept } from 'hono/utils/accept'
-import { tryGetI18n, type I18nManager, type Translator } from '../../i18n'
+import { resolveI18n, type I18nManager, type Translator } from '../../i18n'
 import { tryGetRequestContainer } from '../request-container'
 
 /** Context key for the resolved request locale (read by Inertia for `<html lang>`). */
@@ -147,7 +147,7 @@ export function detectLocaleMiddleware(options: DetectLocaleOptions) {
     const i18n =
       options.i18n === false
         ? undefined
-        : options.i18n ?? tryGetRequestContainer(c)?.makeOptional('i18n') ?? tryGetI18n()
+        : options.i18n ?? tryGetRequestContainer(c)?.makeOptional('i18n') ?? resolveI18n()
     if (i18n) {
       await i18n.loadLocale(resolved).catch(() => {})
 

--- a/packages/server/src/i18n/I18nManager.ts
+++ b/packages/server/src/i18n/I18nManager.ts
@@ -6,7 +6,8 @@ import type {
 } from './types'
 import { Translator } from './Translator'
 import { JsonLoader } from './loaders/JsonLoader'
-import { ambientBinding } from '../http/default-application'
+import { ambientBinding, bindAmbient } from '../http/default-application'
+import { warnDeprecatedGetter, warnDeprecatedSetter } from '../support/deprecate'
 
 export class I18nManager {
   private config: I18nConfig
@@ -148,31 +149,55 @@ export function createI18n(config: I18nConfig): I18nManager {
   return new I18nManager(config)
 }
 
-/** Set the global I18n manager. */
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Pass
+ * `createApp({ i18n })`, or bind it from a provider as
+ * `this.container.instance('i18n', manager)`.
+ */
 export function setI18n(i18n: I18nManager): void {
-  globalI18n = i18n
+  warnDeprecatedSetter('setI18n')
+  globalI18n = bindAmbient('i18n', i18n) ? null : i18n
 }
 
-/** The default application's `i18n`, else the one `setI18n()` installed. */
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Use `this.t(key)` in a
+ * controller, `getRequestTranslator(ctx)` in middleware, or
+ * `defaultContainer().make('i18n')`. `t()` / `tc()` are unaffected.
+ */
 export function getI18n(): I18nManager {
-  const i18n = tryGetI18n()
+  warnDeprecatedGetter('getI18n')
+  return resolveI18nOrFail()
+}
+
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Use
+ * `container.makeOptional('i18n')` on the container that owns the call.
+ */
+export function tryGetI18n(): I18nManager | undefined {
+  warnDeprecatedGetter('tryGetI18n')
+  return resolveI18n()
+}
+
+/** @internal The default application's `i18n`, else the one `setI18n()` installed. */
+export function resolveI18n(): I18nManager | undefined {
+  return ambientBinding('i18n') ?? globalI18n ?? undefined
+}
+
+/** @internal `resolveI18n()` with the message every unconfigured caller should read. */
+function resolveI18nOrFail(): I18nManager {
+  const i18n = resolveI18n()
   if (!i18n) {
     throw new Error('I18n manager not initialized. Pass createApp({ i18n }), or call setI18n() first.')
   }
   return i18n
 }
 
-/** `getI18n()` without the throw: `undefined` when no app binds one and none was set. */
-export function tryGetI18n(): I18nManager | undefined {
-  return ambientBinding('i18n') ?? globalI18n ?? undefined
-}
-
 /** Translate a key using the global I18n manager. */
 export function t(key: string, replacements?: ReplacementValues): string {
-  return getI18n().t(key, replacements)
+  return resolveI18nOrFail().t(key, replacements)
 }
 
 /** Translate a key with count using the global I18n manager. */
 export function tc(key: string, count: number, replacements?: ReplacementValues): string {
-  return getI18n().tc(key, count, replacements)
+  return resolveI18nOrFail().tc(key, count, replacements)
 }

--- a/packages/server/src/i18n/index.ts
+++ b/packages/server/src/i18n/index.ts
@@ -24,6 +24,7 @@ export {
   setI18n,
   getI18n,
   tryGetI18n,
+  resolveI18n,
   t,
   tc,
 } from './I18nManager'

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -540,6 +540,7 @@ export {
   setQueueDriver,
   clearQueueDriver,
   getQueueDriver,
+  resolveQueueDriver,
   registerJob,
   getJob,
   getRegisteredJobs,

--- a/packages/server/src/logging/LogManager.ts
+++ b/packages/server/src/logging/LogManager.ts
@@ -3,7 +3,8 @@ import { Logger, isPromiseLike, type LoggerOptions } from './Logger'
 import { ConsoleChannel } from './channels/ConsoleChannel'
 import { FileChannel } from './channels/FileChannel'
 import { DailyFileChannel } from './channels/DailyFileChannel'
-import { ambientBinding } from '../http/default-application'
+import { ambientBinding, bindAmbient } from '../http/default-application'
+import { warnDeprecatedGetter, warnDeprecatedSetter } from '../support/deprecate'
 
 /** Log manager for managing multiple logging channels. */
 export class LogManager {
@@ -192,12 +193,22 @@ export function createLogManager(config: LogConfig): LogManager {
 
 let globalLogManager: LogManager | null = null
 
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Bind the manager on the
+ * app's container instead — `LogServiceProvider` already does, and a provider of
+ * your own reaches it as `this.container.instance('log', manager)`.
+ */
 export function setLogManager(manager: LogManager): void {
-  globalLogManager = manager
+  warnDeprecatedSetter('setLogManager')
+  globalLogManager = bindAmbient('log', manager) ? null : manager
 }
 
-/** The default application's `log`, else the one `setLogManager()` installed. */
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Use `this.make('log')`
+ * in a controller, job or command, or `defaultContainer().make('log')`.
+ */
 export function getLogManager(): LogManager {
+  warnDeprecatedGetter('getLogManager')
   const manager = ambientBinding('log') ?? globalLogManager
   if (!manager) {
     throw new Error('Log manager has not been initialized. Register LogServiceProvider, or call setLogManager() first.')

--- a/packages/server/src/mail/Mail.ts
+++ b/packages/server/src/mail/Mail.ts
@@ -6,9 +6,10 @@ import type {
 } from './types'
 import type { MailManager } from './MailManager'
 import { Job, registerJob, type QueueDriver, type QueueManager } from '../queue'
-import { enqueueJob, getQueueDriver, pinnedQueueDriver } from '../queue/Job'
+import { enqueueJob, pinnedQueueDriver, resolveQueueDriver } from '../queue/Job'
 import { resolveOptional } from '../container/resolve-optional'
-import { ambientBinding } from '../http/default-application'
+import { ambientBinding, bindAmbient } from '../http/default-application'
+import { warnDeprecatedGetter, warnDeprecatedSetter } from '../support/deprecate'
 import { parseMailAddress as parseAddress } from './address'
 
 /**
@@ -219,7 +220,7 @@ export class Mail {
       return bound.driver()
     }
 
-    return getQueueDriver()
+    return resolveQueueDriver()
   }
 }
 
@@ -230,13 +231,22 @@ interface SendMailJobPayload {
 
 let globalMailManager: MailManager | null = null
 
-/** Set the global mail manager used by queue jobs. */
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Bind the manager on the
+ * app's container instead — `MailServiceProvider` already does, and a provider of
+ * your own reaches it as `this.container.instance('mail', manager)`.
+ */
 export function setMailManager(manager: MailManager): void {
-  globalMailManager = manager
+  warnDeprecatedSetter('setMailManager')
+  globalMailManager = bindAmbient('mail', manager) ? null : manager
 }
 
-/** The default application's `mail`, else the manager `setMailManager()` installed. */
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Use `this.make('mail')`
+ * in a controller, job or command, or `defaultContainer().makeOptional('mail')`.
+ */
 export function getMailManager(): MailManager | null {
+  warnDeprecatedGetter('getMailManager')
   return ambientBinding('mail') ?? globalMailManager
 }
 

--- a/packages/server/src/mvc/Controller.ts
+++ b/packages/server/src/mvc/Controller.ts
@@ -4,7 +4,7 @@ import { renderDocument, type ViewOptions } from './view'
 import { inertia, type InertiaOptions } from './inertia/InertiaEngine'
 import { resolveSharedInertiaProps, type ResolvedSharedInertiaProps } from './inertia/shared'
 import { getRequestLocale, getRequestTranslator, type TranslatorBinding } from '../http/middleware/detect-locale'
-import { tryGetI18n, type I18nManager, type RegisteredTranslationKey, type ReplacementValues } from '../i18n'
+import { resolveI18n, type I18nManager, type RegisteredTranslationKey, type ReplacementValues } from '../i18n'
 import { asRecord, flattenRequestQueries, parseRequestBody, parseRequestUploads } from '../http/request'
 import { getAuthContext } from '../auth/context'
 import type { AuthContext } from '../auth/types'
@@ -12,7 +12,7 @@ import type { ServiceBindings } from '../container/bindings'
 import type { ContainerLike } from '../container/types'
 import { ValidationException } from '../errors/exceptions/ValidationException'
 import { getApiTokenOrFail } from '../auth/api-token'
-import { getGate, type Gate } from '../authorization/Gate'
+import { resolveGate, type Gate } from '../authorization/Gate'
 import { resolveOptional } from '../container/resolve-optional'
 import type { AuthUser } from '../authorization/types'
 
@@ -223,7 +223,7 @@ export class Controller {
 
   /** This app's `gate` (RFC 0023 §2); the ambient one only off a container, as on a bare Hono app. */
   #resolveGate(): Gate {
-    return resolveOptional<Gate>(this._container, 'gate') ?? getGate()
+    return resolveOptional<Gate>(this._container, 'gate') ?? resolveGate()
   }
 
   private async gateUser(): Promise<AuthUser | null> {
@@ -339,7 +339,7 @@ export class Controller {
   }
 
   #resolveI18n(): I18nManager | undefined {
-    return resolveOptional<I18nManager>(this._container, 'i18n') ?? tryGetI18n()
+    return resolveOptional<I18nManager>(this._container, 'i18n') ?? resolveI18n()
   }
 
   protected json<T>(data: T, init: ResponseInit = {}): Response {

--- a/packages/server/src/mvc/inertia/InertiaEngine.ts
+++ b/packages/server/src/mvc/inertia/InertiaEngine.ts
@@ -109,6 +109,14 @@ let documentOptions: InertiaDocumentOptions | undefined;
  * Process-wide, not request-scoped: calling it mid-flight leaks the policy into
  * in-flight requests — use the {@link InertiaOptions} fields per response.
  * Values are emitted verbatim, so never pass user input. `undefined` clears.
+ *
+ * Tagged but silent, as {@link setInertiaSsrRenderer} is: RFC 0023 Open
+ * Question 4 has not settled whether the option or this setter is the endpoint,
+ * and both scaffold templates still write it. `guren upgrade --check-only`
+ * reports it either way.
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Pass
+ * `createApp({ inertia: { document } })`, which binds it on the app rather than
+ * the process. The slot stays the engine's second read.
  */
 export function setInertiaDocument(
   options: InertiaDocumentOptions | undefined
@@ -123,6 +131,13 @@ let defaultSsrRenderer: InertiaSsrRenderer | undefined;
  * cannot resolve a runtime path (Workers has no filesystem for
  * `GUREN_INERTIA_SSR_ENTRY`'s dynamic import). Per-call `ssr.render` still
  * wins; `undefined` clears (test isolation).
+ *
+ * Tagged but silent: the Workers entry `@guren/plugin-cloudflare` generates is
+ * its only known caller, and it stays on this setter until RFC 0023 Open
+ * Question 4 is decided, so a runtime warning would name code no app author
+ * wrote or can change. `guren upgrade --check-only` reports it either way.
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Pass
+ * `createApp({ inertia: { ssrRenderer } })`.
  */
 export function setInertiaSsrRenderer(
   renderer: InertiaSsrRenderer | undefined

--- a/packages/server/src/mvc/inertia/shared.ts
+++ b/packages/server/src/mvc/inertia/shared.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'hono'
 import type { ContainerLike } from '../../container/types'
+import { warnDeprecatedGetter, warnDeprecatedSetter } from '../../support/deprecate'
 
 /**
  * Application-level shared props shape for Inertia responses. Extend it in your
@@ -136,10 +137,15 @@ export function ensureSharedInertiaPropsRegistry(container: SharedPropsContainer
 /**
  * Replace the module-global shared props resolver. Props registered on an
  * application's container (see {@link shareInertiaProps}) are unaffected.
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Use
+ * `shareInertiaProps(fn, container)`, which scopes the registration to one app.
+ * It composes rather than replaces, so a wholesale reset becomes one
+ * registration on a fresh container.
  */
 export function setInertiaSharedProps<Props extends Record<string, unknown> = ResolvedSharedInertiaProps>(
   resolverFn: SharedInertiaPropsResolver<Props> | null,
 ): void {
+  warnDeprecatedSetter('setInertiaSharedProps')
   globalRegistry.set(resolverFn)
 }
 
@@ -147,8 +153,12 @@ export function setInertiaSharedProps<Props extends Record<string, unknown> = Re
  * The module-global registrations composed into one resolver, for manual
  * composition. Container-scoped props are not included — get those from
  * `ensureSharedInertiaPropsRegistry(container).get()`.
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Use
+ * `ensureSharedInertiaPropsRegistry(container).get()` on the container that owns
+ * the call.
  */
 export function getInertiaSharedPropsResolver(): SharedInertiaPropsResolver<ResolvedSharedInertiaProps> | null {
+  warnDeprecatedGetter('getInertiaSharedPropsResolver')
   return globalRegistry.get()
 }
 

--- a/packages/server/src/notifications/NotificationManager.ts
+++ b/packages/server/src/notifications/NotificationManager.ts
@@ -13,7 +13,8 @@ import {
 } from './registry'
 import { resolveNotifiableType } from './notifiable-type'
 import { Job, registerJob } from '../queue'
-import { ambientBinding } from '../http/default-application'
+import { ambientBinding, bindAmbient } from '../http/default-application'
+import { warnDeprecatedGetter, warnDeprecatedSetter } from '../support/deprecate'
 
 /** Sends notifications through multiple registered channels. */
 export class NotificationManager {
@@ -251,6 +252,11 @@ class SendNotificationJob extends Job<SendNotificationPayload> {
   static queue = 'notifications'
   static maxAttempts = 3
 
+  /**
+   * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). The job resolves
+   * `notifications` from the worker's container; `registerQueueJob()` writes
+   * this only so a worker booted without one keeps working.
+   */
   static notificationManager: NotificationManager | null = null
 
   async handle(payload: SendNotificationPayload): Promise<void> {
@@ -324,12 +330,23 @@ class SendNotificationJob extends Job<SendNotificationPayload> {
 
 let globalNotificationManager: NotificationManager | null = null
 
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Bind the manager on the
+ * app's container instead — `NotificationServiceProvider` already does, and a
+ * provider of your own reaches it as `this.container.instance('notifications', m)`.
+ */
 export function setNotificationManager(manager: NotificationManager): void {
-  globalNotificationManager = manager
+  warnDeprecatedSetter('setNotificationManager')
+  globalNotificationManager = bindAmbient('notifications', manager) ? null : manager
 }
 
-/** The default application's `notifications`, else the one `setNotificationManager()` installed. */
+/**
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Use
+ * `this.make('notifications')` in a controller, job or command, or
+ * `defaultContainer().make('notifications')`.
+ */
 export function getNotificationManager(): NotificationManager {
+  warnDeprecatedGetter('getNotificationManager')
   const manager = ambientBinding('notifications') ?? globalNotificationManager
   if (!manager) {
     throw new Error('NotificationManager not initialized. Register NotificationServiceProvider, or call setNotificationManager() first.')

--- a/packages/server/src/queue/Job.ts
+++ b/packages/server/src/queue/Job.ts
@@ -5,6 +5,7 @@ import type { ServiceBindings } from '../container/bindings'
 import type { ContainerLike } from '../container/types'
 import { resolveOptional } from '../container/resolve-optional'
 import { ambientBinding, ambientContainer, defaultContainer } from '../http/default-application'
+import { warnDeprecatedGetter, warnDeprecatedSetter } from '../support/deprecate'
 
 /**
  * The pin `setQueueDriver()` writes, and nothing else does. A manager that
@@ -17,8 +18,14 @@ let globalDriver: QueueDriver | null = null
  * Pins the driver `Job.dispatch()` sends through, ahead of the container's
  * `queue` manager. An explicit override rather than a fallback: `@guren/testing`'s
  * `fakeQueue()` and the tutorial's queue test inject through it (RFC 0023 §3).
+ * The pin survives its deprecation window because nothing else expresses it; it
+ * goes with this setter in Part 3.
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Bind the manager on the
+ * app's container — `QueueServiceProvider` already does — and inject a fake with
+ * `app.container.fake('queue', manager)`.
  */
 export function setQueueDriver(driver: QueueDriver): void {
+  warnDeprecatedSetter('setQueueDriver')
   globalDriver = driver
 }
 
@@ -43,8 +50,17 @@ function boundQueueManager(): QueueManager | null {
  * Total by contract — every caller treats it as `QueueDriver | null`, so a
  * manager bound with no factory for its default must read as absent rather
  * than throw.
+ * @deprecated since 2.23.0, removed in 3.0.0 (RFC 0023). Resolve the manager
+ * from the container that owns the call — `this.make('queue')` in a controller,
+ * job or command — and take `manager.driver()`.
  */
 export function getQueueDriver(): QueueDriver | null {
+  warnDeprecatedGetter('getQueueDriver')
+  return resolveQueueDriver()
+}
+
+/** @internal `getQueueDriver()` without the warning, for the framework's own dispatch paths. */
+export function resolveQueueDriver(): QueueDriver | null {
   if (globalDriver) return globalDriver
 
   const manager = boundQueueManager()
@@ -154,7 +170,7 @@ export abstract class Job<T = unknown> {
     payload: T,
     options: JobOptions = {}
   ): Promise<string> {
-    const driver = getQueueDriver()
+    const driver = resolveQueueDriver()
     if (!driver) {
       throw new Error(missingQueueDriverMessage())
     }

--- a/packages/server/src/queue/index.ts
+++ b/packages/server/src/queue/index.ts
@@ -13,6 +13,7 @@ export {
   setQueueDriver,
   clearQueueDriver,
   getQueueDriver,
+  resolveQueueDriver,
   registerJob,
   getJob,
   getRegisteredJobs,

--- a/packages/server/src/support/deprecate.ts
+++ b/packages/server/src/support/deprecate.ts
@@ -1,0 +1,47 @@
+import { warnOnce } from './warn-once'
+
+/** The release these shims were deprecated in, and the one that removes them (RFC 0023 Part 3). */
+const SINCE = '2.23.0'
+const REMOVED_IN = '3.0.0'
+
+/** RFC 0023 §5: the module-level service slots, split by direction. */
+export const GLOBAL_SERVICE_SETTERS = 'global-service-setters'
+export const GLOBAL_SERVICE_GETTERS = 'global-service-getters'
+
+const SETTER_REPLACEMENT =
+  "Bind the service on the owning app's container instead — container.instance(key, value) from a "
+  + 'service provider. createApp({ inertia }) covers the two Inertia options, and '
+  + 'shareInertiaProps(fn, container) the shared props.'
+
+const GETTER_REPLACEMENT =
+  'Resolve from the container that owns the call — this.make(key) in a controller, job or command, '
+  + 'getRequestContainer(ctx).make(key) in middleware, defaultContainer().make(key) elsewhere.'
+
+/**
+ * @internal The deprecation policy's warning format
+ * (`contributing/deprecation-policy.md`), keyed per symbol so one deprecated
+ * call does not silence its siblings.
+ */
+export function warnDeprecated(
+  id: string,
+  symbol: string,
+  replacement: string,
+  versions: { since: string; removedIn: string } = { since: SINCE, removedIn: REMOVED_IN },
+): void {
+  warnOnce(
+    `${id}:${symbol}`,
+    `[guren] Deprecation (${id}): ${symbol}() is deprecated\n`
+      + `  since ${versions.since}, will be removed in ${versions.removedIn}.\n`
+      + `  ${replacement}`,
+  )
+}
+
+/** @internal */
+export function warnDeprecatedSetter(symbol: string): void {
+  warnDeprecated(GLOBAL_SERVICE_SETTERS, symbol, SETTER_REPLACEMENT)
+}
+
+/** @internal */
+export function warnDeprecatedGetter(symbol: string): void {
+  warnDeprecated(GLOBAL_SERVICE_GETTERS, symbol, GETTER_REPLACEMENT)
+}

--- a/packages/server/tests/authorization/two-applications.test.ts
+++ b/packages/server/tests/authorization/two-applications.test.ts
@@ -99,7 +99,10 @@ describe('two Applications in one process (RFC 0023)', () => {
 
     expect(getGate()).toBe(closed.container.make('gate'))
     expect(await can('enter')).toBe(false)
-    expect(warn).toHaveBeenCalledTimes(1)
+    // getGate() itself is deprecated in 2.23.0 and warns too, so the ambiguity
+    // warning is counted by its own text rather than by call count.
+    const ambiguity = (warn.mock.calls as unknown[][]).filter((call) => String(call[0]).includes('Two Applications'))
+    expect(ambiguity).toHaveLength(1)
 
     useAsDefaultApplication(open)
     expect(getGate()).toBe(open.container.make('gate'))

--- a/packages/server/tests/deprecations/declaration-tags.test.ts
+++ b/packages/server/tests/deprecations/declaration-tags.test.ts
@@ -1,0 +1,60 @@
+/**
+ * The `@deprecated` tag is only a deprecation where a user's editor sees it,
+ * which is the built declarations, not these sources: `@guren/core` re-exports
+ * `@guren/server` wholesale, so the tag reaches an app through the built file
+ * the re-export resolves to.
+ */
+import { describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const SERVER_DIST = join(import.meta.dir, '../../dist')
+const CORE_DIST = join(import.meta.dir, '../../../core/dist')
+
+/** Every deprecated symbol, with the declaration file it is emitted into. */
+const DEPRECATED: Record<string, string[]> = {
+  'authorization/Gate.d.ts': ['setGate', 'getGate'],
+  'encryption/Encrypter.d.ts': ['setEncrypter', 'getEncrypter'],
+  'mail/Mail.d.ts': ['setMailManager', 'getMailManager'],
+  'queue/Job.d.ts': ['setQueueDriver', 'getQueueDriver'],
+  'i18n/I18nManager.d.ts': ['setI18n', 'getI18n', 'tryGetI18n'],
+  'logging/LogManager.d.ts': ['setLogManager', 'getLogManager'],
+  'notifications/NotificationManager.d.ts': ['setNotificationManager', 'getNotificationManager'],
+  'broadcasting/BroadcastManager.d.ts': ['setBroadcastManager', 'getBroadcastManager'],
+  'errors/ExceptionHandler.d.ts': ['setExceptionHandler', 'getExceptionHandler'],
+  'container/Container.d.ts': ['setContainer', 'getContainer'],
+  'mvc/inertia/InertiaEngine.d.ts': ['setInertiaDocument', 'setInertiaSsrRenderer'],
+  'mvc/inertia/shared.d.ts': ['setInertiaSharedProps', 'getInertiaSharedPropsResolver'],
+}
+
+function read(base: string, file: string): string {
+  const path = join(base, file)
+  if (!existsSync(path)) {
+    throw new Error(`Expected ${path}; run \`bun run build server core\` before this test.`)
+  }
+  return readFileSync(path, 'utf8')
+}
+
+describe('the built declarations', () => {
+  test.each(Object.entries(DEPRECATED))('carry @deprecated on %s', (file, symbols) => {
+    const source = read(SERVER_DIST, file)
+    for (const symbol of symbols) {
+      const declaration = source.indexOf(`declare function ${symbol}`)
+      expect(declaration).toBeGreaterThan(-1)
+      // The doc block immediately above the declaration, not merely somewhere
+      // in a file that deprecates one of its siblings.
+      const block = source.slice(source.lastIndexOf('/**', declaration), declaration)
+      expect(block).toContain('@deprecated')
+    }
+  })
+
+  test("reach an app through @guren/core's re-export", () => {
+    const index = read(CORE_DIST, 'index.d.ts')
+    expect(index).toContain('export * from "@guren/server"')
+
+    const serverIndex = read(SERVER_DIST, 'index.d.ts')
+    for (const symbol of Object.values(DEPRECATED).flat()) {
+      expect(serverIndex).toContain(symbol)
+    }
+  })
+})

--- a/packages/server/tests/deprecations/global-service-shims.test.ts
+++ b/packages/server/tests/deprecations/global-service-shims.test.ts
@@ -1,0 +1,173 @@
+/**
+ * RFC 0023 Part 2: the module-level accessors warn once and write the ambient
+ * app's container, while the functional helpers built on them stay silent.
+ */
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
+import { Hono } from 'hono'
+import { Application, createApp } from '../../src/http/Application'
+import { Controller } from '../../src/mvc/Controller'
+import { detectLocaleMiddleware } from '../../src/http/middleware/detect-locale'
+import { createGate, defineGate, can, getGate, setGate } from '../../src/authorization/Gate'
+import { createEncrypter, decrypt, encrypt, generateKey, getEncrypter, setEncrypter } from '../../src/encryption'
+import { createI18n, getI18n, setI18n, t, tryGetI18n } from '../../src/i18n/I18nManager'
+import { createLogManager, getLogManager, setLogManager } from '../../src/logging/LogManager'
+import { getContainer, setContainer, createContainer } from '../../src/container/Container'
+import { setInertiaDocument, setInertiaSsrRenderer } from '../../src/mvc/inertia/InertiaEngine'
+import { resetDefaultApplication } from '../../src/http/default-application'
+import { resetWarnOnce } from '../../src/support/warn-once'
+
+
+function i18n() {
+  return createI18n({ locale: 'en', fallbackLocale: 'en', messages: { en: { hello: 'Hello' } } })
+}
+
+describe('the deprecated service accessors', () => {
+  let warn: ReturnType<typeof spyOn>
+
+  /** Every `console.warn` message this test has seen, as strings. */
+  const warned = (): string[] => (warn.mock.calls as unknown[][]).map((call) => String(call[0]))
+
+  beforeEach(() => {
+    resetDefaultApplication()
+    resetWarnOnce()
+    warn = spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warn.mockRestore()
+    resetDefaultApplication()
+    resetWarnOnce()
+    setInertiaDocument(undefined)
+    setInertiaSsrRenderer(undefined)
+  })
+
+  it('warns once per symbol, in the deprecation policy format', () => {
+    const app = new Application()
+    setGate(createGate())
+    setGate(createGate())
+    getGate()
+
+    const messages = warned()
+    expect(messages.filter((message: string) => message.includes('setGate()'))).toHaveLength(1)
+    expect(messages.filter((message: string) => message.includes('getGate()'))).toHaveLength(1)
+    expect(messages[0]).toContain('[guren] Deprecation (global-service-setters): setGate() is deprecated')
+    expect(messages[0]).toContain('since 2.23.0, will be removed in 3.0.0.')
+    expect(app.container.has('gate')).toBe(true)
+  })
+
+  it('binds the value on the ambient container, leaving no slot behind', () => {
+    const app = new Application()
+    const gate = createGate()
+    setGate(gate)
+
+    expect(app.container.make('gate')).toBe(gate)
+
+    // Nothing is left in the module slot for a later app to inherit.
+    resetDefaultApplication()
+    expect(() => getGate()).toThrow('Gate not initialized')
+  })
+
+  it('falls back to the module slot when no application exists yet', () => {
+    const gate = createGate()
+    setGate(gate)
+
+    expect(getGate()).toBe(gate)
+  })
+
+  it('keeps the locale middleware silent on its last-resort read', async () => {
+    // No `i18n` option and no container binding, so the fallback every request
+    // would otherwise warn from is the one actually taken.
+    const hono = new Hono()
+    hono.use(detectLocaleMiddleware({ supported: ['en'] }))
+    hono.get('/', (c) => c.text('ok'))
+
+    await hono.request('/', { headers: { 'accept-language': 'en' } })
+
+    expect(warned().filter((message) => message.includes('Deprecation'))).toEqual([])
+  })
+
+  it('keeps a controller silent when its container binds no i18n', async () => {
+    class LocaleController extends Controller {
+      async show() {
+        try {
+          return this.json({ text: this.t('hello') })
+        } catch {
+          return this.json({ text: null })
+        }
+      }
+    }
+
+    const app = createApp({
+      routes: (router) => {
+        router.get('/locale', [LocaleController, 'show'])
+      },
+    })
+    await app.boot()
+
+    // Whether the ambient read finds a manager depends on what else ran in this
+    // process; that it is reached at all is what this asserts, and the app's own
+    // container binds no i18n for it to short-circuit on.
+    expect((await app.hono.request('/locale')).status).toBe(200)
+    expect(warned().filter((message) => message.includes('Deprecation'))).toEqual([])
+  })
+
+  it('keeps the functional helpers silent', async () => {
+    const app = new Application()
+    app.container.instance('encrypter', createEncrypter({ key: generateKey() }))
+    app.container.instance('gate', createGate())
+    app.container.instance('i18n', i18n())
+
+    defineGate('enter', () => true)
+    expect(await can('enter')).toBe(true)
+    expect(decrypt<string>(encrypt('secret'))).toBe('secret')
+    expect(t('hello')).toBe('Hello')
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('keeps a booted application silent', async () => {
+    const app = new Application()
+    await app.boot()
+
+    expect(warned().filter((message: string) => message.includes('Deprecation'))).toEqual([])
+  })
+
+  it('warns for every accessor an app can still call', () => {
+    const app = new Application()
+    setEncrypter(createEncrypter({ key: generateKey() }))
+    getEncrypter()
+    setI18n(i18n())
+    getI18n()
+    tryGetI18n()
+    setLogManager(createLogManager({ default: 'null', channels: { null: { driver: 'null' } } }))
+    getLogManager()
+    setContainer(createContainer())
+    getContainer()
+
+    const symbols = warned()
+      .filter((message: string) => message.includes('Deprecation'))
+      .map((message: string) => message.match(/\): (\w+)\(\)/)?.[1])
+
+    expect(new Set(symbols)).toEqual(
+      new Set([
+        'setEncrypter',
+        'getEncrypter',
+        'setI18n',
+        'getI18n',
+        'tryGetI18n',
+        'setLogManager',
+        'getLogManager',
+        'setContainer',
+        'getContainer',
+      ]),
+    )
+    expect(app.container.has('encrypter')).toBe(true)
+  })
+
+  it('leaves the two Inertia setters silent while Open Question 4 is open', () => {
+    setInertiaDocument({ head: '<meta name="x" content="y">' })
+    setInertiaSsrRenderer(undefined)
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/server/tests/http/default-application.test.ts
+++ b/packages/server/tests/http/default-application.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
 import { Application } from '../../src/http/Application'
-import { createContainer, getContainer, setContainer } from '../../src/container/Container'
+import { createContainer, installContainer, requireContainer } from '../../src/container/Container'
 import {
   defaultApplication,
   defaultContainer,
@@ -34,7 +34,7 @@ describe('the default application', () => {
 
     expect(defaultApplication()).toBe(app)
     expect(defaultContainer()).toBe(app.container)
-    expect(getContainer()).toBe(app.container)
+    expect(requireContainer()).toBe(app.container)
     expect(warn).not.toHaveBeenCalled()
   })
 
@@ -65,7 +65,7 @@ describe('the default application', () => {
     const app = new Application()
     const bare = createContainer()
 
-    setContainer(bare)
+    installContainer(bare)
 
     expect(defaultApplication()).toBeNull()
     expect(defaultContainer()).toBe(bare)
@@ -74,7 +74,7 @@ describe('the default application', () => {
 
   it('does not count a construction that replaces a displaced default as ambiguous', () => {
     new Application()
-    setContainer(createContainer())
+    installContainer(createContainer())
 
     new Application()
     defaultContainer()

--- a/packages/server/tests/mail/queued-mail-container.test.ts
+++ b/packages/server/tests/mail/queued-mail-container.test.ts
@@ -40,19 +40,29 @@ describe('queued mail resolved through the container (RFC 0023 §4)', () => {
     expect(ambient.transport.getMessages()).toHaveLength(0)
   })
 
-  it('answers getMailManager() from the default application, with the setter as the fallback', async () => {
+  it('binds setMailManager() on the default application, and its slot only without one', async () => {
     const app = new Application()
     const bound = memoryMailer(app.container)
     app.container.instance('mail', bound.manager)
 
     expect(getMailManager()).toBe(bound.manager)
 
+    // RFC 0023 Part 2: the shim writes the ambient app's container, so the call
+    // now replaces that app's binding instead of being shadowed by it.
     const hand = memoryMailer()
     setMailManager(hand.manager)
-    expect(getMailManager()).toBe(bound.manager)
-
-    resetDefaultApplication()
+    expect(app.container.make('mail')).toBe(hand.manager)
     expect(getMailManager()).toBe(hand.manager)
+
+    // Nothing was left in a module slot for the next app to inherit.
+    resetDefaultApplication()
+    expect(getMailManager()).toBeNull()
+
+    // With no application to bind — every scaffold calls the Inertia setters at
+    // module scope before createApp() — the slot is still where it lands.
+    const early = memoryMailer()
+    setMailManager(early.manager)
+    expect(getMailManager()).toBe(early.manager)
   })
 
   it('dispatches through the queue bound beside the mail manager, not the default application\'s', async () => {

--- a/rfcs/0023-container-only-service-resolution.md
+++ b/rfcs/0023-container-only-service-resolution.md
@@ -431,7 +431,7 @@ deprecations (`bunx guren upgrade --check-only` lists affected files) and
 | App code today | After | Codemod |
 |---|---|---|
 | `getGate().policy(Post, PostPolicy)` in a provider `boot()` (blog template) | `this.container.make('gate').policy(Post, PostPolicy)` | Yes: inside a class extending `ServiceProvider`, `getGate()` → `this.container.make('gate')`; same for the other getters by key |
-| `setMailManager(manager)` in a provider that also binds `mail` (scaffold) | delete the call | Yes, when the same class binds the key; otherwise reported |
+| `setMailManager(manager)` in a provider that also binds `mail` (scaffold) | delete the call | Yes, when ~~the same class~~ a provider in the same file binds the key (amended, below); otherwise reported |
 | `setMailManager(m)` in a provider that binds nothing (`examples/blog`) | `this.container.instance('mail', m)` | Yes |
 | `setInertiaDocument({...})` at module scope with an inline literal | `createApp({ inertia: { document: {...} } })` | Yes, when `createApp(` is in the same file; otherwise reported |
 | `getContainer().make('storage')` in `config/attachments.ts` | `(container) => container.make('storage')` | Yes, inside a `configureAttachments()` factory; elsewhere reported |
@@ -442,6 +442,18 @@ The codemod is idempotent, AST-based (`@babel/parser`, as `deprecations.ts`
 already uses) and tested against `examples/blog`. Timeline: deprecated in the
 Part 2 minor, removed at server `3.0.0` / core `2.0.0`, two minors later at
 the earliest.
+
+**Amended in implementation:** the deletion rule reads the file, not the class.
+The blog example's `setMailManager(mailManager)` sits in a module-scope helper
+its provider invokes (`EventServiceProvider.ts:51`), which is the common shape
+and the one the policy names as the codemod's test target; a rule keyed on the
+class reaches neither. The residual risk is a file whose provider binds the key
+to something other than what the setter passes, where deletion loses a
+meaningful call, so this is the one rewrite that cannot be read back off the
+result. A `this.…` rewrite is additionally skipped where `this` is not the
+instance — inside a `static` member, or a non-arrow function nested in the class
+— because a rewrite that compiles and then throws is worse than the warning it
+replaces.
 
 ## Open Questions
 

--- a/rfcs/0023-container-only-service-resolution.md
+++ b/rfcs/0023-container-only-service-resolution.md
@@ -312,7 +312,7 @@ Every exported setter and getter keeps its signature and forwards:
 /** @deprecated since 2.23.0, removed in 3.0.0. Bind `gate` on the app's container; providers already do. */
 export function setGate(gate: Gate): void {
   warnDeprecated('global-service-setters', 'setGate')
-  defaultContainer().instance('gate', gate)
+  globalGate = bindAmbient('gate', gate) ? null : gate // amended, see below
 }
 /** @deprecated since 2.23.0, removed in 3.0.0. Use `this.make('gate')`, `getRequestContainer(ctx)`, or `defaultContainer()`. */
 export function getGate(): Gate {
@@ -322,15 +322,40 @@ export function getGate(): Gate {
 ```
 
 `warnDeprecated(id, symbol)` is `warnOnce` keyed per symbol in the policy's
-message format (`Seeder.ts:27-33` is the existing shape). The module-private
-`let global*` declarations go in Part 2; only the exported functions are
+message format (`Seeder.ts:27-33` is the existing shape). ~~The module-private
+`let global*` declarations go in Part 2~~; only the exported functions are
 under the policy's window.
+
+**Amended in implementation:** the slots stay through Part 2 and a setter can
+still write one. Both scaffold templates call `setInertiaDocument()` at module
+scope in `src/app.ts` *above* `createApp()`, so a shim that could only write
+`defaultContainer()` would throw at import in every scaffolded app. A setter
+therefore binds the ambient container when one exists — clearing its own slot,
+so a value cannot outlive the app that received it — and writes the slot only
+when no `Application` has been constructed yet; the getters keep reading the
+slot second. The visible change is that a hand-written `setX()` beside a live
+app now *replaces* that app's binding rather than being silently shadowed by it.
+
+Two setters are tagged and registered but do not warn at runtime.
+`setInertiaSsrRenderer` is called by the Workers entry `@guren/plugin-cloudflare`
+generates, which stays on it until Open Question 4 is decided, and
+`setInertiaDocument` is what both scaffold templates and four guides still
+write; a warning naming code the framework itself emits is not actionable. Both
+are reported by `guren upgrade --check-only` and rewritten by the codemod, and
+the warning lands with Open Question 4.
 
 | Deprecation id | Symbols | Replacement |
 |---|---|---|
 | `global-service-setters` | `setGate`, `setEncrypter`, `setMailManager`, `setQueueDriver`, `setI18n`, `setLogManager`, `setNotificationManager`, `setBroadcastManager`, `setExceptionHandler`, `setContainer`, `setInertiaDocument`, `setInertiaSsrRenderer`, `setInertiaSharedProps` | `container.instance(key, value)` in a provider; `createApp({ inertia })` for the two Inertia options; `shareInertiaProps(fn, container)` |
 | `global-service-getters` | `getGate`, `getEncrypter`, `getMailManager`, `getQueueDriver`, `getI18n`, `tryGetI18n`, `getLogManager`, `getNotificationManager`, `getBroadcastManager`, `getExceptionHandler`, `getContainer`, `getInertiaSharedPropsResolver` | `this.make(key)`, `getRequestContainer(ctx).make(key)`, `defaultContainer().make(key)` |
-| `attachments-active-engine` (`@guren/core`) | `setActiveAttachmentEngine`, `getActiveAttachmentEngine` | ~~`configureAttachments({ app })`~~ `engine.bindTo(container)` from a provider (amended, see §4), `container.make('attachments')` |
+| ~~`attachments-active-engine` (`@guren/core`)~~ | ~~`setActiveAttachmentEngine`, `getActiveAttachmentEngine`~~ | ~~`configureAttachments({ app })`~~ `engine.bindTo(container)` from a provider (amended, see §4), `container.make('attachments')` |
+
+**Amended in implementation:** there is no `attachments-active-engine`
+deprecation. Neither symbol is exported from `@guren/core` — the barrel
+(`attachments/index.ts`) publishes `configureAttachments`, the engine *type* and
+the delivery pieces, and nothing else — so no app can call one, a `detect()`
+scanning import specifiers can never match, and a runtime warning would only
+fire from core's own tests. Both go with the slot in Part 3.
 
 Not deprecated: `encrypt`, `decrypt`, `t`, `tc`, `can`, `cannot`,
 `defineGate`, `authorizeAbility`, `resolve`, `Job.dispatch`, `Job.make`. Same
@@ -357,10 +382,13 @@ Referencing `RFC 0023` in each PR:
 2. **Deprecate** (server + cli, minor, target `2.23.0`): stages 1 to 5 of
    `contributing/deprecation-policy.md`. JSDoc `@deprecated` on the 25
    symbols; `warnDeprecated` on first call; the three
-   `packages/cli/src/deprecations.ts` entries above, `detect()` scanning
+   `packages/cli/src/deprecations.ts` entries above (amended to two, §5),
+   `detect()` scanning
    import specifiers from `@guren/core` and `@guren/server`; CHANGELOG
-   `### Deprecated`; the codemod (Migration Path). Part 1's fallback reads
-   go here: the shims now write to the container, so no slot is left to read.
+   `### Deprecated`; the codemod (Migration Path). ~~Part 1's fallback reads
+   go here: the shims now write to the container, so no slot is left to read.~~
+   **Amended in implementation:** the shims write the container when there is
+   one and their slot when there is not, so the fallback reads stay (§5).
 3. **Remove** (server `3.0.0` and core `2.0.0`, same release): delete the
    shims, `let global*`, `SendNotificationJob.notificationManager`, and the
    `clear*`/`reset*` seams that existed only for them. Core majors with


### PR DESCRIPTION
RFC 0023 Part 2: stages 1 to 5 of `contributing/deprecation-policy.md` for the
module-level service slots. Nothing is removed; Part 3 deletes the shims,
`Container.scoped*` and the `let global*` declarations at server 3.0.0 / core
2.0.0, two minors later at the earliest.

## What ships

**Announce and warn.** `@deprecated` JSDoc on the 25 symbols, each naming its
replacement, plus a `warnDeprecated` on first call keyed per symbol in the
policy's message format. `packages/server/tests/deprecations/declaration-tags.test.ts`
pins the tag surviving into `packages/server/dist/**/*.d.ts` and reaching an app
through `@guren/core`'s `export * from "@guren/server"` — the tag is only a
deprecation where a user's editor sees it, which is the built declarations, not
these sources.

**Register.** Two entries in `packages/cli/src/deprecations.ts`,
`global-service-setters` and `global-service-getters`, whose `detect()` scans
import specifiers from both `@guren/core` and `@guren/server` over a wider file
set than the other entries: `config/`, `src/` and `app/` of the app and its
modules, plus test files, because the setters live in `src/app.ts` and
`config/*.ts` and the test-injection row of the migration table is reported
rather than rewritten.

**Codemod.** `container-only-service-resolution`, the first entry in the codemod
registry, AST-based on `@babel/parser` and idempotent. It covers the Migration
Path table: a getter inside a provider becomes `this.container.make(key)`; a
setter whose key a provider in the same file binds is deleted, and one in a
provider that binds nothing becomes `this.container.instance(key, value)`; an
inline `setInertiaDocument({ … })` moves into `createApp({ inertia: { document } })`
with its comment; the attachments `storage` factory becomes
`(container) => container.make('storage')`; `getContainer().make(key)` inside a
`Job` becomes `this.make(key)`; and unused Guren import specifiers left behind
are removed. A `this.…` rewrite is skipped where `this` is not the instance — a
`static` member, or a non-arrow function nested in the class — so the codemod
reports rather than emitting code that compiles and then throws. `detect()` and `apply()` answer from one `transformSource()`, so a
file `--dry-run` lists is exactly a file `guren upgrade` writes. Tested against
`examples/blog` (it rewrites `EventServiceProvider.ts` and changes nothing on a
second run) and through `runCodemods()` rather than by calling `apply()`
directly, because the version filter had never been exercised.

**Document.** A `### Deprecated` changeset for `@guren/server` + `@guren/core`,
one for `@guren/cli`, and a `2.22.x → 2.23.0` section in
`docs/{en,ja}/guides/upgrading.md`.

## The behaviour change worth reading

Part 1 made every consumer read the container first and the slot second, which
left a hand-written `setMailManager(m)` silently shadowed by the binding a
provider had already made. The shim now binds the key on the ambient container
and clears its own slot, so a value cannot outlive the app that received it.
Where no `Application` exists yet the slot is still where the value lands, and
the getters keep reading it second.

## Deviations, amended in the RFC

- **The slots stay and the fallback reads stay.** The plan said the shims would
  write `defaultContainer()`, leaving no slot to read. Both scaffold templates
  call `setInertiaDocument()` at module scope in `src/app.ts` *above*
  `createApp()`, so that shim would throw at import in every scaffolded app.
- **`setInertiaDocument` / `setInertiaSsrRenderer` are tagged and reported but
  do not warn.** Open Question 4 has not settled whether the option or the
  setter is the endpoint, the Workers entry `@guren/plugin-cloudflare` generates
  still calls the SSR setter, and both templates plus four guides still write
  the document setter. A warning naming code the framework itself emits is not
  actionable. The codemod rewrites both for an app that wants to move now, and
  the warning lands with Open Question 4.
- **There is no `attachments-active-engine` deprecation.**
  `setActiveAttachmentEngine` / `getActiveAttachmentEngine` are not exported
  from `@guren/core` — the attachments barrel publishes `configureAttachments`,
  the engine type and the delivery pieces, and nothing else — so no app can call
  one, a `detect()` scanning import specifiers can never match, and a runtime
  warning would only fire from core's own tests. Both go with the slot in Part 3.
- **`setQueueDriver()` keeps its override**, as the RFC already amended:
  `@guren/testing`'s `fakeQueue()` and the tutorial's queue chapter inject
  through the pin and nothing else expresses it. The pin goes with the setter in
  Part 3.

## Follow-up, deliberately not here

`docs/{en,ja}/guides/authorization.md`, tutorials 07 / 08 / 09 and the blog
showcase template still teach `getGate()` in a provider's `boot()`, and
tutorial 11 teaches `setQueueDriver`/`getQueueDriver` while still saying
`Job.dispatch()` reads a module-level driver, which Part 1 already changed. Those
examples now warn once at boot. Migrating them, and the templates' Inertia
setters (which needs `packages/create-app` and the smoke assertions that read
them), is a docs-and-scaffold pass outside this PR's server + cli scope.

## Gates

`bun run typecheck`, `bun run lint`, `bun run test:examples`, `bun run audit:prose`,
`audit:docs`, `audit:core-first`, `audit:core-semver` and `audit:starter-template`
all pass. Package suites were run directly — `packages/server` 3218 pass,
`packages/core` 257 pass, `packages/cli` 2449 pass, plus every other package —
rather than through `bun run test:bun`, which wedges under `--isolate` on this
machine (Bun 1.3.14).
