### PR TITLE
docs: count runs, not tasks, in the README benchmark line

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ A scaffolded app installs the harness those commands feed: `CLAUDE.md`, glob-sco
 claude plugin marketplace add gurenjs/agent-skills   # or: npx skills add gurenjs/agent-skills
 ```
 
-The effect is measured. [Agents on Guren](https://github.com/gurenjs/agents-on-guren) runs 20 bug, security and feature tasks with hidden acceptance tests across three models, with and without the harness the scaffold ships: 360 runs, each one's patch, logs and verdict published. On Sonnet 5 the harness passed 60 of 60 tasks against 58 of 60 bare, at 28% fewer turns and 25% lower cost. Opus 5 went 60 of 60 either way, at 26% fewer turns. On Haiku 4.5 the pass rate itself moved, 51 of 60 to 54. Agents that had the harness ran `guren check` in 119 of their 180 runs; bare, 15.
+The effect is measured. [Agents on Guren](https://github.com/gurenjs/agents-on-guren) runs 20 bug, security and feature tasks with hidden acceptance tests across three models, with and without the harness the scaffold ships: 360 runs, each one's patch, logs and verdict published. On Sonnet 5 the harness passed 60 of 60 runs against 58 of 60 bare, at 28% fewer turns and 25% lower cost. Opus 5 went 60 of 60 either way, at 26% fewer turns and 12% lower cost. On Haiku 4.5 the pass rate itself moved, 51 of 60 to 54, at 6% higher cost. Agents that had the harness ran `guren check` in 119 of their 180 runs; bare, 15.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #798 and #799, both merged. Two problems in the README's benchmark sentence.

**`tasks` was the wrong unit.** The `pass` column in `agents-on-guren`'s `results/RESULTS.md` headline counts cells, not tasks: the corpus is 20 tasks run 3 times each, so 60 is the trial count. Confirmed against the per-task tables (20 rows, each `3/3 -> 3/3`) and the failure taxonomy (haiku bare is 60 - 51 = 9 fails, and the per-task fail rows sum to exactly 9 cells). The same README sentence already says "runs 20 bug, security and feature tasks" two clauses earlier, so it contradicted itself. `guren check in 119 of their 180 runs` at the end of the line was already correct.

**The cost deltas were selected, not summarized.** The line gave Sonnet both turns and cost, Opus turns only, and Haiku neither. The two models whose cost fell got a cost number; the one where it rose did not. Each clause was true, but the selection carried a conclusion the data does not support. Opus's -12% and Haiku's +6% are now both stated. `RESULTS.md` frames Haiku as the tier where pass rate moves instead of effort, which the sentence already says.

Every figure read from the raw file, not a summary:

| model | pass bare -> shipped | turns | cost |
|---|---|---|---|
| sonnet-5 | 58/60 -> 60/60 | -28% | -25% |
| opus-5 | 60/60 -> 60/60 | -26% | -12% |
| haiku-4-5 | 51/60 -> 54/60 | -16% | **+6%** |

This also brings the README in line with `docs/{en,ja}/guides/why-guren.md` as #799 left them, so the three files now state the same numbers in the same units.

## Scope

docs (`README.md`). One sentence, no framework source, no behavior change, so no changeset — matching #798 and #799, both docs-only and neither carrying one.

## Risk Assessment

None.

## Validation

```
bun run ./scripts/smoke/prose-audit.ts README.md    Prose audit passed: 1 file(s).
```

`audit:prose` defaults to `docs/en` and `docs/ja`, so the README is outside its normal scope; it was run against the file explicitly instead.

`audit:docs` does read `README.md`, but only asserts it contains six command strings (`bunx guren add auth`, `add notifications`, `add storage`, `add broadcasting`, `bun run codegen`, `bun run build`). All six were confirmed still present; none is in the edited sentence.

- [ ] `bun run build` — not run; no package source touched
- [ ] `bun run typecheck` — not run; no TypeScript touched
- [ ] `bun run test` — not run; no behavior change

## Checklist

- [x] I followed existing project conventions.
- [x] I considered backward compatibility and documented intentional breaks.
- [ ] I added/updated tests for behavior changes — no behavior change.
- [x] I updated relevant documentation.
