### PR TITLE
docs: wire SQS through a queue provider, not the deprecated pin

### DIFF
--- a/docs/en/guides/serverless.md
+++ b/docs/en/guides/serverless.md
@@ -58,20 +58,32 @@ Wraps the app's fetch handler for API Gateway v1/v2 and ALB. Routes, controllers
 
 Processes SQS messages as Guren jobs. Supports **partial batch failure**: only failed messages are returned to SQS for retry.
 
-Configure the SQS driver in your queue provider:
+Configure the SQS driver in the queue provider `guren add queue` scaffolds at `app/Providers/QueueProvider.ts`:
 
 ```typescript
 import { SQSClient } from '@aws-sdk/client-sqs'
-import { createSqsAdapter, SqsDriver, setQueueDriver } from '@guren/core'
+import { ServiceProvider, createQueueManager, createSqsAdapter, SqsDriver } from '@guren/core'
 
-const adapter = createSqsAdapter(new SQSClient({ region: 'ap-northeast-1' }))
-setQueueDriver(new SqsDriver(adapter, {
-  queueUrl: process.env.SQS_QUEUE_URL!,
-  // Optional: map logical queue names to separate SQS URLs
-  queueUrls: {
-    emails: process.env.SQS_EMAILS_QUEUE_URL!,
-  },
-}))
+export default class QueueProvider extends ServiceProvider {
+  register(): void {
+    const adapter = createSqsAdapter(new SQSClient({ region: 'ap-northeast-1' }))
+    const queue = createQueueManager({
+      default: 'sqs',
+      drivers: {
+        sqs: () =>
+          new SqsDriver(adapter, {
+            queueUrl: process.env.SQS_QUEUE_URL!,
+            // Optional: map logical queue names to separate SQS URLs
+            queueUrls: {
+              emails: process.env.SQS_EMAILS_QUEUE_URL!,
+            },
+          }),
+      },
+    })
+
+    this.container.instance('queue', queue)
+  }
+}
 ```
 
 Jobs are dispatched the same way as on the server: `await SendEmailJob.dispatch({ to: 'user@example.com' })`. The `SqsDriver` serializes the job to SQS, and the Lambda handler deserializes and executes it.

--- a/docs/ja/guides/serverless.md
+++ b/docs/ja/guides/serverless.md
@@ -58,20 +58,32 @@ bunx guren lambda:build
 
 SQS メッセージを Guren のジョブとして処理します。**部分バッチ失敗**に対応しており、失敗したメッセージだけが SQS に戻されてリトライされます。
 
-キュープロバイダで SQS ドライバを設定します:
+`guren add queue` が `app/Providers/QueueProvider.ts` に置くキュープロバイダで、SQS ドライバを設定します:
 
 ```typescript
 import { SQSClient } from '@aws-sdk/client-sqs'
-import { createSqsAdapter, SqsDriver, setQueueDriver } from '@guren/core'
+import { ServiceProvider, createQueueManager, createSqsAdapter, SqsDriver } from '@guren/core'
 
-const adapter = createSqsAdapter(new SQSClient({ region: 'ap-northeast-1' }))
-setQueueDriver(new SqsDriver(adapter, {
-  queueUrl: process.env.SQS_QUEUE_URL!,
-  // オプション: 論理キュー名を別の SQS URL にマッピング
-  queueUrls: {
-    emails: process.env.SQS_EMAILS_QUEUE_URL!,
-  },
-}))
+export default class QueueProvider extends ServiceProvider {
+  register(): void {
+    const adapter = createSqsAdapter(new SQSClient({ region: 'ap-northeast-1' }))
+    const queue = createQueueManager({
+      default: 'sqs',
+      drivers: {
+        sqs: () =>
+          new SqsDriver(adapter, {
+            queueUrl: process.env.SQS_QUEUE_URL!,
+            // オプション: 論理キュー名を別の SQS URL にマッピング
+            queueUrls: {
+              emails: process.env.SQS_EMAILS_QUEUE_URL!,
+            },
+          }),
+      },
+    })
+
+    this.container.instance('queue', queue)
+  }
+}
 ```
 
 ジョブのディスパッチはサーバー上と同じです（`await SendEmailJob.dispatch({ to: 'user@example.com' })`）。`SqsDriver` がジョブを SQS にシリアライズし、Lambda ハンドラーがデシリアライズして実行します。


### PR DESCRIPTION
## The gap

RFC 0023 Part 2 (#797) deprecated `setQueueDriver()`, and #801 migrated the
guides and scaffolds off the deprecated setters. The Lambda guide's SQS section
was missed: it taught

```ts
setQueueDriver(new SqsDriver(adapter, { … }))
```

at module scope as the only wiring shown for SQS, under a heading that already
read "Configure the SQS driver in your queue provider" while the snippet used no
provider. `setQueueDriver` is now `@deprecated since 2.23.0, removed in 3.0.0`
and warns on first call, so a reader following the deployment guide wrote code
that warns at boot and breaks at the next major.

## The change

Both locales now show the shape `guren add queue` already scaffolds at
`app/Providers/QueueProvider.ts`: a `QueueManager` whose `sqs` driver factory
builds the `SqsDriver`, bound with `this.container.instance('queue', queue)`.
The prose names that file so the class has somewhere to live.

Nothing else changes. The other `setQueueDriver` mentions in the docs are the
testing pin that RFC 0023 keeps until Part 3 (`@guren/testing`'s `fakeQueue()`
and tutorial 11), and they describe it accurately as taking precedence over the
container's manager.

## Test plan

- `bun run audit:prose`: `Prose audit passed: 144 file(s).`
- `bun run audit:docs`: passed, 1628 named imports across 1003 first-party
  import statements — this is what proves `ServiceProvider`,
  `createQueueManager`, `createSqsAdapter` and `SqsDriver` all resolve from
  `@guren/core`.
- The snippet was compiled as real code against `packages/server/src` (a
  throwaway file, since removed): the only error is the unresolvable
  `@aws-sdk/client-sqs`, an optional peer this repo does not install and which
  the previous snippet imported too. The config shape and the container key
  typecheck.

Docs only, so no changeset, matching the recent docs PRs.
