### PR TITLE
docs: refresh the README against what the framework ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ bunx guren add broadcasting    # Real-time (SSE)
 bunx guren add schedule        # Cron scheduling
 bunx guren add prototype       # Prototype mode: pages from fixtures, no backend yet
 bunx guren add lint            # oxlint with the Guren rules
-bunx guren add plugin <pkg>    # Install a plugin and register its provider
+bunx guren add plugin @acme/guren-plugin-foo   # Install a plugin, register its provider
 ```
 
 Run `bun run codegen` after adding features to regenerate types. When you are ready to ship, `bun run build` creates the production build.
@@ -73,7 +73,7 @@ A scaffolded app installs the harness those commands feed: `CLAUDE.md`, glob-sco
 claude plugin marketplace add gurenjs/agent-skills   # or: npx skills add gurenjs/agent-skills
 ```
 
-The effect is measured. [Agents on Guren](https://github.com/gurenjs/agents-on-guren) runs 20 bug, security and feature tasks with hidden acceptance tests across three models, with and without the harness the scaffold ships: 360 runs, every event stream published. Sonnet 5 passed 60 of 60 tasks with the harness against 58 of 60 bare, at 28% fewer turns and 25% lower cost. Agents that had the harness ran `guren check` in 119 of their 180 runs; bare, 15.
+The effect is measured. [Agents on Guren](https://github.com/gurenjs/agents-on-guren) runs 20 bug, security and feature tasks with hidden acceptance tests across three models, with and without the harness the scaffold ships: 360 runs, each one's patch, logs and verdict published. On Sonnet 5 the harness passed 60 of 60 tasks against 58 of 60 bare, at 28% fewer turns and 25% lower cost. Opus 5 went 60 of 60 either way, at 26% fewer turns. On Haiku 4.5 the pass rate itself moved, 51 of 60 to 54. Agents that had the harness ran `guren check` in 119 of their 180 runs; bare, 15.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 **The fullstack TypeScript framework for the AI-agent era.**
 
-Laravel-style conventions, end-to-end type safety, and built-in agent introspection and verification — routing, controllers, ORM, authentication, and Inertia.js + React in one cohesive experience that humans and AI coding agents navigate from the same map.
+Guren is a fullstack framework for Bun where your coding agent works from the same map you do. Laravel-style conventions, type safety from the route definition to the React component, and mechanical checks that verify the work. Secure by default, agent-ready by default.
 
-> **v2** — Stable. Breaking changes only in major releases, per the [release policy](docs/en/guides/release-policy.md).
+> **v2** is stable. Breaking changes only in major releases, per the [release policy](docs/en/guides/release-policy.md).
 
 ---
 
@@ -20,7 +20,7 @@ Laravel-style conventions, end-to-end type safety, and built-in agent introspect
 bunx create-guren-app my-app --auth
 cd my-app
 
-# 2. Run migrations and seed the demo user (SQLite by default — no server needed)
+# 2. Run migrations and seed the demo user (SQLite by default, no server needed)
 bun run db:migrate
 bun run db:seed
 
@@ -33,32 +33,63 @@ Open `http://localhost:3333` and sign in at `/login` with `demo@example.com` / `
 ### Add features as you go
 
 ```bash
-bunx guren add auth            # Authentication
+bunx guren add auth            # Session auth: login, registration, middleware
+bunx guren add oauth           # OAuth providers with callback routes
+bunx guren add session         # Database-backed sessions
 bunx guren add resource posts --fields "title:string,body:text"  # CRUD resource
+bunx guren add admin           # Starter admin dashboard, auth-guarded
 bunx guren add queue           # Background jobs
 bunx guren add mail            # Email sending
 bunx guren add cache           # Cache layer
 bunx guren add notifications   # Multi-channel notifications
-bunx guren add storage         # File storage
+bunx guren add storage         # File storage disks
+bunx guren add attachments     # Uploads attached to your models
 bunx guren add events          # Events & listeners
 bunx guren add broadcasting    # Real-time (SSE)
 bunx guren add schedule        # Cron scheduling
+bunx guren add prototype       # Prototype mode: pages from fixtures, no backend yet
 bunx guren add lint            # oxlint with the Guren rules
+bunx guren add plugin <pkg>    # Install a plugin and register its provider
 ```
 
 Run `bun run codegen` after adding features to regenerate types. When you are ready to ship, `bun run build` creates the production build.
 
 ---
 
+## Your agent works from the same map
+
+A coding agent is a first-class user of the framework here, not an afterthought. Project knowledge is derived where possible, declared where not, and checked always.
+
+```bash
+bunx guren context User    # One entity: model, routes, pages, resource, policy, linked docs
+bunx guren spec:generate   # ER, domain and screen views, derived from code
+bunx guren check           # Route/controller/page wiring, doc links, spec freshness
+bunx guren audit           # Validation, authorization, raw SQL, secrets
+```
+
+A scaffolded app installs the harness those commands feed: `CLAUDE.md`, glob-scoped rules, skills, hooks and an MCP config, written by `bunx guren agent:init` and refreshed by `agent:sync`. Before an app exists, two on-ramp skills cover the gap. Install them at user scope, since they apply whatever you are building:
+
+```bash
+claude plugin marketplace add gurenjs/agent-skills   # or: npx skills add gurenjs/agent-skills
+```
+
+The effect is measured. [Agents on Guren](https://github.com/gurenjs/agents-on-guren) runs 20 bug, security and feature tasks with hidden acceptance tests across three models, with and without the harness the scaffold ships: 360 runs, every event stream published. Sonnet 5 passed 60 of 60 tasks with the harness against 58 of 60 bare, at 28% fewer turns and 25% lower cost. Agents that had the harness ran `guren check` in 119 of their 180 runs; bare, 15.
+
+---
+
 ## What you get
 
-- **Agent-ready by default** — `guren context` hands an agent the project map with API signatures, `guren check` and `guren audit` verify its work mechanically, and every new app ships an agent harness — and before you have an app, the Guren skills are one `npx skills add gurenjs/agent-skills` (or `claude plugin marketplace add gurenjs/agent-skills`) away. In a [public, blind-scored evaluation](https://github.com/gurenjs/framework-comparison/tree/main/agent-eval), every agent trial shipped a working feature
-- **Laravel-style MVC** — routes, controllers, and an Eloquent-inspired Model API
-- **Inertia.js + React** — SPA-like UX without a separate frontend app
-- **Drizzle ORM** — swap database backends through an adapter (PostgreSQL / MySQL / SQLite)
-- **End-to-end type safety** — `bunx guren codegen` generates types from schema to frontend props
-- **Batteries included** — auth, queues, mail, cache, notifications, storage, broadcasting, scheduling
-- **Bun-first, deploy anywhere** — develop on the Bun toolchain, then self-host on a Bun server or ship to AWS Lambda, Vercel, or Cloudflare Workers with first-party plugins
+- **Laravel-style MVC.** A route points at a controller, the controller validates input and returns an Inertia page, and an Eloquent-inspired Model API rides on Drizzle ORM.
+- **No API layer to babysit.** Inertia.js hands controller props straight to your React components, so there is no REST or GraphQL glue to keep in sync.
+- **End-to-end type safety.** `bunx guren codegen` turns routes, page props and resources into compile-time contracts. Rename a route and the build fails instead of your users.
+- **Secure by default.** Mass assignment is blocked structurally, CSRF protection mounts with sessions, and security headers and same-origin CORS are on before you configure anything.
+- **Batteries included.** Auth, sessions, queues, mail, cache, notifications, storage, attachments, events, broadcasting, scheduling and i18n are first-party subsystems, not a shopping list of npm packages.
+- **Bun-first, deploy anywhere.** Develop on the Bun toolchain, then self-host on a Bun server or ship the same app to Cloudflare Workers, Vercel or AWS Lambda with first-party plugins. [guren.dev](https://guren.dev/) is a Guren app running on Workers.
+- **PostgreSQL, MySQL or SQLite.** One ORM adapter covers all three, and SQLite needs no server for local work.
+
+### Measured, not promised
+
+The same spec app on Guren and on an equivalent Node.js MVC stack, self-hosted and benchmarked under identical conditions with the app code held constant: **2.3× the throughput on full SSR pages, 3.5× on the JSON path, and 1.8× faster cold starts**. The gap is Bun itself, and that is the point: keep the Laravel-style architecture, change the engine. [Methodology and one-command reproduction](https://github.com/gurenjs/framework-comparison/blob/main/BENCHMARK.md).
 
 ---
 
@@ -118,15 +149,16 @@ const post = await Post.findOrFail(1)
 
 ## Documentation
 
-- [Official docs](https://guren.dev/) — tutorials, API reference, guides
-- [examples/blog](./examples/blog) — reference implementation
+- [Official docs](https://guren.dev/): tutorials, guides and API reference
+- [Why Guren](https://guren.dev/docs/guides/why-guren): how it compares, and when to pick something else
+- [examples/blog](./examples/blog): the reference implementation
 
 ---
 
 ## Requirements
 
-- [Bun](https://bun.sh/) v1.1+
-- Docker (for the bundled PostgreSQL container)
+- [Bun](https://bun.sh/) v1.1 or later
+- Docker only if you want the bundled PostgreSQL or MySQL container. SQLite is the default and needs nothing.
 
 ---
 


### PR DESCRIPTION
## Why

The README had drifted from both the CLI and the site.

- **`guren add` listed 11 of the 16 blueprints.** Missing: `admin`, `attachments`, `oauth`, `session`, `prototype`, plus `add plugin` (which `addCommand` prints separately from `listBlueprints()`, so it is listed on its own line here too).
- **The agent evidence was the old one.** The README cited `framework-comparison/agent-eval` (45 trials) while the homepage already leads with `agents-on-guren` (360 runs, 20 tasks x 3 models x bare/shipped x 3 trials). Two different numbers for the same claim in two places.
- **Requirements read as if Docker were mandatory**, which contradicts the Quick Start's "SQLite by default, no server needed" three sections above.
- **Em-dash density was 34.7 per 1000 prose words**, against the 5 per 1000 ceiling in `.claude/rules/prose.md`. The README is outside `audit:prose`'s locale scope, so nothing was catching it.

## What changed

- Full `add` blueprint list, each with what it installs.
- New "Your agent works from the same map" section: the four introspection commands, the harness `agent:init` writes, the on-ramp skills, and the measured effect. The `What you get` agent bullet folded into it rather than repeating the command names.
- Agent numbers from `agents-on-guren` `results/RESULTS.md`, verified against the raw file: Sonnet 5 shipped 60/60 vs bare 58/60, -28% turns, -25% cost; `guren check` run in 119/180 shipped cells vs 15/180 bare. The cost figure stays attached to its pass rates, since on its own it reads as "cheaper, maybe worse".
- Throughput and cold-start ratios (2.3x / 3.5x / 1.8x) with the self-hosted qualifier and the reproduction link.
- Feature bullets rewritten to say what the thing does; `secure by default`, attachments, sessions and i18n were absent.
- Docker is described as optional.
- Prose now passes `bun scripts/smoke/prose-audit.ts README.md`.

## Follow-up (not in this PR)

`docs/en/guides/why-guren.md:35` and its `ja` counterpart still carry the `agent-eval` numbers (43 of 45 trials, -29% cost). They are now older than the README. Worth a separate PR, since both locales are under `audit:prose` and `audit:docs` and the section needs rewriting rather than a number swap.

`packages/create-app/templates/default/README.md` has the same `add` list gap. Kept out of this PR because `audit:starter-template` asserts scaffold contents literally.

## Verification

```
bun scripts/smoke/prose-audit.ts README.md   # passed
bun run audit:docs                            # passed
bun run audit:core-first                      # passed
```

Docs only, no source or template files touched.
